### PR TITLE
th#757: download_failed ModelEvent carries the root cause (0.14.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.14.4 (2026-07-11)
+
+- **th#757 (worker side): terminal download failures carry the root cause.**
+  The generic `download_failed` ModelEvent now appends the sanitized
+  exception (`download_failed: <Type>: <detail>`, 200 chars) — serve pods
+  are often unreachable (no SSH/logs), making the hub log the only forensic
+  surface; J24M run11's starved request was undiagnosable without it. The
+  exact-match vocab strings the hub switches on (`url_expired`,
+  `missing_snapshot`, `insufficient_disk`, `digest_mismatch`) are unchanged.
+
+
 ## 0.14.5 (2026-07-11)
 
 - **gw#504: media-output wire contract pinned — save_image on ANY job kind

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -655,8 +655,14 @@ class ModelStore:
                 except Exception as exc:
                     terminal = _is_terminal_download_error(exc) or attempt >= _DOWNLOAD_RETRIES
                     if terminal:
-                        await self._event(ref, pb.MODEL_STATE_FAILED,
-                                          error=self._error_vocab(exc))
+                        vocab = self._error_vocab(exc)
+                        if vocab == "download_failed":
+                            # th#757: the generic bucket must carry the root
+                            # cause — pods are often unreachable and the hub
+                            # log is the only forensic surface (J24M run11:
+                            # a starved request was undiagnosable hub-side).
+                            vocab = f"download_failed: {_sanitize(f'{type(exc).__name__}: {exc}')[:200]}"
+                        await self._event(ref, pb.MODEL_STATE_FAILED, error=vocab)
                         raise
                     logger.warning("download of %s failed (attempt %d): %s; retrying in %.1fs",
                                    ref, attempt, exc, delay)


### PR DESCRIPTION
J24M runs 10-12: qwen-image-edit-2511#fp8 failed download deterministically on three pods while its blobs verify byte-perfect from R2 — and the hub log's bare 'download_failed' made the root cause invisible (pods unreachable: no public IP, proxy SSH needs account keys). The generic bucket now appends the sanitized exception (Type: detail, 200 chars). Exact-match vocab strings the hub switches on are unchanged. 64 download/vocab tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)