### PR TITLE
th#611: civitai gguf-only ingest publishes as-is (strategy=gguf) — 0.13.27

### DIFF
--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -511,6 +511,23 @@ def _resolve_civitai_family(base_family: str, layout_family: str) -> str:
     return base_family
 
 
+def _local_gguf_quant(path: Path) -> str:
+    """Quant token ("q5_k_m") from a local gguf header's general.file_type."""
+    try:
+        from gguf import GGUFReader
+        from gguf.constants import LlamaFileType
+
+        reader = GGUFReader(str(path), "r")
+        field = reader.fields.get("general.file_type")
+        if field is None:
+            return ""
+        ft = int(field.contents())
+        name = LlamaFileType(ft).name
+        return name.removeprefix("MOSTLY_").lower()
+    except Exception:
+        return ""
+
+
 def ingest_civitai(
     model_version_id: int,
     dest_dir: Path,
@@ -560,6 +577,26 @@ def ingest_civitai(
         if isinstance(payload.get("model"), dict) else ""
     if model_kind in {"lora", "locon", "lycoris", "dora"}:
         attrs["runtime_library"] = "diffusers-lora"
+
+    # th#611: gguf-only civitai versions publish AS-IS (single unshardable
+    # artifact; the hub classifies family + flavor from the header). Without
+    # a classification the clone falls into the safetensors repackage path
+    # and dies with "no safetensors entry for repackage".
+    classification: RepoClassification | None = None
+    gguf_names = [f for f in files if f.lower().endswith(".gguf")]
+    st_names = [f for f in files if f.lower().endswith(".safetensors")]
+    if gguf_names and not st_names:
+        quant = _local_gguf_quant(dest_dir / gguf_names[0])
+        attrs["dtype"] = f"gguf:{quant}" if quant else "gguf"
+        attrs["file_type"] = "gguf"
+        attrs["file_layout"] = "singlefile"
+        classification = RepoClassification(
+            strategy="gguf",
+            runtime_library="diffusers-single-file",
+            allow_patterns=list(files),
+            attrs=dict(attrs),
+            detection_reason=f"civitai gguf-only version ({len(gguf_names)} gguf)",
+        )
     metadata = {
         "source_provider": "civitai",
         "source_repo": str(version_id),
@@ -596,6 +633,7 @@ def ingest_civitai(
         attrs=attrs,
         metadata=metadata,
         repo_spec=repo_spec,
+        classification=classification,
     )
 
 

--- a/tests/convert/test_civitai_gguf_select.py
+++ b/tests/convert/test_civitai_gguf_select.py
@@ -86,3 +86,30 @@ def test_gguf_quant_from_download_url():
     ]}, gguf_quant="q8_0")
     assert len(files) == 1
     assert files[0]["id"] == 2
+
+
+def test_ingest_civitai_gguf_classification(tmp_path, monkeypatch):
+    """gguf-only civitai trees classify strategy=gguf (as-is publish)."""
+    import struct
+    from gen_worker.convert import ingest as ing
+
+    # Minimal real gguf header: magic/v3, 0 tensors, 1 KV (general.file_type=17).
+    buf = b"GGUF" + struct.pack("<IQQ", 3, 0, 1)
+    key = b"general.file_type"
+    buf += struct.pack("<Q", len(key)) + key + struct.pack("<I", 4) + struct.pack("<I", 17)
+    (tmp_path / "model.gguf").write_bytes(buf)
+
+    monkeypatch.setattr(
+        "gen_worker.models.download.fetch_civitai_model_version",
+        lambda vid, api_key="": {"baseModel": "Flux.2 Klein 9B", "modelId": 1,
+                                 "model": {"type": "Checkpoint"}},
+    )
+    monkeypatch.setattr(
+        "gen_worker.models.download.download_civitai",
+        lambda vid, dest, api_key="", progress=None, gguf_quant=None: dest,
+    )
+    src = ing.ingest_civitai(123, tmp_path, civitai_api_key="", gguf_quant="q5_k_m")
+    assert src.classification is not None
+    assert src.classification.strategy == "gguf"
+    assert src.attrs["dtype"] == "gguf:q5_k_m"
+    assert src.attrs["file_type"] == "gguf"


### PR DESCRIPTION
Live proof run 11: the civitai gguf clone (single-gguf selection from #185/#186) downloaded fine, then died in `build_flavor_tree` — `clone produced no publishable flavor: no safetensors entry for repackage`. `ingest_civitai` returned no classification, so `run_clone`'s as-is lane (`publish_as_is` keys on `classification.strategy`) never engaged and the default bf16/diffusers spec tried to repackage a gguf.

gguf-only civitai trees now classify at ingest: `strategy=gguf`, `runtime_library=diffusers-single-file`, `dtype=gguf:<quant>` read from the LOCAL header (`general.file_type` via the `gguf` package — civitai filenames/API don't carry the quant reliably). The as-is lane publishes the single artifact; the hub (tensorhub th#611) stamps family + the `gguf-<qtype>` flavor row from the same header server-side. Safetensors-bearing versions unchanged.

Tests: ingest-level unit (synthetic gguf header, mocked provider API) + full `tests/convert/` green. Version 0.13.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)