### PR TITLE
fix(executor,cli): redact credentials in fatal errors; gen-worker run --source-path (te#42)

### DIFF
--- a/packages/cozy_convert/pyproject.toml
+++ b/packages/cozy_convert/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "ruff>=0.6.0",
     "torch>=2.11.0",
     "safetensors>=0.7.0",
+    "flashpack>=0.2.1",
     "transformers>=4.50.0",
     "accelerate>=1.0.0",
     "bitsandbytes>=0.45.0; sys_platform == 'linux'",

--- a/packages/cozy_convert/tests/test_flashpack.py
+++ b/packages/cozy_convert/tests/test_flashpack.py
@@ -1,0 +1,62 @@
+"""convert_safetensors_to_flashpack packs non-float buffers (int64 position
+ids, bool masks) alongside float weights and round-trips exactly (te#42)."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("flashpack")
+pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file  # noqa: E402
+
+from cozy_convert.flashpack import convert_safetensors_to_flashpack  # noqa: E402
+from cozy_convert.writer import ConversionImplementationError  # noqa: E402
+
+
+def _roundtrip(path):
+    from flashpack.deserialization import (
+        iterate_from_flash_tensor,
+        read_flashpack_file,
+    )
+
+    storage, meta = read_flashpack_file(str(path))
+    return dict(iterate_from_flash_tensor(storage, meta))
+
+
+def test_pack_mixed_dtypes_roundtrip(tmp_path):
+    tensors = {
+        "unet.conv.weight": torch.randn(4, 4, dtype=torch.bfloat16),
+        "te.embeddings.position_ids": torch.arange(77, dtype=torch.int64).unsqueeze(0),
+        "te.mask": torch.tensor([[True, False], [False, True]]),
+        "vae.scale": torch.randn(8, dtype=torch.float16),
+    }
+    src = tmp_path / "in.safetensors"
+    save_file(tensors, str(src))
+    out = tmp_path / "out.flashpack"
+
+    result = convert_safetensors_to_flashpack(src, out, target_dtype="preserve")
+
+    assert out.is_file() and result["output_path"] == str(out)
+    got = _roundtrip(out)
+    assert set(got) == set(tensors)
+    for name, want in tensors.items():
+        assert got[name].dtype == want.dtype, name
+        assert torch.equal(got[name].cpu(), want), name
+
+
+def test_pack_missing_input_is_deterministic_error(tmp_path):
+    with pytest.raises(ConversionImplementationError, match="input_missing"):
+        convert_safetensors_to_flashpack(
+            tmp_path / "absent.safetensors", tmp_path / "out.flashpack",
+            target_dtype="preserve",
+        )
+
+
+def test_pack_rejects_unwired_dtype_mode(tmp_path):
+    with pytest.raises(ConversionImplementationError, match="dtype_mode_not_wired"):
+        convert_safetensors_to_flashpack(
+            tmp_path / "x.safetensors", tmp_path / "out.flashpack",
+            target_dtype="bf16",
+        )

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -99,6 +99,15 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
         ),
     )
     p.add_argument(
+        "--source-path", dest="source_path", default=None,
+        help=(
+            "Local snapshot directory to use as the reserved `source` "
+            "payload's materialized checkpoint: populates ctx.source_path "
+            "exactly like the production worker does after Hub-resolve, so "
+            "reserved-source producer functions run without a hub."
+        ),
+    )
+    p.add_argument(
         "--pretty", action="store_true",
         help="Pretty-print the stdout result with newlines + 2-space indent.",
     )
@@ -322,6 +331,28 @@ def _apply_field_tokens(
     except ArgError as e:
         raise _UsageError(str(e)) from e
     return json.dumps(merged, separators=(",", ":")).encode("utf-8")
+
+
+def _inject_default_source(
+    raw_bytes: bytes, payload_type: type, source_path: Path,
+) -> bytes:
+    """When ``--source-path`` is given and the payload type declares a
+    reserved ``source`` field the user didn't fill in, synthesize a local ref
+    so decode passes. An explicit ``source`` in the payload is left alone."""
+    try:
+        field_names = {f.name for f in msgspec.structs.fields(payload_type)}
+    except Exception:
+        return raw_bytes
+    if "source" not in field_names:
+        return raw_bytes
+    try:
+        base = json.loads(raw_bytes.decode("utf-8") or "{}") if raw_bytes else {}
+    except json.JSONDecodeError:
+        return raw_bytes
+    if not isinstance(base, dict) or base.get("source"):
+        return raw_bytes
+    base["source"] = {"ref": f"local/{source_path.name}"}
+    return json.dumps(base, separators=(",", ":")).encode("utf-8")
 
 
 def _decode_payload(
@@ -1052,6 +1083,19 @@ def _run_inner(args: argparse.Namespace) -> int:
         raw_bytes, getattr(args, "fields", None), selected.payload_type,
     )
 
+    # Reserved-source contract, local mode: --source-path stands in for the
+    # worker's Hub-resolve + materialize step. If the payload declares a
+    # `source` field and none was provided, synthesize one so validation
+    # passes; ctx.source_path is set on the context below.
+    source_path: Optional[Path] = None
+    if getattr(args, "source_path", None):
+        source_path = Path(args.source_path).expanduser().resolve()
+        if not source_path.exists():
+            raise _UsageError(f"--source-path does not exist: {source_path}")
+        raw_bytes = _inject_default_source(
+            raw_bytes, selected.payload_type, source_path,
+        )
+
     from .local_context import _stderr_emitter
 
     # 4. Build the local context for this kind.
@@ -1059,6 +1103,14 @@ def _run_inner(args: argparse.Namespace) -> int:
         kind=selected.kind,
         allow_publish=bool(args.allow_publish),
     )
+    if source_path is not None:
+        set_source = getattr(ctx, "_set_source_path", None)
+        if not callable(set_source):
+            raise _UsageError(
+                f"--source-path: {selected.kind!r} endpoints have no reserved "
+                "source contract (conversion/dataset/training only)."
+            )
+        set_source(str(source_path))
     # Honor --device by stashing it on the context. (RequestContext doesn't
     # currently expose a `.device` setter; tenants typically read it via
     # torch directly. We surface the override via env so user code can

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import threading
 import time
@@ -74,11 +75,20 @@ except Exception:  # pragma: no cover
     torch = None  # type: ignore[assignment]
 
 
+# Credential material inside exception messages (auth headers, presigned-URL
+# query params). Redacted in place — replacing the whole message with
+# "internal error" made every download/publish failure undiagnosable from the
+# hub (pods ship no logs; presigned URLs carry X-Amz-* params).
+_REDACTIONS = (
+    re.compile(r"Bearer\s+[^\s\"'&]+"),
+    re.compile(r"(?:X-Amz-[A-Za-z0-9-]+|Signature)=[^&\s\"']*"),
+)
+
+
 def _sanitize(message: str) -> str:
     out = str(message or "").strip()
-    for needle in ("Bearer ", "X-Amz-", "Signature="):
-        if needle in out:
-            return "internal error"
+    for pat in _REDACTIONS:
+        out = pat.sub("[redacted]", out)
     return out[:1024]
 
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -23,7 +23,8 @@ import msgspec
 
 import gen_worker.cli as cli
 import gen_worker.cli.run as run_mod
-from gen_worker import RequestContext, endpoint
+from gen_worker import ConversionContext, RequestContext, endpoint
+from gen_worker.api.types import SourceRepo
 
 
 class _In(msgspec.Struct):
@@ -241,3 +242,74 @@ def test_pyproject_tool_gen_worker_main(tmp_path) -> None:
     import pytest as _pytest
     with _pytest.raises(ValueError, match=r"tool\.gen_worker"):
         load_project_config(tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# --source-path: reserved-source producer functions run locally (te#42)       #
+# --------------------------------------------------------------------------- #
+
+
+class _ConvIn(msgspec.Struct):
+    source: SourceRepo
+
+
+class _ConvOut(msgspec.Struct):
+    source_path: str
+    source_ref: str
+
+
+def _conversion_module(name: str = "_test_conv_src") -> types.ModuleType:
+    mod = types.ModuleType(name)
+
+    @endpoint(kind="conversion")
+    class Conv:
+        def probe_source(self, ctx: ConversionContext, data: _ConvIn) -> _ConvOut:
+            return _ConvOut(
+                source_path=str(ctx.source_path or ""), source_ref=data.source.ref,
+            )
+
+    Conv.__module__ = name
+    mod.Conv = Conv
+    sys.modules[name] = mod
+    return mod
+
+
+def test_run_source_path_materializes_reserved_source(tmp_path, capsys, monkeypatch) -> None:
+    _conversion_module()
+    monkeypatch.setattr(run_mod, "_warm_serve_socket", lambda: None)
+    snap = tmp_path / "snapshot"
+    snap.mkdir()
+
+    # No payload at all: `source` is synthesized from --source-path.
+    assert cli.main(["run", "--module", "_test_conv_src", "--source-path", str(snap)]) == 0
+    last = _last_event(capsys)
+    assert last["value"]["source_path"] == str(snap)
+    assert last["value"]["source_ref"] == "local/snapshot"
+
+    # Explicit payload source is left alone; ctx.source_path still set.
+    assert cli.main([
+        "run", "--module", "_test_conv_src", "--source-path", str(snap),
+        "--payload", json.dumps({"source": {"ref": "acme/sd15-mirror:prod"}}),
+    ]) == 0
+    last = _last_event(capsys)
+    assert last["value"]["source_path"] == str(snap)
+    assert last["value"]["source_ref"] == "acme/sd15-mirror:prod"
+
+
+def test_run_source_path_usage_errors(tmp_path, capsys, monkeypatch) -> None:
+    monkeypatch.setattr(run_mod, "_warm_serve_socket", lambda: None)
+
+    # Nonexistent path -> usage error.
+    _conversion_module()
+    assert cli.main([
+        "run", "--module", "_test_conv_src", "--source-path", str(tmp_path / "missing"),
+    ]) == 2
+
+    # Inference endpoints have no reserved source contract.
+    _marco_module()
+    snap = tmp_path / "snap"
+    snap.mkdir()
+    assert cli.main([
+        "run", "--module", "_test_marco", "--source-path", str(snap),
+        "--payload", json.dumps({"text": "marco"}),
+    ]) == 2

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -94,3 +94,24 @@ def test_select_function_base_fn_wins_exact_match_over_variant_attr_matches():
     assert base.fn_name == "generate"
     variant = cli_run._select_function(candidates, cls_name=None, method_name="generate_alt")
     assert variant.fn_name == "generate-alt"
+
+
+def test_map_exception_redacts_presigned_url_but_keeps_context():
+    # Presigned-URL download failures used to collapse to "internal error";
+    # the message must survive with only the credential material redacted.
+    exc = RuntimeError(
+        "download failed for https://r2.example.com/cas/ab12?"
+        "X-Amz-Credential=AKIAEXAMPLE%2F20260706&X-Amz-Signature=deadbeef123"
+    )
+    status, msg = _map_exception(exc)
+    assert status == pb.JOB_STATUS_FATAL
+    assert msg.startswith("RuntimeError: download failed")
+    assert "r2.example.com" in msg
+    assert "AKIAEXAMPLE" not in msg and "deadbeef123" not in msg
+    assert "[redacted]" in msg
+
+
+def test_map_exception_redacts_bare_signature_param():
+    status, msg = _map_exception(RuntimeError("PUT 403: Signature=abc123 rejected"))
+    assert status == pb.JOB_STATUS_FATAL
+    assert "abc123" not in msg and "rejected" in msg

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,7 @@ dependencies = [
 dev = [
     { name = "accelerate" },
     { name = "bitsandbytes", marker = "sys_platform == 'linux'" },
+    { name = "flashpack" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -409,6 +410,7 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "bitsandbytes", marker = "sys_platform == 'linux' and extra == 'dev'", specifier = ">=0.45.0" },
     { name = "blake3", specifier = ">=1.0.0" },
+    { name = "flashpack", marker = "extra == 'dev'", specifier = ">=0.2.1" },
     { name = "flashpack", marker = "extra == 'flashpack'", specifier = ">=0.2.1" },
     { name = "gen-worker", editable = "." },
     { name = "gguf", specifier = ">=0.10.0" },


### PR DESCRIPTION
Closes the gen-worker side of training-endpoints #42 (convert-flashpack worker-side opaque fatal).

## What
- **executor**: `_sanitize` now REDACTS credential material (`Bearer …`, `X-Amz-*=…`, `Signature=…`) in place instead of replacing the whole message with `internal error`. Presigned-URL download/publish failures — the exact shape of the surviving run-8 root-cause candidates — now name themselves (PR#69 gave fatal errors class+detail; this closes the sanitize hole that still made URL-bearing failures opaque).
- **cli**: `gen-worker run --source-path <dir>` populates `ctx.source_path` the way the production worker does after Hub-resolve, and synthesizes the reserved `source` payload field when absent. Reserved-source producer functions were previously un-runnable locally (the issue's local-repro doctrine command didn't exist).
- **cozy_convert**: flashpack packing unit tests incl. non-float buffers (int64 position ids, bool mask) + deterministic-error paths; `flashpack` added to the dev extra.

## Local repro evidence (te#42 task 1)
The exact pinned code (cozy-convert 1de873b, the run-8 image) packs BOTH J9 rung-3 source shapes on CPU with no error:
- sd15 fp16 diffusers mirror-shape (variant-named files): 2.13GB merged → 2.13GB flashpack, 11s, peak RSS 4.6GB
- sd15 2.10GB singlefile (rung-2 artifact analog, incl. int64 position_ids): 29s, peak RSS 4.5GB

vs the 16GB/60GB CPU pod spec — the converter/packing path is exonerated; the fatal came from the hub-interaction surface, which 0.9.1 collapsed to `internal error`. With this + PR#69 in the image, the next live run names the real failure.

`gen-worker run --module conversion.main --class Transform --method convert_flashpack --source-path <sd15 snapshot>` now runs the real tenant function end-to-end locally (stops at publish with a loud, named HubPublishError — correct local-mode behavior).

## Tests
- root: 256 passed, 1 skipped
- packages/cozy_convert: 53 passed (incl. 3 new flashpack tests), 8 integration deselected