### PR TITLE
gw#438: J19 training first-light blockers — UUID dataset refs + ctx progress emitter

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -9,6 +9,7 @@ asyncio loop; sync tenant code runs in threads via asyncio.to_thread.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
 import os
 import re
@@ -61,6 +62,10 @@ _CONTEXT_BY_KIND: Dict[str, type] = {
 logger = logging.getLogger(__name__)
 
 INLINE_RESULT_MAX_BYTES = 64 * 1024
+# ctx.progress/log/checkpoint events ride the JobProgress stream; the hub fans
+# them to /v1/requests/:id/events SSE as output.delta envelopes whose
+# payload.delta carries this JSON verbatim (th#640).
+EVENT_CONTENT_TYPE = "application/x-request-event+json"
 _CANCEL_GRACE_S = 5.0
 _STUCK_THREAD_RECYCLE_S = 30.0
 _DOWNLOAD_RETRIES = 3
@@ -635,6 +640,10 @@ class _Job:
     finished: bool = False
     superseded: bool = False
     admitted_at: float = dc_field(default_factory=time.monotonic)
+    # One JobProgress seq space per job, shared by stream chunks and ctx
+    # events so interleaved sends stay monotonic. itertools.count.__next__
+    # is atomic under the GIL — safe from handler threads.
+    seq: "itertools.count[int]" = dc_field(default_factory=lambda: itertools.count(1))
 
 
 class _GpuSlotLease:
@@ -1589,6 +1598,7 @@ class Executor:
         ctx_cls = _CONTEXT_BY_KIND.get(spec.kind, RequestContext)
         ctx = ctx_cls(
             request_id=run.request_id,
+            emitter=self._make_ctx_emitter(job),
             owner=run.tenant or None,
             invoker_id=run.invoker_id or None,
             timeout_ms=timeout_ms or None,
@@ -1941,16 +1951,41 @@ class Executor:
             request_id=job.request_id, attempt=job.attempt, seq=seq,
             data=data, content_type=content_type)))
 
+    def _make_ctx_emitter(self, job: _Job) -> Callable[[Dict[str, Any]], None]:
+        """RequestContext emitter: ctx.progress/log/checkpoint events →
+        JobProgress on the worker stream (best-effort, droppable by contract).
+        Callable from any thread (handler thread, run_process reader)."""
+        loop = asyncio.get_running_loop()
+
+        async def _send_event(data: bytes) -> None:
+            try:
+                await self._emit_progress(job, next(job.seq), data, EVENT_CONTENT_TYPE)
+            except Exception:
+                logger.debug("ctx event send failed for %s", job.request_id, exc_info=True)
+
+        def _emit(event: Dict[str, Any]) -> None:
+            if job.finished:
+                return
+            try:
+                data = msgspec.json.encode(event)
+            except Exception:
+                logger.debug("unencodable ctx event dropped for %s", job.request_id)
+                return
+            try:
+                asyncio.run_coroutine_threadsafe(_send_event(data), loop)
+            except RuntimeError:
+                pass  # loop closed — worker shutting down
+
+        return _emit
+
     async def _pump_async_gen(self, job: _Job, agen: Any) -> None:
-        seq = 0
         async for item in agen:
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()
             enc = self._encode_chunk(item)
             if enc is None:
                 break
-            seq += 1
-            await self._emit_progress(job, seq, enc[0], enc[1])
+            await self._emit_progress(job, next(job.seq), enc[0], enc[1])
 
     def _pump_sync_gen(
         self,
@@ -1965,16 +2000,14 @@ class Executor:
                 torch.cuda.set_device(gpu_index)
             except Exception:
                 pass
-        seq = 0
         for item in bound(**call_kwargs):
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()
             enc = self._encode_chunk(item)
             if enc is None:
                 break
-            seq += 1
             fut = asyncio.run_coroutine_threadsafe(
-                self._emit_progress(job, seq, enc[0], enc[1]), loop
+                self._emit_progress(job, next(job.seq), enc[0], enc[1]), loop
             )
             fut.result()  # backpressure: block the producer on queue overflow
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -486,6 +486,27 @@ class RequestContext:
             payload["stage"] = stage
         self._emit_event("request.progress", payload)
 
+    def _emit_checkpoint_saved(
+        self,
+        ref: str,
+        *,
+        step_number: Optional[int] = None,
+        epoch_number: Optional[int] = None,
+        output_kind: Optional[str] = None,
+        size_bytes: Optional[int] = None,
+    ) -> None:
+        """Emit a checkpoint-saved event (best-effort; rides JobProgress)."""
+        payload: Dict[str, Any] = {"ref": ref}
+        if step_number is not None:
+            payload["step_number"] = int(step_number)
+        if epoch_number is not None:
+            payload["epoch_number"] = int(epoch_number)
+        if output_kind:
+            payload["output_kind"] = str(output_kind)
+        if size_bytes is not None:
+            payload["size_bytes"] = int(size_bytes)
+        self._emit_event("request.checkpoint", payload)
+
     def log(self, message: str, level: str = "info") -> None:
         self._emit_event("request.log", {"message": message, "level": level})
 
@@ -937,10 +958,18 @@ class _PublisherMixin:
                         stream.write(chunk)
                 out = stream.finalize()
                 if isinstance(out, Tensors):
+                    self._emit_checkpoint_saved(
+                        ref, step_number=step_number, epoch_number=epoch_number,
+                        output_kind=output_kind, size_bytes=size,
+                    )
                     return out
                 raise RuntimeError("file save failed (invalid_tensors_response)")
 
             asset = self.save_file(ref, src)
+        self._emit_checkpoint_saved(
+            ref, step_number=step_number, epoch_number=epoch_number,
+            output_kind=output_kind, size_bytes=size,
+        )
         return Tensors(
             ref=asset.ref,
             owner=asset.owner,
@@ -990,10 +1019,18 @@ class _PublisherMixin:
             stream.write(payload)
             out = stream.finalize()
             if isinstance(out, Tensors):
+                self._emit_checkpoint_saved(
+                    ref, step_number=step_number, epoch_number=epoch_number,
+                    output_kind=output_kind, size_bytes=len(payload),
+                )
                 return out
             raise RuntimeError("file save failed (invalid_tensors_response)")
 
         asset = self.save_bytes(ref, payload)
+        self._emit_checkpoint_saved(
+            ref, step_number=step_number, epoch_number=epoch_number,
+            output_kind=output_kind, size_bytes=len(payload),
+        )
         return Tensors(
             ref=asset.ref,
             owner=asset.owner,
@@ -1177,11 +1214,17 @@ class _PublisherMixin:
         return d
 
     def resolve_dataset(self, ref: str) -> str:
-        """Materialize a dataset by ``owner/name`` ref; return the local root.
+        """Materialize a dataset by bare dataset-id or ``owner/name`` ref;
+        return the local root.
 
-        Flow (th#642 wire format):
+        Production refs are bare dataset UUIDs (th#641: the hub rewrites
+        ``payload.datasets[].ref`` at submit and mints the ``read_dataset``
+        grant by UUID; a grant-scoped token can't list) — those hit
+        materialize directly. ``owner/name`` refs stay for local/dev via the
+        ``?tenant=`` list lookup. Flow (th#642 wire format):
 
-        1. ``GET /api/v1/datasets?owner=<owner>`` → the row's ``dataset_id``.
+        1. Slash-less ref → dataset_id verbatim; otherwise
+           ``GET /api/v1/datasets?tenant=<owner>`` → the row's ``dataset_id``.
         2. ``GET /api/v1/datasets/:id/materialize?format=parquet&include_urls=true``
            → HF-datasets columnar parquet shards (image bytes embedded) with
            presigned URLs, sizes and blake3 checksums.
@@ -1201,17 +1244,24 @@ class _PublisherMixin:
         cached = self.dataset_paths.get(ref)
         if cached:
             return cached
-        owner, name = _parse_owner_repo(ref)
         base = (self._file_api_base_url or "").strip().rstrip("/")
         if not base:
             raise RuntimeError(f"resolve_dataset({ref!r}): no file_api_base_url")
         token = self._get_worker_capability_token()
 
-        dataset_id = lookup_dataset_id(base, token, owner, name)
-        snapshot_id, entries = fetch_materialize_manifest(base, token, owner, dataset_id)
+        if "/" in ref:
+            owner, name = _parse_owner_repo(ref)
+            dataset_id = lookup_dataset_id(base, token, owner, name)
+            cache_key = (owner, name)
+        else:
+            dataset_id = ref.strip()
+            if not dataset_id:
+                raise RuntimeError("resolve_dataset: empty ref")
+            cache_key = ("by-id", dataset_id)
+        snapshot_id, entries = fetch_materialize_manifest(base, token, dataset_id)
 
         cache_root = Path(tempfile.gettempdir()) / "gen_worker_datasets"
-        target_root = cache_root / owner / name / (snapshot_id or dataset_id)
+        target_root = cache_root.joinpath(*cache_key) / (snapshot_id or dataset_id)
         target_root.mkdir(parents=True, exist_ok=True)
         download_entries(
             entries, target_root,
@@ -1384,11 +1434,11 @@ class DatasetContext(_PublisherMixin, RequestContext):
         if snapshot_manifest:
             features_payload["__cozy_snapshot_manifest__"] = snapshot_manifest
 
-        # Step 1: look up any existing dataset by (owner, name). tensorhub
-        # currently lists by owner and filters client-side; this is O(N)
-        # but N is small (typically <100 datasets per org in practice).
+        # Step 1: look up any existing dataset by (tenant, name). tensorhub
+        # lists by ?tenant= and we filter client-side; this is O(N) but N is
+        # small (typically <100 datasets per org in practice).
         list_url = (
-            f"{base}/api/v1/datasets?owner={urllib.parse.quote(owner, safe='')}"
+            f"{base}/api/v1/datasets?tenant={urllib.parse.quote(owner, safe='')}"
         )
         list_resp = requests.get(list_url, headers=headers, timeout=30)
         existing_id = ""
@@ -1406,7 +1456,7 @@ class DatasetContext(_PublisherMixin, RequestContext):
             # Step 2a: create.
             create_url = f"{base}/api/v1/datasets"
             create_body = {
-                "owner": owner,
+                "tenant": owner,
                 "name": name,
                 "visibility": visibility,
                 "schema": features_payload,

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -1,7 +1,7 @@
 """Dataset snapshot materialization against the tensorhub datasets API.
 
 Free functions used by ``_PublisherMixin.resolve_dataset``: look up a dataset
-row by (owner, name), fetch its parquet materialize manifest (presigned shard
+row by (tenant, name), fetch its parquet materialize manifest (presigned shard
 URLs, th#642 wire format), and stream each shard to disk with digest
 verification + bounded retries.
 """
@@ -22,12 +22,17 @@ _DOWNLOAD_BACKOFF_S = 1.0
 _CHUNK_BYTES = 1024 * 1024
 
 
-def lookup_dataset_id(base: str, token: str, owner: str, name: str) -> str:
-    """GET /api/v1/datasets?owner= → dataset_id of the row named ``name``."""
+def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
+    """GET /api/v1/datasets?tenant= → dataset_id of the row named ``name``.
+
+    Only used for owner/name refs (local/dev). Production refs arrive as bare
+    dataset UUIDs and skip the lookup — a grant-scoped read_dataset capability
+    token cannot list datasets at all.
+    """
     import requests
 
-    url = f"{base}/api/v1/datasets?owner={urllib.parse.quote(owner, safe='')}"
-    headers = {"Authorization": f"Bearer {token}", "X-Cozy-Owner": owner}
+    url = f"{base}/api/v1/datasets?tenant={urllib.parse.quote(tenant, safe='')}"
+    headers = {"Authorization": f"Bearer {token}"}
     resp = requests.get(url, headers=headers, timeout=30)
     if resp.status_code in (401, 403):
         raise AuthError(f"dataset lookup unauthorized ({resp.status_code})")
@@ -39,14 +44,15 @@ def lookup_dataset_id(base: str, token: str, owner: str, name: str) -> str:
             dataset_id = str(it.get("dataset_id") or "")
             if dataset_id:
                 return dataset_id
-    raise RuntimeError(f"dataset not found for owner={owner} name={name}")
+    raise RuntimeError(f"dataset not found for tenant={tenant} name={name}")
 
 
 def fetch_materialize_manifest(
-    base: str, token: str, owner: str, dataset_id: str
+    base: str, token: str, dataset_id: str
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """GET /datasets/:id/materialize?format=parquet&include_urls=true.
 
+    Authorizes by dataset id + read_dataset grant (or tenant read perm).
     Returns (snapshot_id, entries); entries carry
     {path, url?, size_bytes?, checksum?, inline_text?, blob_digest?}.
     """
@@ -56,7 +62,7 @@ def fetch_materialize_manifest(
         f"{base}/api/v1/datasets/{urllib.parse.quote(dataset_id, safe='')}"
         "/materialize?format=parquet&include_urls=true"
     )
-    headers = {"Authorization": f"Bearer {token}", "X-Cozy-Owner": owner}
+    headers = {"Authorization": f"Bearer {token}"}
     resp = requests.get(url, headers=headers, timeout=120)
     if resp.status_code in (401, 403):
         raise AuthError(f"dataset materialize unauthorized ({resp.status_code})")

--- a/tests/test_dataset_materialization.py
+++ b/tests/test_dataset_materialization.py
@@ -15,18 +15,26 @@ import threading
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import blake3
 import msgspec
 import pytest
 
+from gen_worker.api.errors import AuthError
 from gen_worker.api.types import DatasetRef
 from gen_worker.executor import Executor
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
 from gen_worker.request_context import TrainingContext
 from gen_worker.request_context import _datasets as datasets_mod
+
+# th#641 production shape: the hub rewrites payload.datasets[].ref to the
+# dataset UUID at submit and mints the read_dataset grant by UUID.
+_DATASET_UUID = "0b6e0c33-8f5e-4a8e-9d0f-2f6f19e1c9aa"
+# A capability token carrying ONLY a read_dataset grant — can materialize by
+# id, cannot list.
+_GRANT_TOKEN = "cap-tok-read-grant"
 
 
 def _tiny_parquet_bytes() -> bytes:
@@ -58,7 +66,11 @@ class _FakeHub:
         self.fail_first_n_shard_gets = 0
         self.lie_about_digest = False
         self.shard_requests = 0
+        self.list_requests = 0
         self.seen_auth: List[str] = []
+        # Rows the list endpoint knows + ids materialize serves. th#641
+        # production refs are bare UUIDs the list endpoint never saw.
+        self.known_ids = {"ds-1", _DATASET_UUID}
 
         outer = self
 
@@ -68,18 +80,37 @@ class _FakeHub:
 
             def do_GET(self) -> None:  # noqa: N802
                 parsed = urllib.parse.urlparse(self.path)
-                outer.seen_auth.append(self.headers.get("Authorization") or "")
+                auth = self.headers.get("Authorization") or ""
+                outer.seen_auth.append(auth)
+                parts = parsed.path.strip("/").split("/")
                 if parsed.path == "/api/v1/datasets":
+                    outer.list_requests += 1
+                    # Grant-scoped read_dataset capability tokens cannot list
+                    # (tensorhub resolveTargetTenant requires create_dataset).
+                    if auth == f"Bearer {_GRANT_TOKEN}":
+                        self._status(403)
+                        return
+                    # The hub reads ?tenant= — ?owner= is silently ignored
+                    # there, which here is a hard failure.
+                    q = urllib.parse.parse_qs(parsed.query)
+                    if q.get("tenant", [""])[0] != "acme":
+                        self._status(400)
+                        return
                     self._json({"items": [
                         {"dataset_id": "ds-1", "tenant": "acme", "name": "faces"},
                         {"dataset_id": "ds-2", "tenant": "acme", "name": "other"},
                     ]})
-                elif parsed.path == "/api/v1/datasets/ds-1/materialize":
+                elif (len(parts) == 5 and parts[:3] == ["api", "v1", "datasets"]
+                      and parts[4] == "materialize"):
+                    ds_id = parts[3]
+                    if ds_id not in outer.known_ids:
+                        self._status(404)
+                        return
                     digest = outer.shard_digest
                     if outer.lie_about_digest:
                         digest = "blake3:" + "0" * 64
                     self._json({
-                        "dataset_id": "ds-1",
+                        "dataset_id": ds_id,
                         "format": "parquet_ref",
                         "snapshot_id": outer.snapshot_id,
                         "entries": [
@@ -108,6 +139,11 @@ class _FakeHub:
                 else:
                     self.send_response(404)
                     self.end_headers()
+
+            def _status(self, code: int) -> None:
+                self.send_response(code)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
 
             def _json(self, payload: Dict) -> None:
                 body = json.dumps(payload).encode()
@@ -197,6 +233,37 @@ def test_resolve_dataset_unknown_name(hub) -> None:
         ctx.resolve_dataset("acme/nope")
 
 
+def test_resolve_dataset_uuid_ref_skips_list(hub) -> None:
+    """th#641 production path: bare UUID ref + grant-scoped token → straight
+    to materialize; the list endpoint (403 for this token) is never touched."""
+    ctx = TrainingContext(
+        request_id="r1",
+        file_api_base_url=hub.base,
+        worker_capability_token=_GRANT_TOKEN,
+    )
+    root = Path(ctx.resolve_dataset(_DATASET_UUID))
+    _assert_snapshot(root, hub)
+    assert ctx.dataset_paths[_DATASET_UUID] == str(root)
+    assert hub.list_requests == 0
+    assert f"Bearer {_GRANT_TOKEN}" in hub.seen_auth
+    # Cache hit on second resolve.
+    n = hub.shard_requests
+    assert ctx.resolve_dataset(_DATASET_UUID) == str(root)
+    assert hub.shard_requests == n
+
+
+def test_grant_scoped_token_cannot_use_owner_name_refs(hub) -> None:
+    """owner/name refs need the list endpoint, which read-only grant tokens
+    can't call — AuthError, not a silent wrong answer."""
+    ctx = TrainingContext(
+        request_id="r1",
+        file_api_base_url=hub.base,
+        worker_capability_token=_GRANT_TOKEN,
+    )
+    with pytest.raises(AuthError):
+        ctx.resolve_dataset("acme/faces")
+
+
 # ---- executor: payload.datasets materialized before the handler runs -------
 
 
@@ -219,7 +286,7 @@ def _train(ctx, payload: _TrainIn) -> _TrainOut:
     )
 
 
-def _run_training_job(hub: _FakeHub, payload: _TrainIn) -> pb.JobResult:
+def _run_training_job(hub: _FakeHub, payload: _TrainIn, *, token: str = "cap-tok") -> pb.JobResult:
     async def _go() -> pb.JobResult:
         sent: List[pb.WorkerMessage] = []
 
@@ -234,7 +301,7 @@ def _run_training_job(hub: _FakeHub, payload: _TrainIn) -> pb.JobResult:
         ex.file_base_url = hub.base
         await ex.handle_run_job(pb.RunJob(
             request_id="r1", attempt=1, function_name="train-lora",
-            capability_token="cap-tok",
+            capability_token=token,
             input_payload=msgspec.msgpack.encode(payload)))
         job = ex.jobs[("r1", 1)]
         assert job.task is not None
@@ -259,3 +326,16 @@ def test_executor_dataset_failure_is_job_failure(hub) -> None:
     hub.lie_about_digest = True
     res = _run_training_job(hub, _TrainIn(datasets=[DatasetRef(ref="acme/faces")]))
     assert res.status != pb.JOB_STATUS_OK
+
+
+def test_executor_materializes_uuid_payload_datasets(hub) -> None:
+    """The gw#425 pre-materialization path must accept th#641's rewritten
+    UUID refs with a grant-scoped token — the production shape."""
+    res = _run_training_job(
+        hub, _TrainIn(datasets=[DatasetRef(ref=_DATASET_UUID)]), token=_GRANT_TOKEN,
+    )
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    out = msgspec.msgpack.decode(res.inline, type=_TrainOut)
+    assert _DATASET_UUID in out.dataset_paths
+    assert out.shard_exists
+    assert hub.list_requests == 0

--- a/tests/test_executor_progress_events.py
+++ b/tests/test_executor_progress_events.py
@@ -1,0 +1,133 @@
+"""th#640/J19: ctx.progress from an orchestrated handler must reach the hub.
+
+The executor wires a RequestContext emitter that turns ctx.progress / ctx.log /
+checkpoint events into JobProgress envelopes on the worker gRPC stream
+(content_type application/x-request-event+json, JSON event verbatim in data).
+tensorhub fans those to /v1/requests/:id/events SSE as output.delta with
+payload.delta carrying the JSON — J19 parses "training step N/M loss=X" and
+checkpoint markers out of exactly that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Dict, List
+
+import msgspec
+import pytest
+
+from gen_worker.executor import EVENT_CONTENT_TYPE, Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+from gen_worker.request_context import TrainingContext
+
+
+class _In(msgspec.Struct):
+    steps: int = 500
+
+
+class _Out(msgspec.Struct):
+    ok: bool
+
+
+def _train(ctx, payload: _In) -> _Out:
+    for step in (100, 250):
+        ctx.progress(step / payload.steps, f"training step {step}/{payload.steps} loss=0.0123")
+    ctx.log("saving checkpoint", level="info")
+    return _Out(ok=True)
+
+
+def _run(kind: str, method) -> List[pb.WorkerMessage]:
+    async def _go() -> List[pb.WorkerMessage]:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(
+            name="fn", method=method, kind=kind,
+            payload_type=_In, output_mode="single",
+        )
+        ex = Executor([spec], _send)
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="fn",
+            input_payload=msgspec.msgpack.encode(_In())))
+        job = ex.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        # Drain event coroutines scheduled from the handler thread.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        return sent
+
+    return asyncio.run(_go())
+
+
+def _events(sent: List[pb.WorkerMessage]) -> List[Dict]:
+    out = []
+    for m in sent:
+        if m.WhichOneof("msg") != "job_progress":
+            continue
+        p = m.job_progress
+        if p.content_type != EVENT_CONTENT_TYPE:
+            continue
+        out.append({"seq": p.seq, "event": json.loads(p.data)})
+    return out
+
+
+def test_training_ctx_progress_reaches_job_progress_stream() -> None:
+    sent = _run("training", _train)
+    events = _events(sent)
+    assert len(events) == 3
+
+    types = [e["event"]["type"] for e in events]
+    assert types == ["request.progress", "request.progress", "request.log"]
+    for e in events:
+        assert e["event"]["request_id"] == "r1"
+
+    stages = [e["event"]["payload"].get("stage", "") for e in events[:2]]
+    assert stages == ["training step 100/500 loss=0.0123",
+                      "training step 250/500 loss=0.0123"]
+    assert events[0]["event"]["payload"]["progress"] == pytest.approx(0.2)
+
+    seqs = [e["seq"] for e in events]
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+
+
+def test_inference_ctx_progress_also_flows() -> None:
+    def _infer(ctx, payload: _In) -> _Out:
+        ctx.progress(0.5, "denoise")
+        return _Out(ok=True)
+
+    events = _events(_run("inference", _infer))
+    assert [e["event"]["type"] for e in events] == ["request.progress"]
+
+
+def test_save_checkpoint_emits_checkpoint_event(tmp_path) -> None:
+    """The trainer's periodic LoRA saves must surface as checkpoint events
+    (J19 asserts markers at steps 250/500)."""
+    src = tmp_path / "lora_000000250.safetensors"
+    src.write_bytes(b"weights")
+    captured: List[Dict] = []
+    ctx = TrainingContext(
+        request_id="r1",
+        emitter=captured.append,
+        local_output_dir=str(tmp_path / "outs"),
+        worker_capability_token="cap-tok",
+        execution_hints={"kind": "training"},
+    )
+    ctx.save_checkpoint(
+        "checkpoints/lora_000000250.safetensors", str(src),
+        step_number=250, output_kind="lora",
+    )
+    ckpt = [e for e in captured if e["type"] == "request.checkpoint"]
+    assert len(ckpt) == 1
+    payload = ckpt[0]["payload"]
+    assert payload["step_number"] == 250
+    assert payload["output_kind"] == "lora"
+    assert payload["ref"].endswith("lora_000000250.safetensors")
+    assert payload["size_bytes"] == len(b"weights")


### PR DESCRIPTION
Two live-run blockers found by e2e J19 pre-flight verification (e2e PR #40).

## Blocker 1 — resolve_dataset can't take UUID refs
tensorhub (th#641) rewrites `payload.datasets[].ref` owner/name → dataset UUID at submit and mints the `read_dataset` grant by UUID. `resolve_dataset` raised on slash-less refs (`_parse_owner_repo`), listed with the wrong param (`?owner=`; the hub reads `?tenant=`, datasets.go `listDatasets`), and a grant-scoped capability token can't list datasets at all.

- Slash-less ref = dataset_id: hit `GET /api/v1/datasets/:id/materialize?format=parquet&include_urls=true` directly (authorizes by UUID + grant), no list lookup. Covers the executor's `payload.datasets` pre-materialization (gw#425) — the production path.
- owner/name refs keep working for local/dev; list lookup fixed to `?tenant=`; dropped the unread `X-Cozy-Owner` header.
- Same `?owner=` bug fixed in `publish_dataset_revision` (list lookup + create body `tenant` field, matching `createDatasetReq`).

## Blocker 2 — ctx.progress never reaches the hub in orchestrated mode
The executor constructed contexts with no emitter, so progress/checkpoint events were dropped worker-side. No context kind had one wired (inference streaming used the JobProgress pump only for output chunks).

- Executor wires an emitter into every context (training/conversion/dataset/inference): ctx events are JSON-encoded verbatim and sent as `JobProgress` with `content_type=application/x-request-event+json`; the hub fans them to `/v1/requests/:id/events` SSE as `output.delta` envelopes whose `payload.delta` carries the event JSON (th#640 path: JobProgress → ProgressHub → SSE; never postgres).
- `save_checkpoint` / `save_checkpoint_bytes` now emit `request.checkpoint` events (ref, step_number, epoch_number, output_kind, size_bytes) so J19's checkpoint markers at steps 250/500 surface on SSE.
- Stream chunks and ctx events share one per-job seq space (monotonic on the wire).

## Tests (real codepaths)
- Local HTTP hub stand-in: materialize-by-UUID with a grant-scoped token that 403s on list (list never called); `?tenant=` enforced (400 otherwise); executor end-to-end with a UUID `payload.datasets` ref.
- Emitter-capture: kind=training handler's `ctx.progress("training step N/M loss=…")` produces the JobProgress envelope (content-type, JSON body, monotonic seq); inference ctx.progress flows too; `save_checkpoint` emits `request.checkpoint` with step_number.

Full suite: 614 passed, 4 skipped. ruff clean on `src/gen_worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)