### PR TITLE
fix(cli): CAS dir env fallback + offline tag-ref memory (#379 follow-up)

### DIFF
--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -504,6 +504,16 @@ class _ModelResolutionError(Exception):
     """Raised when a model binding cannot be resolved (exit 3)."""
 
 
+def _hub_ref_map_path(cache_dir: Path, thref: Any) -> Path:
+    """CAS-local memory of tag->snapshot resolutions, so a previously-fetched
+    tag ref keeps working offline: cas/refs/<owner>/<repo>/<tag>[#flavor]."""
+    name = str(thref.tag or "latest")
+    if thref.flavor:
+        name += "#" + str(thref.flavor)
+    safe = "".join(ch if (ch.isalnum() or ch in "._#-") else "_" for ch in name)
+    return cache_dir / "refs" / str(thref.owner) / str(thref.repo) / safe
+
+
 def _fetch_tensorhub_snapshot(
     thref: Any, *, cache_dir: Path, emit: Callable[[Dict[str, Any]], None],
 ) -> str:
@@ -532,6 +542,7 @@ def _fetch_tensorhub_snapshot(
     # Already materialized under the resolved digest? No download.
     snap_dir = cache_dir / "snapshots" / resolved.snapshot_digest
     if snap_dir.exists():
+        _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
         emit({"kind": "model_fetch.completed", "ref": canonical,
               "provider": "tensorhub", "local_dir": str(snap_dir)})
         return str(snap_dir)
@@ -565,6 +576,7 @@ def _fetch_tensorhub_snapshot(
         raise _ModelResolutionError(
             f"failed to download tensorhub snapshot for {canonical}: {e}"
         ) from e
+    _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
     emit({"kind": "model_fetch.completed", "ref": canonical,
           "provider": "tensorhub", "local_dir": str(snap)})
     return str(snap)
@@ -599,9 +611,8 @@ def _resolve_local_path(
     from ..models.cache_paths import tensorhub_cas_dir
     from ..models.refs import parse_model_ref
 
-    cache_dir = Path(os.getenv("TENSORHUB_CAS_DIR", "")) or tensorhub_cas_dir()
-    if not isinstance(cache_dir, Path):
-        cache_dir = Path(cache_dir)
+    env_cas = (os.getenv("TENSORHUB_CAS_DIR") or "").strip()
+    cache_dir = Path(env_cas) if env_cas else Path(tensorhub_cas_dir())
 
     # Decode the bare ref into typed parts using the explicit provider.
     # No string-prefix sniffing — provider is the source of truth.
@@ -696,6 +707,12 @@ def _resolve_local_path(
     # (optional) unlocks private repos. Offline stays CAS-only.
     if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
         if offline:
+            # Tag refs: a previous online resolve remembered tag->digest.
+            ref_map = _hub_ref_map_path(cache_dir, parsed.tensorhub)
+            if ref_map.exists():
+                snap = cache_dir / "snapshots" / ref_map.read_text().strip()
+                if snap.exists():
+                    return str(snap)
             raise _ModelResolutionError(
                 f"--offline: tensorhub ref {parsed.tensorhub.canonical()} not in local "
                 f"CAS ({cache_dir}); warm the cache by running without "
@@ -769,6 +786,15 @@ def _resolve_local_path(
     raise _ModelResolutionError(
         f"unsupported model ref: {ref!r} (provider={provider!r})"
     )
+
+
+def _remember_hub_ref(cache_dir: Path, thref: Any, digest: str) -> None:
+    try:
+        p = _hub_ref_map_path(cache_dir, thref)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(digest)
+    except OSError:
+        pass
 
 
 def _resolve_models_for_setup(

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -211,6 +211,27 @@ def test_hub_offline_is_cas_only(monkeypatch, tmp_path):
     assert local == str(snap)
 
 
+def test_hub_offline_reuses_remembered_tag_ref(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"w.bin": b"tag-ref-weights"})
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    online = run_mod._resolve_local_path(
+        ref="root/tiny:latest", provider="tensorhub", offline=False, emit=lambda e: None,
+    )
+    # Now fully offline (hub unreachable): the tag->digest memory serves it.
+    monkeypatch.setenv("TENSORHUB_URL", "http://127.0.0.1:9")
+    offline = run_mod._resolve_local_path(
+        ref="root/tiny:latest", provider="tensorhub", offline=True, emit=lambda e: None,
+    )
+    assert offline == online
+    # A never-fetched tag still misses with the typed error.
+    with pytest.raises(run_mod._ModelResolutionError, match="--offline"):
+        run_mod._resolve_local_path(
+            ref="root/tiny:other", provider="tensorhub", offline=True, emit=lambda e: None,
+        )
+
+
 def test_hub_no_base_url_is_actionable(monkeypatch, tmp_path):
     monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
     monkeypatch.delenv("TENSORHUB_URL", raising=False)


### PR DESCRIPTION
Two fixes surfaced by live e2e against a local tensorhub:

- `Path(os.getenv("TENSORHUB_CAS_DIR", ""))` is truthy even when the env is unset (`Path('')` == `.`), so `_resolve_local_path` wrote the CAS into the endpoint cwd instead of `tensorhub_cas_dir()`.
- Hub TAG refs had no offline path (only digest-pinned refs could hit the CAS). Successful resolves now record tag→snapshot-digest under `cas/refs/<owner>/<repo>/<tag>[#flavor]`; `--offline` consults it and still raises the typed miss for never-fetched refs.

Live verification: anonymous `gen-worker prefetch` of a seeded public repo → blake3-verified blobs in the CAS; offline prefetch/resolve reuse; cross-repo blob dedup (2 repos sharing a VAE blob → stored once). Full suite 322 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)