### PR TITLE
gw#502: gpu-ci runner fixes — python 3.12 pin + C compiler for triton 3.7 JIT

### DIFF
--- a/.github/gpu-runner/Dockerfile
+++ b/.github/gpu-runner/Dockerfile
@@ -9,8 +9,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUNNER_ALLOW_RUNASROOT=1 \
     UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
+# gcc/libc6-dev: triton >=3.7 JIT-compiles launcher stubs at runtime and
+# needs a host C compiler (same reason the conversion image ships gcc).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git jq tar \
+        ca-certificates curl git jq tar gcc libc6-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
@@ -23,7 +25,7 @@ RUN mkdir /runner && cd /runner \
     && rm -rf /var/lib/apt/lists/*
 
 # Bake the interpreter so job-time `uv sync` only resolves wheels.
-RUN uv python install 3.11
+RUN uv python install 3.12
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -125,7 +125,20 @@ jobs:
 
       - name: Sync deps (cu129 lock)
         id: sync
-        run: uv sync --extra dev --extra torch --extra images
+        # Pin the interpreter to the fleet floor: without this, a runner whose
+        # baked python predates requires-python makes uv download the newest
+        # CPython (3.14 incident, gw#502).
+        run: uv sync --python 3.12 --extra dev --extra torch --extra images
+
+      # triton >=3.7 JIT-compiles launcher stubs at runtime and needs a host
+      # C compiler. Baked into the runner image; the apt fallback covers pods
+      # booted from a pre-gcc image (rebuild races this same push).
+      - name: Ensure C compiler (triton JIT)
+        run: |
+          command -v cc >/dev/null 2>&1 || {
+            apt-get update -qq
+            apt-get install -y -qq --no-install-recommends gcc libc6-dev
+          }
 
       - name: Run tests
         run: uv run --extra dev --extra torch --extra images pytest tests/ -q --junitxml=gpu-junit.xml


### PR DESCRIPTION
Post-merge gpu-ci fallout from #195 (the FLUX smoke step):

- **py3.14 venv**: the runner image bakes python 3.11, which no longer satisfies `requires-python>=3.12` — job-time uv silently downloaded CPython 3.14. Fix: `uv sync --python 3.12` + bake 3.12 in the runner image.
- **triton 3.7 JIT needs cc**: `RuntimeError: Failed to find C compiler` in `triton/runtime/build.py` during generation. Fix: gcc/libc6-dev baked into the runner image + a job-time apt fallback (covers the rebuild race on this same push).

NOT addressed: `test_content_lanes::test_lane_swap_moves_only_the_exclusive_module` (Tier.VRAM vs RAM) — pre-existing, identical on the five master gpu-ci runs BEFORE the dep bump merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)