### PR TITLE
gw#415: SVDQuant/nunchaku 4-bit loader mode (serve) + svdq flavor tree builder (produce/mirror)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.12.3
+
+- **SVDQuant/nunchaku 4-bit loader mode (gw#415).** A `#svdq-fp4-rN` /
+  `#svdq-int4-rN` flavor (diffusers tree whose denoiser dir holds one
+  nunchaku single-file checkpoint) is detected from safetensors
+  `__metadata__` and served by swapping the nunchaku transformer into the
+  standard pipeline (`gen_worker.models.svdq`). Hard (nunchaku, diffusers,
+  torch/cu) pin matrix with typed `SvdqStackError` at selection AND load —
+  nunchaku 1.2.x requires diffusers>=0.36,<0.37 (gw#405 live crash on
+  0.38/0.39). New fit verdicts `svdq_fp4` / `svdq_int4`: on sm_120/121 a
+  fitting svdq-fp4 row outranks everything (faster AND smaller than
+  fp8-storage, measured); svdq-int4 (sm_75–89) is a fit rung ahead of
+  emergency-nf4 only. `variant_fit`/`select_variant` are binding-aware;
+  worker capabilities now probe `nunchaku` + `deepcompressor`.
+  Convert side: `gen_worker.convert.build_svdq_flavor_tree` /
+  `fetch_svdq_checkpoint` build the flavor shape for the mirror + produce
+  lanes (>5GB artifacts refused: sharding would strip nunchaku metadata).
+
 ## 0.12.2 (2026-07-09)
 
 - fix: CLI str/Path model-slot injection passes the snapshot path instead of loading a pipeline (gw#416)
@@ -7,21 +25,6 @@
 - feat: emergency nf4 quantization is always-on for CUDA hosts (env flag removed); bitsandbytes added to the [torch] extra (gw#420)
 - residency tests rewritten against real tiny pipelines (no fake pipes)
 - note: 0.12.1 on PyPI was published from a pre-fix tree (gw#427) — use 0.12.2
-
-## Unreleased
-
-- **gw#416**: CLI `run`/`serve` str/`Path`-typed setup slots now receive the
-  snapshot PATH (executor parity) instead of a loaded `DiffusionPipeline`.
-- **gw#417**: fixed the CUDA-host promote livelock — object-less RAM ledger
-  entries (str-slot/opaque setups) are exempt from promote-or-die, so RunJob
-  no longer retries forever on `promotion ... failed`. Residency tests now run
-  against real tiny diffusers pipelines (no fake pipes); they need CUDA and
-  skip cleanly without it.
-- **gw#420**: emergency nf4 quantization is AUTOMATIC on CUDA hosts — the
-  `GEN_WORKER_EMERGENCY_QUANT` env gate is deleted (loud warning stays);
-  `variant_fit`/`select_variant` arm the rung from declared capabilities.
-  `bitsandbytes` ships with the `[torch]` extra so the rung works out of the
-  box.
 
 ## 0.12.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.12.2"
+version = "0.12.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -133,7 +133,8 @@ def function_entries(
         if variant_of:
             entry["variant_of"] = variant_of
         if caps is not None:
-            fit, reason = variant_fit(resources, caps, free_gb)
+            primary = next(iter((getattr(c, "bindings", {}) or {}).values()), None)
+            fit, reason = variant_fit(resources, caps, free_gb, binding=primary)
             entry["fit"] = fit
             if reason:
                 entry["fit_reason"] = reason

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -378,13 +378,19 @@ def select_function_with_variant(
     from ..models.hub_policy import detect_worker_capabilities, select_variant
     from ..models.memory import get_available_vram_gb
 
+    def _primary_binding(c: "_SelectedFunction") -> Any:
+        return next(iter((c.bindings or {}).values()), None)
+
     caps = detect_worker_capabilities()
     free_gb = get_available_vram_gb()
     choice = select_variant(
-        [(m.fn_name, m.resources) for m in variant_rows],
+        [(m.fn_name, m.resources, _primary_binding(m)) for m in variant_rows],
         caps,
         free_gb,
-        base=(base.fn_name, base.resources) if base is not None else None,
+        base=(
+            (base.fn_name, base.resources, _primary_binding(base))
+            if base is not None else None
+        ),
     )
     if choice is None:
         raise _ModelResolutionError(

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -213,8 +213,14 @@ class _SelectedFunction:
 
 
 def _variant_names(cls: Optional[type]) -> set:
+    """Declared variant names in their ROUTED (slugified) form — the registry
+    slugifies fn_name, so raw declaration names ("generate_fp8") never match
+    es.name ("generate-fp8") and every variant row would lose its variant_of
+    marker (--variant auto then silently ran the base binding; gw#415 live)."""
+    from gen_worker.discovery.names import slugify_name
+
     decl = getattr(cls, _ENDPOINT_ATTR, None) if cls is not None else None
-    return {v.name for v in (getattr(decl, "variants", ()) or ())}
+    return {slugify_name(v.name) for v in (getattr(decl, "variants", ()) or ())}
 
 
 def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -32,6 +32,7 @@ from .loaded_component import LoadedComponent
 from .produced import ProducedFlavor
 from .publish import publish_flavors
 from .source import FileLayout, Source
+from .svdq import build_svdq_flavor_tree, fetch_svdq_checkpoint, svdq_flavor_label
 from .writer import (
     streaming_cast_snapshot,
     streaming_dtype_cast,
@@ -43,6 +44,9 @@ from .writer import (
 from . import clone
 
 __all__ = [
+    "build_svdq_flavor_tree",
+    "fetch_svdq_checkpoint",
+    "svdq_flavor_label",
     # Tenant SDK
     "Source",
     "Component",

--- a/src/gen_worker/convert/svdq.py
+++ b/src/gen_worker/convert/svdq.py
@@ -1,0 +1,141 @@
+"""SVDQuant flavor trees (gw#415) — build + mirror.
+
+A ``#svdq-fp4-rN`` / ``#svdq-int4-rN`` flavor is the base checkpoint's
+diffusers tree with the denoiser's plain weights replaced by ONE
+nunchaku-format single-file checkpoint (self-describing safetensors
+``__metadata__``; see ``gen_worker.models.svdq``). CAS dedup makes the shared
+components (VAE / text encoders / scheduler / tokenizer) free — the flavor
+stores only the 4-bit denoiser.
+
+Two producers emit this shape:
+  - MIRROR: fetch an official nunchaku artifact (e.g.
+    ``nunchaku-ai/nunchaku-z-image-turbo``) and marry it to our mirrored base.
+  - PRODUCE: a deepcompressor SVDQuant run whose ``convert.py`` output is the
+    same single-file format.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from ..models.svdq import SvdqArtifact, detect_svdq_artifact
+from .writer import copy_non_weight_files
+
+logger = logging.getLogger(__name__)
+
+# R2 single-PUT cap (clone.py reshards bigger files) — but sharding a nunchaku
+# checkpoint strips the __metadata__ its loader needs, so oversize svdq
+# artifacts are refused until component-level reassembly lands (qwen-image
+# files are 11.5-13.1 GB; z-image/flux fit). Tracked in the qwen rollout issue.
+MAX_SVDQ_FILE_BYTES = 5 * 1000**3
+
+
+def svdq_flavor_label(art: SvdqArtifact) -> str:
+    """Canonical flavor token: precision + rank explicit (``svdq-fp4-r128``)."""
+    return f"svdq-{art.precision}-r{art.rank}"
+
+
+def build_svdq_flavor_tree(
+    base_dir: Path,
+    svdq_file: Path,
+    out_dir: Path,
+    *,
+    component: Optional[str] = None,
+) -> tuple[Path, dict[str, str]]:
+    """Materialize one svdq flavor tree: the full base tree minus the
+    denoiser's weights, plus the nunchaku single-file checkpoint under the
+    denoiser directory. Returns ``(tree_root, attrs)``."""
+    base_dir = Path(base_dir)
+    svdq_file = Path(svdq_file)
+    out_dir = Path(out_dir)
+
+    art = detect_svdq_artifact(svdq_file)
+    if art is None:
+        raise ValueError(
+            f"{svdq_file} is not a nunchaku SVDQuant checkpoint (missing "
+            "model_class/quantization_config safetensors metadata)"
+        )
+    size = svdq_file.stat().st_size
+    if size > MAX_SVDQ_FILE_BYTES:
+        raise ValueError(
+            f"svdq file {svdq_file.name} is {size / 1e9:.1f} GB > single-PUT "
+            f"cap; sharding would strip nunchaku metadata — component-level "
+            f"reassembly is not implemented yet (gw#415 follow-up)"
+        )
+    if component is None:
+        component = next(
+            (c for c in ("transformer", "unet") if (base_dir / c).is_dir()), "",
+        )
+    if not component:
+        raise ValueError(
+            f"base tree {base_dir} has no transformer/unet component to swap"
+        )
+    if not (base_dir / "model_index.json").exists():
+        raise ValueError(
+            f"base tree {base_dir} is not a diffusers pipeline layout "
+            "(model_index.json missing) — svdq flavors swap a pipeline's denoiser"
+        )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    copy_non_weight_files(base_dir, out_dir, skip_components={component})
+    dest_dir = out_dir / component
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / svdq_file.name
+    if dest.exists():
+        dest.unlink()
+    try:
+        os.link(svdq_file, dest)
+    except OSError:
+        import shutil
+
+        shutil.copy2(svdq_file, dest)
+
+    flavor = svdq_flavor_label(art)
+    attrs = {
+        "flavor": flavor,
+        "quantization_method": "svdquant",
+        "quantization_library": "nunchaku",
+        "svdq_precision": art.precision,
+        "svdq_rank": str(art.rank),
+        "svdq_model_class": art.model_class,
+        "svdq_component": component,
+    }
+    logger.info(
+        "built svdq flavor tree %s: %s <- %s (%.2f GB)",
+        flavor, out_dir, svdq_file.name, size / 1e9,
+    )
+    return out_dir, attrs
+
+
+def fetch_svdq_checkpoint(
+    repo_id: str,
+    filename: str,
+    dest_dir: Path,
+    *,
+    revision: Optional[str] = None,
+    hf_token: Optional[str] = None,
+) -> Path:
+    """Download ONE nunchaku checkpoint file from an HF repo (mirror lane)."""
+    from huggingface_hub import hf_hub_download
+
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    local = hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        revision=revision,
+        local_dir=str(dest_dir),
+        token=hf_token or None,
+    )
+    return Path(local)
+
+
+__all__ = [
+    "MAX_SVDQ_FILE_BYTES",
+    "build_svdq_flavor_tree",
+    "fetch_svdq_checkpoint",
+    "svdq_flavor_label",
+]

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -625,7 +625,10 @@ def _link_or_copy(src: Path, dst: Path) -> None:
     if dst.exists():
         return
     try:
-        os.link(src, dst)
+        # Resolve first: HF-cache snapshots are relative-symlink farms and a
+        # hardlink to the SYMLINK breaks the moment the tree is moved
+        # (gw#415 live: model_index.json -> ../../blobs/... dangling).
+        os.link(src.resolve(), dst)
     except OSError:
         shutil.copy2(src, dst)
 

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -40,7 +40,8 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
 
     # Known optional libs that affect artifact compatibility.
     # Keep this hardcoded (no env config), per Cozy design.
-    known = ["bitsandbytes", "torchao", "transformer_engine", "tensorrt"]
+    known = ["bitsandbytes", "torchao", "transformer_engine", "tensorrt",
+             "nunchaku", "deepcompressor"]
     if extra_libs:
         known.extend(extra_libs)
     for name in known:
@@ -93,9 +94,22 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
 # ---------------------------------------------------------------------------
 
 FIT_FITS = "fits"
+FIT_SVDQ_FP4 = "svdq_fp4"
+FIT_SVDQ_INT4 = "svdq_int4"
 FIT_EMERGENCY = "emergency_quant"
 FIT_OFFLOAD = "offload"
 FIT_INCOMPATIBLE = "incompatible"
+
+
+def svdq_flavor_kind(binding: Any) -> str:
+    """"fp4" / "int4" / "" — is this binding an svdq stored-flavor row?
+    The flavor token is the selector (th#597): ``svdq-fp4-*`` / ``svdq-int4-*``."""
+    flavor = str(getattr(binding, "flavor", "") or "").strip().lower()
+    if flavor.startswith("svdq-fp4"):
+        return "fp4"
+    if flavor.startswith("svdq-int4"):
+        return "int4"
+    return ""
 
 
 @dataclass(frozen=True)
@@ -109,11 +123,18 @@ def variant_fit(
     resources: Any,
     caps: TensorhubWorkerCapabilities,
     free_vram_gb: float,
+    *,
+    binding: Any = None,
 ) -> tuple[str, str]:
     """Fit verdict for ONE function/variant's ``Resources`` on this machine.
 
     - ``incompatible``: hard gates unmet (no CUDA GPU, compute_capability
-      above this GPU's SM, required quant libraries not installed).
+      above this GPU's SM, required quant libraries not installed, or an
+      svdq row whose SM window / nunchaku-diffusers pin matrix fails).
+    - ``svdq_fp4`` / ``svdq_int4``: the binding is a stored SVDQuant flavor
+      (gw#415) and every gate passes — on Blackwell, svdq_fp4 OUTRANKS every
+      other fitting row (faster AND smaller, QUANTIZATION-POLICY fit ladder);
+      svdq_int4 is a fit rung ahead of emergency-nf4 only.
     - ``emergency_quant``: does not fit, but the emergency nf4 rung (th#546
       emergency lane; loading layer, automatic on CUDA hosts) applies and
       the 4-bit estimate fits — runs at below-platform quality, loudly.
@@ -134,8 +155,32 @@ def variant_fit(
     missing = [lib for lib in libs if lib not in (caps.installed_libs or [])]
     if missing:
         return FIT_INCOMPATIBLE, f"missing libraries: {', '.join(missing)}"
+    svdq_kind = svdq_flavor_kind(binding)
+    if svdq_kind:
+        from .svdq import (
+            SVDQ_FP4_SMS,
+            SVDQ_INT4_SMS,
+            svdq_precision_for_sm,
+            svdq_stack_reason,
+        )
+
+        window = SVDQ_FP4_SMS if svdq_kind == "fp4" else SVDQ_INT4_SMS
+        if caps.gpu_sm not in window:
+            runs = svdq_precision_for_sm(caps.gpu_sm)
+            return FIT_INCOMPATIBLE, (
+                f"svdq-{svdq_kind} kernels need SM in "
+                f"{'/'.join(str(x) for x in window)}; GPU is SM{caps.gpu_sm}"
+                + (f" (runs svdq-{runs})" if runs and runs != svdq_kind else "")
+            )
+        reason = svdq_stack_reason()
+        if reason is not None:
+            return FIT_INCOMPATIBLE, reason
     vram = getattr(resources, "vram_gb", None)
     if vram is None or float(vram) <= float(free_vram_gb):
+        if svdq_kind == "fp4":
+            return FIT_SVDQ_FP4, "svdq-fp4 stored flavor (Blackwell 4-bit rung)"
+        if svdq_kind == "int4":
+            return FIT_SVDQ_INT4, "svdq-int4 stored flavor (4-bit fit rung)"
         return FIT_FITS, ""
     from .loading import EMERGENCY_FIT_FACTOR
 
@@ -153,51 +198,62 @@ def variant_fit(
 
 
 def select_variant(
-    variants: List[tuple[str, Any]],
+    variants: List[tuple],
     caps: TensorhubWorkerCapabilities,
     free_vram_gb: float,
     *,
-    base: Optional[tuple[str, Any]] = None,
+    base: Optional[tuple] = None,
 ) -> Optional[VariantChoice]:
     """Pick the best routable variant.
 
-    ``variants`` is ``[(fn_name, Resources), ...]``; ``base`` is the base
-    binding's row when the class declares one. Policy:
-      1. drop incompatible rows (SM / library gates);
-      2. among variants that FIT free VRAM, prefer the largest declared
+    ``variants`` rows are ``(fn_name, Resources)`` or
+    ``(fn_name, Resources, binding)``; ``base`` is the base binding's row when
+    the class declares one. Policy (QUANTIZATION-POLICY fit ladder):
+      1. drop incompatible rows (SM / library / svdq pin-matrix gates);
+      2. a fitting svdq_fp4 row wins outright — on Blackwell the SVDQuant
+         flavor beats fp8/bf16 on BOTH latency and VRAM (gw#405 measured);
+      3. among plain rows that FIT free VRAM, prefer the largest declared
          vram_gb (bigger = higher-quality precision);
-      3. none fit → an emergency_quant row if the nf4 rung applies
+      4. a fitting svdq_int4 row (4-bit fit rung: nothing bigger fits);
+      5. an emergency_quant row if the nf4 rung applies
          (runs at below-platform quality, loudly);
-      4. else the base binding + the offload ladder;
-      5. no base → the smallest-VRAM compatible variant, offloaded;
-      6. nothing routable → None.
+      6. else the base binding + the offload ladder;
+      7. no base → the smallest-VRAM compatible variant, offloaded;
+      8. nothing routable → None.
     """
     def _vram(res: Any) -> float:
         v = getattr(res, "vram_gb", None)
         return float(v) if v is not None else 0.0
 
     compat: List[tuple[str, Any, str, str]] = []
-    for name, res in variants:
-        fit, reason = variant_fit(res, caps, free_vram_gb)
+    for row in variants:
+        name, res = row[0], row[1]
+        row_binding = row[2] if len(row) > 2 else None
+        fit, reason = variant_fit(res, caps, free_vram_gb, binding=row_binding)
         if fit != FIT_INCOMPATIBLE:
             compat.append((name, res, fit, reason))
 
-    fitting = [row for row in compat if row[2] == FIT_FITS]
-    if fitting:
-        name, _res, fit, reason = max(fitting, key=lambda r: _vram(r[1]))
-        return VariantChoice(name=name, fit=fit, reason=reason)
+    for rung in (FIT_SVDQ_FP4, FIT_FITS):
+        fitting = [row for row in compat if row[2] == rung]
+        if fitting:
+            name, _res, fit, reason = max(fitting, key=lambda r: _vram(r[1]))
+            return VariantChoice(name=name, fit=fit, reason=reason)
 
+    # svdq_int4 (gw#415): a stored 4-bit flavor that fits when nothing
+    # full-precision does — ahead of the emergency runtime-quant rung.
     # Emergency rung (th#546): nothing fits, but 4-bit emergency quantization
     # would — prefer it over the offload ladder (ladder position: after
     # stored flavors, before CPU offload).
-    emergency = [row for row in compat if row[2] == FIT_EMERGENCY]
-    if emergency:
-        name, _res, fit, reason = max(emergency, key=lambda r: _vram(r[1]))
-        return VariantChoice(name=name, fit=fit, reason=reason)
+    for rung in (FIT_SVDQ_INT4, FIT_EMERGENCY):
+        rows = [row for row in compat if row[2] == rung]
+        if rows:
+            name, _res, fit, reason = max(rows, key=lambda r: _vram(r[1]))
+            return VariantChoice(name=name, fit=fit, reason=reason)
 
     if base is not None:
-        base_name, base_res = base
-        fit, reason = variant_fit(base_res, caps, free_vram_gb)
+        base_name, base_res = base[0], base[1]
+        base_binding = base[2] if len(base) > 2 else None
+        fit, reason = variant_fit(base_res, caps, free_vram_gb, binding=base_binding)
         if fit != FIT_INCOMPATIBLE:
             return VariantChoice(name=base_name, fit=fit, reason=reason)
 

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -492,6 +492,16 @@ def load_from_pretrained(
     fit free VRAM (automatic on CUDA hosts). Used by the executor to satisfy
     pipeline-typed ``setup()`` annotations; endpoints may also call it."""
     path = str(path)
+    # SVDQuant/nunchaku 4-bit flavors (gw#415): self-describing snapshots take
+    # the svdq lane — a nunchaku transformer swapped into the standard
+    # pipeline. Detection precedes every other rung; failures are typed
+    # (SvdqStackError / SvdqHardwareError / SvdqSnapshotError), never a
+    # mid-denoise crash.
+    from .svdq import detect_svdq_artifact, load_svdq_pipeline
+
+    svdq_art = detect_svdq_artifact(Path(path))
+    if svdq_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        return load_svdq_pipeline(cls, Path(path), svdq_art)
     ensure_quant_library_imported(attrs)
     kwargs: Dict[str, Any] = {}
     if dtype:

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -1,0 +1,350 @@
+"""SVDQuant/nunchaku 4-bit loader mode (gw#415).
+
+A ``#svdq-fp4-*`` / ``#svdq-int4-*`` flavor is a normal diffusers tree whose
+denoiser directory holds ONE nunchaku-format single-file checkpoint instead of
+plain safetensors shards. The file self-describes in its safetensors
+``__metadata__``: ``model_class`` names the nunchaku transformer class and
+``quantization_config`` carries ``{"method": "svdquant", "weight": {"dtype":
+"fp4_e2m1_all" | "int4"}, "rank": N}``. Loading swaps the nunchaku module into
+the standard pipeline — same pipeline class, same handler, no new endpoint.
+
+Hardware: fp4 kernels exist ONLY on consumer Blackwell (sm_120/121); int4 on
+sm_75–89. No sm_90/100 (datacenter stays the TRT lane). Version coupling is
+HARD (gw#405, live-hit): nunchaku wheels are per-(torch minor, CUDA) and each
+nunchaku release calls diffusers transformer forwards positionally against one
+diffusers signature window — 1.2.x/1.3.x require diffusers 0.36/0.37 and crash
+on 0.38+. The pin matrix below is enforced with typed errors both at variant
+selection (fit gating) and at load."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+SVDQ_METHOD = "svdquant"
+# Nunchaku ships fp4 kernels for consumer Blackwell only and int4 kernels for
+# Turing→Ada. sm_90 (Hopper) and sm_100 (B200) are deliberately absent.
+SVDQ_FP4_SMS = (120, 121)
+SVDQ_INT4_SMS = (75, 80, 86, 89)
+
+_MAX_HEADER_BYTES = 100 << 20
+
+
+class SvdqError(RuntimeError):
+    """Base class for typed svdq loader-mode failures."""
+
+
+class SvdqStackError(SvdqError):
+    """The (nunchaku, diffusers, torch/cuda) stack violates the pin matrix."""
+
+
+class SvdqHardwareError(SvdqError):
+    """The artifact's precision has no kernels on this GPU."""
+
+
+class SvdqSnapshotError(SvdqError):
+    """The flavor snapshot is not a loadable svdq tree."""
+
+
+# ---------------------------------------------------------------------------
+# Pin matrix — (nunchaku minor) -> required diffusers window.
+#
+# nunchaku calls ``super().forward(...)`` POSITIONALLY against the diffusers
+# transformer signatures it was released against; a newer diffusers inserts
+# arguments and the call crashes mid-denoise (gw#405: 1.2.1 on 0.38.0.dev0 and
+# 0.39.0 -> "TypeError: argument of type 'int' is not iterable"). Torch/CUDA
+# coupling is carried in the wheel's local version tag (e.g.
+# ``1.2.1+cu13.0torch2.11``) and checked against the running interpreter.
+# Re-verify and extend this table on every nunchaku release.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SvdqPin:
+    nunchaku_minor: tuple[int, int]
+    diffusers_min: tuple[int, int]
+    diffusers_max_exclusive: tuple[int, int]
+
+
+_PIN_MATRIX: tuple[SvdqPin, ...] = (
+    # 1.2.x: CI-pinned to diffusers 0.36 (verified live in gw#405).
+    SvdqPin((1, 2), (0, 36), (0, 37)),
+)
+
+
+def _version_tuple(raw: str, n: int = 2) -> tuple[int, ...]:
+    """Leading numeric components of a version string ("0.38.0.dev0" ->
+    (0, 38)). Missing/unparseable parts are 0."""
+    parts: list[int] = []
+    for tok in re.split(r"[.+]", str(raw or "").strip()):
+        m = re.match(r"^(\d+)", tok)
+        if m is None:
+            break
+        parts.append(int(m.group(1)))
+        if len(parts) >= n:
+            break
+    while len(parts) < n:
+        parts.append(0)
+    return tuple(parts)
+
+
+def _wheel_local_tag(nunchaku_version: str) -> tuple[str, str]:
+    """(cuda, torch) from a nunchaku wheel version's local tag, e.g.
+    ``1.2.1+cu13.0torch2.11`` -> ("13.0", "2.11"). Empty strings when the
+    tag is absent (source builds)."""
+    if "+" not in str(nunchaku_version or ""):
+        return "", ""
+    local = str(nunchaku_version).split("+", 1)[1]
+    m = re.match(r"^cu([\d.]+)torch([\d.]+)$", local)
+    if m is None:
+        return "", ""
+    return m.group(1), m.group(2)
+
+
+def check_svdq_stack_versions(
+    *, nunchaku_version: str, diffusers_version: str,
+    torch_version: str = "", cuda_version: str = "",
+) -> None:
+    """Pure pin-matrix check over version strings. Raises SvdqStackError with
+    the precise coupling that failed; returns None when the stack is legal."""
+    nv = _version_tuple(nunchaku_version)
+    pin = next((p for p in _PIN_MATRIX if p.nunchaku_minor == nv), None)
+    if pin is None:
+        known = ", ".join(f"{a}.{b}" for a, b in (p.nunchaku_minor for p in _PIN_MATRIX))
+        raise SvdqStackError(
+            f"nunchaku {nunchaku_version} is not in the svdq pin matrix "
+            f"(known: {known}); its diffusers signature window must be "
+            f"verified and added before the svdq rung can serve on it"
+        )
+    dv = _version_tuple(diffusers_version)
+    if not (pin.diffusers_min <= dv < pin.diffusers_max_exclusive):
+        lo = ".".join(map(str, pin.diffusers_min))
+        hi = ".".join(map(str, pin.diffusers_max_exclusive))
+        raise SvdqStackError(
+            f"nunchaku {nunchaku_version} requires diffusers>={lo},<{hi} "
+            f"(positional transformer forward coupling, gw#405); installed "
+            f"diffusers is {diffusers_version}"
+        )
+    wheel_cuda, wheel_torch = _wheel_local_tag(nunchaku_version)
+    if wheel_torch and torch_version and _version_tuple(torch_version) != _version_tuple(wheel_torch):
+        raise SvdqStackError(
+            f"nunchaku wheel {nunchaku_version} was built for torch "
+            f"{wheel_torch}.x; installed torch is {torch_version}"
+        )
+    if wheel_cuda and cuda_version and _version_tuple(wheel_cuda, 1) != _version_tuple(cuda_version, 1):
+        raise SvdqStackError(
+            f"nunchaku wheel {nunchaku_version} was built for CUDA "
+            f"{wheel_cuda}; torch reports CUDA {cuda_version}"
+        )
+
+
+def svdq_stack_reason() -> Optional[str]:
+    """Non-raising stack check against the INSTALLED environment (importlib
+    metadata only — does not import nunchaku's CUDA extension). Returns the
+    failure reason, or None when the svdq lane is servable here."""
+    import importlib.metadata as md
+
+    try:
+        nunchaku_version = md.version("nunchaku")
+    except md.PackageNotFoundError:
+        return "nunchaku is not installed"
+    try:
+        diffusers_version = md.version("diffusers")
+    except md.PackageNotFoundError:
+        return "diffusers is not installed"
+    torch_version = cuda_version = ""
+    try:
+        import torch
+
+        torch_version = str(torch.__version__ or "")
+        cuda_version = str(getattr(torch.version, "cuda", "") or "")
+    except ImportError:
+        pass
+    try:
+        check_svdq_stack_versions(
+            nunchaku_version=nunchaku_version,
+            diffusers_version=diffusers_version,
+            torch_version=torch_version,
+            cuda_version=cuda_version,
+        )
+    except SvdqStackError as exc:
+        return str(exc)
+    return None
+
+
+def svdq_precision_for_sm(gpu_sm: int) -> str:
+    """"fp4" / "int4" / "" — which svdq kernel family this GPU can run."""
+    if gpu_sm in SVDQ_FP4_SMS:
+        return "fp4"
+    if gpu_sm in SVDQ_INT4_SMS:
+        return "int4"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Artifact detection — safetensors __metadata__ sniff
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SvdqArtifact:
+    component: str      # denoiser dir name inside the tree ("transformer"/"unet")
+    file: Path          # the nunchaku single-file checkpoint
+    model_class: str    # e.g. "NunchakuZImageTransformer2DModel"
+    precision: str      # "fp4" | "int4"
+    rank: int
+
+
+def _read_safetensors_metadata(path: Path) -> dict:
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(8)
+            if len(raw) < 8:
+                return {}
+            (n,) = struct.unpack("<Q", raw)
+            if n <= 0 or n > _MAX_HEADER_BYTES:
+                return {}
+            header = json.loads(f.read(n))
+    except (OSError, ValueError):
+        return {}
+    meta = header.get("__metadata__") if isinstance(header, dict) else None
+    return meta if isinstance(meta, dict) else {}
+
+
+def _svdq_from_file(component: str, path: Path) -> Optional[SvdqArtifact]:
+    meta = _read_safetensors_metadata(path)
+    model_class = str(meta.get("model_class") or "")
+    qc_raw = meta.get("quantization_config")
+    try:
+        qc = json.loads(qc_raw) if isinstance(qc_raw, str) else (qc_raw or {})
+    except ValueError:
+        qc = {}
+    if not isinstance(qc, dict) or str(qc.get("method") or "") != SVDQ_METHOD:
+        return None
+    if not model_class.startswith("Nunchaku"):
+        return None
+    weight_dtype = str((qc.get("weight") or {}).get("dtype") or "").lower()
+    if "fp4" in weight_dtype:
+        precision = "fp4"
+    elif "int4" in weight_dtype:
+        precision = "int4"
+    else:
+        logger.warning("svdq artifact %s has unknown weight dtype %r", path, weight_dtype)
+        return None
+    return SvdqArtifact(
+        component=component,
+        file=path,
+        model_class=model_class,
+        precision=precision,
+        rank=int(qc.get("rank") or 0),
+    )
+
+
+_SVDQ_COMPONENT_DIRS = ("transformer", "unet")
+
+
+def detect_svdq_artifact(model_path: Path) -> Optional[SvdqArtifact]:
+    """Find the nunchaku single-file checkpoint inside a snapshot: the
+    denoiser dir's (or, for a bare artifact, the root's) sole svdq-tagged
+    safetensors. Cheap — header reads only."""
+    root = Path(model_path)
+    if root.is_file():
+        return _svdq_from_file("", root) if root.suffix == ".safetensors" else None
+    if not root.is_dir():
+        return None
+    for comp in _SVDQ_COMPONENT_DIRS:
+        comp_dir = root / comp
+        if not comp_dir.is_dir():
+            continue
+        for f in sorted(comp_dir.glob("*.safetensors")):
+            art = _svdq_from_file(comp, f)
+            if art is not None:
+                return art
+    for f in sorted(root.glob("*.safetensors")):
+        art = _svdq_from_file("", f)
+        if art is not None:
+            return art
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Loading — nunchaku transformer swap into the standard pipeline
+# ---------------------------------------------------------------------------
+
+def check_svdq_loadable(art: SvdqArtifact) -> None:
+    """All typed gates for actually serving ``art`` on this machine."""
+    reason = svdq_stack_reason()
+    if reason is not None:
+        raise SvdqStackError(reason)
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SvdqHardwareError("svdq artifacts require a CUDA GPU")
+    major, minor = torch.cuda.get_device_capability()
+    sm = major * 10 + minor
+    expected = svdq_precision_for_sm(sm)
+    if expected != art.precision:
+        raise SvdqHardwareError(
+            f"svdq-{art.precision} has no kernels on SM{sm} "
+            f"(fp4: sm_120/121, int4: sm_75-89"
+            + (f"; this GPU runs svdq-{expected}" if expected else "")
+            + ")"
+        )
+
+
+def load_svdq_pipeline(cls: Any, path: Path, art: SvdqArtifact) -> Any:
+    """Build the pipeline with the nunchaku transformer swapped in.
+
+    Compute dtype is pinned to bf16 — nunchaku's kernels and the surrounding
+    scales are bf16-oriented (every upstream example and the gw#405 probe used
+    bf16); honoring an fp16 binding here would change numerics silently."""
+    check_svdq_loadable(art)
+    import nunchaku
+    import torch
+
+    if not art.component:
+        raise SvdqSnapshotError(
+            f"svdq snapshot {path} is a bare single-file transformer; a "
+            f"servable #svdq flavor must be a full diffusers tree with the "
+            f"nunchaku file under its denoiser directory"
+        )
+    ncls = getattr(nunchaku, art.model_class, None)
+    if ncls is None:
+        raise SvdqStackError(
+            f"installed nunchaku has no {art.model_class} (artifact needs a "
+            f"newer nunchaku release / unsupported family)"
+        )
+    dtype = torch.bfloat16
+    logger.info(
+        "svdq loader mode: %s %s r%d via %s (file %s)",
+        art.precision, art.component, art.rank, art.model_class, art.file.name,
+    )
+    denoiser = ncls.from_pretrained(str(art.file), torch_dtype=dtype)
+    # low_cpu_mem_usage=False is nunchaku's documented requirement for the
+    # component-swap pipeline build (meta-device init breaks its buffers).
+    return cls.from_pretrained(
+        str(path), torch_dtype=dtype, low_cpu_mem_usage=False,
+        **{art.component: denoiser},
+    )
+
+
+__all__ = [
+    "SVDQ_FP4_SMS",
+    "SVDQ_INT4_SMS",
+    "SvdqArtifact",
+    "SvdqError",
+    "SvdqHardwareError",
+    "SvdqSnapshotError",
+    "SvdqStackError",
+    "check_svdq_loadable",
+    "check_svdq_stack_versions",
+    "detect_svdq_artifact",
+    "load_svdq_pipeline",
+    "svdq_precision_for_sm",
+    "svdq_stack_reason",
+]

--- a/tests/test_svdq_loading.py
+++ b/tests/test_svdq_loading.py
@@ -409,3 +409,24 @@ def test_build_svdq_flavor_tree_rejects_plain_file(tmp_path: Path) -> None:
     _write_plain_safetensors(plain)
     with pytest.raises(ValueError, match="not a nunchaku"):
         build_svdq_flavor_tree(base, plain, tmp_path / "out")
+
+
+def test_variant_names_are_slugified() -> None:
+    """--variant auto regression (found live in the gw#415 acceptance): the
+    registry routes variants under slugified names, so the variant_of marker
+    must compare slugs, not raw declaration names."""
+    from gen_worker import HF, endpoint
+    from gen_worker.cli.run import _variant_names
+
+    @endpoint(
+        model=HF("acme/base", dtype="bf16"),
+        variants={"generate_svdq_fp4": HF("acme/base-svdq")},
+    )
+    class _Ep:
+        def setup(self, pipeline: str) -> None:
+            pass
+
+        def generate(self, ctx, payload: dict) -> dict:  # type: ignore[no-untyped-def]
+            return {}
+
+    assert _variant_names(_Ep) == {"generate-svdq-fp4"}

--- a/tests/test_svdq_loading.py
+++ b/tests/test_svdq_loading.py
@@ -1,0 +1,411 @@
+"""SVDQuant/nunchaku loader mode (gw#415): artifact detection, the pin
+matrix, the svdq fit rungs, and the load_from_pretrained routing.
+
+Real nunchaku/diffusers/CUDA are absent in CI — kernels and the live serve
+band are the gw#415 5090 acceptance run."""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker import Hub, Resources
+from gen_worker.models.hub_policy import (
+    FIT_FITS,
+    FIT_INCOMPATIBLE,
+    FIT_SVDQ_FP4,
+    FIT_SVDQ_INT4,
+    TensorhubWorkerCapabilities,
+    select_variant,
+    svdq_flavor_kind,
+    variant_fit,
+)
+from gen_worker.models.svdq import (
+    SvdqStackError,
+    check_svdq_stack_versions,
+    detect_svdq_artifact,
+    svdq_precision_for_sm,
+)
+
+
+# --------------------------------------------------------------------------
+# fixtures — synthetic nunchaku safetensors
+# --------------------------------------------------------------------------
+
+def _write_svdq_safetensors(
+    path: Path,
+    *,
+    model_class: str = "NunchakuZImageTransformer2DModel",
+    weight_dtype: str = "fp4_e2m1_all",
+    rank: int = 128,
+) -> None:
+    qc = {
+        "method": "svdquant",
+        "weight": {"dtype": weight_dtype, "group_size": 16},
+        "activation": {"dtype": weight_dtype, "group_size": 16},
+        "rank": rank,
+    }
+    header = {
+        "__metadata__": {
+            "model_class": model_class,
+            "quantization_config": json.dumps(qc),
+            "config": json.dumps({"_class_name": "ZImageTransformer2DModel"}),
+        },
+        "w": {"dtype": "BF16", "shape": [4], "data_offsets": [0, 8]},
+    }
+    blob = json.dumps(header).encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+        f.write(b"\x00" * 8)
+
+
+def _write_plain_safetensors(path: Path) -> None:
+    header = {"w": {"dtype": "BF16", "shape": [4], "data_offsets": [0, 8]}}
+    blob = json.dumps(header).encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+        f.write(b"\x00" * 8)
+
+
+def _svdq_tree(tmp_path: Path, *, weight_dtype: str = "fp4_e2m1_all") -> Path:
+    root = tmp_path / "snap"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "ZImagePipeline",
+        "transformer": ["diffusers", "ZImageTransformer2DModel"],
+    }))
+    _write_svdq_safetensors(
+        root / "transformer" / "svdq-fp4_r128-z-image-turbo.safetensors",
+        weight_dtype=weight_dtype,
+    )
+    _write_plain_safetensors(root / "vae" / "diffusion_pytorch_model.safetensors")
+    return root
+
+
+# --------------------------------------------------------------------------
+# detection
+# --------------------------------------------------------------------------
+
+def test_detect_svdq_artifact_fp4_tree(tmp_path: Path) -> None:
+    root = _svdq_tree(tmp_path)
+    art = detect_svdq_artifact(root)
+    assert art is not None
+    assert art.component == "transformer"
+    assert art.precision == "fp4"
+    assert art.rank == 128
+    assert art.model_class == "NunchakuZImageTransformer2DModel"
+
+
+def test_detect_svdq_artifact_int4_file(tmp_path: Path) -> None:
+    f = tmp_path / "svdq-int4_r128.safetensors"
+    _write_svdq_safetensors(f, weight_dtype="int4")
+    art = detect_svdq_artifact(f)
+    assert art is not None
+    assert art.component == ""
+    assert art.precision == "int4"
+
+
+def test_detect_svdq_artifact_negative(tmp_path: Path) -> None:
+    root = tmp_path / "plain"
+    _write_plain_safetensors(root / "transformer" / "diffusion_pytorch_model.safetensors")
+    (root / "model_index.json").write_text("{}")
+    assert detect_svdq_artifact(root) is None
+
+
+# --------------------------------------------------------------------------
+# pin matrix
+# --------------------------------------------------------------------------
+
+def test_pin_matrix_accepts_verified_stack() -> None:
+    check_svdq_stack_versions(
+        nunchaku_version="1.2.1+cu13.0torch2.11",
+        diffusers_version="0.36.0",
+        torch_version="2.11.0+cu130",
+        cuda_version="13.0",
+    )
+
+
+@pytest.mark.parametrize("diffusers_version", ["0.38.0.dev0", "0.39.0", "0.35.1"])
+def test_pin_matrix_rejects_diffusers_window(diffusers_version: str) -> None:
+    with pytest.raises(SvdqStackError, match="diffusers"):
+        check_svdq_stack_versions(
+            nunchaku_version="1.2.1", diffusers_version=diffusers_version,
+        )
+
+
+def test_pin_matrix_rejects_unknown_nunchaku() -> None:
+    with pytest.raises(SvdqStackError, match="pin matrix"):
+        check_svdq_stack_versions(
+            nunchaku_version="1.4.0", diffusers_version="0.36.0",
+        )
+
+
+def test_pin_matrix_rejects_wheel_torch_mismatch() -> None:
+    with pytest.raises(SvdqStackError, match="torch"):
+        check_svdq_stack_versions(
+            nunchaku_version="1.2.1+cu12.8torch2.10",
+            diffusers_version="0.36.0",
+            torch_version="2.11.0+cu128",
+            cuda_version="12.8",
+        )
+
+
+def test_pin_matrix_rejects_wheel_cuda_mismatch() -> None:
+    with pytest.raises(SvdqStackError, match="CUDA"):
+        check_svdq_stack_versions(
+            nunchaku_version="1.2.1+cu13.0torch2.11",
+            diffusers_version="0.36.0",
+            torch_version="2.11.0+cu128",
+            cuda_version="12.8",
+        )
+
+
+def test_precision_for_sm_windows() -> None:
+    assert svdq_precision_for_sm(120) == "fp4"
+    assert svdq_precision_for_sm(121) == "fp4"
+    assert svdq_precision_for_sm(89) == "int4"
+    assert svdq_precision_for_sm(75) == "int4"
+    # Hopper + datacenter Blackwell are deliberately OUT (TRT lane).
+    assert svdq_precision_for_sm(90) == ""
+    assert svdq_precision_for_sm(100) == ""
+
+
+# --------------------------------------------------------------------------
+# fit rungs
+# --------------------------------------------------------------------------
+
+def _caps(sm: int, libs: list[str] | None = None) -> TensorhubWorkerCapabilities:
+    return TensorhubWorkerCapabilities(
+        cuda_version="13.0", gpu_sm=sm, torch_version="2.11.0",
+        installed_libs=libs if libs is not None else ["nunchaku"],
+    )
+
+
+_FP4_BINDING = Hub("Tongyi-MAI/Z-Image-Turbo", flavor="svdq-fp4-r128")
+_INT4_BINDING = Hub("Tongyi-MAI/Z-Image-Turbo", flavor="svdq-int4-r128")
+_PLAIN_BINDING = Hub("Tongyi-MAI/Z-Image-Turbo")
+
+
+def test_svdq_flavor_kind() -> None:
+    assert svdq_flavor_kind(_FP4_BINDING) == "fp4"
+    assert svdq_flavor_kind(_INT4_BINDING) == "int4"
+    assert svdq_flavor_kind(_PLAIN_BINDING) == ""
+    assert svdq_flavor_kind(None) == ""
+
+
+@pytest.fixture
+def stack_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "gen_worker.models.svdq.svdq_stack_reason", lambda: None,
+    )
+
+
+def test_variant_fit_svdq_fp4_on_blackwell(stack_ok: None) -> None:
+    fit, reason = variant_fit(
+        Resources(vram_gb=14), _caps(120), 30.0, binding=_FP4_BINDING,
+    )
+    assert fit == FIT_SVDQ_FP4
+    assert "svdq-fp4" in reason
+
+
+def test_variant_fit_svdq_fp4_rejected_off_blackwell(stack_ok: None) -> None:
+    for sm in (89, 90, 100):
+        fit, reason = variant_fit(
+            Resources(vram_gb=14), _caps(sm), 30.0, binding=_FP4_BINDING,
+        )
+        assert fit == FIT_INCOMPATIBLE, sm
+        assert "SM" in reason
+
+
+def test_variant_fit_svdq_int4_window(stack_ok: None) -> None:
+    fit, _ = variant_fit(
+        Resources(vram_gb=10), _caps(89), 20.0, binding=_INT4_BINDING,
+    )
+    assert fit == FIT_SVDQ_INT4
+    fit, _ = variant_fit(
+        Resources(vram_gb=10), _caps(120), 20.0, binding=_INT4_BINDING,
+    )
+    assert fit == FIT_INCOMPATIBLE
+
+
+def test_variant_fit_svdq_pin_violation_is_typed_incompatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "gen_worker.models.svdq.svdq_stack_reason",
+        lambda: "nunchaku 1.2.1 requires diffusers>=0.36,<0.37",
+    )
+    fit, reason = variant_fit(
+        Resources(vram_gb=14), _caps(120), 30.0, binding=_FP4_BINDING,
+    )
+    assert fit == FIT_INCOMPATIBLE
+    assert "diffusers" in reason
+
+
+def test_variant_fit_svdq_requires_nunchaku_library(stack_ok: None) -> None:
+    fit, reason = variant_fit(
+        Resources(vram_gb=14, libraries=("nunchaku",)),
+        _caps(120, libs=[]), 30.0, binding=_FP4_BINDING,
+    )
+    assert fit == FIT_INCOMPATIBLE
+    assert "nunchaku" in reason
+
+
+# --------------------------------------------------------------------------
+# selection ordering (QUANTIZATION-POLICY fit ladder)
+# --------------------------------------------------------------------------
+
+def _rows() -> list[tuple[str, Any, Any]]:
+    return [
+        ("generate_turbo_bf16", Resources(vram_gb=24), _PLAIN_BINDING),
+        ("generate_turbo_fp8", Resources(vram_gb=15), Hub(
+            "Tongyi-MAI/Z-Image-Turbo", flavor="fp8")),
+        ("generate_turbo_svdq_fp4", Resources(vram_gb=14), _FP4_BINDING),
+    ]
+
+
+def test_select_variant_svdq_fp4_outranks_everything_fitting(stack_ok: None) -> None:
+    choice = select_variant(_rows(), _caps(120), 30.0)
+    assert choice is not None
+    assert choice.name == "generate_turbo_svdq_fp4"
+    assert choice.fit == FIT_SVDQ_FP4
+
+
+def test_select_variant_falls_back_when_pin_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "gen_worker.models.svdq.svdq_stack_reason", lambda: "stack broken",
+    )
+    choice = select_variant(_rows(), _caps(120), 30.0)
+    assert choice is not None
+    assert choice.name == "generate_turbo_bf16"
+    assert choice.fit == FIT_FITS
+
+
+def test_select_variant_int4_is_fit_rung_not_speed_rung(stack_ok: None) -> None:
+    rows = [
+        ("generate_bf16", Resources(vram_gb=24), _PLAIN_BINDING),
+        ("generate_fp8", Resources(vram_gb=15), Hub(
+            "Tongyi-MAI/Z-Image-Turbo", flavor="fp8")),
+        ("generate_svdq_int4", Resources(vram_gb=10), _INT4_BINDING),
+    ]
+    caps = _caps(89)
+    # fp8 fits -> fp8 wins (int4 never outranks a fitting full-precision row).
+    choice = select_variant(rows, caps, 16.0)
+    assert choice is not None and choice.name == "generate_fp8"
+    # nothing but the int4 flavor fits -> int4 rung fires.
+    choice = select_variant(rows, caps, 12.0)
+    assert choice is not None
+    assert choice.name == "generate_svdq_int4"
+    assert choice.fit == FIT_SVDQ_INT4
+
+
+def test_select_variant_non_blackwell_ignores_fp4_row(stack_ok: None) -> None:
+    choice = select_variant(_rows(), _caps(89), 30.0)
+    assert choice is not None
+    assert choice.name == "generate_turbo_bf16"
+
+
+# --------------------------------------------------------------------------
+# load routing
+# --------------------------------------------------------------------------
+
+def test_load_from_pretrained_routes_svdq_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.models import svdq as svdq_mod
+    from gen_worker.models.loading import load_from_pretrained
+
+    root = _svdq_tree(tmp_path)
+    calls: list[Any] = []
+
+    def _fake_load(cls: Any, path: Path, art: Any) -> str:
+        calls.append((cls, Path(path), art))
+        return "svdq-pipe"
+
+    monkeypatch.setattr(svdq_mod, "load_svdq_pipeline", _fake_load)
+
+    class _Pipe:
+        @classmethod
+        def from_pretrained(cls, *a: Any, **kw: Any) -> None:
+            raise AssertionError("svdq snapshot must not take the plain lane")
+
+    out = load_from_pretrained(_Pipe, root, dtype="bf16")
+    assert out == "svdq-pipe"
+    assert calls and calls[0][2].precision == "fp4"
+
+
+def test_load_from_pretrained_svdq_without_nunchaku_is_typed(
+    tmp_path: Path,
+) -> None:
+    """No nunchaku installed (CI): the svdq lane fails with SvdqStackError,
+    never a mid-denoise crash or a silent fall-through to bf16."""
+    from gen_worker.models.loading import load_from_pretrained
+
+    root = _svdq_tree(tmp_path)
+
+    class _Pipe:
+        @classmethod
+        def from_pretrained(cls, *a: Any, **kw: Any) -> None:
+            raise AssertionError("must not fall through")
+
+    with pytest.raises(SvdqStackError):
+        load_from_pretrained(_Pipe, root, dtype="bf16")
+
+
+# --------------------------------------------------------------------------
+# convert-side flavor tree
+# --------------------------------------------------------------------------
+
+def test_build_svdq_flavor_tree(tmp_path: Path) -> None:
+    from gen_worker.convert.svdq import build_svdq_flavor_tree
+
+    base = tmp_path / "base"
+    (base / "transformer").mkdir(parents=True)
+    (base / "model_index.json").write_text(json.dumps({
+        "_class_name": "ZImagePipeline",
+        "transformer": ["diffusers", "ZImageTransformer2DModel"],
+    }))
+    (base / "transformer" / "config.json").write_text("{}")
+    _write_plain_safetensors(base / "transformer" / "diffusion_pytorch_model.safetensors")
+    _write_plain_safetensors(base / "vae" / "diffusion_pytorch_model.safetensors")
+    (base / "scheduler").mkdir()
+    (base / "scheduler" / "scheduler_config.json").write_text("{}")
+
+    svdq_file = tmp_path / "svdq-fp4_r128-z-image-turbo.safetensors"
+    _write_svdq_safetensors(svdq_file)
+
+    out, attrs = build_svdq_flavor_tree(base, svdq_file, tmp_path / "out")
+    assert attrs["flavor"] == "svdq-fp4-r128"
+    assert attrs["quantization_method"] == "svdquant"
+    assert attrs["quantization_library"] == "nunchaku"
+    # the tree: base minus plain denoiser weights, plus the nunchaku file
+    assert (out / "model_index.json").exists()
+    assert (out / "vae" / "diffusion_pytorch_model.safetensors").exists()
+    assert (out / "scheduler" / "scheduler_config.json").exists()
+    assert (out / "transformer" / svdq_file.name).exists()
+    assert not (out / "transformer" / "diffusion_pytorch_model.safetensors").exists()
+    # and it is itself detectable + loadable by the serve-side sniffer
+    art = detect_svdq_artifact(out)
+    assert art is not None and art.component == "transformer"
+
+
+def test_build_svdq_flavor_tree_rejects_plain_file(tmp_path: Path) -> None:
+    from gen_worker.convert.svdq import build_svdq_flavor_tree
+
+    base = tmp_path / "base"
+    (base / "transformer").mkdir(parents=True)
+    (base / "model_index.json").write_text("{}")
+    plain = tmp_path / "plain.safetensors"
+    _write_plain_safetensors(plain)
+    with pytest.raises(ValueError, match="not a nunchaku"):
+        build_svdq_flavor_tree(base, plain, tmp_path / "out")

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## SERVE — the svdq loader mode (gw#415 Part A)

- `gen_worker/models/svdq.py`: a `#svdq-fp4-rN`/`#svdq-int4-rN` flavor is a normal diffusers tree whose denoiser dir holds ONE nunchaku single-file checkpoint. Detection is metadata-driven (safetensors `__metadata__`: `model_class=Nunchaku*`, `quantization_config.method=svdquant`) so the lane is family-agnostic — the nunchaku class to load comes from the artifact itself.
- `load_from_pretrained` routes svdq snapshots to the swap lane: `Nunchaku*.from_pretrained(file)` → `Pipeline.from_pretrained(tree, transformer=..., low_cpu_mem_usage=False)`. Same pipeline class, same handler, no new endpoint fn.
- **Pin matrix as code** (`check_svdq_stack_versions`): nunchaku 1.2.x ⇒ diffusers>=0.36,<0.37 (positional `super().forward` coupling, live-crashed on 0.38.0.dev0/0.39.0 in gw#405); wheel local tag (`+cu13.0torch2.11`) checked against installed torch/CUDA. Typed `SvdqStackError` at BOTH variant selection (verdict `incompatible`, falls back to fp8/bf16) and load. Unknown nunchaku releases fail closed until verified. Upstream note: nunchaku is dormant since 2026-03; latest stable stays 1.2.1, nightlies still CI-pin diffusers==0.36.
- **Fit rungs** (QUANTIZATION-POLICY ladder): new verdicts `svdq_fp4`/`svdq_int4`. `variant_fit`/`select_variant` are binding-aware (flavor token is the selector). sm_120/121: a fitting svdq-fp4 row OUTRANKS everything (gw#405: −41% latency, −39% VRAM vs bf16, beats fp8-storage on both axes). sm_75–89: svdq-int4 is a fit rung only — never outranks a fitting full-precision row, sits ahead of emergency-nf4. Hopper/B200 excluded (no kernels; TRT lane).
- Worker capabilities probe `nunchaku` + `deepcompressor`.

## PRODUCE/MIRROR — flavor tree builder (Part B rails)

- `gen_worker/convert/svdq.py`: `build_svdq_flavor_tree` (base tree minus denoiser weights + the nunchaku file; CAS dedups the shared components) and `fetch_svdq_checkpoint` (one-file HF fetch). >5GB artifacts refused with a typed error — offset-sharding would strip the `__metadata__` nunchaku's loader requires (qwen transport = follow-up).

## Tests

27 new tests (detection, pin matrix, rungs, selection ordering, load routing, tree builder). Full suite green except 3 pre-existing host-dependent failures reproduced on clean master (`test_executor_residency`, `test_worker_grpc_e2e` ×2).

Version → 0.12.1 (training-endpoints conversion fns consume the new convert exports from PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)