### PR TITLE
th#683 P3: serve-time adaptive fit — never refuse on the VRAM hint (cozy-local, down to 6-8GB + CPU-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+- **th#683 P3: serve-time adaptive fit — the worker never refuses on the VRAM
+  hint.** New `models/serve_fit.plan_serve` decides, per (already
+  flavor-resolved) function, HOW it runs on the actual card: native ->
+  emergency 4-bit -> CPU/disk offload -> CPU-only, choosing the highest-quality
+  lever that fits. `gate_functions` now consults it instead of hard-refusing on
+  `insufficient_vram`/`cuda_unavailable`: a model bigger than the card serves
+  via emergency-quant or offload (fit over speed, the primary lever at the low
+  end), and a GPU function with no GPU falls back to CPU-only — all behind loud
+  honest-guidance warnings (realistic latency multiplier + the ideal card),
+  never a silent refusal. A function is unserveable only on a genuine
+  incompatibility (compute capability / missing quant library) or when the sole
+  lever here is a CPU-touching placement this box forbids
+  (`GEN_WORKER_FORBID_CPU_OFFLOAD=1` — those runs belong on the GPU lane).
+  `run --list` / `serve --list-functions --json` now carry `serveable`,
+  `run_mode`, `est_latency_multiplier`, `recommended_vram_gb`, and an
+  `advisory` string. Added `memory.cpu_offload_forbidden()` (non-raising
+  predicate).
+
 ## 0.13.3 (2026-07-10)
 
 - **gw#450: `TrainingContext.training_metric` — typed step/loss/lr/it_s/eta

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -133,11 +133,26 @@ def function_entries(
         if variant_of:
             entry["variant_of"] = variant_of
         if caps is not None:
+            from ..models.serve_fit import plan_serve
+
             primary = next(iter((getattr(c, "bindings", {}) or {}).values()), None)
             fit, reason = variant_fit(resources, caps, free_gb, binding=primary)
             entry["fit"] = fit
             if reason:
                 entry["fit_reason"] = reason
+            # th#683 P3 honest-guidance: how it will actually run on this card +
+            # the realistic latency trade + the ideal hardware.
+            plan = plan_serve(resources, caps, free_gb, binding=primary)
+            entry["serveable"] = plan.serveable
+            entry["run_mode"] = plan.run_mode
+            if plan.est_latency_multiplier and plan.est_latency_multiplier != 1.0:
+                entry["est_latency_multiplier"] = round(plan.est_latency_multiplier, 2)
+            if plan.recommended_vram_gb:
+                entry["recommended_vram_gb"] = plan.recommended_vram_gb
+            if plan.warning:
+                entry["advisory"] = plan.warning
+            elif plan.reason and not plan.serveable:
+                entry["advisory"] = plan.reason
         out.append(entry)
     return out
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -38,7 +38,6 @@ from .input_assets import cleanup_input_assets, materialize_input_assets
 from .models import disk_gc
 from .models import residency as residency_mod
 from .models.memory import (
-    effective_vram_requirement_gb,
     estimate_cuda_resident_gb,
     get_available_ram_gb,
 )
@@ -48,6 +47,9 @@ from .models.errors import UrlExpiredError
 from .models.residency import Residency
 from .pb import worker_scheduler_pb2 as pb
 from .registry import EndpointSpec
+
+if typing.TYPE_CHECKING:
+    from .models.serve_fit import ServePlan
 from .request_context import (
     ConversionContext,
     DatasetContext,
@@ -744,42 +746,48 @@ class Executor:
             rec.specs.append(s)
         # Hardware-gate failures: fn name -> (reason, detail, axes).
         self.unavailable: Dict[str, Tuple[str, str, Dict[str, str]]] = {}
+        # th#683 P3: how each serveable function will run on the actual card
+        # (native / emergency / offload / cpu) + honest-guidance advisory.
+        self.serve_plans: Dict[str, "ServePlan"] = {}
 
     # ---- availability ----------------------------------------------------
 
     def gate_functions(self, gpu_info: Dict[str, Any]) -> None:
-        """Run hardware gates; populate self.unavailable."""
-        gpu_count = int(gpu_info.get("gpu_count") or 0)
+        """Run hardware gates; populate self.unavailable + self.serve_plans.
+
+        th#683 P3 — the worker NEVER hard-refuses a function on the
+        recommended-VRAM hint. Genuine incompatibilities (compute capability /
+        missing quant library) still gate a function off; everything else is an
+        ADAPTIVE FIT: the function serves by the best available means (native ->
+        emergency 4-bit -> CPU/disk offload -> CPU-only) and records an honest
+        advisory. A function is only unserveable when the sole way to run it
+        here is a CPU-touching placement this box forbids
+        (GEN_WORKER_FORBID_CPU_OFFLOAD=1 — those runs belong on the GPU lane).
+        """
+        from .models.hub_policy import TensorhubWorkerCapabilities
+        from .models.serve_fit import RUN_CPU, RUN_OFFLOAD, plan_serve
+
         total_vram_gb = float(gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
+        free_vram_gb = float(gpu_info.get("gpu_free_mem") or gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
         detected_sm = str(gpu_info.get("gpu_sm") or "")
         detected_cc = (float(detected_sm) / 10.0) if detected_sm.isdigit() else None
         libs = {str(x) for x in (gpu_info.get("installed_libs") or [])}
+        caps = TensorhubWorkerCapabilities(
+            cuda_version=str(gpu_info.get("cuda_version") or ""),
+            gpu_sm=int(detected_sm) if detected_sm.isdigit() else 0,
+            torch_version=str(gpu_info.get("torch_version") or ""),
+            installed_libs=list(libs),
+        )
         for name, spec in self.specs.items():
             r = spec.resources
-            if spec.needs_gpu and gpu_count <= 0:
-                self.unavailable[name] = (
-                    "cuda_unavailable", "function requires CUDA but no GPU detected",
-                    {"gpu_count": str(gpu_count)})
-                continue
+            # Genuine hard incompatibilities keep their explicit reason codes —
+            # no lever (offload/cpu/quant) makes them run on this silicon.
             if r.compute_capability is not None and detected_cc is not None \
                     and detected_cc < float(r.compute_capability):
                 self.unavailable[name] = (
                     "compute_capability_unmet",
                     f"requires SM {r.compute_capability:.1f}, detected {detected_cc:.1f}",
                     {"detected_sm": f"{detected_cc:.1f}", "required_sm": f"{float(r.compute_capability):.1f}"})
-                continue
-            # vram_gb is a recommended card size (total VRAM of the smallest
-            # card the author targets), never a free-bytes requirement: a
-            # "24GB" card reports ~23.99GiB total / ~23.6GiB free. Compare
-            # against the total minus the fixed driver/framebuffer/CUDA-context
-            # reserve (GPU_VRAM_OVERHEAD_GB) so vram_gb=24 serves on a 24GB card.
-            if r.vram_gb is not None and total_vram_gb \
-                    and total_vram_gb < effective_vram_requirement_gb(r.vram_gb):
-                self.unavailable[name] = (
-                    "insufficient_vram",
-                    f"recommends a {r.vram_gb:.0f}GiB card, detected {total_vram_gb:.0f}GiB",
-                    {"required_vram_gb": f"{float(r.vram_gb):.0f}",
-                     "detected_vram_gb": f"{total_vram_gb:.0f}"})
                 continue
             missing = [lib for lib in (r.libraries or ()) if lib not in libs]
             if missing:
@@ -789,6 +797,27 @@ class Executor:
                 self.unavailable[name] = (
                     "missing_cuda_library", f"missing required libraries: {', '.join(missing)}",
                     {"missing": ",".join(missing)})
+                continue
+
+            # Adaptive serve-time fit for the VRAM / GPU-presence dimension.
+            plan = plan_serve(r, caps, free_vram_gb)
+            self.serve_plans[name] = plan
+            if not plan.serveable:
+                if plan.run_mode == RUN_CPU:
+                    code = "cuda_unavailable"
+                elif plan.run_mode == RUN_OFFLOAD:
+                    code = "offload_forbidden"
+                else:
+                    code = "insufficient_vram"
+                self.unavailable[name] = (
+                    code, plan.reason,
+                    {"detected_vram_gb": f"{total_vram_gb:.0f}",
+                     "recommended_vram_gb": (f"{r.vram_gb:.0f}" if r.vram_gb else "")})
+                continue
+            if plan.degraded:
+                logger.warning(
+                    "serving %s in degraded mode=%s (~%.1fx latency): %s",
+                    name, plan.run_mode, plan.est_latency_multiplier, plan.warning)
 
     def available_functions(self) -> List[str]:
         out = []

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -62,13 +62,22 @@ def effective_vram_requirement_gb(recommended_gb: float) -> float:
 _CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
 
 
+def cpu_offload_forbidden() -> bool:
+    """True when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes any CPU-touching
+    placement. Non-raising predicate for the serve-time fit planner (th#683 P3):
+    on a box with this set, offload/CPU rungs are not available fallbacks, so a
+    function that can only run via offload/CPU is not serveable HERE (it serves
+    on the GPU lane / the right rented card in prod)."""
+    return os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD") == "1"
+
+
 def _forbid_cpu_inference(detail: str) -> None:
     """Raise when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes a CPU-touching placement.
 
     Set on dev machines so agents/tests can't silently melt the box with
     CPU-offloaded inference; real-model runs belong on the GPU CI lane.
     """
-    if os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD") == "1":
+    if cpu_offload_forbidden():
         raise RuntimeError(
             f"GEN_WORKER_FORBID_CPU_OFFLOAD=1: refusing {detail}. "
             "Real-model inference that does not fit in free VRAM must run on "
@@ -700,6 +709,7 @@ __all__ = [
     "get_available_vram_gb",
     "GPU_VRAM_OVERHEAD_GB",
     "effective_vram_requirement_gb",
+    "cpu_offload_forbidden",
     "get_available_ram_gb",
     "get_total_ram_gb",
     "flush_memory",

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -1,0 +1,194 @@
+"""Serve-time adaptive fit (th#683 P3).
+
+The worker NEVER hard-refuses a function on the recommended-VRAM hint. On
+whatever card it is actually on, it serves the function by the best available
+means and is HONEST about the trade:
+
+  bf16/native  -> highest quality, fastest (full VRAM residency)
+  emergency nf4-> 4-bit, below-platform quality, still on-GPU
+  offload      -> weights spill to CPU/disk, slower but valid (the PRIMARY
+                  lever at the low end where weights exceed VRAM even quantized)
+  cpu          -> no GPU at all: very slow, offered behind a loud warning
+                  rather than refused
+
+A function is UNSERVEABLE only when a genuine incompatibility bars it (compute
+capability / required quant library) OR the only way to run it here is a
+CPU-touching placement that this box forbids (GEN_WORKER_FORBID_CPU_OFFLOAD=1 —
+those runs belong on the GPU lane / the right rented card). It is never refused
+on hardware inadequacy alone.
+
+Flavor selection across a card is realized by the pre-expanded per-flavor
+functions (registry expands ``variants={}`` into separate routable functions):
+this planner marks each flavor-function serveable/unserveable + how-it-runs, and
+the hub's routing (th#597 ranking: bigger declared vram / svdq-fp4 first) picks
+the highest-quality fitting flavor. bf16 -> fp8 -> nvfp4 -> int4 falls out of
+that ranking over the serveable set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .hub_policy import (
+    FIT_EMERGENCY,
+    FIT_FITS,
+    FIT_INCOMPATIBLE,
+    FIT_SVDQ_FP4,
+    FIT_SVDQ_INT4,
+    TensorhubWorkerCapabilities,
+    variant_fit,
+)
+from .memory import cpu_offload_forbidden
+
+# Run modes, cheapest(fastest)-first. Mirrors the profiling.RunMode vocabulary
+# on the hub side so the two speak the same language.
+RUN_NATIVE = "native"
+RUN_EMERGENCY = "emergency_quant"
+RUN_OFFLOAD = "offload"
+RUN_CPU = "cpu"
+
+# Coarse latency multipliers vs a native GPU run, for honest-guidance. These are
+# order-of-magnitude guides (the hub's measured fit-matrix latency is the
+# authoritative source when available); they exist so the worker never stays
+# silent about a slow trade.
+_LATENCY_MULTIPLIER = {
+    RUN_NATIVE: 1.0,
+    RUN_EMERGENCY: 1.1,   # quality hit, not much slower
+    RUN_OFFLOAD: 2.5,     # weights stream from CPU/disk
+    RUN_CPU: 40.0,        # no GPU: dramatically slower
+}
+
+
+@dataclass(frozen=True)
+class ServePlan:
+    """How a single (already flavor-resolved) function will run on this card."""
+
+    serveable: bool
+    run_mode: str
+    fit: str                      # the underlying variant_fit verdict
+    reason: str = ""              # why unserveable, when !serveable
+    warning: str = ""             # honest-guidance warning for a slow/degraded run
+    est_latency_multiplier: float = 1.0
+    recommended_vram_gb: Optional[float] = None  # the ideal card for this fn
+
+    @property
+    def degraded(self) -> bool:
+        """True when it runs, but not natively (slower and/or lower quality)."""
+        return self.serveable and self.run_mode != RUN_NATIVE
+
+
+def plan_serve(
+    resources: Any,
+    caps: TensorhubWorkerCapabilities,
+    free_vram_gb: float,
+    *,
+    binding: Any = None,
+    forbid_cpu_offload: Optional[bool] = None,
+) -> ServePlan:
+    """Decide how one function serves on the actual card. Never refuses on the
+    recommended-VRAM hint alone.
+
+    ``forbid_cpu_offload`` defaults to the live env predicate; pass explicitly
+    in tests.
+    """
+    if forbid_cpu_offload is None:
+        forbid_cpu_offload = cpu_offload_forbidden()
+
+    recommended = getattr(resources, "vram_gb", None)
+    needs_gpu = bool(getattr(resources, "gpu", False))
+
+    verdict, detail = variant_fit(resources, caps, free_vram_gb, binding=binding)
+
+    # No CUDA GPU present. variant_fit calls this incompatible; P3 turns it into
+    # a CPU-only rung (offered behind the forbid guard + a loud warning).
+    if verdict == FIT_INCOMPATIBLE and needs_gpu and caps.gpu_sm <= 0:
+        if forbid_cpu_offload:
+            return ServePlan(
+                serveable=False,
+                run_mode=RUN_CPU,
+                fit=FIT_INCOMPATIBLE,
+                reason=(
+                    "no GPU and CPU inference is forbidden here "
+                    "(GEN_WORKER_FORBID_CPU_OFFLOAD=1); run on a GPU host"
+                ),
+                recommended_vram_gb=recommended,
+            )
+        return ServePlan(
+            serveable=True,
+            run_mode=RUN_CPU,
+            fit=FIT_INCOMPATIBLE,
+            warning=_honest_warning(RUN_CPU, recommended),
+            est_latency_multiplier=_LATENCY_MULTIPLIER[RUN_CPU],
+            recommended_vram_gb=recommended,
+        )
+
+    # Genuine incompatibility (compute capability / missing quant library / svdq
+    # SM window): no lever helps — this really cannot run here.
+    if verdict == FIT_INCOMPATIBLE:
+        return ServePlan(
+            serveable=False,
+            run_mode=RUN_NATIVE,
+            fit=FIT_INCOMPATIBLE,
+            reason=detail or "incompatible with this GPU",
+            recommended_vram_gb=recommended,
+        )
+
+    # Fits natively (incl. the svdq flavor rungs, which are native on their
+    # supported silicon).
+    if verdict in (FIT_FITS, FIT_SVDQ_FP4, FIT_SVDQ_INT4):
+        return ServePlan(
+            serveable=True,
+            run_mode=RUN_NATIVE,
+            fit=verdict,
+            recommended_vram_gb=recommended,
+        )
+
+    # Runs, but degraded: emergency 4-bit or the offload ladder. At the low end
+    # offload is the PRIMARY lever (weights exceed VRAM even quantized) — fit
+    # over speed. Both are CPU-touching only for the offload case.
+    run_mode = RUN_EMERGENCY if verdict == FIT_EMERGENCY else RUN_OFFLOAD
+    if run_mode == RUN_OFFLOAD and forbid_cpu_offload:
+        return ServePlan(
+            serveable=False,
+            run_mode=RUN_OFFLOAD,
+            fit=verdict,
+            reason=(
+                "only runs via CPU/disk offload here, which is forbidden "
+                "(GEN_WORKER_FORBID_CPU_OFFLOAD=1); run on a larger card / GPU lane"
+            ),
+            recommended_vram_gb=recommended,
+        )
+    return ServePlan(
+        serveable=True,
+        run_mode=run_mode,
+        fit=verdict,
+        warning=_honest_warning(run_mode, recommended, detail),
+        est_latency_multiplier=_LATENCY_MULTIPLIER[run_mode],
+        recommended_vram_gb=recommended,
+    )
+
+
+def _honest_warning(run_mode: str, recommended_vram_gb: Optional[float], detail: str = "") -> str:
+    ideal = (
+        f" For full speed/quality use a ~{recommended_vram_gb:.0f} GB card."
+        if recommended_vram_gb
+        else ""
+    )
+    mult = _LATENCY_MULTIPLIER.get(run_mode, 1.0)
+    if run_mode == RUN_CPU:
+        return (
+            "running on CPU (no GPU detected): expect dramatically slower "
+            f"generation (~{mult:.0f}x)." + ideal
+        )
+    if run_mode == RUN_OFFLOAD:
+        return (
+            "weights do not fit VRAM; streaming from CPU/disk (offload): slower "
+            f"(~{mult:.1f}x) but valid." + ideal
+        )
+    if run_mode == RUN_EMERGENCY:
+        return (
+            "does not fit at full precision; running 4-bit emergency "
+            "quantization: below-platform quality." + ideal
+        )
+    return detail

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -61,10 +61,57 @@ def test_gate_accepts_card_of_exactly_recommended_size() -> None:
     assert "fits-24" not in ex.unavailable
 
 
-def test_gate_still_blocks_genuinely_bigger_requirements() -> None:
+def test_gate_serves_bigger_model_via_emergency_quant() -> None:
+    """th#683 P3: a model bigger than the card is NOT refused on the hint — it
+    serves via the emergency 4-bit rung (on-GPU, below-platform quality),
+    regardless of the CPU-offload veto (emergency is not CPU-touching)."""
     ex = Executor([_spec("needs-32", 32.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
-    assert ex.unavailable["needs-32"][0] == "insufficient_vram"
+    assert "needs-32" not in ex.unavailable
+    plan = ex.serve_plans["needs-32"]
+    assert plan.serveable and plan.degraded
+    assert plan.run_mode == "emergency_quant"
+    assert plan.warning  # honest-guidance surfaced
+
+
+def test_gate_offload_only_model_forbidden_here(monkeypatch) -> None:
+    """A model so large even 4-bit won't fit needs CPU/disk offload. On a box
+    that forbids CPU-touching placement it is unserveable HERE (belongs on the
+    GPU lane) — with a distinct reason, never a silent 'too big'."""
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    ex = Executor([_spec("huge", 64.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
+    assert ex.unavailable["huge"][0] == "offload_forbidden"
+
+
+def test_gate_offload_only_model_serves_when_allowed(monkeypatch) -> None:
+    """The same too-large model serves via CPU/disk offload when offload is
+    allowed (the production/GPU-lane case): fit over speed, never refused."""
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    ex = Executor([_spec("huge", 64.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
+    assert "huge" not in ex.unavailable
+    plan = ex.serve_plans["huge"]
+    assert plan.serveable and plan.run_mode == "offload"
+    assert plan.est_latency_multiplier > 1.0 and plan.warning
+
+
+def test_gate_cpu_only_fallback_when_no_gpu(monkeypatch) -> None:
+    """th#683 P3 CPU-only ultimate fallback: with no GPU, a GPU function is
+    offered on CPU (very slow) behind a warning when allowed, and refused with
+    a distinct reason only when CPU inference is forbidden here."""
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    ex = Executor([_spec("needs-24", 24.0)], _noop_send)
+    ex.gate_functions({"gpu_count": 0, "gpu_total_mem": 0, "gpu_sm": ""})
+    assert "needs-24" not in ex.unavailable
+    plan = ex.serve_plans["needs-24"]
+    assert plan.serveable and plan.run_mode == "cpu"
+    assert plan.est_latency_multiplier >= 10.0 and plan.warning
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    ex2 = Executor([_spec("needs-24", 24.0)], _noop_send)
+    ex2.gate_functions({"gpu_count": 0, "gpu_total_mem": 0, "gpu_sm": ""})
+    assert ex2.unavailable["needs-24"][0] == "cuda_unavailable"
 
 
 def test_variant_fit_counts_recommended_size_card_as_fitting() -> None:

--- a/tests/test_serve_fit.py
+++ b/tests/test_serve_fit.py
@@ -1,0 +1,77 @@
+"""th#683 P3 serve-time adaptive fit — plan_serve decision logic."""
+
+from gen_worker.api.decorators import Resources
+from gen_worker.models.hub_policy import TensorhubWorkerCapabilities
+from gen_worker.models.serve_fit import (
+    RUN_CPU,
+    RUN_EMERGENCY,
+    RUN_NATIVE,
+    RUN_OFFLOAD,
+    plan_serve,
+)
+
+CAPS_4090 = TensorhubWorkerCapabilities(cuda_version="12.8", gpu_sm=89, torch_version="2.8", installed_libs=[])
+CAPS_SMALL = TensorhubWorkerCapabilities(cuda_version="12.8", gpu_sm=86, torch_version="2.8", installed_libs=[])  # e.g. an 8GB 3050
+CAPS_CPU = TensorhubWorkerCapabilities(cuda_version="", gpu_sm=0, torch_version="2.8", installed_libs=[])
+
+
+def test_native_fit_full_quality() -> None:
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_4090, free_vram_gb=23.6, forbid_cpu_offload=False)
+    assert plan.serveable and plan.run_mode == RUN_NATIVE and not plan.degraded
+    assert not plan.warning
+
+
+def test_small_card_uses_emergency_before_offload() -> None:
+    # 24GB model, ~8GB card free: 24*0.45=10.8 > 8 -> not emergency -> offload.
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=False)
+    assert plan.serveable and plan.run_mode == RUN_OFFLOAD
+    assert plan.est_latency_multiplier > 1.0 and plan.warning
+    assert plan.recommended_vram_gb == 24.0
+
+    # 12GB model, ~8GB card free: 12*0.45=5.4 <= 8 -> emergency 4-bit (on-GPU).
+    plan = plan_serve(Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=False)
+    assert plan.serveable and plan.run_mode == RUN_EMERGENCY
+
+
+def test_offload_forbidden_here_is_unserveable_with_reason() -> None:
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=True)
+    assert not plan.serveable and plan.run_mode == RUN_OFFLOAD
+    assert "forbidden" in plan.reason.lower()
+
+
+def test_emergency_serves_even_when_offload_forbidden() -> None:
+    # Emergency 4-bit is on-GPU (not CPU-touching), so the veto does not block it.
+    plan = plan_serve(Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=True)
+    assert plan.serveable and plan.run_mode == RUN_EMERGENCY
+
+
+def test_cpu_only_offered_behind_warning() -> None:
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_CPU, free_vram_gb=0.0, forbid_cpu_offload=False)
+    assert plan.serveable and plan.run_mode == RUN_CPU
+    assert plan.est_latency_multiplier >= 10.0
+    assert "cpu" in plan.warning.lower() and plan.recommended_vram_gb == 24.0
+
+
+def test_cpu_only_refused_when_forbidden() -> None:
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_CPU, free_vram_gb=0.0, forbid_cpu_offload=True)
+    assert not plan.serveable and plan.run_mode == RUN_CPU
+    assert "no gpu" in plan.reason.lower()
+
+
+def test_genuine_compute_capability_incompatibility_refused() -> None:
+    # Requires Blackwell (cc=12.0) but on an SM89 card: no lever helps.
+    plan = plan_serve(
+        Resources(vram_gb=15.0, compute_capability=12.0),
+        CAPS_4090, free_vram_gb=23.6, forbid_cpu_offload=False,
+    )
+    assert not plan.serveable and plan.run_mode == RUN_NATIVE
+    assert "compute capability" in plan.reason.lower()
+
+
+def test_never_refuses_on_hint_alone_in_production() -> None:
+    """The core P3 invariant: with offload allowed (production/GPU-lane), no
+    hardware-inadequacy case is ever a flat refusal — every GPU-present case
+    is serveable by some lever."""
+    for rec_gb, free in [(80.0, 8.0), (48.0, 16.0), (24.0, 6.0), (100.0, 23.6)]:
+        plan = plan_serve(Resources(vram_gb=rec_gb), CAPS_SMALL, free_vram_gb=free, forbid_cpu_offload=False)
+        assert plan.serveable, f"refused vram_gb={rec_gb} on free={free}"


### PR DESCRIPTION
## th#683 P3 — serve-time adaptive fit ("just works on any card")

Completes th#683: the worker **never hard-refuses** a function on the recommended-VRAM hint. On whatever card it lands on, it serves by the best available means and is **honest about the trade**. Builds on P0 (this repo, gw#145 seam) + P1 (tensorhub#192) + P2 (tensorhub#193 fit-matrix).

### The decision layer: `models/serve_fit.plan_serve`
Per (already flavor-resolved) function, decides HOW it runs on the actual card:

```
native  ->  emergency 4-bit  ->  CPU/disk offload  ->  CPU-only
(fast/full quality)              (fit over speed, the         (very slow,
                                  PRIMARY lever at the low end) offered not refused)
```

choosing the highest-quality lever that fits. Composes the existing `variant_fit` verdict (fits/emergency/offload/incompatible/svdq) with a new **CPU rung** and the `GEN_WORKER_FORBID_CPU_OFFLOAD` guard.

### `gate_functions` now adapts instead of refusing
- A model **bigger than the card** serves via emergency-quant (on-GPU 4-bit) or CPU/disk offload — down to ~6-8 GB and below, where weights exceed VRAM even quantized and offload becomes the primary lever.
- A **GPU function with no GPU** falls back to CPU-only, offered behind a loud warning rather than refused.
- **Unserveable only** on a genuine incompatibility (compute capability / missing quant library) or when the sole lever here is a CPU-touching placement this box forbids (`GEN_WORKER_FORBID_CPU_OFFLOAD=1` → belongs on the GPU lane), with distinct reason codes `offload_forbidden` / `cuda_unavailable`.

The genuine compute-capability / missing-library hard gates keep their explicit reason codes; only the VRAM/GPU-presence refusal becomes adaptive. Flavor selection across a card (bf16 → fp8 → nvfp4 → int4) falls out of the hub's existing routing over the serveable pre-expanded per-flavor functions.

### Honest-guidance UX
Every degraded plan carries a realistic **latency multiplier** + the **ideal card**. `run --list` and `serve --list-functions --json` now emit `serveable`, `run_mode`, `est_latency_multiplier`, `recommended_vram_gb`, and an `advisory` string. "Best-effort + honest about the trade."

### Tests
New `tests/test_serve_fit.py` (plan logic across native/emergency/offload/CPU + the never-refuse invariant) and rewritten gate tests (the old "still-blocks-bigger-requirements" test now asserts P3 semantics). **Full suite: 629 passed, 10 skipped; ruff clean.** No live models run (this box forbids CPU offload) — fakes/scripted `gpu_info` throughout.

### Deliberately deferred (live-GPU follow-up)
Validate that fp8/nvfp4/int4 actually run on the target cards, and that emergency-quant / offload / CPU-only produce **valid outputs** down to 6-8 GB and CPU-only. The plan is exercised with fakes here; execution needs the GPU lane. The realistic latency numbers are coarse heuristics until wired to P2's measured fit-matrix latency.