### PR TITLE
th#611: civitai GGUF-only ingest — single-gguf selection + gguf_quant (0.13.25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.24"
+version = "0.13.25"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -673,6 +673,7 @@ def run_clone(
                 plan = plan_civitai(
                     int(civitai_model_version_id or 0),
                     civitai_api_key=civitai_api_key,
+                    gguf_quant=gguf_quant,
                 )
         except Exception as exc:
             logger.warning(
@@ -728,6 +729,7 @@ def run_clone(
             source = ingest_civitai(
                 int(civitai_model_version_id or 0), workdir / "source",
                 civitai_api_key=civitai_api_key, progress=_dl_progress,
+                gguf_quant=gguf_quant,
             )
 
         _progress(0.5, "clone.convert")
@@ -946,6 +948,7 @@ def from_civitai(ctx: Any, payload: Any, *, civitai_api_key: str | None = None) 
         outputs=getattr(payload, "outputs", None),
         quantize_components=getattr(payload, "quantize_components", None),
         overwrite_repo=bool(getattr(payload, "overwrite_repo", False)),
+        gguf_quant=getattr(payload, "gguf_quant", None),
         civitai_api_key=civitai_api_key,
     )
 

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -288,7 +288,10 @@ def plan_huggingface(
     )
 
 
-def plan_civitai(model_version_id: int, *, civitai_api_key: str | None = None) -> CivitaiSourcePlan:
+def plan_civitai(
+    model_version_id: int, *, civitai_api_key: str | None = None,
+    gguf_quant: str | None = None,
+) -> CivitaiSourcePlan:
     """Fetch one civitai model version's metadata (no downloads)."""
     from gen_worker.models.download import _civitai_select_files, fetch_civitai_model_version
 
@@ -296,7 +299,7 @@ def plan_civitai(model_version_id: int, *, civitai_api_key: str | None = None) -
     if version_id <= 0:
         raise ValueError("civitai_model_version_id is required")
     payload = fetch_civitai_model_version(version_id, api_key=(civitai_api_key or ""))
-    files = _civitai_select_files(payload)
+    files = _civitai_select_files(payload, gguf_quant=gguf_quant)
     return CivitaiSourcePlan(
         version_id=version_id,
         payload=payload,
@@ -514,6 +517,7 @@ def ingest_civitai(
     *,
     civitai_api_key: str | None = None,
     progress: ProgressFn | None = None,
+    gguf_quant: str | None = None,
 ) -> IngestedSource:
     """Fetch one civitai model version into ``dest_dir`` (bounded provider API)."""
     from gen_worker.models.download import download_civitai, fetch_civitai_model_version
@@ -524,7 +528,8 @@ def ingest_civitai(
     payload = fetch_civitai_model_version(version_id, api_key=(civitai_api_key or ""))
 
     dest_dir = Path(dest_dir)
-    download_civitai(version_id, dest_dir, api_key=(civitai_api_key or ""), progress=progress)
+    download_civitai(version_id, dest_dir, api_key=(civitai_api_key or ""),
+                     progress=progress, gguf_quant=gguf_quant)
 
     files = sorted(p.name for p in dest_dir.iterdir() if p.is_file() and p.name != ".civitai.json")
     layout_info = detect_huggingface_source_layout(repo_dir=dest_dir, files=files)

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path
@@ -645,31 +646,83 @@ def fetch_civitai_model_version(version_id: int, *, api_key: str = "") -> dict[s
     return _civitai_get_json(f"{_CIVITAI_API}/model-versions/{int(version_id)}", api_key)
 
 
-def _civitai_select_files(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
-    """Downloadable safetensors files of a model version, primary first."""
-    out: list[dict[str, Any]] = []
+def _civitai_file_entry(raw: Mapping[str, Any]) -> dict[str, Any]:
+    size = raw.get("sizeBytes")
+    if not isinstance(size, int) or size <= 0:
+        kb = raw.get("sizeKB")
+        size = int(float(kb) * 1024) if isinstance(kb, (int, float)) and kb > 0 else 0
+    hashes = raw.get("hashes") if isinstance(raw.get("hashes"), Mapping) else {}
+    meta = raw.get("metadata") if isinstance(raw.get("metadata"), Mapping) else {}
+    return {
+        "id": int(raw.get("id") or 0),
+        "name": Path(str(raw.get("name") or "").strip()).name,
+        "url": str(raw.get("downloadUrl") or raw.get("download_url") or "").strip(),
+        "size_bytes": int(size),
+        "sha256": str((hashes or {}).get("SHA256") or "").strip().lower(),
+        "primary": bool(raw.get("primary")),
+        "quant_type": str((meta or {}).get("quantType") or "").strip().lower(),
+    }
+
+
+# Servable-first gguf quant preference (mirrors gen_worker.convert.classifier
+# _GGUF_QUANT_PREFERENCE; duplicated to avoid a models→convert import cycle).
+_CIVITAI_GGUF_QUANT_PREFERENCE = (
+    "q8_0", "q6_k", "q5_k_m", "q5_k_s", "q4_k_m", "q4_k_s", "q4_0",
+    "q3_k_m", "q3_k_s", "q2_k", "f16", "bf16", "f32",
+)
+
+_CIVITAI_GGUF_QTYPE_RE = re.compile(r"(?:ud-)?(?:i?q\d[0-9a-z_]*|bf16|f16|f32)")
+
+
+def _civitai_gguf_quant_of(f: Mapping[str, Any]) -> str:
+    if f.get("quant_type"):
+        return str(f["quant_type"]).lower()
+    m = _CIVITAI_GGUF_QTYPE_RE.search(str(f.get("name") or "").lower())
+    return m.group(0) if m else ""
+
+
+def _civitai_select_files(
+    payload: Mapping[str, Any], *, gguf_quant: str | None = None,
+) -> list[dict[str, Any]]:
+    """Downloadable weight files of a model version, primary first.
+
+    Safetensors files win when present (unchanged behavior). GGUF-only
+    versions (th#611: klein/qwen fine-tunes published only as quants)
+    select exactly ONE gguf — civitai reuses a single filename across
+    quantType variants, so downloading several would collide on disk:
+    ``gguf_quant`` picks it explicitly, else the preference order applies.
+    """
+    st: list[dict[str, Any]] = []
+    gg: list[dict[str, Any]] = []
     for raw in payload.get("files") or []:
         if not isinstance(raw, Mapping):
             continue
-        name = str(raw.get("name") or "").strip()
-        url = str(raw.get("downloadUrl") or raw.get("download_url") or "").strip()
-        if not url or not name.lower().endswith(".safetensors"):
+        entry = _civitai_file_entry(raw)
+        if not entry["url"] or not entry["name"]:
             continue
-        size = raw.get("sizeBytes")
-        if not isinstance(size, int) or size <= 0:
-            kb = raw.get("sizeKB")
-            size = int(float(kb) * 1024) if isinstance(kb, (int, float)) and kb > 0 else 0
-        hashes = raw.get("hashes") if isinstance(raw.get("hashes"), Mapping) else {}
-        out.append({
-            "id": int(raw.get("id") or 0),
-            "name": Path(name).name,
-            "url": url,
-            "size_bytes": int(size),
-            "sha256": str((hashes or {}).get("SHA256") or "").strip().lower(),
-            "primary": bool(raw.get("primary")),
-        })
-    out.sort(key=lambda f: (0 if f["primary"] else 1, f["id"], f["name"]))
-    return out
+        lower = entry["name"].lower()
+        if lower.endswith(".safetensors"):
+            st.append(entry)
+        elif lower.endswith(".gguf"):
+            gg.append(entry)
+    if st:
+        st.sort(key=lambda f: (0 if f["primary"] else 1, f["id"], f["name"]))
+        return st
+    if not gg:
+        return []
+    gg.sort(key=lambda f: (f["id"], f["name"]))
+    if gguf_quant:
+        want = str(gguf_quant).strip().lower()
+        picked = [f for f in gg if want in (_civitai_gguf_quant_of(f) or "")
+                  or want in f["name"].lower()]
+        if not picked:
+            raise ValueError(f"civitai_gguf_quant_not_found: {want}")
+        return picked[:1]
+    for q in _CIVITAI_GGUF_QUANT_PREFERENCE:
+        picked = [f for f in gg if _civitai_gguf_quant_of(f) == q]
+        if picked:
+            return picked[:1]
+    return gg[:1]
 
 
 def _civitai_stream_one(
@@ -729,13 +782,14 @@ def download_civitai(
     *,
     api_key: str = "",
     progress: Optional[ProgressFn] = None,
+    gguf_quant: str | None = None,
 ) -> Path:
     """Blocking civitai model-version fetch (call via ``ensure_local`` /
-    ``asyncio.to_thread``). Downloads the version's safetensors files with
+    ``asyncio.to_thread``). Downloads the version's weight files with
     size + sha256 validation. Returns the single artifact path when the
     version has exactly one file, else the directory."""
     payload = fetch_civitai_model_version(version_id, api_key=api_key)
-    files = _civitai_select_files(payload)
+    files = _civitai_select_files(payload, gguf_quant=gguf_quant)
     if not files:
         raise ValueError("civitai_no_supported_files")
 

--- a/tests/convert/test_civitai_gguf_select.py
+++ b/tests/convert/test_civitai_gguf_select.py
@@ -1,0 +1,73 @@
+"""th#611: civitai gguf-only versions select exactly one gguf file.
+
+Safetensors-bearing versions keep the existing behavior (safetensors only,
+primary first). GGUF-only versions pick ONE gguf — civitai reuses a single
+filename across quantType variants, so plural downloads would collide.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.models.download import _civitai_select_files
+
+
+def _f(name, *, id=1, primary=False, quant=None, size_kb=1000):
+    meta = {"format": "GGUF" if name.endswith(".gguf") else "SafeTensor"}
+    if quant:
+        meta["quantType"] = quant
+    return {
+        "id": id,
+        "name": name,
+        "downloadUrl": f"https://civitai.example/{id}",
+        "sizeKB": size_kb,
+        "primary": primary,
+        "metadata": meta,
+        "hashes": {"SHA256": "ab" * 32},
+    }
+
+
+def test_safetensors_win_over_gguf():
+    files = _civitai_select_files({"files": [
+        _f("model.gguf", id=1, quant="Q5_K_M"),
+        _f("model.safetensors", id=2, primary=True),
+    ]})
+    assert [f["name"] for f in files] == ["model.safetensors"]
+
+
+def test_gguf_only_picks_one_by_preference():
+    files = _civitai_select_files({"files": [
+        _f("m.gguf", id=1, quant="Q5_K_M"),
+        _f("m.gguf", id=2, quant="Q8_0"),
+    ]})
+    assert len(files) == 1
+    assert files[0]["quant_type"] == "q8_0"  # preference head
+
+
+def test_gguf_only_explicit_quant_pick():
+    files = _civitai_select_files({"files": [
+        _f("m.gguf", id=1, quant="Q5_K_M"),
+        _f("m.gguf", id=2, quant="Q8_0"),
+    ]}, gguf_quant="q5_k_m")
+    assert len(files) == 1
+    assert files[0]["quant_type"] == "q5_k_m"
+
+
+def test_gguf_only_quant_from_filename():
+    files = _civitai_select_files({"files": [
+        _f("model-Q4_K_M.gguf", id=1),
+        _f("model-Q8_0.gguf", id=2),
+    ]}, gguf_quant="q4_k_m")
+    assert len(files) == 1
+    assert files[0]["name"] == "model-Q4_K_M.gguf"
+
+
+def test_gguf_quant_not_found_raises():
+    with pytest.raises(ValueError, match="civitai_gguf_quant_not_found"):
+        _civitai_select_files({"files": [
+            _f("m.gguf", id=1, quant="Q5_K_M"),
+        ]}, gguf_quant="q4_k_m")
+
+
+def test_no_weights_empty():
+    assert _civitai_select_files({"files": [_f("notes.zip", id=1)]}) == []

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.23"
+version = "0.13.25"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Ingest half of th#611 for civitai sources (sibling of gw#483's HF-lane fixes; the loader/rung epic gw#402 is untouched).

- `_civitai_select_files`: safetensors-bearing versions keep the exact existing behavior. **GGUF-only** versions now select exactly ONE gguf instead of raising `civitai_no_supported_files` — civitai reuses a single filename across quantType variants (Big Love, Fascium), so plural downloads would collide on disk. Pick: `gguf_quant` (metadata `quantType` or filename token; `civitai_gguf_quant_not_found` on miss), else the classifier's quant preference order.
- `gguf_quant` now threads the civitai lane end to end: `CloneCivitaiInput.gguf_quant` (payload) → `from_civitai` → `run_clone` → `plan_civitai` → `ingest_civitai` → `download_civitai`. HF lane already had it; the flavor bank key already included it.
- Version 0.13.25.

Tests: `tests/convert/test_civitai_gguf_select.py` (6 cases: safetensors-win, preference pick, explicit pick, filename-token pick, not-found, no-weights); full `tests/convert/` suite green (169 passed).

Downstream: hub-side classification/flavor stamping (tensorhub PR #257) makes these publishes land as `#gguf-<qtype>` flavor rows with a diffusion family. Conversion image bump rides training-endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)