### PR TITLE
feat(executor): per-request LoRA adapter serving + cache + swap-cost metrics (gw#393)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field as dc_field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
+import uuid
+
 import msgspec
 
 from .api.binding import wire_ref
@@ -48,6 +50,7 @@ from .request_context import (
     RequestContext,
     TrainingContext,
 )
+from .utils import lora as lora_util
 
 _CONTEXT_BY_KIND: Dict[str, type] = {
     "inference": RequestContext,
@@ -560,6 +563,8 @@ class Executor:
         # Model loads/promotions serialize so allocator-delta measurements
         # and free-VRAM reads don't cross-contaminate (#369).
         self._load_lock = asyncio.Lock()
+        # Parsed per-request LoRA state dicts, keyed by ref@digest (gw#393).
+        self._adapter_cache = lora_util.AdapterCache()
         self._on_state_change = on_state_change or (lambda: None)
         self.file_base_url: str = ""
         self.draining = False
@@ -1283,6 +1288,12 @@ class Executor:
                 gpu_count=int(compute.gpu_count) if compute is not None else 0,
             ),
             models={b.slot: b.ref for b in run.models},
+            loras={
+                b.slot: tuple(
+                    {"ref": ov.ref, "weight": float(ov.weight) or 1.0} for ov in b.loras
+                )
+                for b in run.models if b.loras
+            },
             source_info=source_info,
             destination_info=destination_info,
             execution_hints=(
@@ -1300,6 +1311,7 @@ class Executor:
             await asyncio.to_thread(materialize_input_assets, payload, run.request_id)
             instance = await self.ensure_setup(spec, snapshots)
             kwargs = await self._handler_kwargs(spec, snapshots)
+            adapters = await self._prepare_adapters(run, spec, snapshots)
         except asyncio.CancelledError:
             await self._finish(job, pb.JOB_STATUS_CANCELED, safe_message="canceled")
             return
@@ -1331,12 +1343,28 @@ class Executor:
                 if job.ctx.cancelled:
                     raise CanceledError("canceled")
             started = time.monotonic()
-            # Pin-while-executing: the models this job uses are not eviction
-            # candidates for its duration (cross-pipeline eviction safety).
+            # Pin-while-executing: the models (and adapter snapshots) this job
+            # uses are not eviction candidates for its duration.
             exec_refs = [wire_ref(b) for b in spec.models.values()]
-            with self.store.residency.executing(*exec_refs):
-                output = await self._execute(job, spec, instance, ctx, payload, kwargs,
-                                             timeout_ms=timeout_ms, gpu_index=gpu_index)
+            adapter_refs = [a.ref for group in adapters.values() for a in group]
+            with self.store.residency.executing(*exec_refs, *adapter_refs):
+                lora_pipes: List[Any] = []
+                try:
+                    for slot, prepared in adapters.items():
+                        pipe = self._adapter_target(spec, slot)
+                        await asyncio.to_thread(
+                            lora_util.apply_adapters, pipe, prepared, run.request_id
+                        )
+                        lora_pipes.append(pipe)
+                    output = await self._execute(job, spec, instance, ctx, payload, kwargs,
+                                                 timeout_ms=timeout_ms, gpu_index=gpu_index)
+                finally:
+                    # Request-scoped adapters: guaranteed-clean teardown on
+                    # every exit (OK / cancel / deadline / handler error).
+                    for pipe in lora_pipes:
+                        await asyncio.to_thread(
+                            lora_util.unload_adapters, pipe, run.request_id
+                        )
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
                                     output=output)
             # Handler GPU work is done — free the slot before result-blob
@@ -1401,6 +1429,71 @@ class Executor:
             path = await self.store.ensure_local(ref, snapshots.get(ref), binding=binding)
             kwargs[name] = Path(path) if sig.get(name) is Path else str(path)
         return kwargs
+
+    async def _prepare_adapters(
+        self, run: pb.RunJob, spec: EndpointSpec, snapshots: Dict[str, pb.Snapshot]
+    ) -> Dict[str, List[lora_util.PreparedAdapter]]:
+        """Materialize + parse the job's per-slot LoRA overlays (gw#393).
+
+        Downloads ride the normal ensure_local snapshot path (disk GC,
+        ref-index, ModelEvents — so the hub learns adapter download bandwidth
+        like any ref); parsed state dicts hit the digest-keyed RAM LRU.
+        GPU-free: application happens later, under the job's GPU slot."""
+        overlays = [(b.slot, list(b.loras)) for b in run.models if b.loras]
+        if not overlays:
+            return {}
+        total = sum(len(loras) for _, loras in overlays)
+        if total > lora_util.MAX_LORAS_PER_REQUEST:
+            raise ValidationError(
+                f"too many lora adapters: {total} "
+                f"(max {lora_util.MAX_LORAS_PER_REQUEST} per request)"
+            )
+        out: Dict[str, List[lora_util.PreparedAdapter]] = {}
+        seq = 0
+        for slot, loras in overlays:
+            if slot not in spec.models:
+                raise ValidationError(f"lora overlay names unknown model slot {slot!r}")
+            prepared: List[lora_util.PreparedAdapter] = []
+            for overlay in loras:
+                ref = str(overlay.ref or "").strip()
+                if not ref:
+                    raise ValidationError(f"lora overlay on slot {slot!r} has an empty ref")
+                weight = lora_util.validate_overlay_weight(overlay.weight, ref=ref)
+                t0 = time.monotonic()
+                path = await self.store.ensure_local(ref, snapshots.get(ref))
+                ensure_ms = int((time.monotonic() - t0) * 1000)
+                snap = snapshots.get(ref)
+                digest = (snap.digest if snap is not None else "") or path.name
+                cache_key = f"{ref}@{digest}"
+                t1 = time.monotonic()
+                state_dict = self._adapter_cache.get(cache_key)
+                from_cache = state_dict is not None
+                if state_dict is None:
+                    file = lora_util.find_adapter_file(path, ref=ref)
+                    state_dict = await asyncio.to_thread(
+                        lora_util.load_adapter_state_dict, file, ref=ref
+                    )
+                    self._adapter_cache.put(cache_key, state_dict)
+                parse_ms = int((time.monotonic() - t1) * 1000)
+                prepared.append(lora_util.PreparedAdapter(
+                    slot=slot, ref=ref,
+                    name=f"req{seq}-{uuid.uuid4().hex[:8]}",
+                    weight=weight, state_dict=state_dict,
+                    from_cache=from_cache, ensure_ms=ensure_ms, parse_ms=parse_ms,
+                ))
+                seq += 1
+            out[slot] = prepared
+        return out
+
+    def _adapter_target(self, spec: EndpointSpec, slot: str) -> Any:
+        """The worker-managed pipeline object adapters for ``slot`` apply to."""
+        pipe = self.store.residency.obj(wire_ref(spec.models[slot]))
+        if pipe is None:
+            raise ValidationError(
+                f"model slot {slot!r} has no worker-managed pipeline; "
+                "lora overlays require a pipeline-injected setup slot"
+            )
+        return pipe
 
     async def _execute(
         self,

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -118,6 +118,7 @@ class RequestContext:
         destination_info: Optional[Dict[str, Any]] = None,
         compute: Optional["Compute"] = None,
         models: Optional[Dict[str, Any]] = None,
+        loras: Optional[Dict[str, Any]] = None,
         hf_token: str = "",
     ) -> None:
         self._request_id = str(request_id or "").strip()
@@ -159,6 +160,7 @@ class RequestContext:
         # None-checks.
         self._compute: "Compute" = compute if compute is not None else _default_compute()
         self._models = _copy_context_metadata(models or {})
+        self._loras = _copy_context_metadata(loras or {})
 
         # Upload-session manager (issue #20). Lazy-created on first
         # ctx.save_file / ctx.save_checkpoint / ctx.save_output_stream use.
@@ -202,6 +204,14 @@ class RequestContext:
     def models(self) -> Dict[str, Any]:
         """Resolved model refs for this invocation, keyed by slot name."""
         return _copy_context_metadata(self._models)
+
+    @property
+    def loras(self) -> Dict[str, Any]:
+        """Per-request LoRA overlays riding each model slot (gw#393):
+        slot name -> tuple of ``{"ref", "weight"}``. Empty for adapter-free
+        requests. The worker applies/removes the adapters around the handler
+        call; this surface is read-only metadata."""
+        return _copy_context_metadata(self._loras)
 
     @property
     def device(self) -> "torch.device":

--- a/src/gen_worker/utils/__init__.py
+++ b/src/gen_worker/utils/__init__.py
@@ -1,1 +1,15 @@
-from .lora import load_loras
+from .lora import (
+    AdapterCache,
+    LoraCapablePipeline,
+    PreparedAdapter,
+    apply_adapters,
+    unload_adapters,
+)
+
+__all__ = [
+    "AdapterCache",
+    "LoraCapablePipeline",
+    "PreparedAdapter",
+    "apply_adapters",
+    "unload_adapters",
+]

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -1,12 +1,51 @@
+"""Per-request LoRA adapter overlays (gw#393 BYOM).
+
+``RunJob.models[].loras`` reaches the executor, which materializes each
+adapter snapshot via the normal ``ensure_local`` path, parses + validates the
+state dict (digest-keyed RAM LRU so repeat requests skip disk + parse), then
+applies the adapters UNFUSED via ``load_lora_weights`` + ``set_adapters``
+around the handler call and unloads them after — the base pipeline is
+restored between requests (anima's hot-toggle pattern).
+"""
+
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
-from typing import Any, Generator, Protocol, runtime_checkable
+import math
+import re
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, runtime_checkable
 
-from ..api.types import Tensors
+from ..api.errors import RefCompatibilitySurprise, ValidationError
 
 logger = logging.getLogger(__name__)
+
+_GiB = 1024**3
+
+# Worker-side sanity bounds. Weight bounds mirror the hub's `_models` gate;
+# the rest guard a worker that receives a job from a buggy/bypassed hub.
+MAX_LORAS_PER_REQUEST = 8
+MAX_LORA_FILE_BYTES = 2 * _GiB
+LORA_WEIGHT_BOUND = 4.0
+ADAPTER_CACHE_MAX_BYTES = 1 * _GiB
+
+# LoRA-shaped keys only: kohya (`…lora_down.weight` / `…lora_up.weight` /
+# `….alpha`), peft (`…lora_A.weight` / `…lora_B.weight`, DoRA magnitude), and
+# diffusers attn-processor (`…lora.down.weight`) conventions. Anything else in
+# an adapter file is key stuffing and is rejected before touching the model.
+_LORA_KEY_RE = re.compile(
+    r"(?:"
+    r"\.(?:lora[._])?(?:down|up)\.weight"
+    r"|\.lora_[AB](?:\.[\w-]+)?\.weight"
+    r"|\.alpha"
+    r"|\.dora_scale"
+    r"|\.lora_magnitude_vector(?:\.[\w-]+)?(?:\.weight)?"
+    r")$"
+)
 
 
 @runtime_checkable
@@ -16,66 +55,219 @@ class LoraCapablePipeline(Protocol):
     def unload_lora_weights(self) -> None: ...
 
 
-@contextmanager
-def load_loras(
-    pipeline: LoraCapablePipeline,
-    loras: list[Any],
-    request_id: str = "",
-) -> Generator[None, None, None]:
-    """Context manager that loads LoRA adapters onto *pipeline* for the duration
-    of the ``with`` block, then unloads them.
+@dataclass
+class PreparedAdapter:
+    """One overlay, materialized and parsed, ready for GPU application."""
 
-    Handles:
-    - Missing ``alpha`` keys (injects alpha = rank so diffusers doesn't error)
-    - Multi-adapter ``set_adapters`` with per-lora weights
-    - Guaranteed cleanup via ``unload_lora_weights`` in the finally block
+    slot: str
+    ref: str
+    name: str  # unique-per-request diffusers adapter_name
+    weight: float
+    state_dict: Dict[str, Any]
+    from_cache: bool = False
+    ensure_ms: int = 0  # snapshot materialization (0 when already on disk)
+    parse_ms: int = 0   # safetensors read + validation (0 on cache hit)
 
-    Usage::
 
-        with load_loras(pipeline, payload.loras, ctx.request_id):
-            result = pipeline(...)
-    """
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_overlay_weight(weight: float, *, ref: str = "") -> float:
+    """Mirror the hub's [-4, 4] weight gate. 0.0 (proto3 unset) means 1.0."""
+    w = float(weight)
+    if not math.isfinite(w) or abs(w) > LORA_WEIGHT_BOUND:
+        raise ValidationError(
+            f"lora weight {w} out of bounds [-{LORA_WEIGHT_BOUND:g}, "
+            f"{LORA_WEIGHT_BOUND:g}] (ref={ref})"
+        )
+    return w if w != 0.0 else 1.0
+
+
+def validate_lora_keys(keys: Iterable[str], *, ref: str = "") -> None:
+    bad = [k for k in keys if not _LORA_KEY_RE.search(k)]
+    if bad:
+        raise RefCompatibilitySurprise(
+            f"adapter contains {len(bad)} non-LoRA key(s) "
+            f"(e.g. {', '.join(sorted(bad)[:3])}) — only "
+            "lora_down/up, lora_A/B, and alpha-shaped keys are accepted",
+            ref=ref,
+            axis="state_dict",
+        )
+
+
+def find_adapter_file(snapshot_path: Path, *, ref: str = "") -> Path:
+    """The adapter payload inside a materialized snapshot: its (largest)
+    ``.safetensors`` file. Safetensors-only — no pickle formats, ever."""
+    p = Path(snapshot_path)
+    if p.is_file():
+        if p.suffix != ".safetensors":
+            raise RefCompatibilitySurprise(
+                f"adapter file is not safetensors: {p.name}",
+                ref=ref, axis="component_missing",
+            )
+        return p
+    files = sorted(p.rglob("*.safetensors"), key=lambda f: f.stat().st_size, reverse=True)
+    if not files:
+        raise RefCompatibilitySurprise(
+            "adapter snapshot contains no .safetensors file",
+            ref=ref, axis="component_missing",
+        )
+    return files[0]
+
+
+def load_adapter_state_dict(path: Path, *, ref: str = "") -> Dict[str, Any]:
+    """Parse + validate one adapter file. Injects missing kohya ``alpha``
+    keys (alpha = rank) so diffusers doesn't error."""
     from safetensors.torch import load_file as load_safetensors
     import torch
 
-    loaded_adapters: list[str] = []
+    size = Path(path).stat().st_size
+    if size > MAX_LORA_FILE_BYTES:
+        raise ValidationError(
+            f"lora adapter too large: {size} bytes (max {MAX_LORA_FILE_BYTES}) (ref={ref})"
+        )
     try:
-        for i, spec in enumerate(loras):
-            tensors = getattr(spec, "tensors", None)
-            if not isinstance(tensors, Tensors):
-                raise RuntimeError(
-                    f"LoRA {i} must expose a tensors: Tensors field"
-                )
-            if tensors.local_path is None:
-                raise RuntimeError(f"LoRA {i} not materialized (local_path is None)")
-            name = spec.adapter_name or f"lora_{i}"
-            state_dict = load_safetensors(tensors.local_path)
-            for key in list(state_dict.keys()):
-                if "lora_down.weight" in key:
-                    alpha_key = key.replace("lora_down.weight", "alpha")
-                    if alpha_key not in state_dict:
-                        rank = state_dict[key].shape[0]
-                        state_dict[alpha_key] = torch.tensor(float(rank))
-                        logger.info(
-                            "[request_id=%s] injected missing alpha key %r = %d",
-                            request_id,
-                            alpha_key,
-                            rank,
-                        )
-            pipeline.load_lora_weights(state_dict, adapter_name=name)
-            loaded_adapters.append(name)
+        state_dict = load_safetensors(str(path))
+    except Exception as exc:
+        raise RefCompatibilitySurprise(
+            f"unreadable adapter safetensors: {exc}", ref=ref, axis="state_dict"
+        ) from exc
+    validate_lora_keys(state_dict.keys(), ref=ref)
+    for key in list(state_dict.keys()):
+        if key.endswith("lora_down.weight"):
+            alpha_key = key[: -len("lora_down.weight")] + "alpha"
+            if alpha_key not in state_dict:
+                state_dict[alpha_key] = torch.tensor(float(state_dict[key].shape[0]))
+    return state_dict
 
-        if loaded_adapters:
-            pipeline.set_adapters(
-                loaded_adapters,
-                adapter_weights=[float(getattr(s, "weight", 1.0)) for s in loras],
-            )
 
-        yield
+# ---------------------------------------------------------------------------
+# Digest-keyed RAM cache of parsed state dicts
+# ---------------------------------------------------------------------------
 
-    finally:
-        if loaded_adapters and hasattr(pipeline, "unload_lora_weights"):
+
+def state_dict_bytes(state_dict: Dict[str, Any]) -> int:
+    total = 0
+    for v in state_dict.values():
+        n = getattr(v, "nbytes", 0)
+        total += int(n or 0)
+    return total
+
+
+class AdapterCache:
+    """LRU of parsed adapter state dicts keyed by ``ref@digest`` (RAM tier).
+
+    LoRAs are small; a modest byte cap lets repeat requests skip disk + parse
+    without competing with base-component residency. Thread-safe."""
+
+    def __init__(self, max_bytes: int = ADAPTER_CACHE_MAX_BYTES) -> None:
+        self._max = int(max_bytes)
+        self._entries: "OrderedDict[str, tuple[Dict[str, Any], int]]" = OrderedDict()
+        self._bytes = 0
+        self._lock = threading.Lock()
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            hit = self._entries.get(key)
+            if hit is None:
+                self.misses += 1
+                return None
+            self._entries.move_to_end(key)
+            self.hits += 1
+            return hit[0]
+
+    def put(self, key: str, state_dict: Dict[str, Any]) -> None:
+        size = state_dict_bytes(state_dict)
+        if size > self._max:
+            return
+        with self._lock:
+            if key in self._entries:
+                return
+            self._entries[key] = (state_dict, size)
+            self._bytes += size
+            while self._bytes > self._max and len(self._entries) > 1:
+                _, (_, evicted) = self._entries.popitem(last=False)
+                self._bytes -= evicted
+
+    @property
+    def total_bytes(self) -> int:
+        with self._lock:
+            return self._bytes
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+# ---------------------------------------------------------------------------
+# Apply / unload (GPU side; run off the event loop)
+# ---------------------------------------------------------------------------
+
+
+def apply_adapters(
+    pipeline: Any, adapters: Sequence[PreparedAdapter], request_id: str = ""
+) -> None:
+    """Load *adapters* onto *pipeline* as named UNFUSED adapters and activate
+    them with their weights. Any failure rolls the pipeline back clean."""
+    if not isinstance(pipeline, LoraCapablePipeline):
+        raise ValidationError(
+            "model slot does not support LoRA adapters "
+            "(pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)"
+        )
+    loaded: List[str] = []
+    t0 = time.monotonic()
+    try:
+        for a in adapters:
             try:
-                pipeline.unload_lora_weights()
-            except Exception:
-                logger.warning("unload_lora_weights failed; pipeline may have stale adapters", exc_info=True)
+                # Shallow copy: diffusers' conversion utilities consume the
+                # dict they're given; the cached entry must stay intact.
+                pipeline.load_lora_weights(dict(a.state_dict), adapter_name=a.name)
+            except (ValidationError, RefCompatibilitySurprise):
+                raise
+            except Exception as exc:
+                raise RefCompatibilitySurprise(
+                    f"adapter failed to load onto base pipeline: {exc}",
+                    ref=a.ref, axis="pipeline_load",
+                ) from exc
+            loaded.append(a.name)
+        load_ms = int((time.monotonic() - t0) * 1000)
+        t1 = time.monotonic()
+        pipeline.set_adapters(
+            [a.name for a in adapters], adapter_weights=[a.weight for a in adapters]
+        )
+        set_ms = int((time.monotonic() - t1) * 1000)
+        logger.info(
+            "[request_id=%s] lora adapters active: %s (load_ms=%d set_ms=%d)",
+            request_id,
+            "; ".join(
+                f"{a.ref}@{a.weight:g} [{'cache' if a.from_cache else 'cold'}"
+                f" ensure_ms={a.ensure_ms} parse_ms={a.parse_ms}]"
+                for a in adapters
+            ),
+            load_ms, set_ms,
+        )
+    except BaseException:
+        if loaded:
+            unload_adapters(pipeline, request_id=request_id)
+        raise
+
+
+def unload_adapters(pipeline: Any, request_id: str = "") -> int:
+    """Remove every request-scoped adapter from *pipeline* (guaranteed-clean
+    teardown; never raises). Returns unload wall ms, -1 on failure."""
+    t0 = time.monotonic()
+    try:
+        pipeline.unload_lora_weights()
+    except Exception:
+        logger.warning(
+            "[request_id=%s] unload_lora_weights failed; pipeline may have stale adapters",
+            request_id, exc_info=True,
+        )
+        return -1
+    ms = int((time.monotonic() - t0) * 1000)
+    logger.info("[request_id=%s] lora adapters unloaded (unload_ms=%d)", request_id, ms)
+    return ms

--- a/tests/test_executor_lora.py
+++ b/tests/test_executor_lora.py
@@ -1,0 +1,432 @@
+"""gw#393 per-request LoRA overlays: wire -> materialize -> apply -> unload.
+
+RunJob ModelBinding.loras reaches the executor; adapter snapshots ride the
+normal ensure_local path; state dicts hit the digest-keyed RAM LRU; adapters
+apply UNFUSED around the handler call and are removed on EVERY exit path
+(OK / handler error / cancel). Validation mirrors the hub gates worker-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.api.errors import RefCompatibilitySurprise, ValidationError
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+from gen_worker.utils import lora as lora_util
+
+MODEL_REF = "acme/sdxl-base"
+LORA_A = "user1/lora-anime"
+LORA_B = "user1/lora-sketch"
+
+
+class _FakeTensor:
+    def __init__(self, nbytes: int = 64) -> None:
+        self.nbytes = nbytes
+        self.shape = (4, 4)
+
+
+def _fake_state_dict(nbytes: int = 64) -> Dict[str, Any]:
+    return {"unet.mid_block.attn.to_q.lora_down.weight": _FakeTensor(nbytes)}
+
+
+class _FakeLoraPipe:
+    def __init__(self, fail_load: bool = False) -> None:
+        self.calls: List[Any] = []
+        self.active: List[str] = []
+        self.weights: List[float] = []
+        self.fail_load = fail_load
+
+    def load_lora_weights(self, state_dict, adapter_name: str = "") -> None:
+        if self.fail_load:
+            raise RuntimeError("size mismatch for lora_up.weight")
+        self.calls.append(("load", adapter_name))
+
+    def set_adapters(self, names, adapter_weights=None) -> None:
+        self.calls.append(("set", tuple(names), tuple(adapter_weights)))
+        self.active = list(names)
+        self.weights = list(adapter_weights)
+
+    def unload_lora_weights(self) -> None:
+        self.calls.append(("unload",))
+        self.active = []
+        self.weights = []
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    fail: bool = False
+
+
+class _Out(msgspec.Struct):
+    active_adapters: int = 0
+    weights: List[float] = []
+    lora_meta: List[List[Any]] = []
+    adapter_ref_pinned: bool = False
+
+
+class _Endpoint:
+    pipe: Optional[_FakeLoraPipe] = None
+    store: Any = None
+
+    def setup(self, pipeline: str) -> None:  # pragma: no cover
+        pass
+
+    def run(self, ctx, payload: _In) -> _Out:
+        if payload.fail:
+            raise RuntimeError("boom")
+        pipe = type(self).pipe
+        meta = [
+            [slot, ov["ref"], ov["weight"]]
+            for slot, loras in sorted(ctx.loras.items()) for ov in loras
+        ]
+        pinned = bool(type(self).store and type(self).store.residency.in_use(LORA_A))
+        return _Out(
+            active_adapters=len(pipe.active), weights=list(pipe.weights),
+            lora_meta=meta, adapter_ref_pinned=pinned,
+        )
+
+
+def _spec() -> EndpointSpec:
+    return EndpointSpec(
+        name="txt2img", method=_Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Endpoint,
+        attr_name="run", models={"pipeline": Hub(MODEL_REF)},
+    )
+
+
+class _Harness:
+    def __init__(self, tmp_path: Path, monkeypatch, *, pipe: Optional[_FakeLoraPipe] = None) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.ensured: List[str] = []
+        self.parsed: List[str] = []
+        self.tmp_path = tmp_path
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        spec = _spec()
+        self.spec = spec
+        self.executor = Executor([spec], _send)
+        self.pipe = pipe or _FakeLoraPipe()
+        _Endpoint.pipe = self.pipe
+        _Endpoint.store = self.executor.store
+        rec = self.executor._classes[spec.instance_key]
+        rec.instance = _Endpoint()
+        rec.ready = True
+        self.executor.store.residency.track_vram(
+            wire_ref(spec.models["pipeline"]), self.pipe, vram_bytes=1)
+
+        async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+            self.ensured.append(ref)
+            d = tmp_path / ref.replace("/", "--")
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "adapter.safetensors").write_bytes(b"x" * 8)
+            self.executor.store.residency.track_disk(ref, d)
+            return d
+
+        self.executor.store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+
+        def _fake_parse(path: Path, *, ref: str = "") -> Dict[str, Any]:
+            self.parsed.append(ref)
+            return _fake_state_dict()
+
+        monkeypatch.setattr(lora_util, "load_adapter_state_dict", _fake_parse)
+
+    async def run(self, *, loras=(), payload: Optional[_In] = None,
+                  request_id: str = "r1", snapshots=None) -> pb.JobResult:
+        run = pb.RunJob(
+            request_id=request_id, attempt=1, function_name="txt2img",
+            input_payload=msgspec.msgpack.encode(payload or _In()),
+            models=[pb.ModelBinding(slot="pipeline", ref=MODEL_REF, loras=list(loras))],
+        )
+        for ref, digest in (snapshots or {}).items():
+            run.snapshots[ref].digest = digest
+        await self.executor.handle_run_job(run)
+        job = self.executor.jobs[(request_id, 1)]
+        assert job.task is not None
+        await job.task
+        results = [m.job_result for m in self.sent if m.WhichOneof("msg") == "job_result"]
+        assert results, f"no job_result; sent={self.sent}"
+        return results[-1]
+
+
+def _ov(ref: str, weight: float = 1.0) -> pb.LoraOverlay:
+    return pb.LoraOverlay(ref=ref, weight=weight)
+
+
+# ---------------------------------------------------------------------------
+# Wire -> apply -> unload
+# ---------------------------------------------------------------------------
+
+
+def test_adapters_active_during_handler_and_unloaded_after(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run(loras=[_ov(LORA_A, 0.8), _ov(LORA_B, -0.5)])
+        assert res.status == pb.JOB_STATUS_OK
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.active_adapters == 2
+        assert out.weights == [0.8, -0.5]
+        assert out.adapter_ref_pinned  # executing() covers adapter refs
+        assert h.ensured == [LORA_A, LORA_B]
+        kinds = [c[0] for c in h.pipe.calls]
+        assert kinds == ["load", "load", "set", "unload"]
+        assert h.pipe.active == []  # clean after the request
+
+    asyncio.run(_run())
+
+
+def test_ctx_loras_surfaces_refs_and_weights(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run(loras=[_ov(LORA_A, 0.8)])
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.lora_meta == [["pipeline", LORA_A, 0.8]]
+
+    asyncio.run(_run())
+
+
+def test_no_loras_is_a_no_op(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run()
+        assert res.status == pb.JOB_STATUS_OK
+        assert h.pipe.calls == []
+        assert h.ensured == []
+
+    asyncio.run(_run())
+
+
+def test_unload_runs_when_handler_raises(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run(loras=[_ov(LORA_A)], payload=_In(fail=True))
+        assert res.status == pb.JOB_STATUS_FATAL
+        assert h.pipe.calls[-1] == ("unload",)
+        assert h.pipe.active == []
+
+    asyncio.run(_run())
+
+
+def test_failed_adapter_load_rolls_back_and_is_invalid(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch, pipe=_FakeLoraPipe(fail_load=True))
+        # Second adapter fails to load -> the first is rolled back; the job
+        # fails INVALID (ref_compatibility_surprise), never reaches the handler.
+        h.pipe.fail_load = False
+        real_load = h.pipe.load_lora_weights
+
+        def _load_second_fails(state_dict, adapter_name=""):
+            if len([c for c in h.pipe.calls if c[0] == "load"]) >= 1:
+                raise RuntimeError("size mismatch for lora_up.weight")
+            real_load(state_dict, adapter_name=adapter_name)
+
+        h.pipe.load_lora_weights = _load_second_fails
+        res = await h.run(loras=[_ov(LORA_A), _ov(LORA_B)])
+        assert res.status == pb.JOB_STATUS_INVALID
+        assert "failed to load onto base pipeline" in res.safe_message
+        assert h.pipe.calls[-1] == ("unload",)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Validation (worker-side mirrors of the hub gates)
+# ---------------------------------------------------------------------------
+
+
+def test_weight_out_of_bounds_is_invalid(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run(loras=[_ov(LORA_A, 4.5)])
+        assert res.status == pb.JOB_STATUS_INVALID
+        assert "out of bounds" in res.safe_message
+        assert h.pipe.calls == []
+        assert h.ensured == []  # rejected before any download
+
+    asyncio.run(_run())
+
+
+def test_too_many_adapters_is_invalid(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        overlays = [_ov(f"u/l{i}") for i in range(lora_util.MAX_LORAS_PER_REQUEST + 1)]
+        res = await h.run(loras=overlays)
+        assert res.status == pb.JOB_STATUS_INVALID
+        assert "too many lora adapters" in res.safe_message
+        assert h.ensured == []
+
+    asyncio.run(_run())
+
+
+def test_unknown_slot_is_invalid(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        run = pb.RunJob(
+            request_id="r1", attempt=1, function_name="txt2img",
+            input_payload=msgspec.msgpack.encode(_In()),
+            models=[
+                pb.ModelBinding(slot="pipeline", ref=MODEL_REF),
+                pb.ModelBinding(slot="ghost", ref="x/y", loras=[_ov(LORA_A)]),
+            ],
+        )
+        await h.executor.handle_run_job(run)
+        await h.executor.jobs[("r1", 1)].task
+        results = [m.job_result for m in h.sent if m.WhichOneof("msg") == "job_result"]
+        assert results[-1].status == pb.JOB_STATUS_INVALID
+        assert "unknown model slot" in results[-1].safe_message
+
+    asyncio.run(_run())
+
+
+def test_slot_without_worker_managed_pipeline_is_invalid(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        # Simulate a tenant-loaded slot: residency has no object for the ref.
+        h.executor.store.residency.evict(wire_ref(h.spec.models["pipeline"]), force=True)
+        res = await h.run(loras=[_ov(LORA_A)])
+        assert res.status == pb.JOB_STATUS_INVALID
+        assert "no worker-managed pipeline" in res.safe_message
+
+    asyncio.run(_run())
+
+
+def test_weight_zero_means_default_one(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        res = await h.run(loras=[_ov(LORA_A, 0.0)])  # proto3 unset
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.weights == [1.0]
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Adapter RAM cache
+# ---------------------------------------------------------------------------
+
+
+def test_repeat_request_hits_adapter_cache(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc123"}
+        await h.run(loras=[_ov(LORA_A)], request_id="r1", snapshots=snaps)
+        await h.run(loras=[_ov(LORA_A)], request_id="r2", snapshots=snaps)
+        assert h.parsed == [LORA_A]  # parsed once, served from RAM after
+        assert h.executor._adapter_cache.hits == 1
+
+    asyncio.run(_run())
+
+
+def test_digest_change_invalidates_cache_key(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        await h.run(loras=[_ov(LORA_A)], request_id="r1",
+                    snapshots={LORA_A: "sha256:aaa"})
+        await h.run(loras=[_ov(LORA_A)], request_id="r2",
+                    snapshots={LORA_A: "sha256:bbb"})
+        assert h.parsed == [LORA_A, LORA_A]  # re-parsed under the new digest
+
+    asyncio.run(_run())
+
+
+def test_adapter_cache_lru_byte_cap() -> None:
+    cache = lora_util.AdapterCache(max_bytes=100)
+    cache.put("a", _fake_state_dict(60))
+    cache.put("b", _fake_state_dict(60))  # over cap -> LRU 'a' evicted
+    assert cache.get("a") is None
+    assert cache.get("b") is not None
+    cache.put("huge", _fake_state_dict(1000))  # larger than cap -> not cached
+    assert cache.get("huge") is None
+    assert len(cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# State-dict validation (key stuffing, weights, files)
+# ---------------------------------------------------------------------------
+
+
+def test_lora_key_patterns() -> None:
+    good = [
+        "lora_unet_down_blocks_0_attn.lora_down.weight",
+        "lora_unet_down_blocks_0_attn.lora_up.weight",
+        "lora_unet_down_blocks_0_attn.alpha",
+        "unet.mid.attn.to_q.lora_A.weight",
+        "unet.mid.attn.to_q.lora_B.weight",
+        "text_encoder.layers.0.q.lora_A.default.weight",
+        "unet.up.attn.processor.to_v_lora.down.weight",
+        "unet.up.attn.processor.to_v_lora.up.weight",
+        "unet.mid.attn.to_q.lora_magnitude_vector",  # DoRA
+        "unet.mid.attn.to_q.dora_scale",
+    ]
+    lora_util.validate_lora_keys(good)
+
+    for bad in (
+        "unet.mid_block.attn.to_q.weight",       # full-weight replacement
+        "state_dict_pickle_payload",             # junk
+        "unet.conv_in.bias",                     # bias stuffing
+        "text_model.embeddings.token_embedding.weight",  # embedding stuffing
+    ):
+        with pytest.raises(RefCompatibilitySurprise):
+            lora_util.validate_lora_keys(good + [bad])
+
+
+def test_weight_bound_helper() -> None:
+    assert lora_util.validate_overlay_weight(0.0) == 1.0
+    assert lora_util.validate_overlay_weight(-4.0) == -4.0
+    with pytest.raises(ValidationError):
+        lora_util.validate_overlay_weight(4.01)
+    with pytest.raises(ValidationError):
+        lora_util.validate_overlay_weight(float("nan"))
+
+
+def test_find_adapter_file_prefers_safetensors(tmp_path) -> None:
+    d = tmp_path / "snap"
+    d.mkdir()
+    (d / "small.safetensors").write_bytes(b"x" * 4)
+    (d / "big.safetensors").write_bytes(b"x" * 400)
+    (d / "README.md").write_text("readme")
+    assert lora_util.find_adapter_file(d).name == "big.safetensors"
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(RefCompatibilitySurprise):
+        lora_util.find_adapter_file(empty)
+
+
+def test_state_dict_parse_validates_and_injects_alpha(tmp_path) -> None:
+    st = pytest.importorskip("safetensors.torch")
+    torch = pytest.importorskip("torch")
+
+    f = tmp_path / "ok.safetensors"
+    st.save_file({
+        "lora_unet_mid_attn.lora_down.weight": torch.zeros(4, 8),
+        "lora_unet_mid_attn.lora_up.weight": torch.zeros(8, 4),
+    }, str(f))
+    sd = lora_util.load_adapter_state_dict(f)
+    assert float(sd["lora_unet_mid_attn.alpha"]) == 4.0  # alpha = rank
+
+    stuffed = tmp_path / "stuffed.safetensors"
+    st.save_file({
+        "lora_unet_mid_attn.lora_down.weight": torch.zeros(4, 8),
+        "unet.conv_in.weight": torch.zeros(3, 3),  # full-weight stuffing
+    }, str(stuffed))
+    with pytest.raises(RefCompatibilitySurprise):
+        lora_util.load_adapter_state_dict(stuffed)
+
+
+def test_oversized_adapter_rejected(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("safetensors.torch")
+    monkeypatch.setattr(lora_util, "MAX_LORA_FILE_BYTES", 4)
+    f = tmp_path / "big.safetensors"
+    f.write_bytes(b"x" * 64)
+    with pytest.raises(ValidationError):
+        lora_util.load_adapter_state_dict(f)

--- a/tests/test_lora_e2e_local.py
+++ b/tests/test_lora_e2e_local.py
@@ -1,0 +1,199 @@
+"""gw#393 local end-to-end: REAL diffusers pipeline on CPU, real safetensors
+LoRA file, full executor RunJob path (wire -> ensure_local -> parse/validate ->
+load_lora_weights/set_adapters -> handler -> unload).
+
+Proves, with pixel equality:
+  1. an applied adapter changes the output deterministically,
+  2. unload restores the baseline exactly (pipeline byte-clean per request),
+  3. a repeat request serves the parsed state dict from the RAM cache.
+
+Requires torch + diffusers (+ transformers/peft); skipped otherwise. Run:
+  uv run --extra dev pytest tests/test_lora_e2e_local.py  (in a torch venv)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import msgspec
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+pytest.importorskip("peft")
+
+from gen_worker.api.binding import Hub, wire_ref  # noqa: E402
+from gen_worker.executor import Executor  # noqa: E402
+from gen_worker.pb import worker_scheduler_pb2 as pb  # noqa: E402
+from gen_worker.registry import EndpointSpec  # noqa: E402
+
+TINY_SD = "hf-internal-testing/tiny-stable-diffusion-torch"
+MODEL_REF = "acme/tiny-sd"
+LORA_REF = "user1/tiny-lora"
+
+
+class _In(msgspec.Struct):
+    seed: int = 0
+
+
+class _Out(msgspec.Struct):
+    checksum: str = ""
+
+
+class _Endpoint:
+    pipe: Any = None
+
+    def setup(self, pipeline: str) -> None:  # pragma: no cover
+        pass
+
+    def run(self, ctx, payload: _In) -> _Out:
+        import hashlib
+
+        out = type(self).pipe(
+            "a photo of a cat",
+            num_inference_steps=2,
+            guidance_scale=7.5,
+            generator=torch.Generator("cpu").manual_seed(payload.seed),
+            output_type="np",
+        ).images[0]
+        return _Out(checksum=hashlib.sha256(out.tobytes()).hexdigest())
+
+
+def _kohya_lora_file(pipe: Any, path: Path, *, rank: int = 4, seed: int = 7) -> None:
+    """Build a real kohya-format LoRA safetensors targeting the pipe's unet
+    attention projections — the format civitai LoRAs arrive in."""
+    from safetensors.torch import save_file
+
+    g = torch.Generator("cpu").manual_seed(seed)
+    sd: Dict[str, torch.Tensor] = {}
+    n = 0
+    for name, mod in pipe.unet.named_modules():
+        if not isinstance(mod, torch.nn.Linear):
+            continue
+        if not name.endswith(("to_q", "to_k", "to_v")):
+            continue
+        kohya = "lora_unet_" + name.replace(".", "_")
+        sd[f"{kohya}.lora_down.weight"] = torch.randn(
+            rank, mod.in_features, generator=g) * 0.5
+        sd[f"{kohya}.lora_up.weight"] = torch.randn(
+            mod.out_features, rank, generator=g) * 0.5
+        sd[f"{kohya}.alpha"] = torch.tensor(float(rank))
+        n += 1
+        if n >= 4:
+            break
+    assert n > 0, "tiny unet exposed no attention Linears"
+    save_file(sd, str(path))
+
+
+@pytest.fixture(scope="module")
+def tiny_pipe():
+    pipe = diffusers.StableDiffusionPipeline.from_pretrained(TINY_SD)
+    pipe.set_progress_bar_config(disable=True)
+    return pipe
+
+
+class _Harness:
+    def __init__(self, tmp_path: Path, pipe: Any) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.pipe = pipe
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        spec = EndpointSpec(
+            name="txt2img", method=_Endpoint.run, kind="inference",
+            payload_type=_In, output_mode="single", cls=_Endpoint,
+            attr_name="run", models={"pipeline": Hub(MODEL_REF)},
+        )
+        self.executor = Executor([spec], _send)
+        _Endpoint.pipe = pipe
+        rec = self.executor._classes[spec.instance_key]
+        rec.instance = _Endpoint()
+        rec.ready = True
+        self.executor.store.residency.track_ram(wire_ref(spec.models["pipeline"]), pipe)
+
+        lora_dir = tmp_path / "lora-snap"
+        lora_dir.mkdir(parents=True, exist_ok=True)
+        _kohya_lora_file(pipe, lora_dir / "adapter.safetensors")
+
+        async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+            assert ref == LORA_REF, f"unexpected ensure_local({ref})"
+            self.executor.store.residency.track_disk(ref, lora_dir)
+            return lora_dir
+
+        self.executor.store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+
+    async def run(self, request_id: str, *, lora_weight: Optional[float] = None) -> str:
+        loras = [] if lora_weight is None else [
+            pb.LoraOverlay(ref=LORA_REF, weight=lora_weight)
+        ]
+        run = pb.RunJob(
+            request_id=request_id, attempt=1, function_name="txt2img",
+            input_payload=msgspec.msgpack.encode(_In(seed=0)),
+            models=[pb.ModelBinding(slot="pipeline", ref=MODEL_REF, loras=loras)],
+        )
+        run.snapshots[LORA_REF].digest = "sha256:tiny-lora-v1"
+        await self.executor.handle_run_job(run)
+        job = self.executor.jobs[(request_id, 1)]
+        await job.task
+        results = [m.job_result for m in self.sent if m.WhichOneof("msg") == "job_result"]
+        res = results[-1]
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+        return msgspec.msgpack.decode(res.inline, type=_Out).checksum
+
+
+def test_adapter_changes_output_and_unload_restores_baseline(tmp_path, tiny_pipe) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, tiny_pipe)
+
+        baseline = await h.run("r-base-1")
+        with_lora = await h.run("r-lora-1", lora_weight=1.0)
+        after = await h.run("r-base-2")
+        repeat = await h.run("r-lora-2", lora_weight=1.0)
+
+        assert with_lora != baseline, "adapter had no visual effect"
+        assert after == baseline, "unload did not restore the baseline pipeline"
+        assert repeat == with_lora, "adapter application is not deterministic"
+        # Repeat adapter request came from the RAM cache (no re-parse).
+        assert h.executor._adapter_cache.hits == 1
+        assert h.executor._adapter_cache.misses == 1
+
+        half = await h.run("r-lora-3", lora_weight=0.5)
+        assert half not in (baseline, with_lora), "weight scaling had no effect"
+
+    asyncio.run(_run())
+
+
+def test_stuffed_adapter_rejected_end_to_end(tmp_path, tiny_pipe) -> None:
+    from safetensors.torch import save_file
+
+    async def _run() -> None:
+        h = _Harness(tmp_path, tiny_pipe)
+        bad_dir = tmp_path / "bad-snap"
+        bad_dir.mkdir()
+        save_file(
+            {"unet.conv_in.weight": torch.zeros(3, 3)},
+            str(bad_dir / "adapter.safetensors"),
+        )
+
+        async def _bad_ensure(ref, snapshot=None, *, binding=None) -> Path:
+            return bad_dir
+
+        h.executor.store.ensure_local = _bad_ensure  # type: ignore[method-assign]
+        run = pb.RunJob(
+            request_id="r-bad", attempt=1, function_name="txt2img",
+            input_payload=msgspec.msgpack.encode(_In()),
+            models=[pb.ModelBinding(
+                slot="pipeline", ref=MODEL_REF,
+                loras=[pb.LoraOverlay(ref="evil/stuffed", weight=1.0)],
+            )],
+        )
+        await h.executor.handle_run_job(run)
+        await h.executor.jobs[("r-bad", 1)].task
+        results = [m.job_result for m in h.sent if m.WhichOneof("msg") == "job_result"]
+        assert results[-1].status == pb.JOB_STATUS_INVALID
+        assert "non-LoRA key" in results[-1].safe_message
+
+    asyncio.run(_run())

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -1,4 +1,4 @@
-"""RequestContext surface: <=15 public members, one cancellation spelling,
+"""RequestContext surface: <=16 public members, one cancellation spelling,
 typed save_* assets, generator(seed), and real subclass inheritance for the
 producer contexts (no import-time setattr)."""
 
@@ -20,7 +20,7 @@ def _ctx(**kw) -> RequestContext:
     return RequestContext(request_id="r1", **kw)
 
 
-def test_public_surface_is_capped_at_15_members() -> None:
+def test_public_surface_is_capped_at_16_members() -> None:
     members = sorted(
         n for n in dir(RequestContext)
         if not n.startswith("_")
@@ -29,10 +29,10 @@ def test_public_surface_is_capped_at_15_members() -> None:
         "request_id", "device", "deadline", "time_remaining",
         "cancelled", "raise_if_cancelled", "progress", "log",
         "save_bytes", "save_file", "save_image", "save_audio", "save_video",
-        "generator", "models",
+        "generator", "models", "loras",
     }
     assert set(members) == expected
-    assert len(members) <= 15
+    assert len(members) <= 16
 
 
 def test_one_cancellation_spelling() -> None:


### PR DESCRIPTION
Implements the worker half of gw#393 (BYOM LoRA serving) on top of the #101 proto re-add.

## Wire -> serving
- `RunJob.models[].loras` (LoraOverlay{ref, weight}) materializes through the normal `ensure_local` snapshot path (disk GC, ref-index, ModelEvents — hub learns adapter download bandwidth like any ref)
- Adapters apply UNFUSED via `load_lora_weights` + `set_adapters` around the handler call (anima hot-toggle pattern), scoped to the request: unloaded on EVERY exit path (OK / handler error / cancel / deadline), rollback on partial multi-adapter load failure
- Adapter refs ride the `executing()` pin — not eviction candidates mid-job
- `ctx.loras`: read-only slot -> ({ref, weight}, …) metadata surface

## Adapter RAM cache
- `AdapterCache`: LRU of parsed state dicts keyed by `ref@digest` (snapshot digest, falls back to CAS dir name), 1 GiB byte cap; repeat requests skip disk+parse. `LoadedComponentKey.adapter_id` left for a later fused-variant cache.

## Validation (worker-side mirrors)
- weight in [-4, 4] (0.0 = proto3 unset = 1.0); max 8 adapters/request; 2 GiB per-file sanity cap; safetensors-only
- key-pattern gate: only lora_down/up, lora_A/B (+DoRA), alpha-shaped keys — key stuffing => typed `RefCompatibilitySurprise` => JOB_STATUS_INVALID
- unknown slot / slot without a worker-managed pipeline => INVALID

## Measured swap cost (real SD1.5 + real LCM-LoRA sdv1-5, 135 MB, CPU)
- parse+validate cold: 822 ms; cache hit: ~3 µs
- `load_lora_weights`: 294–414 ms; `set_adapters`: 10–12 ms; `unload`: 47–66 ms
- logged per request: `lora adapters active: <ref>@<w> [cache|cold ensure_ms parse_ms] (load_ms set_ms)` + `unload_ms`

## Tests
- `tests/test_executor_lora.py`: 18 wire/validation/cache/rollback tests
- `tests/test_lora_e2e_local.py`: real-diffusers CPU e2e — adapter changes output deterministically, unload restores the exact baseline checksum, repeat request cache-hits; stuffed adapter rejected end-to-end (2 passed in torch venv)
- Full suite: 359 passed, 5 skipped; 4 failed + 2 errors in `test_fp8_and_emergency_loading.py` are pre-existing on origin/master (torch-less env), unrelated

Deferred: `gen-worker run/serve` local `_models.loras` parity (follow-up issue; CLI surface is being reworked by a sibling).