### PR TITLE
gw#456: clone downloads can no longer hang forever — HF timeout floor + stall watchdog + bounded resumable retries

### DIFF
--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -9,14 +9,38 @@ fetch from ``gen_worker.models.download`` plus clone-side metadata
 from __future__ import annotations
 
 import json
+import logging
+import os
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from ..net import install_hf_http_timeouts
 from .classifier import RepoClassification, classify_repo
 from .layout import detect_huggingface_source_layout
 
+logger = logging.getLogger(__name__)
+
 ProgressFn = Callable[[int, Optional[int]], None]
+
+
+class CloneDownloadError(RuntimeError):
+    """Source download failed after bounded retries (gw#456) — the clone job
+    fails cleanly instead of hanging."""
+
+
+_DOWNLOAD_ATTEMPTS_ENV = "COZY_CLONE_DOWNLOAD_ATTEMPTS"
+
+
+def _download_attempts() -> int:
+    raw = os.environ.get(_DOWNLOAD_ATTEMPTS_ENV, "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return 3
 
 _SAFETENSORS_DTYPE_NAMES = {
     "F32": "fp32", "F16": "fp16", "BF16": "bf16",
@@ -255,6 +279,7 @@ def plan_huggingface(
     hf_token: str | None = None,
 ) -> HFSourcePlan:
     """Resolve + classify one HF repo from metadata alone (no weight bytes)."""
+    install_hf_http_timeouts()
     repo_id, sha = resolve_hf_identity(source_ref, revision=revision, hf_token=hf_token)
     rev = sha or (str(revision).strip() if revision else None)
     paths, sizes, side, content_ids = _hf_classification_inputs(repo_id, rev, hf_token)
@@ -290,6 +315,72 @@ def plan_civitai(model_version_id: int, *, civitai_api_key: str | None = None) -
     )
 
 
+def _snapshot_download_with_retries(
+    repo_id: str,
+    revision: str | None,
+    dest_dir: Path,
+    *,
+    allow_patterns: list[str],
+    hf_token: str | None,
+    progress: ProgressFn | None,
+    total_hint: Optional[int],
+) -> None:
+    """Bounded, resumable ``snapshot_download`` (gw#456): every socket has a
+    timeout floor (:mod:`gen_worker.net`), the stall watchdog reports byte
+    progress and aborts no-progress downloads, and transient network failures
+    retry (hf_hub resumes ``.incomplete`` files via Range). Exhausted retries
+    raise :class:`CloneDownloadError`."""
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import (
+        EntryNotFoundError,
+        GatedRepoError,
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+    )
+
+    from gen_worker.models.download import (
+        _hf_stall_timeout_s,
+        _hf_wallclock_max_s,
+        _run_with_stall_watchdog,
+    )
+
+    attempts = _download_attempts()
+    last: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            _run_with_stall_watchdog(
+                lambda: snapshot_download(
+                    repo_id,
+                    revision=revision,
+                    local_dir=str(dest_dir),
+                    allow_patterns=allow_patterns,
+                    token=(hf_token or None),
+                ),
+                label=f"clone {repo_id}@{revision or 'main'}",
+                progress_root=dest_dir,
+                progress_callback=progress,
+                total_hint=total_hint,
+                stall_timeout=_hf_stall_timeout_s(),
+                wall_clock_max=_hf_wallclock_max_s(),
+            )
+            return
+        except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError,
+                EntryNotFoundError, ValueError, TypeError):
+            raise  # permanent — retrying cannot help
+        except Exception as exc:
+            # Transport errors: httpx exceptions, HfHubHTTPError (5xx/429),
+            # raw socket OSErrors, DownloadStalledError — all bounded-retried.
+            last = exc
+            if attempt < attempts:
+                logger.warning(
+                    "clone download %s attempt %d/%d failed (%s: %s); retrying (resumable)",
+                    repo_id, attempt, attempts, type(exc).__name__, exc)
+                time.sleep(min(10.0, 2.0 * attempt))
+    raise CloneDownloadError(
+        f"clone download of {repo_id} failed after {attempts} attempt(s): "
+        f"{type(last).__name__}: {last}") from last
+
+
 def ingest_huggingface(
     source_ref: str,
     dest_dir: Path,
@@ -305,8 +396,7 @@ def ingest_huggingface(
 
     ``plan`` (from :func:`plan_huggingface`) skips re-doing the metadata
     calls when the caller already planned this source."""
-    from huggingface_hub import snapshot_download
-
+    install_hf_http_timeouts()
     if plan is None:
         plan = plan_huggingface(
             source_ref, revision=revision, dtype_preference=dtype_preference,
@@ -321,12 +411,12 @@ def ingest_huggingface(
     selected_bytes = sum(int(sizes.get(p, 0)) for p in classification.allow_patterns)
     if progress is not None:
         progress(0, selected_bytes or None)
-    snapshot_download(
-        repo_id,
-        revision=rev,
-        local_dir=str(dest_dir),
+    _snapshot_download_with_retries(
+        repo_id, rev, dest_dir,
         allow_patterns=list(classification.allow_patterns),
-        token=(hf_token or None),
+        hf_token=hf_token,
+        progress=progress,
+        total_hint=selected_bytes or None,
     )
     if progress is not None:
         progress(selected_bytes, selected_bytes or None)
@@ -501,6 +591,7 @@ def ingest_civitai(
 
 __all__ = [
     "CivitaiSourcePlan",
+    "CloneDownloadError",
     "HFSourcePlan",
     "IngestedSource",
     "ingest_civitai",

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -503,6 +503,10 @@ def download_hf(
             "huggingface_hub is required for hf model refs; install gen-worker with the HF extra."
         ) from e
 
+    from ..net import install_hf_http_timeouts
+
+    install_hf_http_timeouts()  # gw#456: no HF socket may wait forever
+
     repo_id = (ref.repo_id or "").strip()
     if not repo_id:
         raise ValueError("empty hf repo_id")
@@ -599,6 +603,18 @@ def download_hf(
 _CIVITAI_API = "https://civitai.com/api/v1"
 _CIVITAI_AUTH_HOSTS = {"civitai.com", "www.civitai.com", "api.civitai.com"}
 _CIVITAI_CHUNK = 4 * 1024 * 1024
+_CIVITAI_JSON_TIMEOUT = (30.0, 120.0)    # (connect, read) seconds
+_CIVITAI_STREAM_TIMEOUT = (60.0, 180.0)  # read timeout doubles as stall bound
+
+
+def _civitai_attempts() -> int:
+    raw = os.environ.get("COZY_CIVITAI_DOWNLOAD_ATTEMPTS", "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return 3
 
 
 def parse_civitai_version_id(raw: str) -> int:
@@ -624,7 +640,7 @@ def _civitai_get_json(url: str, api_key: str = "") -> dict[str, Any]:
     headers: Dict[str, str] = {}
     if api_key and urlparse(url).hostname in _CIVITAI_AUTH_HOSTS:
         headers["Authorization"] = f"Bearer {api_key}"
-    resp = requests.get(url, headers=headers, timeout=(30, 120))
+    resp = requests.get(url, headers=headers, timeout=_CIVITAI_JSON_TIMEOUT)
     if resp.status_code in (401, 403):
         raise ValueError("civitai_access_denied")
     if resp.status_code == 404:
@@ -695,7 +711,7 @@ def _civitai_stream_one(
     tmp = dst.with_suffix(dst.suffix + ".part")
     h = hashlib.sha256()
     written = 0
-    with requests.get(url, headers=headers, stream=True, timeout=(60, 180)) as resp:
+    with requests.get(url, headers=headers, stream=True, timeout=_CIVITAI_STREAM_TIMEOUT) as resp:
         if resp.status_code in (401, 403):
             raise ValueError("civitai_access_denied")
         if resp.status_code == 404:
@@ -755,6 +771,8 @@ def download_civitai(
             except Exception:
                 pass
 
+    import requests
+
     local_paths: list[Path] = []
     for f in files:
         dst = out_dir / f["name"]
@@ -762,13 +780,28 @@ def download_civitai(
         if dst.exists() and (not f["size_bytes"] or dst.stat().st_size == f["size_bytes"]):
             done += f["size_bytes"]
             continue
-        _civitai_stream_one(
-            f["url"], dst,
-            api_key=api_key,
-            expected_size=f["size_bytes"],
-            expected_sha256=f["sha256"],
-            on_bytes=_on_bytes,
-        )
+        attempts = _civitai_attempts()
+        file_start = done
+        for attempt in range(1, attempts + 1):
+            try:
+                _civitai_stream_one(
+                    f["url"], dst,
+                    api_key=api_key,
+                    expected_size=f["size_bytes"],
+                    expected_sha256=f["sha256"],
+                    on_bytes=_on_bytes,
+                )
+                break
+            except (requests.RequestException, OSError) as exc:
+                done = file_start  # rewind progress from the failed partial
+                if attempt >= attempts:
+                    raise RuntimeError(
+                        f"civitai download of {f['name']} failed after "
+                        f"{attempts} attempt(s): {type(exc).__name__}: {exc}") from exc
+                logger.warning(
+                    "civitai download %s attempt %d/%d failed (%s: %s); retrying",
+                    f["name"], attempt, attempts, type(exc).__name__, exc)
+                time.sleep(min(10.0, 2.0 * attempt))
     manifest_path.write_text(json.dumps(
         {"model_version_id": int(version_id),
          "files": [{"name": f["name"], "size_bytes": f["size_bytes"], "sha256": f["sha256"]} for f in files]},

--- a/src/gen_worker/net.py
+++ b/src/gen_worker/net.py
@@ -1,0 +1,107 @@
+"""Process-wide HTTP timeout floor for huggingface_hub (gw#456).
+
+huggingface_hub's default HTTP client has NO timeout (httpx.Client(timeout=None)
+on 1.x; requests never times out by default on 0.x), and several HfApi methods
+pass an explicit ``timeout=None``. One stalled connection then blocks a clone
+forever: sockets sit in CLOSE-WAIT, the job never fails, and tensorhub's mirror
+demand rows dedup-join the hung job (observed live on cozy-r2).
+
+:func:`install_hf_http_timeouts` installs a client factory whose requests can
+never wait forever: caller-provided numeric timeouts are kept, infinite ones
+are floored to env-tunable defaults. The read timeout applies per socket read,
+so it doubles as a stall detector for streaming bodies.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+CONNECT_TIMEOUT_ENV = "COZY_HTTP_CONNECT_TIMEOUT_S"
+READ_TIMEOUT_ENV = "COZY_HTTP_READ_TIMEOUT_S"
+DEFAULT_CONNECT_TIMEOUT_S = 15.0
+DEFAULT_READ_TIMEOUT_S = 60.0
+
+_lock = threading.Lock()
+_installed = False
+
+
+def _env_seconds(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if raw:
+        try:
+            return max(0.1, float(raw))
+        except ValueError:
+            pass
+    return default
+
+
+def http_timeouts() -> tuple[float, float]:
+    """(connect, read) floor, read from env on every call (test-tunable)."""
+    return (
+        _env_seconds(CONNECT_TIMEOUT_ENV, DEFAULT_CONNECT_TIMEOUT_S),
+        _env_seconds(READ_TIMEOUT_ENV, DEFAULT_READ_TIMEOUT_S),
+    )
+
+
+def _floor_timeout_hook(request: Any) -> None:
+    """httpx request event hook: entries in request.extensions['timeout'] are
+    None when infinite — replace only those; explicit numbers win."""
+    connect, read = http_timeouts()
+    defaults = {"connect": connect, "read": read, "write": read, "pool": connect}
+    current = dict(request.extensions.get("timeout") or {})
+    request.extensions["timeout"] = {
+        k: (current[k] if current.get(k) is not None else v)
+        for k, v in defaults.items()
+    }
+
+
+def install_hf_http_timeouts() -> None:
+    """Idempotent; call before any huggingface_hub network use."""
+    global _installed
+    with _lock:
+        if _installed:
+            return
+        try:
+            from huggingface_hub.utils import _http as hf_http
+
+            default_factory = hf_http.default_client_factory
+            set_factory = hf_http.set_client_factory
+        except (ImportError, AttributeError):
+            _install_requests_backend()  # huggingface_hub 0.x
+            _installed = True
+            return
+
+        def _factory() -> Any:
+            client = default_factory()
+            client.event_hooks["request"] = [_floor_timeout_hook] + list(
+                client.event_hooks.get("request") or []
+            )
+            return client
+
+        set_factory(_factory)
+        _installed = True
+
+
+def _install_requests_backend() -> None:
+    """huggingface_hub 0.x (requests): default a (connect, read) timeout on
+    every Session request that would otherwise wait forever."""
+    import requests
+    from huggingface_hub import configure_http_backend
+
+    class _TimeoutSession(requests.Session):
+        def request(self, method: str, url: str, **kwargs: Any) -> Any:  # type: ignore[override]
+            if kwargs.get("timeout") is None:
+                kwargs["timeout"] = http_timeouts()
+            return super().request(method, url, **kwargs)
+
+    configure_http_backend(backend_factory=_TimeoutSession)
+
+
+__all__ = [
+    "CONNECT_TIMEOUT_ENV",
+    "READ_TIMEOUT_ENV",
+    "http_timeouts",
+    "install_hf_http_timeouts",
+]

--- a/tests/convert/test_clone_network_timeouts.py
+++ b/tests/convert/test_clone_network_timeouts.py
@@ -1,0 +1,322 @@
+"""gw#456: clone downloads must never hang on a stalled connection.
+
+Real sockets, real client codepaths: a threaded local HTTP server speaks just
+enough of the HF hub protocol (repo_info, tree listing, HEAD/GET resolve with
+Range) plus a civitai endpoint. Failure modes are injected at the socket level
+(never respond / drop mid-body / 500), never by mocking the client.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+REV = "a" * 40
+
+
+def _tiny_safetensors(n_bytes: int = 1 << 20) -> bytes:
+    """A minimal valid safetensors blob of roughly n_bytes."""
+    header = json.dumps({
+        "__metadata__": {"format": "pt"},
+        "w": {"dtype": "F16", "shape": [n_bytes // 2], "data_offsets": [0, n_bytes]},
+    }).encode()
+    return struct.pack("<Q", len(header)) + header + b"\0" * n_bytes
+
+
+class _FakeHF(BaseHTTPRequestHandler):
+    """Minimal HF hub + civitai file server with per-path failure modes:
+    'ok' | 'stall' (accept, never respond) | 'drop_once' (half body, abort)
+    | 'error_once' (one 500)."""
+
+    protocol_version = "HTTP/1.0"
+
+    def log_message(self, *a) -> None:  # silence
+        pass
+
+    # -- helpers -----------------------------------------------------------
+    def _send_json(self, payload, code: int = 200) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _mode(self, name: str) -> str:
+        return self.server.modes.get(name, "ok")  # type: ignore[attr-defined]
+
+    def _consume_once(self, name: str, mode: str) -> bool:
+        srv = self.server
+        with srv.lock:  # type: ignore[attr-defined]
+            if self._mode(name) == mode:
+                srv.modes[name] = "ok"  # type: ignore[attr-defined]
+                return True
+        return False
+
+    def _stall(self) -> None:
+        # Accept the request, never respond — the live incident's shape.
+        self.server.stop_event.wait(60)  # type: ignore[attr-defined]
+
+    # -- routes ------------------------------------------------------------
+    def do_HEAD(self) -> None:  # noqa: N802
+        srv = self.server
+        if "/resolve/" in self.path:
+            name = self.path.rsplit("/", 1)[-1]
+            data = srv.files.get(name)  # type: ignore[attr-defined]
+            if data is None:
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("ETag", f'"{name}-etag"')
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("X-Repo-Commit", REV)
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        srv = self.server
+        path = self.path.split("?", 1)[0]
+        if path.startswith("/api/") and srv.modes.get("_api") == "stall":  # type: ignore[attr-defined]
+            self._stall()
+            return
+        repo = srv.repo_id  # type: ignore[attr-defined]
+
+        # civitai model-version metadata
+        if path.startswith("/api/v1/model-versions/"):
+            self._send_json(srv.civitai_payload)  # type: ignore[attr-defined]
+            return
+
+        # HfApi.repo_info
+        if path in (f"/api/models/{repo}", f"/api/models/{repo}/revision/{REV}",
+                    "/api/models/" + repo + "/revision/main"):
+            self._send_json({
+                "id": repo, "modelId": repo, "sha": REV, "private": False,
+                "tags": [], "downloads": 0, "likes": 0,
+                "siblings": [{"rfilename": n} for n in sorted(srv.files)],  # type: ignore[attr-defined]
+            })
+            return
+
+        # HfApi.list_repo_tree
+        if path.startswith(f"/api/models/{repo}/tree/"):
+            entries = []
+            for name, data in sorted(srv.files.items()):  # type: ignore[attr-defined]
+                e = {"type": "file", "path": name, "size": len(data), "oid": "git-" + name}
+                if name.endswith(".safetensors"):
+                    e["lfs"] = {"oid": "f" * 64, "size": len(data), "pointerSize": 135}
+                entries.append(e)
+            self._send_json(entries)
+            return
+
+        # file bytes: /{repo}/resolve/{rev}/{name} and civitai /dl/{name}
+        if "/resolve/" in path or path.startswith("/dl/"):
+            name = path.rsplit("/", 1)[-1]
+            data = srv.files.get(name)  # type: ignore[attr-defined]
+            if data is None:
+                self._send_json({"error": "not found"}, code=404)
+                return
+            with srv.lock:  # type: ignore[attr-defined]
+                srv.get_counts[name] = srv.get_counts.get(name, 0) + 1  # type: ignore[attr-defined]
+            if self._mode(name) == "stall":
+                self._stall()
+                return
+            if self._consume_once(name, "error_once"):
+                self._send_json({"error": "boom"}, code=500)
+                return
+            start = 0
+            rng = self.headers.get("Range", "")
+            if rng.startswith("bytes="):
+                start = int(rng[6:].split("-", 1)[0] or 0)
+                srv.ranges.append((name, start))  # type: ignore[attr-defined]
+            body = data[start:]
+            drop = self._consume_once(name, "drop_once")
+            stall_mid = self._consume_once(name, "stall_mid_once")
+            self.send_response(206 if start else 200)
+            if start:
+                self.send_header("Content-Range", f"bytes {start}-{len(data)-1}/{len(data)}")
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("ETag", f'"{name}-etag"')
+            self.send_header("X-Repo-Commit", REV)
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            if drop:
+                self.wfile.write(body[: max(1, len(body) // 2)])
+                self.wfile.flush()
+                self.connection.close()  # abrupt mid-body disconnect
+                return
+            if stall_mid:
+                self.wfile.write(body[: max(1, len(body) // 2)])
+                self.wfile.flush()
+                self._stall()  # half the body, then dead air
+                return
+            self.wfile.write(body)
+            return
+
+        self._send_json({"error": "not found"}, code=404)
+
+
+@pytest.fixture()
+def hf_server():
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _FakeHF)
+    srv.daemon_threads = True
+    srv.repo_id = "acme/tiny-model"
+    weights = _tiny_safetensors()
+    srv.files = {
+        "config.json": json.dumps({"architectures": ["LlamaForCausalLM"],
+                                   "model_type": "llama"}).encode(),
+        "model.safetensors": weights,
+    }
+    srv.modes = {}
+    srv.get_counts = {}
+    srv.ranges = []
+    srv.lock = threading.Lock()
+    srv.stop_event = threading.Event()
+    srv.civitai_payload = {}
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield srv
+    finally:
+        srv.stop_event.set()
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.fixture()
+def hf_env(hf_server, monkeypatch, tmp_path):
+    """Point huggingface_hub at the fake server; small timeouts; fresh cache."""
+    import huggingface_hub.constants as hc
+
+    from gen_worker import net
+
+    base = f"http://127.0.0.1:{hf_server.server_port}"
+    monkeypatch.setattr(hc, "ENDPOINT", base)
+    monkeypatch.setattr(hc, "HUGGINGFACE_CO_URL_TEMPLATE",
+                        base + "/{repo_id}/resolve/{revision}/{filename}")
+    monkeypatch.setattr(hc, "HF_HUB_CACHE", str(tmp_path / "hf-cache"))
+    monkeypatch.setenv(net.CONNECT_TIMEOUT_ENV, "2")
+    monkeypatch.setenv(net.READ_TIMEOUT_ENV, "2")
+    monkeypatch.setenv("COZY_CLONE_DOWNLOAD_ATTEMPTS", "2")
+    # Socket timeouts are the stall detector under test; keep the disk-scan
+    # watchdog out of the way.
+    monkeypatch.setenv("COZY_HF_DOWNLOAD_STALL_TIMEOUT_S", "60")
+    net.install_hf_http_timeouts()
+    return base
+
+
+def test_metadata_stall_fails_fast(hf_server, hf_env):
+    """HfApi.repo_info passes an explicit timeout=None — the floor hook must
+    still time it out (the exact live-incident hang: request sent, upstream
+    never answers, job stuck forever)."""
+    from gen_worker.convert.ingest import plan_huggingface
+
+    hf_server.modes["_api"] = "stall"
+    t0 = time.monotonic()
+    with pytest.raises(Exception) as exc_info:
+        plan_huggingface(hf_server.repo_id)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 20, f"metadata stall not bounded: {elapsed:.1f}s"
+    assert "timed out" in str(exc_info.value).lower() or "timeout" in type(exc_info.value).__name__.lower()
+
+
+def test_download_stall_aborts_cleanly(hf_server, hf_env, tmp_path):
+    """Weights GET accepts the request and never responds: the clone must
+    surface CloneDownloadError within the bounded retry budget, not hang."""
+    from gen_worker.convert.ingest import CloneDownloadError, ingest_huggingface
+
+    hf_server.modes["model.safetensors"] = "stall"
+    t0 = time.monotonic()
+    with pytest.raises(CloneDownloadError):
+        ingest_huggingface(hf_server.repo_id, tmp_path / "snap")
+    elapsed = time.monotonic() - t0
+    assert elapsed < 60, f"stalled download not bounded: {elapsed:.1f}s"
+
+
+def test_drop_mid_body_outer_retry_succeeds(hf_server, hf_env, tmp_path):
+    """First weights GET dies mid-body (peer close): hf_hub does not retry
+    that, so the clone's bounded outer retry must recover byte-identically."""
+    from gen_worker.convert.ingest import ingest_huggingface
+
+    hf_server.modes["model.safetensors"] = "drop_once"
+    calls: list[tuple[int, int | None]] = []
+    src = ingest_huggingface(hf_server.repo_id, tmp_path / "snap",
+                             progress=lambda done, total: calls.append((done, total)))
+    got = (Path(src.dir) / "model.safetensors").read_bytes()
+    assert got == hf_server.files["model.safetensors"]
+    assert (Path(src.dir) / "config.json").exists()
+    assert hf_server.get_counts["model.safetensors"] >= 2
+    dones = [d for d, _ in calls]
+    assert dones == sorted(dones) and dones[-1] > 0  # monotonic, reached total
+
+
+def test_stall_mid_body_resumes_via_range(hf_server, hf_env, tmp_path, monkeypatch):
+    """Mid-body stall (the CDN CLOSE-WAIT shape): the floored read timeout
+    aborts the dead socket and hf_hub resumes with a Range request instead of
+    hanging or restarting from zero."""
+    import huggingface_hub.constants as hc
+
+    from gen_worker.convert.ingest import ingest_huggingface
+
+    monkeypatch.setattr(hc, "DOWNLOAD_CHUNK_SIZE", 64 * 1024)
+    hf_server.modes["model.safetensors"] = "stall_mid_once"
+    t0 = time.monotonic()
+    src = ingest_huggingface(hf_server.repo_id, tmp_path / "snap")
+    elapsed = time.monotonic() - t0
+    got = (Path(src.dir) / "model.safetensors").read_bytes()
+    assert got == hf_server.files["model.safetensors"]
+    assert any(name == "model.safetensors" and off > 0 for name, off in hf_server.ranges), \
+        f"no Range resume observed: {hf_server.ranges}"
+    assert elapsed < 60, f"mid-body stall not bounded: {elapsed:.1f}s"
+
+
+def test_http_500_once_outer_retry_succeeds(hf_server, hf_env, tmp_path):
+    """A transient 500 on the weights GET is retried by the clone's own
+    bounded retry loop (hf_hub does not retry 5xx) and then succeeds."""
+    from gen_worker.convert.ingest import ingest_huggingface
+
+    hf_server.modes["model.safetensors"] = "error_once"
+    src = ingest_huggingface(hf_server.repo_id, tmp_path / "snap")
+    got = (Path(src.dir) / "model.safetensors").read_bytes()
+    assert got == hf_server.files["model.safetensors"]
+    assert hf_server.get_counts["model.safetensors"] >= 2
+
+
+def test_civitai_drop_mid_body_retries(hf_server, hf_env, tmp_path, monkeypatch):
+    """Civitai stream dies mid-body once; the per-file retry re-downloads and
+    the sha256 check passes."""
+    import hashlib
+
+    from gen_worker.models import download as dl
+
+    data = hf_server.files["model.safetensors"]
+    name = "civi-model.safetensors"
+    hf_server.files[name] = data
+    hf_server.modes[name] = "drop_once"
+    hf_server.civitai_payload = {
+        "id": 123, "modelId": 7, "baseModel": "SDXL 1.0", "air": "",
+        "model": {"type": "Checkpoint"},
+        "files": [{
+            "id": 1, "name": name, "primary": True,
+            "downloadUrl": f"{hf_env}/dl/{name}",
+            "sizeBytes": len(data),
+            "hashes": {"SHA256": hashlib.sha256(data).hexdigest()},
+        }],
+    }
+    monkeypatch.setattr(dl, "_CIVITAI_API", f"{hf_env}/api/v1")
+    monkeypatch.setenv("COZY_CIVITAI_DOWNLOAD_ATTEMPTS", "2")
+
+    out = dl.download_civitai(123, tmp_path / "civi")
+    assert Path(out).read_bytes() == data
+    assert hf_server.get_counts[name] == 2  # one drop, one clean re-download


### PR DESCRIPTION
Fixes gw#456 (observed live on cozy-r2: two clone-huggingface jobs sat >15 min with empty workdirs, sockets in CLOSE-WAIT, jobs "running" forever, wedging the th#636 demand rows joined to them).

## Root cause
huggingface_hub's default HTTP client has **no timeout** (`httpx.Client(timeout=None)` on 1.x), and `HfApi.repo_info` even passes an explicit `timeout=None` per request — so the clone's metadata phase (`repo_info`, `list_repo_tree` pagination, safetensors sniff) can block on a dead connection forever. The clone ingest path also ran `snapshot_download` bare: no stall watchdog, no retries, and progress only reported at 0%/100% (the frozen 0.05–0.5 progress band).

## Fix
- **`gen_worker/net.py`** — process-wide timeout floor via `set_client_factory`: an httpx request hook floors any infinite timeout component to `COZY_HTTP_CONNECT_TIMEOUT_S` (15) / `COZY_HTTP_READ_TIMEOUT_S` (60); explicit numeric timeouts win. Requests-Session fallback for hub 0.x (pyproject floor is >=0.26). The read timeout applies per socket read, so it doubles as the stall detector for streaming bodies.
- **`convert/ingest.py`** — `snapshot_download` now runs under the existing gw#379 stall watchdog (which also gives real byte progress during clone downloads) with bounded retries (`COZY_CLONE_DOWNLOAD_ATTEMPTS`=3, backoff, hf_hub Range-resumes `.incomplete` files). Permanent errors (gated/not-found/revision) raise immediately; exhausted retries raise typed `CloneDownloadError` → the job fails cleanly, workdir retained for resume.
- **`models/download.py`** — civitai per-file bounded retry (`COZY_CIVITAI_DOWNLOAD_ATTEMPTS`=3, progress rewound on retry); `download_hf` installs the floor too (its `list_repo_files`/`list_repo_tree` had the same infinite-timeout hole).

## Tests (real codepaths, no mock pipes)
`tests/convert/test_clone_network_timeouts.py`: a threaded local HTTP server speaks enough HF hub protocol (repo_info, tree, HEAD/GET resolve with Range, civitai model-versions) with **socket-level** failure injection:
- metadata request accepted, never answered (the live incident's shape) → bounded abort ~2s
- weights GET accepted, never answered → `CloneDownloadError` within retry budget
- mid-body stall → floored read timeout aborts, hf_hub resumes **via Range** (asserted server-side), byte-identical output
- peer-close mid-body and 500-once → outer bounded retry succeeds
- civitai mid-body drop → per-file retry, sha256 verified

6 new tests pass; 171 passed / 2 skipped across convert + download suites; ruff + mypy clean.

Tensorhub-side lease/requeue gap for the wedged demand rows is being filed/fixed separately.