### PR TITLE
fix(cozy_convert): HubClient supports the R2 SDK transfer-grant upload path

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/hub.py
+++ b/packages/cozy_convert/src/cozy_convert/hub.py
@@ -173,9 +173,46 @@ class HubClient:
     def _upload_one(self, repo_path: str, revision_id: str, entry: Mapping[str, Any],
                     local_path: Path) -> None:
         upload_id = str(entry.get("upload_id") or "").strip()
+        if not upload_id:
+            raise HubPublishError(f"commit upload entry missing upload_id for {entry.get('path')!r}")
+        complete_path = (
+            f"{repo_path}/commits/{urllib.parse.quote(revision_id, safe='')}"
+            f"/uploads/{urllib.parse.quote(upload_id, safe='')}/complete"
+        )
+
+        # SDK transfer-grant path (R2): the server returns a scoped temporary
+        # credential instead of presigned multipart part URLs. Upload the
+        # object directly with the S3 SDK, then complete with the transfer
+        # block (same wire shape gen_worker.presigned_upload uses for media).
+        grant_raw = entry.get("transfer_grant")
+        if isinstance(grant_raw, Mapping):
+            from gen_worker.s3_transfer import S3TransferGrant, upload_file_with_grant
+
+            grant = S3TransferGrant.from_mapping(grant_raw)
+            size_bytes = int(entry.get("size_bytes") or local_path.stat().st_size)
+            result = upload_file_with_grant(
+                file_path=local_path,
+                grant=grant,
+                blake3_hex=str(entry.get("blake3") or ""),
+                size_bytes=size_bytes,
+            )
+            resp = self._post(complete_path, {"transfer": {
+                "mode": "s3_sdk",
+                "bucket": result.bucket,
+                "key": result.key,
+                "size_bytes": result.size_bytes,
+                "blake3": result.blake3,
+                "etag": result.etag,
+            }})
+            if resp.status_code < 200 or resp.status_code >= 300:
+                raise HubPublishError(
+                    f"upload complete failed ({resp.status_code}) for {entry.get('path')!r}: "
+                    f"{resp.text[:500]}")
+            return
+
         part_urls = list(entry.get("part_urls") or [])
         part_size = int(entry.get("part_size") or 0)
-        if not upload_id or not part_urls or part_size <= 0:
+        if not part_urls or part_size <= 0:
             raise HubPublishError(f"commit upload entry missing presign data for {entry.get('path')!r}")
         parts: list[dict[str, Any]] = []
         with open(local_path, "rb") as f:
@@ -192,10 +229,6 @@ class HubClient:
                         f"part PUT failed ({resp.status_code}) for {entry.get('path')!r}")
                 etag = str(resp.headers.get("ETag") or "").strip().strip('"')
                 parts.append({"part_number": i + 1, "etag": etag})
-        complete_path = (
-            f"{repo_path}/commits/{urllib.parse.quote(revision_id, safe='')}"
-            f"/uploads/{urllib.parse.quote(upload_id, safe='')}/complete"
-        )
         resp = self._post(complete_path, {"parts": parts})
         if resp.status_code < 200 or resp.status_code >= 300:
             raise HubPublishError(

--- a/packages/cozy_convert/tests/conftest.py
+++ b/packages/cozy_convert/tests/conftest.py
@@ -52,6 +52,22 @@ class _FakeHub(BaseHTTPRequestHandler):
                     continue
                 uid = f"up-{i}"
                 base = f"http://127.0.0.1:{self.server.server_port}"
+                if st.get("grant_mode"):
+                    # R2 SDK-transfer shape: scoped temp credential, no
+                    # multipart part URLs.
+                    uploads.append({
+                        "path": op["path"], "blake3": op["blake3"], "exists": False,
+                        "upload_id": uid,
+                        "size_bytes": int(op["size_bytes"]),
+                        "transfer_grant": {
+                            "endpoint_url": "https://acct.r2.cloudflarestorage.com",
+                            "bucket": "repo-cas",
+                            "key": f"__presigned_staging/v1/{uid}/object",
+                            "access_key_id": "k", "secret_access_key": "s",
+                            "session_token": "t", "region": "auto",
+                        },
+                    })
+                    continue
                 uploads.append({
                     "path": op["path"], "blake3": op["blake3"], "exists": False,
                     "upload_id": uid,

--- a/packages/cozy_convert/tests/test_hub.py
+++ b/packages/cozy_convert/tests/test_hub.py
@@ -55,6 +55,44 @@ def test_commit_uploads_completes_and_finalizes(fake_hub, tmp_path: Path, monkey
     assert st["auth"] == "Bearer cap-token"
 
 
+def test_commit_uses_sdk_transfer_grant_when_offered(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    # R2 path (found live in e2e J7): the server returns a scoped temporary
+    # credential (transfer_grant) instead of presigned multipart part URLs;
+    # the client must SDK-upload and complete with the transfer block.
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["grant_mode"] = True
+    _FakeHub.state["finalize_calls"] = 1  # finalize 200 immediately
+
+    calls: list[dict] = []
+
+    def _fake_upload(*, file_path, grant, blake3_hex, size_bytes, on_progress=None):
+        from gen_worker.s3_transfer import S3TransferResult
+        calls.append({"file_path": str(file_path), "bucket": grant.bucket,
+                      "key": grant.key, "blake3": blake3_hex, "size": size_bytes})
+        return S3TransferResult(bucket=grant.bucket, key=grant.key,
+                                size_bytes=size_bytes, blake3=blake3_hex, etag="sdk-etag")
+
+    import gen_worker.s3_transfer as s3t
+    monkeypatch.setattr(s3t, "upload_file_with_grant", _fake_upload)
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x02" * 48)
+    result = _client(fake_hub).commit(
+        destination_repo="acme/my-model",
+        files=[CommitFile(path="model.safetensors", local_path=f)],
+    )
+    assert result.uploaded == 1 and result.deduped == 0
+    assert len(calls) == 1
+    assert calls[0]["bucket"] == "repo-cas"
+    assert calls[0]["size"] == 48
+    # No raw part PUTs happened; complete carried the transfer block.
+    assert "put_bytes" not in _FakeHub.state
+    body = _FakeHub.state["complete_bodies"][0]
+    assert body["transfer"]["mode"] == "s3_sdk"
+    assert body["transfer"]["etag"] == "sdk-etag"
+    assert body["transfer"]["blake3"] == blake3_file(f)
+
+
 def test_dedup_skips_put(fake_hub, tmp_path: Path) -> None:
     f = tmp_path / "model.safetensors"
     f.write_bytes(b"\x01" * 32)


### PR DESCRIPTION
## Summary
- tensorhub's `POST /commits` returns two upload shapes per file: presigned multipart `part_urls` (minio/AWS) **or** a scoped temporary credential `transfer_grant` (Cloudflare R2 only, via `TemporaryObjectWriteGrant`). `HubClient._upload_one` only knew the multipart shape, so the first-ever publish against REAL R2 failed instantly with `commit upload entry missing presign data` (found live in e2e J7 — tensorhub PR#73's probe ran against minio, which never takes the grant path).
- Fix: consume the grant with the same `gen_worker.s3_transfer.upload_file_with_grant` machinery media uploads already use (`presigned_upload.py`), then complete with the `{"transfer": {"mode": "s3_sdk", ...}}` block that repo-cas `/complete` already accepts (`handleCompleteRepoJobUploadPresigned`). Multipart path unchanged as the non-R2 fallback.

## Test plan
- [x] New unit `test_commit_uses_sdk_transfer_grant_when_offered` (fake hub returns the grant shape; SDK upload mocked; asserts no raw part PUTs + transfer complete body)
- [x] `pytest packages/cozy_convert/tests/test_hub.py tests/test_classifier.py` — 24 passed
- [x] Live verification follows in the e2e J7 rerun (real R2)