### PR TITLE
feat(cozy-convert): launch-catalog ingest — family normalization, z-image split, dtype-true repackage, source mirrors

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/base_model_families.py
+++ b/packages/cozy_convert/src/cozy_convert/base_model_families.py
@@ -37,7 +37,7 @@ CANONICAL_FAMILIES: frozenset[str] = frozenset({
     "flux2-dev", "flux.2-klein-4b", "flux.2-klein-9b", "flux2-pro",
     "stable-cascade", "playground-v2", "pixart-alpha", "pixart-sigma",
     "lumina", "kolors", "hunyuan-1", "auraflow",
-    "qwen-image", "z-image",
+    "qwen-image", "z-image", "z-image-turbo", "ernie", "anima",
 
     # Video diffusion
     "svd", "svd-xt", "wan21", "wan22", "ltx-video",
@@ -149,6 +149,19 @@ _CIVITAI_TO_FAMILY: Mapping[str, str] = {
     "SD 3.5 Medium": "sd35-medium",
     "SD 3.5 Large": "sd35-large",
     "SD 3.5 Large Turbo": "sd35-large-turbo",
+    "Flux.2 Klein 9B": "flux.2-klein-9b",
+    "Flux.2 Klein 9B-base": "flux.2-klein-9b",
+    "ZImageTurbo": "z-image-turbo",
+    "ZImageBase": "z-image",
+    "Qwen": "qwen-image",
+    "Ernie": "ernie",
+    "Anima": "anima",
+    "NoobAI": "sdxl-illustrious",
+    "SD 1.5 LCM": "sd15",
+    "SDXL 1.0 LCM": "sdxl",
+    "Wan Video 2.2 I2V-A14B": "wan22",
+    "Wan Video 2.2 T2V-A14B": "wan22",
+    "Wan Video 2.2 TI2V-5B": "wan22",
     "Other": "other",
 }
 

--- a/packages/cozy_convert/src/cozy_convert/clone.py
+++ b/packages/cozy_convert/src/cozy_convert/clone.py
@@ -12,6 +12,7 @@ and :func:`run_clone` (keyword-explicit).
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -31,6 +32,9 @@ _PUBLIC_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{0,127}$")
 _PUBLIC_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
 
 _KNOWN_DTYPES = {
+    # "source" = publish the source's own weights untouched (pure mirror);
+    # the flavor's recorded dtype is the detected on-disk dtype.
+    "source",
     "fp32", "fp16", "bf16", "fp8", "fp8:e4m3", "fp8:e5m2", "nvfp4",
     "int8", "int8:awq", "int8:gptq",
     "int4", "int4:wo", "int4:nf4", "int4:fp4", "int4:awq", "int4:gptq",
@@ -42,10 +46,10 @@ _KNOWN_DTYPES = {
 _KNOWN_FILE_LAYOUTS = {"diffusers", "singlefile"}
 _KNOWN_FILE_TYPES = {"safetensors", "flashpack", "gguf"}
 
-_REPACKAGE_FAMILIES = {
-    "stable-diffusion", "sd", "sd15", "sd1", "sd2", "sdxl",
-    "flux", "pixart", "dit", "kandinsky", "playground",
-}
+# Families whose singlefile<->diffusers repackage is implemented, in the
+# repackage module's normalized vocabulary (fine-tune lineages like
+# sdxl-illustrious / flux1-dev / z-image-turbo normalize onto these).
+_REPACKAGE_NORMALIZED_FAMILIES = {"sd15_sd2", "sdxl", "flux", "zimage"}
 
 _WEIGHT_EXTS = (".safetensors",)
 _DEFAULT_QUANT_COMPONENTS = ("transformer", "unet", "text_encoder", "text_encoder_2",
@@ -151,25 +155,34 @@ def _is_weight(path: Path) -> bool:
 
 def _weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Path]]:
     """(component, entry_path) per weight set. entry is the index.json for
-    sharded sets, else the single safetensors file."""
+    sharded sets, else the safetensors file. A singlefile-layout source can
+    still carry several root weight files (civitai bundles ship the
+    diffusion model + text encoder + VAE side by side) — every one is its
+    own group, or a dtype pass would convert only the first and the tree
+    copy would silently drop the rest."""
     groups: list[tuple[str, Path]] = []
 
-    def _entry_for(d: Path) -> Optional[Path]:
+    def _entries_for(d: Path) -> list[Path]:
         idx = sorted(d.glob("*.safetensors.index.json"))
-        if idx:
-            return idx[0]
-        st = sorted(p for p in d.glob("*.safetensors") if p.is_file())
-        return st[0] if st else None
+        sharded_members: set[str] = set()
+        for i in idx:
+            try:
+                weight_map = json.loads(i.read_text("utf-8")).get("weight_map") or {}
+                sharded_members.update(str(v) for v in weight_map.values())
+            except Exception:
+                pass
+        loose = [p for p in sorted(d.glob("*.safetensors"))
+                 if p.is_file() and p.name not in sharded_members]
+        return idx + loose
 
     if layout == "diffusers":
         for entry in sorted(source_dir.iterdir()):
             if entry.is_dir():
-                found = _entry_for(entry)
-                if found is not None:
-                    groups.append((entry.name, found))
+                found = _entries_for(entry)
+                if found:
+                    groups.append((entry.name, found[0]))
     else:
-        found = _entry_for(source_dir)
-        if found is not None:
+        for found in _entries_for(source_dir):
             groups.append(("", found))
     return groups
 
@@ -238,6 +251,24 @@ def build_flavor_tree(
     source_layout = source.layout if source.layout in _KNOWN_FILE_LAYOUTS else "singlefile"
     source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
 
+    # dtype="source": pure mirror — publish the source weights untouched and
+    # record the detected on-disk dtype. Refuses combos that would still
+    # rewrite tensors (layout/container changes) or an undetectable source.
+    if spec.dtype == "source":
+        if spec.file_type != "safetensors":
+            raise ValueError('dtype="source" requires file_type="safetensors"')
+        if spec.file_layout != source_layout:
+            raise ValueError(
+                f'dtype="source" cannot repackage {source_layout}->{spec.file_layout}; '
+                "request an explicit dtype")
+        if not source_dtype:
+            raise ValueError(
+                'dtype="source" needs a detectable on-disk dtype; request an explicit dtype')
+        attrs["dtype"] = source_dtype
+        _copy_non_weights(source_dir, out_dir, skip_components=set())
+        _stage_oversize_safetensors(out_dir)
+        return out_dir, attrs
+
     # GGUF / flashpack: single-artifact containers.
     if spec.file_type == "gguf":
         groups = _weight_groups(source_dir, source_layout)
@@ -264,12 +295,13 @@ def build_flavor_tree(
     work_root = source_dir
     work_layout = source_layout
     if spec.file_layout != source_layout:
+        from .repackage import _normalize_family, diffusers_to_singlefile, singlefile_to_diffusers
+
         family = str(source.model_family or "").strip().lower()
-        if family not in _REPACKAGE_FAMILIES:
+        if _normalize_family(family) not in _REPACKAGE_NORMALIZED_FAMILIES:
             raise ValueError(
                 f"layout repackage {source_layout}->{spec.file_layout} unsupported "
                 f"for model_family={family!r}")
-        from .repackage import diffusers_to_singlefile, singlefile_to_diffusers
 
         repack_dir = out_dir.parent / f"{out_dir.name}.__repack__"
         repack_dir.mkdir(parents=True, exist_ok=True)
@@ -277,7 +309,8 @@ def build_flavor_tree(
             groups = _weight_groups(source_dir, "singlefile")
             if not groups:
                 raise ValueError("no safetensors entry for repackage")
-            singlefile_to_diffusers(groups[0][1], repack_dir, model_family=family)
+            singlefile_to_diffusers(
+                groups[0][1], repack_dir, model_family=family, output_dtype=spec.dtype)
         else:
             diffusers_to_singlefile(source_dir, repack_dir / "model.safetensors",
                                     model_family=family)
@@ -457,6 +490,8 @@ def run_clone(
                         source, spec, flavor_dir,
                         quantize_components=quantize_components,
                     )
+                    # dtype="source" resolves to the detected on-disk dtype.
+                    flavor_label = str(attrs.get("dtype") or spec.dtype)
             except InlineConversionNotPossible as exc:
                 entry: dict[str, Any] = {
                     "spec_label": spec.label, "dtype": spec.dtype,

--- a/packages/cozy_convert/src/cozy_convert/ingest.py
+++ b/packages/cozy_convert/src/cozy_convert/ingest.py
@@ -18,6 +18,41 @@ from .layout import detect_huggingface_source_layout
 
 ProgressFn = Callable[[int, Optional[int]], None]
 
+_SAFETENSORS_DTYPE_NAMES = {
+    "F32": "fp32", "F16": "fp16", "BF16": "bf16",
+    "F8_E4M3": "fp8", "F8_E5M2": "fp8:e5m2",
+}
+_MAX_SAFETENSORS_HEADER_BYTES = 100 * 1024 * 1024
+
+
+def _detect_snapshot_dtype(root: Path) -> str:
+    """Majority weight dtype across a snapshot's safetensors headers
+    ('bf16' / 'fp16' / 'fp32' / 'fp8', '' when undetectable). Civitai
+    version metadata is unreliable (fp labels routinely contradict the
+    file bytes), so read the headers."""
+    import struct
+
+    counts: dict[str, int] = {}
+    try:
+        for p in sorted(Path(root).rglob("*.safetensors")):
+            with open(p, "rb") as f:
+                raw = f.read(8)
+                if len(raw) < 8:
+                    continue
+                (n,) = struct.unpack("<Q", raw)
+                if n <= 0 or n > _MAX_SAFETENSORS_HEADER_BYTES:
+                    continue
+                header = json.loads(f.read(n))
+            for value in header.values():
+                if isinstance(value, dict) and "dtype" in value:
+                    counts[str(value["dtype"])] = counts.get(str(value["dtype"]), 0) + 1
+    except (OSError, ValueError):
+        return ""
+    if not counts:
+        return ""
+    top = max(counts, key=lambda k: counts[k])
+    return _SAFETENSORS_DTYPE_NAMES.get(top, "")
+
 
 @dataclass
 class IngestedSource:
@@ -233,6 +268,9 @@ def ingest_civitai(
         "lineage_source": "civitai_baseModel" if base_model_raw else "unknown",
         "file_layout": layout_info.source_layout if layout_info.source_layout != "unknown" else "singlefile",
     }
+    on_disk_dtype = _detect_snapshot_dtype(dest_dir)
+    if on_disk_dtype:
+        attrs["dtype"] = on_disk_dtype
     model_kind = str((payload.get("model") or {}).get("type") or "").strip().lower() \
         if isinstance(payload.get("model"), dict) else ""
     if model_kind in {"lora", "locon", "lycoris", "dora"}:

--- a/packages/cozy_convert/src/cozy_convert/layout.py
+++ b/packages/cozy_convert/src/cozy_convert/layout.py
@@ -57,7 +57,11 @@ def _normalize_letters_digits(raw: str) -> str:
 
 def canonical_model_family_from_variant(variant: str) -> str:
     raw = str(variant or "").strip().lower()
-    if raw in {"flux1", "flux2", "flex2", "z_image", "qwen_image"}:
+    if raw == "z_image":
+        return "z-image"
+    if raw == "qwen_image":
+        return "qwen-image"
+    if raw in {"flux1", "flux2", "flex2"}:
         return "flux"
     if raw in {"wan21", "wan22", "wan"}:
         return "wan"

--- a/packages/cozy_convert/src/cozy_convert/repackage.py
+++ b/packages/cozy_convert/src/cozy_convert/repackage.py
@@ -19,20 +19,25 @@ _SINGLEFILE_PIPELINE_CONFIGS: dict[str, tuple[str, ...]] = {
     "StableDiffusionXLPipeline": ("stabilityai/stable-diffusion-xl-base-1.0",),
     "FluxPipeline": ("black-forest-labs/FLUX.1-dev", "black-forest-labs/FLUX.1-schnell"),
     "Flux2Pipeline": ("black-forest-labs/FLUX.2-klein-4B", "black-forest-labs/FLUX.2-klein-9B"),
+    "ZImagePipeline": ("Tongyi-MAI/Z-Image-Turbo", "Tongyi-MAI/Z-Image"),
 }
 
 
 def _normalize_family(family: str | None) -> str:
+    """Collapse canonical family slugs — including fine-tune lineages like
+    sdxl-illustrious / sdxl-pony / flux1-dev — onto the repackage family."""
     raw = str(family or "").strip().lower()
-    if raw in {"sd15", "sd2", "sd1", "sd15_sd2"}:
+    if raw in {"sd1", "sd15_sd2", "stable-diffusion", "sd"} or raw.startswith(("sd1", "sd2")):
         return "sd15_sd2"
-    if raw in {"sdxl"}:
+    if raw == "sdxl" or raw.startswith("sdxl"):
         return "sdxl"
-    if raw in {"flux", "flux1", "flux2", "flex2"}:
+    if raw in {"flux", "flex2"} or raw.startswith(("flux1", "flux2", "flux.")):
         return "flux"
+    if raw.startswith(("z-image", "zimage")):
+        return "zimage"
     if raw in {"auraflow"}:
         return "auraflow"
-    if raw in {"wan", "wan21", "wan22"}:
+    if raw in {"wan"} or raw.startswith(("wan2", "wan-2")):
         return "wan"
     return "unknown"
 
@@ -211,17 +216,38 @@ def _singlefile_attempts_for_family(model_family: str) -> list[tuple[str, str | 
             for cfg in _SINGLEFILE_PIPELINE_CONFIGS.get(cls, ()):
                 add(cls, cfg)
         return attempts
+    if family == "zimage":
+        add("ZImagePipeline")
+        for cfg in _SINGLEFILE_PIPELINE_CONFIGS.get("ZImagePipeline", ()):
+            add("ZImagePipeline", cfg)
+        return attempts
     return attempts
 
 
-def _load_singlefile_pipeline(*, input_path: Path, pipeline_class: str, config: str | None) -> Any:
+def _repackage_torch_dtype(dtype: str | None) -> Any:
+    """Map a requested output dtype onto the torch dtype the single-file
+    pipeline is materialized in. fp16 sources must stay fp16 — loading them
+    bf16 rounds the 10-bit mantissa to 7 bits and the later fp16 cast can't
+    recover it. Non-cast dtypes (quant targets) load bf16."""
+    name = str(dtype or "").strip().lower()
+    torch_mod = _torch()
+    if name in {"fp16", "f16", "float16"}:
+        return torch_mod.float16
+    if name in {"fp32", "f32", "float32"}:
+        return torch_mod.float32
+    return torch_mod.bfloat16
+
+
+def _load_singlefile_pipeline(
+    *, input_path: Path, pipeline_class: str, config: str | None, torch_dtype: Any,
+) -> Any:
     import diffusers
 
     cls = getattr(diffusers, pipeline_class, None)
     if cls is None:
         raise ValueError(f"pipeline_class_unavailable:{pipeline_class}")
 
-    kwargs: dict[str, Any] = {"torch_dtype": _torch().bfloat16}
+    kwargs: dict[str, Any] = {"torch_dtype": torch_dtype}
     if config:
         kwargs["config"] = config
 
@@ -236,7 +262,9 @@ def _load_singlefile_pipeline(*, input_path: Path, pipeline_class: str, config: 
     return fn(cls, str(input_path), **kwargs)
 
 
-def singlefile_to_diffusers(input_path: Path, output_dir: Path, *, model_family: str) -> dict[str, str]:
+def singlefile_to_diffusers(
+    input_path: Path, output_dir: Path, *, model_family: str, output_dtype: str | None = None,
+) -> dict[str, str]:
     family = _normalize_family(model_family)
     attempts = _singlefile_attempts_for_family(family)
     if not attempts:
@@ -252,6 +280,7 @@ def singlefile_to_diffusers(input_path: Path, output_dir: Path, *, model_family:
                 input_path=input_path,
                 pipeline_class=pipeline_class,
                 config=config,
+                torch_dtype=_repackage_torch_dtype(output_dtype),
             )
             pipe.save_pretrained(str(output_dir), safe_serialization=True)
             return {

--- a/packages/cozy_convert/tests/test_repackage_families.py
+++ b/packages/cozy_convert/tests/test_repackage_families.py
@@ -1,0 +1,210 @@
+"""Family normalization + dtype threading for the singlefile<->diffusers
+repackage path (e2e tracker #112: launch-catalog ingest)."""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from cozy_convert.base_model_families import civitai_to_family
+from cozy_convert.clone import _REPACKAGE_NORMALIZED_FAMILIES
+from cozy_convert.ingest import _detect_snapshot_dtype
+from cozy_convert.layout import canonical_model_family_from_variant
+from cozy_convert.repackage import (
+    _normalize_family,
+    _repackage_torch_dtype,
+    _singlefile_attempts_for_family,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("sdxl", "sdxl"),
+        ("sdxl-illustrious", "sdxl"),
+        ("sdxl-pony", "sdxl"),
+        ("sdxl-lightning", "sdxl"),
+        ("sd15", "sd15_sd2"),
+        ("sd14", "sd15_sd2"),
+        ("sd2", "sd15_sd2"),
+        ("flux1-dev", "flux"),
+        ("flux1-schnell", "flux"),
+        ("flux.2-klein-9b", "flux"),
+        ("flux2-dev", "flux"),
+        ("z-image", "zimage"),
+        ("z-image-turbo", "zimage"),
+        ("qwen-image", "unknown"),
+        ("wan22", "wan"),
+        ("ernie", "unknown"),
+        ("anima", "unknown"),
+        ("sd3-medium", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_normalize_family(raw: str, expected: str) -> None:
+    assert _normalize_family(raw) == expected
+
+
+def test_repackage_families_all_have_singlefile_attempts() -> None:
+    for family in _REPACKAGE_NORMALIZED_FAMILIES:
+        assert _singlefile_attempts_for_family(family), family
+
+
+def test_zimage_attempts_use_zimage_pipeline() -> None:
+    attempts = _singlefile_attempts_for_family("zimage")
+    assert attempts[0][0] == "ZImagePipeline"
+    assert ("ZImagePipeline", "Tongyi-MAI/Z-Image-Turbo") in attempts
+
+
+def test_repackage_torch_dtype() -> None:
+    import torch
+
+    assert _repackage_torch_dtype("fp16") is torch.float16
+    assert _repackage_torch_dtype("fp32") is torch.float32
+    assert _repackage_torch_dtype("bf16") is torch.bfloat16
+    assert _repackage_torch_dtype("int4:nf4") is torch.bfloat16
+    assert _repackage_torch_dtype(None) is torch.bfloat16
+
+
+def test_variant_to_family_zimage_and_qwen_are_not_flux() -> None:
+    assert canonical_model_family_from_variant("z_image") == "z-image"
+    assert canonical_model_family_from_variant("qwen_image") == "qwen-image"
+    assert canonical_model_family_from_variant("flux1") == "flux"
+
+
+@pytest.mark.parametrize(
+    ("base", "family"),
+    [
+        ("ZImageTurbo", "z-image-turbo"),
+        ("ZImageBase", "z-image"),
+        ("Ernie", "ernie"),
+        ("Qwen", "qwen-image"),
+        ("Anima", "anima"),
+        ("Flux.2 Klein 9B", "flux.2-klein-9b"),
+        ("Flux.2 Klein 9B-base", "flux.2-klein-9b"),
+        ("Wan Video 2.2 I2V-A14B", "wan22"),
+        ("NoobAI", "sdxl-illustrious"),
+        ("Illustrious", "sdxl-illustrious"),
+        ("Pony", "sdxl-pony"),
+    ],
+)
+def test_civitai_to_family_launch_bases(base: str, family: str) -> None:
+    assert civitai_to_family(base) == family
+
+
+def _write_safetensors(path: Path, dtype: str, n: int = 4) -> None:
+    import torch
+    from safetensors.torch import save_file
+
+    torch_dtype = {
+        "F16": torch.float16, "BF16": torch.bfloat16,
+        "F32": torch.float32, "F8_E4M3": torch.float8_e4m3fn,
+    }[dtype]
+    tensors = {
+        f"w{i}": torch.zeros(4, dtype=torch.float32).to(torch_dtype) for i in range(n)
+    }
+    save_file(tensors, str(path))
+
+
+def test_detect_snapshot_dtype(tmp_path: Path) -> None:
+    _write_safetensors(tmp_path / "model.safetensors", "F16")
+    assert _detect_snapshot_dtype(tmp_path) == "fp16"
+
+    fp8 = tmp_path / "fp8"
+    fp8.mkdir()
+    _write_safetensors(fp8 / "dit.safetensors", "F8_E4M3", n=8)
+    _write_safetensors(fp8 / "vae.safetensors", "BF16", n=2)
+    assert _detect_snapshot_dtype(fp8) == "fp8"
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert _detect_snapshot_dtype(empty) == ""
+
+
+def test_weight_groups_singlefile_multi_entry(tmp_path: Path) -> None:
+    """Civitai bundles ship several root weight files (DiT + text encoder +
+    VAE); every one must be its own group or a dtype pass drops all but the
+    first (latent data loss, found preparing e2e #112)."""
+    from cozy_convert.clone import _weight_groups
+
+    _write_safetensors(tmp_path / "dit.safetensors", "F8_E4M3")
+    _write_safetensors(tmp_path / "txt.safetensors", "BF16")
+    _write_safetensors(tmp_path / "vae.safetensors", "BF16")
+    groups = _weight_groups(tmp_path, "singlefile")
+    assert [g[1].name for g in groups] == [
+        "dit.safetensors", "txt.safetensors", "vae.safetensors"]
+    assert all(comp == "" for comp, _ in groups)
+
+
+def test_weight_groups_singlefile_sharded_index_wins(tmp_path: Path) -> None:
+    from cozy_convert.clone import _weight_groups
+
+    _write_safetensors(tmp_path / "model-00001-of-00002.safetensors", "BF16")
+    _write_safetensors(tmp_path / "model-00002-of-00002.safetensors", "BF16")
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps({
+        "weight_map": {
+            "a": "model-00001-of-00002.safetensors",
+            "b": "model-00002-of-00002.safetensors",
+        }
+    }))
+    groups = _weight_groups(tmp_path, "singlefile")
+    assert [g[1].name for g in groups] == ["model.safetensors.index.json"]
+
+
+def test_build_flavor_tree_source_dtype_passthrough(tmp_path: Path) -> None:
+    """dtype='source' publishes every source file untouched and records the
+    detected on-disk dtype (mixed-dtype bundles keep their majority label)."""
+    from cozy_convert.clone import OutputSpec, build_flavor_tree
+    from cozy_convert.ingest import IngestedSource
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_safetensors(src / "dit.safetensors", "F8_E4M3", n=8)
+    _write_safetensors(src / "txt.safetensors", "BF16", n=2)
+    (src / "workflow.json").write_text("{}")
+
+    source = IngestedSource(
+        provider="civitai", source_ref="1", source_revision="x", dir=src,
+        layout="singlefile", model_family="ernie", model_family_variant="unknown",
+        attrs={"dtype": _detect_snapshot_dtype(src), "file_layout": "singlefile"},
+    )
+    tree, attrs = build_flavor_tree(
+        source,
+        OutputSpec(dtype="source", file_layout="singlefile", file_type="safetensors"),
+        tmp_path / "flavor",
+    )
+    assert attrs["dtype"] == "fp8"
+    got = sorted(p.name for p in tree.rglob("*") if p.is_file())
+    assert got == ["dit.safetensors", "txt.safetensors", "workflow.json"]
+    assert (tree / "dit.safetensors").read_bytes() == (src / "dit.safetensors").read_bytes()
+
+
+def test_build_flavor_tree_source_dtype_refuses_repackage(tmp_path: Path) -> None:
+    from cozy_convert.clone import OutputSpec, build_flavor_tree
+    from cozy_convert.ingest import IngestedSource
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_safetensors(src / "model.safetensors", "BF16")
+    source = IngestedSource(
+        provider="civitai", source_ref="1", source_revision="x", dir=src,
+        layout="singlefile", model_family="sdxl", model_family_variant="unknown",
+        attrs={"dtype": "bf16", "file_layout": "singlefile"},
+    )
+    with pytest.raises(ValueError, match="source"):
+        build_flavor_tree(
+            source,
+            OutputSpec(dtype="source", file_layout="diffusers", file_type="safetensors"),
+            tmp_path / "flavor",
+        )
+
+
+def test_detect_snapshot_dtype_ignores_garbage(tmp_path: Path) -> None:
+    # A non-safetensors payload with a plausible header length must not crash.
+    bogus = tmp_path / "bogus.safetensors"
+    header = json.dumps({"not_a_tensor": "x"}).encode()
+    bogus.write_bytes(struct.pack("<Q", len(header)) + header)
+    assert _detect_snapshot_dtype(tmp_path) == ""


### PR DESCRIPTION
Closes the cozy-convert side of e2e tracker #112 (LAUNCH-MODELS catalog ingest).

## What
- **repackage**: family slugs are prefix-normalized — `sdxl-illustrious`/`sdxl-pony`/`flux1-dev`/`z-image-turbo` (what civitai baseModel mapping actually emits) now reach the singlefile->diffusers split instead of failing `unsupported_family`; adds `ZImagePipeline` single-file attempts (diffusers >=0.38 has z-image single-file support); threads the requested output dtype into `from_single_file` — fp16 SDXL sources were hardcoded-loaded bf16, a double-lossy fp16->bf16->fp16 round-trip for the entire SDXL cohort.
- **clone**: new `dtype="source"` output — publish weights untouched, recording the *detected* on-disk dtype (pure mirrors for fp8/scaled + mixed-dtype civitai bundles where any cast would be wrong); `_weight_groups` now returns every root weight file of a singlefile source — multi-file bundles (DiT+text-encoder+VAE side by side, e.g. RedCraft ERNIE) silently lost all but the first file in a dtype pass.
- **ingest**: civitai sources get their dtype detected from safetensors headers (incl. F8_E4M3) — version metadata routinely lies, and without this passthrough never triggered.
- **layout**: `z_image`/`qwen_image` variants no longer masquerade as family "flux" (a z-image single-file would have been repackaged via FluxPipeline).
- **base_model_families**: civitai `baseModel` mappings for the 2025/26 rows: ZImageTurbo/ZImageBase/Ernie/Qwen/Anima/Flux.2-Klein-9B(-base)/Wan-2.2/NoobAI/LCM.

## Verified
- 256 gen-worker tests + 100 cozy_convert tests green (incl. new unit coverage for normalization, source-dtype passthrough, multi-entry weight groups, fp8 detection).
- Local real-checkpoint repro (pre-pod, per the local-repro rule): Babes SD1.5 3.1 (2GB fp16) and WAI-Illustrious v17 (6.5GB fp16) split end-to-end via `build_flavor_tree` — correct diffusers trees, fp16 preserved, unet sharded at the 2GB cap with index.