### PR TITLE
fix(models): host-RAM admission + off-loop snapshot materialization — end the heartbeat-stall livelock (gw#407)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -36,7 +36,7 @@ from .capability import HardwareUnmetError, InsufficientDiskError
 from .input_assets import cleanup_input_assets, materialize_input_assets
 from .models import disk_gc
 from .models import residency as residency_mod
-from .models.memory import estimate_cuda_resident_gb
+from .models.memory import estimate_cuda_resident_gb, get_available_ram_gb
 from .models.cache_paths import tensorhub_cas_dir
 from .models.download import ensure_local
 from .models.errors import UrlExpiredError
@@ -437,7 +437,10 @@ class ModelStore:
                         progress=_progress,
                     )
                     self.residency.track_disk(ref, path)
-                    self._index.record(ref, path, disk_gc.tree_bytes(path))
+                    # tree_bytes stats every file — off-loop (gw#407: no
+                    # multi-GB directory walks on the event loop).
+                    size = await asyncio.to_thread(disk_gc.tree_bytes, path)
+                    self._index.record(ref, path, size)
                     return path
                 except Exception as exc:
                     terminal = _is_terminal_download_error(exc) or attempt >= _DOWNLOAD_RETRIES
@@ -685,8 +688,10 @@ class Executor:
             return instance
 
     def _mark_setup_failed(self, rec: _ClassRecord, exc: BaseException) -> None:
-        if isinstance(exc, InsufficientDiskError):
-            return  # transient: disk GC frees space; the next LOAD retries
+        if isinstance(exc, (InsufficientDiskError, RetryableError)):
+            # Transient pressure (disk GC frees space / warm-tier RAM drains):
+            # fail the op RETRYABLE, never disable the function.
+            return
         if isinstance(exc, HardwareUnmetError):
             reason = getattr(exc, "reason", "hardware_unmet")
             axes = {str(k): str(v) for k, v in (exc.axes() or {}).items()}
@@ -715,6 +720,7 @@ class Executor:
         # Loads serialize: concurrent setups would cross-contaminate each
         # other's allocator deltas and place_pipeline's free-VRAM reads.
         async with self._load_lock:
+            await self._ensure_host_ram_for(spec, paths)
             await self._make_room_for(spec, setup_slots)
             instance = spec.cls()
             setup = getattr(instance, "setup", None)
@@ -805,6 +811,30 @@ class Executor:
                             )
         for ref in refs:
             res.touch(ref)
+
+    async def _ensure_host_ram_for(self, spec: EndpointSpec, paths: Dict[str, str]) -> None:
+        """Load-size-aware host-RAM admission (gw#407). ``from_pretrained``
+        stages the full weight set in host RAM before placement; loading into
+        a nearly-full host pushes it into reclaim-thrash that stalls the whole
+        process — including gRPC keepalive acks — so the hub disconnects and
+        requeues in a livelock (J17: 16 SDXL variants on a 31GB host). Free
+        warm RAM-tier LRU pipelines first; when even that cannot cover the
+        incoming bytes plus the floor, fail RETRYABLE instead of thrashing."""
+        if not paths:
+            return
+        incoming = 0
+        for p in paths.values():
+            incoming += await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
+        if incoming <= 0:
+            return
+        if await asyncio.to_thread(self.store.residency.make_room_ram, incoming):
+            return
+        avail = get_available_ram_gb()
+        raise RetryableError(
+            f"insufficient host RAM to load {spec.name}: "
+            f"~{incoming / _GiB:.1f}GiB incoming, {avail:.1f}GiB available "
+            "after releasing the warm tier"
+        )
 
     async def _make_room_for(self, spec: EndpointSpec, setup_slots: List[str]) -> None:
         """Evict idle LRU pipelines before loading instead of degrading the

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -209,26 +209,13 @@ class CozySnapshotDownloader:
         try:
             _log.info("snapshot_build_start digest=%s files=%d", res.snapshot_digest[:16], len(res.files))
             await self._ensure_blobs(blobs_root, res.files, progress=progress)
-
-            tmp = snaps_root / f"{res.snapshot_digest}.building"
-            if tmp.exists():
-                shutil.rmtree(tmp)
-            tmp.mkdir(parents=True, exist_ok=True)
-
-            self._reassemble_chunked(blobs_root, tmp, res.files)
-            self._materialize_regular(blobs_root, tmp, res.files)
-
-            # Atomic rename; handle race with concurrent builder.
-            if snap_dir.exists():
-                shutil.rmtree(tmp, ignore_errors=True)
-            else:
-                try:
-                    tmp.rename(snap_dir)
-                except OSError:
-                    shutil.rmtree(tmp, ignore_errors=True)
-                    if not snap_dir.exists():
-                        raise
-
+            # Materialization copies/concatenates multi-GB trees — strictly
+            # off the event loop (gw#407: a loop blocked for the duration of
+            # a snapshot build cannot answer the hub; under page-cache
+            # pressure that IO takes minutes).
+            await asyncio.to_thread(
+                self._materialize_snapshot, blobs_root, snaps_root, snap_dir, res
+            )
             _log.info("snapshot_build_done digest=%s", res.snapshot_digest[:16])
             return snap_dir
         except BaseException as exc:
@@ -243,6 +230,34 @@ class CozySnapshotDownloader:
                 if _SNAP_ENTRIES.get(res.snapshot_digest) is entry:
                     del _SNAP_ENTRIES[res.snapshot_digest]
             entry.event.set()
+
+    def _materialize_snapshot(
+        self,
+        blobs_root: Path,
+        snaps_root: Path,
+        snap_dir: Path,
+        res: WorkerResolvedRepo,
+    ) -> None:
+        """Blocking build phase (worker thread): reassemble + hardlink into a
+        ``.building`` dir, then atomically rename into place."""
+        tmp = snaps_root / f"{res.snapshot_digest}.building"
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        tmp.mkdir(parents=True, exist_ok=True)
+
+        self._reassemble_chunked(blobs_root, tmp, res.files)
+        self._materialize_regular(blobs_root, tmp, res.files)
+
+        # Atomic rename; handle race with concurrent builder.
+        if snap_dir.exists():
+            shutil.rmtree(tmp, ignore_errors=True)
+        else:
+            try:
+                tmp.rename(snap_dir)
+            except OSError:
+                shutil.rmtree(tmp, ignore_errors=True)
+                if not snap_dir.exists():
+                    raise
 
     # ------------------------------------------------------------------
     # Blob download (deduplicated, parallel)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -70,6 +70,16 @@ def get_available_ram_gb() -> float:
         return 0.0
 
 
+def get_total_ram_gb() -> float:
+    """Total system RAM (adaptive RAM-floor input). 0.0 if psutil missing."""
+    try:
+        import psutil
+
+        return float(psutil.virtual_memory().total) / float(1024**3)
+    except Exception:
+        return 0.0
+
+
 def cuda_allocated_bytes(device_index: Optional[int] = None) -> int:
     """``torch.cuda.memory_allocated`` (0 without CUDA). Deltas across a load
     are the measured VRAM footprint reported in ModelEvent.vram_bytes."""
@@ -651,5 +661,6 @@ __all__ = [
     "cuda_allocated_bytes",
     "get_available_vram_gb",
     "get_available_ram_gb",
+    "get_total_ram_gb",
     "flush_memory",
 ]

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -36,6 +36,7 @@ from .memory import (
     estimate_pipeline_size_gb,
     flush_memory,
     get_available_ram_gb,
+    get_total_ram_gb,
     repair_device_placement,
 )
 
@@ -45,8 +46,19 @@ _GiB = 1024 ** 3
 # Free-VRAM slack preserved beyond the requested headroom (activations).
 _VRAM_MARGIN_BYTES = 2 * _GiB
 # Host-RAM floor below which the warm RAM tier is refused (don't push the
-# host into swap); demote() then fails and the owner tears down instead.
+# host into reclaim-thrash: a thrashing host stalls the whole process incl.
+# gRPC keepalive acks -> hub disconnect livelock, gw#407); demote() then
+# fails and the owner tears down instead. Small hosts use an adaptive floor
+# (a fraction of total RAM) so dev boxes are not gated out entirely.
 _RAM_FLOOR_GB = 8.0
+_RAM_FLOOR_FRACTION = 0.2
+
+
+def _effective_ram_floor_gb() -> float:
+    total = get_total_ram_gb()
+    if total <= 0:
+        return _RAM_FLOOR_GB
+    return min(_RAM_FLOOR_GB, max(1.0, total * _RAM_FLOOR_FRACTION))
 
 # Residency event states (mirrors the wire ModelEvent vocabulary).
 ON_DISK = "on_disk"
@@ -280,7 +292,20 @@ class Residency:
             e = self._entries.get(ref)
             if e is None or e.tier is not Tier.VRAM or e.pinned or e.refcount > 0:
                 return False
-            if not e.movable or get_available_ram_gb() < _RAM_FLOOR_GB:
+            if not e.movable:
+                return False
+            # Size-aware RAM floor (gw#407): demoting a pipeline of size X
+            # eats ~X host RAM — landing it must still leave the floor, or
+            # the host thrashes into the keepalive-stall livelock.
+            need_gb = float(e.vram_hint or e.vram_bytes) / _GiB
+            if need_gb <= 0.0:
+                need_gb = estimate_pipeline_size_gb(e.obj)
+            if get_available_ram_gb() - need_gb < _effective_ram_floor_gb():
+                logger.info(
+                    "residency: refusing VRAM->RAM demote of %s (~%.1fGiB into "
+                    "%.1fGiB available; floor %.1fGiB)",
+                    ref, need_gb, get_available_ram_gb(), _effective_ram_floor_gb(),
+                )
                 return False
             if self.pre_demote is not None:
                 try:
@@ -502,6 +527,43 @@ class Residency:
             if self.free_vram_bytes() >= target:
                 return True
         return self.free_vram_bytes() >= target
+
+    def lru_ram_victims(self) -> List[str]:
+        """Droppable warm RAM-tier refs, LRU first (pinned/executing excluded)."""
+        with self._lock:
+            candidates = [
+                e for e in self._entries.values()
+                if e.tier is Tier.RAM and e.obj is not None
+                and not e.pinned and e.refcount <= 0
+            ]
+            candidates.sort(key=lambda e: e.last_used)
+            return [e.ref for e in candidates]
+
+    def make_room_ram(self, needed_bytes: int) -> bool:
+        """Host-RAM admission for an incoming load of ``needed_bytes`` (gw#407):
+        release warm RAM-tier LRU entries to disk until available host RAM
+        covers the load plus the RAM floor. False means even an empty warm
+        tier cannot make the load safe — the caller must refuse the load
+        (RETRYABLE) instead of thrashing the host into the keepalive-stall
+        livelock (J17: 16 SDXL variants on a 31GB host)."""
+        floor_bytes = int(_effective_ram_floor_gb() * _GiB)
+        target = int(needed_bytes) + floor_bytes
+
+        def _avail() -> int:
+            return int(get_available_ram_gb() * _GiB)
+
+        if _avail() >= target:
+            return True
+        for ref in self.lru_ram_victims():
+            if not self.release_to_disk(ref):
+                continue
+            logger.info(
+                "residency: released warm %s to disk for %d bytes of host-RAM headroom",
+                ref, needed_bytes,
+            )
+            if _avail() >= target:
+                return True
+        return _avail() >= target
 
     # ---- shared components (#335, folded in) -----------------------------------
 

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
+import threading
+import time
 from typing import Any, Dict, List, Optional
 
 from .config import Settings
@@ -20,6 +22,61 @@ from .transport import FatalTransportError, Transport
 logger = logging.getLogger(__name__)
 
 _SIGNAL_DRAIN_DEADLINE_MS = 30_000
+
+
+class _LoopStallWatchdog:
+    """Forensics for gw#407: a host in RAM reclaim-thrash stalls the whole
+    process — the event loop AND the gRPC C threads that answer h2 keepalive
+    pings — and the hub reaps the worker as dead within ~30s. This thread
+    pings the loop and logs LOUDLY (with available host RAM) when the ping
+    isn't serviced within ``warn_after_s``, so the stall episode is visible
+    in worker logs instead of only as a hub-side disconnect."""
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        interval_s: float = 5.0,
+        warn_after_s: float = 10.0,
+    ) -> None:
+        self._loop = loop
+        self._interval = interval_s
+        self._warn_after = warn_after_s
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="loop-stall-watchdog", daemon=True
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            ping = threading.Event()
+            t0 = time.monotonic()
+            try:
+                self._loop.call_soon_threadsafe(ping.set)
+            except RuntimeError:
+                return  # loop closed
+            while not ping.wait(self._warn_after):
+                if self._stop.is_set() or self._loop.is_closed():
+                    return
+                lag = time.monotonic() - t0
+                avail_gb = 0.0
+                try:
+                    from .models.memory import get_available_ram_gb
+
+                    avail_gb = get_available_ram_gb()
+                except Exception:
+                    pass
+                logger.warning(
+                    "event loop stalled for %.1fs (available host RAM %.1fGiB) — "
+                    "host under memory/IO pressure; hub keepalive may lapse (gw#407)",
+                    lag, avail_gb,
+                )
 
 
 class Worker:
@@ -92,6 +149,8 @@ class Worker:
             except (NotImplementedError, RuntimeError):
                 pass
 
+        watchdog = _LoopStallWatchdog(loop)
+        watchdog.start()
         startup = asyncio.create_task(self.lifecycle.startup(), name="startup")
         transport_task = asyncio.create_task(self.transport.run(), name="transport")
         try:
@@ -100,6 +159,7 @@ class Worker:
             logger.error("worker exiting: %s", exc)
             return 1
         finally:
+            watchdog.stop()
             startup.cancel()
             await asyncio.gather(startup, return_exceptions=True)
         if self.lifecycle.drained.is_set():

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -1,0 +1,258 @@
+"""Host-RAM admission (gw#407) — CPU-only, deterministic.
+
+J17 livelock: 16 SDXL variants on a 31GB host — every load/demote grew the
+warm RAM tier until the host entered reclaim-thrash, which stalled the whole
+process (including gRPC keepalive acks), so the hub disconnected, requeued the
+same job, and the cycle repeated. The RAM tier is now admission-controlled:
+demote is size-aware, loads free the warm tier first via make_room_ram, and a
+load that still cannot fit fails RETRYABLE instead of thrashing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.api.errors import RetryableError
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models import residency as residency_mod
+from gen_worker.models.residency import Residency, Tier
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+_GiB = 1024 ** 3
+
+
+def _res(events: list | None = None, budget_gb: int = 24) -> Residency:
+    ev = events if events is not None else []
+    return Residency(
+        on_event=lambda ref, state, vb: ev.append((ref, state, vb)),
+        vram_budget_bytes=budget_gb * _GiB,
+    )
+
+
+class _Pipe:
+    def to(self, device: str) -> "_Pipe":
+        return self
+
+
+# --------------------------------------------------------------------------- #
+# Size-aware demote floor
+# --------------------------------------------------------------------------- #
+
+
+def test_demote_floor_is_size_aware(monkeypatch) -> None:
+    """Demoting a 6GiB pipeline into 12GiB available must be refused on a
+    64GiB host (floor 8GiB): 12 - 6 < 8 would land in thrash territory."""
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 64.0)
+    res = _res()
+    res.track_vram("m/a", _Pipe(), vram_bytes=6 * _GiB)
+
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 12.0)
+    assert res.demote("m/a") is False
+    assert res.tier("m/a") is Tier.VRAM
+
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 20.0)
+    assert res.demote("m/a") is True
+    assert res.tier("m/a") is Tier.RAM
+
+
+def test_ram_floor_adapts_to_small_hosts(monkeypatch) -> None:
+    """A 16GiB dev box uses a fractional floor (3.2GiB), not the flat 8GiB —
+    otherwise small hosts could never hold a warm tier at all."""
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 16.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 10.0)
+    res = _res()
+    res.track_vram("m/a", _Pipe(), vram_bytes=6 * _GiB)
+    # 10 - 6 = 4 >= 3.2 floor -> allowed on the small host…
+    assert res.demote("m/a") is True
+    # …but the same numbers on a big host (8GiB floor) refuse.
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 64.0)
+    res2 = _res()
+    res2.track_vram("m/b", _Pipe(), vram_bytes=6 * _GiB)
+    assert res2.demote("m/b") is False
+
+
+# --------------------------------------------------------------------------- #
+# make_room_ram: warm-tier LRU release under host-RAM pressure
+# --------------------------------------------------------------------------- #
+
+
+def test_make_room_ram_releases_lru_until_headroom(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    res = _res()
+    sizes = {"m/a": 6.0, "m/b": 6.0}
+
+    def _avail() -> float:
+        # Warm entries eat their size; releases give it back.
+        used = sum(gb for ref, gb in sizes.items() if res.tier(ref) is Tier.RAM)
+        return 19.0 - used
+
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", _avail)
+    res.track_ram("m/a", _Pipe(), path=tmp_path)
+    res.touch("m/a")
+    res.track_ram("m/b", _Pipe(), path=tmp_path)
+
+    # Incoming 6GiB load: available 7, target 6 + 6.2 floor -> release LRU (a).
+    assert res.make_room_ram(6 * _GiB) is True
+    assert res.tier("m/a") is Tier.DISK
+    assert res.tier("m/b") is Tier.RAM  # only as much as needed was released
+
+
+def test_make_room_ram_skips_pinned_and_executing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 2.0)
+    res = _res()
+    res.track_ram("m/pinned", _Pipe(), path=tmp_path)
+    res.pin("m/pinned")
+    res.track_ram("m/busy", _Pipe(), path=tmp_path)
+    with res.executing("m/busy"):
+        assert res.make_room_ram(6 * _GiB) is False
+        assert res.tier("m/pinned") is Tier.RAM
+        assert res.tier("m/busy") is Tier.RAM
+
+
+# --------------------------------------------------------------------------- #
+# Executor load gate: refuse RETRYABLE instead of thrashing; never disable fn
+# --------------------------------------------------------------------------- #
+
+
+class _In(msgspec.Struct):
+    x: str
+
+
+class _FakePipe:
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        return cls()
+
+    def to(self, device: str) -> "_FakePipe":
+        return self
+
+
+def _spec(name: str, cls: type, models: dict) -> EndpointSpec:
+    return EndpointSpec(
+        name=name, method=cls.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=cls, attr_name="run", models=models,
+        resources=Resources(),
+    )
+
+
+def _executor(specs, tmp_path: Path) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        pass
+
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=24 * _GiB)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        store.residency.track_disk(ref, tmp_path)
+        return tmp_path
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return Executor(specs, _send, store=store)
+
+
+def test_setup_refused_retryable_when_host_ram_insufficient(tmp_path: Path, monkeypatch) -> None:
+    from gen_worker.models import disk_gc
+
+    class Endpoint:
+        def setup(self, m: _FakePipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    spec = _spec("ep", Endpoint, {"m": HF("acme/big")})
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda p: 6 * _GiB)
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 8.0)
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path)
+        with pytest.raises(RetryableError, match="insufficient host RAM"):
+            await ex.ensure_setup(spec)
+        # Transient pressure: the function is NOT disabled and not failed.
+        assert "ep" not in ex.unavailable
+        assert ex._classes[spec.instance_key].failed is None
+
+        # Pressure gone -> the retry loads normally.
+        monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 24.0)
+        inst = await ex.ensure_setup(spec)
+        assert isinstance(inst.m, _FakePipe)
+
+    asyncio.run(_run())
+
+
+def test_setup_frees_warm_tier_before_refusing(tmp_path: Path, monkeypatch) -> None:
+    from gen_worker.models import disk_gc
+
+    class A:
+        def setup(self, m: _FakePipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    class B:
+        def setup(self, m: _FakePipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    spec_a = _spec("a", A, {"m": HF("acme/a")})
+    spec_b = _spec("b", B, {"m": HF("acme/b")})
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda p: 6 * _GiB)
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+
+    async def _run() -> None:
+        ex = _executor([spec_a, spec_b], tmp_path)
+        res = ex.store.residency
+
+        monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 24.0)
+        await ex.ensure_setup(spec_a)
+        # CPU-only harness: the loaded pipeline books straight into the warm
+        # RAM tier — exactly the tier make_room_ram drains.
+        assert res.tier("acme/a") is Tier.RAM
+
+        # B's load: 7GiB available < 6 + 6.2 floor, but releasing warm A
+        # (6GiB) makes room -> the load proceeds, A lands on disk.
+        def _avail() -> float:
+            return 7.0 + (6.0 if res.tier("acme/a") is not Tier.RAM else 0.0)
+
+        monkeypatch.setattr(residency_mod, "get_available_ram_gb", _avail)
+        inst_b = await ex.ensure_setup(spec_b)
+        assert isinstance(inst_b.m, _FakePipe)
+        assert res.tier("acme/a") is Tier.DISK
+
+    asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------- #
+# Loop-stall watchdog: stall episodes are visible in worker logs
+# --------------------------------------------------------------------------- #
+
+
+def test_loop_stall_watchdog_logs_stall(caplog) -> None:
+    from gen_worker.worker import _LoopStallWatchdog
+
+    async def _main() -> None:
+        wd = _LoopStallWatchdog(
+            asyncio.get_running_loop(), interval_s=0.05, warn_after_s=0.1
+        )
+        wd.start()
+        await asyncio.sleep(0.1)  # let the first ping cycle start
+        time.sleep(0.5)  # block the loop (simulated reclaim stall)
+        await asyncio.sleep(0.05)
+        wd.stop()
+
+    with caplog.at_level(logging.WARNING, logger="gen_worker.worker"):
+        asyncio.run(_main())
+    assert any("event loop stalled" in r.message for r in caplog.records)


### PR DESCRIPTION
## gw#407 — RAM-pressure heartbeat-stall livelock

**Root cause (from the J17 forensics + contract §3):** liveness is HTTP/2 keepalive ONLY, answered by gRPC's C threads — no Python-level heartbeat exists to isolate. What stalled it on the 31GB/16-SDXL-variant host was *host-level reclaim-thrash*: every load and VRAM->RAM demote grew the warm RAM tier unchecked, available RAM hit zero, and the resulting page-cache/reclaim stalls froze the whole process (C threads included) past the 10s keepalive timeout. Hub disconnects, requeues the same head-of-queue job, worker recovers, loads the same model, stalls again — livelock (41 requeues observed; 35/70 requests lost). Two loop-blocking multi-GB IO paths made it worse.

**Fix — the worker never enters the thrash state:**
- `Residency.demote` is size-aware: landing a pipeline of size X in RAM must still leave the floor. Floor is adaptive — `min(8GiB, 20% of total)` — so small dev boxes keep a warm tier.
- New `Residency.make_room_ram(needed)`: releases warm RAM-tier LRU entries to disk until `incoming + floor` fits; the executor gates every setup load on it (`_ensure_host_ram_for`, load size = actual on-disk tree bytes) and fails **RETRYABLE** — function never disabled — when even an empty warm tier can't make the load safe. The hub reroutes instead of the worker wedging.
- Snapshot materialization (multi-GB reassemble/hardlink/rename) and the ref-index `tree_bytes` walk moved **off the event loop**.
- `_LoopStallWatchdog`: logs stall episodes with available host RAM, so the next keepalive lapse is diagnosable from worker logs (previously only visible as a hub-side disconnect).

Hub-side complement (rotate/backoff a request after N `worker_disconnected` requeues) is a tensorhub issue, cross-linked in the tracker.

**Tests:** `tests/test_ram_admission.py` — size-aware demote floor (+ adaptive small-host floor), make_room_ram LRU release/pinned-skip, executor refuse-RETRYABLE + warm-tier-drain-then-load, watchdog stall logging. The full 31GB/16-model reproduction is not feasible in CI; live verification = J17 single-worker burst re-run (e2e#127).

Full suite with torch: **421 passed, 2 skipped** (CI test job lacks torch; identical 5 pre-existing torch-quirk failures as master).