### PR TITLE
feat(models): snapshot wins over provider-direct download (mirror-first, tensorhub #557)

### DIFF
--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
 from .cache_paths import tensorhub_cas_dir
-from .refs import HuggingFaceRef, parse_model_ref
+from .refs import HuggingFaceRef, TensorhubRef, parse_model_ref
 
 logger = logging.getLogger("gen_worker.download")
 
@@ -138,6 +138,24 @@ def build_provider_index_from_manifest(manifest: Optional[Mapping[str, Any]]) ->
 # ---------------------------------------------------------------------------
 
 
+def _snapshot_ref(parsed: Any, raw: str) -> TensorhubRef:
+    """Ref identity for a snapshot download. Snapshot trees are addressed by
+    digest, so for non-tensorhub providers (mirror-first refs) this only names
+    the download in logs."""
+    if parsed.tensorhub is not None:
+        return parsed.tensorhub
+    if parsed.hf is not None:
+        owner, _, repo = parsed.hf.repo_id.partition("/")
+        return TensorhubRef(owner=owner, repo=repo)
+    if parsed.civitai is not None:
+        return TensorhubRef(owner="civitai", repo=parsed.civitai.model_id)
+    if parsed.modelscope is not None:
+        owner, _, repo = parsed.modelscope.repo_id.partition("/")
+        return TensorhubRef(owner=owner, repo=repo)
+    owner, _, repo = raw.partition("/")
+    return TensorhubRef(owner=owner or "unknown", repo=repo or raw)
+
+
 async def ensure_local(
     ref: str,
     *,
@@ -152,28 +170,37 @@ async def ensure_local(
 ) -> Path:
     """Materialize ``ref`` on disk; return its local path.
 
-    ``snapshot`` (tensorhub only) is the orchestrator-resolved manifest — a
-    mapping with ``snapshot_digest`` + ``files``/``entries`` carrying presigned
-    URLs or transfer grants. hf/civitai/modelscope refs need none.
+    ``snapshot`` is the orchestrator-resolved manifest — a mapping with
+    ``snapshot_digest`` + ``files``/``entries`` carrying presigned URLs or
+    transfer grants. The orchestrator is the only resolver: when it ships a
+    snapshot for a ref — including an hf/civitai binding ref resolved through
+    a platform mirror under mirror-first (tensorhub #557) — the snapshot is
+    authoritative and the bytes come from tensorhub-CAS, never the upstream
+    registry. Refs without a snapshot fall back to their provider's direct
+    download (hf/civitai/modelscope) or fail retryably (tensorhub).
     """
     base = Path(cache_dir) if cache_dir is not None else tensorhub_cas_dir()
     prov = provider or lookup_provider_for_ref(ref)
     parsed = parse_model_ref(ref, provider=prov)
 
-    if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
-        if snapshot is None:
-            # Hub-side residency bug (the orchestrator failed to pre-resolve),
-            # not bad client input — RETRYABLE, never a client-visible 400.
-            from ..api.errors import RetryableError
-
-            raise RetryableError(
-                f"tensorhub ref {ref!r} needs an orchestrator-resolved snapshot "
-                "and none was provided"
-            )
+    if snapshot is not None:
         from .cozy_snapshot import ensure_snapshot_async
 
         return await ensure_snapshot_async(
-            base_dir=base, ref=parsed.tensorhub, resolved=snapshot, progress=progress,
+            base_dir=base,
+            ref=_snapshot_ref(parsed, ref),
+            resolved=snapshot,
+            progress=progress,
+        )
+
+    if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
+        # Hub-side residency bug (the orchestrator failed to pre-resolve),
+        # not bad client input — RETRYABLE, never a client-visible 400.
+        from ..api.errors import RetryableError
+
+        raise RetryableError(
+            f"tensorhub ref {ref!r} needs an orchestrator-resolved snapshot "
+            "and none was provided"
         )
 
     if parsed.provider == "hf" and parsed.hf is not None:

--- a/tests/test_mirror_first_snapshot.py
+++ b/tests/test_mirror_first_snapshot.py
@@ -1,0 +1,93 @@
+"""Mirror-first serving (tensorhub #557): an orchestrator-shipped snapshot is
+authoritative for ANY provider. An hf/civitai binding ref that arrives with a
+resolved snapshot (its platform mirror, presigned R2) must download through the
+tensorhub-CAS snapshot machinery and never touch the upstream registry; refs
+without a snapshot keep their provider-direct path."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import gen_worker.models.cozy_snapshot as snap_mod
+import gen_worker.models.download as dl_mod
+from gen_worker.models.download import ensure_local
+
+_DIGEST = "12" * 32
+
+
+def _resolved() -> dict:
+    return {
+        "snapshot_digest": _DIGEST,
+        "files": [{
+            "path": "model_index.json",
+            "size_bytes": 4,
+            "blake3": "cd" * 32,
+            "url": "http://r2.invalid/presigned",
+        }],
+    }
+
+
+@pytest.fixture()
+def fake_blob(monkeypatch):
+    """Stub the CAS blob leaf; poison provider-direct paths so any upstream
+    contact fails the test loudly."""
+    async def _fake_download(url: str, dst: Path, expected_size: int, expected_blake3: str, on_bytes=None) -> None:
+        assert url == "http://r2.invalid/presigned"
+        dst.write_bytes(b"mock")
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _fake_download)
+
+    def _upstream_forbidden(*a, **kw):
+        raise AssertionError("upstream registry contacted despite resolved snapshot")
+
+    monkeypatch.setattr(dl_mod, "download_hf", _upstream_forbidden)
+    monkeypatch.setattr(dl_mod, "download_civitai", _upstream_forbidden)
+    snap_mod._SNAP_ENTRIES.clear()
+
+
+def test_hf_ref_with_snapshot_downloads_from_cas(tmp_path: Path, fake_blob) -> None:
+    out = asyncio.run(ensure_local(
+        "black-forest-labs/FLUX.1-dev",
+        provider="hf",
+        snapshot=_resolved(),
+        cache_dir=tmp_path,
+    ))
+    assert (out / "model_index.json").read_bytes() == b"mock"
+    assert out.name == _DIGEST  # digest-addressed snapshot tree
+
+
+def test_civitai_ref_with_snapshot_downloads_from_cas(tmp_path: Path, fake_blob) -> None:
+    out = asyncio.run(ensure_local(
+        "993999",
+        provider="civitai",
+        snapshot=_resolved(),
+        cache_dir=tmp_path,
+    ))
+    assert (out / "model_index.json").read_bytes() == b"mock"
+
+
+def test_hf_ref_without_snapshot_stays_provider_direct(tmp_path: Path, monkeypatch) -> None:
+    sentinel = tmp_path / "hf-direct"
+
+    def _fake_hf(parsed, **kw):
+        sentinel.mkdir()
+        return sentinel
+
+    monkeypatch.setattr(dl_mod, "download_hf", _fake_hf)
+    out = asyncio.run(ensure_local(
+        "owner/repo",
+        provider="hf",
+        snapshot=None,
+        cache_dir=tmp_path,
+    ))
+    assert out == sentinel
+
+
+def test_tensorhub_ref_without_snapshot_is_retryable(tmp_path: Path) -> None:
+    from gen_worker.api.errors import RetryableError
+
+    with pytest.raises(RetryableError):
+        asyncio.run(ensure_local("acme/checkpoint", provider="tensorhub", cache_dir=tmp_path))


### PR DESCRIPTION
Worker counterpart of tensorhub#115 (mirror-first serving default).

`ensure_local` now treats an orchestrator-resolved snapshot as authoritative for ANY provider: hf/civitai binding refs whose release resolved through a platform mirror download from tensorhub-CAS (presigned R2, blake3-verified, digest-pinned) and never contact the upstream registry. No snapshot = provider-direct path unchanged (old stacks unaffected).

Tests: 315 passed, 2 skipped (full suite). New tests/test_mirror_first_snapshot.py: hf+civitai refs with snapshots download via CAS with upstream paths poisoned; hf without snapshot stays provider-direct; tensorhub without snapshot stays retryable.