### PR TITLE
feat(cozy_convert): CommitResult.checkpoint_id from finalize response

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/hub.py
+++ b/packages/cozy_convert/src/cozy_convert/hub.py
@@ -176,6 +176,10 @@ class CommitResult:
     uploaded: int
     deduped: int
     total_bytes: int
+    # Content-addressed checkpoint id minted at finalize (tensorhub derives it
+    # from the snapshot manifest); THE id for tree/lineage queries. The
+    # revision_id above is the upload-session id, not queryable post-finalize.
+    checkpoint_id: str = ""
     response: dict[str, Any] = field(default_factory=dict)
 
 
@@ -455,6 +459,7 @@ class HubClient:
             uploaded=uploaded,
             deduped=deduped,
             total_bytes=sum(f.size_bytes for f in resolved),
+            checkpoint_id=str(final.get("checkpoint_id") or "").strip(),
             response=final,
         )
 

--- a/packages/cozy_convert/tests/test_hub.py
+++ b/packages/cozy_convert/tests/test_hub.py
@@ -37,6 +37,8 @@ def test_commit_uploads_completes_and_finalizes(fake_hub, tmp_path: Path, monkey
         auto_create_external_parent=True,
     )
     assert result.revision_id == "rev-1"
+    # THE queryable id: minted at finalize from the snapshot manifest.
+    assert result.checkpoint_id == "blake3:abc"
     assert result.uploaded == 2 and result.deduped == 0
 
     st = _FakeHub.state


### PR DESCRIPTION
tensorhub finalize now mints a content-addressed checkpoint_id (computeCheckpointID over the snapshot manifest) — the upload-session revision_id is no longer queryable (tree?checkpoint_id= 404s; found live, te#44 J9 run11: nvfp4 job OK but the evidence tree assert 404'd on the session id). CommitResult now carries checkpoint_id from the finalize response so producers can report the real id. Tests: 110 passed.