### PR TITLE
typing: tighten public authoring surface + ship py.typed

### DIFF
--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import inspect
 import typing
-from typing import Any, Callable, Literal, Mapping, Optional, Sequence, TypeVar
+from typing import Any, Callable, Literal, Mapping, Optional, Sequence, TypeVar, overload
 
 import msgspec
 
@@ -498,6 +498,25 @@ def _decorate_function(
     )
     setattr(fn, ATTR, decl)
     return fn
+
+
+@overload
+def endpoint(target: T) -> T: ...  # bare @endpoint on a class/function
+
+
+@overload
+def endpoint(
+    *,
+    kind: str = ...,
+    model: Optional[Binding] = ...,
+    models: Optional[Mapping[str, Binding]] = ...,
+    resources: Optional[Resources] = ...,
+    variants: Optional[Mapping[str, Any]] = ...,
+    runtime: Optional[str] = ...,
+    name: Optional[str] = ...,
+    compile: Optional[Compile] = ...,
+    route: Optional[Callable[[Any], Sequence[str]]] = ...,
+) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
 def endpoint(

--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -99,8 +99,12 @@ class AudioAsset(MediaAsset):
     """Reference to audio media bytes."""
 
 
-class StringEnum(StrEnum):
-    """Base class for endpoint-declared string enum payload fields."""
+# Named, documented base for endpoint string-enum payload fields. It is a
+# direct alias for enum.StrEnum, NOT a subclass: subclassing an empty enum base
+# makes members of a tenant's `class Size(StringEnum)` resolve as `str` to mypy
+# (an empty-enum-base gap), which forced `# type: ignore[assignment]` on every
+# preset default `size: Size = Size.SQUARE`. The alias checks clean (ie#345).
+StringEnum = StrEnum
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -15,12 +15,33 @@ import urllib.parse
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Literal, Mapping, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    TypedDict,
+)
 
 if TYPE_CHECKING:  # heavy deps stay import-time-free; methods import lazily
+    import numpy as np
     import torch
+    from PIL import Image
 
     from ._concurrent_upload import BudgetGate
+
+
+class LoraOverlay(TypedDict):
+    """One per-request LoRA overlay riding a model slot (gw#393)."""
+
+    ref: str
+    weight: float
 
 from ..api.errors import AuthError
 from ..api.types import (
@@ -182,12 +203,12 @@ class RequestContext:
         return self._deadline
 
     @property
-    def models(self) -> Dict[str, Any]:
+    def models(self) -> Dict[str, str]:
         """Resolved model refs for this invocation, keyed by slot name."""
         return _copy_context_metadata(self._models)
 
     @property
-    def loras(self) -> Dict[str, Any]:
+    def loras(self) -> Dict[str, Tuple[LoraOverlay, ...]]:
         """Per-request LoRA overlays riding each model slot (gw#393):
         slot name -> tuple of ``{"ref", "weight"}``. Empty for adapter-free
         requests. The worker applies/removes the adapters around the handler
@@ -514,7 +535,7 @@ class RequestContext:
 
     def save_image(
         self,
-        image: Any,
+        image: "Image.Image",
         ref: Optional[str] = None,
         *,
         format: str = "webp",
@@ -559,7 +580,7 @@ class RequestContext:
 
     def save_audio(
         self,
-        audio: Any,
+        audio: "np.ndarray[Any, Any] | torch.Tensor | bytes",
         ref: Optional[str] = None,
         *,
         sample_rate: int = 44100,
@@ -589,7 +610,7 @@ class RequestContext:
                 raise ValidationError(
                     "save_audio needs the audio extra: pip install 'gen-worker[audio]'"
                 ) from exc
-            arr = audio
+            arr: Any = audio
             if hasattr(arr, "detach"):
                 arr = arr.detach().cpu().numpy()
             arr = np.asarray(arr)


### PR DESCRIPTION
Public-surface typing audit of the authoring API. Every change is a pure typing tightening — runtime behavior is unchanged. `mypy src/gen_worker` stays at **0 errors** (verified before and after in the pinned-dep venv).

## Fixes
| # | file:line | before → after |
|---|---|---|
| 1 | `api/decorators.py:503` | `endpoint(...) -> Any` → two `@overload`s: bare `@endpoint` is `T -> T`, configured `@endpoint(...)` is `Callable[[T], T]`. Previously **every** decorated endpoint class/function resolved as `Any` to downstream checkers, even with py.typed. |
| 2 | `api/types.py:102` | `class StringEnum(StrEnum)` → `StringEnum = StrEnum` (alias). Subclassing an empty enum base made members of a tenant's `class Size(StringEnum)` resolve as `str` to mypy, forcing `# type: ignore[assignment]` on the SDK-prescribed preset-default idiom (ie#345). The alias checks clean; nothing does `issubclass(x, StringEnum)`. |
| 3 | `request_context/__init__.py:205,210` | `ctx.models: Dict[str, Any]` → `Dict[str, str]`; `ctx.loras: Dict[str, Any]` → `Dict[str, Tuple[LoraOverlay, ...]]` (new `TypedDict`). Honest to the runtime shape (`executor.py:2343` stamps `slot->ref` strings / `{ref, weight}` rows). Removes the defensive `str(ctx.models.get(...) or "")` casts endpoints needed. |
| 4 | `request_context/__init__.py:538,583` | `save_image(image: Any)` → `Image.Image`; `save_audio(audio: Any)` → `np.ndarray \| torch.Tensor \| bytes`, both under `TYPE_CHECKING`. |
| 5 | `src/gen_worker/py.typed` (new) | PEP 561 marker — verified present in the built wheel (`gen_worker/py.typed`). The package previously advertised no typing at all, so none of the above reached tenant checkers. |

## Deliberately NOT changed
- **`variants=` typing** — slated for deletion (pgw#509 / th#761); not worth typing.
- **`route=` payload / returned-slot validation** — `route` is a black-box `Callable`, so returned slot names cannot be validated at *decoration* time; they already ARE validated at runtime (`executor.py:2399-2404`). Typing the payload would require threading a per-endpoint payload TypeVar that the generic `EndpointDecl` field can't carry. Left as-is.

## Tests
`pytest -m "not integration"`: **890 passed**, 11 skipped. The 5 failures are this box's `GEN_WORKER_FORBID_CPU_OFFLOAD=1` guard (real-model/CPU-offload inference forbidden on the shared box), not typing. Directly-relevant `test_discovery_and_decorators` + `test_request_context` (34 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)