### PR TITLE
feat(api): allow_lora on Hub/HF bindings — endpoint-declared LoRA opt-in (ie#358)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.10.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -39,7 +39,13 @@ def _clean_storage_dtype(v: object) -> str:
 
 @dataclass(frozen=True)
 class Hub:
-    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=)``."""
+    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=, allow_lora=)``.
+
+    ``allow_lora=True`` opts the slot into per-request LoRA overlays
+    (``_models.<slot>.loras``, ie#358) — the endpoint must also declare
+    ``Compile(family=...)`` so the hub's architecture gate can police
+    adapter targets.
+    """
 
     PROVIDER: ClassVar[str] = "tensorhub"
 
@@ -47,12 +53,14 @@ class Hub:
     tag: str = "prod"
     flavor: str = ""
     storage_dtype: str = ""
+    allow_lora: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "ref", _clean(self.ref))
         object.__setattr__(self, "tag", _clean(self.tag) or "prod")
         object.__setattr__(self, "flavor", _clean(self.flavor))
         object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
+        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
         if not self.ref:
             raise ValueError(f"{type(self).__name__} requires a non-empty ref")
 
@@ -81,6 +89,7 @@ class HF:
     subfolder: str = ""
     files: tuple[str, ...] = ()
     storage_dtype: str = ""
+    allow_lora: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "ref", _clean(self.ref))
@@ -91,6 +100,7 @@ class HF:
             self, "files", tuple(_clean(p) for p in self.files if _clean(p))
         )
         object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
+        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
         if "/" not in self.ref:
             raise ValueError(f"HF(id=) must be 'owner/repo', got {self.ref!r}")
 

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -33,6 +33,8 @@ def describe_binding(binding: Any) -> Dict[str, Any]:
             v = getattr(binding, key, "")
             if v:
                 out[key] = v
+        if getattr(binding, "allow_lora", False):
+            out["allow_lora"] = True
         files = tuple(getattr(binding, "files", ()) or ())
         if files:
             out["files"] = list(files)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -292,6 +292,8 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
         out["tag"] = binding.tag
         if binding.flavor:
             out["flavor"] = binding.flavor
+        if binding.allow_lora:
+            out["allow_lora"] = True
     elif isinstance(binding, HF):
         for k in ("revision", "dtype", "subfolder"):
             v = getattr(binding, k)
@@ -299,6 +301,8 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
                 out[k] = v
         if binding.files:
             out["files"] = list(binding.files)
+        if binding.allow_lora:
+            out["allow_lora"] = True
     elif isinstance(binding, Civitai):
         if binding.version:
             out["version"] = binding.version
@@ -435,6 +439,18 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             key: _binding_to_manifest(binding, key)
             for key, binding in es.models.items()
         }
+        # allow_lora bindings carry the endpoint's architecture family so the
+        # hub's th#586 gate can police adapter targets (builder rejects
+        # allow_lora without family).
+        compile_family = es.compile.family if es.compile is not None else ""
+        for block in bindings_block.values():
+            if block.get("allow_lora"):
+                if not compile_family:
+                    raise ValueError(
+                        f"{es.name}: allow_lora bindings require "
+                        "Compile(family=...) on the endpoint"
+                    )
+                block["family"] = compile_family
 
         input_schema, input_sha = _schema_and_hash(es.payload_type)
         moderation = _collect_payload_moderation_metadata(es.payload_type)

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -493,3 +493,46 @@ def test_model_shorthand_skips_server_handle_setup_param() -> None:
     (s,) = extract_specs(Chat)
     assert list(s.models) == ["model"]
     assert s.models["model"].ref == "o/llm"
+
+
+# --------------------------------------------------------------------------- #
+# 8. allow_lora bindings (ie#358)                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_allow_lora_binding_emits_flag_and_family() -> None:
+    from gen_worker import Compile, Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(
+        model=Hub("cozy/sdxl-base", allow_lora=True),
+        resources=Resources(vram_gb=12),
+        compile=Compile(family="sdxl", shapes=((1024, 1024),)),
+    )
+    class Gen:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    (entry,) = _extract_entries(Gen, "testmod")
+    (block,) = entry["bindings"].values()
+    assert block["allow_lora"] is True
+    assert block["family"] == "sdxl"
+
+
+def test_allow_lora_without_compile_family_raises() -> None:
+    from gen_worker import Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(model=Hub("cozy/sdxl-base", allow_lora=True), resources=Resources(vram_gb=12))
+    class Gen:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    with pytest.raises(ValueError, match="allow_lora"):
+        _extract_entries(Gen, "testmod")

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the gen-worker side of ie#358 (BYOM LoRA pilot, endpoint declaration surface).

- `Hub()` / `HF()` gain `allow_lora=` — the per-slot opt-in for request-time LoRA overlays (`_models.<slot>.loras`).
- Discovery emits `allow_lora` + `family` (from `Compile(family=)`) on the binding block; raises at collection when `allow_lora` is set without a compile family (the hub's builder rejects that shape — th#586 gate needs a family).
- `run --list` surfaces the flag.
- Version 0.10.0 → 0.10.1 (PyPI 0.10.0 predates gw#393 adapter serving; next release carries both).

Tests: 361 passed, 5 skipped; the 4 fp8-loading failures + 2 errors are pre-existing on master (env-dependent), verified by stash-run.