### PR TITLE
fix(examples): qwen-edit-hub-image needs torchvision

### DIFF
--- a/examples/qwen-edit-hub-image/pyproject.toml
+++ b/examples/qwen-edit-hub-image/pyproject.toml
@@ -10,6 +10,11 @@ dependencies = [
     "accelerate>=1.0",
     "msgspec>=0.18",
     "pillow>=10",
+    # Qwen2VLProcessor instantiates its VIDEO processor at load time (the 2511
+    # repo ships processor/video_preprocessor_config.json) and
+    # Qwen2VLVideoProcessor hard-imports torchvision: load-time ImportError
+    # without it. Discovery can't catch it -- the module imports clean.
+    "torchvision>=0.24",
 ]
 
 [build-system]


### PR DESCRIPTION
Qwen2VLProcessor instantiates its video processor at load time (Qwen-Image-Edit-2511 ships processor/video_preprocessor_config.json) and Qwen2VLVideoProcessor hard-imports torchvision. Without it the worker dies with a bare load-time ImportError — proven live in e2e #111 qwen first-light run 4, reproduced + fix verified inside the exact serve image. Discovery can't catch it: the module imports clean.