### PR TITLE
gw#450: TrainingContext.training_metric — typed training-metric events (0.13.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.13.3 (2026-07-10)
+
+- **gw#450: `TrainingContext.training_metric` — typed step/loss/lr/it_s/eta
+  channel.** Emits a `request.training_metric` event (msgspec `TrainingMetric`
+  payload: `{step, total, loss, lr?, it_s?, eta_s?}`, None fields omitted) over
+  the ctx emitter / JobProgress envelope from gw#438, so tensorhub can
+  downsample-persist a chartable series (th#681). Built-in min-interval
+  throttle (`metric_min_interval_s`, default 5s); the first and the final
+  (`step >= total`) metric always emit. `ctx.progress` stays the
+  human-readable stage-text channel.
+
 ## 0.13.2 (2026-07-10)
 
 - **gw#452: media uploads target the capability-token-bound owner.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.2"
+version = "0.13.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -43,6 +43,7 @@ from .request_context import (
     DatasetContext,
     RequestContext,
     TrainingContext,
+    TrainingMetric,
 )
 from .subproc import run_process
 
@@ -61,6 +62,7 @@ __all__ = [
     "ConversionContext",
     "DatasetContext",
     "TrainingContext",
+    "TrainingMetric",
     # Delegated-trainer subprocess primitive.
     "run_process",
     # Errors.

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import msgspec
 import os
 import base64
 import re
@@ -1527,6 +1528,19 @@ class DatasetContext(_PublisherMixin, RequestContext):
             "existed": True,
         }
 
+class TrainingMetric(msgspec.Struct, frozen=True, kw_only=True):
+    """Typed per-step training metric (pgw#450), payload of a
+    ``request.training_metric`` event. tensorhub downsample-persists these
+    as ``job.training.metric`` request_events rows (th#681)."""
+
+    step: int
+    total: int
+    loss: float
+    lr: Optional[float] = None
+    it_s: Optional[float] = None
+    eta_s: Optional[float] = None
+
+
 class TrainingContext(_PublisherMixin, RequestContext):
     """RequestContext for ``@endpoint(kind="training")`` endpoints.
 
@@ -1539,3 +1553,42 @@ class TrainingContext(_PublisherMixin, RequestContext):
     Delegated trainers (subprocess ai-toolkit and friends) run through
     ``gen_worker.subproc.run_process`` with ``ctx=self`` for cancellation.
     """
+
+    #: Min seconds between emitted metric events; first and last (step>=total)
+    #: always emit. Trainers call every step, the throttle keeps the wire sane.
+    metric_min_interval_s: float = 5.0
+
+    _last_metric_monotonic: Optional[float] = None
+
+    def training_metric(
+        self,
+        *,
+        step: int,
+        total: int,
+        loss: float,
+        lr: Optional[float] = None,
+        it_s: Optional[float] = None,
+        eta_s: Optional[float] = None,
+    ) -> None:
+        """Emit a typed ``request.training_metric`` event (throttled).
+
+        Keep ``ctx.progress`` for human-readable stage text; this is the
+        machine channel a UI charts (loss curve, it/s, ETA).
+        """
+        now = time.monotonic()
+        last = self._last_metric_monotonic
+        is_first = last is None
+        is_last = total > 0 and step >= total
+        if not is_first and not is_last and (now - last) < self.metric_min_interval_s:
+            return
+        self._last_metric_monotonic = now
+        metric = TrainingMetric(
+            step=int(step),
+            total=int(total),
+            loss=float(loss),
+            lr=None if lr is None else float(lr),
+            it_s=None if it_s is None else float(it_s),
+            eta_s=None if eta_s is None else float(eta_s),
+        )
+        payload = {k: v for k, v in msgspec.to_builtins(metric).items() if v is not None}
+        self._emit_event("request.training_metric", payload)

--- a/tests/test_executor_progress_events.py
+++ b/tests/test_executor_progress_events.py
@@ -131,3 +131,45 @@ def test_save_checkpoint_emits_checkpoint_event(tmp_path) -> None:
     assert payload["output_kind"] == "lora"
     assert payload["ref"].endswith("lora_000000250.safetensors")
     assert payload["size_bytes"] == len(b"weights")
+
+
+def _train_metrics(ctx, payload: _In) -> _Out:
+    # 10 fast steps: throttle (5s default) keeps only first + last.
+    for step in range(1, 11):
+        ctx.training_metric(step=step, total=10, loss=1.0 / step, lr=1e-4)
+    return _Out(ok=True)
+
+
+def test_training_metric_flows_first_and_last_throttled() -> None:
+    """pgw#450: ctx.training_metric rides the same JobProgress envelope;
+    the built-in min-interval throttle drops mid-run spam but always
+    emits the first and the final (step==total) metric."""
+    sent = _run("training", _train_metrics)
+    events = [e for e in _events(sent)
+              if e["event"]["type"] == "request.training_metric"]
+    assert [e["event"]["payload"]["step"] for e in events] == [1, 10]
+
+    first = events[0]["event"]["payload"]
+    assert first == {"step": 1, "total": 10, "loss": 1.0, "lr": 1e-4}
+    # Optional fields not passed must be absent, not null.
+    assert "it_s" not in first and "eta_s" not in first
+
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+
+
+def test_training_metric_unthrottled_payload_shape() -> None:
+    """Direct-ctx: interval 0 emits every step with the full typed payload."""
+    captured: List[Dict] = []
+    ctx = TrainingContext(request_id="r1", emitter=captured.append)
+    ctx.metric_min_interval_s = 0.0
+    for step in (1, 2, 3):
+        ctx.training_metric(step=step, total=100, loss=0.5,
+                            lr=2e-5, it_s=1.7, eta_s=57.1)
+    metrics = [e for e in captured if e["type"] == "request.training_metric"]
+    assert len(metrics) == 3
+    assert metrics[-1]["payload"] == {
+        "step": 3, "total": 100, "loss": 0.5,
+        "lr": 2e-5, "it_s": 1.7, "eta_s": 57.1,
+    }
+    assert all(e["request_id"] == "r1" for e in metrics)

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Paired with th#681 (tensorhub downsample-persist) and te#60 (trainer emit sites).

- `TrainingContext.training_metric(step=, total=, loss=, lr=None, it_s=None, eta_s=None)`
  emits a `request.training_metric` event over the existing ctx emitter
  (gw#438 JobProgress envelope, `application/x-request-event+json`).
- Payload is a msgspec struct (`TrainingMetric`); None fields are omitted on the wire.
- Built-in min-interval throttle (`metric_min_interval_s`, default 5s); the first and the
  final (`step >= total`) metric always emit.
- `ctx.progress` stays the human-readable stage-text channel.
- Real-codepath tests via the gw#438 emitter-capture harness (executor -> JobProgress
  envelope) + direct-ctx payload-shape test. Full suite: 484 passed, 8 skipped.
- Version 0.13.3 + CHANGELOG (tag-triggered PyPI publish after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)