### PR TITLE
gw#421 smoke fix: pass prompt= by keyword (first positional is edit image)

### DIFF
--- a/tests/test_gpu_generation_smoke.py
+++ b/tests/test_gpu_generation_smoke.py
@@ -179,8 +179,10 @@ def test_flux2_klein_turbo_generates_real_image(tmp_path: Path) -> None:
     # NATIVE-PARAMS RULE: prompt + fixed seed only; native resolution and the
     # distilled step count. Turbo ignores guidance.
     t0 = time.monotonic()
+    # prompt must be a keyword: __call__'s first positional is the edit-
+    # conditioning image.
     image = pipe(
-        PROMPT,
+        prompt=PROMPT,
         num_inference_steps=STEPS,
         generator=torch.Generator("cpu").manual_seed(SEED),
     ).images[0]


### PR DESCRIPTION
Live run 29059955758 failed in the smoke step: `Flux2KleinPipeline.__call__(image=None, prompt=None, ...)` takes the edit-conditioning image as its first positional, so the positional prompt landed in `image` and check_inputs raised "Provide either prompt or prompt_embeds". One-line fix: `pipe(prompt=PROMPT, ...)`.

Positive signal from the failed run: download + production-path load of the ~16GB klein snapshot completed in ~35s wall on the pod, suite stayed green, image artifact step wired, sweep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)