### PR TITLE
gw#401 + th#606: replace worker-declared lineage with worker-addable provenance

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -372,13 +372,11 @@ def run_clone(
                 hf_token=effective_hf_token,
                 progress=_dl_progress,
             )
-            lineage_parent = f"hf:{source.source_ref}"
         elif provider == "civitai":
             source = ingest_civitai(
                 int(civitai_model_version_id or 0), workdir / "source",
                 civitai_api_key=civitai_api_key, progress=_dl_progress,
             )
-            lineage_parent = f"civitai:{source.source_ref}"
         else:
             raise ValueError(f"unsupported clone provider: {provider!r}")
 
@@ -387,11 +385,10 @@ def run_clone(
 
         hubclient = HubClient.from_ctx(ctx)
         result = CloneResult(destination_repo=destination, metadata=dict(source.metadata))
-        lineage = [{
-            "parent_repo": "external-sources/upstream",
-            "parent_checkpoint_id": lineage_parent,
-            "relationship_kind": "import",
-        }]
+        # th#606: upstream identity (upstream_ref + derivation_op=import) is
+        # orchestrator-derived and rides the capability token; the worker only
+        # ADDS the revision it actually resolved during download.
+        provenance = {"upstream_revision": str(source.source_revision or "")}
         mode = "replace" if overwrite_repo else "merge"
 
         # Non-diffusers-class sources publish as-is; extra output specs that
@@ -481,9 +478,8 @@ def run_clone(
                 file_type=str(attrs.get("file_type") or spec.file_type),
                 message=f"clone {provider}:{source.source_ref}@{source.source_revision}",
                 metadata=metadata,
-                lineage=lineage,
+                provenance=provenance,
                 repo_spec=source.repo_spec,
-                auto_create_external_parent=True,
             )
             result.published.append({
                 "flavor": flavor_label,

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -5,7 +5,7 @@ The write API is HF `create_commit`-shaped:
   POST /api/v1/repos/{tenant}/{name}/commits
       {operations: [{type:"add", path, blake3, size_bytes}, ...],
        tags: [{tag, default_flavor?}], mode: "merge"|"replace",
-       flavor/dtype/file_layout/file_type, metadata, lineage, repo spec}
+       flavor/dtype/file_layout/file_type, metadata, provenance, repo spec}
   → {revision_id, uploads: [{path, exists, upload_id, part_urls, part_size,
                              complete_url, ...}]}
 
@@ -368,9 +368,8 @@ class HubClient:
         file_type: str = "",
         message: str = "",
         metadata: Mapping[str, Any] | None = None,
-        lineage: list[dict[str, Any]] | None = None,
+        provenance: Mapping[str, Any] | None = None,
         repo_spec: Mapping[str, str] | None = None,
-        auto_create_external_parent: bool = False,
         progress: Any = None,
     ) -> CommitResult:
         """Publish one checkpoint: one POST /commits, PUT the parts, finalize.
@@ -406,9 +405,13 @@ class HubClient:
             body["flavors"] = list(flavors)
         if metadata:
             body["metadata"] = dict(metadata)
-        if lineage:
-            body["lineage"] = list(lineage)
-            body["auto_create_external_parent"] = bool(auto_create_external_parent)
+        if provenance:
+            # th#606: WORKER-ADDABLE stamp fields only (step_number,
+            # epoch_number, quantization_method, quantization_library,
+            # upstream_revision). Parents / derivation_op / upstream_ref are
+            # orchestrator-derived (signed into the capability token) — the
+            # server 400s any attempt to send them from here.
+            body["provenance"] = {k: v for k, v in dict(provenance).items() if v}
         for key in ("kind", "library_name", "model_family", "class_name",
                     "adapter_for_family"):
             val = str((repo_spec or {}).get(key) or "").strip()

--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -60,6 +60,15 @@ def publish_flavors(
     for flavor in flavors:
         attrs = {str(k): str(v) for k, v in (flavor.attributes or {}).items()}
         label = str(flavor.flavor or attrs.get("flavor") or attrs.get("dtype") or "").strip()
+        # th#606: worker-addable provenance stamp fields. Producers declare
+        # quant identity in the flavor attribute bag; it rides the commit's
+        # `provenance` object onto the checkpoint's node stamp (parents /
+        # derivation_op come from the orchestrator's token claim, never here).
+        provenance = {
+            k: attrs[k]
+            for k in ("quantization_method", "quantization_library")
+            if attrs.get(k)
+        }
         results.append(client.commit(
             destination_repo=dest,
             files=_flavor_files(flavor),
@@ -71,6 +80,7 @@ def publish_flavors(
             file_layout=attrs.get("file_layout", ""),
             file_type=attrs.get("file_type", ""),
             metadata={**(dict(metadata) if metadata else {}), **attrs},
+            provenance=provenance,
         ))
     return results
 

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -204,10 +204,11 @@ def presigned_upload_file(
         on_progress: Optional callback(parts_done, total_parts, bytes_uploaded).
         cancel_check: Optional callable that returns True if canceled.
         complete_extra: Optional extra fields merged into the /complete POST
-            body (after the `parts` array). Used by repo-cas uploads to carry
-            lineage metadata — step_number, epoch_number, output_kind,
-            target_dtype, flavor, produced_by_kind. Tensorhub persists
-            these into checkpoint_lineage.
+            body (after the `parts` array). NOTE (gw#401/th#606): tensorhub's
+            per-file /complete is parts-only and does NOT persist lineage
+            metadata; step/epoch/quant identity reach the catalog via the
+            commit body's `provenance` object (worker-addable stamp fields),
+            not through this seam.
     """
     # Per-save connection scope (issue #385): one hub Session + one R2 PUT
     # pool live exactly as long as this save, then close. Never cross-request.

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -31,10 +31,9 @@ def test_commit_uploads_completes_and_finalizes(fake_hub, tmp_path: Path, monkey
         dtype="bf16",
         file_layout="diffusers",
         file_type="safetensors",
-        lineage=[{"parent_repo": "external-sources/upstream",
-                  "parent_checkpoint_id": "hf:org/name",
-                  "relationship_kind": "import"}],
-        auto_create_external_parent=True,
+        provenance={"upstream_revision": "abc123",
+                    "quantization_method": "",  # empty values are dropped
+                    "step_number": 0},
     )
     assert result.revision_id == "rev-1"
     # THE queryable id: minted at finalize from the snapshot manifest.
@@ -46,7 +45,10 @@ def test_commit_uploads_completes_and_finalizes(fake_hub, tmp_path: Path, monkey
     assert req["mode"] == "replace"
     assert req["tags"] == [{"tag": "prod"}]
     assert req["flavor"] == "bf16"
-    assert req["auto_create_external_parent"] is True
+    # th#606: only non-empty worker-addable provenance fields are sent;
+    # the old worker-declared lineage contract is gone.
+    assert req["provenance"] == {"upstream_revision": "abc123"}
+    assert "lineage" not in req and "auto_create_external_parent" not in req
     ops = {op["path"]: op for op in req["operations"]}
     assert set(ops) == {"config.json", "sub/weights.safetensors"}
     assert ops["config.json"]["blake3"] == blake3_file(tmp_path / "config.json")


### PR DESCRIPTION
Lockstep with tensorhub PR #150 (th#606 provenance node-stamp spine).

The commit body's `lineage[]` + `auto_create_external_parent` (worker-declared import edges against the `external-sources/upstream` 0-byte placeholder) are gone — the orchestrator now derives parents/derivation_op/upstream_ref and signs them into the capability token; the worker cannot forge lineage, and tensorhub 400s the old fields.

- `HubClient.commit()`: `provenance=` carries ONLY the worker-addable stamp fields (`step_number`, `epoch_number`, `quantization_method`, `quantization_library`, `upstream_revision`)
- `clone.py`: sends the actually-resolved source revision as `provenance.upstream_revision` (the orchestrator's claim carries `upstream_ref`; a pinned revision in the claim wins server-side)
- `publish_flavors`: lifts `quantization_method`/`quantization_library` from the flavor attribute bag into the commit provenance (th#258 quant identity finally lands on the stamp)
- gw#401: deleted the false "Tensorhub persists these into checkpoint_lineage" docstring contract on the presigned-upload `complete_extra` seam

Tests: tests/convert suite green (fake-hub asserts the new wire shape; empty provenance values dropped; old fields absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)