### PR TITLE
chore(release): bump to 0.11.2 (gw#403 stale-wheel remediation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ src/gen_worker/pb/**/*.pyo
 .mock-files*
 # CodeGraph index (local, regenerated)
 .codegraph/
+.runtime/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.2
+
+- Republish: the 0.11.0 and 0.11.1 PyPI wheels were both built from a stale local checkout (19 commits behind master, mixed-commit tree) and lack `allow_lora`, `LoraOverlay`, and `inductor_counters`. No code changes vs 0.11.1 master; version bump only, publish from clean `origin/master` HEAD.
+- gitignore `.runtime/`.
+
 ## 0.11.1
 
 - **Republish from HEAD.** The 0.11.0 PyPI wheel was stale (missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.11.1"
+version = "0.11.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
0.11.0 and 0.11.1 PyPI wheels were both built from a stale local tree (byte-verified in gw#403). This bumps to 0.11.2 so Paul can publish from clean origin/master HEAD. Version + changelog + .gitignore .runtime/ only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)