### PR TITLE
docs: clone workdir flock is gw#442, not gw#441 (id collision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.1 (2026-07-10)
 
-- **gw#441: clone workdir flock — concurrent duplicate clones serialize.**
+- **gw#442: clone workdir flock — concurrent duplicate clones serialize.**
   Two clones of the same (provider, source, destination) share the resumable
   workdir; hf_hub's local-dir download unlinks + re-fetches files the peer
   clone is mid-reading, so the leading clone's convert phase failed with

--- a/tests/convert/test_clone_concurrency.py
+++ b/tests/convert/test_clone_concurrency.py
@@ -1,4 +1,4 @@
-"""Concurrent duplicate clones must serialize on the keyed workdir (gw#441).
+"""Concurrent duplicate clones must serialize on the keyed workdir (gw#442).
 
 Live failure (e2e J19): a crash-recovery re-queue put two clones of the same
 (provider, source, destination) on one worker concurrently. Both shared


### PR DESCRIPTION
gw#441 is the group-offloaded SDXL VAE issue; the 0.13.1 flock fix is tracked as gw#442. Fixes CHANGELOG + test docstring references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)