### PR TITLE
feat: step-aware progress — ctx.progress step/total + diffusers step callback (#482)

### DIFF
--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -22,6 +22,7 @@ from .api.errors import (
     RetryableError,
     ValidationError,
 )
+from .api.progress import diffusers_step_callback
 from .api.streaming import (
     BatchItemDelta,
     Done,
@@ -66,6 +67,8 @@ __all__ = [
     "DatasetContext",
     "TrainingContext",
     "TrainingMetric",
+    # Per-step progress helper for diffusers pipelines.
+    "diffusers_step_callback",
     # Delegated-trainer subprocess primitive.
     "run_process",
     # Errors.

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -15,6 +15,7 @@ from .errors import (
     ValidationError,
     WorkerError,
 )
+from .progress import diffusers_step_callback
 from .streaming import (
     BatchItemDelta,
     Done,
@@ -49,6 +50,7 @@ __all__ = [
     "ModelScope",
     "Resources",
     "endpoint",
+    "diffusers_step_callback",
     "AuthError",
     "CanceledError",
     "FatalError",

--- a/src/gen_worker/api/progress.py
+++ b/src/gen_worker/api/progress.py
@@ -1,0 +1,61 @@
+"""Per-step progress helper for diffusers pipelines (pgw#482).
+
+Free function over a context method so :class:`RequestContext` keeps its
+capped surface. Does not import diffusers — it just returns a callable that
+matches the ``callback_on_step_end`` contract.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+if TYPE_CHECKING:
+    from ..request_context import RequestContext
+
+#: Min seconds between emitted step events; first and last steps always emit.
+#: Mirrors the ``training_metric`` throttle so 20-step turbo runs don't spam.
+DEFAULT_STEP_MIN_INTERVAL_S = 0.25
+
+
+def diffusers_step_callback(
+    ctx: "RequestContext",
+    num_inference_steps: int,
+    *,
+    stage: Optional[str] = "denoise",
+    min_interval_s: float = DEFAULT_STEP_MIN_INTERVAL_S,
+) -> Callable[..., Dict[str, Any]]:
+    """Wire a diffusers pipeline's per-step callback to ``ctx.progress``.
+
+    One line in an endpoint function::
+
+        pipe(..., callback_on_step_end=diffusers_step_callback(ctx, steps))
+
+    After each denoise step it emits ``ctx.progress(step/total, stage,
+    step=step, total=total)``, throttled to one event per ``min_interval_s``
+    (first and last steps always emit). It also calls
+    ``ctx.raise_if_cancelled()`` every step, so a cancelled request aborts
+    the pipeline mid-run instead of denoising to completion.
+    """
+    total = int(num_inference_steps)
+    last_emit: Optional[float] = None
+
+    def _on_step_end(
+        _pipe: Any,
+        step_index: int,
+        _timestep: Any = None,
+        callback_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        nonlocal last_emit
+        ctx.raise_if_cancelled()
+        step = int(step_index) + 1  # fires after the step ends -> 1-based count
+        now = time.monotonic()
+        is_first = last_emit is None
+        is_last = total > 0 and step >= total
+        if is_first or is_last or (now - last_emit) >= min_interval_s:
+            last_emit = now
+            fraction = min(step / total, 1.0) if total > 0 else 0.0
+            ctx.progress(fraction, stage, step=step, total=total)
+        return callback_kwargs if callback_kwargs is not None else {}
+
+    return _on_step_end

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -429,10 +429,27 @@ class RequestContext:
             "timestamp": time.time(),
         })
 
-    def progress(self, progress: float, stage: Optional[str] = None) -> None:
+    def progress(
+        self,
+        progress: float,
+        stage: Optional[str] = None,
+        *,
+        step: Optional[int] = None,
+        total: Optional[int] = None,
+    ) -> None:
+        """Report request progress (best-effort, rides ``request.progress``).
+
+        ``progress`` is a 0..1 fraction; ``step``/``total`` carry the exact
+        step counter when known (e.g. denoise step 5 of 20) so UIs can render
+        "5 / 20" instead of a bare percentage.
+        """
         payload: Dict[str, Any] = {"progress": progress}
         if stage is not None:
             payload["stage"] = stage
+        if step is not None:
+            payload["step"] = int(step)
+        if total is not None:
+            payload["total"] = int(total)
         self._emit_event("request.progress", payload)
 
     def _emit_checkpoint_saved(

--- a/tests/test_progress_helper.py
+++ b/tests/test_progress_helper.py
@@ -1,0 +1,64 @@
+"""diffusers_step_callback (pgw#482): one-line per-step progress for
+diffusers pipelines — step/total on the wire, throttled, cancel-aware."""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import CanceledError, RequestContext, diffusers_step_callback
+
+
+def _ctx(events: list) -> RequestContext:
+    return RequestContext(request_id="r1", emitter=events.append)
+
+
+def _run_steps(cb, total: int) -> None:
+    for i in range(total):
+        cb(None, i, None, {})
+
+
+def test_emits_step_total_and_fraction() -> None:
+    events: list = []
+    cb = diffusers_step_callback(_ctx(events), 4, min_interval_s=0.0)
+    _run_steps(cb, 4)
+    assert [e["type"] for e in events] == ["request.progress"] * 4
+    payloads = [e["payload"] for e in events]
+    assert payloads[0] == {"progress": 0.25, "stage": "denoise", "step": 1, "total": 4}
+    assert payloads[-1] == {"progress": 1.0, "stage": "denoise", "step": 4, "total": 4}
+
+
+def test_throttles_but_always_emits_first_and_last() -> None:
+    events: list = []
+    # Huge interval: only the first and last of 20 steps get through.
+    cb = diffusers_step_callback(_ctx(events), 20, min_interval_s=3600.0)
+    _run_steps(cb, 20)
+    steps = [e["payload"]["step"] for e in events]
+    assert steps == [1, 20]
+
+
+def test_returns_callback_kwargs_unchanged() -> None:
+    events: list = []
+    cb = diffusers_step_callback(_ctx(events), 2, min_interval_s=0.0)
+    kwargs = {"latents": object()}
+    assert cb(None, 0, None, kwargs) is kwargs
+    assert cb(None, 1, None) == {}  # pipelines that pass no kwargs
+
+
+def test_custom_stage_and_stage_none() -> None:
+    events: list = []
+    ctx = _ctx(events)
+    diffusers_step_callback(ctx, 1, stage="upscale", min_interval_s=0.0)(None, 0, None, {})
+    diffusers_step_callback(ctx, 1, stage=None, min_interval_s=0.0)(None, 0, None, {})
+    assert events[0]["payload"]["stage"] == "upscale"
+    assert "stage" not in events[1]["payload"]
+
+
+def test_cancelled_request_aborts_mid_pipeline() -> None:
+    events: list = []
+    ctx = _ctx(events)
+    cb = diffusers_step_callback(ctx, 10, min_interval_s=0.0)
+    cb(None, 0, None, {})
+    ctx._cancel()
+    with pytest.raises(CanceledError):
+        cb(None, 1, None, {})
+    assert len(events) == 1  # nothing emitted after cancellation

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -65,6 +65,17 @@ def test_progress_and_log_emit_events() -> None:
     assert events[0]["payload"] == {"progress": 0.5, "stage": "denoise"}
 
 
+def test_progress_carries_optional_step_and_total() -> None:
+    events = []
+    ctx = RequestContext(request_id="r1", emitter=events.append)
+    ctx.progress(0.25, "denoise", step=5, total=20)
+    ctx.progress(0.9)  # step/total omitted -> keys absent, not null
+    assert events[0]["payload"] == {
+        "progress": 0.25, "stage": "denoise", "step": 5, "total": 20,
+    }
+    assert events[1]["payload"] == {"progress": 0.9}
+
+
 def test_save_bytes_and_typed_image_asset(tmp_path) -> None:
     ctx = RequestContext(request_id="r1", local_output_dir=str(tmp_path))
     asset = ctx.save_bytes("out/a.bin", b"hello")


### PR DESCRIPTION
Tracker: python-gen-worker #482 (cozy-art #172 rich job card; hub counterpart tensorhub #737).

## What

- `ctx.progress(progress, stage=None, *, step=None, total=None)` — optional keyword-only step counters, emitted in the `request.progress` payload as `{progress, stage?, step?, total?}` so the cozy.art job card can render "5 / 20" instead of a bare percentage. Keys are absent (not null) when unset; the executor JSON-encodes ctx events opaquely, so no wire/executor changes.
- `gen_worker.diffusers_step_callback(ctx, num_inference_steps, *, stage="denoise", min_interval_s=0.25)` — free function (RequestContext surface stays capped at 16) returning a `callback_on_step_end`-compatible callable:

  ```python
  pipe(..., callback_on_step_end=diffusers_step_callback(ctx, steps))
  ```

  Emits 1-based `step`/`total` + fraction per denoise step, throttled to one event per 0.25s with first/last always emitting (same idiom as the `training_metric` throttle), and calls `ctx.raise_if_cancelled()` each step so cancellation aborts the pipeline mid-run. No diffusers import.

## Tests

- `tests/test_request_context.py`: step/total in payload, keys absent when omitted.
- `tests/test_progress_helper.py`: fraction/step/total emission, first/last-always throttle, callback_kwargs passthrough, custom/None stage, cancel abort.

`pytest tests/` (minus `tests/convert`): 697 passed, 17 skipped. Remaining failures are pre-existing on origin/master in this environment (`test_cli_run_setup_injection` — GEN_WORKER_FORBID_CPU_OFFLOAD box guard; `test_ram_admission`, `test_snapshot_corruption` — fail identically on a pristine master tree). ruff clean; mypy error count unchanged vs master (pre-existing noise only).

Endpoint adoption (sdxl, z-image, klein, wan/ltx, qwen-image families) is deliberately NOT in this PR — follow-up list filed on tracker #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)