### PR TITLE
feat(models): quantize= on model bindings — runtime quantization lane (gw#389, th#546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ class Generate:
         return Output(text=ctx.save_image(image).ref)
 ```
 
-Bindings: `HF(id, revision=, dtype=, subfolder=, files=)`,
-`Hub(ref, tag=, flavor=)`, `Civitai(id, version=)`, `ModelScope(id, ...)`.
+Bindings: `HF(id, revision=, dtype=, subfolder=, files=, quantize=)`,
+`Hub(ref, tag=, flavor=, quantize=)`, `Civitai(id, version=)`, `ModelScope(id, ...)`.
 The slot name comes from the `models={}` key or the `setup()` parameter —
-never a constructor argument.
+never a constructor argument. `quantize="int8"|"nf4"|"fp4"|"int8-torchao"|
+"int4-torchao"|"fp8-torchao"` applies runtime quantization to the denoiser at
+load time (ignored with a warning on CPU-only hosts).
 
 Multi-variant endpoints (`bf16`/`fp8`/... checkpoints with different VRAM
 envelopes) declare `variants={name: (binding, Resources)}` — one handler body,

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -63,13 +63,22 @@ The slot name is the `models={}` key (or, with the single-binding `model=`
 shorthand, the `setup()` parameter name). It is never a constructor argument.
 
 ```python
-HF("owner/repo", revision=..., dtype=..., subfolder=..., files=(...))
-Hub("owner/repo", tag="prod", flavor="")     # tensorhub
+HF("owner/repo", revision=..., dtype=..., subfolder=..., files=(...), quantize=...)
+Hub("owner/repo", tag="prod", flavor="", quantize="")   # tensorhub
 Civitai("123456", version="789")             # civitai model id
 ModelScope("owner/repo", revision=..., files=(...))
 ```
 
 `files` are `snapshot_download` allow-patterns for split-checkpoint repos.
+
+`quantize=` selects runtime (load-time) quantization of the denoiser —
+`"int8" | "nf4" | "fp4"` (bitsandbytes) or
+`"int8-torchao" | "int4-torchao" | "fp8-torchao"` (torchao weight-only).
+The loading layer applies it at `from_pretrained` time; endpoint code stays
+quantize-agnostic, `ModelEvent.vram_bytes` reports the measured post-quant
+size, and on CPU-only hosts the method is ignored with a warning. A lower-VRAM
+variant is just a variant binding: `variants={"generate-nf4":
+(HF("org/base", dtype="bf16", quantize="nf4"), Resources(vram_gb=8))}`.
 
 ## Variants
 

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -20,20 +20,41 @@ def _clean(s: object) -> str:
     return str(s or "").strip()
 
 
+# Runtime (load-time) quantization methods (th#546 / #389). Applied by the
+# loading layer at from_pretrained time; never a stored artifact, never on the
+# wire ref. bnb: "int8" (LLM.int8), "nf4"/"fp4" (4-bit, bf16 compute).
+# torchao (weight-only): "int8-torchao", "int4-torchao", "fp8-torchao"
+# (fp8 weight storage needs SM >= 8.9 kernels).
+QUANTIZE_METHODS: tuple[str, ...] = (
+    "int8", "nf4", "fp4", "int8-torchao", "int4-torchao", "fp8-torchao",
+)
+
+
+def _clean_quantize(v: object) -> str:
+    q = _clean(v).lower()
+    if q and q not in QUANTIZE_METHODS:
+        raise ValueError(
+            f"unknown quantize method {q!r}; expected one of {QUANTIZE_METHODS}"
+        )
+    return q
+
+
 @dataclass(frozen=True)
 class Hub:
-    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=)``."""
+    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, quantize=)``."""
 
     PROVIDER: ClassVar[str] = "tensorhub"
 
     ref: str
     tag: str = "prod"
     flavor: str = ""
+    quantize: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "ref", _clean(self.ref))
         object.__setattr__(self, "tag", _clean(self.tag) or "prod")
         object.__setattr__(self, "flavor", _clean(self.flavor))
+        object.__setattr__(self, "quantize", _clean_quantize(self.quantize))
         if not self.ref:
             raise ValueError(f"{type(self).__name__} requires a non-empty ref")
 
@@ -44,12 +65,14 @@ class Hub:
 
 @dataclass(frozen=True)
 class HF:
-    """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=)``.
+    """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=, quantize=)``.
 
     ``files`` are ``snapshot_download`` ``allow_patterns`` globs — set them to
     fetch only specific files (ComfyUI / split-checkpoint repos with no
     ``model_index.json``). ``dtype`` selects the torch precision at load time
-    (``"bf16"`` / ``"fp16"`` / ``"fp32"``).
+    (``"bf16"`` / ``"fp16"`` / ``"fp32"``). ``quantize`` selects a runtime
+    quantization method applied at load time (see ``QUANTIZE_METHODS``);
+    ignored with a warning on CPU-only hosts.
     """
 
     PROVIDER: ClassVar[str] = "hf"
@@ -59,6 +82,7 @@ class HF:
     dtype: str = ""
     subfolder: str = ""
     files: tuple[str, ...] = ()
+    quantize: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "ref", _clean(self.ref))
@@ -68,6 +92,7 @@ class HF:
         object.__setattr__(
             self, "files", tuple(_clean(p) for p in self.files if _clean(p))
         )
+        object.__setattr__(self, "quantize", _clean_quantize(self.quantize))
         if "/" not in self.ref:
             raise ValueError(f"HF(id=) must be 'owner/repo', got {self.ref!r}")
 
@@ -136,8 +161,8 @@ def wire_ref(binding: Binding) -> str:
     """Canonical ref string for the wire / cache key.
 
     Hub refs carry ``:tag`` (non-prod) and ``#flavor`` suffixes; HF refs
-    carry ``@revision``. Load-time metadata (dtype/subfolder/files) never
-    enters the ref.
+    carry ``@revision``. Load-time metadata (dtype/subfolder/files/quantize)
+    never enters the ref.
     """
     out = binding.ref
     if isinstance(binding, Hub):
@@ -150,4 +175,7 @@ def wire_ref(binding: Binding) -> str:
     return out
 
 
-__all__ = ["Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelScope", "wire_ref"]
+__all__ = [
+    "Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelScope",
+    "QUANTIZE_METHODS", "wire_ref",
+]

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -29,7 +29,7 @@ def describe_binding(binding: Any) -> Dict[str, Any]:
             "provider": binding.provider,
             "ref": binding.ref,
         }
-        for key in ("tag", "flavor", "revision", "dtype", "subfolder", "version"):
+        for key in ("tag", "flavor", "revision", "dtype", "subfolder", "version", "quantize"):
             v = getattr(binding, key, "")
             if v:
                 out[key] = v

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -849,9 +849,10 @@ class Executor:
 
                 binding = spec.models.get(slot)
                 dtype = str(getattr(binding, "dtype", "") or "")
+                quantize = str(getattr(binding, "quantize", "") or "")
                 before = self._vram_allocated()
                 pipe = await asyncio.to_thread(
-                    load_from_pretrained, ann, path, dtype=dtype
+                    load_from_pretrained, ann, path, dtype=dtype, quantize=quantize
                 )
                 # Worker-owned placement/offload policy: one decider for the
                 # whole worker; endpoints never write device/offload code.

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -174,6 +174,82 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
     return BitsAndBytesConfig(load_in_8bit=True)
 
 
+# Default pipeline components a binding-level quantize= applies to: the
+# denoiser dominates VRAM and tolerates weight quantization; text encoders /
+# VAE stay at full precision (quality-safe default). Names absent from a
+# given pipeline are simply never matched by diffusers.
+_QUANTIZE_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+
+
+def _quantize_backend_kwargs(method: str) -> tuple[str, Dict[str, Any]]:
+    """(PipelineQuantizationConfig backend, quant_kwargs) for a quantize method."""
+    import torch
+
+    if method == "int8":
+        return "bitsandbytes_8bit", {"load_in_8bit": True}
+    if method in ("nf4", "fp4"):
+        return "bitsandbytes_4bit", {
+            "load_in_4bit": True,
+            "bnb_4bit_quant_type": method,
+            "bnb_4bit_compute_dtype": torch.bfloat16,
+            "bnb_4bit_use_double_quant": True,
+        }
+    if method == "int8-torchao":
+        return "torchao", {"quant_type": "int8wo"}
+    if method == "int4-torchao":
+        return "torchao", {"quant_type": "int4wo"}
+    if method == "fp8-torchao":
+        return "torchao", {"quant_type": "float8wo_e4m3"}
+    raise ValueError(f"unknown quantize method {method!r}")
+
+
+def binding_quantization_config(method: str, cls: Any) -> Optional[Any]:
+    """Quantization config for a binding-level ``quantize=`` method (#389).
+
+    Pipeline classes get a diffusers ``PipelineQuantizationConfig`` scoped to
+    the denoiser; bare component classes get the matching component-level
+    config. CPU-only hosts return None with a warning (local-dev fallback —
+    bnb/torchao quantized load requires CUDA)."""
+    if not method:
+        return None
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            logger.warning(
+                "quantize=%r ignored: CUDA unavailable (CPU dev fallback)", method
+            )
+            return None
+    except ImportError:
+        logger.warning("quantize=%r ignored: torch not installed", method)
+        return None
+
+    backend, kwargs = _quantize_backend_kwargs(method)
+    try:
+        import diffusers
+        from diffusers.quantizers import PipelineQuantizationConfig
+    except ImportError as exc:
+        raise RuntimeError(
+            f"quantize={method!r} requires diffusers with pipeline-level "
+            f"quantization support (PipelineQuantizationConfig): {exc}"
+        ) from exc
+
+    if isinstance(cls, type) and issubclass(cls, diffusers.DiffusionPipeline):
+        return PipelineQuantizationConfig(
+            quant_backend=backend,
+            quant_kwargs=kwargs,
+            components_to_quantize=list(_QUANTIZE_COMPONENTS),
+        )
+    # Bare component (e.g. a transformer/unet class): component-level config.
+    if backend == "torchao":
+        from diffusers.quantizers.quantization_config import TorchAoConfig
+
+        return TorchAoConfig(**kwargs)
+    from diffusers.quantizers.quantization_config import BitsAndBytesConfig
+
+    return BitsAndBytesConfig(**kwargs)
+
+
 def _single_file_checkpoint(path: Path) -> Optional[Path]:
     """A snapshot that is one loose checkpoint rather than a pretrained layout:
     the path itself when it's a ``.safetensors`` file, or the directory's sole
@@ -270,11 +346,14 @@ def load_from_pretrained(
     *,
     dtype: str = "",
     attrs: Optional[Dict[str, str]] = None,
+    quantize: str = "",
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
     preload, and quant-config synthesis; single-file checkpoints route through
-    ``cls.from_single_file``. Used by the executor to satisfy pipeline-typed
+    ``cls.from_single_file``. ``quantize`` is the binding's runtime
+    quantization method (#389), applied here so endpoint code stays
+    quantize-agnostic. Used by the executor to satisfy pipeline-typed
     ``setup()`` annotations; endpoints may also call it."""
     path = str(path)
     ensure_quant_library_imported(attrs)
@@ -300,8 +379,24 @@ def load_from_pretrained(
                 # torch-less environment (unit tests / CPU tools) — loaders
                 # that actually need torch will fail on their own terms.
                 pass
-    if not read_on_disk_quant_config(Path(path)):
+    binding_qc = False
+    if read_on_disk_quant_config(Path(path)):
+        # Already-quantized bytes on disk win — re-quantizing is invalid.
+        if quantize:
+            logger.warning(
+                "quantize=%r ignored: checkpoint already carries a "
+                "quantization_config", quantize,
+            )
+    else:
         qc = synthesize_quantization_config(attrs)
+        if qc is not None and quantize:
+            logger.warning(
+                "quantize=%r ignored: checkpoint attrs declare pre-quantized "
+                "weights", quantize,
+            )
+        if qc is None and quantize:
+            qc = binding_quantization_config(quantize, cls)
+            binding_qc = qc is not None
         if qc is not None:
             kwargs["quantization_config"] = qc
     single = _single_file_checkpoint(Path(path))
@@ -313,8 +408,11 @@ def load_from_pretrained(
     except (TypeError, ValueError):
         # Not every loader takes variant=/quantization_config= (transformers
         # models, single-file components); retry with the bare essentials.
+        # An explicitly-requested binding quantize is never silently dropped —
+        # if the loader rejects it, the second call's error propagates.
         kwargs.pop("variant", None)
-        kwargs.pop("quantization_config", None)
+        if not binding_qc:
+            kwargs.pop("quantization_config", None)
         return cls.from_pretrained(path, **kwargs)
 
 
@@ -325,5 +423,6 @@ __all__ = [
     "ensure_quant_library_imported",
     "read_on_disk_quant_config",
     "synthesize_quantization_config",
+    "binding_quantization_config",
     "load_from_pretrained",
 ]

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -46,6 +46,30 @@ def test_bindings_are_hashable_and_equal_by_value() -> None:
     assert len({HF("o/r"), HF("o/r"), HF("o/r", dtype="bf16")}) == 2
 
 
+def test_quantize_metadata_validated_and_normalized() -> None:
+    from gen_worker.api.binding import QUANTIZE_METHODS
+
+    assert HF("o/r", quantize=" NF4 ").quantize == "nf4"
+    assert Hub("o/r", quantize="int8-torchao").quantize == "int8-torchao"
+    assert HF("o/r").quantize == ""
+    for m in QUANTIZE_METHODS:
+        assert HF("o/r", quantize=m).quantize == m
+    with pytest.raises(ValueError, match="unknown quantize method"):
+        HF("o/r", quantize="q4_k_m")
+    with pytest.raises(ValueError):
+        Hub("o/r", quantize="8bit")
+
+
+def test_quantize_never_enters_wire_ref_but_surfaces_in_manifest() -> None:
+    from gen_worker.cli.listing import describe_binding
+
+    assert wire_ref(HF("o/r", quantize="nf4")) == "o/r"
+    assert wire_ref(Hub("o/r", quantize="int8")) == "o/r"
+    assert describe_binding(HF("o/r", quantize="nf4"))["quantize"] == "nf4"
+    assert describe_binding(Hub("o/r", flavor="bf16", quantize="int8"))["quantize"] == "int8"
+    assert "quantize" not in describe_binding(HF("o/r"))
+
+
 def test_wire_ref_encoding() -> None:
     assert wire_ref(Hub("o/r")) == "o/r"
     assert wire_ref(Hub("o/r", tag="canary")) == "o/r:canary"

--- a/tests/test_quantize_loading.py
+++ b/tests/test_quantize_loading.py
@@ -1,0 +1,185 @@
+"""Binding-level quantize= plumbing in the loading layer (#389).
+
+Real diffusers/CUDA are absent in CI — the from_pretrained handoff is tested
+against a faked diffusers module; real quantized loads are proven in the GPU
+matrix campaign (th#546)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker.models.loading import (
+    binding_quantization_config,
+    load_from_pretrained,
+)
+
+
+class _FakePipelineQuantizationConfig:
+    def __init__(self, quant_backend: str, quant_kwargs: Dict[str, Any],
+                 components_to_quantize: list) -> None:
+        self.quant_backend = quant_backend
+        self.quant_kwargs = quant_kwargs
+        self.components_to_quantize = components_to_quantize
+
+
+class _FakeComponentConfig:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class _FakeDiffusionPipeline:
+    pass
+
+
+@pytest.fixture
+def fake_diffusers(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    root = types.ModuleType("diffusers")
+    quantizers = types.ModuleType("diffusers.quantizers")
+    qc_mod = types.ModuleType("diffusers.quantizers.quantization_config")
+    root.DiffusionPipeline = _FakeDiffusionPipeline
+    quantizers.PipelineQuantizationConfig = _FakePipelineQuantizationConfig
+    qc_mod.BitsAndBytesConfig = _FakeComponentConfig
+    qc_mod.TorchAoConfig = _FakeComponentConfig
+    root.quantizers = quantizers
+    quantizers.quantization_config = qc_mod
+    monkeypatch.setitem(sys.modules, "diffusers", root)
+    monkeypatch.setitem(sys.modules, "diffusers.quantizers", quantizers)
+    monkeypatch.setitem(
+        sys.modules, "diffusers.quantizers.quantization_config", qc_mod
+    )
+    return root
+
+
+@pytest.fixture
+def cuda_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+
+class _Pipe(_FakeDiffusionPipeline):
+    calls: list = []
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs: Any) -> Any:
+        cls.calls.append(kwargs)
+        return cls()
+
+
+def _snapshot(tmp_path: Path, quantized: bool = False) -> Path:
+    index: Dict[str, Any] = {"_class_name": "Pipe"}
+    if quantized:
+        index["quantization_config"] = {"quant_method": "bitsandbytes"}
+    (tmp_path / "model_index.json").write_text(json.dumps(index))
+    return tmp_path
+
+
+def test_no_cuda_falls_back_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import torch
+
+    if torch.cuda.is_available():
+        pytest.skip("CPU-only path")
+    with caplog.at_level("WARNING"):
+        assert binding_quantization_config("nf4", _Pipe) is None
+    assert "CUDA unavailable" in caplog.text
+
+
+def test_pipeline_config_synthesis(fake_diffusers: Any, cuda_on: None) -> None:
+    import torch
+
+    qc = binding_quantization_config("nf4", _Pipe)
+    assert isinstance(qc, _FakePipelineQuantizationConfig)
+    assert qc.quant_backend == "bitsandbytes_4bit"
+    assert qc.quant_kwargs["bnb_4bit_quant_type"] == "nf4"
+    assert qc.quant_kwargs["bnb_4bit_compute_dtype"] is torch.bfloat16
+    assert "transformer" in qc.components_to_quantize
+
+    qc8 = binding_quantization_config("int8", _Pipe)
+    assert qc8.quant_backend == "bitsandbytes_8bit"
+    assert qc8.quant_kwargs == {"load_in_8bit": True}
+
+    for method, quant_type in (
+        ("int8-torchao", "int8wo"),
+        ("int4-torchao", "int4wo"),
+        ("fp8-torchao", "float8wo_e4m3"),
+    ):
+        q = binding_quantization_config(method, _Pipe)
+        assert q.quant_backend == "torchao"
+        assert q.quant_kwargs == {"quant_type": quant_type}
+
+
+def test_component_class_gets_component_config(
+    fake_diffusers: Any, cuda_on: None
+) -> None:
+    class NotAPipeline:
+        pass
+
+    qc = binding_quantization_config("nf4", NotAPipeline)
+    assert isinstance(qc, _FakeComponentConfig)
+    assert qc.kwargs["load_in_4bit"] is True
+    qao = binding_quantization_config("fp8-torchao", NotAPipeline)
+    assert qao.kwargs == {"quant_type": "float8wo_e4m3"}
+
+
+def test_load_injects_binding_quantization_config(
+    fake_diffusers: Any, cuda_on: None, tmp_path: Path
+) -> None:
+    _Pipe.calls = []
+    load_from_pretrained(_Pipe, _snapshot(tmp_path), dtype="bf16", quantize="nf4")
+    (kwargs,) = _Pipe.calls
+    qc = kwargs["quantization_config"]
+    assert isinstance(qc, _FakePipelineQuantizationConfig)
+    assert qc.quant_backend == "bitsandbytes_4bit"
+
+
+def test_on_disk_quant_config_wins_over_binding_quantize(
+    fake_diffusers: Any, cuda_on: None, tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _Pipe.calls = []
+    with caplog.at_level("WARNING"):
+        load_from_pretrained(
+            _Pipe, _snapshot(tmp_path, quantized=True), quantize="nf4"
+        )
+    (kwargs,) = _Pipe.calls
+    assert "quantization_config" not in kwargs
+    assert "already carries" in caplog.text
+
+
+def test_binding_quantize_is_never_silently_dropped(
+    fake_diffusers: Any, cuda_on: None, tmp_path: Path
+) -> None:
+    class Rejects(_FakeDiffusionPipeline):
+        calls: list = []
+
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: Any) -> Any:
+            cls.calls.append(kwargs)
+            if "quantization_config" in kwargs:
+                raise TypeError("no quantization_config here")
+            return cls()
+
+    with pytest.raises(TypeError):
+        load_from_pretrained(Rejects, _snapshot(tmp_path), quantize="int8")
+    # both attempts carried the config — the retry didn't strip it
+    assert all("quantization_config" in k for k in Rejects.calls)
+
+    # without quantize, the legacy retry still strips loader-rejected kwargs
+    Rejects.calls = []
+    out = load_from_pretrained(Rejects, _snapshot(tmp_path))
+    assert isinstance(out, Rejects)
+
+
+def test_no_quantize_means_no_config(tmp_path: Path) -> None:
+    _Pipe.calls = []
+    load_from_pretrained(_Pipe, _snapshot(tmp_path))
+    (kwargs,) = _Pipe.calls
+    assert "quantization_config" not in kwargs


### PR DESCRIPTION
Closes gw#389 (tracker). The load-time half of th#546's two-lane quantization strategy.

- `quantize=` kwarg on HF/Hub bindings (int8 / nf4 / fp4 / int8-torchao / int4-torchao / fp8-torchao), applied by the loading layer at from_pretrained time — same injection point as the compile policy; endpoint code stays quantize-agnostic
- Denoiser-scoped PipelineQuantizationConfig for pipelines; component-level configs for bare model classes
- On-disk/attrs pre-quantized checkpoints win over binding quantize (warn); binding quantize is never silently dropped
- CPU-safe: ignored with a warning without CUDA
- Discovery manifest surfaces the method; vram_bytes reports measured post-quant size for free

Tests: 326 passed, 1 skipped (full suite); ruff + mypy clean. GPU (method x model x SKU) proof matrix runs as the th#546 campaign next.