### PR TITLE
fix(executor): scope host-RAM admission to worker-loaded slots (gw#407 follow-up)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -949,6 +949,26 @@ class Executor:
         for ref in refs:
             res.touch(ref)
 
+    @staticmethod
+    def _worker_loaded_slots(spec: EndpointSpec) -> set:
+        """Setup slots the WORKER materializes in host RAM (class-typed
+        annotations loaded via ``from_pretrained``). str/Path slots and
+        engine runtimes (vllm/llama-server) stream weights themselves and
+        must not be counted against the host-RAM admission gate."""
+        if spec.cls is None or spec.runtime:
+            return set()
+        setup = getattr(spec.cls, "setup", None)
+        if setup is None:
+            return set()
+        try:
+            hints = typing.get_type_hints(setup)
+        except Exception:
+            return set()
+        return {
+            name for name, ann in hints.items()
+            if isinstance(ann, type) and callable(getattr(ann, "from_pretrained", None))
+        }
+
     async def _ensure_host_ram_for(self, spec: EndpointSpec, paths: Dict[str, str]) -> None:
         """Load-size-aware host-RAM admission (gw#407). ``from_pretrained``
         stages the full weight set in host RAM before placement; loading into
@@ -956,12 +976,17 @@ class Executor:
         process — including gRPC keepalive acks — so the hub disconnects and
         requeues in a livelock (J17: 16 SDXL variants on a 31GB host). Free
         warm RAM-tier LRU pipelines first; when even that cannot cover the
-        incoming bytes plus the floor, fail RETRYABLE instead of thrashing."""
-        if not paths:
+        incoming bytes plus the floor, fail RETRYABLE instead of thrashing.
+
+        Only worker-loaded (pipeline-typed) slots count: tenant-owned and
+        engine-runtime slots do not stage full weight sets in host RAM."""
+        slots = self._worker_loaded_slots(spec)
+        if not paths or not slots:
             return
         incoming = 0
-        for p in paths.values():
-            incoming += await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
+        for slot, p in paths.items():
+            if slot in slots:
+                incoming += await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
         if incoming <= 0:
             return
         if await asyncio.to_thread(self.store.residency.make_room_ram, incoming):

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -235,6 +235,32 @@ def test_setup_frees_warm_tier_before_refusing(tmp_path: Path, monkeypatch) -> N
     asyncio.run(_run())
 
 
+def test_gate_ignores_tenant_owned_slots(tmp_path: Path, monkeypatch) -> None:
+    """str/Path-typed slots (tenant-owned loads, engine runtimes) must not be
+    counted: a 26GiB vllm model on a 32GiB host is NOT a from_pretrained
+    host-RAM staging load and must not be refused by the gate."""
+    from gen_worker.models import disk_gc
+
+    class Endpoint:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    spec = _spec("ep", Endpoint, {"model": HF("acme/huge-llm")})
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda p: 26 * _GiB)
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 32.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 28.0)
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path)
+        inst = await ex.ensure_setup(spec)  # gate skipped -> loads fine
+        assert inst.model  # slot injected as the local path
+
+    asyncio.run(_run())
+
+
 # --------------------------------------------------------------------------- #
 # Loop-stall watchdog: stall episodes are visible in worker logs
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follow-up to #118: the host-RAM gate counted every setup slot's on-disk bytes, but str/Path slots (tenant-owned loads) and engine runtimes (vllm/llama-server) stream weights themselves and never stage the full set in host RAM — a 26GiB LLM on a 32GiB host would have been refused RETRYABLE forever. The gate now counts only pipeline-typed (`from_pretrained`) slots, matching what the worker actually stages.

Test: `test_gate_ignores_tenant_owned_slots` (26GiB str-slot on a 32GiB host loads fine).

Full suite with torch: **430 passed, 2 skipped**.