### PR TITLE
gw#477: HF clone applies the multi-weight-bundle library_name opt-out (chatterbox publish rejection)

### DIFF
--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -439,6 +439,13 @@ def ingest_huggingface(
         "selected_bytes": str(selected_bytes),
         "source_file_count": str(len(paths)),
     }
+    if library == "diffusers-single-file" and _is_multi_weight_bundle(dest_dir):
+        # Multi-component bundle (distinct component single-files, e.g.
+        # chatterbox t3/s3gen/ve): no library loads it as one artifact —
+        # opt out of the layout contract exactly like the civitai branch
+        # (empty library_name skips finalize-side validation; e2e #112).
+        repo_spec["library_name"] = ""
+        metadata["multi_weight_bundle"] = "true"
     return IngestedSource(
         provider="huggingface",
         source_ref=repo_id,

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -166,3 +166,32 @@ def test_too_large_refused() -> None:
             sizes={"transformer/x.safetensors": 200 * 1024 * 1024 * 1024},
         )
     assert exc.value.reason == "too_large"
+
+
+def test_hf_multi_weight_bundle_opts_out_of_layout_contract(tmp_path, monkeypatch) -> None:
+    """chatterbox regression (ie#368): HF multi-component single-file repos
+    (t3/s3gen/ve) must publish with library_name unset, mirroring the civitai
+    branch (e2e #112) — tensorhub finalize rejects diffusers/single-file
+    manifests carrying multiple distinct weights."""
+    from pathlib import Path
+
+    from gen_worker.convert import ingest as ing
+    from gen_worker.convert.classifier import classify_repo
+
+    paths = ["t3_cfg.safetensors", "s3gen.safetensors", "ve.safetensors", "tokenizer.json"]
+    sizes = {p: 2 * 1024**3 for p in paths if p.endswith(".safetensors")}
+    classification = classify_repo(paths, sizes=sizes)
+    assert classification.strategy == "aio_singlefile"
+    plan = ing.HFSourcePlan(
+        repo_id="ResembleAI/chatterbox", revision="deadbeef", paths=paths,
+        sizes=sizes, side={}, classification=classification, content_ids={})
+
+    def fake_dl(repo_id, rev, dest, *, allow_patterns, **kw):
+        for p in allow_patterns:
+            (Path(dest) / p).write_bytes(b"x")
+
+    monkeypatch.setattr(ing, "_snapshot_download_with_retries", fake_dl)
+    monkeypatch.setattr(ing, "install_hf_http_timeouts", lambda: None)
+    src = ing.ingest_huggingface("ResembleAI/chatterbox", tmp_path / "d", plan=plan)
+    assert src.repo_spec["library_name"] == ""
+    assert src.metadata["multi_weight_bundle"] == "true"

--- a/tests/convert/test_repackage_families.py
+++ b/tests/convert/test_repackage_families.py
@@ -270,3 +270,4 @@ def test_multi_weight_bundle_detection(tmp_path) -> None:
     # a second distinct component IS a bundle
     (d / "qwen_image_vae.safetensors").write_bytes(b"x")
     assert _is_multi_weight_bundle(d)
+


### PR DESCRIPTION
The e2e#112 multi-weight-bundle opt-out (publish with `library_name` unset when a snapshot carries multiple distinct top-level weight single-files) existed only in the **civitai** ingest branch. The HuggingFace branch classifies such repos `aio_singlefile` → `diffusers-single-file` → `library_name="diffusers"`, and tensorhub commit finalize correctly rejects the manifest (`invalid_manifest_for_kind` / `multiple_files_for_single_file_layout`).

Hit live in the J30 audio lane (ie#368): `clone-huggingface ResembleAI/chatterbox` (t3/s3gen/ve + tokenizer, 7 root safetensors) → HubPublishError 400.

Fix mirrors the civitai opt-out in `ingest_huggingface`: `library == "diffusers-single-file" && _is_multi_weight_bundle(dest_dir)` → `library_name=""` + `multi_weight_bundle=true` metadata. Precedent: anima/ernie civitai bundles serve green with the opt-out (J20/J21).

Regression test drives the real ingest path via a prebuilt `HFSourcePlan` with only the snapshot download stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)