### PR TITLE
fix(cozy-convert): civitai baseModel beats filename-token family inference (e2e #112)

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/ingest.py
+++ b/packages/cozy_convert/src/cozy_convert/ingest.py
@@ -227,6 +227,21 @@ def ingest_huggingface(
     )
 
 
+def _resolve_civitai_family(base_family: str, layout_family: str) -> str:
+    """Civitai's structured baseModel is authoritative over filename-token
+    inference: creator filenames routinely carry other arch names (e.g.
+    'gonzalomoXLFluxPony_v70PhotoXLDMD.safetensors' is an SDXL 1.0 build
+    whose name poisoned the family to flux and broke the repackage — found
+    live, e2e tracker #112). Filename hints are the fallback."""
+    base_family = str(base_family or "").strip()
+    layout_family = str(layout_family or "").strip()
+    if base_family and base_family != "other":
+        return base_family
+    if layout_family not in ("", "unknown"):
+        return layout_family
+    return base_family
+
+
 def ingest_civitai(
     model_version_id: int,
     dest_dir: Path,
@@ -255,9 +270,8 @@ def ingest_civitai(
         base_family = civitai_to_family(base_model_raw) or ""
     except Exception:
         base_family = ""
-    model_family = str(layout_info.model_family or "").strip()
-    if model_family in ("", "unknown") and base_family:
-        model_family = base_family
+    model_family = _resolve_civitai_family(
+        base_family, str(layout_info.model_family or ""))
 
     model_id = int(payload.get("modelId") or 0)
     air = str(payload.get("air") or "")

--- a/packages/cozy_convert/tests/test_repackage_families.py
+++ b/packages/cozy_convert/tests/test_repackage_families.py
@@ -208,3 +208,24 @@ def test_detect_snapshot_dtype_ignores_garbage(tmp_path: Path) -> None:
     header = json.dumps({"not_a_tensor": "x"}).encode()
     bogus.write_bytes(struct.pack("<Q", len(header)) + header)
     assert _detect_snapshot_dtype(tmp_path) == ""
+
+
+def test_civitai_base_model_beats_filename_tokens() -> None:
+    """GonzaLomo regression (e2e #112): an SDXL 1.0 checkpoint whose FILENAME
+    contains 'flux' must classify as sdxl via the structured baseModel."""
+    from cozy_convert.layout import (
+        detect_huggingface_source_layout,
+        infer_model_family_variant_from_hint,
+    )
+
+    # The filename alone still reads as flux (that is the hazard)…
+    assert infer_model_family_variant_from_hint(
+        "gonzalomoXLFluxPony_v70PhotoXLDMD.safetensors") in ("flux1", "flux2")
+    # the ingest-level precedence keeps baseModel authoritative.
+    from cozy_convert.ingest import _resolve_civitai_family
+
+    assert _resolve_civitai_family("sdxl", "flux") == "sdxl"
+    assert _resolve_civitai_family("", "flux") == "flux"
+    assert _resolve_civitai_family("other", "flux") == "flux"
+    assert _resolve_civitai_family("other", "unknown") == "other"
+    assert _resolve_civitai_family("", "unknown") == ""


### PR DESCRIPTION
'gonzalomoXLFluxPony_v70PhotoXLDMD.safetensors' is an SDXL 1.0 checkpoint
whose filename contains 'flux' — the hint inference overrode the structured
baseModel, routed the repackage through Flux2Pipeline, and the clone failed
live. Structured metadata is now authoritative; filename hints are the
fallback (with baseModel 'Other' deferring to hints).
