### PR TITLE
refactor: one per-file hub upload engine — convert publish + worker saves share bytes-movement and /complete armor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
   torch-free (import-graph guard now covers `gen_worker.convert`). Docs:
   `docs/convert.md`.
 
+- **ONE per-file hub upload engine.** `HubClient` (`/commits` publishes) and
+  the worker save paths (`ctx.save_file` / `save_checkpoint` /
+  `open_checkpoint_stream`) now move bytes through the same
+  `presigned_upload.upload_entry_and_complete` (grant-or-parts dispatch,
+  hardened PutPool part transport, e2e#110 409-poll). The te#44 J9
+  network-severed /complete re-POST patience — previously convert-only — now
+  protects the worker save paths too. blake3 file hashing collapsed to the
+  one multithreaded `blake3_hash_file` (was 3 copies).
+
 ## 0.11.2
 
 - Republish: the 0.11.0 and 0.11.1 PyPI wheels were both built from a stale local checkout (19 commits behind master, mixed-commit tree) and lack `allow_lora`, `LoraOverlay`, and `inductor_counters`. No code changes vs 0.11.1 master; version bump only, publish from clean `origin/master` HEAD.

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -9,9 +9,12 @@ The write API is HF `create_commit`-shaped:
   → {revision_id, uploads: [{path, exists, upload_id, part_urls, part_size,
                              complete_url, ...}]}
 
-Then per non-dedup'd upload: PUT the parts, POST …/uploads/{id}/complete
-with the ETags, and finally POST …/commits/{revision_id}/finalize (no body;
-202 → poll). One commit == one checkpoint == one flavor.
+Then per non-dedup'd upload: move the bytes (R2 SDK grant or presigned
+multipart parts) and POST …/uploads/{id}/complete — both via the shared
+per-file engine ``gen_worker.presigned_upload.upload_entry_and_complete``
+(one implementation of the e2e#110 409-poll + te#44 J9 network-severed
+/complete armor) — and finally POST …/commits/{revision_id}/finalize
+(no body; 202 → poll). One commit == one checkpoint == one flavor.
 """
 
 from __future__ import annotations
@@ -27,34 +30,18 @@ from typing import Any, Callable, Mapping, Optional
 
 import requests
 
+from gen_worker.api.errors import ArtifactTransferError, AuthError
+
+# ONE blake3-file implementation library-wide (multithreaded, issue #269) and
+# ONE per-file upload engine (grant-or-parts + patient /complete).
+from gen_worker.presigned_upload import blake3_hash_file as blake3_file
+from gen_worker.presigned_upload import upload_entry_and_complete
+
 logger = logging.getLogger(__name__)
 
 _RETRY_ATTEMPTS = 5
 _RETRY_BASE_DELAY_S = 1.0
 _RETRY_MAX_DELAY_S = 30.0
-
-# tensorhub's /complete verifies the whole object synchronously (streams it
-# back from R2 and hashes it) before responding, holding a per-upload lock
-# for the duration. For large single files this can outlast whatever timeout
-# sits in front of tensorhub -- the client sees a 5xx/timeout on an attempt
-# that is still running server-side, retries, and races the first attempt
-# into 409 upload_complete_in_progress. Found live mirroring a ~6.94GB SDXL
-# checkpoint: the default 120s request timeout expired while the server was
-# still hashing, the retry got 409, and _upload_one raised immediately --
-# aborting the whole commit even though the first attempt was about to
-# succeed (e2e tracker #110).
-_COMPLETE_TIMEOUT_S = 600.0
-_COMPLETE_IN_PROGRESS_POLL_S = 5.0
-
-# A severed /complete connection is NOT fatal either: middleboxes on the
-# worker->hub path (NAT idle eviction, tunnel circuit caps) kill the idle
-# ~5-minute verify of multi-GB shards, so the client sees a network error
-# while the server may finish (sess.Finalized fast path answers the re-POST)
-# or may have aborted (a re-POST restarts the verify). Re-POST patiently —
-# each attempt can legitimately take a full verify. Found live twice on the
-# flux2-klein-4b clone (te#44 J9 runs 7+8: RemoteDisconnected at ~4m50s).
-_COMPLETE_NETWORK_RETRY_DELAY_S = 15.0
-_COMPLETE_NETWORK_MAX_WAIT_S = 1800.0
 
 _SESSION: Optional[requests.Session] = None
 
@@ -98,22 +85,6 @@ def _retry_after_s(resp: requests.Response) -> Optional[float]:
     return min(value, _RETRY_MAX_DELAY_S) if value > 0 else None
 
 
-def _error_code_of(resp: requests.Response) -> str:
-    """Best-effort extraction of the structured `error.code` field
-    (docs/api-conventions.md: `{"error": {"code": ..., ...}}`); "" if the
-    body isn't that shape."""
-    try:
-        body = resp.json() if resp.text else {}
-    except Exception:
-        return ""
-    if not isinstance(body, dict):
-        return ""
-    err = body.get("error")
-    if not isinstance(err, dict):
-        return ""
-    return str(err.get("code") or "")
-
-
 def _send_with_retries(what: str, send: Callable[[], requests.Response]) -> requests.Response:
     """Bounded retries on network errors, 429, and 5xx (honors Retry-After).
 
@@ -138,19 +109,6 @@ def _send_with_retries(what: str, send: Callable[[], requests.Response]) -> requ
         time.sleep(delay + random.uniform(0, delay * 0.1))
         delay = min(delay * 2, _RETRY_MAX_DELAY_S)
     raise HubPublishError(f"{what} failed after {_RETRY_ATTEMPTS} attempts")
-
-
-def blake3_file(path: Path, *, chunk: int = 8 * 1024 * 1024) -> str:
-    from blake3 import blake3
-
-    h = blake3()
-    with open(path, "rb") as f:
-        while True:
-            buf = f.read(chunk)
-            if not buf:
-                break
-            h.update(buf)
-    return h.hexdigest()
 
 
 @dataclass
@@ -242,33 +200,6 @@ class HubClient:
             out = {}
         return out if isinstance(out, dict) else {}
 
-    def _post_complete(self, complete_path: str, payload: dict) -> requests.Response:
-        """POST .../complete with a generous timeout (large single files
-        verify synchronously server-side, see _COMPLETE_TIMEOUT_S), then poll
-        through a 409 upload_complete_in_progress race instead of treating it
-        as fatal: /complete is idempotent once finalized (tensorhub's
-        sess.Finalized fast path returns the same success payload), so
-        re-POSTing catches up to whatever the in-flight attempt decides.
-        Network-severed attempts get the same treatment on a longer clock
-        (_COMPLETE_NETWORK_MAX_WAIT_S): each re-POST may re-run a full
-        multi-minute verify, so give it room instead of failing the commit."""
-        deadline = time.monotonic() + _COMPLETE_NETWORK_MAX_WAIT_S
-        while True:
-            try:
-                resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
-            except HubPublishError:
-                if time.monotonic() >= deadline:
-                    raise
-                logger.warning("POST %s network-severed; re-POSTing (idempotent complete)", complete_path)
-                time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
-                continue
-            if resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
-                if time.monotonic() >= deadline:
-                    return resp
-                time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
-                continue
-            return resp
-
     def _upload_one(self, repo_path: str, revision_id: str, entry: Mapping[str, Any],
                     local_path: Path) -> None:
         upload_id = str(entry.get("upload_id") or "").strip()
@@ -278,61 +209,21 @@ class HubClient:
             f"{repo_path}/commits/{urllib.parse.quote(revision_id, safe='')}"
             f"/uploads/{urllib.parse.quote(upload_id, safe='')}/complete"
         )
-
-        # SDK transfer-grant path (R2): the server returns a scoped temporary
-        # credential instead of presigned multipart part URLs. Upload the
-        # object directly with the S3 SDK, then complete with the transfer
-        # block (same wire shape gen_worker.presigned_upload uses for media).
-        grant_raw = entry.get("transfer_grant")
-        if isinstance(grant_raw, Mapping):
-            from gen_worker.s3_transfer import S3TransferGrant, upload_file_with_grant
-
-            grant = S3TransferGrant.from_mapping(grant_raw)
-            size_bytes = int(entry.get("size_bytes") or local_path.stat().st_size)
-            result = upload_file_with_grant(
+        # Byte movement + patient /complete ride the shared per-file engine
+        # (grant-or-parts dispatch, e2e#110 409-poll, te#44 J9 network
+        # patience, hardened PutPool part transport). The keepalive session
+        # protects the long idle server-side verify (NAT/conntrack eviction).
+        try:
+            upload_entry_and_complete(
                 file_path=local_path,
-                grant=grant,
-                blake3_hex=str(entry.get("blake3") or ""),
-                size_bytes=size_bytes,
+                entry=dict(entry),
+                complete_url=f"{self.base_url}{complete_path}",
+                headers=self._headers(),
+                session=_http_session(),
             )
-            resp = self._post_complete(complete_path, {"transfer": {
-                "mode": "s3_sdk",
-                "bucket": result.bucket,
-                "key": result.key,
-                "size_bytes": result.size_bytes,
-                "blake3": result.blake3,
-                "etag": result.etag,
-            }})
-            if resp.status_code < 200 or resp.status_code >= 300:
-                raise HubPublishError(
-                    f"upload complete failed ({resp.status_code}) for {entry.get('path')!r}: "
-                    f"{resp.text[:500]}")
-            return
-
-        part_urls = list(entry.get("part_urls") or [])
-        part_size = int(entry.get("part_size") or 0)
-        if not part_urls or part_size <= 0:
-            raise HubPublishError(f"commit upload entry missing presign data for {entry.get('path')!r}")
-        parts: list[dict[str, Any]] = []
-        with open(local_path, "rb") as f:
-            for i, url in enumerate(part_urls):
-                buf = f.read(part_size)
-                if not buf and i > 0:
-                    break
-                def _put(u: str = url, b: bytes = buf) -> requests.Response:
-                    return _http_session().put(u, data=b, timeout=self.timeout_s * 5)
-
-                resp = _send_with_retries(f"part PUT {entry.get('path')!r} #{i + 1}", _put)
-                if resp.status_code < 200 or resp.status_code >= 300:
-                    raise HubPublishError(
-                        f"part PUT failed ({resp.status_code}) for {entry.get('path')!r}")
-                etag = str(resp.headers.get("ETag") or "").strip().strip('"')
-                parts.append({"part_number": i + 1, "etag": etag})
-        resp = self._post_complete(complete_path, {"parts": parts})
-        if resp.status_code < 200 or resp.status_code >= 300:
+        except (ArtifactTransferError, AuthError) as exc:
             raise HubPublishError(
-                f"upload complete failed ({resp.status_code}) for {entry.get('path')!r}: "
-                f"{resp.text[:500]}")
+                f"upload failed for {entry.get('path')!r}: {exc}") from exc
 
     def _finalize(self, repo_path: str, revision_id: str, *, poll_timeout_s: float = 1800.0) -> dict[str, Any]:
         path = f"{repo_path}/commits/{urllib.parse.quote(revision_id, safe='')}/finalize"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -515,9 +515,9 @@ class ModelStore:
         manifest-less trees (hf/civitai) get the structural safetensors check
         (header parses + every declared tensor byte present). Returns
         ``(ok, bad_digests)`` — the digests name blobs to quarantine."""
-        from .models.cozy_cas import _blake3_file
         from .models.cozy_snapshot import _is_part_file, _is_parts_manifest, _norm_rel_path
         from .models.loading import safetensors_file_valid
+        from .presigned_upload import blake3_hash_file
 
         p = Path(path)
         bad: List[str] = []
@@ -538,7 +538,7 @@ class ModelStore:
                         raise ValueError("missing")
                     if f.size_bytes and dst.stat().st_size != int(f.size_bytes):
                         raise ValueError("size mismatch")
-                    if digest and _blake3_file(dst).lower() != digest:
+                    if digest and blake3_hash_file(dst).lower() != digest:
                         raise ValueError("blake3 mismatch")
                 except (OSError, ValueError) as exc:
                     logger.warning("snapshot file %s/%s corrupt: %s", p.name, f.path, exc)

--- a/src/gen_worker/models/cozy_cas.py
+++ b/src/gen_worker/models/cozy_cas.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from typing import Callable, Dict, Optional
 
 import requests
-from blake3 import blake3
 
 from ..capability import InsufficientDiskError
+from ..presigned_upload import blake3_hash_file
 from .errors import UrlExpiredError
 
 _log = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ def _download_one_file_sync(
             if expected_size and dst.stat().st_size != expected_size:
                 raise ValueError("size mismatch")
             if expected_blake3:
-                got = _blake3_file(dst)
+                got = blake3_hash_file(dst, chunk_size=_DOWNLOAD_CHUNK_BYTES)
                 if got.lower() != expected_blake3.lower():
                     raise ValueError("blake3 mismatch")
             log.info("download_cached path=%s size=%s", dst.name, _human_size(dst.stat().st_size))
@@ -140,7 +140,7 @@ def _download_one_file_sync(
 
     # Partial file already complete? Validate and finalize.
     if offset and expected_size and offset == expected_size:
-        got = _blake3_file(tmp)
+        got = blake3_hash_file(tmp, chunk_size=_DOWNLOAD_CHUNK_BYTES)
         if expected_blake3 and got.lower() != expected_blake3.lower():
             log.warning("partial_corrupt path=%s (blake3 mismatch, restarting)", dst.name)
             tmp.unlink(missing_ok=True)
@@ -210,7 +210,7 @@ def _download_one_file_sync(
         raise ValueError(f"size mismatch (expected {expected_size}, got {actual_size})")
 
     if expected_blake3:
-        got = _blake3_file(tmp)
+        got = blake3_hash_file(tmp, chunk_size=_DOWNLOAD_CHUNK_BYTES)
         if got.lower() != expected_blake3.lower():
             log.error("download_blake3_mismatch path=%s expected=%s got=%s",
                       dst.name, expected_blake3[:16], got[:16])
@@ -260,14 +260,3 @@ def fsync_dir(path: Path) -> None:
         os.close(fd)
 
 
-def _blake3_file(path: Path, chunk_size: int = _DOWNLOAD_CHUNK_BYTES) -> str:
-    # Fan BLAKE3 across cores via AUTO threading (issue #269). Used on
-    # download-verify path; same throughput win as the upload-side hash.
-    h = blake3(max_threads=blake3.AUTO)
-    with open(path, "rb") as f:
-        while True:
-            b = f.read(chunk_size)
-            if not b:
-                break
-            h.update(b)
-    return h.hexdigest()

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -84,6 +84,15 @@ _FINALIZE_RETRY_BACKOFF_S = 0.5
 _COMPLETE_IN_PROGRESS_POLL_S = 5.0
 _COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600.0
 
+# A severed /complete connection is NOT fatal either (te#44 J9): middleboxes
+# on the worker->hub path (NAT idle eviction, tunnel circuit caps) kill the
+# idle multi-minute verify of multi-GB objects, so the client sees a network
+# error while the server may finish (`sess.Finalized` fast path answers the
+# re-POST) or may have aborted (a re-POST restarts the verify). Re-POST
+# patiently on a deadline — each attempt can legitimately take a full verify.
+_COMPLETE_NETWORK_RETRY_DELAY_S = 15.0
+_COMPLETE_NETWORK_MAX_WAIT_S = 1800.0
+
 # Default part size sent by server, but we read it from the response.
 _FALLBACK_PART_SIZE = 64 * 1024 * 1024  # 64 MiB
 
@@ -100,6 +109,7 @@ __all__ = [
     "PresignedUploadResult",
     "blake3_hash_file",
     "presigned_upload_file",
+    "upload_entry_and_complete",
 ]
 
 
@@ -298,10 +308,72 @@ def _presigned_upload_file_scoped(
             retryable=False,
         )
 
-    transfer_grant = parsed.get("transfer_grant") or parsed.get("s3_transfer_grant")
+    if _is_tensorhub_model_weight_upload(endpoint_path) and not isinstance(
+        parsed.get("transfer_grant") or parsed.get("s3_transfer_grant"), dict
+    ):
+        raise ArtifactTransferError(
+            "tensorhub model upload response missing transfer_grant",
+            provider="tensorhub",
+            phase="create",
+            retryable=False,
+        )
+
+    result_meta = upload_entry_and_complete(
+        file_path=file_path,
+        entry=parsed,
+        complete_url=f"{url}/{upload_id}/complete",
+        abort_url=f"{url}/{upload_id}",
+        headers=headers,
+        session=session,
+        blake3_hex=blake3_hex,
+        size_bytes=size_bytes,
+        put_pool=put_pool,
+        on_progress=on_progress,
+        cancel_check=cancel_check,
+        complete_extra=complete_extra,
+    )
+    return PresignedUploadResult(meta=result_meta, dedup=False)
+
+
+def upload_entry_and_complete(
+    *,
+    file_path: str | Path,
+    entry: Dict[str, Any],
+    complete_url: str,
+    headers: Dict[str, str],
+    session: requests.Session,
+    blake3_hex: str = "",
+    size_bytes: int = 0,
+    put_pool: Optional[PutPool] = None,
+    on_progress: Optional[Any] = None,
+    cancel_check: Optional[Any] = None,
+    complete_extra: Optional[Dict[str, Any]] = None,
+    abort_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Move one local file's bytes into tensorhub staging for an
+    already-created upload entry, then patiently POST ``complete_url``.
+
+    THE per-file hub upload engine — every gen-worker byte-mover rides it:
+    media/user-file upload sessions (``presigned_upload_file``), job-scoped
+    repo-CAS checkpoint streams (``ctx.save_checkpoint``), and ``/commits``
+    publishes (``gen_worker.convert.hub.HubClient``). ``entry`` is the
+    server's upload descriptor: ``transfer_grant`` (R2 SDK transfer) or
+    ``part_urls`` + ``part_size`` (presigned multipart). Carries the full
+    /complete armor: 409 upload_complete_in_progress poll (e2e #110) and
+    network-severed re-POST patience (te#44 J9).
+
+    ``abort_url``: DELETEd (best-effort) when the multipart PUT phase fails,
+    so the server can GC staged parts. Grant-path and /complete failures never
+    abort — the object may already be fully staged server-side.
+    """
+    transfer_grant = entry.get("transfer_grant") or entry.get("s3_transfer_grant")
     if isinstance(transfer_grant, dict):
         from .s3_transfer import S3TransferGrant, upload_file_with_grant
 
+        if not size_bytes:
+            size_bytes = int(entry.get("size_bytes") or os.path.getsize(file_path))
+        if not blake3_hex:
+            blake3_hex = str(entry.get("blake3") or "")
         grant = S3TransferGrant.from_mapping(transfer_grant)
         sdk_result = upload_file_with_grant(
             file_path=file_path,
@@ -324,38 +396,24 @@ def _presigned_upload_file_scoped(
             for k, v in complete_extra.items():
                 if v is not None and k != "transfer":
                     complete_payload[k] = v
-        result_meta = _complete_upload_session(
-            complete_url=f"{url}/{upload_id}/complete",
+        return _complete_upload_session(
+            complete_url=complete_url,
             headers=headers,
             payload=complete_payload,
             cancel_check=cancel_check,
             session=session,
         )
-        return PresignedUploadResult(meta=result_meta, dedup=False)
 
-    if _is_tensorhub_model_weight_upload(endpoint_path):
-        raise ArtifactTransferError(
-            "tensorhub model upload response missing transfer_grant",
-            provider="tensorhub",
-            phase="create",
-            retryable=False,
-        )
-
-    part_urls: List[str] = parsed.get("part_urls") or []
-    part_size: int = int(parsed.get("part_size") or _FALLBACK_PART_SIZE)
-    total_parts: int = int(parsed.get("total_parts") or len(part_urls))
-
+    part_urls: List[str] = list(entry.get("part_urls") or [])
+    part_size: int = int(entry.get("part_size") or _FALLBACK_PART_SIZE)
+    total_parts: int = int(entry.get("total_parts") or len(part_urls))
     if not part_urls or total_parts == 0:
         raise ArtifactTransferError(
-            "tensorhub upload create response missing part URLs",
+            "tensorhub upload entry missing transfer_grant/part URLs",
             provider="tensorhub",
             phase="create",
             retryable=False,
         )
-
-    # --- Step 2: Upload parts to S3 ---
-    session_id = upload_id
-    abort_url = f"{url}/{session_id}"
 
     try:
         etags = _upload_parts_to_s3(
@@ -368,17 +426,15 @@ def _presigned_upload_file_scoped(
             put_pool=put_pool,
         )
     except BaseException:
-        # Abort the multipart upload on failure.
-        try:
-            abort_headers = dict(headers)
-            session.delete(abort_url, headers=abort_headers, timeout=15)
-        except Exception:
-            pass
+        # Abort the multipart upload on failure so staged parts get GC'd.
+        if abort_url:
+            try:
+                session.delete(abort_url, headers=dict(headers), timeout=15)
+            except Exception:
+                pass
         raise
 
-    # --- Step 3: Complete ---
-    complete_url = f"{url}/{session_id}/complete"
-    complete_payload: Dict[str, Any] = {
+    complete_payload = {
         "parts": [{"part_number": pn, "etag": et} for pn, et in etags],
     }
     if complete_extra:
@@ -389,14 +445,13 @@ def _presigned_upload_file_scoped(
             if k == "parts":
                 continue
             complete_payload[k] = v
-    result_meta = _complete_upload_session(
+    return _complete_upload_session(
         complete_url=complete_url,
         headers=headers,
         payload=complete_payload,
         cancel_check=cancel_check,
         session=session,
     )
-    return PresignedUploadResult(meta=result_meta, dedup=False)
 
 
 def _error_code_of(resp: requests.Response) -> str:
@@ -479,8 +534,9 @@ def _complete_upload_session(
 ) -> Dict[str, Any]:
     complete_headers = dict(headers)
     complete_headers["Content-Type"] = "application/json"
-    last_exc: Optional[BaseException] = None
-    for attempt in range(1, _FINALIZE_RETRY_ATTEMPTS + 1):
+    network_deadline = time.monotonic() + _COMPLETE_NETWORK_MAX_WAIT_S
+    server_errors = 0
+    while True:
         if cancel_check and cancel_check():
             raise CanceledError("canceled")
         try:
@@ -491,49 +547,52 @@ def _complete_upload_session(
                 timeout=_FINALIZE_TIMEOUT_S,
             )
         except requests.RequestException as e:
-            last_exc = ArtifactTransferError(
-                f"tensorhub upload finalize request failed: {e}",
-                provider="tensorhub",
-                phase="complete",
-                retryable=True,
-                cause_type=type(e).__name__,
+            # Severed /complete (te#44 J9): idempotent once finalized — re-POST
+            # patiently on the long deadline (each attempt can re-run a full
+            # multi-minute verify) instead of failing the save/commit.
+            if time.monotonic() >= network_deadline:
+                raise ArtifactTransferError(
+                    f"tensorhub upload finalize request failed: {e}",
+                    provider="tensorhub",
+                    phase="complete",
+                    retryable=True,
+                    cause_type=type(e).__name__,
+                ) from e
+            logger.warning("POST %s network-severed; re-POSTing (idempotent complete)", complete_url)
+            time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
+            continue
+        code = resp.status_code
+        if code in (401, 403):
+            raise AuthError(f"file save unauthorized ({code})")
+        if code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
+            return _poll_until_finalized(
+                complete_url=complete_url,
+                complete_headers=complete_headers,
+                payload=payload,
+                cancel_check=cancel_check,
+                session=session,
             )
-        else:
-            code = resp.status_code
-            if code in (401, 403):
-                raise AuthError(f"file save unauthorized ({code})")
-            if code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
-                return _poll_until_finalized(
-                    complete_url=complete_url,
-                    complete_headers=complete_headers,
-                    payload=payload,
-                    cancel_check=cancel_check,
-                    session=session,
-                )
-            if code >= 500:
-                last_exc = ArtifactTransferError(
+        if code >= 500:
+            server_errors += 1
+            if server_errors >= _FINALIZE_RETRY_ATTEMPTS:
+                raise ArtifactTransferError(
                     f"tensorhub upload finalize failed: {_response_body_sample(resp)}",
                     provider="tensorhub",
                     phase="complete",
                     retryable=True,
                     status_code=code,
                 )
-            elif code < 200 or code >= 300:
-                raise ArtifactTransferError(
-                    f"tensorhub upload finalize failed: {_response_body_sample(resp)}",
-                    provider="tensorhub",
-                    phase="complete",
-                    retryable=code == 429,
-                    status_code=code,
-                )
-            else:
-                return _parse_json_response(resp, phase="complete")
-        if attempt < _FINALIZE_RETRY_ATTEMPTS:
             time.sleep(_FINALIZE_RETRY_BACKOFF_S)
-
-    if last_exc:
-        raise last_exc
-    raise ArtifactTransferError("tensorhub upload failed", provider="tensorhub", retryable=False)
+            continue
+        if code < 200 or code >= 300:
+            raise ArtifactTransferError(
+                f"tensorhub upload finalize failed: {_response_body_sample(resp)}",
+                provider="tensorhub",
+                phase="complete",
+                retryable=code == 429,
+                status_code=code,
+            )
+        return _parse_json_response(resp, phase="complete")
 
 
 def _upload_parts_to_s3(

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -50,9 +50,12 @@ def test_commit_uploads_completes_and_finalizes(fake_hub, tmp_path: Path, monkey
     ops = {op["path"]: op for op in req["operations"]}
     assert set(ops) == {"config.json", "sub/weights.safetensors"}
     assert ops["config.json"]["blake3"] == blake3_file(tmp_path / "config.json")
-    # Bytes actually PUT + parts echoed on complete.
+    # Bytes actually PUT + parts echoed on complete (the shared engine passes
+    # the R2 ETag header through verbatim, quotes included).
     assert len(st["put_bytes"]) == 2
-    assert st["complete_bodies"][0]["parts"][0] == {"part_number": 1, "etag": "etag-1"}
+    first_part = st["complete_bodies"][0]["parts"][0]
+    assert first_part["part_number"] == 1
+    assert first_part["etag"].strip('"') == "etag-1"
     assert st["finalize_calls"] == 2  # 202 then 200
     assert st["auth"] == "Bearer cap-token"
 
@@ -196,12 +199,12 @@ def test_complete_gives_up_after_deadline_if_race_never_resolves(
     """A genuinely stuck server (never finalizes) must still fail eventually
     rather than polling forever."""
     monkeypatch.setattr("time.sleep", lambda *_: None)
-    monkeypatch.setattr("gen_worker.convert.hub._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
+    monkeypatch.setattr("gen_worker.presigned_upload._COMPLETE_IN_PROGRESS_MAX_WAIT_S", 0.0)
     _FakeHub.state["complete_race_count"] = 10_000
 
     f = tmp_path / "model.safetensors"
     f.write_bytes(b"\x05" * 48)
-    with pytest.raises(HubPublishError, match="upload complete failed"):
+    with pytest.raises(HubPublishError, match="upload failed"):
         _client(fake_hub).commit(
             destination_repo="acme/my-model",
             files=[CommitFile(path="model.safetensors", local_path=f)],
@@ -219,47 +222,3 @@ def test_files_from_tree_skips_hf_cache_junk(tmp_path: Path) -> None:
 
     paths = [f.path for f in files_from_tree(tmp_path)]
     assert paths == [".gitignore", "config.json"]
-
-
-def test_complete_repost_through_network_severed_attempts(monkeypatch) -> None:
-    """te#44 J9 runs 7+8: the idle multi-minute /complete verify gets severed
-    by middleboxes; the client must re-POST (idempotent) instead of failing
-    the commit after the quick generic retries are exhausted."""
-    from gen_worker.convert.hub import HubClient, HubPublishError
-
-    monkeypatch.setattr("time.sleep", lambda *_: None)
-    client = HubClient(base_url="http://hub", token="t", owner="acme")
-    calls = {"n": 0}
-
-    class _OK:
-        status_code = 200
-        text = "{}"
-
-        @staticmethod
-        def json():
-            return {}
-
-    def _post(path, payload=None, *, timeout=None):
-        calls["n"] += 1
-        if calls["n"] <= 2:
-            raise HubPublishError(f"POST {path} failed (network): severed")
-        return _OK()
-
-    monkeypatch.setattr(client, "_post", _post)
-    resp = client._post_complete("/complete", {})
-    assert resp.status_code == 200 and calls["n"] == 3
-
-
-def test_complete_network_severed_raises_after_deadline(monkeypatch) -> None:
-    from gen_worker.convert.hub import HubClient, HubPublishError
-
-    monkeypatch.setattr("time.sleep", lambda *_: None)
-    monkeypatch.setattr("gen_worker.convert.hub._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
-    client = HubClient(base_url="http://hub", token="t", owner="acme")
-
-    def _post(path, payload=None, *, timeout=None):
-        raise HubPublishError("POST /complete failed (network): severed")
-
-    monkeypatch.setattr(client, "_post", _post)
-    with pytest.raises(HubPublishError, match="network"):
-        client._post_complete("/complete", {})

--- a/tests/test_presigned_upload_complete_retry.py
+++ b/tests/test_presigned_upload_complete_retry.py
@@ -122,3 +122,48 @@ def test_complete_upload_session_other_409_is_not_polled():
         )
     assert exc_info.value.retryable is False
     assert exc_info.value.status_code == 409
+
+def test_complete_upload_session_reposts_through_network_severed_attempts():
+    """te#44 J9 runs 7+8: the idle multi-minute /complete verify gets severed
+    by middleboxes; the client must re-POST (idempotent once finalized) on the
+    long network deadline instead of failing the save/commit after a handful
+    of quick generic retries."""
+    import requests
+
+    calls = {"n": 0}
+
+    def fake_post(*_a, **_kw):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise requests.ConnectionError("severed mid-verify")
+        return _FakeResponse(200, {"ok": True})
+
+    with patch("gen_worker.presigned_upload.time.sleep"):
+        result = _complete_upload_session(
+            complete_url="https://tensorhub.test/complete",
+            headers={},
+            payload={"parts": []},
+            cancel_check=None,
+            session=_FakeSession(fake_post),
+        )
+    assert result == {"ok": True}
+    assert calls["n"] == 3
+
+
+def test_complete_upload_session_network_severed_raises_after_deadline(monkeypatch):
+    import requests
+
+    monkeypatch.setattr("gen_worker.presigned_upload._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
+
+    def fake_post(*_a, **_kw):
+        raise requests.ConnectionError("severed")
+
+    with patch("gen_worker.presigned_upload.time.sleep"):
+        with pytest.raises(ArtifactTransferError, match="finalize request failed"):
+            _complete_upload_session(
+                complete_url="https://tensorhub.test/complete",
+                headers={},
+                payload={"parts": []},
+                cancel_check=None,
+                session=_FakeSession(fake_post),
+            )


### PR DESCRIPTION
Integration pass after the gw#406 fold (#121): now that the ETL lives in-tree, its hub client and the worker's upload machinery stop being parallel implementations.

**Unified (real wins):**
- `HubClient._upload_one` (the `/commits` per-file path) rides `presigned_upload.upload_entry_and_complete` — a new engine extracted from `_presigned_upload_file_scoped`'s steps 2-3. One implementation of: transfer-grant vs presigned-multipart dispatch, hardened `PutPool` part transport (R2 stale-socket guard, parallel parts — convert previously had a naive sequential PUT loop), and the patient `/complete`.
- `/complete` armor is now ONE implementation with the union of both sides' hardening: e2e#110 409 `upload_complete_in_progress` poll (was in both) + te#44 J9 network-severed re-POST patience on a 30-min deadline (was convert-only; worker `save_file`/`save_checkpoint`/`open_checkpoint_stream` gain it).
- blake3 file hashing: 3 copies (`presigned_upload.blake3_hash_file`, `cozy_cas._blake3_file`, `convert/hub.blake3_file`) → 1 multithreaded `blake3_hash_file`.
- `_error_code_of`: 2 copies → 1.

**Deliberately kept apart** (inspected, not force-merged):
- `save_checkpoint` (job-scoped `/revisions` upload sessions) vs `publish_flavors` (manifest-first `/commits`): different tensorhub routes with different semantics (lazy session + finalize-per-request vs dedup-by-blake3 commit body carrying flavor/tags/lineage). Byte movement is now shared; collapsing the control-plane protocols is a tensorhub API decision, not a client-side refactor. save_checkpoint wire behavior unchanged.
- HF fetching: worker `models/download.py` (serve variant fit-ladder + stall watchdog) vs `convert/ingest.py` (classifier-driven selective ETL ingest) — same `huggingface_hub` primitive, genuinely different selection policies. Civitai was already shared.
- `loading._merge_sharded_checkpoint` (merge shards, serve path) vs `convert/writer.shard_safetensors_by_offset` (split, ETL path): inverse ops sharing ~4 lines of standard safetensors header parsing — coupling the serve path to the convert module isn't worth it.
- convert's keepalive `_http_session` stays as HubClient's transport policy, passed into the shared engine.

Net: -57 LOC in src (209 insertions incl. docstrings/tests, 266 deletions). Tests: full suite 542 passed w/ torch; convert integration 6 passed, 2 skipped; the two J9 armor tests moved from `tests/convert/test_hub.py` to `tests/test_presigned_upload_complete_retry.py` (they now guard the shared engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)