### PR TITLE
gw#494: transactional HelloAck re-resolution — residency re-keys, single pick-fold, gates re-run (0.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.14.2 (2026-07-11)
+
+- **gw#494: transactional HelloAck re-resolution — residency re-keys, gates
+  re-run.** The literal th#736 mechanic worker-side is closed. ONE pick-fold:
+  `rebind_pick` (api/binding.py) is shared by the hub HelloAck path and the
+  local ladder (`resolve_local_bindings`) — both now carry the round-trip
+  guard. Residency booking and clearing are provably same-space: `_setup_locked`
+  derives its wire refs ONCE, books under them, and stamps them as the class
+  record's `held_refs`; `_vacate_record` / `_record_holding` / `_record_in_use`
+  operate on `held_refs`, never a re-derivation over possibly-rebound
+  `spec.models`. A resolution re-pick marks divergent ready records stale and
+  vacates them (async revalidate task + vacate-on-next-setup), releasing the
+  OLD resolved refs' VRAM — no orphaned bookings, pins/promotes/LoRA targets
+  hit the live entry after reload. `gate_functions` is idempotent (gate-owned
+  unavailable marks cleared on re-gate; setup failures survive), remembers the
+  probe, and re-runs inside `apply_model_resolutions` — closing the
+  startup-vs-HelloAck gate race. Regression: `tests/test_resolution_rekey_gw494.py`
+  (resolve→book→re-resolve→clear leaves zero orphans; revert-to-declared;
+  HF-pick rejection; re-gate idempotence; single-fold contract).
+
 ## 0.14.1 (2026-07-11)
 
 - **gw#492: ONE ref normal form.** `gen_worker.models.refs` is now the single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.1"
+version = "0.14.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -187,7 +187,57 @@ def wire_ref(binding: Binding) -> str:
     return binding.ref
 
 
+def rebind_pick(
+    binding: Binding,
+    *,
+    resolved_ref: str = "",
+    flavor: "str | None" = None,
+    cast: str = "",
+) -> Binding:
+    """THE fold of a precision pick into a binding (gw#494) — the hub
+    HelloAck path (``resolved_ref`` + ``cast``) and the local-ladder path
+    (``flavor`` + ``cast``) share this one implementation.
+
+    ``resolved_ref`` is authoritative when given: its flavor (possibly none)
+    replaces the binding's. ``flavor=None`` leaves the binding's flavor
+    untouched. Raises ``ValueError`` when the pick cannot round-trip through
+    ``wire_ref`` — a pick the rebound binding cannot re-mint would split the
+    slot into two residency identities (the th#736 mechanic).
+    """
+    import dataclasses
+
+    from ..models.refs import fold_ref, normalize_model_ref, parse_model_ref
+
+    if resolved_ref:
+        parsed = parse_model_ref(resolved_ref)
+        if parsed.tensorhub is None:
+            raise ValueError(f"resolution {resolved_ref!r} is not a tensorhub ref")
+        flavor = parsed.tensorhub.flavor or ""
+    rebound = binding
+    try:
+        if flavor is not None and flavor != getattr(binding, "flavor", ""):
+            rebound = dataclasses.replace(rebound, flavor=flavor)
+        if cast:
+            rebound = dataclasses.replace(rebound, storage_dtype=cast)
+    except TypeError as exc:
+        # e.g. folding a flavor into an HF/Civitai binding that has no
+        # flavor axis — same rejection channel as a round-trip failure.
+        raise ValueError(f"pick does not fit binding {binding!r}: {exc}") from exc
+    if resolved_ref:
+        expected = normalize_model_ref(resolved_ref)
+    elif flavor:
+        expected = fold_ref(wire_ref(binding), flavor=flavor)
+    else:
+        expected = None
+    if expected is not None and wire_ref(rebound) != expected:
+        raise ValueError(
+            f"pick {expected!r} does not round-trip through the binding "
+            f"(got {wire_ref(rebound)!r})"
+        )
+    return rebound
+
+
 __all__ = [
     "Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelScope",
-    "STORAGE_DTYPES", "wire_ref",
+    "STORAGE_DTYPES", "rebind_pick", "wire_ref",
 ]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -764,6 +764,14 @@ class _ClassRecord:
     # Content-keyed shared components this record holds (gw#479): released
     # (refcount--) at vacate so the entries become LRU/drain candidates.
     shared_keys: List[Any] = dc_field(default_factory=list)
+    # gw#494: the wire refs this record's instance BOOKED at load time —
+    # teardown releases exactly these (never a re-derivation from the
+    # possibly-rebound spec.models), so booking and clearing are provably
+    # the same key space.
+    held_refs: List[str] = dc_field(default_factory=list)
+    # gw#494: a resolution re-pick moved the specs' bindings away from
+    # held_refs; the instance serves the OLD pick and must be vacated.
+    stale: bool = False
 
 
 def _shared_loader_must_hit() -> Any:
@@ -903,6 +911,12 @@ class Executor:
             rec.specs.append(s)
         # Hardware-gate failures: fn name -> (reason, detail, axes).
         self.unavailable: Dict[str, Tuple[str, str, Dict[str, str]]] = {}
+        # gw#494: entries in `unavailable` that gate_functions owns — cleared
+        # and re-derived on every (re-)gate so gating is idempotent; setup
+        # failures (owned by _mark_setup_failed) survive re-gates.
+        self._gate_owned: set = set()
+        # Last hardware probe, so resolutions can re-run the gates.
+        self._last_gpu_info: Optional[Dict[str, Any]] = None
         # th#683 P3: how each serveable function will run on the actual card
         # (native / emergency / offload / cpu) + honest-guidance advisory.
         self.serve_plans: Dict[str, "ServePlan"] = {}
@@ -919,14 +933,18 @@ class Executor:
         ``resolutions`` maps a DECLARED wire ref to ``(resolved_ref, cast)``
         (HelloAck full-replace semantics: refs absent from the map revert to
         their authored bindings). Rebinding folds the resolved flavor into
-        the binding and stamps ``cast`` as ``storage_dtype``, so every
+        the binding via :func:`rebind_pick` (THE single fold, shared with the
+        local ladder) and stamps ``cast`` as ``storage_dtype``, so every
         downstream consumer — wire_ref residency keys, downloads, setup,
-        loading — follows the pick with no per-call-site changes. Already-
-        loaded pipelines are not reloaded; picks apply to future setups.
-        """
-        import dataclasses
+        loading — follows the pick with no per-call-site changes.
 
-        from .models.refs import parse_model_ref
+        Application is TRANSACTIONAL (gw#494): a ready instance whose loaded
+        refs no longer match its (re)bound refs is marked stale and vacated —
+        its residency bookings under the OLD resolved refs are released and
+        the next setup/LOAD loads the new pick — and the hardware gates +
+        serve plans re-run against the rebound bindings.
+        """
+        from .api.binding import rebind_pick
 
         changed = False
         rehomed: List[Tuple[Any, EndpointSpec]] = []
@@ -942,28 +960,16 @@ class Executor:
                 if pick is not None:
                     resolved_ref, cast = pick
                     try:
-                        rebound = base_binding
-                        if resolved_ref and resolved_ref != base_ref:
-                            parsed = parse_model_ref(resolved_ref)
-                            if parsed.tensorhub is None:
-                                raise ValueError(
-                                    f"resolution {resolved_ref!r} is not a "
-                                    "tensorhub ref")
-                            rebound = dataclasses.replace(
-                                rebound, flavor=parsed.tensorhub.flavor)
-                        if cast:
-                            rebound = dataclasses.replace(rebound, storage_dtype=cast)
-                        if resolved_ref and wire_ref(rebound) != resolved_ref:
-                            logger.warning(
-                                "precision resolution %s -> %s does not round-trip "
-                                "through the binding (got %s); keeping declared ref",
-                                base_ref, resolved_ref, wire_ref(rebound))
-                        else:
-                            new_binding = rebound
+                        new_binding = rebind_pick(
+                            base_binding,
+                            resolved_ref=(
+                                resolved_ref if resolved_ref != base_ref else ""),
+                            cast=cast)
                     except (ValueError, TypeError, AttributeError) as exc:
                         logger.warning(
                             "precision resolution %s -> %r rejected: %s",
                             base_ref, pick, exc)
+                        new_binding = base_binding
                 if spec.models.get(slot) is not new_binding:
                     spec.models[slot] = new_binding
                     self.store.register_binding(wire_ref(new_binding), new_binding)
@@ -1002,7 +1008,51 @@ class Executor:
             if rec is not None and not rec.specs and self._classes.get(old_key) is rec:
                 self._classes.pop(old_key, None)
         if changed:
+            # gw#494: transactional application — (1) a ready instance whose
+            # loaded refs diverged from the rebound refs is stale: vacate it
+            # so nothing stays booked under the old resolved refs (pins,
+            # promotes, adapters and UNLOAD all key off the CURRENT wire
+            # refs; a divergent record orphans its VRAM forever).
+            stale: List[_ClassRecord] = []
+            seen: set = set()
+            for rec in self._classes.values():
+                if id(rec) in seen:
+                    continue
+                seen.add(id(rec))
+                if not rec.ready or not rec.held_refs:
+                    continue
+                wanted = {wire_ref(b) for s in rec.specs for b in s.models.values()}
+                if set(rec.held_refs) != wanted:
+                    rec.stale = True
+                    stale.append(rec)
+            if stale:
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None  # sync context: ensure_setup vacates on next touch
+                if loop is not None:
+                    for rec in stale:
+                        loop.create_task(self._revalidate_record(rec))
+            # (2) gates + serve plans re-run against the rebound bindings
+            # (idempotent; also settles the startup()-vs-HelloAck order race).
+            if self._last_gpu_info is not None:
+                self.gate_functions(self._last_gpu_info)
             self._on_state_change()
+
+    async def _revalidate_record(self, rec: "_ClassRecord") -> None:
+        """Vacate a stale instance (gw#494): its pipelines were loaded for a
+        superseded pick, so release the residency bookings under the OLD
+        resolved refs; the next setup/LOAD loads the current pick. Records
+        with jobs in flight are left for ``ensure_setup`` to vacate on the
+        next touch."""
+        async with rec.lock:
+            if not rec.ready or not rec.stale:
+                return
+            async with self._load_lock:
+                if self._record_in_use(rec):
+                    return
+                await self._vacate_record(rec)
+        self._on_state_change()
 
     # ---- availability ----------------------------------------------------
 
@@ -1026,6 +1076,14 @@ class Executor:
         from .models.hub_policy import FIT_INCOMPATIBLE, TensorhubWorkerCapabilities
         from .models.serve_fit import RUN_CPU, RUN_OFFLOAD, plan_serve
 
+        # Idempotent re-gate (gw#494): drop only the marks THIS gate made
+        # last time; setup failures and other owners survive. Remember the
+        # probe so apply_model_resolutions can re-run us.
+        self._last_gpu_info = dict(gpu_info)
+        for fn in self._gate_owned:
+            self.unavailable.pop(fn, None)
+        self._gate_owned = set()
+
         total_vram_gb = float(gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
         free_vram_gb = float(gpu_info.get("gpu_free_mem") or gpu_info.get("gpu_total_mem") or 0) / (1024 ** 3)
         detected_sm = str(gpu_info.get("gpu_sm") or "")
@@ -1047,6 +1105,7 @@ class Executor:
                     "compute_capability_unmet",
                     f"requires SM {r.compute_capability:.1f}, detected {detected_cc:.1f}",
                     {"detected_sm": f"{detected_cc:.1f}", "required_sm": f"{float(r.compute_capability):.1f}"})
+                self._gate_owned.add(name)
                 continue
             missing = [lib for lib in (r.libraries or ()) if lib not in libs]
             if missing:
@@ -1056,6 +1115,7 @@ class Executor:
                 self.unavailable[name] = (
                     "missing_cuda_library", f"missing required libraries: {', '.join(missing)}",
                     {"missing": ",".join(missing)})
+                self._gate_owned.add(name)
                 continue
 
             # Adaptive serve-time fit for the VRAM / GPU-presence / stored-
@@ -1080,6 +1140,7 @@ class Executor:
                     code, plan.reason,
                     {"detected_vram_gb": f"{total_vram_gb:.0f}",
                      "recommended_vram_gb": (f"{r.vram_gb:.0f}" if r.vram_gb else "")})
+                self._gate_owned.add(name)
                 continue
             if plan.degraded:
                 logger.warning(degraded_log_line(
@@ -1190,6 +1251,12 @@ class Executor:
         self.store.bind_loop()
         rec = self._classes[spec.instance_key]
         async with rec.lock:
+            if rec.ready and rec.stale:
+                # gw#494: the instance was loaded for a superseded pick —
+                # vacate (releasing its OLD-ref bookings) and set up fresh
+                # with the current bindings.
+                async with self._load_lock:
+                    await self._vacate_record(rec)
             if rec.ready:
                 await self._promote_setup_refs(spec, promote_slots)
                 return rec.instance
@@ -1236,10 +1303,17 @@ class Executor:
     ) -> Any:
         assert spec.cls is not None  # guarded by ensure_setup
         setup_slots = self._setup_slots(spec)
+        # gw#494: residency keys for this setup are derived ONCE, here, in
+        # resolved space; downloads, booking and the record's held_refs all
+        # use these exact strings (a HelloAck rebind during an await below
+        # cannot split download/booking/teardown identities).
+        slot_refs: Dict[str, str] = {
+            slot: wire_ref(spec.models[slot]) for slot in setup_slots
+        }
         paths: Dict[str, str] = {}
         for slot in setup_slots:
             binding = spec.models[slot]
-            ref = wire_ref(binding)
+            ref = slot_refs[slot]
             snap = (snapshots or {}).get(ref)
             path = await self.store.ensure_local(ref, snap, binding=binding)
             paths[slot] = str(path)
@@ -1294,7 +1368,10 @@ class Executor:
                     process_vram_bytes, rec.server.process.pid)
             self._register_residency(
                 spec, setup_slots, inj.loaded, vram_delta,
-                lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes)
+                lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes,
+                slot_refs=slot_refs)
+            rec.held_refs = sorted(set(slot_refs.values()))
+            rec.stale = False
         return instance
 
     def _register_residency(
@@ -1306,6 +1383,7 @@ class Executor:
         *,
         lane_slots: Optional[set] = None,
         shared_bytes: int = 0,
+        slot_refs: Optional[Dict[str, str]] = None,
     ) -> None:
         """Honest per-ref residency after a setup (#369). Worker-constructed
         pipelines carry their own measured allocator delta AND the object
@@ -1317,11 +1395,14 @@ class Executor:
         them here would clobber a mid-setup demotion."""
         res = self.store.residency
         lanes = lane_slots or set()
+        refs = slot_refs or {}
         per_ref: Dict[str, Tuple[Any, int]] = {}
         for slot in setup_slots:
             if slot in lanes:
                 continue
-            ref = wire_ref(spec.models[slot])
+            # gw#494: book under the SAME key the setup derived (never a
+            # fresh wire_ref over possibly-rebound spec.models).
+            ref = refs.get(slot) or wire_ref(spec.models[slot])
             obj, measured = loaded.get(slot, (None, 0))
             prev_obj, prev_bytes = per_ref.get(ref, (None, 0))
             per_ref[ref] = (obj or prev_obj, prev_bytes + measured)
@@ -2115,20 +2196,34 @@ class Executor:
                 return True
         return False
 
+    def _record_refs(self, rec: _ClassRecord) -> List[str]:
+        """The wire refs a record's instance holds: the load-time booking
+        keys when stamped (gw#494), else the current binding derivation
+        (records that never completed a setup)."""
+        if rec.held_refs:
+            return list(rec.held_refs)
+        return [wire_ref(b) for s in rec.specs for b in s.models.values()]
+
     def _record_holding(self, ref: str) -> Optional[_ClassRecord]:
         for rec in self._classes.values():
             if not rec.ready:
                 continue
-            if any(ref in (wire_ref(b) for b in s.models.values()) for s in rec.specs):
+            if ref in self._record_refs(rec):
                 return rec
         return None
 
     def _record_in_use(self, rec: _ClassRecord) -> bool:
-        for s in rec.specs:
-            for b in s.models.values():
-                ref = wire_ref(b)
-                if self._ref_in_use(ref) or self.store.residency.in_use(ref):
-                    return True
+        # A job on a rebound spec no longer references the record's held
+        # refs — membership of the job's spec in this record is the honest
+        # "instance in use" signal (gw#494).
+        for job in self.jobs.values():
+            if job.finished or job.superseded or job.spec is None:
+                continue
+            if job.spec in rec.specs:
+                return True
+        for ref in self._record_refs(rec):
+            if self._ref_in_use(ref) or self.store.residency.in_use(ref):
+                return True
         return False
 
     async def _vacate_record(self, rec: _ClassRecord) -> None:
@@ -2153,9 +2248,13 @@ class Executor:
                 await asyncio.to_thread(torch.cuda.empty_cache)
             except Exception:
                 pass
-        for s in rec.specs:
-            for b in s.models.values():
-                self.store.residency.release_to_disk(wire_ref(b))
+        # gw#494: release exactly what the instance BOOKED (held_refs) —
+        # re-deriving from spec.models would release the wrong keys after a
+        # resolution rebind, leaving the old entries' VRAM booked forever.
+        for ref in self._record_refs(rec):
+            self.store.residency.release_to_disk(ref)
+        rec.held_refs = []
+        rec.stale = False
         if rec.shared_keys:
             # Drop this record's holds on content-keyed shared components
             # (gw#479); entries no other record references get evicted.

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -350,8 +350,6 @@ def resolve_local_bindings(
     laddered; any failure keeps the declared binding (fail-open — the
     loading layer's fit ladder still applies at load time).
     """
-    import dataclasses
-
     from .refs import parse_model_ref
 
     out: dict[str, Any] = {}
@@ -381,11 +379,19 @@ def resolve_local_bindings(
         )
         if res.refusal or (not res.flavor and not res.cast):
             continue
-        rebound = binding
-        if res.flavor:
-            rebound = dataclasses.replace(rebound, flavor=res.flavor)
-        if res.cast:
-            rebound = dataclasses.replace(rebound, storage_dtype=res.cast)
+        # gw#494: THE single pick-fold (shared with the hub HelloAck path),
+        # round-trip guard included — a pick the rebound binding can't
+        # re-mint would split residency identities.
+        from ..api.binding import rebind_pick
+
+        try:
+            rebound = rebind_pick(
+                binding, flavor=res.flavor or None, cast=res.cast)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "local ladder: pick for %s rejected (%s); keeping declared",
+                name, exc)
+            continue
         logger.info(
             "local precision ladder: %s %s -> flavor=%s cast=%s (sm%d, %.1f GB free)",
             name, base_ref, res.flavor or "-", res.cast or "-",

--- a/tests/test_resolution_rekey_gw494.py
+++ b/tests/test_resolution_rekey_gw494.py
@@ -1,0 +1,207 @@
+"""gw#494: HelloAck re-resolution is transactional — residency re-keys and
+gates re-run.
+
+The th#736 mechanic worker-side: a second HelloAck with a different pick
+rebinds ``spec.models`` while loaded pipelines stay booked under the OLD
+resolved ref (VRAM orphaned forever, pins/promotes/adapters miss, UNLOAD by
+the new ref frees nothing). These tests pin the closure: booking and clearing
+derive from ONE keying (the record's load-time ``held_refs``), a pick change
+marks the record stale and vacates it, and ``gate_functions`` re-runs
+idempotently against the rebound bindings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import HF, Hub, rebind_pick, wire_ref
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Fake:
+    def setup(self, pipeline) -> None:  # pragma: no cover - never run here
+        self.pipeline = pipeline
+
+    def generate(self, ctx, payload: _In) -> dict:  # pragma: no cover
+        return {}
+
+
+def _spec(**kw) -> EndpointSpec:
+    return EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": Hub("acme/z-image")},
+        resources=kw.pop("resources", Resources(gpu=True)),
+        **kw,
+    )
+
+
+def _executor(spec: EndpointSpec | None = None) -> Executor:
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    return Executor([spec or _spec()], _send)
+
+
+def _simulate_loaded(ex: Executor, spec: EndpointSpec) -> str:
+    """Pretend ensure_setup completed for the spec's CURRENT bindings:
+    book residency and stamp held_refs the way _setup_locked does."""
+    rec = ex._classes[spec.instance_key]
+    refs = sorted({wire_ref(b) for b in spec.models.values()})
+    for ref in refs:
+        ex.store.residency.track_vram(ref, object(), vram_bytes=1024)
+    rec.held_refs = list(refs)
+    rec.stale = False
+    rec.instance = _Fake()
+    rec.ready = True
+    return refs[0]
+
+
+def _vram_refs(ex: Executor) -> set:
+    from gen_worker.models.residency import Tier
+
+    res = ex.store.residency
+    return {
+        m.ref for m in ex.store.residency_snapshot()
+        if res.tier(m.ref) is Tier.VRAM
+    }
+
+
+def test_repick_rekeys_residency_zero_orphans() -> None:
+    """resolve -> book -> re-resolve -> clear leaves ZERO orphans: nothing
+    stays VRAM-booked under a key no longer reachable from any binding."""
+
+    async def _run() -> None:
+        ex = _executor()
+        spec = ex.specs["generate"]
+
+        # HelloAck 1: pick #fp8; instance loads and books under the pick.
+        ex.apply_model_resolutions({"acme/z-image": ("acme/z-image#fp8", "")})
+        assert wire_ref(spec.models["pipeline"]) == "acme/z-image#fp8"
+        old_ref = _simulate_loaded(ex, spec)
+        assert old_ref == "acme/z-image#fp8"
+        assert _vram_refs(ex) == {"acme/z-image#fp8"}
+        rec = ex._classes[spec.instance_key]
+
+        # HelloAck 2: different pick. The record is stale and gets vacated —
+        # the OLD key's VRAM booking is released (no orphan), ready drops.
+        ex.apply_model_resolutions(
+            {"acme/z-image": ("acme/z-image#svdq-int4-r128", "")})
+        assert rec.stale is True
+        await asyncio.sleep(0.05)  # let the scheduled revalidate task run
+        assert rec.ready is False
+        assert rec.held_refs == []
+        assert _vram_refs(ex) == set()
+
+        # Instance reloads under the new pick; a revert-to-declared HelloAck
+        # (empty map) vacates again — still zero orphans anywhere.
+        new_ref = _simulate_loaded(ex, spec)
+        assert new_ref == "acme/z-image#svdq-int4-r128"
+        rec2 = ex._classes[spec.instance_key]
+        ex.apply_model_resolutions({})
+        assert wire_ref(spec.models["pipeline"]) == "acme/z-image"
+        assert rec2.stale is True
+        await asyncio.sleep(0.05)
+        assert rec2.ready is False
+        assert _vram_refs(ex) == set()
+
+    asyncio.run(_run())
+
+
+def test_vacate_releases_booked_keys_not_rebound_ones() -> None:
+    """_vacate_record must release the LOAD-TIME keys even after the spec
+    was rebound (the exact orphan mechanic)."""
+
+    async def _run() -> None:
+        ex = _executor()
+        spec = ex.specs["generate"]
+        old_ref = _simulate_loaded(ex, spec)  # booked under declared ref
+        rec = ex._classes[spec.instance_key]
+
+        # Rebind WITHOUT vacating first (simulates the pre-fix window).
+        ex.apply_model_resolutions({"acme/z-image": ("acme/z-image#fp8", "")})
+        # The rehome carried the live record to the new key; vacate it.
+        rec = next(r for r in ex._classes.values() if r is rec)
+        await ex._vacate_record(rec)
+        assert _vram_refs(ex) == set(), f"orphan under {old_ref!r}"
+        await asyncio.sleep(0.05)  # settle the scheduled revalidate task
+
+    asyncio.run(_run())
+
+
+def test_hf_binding_resolution_is_rejected_keeps_declared() -> None:
+    ex = _executor(EndpointSpec(
+        name="generate", method=_Fake.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Fake,
+        models={"pipeline": HF("bfl/FLUX.2-klein-4B")},
+        resources=Resources(gpu=True),
+    ))
+    spec = ex.specs["generate"]
+    ex.apply_model_resolutions(
+        {"bfl/FLUX.2-klein-4B": ("bfl/FLUX.2-klein-4B#fp8", "")})
+    # HF picks fold flavor -- but HF has no flavor field: rejected, declared kept.
+    assert spec.models["pipeline"] == HF("bfl/FLUX.2-klein-4B")
+
+
+def test_regate_runs_after_resolutions_and_is_idempotent() -> None:
+    """apply_model_resolutions re-runs gate_functions against the rebound
+    bindings; gate marks are gate-owned (cleared on re-gate), setup failures
+    survive."""
+    spec = _spec(resources=Resources(gpu=True, compute_capability=8.9))
+    ex = _executor(spec)
+
+    small = {"gpu_total_mem": 48 * 1024**3, "gpu_free_mem": 48 * 1024**3,
+             "gpu_sm": "75", "installed_libs": []}
+    big = dict(small, gpu_sm="90")
+
+    ex.gate_functions(small)
+    assert ex.unavailable["generate"][0] == "compute_capability_unmet"
+
+    # Re-gate with capable silicon: the gate-owned mark clears.
+    ex.gate_functions(big)
+    assert "generate" not in ex.unavailable
+
+    # A setup failure is NOT gate-owned and survives a re-gate.
+    ex.unavailable["generate"] = ("setup_failed", "boom", {})
+    ex.gate_functions(big)
+    assert ex.unavailable["generate"][0] == "setup_failed"
+
+    # Resolutions re-run the gates using the remembered probe.
+    ex.unavailable.pop("generate")
+    ex.apply_model_resolutions({"acme/z-image": ("acme/z-image#fp8", "")})
+    assert ex._last_gpu_info is not None
+    assert "generate" in ex.serve_plans
+
+
+def test_rebind_pick_is_the_single_fold() -> None:
+    b = Hub("acme/z-image")
+
+    # hub path: resolved_ref authoritative (flavor fold + cast stamp)
+    out = rebind_pick(b, resolved_ref="acme/z-image#fp8", cast="")
+    assert wire_ref(out) == "acme/z-image#fp8"
+    out = rebind_pick(b, resolved_ref="", cast="fp8")
+    assert out.storage_dtype == "fp8" and wire_ref(out) == "acme/z-image"
+    # non-normal hub spelling still round-trips (':latest' is elided form)
+    out = rebind_pick(b, resolved_ref="acme/z-image:latest#fp8")
+    assert wire_ref(out) == "acme/z-image#fp8"
+
+    # ladder path: flavor/cast overlay with the same guard
+    out = rebind_pick(b, flavor="svdq-int4-r128", cast="")
+    assert wire_ref(out) == "acme/z-image#svdq-int4-r128"
+    with pytest.raises(ValueError):
+        rebind_pick(b, resolved_ref="acme/OTHER#fp8")  # ref mismatch
+    with pytest.raises(ValueError):
+        rebind_pick(HF("o/r"), resolved_ref="o/r#fp8")  # HF has no flavor

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the literal th#736 mechanic worker-side (gw#491 audit, HIGH): a second HelloAck with a different pick rebinds `spec.models` while loaded pipelines stay booked under the OLD resolved ref — VRAM orphaned forever, exec pins pin nothing, `_promote_setup_refs` misses, `_vacate_record` releases the wrong keys, `_adapter_target` returns None while `rec.ready` stays True; and `gate_functions` raced startup vs. HelloAck and was never re-run after resolutions.

**One fold.** `rebind_pick` (api/binding.py) is THE pick-fold: the hub HelloAck path (`resolved_ref`+`cast`) and cozy-local's ladder (`resolve_local_bindings`, previously a guard-less second copy) both use it; the round-trip guard (a pick the rebound binding can't re-mint = a split residency identity) now protects both paths. Guard compares against the gw#492 normal form, so hub spellings like `x:latest#fp8` still round-trip.

**One key space.** `_setup_locked` derives its wire refs ONCE (resolved space), downloads AND books under exactly those strings, and stamps them as the class record's `held_refs`. Teardown (`_vacate_record`), holder lookup (`_record_holding`) and in-use checks (`_record_in_use`) operate on `held_refs` — never a fresh derivation over possibly-rebound `spec.models`. Booking and clearing are provably the same space.

**Transactional application.** `apply_model_resolutions` marks ready records whose `held_refs` diverged from the rebound bindings as stale and (a) schedules an async revalidate that vacates them (skipping in-use instances — job-spec membership, not ref matching, is the in-use signal), (b) `ensure_setup` also vacates stale records on next touch, so the new pick loads fresh either way. Old resolved refs' VRAM is released — zero orphans; pins/promotes/LoRA targets hit the live entry after reload.

**Gates re-run.** `gate_functions` is idempotent (its `unavailable` marks are gate-owned and cleared on re-gate; `setup_failed` survives), remembers the hardware probe, and re-runs inside `apply_model_resolutions` — whichever of startup()/HelloAck runs first, gates + ServePlans settle on the rebound bindings.

Regression (`tests/test_resolution_rekey_gw494.py`): resolve→book→re-resolve→clear leaves ZERO VRAM-booked orphans (incl. revert-to-declared full-replace); vacate releases load-time keys after a rebind; HF-pick rejection keeps declared; re-gate idempotence + gate-owned vs setup-failed marks; single-fold contract.

Suite: 906 passed / 19 skipped on the 0.14 stack (torch 2.13 / transformers 5.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)