### PR TITLE
gw#479: prune parent-duplicated sub-config keys from canonical config digests (0.14.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.14.9 (2026-07-12)
+
+- **gw#479: canonical config digests prune sub-config keys duplicating the
+  parent.** Live qwen evidence (fp8 lanes, A100): transformers 4.53
+  serialized vision_start/end_token_id into BOTH the top-level VL config
+  and text_config; 4.57 writes them only at top — materialized top-level
+  values identical, but the sub-config duplicate kept two byte-identical
+  text encoders on separate content keys (each lane booked its own 9.4GB
+  TE; only the vae shared). Sub-config values that DIFFER from the parent
+  still separate keys.
+
+
 ## 0.14.8 (2026-07-12)
 
 - **ie#463: `diffusers_step_callback` gains `window=(start, end)`.** Multi-stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.8"
+version = "0.14.9"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/config_identity.py
+++ b/src/gen_worker/models/config_identity.py
@@ -50,6 +50,17 @@ def _normalize(value: Any) -> Any:
             if k == "torch_dtype":
                 k = "dtype"
             out[k] = _normalize(v)
+        # Prune sub-dict keys that duplicate the parent's same-named scalar:
+        # save-era redundancy, not content (qwen live evidence: transformers
+        # 4.53 wrote vision_start/end_token_id into BOTH the top-level VL
+        # config and text_config; 4.57 writes them only at top — the
+        # materialized top-level values are identical either way).
+        for k, v in out.items():
+            if isinstance(v, dict):
+                out[k] = {
+                    kk: vv for kk, vv in v.items()
+                    if isinstance(vv, (dict, list)) or kk not in out or out[kk] != vv
+                }
         return out
     if isinstance(value, list):
         return [_normalize(v) for v in value]

--- a/tests/test_content_lanes.py
+++ b/tests/test_content_lanes.py
@@ -223,6 +223,36 @@ def test_canonical_config_digest_folds_save_era_noise(tmp_path) -> None:
     assert ca and ca == cb
 
 
+def test_canonical_config_prunes_parent_duplicated_subconfig_keys(tmp_path) -> None:
+    """Live qwen pair: transformers 4.53 serialized vision token ids into
+    BOTH the top-level VL config and text_config; 4.57 only at top. The
+    materialized top-level values are identical — the sub-config duplicate
+    is save-era redundancy and must not split content keys. A sub-config
+    value that DIFFERS from the parent still separates."""
+    import json
+
+    from gen_worker.models.config_identity import canonical_json_digest
+
+    a, b, c = tmp_path / "a", tmp_path / "b", tmp_path / "c"
+    for d in (a, b, c):
+        d.mkdir()
+    top = {"model_type": "qwen2_5_vl", "vision_start_token_id": 151652,
+           "vision_end_token_id": 151653}
+    saved_by_453 = dict(top, text_config={"hidden_size": 8, "vision_start_token_id": 151652,
+                                          "vision_end_token_id": 151653})
+    saved_by_457 = dict(top, text_config={"hidden_size": 8})
+    genuinely_diff = dict(top, text_config={"hidden_size": 8, "vision_start_token_id": 99})
+    # cfg.json name => structural path (no AutoConfig instantiation noise).
+    (a / "cfg.json").write_text(json.dumps(saved_by_453))
+    (b / "cfg.json").write_text(json.dumps(saved_by_457))
+    (c / "cfg.json").write_text(json.dumps(genuinely_diff))
+    da = canonical_json_digest(a / "cfg.json")
+    db = canonical_json_digest(b / "cfg.json")
+    dc = canonical_json_digest(c / "cfg.json")
+    assert da and da == db
+    assert dc != da
+
+
 def test_share_plan_survives_config_provenance_noise(tmp_path, lane_repos) -> None:
     """Repo B's vae config rewritten by a 'newer library' (provenance stamp +
     reindented + explicit null): the vae must STILL share."""


### PR DESCRIPTION
Live A100 evidence (J24M run15): sharing engaged for vae+tokenizer but each lane still booked its own 9.4GB fp8 TE — the ONLY residual key difference was text_config.vision_start/end_token_id, which transformers 4.53 serialized into both the top-level VL config and text_config while 4.57 writes them only at top; both configs materialize identical top-level values. Canonicalization now prunes sub-dict keys whose scalar value duplicates the parent's same-named key (save-era redundancy, zero architecture knowledge); differing sub-config values still separate. Verified on the two real fp8 TE configs (digests now equal) + regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)