### PR TITLE
feat(cli): standalone Hub-ref resolve + variant auto-selection (#379, #380)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.9.2"
+version = "0.10.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/invoke.py
+++ b/src/gen_worker/cli/invoke.py
@@ -145,6 +145,14 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
         help="Python module to import for schema (overrides [tool.gen_worker] main).",
     )
     p.add_argument(
+        "--variant", dest="variant", default=None,
+        help=(
+            "Resolve <function-name> to a declared `variants={}` row before "
+            "sending: a variant name, or 'auto' to pick the best fit for "
+            "this machine (needs the endpoint module importable locally)."
+        ),
+    )
+    p.add_argument(
         "--socket", dest="socket_path", default=DEFAULT_SOCKET_PATH,
         help=(
             "Unix domain socket of the running serve "
@@ -362,9 +370,32 @@ def _print_value(value: Any, pretty: bool) -> None:
     sys.stdout.flush()
 
 
+def _resolve_variant_name(args: argparse.Namespace) -> str:
+    """``--variant``: map <function-name> to the chosen variant row's fn_name
+    via the shared #380 selector (imports the endpoint module, no model load)."""
+    _root, mod = run_mod.load_endpoint_module(
+        config_path=args.config_path, module=args.module,
+    )
+    candidates = run_mod.discover_candidates(mod)
+    selected = run_mod.select_function_with_variant(
+        candidates,
+        cls_name=None,
+        method_name=args.function_name,
+        variant=args.variant,
+    )
+    return selected.fn_name
+
+
 def _handle_invoke(args: argparse.Namespace) -> int:
     stream = bool(getattr(args, "stream", False))
     try:
+        if getattr(args, "variant", None):
+            resolved_name = _resolve_variant_name(args)
+            if resolved_name != args.function_name:
+                sys.stderr.write(
+                    f"gen-worker invoke: variant -> {resolved_name}\n"
+                )
+                args.function_name = resolved_name
         payload = _resolve_payload(args)
         # Unix paths resolve to absolute; a tcp://host:port spec passes through.
         if transport.is_unix(args.socket_path):
@@ -388,6 +419,9 @@ def _handle_invoke(args: argparse.Namespace) -> int:
     except run_mod._UsageError as e:
         sys.stderr.write(f"gen-worker invoke: {e}\n")
         return run_mod.EXIT_USAGE
+    except run_mod._ModelResolutionError as e:
+        sys.stderr.write(f"gen-worker invoke: {e}\n")
+        return run_mod.EXIT_MODEL_RESOLUTION
 
     if not resp.get("ok", False):
         err = resp.get("error") or {}

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -62,15 +62,55 @@ def _function_input_schema(payload_type: Optional[type]) -> Dict[str, Any]:
     return s
 
 
+def _describe_resources(resources: Any) -> Dict[str, Any]:
+    """JSON-able view of a function's ``Resources`` declaration."""
+    if resources is None:
+        return {}
+    try:
+        d = msgspec.to_builtins(resources)
+        return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+def detected_capabilities() -> Dict[str, Any]:
+    """This machine's capabilities block (#380): SM, torch/cuda, installed
+    quant libs, free VRAM. Imports torch; loads no model."""
+    from ..models.hub_policy import detect_worker_capabilities
+    from ..models.memory import get_available_vram_gb
+
+    caps = detect_worker_capabilities()
+    out = caps.to_dict()
+    out["free_vram_gb"] = round(get_available_vram_gb(), 2)
+    return out
+
+
 def function_entries(
     candidates: List["_SelectedFunction"],
+    *,
+    detected: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """The stable ``functions`` array, shared by ``run --list`` and
-    ``serve --list-functions --json``."""
+    ``serve --list-functions --json``. With ``detected`` (the
+    ``detected_capabilities()`` block), each entry carries a ``fit`` verdict
+    (``fits | offload | incompatible``) computed from its ``Resources``."""
+    from ..models.hub_policy import TensorhubWorkerCapabilities, variant_fit
+
+    caps: Optional[TensorhubWorkerCapabilities] = None
+    free_gb = 0.0
+    if detected is not None:
+        caps = TensorhubWorkerCapabilities(
+            cuda_version=str(detected.get("cuda_version") or ""),
+            gpu_sm=int(detected.get("gpu_sm") or 0),
+            torch_version=str(detected.get("torch_version") or ""),
+            installed_libs=list(detected.get("installed_libs") or []),
+        )
+        free_gb = float(detected.get("free_vram_gb") or 0.0)
+
     out: List[Dict[str, Any]] = []
     for c in sorted(candidates, key=lambda c: c.fn_name):
         output_type = getattr(c, "output_type", None)
-        out.append({
+        entry: Dict[str, Any] = {
             "name": c.fn_name,
             "class": getattr(c.cls, "__name__", None) if c.cls is not None else None,
             "method": getattr(c, "attr_name", None) or None,
@@ -82,7 +122,20 @@ def function_entries(
                 param: describe_binding(binding)
                 for param, binding in (getattr(c, "bindings", {}) or {}).items()
             },
-        })
+        }
+        resources = getattr(c, "resources", None)
+        res_dict = _describe_resources(resources)
+        if res_dict:
+            entry["resources"] = res_dict
+        variant_of = str(getattr(c, "variant_of", "") or "")
+        if variant_of:
+            entry["variant_of"] = variant_of
+        if caps is not None:
+            fit, reason = variant_fit(resources, caps, free_gb)
+            entry["fit"] = fit
+            if reason:
+                entry["fit_reason"] = reason
+        out.append(entry)
     return out
 
 
@@ -96,14 +149,16 @@ def build_description(
         c.cls.__name__ for c in candidates if c.cls is not None
     })
     kinds = sorted({str(getattr(c, "kind", "") or "") for c in candidates if getattr(c, "kind", "")})
+    detected = detected_capabilities()
     return {
         "protocol_version": PROTOCOL_VERSION,
         "gen_worker_version": gen_worker_version(),
         "capabilities": list(CAPABILITIES),
+        "detected": detected,
         "endpoint": {
             "main_module": main_module,
             "kind": kinds[0] if len(kinds) == 1 else kinds,
             "classes": classes,
         },
-        "functions": function_entries(candidates),
+        "functions": function_entries(candidates, detected=detected),
     }

--- a/src/gen_worker/cli/protocol.py
+++ b/src/gen_worker/cli/protocol.py
@@ -27,6 +27,8 @@ PROTOCOL_VERSION = 1
 #   - "streaming"      : multi-frame streamed responses, `{"stream":true}` (#344)
 #   - "tcp_listen"     : `serve --listen tcp://host:port` (#347)
 #   - "serve_sidecar"  : machine-readable `.gen-worker.serve.json` handle (#349)
+#   - "hub_resolve"    : standalone Hub-ref resolve via TENSORHUB_URL (#379)
+#   - "variant_auto"   : `--variant auto` + listing fit verdicts (#380)
 CAPABILITIES: List[str] = [
     "describe",
     "list_functions",
@@ -35,6 +37,8 @@ CAPABILITIES: List[str] = [
     "streaming",
     "tcp_listen",
     "serve_sidecar",
+    "hub_resolve",
+    "variant_auto",
 ]
 
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -65,6 +65,15 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
         help="Method name to invoke (inferred when only one is registered).",
     )
     p.add_argument(
+        "--variant", dest="variant", default=None,
+        help=(
+            "Pick a declared `variants={}` row by name, or 'auto' to select "
+            "the best variant for this machine (SM/libraries gates, then the "
+            "largest precision that fits free VRAM; falls back to the base "
+            "binding + the offload ladder)."
+        ),
+    )
+    p.add_argument(
         "--payload", dest="payload", default=None,
         help="Inline JSON payload string. Mutually exclusive with --payload-file.",
     )
@@ -185,6 +194,8 @@ class _SelectedFunction:
         output_type: Optional[type],
         is_generator: bool,
         bindings: Dict[str, Any],
+        resources: Any = None,
+        variant_of: str = "",
     ) -> None:
         self.cls = cls
         self.attr_name = attr_name
@@ -195,6 +206,15 @@ class _SelectedFunction:
         self.output_type = output_type
         self.is_generator = is_generator
         self.bindings = bindings
+        self.resources = resources
+        # Non-empty when this function is one row of a `variants={}` fan-out:
+        # the shared python attr name (also the base function's fn_name).
+        self.variant_of = variant_of
+
+
+def _variant_names(cls: Optional[type]) -> set:
+    decl = getattr(cls, _ENDPOINT_ATTR, None) if cls is not None else None
+    return {v.name for v in (getattr(decl, "variants", ()) or ())}
 
 
 def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:
@@ -214,6 +234,8 @@ def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:
             output_type=es.output_type,
             is_generator=es.output_mode == "stream",
             bindings=dict(es.models),
+            resources=es.resources,
+            variant_of=es.attr_name if es.name in _variant_names(es.cls) else "",
         )
         for es in collect_from_namespace(mod)
     ]
@@ -285,6 +307,102 @@ def _select_function(
             f"specify --class and/or --method.\nmatches:{listing}"
         )
     return matches[0]
+
+
+def select_function_with_variant(
+    candidates: List[_SelectedFunction],
+    *,
+    cls_name: Optional[str],
+    method_name: Optional[str],
+    default_name: Optional[str] = None,
+    variant: Optional[str] = None,
+    emit: Optional[Callable[[Dict[str, Any]], None]] = None,
+) -> _SelectedFunction:
+    """``_select_function`` plus ``--variant`` resolution (#380).
+
+    With ``--variant``, the --class/--method filters select a variant GROUP
+    (base + `variants={}` rows sharing one attr name); the variant flag then
+    picks the row — by name, or ``auto`` via ``models.hub_policy``.
+    """
+    if not variant:
+        return _select_function(
+            candidates, cls_name=cls_name, method_name=method_name,
+            default_name=default_name,
+        )
+
+    from gen_worker.discovery.names import slugify_name
+
+    matches = list(candidates)
+    if cls_name:
+        matches = [c for c in matches if c.cls is not None and c.cls.__name__ == cls_name]
+    if method_name:
+        wanted = slugify_name(method_name)
+        matches = [c for c in matches if c.attr_name == method_name or c.fn_name == wanted]
+    groups: Dict[Tuple[Optional[type], str], List[_SelectedFunction]] = {}
+    for c in matches:
+        groups.setdefault((c.cls, c.attr_name), []).append(c)
+    if len(groups) != 1:
+        if len(groups) > 1 and not cls_name and not method_name and default_name:
+            wanted = slugify_name(default_name)
+            keyed = [g for g in groups.values() if any(m.fn_name == wanted or m.attr_name == wanted for m in g)]
+            if len(keyed) == 1:
+                groups = {(keyed[0][0].cls, keyed[0][0].attr_name): keyed[0]}
+        if len(groups) != 1:
+            names = sorted({c.fn_name for c in matches}) or ["(none)"]
+            raise _UsageError(
+                f"--variant needs exactly one function group; filters match "
+                f"{len(groups)} (functions: {', '.join(names)}). "
+                "Narrow with --class/--method."
+            )
+    group = next(iter(groups.values()))
+
+    if variant != "auto":
+        wanted = slugify_name(variant)
+        exact = [m for m in group if m.fn_name == wanted]
+        if len(exact) != 1:
+            avail = sorted(m.fn_name for m in group)
+            raise _UsageError(
+                f"--variant {variant!r} does not name a declared variant; "
+                f"available: {', '.join(avail)}"
+            )
+        return exact[0]
+
+    variant_rows = [m for m in group if m.variant_of]
+    base = next((m for m in group if not m.variant_of), None)
+    if not variant_rows:
+        # No variants declared — `--variant auto` degrades to plain selection.
+        if base is not None:
+            return base
+        raise _UsageError("--variant auto: the selected function has no variants")
+
+    from ..models.hub_policy import detect_worker_capabilities, select_variant
+    from ..models.memory import get_available_vram_gb
+
+    caps = detect_worker_capabilities()
+    free_gb = get_available_vram_gb()
+    choice = select_variant(
+        [(m.fn_name, m.resources) for m in variant_rows],
+        caps,
+        free_gb,
+        base=(base.fn_name, base.resources) if base is not None else None,
+    )
+    if choice is None:
+        raise _ModelResolutionError(
+            f"--variant auto: no variant of {group[0].attr_name!r} is "
+            f"compatible with this machine (SM{caps.gpu_sm}, "
+            f"{free_gb:.1f} GB VRAM free)"
+        )
+    if emit is not None:
+        emit({
+            "kind": "variant.selected",
+            "function": choice.name,
+            "fit": choice.fit,
+            "reason": choice.reason,
+            "gpu_sm": caps.gpu_sm,
+            "free_vram_gb": round(free_gb, 2),
+        })
+    picked = next(m for m in group if m.fn_name == choice.name)
+    return picked
 
 
 # --------------------------------------------------------------------------
@@ -386,6 +504,72 @@ class _ModelResolutionError(Exception):
     """Raised when a model binding cannot be resolved (exit 3)."""
 
 
+def _fetch_tensorhub_snapshot(
+    thref: Any, *, cache_dir: Path, emit: Callable[[Dict[str, Any]], None],
+) -> str:
+    """Resolve a Hub ref via th#560 and download its snapshot into the CAS.
+
+    One re-resolve retry on a presigned-URL expiry mid-download (the same
+    contract the orchestrator honors on ``url_expired``).
+    """
+    import asyncio
+
+    from ..models.cozy_snapshot import ensure_snapshot_async
+    from ..models.errors import UrlExpiredError
+    from ..models.hub_client import HubResolveError, resolve_repo
+
+    canonical = thref.canonical()
+
+    def _resolve() -> Any:
+        try:
+            return resolve_repo(thref)
+        except HubResolveError as e:
+            raise _ModelResolutionError(str(e)) from e
+
+    emit({"kind": "model_fetch.started", "ref": canonical, "provider": "tensorhub"})
+    resolved = _resolve()
+
+    # Already materialized under the resolved digest? No download.
+    snap_dir = cache_dir / "snapshots" / resolved.snapshot_digest
+    if snap_dir.exists():
+        emit({"kind": "model_fetch.completed", "ref": canonical,
+              "provider": "tensorhub", "local_dir": str(snap_dir)})
+        return str(snap_dir)
+
+    last_at = [0.0]
+
+    def _progress(done: int, total: Optional[int]) -> None:
+        now = time.monotonic()
+        if now - last_at[0] < 1.0 and (total is None or done < total):
+            return
+        last_at[0] = now
+        emit({"kind": "model_fetch.progress", "ref": canonical,
+              "provider": "tensorhub", "done_bytes": int(done),
+              "total_bytes": int(total) if total else None})
+
+    async def _download(res: Any) -> Path:
+        return await ensure_snapshot_async(
+            base_dir=cache_dir, ref=thref, resolved=res, progress=_progress,
+        )
+
+    try:
+        try:
+            snap = asyncio.run(_download(resolved))
+        except UrlExpiredError:
+            emit({"kind": "model_fetch.reresolve", "ref": canonical,
+                  "provider": "tensorhub", "reason": "url_expired"})
+            snap = asyncio.run(_download(_resolve()))
+    except _ModelResolutionError:
+        raise
+    except Exception as e:
+        raise _ModelResolutionError(
+            f"failed to download tensorhub snapshot for {canonical}: {e}"
+        ) from e
+    emit({"kind": "model_fetch.completed", "ref": canonical,
+          "provider": "tensorhub", "local_dir": str(snap)})
+    return str(snap)
+
+
 def _resolve_binding_to_ref(*, param_name: str, binding: Any) -> Tuple[str, str]:
     """Return ``(model_ref, provider)`` for one binding."""
     if isinstance(binding, BINDING_TYPES):
@@ -429,7 +613,8 @@ def _resolve_local_path(
         ) from e
 
     if parsed.provider == "tensorhub" and parsed.tensorhub and parsed.tensorhub.digest:
-        digest = parsed.tensorhub.digest
+        # Snapshot dirs are keyed by the bare hex digest (no algo prefix).
+        digest = parsed.tensorhub.digest.split(":", 1)[-1]
         snap_dir = cache_dir / "snapshots" / digest
         if snap_dir.exists():
             return str(snap_dir)
@@ -505,23 +690,20 @@ def _resolve_local_path(
         emit({"kind": "model_fetch.completed", "ref": parsed.modelscope.canonical(), "local_dir": str(local)})
         return str(local)
 
-    # Cozy refs that miss the CAS: not yet wired to tensorhub directly from
-    # the CLI (requires the presigned-manifest fetch that's owned by the
-    # orchestrator in production). Exit 3 with a clear pointer.
+    # Cozy refs that miss the CAS (#379): resolve standalone against
+    # tensorhub's public resolve route (th#560) and feed the shared
+    # cozy_snapshot downloader. TENSORHUB_URL selects the hub; TENSORHUB_TOKEN
+    # (optional) unlocks private repos. Offline stays CAS-only.
     if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
-        digest = parsed.tensorhub.digest or "(unresolved tag)"
         if offline:
             raise _ModelResolutionError(
                 f"--offline: tensorhub ref {parsed.tensorhub.canonical()} not in local "
-                f"CAS ({cache_dir}); warm the cache by running this endpoint "
-                "via the orchestrator at least once (or set TENSORHUB_CAS_DIR "
-                "to a path with the snapshot pre-seeded)."
+                f"CAS ({cache_dir}); warm the cache by running without "
+                "--offline once (or set TENSORHUB_CAS_DIR to a path with the "
+                "snapshot pre-seeded)."
             )
-        raise _ModelResolutionError(
-            f"tensorhub ref {parsed.tensorhub.canonical()} not in local CAS "
-            f"({cache_dir}). gen-worker run cannot fetch cozy refs from "
-            "tensorhub directly yet — invoke this endpoint via the "
-            "orchestrator once to populate the cache, then re-run."
+        return _fetch_tensorhub_snapshot(
+            parsed.tensorhub, cache_dir=cache_dir, emit=emit,
         )
 
     # Civitai refs: download the model-version files directly. Auth (for gated
@@ -1005,9 +1187,10 @@ def _run_via_warm_serve(
         config_path=args.config_path, module=args.module,
     )
     candidates = discover_candidates(mod)
-    selected = _select_function(
+    selected = select_function_with_variant(
         candidates, cls_name=args.cls_name, method_name=args.method_name,
         default_name=getattr(mod, "__name__", "").split(".", 1)[0],
+        variant=getattr(args, "variant", None),
     )
 
     raw_bytes = _apply_field_tokens(
@@ -1092,12 +1275,16 @@ def _run_inner(args: argparse.Namespace) -> int:
     )
 
     # 2. Discover routable functions on every @endpoint object.
+    from .local_context import _stderr_emitter as _emit_stderr
+
     candidates = discover_candidates(mod)
-    selected = _select_function(
+    selected = select_function_with_variant(
         candidates,
         cls_name=args.cls_name,
         method_name=args.method_name,
         default_name=getattr(mod, "__name__", "").split(".", 1)[0],
+        variant=getattr(args, "variant", None),
+        emit=_emit_stderr,
     )
 
     # Ergonomic `field=value` tokens -> payload bytes (coerced via the function's

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -949,11 +949,15 @@ def _serve_inner(args: argparse.Namespace) -> int:
     if getattr(args, "list_functions", False):
         if getattr(args, "json_output", False):
             # Thin alias of `gen-worker run --list`'s functions array — one
-            # shared builder, one shape.
-            from .listing import function_entries
+            # shared builder, one shape (incl. detected caps + fit verdicts).
+            from .listing import detected_capabilities, function_entries
 
+            detected = detected_capabilities()
             sys.stdout.write(
-                json.dumps({"functions": function_entries(candidates)}) + "\n"
+                json.dumps({
+                    "detected": detected,
+                    "functions": function_entries(candidates, detected=detected),
+                }) + "\n"
             )
             sys.stdout.flush()
             return run_mod.EXIT_OK

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
+from .refs import TensorhubRef
 
-# In-memory shape of an orchestrator-resolved cozy: ref. These used to be
-# populated by an HTTP resolve call against tensorhub from inside the worker;
-# now the orchestrator pre-resolves every cozy ref a job needs and ships the
-# manifest + presigned URLs via JobExecutionRequest.resolved_repos_by_id over
-# gRPC. The worker never talks to tensorhub's resolve endpoint directly.
+
+# In-memory shape of a resolved cozy: ref. PRODUCTION workers never resolve
+# these themselves — the orchestrator pre-resolves every cozy ref a job needs
+# and ships the manifest + presigned URLs via
+# JobExecutionRequest.resolved_repos_by_id over gRPC. STANDALONE clients
+# (gen-worker run/serve/prefetch under cozy, #379) resolve the same shape over
+# HTTP via ``resolve_repo`` against tensorhub's public resolve route (th#560).
 
 
 @dataclass(frozen=True)
@@ -24,3 +28,106 @@ class WorkerResolvedRepoFile:
 class WorkerResolvedRepo:
     snapshot_digest: str
     files: List[WorkerResolvedRepoFile]
+
+
+class HubResolveError(RuntimeError):
+    """Base for standalone tensorhub resolve failures."""
+
+
+class HubRepoNotFoundError(HubResolveError):
+    """404: unknown repo/tag/flavor OR a private repo the caller may not see
+    (the route deliberately never distinguishes these)."""
+
+
+class HubAuthError(HubResolveError):
+    """401/403: the supplied TENSORHUB_TOKEN was rejected."""
+
+
+def hub_base_url(base_url: Optional[str] = None) -> str:
+    return (base_url or os.getenv("TENSORHUB_URL") or "").strip().rstrip("/")
+
+
+def resolve_repo(
+    ref: TensorhubRef,
+    *,
+    base_url: Optional[str] = None,
+    token: Optional[str] = None,
+    timeout: float = 60.0,
+) -> WorkerResolvedRepo:
+    """Resolve a Hub ref against ``GET /api/v1/repos/:tenant/:name/resolve``.
+
+    Anonymous for public repos; bearer ``token`` (default ``TENSORHUB_TOKEN``)
+    for private. Returns the manifest + presigned GET URLs ready for
+    ``cozy_snapshot.ensure_snapshot_async``.
+    """
+    import requests
+
+    base = hub_base_url(base_url)
+    if not base:
+        raise HubResolveError(
+            "no tensorhub base URL: set TENSORHUB_URL (e.g. https://tensorhub.com)"
+        )
+    tok = (token or os.getenv("TENSORHUB_TOKEN") or "").strip()
+    headers = {"Authorization": f"Bearer {tok}"} if tok else {}
+    params: dict[str, str] = {}
+    if ref.digest:
+        params["digest"] = ref.digest
+    elif ref.tag:
+        params["tag"] = ref.tag
+    if ref.flavor:
+        params["flavor"] = ref.flavor
+
+    url = f"{base}/api/v1/repos/{ref.owner}/{ref.repo}/resolve"
+    try:
+        resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+    except requests.RequestException as e:
+        raise HubResolveError(f"tensorhub resolve failed for {ref.canonical()}: {e}") from e
+
+    if resp.status_code == 404:
+        raise HubRepoNotFoundError(
+            f"tensorhub repo {ref.canonical()} not found (unknown repo/tag/"
+            "flavor, or a private repo — set TENSORHUB_TOKEN for private pulls)"
+        )
+    if resp.status_code in (401, 403):
+        raise HubAuthError(
+            f"tensorhub rejected the token for {ref.canonical()} (HTTP {resp.status_code})"
+        )
+    if resp.status_code == 429:
+        raise HubResolveError(
+            f"tensorhub rate-limited the resolve for {ref.canonical()}; retry later"
+        )
+    if resp.status_code != 200:
+        raise HubResolveError(
+            f"tensorhub resolve for {ref.canonical()} returned HTTP {resp.status_code}"
+        )
+
+    try:
+        body = resp.json()
+    except ValueError as e:
+        raise HubResolveError(f"tensorhub resolve returned invalid JSON: {e}") from e
+
+    digest = str(body.get("snapshot_digest") or "").strip()
+    if digest.lower().startswith("blake3:"):
+        digest = digest[7:]
+    files: List[WorkerResolvedRepoFile] = []
+    for ent in body.get("files") or []:
+        if not isinstance(ent, dict):
+            continue
+        path = str(ent.get("path") or "").strip()
+        b3 = str(ent.get("blake3") or "").strip().lower()
+        if b3.startswith("blake3:"):
+            b3 = b3[7:]
+        u = str(ent.get("url") or "").strip() or None
+        if not path or not b3 or not u:
+            raise HubResolveError(
+                f"tensorhub resolve for {ref.canonical()}: manifest entry "
+                f"missing path/blake3/url ({ent.get('path')!r})"
+            )
+        files.append(WorkerResolvedRepoFile(
+            path=path, size_bytes=int(ent.get("size_bytes") or 0), blake3=b3, url=u,
+        ))
+    if not digest or not files:
+        raise HubResolveError(
+            f"tensorhub resolve for {ref.canonical()}: empty snapshot manifest"
+        )
+    return WorkerResolvedRepo(snapshot_digest=digest, files=files)

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -71,3 +71,102 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
         torch_version=torch_version,
         installed_libs=installed,
     )
+
+
+# ---------------------------------------------------------------------------
+# Variant auto-selection (#380) — pick the best routable variant for THIS
+# machine from `variants={name: (binding, Resources)}` declarations. Pure
+# logic over (Resources, capabilities, free VRAM); consumer CLIs (cozy) call
+# it through `run --list` / `--variant auto` instead of reimplementing
+# hardware policy in Go.
+# ---------------------------------------------------------------------------
+
+FIT_FITS = "fits"
+FIT_OFFLOAD = "offload"
+FIT_INCOMPATIBLE = "incompatible"
+
+
+@dataclass(frozen=True)
+class VariantChoice:
+    name: str
+    fit: str  # fits | offload
+    reason: str = ""
+
+
+def variant_fit(
+    resources: Any,
+    caps: TensorhubWorkerCapabilities,
+    free_vram_gb: float,
+) -> tuple[str, str]:
+    """Fit verdict for ONE function/variant's ``Resources`` on this machine.
+
+    - ``incompatible``: hard gates unmet (no CUDA GPU, compute_capability
+      above this GPU's SM, required quant libraries not installed).
+    - ``offload``: runnable, but declared vram_gb exceeds free VRAM — the
+      models/memory.py offload ladder carries it (slower).
+    - ``fits``: full-VRAM residency expected.
+    """
+    needs_gpu = bool(getattr(resources, "gpu", False))
+    req_cc = getattr(resources, "compute_capability", None)
+    libs = tuple(getattr(resources, "libraries", ()) or ())
+    if needs_gpu and caps.gpu_sm <= 0:
+        return FIT_INCOMPATIBLE, "no CUDA GPU detected"
+    if req_cc is not None and caps.gpu_sm < int(round(float(req_cc) * 10)):
+        return FIT_INCOMPATIBLE, (
+            f"requires compute capability >= {float(req_cc):g}, "
+            f"GPU is SM{caps.gpu_sm}"
+        )
+    missing = [l for l in libs if l not in (caps.installed_libs or [])]
+    if missing:
+        return FIT_INCOMPATIBLE, f"missing libraries: {', '.join(missing)}"
+    vram = getattr(resources, "vram_gb", None)
+    if vram is None or float(vram) <= float(free_vram_gb):
+        return FIT_FITS, ""
+    return FIT_OFFLOAD, (
+        f"declares {float(vram):g} GB VRAM, {float(free_vram_gb):.1f} GB free"
+    )
+
+
+def select_variant(
+    variants: List[tuple[str, Any]],
+    caps: TensorhubWorkerCapabilities,
+    free_vram_gb: float,
+    *,
+    base: Optional[tuple[str, Any]] = None,
+) -> Optional[VariantChoice]:
+    """Pick the best routable variant.
+
+    ``variants`` is ``[(fn_name, Resources), ...]``; ``base`` is the base
+    binding's row when the class declares one. Policy:
+      1. drop incompatible rows (SM / library gates);
+      2. among variants that FIT free VRAM, prefer the largest declared
+         vram_gb (bigger = higher-quality precision);
+      3. none fit → the base binding + the offload ladder;
+      4. no base → the smallest-VRAM compatible variant, offloaded;
+      5. nothing routable → None.
+    """
+    def _vram(res: Any) -> float:
+        v = getattr(res, "vram_gb", None)
+        return float(v) if v is not None else 0.0
+
+    compat: List[tuple[str, Any, str, str]] = []
+    for name, res in variants:
+        fit, reason = variant_fit(res, caps, free_vram_gb)
+        if fit != FIT_INCOMPATIBLE:
+            compat.append((name, res, fit, reason))
+
+    fitting = [row for row in compat if row[2] == FIT_FITS]
+    if fitting:
+        name, _res, fit, reason = max(fitting, key=lambda r: _vram(r[1]))
+        return VariantChoice(name=name, fit=fit, reason=reason)
+
+    if base is not None:
+        base_name, base_res = base
+        fit, reason = variant_fit(base_res, caps, free_vram_gb)
+        if fit != FIT_INCOMPATIBLE:
+            return VariantChoice(name=base_name, fit=fit, reason=reason)
+
+    if compat:
+        name, _res, fit, reason = min(compat, key=lambda r: _vram(r[1]))
+        return VariantChoice(name=name, fit=fit, reason=reason)
+    return None

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -1,0 +1,414 @@
+"""#379 client-side Hub resolve + #380 variant auto-selection.
+
+#379: ``_resolve_local_path`` on a tensorhub ref resolves against a REAL local
+HTTP server speaking tensorhub's public resolve route (th#560) and downloads
+blobs into the blake3 CAS via the shared cozy_snapshot path — no mocks on the
+unit under test, only a stdlib HTTP server standing in for the hub + R2.
+
+#380: ``select_variant`` policy (SM/library gates, VRAM ladder, base
+fallback), listing fit verdicts, and ``--variant auto`` selection.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, List, Optional, Tuple
+
+import msgspec
+import pytest
+from blake3 import blake3
+
+import gen_worker.cli.run as run_mod
+from gen_worker import RequestContext, endpoint
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.models.hub_client import (
+    HubRepoNotFoundError,
+    HubResolveError,
+    resolve_repo,
+)
+from gen_worker.models.hub_policy import (
+    TensorhubWorkerCapabilities,
+    select_variant,
+    variant_fit,
+)
+from gen_worker.models.refs import parse_model_ref
+
+
+# ---------------------------------------------------------------------------
+# Local hub double: resolve route + blob GETs over real HTTP
+# ---------------------------------------------------------------------------
+
+class _HubState:
+    def __init__(self) -> None:
+        self.blobs: Dict[str, bytes] = {}
+        self.snapshot_digest = ""
+        self.manifest: List[Dict[str, Any]] = []
+        self.resolves = 0
+        self.auth_headers: List[str] = []
+        self.status = 200
+        self.blob_status: Dict[str, int] = {}  # digest -> forced status once
+
+
+def _make_handler(state: _HubState, base_url_holder: List[str]):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_a: Any) -> None:
+            pass
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.startswith("/api/v1/repos/") and "/resolve" in self.path:
+                state.resolves += 1
+                state.auth_headers.append(self.headers.get("Authorization") or "")
+                if state.status != 200:
+                    self.send_response(state.status)
+                    self.end_headers()
+                    return
+                files = []
+                for ent in state.manifest:
+                    e = dict(ent)
+                    e["url"] = f"{base_url_holder[0]}/blobs/{e['blake3']}"
+                    files.append(e)
+                body = json.dumps({
+                    "tenant": "root", "name": "tiny", "tag": "latest",
+                    "snapshot_digest": state.snapshot_digest,
+                    "files": files,
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path.startswith("/blobs/"):
+                digest = self.path.rsplit("/", 1)[-1]
+                forced = state.blob_status.pop(digest, 0)
+                if forced:
+                    self.send_response(forced)
+                    self.end_headers()
+                    return
+                blob = state.blobs.get(digest)
+                if blob is None:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(blob)))
+                self.end_headers()
+                self.wfile.write(blob)
+                return
+            self.send_response(404)
+            self.end_headers()
+
+    return Handler
+
+
+@pytest.fixture()
+def local_hub():
+    state = _HubState()
+    holder: List[str] = [""]
+    srv = HTTPServer(("127.0.0.1", 0), _make_handler(state, holder))
+    holder[0] = f"http://127.0.0.1:{srv.server_port}"
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield holder[0], state
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _seed(state: _HubState, files: Dict[str, bytes]) -> None:
+    manifest = []
+    for path, data in files.items():
+        d = blake3(data).hexdigest()
+        state.blobs[d] = data
+        manifest.append({"path": path, "size_bytes": len(data), "blake3": d})
+    state.manifest = manifest
+    state.snapshot_digest = blake3(b"".join(sorted(files.values()))).hexdigest()
+
+
+def _events() -> Tuple[List[Dict[str, Any]], Any]:
+    seen: List[Dict[str, Any]] = []
+    return seen, seen.append
+
+
+# ---------------------------------------------------------------------------
+# #379 resolve → download → CAS
+# ---------------------------------------------------------------------------
+
+def test_hub_ref_resolves_and_lands_in_cas(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"unet/model.safetensors": b"weights-bytes", "config.json": b"{}"})
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.delenv("TENSORHUB_TOKEN", raising=False)
+
+    seen, emit = _events()
+    local = run_mod._resolve_local_path(
+        ref="root/tiny", provider="tensorhub", offline=False, emit=emit,
+    )
+    assert local.endswith(state.snapshot_digest)
+    snap = tmp_path / "snapshots" / state.snapshot_digest
+    assert (snap / "unet" / "model.safetensors").read_bytes() == b"weights-bytes"
+    assert (snap / "config.json").read_bytes() == b"{}"
+    # Blobs stored content-addressed.
+    d = blake3(b"weights-bytes").hexdigest()
+    assert (tmp_path / "blobs" / "blake3" / d[:2] / d[2:4] / d).exists()
+    # Anonymous pull: no Authorization header was sent.
+    assert state.auth_headers == [""]
+    kinds = [e.get("kind") for e in seen]
+    assert "model_fetch.started" in kinds and "model_fetch.completed" in kinds
+    assert all(e.get("provider") == "tensorhub" for e in seen)
+
+    # Second resolve is a no-download cache hit (snapshot dir short-circuits).
+    local2 = run_mod._resolve_local_path(
+        ref="root/tiny", provider="tensorhub", offline=False, emit=lambda e: None,
+    )
+    assert local2 == local
+
+
+def test_hub_token_sent_as_bearer(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"a.bin": b"aa"})
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.setenv("TENSORHUB_TOKEN", "oat_secret")
+    run_mod._resolve_local_path(
+        ref="root/tiny:latest", provider="tensorhub", offline=False, emit=lambda e: None,
+    )
+    assert state.auth_headers == ["Bearer oat_secret"]
+
+
+def test_hub_404_is_typed_not_found(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    state.status = 404
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    ref = parse_model_ref("root/ghost", provider="tensorhub").tensorhub
+    with pytest.raises(HubRepoNotFoundError, match="not found"):
+        resolve_repo(ref, base_url=base)
+    with pytest.raises(run_mod._ModelResolutionError, match="not found"):
+        run_mod._resolve_local_path(
+            ref="root/ghost", provider="tensorhub", offline=False, emit=lambda e: None,
+        )
+
+
+def test_hub_offline_is_cas_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.setenv("TENSORHUB_URL", "http://127.0.0.1:9")  # must not be dialed
+    with pytest.raises(run_mod._ModelResolutionError, match="--offline"):
+        run_mod._resolve_local_path(
+            ref="root/tiny", provider="tensorhub", offline=True, emit=lambda e: None,
+        )
+    # Digest-pinned ref whose snapshot IS pre-seeded works offline.
+    snap = tmp_path / "snapshots" / "abcd1234"
+    snap.mkdir(parents=True)
+    local = run_mod._resolve_local_path(
+        ref="root/tiny@blake3:abcd1234", provider="tensorhub", offline=True,
+        emit=lambda e: None,
+    )
+    assert local == str(snap)
+
+
+def test_hub_no_base_url_is_actionable(monkeypatch, tmp_path):
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.delenv("TENSORHUB_URL", raising=False)
+    with pytest.raises(run_mod._ModelResolutionError, match="TENSORHUB_URL"):
+        run_mod._resolve_local_path(
+            ref="root/tiny", provider="tensorhub", offline=False, emit=lambda e: None,
+        )
+
+
+def test_url_expired_triggers_one_reresolve(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"model.bin": b"expiring-blob"})
+    d = blake3(b"expiring-blob").hexdigest()
+    state.blob_status[d] = 403  # first GET: presign "expired"
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+
+    seen, emit = _events()
+    local = run_mod._resolve_local_path(
+        ref="root/tiny", provider="tensorhub", offline=False, emit=emit,
+    )
+    assert state.resolves == 2  # initial + one re-resolve
+    assert (tmp_path / "snapshots" / state.snapshot_digest / "model.bin").exists()
+    assert local.endswith(state.snapshot_digest)
+    assert any(e.get("kind") == "model_fetch.reresolve" for e in seen)
+
+
+def test_resolve_repo_flavor_and_digest_params(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"m.bin": b"fp8"})
+    ref = parse_model_ref("root/tiny#fp8", provider="tensorhub").tensorhub
+    assert ref.flavor == "fp8"
+    out = resolve_repo(ref, base_url=base)
+    assert out.snapshot_digest == state.snapshot_digest
+    assert out.files[0].url.startswith(base)
+
+
+# ---------------------------------------------------------------------------
+# #380 select_variant policy
+# ---------------------------------------------------------------------------
+
+_CAPS_4070 = TensorhubWorkerCapabilities(
+    cuda_version="12.8", gpu_sm=89, torch_version="2.11", installed_libs=["torchao"],
+)
+_CAPS_B200 = TensorhubWorkerCapabilities(
+    cuda_version="12.8", gpu_sm=100, torch_version="2.11", installed_libs=["torchao"],
+)
+_CAPS_CPU = TensorhubWorkerCapabilities(
+    cuda_version="", gpu_sm=0, torch_version="", installed_libs=[],
+)
+
+_FLUX_VARIANTS = [
+    ("flux-bf16", Resources(vram_gb=24)),
+    ("flux-fp8", Resources(vram_gb=14)),
+    ("flux-nvfp4", Resources(vram_gb=12, compute_capability=10.0)),
+]
+
+
+def test_sm_gate_rejects_nvfp4_on_sm89():
+    fit, reason = variant_fit(Resources(vram_gb=12, compute_capability=10.0), _CAPS_4070, 8.0)
+    assert fit == "incompatible" and "compute capability" in reason
+
+
+def test_library_gate():
+    fit, reason = variant_fit(Resources(vram_gb=4, libraries=("transformer_engine",)), _CAPS_4070, 8.0)
+    assert fit == "incompatible" and "transformer_engine" in reason
+
+
+def test_vram_ladder_picks_largest_fitting():
+    # 16 GB free on SM89: bf16 (24) offloads, fp8 (14) fits, nvfp4 SM-gated.
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 16.0)
+    assert choice is not None and choice.name == "flux-fp8" and choice.fit == "fits"
+    # 30 GB free: prefer the largest precision that fits.
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 30.0)
+    assert choice.name == "flux-bf16"
+    # SM100 with 13 GB free: nvfp4 unlocked and the only fit.
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_B200, 13.0)
+    assert choice.name == "flux-nvfp4"
+
+
+def test_base_fallback_below_every_floor():
+    # 8 GB free: nothing fits -> base binding + offload ladder.
+    choice = select_variant(
+        _FLUX_VARIANTS, _CAPS_4070, 8.0, base=("flux", Resources(vram_gb=24)),
+    )
+    assert choice.name == "flux" and choice.fit == "offload"
+    # No base declared -> smallest compatible variant, offloaded.
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 8.0)
+    assert choice.name == "flux-fp8" and choice.fit == "offload"
+
+
+def test_cpu_box_has_no_routable_gpu_variant():
+    assert select_variant(_FLUX_VARIANTS, _CAPS_CPU, 0.0) is None
+    fit, _ = variant_fit(Resources(), _CAPS_CPU, 0.0)
+    assert fit == "fits"  # CPU-only endpoints still fit
+
+
+# ---------------------------------------------------------------------------
+# #380 CLI surfaces: listing fit verdicts + --variant auto selection
+# ---------------------------------------------------------------------------
+
+class _VIn(msgspec.Struct):
+    prompt: str = ""
+
+
+class _VOut(msgspec.Struct):
+    ok: bool
+
+
+def _variant_module():
+    import types
+
+    mod = types.ModuleType("_test_variants")
+
+    @endpoint(
+        kind="inference",
+        resources=Resources(vram_gb=24),
+        models={"pipeline": HF("org/base")},
+        variants={
+            "gen-fp8": (HF("org/base-fp8"), Resources(vram_gb=14)),
+            "gen-nvfp4": (HF("org/base-nvfp4"), Resources(vram_gb=12, compute_capability=10.0)),
+        },
+    )
+    class Gen:
+        def setup(self, pipeline: object) -> None:
+            pass
+
+        def generate(self, ctx: RequestContext, payload: _VIn) -> _VOut:
+            return _VOut(ok=True)
+
+    mod.Gen = Gen
+    return mod
+
+
+def _patched_hw(monkeypatch, *, sm: int, free_gb: float, libs=()):  # helpers
+    import gen_worker.models.hub_policy as hp
+    import gen_worker.models.memory as mem
+
+    caps = TensorhubWorkerCapabilities(
+        cuda_version="12.8" if sm else "", gpu_sm=sm,
+        torch_version="2.11", installed_libs=list(libs),
+    )
+    monkeypatch.setattr(hp, "detect_worker_capabilities", lambda **_k: caps)
+    monkeypatch.setattr(mem, "get_available_vram_gb", lambda *a, **k: free_gb)
+
+
+def test_listing_carries_fit_and_variant_of(monkeypatch):
+    from gen_worker.cli.listing import build_description
+
+    _patched_hw(monkeypatch, sm=89, free_gb=16.0)
+    mod = _variant_module()
+    candidates = run_mod.discover_candidates(mod)
+    doc = build_description(main_module="_test_variants", candidates=candidates)
+
+    assert doc["detected"]["gpu_sm"] == 89
+    assert doc["detected"]["free_vram_gb"] == 16.0
+    by_name = {f["name"]: f for f in doc["functions"]}
+    assert set(by_name) == {"generate", "gen-fp8", "gen-nvfp4"}
+    assert by_name["generate"]["fit"] == "offload"          # 24 GB > 16 free
+    assert "variant_of" not in by_name["generate"]
+    assert by_name["gen-fp8"]["fit"] == "fits"
+    assert by_name["gen-fp8"]["variant_of"] == "generate"
+    assert by_name["gen-nvfp4"]["fit"] == "incompatible"
+    assert by_name["gen-nvfp4"]["resources"]["vram_gb"] == 12.0
+
+
+def test_variant_auto_picks_fp8_on_sm89(monkeypatch):
+    _patched_hw(monkeypatch, sm=89, free_gb=16.0)
+    mod = _variant_module()
+    candidates = run_mod.discover_candidates(mod)
+    picked = run_mod.select_function_with_variant(
+        candidates, cls_name=None, method_name="generate",
+        default_name=None, variant="auto",
+    )
+    assert picked.fn_name == "gen-fp8"
+
+
+def test_variant_auto_base_fallback_below_floor(monkeypatch):
+    _patched_hw(monkeypatch, sm=89, free_gb=8.0)
+    mod = _variant_module()
+    candidates = run_mod.discover_candidates(mod)
+    picked = run_mod.select_function_with_variant(
+        candidates, cls_name=None, method_name="generate",
+        default_name=None, variant="auto",
+    )
+    assert picked.fn_name == "generate"  # base + offload ladder
+
+
+def test_variant_by_name_and_unknown(monkeypatch):
+    mod = _variant_module()
+    candidates = run_mod.discover_candidates(mod)
+    picked = run_mod.select_function_with_variant(
+        candidates, cls_name=None, method_name="generate",
+        default_name=None, variant="gen-fp8",
+    )
+    assert picked.fn_name == "gen-fp8"
+    with pytest.raises(run_mod._UsageError, match="available"):
+        run_mod.select_function_with_variant(
+            candidates, cls_name=None, method_name="generate",
+            default_name=None, variant="nope",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes gen-worker #379 + #380 (tracker).

## #379 client-side Hub-ref resolve
- `models/hub_client.resolve_repo(ref, base_url=TENSORHUB_URL, token=TENSORHUB_TOKEN)` against tensorhub's public resolve route (th#560, merged as tensorhub PR #113) → `WorkerResolvedRepo` (manifest + presigned R2 GETs). Typed errors: not-found (404, incl. flavor-missing), auth (401/403), rate-limited (429).
- `cli/run.py` tensorhub branch: exit-3 stub → resolve → shared `cozy_snapshot` download into the `TENSORHUB_CACHE_DIR` blake3 CAS; `prefetch`/`serve` inherit (progress events carry provider=tensorhub, throttled `model_fetch.progress`). One re-resolve retry on `url_expired`. `--offline` stays CAS-only with actionable miss errors. Fixed digest-pinned CAS lookup (`blake3:` prefix vs bare-hex snapshot dirs).
- Production worker path untouched (orchestrator still pre-resolves over gRPC).

## #380 variant auto-selection
- `hub_policy.variant_fit()` + `select_variant()`: SM/compute-capability + quant-library gates, then largest-precision variant fitting free VRAM; below every floor → base binding + models/memory.py offload ladder; no base → smallest compatible variant offloaded.
- `run --list` / `serve --list-functions --json`: top-level `detected` block (gpu_sm, cuda/torch, installed libs, free_vram_gb) + per-function `resources`, `variant_of`, `fit`/`fit_reason`.
- `run`/`invoke` `--variant <name|auto>` resolve before setup().
- Capabilities += `hub_resolve`, `variant_auto`; version 0.9.2 → 0.10.0.

## Tests
- New `tests/test_hub_resolve_and_variants.py` (16 tests): real local HTTP hub double (resolve + blob GETs) → CAS blobs blake3-verified, anonymous vs bearer, 404 typed, offline posture, url_expired re-resolve; select_variant matrix (SM89 vs SM100, library gate, VRAM ladder, base fallback, CPU box); listing fit verdicts; --variant auto/name selection.
- Full suite: 321 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)