### PR TITLE
gw#402: llama.cpp/GGUF first-class serving runtime (0.13.24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,16 @@ jobs:
       - name: HTTP timeout guard (gw#467)
         run: uv run python scripts/lint_http_timeouts.py
 
+      # Pinned CPU build so the gw#402 llama.cpp runtime tests exercise the
+      # real llama-server codepath (tests skip when the binary is absent).
+      - name: Install llama-server (pinned, CPU)
+        run: |
+          curl -sSL --retry 3 -o /tmp/llama.tgz \
+            https://github.com/ggml-org/llama.cpp/releases/download/b9964/llama-b9964-bin-ubuntu-x64.tar.gz
+          tar xzf /tmp/llama.tgz -C "$HOME"
+          echo "$HOME/llama-b9964" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=$HOME/llama-b9964" >> "$GITHUB_ENV"
+
       - name: Run tests
         run: uv run pytest tests/ -v
 

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -183,6 +183,15 @@ For multi-item binary streams yield `gen_worker.BatchItemDelta(index=,
 total=, item_id=, finished=, error=, chunk=, content_type=)` — no ad-hoc
 field names.
 
+Live deltas are droppable; the completed request keeps a terminal record:
+the worker folds every yielded delta into a `StreamResult` (`text`,
+per-`item_id` `texts`, batch `items`, `usage`) and serializes it as the
+request's output, so a client that never attached to the stream still
+retrieves the result. Token endpoints should yield one
+`gen_worker.TokenUsage(prompt_tokens=, completion_tokens=,
+tokens_per_second=)` at the end of the stream — billing reads it from the
+terminal `StreamResult.usage`.
+
 ## Engine-hosted runtimes
 
 `@endpoint(runtime="vllm")` (or `"llama-server"`) makes the worker boot the
@@ -200,6 +209,38 @@ class Chat:
 ```
 
 The worker aborts the boot on failure and stops the server at teardown.
+
+### llama.cpp / GGUF
+
+For `runtime="llama-server"` the bound snapshot may be the `.gguf` file or
+a dir holding exactly one GGUF model (split shards count as one; several
+quants fail closed — pin the flavor). Unless `-ngl`/`-c` are pinned in
+`extra_args`, the worker reads the GGUF header and sizes `-ngl` + context
+to the free-VRAM budget, degrading through fewer GPU layers (down to
+CPU-only) instead of failing the boot. The serve image provides the
+`llama-server` binary (native-build image class); gen-worker adds no
+Python binding dependency.
+
+`gen_worker.runtimes.llama` has the streaming client half —
+`chat_deltas(server, messages, ...)` / `completion_deltas(server, prompt,
+...)` are sync generators yielding `IncrementalTokenDelta` then one
+`TokenUsage`, so a handler is one `yield from`:
+
+```python
+from gen_worker.runtimes.llama import chat_deltas
+from gen_worker.runtimes.server import ServerHandle
+
+@endpoint(model=Hub("org/llm-gguf"), resources=Resources(vram_gb=24),
+          runtime="llama-server")
+class Chat:
+    def setup(self, model: str, server: ServerHandle) -> None:
+        self.server = server
+
+    def chat(self, ctx, p: ChatIn) -> Iterator[IncrementalTokenDelta]:
+        yield from chat_deltas(self.server, p.messages,
+                               max_tokens=p.max_tokens,
+                               cancelled=lambda: ctx.cancelled)
+```
 
 ## RequestContext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.26"
+version = "0.13.27"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -27,6 +27,9 @@ from .api.streaming import (
     Done,
     Error,
     IncrementalTokenDelta,
+    StreamItem,
+    StreamResult,
+    TokenUsage,
     iter_transformers_text_deltas,
 )
 from .api.types import (
@@ -75,6 +78,9 @@ __all__ = [
     "Done",
     "Error",
     "IncrementalTokenDelta",
+    "StreamItem",
+    "StreamResult",
+    "TokenUsage",
     "iter_transformers_text_deltas",
     # Payload + media helpers.
     "Asset",

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -20,7 +20,10 @@ from .streaming import (
     Done,
     Error,
     IncrementalTokenDelta,
+    StreamItem,
+    StreamResult,
     TokenStreamSignal,
+    TokenUsage,
     iter_transformers_text_deltas,
 )
 from .types import (
@@ -61,7 +64,10 @@ __all__ = [
     "Done",
     "Error",
     "IncrementalTokenDelta",
+    "StreamItem",
+    "StreamResult",
     "TokenStreamSignal",
+    "TokenUsage",
     "iter_transformers_text_deltas",
     "Asset",
     "AudioAsset",

--- a/src/gen_worker/api/streaming.py
+++ b/src/gen_worker/api/streaming.py
@@ -47,6 +47,19 @@ class BatchItemDelta(msgspec.Struct, frozen=True, kw_only=True):
     content_type: str = "application/octet-stream"
 
 
+class TokenUsage(msgspec.Struct, frozen=True, kw_only=True):
+    """Terminal usage signal for token-streaming endpoints.
+
+    Yield one at the end of the stream; the executor folds it into the
+    terminal :class:`StreamResult` (billing reads it there) and forwards it
+    live as a JSON chunk.
+    """
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    tokens_per_second: float = 0.0
+
+
 class Done(msgspec.Struct, frozen=True, kw_only=True):
     """End-of-stream marker. Yield exactly one Done() to terminate cleanly.
 
@@ -67,8 +80,122 @@ class Error(msgspec.Struct, frozen=True, kw_only=True):
 
 
 # Tuple form for runtime ``isinstance`` checks in the dispatcher.
-_SIGNAL_TYPES: tuple[type, ...] = (IncrementalTokenDelta, BatchItemDelta, Done, Error)
-TokenStreamSignal = Union[IncrementalTokenDelta, BatchItemDelta, Done, Error]
+_SIGNAL_TYPES: tuple[type, ...] = (
+    IncrementalTokenDelta, BatchItemDelta, TokenUsage, Done, Error,
+)
+TokenStreamSignal = Union[IncrementalTokenDelta, BatchItemDelta, TokenUsage, Done, Error]
+
+
+# ============================================================================
+# Terminal stream output (gw#475): live deltas are droppable by contract, so
+# the executor folds them into a StreamResult and serializes it as the
+# completed request's authoritative output.
+# ============================================================================
+
+
+class StreamItem(msgspec.Struct, frozen=True, kw_only=True):
+    """One accumulated batch item in the terminal output.
+
+    ``content`` is ``str`` for ``text/*`` items (lossless through the JSON
+    SSE/webhook decode surfaces), raw ``bytes`` otherwise.
+    """
+
+    item_id: str | None = None
+    index: int = 0
+    # str for text/*, bytes otherwise (msgspec typed decode can't take a
+    # str|bytes union; msgpack distinguishes them on the wire regardless).
+    content: Any = b""
+    content_type: str = "application/octet-stream"
+    error: str = ""
+
+
+class StreamResult(msgspec.Struct, frozen=True, kw_only=True, omit_defaults=True):
+    """Terminal output of a stream-mode request.
+
+    ``text`` is the concatenated token stream (default item); ``texts``
+    holds per-``item_id`` streams when multiplexed; ``items`` the finished
+    batch items; ``usage`` the endpoint's TokenUsage signal. ``truncated``
+    marks content dropped past the accumulation cap (metadata is always
+    kept). Empty fields are omitted on the wire — a plain token stream
+    encodes as exactly ``{"text": ...}``.
+    """
+
+    text: str = ""
+    texts: dict[str, str] = {}
+    items: list[StreamItem] = []
+    usage: TokenUsage | None = None
+    truncated: bool = False
+
+
+# Binary/batch content past this cap is dropped from the terminal record
+# (item metadata survives); token text is never dropped in practice.
+_ACCUM_MAX_BYTES = 64 * 1024 * 1024
+
+
+class StreamAccumulator:
+    """Folds yielded stream signals into the terminal StreamResult."""
+
+    def __init__(self, max_bytes: int = _ACCUM_MAX_BYTES) -> None:
+        self._max = max_bytes
+        self._size = 0
+        self._texts: dict[str, list[str]] = {}
+        self._items: dict[tuple[str | None, int], dict[str, Any]] = {}
+        self._finished: list[StreamItem] = []
+        self._usage: TokenUsage | None = None
+        self._truncated = False
+
+    def add(self, item: Any) -> None:
+        if isinstance(item, IncrementalTokenDelta):
+            if self._book(len(item.text)):
+                self._texts.setdefault(item.item_id or "", []).append(item.text)
+        elif isinstance(item, BatchItemDelta):
+            key = (item.item_id, item.index)
+            rec = self._items.get(key)
+            if rec is None:
+                rec = {"chunks": [], "content_type": item.content_type, "error": ""}
+                self._items[key] = rec
+            if item.chunk and self._book(len(item.chunk)):
+                rec["chunks"].append(item.chunk)
+            if item.content_type != "application/octet-stream":
+                rec["content_type"] = item.content_type
+            if item.error:
+                rec["error"] = item.error
+            if item.finished or item.error:
+                # Only finished/errored items reach the terminal record.
+                content: Union[str, bytes] = b"".join(rec["chunks"])
+                if rec["content_type"].startswith("text/"):
+                    content = content.decode("utf-8", errors="replace")
+                self._finished.append(StreamItem(
+                    item_id=key[0], index=key[1], content=content,
+                    content_type=rec["content_type"], error=rec["error"],
+                ))
+                self._items.pop(key, None)
+        elif isinstance(item, TokenUsage):
+            self._usage = item
+
+    def _book(self, n: int) -> bool:
+        if self._size + n > self._max:
+            self._truncated = True
+            return False
+        self._size += n
+        return True
+
+    def result(self) -> StreamResult | None:
+        """The terminal record, or None when nothing accumulated (an empty
+        stream keeps an output-less OK result)."""
+        texts = {k: "".join(v) for k, v in self._texts.items()}
+        text = texts.pop("", "")
+        if not text and len(texts) == 1:
+            text = next(iter(texts.values()))
+        if not (text or texts or self._finished or self._usage or self._truncated):
+            return None
+        return StreamResult(
+            text=text,
+            texts=texts,
+            items=list(self._finished),
+            usage=self._usage,
+            truncated=self._truncated,
+        )
 
 
 def iter_transformers_text_deltas(

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -31,7 +31,14 @@ from .api.errors import (
     RetryableError,
     ValidationError,
 )
-from .api.streaming import BatchItemDelta, Done, Error, IncrementalTokenDelta
+from .api.streaming import (
+    BatchItemDelta,
+    Done,
+    Error,
+    IncrementalTokenDelta,
+    StreamAccumulator,
+    StreamResult,
+)
 from .api.types import Compute, MediaAsset
 from .capability import HardwareUnmetError, InsufficientDiskError
 from .input_assets import cleanup_input_assets, materialize_input_assets
@@ -209,52 +216,6 @@ def _output_media_seconds(output: Any) -> float:
         elif isinstance(item, msgspec.Struct):
             stack.extend(getattr(item, f, None) for f in item.__struct_fields__)
     return total
-
-
-class _StreamAccumulator:
-    """gw#475: collect stream deltas into the terminal output.
-
-    ``IncrementalTokenDelta`` texts concatenate into ``{"text": ...}``;
-    ``BatchItemDelta`` chunks accumulate per (item_id, index) and each
-    finished item lands in ``{"items": [...]}`` (text/* content decoded to
-    str so the JSON surfaces stay lossless). Other yielded structs are
-    stream-only, as before.
-    """
-
-    def __init__(self) -> None:
-        self._text: List[str] = []
-        self._items: List[Dict[str, Any]] = []
-        self._chunks: Dict[Tuple[Optional[str], int], bytearray] = {}
-
-    def add(self, item: Any) -> None:
-        if isinstance(item, IncrementalTokenDelta):
-            if item.text:
-                self._text.append(item.text)
-            return
-        if isinstance(item, BatchItemDelta):
-            key = (item.item_id, item.index)
-            buf = self._chunks.setdefault(key, bytearray())
-            buf += item.chunk
-            if item.finished or item.error:
-                content: Any = bytes(buf)
-                if item.content_type.startswith("text/"):
-                    content = content.decode("utf-8", errors="replace")
-                self._items.append({
-                    "index": item.index,
-                    "item_id": item.item_id,
-                    "content_type": item.content_type,
-                    "content": content,
-                    "error": item.error,
-                })
-                self._chunks.pop(key, None)
-
-    def result(self) -> Optional[Dict[str, Any]]:
-        out: Dict[str, Any] = {}
-        if self._text:
-            out["text"] = "".join(self._text)
-        if self._items:
-            out["items"] = self._items
-        return out or None
 
 
 # ---------------------------------------------------------------------------
@@ -1286,6 +1247,14 @@ class Executor:
                         stats.get("fxgraph_cache_miss", 0),
                         time.monotonic() - warm_t0)
             vram_delta = max(0, self._vram_allocated() - vram_before)
+            if rec.server is not None:
+                # Engine subprocess VRAM is invisible to torch's allocator;
+                # book the measured per-PID footprint so the LRU ledger is
+                # honest and eviction (record teardown -> server.stop) works.
+                from .runtimes.server import process_vram_bytes
+
+                vram_delta += await asyncio.to_thread(
+                    process_vram_bytes, rec.server.process.pid)
             self._register_residency(
                 spec, setup_slots, inj.loaded, vram_delta,
                 lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes)
@@ -2413,7 +2382,7 @@ class Executor:
             if spec.output_mode == "stream":
                 # gw#475: live deltas are droppable by contract (in-memory
                 # ProgressHub only) — the terminal JobResult carries the
-                # accumulated stream output so completed requests stay
+                # accumulated StreamResult so completed requests stay
                 # retrievable after the live stream ends.
                 inline: Optional[bytes] = None
                 blob_ref: Optional[str] = None
@@ -2703,7 +2672,7 @@ class Executor:
     # ---- streaming ---------------------------------------------------------
 
     def _encode_chunk(self, item: Any) -> Optional[Tuple[bytes, str]]:
-        # NOTE: keep in sync with _StreamAccumulator.add (gw#475).
+        # NOTE: keep in sync with api.streaming.StreamAccumulator.add (gw#475).
         if isinstance(item, Done):
             return None
         if isinstance(item, Error):
@@ -2747,8 +2716,10 @@ class Executor:
 
         return _emit
 
-    async def _pump_async_gen(self, job: _Job, agen: Any) -> Optional[Dict[str, Any]]:
-        acc = _StreamAccumulator()
+    async def _pump_async_gen(self, job: _Job, agen: Any) -> Optional[StreamResult]:
+        """Pump a streaming handler; returns the terminal StreamResult
+        (gw#475: live deltas are droppable, the aggregate is the record)."""
+        acc = StreamAccumulator()
         async for item in agen:
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()
@@ -2766,13 +2737,13 @@ class Executor:
         call_kwargs: Dict[str, Any],
         gpu_index: int,
         loop: asyncio.AbstractEventLoop,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[StreamResult]:
         if torch is not None and torch.cuda.is_available():
             try:
                 torch.cuda.set_device(gpu_index)
             except Exception:
                 pass
-        acc = _StreamAccumulator()
+        acc = StreamAccumulator()
         for item in bound(**call_kwargs):
             if job.ctx is not None:
                 job.ctx.raise_if_cancelled()

--- a/src/gen_worker/runtimes/llama.py
+++ b/src/gen_worker/runtimes/llama.py
@@ -1,0 +1,378 @@
+"""llama.cpp serving runtime (gw#402).
+
+GGUF checkpoint resolution, VRAM fit planning (n_gpu_layers / context from
+the free-VRAM budget — degraded mode is fewer GPU layers, never a crash),
+and OpenAI-compatible streaming helpers for ``llama-server`` endpoints.
+
+Torch-free: works in llama-server-only serve images. The ``gguf`` reader
+(core dep) is imported lazily so discovery stays cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional, Sequence, Union
+
+import msgspec
+
+from ..api.errors import FatalError
+from ..api.streaming import IncrementalTokenDelta, TokenUsage
+
+logger = logging.getLogger(__name__)
+
+_GiB = 1024**3
+# Non-weight VRAM llama.cpp needs on top of layers + KV (compute graph,
+# scratch buffers, CUDA pool). Conservative; sized for 7B-class contexts.
+_OVERHEAD_GB = 1.0
+_SPLIT_RE = re.compile(r"-\d{5}-of-\d{5}\.gguf$")
+
+__all__ = [
+    "GGUFInfo",
+    "LlamaFitPlan",
+    "chat_deltas",
+    "completion_deltas",
+    "free_vram_gb",
+    "plan_fit",
+    "read_gguf_info",
+    "resolve_gguf",
+]
+
+
+# ---------------------------------------------------------------------------
+# GGUF resolution: snapshot dir (Hub()-injected str/Path) -> the .gguf file
+# ---------------------------------------------------------------------------
+
+
+def _split_stem(path: Path) -> str:
+    """Logical model stem: split shards of one model share a stem."""
+    return _SPLIT_RE.sub(".gguf", path.name)
+
+
+def resolve_gguf(source: Union[str, Path]) -> Path:
+    """Resolve a model binding path to the single ``.gguf`` file to serve.
+
+    A ``.gguf`` file path passes through. A directory (the usual Hub()
+    snapshot dir) must contain exactly one logical GGUF model; split shards
+    (``-00001-of-0000N.gguf``) count as one model and the first shard is
+    returned (llama.cpp discovers the rest). Multiple distinct models fail
+    closed — pin a flavor instead of guessing a quant.
+    """
+    p = Path(source)
+    if p.suffix == ".gguf":
+        return p
+    if not p.is_dir():
+        raise FatalError(f"model binding {str(p)!r} is neither a .gguf file nor a directory")
+    ggufs = sorted(q for q in p.rglob("*.gguf") if q.is_file())
+    if not ggufs:
+        raise FatalError(f"no .gguf file found under snapshot dir {str(p)!r}")
+    stems = sorted({_split_stem(q) for q in ggufs})
+    if len(stems) > 1:
+        raise FatalError(
+            f"snapshot dir {str(p)!r} holds {len(stems)} distinct GGUF models "
+            f"({', '.join(stems)}); pin the flavor to exactly one quant"
+        )
+    return ggufs[0]
+
+
+def _shard_group(gguf: Path) -> list[Path]:
+    """All shards belonging to the same logical model as ``gguf``."""
+    stem = _split_stem(gguf)
+    siblings = [q for q in gguf.parent.glob("*.gguf") if _split_stem(q) == stem]
+    return sorted(siblings) or [gguf]
+
+
+# ---------------------------------------------------------------------------
+# Header introspection (lazy `gguf` import)
+# ---------------------------------------------------------------------------
+
+
+class GGUFInfo(msgspec.Struct, frozen=True, kw_only=True):
+    """Fit-relevant facts from a GGUF header (weights never read)."""
+
+    architecture: str = ""
+    n_layers: int = 0
+    n_ctx_train: int = 0
+    n_embd: int = 0
+    n_head: int = 0
+    n_head_kv: int = 0
+    size_bytes: int = 0
+
+
+def _field_int(reader: Any, key: str) -> int:
+    field = reader.get_field(key)
+    if field is None:
+        return 0
+    try:
+        return int(field.contents())
+    except Exception:
+        return 0
+
+
+def read_gguf_info(path: Union[str, Path]) -> GGUFInfo:
+    """Read fit metadata from a GGUF header. ``size_bytes`` sums all shards."""
+    try:
+        from gguf import GGUFReader
+    except ImportError as exc:  # pragma: no cover - gguf is a core dep
+        raise FatalError(
+            "the 'gguf' package is required for the llama.cpp runtime; "
+            "install with 'pip install gen-worker'"
+        ) from exc
+
+    gguf_path = Path(path)
+    reader = GGUFReader(str(gguf_path), "r")
+    arch_field = reader.get_field("general.architecture")
+    arch = str(arch_field.contents()) if arch_field is not None else ""
+    n_head = _field_int(reader, f"{arch}.attention.head_count")
+    n_head_kv = _field_int(reader, f"{arch}.attention.head_count_kv") or n_head
+    return GGUFInfo(
+        architecture=arch,
+        n_layers=_field_int(reader, f"{arch}.block_count"),
+        n_ctx_train=_field_int(reader, f"{arch}.context_length"),
+        n_embd=_field_int(reader, f"{arch}.embedding_length"),
+        n_head=n_head,
+        n_head_kv=n_head_kv,
+        size_bytes=sum(q.stat().st_size for q in _shard_group(gguf_path)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fit planning: free VRAM -> n_gpu_layers / n_ctx. Never raises.
+# ---------------------------------------------------------------------------
+
+
+class LlamaFitPlan(msgspec.Struct, frozen=True, kw_only=True):
+    n_gpu_layers: int = 0
+    n_ctx: int = 0
+    degraded: bool = False
+    reason: str = ""
+
+
+def kv_bytes_per_token(info: GGUFInfo, *, bytes_per_elem: float = 2.0) -> int:
+    """K+V cache bytes per context token (f16 default; q8_0 ≈ 1.06)."""
+    if not (info.n_layers and info.n_head and info.n_head_kv and info.n_embd):
+        return 0
+    head_dim = info.n_embd / info.n_head
+    return int(info.n_layers * info.n_head_kv * head_dim * 2 * bytes_per_elem)
+
+
+def plan_fit(
+    info: GGUFInfo,
+    *,
+    free_vram_gb: float,
+    n_ctx: Optional[int] = None,
+    kv_bytes_per_elem: float = 2.0,
+    overhead_gb: float = _OVERHEAD_GB,
+) -> LlamaFitPlan:
+    """Size ``-ngl`` / ``-c`` to the VRAM budget.
+
+    Full offload when everything fits; otherwise as many layers as fit with
+    their share of the KV cache (the rest runs on CPU). Floor is 0 GPU
+    layers — a plan is always returned, never an exception (fit-ladder
+    contract: degraded, not dead).
+    """
+    ctx = int(n_ctx or info.n_ctx_train or 4096)
+    if info.n_ctx_train:
+        ctx = min(ctx, info.n_ctx_train)
+    total_layers = info.n_layers + 1  # +1: output/embedding layer
+    budget = free_vram_gb * _GiB - overhead_gb * _GiB
+    if budget <= 0 or not info.n_layers or not info.size_bytes:
+        why = "no VRAM budget" if budget <= 0 else "unknown model geometry"
+        return LlamaFitPlan(
+            n_gpu_layers=0, n_ctx=ctx, degraded=free_vram_gb > 0,
+            reason=f"{why}; running all layers on CPU",
+        )
+    kv_total = kv_bytes_per_token(info, bytes_per_elem=kv_bytes_per_elem) * ctx
+    if budget >= info.size_bytes + kv_total:
+        return LlamaFitPlan(
+            n_gpu_layers=total_layers, n_ctx=ctx, degraded=False,
+            reason=f"full offload: {total_layers} layers + {kv_total // _GiB}GiB KV fit",
+        )
+    layer_bytes = info.size_bytes / total_layers
+    kv_per_layer = kv_total / info.n_layers if info.n_layers else 0
+    n = int(budget // (layer_bytes + kv_per_layer))
+    n = max(0, min(n, total_layers))
+    return LlamaFitPlan(
+        n_gpu_layers=n, n_ctx=ctx, degraded=True,
+        reason=(
+            f"partial offload: {n}/{total_layers} layers fit in "
+            f"{free_vram_gb:.1f}GiB free VRAM (ctx={ctx})"
+        ),
+    )
+
+
+def free_vram_gb() -> float:
+    """Free VRAM on device 0. Torch-free fallback: nvidia-smi (llama-server
+    serve images carry no torch)."""
+    from ..models.memory import get_available_vram_gb
+
+    via_torch = get_available_vram_gb()
+    if via_torch > 0:
+        return via_torch
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout.strip().splitlines()
+        return float(out[0]) / 1024.0 if out else 0.0
+    except Exception:
+        return 0.0
+
+
+def plan_for(
+    gguf_path: Union[str, Path],
+    *,
+    vram_budget_gb: Optional[float] = None,
+    n_ctx: Optional[int] = None,
+) -> Optional[LlamaFitPlan]:
+    """Best-effort plan for a checkpoint: None when the header is unreadable
+    (caller falls back to llama.cpp defaults rather than failing the boot)."""
+    try:
+        info = read_gguf_info(gguf_path)
+    except Exception as exc:
+        logger.debug("gguf header unreadable for %s: %s", gguf_path, exc)
+        return None
+    budget = free_vram_gb() if vram_budget_gb is None else vram_budget_gb
+    plan = plan_fit(info, free_vram_gb=budget, n_ctx=n_ctx)
+    logger.info("llama fit plan for %s: %s", Path(gguf_path).name, plan.reason)
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Streaming client (sync generators; the executor pumps sync gens in a
+# thread). Yields IncrementalTokenDelta per token group, then one TokenUsage
+# terminal signal for billing.
+# ---------------------------------------------------------------------------
+
+
+def _base_url(server: Any) -> str:
+    url = getattr(server, "base_url", server)
+    if not isinstance(url, str) or not url.startswith("http"):
+        raise FatalError(f"expected a ServerHandle or base URL, got {server!r}")
+    return url.rstrip("/")
+
+
+def _delta_text(choice: dict[str, Any]) -> str:
+    delta = choice.get("delta")
+    if isinstance(delta, dict) and isinstance(delta.get("content"), str):
+        return delta["content"]
+    if isinstance(choice.get("text"), str):
+        return choice["text"]
+    return ""
+
+
+def _stream(
+    url: str,
+    payload: dict[str, Any],
+    cancelled: Optional[Callable[[], bool]],
+    idle_timeout_s: float,
+) -> Iterator[Union[IncrementalTokenDelta, TokenUsage]]:
+    import requests
+
+    prompt_tokens = completion_tokens = 0
+    tokens_per_second = 0.0
+    started = time.monotonic()
+    with requests.post(
+        url, json=payload, stream=True, timeout=(10.0, idle_timeout_s)
+    ) as resp:
+        resp.raise_for_status()
+        for raw in resp.iter_lines(decode_unicode=True):
+            if cancelled is not None and cancelled():
+                return
+            line = (raw or "").strip()
+            if not line.startswith("data:"):
+                continue
+            data = line.removeprefix("data:").strip()
+            if data == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                logger.warning("malformed llama-server stream chunk ignored: %.200r", data)
+                continue
+            usage = chunk.get("usage")
+            if isinstance(usage, dict):
+                prompt_tokens = int(usage.get("prompt_tokens") or 0)
+                completion_tokens = int(usage.get("completion_tokens") or 0)
+            timings = chunk.get("timings")
+            if isinstance(timings, dict):
+                tokens_per_second = float(timings.get("predicted_per_second") or 0.0)
+                prompt_tokens = int(timings.get("prompt_n") or prompt_tokens)
+                completion_tokens = int(timings.get("predicted_n") or completion_tokens)
+            for choice in chunk.get("choices") or []:
+                if isinstance(choice, dict):
+                    text = _delta_text(choice)
+                    if text:
+                        yield IncrementalTokenDelta(text=text)
+    if not tokens_per_second and completion_tokens:
+        elapsed = max(time.monotonic() - started, 1e-6)
+        tokens_per_second = completion_tokens / elapsed
+    yield TokenUsage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        tokens_per_second=round(tokens_per_second, 2),
+    )
+
+
+def chat_deltas(
+    server: Any,
+    messages: Sequence[dict[str, str]],
+    *,
+    max_tokens: int = 256,
+    temperature: float = 0.7,
+    top_p: float = 0.95,
+    stop: Optional[Sequence[str]] = None,
+    cancelled: Optional[Callable[[], bool]] = None,
+    idle_timeout_s: float = 300.0,
+    extra: Optional[dict[str, Any]] = None,
+) -> Iterator[Union[IncrementalTokenDelta, TokenUsage]]:
+    """Stream a chat completion from llama-server as typed deltas + usage."""
+    payload: dict[str, Any] = {
+        "messages": list(messages),
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": int(max_tokens),
+        "temperature": float(temperature),
+        "top_p": float(top_p),
+    }
+    if stop:
+        payload["stop"] = list(stop)
+    if extra:
+        payload.update(extra)
+    yield from _stream(
+        f"{_base_url(server)}/v1/chat/completions", payload, cancelled, idle_timeout_s
+    )
+
+
+def completion_deltas(
+    server: Any,
+    prompt: str,
+    *,
+    max_tokens: int = 256,
+    temperature: float = 0.7,
+    top_p: float = 0.95,
+    stop: Optional[Sequence[str]] = None,
+    cancelled: Optional[Callable[[], bool]] = None,
+    idle_timeout_s: float = 300.0,
+    extra: Optional[dict[str, Any]] = None,
+) -> Iterator[Union[IncrementalTokenDelta, TokenUsage]]:
+    """Stream a raw text completion from llama-server as typed deltas + usage."""
+    payload: dict[str, Any] = {
+        "prompt": prompt,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": int(max_tokens),
+        "temperature": float(temperature),
+        "top_p": float(top_p),
+    }
+    if stop:
+        payload["stop"] = list(stop)
+    if extra:
+        payload.update(extra)
+    yield from _stream(
+        f"{_base_url(server)}/v1/completions", payload, cancelled, idle_timeout_s
+    )

--- a/src/gen_worker/runtimes/server.py
+++ b/src/gen_worker/runtimes/server.py
@@ -150,33 +150,115 @@ def vllm_server(
     )
 
 
+class DegradingBoot:
+    """Try candidate server commands in order; first healthy one wins.
+
+    The llama.cpp fit ladder rides this: planned ``-ngl``, then half, then
+    CPU-only — a VRAM-tight boot degrades instead of crashing.
+    """
+
+    def __init__(self, candidates: Sequence[ServerProcess]) -> None:
+        if not candidates:
+            raise ValueError("DegradingBoot needs at least one candidate")
+        self.candidates = list(candidates)
+
+    def start(self) -> ServerHandle:
+        last: Optional[ServerBootError] = None
+        for proc in self.candidates:
+            try:
+                return proc.start()
+            except ServerBootError as exc:
+                last = exc
+                logger.warning("engine boot failed (%s); trying degraded rung", exc)
+        assert last is not None
+        raise last
+
+
+_NGL_FLAGS = {"-ngl", "--n-gpu-layers", "--gpu-layers"}
+_CTX_FLAGS = {"-c", "--ctx-size"}
+
+
 def llama_server(
-    gguf_path: str,
+    model_source: str,
     *,
     port: Optional[int] = None,
     extra_args: Sequence[str] = (),
     boot_timeout_s: float = _DEFAULT_BOOT_TIMEOUT_S,
-) -> ServerProcess:
-    """``llama-server -m <gguf>`` with the built-in /health endpoint."""
-    p = port or free_port()
-    return ServerProcess(
-        ["llama-server", "-m", gguf_path, "--host", "127.0.0.1",
-         "--port", str(p), *extra_args],
-        health_url=f"http://127.0.0.1:{p}/health",
-        base_url=f"http://127.0.0.1:{p}",
-        boot_timeout_s=boot_timeout_s,
-    )
+    vram_budget_gb: Optional[float] = None,
+    n_ctx: Optional[int] = None,
+):
+    """``llama-server -m <gguf>`` with the built-in /health endpoint.
+
+    ``model_source`` may be the ``.gguf`` file or a snapshot dir (the
+    Hub()-injected path) — dirs resolve to their single GGUF model. Unless
+    the caller pins ``-ngl``/``-c`` in ``extra_args``, ``-ngl`` and context
+    are sized to the free-VRAM budget (gw#402) and the boot degrades
+    through fewer GPU layers rather than failing.
+    """
+    from .llama import plan_for, resolve_gguf
+
+    gguf_path = str(resolve_gguf(model_source))
+    args = [str(a) for a in extra_args]
+
+    def _proc(fit_args: Sequence[str]) -> ServerProcess:
+        p = port or free_port()
+        return ServerProcess(
+            ["llama-server", "-m", gguf_path, "--host", "127.0.0.1",
+             "--port", str(p), *fit_args, *args],
+            health_url=f"http://127.0.0.1:{p}/health",
+            base_url=f"http://127.0.0.1:{p}",
+            boot_timeout_s=boot_timeout_s,
+        )
+
+    if any(a in _NGL_FLAGS for a in args):
+        return _proc(())
+    plan = plan_for(gguf_path, vram_budget_gb=vram_budget_gb, n_ctx=n_ctx)
+    if plan is None:
+        return _proc(())
+    ctx_args = [] if any(a in _CTX_FLAGS for a in args) else ["-c", str(plan.n_ctx)]
+    rungs = [plan.n_gpu_layers]
+    if plan.n_gpu_layers > 1:
+        rungs.append(plan.n_gpu_layers // 2)
+    if plan.n_gpu_layers > 0:
+        rungs.append(0)
+    candidates = [_proc(["-ngl", str(n), *ctx_args]) for n in rungs]
+    return candidates[0] if len(candidates) == 1 else DegradingBoot(candidates)
+
+
+def process_vram_bytes(pid: int) -> int:
+    """Measured VRAM of one process via nvidia-smi. 0 when unavailable —
+    engine subprocesses are invisible to torch's allocator, so residency
+    accounting for server runtimes books this number instead."""
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-compute-apps=pid,used_memory",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10, check=True,
+        ).stdout
+    except Exception:
+        return 0
+    total = 0
+    for line in out.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 2 and parts[0].isdigit() and int(parts[0]) == pid:
+            try:
+                total += int(parts[1]) * 1024 * 1024
+            except ValueError:
+                pass
+    return total
 
 
 RUNTIME_FACTORIES = {"vllm": vllm_server, "llama-server": llama_server}
 
 
 __all__ = [
+    "DegradingBoot",
     "RUNTIME_FACTORIES",
     "ServerBootError",
     "ServerHandle",
     "ServerProcess",
     "free_port",
     "llama_server",
+    "process_vram_bytes",
     "vllm_server",
 ]

--- a/tests/test_llama_runtime.py
+++ b/tests/test_llama_runtime.py
@@ -1,0 +1,386 @@
+"""gw#402: llama.cpp/GGUF serving runtime.
+
+Unit: GGUF resolution, fit planning, stream accumulation, command shapes.
+Integration (real llama-server + tiny stories15M gguf, CPU): boot, stream,
+terminal output, token counts. Binary resolution: $GEN_WORKER_LLAMA_SERVER_BIN
+or PATH; tests skip when absent. GPU smoke is GEN_WORKER_GPU_SMOKE-gated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from typing import Iterator, List
+
+import msgspec
+import pytest
+
+from gen_worker.api.errors import FatalError
+from gen_worker.api.streaming import (
+    BatchItemDelta,
+    IncrementalTokenDelta,
+    StreamAccumulator,
+    StreamResult,
+    TokenUsage,
+)
+from gen_worker.runtimes.llama import (
+    GGUFInfo,
+    chat_deltas,
+    completion_deltas,
+    plan_fit,
+    read_gguf_info,
+    resolve_gguf,
+)
+from gen_worker.runtimes.server import DegradingBoot, ServerProcess, llama_server
+
+# ---------------------------------------------------------------------------
+# resolve_gguf
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_gguf_file_passthrough() -> None:
+    assert resolve_gguf("/models/x.gguf") == Path("/models/x.gguf")
+
+
+def test_resolve_gguf_single_in_dir(tmp_path) -> None:
+    (tmp_path / "sub").mkdir()
+    target = tmp_path / "sub" / "model-q4_k_m.gguf"
+    target.write_bytes(b"x")
+    assert resolve_gguf(tmp_path) == target
+
+
+def test_resolve_gguf_split_shards_pick_first(tmp_path) -> None:
+    for i in (2, 1, 3):
+        (tmp_path / f"big-q4-0000{i}-of-00003.gguf").write_bytes(b"x")
+    assert resolve_gguf(tmp_path).name == "big-q4-00001-of-00003.gguf"
+
+
+def test_resolve_gguf_multiple_models_fail_closed(tmp_path) -> None:
+    (tmp_path / "a-q4_k_m.gguf").write_bytes(b"x")
+    (tmp_path / "a-q8_0.gguf").write_bytes(b"x")
+    with pytest.raises(FatalError, match="pin the flavor"):
+        resolve_gguf(tmp_path)
+
+
+def test_resolve_gguf_empty_dir_fails(tmp_path) -> None:
+    with pytest.raises(FatalError, match="no .gguf"):
+        resolve_gguf(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# plan_fit — degraded is fewer layers, never a crash
+# ---------------------------------------------------------------------------
+
+_INFO = GGUFInfo(
+    architecture="llama", n_layers=32, n_ctx_train=4096,
+    n_embd=4096, n_head=32, n_head_kv=8, size_bytes=4 * 1024**3,
+)
+
+
+def test_plan_full_offload_when_everything_fits() -> None:
+    plan = plan_fit(_INFO, free_vram_gb=80.0)
+    assert plan.n_gpu_layers == 33  # +1 output layer
+    assert not plan.degraded
+    assert plan.n_ctx == 4096
+
+
+def test_plan_partial_offload_degrades() -> None:
+    plan = plan_fit(_INFO, free_vram_gb=3.0)
+    assert 0 < plan.n_gpu_layers < 33
+    assert plan.degraded
+
+
+def test_plan_monotonic_in_budget() -> None:
+    layers = [plan_fit(_INFO, free_vram_gb=g).n_gpu_layers for g in (0.0, 2.0, 3.0, 5.0, 80.0)]
+    assert layers == sorted(layers)
+    assert layers[0] == 0 and layers[-1] == 33
+
+
+def test_plan_no_budget_is_cpu_not_crash() -> None:
+    for gb in (0.0, -5.0, 0.5):
+        plan = plan_fit(_INFO, free_vram_gb=gb)
+        assert plan.n_gpu_layers == 0
+
+
+def test_plan_unknown_geometry_is_cpu_not_crash() -> None:
+    plan = plan_fit(GGUFInfo(), free_vram_gb=24.0)
+    assert plan.n_gpu_layers == 0
+    assert plan.n_ctx == 4096
+
+
+def test_plan_ctx_clamped_to_trained() -> None:
+    plan = plan_fit(_INFO, free_vram_gb=80.0, n_ctx=1_000_000)
+    assert plan.n_ctx == 4096
+
+
+# ---------------------------------------------------------------------------
+# llama_server command shapes
+# ---------------------------------------------------------------------------
+
+
+def test_caller_pinned_ngl_respected() -> None:
+    proc = llama_server("/models/x.gguf", port=4321, extra_args=["-ngl", "99", "-c", "8192"])
+    assert isinstance(proc, ServerProcess)
+    assert proc.command[:3] == ["llama-server", "-m", "/models/x.gguf"]
+    assert proc.command.count("-ngl") == 1
+
+
+def test_unreadable_header_boots_with_defaults() -> None:
+    proc = llama_server("/models/x.gguf", port=4321)
+    assert isinstance(proc, ServerProcess)
+    assert "-ngl" not in proc.command
+
+
+def test_auto_fit_builds_degrade_ladder(tmp_path, monkeypatch) -> None:
+    gguf = tmp_path / "m.gguf"
+    gguf.write_bytes(b"GGUF")
+    import gen_worker.runtimes.llama as llama_mod
+
+    monkeypatch.setattr(llama_mod, "read_gguf_info", lambda p: _INFO)
+    monkeypatch.setattr(llama_mod, "free_vram_gb", lambda: 3.0)
+    boot = llama_server(str(gguf))
+    assert isinstance(boot, DegradingBoot)
+    ngls = [c.command[c.command.index("-ngl") + 1] for c in boot.candidates]
+    assert ngls[-1] == "0" and len(ngls) == 3
+    assert int(ngls[0]) > int(ngls[1]) > 0
+
+
+# ---------------------------------------------------------------------------
+# StreamAccumulator / terminal StreamResult (gw#475)
+# ---------------------------------------------------------------------------
+
+
+def test_accumulator_concatenates_tokens_and_usage() -> None:
+    acc = StreamAccumulator()
+    for t in ("Hel", "lo ", "world"):
+        acc.add(IncrementalTokenDelta(text=t))
+    acc.add(TokenUsage(prompt_tokens=5, completion_tokens=3, tokens_per_second=42.0))
+    out = acc.result()
+    assert out.text == "Hello world"
+    assert out.usage is not None and out.usage.completion_tokens == 3
+    assert not out.truncated
+
+
+def test_accumulator_multiplexes_item_ids() -> None:
+    acc = StreamAccumulator()
+    acc.add(IncrementalTokenDelta(text="a", item_id="x"))
+    acc.add(IncrementalTokenDelta(text="b", item_id="y"))
+    out = acc.result()
+    assert out.texts == {"x": "a", "y": "b"}
+    assert out.text == ""
+
+
+def test_accumulator_batch_items_with_chunks_and_errors() -> None:
+    acc = StreamAccumulator()
+    acc.add(BatchItemDelta(index=0, item_id="a", chunk=b"cap", content_type="text/plain"))
+    acc.add(BatchItemDelta(index=0, item_id="a", chunk=b"tion", finished=True,
+                           content_type="text/plain"))
+    acc.add(BatchItemDelta(index=1, item_id="b", error="boom", finished=True))
+    out = acc.result()
+    assert out is not None and len(out.items) == 2
+    assert out.items[0].content == "caption" and out.items[0].content_type == "text/plain"
+    assert out.items[1].error == "boom"
+
+
+def test_accumulator_caps_content_not_metadata() -> None:
+    acc = StreamAccumulator(max_bytes=4)
+    acc.add(BatchItemDelta(index=0, chunk=b"12345678", finished=True))
+    out = acc.result()
+    assert out is not None and out.truncated
+    assert out.items[0].content == b""  # metadata survives, content dropped
+
+
+def test_accumulator_empty_stream_returns_none() -> None:
+    assert StreamAccumulator().result() is None
+
+
+def test_stream_mode_terminal_output_retrievable() -> None:
+    """gw#475: a completed stream request's JobResult carries the aggregate."""
+    from gen_worker.executor import Executor
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+    from gen_worker.registry import EndpointSpec
+
+    class _In(msgspec.Struct):
+        prompt: str = "hi"
+
+    def _gen(ctx, payload: _In) -> Iterator[IncrementalTokenDelta]:
+        yield IncrementalTokenDelta(text="to")
+        yield IncrementalTokenDelta(text="ken")
+        yield TokenUsage(prompt_tokens=1, completion_tokens=2, tokens_per_second=9.0)
+
+    async def _go() -> List:
+        sent: List = []
+
+        async def _send(msg) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(name="fn", method=_gen, kind="inference",
+                            payload_type=_In, output_mode="stream")
+        ex = Executor([spec], _send)
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="fn",
+            input_payload=msgspec.msgpack.encode(_In())))
+        job = ex.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        return sent
+
+    sent = asyncio.run(_go())
+    chunks = [m.job_progress for m in sent if m.WhichOneof("msg") == "job_progress"]
+    assert [c.data for c in chunks if c.content_type == "text/plain"] == [b"to", b"ken"]
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+    out = msgspec.msgpack.decode(results[-1].inline, type=StreamResult)
+    assert out.text == "token"
+    assert out.usage is not None
+    assert out.usage.prompt_tokens == 1 and out.usage.completion_tokens == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: real llama-server, tiny real GGUF, CPU inference.
+# ---------------------------------------------------------------------------
+
+_TINY_REPO = "ggml-org/models-moved"
+_TINY_FILE = "tinyllamas/stories15M-q4_0.gguf"
+
+
+def _llama_bin() -> str | None:
+    env = os.environ.get("GEN_WORKER_LLAMA_SERVER_BIN", "")
+    if env and Path(env).is_file():
+        return env
+    return shutil.which("llama-server")
+
+
+needs_llama = pytest.mark.skipif(
+    _llama_bin() is None,
+    reason="llama-server binary not found (PATH or GEN_WORKER_LLAMA_SERVER_BIN)",
+)
+
+
+@pytest.fixture(scope="session")
+def tiny_gguf_dir(tmp_path_factory) -> Path:
+    from gen_worker.net import hf
+
+    path = hf().hf_hub_download(repo_id=_TINY_REPO, filename=_TINY_FILE)
+    snap = tmp_path_factory.mktemp("gguf-snap")
+    (snap / Path(_TINY_FILE).name).symlink_to(path)
+    return snap
+
+
+@pytest.fixture()
+def llama_path(monkeypatch) -> None:
+    bin_path = _llama_bin()
+    assert bin_path is not None
+    monkeypatch.setenv("PATH", f"{Path(bin_path).parent}:{os.environ.get('PATH', '')}")
+
+
+@needs_llama
+@pytest.mark.integration
+def test_real_server_stream_and_usage(tiny_gguf_dir, llama_path) -> None:
+    handle = llama_server(str(tiny_gguf_dir), boot_timeout_s=120).start()
+    try:
+        deltas = list(completion_deltas(
+            handle, "Once upon a time", max_tokens=16, temperature=0.0))
+        text = "".join(d.text for d in deltas if isinstance(d, IncrementalTokenDelta))
+        assert text.strip()
+        usages = [d for d in deltas if isinstance(d, TokenUsage)]
+        assert len(usages) == 1
+        u = usages[0]
+        assert u.prompt_tokens > 0
+        assert 0 < u.completion_tokens <= 20
+        assert u.tokens_per_second > 0
+
+        chat = list(chat_deltas(
+            handle, [{"role": "user", "content": "Tell me a story."}],
+            max_tokens=8, temperature=0.0))
+        assert any(isinstance(d, IncrementalTokenDelta) and d.text for d in chat)
+        assert isinstance(chat[-1], TokenUsage)
+    finally:
+        handle.stop()
+    assert not handle.alive
+
+
+@needs_llama
+@pytest.mark.integration
+def test_real_server_terminal_output_via_executor(tiny_gguf_dir, llama_path) -> None:
+    """Full pump path against a live llama-server: live chunks AND a
+    retrievable terminal StreamResult with sane token counts."""
+    from gen_worker.executor import Executor
+    from gen_worker.pb import worker_scheduler_pb2 as pb
+    from gen_worker.registry import EndpointSpec
+
+    handle = llama_server(str(tiny_gguf_dir), boot_timeout_s=120).start()
+
+    class _In(msgspec.Struct):
+        prompt: str = "Once upon a time"
+
+    def _complete(ctx, payload: _In) -> Iterator[IncrementalTokenDelta]:
+        yield from completion_deltas(
+            handle, payload.prompt, max_tokens=12, temperature=0.0,
+            cancelled=lambda: ctx.cancelled)
+
+    async def _go() -> List:
+        sent: List = []
+
+        async def _send(msg) -> None:
+            sent.append(msg)
+
+        spec = EndpointSpec(name="complete", method=_complete, kind="inference",
+                            payload_type=_In, output_mode="stream")
+        ex = Executor([spec], _send)
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="complete",
+            input_payload=msgspec.msgpack.encode(_In())))
+        job = ex.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        return sent
+
+    try:
+        sent = asyncio.run(_go())
+    finally:
+        handle.stop()
+
+    live = b"".join(
+        m.job_progress.data for m in sent
+        if m.WhichOneof("msg") == "job_progress"
+        and m.job_progress.content_type == "text/plain")
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+    assert results and results[-1].status == pb.JOB_STATUS_OK
+    out = msgspec.msgpack.decode(results[-1].inline, type=StreamResult)
+    assert out.text and out.text.encode() == live  # terminal == what streamed
+    assert out.usage is not None and out.usage.completion_tokens > 0
+
+
+@needs_llama
+@pytest.mark.integration
+def test_real_gguf_header_info(tiny_gguf_dir) -> None:
+    info = read_gguf_info(resolve_gguf(tiny_gguf_dir))
+    assert info.architecture == "llama"
+    assert info.n_layers > 0 and info.size_bytes > 1_000_000
+    plan = plan_fit(info, free_vram_gb=80.0)
+    assert plan.n_gpu_layers == info.n_layers + 1
+
+
+# ---------------------------------------------------------------------------
+# GPU smoke (nightly lane): CUDA llama-server build required.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.environ.get("GEN_WORKER_GPU_SMOKE") != "1",
+                    reason="GPU smoke runs on the nightly GPU CI lane")
+@needs_llama
+@pytest.mark.integration
+def test_gpu_smoke_offload_and_measured_vram(tiny_gguf_dir, llama_path) -> None:
+    from gen_worker.runtimes.server import process_vram_bytes
+
+    boot = llama_server(str(tiny_gguf_dir), boot_timeout_s=300)
+    handle = boot.start()
+    try:
+        deltas = list(completion_deltas(handle, "Once", max_tokens=4, temperature=0.0))
+        assert any(isinstance(d, IncrementalTokenDelta) and d.text for d in deltas)
+        assert process_vram_bytes(handle.process.pid) > 0
+    finally:
+        handle.stop()


### PR DESCRIPTION
Implements the LLM/llama.cpp lane of the GGUF revival (gw#402): GGUF checkpoints served through llama-server as a first-class gen-worker runtime.

## Runtime choice
llama-server subprocess (no Python binding dep). llama-cpp-python rejected: no cu128 wheel in the official index, lags llama.cpp for new archs, and MTP speculative decoding (qwen3.6-27b-mtp-gguf) is llama-server-only. The fleet image policy already carries the Paul-approved native-build exception compiling llama.cpp with SM_TARGET.

## What's new
- **runtimes/llama.py** — GGUF resolution (Hub() snapshot dir → single .gguf; split shards = one model; multiple quants fail closed), header introspection via the `gguf` core dep, `plan_fit` (fit ladder: -ngl/-c sized to free VRAM, floor 0 GPU layers, never a crash), torch-free VRAM probe (nvidia-smi fallback for binding-less serve images), and `chat_deltas`/`completion_deltas` sync-generator clients yielding `IncrementalTokenDelta` then one `TokenUsage`.
- **runtimes/server.py** — `llama_server()` accepts dirs, auto-sizes `-ngl` unless caller-pinned, boots through a `DegradingBoot` ladder (planned → half → CPU-only); `process_vram_bytes(pid)` measures engine-subprocess VRAM.
- **gw#475 fixed** — stream-mode requests now finish with a terminal `StreamResult` (accumulated token text, per-item_id texts, batch items, usage) serialized as the JobResult output. Live deltas stay a streaming optimization; the completed request is retrievable and billable (`usage.prompt_tokens`/`completion_tokens`/`tokens_per_second`).
- **Residency** — measured engine-subprocess VRAM is booked into the ledger (object-less, non-movable); LRU eviction reclaims via record teardown → server stop. UNLOAD works the same way.
- **Discovery** — unchanged/CPU-only clean: no heavy imports at module scope.

## Tests (real codepaths, no mocks)
- Real llama-server (pinned b9964 CPU build, installed by CI) + real tiny GGUF (ggml-org stories15M-q4_0, 19MB): boot from snapshot dir, streamed completion + chat, usage token counts sane, terminal StreamResult via the actual executor pump equal to the streamed bytes.
- Unit: resolution edge cases, fit-plan math (monotonic, clamped, never negative), accumulator semantics incl. content cap, degrade-ladder shape, gw#475 executor test.
- GPU smoke env-gated (GEN_WORKER_GPU_SMOKE) for the nightly lane.
- Full suite: 840 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)