### PR TITLE
fix(executor): VRAM gate tolerates the card-class driver/ECC reserve (gw#410)

### DIFF
--- a/packages/cozy_convert/src/cozy_convert/repackage.py
+++ b/packages/cozy_convert/src/cozy_convert/repackage.py
@@ -340,7 +340,10 @@ def singlefile_to_diffusers(
             }
         except Exception as exc:  # noqa: BLE001
             cfg = f" config={config}" if config else ""
-            errors.append(f"{pipeline_class}{cfg}: {exc}")
+            # single-line: the worker fatal path keeps only the first line,
+            # which hid 5 of 6 attempt errors (e2e #112 flux diagnosis).
+            flat = str(exc).replace("\n", " | ")
+            errors.append(f"{pipeline_class}{cfg}: {flat}")
             continue
 
     raise ConversionImplementationError(

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -609,10 +609,13 @@ class Executor:
                     f"requires SM {r.compute_capability:.1f}, detected {detected_cc:.1f}",
                     {"detected_sm": f"{detected_cc:.1f}", "required_sm": f"{float(r.compute_capability):.1f}"})
                 continue
-            # Compare on the rounded GiB: a "24GB" card reports ~23.99GiB via
-            # mem_get_info (driver/ECC reserve), which must not gate off
-            # functions declaring vram_gb=24.
-            if r.vram_gb is not None and total_vram_gb and round(total_vram_gb) < float(r.vram_gb):
+            # Declared vram_gb names a card class, not a byte budget: the
+            # driver/ECC reserve mem_get_info subtracts scales with card size
+            # (~0.01GiB on a 24GB RTX 4090, ~0.9GiB on an 80GB H100 PCIe —
+            # "detected 79GiB" must not gate off vram_gb=80, e2e#118 L1).
+            # Accept when detected VRAM is within 2% of the declaration.
+            if r.vram_gb is not None and total_vram_gb \
+                    and total_vram_gb < float(r.vram_gb) * 0.98:
                 self.unavailable[name] = (
                     "insufficient_vram",
                     f"requires {r.vram_gb:.0f}GiB VRAM, detected {total_vram_gb:.0f}GiB",

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -49,12 +49,27 @@ async def _noop_send(msg) -> None:  # pragma: no cover
 
 
 RTX_4090_TOTAL_BYTES = 25_757_220_864  # 23.99 GiB — what mem_get_info reports
+H100_PCIE_TOTAL_BYTES = 85_045_411_840  # 79.20 GiB — 80GB card minus driver/ECC reserve
 
 
 def test_gate_rounds_detected_gib_up_to_declared_24() -> None:
     ex = Executor([_spec("fits-24", 24.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
     assert "fits-24" not in ex.unavailable
+
+
+def test_gate_tolerates_80gb_card_reserve() -> None:
+    """H100 PCIe reports ~79.2GiB; must not gate off vram_gb=80 (e2e#118 L1)."""
+    ex = Executor([_spec("fits-80", 80.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": H100_PCIE_TOTAL_BYTES, "gpu_sm": "90"})
+    assert "fits-80" not in ex.unavailable
+
+
+def test_gate_still_blocks_next_class_down() -> None:
+    """A 48GB card is NOT an 80GB card — tolerance must stay narrow."""
+    ex = Executor([_spec("needs-80", 80.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": 48 * 1024**3, "gpu_sm": "89"})
+    assert ex.unavailable["needs-80"][0] == "insufficient_vram"
 
 
 def test_gate_still_blocks_genuinely_bigger_requirements() -> None:


### PR DESCRIPTION
Found live in e2e#118 run7 chapter L1 — the first LTX 2.3 inference attempt.

An 80GB H100 PCIe reports 79.20GiB via torch.cuda.mem_get_info (driver/ECC reserve scales with card size); the gate's round(total) < vram_gb comparison disabled every ltx-video-2.3 function (honest vram_gb=80 per ie#351) on exactly the SKU it targets, and the request burned 5 instant retryable attempts ("function unavailable: insufficient_vram", detected_vram_gb:79 required_vram_gb:80).

Declared vram_gb names a card class, not a byte budget: accept when detected VRAM is within 2% of the declaration. 24GB@24 passes, 79.2GiB@80 passes, 48GB@80 still gated.

Hub-side follow-up (assigning to a worker whose FnUnavailable signal it already logged) filed as th#626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)