### PR TITLE
feat(cozy_convert): per-tensor streaming cast + fp8-E4M3 storage flavor (gw#395, gw#396)

### DIFF
--- a/packages/cozy_convert/README.md
+++ b/packages/cozy_convert/README.md
@@ -3,9 +3,25 @@
 Cozy Creator's model ETL, split out of `gen-worker` (issue #367).
 
 - **Ingest**: HuggingFace (`HfApi.list_repo_files` + classifier + `snapshot_download(allow_patterns=…)`) and Civitai (bounded provider API).
-- **Convert**: streaming dtype cast, weight-only quant (torchao / bitsandbytes), GGUF (llama.cpp toolchain), singlefile↔diffusers repackage.
+- **Convert**: streaming dtype cast + fp8-E4M3 storage cast (`#fp8` flavor), bitsandbytes nf4/fp4, GGUF (llama.cpp toolchain), singlefile↔diffusers repackage.
 - **Publish**: one commit call against Tensorhub's HF-shaped `/commits` write API (`mode: merge|replace`).
 - **Tenant SDK**: `Source`, `Component`, `Dataset`, `ProducedFlavor`, `StreamingWriter`, calibration policy — for `@endpoint(kind="conversion")` endpoints.
+
+## Memory floors per operation (gw#395/#396)
+
+Model size must never dictate converter hardware. What each operation actually needs:
+
+| Operation | Peak anonymous RAM | Why |
+|---|---|---|
+| dtype cast (`streaming_dtype_cast` / `streaming_cast_snapshot`) | ≈ largest single tensor | two-pass streaming: header-only shard plan, then one tensor at a time |
+| fp8-E4M3 storage flavor (`streaming_fp8_storage_cast` / `streaming_fp8_snapshot`) | ≈ largest single tensor | same engine; clamp ±448 + layerwise-cast skip patterns |
+| byte-offset reshard / shard merge (`shard_safetensors_by_offset`) | O(1) (8 MB copy chunks) | raw byte-range copy, no tensor decode |
+| bnb nf4/fp4 | full component | `from_pretrained` load, inherent to bnb |
+| singlefile↔diffusers repackage | **full model** | `from_single_file` / whole-keyspace remap needs the full tensor set — the one legitimate big-RAM operation |
+| GGUF | full model (llama.cpp converter) | external toolchain |
+
+Casts and fp8 flavor production run on the standard 32 GB CPU class regardless of model size;
+only repackage/GGUF of huge models still needs RAM sized to the model.
 
 ```python
 from cozy_convert import clone_huggingface

--- a/packages/cozy_convert/README.md
+++ b/packages/cozy_convert/README.md
@@ -5,7 +5,7 @@ Cozy Creator's model ETL, split out of `gen-worker` (issue #367).
 - **Ingest**: HuggingFace (`HfApi.list_repo_files` + classifier + `snapshot_download(allow_patterns=…)`) and Civitai (bounded provider API).
 - **Convert**: streaming dtype cast + fp8-E4M3 storage cast (`#fp8` flavor), bitsandbytes nf4/fp4, GGUF (llama.cpp toolchain), singlefile↔diffusers repackage.
 - **Publish**: one commit call against Tensorhub's HF-shaped `/commits` write API (`mode: merge|replace`).
-- **Tenant SDK**: `Source`, `Component`, `Dataset`, `ProducedFlavor`, `StreamingWriter`, calibration policy — for `@endpoint(kind="conversion")` endpoints.
+- **Tenant SDK**: `Source`, `Component`, `Dataset`, `ProducedFlavor`, streaming cast/fp8 writers, calibration policy — for `@endpoint(kind="conversion")` endpoints.
 
 ## Memory floors per operation (gw#395/#396)
 

--- a/packages/cozy_convert/src/cozy_convert/__init__.py
+++ b/packages/cozy_convert/src/cozy_convert/__init__.py
@@ -32,7 +32,13 @@ from .loaded_component import LoadedComponent
 from .produced import ProducedFlavor
 from .publish import publish_flavors
 from .source import FileLayout, Source
-from .writer import StreamingWriter
+from .writer import (
+    StreamingWriter,
+    streaming_cast_snapshot,
+    streaming_dtype_cast,
+    streaming_fp8_snapshot,
+    streaming_fp8_storage_cast,
+)
 
 # `cozy_convert.clone` module alias (clone.from_huggingface style).
 from . import clone
@@ -46,6 +52,10 @@ __all__ = [
     "Dataset",
     "ProducedFlavor",
     "StreamingWriter",
+    "streaming_cast_snapshot",
+    "streaming_dtype_cast",
+    "streaming_fp8_snapshot",
+    "streaming_fp8_storage_cast",
     "CalibrationAction",
     "CalibrationPolicy",
     "resolve_calibration_action",

--- a/packages/cozy_convert/src/cozy_convert/__init__.py
+++ b/packages/cozy_convert/src/cozy_convert/__init__.py
@@ -2,7 +2,7 @@
 
 Tenant SDK (conversion endpoints)::
 
-    from cozy_convert import Source, StreamingWriter, ProducedFlavor, Dataset
+    from cozy_convert import Source, ProducedFlavor, Dataset
 
 Clone / mirror::
 
@@ -33,7 +33,6 @@ from .produced import ProducedFlavor
 from .publish import publish_flavors
 from .source import FileLayout, Source
 from .writer import (
-    StreamingWriter,
     streaming_cast_snapshot,
     streaming_dtype_cast,
     streaming_fp8_snapshot,
@@ -51,7 +50,6 @@ __all__ = [
     "FileLayout",
     "Dataset",
     "ProducedFlavor",
-    "StreamingWriter",
     "streaming_cast_snapshot",
     "streaming_dtype_cast",
     "streaming_fp8_snapshot",

--- a/packages/cozy_convert/src/cozy_convert/calibration.py
+++ b/packages/cozy_convert/src/cozy_convert/calibration.py
@@ -3,18 +3,17 @@
 Training functions that quantize weights fall into three buckets:
 
 - ``"required"`` — the recipe produces broken-but-not-erroring weights
-  without a calibration forward pass. Example: ``int4_awq``, ``w4a8_awq``.
+  without a calibration forward pass (activation-scale PTQ recipes).
   No dataset → refuse the job up-front (unless the caller explicitly
   opts into a tiny smoke-test pool via ``allow_dummy``).
 
 - ``"beneficial"`` — the recipe works without calibration but quality
-  suffers measurably when skipped. Example: modelopt ``fp8`` / ``int8`` /
-  ``nvfp4`` — activation scales default to per-tensor max without a
-  forward pass. Default behavior is "use calibration"; callers who value
+  suffers measurably when skipped. Example: modelopt ``fp8`` — activation
+  scales default to per-tensor max without a forward pass. Default behavior is "use calibration"; callers who value
   speed over quality can set ``skip_calibration=True`` on their spec.
 
 - ``"unsupported"`` — the recipe is weight-only and never consumes
-  calibration data. Example: torchao ``int4_wo`` / ``int8_wo`` / ``fp8_wo``,
+  calibration data. Example: the fp8-E4M3 storage cast,
   bitsandbytes ``nf4`` / ``fp4``. If the caller passes a dataset it's a
   mistake (wasted generation + wrong expectations about output quality);
   fail loudly rather than silently discard.
@@ -198,7 +197,7 @@ def resolve_calibration_action(
                 f"calibration{label}: scheme is weight-only (policy="
                 f"'unsupported') — a calibration dataset is not used. Drop "
                 f"the calibration dataset, or switch to a calibrated "
-                f"quantization recipe such as int4_awq / w4a8_awq."
+                f"quantization recipe (e.g. nvfp4)."
             )
         return "skip"
 

--- a/packages/cozy_convert/src/cozy_convert/clone.py
+++ b/packages/cozy_convert/src/cozy_convert/clone.py
@@ -12,7 +12,6 @@ and :func:`run_clone` (keyword-explicit).
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import re
@@ -24,7 +23,13 @@ from typing import Any, Iterable, Optional
 
 from .hub import HubClient, files_from_tree
 from .ingest import IngestedSource, ingest_civitai, ingest_huggingface
-from .writer import MAX_SAFETENSORS_SHARD_BYTES, shard_safetensors_by_offset
+from .writer import (
+    FP8_DEFAULT_COMPONENTS,
+    MAX_SAFETENSORS_SHARD_BYTES,
+    copy_non_weight_files,
+    shard_safetensors_by_offset,
+    snapshot_weight_groups,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +40,8 @@ _KNOWN_DTYPES = {
     # "source" = publish the source's own weights untouched (pure mirror);
     # the flavor's recorded dtype is the detected on-disk dtype.
     "source",
-    "fp32", "fp16", "bf16", "fp8", "fp8:e4m3", "fp8:e5m2", "nvfp4",
-    "int8", "int8:awq", "int8:gptq",
-    "int4", "int4:wo", "int4:nf4", "int4:fp4", "int4:awq", "int4:gptq",
-    "nf4", "fp4",
+    "fp32", "fp16", "bf16", "fp8", "nvfp4",
+    "int4", "int4:nf4", "int4:fp4", "nf4", "fp4",
     # GGUF encodings ride the dtype axis with file_type="gguf".
     "f16", "f32", "q8_0", "q6_k", "q5_k_m", "q5_k_s", "q4_k_m", "q4_k_s",
     "q4_0", "q4_1", "q3_k_m", "q3_k_s", "q2_k",
@@ -51,7 +54,6 @@ _KNOWN_FILE_TYPES = {"safetensors", "gguf"}
 # sdxl-illustrious / flux1-dev / z-image-turbo normalize onto these).
 _REPACKAGE_NORMALIZED_FAMILIES = {"sd15_sd2", "sdxl", "flux", "zimage"}
 
-_WEIGHT_EXTS = (".safetensors",)
 _DEFAULT_QUANT_COMPONENTS = ("transformer", "unet", "text_encoder", "text_encoder_2",
                              "text_encoder_3", "image_encoder", "prior", "controlnet")
 _MIN_CONVERT_BYTES = 100 * 1024 * 1024  # leave tiny weights (embeddings) untouched
@@ -114,7 +116,9 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
         if item is None:
             continue
         get = (lambda k: item.get(k)) if isinstance(item, dict) else (lambda k: getattr(item, k, None))
-        dtype = str(get("dtype") or "").strip().lower().replace("fp8-e4m3", "fp8:e4m3").replace("fp8-e5m2", "fp8:e5m2")
+        # fp8 spellings collapse onto the flavor name: e4m3 is THE fp8 format.
+        dtype = str(get("dtype") or "").strip().lower()
+        dtype = {"fp8-e4m3": "fp8", "fp8:e4m3": "fp8"}.get(dtype, dtype)
         layout = str(get("file_layout") or "").strip().lower() or layout_hint
         ftype = str(get("file_type") or "").strip().lower() or "safetensors"
         if not dtype:
@@ -138,73 +142,6 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
 # ---------------------------------------------------------------------------
 # Flavor tree construction
 # ---------------------------------------------------------------------------
-
-def _link_or_copy(src: Path, dst: Path) -> None:
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    if dst.exists():
-        return
-    try:
-        os.link(src, dst)
-    except OSError:
-        shutil.copy2(src, dst)
-
-
-def _is_weight(path: Path) -> bool:
-    return path.suffix in _WEIGHT_EXTS
-
-
-def _weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Path]]:
-    """(component, entry_path) per weight set. entry is the index.json for
-    sharded sets, else the safetensors file. A singlefile-layout source can
-    still carry several root weight files (civitai bundles ship the
-    diffusion model + text encoder + VAE side by side) — every one is its
-    own group, or a dtype pass would convert only the first and the tree
-    copy would silently drop the rest."""
-    groups: list[tuple[str, Path]] = []
-
-    def _entries_for(d: Path) -> list[Path]:
-        idx = sorted(d.glob("*.safetensors.index.json"))
-        sharded_members: set[str] = set()
-        for i in idx:
-            try:
-                weight_map = json.loads(i.read_text("utf-8")).get("weight_map") or {}
-                sharded_members.update(str(v) for v in weight_map.values())
-            except Exception:
-                pass
-        loose = [p for p in sorted(d.glob("*.safetensors"))
-                 if p.is_file() and p.name not in sharded_members]
-        return idx + loose
-
-    if layout == "diffusers":
-        for entry in sorted(source_dir.iterdir()):
-            if entry.is_dir():
-                found = _entries_for(entry)
-                if found:
-                    groups.append((entry.name, found[0]))
-    else:
-        for found in _entries_for(source_dir):
-            groups.append(("", found))
-    return groups
-
-
-def _copy_non_weights(source_dir: Path, out_dir: Path, *, skip_components: set[str]) -> None:
-    """Hardlink every non-weight file into the flavor tree; weight files and
-    their sharded indexes for converted components are skipped."""
-    for f in sorted(source_dir.rglob("*")):
-        if not f.is_file():
-            continue
-        rel = f.relative_to(source_dir)
-        if rel.parts[:2] == (".cache", "huggingface"):
-            continue  # hf local-dir download metadata, not repo content
-        comp = rel.parts[0] if len(rel.parts) > 1 else ""
-        name = f.name
-        is_weightish = _is_weight(f) or name.endswith(".safetensors.index.json")
-        if is_weightish and (comp in skip_components or ("" in skip_components and comp == "")):
-            continue
-        if name == ".civitai.json":
-            continue
-        _link_or_copy(f, out_dir / rel)
-
 
 def _stage_oversize_safetensors(tree: Path) -> None:
     """Replace any >5 GB safetensors in the tree with HF-convention byte-offset
@@ -265,13 +202,13 @@ def build_flavor_tree(
             raise ValueError(
                 'dtype="source" needs a detectable on-disk dtype; request an explicit dtype')
         attrs["dtype"] = source_dtype
-        _copy_non_weights(source_dir, out_dir, skip_components=set())
+        copy_non_weight_files(source_dir, out_dir, skip_components=set())
         _stage_oversize_safetensors(out_dir)
         return out_dir, attrs
 
     # GGUF: single-artifact container.
     if spec.file_type == "gguf":
-        groups = _weight_groups(source_dir, source_layout)
+        groups = snapshot_weight_groups(source_dir, source_layout)
         if not groups:
             raise ValueError("no safetensors weights found for gguf conversion")
         result = run_inline_conversion(
@@ -296,7 +233,7 @@ def build_flavor_tree(
         repack_dir = out_dir.parent / f"{out_dir.name}.__repack__"
         repack_dir.mkdir(parents=True, exist_ok=True)
         if source_layout == "singlefile":
-            groups = _weight_groups(source_dir, "singlefile")
+            groups = snapshot_weight_groups(source_dir, "singlefile")
             if not groups:
                 raise ValueError("no safetensors entry for repackage")
             singlefile_to_diffusers(
@@ -311,13 +248,25 @@ def build_flavor_tree(
     # Passthrough: dtype already matches (or repackage output is final).
     needs_dtype_pass = spec.dtype != source_dtype or work_root is not source_dir
     if spec.dtype == source_dtype and work_root is source_dir:
-        _copy_non_weights(source_dir, out_dir, skip_components=set())
+        copy_non_weight_files(source_dir, out_dir, skip_components=set())
         _stage_oversize_safetensors(out_dir)
         return out_dir, attrs
 
     # Dtype conversion per weight set.
-    groups = _weight_groups(work_root, work_layout)
-    target_names = set(quantize_components or _DEFAULT_QUANT_COMPONENTS)
+    groups = snapshot_weight_groups(work_root, work_layout)
+    is_fp8 = spec.dtype == "fp8"
+    if is_fp8 and work_layout != "diffusers":
+        raise ValueError(
+            "fp8 storage flavors are component-scoped; request "
+            'file_layout="diffusers" (repackage first for singlefile sources)')
+    if quantize_components:
+        target_names = set(quantize_components)
+    elif is_fp8:
+        # Denoiser-only by default: matches apply_fp8_storage's consumption
+        # scope; TEs join explicitly via the component-wise ladder (gw#392).
+        target_names = set(FP8_DEFAULT_COMPONENTS)
+    else:
+        target_names = set(_DEFAULT_QUANT_COMPONENTS)
     is_quant = spec.dtype not in {"bf16", "fp16", "fp32", "f16", "f32"}
     converted: set[str] = set()
     for comp, entry in groups:
@@ -344,7 +293,7 @@ def build_flavor_tree(
     if needs_dtype_pass and not converted and not groups:
         raise ValueError("no safetensors weights found to convert")
 
-    _copy_non_weights(work_root, out_dir, skip_components=converted)
+    copy_non_weight_files(work_root, out_dir, skip_components=converted)
     _stage_oversize_safetensors(out_dir)
     if work_root is not source_dir:
         shutil.rmtree(work_root, ignore_errors=True)

--- a/packages/cozy_convert/src/cozy_convert/component.py
+++ b/packages/cozy_convert/src/cozy_convert/component.py
@@ -4,7 +4,7 @@ A diffusers-layout ``Source`` exposes ``components: dict[str, Component]``.
 Each Component is a self-contained HF module directory with its own
 config.json and weight file(s). Tenants can iterate tensors of one specific
 component (``source.components['transformer'].iter_tensors()``) or let the
-library's ``StreamingWriter`` auto-passthrough components the tenant didn't
+library's snapshot writers auto-passthrough components the tenant didn't
 touch.
 """
 

--- a/packages/cozy_convert/src/cozy_convert/convert.py
+++ b/packages/cozy_convert/src/cozy_convert/convert.py
@@ -11,16 +11,16 @@ Three buckets:
    matching ``target_dtype`` against what the classifier saw in the source
    files. No conversion needed.
 
-2. **Inline-supported** — weight-only schemes that don't need calibration:
+2. **Inline-supported** — weight-only schemes that don't need calibration,
+   streaming per-tensor (peak anon RAM ≈ largest single tensor) except bnb:
    - ``bf16`` / ``fp16`` / ``fp32`` (streaming dtype cast)
-   - ``fp8:e4m3`` / ``fp8:e5m2`` / ``int8`` / ``int4`` (torchao weight-only)
+   - ``fp8`` / ``fp8:e4m3`` (streaming fp8-E4M3 storage cast — the ``#fp8``
+     flavor; scale-free, consumed via diffusers layerwise casting)
+   - ``nf4`` / ``fp4`` / ``int4`` (bitsandbytes; full component load)
    - GGUF quants (``q4_k_m``, ``q8_0``, …) via convert_hf_to_gguf + llama-quantize
 
 3. **Calibration-required** — raise ``InlineConversionNotPossible`` with a
-   clear structured refusal:
-   - ``int4:awq`` / ``int4:gptq`` (modelopt + dataset)
-   - ``nvfp4`` calibrated (modelopt + dataset)
-   - ``int8:awq`` / ``int8:gptq``
+   clear structured refusal: ``nvfp4`` (modelopt + calibration dataset + GPU).
 
 The exception carries structured requirements so callers can render their own
 guidance without this worker package knowing about any particular published
@@ -97,16 +97,9 @@ class InlineConversionNotPossible(Exception):
 # Dispatch policy
 # ---------------------------------------------------------------------------
 
-# Weight-only quants we can run inline today. These don't need a calibration
-# dataset — torchao fp8_wo / int8_wo derive scales per-tensor from the
-# weight itself. (int4 routes through bitsandbytes nf4 on CPU because
-# torchao's Int4Tensor requires fbgemm_gpu + CUDA.)
-_INLINE_TORCHAO_SCHEMES: dict[str, str] = {
-    "fp8:e4m3":      "fp8_wo",
-    "fp8:e5m2":      "fp8_wo",        # torchao uses one fp8 wo path; e5m2 falls back to e4m3 for now
-    "fp8":           "fp8_wo",
-    "int8":          "int8_wo",
-}
+# fp8-E4M3 storage flavor (`#fp8`) — a streaming per-tensor cast with the
+# layerwise-casting skip patterns honored. No model load, no scales.
+_INLINE_FP8_STORAGE_DTYPES: frozenset[str] = frozenset({"fp8", "fp8:e4m3"})
 
 # bitsandbytes 4-bit weight-only: nf4 / fp4. Works on CPU (the quantization
 # pass + save_pretrained run end-to-end without CUDA; LLM.int8() is the only
@@ -137,42 +130,13 @@ _INLINE_GGUF_ENCODINGS: frozenset[str] = frozenset({
 })
 
 # Calibration-required quants. We refuse these inline — they need a calibration
-# dataset and (for some) a GPU; running them silently as part of clone would
-# either hang or produce garbage. The caller renders any product-specific
-# follow-up guidance from the structured requirement.
+# dataset and a GPU; running them silently as part of clone would either hang
+# or produce garbage. nvfp4 in particular is NOT producible weight-only: the
+# te#44 quality verdict (sd15, real forward passes through a generic prompt
+# pool) was a hard FAIL, so there is no honest calibration-free nvfp4 path.
+# The caller renders any product-specific follow-up guidance from the
+# structured requirement.
 _CALIBRATED_DTYPES: dict[str, DeferredConversionRequirement] = {
-    "int4:awq": DeferredConversionRequirement(
-        kind="calibrated_quantization",
-        target_dtype="int4:awq",
-        scheme="int4_awq",
-        requires_calibration=True,
-        requires_gpu=True,
-        runtime="modelopt",
-    ),
-    "int4:gptq": DeferredConversionRequirement(
-        kind="calibrated_quantization",
-        target_dtype="int4:gptq",
-        scheme="int4_gptq",
-        requires_calibration=True,
-        requires_gpu=True,
-        runtime="modelopt",
-    ),
-    "int8:awq": DeferredConversionRequirement(
-        kind="calibrated_quantization",
-        target_dtype="int8:awq",
-        scheme="int8_awq",
-        requires_calibration=True,
-        requires_gpu=True,
-        runtime="modelopt",
-    ),
-    "int8:gptq": DeferredConversionRequirement(
-        kind="calibrated_quantization",
-        target_dtype="int8:gptq",
-        scheme="int8_gptq",
-        requires_calibration=True,
-        requires_gpu=True,
-        runtime="modelopt",
-    ),
     "nvfp4": DeferredConversionRequirement(
         kind="calibrated_quantization",
         target_dtype="nvfp4",
@@ -203,7 +167,7 @@ def is_inline_supported(target_dtype: str, *, target_file_type: str = "safetenso
         return dtype in _INLINE_GGUF_ENCODINGS
     if dtype in _INLINE_CAST_DTYPES:
         return True
-    if dtype in _INLINE_TORCHAO_SCHEMES:
+    if dtype in _INLINE_FP8_STORAGE_DTYPES:
         return True
     if dtype in _INLINE_BNB_SCHEMES:
         return True
@@ -223,7 +187,7 @@ def deferred_conversion_requirement(target_dtype: str) -> DeferredConversionRequ
 class InlineConversionResult:
     """Result of an inline conversion pass.
 
-    Mirrors the shape of streaming_dtype_cast / streaming_nvfp4_quantize so
+    Mirrors the shape of streaming_dtype_cast / streaming_fp8_storage_cast so
     callers can promote ``output_paths`` + ``index_path`` to CAS the same
     way they handle the existing per-component conversion jobs.
     """
@@ -246,20 +210,18 @@ def run_inline_conversion(
     out_dir: Path,
     target_dtype: str,
     target_file_type: str = "safetensors",
-    component_name: str = "",
     shard_prefix: str = "model",
     source_repo_dir: Path | None = None,
 ) -> InlineConversionResult:
     """Run the appropriate inline conversion for the requested target_dtype.
 
-    ``source_path`` is the materialized input — for cast / torchao paths
-    this is the safetensors file (or .index.json) we'll read; for GGUF
-    this is also the safetensors file (we look up sidecar configs via
-    ``source_repo_dir``).
+    ``source_path`` is the materialized input — for cast / fp8 paths this is
+    the safetensors file (or .index.json) we'll read; for GGUF this is also
+    the safetensors file (we look up sidecar configs via ``source_repo_dir``).
 
     ``source_repo_dir`` is the parent component directory containing
     ``config.json`` and tokenizer assets — used by the GGUF path and by
-    the torchao path (which loads the component as an HF model). When
+    the bnb path (which loads the component as an HF model). When
     omitted we fall back to ``source_path.parent``.
 
     Raises ``InlineConversionNotPossible`` for calibrated dtypes; the
@@ -303,15 +265,12 @@ def run_inline_conversion(
             shard_prefix=shard_prefix,
         )
 
-    # Torchao weight-only quantization — fp8 / int8. Loads the component as
-    # an HF model and saves via flatten_tensor_state_dict + safetensors.
-    if dtype in _INLINE_TORCHAO_SCHEMES:
-        return _run_torchao_inline(
+    # fp8-E4M3 storage flavor — streaming per-tensor cast, no model load.
+    if dtype in _INLINE_FP8_STORAGE_DTYPES:
+        return _run_fp8_storage_inline(
             source_path=source_path,
-            source_repo_dir=source_repo_dir or source_path.parent,
             out_dir=out_dir,
-            target_dtype=dtype,
-            component_name=component_name,
+            shard_prefix=shard_prefix,
         )
 
     # bitsandbytes nf4 / fp4 — runs on CPU for the quant pass; save_pretrained
@@ -390,266 +349,37 @@ def _run_cast_inline(
     )
 
 
-def _run_torchao_inline(
+def _run_fp8_storage_inline(
     *,
     source_path: Path,
-    source_repo_dir: Path,
     out_dir: Path,
-    target_dtype: str,
-    component_name: str,
+    shard_prefix: str,
 ) -> InlineConversionResult:
-    """fp8/int8/int4 torchao weight-only quantization.
+    """fp8-E4M3 storage cast of one weight set (the ``#fp8`` flavor),
+    streaming per-tensor. Layerwise-casting skip patterns are honored so a
+    consumer's ``apply_fp8_storage`` reproduces the runtime fp8-storage lane
+    exactly. Stamps dtype ``fp8`` — the detector keys on F8_E4M3 headers."""
+    from .writer import streaming_fp8_storage_cast
 
-    Bypasses transformers' ``TorchAoConfig`` integration entirely (broken
-    in transformers 4.57 + torchao 0.17 — both the ``autoquant`` import
-    and the safe-serialization allowlist refuse non-fp8 schemes). Instead:
-
-      1. Load the model in bf16 via plain ``from_pretrained`` (no quant
-         config, no integration path that would trip the autoquant import).
-      2. ``torchao.quantization.quantize_(model, <Config>(version=2))``
-         — modern torchao API; produces tensor subclass weights.
-      3. Flatten the state_dict via ``torchao.prototype.safetensors.
-         safetensors_support.flatten_tensor_state_dict`` — splits each
-         subclass tensor (Float8Tensor, Int8Tensor, Int4Tensor) into
-         (qdata, scale, [zero_point]) plus a JSON metadata blob describing
-         how to reconstruct.
-      4. ``safetensors.torch.save_file(flat_data, out, metadata=meta)`` —
-         standard safetensors with the per-tensor metadata stashed in the
-         file header. Inference workers that call torchao's
-         ``unflatten_tensor_state_dict`` reconstruct the subclass weights.
-      5. Copy config.json / tokenizer files from source. Stamp
-         quantization_config in config.json so transformers' integration
-         picks it up on a future ``from_pretrained`` (the integration's
-         load path is intact even when the save path is broken).
-
-    For transformers (singlefile) sources this is one model load. Diffusers
-    sources are deferred to phase 2 (per-component quantize).
-    """
-    import json as _json
-    import shutil as _shutil
-    import torch
-
-    dtype = _normalize(target_dtype)
-    scheme = _INLINE_TORCHAO_SCHEMES.get(dtype)
-    if scheme is None:
-        raise InlineConversionNotPossible(
-            reason=f"_run_torchao_inline got unexpected dtype {dtype!r}",
-            target_dtype=dtype,
-        )
-    # Stamp the PRODUCED dtype, not the requested one: torchao's fp8 wo path
-    # always emits e4m3 kernels (an e5m2 request falls back), so a checkpoint
-    # labeled fp8:e5m2 would make inference dispatch on a lie (#358).
-    produced_dtype = {"fp8_wo": "fp8:e4m3", "int8_wo": "int8"}[scheme]
-    if produced_dtype != dtype:
-        logger.warning(
-            "inline torchao: requested dtype %s produces %s kernels; stamping %s",
-            dtype, produced_dtype, produced_dtype,
-        )
-
-    repo_dir = Path(source_repo_dir)
-    if not repo_dir.exists() or not repo_dir.is_dir():
-        repo_dir = Path(source_path).parent
-
-    is_diffusers = (repo_dir / "model_index.json").is_file()
-    is_transformers = (repo_dir / "config.json").is_file() and not is_diffusers
-    if not (is_diffusers or is_transformers):
-        raise InlineConversionNotPossible(
-            reason=(
-                f"source dir at {repo_dir} has neither model_index.json "
-                f"(diffusers) nor config.json (transformers) — can't pick "
-                f"an inline quantization loader"
-            ),
-            target_dtype=dtype,
-        )
-
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        import safetensors.torch as st
-        from torchao.quantization import (
-            Float8DynamicActivationFloat8WeightConfig,
-            Float8WeightOnlyConfig,
-            Int4WeightOnlyConfig,
-            Int8WeightOnlyConfig,
-            quantize_,
-        )
-        from torchao.prototype.safetensors.safetensors_support import (
-            flatten_tensor_state_dict,
-        )
-        from ._hf_load import load_component_module
-    except ImportError as exc:
-        raise InlineConversionNotPossible(
-            reason=(
-                f"torchao or transformers not installed — can't run inline "
-                f"{dtype} quantization: {exc}"
-            ),
-            target_dtype=dtype,
-        ) from exc
-
-    # version=2 is required for ALL configs to produce the modern tensor
-    # subclasses (Float8Tensor / Int8Tensor / Int4Tensor) that
-    # flatten_tensor_state_dict knows how to serialize. v1 produces the
-    # deprecated AffineQuantizedTensor which has no flatten support.
-    cfg_for_scheme: dict[str, Any] = {
-        "fp8_wo":      lambda: Float8WeightOnlyConfig(version=2),
-        "fp8_dynamic": lambda: Float8DynamicActivationFloat8WeightConfig(),
-        "int8_wo":     lambda: Int8WeightOnlyConfig(version=2),
-        "int4_wo":     lambda: Int4WeightOnlyConfig(group_size=128),
-    }
-    cfg_factory = cfg_for_scheme.get(scheme)
-    if cfg_factory is None:
-        raise InlineConversionNotPossible(
-            reason=f"unsupported torchao scheme: {scheme}",
-            target_dtype=dtype,
-        )
-
-    # Diffusers-layout fan-out: per-component load + quantize + flatten + save.
-    # vae / scheduler / tokenizer* / feature_extractor / safety_checker pass
-    # through unchanged (these are config-only or precision-sensitive).
-    # transformer / unet / text_encoder* / image_encoder / prior / controlnet
-    # are quantized.
-    if is_diffusers:
-        return _run_torchao_diffusers_inline(
-            repo_dir=repo_dir,
-            out_dir=out_dir,
-            dtype=dtype,
-            scheme=scheme,
-            cfg_factory=cfg_factory,
-        )
-
-    # Use load_component_module so diffusers components (FluxTransformer2DModel,
-    # CLIPTextModel, etc.) and transformers causal LMs both load via their
-    # canonical class. AutoModelForCausalLM was wrong here — it only handles
-    # decoder-only LM checkpoints, not diffusers transformers or CLIP encoders.
-    cfg_path = repo_dir / "config.json"
-    try:
-        cfg_blob = _json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.is_file() else {}
-    except Exception:
-        cfg_blob = {}
-    try:
-        model = load_component_module(
-            repo_dir, cfg_blob, torch_dtype=torch.bfloat16,
-        )
-    except Exception as exc:
-        raise InlineConversionNotPossible(
-            reason=f"failed to load source model for inline {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-
-    cfg = cfg_factory()
-    try:
-        quantize_(model, cfg)
-    except ImportError as exc:
-        # Common case: int4 requires fbgemm_gpu + CUDA which isn't available
-        # on the CPU-only build. The error message ("Requires mslk >= 1.0.0")
-        # is misleading; the real cause is libc10_cuda.so missing because the
-        # cpu profile doesn't bundle CUDA runtime. Surface a clear hint.
-        msg = str(exc)
-        if "mslk" in msg or "fbgemm" in msg.lower() or "c10_cuda" in msg.lower():
-            raise InlineConversionNotPossible(
-                reason=(
-                    f"{dtype} quantization requires fbgemm_gpu + CUDA runtime "
-                    f"(not available on this CPU-only worker). Run on a GPU "
-                    f"worker, or use fp8:e4m3 / int8 which work on CPU."
-                ),
-                target_dtype=dtype,
-            ) from exc
-        raise InlineConversionNotPossible(
-            reason=f"torchao quantize_ ImportError for {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-    except Exception as exc:
-        raise InlineConversionNotPossible(
-            reason=f"torchao quantize_ failed for {dtype}: {exc}",
-            target_dtype=dtype,
-        ) from exc
-
-    state_dict = model.state_dict()
-    try:
-        tensors_data, sd_metadata = flatten_tensor_state_dict(state_dict)
-    except Exception as exc:
-        raise InlineConversionNotPossible(
-            reason=(
-                f"torchao flatten_tensor_state_dict failed for {dtype}: {exc} "
-                f"(this is usually a torchao version-bump issue; the "
-                f"same flatten helper is used by packaged conversion "
-                f"entrypoints)"
-            ),
-            target_dtype=dtype,
-        ) from exc
-
-    # Copy non-weight source files (config.json, tokenizer, generation_config)
-    # so the destination is a complete loadable repo.
-    for src_file in repo_dir.iterdir():
-        if not src_file.is_file():
-            continue
-        # Skip the source weights — we're writing replacement quantized ones.
-        if src_file.suffix in {".safetensors", ".bin", ".pt", ".ckpt", ".pth"}:
-            continue
-        if src_file.name.endswith(".safetensors.index.json"):
-            continue
-        _shutil.copy2(src_file, out_dir / src_file.name)
-
-    # Write the flattened quantized weights to a single safetensors file. The
-    # subclass metadata is stashed in the safetensors header — torchao's
-    # unflatten_tensor_state_dict reads it back via `f.metadata()`.
-    weights_path = out_dir / "model.safetensors"
-    st.save_file(tensors_data, str(weights_path), metadata=sd_metadata)
-
-    # Stamp quantization_config in config.json so transformers' integration
-    # picks up the right TorchAoConfig on a future from_pretrained. This is
-    # the side-channel that lets unflatten happen automatically at load time.
-    config_json_path = out_dir / "config.json"
-    if config_json_path.is_file():
-        try:
-            cfg_data = _json.loads(config_json_path.read_text(encoding="utf-8"))
-        except Exception:
-            cfg_data = {}
-        cfg_data["quantization_config"] = {
-            "quant_method": "torchao",
-            "quant_type": _torchao_quant_type_name(scheme),
-            "modules_to_not_convert": None,
-            "include_input_output_embeddings": False,
-            "untie_embedding_weights": False,
-        }
-        config_json_path.write_text(
-            _json.dumps(cfg_data, indent=2), encoding="utf-8",
-        )
-
-    saved_files: list[Path] = sorted(
-        f for f in out_dir.rglob("*") if f.is_file()
+    result = streaming_fp8_storage_cast(
+        Path(source_path), Path(out_dir), shard_prefix=shard_prefix,
     )
-    if not saved_files:
-        raise RuntimeError(
-            f"_run_torchao_inline: no files produced for {dtype} from {repo_dir}"
-        )
-
-    try:
-        import torchao
-        torchao_version = str(torchao.__version__)
-    except Exception:
-        torchao_version = ""
-
+    index_path = result.get("index_path")
     attrs = {
-        "dtype": produced_dtype,
+        "dtype": "fp8",
         "file_type": "safetensors",
-        "conversion_strategy": "inline_torchao",
-        "quant_scheme": f"torchao:{scheme}",
-        "quant_library": "torchao",
+        "conversion_strategy": "inline_fp8_storage_cast",
+        "quant_recipe": "fp8:e4m3-storage",
+        "tensor_count": str(int(result.get("tensor_count") or 0)),
+        "converted_count": str(int(result.get("converted_count") or 0)),
     }
-    if torchao_version:
-        attrs["quant_library_version"] = torchao_version
     return InlineConversionResult(
-        output_paths=saved_files,
-        index_path=None,
-        target_dtype=produced_dtype,
+        output_paths=[Path(p) for p in result.get("output_paths") or []],
+        index_path=Path(index_path) if index_path is not None else None,
+        target_dtype="fp8",
         target_file_type="safetensors",
         attributes=attrs,
-        summary={
-            "scheme": scheme,
-            "file_count": len(saved_files),
-        },
+        summary=dict(result),
     )
 
 
@@ -662,9 +392,8 @@ def _run_bnb_inline(
 ) -> InlineConversionResult:
     """bitsandbytes nf4 / fp4 weight-only quantization (CPU-friendly).
 
-    Routes through transformers' ``BitsAndBytesConfig`` integration which is
-    mature and stable (unlike the torchao path which is broken in transformers
-    4.57). bitsandbytes' ``Params4bit`` is a parameter subclass that handles
+    Routes through transformers' ``BitsAndBytesConfig`` integration.
+    bitsandbytes' ``Params4bit`` is a parameter subclass that handles
     its own save/load via ``save_pretrained`` directly — no flatten helper
     needed.
 
@@ -808,192 +537,6 @@ _DIFFUSERS_ROOT_FILES: tuple[str, ...] = (
 )
 
 
-def _run_torchao_diffusers_inline(
-    *,
-    repo_dir: Path,
-    out_dir: Path,
-    dtype: str,
-    scheme: str,
-    cfg_factory: Any,
-) -> InlineConversionResult:
-    """Per-component torchao quantization for a diffusers-layout source.
-
-    Walks each subdir under ``repo_dir``. Quantizes weight-bearing components
-    (transformer / unet / text_encoder*); copies the rest verbatim. Each
-    quantized component lands at ``<out_dir>/<comp_name>/model.safetensors``
-    with a flatten metadata blob in the safetensors header. The destination
-    is a complete diffusers snapshot — model_index.json + every component
-    subdir + (quantized weights | passthrough copy).
-    """
-    import json as _json
-    import shutil as _shutil
-    import torch
-    import safetensors.torch as st
-
-    from torchao.quantization import quantize_
-    from torchao.prototype.safetensors.safetensors_support import (
-        flatten_tensor_state_dict,
-    )
-    from ._hf_load import load_component_module
-
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    quantized_components: list[str] = []
-    passthrough_components: list[str] = []
-
-    for entry in sorted(repo_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        comp_name = entry.name
-        comp_out = out_dir / comp_name
-
-        if comp_name in _DIFFUSERS_QUANT_COMPONENTS:
-            cfg_path = entry / "config.json"
-            if not cfg_path.is_file():
-                # No config → can't load → passthrough as a safety fallback.
-                _shutil.copytree(entry, comp_out, dirs_exist_ok=True)
-                passthrough_components.append(comp_name)
-                continue
-            try:
-                cfg_data = _json.loads(cfg_path.read_text(encoding="utf-8"))
-            except Exception:
-                cfg_data = {}
-            try:
-                module = load_component_module(
-                    entry, cfg_data, torch_dtype=torch.bfloat16,
-                )
-            except Exception as exc:
-                raise InlineConversionNotPossible(
-                    reason=(
-                        f"failed to load diffusers component {comp_name!r} for "
-                        f"inline {dtype}: {exc}"
-                    ),
-                    target_dtype=dtype,
-                ) from exc
-
-            try:
-                quantize_(module, cfg_factory())
-            except ImportError as exc:
-                msg = str(exc)
-                if "mslk" in msg or "fbgemm" in msg.lower() or "c10_cuda" in msg.lower():
-                    raise InlineConversionNotPossible(
-                        reason=(
-                            f"{dtype} quantization requires fbgemm_gpu + CUDA "
-                            f"(component {comp_name!r}). Run on a GPU worker."
-                        ),
-                        target_dtype=dtype,
-                    ) from exc
-                raise
-
-            # Per-component flatten + safetensors save.
-            comp_out.mkdir(parents=True, exist_ok=True)
-            tensors_data, sd_metadata = flatten_tensor_state_dict(module.state_dict())
-            st.save_file(
-                tensors_data,
-                str(comp_out / "model.safetensors"),
-                metadata=sd_metadata,
-            )
-            # Carry the component's config files (not weights) so reload works.
-            for src_file in entry.iterdir():
-                if not src_file.is_file():
-                    continue
-                if src_file.suffix in {".safetensors", ".bin", ".pt", ".pth"}:
-                    continue
-                if src_file.name.endswith(".safetensors.index.json"):
-                    continue
-                _shutil.copy2(src_file, comp_out / src_file.name)
-            # Stamp quantization_config in the component's config.json so a
-            # downstream from_pretrained picks the right TorchAoConfig.
-            comp_cfg = comp_out / "config.json"
-            if comp_cfg.is_file():
-                try:
-                    cfg_blob = _json.loads(comp_cfg.read_text(encoding="utf-8"))
-                except Exception:
-                    cfg_blob = {}
-                cfg_blob["quantization_config"] = {
-                    "quant_method": "torchao",
-                    "quant_type": _torchao_quant_type_name(scheme),
-                    "modules_to_not_convert": None,
-                }
-                comp_cfg.write_text(
-                    _json.dumps(cfg_blob, indent=2), encoding="utf-8",
-                )
-            quantized_components.append(comp_name)
-            del module
-        else:
-            # Passthrough: vae / scheduler / tokenizer / feature_extractor /
-            # safety_checker — copy verbatim.
-            _shutil.copytree(entry, comp_out, dirs_exist_ok=True)
-            passthrough_components.append(comp_name)
-
-    # Top-level files (model_index.json, README, LICENSE).
-    for fname in _DIFFUSERS_ROOT_FILES:
-        src = repo_dir / fname
-        if src.is_file():
-            _shutil.copy2(src, out_dir / fname)
-
-    if not quantized_components:
-        raise InlineConversionNotPossible(
-            reason=(
-                f"diffusers source at {repo_dir} has no quantizable "
-                f"components (looked for: {sorted(_DIFFUSERS_QUANT_COMPONENTS)})"
-            ),
-            target_dtype=dtype,
-        )
-
-    saved_files: list[Path] = sorted(
-        f for f in out_dir.rglob("*") if f.is_file()
-    )
-
-    try:
-        import torchao
-        torchao_version = str(torchao.__version__)
-    except Exception:
-        torchao_version = ""
-
-    attrs = {
-        "dtype": dtype,
-        "file_type": "safetensors",
-        "conversion_strategy": "inline_torchao_diffusers",
-        "quant_scheme": f"torchao:{scheme}",
-        "quant_library": "torchao",
-        "quant_components": ",".join(sorted(quantized_components)),
-        "passthrough_components": ",".join(sorted(passthrough_components)),
-    }
-    if torchao_version:
-        attrs["quant_library_version"] = torchao_version
-    return InlineConversionResult(
-        output_paths=saved_files,
-        index_path=None,
-        target_dtype=dtype,
-        target_file_type="safetensors",
-        attributes=attrs,
-        summary={
-            "scheme": scheme,
-            "quantized_components": quantized_components,
-            "passthrough_components": passthrough_components,
-            "file_count": len(saved_files),
-        },
-    )
-
-
-def _torchao_quant_type_name(scheme: str) -> str:
-    """Map our internal scheme name → transformers' TorchAoConfig.quant_type string.
-
-    Stamped into config.json's quantization_config so a future
-    AutoModelForCausalLM.from_pretrained(...) on the destination repo
-    rebuilds the right config. The string itself is what transformers'
-    TorchAoConfig._get_torchao_quant_type_to_method consumes.
-    """
-    return {
-        "int8_wo":      "int8_weight_only",
-        "int4_wo":      "int4_weight_only",
-        "fp8_wo":       "float8_weight_only",
-        "fp8_dynamic":  "float8_dynamic_activation_float8_weight",
-    }.get(scheme, scheme)
-
-
 def _run_bnb_diffusers_inline(
     *,
     repo_dir: Path,
@@ -1003,7 +546,7 @@ def _run_bnb_diffusers_inline(
 ) -> InlineConversionResult:
     """Per-component bitsandbytes nf4/fp4 for a diffusers-layout source.
 
-    Same shape as `_run_torchao_diffusers_inline`: walk components, quantize
+    Walk components, quantize
     weight-bearing ones (transformer / unet / text_encoder*), copy the rest
     verbatim. bitsandbytes' `Params4bit` is a parameter subclass that
     handles its own save/load via ``module.save_pretrained`` directly — no

--- a/packages/cozy_convert/src/cozy_convert/loaded_component.py
+++ b/packages/cozy_convert/src/cozy_convert/loaded_component.py
@@ -10,10 +10,7 @@ Each LoadedComponent has been resolved to one of four states:
                        subdir under ``out_dir`` via ``save_pretrained``.
   - ``bf16_cpu``     — loaded into CPU memory in ``torch_dtype``, NOT
                        quantized. Yielded by ``iter_hf_components_streaming``
-                       for tenants that want to drive quantization themselves
-                       (e.g. ``torchao.quantization.quantize_(component.module,
-                       config, device='cuda')``, which streams one Linear at
-                       a time to GPU rather than staging the full bf16 there).
+                       for tenants that drive an in-place transform themselves.
                        After the tenant mutates the module in-place,
                        ``save_to`` writes it the same way as ``quantized``.
   - ``passthrough``  — pure file copy; kind for tokenizer / scheduler / vae /
@@ -41,37 +38,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 
-def _maybe_unwrap_torchao_subclasses(module: Any) -> None:
-    """If `module` contains torchao tensor subclasses (AffineQuantizedTensor,
-    etc.), unwrap them so the underlying raw tensors become safetensors-
-    serializable. No-op if torchao isn't installed or the module has no such
-    subclasses to unwrap.
-
-    torchao 0.15+ ships native safetensors hooks on its new per-config tensor
-    classes (Float8Tensor, Int4TilePackedTo4dTensor, IntxUnpackedToInt8Tensor)
-    so this unwrap is in principle unneeded for those. Kept as a defensive
-    fallback because (1) older AffineQuantizedTensor paths still appear in
-    some torchao Config combinations and (2) the call is a cheap idempotent
-    no-op when the model already serializes natively. Remove only after
-    verifying every Config we ship round-trips through save_pretrained
-    + from_pretrained without the unwrap.
-
-    Called by `LoadedComponent.save_to` for kind in ('quantized', 'bf16_cpu').
-    """
-    try:
-        from torchao.utils import unwrap_tensor_subclass
-    except Exception:
-        return
-    try:
-        unwrap_tensor_subclass(module)
-    except Exception:
-        # If the module doesn't contain torchao subclasses (or torchao raised
-        # for some other reason), swallow — the subsequent save_pretrained
-        # will surface a clear error if the module still has incompatible
-        # tensor types.
-        pass
-
-
 ComponentKind = Literal["quantized", "bf16_cpu", "passthrough", "root"]
 
 
@@ -81,10 +47,10 @@ class LoadedComponent:
     kind: ComponentKind
     # Populated when kind in ("quantized", "bf16_cpu"): the loaded HF module.
     #   - "quantized": already carries quantization state (Linear8bitLt /
-    #     Linear4bit / torchao AffineQuantizedTensor / modelopt fake-quant
-    #     subclasses) from HF's from_pretrained(quantization_config=...).
-    #   - "bf16_cpu": plain bf16 module on CPU; tenant will mutate in-place
-    #     (e.g. torchao.quantize_(module, config, device='cuda')) before save.
+    #     Linear4bit / modelopt fake-quant subclasses) from HF's
+    #     from_pretrained(quantization_config=...).
+    #   - "bf16_cpu": plain bf16 module on CPU; tenant mutates in-place
+    #     before save.
     # save_to calls .save_pretrained on it.
     _module: Any = None
     # Populated when kind == "passthrough": absolute path to the source-side
@@ -129,17 +95,7 @@ class LoadedComponent:
                 )
             target = out_dir / self.name
             target.mkdir(parents=True, exist_ok=True)
-            # safetensors is required (Cozy policy: safetensors, never
-            # pickle). torchao's AffineQuantizedTensor and similar
-            # tensor subclasses aren't directly serializable by safetensors —
-            # they wrap raw int_data + scale + zero_point in one Python
-            # object. Call `unwrap_tensor_subclass` to flatten the subclasses
-            # back into raw state-dict entries that safetensors can write.
-            # No-op for modules without torchao subclasses, and a no-op if
-            # torchao isn't installed. bf16_cpu modules that were quantized
-            # in-place by the tenant (e.g. torchao streaming-quant) carry the
-            # same subclasses, so the unwrap applies to them too.
-            _maybe_unwrap_torchao_subclasses(self._module)
+            # safetensors is required (Cozy policy: safetensors, never pickle).
             self._module.save_pretrained(str(target), safe_serialization=True)
             return
 

--- a/packages/cozy_convert/src/cozy_convert/source.py
+++ b/packages/cozy_convert/src/cozy_convert/source.py
@@ -27,7 +27,7 @@ FileLayout = Literal["singlefile", "diffusers"]
 # path covers when the tenant doesn't explicitly opt them out. These are
 # config / tokenizer / scheduler / non-quantizable bits that should travel
 # verbatim into the output snapshot. vae is here because most quant tenants
-# (bnb / torchao) leave the vae bf16; modelopt may override per spec.
+# (bnb) leave the vae bf16; modelopt may override per spec.
 _DEFAULT_PASSTHROUGH_COMPONENTS: frozenset[str] = frozenset({
     "vae", "scheduler",
     "tokenizer", "tokenizer_2", "tokenizer_3",
@@ -368,14 +368,14 @@ class Source:
     ) -> Iterator[LoadedComponent]:
         """Yield ``LoadedComponent`` payloads in arrival / discovery order.
 
-        This is the recommended path for quant tenants (bnb / torchao /
+        This is the recommended path for quant tenants (bnb /
         modelopt). It pushes three concerns into the library:
 
           1. **Per-component HF loading.** Each heavy component is loaded
              via ``<Class>.from_pretrained(component_path,
              quantization_config=..., torch_dtype=compute_dtype,
              device_map='auto', offload_folder=offload_folder)``. The
-             quantization_config is what triggers bnb / torchao / modelopt
+             quantization_config is what triggers bnb / modelopt
              to swap weights in-place during load. ``device_map='auto'``
              plus ``offload_folder`` lets accelerate spill to disk when
              VRAM is tight — that's how a 4 GB transformer fits on a 7 GB
@@ -403,8 +403,8 @@ class Source:
             ``controlnet``). Passing an explicit iterable narrows or
             widens.
           quantization_config: HuggingFace quant config object —
-            ``BitsAndBytesConfig``, ``TorchAoConfig``,
-            ``ModeloptQuantizationConfig``, etc. ``None`` skips quant
+            ``BitsAndBytesConfig``, ``ModeloptQuantizationConfig``, etc.
+            ``None`` skips quant
             (then ``quant_only`` becomes a passthrough-on-load filter,
             useful for dtype-cast tenants).
           compute_dtype: torch dtype used as ``torch_dtype`` on the
@@ -472,13 +472,11 @@ class Source:
         in-place (typically via a library-specific streaming-quant call) and
         then invokes ``component.save_to(out_dir)``.
 
-        Use this for libraries that have a documented streaming-quant API,
-        like torchao's ``quantize_(module, config, device='cuda')``, which
+        Use this for libraries with a documented streaming-quant API that
         sends each ``Linear`` to GPU individually rather than staging the
         full bf16 component there. Peak VRAM ≈ size of the largest single
         ``Linear`` plus the accumulating quantized result — not the full
-        component. Lets FLUX-class int8/fp8 conversions complete on 8 GB
-        consumer GPUs.
+        component.
 
         For non-streaming libraries (bnb, modelopt), keep using
         :meth:`iter_hf_components` with a ``quantization_config``.
@@ -687,7 +685,7 @@ def _iter_diffusers_components_streaming(
     Yields ``kind='bf16_cpu'`` for quant-candidate components (loaded on CPU
     in ``compute_dtype``, no ``quantization_config``). Tenant is expected
     to invoke a library-specific in-place quant call (e.g.
-    ``torchao.quantize_(component.module, config, device='cuda')``) before
+    an in-place streaming quant call) before
     ``component.save_to(out_dir)``.
 
     Passthrough and root yields are identical to the non-streaming variant.

--- a/packages/cozy_convert/src/cozy_convert/source.py
+++ b/packages/cozy_convert/src/cozy_convert/source.py
@@ -233,9 +233,6 @@ class Source:
           Only components with weight files are iterated; scheduler/tokenizer
           subdirs are skipped.
         - If ``components`` is passed, only those components are iterated.
-          The library's StreamingWriter auto-passes untouched components on
-          finalize() — the tenant can filter iteration without losing output
-          coverage.
 
         Handles pickle → safetensors conversion and sharded-safetensors via
         .index.json internally. Tenant sees a flat iteration.

--- a/packages/cozy_convert/src/cozy_convert/writer.py
+++ b/packages/cozy_convert/src/cozy_convert/writer.py
@@ -7,9 +7,10 @@ safetensors_io) into one:
   - shard planning (HF 5 GB convention) + index.json emit
   - IncrementalSafetensorsWriter: header first, then tensor bytes — O(1) memory
   - tensor iteration over single/sharded/pickle sources
-  - streaming_dtype_cast: read one tensor, cast, write into its shard
+  - streaming_dtype_cast / streaming_fp8_storage_cast: read one tensor,
+    transform, write into its planned shard (peak RAM ~ largest tensor)
+  - streaming_cast_snapshot / streaming_fp8_snapshot: whole-tree variants
   - shard_safetensors_by_offset: raw byte-range re-shard, zero decode
-  - StreamingWriter: the tenant-facing per-variant output writer
 
 torch/safetensors imports are deferred so importing cozy_convert stays cheap.
 """
@@ -26,8 +27,6 @@ from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional
 if TYPE_CHECKING:
     import torch
 
-    from .component import Component
-    from .source import Source
 
 
 class ConversionImplementationError(RuntimeError):
@@ -842,139 +841,6 @@ def shard_safetensors_by_offset(
         os.close(fd)
 
 
-# ---------------------------------------------------------------------------
-# StreamingWriter — the tenant-facing per-variant output writer
-# ---------------------------------------------------------------------------
-
-_PASSTHROUGH_FILES = frozenset({
-    "model_index.json", "config.json", "tokenizer.json", "tokenizer_config.json",
-    "special_tokens_map.json", "scheduler_config.json", "preprocessor_config.json",
-    "generation_config.json", "tokenizer.model",
-})
-
-
-class StreamingWriter:
-    """Per-variant output writer for conversion tenants.
-
-    Tenants iterate ``source.iter_tensors()`` and ``write(component, name,
-    tensor)`` each output tensor. ``finalize()`` flushes per-component
-    safetensors (auto-sharded past 5 GB), auto-passes-through untouched
-    components + known config/tokenizer files, and returns the output path.
-    """
-
-    def __init__(self, *, source: "Source", out_dir: Path) -> None:
-        self._source = source
-        self._out_dir = Path(out_dir)
-        self._out_dir.mkdir(parents=True, exist_ok=True)
-        self._by_component: dict[str, dict[str, Any]] = {}
-        self._written_components: set[str] = set()
-        self._explicit_passthrough: set[str] = set()
-        self._finalized = False
-
-    def write(self, component: str, name: str, tensor: "torch.Tensor") -> None:
-        if self._finalized:
-            raise RuntimeError("StreamingWriter.write called after finalize()")
-        self._by_component.setdefault(component, {})[name] = tensor
-        self._written_components.add(component)
-
-    def passthrough(self, component: "Component") -> None:
-        if self._finalized:
-            raise RuntimeError("StreamingWriter.passthrough called after finalize()")
-        self._explicit_passthrough.add(component.name)
-
-    def finalize(self) -> Path:
-        if self._finalized:
-            raise RuntimeError("StreamingWriter.finalize called twice")
-        self._finalized = True
-
-        if self._source.file_layout == "singlefile":
-            written = self._write_safetensors(
-                self._out_dir / "model.safetensors", self._by_component.get("", {}))
-            self._copy_passthrough_files(self._source.path, self._out_dir)
-            if written is None:
-                return self._out_dir
-            return written if written.suffix == ".safetensors" else self._out_dir
-
-        for comp_name, tensors in self._by_component.items():
-            if not comp_name:
-                raise RuntimeError(
-                    "StreamingWriter.write called with empty component on a "
-                    "diffusers source — name the component (unet, vae, transformer, ...)")
-            self._write_component(comp_name, tensors)
-
-        source_components = set(self._source.components.keys())
-        touched = self._written_components | self._explicit_passthrough
-        for comp_name in source_components - touched:
-            src = self._source.components[comp_name].path
-            dst = self._out_dir / comp_name
-            if not dst.exists():
-                shutil.copytree(str(src), str(dst))
-        for entry in self._source.path.iterdir():
-            if entry.is_dir() and entry.name not in source_components:
-                dst = self._out_dir / entry.name
-                if not dst.exists():
-                    shutil.copytree(str(entry), str(dst))
-        self._copy_passthrough_files(self._source.path, self._out_dir)
-        return self._out_dir
-
-    # ---- internals ----
-
-    def _write_component(self, comp_name: str, tensors: dict[str, Any]) -> None:
-        subdir = self._out_dir / comp_name
-        subdir.mkdir(parents=True, exist_ok=True)
-        if comp_name.startswith("text_encoder") or comp_name == "image_encoder":
-            prefix = "model"
-        else:
-            prefix = "diffusion_pytorch_model"
-        self._write_safetensors(subdir, tensors, shard_prefix=prefix)
-        self._copy_passthrough_files(self._source.components[comp_name].path, subdir)
-
-    def _write_safetensors(
-        self, target: Path, tensors: dict[str, Any], *, shard_prefix: str = "model",
-    ) -> Optional[Path]:
-        if not tensors:
-            return None
-        from safetensors.torch import save_file
-
-        def _size(t: Any) -> int:
-            try:
-                return int(t.numel()) * int(t.element_size())
-            except AttributeError:
-                return int(getattr(t, "nbytes"))
-
-        sizes = {name: _size(t) for name, t in tensors.items()}
-        if sum(sizes.values()) <= MAX_SAFETENSORS_SHARD_BYTES:
-            if target.suffix == ".safetensors":
-                out = target
-                out.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                target.mkdir(parents=True, exist_ok=True)
-                out = target / f"{shard_prefix}.safetensors"
-            save_file(tensors, str(out))
-            return out
-
-        shard_dir = target.parent if target.suffix == ".safetensors" else target
-        shard_dir.mkdir(parents=True, exist_ok=True)
-        plan = plan_shards(sizes, shard_prefix=shard_prefix)
-        buckets: dict[str, dict[str, Any]] = {}
-        for name, tensor in tensors.items():
-            buckets.setdefault(plan.weight_map[name], {})[name] = tensor
-        for shard_name, bucket in buckets.items():
-            save_file(bucket, str(shard_dir / shard_name))
-        index_path = shard_dir / f"{shard_prefix}.safetensors.index.json"
-        index_path.write_text(json.dumps(build_index(plan), separators=(",", ":")))
-        return index_path
-
-    def _copy_passthrough_files(self, src_dir: Path, dst_dir: Path) -> None:
-        if not src_dir.is_dir():
-            return
-        for entry in src_dir.iterdir():
-            if entry.is_file() and entry.name in _PASSTHROUGH_FILES:
-                dst = dst_dir / entry.name
-                if not dst.exists():
-                    shutil.copy2(str(entry), str(dst))
-
-
 __all__ = [
     "ConversionImplementationError",
     "MAX_SAFETENSORS_SHARD_BYTES",
@@ -998,5 +864,4 @@ __all__ = [
     "FP8_SKIP_TENSOR_PATTERNS",
     "FP8_DEFAULT_COMPONENTS",
     "shard_safetensors_by_offset",
-    "StreamingWriter",
 ]

--- a/packages/cozy_convert/src/cozy_convert/writer.py
+++ b/packages/cozy_convert/src/cozy_convert/writer.py
@@ -170,14 +170,19 @@ def list_shard_files_from_index(index_path: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 class IncrementalSafetensorsWriter:
-    """Write a safetensors file one tensor at a time (no full dict in memory)."""
+    """Write a safetensors file one tensor at a time (no full dict in memory).
 
-    def __init__(self, output_path: Path) -> None:
+    ``metadata`` (string-valued) is emitted as the header's ``__metadata__``.
+    """
+
+    def __init__(self, output_path: Path, *, metadata: Mapping[str, str] | None = None) -> None:
         self._output_path = Path(output_path)
         self._meta: list[tuple[str, str, list[int]]] = []  # (name, st_dtype, shape)
+        self._metadata = {str(k): str(v) for k, v in (metadata or {}).items()}
         self._header_written = False
         self._fh: Any = None
         self._written: set[str] = set()
+        self._sizes: list[int] = []
 
     def __enter__(self) -> "IncrementalSafetensorsWriter":
         return self
@@ -196,6 +201,10 @@ class IncrementalSafetensorsWriter:
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
         self._fh = open(self._output_path, "wb")
         header: dict[str, Any] = {}
+        if self._metadata:
+            # Sorted for byte-determinism: safe_open().metadata() iterates in
+            # randomized (Rust HashMap) order.
+            header["__metadata__"] = dict(sorted(self._metadata.items()))
         offset = 0
         for name, dtype, shape in self._meta:
             elem = _ST_DTYPE_SIZES.get(dtype)
@@ -206,6 +215,7 @@ class IncrementalSafetensorsWriter:
                 numel *= dim
             size = numel * elem
             header[name] = {"dtype": dtype, "shape": shape, "data_offsets": [offset, offset + size]}
+            self._sizes.append(size)
             offset += size
         blob = json.dumps(header, separators=(",", ":")).encode("utf-8")
         blob += b" " * ((8 - (len(blob) % 8)) % 8)
@@ -213,14 +223,20 @@ class IncrementalSafetensorsWriter:
         self._fh.write(blob)
         self._header_written = True
 
-    def write_tensor(self, name: str, data: bytes) -> None:
+    def write_tensor(self, name: str, data: Any) -> None:
+        """``data`` is any bytes-like buffer (bytes / memoryview / ndarray)."""
         if not self._header_written or self._fh is None:
             raise RuntimeError("write_header() must run before write_tensor()")
-        expected = self._meta[len(self._written)][0]
+        idx = len(self._written)
+        expected = self._meta[idx][0]
         if name != expected:
             raise RuntimeError(f"expected tensor {expected!r}, got {name!r} (write in order)")
         if name in self._written:
             raise RuntimeError(f"tensor {name!r} already written")
+        nbytes = memoryview(data).nbytes
+        if nbytes != self._sizes[idx]:
+            raise RuntimeError(
+                f"tensor {name!r}: got {nbytes} bytes, header declared {self._sizes[idx]}")
         self._fh.write(data)
         self._written.add(name)
 
@@ -230,11 +246,11 @@ class IncrementalSafetensorsWriter:
             self._fh = None
 
 
-def _tensor_to_bytes(t: "torch.Tensor") -> bytes:
-    """Contiguous little-endian raw bytes via one C-level memcpy."""
+def _tensor_to_bytes(t: "torch.Tensor") -> Any:
+    """Contiguous little-endian raw byte buffer (zero-copy numpy view)."""
     import torch
 
-    return t.contiguous().flatten().view(torch.uint8).numpy().tobytes()
+    return t.contiguous().flatten().view(torch.uint8).numpy()
 
 
 # ---------------------------------------------------------------------------
@@ -351,47 +367,53 @@ def iter_source_tensors(
 
 
 # ---------------------------------------------------------------------------
-# Streaming dtype cast — one tensor in memory at a time, direct-to-shard
+# Streaming per-tensor re-encode — one tensor in memory at a time
 # ---------------------------------------------------------------------------
 
-def streaming_dtype_cast(
+_ST_FLOAT_DTYPES: frozenset[str] = frozenset(
+    {"F64", "F32", "F16", "BF16", "F8_E4M3", "F8_E5M2"})
+
+
+def _stream_reencode(
     input_path: Path,
     out_dir: Path,
     *,
-    target_dtype: "torch.dtype",
-    shard_prefix: str = "model",
-    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+    out_st_dtype_for: Any,   # (name, src_st_dtype, shape) -> output st dtype
+    transform: Any,          # (name, tensor, out_st_dtype) -> tensor
+    shard_prefix: str,
+    shard_threshold: int,
 ) -> dict[str, Any]:
-    """Cast float tensors to ``target_dtype``, writing directly into N shards.
+    """Two-pass streaming re-encode over safetensors input(s).
 
-    Non-float tensors keep their source dtype. Returns ``output_paths``
-    (list of shard files), ``index_path`` (None for a single shard),
-    ``tensor_count`` / ``converted_count`` / ``shard_sizes``.
+    Pass 1 reads only the shard headers (``get_slice`` — no tensor data) to
+    plan output shards; pass 2 reads one tensor at a time, applies
+    ``transform``, and appends it to its output shard. Peak anonymous memory
+    ≈ the largest single tensor. Source ``__metadata__`` is preserved.
     """
     from safetensors import safe_open
 
     shards_in = _resolve_input_shards(Path(input_path))
-    target_st = torch_dtype_to_st(target_dtype)
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # Pass 1: metadata walk — output dtype + byte size per tensor.
+    # Pass 1: header-only walk — output dtype + byte size per tensor.
     metas: list[tuple[str, str, list[int], Path]] = []  # name, out_dtype, shape, src_shard
     size_map: dict[str, int] = {}
-    elem_size = _ST_DTYPE_SIZES[target_st]
+    source_metadata: dict[str, str] = {}
     for shard_path in shards_in:
         with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            md = f.metadata()
+            if md:
+                source_metadata.update({str(k): str(v) for k, v in md.items()})
             for name in f.keys():
-                t = f.get_tensor(name)
-                if t.is_floating_point():
-                    out_dtype = target_st
-                    nbytes = int(t.numel()) * elem_size
-                else:
-                    out_dtype = torch_dtype_to_st(t.dtype)
-                    nbytes = int(t.numel() * t.element_size())
-                metas.append((name, out_dtype, list(t.shape), shard_path))
-                size_map[name] = nbytes
-                del t
+                sl = f.get_slice(name)
+                shape = list(sl.get_shape())
+                out_dtype = str(out_st_dtype_for(name, str(sl.get_dtype()), shape))
+                numel = 1
+                for dim in shape:
+                    numel *= dim
+                metas.append((name, out_dtype, shape, shard_path))
+                size_map[name] = numel * _ST_DTYPE_SIZES[out_dtype]
 
     plan = plan_shards(size_map, max_shard_bytes=shard_threshold, shard_prefix=shard_prefix)
     per_shard: dict[str, list[tuple[str, str, list[int], Path]]] = {n: [] for n in plan.shard_names}
@@ -402,23 +424,37 @@ def streaming_dtype_cast(
 
     tensor_count = 0
     converted = 0
-    for shard_name in plan.shard_names:
-        entries = per_shard[shard_name]
-        with IncrementalSafetensorsWriter(out_dir / shard_name) as w:
-            for name, out_dtype, shape, _src in entries:
-                w.add_tensor_metadata(name, dtype=out_dtype, shape=shape)
-            w.write_header()
-            for name, _out_dtype, _shape, src in entries:
-                with safe_open(str(src), framework="pt", device="cpu") as f:
+    handles: dict[Path, Any] = {}
+    try:
+        for shard_name in plan.shard_names:
+            entries = per_shard[shard_name]
+            with IncrementalSafetensorsWriter(
+                out_dir / shard_name, metadata=source_metadata,
+            ) as w:
+                for name, out_dtype, shape, _src in entries:
+                    w.add_tensor_metadata(name, dtype=out_dtype, shape=shape)
+                w.write_header()
+                for name, out_dtype, _shape, src in entries:
+                    f = handles.get(src)
+                    if f is None:
+                        f = handles[src] = safe_open(str(src), framework="pt", device="cpu")
                     t = f.get_tensor(name)
-                tensor_count += 1
-                if t.is_floating_point():
-                    result = t.to(dtype=target_dtype)
-                    converted += 1
-                else:
-                    result = t
-                w.write_tensor(name, _tensor_to_bytes(result))
-                del t, result
+                    tensor_count += 1
+                    result = transform(name, t, out_dtype)
+                    if result is not t:
+                        converted += 1
+                    if torch_dtype_to_st(result.dtype) != out_dtype:
+                        raise ConversionImplementationError(
+                            f"transform produced {result.dtype} for {name!r}; "
+                            f"planned {out_dtype}")
+                    w.write_tensor(name, _tensor_to_bytes(result))
+                    del t, result
+    finally:
+        for f in handles.values():
+            try:
+                f.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
 
     index_path: Optional[Path] = None
     if len(plan.shard_names) > 1:
@@ -433,7 +469,265 @@ def streaming_dtype_cast(
         "output_paths": [out_dir / n for n in plan.shard_names],
         "index_path": index_path,
         "shard_sizes": dict(plan.shard_sizes),
+        "metadata": dict(source_metadata),
     }
+
+
+def streaming_dtype_cast(
+    input_path: Path,
+    out_dir: Path,
+    *,
+    target_dtype: "torch.dtype",
+    shard_prefix: str = "model",
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> dict[str, Any]:
+    """Cast float tensors to ``target_dtype``, streaming directly into N shards.
+
+    Non-float tensors keep their source dtype. Returns ``output_paths``
+    (list of shard files), ``index_path`` (None for a single shard),
+    ``tensor_count`` / ``converted_count`` / ``shard_sizes`` / ``metadata``.
+    """
+    target_st = torch_dtype_to_st(target_dtype)
+
+    def out_st_dtype_for(_name: str, src_st: str, _shape: list[int]) -> str:
+        return target_st if src_st in _ST_FLOAT_DTYPES else src_st
+
+    def transform(_name: str, t: "torch.Tensor", _out_st: str) -> "torch.Tensor":
+        if t.is_floating_point() and t.dtype != target_dtype:
+            return t.to(dtype=target_dtype)
+        return t
+
+    return _stream_reencode(
+        Path(input_path), Path(out_dir),
+        out_st_dtype_for=out_st_dtype_for, transform=transform,
+        shard_prefix=shard_prefix, shard_threshold=shard_threshold,
+    )
+
+
+# fp8-E4M3 storage cast (the `#fp8` flavor): matches the consumption side —
+# diffusers layerwise casting (gen_worker.models.loading.apply_fp8_storage)
+# casts only Linear/Conv modules whose qualified name misses the skip
+# patterns, and upcasts them per-layer at compute time. The producer casts
+# strictly LESS than any consumer would: only >=2-D `.weight` tensors whose
+# module path misses the union of diffusers' skip patterns (defaults + every
+# per-class `_skip_layerwise_casting_patterns`). Anything skipped here that a
+# consumer does cast merely stores bigger — never a baked-in quality loss.
+FP8_SKIP_TENSOR_PATTERNS: tuple[str, ...] = (
+    "embed",            # pos_embed / patch_embed(ding|der) / *_embedder / embed_tokens / time_embedding
+    "norm",
+    "pooler",
+    "adaln_single",
+    "final_layer",
+    "quantize",
+    "decoder",
+    "preprocess_conv", "postprocess_conv",
+    r"^proj_in$", r"^proj_out$", r"^proj$",
+)
+
+_FP8_E4M3_MAX = 448.0  # torch float8_e4m3fn cast does NOT saturate; clamp first
+
+
+def fp8_cast_eligible(
+    name: str, src_st_dtype: str, shape: list[int],
+    *, skip_patterns: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS,
+) -> bool:
+    """True when a tensor is safe to store as fp8-E4M3 for the ``#fp8`` flavor."""
+    import re
+
+    if src_st_dtype not in {"F64", "F32", "F16", "BF16"}:
+        return False
+    if len(shape) < 2 or not name.endswith(".weight"):
+        return False
+    module_path = name[: -len(".weight")]
+    return not any(re.search(p, module_path) for p in skip_patterns)
+
+
+def streaming_fp8_storage_cast(
+    input_path: Path,
+    out_dir: Path,
+    *,
+    shard_prefix: str = "model",
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+    skip_patterns: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS,
+) -> dict[str, Any]:
+    """Produce the fp8-E4M3 storage flavor of one weight set, streaming.
+
+    Eligible weights are clamped to ±448 and stored as F8_E4M3; everything
+    else keeps its source dtype. Scale-free by design: consumption is
+    diffusers layerwise casting (fp8 bytes resident, bf16/fp16 compute).
+    """
+    import torch
+
+    def out_st_dtype_for(name: str, src_st: str, shape: list[int]) -> str:
+        if fp8_cast_eligible(name, src_st, shape, skip_patterns=skip_patterns):
+            return "F8_E4M3"
+        return src_st
+
+    def transform(_name: str, t: "torch.Tensor", out_st: str) -> "torch.Tensor":
+        if out_st == "F8_E4M3" and t.dtype != torch.float8_e4m3fn:
+            return t.clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+        return t
+
+    return _stream_reencode(
+        Path(input_path), Path(out_dir),
+        out_st_dtype_for=out_st_dtype_for, transform=transform,
+        shard_prefix=shard_prefix, shard_threshold=shard_threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-level streaming conversion (whole source tree, per weight group)
+# ---------------------------------------------------------------------------
+
+# Components fp8 storage targets by default: the denoiser dominates VRAM and
+# is what apply_fp8_storage consumes (QUANTIZATION-POLICY.md order of
+# sacrifice; TEs join via gw#392's component-wise ladder, explicitly).
+FP8_DEFAULT_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+
+
+def snapshot_weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Path]]:
+    """(component, entry_path) per weight set. entry is the index.json for
+    sharded sets, else the safetensors file. A singlefile-layout source can
+    still carry several root weight files (civitai bundles ship the
+    diffusion model + text encoder + VAE side by side) — every one is its
+    own group, or a dtype pass would convert only the first and the tree
+    copy would silently drop the rest."""
+    groups: list[tuple[str, Path]] = []
+
+    def _entries_for(d: Path) -> list[Path]:
+        idx = sorted(d.glob("*.safetensors.index.json"))
+        sharded_members: set[str] = set()
+        for i in idx:
+            try:
+                weight_map = json.loads(i.read_text("utf-8")).get("weight_map") or {}
+                sharded_members.update(str(v) for v in weight_map.values())
+            except Exception:
+                pass
+        loose = [p for p in sorted(d.glob("*.safetensors"))
+                 if p.is_file() and p.name not in sharded_members]
+        return idx + loose
+
+    if layout == "diffusers":
+        for entry in sorted(source_dir.iterdir()):
+            if entry.is_dir():
+                found = _entries_for(entry)
+                if found:
+                    groups.append((entry.name, found[0]))
+    else:
+        for found in _entries_for(source_dir):
+            groups.append(("", found))
+    return groups
+
+
+def _link_or_copy(src: Path, dst: Path) -> None:
+    import os
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        return
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def copy_non_weight_files(source_dir: Path, out_dir: Path, *, skip_components: set[str]) -> None:
+    """Hardlink every non-weight file into the output tree; weight files and
+    their sharded indexes for converted components are skipped."""
+    for f in sorted(source_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        rel = f.relative_to(source_dir)
+        if rel.parts[:2] == (".cache", "huggingface"):
+            continue  # hf local-dir download metadata, not repo content
+        comp = rel.parts[0] if len(rel.parts) > 1 else ""
+        name = f.name
+        is_weightish = f.suffix == ".safetensors" or name.endswith(".safetensors.index.json")
+        if is_weightish and (comp in skip_components or ("" in skip_components and comp == "")):
+            continue
+        if name == ".civitai.json":
+            continue
+        _link_or_copy(f, out_dir / rel)
+
+
+def _group_shard_prefix(entry: Path) -> str:
+    stem = entry.name
+    for suffix in (".safetensors.index.json", ".safetensors"):
+        if stem.endswith(suffix):
+            return stem[: -len(suffix)] or "model"
+    return stem or "model"
+
+
+def streaming_cast_snapshot(
+    source_dir: Path,
+    out_dir: Path,
+    *,
+    file_layout: str,
+    target_dtype: "torch.dtype",
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> dict[str, Any]:
+    """Streaming dtype cast of a whole snapshot: every weight group is cast
+    per-tensor (peak anon RAM ≈ largest tensor); configs/tokenizers hardlink
+    through. Output is a complete loadable tree."""
+    source_dir, out_dir = Path(source_dir), Path(out_dir)
+    groups = snapshot_weight_groups(source_dir, file_layout)
+    if not groups:
+        raise ConversionImplementationError("no safetensors weights found to cast")
+    tensor_count = converted = 0
+    done: set[str] = set()
+    for comp, entry in groups:
+        result = streaming_dtype_cast(
+            entry, (out_dir / comp) if comp else out_dir,
+            target_dtype=target_dtype,
+            shard_prefix=_group_shard_prefix(entry),
+            shard_threshold=shard_threshold,
+        )
+        tensor_count += int(result["tensor_count"])
+        converted += int(result["converted_count"])
+        done.add(comp)
+    copy_non_weight_files(source_dir, out_dir, skip_components=done)
+    return {"tensor_count": tensor_count, "converted_count": converted,
+            "components": sorted(done), "output_dir": out_dir}
+
+
+def streaming_fp8_snapshot(
+    source_dir: Path,
+    out_dir: Path,
+    *,
+    file_layout: str,
+    components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> dict[str, Any]:
+    """Produce the ``#fp8`` flavor of a diffusers snapshot, streaming.
+
+    Only ``components`` (default: the denoiser) are fp8-cast; every other
+    component passes through untouched. Refuses singlefile layouts — fp8
+    storage is component-scoped and single-file keyspaces don't name
+    components reliably."""
+    if file_layout != "diffusers":
+        raise ConversionImplementationError(
+            "fp8 storage flavors are produced from diffusers layouts only "
+            "(component-scoped); repackage singlefile sources first")
+    source_dir, out_dir = Path(source_dir), Path(out_dir)
+    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
+              if c in set(components)]
+    if not groups:
+        raise ConversionImplementationError(
+            f"no fp8-castable components found (looked for {sorted(components)})")
+    tensor_count = converted = 0
+    done: set[str] = set()
+    for comp, entry in groups:
+        result = streaming_fp8_storage_cast(
+            entry, out_dir / comp,
+            shard_prefix=_group_shard_prefix(entry),
+            shard_threshold=shard_threshold,
+        )
+        tensor_count += int(result["tensor_count"])
+        converted += int(result["converted_count"])
+        done.add(comp)
+    copy_non_weight_files(source_dir, out_dir, skip_components=done)
+    return {"tensor_count": tensor_count, "converted_count": converted,
+            "components": sorted(done), "output_dir": out_dir}
 
 
 # ---------------------------------------------------------------------------
@@ -695,6 +989,14 @@ __all__ = [
     "iter_component_tensors",
     "iter_source_tensors",
     "streaming_dtype_cast",
+    "streaming_fp8_storage_cast",
+    "streaming_cast_snapshot",
+    "streaming_fp8_snapshot",
+    "snapshot_weight_groups",
+    "copy_non_weight_files",
+    "fp8_cast_eligible",
+    "FP8_SKIP_TENSOR_PATTERNS",
+    "FP8_DEFAULT_COMPONENTS",
     "shard_safetensors_by_offset",
     "StreamingWriter",
 ]

--- a/packages/cozy_convert/tests/test_integration.py
+++ b/packages/cozy_convert/tests/test_integration.py
@@ -144,8 +144,8 @@ def test_calibrated_dtype_refused(tiny_llama, tmp_path: Path) -> None:
     with pytest.raises(InlineConversionNotPossible) as exc:
         run_inline_conversion(
             source_path=tiny_llama.dir / "model.safetensors",
-            out_dir=tmp_path / "awq",
-            target_dtype="int4:awq",
+            out_dir=tmp_path / "nvfp4",
+            target_dtype="nvfp4",
             source_repo_dir=tiny_llama.dir,
         )
     assert exc.value.deferred_requirement is not None

--- a/packages/cozy_convert/tests/test_repackage_families.py
+++ b/packages/cozy_convert/tests/test_repackage_families.py
@@ -128,7 +128,7 @@ def test_weight_groups_singlefile_multi_entry(tmp_path: Path) -> None:
     """Civitai bundles ship several root weight files (DiT + text encoder +
     VAE); every one must be its own group or a dtype pass drops all but the
     first (latent data loss, found preparing e2e #112)."""
-    from cozy_convert.clone import _weight_groups
+    from cozy_convert.writer import snapshot_weight_groups as _weight_groups
 
     _write_safetensors(tmp_path / "dit.safetensors", "F8_E4M3")
     _write_safetensors(tmp_path / "txt.safetensors", "BF16")
@@ -140,7 +140,7 @@ def test_weight_groups_singlefile_multi_entry(tmp_path: Path) -> None:
 
 
 def test_weight_groups_singlefile_sharded_index_wins(tmp_path: Path) -> None:
-    from cozy_convert.clone import _weight_groups
+    from cozy_convert.writer import snapshot_weight_groups as _weight_groups
 
     _write_safetensors(tmp_path / "model-00001-of-00002.safetensors", "BF16")
     _write_safetensors(tmp_path / "model-00002-of-00002.safetensors", "BF16")

--- a/packages/cozy_convert/tests/test_streaming_convert.py
+++ b/packages/cozy_convert/tests/test_streaming_convert.py
@@ -1,0 +1,389 @@
+"""gw#395/#396 — per-tensor streaming dtype cast + fp8-E4M3 storage flavor.
+
+Covers: shard layout + index + __metadata__ preservation, determinism and
+semantic equality vs an in-memory reference, fp8 eligibility/clamping, the
+snapshot-level helpers, and the peak anonymous-RSS bound (< 2x the largest
+tensor — the property that lets a 100 GB model cast on a 32 GB pod).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from cozy_convert.writer import (
+    fp8_cast_eligible,
+    plan_shards,
+    streaming_cast_snapshot,
+    streaming_dtype_cast,
+    streaming_fp8_snapshot,
+    streaming_fp8_storage_cast,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _write_sharded_fixture(root: Path, *, seed: int = 7) -> Path:
+    """3-shard fp32 fixture with an index, mixed float/int tensors and
+    __metadata__ on every shard. Returns the index path."""
+    g = torch.Generator().manual_seed(seed)
+    shards = {
+        "model-00001-of-00003.safetensors": {
+            "blocks.0.attn.to_q.weight": torch.randn(64, 64, generator=g),
+            "blocks.0.attn.to_q.bias": torch.randn(64, generator=g),
+            "blocks.0.norm1.weight": torch.randn(64, generator=g),
+        },
+        "model-00002-of-00003.safetensors": {
+            "blocks.1.ff.net.0.proj.weight": torch.randn(128, 64, generator=g),
+            "blocks.1.step_counter": torch.arange(10, dtype=torch.int64),
+        },
+        "model-00003-of-00003.safetensors": {
+            "pos_embed.proj.weight": torch.randn(32, 32, generator=g),
+            "blocks.2.attn.to_v.weight": torch.randn(64, 64, generator=g),
+        },
+    }
+    root.mkdir(parents=True, exist_ok=True)
+    weight_map: dict[str, str] = {}
+    total = 0
+    for shard_name, tensors in shards.items():
+        save_file(tensors, str(root / shard_name), metadata={"format": "pt", "origin": "fixture"})
+        for name, t in tensors.items():
+            weight_map[name] = shard_name
+            total += t.numel() * t.element_size()
+    index = root / "model.safetensors.index.json"
+    index.write_text(json.dumps(
+        {"metadata": {"total_size": total}, "weight_map": weight_map}))
+    return index
+
+
+def _all_tensors(entry: Path) -> dict[str, torch.Tensor]:
+    out: dict[str, torch.Tensor] = {}
+    if entry.name.endswith(".index.json"):
+        weight_map = json.loads(entry.read_text())["weight_map"]
+        shard_files = sorted(set(weight_map.values()))
+    else:
+        shard_files = [entry.name]
+    for shard in shard_files:
+        with safe_open(str(entry.parent / shard), framework="pt") as f:
+            for k in f.keys():
+                out[k] = f.get_tensor(k)
+    return out
+
+
+def _tree_digest(paths: list[Path]) -> str:
+    h = hashlib.sha256()
+    for p in sorted(paths):
+        h.update(p.name.encode())
+        h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Streaming cast — correctness
+# ---------------------------------------------------------------------------
+
+def test_cast_semantic_equality_vs_in_memory_reference(tmp_path: Path) -> None:
+    """Streaming output == the straightforward load-everything reference,
+    tensor for tensor, plus dtype rules (floats cast, ints untouched)."""
+    index = _write_sharded_fixture(tmp_path / "src")
+    result = streaming_dtype_cast(index, tmp_path / "out", target_dtype=torch.bfloat16)
+
+    src = _all_tensors(index)
+    reference = {k: (v.to(torch.bfloat16) if v.is_floating_point() else v)
+                 for k, v in src.items()}
+    got = _all_tensors(result["index_path"] or result["output_paths"][0])
+
+    assert set(got) == set(reference)
+    for k in reference:
+        assert got[k].dtype == reference[k].dtype, k
+        assert torch.equal(got[k], reference[k]), k
+    assert got["blocks.1.step_counter"].dtype == torch.int64
+    assert result["tensor_count"] == len(src)
+
+
+def test_cast_is_byte_deterministic_across_runs(tmp_path: Path) -> None:
+    index = _write_sharded_fixture(tmp_path / "src")
+    r1 = streaming_dtype_cast(index, tmp_path / "out1", target_dtype=torch.float16)
+    r2 = streaming_dtype_cast(index, tmp_path / "out2", target_dtype=torch.float16)
+    files1 = list(r1["output_paths"]) + ([r1["index_path"]] if r1["index_path"] else [])
+    files2 = list(r2["output_paths"]) + ([r2["index_path"]] if r2["index_path"] else [])
+    assert [p.name for p in files1] == [p.name for p in files2]
+    assert _tree_digest(files1) == _tree_digest(files2)
+
+
+def test_cast_preserves_source_metadata(tmp_path: Path) -> None:
+    index = _write_sharded_fixture(tmp_path / "src")
+    result = streaming_dtype_cast(index, tmp_path / "out", target_dtype=torch.bfloat16)
+    assert result["metadata"].get("origin") == "fixture"
+    for shard in result["output_paths"]:
+        with safe_open(str(shard), framework="pt") as f:
+            md = f.metadata()
+            assert md and md.get("format") == "pt" and md.get("origin") == "fixture"
+
+
+def test_cast_sharded_output_layout_and_index(tmp_path: Path) -> None:
+    """A small shard threshold forces a multi-shard output whose index the
+    stock loaders (and plan_shards) agree on."""
+    index = _write_sharded_fixture(tmp_path / "src")
+    result = streaming_dtype_cast(
+        index, tmp_path / "out", target_dtype=torch.float32, shard_threshold=36_000)
+    assert result["index_path"] is not None
+    payload = json.loads(result["index_path"].read_text())
+    sizes = {k: t.numel() * 4 if t.is_floating_point() else t.numel() * t.element_size()
+             for k, t in _all_tensors(index).items()}
+    expected_plan = plan_shards(sizes, max_shard_bytes=36_000, shard_prefix="model")
+    assert payload["weight_map"] == expected_plan.weight_map
+    assert payload["metadata"]["total_size"] == expected_plan.total_size
+    got = _all_tensors(result["index_path"])
+    assert set(got) == set(sizes)
+
+
+def test_cast_single_file_input(tmp_path: Path) -> None:
+    src = tmp_path / "one.safetensors"
+    save_file({"w": torch.randn(8, 8)}, str(src), metadata={"k": "v"})
+    result = streaming_dtype_cast(src, tmp_path / "out", target_dtype=torch.float16)
+    assert result["index_path"] is None
+    got = _all_tensors(result["output_paths"][0])
+    assert got["w"].dtype == torch.float16
+
+
+# ---------------------------------------------------------------------------
+# fp8-E4M3 storage cast
+# ---------------------------------------------------------------------------
+
+def test_fp8_eligibility_rules() -> None:
+    assert fp8_cast_eligible("blocks.0.attn.to_q.weight", "F32", [64, 64])
+    assert fp8_cast_eligible("down_blocks.0.resnets.0.conv1.weight", "F16", [4, 4, 3, 3])
+    # skip patterns
+    assert not fp8_cast_eligible("blocks.0.norm1.weight", "F32", [64, 64])
+    assert not fp8_cast_eligible("pos_embed.proj.weight", "F32", [32, 32])
+    assert not fp8_cast_eligible("time_embedding.linear_1.weight", "F32", [64, 64])
+    assert not fp8_cast_eligible("proj_out.weight", "F32", [64, 64])
+    # 1-D / biases / non-weight / non-float stay
+    assert not fp8_cast_eligible("blocks.0.attn.to_q.bias", "F32", [64])
+    assert not fp8_cast_eligible("blocks.0.attn.to_q.weight", "I64", [64, 64])
+    assert not fp8_cast_eligible("blocks.1.step_counter", "I64", [10])
+    # already-fp8 input is never re-quantized
+    assert not fp8_cast_eligible("blocks.0.attn.to_q.weight", "F8_E4M3", [64, 64])
+
+
+def test_fp8_cast_values_clamp_and_selectivity(tmp_path: Path) -> None:
+    index = _write_sharded_fixture(tmp_path / "src")
+    # Inject an out-of-range weight to prove clamping (fp8-e4m3 has no inf;
+    # an unclamped 1000.0 becomes NaN).
+    hot = torch.full((16, 16), 1000.0)
+    save_file(
+        {"blocks.3.attn.to_k.weight": hot},
+        str(tmp_path / "src" / "model-00004-of-00004.safetensors"),
+        metadata={"format": "pt"},
+    )
+    payload = json.loads((tmp_path / "src" / "model.safetensors.index.json").read_text())
+    payload["weight_map"]["blocks.3.attn.to_k.weight"] = "model-00004-of-00004.safetensors"
+    (tmp_path / "src" / "model.safetensors.index.json").write_text(json.dumps(payload))
+
+    index = tmp_path / "src" / "model.safetensors.index.json"
+    result = streaming_fp8_storage_cast(index, tmp_path / "out")
+    got = _all_tensors(result["index_path"] or result["output_paths"][0])
+
+    assert got["blocks.0.attn.to_q.weight"].dtype == torch.float8_e4m3fn
+    assert got["blocks.1.ff.net.0.proj.weight"].dtype == torch.float8_e4m3fn
+    # skip patterns / 1-D / int keep source dtype
+    assert got["blocks.0.norm1.weight"].dtype == torch.float32
+    assert got["pos_embed.proj.weight"].dtype == torch.float32
+    assert got["blocks.0.attn.to_q.bias"].dtype == torch.float32
+    assert got["blocks.1.step_counter"].dtype == torch.int64
+    # clamped, not NaN
+    hot_out = got["blocks.3.attn.to_k.weight"].to(torch.float32)
+    assert not torch.isnan(hot_out).any()
+    assert hot_out.max().item() == pytest.approx(448.0)
+    # values within fp8 range round-trip through the same rounding the
+    # runtime storage lane applies
+    src = _all_tensors(index)
+    expected = src["blocks.0.attn.to_q.weight"].clamp(-448, 448).to(torch.float8_e4m3fn)
+    assert torch.equal(
+        got["blocks.0.attn.to_q.weight"].view(torch.uint8),
+        expected.view(torch.uint8))
+
+
+def test_fp8_majority_dtype_detectable(tmp_path: Path) -> None:
+    """The serve-side sniffer keys on majority F8_E4M3 headers; a denoiser
+    where big weights dominate must sniff as fp8."""
+    src = tmp_path / "d.safetensors"
+    save_file({
+        f"blocks.{i}.attn.to_q.weight": torch.randn(64, 64) for i in range(4)
+    } | {"blocks.0.norm1.weight": torch.randn(64)}, str(src))
+    result = streaming_fp8_storage_cast(src, tmp_path / "out")
+    counts: dict[str, int] = {}
+    with safe_open(str(result["output_paths"][0]), framework="pt") as f:
+        for k in f.keys():
+            d = str(f.get_slice(k).get_dtype())
+            counts[d] = counts.get(d, 0) + 1
+    assert max(counts, key=counts.get) == "F8_E4M3"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-level helpers (diffusers tree)
+# ---------------------------------------------------------------------------
+
+def _write_diffusers_tree(root: Path) -> Path:
+    root.mkdir(parents=True)
+    (root / "model_index.json").write_text('{"_class_name": "FakePipeline"}')
+    (root / "unet").mkdir()
+    save_file(
+        {"down.0.attn.to_q.weight": torch.randn(64, 64),
+         "down.0.norm.weight": torch.randn(64)},
+        str(root / "unet" / "diffusion_pytorch_model.safetensors"))
+    (root / "unet" / "config.json").write_text("{}")
+    (root / "vae").mkdir()
+    save_file({"encoder.conv_in.weight": torch.randn(4, 4, 3, 3)},
+              str(root / "vae" / "diffusion_pytorch_model.safetensors"))
+    (root / "vae" / "config.json").write_text("{}")
+    (root / "scheduler").mkdir()
+    (root / "scheduler" / "scheduler_config.json").write_text("{}")
+    return root
+
+
+def test_streaming_cast_snapshot_full_tree(tmp_path: Path) -> None:
+    src = _write_diffusers_tree(tmp_path / "src")
+    out = tmp_path / "out"
+    result = streaming_cast_snapshot(
+        src, out, file_layout="diffusers", target_dtype=torch.float16)
+    assert sorted(result["components"]) == ["unet", "vae"]
+    assert (out / "model_index.json").is_file()
+    assert (out / "scheduler" / "scheduler_config.json").is_file()
+    assert (out / "unet" / "config.json").is_file()
+    unet = _all_tensors(out / "unet" / "diffusion_pytorch_model.safetensors")
+    vae = _all_tensors(out / "vae" / "diffusion_pytorch_model.safetensors")
+    assert all(t.dtype == torch.float16 for t in unet.values())
+    assert all(t.dtype == torch.float16 for t in vae.values())
+
+
+def test_streaming_fp8_snapshot_denoiser_only(tmp_path: Path) -> None:
+    src = _write_diffusers_tree(tmp_path / "src")
+    out = tmp_path / "out"
+    streaming_fp8_snapshot(src, out, file_layout="diffusers")
+    unet = _all_tensors(out / "unet" / "diffusion_pytorch_model.safetensors")
+    assert unet["down.0.attn.to_q.weight"].dtype == torch.float8_e4m3fn
+    assert unet["down.0.norm.weight"].dtype == torch.float32
+    # vae passes through byte-identical
+    src_vae = (src / "vae" / "diffusion_pytorch_model.safetensors").read_bytes()
+    out_vae = (out / "vae" / "diffusion_pytorch_model.safetensors").read_bytes()
+    assert src_vae == out_vae
+    assert (out / "model_index.json").is_file()
+
+
+def test_streaming_fp8_snapshot_refuses_singlefile(tmp_path: Path) -> None:
+    from cozy_convert.writer import ConversionImplementationError
+
+    (tmp_path / "src").mkdir()
+    save_file({"w": torch.randn(4, 4)}, str(tmp_path / "src" / "model.safetensors"))
+    with pytest.raises(ConversionImplementationError):
+        streaming_fp8_snapshot(tmp_path / "src", tmp_path / "out", file_layout="singlefile")
+
+
+def test_clone_normalizes_fp8_spellings() -> None:
+    from cozy_convert.clone import normalize_outputs
+
+    specs = normalize_outputs([
+        {"dtype": "fp8:e4m3"}, {"dtype": "fp8-e4m3"}, {"dtype": "fp8"},
+    ])
+    assert [s.dtype for s in specs] == ["fp8"]  # all collapse + dedupe
+
+
+def test_inline_conversion_fp8_route(tmp_path: Path) -> None:
+    from cozy_convert.convert import run_inline_conversion
+
+    src = tmp_path / "model.safetensors"
+    save_file({"blocks.0.attn.to_q.weight": torch.randn(64, 64)}, str(src))
+    result = run_inline_conversion(
+        source_path=src, out_dir=tmp_path / "out", target_dtype="fp8")
+    assert result.target_dtype == "fp8"
+    assert result.attributes["conversion_strategy"] == "inline_fp8_storage_cast"
+    got = _all_tensors(result.output_paths[0])
+    assert got["blocks.0.attn.to_q.weight"].dtype == torch.float8_e4m3fn
+
+
+# ---------------------------------------------------------------------------
+# Peak anonymous-RSS bound — the property gw#395/#396 exist for
+# ---------------------------------------------------------------------------
+
+def _rss_anon_kb() -> int:
+    for line in open("/proc/self/status"):
+        if line.startswith("RssAnon"):
+            return int(line.split()[1])
+    return 0
+
+
+class _AnonPeakSampler:
+    """Samples RssAnon on a thread; mmap'd file pages (RssFile) are
+    deliberately excluded — they are reclaimable and the kernel evicts them
+    under a memory cap, so anonymous memory is what OOMs a pod."""
+
+    def __init__(self) -> None:
+        self.peak = 0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self.peak = max(self.peak, _rss_anon_kb())
+            time.sleep(0.002)
+
+    def __enter__(self) -> "_AnonPeakSampler":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        self._stop.set()
+        self._thread.join()
+
+
+def _write_big_fixture(root: Path, *, n_shards: int = 3, tensors_per_shard: int = 3,
+                       largest_elems: int = 12_000_000) -> tuple[Path, int]:
+    """3 shards x 3 fp32 tensors; largest tensor 48 MB. Total ~410 MB."""
+    root.mkdir(parents=True, exist_ok=True)
+    weight_map: dict[str, str] = {}
+    total = 0
+    largest_bytes = 0
+    for s in range(n_shards):
+        shard = f"model-{s + 1:05d}-of-{n_shards:05d}.safetensors"
+        tensors = {}
+        for i in range(tensors_per_shard):
+            elems = largest_elems if i == 0 else largest_elems // 2
+            name = f"blocks.{s * tensors_per_shard + i}.attn.to_q.weight"
+            tensors[name] = torch.rand(elems // 1000, 1000)
+            weight_map[name] = shard
+            nbytes = tensors[name].numel() * 4
+            total += nbytes
+            largest_bytes = max(largest_bytes, nbytes)
+        save_file(tensors, str(root / shard), metadata={"format": "pt"})
+    index = root / "model.safetensors.index.json"
+    index.write_text(json.dumps(
+        {"metadata": {"total_size": total}, "weight_map": weight_map}))
+    return index, largest_bytes
+
+
+@pytest.mark.parametrize("op", ["cast_bf16", "fp8"])
+def test_peak_anon_rss_below_2x_largest_tensor(tmp_path: Path, op: str) -> None:
+    index, largest = _write_big_fixture(tmp_path / "src")
+    baseline = _rss_anon_kb()
+    with _AnonPeakSampler() as sampler:
+        if op == "cast_bf16":
+            streaming_dtype_cast(index, tmp_path / "out", target_dtype=torch.bfloat16)
+        else:
+            streaming_fp8_storage_cast(index, tmp_path / "out")
+    delta_kb = sampler.peak - baseline
+    limit_kb = (2 * largest) // 1024
+    assert delta_kb < limit_kb, (
+        f"{op}: peak anon RSS delta {delta_kb} KB >= 2x largest tensor "
+        f"({limit_kb} KB) — streaming bound broken")

--- a/src/gen_worker/trt_engine.py
+++ b/src/gen_worker/trt_engine.py
@@ -37,11 +37,10 @@ import hashlib
 import io
 import json
 import logging
-import os
 import tarfile
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from .compile_cache import AdoptError, _clean_tarinfo, family_from_ref, sku_slug
 


### PR DESCRIPTION
Closes gw#395 (streaming dtype cast) and the weight-only half of gw#396 (low-memory quantization). Also executes the off-policy quant-surface prune (two-format ruling).

## gw#395 — per-TENSOR streaming cast
- `_stream_reencode` engine in `cozy_convert.writer`: pass 1 walks shard headers only (`get_slice` — no tensor data), plans output shards; pass 2 streams one tensor at a time into `IncrementalSafetensorsWriter`. Peak anonymous RAM ≈ largest single tensor, independent of model size.
- Preserves shard layout, `index.json`, and `__metadata__` (keys sorted — `safe_open().metadata()` iterates in randomized Rust-HashMap order, which broke byte-determinism).
- Snapshot-level `streaming_cast_snapshot` / `streaming_fp8_snapshot` (weight-group walk + non-weight hardlink passthrough, shared with clone).
- Single-file merge/repackage paths keep their documented full-model RAM floor (README memory-floor table).

## gw#396 — fp8-E4M3 storage flavor via the same stream
- `streaming_fp8_storage_cast`: clamp ±448 (torch's fp8 cast does NOT saturate — 500→NaN) + F8_E4M3 storage for ≥2-D `.weight` tensors whose module path misses the union of diffusers' layerwise-casting skip patterns. Scale-free by design: consumption is `apply_fp8_storage` (layerwise upcast), so stored values reproduce the measured runtime fp8-storage lane; anything skipped that a consumer casts anyway merely stores bigger — never a baked-in quality loss.
- Clone `dtype=fp8` routes here, denoiser components only by default; refused for singlefile layouts (component scoping is unreliable there).
- **Weight-only nvfp4 deliberately NOT shipped**: te#44's live quality verdict (sd15, real forward passes through a genuine prompt pool ≈ better than weight-only) was a hard FAIL. nvfp4 stays calibration-required (modelopt).

## Prune (two-format ruling, QUANTIZATION-POLICY.md)
torchao inline paths, awq/gptq deferred rows, `fp8:e5m2`/`int8` dtypes, LoadedComponent torchao unwrap — removed. Re-add from history if ever needed. bnb nf4/fp4 inline kept (emergency-rung producer).

## Evidence
- 22 GiB fp32 fixture under `systemd-run -p MemoryMax=4G -p MemorySwapMax=0`:
  - cast→bf16: **peak RssAnon delta 513 MiB**, 22 s, 11 GiB out
  - fp8: **peak RssAnon delta 1281 MiB**, 49 s, 5.5 GiB out
  (1 GiB largest tensor; both < 2× largest tensor — a 100 GB model casts on the 32 GB pod class)
- Peak-RSS asserts in `test_streaming_convert.py` (anon-RSS sampler, < 2× largest tensor for cast and fp8), byte-determinism, in-memory-reference equality, `__metadata__`/index preservation, fp8 eligibility + clamp + majority-dtype sniffability.
- `uv run --extra dev pytest -q -m "not integration"`: **384 passed, 2 skipped**. ruff clean.