### PR TITLE
gw#465/gw#469: model-op prefetch never cascades or conflates; unavailable rungs skipped; dtype-safe offload (0.13.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.13.16 (2026-07-10)
+
+- **gw#465: boot-prefetch model-op batches no longer fail systematically.**
+  Three worker-side fixes for the paired `download_failed` (variant) +
+  `load_failed` (companion vae) signature seen on every J23 GPU worker:
+  - `ModelOp{LOAD}` no longer cascades: a LOAD for a shared companion ref
+    (one vae bound to every variant of a family) satisfied by a READY
+    instance just touches/promotes it — it never cold-sets-up sibling
+    variant specs. A cold LOAD sets up exactly ONE spec whose every slot is
+    materializable.
+  - The store remembers every digest-carrying snapshot per ref, so
+    snapshot-less ops (LOAD, companion-slot setups) can materialize refs the
+    hub already resolved. Stale URLs self-heal via the url_expired re-mint.
+  - A tensorhub ref with no snapshot anywhere is a deterministic local miss:
+    typed `MissingSnapshotError`, failed FAST (no DOWNLOADING ghost event, no
+    1s+4s retry burn — the observed ~5s failure) with its own contract
+    vocabulary `missing_snapshot` instead of a phantom `download_failed`;
+    the hub re-mints and re-sends DOWNLOAD (tensorhub-side handler), and the
+    function is never disabled by it.
+- **gw#469: unavailable ladder rungs are skipped, and no rung renders with
+  broken dtype.**
+  - The emergency bnb-nf4 rung is gated on bitsandbytes importability: absent
+    from the endpoint image -> the rung is SKIPPED with a logged reason (the
+    offload ladder carries the load), never attempted into a
+    `PackageNotFoundError` setup_failed.
+  - A `force_upcast` VAE (SDXL family) is never hook-managed by any offload
+    rung (gw#441): group offload excludes it (`exclude_modules`), the
+    model/sequential rungs exclude it via diffusers'
+    `_exclude_from_cpu_offload`; it stays resident on the execution device so
+    the pipeline's own upcast dance works — no more Half/float decode fatals.
+
 ## 0.13.15 (2026-07-10)
 
 - **fp8: SM-aware ladder ordering + remove the pre-Ada fp8 refuse-bug.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.15"
+version = "0.13.16"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -49,8 +49,8 @@ from .models.memory import (
     is_cuda_oom,
 )
 from .models.cache_paths import tensorhub_cas_dir
-from .models.download import ensure_local
-from .models.errors import UrlExpiredError
+from .models.download import ensure_local, lookup_provider_for_ref
+from .models.errors import MissingSnapshotError, UrlExpiredError
 from .models.residency import Residency
 from .pb import worker_scheduler_pb2 as pb
 from .registry import EndpointSpec
@@ -232,6 +232,8 @@ def _model_op_error_vocab(exc: BaseException) -> str:
     """Contract §9 ModelEvent.error vocabulary for LOAD/UNLOAD failures."""
     if is_cuda_oom(exc):
         return "oom"
+    if isinstance(exc, MissingSnapshotError):
+        return "missing_snapshot"
     text = str(exc).lower()
     if "out of memory" in text or "cuda oom" in text:
         return "oom"
@@ -260,7 +262,7 @@ def _is_corrupt_load_error(exc: BaseException) -> bool:
 
 
 def _is_terminal_download_error(exc: BaseException) -> bool:
-    if isinstance(exc, (UrlExpiredError, InsufficientDiskError)):
+    if isinstance(exc, (UrlExpiredError, InsufficientDiskError, MissingSnapshotError)):
         return True
     status = getattr(exc, "status_code", None)
     if not isinstance(status, int):
@@ -318,6 +320,12 @@ class ModelStore:
         # (gw#408): a cached snapshot is re-verified on first use per process
         # so pod-churn corruption can never be trusted forever.
         self._verified: set[str] = set()
+        # Last digest-carrying snapshot seen per ref (gw#465): ModelOp{LOAD}
+        # and companion-slot setups arrive snapshot-less; without memory of
+        # the hub's earlier DOWNLOAD snapshot they cannot materialize
+        # tensorhub refs. Stale URLs self-heal: they fail url_expired and the
+        # hub re-mints.
+        self._snapshots: Dict[str, pb.Snapshot] = {}
 
     def _default_disk_free(self) -> int:
         p = Path(self._cache_dir)
@@ -369,6 +377,11 @@ class ModelStore:
 
     def local_path(self, ref: str) -> Optional[Path]:
         return self.residency.local_path(ref)
+
+    def has_snapshot(self, ref: str) -> bool:
+        """A digest-carrying snapshot for ``ref`` was seen this connection
+        (gw#465): snapshot-less ops for it can still materialize the bytes."""
+        return ref in self._snapshots
 
     # ---- disk retention (#370) ------------------------------------------------
 
@@ -462,6 +475,10 @@ class ModelStore:
         self.bind_loop()
         if binding is None:
             binding = self._bindings.get(ref)
+        if snapshot is not None and snapshot.digest and snapshot.files:
+            self._snapshots[ref] = snapshot
+        elif snapshot is None:
+            snapshot = self._snapshots.get(ref)
         async with self._lock(ref):
             cached = self.residency.local_path(ref)
             # A digest-carrying snapshot is authoritative: a cached
@@ -501,6 +518,24 @@ class ModelStore:
                 await self._ensure_disk_headroom(
                     ref, sum(int(f.size_bytes) for f in snapshot.files)
                 )
+            if snapshot is None or not snapshot.digest:
+                # Confident classification only (binding / boot provider
+                # index) — unknown refs still flow to the download layer's
+                # dispatch, which raises the same typed error terminally.
+                prov = (getattr(binding, "provider", None)
+                        or lookup_provider_for_ref(ref, default=""))
+                if prov == "tensorhub":
+                    # Deterministic local condition (gw#465): the worker
+                    # cannot resolve tensorhub-CAS refs itself. Fail fast
+                    # (no DOWNLOADING event, no retry burn) with its own
+                    # vocabulary so the hub re-mints instead of counting a
+                    # phantom download_failed.
+                    await self._event(ref, pb.MODEL_STATE_FAILED,
+                                      error="missing_snapshot")
+                    raise MissingSnapshotError(
+                        f"tensorhub ref {ref!r} needs an orchestrator-resolved "
+                        "snapshot and none was provided or previously seen"
+                    )
             last_progress = 0.0
 
             def _progress(done: int, total: Optional[int]) -> None:
@@ -644,6 +679,8 @@ class ModelStore:
 
     @staticmethod
     def _error_vocab(exc: BaseException) -> str:
+        if isinstance(exc, MissingSnapshotError):
+            return "missing_snapshot"
         if isinstance(exc, UrlExpiredError):
             return "url_expired"
         if isinstance(exc, InsufficientDiskError):
@@ -1030,9 +1067,10 @@ class Executor:
             return instance
 
     def _mark_setup_failed(self, rec: _ClassRecord, exc: BaseException) -> None:
-        if isinstance(exc, (InsufficientDiskError, RetryableError)):
-            # Transient pressure (disk GC frees space / warm-tier RAM drains):
-            # fail the op RETRYABLE, never disable the function.
+        if isinstance(exc, (InsufficientDiskError, RetryableError, MissingSnapshotError)):
+            # Transient pressure (disk GC frees space / warm-tier RAM drains /
+            # the hub re-mints a snapshot): fail the op RETRYABLE, never
+            # disable the function.
             return
         if isinstance(exc, HardwareUnmetError):
             reason = getattr(exc, "reason", "hardware_unmet")
@@ -1232,6 +1270,24 @@ class Executor:
             if await asyncio.to_thread(res.make_room, needed):
                 break
         self._on_state_change()
+
+    def _missing_slot_refs(
+        self, spec: EndpointSpec, snapshots: Optional[Dict[str, pb.Snapshot]]
+    ) -> set:
+        """Tensorhub setup-slot refs of ``spec`` the worker cannot materialize
+        right now: not on disk, no snapshot in this op, none remembered
+        (gw#465). Non-tensorhub slots self-fetch and never block."""
+        missing: set = set()
+        for slot in self._setup_slots(spec):
+            binding = spec.models[slot]
+            if getattr(binding, "provider", "tensorhub") != "tensorhub":
+                continue
+            r = wire_ref(binding)
+            if (self.store.local_path(r) is None
+                    and not (snapshots and r in snapshots)
+                    and not self.store.has_snapshot(r)):
+                missing.add(r)
+        return missing
 
     @staticmethod
     def _setup_slots(spec: EndpointSpec) -> List[str]:
@@ -1453,16 +1509,47 @@ class Executor:
                 await self.store.ensure_local(ref, snap)
             elif op.op == pb.MODEL_OP_KIND_LOAD:
                 await self.store.ensure_local(ref, snap)
-                loaded = False
                 snapshots = {ref: snap} if snap is not None else None
-                for spec in self.specs.values():
-                    if ref in (wire_ref(b) for b in spec.models.values()):
-                        await self.ensure_setup(spec, snapshots)
-                        loaded = True
-                if not loaded:
+                specs = [s for s in self.specs.values()
+                         if ref in (wire_ref(b) for b in s.models.values())]
+                if not specs:
                     # No endpoint binds this ref; nothing owns a VRAM load for it.
                     await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
                         ref=ref, state=pb.MODEL_STATE_FAILED, error="load_failed")))
+                    return
+                ready = [s for s in specs if self._classes[s.instance_key].ready]
+                if ready:
+                    # A resident instance already owns the ref: promote/touch it.
+                    # Never cold-set-up the OTHER specs sharing the ref — a
+                    # shared companion (one vae bound to every variant of a
+                    # family) would cascade one LOAD into loading every sibling
+                    # checkpoint (gw#465).
+                    for s in ready:
+                        await self.ensure_setup(s, snapshots)
+                else:
+                    target = next(
+                        (s for s in specs
+                         if not self._missing_slot_refs(s, snapshots)), None)
+                    if target is None:
+                        # Every candidate needs a sibling slot the worker cannot
+                        # materialize. Name the blockers so the hub re-mints and
+                        # re-sends DOWNLOAD for them, and fail THIS op with the
+                        # same vocabulary — never a phantom download_failed.
+                        blockers: set = set()
+                        for s in specs:
+                            blockers |= self._missing_slot_refs(s, snapshots)
+                        for m in sorted(blockers):
+                            logger.warning(
+                                "ModelOp LOAD %s deferred: sibling slot %s has "
+                                "no snapshot; reporting missing_snapshot", ref, m)
+                            await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                                ref=m, state=pb.MODEL_STATE_FAILED,
+                                error="missing_snapshot")))
+                        await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                            ref=ref, state=pb.MODEL_STATE_FAILED,
+                            error="missing_snapshot")))
+                        return
+                    await self.ensure_setup(target, snapshots)
             elif op.op == pb.MODEL_OP_KIND_UNLOAD:
                 if self._ref_in_use(ref):
                     await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -194,11 +194,12 @@ async def ensure_local(
         )
 
     if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
-        # Hub-side residency bug (the orchestrator failed to pre-resolve),
-        # not bad client input — RETRYABLE, never a client-visible 400.
-        from ..api.errors import RetryableError
+        # The worker cannot resolve tensorhub-CAS refs itself (gw#465):
+        # typed + terminal so callers fail fast with "missing_snapshot"
+        # instead of burning retries on a deterministic local condition.
+        from .errors import MissingSnapshotError
 
-        raise RetryableError(
+        raise MissingSnapshotError(
             f"tensorhub ref {ref!r} needs an orchestrator-resolved snapshot "
             "and none was provided"
         )

--- a/src/gen_worker/models/errors.py
+++ b/src/gen_worker/models/errors.py
@@ -12,4 +12,11 @@ class UrlExpiredError(RuntimeError):
         self.status_code = int(status_code)
 
 
-__all__ = ["UrlExpiredError"]
+class MissingSnapshotError(RuntimeError):
+    """A tensorhub-CAS ref cannot be materialized: no orchestrator-resolved
+    snapshot was provided, cached, or previously seen (gw#465). Deterministic
+    local condition — never retried worker-side; the orchestrator re-mints and
+    re-sends DOWNLOAD on ``ModelEvent{FAILED, error:"missing_snapshot"}``."""
+
+
+__all__ = ["UrlExpiredError", "MissingSnapshotError"]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -592,9 +592,31 @@ def snapshot_weight_bytes(model_path: Path) -> int:
     return total
 
 
+def bitsandbytes_available() -> bool:
+    """Importability gate for the bnb-nf4 rung (gw#469): the quant config
+    constructs fine without bitsandbytes and the load then dies deep in
+    ``validate_environment`` (PackageNotFoundError -> setup_failed). An
+    unavailable rung must be SKIPPED, never attempted."""
+    import importlib.util
+    import sys
+
+    if "bitsandbytes" in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec("bitsandbytes") is not None
+    except (ImportError, ValueError):
+        return False
+
+
 def emergency_quantization_config(cls: Any) -> Optional[Any]:
     """Denoiser-scoped bnb-nf4 config for the emergency rung. None (with a
     warning) when the stack can't do it — the offload ladder then carries it."""
+    if not bitsandbytes_available():
+        logger.warning(
+            "emergency nf4 unavailable (bitsandbytes not installed in this "
+            "image); skipping the quantized rung — the offload ladder carries it"
+        )
+        return None
     try:
         import torch
 
@@ -771,6 +793,7 @@ __all__ = [
     "synthesize_quantization_config",
     "apply_fp8_storage",
     "emergency_quant_enabled",
+    "bitsandbytes_available",
     "runtime_fp8_storage_supported",
     "emergency_quantization_config",
     "snapshot_weight_bytes",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -456,6 +456,41 @@ def _apply_vae_and_attention(pipeline: Any, applied: Dict[str, bool]) -> None:
         applied["attention_slicing"] = True
 
 
+def _dtype_fragile_vae(pipeline: Any) -> Optional[Any]:
+    """The pipeline's VAE when ``config.force_upcast`` is set (SDXL family).
+    Such a VAE mutates dtype at decode time (``upcast_vae`` -> fp32 -> back);
+    hook-managed weights miss the runtime cast and decode fatals with
+    Half/float mismatches (gw#441/gw#469). It must stay resident on the
+    execution device — never hook-managed by any offload rung."""
+    vae = getattr(pipeline, "vae", None)
+    if vae is None or not hasattr(vae, "parameters"):
+        return None
+    if bool(getattr(getattr(vae, "config", None), "force_upcast", False)):
+        return vae
+    return None
+
+
+def _pin_fragile_vae(pipeline: Any, applied: Dict[str, bool], log: logging.Logger) -> None:
+    """Keep a force_upcast VAE out of the diffusers CPU-offload hooks.
+    ``_exclude_from_cpu_offload`` is honored by BOTH the model and sequential
+    rungs, which move excluded components to the execution device
+    themselves."""
+    if _dtype_fragile_vae(pipeline) is None:
+        return
+    excl = list(getattr(pipeline, "_exclude_from_cpu_offload", None) or [])
+    if "vae" not in excl:
+        excl.append("vae")
+    try:
+        pipeline._exclude_from_cpu_offload = excl
+    except Exception:
+        return
+    applied["vae_resident"] = True
+    log.info(
+        "low_vram: force_upcast vae stays resident (excluded from offload "
+        "hooks — dtype-safety, gw#441/gw#469)"
+    )
+
+
 def _apply_group_offload(
     pipeline: Any,
     applied: Dict[str, bool],
@@ -478,10 +513,29 @@ def _apply_group_offload(
     if offload_to_disk_path:
         kwargs["offload_to_disk_path"] = offload_to_disk_path
 
+    fragile_vae = _dtype_fragile_vae(pipeline)
+
+    def _keep_vae_resident() -> None:
+        if fragile_vae is None:
+            return
+        try:
+            fragile_vae.to("cuda")
+        except Exception as exc:
+            _LOG.warning("low_vram: resident vae move failed: %s", exc)
+        applied["vae_resident"] = True
+        _LOG.info(
+            "low_vram: force_upcast vae stays resident under group offload "
+            "(dtype-safety, gw#441/gw#469)"
+        )
+
     fn = getattr(pipeline, "enable_group_offload", None)
     if callable(fn):
         try:
-            fn(**kwargs)
+            if fragile_vae is not None:
+                fn(**kwargs, exclude_modules=["vae"])
+            else:
+                fn(**kwargs)
+            _keep_vae_resident()
             applied["group_offload"] = True
             if offload_to_disk_path:
                 applied["disk_offload_path"] = True
@@ -498,6 +552,8 @@ def _apply_group_offload(
     for attr in ("transformer", "unet", "vae", "text_encoder", "text_encoder_2"):
         mod = getattr(pipeline, attr, None)
         if mod is None:
+            continue
+        if attr == "vae" and fragile_vae is not None:
             continue
         mod_fn = getattr(mod, "enable_group_offload", None)
         if callable(mod_fn):
@@ -521,6 +577,7 @@ def _apply_group_offload(
                 _LOG.debug("low_vram: apply_group_offloading(%s) failed: %s", attr, exc)
 
     if any_applied:
+        _keep_vae_resident()
         applied["group_offload"] = True
         if offload_to_disk_path:
             applied["disk_offload_path"] = True
@@ -686,6 +743,7 @@ def apply_low_vram_config(
             )
 
     if effective_mode == "model_offload":
+        _pin_fragile_vae(pipeline, applied, log)
         ok = _call_if_present(pipeline, "enable_model_cpu_offload")
         if not ok:
             try:
@@ -705,6 +763,7 @@ def apply_low_vram_config(
             effective_mode = "sequential"
 
     if effective_mode == "sequential":
+        _pin_fragile_vae(pipeline, applied, log)
         _move_pipeline_to_cpu(pipeline)
         flush_memory()
         ok = _call_if_present(pipeline, "enable_sequential_cpu_offload")

--- a/tests/test_fp8_and_emergency_loading.py
+++ b/tests/test_fp8_and_emergency_loading.py
@@ -78,6 +78,8 @@ def fake_diffusers(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     monkeypatch.setitem(sys.modules, "diffusers", root)
     monkeypatch.setitem(sys.modules, "diffusers.quantizers", quantizers)
     monkeypatch.setitem(sys.modules, "diffusers.quantizers.quantization_config", qc_mod)
+    # the nf4 rung is gated on bitsandbytes availability (gw#469)
+    monkeypatch.setitem(sys.modules, "bitsandbytes", types.ModuleType("bitsandbytes"))
     return root
 
 
@@ -256,6 +258,29 @@ def test_nf4_rung_engages_when_even_fp8_estimate_cannot_fit(
     assert isinstance(qc, _FakePipelineQuantizationConfig)
     assert qc.quant_kwargs["bnb_4bit_quant_type"] == "nf4"
     assert pipe.transformer.casting_calls == []
+
+
+def test_nf4_rung_skipped_without_bitsandbytes(
+    fake_diffusers: Any, emergency_on: None, tmp_path: Path,
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gw#469: bitsandbytes absent from the endpoint image — the nf4 rung is
+    SKIPPED with a logged reason (the offload ladder carries the load), never
+    attempted into a PackageNotFoundError setup_failed."""
+    import importlib.util
+    import sys
+
+    monkeypatch.delitem(sys.modules, "bitsandbytes", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec",
+                        lambda name, *a, **k: None if name == "bitsandbytes"
+                        else importlib.util._bootstrap._find_spec(name, None))
+    snap = _snapshot(tmp_path, "BF16", 20 << 30)  # nf4 territory (fp8 can't fit)
+    _Pipe.calls = []
+    with caplog.at_level("WARNING"):
+        load_from_pretrained(_Pipe, snap, dtype="bf16")
+    (kwargs,) = _Pipe.calls
+    assert "quantization_config" not in kwargs, "unavailable rung was attempted"
+    assert "bitsandbytes not installed" in caplog.text
 
 
 def test_emergency_rung_stays_out_without_cuda(

--- a/tests/test_mirror_first_snapshot.py
+++ b/tests/test_mirror_first_snapshot.py
@@ -86,8 +86,8 @@ def test_hf_ref_without_snapshot_stays_provider_direct(tmp_path: Path, monkeypat
     assert out == sentinel
 
 
-def test_tensorhub_ref_without_snapshot_is_retryable(tmp_path: Path) -> None:
-    from gen_worker.api.errors import RetryableError
+def test_tensorhub_ref_without_snapshot_is_missing_snapshot(tmp_path: Path) -> None:
+    from gen_worker.models.errors import MissingSnapshotError
 
-    with pytest.raises(RetryableError):
+    with pytest.raises(MissingSnapshotError):
         asyncio.run(ensure_local("acme/checkpoint", provider="tensorhub", cache_dir=tmp_path))

--- a/tests/test_model_op_prefetch_no_cascade.py
+++ b/tests/test_model_op_prefetch_no_cascade.py
@@ -1,0 +1,194 @@
+"""gw#465: boot-prefetch/preposition ModelOps must never cascade or conflate.
+
+The J23 failure: a snapshot-less ModelOp{LOAD} for a SHARED companion ref (one
+vae bound to every variant of an SDXL family) cold-set-up the first non-ready
+variant spec; its checkpoint slot had no snapshot, the worker can't resolve
+tensorhub refs itself, and the deterministic local miss burned the 1s+4s retry
+loop before being mislabeled ``download_failed`` (paired with the companion's
+``load_failed``). Demand ops for the same refs — which carry snapshots —
+succeeded seconds later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import Hub
+from gen_worker.executor import Executor
+from gen_worker.models.errors import MissingSnapshotError
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    x: str
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+VAE = Hub("tensorhub/sdxl-vae-fp16-fix")
+VARIANT_A = Hub("acme/variant-a")
+VARIANT_B = Hub("acme/variant-b")
+
+
+def _spec(name: str, checkpoint: Hub, calls: List[str]) -> EndpointSpec:
+    class Endpoint:
+        def setup(self, model: str, vae: str) -> None:
+            calls.append(name)
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out(y=payload.x)
+
+    return EndpointSpec(
+        name=name, method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="run", models={"model": checkpoint, "vae": VAE},
+    )
+
+
+def _snapshot(digest: str = "ab" * 32) -> pb.Snapshot:
+    return pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
+        path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+        url="http://r2.invalid/presigned")])
+
+
+def _harness(tmp_path: Path, calls: List[str], *, on_disk: List[str] = ()):
+    """Executor with the REAL ModelStore/handle_model_op orchestration; only
+    the network-touching download primitive is faked (existing test pattern).
+    """
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor([_spec("gen-a", VARIANT_A, calls), _spec("gen-b", VARIANT_B, calls)], _send)
+
+    downloads: List[Dict[str, Any]] = []
+
+    async def _fake_download(ref: str, **kwargs: Any) -> Path:
+        downloads.append({"ref": ref, **kwargs})
+        if kwargs.get("snapshot") is None:
+            raise MissingSnapshotError(f"tensorhub ref {ref!r} needs a snapshot")
+        p = tmp_path / ref.replace("/", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import gen_worker.executor as ex_mod
+    for ref in on_disk:
+        p = tmp_path / ref.replace("/", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        ex.store.residency.track_disk(ref, p)
+        ex.store._verified.add(ref)
+    return ex, sent, downloads, ex_mod, _fake_download
+
+
+def _failed_events(sent: List[pb.WorkerMessage]) -> List[pb.ModelEvent]:
+    return [m.model_event for m in sent
+            if m.WhichOneof("msg") == "model_event"
+            and m.model_event.state == pb.MODEL_STATE_FAILED]
+
+
+def test_load_of_shared_companion_does_not_cascade(tmp_path, monkeypatch) -> None:
+    """A LOAD for the shared vae while instance A is ready must touch/promote
+    A only — NOT cold-set-up variant B (whose checkpoint has no snapshot)."""
+    calls: List[str] = []
+    ex, sent, downloads, ex_mod, fake = _harness(
+        tmp_path, calls, on_disk=["acme/variant-a", "tensorhub/sdxl-vae-fp16-fix"])
+    monkeypatch.setattr(ex_mod, "ensure_local", fake)
+
+    async def _run() -> None:
+        spec_a = ex.specs["gen-a"]
+        await ex.ensure_setup(spec_a)  # instance A resident
+        assert calls == ["gen-a"]
+        await ex.handle_model_op(pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref="tensorhub/sdxl-vae-fp16-fix"))
+
+    asyncio.run(_run())
+    assert calls == ["gen-a"], f"LOAD(vae) cascaded into cold setups: {calls}"
+    assert not _failed_events(sent), (
+        f"LOAD(vae) with a ready owner emitted failures: {_failed_events(sent)}")
+
+
+def test_cold_load_missing_sibling_snapshot_fails_fast_and_typed(tmp_path, monkeypatch) -> None:
+    """Cold worker, LOAD(vae): every candidate spec needs a checkpoint the
+    worker cannot materialize. The op must fail FAST (no 1s+4s local retry
+    burn) with ``missing_snapshot`` naming the blocking refs — never a phantom
+    ``download_failed`` — and must not disable any function."""
+    calls: List[str] = []
+    ex, sent, downloads, ex_mod, fake = _harness(
+        tmp_path, calls, on_disk=["tensorhub/sdxl-vae-fp16-fix"])
+    monkeypatch.setattr(ex_mod, "ensure_local", fake)
+
+    t0 = time.monotonic()
+    asyncio.run(ex.handle_model_op(pb.ModelOp(
+        op=pb.MODEL_OP_KIND_LOAD, ref="tensorhub/sdxl-vae-fp16-fix")))
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 1.0, f"deterministic local miss burned retries ({elapsed:.1f}s)"
+    assert calls == [], f"unmaterializable specs were cold-set-up: {calls}"
+    failed = _failed_events(sent)
+    errors = {(e.ref, e.error) for e in failed}
+    assert ("acme/variant-a", "missing_snapshot") in errors
+    assert ("acme/variant-b", "missing_snapshot") in errors
+    assert ("tensorhub/sdxl-vae-fp16-fix", "missing_snapshot") in errors
+    assert all(e.error != "download_failed" for e in failed), errors
+    assert not ex.unavailable, f"functions disabled by a transient miss: {ex.unavailable}"
+
+
+def test_snapshot_memory_enables_companion_setup(tmp_path, monkeypatch) -> None:
+    """The store remembers digest-carrying snapshots (gw#465): after the hub's
+    DOWNLOAD(variant-b, snapshot), a snapshot-less LOAD(vae) can set up the
+    variant-b spec — the boot-prefetch batch lands instead of wedging."""
+    calls: List[str] = []
+    ex, sent, downloads, ex_mod, fake = _harness(
+        tmp_path, calls, on_disk=["tensorhub/sdxl-vae-fp16-fix"])
+    monkeypatch.setattr(ex_mod, "ensure_local", fake)
+
+    async def _run() -> None:
+        await ex.handle_model_op(pb.ModelOp(
+            op=pb.MODEL_OP_KIND_DOWNLOAD, ref="acme/variant-b",
+            snapshot=_snapshot()))
+        assert ex.store.has_snapshot("acme/variant-b")
+        await ex.handle_model_op(pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref="tensorhub/sdxl-vae-fp16-fix"))
+
+    asyncio.run(_run())
+    assert calls == ["gen-b"], f"companion LOAD did not set up variant-b: {calls}"
+    assert not _failed_events(sent), _failed_events(sent)
+
+
+def test_store_missing_snapshot_is_fast_and_never_says_download_failed(tmp_path) -> None:
+    """ModelStore.ensure_local on a snapshot-less tensorhub ref: no DOWNLOADING
+    event ("model download started" ghost), no retry burn, FAILED carries
+    ``missing_snapshot``."""
+    from gen_worker.executor import ModelStore
+
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path)
+    # endpoint refs are registered at boot (#377) — that's what makes the
+    # provider classification confident enough to fail fast
+    store.register_binding("acme/never-resolved", Hub("acme/never-resolved"))
+
+    async def _run() -> None:
+        with pytest.raises(MissingSnapshotError):
+            await store.ensure_local("acme/never-resolved")
+
+    t0 = time.monotonic()
+    asyncio.run(_run())
+    assert time.monotonic() - t0 < 1.0
+    states = [m.model_event.state for m in sent if m.WhichOneof("msg") == "model_event"]
+    assert pb.MODEL_STATE_DOWNLOADING not in states
+    failed = _failed_events(sent)
+    assert failed and failed[-1].error == "missing_snapshot"

--- a/tests/test_offload_dtype_safety.py
+++ b/tests/test_offload_dtype_safety.py
@@ -1,0 +1,78 @@
+"""gw#441/gw#469: no offload rung may render with broken dtype.
+
+A ``force_upcast`` VAE (SDXL family) mutates dtype at decode (``upcast_vae``
+-> fp32 -> back); hook-managed weights miss the runtime cast and decode fatals
+with Half/float mismatches. Every offload rung must keep such a VAE resident:
+group offload excludes it, model/sequential rungs exclude it via diffusers'
+``_exclude_from_cpu_offload`` (which moves excluded components to the
+execution device itself).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gen_worker.models.memory import _dtype_fragile_vae, _pin_fragile_vae
+
+diffusers = pytest.importorskip("diffusers")
+
+
+def _tiny_vae(force_upcast: bool):
+    from diffusers import AutoencoderKL
+
+    return AutoencoderKL(
+        in_channels=3, out_channels=3,
+        down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+        block_out_channels=(4,), layers_per_block=1,
+        latent_channels=4, norm_num_groups=2, sample_size=8,
+        force_upcast=force_upcast,
+    )
+
+
+class _Pipe:
+    def __init__(self, vae) -> None:
+        self.vae = vae
+
+
+def test_force_upcast_vae_detected() -> None:
+    assert _dtype_fragile_vae(_Pipe(_tiny_vae(True))) is not None
+    assert _dtype_fragile_vae(_Pipe(_tiny_vae(False))) is None  # fp16-fix vae
+    assert _dtype_fragile_vae(_Pipe(None)) is None
+
+
+def test_pin_excludes_vae_from_cpu_offload_hooks() -> None:
+    pipe = _Pipe(_tiny_vae(True))
+    applied: dict = {}
+    _pin_fragile_vae(pipe, applied, logging.getLogger(__name__))
+    assert "vae" in pipe._exclude_from_cpu_offload
+    assert applied.get("vae_resident") is True
+    # idempotent — a second application must not duplicate the entry
+    _pin_fragile_vae(pipe, applied, logging.getLogger(__name__))
+    assert pipe._exclude_from_cpu_offload.count("vae") == 1
+
+
+def test_pin_leaves_safe_vae_hook_managed() -> None:
+    pipe = _Pipe(_tiny_vae(False))
+    applied: dict = {}
+    _pin_fragile_vae(pipe, applied, logging.getLogger(__name__))
+    assert "vae" not in (getattr(pipe, "_exclude_from_cpu_offload", None) or [])
+    assert "vae_resident" not in applied
+
+
+def test_real_pipeline_exclusion_is_honored_by_diffusers() -> None:
+    """The mechanism contract: DiffusionPipeline's offload rungs consult
+    ``self._exclude_from_cpu_offload`` (and move excluded components to the
+    execution device). Guard the attribute so a diffusers rename cannot
+    silently re-hook the fragile VAE."""
+    from diffusers import DiffusionPipeline
+
+    assert hasattr(DiffusionPipeline, "_exclude_from_cpu_offload")
+    import inspect
+
+    src = inspect.getsource(DiffusionPipeline.enable_sequential_cpu_offload)
+    assert "_exclude_from_cpu_offload" in src
+    src = inspect.getsource(DiffusionPipeline.enable_model_cpu_offload)
+    assert "_exclude_from_cpu_offload" in src

--- a/tests/test_provider_routing.py
+++ b/tests/test_provider_routing.py
@@ -179,14 +179,14 @@ def test_civitai_ref_routes_to_civitai_branch(tmp_path: Path, monkeypatch) -> No
 def test_tensorhub_refs_require_a_snapshot(tmp_path: Path, monkeypatch, ref, index) -> None:
     """Workers never resolve tensorhub refs themselves — the orchestrator
     pre-resolves and ships a Snapshot. Without one, the tensorhub branch
-    raises RETRYABLE (a hub residency bug, not client input; #373) and the
+    raises the typed terminal MissingSnapshotError (gw#465) and the
     HF branch is NOT touched."""
-    from gen_worker.api.errors import RetryableError
+    from gen_worker.models.errors import MissingSnapshotError
 
     calls: list = []
     monkeypatch.setattr(dl_mod, "download_hf", lambda *a, **k: calls.append(a) or tmp_path)
     set_provider_index(index)
-    with pytest.raises(RetryableError, match="orchestrator-resolved snapshot"):
+    with pytest.raises(MissingSnapshotError, match="orchestrator-resolved snapshot"):
         asyncio.run(ensure_local(ref, cache_dir=tmp_path))
     assert calls == []
 


### PR DESCRIPTION
## gw#465 — boot-prefetch model-op batches failed systematically

Root cause (matches the J23 evidence exactly, including the ~5s timing): a snapshot-less \`ModelOp{LOAD}\` for a **shared companion ref** (one vae bound to every variant of an SDXL family) iterated ALL specs binding it and cold-set-up the first non-ready variant spec. That variant's checkpoint slot had no snapshot (LOAD ops never carried one; \`handle_model_op\` passed only its own ref's), the worker cannot resolve tensorhub-CAS refs itself, and the resulting deterministic local error burned the executor's 1s+4s retry backoff (= the observed ~5s after \"model download started\") before \`_error_vocab\` mislabeled it \`download_failed\` — while the op wrapper emitted the companion's \`load_failed\`. One LOAD(vae) produced all three observed hub log lines. Demand ops succeeded because RunJob carries resolved snapshots for every ref.

### Fixes (all on the existing unified admission path)
- **LOAD no-cascade**: a LOAD satisfied by a READY instance touches/promotes it only. A cold LOAD sets up exactly ONE spec whose every slot is materializable. Otherwise the op fails typed, naming the blocking refs.
- **Snapshot memory**: the store remembers every digest-carrying snapshot per ref, so snapshot-less ops (LOAD, companion-slot setups) can materialize refs the hub already resolved. Stale URLs self-heal via the existing url_expired re-mint.
- **Typed \`missing_snapshot\`**: deterministic local miss => \`MissingSnapshotError\`, failed FAST (no DOWNLOADING ghost event, no retry burn), never disables the function, and the hub re-mints + re-sends DOWNLOAD (tensorhub PR, paired).

Prefetch under VRAM pressure already demotes through the gw#463 ladder (\`_make_room_for\` LRU eviction + \`place_pipeline\` OOM demotion) — the LOAD path rides the same \`ensure_setup\` as demand, no parallel mechanism.

## gw#469 — remaining gaps
- **bnb rung gate**: \`emergency_quantization_config\` now requires bitsandbytes importability (like the svdq gates) — absent from the endpoint image means the rung is SKIPPED with a logged reason and the offload ladder carries the load, never a \`PackageNotFoundError\` setup_failed.
- **No rung renders with broken dtype** (gw#441 family): a \`force_upcast\` VAE is never hook-managed by any offload rung — group offload excludes it (\`exclude_modules\`), model/sequential rungs exclude it via diffusers' \`_exclude_from_cpu_offload\` (which pins excluded components on the execution device), so the pipeline's own upcast dance works.

## Tests
- \`tests/test_model_op_prefetch_no_cascade.py\`: shared-companion LOAD with a ready owner does not cascade; cold LOAD with unmaterializable siblings fails fast + typed (<1s, no download_failed, no fn disable); snapshot memory lets a companion LOAD land the sibling spec; store-level missing-snapshot emits no DOWNLOADING ghost.
- \`tests/test_offload_dtype_safety.py\`: force_upcast detection, hook exclusion, diffusers-contract guard.
- \`tests/test_fp8_and_emergency_loading.py\`: nf4 rung skipped without bitsandbytes (plus fixture now models bnb availability).
- Full suite: 630 passed, 9 skipped.

Paired tensorhub PR: hub treats \`missing_snapshot\` like \`url_expired\` (re-mint + DOWNLOAD) and attaches snapshots to LOAD ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)