### PR TITLE
fix(cozy-convert): load dtype-variant-named weights in repackage + as_hf_model

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/repackage.py
+++ b/packages/cozy_convert/src/cozy_convert/repackage.py
@@ -87,6 +87,9 @@ def _load_component_state_dict(
     - <base>.safetensors.index.json (sharded)
     - <base>.bin.safetensors (common in some HF repos)
     - <base>.bin.safetensors.index.json (rare; but cheap to support)
+    - <base>.<variant>.safetensors and its sharded index (HF dtype-variant
+      downloads keep the suffix — e.g. diffusion_pytorch_model.fp16.safetensors
+      in repo-cas mirrors cloned with a dtype preference)
 
     Optional legacy fallback (unsafe for untrusted repos):
     - <bin_base>.bin
@@ -108,6 +111,14 @@ def _load_component_state_dict(
             return cast(dict[str, Any], _st_load(st_path))
         if st_index.exists():
             return _load_sharded_safetensors(st_index)
+
+        # Dtype-variant names, exact-name misses only.
+        for st in sorted(component_dir.glob(f"{base}.*.safetensors")):
+            return cast(dict[str, Any], _st_load(st))
+        for idx in sorted(component_dir.glob(f"{base}.safetensors.*.index.json")) + sorted(
+            component_dir.glob(f"{base}.*.safetensors.index.json")
+        ):
+            return _load_sharded_safetensors(idx)
 
     if bin_base:
         bin_path = component_dir / f"{bin_base}.bin"

--- a/packages/cozy_convert/src/cozy_convert/source.py
+++ b/packages/cozy_convert/src/cozy_convert/source.py
@@ -184,6 +184,24 @@ class Source:
             self._tokenizer = AutoTokenizer.from_pretrained(str(self._path))
         return self._tokenizer
 
+    def diffusers_variant(self) -> str | None:
+        """Detect a diffusers ``variant=`` value from files on disk
+        (e.g. ``unet/diffusion_pytorch_model.fp16.safetensors`` → ``"fp16"``).
+        Mirrors gen_worker.models.loading.detect_diffusers_variant — repo-cas
+        mirrors cloned with a dtype preference keep HF's variant suffix."""
+        if self._file_layout != "diffusers":
+            return None
+        candidates = ("bf16", "fp8", "fp16", "int8", "int4")
+        try:
+            for p in self._path.rglob("*.safetensors"):
+                name = p.name.lower()
+                for v in candidates:
+                    if f".{v}." in name or name.endswith(f".{v}.safetensors"):
+                        return v
+        except OSError:
+            return None
+        return None
+
     def as_hf_model(self, **kwargs: Any) -> Any:
         """Auto-dispatch model load.
 
@@ -192,6 +210,9 @@ class Source:
         Override by passing an explicit ``model_cls=SomeClass`` kwarg.
         """
         model_cls = kwargs.pop("model_cls", None)
+        if self._file_layout == "diffusers" and "variant" not in kwargs:
+            if v := self.diffusers_variant():
+                kwargs["variant"] = v
         if model_cls is not None:
             return model_cls.from_pretrained(str(self._path), **kwargs)
         if self._file_layout == "diffusers":

--- a/packages/cozy_convert/tests/test_variant_names.py
+++ b/packages/cozy_convert/tests/test_variant_names.py
@@ -1,0 +1,58 @@
+"""Variant-named mirrors (repo-cas clones with a dtype preference keep HF's
+``.fp16.``/``.bf16.`` filename suffix) must load through every consumer.
+Found live: e2e J9 repackage-singlefile went FATAL on an fp16-named sd15
+mirror because _load_component_state_dict only tried exact names."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from cozy_convert.repackage import _load_component_state_dict
+from cozy_convert.source import Source
+
+
+def _tensors() -> dict[str, torch.Tensor]:
+    return {"w": torch.zeros(2, 2)}
+
+
+class TestLoadComponentStateDictVariants:
+    def test_exact_name_still_preferred(self, tmp_path: Path) -> None:
+        save_file(_tensors(), str(tmp_path / "diffusion_pytorch_model.safetensors"))
+        save_file({"v": torch.ones(1)}, str(tmp_path / "diffusion_pytorch_model.fp16.safetensors"))
+        sd = _load_component_state_dict(tmp_path, safetensors_bases=["diffusion_pytorch_model"])
+        assert "w" in sd
+
+    def test_fp16_variant_name(self, tmp_path: Path) -> None:
+        save_file(_tensors(), str(tmp_path / "diffusion_pytorch_model.fp16.safetensors"))
+        sd = _load_component_state_dict(tmp_path, safetensors_bases=["diffusion_pytorch_model"])
+        assert "w" in sd
+
+    def test_bf16_variant_text_encoder_base(self, tmp_path: Path) -> None:
+        save_file(_tensors(), str(tmp_path / "model.bf16.safetensors"))
+        sd = _load_component_state_dict(tmp_path, safetensors_bases=["model", "pytorch_model"])
+        assert "w" in sd
+
+    def test_missing_still_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            _load_component_state_dict(tmp_path, safetensors_bases=["diffusion_pytorch_model"])
+
+
+class TestSourceDiffusersVariant:
+    def _diffusers_tree(self, tmp_path: Path, weight_name: str) -> Path:
+        root = tmp_path / "model"
+        (root / "unet").mkdir(parents=True)
+        (root / "model_index.json").write_text("{}")
+        save_file(_tensors(), str(root / "unet" / weight_name))
+        return root
+
+    def test_detects_fp16(self, tmp_path: Path) -> None:
+        root = self._diffusers_tree(tmp_path, "diffusion_pytorch_model.fp16.safetensors")
+        assert Source(root).diffusers_variant() == "fp16"
+
+    def test_plain_names_no_variant(self, tmp_path: Path) -> None:
+        root = self._diffusers_tree(tmp_path, "diffusion_pytorch_model.safetensors")
+        assert Source(root).diffusers_variant() is None


### PR DESCRIPTION
Found live in e2e J9 (conversion ladder, te#41): repo-cas mirrors cloned with a dtype preference keep HF's variant filename suffix (`unet/diffusion_pytorch_model.fp16.safetensors`). `repackage-singlefile` went FATAL ('missing weights for unet') on the fp16-named sd15 mirror; `as_hf_model` (modelopt rung) would fail the same way. gen-worker's platform loader already handles this (`detect_diffusers_variant`) — cozy_convert consumers now match.

- `_load_component_state_dict`: variant-name fallback after exact-name misses (single + sharded index)
- `Source.diffusers_variant()` + `as_hf_model` passes `variant=` for diffusers loads unless caller set one

Tests: cozy_convert 57 passed / 1 skipped (6 new); gen-worker root 242 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)