### PR TITLE
gw#464: storage-side fp8 for text encoders — writer mirrors the gw#460 loader (0.13.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.12 (2026-07-10)
+
+- **gw#464: storage-side fp8 for text encoders — `streaming_fp8_snapshot(te_components=...)`.**
+  The gw#460 loader casts transformers TEs with block-window weight-only
+  rules; the writer can now produce the same cast as a STORED flavor with
+  zero drift: `te_fp8_castable_keys()` meta-instantiates the component's
+  architecture from its config, runs the loader's own
+  `_fp8_block_windows` walk, and maps the checkpoint's stored key names
+  onto the graph with transformers' own load-path renaming (old-layout
+  Gemma3 `language_model.model.*` resolves exactly like `from_pretrained`;
+  zero matches is a hard error, never a silent no-op). New
+  `streaming_fp8_te_cast()`, `FP8_TE_COMPONENTS` (drift-guarded against
+  the loader constant). Embeddings/norms/biases/tied lm_head pass through
+  at source precision.
+
 ## 0.13.11 (2026-07-10)
 
 - **gw#463: CUDA OOM never fatals — degraded mode is the fit-ladder's formal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.11"
+version = "0.13.12"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -34,10 +34,13 @@ from .publish import publish_flavors
 from .source import FileLayout, Source
 from .svdq import build_svdq_flavor_tree, fetch_svdq_checkpoint, svdq_flavor_label
 from .writer import (
+    FP8_TE_COMPONENTS,
     streaming_cast_snapshot,
     streaming_dtype_cast,
     streaming_fp8_snapshot,
     streaming_fp8_storage_cast,
+    streaming_fp8_te_cast,
+    te_fp8_castable_keys,
 )
 
 # `gen_worker.convert.clone` module alias (clone.from_huggingface style).
@@ -58,6 +61,9 @@ __all__ = [
     "streaming_dtype_cast",
     "streaming_fp8_snapshot",
     "streaming_fp8_storage_cast",
+    "streaming_fp8_te_cast",
+    "te_fp8_castable_keys",
+    "FP8_TE_COMPONENTS",
     "CalibrationAction",
     "CalibrationPolicy",
     "resolve_calibration_action",

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -701,13 +701,64 @@ FP8_TE_COMPONENTS: tuple[str, ...] = (
 )
 
 
+def _component_stored_tensor_names(component_dir: Path) -> frozenset[str]:
+    """Tensor names as stored in the component's safetensors file(s)."""
+    names: set[str] = set()
+    idx = sorted(component_dir.glob("*.safetensors.index.json"))
+    if idx:
+        payload = json.loads(idx[0].read_text(encoding="utf-8"))
+        names.update(str(k) for k in (payload.get("weight_map") or {}))
+        return frozenset(names)
+    for f in sorted(component_dir.glob("*.safetensors")):
+        with open(f, "rb") as fh:
+            header_len = struct.unpack("<Q", fh.read(8))[0]
+            header = json.loads(fh.read(header_len))
+        names.update(k for k in header if k != "__metadata__")
+    return frozenset(names)
+
+
+def _loader_key_translator(model: Any) -> Any:
+    """Checkpoint-key -> module-graph-key translation using transformers' OWN
+    load-path machinery (WeightRenaming rules + base-model-prefix
+    reconciliation) — the same code ``from_pretrained`` runs, so old-layout
+    checkpoints (e.g. Gemma3 ``language_model.model.*`` vs the 4.52+
+    ``model.language_model.*`` graph) resolve exactly like the loader."""
+    try:
+        from transformers.conversion_mapping import get_model_conversion_mapping
+        from transformers.core_model_loading import (
+            WeightRenaming,
+            rename_source_key,
+        )
+    except ImportError:  # older transformers: keys match the graph directly
+        return lambda k: k
+    try:
+        transforms = get_model_conversion_mapping(model)
+    except Exception:  # noqa: BLE001
+        transforms = []
+    renamings = [t for t in transforms if isinstance(t, WeightRenaming)]
+    converters = [t for t in transforms if not isinstance(t, WeightRenaming)]
+    meta_sd = model.state_dict()
+    prefix = getattr(model, "base_model_prefix", None)
+
+    def translate(key: str) -> str:
+        try:
+            renamed, _ = rename_source_key(key, renamings, converters, prefix, meta_sd)
+            return renamed
+        except Exception:  # noqa: BLE001
+            return key
+
+    return translate
+
+
 def te_fp8_castable_keys(component_dir: Path) -> frozenset[str]:
-    """State-dict keys the ``fp8+te`` LOADER casts for a transformers text
-    encoder — derived by meta-instantiating the checkpoint's architecture
-    and running the SAME block-window selection the runtime applies
-    (:func:`gen_worker.models.loading._fp8_block_windows`, gw#460). Using
-    the loader's own graph walk is the zero-drift contract: the stored
-    artifact is byte-identical to what cast-at-load would produce.
+    """STORED tensor names the ``fp8+te`` LOADER casts for a transformers
+    text encoder — derived by meta-instantiating the checkpoint's
+    architecture and running the SAME block-window selection the runtime
+    applies (:func:`gen_worker.models.loading._fp8_block_windows`, gw#460),
+    then mapping the component's stored key names onto the module graph with
+    transformers' own checkpoint-conversion machinery. Using the loader's
+    graph walk + the loader's key translation is the zero-drift contract:
+    the stored artifact is byte-identical to what cast-at-load produces.
 
     Block-window rules (gw#460): castable = Linear/conv WEIGHTS inside the
     children of top-level ``nn.ModuleList`` containers, excluding params
@@ -736,8 +787,21 @@ def te_fp8_castable_keys(component_dir: Path) -> frozenset[str]:
         raise ConversionImplementationError(
             f"no fp8-castable weights in {component_dir} ({archs[0]})")
     castable = {id(p) for _, _, params in windows for p in params}
-    return frozenset(
-        n for n, p in model.named_parameters() if id(p) in castable)
+    graph_keys = {
+        n for n, p in model.named_parameters() if id(p) in castable}
+
+    stored = _component_stored_tensor_names(component_dir)
+    if not stored:
+        raise ConversionImplementationError(
+            f"no safetensors tensor names found in {component_dir}")
+    translate = _loader_key_translator(model)
+    matched = frozenset(k for k in stored if translate(k) in graph_keys)
+    if not matched:
+        raise ConversionImplementationError(
+            f"fp8+te key translation matched nothing in {component_dir} "
+            f"({archs[0]}: {len(graph_keys)} castable graph keys, "
+            f"{len(stored)} stored keys) — layout drift vs the loader")
+    return matched
 
 
 def streaming_fp8_te_cast(

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -692,38 +692,131 @@ def streaming_cast_snapshot(
             "components": sorted(done), "output_dir": out_dir}
 
 
+# Text-encoder components the ``fp8+te`` rung casts (must mirror
+# gen_worker.models.loading._FP8_TEXT_ENCODER_COMPONENTS — drift guard in
+# tests/test_fp8_te_writer.py; not imported here to keep this module's
+# import cheap).
+FP8_TE_COMPONENTS: tuple[str, ...] = (
+    "text_encoder", "text_encoder_2", "text_encoder_3",
+)
+
+
+def te_fp8_castable_keys(component_dir: Path) -> frozenset[str]:
+    """State-dict keys the ``fp8+te`` LOADER casts for a transformers text
+    encoder — derived by meta-instantiating the checkpoint's architecture
+    and running the SAME block-window selection the runtime applies
+    (:func:`gen_worker.models.loading._fp8_block_windows`, gw#460). Using
+    the loader's own graph walk is the zero-drift contract: the stored
+    artifact is byte-identical to what cast-at-load would produce.
+
+    Block-window rules (gw#460): castable = Linear/conv WEIGHTS inside the
+    children of top-level ``nn.ModuleList`` containers, excluding params
+    shared with modules outside a block (tied lm_head / embeddings).
+    Embeddings, norms, biases, poolers stay at source precision."""
+    import torch
+    import transformers
+
+    from gen_worker.models.loading import (
+        _fp8_block_windows,
+        _fp8_block_windows_whole,
+    )
+
+    component_dir = Path(component_dir)
+    cfg = transformers.AutoConfig.from_pretrained(str(component_dir))
+    archs = list(getattr(cfg, "architectures", None) or [])
+    cls = getattr(transformers, archs[0], None) if archs else None
+    if cls is None:
+        raise ConversionImplementationError(
+            f"cannot resolve transformers architecture for {component_dir} "
+            f"(architectures={archs})")
+    with torch.device("meta"):
+        model = cls(cfg)
+    windows = _fp8_block_windows(model) or _fp8_block_windows_whole(model)
+    if not windows:
+        raise ConversionImplementationError(
+            f"no fp8-castable weights in {component_dir} ({archs[0]})")
+    castable = {id(p) for _, _, params in windows for p in params}
+    return frozenset(
+        n for n, p in model.named_parameters() if id(p) in castable)
+
+
+def streaming_fp8_te_cast(
+    input_path: Path,
+    out_dir: Path,
+    *,
+    castable_keys: frozenset[str],
+    shard_prefix: str = "model",
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> dict[str, Any]:
+    """fp8-E4M3 storage cast of one transformers weight set: exactly the
+    ``castable_keys`` (the loader's block-window weight set) become
+    F8_E4M3 (clamp ±448 first — torch's cast does not saturate); every
+    other tensor keeps its source dtype byte-identically."""
+    import torch
+
+    def out_st_dtype_for(name: str, src_st: str, shape: list[int]) -> str:
+        if name in castable_keys and src_st in {"F64", "F32", "F16", "BF16"}:
+            return "F8_E4M3"
+        return src_st
+
+    def transform(_name: str, t: "torch.Tensor", out_st: str) -> "torch.Tensor":
+        if out_st == "F8_E4M3" and t.dtype != torch.float8_e4m3fn:
+            return t.clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+        return t
+
+    return _stream_reencode(
+        Path(input_path), Path(out_dir),
+        out_st_dtype_for=out_st_dtype_for, transform=transform,
+        shard_prefix=shard_prefix, shard_threshold=shard_threshold,
+    )
+
+
 def streaming_fp8_snapshot(
     source_dir: Path,
     out_dir: Path,
     *,
     file_layout: str,
     components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
+    te_components: tuple[str, ...] = (),
     shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
 ) -> dict[str, Any]:
     """Produce the ``#fp8`` flavor of a diffusers snapshot, streaming.
 
-    Only ``components`` (default: the denoiser) are fp8-cast; every other
-    component passes through untouched. Refuses singlefile layouts — fp8
-    storage is component-scoped and single-file keyspaces don't name
-    components reliably."""
+    ``components`` (default: the denoiser) get the name-pattern fp8 cast;
+    ``te_components`` (the ``fp8+te`` rung, gw#460 — pass
+    :data:`FP8_TE_COMPONENTS`) get the transformers block-window cast whose
+    eligible set is derived from the loader itself. Every other component
+    passes through untouched. Refuses singlefile layouts — fp8 storage is
+    component-scoped and single-file keyspaces don't name components
+    reliably."""
     if file_layout != "diffusers":
         raise ConversionImplementationError(
             "fp8 storage flavors are produced from diffusers layouts only "
             "(component-scoped); repackage singlefile sources first")
     source_dir, out_dir = Path(source_dir), Path(out_dir)
+    denoiser_set, te_set = set(components), set(te_components)
     groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
-              if c in set(components)]
+              if c in denoiser_set | te_set]
     if not groups:
         raise ConversionImplementationError(
-            f"no fp8-castable components found (looked for {sorted(components)})")
+            f"no fp8-castable components found "
+            f"(looked for {sorted(denoiser_set | te_set)})")
     tensor_count = converted = 0
     done: set[str] = set()
     for comp, entry in groups:
-        result = streaming_fp8_storage_cast(
-            entry, out_dir / comp,
-            shard_prefix=_group_shard_prefix(entry),
-            shard_threshold=shard_threshold,
-        )
+        if comp in te_set:
+            result = streaming_fp8_te_cast(
+                entry, out_dir / comp,
+                castable_keys=te_fp8_castable_keys(source_dir / comp),
+                shard_prefix=_group_shard_prefix(entry),
+                shard_threshold=shard_threshold,
+            )
+        else:
+            result = streaming_fp8_storage_cast(
+                entry, out_dir / comp,
+                shard_prefix=_group_shard_prefix(entry),
+                shard_threshold=shard_threshold,
+            )
         tensor_count += int(result["tensor_count"])
         converted += int(result["converted_count"])
         done.add(comp)
@@ -866,5 +959,8 @@ __all__ = [
     "fp8_cast_eligible",
     "FP8_SKIP_TENSOR_PATTERNS",
     "FP8_DEFAULT_COMPONENTS",
+    "FP8_TE_COMPONENTS",
+    "te_fp8_castable_keys",
+    "streaming_fp8_te_cast",
     "shard_safetensors_by_offset",
 ]

--- a/tests/test_fp8_te_writer.py
+++ b/tests/test_fp8_te_writer.py
@@ -72,6 +72,82 @@ def test_te_castable_keys_match_loader_windows(tmp_path: Path) -> None:
     assert not any("embed" in k or "layer_norm" in k for k in keys)
 
 
+def _tiny_gemma3_old_layout(tmp_path: Path) -> tuple[Path, "transformers.PreTrainedModel"]:
+    """A Gemma3 multimodal TE saved with the PRE-4.52 key layout
+    (``language_model.model.*`` / ``vision_tower.*``) — the layout the real
+    LTX-2.3 text_encoder snapshot uses. Loading it must translate keys the
+    way ``from_pretrained`` does."""
+    import re
+
+    from safetensors.torch import save_file
+
+    cfg = transformers.Gemma3Config(
+        text_config=dict(hidden_size=32, intermediate_size=64,
+                         num_hidden_layers=2, num_attention_heads=4,
+                         num_key_value_heads=2, head_dim=8, vocab_size=256),
+        vision_config=dict(hidden_size=32, intermediate_size=64,
+                           num_hidden_layers=2, num_attention_heads=4,
+                           image_size=28, patch_size=14),
+        mm_tokens_per_image=4,
+    )
+    model = transformers.Gemma3ForConditionalGeneration(cfg).to(torch.bfloat16)
+
+    def to_old(k: str) -> str:
+        k = re.sub(r"^model\.language_model\.", "language_model.model.", k)
+        k = re.sub(r"^model\.vision_tower\.", "vision_tower.", k)
+        k = re.sub(r"^model\.multi_modal_projector\.", "multi_modal_projector.", k)
+        return k
+
+    old_sd = {to_old(k): v.clone() for k, v in model.state_dict().items()
+              if k != "lm_head.weight"}
+    comp = tmp_path / "src" / "text_encoder"
+    comp.mkdir(parents=True)
+    cfg.architectures = ["Gemma3ForConditionalGeneration"]
+    cfg.save_pretrained(comp)
+    save_file(old_sd, comp / "model.safetensors", metadata={"format": "pt"})
+    return comp, model
+
+
+def test_old_layout_gemma3_keys_translate_like_loader(tmp_path: Path) -> None:
+    comp, model = _tiny_gemma3_old_layout(tmp_path)
+    keys = te_fp8_castable_keys(comp)
+
+    windows = loading_mod._fp8_block_windows(model)
+    castable = {id(p) for _, _, params in windows for p in params}
+    graph_keys = {n for n, p in model.named_parameters() if id(p) in castable}
+
+    # Returned keys are STORED (old-layout) names covering exactly the
+    # loader's castable graph set.
+    assert keys
+    assert all(k.startswith(("language_model.model.", "vision_tower."))
+               for k in keys), sorted(keys)[:5]
+    assert len(keys) == len(graph_keys)
+    assert not any("embed" in k or "norm" in k or k.endswith(".bias")
+                   for k in keys)
+
+
+def test_old_layout_gemma3_snapshot_cast(tmp_path: Path) -> None:
+    comp, _model = _tiny_gemma3_old_layout(tmp_path)
+    out = tmp_path / "out"
+    streaming_fp8_snapshot(
+        comp.parent, out, file_layout="diffusers",
+        components=(), te_components=("text_encoder",),
+    )
+    keys = te_fp8_castable_keys(comp)
+    src_t = _load_all_tensors(comp)
+    out_t = _load_all_tensors(out / "text_encoder")
+    assert set(src_t) == set(out_t)
+    for name, s in src_t.items():
+        o = out_t[name]
+        if name in keys:
+            assert o.dtype == torch.float8_e4m3fn, name
+            expect = s.to(torch.float8_e4m3fn)
+            assert torch.equal(o.view(torch.uint8), expect.view(torch.uint8)), name
+        else:
+            assert o.dtype == s.dtype, name
+            assert torch.equal(o.view(torch.uint8), s.view(torch.uint8)), name
+
+
 def test_snapshot_te_cast_is_loader_byte_identical(tmp_path: Path) -> None:
     comp = _tiny_t5_encoder(tmp_path)
     src = comp.parent

--- a/tests/test_fp8_te_writer.py
+++ b/tests/test_fp8_te_writer.py
@@ -1,0 +1,105 @@
+"""gw#463: storage-side fp8 for text encoders mirrors the gw#460 loader.
+
+The contract under test: ``streaming_fp8_snapshot(te_components=...)``
+produces, for a transformers text encoder, EXACTLY the tensors the
+``storage_dtype="fp8+te"`` loader would cast — same key set (derived from
+the loader's own ``_fp8_block_windows`` on a meta-instantiated module) and
+byte-identical fp8 payloads; everything else passes through untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+transformers = pytest.importorskip("transformers")
+
+from gen_worker.convert import (  # noqa: E402
+    FP8_TE_COMPONENTS,
+    streaming_fp8_snapshot,
+    te_fp8_castable_keys,
+)
+from gen_worker.models import loading as loading_mod  # noqa: E402
+
+
+def _tiny_t5_encoder(tmp_path: Path) -> Path:
+    cfg = transformers.T5Config(
+        d_model=32, d_ff=64, d_kv=8, num_heads=4,
+        num_layers=2, vocab_size=128, decoder_start_token_id=0,
+    )
+    model = transformers.T5EncoderModel(cfg).to(torch.bfloat16)
+    comp = tmp_path / "src" / "text_encoder"
+    model.save_pretrained(comp, safe_serialization=True)
+    return comp
+
+
+def _load_all_tensors(component_dir: Path) -> dict[str, "torch.Tensor"]:
+    from safetensors import safe_open
+
+    out: dict[str, torch.Tensor] = {}
+    files = sorted(component_dir.glob("*.safetensors"))
+    idx = component_dir / "model.safetensors.index.json"
+    if idx.exists():
+        wm = json.loads(idx.read_text())["weight_map"]
+        files = sorted({component_dir / v for v in wm.values()})
+    for f in files:
+        with safe_open(str(f), framework="pt") as fh:
+            for k in fh.keys():
+                out[k] = fh.get_tensor(k)
+    return out
+
+
+def test_te_components_mirror_loader() -> None:
+    assert FP8_TE_COMPONENTS == loading_mod._FP8_TEXT_ENCODER_COMPONENTS
+
+
+def test_te_castable_keys_match_loader_windows(tmp_path: Path) -> None:
+    comp = _tiny_t5_encoder(tmp_path)
+    keys = te_fp8_castable_keys(comp)
+
+    # The authority: the loader's block-window walk on the REAL module.
+    model = transformers.T5EncoderModel.from_pretrained(comp)
+    windows = loading_mod._fp8_block_windows(model)
+    castable = {id(p) for _, _, params in windows for p in params}
+    loader_keys = {n for n, p in model.named_parameters() if id(p) in castable}
+
+    assert keys == frozenset(loader_keys)
+    assert keys, "tiny T5 must have castable block weights"
+    # Embeddings and norms never cast (gw#460).
+    assert not any("embed" in k or "layer_norm" in k for k in keys)
+
+
+def test_snapshot_te_cast_is_loader_byte_identical(tmp_path: Path) -> None:
+    comp = _tiny_t5_encoder(tmp_path)
+    src = comp.parent
+    out = tmp_path / "out"
+
+    stats = streaming_fp8_snapshot(
+        src, out, file_layout="diffusers",
+        components=(), te_components=("text_encoder",),
+    )
+    assert "text_encoder" in stats["components"]
+
+    keys = te_fp8_castable_keys(comp)
+    src_t = _load_all_tensors(comp)
+    out_t = _load_all_tensors(out / "text_encoder")
+    assert set(src_t) == set(out_t)
+
+    n_cast = 0
+    for name, s in src_t.items():
+        o = out_t[name]
+        if name in keys:
+            assert o.dtype == torch.float8_e4m3fn, name
+            # Loader-equivalent bytes: bare .to() == clamp().to() for real
+            # weights (torch fp8 cast doesn't saturate; clamp only guards
+            # |w|>448 outliers, absent here and in practice).
+            expect = s.to(torch.float8_e4m3fn)
+            assert torch.equal(o.view(torch.uint8), expect.view(torch.uint8)), name
+            n_cast += 1
+        else:
+            assert o.dtype == s.dtype, name
+            assert torch.equal(o.view(torch.uint8), s.view(torch.uint8)), name
+    assert n_cast == len(keys)

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.10"
+version = "0.13.12"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
The gw#460 loader (PR #161) casts transformers TEs with block-window weight-only rules at load time. This lets the conversion writer produce the SAME cast as a stored flavor with zero drift:

- `te_fp8_castable_keys(component_dir)`: meta-instantiate the component's architecture from config.json and run the loader's own `_fp8_block_windows` walk — the castable key set IS the loader's, by construction.
- `streaming_fp8_te_cast()`: include-set streaming cast (clamp ±448 → F8_E4M3 for castable weights; everything else byte-identical passthrough).
- `streaming_fp8_snapshot(te_components=...)` + `FP8_TE_COMPONENTS` (drift-guard test against `loading._FP8_TEXT_ENCODER_COMPONENTS`).

Tests: key-set equality vs loader windows on a real module, byte-identity vs loader cast, component-list drift guard (3 new; fp8/writer/convert subset 212 passed).

Consumer: training-endpoints cast-dtype grows dtype "fp8+te" publishing as flavor "fp8" (mode=replace — th#697 has one fp8 rung; ie#377 binds one flavor). First artifact: tensorhub/ltx-2.3-distilled (ie#373 follow-up, prefetch ~41GB -> ~29.5GB).