### PR TITLE
gw#475: stream-mode terminal output; gw#483: LLM-GGUF clone lane fixes (0.13.24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.23"
+version = "0.13.24"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -42,6 +42,10 @@ _GGUF_QUANT_PREFERENCE = (
     "q3_k_m", "q3_k_s", "q2_k", "f16", "bf16", "f32",
 )
 
+# Full quant token in a gguf FILENAME, incl. unsloth-dynamic ("UD-Q4_K_XL")
+# and i-quant ("IQ4_XS") forms the preference list doesn't name.
+_GGUF_QTYPE_RE = re.compile(r"(?:ud-)?(?:i?q\d[0-9a-z_]*|bf16|f16|f32)")
+
 
 class RepoRefusal(RuntimeError):
     """The repo can't be ingested. ``reason`` is a stable machine token:
@@ -147,10 +151,6 @@ def classify_repo(
     root = _root(paths)
     root_set = {p.lower() for p in root}
 
-    total = sum(int(sizes.get(p, 0)) for p in paths)
-    if total > _SIZE_REFUSE_BYTES:
-        raise RepoRefusal("too_large", files_seen=paths, detail=f"{total} bytes")
-
     configs = [
         p for p in paths
         if _ext(p) in {".json", ".txt", ".model", ".jinja", ".yaml", ".yml"}
@@ -162,6 +162,13 @@ def classify_repo(
     def _finish(strategy: str, library: str, weights: list[str], indexes: list[str],
                 attrs: dict[str, str], reason: str) -> RepoClassification:
         allow = sorted(set(weights) | set(indexes) | set(configs) | set(always))
+        # Size gate on the SELECTED set, not the whole repo: only
+        # allow_patterns are downloaded, and multi-quant GGUF repos
+        # legitimately total 100s of GB while one quant is ~18GB.
+        selected = sum(int(sizes.get(p, 0)) for p in allow)
+        if selected > _SIZE_REFUSE_BYTES:
+            raise RepoRefusal("too_large", files_seen=paths,
+                              detail=f"{selected} bytes selected")
         return RepoClassification(
             strategy=strategy, runtime_library=library, allow_patterns=allow,
             attrs=attrs, detection_reason=reason,
@@ -247,11 +254,12 @@ def classify_repo(
     gguf_files = [p for p in root if p.lower().endswith(".gguf")]
     if gguf_files:
         def _quant_of(p: str) -> str:
-            base = p.lower()
+            base = p.rsplit("/", 1)[-1].lower()
             for q in _GGUF_QUANT_PREFERENCE:
                 if q in base:
                     return q
-            return ""
+            m = _GGUF_QTYPE_RE.search(base)
+            return m.group(0) if m else ""
         gguf_pick: Optional[str] = None
         if gguf_quant:
             want = str(gguf_quant).strip().lower()

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -777,6 +777,10 @@ def run_clone(
                     )
                     # dtype="source" resolves to the detected on-disk dtype.
                     flavor_label = str(attrs.get("dtype") or spec.dtype)
+                # Hub flavor tokens are [a-z0-9][a-z0-9._-]{0,63}: the gguf
+                # dtype-axis label ("gguf:q4_k_m") publishes as "gguf-q4_k_m"
+                # (the th#611 flavor convention).
+                flavor_label = flavor_label.replace(":", "-")
             except InlineConversionNotPossible as exc:
                 entry: dict[str, Any] = {
                     "spec_label": spec.label, "dtype": spec.dtype,

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -211,6 +211,52 @@ def _output_media_seconds(output: Any) -> float:
     return total
 
 
+class _StreamAccumulator:
+    """gw#475: collect stream deltas into the terminal output.
+
+    ``IncrementalTokenDelta`` texts concatenate into ``{"text": ...}``;
+    ``BatchItemDelta`` chunks accumulate per (item_id, index) and each
+    finished item lands in ``{"items": [...]}`` (text/* content decoded to
+    str so the JSON surfaces stay lossless). Other yielded structs are
+    stream-only, as before.
+    """
+
+    def __init__(self) -> None:
+        self._text: List[str] = []
+        self._items: List[Dict[str, Any]] = []
+        self._chunks: Dict[Tuple[Optional[str], int], bytearray] = {}
+
+    def add(self, item: Any) -> None:
+        if isinstance(item, IncrementalTokenDelta):
+            if item.text:
+                self._text.append(item.text)
+            return
+        if isinstance(item, BatchItemDelta):
+            key = (item.item_id, item.index)
+            buf = self._chunks.setdefault(key, bytearray())
+            buf += item.chunk
+            if item.finished or item.error:
+                content: Any = bytes(buf)
+                if item.content_type.startswith("text/"):
+                    content = content.decode("utf-8", errors="replace")
+                self._items.append({
+                    "index": item.index,
+                    "item_id": item.item_id,
+                    "content_type": item.content_type,
+                    "content": content,
+                    "error": item.error,
+                })
+                self._chunks.pop(key, None)
+
+    def result(self) -> Optional[Dict[str, Any]]:
+        out: Dict[str, Any] = {}
+        if self._text:
+            out["text"] = "".join(self._text)
+        if self._items:
+            out["items"] = self._items
+        return out or None
+
+
 # ---------------------------------------------------------------------------
 # Model seam: models.download (ensure-local) + models.residency (tier map),
 # with ModelEvent emission. Single-loop, per-ref asyncio locks — no
@@ -2077,7 +2123,16 @@ class Executor:
             if lease is not None:
                 lease.yield_slot()
             if spec.output_mode == "stream":
-                await self._finish(job, pb.JOB_STATUS_OK, metrics=metrics)
+                # gw#475: live deltas are droppable by contract (in-memory
+                # ProgressHub only) — the terminal JobResult carries the
+                # accumulated stream output so completed requests stay
+                # retrievable after the live stream ends.
+                inline: Optional[bytes] = None
+                blob_ref: Optional[str] = None
+                if output is not None:
+                    inline, blob_ref = await self._serialize_output(ctx, run, output)
+                await self._finish(job, pb.JOB_STATUS_OK, inline=inline, blob_ref=blob_ref,
+                                   metrics=metrics)
             else:
                 inline, blob_ref = await self._serialize_output(ctx, run, output)
                 await self._finish(job, pb.JOB_STATUS_OK, inline=inline, blob_ref=blob_ref,
@@ -2360,6 +2415,7 @@ class Executor:
     # ---- streaming ---------------------------------------------------------
 
     def _encode_chunk(self, item: Any) -> Optional[Tuple[bytes, str]]:
+        # NOTE: keep in sync with _StreamAccumulator.add (gw#475).
         if isinstance(item, Done):
             return None
         if isinstance(item, Error):
@@ -2403,14 +2459,17 @@ class Executor:
 
         return _emit
 
-    async def _pump_async_gen(self, job: _Job, agen: Any) -> None:
+    async def _pump_async_gen(self, job: _Job, agen: Any) -> Optional[Dict[str, Any]]:
+        acc = _StreamAccumulator()
         async for item in agen:
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()
             enc = self._encode_chunk(item)
             if enc is None:
                 break
+            acc.add(item)
             await self._emit_progress(job, next(job.seq), enc[0], enc[1])
+        return acc.result()
 
     def _pump_sync_gen(
         self,
@@ -2419,22 +2478,25 @@ class Executor:
         call_kwargs: Dict[str, Any],
         gpu_index: int,
         loop: asyncio.AbstractEventLoop,
-    ) -> None:
+    ) -> Optional[Dict[str, Any]]:
         if torch is not None and torch.cuda.is_available():
             try:
                 torch.cuda.set_device(gpu_index)
             except Exception:
                 pass
+        acc = _StreamAccumulator()
         for item in bound(**call_kwargs):
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()
             enc = self._encode_chunk(item)
             if enc is None:
                 break
+            acc.add(item)
             fut = asyncio.run_coroutine_threadsafe(
                 self._emit_progress(job, next(job.seq), enc[0], enc[1]), loop
             )
             fut.result()  # backpressure: block the producer on queue overflow
+        return acc.result()
 
     # ---- results -----------------------------------------------------------
 

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -198,7 +198,7 @@ def test_hf_multi_weight_bundle_opts_out_of_layout_contract(tmp_path, monkeypatc
 
 
 def test_gguf_multiquant_repo_size_gate_on_selected_set() -> None:
-    """gw#480: the too_large gate applies to the SELECTED quant, not the
+    """gw#483: the too_large gate applies to the SELECTED quant, not the
     whole multi-quant repo (unsloth repos total 100s of GB; one quant ~18GB)."""
     gib = 1024 * 1024 * 1024
     files = [f"m-{q}.gguf" for q in (

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -195,3 +195,32 @@ def test_hf_multi_weight_bundle_opts_out_of_layout_contract(tmp_path, monkeypatc
     src = ing.ingest_huggingface("ResembleAI/chatterbox", tmp_path / "d", plan=plan)
     assert src.repo_spec["library_name"] == ""
     assert src.metadata["multi_weight_bundle"] == "true"
+
+
+def test_gguf_multiquant_repo_size_gate_on_selected_set() -> None:
+    """gw#480: the too_large gate applies to the SELECTED quant, not the
+    whole multi-quant repo (unsloth repos total 100s of GB; one quant ~18GB)."""
+    gib = 1024 * 1024 * 1024
+    files = [f"m-{q}.gguf" for q in (
+        "Q2_K", "Q3_K_M", "Q4_K_M", "Q5_K_M", "Q6_K", "Q8_0",
+        "UD-Q4_K_XL", "UD-Q8_K_XL",
+    )] + ["mmproj-F16.gguf", "README.md"]
+    sizes = {p: 20 * gib for p in files if p.endswith(".gguf")}
+    c = classify_repo(files, sizes=sizes, gguf_quant="UD-Q4_K_XL")
+    assert c.strategy == "gguf"
+    assert [p for p in c.allow_patterns if p.endswith(".gguf")] == ["m-UD-Q4_K_XL.gguf"]
+    # 20GiB selected << 160GiB repo total: must NOT refuse.
+    assert c.attrs["dtype"] == "gguf:ud-q4_k_xl"
+
+    # A single selected gguf above the threshold still refuses.
+    with pytest.raises(RepoRefusal) as exc:
+        classify_repo(
+            ["huge-Q8_0.gguf"], sizes={"huge-Q8_0.gguf": 200 * gib})
+    assert exc.value.reason == "too_large"
+
+
+def test_gguf_ud_and_iquant_tokens_labeled() -> None:
+    c = classify_repo(["Qwen3.6-27B-UD-Q4_K_XL.gguf"])
+    assert c.attrs["dtype"] == "gguf:ud-q4_k_xl"
+    c2 = classify_repo(["model-IQ4_XS.gguf"])
+    assert c2.attrs["dtype"] == "gguf:iq4_xs"

--- a/tests/test_stream_terminal_output.py
+++ b/tests/test_stream_terminal_output.py
@@ -1,0 +1,118 @@
+"""gw#475: stream-mode functions must produce a NON-empty terminal output.
+
+Live deltas are droppable by contract (tensorhub #505: in-memory ProgressHub
+only, never persisted). The terminal JobResult is the authoritative record:
+the executor accumulates yielded deltas and serializes them as the result —
+concatenated text for IncrementalTokenDelta, finished items[] for
+BatchItemDelta — while the live JobProgress stream is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Iterator, List
+
+import msgspec
+
+from gen_worker.api.streaming import BatchItemDelta, IncrementalTokenDelta
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    n: int = 3
+
+
+async def _token_stream(ctx, payload: _In) -> AsyncIterator[IncrementalTokenDelta]:
+    for i in range(payload.n):
+        yield IncrementalTokenDelta(text=f"tok{i} ")
+
+
+async def _empty_stream(ctx, payload: _In) -> AsyncIterator[IncrementalTokenDelta]:
+    if False:  # pragma: no cover
+        yield IncrementalTokenDelta(text="")
+
+
+def _batch_stream(ctx, payload: _In) -> Iterator[BatchItemDelta]:
+    # Item 0 arrives in two chunks; item 1 in one finished delta.
+    yield BatchItemDelta(index=0, total=2, chunk=b"a red ", content_type="text/plain")
+    yield BatchItemDelta(index=0, total=2, chunk=b"apple", content_type="text/plain",
+                         finished=True)
+    yield BatchItemDelta(index=1, total=2, item_id="b", chunk=b"\x81\xa1x",
+                         content_type="application/octet-stream", finished=True)
+
+
+def _run(method, *, is_async_gen: bool) -> List[pb.WorkerMessage]:
+    async def _go() -> List[pb.WorkerMessage]:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(
+            name="fn", method=method, kind="inference",
+            payload_type=_In, output_mode="stream",
+            delta_type=IncrementalTokenDelta,
+            is_async=is_async_gen, is_async_gen=is_async_gen,
+        )
+        ex = Executor([spec], _send)
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="fn",
+            input_payload=msgspec.msgpack.encode(_In())))
+        job = ex.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        for _ in range(20):
+            await asyncio.sleep(0)
+        return sent
+
+    return asyncio.run(_go())
+
+
+def _result(sent: List[pb.WorkerMessage]) -> pb.JobResult:
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert len(results) == 1
+    return results[0]
+
+
+def _progress(sent: List[pb.WorkerMessage]) -> List[pb.JobProgress]:
+    return [m.job_progress for m in sent if m.WhichOneof("msg") == "job_progress"]
+
+
+def test_token_stream_terminal_output_carries_full_text() -> None:
+    sent = _run(_token_stream, is_async_gen=True)
+    res = _result(sent)
+    assert res.status == pb.JOB_STATUS_OK
+    assert res.WhichOneof("output") == "inline"
+    out = msgspec.msgpack.decode(res.inline)
+    assert out == {"text": "tok0 tok1 tok2 "}
+    # Live stream unchanged: one text/plain chunk per delta.
+    chunks = _progress(sent)
+    assert [c.data for c in chunks] == [b"tok0 ", b"tok1 ", b"tok2 "]
+    assert {c.content_type for c in chunks} == {"text/plain"}
+
+
+def test_batch_stream_terminal_output_accumulates_finished_items() -> None:
+    sent = _run(_batch_stream, is_async_gen=False)
+    res = _result(sent)
+    assert res.status == pb.JOB_STATUS_OK
+    assert res.WhichOneof("output") == "inline"
+    out = msgspec.msgpack.decode(res.inline)
+    items = out["items"]
+    assert len(items) == 2
+    # Chunked text item: concatenated and decoded to str.
+    assert items[0]["index"] == 0
+    assert items[0]["content"] == "a red apple"
+    assert items[0]["content_type"] == "text/plain"
+    assert items[0]["error"] == ""
+    # Binary item: bytes preserved verbatim.
+    assert items[1]["item_id"] == "b"
+    assert items[1]["content"] == b"\x81\xa1x"
+
+
+def test_empty_stream_keeps_empty_terminal_output() -> None:
+    sent = _run(_empty_stream, is_async_gen=True)
+    res = _result(sent)
+    assert res.status == pb.JOB_STATUS_OK
+    assert res.WhichOneof("output") is None


### PR DESCRIPTION
## gw#475 — stream-mode functions produce an EMPTY terminal output

Live deltas are droppable by contract (th#505: in-memory ProgressHub only). For
`output_mode == "stream"` functions the terminal JobResult serialized msgpack nil — a
completed, billed request whose result was unrecoverable after the live stream ended.
Every streaming TEXT family hits this (joycaption captions, LLM completions).

- `_StreamAccumulator` (executor.py): `IncrementalTokenDelta` texts concatenate into
  `{"text": ...}`; `BatchItemDelta` chunks accumulate per (item_id, index) and each
  finished/errored item lands in `{"items": [...]}` with `text/*` content decoded to str
  (lossless through tensorhub's decodeMsgpack JSON surfaces).
- Pumps return the accumulated dict; the stream terminal branch serializes it through the
  ordinary `_serialize_output` (inline ≤64KB, blob_ref above). Empty streams keep an
  output-less OK result. Live JobProgress stream unchanged.

## gw#483 — LLM-GGUF clone lane was dead on arrival

First live use of clone-huggingface on a GGUF source (unsloth/Qwen3.6-27B-MTP-GGUF, the
llama.cpp lane th#611 leaves unchanged) found three blockers:

1. too_large gate summed the WHOLE repo (~380GB multi-quant) before gguf_quant selection —
   now gates on the SELECTED allow_patterns set (all that snapshot_download fetches).
2. UD-/IQ-quant filenames labeled `gguf:unknown` — `_GGUF_QTYPE_RE` fallback labels
   `gguf:ud-q4_k_xl` / `gguf:iq4_xs`.
3. publish used the dtype-axis label verbatim as the hub flavor (`gguf:q4_k_m`);
   IsValidFlavorToken rejects `:` — flavor now publishes as `gguf-<qtype>` (the th#611
   flavor convention); the dtype attr keeps the colon form.

Tests: tests/test_stream_terminal_output.py (3 new), classifier regressions (2 new);
convert suite 163 passed / 2 skipped; executor/stream set 37 passed.

Live proof lands in e2e J32 (qwen3.6-27b-mtp-gguf + qwen3.6-35b-a3b families, ie#368).