### PR TITLE
chore(executor): per-job admitted/finished lifecycle logs at INFO

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -645,7 +645,7 @@ class Executor:
         job = _Job(request_id=run.request_id, attempt=run.attempt, spec=spec)
         self.jobs[key] = job
         self._idle.clear()
-        logger.debug("job admitted %s attempt=%d", run.request_id, run.attempt)
+        logger.info("job admitted %s attempt=%d", run.request_id, run.attempt)
         await self._send(pb.WorkerMessage(job_accepted=pb.JobAccepted(
             request_id=run.request_id, attempt=run.attempt)))
         job.task = asyncio.create_task(self._run_job(job, run), name=f"job-{run.request_id}")
@@ -991,7 +991,7 @@ class Executor:
         if job.finished:
             return
         job.finished = True
-        logger.debug("job finished %s attempt=%d status=%s", job.request_id, job.attempt, status)
+        logger.info("job finished %s attempt=%d status=%s", job.request_id, job.attempt, status)
         if not job.superseded:
             await self._send_result(job.request_id, job.attempt, status, **kw)
         # Keep finished records so a RunJob retransmission doesn't re-execute;


### PR DESCRIPTION
One line per (request_id, attempt) on admit and on terminal status —
standard production observability, and the outside-observable evidence
the e2e suite (e2e #100 S4/S5) uses to assert exactly-once execution and
orchestrator-bumped attempts.
