### PR TITLE
feat(compile): per-SKU torch.compile cache artifacts (#384)

### DIFF
--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -1,0 +1,34 @@
+# torch.compile cache artifacts (#384)
+
+Compile wins 15-34% warm latency on flux-class models but costs 20-46s per
+(model, shape) and needs a C toolchain prod worker images don't ship. The
+split:
+
+- **Producer** — the platform's first-party compile job (training-endpoints
+  `produce-inductor-cache`) runs on the target GPU SKU with a toolchain,
+  compiles the declared shape set, and publishes the captured
+  `TORCHINDUCTOR_CACHE_DIR` + `TRITON_CACHE_DIR` as ONE deterministic
+  `.tar.gz` flavor `#inductor-<sku>-torch<maj.min>` of the family system repo
+  `_system/family-<family>`.
+- **Consumer** — an endpoint opts in with
+  `@endpoint(compile=Compile(family="flux2-klein-4b", shapes=((768,768),(1024,1024))))`.
+  At load the worker seeds a VERIFIED artifact (exact-match on family, SKU,
+  torch, triton, diffusers/transformers), then arms guarded `torch.compile`
+  (dynamic=False) on `Compile.targets`. Any miss/mismatch => eager. A
+  compiled call that still needs a fresh compile (undeclared shape, no
+  toolchain) permanently unwraps to eager — never a failed request.
+
+Artifact sources today: `GEN_WORKER_COMPILE_CACHE` (local tar) or
+`GEN_WORKER_COMPILE_CACHE_URL` (presigned GET). Hub-side per-(SKU, torch)
+snapshot attach is tensorhub #569. `GEN_WORKER_COMPILE_ALLOW_COLD=1` permits
+cold compilation (compile job / dev only; requires a toolchain).
+
+Trust: compiled artifacts are CODE. Only platform jobs may publish to
+`_system/*` (invoke-time destination-write preflight + cap-token repo+owner
+gate + the tenant slug grammar bars `_system`). Tenant custom-code endpoints
+get per-release private caches (same-principal rule) — not implemented yet.
+
+Family keying: caches key on the traced graph + shapes, not weights — one
+artifact serves every fine-tune of a family. Add a boot `warmup()` that
+renders each declared shape (see examples/flux2-klein-image) so requests
+never see the (cache-served) compile.

--- a/examples/flux2-klein-image/src/flux2_klein_image/main.py
+++ b/examples/flux2-klein-image/src/flux2_klein_image/main.py
@@ -18,7 +18,7 @@ import msgspec
 import torch
 
 from diffusers import Flux2KleinPipeline
-from gen_worker import HF, RequestContext, Resources, ValidationError, endpoint
+from gen_worker import Compile, HF, RequestContext, Resources, ValidationError, endpoint
 from gen_worker import io as gw_io
 from gen_worker.api.types import ImageAsset
 
@@ -53,10 +53,29 @@ class KleinTurboOutput(msgspec.Struct):
         ),
     ),
     resources=Resources(vram_gb=20),
+    # Opt into torch.compile (#384). Safe by construction: the worker arms
+    # compile ONLY when a verified per-(model, SKU, torch, triton) cache
+    # artifact is seeded (GEN_WORKER_COMPILE_CACHE[_URL]); otherwise eager.
+    compile=Compile(shapes=((768, 768), (1024, 1024))),
 )
 class Flux2KleinTurbo:
     def setup(self, model: Flux2KleinPipeline) -> None:
         self._pipe = model
+
+    def warmup(self) -> None:
+        """When compile is armed, pay the (cache-served) compile cost at boot
+        over the declared shapes so no request ever sees the stall."""
+        info = getattr(self._pipe, "_cozy_compile", None)
+        if not info:
+            return
+        for w, h in info.get("shapes") or ():
+            self._pipe(
+                prompt="warmup",
+                num_inference_steps=1,
+                width=int(w),
+                height=int(h),
+                generator=torch.Generator(device=self._pipe.device).manual_seed(0),
+            )
 
     def generate_turbo(self, ctx: RequestContext, p: KleinTurboInput) -> KleinTurboOutput:
         if not str(p.prompt or "").strip():

--- a/examples/flux2-klein-image/src/flux2_klein_image/main.py
+++ b/examples/flux2-klein-image/src/flux2_klein_image/main.py
@@ -56,7 +56,7 @@ class KleinTurboOutput(msgspec.Struct):
     # Opt into torch.compile (#384). Safe by construction: the worker arms
     # compile ONLY when a verified per-(model, SKU, torch, triton) cache
     # artifact is seeded (GEN_WORKER_COMPILE_CACHE[_URL]); otherwise eager.
-    compile=Compile(shapes=((768, 768), (1024, 1024))),
+    compile=Compile(family="flux2-klein-4b", shapes=((768, 768), (1024, 1024))),
 )
 class Flux2KleinTurbo:
     def setup(self, model: Flux2KleinPipeline) -> None:

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -15,7 +15,7 @@ subclass from ``@endpoint(kind=...)`` before dispatch.
 
 from . import io
 from .api.binding import Civitai, HF, Hub, ModelScope
-from .api.decorators import Resources, endpoint
+from .api.decorators import Compile, Resources, endpoint
 from .api.errors import (
     CanceledError,
     FatalError,
@@ -50,6 +50,7 @@ __all__ = [
     # The decorator + bindings.
     "endpoint",
     "Resources",
+    "Compile",
     "HF",
     "Hub",
     "Civitai",

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -88,15 +88,18 @@ class Variant(msgspec.Struct, frozen=True):
 class Compile(msgspec.Struct, frozen=True):
     """Opt-in torch.compile over pre-built per-SKU cache artifacts (#384).
 
-    ``Compile(shapes=((768, 768), (1024, 1024)))`` declares the (width,
-    height) set the compile job warms. Declaring this does NOT force
-    compilation: the worker arms torch.compile only when a verified cache
-    artifact for (model, SKU, torch, triton) is seeded — otherwise it stays
-    eager. See ``gen_worker.compile_cache``.
+    ``Compile(family="flux2-klein-4b", shapes=((768, 768), (1024, 1024)))``
+    names the model FAMILY (caches key on the traced graph, so every
+    fine-tune of a family shares one artifact) and the (width, height) set
+    the compile job warms. Declaring this does NOT force compilation: the
+    worker arms torch.compile only when a verified cache artifact for
+    (family, SKU, torch, triton) is seeded — otherwise it stays eager.
+    See ``gen_worker.compile_cache``.
     """
 
     shapes: tuple[tuple[int, int], ...]
     targets: tuple[str, ...] = ("transformer", "vae.decode")
+    family: str = ""
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -110,6 +113,7 @@ class Compile(msgspec.Struct, frozen=True):
         if not targets:
             raise ValueError("Compile.targets must not be empty")
         force(self, "targets", targets)
+        force(self, "family", str(self.family or "").strip())
 
 
 class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -85,6 +85,33 @@ class Variant(msgspec.Struct, frozen=True):
     resources: Resources | None = None
 
 
+class Compile(msgspec.Struct, frozen=True):
+    """Opt-in torch.compile over pre-built per-SKU cache artifacts (#384).
+
+    ``Compile(shapes=((768, 768), (1024, 1024)))`` declares the (width,
+    height) set the compile job warms. Declaring this does NOT force
+    compilation: the worker arms torch.compile only when a verified cache
+    artifact for (model, SKU, torch, triton) is seeded — otherwise it stays
+    eager. See ``gen_worker.compile_cache``.
+    """
+
+    shapes: tuple[tuple[int, int], ...]
+    targets: tuple[str, ...] = ("transformer", "vae.decode")
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        shapes = tuple((int(w), int(h)) for w, h in (tuple(s) for s in self.shapes))
+        if not shapes or any(w <= 0 or h <= 0 for w, h in shapes):
+            raise ValueError(
+                f"Compile.shapes must be positive (w, h) pairs, got {self.shapes!r}"
+            )
+        force(self, "shapes", shapes)
+        targets = tuple(str(t).strip() for t in self.targets if str(t).strip())
+        if not targets:
+            raise ValueError("Compile.targets must not be empty")
+        force(self, "targets", targets)
+
+
 class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     """Metadata attached by ``@endpoint``; read by the registry walker."""
 
@@ -95,6 +122,7 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     runtime: Optional[str] = None
     name: Optional[str] = None  # function-shaped endpoints only
     is_function: bool = False
+    compile: Optional[Compile] = None
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -335,6 +363,7 @@ def _decorate_class(
     models: dict[str, Binding],
     variants: Optional[Mapping[str, Any]],
     runtime: Optional[str],
+    compile: Optional[Compile] = None,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -363,7 +392,7 @@ def _decorate_class(
 
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models,
-        variants=variant_rows, runtime=runtime,
+        variants=variant_rows, runtime=runtime, compile=compile,
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
@@ -378,6 +407,7 @@ def _decorate_function(
     models: dict[str, Binding],
     runtime: Optional[str],
     name: Optional[str],
+    compile: Optional[Compile] = None,
 ) -> Callable[..., Any]:
     _validate_handler_shape(fn.__name__, fn, is_method=False)
     _reject_producer_generator(fn.__name__, fn, kind)
@@ -399,6 +429,7 @@ def _decorate_function(
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models,
         runtime=None, name=(name or fn.__name__), is_function=True,
+        compile=compile,
     )
     setattr(fn, ATTR, decl)
     return fn
@@ -414,6 +445,7 @@ def endpoint(
     variants: Optional[Mapping[str, Any]] = None,
     runtime: Optional[str] = None,
     name: Optional[str] = None,
+    compile: Optional[Compile] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes."""
     if kind not in KINDS:
@@ -422,6 +454,10 @@ def endpoint(
     if resources is not None and not isinstance(resources, Resources):
         raise TypeError(
             f"@endpoint resources= must be a Resources, got {type(resources).__name__}"
+        )
+    if compile is not None and not isinstance(compile, Compile):
+        raise TypeError(
+            f"@endpoint compile= must be a Compile, got {type(compile).__name__}"
         )
     model_map = _normalize_models(model, models)
 
@@ -432,7 +468,7 @@ def endpoint(
                                  "class handlers route by method name")
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=model_map,
-                variants=variants, runtime=runtime,
+                variants=variants, runtime=runtime, compile=compile,
             )
         if inspect.isfunction(obj):
             if variants:
@@ -442,7 +478,7 @@ def endpoint(
                 )
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
-                runtime=runtime, name=name,
+                runtime=runtime, name=name, compile=compile,
             )
         raise TypeError(
             f"@endpoint requires a function or class, got {type(obj).__name__}"
@@ -453,4 +489,4 @@ def endpoint(
     return apply
 
 
-__all__ = ["EndpointDecl", "Resources", "Variant", "endpoint"]
+__all__ = ["Compile", "EndpointDecl", "Resources", "Variant", "endpoint"]

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -802,15 +802,21 @@ def run_setup(instance: Any, resolved_models: Dict[str, str]) -> None:
         hints = typing.get_type_hints(setup_fn)
     except (TypeError, ValueError, NameError):
         hints = {}
+    decl = getattr(type(instance), _ENDPOINT_ATTR, None)
     loaded = {
-        k: _load_injected_model(hints.get(k), v)
+        k: _load_injected_model(hints.get(k), v, decl=decl, slot=k)
         for k, v in resolved_models.items()
         if k in wanted
     }
     setup_fn(**loaded)
+    # Executor parity: warmup() runs once after setup (compile warm-up etc.).
+    warmup_fn = getattr(instance, "warmup", None)
+    if callable(warmup_fn):
+        warmup_fn()
 
 
 _INJECTED_CACHE: Dict[Tuple[str, str], Any] = {}
+_ENDPOINT_ATTR = "__gen_worker_endpoint__"
 
 
 def _build_injected_kwargs(bound_method: Any, resolved_models: Dict[str, str]) -> Dict[str, Any]:
@@ -826,14 +832,20 @@ def _build_injected_kwargs(bound_method: Any, resolved_models: Dict[str, str]) -
         hints = typing.get_type_hints(bound_method)
     except (TypeError, ValueError, NameError):
         return {}
+    owner = getattr(bound_method, "__self__", None)
+    decl = getattr(type(owner), _ENDPOINT_ATTR, None) if owner is not None else None
     kwargs: Dict[str, Any] = {}
     for name in list(sig.parameters)[2:]:  # skip ctx, payload (self already bound)
         if name in resolved_models:
-            kwargs[name] = _load_injected_model(hints.get(name), resolved_models[name])
+            kwargs[name] = _load_injected_model(
+                hints.get(name), resolved_models[name], decl=decl, slot=name
+            )
     return kwargs
 
 
-def _load_injected_model(annotation: Any, local_path: str) -> Any:
+def _load_injected_model(
+    annotation: Any, local_path: str, *, decl: Any = None, slot: str = ""
+) -> Any:
     key = (str(annotation), str(local_path))
     if key in _INJECTED_CACHE:
         return _INJECTED_CACHE[key]
@@ -845,10 +857,14 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
         cls = DiffusionPipeline
     # fp16 kernels are CUDA-only for several ops; on a CPU device run use fp32.
     device = (os.getenv("GEN_WORKER_LOCAL_DEVICE") or "").strip().lower()
+    binding = (getattr(decl, "models", None) or {}).get(slot) if decl is not None else None
+    # Executor parity: honor the binding's declared dtype (bf16 endpoints must
+    # not silently load fp16 locally); fall back to the device default.
+    dtype = str(getattr(binding, "dtype", "") or "") or ("fp32" if device == "cpu" else "fp16")
     # Same loader the production executor uses: handles diffusers-layout dirs,
     # module-layout dirs (root config.json, e.g. a bare VAE/UNet repo), and
     # single-file checkpoints.
-    pipe = load_from_pretrained(cls, local_path, dtype="fp32" if device == "cpu" else "fp16")
+    pipe = load_from_pretrained(cls, local_path, dtype=dtype)
     if device != "cpu":
         # Worker-owned placement (executor parity): endpoints never write
         # device/offload code, so the cold `run` path must place the loaded
@@ -858,6 +874,16 @@ def _load_injected_model(annotation: Any, local_path: str) -> Any:
         from gen_worker.models.memory import place_pipeline
 
         place_pipeline(pipe)
+        compile_cfg = getattr(decl, "compile", None) if decl is not None else None
+        if compile_cfg is not None:
+            # Executor parity for #384: seed a verified per-SKU cache artifact
+            # if configured, else stay eager.
+            from gen_worker import compile_cache
+            from gen_worker.api.binding import wire_ref
+
+            compile_cache.enable(
+                pipe, compile_cfg, wire_ref(binding) if binding is not None else ""
+            )
     _INJECTED_CACHE[key] = pipe
     return pipe
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -879,11 +879,8 @@ def _load_injected_model(
             # Executor parity for #384: seed a verified per-SKU cache artifact
             # if configured, else stay eager.
             from gen_worker import compile_cache
-            from gen_worker.api.binding import wire_ref
 
-            compile_cache.enable(
-                pipe, compile_cfg, wire_ref(binding) if binding is not None else ""
-            )
+            compile_cache.enable(pipe, compile_cfg)
     _INJECTED_CACHE[key] = pipe
     return pipe
 

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -362,12 +362,16 @@ def _guarded(original: Callable[..., Any], compiled: Callable[..., Any], label: 
     return wrapper
 
 
-def apply(pipeline: Any, cfg: Any, *, cache_ready: bool) -> bool:
-    """Wrap ``cfg.targets`` on ``pipeline`` with guarded compiled callables.
+def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> bool:
+    """Wrap ``cfg.targets`` on ``pipeline`` with compiled callables.
 
     Only compiles when a verified cache artifact was seeded (``cache_ready``)
     or the process explicitly opted into cold compilation AND has a C
     toolchain. Anything else is a logged no-op — eager, never a stall.
+
+    ``guard=True`` (consumer): a failing compiled call permanently unwraps to
+    eager. ``guard=False`` (compile job): failures must raise, a silently
+    eager warm-up would publish an empty artifact as success.
     """
     if getattr(pipeline, _MARKER_ATTR, None) is not None:
         return True
@@ -405,7 +409,7 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool) -> bool:
             if vae is not None:
                 vae.to(memory_format=torch.channels_last)
         compiled = torch.compile(fn, dynamic=False)
-        setattr(owner, attr, _guarded(fn, compiled, target))
+        setattr(owner, attr, _guarded(fn, compiled, target) if guard else compiled)
         applied.append(target)
     if not applied:
         return False
@@ -425,8 +429,92 @@ def enable(pipeline: Any, cfg: Any, model_ref: str = "", cache_dir: Optional[Pat
     return apply(pipeline, cfg, cache_ready=meta is not None)
 
 
+# ---------------------------------------------------------------------------
+# Build (the compile job / conversion producer)
+# ---------------------------------------------------------------------------
+
+
+def build(
+    model_path: str | Path,
+    out_dir: str | Path,
+    *,
+    shapes: Iterable[Tuple[int, int]],
+    targets: Iterable[str] = ("transformer", "vae.decode"),
+    model_ref: str = "",
+    model_digest: str = "",
+    dtype: str = "bf16",
+    steps: int = 2,
+    prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
+) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
+    """Compile a diffusers pipeline over ``shapes`` and package the resulting
+    inductor+triton caches as a per-SKU artifact.
+
+    Runs on the TARGET GPU SKU with a C toolchain present (cold compile).
+    Returns ``(artifact_path, metadata, per-shape warm-up seconds)`` — the
+    first call per shape is the compile cost. Raises on any compile failure
+    or an empty capture; a silently-eager build must never publish.
+    """
+    from .api.decorators import Compile as CompileCfg
+    from .models.loading import load_from_pretrained
+
+    if not toolchain_present():
+        raise RuntimeError(
+            "compile-cache build needs a C toolchain (cc/gcc); run in the "
+            "compile-job image, not a prod worker image"
+        )
+    out_dir = Path(out_dir)
+    capture_root = out_dir / "capture"
+    capture_env(capture_root)
+
+    import torch
+    from diffusers import DiffusionPipeline
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("compile-cache build requires CUDA")
+
+    cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets))
+    pipe = load_from_pretrained(DiffusionPipeline, str(model_path), dtype=dtype)
+    pipe.to("cuda")
+    if callable(getattr(pipe, "set_progress_bar_config", None)):
+        pipe.set_progress_bar_config(disable=True)
+    os.environ[ENV_ALLOW_COLD] = "1"
+    if not apply(pipe, cfg, cache_ready=False, guard=False):
+        raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
+
+    timings: Dict[str, float] = {}
+    for w, h in cfg.shapes:
+        torch.cuda.synchronize()
+        t = time.monotonic()
+        pipe(
+            prompt=prompt,
+            num_inference_steps=int(steps),
+            width=int(w),
+            height=int(h),
+            generator=torch.Generator(device="cuda").manual_seed(0),
+        )
+        torch.cuda.synchronize()
+        timings[f"{w}x{h}"] = round(time.monotonic() - t, 2)
+        logger.info("compile-cache build: warmed %dx%d in %.1fs", w, h, timings[f"{w}x{h}"])
+
+    captured = [p for p in (capture_root / "inductor").rglob("*") if p.is_file()]
+    if not captured:
+        raise RuntimeError(
+            "compile warm-up captured nothing under TORCHINDUCTOR_CACHE_DIR — "
+            "was inductor already latched to another dir in this process?"
+        )
+
+    meta = artifact_metadata(
+        model_ref=model_ref, model_digest=model_digest,
+        shapes=cfg.shapes, targets=cfg.targets,
+    )
+    label = flavor_label(meta["sku"], meta["torch"])
+    artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)
+    return artifact, meta, timings
+
+
 __all__ = [
     "ARTIFACT_FORMAT",
+    "build",
     "ENV_ALLOW_COLD",
     "ENV_CACHE_PATH",
     "ENV_CACHE_URL",

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1,0 +1,446 @@
+"""Per-SKU torch.compile cache artifacts (#384).
+
+torch.compile wins 15-34% warm latency on flux-class models but costs 20-46s
+of compile per (model, resolution) and needs a C toolchain the prod worker
+images don't ship. The split: a platform compile job (training-endpoints
+``produce-inductor-cache``) compiles once per GPU SKU and publishes the
+inductor+triton cache dirs as a repo flavor; workers that opt in via
+``@endpoint(compile=Compile(...))`` seed those dirs before load and hit the
+cache with no compiler and no stall.
+
+Policy: cache miss / key mismatch / no artifact => eager, never a boot stall
+or a runtime compile attempt in prod. The compile job itself opts into cold
+compilation with ``GEN_WORKER_COMPILE_ALLOW_COLD=1`` (requires a toolchain).
+
+Artifact = deterministic ``.tar.gz``::
+
+    metadata.json      key: sku/torch/triton/cuda, model ref+digest, shapes,
+                       targets, diffusers/transformers versions
+    inductor/**        TORCHINDUCTOR_CACHE_DIR contents
+    triton/**          TRITON_CACHE_DIR contents
+
+Key sensitivity (all exact-match): GPU SKU (autotune choices + cubin arch),
+torch (fx-graph cache key), triton (cubin/launcher cache key), diffusers
+(the traced graph is its code). Model digest is recorded by the producer and
+checked when the consumer knows its own; the model REF always must match.
+"""
+
+from __future__ import annotations
+
+import functools
+import gzip
+import hashlib
+import io
+import json
+import logging
+import os
+import shutil
+import tarfile
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+ENV_CACHE_PATH = "GEN_WORKER_COMPILE_CACHE"       # local artifact (tar) or seeded dir
+ENV_CACHE_URL = "GEN_WORKER_COMPILE_CACHE_URL"    # http(s) URL to the artifact
+ENV_ALLOW_COLD = "GEN_WORKER_COMPILE_ALLOW_COLD"  # compile without an artifact (needs cc)
+
+METADATA_NAME = "metadata.json"
+ARTIFACT_FORMAT = 1
+_MARKER_ATTR = "_cozy_compile"
+_JUNK_SUFFIXES = (".lock", ".tmp", ".pid")
+
+
+# ---------------------------------------------------------------------------
+# Key
+# ---------------------------------------------------------------------------
+
+
+def sku_slug(gpu_name: str) -> str:
+    """Deterministic SKU slug: ``NVIDIA GeForce RTX 4090`` -> ``rtx-4090``,
+    ``NVIDIA H100 80GB HBM3`` -> ``h100-80gb-hbm3``."""
+    s = str(gpu_name or "").lower()
+    for noise in ("nvidia", "geforce"):
+        s = s.replace(noise, " ")
+    out = "".join(c if c.isalnum() else "-" for c in s).strip("-")
+    while "--" in out:
+        out = out.replace("--", "-")
+    return out
+
+
+def runtime_key() -> Dict[str, str]:
+    """The consumer-side half of the cache key, probed from this process."""
+    key = {"sku": "", "torch": "", "triton": "", "cuda": ""}
+    try:
+        import torch
+
+        key["torch"] = str(torch.__version__)
+        key["cuda"] = str(torch.version.cuda or "")
+        if torch.cuda.is_available():
+            key["sku"] = sku_slug(torch.cuda.get_device_name(0))
+    except Exception:
+        pass
+    try:
+        import triton
+
+        key["triton"] = str(triton.__version__)
+    except Exception:
+        pass
+    return key
+
+
+def _lib_versions() -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for lib in ("diffusers", "transformers"):
+        try:
+            out[lib] = str(__import__(lib).__version__)
+        except Exception:
+            pass
+    return out
+
+
+def flavor_label(sku: str, torch_version: str) -> str:
+    """Repo-flavor label for an artifact: ``inductor-rtx-4090-torch2.9``.
+    The full versions live in metadata; the label is for humans + selection."""
+    short = ".".join(str(torch_version).split("+")[0].split(".")[:2])
+    return f"inductor-{sku}-torch{short}"
+
+
+def artifact_metadata(
+    *,
+    model_ref: str,
+    model_digest: str = "",
+    shapes: Iterable[Tuple[int, int]] = (),
+    targets: Iterable[str] = (),
+) -> Dict[str, Any]:
+    """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
+    identical content must be byte-identical)."""
+    return {
+        "format": ARTIFACT_FORMAT,
+        "kind": "torch-inductor-cache",
+        **runtime_key(),
+        "model_ref": str(model_ref or ""),
+        "model_digest": str(model_digest or ""),
+        "shapes": [[int(w), int(h)] for w, h in shapes],
+        "targets": list(targets),
+        "libs": _lib_versions(),
+    }
+
+
+def verify(meta: Dict[str, Any], *, model_ref: str = "") -> str:
+    """'' when the artifact matches this runtime, else the mismatch reason."""
+    if int(meta.get("format") or 0) != ARTIFACT_FORMAT:
+        return f"format {meta.get('format')!r} != {ARTIFACT_FORMAT}"
+    here = runtime_key()
+    for field in ("sku", "torch", "triton"):
+        want, have = str(meta.get(field) or ""), here[field]
+        if want != have:
+            return f"{field} {want!r} != runtime {have!r}"
+    for lib, have in _lib_versions().items():
+        want = str((meta.get("libs") or {}).get(lib) or "")
+        if want and want != have:
+            return f"{lib} {want!r} != runtime {have!r}"
+    want_ref = str(meta.get("model_ref") or "")
+    if model_ref and want_ref and want_ref != model_ref:
+        return f"model_ref {want_ref!r} != {model_ref!r}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Pack / unpack
+# ---------------------------------------------------------------------------
+
+
+def _clean_tarinfo(ti: tarfile.TarInfo, executable: bool = False) -> tarfile.TarInfo:
+    ti.uid = ti.gid = 0
+    ti.uname = ti.gname = ""
+    ti.mtime = 0
+    ti.mode = 0o755 if executable else 0o644
+    return ti
+
+
+def pack(cache_root: Path, out_path: Path, metadata: Dict[str, Any]) -> Path:
+    """Deterministic artifact from a capture root holding ``inductor/`` and
+    ``triton/``: sorted entries, zeroed times/owners, gzip mtime 0 — identical
+    content always packs to identical bytes."""
+    cache_root = Path(cache_root)
+    out_path = Path(out_path)
+    files: list[Path] = []
+    for sub in ("inductor", "triton"):
+        base = cache_root / sub
+        if base.is_dir():
+            files.extend(
+                p for p in base.rglob("*")
+                if p.is_file() and not p.name.endswith(_JUNK_SUFFIXES)
+            )
+    files.sort(key=lambda p: str(p.relative_to(cache_root)))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as raw:
+        with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
+            with tarfile.open(fileobj=gz, mode="w") as tar:
+                meta_bytes = json.dumps(metadata, sort_keys=True, indent=1).encode()
+                ti = _clean_tarinfo(tarfile.TarInfo(METADATA_NAME))
+                ti.size = len(meta_bytes)
+                tar.addfile(ti, io.BytesIO(meta_bytes))
+                for p in files:
+                    rel = str(p.relative_to(cache_root))
+                    ti = _clean_tarinfo(
+                        tarfile.TarInfo(rel), executable=os.access(p, os.X_OK)
+                    )
+                    ti.size = p.stat().st_size
+                    with open(p, "rb") as f:
+                        tar.addfile(ti, f)
+    return out_path
+
+
+def unpack(artifact: Path, dest_root: Path) -> Dict[str, Any]:
+    """Extract an artifact's ``inductor/``+``triton/`` trees into ``dest_root``
+    (merging with whatever is already seeded) and return its metadata."""
+    dest_root = Path(dest_root)
+    dest_root.mkdir(parents=True, exist_ok=True)
+    meta: Dict[str, Any] = {}
+    with tarfile.open(artifact, mode="r:*") as tar:
+        for member in tar:
+            name = member.name.lstrip("./")
+            if name == METADATA_NAME:
+                f = tar.extractfile(member)
+                meta = json.loads(f.read().decode()) if f else {}
+                continue
+            if not member.isfile():
+                continue
+            parts = Path(name).parts
+            if (
+                not parts
+                or parts[0] not in ("inductor", "triton")
+                or ".." in parts
+                or Path(name).is_absolute()
+            ):
+                raise ValueError(f"unsafe or unknown member in compile-cache artifact: {member.name!r}")
+            target = dest_root.joinpath(*parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            src = tar.extractfile(member)
+            assert src is not None
+            with open(target, "wb") as out:
+                shutil.copyfileobj(src, out)
+            if member.mode & 0o100:
+                target.chmod(0o755)
+    if not meta:
+        raise ValueError(f"compile-cache artifact {artifact} has no {METADATA_NAME}")
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Capture (producer) / seed (consumer)
+# ---------------------------------------------------------------------------
+
+
+def capture_env(root: Path) -> Path:
+    """Point inductor+triton at fresh dirs under ``root`` for a compile job.
+    Must run before this process first touches torch.compile / triton."""
+    root = Path(root)
+    for sub, env in (("inductor", "TORCHINDUCTOR_CACHE_DIR"), ("triton", "TRITON_CACHE_DIR")):
+        d = root / sub
+        d.mkdir(parents=True, exist_ok=True)
+        os.environ[env] = str(d)
+    return root
+
+
+# seeding reuses the same env contract
+seed_env = capture_env
+
+
+def toolchain_present() -> bool:
+    return any(shutil.which(c) for c in ("cc", "gcc", "g++", "clang"))
+
+
+def _fetch_url(url: str, dest_dir: Path) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    name = hashlib.sha256(url.encode()).hexdigest()[:16] + ".tar.gz"
+    target = dest_dir / name
+    if target.exists():
+        return target
+    t = time.monotonic()
+    tmp = target.with_suffix(".part")
+    with urllib.request.urlopen(url, timeout=120) as resp, open(tmp, "wb") as out:
+        shutil.copyfileobj(resp, out)
+    tmp.rename(target)
+    logger.info(
+        "compile-cache: downloaded artifact (%d bytes in %.1fs)",
+        target.stat().st_size, time.monotonic() - t,
+    )
+    return target
+
+
+def prepare(model_ref: str, cache_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Locate, verify, and seed a compile-cache artifact for this runtime.
+
+    Sources, in order: ``GEN_WORKER_COMPILE_CACHE`` (local tar), then
+    ``GEN_WORKER_COMPILE_CACHE_URL``. Returns the artifact metadata on a
+    verified hit (cache dirs seeded), else None with the reason logged.
+    Hub-flavor auto-resolution per SKU needs a hub-side resolve path and is
+    tracked separately.
+    """
+    artifact: Optional[Path] = None
+    local = (os.getenv(ENV_CACHE_PATH) or "").strip()
+    url = (os.getenv(ENV_CACHE_URL) or "").strip()
+    root = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "gen-worker"
+    root = root / "compile-cache"
+    try:
+        if local:
+            artifact = Path(local)
+            if not artifact.exists():
+                logger.warning("compile-cache: %s=%s does not exist", ENV_CACHE_PATH, local)
+                return None
+        elif url:
+            artifact = _fetch_url(url, root / "artifacts")
+        else:
+            logger.info("compile-cache: no artifact configured; staying eager")
+            return None
+        meta = unpack(artifact, root)
+        reason = verify(meta, model_ref=model_ref)
+        if reason:
+            logger.warning("compile-cache: artifact key mismatch (%s); staying eager", reason)
+            return None
+        seed_env(root)
+        logger.info(
+            "compile-cache: seeded verified artifact (sku=%s torch=%s shapes=%s)",
+            meta.get("sku"), meta.get("torch"), meta.get("shapes"),
+        )
+        return meta
+    except Exception as exc:
+        logger.warning("compile-cache: artifact unusable (%s); staying eager", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target(pipeline: Any, target: str) -> Optional[Tuple[Any, str, Callable[..., Any]]]:
+    """``"transformer"`` -> (module, 'forward', fn); ``"vae.decode"`` ->
+    (vae, 'decode', fn). None when the pipeline has no such attribute."""
+    obj = pipeline
+    parts = target.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    leaf = getattr(obj, parts[-1], None)
+    if leaf is None:
+        return None
+    if callable(getattr(leaf, "forward", None)) and parts[-1] != "forward":
+        # a Module: compile its bound forward
+        return leaf, "forward", leaf.forward
+    if callable(leaf):
+        return obj, parts[-1], leaf
+    return None
+
+
+def _guarded(original: Callable[..., Any], compiled: Callable[..., Any], label: str) -> Callable[..., Any]:
+    """Never fail a request on compile problems: first error permanently
+    unwraps to eager (prod images can't compile uncached shapes)."""
+    state = {"failed": False}
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if state["failed"]:
+            return original(*args, **kwargs)
+        try:
+            return compiled(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 — any compile failure => eager
+            state["failed"] = True
+            logger.warning(
+                "compile-cache: compiled %s failed (%s: %s); eager for the rest "
+                "of this process", label, type(exc).__name__, exc,
+            )
+            return original(*args, **kwargs)
+
+    return wrapper
+
+
+def apply(pipeline: Any, cfg: Any, *, cache_ready: bool) -> bool:
+    """Wrap ``cfg.targets`` on ``pipeline`` with guarded compiled callables.
+
+    Only compiles when a verified cache artifact was seeded (``cache_ready``)
+    or the process explicitly opted into cold compilation AND has a C
+    toolchain. Anything else is a logged no-op — eager, never a stall.
+    """
+    if getattr(pipeline, _MARKER_ATTR, None) is not None:
+        return True
+    try:
+        import torch
+    except Exception:
+        return False
+    if not torch.cuda.is_available():
+        logger.info("compile-cache: no CUDA; staying eager")
+        return False
+    if not cache_ready:
+        allow_cold = (os.getenv(ENV_ALLOW_COLD) or "").strip().lower() in ("1", "true", "yes")
+        if not allow_cold:
+            logger.info("compile-cache: no verified cache artifact; staying eager")
+            return False
+        if not toolchain_present():
+            logger.warning(
+                "compile-cache: %s set but no C compiler on PATH; staying eager",
+                ENV_ALLOW_COLD,
+            )
+            return False
+
+    applied: list[str] = []
+    for target in cfg.targets:
+        resolved = _resolve_target(pipeline, target)
+        if resolved is None:
+            logger.debug("compile-cache: pipeline has no target %r; skipping", target)
+            continue
+        owner, attr, fn = resolved
+        if target.startswith("vae"):
+            # channels_last + compiled decode is the measured win combo (#382);
+            # memory format changes strides, so it is part of the cache key —
+            # producer and consumer both come through here.
+            vae = getattr(pipeline, "vae", None)
+            if vae is not None:
+                vae.to(memory_format=torch.channels_last)
+        compiled = torch.compile(fn, dynamic=False)
+        setattr(owner, attr, _guarded(fn, compiled, target))
+        applied.append(target)
+    if not applied:
+        return False
+    setattr(pipeline, _MARKER_ATTR, {
+        "targets": applied,
+        "shapes": [tuple(s) for s in cfg.shapes],
+        "cache": bool(cache_ready),
+    })
+    logger.info("compile-cache: torch.compile armed for %s (cache=%s)", applied, cache_ready)
+    return True
+
+
+def enable(pipeline: Any, cfg: Any, model_ref: str = "", cache_dir: Optional[Path] = None) -> bool:
+    """The one consumer entry point (executor + local CLI): seed a verified
+    artifact if one is configured, then arm compile under the safety policy."""
+    meta = prepare(model_ref, cache_dir=cache_dir)
+    return apply(pipeline, cfg, cache_ready=meta is not None)
+
+
+__all__ = [
+    "ARTIFACT_FORMAT",
+    "ENV_ALLOW_COLD",
+    "ENV_CACHE_PATH",
+    "ENV_CACHE_URL",
+    "apply",
+    "artifact_metadata",
+    "capture_env",
+    "enable",
+    "flavor_label",
+    "pack",
+    "prepare",
+    "runtime_key",
+    "seed_env",
+    "sku_slug",
+    "toolchain_present",
+    "unpack",
+    "verify",
+]

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -12,17 +12,24 @@ Policy: cache miss / key mismatch / no artifact => eager, never a boot stall
 or a runtime compile attempt in prod. The compile job itself opts into cold
 compilation with ``GEN_WORKER_COMPILE_ALLOW_COLD=1`` (requires a toolchain).
 
+Artifacts are FAMILY-keyed (settled 2026-07-06): torch.compile caches key on
+the traced graph + shapes, not the weights, so one artifact serves every
+fine-tune of a model family. They live in a system-owned repo per family
+(``_system/family-<family>``), one flavor per (SKU, torch) cell — and they
+are CODE: only the platform's first-party compile job publishes shared ones.
+
 Artifact = deterministic ``.tar.gz``::
 
-    metadata.json      key: sku/torch/triton/cuda, model ref+digest, shapes,
-                       targets, diffusers/transformers versions
+    metadata.json      key: family, sku/torch/triton/cuda, shapes, targets,
+                       diffusers/transformers versions (+ source_ref info)
     inductor/**        TORCHINDUCTOR_CACHE_DIR contents
     triton/**          TRITON_CACHE_DIR contents
 
-Key sensitivity (all exact-match): GPU SKU (autotune choices + cubin arch),
-torch (fx-graph cache key), triton (cubin/launcher cache key), diffusers
-(the traced graph is its code). Model digest is recorded by the producer and
-checked when the consumer knows its own; the model REF always must match.
+Key sensitivity (all exact-match): family (graph identity), GPU SKU
+(autotune choices + cubin arch), torch (fx-graph cache key), triton
+(cubin/launcher cache key), diffusers (the traced graph is its code).
+``source_ref`` records which family member the producer compiled from —
+informational, never part of the match.
 """
 
 from __future__ import annotations
@@ -108,29 +115,43 @@ def flavor_label(sku: str, torch_version: str) -> str:
     return f"inductor-{sku}-torch{short}"
 
 
+def system_repo(family: str) -> str:
+    """The system-owned repo holding one family's compiled-artifact cells."""
+    fam = str(family or "").strip()
+    if not fam:
+        raise ValueError("compile-cache family must be non-empty")
+    return f"_system/family-{fam}"
+
+
 def artifact_metadata(
     *,
-    model_ref: str,
-    model_digest: str = "",
+    family: str,
+    source_ref: str = "",
+    source_digest: str = "",
     shapes: Iterable[Tuple[int, int]] = (),
     targets: Iterable[str] = (),
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
-    identical content must be byte-identical)."""
+    identical content must be byte-identical). ``source_ref``/``source_digest``
+    record the family member compiled from — informational only."""
     return {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
         **runtime_key(),
-        "model_ref": str(model_ref or ""),
-        "model_digest": str(model_digest or ""),
+        "family": str(family or ""),
+        "source_ref": str(source_ref or ""),
+        "source_digest": str(source_digest or ""),
         "shapes": [[int(w), int(h)] for w, h in shapes],
         "targets": list(targets),
         "libs": _lib_versions(),
     }
 
 
-def verify(meta: Dict[str, Any], *, model_ref: str = "") -> str:
-    """'' when the artifact matches this runtime, else the mismatch reason."""
+def verify(meta: Dict[str, Any], *, family: str = "") -> str:
+    """'' when the artifact matches this runtime, else the mismatch reason.
+
+    Family is the graph-identity half of the key: checked when both sides
+    declare one (fine-tunes of the same family share caches by design)."""
     if int(meta.get("format") or 0) != ARTIFACT_FORMAT:
         return f"format {meta.get('format')!r} != {ARTIFACT_FORMAT}"
     here = runtime_key()
@@ -142,9 +163,9 @@ def verify(meta: Dict[str, Any], *, model_ref: str = "") -> str:
         want = str((meta.get("libs") or {}).get(lib) or "")
         if want and want != have:
             return f"{lib} {want!r} != runtime {have!r}"
-    want_ref = str(meta.get("model_ref") or "")
-    if model_ref and want_ref and want_ref != model_ref:
-        return f"model_ref {want_ref!r} != {model_ref!r}"
+    want_fam = str(meta.get("family") or "")
+    if family and want_fam and want_fam != family:
+        return f"family {want_fam!r} != {family!r}"
     return ""
 
 
@@ -274,7 +295,7 @@ def _fetch_url(url: str, dest_dir: Path) -> Path:
     return target
 
 
-def prepare(model_ref: str, cache_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+def prepare(family: str, cache_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
     """Locate, verify, and seed a compile-cache artifact for this runtime.
 
     Sources, in order: ``GEN_WORKER_COMPILE_CACHE`` (local tar), then
@@ -300,7 +321,7 @@ def prepare(model_ref: str, cache_dir: Optional[Path] = None) -> Optional[Dict[s
             logger.info("compile-cache: no artifact configured; staying eager")
             return None
         meta = unpack(artifact, root)
-        reason = verify(meta, model_ref=model_ref)
+        reason = verify(meta, family=family)
         if reason:
             logger.warning("compile-cache: artifact key mismatch (%s); staying eager", reason)
             return None
@@ -422,10 +443,10 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
     return True
 
 
-def enable(pipeline: Any, cfg: Any, model_ref: str = "", cache_dir: Optional[Path] = None) -> bool:
+def enable(pipeline: Any, cfg: Any, cache_dir: Optional[Path] = None) -> bool:
     """The one consumer entry point (executor + local CLI): seed a verified
     artifact if one is configured, then arm compile under the safety policy."""
-    meta = prepare(model_ref, cache_dir=cache_dir)
+    meta = prepare(getattr(cfg, "family", "") or "", cache_dir=cache_dir)
     return apply(pipeline, cfg, cache_ready=meta is not None)
 
 
@@ -440,8 +461,9 @@ def build(
     *,
     shapes: Iterable[Tuple[int, int]],
     targets: Iterable[str] = ("transformer", "vae.decode"),
-    model_ref: str = "",
-    model_digest: str = "",
+    family: str = "",
+    source_ref: str = "",
+    source_digest: str = "",
     dtype: str = "bf16",
     steps: int = 2,
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
@@ -504,7 +526,7 @@ def build(
         )
 
     meta = artifact_metadata(
-        model_ref=model_ref, model_digest=model_digest,
+        family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
     )
     label = flavor_label(meta["sku"], meta["torch"])
@@ -528,6 +550,7 @@ __all__ = [
     "runtime_key",
     "seed_env",
     "sku_slug",
+    "system_repo",
     "toolchain_present",
     "unpack",
     "verify",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -803,6 +803,16 @@ class Executor:
                 # Worker-owned placement/offload policy: one decider for the
                 # whole worker; endpoints never write device/offload code.
                 await asyncio.to_thread(place_pipeline, pipe)
+                if spec.compile is not None:
+                    # Opt-in torch.compile against a pre-built per-SKU cache
+                    # artifact (#384); no verified artifact => stays eager.
+                    from . import compile_cache
+
+                    await asyncio.to_thread(
+                        compile_cache.enable, pipe, spec.compile,
+                        wire_ref(binding) if binding is not None else "",
+                        self.store._cache_dir,
+                    )
                 loaded[slot] = (pipe, max(0, self._vram_allocated() - before))
                 kwargs[slot] = pipe
             else:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -810,7 +810,6 @@ class Executor:
 
                     await asyncio.to_thread(
                         compile_cache.enable, pipe, spec.compile,
-                        wire_ref(binding) if binding is not None else "",
                         self.store._cache_dir,
                     )
                 loaded[slot] = (pipe, max(0, self._vram_allocated() - before))

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional
 import msgspec
 
 from .api.binding import Binding
-from .api.decorators import ATTR, EndpointDecl, Resources
+from .api.decorators import ATTR, Compile, EndpointDecl, Resources
 from .discovery.names import slugify_name
 from .discovery.walk import find_endpoints
 
@@ -58,6 +58,7 @@ class EndpointSpec:
     models: Dict[str, Binding] = field(default_factory=dict)  # slot -> binding
     timeout_ms: Optional[int] = None
     runtime: Optional[str] = None
+    compile: Optional[Compile] = None  # opt-in torch.compile spec (#384)
     module: str = ""              # declaring module
     walked_module: str = ""       # top-level package the object was found under
 
@@ -155,6 +156,7 @@ def _spec_for_handler(
         resources=resources,
         models=dict(models),
         runtime=decl.runtime,
+        compile=decl.compile,
         module=getattr(cls or method, "__module__", "") or "",
         walked_module=walked_module,
     )

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1,0 +1,203 @@
+"""#384: per-SKU torch.compile cache artifacts — key, packaging, safety policy."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import msgspec
+import pytest
+
+from gen_worker import Compile, Resources, endpoint
+from gen_worker import compile_cache as cc
+from gen_worker.registry import collect_from_namespace
+
+
+# ---------------------------------------------------------------------------
+# key
+# ---------------------------------------------------------------------------
+
+
+def test_sku_slug():
+    assert cc.sku_slug("NVIDIA GeForce RTX 4090") == "rtx-4090"
+    assert cc.sku_slug("NVIDIA H100 80GB HBM3") == "h100-80gb-hbm3"
+    assert cc.sku_slug("NVIDIA RTX 5090") == "rtx-5090"
+    assert cc.sku_slug("") == ""
+
+
+def test_flavor_label():
+    assert cc.flavor_label("rtx-4090", "2.9.1+cu128") == "inductor-rtx-4090-torch2.9"
+    assert cc.flavor_label("h100-80gb-hbm3", "2.11.0") == "inductor-h100-80gb-hbm3-torch2.11"
+
+
+def test_verify_mismatches():
+    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
+    assert cc.verify(meta, model_ref="owner/model") == ""
+    assert cc.verify(meta, model_ref="") == ""  # consumer without a ref: key-only check
+
+    other = dict(meta, torch="0.0.0")
+    assert "torch" in cc.verify(other, model_ref="owner/model")
+
+    other = dict(meta, sku="not-this-gpu")
+    assert "sku" in cc.verify(other, model_ref="owner/model")
+
+    assert "model_ref" in cc.verify(meta, model_ref="different/model")
+
+    other = dict(meta, format=99)
+    assert "format" in cc.verify(other, model_ref="owner/model")
+
+
+# ---------------------------------------------------------------------------
+# pack / unpack
+# ---------------------------------------------------------------------------
+
+
+def _capture_tree(root):
+    (root / "inductor" / "ab").mkdir(parents=True)
+    (root / "inductor" / "ab" / "graph.py").write_text("code")
+    (root / "inductor" / "stale.lock").write_text("")  # junk: excluded
+    (root / "triton" / "kern").mkdir(parents=True)
+    (root / "triton" / "kern" / "kernel.cubin").write_bytes(b"\x00\x01")
+    return root
+
+
+def test_pack_is_deterministic_and_roundtrips(tmp_path):
+    src = _capture_tree(tmp_path / "cap")
+    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
+
+    a = cc.pack(src, tmp_path / "a.tar.gz", meta)
+    b = cc.pack(src, tmp_path / "b.tar.gz", meta)
+    assert a.read_bytes() == b.read_bytes()
+
+    dest = tmp_path / "seed"
+    got = cc.unpack(a, dest)
+    assert got["model_ref"] == "owner/model"
+    assert (dest / "inductor" / "ab" / "graph.py").read_text() == "code"
+    assert (dest / "triton" / "kern" / "kernel.cubin").read_bytes() == b"\x00\x01"
+    assert not (dest / "inductor" / "stale.lock").exists()
+
+    # merge: a second artifact lands next to the first
+    (src / "inductor" / "cd").mkdir()
+    (src / "inductor" / "cd" / "more.py").write_text("x")
+    c = cc.pack(src, tmp_path / "c.tar.gz", meta)
+    cc.unpack(c, dest)
+    assert (dest / "inductor" / "ab" / "graph.py").exists()
+    assert (dest / "inductor" / "cd" / "more.py").exists()
+
+
+def test_unpack_rejects_traversal(tmp_path):
+    evil = tmp_path / "evil.tar.gz"
+    import gzip
+
+    with open(evil, "wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as gz:
+        with tarfile.open(fileobj=gz, mode="w") as tar:
+            data = b"{}"
+            ti = tarfile.TarInfo(cc.METADATA_NAME)
+            ti.size = len(data)
+            tar.addfile(ti, io.BytesIO(data))
+            ti = tarfile.TarInfo("inductor/../../escape.py")
+            ti.size = 1
+            tar.addfile(ti, io.BytesIO(b"x"))
+    with pytest.raises(ValueError, match="unsafe"):
+        cc.unpack(evil, tmp_path / "seed")
+
+
+def test_unpack_requires_metadata(tmp_path):
+    bad = tmp_path / "bad.tar.gz"
+    with tarfile.open(bad, mode="w:gz") as tar:
+        ti = tarfile.TarInfo("inductor/x")
+        ti.size = 1
+        tar.addfile(ti, io.BytesIO(b"x"))
+    with pytest.raises(ValueError, match="metadata"):
+        cc.unpack(bad, tmp_path / "seed")
+
+
+def test_capture_env_sets_cache_dirs(tmp_path, monkeypatch):
+    monkeypatch.delenv("TORCHINDUCTOR_CACHE_DIR", raising=False)
+    monkeypatch.delenv("TRITON_CACHE_DIR", raising=False)
+    import os
+
+    cc.capture_env(tmp_path / "cap")
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(tmp_path / "cap" / "inductor")
+    assert os.environ["TRITON_CACHE_DIR"] == str(tmp_path / "cap" / "triton")
+
+
+# ---------------------------------------------------------------------------
+# safety policy
+# ---------------------------------------------------------------------------
+
+
+class _FakePipe:
+    pass
+
+
+def test_apply_stays_eager_without_cache(monkeypatch):
+    """No verified artifact and no explicit cold opt-in => untouched pipeline."""
+    monkeypatch.delenv(cc.ENV_ALLOW_COLD, raising=False)
+    pipe = _FakePipe()
+    cfg = Compile(shapes=((768, 768),))
+    assert cc.apply(pipe, cfg, cache_ready=False) is False
+    assert getattr(pipe, "_cozy_compile", None) is None
+
+
+def test_prepare_without_sources_is_none(monkeypatch, tmp_path):
+    monkeypatch.delenv(cc.ENV_CACHE_PATH, raising=False)
+    monkeypatch.delenv(cc.ENV_CACHE_URL, raising=False)
+    assert cc.prepare("owner/model", cache_dir=tmp_path) is None
+
+
+def test_prepare_rejects_key_mismatch(monkeypatch, tmp_path):
+    src = _capture_tree(tmp_path / "cap")
+    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
+    meta["torch"] = "0.0.0"  # never matches this runtime
+    art = cc.pack(src, tmp_path / "art.tar.gz", meta)
+    monkeypatch.setenv(cc.ENV_CACHE_PATH, str(art))
+    assert cc.prepare("owner/model", cache_dir=tmp_path / "cache") is None
+
+
+# ---------------------------------------------------------------------------
+# declaration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_compile_struct_validation():
+    c = Compile(shapes=[[768, 768], (1024, 1024)])
+    assert c.shapes == ((768, 768), (1024, 1024))
+    assert c.targets == ("transformer", "vae.decode")
+    with pytest.raises(ValueError):
+        Compile(shapes=())
+    with pytest.raises(ValueError):
+        Compile(shapes=((0, 768),))
+    with pytest.raises(ValueError):
+        Compile(shapes=((768, 768),), targets=())
+
+
+class In(msgspec.Struct):
+    prompt: str = ""
+
+
+class Out(msgspec.Struct):
+    ok: bool = True
+
+
+def test_endpoint_compile_reaches_spec():
+    import types
+
+    @endpoint(resources=Resources(vram_gb=4), compile=Compile(shapes=((768, 768),)))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def gen(self, ctx, p: In) -> Out:
+            return Out()
+
+    mod = types.SimpleNamespace(Ep=Ep)
+    specs = collect_from_namespace(mod)
+    assert len(specs) == 1
+    assert specs[0].compile is not None
+    assert specs[0].compile.shapes == ((768, 768),)
+
+    with pytest.raises(TypeError, match="compile="):
+        @endpoint(compile="yes")  # type: ignore[arg-type]
+        def bad(ctx, p: In) -> Out:
+            return Out()

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -31,20 +31,26 @@ def test_flavor_label():
 
 
 def test_verify_mismatches():
-    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
-    assert cc.verify(meta, model_ref="owner/model") == ""
-    assert cc.verify(meta, model_ref="") == ""  # consumer without a ref: key-only check
+    meta = cc.artifact_metadata(family="sd15", shapes=[(768, 768)], targets=["transformer"])
+    assert cc.verify(meta, family="sd15") == ""
+    assert cc.verify(meta, family="") == ""  # consumer without a family: key-only check
 
     other = dict(meta, torch="0.0.0")
-    assert "torch" in cc.verify(other, model_ref="owner/model")
+    assert "torch" in cc.verify(other, family="sd15")
 
     other = dict(meta, sku="not-this-gpu")
-    assert "sku" in cc.verify(other, model_ref="owner/model")
+    assert "sku" in cc.verify(other, family="sd15")
 
-    assert "model_ref" in cc.verify(meta, model_ref="different/model")
+    assert "family" in cc.verify(meta, family="sdxl")
 
     other = dict(meta, format=99)
-    assert "format" in cc.verify(other, model_ref="owner/model")
+    assert "format" in cc.verify(other, family="sd15")
+
+
+def test_system_repo():
+    assert cc.system_repo("sd15") == "_system/family-sd15"
+    with pytest.raises(ValueError):
+        cc.system_repo("")
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +69,7 @@ def _capture_tree(root):
 
 def test_pack_is_deterministic_and_roundtrips(tmp_path):
     src = _capture_tree(tmp_path / "cap")
-    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
+    meta = cc.artifact_metadata(family="sd15", source_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
 
     a = cc.pack(src, tmp_path / "a.tar.gz", meta)
     b = cc.pack(src, tmp_path / "b.tar.gz", meta)
@@ -71,7 +77,8 @@ def test_pack_is_deterministic_and_roundtrips(tmp_path):
 
     dest = tmp_path / "seed"
     got = cc.unpack(a, dest)
-    assert got["model_ref"] == "owner/model"
+    assert got["family"] == "sd15"
+    assert got["source_ref"] == "owner/model"
     assert (dest / "inductor" / "ab" / "graph.py").read_text() == "code"
     assert (dest / "triton" / "kern" / "kernel.cubin").read_bytes() == b"\x00\x01"
     assert not (dest / "inductor" / "stale.lock").exists()
@@ -143,16 +150,16 @@ def test_apply_stays_eager_without_cache(monkeypatch):
 def test_prepare_without_sources_is_none(monkeypatch, tmp_path):
     monkeypatch.delenv(cc.ENV_CACHE_PATH, raising=False)
     monkeypatch.delenv(cc.ENV_CACHE_URL, raising=False)
-    assert cc.prepare("owner/model", cache_dir=tmp_path) is None
+    assert cc.prepare("sd15", cache_dir=tmp_path) is None
 
 
 def test_prepare_rejects_key_mismatch(monkeypatch, tmp_path):
     src = _capture_tree(tmp_path / "cap")
-    meta = cc.artifact_metadata(model_ref="owner/model", shapes=[(768, 768)], targets=["transformer"])
+    meta = cc.artifact_metadata(family="sd15", shapes=[(768, 768)], targets=["transformer"])
     meta["torch"] = "0.0.0"  # never matches this runtime
     art = cc.pack(src, tmp_path / "art.tar.gz", meta)
     monkeypatch.setenv(cc.ENV_CACHE_PATH, str(art))
-    assert cc.prepare("owner/model", cache_dir=tmp_path / "cache") is None
+    assert cc.prepare("sd15", cache_dir=tmp_path / "cache") is None
 
 
 # ---------------------------------------------------------------------------
@@ -161,9 +168,10 @@ def test_prepare_rejects_key_mismatch(monkeypatch, tmp_path):
 
 
 def test_compile_struct_validation():
-    c = Compile(shapes=[[768, 768], (1024, 1024)])
+    c = Compile(shapes=[[768, 768], (1024, 1024)], family=" sd15 ")
     assert c.shapes == ((768, 768), (1024, 1024))
     assert c.targets == ("transformer", "vae.decode")
+    assert c.family == "sd15"
     with pytest.raises(ValueError):
         Compile(shapes=())
     with pytest.raises(ValueError):


### PR DESCRIPTION
Closes tracker #384 (torch.compile cache-as-artifact).

## What

torch.compile as a shipped per-SKU artifact: a platform compile job builds the inductor+triton caches once per (family, SKU, torch) cell; workers seed them and run compiled with **no C toolchain and no compile stall**. Compile stays opt-in per endpoint and is safe by construction — no verified artifact ⇒ eager.

- `gen_worker/compile_cache.py`: deterministic `.tar.gz` artifact (metadata.json + inductor/ + triton/; sorted entries, zeroed times, gzip mtime 0 — identical content ⇒ identical bytes), key = (family, SKU slug, torch, triton, diffusers/transformers), `verify → seed → apply` consumer chain, `build()` producer core, flavor naming `inductor-<sku>-torch<maj.min>`, `_system/family-<f>` repo convention (settled design).
- `@endpoint(compile=Compile(family=..., shapes=..., targets=...))`; spec/registry/decl plumbing; executor arms it after `place_pipeline`; local CLI (`gen-worker run`) has executor parity (+ fix: binding dtype honored in local injection — bf16 endpoints no longer silently load fp16; + warmup() called after setup).
- Guarded compile: a compiled call that would need a fresh compile (undeclared shape, no toolchain) permanently unwraps to eager — never a failed request. `GEN_WORKER_COMPILE_ALLOW_COLD=1` (toolchain required) is the compile-job/dev escape hatch; `build()` uses `guard=False` so a silently-eager warm-up can never publish an empty artifact.
- klein example opts in (768²/1024²) with a boot `warmup()`; artifact sources today: `GEN_WORKER_COMPILE_CACHE` / `GEN_WORKER_COMPILE_CACHE_URL` (hub-side per-(SKU, torch) snapshot attach = tensorhub #569).

## Live proof (RTX 4090, torch 2.9.1+cu128, triton 3.5.1, diffusers 0.39.0)

RESULTS_PLACEHOLDER

## Tests

`uv run --extra dev pytest -q` → 265 passed, 1 skipped (12 new in tests/test_compile_cache.py: key/slug/verify, deterministic pack, traversal-safe unpack, safety-policy gates, decorator plumbing).
