### PR TITLE
gw#477 bank leg: banked repo_specs must not resurrect a stale bundle library_name (0.13.22)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.21"
+version = "0.13.22"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -28,6 +28,7 @@ from .bank import build_bank_payload, flavor_bank_key
 from .hub import CommitFile, HubClient, HubPublishError, files_from_tree
 from .ingest import (
     IngestedSource,
+    _is_multi_weight_names,
     ingest_civitai,
     ingest_huggingface,
     plan_civitai,
@@ -433,6 +434,16 @@ def _publish_from_bank(
             metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
             metadata = dict(metadata)
             metadata["download_skip"] = "bank"
+            # Banked repo_specs are frozen at bank time and can carry a stale
+            # pre-gw#477 library_name="diffusers" for multi-weight bundles —
+            # recompute the opt-out from the banked file names so a bank-path
+            # publish never (re)creates a repo the layout contract rejects.
+            repo_spec = {k: str(v) for k, v in dict(payload.get("repo_spec") or {}).items()}
+            if repo_spec.get("library_name") == "diffusers" and _is_multi_weight_names(
+                    str(f.get("path") or "") for f in payload["files"]
+                    if "/" not in str(f.get("path") or "")):
+                repo_spec["library_name"] = ""
+                metadata["multi_weight_bundle"] = "true"
             if callable(progress):
                 progress(0.1 + 0.85 * (i / max(1, len(specs))),
                          f"clone.publish.{spec.label}")
@@ -451,7 +462,7 @@ def _publish_from_bank(
                 ),
                 metadata=metadata,
                 provenance=provenance,
-                repo_spec={k: str(v) for k, v in dict(payload.get("repo_spec") or {}).items()},
+                repo_spec=repo_spec,
             )
             result.published.append({
                 "flavor": str(payload.get("flavor") or spec.dtype),

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -14,7 +14,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from ..net import hf, install_hf_http_timeouts
 from .classifier import RepoClassification, classify_repo
@@ -464,6 +464,24 @@ def ingest_huggingface(
 _SHARD_NAME_RE = None
 
 
+def _is_multi_weight_names(names: Iterable[str]) -> bool:
+    """Pure-name core of :func:`_is_multi_weight_bundle`: True when the
+    TOP-LEVEL weight file names form more than one logical weight set
+    (HF-convention shards collapse into one). Callers pass basenames only."""
+    global _SHARD_NAME_RE
+    import re
+
+    if _SHARD_NAME_RE is None:
+        _SHARD_NAME_RE = re.compile(r"^(.+)-(\d+)-of-(\d+)\.(safetensors|gguf)$")
+    logical: set[tuple[str, str]] = set()
+    for name in names:
+        if not (name.endswith(".safetensors") or name.endswith(".gguf")):
+            continue
+        m = _SHARD_NAME_RE.match(name)
+        logical.add((m.group(1), m.group(3)) if m else (name, ""))
+    return len(logical) > 1
+
+
 def _is_multi_weight_bundle(dest_dir: Path) -> bool:
     """True when a snapshot carries MULTIPLE distinct top-level weight files
     that are not one HF-convention shard set — e.g. Anima/Ernie civitai
@@ -471,18 +489,8 @@ def _is_multi_weight_bundle(dest_dir: Path) -> bool:
     tensorhub's diffusers/single-file layout contract rightly rejects these
     (multiple_files_for_single_file_layout, found live e2e #112); they must
     publish with library_name unset (validator opt-out)."""
-    global _SHARD_NAME_RE
-    import re
-
-    if _SHARD_NAME_RE is None:
-        _SHARD_NAME_RE = re.compile(r"^(.+)-(\d+)-of-(\d+)\.(safetensors|gguf)$")
-    logical: set[tuple[str, str]] = set()
-    for p in dest_dir.iterdir():
-        if not p.is_file() or p.suffix not in {".safetensors", ".gguf"}:
-            continue
-        m = _SHARD_NAME_RE.match(p.name)
-        logical.add((m.group(1), m.group(3)) if m else (p.name, ""))
-    return len(logical) > 1
+    return _is_multi_weight_names(
+        p.name for p in dest_dir.iterdir() if p.is_file())
 
 
 def _resolve_civitai_family(base_family: str, layout_family: str) -> str:

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -439,6 +439,13 @@ def ingest_huggingface(
         "selected_bytes": str(selected_bytes),
         "source_file_count": str(len(paths)),
     }
+    if library == "diffusers-single-file" and _is_multi_weight_bundle(dest_dir):
+        # Multi-component bundle (distinct component single-files, e.g.
+        # chatterbox t3/s3gen/ve): no library loads it as one artifact —
+        # opt out of the layout contract exactly like the civitai branch
+        # (empty library_name skips finalize-side validation; e2e #112).
+        repo_spec["library_name"] = ""
+        metadata["multi_weight_bundle"] = "true"
     return IngestedSource(
         provider="huggingface",
         source_ref=repo_id,

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -166,3 +166,32 @@ def test_too_large_refused() -> None:
             sizes={"transformer/x.safetensors": 200 * 1024 * 1024 * 1024},
         )
     assert exc.value.reason == "too_large"
+
+
+def test_hf_multi_weight_bundle_opts_out_of_layout_contract(tmp_path, monkeypatch) -> None:
+    """chatterbox regression (ie#368): HF multi-component single-file repos
+    (t3/s3gen/ve) must publish with library_name unset, mirroring the civitai
+    branch (e2e #112) — tensorhub finalize rejects diffusers/single-file
+    manifests carrying multiple distinct weights."""
+    from pathlib import Path
+
+    from gen_worker.convert import ingest as ing
+    from gen_worker.convert.classifier import classify_repo
+
+    paths = ["t3_cfg.safetensors", "s3gen.safetensors", "ve.safetensors", "tokenizer.json"]
+    sizes = {p: 2 * 1024**3 for p in paths if p.endswith(".safetensors")}
+    classification = classify_repo(paths, sizes=sizes)
+    assert classification.strategy == "aio_singlefile"
+    plan = ing.HFSourcePlan(
+        repo_id="ResembleAI/chatterbox", revision="deadbeef", paths=paths,
+        sizes=sizes, side={}, classification=classification, content_ids={})
+
+    def fake_dl(repo_id, rev, dest, *, allow_patterns, **kw):
+        for p in allow_patterns:
+            (Path(dest) / p).write_bytes(b"x")
+
+    monkeypatch.setattr(ing, "_snapshot_download_with_retries", fake_dl)
+    monkeypatch.setattr(ing, "install_hf_http_timeouts", lambda: None)
+    src = ing.ingest_huggingface("ResembleAI/chatterbox", tmp_path / "d", plan=plan)
+    assert src.repo_spec["library_name"] == ""
+    assert src.metadata["multi_weight_bundle"] == "true"

--- a/tests/convert/test_download_skip.py
+++ b/tests/convert/test_download_skip.py
@@ -321,3 +321,36 @@ def test_hf_repackaged_flavor_never_banked(fake_hub, tmp_path, monkeypatch) -> N
                   destination_repo="acme/dst")
     assert r.published
     assert "bank_records" not in _FakeHub.state
+
+
+def test_publish_from_bank_strips_stale_bundle_library_name(fake_hub) -> None:
+    """gw#477 bank leg: a banked repo_spec frozen before the multi-weight
+    opt-out carries library_name="diffusers"; the bank publish must strip it
+    from the commit (multiple top-level weights can never satisfy the
+    diffusers/single-file layout contract — chatterbox, J30 run 4)."""
+    plan = _Plan([("t3_cfg.safetensors", 100, "sha256:" + "a" * 64)])
+    key = flavor_bank_key(plan, _SPEC.label, layout_hint="diffusers")
+    payload = build_bank_payload(
+        files=[
+            {"path": "t3_cfg.safetensors", "blake3": "1" * 64, "size_bytes": 100},
+            {"path": "s3gen.safetensors", "blake3": "2" * 64, "size_bytes": 100},
+            {"path": "ve.safetensors", "blake3": "3" * 64, "size_bytes": 10},
+            {"path": "tokenizer.json", "blake3": "4" * 64, "size_bytes": 5},
+        ],
+        flavor="bf16", dtype="bf16", file_layout="singlefile", file_type="safetensors",
+        metadata={"source_provider": "huggingface", "source_repo": "ResembleAI/chatterbox"},
+        repo_spec={"kind": "model", "library_name": "diffusers"},
+        source_revision="deadbeef",
+    )
+    st = _FakeHub.state
+    st.setdefault("bank_manifests", {})[key] = payload
+    st.setdefault("cas_blobs", set()).update({"1" * 64, "2" * 64, "3" * 64, "4" * 64})
+
+    result = clone_mod._publish_from_bank(_client(fake_hub), **_bank_args(plan))
+    assert result is not None
+    req = _FakeHub.state["commit_request"]
+    # Empty library_name is dropped by the hub client marshaling — the commit
+    # must NOT carry the stale "diffusers".
+    assert "library_name" not in req
+    assert req["kind"] == "model"
+    assert req["metadata"]["multi_weight_bundle"] == "true"

--- a/tests/convert/test_repackage_families.py
+++ b/tests/convert/test_repackage_families.py
@@ -270,3 +270,4 @@ def test_multi_weight_bundle_detection(tmp_path) -> None:
     # a second distinct component IS a bundle
     (d / "qwen_image_vae.safetensors").write_bytes(b"x")
     assert _is_multi_weight_bundle(d)
+


### PR DESCRIPTION
Run-4 live finding (J30 audio lane, chatterbox): the th#592 download-skip bank publishes with the `repo_spec` frozen AT BANK TIME. Records banked by pre-gw#477 clones carry `library_name="diffusers"` for multi-weight bundles; the bank publish auto-creates the destination repo poisoned (th#725 makes it sticky), and the fixed full-clone fallback then fails finalize against the poisoned row — so #179 alone never takes effect when the bank hits.

Fix: recompute the multi-weight opt-out from the banked file names (new pure-name core `_is_multi_weight_names`, shared with `_is_multi_weight_bundle`) and strip the stale `library_name` on the bank leg. Regression test against the fake hub asserts the commit request carries no `library_name` and stamps `multi_weight_bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)