### PR TITLE
gw#479: content-keyed shared components + transformer lanes (0.13.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.13.25 (2026-07-11)
+
+- **gw#479: content-keyed shared components + transformer lanes.**
+  `LoadedComponentKey` identity is now the component's CONTENT — the sorted
+  blake3 digest set of its files (`content_set_digest`) plus load facts
+  (dtype, quant/storage_dtype + config digest, device, placement, component
+  name, adapter overlay). ref/revision drop out of identity (readable label
+  only), so byte-identical components mirrored under different Hub refs
+  share ONE in-memory copy. Executor: class records binding 2+ pipeline
+  slots get lane loading — the shared set loads once via `acquire_shared`
+  (VRAM counted once, refcount-held), later slots inject the same module
+  objects into `from_pretrained` and load only exclusive weights; each
+  lane's residency entry is its exclusive module set, so the existing
+  make_room/LRU ladder swaps ONLY the transformer (dual-resident when the
+  budget admits, swap-mode otherwise). New `@endpoint(route=)`:
+  `route(payload) -> slot names` makes per-request promote/pin selective —
+  swap-mode lanes never thrash both transformers. Telemetry: promote/demote
+  are timed + counted per entry (`Residency.transition_stats()`); wire
+  `ModelEvent.duration_ms` now carries swap walls; lanes appear as distinct
+  refs in `Hello.models`. `apply_fp8_storage` is idempotent per module
+  (shared injected modules are never double-hooked).
+  `load_from_pretrained(components=)` forwards preloaded modules. Offload
+  placement and sharing are mutually exclusive (guarded, monolithic
+  fallback). Sharing engages only when wire snapshots carry digests and
+  keys collide; single-slot records are byte-for-byte unchanged.
+
 ## 0.13.23 (2026-07-11)
 
 - **th#721: adaptive RAM tier — host-RAM probes are cgroup-aware.**

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -108,6 +108,29 @@ is stamped only when the class declares `model=`/`models=`. If your payload
 echoes the variant in a `variant` field, type it `Literal[...]` — members are
 validated against the declared variants at import time.
 
+## Lanes: multi-model classes with input routing (gw#479)
+
+A class binding 2+ pipeline slots whose snapshots share byte-identical
+components (content-keyed by the files' blake3 digests) loads the shared set
+ONCE; each slot's exclusive weights (its transformer) are an independent
+residency entry the worker LRU-swaps under VRAM pressure. Declare `route=`
+so only the lane a request needs is promoted/pinned:
+
+```python
+def _route(p: In) -> tuple[str, ...]:
+    return ("edit",) if p.images else ("t2i",)
+
+@endpoint(models={"t2i": Hub("org/base"), "edit": Hub("org/edit")}, route=_route)
+class Generate:
+    def setup(self, t2i: QwenImagePipeline, edit: QwenImageEditPlusPipeline): ...
+    def generate(self, ctx, p: In) -> Out: ...  # picks self.t2i / self.edit
+```
+
+The handler must only touch the lane(s) `route` named — the idle lane may be
+warm in host RAM. This mechanism COMPENSATES for split-vendor base+edit
+releases (Qwen, HiDream, Wan t2v/i2v); unified models (one transformer doing
+t2i + edit) need no lanes — bind one model and skip `route=`.
+
 ## Resources
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.24"
+version = "0.13.25"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -171,6 +171,11 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     name: Optional[str] = None  # function-shaped endpoints only
     is_function: bool = False
     compile: Optional[Compile] = None
+    # Payload-driven slot routing (gw#479): ``route(payload) -> slot names``
+    # the request actually needs. The executor promotes/pins only those
+    # slots, so multi-lane classes (two transformers over one shared
+    # encoder) swap the idle lane instead of thrashing both per request.
+    route: Optional[Callable[[Any], Sequence[str]]] = None
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -412,6 +417,7 @@ def _decorate_class(
     variants: Optional[Mapping[str, Any]],
     runtime: Optional[str],
     compile: Optional[Compile] = None,
+    route: Optional[Callable[[Any], Sequence[str]]] = None,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -437,10 +443,21 @@ def _decorate_class(
             f"@endpoint class {cls.__name__!r}: runtime must be 'vllm' or "
             f"'llama-server', got {runtime!r}"
         )
+    if route is not None:
+        if not callable(route):
+            raise TypeError(
+                f"@endpoint class {cls.__name__!r}: route= must be callable "
+                f"(payload -> model slot names), got {type(route).__name__}"
+            )
+        if len(models) < 2:
+            raise ValueError(
+                f"@endpoint class {cls.__name__!r}: route= needs 2+ model "
+                f"slots to route between (declared {sorted(models) or 'none'})"
+            )
 
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models,
-        variants=variant_rows, runtime=runtime, compile=compile,
+        variants=variant_rows, runtime=runtime, compile=compile, route=route,
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
@@ -494,6 +511,7 @@ def endpoint(
     runtime: Optional[str] = None,
     name: Optional[str] = None,
     compile: Optional[Compile] = None,
+    route: Optional[Callable[[Any], Sequence[str]]] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes."""
     if kind not in KINDS:
@@ -516,13 +534,18 @@ def endpoint(
                                  "class handlers route by method name")
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=model_map,
-                variants=variants, runtime=runtime, compile=compile,
+                variants=variants, runtime=runtime, compile=compile, route=route,
             )
         if inspect.isfunction(obj):
             if variants:
                 raise ValueError(
                     f"@endpoint function {obj.__name__!r}: variants= requires a "
                     "class (each variant needs its own setup state)."
+                )
+            if route is not None:
+                raise ValueError(
+                    f"@endpoint function {obj.__name__!r}: route= requires a "
+                    "class with setup() (slot routing selects among loaded lanes)."
                 )
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -392,13 +392,19 @@ class ModelStore:
         except RuntimeError:
             pass
 
-    def _on_residency_event(self, ref: str, state: str, vram_bytes: int) -> None:
+    def _on_residency_event(
+        self, ref: str, state: str, vram_bytes: int, duration_ms: int = 0
+    ) -> None:
         pb_state = _RESIDENCY_STATE_TO_PB.get(state)
         if pb_state is None:
             return
         kw: Dict[str, Any] = {}
         if state == residency_mod.IN_VRAM:
             kw["vram_bytes"] = int(vram_bytes)
+        if duration_ms > 0:
+            # Swap telemetry (gw#479): promote/demote wall time rides the
+            # existing ModelEvent.duration_ms field.
+            kw["duration_ms"] = int(duration_ms)
         coro = self._event(ref, pb_state, **kw)
         try:
             loop = asyncio.get_running_loop()
@@ -428,6 +434,45 @@ class ModelStore:
         """A digest-carrying snapshot for ``ref`` was seen this connection
         (gw#465): snapshot-less ops for it can still materialize the bytes."""
         return ref in self._snapshots
+
+    def component_digests(self, ref: str) -> Dict[str, str]:
+        """Per-component content identity of ``ref``'s snapshot (gw#479):
+        ``{top_level_subfolder: content_set_digest}`` derived from the wire
+        snapshot's per-file blake3 digests. Root-level files group under
+        ``""`` (never shared — model_index.json etc. differ per repo).
+        Empty when no digest-carrying snapshot was seen — content-keyed
+        sharing then stays off; the loader never hashes snapshots itself."""
+        snap = self._snapshots.get(ref)
+        if snap is None:
+            return {}
+        groups: Dict[str, Dict[str, str]] = {}
+        for f in snap.files:
+            rel = str(f.path).strip().lstrip("/")
+            if not rel or not f.blake3:
+                continue
+            comp, _, rest = rel.partition("/")
+            if not rest:
+                comp, rest = "", rel
+            groups.setdefault(comp, {})[rest] = str(f.blake3)
+        return {c: residency_mod.content_set_digest(files)
+                for c, files in groups.items()}
+
+    def component_sizes(self, ref: str) -> Dict[str, int]:
+        """Per-top-level-subfolder byte totals of ``ref``'s snapshot (gw#479):
+        the make_room estimate for loading a subset of components."""
+        snap = self._snapshots.get(ref)
+        if snap is None:
+            return {}
+        sizes: Dict[str, int] = {}
+        for f in snap.files:
+            rel = str(f.path).strip().lstrip("/")
+            if not rel:
+                continue
+            comp, _, rest = rel.partition("/")
+            if not rest:
+                comp = ""
+            sizes[comp] = sizes.get(comp, 0) + int(f.size_bytes)
+        return sizes
 
     # ---- disk retention (#370) ------------------------------------------------
 
@@ -755,6 +800,29 @@ class _ClassRecord:
     ready: bool = False
     failed: Optional[str] = None
     lock: asyncio.Lock = dc_field(default_factory=asyncio.Lock)
+    # Content-keyed shared components this record holds (gw#479): released
+    # (refcount--) at vacate so the entries become LRU/drain candidates.
+    shared_keys: List[Any] = dc_field(default_factory=list)
+
+
+def _shared_loader_must_hit() -> Any:
+    """acquire_shared loader for peeked keys (gw#479): the object was seen in
+    the cache under the load lock, so a miss here is a bookkeeping bug."""
+    raise RuntimeError("shared component vanished between peek and acquire")
+
+
+@dataclass
+class _InjectionResult:
+    """What one setup injection produced (gw#479): the setup kwargs, the
+    per-slot residency objects+bytes, which slots were lane-registered
+    inline, the shared keys this record now holds, and the VRAM booked on
+    shared:: entries (counted once, excluded from per-slot residuals)."""
+
+    kwargs: Dict[str, Any]
+    loaded: Dict[str, Tuple[Any, int]]
+    lane_slots: set = dc_field(default_factory=set)
+    shared_keys: List[Any] = dc_field(default_factory=list)
+    shared_bytes: int = 0
 
 
 @dataclass
@@ -1113,14 +1181,19 @@ class Executor:
 
     # ---- setup -------------------------------------------------------------
 
-    async def ensure_setup(self, spec: EndpointSpec, snapshots: Optional[Dict[str, pb.Snapshot]] = None) -> Any:
+    async def ensure_setup(
+        self,
+        spec: EndpointSpec,
+        snapshots: Optional[Dict[str, pb.Snapshot]] = None,
+        promote_slots: Optional[List[str]] = None,
+    ) -> Any:
         if spec.cls is None:
             return None  # function-shaped endpoint: no instance, no setup
         self.store.bind_loop()
         rec = self._classes[spec.instance_key]
         async with rec.lock:
             if rec.ready:
-                await self._promote_setup_refs(spec)
+                await self._promote_setup_refs(spec, promote_slots)
                 return rec.instance
             try:
                 instance = await self._setup_locked(spec, rec, snapshots)
@@ -1180,18 +1253,19 @@ class Executor:
             await self._make_room_for(spec, setup_slots)
             instance = spec.cls()
             setup = getattr(instance, "setup", None)
-            loaded: Dict[str, Tuple[Any, int]] = {}
+            inj = _InjectionResult(kwargs={}, loaded={})
             vram_before = self._vram_allocated()
             if spec.runtime:
                 rec.server = await self._boot_engine_server(spec, paths)
             if callable(setup):
-                kwargs, loaded = await self._injection_kwargs(
+                inj = await self._injection_kwargs(
                     spec, setup, paths, server=rec.server,
                     compile_artifact=compile_artifact, snapshots=snapshots)
+                rec.shared_keys.extend(inj.shared_keys)
                 if asyncio.iscoroutinefunction(setup):
-                    await setup(**kwargs)
+                    await setup(**inj.kwargs)
                 else:
-                    await asyncio.to_thread(setup, **kwargs)
+                    await asyncio.to_thread(setup, **inj.kwargs)
             warmup = getattr(instance, "warmup", None)
             if callable(warmup):
                 from . import compile_cache
@@ -1212,7 +1286,9 @@ class Executor:
                         stats.get("fxgraph_cache_miss", 0),
                         time.monotonic() - warm_t0)
             vram_delta = max(0, self._vram_allocated() - vram_before)
-            self._register_residency(spec, setup_slots, loaded, vram_delta)
+            self._register_residency(
+                spec, setup_slots, inj.loaded, vram_delta,
+                lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes)
         return instance
 
     def _register_residency(
@@ -1221,20 +1297,31 @@ class Executor:
         setup_slots: List[str],
         loaded: Dict[str, Tuple[Any, int]],
         total_delta: int,
+        *,
+        lane_slots: Optional[set] = None,
+        shared_bytes: int = 0,
     ) -> None:
         """Honest per-ref residency after a setup (#369). Worker-constructed
         pipelines carry their own measured allocator delta AND the object
         (Residency owns it: demote/promote actually move memory). Refs the
         tenant loaded inside setup() split the residual delta — no object,
-        so their VRAM is only reclaimable by record teardown."""
+        so their VRAM is only reclaimable by record teardown. Lane slots
+        (gw#479) were registered inline during injection — their bytes and
+        the shared-entry bytes still reduce the residual, but re-tracking
+        them here would clobber a mid-setup demotion."""
         res = self.store.residency
+        lanes = lane_slots or set()
         per_ref: Dict[str, Tuple[Any, int]] = {}
         for slot in setup_slots:
+            if slot in lanes:
+                continue
             ref = wire_ref(spec.models[slot])
             obj, measured = loaded.get(slot, (None, 0))
             prev_obj, prev_bytes = per_ref.get(ref, (None, 0))
             per_ref[ref] = (obj or prev_obj, prev_bytes + measured)
-        residual = max(0, total_delta - sum(b for _, b in per_ref.values()))
+        lane_bytes = sum(loaded[s][1] for s in lanes if s in loaded)
+        residual = max(0, total_delta - sum(b for _, b in per_ref.values())
+                       - lane_bytes - max(0, int(shared_bytes)))
         opaque = [r for r, (obj, _) in per_ref.items() if obj is None]
         share = residual // len(opaque) if opaque else 0
         for ref, (obj, measured) in per_ref.items():
@@ -1246,11 +1333,18 @@ class Executor:
             else:
                 res.track_ram(ref, obj)   # CPU-only host / offloaded load
 
-    async def _promote_setup_refs(self, spec: EndpointSpec) -> None:
+    async def _promote_setup_refs(
+        self, spec: EndpointSpec, slots: Optional[List[str]] = None
+    ) -> None:
         """RunJob/LOAD for a demoted (RAM-tier) instance: swap the pipelines
-        back into VRAM instead of a cold reload (#371)."""
+        back into VRAM instead of a cold reload (#371). ``slots`` narrows the
+        promote to the lanes a routed request needs (gw#479) — promoting an
+        idle lane would thrash swap-mode records on every request."""
         res = self.store.residency
-        refs = [wire_ref(spec.models[s]) for s in self._setup_slots(spec)]
+        setup_slots = self._setup_slots(spec)
+        if slots is not None:
+            setup_slots = [s for s in setup_slots if s in slots]
+        refs = [wire_ref(spec.models[s]) for s in setup_slots]
         cuda_host = torch is not None and torch.cuda.is_available()
         if any(res.tier(r) is residency_mod.Tier.RAM for r in refs):
             async with self._load_lock:
@@ -1418,6 +1512,65 @@ class Executor:
                 )
         return None
 
+    def _component_share_plan(
+        self, spec: EndpointSpec, paths: Dict[str, str], hints: Dict[str, Any]
+    ) -> Optional[Dict[str, Dict[str, Any]]]:
+        """Content-keyed shared-component plan for a multi-lane record
+        (gw#479): ``{slot: {component: LoadedComponentKey}}`` restricted to
+        components whose CONTENT key appears under 2+ pipeline slots. None
+        when the record has <2 pipeline slots, digests are unavailable, or
+        nothing is byte-identical — loading then stays monolithic."""
+        pipe_slots = [
+            s for s in paths
+            if isinstance(hints.get(s), type)
+            and callable(getattr(hints[s], "from_pretrained", None))
+        ]
+        if len(pipe_slots) < 2:
+            return None
+        keys: Dict[str, Dict[str, Any]] = {}
+        for slot in pipe_slots:
+            binding = spec.models.get(slot)
+            if binding is None:
+                return None
+            ref = wire_ref(binding)
+            digests = self.store.component_digests(ref)
+            keys[slot] = {
+                comp: residency_mod.LoadedComponentKey.for_component(
+                    content_digest=digest, component=comp, binding=binding,
+                    label=f"{ref}/{comp}",
+                )
+                for comp, digest in digests.items() if comp
+            }
+        counts: Dict[Any, int] = {}
+        for slot_keys in keys.values():
+            for k in slot_keys.values():
+                counts[k] = counts.get(k, 0) + 1
+        plan = {
+            slot: {c: k for c, k in slot_keys.items() if counts[k] >= 2}
+            for slot, slot_keys in keys.items()
+        }
+        if not any(plan.values()):
+            return None
+        shared = sorted({c for m in plan.values() for c in m})
+        logger.info(
+            "content-keyed lanes for %s: shared components %s across %d slots",
+            spec.name, shared, len(pipe_slots),
+        )
+        return plan
+
+    @staticmethod
+    def _model_index_components(path: str) -> set:
+        """Component names the snapshot's model_index.json declares — the
+        only names safe to pass as preloaded modules to from_pretrained."""
+        try:
+            import json
+
+            with open(Path(path) / "model_index.json", "r", encoding="utf-8") as f:
+                index = json.load(f)
+            return {k for k in index if not k.startswith("_")}
+        except Exception:
+            return set()
+
     async def _injection_kwargs(
         self,
         spec: EndpointSpec,
@@ -1427,7 +1580,7 @@ class Executor:
         server: Any = None,
         compile_artifact: Optional[Path] = None,
         snapshots: Optional[Dict[str, pb.Snapshot]] = None,
-    ) -> Tuple[Dict[str, Any], Dict[str, Tuple[Any, int]]]:
+    ) -> "_InjectionResult":
         """Typed injection: each slot receives exactly what its ``setup``
         annotation says — a ``str``/``Path`` local path, or a constructed
         pipeline for a class annotation exposing ``from_pretrained`` (built off
@@ -1435,9 +1588,14 @@ class Executor:
         placement/offload policy to the result). A parameter annotated
         ``ServerHandle`` receives the booted engine server.
 
-        Returns ``(kwargs, loaded)`` where ``loaded`` maps each pipeline slot
-        to ``(pipeline, allocator_delta)`` — the per-ref measurement residency
-        books (#369; caller holds the load lock)."""
+        Multi-lane records (gw#479): when 2+ pipeline slots carry
+        byte-identical components (content keys), the first lane loads them
+        and registers them in the shared cache; later lanes inject the very
+        same module objects into ``from_pretrained`` and load only their
+        exclusive weights. Each lane's residency entry is then the exclusive
+        module set — LRU swap moves ONLY the transformer, never the shared
+        encoder. Lane slots are residency-registered inline (per slot) so
+        make_room can demote lane N-1 while lane N loads."""
         from .runtimes.server import ServerHandle
 
         try:
@@ -1446,6 +1604,8 @@ class Executor:
             hints = {}
         kwargs: Dict[str, Any] = {}
         loaded: Dict[str, Tuple[Any, int]] = {}
+        result = _InjectionResult(kwargs=kwargs, loaded=loaded)
+        share_plan = self._component_share_plan(spec, paths, hints)
         if server is not None:
             for pname, ann in hints.items():
                 if ann is ServerHandle:
@@ -1463,35 +1623,6 @@ class Executor:
                 binding = spec.models.get(slot)
                 dtype = str(getattr(binding, "dtype", "") or "")
                 storage_dtype = str(getattr(binding, "storage_dtype", "") or "")
-                before = self._vram_allocated()
-                try:
-                    pipe = await asyncio.to_thread(
-                        load_from_pretrained, ann, path, dtype=dtype,
-                        storage_dtype=storage_dtype,
-                    )
-                except Exception as exc:
-                    # Corruption-shaped load failure (gw#408): digest-verify
-                    # the snapshot; quarantine + re-materialize + retry ONCE
-                    # when corruption is confirmed, re-raise otherwise.
-                    fresh: Optional[Path] = None
-                    if binding is not None and _is_corrupt_load_error(exc):
-                        ref = wire_ref(binding)
-                        fresh = await self.store.refetch_corrupt(
-                            ref, (snapshots or {}).get(ref), binding=binding
-                        )
-                    if fresh is None:
-                        raise
-                    logger.warning(
-                        "weights load for slot %r failed on a corrupt snapshot "
-                        "(%s: %s); retrying once after re-materialization",
-                        slot, type(exc).__name__, exc,
-                    )
-                    path = str(fresh)
-                    paths[slot] = path
-                    pipe = await asyncio.to_thread(
-                        load_from_pretrained, ann, path, dtype=dtype,
-                        storage_dtype=storage_dtype,
-                    )
                 # Worker-owned placement/offload policy: one decider for the
                 # whole worker; endpoints never write device/offload code.
                 # Plan-time offload verdicts and the learned degraded floor
@@ -1508,6 +1639,63 @@ class Executor:
                 floor = self.degraded_floor.get(ref, "")
                 if floor:
                     mode = deeper_offload_mode("" if mode == "auto" else mode, floor)
+                slot_share = dict((share_plan or {}).get(slot) or {})
+                if slot_share and mode != "auto":
+                    # Offload hooks on a shared module would poison sibling
+                    # lanes; a planned-offload record loads monolithically.
+                    logger.warning(
+                        "content-keyed sharing disabled for %s slot %s: "
+                        "placement mode %s", spec.name, slot, mode)
+                    slot_share = {}
+                res = self.store.residency
+                injected: Dict[str, Any] = {}
+                if slot_share:
+                    valid = self._model_index_components(path)
+                    for comp, key in list(slot_share.items()):
+                        if comp not in valid:
+                            del slot_share[comp]
+                            continue
+                        if res.shared_obj(key) is not None:
+                            injected[comp] = res.acquire_shared(
+                                key, _shared_loader_must_hit)
+                            result.shared_keys.append(key)
+                    # Exclusive-weights headroom BEFORE the load: demote idle
+                    # LRU lanes now so placement never has to walk the
+                    # offload ladder mid-lane (dual-resident when the budget
+                    # admits, swap-mode otherwise — existing make_room path).
+                    sizes = self.store.component_sizes(ref)
+                    excl_bytes = sum(
+                        b for comp, b in sizes.items() if comp not in injected)
+                    if excl_bytes > 0:
+                        await asyncio.to_thread(res.make_room, excl_bytes)
+                before = self._vram_allocated()
+                try:
+                    pipe = await asyncio.to_thread(
+                        load_from_pretrained, ann, path, dtype=dtype,
+                        storage_dtype=storage_dtype, components=injected,
+                    )
+                except Exception as exc:
+                    # Corruption-shaped load failure (gw#408): digest-verify
+                    # the snapshot; quarantine + re-materialize + retry ONCE
+                    # when corruption is confirmed, re-raise otherwise.
+                    fresh: Optional[Path] = None
+                    if binding is not None and _is_corrupt_load_error(exc):
+                        fresh = await self.store.refetch_corrupt(
+                            ref, (snapshots or {}).get(ref), binding=binding
+                        )
+                    if fresh is None:
+                        raise
+                    logger.warning(
+                        "weights load for slot %r failed on a corrupt snapshot "
+                        "(%s: %s); retrying once after re-materialization",
+                        slot, type(exc).__name__, exc,
+                    )
+                    path = str(fresh)
+                    paths[slot] = path
+                    pipe = await asyncio.to_thread(
+                        load_from_pretrained, ann, path, dtype=dtype,
+                        storage_dtype=storage_dtype, components=injected,
+                    )
                 placed = await asyncio.to_thread(place_pipeline, pipe, mode=mode, ref=ref)
                 if placed.get("oom_demotions"):
                     self._record_demotion(
@@ -1517,6 +1705,11 @@ class Executor:
                         needed_gb=estimate_pipeline_size_gb(pipe),
                         detail="CUDA OOM at load; pipeline placed offloaded",
                     )
+                if slot_share and str(placed.get("mode") or "") not in ("", "off", "cpu"):
+                    raise RetryableError(
+                        f"lane {slot!r} of {spec.name} placed "
+                        f"{placed.get('mode')!r}: shared-component lanes "
+                        "require resident placement; retrying")
                 if spec.compile is not None:
                     # Opt-in acceleration against a pre-built per-SKU artifact:
                     # a TRT engine (#390, refit with this pipeline's weights)
@@ -1525,11 +1718,71 @@ class Executor:
                     await asyncio.to_thread(
                         self._enable_compiled, pipe, spec.compile, compile_artifact,
                     )
-                loaded[slot] = (pipe, max(0, self._vram_allocated() - before))
+                delta = max(0, self._vram_allocated() - before)
+                if slot_share:
+                    lane_obj, lane_bytes = self._register_lane(
+                        slot, ref, pipe, slot_share, injected, delta, result)
+                    loaded[slot] = (lane_obj, lane_bytes)
+                    result.lane_slots.add(slot)
+                else:
+                    loaded[slot] = (pipe, delta)
                 kwargs[slot] = pipe
             else:
                 kwargs[slot] = path
-        return kwargs, loaded
+        return result
+
+    def _register_lane(
+        self,
+        slot: str,
+        ref: str,
+        pipe: Any,
+        slot_share: Dict[str, Any],
+        injected: Dict[str, Any],
+        delta: int,
+        result: "_InjectionResult",
+    ) -> Tuple[Any, int]:
+        """Book one lane's residency (gw#479): freshly loaded shared
+        components go into the content-keyed cache (VRAM counted once, held
+        by refcount); the lane's own entry is its EXCLUSIVE module set, so
+        LRU demote/promote swaps only lane-owned weights (the transformer),
+        never the shared encoder."""
+        import torch.nn as nn
+
+        res = self.store.residency
+        fresh_bytes = 0
+        for comp, key in slot_share.items():
+            if comp in injected:
+                continue
+            module = getattr(pipe, comp, None)
+            if module is None:
+                continue
+            measured = 0
+            if isinstance(module, nn.Module):
+                measured = int(estimate_cuda_resident_gb(module) * _GiB)
+            res.acquire_shared(key, lambda m=module: m, vram_bytes=measured)
+            result.shared_keys.append(key)
+            fresh_bytes += measured
+        comps = getattr(pipe, "components", None) or {}
+        exclusive = {
+            name: m for name, m in comps.items()
+            if isinstance(m, nn.Module) and name not in slot_share
+        }
+        lane_obj: Any = nn.ModuleDict(exclusive) if exclusive else pipe
+        lane_bytes = max(0, delta - fresh_bytes)
+        result.shared_bytes += fresh_bytes
+        logger.info(
+            "lane %s (%s): exclusive %s (%.2f GiB), shared %s (%.2f GiB %s)",
+            slot, ref, sorted(exclusive) or ["<none>"], lane_bytes / _GiB,
+            sorted(slot_share), fresh_bytes / _GiB,
+            "fresh" if fresh_bytes else "reused",
+        )
+        if lane_bytes > 0:
+            res.track_vram(ref, lane_obj, vram_bytes=lane_bytes)
+        elif int(estimate_cuda_resident_gb(lane_obj) * _GiB) > 0:
+            res.track_vram(ref, lane_obj)
+        else:
+            res.track_ram(ref, lane_obj)
+        return lane_obj, lane_bytes
 
     def _enable_compiled(self, pipe: Any, cfg: Any, artifact: Optional[Path]) -> bool:
         """Arm the best available compiled path for a freshly loaded pipeline:
@@ -1851,6 +2104,13 @@ class Executor:
         for s in rec.specs:
             for b in s.models.values():
                 self.store.residency.release_to_disk(wire_ref(b))
+        if rec.shared_keys:
+            # Drop this record's holds on content-keyed shared components
+            # (gw#479); entries no other record references get evicted.
+            for key in rec.shared_keys:
+                self.store.residency.release_shared(key)
+            rec.shared_keys.clear()
+            self.store.residency.drain_shared()
         self._on_state_change()
 
     async def _unload_ref(self, ref: str) -> None:
@@ -1940,25 +2200,52 @@ class Executor:
 
     # ---- job execution -----------------------------------------------------
 
+    def _routed_slots(self, spec: EndpointSpec, payload: Any) -> List[str]:
+        """Model slots this request needs (gw#479). Classes without route=
+        use every declared slot (single-lane behavior, unchanged)."""
+        if spec.route is None or spec.cls is None:
+            return list(spec.models)
+        try:
+            routed = [str(s) for s in spec.route(payload)]
+        except Exception as exc:
+            raise ValidationError(
+                f"route() for {spec.name} failed: {exc}") from exc
+        unknown = [s for s in routed if s not in spec.models]
+        if unknown or not routed:
+            raise ValidationError(
+                f"route() for {spec.name} returned {routed!r}; declared model "
+                f"slots are {sorted(spec.models)}")
+        return routed
+
     async def _run_job(self, job: _Job, run: pb.RunJob) -> None:
         spec = job.spec
         assert spec is not None
-        # Pin this job's model refs for its WHOLE lifetime (gw#409): the gap
-        # between ensure_setup's promote and the execution-time pin let a
-        # concurrent job's make_room demote a just-promoted pipeline. Refs
-        # without entries yet are no-ops; the inner pin still covers adapters.
-        with self.store.residency.executing(*(wire_ref(b) for b in spec.models.values())):
-            await self._run_job_pinned(job, run)
-
-    async def _run_job_pinned(self, job: _Job, run: pb.RunJob) -> None:
-        spec = job.spec
-        assert spec is not None
-        concurrency_at_start = len(self.in_flight_keys()) - 1
+        # Decode BEFORE pinning: payload-driven routing (gw#479) decides which
+        # lanes this job pins/promotes — pinning an idle lane would block the
+        # make_room swap that promoting the routed lane needs.
         try:
             payload = msgspec.msgpack.decode(run.input_payload, type=spec.payload_type)
         except (msgspec.ValidationError, msgspec.DecodeError) as exc:
             await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
             return
+        try:
+            routed = self._routed_slots(spec, payload)
+        except ValidationError as exc:
+            await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
+            return
+        # Pin this job's model refs for its WHOLE lifetime (gw#409): the gap
+        # between ensure_setup's promote and the execution-time pin let a
+        # concurrent job's make_room demote a just-promoted pipeline. Refs
+        # without entries yet are no-ops; the inner pin still covers adapters.
+        with self.store.residency.executing(*(wire_ref(spec.models[s]) for s in routed)):
+            await self._run_job_pinned(job, run, payload, routed)
+
+    async def _run_job_pinned(
+        self, job: _Job, run: pb.RunJob, payload: Any, routed: List[str]
+    ) -> None:
+        spec = job.spec
+        assert spec is not None
+        concurrency_at_start = len(self.in_flight_keys()) - 1
 
         snapshots = dict(run.snapshots) if run.snapshots else {}
         compute = run.compute if run.HasField("compute") else None
@@ -2037,7 +2324,7 @@ class Executor:
             # Typed media inputs: URL-ref Assets (hub-approved remote media)
             # are downloaded and given a local_path before the handler runs.
             await asyncio.to_thread(materialize_input_assets, payload, run.request_id)
-            instance = await self.ensure_setup(spec, snapshots)
+            instance = await self.ensure_setup(spec, snapshots, promote_slots=routed)
             kwargs = await self._handler_kwargs(spec, snapshots)
             adapters = await self._prepare_adapters(run, spec, snapshots)
         except asyncio.CancelledError:
@@ -2072,8 +2359,9 @@ class Executor:
                     raise CanceledError("canceled")
             started = time.monotonic()
             # Pin-while-executing: the models (and adapter snapshots) this job
-            # uses are not eviction candidates for its duration.
-            exec_refs = [wire_ref(b) for b in spec.models.values()]
+            # uses are not eviction candidates for its duration. Routed lanes
+            # only (gw#479): an idle lane must stay demotable.
+            exec_refs = [wire_ref(spec.models[s]) for s in routed]
             adapter_refs = [a.ref for group in adapters.values() for a in group]
             with self.store.residency.executing(*exec_refs, *adapter_refs):
                 active: List[Tuple[str, Any]] = []

--- a/src/gen_worker/models/__init__.py
+++ b/src/gen_worker/models/__init__.py
@@ -15,6 +15,7 @@ from .download import (
 from .refs import HuggingFaceRef, ParsedModelRef, TensorhubRef, parse_model_ref
 from .residency import (
     LoadedComponentKey,
+    content_set_digest,
     Residency,
     Tier,
     build_function_owned_pipeline,
@@ -36,5 +37,6 @@ __all__ = [
     "Residency",
     "Tier",
     "LoadedComponentKey",
+    "content_set_digest",
     "build_function_owned_pipeline",
 ]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -404,6 +404,11 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
 
     applied = False
     for name, mod in targets:
+        if getattr(mod, "_cozy_fp8_storage_applied", False):
+            # Idempotence (gw#479): a content-shared module injected into a
+            # sibling lane is already armed; double hooks would double-cast.
+            applied = True
+            continue
         try:
             fn = getattr(mod, "enable_layerwise_casting", None)
             if callable(fn):
@@ -411,6 +416,7 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
                 fn(storage_dtype=storage, compute_dtype=compute_dtype)
             else:
                 _apply_transformers_fp8(mod, storage, compute_dtype)
+            mod._cozy_fp8_storage_applied = True
             applied = True
             logger.info("fp8 storage enabled on %s (compute %s)", name, compute_dtype)
         except Exception as exc:
@@ -701,6 +707,7 @@ def load_from_pretrained(
     dtype: str = "",
     attrs: Optional[Dict[str, str]] = None,
     storage_dtype: str = "",
+    components: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
@@ -710,7 +717,10 @@ def load_from_pretrained(
     the compute dtype; ``"fp8+te"`` extends that to the pipeline's text
     encoders (transformers-aware, gw#460). When the snapshot cannot fit free
     VRAM as stored, the adaptive fit ladder engages runtime fp8-E4M3 storage
-    first, then the emergency nf4 rung (automatic on CUDA hosts). Used by the
+    first, then the emergency nf4 rung (automatic on CUDA hosts).
+    ``components`` are PRELOADED module objects (content-keyed shared
+    components, gw#479) forwarded to ``from_pretrained`` — diffusers skips
+    loading those from disk and wires the given objects in. Used by the
     executor to satisfy pipeline-typed ``setup()`` annotations; endpoints may
     also call it."""
     path = str(path)
@@ -723,9 +733,13 @@ def load_from_pretrained(
 
     svdq_art = detect_svdq_artifact(Path(path))
     if svdq_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        if components:
+            logger.warning("preloaded components ignored on the svdq lane")
         return load_svdq_pipeline(cls, Path(path), svdq_art)
     ensure_quant_library_imported(attrs)
     kwargs: Dict[str, Any] = {}
+    if components:
+        kwargs.update(components)
     if dtype:
         try:
             kwargs["torch_dtype"] = get_torch_dtype(dtype)

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -67,7 +67,7 @@ IN_RAM = "in_ram"
 IN_VRAM = "in_vram"
 EVICTED = "evicted"
 
-EventFn = Callable[[str, str, int], None]  # (ref, state, vram_bytes)
+EventFn = Callable[[str, str, int, int], None]  # (ref, state, vram_bytes, duration_ms)
 
 
 class Tier(str, Enum):
@@ -87,6 +87,11 @@ class _Entry:
     pinned: bool = False
     refcount: int = 0            # live executions / shared holders
     last_used: float = field(default_factory=time.monotonic)
+    # Swap telemetry (gw#479): tier-transition counts + last durations.
+    promote_count: int = 0
+    demote_count: int = 0
+    last_promote_ms: int = 0
+    last_demote_ms: int = 0
 
     @property
     def movable(self) -> bool:
@@ -159,11 +164,11 @@ class Residency:
 
     # ---- events -------------------------------------------------------------
 
-    def _emit(self, ref: str, state: str, vram_bytes: int = 0) -> None:
+    def _emit(self, ref: str, state: str, vram_bytes: int = 0, duration_ms: int = 0) -> None:
         if self._on_event is None:
             return
         try:
-            self._on_event(ref, state, int(vram_bytes))
+            self._on_event(ref, state, int(vram_bytes), int(duration_ms))
         except Exception:
             logger.exception("residency event callback failed for %s", ref)
 
@@ -309,6 +314,7 @@ class Residency:
                     ref, need_gb, get_available_ram_gb(), _effective_ram_floor_gb(),
                 )
                 return False
+            t0 = time.monotonic()
             if self.pre_demote is not None:
                 try:
                     self.pre_demote(ref, e.obj)
@@ -318,8 +324,11 @@ class Residency:
                 return False  # entry stays VRAM; object restored to cuda
             e.tier = Tier.RAM
             e.vram_bytes = 0
+            e.demote_count += 1
+            e.last_demote_ms = int((time.monotonic() - t0) * 1000)
+            duration_ms = e.last_demote_ms
         flush_memory()
-        self._emit(ref, IN_RAM)
+        self._emit(ref, IN_RAM, duration_ms=duration_ms)
         return True
 
     def _move_verified(self, obj: Any, device: str, *, ref: str = "") -> bool:
@@ -408,6 +417,7 @@ class Residency:
             # for real headroom instead of 0 (a 0-byte ask promoted 6.9GB
             # pipelines into ~2GB free and OOMed mid-move, gw#409).
             hint = int(estimate_pipeline_size_gb(obj) * _GiB)
+        t0 = time.monotonic()  # swap wall incl. the make_room demote (gw#479)
         self.make_room(hint)
         with self._lock:
             e = self._entries.get(ref)
@@ -419,8 +429,11 @@ class Residency:
             e.vram_bytes = int(estimate_cuda_resident_gb(e.obj) * _GiB) or hint
             e.vram_hint = max(e.vram_hint, e.vram_bytes)
             e.last_used = time.monotonic()
+            e.promote_count += 1
+            e.last_promote_ms = int((time.monotonic() - t0) * 1000)
             measured = e.vram_bytes
-        self._emit(ref, IN_VRAM, measured)
+            duration_ms = e.last_promote_ms
+        self._emit(ref, IN_VRAM, measured, duration_ms=duration_ms)
         return True
 
     def release_to_disk(self, ref: str) -> bool:
@@ -639,6 +652,21 @@ class Residency:
                 ],
             }
 
+    def transition_stats(self) -> Dict[str, Dict[str, int]]:
+        """Per-ref swap telemetry (gw#479): promote/demote counts + last wall
+        durations for every entry that has ever transitioned."""
+        with self._lock:
+            return {
+                e.ref: {
+                    "promotes": e.promote_count,
+                    "demotes": e.demote_count,
+                    "last_promote_ms": e.last_promote_ms,
+                    "last_demote_ms": e.last_demote_ms,
+                }
+                for e in self._entries.values()
+                if e.promote_count or e.demote_count
+            }
+
     def drain_shared(self, *, force: bool = False) -> int:
         """Evict shared entries with refcount 0 (or everything when ``force``)."""
         with self._lock:
@@ -672,66 +700,82 @@ def _digest(value: Any) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
+def content_set_digest(files: Any) -> str:
+    """Digest of a component's sorted ``(relative_path, blake3)`` pairs — the
+    CONTENT identity of the file set (gw#479). Content-addressed = immutable:
+    a tag moving to new bytes changes file digests, hence this digest."""
+    rows = sorted(f"{str(p)}\x1f{str(d)}" for p, d in dict(files).items())
+    if not rows:
+        return ""
+    return hashlib.sha256("\n".join(rows).encode("utf-8")).hexdigest()[:32]
+
+
 @dataclass(frozen=True)
 class LoadedComponentKey:
-    """Canonical identity of a loadable immutable component set. Two bindings
-    share one loaded entry IFF every field is equal — the fields cover every
-    dimension that would make the loaded bytes unshareable (provider/ref,
-    revision/snapshot, dtype, quant scheme+config, GPU index, placement mode,
-    subfolder, component-set/pipeline-class identity, adapter overlays)."""
+    """Canonical identity of a loadable immutable component set, keyed by
+    CONTENT (gw#479). Two bindings share one loaded entry IFF the bytes and
+    every load-affecting fact are equal: the file-set content digest plus
+    dtype, quant scheme+config, GPU index, placement mode, component name and
+    adapter overlays. ref/revision are NOT identity — byte-identical
+    components mirrored under different refs share one in-memory copy; the
+    readable ref survives only in the ``label`` (cache_id display)."""
 
-    provider: str = "tensorhub"
-    ref: str = ""
-    revision: str = ""
+    content_digest: str = ""      # content_set_digest of the component's files
     dtype: str = ""
-    quantization: str = ""
+    quantization: str = ""        # quant scheme / storage_dtype
     quant_config_digest: str = ""
     device_id: int = 0
     placement: str = "full"
-    subfolder: str = ""
-    component_set: str = ""
+    component_set: str = ""       # component name (e.g. "text_encoder")
     adapter_id: str = ""
+    label: str = field(default="", compare=False)  # readable, non-identity
 
     @classmethod
-    def from_binding(
+    def for_component(
         cls,
-        binding: Any,
         *,
-        device_id: int = 0,
-        placement: str = "full",
-        component_set: str = "",
-        snapshot_digest: str = "",
+        content_digest: str,
+        component: str = "",
+        binding: Any = None,
+        dtype: str = "",
         quantization: str = "",
         quant_config: Any = None,
+        device_id: int = 0,
+        placement: str = "full",
         adapter_id: str = "",
+        label: str = "",
     ) -> "LoadedComponentKey":
-        provider = str(getattr(binding, "provider", "tensorhub") or "tensorhub").strip()
-        ref = str(getattr(binding, "ref", "") or "").strip()
-        dtype = str(getattr(binding, "dtype", "") or "").strip().lower()
-        revision = str(getattr(binding, "revision", "") or "").strip() or str(snapshot_digest or "").strip()
-        subfolder = str(getattr(binding, "subfolder", "") or "").strip()
+        """Key for one component of a bound snapshot: content digest + the
+        binding's load-affecting facts (dtype, storage_dtype)."""
+        if binding is not None:
+            dtype = dtype or str(getattr(binding, "dtype", "") or "")
+            quantization = quantization or str(getattr(binding, "storage_dtype", "") or "")
+            if not label:
+                ref = str(getattr(binding, "ref", "") or "")
+                label = f"{ref}/{component}" if ref else component
         return cls(
-            provider=provider,
-            ref=ref,
-            revision=revision,
-            dtype=dtype,
+            content_digest=str(content_digest or "").strip(),
+            dtype=str(dtype or "").strip().lower(),
             quantization=str(quantization or "").strip().lower(),
             quant_config_digest=_digest(quant_config),
             device_id=int(device_id),
             placement=str(placement or "full").strip() or "full",
-            subfolder=subfolder,
-            component_set=str(component_set or "").strip(),
+            component_set=str(component or "").strip(),
             adapter_id=str(adapter_id or "").strip(),
+            label=str(label or component or "").strip(),
         )
 
     def cache_id(self) -> str:
         fields = (
-            self.provider, self.ref, self.revision, self.dtype,
-            self.quantization, self.quant_config_digest, str(self.device_id),
-            self.placement, self.subfolder, self.component_set, self.adapter_id,
+            self.content_digest, self.dtype, self.quantization,
+            self.quant_config_digest, str(self.device_id), self.placement,
+            self.component_set, self.adapter_id,
         )
         digest = hashlib.sha256("\x1f".join(fields).encode("utf-8")).hexdigest()[:16]
-        readable = (self.ref or "?").replace("/", "--")[:48]
+        # Readable part comes from IDENTITY fields only: equal keys MUST map
+        # to one cache entry even when their ref labels differ (that is the
+        # entire point of content keying).
+        readable = (self.component_set or "?").replace("/", "--")[:48]
         return f"shared::{readable}::dev{self.device_id}::{digest}"
 
 
@@ -761,5 +805,6 @@ __all__ = [
     "Tier",
     "LoadedComponentKey",
     "build_function_owned_pipeline",
+    "content_set_digest",
     "ON_DISK", "IN_RAM", "IN_VRAM", "EVICTED",
 ]

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -59,6 +59,9 @@ class EndpointSpec:
     timeout_ms: Optional[int] = None
     runtime: Optional[str] = None
     compile: Optional[Compile] = None  # opt-in torch.compile spec (#384)
+    # Payload-driven slot routing (gw#479): promotes/pins only the slots a
+    # request needs; None = every slot (single-lane classes, functions).
+    route: Optional[Callable[[Any], Any]] = None
     module: str = ""              # declaring module
     walked_module: str = ""       # top-level package the object was found under
 
@@ -157,6 +160,7 @@ def _spec_for_handler(
         models=dict(models),
         runtime=decl.runtime,
         compile=decl.compile,
+        route=decl.route,
         module=getattr(cls or method, "__module__", "") or "",
         walked_module=walked_module,
     )

--- a/tests/test_content_lanes.py
+++ b/tests/test_content_lanes.py
@@ -1,0 +1,363 @@
+"""Content-keyed shared components + transformer lanes (gw#479), against REAL
+tiny diffusers pipelines and the REAL executor injection path.
+
+Two Hub-style refs whose ``vae`` files are byte-identical (same blake3 set in
+their wire snapshots) must share ONE in-memory vae; each lane's exclusive
+``unet`` is an independent residency entry that LRU demote/promote swaps
+WITHOUT touching the shared module. A dtype mismatch must NOT share.
+
+CUDA required for the residency-move tests (residency moves real memory,
+gw#417); the digest/plan/routing tests run anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import msgspec
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+from diffusers import AutoencoderKL, DDPMScheduler, DiffusionPipeline, UNet2DModel
+
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.api.errors import ValidationError
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models.cozy_cas import _blake3_file
+from gen_worker.models.residency import Tier
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+_GiB = 1024 ** 3
+_MiB = 1024 ** 2
+
+_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="residency moves real memory between VRAM/RAM (gw#417); needs CUDA",
+)
+
+
+class TinyLanePipe(DiffusionPipeline):
+    """Real DiffusionPipeline subclass: exclusive ``unet`` + shared ``vae``."""
+
+    def __init__(self, unet, vae, scheduler) -> None:
+        super().__init__()
+        self.register_modules(unet=unet, vae=vae, scheduler=scheduler)
+
+
+def _tiny_unet(channels: int, seed: int) -> UNet2DModel:
+    torch.manual_seed(seed)
+    return UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3, layers_per_block=1,
+        block_out_channels=(channels, channels), norm_num_groups=8,
+        down_block_types=("DownBlock2D", "DownBlock2D"),
+        up_block_types=("UpBlock2D", "UpBlock2D"),
+    )
+
+
+def _tiny_vae(seed: int = 7) -> AutoencoderKL:
+    torch.manual_seed(seed)
+    return AutoencoderKL(
+        in_channels=3, out_channels=3, latent_channels=4,
+        down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+        block_out_channels=(32,), layers_per_block=1, norm_num_groups=8,
+    )
+
+
+def _save_lane_repo(path: Path, *, unet_seed: int, channels: int = 384) -> None:
+    TinyLanePipe(
+        unet=_tiny_unet(channels, unet_seed), vae=_tiny_vae(),
+        scheduler=DDPMScheduler(num_train_timesteps=10),
+    ).save_pretrained(str(path))
+
+
+def _snapshot_pb(root: Path) -> pb.Snapshot:
+    """Wire snapshot with REAL per-file blake3 digests, like the hub sends."""
+    files = []
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        files.append(pb.SnapshotFile(
+            path=str(p.relative_to(root)),
+            size_bytes=p.stat().st_size,
+            blake3=_blake3_file(p),
+        ))
+    return pb.Snapshot(digest=f"snap-{root.name}", files=files)
+
+
+@pytest.fixture(scope="module")
+def lane_repos(tmp_path_factory) -> dict:
+    """repo-a and repo-b: different unets, BYTE-IDENTICAL vae (copied)."""
+    import shutil
+
+    root = tmp_path_factory.mktemp("lane-repos")
+    a, b = root / "repo-a", root / "repo-b"
+    _save_lane_repo(a, unet_seed=1)
+    _save_lane_repo(b, unet_seed=2)
+    # Byte-identical shared component: replace b's vae with a's bytes.
+    shutil.rmtree(b / "vae")
+    shutil.copytree(a / "vae", b / "vae")
+    assert (
+        _blake3_file(next((a / "vae").glob("*.safetensors")))
+        == _blake3_file(next((b / "vae").glob("*.safetensors")))
+    )
+    return {"a": a, "b": b}
+
+
+class _In(msgspec.Struct):
+    x: str
+
+
+def _route(payload: "_In"):
+    return ("a",) if payload.x == "a" else ("b",)
+
+
+def _lane_spec(cls: type, models: dict, route=None) -> EndpointSpec:
+    return EndpointSpec(
+        name="lanes", method=cls.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=cls, attr_name="run", models=models,
+        resources=Resources(), route=route,
+    )
+
+
+def _executor(specs, tmp_path: Path, budget_bytes: int, sent: list,
+              repos: dict) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=budget_bytes)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        path = repos[ref]
+        store.residency.track_disk(ref, path)
+        return path
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    for ref, path in repos.items():
+        store._snapshots[ref] = _snapshot_pb(path)
+    return Executor(specs, _send, store=store)
+
+
+class _Lanes:
+    def setup(self, a: TinyLanePipe, b: TinyLanePipe) -> None:
+        self.a, self.b = a, b
+
+    def run(self, ctx, payload: _In):  # pragma: no cover
+        return payload
+
+
+# --------------------------------------------------------------------------- #
+# Content identity plumbing (no CUDA needed)
+# --------------------------------------------------------------------------- #
+
+
+def test_component_digests_group_by_subfolder(tmp_path, lane_repos) -> None:
+    sent: list = []
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    ex = _executor([], tmp_path, 4 * _GiB, sent, repos)
+
+    da = ex.store.component_digests("acme/a")
+    db = ex.store.component_digests("acme/b")
+    assert set(da) == {"", "unet", "vae", "scheduler"}
+    assert da["vae"] == db["vae"]          # byte-identical -> same content id
+    assert da["unet"] != db["unet"]        # different weights -> different id
+    assert da[""] != "" and "unet" in ex.store.component_sizes("acme/a")
+    assert ex.store.component_digests("acme/unknown") == {}
+
+
+def test_share_plan_only_covers_byte_identical_components(tmp_path, lane_repos) -> None:
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(_Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
+    ex = _executor([spec], tmp_path, 4 * _GiB, [], repos)
+
+    hints = {"a": TinyLanePipe, "b": TinyLanePipe}
+    paths = {"a": str(lane_repos["a"]), "b": str(lane_repos["b"])}
+    plan = ex._component_share_plan(spec, paths, hints)
+    assert plan is not None
+    # vae + scheduler are byte-identical across the repos; unet never shares.
+    assert set(plan["a"]) == set(plan["b"]) == {"vae", "scheduler"}
+    assert plan["a"]["vae"] == plan["b"]["vae"]
+
+    # dtype mismatch: same bytes, different load facts -> no plan.
+    spec2 = _lane_spec(_Lanes, {"a": HF("acme/a", dtype="fp16"), "b": HF("acme/b")})
+    assert ex._component_share_plan(spec2, paths, hints) is None
+
+
+def test_routed_slots_validation(tmp_path, lane_repos) -> None:
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+    ex = _executor([spec], tmp_path, 4 * _GiB, [], repos)
+
+    assert ex._routed_slots(spec, _In(x="a")) == ["a"]
+    assert ex._routed_slots(spec, _In(x="edit")) == ["b"]
+
+    bad = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")},
+        route=lambda p: ("nope",))
+    with pytest.raises(ValidationError):
+        ex._routed_slots(bad, _In(x="a"))
+    empty = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=lambda p: ())
+    with pytest.raises(ValidationError):
+        ex._routed_slots(empty, _In(x="a"))
+    # No route= -> every slot (unchanged single-lane behavior).
+    plain = _lane_spec(_Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
+    assert ex._routed_slots(plain, _In(x="a")) == ["a", "b"]
+
+
+def test_route_decorator_validation() -> None:
+    from gen_worker import Hub, endpoint
+
+    with pytest.raises(ValueError):
+        @endpoint(model=Hub("o/r"), route=lambda p: ("m",))
+        class OneSlot:
+            def setup(self, m: str) -> None: ...
+            def run(self, ctx, payload: _In) -> _In: ...
+
+    @endpoint(models={"a": Hub("o/a"), "b": Hub("o/b")}, route=_route)
+    class TwoSlots:
+        def setup(self, a: str, b: str) -> None: ...
+        def run(self, ctx, payload: _In) -> _In: ...
+
+    assert TwoSlots.__gen_worker_endpoint__.route is _route
+
+
+# --------------------------------------------------------------------------- #
+# Real loads: sharing, accounting, lane swap (CUDA)
+# --------------------------------------------------------------------------- #
+
+
+@_cuda
+def test_lanes_share_one_vae_instance_and_count_it_once(tmp_path, lane_repos) -> None:
+    sent: list = []
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, repos)
+        inst = await ex.ensure_setup(spec)
+        res = ex.store.residency
+
+        # Object identity: ONE vae instance wired into both lane pipelines.
+        assert inst.a.vae is inst.b.vae
+        assert inst.a.unet is not inst.b.unet
+
+        stats = res.shared_stats()
+        assert stats["hits"] >= 1            # lane b reused lane a's modules
+        vae_entries = [e for e in stats["entries"] if "vae" in e["ref"]]
+        assert len(vae_entries) == 1         # one shared vae entry, counted once
+        assert vae_entries[0]["refcount"] == 2
+
+        # Memory accounting: lane entries carry ~the exclusive unet (148MB
+        # fp32), NOT unet+vae; the shared vae is booked once on its own entry.
+        assert res.vram_bytes("acme/a") == pytest.approx(148 * _MiB, rel=0.3)
+        assert res.vram_bytes("acme/b") == pytest.approx(148 * _MiB, rel=0.3)
+        tracked = 4 * _GiB - res.free_vram_bytes()
+        vae_bytes = vae_entries[0]["vram_bytes"]
+        assert vae_bytes > 0
+        assert tracked == pytest.approx(
+            res.vram_bytes("acme/a") + res.vram_bytes("acme/b") + vae_bytes
+            + sum(e["vram_bytes"] for e in stats["entries"] if "vae" not in e["ref"]),
+            rel=0.05,
+        )
+
+    asyncio.run(_run())
+
+
+@_cuda
+def test_lane_swap_moves_only_the_exclusive_module(tmp_path, lane_repos) -> None:
+    """Tight budget: both 148MB unets cannot be VRAM-booked at once (2GiB
+    make_room margin). Setup lands lane b resident + lane a demoted; a routed
+    promote of lane a swaps b out. The shared vae NEVER moves."""
+    sent: list = []
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+
+    def _dev(module) -> str:
+        return next(module.parameters()).device.type
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path, int(2.3 * _GiB), sent, repos)
+        inst = await ex.ensure_setup(spec)
+        res = ex.store.residency
+
+        # Swap-mode admission: loading lane b demoted lane a's unet — and
+        # ONLY the unet; the shared vae stayed put on cuda.
+        assert res.tier("acme/a") is Tier.RAM
+        assert res.tier("acme/b") is Tier.VRAM
+        assert _dev(inst.a.unet) == "cpu"
+        assert _dev(inst.b.unet) == "cuda"
+        assert inst.a.vae is inst.b.vae and _dev(inst.a.vae) == "cuda"
+
+        # Routed request for lane a: promote a, LRU-demote b — vae untouched.
+        again = await ex.ensure_setup(spec, promote_slots=["a"])
+        assert again is inst
+        assert res.tier("acme/a") is Tier.VRAM
+        assert res.tier("acme/b") is Tier.RAM
+        assert _dev(inst.a.unet) == "cuda"
+        assert _dev(inst.b.unet) == "cpu"
+        assert _dev(inst.a.vae) == "cuda"
+
+        # Swap telemetry (gw#479): counts + durations recorded per lane.
+        stats = res.transition_stats()
+        assert stats["acme/a"]["demotes"] >= 1
+        assert stats["acme/a"]["promotes"] >= 1
+        assert stats["acme/b"]["demotes"] >= 1
+
+    asyncio.run(_run())
+    # Promote/demote ModelEvents carry duration_ms (the hub-visible signal).
+    durs = [m.model_event.duration_ms for m in sent
+            if m.WhichOneof("msg") == "model_event"
+            and m.model_event.state in (pb.MODEL_STATE_IN_RAM, pb.MODEL_STATE_IN_VRAM)]
+    assert durs, "expected residency transition events"
+
+
+@_cuda
+def test_dtype_mismatch_loads_monolithically(tmp_path, lane_repos) -> None:
+    sent: list = []
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(
+        _Lanes, {"a": HF("acme/a", dtype="fp16"), "b": HF("acme/b")})
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, repos)
+        inst = await ex.ensure_setup(spec)
+        res = ex.store.residency
+
+        assert inst.a.vae is not inst.b.vae   # no content-key match -> no share
+        assert res.shared_stats()["entries"] == []
+        # Monolithic entries own whole pipelines (today's behavior).
+        assert res.obj("acme/a") is inst.a
+        assert res.obj("acme/b") is inst.b
+
+    asyncio.run(_run())
+
+
+@_cuda
+def test_vacate_releases_shared_holds(tmp_path, lane_repos) -> None:
+    sent: list = []
+    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
+    spec = _lane_spec(
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+
+    async def _run() -> None:
+        ex = _executor([spec], tmp_path, 4 * _GiB, sent, repos)
+        await ex.ensure_setup(spec)
+        res = ex.store.residency
+        assert res.shared_stats()["entries"]
+
+        rec = ex._classes[spec.instance_key]
+        await ex._vacate_record(rec)
+        # All shared holds released and unreferenced entries drained.
+        assert res.shared_stats()["entries"] == []
+        assert rec.shared_keys == []
+
+    asyncio.run(_run())

--- a/tests/test_promote_device_integrity.py
+++ b/tests/test_promote_device_integrity.py
@@ -25,7 +25,7 @@ def _plenty_of_ram(monkeypatch):
 
 def _res(events: list, budget_gb: int = 24) -> Residency:
     return Residency(
-        on_event=lambda ref, state, vb: events.append((ref, state, vb)),
+        on_event=lambda ref, state, vb, dur=0: events.append((ref, state, vb)),
         vram_budget_bytes=budget_gb * _GiB,
     )
 

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -33,7 +33,7 @@ _GiB = 1024 ** 3
 def _res(events: list | None = None, budget_gb: int = 24) -> Residency:
     ev = events if events is not None else []
     return Residency(
-        on_event=lambda ref, state, vb: ev.append((ref, state, vb)),
+        on_event=lambda ref, state, vb, dur=0: ev.append((ref, state, vb)),
         vram_budget_bytes=budget_gb * _GiB,
     )
 

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -34,7 +34,7 @@ def _plenty_of_ram(monkeypatch):
 
 def _res(events: list, budget_gb: int = 10) -> Residency:
     return Residency(
-        on_event=lambda ref, state, vb: events.append((ref, state, vb)),
+        on_event=lambda ref, state, vb, dur=0: events.append((ref, state, vb)),
         vram_budget_bytes=budget_gb * _GiB,
     )
 

--- a/tests/test_shared_components.py
+++ b/tests/test_shared_components.py
@@ -1,5 +1,6 @@
-"""Shared-component identity + single-count VRAM accounting (#335, now folded
-into the models-layer Residency manager, #366).
+"""Shared-component identity + single-count VRAM accounting (#335/#366),
+re-keyed by CONTENT (gw#479): identity = the component's file digest set +
+load-affecting facts. ref/revision are labels, not identity.
 
 Validates sharing + refcount + accounting with lightweight REAL objects: a fake
 "pipeline" is a plain object carrying a ``.components`` dict, exercising the
@@ -10,15 +11,19 @@ from __future__ import annotations
 
 import pytest
 
-from gen_worker import HF, Civitai, Hub
+from gen_worker import HF, Hub
 from gen_worker.models import (
     LoadedComponentKey,
     Residency,
     Tier,
     build_function_owned_pipeline,
+    content_set_digest,
 )
 
 _GiB = 1024 ** 3
+
+_FILES_A = {"model-00001.safetensors": "b3" + "a" * 62, "config.json": "b3" + "c" * 62}
+_FILES_B = {"model-00001.safetensors": "b3" + "d" * 62, "config.json": "b3" + "c" * 62}
 
 
 # --------------------------------------------------------------------------- #
@@ -57,61 +62,72 @@ def _residency_100gb() -> Residency:
     return Residency(vram_budget_bytes=100 * _GiB)
 
 
+def _key(files=None, **kw) -> LoadedComponentKey:
+    return LoadedComponentKey.for_component(
+        content_digest=content_set_digest(files if files is not None else _FILES_A),
+        **kw,
+    )
+
+
 # --------------------------------------------------------------------------- #
-# LoadedComponentKey canonicalization                                           #
+# Content-keyed canonicalization (gw#479)                                       #
 # --------------------------------------------------------------------------- #
 
 
-def test_identical_bindings_produce_equal_keys() -> None:
-    a = HF("bfl/flux.2-klein-4b", dtype="bf16")
-    b = HF("bfl/flux.2-klein-4b", dtype="bf16")
-    ka = LoadedComponentKey.from_binding(a, device_id=0, component_set="pkg.Flux2KleinPipeline")
-    kb = LoadedComponentKey.from_binding(b, device_id=0, component_set="pkg.Flux2KleinPipeline")
+def test_byte_identical_components_share_across_refs() -> None:
+    """THE gw#479 property: two different Hub refs whose component files are
+    byte-identical (same blake3 set) produce EQUAL keys — one loaded copy."""
+    a = Hub("tensorhub/qwen-image")
+    b = Hub("tensorhub/qwen-image-edit-2511")
+    ka = _key(component="text_encoder", binding=a)
+    kb = _key(component="text_encoder", binding=b)
     assert ka == kb
     assert ka.cache_id() == kb.cache_id()
+    # The readable label differs but is non-identity (compare=False).
+    assert ka.label != kb.label
 
 
-@pytest.mark.parametrize(
-    "mutate",
-    [
-        lambda b: HF(b.ref, dtype="fp16"),
-        lambda b: HF(b.ref, dtype=b.dtype, revision="deadbeef"),
-        lambda b: HF(b.ref, dtype=b.dtype, subfolder="text_encoder"),
-    ],
-)
-def test_binding_attribute_differences_do_not_share(mutate) -> None:
-    base = HF("bfl/flux.2-klein-4b", dtype="bf16")
-    k_base = LoadedComponentKey.from_binding(base, device_id=0, component_set="P")
-    k_other = LoadedComponentKey.from_binding(mutate(base), device_id=0, component_set="P")
-    assert k_base != k_other
-    assert k_base.cache_id() != k_other.cache_id()
-
-
-def test_device_dtype_quant_component_set_differences_do_not_share() -> None:
-    b = HF("bfl/flux.2-klein-4b", dtype="bf16")
-    k0 = LoadedComponentKey.from_binding(b, device_id=0, component_set="P")
-    assert k0 != LoadedComponentKey.from_binding(b, device_id=1, component_set="P")
-    assert k0 != LoadedComponentKey.from_binding(b, device_id=0, component_set="Q")
-    assert k0 != LoadedComponentKey.from_binding(
-        b, device_id=0, component_set="P", quantization="fp8"
-    )
-    assert LoadedComponentKey.from_binding(
-        b, device_id=0, component_set="P", quantization="fp8", quant_config={"a": 1}
-    ) != LoadedComponentKey.from_binding(
-        b, device_id=0, component_set="P", quantization="fp8", quant_config={"a": 2}
-    )
-    assert LoadedComponentKey.from_binding(Hub("o/r"), device_id=0) != LoadedComponentKey.from_binding(
-        Civitai("123"), device_id=0
+def test_content_difference_does_not_share() -> None:
+    b = Hub("o/r")
+    assert _key(_FILES_A, component="text_encoder", binding=b) != _key(
+        _FILES_B, component="text_encoder", binding=b
     )
 
 
-def test_unpinned_revision_falls_back_to_snapshot_digest() -> None:
-    b = HF("bfl/flux.2-klein-4b")  # no explicit revision
-    same = LoadedComponentKey.from_binding(b, snapshot_digest="/cache/snap-A")
-    same2 = LoadedComponentKey.from_binding(b, snapshot_digest="/cache/snap-A")
-    diff = LoadedComponentKey.from_binding(b, snapshot_digest="/cache/snap-B")
-    assert same == same2
-    assert same != diff
+def test_content_set_digest_is_order_invariant_and_path_sensitive() -> None:
+    reordered = dict(reversed(list(_FILES_A.items())))
+    assert content_set_digest(_FILES_A) == content_set_digest(reordered)
+    moved = {"sub/" + p: d for p, d in _FILES_A.items()}
+    assert content_set_digest(_FILES_A) != content_set_digest(moved)
+    assert content_set_digest({}) == ""
+
+
+def test_load_fact_differences_do_not_share() -> None:
+    k0 = _key(component="text_encoder", dtype="bf16")
+    assert k0 != _key(component="text_encoder", dtype="fp16")
+    assert k0 != _key(component="text_encoder", dtype="bf16", device_id=1)
+    assert k0 != _key(component="vae", dtype="bf16")
+    assert k0 != _key(component="text_encoder", dtype="bf16", quantization="fp8")
+    assert _key(
+        component="text_encoder", quantization="fp8", quant_config={"a": 1}
+    ) != _key(component="text_encoder", quantization="fp8", quant_config={"a": 2})
+    assert k0 != _key(component="text_encoder", dtype="bf16", placement="offload")
+
+
+def test_binding_dtype_and_storage_dtype_enter_identity() -> None:
+    bf16 = HF("o/r", dtype="bf16")
+    fp16 = HF("o/r", dtype="fp16")
+    assert _key(component="te", binding=bf16) != _key(component="te", binding=fp16)
+    fp8 = Hub("o/r", flavor="fp8", storage_dtype="fp8+te")
+    bare = Hub("o/r")
+    assert _key(component="te", binding=fp8) != _key(component="te", binding=bare)
+
+
+def test_ref_is_not_identity() -> None:
+    """Same bytes + same facts under different providers/refs: SHARED."""
+    assert _key(component="te", binding=HF("mirror-one/repo", dtype="bf16")) == _key(
+        component="te", binding=HF("mirror-two/other", dtype="bf16")
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -121,7 +137,7 @@ def test_unpinned_revision_falls_back_to_snapshot_digest() -> None:
 
 def test_identical_components_are_shared_one_instance_refcount_two() -> None:
     res = _residency_100gb()
-    key = LoadedComponentKey(ref="bfl/flux.2-klein-4b", dtype="bf16", component_set="P")
+    key = _key(component="P", dtype="bf16", label="bfl/flux.2-klein-4b/P")
 
     base = _new_base()
     loads = {"n": 0}
@@ -143,7 +159,7 @@ def test_identical_components_are_shared_one_instance_refcount_two() -> None:
 
 def test_shared_vram_counted_once() -> None:
     res = _residency_100gb()
-    key = LoadedComponentKey(ref="bfl/flux.2-klein-4b", dtype="bf16", component_set="P")
+    key = _key(component="P", dtype="bf16")
     base = _new_base()
 
     before = res.free_vram_bytes()
@@ -160,7 +176,7 @@ def test_shared_vram_counted_once() -> None:
 
 def test_shared_component_not_evicted_while_referenced() -> None:
     res = _residency_100gb()
-    key = LoadedComponentKey(ref="shared/base", dtype="bf16", component_set="P")
+    key = _key(component="P", dtype="bf16", label="shared/base")
     base = _new_base()
     res.acquire_shared(key, lambda: base, vram_bytes=20 * _GiB)
     res.acquire_shared(key, lambda: base, vram_bytes=20 * _GiB)  # refcount 2
@@ -179,7 +195,7 @@ def test_shared_component_not_evicted_while_referenced() -> None:
 
 def test_releasing_all_refs_makes_entry_evictable() -> None:
     res = _residency_100gb()
-    key = LoadedComponentKey(ref="shared/base", dtype="bf16", component_set="P")
+    key = _key(component="P", dtype="bf16", label="shared/base")
     base = _new_base()
     res.acquire_shared(key, lambda: base, vram_bytes=20 * _GiB)
     res.acquire_shared(key, lambda: base, vram_bytes=20 * _GiB)
@@ -197,8 +213,8 @@ def test_releasing_all_refs_makes_entry_evictable() -> None:
 
 def test_drain_skips_referenced_then_force_clears_all() -> None:
     res = _residency_100gb()
-    held = LoadedComponentKey(ref="a/held", component_set="P")
-    free = LoadedComponentKey(ref="b/free", component_set="P")
+    held = _key(_FILES_A, component="P", label="a/held")
+    free = _key(_FILES_B, component="P", label="b/free")
     res.acquire_shared(held, _new_base, vram_bytes=5 * _GiB)   # refcount 1
     res.acquire_shared(free, _new_base, vram_bytes=5 * _GiB)
     res.release_shared(free)                                    # refcount 0
@@ -218,11 +234,9 @@ def test_drain_skips_referenced_then_force_clears_all() -> None:
 
 
 def test_lora_and_override_bindings_isolate_from_clean_base() -> None:
-    base = HF("bfl/flux.2-klein-4b", dtype="bf16")
-
-    k_clean = LoadedComponentKey.from_binding(base, component_set="P")
-    k_lora = LoadedComponentKey.from_binding(base, component_set="P", adapter_id="lora:set-7")
-    k_override = LoadedComponentKey.from_binding(base, component_set="P", adapter_id="override:Pipe")
+    k_clean = _key(component="P", dtype="bf16")
+    k_lora = _key(component="P", dtype="bf16", adapter_id="lora:set-7")
+    k_override = _key(component="P", dtype="bf16", adapter_id="override:Pipe")
 
     assert k_clean != k_lora
     assert k_clean != k_override
@@ -231,9 +245,8 @@ def test_lora_and_override_bindings_isolate_from_clean_base() -> None:
 
 
 def test_adapter_identity_separates_two_lora_overlays() -> None:
-    b = HF("bfl/flux.2-klein-4b", dtype="bf16")
-    k1 = LoadedComponentKey.from_binding(b, component_set="P", adapter_id="lora:A")
-    k2 = LoadedComponentKey.from_binding(b, component_set="P", adapter_id="lora:B")
+    k1 = _key(component="P", adapter_id="lora:A")
+    k2 = _key(component="P", adapter_id="lora:B")
     assert k1 != k2
 
 


### PR DESCRIPTION
## Summary
- **LoadedComponentKey re-keyed to CONTENT** (gw#479): identity = sorted blake3 digest set of the component's files (`content_set_digest`) + load facts (dtype, quantization/storage_dtype + config digest, device, placement, component name, adapter overlay). ref/revision drop to a `compare=False` label — byte-identical components mirrored under different Hub refs (qwen-image / qwen-image-edit-2511's 16.84GB encoder+VAE+tokenizer) share ONE in-memory copy. Immutability = free invalidation: a tag moving to new bytes changes digests, hence the key.
- **Lane loading in the executor**: class records binding 2+ pipeline slots get a content share plan from the wire snapshots' per-file digests (`ModelStore.component_digests`). First lane loads monolithically and registers shared components via `acquire_shared` (VRAM counted once, refcount-held); later lanes inject the very same module objects into `from_pretrained` (`load_from_pretrained(components=)`) and load only exclusive weights. Each lane's residency entry is an `nn.ModuleDict` of its EXCLUSIVE modules, registered inline per slot — the existing make_room/LRU ladder (v0.13.11+ degraded-mode ladder, nothing parallel added) swaps ONLY the transformer: dual-resident when the budget admits, swap-mode otherwise.
- **`@endpoint(route=)`**: `route(payload) -> slot names` — the executor decodes before pinning and promotes/pins only the routed lane. Without this, swap-mode lanes would thrash both 40.9GB transformers on every request.
- **Telemetry**: promote/demote timed + counted per entry (`Residency.transition_stats()`); swap walls ride the existing `ModelEvent.duration_ms` (zero proto changes); lanes are distinct refs in `Hello.models`; `shared::` entries already ride `snapshot()`/`shared_stats()`.
- **Safety rails**: offload placement and sharing are mutually exclusive (planned-offload → monolithic fallback; post-placement offload with shares → RETRYABLE); `apply_fp8_storage` idempotent per module (injected shared modules never double-hooked); sharing engages only when digests exist and keys collide — single-slot records byte-for-byte unchanged.

## Tests
- `tests/test_shared_components.py` rewritten for content keys (share across refs, dtype/storage_dtype/quant/adapter isolation, refcount + single-count accounting) — CPU, passing.
- `tests/test_content_lanes.py` NEW: real tiny diffusers pipelines through the REAL executor path — byte-identical vae shares one instance (object identity + counted once), tight-budget lane swap moves ONLY the exclusive unet (shared vae never moves), dtype mismatch loads monolithically, vacate releases shared holds, route validation. CUDA-gated moves (same pattern as test_executor_residency); digest/plan/routing tests run on CPU.
- Full suite: 823 passed / 14 skipped. Ruff + HTTP-timeout guard green; mypy error count unchanged (97 pre-existing).

Counterpart: ie#394 (merged single-function qwen-image endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)