### PR TITLE
fix(cozy_convert): shrink shard size to stay clear of a ~300s tunnel timeout

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/writer.py
+++ b/packages/cozy_convert/src/cozy_convert/writer.py
@@ -34,7 +34,20 @@ class ConversionImplementationError(RuntimeError):
     """A conversion primitive can't proceed (bad input, missing dep)."""
 
 
-MAX_SAFETENSORS_SHARD_BYTES: int = 5 * 1024 * 1024 * 1024  # HF default shard size
+MAX_SAFETENSORS_SHARD_BYTES: int = 2 * 1024 * 1024 * 1024
+# Was 5GB (HF's own default shard size) until e2e tracker #110: tensorhub's
+# per-upload /complete verifies the whole shard synchronously (streams it
+# back from R2 and hashes it) in one HTTP request, and something in front of
+# it (observed: a consistent, exact ~300s ceiling, almost certainly the
+# ngrok tunnel this whole cloud stack rides on rather than tensorhub itself)
+# kills that request outright regardless of tensorhub's own generous
+# timeout. Live: a 5.36GB shard sometimes finished in ~200-260s (racy, close
+# to the wall); a 9.8GB shard failed the SAME way on every one of 5 retries
+# (it deterministically needs longer than the wall allows, so retrying
+# doesn't help). 2GB keeps every shard's verify time comfortably clear of
+# that ceiling regardless of R2 throughput variance. cozy_convert.hub's
+# retry/poll resilience (#62/#63) still covers the remaining transient case;
+# this fixes the deterministic one.
 
 _PICKLE_EXTS = (".ckpt", ".pt", ".pth", ".bin")
 

--- a/packages/cozy_convert/tests/test_writer.py
+++ b/packages/cozy_convert/tests/test_writer.py
@@ -10,6 +10,7 @@ import torch
 from safetensors.torch import load_file, save_file
 
 from cozy_convert.writer import (
+    MAX_SAFETENSORS_SHARD_BYTES,
     IncrementalSafetensorsWriter,
     materialize_pickle_to_safetensors,
     plan_shards,
@@ -17,6 +18,18 @@ from cozy_convert.writer import (
     streaming_dtype_cast,
     torch_dtype_to_st,
 )
+
+
+def test_max_shard_bytes_stays_clear_of_the_tunnel_timeout() -> None:
+    """Regression guard for e2e tracker #110: tensorhub's per-upload
+    /complete verifies a shard synchronously in one HTTP request, and a
+    consistent ~300s ceiling in front of it (observed live; almost
+    certainly the ngrok tunnel this stack rides on) deterministically
+    kills any shard whose verify time exceeds it -- a 9.8GB shard failed
+    identically on every one of 5 retries. This must stay meaningfully
+    below the old 5GB (HF default) that caused it, not silently drift
+    back up."""
+    assert MAX_SAFETENSORS_SHARD_BYTES <= 2 * 1024 * 1024 * 1024
 
 
 def _make_safetensors(path: Path, tensors: dict[str, torch.Tensor]) -> Path:


### PR DESCRIPTION
## Summary
- tensorhub's per-upload `/complete` verifies a shard synchronously (streams it back from R2 and hashes it) in one HTTP request, and something in front of it (observed live: a consistent, exact ~300s ceiling on every failure — almost certainly the ngrok tunnel this whole cloud stack rides on, not tensorhub's own generous 600s timeout from #62/#63) kills that request outright regardless of retries.
- A 5.36GB shard sometimes finished in ~200-260s (racy, close to the wall); a 9.8GB shard failed the SAME way on every one of 5 retries — it deterministically needs longer than the wall allows, so retrying more doesn't help.
- Found live bulk-ingesting `flux2-klein-9b` (e2e tracker #110).
- Fix: `MAX_SAFETENSORS_SHARD_BYTES` 5GB (HF's default) → 2GB, keeping every shard's verify time comfortably clear of that ceiling regardless of R2 throughput variance. The retry/poll resilience from #62/#63 still covers genuinely transient failures; this fixes the deterministic one.

## Test plan
- [x] New guard test in `test_writer.py` asserting the constant stays ≤2GB
- [x] `cd packages/cozy_convert && uv run --extra dev pytest -q` — 50 passed, 1 skipped
- [x] `uv run --extra dev pytest -q` (workspace root) — 234 passed, 1 skipped