### PR TITLE
pgw#509: delete variants=; checkpoint selection is a typed model= payload arg (0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.15.0 (2026-07-12)
+
+- **pgw#509: `variants=` is deleted; checkpoint selection is a typed `model=`
+  payload argument (BREAKING).** The three-boundary rule — class = memory
+  (weights load once per instance), method = wire contract, arg = checkpoint.
+  A handler whose payload declares a field typed with a `ModelChoice` subclass
+  picks, per request, which curated checkpoint runs against the resident base;
+  16 near-identical fine-tunes collapse from 16 routable functions to one
+  `generate(model=)`. New authoring surface (`gen_worker.api.model`, exported
+  as `Model`, `ModelChoice`, `ModelDefaults`): the curated set is DATA — a
+  `str`-valued enum whose members are `Model` rows carrying a `ModelRef`
+  binding + typed per-model `ModelDefaults` (+ optional `hot`/`price` hints).
+  The handler reads `payload.model.defaults` as typed data (no `ctx.models`
+  string-sniffing); on the wire a pick is its id string and the JSON schema is
+  a closed `enum`. **BYOM is the field TYPE**: `model: SomeChoice` is
+  curated-only, `model: SomeChoice | ModelRef` opens an arbitrary
+  client-supplied ref — no `@byom` decorator, arch compat derived from the
+  loaded pipeline. Discovery emits a new per-function `model` block (field +
+  `byom` + `slot` + curated `choices[]` with structured binding/defaults/hints)
+  — the SDK→tensorhub contract the scheduler warm-pools against (th#761).
+- **`route=` (gw#479 payload-driven slot routing) is deleted** — zero endpoints
+  used it. Multi-slot lane classes still content-share and LRU-swap under VRAM
+  pressure; every declared slot is now promoted (no per-request lane pick).
+- Endpoints pinned `gen-worker<0.15` keep the old `variants=` surface until
+  they migrate (ie#469).
+
 ## 0.14.14 (2026-07-12)
 
 - **gw#407 host-RAM admission sizes multi-slot setups by the LARGEST slot,

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ never a constructor argument. `storage_dtype="fp8"` keeps denoiser weights in
 fp8-E4M3 storage with per-layer upcast to the compute `dtype` (half the VRAM
 on any card); fp8-stored `#fp8` flavors get the same treatment automatically.
 
-Multi-variant endpoints (`bf16`/`fp8`/... checkpoints with different VRAM
-envelopes) declare `variants={name: (binding, Resources)}` — one handler body,
-one routable function per variant. Streaming = an async-generator handler.
+Curated checkpoint selection is a runtime payload argument: a handler declares
+`model: SomeModelChoice` (a `ModelChoice` enum of `Model` rows, each carrying a
+`ModelRef` binding + typed per-model defaults) and reads `payload.model.defaults`
+typed — one `generate(model=)` replaces N near-identical functions. `model:
+SomeModelChoice | ModelRef` opens BYOM. Streaming = an async-generator handler.
 Engine-hosted endpoints declare `runtime="vllm"` and get a booted,
 health-checked server subprocess injected into `setup()`.
 

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -85,51 +85,73 @@ runtime-quantizes the denoiser to 4-bit nf4 with a loud warning (quality
 below platform standards) rather than falling straight to CPU offload.
 Fit ladder: bf16 → `#fp8` → `#nvfp4` (Blackwell) → emergency-nf4 → offload.
 
-## Variants
+## Model selection: `model=` is a payload argument (pgw#509)
 
-One handler body, N separately-placeable routable functions:
+Checkpoint selection is a runtime PAYLOAD FIELD, not a build-time fan-out. A
+handler whose payload declares a field typed with a `ModelChoice` subclass
+picks, per request, which curated checkpoint runs against the resident base.
+16 near-identical fine-tunes = ONE `generate(model=)`, not 16 functions.
+
+Declare the curated set as DATA — one row per checkpoint carrying its
+`ModelRef` binding + typed per-model defaults:
 
 ```python
-@endpoint(
-    model=HF("org/base", dtype="bf16"),
-    resources=Resources(vram_gb=24),
-    variants={
-        "generate-fp8": (HF("org/base-fp8"), Resources(vram_gb=14)),
-    },
-)
-class Generate:
-    def setup(self, model: FluxPipeline): self.model = model
-    def generate(self, ctx, p: In) -> Out: ...
+class SdxlDefaults(ModelDefaults, frozen=True):
+    scheduler: Literal["euler_a", "dpmpp_2m_karras"]
+    steps: int
+    guidance: float
+
+class SdxlModel(ModelChoice[SdxlDefaults], enum.Enum):
+    WAI  = Model("wai-illustrious",     Hub("tensorhub/wai-illustrious"), SdxlDefaults("euler_a", 28, 6.0), hot=True)
+    PONY = Model("cyberrealistic-pony", Hub("tensorhub/cyberrealistic-pony"), SdxlDefaults("dpmpp_2m_karras", 30, 5.0))
+
+class TextToImage(msgspec.Struct):
+    prompt: str
+    model: SdxlModel = SdxlModel.WAI          # curated-only
+
+@endpoint(models={"pipeline": Hub("tensorhub/wai-illustrious"), "vae": Hub("tensorhub/sdxl-vae")})
+class SDXLFamily:
+    def setup(self, pipeline, vae): ...
+    def generate(self, ctx, p: TextToImage) -> ImageOutput:
+        d = p.model.defaults                  # typed SdxlDefaults — no ctx.models sniffing
+        ...
 ```
 
-Each variant key is a routable function name with its own binding and
-`Resources` (falls back to the class values). The base method-named function
-is stamped only when the class declares `model=`/`models=`. If your payload
-echoes the variant in a `variant` field, type it `Literal[...]` — members are
-validated against the declared variants at import time.
+On the wire a pick is its id string (`"wai-illustrious"`); the JSON schema is
+a closed `enum` (the curated allowlist). Defaults are manifest-exported so the
+catalog/UI can render `steps: 28` before submit. Discovery emits the whole set
+(each choice's binding + defaults + `hot`/`price` hints) for the scheduler to
+warm-pool per checkpoint.
 
-## Lanes: multi-model classes with input routing (gw#479)
+**BYOM is the field TYPE.** `model: SdxlModel` is curated-only; `model:
+SdxlModel | ModelRef` additionally accepts an arbitrary client-supplied
+`ModelRef` (bring-your-own-model). No `@byom` decorator, no `sources=` —
+architecture compatibility is derived from the pipeline the endpoint's
+`models=` loads. Per-method policy falls out of method=contract: a `generate`
+method can be BYOM-open while a `generate_turbo` method (fixed distillation
+LoRA) stays curated.
+
+Divergent WIRE contracts are separate METHODS, not `Optional` fields; only
+weight-sharing forces one class. A distilled turbo that shares the base is a
+`generate_turbo` method on the same class (shares the resident base); a
+standalone distilled checkpoint is a separate class/endpoint.
+
+## Lanes: multi-model classes with shared components (gw#479)
 
 A class binding 2+ pipeline slots whose snapshots share byte-identical
 components (content-keyed by the files' blake3 digests) loads the shared set
 ONCE; each slot's exclusive weights (its transformer) are an independent
-residency entry the worker LRU-swaps under VRAM pressure. Declare `route=`
-so only the lane a request needs is promoted/pinned:
+residency entry the worker LRU-swaps under VRAM pressure:
 
 ```python
-def _route(p: In) -> tuple[str, ...]:
-    return ("edit",) if p.images else ("t2i",)
-
-@endpoint(models={"t2i": Hub("org/base"), "edit": Hub("org/edit")}, route=_route)
+@endpoint(models={"t2i": Hub("org/base"), "edit": Hub("org/edit")})
 class Generate:
     def setup(self, t2i: QwenImagePipeline, edit: QwenImageEditPlusPipeline): ...
     def generate(self, ctx, p: In) -> Out: ...  # picks self.t2i / self.edit
 ```
 
-The handler must only touch the lane(s) `route` named — the idle lane may be
-warm in host RAM. This mechanism COMPENSATES for split-vendor base+edit
-releases (Qwen, HiDream, Wan t2v/i2v); unified models (one transformer doing
-t2i + edit) need no lanes — bind one model and skip `route=`.
+This COMPENSATES for split-vendor base+edit releases (Qwen, HiDream, Wan
+t2v/i2v); unified models (one transformer doing t2i + edit) bind one model.
 
 ## Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.14"
+version = "0.15.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -16,6 +16,7 @@ subclass from ``@endpoint(kind=...)`` before dispatch.
 from . import io
 from .api.binding import Civitai, HF, Hub, ModelRef, ModelScope
 from .api.decorators import Compile, Resources, endpoint
+from .api.model import Model, ModelChoice, ModelDefaults
 from .api.errors import (
     CanceledError,
     FatalError,
@@ -61,6 +62,10 @@ __all__ = [
     "Civitai",
     "ModelRef",
     "ModelScope",
+    # Curated model-selection (payload `model=` placement key).
+    "Model",
+    "ModelChoice",
+    "ModelDefaults",
     # Context types.
     "RequestContext",
     "ConversionContext",

--- a/src/gen_worker/api/__init__.py
+++ b/src/gen_worker/api/__init__.py
@@ -2,6 +2,7 @@
 
 from .binding import Binding, Civitai, HF, Hub, ModelRef, ModelScope
 from .decorators import Resources, endpoint
+from .model import Model, ModelChoice, ModelDefaults
 from .errors import (
     AuthError,
     CanceledError,
@@ -47,6 +48,9 @@ __all__ = [
     "Civitai",
     "HF",
     "Hub",
+    "Model",
+    "ModelChoice",
+    "ModelDefaults",
     "ModelRef",
     "ModelScope",
     "Resources",

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -22,17 +22,18 @@
 * An async-generator handler streams (inference only); there is no separate
   streaming decorator.
 * ``runtime="vllm"`` boots an engine-hosting server subprocess before setup.
-* ``variants={name: (binding, Resources)}`` stamps one separately-routable,
-  separately-placeable function per variant from a single handler body. With
-  ``models={}`` the variant binding swaps the FIRST declared slot; remaining
-  aux slots (e.g. a shared VAE) are inherited by every variant.
+
+Checkpoint SELECTION is a runtime payload argument, not a build-time fan-out:
+a handler whose payload declares a field typed with a ``ModelChoice`` subclass
+picks, per request, which curated checkpoint runs against the resident base
+(pgw#509 — ``gen_worker.api.model``). Divergent WIRE contracts are separate
+methods; only weight-sharing forces one class.
 """
 
 from __future__ import annotations
 
 import inspect
-import typing
-from typing import Any, Callable, Literal, Mapping, Optional, Sequence, TypeVar, overload
+from typing import Any, Callable, Mapping, Optional, TypeVar, overload
 
 import msgspec
 
@@ -93,14 +94,6 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
             ))
         if self.vram_gb is not None or self.compute_capability is not None:
             force(self, "gpu", True)
-
-
-class Variant(msgspec.Struct, frozen=True):
-    """One resolved ``variants={}`` row: binding + optional Resources override."""
-
-    name: str
-    binding: Any
-    resources: Resources | None = None
 
 
 class Compile(msgspec.Struct, frozen=True):
@@ -166,16 +159,10 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     kind: str = "inference"
     resources: Resources = msgspec.field(default_factory=Resources)
     models: Mapping[str, Binding] = msgspec.field(default_factory=dict)
-    variants: tuple[Variant, ...] = ()
     runtime: Optional[str] = None
     name: Optional[str] = None  # function-shaped endpoints only
     is_function: bool = False
     compile: Optional[Compile] = None
-    # Payload-driven slot routing (gw#479): ``route(payload) -> slot names``
-    # the request actually needs. The executor promotes/pins only those
-    # slots, so multi-lane classes (two transformers over one shared
-    # encoder) swap the idle lane instead of thrashing both per request.
-    route: Optional[Callable[[Any], Sequence[str]]] = None
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -241,74 +228,6 @@ def _normalize_models(
             )
         out[k] = b
     return out
-
-
-def _normalize_variants(
-    variants: Optional[Mapping[str, Any]], default_resources: Resources
-) -> tuple[Variant, ...]:
-    if not variants:
-        return ()
-    rows: list[Variant] = []
-    seen: set[str] = set()
-    for raw_name, value in variants.items():
-        name = str(raw_name or "").strip()
-        if not name:
-            raise ValueError("@endpoint variants: empty variant name")
-        if name in seen:
-            raise ValueError(f"@endpoint variants: duplicate name {name!r}")
-        seen.add(name)
-        res: Resources | None = None
-        if isinstance(value, tuple):
-            if len(value) != 2 or not isinstance(value[1], Resources):
-                raise TypeError(
-                    f"@endpoint variants[{name!r}] must be a binding or "
-                    "(binding, Resources) pair"
-                )
-            binding, res = value
-        else:
-            binding = value
-        if not isinstance(binding, BINDING_TYPES):
-            raise TypeError(
-                f"@endpoint variants[{name!r}]: expected a HF/Hub/Civitai/"
-                f"ModelScope binding, got {type(binding).__name__}"
-            )
-        rows.append(Variant(name=name, binding=binding, resources=res or default_resources))
-    return tuple(rows)
-
-
-def _literal_members(t: Any) -> Optional[tuple[Any, ...]]:
-    if typing.get_origin(t) is Literal:
-        return tuple(typing.get_args(t))
-    return None
-
-
-def _validate_variant_literal(cls_name: str, method: Callable[..., Any], names: Sequence[str]) -> None:
-    """If the handler payload declares a ``variant`` field, it must be a
-    ``Literal[...]`` whose members are a subset of the declared variant names
-    (build-time validation of the discriminator, carried over from the old
-    dispatch() Literal check)."""
-    try:
-        hints = typing.get_type_hints(method)
-        params = _handler_params(method, is_method=True)
-        payload_type = hints.get(params[1].name)
-        field_hints = typing.get_type_hints(payload_type)
-    except Exception:
-        return
-    field_type = field_hints.get("variant")
-    if field_type is None:
-        return
-    members = _literal_members(field_type)
-    if members is None:
-        raise ValueError(
-            f"@endpoint class {cls_name!r}: payload field 'variant' must be "
-            f"Literal[...]-typed so variant names are validated (got {field_type!r})."
-        )
-    unknown = sorted({str(m) for m in members} - set(names))
-    if unknown:
-        raise ValueError(
-            f"@endpoint class {cls_name!r}: payload 'variant' Literal member(s) "
-            f"{unknown} match no declared variant (variants: {sorted(names)})."
-        )
 
 
 def _find_handler_methods(cls: type) -> list[tuple[str, Callable[..., Any]]]:
@@ -414,10 +333,8 @@ def _decorate_class(
     kind: str,
     resources: Resources,
     models: dict[str, Binding],
-    variants: Optional[Mapping[str, Any]],
     runtime: Optional[str],
     compile: Optional[Compile] = None,
-    route: Optional[Callable[[Any], Sequence[str]]] = None,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -425,39 +342,15 @@ def _decorate_class(
     models = _resolve_single_slot(cls, models, handlers)
     _validate_class_models(cls, models)
 
-    variant_rows = _normalize_variants(variants, resources)
-    if variant_rows:
-        if len(handlers) != 1:
-            raise ValueError(
-                f"@endpoint class {cls.__name__!r}: variants= requires exactly "
-                f"ONE handler method to fan out over (found {len(handlers)})."
-            )
-        # Multi-slot classes: variants swap the FIRST declared slot; the
-        # remaining (aux) slots are shared across all variants.
-        _validate_variant_literal(
-            cls.__name__, handlers[0][1], [v.name for v in variant_rows]
-        )
-
     if runtime is not None and runtime not in ("vllm", "llama-server"):
         raise ValueError(
             f"@endpoint class {cls.__name__!r}: runtime must be 'vllm' or "
             f"'llama-server', got {runtime!r}"
         )
-    if route is not None:
-        if not callable(route):
-            raise TypeError(
-                f"@endpoint class {cls.__name__!r}: route= must be callable "
-                f"(payload -> model slot names), got {type(route).__name__}"
-            )
-        if len(models) < 2:
-            raise ValueError(
-                f"@endpoint class {cls.__name__!r}: route= needs 2+ model "
-                f"slots to route between (declared {sorted(models) or 'none'})"
-            )
 
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models,
-        variants=variant_rows, runtime=runtime, compile=compile, route=route,
+        runtime=runtime, compile=compile,
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
@@ -511,11 +404,9 @@ def endpoint(
     model: Optional[Binding] = ...,
     models: Optional[Mapping[str, Binding]] = ...,
     resources: Optional[Resources] = ...,
-    variants: Optional[Mapping[str, Any]] = ...,
     runtime: Optional[str] = ...,
     name: Optional[str] = ...,
     compile: Optional[Compile] = ...,
-    route: Optional[Callable[[Any], Sequence[str]]] = ...,
 ) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
@@ -526,11 +417,9 @@ def endpoint(
     model: Optional[Binding] = None,
     models: Optional[Mapping[str, Binding]] = None,
     resources: Optional[Resources] = None,
-    variants: Optional[Mapping[str, Any]] = None,
     runtime: Optional[str] = None,
     name: Optional[str] = None,
     compile: Optional[Compile] = None,
-    route: Optional[Callable[[Any], Sequence[str]]] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes."""
     if kind not in KINDS:
@@ -553,19 +442,9 @@ def endpoint(
                                  "class handlers route by method name")
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=model_map,
-                variants=variants, runtime=runtime, compile=compile, route=route,
+                runtime=runtime, compile=compile,
             )
         if inspect.isfunction(obj):
-            if variants:
-                raise ValueError(
-                    f"@endpoint function {obj.__name__!r}: variants= requires a "
-                    "class (each variant needs its own setup state)."
-                )
-            if route is not None:
-                raise ValueError(
-                    f"@endpoint function {obj.__name__!r}: route= requires a "
-                    "class with setup() (slot routing selects among loaded lanes)."
-                )
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 runtime=runtime, name=name, compile=compile,
@@ -579,4 +458,4 @@ def endpoint(
     return apply
 
 
-__all__ = ["Compile", "EndpointDecl", "Resources", "Variant", "endpoint"]
+__all__ = ["Compile", "EndpointDecl", "Resources", "endpoint"]

--- a/src/gen_worker/api/model.py
+++ b/src/gen_worker/api/model.py
@@ -1,0 +1,182 @@
+"""``model=`` — the payload-level checkpoint placement key (pgw#509).
+
+Model selection is a runtime PAYLOAD ARGUMENT, not a build-time fan-out.
+The three-boundary rule:
+
+* **class = memory-sharing unit** — weights load once in ``setup()``, resident
+  per instance.
+* **method = wire contract** — every ``@endpoint`` method is its own routable
+  function with its own payload schema.
+* **arg = checkpoint** — a handler whose payload declares a field typed with a
+  ``ModelChoice`` subclass selects, per request, which curated checkpoint runs
+  against the resident base. One ``generate(model=)`` replaces N near-identical
+  functions.
+
+A ``ModelChoice`` is authored as DATA: a ``str``-valued :class:`enum.Enum`
+whose members are :class:`Model` rows, each carrying its :class:`ModelRef`
+binding + a typed per-model :class:`ModelDefaults`::
+
+    class SdxlDefaults(ModelDefaults, frozen=True):
+        scheduler: Literal["euler_a", "dpmpp_2m_karras"]
+        steps: int
+        guidance: float
+
+    class SdxlModel(ModelChoice[SdxlDefaults], enum.Enum):
+        WAI = Model("wai-illustrious", Hub("tensorhub/wai-illustrious"),
+                    SdxlDefaults("euler_a", 28, 6.0))
+        PONY = Model("cyberrealistic-pony", Hub("tensorhub/cyberrealistic-pony"),
+                     SdxlDefaults("dpmpp_2m_karras", 30, 5.0))
+
+    class TextToImage(msgspec.Struct):
+        prompt: str
+        model: SdxlModel = SdxlModel.WAI          # curated-only
+
+The handler reads the pick as fully-typed data — no ``ctx.models`` string
+sniffing::
+
+    def generate(self, ctx, p: TextToImage) -> ...:
+        d = p.model.defaults          # typed SdxlDefaults
+        steps = d.steps
+
+On the wire a curated pick is just its id string (``"wai-illustrious"``); the
+JSON schema is a closed ``enum`` — the curated allowlist, introspectable by
+discovery.
+
+**BYOM is the FIELD TYPE.** A field typed ``SdxlModel`` is curated-only; a
+field typed ``SdxlModel | ModelRef`` additionally accepts an arbitrary
+client-supplied :class:`ModelRef` (bring-your-own-model). No decorator, no
+``sources=``/``scope=`` — architecture compatibility is derived downstream
+from the pipeline the endpoint's ``models=`` loads. Per-method policy falls
+straight out of method=contract: ``generate`` can be BYOM-open while
+``generate_turbo`` (fixed distillation LoRA) stays curated.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, Generic, Optional, TypeVar
+
+import msgspec
+
+from .binding import ModelRef
+
+
+class ModelDefaults(msgspec.Struct, frozen=True):
+    """Base for a ``ModelChoice``'s per-model inference-default row. Authors
+    subclass with their own fields (steps, guidance, scheduler, prompt
+    dialect, ...). Frozen + typed so a pick's defaults are read as data, and
+    the whole row is manifest-exportable (the catalog/UI can render the
+    effective ``steps: 28`` before submit — a gap ``Optional[int] = None``
+    payload fields hide)."""
+
+
+D = TypeVar("D", bound=ModelDefaults)
+
+
+class Model(Generic[D]):
+    """One curated checkpoint row: a stable ``id`` (its wire value + the
+    scheduler's warm-pool key), the structured :class:`ModelRef` it resolves
+    to, and its typed :class:`ModelDefaults`. Optional ``hot`` (keep a warm
+    pool for it) and ``price`` (per-model pricing) hints ride along into the
+    manifest.
+
+    Assign one per :class:`ModelChoice` enum member; the base's ``__new__``
+    unpacks it (``_value_ = id``)."""
+
+    __slots__ = ("id", "ref", "defaults", "hot", "price")
+
+    id: str
+    ref: ModelRef
+    defaults: D
+    hot: bool
+    price: Optional[float]
+
+    def __init__(
+        self,
+        id: str,
+        ref: ModelRef,
+        defaults: D,
+        *,
+        hot: bool = False,
+        price: Optional[float] = None,
+    ) -> None:
+        cid = str(id or "").strip()
+        if not cid:
+            raise ValueError("Model requires a non-empty id")
+        if not isinstance(ref, ModelRef):
+            raise TypeError(
+                f"Model({cid!r}) ref must be a ModelRef (Hub/HF/Civitai/"
+                f"ModelScope), got {type(ref).__name__}"
+            )
+        if not isinstance(defaults, ModelDefaults):
+            raise TypeError(
+                f"Model({cid!r}) defaults must be a ModelDefaults subclass, "
+                f"got {type(defaults).__name__}"
+            )
+        self.id = cid
+        self.ref = ref
+        self.defaults = defaults
+        self.hot = bool(hot)
+        self.price = price
+
+
+class ModelChoice(Generic[D]):
+    """Mixin for a curated model enum. Combine with ``str`` + ``enum.Enum``
+    and parametrize with the endpoint's :class:`ModelDefaults` subclass::
+
+        class SdxlModel(ModelChoice[SdxlDefaults], enum.Enum): ...
+
+    Every member is a :class:`Model` row; the mixin exposes it as typed
+    attributes (``.ref``, ``.defaults``, ``.hot``, ``.price``) and provides
+    :meth:`rows` for discovery introspection. The enum's wire value is the
+    member id, so a payload field typed with the subclass encodes to that
+    string and its JSON schema is a closed ``enum`` (the curated allowlist)."""
+
+    _model_: "Model[D]"
+
+    def __new__(cls, model: "Model[D]") -> "ModelChoice[D]":
+        if not isinstance(model, Model):
+            raise TypeError(
+                f"{cls.__name__} members must be Model(...) rows, got "
+                f"{type(model).__name__}"
+            )
+        obj = object.__new__(cls)
+        obj._value_ = model.id  # type: ignore[attr-defined]
+        obj._model_ = model
+        return obj
+
+    @property
+    def id(self) -> str:
+        return self._model_.id
+
+    @property
+    def ref(self) -> ModelRef:
+        """The structured :class:`ModelRef` this pick resolves to."""
+        return self._model_.ref
+
+    @property
+    def defaults(self) -> D:
+        """This checkpoint's typed per-model inference defaults."""
+        return self._model_.defaults
+
+    @property
+    def hot(self) -> bool:
+        return self._model_.hot
+
+    @property
+    def price(self) -> Optional[float]:
+        return self._model_.price
+
+    @classmethod
+    def rows(cls) -> "tuple[Model[Any], ...]":
+        """Every curated :class:`Model` row, declaration order — the set
+        discovery emits and the scheduler warm-pools over."""
+        return tuple(member._model_ for member in cls.__members__.values())  # type: ignore[attr-defined]
+
+
+def is_model_choice(t: Any) -> bool:
+    """True when ``t`` is a concrete :class:`ModelChoice` enum subclass."""
+    return isinstance(t, type) and issubclass(t, ModelChoice) and issubclass(t, enum.Enum)
+
+
+__all__ = ["Model", "ModelChoice", "ModelDefaults", "ModelRef"]

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -213,17 +213,6 @@ class _SelectedFunction:
         self.variant_of = variant_of
 
 
-def _variant_names(cls: Optional[type]) -> set:
-    """Declared variant names in their ROUTED (slugified) form — the registry
-    slugifies fn_name, so raw declaration names ("generate_fp8") never match
-    es.name ("generate-fp8") and every variant row would lose its variant_of
-    marker (--variant auto then silently ran the base binding; gw#415 live)."""
-    from gen_worker.discovery.names import slugify_name
-
-    decl = getattr(cls, _ENDPOINT_ATTR, None) if cls is not None else None
-    return {slugify_name(v.name) for v in (getattr(decl, "variants", ()) or ())}
-
-
 def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:
     """Collect every routable function on every @endpoint object in a module
     namespace. Delegates signature inspection to ``gen_worker.registry`` — the
@@ -242,7 +231,6 @@ def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:
             is_generator=es.output_mode == "stream",
             bindings=dict(es.models),
             resources=es.resources,
-            variant_of=es.attr_name if es.name in _variant_names(es.cls) else "",
         )
         for es in collect_from_namespace(mod)
     ]

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -309,6 +309,97 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
     return out
 
 
+def _model_choice_in(ann: Any) -> Tuple[Optional[type], bool]:
+    """Inspect a payload field annotation for a curated ``ModelChoice`` set.
+
+    Returns ``(choice_enum, accepts_byom)``: the ``ModelChoice`` subclass the
+    field is typed with (or ``None``), and whether the field ALSO accepts an
+    arbitrary client-supplied :class:`ModelRef` (``ModelChoice | ModelRef`` =
+    BYOM-open). ``Optional[...]`` (a ``None`` union member) does not imply
+    BYOM."""
+    from gen_worker.api.binding import ModelRef
+    from gen_worker.api.model import is_model_choice
+
+    origin = typing.get_origin(ann)
+    if origin in (typing.Union, py_types.UnionType):
+        args = typing.get_args(ann)
+    else:
+        args = (ann,)
+    choice: Optional[type] = None
+    byom = False
+    for arg in args:
+        if is_model_choice(arg):
+            if choice is not None and choice is not arg:
+                raise ValueError(
+                    "a payload field may reference only one ModelChoice set"
+                )
+            choice = arg
+        elif arg is ModelRef:
+            byom = True
+    return choice, byom
+
+
+def _collect_model_placement_key(
+    payload_type: type, models: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """The handler's checkpoint placement key (pgw#509), or ``None``.
+
+    Scans the payload's top-level fields for one typed with a ``ModelChoice``
+    subclass and emits the curated set — each choice's structured
+    :class:`ModelRef` binding, typed per-model defaults, and optional
+    ``hot``/``price`` hints — plus whether the field accepts BYOM and which
+    ``models=`` slot the pick swaps into. This is the SDK->tensorhub contract
+    (th#761): the scheduler warm-pools per ``choices[].binding`` ref; the
+    catalog/UI renders ``choices[].defaults``."""
+    try:
+        hints = typing.get_type_hints(payload_type)
+    except Exception:
+        hints = getattr(payload_type, "__annotations__", {}) or {}
+
+    field_name: Optional[str] = None
+    choice_enum: Optional[type] = None
+    byom = False
+    for name in getattr(payload_type, "__struct_fields__", ()) or ():
+        if name not in hints:
+            continue
+        found, field_byom = _model_choice_in(hints[name])
+        if found is None:
+            continue
+        if choice_enum is not None:
+            raise ValueError(
+                f"{payload_type.__name__}: multiple ModelChoice fields "
+                f"({field_name!r}, {name!r}); a handler has one placement key"
+            )
+        field_name, choice_enum, byom = name, found, field_byom
+
+    if choice_enum is None or field_name is None:
+        return None
+
+    # The pick swaps the primary (first-declared) model slot.
+    slot = next(iter(models), "")
+    choices: List[Dict[str, Any]] = []
+    for row in choice_enum.rows():  # type: ignore[attr-defined]
+        entry: Dict[str, Any] = {
+            "id": row.id,
+            "binding": _binding_to_manifest(row.ref, slot),
+            "defaults": msgspec.to_builtins(row.defaults),
+        }
+        if row.hot:
+            entry["hot"] = True
+        if row.price is not None:
+            entry["price"] = row.price
+        choices.append(entry)
+    if not choices:
+        raise ValueError(
+            f"{payload_type.__name__}.{field_name}: ModelChoice "
+            f"{choice_enum.__name__} declares no models"
+        )
+    block: Dict[str, Any] = {"field": field_name, "byom": byom, "choices": choices}
+    if slot:
+        block["slot"] = slot
+    return block
+
+
 def _schema_and_hash(t: type) -> Tuple[Dict[str, Any], str]:
     """Generate JSON schema and SHA256 hash for a msgspec type."""
     schema = msgspec.json.schema(t)
@@ -353,7 +444,7 @@ def _assert_unique_function_names(functions: List[Dict[str, Any]]) -> None:
     raise ValueError(
         "duplicate function name(s) within the endpoint — function names are the "
         "external routing identifiers and must be unique. Rename the handler "
-        "method (or a variants= key):\n" + "\n".join(lines)
+        "method:\n" + "\n".join(lines)
     )
 
 
@@ -388,8 +479,8 @@ def discover_functions(root: Optional[Path] = None, *, main_module: str | None =
     seen: Set[Tuple[str, str, str, str]] = set()
     for f in found:
         for entry in _extract_entries(f.obj, f.walked_module):
-            # name is part of the key: variants= share (module, class,
-            # python_name) with their base function but stamp distinct names.
+            # (module, class, python_name, name) dedups objects re-found under
+            # multiple walked packages; name is one handler per method now.
             key = (
                 entry.get("declared_module", entry.get("module", "")),
                 entry.get("class_name", ""),
@@ -442,6 +533,7 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
 
         input_schema, input_sha = _schema_and_hash(es.payload_type)
         moderation = _collect_payload_moderation_metadata(es.payload_type)
+        model_key = _collect_model_placement_key(es.payload_type, es.models)
         output_type = es.output_type
         if output_type is None:
             raise ValueError(
@@ -485,6 +577,8 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             "is_async": es.is_async,
             "timeout_ms": es.timeout_ms,
         }
+        if model_key is not None:
+            fn["model"] = model_key
         if incremental and es.delta_type is not None:
             fn["delta_type"] = _type_id(es.delta_type)
             fn["delta_schema_sha256"] = delta_sha

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2414,39 +2414,15 @@ class Executor:
 
     # ---- job execution -----------------------------------------------------
 
-    def _routed_slots(self, spec: EndpointSpec, payload: Any) -> List[str]:
-        """Model slots this request needs (gw#479). Classes without route=
-        use every declared slot (single-lane behavior, unchanged)."""
-        if spec.route is None or spec.cls is None:
-            return list(spec.models)
-        try:
-            routed = [str(s) for s in spec.route(payload)]
-        except Exception as exc:
-            raise ValidationError(
-                f"route() for {spec.name} failed: {exc}") from exc
-        unknown = [s for s in routed if s not in spec.models]
-        if unknown or not routed:
-            raise ValidationError(
-                f"route() for {spec.name} returned {routed!r}; declared model "
-                f"slots are {sorted(spec.models)}")
-        return routed
-
     async def _run_job(self, job: _Job, run: pb.RunJob) -> None:
         spec = job.spec
         assert spec is not None
-        # Decode BEFORE pinning: payload-driven routing (gw#479) decides which
-        # lanes this job pins/promotes — pinning an idle lane would block the
-        # make_room swap that promoting the routed lane needs.
         try:
             payload: Any = msgspec.msgpack.decode(run.input_payload, type=spec.payload_type)
         except (msgspec.ValidationError, msgspec.DecodeError) as exc:
             await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
             return
-        try:
-            routed = self._routed_slots(spec, payload)
-        except ValidationError as exc:
-            await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
-            return
+        routed = list(spec.models)
         # Pin this job's model refs for its WHOLE lifetime (gw#409): the gap
         # between ensure_setup's promote and the execution-time pin let a
         # concurrent job's make_room demote a just-promoted pipeline. Refs

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -59,9 +59,6 @@ class EndpointSpec:
     timeout_ms: Optional[int] = None
     runtime: Optional[str] = None
     compile: Optional[Compile] = None  # opt-in torch.compile spec (#384)
-    # Payload-driven slot routing (gw#479): promotes/pins only the slots a
-    # request needs; None = every slot (single-lane classes, functions).
-    route: Optional[Callable[[Any], Any]] = None
     module: str = ""              # declaring module
     walked_module: str = ""       # top-level package the object was found under
 
@@ -71,8 +68,8 @@ class EndpointSpec:
 
     @property
     def instance_key(self) -> Any:
-        """Specs sharing this key share one class instance. Variant specs of
-        the same class differ in their bindings and get separate instances."""
+        """Specs sharing this key share one class instance (same class + same
+        resolved binding set)."""
         return (self.cls, tuple(sorted(self.models.items())))
 
 
@@ -160,14 +157,13 @@ def _spec_for_handler(
         models=dict(models),
         runtime=decl.runtime,
         compile=decl.compile,
-        route=decl.route,
         module=getattr(cls or method, "__module__", "") or "",
         walked_module=walked_module,
     )
 
 
 def extract_specs(obj: Any, *, walked_module: str = "") -> List[EndpointSpec]:
-    """All EndpointSpecs declared by one decorated object (variants expanded)."""
+    """All EndpointSpecs declared by one decorated object (one per handler)."""
     decl: Optional[EndpointDecl] = getattr(obj, ATTR, None)
     if decl is None:
         return []
@@ -190,28 +186,6 @@ def extract_specs(obj: Any, *, walked_module: str = "") -> List[EndpointSpec]:
         getattr(cls, "__gen_worker_handlers__", []) or []
     )
     out: List[EndpointSpec] = []
-
-    if decl.variants:
-        attr_name, method = handlers[0]
-        slot = next(iter(decl.models), "model")
-        # Base function (method-named) only when the class declares its own
-        # binding; otherwise the variants fully define the routable set.
-        if decl.models:
-            out.append(_spec_for_handler(
-                fn_name=attr_name, method=method, decl=decl, cls=cls,
-                attr_name=attr_name, models=dict(decl.models),
-                resources=decl.resources, walked_module=walked,
-            ))
-        for variant in decl.variants:
-            # Variants swap only the primary slot; shared aux slots (vae,
-            # refiner, extra encoders) are inherited from the class binding.
-            out.append(_spec_for_handler(
-                fn_name=variant.name, method=method, decl=decl, cls=cls,
-                attr_name=attr_name, models={**decl.models, slot: variant.binding},
-                resources=variant.resources or decl.resources,
-                walked_module=walked,
-            ))
-        return out
 
     for attr_name, method in handlers:
         out.append(_spec_for_handler(

--- a/tests/test_cli_run_setup_injection.py
+++ b/tests/test_cli_run_setup_injection.py
@@ -82,41 +82,6 @@ def test_map_exception_fatal_sanitizes_secrets():
     assert "abc123" not in msg and msg.startswith("RuntimeError")
 
 
-def test_select_function_base_fn_wins_exact_match_over_variant_attr_matches():
-    # Base fn + variants share one attr name; --method <base> must select the
-    # base spec instead of erroring ambiguous (ie#348).
-    import types
-
-    import msgspec
-
-    from gen_worker import HF, RequestContext, endpoint
-
-    class _In(msgspec.Struct):
-        prompt: str
-
-    class _Out(msgspec.Struct):
-        result: str
-
-    @endpoint(
-        model=HF("o/base", dtype="fp16"),
-        variants={"generate_alt": HF("o/alt")},
-    )
-    class Gen:
-        def setup(self, pipeline: str) -> None: ...
-
-        def generate(self, ctx: RequestContext, data: _In) -> _Out:
-            return _Out(result="")
-
-    mod = types.SimpleNamespace(Gen=Gen)
-    candidates = cli_run._collect_class_methods(mod)
-    assert len(candidates) == 2
-
-    base = cli_run._select_function(candidates, cls_name=None, method_name="generate")
-    assert base.fn_name == "generate"
-    variant = cli_run._select_function(candidates, cls_name=None, method_name="generate_alt")
-    assert variant.fn_name == "generate-alt"
-
-
 def test_map_exception_redacts_presigned_url_but_keeps_context():
     # Presigned-URL download failures used to collapse to "internal error";
     # the message must survive with only the credential material redacted.

--- a/tests/test_content_lanes.py
+++ b/tests/test_content_lanes.py
@@ -25,7 +25,6 @@ from diffusers import AutoencoderKL, DDPMScheduler, DiffusionPipeline, UNet2DMod
 
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
-from gen_worker.api.errors import ValidationError
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.models.cozy_cas import _blake3_file
 from gen_worker.models.residency import Tier
@@ -113,15 +112,11 @@ class _In(msgspec.Struct):
     x: str
 
 
-def _route(payload: "_In"):
-    return ("a",) if payload.x == "a" else ("b",)
-
-
-def _lane_spec(cls: type, models: dict, route=None) -> EndpointSpec:
+def _lane_spec(cls: type, models: dict) -> EndpointSpec:
     return EndpointSpec(
         name="lanes", method=cls.run, kind="inference", payload_type=_In,
         output_mode="single", cls=cls, attr_name="run", models=models,
-        resources=Resources(), route=route,
+        resources=Resources(),
     )
 
 
@@ -282,48 +277,8 @@ def test_share_plan_survives_config_provenance_noise(tmp_path, lane_repos) -> No
     assert "unet" not in plan["a"]                        # weights still gate
 
 
-def test_routed_slots_validation(tmp_path, lane_repos) -> None:
-    repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
-    spec = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
-    ex = _executor([spec], tmp_path, 4 * _GiB, [], repos)
-
-    assert ex._routed_slots(spec, _In(x="a")) == ["a"]
-    assert ex._routed_slots(spec, _In(x="edit")) == ["b"]
-
-    bad = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")},
-        route=lambda p: ("nope",))
-    with pytest.raises(ValidationError):
-        ex._routed_slots(bad, _In(x="a"))
-    empty = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=lambda p: ())
-    with pytest.raises(ValidationError):
-        ex._routed_slots(empty, _In(x="a"))
-    # No route= -> every slot (unchanged single-lane behavior).
-    plain = _lane_spec(_Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
-    assert ex._routed_slots(plain, _In(x="a")) == ["a", "b"]
-
-
-def test_route_decorator_validation() -> None:
-    from gen_worker import Hub, endpoint
-
-    with pytest.raises(ValueError):
-        @endpoint(model=Hub("o/r"), route=lambda p: ("m",))
-        class OneSlot:
-            def setup(self, m: str) -> None: ...
-            def run(self, ctx, payload: _In) -> _In: ...
-
-    @endpoint(models={"a": Hub("o/a"), "b": Hub("o/b")}, route=_route)
-    class TwoSlots:
-        def setup(self, a: str, b: str) -> None: ...
-        def run(self, ctx, payload: _In) -> _In: ...
-
-    assert TwoSlots.__gen_worker_endpoint__.route is _route
-
-
 # --------------------------------------------------------------------------- #
-# Real loads: sharing, accounting, lane swap (CUDA)
+# Real loads: sharing, accounting, lane swap (CUDA)                             #
 # --------------------------------------------------------------------------- #
 
 
@@ -331,8 +286,7 @@ def test_route_decorator_validation() -> None:
 def test_lanes_share_one_vae_instance_and_count_it_once(tmp_path, lane_repos) -> None:
     sent: list = []
     repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
-    spec = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+    spec = _lane_spec(_Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
 
     async def _run() -> None:
         ex = _executor([spec], tmp_path, 4 * _GiB, sent, repos)
@@ -373,7 +327,7 @@ def test_lane_swap_moves_only_the_exclusive_module(tmp_path, lane_repos) -> None
     sent: list = []
     repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
     spec = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
 
     def _dev(module) -> str:
         return next(module.parameters()).device.type
@@ -440,7 +394,7 @@ def test_vacate_releases_shared_holds(tmp_path, lane_repos) -> None:
     sent: list = []
     repos = {"acme/a": lane_repos["a"], "acme/b": lane_repos["b"]}
     spec = _lane_spec(
-        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")}, route=_route)
+        _Lanes, {"a": HF("acme/a"), "b": HF("acme/b")})
 
     async def _run() -> None:
         ex = _executor([spec], tmp_path, 4 * _GiB, sent, repos)

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -4,8 +4,9 @@ One test per distinct behavior:
 
   1. Plain-function endpoint: discovered + dispatched with no class/setup.
   2. Class endpoint: public methods are routable; helpers must be private.
-  3. variants={name: (binding, Resources)} stamps N routable functions with
-     per-variant binding/resources (+ payload 'variant' Literal validation).
+  3. model= placement key: a ModelChoice payload field is a curated closed
+     enum whose picks carry typed defaults; `Choice | ModelRef` opens BYOM;
+     ONE handler stays ONE function (no fan-out).
   4. Optional shutdown/setup; async-generator = streaming.
   5. Resources(vram_gb=..) implies gpu.
   6. msgspec.Meta bounds compile into the discovered endpoint.lock schema.
@@ -16,15 +17,19 @@ One test per distinct behavior:
 
 from __future__ import annotations
 
+import enum
 import logging
 import textwrap
 from pathlib import Path
-from typing import Annotated, AsyncIterator, Literal
+from typing import Annotated, AsyncIterator, Union
 
 import msgspec
 import pytest
 
-from gen_worker import HF, Hub, RequestContext, Resources, endpoint
+from gen_worker import (
+    HF, Hub, Model, ModelChoice, ModelDefaults, ModelRef, RequestContext,
+    Resources, endpoint,
+)
 from gen_worker.registry import collect_from_namespace, extract_specs
 
 
@@ -36,12 +41,14 @@ class _Out(msgspec.Struct):
     result: str
 
 
-class _VarIn(msgspec.Struct):
-    variant: str = "a"
+class _Defaults(ModelDefaults, frozen=True):
+    steps: int
+    guidance: float = 5.0
 
 
-class _VarIn2(msgspec.Struct):
-    variant: Literal["a", "zz"] = "a"
+class _Model(ModelChoice[_Defaults], enum.Enum):
+    SMALL = Model("small", Hub("o/small"), _Defaults(20), hot=True)
+    LARGE = Model("large", HF("o/large"), _Defaults(30, 7.0), price=3.0)
 
 
 # --------------------------------------------------------------------------- #
@@ -143,96 +150,72 @@ def test_model_slot_must_match_setup_param() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 3. variants fan-out                                                           #
+# 3. model= placement key (pgw#509)                                             #
 # --------------------------------------------------------------------------- #
 
 
-def test_variants_stamp_routable_functions_with_per_variant_overrides() -> None:
+class _CuratedIn(msgspec.Struct):
+    prompt: str = ""
+    model: _Model = _Model.SMALL
+
+
+class _ByomIn(msgspec.Struct):
+    prompt: str = ""
+    model: Union[_Model, ModelRef] = _Model.SMALL
+
+
+def test_model_choice_is_a_closed_enum_with_typed_defaults() -> None:
+    # Wire form is the id string; the pick decodes back to a member whose
+    # defaults are read as typed data (no ctx.models string-sniffing).
+    raw = msgspec.msgpack.encode(_CuratedIn(model=_Model.LARGE))
+    assert msgspec.msgpack.decode(raw) == {"prompt": "", "model": "large"}
+    back = msgspec.msgpack.decode(raw, type=_CuratedIn)
+    assert back.model is _Model.LARGE
+    assert back.model.defaults.steps == 30
+    assert back.model.ref.source == "huggingface" and back.model.ref.path == "o/large"
+    assert back.model.hot is False and back.model.price == 3.0
+    # JSON schema is a closed enum — the curated allowlist.
+    schema = msgspec.json.schema(_CuratedIn)
+    assert schema["$defs"]["_Model"]["enum"] == ["large", "small"]
+
+
+def test_model_choice_byom_union_accepts_client_modelref() -> None:
+    # A curated pick and an arbitrary client ModelRef decode through the same
+    # field, distinguished on the wire by JSON type (string vs object).
+    cur = msgspec.json.encode(_ByomIn(model=_Model.SMALL))
+    byo = msgspec.json.encode(
+        _ByomIn(model=ModelRef(source="civitai", path="12345"))
+    )
+    assert msgspec.json.decode(cur, type=_ByomIn).model is _Model.SMALL
+    picked = msgspec.json.decode(byo, type=_ByomIn).model
+    assert isinstance(picked, ModelRef) and picked.path == "12345"
+
+
+def test_one_handler_is_one_function_not_a_fan_out() -> None:
+    # 16 near-identical checkpoints used to be 16 variant functions; now the
+    # class exposes ONE routable `generate` and selection is the payload arg.
     @endpoint(
-        model=HF("o/base", dtype="bf16"),
-        resources=Resources(vram_gb=24),
-        variants={
-            "gen-fp8": (HF("o/base-fp8"), Resources(vram_gb=14)),
-            "gen-nvfp4": HF("o/base-nvfp4"),  # bare binding: class resources
-        },
+        models={"pipeline": Hub("o/base"), "vae": Hub("o/vae")},
+        resources=Resources(vram_gb=12),
     )
     class Gen:
-        def setup(self, model: str) -> None:
-            self.model = model
+        def setup(self, pipeline: object, vae: object) -> None: ...
 
-        def generate(self, ctx: RequestContext, data: _In) -> _Out:
-            return _Out(result="")
+        def generate(self, ctx: RequestContext, data: _CuratedIn) -> _Out:
+            return _Out(result=str(data.model.defaults.steps))
 
-    specs = {s.name: s for s in extract_specs(Gen)}
-    assert sorted(specs) == ["gen-fp8", "gen-nvfp4", "generate"]
-    assert specs["generate"].models["model"].ref == "o/base"
-    assert specs["generate"].resources.vram_gb == 24
-    assert specs["gen-fp8"].models["model"].ref == "o/base-fp8"
-    assert specs["gen-fp8"].resources.vram_gb == 14
-    assert specs["gen-nvfp4"].resources.vram_gb == 24
-    # Variant specs must not share one instance (different weights).
-    assert len({s.instance_key for s in specs.values()}) == 3
+    specs = extract_specs(Gen)
+    assert [s.name for s in specs] == ["generate"]
+    assert list(specs[0].models) == ["pipeline", "vae"]
 
 
-def test_variants_inherit_shared_aux_slots() -> None:
-    @endpoint(
-        models={"pipeline": HF("o/base", dtype="fp16"), "vae": HF("o/vae-fix", dtype="fp16")},
-        variants={"gen-alt": HF("o/alt")},
-    )
-    class Gen:
-        def setup(self, pipeline: str, vae: str) -> None: ...
-
-        def generate(self, ctx: RequestContext, data: _In) -> _Out:
-            return _Out(result="")
-
-    specs = {s.name: s for s in extract_specs(Gen)}
-    # The variant swaps only the primary slot; the aux vae slot is inherited.
-    assert specs["gen-alt"].models["pipeline"].ref == "o/alt"
-    assert specs["gen-alt"].models["vae"].ref == "o/vae-fix"
-    assert specs["generate"].models["pipeline"].ref == "o/base"
-
-
-def test_variants_without_class_model_are_the_full_routable_set() -> None:
-    @endpoint(variants={
-        "small": Hub("o/small"),
-        "large": Hub("o/large"),
-    })
-    class Gen:
-        def setup(self, model: str) -> None:
-            self.model = model
-
-        def generate(self, ctx: RequestContext, data: _In) -> _Out:
-            return _Out(result="")
-
-    assert sorted(s.name for s in extract_specs(Gen)) == ["large", "small"]
-
-
-def test_variants_validation() -> None:
-    with pytest.raises(ValueError, match="exactly\\s+ONE handler"):
-        @endpoint(variants={"a": HF("o/r")})
-        class TwoHandlers:
-            def setup(self, model: str) -> None: ...
-            def f(self, ctx: RequestContext, data: _In) -> _Out: ...
-            def g(self, ctx: RequestContext, data: _In) -> _Out: ...
-
-    with pytest.raises(ValueError, match="duplicate"):
-        @endpoint(variants={" a": HF("o/r"), "a": HF("o/r2")})
-        class DupNames:
-            def setup(self, model: str) -> None: ...
-            def gen(self, ctx: RequestContext, data: _In) -> _Out: ...
-
-    # payload 'variant' field must be Literal-typed with declared members.
-    with pytest.raises(ValueError, match="Literal"):
-        @endpoint(variants={"a": HF("o/r")})
-        class BadLiteral:
-            def setup(self, model: str) -> None: ...
-            def gen(self, ctx: RequestContext, data: _VarIn) -> _Out: ...
-
-    with pytest.raises(ValueError, match="zz"):
-        @endpoint(variants={"a": HF("o/r")})
-        class BadMember:
-            def setup(self, model: str) -> None: ...
-            def gen(self, ctx: RequestContext, data: _VarIn2) -> _Out: ...
+def test_model_row_rejects_non_modelref_and_bad_defaults() -> None:
+    with pytest.raises(TypeError, match="ModelRef"):
+        Model("x", "not-a-ref", _Defaults(10))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="ModelDefaults"):
+        Model("x", Hub("o/r"), object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="non-empty id"):
+        Model("", Hub("o/r"), _Defaults(10))
 
 
 # --------------------------------------------------------------------------- #
@@ -442,39 +425,62 @@ def test_from_scratch_example_uses_publish_contract() -> None:
     assert s.output_type is mod.FromScratchResult
 
 
-def test_manifest_keeps_variant_entries(tmp_pkg: Path) -> None:
-    """variants= rows share (module, class, python_name) with their base
-    function; the manifest dedup must key on the stamped name too."""
+def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
+    """One handler -> one function; a ModelChoice payload field emits the
+    `model` block (field + byom + slot + curated choices carrying structured
+    ModelRef bindings, typed defaults, and hot/price hints) — the pgw#509
+    SDK->tensorhub (th#761) contract."""
     from gen_worker.discovery.discover import discover_functions
 
-    pkg = tmp_pkg / "ep_variants"
+    pkg = tmp_pkg / "ep_model"
     pkg.mkdir()
     (pkg / "__init__.py").write_text("")
     (pkg / "main.py").write_text(textwrap.dedent("""
+        import enum
+        from typing import Union
         import msgspec
-        from gen_worker import HF, RequestContext, Resources, endpoint
+        from gen_worker import (Hub, HF, Model, ModelChoice, ModelDefaults,
+                                ModelRef, RequestContext, Resources, endpoint)
+
+        class D(ModelDefaults, frozen=True):
+            steps: int
+            guidance: float = 5.0
+
+        class M(ModelChoice[D], enum.Enum):
+            WAI = Model("wai", Hub("o/wai", allow_lora=True), D(28, 6.0), hot=True)
+            PONY = Model("pony", HF("o/pony"), D(30), price=2.0)
 
         class In_(msgspec.Struct):
-            x: str = ""
+            prompt: str = ""
+            model: Union[M, ModelRef] = M.WAI
 
         class Out_(msgspec.Struct):
             y: str
 
-        @endpoint(
-            model=HF("o/base", dtype="bf16"),
-            resources=Resources(vram_gb=24),
-            variants={"generate_fp8": (HF("o/base-fp8"), Resources(vram_gb=14))},
-        )
+        @endpoint(models={"pipeline": Hub("o/base"), "vae": Hub("o/vae")},
+                  resources=Resources(vram_gb=12))
         class Gen:
-            def setup(self, model: str) -> None:
-                self.model = model
-
+            def setup(self, pipeline: object, vae: object) -> None: ...
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
                 return Out_(y="ok")
     """))
 
-    fns = discover_functions(tmp_pkg, main_module="ep_variants.main")
-    assert sorted(f["name"] for f in fns) == ["generate", "generate-fp8"]
+    fns = discover_functions(tmp_pkg, main_module="ep_model.main")
+    assert [f["name"] for f in fns] == ["generate"]
+    block = fns[0]["model"]
+    assert block["field"] == "model"
+    assert block["byom"] is True
+    assert block["slot"] == "pipeline"
+    by_id = {c["id"]: c for c in block["choices"]}
+    assert set(by_id) == {"wai", "pony"}
+    assert by_id["wai"]["binding"]["provider"] == "tensorhub"
+    assert by_id["wai"]["binding"]["ref"] == "o/wai"
+    assert by_id["wai"]["binding"]["allow_lora"] is True
+    assert by_id["wai"]["defaults"] == {"steps": 28, "guidance": 6.0}
+    assert by_id["wai"]["hot"] is True
+    assert by_id["pony"]["binding"]["provider"] == "hf"
+    assert by_id["pony"]["price"] == 2.0
+    assert "hot" not in by_id["pony"]      # false hint omitted
 
 
 def test_model_shorthand_skips_server_handle_setup_param() -> None:

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -5,8 +5,9 @@ HTTP server speaking tensorhub's public resolve route (th#560) and downloads
 blobs into the blake3 CAS via the shared cozy_snapshot path — no mocks on the
 unit under test, only a stdlib HTTP server standing in for the hub + R2.
 
-#380: ``select_variant`` policy (SM/library gates, VRAM ladder, base
-fallback), listing fit verdicts, and ``--variant auto`` selection.
+#380: ``select_variant`` policy — the serve-time flavor-fit ladder
+(SM/library gates, VRAM ladder, base fallback). This is the precision-flavor
+ladder (th#546/th#683), unrelated to the removed ``variants=`` decorator.
 """
 
 from __future__ import annotations
@@ -14,19 +15,15 @@ from __future__ import annotations
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
-import msgspec
 import pytest
 from blake3 import blake3
 
 import gen_worker.cli.run as run_mod
-from gen_worker import RequestContext, endpoint
-from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
 from gen_worker.models.hub_client import (
     HubRepoNotFoundError,
-    HubResolveError,
     resolve_repo,
 )
 from gen_worker.models.hub_policy import (
@@ -336,117 +333,3 @@ def test_cpu_box_has_no_routable_gpu_variant():
     fit, _ = variant_fit(Resources(), _CAPS_CPU, 0.0)
     assert fit == "fits"  # CPU-only endpoints still fit
 
-
-# ---------------------------------------------------------------------------
-# #380 CLI surfaces: listing fit verdicts + --variant auto selection
-# ---------------------------------------------------------------------------
-
-class _VIn(msgspec.Struct):
-    prompt: str = ""
-
-
-class _VOut(msgspec.Struct):
-    ok: bool
-
-
-def _variant_module():
-    import types
-
-    mod = types.ModuleType("_test_variants")
-
-    @endpoint(
-        kind="inference",
-        resources=Resources(vram_gb=24),
-        models={"pipeline": HF("org/base")},
-        variants={
-            "gen-fp8": (HF("org/base-fp8"), Resources(vram_gb=14)),
-            "gen-nvfp4": (HF("org/base-nvfp4"), Resources(vram_gb=12, compute_capability=10.0)),
-        },
-    )
-    class Gen:
-        def setup(self, pipeline: object) -> None:
-            pass
-
-        def generate(self, ctx: RequestContext, payload: _VIn) -> _VOut:
-            return _VOut(ok=True)
-
-    mod.Gen = Gen
-    return mod
-
-
-def _patched_hw(monkeypatch, *, sm: int, free_gb: float, libs=()):  # helpers
-    import gen_worker.models.hub_policy as hp
-    import gen_worker.models.memory as mem
-
-    caps = TensorhubWorkerCapabilities(
-        cuda_version="12.8" if sm else "", gpu_sm=sm,
-        torch_version="2.11", installed_libs=list(libs),
-    )
-    monkeypatch.setattr(hp, "detect_worker_capabilities", lambda **_k: caps)
-    monkeypatch.setattr(mem, "get_available_vram_gb", lambda *a, **k: free_gb)
-
-
-def test_listing_carries_fit_and_variant_of(monkeypatch):
-    from gen_worker.cli.listing import build_description
-
-    _patched_hw(monkeypatch, sm=89, free_gb=16.0)
-    mod = _variant_module()
-    candidates = run_mod.discover_candidates(mod)
-    doc = build_description(main_module="_test_variants", candidates=candidates)
-
-    assert doc["detected"]["gpu_sm"] == 89
-    assert doc["detected"]["free_vram_gb"] == 16.0
-    by_name = {f["name"]: f for f in doc["functions"]}
-    assert set(by_name) == {"generate", "gen-fp8", "gen-nvfp4"}
-    # 24 GB > 16 free, but 24 * 0.55 fits -> automatic fp8-storage rung (th#683)
-    assert by_name["generate"]["fit"] == "emergency_fp8"
-    assert "variant_of" not in by_name["generate"]
-    assert by_name["gen-fp8"]["fit"] == "fits"
-    assert by_name["gen-fp8"]["variant_of"] == "generate"
-    assert by_name["gen-nvfp4"]["fit"] == "incompatible"
-    assert by_name["gen-nvfp4"]["resources"]["vram_gb"] == 12.0
-
-
-def test_variant_auto_picks_fp8_on_sm89(monkeypatch):
-    _patched_hw(monkeypatch, sm=89, free_gb=16.0)
-    mod = _variant_module()
-    candidates = run_mod.discover_candidates(mod)
-    picked = run_mod.select_function_with_variant(
-        candidates, cls_name=None, method_name="generate",
-        default_name=None, variant="auto",
-    )
-    assert picked.fn_name == "gen-fp8"
-
-
-def test_variant_auto_base_fallback_below_floor(monkeypatch):
-    # 8 GB free: gen-fp8's 4-bit estimate fits -> emergency rung (gw#420).
-    _patched_hw(monkeypatch, sm=89, free_gb=8.0)
-    mod = _variant_module()
-    candidates = run_mod.discover_candidates(mod)
-    picked = run_mod.select_function_with_variant(
-        candidates, cls_name=None, method_name="generate",
-        default_name=None, variant="auto",
-    )
-    assert picked.fn_name == "gen-fp8"
-    # 5 GB free: no 4-bit estimate fits -> base + offload ladder.
-    _patched_hw(monkeypatch, sm=89, free_gb=5.0)
-    picked = run_mod.select_function_with_variant(
-        candidates, cls_name=None, method_name="generate",
-        default_name=None, variant="auto",
-    )
-    assert picked.fn_name == "generate"
-
-
-def test_variant_by_name_and_unknown(monkeypatch):
-    mod = _variant_module()
-    candidates = run_mod.discover_candidates(mod)
-    picked = run_mod.select_function_with_variant(
-        candidates, cls_name=None, method_name="generate",
-        default_name=None, variant="gen-fp8",
-    )
-    assert picked.fn_name == "gen-fp8"
-    with pytest.raises(run_mod._UsageError, match="available"):
-        run_mod.select_function_with_variant(
-            candidates, cls_name=None, method_name="generate",
-            default_name=None, variant="nope",
-        )

--- a/tests/test_svdq_loading.py
+++ b/tests/test_svdq_loading.py
@@ -413,24 +413,3 @@ def test_build_svdq_flavor_tree_rejects_plain_file(tmp_path: Path) -> None:
     _write_plain_safetensors(plain)
     with pytest.raises(ValueError, match="not a nunchaku"):
         build_svdq_flavor_tree(base, plain, tmp_path / "out")
-
-
-def test_variant_names_are_slugified() -> None:
-    """--variant auto regression (found live in the gw#415 acceptance): the
-    registry routes variants under slugified names, so the variant_of marker
-    must compare slugs, not raw declaration names."""
-    from gen_worker import HF, endpoint
-    from gen_worker.cli.run import _variant_names
-
-    @endpoint(
-        model=HF("acme/base", dtype="bf16"),
-        variants={"generate_svdq_fp4": HF("acme/base-svdq")},
-    )
-    class _Ep:
-        def setup(self, pipeline: str) -> None:
-            pass
-
-        def generate(self, ctx, payload: dict) -> dict:  # type: ignore[no-untyped-def]
-            return {}
-
-    assert _variant_names(_Ep) == {"generate-svdq-fp4"}


### PR DESCRIPTION
## What

The keystone SDK contract change for pgw#509. **HARD CUT, no back-compat.**
`variants=` is deleted; checkpoint selection becomes a runtime `model=` payload
argument that is a first-class placement key.

**Three-boundary rule:** class = memory-sharing unit (weights load once per
instance) · method = wire contract · **arg = checkpoint**. SDXL's 16
near-identical fine-tunes go from 16 routable functions to one `generate(model=)`.

## The `model=` construct (`gen_worker.api.model`)

A curated model set is declared as DATA — a `str`-valued enum whose members are
`Model` rows, each carrying a `ModelRef` binding + typed per-model `ModelDefaults`:

```python
class SdxlDefaults(ModelDefaults, frozen=True):
    scheduler: Literal["euler_a", "dpmpp_2m_karras"]
    steps: int
    guidance: float

class SdxlModel(ModelChoice[SdxlDefaults], enum.Enum):
    WAI  = Model("wai-illustrious",     Hub("tensorhub/wai-illustrious"), SdxlDefaults("euler_a", 28, 6.0), hot=True)
    PONY = Model("cyberrealistic-pony", Hub("tensorhub/cyberrealistic-pony"), SdxlDefaults("dpmpp_2m_karras", 30, 5.0))

class TextToImage(msgspec.Struct):
    prompt: str
    model: SdxlModel = SdxlModel.WAI          # curated-only

def generate(self, ctx, p: TextToImage) -> ImageOutput:
    d = p.model.defaults                      # typed SdxlDefaults, no ctx.models sniffing
```

- Wire form of a pick is its **id string**; JSON schema is a closed `enum` (the curated allowlist).
- `.defaults` is typed via `ModelChoice[D]` (`Generic`) — mypy-clean, no `Any`.
- **BYOM is the field TYPE**: `model: SdxlModel` = curated-only; `model: SdxlModel | ModelRef` = BYOM-open (msgspec decodes string→member, object→`ModelRef`). No `@byom` decorator, no `sources=`; arch compat derived from the loaded pipeline.

## New manifest block (SDK→tensorhub contract, th#761)

One function per handler; each function gains a `model` block:

```jsonc
"model": {
  "field": "model",         // the placement-key payload field
  "byom": true,             // field type accepts an arbitrary ModelRef
  "slot": "pipeline",       // models= slot the pick swaps into
  "choices": [
    { "id": "wai-illustrious",
      "binding": { "provider": "tensorhub", "ref": "...", "allow_lora": true },   // structured ModelRef via _binding_to_manifest
      "defaults": { "scheduler": "euler_a", "steps": 28, "guidance": 6.0 },
      "hot": true },        // price optional; false hints omitted
    ...
  ]
}
```

## Deleted (all dead once variants go)

- `decorators.py`: `variants=`, `Variant`, `_normalize_variants`, `_validate_variant_literal`, `_literal_members`, class-stamping, `route=` + slot validation, `route`/`variants` on `EndpointDecl`.
- `registry.py`: variant expansion in `extract_specs`, `EndpointSpec.route`.
- `executor.py`: `_routed_slots` + route dispatch (`routed = list(spec.models)`) — only that region.
- `cli/run.py`: dead `_variant_names`/`variant_of` computation.

`route=` had **zero** endpoint users (grepped both endpoint repos).

## Verify

- `mypy src/gen_worker` → **0 errors** (blocking gate), 101 files.
- ruff clean on all changed src.
- Full non-integration suite: **887 passed**, 5 pre-existing failures (real-model loads blocked by `GEN_WORKER_FORBID_CPU_OFFLOAD=1` on this box — identical on baseline, confirmed by stash).
- Variant-mechanism tests replaced with `model=`/manifest tests. `hub_policy.select_variant` (the th#546/th#683 flavor-fit ladder, unrelated to the decorator) kept.

## Notes / decisions

- **0.15.0 (breaking).** Endpoints pinned `gen-worker<0.15` keep the old `variants=` surface until they migrate (ie#469).
- Curated rows carry a `ModelRef` (the merged pgw#511 type; `Hub`/`HF`/... are factories over it). Curated + BYOM are the same underlying type — exactly pgw#511's goal.
- **Vestigial, flagged for follow-up:** the CLI `--variant` fit-ladder (`select_function_with_variant`) + its `variants={}` help text now degrade to base selection (no fan-out can feed them). Left intact to avoid colliding with the pgw#515 cli de-fork; recommend removing/repurposing there.
- Runtime CONSUMPTION of `payload.model` (loading the chosen checkpoint into the slot) is intentionally NOT wired here — that is th#761 (scheduler) + a later executor change. This PR is the SDK contract: types + manifest emission.