### PR TITLE
gw#479: canonical JSON-config digests in content keys (0.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.14.3 (2026-07-11)
+
+- **gw#479 follow-up: canonical JSON-config digests in content keys.** Live
+  qwen fp8 casts proved split-vendor pairs ship byte-identical component
+  weights whose tiny JSON sidecars differ only in save-era serialization
+  (provenance stamps `_name_or_path`/`transformers_version`/
+  `_diffusers_version`, explicit class defaults vs omitted, nulls,
+  transformers 4.56 `torch_dtype`->`dtype` rename) — all-file content keys
+  never shared. `ModelStore.component_digests(ref, local_path=)` now hashes
+  small (<=256KB) JSON sidecars CANONICALLY from the local snapshot
+  (`models/config_identity.py`): structural normalization for all configs,
+  plus AutoConfig `to_diff_dict()` default-folding for transformers
+  `config.json`. Weights keep manifest blake3 (never hashed from disk);
+  parse failures fall back to raw digests (conservative no-share). Keys are
+  process-local, so folding through the installed transformers version is
+  safe by construction.
+
 ## 0.14.2 (2026-07-11)
 
 - **gw#494: transactional HelloAck re-resolution — residency re-keys, gates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.2"
+version = "0.14.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -396,13 +396,19 @@ class ModelStore:
         (gw#465): snapshot-less ops for it can still materialize the bytes."""
         return ref in self._snapshots
 
-    def component_digests(self, ref: str) -> Dict[str, str]:
+    def component_digests(self, ref: str, local_path: Optional[Path] = None) -> Dict[str, str]:
         """Per-component content identity of ``ref``'s snapshot (gw#479):
-        ``{top_level_subfolder: content_set_digest}`` derived from the wire
-        snapshot's per-file blake3 digests. Root-level files group under
-        ``""`` (never shared — model_index.json etc. differ per repo).
-        Empty when no digest-carrying snapshot was seen — content-keyed
-        sharing then stays off; the loader never hashes snapshots itself."""
+        ``{top_level_subfolder: content_set_digest}``. Weight/data files use
+        the wire snapshot's per-file blake3; small JSON sidecars use
+        CANONICAL digests read from ``local_path`` (save-era serialization —
+        provenance stamps, explicit defaults, torch_dtype/dtype vocabulary —
+        must not break sharing of byte-identical weights; see
+        models/config_identity.py). Root-level files group under ``""``
+        (never shared — model_index.json etc. differ per repo). Empty when
+        no digest-carrying snapshot was seen — sharing stays off; weights
+        are never hashed from disk."""
+        from .models.config_identity import CANONICAL_JSON_MAX_BYTES, canonical_json_digest
+
         snap = self._snapshots.get(ref)
         if snap is None:
             return {}
@@ -414,7 +420,14 @@ class ModelStore:
             comp, _, rest = rel.partition("/")
             if not rest:
                 comp, rest = "", rel
-            groups.setdefault(comp, {})[rest] = str(f.blake3)
+            digest = str(f.blake3)
+            if (local_path is not None and comp
+                    and rest.endswith(".json")
+                    and int(f.size_bytes) <= CANONICAL_JSON_MAX_BYTES):
+                canonical = canonical_json_digest(Path(local_path) / rel)
+                if canonical:
+                    digest = canonical
+            groups.setdefault(comp, {})[rest] = digest
         return {c: residency_mod.content_set_digest(files)
                 for c, files in groups.items()}
 
@@ -1620,7 +1633,7 @@ class Executor:
             if binding is None:
                 return None
             ref = wire_ref(binding)
-            digests = self.store.component_digests(ref)
+            digests = self.store.component_digests(ref, local_path=Path(paths[slot]))
             keys[slot] = {
                 comp: residency_mod.LoadedComponentKey.for_component(
                     content_digest=digest, component=comp, binding=binding,

--- a/src/gen_worker/models/config_identity.py
+++ b/src/gen_worker/models/config_identity.py
@@ -1,0 +1,99 @@
+"""Canonical JSON-config digests for content-keyed sharing (gw#479).
+
+Split-vendor repo pairs ship byte-identical component WEIGHTS whose tiny JSON
+sidecars differ only in save-era serialization: provenance stamps
+(`_name_or_path`, `transformers_version`, `_diffusers_version`), explicit
+class-default fields vs omitted ones, `null` vs absent, and the transformers
+4.56 `torch_dtype` -> `dtype` key rename (live evidence: Qwen-Image vs
+Qwen-Image-Edit-2511 text encoders, saved by 4.53 vs 4.57). Content identity
+must track what the loader CONSTRUCTS, not save-time vocabulary — so weights
+keep their manifest blake3 and small JSON sidecars are hashed canonically:
+
+- ``config.json`` folds through the INSTALLED transformers' AutoConfig
+  ``to_diff_dict()`` (explicit defaults drop out) when it parses; anything
+  else (diffusers configs, tokenizer/processor configs) gets structural
+  canonicalization only.
+- structural canonicalization: recursively drop provenance keys and nulls,
+  rename ``torch_dtype`` -> ``dtype``, then a sorted-key compact dump.
+
+Content keys are PROCESS-LOCAL identity (the in-memory shared-component
+cache), so folding through whatever transformers version is installed is
+safe by construction — both lanes in one process fold identically. Any
+parse failure falls back conservatively (raw manifest digest = no sharing).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# JSON files above this are data (tokenizer.json vocab/merges), not configs:
+# they keep their manifest digest.
+CANONICAL_JSON_MAX_BYTES = 256 * 1024
+
+_PROVENANCE_KEYS = frozenset({
+    "_name_or_path", "transformers_version", "_diffusers_version",
+})
+
+
+def _normalize(value: Any) -> Any:
+    if isinstance(value, dict):
+        out = {}
+        for k, v in value.items():
+            if k in _PROVENANCE_KEYS or v is None:
+                continue
+            if k == "torch_dtype":
+                k = "dtype"
+            out[k] = _normalize(v)
+        return out
+    if isinstance(value, list):
+        return [_normalize(v) for v in value]
+    return value
+
+
+def _digest_of(obj: Any) -> str:
+    raw = json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+    return "cj:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+def _transformers_folded(path: Path) -> Any:
+    """AutoConfig round-trip for a transformers ``config.json``: class
+    defaults fold out of the serialized form, save-era vocabulary
+    normalizes. None when this isn't a transformers config."""
+    import transformers
+
+    cfg = transformers.AutoConfig.from_pretrained(
+        str(path.parent), local_files_only=True, trust_remote_code=False,
+    )
+    return cfg.to_diff_dict()
+
+
+def canonical_json_digest(path: Path) -> str:
+    """Canonical digest ("cj:"-prefixed, never collides with a raw blake3)
+    of one small JSON sidecar; "" when the file cannot be canonicalized
+    (caller keeps the raw manifest digest — conservative no-share)."""
+    path = Path(path)
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return ""
+    if len(raw) > CANONICAL_JSON_MAX_BYTES:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return ""
+    if path.name == "config.json":
+        try:
+            parsed = _transformers_folded(path)
+        except Exception:
+            pass  # diffusers/other config: structural canonicalization only
+    return _digest_of(_normalize(parsed))
+
+
+__all__ = ["canonical_json_digest", "CANONICAL_JSON_MAX_BYTES"]

--- a/tests/test_content_lanes.py
+++ b/tests/test_content_lanes.py
@@ -188,6 +188,70 @@ def test_share_plan_only_covers_byte_identical_components(tmp_path, lane_repos) 
     assert ex._component_share_plan(spec2, paths, hints) is None
 
 
+def test_canonical_config_digest_folds_save_era_noise(tmp_path) -> None:
+    """gw#479 live lesson (qwen fp8 casts): byte-identical weights, configs
+    differing only in save-era serialization must share; real field changes
+    must not."""
+    import json
+
+    from gen_worker.models.config_identity import canonical_json_digest
+
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir(), b.mkdir()
+
+    base = {"act_fn": "silu", "torch_dtype": "float32", "sample_size": 32,
+            "_diffusers_version": "0.34.0.dev0", "latents_mean": None}
+    saved_by_newer = {"act_fn": "silu", "dtype": "float32", "sample_size": 32,
+                      "_diffusers_version": "0.36.0.dev0"}
+    (a / "cfg.json").write_text(json.dumps(base))
+    (b / "cfg.json").write_text(json.dumps(saved_by_newer, indent=2))
+    da, db = canonical_json_digest(a / "cfg.json"), canonical_json_digest(b / "cfg.json")
+    assert da and da == db                       # provenance/null/dtype-rename fold
+
+    real_change = dict(saved_by_newer, sample_size=64)
+    (b / "cfg2.json").write_text(json.dumps(real_change))
+    assert canonical_json_digest(b / "cfg2.json") != da   # real field differs
+
+    # transformers config.json: explicit class defaults fold out via AutoConfig.
+    gpt_a = {"model_type": "gpt2", "n_layer": 2, "n_head": 2, "n_embd": 8}
+    gpt_b = {"model_type": "gpt2", "n_layer": 2, "n_head": 2, "n_embd": 8,
+             "resid_pdrop": 0.1, "_name_or_path": "/scratch/x",
+             "transformers_version": "4.53.1"}  # resid_pdrop 0.1 IS the default
+    (a / "config.json").write_text(json.dumps(gpt_a))
+    (b / "config.json").write_text(json.dumps(gpt_b))
+    ca, cb = canonical_json_digest(a / "config.json"), canonical_json_digest(b / "config.json")
+    assert ca and ca == cb
+
+
+def test_share_plan_survives_config_provenance_noise(tmp_path, lane_repos) -> None:
+    """Repo B's vae config rewritten by a 'newer library' (provenance stamp +
+    reindented + explicit null): the vae must STILL share."""
+    import json
+    import shutil
+
+    src_a, src_b = lane_repos["a"], lane_repos["b"]
+    a = tmp_path / "repo-a"
+    b = tmp_path / "repo-b"
+    shutil.copytree(src_a, a)
+    shutil.copytree(src_b, b)
+    cfg_path = b / "vae" / "config.json"
+    cfg = json.loads(cfg_path.read_text())
+    cfg["_diffusers_version"] = "9.99.9"
+    cfg["latents_mean"] = None
+    cfg_path.write_text(json.dumps(cfg, indent=4, sort_keys=True))
+
+    repos = {"acme/a": a, "acme/b": b}
+    spec = _lane_spec(_Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
+    ex = _executor([spec], tmp_path / "cache", 4 * _GiB, [], repos)
+    hints = {"a": TinyLanePipe, "b": TinyLanePipe}
+    paths = {"a": str(a), "b": str(b)}
+    plan = ex._component_share_plan(spec, paths, hints)
+    assert plan is not None
+    assert "vae" in plan["a"] and "vae" in plan["b"]     # canonical digests folded the noise
+    assert plan["a"]["vae"] == plan["b"]["vae"]
+    assert "unet" not in plan["a"]                        # weights still gate
+
+
 def test_routed_slots_validation(tmp_path, lane_repos) -> None:
     repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
     spec = _lane_spec(


### PR DESCRIPTION
Live J24M evidence (qwen fp8 casts): the two qwen repos' text encoders are byte-identical in WEIGHTS, but config.json/generation_config.json differ purely in save-era serialization (saved by transformers 4.53 vs 4.57: torch_dtype->dtype rename, explicit-default vision token ids vs omitted, nulls vs absent, _name_or_path/transformers_version; the vae differs only in _diffusers_version). All-file content keys therefore never shared — the exact case gw#479 exists for.

Fix: `component_digests(ref, local_path=)` hashes small (<=256KB) JSON sidecars canonically from the local snapshot (`models/config_identity.py`): recursive provenance-key + null drop, torch_dtype->dtype rename, sorted compact dump; transformers `config.json` additionally folds class defaults via `AutoConfig(...).to_diff_dict()`. Weights keep manifest blake3; canonical digests are `cj:`-prefixed (never collide with raw); any parse failure falls back to the raw digest (conservative no-share). Content keys are process-local identity, so folding through the installed transformers version is safe by construction.

Tests: canonical digest folds the exact qwen deltas + rejects real field changes; AutoConfig default-folding (gpt2 tiny config); share plan survives provenance-noise mutation of a component config while weights still gate. Full suite 909 passed / 18 skipped; ruff + http-guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)