### PR TITLE
gw#416 + gw#417 + gw#420: str/Path slot injection, promote livelock fix, always-on emergency quant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- **gw#416**: CLI `run`/`serve` str/`Path`-typed setup slots now receive the
+  snapshot PATH (executor parity) instead of a loaded `DiffusionPipeline`.
+- **gw#417**: fixed the CUDA-host promote livelock — object-less RAM ledger
+  entries (str-slot/opaque setups) are exempt from promote-or-die, so RunJob
+  no longer retries forever on `promotion ... failed`. Residency tests now run
+  against real tiny diffusers pipelines (no fake pipes); they need CUDA and
+  skip cleanly without it.
+- **gw#420**: emergency nf4 quantization is AUTOMATIC on CUDA hosts — the
+  `GEN_WORKER_EMERGENCY_QUANT` env gate is deleted (loud warning stays);
+  `variant_fit`/`select_variant` arm the rung from declared capabilities.
+  `bitsandbytes` ships with the `[torch]` extra so the rung works out of the
+  box.
+
 ## 0.12.0
 
 - **`gen_worker.convert`: the cozy-convert workspace package folded into

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -79,7 +79,7 @@ automatically; endpoint code stays precision-agnostic and
 `ModelEvent.vram_bytes` reports the measured resident size. Quantized
 formats are platform-produced stored flavors (`#fp8`, `#nvfp4` on Blackwell)
 — there is no runtime "quantize my model" kwarg. The one exception is the
-env-gated EMERGENCY rung (`GEN_WORKER_EMERGENCY_QUANT=1`, cozy-local): when
+EMERGENCY rung (automatic on CUDA hosts): when
 even the downloaded flavor cannot fit free VRAM, the loading layer
 runtime-quantizes the denoiser to 4-bit nf4 with a loud warning (quality
 below platform standards) rather than falling straight to CPU offload.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ gen-worker = "gen_worker.cli:main"
 torch = [
     "torch>=2.11.0",
     "safetensors>=0.7.0",
+    # Emergency nf4 fit rung (gw#420) — automatic on CUDA hosts, needs bnb.
+    "bitsandbytes>=0.45.0; sys_platform == 'linux' or sys_platform == 'win32'",
 ]
 vision = [
     "torchvision>=0.26.0",
@@ -71,7 +73,12 @@ video = [
 ]
 dev = [
     "av>=12",
+    # Real tiny-pipeline residency tests (gw#417) build local diffusers pipes;
+    # transformers+accelerate activate the bnb nf4 convert integration test.
+    "accelerate>=1.0",
+    "diffusers>=0.36.0",
     "grpcio-tools>=1.80.0",
+    "transformers>=4.55",
     "mypy>=1.10.0",
     "ruff>=0.6.0",
     "pytest>=9.0.0",

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -1060,6 +1060,10 @@ def _load_injected_model(
     from gen_worker.models.loading import load_from_pretrained
 
     cls = annotation if isinstance(annotation, type) else None
+    if cls is not None and issubclass(cls, (str, os.PathLike)):
+        # Executor parity (gw#416): a str/Path-typed slot receives the
+        # snapshot PATH — the endpoint loads itself.
+        return local_path if cls is str else Path(local_path)
     if cls is None or not hasattr(cls, "from_pretrained"):
         from diffusers import DiffusionPipeline
         cls = DiffusionPipeline

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -939,10 +939,15 @@ class Executor:
                     if res.tier(ref) is residency_mod.Tier.RAM:
                         ok = await asyncio.to_thread(res.promote, ref)
                         self._on_state_change()
-                        if not ok and cuda_host and res.tier(ref) is residency_mod.Tier.RAM:
+                        if (not ok and cuda_host
+                                and res.tier(ref) is residency_mod.Tier.RAM
+                                and res.movable(ref)):
                             # Promote refused/rolled back (gw#409): fail the
                             # job RETRYABLE at promote time — never hand a
                             # handler a pipeline that fatals mid-denoise.
+                            # Non-movable entries (object-less ledger refs,
+                            # offload-hooked pipelines) can never promote —
+                            # promote-or-die on them livelocks (gw#417).
                             raise RetryableError(
                                 f"promotion of {ref} to VRAM failed; retrying"
                             )

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -114,9 +114,9 @@ def variant_fit(
 
     - ``incompatible``: hard gates unmet (no CUDA GPU, compute_capability
       above this GPU's SM, required quant libraries not installed).
-    - ``emergency_quant``: does not fit, but the env-gated emergency nf4 rung
-      (th#546 emergency lane; loading layer) is enabled and the 4-bit
-      estimate fits — runs at below-platform quality, loudly.
+    - ``emergency_quant``: does not fit, but the emergency nf4 rung (th#546
+      emergency lane; loading layer, automatic on CUDA hosts) applies and
+      the 4-bit estimate fits — runs at below-platform quality, loudly.
     - ``offload``: runnable, but declared vram_gb exceeds free VRAM — the
       models/memory.py offload ladder carries it (slower).
     - ``fits``: full-VRAM residency expected.
@@ -137,9 +137,11 @@ def variant_fit(
     vram = getattr(resources, "vram_gb", None)
     if vram is None or float(vram) <= float(free_vram_gb):
         return FIT_FITS, ""
-    from .loading import EMERGENCY_FIT_FACTOR, emergency_quant_enabled
+    from .loading import EMERGENCY_FIT_FACTOR
 
-    if emergency_quant_enabled() and \
+    # Emergency rung is automatic on CUDA hosts (gw#420) — a pure function of
+    # the declared capabilities, so verdicts don't depend on the probing host.
+    if caps.gpu_sm > 0 and \
             float(vram) * EMERGENCY_FIT_FACTOR <= float(free_vram_gb):
         return FIT_EMERGENCY, (
             f"runs (emergency quality): {float(vram):g} GB VRAM via 4-bit "
@@ -164,7 +166,7 @@ def select_variant(
       1. drop incompatible rows (SM / library gates);
       2. among variants that FIT free VRAM, prefer the largest declared
          vram_gb (bigger = higher-quality precision);
-      3. none fit → an emergency_quant row if the env-gated nf4 rung applies
+      3. none fit → an emergency_quant row if the nf4 rung applies
          (runs at below-platform quality, loudly);
       4. else the base binding + the offload ladder;
       5. no base → the smallest-VRAM compatible variant, offloaded;

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -372,10 +372,9 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
 # --- Emergency 4-bit rung (th#546 emergency lane) --------------------------
 # Fit ladder: bf16 -> #fp8 flavor -> #nvfp4 (Blackwell) -> EMERGENCY nf4 ->
 # CPU offload. The emergency rung runtime-quantizes the denoiser to bnb nf4 at
-# load when even the downloaded flavor cannot fit free VRAM. LOCAL/fit-
-# emergency only: enabled by env (cozy-local sets it), never a binding kwarg,
-# never scheduled by the production hub.
-EMERGENCY_QUANT_ENV = "GEN_WORKER_EMERGENCY_QUANT"
+# load when even the downloaded flavor cannot fit free VRAM. Always armed on
+# CUDA hosts (gw#420: fitting is the runtime's job, not a flag); the platform
+# never reaches it because its scheduler places by declared Resources.
 # Coarse whole-model resident factor after nf4-quantizing the denoiser
 # (denoiser ~4x smaller; encoders/VAE stay at compute dtype).
 EMERGENCY_FIT_FACTOR = 0.45
@@ -383,9 +382,12 @@ _EMERGENCY_MARGIN_GB = 2.0
 
 
 def emergency_quant_enabled() -> bool:
-    import os
+    try:
+        import torch
 
-    return os.environ.get(EMERGENCY_QUANT_ENV, "").strip().lower() in ("1", "true", "yes")
+        return bool(torch.cuda.is_available())
+    except ImportError:
+        return False
 
 
 def snapshot_weight_bytes(model_path: Path) -> int:
@@ -487,7 +489,7 @@ def load_from_pretrained(
     ``cls.from_single_file``. ``storage_dtype="fp8"`` (or an fp8-stored
     snapshot) keeps denoiser weights in fp8 storage with per-layer upcast to
     the compute dtype; the emergency nf4 rung engages when even that cannot
-    fit free VRAM (env-gated, cozy-local). Used by the executor to satisfy
+    fit free VRAM (automatic on CUDA hosts). Used by the executor to satisfy
     pipeline-typed ``setup()`` annotations; endpoints may also call it."""
     path = str(path)
     ensure_quant_library_imported(attrs)

--- a/tests/convert/test_integration.py
+++ b/tests/convert/test_integration.py
@@ -128,8 +128,9 @@ def test_repackage_direction_diffusers_to_singlefile(tiny_sdxl, tmp_path: Path) 
 
 
 @pytest.mark.skipif(
-    importlib.util.find_spec("bitsandbytes") is None,
-    reason="bitsandbytes not installed",
+    any(importlib.util.find_spec(m) is None
+        for m in ("bitsandbytes", "transformers", "accelerate")),
+    reason="bitsandbytes/transformers/accelerate not installed",
 )
 def test_quant_direction_nf4(tiny_llama, tmp_path: Path) -> None:
     from gen_worker.convert.convert import run_inline_conversion

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -30,6 +30,27 @@ def test_run_setup_loads_annotated_slot(tmp_path, monkeypatch):
     assert seen["pipeline"].loaded_from == str(tmp_path)
 
 
+def test_run_setup_str_slot_receives_snapshot_path(tmp_path, monkeypatch):
+    # gw#416: a str-typed slot gets the snapshot PATH (executor contract) —
+    # never a loaded DiffusionPipeline.
+    from pathlib import Path
+
+    (tmp_path / "model_index.json").write_text("{}")
+    seen = {}
+
+    class EP:
+        def setup(self, pipeline: str, aux: Path) -> None:
+            seen["pipeline"] = pipeline
+            seen["aux"] = aux
+
+    monkeypatch.setattr(cli_run, "_INJECTED_CACHE", {})
+    cli_run.run_setup(EP(), {"pipeline": str(tmp_path), "aux": str(tmp_path)})
+    assert seen["pipeline"] == str(tmp_path)
+    assert isinstance(seen["pipeline"], str)
+    assert seen["aux"] == Path(tmp_path)
+    assert isinstance(seen["aux"], Path)
+
+
 def test_run_setup_loads_module_layout_slot(tmp_path, monkeypatch):
     # Module-layout repo (root config.json, no model_index.json): e.g. a bare
     # AutoencoderKL repo like madebyollin/sdxl-vae-fp16-fix. Must route through

--- a/tests/test_executor_residency.py
+++ b/tests/test_executor_residency.py
@@ -1,76 +1,74 @@
-"""Executor <-> Residency unification (#369/#371) — CPU-only, deterministic.
+"""Executor <-> Residency unification (#369/#371) against REAL tiny pipelines.
 
-A fake CUDA allocator (module counter) + fake pipelines with ``from_pretrained``
-drive the REAL ensure_setup / handle_model_op paths against a budgeted
-Residency: per-ref measured vram_bytes, serialized loads, UNLOAD demoting to
-the warm RAM tier, and make_room-before-load demote/promote swaps.
+No fake pipes (gw#417): the subject is whether memory actually moves between
+VRAM/RAM/disk, so these tests build tiny-config real diffusers pipelines
+locally (no network) and assert on real allocator deltas and real device
+placement. CUDA required; skips cleanly on CPU-only hosts.
 """
 
 import asyncio
-import time
 from pathlib import Path
 
 import msgspec
 import pytest
 
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
 from gen_worker.executor import Executor, ModelStore
-from gen_worker.models import residency as residency_mod
-from gen_worker.models.residency import Tier
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
+from gen_worker.models.residency import Tier
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="residency moves real memory between VRAM/RAM (gw#417); needs CUDA",
+)
 
 _GiB = 1024 ** 3
+_MiB = 1024 ** 2
+
+
+def _save_tiny_ddpm(path: Path, channels: int) -> None:
+    """Real DDPMPipeline with a tiny-config UNet, built locally (no network).
+    channels=384 -> ~148MB fp32; 256 -> ~66MB; 128 -> ~16MB."""
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3, layers_per_block=1,
+        block_out_channels=(channels, channels), norm_num_groups=8,
+        down_block_types=("DownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "UpBlock2D"),
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler(num_train_timesteps=10)
+                 ).save_pretrained(str(path))
+
+
+@pytest.fixture(scope="module")
+def snapshots(tmp_path_factory) -> dict:
+    root = tmp_path_factory.mktemp("tiny-pipes")
+    out = {}
+    for name, channels in (("big-a", 384), ("big-b", 384),
+                           ("mid", 256), ("small", 128)):
+        _save_tiny_ddpm(root / name, channels)
+        out[name] = root / name
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _settle_allocator():
+    """Free the previous test's pipelines before measuring this one's."""
+    import gc
+
+    gc.collect()
+    torch.cuda.empty_cache()
+    yield
 
 
 class _In(msgspec.Struct):
     x: str
-
-
-class _Alloc:
-    bytes = 0
-
-
-class _FakePipe:
-    """Stands in for a diffusers pipeline: from_pretrained allocates, .to()
-    moves the same object the endpoint instance holds."""
-
-    size = 1 * _GiB
-    load_sleep_s = 0.0
-
-    def __init__(self) -> None:
-        self.device = "cuda"
-
-    @classmethod
-    def from_pretrained(cls, path, **kwargs):
-        _Alloc.bytes += cls.size
-        if cls.load_sleep_s:
-            time.sleep(cls.load_sleep_s)
-        return cls()
-
-    def to(self, device: str) -> "_FakePipe":
-        if device == "cpu" and self.device == "cuda":
-            _Alloc.bytes -= self.size
-        elif device == "cuda" and self.device == "cpu":
-            _Alloc.bytes += self.size
-        self.device = device
-        return self
-
-
-class _Unet(_FakePipe):
-    size = 3 * _GiB
-
-
-class _Vae(_FakePipe):
-    size = 1 * _GiB
-
-
-@pytest.fixture(autouse=True)
-def _fake_gpu(monkeypatch):
-    _Alloc.bytes = 0
-    monkeypatch.setattr(Executor, "_vram_allocated", staticmethod(lambda: _Alloc.bytes))
-    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 64.0)
 
 
 def _spec(name: str, cls: type, models: dict, vram_gb: float | None = None) -> EndpointSpec:
@@ -81,15 +79,17 @@ def _spec(name: str, cls: type, models: dict, vram_gb: float | None = None) -> E
     )
 
 
-def _executor(specs, tmp_path: Path, budget_gb: int, sent: list) -> Executor:
+def _executor(specs, tmp_path: Path, budget_bytes: int, sent: list,
+              refs_to_snapshots: dict) -> Executor:
     async def _send(msg: pb.WorkerMessage) -> None:
         sent.append(msg)
 
-    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=budget_gb * _GiB)
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=budget_bytes)
 
     async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
-        store.residency.track_disk(ref, tmp_path)
-        return tmp_path
+        path = refs_to_snapshots[ref]
+        store.residency.track_disk(ref, path)
+        return path
 
     store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
     return Executor(specs, _send, store=store)
@@ -100,85 +100,99 @@ def _events(sent, state) -> list:
             if m.WhichOneof("msg") == "model_event" and m.model_event.state == state]
 
 
+def _device(pipe) -> str:
+    return next(pipe.unet.parameters()).device.type
+
+
 # --------------------------------------------------------------------------- #
 # #369: per-ref measured vram_bytes; residency owns the pipeline objects
 # --------------------------------------------------------------------------- #
 
 
-def test_two_model_setup_books_per_ref_measured_bytes(tmp_path: Path) -> None:
+def test_two_model_setup_books_per_ref_measured_bytes(tmp_path, snapshots) -> None:
+    from diffusers import DDPMPipeline
+
     class Endpoint:
-        def setup(self, unet: _Unet, vae: _Vae) -> None:
-            self.unet, self.vae = unet, vae
+        def setup(self, mid: DDPMPipeline, small: DDPMPipeline) -> None:
+            self.mid, self.small = mid, small
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
-    spec = _spec("ep", Endpoint, {"unet": HF("acme/unet"), "vae": HF("acme/vae")})
+    spec = _spec("ep", Endpoint, {"mid": HF("acme/mid"), "small": HF("acme/small")})
     sent: list = []
+    refs = {"acme/mid": snapshots["mid"], "acme/small": snapshots["small"]}
 
     async def _run() -> None:
-        ex = _executor([spec], tmp_path, budget_gb=10, sent=sent)
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, refs)
         inst = await ex.ensure_setup(spec)
         res = ex.store.residency
-        assert res.vram_bytes("acme/unet") == 3 * _GiB
-        assert res.vram_bytes("acme/vae") == 1 * _GiB
-        # Residency owns the very objects the instance uses.
-        assert res.obj("acme/unet") is inst.unet
-        assert res.obj("acme/vae") is inst.vae
+        # Real allocator deltas: ~66MB and ~16MB fp32 parameter sets.
+        assert res.vram_bytes("acme/mid") == pytest.approx(66 * _MiB, rel=0.25)
+        assert res.vram_bytes("acme/small") == pytest.approx(16 * _MiB, rel=0.25)
+        # Residency owns the very objects the instance uses, on cuda for real.
+        assert res.obj("acme/mid") is inst.mid
+        assert res.obj("acme/small") is inst.small
+        assert _device(inst.mid) == "cuda" and _device(inst.small) == "cuda"
 
     asyncio.run(_run())
-    vram_events = [(m.model_event.ref, m.model_event.vram_bytes) for m in sent
+    vram_events = {m.model_event.ref for m in sent
                    if m.WhichOneof("msg") == "model_event"
-                   and m.model_event.state == pb.MODEL_STATE_IN_VRAM]
-    assert ("acme/unet", 3 * _GiB) in vram_events
-    assert ("acme/vae", 1 * _GiB) in vram_events
+                   and m.model_event.state == pb.MODEL_STATE_IN_VRAM
+                   and m.model_event.vram_bytes > 0}
+    assert vram_events == {"acme/mid", "acme/small"}
 
 
-def test_tenant_loaded_ref_gets_residual_delta(tmp_path: Path) -> None:
+def test_tenant_loaded_ref_gets_residual_delta(tmp_path, snapshots) -> None:
     class Endpoint:
         def setup(self, model: str) -> None:
-            _Alloc.bytes += 2 * _GiB  # tenant loads weights itself
+            # Tenant loads weights itself: a real 64MiB CUDA allocation.
+            self.buf = torch.zeros(64 * _MiB, dtype=torch.uint8, device="cuda")
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
     spec = _spec("ep", Endpoint, {"model": HF("acme/opaque")})
+    refs = {"acme/opaque": snapshots["small"]}
 
     async def _run() -> None:
-        ex = _executor([spec], tmp_path, budget_gb=10, sent=[])
+        ex = _executor([spec], tmp_path, 4 * _GiB, [], refs)
         await ex.ensure_setup(spec)
-        assert ex.store.residency.vram_bytes("acme/opaque") == 2 * _GiB
-        assert ex.store.residency.movable("acme/opaque") is False
+        res = ex.store.residency
+        assert res.vram_bytes("acme/opaque") == pytest.approx(64 * _MiB, rel=0.1)
+        assert res.movable("acme/opaque") is False
 
     asyncio.run(_run())
 
 
-def test_concurrent_cold_setups_do_not_cross_contaminate(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(_FakePipe, "load_sleep_s", 0.05)
+def test_concurrent_cold_setups_do_not_cross_contaminate(tmp_path, snapshots) -> None:
+    from diffusers import DDPMPipeline
 
     class A:
-        def setup(self, m: _Unet) -> None:
+        def setup(self, m: DDPMPipeline) -> None:
             self.m = m
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
     class B:
-        def setup(self, m: _Vae) -> None:
+        def setup(self, m: DDPMPipeline) -> None:
             self.m = m
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
-    spec_a = _spec("a", A, {"m": HF("acme/a")})
-    spec_b = _spec("b", B, {"m": HF("acme/b")})
+    spec_a = _spec("a", A, {"m": HF("acme/mid")})
+    spec_b = _spec("b", B, {"m": HF("acme/small")})
+    refs = {"acme/mid": snapshots["mid"], "acme/small": snapshots["small"]}
 
     async def _run() -> None:
-        ex = _executor([spec_a, spec_b], tmp_path, budget_gb=20, sent=[])
+        ex = _executor([spec_a, spec_b], tmp_path, 4 * _GiB, [], refs)
         await asyncio.gather(ex.ensure_setup(spec_a), ex.ensure_setup(spec_b))
         # Interleaved loads would double-count each other's allocations.
-        assert ex.store.residency.vram_bytes("acme/a") == 3 * _GiB
-        assert ex.store.residency.vram_bytes("acme/b") == 1 * _GiB
+        res = ex.store.residency
+        assert res.vram_bytes("acme/mid") == pytest.approx(66 * _MiB, rel=0.25)
+        assert res.vram_bytes("acme/small") == pytest.approx(16 * _MiB, rel=0.25)
 
     asyncio.run(_run())
 
@@ -188,9 +202,11 @@ def test_concurrent_cold_setups_do_not_cross_contaminate(tmp_path: Path, monkeyp
 # --------------------------------------------------------------------------- #
 
 
-def test_unload_demotes_to_ram_and_next_setup_promotes(tmp_path: Path) -> None:
+def test_unload_demotes_to_ram_and_next_setup_promotes(tmp_path, snapshots) -> None:
+    from diffusers import DDPMPipeline
+
     class Endpoint:
-        def setup(self, m: _Unet) -> None:
+        def setup(self, m: DDPMPipeline) -> None:
             self.m = m
 
         def run(self, ctx, payload: _In):  # pragma: no cover
@@ -198,92 +214,105 @@ def test_unload_demotes_to_ram_and_next_setup_promotes(tmp_path: Path) -> None:
 
     spec = _spec("ep", Endpoint, {"m": HF("acme/unet")})
     sent: list = []
+    refs = {"acme/unet": snapshots["big-a"]}
 
     async def _run() -> None:
-        ex = _executor([spec], tmp_path, budget_gb=10, sent=sent)
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, refs)
         inst = await ex.ensure_setup(spec)
+        base = torch.cuda.memory_allocated()
         await ex.handle_model_op(pb.ModelOp(op=pb.MODEL_OP_KIND_UNLOAD, ref="acme/unet"))
         res = ex.store.residency
         assert res.tier("acme/unet") is Tier.RAM
-        assert inst.m.device == "cpu"          # actually moved, not just booked
+        assert _device(inst.m) == "cpu"        # actually moved, not just booked
+        assert torch.cuda.memory_allocated() <= base - 100 * _MiB  # VRAM freed
         rec = ex._classes[spec.instance_key]
         assert rec.ready and rec.instance is inst  # no teardown
 
         again = await ex.ensure_setup(spec)     # RunJob path: promote, no reload
         assert again is inst
         assert res.tier("acme/unet") is Tier.VRAM
-        assert inst.m.device == "cuda"
+        assert _device(inst.m) == "cuda"
 
     asyncio.run(_run())
     assert _events(sent, pb.MODEL_STATE_IN_RAM) == ["acme/unet"]
     assert _events(sent, pb.MODEL_STATE_IN_VRAM) == ["acme/unet", "acme/unet"]
 
 
-def test_unload_of_tenant_loaded_ref_tears_down_record(tmp_path: Path) -> None:
+def test_unload_of_tenant_loaded_ref_tears_down_record(tmp_path, snapshots) -> None:
     class Endpoint:
         def setup(self, model: str) -> None:
-            _Alloc.bytes += 2 * _GiB
+            self.buf = torch.zeros(64 * _MiB, dtype=torch.uint8, device="cuda")
 
         def shutdown(self) -> None:
-            _Alloc.bytes -= 2 * _GiB
+            self.buf = None
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
     spec = _spec("ep", Endpoint, {"model": HF("acme/opaque")})
     sent: list = []
+    refs = {"acme/opaque": snapshots["small"]}
 
     async def _run() -> None:
-        ex = _executor([spec], tmp_path, budget_gb=10, sent=sent)
+        base = torch.cuda.memory_allocated()
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, refs)
         await ex.ensure_setup(spec)
+        assert torch.cuda.memory_allocated() >= base + 64 * _MiB
         await ex.handle_model_op(pb.ModelOp(op=pb.MODEL_OP_KIND_UNLOAD, ref="acme/opaque"))
         assert ex.store.residency.tier("acme/opaque") is Tier.DISK
         assert ex._classes[spec.instance_key].ready is False
-        assert _Alloc.bytes == 0  # shutdown() actually freed the memory
+        assert torch.cuda.memory_allocated() == base  # shutdown really freed it
 
     asyncio.run(_run())
     assert _events(sent, pb.MODEL_STATE_ON_DISK)[-1] == "acme/opaque"
 
 
-def test_alternating_endpoints_swap_via_demote_promote(tmp_path: Path) -> None:
-    """Budget fits one 3GiB pipeline (+2GiB make_room margin): alternating
+def test_alternating_endpoints_swap_via_demote_promote(tmp_path, snapshots) -> None:
+    """Budget fits one ~148MB pipeline (+2GiB make_room margin): alternating
     setups must demote/promote, never tear down or degrade to offload."""
+    from diffusers import DDPMPipeline
 
     class A:
-        def setup(self, m: _Unet) -> None:
+        def setup(self, m: DDPMPipeline) -> None:
             self.m = m
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
     class B:
-        def setup(self, m: _Unet) -> None:
+        def setup(self, m: DDPMPipeline) -> None:
             self.m = m
 
         def run(self, ctx, payload: _In):  # pragma: no cover
             return payload
 
-    spec_a = _spec("a", A, {"m": HF("acme/a")}, vram_gb=3.0)
-    spec_b = _spec("b", B, {"m": HF("acme/b")}, vram_gb=3.0)
+    # Real pipelines are ~148MB (0.145GiB). make_room targets needed + 2GiB
+    # margin; a 2.2GiB budget holds exactly one pipeline: loading the second
+    # (declared 0.15GiB) finds 2.2 - 0.145 < 2.15 and must demote the LRU.
+    spec_a = _spec("a", A, {"m": HF("acme/a")}, vram_gb=0.15)
+    spec_b = _spec("b", B, {"m": HF("acme/b")}, vram_gb=0.15)
     sent: list = []
+    refs = {"acme/a": snapshots["big-a"], "acme/b": snapshots["big-b"]}
 
     async def _run() -> None:
-        ex = _executor([spec_a, spec_b], tmp_path, budget_gb=6, sent=sent)
+        ex = _executor([spec_a, spec_b], tmp_path, int(2.2 * _GiB), sent, refs)
         res = ex.store.residency
 
         inst_a = await ex.ensure_setup(spec_a)
         assert res.tier("acme/a") is Tier.VRAM
+        assert _device(inst_a.m) == "cuda"
 
         inst_b = await ex.ensure_setup(spec_b)  # make_room demotes idle A first
         assert res.tier("acme/b") is Tier.VRAM
         assert res.tier("acme/a") is Tier.RAM
-        assert inst_a.m.device == "cpu"
+        assert _device(inst_a.m) == "cpu"
 
         again_a = await ex.ensure_setup(spec_a)  # promote A back; B demoted
         assert again_a is inst_a                 # instance survived throughout
         assert res.tier("acme/a") is Tier.VRAM
         assert res.tier("acme/b") is Tier.RAM
-        assert inst_b.m.device == "cpu"
+        assert _device(inst_a.m) == "cuda"
+        assert _device(inst_b.m) == "cpu"
         for rec in ex._classes.values():
             assert rec.ready
 

--- a/tests/test_fp8_and_emergency_loading.py
+++ b/tests/test_fp8_and_emergency_loading.py
@@ -166,7 +166,7 @@ def test_no_storage_dtype_means_no_casting(tmp_path: Path) -> None:
 
 @pytest.fixture
 def emergency_on(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GEN_WORKER_EMERGENCY_QUANT", "1")
+    """A CUDA host with 10GB free — the rung is automatic there (gw#420)."""
     import torch
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
@@ -179,10 +179,13 @@ def test_snapshot_weight_bytes_reads_headers(tmp_path: Path) -> None:
     assert snapshot_weight_bytes(_snapshot(tmp_path, "BF16", 4096)) == 4096
 
 
-def test_emergency_env_gate(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("GEN_WORKER_EMERGENCY_QUANT", raising=False)
+def test_emergency_always_on_cuda_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    # gw#420: no env flag — the rung is armed iff the host has CUDA.
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     assert emergency_quant_enabled() is False
-    monkeypatch.setenv("GEN_WORKER_EMERGENCY_QUANT", "true")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     assert emergency_quant_enabled() is True
 
 
@@ -220,10 +223,12 @@ def test_emergency_rung_counts_planned_fp8_halving(
     assert len(pipe.transformer.casting_calls) == 1
 
 
-def test_emergency_rung_stays_out_without_env(
+def test_emergency_rung_stays_out_without_cuda(
     fake_diffusers: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    monkeypatch.delenv("GEN_WORKER_EMERGENCY_QUANT", raising=False)
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     snap = _snapshot(tmp_path, "F8_E4M3", 27 << 30)
     _Pipe.calls = []
     load_from_pretrained(_Pipe, snap)
@@ -236,7 +241,8 @@ def test_emergency_rung_stays_out_without_env(
 # --------------------------------------------------------------------------
 
 
-def test_variant_fit_emergency_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_variant_fit_emergency_verdict() -> None:
+    # gw#420: the rung is automatic on CUDA hosts — no flag anywhere.
     from gen_worker.api import Resources
     from gen_worker.models.hub_policy import (
         FIT_EMERGENCY,
@@ -249,27 +255,20 @@ def test_variant_fit_emergency_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
         cuda_version="12.8", gpu_sm=89, torch_version="2.11", installed_libs=[])
     res = Resources(vram_gb=34)  # klein-9b-class on a 24GB card, 20 free
 
-    monkeypatch.delenv("GEN_WORKER_EMERGENCY_QUANT", raising=False)
-    assert variant_fit(res, caps, 20.0)[0] == FIT_OFFLOAD
-
-    monkeypatch.setenv("GEN_WORKER_EMERGENCY_QUANT", "1")
     fit, reason = variant_fit(res, caps, 20.0)
     assert fit == FIT_EMERGENCY
     assert "emergency quality" in reason
-    # 4-bit estimate still too big -> offload even with the env set
+    # 4-bit estimate still too big -> offload even on a CUDA host
     assert variant_fit(Resources(vram_gb=60), caps, 20.0)[0] == FIT_OFFLOAD
 
 
-def test_select_variant_prefers_emergency_over_offload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_select_variant_prefers_emergency_over_offload() -> None:
     from gen_worker.api import Resources
     from gen_worker.models.hub_policy import (
         TensorhubWorkerCapabilities,
         select_variant,
     )
 
-    monkeypatch.setenv("GEN_WORKER_EMERGENCY_QUANT", "1")
     caps = TensorhubWorkerCapabilities(
         cuda_version="12.8", gpu_sm=89, torch_version="2.11", installed_libs=[])
     choice = select_variant(

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -313,13 +313,19 @@ def test_vram_ladder_picks_largest_fitting():
 
 
 def test_base_fallback_below_every_floor():
-    # 8 GB free: nothing fits -> base binding + offload ladder.
+    # 8 GB free: nothing fits resident, but fp8's 4-bit estimate (14 * 0.45
+    # = 6.3) does -> the automatic emergency rung (gw#420) outranks offload.
     choice = select_variant(
         _FLUX_VARIANTS, _CAPS_4070, 8.0, base=("flux", Resources(vram_gb=24)),
     )
+    assert choice.name == "flux-fp8" and choice.fit == "emergency_quant"
+    # 5 GB free: even 4-bit estimates too big -> base binding + offload ladder.
+    choice = select_variant(
+        _FLUX_VARIANTS, _CAPS_4070, 5.0, base=("flux", Resources(vram_gb=24)),
+    )
     assert choice.name == "flux" and choice.fit == "offload"
     # No base declared -> smallest compatible variant, offloaded.
-    choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 8.0)
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 5.0)
     assert choice.name == "flux-fp8" and choice.fit == "offload"
 
 
@@ -390,7 +396,8 @@ def test_listing_carries_fit_and_variant_of(monkeypatch):
     assert doc["detected"]["free_vram_gb"] == 16.0
     by_name = {f["name"]: f for f in doc["functions"]}
     assert set(by_name) == {"generate", "gen-fp8", "gen-nvfp4"}
-    assert by_name["generate"]["fit"] == "offload"          # 24 GB > 16 free
+    # 24 GB > 16 free, but 24 * 0.45 fits -> automatic emergency rung (gw#420)
+    assert by_name["generate"]["fit"] == "emergency_quant"
     assert "variant_of" not in by_name["generate"]
     assert by_name["gen-fp8"]["fit"] == "fits"
     assert by_name["gen-fp8"]["variant_of"] == "generate"
@@ -410,6 +417,7 @@ def test_variant_auto_picks_fp8_on_sm89(monkeypatch):
 
 
 def test_variant_auto_base_fallback_below_floor(monkeypatch):
+    # 8 GB free: gen-fp8's 4-bit estimate fits -> emergency rung (gw#420).
     _patched_hw(monkeypatch, sm=89, free_gb=8.0)
     mod = _variant_module()
     candidates = run_mod.discover_candidates(mod)
@@ -417,7 +425,14 @@ def test_variant_auto_base_fallback_below_floor(monkeypatch):
         candidates, cls_name=None, method_name="generate",
         default_name=None, variant="auto",
     )
-    assert picked.fn_name == "generate"  # base + offload ladder
+    assert picked.fn_name == "gen-fp8"
+    # 5 GB free: no 4-bit estimate fits -> base + offload ladder.
+    _patched_hw(monkeypatch, sm=89, free_gb=5.0)
+    picked = run_mod.select_function_with_variant(
+        candidates, cls_name=None, method_name="generate",
+        default_name=None, variant="auto",
+    )
+    assert picked.fn_name == "generate"
 
 
 def test_variant_by_name_and_unknown(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +73,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
     { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
     { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
+]
+
+[[package]]
+name = "bitsandbytes"
+version = "0.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815, upload-time = "2026-02-16T21:26:06.783Z" },
+    { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714, upload-time = "2026-02-16T21:26:11.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d4/501655842ad6771fb077f576d78cbedb5445d15b1c3c91343ed58ca46f0e/bitsandbytes-0.49.2-py3-none-win_amd64.whl", hash = "sha256:2e0ddd09cd778155388023cbe81f00afbb7c000c214caef3ce83386e7144df7d", size = 55372289, upload-time = "2026-02-16T21:26:16.267Z" },
 ]
 
 [[package]]
@@ -489,6 +523,26 @@ nvtx = [
 ]
 
 [[package]]
+name = "diffusers"
+version = "0.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "importlib-metadata" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/81/6095237b86a3116c4789f28c4435d5296c00c0fc74ffde99008fd6b3a36c/diffusers-0.39.0.tar.gz", hash = "sha256:14bb1d98c85a0e463d734c99aaa73b480a7bc9bad22af30fbf730ef8f09c1d67", size = 4651240, upload-time = "2026-07-03T08:48:47.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3f/7469c46e9d22307ea686bab687d70e6bf328722952f9d10339f5e913e608/diffusers-0.39.0-py3-none-any.whl", hash = "sha256:912aca51b5787365110806e984d5555735bf8a461073bb8459029d0bca7870ef", size = 5631176, upload-time = "2026-07-03T08:48:45.337Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -531,11 +585,14 @@ audio = [
     { name = "soundfile" },
 ]
 dev = [
+    { name = "accelerate" },
     { name = "av" },
+    { name = "diffusers" },
     { name = "grpcio-tools" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "transformers" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
@@ -543,6 +600,7 @@ images = [
     { name = "pillow" },
 ]
 torch = [
+    { name = "bitsandbytes", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "safetensors" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -561,10 +619,13 @@ vision = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "av", marker = "extra == 'dev'", specifier = ">=12" },
     { name = "av", marker = "extra == 'video'", specifier = ">=12" },
+    { name = "bitsandbytes", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=0.45.0" },
     { name = "blake3", specifier = ">=1.0.0" },
     { name = "boto3", specifier = ">=1.41.0" },
+    { name = "diffusers", marker = "extra == 'dev'", specifier = ">=0.36.0" },
     { name = "gguf", specifier = ">=0.10.0" },
     { name = "grpcio", specifier = ">=1.80.0" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
@@ -588,6 +649,7 @@ requires-dist = [
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=2.11.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'torch'", specifier = ">=2.11.0" },
     { name = "torchvision", marker = "extra == 'vision'", specifier = ">=0.26.0" },
+    { name = "transformers", marker = "extra == 'dev'", specifier = ">=4.55" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.4.20250913" },
 ]
@@ -808,6 +870,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -1684,6 +1758,110 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.6.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/05/e4f219230e11e774a6c9987d2ab0d0c6b8573e13a17e143d0015bee710ef/regex-2026.6.28.tar.gz", hash = "sha256:3cb4b6c5cb3060cc31efdc1fbb27c25fb9b29044afd87e40601a1c4d9db54342", size = 416101, upload-time = "2026-06-28T19:56:55.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/db/9051b36294bdbabaa9c7db57db0fbcdfbd17f7a106c539bb423d0323faea/regex-2026.6.28-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a71b51dd08b9b62f055fafab3dee8af8bd2ec81b373a44caef18d6c5ca28f43a", size = 489481, upload-time = "2026-06-28T19:53:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3f/24097a3c3ff30f9a639888900faaecabcf5f54a5bc9c851c297e11b349ef/regex-2026.6.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c26a47770d30a0f85c01e261d2a3ebc342c4af6fd666dbd8c1fe4cbf3adf726", size = 291292, upload-time = "2026-06-28T19:53:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/cc/e0d762a189cfb4e8926d16e691720690d139a977b38fdb80230c259332ab/regex-2026.6.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e5efbc1af38f97e300d43028e5a92e752d924bcfb7f465d8669d5d5a6e78c233", size = 289232, upload-time = "2026-06-28T19:53:40.181Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c8/ca0ac7f09cc88ca61e0c61c53f7db29334f660ffba5d0b52378e7c44723c/regex-2026.6.28-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1758df6fdd8c800620a5638958720e8a635e1da49a2f09df2dd63e94a24ec4a", size = 792332, upload-time = "2026-06-28T19:53:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/92/04ae94cbe0dd1f478b2aef6c46f995bb6946d3e338d4b28605478b66a2b7/regex-2026.6.28-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ad73ecf20c1ef5c975639f8bf845a9370fcf7dada7edc1e3b0bca20e2f8202f6", size = 861743, upload-time = "2026-06-28T19:53:43.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ec/024d7638c807679ff8a0e6081d01d66c7762339af1cac71e45911587ff9a/regex-2026.6.28-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d80c798b0eec6ea3d45f8816a1e8886c5664615d347d89e8c075b576a1b5a5d", size = 906481, upload-time = "2026-06-28T19:53:44.948Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/fd/93bfe5af45f0be4fa8983945455c0e6924e1aeb879cde227958869c1e71c/regex-2026.6.28-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a361feeaf1b6ba1df060f2ff5c5947092edf537a35ce78e76387ac56d3e0f4a4", size = 799867, upload-time = "2026-06-28T19:53:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fd/e5d965d41f2398c8ce0f37a4652f03bb297fd009bb796d390134225dda12/regex-2026.6.28-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b92366d9c8bba9642989534073662abdd9b41faf7603a7ae71597833f3b88f0", size = 773632, upload-time = "2026-06-28T19:53:48.892Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/ff39afaec92b9ee2dba0302a4783976005091681069808938c31cf8df3b6/regex-2026.6.28-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:11251768cc23f097dd61b18f67966e70f74da822784d17e12a444eb6b29d4288", size = 781669, upload-time = "2026-06-28T19:53:50.693Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4e/e2fd4bb8228e10c24af2d7ff867182372190e498eab9fd29cbe54c403c95/regex-2026.6.28-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ad5c67786145ec28a71a267d9f9d92bdc8d70d65541eea852c253f520a01f918", size = 854497, upload-time = "2026-06-28T19:53:52.323Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7c/f0340384a973082979064156d05f3d2cc1dced7371efcd7a1b45726a1a8a/regex-2026.6.28-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f1da438e739765c3e85175ede05816cbede3caaacb1e0680568bda6119bfdfca", size = 763335, upload-time = "2026-06-28T19:53:54.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/90ce0d0898e205506cc22b9c81cfb16b722e06ca5f50fad51c053c2a727b/regex-2026.6.28-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d98b639046e51c5de64d9f77351532105e99ca271cb6f7640e1f903d6ab63032", size = 844615, upload-time = "2026-06-28T19:53:56.216Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/55abb149599dce1ade687170557129524011eeb3d92afe02429cea7754a2/regex-2026.6.28-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e164ace4dbab5c6ad4a4ac7c41a2638fe226d0c770a86f2eb041f594bac6ee7", size = 789193, upload-time = "2026-06-28T19:53:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ea/cf7f6f6f152e52fdad978b913bf24c14df647eca0f81ef31f3aee0be8982/regex-2026.6.28-cp311-cp311-win32.whl", hash = "sha256:3169a3159e4d99d9ae85ff0ed90ef3b8906cc3152653b6078b842ace6c8f72c3", size = 266731, upload-time = "2026-06-28T19:53:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cf/a48d8e8d406b22481cad146f48fa0dfca3c5f402b91f26d8e5a0fe4f513d/regex-2026.6.28-cp311-cp311-win_amd64.whl", hash = "sha256:5977295b0a74e8241df8a4b3b27b12412a831f6fa32ee8b755039592cd768c3d", size = 277918, upload-time = "2026-06-28T19:54:01.502Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b2/a222392207db7ed86281a732a99f7cf7f2bb35d332799e892b8510be000e/regex-2026.6.28-cp311-cp311-win_arm64.whl", hash = "sha256:f5fbaef40c3e9282ccee4b075f5600a0d858aa0c34147732f1baa69c8188a95d", size = 276876, upload-time = "2026-06-28T19:54:03.411Z" },
+    { url = "https://files.pythonhosted.org/packages/da/21/44aa415873032056c43eac21c67285deb2cf66cddb2a964c3cdc8f803efc/regex-2026.6.28-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:81cc5793ad33a10444445e8d29d3c73e752c8fb2e120772d70fcb6d41df40fe1", size = 490480, upload-time = "2026-06-28T19:54:05.392Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5f/30d4116093c2128099f78b6990dfc1698fdbf3ee528f1e1c647378034c79/regex-2026.6.28-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e18225243250a1f7d7e5e5d883f3b96465cd79031acf5c6db902b7025f2125d9", size = 292137, upload-time = "2026-06-28T19:54:07.088Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/ca20a0e0de49837e6337603a91ab77556aa27033ac5b975615d98698cfb3/regex-2026.6.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ecd1638b1c2db1f2d01c182a4b0d3e2e88b0e99910320a745c1727ee3638ddab", size = 289623, upload-time = "2026-06-28T19:54:08.762Z" },
+    { url = "https://files.pythonhosted.org/packages/50/11/c013422a7e2c59946df8ac93e792a4922c98287f2a2181341603c78a5d98/regex-2026.6.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4303ebe16b74eeb3fe2715745023266fea92fd44a23f3e7bb2fb48c7a7bbc195", size = 796756, upload-time = "2026-06-28T19:54:10.616Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/95/1309645a0e1ee6fb91d954501da57a0b33d50ad2a9acb313702851a7054e/regex-2026.6.28-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56b856b70b96c381d837f609eee442a1bd320cd2159f5c294b679552fb1a7eaf", size = 865465, upload-time = "2026-06-28T19:54:12.742Z" },
+    { url = "https://files.pythonhosted.org/packages/20/06/491802db47c6f5e2904ffa2518ad3ac27fe6bbf5a66d73210a95cc080d47/regex-2026.6.28-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f74675ab76ab1d005ffba4dee308e53e89efc22be6e9f9fae5b539a3f81bdff2", size = 912350, upload-time = "2026-06-28T19:54:14.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/60/3ba57840bcc7e2367090360de0c15a5ba6ad22be89314251105f2e943f43/regex-2026.6.28-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90581684565a93f7258af1e5d3f41ef20d7d7c61f2a428183a342bcb65485e38", size = 801261, upload-time = "2026-06-28T19:54:16.432Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/27/af1eb74e9a78c782b3e450b611a595e44906da8a5107e1227f4a7fd0480b/regex-2026.6.28-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:28f9e6c28f9b90f6f784595a33240a57e181e61b6ee3dc259b25c61e356d1aa3", size = 777072, upload-time = "2026-06-28T19:54:18.128Z" },
+    { url = "https://files.pythonhosted.org/packages/20/18/fdd4c883a39e3ed00d669062af1135809bfd3281bf528150849fbd68825b/regex-2026.6.28-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:378a71d861fc7c8806b04ac5b133d53c0e774f92f5d9663a539872d3fa2b0417", size = 785119, upload-time = "2026-06-28T19:54:20.314Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/79/0aabe34b8482dcadf64355f70f96e22eba5ec6c1efb33563f89654f4061c/regex-2026.6.28-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4cc199874ecd6267a49b111052250825bfe19b5101b23b2ba80f54efa3e0994e", size = 860118, upload-time = "2026-06-28T19:54:22.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2c/c973323306a27c9db7d160e9584eb7e0ece2a96224ccb0d39060558b31f9/regex-2026.6.28-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b916a10431494ef4b4d62c6c89cab6426af7873125b8cd6c15811bf5fc58eec8", size = 765786, upload-time = "2026-06-28T19:54:24.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/df/9ca3e378e352242a4cb45573a5e9162c3ee791507702a23966fa559e36b5/regex-2026.6.28-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2e27727fba075f1e4409416d2f537d4c30fc11f012ea507f7bd74d3e19ecb57a", size = 852120, upload-time = "2026-06-28T19:54:25.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/3e/3e31e255c4971f53cbce6306b5e3c76cbd3735a54f419bb3b2f194e9f68c/regex-2026.6.28-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:700fc6a7844bb2c4149292ac79d1df8841a00acd4d45cd32c1ebc7bcc1fd0da8", size = 789503, upload-time = "2026-06-28T19:54:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/72/01/d36561c21c3033d7eeb31d51b491916817de7861acefccc5fc9db8a5037c/regex-2026.6.28-cp312-cp312-win32.whl", hash = "sha256:03376d60b6a11aecb88a79fa2be06b40faa01c6693bc31ef69435cd4818b9463", size = 267109, upload-time = "2026-06-28T19:54:29.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/59/bbbb0591f38b18c65977cd65ce64749eba1c1996c99ac04e900fc30c0dcb/regex-2026.6.28-cp312-cp312-win_amd64.whl", hash = "sha256:fbd2ded482bf99e6651992bbfcde460272724d4bbc49ef3d6b46d9312867ec84", size = 277711, upload-time = "2026-06-28T19:54:31.143Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/be4f6b337d773ae5739a1bc238f97c16926e72017243735853c030f4c628/regex-2026.6.28-cp312-cp312-win_arm64.whl", hash = "sha256:37294d3d7ddb64c7e89184b2894e0f8f0a19c514bc59513d71fe692c3a8d5fc6", size = 277022, upload-time = "2026-06-28T19:54:32.97Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/53/d5c1b3cc0b5a0c985563ad6fac93d73ff2b300cb84342d89f044625d6bc7/regex-2026.6.28-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b295a83426e0e44e9e60fde99789e181bd26788a1890ae7fe2a24c69bb6246ca", size = 490329, upload-time = "2026-06-28T19:54:35.775Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9f/0c3503e819e91ca0e7a901a8e989ebf840ac7c7aea20b1fc7f31b6759f77/regex-2026.6.28-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0c31665c0deb5c111557a1cac8c27bd5629e2f9e7fd5058900a03576c33b601c", size = 292039, upload-time = "2026-06-28T19:54:37.977Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7f/cd004e13fcad23b3794a82307dfd222e6365eb7f598bd3caab148a830bff/regex-2026.6.28-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6bf295f2c59de77d1ea7de053607ae4dc9ceb3d57bbb6c7ec51ef4acc4ccff94", size = 289488, upload-time = "2026-06-28T19:54:39.545Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4c/293fb34586fbcdc47eac436069e9c11f71fae5dadfd4889b475d7d2e5f7a/regex-2026.6.28-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17c077586770f67e05bbffeba07fbee6b2b22244f4d4caf8d94e59d574befe04", size = 796772, upload-time = "2026-06-28T19:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fa/c0cd1a90b7d12d9dc155cfc8bdea8df9720988ea5b07e8fa1eccbd0ab2dd/regex-2026.6.28-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e6cb5a61486f9062397d2e189573b39d38ecfaed698fd9fb6e2756a8ebb8762", size = 865467, upload-time = "2026-06-28T19:54:43.485Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/db/0b479973046d005a1eaea299d5d536aeecb9488a16d9cbb8286338102e2d/regex-2026.6.28-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e86e91a2664f44c3a4e363a7d78fb17c27d5046882e30ea5a877f5e89b28d2ba", size = 912345, upload-time = "2026-06-28T19:54:46.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5b/d65adfbd02f32212431bca1f06d1e2eb763a20b12978b454bafaf23dacb7/regex-2026.6.28-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4dfd1331c49233998d84fc5f1f4436cf7a435a7655f6cf0f490229bb5c7254e5", size = 801291, upload-time = "2026-06-28T19:54:48.3Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/09/2103686defaf9a0a31c1663782359d5b45f42524c64cca681f5481e44a5e/regex-2026.6.28-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cadea12805a1bce0b091c302b814207be26fb60a9c0e7f9ad2f9e21790a429fe", size = 777106, upload-time = "2026-06-28T19:54:50.326Z" },
+    { url = "https://files.pythonhosted.org/packages/85/5a/b57593c0aa23ed269ec332fbcf07852abcb6b746e811d9464e0d09b4e25f/regex-2026.6.28-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f2c1682b67ad5d2376498f2a5a2a8f782fa2e4a06d0465b5e357799806e8a20", size = 785175, upload-time = "2026-06-28T19:54:52.172Z" },
+    { url = "https://files.pythonhosted.org/packages/79/59/c36e756ad29bf14d7b6c6d7138952476b21f6160286cedb98ac13481c993/regex-2026.6.28-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:64e142eb55e84868087da1375d7c36ff97d55010951849f515322a91d5fef1b4", size = 860186, upload-time = "2026-06-28T19:54:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/49808aea0da9649c300139360708fb91b7144be1f962fcebf96755fde948/regex-2026.6.28-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:abb4daabe7be63273787a62dfd6164dadf8f7a63fbec3d2730e5e5e7126d858c", size = 765754, upload-time = "2026-06-28T19:54:56.04Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c5/52bbd436cf2200decdf48825fa38363eaaeebb77011ea9928a1ef9e0b9f2/regex-2026.6.28-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec2b2ad00ab8c16a2798cc8db80c53c4d5b8b3a2441f6cbaef06625f5ca25854", size = 852085, upload-time = "2026-06-28T19:54:57.988Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c3/0390b66e3019497143fe768b3ba567b64d8b24f3812d09506deb86f4a0f0/regex-2026.6.28-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bfc9677982c914d9085b8e1c3b3ae6e88f139fb56531c2416d6c8f338093c22b", size = 789600, upload-time = "2026-06-28T19:54:59.977Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fd/ab5b03653a244975069fed93d73f4f5f7484c03a84cedb238292510d7182/regex-2026.6.28-cp313-cp313-win32.whl", hash = "sha256:bf54bc693fc4e0530e666ba5ec4bcba14dbe8f66b7cfc15c27317d1a6e40b9a5", size = 267088, upload-time = "2026-06-28T19:55:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/68/55/21022f7d3143210ae8d4ff905c45306237b657375cc0b97883f49db3d423/regex-2026.6.28-cp313-cp313-win_amd64.whl", hash = "sha256:e128feaf65bf3d9eb91bec92322a8f7e4835e9c798f3e9ea4b69f4def85620e3", size = 277680, upload-time = "2026-06-28T19:55:04.185Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/7f664804f1aef924542b0b233996b78b3e4d0a52d9951358aac99f129f51/regex-2026.6.28-cp313-cp313-win_arm64.whl", hash = "sha256:695873e0ea8d3815ea9e92e2c68faf039cc450e2c0a62a31afe2049eb11be767", size = 277017, upload-time = "2026-06-28T19:55:06.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/9eb83518e159d719fd681c4932dc2aaff855ce72451e1d05d69466f25a96/regex-2026.6.28-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:189dbf9fc4252d9f1352bf4bd1bef885edb6cc4b7341df202a65f821aaa3891c", size = 494195, upload-time = "2026-06-28T19:55:08.292Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e2/e259c5f2f7be269d0e2fb54275c1fa6a13fb47019f389c3f3ae457447825/regex-2026.6.28-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9277a4c6503390aa39cb4483b87ec0384faee0850a23b5cea33d008b5d8d83f1", size = 293976, upload-time = "2026-06-28T19:55:10.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4e/9bdf444014d22b045d0c82ca114fac7e07a597b5b5331b7c4ce6328426e2/regex-2026.6.28-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:17eddca4e8ea9af0b5739314776cdf0172a49731ab61f2e1ea66e066ddd46c97", size = 292340, upload-time = "2026-06-28T19:55:11.88Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/f49b11e59cbfe187ace0053a460bd72a0169b8cd52e7db9421a074ce7a43/regex-2026.6.28-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4466b8641e00c697aab5a73150150d2b2ea96b131c595691f42031abafd9f4d", size = 811704, upload-time = "2026-06-28T19:55:13.612Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/fb/ad04c39e149bf8b6cf357df5fff78341733ec366780a00c803a36735818c/regex-2026.6.28-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cfcd4b0bdcf768c498415c170d1ed2a25a99bf0b65fa253bbd02f68ceba6475", size = 871157, upload-time = "2026-06-28T19:55:15.797Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/0e5ba31c11eb8ef7aac19a690c1211fc9aa9990caf09565785ebb0081b9a/regex-2026.6.28-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:80c7adf1ef647f6b1e8aa2ca280e517174cd08bdf7a2e412cdfb68bd6a0917cb", size = 917287, upload-time = "2026-06-28T19:55:18.692Z" },
+    { url = "https://files.pythonhosted.org/packages/11/75/6b78df2b858c2fcbbc4858fdc3f2975cf2703be374b2842db7d2c32591a7/regex-2026.6.28-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a043f5770e82283a22aed4cefef1a4e0f9dd8fd7184cb6ce0ad2e579e2134a9e", size = 816333, upload-time = "2026-06-28T19:55:20.973Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/01/ecfe665a3694d5eda9f3ec686c856438ada0943947b6005e90556a1e2cdf/regex-2026.6.28-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3bd630a8dba06b55254ea5ee862194edab52ec783100d2ef1cd15a9c512fee27", size = 785518, upload-time = "2026-06-28T19:55:23.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0a/88f9cd88ff1e82881605c4ffd62d77ee67d051232cfe6f8e9a64b86cf0e8/regex-2026.6.28-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b77207e3cee13086f1906a6a2a12b41244c577e8ad9370d4b35ae1d548d354f3", size = 801371, upload-time = "2026-06-28T19:55:24.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/97/601483732f93275482ceb9fed57813dfed7c47d3a019db6ec4a3bb6e23e0/regex-2026.6.28-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:6de82c268e5d101ee9e3ffd869924aa9a371e3a21e752cf4fa17b6ce50d219f7", size = 866517, upload-time = "2026-06-28T19:55:27.232Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/385c2a0351b994a693453c1d1a6e9af9eb35db3c9460d76b5078acd70c62/regex-2026.6.28-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b15859e3908544fb99cf47341dcf0bfd089147d258c4c4d8a29e5b087f8085cb", size = 772834, upload-time = "2026-06-28T19:55:29.154Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bc/bbf4a5b3b29770d7f307d3c28b5b1bca0105b0cb424be0a4eb1339bc92cf/regex-2026.6.28-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:c91487a917edd48a1ea646fdf60d7936d304f0e686fa7ea8326e47efca51d816", size = 856606, upload-time = "2026-06-28T19:55:32.186Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/51d74fff82f682819979249f8d700267108ba5dc4eb284b0e11b9c85e4b3/regex-2026.6.28-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4ac65f3e3a99fd8f3a4a74e7a6610acd1ce9dfe9b8a03d346a4922380d68aeb", size = 803475, upload-time = "2026-06-28T19:55:34.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3e/6be10cefdc813533fe604dbf5d3c77d2638e7ee658b2749ebadc113b6b2e/regex-2026.6.28-cp313-cp313t-win32.whl", hash = "sha256:3f6316f258bc7e6c9c2acbe9954947bbd397a81be3742a637a555f1855d6618d", size = 269126, upload-time = "2026-06-28T19:55:36.565Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3c/32cda905ea1a6eeeb798291c294d8ec66ee0efe0cdba28b061e248b1d396/regex-2026.6.28-cp313-cp313t-win_amd64.whl", hash = "sha256:1484bdd6fba28422df9b5ebb04055b2e1b680e8e4f08490bb21ff0f3cc50d0ab", size = 279961, upload-time = "2026-06-28T19:55:38.456Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b9/69f4e5cd6fbe0bb420cb2dbae441ca118f2495bdda522a74da75aa9829e7/regex-2026.6.28-cp313-cp313t-win_arm64.whl", hash = "sha256:3f15020f0b69cafe57baa067ff65b29acef68ff6b1670a53bef1ca11d708e02d", size = 279266, upload-time = "2026-06-28T19:55:40.62Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/fb/fad3b810a5bb1e09b9e5d6913fc6ba88cab738fdf283196827a3c59a4c10/regex-2026.6.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:f7c032b0c8a73739ff8ff1aaf30c281fa19c17bf7f1543256c8507390db7807c", size = 490407, upload-time = "2026-06-28T19:55:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/52/b8c79d12276d93e90e707e939b396034c04980caf1235312ef790f8e11fc/regex-2026.6.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f6710f512c57b84f127a23d0f59560a03b64136eff419ae1be5ab557577fe5e3", size = 291988, upload-time = "2026-06-28T19:55:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/6a911f18279daa8d7bb8b20d771ddb6ef31fabd35f5921f9d3ba21640e80/regex-2026.6.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0013958f427bd82509a186b9ff206d66cb8d60a81fc797a4c717afd18c5b0ba", size = 289704, upload-time = "2026-06-28T19:55:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/22/ad1955c47c669291a05804d53d7071cc0732dfdf166857be38003cedc2d1/regex-2026.6.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f06cdcd6421f8e194ad312ea608020381250df9b8a57661c1b57e9e5273878", size = 797017, upload-time = "2026-06-28T19:55:48.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/a83159ff8703ab4d0c2cf99e76ebf289b7b4a501623241d09f88f3614f80/regex-2026.6.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec9689392f7494ff4e3f8e7e8522f9158f11023f337eaaf04a64542fc45bbf26", size = 866112, upload-time = "2026-06-28T19:55:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/7bff2d6dbbd77421b3274aa51db1c887381cbc5b6eda93598c3e882ea345/regex-2026.6.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aa084684e6d2078bf6139e374d1fc2af5ddc1ac7122759a2db716d68169f6fd0", size = 911554, upload-time = "2026-06-28T19:55:53.707Z" },
+    { url = "https://files.pythonhosted.org/packages/29/44/ae59c3826e7ba492e56795cdf74ea2a7b5b7c5ea116afb79ee4956a5dff1/regex-2026.6.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40455e6840dc4e96a6fe50f4cedc957de2752c954d91e789812be55d49be199a", size = 800665, upload-time = "2026-06-28T19:55:55.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/19/6fd033d2ab00f35d445aaeaf3307c1e721424dcbfd48f6f65c857cb939cf/regex-2026.6.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:530b5c223b9ca5dd8370ac502e080aee0e4ded32be987c6564b425fb5523d581", size = 777243, upload-time = "2026-06-28T19:55:57.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9d/99730f26df4938049ab1e652ca75e967b4c6739444e18d9707bfdb8af20c/regex-2026.6.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e0ed273ecd1a89be84466c1749bfe58609cc2a32b5d5e05006c4625ba96411b", size = 785784, upload-time = "2026-06-28T19:56:00.072Z" },
+    { url = "https://files.pythonhosted.org/packages/48/49/105cd57162f5fc5c04cc917a1388a060cf8427e5c14353cd9044660fbf4d/regex-2026.6.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0ab0d5344311fc8e8667078942056c3b9c9b4a4b1cc99f2eb8a5af54554f4acc", size = 860914, upload-time = "2026-06-28T19:56:02.017Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/788245a95b69018f58bff2f4fd27d007cacaea088cdb390979743f1b2571/regex-2026.6.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:eacb79625323d9f7e7925366b917f492b8356fad58f5dc4fa12ff8c21d8f4ca9", size = 765915, upload-time = "2026-06-28T19:56:05.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/292065a39a004b05e67a337b18213670a7cb919d6856ac2d7df7f1a10dbb/regex-2026.6.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20f4d87702702aa1d572721e146f301660c50eef6fd6cb596e48a22b0ace17db", size = 851404, upload-time = "2026-06-28T19:56:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a93d865db0e13483ae1a01d81e2ce16d4a7fe2f9b9fe4aac4cc08590b136/regex-2026.6.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e693940a3b9e6d6e4dc2a54ecaa74b74934f77af1ef95f518a74261ef7cc1bc", size = 789373, upload-time = "2026-06-28T19:56:09.894Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0c/38b1685ad4017d78efbc8fa7dbbf96d8113b53750c8aa2d3609defd46605/regex-2026.6.28-cp314-cp314-win32.whl", hash = "sha256:234a51e20ebc18ab83b2c0600cf28f2e884560a0e00f743878f0b7d8e7c4cf03", size = 272496, upload-time = "2026-06-28T19:56:11.83Z" },
+    { url = "https://files.pythonhosted.org/packages/55/50/e19f261ff9ba9b50722a529e09b1743ecf65eb348be99d0fd2cd7fcede1c/regex-2026.6.28-cp314-cp314-win_amd64.whl", hash = "sha256:7b15c437bc4604f03ceb3f8d37eae2f8930e320e1bc556b259848c639d9eec1a", size = 280754, upload-time = "2026-06-28T19:56:13.758Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b8/c9e68f3a9e33be73f20990b2c065b144ff2d0aa242608a950d8c4f3b56e8/regex-2026.6.28-cp314-cp314-win_arm64.whl", hash = "sha256:c6e6f790d01380a74ad564f216c533b86504afb61bf66f2b2e11e7f1a3e287a7", size = 280979, upload-time = "2026-06-28T19:56:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e6/21c425a37880c650d007c4171c6a80325446d830d85f5fbf335e7205b1e7/regex-2026.6.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3527a72adcbe9e3600f1553b497d397c1a371d227580d41d96c3c5964109b65c", size = 494282, upload-time = "2026-06-28T19:56:18.049Z" },
+    { url = "https://files.pythonhosted.org/packages/07/50/6647a7ccf5ffff995ba955a0b7d766440f4e58ce1666549c8ee998f2b972/regex-2026.6.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a644f6408692812f5ead82519eed680e08d5d546fddbd9f7d9514e3c73899aa5", size = 293977, upload-time = "2026-06-28T19:56:20.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/dc/a3e141a4eaf125e50f63105570c01fa477c06ac5259dcfa95e9b90760e84/regex-2026.6.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8e2fae6bb883648346f84db270dc9aafc29d8e895f62b88a75ccc83b09519820", size = 292432, upload-time = "2026-06-28T19:56:22.345Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ee/2ac1a6b9f167f8ff69f5a789938cc103b60cff41b24a6990daced8b88e34/regex-2026.6.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:debe623e09cee97ef9404575e936c610aac9bb08358c5099aaef14644a6871f2", size = 811877, upload-time = "2026-06-28T19:56:25.056Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7b/9a5505ee92180bcae300b1018b9ff3d3c19962436e66f2505f255e9fde35/regex-2026.6.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc579c91fb4605773483a8d940b136bcc5b854fff44fa14a1572a038f46563f1", size = 871212, upload-time = "2026-06-28T19:56:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4d/d61a702a9f9d1bd29b22cbef1aed6d477baa961232a7eb4d91b7775b0b3e/regex-2026.6.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e7c42be203d84ecf7d487ff23f8a61ef0eb0534fa0fc317a2fce8c065d20618f", size = 917507, upload-time = "2026-06-28T19:56:29.762Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/1308066f5966b65fbb6905b99ba37e9f1cd753dd0ac08485f8257334ee92/regex-2026.6.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8184b4e2fdaf9cdfe77e38f15a4d9dc149168c9c29eb0ea17c5481d3bb80546", size = 816389, upload-time = "2026-06-28T19:56:32.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/57ce2cb8d714ee0b7f11c7ee4cfe2af66df2b90f147feadcb538609a3a02/regex-2026.6.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:697f103104f5872d64078d8eeac59979960be8ee76115a2d3f31096312e2a400", size = 785890, upload-time = "2026-06-28T19:56:34.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fd/1d5350d3a8a327bff0fccacb911732baf7b5b6f5529c0e3fa602a23e7dad/regex-2026.6.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:714d2b1aa29beef0ddfcdc72ad0771c05326551a8bb0680b0ddf74bfaad87387", size = 801451, upload-time = "2026-06-28T19:56:36.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/79/3c9e4f8a0306e030ad5a43bbbc01625fb28d58a813bc52d42fd1cc63fb2e/regex-2026.6.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0f09f62e450cc2f113018cc8412aeea3a120a04e1ca7e801a0d441583f9a3b06", size = 866504, upload-time = "2026-06-28T19:56:38.994Z" },
+    { url = "https://files.pythonhosted.org/packages/65/12/f747de475b54f4709efb24dd0fbc8467c64cec91f5db0d047b079646ee78/regex-2026.6.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:731ea12d5aeb2577eaef2393d6428b995f76eb35f68a89e03e15a97719d1de19", size = 773047, upload-time = "2026-06-28T19:56:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3c/f02f860e0500c1b2d61a79dec7e214b37fb9656281dcddc92397edf96678/regex-2026.6.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:51e952c8783eabd4706d0f63922f219bcfc1bef9b8cb35941c0d1a0396578858", size = 856665, upload-time = "2026-06-28T19:56:43.466Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6c/28b3fa222513484be9dee26b7222bda109056c43ea28aa2314262ca48816/regex-2026.6.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43248fe4c0ab8fbb223588a0795b11268940072c97bba30ea8f9b49d8cdfde34", size = 803573, upload-time = "2026-06-28T19:56:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/8f86cf1a1fd85c5ab0c503c9fe4607ad4ad48978b2d8b435d94465e134c7/regex-2026.6.28-cp314-cp314t-win32.whl", hash = "sha256:fc1eddc25ad23c0f1344ab280d961ac595ead48292d7c779497975942373f493", size = 274515, upload-time = "2026-06-28T19:56:47.948Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/de/f8613c03b36786ddef2c930d28f9bcae861fcd541cc9203a870956cf1e83/regex-2026.6.28-cp314-cp314t-win_amd64.whl", hash = "sha256:ede8d8e53b6dde0a50f7eca902f0af76d87ab02a55aba7542da68ae3e5dfe83d", size = 283650, upload-time = "2026-06-28T19:56:50.614Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f3/f5ec86839bbabe33b6dee649b62ff9a445d43de6b0ad780cf6b83c56f61e/regex-2026.6.28-cp314-cp314t-win_arm64.whl", hash = "sha256:4da6f6a72f8700b97a1a765e837fb7d5750bfd9f13acea7bae498f573e3a70a8", size = 283338, upload-time = "2026-06-28T19:56:52.879Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1750,24 +1928,26 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
-    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -1826,6 +2006,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -1977,6 +2183,26 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "5.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/e1/720ff7ff666b04279fea5bb7ac3ef8675e98f0ddbc1b8cb8bc9f3889d62e/transformers-5.13.0.tar.gz", hash = "sha256:940c1428e42a4238f9ccf0cd41e63c590701aa63c19fd2ce3d7d602222d68495", size = 9195801, upload-time = "2026-07-03T16:05:39.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/3a/d99704c5effe10c6339c98cb236259161103e159bb99a78468b6729572ec/transformers-5.13.0-py3-none-any.whl", hash = "sha256:8adbc1d20bd5463cd6876b2eb7cb31971e1065788e7dc6bc12bab597a7c504b7", size = 11503730, upload-time = "2026-07-03T16:05:35.569Z" },
+]
+
+[[package]]
 name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2047,4 +2273,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Fixes three tracker issues (cozy-creator-tracker/python-gen-worker/progress.md).

## gw#416 — CLI str/Path slot injection
`cli/run.py:_load_injected_model` treated any non-class annotation as "load a DiffusionPipeline", so a `setup(self, pipeline: str)` slot got a fully-loaded pipeline instead of the snapshot PATH (executor contract). Added the str/`os.PathLike` guard + the missing str-slot injection test. Unblocks the cozy-local golden path (`TypeError: stat: path should be string ... not StableDiffusionPipeline`).

## gw#417 — CUDA-host promote livelock + real residency tests
- **Real bug**: `_promote_setup_refs` raised RetryableError whenever promote failed on a CUDA host — but refs tracked via `track_ram(ref, obj=None)` (str-slot/opaque setups) can NEVER promote, so RunJob retried forever. Promote-or-die now applies only to entries residency can actually move (`res.movable(ref)`).
- **Unload path checked**: real pipelines book VRAM-tier from measured allocator deltas and UNLOAD correctly demotes VRAM→RAM keep-warm (now proven by a real-pipeline test on CUDA); teardown-to-DISK only applies to tenant-loaded (object-less) refs, which is the intended #371 semantics — no code change needed there.
- **Test rewrite (Paul's direction, no fake pipes)**: `tests/test_executor_residency.py` rebuilt against real tiny-config diffusers DDPMPipelines (~16-148MB, constructed locally, no network): real tensors, real `.to(device)`, real `torch.cuda.memory_allocated` deltas. All 6 tests kept real, none deleted. They require CUDA and skip cleanly without it (GPU CI lane = gw#421). `diffusers` added to the dev extra.
- The two grpc e2e model-op tests already ran real tiny weights through the real load path; they pass unchanged with the livelock fix.

## gw#420 — emergency quantization always-on
- `GEN_WORKER_EMERGENCY_QUANT` env gate deleted; `emergency_quant_enabled()` is true iff the host has CUDA (no opt-out flag — fitting is the runtime's job). LOUD warning kept.
- `variant_fit`/`select_variant` arm the rung from declared capabilities (`caps.gpu_sm > 0`) instead of probing torch, keeping fit verdicts a pure function of their inputs (host-independent tests).
- `bitsandbytes` ships with the `[torch]` extra so the rung works out of the box (verified separately on the 4070: rung engages, SDXL ~2.3GB VRAM).
- Fit-policy tests updated: on CUDA-class caps, a fitting 4-bit estimate now outranks base+offload (per the ladder); added below-4-bit-floor cases that still fall to offload.
- Side effect: installing bnb unlocked `tests/convert/test_integration.py::test_quant_direction_nf4`, which needs transformers+accelerate — skip gate extended and both added to the dev extra so the bnb convert lane actually runs on GPU boxes.

## Verification (RTX 4070 Laptop 8GB, torch 2.11.0+cu128)
- `uv run --extra dev pytest tests/ -q`: **562 passed, 2 skipped** (previously 544 passed / 4 failed / 3 skipped)
- `CUDA_VISIBLE_DEVICES="" uv run --extra dev pytest tests/ -q`: **556 passed, 8 skipped** (6 = real residency tests skipping without CUDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)