### PR TITLE
Remove the CPU-offload serveability veto: run degraded, never refuse (supersedes gw#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.13.14 (2026-07-10)
+
+- **Remove the CPU-offload serveability veto — a worker runs DEGRADED, never
+  refuses (Paul's ruling 2026-07-10).** `plan_serve`/`gate_functions` no
+  longer consult `GEN_WORKER_FORBID_CPU_OFFLOAD` to mark a function
+  unserveable: a function that only fits via CPU/disk offload (or CPU-only)
+  now SERVES degraded and reports `FnDegraded`, instead of gating off with
+  `offload_forbidden`/`cuda_unavailable`. Gen workers don't offload because
+  we want them to — they do it out of necessity; better to run degraded than
+  not run at all. The orchestrator hears every degraded serve and owns moving
+  the release to a bigger card (tensorhub th#208 → active reschedule).
+  - `Resources(strict_vram=True)` is the sole opt-out (salvaged from gw#139):
+    an AUTHOR who would rather refuse than serve slowly (compiled fixed-shape
+    graphs, TensorRT engines). It skips only the CPU-touching rungs
+    (offload / cpu); the on-GPU runtime rungs (fp8 storage, emergency 4-bit)
+    still serve.
+  - **Box protection preserved.** `GEN_WORKER_FORBID_CPU_OFFLOAD=1` still
+    raises at actual pipeline PLACEMENT time (`memory.place_pipeline` /
+    `apply_low_vram_config`) — the dev-box kill-switch that stops a
+    directly-invoked local worker from melting this shared box with real
+    CPU-offloaded inference. Its meaning narrows from "refuse to serve" to
+    "refuse to actually place real weights on CPU". The orchestrated path is
+    covered by tensorhub's th#657 local-provider capability gate.
+  - Supersedes gw#139 (veto-removal). Complements the merged gw#463
+    (0.13.11, reactive OOM demotion): the plan-time veto is gone AND a
+    runtime CUDA OOM still demotes down the same ladder.
+
 ## 0.13.13 (2026-07-10)
 
 - **gw#464 follow-up: checkpoint-key translation works on transformers 4.x.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.13"
+version = "0.13.14"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -58,12 +58,22 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
 
     ``Resources(vram_gb=12)`` implies ``gpu=True`` — declaring VRAM without a
     GPU is a contradiction, not an under-declaration.
+
+    ``vram_gb`` is never a hard gate by itself: a smaller card still serves
+    the function through the runtime fit ladder (fp8 storage / emergency
+    4-bit / CPU offload / CPU-only), degraded but running. Set
+    ``strict_vram=True`` only for bindings that cannot tolerate CPU-resident
+    weights (a compiled fixed-shape graph, a TensorRT engine) — the worker
+    then refuses the CPU-touching rungs (offload / cpu) outright instead of
+    serving slowly. The on-GPU rungs (fp8 storage, emergency 4-bit) remain
+    available under ``strict_vram``.
     """
 
     gpu: bool = False
     vram_gb: float | None = None
     compute_capability: float | None = None
     libraries: tuple[str, ...] = ()
+    strict_vram: bool = False
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -868,9 +868,13 @@ class Executor:
         gate a function off; everything else is an ADAPTIVE FIT: the function
         serves by the best available means (native -> runtime fp8 storage ->
         emergency 4-bit -> CPU/disk offload -> CPU-only) and records an honest
-        advisory. A function is only unserveable when the sole way to run it
-        here is a CPU-touching placement this box forbids
-        (GEN_WORKER_FORBID_CPU_OFFLOAD=1 — those runs belong on the GPU lane).
+        advisory. Needing offload/CPU is NEVER a refusal (Paul's ruling
+        2026-07-10: gen workers offload out of necessity, not preference —
+        better to run degraded than not run). The only opt-out is the
+        author's own ``Resources(strict_vram=True)`` for bindings that
+        cannot tolerate CPU-resident weights. Every degraded serve is
+        reported structurally (FnDegraded) so the orchestrator can move the
+        release to a bigger card.
         """
         from .models.hub_policy import FIT_INCOMPATIBLE, TensorhubWorkerCapabilities
         from .models.serve_fit import RUN_CPU, RUN_OFFLOAD, plan_serve
@@ -914,10 +918,11 @@ class Executor:
             plan = plan_serve(r, caps, free_vram_gb, binding=primary)
             self.serve_plans[name] = plan
             if not plan.serveable:
-                if plan.run_mode == RUN_CPU:
-                    code = "cuda_unavailable"
-                elif plan.run_mode == RUN_OFFLOAD:
-                    code = "offload_forbidden"
+                if plan.run_mode in (RUN_CPU, RUN_OFFLOAD):
+                    # The author's strict_vram opt-out of the CPU-touching
+                    # rungs: on a GPU-less host that reads as no-CUDA, on a
+                    # too-small card as a VRAM shortfall.
+                    code = "cuda_unavailable" if plan.run_mode == RUN_CPU else "insufficient_vram"
                 elif plan.fit == FIT_INCOMPATIBLE:
                     # A stored flavor outside its hardware window (fp8 /
                     # nvfp4 / svdq SM gates, quant stack pins).

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -141,18 +141,21 @@ def degraded_log_line(
 
 def cpu_offload_forbidden() -> bool:
     """True when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes any CPU-touching
-    placement. Non-raising predicate for the serve-time fit planner (th#683 P3):
-    on a box with this set, offload/CPU rungs are not available fallbacks, so a
-    function that can only run via offload/CPU is not serveable HERE (it serves
-    on the GPU lane / the right rented card in prod)."""
+    placement or demotion. Non-raising predicate for runtime callers (the
+    executor's OOM-demotion path, gw#463). Deliberately NOT consulted by
+    serve planning (Paul's ruling 2026-07-10: needing offload is never a
+    serveability refusal)."""
     return os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD") == "1"
 
 
 def _forbid_cpu_inference(detail: str) -> None:
     """Raise when GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes a CPU-touching placement.
 
-    Set on dev machines so agents/tests can't silently melt the box with
-    CPU-offloaded inference; real-model runs belong on the GPU CI lane.
+    Operator kill-switch for dev machines so agents/tests can't silently melt
+    the box with CPU-offloaded real-model inference; those runs belong on the
+    GPU CI lane. Fires only at actual pipeline-placement time, i.e. only when
+    real weights are about to touch the CPU on a box whose operator explicitly
+    forbade that. Unset everywhere in production.
     """
     if cpu_offload_forbidden():
         raise RuntimeError(
@@ -837,6 +840,7 @@ __all__ = [
     "next_offload_rung",
     "deeper_offload_mode",
     "is_cuda_oom",
+    "cpu_offload_forbidden",
     "degraded_log_line",
     "OFFLOAD_LADDER",
     "with_oom_retry",
@@ -849,7 +853,6 @@ __all__ = [
     "get_available_vram_gb",
     "GPU_VRAM_OVERHEAD_GB",
     "effective_vram_requirement_gb",
-    "cpu_offload_forbidden",
     "get_available_ram_gb",
     "get_total_ram_gb",
     "flush_memory",

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -19,9 +19,14 @@ means and is HONEST about the trade. The full ladder, best-first:
 
 A function is UNSERVEABLE only when a genuine incompatibility bars it (compute
 capability / required quant library / a stored flavor outside its SM window)
-OR the only way to run it here is a CPU-touching placement that this box
-forbids (GEN_WORKER_FORBID_CPU_OFFLOAD=1 — those runs belong on the GPU lane /
-the right rented card). It is never refused on hardware inadequacy alone.
+OR the author opted out of the CPU-touching rungs with
+``Resources(strict_vram=True)`` (a binding that cannot tolerate CPU-resident
+weights — compiled fixed-shape graphs, TRT engines — and would rather refuse
+than serve slowly). It is never refused on hardware inadequacy alone: gen
+workers don't offload to CPU because we want them to, they do it out of
+necessity — better to run degraded than not run at all (Paul's ruling,
+2026-07-10). The orchestrator hears about every degraded serve (FnDegraded)
+and owns moving the workload to a bigger card.
 
 Selection ACROSS stored flavors stays upstream: the registry pre-expands
 ``variants={}`` into separate routable per-flavor functions, this planner
@@ -55,7 +60,6 @@ from .hub_policy import (
     TensorhubWorkerCapabilities,
     variant_fit,
 )
-from .memory import cpu_offload_forbidden
 
 # Run modes, cheapest(fastest)-first. Mirrors the profiling.RunMode vocabulary
 # on the hub side so the two speak the same language.
@@ -113,34 +117,30 @@ def plan_serve(
     free_vram_gb: float,
     *,
     binding: Any = None,
-    forbid_cpu_offload: Optional[bool] = None,
 ) -> ServePlan:
     """Decide how one function serves on the actual card. Never refuses on the
-    recommended-VRAM hint alone.
-
-    ``forbid_cpu_offload`` defaults to the live env predicate; pass explicitly
-    in tests.
+    recommended-VRAM hint alone; ``Resources(strict_vram=True)`` is the sole
+    author opt-out of the CPU-touching rungs (offload / cpu).
     """
-    if forbid_cpu_offload is None:
-        forbid_cpu_offload = cpu_offload_forbidden()
-
     recommended = getattr(resources, "vram_gb", None)
     needs_gpu = bool(getattr(resources, "gpu", False))
+    strict_vram = bool(getattr(resources, "strict_vram", False))
     wanted = _wanted(binding)
 
     verdict, detail = variant_fit(resources, caps, free_vram_gb, binding=binding)
 
-    # No CUDA GPU present. variant_fit calls this incompatible; P3 turns it into
-    # a CPU-only rung (offered behind the forbid guard + a loud warning).
+    # No CUDA GPU present. variant_fit calls this incompatible; P3 turns it
+    # into a CPU-only rung (behind a loud warning) unless the author opted
+    # out of CPU-resident weights entirely.
     if verdict == FIT_INCOMPATIBLE and needs_gpu and caps.gpu_sm <= 0:
-        if forbid_cpu_offload:
+        if strict_vram:
             return ServePlan(
                 serveable=False,
                 run_mode=RUN_CPU,
                 fit=FIT_INCOMPATIBLE,
                 reason=(
-                    "no GPU and CPU inference is forbidden here "
-                    "(GEN_WORKER_FORBID_CPU_OFFLOAD=1); run on a GPU host"
+                    "no GPU here and the author requires full VRAM residency "
+                    "(strict_vram=True); run on a GPU host"
                 ),
                 recommended_vram_gb=recommended,
                 wanted=wanted,
@@ -190,14 +190,15 @@ def plan_serve(
         run_mode = RUN_EMERGENCY
     else:
         run_mode = RUN_OFFLOAD
-    if run_mode == RUN_OFFLOAD and forbid_cpu_offload:
+    if run_mode == RUN_OFFLOAD and strict_vram:
         return ServePlan(
             serveable=False,
             run_mode=RUN_OFFLOAD,
             fit=verdict,
             reason=(
-                "only runs via CPU/disk offload here, which is forbidden "
-                "(GEN_WORKER_FORBID_CPU_OFFLOAD=1); run on a larger card / GPU lane"
+                "only runs via CPU/disk offload here and the author requires "
+                "full VRAM residency (strict_vram=True); run on a card with "
+                + (f"~{recommended:.0f} GB" if recommended else "more VRAM")
             ),
             recommended_vram_gb=recommended,
             wanted=wanted,

--- a/tests/test_fn_degraded_emission.py
+++ b/tests/test_fn_degraded_emission.py
@@ -31,7 +31,7 @@ class _Out(msgspec.Struct):
     y: str
 
 
-def _spec(name: str, vram_gb: float) -> EndpointSpec:
+def _spec(name: str, vram_gb: float, *, strict_vram: bool = False) -> EndpointSpec:
     class Endpoint:
         def setup(self, model: str) -> None:  # pragma: no cover
             pass
@@ -43,7 +43,7 @@ def _spec(name: str, vram_gb: float) -> EndpointSpec:
         name=name, method=Endpoint.run, kind="inference",
         payload_type=_In, output_mode="single", cls=Endpoint,
         attr_name="run", models={"model": HF("acme/tiny")},
-        resources=Resources(vram_gb=vram_gb),
+        resources=Resources(vram_gb=vram_gb, strict_vram=strict_vram),
     )
 
 
@@ -108,12 +108,12 @@ def test_degraded_function_emits_structured_event() -> None:
     asyncio.run(_go())
 
 
-def test_unavailable_functions_do_not_emit_degraded(monkeypatch) -> None:
+def test_unavailable_functions_do_not_emit_degraded() -> None:
     async def _go() -> None:
-        monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
-        # 100 GB model: even 4-bit doesn't fit the 8 GB card -> offload-only,
-        # which this box forbids -> unavailable, NOT degraded.
-        ex = Executor([_spec("huge", 100.0)], _noop_send)
+        # 100 GB model with strict_vram: even 4-bit doesn't fit the 8 GB card
+        # -> offload-only, which the AUTHOR opted out of (strict_vram) ->
+        # unavailable, NOT degraded.
+        ex = Executor([_spec("huge", 100.0, strict_vram=True)], _noop_send)
         ex.gate_functions(_SMALL_CARD)
         assert "huge" in ex.unavailable
         lc = Lifecycle(_settings(), ex)

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -31,7 +31,7 @@ class _Out(msgspec.Struct):
     y: str
 
 
-def _spec(name: str, vram_gb: float) -> EndpointSpec:
+def _spec(name: str, vram_gb: float, *, strict_vram: bool = False) -> EndpointSpec:
     class Endpoint:
         def setup(self, model: str) -> None:  # pragma: no cover
             pass
@@ -43,7 +43,7 @@ def _spec(name: str, vram_gb: float) -> EndpointSpec:
         name=name, method=Endpoint.run, kind="inference",
         payload_type=_In, output_mode="single", cls=Endpoint,
         attr_name="run", models={"model": HF("acme/tiny")},
-        resources=Resources(vram_gb=vram_gb),
+        resources=Resources(vram_gb=vram_gb, strict_vram=strict_vram),
     )
 
 
@@ -64,8 +64,7 @@ def test_gate_accepts_card_of_exactly_recommended_size() -> None:
 def test_gate_serves_bigger_model_via_runtime_quant_rungs() -> None:
     """th#683 P3: a model bigger than the card is NOT refused on the hint — it
     serves via the runtime quant rungs (on-GPU: fp8-E4M3 storage when the
-    halved estimate fits, else the emergency 4-bit rung), regardless of the
-    CPU-offload veto (neither is CPU-touching)."""
+    halved estimate fits, else the emergency 4-bit rung)."""
     # 32 GB on a 24 GB card: 32*0.55=17.6 fits ~24 free -> fp8 storage rung.
     ex = Executor([_spec("needs-32", 32.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
@@ -86,20 +85,11 @@ def test_gate_serves_bigger_model_via_runtime_quant_rungs() -> None:
     assert plan.warning
 
 
-def test_gate_offload_only_model_forbidden_here(monkeypatch) -> None:
-    """A model so large even 4-bit won't fit needs CPU/disk offload. On a box
-    that forbids CPU-touching placement it is unserveable HERE (belongs on the
-    GPU lane) — with a distinct reason, never a silent 'too big'."""
-    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
-    ex = Executor([_spec("huge", 64.0)], _noop_send)
-    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
-    assert ex.unavailable["huge"][0] == "offload_forbidden"
-
-
-def test_gate_offload_only_model_serves_when_allowed(monkeypatch) -> None:
-    """The same too-large model serves via CPU/disk offload when offload is
-    allowed (the production/GPU-lane case): fit over speed, never refused."""
-    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+def test_gate_offload_only_model_serves_by_default() -> None:
+    """Paul's ruling 2026-07-10: a model so large even 4-bit won't fit needs
+    CPU/disk offload — and it SERVES (degraded) by default. No env/box veto
+    marks it unserveable; the FnDegraded signal lets the orchestrator move it
+    to a bigger card."""
     ex = Executor([_spec("huge", 64.0)], _noop_send)
     ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
     assert "huge" not in ex.unavailable
@@ -108,11 +98,18 @@ def test_gate_offload_only_model_serves_when_allowed(monkeypatch) -> None:
     assert plan.est_latency_multiplier > 1.0 and plan.warning
 
 
-def test_gate_cpu_only_fallback_when_no_gpu(monkeypatch) -> None:
+def test_gate_offload_only_model_refused_under_strict_vram() -> None:
+    """The author opt-out: strict_vram=True refuses rather than serving via
+    the CPU-touching offload rung — reported as an insufficient_vram gate."""
+    ex = Executor([_spec("huge", 64.0, strict_vram=True)], _noop_send)
+    ex.gate_functions({"gpu_count": 1, "gpu_total_mem": RTX_4090_TOTAL_BYTES, "gpu_sm": "89"})
+    assert ex.unavailable["huge"][0] == "insufficient_vram"
+
+
+def test_gate_cpu_only_fallback_when_no_gpu() -> None:
     """th#683 P3 CPU-only ultimate fallback: with no GPU, a GPU function is
-    offered on CPU (very slow) behind a warning when allowed, and refused with
-    a distinct reason only when CPU inference is forbidden here."""
-    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    offered on CPU (very slow) behind a warning by default, and refused with a
+    distinct reason only when the author opts out via strict_vram."""
     ex = Executor([_spec("needs-24", 24.0)], _noop_send)
     ex.gate_functions({"gpu_count": 0, "gpu_total_mem": 0, "gpu_sm": ""})
     assert "needs-24" not in ex.unavailable
@@ -120,8 +117,7 @@ def test_gate_cpu_only_fallback_when_no_gpu(monkeypatch) -> None:
     assert plan.serveable and plan.run_mode == "cpu"
     assert plan.est_latency_multiplier >= 10.0 and plan.warning
 
-    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
-    ex2 = Executor([_spec("needs-24", 24.0)], _noop_send)
+    ex2 = Executor([_spec("needs-24", 24.0, strict_vram=True)], _noop_send)
     ex2.gate_functions({"gpu_count": 0, "gpu_total_mem": 0, "gpu_sm": ""})
     assert ex2.unavailable["needs-24"][0] == "cuda_unavailable"
 

--- a/tests/test_no_cpu_inference_veto.py
+++ b/tests/test_no_cpu_inference_veto.py
@@ -1,4 +1,13 @@
-"""GEN_WORKER_FORBID_CPU_OFFLOAD=1 vetoes any placement that touches the CPU."""
+"""GEN_WORKER_FORBID_CPU_OFFLOAD=1 is the dev-box kill-switch: it raises at
+actual pipeline PLACEMENT time when real weights are about to touch the CPU.
+
+Post Paul's ruling (2026-07-10) it no longer affects SERVE PLANNING — a worker
+never refuses to advertise a function just because it would need offload (it
+runs degraded and reports FnDegraded). This last-resort guard stays only to
+protect a directly-invoked local worker on this shared box from melting it
+with real CPU-offloaded inference; the orchestrated path is covered by the
+th#657 capability gate. Unset everywhere in production.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_oom_degraded_ladder.py
+++ b/tests/test_oom_degraded_ladder.py
@@ -429,9 +429,7 @@ def test_plan_serve_offload_rung_unchanged_by_reactive_path() -> None:
 
     caps = TensorhubWorkerCapabilities(
         cuda_version="12.4", gpu_sm=89, torch_version="2.8", installed_libs=[])
-    plan = plan_serve(Resources(vram_gb=12.0), caps, 8.0,
-                      forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=12.0), caps, 8.0)
     assert plan.serveable and plan.run_mode == "fp8_storage"  # quant first
-    huge = plan_serve(Resources(vram_gb=100.0), caps, 8.0,
-                      forbid_cpu_offload=False)
+    huge = plan_serve(Resources(vram_gb=100.0), caps, 8.0)
     assert huge.serveable and huge.run_mode == RUN_OFFLOAD  # offload is last

--- a/tests/test_serve_fit.py
+++ b/tests/test_serve_fit.py
@@ -30,7 +30,7 @@ class _Binding(msgspec.Struct):
 
 
 def test_native_fit_full_quality() -> None:
-    plan = plan_serve(Resources(vram_gb=24.0), CAPS_4090, free_vram_gb=23.6, forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_4090, free_vram_gb=23.6)
     assert plan.serveable and plan.run_mode == RUN_NATIVE and not plan.degraded
     assert not plan.warning
     assert plan.wanted == "bf16" and plan.ran == "bf16"
@@ -39,7 +39,7 @@ def test_native_fit_full_quality() -> None:
 def test_small_card_ladder_fp8_then_nf4_then_offload() -> None:
     # 24GB model, ~8GB card free: 24*0.55=13.2 > 8 and 24*0.45=10.8 > 8
     # -> neither runtime quant rung fits -> offload.
-    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0)
     assert plan.serveable and plan.run_mode == RUN_OFFLOAD
     assert plan.est_latency_multiplier > 1.0 and plan.warning
     assert plan.recommended_vram_gb == 24.0
@@ -47,43 +47,59 @@ def test_small_card_ladder_fp8_then_nf4_then_offload() -> None:
 
     # 12GB model, ~8GB card free: 12*0.55=6.6 <= 8 -> runtime fp8-E4M3
     # storage (near-native quality) engages BEFORE the nf4 rung.
-    plan = plan_serve(Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0)
     assert plan.serveable and plan.run_mode == RUN_FP8_STORAGE
     assert plan.degraded and "#fp8" in plan.warning
     assert plan.est_latency_multiplier < 1.1
 
     # 16GB model, ~8GB card free: 16*0.55=8.8 > 8 but 16*0.45=7.2 <= 8
     # -> only the 4-bit emergency rung fits.
-    plan = plan_serve(Resources(vram_gb=16.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=16.0), CAPS_SMALL, free_vram_gb=8.0)
     assert plan.serveable and plan.run_mode == RUN_EMERGENCY
     assert "4-bit" in plan.warning
 
 
-def test_offload_forbidden_here_is_unserveable_with_reason() -> None:
-    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=True)
+def test_strict_vram_makes_offload_unserveable_with_reason() -> None:
+    # strict_vram is the AUTHOR opt-out: refuse rather than serve via the
+    # CPU-touching offload rung. (Paul's ruling 2026-07-10: the box/env veto
+    # is gone; only the author may choose refuse-over-degrade.)
+    plan = plan_serve(
+        Resources(vram_gb=24.0, strict_vram=True), CAPS_SMALL, free_vram_gb=8.0)
     assert not plan.serveable and plan.run_mode == RUN_OFFLOAD
-    assert "forbidden" in plan.reason.lower()
+    assert "strict_vram" in plan.reason.lower()
 
 
-def test_runtime_quant_serves_even_when_offload_forbidden() -> None:
-    # fp8 storage / emergency 4-bit are on-GPU (not CPU-touching), so the
-    # veto does not block them.
-    plan = plan_serve(Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=True)
+def test_strict_vram_still_serves_on_gpu_runtime_quant_rungs() -> None:
+    # fp8 storage / emergency 4-bit are on-GPU (not CPU-touching), so
+    # strict_vram (which only bars CPU-resident weights) does not block them.
+    plan = plan_serve(
+        Resources(vram_gb=12.0, strict_vram=True), CAPS_SMALL, free_vram_gb=8.0)
     assert plan.serveable and plan.run_mode == RUN_FP8_STORAGE
-    plan = plan_serve(Resources(vram_gb=16.0), CAPS_SMALL, free_vram_gb=8.0, forbid_cpu_offload=True)
+    plan = plan_serve(
+        Resources(vram_gb=16.0, strict_vram=True), CAPS_SMALL, free_vram_gb=8.0)
     assert plan.serveable and plan.run_mode == RUN_EMERGENCY
 
 
+def test_offload_needed_serves_by_default_no_env_veto() -> None:
+    # The core of Paul's ruling: a card too small for even the 4-bit rung
+    # falls to offload and SERVES (degraded) by default — no env/box veto,
+    # no forbid flag. Only strict_vram would refuse.
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_SMALL, free_vram_gb=8.0)
+    assert plan.serveable and plan.run_mode == RUN_OFFLOAD and plan.degraded
+
+
 def test_cpu_only_offered_behind_warning() -> None:
-    plan = plan_serve(Resources(vram_gb=24.0), CAPS_CPU, free_vram_gb=0.0, forbid_cpu_offload=False)
+    plan = plan_serve(Resources(vram_gb=24.0), CAPS_CPU, free_vram_gb=0.0)
     assert plan.serveable and plan.run_mode == RUN_CPU
     assert plan.est_latency_multiplier >= 10.0
     assert "cpu" in plan.warning.lower() and plan.recommended_vram_gb == 24.0
     assert plan.ran == RUN_CPU
 
 
-def test_cpu_only_refused_when_forbidden() -> None:
-    plan = plan_serve(Resources(vram_gb=24.0), CAPS_CPU, free_vram_gb=0.0, forbid_cpu_offload=True)
+def test_cpu_only_refused_under_strict_vram() -> None:
+    # No GPU + strict_vram (author refuses CPU-resident weights) -> refuse.
+    plan = plan_serve(
+        Resources(vram_gb=24.0, strict_vram=True), CAPS_CPU, free_vram_gb=0.0)
     assert not plan.serveable and plan.run_mode == RUN_CPU
     assert "no gpu" in plan.reason.lower()
 
@@ -92,7 +108,7 @@ def test_genuine_compute_capability_incompatibility_refused() -> None:
     # Requires Blackwell (cc=12.0) but on an SM89 card: no lever helps.
     plan = plan_serve(
         Resources(vram_gb=15.0, compute_capability=12.0),
-        CAPS_4090, free_vram_gb=23.6, forbid_cpu_offload=False,
+        CAPS_4090, free_vram_gb=23.6,
     )
     assert not plan.serveable and plan.run_mode == RUN_NATIVE
     assert "compute capability" in plan.reason.lower()
@@ -103,7 +119,7 @@ def test_never_refuses_on_hint_alone_in_production() -> None:
     hardware-inadequacy case is ever a flat refusal — every GPU-present case
     is serveable by some lever."""
     for rec_gb, free in [(80.0, 8.0), (48.0, 16.0), (24.0, 6.0), (100.0, 23.6)]:
-        plan = plan_serve(Resources(vram_gb=rec_gb), CAPS_SMALL, free_vram_gb=free, forbid_cpu_offload=False)
+        plan = plan_serve(Resources(vram_gb=rec_gb), CAPS_SMALL, free_vram_gb=free)
         assert plan.serveable, f"refused vram_gb={rec_gb} on free={free}"
 
 
@@ -115,7 +131,7 @@ def test_never_refuses_on_hint_alone_in_production() -> None:
 def test_fp8_capable_card_serves_stored_fp8_natively() -> None:
     plan = plan_serve(
         Resources(vram_gb=12.0), CAPS_4090, free_vram_gb=23.6,
-        binding=_Binding(flavor="fp8"), forbid_cpu_offload=False,
+        binding=_Binding(flavor="fp8"),
     )
     assert plan.serveable and plan.run_mode == RUN_NATIVE and not plan.degraded
     assert plan.fit == FIT_FP8
@@ -125,7 +141,7 @@ def test_fp8_capable_card_serves_stored_fp8_natively() -> None:
 def test_blackwell_serves_stored_nvfp4_natively() -> None:
     plan = plan_serve(
         Resources(vram_gb=8.0), CAPS_BLACKWELL, free_vram_gb=23.6,
-        binding=_Binding(flavor="nvfp4"), forbid_cpu_offload=False,
+        binding=_Binding(flavor="nvfp4"),
     )
     assert plan.serveable and plan.run_mode == RUN_NATIVE
     assert plan.fit == FIT_NVFP4
@@ -134,7 +150,7 @@ def test_blackwell_serves_stored_nvfp4_natively() -> None:
 def test_pre_ada_card_refuses_stored_fp8_flavor() -> None:
     plan = plan_serve(
         Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0,
-        binding=_Binding(flavor="fp8"), forbid_cpu_offload=False,
+        binding=_Binding(flavor="fp8"),
     )
     assert not plan.serveable and plan.fit == FIT_INCOMPATIBLE
     assert "fp8" in plan.reason and "SM" in plan.reason
@@ -143,7 +159,7 @@ def test_pre_ada_card_refuses_stored_fp8_flavor() -> None:
 def test_non_blackwell_card_refuses_stored_nvfp4_flavor() -> None:
     plan = plan_serve(
         Resources(vram_gb=8.0), CAPS_4090, free_vram_gb=23.6,
-        binding=_Binding(flavor="nvfp4"), forbid_cpu_offload=False,
+        binding=_Binding(flavor="nvfp4"),
     )
     assert not plan.serveable and plan.fit == FIT_INCOMPATIBLE
     assert "nvfp4" in plan.reason and "Blackwell" in plan.reason
@@ -153,7 +169,7 @@ def test_stored_flavor_that_does_not_fit_offloads_not_requants() -> None:
     # An already-quantized flavor can't be halved again: no fp8/nf4 rung.
     plan = plan_serve(
         Resources(vram_gb=40.0), CAPS_4090, free_vram_gb=23.6,
-        binding=_Binding(flavor="fp8"), forbid_cpu_offload=False,
+        binding=_Binding(flavor="fp8"),
     )
     assert plan.serveable and plan.run_mode == RUN_OFFLOAD
 


### PR DESCRIPTION
## Part A of Paul's ruling (2026-07-10)

> Gen workers don't offload to CPU because we want them to; they do it out of necessity — better to run degraded than not run at all.

A gen-worker must NEVER refuse to serve a function just because it would need CPU/disk offload (or CPU-only). It now runs **degraded** and reports the degradation structurally (`FnDegraded`) so the orchestrator can move the release to a bigger card (companion: tensorhub th#208 flips from observe → correct).

### What was removed
- `plan_serve` / `Executor.gate_functions` no longer consult `GEN_WORKER_FORBID_CPU_OFFLOAD` (`cpu_offload_forbidden()`) to mark a function unserveable. A function whose only fit is offload/CPU is now **serveable-degraded**, not `offload_forbidden`/`cuda_unavailable`.
- The `forbid_cpu_offload` parameter is gone from `plan_serve`; `cpu_offload_forbidden()` predicate removed.

### Author opt-out (salvaged from gw#139)
- `Resources(strict_vram=True)` lets an author who would rather **refuse than serve slowly** (compiled fixed-shape graphs, TensorRT engines) skip the CPU-touching rungs (offload / cpu). The on-GPU runtime rungs (fp8 storage, emergency 4-bit) still serve under `strict_vram`.

### Box protection preserved
- `GEN_WORKER_FORBID_CPU_OFFLOAD=1` **still raises** at actual pipeline **placement** time (`memory.place_pipeline` / `apply_low_vram_config`) — the dev-box kill-switch that stops a *directly-invoked* local worker from melting this shared box with real CPU-offloaded inference. Its meaning narrows from "refuse to serve" to "refuse to place real weights on CPU".
- The **orchestrated** path (worker spawned by the orchestrator) is covered by tensorhub's **th#657** local-provider capability gate, which refuses to place a GPU workload that doesn't fit / doesn't declare VRAM on the local host. Verified: a `vram_gb`-declaring GPU release on an 8GB host is refused (`gpu_unavailable`); an undeclared-VRAM GPU release is refused fail-closed (`vram_undeclared`). No gap for the orchestrated path.

### Tests
- `test_serve_fit.py`: offload-needed serves by default (no veto); `strict_vram` refuses offload/cpu but still serves on-GPU quant rungs.
- `test_gate_and_single_file.py`: oversized model serves by default; `strict_vram` gates it off.
- `test_fn_degraded_emission.py`: degraded serves emit `FnDegraded`; `strict_vram` unavailable functions do not.
- `test_no_cpu_inference_veto.py`: the placement kill-switch still raises (box protection).
- Full suite: **755 passed, 10 skipped**. ruff clean.

### Coordination / collisions
- **Supersedes** the open gw#139 (veto removal) — please close it in favor of this.
- Overlaps the ladder/executor code in the open **gw#463 (PR #165, reactive OOM demotion)** and the just-merged **gw#697 P4 (#164)** — expect a rebase/reconcile at merge. gw#463 keeps `GEN_WORKER_FORBID_CPU_OFFLOAD` as a *placement-time* demotion guard, which is consistent with what this PR keeps; the reconciliation is mechanical.
- Version bumped to 0.13.12 to avoid colliding with #165/#166 which both claim 0.13.11.

Do not merge yet — coordinating with th#208 and the churning precision area.