### PR TITLE
gw#463: CUDA OOM never fatals — degraded mode as the fit-ladder's formal terminal rung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.13.11 (2026-07-10)
+
+- **gw#463: CUDA OOM never fatals — degraded mode is the fit-ladder's formal
+  terminal rung, plan-time AND reactive.** One unified ladder: `plan_serve`'s
+  offload verdict now drives `place_pipeline`'s starting placement (a plan
+  that already says "can't fit resident" never pays the doomed resident
+  attempt — ie#369 measured 9-28 min for 70 GB models), and a runtime CUDA
+  OOM is a ladder *transition*, not a failure. Two core catch-sites:
+  (a) setup/load — an OOM inside placement flushes and demotes one offload
+  rung (`model_offload -> group_offload -> sequential`) and retries;
+  (b) mid-inference — the executor flushes the CUDA cache, demotes the
+  function's resident pipelines one rung, and retries the request ONCE in
+  degraded mode; the job only fails (RETRYABLE `out of memory`, never FATAL)
+  if degraded also fails. Demotions are sticky per model until reload and
+  learned in-process (`Executor.degraded_floor`), so subsequent loads start
+  at the learned rung. Every transition logs
+  `DEGRADED_MODE=engaged fn=... model=... phase=... rung=a->b needed_gb=..
+  free_gb=..`, updates the ServePlan, emits a per-request `ctx.log` event,
+  and re-emits `FnDegraded` with `ran="offload:<mode>"` (lifecycle dedupe is
+  now per-rung; the emit passes also run on unchanged StateDelta bytes —
+  previously a plan change without a delta change was never reported).
+  Allocator-flavored `RuntimeError`s ("CUDA error: out of memory",
+  CUBLAS/CUDNN alloc failures) now classify as OOM (`is_cuda_oom`) instead of
+  falling through to FATAL. `GEN_WORKER_FORBID_CPU_OFFLOAD=1` still vetoes
+  every CPU-touching demotion (dev-box guard). Generalizes ltx-video-2.3's
+  bespoke OOM fallback (ie PR #22) into the worker core.
+
 ## 0.13.10 (2026-07-10)
 
 - **gw#462: conversion worker hardening — disk preflight, scratch hygiene,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.10"
+version = "0.13.11"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -38,8 +38,15 @@ from .input_assets import cleanup_input_assets, materialize_input_assets
 from .models import disk_gc
 from .models import residency as residency_mod
 from .models.memory import (
+    cpu_offload_forbidden,
+    deeper_offload_mode,
+    degraded_log_line,
     estimate_cuda_resident_gb,
+    estimate_pipeline_size_gb,
+    flush_memory,
     get_available_ram_gb,
+    get_available_vram_gb,
+    is_cuda_oom,
 )
 from .models.cache_paths import tensorhub_cas_dir
 from .models.download import ensure_local
@@ -166,7 +173,9 @@ def _map_exception(exc: BaseException) -> Tuple[int, str]:
     if isinstance(exc, UrlExpiredError):
         # Hub-side URL staleness, not a client problem — retry re-mints URLs.
         return pb.JOB_STATUS_RETRYABLE, "model download url expired"
-    if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
+    if is_cuda_oom(exc):
+        # Never FATAL (gw#463): a bigger/idler card can serve this. The
+        # degraded-mode retry already ran by the time this maps.
         return pb.JOB_STATUS_RETRYABLE, "out of memory"
     # Unexpected exception: keep it terse but NEVER opaque — "internal error"
     # made every novel worker-side failure undiagnosable from the hub (pods
@@ -221,7 +230,7 @@ def _snapshot_to_resolved(snap: pb.Snapshot) -> Dict[str, Any]:
 
 def _model_op_error_vocab(exc: BaseException) -> str:
     """Contract §9 ModelEvent.error vocabulary for LOAD/UNLOAD failures."""
-    if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
+    if is_cuda_oom(exc):
         return "oom"
     text = str(exc).lower()
     if "out of memory" in text or "cuda oom" in text:
@@ -785,6 +794,10 @@ class Executor:
         # th#683 P3: how each serveable function will run on the actual card
         # (native / emergency / offload / cpu) + honest-guidance advisory.
         self.serve_plans: Dict[str, "ServePlan"] = {}
+        # gw#463: learned degraded floor per model ref — "this model+GPU
+        # needed offload mode X". In-process only; consulted at every load so
+        # a doomed fully-resident attempt is never paid twice (ie#369).
+        self.degraded_floor: Dict[str, str] = {}
 
     # ---- precision resolutions (th#697) -----------------------------------
 
@@ -917,9 +930,43 @@ class Executor:
                      "recommended_vram_gb": (f"{r.vram_gb:.0f}" if r.vram_gb else "")})
                 continue
             if plan.degraded:
-                logger.warning(
-                    "serving %s in degraded mode=%s (~%.1fx latency): %s",
-                    name, plan.run_mode, plan.est_latency_multiplier, plan.warning)
+                logger.warning(degraded_log_line(
+                    event="planned", fn=name, phase="gate",
+                    from_rung=plan.wanted, to_rung=plan.ran or plan.run_mode,
+                    free_gb=free_vram_gb,
+                    detail=f"~{plan.est_latency_multiplier:.1f}x latency: {plan.warning}",
+                ))
+
+    def _record_demotion(
+        self,
+        spec: EndpointSpec,
+        *,
+        ref: str,
+        phase: str,
+        from_rung: str,
+        to_rung: str,
+        needed_gb: float = 0.0,
+        detail: str = "",
+    ) -> None:
+        """One ladder-demotion bookkeeper (gw#463): learned per-ref floor +
+        updated ServePlan + loud DEGRADED_MODE warning + FnDegraded re-emit
+        via the state-delta path."""
+        from .models.serve_fit import demoted
+
+        if ref:
+            self.degraded_floor[ref] = deeper_offload_mode(
+                self.degraded_floor.get(ref, ""), to_rung)
+        line = degraded_log_line(
+            event="engaged", fn=spec.name, model=ref, phase=phase,
+            from_rung=from_rung, to_rung=to_rung,
+            needed_gb=needed_gb, free_gb=get_available_vram_gb(),
+            detail=(detail or "CUDA OOM") + " — sticky for this worker until "
+                   "reload; fix capacity/config, do not rely on this mode",
+        )
+        logger.warning(line)
+        self.serve_plans[spec.name] = demoted(
+            self.serve_plans.get(spec.name), detail=line, placement_mode=to_rung)
+        self._on_state_change()
 
     def available_functions(self) -> List[str]:
         out = []
@@ -1310,7 +1357,29 @@ class Executor:
                     )
                 # Worker-owned placement/offload policy: one decider for the
                 # whole worker; endpoints never write device/offload code.
-                await asyncio.to_thread(place_pipeline, pipe)
+                # Plan-time offload verdicts and the learned degraded floor
+                # pick the starting rung so a doomed fully-resident attempt
+                # is never paid (gw#463 / ie#369); a CUDA OOM inside is a
+                # ladder transition, not a failure.
+                from .models.serve_fit import RUN_OFFLOAD
+
+                ref = wire_ref(binding) if binding is not None else ""
+                plan = self.serve_plans.get(spec.name)
+                mode = "model_offload" if (
+                    plan is not None and plan.run_mode == RUN_OFFLOAD
+                ) else "auto"
+                floor = self.degraded_floor.get(ref, "")
+                if floor:
+                    mode = deeper_offload_mode("" if mode == "auto" else mode, floor)
+                placed = await asyncio.to_thread(place_pipeline, pipe, mode=mode, ref=ref)
+                if placed.get("oom_demotions"):
+                    self._record_demotion(
+                        spec, ref=ref, phase="load",
+                        from_rung=str(placed.get("requested_mode") or mode),
+                        to_rung=str(placed.get("mode") or ""),
+                        needed_gb=estimate_pipeline_size_gb(pipe),
+                        detail="CUDA OOM at load; pipeline placed offloaded",
+                    )
                 if spec.compile is not None:
                     # Opt-in acceleration against a pre-built per-SKU artifact:
                     # a TRT engine (#390, refit with this pipeline's weights)
@@ -1861,8 +1930,17 @@ class Executor:
                                 await asyncio.to_thread(
                                     self._adapters.deactivate, ref, pipe, run.request_id
                                 )
-                    output = await self._execute(job, spec, instance, ctx, payload, kwargs,
-                                                 timeout_ms=timeout_ms, gpu_index=gpu_index)
+                    try:
+                        output = await self._execute(job, spec, instance, ctx, payload, kwargs,
+                                                     timeout_ms=timeout_ms, gpu_index=gpu_index)
+                    except BaseException as exc:
+                        # Mid-inference CUDA OOM is a ladder transition, not a
+                        # request killer (gw#463): demote to the offload rung
+                        # and retry this request ONCE in degraded mode.
+                        if not await self._enter_degraded_for_oom(spec, ctx, exc):
+                            raise
+                        output = await self._execute(job, spec, instance, ctx, payload, kwargs,
+                                                     timeout_ms=timeout_ms, gpu_index=gpu_index)
                 finally:
                     # Guaranteed-inactive on every exit (OK / cancel /
                     # deadline / handler error); attachments stay resident.
@@ -2016,6 +2094,79 @@ class Executor:
                 "lora overlays require a pipeline-injected setup slot"
             )
         return pipe
+
+    async def _enter_degraded_for_oom(
+        self, spec: EndpointSpec, ctx: RequestContext, exc: BaseException,
+    ) -> bool:
+        """Mid-inference CUDA OOM -> degraded-mode ladder transition (gw#463).
+
+        Flushes the CUDA cache, demotes this function's worker-owned resident
+        pipelines one offload rung (sticky until reload), records + reports
+        the demotion. True when the request should retry once in degraded
+        mode; False re-raises the original failure.
+        """
+        if not is_cuda_oom(exc) or getattr(ctx, "cancelled", False):
+            return False
+        if spec.kind != "inference":
+            # Producer jobs (training/conversion) must surface RETRYABLE to
+            # the hub — an in-process whole-job replay would redo hours of
+            # work the hub can resume from a checkpoint instead.
+            return False
+        if spec.output_mode == "stream":
+            return False  # chunks already emitted; a replay would duplicate them
+        if cpu_offload_forbidden():
+            return False  # dev-box guard: fail the job rather than CPU-offload
+        pipes: List[Tuple[str, Any]] = []
+        for slot in spec.models:
+            ref = wire_ref(spec.models[slot])
+            obj = self.store.residency.obj(ref)
+            if obj is not None:
+                pipes.append((ref, obj))
+        demotions = await asyncio.to_thread(self._demote_pipelines, pipes)
+        if pipes and not demotions:
+            return False  # every pipeline already terminal — degraded failed too
+        for ref, from_mode, to_mode, needed_gb in demotions:
+            self._record_demotion(
+                spec, ref=ref, phase="inference",
+                from_rung=from_mode or "resident", to_rung=to_mode,
+                needed_gb=needed_gb,
+                detail=f"CUDA OOM mid-inference ({type(exc).__name__}); "
+                       "retrying this request once offloaded",
+            )
+        if not demotions:
+            logger.warning(degraded_log_line(
+                event="engaged", fn=spec.name, phase="inference",
+                free_gb=get_available_vram_gb(),
+                detail="CUDA OOM with no worker-owned pipeline to demote; "
+                       "flushed CUDA cache, retrying this request once"))
+        try:
+            # Platform-visible request event (the ie#369 bar): pod log AND
+            # hub event stream both say degraded mode engaged.
+            ctx.log(
+                f"DEGRADED_MODE=engaged fn={spec.name}: CUDA OOM; retrying "
+                "once with CPU offload (slower). Sticky for this worker.",
+                level="warning",
+            )
+        except Exception:
+            pass
+        return True
+
+    @staticmethod
+    def _demote_pipelines(
+        pipes: List[Tuple[str, Any]],
+    ) -> List[Tuple[str, str, str, float]]:
+        """Sync half (thread): flush, then one ladder rung down per pipeline.
+        Returns (ref, from_mode, to_mode, needed_gb) per demoted pipeline."""
+        from .models.memory import demote_pipeline, low_vram_mode
+
+        flush_memory()
+        out: List[Tuple[str, str, str, float]] = []
+        for ref, pipe in pipes:
+            before = low_vram_mode(pipe)
+            after = demote_pipeline(pipe, logger=logger)
+            if after:
+                out.append((ref, before, after, estimate_pipeline_size_gb(pipe)))
+        return out
 
     async def _execute(
         self,

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -91,7 +91,9 @@ class Lifecycle:
         self.drained = asyncio.Event()  # set when drain completed -> exit 0
         self._last_delta: Optional[bytes] = None
         self._emitted_unavailable: set[str] = set()
-        self._emitted_degraded: set[str] = set()
+        # fn name -> the "ran" rung last reported. Keyed on the rung (not
+        # mere membership) so a runtime ladder demotion (gw#463) re-emits.
+        self._emitted_degraded: dict[str, str] = {}
         self._drain_task: Optional[asyncio.Task] = None
 
     # ---- snapshots -----------------------------------------------------------
@@ -194,10 +196,11 @@ class Lifecycle:
             return
         delta = self._state_delta()
         raw = delta.SerializeToString(deterministic=True)
-        if raw == self._last_delta:
-            return
-        self._last_delta = raw
-        await self.transport.send(pb.WorkerMessage(state_delta=delta))
+        if raw != self._last_delta:
+            self._last_delta = raw
+            await self.transport.send(pb.WorkerMessage(state_delta=delta))
+        # Deduped internally; must run even on an unchanged delta — a runtime
+        # ladder demotion (gw#463) changes the ServePlan, not the delta bytes.
         await self._emit_unavailable()
         await self._emit_degraded()
 
@@ -226,13 +229,14 @@ class Lifecycle:
         for name, plan in sorted(self.executor.serve_plans.items()):
             if not plan.degraded or name in self.executor.unavailable:
                 continue
-            if name in self._emitted_degraded:
+            ran = plan.ran or plan.run_mode
+            if self._emitted_degraded.get(name) == ran:
                 continue
-            self._emitted_degraded.add(name)
+            self._emitted_degraded[name] = ran
             await self.transport.send(pb.WorkerMessage(fn_degraded=pb.FnDegraded(
                 function_name=name,
                 wanted=plan.wanted,
-                ran=plan.ran or plan.run_mode,
+                ran=ran,
                 reason=plan.warning,
                 est_latency_multiplier=float(plan.est_latency_multiplier),
                 recommended_vram_gb=float(plan.recommended_vram_gb or 0.0),

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -61,6 +61,83 @@ def effective_vram_requirement_gb(recommended_gb: float) -> float:
 # Modes that spill model weights to system RAM and run parts of inference on CPU.
 _CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
 
+# The reactive (degraded-mode) half of the fit ladder, shallowest first
+# (gw#463). A CUDA OOM — at load OR mid-inference — demotes a pipeline one
+# rung at a time; the terminal rung is sequential offload.
+OFFLOAD_LADDER: tuple[str, ...] = _CPU_OFFLOAD_MODES
+
+
+def next_offload_rung(mode: Optional[str]) -> Optional[str]:
+    """The next rung down the offload ladder from ``mode``.
+
+    Resident modes (''/off/vae_only/auto) fall to model_offload; each offload
+    mode falls to the next deeper one; None when already terminal.
+    """
+    cur = str(mode or "")
+    if cur not in OFFLOAD_LADDER:
+        return OFFLOAD_LADDER[0]
+    idx = OFFLOAD_LADDER.index(cur) + 1
+    return OFFLOAD_LADDER[idx] if idx < len(OFFLOAD_LADDER) else None
+
+
+def deeper_offload_mode(a: Optional[str], b: Optional[str]) -> str:
+    """The more-degraded of two placement modes ('' / non-ladder = shallowest)."""
+    def rank(m: Optional[str]) -> int:
+        m = str(m or "")
+        return OFFLOAD_LADDER.index(m) + 1 if m in OFFLOAD_LADDER else 0
+    a_s, b_s = str(a or ""), str(b or "")
+    return a_s if rank(a_s) >= rank(b_s) else b_s
+
+
+def is_cuda_oom(exc: Optional[BaseException]) -> bool:
+    """CUDA allocator exhaustion in any of its shapes: torch.cuda.OutOfMemoryError
+    (class name match — no torch import needed) plus the allocator's RuntimeError
+    flavors ("CUDA error: out of memory", CUBLAS/CUDNN alloc failures)."""
+    if exc is None:
+        return False
+    if type(exc).__name__ in ("OutOfMemoryError", "CUDAOutOfMemoryError"):
+        return True
+    if isinstance(exc, RuntimeError):
+        text = str(exc).lower()
+        return (
+            "out of memory" in text
+            or "cuda oom" in text
+            or "cublas_status_alloc_failed" in text
+            or "cudnn_status_alloc_failed" in text
+        )
+    return False
+
+
+def degraded_log_line(
+    *,
+    event: str,
+    fn: str = "",
+    model: str = "",
+    phase: str = "",
+    from_rung: str = "",
+    to_rung: str = "",
+    needed_gb: float = 0.0,
+    free_gb: float = 0.0,
+    detail: str = "",
+) -> str:
+    """The ONE degraded-mode log format (gw#463; quality bar: ie#369's ltx
+    DEGRADED_MODE lines). event: planned | engaged | serving."""
+    parts = [f"DEGRADED_MODE={event}"]
+    if fn:
+        parts.append(f"fn={fn}")
+    if model:
+        parts.append(f"model={model}")
+    if phase:
+        parts.append(f"phase={phase}")
+    if from_rung or to_rung:
+        parts.append(f"rung={from_rung or '?'}->{to_rung or '?'}")
+    if needed_gb > 0:
+        parts.append(f"needed_gb={needed_gb:.1f}")
+    if free_gb > 0:
+        parts.append(f"free_gb={free_gb:.1f}")
+    line = " ".join(parts)
+    return f"{line}: {detail}" if detail else line
+
 
 def cpu_offload_forbidden() -> bool:
     """True when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes any CPU-touching
@@ -447,13 +524,27 @@ def _apply_group_offload(
     return any_applied
 
 
-def place_pipeline(pipeline: Any, *, logger: Optional[logging.Logger] = None) -> Dict[str, Any]:
+def place_pipeline(
+    pipeline: Any,
+    *,
+    logger: Optional[logging.Logger] = None,
+    mode: Mode = "auto",
+    ref: str = "",
+) -> Dict[str, Any]:
     """Worker-owned placement + offload policy for a freshly-loaded pipeline.
 
-    Runs the one low-VRAM decider against free VRAM: plenty of headroom puts
-    the whole pipeline on CUDA; tighter budgets step down the offload ladder.
-    Endpoints never write device/offload code — the worker calls this around
-    ``setup()`` injection. No-op without CUDA.
+    ``mode="auto"`` runs the one low-VRAM decider against free VRAM: plenty of
+    headroom puts the whole pipeline on CUDA; tighter budgets step down the
+    offload ladder. Callers with plan-time knowledge (a ServePlan offload
+    verdict, a learned degraded floor) pass ``mode`` explicitly so a doomed
+    fully-resident attempt is never paid (ie#369). Endpoints never write
+    device/offload code — the worker calls this around ``setup()`` injection.
+    No-op without CUDA.
+
+    A CUDA OOM during placement is a ladder transition, not a failure
+    (gw#463): flush, demote one offload rung, retry — down to sequential.
+    The result dict carries ``oom_demotions``/``requested_mode`` when that
+    happened so the caller can record + report the degradation.
     """
     log = logger or _LOG
     try:
@@ -465,13 +556,56 @@ def place_pipeline(pipeline: Any, *, logger: Optional[logging.Logger] = None) ->
     except Exception:
         _forbid_cpu_inference("CPU-only inference (torch/CUDA unavailable)")
         return {"mode": "cpu"}
-    mode = select_auto_mode(pipeline=pipeline)
-    if mode in ("off", "vae_only") and callable(getattr(pipeline, "to", None)):
+    effective = select_auto_mode(pipeline=pipeline) if mode == "auto" else mode
+    requested = effective
+    demotions = 0
+    while True:
         try:
-            pipeline.to("cuda")
-        except Exception as exc:
-            log.warning("place_pipeline: .to('cuda') failed: %s", exc)
-    return apply_low_vram_config(pipeline, mode=mode, logger=log)
+            if effective in ("off", "vae_only") and callable(getattr(pipeline, "to", None)):
+                try:
+                    pipeline.to("cuda")
+                except BaseException as exc:
+                    if is_cuda_oom(exc):
+                        raise
+                    log.warning("place_pipeline: .to('cuda') failed: %s", exc)
+            applied = apply_low_vram_config(pipeline, mode=effective, logger=log)
+            if demotions:
+                applied["oom_demotions"] = demotions
+                applied["requested_mode"] = requested
+            return applied
+        except BaseException as exc:
+            if not is_cuda_oom(exc):
+                raise
+            nxt = next_offload_rung(effective)
+            if nxt is None:
+                raise
+            flush_memory()
+            log.warning(degraded_log_line(
+                event="engaged", model=ref, phase="load",
+                from_rung=effective, to_rung=nxt,
+                needed_gb=estimate_pipeline_size_gb(pipeline),
+                free_gb=get_available_vram_gb(),
+                detail=f"CUDA OOM during placement ({type(exc).__name__}); retrying offloaded",
+            ))
+            demotions += 1
+            effective = nxt
+
+
+def demote_pipeline(pipeline: Any, *, logger: Optional[logging.Logger] = None) -> Optional[str]:
+    """Runtime ladder transition (gw#463): move an already-placed pipeline one
+    offload rung deeper after a mid-inference CUDA OOM. Returns the new mode,
+    or None when already terminal (sequential). Sticky: the applied mode is
+    recorded on the pipeline, so it stays degraded until reload."""
+    log = logger or _LOG
+    nxt = next_offload_rung(low_vram_mode(pipeline))
+    if nxt is None:
+        return None
+    try:
+        delattr(pipeline, _COZY_MODE_ATTR)
+    except AttributeError:
+        pass
+    apply_low_vram_config(pipeline, mode=nxt, logger=log)
+    return nxt
 
 
 def apply_low_vram_config(
@@ -699,6 +833,12 @@ __all__ = [
     "apply_low_vram_config",
     "low_vram_mode",
     "place_pipeline",
+    "demote_pipeline",
+    "next_offload_rung",
+    "deeper_offload_mode",
+    "is_cuda_oom",
+    "degraded_log_line",
+    "OFFLOAD_LADDER",
     "with_oom_retry",
     "select_auto_mode",
     "device_mismatches",

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -40,7 +40,7 @@ STRUCTURALLY to the orchestrator (FnDegraded) as a placement signal.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Optional
 
 from .hub_policy import (
@@ -211,6 +211,31 @@ def plan_serve(
         recommended_vram_gb=recommended,
         wanted=wanted,
         ran=run_mode,
+    )
+
+
+def demoted(
+    plan: Optional[ServePlan],
+    *,
+    detail: str,
+    placement_mode: str = "",
+) -> ServePlan:
+    """The reactive ladder transition (gw#463): a runtime CUDA OOM demoted this
+    function to the offload rung. Produces the updated ServePlan so plan-time
+    and reactive degradation share one vocabulary, warning, and FnDegraded
+    shape. ``placement_mode`` (model_offload/group_offload/sequential) rides
+    ``ran`` as ``offload:<mode>`` so each deeper sub-rung re-reports."""
+    base = plan if plan is not None else ServePlan(
+        serveable=True, run_mode=RUN_NATIVE, fit="", wanted="bf16", ran="bf16",
+    )
+    ran = f"{RUN_OFFLOAD}:{placement_mode}" if placement_mode else RUN_OFFLOAD
+    return replace(
+        base,
+        serveable=True,
+        run_mode=RUN_OFFLOAD,
+        warning=detail,
+        est_latency_multiplier=_LATENCY_MULTIPLIER[RUN_OFFLOAD],
+        ran=ran,
     )
 
 

--- a/tests/test_oom_degraded_ladder.py
+++ b/tests/test_oom_degraded_ladder.py
@@ -1,0 +1,437 @@
+"""gw#463: CUDA OOM never fatals — degraded mode is the fit-ladder's terminal rung.
+
+Real tiny DDPMPipeline (the gw#417 pattern) through the REAL Executor setup /
+injection / job codepaths; only the device-placement boundary is shimmed — a
+DDPMPipeline subclass whose ``.to("cuda")`` raises the real
+``torch.cuda.OutOfMemoryError`` and whose offload hooks record instead of
+touching CUDA — so every fallback line (place_pipeline ladder, executor
+demotion bookkeeping, retry-once, FnDegraded re-emit) executes end to end on a
+CUDA-less host.
+
+GEN_WORKER_FORBID_CPU_OFFLOAD: this box exports =1. Tests that exercise the
+degrade path scope it OFF explicitly — justified because nothing real runs:
+the pipelines are ~1 MB shims, the offload hooks only record, and no model
+inference (GPU or CPU) ever executes. The veto behavior itself is asserted in
+the dedicated FORBID tests below.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import msgspec
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor, ModelStore, _map_exception
+from gen_worker.models import memory
+from gen_worker.models.serve_fit import RUN_OFFLOAD, ServePlan, demoted, plan_serve
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+OOM = torch.cuda.OutOfMemoryError
+
+
+def _save_tiny_ddpm(path: Path) -> None:
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3, layers_per_block=1,
+        block_out_channels=(32, 32), norm_num_groups=8,
+        down_block_types=("DownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "UpBlock2D"),
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler(num_train_timesteps=10)
+                 ).save_pretrained(str(path))
+
+
+class ShimPipe(DDPMPipeline):
+    """Real pipeline; only the device-placement boundary is shimmed.
+
+    ``.to('cuda')`` raises the real allocator exception while ``oom_on_cuda``
+    holds; offload hooks record calls instead of touching CUDA.
+    """
+
+    oom_on_cuda = True
+    to_cuda_attempts = 0
+    offload_calls: list = []
+
+    @classmethod
+    def reset(cls, *, oom_on_cuda: bool = True) -> None:
+        cls.oom_on_cuda = oom_on_cuda
+        cls.to_cuda_attempts = 0
+        cls.offload_calls = []
+
+    def to(self, *args, **kwargs):
+        wants_cuda = any("cuda" in str(v) for v in (*args, *kwargs.values()))
+        if wants_cuda:
+            type(self).to_cuda_attempts += 1
+            if type(self).oom_on_cuda:
+                raise OOM("CUDA out of memory (injected, gw#463 test)")
+        return self
+
+    def enable_model_cpu_offload(self, *a, **k):
+        type(self).offload_calls.append("model_offload")
+
+    def enable_group_offload(self, *a, **k):
+        type(self).offload_calls.append("group_offload")
+
+    def enable_sequential_cpu_offload(self, *a, **k):
+        type(self).offload_calls.append("sequential")
+
+
+@pytest.fixture()
+def shim_env(monkeypatch, tmp_path_factory):
+    """CUDA-less ladder harness: cuda 'present', 20 GB free, veto OFF."""
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")  # see module docstring
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 20.0)
+    ShimPipe.reset()
+    root = tmp_path_factory.mktemp("tiny-ddpm")
+    _save_tiny_ddpm(root / "snap")
+    return root / "snap"
+
+
+# --------------------------------------------------------------------------- #
+# Ladder vocabulary units
+# --------------------------------------------------------------------------- #
+
+
+def test_offload_rung_ordering() -> None:
+    assert memory.next_offload_rung("") == "model_offload"
+    assert memory.next_offload_rung("off") == "model_offload"
+    assert memory.next_offload_rung("vae_only") == "model_offload"
+    assert memory.next_offload_rung("model_offload") == "group_offload"
+    assert memory.next_offload_rung("group_offload") == "sequential"
+    assert memory.next_offload_rung("sequential") is None
+    assert memory.deeper_offload_mode("model_offload", "sequential") == "sequential"
+    assert memory.deeper_offload_mode("", "group_offload") == "group_offload"
+    assert memory.deeper_offload_mode("model_offload", "") == "model_offload"
+
+
+def test_is_cuda_oom_shapes() -> None:
+    assert memory.is_cuda_oom(OOM("CUDA out of memory"))
+    assert memory.is_cuda_oom(RuntimeError("CUDA error: out of memory"))
+    assert memory.is_cuda_oom(RuntimeError("CUBLAS_STATUS_ALLOC_FAILED when calling cublasCreate"))
+    assert not memory.is_cuda_oom(RuntimeError("expected all tensors on the same device"))
+    assert not memory.is_cuda_oom(ValueError("out of memory"))  # not allocator-shaped
+    assert not memory.is_cuda_oom(None)
+
+
+def test_allocator_runtime_error_maps_retryable_not_fatal() -> None:
+    status, msg = _map_exception(RuntimeError("CUDA error: out of memory"))
+    assert status == pb.JOB_STATUS_RETRYABLE and msg == "out of memory"
+
+
+def test_demoted_is_a_ladder_transition() -> None:
+    plan = ServePlan(serveable=True, run_mode="native", fit="fits",
+                     wanted="bf16", ran="bf16")
+    d = demoted(plan, detail="CUDA OOM", placement_mode="model_offload")
+    assert d.degraded and d.run_mode == RUN_OFFLOAD
+    assert d.ran == "offload:model_offload"
+    d2 = demoted(d, detail="again", placement_mode="sequential")
+    assert d2.ran == "offload:sequential"
+    # No prior plan (gate never ran): still produces a reportable plan.
+    assert demoted(None, detail="x", placement_mode="model_offload").degraded
+
+
+# --------------------------------------------------------------------------- #
+# Catch-site (a): setup/load — place_pipeline's OOM ladder
+# --------------------------------------------------------------------------- #
+
+
+def test_load_oom_demotes_to_model_offload(shim_env, caplog) -> None:
+    pipe = ShimPipe.from_pretrained(str(shim_env))
+    with caplog.at_level(logging.WARNING):
+        applied = memory.place_pipeline(pipe, ref="acme/tiny")
+    assert applied["mode"] == "model_offload"
+    assert applied["oom_demotions"] == 1
+    assert ShimPipe.to_cuda_attempts == 1
+    assert ShimPipe.offload_calls == ["model_offload"]
+    assert memory.low_vram_mode(pipe) == "model_offload"
+    line = next(r.message for r in caplog.records if "DEGRADED_MODE" in r.message)
+    assert "DEGRADED_MODE=engaged" in line and "phase=load" in line
+    assert "model=acme/tiny" in line and "rung=off->model_offload" in line
+    assert "needed_gb=" in line and "free_gb=" in line
+
+
+def test_planned_offload_skips_doomed_resident_attempt(shim_env) -> None:
+    pipe = ShimPipe.from_pretrained(str(shim_env))
+    applied = memory.place_pipeline(pipe, mode="model_offload", ref="acme/tiny")
+    assert applied["mode"] == "model_offload"
+    assert "oom_demotions" not in applied
+    assert ShimPipe.to_cuda_attempts == 0  # ie#369: no doomed resident attempt
+
+
+def test_forbid_env_still_vetoes_load_demotion(shim_env, monkeypatch) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    pipe = ShimPipe.from_pretrained(str(shim_env))
+    with pytest.raises(RuntimeError, match="GEN_WORKER_FORBID_CPU_OFFLOAD"):
+        memory.place_pipeline(pipe, ref="acme/tiny")
+
+
+def test_demote_pipeline_walks_and_terminates(shim_env) -> None:
+    pipe = ShimPipe.from_pretrained(str(shim_env))
+    assert memory.demote_pipeline(pipe) == "model_offload"
+    assert memory.demote_pipeline(pipe) == "group_offload"
+    assert memory.demote_pipeline(pipe) == "sequential"
+    assert memory.demote_pipeline(pipe) is None  # terminal rung: stays put
+    assert memory.low_vram_mode(pipe) == "sequential"
+
+
+# --------------------------------------------------------------------------- #
+# Executor end-to-end harness (real ModelStore + real injection/job paths)
+# --------------------------------------------------------------------------- #
+
+
+class _In(msgspec.Struct):
+    x: str = "hi"
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+def _spec(cls) -> EndpointSpec:
+    return EndpointSpec(
+        name="fn", method=cls.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=cls, attr_name="run",
+        models={"m": HF("acme/tiny")}, resources=Resources(vram_gb=1.0),
+    )
+
+
+def _executor(spec: EndpointSpec, tmp_path: Path, snap: Path, sent: list) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=4 << 30)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        store.residency.track_disk(ref, snap)
+        return snap
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return Executor([spec], _send, store=store)
+
+
+async def _run_job(ex: Executor, rid: str) -> None:
+    await ex.handle_run_job(pb.RunJob(
+        request_id=rid, attempt=1, function_name="fn",
+        input_payload=msgspec.msgpack.encode(_In())))
+    job = ex.jobs[(rid, 1)]
+    assert job.task is not None
+    await job.task
+    for _ in range(20):  # drain event coroutines from the handler thread
+        await asyncio.sleep(0)
+
+
+def _result(sent: list, rid: str) -> pb.JobResult:
+    for m in sent:
+        if m.WhichOneof("msg") == "job_result" and m.job_result.request_id == rid:
+            return m.job_result
+    raise AssertionError(f"no job_result for {rid}")
+
+
+def test_setup_oom_learns_floor_and_skips_resident_on_reload(
+        shim_env, tmp_path, caplog) -> None:
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = _spec(Endpoint)
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        with caplog.at_level(logging.WARNING):
+            inst = await ex.ensure_setup(spec)
+        assert memory.low_vram_mode(inst.m) == "model_offload"
+        assert ShimPipe.to_cuda_attempts == 1
+        # Learned floor + demoted ServePlan + loud warning.
+        assert ex.degraded_floor["acme/tiny"] == "model_offload"
+        plan = ex.serve_plans["fn"]
+        assert plan.degraded and plan.ran == "offload:model_offload"
+        assert any("DEGRADED_MODE=engaged" in r.message and "fn=fn" in r.message
+                   for r in caplog.records)
+        # Reload (eviction simulated): the floor drives placement — the
+        # doomed resident attempt is NOT paid again (ie#369).
+        rec = ex._classes[spec.instance_key]
+        rec.ready, rec.instance = False, None
+        await ex.ensure_setup(spec)
+        assert ShimPipe.to_cuda_attempts == 1  # unchanged
+
+    asyncio.run(_go())
+
+
+def test_inference_oom_demotes_and_retries_once(shim_env, tmp_path, caplog) -> None:
+    calls = {"n": 0}
+
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OOM("CUDA out of memory (injected mid-inference)")
+            return _Out()
+
+    ShimPipe.reset(oom_on_cuda=False)  # loads resident; the OOM comes mid-run
+    spec = _spec(Endpoint)
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        with caplog.at_level(logging.WARNING):
+            await _run_job(ex, "r1")
+        assert _result(sent, "r1").status == pb.JOB_STATUS_OK
+        assert calls["n"] == 2  # retried exactly once, in degraded mode
+        pipe = ex.store.residency.obj("acme/tiny")
+        assert memory.low_vram_mode(pipe) == "model_offload"
+        assert ex.degraded_floor["acme/tiny"] == "model_offload"
+        assert ex.serve_plans["fn"].ran == "offload:model_offload"
+        assert any("DEGRADED_MODE=engaged" in r.message and "phase=inference" in r.message
+                   for r in caplog.records)
+        # ie#369 bar: the degradation is platform-visible as a request event.
+        assert any(
+            m.WhichOneof("msg") == "job_progress"
+            and b"DEGRADED_MODE=engaged" in m.job_progress.data
+            for m in sent)
+        # Sticky: the next request stays degraded — no rung flapping.
+        await _run_job(ex, "r2")
+        assert _result(sent, "r2").status == pb.JOB_STATUS_OK
+        assert memory.low_vram_mode(pipe) == "model_offload"
+
+    asyncio.run(_go())
+
+
+def test_inference_oom_in_degraded_mode_fails_retryable(shim_env, tmp_path) -> None:
+    calls = {"n": 0}
+
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:
+            calls["n"] += 1
+            raise OOM("CUDA out of memory (persistent)")
+
+    ShimPipe.reset(oom_on_cuda=False)
+    spec = _spec(Endpoint)
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        await _run_job(ex, "r1")
+        # One degraded retry, then the mapped status — RETRYABLE, never FATAL
+        # (a bigger card can serve it); the ladder floor deepened.
+        assert calls["n"] == 2
+        assert _result(sent, "r1").status == pb.JOB_STATUS_RETRYABLE
+        assert _result(sent, "r1").safe_message == "out of memory"
+        assert ex.degraded_floor["acme/tiny"] == "model_offload"
+        # Next request: demotes one MORE rung (group_offload), retries, fails
+        # RETRYABLE again — walking, not flapping.
+        await _run_job(ex, "r2")
+        assert calls["n"] == 4
+        assert _result(sent, "r2").status == pb.JOB_STATUS_RETRYABLE
+        assert ex.degraded_floor["acme/tiny"] == "group_offload"
+
+    asyncio.run(_go())
+
+
+def test_forbid_env_disables_inference_degrade(shim_env, tmp_path, monkeypatch) -> None:
+    calls = {"n": 0}
+
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:
+            calls["n"] += 1
+            raise OOM("CUDA out of memory")
+
+    ShimPipe.reset(oom_on_cuda=False)
+    spec = _spec(Endpoint)
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        # Veto ON before anything runs: load still fits resident (no OOM at
+        # load, so no CPU-touching placement), but the mid-inference OOM must
+        # NOT degrade on a forbidding box.
+        monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+        await _run_job(ex, "r1")
+        assert calls["n"] == 1  # no degraded retry on a forbidding box
+        assert _result(sent, "r1").status == pb.JOB_STATUS_RETRYABLE
+        assert ex.degraded_floor == {}
+
+    asyncio.run(_go())
+
+
+def test_runtime_demotion_reemits_fn_degraded(shim_env, tmp_path) -> None:
+    """The rung transition is telemetry, not just a log line: FnDegraded
+    re-emits when the active rung changes (lifecycle dedupe is per-rung)."""
+    from types import SimpleNamespace
+
+    from gen_worker.lifecycle import Lifecycle
+
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    class _StubTransport:
+        def __init__(self) -> None:
+            self.sent: list = []
+            self.connected = True
+            self.queue = SimpleNamespace(pending_result_keys=set())
+
+        async def send(self, msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+    spec = _spec(Endpoint)
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        lc = Lifecycle(SimpleNamespace(worker_jwt="", worker_id="w", runpod_pod_id=""), ex)
+        tp = _StubTransport()
+        lc.transport = tp
+        ex._record_demotion(spec, ref="acme/tiny", phase="inference",
+                            from_rung="resident", to_rung="model_offload")
+        await lc.maybe_send_state_delta()
+        ex._record_demotion(spec, ref="acme/tiny", phase="inference",
+                            from_rung="model_offload", to_rung="sequential")
+        await lc.maybe_send_state_delta()
+        events = [m.fn_degraded for m in tp.sent if m.WhichOneof("msg") == "fn_degraded"]
+        assert [e.ran for e in events] == ["offload:model_offload", "offload:sequential"]
+        assert all("DEGRADED_MODE=engaged" in e.reason for e in events)
+        # Same rung again: deduped.
+        await lc.maybe_send_state_delta()
+        assert len([m for m in tp.sent if m.WhichOneof("msg") == "fn_degraded"]) == 2
+
+    asyncio.run(_go())
+
+
+def test_plan_serve_offload_rung_unchanged_by_reactive_path() -> None:
+    """The reactive rung never preempts the quant rungs: a plan that fits
+    fp8/emergency still plans those; offload stays the LAST rung."""
+    from gen_worker.models.hub_policy import TensorhubWorkerCapabilities
+
+    caps = TensorhubWorkerCapabilities(
+        cuda_version="12.4", gpu_sm=89, torch_version="2.8", installed_libs=[])
+    plan = plan_serve(Resources(vram_gb=12.0), caps, 8.0,
+                      forbid_cpu_offload=False)
+    assert plan.serveable and plan.run_mode == "fp8_storage"  # quant first
+    huge = plan_serve(Resources(vram_gb=100.0), caps, 8.0,
+                      forbid_cpu_offload=False)
+    assert huge.serveable and huge.run_mode == RUN_OFFLOAD  # offload is last

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.8"
+version = "0.13.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
Platform rule (Paul): serving endpoints never hard-fail on CUDA OOM — they enter degraded mode (CPU offload), warn loudly, and keep serving slower. Implemented as part of the existing fit-ladder system, not a bolt-on try/except: the ladder's rung machinery owns CPU offload as its formal terminal rung, and BOTH the plan-time path and the reactive OOM path go through the one implementation with shared vocabulary, logging, and telemetry.

- **Unified ladder**: `plan_serve`'s offload verdict + the learned per-ref floor (`Executor.degraded_floor`, in-process) drive `place_pipeline`'s starting rung — a plan that already says offload never pays the doomed fully-resident attempt (ie#369: 9–28 min for 70 GB models). Reactive demotion walks the same offload sub-rungs `model_offload -> group_offload -> sequential`.
- **Catch-site (a) setup/load** (`models/memory.place_pipeline`): OOM during placement -> flush -> demote one rung -> retry, down to sequential. (Also fixes a latent bug: `.to('cuda')` OOM was swallowed with a warning and the pipeline booked resident while actually on CPU.)
- **Catch-site (b) mid-inference** (`executor._enter_degraded_for_oom`, wrapped around `_execute`): flush CUDA cache, demote the function's worker-owned resident pipelines one rung (sticky until reload — no flapping), retry the request ONCE in degraded mode. Fails RETRYABLE `out of memory` (never FATAL — a bigger card can serve it) when degraded also fails. Inference-kind + non-stream only; producers surface RETRYABLE for checkpoint-aware rescheduling.
- **Observability**: every transition logs `DEGRADED_MODE=engaged fn=<fn> model=<ref> phase=load|inference rung=<from>-><to> needed_gb=<n> free_gb=<f>: <detail> — sticky for this worker until reload...` (ltx/ie#369 format, svdq reason-string bar), emits a per-request `ctx.log` warning (hub event stream), updates the ServePlan, and re-emits `FnDegraded` with `ran="offload:<mode>"`. Lifecycle dedupe is now per-rung, and the emit passes run even on unchanged StateDelta bytes (previously a plan change without a delta change was never reported).
- **Ladder order respected**: quant rungs (fp8 storage / emergency nf4) stay ahead; offload remains LAST (asserted in tests).
- **`is_cuda_oom`**: allocator RuntimeError flavors ('CUDA error: out of memory', CUBLAS/CUDNN alloc failures) now classify as OOM -> RETRYABLE instead of falling through to FATAL.
- **`GEN_WORKER_FORBID_CPU_OFFLOAD=1`** still vetoes every CPU-touching demotion (raises at load; skips the degraded retry at inference).
- Generalizes ltx-video-2.3's bespoke OOM fallback (ie PR #22) into the core; the bespoke code is deleted in the inference-endpoints follow-up PR.

Cross-refs: ie#369, ie#372, gw#417, th#683. Tracker: cozy-creator-tracker python-gen-worker #463.

## Test plan
- [x] New `tests/test_oom_degraded_ladder.py` (14 tests): real tiny DDPMPipeline through the REAL Executor setup/injection/job paths; only the device boundary shimmed (`.to('cuda')` raises real `torch.cuda.OutOfMemoryError`, offload hooks record). Covers: load OOM -> model_offload, plan-driven no-resident-attempt, learned-floor reload skip, inference OOM -> demote+retry-once -> OK, persistent OOM -> RETRYABLE + rung walking (not flapping), FORBID veto at both sites, FnDegraded per-rung re-emit, ladder-order preservation, is_cuda_oom shapes.
- [x] Full suite green: 741 passed, 10 skipped (GPU-gated), CUDA-less host, FORBID env respected (scoped off only inside shim tests — nothing real runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)