### PR TITLE
gw#472 follow-up: regional compilation mode (Compile.regional) — 0.13.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.17"
+version = "0.13.18"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -130,6 +130,15 @@ class Compile(msgspec.Struct, frozen=True):
     shapes: tuple[tuple[int, ...], ...]
     targets: tuple[str, ...] = ("transformer", "vae.decode")
     family: str = ""
+    # Regional compilation (diffusers compile_repeated_blocks): compile the
+    # target's repeated transformer blocks instead of the whole forward.
+    # REQUIRED for big fp8 layerwise-cast models (ie#381, measured on LTX
+    # 22B/H100): whole-graph inductor planning co-materializes per-layer
+    # bf16 upcast buffers and OOMs at the largest shapes; per-block graphs
+    # bound that to one block. Also much faster cold compile (one block
+    # graph per shape, reused across blocks). Cells record the mode — a
+    # mode drift consumer stays eager (cache would miss anyway).
+    regional: bool = False
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -168,6 +168,7 @@ def artifact_metadata(
     targets: Iterable[str] = (),
     low_vram_mode: str = "",
     storage_dtype: str = "",
+    compile_mode: str = "whole",
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
@@ -190,6 +191,7 @@ def artifact_metadata(
         "targets": list(targets),
         "low_vram_mode": str(low_vram_mode or ""),
         "storage_dtype": str(storage_dtype or ""),
+        "compile_mode": str(compile_mode or "whole"),
         "libs": _lib_versions(),
     }
 
@@ -527,6 +529,35 @@ def _guarded(original: Callable[..., Any], compiled: Callable[..., Any], label: 
     return wrapper
 
 
+def _clear_regional(mod: Any) -> None:
+    """Undo nn.Module.compile() on every submodule (regional rollback)."""
+    for m in mod.modules():
+        if getattr(m, "_compiled_call_impl", None) is not None:
+            m._compiled_call_impl = None
+
+
+def _guarded_regional(mod: Any, original: Callable[..., Any], label: str) -> Callable[..., Any]:
+    """Regional analogue of :func:`_guarded`: blocks are compiled in place,
+    so eager fallback must first CLEAR the block compilations, then retry."""
+    state = {"failed": False}
+
+    @functools.wraps(original)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not state["failed"]:
+            try:
+                return original(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 — any compile failure => eager
+                state["failed"] = True
+                logger.warning(
+                    "compile-cache: regional-compiled %s failed (%s: %s); eager "
+                    "for the rest of this process", label, type(exc).__name__, exc,
+                )
+                _clear_regional(mod)
+        return original(*args, **kwargs)
+
+    return wrapper
+
+
 def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> bool:
     """Wrap ``cfg.targets`` on ``pipeline`` with compiled callables.
 
@@ -575,14 +606,35 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
     except Exception:
         logger.debug("compile-cache: could not raise recompile limit", exc_info=True)
 
+    regional = bool(getattr(cfg, "regional", False))
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
+    regional_mods: list[Any] = []
     for target in cfg.targets:
         resolved = _resolve_target(pipeline, target)
         if resolved is None:
             logger.debug("compile-cache: pipeline has no target %r; skipping", target)
             continue
         owner, attr, fn = resolved
+        if (
+            regional
+            and attr == "forward"
+            and callable(getattr(owner, "compile_repeated_blocks", None))
+        ):
+            # Per-block graphs (ie#381): bounded memory under fp8 layerwise
+            # casting + much cheaper cold compile. Blocks are compiled in
+            # place; the guard wrapper clears them on the first failure.
+            owner.compile_repeated_blocks(dynamic=False)
+            if guard:
+                setattr(owner, attr, _guarded_regional(owner, fn, target))
+                originals.append((owner, attr, fn))
+            regional_mods.append(owner)
+            applied.append(target)
+            continue
+        if regional:
+            logger.info(
+                "compile-cache: %r has no compile_repeated_blocks; "
+                "whole-forward compile for it", target)
         if target.startswith("vae"):
             # channels_last + compiled decode is the measured win combo (#382);
             # memory format changes strides, so it is part of the cache key —
@@ -601,8 +653,11 @@ def apply(pipeline: Any, cfg: Any, *, cache_ready: bool, guard: bool = True) -> 
         "shapes": [tuple(s) for s in cfg.shapes],
         "cache": bool(cache_ready),
         "originals": originals,
+        "regional_mods": regional_mods,
     })
-    logger.info("compile-cache: torch.compile armed for %s (cache=%s)", applied, cache_ready)
+    logger.info(
+        "compile-cache: torch.compile armed for %s (cache=%s regional=%s)",
+        applied, cache_ready, regional)
     return True
 
 
@@ -619,6 +674,11 @@ def unwrap(pipeline: Any) -> bool:
             setattr(owner, attr, fn)
         except Exception:
             logger.warning("compile-cache: could not restore eager %s.%s", type(owner).__name__, attr)
+    for mod in marker.get("regional_mods") or ():
+        try:
+            _clear_regional(mod)
+        except Exception:
+            logger.warning("compile-cache: could not clear regional compile on %s", type(mod).__name__)
     try:
         delattr(pipeline, _MARKER_ATTR)
     except AttributeError:
@@ -648,6 +708,14 @@ def enable(
         drift = mode_drift(meta, pipeline)
         if drift:
             logger.warning("compile-cache: %s; staying eager", drift)
+            meta = None
+    if meta is not None:
+        want = "regional" if getattr(cfg, "regional", False) else "whole"
+        have = str(meta.get("compile_mode") or "whole")
+        if have != want:
+            logger.warning(
+                "compile-cache: cell compile_mode %r != declared %r; staying "
+                "eager (graphs would miss)", have, want)
             meta = None
     return apply(pipeline, cfg, cache_ready=meta is not None)
 
@@ -707,6 +775,7 @@ def build(
     source_digest: str = "",
     dtype: str = "bf16",
     storage_dtype: str = "",
+    regional: bool = False,
     steps: int = 2,
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
 ) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
@@ -742,7 +811,7 @@ def build(
     if not torch.cuda.is_available():
         raise RuntimeError("compile-cache build requires CUDA")
 
-    cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets))
+    cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets), regional=bool(regional))
     pipe = load_from_pretrained(
         DiffusionPipeline, str(model_path), dtype=dtype,
         storage_dtype=storage_dtype)
@@ -783,6 +852,7 @@ def build(
         shapes=cfg.shapes, targets=cfg.targets,
         low_vram_mode=str(placed.get("mode") or ""),
         storage_dtype=storage_dtype,
+        compile_mode="regional" if regional else "whole",
     )
     label = flavor_label(meta["sku"], meta["torch"])
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -517,6 +517,8 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             storage = str(getattr(primary, "storage_dtype", "") or "")
             if storage:
                 fn["compile"]["storage_dtype"] = storage
+            if getattr(es.compile, "regional", False):
+                fn["compile"]["regional"] = True
         out.append(fn)
 
     return out

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -107,6 +107,75 @@ def test_unwrap_restores_eager():
     assert cc.unwrap(pipe) is False  # idempotent
 
 
+def test_regional_clear_and_guard():
+    """ie#381 regional mode: blocks are compiled in place (nn.Module.compile
+    sets _compiled_call_impl); rollback must CLEAR them, and the guard's
+    first failure does so before retrying eager."""
+
+    class _Block:
+        _compiled_call_impl = None
+
+    class _Mod:
+        def __init__(self):
+            self.b1, self.b2 = _Block(), _Block()
+
+        def modules(self):
+            return [self, self.b1, self.b2]
+
+        def forward(self, x):
+            if getattr(self.b1, "_compiled_call_impl", None) is not None:
+                raise RuntimeError("compiled block exploded")
+            return x + 1
+
+    mod = _Mod()
+    mod.b1._compiled_call_impl = object()  # "compiled"
+    mod.b2._compiled_call_impl = object()
+    guarded = cc._guarded_regional(mod, mod.forward, "transformer")
+    assert guarded(1) == 2  # failure -> cleared -> eager retry succeeds
+    assert mod.b1._compiled_call_impl is None
+    assert mod.b2._compiled_call_impl is None
+    assert guarded(2) == 3  # stays eager
+
+
+def test_unwrap_clears_regional_mods():
+    class _Block:
+        _compiled_call_impl = object()
+
+    class _Mod:
+        def __init__(self):
+            self.block = _Block()
+
+        def modules(self):
+            return [self, self.block]
+
+    class _Pipe3:
+        pass
+
+    pipe = _Pipe3()
+    mod = _Mod()
+    pipe._cozy_compile = {
+        "targets": ["transformer"], "shapes": [(960, 544, 241)],
+        "cache": True, "originals": [], "regional_mods": [mod],
+    }
+    assert cc.unwrap(pipe) is True
+    assert mod.block._compiled_call_impl is None
+
+
+def test_artifact_metadata_records_compile_mode():
+    meta = cc.artifact_metadata(family="ltx-2.3", shapes=[(960, 544, 241)],
+                                targets=["transformer"], compile_mode="regional")
+    assert meta["compile_mode"] == "regional"
+    default = cc.artifact_metadata(family="sd15", shapes=[(768, 768)], targets=["transformer"])
+    assert default["compile_mode"] == "whole"
+
+
+def test_compile_struct_regional_flag():
+    c = Compile(shapes=((960, 544, 241),), targets=("transformer",),
+                family="ltx-2.3", regional=True)
+    assert c.regional is True
+    assert Compile(shapes=((768, 768),)).regional is False
+
+
 def test_system_repo():
     assert cc.system_repo("sd15") == "_system/family-sd15"
     with pytest.raises(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.17"
+version = "0.13.18"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Why (measured live on H100 SXM, ie#381 pod A)

Whole-graph `torch.compile` of the fp8 layerwise-cast LTX 22B DiT **works at 720p (+35s compile, +0.8GiB)** but **OOMs at the 241-frame shapes**: inductor's whole-graph planning co-materializes per-layer bf16 upcast buffers — 75GiB allocated during the 1080p stage-1 compile on a 79.2GiB card. The fp8 memory win is defeated exactly when it matters.

Regional compilation (diffusers `compile_repeated_blocks`) bounds the blowup to one block's weights and is dramatically cheaper cold: **all three LTX shape-classes compile in 57.4s** (block graph per shape reused across 48 blocks: 84 fxgraph hits / 2 misses), cell artifact **15.4MB**, steady-state **-20% (720p-5s) / -14% (10s@1080p)** vs eager, VRAM peak +2.3GiB.

## What

- `Compile(regional: bool = False)` — explicit opt-in; flux2-klein's whole-graph behavior (and its future cells) unchanged.
- `apply()`: regional branch uses `compile_repeated_blocks(dynamic=False)` on targets that support it; guarded fallback CLEARS block compilations (`_compiled_call_impl = None`) before retrying eager; `unwrap()` clears them on rollback.
- `enable()`: cell `compile_mode` vs declared mode drift ⇒ stay eager (graphs would all miss).
- `build(regional=)` + metadata `compile_mode`; discovery emits `compile.regional`.
- Version 0.13.18 (consumers: training-endpoints + ltx endpoint pin it).

## Tests

67 passed (compile_cache / discovery / executor_adopt), incl. regional guard/unwrap/metadata/struct/lock-emission.

Part of ie#381; pairs with tensorhub + training-endpoints `regional` passthrough PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)