### PR TITLE
docs: media-owner fix is gw#452, not gw#451 (tracker id collision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.2 (2026-07-10)
 
-- **gw#451: media uploads target the capability-token-bound owner.**
+- **gw#452: media uploads target the capability-token-bound owner.**
   `/api/v1/media/:owner/uploads` is authorized by the token's `upload_media`
   grant, which is bound to the canonical invoking-org uuid in the token's
   `tenant` claim. The URL owner segment (and `X-Cozy-Owner`) now come from


### PR DESCRIPTION
Same situation as 5c135a2 (gw#441/gw#442): the tracker id #451 was concurrently taken by the vram_gb gate issue; the 0.13.2 media-owner fix is gw#452. CHANGELOG reference corrected.