### PR TITLE
gw#457: resolve_dataset rides the async snapshot 202 contract (DATASET-V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.13.5 (2026-07-10)
+
+- **gw#457: `resolve_dataset` rides the DATASET-V2 async snapshot contract
+  (th#691).** `GET /datasets/:id/materialize` may now answer
+  `202 {status: building, state_version, retry_after}` while the snapshot
+  builds in the background; `fetch_materialize_manifest` polls until ready —
+  long-polling via `?wait=30` (ignored by pre-v2 hubs), honoring `retry_after`
+  with capped exponential backoff, within an overall budget (default 30 min,
+  ≥ the hub's 20-min build budget; `resolve_dataset(..., budget_s=)` to
+  override) and respecting job cancellation mid-poll. A typed
+  `snapshot_build_failed` raises the new `SnapshotBuildFailedError`
+  (`gen_worker.api.errors`, carries `error_code`) instead of a generic
+  non-2xx RuntimeError; transient transport errors and bare 502/503/504
+  retry within the same budget (hub restart mid-build). The executor's
+  `payload.datasets` pre-materialization path (gw#425) goes through the same
+  helper, so training jobs survive a live 202 window. Backward-compatible:
+  today's hub never returns 202. Per-shard download retries unchanged.
+
 ## 0.13.4 (2026-07-10)
 
 - **th#683 P3: serve-time adaptive fit — the worker never refuses on the VRAM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.4"
+version = "0.13.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -11,6 +11,7 @@ from .errors import (
     RefCompatibilitySurprise,
     ResourceError,
     RetryableError,
+    SnapshotBuildFailedError,
     ValidationError,
     WorkerError,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "RefCompatibilitySurprise",
     "ResourceError",
     "RetryableError",
+    "SnapshotBuildFailedError",
     "ValidationError",
     "WorkerError",
     "BatchItemDelta",

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -26,6 +26,14 @@ class AuthError(WorkerError):
     """Authentication/authorization failure; do not retry (token expired or invalid)."""
 
 
+class SnapshotBuildFailedError(WorkerError):
+    """Dataset snapshot build failed hub-side (typed ``snapshot_build_failed``)."""
+
+    def __init__(self, message: str, *, error_code: str = "") -> None:
+        self.error_code = str(error_code or "")
+        super().__init__(message)
+
+
 class ArtifactTransferError(WorkerError):
     """Model/artifact upload or download failed in a provider transfer path."""
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1229,7 +1229,7 @@ class _PublisherMixin:
             self._dataset_paths = d
         return d
 
-    def resolve_dataset(self, ref: str) -> str:
+    def resolve_dataset(self, ref: str, *, budget_s: Optional[float] = None) -> str:
         """Materialize a dataset by bare dataset-id or ``owner/name`` ref;
         return the local root.
 
@@ -1243,13 +1243,16 @@ class _PublisherMixin:
            ``GET /api/v1/datasets?tenant=<owner>`` → the row's ``dataset_id``.
         2. ``GET /api/v1/datasets/:id/materialize?format=parquet&include_urls=true``
            → HF-datasets columnar parquet shards (image bytes embedded) with
-           presigned URLs, sizes and blake3 checksums.
+           presigned URLs, sizes and blake3 checksums. A 202 (async snapshot
+           build, th#691) is polled until ready within ``budget_s`` (default
+           30 min, ≥ the hub's 20-min build budget); a typed
+           ``snapshot_build_failed`` raises ``SnapshotBuildFailedError``.
         3. Stream each shard to disk (bounded memory), digest-verified, with
            bounded retries. Entries lacking a presigned URL fall back to the
            repo-CAS by-digest reader.
 
         Raises ``RuntimeError`` when the dataset isn't found, the manifest is
-        empty, or any download exhausts its retries.
+        empty, the poll budget runs out, or any download exhausts its retries.
         """
         from ._datasets import (
             download_entries,
@@ -1274,7 +1277,12 @@ class _PublisherMixin:
             if not dataset_id:
                 raise RuntimeError("resolve_dataset: empty ref")
             cache_key = ("by-id", dataset_id)
-        snapshot_id, entries = fetch_materialize_manifest(base, token, dataset_id)
+        fetch_kwargs: Dict[str, Any] = {"cancelled": lambda: self.cancelled}
+        if budget_s is not None:
+            fetch_kwargs["budget_s"] = budget_s
+        snapshot_id, entries = fetch_materialize_manifest(
+            base, token, dataset_id, **fetch_kwargs,
+        )
 
         cache_root = Path(tempfile.gettempdir()) / "gen_worker_datasets"
         target_root = cache_root.joinpath(*cache_key) / (snapshot_id or dataset_id)

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -2,8 +2,9 @@
 
 Free functions used by ``_PublisherMixin.resolve_dataset``: look up a dataset
 row by (tenant, name), fetch its parquet materialize manifest (presigned shard
-URLs, th#642 wire format), and stream each shard to disk with digest
-verification + bounded retries.
+URLs, th#642 wire format) — polling 202 until the async snapshot build is
+ready (DATASET-V2 contract, gw#457) — and stream each shard to disk with
+digest verification + bounded retries.
 """
 from __future__ import annotations
 
@@ -13,13 +14,22 @@ import urllib.parse
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from ..api.errors import AuthError
+from ..api.errors import AuthError, SnapshotBuildFailedError
 
 logger = logging.getLogger(__name__)
 
 _DOWNLOAD_RETRIES = 3
 _DOWNLOAD_BACKOFF_S = 1.0
 _CHUNK_BYTES = 1024 * 1024
+
+# DATASET-V2 202 contract (th#691): the hub's snapshot build budget is 20 min;
+# the worker waits it out with headroom (training pods can afford minutes).
+_MATERIALIZE_BUDGET_S = 30.0 * 60.0
+_MATERIALIZE_WAIT_HINT_S = 30  # ?wait long-poll hint (server caps ~30s)
+_POLL_BACKOFF_START_S = 1.0
+_POLL_BACKOFF_CAP_S = 30.0
+_POLL_SLEEP_MAX_S = 60.0  # sanity cap even on a huge server retry_after
+_CANCEL_POLL_SLICE_S = 0.5
 
 
 def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
@@ -47,36 +57,153 @@ def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
     raise RuntimeError(f"dataset not found for tenant={tenant} name={name}")
 
 
+def _check_cancelled(cancelled: Optional[Callable[[], bool]]) -> None:
+    if cancelled is not None and cancelled():
+        raise RuntimeError("dataset materialization cancelled")
+
+
+def _sleep_cancellable(seconds: float, cancelled: Optional[Callable[[], bool]]) -> None:
+    """Sleep in small slices so a cancel lands promptly mid-poll."""
+    deadline = time.monotonic() + max(0.0, seconds)
+    while True:
+        _check_cancelled(cancelled)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(remaining, _CANCEL_POLL_SLICE_S))
+
+
+def _retry_after_s(resp: Any, data: Dict[str, Any]) -> float:
+    """Server-suggested wait from the 202 body's retry_after (seconds),
+    falling back to the Retry-After header; 0 when absent/garbage."""
+    for raw in (data.get("retry_after"), resp.headers.get("Retry-After")):
+        if raw is None:
+            continue
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if val > 0:
+            return val
+    return 0.0
+
+
+def _snapshot_build_failed(resp: Any) -> Optional[SnapshotBuildFailedError]:
+    """Typed snapshot_build_failed from a non-2xx body, else None."""
+    body = resp.text or ""
+    if "snapshot_build_failed" not in body:
+        return None
+    error_code = ""
+    try:
+        data = resp.json()
+        if isinstance(data, dict):
+            error_code = str(data.get("error_code") or "")
+    except Exception:
+        pass
+    detail = f": {error_code}" if error_code else ""
+    return SnapshotBuildFailedError(
+        f"dataset snapshot build failed hub-side{detail} "
+        f"(http {resp.status_code}); a new materialize request re-enqueues the build",
+        error_code=error_code,
+    )
+
+
 def fetch_materialize_manifest(
-    base: str, token: str, dataset_id: str
+    base: str,
+    token: str,
+    dataset_id: str,
+    *,
+    budget_s: float = _MATERIALIZE_BUDGET_S,
+    cancelled: Optional[Callable[[], bool]] = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """GET /datasets/:id/materialize?format=parquet&include_urls=true.
 
     Authorizes by dataset id + read_dataset grant (or tenant read perm).
     Returns (snapshot_id, entries); entries carry
     {path, url?, size_bytes?, checksum?, inline_text?, blob_digest?}.
+
+    DATASET-V2 async contract (th#691 / gw#457): the hub may answer
+    202 ``{status: building, state_version, retry_after}`` while the snapshot
+    builds in the background. We long-poll (``?wait=``, ignored by pre-v2
+    hubs) and retry with backoff — honoring ``retry_after`` — until ready or
+    ``budget_s`` runs out. A typed ``snapshot_build_failed`` raises
+    ``SnapshotBuildFailedError``; transient transport/5xx errors retry within
+    the same budget (hub restart mid-build).
     """
     import requests
 
     url = (
         f"{base}/api/v1/datasets/{urllib.parse.quote(dataset_id, safe='')}"
         "/materialize?format=parquet&include_urls=true"
+        f"&wait={_MATERIALIZE_WAIT_HINT_S}"
     )
     headers = {"Authorization": f"Bearer {token}"}
-    resp = requests.get(url, headers=headers, timeout=120)
-    if resp.status_code in (401, 403):
-        raise AuthError(f"dataset materialize unauthorized ({resp.status_code})")
-    if resp.status_code < 200 or resp.status_code >= 300:
-        raise RuntimeError(
-            f"dataset materialize failed ({resp.status_code}): {resp.text[:256]}"
-        )
-    data = resp.json() if resp.text else {}
-    entries = data.get("entries") or []
-    if not isinstance(entries, list) or not entries:
-        raise RuntimeError(
-            f"dataset materialize returned no entries for dataset_id={dataset_id}"
-        )
-    return str(data.get("snapshot_id") or ""), entries
+    deadline = time.monotonic() + max(0.0, budget_s)
+    backoff = _POLL_BACKOFF_START_S
+
+    def _wait_or_budget_exhausted(sleep_s: float, why: str) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                f"dataset materialize budget exhausted after {budget_s:.0f}s "
+                f"for dataset_id={dataset_id} (last state: {why})"
+            )
+        _sleep_cancellable(min(sleep_s, _POLL_SLEEP_MAX_S, remaining), cancelled)
+
+    while True:
+        _check_cancelled(cancelled)
+        try:
+            resp = requests.get(url, headers=headers, timeout=120)
+        except requests.RequestException as exc:
+            logger.warning(
+                "dataset %s materialize request failed (%s); retrying", dataset_id, exc,
+            )
+            _wait_or_budget_exhausted(backoff, f"transport error: {exc}")
+            backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
+            continue
+
+        if resp.status_code in (401, 403):
+            raise AuthError(f"dataset materialize unauthorized ({resp.status_code})")
+
+        if resp.status_code == 202:
+            try:
+                data = resp.json() if resp.text else {}
+            except ValueError:
+                data = {}
+            if not isinstance(data, dict):
+                data = {}
+            retry_after = _retry_after_s(resp, data)
+            sleep_s = retry_after if retry_after > 0 else backoff
+            logger.info(
+                "dataset %s snapshot building (state_version=%s); polling again in %.1fs",
+                dataset_id, data.get("state_version"), min(sleep_s, _POLL_SLEEP_MAX_S),
+            )
+            _wait_or_budget_exhausted(sleep_s, "202 building")
+            backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
+            continue
+
+        if resp.status_code < 200 or resp.status_code >= 300:
+            failed = _snapshot_build_failed(resp)
+            if failed is not None:
+                raise failed
+            if resp.status_code in (502, 503, 504):
+                logger.warning(
+                    "dataset %s materialize got %d; retrying", dataset_id, resp.status_code,
+                )
+                _wait_or_budget_exhausted(backoff, f"http {resp.status_code}")
+                backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
+                continue
+            raise RuntimeError(
+                f"dataset materialize failed ({resp.status_code}): {resp.text[:256]}"
+            )
+
+        data = resp.json() if resp.text else {}
+        entries = data.get("entries") or []
+        if not isinstance(entries, list) or not entries:
+            raise RuntimeError(
+                f"dataset materialize returned no entries for dataset_id={dataset_id}"
+            )
+        return str(data.get("snapshot_id") or ""), entries
 
 
 def _expected_digest(entry: Dict[str, Any]) -> str:

--- a/tests/test_dataset_materialization.py
+++ b/tests/test_dataset_materialization.py
@@ -21,7 +21,7 @@ import blake3
 import msgspec
 import pytest
 
-from gen_worker.api.errors import AuthError
+from gen_worker.api.errors import AuthError, SnapshotBuildFailedError
 from gen_worker.api.types import DatasetRef
 from gen_worker.executor import Executor
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -68,6 +68,11 @@ class _FakeHub:
         self.shard_requests = 0
         self.list_requests = 0
         self.seen_auth: List[str] = []
+        # DATASET-V2 async snapshot contract (th#691 / gw#457).
+        self.materialize_202s = 0  # 202 {building} responses before the 200
+        self.build_failed = False  # 503 typed snapshot_build_failed
+        self.materialize_requests = 0
+        self.seen_wait: List[str] = []
         # Rows the list endpoint knows + ids materialize serves. th#641
         # production refs are bare UUIDs the list endpoint never saw.
         self.known_ids = {"ds-1", _DATASET_UUID}
@@ -105,6 +110,17 @@ class _FakeHub:
                     ds_id = parts[3]
                     if ds_id not in outer.known_ids:
                         self._status(404)
+                        return
+                    outer.materialize_requests += 1
+                    q = urllib.parse.parse_qs(parsed.query)
+                    outer.seen_wait.append(q.get("wait", [""])[0])
+                    if outer.build_failed:
+                        self._json({"error": "snapshot_build_failed",
+                                    "error_code": "encode_error"}, status=503)
+                        return
+                    if outer.materialize_requests <= outer.materialize_202s:
+                        self._json({"status": "building", "state_version": 7,
+                                    "retry_after": 0.01}, status=202)
                         return
                     digest = outer.shard_digest
                     if outer.lie_about_digest:
@@ -145,9 +161,9 @@ class _FakeHub:
                 self.send_header("Content-Length", "0")
                 self.end_headers()
 
-            def _json(self, payload: Dict) -> None:
+            def _json(self, payload: Dict, status: int = 200) -> None:
                 body = json.dumps(payload).encode()
-                self.send_response(200)
+                self.send_response(status)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
@@ -174,6 +190,8 @@ def hub():
 @pytest.fixture(autouse=True)
 def _fast_retries(monkeypatch):
     monkeypatch.setattr(datasets_mod, "_DOWNLOAD_BACKOFF_S", 0.01)
+    monkeypatch.setattr(datasets_mod, "_POLL_BACKOFF_START_S", 0.01)
+    monkeypatch.setattr(datasets_mod, "_POLL_BACKOFF_CAP_S", 0.02)
 
 
 def _ctx(hub: _FakeHub) -> TrainingContext:
@@ -262,6 +280,49 @@ def test_grant_scoped_token_cannot_use_owner_name_refs(hub) -> None:
     )
     with pytest.raises(AuthError):
         ctx.resolve_dataset("acme/faces")
+
+
+# ---- DATASET-V2 async snapshot contract (th#691 / gw#457) ------------------
+
+
+def test_resolve_dataset_rides_202_until_ready(hub) -> None:
+    """202 {building, retry_after} twice, then 200 → manifest resolves; the
+    worker sent the ?wait long-poll hint on every attempt."""
+    hub.materialize_202s = 2
+    ctx = _ctx(hub)
+    root = Path(ctx.resolve_dataset("acme/faces"))
+    _assert_snapshot(root, hub)
+    assert hub.materialize_requests == 3
+    assert all(w == "30" for w in hub.seen_wait)
+
+
+def test_snapshot_build_failed_is_typed(hub) -> None:
+    hub.build_failed = True
+    ctx = _ctx(hub)
+    with pytest.raises(SnapshotBuildFailedError, match="encode_error") as ei:
+        ctx.resolve_dataset("acme/faces")
+    assert ei.value.error_code == "encode_error"
+    assert hub.materialize_requests == 1  # no retry loop on a typed failure
+    assert "acme/faces" not in ctx.dataset_paths
+
+
+def test_materialize_budget_exhaustion(hub) -> None:
+    hub.materialize_202s = 10**9  # never ready
+    ctx = _ctx(hub)
+    with pytest.raises(RuntimeError, match="budget exhausted"):
+        ctx.resolve_dataset("acme/faces", budget_s=0.05)
+    assert hub.materialize_requests >= 1
+
+
+def test_executor_rides_202_window(hub) -> None:
+    """The executor pre-materialization path (gw#425) survives a live 202
+    window — same helper, same polling."""
+    hub.materialize_202s = 2
+    res = _run_training_job(hub, _TrainIn(datasets=[DatasetRef(ref="acme/faces")]))
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    out = msgspec.msgpack.decode(res.inline, type=_TrainOut)
+    assert out.shard_exists
+    assert hub.materialize_requests == 3
 
 
 # ---- executor: payload.datasets materialized before the handler runs -------

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Implements gw#457 (DATASET-V2, th#691 contract — cozy-creator-tracker/DATASET-V2-DESIGN.md §3/§5).

`GET /api/v1/datasets/:id/materialize` may now answer `202 {status: building, state_version, retry_after}` while the snapshot builds in the background. Previously `fetch_materialize_manifest` was a single 120s GET that raised on ANY non-2xx — a 202 killed the training job (J19: 27/29 casualties).

## What changed
- **Poll-until-ready**: `fetch_materialize_manifest` loops on 202, honoring `retry_after` (body field or `Retry-After` header) with capped exponential backoff (1s → 30s cap, 60s per-sleep sanity cap), sending the `?wait=30` long-poll hint (ignored by pre-v2 hubs).
- **Overall budget**: default 30 min (≥ the hub's 20-min build budget); `resolve_dataset(ref, budget_s=)` overrides. Exhaustion raises a clear `budget exhausted` RuntimeError.
- **Typed failure**: `snapshot_build_failed` (503-class typed body) raises the new `SnapshotBuildFailedError` (`gen_worker.api.errors`, exported from `gen_worker.api`, carries `error_code`) — no retry loop on a terminal build failure.
- **Defense in depth**: transient transport errors and bare 502/503/504 (hub restart mid-build) retry within the same budget; polling sleeps are cancel-aware (`ctx.cancelled` checked every 0.5s).
- **Executor path verified**: `_materialize_datasets` (gw#425) → `ctx.resolve_dataset` → the same helper; covered by a dedicated executor-level test riding a live 202 window.
- Per-shard download retries (`download_entries`) unchanged.
- Release 0.13.5 (0.13.4 is already on PyPI).

## Tests (real codepaths, local HTTP stand-in hub)
- 202,202,200 sequence → manifest resolves; 3 materialize GETs; `?wait=30` on every attempt
- `snapshot_build_failed` → `SnapshotBuildFailedError` with `error_code`, exactly one GET
- endless 202 + tiny budget → budget exhaustion RuntimeError
- executor pre-materialization rides the 202 window end to end

Backward-compatible: today's server never returns 202, so this ships ahead of th#691 safely.

Full suite: 635 passed / 10 skipped; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)