### PR TITLE
feat(executor): adapter residency — repeat LoRA requests cost ~50ms of machinery, not seconds (gw#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Adapter residency: repeat LoRA requests cost ~50ms of machinery, not
+  seconds (#399).** LoRA adapters now stay ATTACHED to the resident pipeline
+  (stable `ref@digest`-derived adapter names); each request only toggles the
+  ACTIVE set — `set_adapters` + `enable_lora` in, `disable_lora` out on every
+  exit path. Zero-leakage becomes explicit activation: adapter-free requests
+  run with adapters disabled (and self-protect against a crashed teardown).
+  Attached-but-inactive adapters are LRU-evicted under count/byte caps
+  (`GEN_WORKER_ATTACHED_LORA_MAX`, `GEN_WORKER_ATTACHED_LORA_MAX_BYTES`);
+  demotion out of VRAM drops attachments (new `Residency.pre_demote` hook),
+  re-attached lazily from the AdapterCache on next use. Forensics for the
+  ie#358 pilot's +5.7s repeat delta (4090, SDXL, the pilot's own 171MB LoRA):
+  `load_lora_weights` re-attach was ~1.6-1.9s/request and unfused adapter
+  compute adds ~59ms/denoise-step; residency removes the re-attach entirely
+  (activate 23ms / disable 24ms / enable 26ms measured on the 4090).
+
 - **Compile-cell adoption: honest cache-hit proof + rekey (#391).** ADOPTED now
   means the seeded inductor cell actually served the warmup trace: the worker
   reports FX-graph `cache_hits`/`cache_misses` + `warmup_s` in the ADOPTED

--- a/proto/CONTRACT.md
+++ b/proto/CONTRACT.md
@@ -247,7 +247,7 @@ to avoid chatter). Never periodic. O overwrites its copy wholesale.
 |---|---|---|---|
 | `slot` | O from endpoint manifest | W injection: maps to the endpoint's declared model parameter | slot name |
 | `ref` | O resolver | W `ensure_local` + injection | canonical ref string |
-| `loras` | O `_models` override gate (AllowLora) + BYOM ingest (th#585) | W per-request adapter overlay (gw#393) | LoRA overlays riding this slot's base model; applied as unfused named adapters for the job's duration and removed after. Empty for adapter-free jobs; workers predating the field ignore it |
+| `loras` | O `_models` override gate (AllowLora) + BYOM ingest (th#585) | W per-request adapter overlay (gw#393) + adapter residency (gw#399) | LoRA overlays riding this slot's base model; attached as unfused named adapters that stay resident on the pipeline, ACTIVE only for jobs that name them (explicit activation — adapter-free jobs always run with adapters disabled). Purely W-side: O never routes on adapter residency. Empty for adapter-free jobs; workers predating the field ignore it |
 
 ### LoraOverlay (embedded in ModelBinding.loras)
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass, field as dc_field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
-import uuid
 
 import msgspec
 
@@ -565,6 +564,10 @@ class Executor:
         self._load_lock = asyncio.Lock()
         # Parsed per-request LoRA state dicts, keyed by ref@digest (gw#393).
         self._adapter_cache = lora_util.AdapterCache()
+        # Adapters attached to resident pipelines; requests toggle the active
+        # set (gw#399). Demotion out of VRAM drops attachments.
+        self._adapters = lora_util.AdapterResidency()
+        self.store.residency.pre_demote = self._adapters.detach
         self._on_state_change = on_state_change or (lambda: None)
         self.file_base_url: str = ""
         self.draining = False
@@ -1412,22 +1415,36 @@ class Executor:
             exec_refs = [wire_ref(b) for b in spec.models.values()]
             adapter_refs = [a.ref for group in adapters.values() for a in group]
             with self.store.residency.executing(*exec_refs, *adapter_refs):
-                lora_pipes: List[Any] = []
+                active: List[Tuple[str, Any]] = []
                 try:
                     for slot, prepared in adapters.items():
                         pipe = self._adapter_target(spec, slot)
+                        ref = wire_ref(spec.models[slot])
                         await asyncio.to_thread(
-                            lora_util.apply_adapters, pipe, prepared, run.request_id
+                            self._adapters.activate, ref, pipe, prepared, run.request_id
                         )
-                        lora_pipes.append(pipe)
+                        active.append((ref, pipe))
+                    # Explicit activation (gw#399): a slot this request names
+                    # no adapters for must run bare even if a previous
+                    # request's teardown failed and left adapters enabled.
+                    for slot in spec.models:
+                        if slot in adapters:
+                            continue
+                        ref = wire_ref(spec.models[slot])
+                        if self._adapters.needs_deactivation(ref):
+                            pipe = self.store.residency.obj(ref)
+                            if pipe is not None:
+                                await asyncio.to_thread(
+                                    self._adapters.deactivate, ref, pipe, run.request_id
+                                )
                     output = await self._execute(job, spec, instance, ctx, payload, kwargs,
                                                  timeout_ms=timeout_ms, gpu_index=gpu_index)
                 finally:
-                    # Request-scoped adapters: guaranteed-clean teardown on
-                    # every exit (OK / cancel / deadline / handler error).
-                    for pipe in lora_pipes:
+                    # Guaranteed-inactive on every exit (OK / cancel /
+                    # deadline / handler error); attachments stay resident.
+                    for ref, pipe in active:
                         await asyncio.to_thread(
-                            lora_util.unload_adapters, pipe, run.request_id
+                            self._adapters.deactivate, ref, pipe, run.request_id
                         )
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
                                     output=output)
@@ -1513,7 +1530,6 @@ class Executor:
                 f"(max {lora_util.MAX_LORAS_PER_REQUEST} per request)"
             )
         out: Dict[str, List[lora_util.PreparedAdapter]] = {}
-        seq = 0
         for slot, loras in overlays:
             if slot not in spec.models:
                 raise ValidationError(f"lora overlay names unknown model slot {slot!r}")
@@ -1540,12 +1556,11 @@ class Executor:
                     self._adapter_cache.put(cache_key, state_dict)
                 parse_ms = int((time.monotonic() - t1) * 1000)
                 prepared.append(lora_util.PreparedAdapter(
-                    slot=slot, ref=ref,
-                    name=f"req{seq}-{uuid.uuid4().hex[:8]}",
+                    slot=slot, ref=ref, cache_key=cache_key,
+                    name=lora_util.adapter_name(cache_key),
                     weight=weight, state_dict=state_dict,
                     from_cache=from_cache, ensure_ms=ensure_ms, parse_ms=parse_ms,
                 ))
-                seq += 1
             out[slot] = prepared
         return out
 

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -132,6 +132,9 @@ class Residency:
         self._vram_budget = vram_budget_bytes
         self._free_vram_fn = free_vram_bytes_fn
         self._move = move_fn
+        # Called with (ref, obj) before a VRAM->RAM demotion moves the object
+        # (executor wires adapter detach here, gw#399). Must never raise.
+        self.pre_demote: Optional[Callable[[str, Any], None]] = None
         self._entries: Dict[str, _Entry] = {}
         self._lock = threading.RLock()
         self._shared_hits = 0
@@ -276,6 +279,11 @@ class Residency:
                 return False
             if not e.movable or get_available_ram_gb() < _RAM_FLOOR_GB:
                 return False
+            if self.pre_demote is not None:
+                try:
+                    self.pre_demote(ref, e.obj)
+                except Exception:
+                    logger.exception("pre_demote hook failed for %s", ref)
             self._move(e.obj, "cpu")
             e.tier = Tier.RAM
             e.vram_bytes = 0

--- a/src/gen_worker/utils/__init__.py
+++ b/src/gen_worker/utils/__init__.py
@@ -1,15 +1,13 @@
 from .lora import (
     AdapterCache,
+    AdapterResidency,
     LoraCapablePipeline,
     PreparedAdapter,
-    apply_adapters,
-    unload_adapters,
 )
 
 __all__ = [
     "AdapterCache",
+    "AdapterResidency",
     "LoraCapablePipeline",
     "PreparedAdapter",
-    "apply_adapters",
-    "unload_adapters",
 ]

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -1,24 +1,32 @@
-"""Per-request LoRA adapter overlays (gw#393 BYOM).
+"""Per-request LoRA adapter overlays with adapter residency (gw#393 + gw#399).
 
 ``RunJob.models[].loras`` reaches the executor, which materializes each
-adapter snapshot via the normal ``ensure_local`` path, parses + validates the
-state dict (digest-keyed RAM LRU so repeat requests skip disk + parse), then
-applies the adapters UNFUSED via ``load_lora_weights`` + ``set_adapters``
-around the handler call and unloads them after — the base pipeline is
-restored between requests (anima's hot-toggle pattern).
+adapter snapshot via the normal ``ensure_local`` path and parses + validates
+the state dict (digest-keyed RAM LRU so repeat requests skip disk + parse).
+
+Adapters stay ATTACHED to the resident pipeline (``load_lora_weights`` is the
+expensive step — ~1s at SDXL scale, measured); each request only toggles the
+ACTIVE SET: ``set_adapters(named list)`` + ``enable_lora`` on the way in
+(~50ms), ``disable_lora`` on every exit path (~25ms). Nothing is ever active
+unless the current request named it — zero-leakage by explicit activation.
+Attached-but-inactive adapters are LRU-evicted under count/byte caps and
+dropped when the pipeline demotes out of VRAM (re-attached lazily from the
+AdapterCache on next use).
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
+import os
 import re
 import threading
 import time
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, runtime_checkable
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, runtime_checkable
 
 from ..api.errors import RefCompatibilitySurprise, ValidationError
 
@@ -32,6 +40,12 @@ MAX_LORAS_PER_REQUEST = 8
 MAX_LORA_FILE_BYTES = 2 * _GiB
 LORA_WEIGHT_BOUND = 4.0
 ADAPTER_CACHE_MAX_BYTES = 1 * _GiB
+
+# Residency caps for adapters left attached to a pipeline between requests.
+MAX_ATTACHED_ADAPTERS = int(os.getenv("GEN_WORKER_ATTACHED_LORA_MAX", "8"))
+MAX_ATTACHED_ADAPTER_BYTES = int(
+    os.getenv("GEN_WORKER_ATTACHED_LORA_MAX_BYTES", str(2 * _GiB))
+)
 
 # LoRA-shaped keys only: kohya (`…lora_down.weight` / `…lora_up.weight` /
 # `….alpha`), peft (`…lora_A.weight` / `…lora_B.weight`, DoRA magnitude), and
@@ -55,13 +69,20 @@ class LoraCapablePipeline(Protocol):
     def unload_lora_weights(self) -> None: ...
 
 
+def adapter_name(cache_key: str) -> str:
+    """Stable diffusers adapter_name for one ``ref@digest`` — identical across
+    requests so a repeat request reuses the already-attached adapter."""
+    return "gw-" + hashlib.sha1(cache_key.encode()).hexdigest()[:12]
+
+
 @dataclass
 class PreparedAdapter:
     """One overlay, materialized and parsed, ready for GPU application."""
 
     slot: str
     ref: str
-    name: str  # unique-per-request diffusers adapter_name
+    cache_key: str  # ref@digest — the AdapterCache / attachment identity
+    name: str       # stable diffusers adapter_name (adapter_name(cache_key))
     weight: float
     state_dict: Dict[str, Any]
     from_cache: bool = False
@@ -204,70 +225,184 @@ class AdapterCache:
 
 
 # ---------------------------------------------------------------------------
-# Apply / unload (GPU side; run off the event loop)
+# Adapter residency: attachments persist on the pipeline; requests toggle the
+# active set (GPU side; run off the event loop)
 # ---------------------------------------------------------------------------
 
 
-def apply_adapters(
-    pipeline: Any, adapters: Sequence[PreparedAdapter], request_id: str = ""
-) -> None:
-    """Load *adapters* onto *pipeline* as named UNFUSED adapters and activate
-    them with their weights. Any failure rolls the pipeline back clean."""
-    if not isinstance(pipeline, LoraCapablePipeline):
-        raise ValidationError(
-            "model slot does not support LoRA adapters "
-            "(pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)"
-        )
-    loaded: List[str] = []
-    t0 = time.monotonic()
-    try:
-        for a in adapters:
+@dataclass
+class _PipeAttachments:
+    """Adapters currently attached to one pipeline object."""
+
+    pipe_id: int  # id(pipe) — detects object replacement after reload
+    attached: "OrderedDict[str, tuple[str, int]]" = field(
+        default_factory=OrderedDict)  # cache_key -> (adapter_name, bytes)
+    active: bool = False  # an activation may be live (crash-leak guard)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(b for _, b in self.attached.values())
+
+
+class AdapterResidency:
+    """Per-pipeline attachment registry (gw#399), keyed by model ref.
+
+    ``activate`` attaches missing adapters (load_lora_weights — the ~1s step,
+    paid once per adapter per pipeline), toggles the active set, and LRU-evicts
+    attached-but-inactive adapters over the count/byte caps. ``deactivate``
+    disables all adapters (never raises). Thread-safe; all pipeline calls run
+    on the caller's (worker) thread."""
+
+    def __init__(
+        self,
+        max_attached: int = MAX_ATTACHED_ADAPTERS,
+        max_attached_bytes: int = MAX_ATTACHED_ADAPTER_BYTES,
+    ) -> None:
+        self._max = max(1, int(max_attached))
+        self._max_bytes = int(max_attached_bytes)
+        self._pipes: Dict[str, _PipeAttachments] = {}
+        self._lock = threading.RLock()
+
+    def _state(self, ref: str, pipe: Any) -> _PipeAttachments:
+        st = self._pipes.get(ref)
+        if st is None or st.pipe_id != id(pipe):
+            # New or replaced pipeline object: prior attachments died with it.
+            st = _PipeAttachments(pipe_id=id(pipe))
+            self._pipes[ref] = st
+        return st
+
+    def activate(
+        self, ref: str, pipe: Any, adapters: Sequence[PreparedAdapter],
+        request_id: str = "",
+    ) -> None:
+        """Make exactly *adapters* the pipeline's active set. Attach failure
+        rolls back to a fully-deactivated pipeline."""
+        if not isinstance(pipe, LoraCapablePipeline):
+            raise ValidationError(
+                "model slot does not support LoRA adapters "
+                "(pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)"
+            )
+        with self._lock:
+            st = self._state(ref, pipe)
             try:
-                # Shallow copy: diffusers' conversion utilities consume the
-                # dict they're given; the cached entry must stay intact.
-                pipeline.load_lora_weights(dict(a.state_dict), adapter_name=a.name)
-            except (ValidationError, RefCompatibilitySurprise):
+                load_ms = 0
+                attached_now: List[str] = []
+                for a in adapters:
+                    if a.cache_key in st.attached:
+                        st.attached.move_to_end(a.cache_key)
+                        continue
+                    t0 = time.monotonic()
+                    try:
+                        # Shallow copy: diffusers' conversion utilities consume
+                        # the dict; the cached entry must stay intact.
+                        pipe.load_lora_weights(dict(a.state_dict), adapter_name=a.name)
+                    except (ValidationError, RefCompatibilitySurprise):
+                        raise
+                    except Exception as exc:
+                        raise RefCompatibilitySurprise(
+                            f"adapter failed to load onto base pipeline: {exc}",
+                            ref=a.ref, axis="pipeline_load",
+                        ) from exc
+                    load_ms += int((time.monotonic() - t0) * 1000)
+                    st.attached[a.cache_key] = (a.name, state_dict_bytes(a.state_dict))
+                    attached_now.append(a.name)
+                t1 = time.monotonic()
+                pipe.set_adapters(
+                    [a.name for a in adapters],
+                    adapter_weights=[a.weight for a in adapters],
+                )
+                # disable_lora (deactivate) flips a peft-level disable flag
+                # that set_adapters alone does NOT clear — always re-enable.
+                if hasattr(pipe, "enable_lora"):
+                    pipe.enable_lora()
+                set_ms = int((time.monotonic() - t1) * 1000)
+                st.active = True
+                self._evict_over_caps(st, pipe, keep={a.cache_key for a in adapters})
+                logger.info(
+                    "[request_id=%s] lora adapters active: %s (load_ms=%d set_ms=%d "
+                    "attached=%d attached_bytes=%d)",
+                    request_id,
+                    "; ".join(
+                        f"{a.ref}@{a.weight:g} "
+                        f"[{'resident' if a.name not in attached_now else 'attach'}"
+                        f" {'cache' if a.from_cache else 'cold'}"
+                        f" ensure_ms={a.ensure_ms} parse_ms={a.parse_ms}]"
+                        for a in adapters
+                    ),
+                    load_ms, set_ms, len(st.attached), st.total_bytes,
+                )
+            except BaseException:
+                self.deactivate(ref, pipe, request_id=request_id)
                 raise
-            except Exception as exc:
-                raise RefCompatibilitySurprise(
-                    f"adapter failed to load onto base pipeline: {exc}",
-                    ref=a.ref, axis="pipeline_load",
-                ) from exc
-            loaded.append(a.name)
-        load_ms = int((time.monotonic() - t0) * 1000)
-        t1 = time.monotonic()
-        pipeline.set_adapters(
-            [a.name for a in adapters], adapter_weights=[a.weight for a in adapters]
-        )
-        set_ms = int((time.monotonic() - t1) * 1000)
-        logger.info(
-            "[request_id=%s] lora adapters active: %s (load_ms=%d set_ms=%d)",
-            request_id,
-            "; ".join(
-                f"{a.ref}@{a.weight:g} [{'cache' if a.from_cache else 'cold'}"
-                f" ensure_ms={a.ensure_ms} parse_ms={a.parse_ms}]"
-                for a in adapters
-            ),
-            load_ms, set_ms,
-        )
-    except BaseException:
-        if loaded:
-            unload_adapters(pipeline, request_id=request_id)
-        raise
 
+    def deactivate(self, ref: str, pipe: Any, request_id: str = "") -> None:
+        """Nothing active after this call (attachments stay). Never raises."""
+        with self._lock:
+            st = self._pipes.get(ref)
+            if st is None:
+                return
+            if st.pipe_id != id(pipe):
+                self._pipes.pop(ref, None)  # pipeline was replaced; state is stale
+                return
+            t0 = time.monotonic()
+            try:
+                if hasattr(pipe, "disable_lora"):
+                    pipe.disable_lora()
+                else:
+                    pipe.unload_lora_weights()
+                    st.attached.clear()
+                st.active = False
+                logger.info(
+                    "[request_id=%s] lora adapters deactivated (disable_ms=%d attached=%d)",
+                    request_id, int((time.monotonic() - t0) * 1000), len(st.attached),
+                )
+            except Exception:
+                logger.warning(
+                    "[request_id=%s] lora deactivate failed; pipeline may have "
+                    "active adapters", request_id, exc_info=True,
+                )
 
-def unload_adapters(pipeline: Any, request_id: str = "") -> int:
-    """Remove every request-scoped adapter from *pipeline* (guaranteed-clean
-    teardown; never raises). Returns unload wall ms, -1 on failure."""
-    t0 = time.monotonic()
-    try:
-        pipeline.unload_lora_weights()
-    except Exception:
-        logger.warning(
-            "[request_id=%s] unload_lora_weights failed; pipeline may have stale adapters",
-            request_id, exc_info=True,
-        )
-        return -1
-    ms = int((time.monotonic() - t0) * 1000)
-    logger.info("[request_id=%s] lora adapters unloaded (unload_ms=%d)", request_id, ms)
-    return ms
+    def needs_deactivation(self, ref: str) -> bool:
+        """Cheap guard for bare requests: True only when a previous request's
+        activation may still be live on this ref's pipeline."""
+        with self._lock:
+            st = self._pipes.get(ref)
+            return bool(st and st.active)
+
+    def detach(self, ref: str, pipe: Any) -> None:
+        """Drop every attachment from the pipeline (demotion out of VRAM);
+        the AdapterCache re-attaches lazily on next use. Never raises."""
+        with self._lock:
+            st = self._pipes.pop(ref, None)
+            if st is None or not st.attached or st.pipe_id != id(pipe):
+                return
+            try:
+                pipe.unload_lora_weights()
+                logger.info(
+                    "lora attachments dropped on demote: ref=%s adapters=%d",
+                    ref, len(st.attached),
+                )
+            except Exception:
+                logger.warning("lora detach on demote failed for %s", ref, exc_info=True)
+
+    def _evict_over_caps(self, st: _PipeAttachments, pipe: Any, keep: Set[str]) -> None:
+        while len(st.attached) > self._max or (
+            st.total_bytes > self._max_bytes and len(st.attached) > 1
+        ):
+            victim = next((k for k in st.attached if k not in keep), None)
+            if victim is None:
+                return
+            name, _ = st.attached.pop(victim)
+            try:
+                pipe.delete_adapters(name)
+                logger.info("lora attachment evicted (LRU): %s", victim)
+            except Exception:
+                logger.warning("lora eviction failed for %s", victim, exc_info=True)
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                ref: {"adapters": len(st.attached), "bytes": st.total_bytes,
+                      "active": st.active}
+                for ref, st in self._pipes.items()
+            }

--- a/tests/test_executor_lora.py
+++ b/tests/test_executor_lora.py
@@ -1,9 +1,11 @@
-"""gw#393 per-request LoRA overlays: wire -> materialize -> apply -> unload.
+"""gw#393 + gw#399 per-request LoRA overlays with adapter residency.
 
 RunJob ModelBinding.loras reaches the executor; adapter snapshots ride the
 normal ensure_local path; state dicts hit the digest-keyed RAM LRU; adapters
-apply UNFUSED around the handler call and are removed on EVERY exit path
-(OK / handler error / cancel). Validation mirrors the hub gates worker-side.
+stay ATTACHED to the resident pipeline while requests toggle the ACTIVE set
+(explicit activation — nothing active unless the request named it, disabled
+on EVERY exit path). Attachments are LRU-capped and dropped on demotion.
+Validation mirrors the hub gates worker-side.
 """
 
 from __future__ import annotations
@@ -38,26 +40,57 @@ def _fake_state_dict(nbytes: int = 64) -> Dict[str, Any]:
 
 
 class _FakeLoraPipe:
+    """Residency-capable fake: tracks attachments, the active set, and the
+    peft-level enabled flag like a diffusers pipeline."""
+
     def __init__(self, fail_load: bool = False) -> None:
         self.calls: List[Any] = []
+        self.attached: List[str] = []
         self.active: List[str] = []
         self.weights: List[float] = []
+        self.enabled = True
         self.fail_load = fail_load
+        self.fail_disable = False
 
     def load_lora_weights(self, state_dict, adapter_name: str = "") -> None:
         if self.fail_load:
             raise RuntimeError("size mismatch for lora_up.weight")
         self.calls.append(("load", adapter_name))
+        self.attached.append(adapter_name)
 
     def set_adapters(self, names, adapter_weights=None) -> None:
         self.calls.append(("set", tuple(names), tuple(adapter_weights)))
         self.active = list(names)
         self.weights = list(adapter_weights)
 
+    def enable_lora(self) -> None:
+        self.calls.append(("enable",))
+        self.enabled = True
+
+    def disable_lora(self) -> None:
+        if self.fail_disable:
+            raise RuntimeError("disable failed")
+        self.calls.append(("disable",))
+        self.enabled = False
+
+    def delete_adapters(self, name: str) -> None:
+        self.calls.append(("delete", name))
+        self.attached.remove(name)
+
     def unload_lora_weights(self) -> None:
         self.calls.append(("unload",))
+        self.attached = []
         self.active = []
         self.weights = []
+
+    def to(self, device: str) -> "_FakeLoraPipe":
+        self.calls.append(("to", device))
+        return self
+
+    @property
+    def live(self) -> List[str]:
+        """Adapters actually affecting compute right now."""
+        return self.active if self.enabled else []
 
 
 class _In(msgspec.Struct):
@@ -89,7 +122,7 @@ class _Endpoint:
         ]
         pinned = bool(type(self).store and type(self).store.residency.in_use(LORA_A))
         return _Out(
-            active_adapters=len(pipe.active), weights=list(pipe.weights),
+            active_adapters=len(pipe.live), weights=list(pipe.weights),
             lora_meta=meta, adapter_ref_pinned=pinned,
         )
 
@@ -167,7 +200,7 @@ def _ov(ref: str, weight: float = 1.0) -> pb.LoraOverlay:
 # ---------------------------------------------------------------------------
 
 
-def test_adapters_active_during_handler_and_unloaded_after(tmp_path, monkeypatch) -> None:
+def test_adapters_active_during_handler_and_disabled_after(tmp_path, monkeypatch) -> None:
     async def _run() -> None:
         h = _Harness(tmp_path, monkeypatch)
         res = await h.run(loras=[_ov(LORA_A, 0.8), _ov(LORA_B, -0.5)])
@@ -178,8 +211,9 @@ def test_adapters_active_during_handler_and_unloaded_after(tmp_path, monkeypatch
         assert out.adapter_ref_pinned  # executing() covers adapter refs
         assert h.ensured == [LORA_A, LORA_B]
         kinds = [c[0] for c in h.pipe.calls]
-        assert kinds == ["load", "load", "set", "unload"]
-        assert h.pipe.active == []  # clean after the request
+        assert kinds == ["load", "load", "set", "enable", "disable"]
+        assert h.pipe.live == []          # nothing active after the request
+        assert len(h.pipe.attached) == 2  # attachments stay resident
 
     asyncio.run(_run())
 
@@ -205,13 +239,13 @@ def test_no_loras_is_a_no_op(tmp_path, monkeypatch) -> None:
     asyncio.run(_run())
 
 
-def test_unload_runs_when_handler_raises(tmp_path, monkeypatch) -> None:
+def test_deactivate_runs_when_handler_raises(tmp_path, monkeypatch) -> None:
     async def _run() -> None:
         h = _Harness(tmp_path, monkeypatch)
         res = await h.run(loras=[_ov(LORA_A)], payload=_In(fail=True))
         assert res.status == pb.JOB_STATUS_FATAL
-        assert h.pipe.calls[-1] == ("unload",)
-        assert h.pipe.active == []
+        assert h.pipe.calls[-1] == ("disable",)
+        assert h.pipe.live == []
 
     asyncio.run(_run())
 
@@ -233,7 +267,8 @@ def test_failed_adapter_load_rolls_back_and_is_invalid(tmp_path, monkeypatch) ->
         res = await h.run(loras=[_ov(LORA_A), _ov(LORA_B)])
         assert res.status == pb.JOB_STATUS_INVALID
         assert "failed to load onto base pipeline" in res.safe_message
-        assert h.pipe.calls[-1] == ("unload",)
+        assert h.pipe.calls[-1] == ("disable",)  # rollback deactivates
+        assert h.pipe.live == []
 
     asyncio.run(_run())
 
@@ -347,6 +382,137 @@ def test_adapter_cache_lru_byte_cap() -> None:
     cache.put("huge", _fake_state_dict(1000))  # larger than cap -> not cached
     assert cache.get("huge") is None
     assert len(cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# Adapter residency (gw#399): attach once, toggle the active set
+# ---------------------------------------------------------------------------
+
+
+def test_repeat_request_reuses_attachment(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc"}
+        await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r1", snapshots=snaps)
+        await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r2", snapshots=snaps)
+        loads = [c for c in h.pipe.calls if c[0] == "load"]
+        sets = [c for c in h.pipe.calls if c[0] == "set"]
+        assert len(loads) == 1  # attached once, reused on repeat
+        assert len(sets) == 2   # every request toggles the active set
+        assert len(h.pipe.attached) == 1
+
+    asyncio.run(_run())
+
+
+def test_weight_change_on_resident_adapter_needs_no_reload(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc"}
+        await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r1", snapshots=snaps)
+        res = await h.run(loras=[_ov(LORA_A, 0.4)], request_id="r2", snapshots=snaps)
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.weights == [0.4]
+        assert len([c for c in h.pipe.calls if c[0] == "load"]) == 1
+
+    asyncio.run(_run())
+
+
+def test_interleaved_lora_bare_lora_never_bleeds(tmp_path, monkeypatch) -> None:
+    """The zero-leakage invariant: bare requests between LoRA requests run
+    with NOTHING live, even though attachments stay resident."""
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc"}
+
+        res = await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r1", snapshots=snaps)
+        assert msgspec.msgpack.decode(res.inline, type=_Out).active_adapters == 1
+
+        res = await h.run(request_id="r2")  # bare
+        assert msgspec.msgpack.decode(res.inline, type=_Out).active_adapters == 0
+        assert len(h.pipe.attached) == 1  # still attached, just not live
+
+        res = await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r3", snapshots=snaps)
+        assert msgspec.msgpack.decode(res.inline, type=_Out).active_adapters == 1
+
+        res = await h.run(request_id="r4")  # bare again
+        assert msgspec.msgpack.decode(res.inline, type=_Out).active_adapters == 0
+        assert h.pipe.live == []
+
+    asyncio.run(_run())
+
+
+def test_bare_request_recovers_from_failed_deactivation(tmp_path, monkeypatch) -> None:
+    """Crash-leak guard: if a LoRA request's teardown fails, the next bare
+    request on the same pipeline explicitly deactivates before running."""
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc"}
+        h.pipe.fail_disable = True
+        await h.run(loras=[_ov(LORA_A, 0.9)], request_id="r1", snapshots=snaps)
+        assert h.pipe.enabled  # teardown failed; adapters still live
+        h.pipe.fail_disable = False
+        res = await h.run(request_id="r2")  # bare request must self-protect
+        assert msgspec.msgpack.decode(res.inline, type=_Out).active_adapters == 0
+        assert not h.pipe.enabled
+
+    asyncio.run(_run())
+
+
+def test_lru_eviction_over_attachment_caps(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        h.executor._adapters = lora_util.AdapterResidency(max_attached=2)
+        for i, ref in enumerate([LORA_A, LORA_B, "user1/lora-third"]):
+            await h.run(loras=[_ov(ref)], request_id=f"r{i}",
+                        snapshots={ref: f"sha256:{i}"})
+        assert len(h.pipe.attached) == 2
+        deletes = [c for c in h.pipe.calls if c[0] == "delete"]
+        assert len(deletes) == 1
+        # LRU victim was the first-attached adapter
+        assert deletes[0][1] == lora_util.adapter_name(f"{LORA_A}@sha256:0")
+
+    asyncio.run(_run())
+
+
+def test_demotion_drops_attachments_and_reattaches_lazily(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "gen_worker.models.residency.get_available_ram_gb", lambda: 999.0)
+        snaps = {LORA_A: "sha256:abc"}
+        ref = wire_ref(h.spec.models["pipeline"])
+        await h.run(loras=[_ov(LORA_A)], request_id="r1", snapshots=snaps)
+        assert len(h.pipe.attached) == 1
+
+        assert h.executor.store.residency.demote(ref)  # VRAM -> RAM
+        assert h.pipe.attached == []  # pre_demote hook dropped attachments
+        assert ("unload",) in h.pipe.calls
+
+        h.executor.store.residency.promote(ref, device="cpu")
+        await h.run(loras=[_ov(LORA_A)], request_id="r2", snapshots=snaps)
+        assert len(h.pipe.attached) == 1  # lazily re-attached
+        assert len([c for c in h.pipe.calls if c[0] == "load"]) == 2
+        # state dict itself still came from the RAM cache (no re-parse)
+        assert h.parsed == [LORA_A]
+
+    asyncio.run(_run())
+
+
+def test_replaced_pipeline_object_resets_attachment_state(tmp_path, monkeypatch) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        snaps = {LORA_A: "sha256:abc"}
+        ref = wire_ref(h.spec.models["pipeline"])
+        await h.run(loras=[_ov(LORA_A)], request_id="r1", snapshots=snaps)
+
+        new_pipe = _FakeLoraPipe()  # cold reload produced a fresh object
+        _Endpoint.pipe = new_pipe
+        h.executor.store.residency.track_vram(ref, new_pipe, vram_bytes=1)
+        await h.run(loras=[_ov(LORA_A)], request_id="r2", snapshots=snaps)
+        assert len([c for c in new_pipe.calls if c[0] == "load"]) == 1
+        assert len(new_pipe.attached) == 1
+
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lora_e2e_local.py
+++ b/tests/test_lora_e2e_local.py
@@ -1,11 +1,13 @@
-"""gw#393 local end-to-end: REAL diffusers pipeline on CPU, real safetensors
-LoRA file, full executor RunJob path (wire -> ensure_local -> parse/validate ->
-load_lora_weights/set_adapters -> handler -> unload).
+"""gw#393 + gw#399 local end-to-end: REAL diffusers pipeline on CPU, real
+safetensors LoRA file, full executor RunJob path (wire -> ensure_local ->
+parse/validate -> attach/activate -> handler -> deactivate).
 
 Proves, with pixel equality:
-  1. an applied adapter changes the output deterministically,
-  2. unload restores the baseline exactly (pipeline byte-clean per request),
-  3. a repeat request serves the parsed state dict from the RAM cache.
+  1. an active adapter changes the output deterministically,
+  2. deactivation restores the baseline exactly — interleaved lora/bare/lora
+     requests on one worker never bleed (adapter residency, gw#399),
+  3. a repeat request reuses the ATTACHED adapter (no load_lora_weights) and
+     serves the parsed state dict from the RAM cache.
 
 Requires torch + diffusers (+ transformers/peft); skipped otherwise. Run:
   uv run --extra dev pytest tests/test_lora_e2e_local.py  (in a torch venv)
@@ -144,24 +146,40 @@ class _Harness:
         return msgspec.msgpack.decode(res.inline, type=_Out).checksum
 
 
-def test_adapter_changes_output_and_unload_restores_baseline(tmp_path, tiny_pipe) -> None:
+def test_interleaved_lora_bare_lora_never_bleeds(tmp_path, tiny_pipe) -> None:
     async def _run() -> None:
         h = _Harness(tmp_path, tiny_pipe)
+        loads: List[str] = []
+        real_load = tiny_pipe.load_lora_weights
 
-        baseline = await h.run("r-base-1")
-        with_lora = await h.run("r-lora-1", lora_weight=1.0)
-        after = await h.run("r-base-2")
-        repeat = await h.run("r-lora-2", lora_weight=1.0)
+        def _counting_load(sd, adapter_name="", **kw):
+            loads.append(adapter_name)
+            return real_load(sd, adapter_name=adapter_name, **kw)
 
-        assert with_lora != baseline, "adapter had no visual effect"
-        assert after == baseline, "unload did not restore the baseline pipeline"
-        assert repeat == with_lora, "adapter application is not deterministic"
-        # Repeat adapter request came from the RAM cache (no re-parse).
-        assert h.executor._adapter_cache.hits == 1
-        assert h.executor._adapter_cache.misses == 1
+        tiny_pipe.load_lora_weights = _counting_load
+        try:
+            baseline = await h.run("r-base-1")
+            with_lora = await h.run("r-lora-1", lora_weight=1.0)
+            after = await h.run("r-base-2")
+            repeat = await h.run("r-lora-2", lora_weight=1.0)
+            after2 = await h.run("r-base-3")
 
-        half = await h.run("r-lora-3", lora_weight=0.5)
-        assert half not in (baseline, with_lora), "weight scaling had no effect"
+            assert with_lora != baseline, "adapter had no visual effect"
+            assert after == baseline, "bare request after LoRA did not match baseline"
+            assert repeat == with_lora, "adapter application is not deterministic"
+            assert after2 == baseline, "second bare request bled adapter state"
+            # Residency: attached once, reused on repeat (no second attach).
+            assert len(loads) == 1, f"expected one attach, saw {loads}"
+            # Repeat adapter request came from the RAM cache (no re-parse).
+            assert h.executor._adapter_cache.hits == 1
+            assert h.executor._adapter_cache.misses == 1
+
+            half = await h.run("r-lora-3", lora_weight=0.5)
+            assert half not in (baseline, with_lora), "weight scaling had no effect"
+            assert len(loads) == 1, "weight change must not re-attach"
+        finally:
+            tiny_pipe.load_lora_weights = real_load
+            tiny_pipe.unload_lora_weights()
 
     asyncio.run(_run())
 


### PR DESCRIPTION
Closes gw#399 (tracker).

## Phase 1 — forensics: where the pilot's +5.7s repeat delta went
Measured on a throwaway 4090 pod (SDXL fp16, the ie#358 pilot's own LoRA — civitai Pixel Art XL mv135931, 171MB, 2166 unet keys, rank 32), N=5:

| stage (repeat request, gw#393 design) | measured |
|---|---|
| ensure_local (snapshot already on disk) | ~0 (dir-exists short-circuit) |
| AdapterCache parse | ~0 (true hit) |
| load_lora_weights re-attach | **1540-1904ms** |
| set_adapters | ~25ms |
| unfused adapter compute tax during denoise | **~59ms/step** (~470ms at 8 steps; ~1.5-2s at pilot step counts) |
| unload_lora_weights | ~130ms |

gw#393's 300-400ms load number was sd15-scale; SDXL is 4-5x. Re-attach + unload + compute tax ≈ 3.5-4s; the remainder of the pilot's 5.7s is single-sample wall noise. Hypotheses (a) cache-miss and (b) disk re-read: disproven (measured hits).

## Phase 2 — adapter residency
- Adapters stay ATTACHED to the resident pipeline under stable `ref@digest`-derived names; requests toggle the ACTIVE set: `set_adapters`+`enable_lora` in (~50ms), `disable_lora` out on every exit path (~25ms).
- Zero-leakage by explicit activation: bare requests always run with adapters disabled and self-protect if a previous teardown failed.
- LRU eviction of attached adapters under count/byte caps (`GEN_WORKER_ATTACHED_LORA_MAX`, `GEN_WORKER_ATTACHED_LORA_MAX_BYTES`).
- VRAM→RAM demotion drops attachments (new `Residency.pre_demote` hook); AdapterCache re-attaches lazily on next use. Replaced pipeline objects reset attachment state.
- Hub stays unaware (no routing refs); timings ride the existing lora log line (+attached count/bytes).
- diffusers landmines found: `set_adapters([])` raises KeyError (bare toggle must be `disable_lora`); `set_adapters` does NOT clear the peft disable flag (activation always re-enables).

## Phase 3 — re-measure (4090)
Attach once 1379ms, then per-request machinery: activate 23ms / disable 24ms / enable 26ms (<100ms target met). delete_adapters (LRU evict) 45ms. The unfused compute tax (~59ms/step) is inherent to unfused serving and is the remaining lever (fuse/unfuse would trade toggle cost — out of scope, noted in tracker).

## Tests
384 passed, 2 skipped (full suite). Real-diffusers CPU e2e proves interleaved lora/bare/lora/bare pixel-exact non-bleeding, repeat without re-attach, weight-change without re-attach; unit tests cover LRU eviction, demote-detach + lazy re-attach, crashed-teardown self-protection, replaced-pipeline reset.