### PR TITLE
fix(convert): clone primary output claims the bare selector row (gw#419)

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -652,6 +652,11 @@ def run_clone(
                 tags=tags,
                 mode=mode if i == 0 else "merge",
                 flavor=flavor_label,
+                # gw#418: the PRIMARY output also owns the bare selector row —
+                # tensorhub (th#597 C1) never moves flavor='' for an
+                # explicit-flavor publish unless default_flavor names it, and
+                # every serve/convert flow references mirrors bare (repo:tag).
+                default_flavor=flavor_label if i == 0 else "",
                 dtype=str(attrs.get("dtype") or spec.dtype),
                 file_layout=str(attrs.get("file_layout") or spec.file_layout),
                 file_type=str(attrs.get("file_type") or spec.file_type),

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -652,7 +652,7 @@ def run_clone(
                 tags=tags,
                 mode=mode if i == 0 else "merge",
                 flavor=flavor_label,
-                # gw#418: the PRIMARY output also owns the bare selector row —
+                # gw#419: the PRIMARY output also owns the bare selector row —
                 # tensorhub (th#597 C1) never moves flavor='' for an
                 # explicit-flavor publish unless default_flavor names it, and
                 # every serve/convert flow references mirrors bare (repo:tag).

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -265,3 +265,35 @@ def test_complete_network_severed_raises_after_deadline(monkeypatch) -> None:
     monkeypatch.setattr(client, "_post", _post)
     with pytest.raises(HubPublishError, match="network"):
         client._post_complete("/complete", {})
+
+
+def test_commit_default_flavor_rides_tags_and_top_level(fake_hub, tmp_path: Path) -> None:
+    # gw#418: the primary clone output must be able to claim the bare
+    # selector row — tensorhub (th#597 C1) only writes flavor='' for an
+    # explicit-flavor publish when default_flavor names it.
+    _FakeHub.state["finalize_calls"] = 1
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x03" * 16)
+    _client(fake_hub).commit(
+        destination_repo="acme/my-model",
+        files=[CommitFile(path="model.safetensors", local_path=f)],
+        tags=["prod"],
+        flavor="fp16",
+        default_flavor="fp16",
+        dtype="fp16",
+    )
+    body = _FakeHub.state["commit_request"]
+    assert body["flavor"] == "fp16"
+    assert body["default_flavor"] == "fp16"
+    assert body["tags"] == [{"tag": "prod", "default_flavor": "fp16"}]
+
+
+def test_clone_primary_output_claims_bare_selector() -> None:
+    # gw#418 regression guard at the clone layer: the i==0 commit passes
+    # default_flavor=<label>; secondary outputs stay explicit-flavor-only.
+    import inspect
+
+    from gen_worker.convert import clone as clone_mod
+
+    src = inspect.getsource(clone_mod)
+    assert 'default_flavor=flavor_label if i == 0 else ""' in src

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -268,7 +268,7 @@ def test_complete_network_severed_raises_after_deadline(monkeypatch) -> None:
 
 
 def test_commit_default_flavor_rides_tags_and_top_level(fake_hub, tmp_path: Path) -> None:
-    # gw#418: the primary clone output must be able to claim the bare
+    # gw#419: the primary clone output must be able to claim the bare
     # selector row — tensorhub (th#597 C1) only writes flavor='' for an
     # explicit-flavor publish when default_flavor names it.
     _FakeHub.state["finalize_calls"] = 1
@@ -289,7 +289,7 @@ def test_commit_default_flavor_rides_tags_and_top_level(fake_hub, tmp_path: Path
 
 
 def test_clone_primary_output_claims_bare_selector() -> None:
-    # gw#418 regression guard at the clone layer: the i==0 commit passes
+    # gw#419 regression guard at the clone layer: the i==0 commit passes
     # default_flavor=<label>; secondary outputs stay explicit-flavor-only.
     import inspect
 


### PR DESCRIPTION
gw#406's cozy-convert fold-in stamps EVERY clone output commit with `flavor=<dtype>`. tensorhub's publish contract (th#597 C1) deliberately never moves the bare `flavor=''` selector row for a publish carrying explicit flavor tokens unless `default_flavor` names it — so a fresh mirror became unresolvable bare: `source ref "tensorhub/convmixed-sd15-mirror:prod": flavor_not_found`, found live in convroute chapter 2 on the first run after the te#53 re-pin (conversion → gen-worker 0.12.0). Every serve/convert flow references mirrors bare.

Fix: the PRIMARY output (i==0) of clone passes `default_flavor=flavor_label`; secondary outputs stay explicit-flavor-only. Conversion/quant publishes (cast-dtype, modelopt) intentionally remain non-bare.

Tests: commit body shape (tags ride `{"tag","default_flavor"}` + top level), clone-layer regression guard. Live proof: convroute verification runs (th#619/th#621) resolve the mirror bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
