### PR TITLE
fix(cozy-convert): source missing single-file components from the family config repo (e2e #112)

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/repackage.py
+++ b/packages/cozy_convert/src/cozy_convert/repackage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -238,10 +239,38 @@ def _repackage_torch_dtype(dtype: str | None) -> Any:
     return torch_mod.bfloat16
 
 
+# diffusers wraps SingleFileComponentError with a remedy snippet naming both
+# the component and its class: "{name} = {class_name}.from_pretrained('...')".
+_MISSING_COMPONENT_RE = re.compile(r"(\w+) = (\w+)\.from_pretrained\('\.\.\.'\)")
+
+
+def _load_component_from_config_repo(
+    config: str, name: str, class_name: str, torch_dtype: Any
+) -> Any:
+    """Load a pipeline component the checkpoint doesn't carry from the family's
+    config repo. DiT-only fine-tunes (common on civitai for z-image) ship no
+    text-encoder/VAE weights — sourcing them from the base repo is exactly the
+    CAS dedup story: the fine-tune tree stores only its denoiser."""
+    import importlib
+
+    comp_cls = None
+    for lib in ("transformers", "diffusers"):
+        comp_cls = getattr(importlib.import_module(lib), class_name, None)
+        if comp_cls is not None:
+            break
+    if comp_cls is None:
+        raise ConversionImplementationError(f"component_class_unavailable:{class_name}")
+    try:
+        return comp_cls.from_pretrained(config, subfolder=name, torch_dtype=torch_dtype)
+    except TypeError:  # non-torch components (tokenizers etc.) reject torch_dtype
+        return comp_cls.from_pretrained(config, subfolder=name)
+
+
 def _load_singlefile_pipeline(
     *, input_path: Path, pipeline_class: str, config: str | None, torch_dtype: Any,
 ) -> Any:
     import diffusers
+    from diffusers.loaders.single_file import SingleFileComponentError
 
     cls = getattr(diffusers, pipeline_class, None)
     if cls is None:
@@ -252,14 +281,35 @@ def _load_singlefile_pipeline(
         kwargs["config"] = config
 
     if hasattr(cls, "from_single_file"):
-        return cls.from_single_file(str(input_path), **kwargs)
+        loader = cls.from_single_file
+    else:
+        from diffusers.loaders.single_file import FromSingleFileMixin
 
-    from diffusers.loaders.single_file import FromSingleFileMixin
+        fn = getattr(FromSingleFileMixin.from_single_file, "__func__", None)
+        if fn is None:
+            raise ValueError(f"pipeline_not_implemented:{pipeline_class}")
 
-    fn = getattr(FromSingleFileMixin.from_single_file, "__func__", None)
-    if fn is None:
-        raise ValueError(f"pipeline_not_implemented:{pipeline_class}")
-    return fn(cls, str(input_path), **kwargs)
+        def loader(path: str, **kw: Any) -> Any:
+            return fn(cls, path, **kw)
+
+    # Components missing from the checkpoint are pulled from the config repo
+    # (bounded: a pipeline has a handful of components).
+    for _ in range(6):
+        try:
+            return loader(str(input_path), **kwargs)
+        except SingleFileComponentError as exc:
+            if not config:
+                raise
+            m = _MISSING_COMPONENT_RE.search(str(exc))
+            if m is None or m.group(1) in kwargs:
+                raise
+            name, class_name = m.group(1), m.group(2)
+            kwargs[name] = _load_component_from_config_repo(
+                config, name, class_name, torch_dtype
+            )
+    raise ConversionImplementationError(
+        f"singlefile_missing_component_loop:{pipeline_class}:{config}"
+    )
 
 
 def singlefile_to_diffusers(

--- a/packages/cozy_convert/tests/test_repackage_families.py
+++ b/packages/cozy_convert/tests/test_repackage_families.py
@@ -229,3 +229,23 @@ def test_civitai_base_model_beats_filename_tokens() -> None:
     assert _resolve_civitai_family("other", "flux") == "flux"
     assert _resolve_civitai_family("other", "unknown") == "other"
     assert _resolve_civitai_family("", "unknown") == ""
+
+
+def test_missing_component_error_parse() -> None:
+    """moody-pro-mix-zit regression (e2e #112): DiT-only single-file checkpoints
+    must source absent components from the family config repo. The component
+    name+class ride in diffusers' SingleFileComponentError remedy snippet."""
+    from cozy_convert.repackage import _MISSING_COMPONENT_RE
+
+    msg = (
+        "Failed to load Qwen3Model. Weights for this component appear to be "
+        "missing in the checkpoint.\n"
+        "Please load the component before passing it in as an argument to "
+        "`from_single_file`.\n\n"
+        "text_encoder = Qwen3Model.from_pretrained('...')\n"
+        "pipe = ZImagePipeline.from_single_file(<checkpoint path>, "
+        "text_encoder=text_encoder)\n\n"
+    )
+    m = _MISSING_COMPONENT_RE.search(msg)
+    assert m is not None
+    assert (m.group(1), m.group(2)) == ("text_encoder", "Qwen3Model")


### PR DESCRIPTION
DiT-only civitai single-file checkpoints (both bf16 z-image fine-tunes in the launch catalog: moody-pro-mix-zit, pornmaster-zit) fail `singlefile_to_diffusers` with `SingleFileComponentError: Failed to load Qwen3Model...` — the checkpoint carries no text-encoder weights.

Fix: parse the component name+class out of diffusers' remedy snippet, load that component from the attempt's config repo (`Tongyi-MAI/Z-Image-Turbo` etc.), and retry `from_single_file` with it passed explicitly. Bounded loop handles multiple missing components (TE, VAE, ...).

This is the CAS-dedup-optimal outcome: the fine-tune's split tree carries base-identical TE/VAE bytes and only its own DiT.

Live evidence: J10 zimage batch, requests 85e5b17a / 5fe77164 (JOB_STATUS_FATAL). Local repro: TE-stripped SDXL single-file splits clean through the new path; fallback TE tensors byte-match the config repo's fp16 cast; slow tokenizer files present (transformers 4.57.6 env). 102 cozy_convert tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)