### PR TITLE
docs: cross-link tensorhub writing-endpoints guide (th#568)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Run it locally, no orchestrator:
 gen-worker run --payload '{"prompt": "hello"}'
 ```
 
-`cozyctl endpoint deploy` (or the platform UI) takes it from here.
+`cozyctl build` / `cozyctl deploy` take it from here — the full path to a
+deployed, billed endpoint is [tensorhub docs/writing-endpoints.md](https://github.com/cozy-creator/tensorhub/blob/master/docs/writing-endpoints.md).
 
 ## Adding a model
 

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -1,5 +1,10 @@
 # Endpoint authoring
 
+API reference for the `@endpoint` surface. For the platform-side narrative —
+quickstart, deploy, pricing, model-binding practice, the DON'Ts — read
+[tensorhub docs/writing-endpoints.md](https://github.com/cozy-creator/tensorhub/blob/master/docs/writing-endpoints.md)
+first.
+
 One decorator: `@endpoint`. A plain function for stateless endpoints; a class
 with an optional `setup()` when you hold state (model weights, an engine).
 


### PR DESCRIPTION
Companion to cozy-creator/tensorhub#108 (tracker tensorhub#568).

- `docs/endpoint-authoring.md`: header now points at tensorhub `docs/writing-endpoints.md` for the platform-side narrative; this file remains the `@endpoint` API reference.
- `README.md`: fixes the stale `cozyctl endpoint deploy` mention (real commands are `cozyctl build` / `cozyctl deploy`) and links the guide.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)