### PR TITLE
fix(entrypoint): ENDPOINT_LOCK_PATH override for non-container runs; example tracks in-repo gen-worker

### DIFF
--- a/examples/marco-polo/pyproject.toml
+++ b/examples/marco-polo/pyproject.toml
@@ -24,3 +24,8 @@ main = "marco_polo.main"
 python_version = "3.12"
 ignore_missing_imports = true
 disallow_untyped_defs = true
+
+# The example tracks the in-repo gen-worker (the @endpoint API it uses is
+# unreleased); published wheels can't run this source.
+[tool.uv.sources]
+gen-worker = { path = "../..", editable = true }

--- a/examples/marco-polo/uv.lock
+++ b/examples/marco-polo/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 [[package]]
 name = "gen-worker"
 version = "0.8.3"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../../" }
 dependencies = [
     { name = "backoff" },
     { name = "blake3" },
@@ -250,8 +250,6 @@ dependencies = [
     { name = "grpcio" },
     { name = "huggingface-hub" },
     { name = "msgspec" },
-    { name = "numpy" },
-    { name = "pillow" },
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -259,10 +257,37 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/3f/659b0f7140a5e91c96fb51dccf765a1f74384b3893d1b56ded6ef260688b/gen_worker-0.8.3.tar.gz", hash = "sha256:426593a6fd95855ec7cf932c5abc32745c3b4e64cd97a3cfe0feca3ac8782edf", size = 596192, upload-time = "2026-06-10T23:17:28.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/fc/cf4ac7697989ab3f07489efe0ebf482d7175a65e6dc11121a02aa9149f4d/gen_worker-0.8.3-py3-none-any.whl", hash = "sha256:c78c42c6c4cf26dfbe7fdf154d9a3db7bc63a4db772659a86405f022284c7c93", size = 668370, upload-time = "2026-06-10T23:17:29.993Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "backoff", specifier = ">=2.2.1" },
+    { name = "blake3", specifier = ">=1.0.0" },
+    { name = "boto3", specifier = ">=1.41.0" },
+    { name = "grpcio", specifier = ">=1.80.0" },
+    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
+    { name = "huggingface-hub", specifier = ">=0.26.0" },
+    { name = "msgspec", specifier = ">=0.18.6" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
+    { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.24" },
+    { name = "pillow", marker = "extra == 'images'", specifier = ">=10.0" },
+    { name = "protobuf", specifier = ">=6.30.0" },
+    { name = "psutil", specifier = ">=7.0.0" },
+    { name = "pyarrow", marker = "extra == 'trainer'", specifier = ">=17.0.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "requests", specifier = ">=2.32.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
+    { name = "safetensors", marker = "extra == 'torch'", specifier = ">=0.7.0" },
+    { name = "soundfile", marker = "extra == 'audio'", specifier = ">=0.12" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'torch'", specifier = ">=2.11.0" },
+    { name = "torchvision", marker = "extra == 'vision'", specifier = ">=0.26.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.4.20250913" },
 ]
+provides-extras = ["torch", "vision", "trainer", "images", "audio", "dev"]
 
 [[package]]
 name = "grpcio"
@@ -411,7 +436,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "gen-worker", specifier = ">=0.8.3" }]
+requires-dist = [{ name = "gen-worker", editable = "../../" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "mypy", specifier = ">=1.10.0" }]
@@ -486,25 +511,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -520,25 +526,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
-]
-
-[[package]]
-name = "pillow"
-version = "12.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
 ]
 
 [[package]]

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -35,6 +35,7 @@ _ENV_TO_FIELD: Dict[str, str] = {
     "WORKER_ID": "worker_id",
     "WORKER_MODE": "worker_mode",
     "WORKER_JWT": "worker_jwt",
+    "ENDPOINT_LOCK_PATH": "endpoint_lock_path",
     "TRAINER_JOB_SPEC_PATH": "trainer_job_spec_path",
     "RUNPOD_POD_ID": "runpod_pod_id",
     "WORKER_DISCONNECTED_TIMEOUT_S": "worker_disconnected_timeout_s",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -38,6 +38,9 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # Per-pod worker identity (orchestrator-injected).
     worker_id: str = ""
     worker_mode: Literal["inference", "trainer"] = "inference"
+    # Path to the discovery manifest (endpoint.lock). Default is the baked
+    # container location; non-container runs (e2e, bare-metal dev) override it.
+    endpoint_lock_path: str = "/app/.tensorhub/endpoint.lock"
     worker_jwt: str = ""
 
     # Trainer mode: path to the job spec JSON file the trainer pod was launched

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -41,6 +41,8 @@ except ImportError as e:
     print("Please ensure the gen_worker package is installed.", file=sys.stderr)
     sys.exit(1)
 
+# Default baked container location; overridden by Settings.endpoint_lock_path
+# (env ENDPOINT_LOCK_PATH) for non-container runs.
 MANIFEST_PATH = Path("/app/.tensorhub/endpoint.lock")
 
 logging.basicConfig(
@@ -91,18 +93,18 @@ def _log_worker_fatal(phase: str, exc: BaseException, *, exit_code: int) -> None
         logger.exception("worker.fatal: %s", exc)
 
 
-def load_manifest() -> Optional[dict]:
+def load_manifest(path: Path = MANIFEST_PATH) -> Optional[dict]:
     """Load the function manifest if it exists (baked in at build time)."""
-    if not MANIFEST_PATH.exists():
+    if not path.exists():
         return None
     try:
-        raw = MANIFEST_PATH.read_text(encoding="utf-8")
+        raw = path.read_text(encoding="utf-8")
         manifest = msgspec.toml.decode(raw)
         if not isinstance(manifest, dict):
             raise ValueError("endpoint.lock must decode to a TOML table")
         return manifest
     except Exception as e:
-        logger.warning("Failed to load manifest from %s: %s", MANIFEST_PATH, e)
+        logger.warning("Failed to load manifest from %s: %s", path, e)
         return None
 
 
@@ -191,14 +193,15 @@ def _run_main() -> int:
             _log_worker_fatal("trainer_runtime", e, exit_code=1)
             return 1
 
-    manifest = load_manifest()
+    manifest_path = Path(settings.endpoint_lock_path or MANIFEST_PATH)
+    manifest = load_manifest(manifest_path)
     user_modules: List[str] = []
     if manifest:
         user_modules = get_modules_from_manifest(manifest)
         _log_startup_phase(
             "manifest_loaded",
             status="ok",
-            manifest_path=str(MANIFEST_PATH),
+            manifest_path=str(manifest_path),
             function_count=len(manifest.get("functions", [])),
             module_count=len(user_modules),
         )
@@ -207,7 +210,7 @@ def _run_main() -> int:
             "manifest_loaded",
             status="error",
             level=logging.ERROR,
-            manifest_path=str(MANIFEST_PATH),
+            manifest_path=str(manifest_path),
             reason="missing_or_invalid_manifest",
         )
 
@@ -232,9 +235,11 @@ def _run_main() -> int:
 
     if not user_modules:
         logger.error(
-            "No user function modules found. A baked manifest at /app/.tensorhub/endpoint.lock is required.\n"
+            "No user function modules found. A baked manifest at %s is required.\n"
             "Your Dockerfile should run discovery at build time:\n"
-            "  RUN mkdir -p /app/.tensorhub && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock"
+            "  RUN mkdir -p /app/.tensorhub && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock\n"
+            "(non-container runs: set ENDPOINT_LOCK_PATH to the generated file)",
+            manifest_path,
         )
         return 1
 

--- a/tests/test_settings_loader.py
+++ b/tests/test_settings_loader.py
@@ -1,0 +1,12 @@
+"""Settings loader: env -> field mapping for the non-container seams."""
+
+from gen_worker.config import load_settings
+
+
+def test_endpoint_lock_path_default() -> None:
+    assert load_settings().endpoint_lock_path == "/app/.tensorhub/endpoint.lock"
+
+
+def test_endpoint_lock_path_env(monkeypatch) -> None:
+    monkeypatch.setenv("ENDPOINT_LOCK_PATH", "/tmp/e2e/endpoint.lock")
+    assert load_settings().endpoint_lock_path == "/tmp/e2e/endpoint.lock"


### PR DESCRIPTION
The e2e harness (e2e #100) runs the real gRPC worker as a bare subprocess:
the baked /app/.tensorhub/endpoint.lock location is container-only, and
examples/marco-polo's lock resolved gen-worker from PyPI (0.8.3, pre-#368)
so the @endpoint example could not even import. Settings gains
endpoint_lock_path (env ENDPOINT_LOCK_PATH, default unchanged); the example
pins gen-worker to the workspace source.
