### PR TITLE
fix(examples): flux2-klein-image passes prompt as a keyword

### DIFF
--- a/examples/flux2-klein-image/src/flux2_klein_image/main.py
+++ b/examples/flux2-klein-image/src/flux2_klein_image/main.py
@@ -67,8 +67,12 @@ class Flux2KleinTurbo:
 
         ctx.raise_if_cancelled()
         generator = torch.Generator(device=self._pipe.device).manual_seed(int(p.seed))
+        # Flux2KleinPipeline.__call__'s FIRST positional parameter is `image`
+        # (it is a text-to-image AND editing pipeline) — prompt must be a
+        # keyword or it lands in the image slot and the pipeline rejects the
+        # call with "Provide either `prompt` or `prompt_embeds`".
         image = self._pipe(
-            p.prompt,
+            prompt=p.prompt,
             num_inference_steps=steps,
             width=p.width,
             height=p.height,


### PR DESCRIPTION
## Summary
- `Flux2KleinPipeline.__call__`'s first positional parameter is `image` (text-to-image AND editing pipeline); the example passed the prompt positionally so it landed in the image slot and every generation failed with `Provide either prompt or prompt_embeds`.
- Found live by e2e #108 (J6) on a real RunPod RTX 4090 — the whole rest of the journey worked (pod create via gpu_tier pin, tunnel connect-back, ~16GB HF download in ~70s at datacenter bandwidth, IN_VRAM vram_bytes=15.9GB).

## Test plan
- [x] Example venv import clean
- [x] Live J6 re-run (in progress)