### PR TITLE
gw#468: env-gate sweep — ambient worker knobs read through the typed Settings loader (0.13.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.21 (2026-07-11)
+
+- **gw#468: env-gate sweep — every ambient worker knob reads through the typed
+  `Settings` loader.** New fields (same env names): `TENSORHUB_URL/_TOKEN/
+  _CACHE_DIR/_CAS_DIR`, `CIVITAI_API_KEY` (alias `CIVITAI_TOKEN`),
+  `COZY_HF_DOWNLOAD_STALL_TIMEOUT_S/_MAX_SECONDS`, `COZY_HF_MAX_REPO_BYTES`,
+  `GEN_WORKER_ATTACHED_LORA_MAX/_MAX_BYTES`, `GEN_WORKER_COMPILE_CACHE/
+  _CACHE_URL/_ALLOW_COLD`, `WORKER_IMAGE_DIGEST`, `WORKER_GIT_COMMIT`;
+  `HUGGING_FACE_HUB_TOKEN` resolves as an `HF_TOKEN` alias. Loader gains a
+  cached `get_settings()` accessor, alias resolution (primary env wins when
+  non-empty), and forgiving source coercion (empty values fall back to struct
+  defaults; bools accept `1/true/yes`). `compile_cache.apply()` takes an
+  explicit `allow_cold` for the producer path (env self-set kept for spawned
+  compile workers). Guard test `tests/test_env_surface.py` fails on any raw
+  `os.getenv`/`os.environ` outside `config/` not on the plumbing allowlist;
+  survivors documented in `docs/environment.md`.
 ## 0.13.19 (2026-07-10)
 
 - **gw#471: checkpoint saves publish via tensorhub's real `/commits` API.**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,76 @@
+# Environment variables
+
+All ambient worker config flows through the typed `Settings` struct
+(`config/settings.py`), loaded by `config/loader.py` with precedence
+env → `./.env` → `/run/secrets` → yaml → struct defaults. Call sites read
+`Settings` (the startup instance, or the cached `get_settings()`), never
+`os.getenv`. The guard test `tests/test_env_surface.py` fails the suite on
+any raw env read outside `config/` that isn't on its plumbing allowlist.
+
+Tenant *endpoint* code reads its own envs freely (`docs/endpoint-envs.md`);
+this page covers the worker itself.
+
+## Secrets (Settings fields)
+
+| Env | Field | Why env |
+|---|---|---|
+| `HF_TOKEN` (alias `HUGGING_FACE_HUB_TOKEN`) | `hf_token` | HF pulls of gated/private repos |
+| `WORKER_JWT` | `worker_jwt` | orchestrator-issued worker identity token |
+| `GRPC_CA_BUNDLE` | `grpc_ca_bundle` | PEM CA path for orchestrator gRPC TLS |
+| `TENSORHUB_TOKEN` | `tensorhub_token` | standalone-CLI private tensorhub pulls |
+| `CIVITAI_API_KEY` (alias `CIVITAI_TOKEN`) | `civitai_api_key` | civitai provider downloads |
+
+## Orchestrator-injected deployment config (Settings fields)
+
+| Env | Field | Why env |
+|---|---|---|
+| `TENSORHUB_PUBLIC_URL` | `tensorhub_public_url` | injected per-cluster at pod launch |
+| `ORCHESTRATOR_PUBLIC_ADDR` | `orchestrator_public_addr` | router address, injected at pod launch |
+| `WORKER_ID` | `worker_id` | per-pod identity |
+| `ENDPOINT_LOCK_PATH` | `endpoint_lock_path` | discovery manifest path (baked default in images) |
+| `RUNPOD_POD_ID` | `runpod_pod_id` | set by the RunPod runtime |
+| `WORKER_DISCONNECTED_TIMEOUT_S` | `worker_disconnected_timeout_s` | self-exit window when orchestrator unreachable |
+| `WORKER_IMAGE_DIGEST` / `WORKER_GIT_COMMIT` | `worker_image_digest` / `worker_git_commit` | provenance stamped by the image build |
+
+## Tuning knobs (Settings fields)
+
+| Env | Field | Why env |
+|---|---|---|
+| `HF_HOME` | `hf_home` | HF cache root (also read by huggingface_hub itself) |
+| `TENSORHUB_URL` | `tensorhub_url` | standalone-CLI resolve base URL |
+| `TENSORHUB_CACHE_DIR` / `TENSORHUB_CAS_DIR` | `tensorhub_cache_dir` / `tensorhub_cas_dir` | move cache/CAS off `/tmp` (cozy local persistence) |
+| `COZY_HF_DOWNLOAD_STALL_TIMEOUT_S` | `hf_download_stall_timeout_s` | HF download stall window (default 180s) |
+| `COZY_HF_DOWNLOAD_MAX_SECONDS` | `hf_download_max_seconds` | HF download wall-clock cap (0 = off) |
+| `COZY_HF_MAX_REPO_BYTES` | `hf_max_repo_bytes` | accidental-huge-repo guard (default 60 GB, 0 = off) |
+| `GEN_WORKER_ATTACHED_LORA_MAX` / `_MAX_BYTES` | `attached_lora_max` / `attached_lora_max_bytes` | LoRA residency caps |
+| `GEN_WORKER_COMPILE_CACHE` / `_CACHE_URL` | `compile_cache_path` / `compile_cache_url` | compile-cache artifact source (path / URL) |
+| `GEN_WORKER_COMPILE_ALLOW_COLD` | `compile_allow_cold` | opt into cold compilation (needs a C toolchain) |
+
+## CI-lane opt-ins (raw env, tests/CI only)
+
+- `GEN_WORKER_GPU_SMOKE` / `GEN_WORKER_SMOKE_OUT` — nightly GPU CI lane
+  selection + artifact dir (`gpu-ci.yml`); never read by worker runtime code.
+
+## Internal plumbing (raw env, allowlisted in tests/test_env_surface.py)
+
+- `PYTORCH_CUDA_ALLOC_CONF` — `entrypoint.py` setdefault before torch import.
+- `TORCHINDUCTOR_CACHE_DIR` / `TRITON_CACHE_DIR` — WRITTEN by
+  `compile_cache.py` to latch inductor/triton onto seeded dirs (children
+  inherit); `GEN_WORKER_COMPILE_ALLOW_COLD` is also written by the producer
+  for its spawned compile workers.
+- `GEN_WORKER_LOCAL_DEVICE` — set by `run/serve --device` for endpoint code;
+  read back on the local path.
+- `GEN_WORKER_LOCAL_OUTPUT_DIR`, `USER` — cozy-local app plumbing / login
+  fallback (`cli/local_context.py`).
+- `GEN_WORKER_NO_PRECISION_LADDER` — local-run ladder opt-out, read
+  per-invocation (`cli/run.py`).
+- `COZY_HTTP_CONNECT_TIMEOUT_S` / `COZY_HTTP_READ_TIMEOUT_S` — http timeout
+  floors, per-call by design so tests can tune them (`net.py`, gw#456).
+- `COZY_CIVITAI_DOWNLOAD_ATTEMPTS`, `COZY_CLONE_DOWNLOAD_ATTEMPTS` —
+  per-call test-tunable retry counts (`models/download.py`,
+  `convert/ingest.py`).
+- `COZY_CONVERT_WORKDIR` / `_DISK_HEADROOM` / `_SCRATCH_TTL_S` /
+  `_RETAIN_WORKDIR` — convert-job scratch knobs set by the invoking harness
+  (`convert/clone.py`).
+- `GEN_WORKER_FORBID_CPU_OFFLOAD` — live CPU-placement veto; removal owned
+  by PR #139 (drop from the allowlist with it).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.20"
+version = "0.13.21"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -28,6 +28,7 @@ import msgspec
 
 from ..api.binding import BINDING_TYPES, wire_ref
 from ..api.errors import CanceledError
+from ..config import get_settings
 from .local_context import build_local_context
 
 
@@ -623,7 +624,7 @@ def _resolve_local_path(
     from ..models.cache_paths import tensorhub_cas_dir
     from ..models.refs import parse_model_ref
 
-    env_cas = (os.getenv("TENSORHUB_CAS_DIR") or "").strip()
+    env_cas = get_settings().tensorhub_cas_dir.strip()
     cache_dir = Path(env_cas) if env_cas else Path(tensorhub_cas_dir())
 
     # Decode the bare ref into typed parts using the explicit provider.
@@ -653,8 +654,8 @@ def _resolve_local_path(
                     repo_id=parsed.hf.repo_id,
                     revision=parsed.hf.revision,
                     local_files_only=True,
-                    cache_dir=os.getenv("HF_HOME") or None,
-                    token=os.getenv("HF_TOKEN") or os.getenv("HUGGING_FACE_HUB_TOKEN") or None,
+                    cache_dir=get_settings().hf_home or None,
+                    token=get_settings().hf_token or None,
                     allow_patterns=list(allow_patterns) or None,
                 )
                 return str(p)
@@ -671,8 +672,8 @@ def _resolve_local_path(
 
             local_dir = download_hf(
                 parsed.hf,
-                hf_home=os.getenv("HF_HOME") or None,
-                hf_token=os.getenv("HF_TOKEN") or os.getenv("HUGGING_FACE_HUB_TOKEN") or None,
+                hf_home=get_settings().hf_home or None,
+                hf_token=get_settings().hf_token or None,
                 allow_patterns=tuple(allow_patterns),
             )
         except Exception as e:
@@ -748,7 +749,7 @@ def _resolve_local_path(
             fetch_civitai_model,
             parse_civitai_version_id,
         )
-        api_key = os.getenv("CIVITAI_API_KEY", "") or os.getenv("CIVITAI_TOKEN", "")
+        api_key = get_settings().civitai_api_key
 
         if civitai_version_id:
             # Explicit version pin via Civitai(version="<id>"). The pinned id

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -52,6 +52,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
+from .config import get_settings
+
 logger = logging.getLogger(__name__)
 
 ENV_CACHE_PATH = "GEN_WORKER_COMPILE_CACHE"       # local artifact (tar) or seeded dir
@@ -451,8 +453,9 @@ def prepare(
     ``GEN_WORKER_COMPILE_CACHE_URL``. Returns the artifact metadata on a
     verified hit (cache dirs seeded), else None with the reason logged.
     """
-    local = (os.getenv(ENV_CACHE_PATH) or "").strip()
-    url = (os.getenv(ENV_CACHE_URL) or "").strip()
+    settings = get_settings()
+    local = settings.compile_cache_path.strip()
+    url = settings.compile_cache_url.strip()
     root = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "gen-worker"
     root = root / "compile-cache"
     try:
@@ -558,12 +561,20 @@ def _guarded_regional(mod: Any, original: Callable[..., Any], label: str) -> Cal
     return wrapper
 
 
-def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> bool:
+def apply(
+    pipeline: Any,
+    cfg: Any,
+    *,
+    cache_ready: bool,
+    guard: bool = True,
+    allow_cold: Optional[bool] = None,
+) -> bool:
     """Wrap ``cfg.targets`` on ``pipeline`` with compiled callables.
 
     Only compiles when a verified cache artifact was seeded (``cache_ready``)
     or the process explicitly opted into cold compilation AND has a C
-    toolchain. Anything else is a logged no-op — eager, never a stall.
+    toolchain (``allow_cold``; defaults to the GEN_WORKER_COMPILE_ALLOW_COLD
+    setting). Anything else is a logged no-op — eager, never a stall.
 
     ``guard=True`` (consumer): a failing compiled call permanently unwraps to
     eager. ``guard=False`` (compile job): failures must raise, a silently
@@ -579,7 +590,8 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
         logger.info("compile-cache: no CUDA; staying eager")
         return False
     if not cache_ready:
-        allow_cold = (os.getenv(ENV_ALLOW_COLD) or "").strip().lower() in ("1", "true", "yes")
+        if allow_cold is None:
+            allow_cold = get_settings().compile_allow_cold
         if not allow_cold:
             logger.info("compile-cache: no verified cache artifact; staying eager")
             return False
@@ -825,8 +837,10 @@ def build(
     placed = place_pipeline(pipe)
     if callable(getattr(pipe, "set_progress_bar_config", None)):
         pipe.set_progress_bar_config(disable=True)
+    # Child processes (inductor compile workers) inherit the opt-in; this
+    # process opts in explicitly via the `allow_cold` param.
     os.environ[ENV_ALLOW_COLD] = "1"
-    if not apply(pipe, cfg, cache_ready=False, guard=False):
+    if not apply(pipe, cfg, cache_ready=False, guard=False, allow_cold=True):
         raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
 
     timings: Dict[str, float] = {}

--- a/src/gen_worker/config/__init__.py
+++ b/src/gen_worker/config/__init__.py
@@ -1,5 +1,5 @@
 """Worker config — single typed `Settings` struct loaded once at startup."""
-from .loader import load_settings
+from .loader import get_settings, load_settings
 from .settings import Settings
 
-__all__ = ["Settings", "load_settings"]
+__all__ = ["Settings", "get_settings", "load_settings"]

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -14,6 +14,7 @@ env name and one .env / yaml / secret key — see the table below.
 """
 from __future__ import annotations
 
+import functools
 import os
 from pathlib import Path
 from typing import Any, Dict, Iterable
@@ -38,9 +39,40 @@ _ENV_TO_FIELD: Dict[str, str] = {
     "ENDPOINT_LOCK_PATH": "endpoint_lock_path",
     "RUNPOD_POD_ID": "runpod_pod_id",
     "WORKER_DISCONNECTED_TIMEOUT_S": "worker_disconnected_timeout_s",
+    "WORKER_IMAGE_DIGEST": "worker_image_digest",
+    "WORKER_GIT_COMMIT": "worker_git_commit",
+    "TENSORHUB_URL": "tensorhub_url",
+    "TENSORHUB_TOKEN": "tensorhub_token",
+    "TENSORHUB_CACHE_DIR": "tensorhub_cache_dir",
+    "TENSORHUB_CAS_DIR": "tensorhub_cas_dir",
+    "CIVITAI_API_KEY": "civitai_api_key",
+    "COZY_HF_DOWNLOAD_STALL_TIMEOUT_S": "hf_download_stall_timeout_s",
+    "COZY_HF_DOWNLOAD_MAX_SECONDS": "hf_download_max_seconds",
+    "COZY_HF_MAX_REPO_BYTES": "hf_max_repo_bytes",
+    "GEN_WORKER_ATTACHED_LORA_MAX": "attached_lora_max",
+    "GEN_WORKER_ATTACHED_LORA_MAX_BYTES": "attached_lora_max_bytes",
+    "GEN_WORKER_COMPILE_CACHE": "compile_cache_path",
+    "GEN_WORKER_COMPILE_CACHE_URL": "compile_cache_url",
+    "GEN_WORKER_COMPILE_ALLOW_COLD": "compile_allow_cold",
+}
+
+# Secondary env names for a field, consulted only when the primary name is
+# unset or empty (mirrors the historical `os.getenv(A) or os.getenv(B)`).
+_ENV_ALIASES: Dict[str, str] = {
+    "CIVITAI_TOKEN": "civitai_api_key",
+    "HUGGING_FACE_HUB_TOKEN": "hf_token",
 }
 
 _FIELD_NAMES = frozenset(_ENV_TO_FIELD.values())
+
+# Field-type metadata for source-value normalization: sources deliver strings;
+# non-str fields get stripped, empty values fall back to the struct default
+# (an exported-but-empty env var must not crash startup), and bool fields use
+# the worker's historical truthy set rather than msgspec's stricter parse.
+_FIELD_TYPES: Dict[str, type] = {
+    f.name: f.type for f in msgspec.structs.fields(Settings) if isinstance(f.type, type)
+}
+_TRUTHY = ("1", "true", "yes")
 
 _YAML_CANDIDATE_PATHS = (
     "/etc/gen-worker/config.yaml",
@@ -69,6 +101,12 @@ def _load_env() -> Dict[str, str]:
     """Read every Settings-relevant env var that's actually set."""
     out: Dict[str, str] = {}
     for env_name, field in _ENV_TO_FIELD.items():
+        val = os.environ.get(env_name)
+        if val is not None:
+            out[field] = val
+    for env_name, field in _ENV_ALIASES.items():
+        if out.get(field):
+            continue  # primary name wins when non-empty
         val = os.environ.get(env_name)
         if val is not None:
             out[field] = val
@@ -164,6 +202,21 @@ def _normalize_init_kwargs(init_kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in init_kwargs.items() if k in _FIELD_NAMES}
 
 
+def _normalize_values(merged: Dict[str, Any]) -> Dict[str, Any]:
+    """Prepare source strings for msgspec.convert per `_FIELD_TYPES`."""
+    out: Dict[str, Any] = {}
+    for field, val in merged.items():
+        ftype = _FIELD_TYPES.get(field, str)
+        if ftype is not str and isinstance(val, str):
+            val = val.strip()
+            if not val:
+                continue  # empty => struct default
+            if ftype is bool:
+                val = val.lower() in _TRUTHY
+        out[field] = val
+    return out
+
+
 def load_settings(**init_kwargs: Any) -> Settings:
     """Build a fresh `Settings`. Call once at startup.
 
@@ -179,4 +232,13 @@ def load_settings(**init_kwargs: Any) -> Settings:
     merged.update(_load_dotenv())
     merged.update(_load_env())
     merged.update(_normalize_init_kwargs(init_kwargs))
-    return msgspec.convert(merged, Settings, strict=False)
+    return msgspec.convert(_normalize_values(merged), Settings, strict=False)
+
+
+@functools.lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Process-wide cached `Settings` for call sites that aren't handed the
+    startup instance (standalone CLI paths, module-level constants). Same
+    sources, loaded lazily on first use. Tests clear via the autouse
+    `_fresh_settings_cache` fixture (`get_settings.cache_clear()`)."""
+    return load_settings()

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -55,3 +55,36 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # shutdown-coordination protocol. Default 600s = 10 min. gen-orchestrator
     # issue #317.
     worker_disconnected_timeout_s: int = 600
+
+    # Provenance stamped into WorkerResources by the image build / launcher.
+    worker_image_digest: str = ""  # WORKER_IMAGE_DIGEST
+    worker_git_commit: str = ""    # WORKER_GIT_COMMIT
+
+    # tensorhub access for standalone clients (run/serve/prefetch). Production
+    # workers get orchestrator-resolved manifests and never dial these.
+    tensorhub_url: str = ""        # TENSORHUB_URL
+    tensorhub_token: str = ""      # TENSORHUB_TOKEN
+    # CAS/cache roots. cache_dir moves the whole tensorhub cache off /tmp
+    # (cozy local persists weights across reboots); cas_dir points standalone
+    # resolve at an explicit CAS root.
+    tensorhub_cache_dir: str = ""  # TENSORHUB_CACHE_DIR
+    tensorhub_cas_dir: str = ""    # TENSORHUB_CAS_DIR
+
+    # Civitai provider credential (CIVITAI_API_KEY, alias CIVITAI_TOKEN).
+    civitai_api_key: str = ""
+
+    # HF snapshot-download guards (#379): stall window (no byte progress),
+    # optional wall-clock cap (0 = off), and the accidental-huge-repo cap
+    # (0 = off).
+    hf_download_stall_timeout_s: float = 180.0  # COZY_HF_DOWNLOAD_STALL_TIMEOUT_S
+    hf_download_max_seconds: float = 0.0        # COZY_HF_DOWNLOAD_MAX_SECONDS
+    hf_max_repo_bytes: int = 60_000_000_000     # COZY_HF_MAX_REPO_BYTES
+
+    # Residency caps for LoRA adapters left attached between requests.
+    attached_lora_max: int = 8                       # GEN_WORKER_ATTACHED_LORA_MAX
+    attached_lora_max_bytes: int = 2 * 1024**3       # GEN_WORKER_ATTACHED_LORA_MAX_BYTES
+
+    # torch.compile cache artifact sources (gw#384) + cold-compile opt-in.
+    compile_cache_path: str = ""    # GEN_WORKER_COMPILE_CACHE
+    compile_cache_url: str = ""     # GEN_WORKER_COMPILE_CACHE_URL
+    compile_allow_cold: bool = False  # GEN_WORKER_COMPILE_ALLOW_COLD

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, List, Optional
 
 import msgspec
 
-from .config import load_settings
+from .config import get_settings
 from .models.cache_paths import tensorhub_cas_dir
 try:
     from .worker import Worker
@@ -177,7 +177,7 @@ def _preflight_cache_dirs() -> Dict[str, str]:
 def _run_main() -> int:
     _log_startup_phase("boot", status="starting")
     try:
-        settings = load_settings()
+        settings = get_settings()
     except Exception as e:
         logger.exception("Failed to load worker settings: %s", e)
         _log_worker_fatal("settings_load", e, exit_code=1)

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -117,8 +117,8 @@ class Lifecycle:
             gpu_name=str(hw.get("gpu_name") or ""),
             gpu_sm=str(hw.get("gpu_sm") or ""),
             installed_libs=[str(x) for x in (hw.get("installed_libs") or [])],
-            image_digest=os.environ.get("WORKER_IMAGE_DIGEST", ""),
-            git_commit=os.environ.get("WORKER_GIT_COMMIT", ""),
+            image_digest=self._settings.worker_image_digest,
+            git_commit=self._settings.worker_git_commit,
             instance_id=self._settings.runpod_pod_id or "",
         )
 

--- a/src/gen_worker/models/cache_paths.py
+++ b/src/gen_worker/models/cache_paths.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from ..config import get_settings
 
 
 TENSORHUB_CACHE_DIR = "/tmp/tensorhub-cache"
@@ -16,8 +17,8 @@ def tensorhub_cache_dir() -> Path:
     (weights survive reboots) instead of ``/tmp``. Falls back to the ``/tmp``
     default when unset, preserving existing worker/orchestrator behavior.
     """
-    env = os.environ.get("TENSORHUB_CACHE_DIR")
-    if env and env.strip():
+    env = get_settings().tensorhub_cache_dir.strip()
+    if env:
         return Path(env).expanduser()
     return Path(TENSORHUB_CACHE_DIR)
 

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -25,14 +25,13 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
+from ..config import get_settings
 from .cache_paths import tensorhub_cas_dir
 from .refs import HuggingFaceRef, TensorhubRef, parse_model_ref
 
 logger = logging.getLogger("gen_worker.download")
 
 ProgressFn = Callable[[int, Optional[int]], None]
-
-_DEFAULT_MAX_REPO_BYTES = 60_000_000_000  # COZY_HF_MAX_REPO_BYTES overrides
 
 # ---------------------------------------------------------------------------
 # Provider index: bare ref string -> provider. Built once at boot from the
@@ -220,7 +219,7 @@ async def ensure_local(
             download_civitai,
             version_id,
             base / "civitai" / str(version_id),
-            api_key=civitai_api_key or os.getenv("CIVITAI_API_KEY", "") or os.getenv("CIVITAI_TOKEN", ""),
+            api_key=civitai_api_key or get_settings().civitai_api_key,
             progress=progress,
         )
 
@@ -364,23 +363,11 @@ def _match_allow_patterns(repo_files: Sequence[str], patterns: Sequence[str]) ->
 
 
 def _hf_stall_timeout_s() -> float:
-    raw = os.environ.get("COZY_HF_DOWNLOAD_STALL_TIMEOUT_S", "").strip()
-    if raw:
-        try:
-            return max(0.0, float(raw))
-        except ValueError:
-            pass
-    return 180.0
+    return max(0.0, get_settings().hf_download_stall_timeout_s)
 
 
 def _hf_wallclock_max_s() -> float:
-    raw = os.environ.get("COZY_HF_DOWNLOAD_MAX_SECONDS", "").strip()
-    if raw:
-        try:
-            return max(0.0, float(raw))
-        except ValueError:
-            pass
-    return 0.0
+    return max(0.0, get_settings().hf_download_max_seconds)
 
 
 class DownloadStalledError(RuntimeError):
@@ -554,10 +541,7 @@ def download_hf(
         }
         wanted = selected if selected is not None else set(repo_files)
         total_hint = sum(sizes.get(p, 0) for p in wanted)
-        try:
-            cap = int(os.getenv("COZY_HF_MAX_REPO_BYTES", "").strip() or _DEFAULT_MAX_REPO_BYTES)
-        except ValueError:
-            cap = _DEFAULT_MAX_REPO_BYTES
+        cap = get_settings().hf_max_repo_bytes
         if cap > 0 and total_hint > cap:
             raise RuntimeError(
                 f"refusing an excessively large Hugging Face selection for {repo_id}: "

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
+from ..config import get_settings
 from .refs import TensorhubRef
 
 
@@ -57,7 +57,7 @@ class HubAuthError(HubResolveError):
 
 
 def hub_base_url(base_url: Optional[str] = None) -> str:
-    return (base_url or os.getenv("TENSORHUB_URL") or "").strip().rstrip("/")
+    return (base_url or get_settings().tensorhub_url).strip().rstrip("/")
 
 
 def resolve_repo(
@@ -80,7 +80,7 @@ def resolve_repo(
         raise HubResolveError(
             "no tensorhub base URL: set TENSORHUB_URL (e.g. https://tensorhub.com)"
         )
-    tok = (token or os.getenv("TENSORHUB_TOKEN") or "").strip()
+    tok = (token or get_settings().tensorhub_token).strip()
     headers = {"Authorization": f"Bearer {tok}"} if tok else {}
     params: dict[str, str] = {}
     if ref.digest:

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import hashlib
 import logging
 import math
-import os
 import re
 import threading
 import time
@@ -29,6 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, runtime_checkable
 
 from ..api.errors import RefCompatibilitySurprise, ValidationError
+from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +41,10 @@ MAX_LORA_FILE_BYTES = 2 * _GiB
 LORA_WEIGHT_BOUND = 4.0
 ADAPTER_CACHE_MAX_BYTES = 1 * _GiB
 
-# Residency caps for adapters left attached to a pipeline between requests.
-MAX_ATTACHED_ADAPTERS = int(os.getenv("GEN_WORKER_ATTACHED_LORA_MAX", "8"))
-MAX_ATTACHED_ADAPTER_BYTES = int(
-    os.getenv("GEN_WORKER_ATTACHED_LORA_MAX_BYTES", str(2 * _GiB))
-)
+# Residency caps for adapters left attached to a pipeline between requests
+# (GEN_WORKER_ATTACHED_LORA_MAX / GEN_WORKER_ATTACHED_LORA_MAX_BYTES).
+MAX_ATTACHED_ADAPTERS = get_settings().attached_lora_max
+MAX_ATTACHED_ADAPTER_BYTES = get_settings().attached_lora_max_bytes
 
 # LoRA-shaped keys only: kohya (`…lora_down.weight` / `…lora_up.weight` /
 # `….alpha`), peft (`…lora_A.weight` / `…lora_B.weight`, DoRA magnitude), and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,17 @@ if _REPO_SRC not in _LOCATION.parents:
     )
 
 
+import pytest  # noqa: E402
+
+from gen_worker.config.loader import get_settings  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings_cache():
+    """`get_settings()` caches process-wide; tests monkeypatch env vars, so
+    every test starts (and ends) with a cleared cache."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+

--- a/tests/test_env_surface.py
+++ b/tests/test_env_surface.py
@@ -1,0 +1,82 @@
+"""gw#468: the typed Settings loader is the ONLY ambient env-read surface.
+
+Every `os.environ` / `os.getenv` in src/gen_worker outside config/ must be a
+known internal-plumbing site (parent→child env passing, per-call test-tunable
+knobs, subprocess env assembly) listed in ALLOWED below. A new worker knob
+belongs on `Settings` (config/settings.py + loader `_ENV_TO_FIELD`), not on
+this list. See docs/environment.md.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+# relpath -> substrings; every env-touching line in that file must contain
+# one of them. One line each on why the site earned raw-env status:
+ALLOWED: dict[str, tuple[str, ...]] = {
+    # setdefault before torch import — must precede any Settings consumer.
+    "entrypoint.py": ("PYTORCH_CUDA_ALLOC_CONF",),
+    # http timeout floors are read per-call BY DESIGN (test-tunable, gw#456).
+    "net.py": ("os.environ.get(name",),
+    # producer→child plumbing: inductor/triton cache dirs + cold-compile
+    # opt-in are exported for spawned compile workers.
+    "compile_cache.py": ("os.environ[env]", "os.environ[ENV_ALLOW_COLD]"),
+    # subprocess env assembly (full environ passthrough to the runtime server).
+    "runtimes/server.py": ("dict(os.environ)",),
+    # live veto lane — removal owned by PR #139; drop this entry with it.
+    "models/memory.py": ("GEN_WORKER_FORBID_CPU_OFFLOAD",),
+    # per-call test-tunable retry knob (mirrors net.py's pattern).
+    "models/download.py": ("COZY_CIVITAI_DOWNLOAD_ATTEMPTS",),
+    # parent→child: `--device` flag exported for endpoint code + ladder
+    # opt-out read per-invocation on the local path.
+    "cli/run.py": ("GEN_WORKER_LOCAL_DEVICE", "GEN_WORKER_NO_PRECISION_LADDER"),
+    "cli/serve.py": ("GEN_WORKER_LOCAL_DEVICE",),
+    # cozy-local app plumbing + login-name fallback.
+    "cli/local_context.py": ("GEN_WORKER_LOCAL_OUTPUT_DIR", '"USER"'),
+    # convert-job scratch/workdir knobs, set by the invoking job harness.
+    "convert/clone.py": ("COZY_CONVERT_",),
+    "convert/ingest.py": ("_DOWNLOAD_ATTEMPTS_ENV",),
+}
+
+
+def _env_touch_lines(tree: ast.AST) -> list[int]:
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+            and node.attr in ("environ", "getenv", "putenv")
+        ):
+            lines.append(node.lineno)
+        elif isinstance(node, ast.ImportFrom) and node.module == "os":
+            if any(a.name in ("environ", "getenv", "putenv") for a in node.names):
+                lines.append(node.lineno)
+    return lines
+
+
+def test_no_raw_env_reads_outside_settings_loader():
+    violations: list[str] = []
+    for path in sorted(SRC.rglob("*.py")):
+        rel = path.relative_to(SRC).as_posix()
+        if rel.startswith("config/"):
+            continue  # the sanctioned surface itself
+        source = path.read_text(encoding="utf-8")
+        if "os." not in source and "import os" not in source:
+            continue
+        src_lines = source.splitlines()
+        allowed = ALLOWED.get(rel, ())
+        for lineno in _env_touch_lines(ast.parse(source, filename=rel)):
+            line = src_lines[lineno - 1].strip()
+            if any(marker in line for marker in allowed):
+                continue
+            violations.append(f"{rel}:{lineno}: {line}")
+    assert not violations, (
+        "raw os.environ/os.getenv outside config/loader.py — move the knob "
+        "onto Settings (config/settings.py + _ENV_TO_FIELD) or, for genuine "
+        "internal plumbing, extend ALLOWED with a one-line justification:\n"
+        + "\n".join(violations)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.20"
+version = "0.13.21"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Consolidates ~15 scattered raw `os.getenv` reads into the sanctioned typed `Settings` loader (`config/loader.py`, env → `.env` → `/run/secrets` → yaml). Same env names keep working; every read now goes through one typed, documented surface.

## Moved onto Settings
- `TENSORHUB_URL` / `TENSORHUB_TOKEN` (models/hub_client.py), `TENSORHUB_CACHE_DIR` (models/cache_paths.py), `TENSORHUB_CAS_DIR` (cli/run.py)
- `CIVITAI_API_KEY` with `CIVITAI_TOKEN` alias (models/download.py, cli/run.py); `HUGGING_FACE_HUB_TOKEN` resolves as an `HF_TOKEN` alias (cli/run.py's HF fallbacks now read `settings.hf_token` / `settings.hf_home`)
- `COZY_HF_DOWNLOAD_STALL_TIMEOUT_S` / `COZY_HF_DOWNLOAD_MAX_SECONDS` / `COZY_HF_MAX_REPO_BYTES` (models/download.py)
- `GEN_WORKER_ATTACHED_LORA_MAX` / `_MAX_BYTES` (utils/lora.py)
- `GEN_WORKER_COMPILE_CACHE` / `_CACHE_URL` / `_ALLOW_COLD` (compile_cache.py) — `apply()` gains an explicit `allow_cold` param for the producer path; the `os.environ[ENV_ALLOW_COLD]` self-set stays so spawned compile workers inherit the opt-in
- `WORKER_IMAGE_DIGEST` / `WORKER_GIT_COMMIT` (lifecycle.py, via the threaded settings instance)

## Loader changes
- `get_settings()` — lru-cached process-wide accessor for call sites without the startup instance; tests clear it via an autouse conftest fixture
- Alias resolution: primary env name wins when non-empty (mirrors the old `getenv(A) or getenv(B)`)
- Forgiving source coercion: empty values for typed fields fall back to struct defaults (an exported-but-empty var must not crash startup); bools accept `1/true/yes`

## Surface stays closed
- `tests/test_env_surface.py`: AST-based guard — any `os.environ`/`os.getenv` in `src/gen_worker` outside `config/` must be on an explicit plumbing allowlist with a one-line justification
- `docs/environment.md`: every env var the repo still reads, grouped (secrets / orchestrator-injected / tuning knobs / CI-lane opt-ins / internal plumbing)

## Deliberately untouched
- `GEN_WORKER_FORBID_CPU_OFFLOAD` — PR #139 owns its removal (allowlisted with a drop-with-it note)
- `net.py` timeout floors + `COZY_*_DOWNLOAD_ATTEMPTS` retry knobs — per-call test-tunable by design (gw#456 / PR #167 territory)
- Parent→child plumbing: `GEN_WORKER_LOCAL_DEVICE`, `GEN_WORKER_LOCAL_OUTPUT_DIR`, `COZY_CONVERT_*`, `PYTORCH_CUDA_ALLOC_CONF`, inductor/triton cache dirs
- `models/download.py` / `cli/run.py` edits kept to pure line swaps to avoid conflicts with open PR #167

Suite: 774 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)