### PR TITLE
fix(cozy_convert): /complete survives network-severed verify attempts (te#44)

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/hub.py
+++ b/packages/cozy_convert/src/cozy_convert/hub.py
@@ -45,7 +45,45 @@ _RETRY_MAX_DELAY_S = 30.0
 # succeed (e2e tracker #110).
 _COMPLETE_TIMEOUT_S = 600.0
 _COMPLETE_IN_PROGRESS_POLL_S = 5.0
-_COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600.0
+
+# A severed /complete connection is NOT fatal either: middleboxes on the
+# worker->hub path (NAT idle eviction, tunnel circuit caps) kill the idle
+# ~5-minute verify of multi-GB shards, so the client sees a network error
+# while the server may finish (sess.Finalized fast path answers the re-POST)
+# or may have aborted (a re-POST restarts the verify). Re-POST patiently —
+# each attempt can legitimately take a full verify. Found live twice on the
+# flux2-klein-4b clone (te#44 J9 runs 7+8: RemoteDisconnected at ~4m50s).
+_COMPLETE_NETWORK_RETRY_DELAY_S = 15.0
+_COMPLETE_NETWORK_MAX_WAIT_S = 1800.0
+
+_SESSION: Optional[requests.Session] = None
+
+
+def _http_session() -> requests.Session:
+    """Shared session with TCP keepalives so NAT/conntrack middleboxes don't
+    evict the idle flow while the server verifies (no response bytes for
+    minutes)."""
+    import socket
+
+    global _SESSION
+    if _SESSION is not None:
+        return _SESSION
+    socket_options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+    for name, value in (("TCP_KEEPIDLE", 60), ("TCP_KEEPINTVL", 30), ("TCP_KEEPCNT", 20)):
+        if hasattr(socket, name):
+            socket_options.append((socket.IPPROTO_TCP, getattr(socket, name), value))
+
+    class _KeepaliveAdapter(requests.adapters.HTTPAdapter):
+        def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["socket_options"] = socket_options
+            super().init_poolmanager(*args, **kwargs)
+
+    session = requests.Session()
+    adapter = _KeepaliveAdapter()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    _SESSION = session
+    return session
 
 
 class HubPublishError(RuntimeError):
@@ -185,7 +223,7 @@ class HubClient:
         )
 
     def _post(self, path: str, payload: Optional[dict] = None, *, timeout: float | None = None) -> requests.Response:
-        return _send_with_retries(f"POST {path}", lambda: requests.post(
+        return _send_with_retries(f"POST {path}", lambda: _http_session().post(
             f"{self.base_url}{path}",
             headers=self._headers(),
             data=json.dumps(payload) if payload is not None else None,
@@ -206,17 +244,26 @@ class HubClient:
         through a 409 upload_complete_in_progress race instead of treating it
         as fatal: /complete is idempotent once finalized (tensorhub's
         sess.Finalized fast path returns the same success payload), so
-        re-POSTing catches up to whatever the in-flight attempt decides."""
-        resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
-        if not (resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress"):
+        re-POSTing catches up to whatever the in-flight attempt decides.
+        Network-severed attempts get the same treatment on a longer clock
+        (_COMPLETE_NETWORK_MAX_WAIT_S): each re-POST may re-run a full
+        multi-minute verify, so give it room instead of failing the commit."""
+        deadline = time.monotonic() + _COMPLETE_NETWORK_MAX_WAIT_S
+        while True:
+            try:
+                resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
+            except HubPublishError:
+                if time.monotonic() >= deadline:
+                    raise
+                logger.warning("POST %s network-severed; re-POSTing (idempotent complete)", complete_path)
+                time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
+                continue
+            if resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
+                if time.monotonic() >= deadline:
+                    return resp
+                time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
+                continue
             return resp
-        deadline = time.monotonic() + _COMPLETE_IN_PROGRESS_MAX_WAIT_S
-        while resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
-            if time.monotonic() >= deadline:
-                break
-            time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
-            resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
-        return resp
 
     def _upload_one(self, repo_path: str, revision_id: str, entry: Mapping[str, Any],
                     local_path: Path) -> None:
@@ -269,7 +316,7 @@ class HubClient:
                 if not buf and i > 0:
                     break
                 def _put(u: str = url, b: bytes = buf) -> requests.Response:
-                    return requests.put(u, data=b, timeout=self.timeout_s * 5)
+                    return _http_session().put(u, data=b, timeout=self.timeout_s * 5)
 
                 resp = _send_with_retries(f"part PUT {entry.get('path')!r} #{i + 1}", _put)
                 if resp.status_code < 200 or resp.status_code >= 300:
@@ -394,7 +441,7 @@ class HubClient:
         except Exception:
             # Abort the revision so tensorhub can GC the staging bytes.
             try:
-                requests.delete(
+                _http_session().delete(
                     f"{self.base_url}{repo_path}/commits/{urllib.parse.quote(revision_id, safe='')}",
                     headers=self._headers(), timeout=30,
                 )

--- a/packages/cozy_convert/tests/test_hub.py
+++ b/packages/cozy_convert/tests/test_hub.py
@@ -194,7 +194,7 @@ def test_complete_gives_up_after_deadline_if_race_never_resolves(
     """A genuinely stuck server (never finalizes) must still fail eventually
     rather than polling forever."""
     monkeypatch.setattr("time.sleep", lambda *_: None)
-    monkeypatch.setattr("cozy_convert.hub._COMPLETE_IN_PROGRESS_MAX_WAIT_S", 0.0)
+    monkeypatch.setattr("cozy_convert.hub._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
     _FakeHub.state["complete_race_count"] = 10_000
 
     f = tmp_path / "model.safetensors"
@@ -217,3 +217,47 @@ def test_files_from_tree_skips_hf_cache_junk(tmp_path: Path) -> None:
 
     paths = [f.path for f in files_from_tree(tmp_path)]
     assert paths == [".gitignore", "config.json"]
+
+
+def test_complete_repost_through_network_severed_attempts(monkeypatch) -> None:
+    """te#44 J9 runs 7+8: the idle multi-minute /complete verify gets severed
+    by middleboxes; the client must re-POST (idempotent) instead of failing
+    the commit after the quick generic retries are exhausted."""
+    from cozy_convert.hub import HubClient, HubPublishError
+
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    client = HubClient(base_url="http://hub", token="t", owner="acme")
+    calls = {"n": 0}
+
+    class _OK:
+        status_code = 200
+        text = "{}"
+
+        @staticmethod
+        def json():
+            return {}
+
+    def _post(path, payload=None, *, timeout=None):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise HubPublishError(f"POST {path} failed (network): severed")
+        return _OK()
+
+    monkeypatch.setattr(client, "_post", _post)
+    resp = client._post_complete("/complete", {})
+    assert resp.status_code == 200 and calls["n"] == 3
+
+
+def test_complete_network_severed_raises_after_deadline(monkeypatch) -> None:
+    from cozy_convert.hub import HubClient, HubPublishError
+
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    monkeypatch.setattr("cozy_convert.hub._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
+    client = HubClient(base_url="http://hub", token="t", owner="acme")
+
+    def _post(path, payload=None, *, timeout=None):
+        raise HubPublishError("POST /complete failed (network): severed")
+
+    monkeypatch.setattr(client, "_post", _post)
+    with pytest.raises(HubPublishError, match="network"):
+        client._post_complete("/complete", {})

--- a/packages/cozy_convert/tests/test_repackage_families.py
+++ b/packages/cozy_convert/tests/test_repackage_families.py
@@ -214,7 +214,6 @@ def test_civitai_base_model_beats_filename_tokens() -> None:
     """GonzaLomo regression (e2e #112): an SDXL 1.0 checkpoint whose FILENAME
     contains 'flux' must classify as sdxl via the structured baseModel."""
     from cozy_convert.layout import (
-        detect_huggingface_source_layout,
         infer_model_family_variant_from_hint,
     )
 


### PR DESCRIPTION
Closes the te#44 J9 blocker (runs 7+8 both died mid-klein-clone on the same call).

The hub verifies multi-GB shards synchronously in /complete (~5min idle response for the klein-4b transformer shard); middleboxes on the pod->ngrok->hub path sever the idle connection at ~290s. The existing generic retry (5 attempts, ~15s span) burns out while the tunnel/lock is still unhealthy, the client raises, and the harness deletes the commit — so the bytes never finalize and every rerun replays the same roulette (2/3 observed failure rate; the ingest lane logged the same class on nova-furry-xl).

- `_post_complete`: network-severed attempts are now re-POSTed patiently (15s spacing, 30min deadline, same loop as the 409 upload_complete_in_progress race) — /complete is idempotent (`sess.Finalized` fast path), so the re-POST either catches the finished verify or restarts it.
- All hub/R2 HTTP now goes through a shared session with TCP keepalives (60s idle, 30s interval) so conntrack/NAT middleboxes see a live flow during the idle verify.
- Removed `_COMPLETE_IN_PROGRESS_MAX_WAIT_S` (unified under the one deadline).

Tests: 95 passed, 8 deselected (network integration) — includes two new tests for the severed path (re-POST-to-success + deadline exhaustion).