### PR TITLE
th#721: adaptive RAM tier — cgroup-aware host-RAM probes; drop ctx.compute memory_gb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.23 (2026-07-11)
+
+- **th#721: adaptive RAM tier — host-RAM probes are cgroup-aware.**
+  `get_total_ram_gb` / `get_available_ram_gb` now return
+  min(/proc/meminfo, cgroup memory limit) via `probe_host_ram()` (cgroup v2
+  `memory.max` walked root→self, v1 `memory.limit_in_bytes` fallback).
+  RunPod containers see their real 31GB cgroup cap instead of the host's
+  62GB meminfo, so warm-tier admission (`make_room_ram`, size-aware demote
+  floor) spills pipelines to disk instead of the kernel SIGKILLing at the
+  ceiling (tensorhub ie#357, wan-2.2 VAE decode). A one-time `RAM_BUDGET=`
+  boot line names the derived budget, its source (cgroup vs meminfo), and
+  the floor.
+- **th#721: `memory_gb` removed from `ctx.compute`.** Host RAM is not
+  provider-selectable; the endpoint adapts to the RAM the pod delivers.
+
 ## 0.13.21 (2026-07-11)
 
 - **gw#468: env-gate sweep — every ambient worker knob reads through the typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.22"
+version = "0.13.23"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -297,6 +297,5 @@ class Compute(msgspec.Struct, frozen=True):
     vram_gb: int = 0
     gpu_count: int = 0
     gpu_tier: Optional[str] = None
-    memory_gb: int = 0
     cpu_cores: int = 0
     disk_gb: int = 0

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -20,9 +20,14 @@ from __future__ import annotations
 import gc
 import logging
 import os
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar
 
+import msgspec
+
 _LOG = logging.getLogger(__name__)
+
+_GIB = 1024 ** 3
 
 Mode = str  # "auto" | "off" | "vae_only" | "model_offload" | "group_offload" | "sequential"
 
@@ -184,23 +189,171 @@ def get_available_vram_gb(device_index: int = 0) -> float:
 
 
 def get_available_ram_gb() -> float:
-    """Available system RAM (for disk-offload decisions). 0.0 if psutil missing."""
-    try:
-        import psutil
-
-        return float(psutil.virtual_memory().available) / float(1024**3)
-    except Exception:
-        return 0.0
+    """Effective available host RAM: min(meminfo available, cgroup headroom)."""
+    return probe_host_ram().available_gb
 
 
 def get_total_ram_gb() -> float:
-    """Total system RAM (adaptive RAM-floor input). 0.0 if psutil missing."""
+    """Effective total host RAM: min(meminfo total, cgroup limit)."""
+    return probe_host_ram().total_gb
+
+
+# ---------------------------------------------------------------------------
+# Cgroup-aware host-RAM probes (th#721): RunPod GPU pods land on lottery-RAM
+# hosts and the container is cgroup-limited below /proc/meminfo — psutil alone
+# over-reports and the kernel SIGKILLs at the cgroup ceiling.
+# ---------------------------------------------------------------------------
+
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+# v1 "unlimited" sentinel territory (kernel reports ~0x7ffffffffffff000).
+_CGROUP_UNLIMITED = 1 << 60
+
+
+class HostRam(msgspec.Struct, frozen=True, kw_only=True):
+    """Effective host-RAM view: meminfo capped by the cgroup memory limit."""
+
+    total_gb: float
+    available_gb: float
+    meminfo_total_gb: float
+    meminfo_available_gb: float
+    cgroup_limit_gb: Optional[float]  # None = no cgroup cap
+    source: str  # "cgroup" | "meminfo"
+
+
+def _read_cgroup_int(path: Path) -> Optional[int]:
+    """Parse a cgroup memory file; None for missing / 'max' / v1 sentinel."""
+    try:
+        raw = path.read_text().strip()
+    except OSError:
+        return None
+    if raw == "max":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if 0 <= value < _CGROUP_UNLIMITED else None
+
+
+def _v2_cgroup_nodes(root: Path, proc_self_cgroup: Path) -> List[Path]:
+    """Cgroup-v2 dirs from root down to this process's own cgroup."""
+    rel = ""
+    try:
+        for line in proc_self_cgroup.read_text().splitlines():
+            if line.startswith("0::"):
+                rel = line[3:].strip().strip("/")
+                break
+    except OSError:
+        pass
+    nodes = [root]
+    node = root
+    for part in Path(rel).parts:
+        node = node / part
+        nodes.append(node)
+    return nodes
+
+
+def cgroup_memory_limit_bytes(
+    root: Path = _CGROUP_ROOT,
+    proc_self_cgroup: Path = _PROC_SELF_CGROUP,
+) -> Optional[int]:
+    """Effective cgroup memory limit for this process; None when uncapped.
+
+    v2: tightest ``memory.max`` on the root->self chain (covers both private
+    and host cgroup namespaces); v1 fallback: ``memory/memory.limit_in_bytes``.
+    """
+    limits = [
+        v for node in _v2_cgroup_nodes(root, proc_self_cgroup)
+        if (v := _read_cgroup_int(node / "memory.max")) is not None
+    ]
+    if limits:
+        return min(limits)
+    return _read_cgroup_int(root / "memory" / "memory.limit_in_bytes")
+
+
+def cgroup_memory_current_bytes(
+    root: Path = _CGROUP_ROOT,
+    proc_self_cgroup: Path = _PROC_SELF_CGROUP,
+) -> Optional[int]:
+    """Current cgroup memory usage; reads the deepest available counter."""
+    for node in reversed(_v2_cgroup_nodes(root, proc_self_cgroup)):
+        v = _read_cgroup_int(node / "memory.current")
+        if v is not None:
+            return v
+    return _read_cgroup_int(root / "memory" / "memory.usage_in_bytes")
+
+
+def probe_host_ram(
+    *,
+    root: Path = _CGROUP_ROOT,
+    proc_self_cgroup: Path = _PROC_SELF_CGROUP,
+) -> HostRam:
+    """One truthful host-RAM snapshot: psutil meminfo min'd with the cgroup cap."""
+    meminfo_total = meminfo_available = 0.0
     try:
         import psutil
 
-        return float(psutil.virtual_memory().total) / float(1024**3)
+        vm = psutil.virtual_memory()
+        meminfo_total = float(vm.total) / float(_GIB)
+        meminfo_available = float(vm.available) / float(_GIB)
     except Exception:
-        return 0.0
+        pass
+    limit = cgroup_memory_limit_bytes(root, proc_self_cgroup)
+    if limit is None:
+        return HostRam(
+            total_gb=meminfo_total,
+            available_gb=meminfo_available,
+            meminfo_total_gb=meminfo_total,
+            meminfo_available_gb=meminfo_available,
+            cgroup_limit_gb=None,
+            source="meminfo",
+        )
+    limit_gb = float(limit) / float(_GIB)
+    current = cgroup_memory_current_bytes(root, proc_self_cgroup)
+    cg_avail_gb = max(0.0, float(limit - (current or 0)) / float(_GIB))
+    total = min(meminfo_total, limit_gb) if meminfo_total > 0 else limit_gb
+    avail = min(meminfo_available, cg_avail_gb) if meminfo_available > 0 else cg_avail_gb
+    constrained = meminfo_total <= 0 or limit_gb < meminfo_total
+    return HostRam(
+        total_gb=total,
+        available_gb=avail,
+        meminfo_total_gb=meminfo_total,
+        meminfo_available_gb=meminfo_available,
+        cgroup_limit_gb=limit_gb,
+        source="cgroup" if constrained else "meminfo",
+    )
+
+
+_ram_budget_logged = False
+
+
+def log_ram_budget_once(*, floor_gb: float) -> None:
+    """One prominent boot line naming the derived warm-RAM-tier budget and its
+    source (cgroup cap vs /proc/meminfo) — DEGRADED_MODE-style greppability."""
+    global _ram_budget_logged
+    if _ram_budget_logged:
+        return
+    _ram_budget_logged = True
+    ram = probe_host_ram()
+    budget = max(0.0, ram.total_gb - floor_gb)
+    parts = [
+        f"RAM_BUDGET={budget:.1f}GiB",
+        f"source={ram.source}",
+        f"total_gb={ram.total_gb:.1f}",
+        f"floor_gb={floor_gb:.1f}",
+    ]
+    if ram.cgroup_limit_gb is not None:
+        parts.append(f"cgroup_limit_gb={ram.cgroup_limit_gb:.1f}")
+    if ram.source == "cgroup":
+        parts.append(f"meminfo_total_gb={ram.meminfo_total_gb:.1f}")
+        _LOG.warning(
+            "%s: container RAM capped below host /proc/meminfo; warm RAM tier "
+            "sized to the cgroup limit (excess pipelines spill to disk)",
+            " ".join(parts),
+        )
+        return
+    _LOG.info(" ".join(parts))
 
 
 def cuda_allocated_bytes(device_index: Optional[int] = None) -> int:

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -37,6 +37,7 @@ from .memory import (
     flush_memory,
     get_available_ram_gb,
     get_total_ram_gb,
+    log_ram_budget_once,
     repair_device_placement,
 )
 
@@ -154,6 +155,7 @@ class Residency:
         self._lock = threading.RLock()
         self._shared_hits = 0
         self._shared_misses = 0
+        log_ram_budget_once(floor_gb=_effective_ram_floor_gb())
 
     # ---- events -------------------------------------------------------------
 

--- a/tests/test_ram_budget.py
+++ b/tests/test_ram_budget.py
@@ -1,0 +1,145 @@
+"""Cgroup-aware host-RAM budget derivation (th#721) — CPU-only, deterministic.
+
+RunPod GPU pods land on lottery-RAM hosts (31GB vs 62GB for the same GPU) and
+the container is cgroup-limited below /proc/meminfo; a probe that trusts
+psutil alone over-reports and the kernel SIGKILLs at the cgroup ceiling.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from gen_worker.models import memory as memory_mod
+from gen_worker.models.memory import (
+    HostRam,
+    cgroup_memory_current_bytes,
+    cgroup_memory_limit_bytes,
+    log_ram_budget_once,
+    probe_host_ram,
+)
+
+_GiB = 1024 ** 3
+
+
+def _fake_cgroup(tmp_path: Path, *, rel: str = "", files: dict[str, str]) -> tuple[Path, Path]:
+    """Build a fake cgroup tree + /proc/self/cgroup pointing at ``rel``."""
+    root = tmp_path / "cgroup"
+    root.mkdir()
+    for name, content in files.items():
+        p = root / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    proc = tmp_path / "proc_self_cgroup"
+    proc.write_text(f"0::/{rel}\n" if rel else "0::/\n")
+    return root, proc
+
+
+def test_v2_limit_at_self_cgroup(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path, rel="kubepods/pod1",
+        files={"kubepods/pod1/memory.max": str(31 * _GiB)},
+    )
+    assert cgroup_memory_limit_bytes(root, proc) == 31 * _GiB
+
+
+def test_v2_tightest_ancestor_limit_wins(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path, rel="kubepods/pod1",
+        files={
+            "kubepods/memory.max": str(16 * _GiB),
+            "kubepods/pod1/memory.max": str(31 * _GiB),
+        },
+    )
+    assert cgroup_memory_limit_bytes(root, proc) == 16 * _GiB
+
+
+def test_v2_max_means_uncapped(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(tmp_path, files={"memory.max": "max"})
+    assert cgroup_memory_limit_bytes(root, proc) is None
+
+
+def test_v1_fallback_limit(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path, files={"memory/memory.limit_in_bytes": str(31 * _GiB)},
+    )
+    assert cgroup_memory_limit_bytes(root, proc) == 31 * _GiB
+
+
+def test_v1_sentinel_means_uncapped(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path, files={"memory/memory.limit_in_bytes": str(0x7FFFFFFFFFFFF000)},
+    )
+    assert cgroup_memory_limit_bytes(root, proc) is None
+
+
+def test_missing_cgroup_files_mean_uncapped(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(tmp_path, files={})
+    assert cgroup_memory_limit_bytes(root, proc) is None
+    assert cgroup_memory_current_bytes(root, proc) is None
+
+
+def test_current_reads_deepest_counter(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path, rel="pod1",
+        files={
+            "memory.current": str(50 * _GiB),
+            "pod1/memory.current": str(20 * _GiB),
+        },
+    )
+    assert cgroup_memory_current_bytes(root, proc) == 20 * _GiB
+
+
+def test_probe_caps_meminfo_at_cgroup_limit(tmp_path: Path) -> None:
+    """RunPod shape: host meminfo says lots, cgroup caps the container."""
+    root, proc = _fake_cgroup(
+        tmp_path,
+        files={"memory.max": str(4 * _GiB), "memory.current": str(1 * _GiB)},
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert isinstance(ram, HostRam)
+    assert ram.source == "cgroup"
+    assert ram.cgroup_limit_gb == pytest.approx(4.0)
+    assert ram.total_gb == pytest.approx(4.0)  # real meminfo total >> 4GiB
+    assert ram.available_gb == pytest.approx(3.0)  # limit - current
+    assert ram.meminfo_total_gb > 4.0
+
+
+def test_probe_without_cgroup_is_meminfo_passthrough(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(tmp_path, files={})
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert ram.source == "meminfo"
+    assert ram.cgroup_limit_gb is None
+    assert ram.total_gb == ram.meminfo_total_gb > 0
+    assert ram.available_gb == ram.meminfo_available_gb > 0
+
+
+def test_log_ram_budget_once_is_once(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(memory_mod, "_ram_budget_logged", False)
+    with caplog.at_level(logging.INFO, logger="gen_worker.models.memory"):
+        log_ram_budget_once(floor_gb=8.0)
+        log_ram_budget_once(floor_gb=8.0)
+    lines = [r.message for r in caplog.records if "RAM_BUDGET=" in r.message]
+    assert len(lines) == 1
+    assert "source=" in lines[0]
+    assert "floor_gb=8.0" in lines[0]
+
+
+def test_log_names_cgroup_constraint(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(memory_mod, "_ram_budget_logged", False)
+    monkeypatch.setattr(memory_mod, "probe_host_ram", lambda **_: HostRam(
+        total_gb=31.0, available_gb=24.0,
+        meminfo_total_gb=62.0, meminfo_available_gb=50.0,
+        cgroup_limit_gb=31.0, source="cgroup",
+    ))
+    with caplog.at_level(logging.INFO, logger="gen_worker.models.memory"):
+        log_ram_budget_once(floor_gb=6.2)
+    [rec] = [r for r in caplog.records if "RAM_BUDGET=" in r.message]
+    assert rec.levelno == logging.WARNING
+    assert "RAM_BUDGET=24.8GiB" in rec.message
+    assert "source=cgroup" in rec.message
+    assert "cgroup_limit_gb=31.0" in rec.message
+    assert "meminfo_total_gb=62.0" in rec.message
+    assert "spill to disk" in rec.message

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.21"
+version = "0.13.23"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Worker side of tensorhub th#721 (Paul's 2026-07-11 ruling: the endpoint does the best with the RAM it has; the platform declares only what it can deliver).

## 1. memory_gb removed from the endpoint-facing schema

- `Compute.memory_gb` (src/gen_worker/api/types.py) deleted — it was never populated (the executor only sets accelerator/vram_gb/gpu_count) and never on the wire (`ResolvedCompute` proto has no memory field). That was the ONLY `memory_gb` in the repo: the authoring `Resources` struct, discovery/lock JSON, docs, examples, and proto never carried it, so **no discovery/lock output changes shape**. The tensorhub-side `endpoint.toml [resources] memory_gb` / `ManifestResources.MemoryGB` removal is a tensorhub change, independent of this repo's lock.
- `disk_gb`, `vram_gb`, `gpu_count`, `cpu_cores`, `accelerator` all stay. No aliases, no shims.

## 2. Adaptive RAM tier (the real fix — tensorhub ie#357)

RunPod GPU pods land on lottery-RAM hosts (31GB vs 62GB for the same GPU type) and the container is cgroup-limited below /proc/meminfo; psutil alone over-reports and the kernel SIGKILLs at the cgroup ceiling (wan-2.2 died at VAE decode).

- **Before:** `get_total_ram_gb`/`get_available_ram_gb` = raw `psutil.virtual_memory()` (host meminfo).
- **After:** both derive from `probe_host_ram()`: min(meminfo, cgroup memory limit). Cgroup v2 `memory.max` is the tightest value walking root→self from `/proc/self/cgroup` (covers private and host cgroup namespaces); v1 `memory/memory.limit_in_bytes` fallback; `max`/sentinel = uncapped. Available = min(meminfo available, limit − memory.current).
- The existing headroom stays as-is: the adaptive RAM floor (`min(8GB, max(1GB, 20% of total))`) now computes from the effective (cgroup-capped) total.
- **Degrade, never die:** the existing seams — `Residency.make_room_ram()` (releases warm RAM-tier LRU pipelines to disk before a load, RETRYABLE when even that can't fit) and the size-aware `demote()` floor refusal — now operate on the true container budget, so a 31GB pod holds fewer warm pipelines and spills to disk instead of being OOM-killed. No new memory-pressure watcher was added: these admission seams already exist and fire on every load/demote; a standalone poller would duplicate them.
- One-time boot line (mirrors the DEGRADED_MODE= pattern), WARNING when cgroup-constrained:
  `RAM_BUDGET=24.8GiB source=cgroup total_gb=31.0 floor_gb=6.2 cgroup_limit_gb=31.0 meminfo_total_gb=62.0: container RAM capped below host /proc/meminfo; warm RAM tier sized to the cgroup limit (excess pipelines spill to disk)`

## Tests

- New `tests/test_ram_budget.py`: cgroup parsing against real tmp-file trees (v2 nested/ancestor-min/'max', v1 sentinel, missing files), probe capping vs live meminfo, one-time log emission + constrained-line content.
- Full suite: `nice -n 10 uv run --extra dev pytest tests/` → **819 passed, 10 skipped**.

No PyPI release published; version bumped to 0.13.23 per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)