### PR TITLE
gw#460: transformers-aware fp8 storage for text encoders (storage_dtype="fp8+te")

### DIFF
--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -25,7 +25,10 @@ def _clean(s: object) -> str:
 # (diffusers layerwise casting) — the universal VRAM-fit mechanism; works on
 # cards without fp8 units. Applied by the loading layer; also auto-applied
 # when the snapshot itself stores fp8 (an `#fp8` flavor artifact).
-STORAGE_DTYPES: tuple[str, ...] = ("fp8",)
+# "fp8+te" additionally casts the pipeline's text encoders via the
+# transformers-aware path (linear weights fp8; embeddings/norms/tied weights
+# stay at compute dtype — component fit-ladder rung 2, gw#460).
+STORAGE_DTYPES: tuple[str, ...] = ("fp8", "fp8+te")
 
 
 def _clean_storage_dtype(v: object) -> str:

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -214,12 +214,163 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
 # tolerates fp8-E4M3 weight rounding; text encoders / VAE stay at compute
 # precision (quality-safe default, QUANTIZATION-POLICY.md component policy).
 _FP8_STORAGE_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+# The "+te" rung (component fit-ladder rung 2): the pipeline's text encoders.
+_FP8_TEXT_ENCODER_COMPONENTS: tuple[str, ...] = (
+    "text_encoder", "text_encoder_2", "text_encoder_3",
+)
+
+class _Fp8WeightWindow:
+    """Weight-only fp8 storage for one transformer block: the block's
+    Linear/conv WEIGHTS live in fp8 at rest; a forward-pre hook upcasts them
+    to the compute dtype for the whole block forward and a forward hook
+    recasts after. Everything else in the block (norms, embeddings, biases,
+    raw parameters) never leaves compute precision.
+
+    Block-window (not per-leaf-layer) granularity is what makes this safe for
+    transformers models, which — unlike diffusers denoisers — read weight
+    dtype and touch weights OUTSIDE the owning leaf's forward (gw#460):
+    Gemma3's embed-scale multiply runs on the embedding output, and T5's
+    ``T5DenseActDense`` casts ACTIVATIONS to ``self.wo.weight.dtype`` before
+    calling ``wo``, so a leaf-hooked (diffusers-style) ``wo`` still poisons
+    the stream with fp8. Inside a block window every dtype read sees the
+    compute dtype. Transient cost: one block resident at compute dtype."""
+
+    def __init__(self, params: List[Any], storage: Any, compute: Any) -> None:
+        self._params = params
+        self._storage = storage
+        self._compute = compute
+
+    def install(self, block: Any) -> None:
+        for p in self._params:
+            p.data = p.data.to(self._storage)
+        block.register_forward_pre_hook(self._pre)
+        block.register_forward_hook(self._post)
+
+    def _pre(self, module: Any, args: Any) -> None:
+        for p in self._params:
+            p.data = p.data.to(self._compute)
+
+    def _post(self, module: Any, args: Any, output: Any) -> None:
+        for p in self._params:
+            p.data = p.data.to(self._storage)
 
 
-def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None) -> bool:
+def _fp8_block_windows(mod: Any) -> List[tuple[str, Any, List[Any]]]:
+    """(name, block, castable params) per repeated transformer block: the
+    children of top-level ``nn.ModuleList`` containers (``model.layers``,
+    ``encoder.block``, vision-tower layers, ...). Castable = Linear/conv
+    weights not shared with any module outside a block (tied lm_head /
+    embedding weights stay at compute dtype). Parameters outside blocks —
+    embeddings, final norms, poolers, lm_head — are never cast."""
+    import torch.nn as nn
+
+    castable_types = (
+        nn.Linear, nn.Conv1d, nn.Conv2d, nn.Conv3d,
+        nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d,
+    )
+    list_names = [n for n, m in mod.named_modules() if isinstance(m, nn.ModuleList)]
+    top = [n for n in list_names
+           if not any(n != o and n.startswith(o + ".") for o in list_names)]
+
+    blocks: List[tuple[str, Any]] = []
+    seen_blocks: set[int] = set()
+    for name in top:
+        ml = mod.get_submodule(name)
+        for i, block in enumerate(ml):
+            if id(block) in seen_blocks:  # ALBERT-style shared blocks
+                continue
+            seen_blocks.add(id(block))
+            blocks.append((f"{name}.{i}", block))
+
+    # Any parameter reachable outside the blocks must keep compute dtype —
+    # a weight cast through a block but read elsewhere is the gw#460 break.
+    block_param_owners: Dict[int, int] = {}
+    for _, block in blocks:
+        for p in block.parameters():
+            block_param_owners[id(p)] = block_param_owners.get(id(p), 0) + 1
+    outside: set[int] = set()
+    for p in mod.parameters():
+        if id(p) not in block_param_owners:
+            outside.add(id(p))
+    for name, m in mod.named_modules():
+        in_block = any(name == bn or name.startswith(bn + ".") for bn, _ in blocks)
+        if not in_block:
+            outside.update(id(p) for p in m.parameters(recurse=False))
+
+    windows: List[tuple[str, Any, List[Any]]] = []
+    for name, block in blocks:
+        params: List[Any] = []
+        seen: set[int] = set()
+        for m in block.modules():
+            if not isinstance(m, castable_types):
+                continue
+            w = getattr(m, "weight", None)
+            if w is None or id(w) in seen or id(w) in outside:
+                continue
+            if not w.is_floating_point():
+                continue
+            seen.add(id(w))
+            params.append(w)
+        if params:
+            windows.append((name, block, params))
+    return windows
+
+
+def _apply_transformers_fp8(mod: Any, storage: Any, compute_dtype: Any) -> None:
+    """Weight-only fp8 storage for a transformers module (Gemma3/T5/CLIP-class
+    text encoders) via per-block :class:`_Fp8WeightWindow` hooks. Falls back
+    to a single whole-module window when no repeated blocks are found."""
+    windows = _fp8_block_windows(mod)
+    if not windows:
+        # No ModuleList blocks: one whole-module window (correct, but the
+        # transient upcast is the full module).
+        all_windows = _fp8_block_windows_whole(mod)
+        if not all_windows:
+            raise ValueError("no fp8-castable weights found")
+        windows = all_windows
+    total = 0
+    for _name, block, params in windows:
+        _Fp8WeightWindow(params, storage, compute_dtype).install(block)
+        total += len(params)
+    logger.info("fp8 weight windows installed: %d blocks, %d weights",
+                len(windows), total)
+
+
+def _fp8_block_windows_whole(mod: Any) -> List[tuple[str, Any, List[Any]]]:
+    import torch.nn as nn
+
+    castable_types = (
+        nn.Linear, nn.Conv1d, nn.Conv2d, nn.Conv3d,
+        nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d,
+    )
+    params: List[Any] = []
+    seen: set[int] = set()
+    shared_out: set[int] = set()
+    for m in mod.modules():
+        if not isinstance(m, castable_types):
+            shared_out.update(id(p) for p in m.parameters(recurse=False))
+    for m in mod.modules():
+        if not isinstance(m, castable_types):
+            continue
+        w = getattr(m, "weight", None)
+        if w is None or id(w) in seen or id(w) in shared_out:
+            continue
+        if not w.is_floating_point():
+            continue
+        seen.add(id(w))
+        params.append(w)
+    if not params:
+        return []
+    return [(type(mod).__name__, mod, params)]
+
+
+def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
+                      text_encoders: bool = False) -> bool:
     """fp8-E4M3 weight storage with per-layer upcast to ``compute_dtype``
     (diffusers layerwise casting) on a pipeline's denoiser — or on ``obj``
     itself when it is a bare module (th#546 two-format policy).
+    ``text_encoders=True`` (the ``storage_dtype="fp8+te"`` rung) extends the
+    cast to the pipeline's text encoders via the transformers-aware path.
 
     This is the universal VRAM-fit mechanism: fp8 bytes resident, bf16/fp16
     compute, no fp8 silicon required. Also the consumption path for stored
@@ -238,8 +389,11 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None) -> bool:
     if compute_dtype is None:
         compute_dtype = torch.bfloat16
 
+    components = _FP8_STORAGE_COMPONENTS
+    if text_encoders:
+        components += _FP8_TEXT_ENCODER_COMPONENTS
     targets: List[tuple[str, Any]] = []
-    for name in _FP8_STORAGE_COMPONENTS:
+    for name in components:
         mod = getattr(obj, name, None)
         if mod is not None and hasattr(mod, "parameters"):
             targets.append((name, mod))
@@ -251,13 +405,10 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None) -> bool:
         try:
             fn = getattr(mod, "enable_layerwise_casting", None)
             if callable(fn):
+                # diffusers ModelMixin — honors the model's own skip patterns.
                 fn(storage_dtype=storage, compute_dtype=compute_dtype)
             else:
-                from diffusers.hooks import apply_layerwise_casting
-
-                apply_layerwise_casting(
-                    mod, storage_dtype=storage, compute_dtype=compute_dtype
-                )
+                _apply_transformers_fp8(mod, storage, compute_dtype)
             applied = True
             logger.info("fp8 storage enabled on %s (compute %s)", name, compute_dtype)
         except Exception as exc:
@@ -528,10 +679,12 @@ def load_from_pretrained(
     preload, and quant-config synthesis; single-file checkpoints route through
     ``cls.from_single_file``. ``storage_dtype="fp8"`` (or an fp8-stored
     snapshot) keeps denoiser weights in fp8 storage with per-layer upcast to
-    the compute dtype; when the snapshot cannot fit free VRAM as stored, the
-    adaptive fit ladder engages runtime fp8-E4M3 storage first, then the
-    emergency nf4 rung (automatic on CUDA hosts). Used by the executor to satisfy
-    pipeline-typed ``setup()`` annotations; endpoints may also call it."""
+    the compute dtype; ``"fp8+te"`` extends that to the pipeline's text
+    encoders (transformers-aware, gw#460). When the snapshot cannot fit free
+    VRAM as stored, the adaptive fit ladder engages runtime fp8-E4M3 storage
+    first, then the emergency nf4 rung (automatic on CUDA hosts). Used by the
+    executor to satisfy pipeline-typed ``setup()`` annotations; endpoints may
+    also call it."""
     path = str(path)
     # SVDQuant/nunchaku 4-bit flavors (gw#415): self-describing snapshots take
     # the svdq lane — a nunchaku transformer swapped into the standard
@@ -570,7 +723,8 @@ def load_from_pretrained(
                 # torch-less environment (unit tests / CPU tools) — loaders
                 # that actually need torch will fail on their own terms.
                 pass
-    fp8_storage = storage_dtype == "fp8" or sniffed == "fp8"
+    fp8_storage = storage_dtype in ("fp8", "fp8+te") or sniffed == "fp8"
+    fp8_text_encoders = storage_dtype == "fp8+te"
     if not read_on_disk_quant_config(Path(path)):
         qc = synthesize_quantization_config(attrs)
         if qc is None:
@@ -596,7 +750,8 @@ def load_from_pretrained(
             kwargs.pop("quantization_config", None)
             pipe = cls.from_pretrained(path, **kwargs)
     if fp8_storage and "quantization_config" not in kwargs:
-        apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"))
+        apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"),
+                          text_encoders=fp8_text_encoders)
     return pipe
 
 

--- a/tests/test_fp8_transformers_te.py
+++ b/tests/test_fp8_transformers_te.py
@@ -1,0 +1,217 @@
+"""Transformers-aware fp8 storage for text encoders (gw#460).
+
+Root cause of the ie#371 fp8-TE break: a naive cast leaves fp8 weights where
+un-hooked transformers ops read them raw — Gemma3's embed-scale multiply
+(``super().forward(input_ids) * self.embed_scale``) is the first to explode
+(``mul_cuda not implemented for Float8_e4m3fn``). The fix is weight-only fp8:
+Linear/conv weights fp8-stored with per-module upcast at forward time;
+embeddings, norms, and anything weight-tied to them stay at compute dtype.
+
+CPU-safe: correctness of the dequant path needs no GPU. Real tiny transformers
+models (Gemma3/T5/CLIP — the TE family) + real diffusers hooks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+transformers = pytest.importorskip("transformers")
+
+from gen_worker.models.loading import apply_fp8_storage  # noqa: E402
+
+FP8 = torch.float8_e4m3fn
+
+
+def _tiny_gemma3() -> Any:
+    from transformers import Gemma3Config, Gemma3ForConditionalGeneration
+
+    cfg = Gemma3Config(
+        text_config=dict(
+            vocab_size=256, hidden_size=64, intermediate_size=128,
+            num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2,
+            head_dim=16, max_position_embeddings=128,
+        ),
+        vision_config=dict(
+            hidden_size=32, intermediate_size=64, num_hidden_layers=1,
+            num_attention_heads=2, image_size=28, patch_size=14,
+        ),
+        mm_tokens_per_image=4, image_token_index=255,
+        boi_token_index=253, eoi_token_index=254,
+    )
+    return Gemma3ForConditionalGeneration(cfg).to(torch.bfloat16).eval()
+
+
+def _tiny_t5() -> Any:
+    from transformers import T5Config, T5EncoderModel
+
+    cfg = T5Config(
+        vocab_size=256, d_model=64, d_kv=16, d_ff=128,
+        num_layers=2, num_heads=4,
+    )
+    return T5EncoderModel(cfg).to(torch.bfloat16).eval()
+
+
+def _tiny_clip() -> Any:
+    from transformers import CLIPTextConfig, CLIPTextModel
+
+    cfg = CLIPTextConfig(
+        vocab_size=256, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4,
+        max_position_embeddings=64,
+    )
+    return CLIPTextModel(cfg).to(torch.bfloat16).eval()
+
+
+def _forward(model: Any, ids: Any) -> Any:
+    with torch.no_grad():
+        out = model(input_ids=ids, attention_mask=torch.ones_like(ids),
+                    output_hidden_states=True)
+    return torch.stack(out.hidden_states, dim=-1).float()
+
+
+def _cosine(a: Any, b: Any) -> float:
+    return torch.nn.functional.cosine_similarity(
+        a.flatten(1), b.flatten(1), dim=-1
+    ).min().item()
+
+
+@pytest.mark.parametrize("factory", [_tiny_gemma3, _tiny_t5, _tiny_clip],
+                         ids=["gemma3", "t5", "clip"])
+def test_fp8_storage_forward_parity(factory) -> None:
+    """fp8-storage forward stays close to bf16 — the dequant path works for
+    the whole TE family (Gemma3 broke pre-fix; fp8 mul is unimplemented on
+    CPU too, so any raw-fp8 leak fails loudly here)."""
+    torch.manual_seed(0)
+    model = factory()
+    ids = torch.randint(0, 250, (1, 16))
+    ref = _forward(model, ids)
+
+    assert apply_fp8_storage(model, compute_dtype=torch.bfloat16) is True
+    fp8_params = [n for n, p in model.named_parameters() if p.dtype == FP8]
+    assert fp8_params, "no weights were actually cast to fp8"
+
+    out = _forward(model, ids)
+    assert _cosine(out, ref) > 0.98
+    # weights are re-stored fp8 after forward (window closed), and the
+    # model-level dtype read (transformers get_parameter_dtype — what
+    # pipelines consult for activation dtypes) still reports compute dtype.
+    assert any(p.dtype == FP8 for p in model.parameters())
+    assert model.dtype == torch.bfloat16
+
+
+def test_t5_wo_dtype_read_is_defended() -> None:
+    """T5DenseActDense casts ACTIVATIONS to ``self.wo.weight.dtype`` before
+    calling wo — outside wo's own forward. Per-leaf hooks cannot defend this
+    (fp8 activations leak); the block window upcasts wo for the whole block
+    forward. wo must be fp8 at rest AND the forward must succeed."""
+    torch.manual_seed(0)
+    model = _tiny_t5()
+    apply_fp8_storage(model, compute_dtype=torch.bfloat16)
+    wo = model.encoder.block[0].layer[1].DenseReluDense.wo
+    assert wo.weight.dtype == FP8
+    ids = torch.randint(0, 250, (1, 16))
+    out = _forward(model, ids)
+    assert out.isfinite().all()
+    assert wo.weight.dtype == FP8  # window recloses after forward
+
+
+def test_gemma3_weight_only_policy() -> None:
+    """Embeddings, norms, and the tied lm_head stay at compute dtype; linear
+    weights go fp8. lm_head shares its weight with the (skipped) token
+    embedding — casting it through the hooked side would feed raw fp8 into
+    the embedding forward (the gw#460 failure class)."""
+    model = _tiny_gemma3()
+    apply_fp8_storage(model, compute_dtype=torch.bfloat16)
+
+    embed = model.get_input_embeddings()
+    assert embed.weight.dtype == torch.bfloat16
+    assert model.lm_head.weight.dtype == torch.bfloat16
+    assert embed.weight is model.lm_head.weight  # tie preserved
+    for name, p in model.named_parameters():
+        if "norm" in name:
+            assert p.dtype == torch.bfloat16, name
+    lm = model.model.language_model
+    assert lm.layers[0].self_attn.q_proj.weight.dtype == FP8
+    assert lm.layers[0].mlp.gate_proj.weight.dtype == FP8
+
+
+def test_pipeline_te_components_opt_in() -> None:
+    """storage_dtype="fp8" touches only the denoiser; text_encoders=True (the
+    "fp8+te" rung) extends to text encoder components."""
+
+    class _Denoiser:
+        def __init__(self) -> None:
+            self.calls: list = []
+
+        def parameters(self):
+            return iter(())
+
+        def enable_layerwise_casting(self, **kw) -> None:
+            self.calls.append(kw)
+
+    class _Pipe:
+        def __init__(self) -> None:
+            self.transformer = _Denoiser()
+            self.text_encoder = _tiny_t5()
+
+    pipe = _Pipe()
+    assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16) is True
+    assert len(pipe.transformer.calls) == 1
+    assert all(p.dtype == torch.bfloat16 for p in pipe.text_encoder.parameters())
+
+    pipe = _Pipe()
+    assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16,
+                             text_encoders=True) is True
+    assert len(pipe.transformer.calls) == 1
+    assert any(p.dtype == FP8 for p in pipe.text_encoder.parameters())
+
+
+def test_binding_accepts_fp8_te() -> None:
+    from gen_worker.api.binding import HF, Hub
+
+    assert Hub("o/r", storage_dtype="fp8+te").storage_dtype == "fp8+te"
+    assert HF("o/r", storage_dtype="fp8+te").storage_dtype == "fp8+te"
+    with pytest.raises(ValueError):
+        Hub("o/r", storage_dtype="fp8+vae")
+
+
+def test_load_from_pretrained_fp8_te(tmp_path) -> None:
+    """The executor path: storage_dtype="fp8+te" reaches the TE component."""
+    import json as _json
+    import struct as _struct
+
+    from gen_worker.models.loading import load_from_pretrained
+
+    header = _json.dumps(
+        {"w": {"dtype": "BF16", "shape": [64], "data_offsets": [0, 64]}}
+    ).encode()
+    (tmp_path / "model_index.json").write_text('{"_class_name": "P"}')
+    with open(tmp_path / "diffusion_pytorch_model.safetensors", "wb") as f:
+        f.write(_struct.pack("<Q", len(header)))
+        f.write(header)
+
+    class _Denoiser:
+        def __init__(self) -> None:
+            self.calls: list = []
+
+        def parameters(self):
+            return iter(())
+
+        def enable_layerwise_casting(self, **kw) -> None:
+            self.calls.append(kw)
+
+    class _P:
+        def __init__(self) -> None:
+            self.transformer = _Denoiser()
+            self.text_encoder = _tiny_clip()
+
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: Any) -> "_P":
+            return cls()
+
+    pipe = load_from_pretrained(_P, tmp_path, dtype="bf16", storage_dtype="fp8+te")
+    assert len(pipe.transformer.calls) == 1
+    assert any(p.dtype == FP8 for p in pipe.text_encoder.parameters())


### PR DESCRIPTION
## Problem

LTX-2.3's text encoder is a 22.7 GB bf16 Gemma3; fp8 storage saves a measured ~11.3 GiB of VRAM (ie#371 smoke), but the gw#389 fp8 lane is denoiser-only, and naive casting breaks Gemma3's forward (`mul_cuda not implemented for Float8_e4m3fn`).

## Root cause (two failure classes, both CPU-reproduced)

Transformers models touch weights **outside the owning leaf module's forward**, which no per-leaf casting scheme can defend:

1. **Weight-adjacent ops on un-hooked paths** — a plain `.to(fp8)` cast fails at `modeling_gemma3.py:107`: `super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)` — `F.embedding` happily index-selects fp8 rows, then the scale multiply hits unimplemented fp8 `mul` (the exact reported error).
2. **Weight-dtype reads at rest** — `T5DenseActDense.forward` casts *activations* to `self.wo.weight.dtype` before calling `wo` (`modeling_t5.py:85-88`). With diffusers-style per-leaf hooks, `wo.weight` is fp8 at rest at read time, so fp8 activations leak into the stream (reproduced: dtype-mismatch in `F.linear`). Same genus: `PreTrainedModel.dtype` reads that pipelines consult for activation dtypes (`pipeline_ltx2.py:295`).

## Fix: block-window weight-only fp8 (our own hooks, pure torch)

One forward-pre/forward hook pair per repeated transformer block (children of top-level `nn.ModuleList`s — `model.layers`, `encoder.block`, vision-tower layers): the block's Linear/conv **weights** are fp8 at rest, upcast to compute dtype for the whole block forward, re-stored after. Inside a block window every dtype read and weight-touching op sees bf16.

- Embeddings, norms, biases, poolers, lm_head live **outside** blocks → never cast (weight-only doctrine, QUANTIZATION-POLICY component policy) → tie-safety and the `.dtype`-read leak closed by construction (first params are embeddings → `model.dtype` reports bf16).
- Params shared with anything outside the blocks are excluded (tied-weight hazard).
- Transient upcast = one block (~0.5 GiB on Gemma3-12B), so the resident saving survives.
- Diffusers denoisers keep their native `enable_layerwise_casting` path — DiT behavior unchanged.

## Surface

`storage_dtype="fp8+te"` on Hub/HF bindings extends the pipeline cast to `text_encoder{,_2,_3}` components (component fit-ladder rung 2). `"fp8"` stays denoiser-only. Flipping any endpoint remains a per-family gated ie decision.

## Tests

`tests/test_fp8_transformers_te.py` — CPU-safe, real tiny transformers models (Gemma3/T5/CLIP family): fp8-storage forward parity vs bf16 (fp8 mul is unimplemented on CPU too, so any raw-fp8 leak fails loudly), weight-only policy assertions (embeddings/norms/tied lm_head stay bf16), T5 `wo` dtype-read defense, pipeline component opt-in, binding validation, executor path.

Live H100 validation (real LTX Gemma3-12B TE, fidelity + VRAM numbers) reported on gw#460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)