### PR TITLE
th#737: castable gate on cast rungs + structural cast-drop reporting (0.13.29)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.28"
+version = "0.13.29"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1115,6 +1115,22 @@ class Executor:
             self.serve_plans.get(spec.name), detail=line, placement_mode=to_rung)
         self._on_state_change()
 
+    def _record_cast_drop(self, spec: EndpointSpec, *, ref: str,
+                          wanted: str, detail: str) -> None:
+        """th#737: a resolved cast (storage_dtype) cannot apply — the
+        pipeline has no denoiser/cast surface. Serve at base precision but
+        surface it STRUCTURALLY (FnDegraded wanted=fp8 ran=bf16 via the
+        state-delta path), never as a silent log-line fallback: the recipe
+        budgeted the cast's VRAM headroom."""
+        from .models.serve_fit import cast_dropped
+
+        logger.warning(
+            "CAST_DROPPED fn=%s model=%s wanted=%s ran=bf16 detail=%s",
+            spec.name, ref, wanted or "fp8", detail)
+        self.serve_plans[spec.name] = cast_dropped(
+            self.serve_plans.get(spec.name), wanted=wanted, detail=detail)
+        self._on_state_change()
+
     def available_functions(self) -> List[str]:
         out = []
         for name, spec in self.specs.items():
@@ -1637,6 +1653,23 @@ class Executor:
                         b for comp, b in sizes.items() if comp not in injected)
                     if excl_bytes > 0:
                         await asyncio.to_thread(res.make_room, excl_bytes)
+                # th#737: a cast directive on a denoiser-less diffusers
+                # tree is a load-time no-op that would silently serve bf16.
+                # Gate it up front when the snapshot's model_index proves
+                # there is no cast surface (unknown layouts pass through;
+                # the post-load outcome check below is the backstop).
+                if storage_dtype in ("fp8", "fp8+te"):
+                    comps = self._model_index_components(path)
+                    if comps and not ({"transformer", "unet"} & comps):
+                        self._record_cast_drop(
+                            spec, ref=ref, wanted="fp8",
+                            detail=(
+                                f"cast {storage_dtype!r} dropped for slot "
+                                f"{slot!r}: pipeline has no denoiser/cast "
+                                f"surface (components: {sorted(comps)}); "
+                                "serving at base precision"),
+                        )
+                        storage_dtype = ""
                 before = self._vram_allocated()
                 try:
                     pipe = await asyncio.to_thread(
@@ -1664,6 +1697,18 @@ class Executor:
                     pipe = await asyncio.to_thread(
                         load_from_pretrained, ann, path, dtype=dtype,
                         storage_dtype=storage_dtype, components=injected,
+                    )
+                if getattr(pipe, "_cozy_fp8_storage_requested", False) and not getattr(
+                        pipe, "_cozy_fp8_storage_ok", True):
+                    # th#737 backstop: the cast was attempted at load and
+                    # failed on every target — structural report, not a
+                    # silent bf16 fallback.
+                    self._record_cast_drop(
+                        spec, ref=ref, wanted="fp8",
+                        detail=(
+                            f"fp8 storage failed on every component of slot "
+                            f"{slot!r} ({type(pipe).__name__}); serving at "
+                            "base precision"),
                     )
                 placed = await asyncio.to_thread(place_pipeline, pipe, mode=mode, ref=ref)
                 if placed.get("oom_demotions"):

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -138,7 +138,10 @@ def placement_from_metadata(meta: Mapping[str, Any] | None) -> Optional[Placemen
 # fp8 bytes resident, per-layer bf16 upcast, no fp8 silicon required).
 # Rung gates: quality floor, placement SM admission, engines within installed
 # libs, est VRAM <= free. local=True appends emergency-nf4 then CPU-offload
-# (the hub never schedules those).
+# (the hub never schedules those). th#737: cast rungs (fp8 cast-at-load,
+# emergency nf4) additionally require model.castable — False for a diffusers
+# tree whose model_index has no transformer/unet component (latent
+# upsamplers): casting those is a load-time no-op that silently serves bf16.
 # ---------------------------------------------------------------------------
 
 # Native fp8 tensor-core compute exists on SM >= 89 (sm_89 Ada, sm_90 Hopper,
@@ -179,6 +182,11 @@ class LadderModel:
     base_size_gb: float = 0.0  # 0 = no bare/base row
     fp8_cast_vram_gb: float = 0.0  # 0 = use CAST_FP8_VRAM_FACTOR * base
     flavors: tuple[FlavorRow, ...] = ()
+    # th#737: whether the base pipeline has a denoiser/cast surface. False
+    # (a diffusers tree whose model_index has no transformer/unet component,
+    # e.g. latent upsamplers) removes ALL cast rungs (fp8 cast-at-load,
+    # emergency nf4); stored flavors and the bf16 base are unaffected.
+    castable: bool = True
 
 
 @dataclass(frozen=True)
@@ -254,7 +262,7 @@ def _rungs(
         stored = _stored_fp8(model, gpu_sm, libs)
         if stored is not None:
             fp8_rung = (stored.token, "", stored.size_gb)
-        elif model.base_size_gb > 0:
+        elif model.base_size_gb > 0 and model.castable:
             est = model.fp8_cast_vram_gb or CAST_FP8_VRAM_FACTOR * model.base_size_gb
             fp8_rung = ("", "fp8", est)
     base_rung: Optional[tuple[str, str, float]] = None
@@ -285,7 +293,7 @@ def resolve(
         if est <= free_vram_gb:
             return Resolution(flavor=flavor, cast=cast, mode=MODE_NATIVE)
     if local:
-        if quality_floor == "" and model.base_size_gb > 0:
+        if quality_floor == "" and model.base_size_gb > 0 and model.castable:
             est = EMERGENCY_NF4_VRAM_FACTOR * model.base_size_gb
             if est <= free_vram_gb:
                 stored = _stored_fp8(model, gpu_sm, lib_set)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -792,8 +792,16 @@ def load_from_pretrained(
             kwargs.pop("quantization_config", None)
             pipe = cls.from_pretrained(path, **kwargs)
     if fp8_storage and "quantization_config" not in kwargs:
-        apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"),
-                          text_encoders=fp8_text_encoders)
+        applied = apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"),
+                                    text_encoders=fp8_text_encoders)
+        # th#737: make the outcome observable — a cast that silently no-ops
+        # (denoiser-less pipeline) must surface as a structural degradation
+        # upstream, not vanish into a log line.
+        try:
+            pipe._cozy_fp8_storage_requested = True
+            pipe._cozy_fp8_storage_ok = bool(applied)
+        except Exception:
+            pass
     return pipe
 
 

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -102,8 +102,14 @@ class ServePlan:
 
     @property
     def degraded(self) -> bool:
-        """True when it runs, but not natively (slower and/or lower quality)."""
-        return self.serveable and self.run_mode != RUN_NATIVE
+        """True when it runs, but not as planned: non-native placement,
+        or (th#737) a precision pick that could not be applied
+        (``ran`` != ``wanted``, e.g. a dropped fp8 cast serving bf16)."""
+        if not self.serveable:
+            return False
+        if self.run_mode != RUN_NATIVE:
+            return True
+        return bool(self.wanted) and bool(self.ran) and self.ran != self.wanted
 
 
 def _wanted(binding: Any) -> str:
@@ -237,6 +243,29 @@ def demoted(
         warning=detail,
         est_latency_multiplier=_LATENCY_MULTIPLIER[RUN_OFFLOAD],
         ran=ran,
+    )
+
+
+def cast_dropped(
+    plan: Optional[ServePlan],
+    *,
+    wanted: str,
+    detail: str,
+) -> ServePlan:
+    """th#737: a resolved cast (``storage_dtype``) could not be applied —
+    the pipeline has no denoiser/cast surface (latent upsamplers, VAE-only
+    repos). The function still runs natively at base precision, but the
+    recipe budgeted the cast's VRAM: report it structurally (FnDegraded
+    wanted=fp8 ran=bf16), never as a silent bf16 fallback."""
+    base = plan if plan is not None else ServePlan(
+        serveable=True, run_mode=RUN_NATIVE, fit="", wanted="", ran="",
+    )
+    return replace(
+        base,
+        serveable=True,
+        wanted=(wanted or base.wanted or "fp8"),
+        ran="bf16",
+        warning=detail,
     )
 
 

--- a/tests/test_cast_drop_th737.py
+++ b/tests/test_cast_drop_th737.py
@@ -1,0 +1,251 @@
+"""th#737: a cast pick that cannot be satisfied is a STRUCTURAL degradation,
+never a silent bf16 fallback.
+
+Three layers under test:
+- ladder: ``castable=False`` removes cast rungs (shared vectors cover the
+  walk; here the local-model plumbing);
+- loading: the cast outcome is stamped on the pipe
+  (``_cozy_fp8_storage_requested`` / ``_cozy_fp8_storage_ok``);
+- executor: a denoiser-less snapshot drops the cast pre-load and records a
+  ``FnDegraded``-shaped ServePlan (wanted=fp8, ran=bf16) via the real
+  ensure_setup/injection path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import struct
+from pathlib import Path
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models.ladder import LadderModel, resolve
+from gen_worker.models.loading import load_from_pretrained
+from gen_worker.models.serve_fit import ServePlan, cast_dropped
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+# --------------------------------------------------------------------------
+# ladder: castable gate
+# --------------------------------------------------------------------------
+
+
+def test_ladder_no_cast_rung_when_not_castable() -> None:
+    got = resolve(
+        LadderModel(base_size_gb=11.4, castable=False),
+        gpu_sm=90, free_vram_gb=79.0,
+    )
+    assert (got.flavor, got.cast, got.refusal) == ("", "", "")
+
+
+def test_ladder_refuses_instead_of_phantom_cast() -> None:
+    got = resolve(
+        LadderModel(base_size_gb=11.4, castable=False),
+        gpu_sm=90, free_vram_gb=10.0,
+    )
+    assert got.refusal == "no_runnable_precision"
+
+
+# --------------------------------------------------------------------------
+# serve_fit: the structural plan
+# --------------------------------------------------------------------------
+
+
+def test_cast_dropped_plan_is_degraded() -> None:
+    plan = cast_dropped(None, wanted="fp8", detail="no cast surface")
+    assert plan.degraded
+    assert plan.wanted == "fp8" and plan.ran == "bf16"
+    assert plan.serveable
+
+
+def test_native_matching_plan_is_not_degraded() -> None:
+    plan = ServePlan(serveable=True, run_mode="native", fit="fits",
+                     wanted="bf16", ran="bf16")
+    assert not plan.degraded
+
+
+# --------------------------------------------------------------------------
+# loading: cast outcome stamped on the pipe
+# --------------------------------------------------------------------------
+
+
+class _Denoiser:
+    def __init__(self) -> None:
+        self.casting_calls: list = []
+
+    def parameters(self):
+        return iter(())
+
+    def enable_layerwise_casting(self, *, storage_dtype, compute_dtype) -> None:
+        self.casting_calls.append((storage_dtype, compute_dtype))
+
+
+class _DenoiserPipe:
+    def __init__(self) -> None:
+        self.transformer = _Denoiser()
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs):
+        return cls()
+
+
+class _NoSurfacePipe:
+    """Latent-upsampler shape: no transformer/unet, not a bare nn.Module."""
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs):
+        return cls()
+
+
+def _write_safetensors(path: Path, dtype: str = "BF16", nbytes: int = 1024) -> None:
+    header = json.dumps(
+        {"w": {"dtype": dtype, "shape": [nbytes], "data_offsets": [0, nbytes]}}
+    ).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def _snapshot(tmp_path: Path, components: dict) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    index = {"_class_name": "Pipe"}
+    index.update(components)
+    (tmp_path / "model_index.json").write_text(json.dumps(index))
+    _write_safetensors(tmp_path / "diffusion_pytorch_model.safetensors")
+    return tmp_path
+
+
+def test_load_stamps_cast_ok(tmp_path: Path) -> None:
+    snap = _snapshot(tmp_path, {"transformer": ["x", "y"]})
+    pipe = load_from_pretrained(_DenoiserPipe, snap, dtype="bf16",
+                                storage_dtype="fp8")
+    assert pipe._cozy_fp8_storage_requested is True
+    assert pipe._cozy_fp8_storage_ok is True
+    assert len(pipe.transformer.casting_calls) == 1
+
+
+def test_load_stamps_cast_failure(tmp_path: Path) -> None:
+    snap = _snapshot(tmp_path, {"latent_upsampler": ["x", "y"]})
+    pipe = load_from_pretrained(_NoSurfacePipe, snap, dtype="bf16",
+                                storage_dtype="fp8")
+    assert pipe._cozy_fp8_storage_requested is True
+    assert pipe._cozy_fp8_storage_ok is False
+
+
+# --------------------------------------------------------------------------
+# executor: pre-load drop + structural report through the real load path
+# --------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    x: str = "hi"
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+def _executor(spec: EndpointSpec, tmp_path: Path, snap: Path, sent: list) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=4 << 30)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        store.residency.track_disk(ref, snap)
+        return snap
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return Executor([spec], _send, store=store)
+
+
+class _UpsamplerShim:
+    """No transformer/unet component; records that the loader saw NO cast."""
+
+    to_calls: list = []
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs):
+        return cls()
+
+    def to(self, *a, **k):
+        type(self).to_calls.append((a, k))
+        return self
+
+
+def test_executor_drops_cast_on_denoiserless_snapshot(
+        tmp_path, monkeypatch, caplog) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+
+    class Endpoint:
+        def setup(self, m: _UpsamplerShim) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="upsample", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"m": Hub("acme/upsampler", storage_dtype="fp8")},
+        resources=Resources(vram_gb=1.0),
+    )
+    snap = _snapshot(tmp_path / "snapdir", {"latent_upsampler": ["a", "b"], "vae": ["a", "b"]})
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, snap, sent)
+        with caplog.at_level(logging.WARNING):
+            inst = await ex.ensure_setup(spec)
+        # The cast was dropped BEFORE load: no fp8 stamp on the pipe.
+        assert not getattr(inst.m, "_cozy_fp8_storage_requested", False)
+        # Structural report, FnDegraded-shaped: wanted fp8, ran bf16.
+        plan = ex.serve_plans["upsample"]
+        assert plan.degraded
+        assert plan.wanted == "fp8" and plan.ran == "bf16"
+        assert "no denoiser/cast surface" in plan.warning
+        assert "CAST_DROPPED" in caplog.text
+
+    asyncio.run(_go())
+
+
+class _DenoiserShim(_DenoiserPipe):
+    def to(self, *a, **k):
+        return self
+
+
+def test_executor_keeps_cast_on_denoiser_snapshot(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+
+    class Endpoint:
+        def setup(self, m: _DenoiserShim) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"m": Hub("acme/z-image", storage_dtype="fp8")},
+        resources=Resources(vram_gb=1.0),
+    )
+    snap = _snapshot(tmp_path / "snapdir", {"transformer": ["a", "b"], "vae": ["a", "b"]})
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, snap, sent)
+        inst = await ex.ensure_setup(spec)
+        assert inst.m._cozy_fp8_storage_requested is True
+        assert inst.m._cozy_fp8_storage_ok is True
+        plan = ex.serve_plans.get("generate")
+        assert plan is None or not plan.degraded
+
+    asyncio.run(_go())

--- a/tests/test_precision_ladder_vectors.py
+++ b/tests/test_precision_ladder_vectors.py
@@ -37,6 +37,7 @@ def _model(spec: dict) -> LadderModel:
         base_size_gb=float(spec.get("base_size_gb", 0.0)),
         fp8_cast_vram_gb=float(spec.get("fp8_cast_vram_gb", 0.0)),
         flavors=rows,
+        castable=bool(spec.get("castable", True)),
     )
 
 

--- a/tests/testdata/precision_ladder_vectors.json
+++ b/tests/testdata/precision_ladder_vectors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "th#697 shared precision-ladder conformance vectors. This file is vendored BYTE-IDENTICALLY in tensorhub (internal/orchestrator/precision/testdata/) and python-gen-worker (tests/testdata/) — the Go resolver and gen_worker.models.ladder.resolve must produce identical outcomes for every vector; any spec change edits BOTH copies. Spec: walk [best admitted 4-bit svdq flavor (fp4>int4, rank desc)] then an SM-CONDITIONAL fp8/bf16 pair (Paul's fp8 ruling): on fp8-compute silicon (gpu_sm>=89: Ada/Hopper/Blackwell) [fp8 stored > fp8 cast-at-load] BEFORE [bf16 base] (fp8 tensor cores => faster AND smaller); below it (gpu_sm<89) [bf16 base] BEFORE [fp8 stored > fp8 cast-at-load] (fp8 storage upcasts to bf16 there — same speed, so fp8 is only a FIT FALLBACK when bf16 won't fit). fp8 cast est = fp8_cast_vram_gb else 0.75*base_size_gb. fp8 is NEVER SM-refused (storage is universal). Each rung gated by quality floor (bf16=3 > fp8=2 > 4bit=1; ''=any), placement SM admission (checkpoint metadata placement block wins, else flavor-token defaults: svdq-fp4 sm 120/121, svdq-int4 sm 75-89, engines nunchaku; fp8/base universal), required engines within libs, and est_vram_gb <= free_vram_gb. local=true appends emergency-nf4 (quality_floor must be '', est 0.45*base, artifact = stored fp8 if admitted else base, cast=nf4) then offload (first arch/engine-eligible rung ignoring fit, requires allow_offload). No rung -> refusal no_runnable_precision; gpu_sm<=0 -> refusal no_cuda_gpu. nvfp4-class flavors are never diffusers rungs (TRT lane).",
+  "_comment": "th#697 shared precision-ladder conformance vectors. This file is vendored BYTE-IDENTICALLY in tensorhub (internal/orchestrator/precision/testdata/) and python-gen-worker (tests/testdata/) — the Go resolver and gen_worker.models.ladder.resolve must produce identical outcomes for every vector; any spec change edits BOTH copies. Spec: walk [best admitted 4-bit svdq flavor (fp4>int4, rank desc)] then an SM-CONDITIONAL fp8/bf16 pair (Paul's fp8 ruling): on fp8-compute silicon (gpu_sm>=89: Ada/Hopper/Blackwell) [fp8 stored > fp8 cast-at-load] BEFORE [bf16 base] (fp8 tensor cores => faster AND smaller); below it (gpu_sm<89) [bf16 base] BEFORE [fp8 stored > fp8 cast-at-load] (fp8 storage upcasts to bf16 there — same speed, so fp8 is only a FIT FALLBACK when bf16 won't fit). fp8 cast est = fp8_cast_vram_gb else 0.75*base_size_gb. fp8 is NEVER SM-refused (storage is universal). Each rung gated by quality floor (bf16=3 > fp8=2 > 4bit=1; ''=any), placement SM admission (checkpoint metadata placement block wins, else flavor-token defaults: svdq-fp4 sm 120/121, svdq-int4 sm 75-89, engines nunchaku; fp8/base universal), required engines within libs, and est_vram_gb <= free_vram_gb. local=true appends emergency-nf4 (quality_floor must be '', est 0.45*base, artifact = stored fp8 if admitted else base, cast=nf4) then offload (first arch/engine-eligible rung ignoring fit, requires allow_offload). No rung -> refusal no_runnable_precision; gpu_sm<=0 -> refusal no_cuda_gpu. nvfp4-class flavors are never diffusers rungs (TRT lane). th#737: model.castable (default true) marks a base pipeline WITH a denoiser/cast surface; castable=false (a diffusers tree whose model_index has no transformer/unet component, e.g. latent upsamplers) removes ALL cast rungs (fp8 cast-at-load, emergency nf4) — stored flavors and the bf16 base are unaffected.",
   "vectors": [
     {
       "name": "blackwell-5090-svdq-fp4-present",
@@ -228,6 +228,30 @@
       "gpu_sm": 89, "free_vram_gb": 23.0, "libs": ["nunchaku"],
       "model": {"base_size_gb": 12.2, "flavors": {"svdq-int4-r32": {"size_gb": 3.5}, "svdq-int4-r128": {"size_gb": 3.9}}},
       "expect": {"flavor": "svdq-int4-r128", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "h100-no-cast-surface-runs-base",
+      "gpu_sm": 90, "free_vram_gb": 79.0, "libs": [],
+      "model": {"base_size_gb": 11.4, "castable": false, "flavors": {}},
+      "expect": {"flavor": "", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "h100-no-cast-surface-tight-vram-refuses-instead-of-cast",
+      "gpu_sm": 90, "free_vram_gb": 10.0, "libs": [],
+      "model": {"base_size_gb": 11.4, "castable": false, "flavors": {}},
+      "expect": {"refusal": "no_runnable_precision"}
+    },
+    {
+      "name": "no-cast-surface-stored-fp8-still-serves",
+      "gpu_sm": 90, "free_vram_gb": 8.0, "libs": [],
+      "model": {"base_size_gb": 11.4, "castable": false, "flavors": {"fp8": {"size_gb": 6.2}}},
+      "expect": {"flavor": "fp8", "cast": "", "mode": "native"}
+    },
+    {
+      "name": "local-no-cast-surface-blocks-emergency-nf4-offloads-instead",
+      "gpu_sm": 89, "free_vram_gb": 6.0, "libs": [], "local": true, "allow_offload": true,
+      "model": {"base_size_gb": 11.4, "castable": false, "flavors": {}},
+      "expect": {"flavor": "", "cast": "", "mode": "offload"}
     }
   ]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.25"
+version = "0.13.29"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
gen-worker half of th#737 (hub half: tensorhub PR#264). A `cast=fp8` pick on a denoiser-less pipeline (`LTX2LatentUpsamplePipeline` — no transformer/unet) failed at load with a bare warning and silently served bf16, wasting the VRAM headroom the recipe budgeted (live: ie#382 dozen lane, sm90 pick on `tensorhub/ltx-2.3-upsampler`).

- **ladder (shared spec)**: `LadderModel.castable` (default true) gates the cast rungs — fp8 cast-at-load AND emergency nf4; stored flavors and the bf16 base are unaffected. Conformance vectors 38 → 42, byte-identical with tensorhub's copy (PR#264).
- **executor pre-load gate**: a `storage_dtype` cast directed at a snapshot whose `model_index.json` has no transformer/unet component is dropped BEFORE load and recorded via `_record_cast_drop` — ServePlan `wanted=fp8 ran=bf16` → `FnDegraded` on the state-delta path (the structural surface th#737 asks for), plus a `CAST_DROPPED` log line. Unknown layouts (single-file, bare modules) pass through.
- **post-load backstop**: `apply_fp8_storage`'s outcome is stamped on the pipe (`_cozy_fp8_storage_requested/_ok`); a cast that fails on every target at runtime also records the structural degradation instead of vanishing into a warning.
- **serve_fit**: `cast_dropped()` plan constructor; `ServePlan.degraded` now covers precision mismatch (`ran != wanted`) alongside placement degradation, so `_emit_degraded` picks it up with zero lifecycle changes.

Tests: new `tests/test_cast_drop_th737.py` (ladder gate, plan semantics, pipe stamps, and both executor paths through the REAL ensure_setup/injection codepath); full suite 866 passed / 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)