### PR TITLE
feat(binding): structured ModelRef replaces stringly owner/repo:tag#flavor (pgw#511)

### DIFF
--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -14,7 +14,7 @@ subclass from ``@endpoint(kind=...)`` before dispatch.
 """
 
 from . import io
-from .api.binding import Civitai, HF, Hub, ModelScope
+from .api.binding import Civitai, HF, Hub, ModelRef, ModelScope
 from .api.decorators import Compile, Resources, endpoint
 from .api.errors import (
     CanceledError,
@@ -59,6 +59,7 @@ __all__ = [
     "HF",
     "Hub",
     "Civitai",
+    "ModelRef",
     "ModelScope",
     # Context types.
     "RequestContext",

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -1,6 +1,6 @@
 """Public SDK surface: the @endpoint decorator, bindings, types, and errors."""
 
-from .binding import Binding, Civitai, HF, Hub, ModelScope
+from .binding import Binding, Civitai, HF, Hub, ModelRef, ModelScope
 from .decorators import Resources, endpoint
 from .errors import (
     AuthError,
@@ -47,6 +47,7 @@ __all__ = [
     "Civitai",
     "HF",
     "Hub",
+    "ModelRef",
     "ModelScope",
     "Resources",
     "endpoint",

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -8,12 +8,22 @@ single ``model=`` binding, the ``setup()``/handler parameter name).
     Hub("owner/repo", tag="canary", flavor="nf4")
     Civitai("123456", version="789012")
     ModelScope("circlestone-labs/Anima", files=("split_files/*.safetensors",))
+
+``ModelRef`` (pgw#511) is the ONE structured type: ``source`` is an explicit
+field (never inferred from which factory built the value), ``path`` is the
+bare repo/model id. ``Hub``/``HF``/``Civitai``/``ModelScope`` are thin
+FACTORY FUNCTIONS over ``ModelRef`` — sugar, not a second type — that pin
+``source`` and keep each registry's historical constructor signature and
+validation.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, ClassVar, Union
+from typing import Any, Literal
+
+import msgspec
+
+ModelSource = Literal["tensorhub", "huggingface", "civitai", "modelscope"]
 
 
 def _clean(s: object) -> str:
@@ -40,8 +50,93 @@ def _clean_storage_dtype(v: object) -> str:
     return q
 
 
-@dataclass(frozen=True)
-class Hub:
+class ModelRef(msgspec.Struct, frozen=True):
+    """ONE structured model reference (pgw#511): ``source`` is explicit, never
+    inferred from shape or which factory built the value.
+
+    Carries the union of every registry's per-source fields (tensorhub:
+    ``tag``/``flavor``/``allow_lora``; huggingface: ``revision``/``dtype``/
+    ``subfolder``/``files``; civitai: ``version``; modelscope: ``revision``/
+    ``files``). ``storage_dtype`` is shared by tensorhub/huggingface. Build
+    one via ``Hub``/``HF``/``Civitai``/``ModelScope`` rather than the raw
+    constructor — they pin ``source`` and apply the per-registry validation
+    below (mirrored in ``__post_init__`` so it holds for direct construction
+    too, e.g. ``msgspec.structs.replace``).
+
+    ``.provider`` and ``.ref`` are back-compat aliases for call sites that
+    predate the explicit ``source``/``path`` fields: ``.provider`` returns
+    the OLDER, narrower vocabulary (``"hf"`` not ``"huggingface"``; no
+    ``"modelscope"``) that tensorhub's build-manifest ``bindings.<slot>.provider``
+    column is DB-CHECK-constrained to — do not repoint manifest/download code
+    at ``.source`` without also widening that constraint.
+    """
+
+    source: ModelSource
+    path: str
+    tag: str = ""
+    flavor: str = ""
+    revision: str = ""
+    subfolder: str = ""
+    dtype: str = ""
+    storage_dtype: str = ""
+    version: str = ""
+    files: tuple[str, ...] = ()
+    allow_lora: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", _clean(self.path))
+        object.__setattr__(self, "tag", _clean(self.tag))
+        object.__setattr__(self, "flavor", _clean(self.flavor))
+        object.__setattr__(self, "revision", _clean(self.revision))
+        object.__setattr__(self, "subfolder", _clean(self.subfolder))
+        object.__setattr__(self, "dtype", _clean(self.dtype))
+        object.__setattr__(self, "version", _clean(self.version))
+        object.__setattr__(
+            self, "files", tuple(_clean(p) for p in self.files if _clean(p))
+        )
+        object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
+        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
+
+        if self.source == "tensorhub":
+            if not self.tag:
+                object.__setattr__(self, "tag", "latest")
+            if not self.path:
+                raise ValueError("Hub requires a non-empty ref")
+        elif self.source == "huggingface":
+            if "/" not in self.path:
+                raise ValueError(f"HF(id=) must be 'owner/repo', got {self.path!r}")
+        elif self.source == "civitai":
+            if not self.path:
+                raise ValueError("Civitai requires a non-empty model id")
+        elif self.source == "modelscope":
+            if "/" not in self.path:
+                raise ValueError(f"ModelScope(id=) must be 'owner/repo', got {self.path!r}")
+        else:
+            raise ValueError(f"unknown ModelRef source {self.source!r}")
+
+    @property
+    def provider(self) -> str:
+        """Back-compat alias, OLD narrower vocabulary: ``"hf"`` (not
+        ``"huggingface"``) for huggingface refs, ``source`` verbatim
+        otherwise. This is what tensorhub's build-manifest
+        ``bindings.<slot>.provider`` column expects — use ``.source`` for
+        anything new (pgw#511 wire vocabulary)."""
+        return "hf" if self.source == "huggingface" else self.source
+
+    @property
+    def ref(self) -> str:
+        """Back-compat alias for ``.path``."""
+        return self.path
+
+
+def Hub(
+    ref: str,
+    *,
+    tag: str = "latest",
+    flavor: str = "",
+    storage_dtype: str = "",
+    allow_lora: bool = False,
+) -> ModelRef:
     """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=, allow_lora=)``.
 
     ``allow_lora=True`` opts the slot into per-request LoRA overlays
@@ -49,31 +144,22 @@ class Hub:
     ``Compile(family=...)`` so the hub's architecture gate can police
     adapter targets.
     """
-
-    PROVIDER: ClassVar[str] = "tensorhub"
-
-    ref: str
-    tag: str = "latest"
-    flavor: str = ""
-    storage_dtype: str = ""
-    allow_lora: bool = False
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "ref", _clean(self.ref))
-        object.__setattr__(self, "tag", _clean(self.tag) or "latest")
-        object.__setattr__(self, "flavor", _clean(self.flavor))
-        object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
-        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
-        if not self.ref:
-            raise ValueError(f"{type(self).__name__} requires a non-empty ref")
-
-    @property
-    def provider(self) -> str:
-        return type(self).PROVIDER
+    return ModelRef(
+        source="tensorhub", path=ref, tag=tag, flavor=flavor,
+        storage_dtype=storage_dtype, allow_lora=allow_lora,
+    )
 
 
-@dataclass(frozen=True)
-class HF:
+def HF(
+    ref: str,
+    *,
+    revision: str = "",
+    dtype: str = "",
+    subfolder: str = "",
+    files: tuple[str, ...] = (),
+    storage_dtype: str = "",
+    allow_lora: bool = False,
+) -> ModelRef:
     """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=, storage_dtype=)``.
 
     ``files`` are ``snapshot_download`` ``allow_patterns`` globs — set them to
@@ -83,89 +169,35 @@ class HF:
     keeps denoiser weights in fp8-E4M3 storage with per-layer upcast to the
     compute dtype (VRAM fit on any card; see ``STORAGE_DTYPES``).
     """
-
-    PROVIDER: ClassVar[str] = "hf"
-
-    ref: str
-    revision: str = ""
-    dtype: str = ""
-    subfolder: str = ""
-    files: tuple[str, ...] = ()
-    storage_dtype: str = ""
-    allow_lora: bool = False
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "ref", _clean(self.ref))
-        object.__setattr__(self, "revision", _clean(self.revision))
-        object.__setattr__(self, "dtype", _clean(self.dtype))
-        object.__setattr__(self, "subfolder", _clean(self.subfolder))
-        object.__setattr__(
-            self, "files", tuple(_clean(p) for p in self.files if _clean(p))
-        )
-        object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
-        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
-        if "/" not in self.ref:
-            raise ValueError(f"HF(id=) must be 'owner/repo', got {self.ref!r}")
-
-    @property
-    def provider(self) -> str:
-        return type(self).PROVIDER
+    return ModelRef(
+        source="huggingface", path=ref, revision=revision, dtype=dtype,
+        subfolder=subfolder, files=files, storage_dtype=storage_dtype,
+        allow_lora=allow_lora,
+    )
 
 
-@dataclass(frozen=True)
-class Civitai:
+def Civitai(ref: str, *, version: str = "") -> ModelRef:
     """Civitai-backed binding: ``Civitai(model_id, version=)``.
 
     ``ref`` is the Civitai MODEL id; pin a specific model-version with
     ``version=``.
     """
-
-    PROVIDER: ClassVar[str] = "civitai"
-
-    ref: str
-    version: str = ""
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "ref", _clean(self.ref))
-        object.__setattr__(self, "version", _clean(self.version))
-        if not self.ref:
-            raise ValueError("Civitai requires a non-empty model id")
-
-    @property
-    def provider(self) -> str:
-        return type(self).PROVIDER
+    return ModelRef(source="civitai", path=ref, version=version)
 
 
-@dataclass(frozen=True)
-class ModelScope:
+def ModelScope(
+    ref: str, *, revision: str = "", files: tuple[str, ...] = (),
+) -> ModelRef:
     """ModelScope-backed binding: ``ModelScope(id, revision=, files=)``.
 
     File-oriented (no diffusers-layout requirement) — the clean source for
     ComfyUI / DiffSynth split checkpoints.
     """
-
-    PROVIDER: ClassVar[str] = "modelscope"
-
-    ref: str
-    revision: str = ""
-    files: tuple[str, ...] = ()
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "ref", _clean(self.ref))
-        object.__setattr__(self, "revision", _clean(self.revision))
-        object.__setattr__(
-            self, "files", tuple(_clean(p) for p in self.files if _clean(p))
-        )
-        if "/" not in self.ref:
-            raise ValueError(f"ModelScope(id=) must be 'owner/repo', got {self.ref!r}")
-
-    @property
-    def provider(self) -> str:
-        return type(self).PROVIDER
+    return ModelRef(source="modelscope", path=ref, revision=revision, files=files)
 
 
-Binding = Union[Hub, HF, Civitai, ModelScope]
-BINDING_TYPES: tuple[type, ...] = (Hub, HF, Civitai, ModelScope)
+Binding = ModelRef
+BINDING_TYPES: tuple[type, ...] = (ModelRef,)
 
 
 def wire_ref(binding: Binding) -> str:
@@ -178,13 +210,13 @@ def wire_ref(binding: Binding) -> str:
     """
     from ..models.refs import HuggingFaceRef, fold_ref
 
-    if isinstance(binding, Hub):
+    if binding.source == "tensorhub":
         # The default tag never overrides one embedded in ``ref``.
         tag = binding.tag if binding.tag != "latest" else ""
-        return fold_ref(binding.ref, tag=tag, flavor=binding.flavor)
-    if isinstance(binding, HF):
-        return HuggingFaceRef(binding.ref, binding.revision or None).canonical()
-    return binding.ref
+        return fold_ref(binding.path, tag=tag, flavor=binding.flavor)
+    if binding.source == "huggingface":
+        return HuggingFaceRef(binding.path, binding.revision or None).canonical()
+    return binding.path
 
 
 def rebind_pick(
@@ -202,9 +234,13 @@ def rebind_pick(
     replaces the binding's. ``flavor=None`` leaves the binding's flavor
     untouched. Raises ``ValueError`` when the pick cannot round-trip through
     ``wire_ref`` — a pick the rebound binding cannot re-mint would split the
-    slot into two residency identities (the th#736 mechanic).
+    slot into two residency identities (the th#736 mechanic). This is also
+    how a flavor/cast fold onto a source without that axis (e.g. an HF ref's
+    flavor, which never enters its wire_ref) gets rejected — the rebound
+    struct always accepts the field (msgspec has no per-source shape), so the
+    round-trip mismatch is the enforcement point.
     """
-    import dataclasses
+    from msgspec import structs
 
     from ..models.refs import fold_ref, normalize_model_ref, parse_model_ref
 
@@ -215,13 +251,11 @@ def rebind_pick(
         flavor = parsed.tensorhub.flavor or ""
     rebound: Any = binding
     try:
-        if flavor is not None and flavor != getattr(binding, "flavor", ""):
-            rebound = dataclasses.replace(rebound, flavor=flavor)
+        if flavor is not None and flavor != binding.flavor:
+            rebound = structs.replace(rebound, flavor=flavor)
         if cast:
-            rebound = dataclasses.replace(rebound, storage_dtype=cast)
+            rebound = structs.replace(rebound, storage_dtype=cast)
     except TypeError as exc:
-        # e.g. folding a flavor into an HF/Civitai binding that has no
-        # flavor axis — same rejection channel as a round-trip failure.
         raise ValueError(f"pick does not fit binding {binding!r}: {exc}") from exc
     if resolved_ref:
         expected = normalize_model_ref(resolved_ref)
@@ -238,6 +272,6 @@ def rebind_pick(
 
 
 __all__ = [
-    "Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelScope",
-    "STORAGE_DTYPES", "rebind_pick", "wire_ref",
+    "Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelRef",
+    "ModelScope", "STORAGE_DTYPES", "rebind_pick", "wire_ref",
 ]

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -21,11 +21,11 @@ if TYPE_CHECKING:
 
 def describe_binding(binding: Any) -> Dict[str, Any]:
     """Introspect one model binding into a JSON-able dict (no model load)."""
-    from ..api.binding import Civitai, HF, Hub, ModelScope
+    from ..api.binding import ModelRef
 
-    if isinstance(binding, (Hub, HF, Civitai, ModelScope)):
+    if isinstance(binding, ModelRef):
         out: Dict[str, Any] = {
-            "type": type(binding).__name__,
+            "type": binding.source,
             "provider": binding.provider,
             "ref": binding.ref,
         }

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -26,7 +26,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import msgspec
 
-from ..api.binding import Civitai, HF, Hub, ModelScope, wire_ref
+from ..api.binding import ModelRef, wire_ref
 from ..api.errors import CanceledError
 from ..config import get_settings
 from .local_context import build_local_context
@@ -597,7 +597,7 @@ def _fetch_tensorhub_snapshot(
 
 def _resolve_binding_to_ref(*, param_name: str, binding: Any) -> Tuple[str, str]:
     """Return ``(model_ref, provider)`` for one binding."""
-    if isinstance(binding, (Hub, HF, Civitai, ModelScope)):
+    if isinstance(binding, ModelRef):
         return wire_ref(binding), binding.provider
     raise _UsageError(
         f"unknown binding type for param {param_name!r}: {type(binding).__name__}"

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import msgspec
 
-from gen_worker.api.binding import HF, Binding, Civitai, Hub, ModelScope
+from gen_worker.api.binding import Binding
 from gen_worker.api.types import (
     Asset,
     AudioAsset,
@@ -279,7 +279,7 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
         "slot_name": param_name,
         "ref": binding.ref,
     }
-    if isinstance(binding, Hub):
+    if binding.source == "tensorhub":
         # Normal form (gw#492): the default tag ('latest') is elided at the
         # manifest boundary so hub-minted keep/routing refs stay byte-equal
         # to worker-minted wire refs (Go folds a non-empty tag verbatim).
@@ -289,7 +289,7 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
             out["flavor"] = binding.flavor
         if binding.allow_lora:
             out["allow_lora"] = True
-    elif isinstance(binding, HF):
+    elif binding.source == "huggingface":
         for k in ("revision", "dtype", "subfolder"):
             v = getattr(binding, k)
             if v:
@@ -298,10 +298,10 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
             out["files"] = list(binding.files)
         if binding.allow_lora:
             out["allow_lora"] = True
-    elif isinstance(binding, Civitai):
+    elif binding.source == "civitai":
         if binding.version:
             out["version"] = binding.version
-    elif isinstance(binding, ModelScope):
+    elif binding.source == "modelscope":
         if binding.revision:
             out["revision"] = binding.revision
         if binding.files:

--- a/tests/test_model_op_prefetch_no_cascade.py
+++ b/tests/test_model_op_prefetch_no_cascade.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 import msgspec
 import pytest
 
-from gen_worker.api.binding import Hub
+from gen_worker.api.binding import Hub, ModelRef
 from gen_worker.executor import Executor
 from gen_worker.models.errors import MissingSnapshotError
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -39,7 +39,7 @@ VARIANT_A = Hub("acme/variant-a")
 VARIANT_B = Hub("acme/variant-b")
 
 
-def _spec(name: str, checkpoint: Hub, calls: List[str]) -> EndpointSpec:
+def _spec(name: str, checkpoint: ModelRef, calls: List[str]) -> EndpointSpec:
     class Endpoint:
         def setup(self, model: str, vae: str) -> None:
             calls.append(name)


### PR DESCRIPTION
## Summary
- Replace the four separate `Hub`/`HF`/`Civitai`/`ModelScope` frozen dataclasses (source inferred from which class you used) with ONE `ModelRef` msgspec.Struct carrying an explicit `source: Literal["tensorhub","huggingface","civitai","modelscope"]` field plus `path`/`tag`/`flavor`/`revision`/`subfolder`/`dtype`/`storage_dtype`/`version`/`files`/`allow_lora`.
- `Hub`/`HF`/`Civitai`/`ModelScope` become plain factory functions that build a source-pinned `ModelRef`, preserving their exact call signatures and each dataclass's original `__post_init__` validation (HF requires `"/"` in path, Hub defaults empty tag to `"latest"`, etc.) — now living in `ModelRef.__post_init__`, branched on `source`.
- `rebind_pick`/`wire_ref` in `binding.py` switch from `isinstance(binding, Hub)` dispatch + `dataclasses.replace` to `binding.source` branching + `msgspec.structs.replace` (msgspec.Struct isn't a dataclass).
- `.provider` stays the OLD narrower vocabulary (`"hf"` not `"huggingface"`, no `"modelscope"` case) that tensorhub's `internal/builder/manifest_contract.go::normalizeProvider` DB-CHECK constraint expects. `.ref` aliases `.path`. Both keep every generic attribute-access call site (`lifecycle.py`, `models/download.py`, `cli/prefetch.py`, `cli/serve.py`, etc.) working with zero changes.
- Fixed the remaining `isinstance(binding, Hub)`/`isinstance(binding, (Hub, HF, Civitai, ModelScope))` dispatch sites to branch on `binding.source` (manifest serializer `discovery/discover.py::_binding_to_manifest`) or `isinstance(binding, ModelRef)` (`cli/run.py::_resolve_binding_to_ref`, `cli/listing.py::describe_binding`).
- `Binding = ModelRef`, `BINDING_TYPES = (ModelRef,)` — every existing `isinstance(x, BINDING_TYPES)` call site (decorators.py, cli/prefetch.py, cli/serve.py) keeps working unmodified.
- `ModelRef` exported from `gen_worker.api` and `gen_worker` top-level `__all__`.
- `wire_ref`/cache-key string output is byte-identical to before (verified by `tests/test_ref_normal_form.py`'s grep-guard and `tests/test_binding.py`'s wire-ref encoding tests).

Hard cut — pre-launch, no back-compat string format kept.

## Test plan
- [x] `mypy src/gen_worker` — 0 errors (100 source files)
- [x] `pytest -m "not integration"` — 890 passed, 11 skipped, 14 deselected, 5 failed (all 5 failures are pre-existing/environment-only: this dev box sets `GEN_WORKER_FORBID_CPU_OFFLOAD=1`, which makes any CPU-placement test raise; verified identical failures on unmodified `master` via `git stash`)
- [x] `tests/test_ref_normal_form.py` grep-guard passes (no new ad-hoc ref-grammar sites introduced)
- [x] `tests/test_binding.py`, `tests/test_resolution_rekey_gw494.py`, `tests/test_discovery_and_decorators.py` pass in full

🤖 Generated with [Claude Code](https://claude.com/claude-code)