### PR TITLE
gw#407/gw#479: multi-slot host-RAM admission uses max slot bytes (0.14.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.14.14 (2026-07-12)
+
+- **gw#407 host-RAM admission sizes multi-slot setups by the LARGEST slot,
+  not the sum.** Slots stage sequentially under the load lock and move to
+  VRAM before the next slot loads; summing refused two 28GiB fp8 lanes as
+  "56.2GiB incoming" on a 61GiB-RAM A100 pod that never stages more than
+  one slot at a time (gw#479 J24M run19). Single-slot behavior unchanged;
+  the J17 16-variant case (separate records) unchanged.
+
+
 ## 0.14.13 (2026-07-12)
 
 - **ie#468 rung 2: `apply_block_window_offload` — block-window weight offload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.14.13"
+version = "0.14.14"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1536,14 +1536,21 @@ class Executor:
         incoming bytes plus the floor, fail RETRYABLE instead of thrashing.
 
         Only worker-loaded (pipeline-typed) slots count: tenant-owned and
-        engine-runtime slots do not stage full weight sets in host RAM."""
+        engine-runtime slots do not stage full weight sets in host RAM.
+
+        Multi-slot setups stage SEQUENTIALLY under the load lock — each
+        slot's weights move to VRAM (freeing host RAM) before the next slot
+        loads — so the honest staging requirement is the LARGEST slot, not
+        the sum (gw#479 live: two 28GiB fp8 lanes were refused as "56.2GiB
+        incoming" on a 61GiB host that stages at most 28GiB at once)."""
         slots = self._worker_loaded_slots(spec)
         if not paths or not slots:
             return
         incoming = 0
         for slot, p in paths.items():
             if slot in slots:
-                incoming += await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
+                slot_bytes = await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
+                incoming = max(incoming, slot_bytes)
         if incoming <= 0:
             return
         if await asyncio.to_thread(self.store.residency.make_room_ram, incoming):

--- a/uv.lock
+++ b/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.14.13"
+version = "0.14.14"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
J24M run19: the merged qwen release's two 28GiB fp8 lane snapshots were summed to '56.2GiB incoming' and refused on a 61.3GiB-RAM A100 pod — but _injection_kwargs stages slots SEQUENTIALLY under the load lock and each slot moves to VRAM before the next loads, so peak staging is one slot (28.1GiB; less on later lanes once content-shared components inject). Admission now takes max(slot bytes). Single-slot and the J17 16-variant (separate records) shapes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)