### PR TITLE
fix(compile): low-VRAM prep mode in the compile-cell key (gw#391 addendum)

### DIFF
--- a/proto/CONTRACT.md
+++ b/proto/CONTRACT.md
@@ -366,8 +366,10 @@ serving in-flight jobs: `ModelEvent{FAILED, error:"model_in_use"}`.
 
 **ADOPT_COMPILE_CACHE** (hot adoption, #567): `ref` is a compile-cache flavor
 ref — `_system/family-<f>#inductor-<sku>-torch<maj.min>`. W downloads the
-artifact snapshot, verifies its key (family/SKU/torch/triton/libs/producer gen-worker version, gw#391) against
-its own runtime, seeds the inductor+triton cache dirs, re-wraps the
+artifact snapshot, verifies its key (family/SKU/torch/triton/libs/producer
+gen-worker version + low-VRAM prep mode, gw#391 — the prep flags are traced
+into the graphs) against its own runtime and resident pipelines, seeds the
+inductor+triton cache dirs, re-wraps the
 already-VRAM-resident modules of endpoints declaring
 `compile=Compile(family=<f>)` (module re-wrap only — weights are untouched,
 no reload), runs one warmup trace, and answers

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -28,10 +28,11 @@ Artifact = deterministic ``.tar.gz``::
 Key sensitivity (all exact-match): family (graph identity), GPU SKU
 (autotune choices + cubin arch), torch (fx-graph cache key), triton
 (cubin/launcher cache key), diffusers (the traced graph is its code), and
-gen-worker itself (gw#391: the worker's load/wrap code shapes the traced
-graph — a cell produced by a different gen-worker can pass every other key
-yet miss inductor's FX-graph cache at trace time, serving eager while
-reporting adopted). ``source_ref`` records which family member the producer
+gen-worker itself plus the producer's low-VRAM prep mode (gw#391: the
+worker's load/wrap/placement code shapes the traced graph — a cell produced
+by a different gen-worker, or traced under different low-VRAM flags, can
+pass every other key yet miss inductor's FX-graph cache at trace time,
+serving eager while reporting adopted). ``source_ref`` records which family member the producer
 compiled from — informational, never part of the match.
 """
 
@@ -165,10 +166,14 @@ def artifact_metadata(
     source_digest: str = "",
     shapes: Iterable[Tuple[int, int]] = (),
     targets: Iterable[str] = (),
+    low_vram_mode: str = "",
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
-    record the family member compiled from — informational only."""
+    record the family member compiled from — informational only.
+    ``low_vram_mode`` is the prep mode the producer pipeline was traced under
+    (gw#391): its flags are traced into the graphs, so a consumer prepped in a
+    different mode must reject the cell."""
     return {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
@@ -179,6 +184,7 @@ def artifact_metadata(
         "source_digest": str(source_digest or ""),
         "shapes": [[int(w), int(h)] for w, h in shapes],
         "targets": list(targets),
+        "low_vram_mode": str(low_vram_mode or ""),
         "libs": _lib_versions(),
     }
 
@@ -391,6 +397,23 @@ def seed_artifact(
     return meta
 
 
+def mode_drift(meta: Dict[str, Any], pipeline: Any) -> str:
+    """'' when the producer's low-VRAM prep mode matches this pipeline's, else
+    the mismatch (gw#391). The prep flags (VAE tiling/slicing, attention
+    slicing, offload hooks) are traced into the FX graphs, so a mode drift is
+    a guaranteed cache miss. Enforced only when the producer recorded one —
+    the check is per-pipeline, so it lives outside :func:`verify`."""
+    want = str(meta.get("low_vram_mode") or "")
+    if not want:
+        return ""
+    from .models.memory import low_vram_mode
+
+    have = low_vram_mode(pipeline)
+    if want != have:
+        return f"low_vram_mode {want!r} != pipeline {have!r}"
+    return ""
+
+
 def _fetch_url(url: str, dest_dir: Path) -> Path:
     dest_dir.mkdir(parents=True, exist_ok=True)
     name = hashlib.sha256(url.encode()).hexdigest()[:16] + ".tar.gz"
@@ -600,6 +623,11 @@ def enable(
     meta = prepare(
         getattr(cfg, "family", "") or "", cache_dir=cache_dir, artifact=artifact
     )
+    if meta is not None:
+        drift = mode_drift(meta, pipeline)
+        if drift:
+            logger.warning("compile-cache: %s; staying eager", drift)
+            meta = None
     return apply(pipeline, cfg, cache_ready=meta is not None)
 
 
@@ -654,9 +682,10 @@ def build(
     # with place_pipeline (placement + vae/attention low-VRAM flags), and
     # those flags are traced INTO the graphs — the FX-graph cache key. A cell
     # built from a differently-prepared pipeline misses at request time, so
-    # the producer must come through the exact same prep. Run on a pod with
-    # the same free-VRAM class as the target workers.
-    place_pipeline(pipe)
+    # the producer must come through the exact same prep, and the mode it
+    # traced under travels in the metadata for adopt-time parity checks. Run
+    # on a pod with the same free-VRAM class as the target workers.
+    placed = place_pipeline(pipe)
     if callable(getattr(pipe, "set_progress_bar_config", None)):
         pipe.set_progress_bar_config(disable=True)
     os.environ[ENV_ALLOW_COLD] = "1"
@@ -688,6 +717,7 @@ def build(
     meta = artifact_metadata(
         family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
+        low_vram_mode=str(placed.get("mode") or ""),
     )
     label = flavor_label(meta["sku"], meta["torch"])
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)
@@ -712,6 +742,7 @@ __all__ = [
     "gen_worker_version",
     "inductor_counters",
     "is_cache_ref",
+    "mode_drift",
     "pack",
     "prepare",
     "runtime_key",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1070,9 +1070,10 @@ class Executor:
         artifact = compile_cache.find_artifact(local)
         if artifact is None:
             return await fail("artifact_missing")
+        meta: Dict[str, Any] = {}
         if not is_trt:
             try:
-                await asyncio.to_thread(
+                meta = await asyncio.to_thread(
                     compile_cache.seed_artifact, artifact, family, self.store._cache_dir
                 )
             except compile_cache.AdoptError as exc:
@@ -1103,6 +1104,13 @@ class Executor:
                         except Exception as exc:
                             return await fail("artifact_invalid", str(exc))
                     else:
+                        # Graph-key parity (gw#391): the producer's low-VRAM
+                        # prep mode is traced into the cells — a drifted
+                        # pipeline can only miss, so reject deterministically
+                        # instead of paying a warmup to find out.
+                        drift = compile_cache.mode_drift(meta, obj)
+                        if drift:
+                            return await fail("key_mismatch", drift)
                         # Re-adoption of a re-published cell: drop the previous
                         # wrap + dynamo's in-memory code so warmup re-traces
                         # against the freshly seeded caches (gw#391).

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -580,8 +580,16 @@ def with_oom_retry(
     raise last_exc
 
 
+def low_vram_mode(pipeline: Any) -> str:
+    """The low-VRAM mode :func:`apply_low_vram_config` prepped this pipeline
+    with ('' when never prepped). Part of the compile-cache graph key (gw#391):
+    the flags are traced into the FX graphs."""
+    return str(getattr(pipeline, _COZY_MODE_ATTR, "") or "")
+
+
 __all__ = [
     "apply_low_vram_config",
+    "low_vram_mode",
     "place_pipeline",
     "with_oom_retry",
     "select_auto_mode",

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -56,6 +56,22 @@ def test_verify_mismatches():
     assert "gen_worker" in cc.verify(other, family="sd15")
 
 
+def test_mode_drift():
+    class _P:
+        pass
+
+    p = _P()
+    meta = cc.artifact_metadata(family="sd15", shapes=[(768, 768)],
+                                targets=["transformer"], low_vram_mode="off")
+    assert meta["low_vram_mode"] == "off"
+    assert cc.mode_drift({}, p) == ""  # producer recorded no mode: unenforced
+    assert "low_vram_mode" in cc.mode_drift(meta, p)  # unprepped pipeline
+    p._cozy_low_vram_mode = "off"
+    assert cc.mode_drift(meta, p) == ""
+    p._cozy_low_vram_mode = "vae_only"
+    assert "low_vram_mode" in cc.mode_drift(meta, p)
+
+
 def test_counters_helpers():
     stats = cc.inductor_counters()  # torch present in the dev venv
     assert set(stats) >= {"fxgraph_cache_hit", "fxgraph_cache_miss"}

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -185,6 +185,24 @@ def test_adopt_zero_cache_hits_rolls_back_and_fails(tmp_path, monkeypatch):
     assert any(isinstance(o, _Pipe) for o in unwrapped)  # rollback ran
 
 
+def test_adopt_prep_mode_drift_is_key_mismatch(tmp_path, monkeypatch):
+    """A cell traced under a different low-VRAM prep mode can only miss —
+    rejected deterministically before any warmup (gw#391 parity)."""
+    from gen_worker.models.memory import _COZY_MODE_ATTR
+
+    _artifact(tmp_path, low_vram_mode="off")
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    obj = ex.store.residency.obj(wire_ref(spec.models["pipeline"]))
+    setattr(obj, _COZY_MODE_ATTR, "vae_only")
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: pytest.fail("must not re-wrap"))
+
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:key_mismatch"
+    assert not _events(sent, pb.MODEL_STATE_ADOPTED)
+
+
 def test_adopt_without_warmup_is_unprovable(tmp_path, monkeypatch):
     """An endpoint without warmup() cannot prove the cell hits — the honest
     answer is adopt_failed:no_warmup, never a blind ADOPTED."""
@@ -214,6 +232,25 @@ def test_adopt_without_warmup_is_unprovable(tmp_path, monkeypatch):
     failed = _events(sent, pb.MODEL_STATE_FAILED)
     assert failed and failed[-1].error == "adopt_failed:no_warmup"
     assert not _events(sent, pb.MODEL_STATE_ADOPTED)
+
+
+def test_adopt_prep_mode_drift_rejected(tmp_path, monkeypatch):
+    """gw#391: the producer's low-VRAM prep mode is part of the graph key — a
+    pipeline prepped under a different mode can only miss, so adoption rejects
+    it deterministically (key_mismatch) before any wrap or warmup."""
+    _artifact(tmp_path, low_vram_mode="off")
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    obj = ex.store.residency.obj(wire_ref(spec.models["pipeline"]))
+    obj._cozy_low_vram_mode = "vae_only"
+    applied: list = []
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: applied.append(1) or True)
+
+    _adopt(ex)
+    failed = _events(sent, pb.MODEL_STATE_FAILED)
+    assert failed and failed[-1].error == "adopt_failed:key_mismatch"
+    assert not _events(sent, pb.MODEL_STATE_ADOPTED)
+    assert not applied  # rejected before the wrap
 
 
 def test_adopt_failed_warmup_reports_reason(tmp_path, monkeypatch):


### PR DESCRIPTION
Addendum to #104 (gw#391): records the producer's `place_pipeline` low-VRAM prep mode in artifact metadata and enforces graph-key parity on consumption.

- `build()` records the traced-under `low_vram_mode` in artifact metadata (the prep flags — VAE tiling/slicing, attention slicing — are traced into the FX graphs, so a mode drift is a guaranteed cache miss)
- `mode_drift(meta, pipeline)` + `memory.low_vram_mode(pipeline)`: boot path (`enable`) stays eager on drift; hot adoption rejects deterministically with `adopt_failed:key_mismatch` before paying a warmup
- CONTRACT.md updated

Tests: `uv run --extra dev pytest -q` — 377 passed, 2 skipped (new: mode_drift unit, adopt-path prep-mode drift => key_mismatch).