### PR TITLE
gw(th#697 P2): precision-ladder walk + shared Go/Py conformance vectors

### DIFF
--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -15,8 +15,9 @@ spec; this module is the classification + placement half both sides share.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from .svdq import SVDQ_FP4_SMS, SVDQ_INT4_SMS
 
@@ -117,16 +118,188 @@ def placement_from_metadata(meta: Mapping[str, Any] | None) -> Optional[Placemen
     return Placement(cls, sm_allowed=sm_allowed, sm_min=sm_min, engines=engines)
 
 
+# ---------------------------------------------------------------------------
+# The ladder walk (th#697 P2) — shared spec with tensorhub's
+# internal/orchestrator/precision package. Both implementations must pass the
+# byte-identical tests/testdata/precision_ladder_vectors.json. Any semantic
+# change edits the vector file in BOTH repos.
+#
+# Preference per arch class (Paul's th#697 ruling): best admitted 4-bit svdq
+# flavor (fp4 > int4, rank desc) > fp8 (stored artifact > cast-at-load) >
+# bf16 base. Rung gates: quality floor, placement SM admission, engines
+# within installed libs, est VRAM <= free. local=True appends emergency-nf4
+# then CPU-offload (the hub never schedules those).
+# ---------------------------------------------------------------------------
+
+CAST_FP8_VRAM_FACTOR = 0.75  # pipeline-level est, gw#389 measured 62-76%
+EMERGENCY_NF4_VRAM_FACTOR = 0.45  # matches loading.EMERGENCY_FIT_FACTOR
+
+MODE_NATIVE = "native"
+MODE_EMERGENCY = "emergency"
+MODE_OFFLOAD = "offload"
+
+REFUSE_NO_GPU = "no_cuda_gpu"
+REFUSE_NO_RUNG = "no_runnable_precision"
+
+# quality rank: higher = closer to baseline quality
+_QUALITY = {CLASS_BASE: 3, CLASS_FP8: 2, CLASS_SVDQ_FP4: 1, CLASS_SVDQ_INT4: 1}
+_FLOOR_RANK = {"": 0, "4bit": 1, "fp8": 2, "bf16": 3}
+
+_RANK_RE = re.compile(r"-r(\d+)$")
+
+
+@dataclass(frozen=True)
+class FlavorRow:
+    """One catalog flavor row for the model being resolved."""
+
+    token: str
+    size_gb: float = 0.0
+    placement: Optional[Placement] = None  # stamped metadata; None -> token defaults
+
+
+@dataclass(frozen=True)
+class LadderModel:
+    """The catalog view of one bound model."""
+
+    base_size_gb: float = 0.0  # 0 = no bare/base row
+    fp8_cast_vram_gb: float = 0.0  # 0 = use CAST_FP8_VRAM_FACTOR * base
+    flavors: tuple[FlavorRow, ...] = ()
+
+
+@dataclass(frozen=True)
+class Resolution:
+    flavor: str = ""  # stored-flavor token to download ("" = bare/base ref)
+    cast: str = ""  # load-time transform: "" | "fp8" | "nf4"
+    mode: str = MODE_NATIVE
+    refusal: str = ""  # non-empty = no runnable rung (flavor/cast/mode unset)
+
+
+def _placement_of(row: FlavorRow) -> Optional[Placement]:
+    return row.placement or placement_for_flavor(row.token)
+
+
+def _admitted(row: FlavorRow, gpu_sm: int, libs: frozenset[str]) -> bool:
+    p = _placement_of(row)
+    if p is None:
+        return False
+    return p.admits_sm(gpu_sm) and all(e in libs for e in p.engines)
+
+
+def _rank_of(token: str) -> int:
+    m = _RANK_RE.search(token)
+    return int(m.group(1)) if m else 0
+
+
+def _quality_ok(precision_class: str, quality_floor: str) -> bool:
+    return _QUALITY.get(precision_class, 0) >= _FLOOR_RANK.get(quality_floor, 0)
+
+
+def _four_bit_candidates(
+    model: LadderModel, gpu_sm: int, libs: frozenset[str]
+) -> list[FlavorRow]:
+    rows = [
+        r
+        for r in model.flavors
+        if classify_flavor_token(r.token) in (CLASS_SVDQ_FP4, CLASS_SVDQ_INT4)
+        and _admitted(r, gpu_sm, libs)
+    ]
+    rows.sort(
+        key=lambda r: (
+            classify_flavor_token(r.token) != CLASS_SVDQ_FP4,  # fp4 first
+            -_rank_of(r.token),
+            r.token,
+        )
+    )
+    return rows
+
+
+def _stored_fp8(model: LadderModel, gpu_sm: int, libs: frozenset[str]) -> Optional[FlavorRow]:
+    rows = [
+        r
+        for r in model.flavors
+        if classify_flavor_token(r.token) == CLASS_FP8 and _admitted(r, gpu_sm, libs)
+    ]
+    rows.sort(key=lambda r: (len(r.token), r.token))
+    return rows[0] if rows else None
+
+
+def _rungs(
+    model: LadderModel, gpu_sm: int, libs: frozenset[str], quality_floor: str
+) -> list[tuple[str, str, float]]:
+    """Eligible native rungs in preference order (ignoring VRAM fit):
+    (flavor, cast, est_vram_gb)."""
+    out: list[tuple[str, str, float]] = []
+    if _quality_ok(CLASS_SVDQ_FP4, quality_floor):
+        for row in _four_bit_candidates(model, gpu_sm, libs):
+            out.append((row.token, "", row.size_gb))
+    if _quality_ok(CLASS_FP8, quality_floor):
+        stored = _stored_fp8(model, gpu_sm, libs)
+        if stored is not None:
+            out.append((stored.token, "", stored.size_gb))
+        elif model.base_size_gb > 0:
+            est = model.fp8_cast_vram_gb or CAST_FP8_VRAM_FACTOR * model.base_size_gb
+            out.append(("", "fp8", est))
+    if model.base_size_gb > 0 and _quality_ok(CLASS_BASE, quality_floor):
+        out.append(("", "", model.base_size_gb))
+    return out
+
+
+def resolve(
+    model: LadderModel,
+    *,
+    gpu_sm: int,
+    free_vram_gb: float,
+    libs: Iterable[str] = (),
+    quality_floor: str = "",
+    local: bool = False,
+    allow_offload: bool = True,
+) -> Resolution:
+    """Walk the precision ladder for ONE model on ONE card. The shared-spec
+    entry point — tensorhub's Go resolver implements the identical walk."""
+    if gpu_sm <= 0:
+        return Resolution(refusal=REFUSE_NO_GPU)
+    lib_set = frozenset(str(lib).strip() for lib in libs if str(lib).strip())
+    rungs = _rungs(model, gpu_sm, lib_set, quality_floor)
+    for flavor, cast, est in rungs:
+        if est <= free_vram_gb:
+            return Resolution(flavor=flavor, cast=cast, mode=MODE_NATIVE)
+    if local:
+        if quality_floor == "" and model.base_size_gb > 0:
+            est = EMERGENCY_NF4_VRAM_FACTOR * model.base_size_gb
+            if est <= free_vram_gb:
+                stored = _stored_fp8(model, gpu_sm, lib_set)
+                return Resolution(
+                    flavor=stored.token if stored else "",
+                    cast="nf4",
+                    mode=MODE_EMERGENCY,
+                )
+        if allow_offload and rungs:
+            flavor, cast, _ = rungs[0]
+            return Resolution(flavor=flavor, cast=cast, mode=MODE_OFFLOAD)
+    return Resolution(refusal=REFUSE_NO_RUNG)
+
+
 __all__ = [
+    "CAST_FP8_VRAM_FACTOR",
     "CLASS_BASE",
     "CLASS_FP8",
     "CLASS_NVFP4",
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
+    "EMERGENCY_NF4_VRAM_FACTOR",
+    "FlavorRow",
+    "LadderModel",
+    "MODE_EMERGENCY",
+    "MODE_NATIVE",
+    "MODE_OFFLOAD",
     "Placement",
+    "REFUSE_NO_GPU",
+    "REFUSE_NO_RUNG",
+    "Resolution",
     "classify_flavor_token",
     "default_placement",
     "placement_for_flavor",
     "placement_from_metadata",
     "placement_to_metadata",
+    "resolve",
 ]

--- a/tests/test_precision_ladder_vectors.py
+++ b/tests/test_precision_ladder_vectors.py
@@ -1,0 +1,65 @@
+"""Shared precision-ladder conformance vectors (th#697).
+
+tests/testdata/precision_ladder_vectors.json is vendored byte-identically in
+tensorhub (internal/orchestrator/precision/testdata/) — the Go resolver runs
+the SAME file. Any ladder semantic change edits both copies.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gen_worker.models.ladder import (
+    FlavorRow,
+    LadderModel,
+    placement_from_metadata,
+    resolve,
+)
+
+_VECTORS = json.loads(
+    (Path(__file__).parent / "testdata" / "precision_ladder_vectors.json").read_text()
+)["vectors"]
+
+
+def _model(spec: dict) -> LadderModel:
+    rows = tuple(
+        FlavorRow(
+            token=token,
+            size_gb=float(row.get("size_gb", 0.0)),
+            placement=placement_from_metadata(row.get("placement")),
+        )
+        for token, row in (spec.get("flavors") or {}).items()
+    )
+    return LadderModel(
+        base_size_gb=float(spec.get("base_size_gb", 0.0)),
+        fp8_cast_vram_gb=float(spec.get("fp8_cast_vram_gb", 0.0)),
+        flavors=rows,
+    )
+
+
+@pytest.mark.parametrize("vec", _VECTORS, ids=[v["name"] for v in _VECTORS])
+def test_precision_ladder_vector(vec: dict) -> None:
+    got = resolve(
+        _model(vec["model"]),
+        gpu_sm=int(vec["gpu_sm"]),
+        free_vram_gb=float(vec["free_vram_gb"]),
+        libs=vec.get("libs") or (),
+        quality_floor=str(vec.get("quality_floor", "")),
+        local=bool(vec.get("local", False)),
+        allow_offload=bool(vec.get("allow_offload", True)),
+    )
+    expect = vec["expect"]
+    if expect.get("refusal"):
+        assert got.refusal == expect["refusal"], got
+    else:
+        assert got.refusal == "", got
+        assert got.flavor == expect.get("flavor", ""), got
+        assert got.cast == expect.get("cast", ""), got
+        assert got.mode == expect.get("mode", "native"), got
+
+
+def test_vector_count_guard() -> None:
+    assert len(_VECTORS) >= 25

--- a/tests/testdata/precision_ladder_vectors.json
+++ b/tests/testdata/precision_ladder_vectors.json
@@ -1,0 +1,203 @@
+{
+  "_comment": "th#697 shared precision-ladder conformance vectors. This file is vendored BYTE-IDENTICALLY in tensorhub (internal/orchestrator/precision/testdata/) and python-gen-worker (tests/testdata/) — the Go resolver and gen_worker.models.ladder.resolve must produce identical outcomes for every vector; any spec change edits BOTH copies. Spec: walk [best admitted 4-bit svdq flavor (fp4>int4, rank desc)] -> [fp8 stored > fp8 cast-at-load (est = fp8_cast_vram_gb else 0.75*base_size_gb)] -> [bf16 base]; each rung gated by quality floor (bf16=3 > fp8=2 > 4bit=1; ''=any), placement SM admission (checkpoint metadata placement block wins, else flavor-token defaults: svdq-fp4 sm 120/121, svdq-int4 sm 75-89, engines nunchaku; fp8/base universal), required engines within libs, and est_vram_gb <= free_vram_gb. local=true appends emergency-nf4 (quality_floor must be '', est 0.45*base, artifact = stored fp8 if admitted else base, cast=nf4) then offload (first arch/engine-eligible rung ignoring fit, requires allow_offload). No rung -> refusal no_runnable_precision; gpu_sm<=0 -> refusal no_cuda_gpu. nvfp4-class flavors are never diffusers rungs (TRT lane).",
+  "vectors": [
+    {
+      "name": "blackwell-5090-svdq-fp4-present",
+      "gpu_sm": 120, "free_vram_gb": 31.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}, "svdq-int4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "svdq-fp4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "blackwell-prefers-higher-rank",
+      "gpu_sm": 121, "free_vram_gb": 31.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r32": {"size_gb": 3.5}, "svdq-fp4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "svdq-fp4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "blackwell-int4-not-admitted-falls-to-fp8-stored",
+      "gpu_sm": 120, "free_vram_gb": 31.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "blackwell-no-nunchaku-lib-falls-to-fp8",
+      "gpu_sm": 120, "free_vram_gb": 31.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "b200-sm100-svdq-never-fp8-stored",
+      "gpu_sm": 100, "free_vram_gb": 170.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "hopper-h100-fp8-stored",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "hopper-h100-fp8-cast-when-no-artifact",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "hopper-svdq-not-admitted-sm90",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}, "svdq-fp4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "ada-4090-svdq-int4-present",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "svdq-int4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "ada-4090-fp4-not-admitted-int4-absent",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "ampere-3090-svdq-int4-admitted",
+      "gpu_sm": 86, "free_vram_gb": 23.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r32": {"size_gb": 3.5}}},
+      "expect": {"flavor": "svdq-int4-r32", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "old-card-sm70-fp8-cast",
+      "gpu_sm": 70, "free_vram_gb": 30.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "quality-floor-bf16-pins-base",
+      "gpu_sm": 120, "free_vram_gb": 31.0, "libs": ["nunchaku"], "quality_floor": "bf16",
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "quality-floor-fp8-excludes-4bit",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"], "quality_floor": "fp8",
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "quality-floor-bf16-unfittable-refuses",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": [], "quality_floor": "bf16",
+      "model": {"base_size_gb": 32.3, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"refusal": "no_runnable_precision"}
+    },
+    {
+      "name": "fit-bf16-too-big-fp8-cast-fits",
+      "gpu_sm": 90, "free_vram_gb": 40.0, "libs": [],
+      "model": {"base_size_gb": 58.0, "fp8_cast_vram_gb": 39.0, "flavors": {}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "fit-cast-factor-default-applies",
+      "gpu_sm": 90, "free_vram_gb": 10.0, "libs": [],
+      "model": {"base_size_gb": 12.0, "flavors": {}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "fit-nothing-fits-hub-refuses",
+      "gpu_sm": 89, "free_vram_gb": 8.0, "libs": [],
+      "model": {"base_size_gb": 32.3, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"refusal": "no_runnable_precision"}
+    },
+    {
+      "name": "local-emergency-nf4-downloads-stored-fp8",
+      "gpu_sm": 89, "free_vram_gb": 15.0, "libs": [], "local": true,
+      "model": {"base_size_gb": 32.3, "fp8_cast_vram_gb": 24.0, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"flavor": "fp8", "cast": "nf4", "mode": "emergency"}
+    },
+    {
+      "name": "local-emergency-nf4-from-base-when-no-fp8",
+      "gpu_sm": 89, "free_vram_gb": 15.0, "libs": [], "local": true,
+      "model": {"base_size_gb": 32.3, "flavors": {}},
+      "expect": {"flavor": "", "cast": "nf4", "mode": "emergency"}
+    },
+    {
+      "name": "local-emergency-respects-quality-floor",
+      "gpu_sm": 89, "free_vram_gb": 15.0, "libs": [], "local": true, "quality_floor": "fp8",
+      "model": {"base_size_gb": 32.3, "fp8_cast_vram_gb": 24.0, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "offload"}
+    },
+    {
+      "name": "local-offload-when-even-nf4-does-not-fit",
+      "gpu_sm": 89, "free_vram_gb": 6.0, "libs": [], "local": true,
+      "model": {"base_size_gb": 32.3, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "offload"}
+    },
+    {
+      "name": "local-offload-forbidden-refuses",
+      "gpu_sm": 89, "free_vram_gb": 6.0, "libs": [], "local": true, "allow_offload": false, "quality_floor": "fp8",
+      "model": {"base_size_gb": 32.3, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"refusal": "no_runnable_precision"}
+    },
+    {
+      "name": "local-offload-picks-preference-order-head",
+      "gpu_sm": 120, "free_vram_gb": 2.0, "libs": ["nunchaku"], "local": true, "quality_floor": "fp8",
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-fp4-r128": {"size_gb": 3.9}, "fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "offload"}
+    },
+    {
+      "name": "metadata-placement-overrides-token-defaults",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9, "placement": {"precision_class": "svdq-int4", "sm_allowed": [89, 90], "engines": ["nunchaku"]}}}},
+      "expect": {"flavor": "svdq-int4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "metadata-placement-engines-gate",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9, "placement": {"precision_class": "svdq-int4", "sm_allowed": [89], "engines": ["nunchaku"]}}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "nvfp4-flavor-is-never-a-diffusers-rung",
+      "gpu_sm": 120, "free_vram_gb": 31.0, "libs": ["nunchaku", "tensorrt"],
+      "model": {"base_size_gb": 12.2, "flavors": {"nvfp4": {"size_gb": 3.4}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "unknown-flavor-tokens-ignored",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"trt-rtx-4090-trt10.16-fp16": {"size_gb": 6.0}, "vae-fix": {"size_gb": 0.2}}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "no-base-no-fp8-artifact-svdq-only-model",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 0, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "svdq-int4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "no-base-hopper-nothing-runnable",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 0, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}}},
+      "expect": {"refusal": "no_runnable_precision"}
+    },
+    {
+      "name": "no-gpu-refuses",
+      "gpu_sm": 0, "free_vram_gb": 0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"refusal": "no_cuda_gpu"}
+    },
+    {
+      "name": "stored-fp8-preferred-over-cast",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "higher-rank-wins-among-int4",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"],
+      "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r32": {"size_gb": 3.5}, "svdq-int4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "svdq-int4-r128", "cast": "", "mode": "native"}
+    }
+  ]
+}


### PR DESCRIPTION
Phase 2 of th#697. Adds the ladder walk to \`gen_worker.models.ladder\`:

- \`resolve(model, gpu_sm, free_vram_gb, libs, quality_floor, local, allow_offload)\` → \`Resolution{flavor, cast, mode}\` or typed refusal.
- Preference per the th#697 ruling: best admitted 4-bit svdq flavor (fp4>int4, rank desc) → fp8 (stored artifact > cast-at-load, est 0.75×base overridable) → bf16 base; every rung gated by quality floor, placement SM admission (stamped metadata wins, token defaults fall back), engine libs, VRAM fit.
- Local-only rungs: emergency-nf4 (0.45×base, floor must be unset, downloads stored #fp8 when admitted) → CPU-offload. The hub never schedules them.
- \`tests/testdata/precision_ladder_vectors.json\` (32 vectors: Blackwell/B200/Hopper/Ada/Ampere/sm70 × flavor presence × floors × local rungs × metadata overrides × refusals) is vendored byte-identically in tensorhub \`internal/orchestrator/precision/testdata/\` — the Go resolver (tensorhub PR, same lane) passes the identical file. sha256 b5923d35…

Tests green (56 ladder tests + full suite in P1 CI), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)