### PR TITLE
gw#464: transformers 4.x fallback for TE key translation (0.13.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.13.13 (2026-07-10)
+
+- **gw#464 follow-up: checkpoint-key translation works on transformers 4.x.**
+  `te_fp8_castable_keys` now falls back to the 4.x class-attr
+  `_checkpoint_conversion_mapping` (regex `re.sub` chain, the
+  `from_pretrained` mechanism of that line) when the 5.x
+  `conversion_mapping`/`core_model_loading` modules are absent — the
+  conversion fleet image locks transformers 4.57. Verified against the
+  real LTX-2.3 Gemma3 TE metadata: 498/498 loader-castable weights match
+  their stored (old-layout) key names.
+
 ## 0.13.12 (2026-07-10)
 
 - **gw#464: storage-side fp8 for text encoders — `streaming_fp8_snapshot(te_components=...)`.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.12"
+version = "0.13.13"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -729,8 +729,21 @@ def _loader_key_translator(model: Any) -> Any:
             WeightRenaming,
             rename_source_key,
         )
-    except ImportError:  # older transformers: keys match the graph directly
-        return lambda k: k
+    except ImportError:
+        # transformers 4.x: the mapping is a class attr of regex->replacement
+        # pairs, applied by from_pretrained via re.sub in order.
+        import re as _re
+
+        mapping = getattr(type(model), "_checkpoint_conversion_mapping", None)
+        if not mapping:
+            return lambda k: k
+
+        def translate_4x(key: str) -> str:
+            for pat, repl in mapping.items():
+                key = _re.sub(pat, repl, key)
+            return key
+
+        return translate_4x
     try:
         transforms = get_model_conversion_mapping(model)
     except Exception:  # noqa: BLE001

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.12"
+version = "0.13.13"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
The conversion fleet image locks transformers 4.57, where checkpoint-key conversion lives on the class attr `_checkpoint_conversion_mapping` (re.sub chain) rather than 5.x's conversion_mapping/core_model_loading modules. te_fp8_castable_keys now uses that mechanism as fallback. Dry-run against the real LTX-2.3 Gemma3 TE metadata under 4.57.6: 498/498 loader-castable weights matched to stored old-layout keys, 0 unmatched, 0 suspicious.