### PR TITLE
fix(models): quarantine corrupt snapshots — first-use verify, load-failure refetch, durable finalize (gw#408)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -187,6 +187,27 @@ def _model_op_error_vocab(exc: BaseException) -> str:
     return "load_failed"
 
 
+def _is_corrupt_load_error(exc: BaseException) -> bool:
+    """Errors a truncated/corrupt snapshot produces at weights-load time
+    (gw#408). Broad on purpose: the digest re-verify gate downstream
+    separates real corruption from code bugs — a verified-clean tree
+    re-raises the original error instead of quarantining."""
+    import errno as _errno
+    import struct as _struct
+
+    if isinstance(exc, OSError):
+        # e.g. "Unable to load weights from checkpoint file" (raised as
+        # OSError by transformers/diffusers), FileNotFoundError from a
+        # half-built tree. Resource exhaustion is not corruption.
+        return getattr(exc, "errno", None) not in (_errno.ENOSPC, _errno.ENOMEM)
+    if isinstance(exc, _struct.error):
+        return True
+    return type(exc).__name__ in (
+        "SafetensorError", "HeaderTooLarge", "MetadataIncompleteBuffer",
+        "UnpicklingError", "JSONDecodeError",
+    )
+
+
 def _is_terminal_download_error(exc: BaseException) -> bool:
     if isinstance(exc, (UrlExpiredError, InsufficientDiskError)):
         return True
@@ -242,6 +263,10 @@ class ModelStore:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._index = disk_gc.RefIndex(self._cache_dir)
         self._disk_free = disk_free_bytes_fn or self._default_disk_free
+        # Refs whose on-disk snapshot passed integrity verification THIS boot
+        # (gw#408): a cached snapshot is re-verified on first use per process
+        # so pod-churn corruption can never be trusted forever.
+        self._verified: set[str] = set()
 
     def _default_disk_free(self) -> int:
         p = Path(self._cache_dir)
@@ -396,8 +421,29 @@ class ModelStore:
             if snapshot is not None and snapshot.digest:
                 want = snapshot.digest.split(":", 1)[-1].strip().lower()
             if cached is not None and cached.exists() and (not want or cached.name == want):
-                self._index.touch(ref)
-                return cached
+                if ref in self._verified:
+                    self._index.touch(ref)
+                    return cached
+                # First use this boot: verify before trusting (gw#408). A
+                # pod-churn-truncated snapshot used to fatal every load until
+                # a manual delete; now it is quarantined + re-materialized.
+                ok, bad = await asyncio.to_thread(
+                    self._verify_snapshot_tree, cached, snapshot
+                )
+                if ok:
+                    self._verified.add(ref)
+                    self._index.touch(ref)
+                    return cached
+                logger.error(
+                    "snapshot for %s failed first-use verification "
+                    "(%d bad files); quarantining and re-materializing",
+                    ref, len(bad),
+                )
+                # Quarantine emits EVICTED; the re-download below emits
+                # DOWNLOADING/ON_DISK (or FAILED on a terminal error) — the
+                # hub sees the true story, not a spurious FAILED.
+                await asyncio.to_thread(self._quarantine_snapshot, ref, cached, bad)
+                # fall through to a fresh download below
             if snapshot is not None and snapshot.files:
                 # Sizes are known up front for tensorhub snapshots: gate on
                 # disk headroom, GC-ing LRU refs first (#370).
@@ -441,6 +487,8 @@ class ModelStore:
                     # multi-GB directory walks on the event loop).
                     size = await asyncio.to_thread(disk_gc.tree_bytes, path)
                     self._index.record(ref, path, size)
+                    # Fresh downloads were digest-verified by the downloader.
+                    self._verified.add(ref)
                     return path
                 except Exception as exc:
                     terminal = _is_terminal_download_error(exc) or attempt >= _DOWNLOAD_RETRIES
@@ -453,6 +501,95 @@ class ModelStore:
                     await asyncio.sleep(delay)
                     delay *= 4
             raise RuntimeError("unreachable")
+
+    # ---- snapshot integrity (gw#408) -------------------------------------------
+
+    def _verify_snapshot_tree(
+        self, path: Path, snapshot: Optional[pb.Snapshot]
+    ) -> Tuple[bool, List[str]]:
+        """Integrity of a materialized snapshot (worker thread; blocking IO).
+
+        With a resolved manifest every regular file is checked against its
+        declared size AND blake3 digest; files the manifest cannot cover
+        (reassembled chunked originals, merged single-file checkpoints) plus
+        manifest-less trees (hf/civitai) get the structural safetensors check
+        (header parses + every declared tensor byte present). Returns
+        ``(ok, bad_digests)`` — the digests name blobs to quarantine."""
+        from .models.cozy_cas import _blake3_file
+        from .models.cozy_snapshot import _is_part_file, _is_parts_manifest, _norm_rel_path
+        from .models.loading import safetensors_file_valid
+
+        p = Path(path)
+        bad: List[str] = []
+        covered: set[Path] = set()
+        files = list(snapshot.files) if snapshot is not None else []
+        if files and p.is_dir():
+            for f in files:
+                if _is_parts_manifest(f.path) or _is_part_file(f.path):
+                    continue  # not materialized: parts live only in blobs/
+                try:
+                    dst = p / _norm_rel_path(f.path)
+                except ValueError:
+                    continue
+                covered.add(dst)
+                digest = (f.blake3 or "").strip().lower()
+                try:
+                    if not dst.exists():
+                        raise ValueError("missing")
+                    if f.size_bytes and dst.stat().st_size != int(f.size_bytes):
+                        raise ValueError("size mismatch")
+                    if digest and _blake3_file(dst).lower() != digest:
+                        raise ValueError("blake3 mismatch")
+                except (OSError, ValueError) as exc:
+                    logger.warning("snapshot file %s/%s corrupt: %s", p.name, f.path, exc)
+                    bad.append(digest or f.path)
+        try:
+            candidates = [p] if p.is_file() else sorted(p.rglob("*.safetensors"))
+        except OSError:
+            candidates = []
+        for st in candidates:
+            if st in covered or st.suffix != ".safetensors":
+                continue
+            if not safetensors_file_valid(st):
+                logger.warning("snapshot file %s structurally invalid (truncated?)", st)
+                bad.append(str(st.relative_to(p)) if st != p else st.name)
+        return (not bad, bad)
+
+    def _quarantine_snapshot(self, ref: str, path: Path, bad: List[str]) -> None:
+        """Evict + delete a corrupt materialization AND the corrupt blobs it
+        was built from, so re-materialization re-downloads instead of
+        re-linking the same bad bytes. Emits EVICTED via residency."""
+        from .models.cozy_snapshot import delete_blobs
+
+        self._verified.discard(ref)
+        self.residency.evict(ref, force=True)
+        disk_gc.delete_ref_bytes(ref, Path(path), self._cache_dir)
+        delete_blobs(self._cache_dir, [d for d in bad if "/" not in d and "." not in d])
+        disk_gc.sweep_orphan_blobs(self._cache_dir)
+        self._index.remove(ref)
+
+    async def refetch_corrupt(
+        self, ref: str, snapshot: Optional[pb.Snapshot] = None, *, binding: Any = None
+    ) -> Optional[Path]:
+        """Load-failure path (gw#408): a weights load failed with a
+        corruption-shaped error — digest-verify the snapshot. A clean tree
+        returns None (the failure is NOT corruption; caller re-raises); a
+        dirty tree is quarantined and re-materialized, returning the fresh
+        path for exactly one load retry."""
+        path = self.residency.local_path(ref) or self._index.path(ref)
+        if path is None:
+            return None
+        async with self._lock(ref):
+            ok, bad = await asyncio.to_thread(self._verify_snapshot_tree, Path(path), snapshot)
+            if ok:
+                self._verified.add(ref)
+                return None
+            logger.error(
+                "load failure traced to corrupt snapshot for %s (%d bad files); "
+                "quarantining and re-materializing", ref, len(bad),
+            )
+            await asyncio.to_thread(self._quarantine_snapshot, ref, Path(path), bad)
+        return await self.ensure_local(ref, snapshot, binding=binding)
 
     @staticmethod
     def _error_vocab(exc: BaseException) -> str:
@@ -731,7 +868,7 @@ class Executor:
             if callable(setup):
                 kwargs, loaded = await self._injection_kwargs(
                     spec, setup, paths, server=rec.server,
-                    compile_artifact=compile_artifact)
+                    compile_artifact=compile_artifact, snapshots=snapshots)
                 if asyncio.iscoroutinefunction(setup):
                     await setup(**kwargs)
                 else:
@@ -922,6 +1059,7 @@ class Executor:
         *,
         server: Any = None,
         compile_artifact: Optional[Path] = None,
+        snapshots: Optional[Dict[str, pb.Snapshot]] = None,
     ) -> Tuple[Dict[str, Any], Dict[str, Tuple[Any, int]]]:
         """Typed injection: each slot receives exactly what its ``setup``
         annotation says — a ``str``/``Path`` local path, or a constructed
@@ -959,10 +1097,34 @@ class Executor:
                 dtype = str(getattr(binding, "dtype", "") or "")
                 storage_dtype = str(getattr(binding, "storage_dtype", "") or "")
                 before = self._vram_allocated()
-                pipe = await asyncio.to_thread(
-                    load_from_pretrained, ann, path, dtype=dtype,
-                    storage_dtype=storage_dtype,
-                )
+                try:
+                    pipe = await asyncio.to_thread(
+                        load_from_pretrained, ann, path, dtype=dtype,
+                        storage_dtype=storage_dtype,
+                    )
+                except Exception as exc:
+                    # Corruption-shaped load failure (gw#408): digest-verify
+                    # the snapshot; quarantine + re-materialize + retry ONCE
+                    # when corruption is confirmed, re-raise otherwise.
+                    fresh: Optional[Path] = None
+                    if binding is not None and _is_corrupt_load_error(exc):
+                        ref = wire_ref(binding)
+                        fresh = await self.store.refetch_corrupt(
+                            ref, (snapshots or {}).get(ref), binding=binding
+                        )
+                    if fresh is None:
+                        raise
+                    logger.warning(
+                        "weights load for slot %r failed on a corrupt snapshot "
+                        "(%s: %s); retrying once after re-materialization",
+                        slot, type(exc).__name__, exc,
+                    )
+                    path = str(fresh)
+                    paths[slot] = path
+                    pipe = await asyncio.to_thread(
+                        load_from_pretrained, ann, path, dtype=dtype,
+                        storage_dtype=storage_dtype,
+                    )
                 # Worker-owned placement/offload policy: one decider for the
                 # whole worker; endpoints never write device/offload code.
                 await asyncio.to_thread(place_pipeline, pipe)

--- a/src/gen_worker/models/cozy_cas.py
+++ b/src/gen_worker/models/cozy_cas.py
@@ -217,9 +217,47 @@ def _download_one_file_sync(
             tmp.unlink(missing_ok=True)
             raise ValueError("blake3 mismatch")
 
-    # Atomic finalize.
+    # Durable atomic finalize (gw#408): rename is only atomic in the
+    # NAMESPACE — a pod hard-kill after the rename but before writeback
+    # persisted a complete-looking blob with truncated/zero data pages,
+    # which then poisoned every snapshot built from it. fsync data before
+    # the rename and the directory entry after.
+    fsync_file(tmp)
     tmp.replace(dst)
+    fsync_dir(dst.parent)
     log.info("download_done path=%s size=%s", dst.name, _human_size(actual_size))
+
+
+def fsync_file(path: Path) -> None:
+    """Force a file's data to stable storage (read-only fd works on Linux)."""
+    import os
+
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def fsync_dir(path: Path) -> None:
+    """Persist a directory entry (the rename itself) to stable storage."""
+    import os
+
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
 
 
 def _blake3_file(path: Path, chunk_size: int = _DOWNLOAD_CHUNK_BYTES) -> str:

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -258,6 +258,10 @@ class CozySnapshotDownloader:
                 shutil.rmtree(tmp, ignore_errors=True)
                 if not snap_dir.exists():
                     raise
+            else:
+                from .cozy_cas import fsync_dir
+
+                fsync_dir(snaps_root)  # persist the rename itself (gw#408)
 
     # ------------------------------------------------------------------
     # Blob download (deduplicated, parallel)
@@ -327,11 +331,11 @@ class CozySnapshotDownloader:
             digest = f.blake3.strip().lower()
             dst = _blob_path(blobs_root, digest)
             dst.parent.mkdir(parents=True, exist_ok=True)
-            if dst.exists():
+            if self._blob_usable(dst, f):
                 _log.info("blob_cached path=%s digest=%s", f.path, digest[:16])
                 return
             async with sem:
-                if dst.exists():
+                if self._blob_usable(dst, f):
                     return
                 _log.info("blob_download_start path=%s size=%s digest=%s",
                           f.path, f.size_bytes, digest[:16])
@@ -359,6 +363,26 @@ class CozySnapshotDownloader:
                 _log.info("blob_download_done path=%s digest=%s", f.path, digest[:16])
 
         await asyncio.gather(*(_dl(f) for f in unique))
+
+    @staticmethod
+    def _blob_usable(dst: Path, f: WorkerResolvedRepoFile) -> bool:
+        """A cached blob is only reusable at the manifest's size (gw#408): a
+        truncated blob from a pre-durability build must be re-downloaded, not
+        silently rebuilt into every future snapshot."""
+        try:
+            if not dst.exists():
+                return False
+            expected = int(f.size_bytes or 0)
+            if expected and dst.stat().st_size != expected:
+                _log.warning(
+                    "blob_corrupt path=%s digest=%s size=%d expected=%d; re-downloading",
+                    f.path, f.blake3[:16], dst.stat().st_size, expected,
+                )
+                dst.unlink(missing_ok=True)
+                return False
+            return True
+        except OSError:
+            return False
 
     @staticmethod
     def _check_disk_headroom(blobs_root: Path, missing_bytes: int) -> None:
@@ -419,6 +443,8 @@ class CozySnapshotDownloader:
                     with open(part_blob, "rb") as in_f:
                         shutil.copyfileobj(in_f, out_f)
                     total_written += part_size
+                out_f.flush()
+                os.fsync(out_f.fileno())  # durable before the snapshot rename (gw#408)
 
             _log.info("reassemble_done file=%s total_size=%s", original_path, total_written)
 
@@ -439,6 +465,21 @@ class CozySnapshotDownloader:
             src = _blob_path(blobs_root, f.blake3)
             _try_hardlink_or_copy(src, dst)
 
+
+
+def delete_blobs(base_dir: Path, digests: Any) -> None:
+    """Remove specific CAS blobs (quarantine of digest-mismatched content,
+    gw#408) so a re-materialization re-downloads them instead of re-linking
+    the same corrupt bytes."""
+    blobs_root = Path(base_dir) / "blobs"
+    for raw in digests or ():
+        digest = _strip_blake3_prefix(str(raw or "")).strip().lower()
+        if len(digest) < 4:
+            continue
+        try:
+            _blob_path(blobs_root, digest).unlink(missing_ok=True)
+        except OSError:
+            continue
 
 
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -66,6 +66,38 @@ _SAFETENSORS_DTYPE_NAMES = {
 _MAX_SAFETENSORS_HEADER_BYTES = 100 << 20
 
 
+def safetensors_file_valid(path: Path) -> bool:
+    """Cheap structural integrity check for one ``.safetensors`` file: the
+    header must parse and the file must contain every declared tensor byte.
+    Catches truncation (pod-churn-interrupted writes, gw#408) without hashing;
+    zero-page corruption inside tensor data needs the digest check instead."""
+    import struct
+
+    try:
+        p = Path(path)
+        size = p.stat().st_size
+        with open(p, "rb") as f:
+            raw = f.read(8)
+            if len(raw) < 8:
+                return False
+            (n,) = struct.unpack("<Q", raw)
+            if n <= 0 or n > _MAX_SAFETENSORS_HEADER_BYTES or 8 + n > size:
+                return False
+            header = json.loads(f.read(n))
+        if not isinstance(header, dict):
+            return False
+        data_end = 0
+        for key, value in header.items():
+            if key == "__metadata__":
+                continue
+            if not isinstance(value, dict) or "data_offsets" not in value:
+                return False
+            data_end = max(data_end, int(value["data_offsets"][1]))
+        return size >= 8 + n + data_end
+    except (OSError, ValueError, KeyError, TypeError):
+        return False
+
+
 def detect_on_disk_dtype(model_path: Path) -> str:
     """Majority weight dtype across the snapshot's safetensors headers
     ("bf16" / "fp16" / "fp32" / "fp8", "" when undetectable). Hub bindings
@@ -274,7 +306,16 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
 
     merged = snapshot_dir / index_path.name[: -len(".index.json")]
     if merged.exists():
-        return merged
+        if safetensors_file_valid(merged):
+            return merged
+        # A pod kill mid-writeback can persist a truncated merged file that
+        # was then trusted forever — every load fataled with "Unable to load
+        # weights from checkpoint file" until manual delete (gw#408).
+        logger.warning(
+            "cached merged checkpoint %s is structurally invalid (truncated?); re-merging",
+            merged.name,
+        )
+        merged.unlink(missing_ok=True)
     with open(index_path) as f:
         index = json.load(f)
     weight_map: Dict[str, str] = index.get("weight_map") or {}
@@ -318,6 +359,10 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
                         raise ValueError(f"short read in {shard_path}")
                     out.write(buf)
                     remaining -= len(buf)
+        out.flush()
+        import os
+
+        os.fsync(out.fileno())  # durable before rename (gw#408)
     tmp.rename(merged)
     logger.info("reassembled sharded single-file checkpoint: %s (%d shards, %d tensors, %d bytes)",
                 merged.name, len(shard_names), len(entries), offset)
@@ -503,6 +548,7 @@ __all__ = [
     "get_torch_dtype",
     "detect_diffusers_variant",
     "detect_on_disk_dtype",
+    "safetensors_file_valid",
     "ensure_quant_library_imported",
     "read_on_disk_quant_config",
     "synthesize_quantization_config",

--- a/src/gen_worker/s3_transfer.py
+++ b/src/gen_worker/s3_transfer.py
@@ -172,7 +172,13 @@ def download_file_with_grant(
             phase="sdk_download",
             retryable=False,
         )
+    # Durable atomic finalize (gw#408): see cozy_cas — data must hit stable
+    # storage before the rename, or a pod hard-kill persists a truncated blob.
+    from .models.cozy_cas import fsync_dir, fsync_file
+
+    fsync_file(tmp)
     os.replace(tmp, dest)
+    fsync_dir(dest.parent)
     return S3TransferResult(bucket=grant.bucket, key=grant.key, size_bytes=size, blake3=digest)
 
 

--- a/tests/test_snapshot_corruption.py
+++ b/tests/test_snapshot_corruption.py
@@ -1,0 +1,319 @@
+"""Corrupt disk snapshots are quarantined + re-materialized (gw#408).
+
+J17 flood: a pod-churn-interrupted write left truncated safetensors in the
+disk tier; every later load fataled ``OSError: Unable to load weights from
+checkpoint file`` (9 user-visible failures) and the snapshot was trusted
+forever. Now: snapshots are integrity-verified on first use per boot, a
+corruption-shaped load failure digest-verifies + quarantines + re-downloads
++ retries once, cached blobs are size-checked before reuse, and merged
+single-file checkpoints are structurally revalidated before reuse.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from pathlib import Path
+
+import msgspec
+import pytest
+from blake3 import blake3
+
+import gen_worker.models.cozy_snapshot as snap_mod
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor, ModelStore, _is_corrupt_load_error
+from gen_worker.models.loading import _single_file_checkpoint, safetensors_file_valid
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+def _tiny_safetensors(tag: bytes = b"\x00\x01\x02\x03") -> bytes:
+    header = {"w": {"dtype": "F32", "shape": [1], "data_offsets": [0, len(tag)]}}
+    hb = json.dumps(header, separators=(",", ":")).encode()
+    return struct.pack("<Q", len(hb)) + hb + tag
+
+
+def _snapshot(digest_hex: str, content: bytes) -> pb.Snapshot:
+    return pb.Snapshot(
+        digest=f"blake3:{digest_hex}",
+        files=[pb.SnapshotFile(
+            path="model.safetensors",
+            size_bytes=len(content),
+            blake3=blake3(content).hexdigest(),
+            url="http://example.invalid/blob",
+        )],
+    )
+
+
+def _wire_download(monkeypatch, content: bytes) -> dict:
+    calls = {"n": 0}
+
+    async def _fake_dl(url, dst, expected_size, expected_blake3, on_bytes=None):
+        calls["n"] += 1
+        dst.write_bytes(content)
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _fake_dl)
+    return calls
+
+
+async def _noop_emit(msg: pb.WorkerMessage) -> None:
+    pass
+
+
+# --------------------------------------------------------------------------- #
+# First-use-per-boot verification: truncation is quarantined + re-materialized
+# --------------------------------------------------------------------------- #
+
+
+def test_truncated_snapshot_is_quarantined_and_rematerialized(tmp_path: Path, monkeypatch) -> None:
+    content = _tiny_safetensors()
+    snap = _snapshot("11" * 32, content)
+    calls = _wire_download(monkeypatch, content)
+
+    store1 = ModelStore(_noop_emit, cache_dir=tmp_path)
+    path = asyncio.run(store1.ensure_local("e2e/sdxl-a", snap))
+    assert (path / "model.safetensors").read_bytes() == content
+    assert calls["n"] == 1
+
+    # Pod churn persists a truncated file (rename landed, data pages lost).
+    # The snapshot file hardlinks the CAS blob, so the blob is equally bad.
+    (path / "model.safetensors").write_bytes(content[:10])
+
+    # Fresh boot: rescan re-registers disk truth; first use re-verifies.
+    store2 = ModelStore(_noop_emit, cache_dir=tmp_path)
+    store2.rescan_disk()
+    path2 = asyncio.run(store2.ensure_local("e2e/sdxl-a", snap))
+    assert calls["n"] == 2  # quarantined + re-downloaded, no manual delete
+    assert (path2 / "model.safetensors").read_bytes() == content
+
+
+def test_clean_snapshot_verified_once_per_boot(tmp_path: Path, monkeypatch) -> None:
+    content = _tiny_safetensors()
+    snap = _snapshot("22" * 32, content)
+    calls = _wire_download(monkeypatch, content)
+
+    store = ModelStore(_noop_emit, cache_dir=tmp_path)
+    asyncio.run(store.ensure_local("e2e/sdxl-b", snap))
+    assert calls["n"] == 1
+
+    verifies = {"n": 0}
+    orig = ModelStore._verify_snapshot_tree
+
+    def _counting(self, path, snapshot):
+        verifies["n"] += 1
+        return orig(self, path, snapshot)
+
+    monkeypatch.setattr(ModelStore, "_verify_snapshot_tree", _counting)
+
+    # Same boot: already verified -> no re-hash, no re-download.
+    asyncio.run(store.ensure_local("e2e/sdxl-b", snap))
+    assert verifies["n"] == 0 and calls["n"] == 1
+
+    # New boot: exactly one verification for the cached tree.
+    store2 = ModelStore(_noop_emit, cache_dir=tmp_path)
+    store2.rescan_disk()
+    asyncio.run(store2.ensure_local("e2e/sdxl-b", snap))
+    assert verifies["n"] == 1 and calls["n"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Load-failure path: digest verify -> quarantine -> re-download -> retry once
+# --------------------------------------------------------------------------- #
+
+
+class _In(msgspec.Struct):
+    x: str
+
+
+class _WeightsPipe:
+    """Loads only when the on-disk weights match `expected` — the exact J17
+    failure shape otherwise."""
+
+    expected: bytes = b""
+
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        data = (Path(path) / "model.safetensors").read_bytes()
+        if data != cls.expected:
+            raise OSError("Unable to load weights from checkpoint file")
+        return cls()
+
+    def to(self, device):
+        return self
+
+
+class _WeightsEndpoint:
+    def setup(self, m: _WeightsPipe) -> None:
+        self.m = m
+
+    def run(self, ctx, payload: _In):  # pragma: no cover
+        return payload
+
+
+class _AlwaysOSError:
+    @classmethod
+    def from_pretrained(cls, path, **kwargs):
+        raise OSError("Unable to load weights from checkpoint file")
+
+    def to(self, device):  # pragma: no cover
+        return self
+
+
+class _AlwaysOSErrorEndpoint:
+    def setup(self, m: _AlwaysOSError) -> None:  # pragma: no cover
+        self.m = m
+
+    def run(self, ctx, payload: _In):  # pragma: no cover
+        return payload
+
+
+def test_corrupt_load_failure_refetches_and_retries_once(tmp_path: Path, monkeypatch) -> None:
+    content = _tiny_safetensors()
+    snap = _snapshot("33" * 32, content)
+    calls = _wire_download(monkeypatch, content)
+    ref = "e2e/sdxl-c"
+    monkeypatch.setattr(_WeightsPipe, "expected", content)
+
+    spec = EndpointSpec(
+        name="ep", method=_WeightsEndpoint.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=_WeightsEndpoint, attr_name="run",
+        models={"m": Hub(ref)}, resources=Resources(),
+    )
+
+    async def _run() -> None:
+        store = ModelStore(_noop_emit, cache_dir=tmp_path)
+        ex = Executor([spec], _noop_emit, store=store)
+        # Materialize once, then corrupt the weights IN PLACE and drop the
+        # verified marker (as a fresh boot would).
+        path = await store.ensure_local(ref, snap)
+        (path / "model.safetensors").write_bytes(b"garbage-that-parses-as-nothing")
+        store._verified.discard(ref)
+
+        # ensure_local short-circuits (digest name matches), the load blows
+        # up with the exact J17 OSError, and the executor digest-verifies,
+        # quarantines, re-downloads, and retries ONCE — setup succeeds.
+        inst = await ex.ensure_setup(spec, {ref: snap})
+        assert isinstance(inst.m, _WeightsPipe)
+        assert (path / "model.safetensors").read_bytes() == content
+
+    asyncio.run(_run())
+    assert calls["n"] == 2
+
+
+def test_non_corrupt_load_failure_is_reraised_not_quarantined(tmp_path: Path, monkeypatch) -> None:
+    """A clean tree + corruption-shaped error re-raises: the verify gate keeps
+    code bugs from triggering pointless quarantine/re-download loops."""
+    content = _tiny_safetensors()
+    snap = _snapshot("44" * 32, content)
+    calls = _wire_download(monkeypatch, content)
+    ref = "e2e/sdxl-d"
+
+    spec = EndpointSpec(
+        name="ep", method=_AlwaysOSErrorEndpoint.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=_AlwaysOSErrorEndpoint, attr_name="run",
+        models={"m": Hub(ref)}, resources=Resources(),
+    )
+
+    async def _run() -> None:
+        store = ModelStore(_noop_emit, cache_dir=tmp_path)
+        ex = Executor([spec], _noop_emit, store=store)
+        with pytest.raises(OSError, match="Unable to load weights"):
+            await ex.ensure_setup(spec, {ref: snap})
+
+    asyncio.run(_run())
+    assert calls["n"] == 1  # tree verified clean: NO re-download happened
+
+
+def test_corrupt_load_error_classifier() -> None:
+    import errno
+
+    assert _is_corrupt_load_error(OSError("Unable to load weights from checkpoint file"))
+    assert _is_corrupt_load_error(FileNotFoundError("model_index.json"))
+    assert _is_corrupt_load_error(json.JSONDecodeError("x", "doc", 0))
+    assert _is_corrupt_load_error(struct.error("unpack"))
+    nospace = OSError(errno.ENOSPC, "no space left on device")
+    assert not _is_corrupt_load_error(nospace)
+    assert not _is_corrupt_load_error(ValueError("bad dtype string"))
+    assert not _is_corrupt_load_error(RuntimeError("CUDA out of memory"))
+
+
+# --------------------------------------------------------------------------- #
+# Cached blobs and merged checkpoints are never trusted blindly
+# --------------------------------------------------------------------------- #
+
+
+def test_truncated_cached_blob_is_redownloaded_at_build(tmp_path: Path, monkeypatch) -> None:
+    content = _tiny_safetensors()
+    digest = blake3(content).hexdigest()
+    calls = _wire_download(monkeypatch, content)
+
+    # A pre-durability boot left a truncated blob at the final CAS path.
+    blob = tmp_path / "blobs" / "blake3" / digest[:2] / digest[2:4] / digest
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(content[:7])
+
+    from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+    from gen_worker.models.refs import TensorhubRef
+
+    resolved = {
+        "snapshot_digest": "55" * 32,
+        "files": [{"path": "model.safetensors", "size_bytes": len(content),
+                   "blake3": digest, "url": "http://example.invalid/blob"}],
+    }
+    out = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path, ref=TensorhubRef(owner="e2e", repo="tiny"),
+        resolved=resolved,
+    ))
+    assert calls["n"] == 1  # size-mismatched cached blob was NOT reused
+    assert (out / "model.safetensors").read_bytes() == content
+
+
+def _sharded_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "snap"
+    d.mkdir()
+    for name, tensor in (("shard-00001.safetensors", "a"), ("shard-00002.safetensors", "b")):
+        header = {tensor: {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}
+        hb = json.dumps(header, separators=(",", ":")).encode()
+        (d / name).write_bytes(struct.pack("<Q", len(hb)) + hb + b"\x0a\x0b\x0c\x0d")
+    (d / "model.safetensors.index.json").write_text(json.dumps({
+        "weight_map": {"a": "shard-00001.safetensors", "b": "shard-00002.safetensors"},
+    }))
+    return d
+
+
+def test_truncated_merged_checkpoint_is_remerged(tmp_path: Path) -> None:
+    d = _sharded_dir(tmp_path)
+    merged = _single_file_checkpoint(d)
+    assert merged is not None and merged.name == "model.safetensors"
+    assert safetensors_file_valid(merged)
+    good = merged.read_bytes()
+
+    # Pod kill mid-writeback: merged file exists but is truncated. Before the
+    # fix this file was returned forever ("Unable to load weights" loop).
+    merged.write_bytes(good[:20])
+    assert not safetensors_file_valid(merged)
+
+    again = _single_file_checkpoint(d)
+    assert again is not None
+    assert safetensors_file_valid(again)
+    assert again.read_bytes() == good
+
+
+def test_safetensors_file_valid(tmp_path: Path) -> None:
+    good = tmp_path / "ok.safetensors"
+    good.write_bytes(_tiny_safetensors())
+    assert safetensors_file_valid(good)
+
+    truncated = tmp_path / "short.safetensors"
+    truncated.write_bytes(_tiny_safetensors()[:12])
+    assert not safetensors_file_valid(truncated)
+
+    garbage = tmp_path / "garbage.safetensors"
+    garbage.write_bytes(b"not a safetensors file at all")
+    assert not safetensors_file_valid(garbage)
+
+    empty = tmp_path / "empty.safetensors"
+    empty.write_bytes(b"")
+    assert not safetensors_file_valid(empty)


### PR DESCRIPTION
## gw#408 — corrupt disk snapshot never digest-reverified

**Root cause:** two holes. (1) Finalize was atomic in the *namespace* only — no fsync before the rename, so a hard pod kill persisted complete-looking files (blobs, merged single-file checkpoints, reassembled chunked files) with truncated data. (2) Once on disk, a snapshot was trusted forever: `ensure_local` short-circuited on existence, cached blobs were reused blindly, and a cached merged checkpoint was returned without validation — so every load fataled `OSError: Unable to load weights from checkpoint file` until manual delete (9 user-visible J17 failures).

**Fix:**
- **Durable atomic finalize**: fsync data before rename + directory entry after, on the blob download path (`cozy_cas`), the S3-grant path, merged checkpoints, and chunk reassembly.
- **First-use-per-boot verification** (`ModelStore`): manifest files checked against declared size AND blake3; reassembled/merged/manifest-less files against a structural safetensors check (header parses, every declared tensor byte present). Failure ⇒ quarantine (evict + delete snapshot + delete the corrupt CAS blobs so re-materialization can't re-link them + EVICTED event) and re-materialize in place. Fresh downloads are digest-verified by the downloader and marked verified.
- **Load-failure path**: corruption-shaped errors (OSError/safetensors/json/struct — resource exhaustion excluded) digest-verify the tree; confirmed corruption ⇒ quarantine → re-download → retry the load exactly ONCE; a verified-clean tree re-raises the original error, so code bugs never trigger re-download loops.
- **Never trust caches blindly**: CAS blobs size-checked against the manifest before reuse; merged single-file checkpoints structurally revalidated before reuse (the exact shape of the J17 single-file-SDXL failures).

**Tests:** `tests/test_snapshot_corruption.py` — deliberately-truncated snapshot quarantined + re-materialized across a simulated boot; verified-once-per-boot; corrupt-load refetch-and-retry-once through the real `ensure_setup` path; clean-tree re-raise (no quarantine); truncated cached blob re-downloaded; truncated merged checkpoint re-merged; structural validator units.

Full suite with torch: **429 passed, 2 skipped** (CI test job lacks torch; identical 5 pre-existing torch-quirk failures as master).