### PR TITLE
chore(release): bump to 0.11.1 — republish from HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1
+
+- **Republish from HEAD.** The 0.11.0 PyPI wheel was stale (missing
+  `allow_lora` gw#393/ie#358, compile-honesty gw#391); no code changes vs
+  HEAD, version bump only to supersede the stale 0.11.0 wheel.
+
 ## 0.11.0
 
 - **Per-request LoRA overlays (gw#393).** `ModelBinding.loras` +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.11.0"
+version = "0.11.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- 0.11.0 was published to PyPI from a stale checkout (~15 commits behind HEAD), missing per-request LoRA overlays (gw#393/ie#358) and compile-cell adoption honesty (gw#391).
- No code changes vs HEAD — version bump + CHANGELOG entry only, to supersede the stale 0.11.0 wheel so the fleet can consume LoRA serving.
- Confirmed `allow_lora=` on `Hub()`/`HF()` bindings, the `LoraOverlay` proto message, and `fxgraph_cache_hit`/`cache_misses`/`warmup_s` ADOPTED-event observability are all present at HEAD.

## Test plan

- [x] `uv run --extra dev pytest -q` — 407 passed, 2 skipped (skips are missing optional `diffusers`/`PIL` deps, unrelated to this change)
- [x] Verified `test_compile_cache.py::test_counters_helpers` and all of `test_executor_adopt.py` pass with real torch (2.11.0+cu128) present — no fxgraph_cache_hit regression