### PR TITLE
gw#441: clone workdir flock — concurrent duplicate clones serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.1 (2026-07-10)
+
+- **gw#441: clone workdir flock — concurrent duplicate clones serialize.**
+  Two clones of the same (provider, source, destination) share the resumable
+  workdir; hf_hub's local-dir download unlinks + re-fetches files the peer
+  clone is mid-reading, so the leading clone's convert phase failed with
+  `FileNotFoundError` on a shard `snapshot_download` had just written (live:
+  e2e J19, crash-recovery re-queue put the same Qwen-Image-Edit-2511 clone on
+  one worker twice). `run_clone` now holds an exclusive flock
+  (`.clone-<digest>.lock`) for its whole lifetime; a duplicate blocks, then
+  (with th#592 banking) publishes by CAS reference without downloading.
+
 ## 0.13.0 (2026-07-09)
 
 - **Breaking (gw#424): the standalone trainer runtime is deleted** —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.0"
+version = "0.13.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -11,6 +11,7 @@ and :func:`run_clone` (keyword-explicit).
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import logging
 import os
@@ -443,6 +444,22 @@ def _clone_workdir(provider: str, source_key: str, destination: str) -> Path:
     return workdir
 
 
+def _acquire_workdir_lock(workdir: Path) -> int:
+    """Exclusive flock serializing clones that share one keyed workdir.
+    Concurrent duplicates (crash-recovery re-queues of the same clone)
+    otherwise corrupt the shared snapshot: hf_hub's local-dir download
+    unlinks + re-fetches files the peer clone is mid-reading."""
+    lock_path = workdir.parent / f".{workdir.name}.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        logger.info(
+            "workdir %s held by a concurrent clone of the same source; waiting", workdir)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
+
+
 def run_clone(
     ctx: Any,
     *,
@@ -480,6 +497,7 @@ def run_clone(
     if source_revision:
         source_key = f"{source_key}@{source_revision}"
     workdir = _clone_workdir(provider, source_key, destination)
+    lock_fd = _acquire_workdir_lock(workdir)
     succeeded = False
     try:
         if provider not in {"huggingface", "civitai"}:
@@ -727,6 +745,7 @@ def run_clone(
             shutil.rmtree(workdir, ignore_errors=True)
         else:
             logger.warning("clone failed; workdir retained for resume: %s", workdir)
+        os.close(lock_fd)  # releases the flock
 
 
 def from_huggingface(ctx: Any, payload: Any, *, hf_token: str | None = None) -> CloneResult:

--- a/tests/convert/test_clone_concurrency.py
+++ b/tests/convert/test_clone_concurrency.py
@@ -1,0 +1,177 @@
+"""Concurrent duplicate clones must serialize on the keyed workdir (gw#441).
+
+Live failure (e2e J19): a crash-recovery re-queue put two clones of the same
+(provider, source, destination) on one worker concurrently. Both shared
+``clone-<digest>/source``; hf_hub's local-dir download unlinks + re-fetches
+files the peer clone had just downloaded and was reading, so the leading
+clone's convert phase hit ``FileNotFoundError: No such file or directory:
+.../source/text_encoder/model-00001-of-00004.safetensors``. run_clone now
+takes an exclusive flock on the workdir for its whole lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from gen_worker.convert.clone import CloneResult, run_clone
+from gen_worker.convert.ingest import IngestedSource
+
+from fake_hub import _FakeHub
+
+
+class _Ctx:
+    def __init__(self, server) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+        self.request_id = "req-1"
+        self.destination = {"repo": "acme/fallback"}
+
+
+def _fake_source(dest_dir: Path) -> IngestedSource:
+    return IngestedSource(
+        provider="huggingface",
+        source_ref="org/tiny",
+        source_revision="sha-1",
+        dir=dest_dir,
+        layout="diffusers",
+        model_family="",
+        model_family_variant="",
+        classification=None,
+        attrs={"dtype": "bf16"},
+        metadata={"source_provider": "huggingface"},
+        repo_spec={"kind": "model", "library_name": "diffusers"},
+    )
+
+
+def test_concurrent_same_source_clones_serialize(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    """Two run_clone calls for the same source+destination never overlap in
+    the ingest/convert window, and both publish."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    # Keep the test offline: plan failure is a supported path (download-skip
+    # disabled, full clone runs).
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.plan_huggingface",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    guard = threading.Lock()
+    state = {"active": 0, "max_active": 0}
+
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        with guard:
+            state["active"] += 1
+            state["max_active"] = max(state["max_active"], state["active"])
+        # Hold the window open so an unserialized peer would overlap.
+        time.sleep(0.5)
+        dest_dir = Path(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "config.json").write_text("{}")
+        with guard:
+            state["active"] -= 1
+        return _fake_source(dest_dir)
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+    results: dict[int, CloneResult | BaseException] = {}
+
+    def _clone(i: int) -> None:
+        try:
+            results[i] = run_clone(
+                _Ctx(fake_hub), provider="huggingface", source_ref="org/tiny",
+                destination_repo="acme/dest",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            results[i] = exc
+
+    threads = [threading.Thread(target=_clone, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    for i in range(2):
+        assert isinstance(results.get(i), CloneResult), f"clone {i}: {results.get(i)!r}"
+        assert len(results[i].published) == 1
+    assert state["max_active"] == 1, "concurrent clones shared the workdir"
+
+
+def test_distinct_destinations_do_not_serialize(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    """The lock is per (provider, source, destination): unrelated clones
+    still run in parallel."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.plan_huggingface",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    both_inside = threading.Barrier(2, timeout=10)
+
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        both_inside.wait()  # deadlocks (Barrier timeout) if serialized
+        dest_dir = Path(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "config.json").write_text("{}")
+        return _fake_source(dest_dir)
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+    results: dict[int, CloneResult | BaseException] = {}
+
+    def _clone(i: int) -> None:
+        try:
+            results[i] = run_clone(
+                _Ctx(fake_hub), provider="huggingface", source_ref="org/tiny",
+                destination_repo=f"acme/dest-{i}",
+            )
+        except BaseException as exc:  # noqa: BLE001
+            results[i] = exc
+
+    threads = [threading.Thread(target=_clone, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    for i in range(2):
+        assert isinstance(results.get(i), CloneResult), f"clone {i}: {results.get(i)!r}"
+
+
+def test_failed_clone_releases_lock_for_retry(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    """A failed clone releases the flock so the retry can take it."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.plan_huggingface",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    calls = {"n": 0}
+
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        calls["n"] += 1
+        dest_dir = Path(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        if calls["n"] == 1:
+            raise RuntimeError("network died mid-download")
+        (dest_dir / "config.json").write_text("{}")
+        return _fake_source(dest_dir)
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+    with pytest.raises(RuntimeError, match="network died"):
+        run_clone(
+            _Ctx(fake_hub), provider="huggingface", source_ref="org/tiny",
+            destination_repo="acme/dest",
+        )
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="org/tiny",
+        destination_repo="acme/dest",
+    )
+    assert len(result.published) == 1


### PR DESCRIPTION
## Root cause (live failure, e2e J19 chapter 0)

A crash-recovery re-queue (stale request from a reused e2e stack DB) put **two clones of the same (provider, source, destination) on one worker concurrently**. Both share the resumable workdir `clone-<digest>/source` (`_clone_workdir` keys by source, not request).

huggingface_hub's `_hf_hub_download_to_local_dir` does `paths.file_path.unlink(missing_ok=True)` inside the per-file lock before re-downloading — so the lagging clone **deletes shard files the leading clone had just downloaded and was reading**. The leading clone's convert phase then hit:

```
FileNotFoundError: No such file or directory:
/tmp/gen-worker-convert/clone-43ebd8856b6d86d9/source/text_encoder/model-00001-of-00004.safetensors
```

(`clone-43ebd8856b6d86d9` == sha256("huggingface|Qwen/Qwen-Image-Edit-2511|tensorhub/qwen-image-edit-2511")[:16]; both requests were assigned to worker …85de85 at 23:39:24, one FATAL'd at 23:41:07, the other was still in flight.)

## Fix

`run_clone` takes an exclusive `flock` on `.clone-<digest>.lock` for its whole lifetime (acquired before the th#592 bank-skip check, released after workdir cleanup). A duplicate clone blocks, then — with banking — publishes by CAS reference without downloading a byte. Distinct sources/destinations are unaffected.

## Tests

- `test_concurrent_same_source_clones_serialize` — two threaded `run_clone`s, asserts the ingest windows never overlap and both publish.
- `test_distinct_destinations_do_not_serialize` — barrier proves unrelated clones still run in parallel.
- `test_failed_clone_releases_lock_for_retry`.

Full suite: 610 passed, 2 skipped.

Bumps 0.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)