### PR TITLE
fix(cozy_convert): diffusers ingest skips root all-in-one checkpoints

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/classifier.py
+++ b/packages/cozy_convert/src/cozy_convert/classifier.py
@@ -195,6 +195,13 @@ def classify_repo(
             comp = p.split("/", 1)[0] if "/" in p else ""
             by_component.setdefault(comp, []).append(p)
         for comp, group in by_component.items():
+            if not comp:
+                # Root-level safetensors next to model_index.json are
+                # all-in-one duplicate checkpoints of the component tree
+                # (e.g. SD1.5's v1-5-pruned*.safetensors, 12GB on top of a
+                # 2.7GB fp16 component set) — never part of a
+                # diffusers-layout ingest.
+                continue
             comp_weights, comp_dtype = _pick_weight_set(group, dtype_pref)
             d_weights.extend(comp_weights)
             if comp and comp_dtype:

--- a/packages/cozy_convert/tests/test_classifier.py
+++ b/packages/cozy_convert/tests/test_classifier.py
@@ -52,6 +52,23 @@ def test_diffusers_dtype_preference_fp16() -> None:
     assert "transformer/diffusion_pytorch_model.bf16.safetensors" not in allow
 
 
+def test_diffusers_skips_root_allinone_checkpoints() -> None:
+    # SD1.5 shape: the repo ships all-in-one root checkpoints (12GB) on top
+    # of the component tree — a diffusers-layout ingest must never pull them
+    # (found live in e2e J7: 14.7GB selected instead of 2.75GB, ENOSPC on
+    # the ingest pod).
+    files = _DIFFUSERS + [
+        "v1-5-pruned.safetensors",
+        "v1-5-pruned-emaonly.safetensors",
+    ]
+    c = classify_repo(files, dtype_pref=("fp16",))
+    assert c.strategy == "diffusers"
+    allow = set(c.allow_patterns)
+    assert "v1-5-pruned.safetensors" not in allow
+    assert "v1-5-pruned-emaonly.safetensors" not in allow
+    assert "transformer/diffusion_pytorch_model.fp16.safetensors" in allow
+
+
 def test_transformers_with_sharded_index_and_onnx_excluded() -> None:
     files = [
         "config.json", "generation_config.json", "tokenizer.json",


### PR DESCRIPTION
## Summary
- The classifier's diffusers strategy grouped safetensors by first path segment and ran the variant picker on the ROOT group too, so repos shipping all-in-one root checkpoints alongside the component tree — SD1.5's `v1-5-pruned.safetensors` (7.7GB) + `v1-5-pruned-emaonly.safetensors` (4.3GB) — selected **14.7GB instead of the 2.75GB fp16 component set**.
- Found live in e2e J7: the `clone-huggingface` ingest pod ENOSPC'd (`[Errno 28] No space left on device` → `clone produced no publishable flavor`) on a 20GB container disk that comfortably fits the correct selection.
- A diffusers-layout ingest never wants the root duplicates; skip the root group in strategy 3. Repos whose weights live ONLY at the root don't take this path (no `model_index.json` → singlefile/AIO strategies handle them).

## Test plan
- [x] New unit `test_diffusers_skips_root_allinone_checkpoints` (SD1.5 shape)
- [x] `pytest packages/cozy_convert/tests` — 29 passed (test_integration/test_writer need torch in the env; pre-existing, unrelated)
- [x] Live verification follows in the e2e J7 rerun (selection drops from 14.71GB/19 files to ~2.75GB)