### PR TITLE
chore(release): bump to 0.11.0, reconcile CHANGELOG with PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.11.0
+
+- **Per-request LoRA overlays (gw#393).** `ModelBinding.loras` +
+  `LoraOverlay{ref, weight}` on the wire; the executor resolves each overlay
+  ref (ordinary tensorhub-CAS refs, no upstream fetch), applies them as
+  unfused adapters around the handler under the executing() pin, and
+  guarantees unload on every exit path (OK / error / cancel / deadline). A
+  digest-keyed `AdapterCache` (byte-capped RAM LRU of parsed state dicts)
+  makes repeat requests cheap; `ctx.loras` exposes the resolved set
+  read-only. `Hub()`/`HF()` gain `allow_lora=` (endpoint opt-in, requires
+  `Compile(family=)`); `run --list` surfaces the flag (ie#358).
 
 - **Adapter residency: repeat LoRA requests cost ~50ms of machinery, not
   seconds (#399).** LoRA adapters now stay ATTACHED to the resident pipeline
@@ -16,6 +26,56 @@
   `load_lora_weights` re-attach was ~1.6-1.9s/request and unfused adapter
   compute adds ~59ms/denoise-step; residency removes the re-attach entirely
   (activate 23ms / disable 24ms / enable 26ms measured on the 4090).
+
+- **Per-SKU TensorRT engine artifacts on the compile-cache rails (gw#390).**
+  A second producer/consumer cell kind alongside inductor:
+  `trt-<sku>-trt<maj.min>-<precision>` flavors carry a weight-stripped
+  refittable engine + a value-matched refit map — one engine serves every
+  fine-tune of a family, refit from the weights already resident in VRAM.
+  `gen_worker.trt_engine` handles key/verify (full TRT version, plans are
+  version-locked), deterministic pack/unpack, and build (ONNX export ->
+  STRIP_PLAN|REFIT); the executor's boot-attach/hot-adopt dispatch prefers
+  TRT over inductor when both resolve, any refit failure unwraps to eager.
+  `hub_policy` advertises `tensorrt==<version>` in `installed_libs` (th#575).
+
+- **Two-format quantization policy: fp8-E4M3 storage + emergency nf4 (gw#389,
+  th#546).** Runtime `quantize=` on HF/Hub bindings is removed; the platform
+  serves exactly two STORED quantized formats — fp8 E4M3 (universal,
+  per-layer upcast to compute dtype via diffusers layerwise casting) and
+  nvfp4 (Blackwell). `storage_dtype="fp8"` replaces it; `#fp8`-flavored
+  snapshots are detected via safetensors headers and their storage precision
+  preserved instead of upcasting into 2x VRAM. An emergency nf4 rung
+  (`GEN_WORKER_EMERGENCY_QUANT`, cozy-local only) runtime-quantizes the
+  denoiser when even the downloaded flavor can't fit free VRAM, surfaced as
+  `runs (emergency quality)`. Ladder: bf16 -> #fp8 -> #nvfp4 -> emergency-nf4
+  -> offload.
+
+- **Streaming dtype cast + fp8-E4M3 storage cast in cozy_convert (gw#395,
+  gw#396).** `_stream_reencode` casts one tensor at a time (peak anonymous
+  RAM ~ largest single tensor regardless of model size; proven on a 22GiB
+  fp32 fixture under a 4G cgroup — 513MiB peak for bf16, 1281MiB for fp8).
+  `streaming_fp8_storage_cast` produces F8_E4M3-stored weight tensors
+  matching the runtime fp8-storage consumption path; weight-only nvfp4 is
+  deliberately not shipped (te#44 quality verdict was a hard FAIL). Off-policy
+  quant surface (torchao inline paths, awq/gptq, fp8:e5m2/int8) pruned per
+  `QUANTIZATION-POLICY.md`; bnb nf4/fp4 inline kept as the emergency-rung
+  producer. The old buffering `StreamingWriter` is deleted.
+
+- **Flavor-collapse ref-grammar conformance + producer publish mode=replace
+  (#112, th#597).** `parse_model_ref` validates the flavor token against the
+  documented grammar `owner/repo[:tag][@sha256|@blake3:<hex>][#flavor]` (one
+  lowercased token; multi-`#` refs now raise instead of silently parsing as
+  one bogus token) — shared conformance vectors vendored and byte-identical
+  with tensorhub. `publish_flavors` now defaults to `mode=replace` (a
+  producer's flavor export is a complete tree; the old merge default let a
+  `#fp8` export merge with the mirror's fp16 base, the te#44 root cause).
+  `mode=merge` stays as an explicit opt-in for overlay publishes.
+
+- **Flashpack format support removed (gw#388).** Dropped everywhere: the
+  unsafe-format gate is safetensors-only, the hub capability probe no longer
+  advertises flashpack, cozy_convert loses the flashpack converter/extra.
+  Evidence (e2e#114): flashpack loses 3.0x cold / 2.7x warm to plain
+  safetensors and is dormant upstream.
 
 - **Compile-cell adoption: honest cache-hit proof + rekey (#391).** ADOPTED now
   means the seeded inductor cell actually served the warmup trace: the worker

--- a/examples/flux2-klein-image/pyproject.toml
+++ b/examples/flux2-klein-image/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "FLUX.2-klein-4B turbo text-to-image example (real GPU inference)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "diffusers>=0.39.0",
     # diffusers' Flux2Klein text encoder is Qwen3ForCausalLM; transformers 5.0
     # reworked internals that load path depends on (see inference-endpoints

--- a/examples/flux2-klein-image/uv.lock
+++ b/examples/flux2-klein-image/uv.lock
@@ -351,7 +351,7 @@ dependencies = [
 requires-dist = [
     { name = "accelerate", specifier = ">=1.0" },
     { name = "diffusers", specifier = ">=0.39.0" },
-    { name = "gen-worker", specifier = ">=0.10.0,<0.11" },
+    { name = "gen-worker", specifier = ">=0.11.0,<0.12" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "protobuf" },
     { name = "sentencepiece" },
@@ -369,7 +369,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -384,9 +384,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/cf/9a8ddbb0c30ec2f240753db748d78998a085c91e68e3eca86184a0eeb882/gen_worker-0.10.0.tar.gz", hash = "sha256:c6f33222d9b676510b769d568b16bfd1af29532417323b784ce6190d01220a2c", size = 254011, upload-time = "2026-07-08T06:51:14.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/bb/eeb2dbba69eb11290e6eb5777dcfa48b98a4947bf8446d92ca57b2f78340/gen_worker-0.11.0.tar.gz", hash = "sha256:8deb48ea8e8b2968f0b8998e3638a15ef90a4909cacf1c4107a77bdc9dcf50ee", size = 254018, upload-time = "2026-07-08T23:39:15.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/47/98db157607ba17d4da93be3b92edc286d56af5d0888fb5fa71112ae708fa/gen_worker-0.10.0-py3-none-any.whl", hash = "sha256:e90edf9c0a409bfd693317202a699d7338d31f90ceda8c60b6229250ae20df45", size = 292529, upload-time = "2026-07-08T06:51:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cf/cd14318e3f7ad268637fdd345d6b2ab051dc65288068948e032c8e5d0020/gen_worker-0.11.0-py3-none-any.whl", hash = "sha256:4fc1a3aa124748aab0f06b06bc4d49d55bc62d31e65274830450b2a04452e943", size = 292528, upload-time = "2026-07-08T23:39:12.556Z" },
 ]
 
 [[package]]

--- a/examples/from-scratch/pyproject.toml
+++ b/examples/from-scratch/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "torch>=2.11.0",
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "cozy-convert>=0.1.0",
     "safetensors",
 ]

--- a/examples/marco-polo/pyproject.toml
+++ b/examples/marco-polo/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Simple function for testing"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
 ]
 
 [dependency-groups]

--- a/examples/marco-polo/uv.lock
+++ b/examples/marco-polo/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "blake3" },

--- a/examples/qwen-edit-hub-image/pyproject.toml
+++ b/examples/qwen-edit-hub-image/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Qwen-Image-Edit-2511 image editing served from a tensorhub repo-cas mirror (Hub binding)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "diffusers>=0.36",
     "transformers>=4.57,<5",
     "accelerate>=1.0",

--- a/examples/qwen-edit-hub-image/uv.lock
+++ b/examples/qwen-edit-hub-image/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -353,9 +353,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/cf/9a8ddbb0c30ec2f240753db748d78998a085c91e68e3eca86184a0eeb882/gen_worker-0.10.0.tar.gz", hash = "sha256:c6f33222d9b676510b769d568b16bfd1af29532417323b784ce6190d01220a2c", size = 254011, upload-time = "2026-07-08T06:51:14.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/bb/eeb2dbba69eb11290e6eb5777dcfa48b98a4947bf8446d92ca57b2f78340/gen_worker-0.11.0.tar.gz", hash = "sha256:8deb48ea8e8b2968f0b8998e3638a15ef90a4909cacf1c4107a77bdc9dcf50ee", size = 254018, upload-time = "2026-07-08T23:39:15.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/47/98db157607ba17d4da93be3b92edc286d56af5d0888fb5fa71112ae708fa/gen_worker-0.10.0-py3-none-any.whl", hash = "sha256:e90edf9c0a409bfd693317202a699d7338d31f90ceda8c60b6229250ae20df45", size = 292529, upload-time = "2026-07-08T06:51:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cf/cd14318e3f7ad268637fdd345d6b2ab051dc65288068948e032c8e5d0020/gen_worker-0.11.0-py3-none-any.whl", hash = "sha256:4fc1a3aa124748aab0f06b06bc4d49d55bc62d31e65274830450b2a04452e943", size = 292528, upload-time = "2026-07-08T23:39:12.556Z" },
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
 requires-dist = [
     { name = "accelerate", specifier = ">=1.0" },
     { name = "diffusers", specifier = ">=0.36" },
-    { name = "gen-worker", specifier = ">=0.10.0,<0.11" },
+    { name = "gen-worker", specifier = ">=0.11.0,<0.12" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pillow", specifier = ">=10" },
     { name = "torchvision", specifier = ">=0.24" },

--- a/examples/sd15-hub-image/pyproject.toml
+++ b/examples/sd15-hub-image/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Stable Diffusion 1.5 served from a tensorhub repo-cas mirror (Hub binding)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "diffusers>=0.31",
     "transformers>=4.46",
     "accelerate>=1.0",

--- a/examples/sd15-hub-image/uv.lock
+++ b/examples/sd15-hub-image/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -380,9 +380,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/cf/9a8ddbb0c30ec2f240753db748d78998a085c91e68e3eca86184a0eeb882/gen_worker-0.10.0.tar.gz", hash = "sha256:c6f33222d9b676510b769d568b16bfd1af29532417323b784ce6190d01220a2c", size = 254011, upload-time = "2026-07-08T06:51:14.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/bb/eeb2dbba69eb11290e6eb5777dcfa48b98a4947bf8446d92ca57b2f78340/gen_worker-0.11.0.tar.gz", hash = "sha256:8deb48ea8e8b2968f0b8998e3638a15ef90a4909cacf1c4107a77bdc9dcf50ee", size = 254018, upload-time = "2026-07-08T23:39:15.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/47/98db157607ba17d4da93be3b92edc286d56af5d0888fb5fa71112ae708fa/gen_worker-0.10.0-py3-none-any.whl", hash = "sha256:e90edf9c0a409bfd693317202a699d7338d31f90ceda8c60b6229250ae20df45", size = 292529, upload-time = "2026-07-08T06:51:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cf/cd14318e3f7ad268637fdd345d6b2ab051dc65288068948e032c8e5d0020/gen_worker-0.11.0-py3-none-any.whl", hash = "sha256:4fc1a3aa124748aab0f06b06bc4d49d55bc62d31e65274830450b2a04452e943", size = 292528, upload-time = "2026-07-08T23:39:12.556Z" },
 ]
 
 [[package]]
@@ -1100,7 +1100,7 @@ dependencies = [
 requires-dist = [
     { name = "accelerate", specifier = ">=1.0" },
     { name = "diffusers", specifier = ">=0.31" },
-    { name = "gen-worker", specifier = ">=0.10.0,<0.11" },
+    { name = "gen-worker", specifier = ">=0.11.0,<0.12" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "transformers", specifier = ">=4.46" },
 ]

--- a/examples/sd15-image/pyproject.toml
+++ b/examples/sd15-image/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Stable Diffusion 1.5 text-to-image example (real GPU inference)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "diffusers>=0.31",
     "transformers>=4.46",
     "accelerate>=1.0",

--- a/examples/sd15-image/uv.lock
+++ b/examples/sd15-image/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "blake3" },

--- a/examples/zimage-hub-image/pyproject.toml
+++ b/examples/zimage-hub-image/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Z-Image-Turbo text-to-image served from a tensorhub repo-cas mirror (Hub binding)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "gen-worker>=0.10.0,<0.11",
+    "gen-worker>=0.11.0,<0.12",
     "diffusers>=0.36",
     "transformers>=4.57,<5",
     "accelerate>=1.0",

--- a/examples/zimage-hub-image/uv.lock
+++ b/examples/zimage-hub-image/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -353,9 +353,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/cf/9a8ddbb0c30ec2f240753db748d78998a085c91e68e3eca86184a0eeb882/gen_worker-0.10.0.tar.gz", hash = "sha256:c6f33222d9b676510b769d568b16bfd1af29532417323b784ce6190d01220a2c", size = 254011, upload-time = "2026-07-08T06:51:14.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/bb/eeb2dbba69eb11290e6eb5777dcfa48b98a4947bf8446d92ca57b2f78340/gen_worker-0.11.0.tar.gz", hash = "sha256:8deb48ea8e8b2968f0b8998e3638a15ef90a4909cacf1c4107a77bdc9dcf50ee", size = 254018, upload-time = "2026-07-08T23:39:15.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/47/98db157607ba17d4da93be3b92edc286d56af5d0888fb5fa71112ae708fa/gen_worker-0.10.0-py3-none-any.whl", hash = "sha256:e90edf9c0a409bfd693317202a699d7338d31f90ceda8c60b6229250ae20df45", size = 292529, upload-time = "2026-07-08T06:51:16.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cf/cd14318e3f7ad268637fdd345d6b2ab051dc65288068948e032c8e5d0020/gen_worker-0.11.0-py3-none-any.whl", hash = "sha256:4fc1a3aa124748aab0f06b06bc4d49d55bc62d31e65274830450b2a04452e943", size = 292528, upload-time = "2026-07-08T23:39:12.556Z" },
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ dependencies = [
 requires-dist = [
     { name = "accelerate", specifier = ">=1.0" },
     { name = "diffusers", specifier = ">=0.36" },
-    { name = "gen-worker", specifier = ">=0.10.0,<0.11" },
+    { name = "gen-worker", specifier = ">=0.11.0,<0.12" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "transformers", specifier = ">=4.57,<5" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.10.1"
+version = "0.11.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- master's pyproject.toml (0.10.1) was behind the PyPI-published 0.11.0. Bumps version + uv.lock.
- CHANGELOG: renames `## Unreleased` to `## 0.11.0`, backfills entries missing from the auto-accumulated Unreleased section: per-request LoRA overlays (gw#393), TRT engine artifacts (gw#390), two-format quantization storage (gw#389), streaming dtype/fp8 cast (gw#395/#396), flavor-parser conformance (#112), flashpack removal (gw#388).
- In-repo examples' `gen-worker` pins bumped `>=0.10.0,<0.11` -> `>=0.11.0,<0.12` (editable path-sourced, but the declared range must cover the local package version for `uv lock` to resolve).

## Test plan
- [x] `uv run --extra dev pytest -q` — 407 passed, 2 skipped
- [x] `uv run python -c "import gen_worker"` — clean
- [x] `uv lock` clean at repo root and in every example except `examples/from-scratch` (pre-existing failure on unmodified master: `cozy-convert` isn't published to PyPI — unrelated to this change, left untouched)