### PR TITLE
ie#468 rung 2: apply_block_window_offload — stream block weights from pinned host RAM (0.14.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.14.12 (2026-07-12)
+## 0.14.13 (2026-07-12)
+
+- **ie#468 rung 2: `apply_block_window_offload` — block-window weight offload
+  to pinned host RAM.** The gw#460 windows in reverse: per-block weights rest
+  in (pinned) host RAM and stream to the device only for that block's
+  forward; params outside the windows move to the device. Composes with fp8
+  storage windows (fp8 bytes over PCIe, on-device upcast). Guaranteed-
+  completion degraded rung for VRAM-constrained cards — quality-preserving,
+  known-slow, never a production mode. PRECEDENCE: the
+  `GEN_WORKER_FORBID_CPU_OFFLOAD=1` operator veto wins over degraded mode —
+  the call raises before parking any weight (same rule as the gw#463
+  OOM-demotion path). Plus `block_offload_active()` probe.
 
 - **gw#476 fix: NVENC probe respected the encoder's minimum dimensions.**
   The boot probe encoded a 64x64 frame — below H.264 NVENC's minimum
@@ -11,6 +22,8 @@
   `StreamingVideoEncoder` opens the codec context eagerly inside `_open()`
   so hardware refusals that FFmpeg defers to the first `encode()` hit the
   per-encode x264 fallback instead of failing the request mid-encode.
+
+## 0.14.12 (2026-07-12)
 
 ## 0.14.11 (2026-07-12)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.12"
+version = "0.14.13"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -397,6 +397,151 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
     return applied
 
 
+class _BlockOffloadWindow:
+    """Degraded-mode rung 2 (ie#468): one transformer block's weights REST in
+    host RAM (pinned when possible) and stream to the execution device only
+    for that block's forward. The pre-hook is PREPENDED so the H2D copy runs
+    before any fp8 upcast window (gw#460) on the same block — composed order:
+    host fp8 bytes -> device fp8 -> device compute dtype. The post-hook
+    rebinds ``.data`` to the pristine host copy (weights are read-only at
+    inference; no copy-back), so whatever dtype games other hooks played in
+    between are discarded. ``always_call`` keeps the rebind on exceptions —
+    a mid-block CUDA OOM must not leave the window resident."""
+
+    def __init__(self, params: List[Any], hosts: List[Any], device: Any) -> None:
+        self._params = params
+        self._hosts = hosts
+        self._device = device
+
+    def install(self, block: Any) -> None:
+        block.register_forward_pre_hook(self._pre, prepend=True)
+        block.register_forward_hook(self._post, always_call=True)
+
+    def _pre(self, module: Any, args: Any) -> None:
+        for p, h in zip(self._params, self._hosts):
+            p.data = h.to(self._device, non_blocking=True)
+
+    def _post(self, module: Any, args: Any, output: Any = None) -> None:
+        for p, h in zip(self._params, self._hosts):
+            p.data = h
+
+
+# Components block-window offload targets on a pipeline object (the VRAM
+# dominators); callers pass their own set for model-specific choices (e.g.
+# ltx adds "connectors" and "text_encoder").
+_BLOCK_OFFLOAD_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+
+
+def apply_block_window_offload(
+    obj: Any,
+    *,
+    components: tuple[str, ...] = _BLOCK_OFFLOAD_COMPONENTS,
+    device: Any = None,
+) -> bool:
+    """Park a module's per-block weights in pinned host RAM and stream each
+    block to ``device`` for its forward only — the gw#460 block windows in
+    reverse (degraded-mode rung 2, ie#468). Quality-preserving but slow
+    (whole-model PCIe traffic per forward); a guaranteed-completion last
+    resort for VRAM-constrained cards, never a production serving mode.
+
+    ``obj`` is a pipeline (named ``components`` are offloaded) or a bare
+    module. Parameters outside the discovered block windows — embeddings,
+    final norms, projections — are moved TO ``device`` (they must be
+    resident; the gw#460 outside-a-block dtype/device hazard applies to
+    device placement too). Composes with fp8 storage windows: fp8 bytes
+    stream over PCIe (half the traffic), upcast happens on-device.
+
+    PRECEDENCE: ``GEN_WORKER_FORBID_CPU_OFFLOAD=1`` VETOES this rung — the
+    operator kill-switch wins over degraded mode, raising instead of parking
+    weights (same precedence as the executor's OOM-demotion path, gw#463).
+
+    Returns True when any module was armed. Idempotent per module."""
+    from .memory import _forbid_cpu_inference
+
+    _forbid_cpu_inference(
+        "block-window host-RAM weight offload (degraded rung 2, ie#468)"
+    )
+    try:
+        import torch
+    except ImportError:
+        logger.warning("block-window offload ignored: torch not installed")
+        return False
+    if device is None:
+        if not torch.cuda.is_available():
+            logger.warning("block-window offload ignored: no CUDA device")
+            return False
+        device = "cuda"
+
+    targets: List[tuple[str, Any]] = []
+    for name in components:
+        mod = getattr(obj, name, None)
+        if mod is not None and hasattr(mod, "parameters"):
+            targets.append((name, mod))
+    if not targets and hasattr(obj, "parameters"):
+        targets.append((type(obj).__name__, obj))
+
+    applied = False
+    for name, mod in targets:
+        if getattr(mod, "_cozy_block_offload_applied", False):
+            applied = True
+            continue
+        windows = _fp8_block_windows(mod) or _fp8_block_windows_whole(mod)
+        if not windows:
+            logger.warning("block-window offload: no weight windows in %s", name)
+            continue
+        pin = True
+        parked_ids: set[int] = set()
+        parked_bytes = 0
+        for _bname, block, params in windows:
+            hosts: List[Any] = []
+            for p in params:
+                host = None
+                if pin:
+                    try:
+                        host = torch.empty_like(p.data, device="cpu", pin_memory=True)
+                    except RuntimeError as exc:
+                        pin = False
+                        logger.warning(
+                            "block-window offload: pinned host alloc failed (%s); "
+                            "falling back to pageable staging (slower)", exc,
+                        )
+                if host is None:
+                    host = torch.empty_like(p.data, device="cpu")
+                host.copy_(p.data)
+                p.data = host
+                hosts.append(host)
+                parked_ids.add(id(p))
+                parked_bytes += host.numel() * host.element_size()
+            _BlockOffloadWindow(params, hosts, device).install(block)
+        # Everything OUTSIDE the windows must be resident on the device.
+        for p in mod.parameters():
+            if id(p) not in parked_ids and p.device != torch.device(device):
+                p.data = p.data.to(device)
+        for b in mod.buffers():
+            if b.device != torch.device(device):
+                b.data = b.data.to(device)
+        mod._cozy_block_offload_applied = True
+        applied = True
+        logger.warning(
+            "DEGRADED_MODE=engaged model=%s phase=load rung=resident->block_offload: "
+            "%d blocks / %.1f GiB parked in %s host RAM, streaming per forward",
+            name, len(windows), parked_bytes / float(1 << 30),
+            "pinned" if pin else "pageable",
+        )
+    return applied
+
+
+def block_offload_active(obj: Any) -> bool:
+    """True when :func:`apply_block_window_offload` armed ``obj`` or any of
+    its standard components."""
+    if getattr(obj, "_cozy_block_offload_applied", False):
+        return True
+    return any(
+        getattr(getattr(obj, name, None), "_cozy_block_offload_applied", False)
+        for name in _BLOCK_OFFLOAD_COMPONENTS
+    )
+
+
 def _single_file_checkpoint(path: Path) -> Optional[Path]:
     """A snapshot that is one loose checkpoint rather than a pretrained layout:
     the path itself when it's a ``.safetensors`` file, or the directory's sole
@@ -794,6 +939,8 @@ __all__ = [
     "read_on_disk_quant_config",
     "synthesize_quantization_config",
     "apply_fp8_storage",
+    "apply_block_window_offload",
+    "block_offload_active",
     "emergency_quant_enabled",
     "bitsandbytes_available",
     "runtime_fp8_storage_supported",

--- a/tests/test_block_window_offload.py
+++ b/tests/test_block_window_offload.py
@@ -1,0 +1,121 @@
+"""Block-window weight offload — degraded-mode rung 2 (ie#468).
+
+The gw#460 windows in reverse: per-block weights rest in host RAM and stream
+to the execution device only for that block's forward. CPU-safe: hook order,
+rebind correctness, fp8-window composition, and the FORBID_CPU_OFFLOAD veto
+precedence need no GPU (``device="cpu"`` exercises the full rebind path).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from gen_worker.models.loading import (  # noqa: E402
+    apply_block_window_offload,
+    apply_fp8_storage,
+    block_offload_active,
+)
+
+
+def _tiny_t5() -> Any:
+    from transformers import T5Config, T5EncoderModel
+
+    cfg = T5Config(
+        vocab_size=256, d_model=64, d_kv=16, d_ff=128,
+        num_layers=2, num_heads=4,
+    )
+    return T5EncoderModel(cfg).to(torch.bfloat16).eval()
+
+
+def _forward(model: Any, ids: Any) -> Any:
+    with torch.no_grad():
+        out = model(input_ids=ids, attention_mask=torch.ones_like(ids))
+    return out.last_hidden_state.float()
+
+
+@pytest.fixture(autouse=True)
+def _no_forbid(monkeypatch):
+    # This dev box exports the veto; the non-veto tests need it clear.
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+
+
+def test_forbid_cpu_offload_veto_wins(monkeypatch):
+    """PRECEDENCE: the operator kill-switch beats degraded rung 2 — the call
+    raises before any weight is parked (same rule as the gw#463 OOM path)."""
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    model = _tiny_t5()
+    before = {n: p.data_ptr() for n, p in model.named_parameters()}
+    with pytest.raises(RuntimeError, match="GEN_WORKER_FORBID_CPU_OFFLOAD"):
+        apply_block_window_offload(model, device="cpu")
+    after = {n: p.data_ptr() for n, p in model.named_parameters()}
+    assert before == after  # untouched
+    assert not block_offload_active(model)
+
+
+def test_offload_preserves_outputs_and_rebinds():
+    model = _tiny_t5()
+    ids = torch.randint(0, 256, (1, 8))
+    ref = _forward(model, ids)
+
+    assert apply_block_window_offload(model, device="cpu") is True
+    assert block_offload_active(model)
+
+    parked = [
+        p for m in model.modules() if isinstance(m, torch.nn.Linear)
+        for p in m.parameters(recurse=False)
+    ]
+    host_ptrs = {p.data_ptr() for p in parked}
+
+    out = _forward(model, ids)
+    assert torch.allclose(ref, out, atol=1e-3)
+    # post-hook rebound every window back to its host copy
+    assert {p.data_ptr() for p in parked} == host_ptrs
+    # second forward (hooks re-fire cleanly)
+    out2 = _forward(model, ids)
+    assert torch.allclose(out, out2)
+
+
+def test_idempotent():
+    model = _tiny_t5()
+    assert apply_block_window_offload(model, device="cpu") is True
+    parked = {p.data_ptr() for p in model.parameters()}
+    assert apply_block_window_offload(model, device="cpu") is True  # no-op
+    assert {p.data_ptr() for p in model.parameters()} == parked
+
+
+def test_composes_with_fp8_windows():
+    """fp8 storage windows (gw#460) + offload windows on the same blocks:
+    fp8 bytes at rest in host RAM, upcast happens inside the forward, and the
+    post-hooks land the params back on the host fp8 copies."""
+    model = _tiny_t5()
+    ids = torch.randint(0, 256, (1, 8))
+    assert apply_fp8_storage(model) is True
+    ref = _forward(model, ids)  # fp8-window baseline
+
+    assert apply_block_window_offload(model, device="cpu") is True
+    out = _forward(model, ids)
+    assert torch.allclose(ref, out, atol=1e-3)
+    fp8 = torch.float8_e4m3fn
+    lin = [
+        p for m in model.modules() if isinstance(m, torch.nn.Linear)
+        for p in m.parameters(recurse=False)
+    ]
+    assert lin and all(p.dtype == fp8 for p in lin)
+    assert all(p.device.type == "cpu" for p in lin)
+
+
+def test_pipeline_component_targeting():
+    class Pipe:
+        def __init__(self) -> None:
+            self.transformer = _tiny_t5()
+            self.vae = torch.nn.Linear(4, 4)
+
+    pipe = Pipe()
+    assert apply_block_window_offload(pipe, device="cpu") is True
+    assert block_offload_active(pipe)
+    assert not getattr(pipe.vae, "_cozy_block_offload_applied", False)

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.12"
+version = "0.14.13"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Degraded-mode rung 2 for ie#468 (guaranteed-completion fallback for VRAM-constrained cards).

- `apply_block_window_offload(obj, components=..., device=...)`: the gw#460 block windows in reverse — per-block weights rest in (pinned, pageable fallback) host RAM and stream to the device only for that block's forward; params/buffers outside the windows move to the device. Idempotent per module; `block_offload_active()` probe.
- Composes with fp8 storage windows: the offload pre-hook is PREPENDED (fp8 bytes over PCIe, upcast on-device) and the post-hook rebinds to the pristine host copy with `always_call=True` (a mid-block OOM cannot leave a window resident).
- **PRECEDENCE: `GEN_WORKER_FORBID_CPU_OFFLOAD=1` wins over degraded mode** — the call raises before parking any weight, same rule as the executor's gw#463 OOM-demotion path.
- CPU-only tests: veto precedence, output preservation + host rebinding, idempotence, fp8-window composition, pipeline component targeting.

Consumer: inference-endpoints ltx-video-2.3 degraded-mode planner (ie#468 PR to follow). Proof probe: 4090-24GiB self-driving pod (walls in the ie tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)