### PR TITLE
fix(residency): verify+repair every device move; refuse mixed-device pipelines (gw#409)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -789,12 +789,20 @@ class Executor:
         back into VRAM instead of a cold reload (#371)."""
         res = self.store.residency
         refs = [wire_ref(spec.models[s]) for s in self._setup_slots(spec)]
+        cuda_host = torch is not None and torch.cuda.is_available()
         if any(res.tier(r) is residency_mod.Tier.RAM for r in refs):
             async with self._load_lock:
                 for ref in refs:
                     if res.tier(ref) is residency_mod.Tier.RAM:
-                        await asyncio.to_thread(res.promote, ref)
+                        ok = await asyncio.to_thread(res.promote, ref)
                         self._on_state_change()
+                        if not ok and cuda_host and res.tier(ref) is residency_mod.Tier.RAM:
+                            # Promote refused/rolled back (gw#409): fail the
+                            # job RETRYABLE at promote time — never hand a
+                            # handler a pipeline that fatals mid-denoise.
+                            raise RetryableError(
+                                f"promotion of {ref} to VRAM failed; retrying"
+                            )
         for ref in refs:
             res.touch(ref)
 
@@ -1321,6 +1329,16 @@ class Executor:
     # ---- job execution -----------------------------------------------------
 
     async def _run_job(self, job: _Job, run: pb.RunJob) -> None:
+        spec = job.spec
+        assert spec is not None
+        # Pin this job's model refs for its WHOLE lifetime (gw#409): the gap
+        # between ensure_setup's promote and the execution-time pin let a
+        # concurrent job's make_room demote a just-promoted pipeline. Refs
+        # without entries yet are no-ops; the inner pin still covers adapters.
+        with self.store.residency.executing(*(wire_ref(b) for b in spec.models.values())):
+            await self._run_job_pinned(job, run)
+
+    async def _run_job_pinned(self, job: _Job, run: pb.RunJob) -> None:
         spec = job.spec
         assert spec is not None
         concurrency_at_start = len(self.in_flight_keys()) - 1

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -83,20 +83,71 @@ def cuda_allocated_bytes(device_index: Optional[int] = None) -> int:
     return 0
 
 
-def _iter_components(pipeline: Any) -> List[Any]:
-    comps: List[Any] = []
+def _named_components(pipeline: Any) -> List[tuple[str, Any]]:
+    out: List[tuple[str, Any]] = []
     raw = getattr(pipeline, "components", None)
     if isinstance(raw, dict):
-        comps.extend(raw.values())
+        out.extend(raw.items())
     else:
         for attr in ("unet", "transformer", "vae", "text_encoder",
                      "text_encoder_2", "text_encoder_3"):
             v = getattr(pipeline, attr, None)
             if v is not None:
-                comps.append(v)
-    if not comps and hasattr(pipeline, "parameters"):
-        comps.append(pipeline)  # bare nn.Module
-    return comps
+                out.append((attr, v))
+    if not out and hasattr(pipeline, "parameters"):
+        out.append(("", pipeline))  # bare nn.Module
+    return out
+
+
+def _iter_components(pipeline: Any) -> List[Any]:
+    return [c for _, c in _named_components(pipeline)]
+
+
+def device_mismatches(obj: Any, device: str) -> List[tuple[str, str, str]]:
+    """Every parameter/buffer of ``obj``'s module components that is NOT on
+    ``device``'s device type, as ``(component, tensor, actual_device)``.
+
+    The paranoid post-move walk (gw#409): a pipeline ``.to()`` that raises or
+    skips mid-way leaves a mixed-device pipeline that fatals mid-denoise
+    ("Expected all tensors to be on the same device"); this surfaces the miss
+    at move time instead. [] without torch / for tensor-less objects."""
+    try:
+        import torch
+
+        target = torch.device(device).type
+    except Exception:
+        return []
+    out: List[tuple[str, str, str]] = []
+    for cname, comp in _named_components(obj):
+        if comp is None or not hasattr(comp, "named_parameters"):
+            continue
+        try:
+            named = list(comp.named_parameters())
+            if hasattr(comp, "named_buffers"):
+                named.extend(comp.named_buffers())
+        except Exception:
+            continue
+        for tname, t in named:
+            if isinstance(t, torch.Tensor) and t.device.type != target:
+                out.append((cname, tname, str(t.device)))
+    return out
+
+
+def repair_device_placement(obj: Any, device: str) -> List[tuple[str, str, str]]:
+    """Targeted ``.to(device)`` on each component holding off-device tensors,
+    then re-walk. Returns the remaining mismatches ([] = fully repaired)."""
+    missed = device_mismatches(obj, device)
+    if not missed:
+        return []
+    bad = {c for c, _, _ in missed}
+    for cname, comp in _named_components(obj):
+        if cname not in bad:
+            continue
+        try:
+            comp.to(device)
+        except Exception as exc:
+            _LOG.warning("device repair: %s.to(%s) failed: %s", cname or "obj", device, exc)
+    return device_mismatches(obj, device)
 
 
 def _sum_tensor_bytes(objs: Iterable[Any], *, cuda_only: bool) -> int:
@@ -593,6 +644,8 @@ __all__ = [
     "place_pipeline",
     "with_oom_retry",
     "select_auto_mode",
+    "device_mismatches",
+    "repair_device_placement",
     "estimate_pipeline_size_gb",
     "estimate_cuda_resident_gb",
     "cuda_allocated_bytes",

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -31,9 +31,12 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from .memory import (
+    device_mismatches,
     estimate_cuda_resident_gb,
+    estimate_pipeline_size_gb,
     flush_memory,
     get_available_ram_gb,
+    repair_device_placement,
 )
 
 logger = logging.getLogger(__name__)
@@ -107,14 +110,14 @@ def _obj_manages_own_device(obj: Any) -> bool:
 
 
 def _move_obj(obj: Any, device: str) -> None:
+    """Whole-object ``.to(device)``. Raises on failure — the caller
+    (:meth:`Residency._move_verified`) owns rollback; swallowing a mid-move
+    CUDA OOM here used to book a half-moved pipeline as resident (gw#409)."""
     if obj is None or _obj_manages_own_device(obj):
         return
-    try:
-        to = getattr(obj, "to", None)
-        if callable(to):
-            to(device)
-    except Exception as exc:
-        logger.warning("residency: .to(%s) failed: %s", device, exc)
+    to = getattr(obj, "to", None)
+    if callable(to):
+        to(device)
 
 
 class Residency:
@@ -284,29 +287,107 @@ class Residency:
                     self.pre_demote(ref, e.obj)
                 except Exception:
                     logger.exception("pre_demote hook failed for %s", ref)
-            self._move(e.obj, "cpu")
+            if not self._move_verified(e.obj, "cpu", ref=ref):
+                return False  # entry stays VRAM; object restored to cuda
             e.tier = Tier.RAM
             e.vram_bytes = 0
         flush_memory()
         self._emit(ref, IN_RAM)
         return True
 
+    def _move_verified(self, obj: Any, device: str, *, ref: str = "") -> bool:
+        """Move + paranoid completeness walk (gw#409): after ``.to(device)``,
+        every module parameter/buffer must actually be on ``device`` — a move
+        that raised (mid-move CUDA OOM) or skipped tensors gets one targeted
+        repair pass, and an unrepairable object is rolled back to the other
+        side. Residency NEVER books a mixed-device pipeline: mixed devices
+        fatal mid-denoise ("Expected all tensors to be on the same device")."""
+        restore = "cpu" if device != "cpu" else "cuda"
+        try:
+            self._move(obj, device)
+            missed = device_mismatches(obj, device)
+            if missed:
+                logger.warning(
+                    "residency: .to(%s) on %s left %d tensors behind (e.g. %s); repairing",
+                    device, ref or type(obj).__name__, len(missed), missed[:3],
+                )
+                missed = repair_device_placement(obj, device)
+            if not missed:
+                return True
+            logger.error(
+                "residency: move of %s to %s incomplete after repair (%s); rolling back",
+                ref or type(obj).__name__, device, missed[:5],
+            )
+        except Exception as exc:
+            logger.error(
+                "residency: .to(%s) failed for %s: %s; rolling back",
+                device, ref or type(obj).__name__, exc,
+            )
+        try:
+            self._move(obj, restore)
+            left = repair_device_placement(obj, restore)
+            if left:
+                logger.critical(
+                    "residency: rollback of %s to %s ALSO incomplete (%s) — "
+                    "object is mixed-device and unusable",
+                    ref or type(obj).__name__, restore, left[:5],
+                )
+        except Exception:
+            logger.exception("residency: rollback .to(%s) failed for %s", restore, ref)
+        flush_memory()
+        return False
+
     def promote(self, ref: str, device: str = "cuda") -> bool:
-        """RAM -> VRAM (makes room first). True when resident afterward."""
+        """RAM -> VRAM (makes room first). True when resident afterward —
+        i.e. every tensor verified on ``device``; a failed/partial move is
+        rolled back to CPU and refused instead of booked (gw#409)."""
         with self._lock:
             e = self._entries.get(ref)
             if e is None or not e.movable:
                 return False
-            if e.tier is Tier.VRAM:
-                e.last_used = time.monotonic()
-                return True
             hint = e.vram_hint
+            obj = e.obj
+            already_vram = e.tier is Tier.VRAM
+            if already_vram:
+                e.last_used = time.monotonic()
+        if already_vram:
+            # Paranoid fast path: a VRAM-booked entry must actually be device-
+            # complete (a crashed rollback / out-of-band .to() must not serve
+            # a mixed-device pipeline). The clean-case walk is tensor metadata
+            # only — no data movement.
+            missed = device_mismatches(obj, device)
+            if not missed:
+                return True
+            logger.warning(
+                "residency: VRAM-tier %s holds %d off-device tensors (e.g. %s); repairing",
+                ref, len(missed), missed[:3],
+            )
+            if not repair_device_placement(obj, device):
+                return True
+            # Unrepairable: book the truth (RAM) and refuse.
+            with self._lock:
+                e = self._entries.get(ref)
+                if e is None:
+                    return False
+                if not self._move_verified(e.obj, "cpu", ref=ref):
+                    logger.critical("residency: %s stuck mixed-device", ref)
+                e.tier = Tier.RAM
+                e.vram_bytes = 0
+            flush_memory()
+            self._emit(ref, IN_RAM)
+            return False
+        if hint <= 0:
+            # Never-measured entry: estimate from weights so make_room asks
+            # for real headroom instead of 0 (a 0-byte ask promoted 6.9GB
+            # pipelines into ~2GB free and OOMed mid-move, gw#409).
+            hint = int(estimate_pipeline_size_gb(obj) * _GiB)
         self.make_room(hint)
         with self._lock:
             e = self._entries.get(ref)
             if e is None or not e.movable:
                 return False
-            self._move(e.obj, device)
+            if not self._move_verified(e.obj, device, ref=ref):
+                return False  # entry stays RAM; object restored to cpu
             e.tier = Tier.VRAM
             e.vram_bytes = int(estimate_cuda_resident_gb(e.obj) * _GiB) or hint
             e.vram_hint = max(e.vram_hint, e.vram_bytes)

--- a/tests/test_promote_device_integrity.py
+++ b/tests/test_promote_device_integrity.py
@@ -1,0 +1,212 @@
+"""RAM->VRAM promote device integrity (gw#409).
+
+The J17 juggle trace lost ~9% of requests to "Expected all tensors to be on
+the same device, index is on cpu": a pipeline ``.to()`` that raised (mid-move
+CUDA OOM) or skipped a component was still booked IN_VRAM, so the handler ran
+a mixed-device pipeline and fataled mid-denoise. Residency now verifies every
+module parameter/buffer after a move (paranoid post-promote walk), repairs
+targeted misses, and rolls back + refuses instead of booking a mixed object.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models import residency as residency_mod
+from gen_worker.models.residency import Residency, Tier
+
+_GiB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def _plenty_of_ram(monkeypatch):
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 64.0)
+
+
+def _res(events: list, budget_gb: int = 24) -> Residency:
+    return Residency(
+        on_event=lambda ref, state, vb: events.append((ref, state, vb)),
+        vram_budget_bytes=budget_gb * _GiB,
+    )
+
+
+class _Pipe:
+    """Torch-less movable object (moves always succeed, nothing to verify)."""
+
+    def __init__(self) -> None:
+        self.moves: list[str] = []
+
+    def to(self, device: str) -> "_Pipe":
+        self.moves.append(device)
+        return self
+
+
+class _FailsTo(_Pipe):
+    """`.to()` raises for the given device (simulated mid-move CUDA OOM)."""
+
+    def __init__(self, fail_device: str) -> None:
+        super().__init__()
+        self._fail = fail_device
+
+    def to(self, device: str) -> "_FailsTo":
+        if device == self._fail:
+            raise RuntimeError("CUDA out of memory (simulated)")
+        return super().to(device)
+
+
+# --------------------------------------------------------------------------- #
+# Move-failure rollback (no torch required)
+# --------------------------------------------------------------------------- #
+
+
+def test_promote_move_failure_is_refused_and_rolled_back() -> None:
+    events: list = []
+    res = _res(events)
+    pipe = _FailsTo("cuda")
+    res.track_ram("m/a", pipe)
+
+    assert res.promote("m/a") is False
+    assert res.tier("m/a") is Tier.RAM
+    assert res.vram_bytes("m/a") == 0
+    # Rollback attempted a restore to cpu; nothing was booked IN_VRAM.
+    assert pipe.moves[-1] == "cpu"
+    assert not any(s == residency_mod.IN_VRAM for _, s, _ in events)
+
+
+def test_demote_move_failure_keeps_vram_tier() -> None:
+    events: list = []
+    res = _res(events)
+    pipe = _FailsTo("cpu")
+    res.track_vram("m/a", pipe, vram_bytes=3 * _GiB)
+    events.clear()
+
+    assert res.demote("m/a") is False
+    assert res.tier("m/a") is Tier.VRAM
+    assert res.vram_bytes("m/a") == 3 * _GiB
+    assert not any(s == residency_mod.IN_RAM for _, s, _ in events)
+
+
+def test_failed_promote_then_retry_succeeds() -> None:
+    """A refused promote leaves a consistent RAM entry; a later attempt (after
+    make_room freed VRAM) promotes normally."""
+    events: list = []
+    res = _res(events)
+
+    class _FlakyOnce(_Pipe):
+        def __init__(self) -> None:
+            super().__init__()
+            self.failures = 1
+
+        def to(self, device: str) -> "_FlakyOnce":
+            if device == "cuda" and self.failures > 0:
+                self.failures -= 1
+                raise RuntimeError("CUDA out of memory (simulated)")
+            return super().to(device)
+
+    pipe = _FlakyOnce()
+    res.track_vram("m/a", pipe, vram_bytes=2 * _GiB)
+    assert res.demote("m/a") is True
+    assert res.promote("m/a") is False
+    assert res.tier("m/a") is Tier.RAM
+    assert res.promote("m/a") is True
+    assert res.tier("m/a") is Tier.VRAM
+    assert res.vram_bytes("m/a") == 2 * _GiB  # hint restored
+
+
+# --------------------------------------------------------------------------- #
+# Post-move completeness walk over real torch modules (buffers included)
+# --------------------------------------------------------------------------- #
+
+
+def _synthetic_pipeline():
+    """Diffusers-shaped pipeline: module components with parameters, a
+    persistent buffer, a NON-persistent buffer, and a non-module component."""
+    torch = pytest.importorskip("torch")
+
+    class _Pipeline:
+        def __init__(self) -> None:
+            self.unet = torch.nn.Linear(2, 2)
+            self.unet.register_buffer("rope", torch.zeros(2))
+            self.unet.register_buffer(
+                "step_index", torch.zeros(2, dtype=torch.long), persistent=False
+            )
+            self.text_encoder = torch.nn.Linear(2, 2)
+            self.scheduler = object()  # non-module component (no tensors)
+            self.components = {
+                "unet": self.unet,
+                "text_encoder": self.text_encoder,
+                "scheduler": self.scheduler,
+            }
+            self.moves: list[str] = []
+
+        # Mimics the gw#409 miss: the whole-pipeline move skips a component.
+        def to(self, device: str) -> "_Pipeline":
+            self.moves.append(device)
+            self.unet.to(device)
+            return self
+
+    return torch, _Pipeline()
+
+
+def test_device_mismatches_walks_params_and_all_buffers() -> None:
+    torch, pipe = _synthetic_pipeline()
+    from gen_worker.models.memory import device_mismatches
+
+    pipe.to("meta")  # moves unet only
+    missed = device_mismatches(pipe, "meta")
+    names = {(c, t) for c, t, _ in missed}
+    assert ("text_encoder", "weight") in names
+    assert ("text_encoder", "bias") in names
+    assert not any(c == "unet" for c, _ in names)  # unet fully moved
+    # And the walk sees buffers: un-move unet's buffers only.
+    assert device_mismatches(pipe, "cpu")  # unet params+buffers now off-cpu
+    unet_named = {t for c, t, _ in device_mismatches(pipe, "cpu") if c == "unet"}
+    assert {"weight", "bias", "rope", "step_index"} <= unet_named
+
+
+def test_promote_repairs_component_skipped_by_pipeline_to() -> None:
+    torch, pipe = _synthetic_pipeline()
+    from gen_worker.models.memory import device_mismatches
+
+    events: list = []
+    res = _res(events)
+    res.track_ram("sdxl/variant", pipe)
+
+    assert res.promote("sdxl/variant", device="meta") is True
+    assert res.tier("sdxl/variant") is Tier.VRAM
+    # The paranoid walk found and repaired the skipped text_encoder: EVERY
+    # param+buffer (incl. the non-persistent one) is on the target device.
+    assert device_mismatches(pipe, "meta") == []
+
+
+def test_promote_refuses_unrepairable_component() -> None:
+    torch, pipe = _synthetic_pipeline()
+
+    class _Stubborn(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(2))
+
+        def _apply(self, fn, recurse=True):  # .to() lands here
+            raise RuntimeError("CUDA out of memory (simulated)")
+
+    pipe.text_encoder = _Stubborn()
+    pipe.components["text_encoder"] = pipe.text_encoder
+
+    res = _res([])
+    res.track_ram("sdxl/variant", pipe)
+    assert res.promote("sdxl/variant", device="meta") is False
+    assert res.tier("sdxl/variant") is Tier.RAM
+
+
+def test_vram_fast_path_repairs_mixed_device_entry() -> None:
+    torch, pipe = _synthetic_pipeline()
+    from gen_worker.models.memory import device_mismatches
+
+    res = _res([])
+    pipe.unet.to("meta")  # text_encoder left on cpu -> mixed
+    res.track_vram("sdxl/variant", pipe, vram_bytes=1 * _GiB)
+
+    # tier is already VRAM: the fast path must still verify + repair.
+    assert res.promote("sdxl/variant", device="meta") is True
+    assert device_mismatches(pipe, "meta") == []


### PR DESCRIPTION
## gw#409 — RAM->VRAM promote leaves a tensor on CPU (~9% of J17 trace fatals)

**Root cause:** `_move_obj` swallowed exceptions from `pipeline.to(device)`. A promote that OOMed (or a pipeline `.to()` that skipped a component) was still booked `IN_VRAM`, so the handler ran a mixed-device pipeline and fataled mid-denoise with `Expected all tensors to be on the same device, index is on cpu`. A second hole: `promote()` with a never-measured entry called `make_room(0)`, promoting ~6.9GB SDXL pipelines into ~2GB free VRAM (the OOM trigger). A third: between `ensure_setup`'s promote and the execution-time pin, a concurrent job's `make_room` could demote the just-promoted pipeline.

**Fix:**
- `Residency._move_verified`: move + paranoid post-move walk (every module param + buffer, incl. non-persistent), targeted repair of skipped components, rollback + refusal when unrepairable. Residency never books a state it didn't fully produce. `demote()` symmetric.
- `promote()` sizes `make_room` from `estimate_pipeline_size_gb` when there is no measured hint.
- VRAM fast path re-verifies device completeness (metadata-only walk when clean).
- Executor: a refused promote raises `RetryableError` at promote time — fails loudly before the handler, never mid-denoise; jobs pin their refs for the whole `_run_job`.

**Tests:** `tests/test_promote_device_integrity.py` — synthetic diffusers-shaped pipeline (params + persistent + non-persistent buffers + non-module scheduler) whose `.to()` skips a component: promote detects + repairs; unrepairable component refuses + rolls back; demote/promote failure rollback; VRAM fast-path repair; retry-after-refusal.

Full suite with torch: **414 passed, 2 skipped** (CI test job lacks torch).