### PR TITLE
gw#467: enforce the gw#456 timeout floor — AST lint guard + hf funnel + runtime floor test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
         continue-on-error: true  # Lint debt (mostly worker.py, being rewritten) — visible in logs, doesn't block CI.
         run: uv run ruff check src/gen_worker
 
+      # GATING (no continue-on-error): a bare HTTP call site is the gw#456
+      # forever-hang reintroduced. hf_hub network use goes through
+      # gen_worker.net.hf(); every httpx/requests call carries a timeout.
+      - name: HTTP timeout guard (gw#467)
+        run: uv run python scripts/lint_http_timeouts.py
+
       - name: Run tests
         run: uv run pytest tests/ -v
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,8 @@ tasks:
         ignore_error: true
       - cmd: uv run --extra dev ruff check src/gen_worker
         ignore_error: true
+      # Hard gate (matches CI): gw#467 HTTP timeout guard.
+      - cmd: uv run python scripts/lint_http_timeouts.py
 
   test:
     desc: Run tests

--- a/scripts/lint_http_timeouts.py
+++ b/scripts/lint_http_timeouts.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""gw#467: no HTTP call in src/gen_worker may be able to wait forever.
+
+Fails when any file (except the sanctioned gen_worker/net.py, where the
+COZY_HTTP_*_TIMEOUT_S floor lives) does one of:
+
+  1. import huggingface_hub network entry points — HfApi, snapshot_download,
+     hf_hub_download, ... must be reached via gen_worker.net.hf(), which
+     installs the timeout floor first. Non-network submodules
+     (huggingface_hub.errors / .constants) stay importable.
+  2. construct httpx.Client/AsyncClient or call an httpx request method
+     without an explicit timeout= keyword.
+  3. call a requests method (requests.get/post/... or *.request) without an
+     explicit timeout= keyword.
+
+Background: huggingface_hub's default client carries timeout=None (there is
+no hf_hub 2.x to fix it — latest is 1.x; we own the floor). A single bare
+call site reintroduces the gw#456 forever-hang.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+SANCTIONED = SRC_ROOT / "net.py"
+
+# huggingface_hub submodules with no network entry points.
+HF_ALLOWED_SUBMODULES = {"errors", "constants"}
+
+HTTPX_NEEDS_TIMEOUT = {
+    "Client", "AsyncClient", "request", "stream",
+    "get", "post", "put", "patch", "delete", "head", "options",
+}
+REQUESTS_NEEDS_TIMEOUT = {
+    "request", "get", "post", "put", "patch", "delete", "head", "options",
+}
+
+
+def _hf_module_banned(name: str) -> bool:
+    if name == "huggingface_hub":
+        return True
+    if name.startswith("huggingface_hub."):
+        return name.split(".")[1] not in HF_ALLOWED_SUBMODULES
+    return False
+
+
+def _has_timeout_kwarg(call: ast.Call) -> bool:
+    return any(kw.arg == "timeout" for kw in call.keywords) or any(
+        kw.arg is None for kw in call.keywords  # **kwargs: assume forwarded
+    )
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    problems: list[tuple[int, str]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _hf_module_banned(alias.name):
+                    problems.append((node.lineno,
+                                     f"import {alias.name} — use gen_worker.net.hf() (gw#467)"))
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level == 0 and _hf_module_banned(mod):
+                problems.append((node.lineno,
+                                 f"from {mod} import ... — use gen_worker.net.hf() (gw#467)"))
+        elif isinstance(node, ast.Call):
+            fn = node.func
+            if not (isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name)):
+                continue
+            base, attr = fn.value.id, fn.attr
+            needs = (base == "httpx" and attr in HTTPX_NEEDS_TIMEOUT) or \
+                    (base == "requests" and attr in REQUESTS_NEEDS_TIMEOUT)
+            if needs and not _has_timeout_kwarg(node):
+                problems.append((node.lineno,
+                                 f"{base}.{attr}(...) without explicit timeout= (gw#467)"))
+    return problems
+
+
+def main() -> int:
+    bad = 0
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if path == SANCTIONED:
+            continue
+        for lineno, msg in check_file(path):
+            print(f"{path.relative_to(SRC_ROOT.parents[1])}:{lineno}: {msg}")
+            bad += 1
+    if bad:
+        print(f"\nlint_http_timeouts: {bad} violation(s). Every HTTP call needs an explicit "
+              "timeout; huggingface_hub goes through gen_worker.net.hf().", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -648,8 +648,8 @@ def _resolve_local_path(
             # Best-effort: check the HF cache (huggingface_hub manages this
             # itself; a cache hit returns a path, miss raises).
             try:
-                from huggingface_hub import snapshot_download as _hf_snap
-                p = _hf_snap(
+                from ..net import hf
+                p = hf().snapshot_download(
                     repo_id=parsed.hf.repo_id,
                     revision=parsed.hf.revision,
                     local_files_only=True,

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from ..net import install_hf_http_timeouts
+from ..net import hf, install_hf_http_timeouts
 from .classifier import RepoClassification, classify_repo
 from .layout import detect_huggingface_source_layout
 
@@ -102,12 +102,10 @@ def resolve_hf_identity(
     hf_token: str | None = None,
 ) -> tuple[str, str]:
     """Resolve (repo_id, commit_sha) via the HF hub API."""
-    from huggingface_hub import HfApi
-
     repo_id = str(source_ref or "").strip()
     if repo_id.count("/") != 1:
         raise ValueError(f"huggingface source ref must be org/name, got {source_ref!r}")
-    info = HfApi(token=(hf_token or None)).repo_info(
+    info = hf().HfApi(token=(hf_token or None)).repo_info(
         repo_id, revision=(str(revision).strip() or None) if revision else None)
     return repo_id, str(getattr(info, "sha", "") or "")
 
@@ -120,9 +118,7 @@ def _hf_classification_inputs(
     """One list_repo_tree walk: paths, sizes, small side signals, and the
     provider's per-file content ids (lfs sha256 / git blob oid) — the
     latter feed the th#592 download-skip bank key."""
-    from huggingface_hub import HfApi
-
-    api = HfApi(token=(hf_token or None))
+    api = hf().HfApi(token=(hf_token or None))
     paths: list[str] = []
     sizes: dict[str, int] = {}
     content_ids: dict[str, str] = {}
@@ -148,10 +144,8 @@ def _hf_classification_inputs(
     side: dict[str, Any] = {}
     if "config.json" in paths:
         try:
-            from huggingface_hub import hf_hub_download
-
-            local = hf_hub_download(repo_id, "config.json", revision=revision,
-                                    token=(hf_token or None))
+            local = hf().hf_hub_download(repo_id, "config.json", revision=revision,
+                                         token=(hf_token or None))
             side["config_json"] = json.loads(Path(local).read_text(encoding="utf-8"))
         except Exception:
             side["config_json"] = None
@@ -160,9 +154,7 @@ def _hf_classification_inputs(
     if root_st and "model_index.json" not in paths and "adapter_config.json" not in paths:
         # LoRA sniff — remote safetensors __metadata__ via the hub API.
         try:
-            from huggingface_hub import get_safetensors_metadata
-
-            st_md = get_safetensors_metadata(repo_id, revision=revision, token=(hf_token or None))
+            st_md = hf().get_safetensors_metadata(repo_id, revision=revision, token=(hf_token or None))
             for fmeta in (getattr(st_md, "files_metadata", None) or {}).values():
                 md = getattr(fmeta, "metadata", None)
                 if md:
@@ -171,9 +163,7 @@ def _hf_classification_inputs(
         except Exception:
             pass
         try:
-            from huggingface_hub import ModelCard
-
-            card = ModelCard.load(repo_id, token=(hf_token or None))
+            card = hf().ModelCard.load(repo_id, token=(hf_token or None))
             tags = getattr(card.data, "tags", None) or []
             side["readme_tags"] = [str(t) for t in tags]
         except Exception:
@@ -330,7 +320,7 @@ def _snapshot_download_with_retries(
     progress and aborts no-progress downloads, and transient network failures
     retry (hf_hub resumes ``.incomplete`` files via Range). Exhausted retries
     raise :class:`CloneDownloadError`."""
-    from huggingface_hub import snapshot_download
+    snapshot_download = hf().snapshot_download
     from huggingface_hub.errors import (
         EntryNotFoundError,
         GatedRepoError,

--- a/src/gen_worker/convert/svdq.py
+++ b/src/gen_worker/convert/svdq.py
@@ -119,11 +119,11 @@ def fetch_svdq_checkpoint(
     hf_token: Optional[str] = None,
 ) -> Path:
     """Download ONE nunchaku checkpoint file from an HF repo (mirror lane)."""
-    from huggingface_hub import hf_hub_download
+    from ..net import hf
 
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
-    local = hf_hub_download(
+    local = hf().hf_hub_download(
         repo_id=repo_id,
         filename=filename,
         revision=revision,

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -496,16 +496,15 @@ def download_hf(
     """Blocking HF snapshot download (call via ``ensure_local`` /
     ``asyncio.to_thread``). Transfer, cache, resume and locking are
     huggingface_hub's; this only plans the file selection."""
+    from ..net import hf
+
     try:
-        from huggingface_hub import HfApi, snapshot_download
+        hub = hf()  # gw#456: no HF socket may wait forever
     except Exception as e:  # pragma: no cover
         raise RuntimeError(
             "huggingface_hub is required for hf model refs; install gen-worker with the HF extra."
         ) from e
-
-    from ..net import install_hf_http_timeouts
-
-    install_hf_http_timeouts()  # gw#456: no HF socket may wait forever
+    HfApi, snapshot_download = hub.HfApi, hub.snapshot_download
 
     repo_id = (ref.repo_id or "").strip()
     if not repo_id:

--- a/src/gen_worker/net.py
+++ b/src/gen_worker/net.py
@@ -99,9 +99,23 @@ def _install_requests_backend() -> None:
     configure_http_backend(backend_factory=_TimeoutSession)
 
 
+def hf() -> Any:
+    """THE sanctioned huggingface_hub accessor (gw#467): installs the timeout
+    floor, then returns the module. Every network entry point (HfApi,
+    snapshot_download, hf_hub_download, ...) must be reached through here —
+    the CI guard (scripts/lint_http_timeouts.py) rejects direct imports
+    anywhere else in src/, so the floor is structurally unskippable.
+    Non-network imports (huggingface_hub.errors / .constants) stay direct."""
+    install_hf_http_timeouts()
+    import huggingface_hub
+
+    return huggingface_hub
+
+
 __all__ = [
     "CONNECT_TIMEOUT_ENV",
     "READ_TIMEOUT_ENV",
+    "hf",
     "http_timeouts",
     "install_hf_http_timeouts",
 ]

--- a/tests/test_net_timeout_floor.py
+++ b/tests/test_net_timeout_floor.py
@@ -1,0 +1,55 @@
+"""gw#467: the wrapper's client can never carry an infinite timeout.
+
+Asserts the EFFECTIVE per-request timeouts on the sanctioned hf client are
+numeric — if an upstream huggingface_hub change ever bypasses our floor
+(different session plumbing, new client factory contract), this fails in
+tests instead of hanging in production. There is no hf_hub 2.x coming to fix
+the timeout=None default; we own the floor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import net
+
+
+def _effective_timeout(client, **request_kwargs) -> dict:
+    """Build a request and run the client's request hooks — exactly what
+    httpx does in send() before the transport reads the timeout."""
+    req = client.build_request("GET", "http://127.0.0.1:9/never", **request_kwargs)
+    for hook in client.event_hooks.get("request", []):
+        hook(req)
+    return dict(req.extensions.get("timeout") or {})
+
+
+@pytest.fixture()
+def hf_client(monkeypatch):
+    monkeypatch.setenv(net.CONNECT_TIMEOUT_ENV, "7")
+    monkeypatch.setenv(net.READ_TIMEOUT_ENV, "11")
+    hub = net.hf()  # the sanctioned accessor installs the floor
+    assert hasattr(hub, "HfApi") and hasattr(hub, "snapshot_download")
+    from huggingface_hub.utils._http import get_session
+
+    return get_session()
+
+
+def test_default_timeouts_are_numeric_never_none(hf_client):
+    t = _effective_timeout(hf_client)
+    for key in ("connect", "read", "write", "pool"):
+        assert isinstance(t.get(key), (int, float)) and t[key] > 0, \
+            f"effective {key} timeout must be numeric, got {t!r}"
+    assert t["connect"] == 7.0 and t["read"] == 11.0
+
+
+def test_explicit_none_is_floored(hf_client):
+    # The HfApi.repo_info shape: an explicit timeout=None must not mean
+    # "wait forever" — it gets the env floor.
+    t = _effective_timeout(hf_client, timeout=None)
+    assert t.get("connect") == 7.0 and t.get("read") == 11.0, t
+
+
+def test_explicit_numeric_timeout_wins(hf_client):
+    t = _effective_timeout(hf_client, timeout=3)
+    for key in ("connect", "read", "write", "pool"):
+        assert t.get(key) == 3.0, t


### PR DESCRIPTION
Paul's follow-up on gw#456: make the forever-hang structurally impossible to reintroduce, not just fixed at today's call sites.

1. **CI lint guard (gating):** `scripts/lint_http_timeouts.py` — AST walk over `src/gen_worker` that fails the build on (a) `httpx.Client/AsyncClient/<method>()` or `requests.<method>()` calls without an explicit `timeout=`, and (b) any `huggingface_hub` network-entry import outside the sanctioned `gen_worker/net.py` (non-network submodules `errors`/`constants` stay importable). Wired as a **non-continue-on-error** CI step and into `task lint`.
2. **Funnel rule:** new `net.hf()` accessor installs the COZY_HTTP_*_TIMEOUT_S floor and returns the module; all 9 direct hf network imports (convert/ingest.py, models/download.py, convert/svdq.py, cli/run.py) converted. The guard makes bypassing the funnel a build failure.
3. **Runtime floor test:** `tests/test_net_timeout_floor.py` builds requests on the wrapper's actual client and runs its request hooks — asserts effective connect/read/write/pool timeouts are numeric for the default case, that an explicit `timeout=None` (the `HfApi.repo_info` shape) is floored to the env values, and that explicit numeric timeouts win. Catches an upstream hf_hub plumbing change in tests instead of production.

Pin awareness: there is no huggingface_hub 2.x (latest 1.x) — upstream will not grow default timeouts; we own the floor.

Evidence: guard finds 9 violations pre-funnel, 0 after; 9/9 floor+clone-network tests pass; 198 passed / 2 skipped across convert, download, hf-selection, import-graph, mirror-first, cli-run suites; ruff + mypy clean on touched files.