### PR TITLE
fix(gate): vram_gb recommends a card SIZE, never a free-bytes requirement (th#683 P0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ class Generate:
         return Output(text=ctx.save_image(image).ref)
 ```
 
+`Resources(vram_gb=N)` recommends a card size — the total VRAM of the smallest
+card the function targets, not free bytes. It's an optional placement hint: the
+platform reserves ~1 GB for driver/framebuffer/CUDA-context overhead, so
+`vram_gb=24` serves on any 24 GB card.
+
 Bindings: `HF(id, revision=, dtype=, subfolder=, files=, storage_dtype=)`,
 `Hub(ref, tag=, flavor=, storage_dtype=)`, `Civitai(id, version=)`, `ModelScope(id, ...)`.
 The slot name comes from the `models={}` key or the `setup()` parameter —

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -48,6 +48,14 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     """Hardware envelope for one function: ``Resources(gpu, vram_gb,
     compute_capability, libraries)``.
 
+    ``vram_gb`` is the recommended minimum CARD size: the total VRAM (GB) of
+    the smallest card the function targets — ``vram_gb=24`` means "runs on a
+    24 GB card". It is an optional placement hint (the orchestrator may use
+    it to pick a GPU SKU), not a free-memory requirement: the platform
+    reserves ~1 GB (``GPU_VRAM_OVERHEAD_GB``) for driver/framebuffer/CUDA
+    context, so ``vram_gb=24`` serves on a 24 GB card even though only
+    ~23.6 GB is free.
+
     ``Resources(vram_gb=12)`` implies ``gpu=True`` — declaring VRAM without a
     GPU is a contradiction, not an under-declaration.
     """

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -37,7 +37,11 @@ from .capability import HardwareUnmetError, InsufficientDiskError
 from .input_assets import cleanup_input_assets, materialize_input_assets
 from .models import disk_gc
 from .models import residency as residency_mod
-from .models.memory import estimate_cuda_resident_gb, get_available_ram_gb
+from .models.memory import (
+    effective_vram_requirement_gb,
+    estimate_cuda_resident_gb,
+    get_available_ram_gb,
+)
 from .models.cache_paths import tensorhub_cas_dir
 from .models.download import ensure_local
 from .models.errors import UrlExpiredError
@@ -764,13 +768,16 @@ class Executor:
                     f"requires SM {r.compute_capability:.1f}, detected {detected_cc:.1f}",
                     {"detected_sm": f"{detected_cc:.1f}", "required_sm": f"{float(r.compute_capability):.1f}"})
                 continue
-            # Compare on the rounded GiB: a "24GB" card reports ~23.99GiB via
-            # mem_get_info (driver/ECC reserve), which must not gate off
-            # functions declaring vram_gb=24.
-            if r.vram_gb is not None and total_vram_gb and round(total_vram_gb) < float(r.vram_gb):
+            # vram_gb is a recommended card size (total VRAM of the smallest
+            # card the author targets), never a free-bytes requirement: a
+            # "24GB" card reports ~23.99GiB total / ~23.6GiB free. Compare
+            # against the total minus the fixed driver/framebuffer/CUDA-context
+            # reserve (GPU_VRAM_OVERHEAD_GB) so vram_gb=24 serves on a 24GB card.
+            if r.vram_gb is not None and total_vram_gb \
+                    and total_vram_gb < effective_vram_requirement_gb(r.vram_gb):
                 self.unavailable[name] = (
                     "insufficient_vram",
-                    f"requires {r.vram_gb:.0f}GiB VRAM, detected {total_vram_gb:.0f}GiB",
+                    f"recommends a {r.vram_gb:.0f}GiB card, detected {total_vram_gb:.0f}GiB",
                     {"required_vram_gb": f"{float(r.vram_gb):.0f}",
                      "detected_vram_gb": f"{total_vram_gb:.0f}"})
                 continue

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -138,8 +138,9 @@ def variant_fit(
     - ``emergency_quant``: does not fit, but the emergency nf4 rung (th#546
       emergency lane; loading layer, automatic on CUDA hosts) applies and
       the 4-bit estimate fits — runs at below-platform quality, loudly.
-    - ``offload``: runnable, but declared vram_gb exceeds free VRAM — the
-      models/memory.py offload ladder carries it (slower).
+    - ``offload``: runnable, but the recommended card size (vram_gb minus the
+      fixed GPU reserve) exceeds free VRAM — the models/memory.py offload
+      ladder carries it (slower).
     - ``fits``: full-VRAM residency expected.
     """
     needs_gpu = bool(getattr(resources, "gpu", False))
@@ -176,7 +177,12 @@ def variant_fit(
         if reason is not None:
             return FIT_INCOMPATIBLE, reason
     vram = getattr(resources, "vram_gb", None)
-    if vram is None or float(vram) <= float(free_vram_gb):
+    # vram_gb recommends a card SIZE (total VRAM), so an idle card of exactly
+    # that size counts as fitting: subtract the fixed driver/framebuffer/CUDA
+    # reserve before comparing against measured free VRAM.
+    from .memory import effective_vram_requirement_gb
+
+    if vram is None or effective_vram_requirement_gb(vram) <= float(free_vram_gb):
         if svdq_kind == "fp4":
             return FIT_SVDQ_FP4, "svdq-fp4 stored flavor (Blackwell 4-bit rung)"
         if svdq_kind == "int4":

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -41,6 +41,23 @@ _DEFAULT_OFF_HEADROOM_GB = 8.0
 # Sentinel attribute set on pipelines to make apply_low_vram_config idempotent.
 _COZY_MODE_ATTR = "_cozy_low_vram_mode"
 
+# Authors declare ``Resources(vram_gb=X)`` as the TOTAL VRAM of the smallest
+# card they target ("runs on a 24 GB card") — a placement recommendation, not
+# measurable free bytes. The platform reserves this much for the fixed
+# driver/framebuffer/CUDA-context overhead when comparing the recommendation
+# against probed VRAM, so vram_gb=24 serves on a 24 GB card (~23.6 GB free).
+GPU_VRAM_OVERHEAD_GB = 1.0
+
+
+def effective_vram_requirement_gb(recommended_gb: float) -> float:
+    """The probed-VRAM floor implied by a ``vram_gb`` recommendation.
+
+    Single definition of "usable VRAM" for every gate/fit comparison:
+    compare probed total or free GB against THIS, never against the raw
+    recommendation.
+    """
+    return max(0.0, float(recommended_gb) - GPU_VRAM_OVERHEAD_GB)
+
 # Modes that spill model weights to system RAM and run parts of inference on CPU.
 _CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
 
@@ -681,6 +698,8 @@ __all__ = [
     "estimate_cuda_resident_gb",
     "cuda_allocated_bytes",
     "get_available_vram_gb",
+    "GPU_VRAM_OVERHEAD_GB",
+    "effective_vram_requirement_gb",
     "get_available_ram_gb",
     "get_total_ram_gb",
     "flush_memory",

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -1,10 +1,13 @@
-"""VRAM-gate GiB rounding + single-file checkpoint loading (#347 roster sweep).
+"""VRAM recommendation gating + single-file checkpoint loading.
 
-A "24GB" card reports ~23.99GiB via torch.cuda.mem_get_info (driver/ECC
-reserve); the availability gate must not disable functions declaring
-``Resources(vram_gb=24)`` on exactly the card they target. Single-file repos
-(Illustrious-XL, civitai checkpoints) have no ``model_index.json`` and must
-route through ``cls.from_single_file``.
+``Resources(vram_gb=X)`` recommends a card SIZE (total VRAM of the smallest
+card the author targets), never a free-bytes requirement. A "24GB" card
+reports ~23.99GiB total / ~23.6GiB free via torch.cuda.mem_get_info
+(driver/framebuffer/CUDA-context reserve); neither the worker self-gate nor
+the variant fit policy may disable ``vram_gb=24`` functions on exactly the
+card they target (GPU_VRAM_OVERHEAD_GB absorbs the reserve). Single-file
+repos (Illustrious-XL, civitai checkpoints) have no ``model_index.json`` and
+must route through ``cls.from_single_file``.
 """
 
 from __future__ import annotations
@@ -49,9 +52,10 @@ async def _noop_send(msg) -> None:  # pragma: no cover
 
 
 RTX_4090_TOTAL_BYTES = 25_757_220_864  # 23.99 GiB — what mem_get_info reports
+RTX_4090_FREE_GB = 23.6  # idle card: total minus driver/framebuffer/context
 
 
-def test_gate_rounds_detected_gib_up_to_declared_24() -> None:
+def test_gate_accepts_card_of_exactly_recommended_size() -> None:
     ex = Executor([_spec("fits-24", 24.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
     assert "fits-24" not in ex.unavailable
@@ -61,6 +65,32 @@ def test_gate_still_blocks_genuinely_bigger_requirements() -> None:
     ex = Executor([_spec("needs-32", 32.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
     assert ex.unavailable["needs-32"][0] == "insufficient_vram"
+
+
+def test_variant_fit_counts_recommended_size_card_as_fitting() -> None:
+    """The z-image footgun: vram_gb=24 on an idle 24GB card (~23.6GB free)
+    must be FIT_FITS, not offload/unavailable."""
+    from gen_worker.models.hub_policy import (
+        FIT_FITS,
+        TensorhubWorkerCapabilities,
+        variant_fit,
+    )
+
+    caps = TensorhubWorkerCapabilities(
+        cuda_version="12.8", gpu_sm=89, torch_version="2.8.0", installed_libs=[],
+    )
+    fit, reason = variant_fit(Resources(vram_gb=24.0), caps, RTX_4090_FREE_GB)
+    assert (fit, reason) == (FIT_FITS, "")
+
+
+def test_effective_vram_requirement_floor() -> None:
+    from gen_worker.models.memory import (
+        GPU_VRAM_OVERHEAD_GB,
+        effective_vram_requirement_gb,
+    )
+
+    assert effective_vram_requirement_gb(24.0) == 24.0 - GPU_VRAM_OVERHEAD_GB
+    assert effective_vram_requirement_gb(0.5) == 0.0  # never negative
 
 
 def test_single_file_checkpoint_detection(tmp_path: Path) -> None:

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -307,8 +307,9 @@ def test_vram_ladder_picks_largest_fitting():
     # 30 GB free: prefer the largest precision that fits.
     choice = select_variant(_FLUX_VARIANTS, _CAPS_4070, 30.0)
     assert choice.name == "flux-bf16"
-    # SM100 with 13 GB free: nvfp4 unlocked and the only fit.
-    choice = select_variant(_FLUX_VARIANTS, _CAPS_B200, 13.0)
+    # SM100 with 12.5 GB free: nvfp4 (12 GB card rec) unlocked and the only
+    # fit — fp8's 14 GB-card recommendation implies a >=13 GB free floor.
+    choice = select_variant(_FLUX_VARIANTS, _CAPS_B200, 12.5)
     assert choice.name == "flux-nvfp4"
 
 


### PR DESCRIPTION
## The footgun
`Resources(vram_gb=24)` means "runs on a 24 GB card", but the fit policy compared the raw number against MEASURED FREE VRAM. A 24 GB 4090 only has ~23.6 GB free (driver/framebuffer/CUDA-context reserve), so a vram_gb=24 function gated itself out on exactly the card it targets — z-image registered `fns=[]` on a 4090 and requests queued forever.

## Fix (th#683 P0, gw#451)
One seam in `models/memory.py`: `GPU_VRAM_OVERHEAD_GB = 1.0` + `effective_vram_requirement_gb(recommended) = max(0, recommended - overhead)`, used by BOTH gates:
- `executor.gate_functions`: total VRAM vs the effective floor (replaces the round() hack)
- `hub_policy.variant_fit`: free VRAM vs the effective floor (was raw `vram <= free`)

Author-facing semantics documented (Resources docstring + README): vram_gb is the recommended minimum CARD size — an optional placement hint, never a free-memory requirement.

Pod selection verified to agree (no Go change needed): gen-orchestrator/runpod-go-sdk catalogs compare the hint against TOTAL card VRAM, so any rented card passes the relaxed worker gate.

## Tests
- gate accepts a 23.99 GiB-total (4090) card for vram_gb=24
- variant_fit returns FIT_FITS for vram_gb=24 at 23.6 GB free (the z-image scenario)
- full suite: 613 passed / 10 skipped

Do not merge yet — staged for review per th#683 P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)