### PR TITLE
gw#491: load-time precision reality reaches ServePlan/FnDegraded (0.13.31)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.30"
+version = "0.13.31"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1115,8 +1115,23 @@ class Executor:
             self.serve_plans.get(spec.name), detail=line, placement_mode=to_rung)
         self._on_state_change()
 
+    def _record_adaptive_rung(self, spec: EndpointSpec, *, ref: str,
+                              rung: str, detail: str) -> None:
+        """gw#491: the load-time adaptive fit ladder engaged an emergency
+        rung (runtime fp8 storage / nf4). Surface it exactly like the
+        plan-time rungs — updated ServePlan + FnDegraded via the state-delta
+        path — never as a log-line-only fallback."""
+        from .models.serve_fit import load_rung_engaged
+
+        logger.warning(
+            "LOAD_RUNG_ENGAGED fn=%s model=%s rung=%s detail=%s",
+            spec.name, ref, rung, detail)
+        self.serve_plans[spec.name] = load_rung_engaged(
+            self.serve_plans.get(spec.name), rung=rung, detail=detail)
+        self._on_state_change()
+
     def _record_cast_drop(self, spec: EndpointSpec, *, ref: str,
-                          wanted: str, detail: str) -> None:
+                          wanted: str, detail: str, ran: str = "bf16") -> None:
         """th#737: a resolved cast (storage_dtype) cannot apply — the
         pipeline has no denoiser/cast surface. Serve at base precision but
         surface it STRUCTURALLY (FnDegraded wanted=fp8 ran=bf16 via the
@@ -1125,10 +1140,11 @@ class Executor:
         from .models.serve_fit import cast_dropped
 
         logger.warning(
-            "CAST_DROPPED fn=%s model=%s wanted=%s ran=bf16 detail=%s",
-            spec.name, ref, wanted or "fp8", detail)
+            "CAST_DROPPED fn=%s model=%s wanted=%s ran=%s detail=%s",
+            spec.name, ref, wanted or "fp8", ran or "bf16", detail)
         self.serve_plans[spec.name] = cast_dropped(
-            self.serve_plans.get(spec.name), wanted=wanted, detail=detail)
+            self.serve_plans.get(spec.name), wanted=wanted, detail=detail,
+            ran=ran)
         self._on_state_change()
 
     def available_functions(self) -> List[str]:
@@ -1662,7 +1678,8 @@ class Executor:
                     comps = self._model_index_components(path)
                     if comps and not ({"transformer", "unet"} & comps):
                         self._record_cast_drop(
-                            spec, ref=ref, wanted="fp8",
+                            spec, ref=ref, wanted=storage_dtype,
+                            ran=(dtype or "bf16"),
                             detail=(
                                 f"cast {storage_dtype!r} dropped for slot "
                                 f"{slot!r}: pipeline has no denoiser/cast "
@@ -1698,13 +1715,29 @@ class Executor:
                         load_from_pretrained, ann, path, dtype=dtype,
                         storage_dtype=storage_dtype, components=injected,
                     )
-                if getattr(pipe, "_cozy_fp8_storage_requested", False) and not getattr(
-                        pipe, "_cozy_fp8_storage_ok", True):
-                    # th#737 backstop: the cast was attempted at load and
-                    # failed on every target — structural report, not a
-                    # silent bf16 fallback.
+                rung = str(getattr(pipe, "_cozy_adaptive_rung", "") or "")
+                cast_failed = getattr(
+                    pipe, "_cozy_fp8_storage_requested", False
+                ) and not getattr(pipe, "_cozy_fp8_storage_ok", True)
+                if rung == "nf4" or (rung == "fp8" and not cast_failed):
+                    # gw#491: the loader engaged an emergency rung because
+                    # free VRAM at load was tighter than gate-time planning
+                    # assumed — reconcile it into ServePlan/FnDegraded.
+                    self._record_adaptive_rung(
+                        spec, ref=ref, rung=rung,
+                        detail=(
+                            f"adaptive fit rung {rung!r} engaged at load for "
+                            f"slot {slot!r} ({type(pipe).__name__}); free "
+                            "VRAM below the stored-precision footprint"),
+                    )
+                elif cast_failed and not rung:
+                    # th#737 backstop: the RESOLUTION cast was attempted at
+                    # load and failed on every target — structural report,
+                    # not a silent bf16 fallback. (A failed adaptive fp8 is
+                    # not a plan deviation: the plan was base precision.)
                     self._record_cast_drop(
-                        spec, ref=ref, wanted="fp8",
+                        spec, ref=ref, wanted=(storage_dtype or "fp8"),
+                        ran=(dtype or "bf16"),
                         detail=(
                             f"fp8 storage failed on every component of slot "
                             f"{slot!r} ({type(pipe).__name__}); serving at "
@@ -2543,7 +2576,11 @@ class Executor:
                 path = await self.store.ensure_local(ref, snapshots.get(ref))
                 ensure_ms = int((time.monotonic() - t0) * 1000)
                 snap = snapshots.get(ref)
+                # gw#491: normalize to the bare-hex spelling — snap.digest may
+                # carry an algo prefix ("blake3:<hex>") while path.name is the
+                # bare hex; one adapter must never mint two cache identities.
                 digest = (snap.digest if snap is not None else "") or path.name
+                digest = digest.split(":", 1)[-1].strip().lower()
                 cache_key = f"{ref}@{digest}"
                 t1 = time.monotonic()
                 state_dict = self._adapter_cache.get(cache_key)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -738,15 +738,18 @@ def load_from_pretrained(
                 pass
     fp8_storage = storage_dtype in ("fp8", "fp8+te") or sniffed == "fp8"
     fp8_text_encoders = storage_dtype == "fp8+te"
+    adaptive_rung = ""  # gw#491: load-time rung engagement, stamped on the pipe
     if not read_on_disk_quant_config(Path(path)):
         qc = synthesize_quantization_config(attrs)
         if qc is None:
             mode, eqc = _adaptive_fit_rung(cls, Path(path), fp8_planned=fp8_storage)
             if mode == "fp8":
                 fp8_storage = True  # runtime fp8-E4M3 storage rung (th#683)
+                adaptive_rung = "fp8"
             elif eqc is not None:
                 qc = eqc
                 fp8_storage = False  # nf4 supersedes the fp8 rung
+                adaptive_rung = "nf4"
         if qc is not None:
             kwargs["quantization_config"] = qc
     single = _single_file_checkpoint(Path(path))
@@ -771,6 +774,13 @@ def load_from_pretrained(
         try:
             pipe._cozy_fp8_storage_requested = True
             pipe._cozy_fp8_storage_ok = bool(applied)
+        except Exception:
+            pass
+    if adaptive_rung:
+        # gw#491: a silently-engaged emergency rung is the th#736 bug class —
+        # the executor reconciles this stamp into ServePlan.ran / FnDegraded.
+        try:
+            pipe._cozy_adaptive_rung = adaptive_rung
         except Exception:
             pass
     return pipe

--- a/src/gen_worker/models/serve_fit.py
+++ b/src/gen_worker/models/serve_fit.py
@@ -113,8 +113,15 @@ class ServePlan:
 
 
 def _wanted(binding: Any) -> str:
+    """The precision the (post-resolution) binding plans to run: its stored
+    flavor, else its cast directive (storage_dtype — a hub pick folds in as
+    one, gw#491), else base bf16. Counting the cast here makes a SUCCESSFUL
+    cast visible (wanted=fp8 ran=fp8) instead of masquerading as bf16."""
     flavor = str(getattr(binding, "flavor", "") or "").strip().lower()
-    return flavor or "bf16"
+    if flavor:
+        return flavor
+    storage = str(getattr(binding, "storage_dtype", "") or "").strip().lower()
+    return storage or "bf16"
 
 
 def plan_serve(
@@ -251,12 +258,14 @@ def cast_dropped(
     *,
     wanted: str,
     detail: str,
+    ran: str = "bf16",
 ) -> ServePlan:
     """th#737: a resolved cast (``storage_dtype``) could not be applied —
     the pipeline has no denoiser/cast surface (latent upsamplers, VAE-only
-    repos). The function still runs natively at base precision, but the
-    recipe budgeted the cast's VRAM: report it structurally (FnDegraded
-    wanted=fp8 ran=bf16), never as a silent bf16 fallback."""
+    repos). The function still runs natively at base precision (``ran``,
+    default bf16), but the recipe budgeted the cast's VRAM: report it
+    structurally (FnDegraded wanted=fp8 ran=bf16), never as a silent
+    fallback."""
     base = plan if plan is not None else ServePlan(
         serveable=True, run_mode=RUN_NATIVE, fit="", wanted="", ran="",
     )
@@ -264,8 +273,33 @@ def cast_dropped(
         base,
         serveable=True,
         wanted=(wanted or base.wanted or "fp8"),
-        ran="bf16",
+        ran=(ran or "bf16"),
         warning=detail,
+    )
+
+
+def load_rung_engaged(
+    plan: Optional[ServePlan],
+    *,
+    rung: str,
+    detail: str,
+) -> ServePlan:
+    """gw#491: the load-time adaptive fit ladder engaged an emergency rung
+    (runtime fp8 storage or nf4) because free VRAM at load was tighter than
+    gate-time planning assumed. Same ServePlan/FnDegraded shape as the
+    plan-time emergency rungs — a 4-bit pipeline must never report
+    RUN_NATIVE wanted==ran."""
+    run_mode = RUN_FP8_STORAGE if rung == "fp8" else RUN_EMERGENCY
+    base = plan if plan is not None else ServePlan(
+        serveable=True, run_mode=RUN_NATIVE, fit="", wanted="bf16", ran="bf16",
+    )
+    return replace(
+        base,
+        serveable=True,
+        run_mode=run_mode,
+        warning=detail,
+        est_latency_multiplier=_LATENCY_MULTIPLIER[run_mode],
+        ran=run_mode,
     )
 
 

--- a/tests/test_adaptive_rung_gw491.py
+++ b/tests/test_adaptive_rung_gw491.py
@@ -1,0 +1,186 @@
+"""gw#491: load-time precision reality must reach ServePlan/FnDegraded.
+
+Three seams under test:
+- serve_fit: ``_wanted`` counts a cast directive (storage_dtype), so a
+  SUCCESSFUL cast reports wanted=fp8 ran=fp8 instead of masquerading as
+  bf16; ``load_rung_engaged`` produces the plan-time emergency shape for
+  load-time rung engagement; ``cast_dropped`` reports the actual base
+  precision it fell back to.
+- loading: an adaptive-fit-rung engagement is stamped on the pipe
+  (``_cozy_adaptive_rung``), same pattern as the th#737 cast stamps.
+- executor: the stamp is reconciled into serve_plans + the state-delta
+  path via the REAL ensure_setup/injection path — a silently nf4-quantized
+  pipeline must never report RUN_NATIVE wanted==ran.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import struct
+from pathlib import Path
+
+import msgspec
+
+import gen_worker.models.loading as loading_mod
+from gen_worker.api.binding import Hub
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models.serve_fit import (
+    RUN_EMERGENCY,
+    RUN_FP8_STORAGE,
+    ServePlan,
+    _wanted,
+    cast_dropped,
+    load_rung_engaged,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+from gen_worker.api.decorators import Resources
+
+
+# --------------------------------------------------------------------------
+# serve_fit: wanted derivation + plan shapes
+# --------------------------------------------------------------------------
+
+
+def test_wanted_counts_storage_dtype() -> None:
+    assert _wanted(Hub("a/b", storage_dtype="fp8")) == "fp8"
+    assert _wanted(Hub("a/b", storage_dtype="fp8+te")) == "fp8+te"
+
+
+def test_wanted_flavor_beats_storage_dtype() -> None:
+    assert _wanted(Hub("a/b", flavor="svdq-int4-r128")) == "svdq-int4-r128"
+    assert _wanted(Hub("a/b")) == "bf16"
+
+
+def test_cast_dropped_reports_actual_base_precision() -> None:
+    plan = cast_dropped(None, wanted="fp8", detail="no surface", ran="fp16")
+    assert plan.degraded
+    assert plan.wanted == "fp8" and plan.ran == "fp16"
+
+
+def test_load_rung_engaged_nf4_is_degraded_emergency() -> None:
+    base = ServePlan(serveable=True, run_mode="native", fit="fits",
+                     wanted="bf16", ran="bf16")
+    plan = load_rung_engaged(base, rung="nf4", detail="tight VRAM")
+    assert plan.degraded
+    assert plan.run_mode == RUN_EMERGENCY and plan.ran == RUN_EMERGENCY
+    assert plan.est_latency_multiplier > 1.0
+
+
+def test_load_rung_engaged_fp8_is_degraded_fp8_storage() -> None:
+    plan = load_rung_engaged(None, rung="fp8", detail="tight VRAM")
+    assert plan.degraded
+    assert plan.run_mode == RUN_FP8_STORAGE and plan.ran == RUN_FP8_STORAGE
+
+
+# --------------------------------------------------------------------------
+# loading: rung engagement stamped on the pipe
+# --------------------------------------------------------------------------
+
+
+class _Pipe:
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs):
+        return cls()
+
+
+def _write_safetensors(path: Path, dtype: str = "BF16", nbytes: int = 1024) -> None:
+    header = json.dumps(
+        {"w": {"dtype": dtype, "shape": [nbytes], "data_offsets": [0, nbytes]}}
+    ).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def _snapshot(tmp_path: Path, components: dict | None = None) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    index: dict = {"_class_name": "Pipe"}
+    index.update(components or {"transformer": ["a", "b"]})
+    (tmp_path / "model_index.json").write_text(json.dumps(index))
+    _write_safetensors(tmp_path / "diffusion_pytorch_model.safetensors")
+    return tmp_path
+
+
+def test_load_stamps_adaptive_rung(tmp_path: Path, monkeypatch) -> None:
+    snap = _snapshot(tmp_path / "snapdir")
+    monkeypatch.setattr(loading_mod, "_adaptive_fit_rung",
+                        lambda *a, **k: ("nf4", ("bnb", {})))
+    pipe = loading_mod.load_from_pretrained(_Pipe, snap, dtype="bf16")
+    assert getattr(pipe, "_cozy_adaptive_rung", "") == "nf4"
+
+
+def test_load_no_stamp_when_rung_stays_out(tmp_path: Path, monkeypatch) -> None:
+    snap = _snapshot(tmp_path / "snapdir")
+    monkeypatch.setattr(loading_mod, "_adaptive_fit_rung",
+                        lambda *a, **k: ("", None))
+    pipe = loading_mod.load_from_pretrained(_Pipe, snap, dtype="bf16")
+    assert getattr(pipe, "_cozy_adaptive_rung", "") == ""
+
+
+# --------------------------------------------------------------------------
+# executor: the stamp reconciles into serve_plans (state-delta path)
+# --------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    x: str = "hi"
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _RungShim(_Pipe):
+    def to(self, *a, **k):
+        return self
+
+
+def _executor(spec: EndpointSpec, tmp_path: Path, snap: Path, sent: list) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path, vram_budget_bytes=4 << 30)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        store.residency.track_disk(ref, snap)
+        return snap
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return Executor([spec], _send, store=store)
+
+
+def test_executor_records_adaptive_rung(tmp_path, monkeypatch, caplog) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+    monkeypatch.setattr(loading_mod, "_adaptive_fit_rung",
+                        lambda *a, **k: ("nf4", ("bnb", {})))
+
+    class Endpoint:
+        def setup(self, m: _RungShim) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"m": Hub("acme/big-model")},
+        resources=Resources(vram_gb=1.0),
+    )
+    snap = _snapshot(tmp_path / "snapdir")
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, snap, sent)
+        with caplog.at_level(logging.WARNING):
+            inst = await ex.ensure_setup(spec)
+        assert getattr(inst.m, "_cozy_adaptive_rung", "") == "nf4"
+        plan = ex.serve_plans["generate"]
+        assert plan.degraded
+        assert plan.ran == RUN_EMERGENCY
+        assert "LOAD_RUNG_ENGAGED" in caplog.text
+
+    asyncio.run(_go())

--- a/tests/test_executor_lora.py
+++ b/tests/test_executor_lora.py
@@ -468,8 +468,10 @@ def test_lru_eviction_over_attachment_caps(tmp_path, monkeypatch) -> None:
         assert len(h.pipe.attached) == 2
         deletes = [c for c in h.pipe.calls if c[0] == "delete"]
         assert len(deletes) == 1
-        # LRU victim was the first-attached adapter
-        assert deletes[0][1] == lora_util.adapter_name(f"{LORA_A}@sha256:0")
+        # LRU victim was the first-attached adapter. Cache keys carry the
+        # bare-hex digest spelling (gw#491: algo prefix stripped so one
+        # adapter never mints two identities).
+        assert deletes[0][1] == lora_util.adapter_name(f"{LORA_A}@0")
 
     asyncio.run(_run())
 

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.30"
+version = "0.13.31"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Part 2 of the gw#491 architecture audit — the contained seam fixes from the dtype/identity inventory (th#736 bug class: a state change in one representation invisible in the other).

## Fixes
- **Silent adaptive rung (the clearest surviving th#736-class member):** `loading._adaptive_fit_rung` could engage runtime fp8 storage or emergency nf4 at load time with only a `logger.warning` — a 4-bit-quantized pipeline kept reporting `RUN_NATIVE wanted==ran`. The loader now stamps `pipe._cozy_adaptive_rung` (same pattern as the th#737 cast stamps) and the executor reconciles it into serve_plans + FnDegraded via a new `_record_adaptive_rung` / `serve_fit.load_rung_engaged` (same shape as the plan-time emergency rungs).
- **`wanted` counts casts:** `serve_fit._wanted` was flavor-only, so a SUCCESSFULLY applied fp8 cast reported wanted=bf16 ran=bf16 while the executor's drop path hardcoded wanted="fp8" (two disagreeing derivations). Now: flavor, else storage_dtype, else bf16 — a successful cast is visible (wanted=fp8 ran=fp8, not degraded), and drops report the real directive (`fp8+te` preserved, no more hardcode).
- **`cast_dropped` ran:** parameterized to the actual base precision (binding dtype) instead of hardcoded "bf16".
- **Backstop disambiguation:** a failed *adaptive* fp8 no longer reports as a resolution-cast drop (the plan was base precision — not a deviation).
- **LoRA adapter cache identity (F3):** `snap.digest` can carry an algo prefix (`blake3:<hex>`) while `path.name` is bare hex — one adapter could mint two cache keys and double-attach against MAX_ATTACHED_ADAPTERS. Digest now normalized to bare hex at the key mint.

## Evidence
- New tests: tests/test_adaptive_rung_gw491.py (8) — wanted derivation, plan shapes, loader stamps, and the executor reconciliation through the real ensure_setup/injection path.
- Full suite: 875 passed, 19 skipped.

Tracker: gw#491; the structural siblings (re-gate after HelloAck, residency re-keying, compile-cell precision) are gw#494/#495/#499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)