### PR TITLE
fp8: SM-aware ladder ordering + remove the pre-Ada fp8 refuse-bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.15 (2026-07-10)
+
+- **fp8: SM-aware ladder ordering + remove the pre-Ada fp8 refuse-bug.**
+  Stored `#fp8` flavors upcast to bf16 at compute (fp8-E4M3 bytes resident,
+  per-layer bf16 upcast — no fp8 silicon required), so they serve on ANY CUDA
+  card; the old `FP8_FLAVOR_MIN_SM=89` refusal is deleted. Preference is now
+  SM-conditional: SM>=89 (Ada/Hopper/Blackwell) prefers fp8 over bf16 (faster
+  AND smaller); SM<89 prefers bf16-if-it-fits with fp8 as a fit fallback.
+  nvfp4 stays SM-gated (genuine Blackwell-native format, no upcast path).
+  - Single-sourced constants: `loading.EMERGENCY_FIT_FACTOR` derives from
+    `ladder.EMERGENCY_NF4_VRAM_FACTOR`; the private `FP8_FLAVOR_MIN_SM` is gone.
+  - SM-conditional ordering encoded in the shared Go/Py conformance vectors
+    (byte-identical with tensorhub).
+  - GPU smoke lane: bf16-vs-fp8 same prompt+seed generation asserts
+    SSIM >= 0.88 (gated by `GEN_WORKER_GPU_SMOKE`; skips on CPU).
+
 ## 0.13.14 (2026-07-10)
 
 - **Remove the CPU-offload serveability veto — a worker runs DEGRADED, never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.14"
+version = "0.13.15"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -103,11 +103,14 @@ FIT_EMERGENCY = "emergency_quant"
 FIT_OFFLOAD = "offload"
 FIT_INCOMPATIBLE = "incompatible"
 
-# Stored-flavor hardware windows (th#683 fit ladder), same SM-gating pattern
-# as the svdq rows: a flavor only serves on silicon whose kernels/format
-# support it. fp8 flavors are an Ada-and-newer rung (sm_89 Ada, sm_90 Hopper,
-# sm_100+ Blackwell); nvfp4 tensor-core kernels exist on Blackwell only.
-FP8_FLAVOR_MIN_SM = 89
+# Stored-flavor hardware windows. nvfp4 is a genuine native-compute format:
+# its tensor-core kernels exist on Blackwell only, so an nvfp4 stored flavor
+# on older silicon is a hard refusal. fp8 is DIFFERENT — fp8-E4M3 storage
+# upcasts per-layer to bf16 at compute (loading.apply_fp8_storage: fp8 bytes
+# resident, no fp8 silicon required), so a stored #fp8 flavor SERVES on ANY
+# CUDA card and is never refused on SM. Whether fp8 is PREFERRED over bf16 is
+# the SM-conditional question (ladder.FP8_COMPUTE_MIN_SM): fp8 tensor cores
+# on SM>=89 make it faster+smaller, below that it merely halves storage.
 NVFP4_FLAVOR_MIN_SM = 100
 
 
@@ -154,11 +157,13 @@ def variant_fit(
     - ``incompatible``: hard gates unmet (no CUDA GPU, compute_capability
       above this GPU's SM, required quant libraries not installed, an svdq
       row whose SM window / nunchaku-diffusers pin matrix fails, or an
-      fp8/nvfp4 stored-flavor row outside its SM window).
-    - ``fp8`` / ``nvfp4``: the binding is a stored quantized flavor whose
-      hardware window passes (fp8: Ada/Hopper+, nvfp4: Blackwell) and it
-      fits free VRAM — native runs on their silicon, ranked below a fitting
-      full-precision row (bf16 > fp8 > nvfp4 quality order).
+      nvfp4 stored-flavor row below Blackwell). A stored #fp8 flavor is
+      NEVER incompatible on SM — its storage upcasts to bf16 at compute.
+    - ``fp8`` / ``nvfp4``: the binding is a stored quantized flavor and it
+      fits free VRAM — nvfp4 is Blackwell-native; fp8 serves on ANY card
+      (bf16-upcast). Ranking is SM-aware: on fp8-compute silicon (SM>=89)
+      fp8 outranks bf16 (faster+smaller); below it fp8 is a fit fallback
+      only (bf16 preferred when it fits).
     - ``svdq_fp4`` / ``svdq_int4``: the binding is a stored SVDQuant flavor
       (gw#415) and every gate passes — on Blackwell, svdq_fp4 OUTRANKS every
       other fitting row (faster AND smaller, QUANTIZATION-POLICY fit ladder);
@@ -209,11 +214,10 @@ def variant_fit(
         if reason is not None:
             return FIT_INCOMPATIBLE, reason
     quant_kind = quant_flavor_kind(binding)
-    if quant_kind == "fp8" and caps.gpu_sm < FP8_FLAVOR_MIN_SM:
-        return FIT_INCOMPATIBLE, (
-            f"fp8 stored flavor needs SM >= {FP8_FLAVOR_MIN_SM} (Ada/Hopper+); "
-            f"GPU is SM{caps.gpu_sm}"
-        )
+    # fp8 has NO SM refusal — a stored #fp8 flavor upcasts to bf16 at compute
+    # and serves on any CUDA card (the refuse-bug fix: the hub could place
+    # #fp8 on an older card the worker then refused). nvfp4 stays gated: it is
+    # a genuine Blackwell-native tensor-core format with no upcast path here.
     if quant_kind == "nvfp4" and caps.gpu_sm < NVFP4_FLAVOR_MIN_SM:
         return FIT_INCOMPATIBLE, (
             f"nvfp4 stored flavor needs Blackwell (SM >= {NVFP4_FLAVOR_MIN_SM}); "
@@ -231,7 +235,7 @@ def variant_fit(
         if svdq_kind == "int4":
             return FIT_SVDQ_INT4, "svdq-int4 stored flavor (4-bit fit rung)"
         if quant_kind == "fp8":
-            return FIT_FP8, "fp8 stored flavor (Ada/Hopper+ rung)"
+            return FIT_FP8, "fp8 stored flavor (universal; bf16-upcast below SM89)"
         if quant_kind == "nvfp4":
             return FIT_NVFP4, "nvfp4 stored flavor (Blackwell rung)"
         return FIT_FITS, ""
@@ -270,24 +274,27 @@ def select_variant(
 
     ``variants`` rows are ``(fn_name, Resources)`` or
     ``(fn_name, Resources, binding)``; ``base`` is the base binding's row when
-    the class declares one. Policy (QUANTIZATION-POLICY fit ladder,
-    bf16 -> fp8 -> nvfp4 -> 4-bit over the HW-compatible fitting set):
-      1. drop incompatible rows (SM / library / svdq pin-matrix / fp8-nvfp4
-         SM-window gates);
+    the class declares one. Policy — SM-aware (the shared-ladder ordering,
+    ``FP8_COMPUTE_MIN_SM``):
+      1. drop incompatible rows (SM / library / svdq pin-matrix / nvfp4
+         Blackwell gate; fp8 is never dropped on SM);
       2. a fitting svdq_fp4 row wins outright — on Blackwell the SVDQuant
          flavor beats fp8/bf16 on BOTH latency and VRAM (gw#405 measured);
-      3. among plain rows that FIT free VRAM, prefer the largest declared
-         vram_gb (bigger = higher-quality precision);
-      4. a fitting stored fp8 row (Ada/Hopper+), then a fitting stored
-         nvfp4 row (Blackwell);
-      5. a fitting svdq_int4 row (4-bit fit rung: nothing bigger fits);
-      6. an emergency_fp8 row (runtime fp8-E4M3 storage), then an
+      3. fp8-vs-bf16 over the fitting set is SM-conditional (Paul's ruling
+         "run fp8 wherever we can"): on fp8-compute silicon (SM>=89) a
+         fitting stored fp8 row outranks bf16 (faster+smaller); below SM89
+         bf16-if-it-fits wins and fp8 is only a fit fallback. Within each
+         rung prefer the largest declared vram_gb; nvfp4 (Blackwell) trails;
+      4. a fitting svdq_int4 row (4-bit fit rung: nothing bigger fits);
+      5. an emergency_fp8 row (runtime fp8-E4M3 storage), then an
          emergency_quant row if the nf4 rung applies
          (runs at below-platform quality, loudly);
-      7. else the base binding + the offload ladder;
-      8. no base → the smallest-VRAM compatible variant, offloaded;
-      9. nothing routable → None.
+      6. else the base binding + the offload ladder;
+      7. no base → the smallest-VRAM compatible variant, offloaded;
+      8. nothing routable → None.
     """
+    from .ladder import FP8_COMPUTE_MIN_SM
+
     def _vram(res: Any) -> float:
         v = getattr(res, "vram_gb", None)
         return float(v) if v is not None else 0.0
@@ -300,7 +307,12 @@ def select_variant(
         if fit != FIT_INCOMPATIBLE:
             compat.append((name, res, fit, reason))
 
-    for rung in (FIT_SVDQ_FP4, FIT_FITS, FIT_FP8, FIT_NVFP4):
+    # SM>=89: fp8 tensor cores → prefer fp8 over bf16. Below: bf16-if-fits first.
+    if caps.gpu_sm >= FP8_COMPUTE_MIN_SM:
+        native_order = (FIT_SVDQ_FP4, FIT_FP8, FIT_FITS, FIT_NVFP4)
+    else:
+        native_order = (FIT_SVDQ_FP4, FIT_FITS, FIT_FP8, FIT_NVFP4)
+    for rung in native_order:
         fitting = [row for row in compat if row[2] == rung]
         if fitting:
             name, _res, fit, reason = max(fitting, key=lambda r: _vram(r[1]))

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -127,15 +127,27 @@ def placement_from_metadata(meta: Mapping[str, Any] | None) -> Optional[Placemen
 # byte-identical tests/testdata/precision_ladder_vectors.json. Any semantic
 # change edits the vector file in BOTH repos.
 #
-# Preference per arch class (Paul's th#697 ruling): best admitted 4-bit svdq
-# flavor (fp4 > int4, rank desc) > fp8 (stored artifact > cast-at-load) >
-# bf16 base. Rung gates: quality floor, placement SM admission, engines
-# within installed libs, est VRAM <= free. local=True appends emergency-nf4
-# then CPU-offload (the hub never schedules those).
+# Preference per arch class (Paul's fp8 ruling): best admitted 4-bit svdq
+# flavor (fp4 > int4, rank desc) first, then SM-aware fp8/bf16 ordering:
+#   SM >= 89 (Ada/Hopper/Blackwell, fp8 tensor cores): fp8 (stored artifact >
+#     cast-at-load) > bf16 base — fp8 is faster AND smaller there.
+#   SM < 89 (no fp8 compute; storage upcasts to bf16 at the same speed):
+#     bf16 base > fp8 — fp8 stays a FIT FALLBACK when bf16 won't fit
+#     (compact storage still halves resident weights on any card).
+# fp8 is NEVER a refusal: storage is universal (loading.apply_fp8_storage —
+# fp8 bytes resident, per-layer bf16 upcast, no fp8 silicon required).
+# Rung gates: quality floor, placement SM admission, engines within installed
+# libs, est VRAM <= free. local=True appends emergency-nf4 then CPU-offload
+# (the hub never schedules those).
 # ---------------------------------------------------------------------------
 
+# Native fp8 tensor-core compute exists on SM >= 89 (sm_89 Ada, sm_90 Hopper,
+# sm_100+/120 Blackwell). Below that, fp8 storage still SERVES (bf16-upcast
+# path) — this floor gates only the fp8-over-bf16 PREFERENCE, never admission.
+FP8_COMPUTE_MIN_SM = 89
+
 CAST_FP8_VRAM_FACTOR = 0.75  # pipeline-level est, gw#389 measured 62-76%
-EMERGENCY_NF4_VRAM_FACTOR = 0.45  # matches loading.EMERGENCY_FIT_FACTOR
+EMERGENCY_NF4_VRAM_FACTOR = 0.45  # nf4 denoiser, encoders/VAE at compute dtype
 
 MODE_NATIVE = "native"
 MODE_EMERGENCY = "emergency"
@@ -230,20 +242,26 @@ def _rungs(
     model: LadderModel, gpu_sm: int, libs: frozenset[str], quality_floor: str
 ) -> list[tuple[str, str, float]]:
     """Eligible native rungs in preference order (ignoring VRAM fit):
-    (flavor, cast, est_vram_gb)."""
+    (flavor, cast, est_vram_gb). fp8 vs bf16 order is SM-aware: fp8 first on
+    fp8-compute silicon (SM>=89, faster AND smaller), bf16 first below it
+    (fp8 upcasts there — same speed, so fp8 is only the fit fallback)."""
     out: list[tuple[str, str, float]] = []
     if _quality_ok(CLASS_SVDQ_FP4, quality_floor):
         for row in _four_bit_candidates(model, gpu_sm, libs):
             out.append((row.token, "", row.size_gb))
+    fp8_rung: Optional[tuple[str, str, float]] = None
     if _quality_ok(CLASS_FP8, quality_floor):
         stored = _stored_fp8(model, gpu_sm, libs)
         if stored is not None:
-            out.append((stored.token, "", stored.size_gb))
+            fp8_rung = (stored.token, "", stored.size_gb)
         elif model.base_size_gb > 0:
             est = model.fp8_cast_vram_gb or CAST_FP8_VRAM_FACTOR * model.base_size_gb
-            out.append(("", "fp8", est))
+            fp8_rung = ("", "fp8", est)
+    base_rung: Optional[tuple[str, str, float]] = None
     if model.base_size_gb > 0 and _quality_ok(CLASS_BASE, quality_floor):
-        out.append(("", "", model.base_size_gb))
+        base_rung = ("", "", model.base_size_gb)
+    pair = (fp8_rung, base_rung) if gpu_sm >= FP8_COMPUTE_MIN_SM else (base_rung, fp8_rung)
+    out.extend(r for r in pair if r is not None)
     return out
 
 
@@ -371,6 +389,7 @@ def resolve_local_bindings(
 
 __all__ = [
     "CAST_FP8_VRAM_FACTOR",
+    "FP8_COMPUTE_MIN_SM",
     "CLASS_BASE",
     "CLASS_FP8",
     "CLASS_NVFP4",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -11,6 +11,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .ladder import EMERGENCY_NF4_VRAM_FACTOR
+
 logger = logging.getLogger(__name__)
 
 _DTYPE_MAP = {
@@ -530,12 +532,16 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
 # platform never reaches it because its scheduler places by declared
 # Resources.
 # Coarse whole-model resident factor after nf4-quantizing the denoiser
-# (denoiser ~4x smaller; encoders/VAE stay at compute dtype).
-EMERGENCY_FIT_FACTOR = 0.45
-# Coarse resident factor vs the declared card size after fp8-E4M3 storage of
-# the denoiser (weights ~halve; encoders/VAE + activations stay bf16). Used
-# by the fit PLANNER (hub_policy.variant_fit); the load path measures the
-# snapshot's actual bytes instead.
+# (denoiser ~4x smaller; encoders/VAE stay at compute dtype). Single-sourced
+# from the shared ladder spec (ladder.EMERGENCY_NF4_VRAM_FACTOR) so the
+# runtime rung and the Go/Py ladder never drift.
+EMERGENCY_FIT_FACTOR = EMERGENCY_NF4_VRAM_FACTOR
+# Resident factor after fp8-E4M3 storage of the denoiser, expressed against
+# the declared CARD SIZE (resources.vram_gb) — a DIFFERENT base than the
+# ladder's CAST_FP8_VRAM_FACTOR (0.75), which is against raw WEIGHT BYTES
+# (base_size_gb). They estimate the same physical fp8-resident VRAM but the
+# denominators differ (card size includes activation/framework headroom over
+# raw weights), so the numbers legitimately differ and must NOT be equated.
 FP8_STORAGE_FIT_FACTOR = 0.55
 _EMERGENCY_MARGIN_GB = 2.0
 

--- a/tests/test_gpu_generation_smoke.py
+++ b/tests/test_gpu_generation_smoke.py
@@ -212,3 +212,102 @@ def test_flux2_klein_turbo_generates_real_image(tmp_path: Path) -> None:
     )
     assert not math.isnan(verdict.metrics["entropy"])
     assert verdict.ok, f"generated image tripped the quality gate: {verdict.failures} [{metrics}]"
+
+
+# ---------------------------------------------------------------------------
+# fp8-vs-bf16 quality comparison (grounds Paul's "prefer fp8" default).
+#
+# We run fp8 storage wherever we can because it is smaller AND (on SM>=89)
+# faster — BUT "fp8 quality ~= bf16" is an assumption that must be VERIFIED,
+# not assumed. This test generates the SAME prompt at the SAME seed twice —
+# once bf16, once with fp8-E4M3 denoiser storage (load path storage_dtype=
+# "fp8", the exact apply_fp8_storage lever the ladder selects) — on a real
+# card and asserts the fp8 output is (a) not garbage and (b) perceptually
+# close to bf16. If fp8 ever degrades a model, this fails and the "prefer
+# fp8" default is caught before it ships.
+#
+# Needs the GPU lane to execute (real inference + ~16GB weights): guarded by
+# GEN_WORKER_GPU_SMOKE=1 and skipped on the CPU-forbidding dev box.
+
+
+def _ssim(img_a, img_b) -> float:
+    """Global single-scale SSIM on luma in [0,1] (numpy-only, no skimage).
+    Coarse but sufficient here: same-seed fp8-vs-bf16 outputs are near
+    structurally identical, so a real fp8 regression (garbage / a
+    substantially different image) collapses this well below the gate."""
+    import numpy as np
+
+    def _luma(img):
+        rgb = np.asarray(img.convert("RGB"), dtype=np.float64) / 255.0
+        return 0.299 * rgb[..., 0] + 0.587 * rgb[..., 1] + 0.114 * rgb[..., 2]
+
+    x, y = _luma(img_a), _luma(img_b)
+    if x.shape != y.shape:
+        return 0.0
+    mx, my = x.mean(), y.mean()
+    vx, vy = x.var(), y.var()
+    cov = ((x - mx) * (y - my)).mean()
+    c1, c2 = 0.01**2, 0.03**2
+    return float(((2 * mx * my + c1) * (2 * cov + c2))
+                 / ((mx * mx + my * my + c1) * (vx + vy + c2)))
+
+
+# Acceptance gate. Same seed => fp8 and bf16 should be near-identical; in
+# practice global SSIM lands >0.95. 0.88 tolerates fp8-E4M3 rounding while
+# still catching a genuine quality regression. Calibrate on the GPU lane and
+# tighten as real numbers land (like the tripwire thresholds above).
+FP8_BF16_MIN_SSIM = 0.88
+
+
+def _generate(cls, snapshot, torch, *, storage_dtype: str):
+    from gen_worker.models.loading import load_from_pretrained
+    from gen_worker.models.memory import place_pipeline
+
+    pipe = load_from_pretrained(cls, snapshot, dtype="bf16", storage_dtype=storage_dtype)
+    place_pipeline(pipe)
+    return pipe(
+        prompt=PROMPT,
+        num_inference_steps=STEPS,
+        generator=torch.Generator("cpu").manual_seed(SEED),
+    ).images[0]
+
+
+def test_fp8_quality_matches_bf16_same_seed(tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA device required")
+    pytest.importorskip("numpy")
+    diffusers = pytest.importorskip("diffusers")
+    from huggingface_hub import snapshot_download
+
+    snapshot = snapshot_download(REPO_ID, allow_patterns=ALLOW_PATTERNS)
+    cls = diffusers.Flux2KleinPipeline
+
+    img_bf16 = _generate(cls, snapshot, torch, storage_dtype="")
+    img_fp8 = _generate(cls, snapshot, torch, storage_dtype="fp8")
+
+    out_dir = Path(os.environ.get("GEN_WORKER_SMOKE_OUT", tmp_path))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    img_bf16.save(out_dir / "flux2-klein-bf16.png")
+    img_fp8.save(out_dir / "flux2-klein-fp8.png")
+
+    v_bf16, v_fp8 = check_image(img_bf16), check_image(img_fp8)
+    ssim = _ssim(img_bf16, img_fp8)
+    print(
+        f"\nfp8-vs-bf16: ssim={ssim:.4f} (gate {FP8_BF16_MIN_SSIM}) "
+        f"bf16_tripwire={'PASS' if v_bf16.ok else 'FAIL'} "
+        f"fp8_tripwire={'PASS' if v_fp8.ok else 'FAIL'}\n"
+        f"  bf16 entropy={v_bf16.metrics['entropy']:.3f} "
+        f"luma_std={v_bf16.metrics['luma_std']:.2f}\n"
+        f"  fp8  entropy={v_fp8.metrics['entropy']:.3f} "
+        f"luma_std={v_fp8.metrics['luma_std']:.2f}"
+    )
+
+    # Both must be real images (fp8 must not silently produce garbage).
+    assert v_bf16.ok, f"bf16 baseline tripped the quality gate: {v_bf16.failures}"
+    assert v_fp8.ok, f"fp8 output tripped the quality gate: {v_fp8.failures}"
+    # fp8 must be perceptually close to the bf16 baseline at the same seed.
+    assert ssim >= FP8_BF16_MIN_SSIM, (
+        f"fp8 diverged from bf16: SSIM {ssim:.4f} < {FP8_BF16_MIN_SSIM} — fp8 "
+        "quality is NOT comparable to bf16 for this model; do not prefer fp8 here"
+    )

--- a/tests/test_serve_fit.py
+++ b/tests/test_serve_fit.py
@@ -147,13 +147,18 @@ def test_blackwell_serves_stored_nvfp4_natively() -> None:
     assert plan.fit == FIT_NVFP4
 
 
-def test_pre_ada_card_refuses_stored_fp8_flavor() -> None:
+def test_pre_ada_card_serves_stored_fp8_flavor() -> None:
+    # The refuse-bug fix: a stored #fp8 flavor upcasts to bf16 at compute
+    # (loading.apply_fp8_storage), so it SERVES natively on a pre-Ada card
+    # (SM86) — never refused. fp8 storage is universal; only the fp8-over-bf16
+    # PREFERENCE is SM-gated.
     plan = plan_serve(
-        Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=8.0,
+        Resources(vram_gb=12.0), CAPS_SMALL, free_vram_gb=23.6,
         binding=_Binding(flavor="fp8"),
     )
-    assert not plan.serveable and plan.fit == FIT_INCOMPATIBLE
-    assert "fp8" in plan.reason and "SM" in plan.reason
+    assert plan.serveable and plan.run_mode == RUN_NATIVE and not plan.degraded
+    assert plan.fit == FIT_FP8
+    assert plan.wanted == "fp8" and plan.ran == "fp8"
 
 
 def test_non_blackwell_card_refuses_stored_nvfp4_flavor() -> None:
@@ -186,8 +191,18 @@ _ROWS = [
 ]
 
 
-def test_select_variant_prefers_bf16_when_it_fits() -> None:
+def test_select_variant_prefers_fp8_on_fp8_compute_card() -> None:
+    # SM89 (Ada) has fp8 tensor cores: with both bf16 and fp8 fitting, fp8
+    # wins (faster AND smaller) — Paul's "run fp8 wherever we can".
     choice = select_variant(_ROWS, CAPS_4090, free_vram_gb=23.6)
+    assert choice is not None and choice.name == "gen@fp8"
+    assert choice.fit == FIT_FP8
+
+
+def test_select_variant_prefers_bf16_below_fp8_compute() -> None:
+    # SM86 (Ampere) has no fp8 tensor cores — fp8 storage upcasts to bf16 at
+    # the same speed, so bf16 is preferred when it fits; fp8 is a fit fallback.
+    choice = select_variant(_ROWS, CAPS_SMALL, free_vram_gb=23.6)
     assert choice is not None and choice.name == "gen@bf16"
 
 
@@ -206,10 +221,11 @@ def test_select_variant_picks_nvfp4_on_blackwell_when_only_it_fits() -> None:
     assert choice.fit == FIT_NVFP4
 
 
-def test_select_variant_incompatible_card_falls_to_runtime_quant() -> None:
-    # SM86: fp8/nvfp4 stored flavors are HW-incompatible and dropped. 12GB
-    # free: bf16 doesn't fit natively (24-1=23 > 12), the fp8-storage rung
-    # doesn't fit (24*0.55=13.2 > 12), the nf4 rung does (24*0.45=10.8 <= 12).
+def test_select_variant_sub_sm89_uses_fp8_fallback_when_bf16_too_big() -> None:
+    # SM86: nvfp4 stays HW-incompatible (Blackwell-only) and is dropped, but
+    # the stored fp8 row is NOT dropped (universal storage). 12GB free: bf16
+    # (24-1=23) doesn't fit, the fp8 row (13-1=12 <= 12) does and serves
+    # natively — fp8 is the fit fallback below fp8-compute silicon.
     choice = select_variant(_ROWS, CAPS_SMALL, free_vram_gb=12.0)
-    assert choice is not None and choice.name == "gen@bf16"
-    assert choice.fit == "emergency_quant"
+    assert choice is not None and choice.name == "gen@fp8"
+    assert choice.fit == FIT_FP8

--- a/tests/test_svdq_loading.py
+++ b/tests/test_svdq_loading.py
@@ -15,7 +15,7 @@ import pytest
 
 from gen_worker import Hub, Resources
 from gen_worker.models.hub_policy import (
-    FIT_FITS,
+    FIT_FP8,
     FIT_INCOMPATIBLE,
     FIT_SVDQ_FP4,
     FIT_SVDQ_INT4,
@@ -287,8 +287,10 @@ def test_select_variant_falls_back_when_pin_fails(
     )
     choice = select_variant(_rows(), _caps(120), 30.0)
     assert choice is not None
-    assert choice.name == "generate_turbo_bf16"
-    assert choice.fit == FIT_FITS
+    # svdq-fp4 drops on the broken pin; on Blackwell (fp8-compute) the stored
+    # fp8 row then outranks bf16 (Paul's fp8-preferred ruling).
+    assert choice.name == "generate_turbo_fp8"
+    assert choice.fit == FIT_FP8
 
 
 def test_select_variant_int4_is_fit_rung_not_speed_rung(stack_ok: None) -> None:
@@ -312,7 +314,9 @@ def test_select_variant_int4_is_fit_rung_not_speed_rung(stack_ok: None) -> None:
 def test_select_variant_non_blackwell_ignores_fp4_row(stack_ok: None) -> None:
     choice = select_variant(_rows(), _caps(89), 30.0)
     assert choice is not None
-    assert choice.name == "generate_turbo_bf16"
+    # fp4 is Blackwell-only and dropped on SM89; the stored fp8 row wins over
+    # bf16 because SM89 (Ada) has fp8 tensor cores (fp8-preferred).
+    assert choice.name == "generate_turbo_fp8"
 
 
 # --------------------------------------------------------------------------

--- a/tests/testdata/precision_ladder_vectors.json
+++ b/tests/testdata/precision_ladder_vectors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "th#697 shared precision-ladder conformance vectors. This file is vendored BYTE-IDENTICALLY in tensorhub (internal/orchestrator/precision/testdata/) and python-gen-worker (tests/testdata/) — the Go resolver and gen_worker.models.ladder.resolve must produce identical outcomes for every vector; any spec change edits BOTH copies. Spec: walk [best admitted 4-bit svdq flavor (fp4>int4, rank desc)] -> [fp8 stored > fp8 cast-at-load (est = fp8_cast_vram_gb else 0.75*base_size_gb)] -> [bf16 base]; each rung gated by quality floor (bf16=3 > fp8=2 > 4bit=1; ''=any), placement SM admission (checkpoint metadata placement block wins, else flavor-token defaults: svdq-fp4 sm 120/121, svdq-int4 sm 75-89, engines nunchaku; fp8/base universal), required engines within libs, and est_vram_gb <= free_vram_gb. local=true appends emergency-nf4 (quality_floor must be '', est 0.45*base, artifact = stored fp8 if admitted else base, cast=nf4) then offload (first arch/engine-eligible rung ignoring fit, requires allow_offload). No rung -> refusal no_runnable_precision; gpu_sm<=0 -> refusal no_cuda_gpu. nvfp4-class flavors are never diffusers rungs (TRT lane).",
+  "_comment": "th#697 shared precision-ladder conformance vectors. This file is vendored BYTE-IDENTICALLY in tensorhub (internal/orchestrator/precision/testdata/) and python-gen-worker (tests/testdata/) — the Go resolver and gen_worker.models.ladder.resolve must produce identical outcomes for every vector; any spec change edits BOTH copies. Spec: walk [best admitted 4-bit svdq flavor (fp4>int4, rank desc)] then an SM-CONDITIONAL fp8/bf16 pair (Paul's fp8 ruling): on fp8-compute silicon (gpu_sm>=89: Ada/Hopper/Blackwell) [fp8 stored > fp8 cast-at-load] BEFORE [bf16 base] (fp8 tensor cores => faster AND smaller); below it (gpu_sm<89) [bf16 base] BEFORE [fp8 stored > fp8 cast-at-load] (fp8 storage upcasts to bf16 there — same speed, so fp8 is only a FIT FALLBACK when bf16 won't fit). fp8 cast est = fp8_cast_vram_gb else 0.75*base_size_gb. fp8 is NEVER SM-refused (storage is universal). Each rung gated by quality floor (bf16=3 > fp8=2 > 4bit=1; ''=any), placement SM admission (checkpoint metadata placement block wins, else flavor-token defaults: svdq-fp4 sm 120/121, svdq-int4 sm 75-89, engines nunchaku; fp8/base universal), required engines within libs, and est_vram_gb <= free_vram_gb. local=true appends emergency-nf4 (quality_floor must be '', est 0.45*base, artifact = stored fp8 if admitted else base, cast=nf4) then offload (first arch/engine-eligible rung ignoring fit, requires allow_offload). No rung -> refusal no_runnable_precision; gpu_sm<=0 -> refusal no_cuda_gpu. nvfp4-class flavors are never diffusers rungs (TRT lane).",
   "vectors": [
     {
       "name": "blackwell-5090-svdq-fp4-present",
@@ -68,9 +68,39 @@
       "expect": {"flavor": "svdq-int4-r32", "cast": "", "mode": "native"}
     },
     {
-      "name": "old-card-sm70-fp8-cast",
+      "name": "old-card-sm70-bf16-preferred-when-it-fits",
       "gpu_sm": 70, "free_vram_gb": 30.0, "libs": ["nunchaku"],
       "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r128": {"size_gb": 3.9}}},
+      "expect": {"flavor": "", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "old-card-sm70-fp8-cast-fallback-when-bf16-too-big",
+      "gpu_sm": 70, "free_vram_gb": 30.0, "libs": [],
+      "model": {"base_size_gb": 32.3, "flavors": {}},
+      "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
+    },
+    {
+      "name": "sub-sm89-bf16-preferred-over-stored-fp8",
+      "gpu_sm": 86, "free_vram_gb": 23.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "sub-sm89-stored-fp8-fallback-when-bf16-too-big",
+      "gpu_sm": 86, "free_vram_gb": 23.0, "libs": [],
+      "model": {"base_size_gb": 32.3, "flavors": {"fp8": {"size_gb": 16.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "sm89-stored-fp8-preferred-over-fitting-bf16",
+      "gpu_sm": 89, "free_vram_gb": 23.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "sm90-fp8-cast-preferred-over-fitting-bf16",
+      "gpu_sm": 90, "free_vram_gb": 78.0, "libs": [],
+      "model": {"base_size_gb": 12.2, "flavors": {}},
       "expect": {"flavor": "", "cast": "fp8", "mode": "native"}
     },
     {


### PR DESCRIPTION
## The refuse-bug (reconciled)

gen-worker `hub_policy` gated stored `#fp8` behind `FP8_FLAVOR_MIN_SM=89`
(Ada+ only) and **refused** it below that; the shared th#697 ladder
(`ClassFP8`/`CLASS_FP8`) treated fp8 as SM-unconstrained ("storage is
universal"). Unreconciled, the hub could **place** `#fp8` on an older card
and the worker then refused the very function it was resolved for → dead
request.

## Empirical truth (from the code, not assumed)

Our stored `#fp8` flavor is **universal**. `loading.apply_fp8_storage` keeps
fp8-E4M3 bytes resident and upcasts **per-layer to bf16 at compute**
(diffusers layerwise casting) — *no fp8 silicon required*. There is no
native-fp8-compute path in our loader (no `scaled_mm`/transformer_engine
Float8Linear). So `#fp8` **serves on ANY CUDA card**; SM only decides whether
it's *faster* than bf16 (fp8 tensor cores exist on SM≥89).

## What changed

- **Removed** `FP8_FLAVOR_MIN_SM` and its refusal — fp8 is never SM-refused.
  `nvfp4` stays gated (genuine Blackwell-native format, no upcast path).
- **SM-conditional preference** (Paul: "run fp8 wherever we can"), encoded in
  the single shared `ladder` and mirrored in `select_variant`:
  - **SM≥89**: fp8 > bf16 (faster AND smaller) → fp8 → bf16 → nvfp4 → 4bit.
  - **SM<89**: bf16-if-it-fits first; fp8 is a fit fallback (same-speed upcast).
- **Shared conformance vectors** updated for the SM-conditional ordering
  (byte-identical with tensorhub; tensorhub PR mirrors it).
- **Single-sourced**: deleted the private SM constant; `loading.EMERGENCY_FIT_FACTOR`
  now derives from `ladder.EMERGENCY_NF4_VRAM_FACTOR` (was a duplicated 0.45).
  The two fp8 VRAM factors (loading `0.55` vs ladder `0.75`) are documented as
  **different bases** (card-VRAM vs weight-bytes) and deliberately NOT equated.

## Quality verification (Task 3)

`test_fp8_quality_matches_bf16_same_seed` generates the **same prompt+seed** at
bf16 vs fp8-E4M3 storage on a real card and asserts (a) both pass the image
tripwire and (b) global SSIM ≥ 0.88. This **grounds** the prefer-fp8 default —
if fp8 ever degrades a model, it fails. **Needs the GPU lane to execute**
(guarded by `GEN_WORKER_GPU_SMOKE=1`; runs on the existing GPU CI smoke step;
skips on the CPU-forbidding dev box). Threshold is commented for calibration.

## Tests

760 passed, 11 skipped. ruff clean on touched files. Rebased on latest
`origin/master` (incl. gw#463/gw#464). Paired with the tensorhub ladder PR.