### PR TITLE
perf(executor): yield the GPU slot during blob uploads (#382)

### DIFF
--- a/examples/flux2-klein-image/src/flux2_klein_image/main.py
+++ b/examples/flux2-klein-image/src/flux2_klein_image/main.py
@@ -79,7 +79,10 @@ class Flux2KleinTurbo:
             generator=generator,
         ).images[0]
 
-        asset = gw_io.write_image(ctx, "image", image, format="png", as_type=ImageAsset)
+        # WEBP q90: measured visually identical to PNG for these outputs at
+        # ~15% of the bytes and ~2.7x less encode CPU (#382) - the upload, not
+        # the GPU, dominated per-image latency with PNG.
+        asset = gw_io.write_image(ctx, "image", image, format="webp", as_type=ImageAsset)
         return KleinTurboOutput(image=asset, width=image.width, height=image.height, seed=p.seed)
 
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 import shutil
+import threading
 import time
 import typing
 from dataclasses import dataclass, field as dc_field
@@ -448,6 +449,50 @@ class _Job:
     finished: bool = False
     superseded: bool = False
     admitted_at: float = dc_field(default_factory=time.monotonic)
+
+
+class _GpuSlotLease:
+    """Thread-safe handle for a job's GPU slot (#382).
+
+    Blob uploads and result sends are network/CPU work; holding the GPU
+    semaphore across them idles the GPU for longer than the model's own
+    compute on turbo image models. The lease lets ``RequestContext`` release
+    the slot from the handler thread while ``save_bytes`` waits on the
+    network (re-acquiring before returning to tenant code), and lets the
+    executor free the slot as soon as ``_execute`` returns — before
+    result-blob upload and result send. Transitions are lock-guarded so a
+    hold is released at most once.
+    """
+
+    __slots__ = ("_sem", "_loop", "_lock", "_held")
+
+    def __init__(self, sem: asyncio.Semaphore, loop: asyncio.AbstractEventLoop) -> None:
+        self._sem = sem
+        self._loop = loop
+        self._lock = threading.Lock()
+        self._held = True
+
+    def yield_slot(self) -> bool:
+        """Release the slot if held (any thread). True iff this call released."""
+        with self._lock:
+            if not self._held:
+                return False
+            self._held = False
+        try:
+            on_loop = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            on_loop = False
+        if on_loop:
+            self._sem.release()
+        else:
+            self._loop.call_soon_threadsafe(self._sem.release)
+        return True
+
+    def reacquire(self) -> None:
+        """Blocking re-acquire from a handler thread."""
+        asyncio.run_coroutine_threadsafe(self._sem.acquire(), self._loop).result()
+        with self._lock:
+            self._held = True
 
 
 class Executor:
@@ -1028,12 +1073,13 @@ class Executor:
             return
 
         queue_ms = int((time.monotonic() - job.admitted_at) * 1000)
-        acquired = False
+        lease: Optional[_GpuSlotLease] = None
         started = time.monotonic()
         try:
             if needs_gpu:
                 await self._gpu_semaphore.acquire()
-                acquired = True
+                lease = _GpuSlotLease(self._gpu_semaphore, asyncio.get_running_loop())
+                ctx._gpu_slot_lease = lease
                 if job.ctx.cancelled:
                     raise CanceledError("canceled")
             started = time.monotonic()
@@ -1044,6 +1090,10 @@ class Executor:
                 output = await self._execute(job, spec, instance, ctx, payload, kwargs,
                                              timeout_ms=timeout_ms, gpu_index=gpu_index)
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index)
+            # Handler GPU work is done — free the slot before result-blob
+            # upload and result send so the next job's compute starts now.
+            if lease is not None:
+                lease.yield_slot()
             if spec.output_mode == "stream":
                 await self._finish(job, pb.JOB_STATUS_OK, metrics=metrics)
             else:
@@ -1061,8 +1111,8 @@ class Executor:
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index)
             await self._finish(job, status, safe_message=msg, metrics=metrics)
         finally:
-            if acquired:
-                self._gpu_semaphore.release()
+            if lease is not None:
+                lease.yield_slot()
             self._maybe_idle()
 
     async def _materialize_source(

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
+from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Mapping, Optional
@@ -182,6 +183,11 @@ class RequestContext:
         # session opens. Empty values are omitted and tensorhub keeps/inherits
         # existing repo values.
         self._repo_spec: Dict[str, str] = {}
+
+        # GPU-slot lease (#382). Set by the executor for GPU jobs; lets
+        # blocking uploads release the GPU slot while they wait on the
+        # network. None for CPU jobs and local (CLI) runs.
+        self._gpu_slot_lease: Optional[Any] = None
 
     @property
     def request_id(self) -> str:
@@ -429,6 +435,29 @@ class RequestContext:
             self._cancel_event.set()
             logger.info("request %s marked for cancellation.", self.request_id)
 
+    @contextmanager
+    def _gpu_slot_yielded(self):
+        """Worker-internal: release the job's GPU slot for the duration of
+        blocking non-GPU I/O (blob upload), re-acquiring before returning to
+        tenant code (#382). No-op when there is no lease (CPU jobs, local
+        runs) or the slot is already yielded (executor freed it post-handler).
+
+        If the job was cancelled while yielded (deadline / CancelJob), the
+        re-acquired slot is released again immediately: the executor's final
+        release already saw ``held == False`` and skipped, so the balance
+        stays exact and the freed slot isn't captured by a dying job.
+        """
+        lease = self._gpu_slot_lease
+        if lease is None or not lease.yield_slot():
+            yield
+            return
+        try:
+            yield
+        finally:
+            lease.reacquire()
+            if self._canceled:
+                lease.yield_slot()
+
     def _emit_event(self, event_type: str, payload: Optional[Dict[str, Any]] = None) -> None:
         """Worker-internal: emit a progress/event payload (best-effort)."""
         if not self._emitter:
@@ -498,8 +527,9 @@ class RequestContext:
             )
 
         stream = self._open_output_stream(ref, create=False, expected_size_bytes=len(data))
-        stream.write(data)
-        out = stream.finalize()
+        with self._gpu_slot_yielded():
+            stream.write(data)
+            out = stream.finalize()
         if isinstance(out, Asset):
             return out
         raise RuntimeError("file save failed (invalid_asset_response)")
@@ -543,7 +573,9 @@ class RequestContext:
             save_kwargs["quality"] = max(1, min(int(quality), 100))
         if pil_format == "WEBP":
             save_kwargs["lossless"] = bool(lossless)
-            save_kwargs["method"] = 6
+            # method=4 (default): method=6 costs ~2.6x the encode CPU for ~4%
+            # smaller files (#382 measurements).
+            save_kwargs["method"] = 4
         img.save(buf, format=pil_format, **save_kwargs)
         return _as_asset(self.save_bytes(ref, buf.getvalue()), ImageAsset)
 

--- a/tests/e2e_endpoints.py
+++ b/tests/e2e_endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from pathlib import Path
 from typing import AsyncIterator
@@ -10,6 +11,11 @@ from typing import AsyncIterator
 import msgspec
 
 from gen_worker import Hub, RequestContext, ValidationError, endpoint
+
+# Cross-thread signals for the GPU-slot-yield tests (#382). The fake-scheduler
+# suite runs the worker in-process, so tests coordinate through these directly.
+SLOT_PROBE_STARTED = threading.Event()
+SLOT_PEER_RAN = threading.Event()
 
 
 class EchoIn(msgspec.Struct):
@@ -40,6 +46,19 @@ class E2EEndpoint:
     def sleepy(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
         time.sleep(0.5)
         return EchoOut(response="done")
+
+    def slot_probe(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        """Holds the GPU slot, then waits for `slot_peer` INSIDE the yielded
+        window. Only completes if the slot is actually released during
+        uploads — with a held slot the peer can never run and this times out."""
+        SLOT_PROBE_STARTED.set()
+        with ctx._gpu_slot_yielded():
+            ok = SLOT_PEER_RAN.wait(timeout=10.0)
+        return EchoOut(response="overlapped" if ok else "starved")
+
+    def slot_peer(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        SLOT_PEER_RAN.set()
+        return EchoOut(response="peer-done")
 
 
 @endpoint(model=Hub("e2e/tiny"))

--- a/tests/test_worker_grpc_e2e.py
+++ b/tests/test_worker_grpc_e2e.py
@@ -379,6 +379,64 @@ def test_gpu_semaphore_serializes_cuda_jobs(scheduler_and_worker) -> None:
     assert elapsed >= 1.0, f"cuda jobs must serialize on 1 gpu slot (took {elapsed:.2f}s)"
 
 
+def test_gpu_slot_yield_lets_peer_run_during_upload_window(scheduler_and_worker) -> None:
+    """#382: a GPU job inside `_gpu_slot_yielded` (the save_bytes upload
+    window) must not starve the next GPU job on the single slot."""
+    import e2e_endpoints as ep
+
+    scheduler, _harness = scheduler_and_worker
+    conn = scheduler.wait_connection(0)
+    conn.wait_for(
+        lambda m: m.WhichOneof("msg") == "state_delta"
+        and m.state_delta.phase == pb.WORKER_PHASE_READY
+    )
+    ep.SLOT_PROBE_STARTED.clear()
+    ep.SLOT_PEER_RAN.clear()
+    cuda = pb.ResolvedCompute(accelerator="cuda", gpu_index=0)
+    conn.send(run_job=pb.RunJob(
+        request_id="r-slot-probe", attempt=1, function_name="slot-probe",
+        input_payload=_msgpack("x"), compute=cuda))
+    assert ep.SLOT_PROBE_STARTED.wait(timeout=10.0), "probe never started"
+    # Probe holds the only GPU slot until it yields for its "upload".
+    conn.send(run_job=pb.RunJob(
+        request_id="r-slot-peer", attempt=1, function_name="slot-peer",
+        input_payload=_msgpack("x"), compute=cuda))
+    res = conn.wait_for(_is_result_for("r-slot-probe")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+    assert _decode_out(res.inline).response == "overlapped"
+    res = conn.wait_for(_is_result_for("r-slot-peer")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+
+
+def test_gpu_slot_survives_cancel_during_yielded_window(scheduler_and_worker) -> None:
+    """#382: cancelling a job while its slot is yielded must not leak or
+    double-release the slot -- a follow-up GPU job still runs."""
+    import e2e_endpoints as ep
+
+    scheduler, _harness = scheduler_and_worker
+    conn = scheduler.wait_connection(0)
+    conn.wait_for(
+        lambda m: m.WhichOneof("msg") == "state_delta"
+        and m.state_delta.phase == pb.WORKER_PHASE_READY
+    )
+    ep.SLOT_PROBE_STARTED.clear()
+    ep.SLOT_PEER_RAN.clear()
+    cuda = pb.ResolvedCompute(accelerator="cuda", gpu_index=0)
+    conn.send(run_job=pb.RunJob(
+        request_id="r-yield-cancel", attempt=1, function_name="slot-probe",
+        input_payload=_msgpack("x"), compute=cuda))
+    assert ep.SLOT_PROBE_STARTED.wait(timeout=10.0)
+    conn.send(cancel_job=pb.CancelJob(request_id="r-yield-cancel", attempt=1))
+    ep.SLOT_PEER_RAN.set()  # unblock the probe's yielded window
+    conn.wait_for(_is_result_for("r-yield-cancel"))
+    # The slot must still be usable afterwards.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-after-cancel", attempt=1, function_name="sleepy",
+        input_payload=_msgpack("x"), compute=cuda))
+    res = conn.wait_for(_is_result_for("r-after-cancel")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+
+
 def test_marco_polo_example_serves_under_the_new_core() -> None:
     """#365 acceptance: examples/marco-polo runs against the fake scheduler."""
     import sys


### PR DESCRIPTION
## Issue
#382 turbo-model inference latency — profile + acceleration ladder.

## What
Profiling (RunPod 4090 + H100, flux2-klein-4B 768px 4-step) showed warm model compute is 0.77s (4090) / 0.33s (H100), while the J-suite measured 4-6s effective per image: the GPU slot is held across PNG encode (180ms), presigned upload (0.6-5s observed to R2), and result send.

- `_GpuSlotLease`: thread-safe GPU-slot handle (release at most once per hold; blocking reacquire from handler threads).
- `ctx.save_bytes` releases the slot while the upload waits on the network, reacquires before returning to tenant code; cancellation during the yielded window keeps the slot balance exact.
- Executor frees the slot when the handler returns — result-blob upload and result send no longer block the next job's compute.
- flux2-klein example: PNG → WEBP q90 (measured visually identical, 171KB vs 1.12MB, 68ms vs 182ms encode). `save_image` WEBP `method` 6 → 4 (2.6× encode CPU for ~4% size).

## Tests
252 passed, 1 skipped (full suite). New: `test_gpu_slot_yield_lets_peer_run_during_upload_window`, `test_gpu_slot_survives_cancel_during_yielded_window`.

Note: e2e j6 asserts the flux example returns PNG; companion e2e change swaps that assertion to WEBP.