### PR TITLE
feat(progress): windowed diffusers_step_callback for multi-stage pipelines (ie#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.14.8 (2026-07-12)
+
+- **ie#463: `diffusers_step_callback` gains `window=(start, end)`.** Multi-stage
+  pipelines (denoise + latent-upsample refine, etc.) now compose two calls,
+  each reporting into its own sub-range of the request's 0..1 progress bar,
+  instead of the second stage resetting the bar to 0. `step`/`total` on the
+  wire still describe progress within the current stage. Default
+  `window=(0.0, 1.0)` is unchanged (fully backward compatible) — every
+  existing single-stage caller is unaffected. Fixes the gap that led
+  ltx-video-2.3 to hand-roll its own step callback, which omitted
+  `raise_if_cancelled()` and left long video jobs uncancellable mid-run.
+
 ## 0.14.7 (2026-07-12)
 
 - **gw#421: retire the gen-worker-repo GPU CI lane; real-GPU coverage moves

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.7"
+version = "0.14.8"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/progress.py
+++ b/src/gen_worker/api/progress.py
@@ -8,7 +8,7 @@ matches the ``callback_on_step_end`` contract.
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
 if TYPE_CHECKING:
     from ..request_context import RequestContext
@@ -17,6 +17,13 @@ if TYPE_CHECKING:
 #: Mirrors the ``training_metric`` throttle so 20-step turbo runs don't spam.
 DEFAULT_STEP_MIN_INTERVAL_S = 0.25
 
+#: A ``(start, end)`` sub-range of the request's overall 0..1 progress bar,
+#: both bounds in ``[0.0, 1.0]`` with ``start <= end``.
+Window = Tuple[float, float]
+
+#: Default window: the callback owns the whole progress bar (single-stage).
+_FULL_WINDOW: Window = (0.0, 1.0)
+
 
 def diffusers_step_callback(
     ctx: "RequestContext",
@@ -24,6 +31,7 @@ def diffusers_step_callback(
     *,
     stage: Optional[str] = "denoise",
     min_interval_s: float = DEFAULT_STEP_MIN_INTERVAL_S,
+    window: Window = _FULL_WINDOW,
 ) -> Callable[..., Dict[str, Any]]:
     """Wire a diffusers pipeline's per-step callback to ``ctx.progress``.
 
@@ -31,13 +39,33 @@ def diffusers_step_callback(
 
         pipe(..., callback_on_step_end=diffusers_step_callback(ctx, steps))
 
-    After each denoise step it emits ``ctx.progress(step/total, stage,
+    After each denoise step it emits ``ctx.progress(fraction, stage,
     step=step, total=total)``, throttled to one event per ``min_interval_s``
     (first and last steps always emit). It also calls
     ``ctx.raise_if_cancelled()`` every step, so a cancelled request aborts
     the pipeline mid-run instead of denoising to completion.
+
+    Multi-stage pipelines (e.g. a base denoise pass followed by a latent
+    upsample/refine pass) compose two calls, each reporting into its own
+    ``window`` of the request's overall progress bar instead of every stage
+    resetting the bar to 0::
+
+        pipe(..., callback_on_step_end=diffusers_step_callback(
+            ctx, base_steps, stage="denoise", window=(0.0, 0.6),
+        ))
+        ...
+        pipe(..., callback_on_step_end=diffusers_step_callback(
+            ctx, refine_steps, stage="refine", window=(0.65, 0.9),
+        ))
+
+    ``step``/``total`` on the wire always describe progress within the
+    current stage (e.g. "3/8"); ``fraction`` is what maps into ``window``.
     """
     total = int(num_inference_steps)
+    start, end = window
+    if not (0.0 <= start <= end <= 1.0):
+        raise ValueError(f"window must satisfy 0.0 <= start <= end <= 1.0, got {window!r}")
+    span = end - start
     last_emit: Optional[float] = None
 
     def _on_step_end(
@@ -53,8 +81,8 @@ def diffusers_step_callback(
         is_last = total > 0 and step >= total
         if last_emit is None or is_last or (now - last_emit) >= min_interval_s:
             last_emit = now
-            fraction = min(step / total, 1.0) if total > 0 else 0.0
-            ctx.progress(fraction, stage, step=step, total=total)
+            step_fraction = min(step / total, 1.0) if total > 0 else 0.0
+            ctx.progress(start + span * step_fraction, stage, step=step, total=total)
         return callback_kwargs if callback_kwargs is not None else {}
 
     return _on_step_end

--- a/tests/test_progress_helper.py
+++ b/tests/test_progress_helper.py
@@ -62,3 +62,45 @@ def test_cancelled_request_aborts_mid_pipeline() -> None:
     with pytest.raises(CanceledError):
         cb(None, 1, None, {})
     assert len(events) == 1  # nothing emitted after cancellation
+
+
+def test_window_maps_progress_into_sub_range_but_step_total_stay_stage_local() -> None:
+    events: list = []
+    cb = diffusers_step_callback(
+        _ctx(events), 4, stage="denoise", min_interval_s=0.0, window=(0.0, 0.6)
+    )
+    _run_steps(cb, 4)
+    payloads = [e["payload"] for e in events]
+    assert payloads[0] == {"progress": 0.15, "stage": "denoise", "step": 1, "total": 4}
+    assert payloads[-1] == {"progress": 0.6, "stage": "denoise", "step": 4, "total": 4}
+
+
+def test_two_stage_pipeline_composes_two_windows_without_resetting_bar() -> None:
+    events: list = []
+    ctx = _ctx(events)
+    denoise = diffusers_step_callback(ctx, 2, stage="denoise", min_interval_s=0.0, window=(0.0, 0.6))
+    refine = diffusers_step_callback(ctx, 3, stage="refine", min_interval_s=0.0, window=(0.65, 0.9))
+    _run_steps(denoise, 2)
+    _run_steps(refine, 3)
+    payloads = [e["payload"] for e in events]
+    # Denoise stage: 0.3, 0.6 (never resets to 0 once refine starts).
+    assert payloads[0]["progress"] == pytest.approx(0.3)
+    assert payloads[1]["progress"] == pytest.approx(0.6)
+    # Refine stage climbs monotonically from where denoise left off.
+    assert payloads[2]["progress"] == pytest.approx(0.65 + 0.25 * (1 / 3))
+    assert payloads[-1]["progress"] == pytest.approx(0.9)
+    assert all(p["progress"] >= payloads[i - 1]["progress"] for i, p in enumerate(payloads) if i)
+
+
+def test_window_validation_rejects_out_of_range_or_inverted_bounds() -> None:
+    ctx = _ctx([])
+    for bad_window in [(-0.1, 0.5), (0.5, 1.1), (0.6, 0.4)]:
+        with pytest.raises(ValueError):
+            diffusers_step_callback(ctx, 4, window=bad_window)  # type: ignore[arg-type]
+
+
+def test_default_window_is_full_range_backward_compatible() -> None:
+    events: list = []
+    cb = diffusers_step_callback(_ctx(events), 4, min_interval_s=0.0)
+    _run_steps(cb, 4)
+    assert [e["payload"]["progress"] for e in events] == [0.25, 0.5, 0.75, 1.0]

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.6"
+version = "0.14.8"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- `diffusers_step_callback` gains an optional `window=(start, end)` (+ `stage=`) so multi-stage diffusers pipelines (e.g. base denoise → latent-upsample refine) can compose two calls that each report into their own sub-range of the request's 0..1 progress bar, instead of every stage resetting to 0.
- `step`/`total` on the wire stay stage-local ("3/8" within the current stage); only the emitted `progress` fraction maps into the window.
- Default `window=(0.0, 1.0)` is unchanged — every existing single-stage caller (sdxl, z-image, qwen-image, etc.) is unaffected.
- Bumped 0.14.7 → 0.14.8 + CHANGELOG entry (follows this repo's per-PR version-bump convention).

## Why (ie#463, DX-REVIEW-2026-07-12 finding #5)
`diffusers_step_callback` already delivers per-step `ctx.raise_if_cancelled()` + `ctx.progress()`, but couldn't express a progress sub-range. Because of that gap, ltx-video-2.3 hand-rolled its own `_progress_callback` to map two stages onto `[0, 0.6]` / `[0.65, 0.9]` — and the hand-rolled version omits `raise_if_cancelled()`, silently reintroducing the exact "uncancellable mid-inference" bug this issue exists to fix. This PR closes that gap at the SDK level; the companion `inference-endpoints` PR deletes ltx's private callback and wires the shared helper everywhere.

## Test plan
- [x] `python -m mypy src/gen_worker` — 0 errors (100 source files)
- [x] `python -m pytest tests/test_progress_helper.py -q` — 9/9 pass (5 existing + 4 new: window sub-range mapping, two-stage composition never resets backward, window validation, default-window backward compatibility)
- [x] `python -m pytest -m "not integration" -q` (full suite, capped) — 894 passed, 11 skipped, 14 deselected; 4 pre-existing failures unrelated to this change (`GEN_WORKER_FORBID_CPU_OFFLOAD=1` env guard rejecting CPU/CUDA-unavailable placement in RAM-admission/snapshot-corruption/module-layout tests — this box has no GPU and that guard is intentionally not bypassed)
- No GPU/real-model inference run (per repo policy on this shared box).