### PR TITLE
gw(th#697 P1): precision-class/placement model + publish-time placement stamping

### DIFF
--- a/src/gen_worker/convert/publish.py
+++ b/src/gen_worker/convert/publish.py
@@ -12,8 +12,47 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from ..models.ladder import (
+    CLASS_BASE,
+    Placement,
+    classify_flavor_token,
+    default_placement,
+    placement_to_metadata,
+)
 from .hub import CommitFile, CommitResult, HubClient, files_from_tree
 from .produced import ProducedFlavor
+
+_PLACEMENT_ATTR_KEYS = ("placement_sm_allowed", "placement_sm_min", "placement_engines")
+
+
+def _csv_ints(raw: str) -> tuple[int, ...]:
+    return tuple(int(v) for v in (s.strip() for s in raw.split(",")) if v)
+
+
+def _csv_strs(raw: str) -> tuple[str, ...]:
+    return tuple(v for v in (s.strip() for s in raw.split(",")) if v)
+
+
+def _placement_block(attrs: Mapping[str, str], label: str) -> dict[str, Any] | None:
+    """th#697: the placement stamp — arch requirements the SKU-aware
+    precision ladder reads back at resolution. Derived from the flavor
+    token's class defaults; producers may override via explicit
+    ``precision_class`` / ``placement_*`` attrs. Base rows stay unstamped
+    (bare = runs wherever it fits, by definition)."""
+    explicit = any(attrs.get(k) for k in _PLACEMENT_ATTR_KEYS)
+    cls = str(attrs.get("precision_class", "") or "").strip().lower()
+    cls = cls or classify_flavor_token(label)
+    if not cls or (cls == CLASS_BASE and not explicit):
+        return None
+    p = default_placement(cls) or Placement(cls)
+    if explicit:
+        p = Placement(
+            cls,
+            sm_allowed=_csv_ints(attrs.get("placement_sm_allowed", "")) or p.sm_allowed,
+            sm_min=int(attrs.get("placement_sm_min", "") or 0) or p.sm_min,
+            engines=_csv_strs(attrs.get("placement_engines", "")) or p.engines,
+        )
+    return placement_to_metadata(p)
 
 
 def _flavor_files(flavor: ProducedFlavor) -> list[CommitFile]:
@@ -69,6 +108,12 @@ def publish_flavors(
             for k in ("quantization_method", "quantization_library")
             if attrs.get(k)
         }
+        placement = _placement_block(attrs, label)
+        meta = {**(dict(metadata) if metadata else {}), **attrs}
+        for k in _PLACEMENT_ATTR_KEYS:
+            meta.pop(k, None)
+        if placement:
+            meta["placement"] = placement
         results.append(client.commit(
             destination_repo=dest,
             files=_flavor_files(flavor),
@@ -79,7 +124,7 @@ def publish_flavors(
             dtype=attrs.get("dtype", ""),
             file_layout=attrs.get("file_layout", ""),
             file_type=attrs.get("file_type", ""),
-            metadata={**(dict(metadata) if metadata else {}), **attrs},
+            metadata=meta,
             provenance=provenance,
         ))
     return results

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -1,0 +1,132 @@
+"""Precision-ladder spec (th#697) — flavor precision classes + placement requirements.
+
+A flavor's *precision class* names its quantization lane (``fp8``,
+``svdq-int4``, ...). A :class:`Placement` states which silicon can run it:
+a discrete SM allow-list (fail-closed — kernel wheels are per-arch), an
+open-ended SM floor, and the importable engine libraries the lane needs.
+
+Produced flavors carry their placement in ``checkpoints.metadata["placement"]``
+(stamped at publish by :func:`gen_worker.convert.publish.publish_flavors`).
+Unstamped/mirrored rows fall back to the token-derived defaults here — the
+same defaults the stamping writes, so both paths agree. The ladder walk
+itself (rung ordering per arch class) lands with the shared Go+Py vector
+spec; this module is the classification + placement half both sides share.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from .svdq import SVDQ_FP4_SMS, SVDQ_INT4_SMS
+
+CLASS_BASE = "base"  # bare bf16/fp16/fp32 row — runs anywhere a card fits it
+CLASS_FP8 = "fp8"  # fp8-E4M3 storage; universal (bf16-upcast path needs no fp8 silicon)
+CLASS_SVDQ_FP4 = "svdq-fp4"  # nunchaku SVDQuant fp4 — consumer Blackwell only
+CLASS_SVDQ_INT4 = "svdq-int4"  # nunchaku SVDQuant int4 — sm_75-89
+CLASS_NVFP4 = "nvfp4"  # plain nvfp4 artifact — Blackwell datacenter, TRT lane (not a diffusers rung)
+
+_BASE_TOKENS = ("", "bf16", "fp16", "fp32")
+
+
+@dataclass(frozen=True)
+class Placement:
+    """Arch requirements for one flavor. Empty fields = unconstrained."""
+
+    precision_class: str
+    sm_allowed: tuple[int, ...] = ()  # discrete allow-list (gpu_sm as int, e.g. 89, 120)
+    sm_min: int = 0  # open-ended floor; 0 = none
+    engines: tuple[str, ...] = ()  # importable libraries required to load
+
+    def admits_sm(self, gpu_sm: int) -> bool:
+        if self.sm_allowed and gpu_sm not in self.sm_allowed:
+            return False
+        if self.sm_min and gpu_sm < self.sm_min:
+            return False
+        return True
+
+
+def classify_flavor_token(flavor: str) -> str:
+    """Flavor token -> precision class; "" when unrecognized (gguf/trt/etc.
+    stay opaque — never ladder rungs)."""
+    token = str(flavor or "").strip().lower()
+    if token in _BASE_TOKENS:
+        return CLASS_BASE
+    if token.startswith("svdq-fp4"):
+        return CLASS_SVDQ_FP4
+    if token.startswith("svdq-int4"):
+        return CLASS_SVDQ_INT4
+    if token == "fp8" or token.startswith("fp8-"):
+        return CLASS_FP8
+    if token == "nvfp4" or token.startswith("nvfp4-"):
+        return CLASS_NVFP4
+    return ""
+
+
+def default_placement(precision_class: str) -> Optional[Placement]:
+    """Token-derived placement defaults — the fallback for unstamped rows
+    and the source the publish-time stamp writes."""
+    if precision_class == CLASS_BASE:
+        return Placement(CLASS_BASE)
+    if precision_class == CLASS_FP8:
+        return Placement(CLASS_FP8)  # fp8-storage serves on any silicon
+    if precision_class == CLASS_SVDQ_FP4:
+        return Placement(CLASS_SVDQ_FP4, sm_allowed=tuple(SVDQ_FP4_SMS), engines=("nunchaku",))
+    if precision_class == CLASS_SVDQ_INT4:
+        return Placement(CLASS_SVDQ_INT4, sm_allowed=tuple(SVDQ_INT4_SMS), engines=("nunchaku",))
+    if precision_class == CLASS_NVFP4:
+        return Placement(CLASS_NVFP4, sm_min=100)
+    return None
+
+
+def placement_for_flavor(flavor: str) -> Optional[Placement]:
+    return default_placement(classify_flavor_token(flavor))
+
+
+def placement_to_metadata(p: Placement) -> dict[str, Any]:
+    """The ``checkpoints.metadata["placement"]`` wire/storage shape."""
+    out: dict[str, Any] = {"precision_class": p.precision_class}
+    if p.sm_allowed:
+        out["sm_allowed"] = list(p.sm_allowed)
+    if p.sm_min:
+        out["sm_min"] = p.sm_min
+    if p.engines:
+        out["engines"] = list(p.engines)
+    return out
+
+
+def placement_from_metadata(meta: Mapping[str, Any] | None) -> Optional[Placement]:
+    """Parse a checkpoint metadata mapping (the whole bag or the placement
+    block itself). Unknown keys ignored; malformed values fail soft (None)."""
+    if not isinstance(meta, Mapping):
+        return None
+    block = meta.get("placement", meta)
+    if not isinstance(block, Mapping):
+        return None
+    cls = str(block.get("precision_class", "") or "").strip().lower()
+    if not cls:
+        return None
+    try:
+        sm_allowed = tuple(int(v) for v in (block.get("sm_allowed") or ()))
+        sm_min = int(block.get("sm_min") or 0)
+    except (TypeError, ValueError):
+        return None
+    engines = tuple(
+        s for s in (str(e).strip() for e in (block.get("engines") or ())) if s
+    )
+    return Placement(cls, sm_allowed=sm_allowed, sm_min=sm_min, engines=engines)
+
+
+__all__ = [
+    "CLASS_BASE",
+    "CLASS_FP8",
+    "CLASS_NVFP4",
+    "CLASS_SVDQ_FP4",
+    "CLASS_SVDQ_INT4",
+    "Placement",
+    "classify_flavor_token",
+    "default_placement",
+    "placement_for_flavor",
+    "placement_from_metadata",
+    "placement_to_metadata",
+]

--- a/tests/convert/test_publish.py
+++ b/tests/convert/test_publish.py
@@ -193,3 +193,49 @@ def test_run_clone_publishing_nothing_is_an_error(
             _Ctx(fake_hub), provider="huggingface", source_ref="org/tiny",
             destination_repo="acme/dest",
         )
+
+
+def test_publish_flavors_stamps_placement(fake_hub, tmp_path: Path) -> None:
+    """th#697 P1: recognized quant flavors carry a structured `placement`
+    block in commit metadata (arch requirements the SKU-aware ladder reads
+    back); base/unknown flavors stay unstamped; explicit placement_* attrs
+    override the token-derived defaults and never leak as flat keys."""
+    _FakeHub.state["finalize_calls"] = 1
+    f = tmp_path / "weights.safetensors"
+    f.write_bytes(b"\x03" * 16)
+
+    publish_flavors(
+        _Ctx(fake_hub),
+        [
+            ProducedFlavor(
+                path=f,
+                flavor="svdq-int4-r128",
+                attributes={"quantization_method": "svdquant",
+                            "quantization_library": "nunchaku"},
+            ),
+            ProducedFlavor(path=f, flavor="fp8"),
+            ProducedFlavor(path=f, flavor="bf16"),
+            ProducedFlavor(path=f, flavor="vae-fix"),
+            ProducedFlavor(
+                path=f,
+                flavor="fp8",
+                attributes={"placement_sm_min": "89", "placement_engines": "transformer_engine"},
+            ),
+        ],
+        destination_repo="acme/dest",
+    )
+    reqs = _FakeHub.state["commit_requests"][-5:]
+    assert reqs[0]["metadata"]["placement"] == {
+        "precision_class": "svdq-int4",
+        "sm_allowed": [75, 80, 86, 89],
+        "engines": ["nunchaku"],
+    }
+    assert reqs[1]["metadata"]["placement"] == {"precision_class": "fp8"}
+    assert "placement" not in (reqs[2].get("metadata") or {})
+    assert "placement" not in (reqs[3].get("metadata") or {})
+    assert reqs[4]["metadata"]["placement"] == {
+        "precision_class": "fp8",
+        "sm_min": 89,
+        "engines": ["transformer_engine"],
+    }
+    assert "placement_sm_min" not in reqs[4]["metadata"]

--- a/tests/test_ladder.py
+++ b/tests/test_ladder.py
@@ -1,0 +1,85 @@
+"""Precision-ladder classification + placement schema (th#697 P1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models.ladder import (
+    CLASS_BASE,
+    CLASS_FP8,
+    CLASS_NVFP4,
+    CLASS_SVDQ_FP4,
+    CLASS_SVDQ_INT4,
+    Placement,
+    classify_flavor_token,
+    default_placement,
+    placement_for_flavor,
+    placement_from_metadata,
+    placement_to_metadata,
+)
+from gen_worker.models.svdq import SVDQ_FP4_SMS, SVDQ_INT4_SMS
+
+
+@pytest.mark.parametrize(
+    "token,cls",
+    [
+        ("", CLASS_BASE),
+        ("bf16", CLASS_BASE),
+        ("fp16", CLASS_BASE),
+        ("fp8", CLASS_FP8),
+        ("FP8", CLASS_FP8),
+        ("svdq-fp4-r128", CLASS_SVDQ_FP4),
+        ("svdq-fp4-r32", CLASS_SVDQ_FP4),
+        ("svdq-int4-r128", CLASS_SVDQ_INT4),
+        ("nvfp4", CLASS_NVFP4),
+        ("gguf-q4km", ""),
+        ("trt-rtx-4090-trt10.16-fp16", ""),
+        ("vae-fix", ""),
+    ],
+)
+def test_classify_flavor_token(token: str, cls: str) -> None:
+    assert classify_flavor_token(token) == cls
+
+
+def test_default_placements_match_svdq_windows() -> None:
+    fp4 = default_placement(CLASS_SVDQ_FP4)
+    int4 = default_placement(CLASS_SVDQ_INT4)
+    assert fp4.sm_allowed == tuple(SVDQ_FP4_SMS) and fp4.engines == ("nunchaku",)
+    assert int4.sm_allowed == tuple(SVDQ_INT4_SMS) and int4.engines == ("nunchaku",)
+    # fp8-storage serves anywhere: no constraints
+    fp8 = default_placement(CLASS_FP8)
+    assert fp8.sm_allowed == () and fp8.sm_min == 0 and fp8.engines == ()
+    assert default_placement(CLASS_NVFP4).sm_min == 100
+    assert default_placement("bogus") is None
+
+
+@pytest.mark.parametrize(
+    "gpu_sm,fp4_ok,int4_ok",
+    [(120, True, False), (121, True, False), (100, False, False),
+     (90, False, False), (89, False, True), (86, False, True), (70, False, False)],
+)
+def test_admits_sm(gpu_sm: int, fp4_ok: bool, int4_ok: bool) -> None:
+    assert placement_for_flavor("svdq-fp4-r128").admits_sm(gpu_sm) is fp4_ok
+    assert placement_for_flavor("svdq-int4-r128").admits_sm(gpu_sm) is int4_ok
+    assert placement_for_flavor("fp8").admits_sm(gpu_sm) is True
+
+
+def test_metadata_roundtrip() -> None:
+    p = Placement(CLASS_SVDQ_INT4, sm_allowed=(75, 80, 86, 89), engines=("nunchaku",))
+    block = placement_to_metadata(p)
+    assert block == {
+        "precision_class": "svdq-int4",
+        "sm_allowed": [75, 80, 86, 89],
+        "engines": ["nunchaku"],
+    }
+    assert placement_from_metadata(block) == p
+    # whole checkpoint metadata bag with the block nested under "placement"
+    assert placement_from_metadata({"placement": block, "kind": "model"}) == p
+
+
+def test_metadata_parse_fails_soft() -> None:
+    assert placement_from_metadata(None) is None
+    assert placement_from_metadata({}) is None
+    assert placement_from_metadata({"placement": "fp8"}) is None
+    assert placement_from_metadata({"precision_class": ""}) is None
+    assert placement_from_metadata({"precision_class": "fp8", "sm_allowed": ["x"]}) is None

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.6"
+version = "0.13.7"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Phase 1 of th#697 (precision ladder — SKU-aware flavor resolution).

- New \`gen_worker.models.ladder\`: flavor-token → precision class; \`Placement\` arch requirements (discrete \`sm_allowed\` fail-closed for nunchaku wheels, \`sm_min\` floor, required \`engines\`); \`checkpoints.metadata["placement"]\` (de)serialization. Defaults derive from the gw#415 svdq SM windows — one source of truth.
- \`publish_flavors\` stamps a structured \`placement\` block on recognized quant flavors; producers may override via \`precision_class\`/\`placement_*\` attrs; base/unknown flavors stay unstamped. Flat \`placement_*\` attrs never leak into metadata.
- No hub write-path change needed: tensorhub's commit path already persists commit metadata into \`checkpoints.metadata\` jsonb (repo_publish.go merge-upsert); the th#697 P3 resolver reads it back, falling back to the same token-derived defaults for unstamped/mirrored rows.

Tests: \`tests/test_ladder.py\` (classification, SM admission incl. sm_90/sm_100 exclusion, roundtrip, fail-soft parse) + placement stamping vectors in \`tests/convert/test_publish.py\` against the fake hub. Full suite 666 passed / 10 skipped; ruff clean.

Part of th#697; next: shared Go+Py ladder vectors (P2), HelloAck-time resolution (P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)