### PR TITLE
gw#476: fast video encode path — NVENC-when-available, streaming encode, fast presets (+ gw#516 core: terminal GPU-slot release at decode->finalize handoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.14.11 (2026-07-12)
+
+- **gw#476: fast video encode path — NVENC when the silicon has it, streaming
+  encode, fast presets.** New `gen_worker.video_encode`: the mp4 backend is
+  probed ONCE per process (one tiny real encode — codec presence in the PyAV
+  wheel is not enough; H100/A100/B200 ship without the NVENC block) and
+  `h264_nvenc` (p4/vbr/cq19) is used when present, else libx264 at
+  `veryfast`/CRF 18 instead of the archival default (medium/CRF 23, 5-10x the
+  encode CPU for invisible gains on short generated clips). Override with
+  `GEN_WORKER_VIDEO_ENCODER=auto|nvenc|x264`. `StreamingVideoEncoder` feeds
+  frames to the encoder in chunks as they are produced, and
+  `gen_worker.io.write_video` now accepts an iterator/generator of frame
+  chunks (VAE framewise-decode seam) so long/4K clips never rebuffer a second
+  raw array. Motivation: B200 gauntlet measured one 10s@1080p clip at 179.6s
+  x264 encode vs 118s GPU compute; a 5s@4K probe spent ~25min encoding while
+  the GPU idle-billed.
+- **gw#516 (core): terminal GPU-slot release at the decode->finalize
+  handoff.** `write_video` releases the request's GPU slot as soon as frames
+  are on the host — the CPU encode + upload tail overlaps the NEXT request's
+  denoise instead of idling the GPU. Unlike the gw#382 yield window there is
+  no reacquire, so a finishing request never blocks behind its successor's
+  denoise just to return; the executor's post-handler release no-ops (lease
+  transitions are once-only) and drain/cancel/failure attribution are
+  unchanged because the job stays in the handler until finalize completes.
+  Buffered encodes take a bounded finalize permit BEFORE the release
+  (`GEN_WORKER_VIDEO_ENCODE_CONCURRENCY`, default 2) so back-pressure holds
+  the slot rather than stacking raw-frame buffers in host RAM. The executor
+  logs `FINALIZE_OVERLAP` with slot-held vs handler-wall ms (overlap evidence
+  until JobMetrics grows a slot-held field).
+
 ## 0.14.10 (2026-07-12)
 
 - **pgw#511 hotfix: ModelRef.__post_init__ uses force_setattr.**
@@ -9,7 +39,6 @@
   discovery advertised NOTHING (J24M run16 image build gate caught it).
   `msgspec.structs.force_setattr` is the repo convention (Resources,
   Compile) and works on both.
-
 
 ## 0.14.9 (2026-07-12)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.10"
+version = "0.14.11"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -855,13 +855,17 @@ class _GpuSlotLease:
     hold is released at most once.
     """
 
-    __slots__ = ("_sem", "_loop", "_lock", "_held")
+    __slots__ = ("_sem", "_loop", "_lock", "_held", "released_at")
 
     def __init__(self, sem: asyncio.Semaphore, loop: asyncio.AbstractEventLoop) -> None:
         self._sem = sem
         self._loop = loop
         self._lock = threading.Lock()
         self._held = True
+        # Monotonic time of the FIRST release — the terminal finalize handoff
+        # (gw#476/gw#516) or the executor's post-handler release, whichever
+        # came first. Reads out the finalize-overlap window.
+        self.released_at: Optional[float] = None
 
     def yield_slot(self) -> bool:
         """Release the slot if held (any thread). True iff this call released."""
@@ -869,6 +873,7 @@ class _GpuSlotLease:
             if not self._held:
                 return False
             self._held = False
+            self.released_at = time.monotonic()
         try:
             on_loop = asyncio.get_running_loop() is self._loop
         except RuntimeError:
@@ -2595,7 +2600,18 @@ class Executor:
             # Handler GPU work is done — free the slot before result-blob
             # upload and result send so the next job's compute starts now.
             if lease is not None:
-                lease.yield_slot()
+                if not lease.yield_slot() and lease.released_at is not None:
+                    # The handler released terminally at the decode->finalize
+                    # handoff (gw#476/gw#516): the whole encode/upload tail
+                    # overlapped the next request. Until JobMetrics grows a
+                    # slot-held field this line IS the overlap evidence.
+                    logger.info(
+                        "FINALIZE_OVERLAP fn=%s request=%s slot_held_ms=%d "
+                        "handler_wall_ms=%d overlap_ms=%d",
+                        spec.name, run.request_id,
+                        int((lease.released_at - started) * 1000),
+                        int((time.monotonic() - started) * 1000),
+                        int((time.monotonic() - lease.released_at) * 1000))
             if spec.output_mode == "stream":
                 # gw#475: live deltas are droppable by contract (in-memory
                 # ProgressHub only) — the terminal JobResult carries the

--- a/src/gen_worker/io.py
+++ b/src/gen_worker/io.py
@@ -213,14 +213,27 @@ def write_video(
     hand-rolling tempfile + ``export_to_video`` and audio survives the mux.
 
     - ``frames``: list of PIL images, a numpy array ``[F, H, W, C]`` (float in
-      [0, 1] or uint8), or a torch tensor of the same shape.
+      [0, 1] or uint8), a torch tensor of the same shape, OR an iterator/
+      generator of such chunks — chunks are encoded as they are produced
+      (VAE framewise decode seam) and the full clip is never rebuffered.
     - ``audio``: waveform ``[channels, samples]`` (numpy or torch, float in
       [-1, 1]); mono is duplicated to stereo. ``audio_sample_rate`` is
       required when audio is given.
+
+    Encoder selection + GPU-slot handoff (gw#476 / gw#516): the backend is
+    NVENC when the card has the encoder block (probed once per process),
+    else libx264 at a fast preset. For array input the request's GPU slot is
+    terminally released once the frames are on the host — the CPU encode and
+    the upload overlap the next request's denoise instead of idling the GPU
+    (measured up to 179s of idle on a CPU-contended host). Do not run more
+    GPU work on ``ctx`` after this call. For iterator input the release
+    happens when the iterator is exhausted (the producer is still decoding
+    on the GPU while chunks stream into the encoder).
     """
     try:
-        import av
-        import numpy as np
+        import numpy as np  # noqa: F401  (hard dep of the encode path)
+
+        from .video_encode import StreamingVideoEncoder, finalize_permit, frames_to_uint8
     except ImportError as e:
         raise ImportError(
             "gen_worker.io.write_video requires PyAV + numpy. "
@@ -232,116 +245,57 @@ def write_video(
             raise ValidationError("write_video: audio_sample_rate is required with audio")
         sample_rate = int(audio_sample_rate)
 
-    arr = _frames_to_uint8(frames, np)
-    height, width = int(arr.shape[1]), int(arr.shape[2])
-    # libx264/yuv420p needs even dimensions; crop a stray row/column.
-    height -= height % 2
-    width -= width % 2
-    arr = arr[:, :height, :width]
-
+    import os
     import tempfile
+
+    streaming = _is_chunk_iterator(frames)
 
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as handle:
         tmp_path = handle.name
     try:
-        container = av.open(tmp_path, mode="w")
-        try:
-            stream = container.add_stream("libx264", rate=round(fps))
-            stream.width = width
-            stream.height = height
-            stream.pix_fmt = "yuv420p"
-            # Both streams must exist before the first mux writes the header.
-            audio_stream = (
-                _prepare_audio_stream(container, sample_rate, av)
-                if audio is not None
-                else None
-            )
-            for frame_array in arr:
-                frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
-                for packet in stream.encode(frame):
-                    container.mux(packet)
-            for packet in stream.encode():
-                container.mux(packet)
-            if audio_stream is not None:
-                _mux_audio(container, audio_stream, audio, sample_rate, av, np)
-        finally:
-            container.close()
+        with StreamingVideoEncoder(
+            tmp_path, fps=fps, audio_sample_rate=sample_rate or None
+        ) as encoder:
+            if streaming:
+                # Chunks arrive while the producer still owns the GPU; the
+                # encode interleaves (NVENC costs zero SMs). Release the slot
+                # only once decode is done, before the flush + upload tail.
+                for chunk in frames:
+                    encoder.add(chunk)
+                _release_gpu_slot_for_finalize(ctx)
+                encoder.finish(audio)
+            else:
+                arr = frames_to_uint8(frames)
+                # Bounded CPU-finalize admission BEFORE the slot release:
+                # back-pressure holds the GPU slot rather than stacking raw
+                # frame buffers in host RAM (gw#516).
+                with finalize_permit():
+                    _release_gpu_slot_for_finalize(ctx)
+                    encoder.add(arr)
+                    del arr
+                    encoder.finish(audio)
         return ctx.save_video(tmp_path, ref, format="mp4")
     finally:
-        import os
-
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
 
 
-def _frames_to_uint8(frames: Any, np: Any) -> Any:
-    """Coerce PIL list / float array / torch tensor to uint8 [F, H, W, C]."""
-    if isinstance(frames, (list, tuple)):
-        if not frames:
-            raise ValidationError("write_video: frames is empty")
-        frames = np.stack([np.asarray(f.convert("RGB") if hasattr(f, "convert") else f) for f in frames])
-    if hasattr(frames, "detach"):  # torch tensor
-        frames = frames.detach().to("cpu").float().numpy()
-    arr = np.asarray(frames)
-    if arr.ndim != 4 or arr.shape[-1] != 3:
-        raise ValidationError(
-            f"write_video: frames must be [F, H, W, 3], got shape {arr.shape}"
-        )
-    if arr.dtype != np.uint8:
-        arr = arr.astype("float32")
-        if float(arr.max(initial=0.0)) <= 1.0:
-            arr = arr * 255.0
-        arr = np.clip(arr.round(), 0, 255).astype("uint8")
-    return arr
+def _is_chunk_iterator(frames: Any) -> bool:
+    """True for generators/iterators of frame chunks (streaming input).
+
+    Lists/tuples (PIL frames), numpy arrays, and torch tensors are buffered
+    input; everything else with ``__next__`` streams.
+    """
+    if isinstance(frames, (list, tuple)) or hasattr(frames, "__array__") or hasattr(frames, "detach"):
+        return False
+    return hasattr(frames, "__next__") or hasattr(frames, "__iter__")
 
 
-def _prepare_audio_stream(container: Any, sample_rate: int, av: Any) -> Any:
-    from fractions import Fraction
-
-    stream = container.add_stream("aac", rate=sample_rate)
-    cc = stream.codec_context
-    cc.sample_rate = sample_rate
-    cc.layout = "stereo"
-    cc.time_base = Fraction(1, sample_rate)
-    return stream
-
-
-def _mux_audio(container: Any, stream: Any, audio: Any, sample_rate: int, av: Any, np: Any) -> None:
-    """Append an AAC stereo track (mirrors diffusers ltx2 export_utils)."""
-    if hasattr(audio, "detach"):
-        audio = audio.detach().to("cpu").float().numpy()
-    wave = np.asarray(audio, dtype="float32")
-    if wave.ndim == 1:
-        wave = wave[None, :]
-    if wave.ndim != 2:
-        raise ValidationError(f"write_video: audio must be [channels, samples], got shape {wave.shape}")
-    if wave.shape[0] == 1:
-        wave = np.repeat(wave, 2, axis=0)
-    elif wave.shape[0] > 2:
-        wave = wave[:2]
-    wave = np.ascontiguousarray(np.clip(wave, -1.0, 1.0))
-
-    cc = stream.codec_context
-    # One packed-s16 input frame; the resampler converts to the encoder's
-    # format and assigns pts (mirrors diffusers ltx2 export_utils._write_audio).
-    pcm = (wave.T * 32767.0).astype("int16")  # [samples, 2] interleaved
-    frame_in = av.AudioFrame.from_ndarray(
-        np.ascontiguousarray(pcm.reshape(1, -1)), format="s16", layout="stereo"
-    )
-    frame_in.sample_rate = sample_rate
-
-    resampler = av.audio.resampler.AudioResampler(
-        format=cc.format or "fltp", layout=cc.layout or "stereo", rate=cc.sample_rate or sample_rate
-    )
-    next_pts = 0
-    for rframe in resampler.resample(frame_in):
-        if rframe.pts is None:
-            rframe.pts = next_pts
-        next_pts += rframe.samples
-        rframe.sample_rate = sample_rate
-        container.mux(stream.encode(rframe))
-    for packet in stream.encode():
-        container.mux(packet)
+def _release_gpu_slot_for_finalize(ctx: Any) -> None:
+    """Terminal GPU-slot release at the decode->finalize handoff (gw#516)."""
+    release = getattr(ctx, "_release_gpu_slot_for_finalize", None)
+    if callable(release):
+        release()
 
 
 __all__ = [

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -419,6 +419,24 @@ class RequestContext:
             if self._canceled:
                 lease.yield_slot()
 
+    def _release_gpu_slot_for_finalize(self) -> None:
+        """Worker-internal: TERMINAL GPU-slot release at the decode->finalize
+        handoff (gw#476 / gw#516). The handler is done with GPU compute; the
+        encode + upload tail proceeds slotless so the next request's denoise
+        starts now instead of idling the GPU (measured up to 179s on a
+        CPU-contended host). Unlike :meth:`_gpu_slot_yielded` there is no
+        reacquire — a finishing request must never block behind the next
+        request's denoise just to return. The executor's post-handler release
+        no-ops (lease transitions are once-only), so the semaphore balance
+        stays exact. Tenant GPU work after this call runs unscheduled —
+        finalize helpers call it only once frames are on the host. No-op
+        without a lease (CPU jobs, local runs) or when already yielded."""
+        lease = self._gpu_slot_lease
+        if lease is not None and lease.yield_slot():
+            logger.info(
+                "request %s: GPU slot released for finalize; encode/upload "
+                "overlaps the next request's compute", self.request_id)
+
     def _emit_event(self, event_type: str, payload: Optional[Dict[str, Any]] = None) -> None:
         """Worker-internal: emit a progress/event payload (best-effort)."""
         if not self._emitter:

--- a/src/gen_worker/video_encode.py
+++ b/src/gen_worker/video_encode.py
@@ -1,0 +1,388 @@
+"""Video encode backend selection + streaming encoder (gw#476).
+
+Software x264 at the PyAV default (preset medium) can dominate request wall
+time on CPU-weak or contended hosts: the B200 gauntlet measured one 10s@1080p
+clip spending 179.6s in mp4 encode against 118s of GPU compute, and a 5s@4K
+probe spent ~25 minutes encoding while the GPU idle-billed. Two fixes live
+here:
+
+- **NVENC when the silicon has it**: consumer RTX (4090/5090) and L40S-class
+  cards carry the dedicated encoder ASIC — encode costs zero SMs and runs at
+  hardware speed. H100/A100/B200 datacenter parts ship WITHOUT NVENC (decode
+  only), so the probe is empirical: one tiny real encode at import of the
+  first video, never per-request. Falls back to libx264.
+- **Fast software preset**: x264 ``veryfast`` + CRF 18 for generated content.
+  The default (medium, CRF 23) is archival tuning — 5-10x the encode CPU for
+  gains invisible on short synthetic clips with high bitrate tolerance.
+
+:class:`StreamingVideoEncoder` feeds frames to the encoder in chunks as they
+are produced (e.g. VAE framewise decode), so long/4K clips never materialize
+a second full raw array inside the encode path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, Optional
+
+from .api.errors import ValidationError
+
+logger = logging.getLogger(__name__)
+
+#: ``auto`` (default) probes NVENC and falls back to x264; ``x264`` skips the
+#: probe; ``nvenc`` insists (still falls back with a loud warning rather than
+#: refusing to serve).
+ENCODER_ENV = "GEN_WORKER_VIDEO_ENCODER"
+#: Max concurrent buffered CPU finalize encodes (gw#516 host-RAM bound).
+ENCODE_CONCURRENCY_ENV = "GEN_WORKER_VIDEO_ENCODE_CONCURRENCY"
+DEFAULT_ENCODE_CONCURRENCY = 2
+
+# Fast presets tuned for short, high-bitrate-tolerant generated clips.
+X264_OPTIONS: Dict[str, str] = {"preset": "veryfast", "crf": "18"}
+# NVENC runs on the dedicated ASIC (zero SMs). p4 + capped-quality VBR
+# mirrors the x264 rung's visual quality at hardware speed.
+NVENC_OPTIONS: Dict[str, str] = {"preset": "p4", "tune": "hq", "rc": "vbr", "cq": "19"}
+
+
+@dataclass(frozen=True)
+class EncoderChoice:
+    codec: str
+    options: Dict[str, str] = field(default_factory=dict)
+    hardware: bool = False
+
+
+_detect_lock = threading.Lock()
+_detected: Optional[EncoderChoice] = None
+
+
+def _x264() -> EncoderChoice:
+    return EncoderChoice("libx264", dict(X264_OPTIONS), hardware=False)
+
+
+def _probe_nvenc() -> bool:
+    """One tiny real encode. Codec presence in the PyAV build is not enough:
+    opening h264_nvenc needs the driver's libnvidia-encode AND a card whose
+    silicon has the encoder block (absent on H100/A100/B200)."""
+    import io as _io
+
+    try:
+        import av
+        import numpy as np
+    except ImportError:
+        return False
+    buf = _io.BytesIO()
+    try:
+        packets = 0
+        with av.open(buf, mode="w", format="mp4") as container:
+            stream: Any = container.add_stream("h264_nvenc", rate=8, options=dict(NVENC_OPTIONS))
+            stream.width = 64
+            stream.height = 64
+            stream.pix_fmt = "yuv420p"
+            frame = av.VideoFrame.from_ndarray(
+                np.zeros((64, 64, 3), dtype=np.uint8), format="rgb24"
+            )
+            for packet in stream.encode(frame):
+                container.mux(packet)
+                packets += 1
+            for packet in stream.encode():
+                container.mux(packet)
+                packets += 1
+        return packets > 0
+    except Exception as exc:
+        logger.info("NVENC probe negative (%s: %s)", type(exc).__name__, exc)
+        return False
+
+
+def detect_encoder(*, refresh: bool = False) -> EncoderChoice:
+    """Pick the video encoder for this process. Probed ONCE, then cached."""
+    global _detected
+    with _detect_lock:
+        if _detected is not None and not refresh:
+            return _detected
+        mode = (os.environ.get(ENCODER_ENV) or "auto").strip().lower()
+        if mode not in ("auto", "nvenc", "x264"):
+            logger.warning("%s=%r not recognized; using auto", ENCODER_ENV, mode)
+            mode = "auto"
+        if mode == "x264":
+            _detected = _x264()
+        elif _probe_nvenc():
+            _detected = EncoderChoice("h264_nvenc", dict(NVENC_OPTIONS), hardware=True)
+        else:
+            if mode == "nvenc":
+                logger.warning(
+                    "%s=nvenc but the NVENC probe failed (datacenter GPU or no "
+                    "driver encoder lib); serving with libx264", ENCODER_ENV)
+            _detected = _x264()
+        logger.info(
+            "video encoder selected: %s %s", _detected.codec, _detected.options)
+        return _detected
+
+
+# ---- bounded finalize concurrency (gw#516) ---------------------------------
+
+_finalize_sem: Optional[threading.BoundedSemaphore] = None
+_finalize_sem_lock = threading.Lock()
+
+
+def _finalize_semaphore() -> threading.BoundedSemaphore:
+    global _finalize_sem
+    with _finalize_sem_lock:
+        if _finalize_sem is None:
+            raw = os.environ.get(ENCODE_CONCURRENCY_ENV, "").strip()
+            try:
+                n = max(1, int(raw)) if raw else DEFAULT_ENCODE_CONCURRENCY
+            except ValueError:
+                n = DEFAULT_ENCODE_CONCURRENCY
+            _finalize_sem = threading.BoundedSemaphore(n)
+        return _finalize_sem
+
+
+@contextmanager
+def finalize_permit() -> Iterator[None]:
+    """Bound concurrent buffered CPU encodes. Acquired BEFORE the GPU slot is
+    released so back-pressure holds the slot (pausing new decodes) instead of
+    letting raw-frame buffers pile up in host RAM (gw#516)."""
+    sem = _finalize_semaphore()
+    sem.acquire()
+    try:
+        yield
+    finally:
+        sem.release()
+
+
+# ---- frame coercion ---------------------------------------------------------
+
+def frames_to_uint8(frames: Any) -> Any:
+    """Coerce PIL list / float array / torch tensor to uint8 ``[F, H, W, 3]``.
+
+    Accepts a single ``[H, W, 3]`` frame too (expanded to ``F=1``). Floats in
+    [0, 1] are scaled; anything else is clipped to [0, 255].
+    """
+    import numpy as np
+
+    if isinstance(frames, (list, tuple)):
+        if not frames:
+            raise ValidationError("write_video: frames is empty")
+        frames = np.stack(
+            [np.asarray(f.convert("RGB") if hasattr(f, "convert") else f) for f in frames]
+        )
+    if hasattr(frames, "detach"):  # torch tensor
+        frames = frames.detach().to("cpu").float().numpy()
+    arr = np.asarray(frames)
+    if arr.ndim == 3 and arr.shape[-1] == 3:
+        arr = arr[None]
+    if arr.ndim != 4 or arr.shape[-1] != 3:
+        raise ValidationError(
+            f"write_video: frames must be [F, H, W, 3], got shape {arr.shape}"
+        )
+    if arr.dtype != np.uint8:
+        arr = arr.astype("float32")
+        if float(arr.max(initial=0.0)) <= 1.0:
+            arr = arr * 255.0
+        arr = np.clip(arr.round(), 0, 255).astype("uint8")
+    return arr
+
+
+# ---- streaming encoder ------------------------------------------------------
+
+class StreamingVideoEncoder:
+    """Incremental H.264/AAC mp4 encoder — feed frame chunks as they exist.
+
+    Built for the VAE-framewise-decode seam (gw#476): call :meth:`add` with
+    each decoded chunk instead of buffering the whole clip, then
+    :meth:`finish` (optionally with the audio waveform). Dimensions latch
+    from the first chunk; odd rows/columns are cropped (yuv420p needs even
+    dims). ``audio_sample_rate`` must be declared up front when audio will be
+    muxed — both streams must exist before the first packet writes the mp4
+    header.
+
+    If the selected hardware encoder fails to OPEN (driver contention,
+    session limits), the encode falls back to libx264 once — before any
+    packet is written. Mid-stream failures propagate: they fail exactly the
+    request that owns this encode.
+    """
+
+    def __init__(
+        self,
+        path: "str | os.PathLike[str]",
+        *,
+        fps: float,
+        audio_sample_rate: Optional[int] = None,
+        encoder: Optional[EncoderChoice] = None,
+    ) -> None:
+        import av  # hard dep for this class; callers gate on the video extra
+
+        self._av = av
+        self._path = str(path)
+        self._fps = float(fps)
+        self._sample_rate = int(audio_sample_rate) if audio_sample_rate else 0
+        self._encoder = encoder or detect_encoder()
+        self._container: Any = None
+        self._stream: Any = None
+        self._audio_stream: Any = None
+        self._frames = 0
+        self._closed = False
+
+    @property
+    def encoder(self) -> EncoderChoice:
+        return self._encoder
+
+    @property
+    def frames_encoded(self) -> int:
+        return self._frames
+
+    def _open(self, height: int, width: int) -> None:
+        av = self._av
+        self._container = av.open(self._path, mode="w")
+        try:
+            self._stream = self._add_video_stream(self._encoder, width, height)
+        except Exception as exc:
+            if not self._encoder.hardware:
+                raise
+            # Opening the hardware encoder can fail even after a positive
+            # boot probe (NVENC session limits under concurrency). Nothing
+            # is muxed yet, so fall back to software for THIS encode only.
+            logger.warning(
+                "hardware encoder %s failed to open (%s: %s); "
+                "falling back to libx264 for this encode",
+                self._encoder.codec, type(exc).__name__, exc)
+            self._encoder = _x264()
+            self._stream = self._add_video_stream(self._encoder, width, height)
+        if self._sample_rate:
+            self._audio_stream = _prepare_audio_stream(
+                self._container, self._sample_rate, av)
+
+    def _add_video_stream(self, enc: EncoderChoice, width: int, height: int) -> Any:
+        stream = self._container.add_stream(
+            enc.codec, rate=round(self._fps), options=dict(enc.options))
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        return stream
+
+    def add(self, frames: Any) -> int:
+        """Encode one chunk (``[F, H, W, 3]`` array / torch tensor / PIL list
+        / single frame). Returns frames encoded so far."""
+        if self._closed:
+            raise RuntimeError("StreamingVideoEncoder is finished")
+        arr = frames_to_uint8(frames)
+        if self._container is None:
+            height = int(arr.shape[1]) - int(arr.shape[1]) % 2
+            width = int(arr.shape[2]) - int(arr.shape[2]) % 2
+            if height <= 0 or width <= 0:
+                raise ValidationError(
+                    f"write_video: frames too small to encode ({arr.shape})")
+            self._open(height, width)
+        arr = arr[:, : self._stream.height, : self._stream.width]
+        for frame_array in arr:
+            frame = self._av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            for packet in self._stream.encode(frame):
+                self._container.mux(packet)
+            self._frames += 1
+        return self._frames
+
+    def finish(self, audio: Any = None) -> str:
+        """Flush the video stream, mux ``audio`` (waveform ``[C, samples]``)
+        when given, close the container. Returns the output path."""
+        if self._closed:
+            return self._path
+        if self._container is None:
+            raise ValidationError("write_video: no frames were encoded")
+        if audio is not None and self._audio_stream is None:
+            raise ValidationError(
+                "write_video: audio given but audio_sample_rate was not "
+                "declared at encoder construction")
+        self._closed = True
+        try:
+            for packet in self._stream.encode():
+                self._container.mux(packet)
+            if audio is not None:
+                import numpy as np
+
+                _mux_audio(self._container, self._audio_stream, audio,
+                           self._sample_rate, self._av, np)
+        finally:
+            self._container.close()
+        return self._path
+
+    def abort(self) -> None:
+        """Close without flushing (error paths); output file is not usable."""
+        self._closed = True
+        if self._container is not None:
+            try:
+                self._container.close()
+            except Exception:
+                logger.debug("encoder abort close failed", exc_info=True)
+
+    def __enter__(self) -> "StreamingVideoEncoder":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if exc_type is not None:
+            self.abort()
+
+
+# ---- audio mux (moved verbatim from gen_worker.io, gw#387) ------------------
+
+def _prepare_audio_stream(container: Any, sample_rate: int, av: Any) -> Any:
+    from fractions import Fraction
+
+    stream = container.add_stream("aac", rate=sample_rate)
+    cc = stream.codec_context
+    cc.sample_rate = sample_rate
+    cc.layout = "stereo"
+    cc.time_base = Fraction(1, sample_rate)
+    return stream
+
+
+def _mux_audio(container: Any, stream: Any, audio: Any, sample_rate: int, av: Any, np: Any) -> None:
+    """Append an AAC stereo track (mirrors diffusers ltx2 export_utils)."""
+    if hasattr(audio, "detach"):
+        audio = audio.detach().to("cpu").float().numpy()
+    wave = np.asarray(audio, dtype="float32")
+    if wave.ndim == 1:
+        wave = wave[None, :]
+    if wave.ndim != 2:
+        raise ValidationError(f"write_video: audio must be [channels, samples], got shape {wave.shape}")
+    if wave.shape[0] == 1:
+        wave = np.repeat(wave, 2, axis=0)
+    elif wave.shape[0] > 2:
+        wave = wave[:2]
+    wave = np.ascontiguousarray(np.clip(wave, -1.0, 1.0))
+
+    cc = stream.codec_context
+    # One packed-s16 input frame; the resampler converts to the encoder's
+    # format and assigns pts (mirrors diffusers ltx2 export_utils._write_audio).
+    pcm = (wave.T * 32767.0).astype("int16")  # [samples, 2] interleaved
+    frame_in = av.AudioFrame.from_ndarray(
+        np.ascontiguousarray(pcm.reshape(1, -1)), format="s16", layout="stereo"
+    )
+    frame_in.sample_rate = sample_rate
+
+    resampler = av.audio.resampler.AudioResampler(
+        format=cc.format or "fltp", layout=cc.layout or "stereo", rate=cc.sample_rate or sample_rate
+    )
+    next_pts = 0
+    for rframe in resampler.resample(frame_in):
+        if rframe.pts is None:
+            rframe.pts = next_pts
+        next_pts += rframe.samples
+        rframe.sample_rate = sample_rate
+        container.mux(stream.encode(rframe))
+    for packet in stream.encode():
+        container.mux(packet)
+
+
+__all__ = [
+    "ENCODER_ENV",
+    "ENCODE_CONCURRENCY_ENV",
+    "EncoderChoice",
+    "StreamingVideoEncoder",
+    "detect_encoder",
+    "finalize_permit",
+    "frames_to_uint8",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,16 @@ issue #345.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import gen_worker
+
+# Deterministic CPU encode wherever the suite runs (gw#476): never probe or
+# engage NVENC from tests — CI has no GPU, and dev boxes that have one must
+# not do GPU work from the unit suite. Selection tests override + refresh
+# the cache explicitly.
+os.environ.setdefault("GEN_WORKER_VIDEO_ENCODER", "x264")
 
 _REPO_SRC = Path(__file__).resolve().parents[1] / "src"
 _LOCATION = Path(gen_worker.__file__).resolve()

--- a/tests/e2e_endpoints.py
+++ b/tests/e2e_endpoints.py
@@ -16,6 +16,8 @@ from gen_worker import Hub, RequestContext, ValidationError, endpoint
 # suite runs the worker in-process, so tests coordinate through these directly.
 SLOT_PROBE_STARTED = threading.Event()
 SLOT_PEER_RAN = threading.Event()
+FINALIZE_PROBE_STARTED = threading.Event()
+FINALIZE_PEER_RAN = threading.Event()
 
 
 class EchoIn(msgspec.Struct):
@@ -58,6 +60,21 @@ class E2EEndpoint:
 
     def slot_peer(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
         SLOT_PEER_RAN.set()
+        return EchoOut(response="peer-done")
+
+    def finalize_probe(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        """gw#476/gw#516: terminally releases its GPU slot at the decode->
+        finalize handoff, then finishes its "encode" only after the peer's
+        compute ran. Unlike `slot_probe` there is NO reacquire — the request
+        must complete without ever waiting on the slot again. With a held
+        slot the peer can never run and this reports "starved"."""
+        FINALIZE_PROBE_STARTED.set()
+        ctx._release_gpu_slot_for_finalize()
+        ok = FINALIZE_PEER_RAN.wait(timeout=10.0)  # the "encode tail"
+        return EchoOut(response="overlapped" if ok else "starved")
+
+    def finalize_peer(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        FINALIZE_PEER_RAN.set()
         return EchoOut(response="peer-done")
 
 

--- a/tests/test_video_encode.py
+++ b/tests/test_video_encode.py
@@ -1,0 +1,265 @@
+"""gw#476 video encode path — encoder selection, streaming encode, fast
+presets, and the terminal GPU-slot release at the decode->finalize handoff.
+
+Integration-style through the real code path: real PyAV encodes (CPU x264 —
+the CI fallback rung), real container probes, a real RequestContext. NVENC
+itself is proven on GPU pods (evidence run), not here.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from gen_worker import RequestContext, ValidationError, io as gw_io
+from gen_worker import video_encode as ve
+
+av = pytest.importorskip("av")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_encoder_state(monkeypatch):
+    """Each test starts with a cold detection cache + default concurrency."""
+    ve._detected = None
+    ve._finalize_sem = None
+    yield
+    ve._detected = None
+    ve._finalize_sem = None
+
+
+def _frames(count: int = 24, height: int = 64, width: int = 64, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.random((count, height, width, 3), dtype=np.float32)
+
+
+def _decode_frame_count(path: str) -> int:
+    with av.open(path) as container:
+        return sum(1 for _ in container.decode(video=0))
+
+
+# ---- encoder selection -------------------------------------------------------
+
+
+def test_env_x264_skips_probe_and_uses_fast_preset(monkeypatch) -> None:
+    monkeypatch.setenv(ve.ENCODER_ENV, "x264")
+    choice = ve.detect_encoder(refresh=True)
+    assert choice.codec == "libx264"
+    assert choice.hardware is False
+    assert choice.options["preset"] == "veryfast"
+    assert "crf" in choice.options
+
+
+def test_detection_is_cached(monkeypatch) -> None:
+    monkeypatch.setenv(ve.ENCODER_ENV, "x264")
+    first = ve.detect_encoder(refresh=True)
+    calls = []
+    monkeypatch.setattr(ve, "_probe_nvenc", lambda: calls.append(1) or False)
+    assert ve.detect_encoder() is first
+    assert calls == []  # cached — no re-probe
+
+
+def test_forced_nvenc_falls_back_when_probe_fails(monkeypatch) -> None:
+    monkeypatch.setenv(ve.ENCODER_ENV, "nvenc")
+    monkeypatch.setattr(ve, "_probe_nvenc", lambda: False)
+    choice = ve.detect_encoder(refresh=True)
+    assert choice.codec == "libx264"  # never refuse to serve
+
+
+def test_auto_picks_nvenc_when_probe_succeeds(monkeypatch) -> None:
+    monkeypatch.setenv(ve.ENCODER_ENV, "auto")
+    monkeypatch.setattr(ve, "_probe_nvenc", lambda: True)
+    choice = ve.detect_encoder(refresh=True)
+    assert choice.codec == "h264_nvenc"
+    assert choice.hardware is True
+    assert choice.options == ve.NVENC_OPTIONS
+
+
+def test_hardware_open_failure_falls_back_per_encode(tmp_path, monkeypatch) -> None:
+    """A positive boot probe + a failing open at encode time (NVENC session
+    limits) must fall back to x264 for THAT encode, not fail the request."""
+    fake_hw = ve.EncoderChoice("h264_nvenc_bogus_codec", {}, hardware=True)
+    out = tmp_path / "fallback.mp4"
+    enc = ve.StreamingVideoEncoder(out, fps=24, encoder=fake_hw)
+    enc.add(_frames(count=4))
+    enc.finish()
+    assert enc.encoder.codec == "libx264"
+    assert _decode_frame_count(str(out)) == 4
+
+
+# ---- streaming encoder -------------------------------------------------------
+
+
+def test_streaming_chunks_equal_buffered_output(tmp_path) -> None:
+    frames = _frames(count=25)
+    buffered = tmp_path / "buffered.mp4"
+    chunked = tmp_path / "chunked.mp4"
+
+    enc = ve.StreamingVideoEncoder(buffered, fps=24)
+    enc.add(frames)
+    enc.finish()
+
+    enc = ve.StreamingVideoEncoder(chunked, fps=24)
+    for i in range(0, 25, 8):  # uneven tail chunk on purpose
+        enc.add(frames[i : i + 8])
+    assert enc.frames_encoded == 25
+    enc.finish()
+
+    assert _decode_frame_count(str(buffered)) == 25
+    assert _decode_frame_count(str(chunked)) == 25
+    # Same encoder, same input, same chunk-invariant output size ballpark.
+    assert abs(buffered.stat().st_size - chunked.stat().st_size) < max(
+        2048, buffered.stat().st_size // 4
+    )
+
+
+def test_streaming_encoder_accepts_single_frames_and_odd_dims(tmp_path) -> None:
+    out = tmp_path / "odd.mp4"
+    enc = ve.StreamingVideoEncoder(out, fps=12)
+    for i in range(5):
+        enc.add(_frames(count=1, height=33, width=65, seed=i)[0])  # [H, W, 3]
+    enc.finish()
+    with av.open(str(out)) as container:
+        stream = container.streams.video[0]
+        assert (stream.width, stream.height) == (64, 32)
+
+
+def test_finish_without_frames_raises(tmp_path) -> None:
+    enc = ve.StreamingVideoEncoder(tmp_path / "empty.mp4", fps=24)
+    with pytest.raises(ValidationError):
+        enc.finish()
+
+
+def test_audio_requires_declared_sample_rate(tmp_path) -> None:
+    enc = ve.StreamingVideoEncoder(tmp_path / "a.mp4", fps=24)
+    enc.add(_frames(count=2))
+    with pytest.raises(ValidationError):
+        enc.finish(audio=np.zeros((1, 100), dtype=np.float32))
+
+
+# ---- write_video: streaming input + slot handoff -----------------------------
+
+
+class _FakeLease:
+    def __init__(self) -> None:
+        self.releases = 0
+
+    def yield_slot(self) -> bool:
+        self.releases += 1
+        return self.releases == 1  # once-only transition, like _GpuSlotLease
+
+    def reacquire(self) -> None:  # pragma: no cover - must NOT be called
+        raise AssertionError("terminal finalize release must never reacquire")
+
+
+def _ctx_with_lease(tmp_path, request_id: str = "r-enc") -> tuple[RequestContext, _FakeLease]:
+    ctx = RequestContext(request_id=request_id, local_output_dir=str(tmp_path))
+    lease = _FakeLease()
+    ctx._gpu_slot_lease = lease
+    return ctx, lease
+
+
+def test_write_video_releases_slot_before_encode(tmp_path, monkeypatch) -> None:
+    ctx, lease = _ctx_with_lease(tmp_path)
+    released_at_encode: list[int] = []
+
+    real_add = ve.StreamingVideoEncoder.add
+
+    def spying_add(self, frames):
+        released_at_encode.append(lease.releases)
+        return real_add(self, frames)
+
+    monkeypatch.setattr(ve.StreamingVideoEncoder, "add", spying_add)
+    asset = gw_io.write_video(ctx, "outputs/r-enc/v", _frames(count=8), fps=24)
+    assert asset.local_path and asset.local_path.endswith(".mp4")
+    # Slot was terminally released BEFORE the first frame hit the encoder,
+    # exactly once, and never reacquired.
+    assert lease.releases >= 1
+    assert released_at_encode and released_at_encode[0] == 1
+
+
+def test_write_video_iterator_streams_and_releases_after_exhaustion(tmp_path) -> None:
+    ctx, lease = _ctx_with_lease(tmp_path)
+    seen_at_chunk: list[int] = []
+
+    def chunks():
+        for i in range(3):
+            seen_at_chunk.append(lease.releases)
+            yield _frames(count=5, seed=i)
+
+    asset = gw_io.write_video(ctx, "outputs/r-enc/stream", chunks(), fps=24)
+    assert _decode_frame_count(asset.local_path) == 15
+    # While the producer was still decoding, the slot was HELD (releases=0);
+    # the terminal release happened only after exhaustion.
+    assert seen_at_chunk == [0, 0, 0]
+    assert lease.releases >= 1
+
+
+def test_write_video_failure_fails_its_own_request(tmp_path) -> None:
+    ctx, _lease = _ctx_with_lease(tmp_path)
+
+    def exploding_chunks():
+        yield _frames(count=2)
+        raise RuntimeError("VAE decode died mid-stream")
+
+    with pytest.raises(RuntimeError, match="VAE decode died"):
+        gw_io.write_video(ctx, "outputs/r-enc/boom", exploding_chunks(), fps=24)
+
+
+def test_write_video_without_lease_is_a_noop_release(tmp_path) -> None:
+    ctx = RequestContext(request_id="r-plain", local_output_dir=str(tmp_path))
+    asset = gw_io.write_video(ctx, "outputs/r-plain/v", _frames(count=4), fps=24)
+    assert asset.width == 64
+
+
+def test_write_video_audio_survives_the_new_path(tmp_path) -> None:
+    ctx = RequestContext(request_id="r-audio", local_output_dir=str(tmp_path))
+    sr = 24000
+    audio = np.sin(np.linspace(0, 440 * 2 * np.pi, sr))[None, :].astype(np.float32)
+    asset = gw_io.write_video(
+        ctx, "outputs/r-audio/v", _frames(), fps=24, audio=audio, audio_sample_rate=sr
+    )
+    assert asset.has_audio is True and asset.sample_rate == sr
+    with av.open(asset.local_path) as container:
+        assert container.streams.audio[0].codec_context.name == "aac"
+
+
+# ---- bounded finalize concurrency (gw#516) -----------------------------------
+
+
+def test_finalize_permit_bounds_concurrency(monkeypatch) -> None:
+    monkeypatch.setenv(ve.ENCODE_CONCURRENCY_ENV, "1")
+    ve._finalize_sem = None
+    active = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def worker() -> None:
+        nonlocal active, peak
+        with ve.finalize_permit():
+            with lock:
+                active += 1
+                peak = max(peak, active)
+            time.sleep(0.05)
+            with lock:
+                active -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert peak == 1
+
+
+def test_x264_stream_uses_fast_preset_options(tmp_path) -> None:
+    """The stream really carries the veryfast/crf options (not silently
+    dropped by PyAV): an unknown option would raise at add_stream."""
+    out = tmp_path / "preset.mp4"
+    enc = ve.StreamingVideoEncoder(
+        out, fps=24, encoder=ve.EncoderChoice("libx264", dict(ve.X264_OPTIONS)))
+    enc.add(_frames(count=4))
+    enc.finish()
+    assert _decode_frame_count(str(out)) == 4

--- a/tests/test_worker_grpc_e2e.py
+++ b/tests/test_worker_grpc_e2e.py
@@ -437,6 +437,45 @@ def test_gpu_slot_survives_cancel_during_yielded_window(scheduler_and_worker) ->
     assert res.status == pb.JOB_STATUS_OK
 
 
+def test_finalize_release_overlaps_peer_compute_and_slot_survives(scheduler_and_worker) -> None:
+    """gw#476/gw#516: a handler that terminally releases its GPU slot at the
+    decode->finalize handoff lets the NEXT job's compute run while it is
+    still encoding, completes without reacquiring, and leaves the semaphore
+    balanced (a third GPU job still runs)."""
+    import e2e_endpoints as ep
+
+    scheduler, _harness = scheduler_and_worker
+    conn = scheduler.wait_connection(0)
+    conn.wait_for(
+        lambda m: m.WhichOneof("msg") == "state_delta"
+        and m.state_delta.phase == pb.WORKER_PHASE_READY
+    )
+    ep.FINALIZE_PROBE_STARTED.clear()
+    ep.FINALIZE_PEER_RAN.clear()
+    cuda = pb.ResolvedCompute(accelerator="cuda", gpu_index=0)
+    conn.send(run_job=pb.RunJob(
+        request_id="r-final-probe", attempt=1, function_name="finalize-probe",
+        input_payload=_msgpack("x"), compute=cuda))
+    assert ep.FINALIZE_PROBE_STARTED.wait(timeout=10.0), "probe never started"
+    # The probe is now inside its encode tail with the slot released; the
+    # peer's compute must be able to run BEFORE the probe's handler returns.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-final-peer", attempt=1, function_name="finalize-peer",
+        input_payload=_msgpack("x"), compute=cuda))
+    res = conn.wait_for(_is_result_for("r-final-probe")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+    assert _decode_out(res.inline).response == "overlapped"
+    res = conn.wait_for(_is_result_for("r-final-peer")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+    # Executor's post-handler release no-oped (already released) without
+    # unbalancing the semaphore: a follow-up GPU job still gets the slot.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-final-after", attempt=1, function_name="sleepy",
+        input_payload=_msgpack("x"), compute=cuda))
+    res = conn.wait_for(_is_result_for("r-final-after")).job_result
+    assert res.status == pb.JOB_STATUS_OK
+
+
 def test_marco_polo_example_serves_under_the_new_core() -> None:
     """#365 acceptance: examples/marco-polo runs against the fake scheduler."""
     import sys

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.10"
+version = "0.14.11"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What

Kills the encode tail-latency problem (B200 gauntlet: one 10s@1080p clip spent **179.6s in x264 encode vs 118s of GPU compute**; a 5s@4K probe spent ~25min encoding while the GPU idle-billed).

### gw#476 — encode speed
- **`gen_worker.video_encode` (new)**: encoder probed ONCE per process — one tiny real encode, because codec presence in the PyAV wheel is not enough (H100/A100/B200 ship without the NVENC block; consumer RTX + L40S/L4/A40 have it). `h264_nvenc` (p4/hq/vbr/cq19) when present; `libx264 veryfast/CRF18` fallback instead of PyAV's archival default (medium/CRF23 — 5-10x the encode CPU for invisible gains on short generated clips). `GEN_WORKER_VIDEO_ENCODER=auto|nvenc|x264` override. Per-encode fallback if the HW encoder fails to open (NVENC session limits) — never fails a request over encoder selection.
- **`StreamingVideoEncoder`**: chunk-feed API for the VAE framewise-decode seam. `gen_worker.io.write_video` now also accepts an iterator/generator of frame chunks — long/4K clips never rebuffer a second raw array.

### gw#516 core — GPU-hot invariant
- `write_video` **terminally releases the request's GPU slot** once frames are on the host: the encode+upload tail overlaps the NEXT request's denoise. Unlike the gw#382 yield window there is **no reacquire** — a finishing request never blocks behind its successor's denoise just to return. The executor's post-handler release no-ops (lease transitions are once-only) so the semaphore balance stays exact; drain/cancel/failure-attribution are unchanged because the job stays in its handler until finalize completes.
- Buffered encodes take a **bounded finalize permit BEFORE the release** (`GEN_WORKER_VIDEO_ENCODE_CONCURRENCY`, default 2): back-pressure holds the slot instead of stacking raw-frame buffers in host RAM (coordinates with the gw#407 host-RAM gate).
- `FINALIZE_OVERLAP` log line (slot-held vs handler-wall ms) is the overlap evidence until JobMetrics grows a slot-held field (left open in gw#516).

## Tests
- `tests/test_video_encode.py`: selection/env-override/caching, forced-nvenc fallback, HW-open-failure per-encode fallback, streaming==buffered parity, single-frame + odd-dims, slot released BEFORE first encoded frame (array input) / only AFTER iterator exhaustion (streaming input), mid-stream failure fails its own request, permit bound, audio mux survives.
- grpc e2e: `test_finalize_release_overlaps_peer_compute_and_slot_survives` — peer's compute runs while the probe is still finalizing, probe completes without reacquiring, and a third GPU job proves the semaphore stayed balanced.
- conftest pins `GEN_WORKER_VIDEO_ENCODER=x264` for the suite: CI has no GPU and dev boxes with one must not do GPU work from unit tests.

919 passed / 17 skipped; mypy + ruff + http-timeout lint clean.

## Evidence
Self-driving 4090 pod measuring old-vs-new encode walls on real LTX gauntlet frames (1080p + 4K) — results land in the tracker under gw#476.

Cross-refs: gw#516 (remaining: hub-visible in-flight finalize count, JobMetrics field, platform 2-request timeline), th#762 (round-trip budget consumes FINALIZE_OVERLAP), ie: ltx endpoint should switch its save path from diffusers `encode_video` to `gw_io.write_video` to pick all of this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)