### PR TITLE
clone: normalize cast-tree filenames to canonical diffusers names (variant shard-index unloadable)

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
+import json
 import logging
 import os
 import re
@@ -151,6 +152,62 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
 # Flavor tree construction
 # ---------------------------------------------------------------------------
 
+_CAST_NORMALIZE_DTYPES = {"fp16", "bf16", "fp32", "f16", "f32"}
+
+_VARIANT_WEIGHT_NAME_RE = re.compile(
+    r"^(?P<base>.+)\.(?P<v>fp16|bf16|fp32)"
+    r"(?P<shard>-\d{5}-of-\d{5})?\.safetensors(?P<idx>\.index\.json)?$"
+)
+
+
+def _normalize_variant_filenames(tree: Path) -> None:
+    """Strip dtype-variant tokens from published weight filenames.
+
+    dtype is a checkpoint axis (flavor) in repo-cas — one dtype per tree — so
+    HF variant suffixes are redundant, and the resharder composes an index
+    name diffusers cannot find (J23 live: juggernaut-xl published
+    "diffusion_pytorch_model.fp16.safetensors.index.json" where diffusers'
+    _add_variant expects "diffusion_pytorch_model.safetensors.index.fp16.json";
+    variant=fp16 serve setup died). Canonical names sidestep the class.
+    A directory whose canonical twin already exists is left untouched
+    (dual-dtype upstream trees must not collide). Quant flavors (fp8/int4/…)
+    are never normalized — their names carry loader semantics."""
+    dirs = sorted({p.parent for p in tree.rglob("*.safetensors*") if p.is_file()})
+    for d in dirs:
+        renames: dict[str, str] = {}
+        for p in sorted(d.iterdir()):
+            m = _VARIANT_WEIGHT_NAME_RE.match(p.name)
+            if not m:
+                continue
+            new_name = f"{m['base']}{m['shard'] or ''}.safetensors{m['idx'] or ''}"
+            if (d / new_name).exists():
+                renames.clear()
+                break
+            renames[p.name] = new_name
+        for old_name, new_name in renames.items():
+            (d / old_name).rename(d / new_name)
+        if not renames:
+            continue
+        for idx in d.glob("*.safetensors.index.json"):
+            try:
+                payload = json.loads(idx.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                continue
+            weight_map = payload.get("weight_map")
+            if not isinstance(weight_map, dict):
+                continue
+            changed = False
+            for key, shard in weight_map.items():
+                if shard in renames:
+                    weight_map[key] = renames[shard]
+                    changed = True
+            if changed:
+                idx.write_text(
+                    json.dumps(payload, separators=(",", ":"), sort_keys=True),
+                    encoding="utf-8",
+                )
+
+
 def _stage_oversize_safetensors(tree: Path) -> None:
     """Replace any >5 GB safetensors in the tree with HF-convention byte-offset
     shards + index (raw copy, no decode)."""
@@ -212,6 +269,8 @@ def build_flavor_tree(
         attrs["dtype"] = source_dtype
         copy_non_weight_files(source_dir, out_dir, skip_components=set())
         _stage_oversize_safetensors(out_dir)
+        if source_dtype in _CAST_NORMALIZE_DTYPES:
+            _normalize_variant_filenames(out_dir)
         return out_dir, attrs
 
     # GGUF: single-artifact container.
@@ -258,6 +317,8 @@ def build_flavor_tree(
     if spec.dtype == source_dtype and work_root is source_dir:
         copy_non_weight_files(source_dir, out_dir, skip_components=set())
         _stage_oversize_safetensors(out_dir)
+        if spec.dtype in _CAST_NORMALIZE_DTYPES:
+            _normalize_variant_filenames(out_dir)
         return out_dir, attrs
 
     # Dtype conversion per weight set.
@@ -303,6 +364,8 @@ def build_flavor_tree(
 
     copy_non_weight_files(work_root, out_dir, skip_components=converted)
     _stage_oversize_safetensors(out_dir)
+    if spec.dtype in _CAST_NORMALIZE_DTYPES:
+        _normalize_variant_filenames(out_dir)
     if work_root is not source_dir:
         shutil.rmtree(work_root, ignore_errors=True)
     return out_dir, attrs

--- a/tests/convert/test_normalize_variant_filenames.py
+++ b/tests/convert/test_normalize_variant_filenames.py
@@ -1,0 +1,75 @@
+"""Published cast trees carry canonical diffusers filenames (no variant
+tokens). Found live (J23 cloud validation): the passthrough+reshard path
+published juggernaut-xl's sharded unet index as
+``diffusion_pytorch_model.fp16.safetensors.index.json`` — diffusers'
+``_add_variant`` looks for ``diffusion_pytorch_model.safetensors.index.fp16.json``,
+so ``variant="fp16"`` serve loads failed."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gen_worker.convert.clone import _normalize_variant_filenames
+
+
+def _mk(tree: Path, rel: str, data: bytes = b"x") -> Path:
+    p = tree / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return p
+
+
+class TestNormalizeVariantFilenames:
+    def test_sharded_variant_unet_and_index(self, tmp_path: Path) -> None:
+        _mk(tmp_path, "unet/diffusion_pytorch_model.fp16-00001-of-00002.safetensors")
+        _mk(tmp_path, "unet/diffusion_pytorch_model.fp16-00002-of-00002.safetensors")
+        idx = _mk(
+            tmp_path, "unet/diffusion_pytorch_model.fp16.safetensors.index.json",
+            json.dumps({
+                "metadata": {"total_size": 2},
+                "weight_map": {
+                    "a": "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+                    "b": "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+                },
+            }).encode(),
+        )
+        del idx
+        _normalize_variant_filenames(tmp_path)
+        unet = tmp_path / "unet"
+        assert (unet / "diffusion_pytorch_model-00001-of-00002.safetensors").exists()
+        assert (unet / "diffusion_pytorch_model-00002-of-00002.safetensors").exists()
+        canon_idx = unet / "diffusion_pytorch_model.safetensors.index.json"
+        assert canon_idx.exists()
+        assert not (unet / "diffusion_pytorch_model.fp16.safetensors.index.json").exists()
+        wm = json.loads(canon_idx.read_text())["weight_map"]
+        assert wm == {
+            "a": "diffusion_pytorch_model-00001-of-00002.safetensors",
+            "b": "diffusion_pytorch_model-00002-of-00002.safetensors",
+        }
+
+    def test_plain_variant_files(self, tmp_path: Path) -> None:
+        _mk(tmp_path, "text_encoder/model.fp16.safetensors")
+        _mk(tmp_path, "vae/diffusion_pytorch_model.bf16.safetensors")
+        _normalize_variant_filenames(tmp_path)
+        assert (tmp_path / "text_encoder/model.safetensors").exists()
+        assert (tmp_path / "vae/diffusion_pytorch_model.safetensors").exists()
+
+    def test_canonical_names_untouched(self, tmp_path: Path) -> None:
+        _mk(tmp_path, "unet/diffusion_pytorch_model.safetensors")
+        _mk(tmp_path, "unet/config.json")
+        _normalize_variant_filenames(tmp_path)
+        assert (tmp_path / "unet/diffusion_pytorch_model.safetensors").exists()
+
+    def test_canonical_twin_blocks_directory(self, tmp_path: Path) -> None:
+        # A dual-dtype tree must not collapse: leave the whole dir alone.
+        _mk(tmp_path, "unet/diffusion_pytorch_model.safetensors", b"fp32")
+        _mk(tmp_path, "unet/diffusion_pytorch_model.fp16.safetensors", b"fp16")
+        _normalize_variant_filenames(tmp_path)
+        assert (tmp_path / "unet/diffusion_pytorch_model.fp16.safetensors").exists()
+        assert (tmp_path / "unet/diffusion_pytorch_model.safetensors").read_bytes() == b"fp32"
+
+    def test_quant_tokens_not_matched(self, tmp_path: Path) -> None:
+        _mk(tmp_path, "transformer/diffusion_pytorch_model.fp8.safetensors")
+        _normalize_variant_filenames(tmp_path)
+        assert (tmp_path / "transformer/diffusion_pytorch_model.fp8.safetensors").exists()


### PR DESCRIPTION
## Bug (found live — J23 sdxl-illustrious cloud validation)

`clone-huggingface` of `RunDiffusion/Juggernaut-XL-v9` (fp16, diffusers) published a tree whose sharded unet is unloadable:

- upstream unet is a single `diffusion_pytorch_model.fp16.safetensors` (5.1GB)
- `_stage_oversize_safetensors` (2GB cap, e2e#110) reshards it with `shard_prefix = f.stem` = `diffusion_pytorch_model.fp16`
- the index is then written as `<prefix>.safetensors.index.json` → `diffusion_pytorch_model.fp16.safetensors.index.json`
- diffusers' `_add_variant` convention for a variant-sharded index is `diffusion_pytorch_model.safetensors.index.fp16.json`, so `variant="fp16"` loads fail:
  `OSError: Error no file named diffusion_pytorch_model.fp16.bin found in directory .../unet` (live worker_function_unavailable, RunPod 4090 serve pod)

Same shape shipped for `dreamshaper-xl`. Both R2 mirrors were repaired metadata-only (mode=replace commit renaming the index path; blobs untouched) by the J23 journey.

## Fix

dtype is a checkpoint **axis** (flavor) in repo-cas — one dtype per published tree — so HF variant filename tokens carry no information. Cast trees (fp16/bf16/fp32) are now normalized to canonical diffusers filenames after staging: plain weight files, shards, and index renamed; index `weight_map` rewritten. This matches the shape of repackaged (`singlefile_to_diffusers`) and non-variant upstreams (e.g. `animagine-xl-3.1`), which serve fine.

Guards: quant flavors (fp8/int8/int4) never normalized (names carry loader semantics); a directory that already holds the canonical twin (dual-dtype upstream) is left untouched.

## Tests

`tests/convert/test_normalize_variant_filenames.py` — sharded index + weight_map rewrite, plain variant files, canonical untouched, dual-dtype collision guard, quant tokens ignored. `tests/convert/`: 58 passed, 5 skipped, 6 pre-existing setup errors (test_clone_network_timeouts, same on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)