### PR TITLE
release 0.13.6 — gw#456 clone-download hang fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.13.5 (2026-07-10)
+## 0.13.6 (2026-07-10)
 
 - **gw#456: clone downloads can no longer hang forever.** huggingface_hub's
   default HTTP client has no timeout (and `HfApi.repo_info` passes an explicit
@@ -17,6 +17,8 @@
   `.incomplete` files), raising typed `CloneDownloadError` when exhausted.
   Civitai files get a bounded per-file retry (`COZY_CIVITAI_DOWNLOAD_ATTEMPTS`=3).
   Tensorhub-side demand-row TTL sweep is th#694.
+
+## 0.13.5 (2026-07-10)
 
 - **gw#457: `resolve_dataset` rides the DATASET-V2 async snapshot contract
   (th#691).** `GET /datasets/:id/materialize` may now answer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.5"
+version = "0.13.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
v0.13.5 was tagged at the gw#457 merge, before gw#456 (PR #151) landed on master; this moves the gw#456 changelog entry to its own 0.13.6 section and bumps the version. Tagging v0.13.6 after merge publishes the wheel that actually carries the fix.