### PR TITLE
gw#491: seam-typing quick wins — pb enum valuetypes, resolution-ref guard (0.13.32)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.13.31"
+version = "0.13.32"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -26,7 +26,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import msgspec
 
-from ..api.binding import BINDING_TYPES, wire_ref
+from ..api.binding import Civitai, HF, Hub, ModelScope, wire_ref
 from ..api.errors import CanceledError
 from ..config import get_settings
 from .local_context import build_local_context
@@ -597,7 +597,7 @@ def _fetch_tensorhub_snapshot(
 
 def _resolve_binding_to_ref(*, param_name: str, binding: Any) -> Tuple[str, str]:
     """Return ``(model_ref, provider)`` for one binding."""
-    if isinstance(binding, BINDING_TYPES):
+    if isinstance(binding, (Hub, HF, Civitai, ModelScope)):
         return wire_ref(binding), binding.provider
     raise _UsageError(
         f"unknown binding type for param {param_name!r}: {type(binding).__name__}"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -165,7 +165,7 @@ def _capability_job_id(token: str) -> Optional[str]:
         return None
 
 
-def _map_exception(exc: BaseException) -> Tuple[int, str]:
+def _map_exception(exc: BaseException) -> Tuple["pb.JobStatus", str]:
     """-> (JobStatus, safe_message)."""
     if isinstance(exc, (CanceledError, asyncio.CancelledError)):
         return pb.JOB_STATUS_CANCELED, "canceled"
@@ -377,7 +377,7 @@ class ModelStore:
             return
         loop.create_task(coro)
 
-    async def _event(self, ref: str, state: int, **kw: Any) -> None:
+    async def _event(self, ref: str, state: "pb.ModelState", **kw: Any) -> None:
         await self._emit(pb.WorkerMessage(model_event=pb.ModelEvent(ref=ref, state=state, **kw)))
 
     # ---- residency facade ----------------------------------------------------
@@ -944,8 +944,13 @@ class Executor:
                     try:
                         rebound = base_binding
                         if resolved_ref and resolved_ref != base_ref:
-                            flavor = parse_model_ref(resolved_ref).tensorhub.flavor
-                            rebound = dataclasses.replace(rebound, flavor=flavor)
+                            parsed = parse_model_ref(resolved_ref)
+                            if parsed.tensorhub is None:
+                                raise ValueError(
+                                    f"resolution {resolved_ref!r} is not a "
+                                    "tensorhub ref")
+                            rebound = dataclasses.replace(
+                                rebound, flavor=parsed.tensorhub.flavor)
                         if cast:
                             rebound = dataclasses.replace(rebound, storage_dtype=cast)
                         if resolved_ref and wire_ref(rebound) != resolved_ref:
@@ -2887,7 +2892,7 @@ class Executor:
         self,
         request_id: str,
         attempt: int,
-        status: int,
+        status: "pb.JobStatus",
         *,
         inline: Optional[bytes] = None,
         blob_ref: Optional[str] = None,
@@ -2904,7 +2909,7 @@ class Executor:
             result.metrics.CopyFrom(metrics)
         await self._send(pb.WorkerMessage(job_result=result))
 
-    async def _finish(self, job: _Job, status: int, **kw: Any) -> None:
+    async def _finish(self, job: _Job, status: "pb.JobStatus", **kw: Any) -> None:
         if job.finished:
             return
         job.finished = True

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -242,7 +242,7 @@ class Lifecycle:
                 recommended_vram_gb=float(plan.recommended_vram_gb or 0.0),
             )))
 
-    async def set_phase(self, phase: int) -> None:
+    async def set_phase(self, phase: "pb.WorkerPhase") -> None:
         if phase == self.phase:
             return
         self.phase = phase

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.13.31"
+version = "0.13.32"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Part 3 of the gw#491 audit — the mechanical typing subset that makes ref/enum space-confusion fail mypy instead of runtime.

- pb enum valuetypes threaded through executor/lifecycle signatures (`_event: pb.ModelState`, `_send_result`/`_finish`/`_map_exception: pb.JobStatus`, `set_phase: pb.WorkerPhase`) — these were the live mypy arg-type errors that ARE the th#736 class (bare int crossing the wire-enum seam).
- `apply_model_resolutions`: explicit ValueError when a resolution ref parses non-tensorhub (was an accidental AttributeError caught by luck — same drop behavior, now stated).
- cli/run: isinstance over the concrete binding classes so mypy narrows (BINDING_TYPES tuple defeated narrowing; wire_ref received `object`).

mypy: 100 -> 94 errors (107 at audit start; not yet gating — the re-add plan + remaining clusters are gw#497). Full suite: 875 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)