### PR TITLE
fix(worker): VRAM-gate GiB rounding + single-file checkpoint loading

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -508,7 +508,10 @@ class Executor:
                     f"requires SM {r.compute_capability:.1f}, detected {detected_cc:.1f}",
                     {"detected_sm": f"{detected_cc:.1f}", "required_sm": f"{float(r.compute_capability):.1f}"})
                 continue
-            if r.vram_gb is not None and total_vram_gb and total_vram_gb < float(r.vram_gb):
+            # Compare on the rounded GiB: a "24GB" card reports ~23.99GiB via
+            # mem_get_info (driver/ECC reserve), which must not gate off
+            # functions declaring vram_gb=24.
+            if r.vram_gb is not None and total_vram_gb and round(total_vram_gb) < float(r.vram_gb):
                 self.unavailable[name] = (
                     "insufficient_vram",
                     f"requires {r.vram_gb:.0f}GiB VRAM, detected {total_vram_gb:.0f}GiB",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -174,6 +174,21 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
     return BitsAndBytesConfig(load_in_8bit=True)
 
 
+def _single_file_checkpoint(path: Path) -> Optional[Path]:
+    """A snapshot that is one loose checkpoint rather than a pretrained layout:
+    the path itself when it's a ``.safetensors`` file, or the directory's sole
+    ``*.safetensors`` when no ``model_index.json``/``config.json`` exists
+    (e.g. Illustrious-XL, civitai checkpoints)."""
+    if path.is_file():
+        return path if path.suffix == ".safetensors" else None
+    if not path.is_dir():
+        return None
+    if (path / "model_index.json").exists() or (path / "config.json").exists():
+        return None
+    singles = sorted(p for p in path.glob("*.safetensors") if p.is_file())
+    return singles[0] if len(singles) == 1 else None
+
+
 def load_from_pretrained(
     cls: Any,
     path: str | Path,
@@ -183,8 +198,9 @@ def load_from_pretrained(
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
-    preload, and quant-config synthesis. Used by the executor to satisfy
-    pipeline-typed ``setup()`` annotations; endpoints may also call it."""
+    preload, and quant-config synthesis; single-file checkpoints route through
+    ``cls.from_single_file``. Used by the executor to satisfy pipeline-typed
+    ``setup()`` annotations; endpoints may also call it."""
     path = str(path)
     ensure_quant_library_imported(attrs)
     kwargs: Dict[str, Any] = {}
@@ -203,6 +219,10 @@ def load_from_pretrained(
         qc = synthesize_quantization_config(attrs)
         if qc is not None:
             kwargs["quantization_config"] = qc
+    single = _single_file_checkpoint(Path(path))
+    if single is not None and callable(getattr(cls, "from_single_file", None)):
+        kwargs.pop("variant", None)
+        return cls.from_single_file(str(single), **kwargs)
     try:
         return cls.from_pretrained(path, **kwargs)
     except (TypeError, ValueError):

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -1,0 +1,122 @@
+"""VRAM-gate GiB rounding + single-file checkpoint loading (#347 roster sweep).
+
+A "24GB" card reports ~23.99GiB via torch.cuda.mem_get_info (driver/ECC
+reserve); the availability gate must not disable functions declaring
+``Resources(vram_gb=24)`` on exactly the card they target. Single-file repos
+(Illustrious-XL, civitai checkpoints) have no ``model_index.json`` and must
+route through ``cls.from_single_file``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import msgspec
+
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor
+from gen_worker.models.loading import _single_file_checkpoint, load_from_pretrained
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    x: str
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+def _spec(name: str, vram_gb: float) -> EndpointSpec:
+    class Endpoint:
+        def setup(self, model: str) -> None:  # pragma: no cover
+            pass
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out(y=payload.x)
+
+    return EndpointSpec(
+        name=name, method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="run", models={"model": HF("acme/tiny")},
+        resources=Resources(vram_gb=vram_gb),
+    )
+
+
+async def _noop_send(msg) -> None:  # pragma: no cover
+    pass
+
+
+RTX_4090_TOTAL_BYTES = 25_757_220_864  # 23.99 GiB — what mem_get_info reports
+
+
+def test_gate_rounds_detected_gib_up_to_declared_24() -> None:
+    ex = Executor([_spec("fits-24", 24.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
+    assert "fits-24" not in ex.unavailable
+
+
+def test_gate_still_blocks_genuinely_bigger_requirements() -> None:
+    ex = Executor([_spec("needs-32", 32.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
+    assert ex.unavailable["needs-32"][0] == "insufficient_vram"
+
+
+def test_single_file_checkpoint_detection(tmp_path: Path) -> None:
+    ckpt = tmp_path / "Illustrious-XL-v1.0.safetensors"
+    ckpt.write_bytes(b"stub")
+    assert _single_file_checkpoint(tmp_path) == ckpt
+    assert _single_file_checkpoint(ckpt) == ckpt
+
+    # A diffusers layout is NOT a single-file checkpoint.
+    (tmp_path / "model_index.json").write_text("{}")
+    assert _single_file_checkpoint(tmp_path) is None
+
+
+def test_single_file_checkpoint_requires_exactly_one(tmp_path: Path) -> None:
+    (tmp_path / "a.safetensors").write_bytes(b"a")
+    (tmp_path / "b.safetensors").write_bytes(b"b")
+    assert _single_file_checkpoint(tmp_path) is None
+    assert _single_file_checkpoint(tmp_path / "missing") is None
+
+
+def test_load_from_pretrained_routes_single_file(tmp_path: Path) -> None:
+    ckpt = tmp_path / "model.safetensors"
+    ckpt.write_bytes(b"stub")
+    calls: dict[str, object] = {}
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):  # pragma: no cover
+            raise AssertionError("single-file snapshot must not use from_pretrained")
+
+        @classmethod
+        def from_single_file(cls, path, **kwargs):
+            calls["path"] = path
+            calls["kwargs"] = kwargs
+            return cls()
+
+    out = load_from_pretrained(FakePipeline, tmp_path, dtype="fp16")
+    assert isinstance(out, FakePipeline)
+    assert calls["path"] == str(ckpt)
+    assert "variant" not in calls["kwargs"]
+
+
+def test_load_from_pretrained_still_uses_pretrained_for_layouts(tmp_path: Path) -> None:
+    (tmp_path / "model_index.json").write_text("{}")
+    calls: dict[str, object] = {}
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["path"] = path
+            return cls()
+
+        @classmethod
+        def from_single_file(cls, path, **kwargs):  # pragma: no cover
+            raise AssertionError("layout snapshot must not use from_single_file")
+
+    out = load_from_pretrained(FakePipeline, tmp_path, dtype="bf16")
+    assert isinstance(out, FakePipeline)
+    assert calls["path"] == str(tmp_path)


### PR DESCRIPTION
Two worker-side load/availability bugs found during the #347 roster support sweep (inference-endpoints tracker):

1. **VRAM gate rounding**: `gate_functions` compares raw `mem_get_info` GiB (23.99 on a 24GB card) against declared `vram_gb`, so every endpoint declaring 24 is unavailable on 24GB cards. Now compares on `round(total_gib)`.
2. **Single-file checkpoints**: typed setup injection called `from_pretrained(dir)` on repos that are one loose safetensors (Illustrious-XL-v1.0, civitai checkpoints) — no `model_index.json`, guaranteed failure. `load_from_pretrained` now routes these through `cls.from_single_file`.

Tests: 240 passed, 1 skipped (6 new in tests/test_gate_and_single_file.py).