### PR TITLE
gw#479: per-digest inflight blob lock (0.14.6) — multi-lane refs corrupted shared .part downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.14.6 (2026-07-11)
+
+- **gw#479: per-digest inflight lock in the content-addressed blob store.**
+  Two refs materializing concurrently share blobs (split-vendor lanes: 9.7GB
+  of byte-identical encoder shards) — both tasks streamed into the SAME
+  `.part` file, interleaved writes failed size/blake3 verification 3x, and
+  the second ref died `download_failed` on every attempt (J24M runs 10-12,
+  three A100 pods, ~2.5min in, while every blob verified byte-perfect in
+  R2). The first task now downloads under a process-wide per-digest
+  asyncio lock; siblings await it, re-check usability, and reuse the
+  finished blob. Regression: concurrent two-ref materialization downloads
+  a shared blob exactly once (fails without the lock).
+- Releases the merged-but-unreleased th#757 forensics change:
+  `download_failed` ModelEvents carry the sanitized root cause.
+
+
 ## 0.14.4 (2026-07-11)
 
 - **th#757 (worker side): terminal download failures carry the root cause.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.5"
+version = "0.14.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -19,6 +19,23 @@ from ..s3_transfer import S3TransferGrant, download_file_with_grant
 
 _log = logging.getLogger("gen_worker.download")
 
+# Per-digest inflight downloads (gw#479 multi-lane fallout, th#757 forensics):
+# two refs materializing concurrently SHARE blobs in the content-addressed
+# store (split-vendor lanes: 9.7GB of identical encoder shards). Without a
+# per-digest lock both tasks streamed into the SAME .part file, interleaved
+# writes failed size/blake3 verification 3x, and the second ref died with
+# download_failed on every attempt (J24M runs 10-12, three pods, ~2.5min in —
+# while every blob verified byte-perfect in R2). First task downloads; the
+# second awaits the lock, re-checks usability, and reuses the finished blob.
+_INFLIGHT_BLOB_LOCKS: dict[str, "asyncio.Lock"] = {}
+_INFLIGHT_BLOB_LOCKS_CAP = 8192
+
+
+def _inflight_blob_lock(digest: str) -> "asyncio.Lock":
+    if len(_INFLIGHT_BLOB_LOCKS) > _INFLIGHT_BLOB_LOCKS_CAP:
+        _INFLIGHT_BLOB_LOCKS.clear()  # bounded memory; races just re-lock
+    return _INFLIGHT_BLOB_LOCKS.setdefault(digest, asyncio.Lock())
+
 ProgressFn = Callable[[int, Optional[int]], None]
 
 # Free space that must remain after downloading the missing blobs.
@@ -314,6 +331,14 @@ class CozySnapshotDownloader:
             if self._blob_usable(dst, f):
                 _log.info("blob_cached path=%s digest=%s", f.path, digest[:16])
                 return
+            async with _inflight_blob_lock(digest):
+                if self._blob_usable(dst, f):
+                    _log.info("blob_shared_inflight path=%s digest=%s (sibling ref downloaded it)",
+                              f.path, digest[:16])
+                    return
+                await _dl_locked(f, digest, dst)
+
+        async def _dl_locked(f: WorkerResolvedRepoFile, digest: str, dst: Path) -> None:
             async with sem:
                 if self._blob_usable(dst, f):
                     return

--- a/tests/test_snapshot_corruption.py
+++ b/tests/test_snapshot_corruption.py
@@ -320,3 +320,60 @@ def test_safetensors_file_valid(tmp_path: Path) -> None:
     empty = tmp_path / "empty.safetensors"
     empty.write_bytes(b"")
     assert not safetensors_file_valid(empty)
+
+
+# --------------------------------------------------------------------------- #
+# gw#479 multi-lane fallout: refs sharing blobs must download each blob ONCE
+# --------------------------------------------------------------------------- #
+
+
+def test_concurrent_refs_sharing_a_blob_download_it_once(tmp_path: Path, monkeypatch) -> None:
+    """Two refs materializing CONCURRENTLY share a blob (split-vendor lanes
+    share 9.7GB of encoder shards): without the per-digest inflight lock both
+    streamed into the same .part, interleaved writes failed verification, and
+    the second ref died download_failed on three real pods (J24M runs 10-12).
+    The second task must WAIT and reuse the finished blob."""
+    content = _tiny_safetensors()
+    digest = blake3(content).hexdigest()
+    calls = {"n": 0, "inflight": 0, "max_inflight": 0}
+
+    async def _slow_dl(url, dst, expected_size, expected_blake3, on_bytes=None):
+        calls["n"] += 1
+        calls["inflight"] += 1
+        calls["max_inflight"] = max(calls["max_inflight"], calls["inflight"])
+        await asyncio.sleep(0.05)  # hold the download open so tasks overlap
+        dst.write_bytes(content)
+        calls["inflight"] -= 1
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _slow_dl)
+
+    from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+    from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+    from gen_worker.models.refs import TensorhubRef
+
+    def _resolved(snap_digest: str, exclusive: bytes) -> WorkerResolvedRepo:
+        return WorkerResolvedRepo(
+            snapshot_digest=snap_digest,
+            files=[
+                WorkerResolvedRepoFile(
+                    path="text_encoder/model.safetensors", size_bytes=len(content),
+                    blake3=digest, url="http://example.invalid/shared"),
+            ],
+        )
+
+    async def _both() -> None:
+        await asyncio.gather(
+            ensure_snapshot_async(
+                base_dir=tmp_path, ref=TensorhubRef(owner="e2e", repo="lane-a"),
+                resolved=_resolved("aa" * 32, b"a")),
+            ensure_snapshot_async(
+                base_dir=tmp_path, ref=TensorhubRef(owner="e2e", repo="lane-b"),
+                resolved=_resolved("bb" * 32, b"b")),
+        )
+
+    asyncio.run(_both())
+    assert calls["n"] == 1, f"shared blob downloaded {calls['n']}x — inflight lock missing"
+    assert calls["max_inflight"] == 1
+    for repo in ("lane-a", "lane-b"):
+        snap_dirs = list((tmp_path).rglob("text_encoder/model.safetensors"))
+    assert len(snap_dirs) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.5"
+version = "0.14.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Root cause of the J24M chapter-4 starvation (runs 10-12, three A100 pods): the merged qwen release keeps two snapshots whose manifests share 16 blobs (9.69GB fp8 encoder/vae/tokenizer). Both snapshot tasks downloaded the SAME digest into the SAME .part path concurrently — interleaved writes → size/blake3 verify failure ×3 (~2.5min, matching observed walls) → ValueError('size mismatch') → generic download_failed → th#757 (no hub re-drive) starved the queued request on a paid pod. Every blob verifies byte-perfect from R2 (28.10GB re-hashed locally).

Fix: process-wide per-digest asyncio lock around blob download+finalize; siblings await, re-check `_blob_usable`, reuse. Regression test: two concurrent `ensure_snapshot_async` refs sharing one blob → exactly one download (verified failing without the lock). Also ships the merged-but-unreleased th#757 error-detail change.

This bug class is new fallout of gw#479's split-vendor lanes — single-repo releases never co-download shared digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)