### PR TITLE
ci: make mypy a blocking gate (repo is 0-error)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Type check
-        continue-on-error: true  # Type debt in clone/conversion/etc — see follow-up; visible in logs, doesn't block publish.
-        run: uv run mypy src/gen_worker
-
+      # mypy already gates ci.yml on every push/PR to master (gw#497); tags are
+      # cut from master after CI passes, so re-running it here is redundant.
       - name: Run tests
         run: uv run pytest tests/ -v
 


### PR DESCRIPTION
## Summary
- `ci.yml` already gates mypy at zero errors (merged separately in #199 / gw#497); verified `uv run mypy src/gen_worker` is still 0-error in the pinned `--extra dev` venv this CI job uses.
- `publish.yml` still ran a second mypy pass under `continue-on-error: true` with a stale "type debt" comment. Removed it — master is CI-verified clean before any release tag is cut, so a second advisory-only pass added nothing.

## Verification
```
$ uv sync --extra dev && uv run mypy src/gen_worker
Success: no issues found in 100 source files
```

## Note
Original task assumed `ci.yml` had no mypy step yet — that landed upstream via #199 (gw#497) since. This PR just closes the remaining gap (the redundant non-blocking pass in `publish.yml`).

## Test plan
- [x] `uv run mypy src/gen_worker` → 0 errors in the CI-matching venv
- [ ] CI green on this PR (ci.yml mypy step unaffected; publish.yml only runs on tag push)