### PR TITLE
Machine-level veto for CPU inference: GEN_WORKER_FORBID_CPU_OFFLOAD

### DIFF
--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -41,6 +41,23 @@ _DEFAULT_OFF_HEADROOM_GB = 8.0
 # Sentinel attribute set on pipelines to make apply_low_vram_config idempotent.
 _COZY_MODE_ATTR = "_cozy_low_vram_mode"
 
+# Modes that spill model weights to system RAM and run parts of inference on CPU.
+_CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
+
+
+def _forbid_cpu_inference(detail: str) -> None:
+    """Raise when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes a CPU-touching placement.
+
+    Set on dev machines so agents/tests can't silently melt the box with
+    CPU-offloaded inference; real-model runs belong on the GPU CI lane.
+    """
+    if os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD") == "1":
+        raise RuntimeError(
+            f"GEN_WORKER_FORBID_CPU_OFFLOAD=1: refusing {detail}. "
+            "Real-model inference that does not fit in free VRAM must run on "
+            "the GPU CI lane, not this machine."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Probes
@@ -417,8 +434,10 @@ def place_pipeline(pipeline: Any, *, logger: Optional[logging.Logger] = None) ->
         import torch
 
         if not torch.cuda.is_available():
+            _forbid_cpu_inference("CPU-only inference (no CUDA available)")
             return {"mode": "cpu"}
     except Exception:
+        _forbid_cpu_inference("CPU-only inference (torch/CUDA unavailable)")
         return {"mode": "cpu"}
     mode = select_auto_mode(pipeline=pipeline)
     if mode in ("off", "vae_only") and callable(getattr(pipeline, "to", None)):
@@ -457,6 +476,8 @@ def apply_low_vram_config(
             pipeline=pipeline, model_size_gb=model_size_gb, peak_vram_gb=peak_vram_gb,
         )
         log.info("low_vram: auto-selected mode=%s", effective_mode)
+    if effective_mode in _CPU_OFFLOAD_MODES:
+        _forbid_cpu_inference(f"CPU-offloaded inference (mode={effective_mode})")
 
     applied: Dict[str, Any] = {
         "mode": effective_mode,

--- a/tests/test_gpu_generation_smoke.py
+++ b/tests/test_gpu_generation_smoke.py
@@ -27,10 +27,17 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get("GEN_WORKER_GPU_SMOKE") != "1",
-    reason="generation smoke runs only with GEN_WORKER_GPU_SMOKE=1 (~16GB download)",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("GEN_WORKER_GPU_SMOKE") != "1",
+        reason="generation smoke runs only with GEN_WORKER_GPU_SMOKE=1 (~16GB download)",
+    ),
+    # Machine-level veto: wins even when GEN_WORKER_GPU_SMOKE=1 is set.
+    pytest.mark.skipif(
+        os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD") == "1",
+        reason="real inference is forbidden on this machine (GPU CI lane only)",
+    ),
+]
 
 # Turbo (step-distilled) klein — verified ungated (anonymous download OK).
 REPO_ID = "black-forest-labs/FLUX.2-klein-4B"

--- a/tests/test_no_cpu_inference_veto.py
+++ b/tests/test_no_cpu_inference_veto.py
@@ -1,0 +1,30 @@
+"""GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes any placement that touches the CPU."""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models.memory import apply_low_vram_config
+
+
+class _DummyPipeline:
+    pass
+
+
+def test_offload_modes_raise_when_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    for mode in ("model_offload", "group_offload", "sequential"):
+        with pytest.raises(RuntimeError, match="FORBID_CPU_OFFLOAD"):
+            apply_low_vram_config(_DummyPipeline(), mode=mode)
+
+
+def test_gpu_resident_modes_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    result = apply_low_vram_config(_DummyPipeline(), mode="off")
+    assert result["mode"] == "off"
+
+
+def test_offload_allowed_without_veto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    result = apply_low_vram_config(_DummyPipeline(), mode="model_offload")
+    assert result["mode"] == "model_offload"


### PR DESCRIPTION
Dev boxes export `GEN_WORKER_FORBID_CPU_OFFLOAD=1`; any placement that would touch the CPU (CPU-only torch, or model/group/sequential offload) raises with a clear error, and the GPU generation smoke skips even when `GEN_WORKER_GPU_SMOKE=1` is set. Real-model runs belong on the GPU CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)