### PR TITLE
th#611: civitai gguf quantType from downloadUrl (0.13.26)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.25"
+version = "0.13.26"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -25,6 +25,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+from urllib.parse import parse_qs, urlparse
 
 from ..config import get_settings
 from .cache_paths import tensorhub_cas_dir
@@ -677,6 +678,13 @@ _CIVITAI_GGUF_QTYPE_RE = re.compile(r"(?:ud-)?(?:i?q\d[0-9a-z_]*|bf16|f16|f32)")
 def _civitai_gguf_quant_of(f: Mapping[str, Any]) -> str:
     if f.get("quant_type"):
         return str(f["quant_type"]).lower()
+    # The model-versions API omits metadata.quantType; the per-file
+    # downloadUrl carries it as a query param (the version's PRIMARY file
+    # gets a bare default URL instead — quant unknowable pre-download).
+    url = str(f.get("url") or "")
+    q = parse_qs(urlparse(url).query).get("quantType", [""])[0]
+    if q:
+        return q.strip().lower()
     m = _CIVITAI_GGUF_QTYPE_RE.search(str(f.get("name") or "").lower())
     return m.group(0) if m else ""
 

--- a/tests/convert/test_civitai_gguf_select.py
+++ b/tests/convert/test_civitai_gguf_select.py
@@ -71,3 +71,18 @@ def test_gguf_quant_not_found_raises():
 
 def test_no_weights_empty():
     assert _civitai_select_files({"files": [_f("notes.zip", id=1)]}) == []
+
+
+def test_gguf_quant_from_download_url():
+    # Real civitai shape (Fascium mv3006357): one filename for all quants,
+    # no metadata.quantType; the non-primary file's URL carries it.
+    files = _civitai_select_files({"files": [
+        {"id": 1, "name": "m.gguf", "sizeKB": 6331446,
+         "downloadUrl": "https://civitai.com/api/download/models/3006357",
+         "metadata": {"format": "GGUF"}},
+        {"id": 2, "name": "m.gguf", "sizeKB": 9514038,
+         "downloadUrl": "https://civitai.com/api/download/models/3006357?type=Model&format=GGUF&quantType=Q8_0",
+         "metadata": {"format": "GGUF"}},
+    ]}, gguf_quant="q8_0")
+    assert len(files) == 1
+    assert files[0]["id"] == 2


### PR DESCRIPTION
Follow-up to #185, found against the real mirror target (Fascium mv3006357): the model-versions API returns `metadata.quantType: null` for every file — the quant only appears in the per-file `downloadUrl` query string, and the version's PRIMARY file gets a bare default URL. `_civitai_gguf_quant_of` now reads the URL query before falling back to filename tokens, so explicit `gguf_quant` picks work on real gguf-only versions (which reuse one filename across quants). Version 0.13.26.

Test: real Fascium API shape (7/7 in test_civitai_gguf_select.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)