### PR TITLE
gw#473: precision rebind re-homes the executor instance-group record (0.13.20)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.19"
+version = "0.13.20"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -854,10 +854,12 @@ class Executor:
         from .models.refs import parse_model_ref
 
         changed = False
+        rehomed: List[Tuple[Any, EndpointSpec]] = []
         for spec in self.specs.values():
             declared = self._declared_models.get(spec.name)
             if not declared:
                 continue
+            key_before = spec.instance_key
             for slot, base_binding in declared.items():
                 base_ref = wire_ref(base_binding)
                 pick = resolutions.get(base_ref)
@@ -891,6 +893,34 @@ class Executor:
                             "precision resolution applied: %s %s/%s -> %s (cast=%s)",
                             spec.name, slot, base_ref, wire_ref(new_binding),
                             getattr(new_binding, "storage_dtype", ""))
+            if spec.cls is not None and spec.instance_key != key_before:
+                rehomed.append((key_before, spec))
+        # spec.instance_key is a live property over spec.models — a rebind
+        # above MOVES the spec's key, so the self._classes instance-group
+        # record must move with it. Leaving it under the stale key makes
+        # every later lookup (state delta, setup, readiness) a KeyError that
+        # crash-loops the hello handler (found live: ie#382 dozen lane, the
+        # sm90 cast=fp8 pick on a bf16 upsampler killed every worker stream
+        # ~1s after HelloAck, churning H100 pods at 60s intervals).
+        for old_key, spec in rehomed:
+            rec = self._classes.get(old_key)
+            if rec is not None and spec in rec.specs:
+                rec.specs.remove(spec)
+            new_key = spec.instance_key
+            target = self._classes.get(new_key)
+            if target is None:
+                if rec is not None and not rec.specs:
+                    # whole group moved (the common case): carry the record —
+                    # and any live instance — to the new key.
+                    self._classes.pop(old_key, None)
+                    target = rec
+                else:
+                    target = _ClassRecord(cls=spec.cls)
+                self._classes[new_key] = target
+            if spec not in target.specs:
+                target.specs.append(spec)
+            if rec is not None and not rec.specs and self._classes.get(old_key) is rec:
+                self._classes.pop(old_key, None)
         if changed:
             self._on_state_change()
 

--- a/tests/test_precision_resolution_apply.py
+++ b/tests/test_precision_resolution_apply.py
@@ -144,3 +144,31 @@ def test_resolve_local_bindings_never_touches_pinned_or_failing() -> None:
         {"c": bare}, caps=_caps(89), free_vram_gb=23.0, resolver=_boom,
     )
     assert out["c"] is bare
+
+
+def test_apply_model_resolutions_rehomes_the_instance_group() -> None:
+    """spec.instance_key is a live property over spec.models — a precision
+    rebind moves it, and the executor's instance-group record must move too.
+    Regression (found live, ie#382): the stale key made every later
+    self._classes[spec.instance_key] a KeyError, crash-looping the hello
+    handler ~1s after HelloAck and churning H100 pods on 60s reap cycles."""
+    ex = _executor()
+    spec = ex.specs["generate"]
+    key_declared = spec.instance_key
+    assert key_declared in ex._classes
+    rec = ex._classes[key_declared]
+
+    ex.apply_model_resolutions({"acme/z-image": ("acme/z-image", "fp8")})
+    key_cast = spec.instance_key
+    assert key_cast != key_declared
+    # the SAME record (with any live instance) now lives under the new key
+    assert ex._classes[key_cast] is rec
+    assert key_declared not in ex._classes
+    assert spec in rec.specs
+
+    # full-replace back to the authored binding re-homes it again
+    ex.apply_model_resolutions({})
+    assert spec.instance_key == key_declared
+    assert ex._classes[key_declared] is rec
+    assert key_cast not in ex._classes
+    assert rec.specs == [spec]

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.18"
+version = "0.13.20"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
th#697 precision picks mutate `spec.models`; `spec.instance_key` is a live property over it, so a rebind moved specs out from under their `self._classes` instance-group record. Every later `self._classes[spec.instance_key]` (state delta, ensure_setup, readiness) raised `KeyError` inside the hello handler — the stream tore down ~1s after HelloAck, the hub reaped the fn-less worker at 60s, and the autoscaler replaced it: an H100 pod churn loop with no worker-side log evidence.

Found live on the ie#382 20s-dozen lane: the hub's sm90 pick `cast=fp8` for the bf16 upsampler triggered it on every pod (12 churned pods); a phone-home debug image captured the KeyError verbatim.

Fix: `apply_model_resolutions` re-homes the record — carrying any live instance — when a spec's key moves; groups split only if part of a group diverges. Regression test drives pick -> revert and asserts record identity and key migration both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)