### PR TITLE
gw#472: compile cells learn video — (w, h, frames) shapes, fp8-parity build, recompile-limit fix (ie#381)

### DIFF
--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -108,8 +108,12 @@ class Compile(msgspec.Struct, frozen=True):
 
     ``Compile(family="flux2-klein-4b", shapes=((768, 768), (1024, 1024)))``
     names the model FAMILY (caches key on the traced graph, so every
-    fine-tune of a family shares one artifact) and the (width, height) set
-    the compile job warms.
+    fine-tune of a family shares one artifact) and the shape set the compile
+    job warms. A shape row is ``(width, height)`` for image models or
+    ``(width, height, frames)`` for video models (ie#381): video DiT graphs
+    key on the token count, which includes the frame axis, so every
+    (resolution, duration) preset pair is its own graph. Two-stage presets
+    contribute BOTH their base and refined resolutions as rows.
 
     SHAPES DERIVE FROM THE PAYLOAD PRESET ENUM (ie#345 fleet policy): when
     the endpoint's payload uses size buckets, ``shapes`` must be exactly
@@ -123,16 +127,21 @@ class Compile(msgspec.Struct, frozen=True):
     See ``gen_worker.compile_cache``.
     """
 
-    shapes: tuple[tuple[int, int], ...]
+    shapes: tuple[tuple[int, ...], ...]
     targets: tuple[str, ...] = ("transformer", "vae.decode")
     family: str = ""
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
-        shapes = tuple((int(w), int(h)) for w, h in (tuple(s) for s in self.shapes))
-        if not shapes or any(w <= 0 or h <= 0 for w, h in shapes):
+        shapes = tuple(tuple(int(v) for v in s) for s in self.shapes)
+        if (
+            not shapes
+            or any(len(s) not in (2, 3) for s in shapes)
+            or any(v <= 0 for s in shapes for v in s)
+        ):
             raise ValueError(
-                f"Compile.shapes must be positive (w, h) pairs, got {self.shapes!r}"
+                "Compile.shapes must be positive (w, h) or (w, h, frames) "
+                f"rows, got {self.shapes!r}"
             )
         force(self, "shapes", shapes)
         targets = tuple(str(t).strip() for t in self.targets if str(t).strip())

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -164,16 +164,20 @@ def artifact_metadata(
     family: str,
     source_ref: str = "",
     source_digest: str = "",
-    shapes: Iterable[Tuple[int, int]] = (),
+    shapes: Iterable[Tuple[int, ...]] = (),
     targets: Iterable[str] = (),
     low_vram_mode: str = "",
+    storage_dtype: str = "",
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
     record the family member compiled from — informational only.
     ``low_vram_mode`` is the prep mode the producer pipeline was traced under
     (gw#391): its flags are traced into the graphs, so a consumer prepped in a
-    different mode must reject the cell."""
+    different mode must reject the cell. ``storage_dtype`` records the weight
+    storage the graphs were traced under (fp8 layerwise-cast hooks are traced
+    INTO the graphs — ie#381); informational, a drift is a cache miss, never
+    an error. Shape rows are (w, h) or (w, h, frames) — see ``Compile``."""
     return {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
@@ -182,9 +186,10 @@ def artifact_metadata(
         "family": str(family or ""),
         "source_ref": str(source_ref or ""),
         "source_digest": str(source_digest or ""),
-        "shapes": [[int(w), int(h)] for w, h in shapes],
+        "shapes": [[int(v) for v in s] for s in shapes],
         "targets": list(targets),
         "low_vram_mode": str(low_vram_mode or ""),
+        "storage_dtype": str(storage_dtype or ""),
         "libs": _lib_versions(),
     }
 
@@ -554,6 +559,22 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
             )
             return False
 
+    # Dynamo's per-code-object recompile limit defaults to 8; a preset table
+    # bigger than that (LTX: 12 video graphs, ie#381) would silently fall
+    # back to eager for every shape past the limit. Size it to the declared
+    # shape set — never lower an operator-raised value.
+    try:
+        import torch._dynamo
+
+        want = len(tuple(cfg.shapes)) + 8
+        torch._dynamo.config.cache_size_limit = max(
+            int(torch._dynamo.config.cache_size_limit), want)
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                int(torch._dynamo.config.recompile_limit), want)
+    except Exception:
+        logger.debug("compile-cache: could not raise recompile limit", exc_info=True)
+
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
     for target in cfg.targets:
@@ -636,21 +657,66 @@ def enable(
 # ---------------------------------------------------------------------------
 
 
+def _warm_call(
+    pipe: Any,
+    shape: Tuple[int, ...],
+    *,
+    steps: int,
+    prompt: str,
+    decode: bool,
+) -> None:
+    """One warm-up call for ``shape``. (w, h) is the classic image call;
+    (w, h, frames) is a video call (ie#381): the DiT graph keys on the token
+    count only, so a plain single-pipeline call traces the same graph the
+    serving path (including a two-stage refine, whose latents arrive from an
+    upsampler of identical shape) will look up. Video calls force the
+    batch-1 no-CFG serving regime (CFG is a graph shape — ``Compile``) and
+    skip decode unless a vae target is declared."""
+    import inspect
+
+    import torch
+
+    kwargs: Dict[str, Any] = dict(
+        prompt=prompt,
+        num_inference_steps=int(steps),
+        width=int(shape[0]),
+        height=int(shape[1]),
+        generator=torch.Generator(device="cuda").manual_seed(0),
+    )
+    if len(shape) == 3:
+        params = inspect.signature(type(pipe).__call__).parameters
+        kwargs["num_frames"] = int(shape[2])
+        kwargs["output_type"] = "np" if decode else "latent"
+        if "frame_rate" in params:
+            kwargs["frame_rate"] = 24.0
+        if "guidance_scale" in params:
+            kwargs["guidance_scale"] = 1.0
+        if "audio_guidance_scale" in params:
+            kwargs["audio_guidance_scale"] = 1.0
+    pipe(**kwargs)
+
+
 def build(
     model_path: str | Path,
     out_dir: str | Path,
     *,
-    shapes: Iterable[Tuple[int, int]],
+    shapes: Iterable[Tuple[int, ...]],
     targets: Iterable[str] = ("transformer", "vae.decode"),
     family: str = "",
     source_ref: str = "",
     source_digest: str = "",
     dtype: str = "bf16",
+    storage_dtype: str = "",
     steps: int = 2,
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
 ) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
     """Compile a diffusers pipeline over ``shapes`` and package the resulting
     inductor+triton caches as a per-SKU artifact.
+
+    ``storage_dtype`` mirrors the serving binding's weight-storage lane
+    (gw#389 fp8 layerwise casting): the cast hooks are traced INTO the FX
+    graphs, so a cell for an fp8-served model must be built from an
+    fp8-loaded pipeline or every request misses the cache (ie#381).
 
     Runs on the TARGET GPU SKU with a C toolchain present (cold compile).
     Returns ``(artifact_path, metadata, per-shape warm-up seconds)`` — the
@@ -677,7 +743,9 @@ def build(
         raise RuntimeError("compile-cache build requires CUDA")
 
     cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets))
-    pipe = load_from_pretrained(DiffusionPipeline, str(model_path), dtype=dtype)
+    pipe = load_from_pretrained(
+        DiffusionPipeline, str(model_path), dtype=dtype,
+        storage_dtype=storage_dtype)
     # Producer/consumer graph parity (gw#391): the worker prepares pipelines
     # with place_pipeline (placement + vae/attention low-VRAM flags), and
     # those flags are traced INTO the graphs — the FX-graph cache key. A cell
@@ -693,19 +761,15 @@ def build(
         raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
 
     timings: Dict[str, float] = {}
-    for w, h in cfg.shapes:
+    decode = any(t.startswith("vae") for t in cfg.targets)
+    for shape in cfg.shapes:
         torch.cuda.synchronize()
         t = time.monotonic()
-        pipe(
-            prompt=prompt,
-            num_inference_steps=int(steps),
-            width=int(w),
-            height=int(h),
-            generator=torch.Generator(device="cuda").manual_seed(0),
-        )
+        _warm_call(pipe, shape, steps=int(steps), prompt=prompt, decode=decode)
         torch.cuda.synchronize()
-        timings[f"{w}x{h}"] = round(time.monotonic() - t, 2)
-        logger.info("compile-cache build: warmed %dx%d in %.1fs", w, h, timings[f"{w}x{h}"])
+        key = "x".join(str(v) for v in shape)
+        timings[key] = round(time.monotonic() - t, 2)
+        logger.info("compile-cache build: warmed %s in %.1fs", key, timings[key])
 
     captured = [p for p in (capture_root / "inductor").rglob("*") if p.is_file()]
     if not captured:
@@ -718,6 +782,7 @@ def build(
         family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
         low_vram_mode=str(placed.get("mode") or ""),
+        storage_dtype=storage_dtype,
     )
     label = flavor_label(meta["sku"], meta["torch"])
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -508,6 +508,15 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
                 "shapes": [[int(v) for v in s] for s in es.compile.shapes],
                 "targets": list(es.compile.targets),
             }
+            # ie#381: the primary binding's weight-storage lane (gw#389 fp8
+            # layerwise casting) rides along so the hub's cell producer
+            # builds from an identically-loaded pipeline — the cast hooks
+            # are traced INTO the FX graphs; a bf16-built cell for an
+            # fp8-served model misses on every request.
+            primary = next(iter(es.models.values()), None)
+            storage = str(getattr(primary, "storage_dtype", "") or "")
+            if storage:
+                fn["compile"]["storage_dtype"] = storage
         out.append(fn)
 
     return out

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -505,7 +505,7 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             # Hub keys family-cache lookups off this block (th#569).
             fn["compile"] = {
                 "family": es.compile.family,
-                "shapes": [[int(w), int(h)] for w, h in es.compile.shapes],
+                "shapes": [[int(v) for v in s] for s in es.compile.shapes],
                 "targets": list(es.compile.targets),
             }
         out.append(fn)

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -240,6 +240,37 @@ def test_compile_struct_validation():
         Compile(shapes=((768, 768),), targets=())
 
 
+def test_compile_struct_video_shapes():
+    """(w, h, frames) rows — video graphs key on the frame axis (ie#381)."""
+    c = Compile(
+        family="ltx-2.3",
+        shapes=[[1280, 704, 121], (960, 544, 241), (1920, 1088, 241)],
+        targets=("transformer",),
+    )
+    assert c.shapes == ((1280, 704, 121), (960, 544, 241), (1920, 1088, 241))
+    # mixed image + video rows are fine (one endpoint, two modality functions)
+    m = Compile(shapes=((768, 768), (1280, 704, 121)))
+    assert m.shapes == ((768, 768), (1280, 704, 121))
+    with pytest.raises(ValueError):
+        Compile(shapes=((1280, 704, 0),))
+    with pytest.raises(ValueError):
+        Compile(shapes=((1280,),))
+    with pytest.raises(ValueError):
+        Compile(shapes=((1280, 704, 121, 24),))
+
+
+def test_artifact_metadata_video_shapes_and_storage_dtype():
+    meta = cc.artifact_metadata(
+        family="ltx-2.3",
+        shapes=[(1280, 704, 121), (1920, 1088, 241)],
+        targets=["transformer"],
+        storage_dtype="fp8",
+    )
+    assert meta["shapes"] == [[1280, 704, 121], [1920, 1088, 241]]
+    assert meta["storage_dtype"] == "fp8"
+    assert cc.verify(meta, family="ltx-2.3") == ""
+
+
 class In(msgspec.Struct):
     prompt: str = ""
 

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -524,10 +524,9 @@ def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
             return _Out(result="")
 
     (entry,) = _extract_entries(Gen, "testmod")
-    (fn,) = entry["functions"]
-    assert fn["compile"]["shapes"] == [[960, 544, 241], [1920, 1088, 241], [1280, 704, 121]]
-    assert fn["compile"]["storage_dtype"] == "fp8"
-    assert fn["compile"]["targets"] == ["transformer"]
+    assert entry["compile"]["shapes"] == [[960, 544, 241], [1920, 1088, 241], [1280, 704, 121]]
+    assert entry["compile"]["storage_dtype"] == "fp8"
+    assert entry["compile"]["targets"] == ["transformer"]
 
 
 def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
@@ -547,8 +546,7 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
             return _Out(result="")
 
     (entry,) = _extract_entries(Gen, "testmod")
-    (fn,) = entry["functions"]
-    assert "storage_dtype" not in fn["compile"]
+    assert "storage_dtype" not in entry["compile"]
 
 
 def test_allow_lora_binding_emits_flag_and_family() -> None:

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -500,6 +500,57 @@ def test_model_shorthand_skips_server_handle_setup_param() -> None:
 # --------------------------------------------------------------------------- #
 
 
+def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
+    """ie#381: the lock's compile block carries (w, h, frames) rows verbatim
+    and the primary binding's weight-storage lane, so the hub's cell producer
+    builds from an identically-loaded (fp8) pipeline."""
+    from gen_worker import Compile, Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(
+        model=Hub("tensorhub/ltx-2.3-distilled", storage_dtype="fp8"),
+        resources=Resources(vram_gb=78),
+        compile=Compile(
+            family="ltx-2.3",
+            shapes=((960, 544, 241), (1920, 1088, 241), (1280, 704, 121)),
+            targets=("transformer",),
+        ),
+    )
+    class Gen:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    (entry,) = _extract_entries(Gen, "testmod")
+    (fn,) = entry["functions"]
+    assert fn["compile"]["shapes"] == [[960, 544, 241], [1920, 1088, 241], [1280, 704, 121]]
+    assert fn["compile"]["storage_dtype"] == "fp8"
+    assert fn["compile"]["targets"] == ["transformer"]
+
+
+def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
+    from gen_worker import Compile, Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(
+        model=Hub("cozy/sdxl-base"),
+        resources=Resources(vram_gb=12),
+        compile=Compile(family="sdxl", shapes=((1024, 1024),)),
+    )
+    class Gen:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    (entry,) = _extract_entries(Gen, "testmod")
+    (fn,) = entry["functions"]
+    assert "storage_dtype" not in fn["compile"]
+
+
 def test_allow_lora_binding_emits_flag_and_family() -> None:
     from gen_worker import Compile, Hub
     from gen_worker.discovery.discover import _extract_entries


### PR DESCRIPTION
## What

Three gaps between the image-only #384 compile-cell machinery and LTX video cells (ie#381):

1. **`Compile.shapes` rows accept `(w, h, frames)`** — a video DiT graph keys on the token count, which includes the frame axis, so every (resolution, duration) preset pair is its own graph. Two-stage presets contribute BOTH base and refined rows. Image `(w, h)` rows are unchanged; lock emission (`discover.py`) and artifact metadata generalized.
2. **`build()` video warm path + `storage_dtype`** — video rows warm via a plain single-pipeline call (`num_frames`, batch-1 `guidance_scale=1.0`, `output_type="latent"`): the refine graph is shape-identical whether latents arrive from an upsampler or noise, so the producer needs no two-stage/upsampler machinery. `storage_dtype` mirrors the serving binding's fp8 layerwise-cast lane (gw#389) — the cast hooks are traced INTO the FX graphs, so a bf16-built cell for an fp8-served model would miss on every request. Recorded in artifact metadata (informational; a drift is a cache miss, never an error).
3. **`apply()` recompile-limit sizing** — dynamo's per-code-object limit defaults to 8; LTX declares 12 graphs, and shapes 9-12 would silently fall back to eager. Sized to the declared shape set, never lowering an operator-raised value.

## Tests

- `test_compile_cache.py`: video/mixed shape validation, metadata roundtrip w/ `storage_dtype`
- `test_conversion` consumers unaffected (training-endpoints picks the new payload fields in its own PR)
- 61 passed locally across test_compile_cache / test_discovery_and_decorators / test_executor_adopt

Part of ie#381 (LTX compile cells). Live H100 validation of the full produce→seed→adopt loop is running in that lane; consumers (training-endpoints producer, ltx endpoint `compile=` declaration) land in follow-up PRs pinned to 0.13.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)