### PR TITLE
fix(dev): install cozy-convert workspace package with dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ audio = [
     "numpy>=1.24",
 ]
 dev = [
+    "cozy-convert",
     "grpcio-tools>=1.80.0",
     "mypy>=1.10.0",
     "ruff>=0.6.0",
@@ -145,6 +146,7 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.uv.sources]
+cozy-convert = { workspace = true }
 torch = [
   { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -619,6 +619,7 @@ audio = [
     { name = "soundfile" },
 ]
 dev = [
+    { name = "cozy-convert" },
     { name = "grpcio-tools" },
     { name = "mypy" },
     { name = "pytest" },
@@ -646,6 +647,7 @@ vision = [
 requires-dist = [
     { name = "blake3", specifier = ">=1.0.0" },
     { name = "boto3", specifier = ">=1.41.0" },
+    { name = "cozy-convert", marker = "extra == 'dev'", editable = "packages/cozy_convert" },
     { name = "grpcio", specifier = ">=1.80.0" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },


### PR DESCRIPTION
Pristine-checkout `uv run --extra dev pytest` failed with ModuleNotFoundError: cozy_convert (test added in PR #50 imports the workspace package, but root dev extras never installed it). Adds cozy-convert to the dev extra via a workspace source. 209 passed, 1 skipped.