### PR TITLE
feat(io): video output media metadata — VideoAsset probe, io.write_video AAC mux, ExpectedOutput.duration_s (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Video output media metadata (#387).** `VideoAsset` gains optional probed
+  container metadata (`duration_s`, `fps`, `width`, `height`, `has_audio`,
+  `sample_rate`); `ctx.save_video` fills it via PyAV (best-effort). New
+  `io.write_video(ctx, ref, frames, fps=, audio=, audio_sample_rate=)`
+  encodes H.264 + AAC-stereo mp4 (PyAV; mirrors diffusers ltx2
+  `export_utils.encode_video`) so video endpoints stop hand-rolling
+  tempfile + `export_to_video` and stop dropping generated audio. New
+  `video` extra (`av` + `numpy`). `ExpectedOutput` gains `duration_s`
+  (literal or `input.<field>` ref, seconds) emitted into the discovery
+  manifest for submit-time planning; media-seconds settlement is th#572.
+
 - **Residency unification + worker-side VRAM juggling + disk GC (#369,
   #370, #371).** The `Residency` registry now owns the executor's pipelines:
   worker-built pipelines register per ref with their own measured allocator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,12 @@ audio = [
     "soundfile>=0.12",
     "numpy>=1.24",
 ]
+video = [
+    "av>=12",
+    "numpy>=1.24",
+]
 dev = [
+    "av>=12",
     "cozy-convert",
     "grpcio-tools>=1.80.0",
     "mypy>=1.10.0",

--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -78,7 +78,21 @@ class ImageAsset(MediaAsset):
 
 
 class VideoAsset(MediaAsset):
-    """Reference to video media bytes."""
+    """Reference to video media bytes, plus probed container metadata.
+
+    ``ctx.save_video`` fills the media fields by probing the container
+    (PyAV, best-effort): ``duration_s``/``fps``/``width``/``height`` from the
+    video stream, ``has_audio``/``sample_rate`` from the audio stream. They
+    stay ``None`` when the probe is unavailable. ``duration_s`` is MEDIA
+    seconds (what per_output_second billing should meter), not wall-clock.
+    """
+
+    duration_s: Optional[float] = None
+    fps: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    has_audio: Optional[bool] = None
+    sample_rate: Optional[int] = None
 
 
 class AudioAsset(MediaAsset):
@@ -116,6 +130,12 @@ class ExpectedOutput:
     aspect_ratio: str | None = None
     mime_type: str | None = None
     media_type: Literal["image", "video", "audio", "file", "other"] | None = None
+    # Expected MEDIA duration in seconds (video/audio): a literal or an
+    # ``input.<field>`` ref to a payload field already denominated in seconds.
+    # Derived expressions (num_frames / fps) are not supported — frame-based
+    # endpoints leave this unset; settlement uses the probed
+    # ``VideoAsset.duration_s`` instead (tensorhub counterpart th#572).
+    duration_s: int | str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -235,6 +235,9 @@ def _collect_expected_output_metadata(payload_type: type, output_type: type) -> 
                 aspect = _expected_output_expr(marker.aspect_ratio, payload_type=payload_type, field=path, key="aspect_ratio")
                 if aspect is not None:
                     item["aspect_ratio"] = aspect
+                duration = _expected_output_expr(marker.duration_s, payload_type=payload_type, field=path, key="duration_s")
+                if duration is not None:
+                    item["duration_s"] = duration
                 mime = (marker.mime_type or "").strip()
                 if mime:
                     item["mime_type"] = mime

--- a/src/gen_worker/io.py
+++ b/src/gen_worker/io.py
@@ -154,6 +154,196 @@ def write_image(
     return out
 
 
+def probe_video(source: "bytes | str | Path") -> dict[str, Any]:
+    """Probe a video container (PyAV) for media metadata.
+
+    Returns a dict with any of ``duration_s``, ``fps``, ``width``, ``height``,
+    ``has_audio``, ``sample_rate`` — empty when PyAV is missing or the probe
+    fails. Used by ``ctx.save_video`` to fill :class:`VideoAsset` metadata.
+    """
+    try:
+        import av
+    except ImportError:
+        return {}
+    out: dict[str, Any] = {}
+    try:
+        opened = av.open(_io.BytesIO(source) if isinstance(source, (bytes, bytearray)) else str(source))
+    except Exception:
+        return {}
+    try:
+        video = next(iter(opened.streams.video), None)
+        if video is not None:
+            if video.width:
+                out["width"] = int(video.width)
+            if video.height:
+                out["height"] = int(video.height)
+            rate = video.average_rate or video.base_rate
+            if rate:
+                out["fps"] = float(rate)
+            container_duration = getattr(opened, "duration", None)
+            if video.duration is not None and video.time_base is not None:
+                out["duration_s"] = float(video.duration * video.time_base)
+            elif container_duration is not None:
+                out["duration_s"] = float(container_duration / av.time_base)
+        audio = next(iter(opened.streams.audio), None)
+        out["has_audio"] = audio is not None
+        if audio is not None and audio.sample_rate:
+            out["sample_rate"] = int(audio.sample_rate)
+    except Exception:
+        pass
+    finally:
+        opened.close()
+    return out
+
+
+def write_video(
+    ctx: Any,
+    ref: str,
+    frames: Any,
+    *,
+    fps: float,
+    audio: Any = None,
+    audio_sample_rate: Optional[int] = None,
+) -> Asset:
+    """Encode ``frames`` (+ optional ``audio``) to an H.264/AAC mp4 and save
+    via ``ctx.save_video(ref=...)``.
+
+    Requires PyAV + numpy (``pip install gen-worker[video]``). Mirrors
+    diffusers' ltx2 ``export_utils.encode_video`` so video endpoints stop
+    hand-rolling tempfile + ``export_to_video`` and audio survives the mux.
+
+    - ``frames``: list of PIL images, a numpy array ``[F, H, W, C]`` (float in
+      [0, 1] or uint8), or a torch tensor of the same shape.
+    - ``audio``: waveform ``[channels, samples]`` (numpy or torch, float in
+      [-1, 1]); mono is duplicated to stereo. ``audio_sample_rate`` is
+      required when audio is given.
+    """
+    try:
+        import av
+        import numpy as np
+    except ImportError as e:
+        raise ImportError(
+            "gen_worker.io.write_video requires PyAV + numpy. "
+            "Install with `pip install gen-worker[video]`."
+        ) from e
+    sample_rate = 0
+    if audio is not None:
+        if not audio_sample_rate:
+            raise ValidationError("write_video: audio_sample_rate is required with audio")
+        sample_rate = int(audio_sample_rate)
+
+    arr = _frames_to_uint8(frames, np)
+    height, width = int(arr.shape[1]), int(arr.shape[2])
+    # libx264/yuv420p needs even dimensions; crop a stray row/column.
+    height -= height % 2
+    width -= width % 2
+    arr = arr[:, :height, :width]
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as handle:
+        tmp_path = handle.name
+    try:
+        container = av.open(tmp_path, mode="w")
+        try:
+            stream = container.add_stream("libx264", rate=round(fps))
+            stream.width = width
+            stream.height = height
+            stream.pix_fmt = "yuv420p"
+            # Both streams must exist before the first mux writes the header.
+            audio_stream = (
+                _prepare_audio_stream(container, sample_rate, av)
+                if audio is not None
+                else None
+            )
+            for frame_array in arr:
+                frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+                for packet in stream.encode(frame):
+                    container.mux(packet)
+            for packet in stream.encode():
+                container.mux(packet)
+            if audio_stream is not None:
+                _mux_audio(container, audio_stream, audio, sample_rate, av, np)
+        finally:
+            container.close()
+        return ctx.save_video(tmp_path, ref, format="mp4")
+    finally:
+        import os
+
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _frames_to_uint8(frames: Any, np: Any) -> Any:
+    """Coerce PIL list / float array / torch tensor to uint8 [F, H, W, C]."""
+    if isinstance(frames, (list, tuple)):
+        if not frames:
+            raise ValidationError("write_video: frames is empty")
+        frames = np.stack([np.asarray(f.convert("RGB") if hasattr(f, "convert") else f) for f in frames])
+    if hasattr(frames, "detach"):  # torch tensor
+        frames = frames.detach().to("cpu").float().numpy()
+    arr = np.asarray(frames)
+    if arr.ndim != 4 or arr.shape[-1] != 3:
+        raise ValidationError(
+            f"write_video: frames must be [F, H, W, 3], got shape {arr.shape}"
+        )
+    if arr.dtype != np.uint8:
+        arr = arr.astype("float32")
+        if float(arr.max(initial=0.0)) <= 1.0:
+            arr = arr * 255.0
+        arr = np.clip(arr.round(), 0, 255).astype("uint8")
+    return arr
+
+
+def _prepare_audio_stream(container: Any, sample_rate: int, av: Any) -> Any:
+    from fractions import Fraction
+
+    stream = container.add_stream("aac", rate=sample_rate)
+    cc = stream.codec_context
+    cc.sample_rate = sample_rate
+    cc.layout = "stereo"
+    cc.time_base = Fraction(1, sample_rate)
+    return stream
+
+
+def _mux_audio(container: Any, stream: Any, audio: Any, sample_rate: int, av: Any, np: Any) -> None:
+    """Append an AAC stereo track (mirrors diffusers ltx2 export_utils)."""
+    if hasattr(audio, "detach"):
+        audio = audio.detach().to("cpu").float().numpy()
+    wave = np.asarray(audio, dtype="float32")
+    if wave.ndim == 1:
+        wave = wave[None, :]
+    if wave.ndim != 2:
+        raise ValidationError(f"write_video: audio must be [channels, samples], got shape {wave.shape}")
+    if wave.shape[0] == 1:
+        wave = np.repeat(wave, 2, axis=0)
+    elif wave.shape[0] > 2:
+        wave = wave[:2]
+    wave = np.ascontiguousarray(np.clip(wave, -1.0, 1.0))
+
+    cc = stream.codec_context
+    # One packed-s16 input frame; the resampler converts to the encoder's
+    # format and assigns pts (mirrors diffusers ltx2 export_utils._write_audio).
+    pcm = (wave.T * 32767.0).astype("int16")  # [samples, 2] interleaved
+    frame_in = av.AudioFrame.from_ndarray(
+        np.ascontiguousarray(pcm.reshape(1, -1)), format="s16", layout="stereo"
+    )
+    frame_in.sample_rate = sample_rate
+
+    resampler = av.audio.resampler.AudioResampler(
+        format=cc.format or "fltp", layout=cc.layout or "stereo", rate=cc.sample_rate or sample_rate
+    )
+    next_pts = 0
+    for rframe in resampler.resample(frame_in):
+        if rframe.pts is None:
+            rframe.pts = next_pts
+        next_pts += rframe.samples
+        rframe.sample_rate = sample_rate
+        container.mux(stream.encode(rframe))
+    for packet in stream.encode():
+        container.mux(packet)
+
+
 __all__ = [
     "read_bytes",
     "open",
@@ -161,4 +351,6 @@ __all__ = [
     "read_image",
     "read_audio",
     "write_image",
+    "write_video",
+    "probe_video",
 ]

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -630,7 +630,8 @@ class RequestContext:
         format: str = "mp4",
     ) -> VideoAsset:
         """Save an encoded video (bytes or a local file path); returns a
-        typed :class:`VideoAsset`."""
+        typed :class:`VideoAsset` with probed container metadata
+        (duration_s/fps/width/height/has_audio/sample_rate, best-effort)."""
         fmt = str(format or "mp4").strip().lower()
         if ref is None or str(ref).strip() == "":
             ref = f"outputs/{self.request_id}/video.{fmt}"
@@ -639,8 +640,19 @@ class RequestContext:
             if Path(ref).suffix == "":
                 ref += f".{fmt}"
         if isinstance(video, (bytes, bytearray)):
-            return _as_asset(self.save_bytes(ref, bytes(video)), VideoAsset)
-        return _as_asset(self.save_file(ref, video), VideoAsset)
+            asset = _as_asset(self.save_bytes(ref, bytes(video)), VideoAsset)
+        else:
+            asset = _as_asset(self.save_file(ref, video), VideoAsset)
+        try:
+            from ..io import probe_video
+
+            for key, value in probe_video(
+                bytes(video) if isinstance(video, (bytes, bytearray)) else video
+            ).items():
+                setattr(asset, key, value)
+        except Exception:
+            logger.debug("save_video: metadata probe failed", exc_info=True)
+        return asset
 
 
     def save_file(self, ref: str, local_path: str | os.PathLike[str]) -> Asset:

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -1,0 +1,96 @@
+"""gen_worker.io.write_video + VideoAsset metadata probe (gw#387).
+
+End-to-end through the real code path: av-encode synthetic frames (+ audio)
+-> ctx.save_video -> probe fills VideoAsset media metadata.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import msgspec
+import numpy as np
+import pytest
+
+from gen_worker import ExpectedOutput, RequestContext, io as gw_io
+from gen_worker.api.types import VideoAsset
+
+av = pytest.importorskip("av")
+
+
+class DurationIn(msgspec.Struct):
+    duration_s: int = 10
+
+
+class DurationOut(msgspec.Struct):
+    video: Annotated[VideoAsset, ExpectedOutput(duration_s="input.duration_s", mime_type="video/mp4")]
+
+
+def _frames(count: int = 24, height: int = 64, width: int = 64) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.random((count, height, width, 3), dtype=np.float32)
+
+
+def test_write_video_with_audio_probes_metadata(tmp_path) -> None:
+    ctx = RequestContext(request_id="r1", local_output_dir=str(tmp_path))
+    sr = 24000
+    audio = np.sin(np.linspace(0, 440 * 2 * np.pi, sr))[None, :].astype(np.float32)  # 1s mono
+
+    asset = gw_io.write_video(
+        ctx, "outputs/r1/video", _frames(), fps=24, audio=audio, audio_sample_rate=sr
+    )
+
+    assert isinstance(asset, VideoAsset)
+    assert asset.local_path and asset.local_path.endswith(".mp4")
+    assert asset.width == 64 and asset.height == 64
+    assert asset.fps == pytest.approx(24.0)
+    assert asset.duration_s == pytest.approx(1.0, abs=0.25)
+    assert asset.has_audio is True
+    assert asset.sample_rate == sr
+
+    # The stored container really carries an AAC audio stream (the mux is not
+    # metadata-only), and the video stream survived intact.
+    with av.open(asset.local_path) as container:
+        assert len(container.streams.audio) == 1
+        assert container.streams.audio[0].codec_context.name == "aac"
+        assert len(container.streams.video) == 1
+
+
+def test_write_video_without_audio(tmp_path) -> None:
+    ctx = RequestContext(request_id="r2", local_output_dir=str(tmp_path))
+    asset = gw_io.write_video(ctx, "outputs/r2/silent", _frames(count=9), fps=24)
+    assert asset.has_audio is False
+    assert asset.sample_rate is None
+    assert asset.width == 64 and asset.height == 64
+
+
+def test_write_video_accepts_torch_and_odd_dims(tmp_path) -> None:
+    torch = pytest.importorskip("torch")
+    ctx = RequestContext(request_id="r3", local_output_dir=str(tmp_path))
+    frames = torch.rand(9, 33, 65, 3)  # odd dims -> cropped to even
+    asset = gw_io.write_video(ctx, "outputs/r3/odd", frames, fps=12)
+    assert asset.width == 64 and asset.height == 32
+
+
+def test_write_video_requires_sample_rate_with_audio(tmp_path) -> None:
+    from gen_worker import ValidationError
+
+    ctx = RequestContext(request_id="r4", local_output_dir=str(tmp_path))
+    with pytest.raises(ValidationError):
+        gw_io.write_video(ctx, "x", _frames(count=2), fps=24, audio=np.zeros((2, 100), dtype=np.float32))
+
+
+def test_save_video_probe_is_best_effort(tmp_path) -> None:
+    ctx = RequestContext(request_id="r5", local_output_dir=str(tmp_path))
+    asset = ctx.save_video(b"not a real container", "outputs/r5/garbage")
+    assert isinstance(asset, VideoAsset)  # save succeeds; metadata stays None
+    assert asset.duration_s is None and asset.has_audio is None
+
+
+def test_expected_output_duration_ref_compiles() -> None:
+    from gen_worker.discovery.discover import _collect_expected_output_metadata
+
+    items = _collect_expected_output_metadata(DurationIn, DurationOut)
+    assert items == [
+        {"field": "video", "type": "video", "count": 1, "duration_s": "input.duration_s", "mime_type": "video/mp4"}
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,32 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/4ee23a7f1609adf9b2f140c7a8ffade64a1449d89ab431d922a809eebf19/av-18.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:88dd8e35e9242662b409a6a05fd24a6775d949eb05da0ba31cab4f250eacbab5", size = 22740741, upload-time = "2026-07-02T06:37:26.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/b9f8363d07aa4521913e483f6a30c7c164973ef01de62769bf9b97049cd8/av-18.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f8f454349c402e2c8d6fa80b54eb2a3f86c00f414d2b399f01ae6dab075c6fd8", size = 18384189, upload-time = "2026-07-02T06:37:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e5/69397019aed280a72a43e97a252dee4295df1a9e608848452e5300ec4dab/av-18.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:88ce194c2201c6a6d40336adee8a5ddde46ed743eacb500e3ae9368d1c6d889e", size = 36749881, upload-time = "2026-07-02T06:37:33.096Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3a/1614d74f0d676ea6745eb59553c9ad01ca25db523cba808d522e838f4f5b/av-18.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:aa15e567a018cc94a26b0ab45da676dee70c4146ace6e92e47d30cc9689cbfbe", size = 38645927, upload-time = "2026-07-02T06:37:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3c/5f54710d69b0ea93634134f92b49c7a2a7fd27da5486a8a7e6251ac1cfb4/av-18.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:613153e48cefc91700746dde0ad0282d4677b194cba22cc771de14c78411cf8b", size = 40454783, upload-time = "2026-07-02T06:37:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/8293e6a267e0591b543abd96ae01e7e8ed228509bdb4e4644a8a8395d90f/av-18.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:30404f53ca1ea7f350ac86ff22a2c04f903014758e9b33f398c5a62de34bd84f", size = 37573117, upload-time = "2026-07-02T06:37:44.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
+]
+
+[[package]]
 name = "bitsandbytes"
 version = "0.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -621,6 +647,7 @@ audio = [
     { name = "soundfile" },
 ]
 dev = [
+    { name = "av" },
     { name = "cozy-convert" },
     { name = "grpcio-tools" },
     { name = "mypy" },
@@ -640,6 +667,10 @@ torch = [
 trainer = [
     { name = "pyarrow" },
 ]
+video = [
+    { name = "av" },
+    { name = "numpy" },
+]
 vision = [
     { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -647,6 +678,8 @@ vision = [
 
 [package.metadata]
 requires-dist = [
+    { name = "av", marker = "extra == 'dev'", specifier = ">=12" },
+    { name = "av", marker = "extra == 'video'", specifier = ">=12" },
     { name = "blake3", specifier = ">=1.0.0" },
     { name = "boto3", specifier = ">=1.41.0" },
     { name = "cozy-convert", marker = "extra == 'dev'", editable = "packages/cozy_convert" },
@@ -656,6 +689,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'video'", specifier = ">=1.24" },
     { name = "pillow", marker = "extra == 'images'", specifier = ">=10.0" },
     { name = "protobuf", specifier = ">=6.30.0" },
     { name = "psutil", specifier = ">=7.0.0" },
@@ -674,7 +708,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.4.20250913" },
 ]
-provides-extras = ["torch", "vision", "trainer", "images", "audio", "dev"]
+provides-extras = ["torch", "vision", "trainer", "images", "audio", "video", "dev"]
 
 [[package]]
 name = "gguf"


### PR DESCRIPTION
Closes gw#387 (code side).

- VideoAsset: optional probed container metadata (duration_s/fps/width/height/has_audio/sample_rate); ctx.save_video fills it via PyAV, best-effort.
- io.write_video(ctx, ref, frames, fps=, audio=, audio_sample_rate=): H.264 + AAC-stereo mp4 mux (PyAV; mirrors diffusers ltx2 export_utils.encode_video) so video endpoints stop hand-rolling tempfile+export_to_video and stop dropping audio.
- ExpectedOutput.duration_s (literal or input.<field> ref in seconds) emitted into the discovery manifest.
- New 'video' extra (av+numpy); av added to dev extra so the tests run.

Deferred (tracker notes): result-level media-seconds on JobExecutionResult rides the th#572 settlement counterpart; duration derived from num_frames/fps needs expression support hub-side.

Tests: 288 passed, 2 skipped (full suite); new tests/test_video_io.py covers the real av encode+probe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)