### PR TITLE
fix(cli,executor): setup() gets loaded models; fatal errors carry class+detail

### DIFF
--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -757,7 +757,20 @@ def run_setup(instance: Any, resolved_models: Dict[str, str]) -> None:
             f"dict (static bindings are injected into setup; dispatch "
             f"bindings are injected into the handler per-request)."
         )
-    setup_fn(**{k: v for k, v in resolved_models.items() if k in wanted})
+    # Load each claimed slot through the same loader the handler-injection
+    # path uses: a setup(pipeline: StableDiffusionXLPipeline) must receive a
+    # constructed pipeline, not the snapshot path string (production executor
+    # behavior; previously setup received raw paths -> 'str' is not callable).
+    try:
+        hints = typing.get_type_hints(setup_fn)
+    except (TypeError, ValueError, NameError):
+        hints = {}
+    loaded = {
+        k: _load_injected_model(hints.get(k), v)
+        for k, v in resolved_models.items()
+        if k in wanted
+    }
+    setup_fn(**loaded)
 
 
 _INJECTED_CACHE: Dict[Tuple[str, str], Any] = {}
@@ -792,9 +805,12 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
     if cls is None or not hasattr(cls, "from_pretrained"):
         from diffusers import DiffusionPipeline
         cls = DiffusionPipeline
+    # fp16 kernels are CUDA-only for several ops; on a CPU device run use fp32.
+    device = (os.getenv("GEN_WORKER_LOCAL_DEVICE") or "").strip().lower()
+    dtype = torch.float32 if device == "cpu" else torch.float16
     p = Path(local_path)
     if p.is_dir() and (p / "model_index.json").exists():
-        pipe = cls.from_pretrained(str(p), torch_dtype=torch.float16)
+        pipe = cls.from_pretrained(str(p), torch_dtype=dtype)
     else:
         single = p if p.is_file() else next(iter(sorted(p.glob("*.safetensors"))), None)
         if single is None or not hasattr(cls, "from_single_file"):
@@ -802,7 +818,7 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
                 f"cannot materialize injected model slot from {p} "
                 f"(no model_index.json, no single-file checkpoint)"
             )
-        pipe = cls.from_single_file(str(single), torch_dtype=torch.float16)
+        pipe = cls.from_single_file(str(single), torch_dtype=dtype)
     _INJECTED_CACHE[key] = pipe
     return pipe
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -113,7 +113,12 @@ def _map_exception(exc: BaseException) -> Tuple[int, str]:
         return pb.JOB_STATUS_RETRYABLE, "model download url expired"
     if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
         return pb.JOB_STATUS_RETRYABLE, "out of memory"
-    return pb.JOB_STATUS_FATAL, "internal error"
+    # Unexpected exception: keep it terse but NEVER opaque — "internal error"
+    # made every novel worker-side failure undiagnosable from the hub (pods
+    # ship no logs). Class name + sanitized first line is safe and decisive.
+    detail = _sanitize(str(exc).splitlines()[0] if str(exc) else "")
+    label = type(exc).__name__
+    return pb.JOB_STATUS_FATAL, f"{label}: {detail}"[:512] if detail else label
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -1,0 +1,43 @@
+"""setup() receives LOADED models (not path strings) + fatal errors carry class+detail."""
+import gen_worker.cli.run as cli_run
+from gen_worker.executor import _map_exception
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+
+class _FakePipe:
+    loaded_from = None
+
+    @classmethod
+    def from_pretrained(cls, path, **kw):
+        obj = cls(); obj.loaded_from = path; return obj
+
+    @classmethod
+    def from_single_file(cls, path, **kw):
+        obj = cls(); obj.loaded_from = path; return obj
+
+
+def test_run_setup_loads_annotated_slot(tmp_path, monkeypatch):
+    (tmp_path / "model_index.json").write_text("{}")
+    seen = {}
+
+    class EP:
+        def setup(self, pipeline: _FakePipe) -> None:
+            seen["pipeline"] = pipeline
+
+    monkeypatch.setattr(cli_run, "_INJECTED_CACHE", {})
+    cli_run.run_setup(EP(), {"pipeline": str(tmp_path)})
+    assert isinstance(seen["pipeline"], _FakePipe)
+    assert seen["pipeline"].loaded_from == str(tmp_path)
+
+
+def test_map_exception_fatal_carries_class_and_detail():
+    status, msg = _map_exception(TypeError("'str' object is not callable"))
+    assert status == pb.JOB_STATUS_FATAL
+    assert msg.startswith("TypeError:")
+    assert "not callable" in msg
+
+
+def test_map_exception_fatal_sanitizes_secrets():
+    status, msg = _map_exception(RuntimeError("boom Bearer abc123"))
+    assert status == pb.JOB_STATUS_FATAL
+    assert "abc123" not in msg and msg.startswith("RuntimeError")


### PR DESCRIPTION
Two fixes from the live SDXL debugging session (J8 pod load_failed + local repro):
1. `gen-worker run` called `setup(**resolved)` with raw snapshot path strings — every setup-style endpoint (sdxl-illustrious, sd15, klein...) crashed locally with 'str' object is not callable. setup slots now load through `_load_injected_model` (same path as handler injection), fp32 when the local device is cpu.
2. `_map_exception` collapsed every unexpected exception to FATAL/'internal error' — combined with pods having no log shipping, novel worker failures were undiagnosable (three campaigns spent pod-hours on archaeology). Fatal messages now carry exception class + sanitized (Bearer/X-Amz/Signature-aware) first line, capped 512 chars.

3 new tests; full suite 247 passed, 1 skipped.