### PR TITLE
gw#451: media uploads target the capability-token-bound owner (0.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.2 (2026-07-10)
+
+- **gw#451: media uploads target the capability-token-bound owner.**
+  `/api/v1/media/:owner/uploads` is authorized by the token's `upload_media`
+  grant, which is bound to the canonical invoking-org uuid in the token's
+  `tenant` claim. The URL owner segment (and `X-Cozy-Owner`) now come from
+  that claim instead of the dispatch-stamped `ctx.owner`, which can be a slug
+  or a destination-repo owner resolving to a DIFFERENT org. Live failure:
+  J19 run34 trained 500/500 steps, then `TrainingContext.save_image` 403'd on
+  `/api/v1/media/tensorhub/uploads` (slug) while the grant was bound to the
+  invoker-org uuid; inference outputs only worked because their dispatch
+  already stamped the uuid. Dev/local paths without a JWT keep `ctx.owner`.
+
 ## 0.13.1 (2026-07-10)
 
 - **gw#442: clone workdir flock — concurrent duplicate clones serialize.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.1"
+version = "0.13.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -317,6 +317,21 @@ class RequestContext:
             return self._worker_capability_token
         return _require_worker_capability_token()
 
+    def _media_upload_owner(self) -> str:
+        """Owner segment for /api/v1/media/:owner/uploads calls.
+
+        The capability token's `tenant` claim is the canonical org uuid its
+        upload_media grant is bound to — the only owner tensorhub authorizes
+        media writes for. Falls back to ctx.owner for dev/local paths where
+        the token is absent or not a JWT.
+        """
+        token = self._worker_capability_token or ""
+        if token:
+            claim = str(_decode_unverified_jwt_claims(token).get("tenant") or "").strip()
+            if claim:
+                return claim
+        return (self._owner or "").strip()
+
     def _resolve_local_output_path(self, ref: str) -> Optional[str]:
         """
         Dev-only local output backend.

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -329,9 +329,6 @@ class _RequestOutputStream:
         base = self._ctx._get_file_api_base_url()
         token = self._ctx._get_worker_capability_token()
         headers: Dict[str, str] = {"Authorization": f"Bearer {token}"}
-        owner = (self._ctx._owner or "").strip()
-        if owner:
-            headers["X-Cozy-Owner"] = owner
 
         # Build endpoint and create payload.
         create_payload: Dict[str, Any] = {}
@@ -343,25 +340,32 @@ class _RequestOutputStream:
             create_payload["content_type"] = content_type
 
         if self._repo_job_scope is None:
-            # Media upload.
+            # Media upload. The URL owner segment MUST be the owner the
+            # capability token's upload_media grant is bound to (the token's
+            # `tenant` claim: the canonical invoking-org uuid). The
+            # dispatch-stamped ctx.owner can be a slug or a destination-repo
+            # owner resolving to a DIFFERENT org — tensorhub then finds no
+            # matching grant and 403s (J19 run34 sample images). Inference
+            # outputs work exactly because URL owner == token-bound owner.
             create_payload["ref"] = self._ref
             job_id = str(self._ctx._job_id or "").strip()
             if job_id:
                 create_payload["job_id"] = job_id
-            # Owner is now an explicit URL segment (mirrors /repos/:owner/...,
-            # /endpoints/:owner/..., /datasets/:owner/...). The capability
-            # token still carries owner binding; tensorhub enforces the URL
-            # owner matches the token-bound owner on each request.
+            owner = self._ctx._media_upload_owner()
             if not owner:
                 raise RuntimeError(
                     "file save failed (missing owner): media uploads require ctx.owner"
                 )
+            headers["X-Cozy-Owner"] = owner
             owner_seg = urllib.parse.quote(owner, safe="")
             endpoint_path = f"/api/v1/media/{owner_seg}/uploads"
         else:
             # Repo-CAS upload — issue #20 session-scoped URL shape. The
             # session is opened lazily by the ctx-level manager on first use
             # and cached so subsequent uploads to the same repo reuse it.
+            owner = (self._ctx._owner or "").strip()
+            if owner:
+                headers["X-Cozy-Owner"] = owner
             repo_owner, repo, _job_id = self._repo_job_scope
             create_payload["path"] = self._ref
             revision_id = self._ctx._checkpoint_revision_id(repo_owner, repo)

--- a/tests/test_media_upload_owner.py
+++ b/tests/test_media_upload_owner.py
@@ -1,0 +1,144 @@
+"""Media uploads target the capability-token-bound owner (J19 run34 fix).
+
+TrainingContext.save_image (and every media-route save_*) must ride the SAME
+worker-authorized mechanism as inference outputs: POST
+/api/v1/media/<token-bound owner>/uploads with the worker capability token.
+Tensorhub authorizes these writes by matching the token's upload_media grant,
+which is bound to the canonical invoking-org uuid in the token's `tenant`
+claim — NOT by the dispatch-stamped ctx.owner, which can be a slug or a
+destination-repo owner resolving to a different org. J19 run34 (2026-07-10):
+ai-toolkit trained 500/500 steps, then died on the sample-image upload because
+the create POST went to /api/v1/media/tensorhub/uploads (slug) while the
+grant was bound to the invoker org uuid -> 403.
+
+Real codepath: a local ThreadingHTTPServer stands in for tensorhub; the ctx
+drives the actual save_image -> save_bytes -> _RequestOutputStream ->
+presigned_upload_file flow over real HTTP. The server answers the create POST
+with a dedup response so the test needs no S3 part scripting.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import RequestContext, TrainingContext
+
+OWNER_UUID = "019f4c33-f3a5-705b-9848-0b3b0863c416"
+
+
+def _unsigned_jwt(claims: Dict[str, Any]) -> str:
+    def seg(obj: Dict[str, Any]) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{seg({'alg': 'none', 'typ': 'JWT'})}.{seg(claims)}.sig"
+
+
+class _HubHandler(BaseHTTPRequestHandler):
+    requests_seen: ClassVar[List[Tuple[str, str, Dict[str, Any]]]] = []
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).requests_seen.append(
+            (self.path, str(self.headers.get("Authorization") or ""), body)
+        )
+        # Dedup response: valid create outcome that needs no part PUTs.
+        resp = json.dumps(
+            {
+                "dedup": True,
+                "ref": body.get("ref") or "",
+                "filename": "out.webp",
+                "blake3": body.get("blake3") or "",
+                "size_bytes": body.get("size_bytes") or 0,
+                "mime_type": "image/webp",
+                "media_id": "m1",
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+@pytest.fixture()
+def hub_server():
+    _HubHandler.requests_seen = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HubHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    host, port = server.server_address[0], server.server_address[1]
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+
+
+def test_training_save_image_uses_token_bound_owner(hub_server: str) -> None:
+    pil = pytest.importorskip("PIL.Image")
+    token = _unsigned_jwt(
+        {
+            "cap_kind": "worker_capability",
+            "tenant": OWNER_UUID,
+            "request_id": "req-run34",
+            "grants": [{"do": "upload_media", "tenant": OWNER_UUID, "job": "req-run34"}],
+        }
+    )
+    # ctx.owner is the dispatch-stamped slug — the run34 failure mode.
+    ctx = TrainingContext(
+        request_id="req-run34",
+        owner="tensorhub",
+        file_api_base_url=hub_server,
+        worker_capability_token=token,
+    )
+    asset = ctx.save_image(pil.new("RGB", (4, 4)), "samples/pair-000.webp")
+
+    assert asset.ref
+    assert len(_HubHandler.requests_seen) == 1
+    path, auth, body = _HubHandler.requests_seen[0]
+    # The create POST rides the worker-authorized media route for the
+    # TOKEN-BOUND owner, with the capability token as bearer auth.
+    assert path == f"/api/v1/media/{OWNER_UUID}/uploads"
+    assert auth == f"Bearer {token}"
+    assert body["ref"] == "samples/pair-000.webp"
+    assert body["request_id"] == "req-run34"
+
+
+def test_inference_save_bytes_same_route_and_owner(hub_server: str) -> None:
+    token = _unsigned_jwt({"tenant": OWNER_UUID, "request_id": "req-inf"})
+    ctx = RequestContext(
+        request_id="req-inf",
+        owner=OWNER_UUID,  # inference dispatch already stamps the uuid
+        file_api_base_url=hub_server,
+        worker_capability_token=token,
+    )
+    ctx.save_bytes("outputs/req-inf/out.bin", b"payload")
+
+    (path, auth, _body) = _HubHandler.requests_seen[0]
+    assert path == f"/api/v1/media/{OWNER_UUID}/uploads"
+    assert auth == f"Bearer {token}"
+
+
+def test_media_owner_falls_back_to_ctx_owner_without_jwt(hub_server: str) -> None:
+    # Dev/local paths: token missing a tenant claim (or not a JWT) keeps the
+    # historical ctx.owner routing.
+    ctx = RequestContext(
+        request_id="r-dev",
+        owner="dev-org",
+        file_api_base_url=hub_server,
+        worker_capability_token="not-a-jwt",
+    )
+    ctx.save_bytes("outputs/r-dev/a.bin", b"x")
+
+    (path, _auth, _body) = _HubHandler.requests_seen[0]
+    assert path == "/api/v1/media/dev-org/uploads"

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.0"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
J19 run34 (live A100, 2026-07-10): ai-toolkit trained the full 500 steps, then the job died with `AuthError: file save unauthorized (403)`. Hub log shows exactly two 403s — `POST /api/v1/media/tensorhub/uploads` at 11:15:58 and 11:57:12, the sample-image uploads at steps 250/500. Token renewal worked (grants re-minted verbatim).

Root cause: tensorhub authorizes worker media writes by the token's `upload_media` grant, bound to the **canonical invoking-org uuid** (`019f4c33-f3a5-...` in run34, the token's `tenant` claim). The worker built the URL from dispatch-stamped `ctx.owner` — the slug `tensorhub`, which resolves to a *different* org uuid (`019f4c33-d183-...`) — so no grant matched and the route 403'd. Inference outputs only ever worked because their dispatch already stamps the uuid (`POST /api/v1/media/<uuid>/uploads` 201s in earlier logs).

Fix: media-route uploads now derive the owner segment (and `X-Cozy-Owner`) from the capability token's `tenant` claim — the exact owner the grant authorizes — falling back to `ctx.owner` for dev/local paths without a JWT. Training `save_image` now rides the identical worker-authorized mechanism as inference outputs: same route, same bearer auth, same moderation posture.

## Tests
- `tests/test_media_upload_owner.py`: real codepath (`save_image`/`save_bytes` → `_RequestOutputStream` → `presigned_upload_file`) over real HTTP against a local hub stand-in; asserts route + `Authorization` header for the token-bound owner, inference parity, and the no-JWT fallback.
- Full suite: 615 passed, 9 skipped.

Releases 0.13.2 (version bump + CHANGELOG included; tag after merge).