### PR TITLE
gw#421: generation smoke runs independently of suite outcome

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -124,6 +124,7 @@ jobs:
         run: nvidia-smi
 
       - name: Sync deps (cu128 lock)
+        id: sync
         run: uv sync --extra dev --extra torch --extra images
 
       - name: Run tests
@@ -142,7 +143,10 @@ jobs:
       # diffusers/transformers are endpoint deps, not gen-worker deps — installed
       # into the synced venv (torch stays the cu128 lock build; pins mirror the
       # klein endpoint); --no-sync keeps uv run from pruning them.
+      # Independent signal: runs whenever deps synced, even if the suite failed
+      # (a flaky unit test must not hide "does the product make pictures").
       - name: Image-generation smoke (FLUX.2-klein-4B turbo)
+        if: ${{ !cancelled() && steps.sync.outcome == 'success' }}
         env:
           GEN_WORKER_GPU_SMOKE: "1"
           GEN_WORKER_SMOKE_OUT: ${{ github.workspace }}/smoke-out


### PR DESCRIPTION
Runs 29060438735 and 29060632069 both failed on the pre-existing `test_peak_anon_rss_below_2x_largest_tensor[cast_bf16]` RSS-bound flake (~104MB vs 93.75MB, machine-sensitive; it was green on the 23:37 pod), which skipped the generation smoke both times. The smoke is an independent "does the product make pictures" signal — gate it on deps-sync success instead of suite success (`!cancelled() && steps.sync.outcome == 'success'`). A garbled image still fails the job; the flaky suite test still fails the job; they just no longer mask each other.

Not touched here: the RSS flake itself — noted in the gw#421 tracker section for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)