### PR TITLE
fix(registry,cli): variants inherit shared aux model slots; local loader handles module-layout repos (gw#383)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.9.1"
+version = "0.9.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -23,7 +23,9 @@
   streaming decorator.
 * ``runtime="vllm"`` boots an engine-hosting server subprocess before setup.
 * ``variants={name: (binding, Resources)}`` stamps one separately-routable,
-  separately-placeable function per variant from a single handler body.
+  separately-placeable function per variant from a single handler body. With
+  ``models={}`` the variant binding swaps the FIRST declared slot; remaining
+  aux slots (e.g. a shared VAE) are inherited by every variant.
 """
 
 from __future__ import annotations
@@ -347,11 +349,8 @@ def _decorate_class(
                 f"@endpoint class {cls.__name__!r}: variants= requires exactly "
                 f"ONE handler method to fan out over (found {len(handlers)})."
             )
-        if len(models) > 1:
-            raise ValueError(
-                f"@endpoint class {cls.__name__!r}: variants= requires a single "
-                f"model slot (found {sorted(models)})."
-            )
+        # Multi-slot classes: variants swap the FIRST declared slot; the
+        # remaining (aux) slots are shared across all variants.
         _validate_variant_literal(
             cls.__name__, handlers[0][1], [v.name for v in variant_rows]
         )

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -257,9 +257,15 @@ def _select_function(
             f"available:{available}"
         )
     if len(matches) > 1:
-        if not cls_name and not method_name and default_name:
-            from gen_worker.discovery.names import slugify_name
+        from gen_worker.discovery.names import slugify_name
 
+        if method_name:
+            # Variant fan-out: the base fn and every variant share one attr
+            # name. An exact fn_name match wins over the attr-name matches.
+            exact = [m for m in matches if m.fn_name == slugify_name(method_name)]
+            if len(exact) == 1:
+                return exact[0]
+        if not cls_name and not method_name and default_name:
             wanted = slugify_name(default_name)
             defaults = [m for m in matches if m.fn_name == wanted]
             if len(defaults) == 1:

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -800,25 +800,18 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
     key = (str(annotation), str(local_path))
     if key in _INJECTED_CACHE:
         return _INJECTED_CACHE[key]
-    import torch
+    from gen_worker.models.loading import load_from_pretrained
+
     cls = annotation if isinstance(annotation, type) else None
     if cls is None or not hasattr(cls, "from_pretrained"):
         from diffusers import DiffusionPipeline
         cls = DiffusionPipeline
     # fp16 kernels are CUDA-only for several ops; on a CPU device run use fp32.
     device = (os.getenv("GEN_WORKER_LOCAL_DEVICE") or "").strip().lower()
-    dtype = torch.float32 if device == "cpu" else torch.float16
-    p = Path(local_path)
-    if p.is_dir() and (p / "model_index.json").exists():
-        pipe = cls.from_pretrained(str(p), torch_dtype=dtype)
-    else:
-        single = p if p.is_file() else next(iter(sorted(p.glob("*.safetensors"))), None)
-        if single is None or not hasattr(cls, "from_single_file"):
-            raise _ModelResolutionError(
-                f"cannot materialize injected model slot from {p} "
-                f"(no model_index.json, no single-file checkpoint)"
-            )
-        pipe = cls.from_single_file(str(single), torch_dtype=dtype)
+    # Same loader the production executor uses: handles diffusers-layout dirs,
+    # module-layout dirs (root config.json, e.g. a bare VAE/UNet repo), and
+    # single-file checkpoints.
+    pipe = load_from_pretrained(cls, local_path, dtype="fp32" if device == "cpu" else "fp16")
     _INJECTED_CACHE[key] = pipe
     return pipe
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -818,6 +818,15 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
     # module-layout dirs (root config.json, e.g. a bare VAE/UNet repo), and
     # single-file checkpoints.
     pipe = load_from_pretrained(cls, local_path, dtype="fp32" if device == "cpu" else "fp16")
+    if device != "cpu":
+        # Worker-owned placement (executor parity): endpoints never write
+        # device/offload code, so the cold `run` path must place the loaded
+        # pipeline too — full CUDA residency or the offload ladder as VRAM
+        # allows. Without this the pipeline stays on CPU while ctx.generator()
+        # hands out CUDA generators.
+        from gen_worker.models.memory import place_pipeline
+
+        place_pipeline(pipe)
     _INJECTED_CACHE[key] = pipe
     return pipe
 

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -197,9 +197,11 @@ def extract_specs(obj: Any, *, walked_module: str = "") -> List[EndpointSpec]:
                 resources=decl.resources, walked_module=walked,
             ))
         for variant in decl.variants:
+            # Variants swap only the primary slot; shared aux slots (vae,
+            # refiner, extra encoders) are inherited from the class binding.
             out.append(_spec_for_handler(
                 fn_name=variant.name, method=method, decl=decl, cls=cls,
-                attr_name=attr_name, models={slot: variant.binding},
+                attr_name=attr_name, models={**decl.models, slot: variant.binding},
                 resources=variant.resources or decl.resources,
                 walked_module=walked,
             ))

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -59,3 +59,38 @@ def test_map_exception_fatal_sanitizes_secrets():
     status, msg = _map_exception(RuntimeError("boom Bearer abc123"))
     assert status == pb.JOB_STATUS_FATAL
     assert "abc123" not in msg and msg.startswith("RuntimeError")
+
+
+def test_select_function_base_fn_wins_exact_match_over_variant_attr_matches():
+    # Base fn + variants share one attr name; --method <base> must select the
+    # base spec instead of erroring ambiguous (ie#348).
+    import types
+
+    import msgspec
+
+    from gen_worker import HF, RequestContext, endpoint
+
+    class _In(msgspec.Struct):
+        prompt: str
+
+    class _Out(msgspec.Struct):
+        result: str
+
+    @endpoint(
+        model=HF("o/base", dtype="fp16"),
+        variants={"generate_alt": HF("o/alt")},
+    )
+    class Gen:
+        def setup(self, pipeline: str) -> None: ...
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    mod = types.SimpleNamespace(Gen=Gen)
+    candidates = cli_run._collect_class_methods(mod)
+    assert len(candidates) == 2
+
+    base = cli_run._select_function(candidates, cls_name=None, method_name="generate")
+    assert base.fn_name == "generate"
+    variant = cli_run._select_function(candidates, cls_name=None, method_name="generate_alt")
+    assert variant.fn_name == "generate-alt"

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -30,6 +30,24 @@ def test_run_setup_loads_annotated_slot(tmp_path, monkeypatch):
     assert seen["pipeline"].loaded_from == str(tmp_path)
 
 
+def test_run_setup_loads_module_layout_slot(tmp_path, monkeypatch):
+    # Module-layout repo (root config.json, no model_index.json): e.g. a bare
+    # AutoencoderKL repo like madebyollin/sdxl-vae-fp16-fix. Must route through
+    # from_pretrained, not the single-file path.
+    (tmp_path / "config.json").write_text("{}")
+    (tmp_path / "diffusion_pytorch_model.safetensors").write_bytes(b"")
+    seen = {}
+
+    class EP:
+        def setup(self, vae: _FakePipe) -> None:
+            seen["vae"] = vae
+
+    monkeypatch.setattr(cli_run, "_INJECTED_CACHE", {})
+    cli_run.run_setup(EP(), {"vae": str(tmp_path)})
+    assert isinstance(seen["vae"], _FakePipe)
+    assert seen["vae"].loaded_from == str(tmp_path)
+
+
 def test_map_exception_fatal_carries_class_and_detail():
     status, msg = _map_exception(TypeError("'str' object is not callable"))
     assert status == pb.JOB_STATUS_FATAL

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -174,6 +174,24 @@ def test_variants_stamp_routable_functions_with_per_variant_overrides() -> None:
     assert len({s.instance_key for s in specs.values()}) == 3
 
 
+def test_variants_inherit_shared_aux_slots() -> None:
+    @endpoint(
+        models={"pipeline": HF("o/base", dtype="fp16"), "vae": HF("o/vae-fix", dtype="fp16")},
+        variants={"gen-alt": HF("o/alt")},
+    )
+    class Gen:
+        def setup(self, pipeline: str, vae: str) -> None: ...
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    specs = {s.name: s for s in extract_specs(Gen)}
+    # The variant swaps only the primary slot; the aux vae slot is inherited.
+    assert specs["gen-alt"].models["pipeline"].ref == "o/alt"
+    assert specs["gen-alt"].models["vae"].ref == "o/vae-fix"
+    assert specs["generate"].models["pipeline"].ref == "o/base"
+
+
 def test_variants_without_class_model_are_the_full_routable_set() -> None:
     @endpoint(variants={
         "small": Hub("o/small"),

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes gw#383 (tracker: cozy-creator-tracker/python-gen-worker/progress.md).

Unblocks inference-endpoints ie#349 (sdxl-illustrious fp16-fix VAE binding).

- registry.extract_specs: variant specs were built as `{slot: binding}`, silently dropping every non-primary model slot. Now `{**decl.models, slot: binding}`: variants swap the FIRST declared slot and inherit shared aux slots (vae, refiner, extra encoders).
- decorators: lift the single-slot restriction on `variants=` (docstring documents the first-slot convention).
- cli/run.`_load_injected_model`: route through `models.loading.load_from_pretrained` — the same loader the production executor uses — so module-layout repos (root config.json, e.g. madebyollin/sdxl-vae-fp16-fix as AutoencoderKL) load via from_pretrained instead of misrouting to from_single_file. Local CLI now has loader parity with prod.
- version 0.9.2 (tag + publish after merge).

Tests: 249 passed, 1 skipped (`uv run --extra dev pytest -q`); new coverage: variant aux-slot inheritance + module-layout injection.