### PR TITLE
hotfix: ModelRef force_setattr — py3.12 serve images could not import ANY endpoint (0.14.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.14.10 (2026-07-12)
+
+- **pgw#511 hotfix: ModelRef.__post_init__ uses force_setattr.**
+  `object.__setattr__` on a frozen msgspec Struct raises "can't apply this
+  __setattr__" under CPython 3.12 (every serve image) while passing on 3.13
+  (dev venvs + CI) — any endpoint import died at decoration time and
+  discovery advertised NOTHING (J24M run16 image build gate caught it).
+  `msgspec.structs.force_setattr` is the repo convention (Resources,
+  Compile) and works on both.
+
+
 ## 0.14.9 (2026-07-12)
 
 - **gw#479: canonical config digests prune sub-config keys duplicating the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.9"
+version = "0.14.10"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -84,18 +84,22 @@ class ModelRef(msgspec.Struct, frozen=True):
     allow_lora: bool = False
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "path", _clean(self.path))
-        object.__setattr__(self, "tag", _clean(self.tag))
-        object.__setattr__(self, "flavor", _clean(self.flavor))
-        object.__setattr__(self, "revision", _clean(self.revision))
-        object.__setattr__(self, "subfolder", _clean(self.subfolder))
-        object.__setattr__(self, "dtype", _clean(self.dtype))
-        object.__setattr__(self, "version", _clean(self.version))
-        object.__setattr__(
-            self, "files", tuple(_clean(p) for p in self.files if _clean(p))
-        )
-        object.__setattr__(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
-        object.__setattr__(self, "allow_lora", bool(self.allow_lora))
+        # msgspec.structs.force_setattr, NOT object.__setattr__: the latter
+        # raises "can't apply this __setattr__" on frozen msgspec Structs
+        # under CPython 3.12 (every serve image) while passing on 3.13 (dev
+        # venvs + CI) — J24M run16 shipped an image whose endpoint import
+        # died at decoration and discovery found no functions.
+        force = msgspec.structs.force_setattr
+        force(self, "path", _clean(self.path))
+        force(self, "tag", _clean(self.tag))
+        force(self, "flavor", _clean(self.flavor))
+        force(self, "revision", _clean(self.revision))
+        force(self, "subfolder", _clean(self.subfolder))
+        force(self, "dtype", _clean(self.dtype))
+        force(self, "version", _clean(self.version))
+        force(self, "files", tuple(_clean(p) for p in self.files if _clean(p)))
+        force(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
+        force(self, "allow_lora", bool(self.allow_lora))
 
         if self.source == "tensorhub":
             if not self.tag:

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -103,7 +103,7 @@ class ModelRef(msgspec.Struct, frozen=True):
 
         if self.source == "tensorhub":
             if not self.tag:
-                object.__setattr__(self, "tag", "latest")
+                msgspec.structs.force_setattr(self, "tag", "latest")
             if not self.path:
                 raise ValueError("Hub requires a non-empty ref")
         elif self.source == "huggingface":

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.8"
+version = "0.14.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
gw PR #209 (structured ModelRef) uses object.__setattr__ in __post_init__, which raises "can't apply this __setattr__ to ModelRef object" on frozen msgspec Structs under CPython 3.12 — the version every serve image runs — while passing on 3.13 (dev venvs + CI). Result: endpoint modules die at decoration, discovery advertises nothing (caught by J24M run16's image discovery gate; verified fixed inside the py3.12 container). Swap to msgspec.structs.force_setattr, the existing repo convention. Suggest a py3.12 CI matrix lane as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)