### PR TITLE
gw#476 fix: NVENC probe at 256x256 (encoder min dims) + eager codec open (0.14.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.14.12 (2026-07-12)
+
+- **gw#476 fix: NVENC probe respected the encoder's minimum dimensions.**
+  The boot probe encoded a 64x64 frame — below H.264 NVENC's minimum
+  (145x49) — so genuinely NVENC-capable cards failed the probe with
+  "Frame Dimension less than the minimum supported value" (measured live on
+  an L4; the GeForce-in-SECURE-tenancy "OpenEncodeSessionEx: unsupported
+  device" refusal is real and unaffected). Probe now encodes 256x256, and
+  `StreamingVideoEncoder` opens the codec context eagerly inside `_open()`
+  so hardware refusals that FFmpeg defers to the first `encode()` hit the
+  per-encode x264 fallback instead of failing the request mid-encode.
+
 ## 0.14.11 (2026-07-12)
 
 - **gw#476: fast video encode path — NVENC when the silicon has it, streaming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.11"
+version = "0.14.12"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/video_encode.py
+++ b/src/gen_worker/video_encode.py
@@ -66,7 +66,14 @@ def _x264() -> EncoderChoice:
 def _probe_nvenc() -> bool:
     """One tiny real encode. Codec presence in the PyAV build is not enough:
     opening h264_nvenc needs the driver's libnvidia-encode AND a card whose
-    silicon has the encoder block (absent on H100/A100/B200)."""
+    silicon has the encoder block (absent on H100/A100/B200) AND a tenancy
+    whose driver grants encode sessions (RunPod SECURE 4090/5090 refuse with
+    "OpenEncodeSessionEx failed: unsupported device"; the L4 grants them).
+
+    Probe frame is 256x256: NVENC enforces minimum encode dimensions
+    (H.264 min is 145x49) — a 64x64 probe fails "Frame Dimension less than
+    the minimum supported value" on GENUINELY capable cards (measured live
+    on an L4, gw#476)."""
     import io as _io
 
     try:
@@ -79,11 +86,11 @@ def _probe_nvenc() -> bool:
         packets = 0
         with av.open(buf, mode="w", format="mp4") as container:
             stream: Any = container.add_stream("h264_nvenc", rate=8, options=dict(NVENC_OPTIONS))
-            stream.width = 64
-            stream.height = 64
+            stream.width = 256
+            stream.height = 256
             stream.pix_fmt = "yuv420p"
             frame = av.VideoFrame.from_ndarray(
-                np.zeros((64, 64, 3), dtype=np.uint8), format="rgb24"
+                np.zeros((256, 256, 3), dtype=np.uint8), format="rgb24"
             )
             for packet in stream.encode(frame):
                 container.mux(packet)
@@ -262,6 +269,12 @@ class StreamingVideoEncoder:
         stream.width = width
         stream.height = height
         stream.pix_fmt = "yuv420p"
+        # Open the codec NOW instead of lazily at the first encode() so a
+        # hardware refusal (NVENC session limit / dimension gate — observed
+        # live as "InitializeEncoder failed" only at first encode, gw#476)
+        # lands in _open()'s per-encode fallback instead of failing the
+        # request mid-encode.
+        stream.codec_context.open(strict=False)
         return stream
 
     def add(self, frames: Any) -> int:

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.11"
+version = "0.14.12"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Live L4 evidence (gw#476 bench pod): driver reports "supports NVENC", but the boot probe's 64x64 frame is below H.264 NVENC's minimum encode dimensions (145x49) — `InitializeEncoder failed: invalid param (8): Frame Dimension less than the minimum supported value`. Every genuinely NVENC-capable card would have failed the probe and silently served x264.

- probe frame 64x64 -> 256x256
- `StreamingVideoEncoder._add_video_stream` opens the codec context eagerly, so hardware refusals FFmpeg defers to the first `encode()` (dimension gate, session limits) land in `_open()`'s per-encode x264 fallback instead of failing the request mid-encode
- unaffected/real: RunPod SECURE GeForce (4090/5090) refuses NVENC sessions at the driver level (`OpenEncodeSessionEx failed: unsupported device (2)`) — tenancy policy, exactly what the probe-at-boot design is for

🤖 Generated with [Claude Code](https://claude.com/claude-code)