### PR TITLE
release 0.13.17 — gw#472 compile cells video support (ie#381)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.16"
+version = "0.13.17"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.13"
+version = "0.13.17"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump only. gw#472 (PR #173, merged 01:29Z) missed the v0.13.16 tag (cut 01:17Z); training-endpoints#78 and the ltx endpoint compile declaration pin >=0.13.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)