### PR TITLE
gw#453: training contexts arm repo-CAS checkpoint routing; samples stay media (release 0.13.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.9 (2026-07-10)
+
+- **gw#453: training contexts arm repo-CAS checkpoint routing.** The executor
+  now populates producer contexts with `kind`, `destination_repo` (reserved
+  `payload.destination.ref` struct or flat `payload.destination_repo` scalar)
+  and the cap token's `job_id` claim, so `ctx.save_checkpoint` /
+  `open_checkpoint_stream` on `kind=training` jobs ride the job-bound repo-CAS
+  checkpoint route (multi-GB per-file grant) instead of silently falling back
+  to the media route (256 MiB/file cap — J19 run41 trained 500/500 steps then
+  died `file_too_large` publishing the final LoRA). Output-stream routing is
+  now split by artifact kind: checkpoint streams -> repo-CAS when the
+  destination scope is armed; asset streams (sample images, media outputs)
+  always -> media route under the `upload_media` grant. A training
+  `save_checkpoint` with no destination scope now fails loudly instead of
+  riding media.
+
 ## 0.13.8 (2026-07-10)
 
 - **th#683 P3: complete the serve-time adaptive-fit ladder + structured degradation events.** `plan_serve` now walks `bf16 -> fp8 -> nvfp4 -> runtime nf4 4-bit -> CPU/disk offload -> CPU-only`, picking the highest-quality lever that fits the actual card. Stored fp8/nvfp4 flavors are HW-gated (fp8 -> SM89 Ada/Hopper, nvfp4 -> SM100 Blackwell); a runtime fp8-E4M3 storage rung needs no fp8 silicon. Never refuses on the recommended-VRAM hint. New `FnDegraded` event (`{function, wanted, ran, reason, est_latency_multiplier, recommended_vram_gb}`) rides the orchestrator transport (cozy-local emits nothing; the honest-guidance advisory is the terminal surface).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.8"
+version = "0.13.9"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -56,6 +56,7 @@ from .request_context import (
     RequestContext,
     TrainingContext,
 )
+from .request_context._helpers import _decode_unverified_jwt_claims
 from .utils import lora as lora_util
 
 _CONTEXT_BY_KIND: Dict[str, type] = {
@@ -118,6 +119,36 @@ def _reserved_repo_info(payload: Any, field_name: str) -> Dict[str, Any]:
     except Exception:
         return {}
     return out if isinstance(out, dict) else {}
+
+
+def _producer_destination_repo(payload: Any, destination_info: Dict[str, Any]) -> str:
+    """Bare ``owner/repo`` the producer publishes into, or "".
+
+    The reserved struct (``payload.destination.ref``) wins; the flat
+    ``payload.destination_repo`` scalar is the wire form gen-orchestrator
+    dispatches. Tag/flavor/checkpoint selectors are stripped.
+    """
+    ref = str(destination_info.get("ref") or destination_info.get("repo") or "").strip()
+    if not ref:
+        ref = str(getattr(payload, "destination_repo", "") or "").strip()
+    for sep in (":", "@", "#"):
+        ref = ref.split(sep, 1)[0]
+    return ref.strip().strip("/")
+
+
+def _capability_job_id(token: str) -> Optional[str]:
+    """job_id claim from the worker capability token ("" claims → None).
+
+    Repo-CAS checkpoint sessions are job-bound: tensorhub requires the
+    session's job_id to equal the cap token's job_id claim (gw#453).
+    """
+    raw = str(token or "").strip()
+    if not raw:
+        return None
+    try:
+        return str(_decode_unverified_jwt_claims(raw).get("job_id") or "").strip() or None
+    except Exception:
+        return None
 
 
 def _map_exception(exc: BaseException) -> Tuple[int, str]:
@@ -1639,9 +1670,25 @@ class Executor:
         source_info = _reserved_repo_info(payload, "source") if producer else {}
         destination_info = _reserved_repo_info(payload, "destination") if producer else {}
 
+        # gw#453: arm repo-CAS checkpoint routing for producer jobs. Without
+        # kind/destination_repo/job_id the ctx's _repo_job_upload_scope() is
+        # None and save_checkpoint silently rides the media route (256 MiB
+        # cap) instead of the job-bound checkpoint grant.
+        execution_hints: Dict[str, Any] = {}
+        if run.output_mode == pb.OUTPUT_MODE_INLINE:
+            execution_hints["output_format"] = "inline"
+        job_id: Optional[str] = None
+        if producer:
+            execution_hints["kind"] = spec.kind
+            dest_repo = _producer_destination_repo(payload, destination_info)
+            if dest_repo:
+                execution_hints["destination_repo"] = dest_repo
+            job_id = _capability_job_id(run.capability_token)
+
         ctx_cls = _CONTEXT_BY_KIND.get(spec.kind, RequestContext)
         ctx = ctx_cls(
             request_id=run.request_id,
+            job_id=job_id,
             emitter=self._make_ctx_emitter(job),
             owner=run.tenant or None,
             invoker_id=run.invoker_id or None,
@@ -1663,9 +1710,7 @@ class Executor:
             },
             source_info=source_info,
             destination_info=destination_info,
-            execution_hints=(
-                {"output_format": "inline"} if run.output_mode == pb.OUTPUT_MODE_INLINE else {}
-            ),
+            execution_hints=execution_hints,
             hf_token=getattr(self._settings, "hf_token", "") or "",
         )
         job.ctx = ctx

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -99,14 +99,15 @@ class _RequestOutputStream:
         self._last_progress_uploaded = 0
         self._session_id: Optional[str] = None
         self._uploader_meta: Dict[str, Any] = {}
-        # Route all output streams (checkpoint AND asset) through the
-        # repo-CAS upload session when the job carries a destination_repo
-        # scope. Without this, clone/conversion jobs splay their non-tensor
-        # auxiliary files (README, config.json, etc.) onto /api/v1/media/:owner/uploads,
-        # which the worker cap-token does not authorize.
-        # Inference jobs have no destination_repo, so scope stays None and
-        # the media route remains the default for those.
-        self._repo_job_scope = self._ctx._repo_job_upload_scope()
+        # Split routing by artifact kind (gw#453): checkpoint streams ride
+        # the repo-CAS upload session when the job carries a destination_repo
+        # scope (job-bound create_checkpoint grant, multi-GB per-file caps);
+        # asset streams (sample images, media outputs) always ride the media
+        # route — that's what the upload_media grant authorizes and caps.
+        # Inference jobs have no destination_repo, so scope stays None.
+        self._repo_job_scope = (
+            self._ctx._repo_job_upload_scope() if self._kind == "checkpoint" else None
+        )
         self._finalized = False
         self._result: Any = None
 

--- a/tests/test_training_checkpoint_route.py
+++ b/tests/test_training_checkpoint_route.py
@@ -1,0 +1,263 @@
+"""gw#453: executor-built training contexts arm repo-CAS checkpoint routing.
+
+J19 run41 trained 500/500 steps then died publishing the final LoRA with
+file_too_large: the executor built TrainingContext with only
+``{"output_format": ...}`` hints — no kind/destination_repo/job_id — so
+``_repo_job_upload_scope()`` was always None and ``ctx.save_checkpoint`` rode
+the MEDIA route (256 MiB/file cap) instead of the repo-CAS checkpoint route
+(the job-bound create_checkpoint grant tensorhub mints for the destination
+repo at dispatch).
+
+Real codepath: a local ThreadingHTTPServer stands in for tensorhub and a real
+Executor runs a kind=training job end to end. The handler saves a checkpoint
+LARGER than the media per-file cap plus a sample asset; the test asserts the
+checkpoint rides POST /api/v1/repos/.../revisions[.../uploads] (session open
+job-bound to the cap token's job_id claim, Bearer cap-token auth) while the
+sample stays on /api/v1/media/<token-bound owner>/uploads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Dict, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker.executor import Executor, _producer_destination_repo
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+OWNER_UUID = "019f4c33-f3a5-705b-9848-0b3b0863c416"
+JOB_ID = "job-run41"
+DEST_REPO = "acme/lora-out"
+MEDIA_MAX_BYTES = 256 * 1024 * 1024  # tensorhub media route per-file cap
+REVISION_ID = "rev-453"
+
+
+def _unsigned_jwt(claims: Dict[str, Any]) -> str:
+    def seg(obj: Dict[str, Any]) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{seg({'alg': 'none', 'typ': 'JWT'})}.{seg(claims)}.sig"
+
+
+class _HubHandler(BaseHTTPRequestHandler):
+    requests_seen: ClassVar[List[Tuple[str, str, Dict[str, Any]]]] = []
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).requests_seen.append(
+            (self.path, str(self.headers.get("Authorization") or ""), body)
+        )
+        if self.path.endswith("/revisions"):
+            # Checkpoint upload-session open.
+            resp_obj: Dict[str, Any] = {"session_id": REVISION_ID, "expires_at": ""}
+        else:
+            # Upload create (repo-CAS or media): dedup outcome, no part PUTs.
+            resp_obj = {
+                "dedup": True,
+                "ref": body.get("ref") or body.get("path") or "",
+                "path": body.get("path") or "",
+                "blake3": body.get("blake3") or "",
+                "size_bytes": body.get("size_bytes") or 0,
+                "mime_type": "application/octet-stream",
+            }
+        resp = json.dumps(resp_obj).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+@pytest.fixture()
+def hub_server():
+    _HubHandler.requests_seen = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HubHandler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+
+
+class _In(msgspec.Struct):
+    destination_repo: str = DEST_REPO
+    destination_repo_tags: List[str] = msgspec.field(default_factory=list)
+
+
+class _Out(msgspec.Struct):
+    ok: bool
+
+
+def _cap_token() -> str:
+    return _unsigned_jwt(
+        {
+            "cap_kind": "worker_capability",
+            "tenant": OWNER_UUID,
+            "request_id": "req-run41",
+            "job_id": JOB_ID,
+            "exp": 4_102_444_800,  # far future: renewal task stays asleep
+            "grants": [
+                {"do": "upload_media", "tenant": OWNER_UUID, "job": "req-run41"},
+                {"do": "create_checkpoint", "repo": DEST_REPO},
+            ],
+        }
+    )
+
+
+def _run_training_job(hub_url: str, method) -> List[pb.WorkerMessage]:
+    async def _go() -> List[pb.WorkerMessage]:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(
+            name="train", method=method, kind="training",
+            payload_type=_In, output_mode="single",
+        )
+        ex = Executor([spec], _send)
+        ex.file_base_url = hub_url
+        await ex.handle_run_job(pb.RunJob(
+            request_id="req-run41", attempt=1, function_name="train",
+            input_payload=msgspec.msgpack.encode(_In()),
+            tenant=OWNER_UUID,
+            capability_token=_cap_token(),
+        ))
+        job = ex.jobs[("req-run41", 1)]
+        assert job.task is not None
+        await job.task
+        for _ in range(20):
+            await asyncio.sleep(0)
+        return sent
+
+    return asyncio.run(_go())
+
+
+def test_training_checkpoint_rides_repo_cas_not_media(hub_server: str, tmp_path) -> None:
+    lora = tmp_path / "lora_000000500.safetensors"
+    # Bigger than the media route's per-file cap: the exact run41 payload class.
+    size = MEDIA_MAX_BYTES + 1024 * 1024
+    with open(lora, "wb") as f:
+        f.truncate(size)
+
+    def _train(ctx, payload: _In) -> _Out:
+        # The executor must have armed the repo-job scope from the payload's
+        # destination + the cap token's job_id claim.
+        assert ctx._execution_hints["kind"] == "training"
+        assert ctx._execution_hints["destination_repo"] == DEST_REPO
+        assert ctx._repo_job_upload_scope() == ("acme", "lora-out", JOB_ID)
+        out = ctx.save_checkpoint(
+            "checkpoints/lora_000000500.safetensors", str(lora),
+            step_number=500, output_kind="lora",
+        )
+        assert out.size_bytes == size
+        assert out.blake3  # repo-CAS route returns a blake3 digest
+        # Samples are media outputs: they must stay on the media route.
+        ctx.save_bytes("samples/sample_000000500.bin", b"sample-bytes")
+        return _Out(ok=True)
+
+    sent = _run_training_job(hub_server, _train)
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+
+    token = _cap_token()
+    seen = _HubHandler.requests_seen
+    paths = [p for p, _, _ in seen]
+
+    # 1. Checkpoint session opens on the destination repo, job-bound.
+    open_calls = [(p, a, b) for p, a, b in seen if p == "/api/v1/repos/acme/lora-out/revisions"]
+    assert len(open_calls) == 1
+    _, auth, body = open_calls[0]
+    assert auth == f"Bearer {token}"
+    assert body["job_id"] == JOB_ID
+
+    # 2. The checkpoint upload create rides the CHECKPOINT endpoints.
+    up_path = f"/api/v1/repos/acme/lora-out/revisions/{REVISION_ID}/uploads"
+    up_calls = [(p, a, b) for p, a, b in seen if p == up_path]
+    assert len(up_calls) == 1
+    _, auth, body = up_calls[0]
+    assert auth == f"Bearer {token}"
+    assert body["path"] == "checkpoints/lora_000000500.safetensors"
+    assert body["size_bytes"] == size
+
+    # 3. NOT the media route: the only media call is the sample asset,
+    #    against the token-bound owner.
+    media_calls = [(p, b) for p, _, b in seen if p.startswith("/api/v1/media/")]
+    assert [(p, b["ref"]) for p, b in media_calls] == [
+        (f"/api/v1/media/{OWNER_UUID}/uploads", "samples/sample_000000500.bin"),
+    ]
+    # And nothing else hit the hub.
+    assert len(paths) == 3
+
+
+def test_training_without_destination_fails_loudly_not_media(hub_server: str, tmp_path) -> None:
+    """No destination bindings → save_checkpoint must raise (the designed
+    fail-loud), never silently fall back to the media route."""
+    src = tmp_path / "lora.safetensors"
+    src.write_bytes(b"weights")
+
+    class _NoDest(msgspec.Struct):
+        pass
+
+    def _train(ctx, payload) -> _Out:
+        with pytest.raises(RuntimeError, match="repo job scope"):
+            ctx.save_checkpoint("checkpoints/lora.safetensors", str(src))
+        return _Out(ok=True)
+
+    async def _go() -> List[pb.WorkerMessage]:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(
+            name="train", method=_train, kind="training",
+            payload_type=_NoDest, output_mode="single",
+        )
+        ex = Executor([spec], _send)
+        ex.file_base_url = hub_server
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r2", attempt=1, function_name="train",
+            input_payload=msgspec.msgpack.encode(_NoDest()),
+            tenant=OWNER_UUID, capability_token=_cap_token(),
+        ))
+        job = ex.jobs[("r2", 1)]
+        await job.task
+        return sent
+
+    sent = asyncio.run(_go())
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+    assert not [p for p, _, _ in _HubHandler.requests_seen if p.startswith("/api/v1/media/")]
+
+
+@pytest.mark.parametrize(
+    ("info", "payload_attr", "want"),
+    [
+        ({"ref": "acme/lora-out"}, "", "acme/lora-out"),
+        ({"ref": "acme/lora-out:latest#fp8"}, "", "acme/lora-out"),
+        ({"repo": "acme/other"}, "", "acme/other"),
+        ({}, "acme/flat", "acme/flat"),
+        ({}, "acme/flat:tag", "acme/flat"),
+        ({}, "", ""),
+    ],
+)
+def test_producer_destination_repo_dual_form(info, payload_attr, want) -> None:
+    class _P(msgspec.Struct):
+        destination_repo: str = ""
+
+    assert _producer_destination_repo(_P(destination_repo=payload_attr), info) == want

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.7"
+version = "0.13.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Problem (live blocker)

J19 run41 trained 500/500 steps, then died publishing the final LoRA with `file_too_large`. The executor built producer contexts with `execution_hints={"output_format": ...}` only — no `kind` / `destination_repo` / `job_id` — so `_repo_job_upload_scope()` was always None for `@endpoint(kind="training")` and `ctx.save_checkpoint` silently rode the MEDIA route (256 MiB/file cap) instead of the repo-CAS checkpoint route (the job-bound `create_checkpoint` grant tensorhub mints for the destination repo at dispatch).

## Fix

- **executor.py**: producer jobs (training/conversion/dataset) get `execution_hints["kind"]`, `execution_hints["destination_repo"]` (reserved `payload.destination.ref` struct wins, flat `payload.destination_repo` scalar is the dispatched wire form; tag/flavor selectors stripped) and `job_id` from the cap token's `job_id` claim — the same value tensorhub binds checkpoint sessions to.
- **_stream.py**: output-stream routing split by artifact kind (the gw#453 greenfield design): `checkpoint` streams ride the repo-CAS upload session when the destination scope is armed; `asset` streams (sample images, media outputs) always ride the media route under the `upload_media` grant.
- Training `save_checkpoint` with no destination scope now fails loudly (`_require_repo_job_scope_for_tensors` finally arms) instead of silently riding media.

## Test (real codepath)

`tests/test_training_checkpoint_route.py`: local ThreadingHTTPServer stands in for tensorhub; a real `Executor` runs a `kind=training` job end to end. The handler saves a checkpoint LARGER than the media per-file cap (256 MiB + 1 MiB) plus a sample asset. Asserts:
- session open `POST /api/v1/repos/acme/lora-out/revisions` with `job_id` == the cap token claim, Bearer cap-token auth,
- checkpoint upload create on `/revisions/<id>/uploads` (path + size), NOT `/api/v1/media/...`,
- the sample stays on `/api/v1/media/<token-bound owner>/uploads`,
- no-destination training `save_checkpoint` raises instead of falling back to media.

688 passed, 10 skipped; ruff clean on changed files.

Tracker: python-gen-worker #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)