### PR TITLE
feat(executor): compile-cache hot adoption + boot-attach consumption (th#567/th#569)

### DIFF
--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -123,6 +123,27 @@ def system_repo(family: str) -> str:
     return f"_system/family-{fam}"
 
 
+def family_from_ref(ref: str) -> str:
+    """Family encoded in a compile-cache ref
+    (``_system/family-<f>[:tag][@digest][#inductor-...]``); '' when the ref
+    is not a compile-cache ref."""
+    repo = str(ref or "").split("#", 1)[0].split("@", 1)[0].split(":", 1)[0]
+    owner, _, name = repo.partition("/")
+    if owner == "_system" and name.startswith("family-"):
+        return name[len("family-"):]
+    return ""
+
+
+def is_cache_ref(ref: str, family: str = "") -> bool:
+    """True when ``ref`` names an inductor compile-cache cell (optionally of
+    one specific family)."""
+    fam = family_from_ref(ref)
+    if not fam or (family and fam != family):
+        return False
+    flavor = ref.split("#", 1)[1] if "#" in ref else ""
+    return flavor.startswith("inductor-")
+
+
 def artifact_metadata(
     *,
     family: str,
@@ -277,6 +298,41 @@ def toolchain_present() -> bool:
     return any(shutil.which(c) for c in ("cc", "gcc", "g++", "clang"))
 
 
+class AdoptError(RuntimeError):
+    """Classified adoption failure (ModelEvent ``adopt_failed:<reason>``)."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        super().__init__(detail or reason)
+
+
+def find_artifact(root: Path) -> Optional[Path]:
+    """The compile-cache tarball inside a downloaded snapshot dir (or the
+    file itself)."""
+    root = Path(root)
+    if root.is_file():
+        return root
+    return next(iter(sorted(root.rglob("*.tar.gz"))), None)
+
+
+def seed_artifact(
+    artifact: Path, family: str, cache_dir: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Unpack + verify + seed one artifact for this runtime. Returns its
+    metadata; raises :class:`AdoptError` (never seeds) on any mismatch."""
+    root = (Path(cache_dir) if cache_dir else Path.home() / ".cache" / "gen-worker")
+    root = root / "compile-cache"
+    try:
+        meta = unpack(Path(artifact), root)
+    except Exception as exc:
+        raise AdoptError("artifact_invalid", str(exc)) from exc
+    reason = verify(meta, family=family)
+    if reason:
+        raise AdoptError("key_mismatch", reason)
+    seed_env(root)
+    return meta
+
+
 def _fetch_url(url: str, dest_dir: Path) -> Path:
     dest_dir.mkdir(parents=True, exist_ok=True)
     name = hashlib.sha256(url.encode()).hexdigest()[:16] + ".tar.gz"
@@ -295,22 +351,29 @@ def _fetch_url(url: str, dest_dir: Path) -> Path:
     return target
 
 
-def prepare(family: str, cache_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+def prepare(
+    family: str,
+    cache_dir: Optional[Path] = None,
+    artifact: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
     """Locate, verify, and seed a compile-cache artifact for this runtime.
 
-    Sources, in order: ``GEN_WORKER_COMPILE_CACHE`` (local tar), then
+    Sources, in order: explicit ``artifact`` (a hub-attached snapshot, #569),
+    then ``GEN_WORKER_COMPILE_CACHE`` (local tar), then
     ``GEN_WORKER_COMPILE_CACHE_URL``. Returns the artifact metadata on a
     verified hit (cache dirs seeded), else None with the reason logged.
-    Hub-flavor auto-resolution per SKU needs a hub-side resolve path and is
-    tracked separately.
     """
-    artifact: Optional[Path] = None
     local = (os.getenv(ENV_CACHE_PATH) or "").strip()
     url = (os.getenv(ENV_CACHE_URL) or "").strip()
     root = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "gen-worker"
     root = root / "compile-cache"
     try:
-        if local:
+        if artifact is not None:
+            artifact = Path(artifact)
+            if not artifact.exists():
+                logger.warning("compile-cache: attached artifact %s does not exist", artifact)
+                return None
+        elif local:
             artifact = Path(local)
             if not artifact.exists():
                 logger.warning("compile-cache: %s=%s does not exist", ENV_CACHE_PATH, local)
@@ -320,12 +383,7 @@ def prepare(family: str, cache_dir: Optional[Path] = None) -> Optional[Dict[str,
         else:
             logger.info("compile-cache: no artifact configured; staying eager")
             return None
-        meta = unpack(artifact, root)
-        reason = verify(meta, family=family)
-        if reason:
-            logger.warning("compile-cache: artifact key mismatch (%s); staying eager", reason)
-            return None
-        seed_env(root)
+        meta = seed_artifact(artifact, family, cache_dir=cache_dir)
         logger.info(
             "compile-cache: seeded verified artifact (sku=%s torch=%s shapes=%s)",
             meta.get("sku"), meta.get("torch"), meta.get("shapes"),
@@ -443,10 +501,18 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
     return True
 
 
-def enable(pipeline: Any, cfg: Any, cache_dir: Optional[Path] = None) -> bool:
+def enable(
+    pipeline: Any,
+    cfg: Any,
+    cache_dir: Optional[Path] = None,
+    artifact: Optional[Path] = None,
+) -> bool:
     """The one consumer entry point (executor + local CLI): seed a verified
-    artifact if one is configured, then arm compile under the safety policy."""
-    meta = prepare(getattr(cfg, "family", "") or "", cache_dir=cache_dir)
+    artifact if one is configured or attached, then arm compile under the
+    safety policy."""
+    meta = prepare(
+        getattr(cfg, "family", "") or "", cache_dir=cache_dir, artifact=artifact
+    )
     return apply(pipeline, cfg, cache_ready=meta is not None)
 
 
@@ -536,6 +602,7 @@ def build(
 
 __all__ = [
     "ARTIFACT_FORMAT",
+    "AdoptError",
     "build",
     "ENV_ALLOW_COLD",
     "ENV_CACHE_PATH",
@@ -544,10 +611,14 @@ __all__ = [
     "artifact_metadata",
     "capture_env",
     "enable",
+    "family_from_ref",
+    "find_artifact",
     "flavor_label",
+    "is_cache_ref",
     "pack",
     "prepare",
     "runtime_key",
+    "seed_artifact",
     "seed_env",
     "sku_slug",
     "system_repo",

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -482,6 +482,13 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             fn["delta_type"] = _type_id(es.delta_type)
             fn["delta_schema_sha256"] = delta_sha
             fn["delta_output_schema"] = delta_schema
+        if es.compile is not None:
+            # Hub keys family-cache lookups off this block (th#569).
+            fn["compile"] = {
+                "family": es.compile.family,
+                "shapes": [[int(w), int(h)] for w, h in es.compile.shapes],
+                "targets": list(es.compile.targets),
+            }
         out.append(fn)
 
     return out

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -631,6 +631,7 @@ class Executor:
                 snap = (snapshots or {}).get(ref)
                 path = await self.store.ensure_local(ref, snap, binding=binding)
                 paths[slot] = str(path)
+            compile_artifact = await self._fetch_compile_snapshot(spec, snapshots)
             # Loads serialize: concurrent setups would cross-contaminate each
             # other's allocator deltas and place_pipeline's free-VRAM reads.
             async with self._load_lock:
@@ -643,7 +644,8 @@ class Executor:
                     rec.server = await self._boot_engine_server(spec, paths)
                 if callable(setup):
                     kwargs, loaded = await self._injection_kwargs(
-                        spec, setup, paths, server=rec.server)
+                        spec, setup, paths, server=rec.server,
+                        compile_artifact=compile_artifact)
                     if asyncio.iscoroutinefunction(setup):
                         await setup(**kwargs)
                     else:
@@ -754,6 +756,30 @@ class Executor:
         proc = factory(model_path)
         return await asyncio.to_thread(proc.start)
 
+    async def _fetch_compile_snapshot(
+        self, spec: EndpointSpec, snapshots: Optional[Dict[str, pb.Snapshot]]
+    ) -> Optional[Path]:
+        """Hub-attached compile-cache snapshot for this endpoint's family
+        (#569 boot-attach, opt-in hub-side). Returns the local artifact path,
+        or None — missing/unusable snapshots mean eager, never an error."""
+        if spec.compile is None or not snapshots:
+            return None
+        from . import compile_cache
+
+        family = getattr(spec.compile, "family", "") or ""
+        for ref, snap in snapshots.items():
+            if not compile_cache.is_cache_ref(ref, family):
+                continue
+            try:
+                local = await self.store.ensure_local(ref, snap)
+                return compile_cache.find_artifact(local)
+            except Exception as exc:
+                logger.warning(
+                    "compile-cache snapshot %s unusable (%s); staying eager", ref, exc
+                )
+                return None
+        return None
+
     async def _injection_kwargs(
         self,
         spec: EndpointSpec,
@@ -761,6 +787,7 @@ class Executor:
         paths: Dict[str, str],
         *,
         server: Any = None,
+        compile_artifact: Optional[Path] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Tuple[Any, int]]]:
         """Typed injection: each slot receives exactly what its ``setup``
         annotation says — a ``str``/``Path`` local path, or a constructed
@@ -806,11 +833,12 @@ class Executor:
                 if spec.compile is not None:
                     # Opt-in torch.compile against a pre-built per-SKU cache
                     # artifact (#384); no verified artifact => stays eager.
+                    # ``compile_artifact`` is a hub-attached snapshot (#569).
                     from . import compile_cache
 
                     await asyncio.to_thread(
                         compile_cache.enable, pipe, spec.compile,
-                        self.store._cache_dir,
+                        self.store._cache_dir, compile_artifact,
                     )
                 loaded[slot] = (pipe, max(0, self._vram_allocated() - before))
                 kwargs[slot] = pipe
@@ -870,6 +898,8 @@ class Executor:
                         ref=ref, state=pb.MODEL_STATE_FAILED, error="model_in_use")))
                     return
                 await self._unload_ref(ref)
+            elif op.op == pb.MODEL_OP_KIND_ADOPT_COMPILE_CACHE:
+                await self._adopt_compile_cache(ref, snap)
         except Exception as exc:
             logger.warning("ModelOp %s on %s failed: %s", op.op, ref, exc)
             # ensure_local already emitted FAILED for download errors; emit for
@@ -880,6 +910,96 @@ class Executor:
                 await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
                     ref=ref, state=pb.MODEL_STATE_FAILED,
                     error=_model_op_error_vocab(exc))))
+
+    async def _adopt_compile_cache(self, ref: str, snap: Optional[pb.Snapshot]) -> None:
+        """Hot adoption (th#567): download+verify+seed a compile-cache
+        artifact and re-wrap the already-resident modules in place — weights
+        untouched, no reload, one warmup trace. ANY failure => stay eager and
+        report ``adopt_failed:<reason>``; adoption must never degrade service."""
+        from . import compile_cache
+
+        t0 = time.monotonic()
+
+        async def fail(reason: str, detail: str = "") -> None:
+            logger.warning("compile-cache adopt %s failed: %s %s", ref, reason, detail)
+            await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                ref=ref, state=pb.MODEL_STATE_FAILED,
+                error=f"adopt_failed:{reason}")))
+
+        family = compile_cache.family_from_ref(ref)
+        if not family or not compile_cache.is_cache_ref(ref):
+            return await fail("bad_ref")
+        candidates = [
+            s for s in self.specs.values()
+            if s.cls is not None and s.compile is not None
+            and (getattr(s.compile, "family", "") or "") == family
+            and s.name not in self.unavailable
+        ]
+        if not candidates:
+            return await fail("no_endpoint")
+        resident: Dict[int, Tuple[_ClassRecord, EndpointSpec]] = {}
+        for s in candidates:
+            rec = self._classes[s.instance_key]
+            if rec.ready:
+                resident.setdefault(id(rec), (rec, s))
+        if not resident:
+            return await fail("not_resident")
+        if self.in_flight_keys():
+            # The hub schedules adoption idle-only; defensive — never touch
+            # a module while any job is in flight.
+            return await fail("model_in_use")
+        try:
+            local = await self.store.ensure_local(ref, snap)
+        except Exception as exc:
+            return await fail("download", str(exc))
+        artifact = compile_cache.find_artifact(local)
+        if artifact is None:
+            return await fail("artifact_missing")
+        try:
+            await asyncio.to_thread(
+                compile_cache.seed_artifact, artifact, family, self.store._cache_dir
+            )
+        except compile_cache.AdoptError as exc:
+            return await fail(exc.reason, str(exc))
+        except Exception as exc:
+            return await fail("artifact_invalid", str(exc))
+
+        # Re-wrap + warmup under the GPU slot: a job landing mid-adoption
+        # queues on the semaphore instead of racing the trace.
+        async with self._gpu_semaphore:
+            adopted: List[Tuple[_ClassRecord, EndpointSpec]] = []
+            for rec, s in resident.values():
+                applied = False
+                for slot in self._setup_slots(s):
+                    obj = self.store.residency.obj(wire_ref(s.models[slot]))
+                    if obj is None:
+                        continue
+                    if await asyncio.to_thread(
+                        compile_cache.apply, obj, s.compile, cache_ready=True
+                    ):
+                        applied = True
+                if applied:
+                    adopted.append((rec, s))
+            if not adopted:
+                return await fail("no_target")
+            for rec, _s in adopted:
+                warmup = getattr(rec.instance, "warmup", None)
+                if not callable(warmup):
+                    continue  # first request pays the (cache-hit) trace
+                try:
+                    if asyncio.iscoroutinefunction(warmup):
+                        await warmup()
+                    else:
+                        await asyncio.to_thread(warmup)
+                except Exception as exc:
+                    # Compiled targets are guard-wrapped: a failing warmup has
+                    # already unwrapped them to eager — service unaffected.
+                    return await fail("warmup", f"{type(exc).__name__}: {exc}")
+
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        logger.info("compile-cache adopt %s: adopted in %dms", ref, duration_ms)
+        await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+            ref=ref, state=pb.MODEL_STATE_ADOPTED, duration_ms=duration_ms)))
 
     def _ref_in_use(self, ref: str) -> bool:
         for job in self.jobs.values():

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1,0 +1,290 @@
+"""th#567 hot adoption: MODEL_OP_KIND_ADOPT_COMPILE_CACHE re-wraps resident
+modules in place — verified seed, one warmup, ADOPTED report; ANY failure
+stays eager with a classified adopt_failed:<reason>. Plus th#569 boot-attach:
+a compile-cache snapshot on RunJob.snapshots reaches compile_cache.enable."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import msgspec
+import pytest
+
+from gen_worker import Compile, RequestContext, endpoint
+from gen_worker import compile_cache as cc
+from gen_worker.api.binding import Hub
+from gen_worker.api.binding import wire_ref
+from gen_worker.executor import Executor, _Job
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+FAMILY = "flux2-klein-4b"
+CACHE_REF = f"_system/family-{FAMILY}#inductor-rtx-4090-torch2.9"
+MODEL_REF = "acme/klein-finetune:latest"
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    y: str = ""
+
+
+class _Pipe:
+    pass
+
+
+class _Endpoint:
+    warmups = 0
+
+    def setup(self, pipeline: str) -> None:  # pragma: no cover
+        pass
+
+    def warmup(self) -> None:
+        type(self).warmups += 1
+
+    def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+        return _Out()
+
+
+def _spec(compile_cfg=None) -> EndpointSpec:
+    return EndpointSpec(
+        name="ep", method=_Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Endpoint,
+        attr_name="run", models={"pipeline": Hub("acme/klein-finetune")},
+        compile=compile_cfg or Compile(shapes=((768, 768),), family=FAMILY),
+    )
+
+
+def _artifact(tmp_path: Path, **meta_overrides) -> Path:
+    cap = tmp_path / "cap"
+    (cap / "inductor" / "g").mkdir(parents=True)
+    (cap / "inductor" / "g" / "code.py").write_text("x")
+    (cap / "triton").mkdir()
+    meta = cc.artifact_metadata(family=FAMILY, shapes=[(768, 768)], targets=["transformer"])
+    meta.update(meta_overrides)
+    snapdir = tmp_path / "snap"
+    snapdir.mkdir(exist_ok=True)
+    return cc.pack(cap, snapdir / "inductor-rtx-4090-torch2.9.tar.gz", meta)
+
+
+def _wire_executor(spec, tmp_path, *, ready=True, resident=True):
+    sent: list[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor([spec], _send)
+    ex.store._cache_dir = tmp_path / "cas"
+    rec = ex._classes[spec.instance_key]
+    if ready:
+        rec.instance = _Endpoint()
+        rec.ready = True
+    if resident:
+        ex.store.residency.track_vram(wire_ref(spec.models["pipeline"]), _Pipe(), vram_bytes=1)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        return tmp_path / "snap"
+
+    ex.store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return ex, sent
+
+
+def _events(sent, state):
+    return [m.model_event for m in sent
+            if m.WhichOneof("msg") == "model_event" and m.model_event.state == state]
+
+
+def _adopt(ex, ref=CACHE_REF):
+    asyncio.run(ex.handle_model_op(
+        pb.ModelOp(op=pb.MODEL_OP_KIND_ADOPT_COMPILE_CACHE, ref=ref)))
+
+
+# ---------------------------------------------------------------------------
+# ref helpers
+# ---------------------------------------------------------------------------
+
+
+def test_family_from_ref_and_is_cache_ref():
+    assert cc.family_from_ref(CACHE_REF) == FAMILY
+    assert cc.family_from_ref(f"_system/family-{FAMILY}:latest@blake3:aa#inductor-x") == FAMILY
+    assert cc.family_from_ref("acme/model:latest") == ""
+    assert cc.family_from_ref("_system/other-repo#inductor-x") == ""
+    assert cc.is_cache_ref(CACHE_REF)
+    assert cc.is_cache_ref(CACHE_REF, FAMILY)
+    assert not cc.is_cache_ref(CACHE_REF, "sdxl")
+    assert not cc.is_cache_ref(f"_system/family-{FAMILY}")  # no inductor flavor
+    assert not cc.is_cache_ref("acme/model#inductor-x")
+
+
+# ---------------------------------------------------------------------------
+# adoption success
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_success_rewraps_warms_and_reports(tmp_path, monkeypatch):
+    _artifact(tmp_path)
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    _Endpoint.warmups = 0
+
+    applied: list[tuple] = []
+
+    def _fake_apply(pipeline, cfg, *, cache_ready, guard=True):
+        applied.append((pipeline, cfg, cache_ready))
+        return True
+
+    monkeypatch.setattr(cc, "apply", _fake_apply)
+    _adopt(ex)
+
+    adopted = _events(sent, pb.MODEL_STATE_ADOPTED)
+    assert len(adopted) == 1
+    assert adopted[0].ref == CACHE_REF
+    assert adopted[0].duration_ms >= 0
+    assert not _events(sent, pb.MODEL_STATE_FAILED)
+    assert len(applied) == 1 and applied[0][2] is True
+    assert isinstance(applied[0][0], _Pipe)
+    assert _Endpoint.warmups == 1
+
+
+def test_adopt_failed_warmup_reports_reason(tmp_path, monkeypatch):
+    _artifact(tmp_path)
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: True)
+    monkeypatch.setattr(_Endpoint, "warmup", lambda self: 1 / 0)
+
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:warmup"
+    assert not _events(sent, pb.MODEL_STATE_ADOPTED)
+
+
+# ---------------------------------------------------------------------------
+# classified failures
+# ---------------------------------------------------------------------------
+
+
+def test_adopt_key_mismatch_stays_eager(tmp_path, monkeypatch):
+    _artifact(tmp_path, sku="not-this-gpu")
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: pytest.fail("must not re-wrap"))
+
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:key_mismatch"
+
+
+def test_adopt_refuses_while_jobs_in_flight(tmp_path):
+    _artifact(tmp_path)
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    ex.jobs[("r1", 1)] = _Job(request_id="r1", attempt=1, spec=spec)
+
+    calls: list[str] = []
+
+    async def _no_download(ref, snapshot=None, *, binding=None):  # pragma: no cover
+        calls.append(ref)
+        return tmp_path / "snap"
+
+    ex.store.ensure_local = _no_download  # type: ignore[method-assign]
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:model_in_use"
+    assert calls == []  # refused before any download
+
+
+def test_adopt_no_endpoint_for_family(tmp_path):
+    spec = _spec(Compile(shapes=((768, 768),), family="sdxl"))
+    ex, sent = _wire_executor(spec, tmp_path)
+    _adopt(ex)  # ref names flux2-klein-4b; only sdxl is declared
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:no_endpoint"
+
+
+def test_adopt_not_resident(tmp_path):
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path, ready=False, resident=False)
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:not_resident"
+
+
+def test_adopt_bad_ref(tmp_path):
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    _adopt(ex, ref="acme/not-a-cache:latest")
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:bad_ref"
+
+
+def test_adopt_artifact_missing(tmp_path):
+    (tmp_path / "snap").mkdir()  # empty snapshot dir: no tarball
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:artifact_missing"
+
+
+def test_old_worker_semantics_unknown_kind_is_silent(tmp_path):
+    """proto3 forward-compat guarantee the hub relies on: an op kind this
+    worker doesn't know produces no ModelEvent at all."""
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    asyncio.run(ex.handle_model_op(pb.ModelOp(op=99, ref=CACHE_REF)))
+    assert not [m for m in sent if m.WhichOneof("msg") == "model_event"]
+
+
+# ---------------------------------------------------------------------------
+# th#569 boot-attach: cache snapshot on RunJob.snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_compile_snapshot_finds_family_cache(tmp_path):
+    artifact = _artifact(tmp_path)
+    spec = _spec()
+    ex, _sent = _wire_executor(spec, tmp_path)
+    snapshots = {
+        MODEL_REF: pb.Snapshot(digest="blake3:aa"),
+        CACHE_REF: pb.Snapshot(digest="blake3:bb"),
+    }
+    got = asyncio.run(ex._fetch_compile_snapshot(spec, snapshots))
+    assert got == artifact
+
+
+def test_fetch_compile_snapshot_ignores_other_families(tmp_path):
+    _artifact(tmp_path)
+    spec = _spec()
+    ex, _sent = _wire_executor(spec, tmp_path)
+    snapshots = {"_system/family-sdxl#inductor-rtx-4090-torch2.9": pb.Snapshot()}
+    assert asyncio.run(ex._fetch_compile_snapshot(spec, snapshots)) is None
+    assert asyncio.run(ex._fetch_compile_snapshot(spec, None)) is None
+
+
+def test_prepare_with_explicit_artifact_seeds(tmp_path, monkeypatch):
+    monkeypatch.delenv(cc.ENV_CACHE_PATH, raising=False)
+    monkeypatch.delenv(cc.ENV_CACHE_URL, raising=False)
+    artifact = _artifact(tmp_path)
+    meta = cc.prepare(FAMILY, cache_dir=tmp_path / "cache", artifact=artifact)
+    assert meta is not None and meta["family"] == FAMILY
+    assert (tmp_path / "cache" / "compile-cache" / "inductor" / "g" / "code.py").exists()
+
+
+def test_manifest_carries_compile_block():
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(compile=Compile(shapes=((768, 768), (1024, 1024)), family=FAMILY))
+    class Ep:
+        def gen(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    (entry,) = _extract_entries(Ep, "testmod")
+    assert entry["compile"] == {
+        "family": FAMILY,
+        "shapes": [[768, 768], [1024, 1024]],
+        "targets": ["transformer", "vae.decode"],
+    }


### PR DESCRIPTION
Worker half of th#567 (hot adoption) + the gen-worker follow-up of th#569 (boot-attach consumption). Wire change already merged (#76 / te#109).

## Hot adoption (th#567)
`ModelOp{ADOPT_COMPILE_CACHE, ref, snapshot}` → download artifact snapshot → verify key (family/SKU/torch/triton/libs) → seed inductor+triton dirs → `torch.compile` re-wrap of the resident pipelines for endpoints declaring `compile=Compile(family=<f>)` (module re-wrap only; no weight reload) → one warmup trace (the endpoint's own `warmup()`, run under the GPU slot so a racing job queues instead of colliding) → `ModelEvent{ADOPTED, duration_ms}`.

ANY failure → discard, stay eager, `ModelEvent{FAILED, error:"adopt_failed:<reason>"}` with a closed reason vocabulary. Defensive `model_in_use` refusal when any job is in flight (hub schedules idle-only anyway). Unknown op kinds remain silent no-ops (old-worker semantics the hub relies on — covered by a test).

## Boot-attach (th#569, opt-in hub-side, default OFF)
`RunJob.snapshots` entries keyed `_system/family-<f>#inductor-…` for the endpoint's declared family are downloaded and passed to `compile_cache.enable(artifact=…)` before pipeline load. Missing/mismatched → eager, never an error.

## Manifest
Discovery emits a `compile` block (`family`, `shapes`, `targets`) per function so the hub can key `_system/family-<f>` lookups.

Tests: 283 passed, 1 skipped (14 new: adopt success/warmup-failure/key-mismatch/busy/no-endpoint/not-resident/bad-ref/artifact-missing/silent-unknown-kind, boot-attach fetch, explicit-artifact prepare, manifest compile block, ref helpers).