### PR TITLE
fix(presigned_upload): poll through upload_complete_in_progress instead of failing

### DIFF
--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -64,6 +64,19 @@ _CREATE_TIMEOUT_S = 60
 _FINALIZE_RETRY_ATTEMPTS = 5
 _FINALIZE_RETRY_BACKOFF_S = 0.5
 
+# tensorhub's /complete verifies the whole object (streams it back from R2 and
+# hashes it) synchronously and holds a per-upload lock for the duration; for
+# large single files this can run past whatever timeout an intermediary in
+# front of tensorhub enforces (~100-120s observed live), so the CLIENT sees a
+# transient 5xx/timeout on an attempt that is still running server-side. Our
+# own retry then races the first attempt and gets 409 upload_complete_in_progress
+# — a false negative (found live: e2e tracker #110, a ~6.94GB singlefile
+# mirror). Poll on that specific 409 rather than treating it as fatal: once
+# the in-flight attempt finishes, /complete's `sess.Finalized` fast path
+# returns the same 200 success payload to the next poll, no data lost.
+_COMPLETE_IN_PROGRESS_POLL_S = 5.0
+_COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600.0
+
 # Default part size sent by server, but we read it from the response.
 _FALLBACK_PART_SIZE = 64 * 1024 * 1024  # 64 MiB
 
@@ -342,6 +355,75 @@ def presigned_upload_file(
     return PresignedUploadResult(meta=result_meta, dedup=False)
 
 
+def _error_code_of(resp: requests.Response) -> str:
+    """Best-effort extraction of the structured `error.code` field
+    (docs/api-conventions.md: `{"error": {"code": ..., ...}}`); "" if the
+    body isn't that shape."""
+    try:
+        body = resp.json()
+    except ValueError:
+        return ""
+    if not isinstance(body, dict):
+        return ""
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return ""
+    return str(err.get("code") or "")
+
+
+def _poll_until_finalized(
+    *,
+    complete_url: str,
+    complete_headers: Dict[str, str],
+    payload: Dict[str, Any],
+    cancel_check: Optional[Any],
+) -> Dict[str, Any]:
+    """A prior /complete attempt is still finalizing server-side (409
+    upload_complete_in_progress) — tensorhub verifies large objects
+    synchronously and can outlast whatever timeout sits in front of it, so the
+    CLIENT'S view (5xx/timeout) can lag the server's. /complete is idempotent
+    once finalized (`sess.Finalized` fast path returns the same success
+    payload), so re-POST it instead of treating the race as fatal."""
+    deadline = time.monotonic() + _COMPLETE_IN_PROGRESS_MAX_WAIT_S
+    while True:
+        if cancel_check and cancel_check():
+            raise CanceledError("canceled")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ArtifactTransferError(
+                "tensorhub upload finalize: gave up waiting for a concurrent "
+                "completion to finish (upload_complete_in_progress persisted "
+                f"past {_COMPLETE_IN_PROGRESS_MAX_WAIT_S:.0f}s)",
+                provider="tensorhub",
+                phase="complete",
+                retryable=True,
+                status_code=409,
+            )
+        time.sleep(min(_COMPLETE_IN_PROGRESS_POLL_S, remaining))
+        try:
+            resp = requests.post(
+                complete_url, headers=complete_headers, data=json.dumps(payload),
+                timeout=_FINALIZE_TIMEOUT_S,
+            )
+        except requests.RequestException:
+            continue  # transient — keep polling within the deadline
+        code = resp.status_code
+        if code in (401, 403):
+            raise AuthError(f"file save unauthorized ({code})")
+        if 200 <= code < 300:
+            return _parse_json_response(resp, phase="complete")
+        if code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
+            continue  # still racing the first attempt
+        # Any other terminal error: stop polling, surface it normally.
+        raise ArtifactTransferError(
+            f"tensorhub upload finalize failed: {_response_body_sample(resp)}",
+            provider="tensorhub",
+            phase="complete",
+            retryable=code >= 500 or code == 429,
+            status_code=code,
+        )
+
+
 def _complete_upload_session(
     *,
     complete_url: str,
@@ -374,6 +456,13 @@ def _complete_upload_session(
             code = resp.status_code
             if code in (401, 403):
                 raise AuthError(f"file save unauthorized ({code})")
+            if code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
+                return _poll_until_finalized(
+                    complete_url=complete_url,
+                    complete_headers=complete_headers,
+                    payload=payload,
+                    cancel_check=cancel_check,
+                )
             if code >= 500:
                 last_exc = ArtifactTransferError(
                     f"tensorhub upload finalize failed: {_response_body_sample(resp)}",

--- a/tests/test_presigned_upload_complete_retry.py
+++ b/tests/test_presigned_upload_complete_retry.py
@@ -1,0 +1,115 @@
+"""Regression tests for the /complete false-negative-on-retry bug (e2e
+tracker #110): tensorhub verifies large single files synchronously and can
+outlast an intermediary's timeout, so a client retry can race the still-running
+first attempt and get 409 upload_complete_in_progress. The client must poll
+that specific condition to the server's actual `Finalized` outcome instead of
+treating it as fatal (which previously aborted the whole commit)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from gen_worker.presigned_upload import (
+    _complete_upload_session,
+    _error_code_of,
+    _poll_until_finalized,
+)
+from gen_worker.api.errors import ArtifactTransferError, CanceledError
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: dict | None = None, text: str | None = None):
+        self.status_code = status_code
+        self._body = body
+        self.text = text if text is not None else (json.dumps(body) if body is not None else "")
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("no json body")
+        return self._body
+
+
+def test_error_code_of_extracts_structured_error_code():
+    resp = _FakeResponse(409, {"error": {"code": "upload_complete_in_progress", "message": "x"}})
+    assert _error_code_of(resp) == "upload_complete_in_progress"
+
+
+def test_error_code_of_returns_empty_for_non_structured_body():
+    assert _error_code_of(_FakeResponse(500, text="internal error")) == ""
+    assert _error_code_of(_FakeResponse(200, {"ok": True})) == ""
+
+
+def test_complete_upload_session_polls_through_upload_complete_in_progress(monkeypatch):
+    """First attempt races a concurrent finalize (409); the poll loop must
+    keep re-POSTing /complete (idempotent per tensorhub's `sess.Finalized`
+    fast path) until it succeeds, rather than raising immediately."""
+    responses = [
+        _FakeResponse(409, {"error": {"code": "upload_complete_in_progress"}}),
+        _FakeResponse(409, {"error": {"code": "upload_complete_in_progress"}}),
+        _FakeResponse(200, {"destination_repo": "tensorhub/sdxl-illustrious", "published": []}),
+    ]
+    calls = {"n": 0}
+
+    def fake_post(*_a, **_kw):
+        resp = responses[calls["n"]]
+        calls["n"] += 1
+        return resp
+
+    with patch("gen_worker.presigned_upload.requests.post", side_effect=fake_post), \
+         patch("gen_worker.presigned_upload.time.sleep"):
+        result = _complete_upload_session(
+            complete_url="https://tensorhub.test/complete",
+            headers={"Authorization": "Bearer x"},
+            payload={"transfer": {"mode": "s3_sdk"}},
+            cancel_check=None,
+        )
+    assert result == {"destination_repo": "tensorhub/sdxl-illustrious", "published": []}
+    assert calls["n"] == 3
+
+
+def test_poll_until_finalized_gives_up_after_deadline(monkeypatch):
+    """A genuinely stuck server (never finalizes) must eventually raise a
+    retryable ArtifactTransferError rather than polling forever."""
+    monkeypatch.setattr(
+        "gen_worker.presigned_upload._COMPLETE_IN_PROGRESS_MAX_WAIT_S", 0.01,
+    )
+    always_409 = _FakeResponse(409, {"error": {"code": "upload_complete_in_progress"}})
+    with patch("gen_worker.presigned_upload.requests.post", return_value=always_409), \
+         patch("gen_worker.presigned_upload.time.sleep"):
+        with pytest.raises(ArtifactTransferError) as exc_info:
+            _poll_until_finalized(
+                complete_url="https://tensorhub.test/complete",
+                complete_headers={},
+                payload={},
+                cancel_check=None,
+            )
+    assert exc_info.value.retryable is True
+
+
+def test_poll_until_finalized_respects_cancel_check():
+    with pytest.raises(CanceledError):
+        _poll_until_finalized(
+            complete_url="https://tensorhub.test/complete",
+            complete_headers={},
+            payload={},
+            cancel_check=lambda: True,
+        )
+
+
+def test_complete_upload_session_other_409_is_not_polled():
+    """A different 409 (e.g. the session was aborted) is a real terminal
+    error, not the in-progress race — must not enter the poll loop."""
+    aborted = _FakeResponse(409, {"error": {"code": "upload_session_aborted"}})
+    with patch("gen_worker.presigned_upload.requests.post", return_value=aborted):
+        with pytest.raises(ArtifactTransferError) as exc_info:
+            _complete_upload_session(
+                complete_url="https://tensorhub.test/complete",
+                headers={},
+                payload={},
+                cancel_check=None,
+            )
+    assert exc_info.value.retryable is False
+    assert exc_info.value.status_code == 409


### PR DESCRIPTION
## Summary
- tensorhub verifies large single-file uploads synchronously (streams the whole object back from R2 and hashes it) before responding to `/complete`, holding a per-upload lock for the duration. For big files this can outlast whatever timeout sits in front of tensorhub — the client sees a 5xx/timeout on an attempt that is still running server-side, retries, and races the first attempt into a `409 upload_complete_in_progress`. That 409 was treated as a hard failure, aborting the whole commit even though the first attempt was about to succeed.
- Found live mirroring a ~6.94GB SDXL checkpoint (single safetensors file, not diffusers multi-component): `/complete` took 110s and returned 503, the retry got 409, the worker aborted the commit, and R2 kept an orphaned partial blob (e2e tracker #110).
- Fix: on `upload_complete_in_progress` specifically, poll by re-POSTing `/complete` (idempotent — tensorhub's `sess.Finalized` fast path returns the same success payload once the in-flight attempt finishes) instead of raising immediately. Bounded by `_COMPLETE_IN_PROGRESS_MAX_WAIT_S` (10 min) so a genuinely stuck server still fails eventually.

## Test plan
- [x] New `tests/test_presigned_upload_complete_retry.py` (6 cases: error-code extraction, polls through 409-in-progress to success, gives up after deadline, respects cancel_check, does NOT poll a different 409 like `upload_session_aborted`)
- [x] `uv run --extra dev pytest -q` — 234 passed, 1 skipped