### PR TITLE
th#597 flavor-collapse: ref-grammar conformance (C5) + producer publish mode=replace (C2)

### DIFF
--- a/examples/marco-polo/uv.lock
+++ b/examples/marco-polo/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "blake3" },

--- a/packages/cozy_convert/src/cozy_convert/hub.py
+++ b/packages/cozy_convert/src/cozy_convert/hub.py
@@ -410,7 +410,7 @@ class HubClient:
             body["lineage"] = list(lineage)
             body["auto_create_external_parent"] = bool(auto_create_external_parent)
         for key in ("kind", "library_name", "model_family", "class_name",
-                    "adapter_for_checkpoint_group", "adapter_for_family"):
+                    "adapter_for_family"):
             val = str((repo_spec or {}).get(key) or "").strip()
             if val:
                 body[key] = val

--- a/packages/cozy_convert/src/cozy_convert/publish.py
+++ b/packages/cozy_convert/src/cozy_convert/publish.py
@@ -37,11 +37,17 @@ def publish_flavors(
     *,
     destination_repo: str = "",
     tags: Iterable[str] | None = None,
-    mode: str = "merge",
+    mode: str = "replace",
     metadata: Mapping[str, Any] | None = None,
 ) -> list[CommitResult]:
     """Publish each ProducedFlavor as one commit. ``destination_repo`` falls
-    back to the reserved-name ``ctx.destination`` payload field."""
+    back to the reserved-name ``ctx.destination`` payload field.
+
+    ``mode`` defaults to ``"replace"`` (th#597 C2): a producer's flavor
+    export is a complete tree by definition — merging with the repo's prior
+    :latest is how te#44 shipped an #fp8 checkpoint carrying 5.2GB of fp16
+    base weights. Pass ``mode="merge"`` explicitly only for deliberate
+    overlay publishes (e.g. a vae swap on top of an existing tree)."""
     dest = str(destination_repo or "").strip()
     if not dest:
         info = getattr(ctx, "destination", None) or {}

--- a/packages/cozy_convert/tests/test_publish.py
+++ b/packages/cozy_convert/tests/test_publish.py
@@ -53,6 +53,27 @@ def test_publish_flavors_file_and_dir(fake_hub, tmp_path: Path) -> None:
     assert [op["path"] for op in reqs[1]["operations"]] == ["config.json"]
 
 
+def test_publish_flavors_defaults_to_replace(fake_hub, tmp_path: Path) -> None:
+    """th#597 C2 regression (te#44): a producer's flavor export is a complete
+    replacement tree — publish_flavors must default to mode=replace so an
+    #fp8 export can never merge with (and silently carry) the repo's prior
+    fp16 base tree. mode=merge remains available only as an explicit opt-in
+    for deliberate overlay publishes."""
+    _FakeHub.state["finalize_calls"] = 1
+    f = tmp_path / "weights.safetensors"
+    f.write_bytes(b"\x02" * 16)
+    publish_flavors(_Ctx(fake_hub), [ProducedFlavor(path=f, flavor="fp8")], destination_repo="acme/dest")
+    assert _FakeHub.state["commit_requests"][-1]["mode"] == "replace"
+
+    publish_flavors(
+        _Ctx(fake_hub),
+        [ProducedFlavor(path=f, flavor="vae-fix")],
+        destination_repo="acme/dest",
+        mode="merge",
+    )
+    assert _FakeHub.state["commit_requests"][-1]["mode"] == "merge"
+
+
 def test_publish_flavors_destination_falls_back_to_ctx(fake_hub, tmp_path: Path) -> None:
     _FakeHub.state["finalize_calls"] = 1
     f = tmp_path / "weights.safetensors"

--- a/src/gen_worker/models/refs.py
+++ b/src/gen_worker/models/refs.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Optional
+
+# th#597 C5: flavor charset [a-z0-9][a-z0-9._-]{0,63} (matches tensorhub's
+# validation.IsValidFlavorToken).
+_TENSORHUB_FLAVOR_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
 
 
 @dataclass(frozen=True)
@@ -152,13 +157,21 @@ def parse_model_ref(raw: str, *, provider: str = "tensorhub") -> ParsedModelRef:
         if "#" in s:
             s, flavor_part = s.split("#", 1)
             flavor_part = flavor_part.strip()
-            if not flavor_part:
-                raise ValueError("tensorhub ref flavor is empty")
             if "?" in flavor_part:
                 flavor_part = flavor_part.split("?", 1)[0].strip()
-            flavor = flavor_part or None
-            if flavor is None:
+            flavor_part = flavor_part.lower()
+            if not flavor_part:
                 raise ValueError("tensorhub ref flavor is empty")
+            # th#597 C5: ONE flavor token per ref, charset
+            # [a-z0-9][a-z0-9._-]{0,63} — `#a#b` is invalid (cells encode
+            # conjunction inside one token). Shared grammar vectors:
+            # tests/testdata/ref_grammar_vectors.json (byte-identical copy in
+            # tensorhub internal/orchestrator/release/testdata/).
+            if not _TENSORHUB_FLAVOR_RE.fullmatch(flavor_part):
+                raise ValueError(
+                    f"tensorhub ref flavor {flavor_part!r} is not a valid flavor token"
+                )
+            flavor = flavor_part
 
         low = s.lower()
         if "@sha256:" in low:

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -839,7 +839,6 @@ class _PublisherMixin:
         library_name: str = "",
         model_family: str = "",
         class_name: str = "",
-        adapter_for_checkpoint_group: str = "",
         adapter_for_family: str = "",
     ) -> None:
         """Set destination repo fields for upload sessions opened from this ctx.
@@ -852,7 +851,6 @@ class _PublisherMixin:
             "library_name": library_name,
             "model_family": model_family,
             "class_name": class_name,
-            "adapter_for_checkpoint_group": adapter_for_checkpoint_group,
             "adapter_for_family": adapter_for_family,
         }
         self._repo_spec = {

--- a/src/gen_worker/request_context/_upload_session.py
+++ b/src/gen_worker/request_context/_upload_session.py
@@ -219,7 +219,6 @@ class _UploadSessionManager:
                 "library_name",
                 "model_family",
                 "class_name",
-                "adapter_for_checkpoint_group",
                 "adapter_for_family",
             ):
                 val = str(repo_spec.get(key) or "").strip()

--- a/tests/test_ref_grammar_vectors.py
+++ b/tests/test_ref_grammar_vectors.py
@@ -1,0 +1,33 @@
+"""th#597 C5: parse_model_ref (provider=tensorhub) must pass the shared
+grammar vectors (tests/testdata/ref_grammar_vectors.json), vendored
+byte-identically in tensorhub (internal/orchestrator/release/testdata/) for
+Go's ParseCanonicalRef. Any grammar change edits the fixture in BOTH repos."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gen_worker.models.refs import parse_model_ref
+
+_VECTORS = json.loads(
+    (Path(__file__).parent / "testdata" / "ref_grammar_vectors.json").read_text()
+)["vectors"]
+
+
+@pytest.mark.parametrize("vec", _VECTORS, ids=[v["ref"] or "<empty>" for v in _VECTORS])
+def test_ref_grammar_vector(vec: dict) -> None:
+    if vec.get("error"):
+        with pytest.raises(ValueError):
+            parse_model_ref(vec["ref"], provider="tensorhub")
+        return
+    parsed = parse_model_ref(vec["ref"], provider="tensorhub")
+    th = parsed.tensorhub
+    assert th is not None
+    assert th.owner == vec["owner"]
+    assert th.repo == vec["repo"]
+    assert th.tag == vec["tag"]
+    assert (th.digest or "") == vec["digest"]
+    assert (th.flavor or "") == vec["flavor"]

--- a/tests/testdata/ref_grammar_vectors.json
+++ b/tests/testdata/ref_grammar_vectors.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "th#597 C5: THE tensorhub ref grammar conformance vectors. This file is vendored byte-identically in tensorhub (internal/orchestrator/release/testdata/) and python-gen-worker (tests/testdata/); both parsers (Go ParseCanonicalRef, Python gen_worker.models.refs.parse_model_ref provider=tensorhub) must pass every vector. Grammar: owner/repo[:tag][@sha256:<hex>|@blake3:<hex>][#flavor]. One flavor token per ref, lowercased, charset [a-z0-9][a-z0-9._-]{0,63}. Non-digest @rev is invalid. Tag defaults to latest.",
+  "vectors": [
+    {"ref": "owner/repo", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "", "flavor": ""},
+    {"ref": "owner/repo:v2.1", "owner": "owner", "repo": "repo", "tag": "v2.1", "digest": "", "flavor": ""},
+    {"ref": "owner/repo:", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "", "flavor": ""},
+    {"ref": "owner/repo#fp8", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "", "flavor": "fp8"},
+    {"ref": "owner/repo:stable#fp8", "owner": "owner", "repo": "repo", "tag": "stable", "digest": "", "flavor": "fp8"},
+    {"ref": "owner/repo#BF16", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "", "flavor": "bf16"},
+    {"ref": "_system/family-sdxl:cells#inductor-rtx-4090-torch2.9", "owner": "_system", "repo": "family-sdxl", "tag": "cells", "digest": "", "flavor": "inductor-rtx-4090-torch2.9"},
+    {"ref": "_system/family-sdxl:cells#trt-rtx-4090-trt10.16-fp16", "owner": "_system", "repo": "family-sdxl", "tag": "cells", "digest": "", "flavor": "trt-rtx-4090-trt10.16-fp16"},
+    {"ref": "owner/repo@blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "flavor": ""},
+    {"ref": "owner/repo:prod@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "owner": "owner", "repo": "repo", "tag": "prod", "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "flavor": ""},
+    {"ref": "owner/repo:prod@blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef#fp8", "owner": "owner", "repo": "repo", "tag": "prod", "digest": "blake3:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "flavor": "fp8"},
+    {"ref": "Black-Forest-Labs/FLUX.2-Klein-9B#fp8", "owner": "Black-Forest-Labs", "repo": "FLUX.2-Klein-9B", "tag": "latest", "digest": "", "flavor": "fp8"},
+    {"ref": "owner/repo#fp8?src=lockfile", "owner": "owner", "repo": "repo", "tag": "latest", "digest": "", "flavor": "fp8"},
+    {"ref": "owner/repo#a#b", "error": true},
+    {"ref": "owner/repo#", "error": true},
+    {"ref": "owner/repo#-fp8", "error": true},
+    {"ref": "owner/repo@main", "error": true},
+    {"ref": "owner/repo@sha256:", "error": true},
+    {"ref": "owner/repo@blake3:", "error": true},
+    {"ref": "repo-only", "error": true},
+    {"ref": "owner/", "error": true},
+    {"ref": "/repo", "error": true},
+    {"ref": "", "error": true}
+  ]
+}


### PR DESCRIPTION
gen-worker side of tensorhub#140 (th#597 flavor-system collapse).

- **C5**: `parse_model_ref` (tensorhub provider) now enforces the ONE documented grammar `owner/repo[:tag][@sha256|@blake3:<hex>][#flavor]` — a single lowercased flavor token, charset `[a-z0-9][a-z0-9._-]{0,63}`. `#a#b` raises instead of silently parsing as one bogus token (the Go parser used to split it into TWO flavors — that divergence is closed from both sides). Shared conformance fixture `tests/testdata/ref_grammar_vectors.json` (23 vectors) is byte-identical to tensorhub's `internal/orchestrator/release/testdata/ref_grammar_vectors.json`; both parsers pass all vectors.
- **C2**: `cozy_convert.publish_flavors` defaults to `mode="replace"` — a producer's flavor export is a complete tree; the old merge default is the te#44 root cause (#fp8 export merged with the mirror's fp16 base: 23 files / 5.2GB of wrong-dtype bytes inside the checkpoint). `mode="merge"` stays as an explicit opt-in for overlay publishes. Regression test pins the wire default.
- **D4** cleanup: the `adapter_for_checkpoint_group` repo-spec field (column dropped hub-side) removed from `set_repo_spec` / upload sessions / cozy_convert.

Tests: full suite 407 passed 2 skipped; cozy_convert 119 passed 1 skipped.