### PR TITLE
fix(models): size-guard the matched files= subset, not the whole repo (ie#355)

### DIFF
--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -353,6 +353,15 @@ def select_hf_files(
     return selected
 
 
+def _match_allow_patterns(repo_files: Sequence[str], patterns: Sequence[str]) -> set[str]:
+    """Repo files matched by ``patterns`` — huggingface_hub semantics
+    (fnmatch; a trailing ``/`` means the whole directory)."""
+    from fnmatch import fnmatch
+
+    pats = [p + "*" if p.endswith("/") else p for p in patterns]
+    return {f for f in repo_files if any(fnmatch(f, p) for p in pats)}
+
+
 def _hf_stall_timeout_s() -> float:
     raw = os.environ.get("COZY_HF_DOWNLOAD_STALL_TIMEOUT_S", "").strip()
     if raw:
@@ -516,7 +525,14 @@ def download_hf(
 
     selected: Optional[set[str]]
     if allow_patterns:
-        selected = None
+        # Size-guard the MATCHED subset, not the whole repo (ie#355: a 795KB
+        # tokenizer files= subset of google/t5-v1_1-xxl tripped the 60GB cap).
+        # Same fnmatch semantics as huggingface_hub.filter_repo_objects.
+        selected = _match_allow_patterns(repo_files, allow_patterns)
+        if not selected:
+            raise ValueError(
+                f"files= patterns matched nothing in {repo_id}: {list(allow_patterns)!r}"
+            )
         kwargs["allow_patterns"] = list(allow_patterns)
     else:
         selected = select_hf_files(repo_files, flavor=ref.flavor)

--- a/tests/test_hf_selection.py
+++ b/tests/test_hf_selection.py
@@ -8,7 +8,12 @@ unknown layouts fall back to the whole repo (returns None).
 
 from __future__ import annotations
 
-from gen_worker.models.download import select_hf_files
+from types import SimpleNamespace
+
+import pytest
+
+from gen_worker.models.download import _match_allow_patterns, download_hf, select_hf_files
+from gen_worker.models.refs import HuggingFaceRef
 
 _DIFFUSERS_REPO = [
     "model_index.json",
@@ -127,6 +132,77 @@ def test_unrecognized_layout_downloads_whole_repo() -> None:
 def test_no_weights_at_all_downloads_whole_repo() -> None:
     assert select_hf_files(["README.md", "config.json"]) is None
     assert select_hf_files([]) is None
+
+
+# --- files= subset size guard (ie#355) --------------------------------------
+# A 795KB tokenizer subset of google/t5-v1_1-xxl (~89GB repo) used to trip the
+# 60GB cap: the guard summed the WHOLE repo when explicit patterns were given.
+
+_T5_REPO = {
+    "config.json": 593,
+    "generation_config.json": 147,
+    "pytorch_model.bin": 44_541_587_809,
+    "special_tokens_map.json": 1_786,
+    "spiece.model": 791_656,
+    "tf_model.h5": 44_542_439_224,
+    "tokenizer_config.json": 1_857,
+}
+_T5_SUBSET = ("spiece.model", "tokenizer_config.json", "special_tokens_map.json")
+
+
+def test_match_allow_patterns() -> None:
+    files = list(_T5_REPO) + ["split_files/vae/ae.safetensors"]
+    assert _match_allow_patterns(files, _T5_SUBSET) == set(_T5_SUBSET)
+    assert _match_allow_patterns(files, ("*.json",)) == {
+        "config.json", "generation_config.json", "special_tokens_map.json", "tokenizer_config.json",
+    }
+    # Trailing slash means the whole directory (huggingface_hub semantics).
+    assert _match_allow_patterns(files, ("split_files/",)) == {"split_files/vae/ae.safetensors"}
+    assert _match_allow_patterns(files, ("nope.bin",)) == set()
+
+
+def _stub_hub(monkeypatch, tmp_path, repo=_T5_REPO):
+    """Stub huggingface_hub at the network edge; download_hf's planning runs real."""
+    import huggingface_hub
+
+    calls: dict[str, object] = {}
+
+    class _Api:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, **kw):
+            return list(repo)
+
+        def list_repo_tree(self, **kw):
+            return [SimpleNamespace(path=p, size=s) for p, s in repo.items()]
+
+    def _snap(**kw):
+        calls.update(kw)
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snap)
+    return calls
+
+
+def test_explicit_files_subset_sized_by_subset_not_whole_repo(monkeypatch, tmp_path) -> None:
+    calls = _stub_hub(monkeypatch, tmp_path)
+    out = download_hf(HuggingFaceRef(repo_id="google/t5-v1_1-xxl"), allow_patterns=_T5_SUBSET)
+    assert str(out) == str(tmp_path)
+    assert calls["allow_patterns"] == list(_T5_SUBSET)
+
+
+def test_full_repo_over_cap_still_refused(monkeypatch, tmp_path) -> None:
+    _stub_hub(monkeypatch, tmp_path)
+    with pytest.raises(RuntimeError, match="excessively large"):
+        download_hf(HuggingFaceRef(repo_id="google/t5-v1_1-xxl"))
+
+
+def test_files_subset_matching_nothing_is_a_clear_error(monkeypatch, tmp_path) -> None:
+    _stub_hub(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="matched nothing"):
+        download_hf(HuggingFaceRef(repo_id="google/t5-v1_1-xxl"), allow_patterns=("spiece.mdoel",))
 
 
 def test_sharded_single_file_checkpoint_reassembles(tmp_path):


### PR DESCRIPTION
Closes the gen-worker half of inference-endpoints #355 (anima worker never servable).

## Root cause
`download_hf` with explicit `allow_patterns` (endpoint `files=` subsets) set `selected=None`, so the 60GB size guard summed the ENTIRE repo (`wanted = set(repo_files)`). The anima endpoint's 795KB t5 tokenizer subset (`spiece.model` + configs) of `google/t5-v1_1-xxl` (~89GB: pytorch_model.bin 44.5GB + tf_model.h5 44.5GB) tripped `RuntimeError: refusing an excessively large Hugging Face selection` -> `download_failed` x3, `generate` never servable.

## Fix
- Match `allow_patterns` against the repo listing with huggingface_hub's fnmatch semantics (`_match_allow_patterns`, incl. trailing-`/` directory expansion) and size-guard only the matched subset (also fixes the progress `total_hint`).
- A `files=` subset that matches nothing is now a clear `ValueError` (catches typo'd filenames at download time) instead of silently downloading nothing.

## Evidence
Real download through the fixed path: `google/t5-v1_1-xxl` subset -> 3 files, 795,299 bytes (previously refused at plan time).

## Tests
- 4 new tests (subset matching, subset-sized guard, whole-repo cap still enforced, no-match error); `tests/test_hf_selection.py` 13 passed.
- Full suite: 346 passed, 2 skipped; the 4 failed + 2 errors in `tests/test_fp8_and_emergency_loading.py` are PRE-EXISTING on master (reproduced identically on a clean master checkout, unrelated fp8 loading tests).