### PR TITLE
perf(upload): save-scoped connection reuse for presigned uploads (#385)

### DIFF
--- a/src/gen_worker/_upload_transport.py
+++ b/src/gen_worker/_upload_transport.py
@@ -14,11 +14,13 @@ This module fixes that with three mechanical changes while preserving the
 Tensorhub upload contract: Tensorhub creates a multipart session and returns
 presigned part URLs; the worker PUTs bytes directly to those URLs.
 
-  1. **Per-part pool isolation.** Each multipart PUT gets its own
-     ``urllib3.PoolManager(maxsize=1, block=False)``; the pool is
-     destroyed after the part completes. A retry on a failed part
-     allocates a fresh pool — guaranteed-new TCP+TLS handshake — so a
-     stale half-closed socket never propagates to the retry.
+  1. **Pool isolation.** Every RETRY attempt allocates a fresh
+     ``urllib3.PoolManager(maxsize=1, block=False)`` — guaranteed-new
+     TCP+TLS handshake — so a stale half-closed socket never propagates
+     to the retry. First attempts within ONE save may share a
+     save-scoped ``PutPool`` (issue #385): keepalive across that save's
+     parts, torn down with the save, never cross-request. See
+     ``PutPool`` for why this scope cannot reproduce the R2 incident.
   2. **Explicit retry classification.** TLS/connection/timeout errors,
      429, and 5xx are retried with exponential backoff + decorrelated
      jitter. 4xx (other than 429) is terminal. The classifier matches
@@ -29,13 +31,12 @@ presigned part URLs; the worker PUTs bytes directly to those URLs.
      stalled.
 
 The control plane (create / complete / abort POSTs to tensorhub) stays
-on ``requests`` because those are small, idempotent JSON calls — the
-TLS-pool pathology is specific to the long-lived multi-GiB S3 PUT
-path.
+on ``requests``, on a per-save ``requests.Session`` owned by
+``presigned_upload.py``.
 
 Public API: ``upload_part_to_presigned_url(url, file_path, offset,
-length)`` -> ``etag``. Caller owns the part-level fan-out
-(``presigned_upload.py``) and the file-level fan-out
+length, pool=None)`` -> ``etag``, plus ``PutPool``. Caller owns the
+part-level fan-out (``presigned_upload.py``) and the file-level fan-out
 (``_concurrent_upload.py``). This module is a pure transport leaf.
 """
 
@@ -129,6 +130,68 @@ class _BoundedFileReader:
         return False
 
 
+class PutPool:
+    """Save-scoped keepalive pool for presigned part PUTs (issue #385).
+
+    Shared by the FIRST attempt of each part PUT within one save, so
+    consecutive parts reuse the R2 TCP+TLS connection instead of paying a
+    fresh handshake each (measured from a pod: fresh-conn PUTs 0.8-5.0s,
+    keepalive 0.6-0.8s). Retry attempts never touch this pool — they get
+    the fresh-per-attempt PoolManager that fixed the R2
+    ``SSLV3_ALERT_BAD_RECORD_MAC`` incident.
+
+    Why this scope cannot reproduce that incident: the 2026-05-16 failure
+    came from a process-global pool whose sockets sat idle across a
+    minutes-long, 64-PUT-in-flight clone until R2's edge half-closed them,
+    and whose retries were handed the same poisoned socket. This pool
+    (a) lives only for the seconds-scale span of one save and is closed
+    with it — never cross-request, (b) idles only for the ms-scale gap
+    between one save's parts, and (c) is cleared on any transport failure,
+    whose retry then runs on a guaranteed-fresh pool. Worst case a stale
+    socket costs one retried attempt — the same recovery path as today.
+
+    Thread-safe (urllib3.PoolManager is); sized for the fixed part fan-out.
+    """
+
+    def __init__(self, maxsize: int = 4) -> None:
+        self._pool = urllib3.PoolManager(
+            num_pools=1,
+            maxsize=maxsize,
+            block=False,
+            retries=False,  # callers own the retry loop
+            timeout=urllib3.Timeout(connect=_CONNECT_TIMEOUT_S, read=_READ_TIMEOUT_S),
+        )
+
+    def put(self, url: str, *, body: Any, length: int) -> Any:
+        # No ``Connection: close`` — keepalive within the save is the point.
+        return self._pool.request(
+            "PUT",
+            url,
+            body=body,
+            headers={"Content-Length": str(length)},
+            preload_content=True,
+            decode_content=False,
+        )
+
+    def discard_connections(self) -> None:
+        """Drop all pooled sockets. Called after any transport failure so a
+        possibly-poisoned connection can never serve another part."""
+        try:
+            self._pool.clear()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        self.discard_connections()
+
+    def __enter__(self) -> "PutPool":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        self.close()
+        return False
+
+
 class TransportError(RuntimeError):
     """Raised when a part upload fails after exhausting retries."""
 
@@ -209,14 +272,16 @@ def upload_part_to_presigned_url(
     length: int,
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     cancel_check: Optional[Any] = None,
+    pool: Optional[PutPool] = None,
 ) -> str:
     """PUT one multipart part to a presigned S3 URL, return the ETag.
 
-    Each attempt allocates its own ``urllib3.PoolManager(maxsize=1)``,
-    issues the PUT, and tears the pool down. Stale-socket reuse — the
-    root cause of the ``SSLV3_ALERT_BAD_RECORD_MAC`` against R2 — is
-    structurally impossible because no connection ever outlives its
-    attempt.
+    With ``pool`` given, the FIRST attempt goes through that save-scoped
+    keepalive pool (issue #385). Every retry attempt — and every attempt
+    when ``pool`` is None — allocates its own ``urllib3.PoolManager
+    (maxsize=1)``, issues the PUT, and tears the pool down, so a stale
+    socket (root cause of the ``SSLV3_ALERT_BAD_RECORD_MAC`` against R2)
+    can never propagate into a retry.
 
     Retries on transport-level failures (TLS, connection reset,
     timeout), 429, and 5xx. Terminal on 4xx (other than 429) and on
@@ -235,43 +300,51 @@ def upload_part_to_presigned_url(
         if cancel_check is not None and cancel_check():
             raise InterruptedError("canceled")
 
-        # Fresh pool per attempt. ``maxsize=1`` keeps the pool's
-        # connection set tiny — there's only one in-flight request, and
-        # ``block=False`` means urllib3 won't queue on it. On context-
-        # manager exit the pool's idle connections are closed, so the
-        # TCP socket is unambiguously released before the next attempt.
+        use_shared_pool = pool is not None and attempt == 1
         try:
             with _BoundedFileReader(file_path, offset, length) as body:
-                with urllib3.PoolManager(
-                    num_pools=1,
-                    maxsize=1,
-                    block=False,
-                    # ssl_context=None  -> use urllib3's default (which uses
-                    # the system's default OpenSSL + CA bundle). No custom
-                    # context: the R2 cert chain is publicly trusted.
-                    retries=False,  # we own the retry loop
-                    timeout=urllib3.Timeout(connect=_CONNECT_TIMEOUT_S, read=_READ_TIMEOUT_S),
-                ) as http:
-                    resp = http.request(
-                        "PUT",
-                        url,
-                        body=body,
-                        headers={
-                            "Content-Length": str(length),
-                            # Force connection teardown after this single
-                            # PUT. Defense in depth — the pool tears down
-                            # anyway, but ``Connection: close`` also tells
-                            # the server-side TLS terminator to not hold
-                            # the socket in its keep-alive table waiting
-                            # for a follow-up request.
-                            "Connection": "close",
-                        },
-                        preload_content=True,
-                        decode_content=False,
-                    )
+                if use_shared_pool:
+                    resp = pool.put(url, body=body, length=length)
+                else:
+                    # Fresh pool per attempt. ``maxsize=1`` keeps the pool's
+                    # connection set tiny — there's only one in-flight request,
+                    # and ``block=False`` means urllib3 won't queue on it. On
+                    # context-manager exit the pool's idle connections are
+                    # closed, so the TCP socket is unambiguously released
+                    # before the next attempt.
+                    with urllib3.PoolManager(
+                        num_pools=1,
+                        maxsize=1,
+                        block=False,
+                        # ssl_context=None  -> use urllib3's default (which uses
+                        # the system's default OpenSSL + CA bundle). No custom
+                        # context: the R2 cert chain is publicly trusted.
+                        retries=False,  # we own the retry loop
+                        timeout=urllib3.Timeout(connect=_CONNECT_TIMEOUT_S, read=_READ_TIMEOUT_S),
+                    ) as http:
+                        resp = http.request(
+                            "PUT",
+                            url,
+                            body=body,
+                            headers={
+                                "Content-Length": str(length),
+                                # Force connection teardown after this single
+                                # PUT. Defense in depth — the pool tears down
+                                # anyway, but ``Connection: close`` also tells
+                                # the server-side TLS terminator to not hold
+                                # the socket in its keep-alive table waiting
+                                # for a follow-up request.
+                                "Connection": "close",
+                            },
+                            preload_content=True,
+                            decode_content=False,
+                        )
         except InterruptedError:
             raise
         except BaseException as exc:
+            if use_shared_pool:
+                # Never let a possibly-poisoned socket serve another part.
+                pool.discard_connections()
             err = _classify_transport_exception(exc)
             last_err = err
             if not err.retryable or attempt >= max_attempts:

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -22,16 +22,22 @@ used at different route prefixes for repo checkpoints
 endpoint source (/api/v1/endpoints/:owner/:endpoint/releases/uploads),
 and user media (/api/v1/media/:owner/uploads).
 
-# HTTP stack (issue #13)
+# HTTP stack (issues #13 / #385)
 
-The control-plane POSTs (create session / abort / complete) go over
-``requests`` — small idempotent JSON calls where the connection-pool
-pathology that bit the data plane doesn't matter.
+Connections are scoped to ONE save (``presigned_upload_file`` call) and
+torn down with it — never shared across saves:
 
-The data-plane multipart PUTs go through ``_upload_transport.upload_part_to_presigned_url``,
-which allocates a fresh ``urllib3.PoolManager`` per attempt to
-structurally prevent the stale-socket reuse that caused
-``SSLV3_ALERT_BAD_RECORD_MAC`` against Cloudflare R2.
+  * control plane (create / complete / abort) — one ``requests.Session``
+    per save, so create -> complete reuses the tensorhub connection
+    instead of paying a fresh TCP+TLS handshake per POST (bare
+    ``requests.post`` builds a new Session per call). Auth headers are
+    passed per-request, so worker JWT rotation never forces a new
+    connection.
+  * data plane (part PUTs) — one ``_upload_transport.PutPool`` per save,
+    shared by first attempts so consecutive parts reuse the R2
+    connection. Retry attempts always get a fresh ``urllib3.PoolManager``
+    — the structural guard against the stale-socket
+    ``SSLV3_ALERT_BAD_RECORD_MAC`` R2 incident (see ``_upload_transport``).
 """
 
 from __future__ import annotations
@@ -51,6 +57,7 @@ from blake3 import blake3
 
 from ._upload_transport import (
     STREAM_CHUNK_BYTES,
+    PutPool,
     TransportError,
     optimal_part_concurrency,
     upload_part_to_presigned_url,
@@ -202,6 +209,40 @@ def presigned_upload_file(
             target_dtype, flavor, produced_by_kind. Tensorhub persists
             these into checkpoint_lineage.
     """
+    # Per-save connection scope (issue #385): one hub Session + one R2 PUT
+    # pool live exactly as long as this save, then close. Never cross-request.
+    with requests.Session() as session, PutPool() as put_pool:
+        return _presigned_upload_file_scoped(
+            file_path=file_path,
+            base_url=base_url,
+            endpoint_path=endpoint_path,
+            headers=headers,
+            create_payload=create_payload,
+            blake3_hex=blake3_hex,
+            size_bytes=size_bytes,
+            on_progress=on_progress,
+            cancel_check=cancel_check,
+            complete_extra=complete_extra,
+            session=session,
+            put_pool=put_pool,
+        )
+
+
+def _presigned_upload_file_scoped(
+    *,
+    file_path: str | Path,
+    base_url: str,
+    endpoint_path: str,
+    headers: Dict[str, str],
+    create_payload: Dict[str, Any],
+    blake3_hex: str,
+    size_bytes: int,
+    on_progress: Optional[Any],
+    cancel_check: Optional[Any],
+    complete_extra: Optional[Dict[str, Any]],
+    session: requests.Session,
+    put_pool: PutPool,
+) -> PresignedUploadResult:
     url = f"{base_url}{endpoint_path}"
 
     # --- Step 1: Create presigned upload session ---
@@ -213,7 +254,7 @@ def presigned_upload_file(
     create_headers["Content-Type"] = "application/json"
 
     try:
-        resp = requests.post(url, headers=create_headers, data=json.dumps(payload), timeout=_CREATE_TIMEOUT_S)
+        resp = session.post(url, headers=create_headers, data=json.dumps(payload), timeout=_CREATE_TIMEOUT_S)
     except requests.RequestException as e:
         raise ArtifactTransferError(
             f"tensorhub upload create request failed: {e}",
@@ -288,6 +329,7 @@ def presigned_upload_file(
             headers=headers,
             payload=complete_payload,
             cancel_check=cancel_check,
+            session=session,
         )
         return PresignedUploadResult(meta=result_meta, dedup=False)
 
@@ -323,12 +365,13 @@ def presigned_upload_file(
             total_parts=total_parts,
             on_progress=on_progress,
             cancel_check=cancel_check,
+            put_pool=put_pool,
         )
     except BaseException:
         # Abort the multipart upload on failure.
         try:
             abort_headers = dict(headers)
-            requests.delete(abort_url, headers=abort_headers, timeout=15)
+            session.delete(abort_url, headers=abort_headers, timeout=15)
         except Exception:
             pass
         raise
@@ -351,6 +394,7 @@ def presigned_upload_file(
         headers=headers,
         payload=complete_payload,
         cancel_check=cancel_check,
+        session=session,
     )
     return PresignedUploadResult(meta=result_meta, dedup=False)
 
@@ -377,6 +421,7 @@ def _poll_until_finalized(
     complete_headers: Dict[str, str],
     payload: Dict[str, Any],
     cancel_check: Optional[Any],
+    session: requests.Session,
 ) -> Dict[str, Any]:
     """A prior /complete attempt is still finalizing server-side (409
     upload_complete_in_progress) — tensorhub verifies large objects
@@ -401,7 +446,7 @@ def _poll_until_finalized(
             )
         time.sleep(min(_COMPLETE_IN_PROGRESS_POLL_S, remaining))
         try:
-            resp = requests.post(
+            resp = session.post(
                 complete_url, headers=complete_headers, data=json.dumps(payload),
                 timeout=_FINALIZE_TIMEOUT_S,
             )
@@ -430,6 +475,7 @@ def _complete_upload_session(
     headers: Dict[str, str],
     payload: Dict[str, Any],
     cancel_check: Optional[Any],
+    session: requests.Session,
 ) -> Dict[str, Any]:
     complete_headers = dict(headers)
     complete_headers["Content-Type"] = "application/json"
@@ -438,7 +484,7 @@ def _complete_upload_session(
         if cancel_check and cancel_check():
             raise CanceledError("canceled")
         try:
-            resp = requests.post(
+            resp = session.post(
                 complete_url,
                 headers=complete_headers,
                 data=json.dumps(payload),
@@ -462,6 +508,7 @@ def _complete_upload_session(
                     complete_headers=complete_headers,
                     payload=payload,
                     cancel_check=cancel_check,
+                    session=session,
                 )
             if code >= 500:
                 last_exc = ArtifactTransferError(
@@ -497,13 +544,15 @@ def _upload_parts_to_s3(
     total_parts: int,
     on_progress: Optional[Any],
     cancel_check: Optional[Any],
+    put_pool: Optional[PutPool] = None,
 ) -> List[Tuple[int, str]]:
     """Upload file parts to S3 using presigned URLs. Returns list of (part_number, etag).
 
     Each part PUT is dispatched through ``_upload_transport`` which
-    owns the per-attempt PoolManager lifecycle, exponential-backoff
-    retry classification, and TLS-pool isolation. This function just
-    fans out across parts and aggregates ETags.
+    owns the pool lifecycle (save-scoped keepalive pool for first
+    attempts, fresh pool per retry), exponential-backoff retry
+    classification, and TLS-pool isolation. This function just fans
+    out across parts and aggregates ETags.
     """
     etags: List[Tuple[int, str]] = []
     file_size = os.path.getsize(file_path)
@@ -521,6 +570,7 @@ def _upload_parts_to_s3(
                     offset=offset,
                     length=length,
                     cancel_check=cancel_check,
+                    pool=put_pool,
                 )
         except InterruptedError as ie:
             raise CanceledError("canceled") from ie

--- a/tests/test_presigned_upload_complete_retry.py
+++ b/tests/test_presigned_upload_complete_retry.py
@@ -20,6 +20,14 @@ from gen_worker.presigned_upload import (
 from gen_worker.api.errors import ArtifactTransferError, CanceledError
 
 
+class _FakeSession:
+    """Session double: the poll/complete helpers now take a per-save
+    requests.Session; only .post is used here."""
+
+    def __init__(self, post):
+        self.post = post
+
+
 class _FakeResponse:
     def __init__(self, status_code: int, body: dict | None = None, text: str | None = None):
         self.status_code = status_code
@@ -58,13 +66,13 @@ def test_complete_upload_session_polls_through_upload_complete_in_progress(monke
         calls["n"] += 1
         return resp
 
-    with patch("gen_worker.presigned_upload.requests.post", side_effect=fake_post), \
-         patch("gen_worker.presigned_upload.time.sleep"):
+    with patch("gen_worker.presigned_upload.time.sleep"):
         result = _complete_upload_session(
             complete_url="https://tensorhub.test/complete",
             headers={"Authorization": "Bearer x"},
             payload={"transfer": {"mode": "s3_sdk"}},
             cancel_check=None,
+            session=_FakeSession(fake_post),
         )
     assert result == {"destination_repo": "tensorhub/sdxl-illustrious", "published": []}
     assert calls["n"] == 3
@@ -77,14 +85,14 @@ def test_poll_until_finalized_gives_up_after_deadline(monkeypatch):
         "gen_worker.presigned_upload._COMPLETE_IN_PROGRESS_MAX_WAIT_S", 0.01,
     )
     always_409 = _FakeResponse(409, {"error": {"code": "upload_complete_in_progress"}})
-    with patch("gen_worker.presigned_upload.requests.post", return_value=always_409), \
-         patch("gen_worker.presigned_upload.time.sleep"):
+    with patch("gen_worker.presigned_upload.time.sleep"):
         with pytest.raises(ArtifactTransferError) as exc_info:
             _poll_until_finalized(
                 complete_url="https://tensorhub.test/complete",
                 complete_headers={},
                 payload={},
                 cancel_check=None,
+                session=_FakeSession(lambda *a, **kw: always_409),
             )
     assert exc_info.value.retryable is True
 
@@ -96,6 +104,7 @@ def test_poll_until_finalized_respects_cancel_check():
             complete_headers={},
             payload={},
             cancel_check=lambda: True,
+            session=_FakeSession(lambda *a, **kw: None),
         )
 
 
@@ -103,13 +112,13 @@ def test_complete_upload_session_other_409_is_not_polled():
     """A different 409 (e.g. the session was aborted) is a real terminal
     error, not the in-progress race — must not enter the poll loop."""
     aborted = _FakeResponse(409, {"error": {"code": "upload_session_aborted"}})
-    with patch("gen_worker.presigned_upload.requests.post", return_value=aborted):
-        with pytest.raises(ArtifactTransferError) as exc_info:
-            _complete_upload_session(
-                complete_url="https://tensorhub.test/complete",
-                headers={},
-                payload={},
-                cancel_check=None,
-            )
+    with pytest.raises(ArtifactTransferError) as exc_info:
+        _complete_upload_session(
+            complete_url="https://tensorhub.test/complete",
+            headers={},
+            payload={},
+            cancel_check=None,
+            session=_FakeSession(lambda *a, **kw: aborted),
+        )
     assert exc_info.value.retryable is False
     assert exc_info.value.status_code == 409

--- a/tests/test_upload_transport_tls.py
+++ b/tests/test_upload_transport_tls.py
@@ -1,0 +1,330 @@
+"""Real-TLS integration for the #385 save-scoped connection reuse.
+
+Drives the REAL transport (urllib3 PoolManager / PutPool, requests.Session,
+real TCP+TLS handshakes against a local ssl-wrapped ThreadingHTTPServer with a
+self-signed cert). The server tags every request with a per-connection serial,
+so the tests assert connection reuse/isolation directly:
+
+  * sequential part PUTs sharing one PutPool ride ONE TLS connection,
+  * without a pool every PUT pays a fresh handshake (the pre-#385 behavior),
+  * a retry NEVER reuses the shared pool's connection (the R2
+    SSLV3_ALERT_BAD_RECORD_MAC guard: fresh pool per retry attempt),
+  * a full presigned_upload_file save reuses the hub connection across
+    create -> complete, and NOTHING is reused across two saves.
+"""
+
+from __future__ import annotations
+
+import json
+import ssl
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from gen_worker._upload_transport import PutPool, upload_part_to_presigned_url
+from gen_worker.presigned_upload import presigned_upload_file, blake3_hash_file
+
+
+# --------------------------------------------------------------------------
+# Local TLS server with per-connection accounting
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tls_cert(tmp_path_factory: pytest.TempPathFactory) -> Tuple[Path, Path]:
+    d = tmp_path_factory.mktemp("tls")
+    cert, key = d / "cert.pem", d / "key.pem"
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-keyout", str(key), "-out", str(cert),
+            "-days", "1", "-nodes", "-subj", "/CN=localhost",
+            "-addext", "subjectAltName=IP:127.0.0.1,DNS:localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert, key
+
+
+@pytest.fixture()
+def trust_local_cert(tls_cert: Tuple[Path, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+    cert, _ = tls_cert
+    # urllib3's default ssl context loads system verify paths (SSL_CERT_FILE);
+    # requests reads REQUESTS_CA_BUNDLE per request.
+    monkeypatch.setenv("SSL_CERT_FILE", str(cert))
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(cert))
+
+
+class _CountingHandler(BaseHTTPRequestHandler):
+    """HTTP/1.1 (keep-alive capable) handler that tags each request with a
+    per-TLS-connection serial in ``server.requests``."""
+
+    protocol_version = "HTTP/1.1"
+    conn_id: int = -1
+
+    def setup(self) -> None:  # one call per accepted (TLS) connection
+        super().setup()
+        srv: Any = self.server
+        with srv.lock:
+            srv.conn_serial += 1
+            self.conn_id = srv.conn_serial
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def _record(self) -> None:
+        srv: Any = self.server
+        with srv.lock:
+            srv.requests.append((self.command, self.path, self.conn_id))
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0"))
+        return self.rfile.read(length) if length else b""
+
+    def _respond(self, status: int, body: bytes = b"", headers: Optional[Dict[str, str]] = None) -> None:
+        self.send_response(status)
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+
+class _ScriptedPutHandler(_CountingHandler):
+    """PUT handler driven by ``server.script``: entries are (status, etag) or
+    the string "drop" (close the connection without responding — simulates the
+    half-closed-socket failure mode behind the R2 bad-record-MAC incident)."""
+
+    def do_PUT(self) -> None:
+        self._read_body()
+        self._record()
+        srv: Any = self.server
+        with srv.lock:
+            entry = srv.script.pop(0) if srv.script else (200, '"etag"')
+        if entry == "drop":
+            self.close_connection = True
+            self.connection.close()
+            return
+        status, etag = entry
+        self._respond(status, headers={"ETag": etag} if etag else None)
+
+
+class _ProtocolHandler(_CountingHandler):
+    """Speaks just enough of the tensorhub presigned-upload protocol for a
+    full presigned_upload_file save: create -> part PUT(s) -> complete."""
+
+    def do_POST(self) -> None:
+        self._read_body()
+        self._record()
+        srv: Any = self.server
+        if self.path.endswith("/complete"):
+            self._respond(200, json.dumps({"published": []}).encode())
+            return
+        with srv.lock:
+            srv.save_serial += 1
+            n = srv.save_serial
+        body = json.dumps({
+            "upload_id": f"u{n}",
+            "part_urls": [f"{srv.base_url}/part/{n}"],
+            "part_size": srv.part_size,
+            "total_parts": 1,
+        }).encode()
+        self._respond(200, body)
+
+    def do_PUT(self) -> None:
+        self._read_body()
+        self._record()
+        self._respond(200, headers={"ETag": '"etag-put"'})
+
+
+def _serve_tls(handler: type, tls_cert: Tuple[Path, Path], **attrs: Any) -> Tuple[ThreadingHTTPServer, str]:
+    cert, key = tls_cert
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(str(cert), str(key))
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    server.lock = threading.Lock()
+    server.conn_serial = 0
+    server.requests = []
+    for k, v in attrs.items():
+        setattr(server, k, v)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    host, port = server.server_address[0], server.server_address[1]
+    base_url = f"https://{host}:{port}"
+    server.base_url = base_url
+    return server, base_url
+
+
+def _put_conn_ids(server: Any) -> List[int]:
+    with server.lock:
+        return [cid for (method, _p, cid) in server.requests if method == "PUT"]
+
+
+# --------------------------------------------------------------------------
+# Transport-level: PutPool reuse scoping
+# --------------------------------------------------------------------------
+
+
+def test_shared_pool_reuses_one_tls_connection_across_parts(
+    tmp_path: Path, tls_cert: Tuple[Path, Path], trust_local_cert: None
+) -> None:
+    src = tmp_path / "f.bin"
+    src.write_bytes(b"0123456789ab")
+
+    server, base = _serve_tls(
+        _ScriptedPutHandler, tls_cert, script=[(200, f'"e{i}"') for i in range(3)]
+    )
+    try:
+        with PutPool() as pool:
+            etags = [
+                upload_part_to_presigned_url(
+                    url=f"{base}/part/{i}", file_path=str(src),
+                    offset=4 * i, length=4, pool=pool,
+                )
+                for i in range(3)
+            ]
+    finally:
+        server.shutdown()
+
+    assert etags == ['"e0"', '"e1"', '"e2"']
+    conn_ids = _put_conn_ids(server)
+    assert len(conn_ids) == 3
+    assert len(set(conn_ids)) == 1  # ONE TLS handshake served all three parts
+
+
+def test_without_pool_every_put_pays_a_fresh_handshake(
+    tmp_path: Path, tls_cert: Tuple[Path, Path], trust_local_cert: None
+) -> None:
+    src = tmp_path / "f.bin"
+    src.write_bytes(b"0123456789ab")
+
+    server, base = _serve_tls(
+        _ScriptedPutHandler, tls_cert, script=[(200, '"e"')] * 3
+    )
+    try:
+        for i in range(3):
+            upload_part_to_presigned_url(
+                url=f"{base}/part/{i}", file_path=str(src), offset=4 * i, length=4,
+            )
+    finally:
+        server.shutdown()
+
+    conn_ids = _put_conn_ids(server)
+    assert len(conn_ids) == 3
+    assert len(set(conn_ids)) == 3  # fresh connection per PUT (pre-#385 behavior)
+
+
+def test_retry_never_rides_the_shared_pool_connection(
+    tmp_path: Path, tls_cert: Tuple[Path, Path], trust_local_cert: None
+) -> None:
+    """503 on the pooled first attempt -> the retry must run on a fresh pool
+    (new TLS connection): the bad-record-MAC guard, unchanged by #385."""
+    src = tmp_path / "f.bin"
+    src.write_bytes(b"payload!")
+
+    server, base = _serve_tls(
+        _ScriptedPutHandler, tls_cert, script=[(503, None), (200, '"recovered"')]
+    )
+    try:
+        with PutPool() as pool, patch("gen_worker._upload_transport.time.sleep"):
+            etag = upload_part_to_presigned_url(
+                url=f"{base}/part/0", file_path=str(src), offset=0, length=8, pool=pool,
+            )
+    finally:
+        server.shutdown()
+
+    assert etag == '"recovered"'
+    conn_ids = _put_conn_ids(server)
+    assert len(conn_ids) == 2
+    assert conn_ids[0] != conn_ids[1]
+
+
+def test_dropped_connection_discards_pool_and_retry_recovers(
+    tmp_path: Path, tls_cert: Tuple[Path, Path], trust_local_cert: None
+) -> None:
+    """Server kills the socket mid-request (the stale/half-closed-socket
+    failure shape). The pooled attempt fails, the pool discards its
+    connections, and the fresh-pool retry succeeds."""
+    src = tmp_path / "f.bin"
+    src.write_bytes(b"payload!")
+
+    server, base = _serve_tls(
+        _ScriptedPutHandler, tls_cert, script=["drop", (200, '"recovered"')]
+    )
+    try:
+        with PutPool() as pool, patch("gen_worker._upload_transport.time.sleep"):
+            etag = upload_part_to_presigned_url(
+                url=f"{base}/part/0", file_path=str(src), offset=0, length=8, pool=pool,
+            )
+            # After the failure the shared pool holds no poisoned socket: a
+            # subsequent first-attempt PUT opens a NEW connection.
+            etag2 = upload_part_to_presigned_url(
+                url=f"{base}/part/1", file_path=str(src), offset=0, length=8, pool=pool,
+            )
+    finally:
+        server.shutdown()
+
+    assert etag == '"recovered"'
+    assert etag2 == '"etag"'
+    conn_ids = _put_conn_ids(server)
+    assert len(conn_ids) == 3
+    assert conn_ids[0] != conn_ids[1]  # retry on a fresh connection
+
+
+# --------------------------------------------------------------------------
+# Save-level: presigned_upload_file scoping (integration)
+# --------------------------------------------------------------------------
+
+
+def test_save_reuses_hub_connection_and_never_crosses_saves(
+    tmp_path: Path, tls_cert: Tuple[Path, Path], trust_local_cert: None
+) -> None:
+    src = tmp_path / "img.webp"
+    src.write_bytes(b"w" * 4096)
+
+    server, base = _serve_tls(
+        _ProtocolHandler, tls_cert, save_serial=0, part_size=4096
+    )
+    try:
+        for _ in range(2):
+            result = presigned_upload_file(
+                file_path=src,
+                base_url=base,
+                endpoint_path="/api/v1/media/o/uploads",
+                headers={"Authorization": "Bearer t"},
+                create_payload={"ref": "img.webp"},
+                blake3_hex=blake3_hash_file(src),
+                size_bytes=4096,
+            )
+            assert result.meta == {"published": []}
+    finally:
+        server.shutdown()
+
+    with server.lock:
+        reqs = list(server.requests)
+
+    def save_conns(n: int) -> Tuple[int, int, int]:
+        # create for save n is the n-th plain /uploads POST
+        creates = [c for (m, p, c) in reqs if m == "POST" and not p.endswith("/complete")]
+        puts = [c for (m, p, c) in reqs if m == "PUT" and p == f"/part/{n}"]
+        completes = [c for (m, p, c) in reqs if m == "POST" and p == f"/api/v1/media/o/uploads/u{n}/complete"]
+        assert len(puts) == 1 and len(completes) == 1
+        return creates[n - 1], puts[0], completes[0]
+
+    c1, p1, f1 = save_conns(1)
+    c2, p2, f2 = save_conns(2)
+
+    # Within a save the hub control plane (create -> complete) rides ONE
+    # requests.Session connection.
+    assert c1 == f1
+    assert c2 == f2
+    # Nothing — hub or R2 — is ever reused across saves.
+    assert {c1, p1} & {c2, p2} == set()


### PR DESCRIPTION
Closes gw#385.

## What

Every asset save did create-session (hub RTT) + presigned PUT (R2) + complete (hub RTT), each on a fresh TLS connection. Connections are now scoped to ONE save (`presigned_upload_file` call) and torn down with it — never cross-request:

- **`_upload_transport.PutPool`** — save-scoped keepalive pool shared by FIRST attempts of the save's part PUTs. Retry attempts keep today's fresh-`PoolManager`-per-attempt behavior (the #13 `SSLV3_ALERT_BAD_RECORD_MAC` guard), and any transport failure discards the pool's connections so a poisoned socket can never serve another part.
- **Per-save `requests.Session`** for the hub control plane (create/complete/abort). Bare `requests.post` built a new Session — and a new connection — per call. Auth headers stay per-request, so worker JWT rotation never forces a new connection.

## Bad-record-MAC history (bounded, not repro'd — no R2 access from this machine)

`git log -S BAD_RECORD_MAC`: 1df8319 + 7efe9bd (2026-05-16 FLUX.2-klein-4B clone). Failure mode was a **process-global** requests pool whose sockets idled across a minutes-long, 64-PUT-in-flight clone until R2's edge half-closed them, with retries replaying the same poisoned socket. This pool (a) lives seconds and never crosses saves, (b) idles only ms between one save's parts, (c) is discarded on any failure while retries always get a fresh pool — worst case one retried attempt, the same recovery path as today.

## Measurement (local TLS server, 40 sequential 170KB PUTs through the real transport)

| path | p50 | p95 | total |
|---|---|---|---|
| PUT old (fresh pool per PUT) | 7.11ms | 10.39ms | 286ms |
| PUT new (save-scoped PutPool) | 1.33ms | 1.69ms | 58ms |
| ctrl old (bare requests.post, create+complete pair) | 92.9ms | 98.0ms | 3733ms |
| ctrl new (per-save Session) | 84.9ms | 91.4ms | 3423ms |

Localhost handshakes are ~ms, so this lower-bounds the win; live-pod WAN numbers (0.6-5s fresh-conn PUTs observed in #382) ride a later window.

## Tests

New `tests/test_upload_transport_tls.py`: real-TLS integration (self-signed cert, ssl-wrapped ThreadingHTTPServer tagging requests with per-connection serials) asserting one handshake across a save's parts, fresh handshake per retry, pool discard on dropped sockets, hub create→complete reuse, and zero reuse across saves. Full suite: 294 passed, 1 skipped.