### PR TITLE
fix(cozy_convert): HubClient polls through upload_complete_in_progress races

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/hub.py
+++ b/packages/cozy_convert/src/cozy_convert/hub.py
@@ -33,6 +33,20 @@ _RETRY_ATTEMPTS = 5
 _RETRY_BASE_DELAY_S = 1.0
 _RETRY_MAX_DELAY_S = 30.0
 
+# tensorhub's /complete verifies the whole object synchronously (streams it
+# back from R2 and hashes it) before responding, holding a per-upload lock
+# for the duration. For large single files this can outlast whatever timeout
+# sits in front of tensorhub -- the client sees a 5xx/timeout on an attempt
+# that is still running server-side, retries, and races the first attempt
+# into 409 upload_complete_in_progress. Found live mirroring a ~6.94GB SDXL
+# checkpoint: the default 120s request timeout expired while the server was
+# still hashing, the retry got 409, and _upload_one raised immediately --
+# aborting the whole commit even though the first attempt was about to
+# succeed (e2e tracker #110).
+_COMPLETE_TIMEOUT_S = 600.0
+_COMPLETE_IN_PROGRESS_POLL_S = 5.0
+_COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600.0
+
 
 class HubPublishError(RuntimeError):
     """Terminal failure talking to tensorhub's commit API."""
@@ -44,6 +58,22 @@ def _retry_after_s(resp: requests.Response) -> Optional[float]:
     except Exception:
         return None
     return min(value, _RETRY_MAX_DELAY_S) if value > 0 else None
+
+
+def _error_code_of(resp: requests.Response) -> str:
+    """Best-effort extraction of the structured `error.code` field
+    (docs/api-conventions.md: `{"error": {"code": ..., ...}}`); "" if the
+    body isn't that shape."""
+    try:
+        body = resp.json() if resp.text else {}
+    except Exception:
+        return ""
+    if not isinstance(body, dict):
+        return ""
+    err = body.get("error")
+    if not isinstance(err, dict):
+        return ""
+    return str(err.get("code") or "")
 
 
 def _send_with_retries(what: str, send: Callable[[], requests.Response]) -> requests.Response:
@@ -170,6 +200,24 @@ class HubClient:
             out = {}
         return out if isinstance(out, dict) else {}
 
+    def _post_complete(self, complete_path: str, payload: dict) -> requests.Response:
+        """POST .../complete with a generous timeout (large single files
+        verify synchronously server-side, see _COMPLETE_TIMEOUT_S), then poll
+        through a 409 upload_complete_in_progress race instead of treating it
+        as fatal: /complete is idempotent once finalized (tensorhub's
+        sess.Finalized fast path returns the same success payload), so
+        re-POSTing catches up to whatever the in-flight attempt decides."""
+        resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
+        if not (resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress"):
+            return resp
+        deadline = time.monotonic() + _COMPLETE_IN_PROGRESS_MAX_WAIT_S
+        while resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
+            resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
+        return resp
+
     def _upload_one(self, repo_path: str, revision_id: str, entry: Mapping[str, Any],
                     local_path: Path) -> None:
         upload_id = str(entry.get("upload_id") or "").strip()
@@ -196,7 +244,7 @@ class HubClient:
                 blake3_hex=str(entry.get("blake3") or ""),
                 size_bytes=size_bytes,
             )
-            resp = self._post(complete_path, {"transfer": {
+            resp = self._post_complete(complete_path, {"transfer": {
                 "mode": "s3_sdk",
                 "bucket": result.bucket,
                 "key": result.key,
@@ -229,7 +277,7 @@ class HubClient:
                         f"part PUT failed ({resp.status_code}) for {entry.get('path')!r}")
                 etag = str(resp.headers.get("ETag") or "").strip().strip('"')
                 parts.append({"part_number": i + 1, "etag": etag})
-        resp = self._post(complete_path, {"parts": parts})
+        resp = self._post_complete(complete_path, {"parts": parts})
         if resp.status_code < 200 or resp.status_code >= 300:
             raise HubPublishError(
                 f"upload complete failed ({resp.status_code}) for {entry.get('path')!r}: "

--- a/packages/cozy_convert/tests/conftest.py
+++ b/packages/cozy_convert/tests/conftest.py
@@ -84,6 +84,16 @@ class _FakeHub(BaseHTTPRequestHandler):
                 st["fail_completes"] -= 1
                 self._send(500, {"error": "boom"})
                 return
+            if st.get("complete_race_count", 0) > 0:
+                # Simulates a still-finalizing concurrent attempt (tensorhub
+                # verifies large single files synchronously and can outlast
+                # the client's timeout -- e2e tracker #110): the caller must
+                # poll rather than treat this 409 as fatal.
+                st["complete_race_count"] -= 1
+                st.setdefault("complete_race_polls", []).append(self.path)
+                self._send(409, {"error": {"code": "upload_complete_in_progress",
+                                           "message": "a concurrent completion is in progress"}})
+                return
             st.setdefault("completed", []).append(self.path)
             body = self._read_json()
             st.setdefault("complete_bodies", []).append(body)

--- a/packages/cozy_convert/tests/test_hub.py
+++ b/packages/cozy_convert/tests/test_hub.py
@@ -135,6 +135,77 @@ def test_transient_failures_are_retried(fake_hub, tmp_path: Path, monkeypatch) -
     assert list(_FakeHub.state["put_bytes"].values()) == [b"\x02" * 48]
 
 
+def test_complete_polls_through_upload_complete_in_progress_race(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """Regression for e2e tracker #110: /complete verifies large single
+    files synchronously and can outlast the client's timeout, so a retry can
+    race the still-running first attempt into 409 upload_complete_in_progress.
+    That must be polled through (idempotent once finalized), not treated as
+    a fatal error that aborts the whole commit."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["complete_race_count"] = 2
+    _FakeHub.state["finalize_calls"] = 1  # finalize returns 200 immediately
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x03" * 48)
+    result = _client(fake_hub).commit(
+        destination_repo="acme/my-model",
+        files=[CommitFile(path="model.safetensors", local_path=f)],
+    )
+    assert result.revision_id == "rev-1"
+    assert result.uploaded == 1
+    assert len(_FakeHub.state["complete_race_polls"]) == 2
+    assert list(_FakeHub.state["put_bytes"].values()) == [b"\x03" * 48]
+
+
+def test_complete_polls_through_race_on_sdk_transfer_grant_path(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """Same race, but on the R2 SDK transfer-grant complete path (the shape
+    actually used by clone-huggingface/clone-civitai mirrors)."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["grant_mode"] = True
+    _FakeHub.state["complete_race_count"] = 1
+    _FakeHub.state["finalize_calls"] = 1
+
+    def _fake_upload(*, file_path, grant, blake3_hex, size_bytes, on_progress=None):
+        from gen_worker.s3_transfer import S3TransferResult
+        return S3TransferResult(bucket=grant.bucket, key=grant.key,
+                                size_bytes=size_bytes, blake3=blake3_hex, etag="sdk-etag")
+
+    import gen_worker.s3_transfer as s3t
+    monkeypatch.setattr(s3t, "upload_file_with_grant", _fake_upload)
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x04" * 48)
+    result = _client(fake_hub).commit(
+        destination_repo="acme/my-model",
+        files=[CommitFile(path="model.safetensors", local_path=f)],
+    )
+    assert result.uploaded == 1
+    assert len(_FakeHub.state["complete_race_polls"]) == 1
+    assert _FakeHub.state["complete_bodies"][0]["transfer"]["etag"] == "sdk-etag"
+
+
+def test_complete_gives_up_after_deadline_if_race_never_resolves(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """A genuinely stuck server (never finalizes) must still fail eventually
+    rather than polling forever."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    monkeypatch.setattr("cozy_convert.hub._COMPLETE_IN_PROGRESS_MAX_WAIT_S", 0.0)
+    _FakeHub.state["complete_race_count"] = 10_000
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x05" * 48)
+    with pytest.raises(HubPublishError, match="upload complete failed"):
+        _client(fake_hub).commit(
+            destination_repo="acme/my-model",
+            files=[CommitFile(path="model.safetensors", local_path=f)],
+        )
+
+
 def test_files_from_tree_skips_hf_cache_junk(tmp_path: Path) -> None:
     (tmp_path / "config.json").write_text("{}")
     junk = tmp_path / ".cache" / "huggingface" / "download"


### PR DESCRIPTION
## Summary
- Follow-up to #62, which fixed the wrong file. `clone-huggingface`/`clone-civitai` publish through `cozy_convert.hub.HubClient`, a separate upload client from `gen_worker.presigned_upload` — #62's fix never reaches this code path, and the same failure reproduced identically live post-#62.
- tensorhub's `/complete` verifies large single-file uploads synchronously (streams the whole object back from R2 and hashes it), holding a per-upload lock for the duration. `HubClient`'s default 120s request timeout is too short for that on big files, so the client sees a timeout/5xx on an attempt still running server-side, retries, and races into `409 upload_complete_in_progress` — which `_upload_one` treated as fatal, aborting the whole commit even though the first attempt was about to succeed.
- Found live mirroring a ~6.94GB SDXL checkpoint via the actual e2e bulk-ingest catalog run (e2e tracker #110).
- Fix: new `_post_complete` helper raises the `/complete` timeout to 600s and, on `409 upload_complete_in_progress` specifically, polls by re-POSTing `/complete` (idempotent — tensorhub's `sess.Finalized` fast path returns the same success payload once the in-flight attempt finishes) instead of raising immediately. Bounded by `_COMPLETE_IN_PROGRESS_MAX_WAIT_S` (10 min) so a genuinely stuck server still fails eventually. Applied to both the R2 SDK transfer-grant complete path and the presigned-multipart complete path.

## Test plan
- [x] 3 new cases in `packages/cozy_convert/tests/test_hub.py` (polls through the race on both complete-payload shapes; gives up after deadline) + a `complete_race_count` simulation in the shared fake-hub fixture
- [x] `cd packages/cozy_convert && uv run --extra dev pytest -q` — 50 passed, 1 skipped
- [x] `uv run --extra dev pytest -q` (workspace root) — 234 passed, 1 skipped