### PR TITLE
gw#485: wire-boundary token hygiene — colon dtype/flavor forms publish as '-' (0.13.25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.27"
+version = "0.13.28"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -475,18 +475,28 @@ class HubClient:
             "mode": mode,
         }
         if tags:
+            df = default_flavor.replace(":", "-")
             body["tags"] = [
-                {"tag": t, **({"default_flavor": default_flavor} if default_flavor else {})}
+                {"tag": t, **({"default_flavor": df} if df else {})}
                 for t in tags
             ]
+        # Wire-boundary token hygiene (gw#488): tensorhub derives a flavor
+        # row from the DTYPE (derivePublishFlavors) and validates every
+        # token against [a-z0-9][a-z0-9._-]{0,63} — the internal dtype-axis
+        # colon forms ("gguf:q4_k_m", "int8:awq") publish as "-" forms.
+        def _token(v: str) -> str:
+            return v.replace(":", "-")
+
         for key, val in (
-            ("message", message), ("flavor", flavor), ("default_flavor", default_flavor),
-            ("dtype", dtype), ("file_layout", file_layout), ("file_type", file_type),
+            ("message", message), ("flavor", _token(flavor)),
+            ("default_flavor", _token(default_flavor)),
+            ("dtype", _token(dtype)), ("file_layout", file_layout),
+            ("file_type", file_type),
         ):
             if val:
                 body[key] = val
         if flavors:
-            body["flavors"] = list(flavors)
+            body["flavors"] = [_token(f) for f in flavors]
         if metadata:
             body["metadata"] = dict(metadata)
         if provenance:

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -297,3 +297,28 @@ def test_clone_primary_output_claims_bare_selector() -> None:
 
     src = inspect.getsource(clone_mod)
     assert 'default_flavor=flavor_label if i == 0 else ""' in src
+
+
+def test_commit_sanitizes_colon_dtype_and_flavor_tokens(fake_hub, tmp_path: Path) -> None:
+    # gw#488: tensorhub derives a flavor row from the commit DTYPE
+    # (derivePublishFlavors) and validates every token against
+    # [a-z0-9][a-z0-9._-]{0,63} — the internal dtype-axis colon forms
+    # ("gguf:ud-q4_k_xl") must publish as "-" forms or every GGUF clone
+    # 400s at finalize (invalid_flavor; hit live, e2e J32 run 10).
+    _FakeHub.state["finalize_calls"] = 1
+    f = tmp_path / "model.gguf"
+    f.write_bytes(b"\x04" * 16)
+    _client(fake_hub).commit(
+        destination_repo="acme/my-gguf",
+        files=[CommitFile(path="model.gguf", local_path=f)],
+        tags=["prod"],
+        flavor="gguf:ud-q4_k_xl",
+        default_flavor="gguf:ud-q4_k_xl",
+        dtype="gguf:ud-q4_k_xl",
+        file_type="gguf",
+    )
+    body = _FakeHub.state["commit_request"]
+    assert body["flavor"] == "gguf-ud-q4_k_xl"
+    assert body["default_flavor"] == "gguf-ud-q4_k_xl"
+    assert body["dtype"] == "gguf-ud-q4_k_xl"
+    assert body["tags"] == [{"tag": "prod", "default_flavor": "gguf-ud-q4_k_xl"}]


### PR DESCRIPTION
tensorhub derives a flavor row from the commit DTYPE (\`derivePublishFlavors\`) and validates every
token against \`[a-z0-9][a-z0-9._-]{0,63}\`. The internal dtype-axis colon forms (\`gguf:ud-q4_k_xl\`,
\`int8:awq\`) made every GGUF clone 400 at finalize (\`invalid_flavor\`) even after gw#483 sanitized
the flavor label — the dtype attr re-derived the colon token hub-side.

Fix: sanitize every flavor-bearing wire field in \`HubClient.commit\` (\`flavor\`, \`default_flavor\`,
\`flavors[]\`, \`dtype\`, \`tags[].default_flavor\`) at the wire boundary; the internal dtype vocab keeps
its colon forms.

Live evidence (e2e J32 run 10): the full GGUF clone pipeline (unsloth/Qwen3.6-27B-MTP-GGUF,
gguf_quant=UD-Q4_K_XL, 17.9GB) ran end-to-end and died only at finalize on this token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)