### PR TITLE
fix(executor,lifecycle): terminal FnUnavailable(setup_failed) on model download/pipeline-setup failure (ernie capability-event roster find, th#581 worker-side)

### DIFF
--- a/proto/CONTRACT.md
+++ b/proto/CONTRACT.md
@@ -386,8 +386,13 @@ refs into model-failure availability handling: a failed cache ref means
 "stays eager", never "function unavailable".
 
 ### FnUnavailable (W → O)
-Emitted when a hardware-axis gate fails at startup or model-load time
-(one message per function, deduplicated).
+Emitted when a hardware-axis gate fails at startup or model-load time, or
+when a function's model download / pipeline setup fails terminally
+(`reason: setup_failed` — the function is dropped from BOTH
+`available_functions` and `loading_functions` instead of sitting in
+loading forever under a READY phase). One message per function,
+deduplicated. A later hub-directed `ModelOp{LOAD}` retries the setup; on
+success the function reappears in `StateDelta.available_functions`.
 
 | field | producer | consumer | semantics |
 |---|---|---|---|

--- a/proto/worker_scheduler.proto
+++ b/proto/worker_scheduler.proto
@@ -320,11 +320,13 @@ enum ModelState {
 // ---------------------------------------------------------------------------
 
 // Worker -> orchestrator: this worker self-disables ONE function on itself
-// because a hardware gate failed. Cleared implicitly by the next Hello.
+// because a hardware gate failed or its model download / pipeline setup
+// failed terminally. Cleared implicitly by the next Hello, or by the
+// function reappearing in StateDelta.available_functions.
 message FnUnavailable {
   string function_name = 1;
   // reason vocabulary: compute_capability_unmet, insufficient_vram,
-  // missing_cuda_library, insufficient_disk, cuda_unavailable.
+  // missing_cuda_library, insufficient_disk, cuda_unavailable, setup_failed.
   string reason = 2;
   string detail = 3; // human-readable elaboration for the admin availability view
   map<string, string> axes = 4; // e.g. {detected_sm: "8.9", required_sm: "10.0"}

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -656,45 +656,81 @@ class Executor:
             if rec.ready:
                 await self._promote_setup_refs(spec)
                 return rec.instance
-            setup_slots = self._setup_slots(spec)
-            paths: Dict[str, str] = {}
-            for slot in setup_slots:
-                binding = spec.models[slot]
-                ref = wire_ref(binding)
-                snap = (snapshots or {}).get(ref)
-                path = await self.store.ensure_local(ref, snap, binding=binding)
-                paths[slot] = str(path)
-            compile_artifact = await self._fetch_compile_snapshot(spec, snapshots)
-            # Loads serialize: concurrent setups would cross-contaminate each
-            # other's allocator deltas and place_pipeline's free-VRAM reads.
-            async with self._load_lock:
-                await self._make_room_for(spec, setup_slots)
-                instance = spec.cls()
-                setup = getattr(instance, "setup", None)
-                loaded: Dict[str, Tuple[Any, int]] = {}
-                vram_before = self._vram_allocated()
-                if spec.runtime:
-                    rec.server = await self._boot_engine_server(spec, paths)
-                if callable(setup):
-                    kwargs, loaded = await self._injection_kwargs(
-                        spec, setup, paths, server=rec.server,
-                        compile_artifact=compile_artifact)
-                    if asyncio.iscoroutinefunction(setup):
-                        await setup(**kwargs)
-                    else:
-                        await asyncio.to_thread(setup, **kwargs)
-                warmup = getattr(instance, "warmup", None)
-                if callable(warmup):
-                    if asyncio.iscoroutinefunction(warmup):
-                        await warmup()
-                    else:
-                        await asyncio.to_thread(warmup)
-                vram_delta = max(0, self._vram_allocated() - vram_before)
-                self._register_residency(spec, setup_slots, loaded, vram_delta)
+            try:
+                instance = await self._setup_locked(spec, rec, snapshots)
+            except Exception as exc:
+                # Honest failure (th#581): a function whose model download /
+                # pipeline setup fails must surface a terminal per-function
+                # error to the hub, not sit in loading_functions forever
+                # while the worker reports READY.
+                self._mark_setup_failed(rec, exc)
+                raise
+            if rec.failed is not None:
+                # Recovery (hub-directed LOAD retry succeeded): lift the
+                # per-function disable; the next StateDelta re-advertises.
+                rec.failed = None
+                for s in rec.specs:
+                    self.unavailable.pop(s.name, None)
             rec.instance = instance
             rec.ready = True
             self._on_state_change()
             return instance
+
+    def _mark_setup_failed(self, rec: _ClassRecord, exc: BaseException) -> None:
+        if isinstance(exc, InsufficientDiskError):
+            return  # transient: disk GC frees space; the next LOAD retries
+        if isinstance(exc, HardwareUnmetError):
+            reason = getattr(exc, "reason", "hardware_unmet")
+            axes = {str(k): str(v) for k, v in (exc.axes() or {}).items()}
+        else:
+            reason, axes = "setup_failed", {}
+        detail = _sanitize(f"{type(exc).__name__}: {exc}")
+        rec.failed = detail
+        for s in rec.specs:
+            self.unavailable[s.name] = (reason, detail, axes)
+        self._on_state_change()
+
+    async def _setup_locked(
+        self, spec: EndpointSpec, rec: _ClassRecord,
+        snapshots: Optional[Dict[str, pb.Snapshot]],
+    ) -> Any:
+        assert spec.cls is not None  # guarded by ensure_setup
+        setup_slots = self._setup_slots(spec)
+        paths: Dict[str, str] = {}
+        for slot in setup_slots:
+            binding = spec.models[slot]
+            ref = wire_ref(binding)
+            snap = (snapshots or {}).get(ref)
+            path = await self.store.ensure_local(ref, snap, binding=binding)
+            paths[slot] = str(path)
+        compile_artifact = await self._fetch_compile_snapshot(spec, snapshots)
+        # Loads serialize: concurrent setups would cross-contaminate each
+        # other's allocator deltas and place_pipeline's free-VRAM reads.
+        async with self._load_lock:
+            await self._make_room_for(spec, setup_slots)
+            instance = spec.cls()
+            setup = getattr(instance, "setup", None)
+            loaded: Dict[str, Tuple[Any, int]] = {}
+            vram_before = self._vram_allocated()
+            if spec.runtime:
+                rec.server = await self._boot_engine_server(spec, paths)
+            if callable(setup):
+                kwargs, loaded = await self._injection_kwargs(
+                    spec, setup, paths, server=rec.server,
+                    compile_artifact=compile_artifact)
+                if asyncio.iscoroutinefunction(setup):
+                    await setup(**kwargs)
+                else:
+                    await asyncio.to_thread(setup, **kwargs)
+            warmup = getattr(instance, "warmup", None)
+            if callable(warmup):
+                if asyncio.iscoroutinefunction(warmup):
+                    await warmup()
+                else:
+                    await asyncio.to_thread(warmup)
+            vram_delta = max(0, self._vram_allocated() - vram_before)
+            self._register_residency(spec, setup_slots, loaded, vram_delta)
+        return instance
 
     def _register_residency(
         self,

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -195,6 +195,9 @@ class Lifecycle:
     async def _emit_unavailable(self) -> None:
         if self.transport is None:
             return
+        # A recovered function leaves executor.unavailable; drop it from the
+        # dedupe set so a later re-failure re-emits.
+        self._emitted_unavailable &= set(self.executor.unavailable)
         for name, (reason, detail, axes) in list(self.executor.unavailable.items()):
             if name in self._emitted_unavailable:
                 continue

--- a/tests/e2e_endpoints.py
+++ b/tests/e2e_endpoints.py
@@ -71,3 +71,23 @@ class ModelBoundEndpoint:
     def model_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
         weights = Path(self.model_path) / "model.safetensors"
         return EchoOut(response=weights.read_text())
+
+
+# Toggled by the setup-failure e2e test: True => BrokenSetupEndpoint.setup
+# raises (the ernie-on-pod shape: import fine, pipeline load fails).
+BREAK_SETUP = threading.Event()
+BREAK_SETUP.set()
+
+
+@endpoint(model=Hub("e2e/broken"))
+class BrokenSetupEndpoint:
+    """Setup raises while BREAK_SETUP is set; a later LOAD retry recovers."""
+
+    def setup(self, model: str) -> None:
+        if BREAK_SETUP.is_set():
+            raise RuntimeError("pipeline exploded: cannot import Ministral3ForCausalLM")
+        self.model_path = model
+
+    def broken_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        weights = Path(self.model_path) / "model.safetensors"
+        return EchoOut(response=weights.read_text())

--- a/tests/test_worker_grpc_e2e.py
+++ b/tests/test_worker_grpc_e2e.py
@@ -798,3 +798,121 @@ def test_model_op_download_load_unload_round_trip(tmp_path, monkeypatch) -> None
         harness.stop()
         server.stop(grace=0)
         httpd.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Setup failure surfaces FnUnavailable (th#581 worker-side / ernie roster
+# find): a function whose pipeline setup raises must NOT sit in
+# loading_functions forever under a READY phase — it leaves BOTH lists and a
+# terminal FnUnavailable{setup_failed} reaches the hub. A later LOAD retry
+# that succeeds re-advertises it; a re-failure re-emits.
+# ---------------------------------------------------------------------------
+
+
+def test_setup_failure_emits_fn_unavailable_and_recovers(tmp_path, monkeypatch) -> None:
+    import http.server
+
+    from blake3 import blake3
+
+    import e2e_endpoints
+
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(tmp_path / "hub-cache"))
+
+    payload = b"tiny-weights"
+    digest = blake3(payload).hexdigest()
+    serve_dir = tmp_path / "www"
+    serve_dir.mkdir()
+    (serve_dir / "blob").write_bytes(payload)
+
+    class _Quiet(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, directory=str(serve_dir), **kw)
+
+        def log_message(self, *a):
+            pass
+
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Quiet)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    blob_url = f"http://127.0.0.1:{httpd.server_address[1]}/blob"
+    snapshot = pb.Snapshot(
+        digest="e2e-snap-broken",
+        files=[pb.SnapshotFile(
+            path="model.safetensors", size_bytes=len(payload),
+            blake3=digest, url=blob_url,
+        )],
+    )
+
+    def _is_fn_unavailable(m: pb.WorkerMessage) -> bool:
+        return (
+            m.WhichOneof("msg") == "fn_unavailable"
+            and m.fn_unavailable.function_name == "broken-echo"
+            and m.fn_unavailable.reason == "setup_failed"
+        )
+
+    e2e_endpoints.BREAK_SETUP.set()
+    scheduler = FakeScheduler()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=8))
+    pb_grpc.add_WorkerSchedulerServicer_to_server(scheduler, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    harness = _Harness(scheduler, port)
+    harness.start()
+    try:
+        conn = scheduler.wait_connection(0)
+        ready = conn.wait_for(
+            lambda m: m.WhichOneof("msg") == "state_delta"
+            and m.state_delta.phase == pb.WORKER_PHASE_READY
+        )
+        assert "broken-echo" in ready.state_delta.loading_functions
+
+        # LOAD -> setup raises -> terminal per-function signal, and the fn
+        # leaves BOTH available and loading (no more silent-ready limbo).
+        conn.send(model_op=pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref="e2e/broken", snapshot=snapshot))
+        sig = conn.wait_for(_is_fn_unavailable).fn_unavailable
+        assert "pipeline exploded" in sig.detail
+        conn.wait_for(
+            lambda m: m.WhichOneof("msg") == "state_delta"
+            and "broken-echo" not in m.state_delta.available_functions
+            and "broken-echo" not in m.state_delta.loading_functions
+        )
+        # The load path also reports the model op failure itself.
+        conn.wait_for(_is_model_event("e2e/broken", pb.MODEL_STATE_FAILED))
+
+        # Hub-directed retry succeeds -> the disable lifts and the function
+        # is advertised (this is the capability-change event the hub needs).
+        e2e_endpoints.BREAK_SETUP.clear()
+        conn.send(model_op=pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref="e2e/broken", snapshot=snapshot))
+        conn.wait_for(
+            lambda m: m.WhichOneof("msg") == "state_delta"
+            and "broken-echo" in m.state_delta.available_functions
+        )
+        assert "broken-echo" not in harness.worker.executor.unavailable
+
+        # Serves for real after recovery.
+        conn.send(run_job=pb.RunJob(
+            request_id="r-broken", attempt=1, function_name="broken-echo",
+            input_payload=_msgpack("marco")))
+        res = conn.wait_for(_is_result_for("r-broken")).job_result
+        assert res.status == pb.JOB_STATUS_OK
+        assert _decode_out(res.inline).response == payload.decode()
+
+        # Re-failure after recovery re-emits (dedupe set is pruned).
+        e2e_endpoints.BREAK_SETUP.set()
+        conn.send(model_op=pb.ModelOp(op=pb.MODEL_OP_KIND_UNLOAD, ref="e2e/broken"))
+        deadline = time.monotonic() + _TIMEOUT
+        while "broken-echo" in harness.worker.executor.available_functions():
+            assert time.monotonic() < deadline, "UNLOAD did not gate broken-echo"
+            time.sleep(0.02)
+        conn.send(model_op=pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref="e2e/broken", snapshot=snapshot))
+        deadline = time.monotonic() + _TIMEOUT
+        while conn.count(_is_fn_unavailable) < 2:
+            assert time.monotonic() < deadline, "no second fn_unavailable"
+            time.sleep(0.02)
+    finally:
+        e2e_endpoints.BREAK_SETUP.set()
+        harness.stop()
+        server.stop(grace=0)
+        httpd.shutdown()


### PR DESCRIPTION
## Root cause (ernie: capability event never fires — ie#347 roster run 9, th#581)

`Executor._ClassRecord.failed` was never assigned anywhere. When a class endpoint's
`ensure_setup` raised (model download or pipeline load), `lifecycle.startup()` /
`handle_model_op(LOAD)` just logged it: the function stayed in
`StateDelta.loading_functions` forever, `available_functions` never changed, no
`FnUnavailable` was emitted, and the worker advertised `READY`. The hub therefore never
got a `[scheduler] worker capability change` event and requests queued until timeout.

Reproduced locally with the real ernie endpoint (2 fns, HF-provider bindings, setup-time
pipeline construction) against a stubbed pipeline load: models reach `on_disk`,
`pipeline_loading -> ready` flips instantly, both fns sit in `loading` forever, zero
`fn_unavailable` — byte-for-byte the roster observation. Ernie's own discovery/wiring is
correct (with a succeeding load both fns advertise fine); the endpoint needs no change.

## Fix

- `ensure_setup` failure now marks `rec.failed` + per-function `executor.unavailable`
  (`reason=setup_failed`, sanitized exception detail; `HardwareUnmetError` keeps its gate
  reason; `InsufficientDiskError` stays transient) and fires a state change: the fn drops
  out of BOTH `available_functions` and `loading_functions` and `FnUnavailable` ships the
  real error to the hub.
- A later hub-directed `ModelOp{LOAD}` retry that succeeds lifts the disable and
  re-advertises the function (capability change fires).
- `lifecycle._emit_unavailable` prunes its dedupe set so recover-then-refail re-emits.
- proto + CONTRACT.md: `setup_failed` added to the `FnUnavailable` reason vocabulary
  (wire-compatible — hub passes `reason` through opaquely to the availability reporter).

## Tests

- New e2e (real gRPC fake-scheduler harness): setup raises -> `FnUnavailable{setup_failed}`
  + fn leaves both lists + `ModelEvent{FAILED}`; LOAD retry succeeds -> fn advertised and
  serves; UNLOAD + re-failure -> second `FnUnavailable`.
- `uv run --extra dev --extra torch pytest -q`: **346 passed, 1 skipped**.
- mypy/ruff on touched files: no new findings vs master.