### PR TITLE
gw#459: TrainingMetric val fields — val_loss/best_step/advice, val events bypass the throttle

### DIFF
--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1547,6 +1547,11 @@ class TrainingMetric(msgspec.Struct, frozen=True, kw_only=True):
     lr: Optional[float] = None
     it_s: Optional[float] = None
     eta_s: Optional[float] = None
+    #: pgw#459 validation fields: periodic val loss, step of the best val so
+    #: far, and a short trainer hint (e.g. "val rising; consider best_step").
+    val_loss: Optional[float] = None
+    best_step: Optional[int] = None
+    advice: Optional[str] = None
 
 
 class TrainingContext(_PublisherMixin, RequestContext):
@@ -1577,17 +1582,26 @@ class TrainingContext(_PublisherMixin, RequestContext):
         lr: Optional[float] = None,
         it_s: Optional[float] = None,
         eta_s: Optional[float] = None,
+        val_loss: Optional[float] = None,
+        best_step: Optional[int] = None,
+        advice: Optional[str] = None,
     ) -> None:
         """Emit a typed ``request.training_metric`` event (throttled).
 
         Keep ``ctx.progress`` for human-readable stage text; this is the
-        machine channel a UI charts (loss curve, it/s, ETA).
+        machine channel a UI charts (loss curve, it/s, ETA). Events carrying
+        ``val_loss`` bypass the throttle like first/last (pgw#459) — val
+        points are sparse and every one must reach the hub.
         """
         now = time.monotonic()
         last = self._last_metric_monotonic
         is_first = last is None
         is_last = total > 0 and step >= total
-        if not is_first and not is_last and (now - last) < self.metric_min_interval_s:
+        has_val = val_loss is not None
+        if (
+            not is_first and not is_last and not has_val
+            and (now - last) < self.metric_min_interval_s
+        ):
             return
         self._last_metric_monotonic = now
         metric = TrainingMetric(
@@ -1597,6 +1611,9 @@ class TrainingContext(_PublisherMixin, RequestContext):
             lr=None if lr is None else float(lr),
             it_s=None if it_s is None else float(it_s),
             eta_s=None if eta_s is None else float(eta_s),
+            val_loss=None if val_loss is None else float(val_loss),
+            best_step=None if best_step is None else int(best_step),
+            advice=advice if advice is None else str(advice),
         )
         payload = {k: v for k, v in msgspec.to_builtins(metric).items() if v is not None}
         self._emit_event("request.training_metric", payload)

--- a/tests/test_executor_progress_events.py
+++ b/tests/test_executor_progress_events.py
@@ -173,3 +173,40 @@ def test_training_metric_unthrottled_payload_shape() -> None:
         "lr": 2e-5, "it_s": 1.7, "eta_s": 57.1,
     }
     assert all(e["request_id"] == "r1" for e in metrics)
+
+
+def test_training_metric_val_fields_flow() -> None:
+    """pgw#459: val_loss/best_step/advice ride the typed payload; absent
+    when not passed (never null)."""
+    captured: List[Dict] = []
+    ctx = TrainingContext(request_id="r1", emitter=captured.append)
+    ctx.metric_min_interval_s = 0.0
+    ctx.training_metric(step=1, total=100, loss=0.9)
+    ctx.training_metric(step=50, total=100, loss=0.4,
+                        val_loss=0.45, best_step=50,
+                        advice="val improving")
+    metrics = [e for e in captured if e["type"] == "request.training_metric"]
+    assert len(metrics) == 2
+    plain, val = metrics[0]["payload"], metrics[1]["payload"]
+    assert "val_loss" not in plain and "best_step" not in plain and "advice" not in plain
+    assert val == {
+        "step": 50, "total": 100, "loss": 0.4,
+        "val_loss": 0.45, "best_step": 50, "advice": "val improving",
+    }
+
+
+def test_training_metric_val_bypasses_throttle() -> None:
+    """pgw#459: a mid-run metric carrying val_loss always emits, even inside
+    the min-interval window; plain mid-run metrics still throttle."""
+    captured: List[Dict] = []
+    ctx = TrainingContext(request_id="r1", emitter=captured.append)
+    # Default 5s throttle; all calls land within the same window.
+    ctx.training_metric(step=1, total=100, loss=1.0)          # first: emits
+    ctx.training_metric(step=2, total=100, loss=0.9)          # throttled
+    ctx.training_metric(step=3, total=100, loss=0.8,
+                        val_loss=0.85, best_step=3)           # val: bypasses
+    ctx.training_metric(step=4, total=100, loss=0.7)          # throttled
+    ctx.training_metric(step=100, total=100, loss=0.1)        # last: emits
+    steps = [e["payload"]["step"] for e in captured
+             if e["type"] == "request.training_metric"]
+    assert steps == [1, 3, 100]

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.4"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Extends the typed training-metric channel (pgw#450) for validation:

- `TrainingMetric` gains optional `val_loss: float`, `best_step: int`, `advice: str` (msgspec frozen struct; None fields still omitted on the wire).
- `TrainingContext.training_metric(...)` accepts the three new kwargs.
- Any event carrying `val_loss` BYPASSES the 5s min-interval throttle, like first/last already do — val points are sparse and every one must reach the hub.
- Emitter-capture tests (gw#438 harness): new-field payload shape + absent-when-not-passed, and mid-window val bypass while plain mid-run metrics still throttle.

Counterpart: tensorhub th#696 persists these through `job.training.metric` and serves the val series + recommended checkpoint.

Full suite: 643 passed / 10 skipped.