### PR TITLE
gw#421: retry pod creation across COMMUNITY/SECURE on capacity 500s

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -76,11 +76,24 @@ jobs:
                 TTL_MINUTES: "45"
               }
             }')
-          pod=$(curl -sf -X POST "https://rest.runpod.io/v1/pods" \
-            -H "Authorization: Bearer $RUNPOD_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$body")
-          echo "created pod $(echo "$pod" | jq -r .id) at \$$(echo "$pod" | jq -r .costPerHr)/hr"
+          # Capacity misses return 500 ("machine does not have the resources") —
+          # retry across cloud types instead of dying on the first attempt.
+          pod=""
+          for attempt in 1 2 3; do
+            for cloud in COMMUNITY SECURE; do
+              try=$(echo "$body" | jq --arg c "$cloud" '.cloudType = $c')
+              resp=$(curl -s -w '\n%{http_code}' -X POST "https://rest.runpod.io/v1/pods" \
+                -H "Authorization: Bearer $RUNPOD_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "$try")
+              code=${resp##*$'\n'}; json=${resp%$'\n'*}
+              if [ "$code" = "200" ] || [ "$code" = "201" ]; then pod="$json"; break 2; fi
+              echo "create attempt $attempt ($cloud) -> HTTP $code: $(echo "$json" | jq -r '.error // .' 2>/dev/null | head -c 200)"
+              sleep 20
+            done
+          done
+          [ -n "$pod" ] || { echo "::error::no 4090 capacity after 6 attempts (COMMUNITY+SECURE x3)"; exit 1; }
+          echo "created pod $(echo "$pod" | jq -r .id) at \$$(echo "$pod" | jq -r .costPerHr)/hr ($(echo "$pod" | jq -r .machine.location // empty))"
 
       - name: Wait for runner to come online
         env:

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -85,7 +85,7 @@ jobs:
               resp=$(curl -s -w '\n%{http_code}' -X POST "https://rest.runpod.io/v1/pods" \
                 -H "Authorization: Bearer $RUNPOD_API_KEY" \
                 -H "Content-Type: application/json" \
-                -d "$try")
+                -d "$try" || true)
               code=${resp##*$'\n'}; json=${resp%$'\n'*}
               if [ "$code" = "200" ] || [ "$code" = "201" ]; then pod="$json"; break 2; fi
               echo "create attempt $attempt ($cloud) -> HTTP $code: $(echo "$json" | jq -r '.error // .' 2>/dev/null | head -c 200)"
@@ -93,7 +93,7 @@ jobs:
             done
           done
           [ -n "$pod" ] || { echo "::error::no 4090 capacity after 6 attempts (COMMUNITY+SECURE x3)"; exit 1; }
-          echo "created pod $(echo "$pod" | jq -r .id) at \$$(echo "$pod" | jq -r .costPerHr)/hr ($(echo "$pod" | jq -r .machine.location // empty))"
+          echo "created pod $(echo "$pod" | jq -r .id) at \$$(echo "$pod" | jq -r .costPerHr)/hr ($(echo "$pod" | jq -r '.machine.location // empty'))"
 
       - name: Wait for runner to come online
         env:
@@ -159,7 +159,8 @@ jobs:
             '.[] | select(.name == $n or ((.name | test("^gw-gpu-ci-[0-9]+$")) and .createdAt < $cutoff)) | .id')
           for id in $ids; do
             echo "terminating pod $id"
-            curl -sf -X DELETE "https://rest.runpod.io/v1/pods/$id" || true
+            curl -sf -X DELETE -H "Authorization: Bearer $RUNPOD_API_KEY" \
+              "https://rest.runpod.io/v1/pods/$id" || true
           done
           sleep 5
           leftover=$(list | jq -r --arg n "$POD_NAME" '.[] | select(.name == $n) | .id')


### PR DESCRIPTION
First live master run died in 22s: RunPod returned 500 'machine does not
have the resources' on the single COMMUNITY create attempt. Retry 3 rounds
across both cloud types with the error surfaced in the log.
