### PR TITLE
feat(cozy-convert): ready for first PyPI publish (gw#406)

### DIFF
--- a/packages/cozy_convert/pyproject.toml
+++ b/packages/cozy_convert/pyproject.toml
@@ -7,15 +7,31 @@ license = "MIT"
 authors = [
     { name = "Paul Fidika", email = "paul@fidika.com" }
 ]
+keywords = ["ai", "ml", "model-conversion", "quantization", "huggingface", "cozy"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 requires-python = ">=3.11"
 dependencies = [
-    "gen-worker",
+    "gen-worker>=0.11.2,<0.12",
     "huggingface-hub>=0.26.0",
     "requests>=2.32.0",
     "msgspec>=0.18.6",
     "blake3>=1.0.0",
     "gguf>=0.10.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/cozy-creator/python-gen-worker"
+Repository = "https://github.com/cozy-creator/python-gen-worker"
+Issues = "https://github.com/cozy-creator/python-gen-worker/issues"
 
 [project.optional-dependencies]
 # torch/safetensors are required for any conversion that touches tensors


### PR DESCRIPTION
## Summary
- `cozy-convert` gen-worker dep goes from a bare `gen-worker` (workspace-resolved in dev) to `gen-worker>=0.11.2,<0.12` — a plain PyPI version floor. Verified the built wheel's METADATA carries `Requires-Dist: gen-worker<0.12,>=0.11.2` (no git/workspace ref), and that it `pip install`s standalone in a fresh venv resolving gen-worker from PyPI, with `from cozy_convert import publish_flavors, ProducedFlavor, Source` importing clean.
- Added PyPI metadata cozy-convert was missing: classifiers, keywords, `[project.urls]`. Description/license/readme/version (0.1.0) were already set.
- Name check: `cozy-convert` is unclaimed on PyPI (404).
- Paul still has to run the actual `uv publish` — tracked in HUMAN_MUST_DO.md, not part of this PR.

## Test plan
- [x] `uv build --package cozy-convert` produces a wheel; inspected METADATA directly
- [x] Fresh venv `pip install dist/cozy_convert-0.1.0-py3-none-any.whl` + import smoke test
- [x] `uv run --extra dev pytest` in packages/cozy_convert: 111 passed, 8 deselected (integration)

CI's torch-missing red is a known pre-existing gap, unrelated to this change.