### PR TITLE
cl#27: local-only GGUF rungs — stored #gguf-<qtype> flavors on small-VRAM cards (0.14.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.15.3 (2026-07-12)
+
+- **cl#27: local-only GGUF rungs — an 8GB card serves 12B-class diffusion
+  via stored `#gguf-<qtype>` flavors.** When no native rung fits and the
+  card has no fp4 cores (SM < 100), the local ladder walk
+  (`resolve_local_bindings`) rebinds a bare tensorhub binding to the best
+  stored k-quant flavor (quality-descending, `q8_0` ... `q2_k`) — ahead of
+  the loading layer's emergency-nf4/offload machinery. Fit uses the
+  flavor's REAL size, two bounds per the component policy: fully-resident
+  (gguf denoiser + VAE/overheads + fp8-stored TEs) first, then the
+  TE-offload bound (denoiser resident, TEs streamed — the 9B-on-8GB
+  story); `GEN_WORKER_FORBID_CPU_OFFLOAD` hosts keep only the resident
+  bound. NOT part of the shared
+  Go/Py ladder spec: production resolvers never pick gguf (LOCAL-ONLY
+  invariant); conformance vectors unchanged.
+- **Composed GGUF snapshots** (`models/gguf_local.py`): a gguf flavor
+  checkpoint is denoiser-only (th#611), so the fetch merges the base
+  manifest minus denoiser weights with the gguf — one snapshot dir,
+  blob-dedup'd, ~1/4 of the bf16 denoiser transfer.
+- **GGUF diffusion loading lane** in `load_from_pretrained`: denoiser via
+  `from_single_file(..., quantization_config=GGUFQuantizationConfig)` with
+  explicit `config=` from the base tree (also the diffusers #13001 klein
+  workaround), rest composed via `from_pretrained`; TEs get fp8 storage
+  (never GGUF — transformers dequants to fp32). Offload ladder clamps
+  at `model_offload` for gguf pipes (sequential offload is a known
+  upstream break on gguf params).
+- **`run --list` / `serve --list-functions` surface the pick**: functions
+  whose declared verdict was emergency/offload get `fit="gguf_quant"` +
+  `fit_flavor` + an honest reduced-quality/no-speedup advisory when the
+  ladder would serve gguf (fail-open probe).
+- **`prefetch` now walks the local precision ladder first**, so it pulls
+  the same flavor setup will rebind to (`#fp8`/`#gguf-*`) instead of the
+  bare bf16 artifact.
+
 ## 0.15.2 (2026-07-12)
 
 - **th#763: cold tensorhub refs block-and-serve instead of fataling the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.15.2"
+version = "0.15.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -87,6 +87,61 @@ def detected_capabilities() -> Dict[str, Any]:
     return out
 
 
+def _gguf_probe(
+    binding: Any, caps: Any, free_gb: float,
+) -> Optional[Dict[str, Any]]:
+    """cl#27: would the local ladder serve this function via a stored
+    #gguf-<qtype> flavor? One hub resolve per bare tensorhub binding, only
+    consulted when the declared-Resources verdict already says the function
+    can't run natively. Quiet + fail-open: any miss/failure returns None and
+    the declared verdict stands."""
+    import os
+
+    if os.getenv("GEN_WORKER_NO_PRECISION_LADDER", "").strip() == "1":
+        return None
+    if getattr(binding, "provider", "") != "tensorhub":
+        return None
+    if getattr(binding, "flavor", "") or getattr(binding, "storage_dtype", ""):
+        return None  # author override — never laddered
+    try:
+        from ..api.binding import wire_ref
+        from ..models.hub_client import resolve_repo
+        from ..models.ladder import (
+            gguf_fit_bounds,
+            ladder_model_from_resolved,
+            resolve,
+            resolve_local_gguf,
+        )
+        from ..models.memory import cpu_offload_forbidden
+        from ..models.refs import parse_model_ref
+
+        thref = parse_model_ref(wire_ref(binding)).tensorhub
+        if thref is None or thref.digest:
+            return None
+        model = ladder_model_from_resolved(resolve_repo(thref, timeout=5.0))
+        gpu_sm = int(getattr(caps, "gpu_sm", 0) or 0)
+        native = resolve(
+            model, gpu_sm=gpu_sm, free_vram_gb=free_gb,
+            libs=tuple(getattr(caps, "installed_libs", ()) or ()),
+        )
+        if not native.refusal:
+            return None  # a native rung fits — the ladder never reaches gguf
+        pick = resolve_local_gguf(
+            model, gpu_sm=gpu_sm, free_vram_gb=free_gb,
+            allow_te_offload=not cpu_offload_forbidden())
+        if pick is None:
+            return None
+        row = next((r for r in model.flavors if r.token == pick.flavor), None)
+        est, te_offload = 0.0, False
+        if row is not None:
+            resident, offloaded = gguf_fit_bounds(model, row.size_gb)
+            te_offload = resident > free_gb
+            est = offloaded if te_offload else resident
+        return {"flavor": pick.flavor, "est_gb": est, "te_offload": te_offload}
+    except Exception:
+        return None
+
+
 def function_entries(
     candidates: List["_SelectedFunction"],
     *,
@@ -96,7 +151,13 @@ def function_entries(
     ``serve --list-functions --json``. With ``detected`` (the
     ``detected_capabilities()`` block), each entry carries a ``fit`` verdict
     (``fits | offload | incompatible``) computed from its ``Resources``."""
-    from ..models.hub_policy import TensorhubWorkerCapabilities, variant_fit
+    from ..models.hub_policy import (
+        FIT_EMERGENCY,
+        FIT_EMERGENCY_FP8,
+        FIT_OFFLOAD,
+        TensorhubWorkerCapabilities,
+        variant_fit,
+    )
 
     caps: Optional[TensorhubWorkerCapabilities] = None
     free_gb = 0.0
@@ -153,6 +214,35 @@ def function_entries(
                 entry["advisory"] = plan.warning
             elif plan.reason and not plan.serveable:
                 entry["advisory"] = plan.reason
+            # cl#27: when nothing native fits, the local ladder may serve a
+            # stored #gguf-<qtype> flavor instead of emergency-nf4/offload —
+            # surface the SAME pick the setup-time walk will make.
+            if fit in (FIT_EMERGENCY_FP8, FIT_EMERGENCY, FIT_OFFLOAD):
+                gguf = _gguf_probe(primary, caps, free_gb)
+                if gguf is not None:
+                    from ..models.hub_policy import FIT_GGUF
+                    from ..models.ladder import gguf_qtype
+
+                    qtype = gguf_qtype(gguf["flavor"]) or gguf["flavor"]
+                    entry["fit"] = FIT_GGUF
+                    entry["fit_flavor"] = gguf["flavor"]
+                    resident_note = (
+                        "denoiser resident, TEs offloaded"
+                        if gguf.get("te_offload") else "fully resident"
+                    )
+                    entry["fit_reason"] = (
+                        f"runs via GGUF {qtype} (local-only, reduced quality): "
+                        f"~{gguf['est_gb']:.1f} GB {resident_note}, "
+                        f"{free_gb:.1f} GB free"
+                    )
+                    entry["serveable"] = True
+                    entry["run_mode"] = FIT_GGUF
+                    entry["est_latency_multiplier"] = 1.75
+                    entry["advisory"] = (
+                        "pre-quantized GGUF rung: fit regime only — "
+                        "no compile/TRT speedups, quality below the stored "
+                        "bf16/fp8 flavors"
+                    )
         out.append(entry)
     return out
 

--- a/src/gen_worker/cli/prefetch.py
+++ b/src/gen_worker/cli/prefetch.py
@@ -86,16 +86,24 @@ def _handle_prefetch(args: argparse.Namespace) -> int:
     candidates = _collect_class_methods(mod)
 
     # Collect unique (ref, provider) jobs so a binding shared across
-    # functions/classes is downloaded once.
+    # functions/classes is downloaded once. The th#697 local ladder walk
+    # runs per class first so prefetch pulls the SAME flavor (#fp8 /
+    # #gguf-<qtype>, cl#27) that setup will rebind to — not the bare bf16.
+    from .run import _apply_local_precision_ladder
+
     jobs: Dict[Tuple[str, str], Tuple[str, str, tuple]] = {}
     for c in candidates:
-        for param_name, binding in c.bindings.items():
+        bindings = {
+            k: v for k, v in c.bindings.items() if isinstance(v, BINDING_TYPES)
+        }
+        bindings = _apply_local_precision_ladder(
+            bindings, offline=bool(args.offline), emit=emit)
+        for param_name, binding in bindings.items():
             try:
-                if isinstance(binding, BINDING_TYPES):
-                    ref, provider = _resolve_binding_to_ref(
-                        param_name=param_name, binding=binding)
-                    ap = tuple(getattr(binding, "files", ()) or ())
-                    jobs[(ref, provider)] = (ref, provider, ap)
+                ref, provider = _resolve_binding_to_ref(
+                    param_name=param_name, binding=binding)
+                ap = tuple(getattr(binding, "files", ()) or ())
+                jobs[(ref, provider)] = (ref, provider, ap)
             except Exception as e:
                 sys.stderr.write(f"prefetch: skipping binding {param_name!r}: {e}\n")
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -707,6 +707,14 @@ def _resolve_local_path(
     # cozy_snapshot downloader. TENSORHUB_URL selects the hub; TENSORHUB_TOKEN
     # (optional) unlocks private repos. Offline stays CAS-only.
     if parsed.provider == "tensorhub" and parsed.tensorhub is not None:
+        from ..models.ladder import gguf_qtype
+
+        if gguf_qtype(str(parsed.tensorhub.flavor or "")):
+            # cl#27: a #gguf-<qtype> flavor is denoiser-only — fetch the
+            # composed snapshot (base tree minus denoiser weights + gguf).
+            return _fetch_gguf_snapshot(
+                parsed.tensorhub, cache_dir=cache_dir, emit=emit, offline=offline,
+            )
         if offline:
             # Tag refs: a previous online resolve remembered tag->digest.
             ref_map = _hub_ref_map_path(cache_dir, parsed.tensorhub)
@@ -787,6 +795,40 @@ def _resolve_local_path(
     raise _ModelResolutionError(
         f"unsupported model ref: {ref!r} (provider={provider!r})"
     )
+
+
+def _fetch_gguf_snapshot(
+    thref: Any, *, cache_dir: Path, emit: Callable[[Dict[str, Any]], None],
+    offline: bool,
+) -> str:
+    """cl#27: composed snapshot for a #gguf-<qtype> ref (gguf denoiser + the
+    base tree's non-denoiser components). Offline honors the remembered
+    composed digest like any other tag ref."""
+    if offline:
+        ref_map = _hub_ref_map_path(cache_dir, thref)
+        if ref_map.exists():
+            cached = cache_dir / "snapshots" / ref_map.read_text().strip()
+            if cached.exists():
+                return str(cached)
+        raise _ModelResolutionError(
+            f"--offline: gguf ref {thref.canonical()} not in local CAS "
+            f"({cache_dir}); warm the cache by running without --offline once."
+        )
+    from ..models.gguf_local import fetch_gguf_snapshot
+    from ..models.hub_client import HubResolveError
+
+    try:
+        snap = fetch_gguf_snapshot(thref, cache_dir=cache_dir, emit=emit)
+    except HubResolveError as e:
+        raise _ModelResolutionError(str(e)) from e
+    except _ModelResolutionError:
+        raise
+    except Exception as e:
+        raise _ModelResolutionError(
+            f"failed to download gguf snapshot for {thref.canonical()}: {e}"
+        ) from e
+    _remember_hub_ref(cache_dir, thref, Path(snap).name)
+    return snap
 
 
 def _remember_hub_ref(cache_dir: Path, thref: Any, digest: str) -> None:

--- a/src/gen_worker/models/gguf_local.py
+++ b/src/gen_worker/models/gguf_local.py
@@ -1,0 +1,167 @@
+"""Local-only GGUF composed snapshots (cl#27, GGUF-DESIGN consumption half).
+
+A ``#gguf-<qtype>`` flavor checkpoint is denoiser-only by contract (th#611:
+exactly one ``.gguf`` weight plus sidecars). Serving it needs the base tag's
+OTHER components (encoders/VAE/scheduler/configs) — without paying for the
+base's bf16 denoiser shards, which the gguf replaces. This module resolves
+BOTH manifests, drops the base's denoiser weights, and materializes ONE
+composed snapshot dir through the ordinary CAS downloader (blob-level dedupe
+with any sibling snapshot is automatic). The loading layer detects the
+result via :data:`GGUF_MARKER`.
+
+Production never reaches this path: the orchestrator's resolver refuses
+``#gguf-*`` (gguf_local_only) and HelloAck picks never carry it — the only
+callers are the local CLI resolve paths (run/serve/prefetch).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from .hub_client import WorkerResolvedRepo
+from .ladder import gguf_qtype, is_denoiser_weight_path
+from .refs import TensorhubRef
+
+logger = logging.getLogger(__name__)
+
+# Written into the composed snapshot dir after materialization; the loading
+# layer's lane detection reads it (with a structural fallback for a dir that
+# lost the marker mid-crash).
+GGUF_MARKER = ".cozy-gguf.json"
+
+
+def composed_digest(flavor_digest: str, base_digest: str) -> str:
+    """Snapshot-dir key for one (flavor, base) composition — distinct from
+    both plain digests so a denoiser-only flavor snapshot and a full base
+    snapshot never collide with the composed tree."""
+    return f"{flavor_digest}.gguf.{base_digest[:16]}"
+
+
+def compose_resolved(
+    base: WorkerResolvedRepo, flavor: WorkerResolvedRepo
+) -> Tuple[WorkerResolvedRepo, str]:
+    """Merge the base manifest (minus denoiser weights) with the flavor
+    manifest. Returns ``(composed, gguf_relpath)``."""
+    ggufs = [f for f in flavor.files if f.path.lower().endswith(".gguf")]
+    if len(ggufs) != 1:
+        raise ValueError(
+            f"gguf flavor manifest has {len(ggufs)} .gguf files, want exactly 1 "
+            "(denoiser-only layout contract)"
+        )
+    files = [f for f in base.files if not is_denoiser_weight_path(f.path)]
+    if not any(f.path.strip().lstrip("/") == "model_index.json" for f in files):
+        raise ValueError(
+            "gguf composition needs a diffusers-tree base (no model_index.json "
+            "in the base manifest)"
+        )
+    have = {f.path for f in files}
+    files.extend(f for f in flavor.files if f.path not in have)
+    composed = WorkerResolvedRepo(
+        snapshot_digest=composed_digest(flavor.snapshot_digest, base.snapshot_digest),
+        files=files,
+    )
+    return composed, ggufs[0].path
+
+
+def write_marker(snap_dir: Path, *, flavor: str, gguf_relpath: str) -> None:
+    marker = {
+        "flavor": flavor,
+        "qtype": gguf_qtype(flavor),
+        "gguf_path": gguf_relpath,
+    }
+    (Path(snap_dir) / GGUF_MARKER).write_text(json.dumps(marker), encoding="utf-8")
+
+
+def read_marker(snap_dir: Path) -> Optional[Dict[str, Any]]:
+    p = Path(snap_dir) / GGUF_MARKER
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def fetch_gguf_snapshot(
+    thref: TensorhubRef,
+    *,
+    cache_dir: Path,
+    emit: Callable[[Dict[str, Any]], None],
+    resolve: Optional[Callable[[TensorhubRef], WorkerResolvedRepo]] = None,
+) -> str:
+    """Resolve + download the composed snapshot for a ``#gguf-*`` tensorhub
+    ref. Mirrors ``_fetch_tensorhub_snapshot``'s contract (progress events,
+    one re-resolve retry on presigned-URL expiry); returns the snapshot dir.
+    """
+    import asyncio
+    import time
+
+    from .cozy_snapshot import ensure_snapshot_async
+    from .errors import UrlExpiredError
+
+    if resolve is not None:
+        resolver = resolve
+    else:
+        from .hub_client import resolve_repo
+
+        resolver = resolve_repo
+
+    if not gguf_qtype(str(thref.flavor or "")):
+        raise ValueError(f"not a servable gguf flavor ref: {thref.canonical()!r}")
+    base_ref = dataclasses.replace(thref, flavor=None)
+    canonical = thref.canonical()
+
+    def _resolve_composed() -> Tuple[WorkerResolvedRepo, str]:
+        return compose_resolved(resolver(base_ref), resolver(thref))
+
+    emit({"kind": "model_fetch.started", "ref": canonical, "provider": "tensorhub"})
+    composed, gguf_rel = _resolve_composed()
+
+    snap_dir = Path(cache_dir) / "snapshots" / composed.snapshot_digest
+    if snap_dir.exists():
+        if read_marker(snap_dir) is None:
+            write_marker(snap_dir, flavor=str(thref.flavor), gguf_relpath=gguf_rel)
+        emit({"kind": "model_fetch.completed", "ref": canonical,
+              "provider": "tensorhub", "local_dir": str(snap_dir)})
+        return str(snap_dir)
+
+    last_at = [0.0]
+
+    def _progress(done: int, total: Optional[int]) -> None:
+        now = time.monotonic()
+        if now - last_at[0] < 1.0 and (total is None or done < total):
+            return
+        last_at[0] = now
+        emit({"kind": "model_fetch.progress", "ref": canonical,
+              "provider": "tensorhub", "done_bytes": int(done),
+              "total_bytes": int(total) if total else None})
+
+    async def _download(res: WorkerResolvedRepo) -> Path:
+        return await ensure_snapshot_async(
+            base_dir=Path(cache_dir), ref=thref, resolved=res, progress=_progress,
+        )
+
+    try:
+        snap = asyncio.run(_download(composed))
+    except UrlExpiredError:
+        emit({"kind": "model_fetch.reresolve", "ref": canonical,
+              "provider": "tensorhub", "reason": "url_expired"})
+        composed, gguf_rel = _resolve_composed()
+        snap = asyncio.run(_download(composed))
+    write_marker(snap, flavor=str(thref.flavor), gguf_relpath=gguf_rel)
+    emit({"kind": "model_fetch.completed", "ref": canonical,
+          "provider": "tensorhub", "local_dir": str(snap)})
+    return str(snap)
+
+
+__all__ = [
+    "GGUF_MARKER",
+    "compose_resolved",
+    "composed_digest",
+    "fetch_gguf_snapshot",
+    "read_marker",
+    "write_marker",
+]

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -100,6 +100,11 @@ FIT_SVDQ_FP4 = "svdq_fp4"
 FIT_SVDQ_INT4 = "svdq_int4"
 FIT_EMERGENCY_FP8 = "emergency_fp8"
 FIT_EMERGENCY = "emergency_quant"
+# cl#27: a stored #gguf-<qtype> flavor fits where nothing native does —
+# local-only, reduced quality, no compile/TRT ever. Never produced by
+# variant_fit (declared-Resources math); the listing layer overrides with it
+# after a live ladder probe (ladder.resolve_local_gguf).
+FIT_GGUF = "gguf_quant"
 FIT_OFFLOAD = "offload"
 FIT_INCOMPATIBLE = "incompatible"
 

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -187,6 +187,14 @@ class LadderModel:
     # e.g. latent upsamplers) removes ALL cast rungs (fp8 cast-at-load,
     # emergency nf4); stored flavors and the bf16 base are unaffected.
     castable: bool = True
+    # Local GGUF rungs (cl#27) only — never read by the shared-spec walk:
+    # base-tree bytes OUTSIDE the denoiser (encoders/VAE/... that load
+    # alongside a gguf denoiser), the text-encoder share of those (TEs get
+    # fp8 storage + offload per the component policy — never GGUF), and
+    # whether the base is a composable diffusers tree (model_index.json).
+    non_denoiser_gb: float = 0.0
+    te_gb: float = 0.0
+    diffusers_tree: bool = False
 
 
 @dataclass(frozen=True)
@@ -309,11 +317,108 @@ def resolve(
 
 
 # ---------------------------------------------------------------------------
+# Local-only GGUF rungs (cl#27, the consumption half of GGUF-DESIGN). NOT part
+# of the shared Go/Py ladder spec: production (tensorhub's Go resolver +
+# HelloAck picks) never selects #gguf-* — the only caller is the local walk
+# below, which production never runs. Quadrant: local ∧ no fp4 cores ∧ no
+# native rung fits. A pre-quantized k-quant flavor beats runtime emergency-nf4
+# on startup (no load-time quant), quality (calibrated super-blocks), and
+# transfer (~¼ of bf16) — so it slots BETWEEN the native rungs and the
+# loading layer's nf4/offload machinery.
+# ---------------------------------------------------------------------------
+
+# fp4 cores (Blackwell, SM >= 100): nvfp4/svdq-fp4 strictly dominate GGUF —
+# the GGUF rung must never appear there (GGUF-DESIGN invariant 2).
+FP4_CORES_MIN_SM = 100
+
+# k-quant preference, quality-descending. Only qtypes diffusers' GGUF
+# dequant loads (Q2_K..Q8_0 + legacy); IQ-quants and float ggufs never rungs.
+GGUF_QUALITY_ORDER = (
+    "q8_0", "q6_k", "q5_k_m", "q5_k_s", "q5_1", "q5_0",
+    "q4_k_m", "q4_k_s", "q4_1", "q4_0", "q3_k_m", "q3_k_s", "q2_k",
+)
+
+_DENOISER_DIRS = ("transformer", "unet")
+
+
+def gguf_qtype(flavor: str) -> str:
+    """``gguf-q4_k_m`` -> ``q4_k_m``; "" for anything that is not a
+    ladder-eligible gguf flavor token."""
+    token = str(flavor or "").strip().lower()
+    if not token.startswith("gguf-"):
+        return ""
+    qtype = token[len("gguf-"):]
+    return qtype if qtype in GGUF_QUALITY_ORDER else ""
+
+
+def is_denoiser_weight_path(path: str) -> bool:
+    """True for a manifest path holding denoiser WEIGHTS — the files a GGUF
+    flavor replaces. Everything under transformer/ or unet/ except the
+    config.json the gguf loader still needs."""
+    p = str(path or "").strip().lstrip("/")
+    head, _, rest = p.partition("/")
+    if head not in _DENOISER_DIRS or not rest:
+        return False
+    return rest != "config.json"
+
+
+def is_te_weight_path(path: str) -> bool:
+    """Text-encoder component files (text_encoder/, text_encoder_2/, ...)."""
+    p = str(path or "").strip().lstrip("/")
+    head, _, rest = p.partition("/")
+    return bool(rest) and head.startswith("text_encoder")
+
+
+# TE fp8 storage halves resident text-encoder bytes (fp8-E4M3 at rest,
+# per-layer bf16 upcast via apply_fp8_storage — no fp8 silicon required).
+GGUF_TE_FP8_FACTOR = 0.5
+
+
+def gguf_fit_bounds(model: LadderModel, size_gb: float) -> tuple[float, float]:
+    """(resident_est, te_offload_est) for one gguf flavor of ``size_gb``.
+
+    Component policy: the gguf artifact replaces only the denoiser; VAE &co
+    stay resident at compute dtype; TEs load with fp8 storage (halved) and
+    are the offloadable component when even that doesn't fit."""
+    overhead = max(0.0, model.non_denoiser_gb - model.te_gb)
+    resident = size_gb + overhead + GGUF_TE_FP8_FACTOR * model.te_gb
+    return resident, size_gb + overhead
+
+
+def resolve_local_gguf(
+    model: LadderModel, *, gpu_sm: int, free_vram_gb: float,
+    allow_te_offload: bool = True,
+) -> Optional[Resolution]:
+    """Best stored #gguf-<qtype> flavor that fits, quality-descending — or
+    None. Fit uses the flavor's REAL size, two bounds per flavor: the
+    fully-resident bound (gguf denoiser + overheads + fp8-stored TEs), then
+    — when the host permits CPU offload — the TE-offload bound (how a
+    9B-class model serves on an 8GB card: denoiser resident, TEs streamed).
+    ``allow_te_offload=False`` (GEN_WORKER_FORBID_CPU_OFFLOAD hosts) keeps
+    only the resident bound."""
+    if gpu_sm <= 0 or gpu_sm >= FP4_CORES_MIN_SM:
+        return None
+    if not model.diffusers_tree:
+        return None  # composition needs a base model_index.json tree
+    rows = [(GGUF_QUALITY_ORDER.index(q), r) for r in model.flavors
+            if (q := gguf_qtype(r.token)) and r.size_gb > 0]
+    rows.sort(key=lambda t: (t[0], t[1].token))
+    for _, row in rows:
+        resident, offloaded = gguf_fit_bounds(model, row.size_gb)
+        if resident <= free_vram_gb or (
+            allow_te_offload and offloaded <= free_vram_gb
+        ):
+            return Resolution(flavor=row.token, mode=MODE_NATIVE)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Local (no-orchestrator) resolution — cozy-local's half of th#697. The hub
 # path delivers picks via HelloAck; this walks the SAME ladder against the
 # hub catalog's sibling-flavor rows and rebinds bare tensorhub bindings to
-# the best NATIVE rung. Emergency-nf4 / offload stay the loading layer's
-# fit machinery (gw#389) — a refusal here just keeps the declared binding.
+# the best NATIVE rung — then, when nothing native fits, the local-only GGUF
+# rungs above. Emergency-nf4 / offload stay the loading layer's fit
+# machinery (gw#389) — a refusal here just keeps the declared binding.
 # ---------------------------------------------------------------------------
 
 
@@ -329,9 +434,23 @@ def ladder_model_from_resolved(rr: Any) -> LadderModel:
             size_gb=float(getattr(sib, "size_bytes", 0) or 0) / 1e9,
             placement=placement_from_metadata(getattr(sib, "placement", None)),
         ))
+    non_denoiser = 0
+    te_bytes = 0
+    diffusers_tree = False
+    for f in getattr(rr, "files", None) or ():
+        path = str(getattr(f, "path", "") or "")
+        if path.strip().lstrip("/") == "model_index.json":
+            diffusers_tree = True
+        if not is_denoiser_weight_path(path):
+            non_denoiser += int(getattr(f, "size_bytes", 0) or 0)
+            if is_te_weight_path(path):
+                te_bytes += int(getattr(f, "size_bytes", 0) or 0)
     return LadderModel(
         base_size_gb=float(getattr(rr, "size_bytes", 0) or 0) / 1e9,
         flavors=tuple(rows),
+        non_denoiser_gb=non_denoiser / 1e9,
+        te_gb=te_bytes / 1e9,
+        diffusers_tree=diffusers_tree,
     )
 
 
@@ -370,14 +489,28 @@ def resolve_local_bindings(
         except Exception as exc:  # resolver/network failures fail open
             logger.debug("local ladder: resolve of %s failed (%s); keeping declared", name, exc)
             continue
+        gpu_sm = int(getattr(caps, "gpu_sm", 0) or 0)
         res = resolve(
             model,
-            gpu_sm=int(getattr(caps, "gpu_sm", 0) or 0),
+            gpu_sm=gpu_sm,
             free_vram_gb=free_vram_gb,
             libs=tuple(getattr(caps, "installed_libs", ()) or ()),
             quality_floor=quality_floor,
         )
-        if res.refusal or (not res.flavor and not res.cast):
+        if res.refusal:
+            # No native rung fits — the local-only GGUF rungs (cl#27) sit
+            # between here and the loading layer's nf4/offload machinery.
+            gguf = None
+            if quality_floor == "":
+                from .memory import cpu_offload_forbidden
+
+                gguf = resolve_local_gguf(
+                    model, gpu_sm=gpu_sm, free_vram_gb=free_vram_gb,
+                    allow_te_offload=not cpu_offload_forbidden())
+            if gguf is None:
+                continue
+            res = gguf
+        if not res.flavor and not res.cast:
             continue
         # gw#494: THE single pick-fold (shared with the hub HelloAck path),
         # round-trip guard included — a pick the rebound binding can't
@@ -410,6 +543,9 @@ __all__ = [
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
     "EMERGENCY_NF4_VRAM_FACTOR",
+    "FP4_CORES_MIN_SM",
+    "GGUF_QUALITY_ORDER",
+    "GGUF_TE_FP8_FACTOR",
     "FlavorRow",
     "LadderModel",
     "MODE_EMERGENCY",
@@ -420,8 +556,13 @@ __all__ = [
     "REFUSE_NO_RUNG",
     "Resolution",
     "classify_flavor_token",
+    "gguf_fit_bounds",
+    "gguf_qtype",
+    "is_denoiser_weight_path",
+    "is_te_weight_path",
     "ladder_model_from_resolved",
     "resolve_local_bindings",
+    "resolve_local_gguf",
     "default_placement",
     "placement_for_flavor",
     "placement_from_metadata",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -542,6 +542,83 @@ def block_offload_active(obj: Any) -> bool:
     )
 
 
+def detect_gguf_snapshot(path: Path) -> Optional[tuple[Path, str]]:
+    """cl#27: a composed GGUF snapshot (gguf denoiser + base tree, built by
+    gguf_local.fetch_gguf_snapshot). Returns ``(gguf_file, qtype)`` or None.
+    Marker-first; structural fallback (sole .gguf + model_index.json) covers
+    a dir that lost its marker."""
+    p = Path(path)
+    if not p.is_dir() or not (p / "model_index.json").exists():
+        return None
+    from .gguf_local import read_marker
+    from .ladder import gguf_qtype
+
+    marker = read_marker(p)
+    if marker:
+        gguf = p / str(marker.get("gguf_path") or "")
+        qtype = str(marker.get("qtype") or "")
+        if gguf.is_file() and qtype:
+            return gguf, qtype
+    ggufs = sorted(x for x in p.rglob("*.gguf") if x.is_file())
+    if len(ggufs) == 1:
+        # Best-effort qtype from the filename tail (telemetry only).
+        tail = ggufs[0].stem.replace(".", "-").rsplit("-", 1)[-1].lower()
+        return ggufs[0], gguf_qtype("gguf-" + tail)
+    return None
+
+
+def load_gguf_pipeline(
+    cls: Any, path: Path, gguf_file: Path, *,
+    components: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """The GGUF diffusion lane (GGUF-DESIGN §1): denoiser via
+    ``from_single_file(..., quantization_config=GGUFQuantizationConfig)`` —
+    dequant-on-use, bf16 compute (the platform quantization-policy compute
+    dtype) — composed with the base tree's other components via
+    ``from_pretrained``. The explicit ``config=`` from the base tree is also
+    the diffusers #13001 workaround (klein shape-init bug). Never
+    ``Pipeline.from_pretrained`` on the gguf itself."""
+    import importlib
+
+    import torch
+    from diffusers import GGUFQuantizationConfig
+
+    path = Path(path)
+    index = json.loads((path / "model_index.json").read_text("utf-8"))
+    comp = next((c for c in _FP8_STORAGE_COMPONENTS
+                 if isinstance(index.get(c), list) and len(index[c]) == 2), None)
+    if comp is None:
+        raise ValueError(
+            f"gguf composition: model_index.json in {path} has no "
+            f"transformer/unet component"
+        )
+    module_name, class_name = index[comp]
+    denoiser_cls = getattr(importlib.import_module(str(module_name)), str(class_name))
+    compute = torch.bfloat16
+    denoiser = denoiser_cls.from_single_file(
+        str(gguf_file),
+        config=str(path / comp),
+        quantization_config=GGUFQuantizationConfig(compute_dtype=compute),
+        torch_dtype=compute,
+    )
+    kwargs: Dict[str, Any] = dict(components or {})
+    kwargs[comp] = denoiser
+    logger.info(
+        "gguf lane: %s %s from %s (compute bf16), rest from %s",
+        comp, class_name, gguf_file.name, path,
+    )
+    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    # Component policy (GGUF-DESIGN §1): TEs are never GGUF — on this fit
+    # rung they take fp8 storage (halved resident bytes, bf16 compute), with
+    # the offload ladder as the relief valve beyond that. The gguf-quantized
+    # denoiser must NOT be fp8-cast, so target the TE modules only.
+    for te_name in _FP8_TEXT_ENCODER_COMPONENTS:
+        mod = getattr(pipe, te_name, None)
+        if mod is not None and hasattr(mod, "parameters"):
+            apply_fp8_storage(mod, compute_dtype=compute)
+    return pipe
+
+
 def _single_file_checkpoint(path: Path) -> Optional[Path]:
     """A snapshot that is one loose checkpoint rather than a pretrained layout:
     the path itself when it's a ``.safetensors`` file, or the directory's sole
@@ -853,6 +930,18 @@ def load_from_pretrained(
         if components:
             logger.warning("preloaded components ignored on the svdq lane")
         return load_svdq_pipeline(cls, Path(path), svdq_art)
+    # GGUF composed snapshots (cl#27): self-describing, like svdq. Already
+    # 4-bit/8-bit stored — the adaptive fit rungs and fp8 storage never
+    # apply; the offload ladder caps at model_offload (memory.py clamp).
+    gguf_art = detect_gguf_snapshot(Path(path))
+    if gguf_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        gguf_file, qtype = gguf_art
+        pipe = load_gguf_pipeline(cls, Path(path), gguf_file, components=components)
+        try:
+            pipe._cozy_gguf_quant = qtype or "gguf"
+        except Exception:
+            pass
+        return pipe
     kwargs: Dict[str, Any] = {}
     if components:
         kwargs.update(components)
@@ -938,6 +1027,8 @@ __all__ = [
     "safetensors_file_valid",
     "read_on_disk_quant_config",
     "synthesize_quantization_config",
+    "detect_gguf_snapshot",
+    "load_gguf_pipeline",
     "apply_fp8_storage",
     "apply_block_window_offload",
     "block_offload_active",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -40,6 +40,11 @@ _DEFAULT_MODEL_OFFLOAD_THRESHOLD_GB = 8.0
 _DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB = 6.0
 # Safety margin below free VRAM reserved for activations.
 _DEFAULT_SAFETY_MARGIN_GB = 2.0
+# cl#27: gguf pipes were picked by the ladder's RESIDENT bound; on small
+# cards the general margin above always eats the rung (an 8GB card is never
+# 2GB clear), so residency is honored with this lane margin + the vae_only
+# decode-spike guards instead of falling to CPU offload.
+_GGUF_RESIDENT_MARGIN_GB = 0.5
 # Free headroom beyond the requirement above which "off" beats "vae_only".
 _DEFAULT_OFF_HEADROOM_GB = 8.0
 
@@ -863,6 +868,27 @@ def apply_low_vram_config(
             effective_mode,
         )
         effective_mode = "model_offload"
+    if (
+        mode == "auto"
+        and effective_mode == "model_offload"
+        and getattr(pipeline, "_cozy_gguf_quant", None)
+    ):
+        # cl#27: the ladder picked this rung on its RESIDENT bound. Honor it:
+        # if the measured pipe fits free VRAM with the lane margin, stay
+        # resident under the vae_only guards rather than CPU-offload (which
+        # FORBID hosts turn into a refusal of a fitting model).
+        measured = (
+            model_size_gb if model_size_gb is not None
+            else estimate_pipeline_size_gb(pipeline)
+        )
+        avail_now = get_available_vram_gb()
+        if measured > 0.0 and measured + _GGUF_RESIDENT_MARGIN_GB <= avail_now:
+            log.info(
+                "low_vram: gguf pipeline fits resident (%.2f GB + %.1f margin "
+                "<= %.2f GB free); vae_only instead of model_offload",
+                measured, _GGUF_RESIDENT_MARGIN_GB, avail_now,
+            )
+            effective_mode = "vae_only"
     if effective_mode in _CPU_OFFLOAD_MODES:
         _forbid_cpu_inference(f"CPU-offloaded inference (mode={effective_mode})")
 

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -850,6 +850,19 @@ def apply_low_vram_config(
             pipeline=pipeline, model_size_gb=model_size_gb, peak_vram_gb=peak_vram_gb,
         )
         log.info("low_vram: auto-selected mode=%s", effective_mode)
+    if effective_mode in ("group_offload", "sequential") and getattr(
+        pipeline, "_cozy_gguf_quant", None
+    ):
+        # GGUF-loaded pipelines (cl#27): enable_model_cpu_offload is the
+        # deepest safe rung — sequential offload is a known upstream break
+        # (accelerate KeyError on gguf-quantized params); group offload is
+        # untested with dequant-on-use. Clamp instead of crashing mid-load.
+        log.warning(
+            "low_vram: %s requested on a gguf pipeline; clamping to "
+            "model_offload (deeper rungs break on gguf-quantized params)",
+            effective_mode,
+        )
+        effective_mode = "model_offload"
     if effective_mode in _CPU_OFFLOAD_MODES:
         _forbid_cpu_inference(f"CPU-offloaded inference (mode={effective_mode})")
 

--- a/tests/test_gguf_local.py
+++ b/tests/test_gguf_local.py
@@ -1,0 +1,358 @@
+"""cl#27: local-only GGUF rungs — ladder pick, composed snapshot, loader lane.
+
+Real codepaths, no torch/network: the ladder walk is pure, composition works
+on typed manifests, and detection reads real files on disk.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gen_worker.api.binding import Hub
+from gen_worker.models.gguf_local import (
+    GGUF_MARKER,
+    compose_resolved,
+    composed_digest,
+    read_marker,
+    write_marker,
+)
+from gen_worker.models.hub_client import (
+    WorkerResolvedFlavor,
+    WorkerResolvedRepo,
+    WorkerResolvedRepoFile,
+)
+from gen_worker.models.ladder import (
+    FlavorRow,
+    LadderModel,
+    gguf_fit_bounds,
+    gguf_qtype,
+    is_denoiser_weight_path,
+    is_te_weight_path,
+    ladder_model_from_resolved,
+    resolve_local_bindings,
+    resolve_local_gguf,
+)
+
+GB = 1_000_000_000
+
+
+# ---------------------------------------------------------------------------
+# token + path predicates
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("token,qtype", [
+    ("gguf-q4_k_m", "q4_k_m"),
+    ("gguf-q8_0", "q8_0"),
+    ("GGUF-Q8_0", "q8_0"),
+    ("gguf-iq4_xs", ""),  # IQ-quants never load in diffusers
+    ("gguf-bf16", ""),
+    ("gguf", ""),
+    ("fp8", ""),
+    ("", ""),
+])
+def test_gguf_qtype(token: str, qtype: str) -> None:
+    assert gguf_qtype(token) == qtype
+
+
+@pytest.mark.parametrize("path,is_weight", [
+    ("transformer/diffusion_pytorch_model-00001-of-00004.safetensors", True),
+    ("transformer/diffusion_pytorch_model.safetensors.index.json", True),
+    ("unet/diffusion_pytorch_model.safetensors", True),
+    ("transformer/config.json", False),
+    ("text_encoder/model.safetensors", False),
+    ("vae/diffusion_pytorch_model.safetensors", False),
+    ("model_index.json", False),
+    ("transformer", False),
+])
+def test_is_denoiser_weight_path(path: str, is_weight: bool) -> None:
+    assert is_denoiser_weight_path(path) == is_weight
+
+
+# ---------------------------------------------------------------------------
+# the local gguf rung walk
+# ---------------------------------------------------------------------------
+
+def _klein_like(*, non_denoiser_gb: float = 1.2, tree: bool = True) -> LadderModel:
+    return LadderModel(
+        base_size_gb=19.0,
+        flavors=(
+            FlavorRow(token="gguf-q8_0", size_gb=9.8),
+            FlavorRow(token="gguf-q4_k_m", size_gb=5.6),
+        ),
+        non_denoiser_gb=non_denoiser_gb,
+        diffusers_tree=tree,
+    )
+
+
+def test_gguf_pick_quality_descending() -> None:
+    m = _klein_like()
+    # Plenty of room: q8_0 (higher quality) wins.
+    res = resolve_local_gguf(m, gpu_sm=89, free_vram_gb=16.0)
+    assert res is not None and res.flavor == "gguf-q8_0"
+    # 8GB card: q8_0 (9.8 + 1.2) misses, q4_k_m (5.6 + 1.2) fits.
+    res = resolve_local_gguf(m, gpu_sm=89, free_vram_gb=7.4)
+    assert res is not None and res.flavor == "gguf-q4_k_m"
+    # Nothing fits.
+    assert resolve_local_gguf(m, gpu_sm=89, free_vram_gb=4.0) is None
+
+
+def test_gguf_fit_uses_real_size_plus_non_denoiser() -> None:
+    m = _klein_like(non_denoiser_gb=3.0)
+    # q4_k_m needs 5.6 + 3.0 = 8.6 — an 8.0 card refuses it now.
+    assert resolve_local_gguf(m, gpu_sm=89, free_vram_gb=8.0) is None
+    assert resolve_local_gguf(m, gpu_sm=89, free_vram_gb=8.7) is not None
+
+
+def test_blackwell_never_gguf() -> None:
+    # fp4 cores (SM >= 100): nvfp4/svdq-fp4 territory — GGUF never picked.
+    m = _klein_like()
+    for sm in (100, 120, 121):
+        assert resolve_local_gguf(m, gpu_sm=sm, free_vram_gb=16.0) is None
+
+
+def test_gguf_requires_diffusers_tree() -> None:
+    assert resolve_local_gguf(
+        _klein_like(tree=False), gpu_sm=89, free_vram_gb=16.0) is None
+
+
+def _resolved_klein(*, fp8: bool = False) -> WorkerResolvedRepo:
+    files = [
+        WorkerResolvedRepoFile(path="model_index.json", size_bytes=1000, blake3="aa", url="u"),
+        WorkerResolvedRepoFile(
+            path="transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+            size_bytes=9 * GB, blake3="bb", url="u"),
+        WorkerResolvedRepoFile(
+            path="transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+            size_bytes=8 * GB, blake3="cc", url="u"),
+        WorkerResolvedRepoFile(path="transformer/config.json", size_bytes=1000, blake3="dd", url="u"),
+        WorkerResolvedRepoFile(path="text_encoder/model.safetensors", size_bytes=1 * GB, blake3="ee", url="u"),
+        WorkerResolvedRepoFile(path="vae/diffusion_pytorch_model.safetensors", size_bytes=200_000_000, blake3="ff", url="u"),
+    ]
+    sibs = [
+        WorkerResolvedFlavor(flavor="gguf-q8_0", size_bytes=int(9.8 * GB)),
+        WorkerResolvedFlavor(flavor="gguf-q4_k_m", size_bytes=int(5.6 * GB)),
+    ]
+    if fp8:
+        sibs.append(WorkerResolvedFlavor(flavor="fp8", size_bytes=9 * GB))
+    return WorkerResolvedRepo(
+        snapshot_digest="basedigest000", files=files,
+        size_bytes=sum(f.size_bytes for f in files), sibling_flavors=sibs,
+    )
+
+
+def test_ladder_model_from_resolved_computes_non_denoiser() -> None:
+    m = ladder_model_from_resolved(_resolved_klein())
+    assert m.diffusers_tree is True
+    # everything except the two transformer weight shards
+    assert m.non_denoiser_gb == pytest.approx(1.2, abs=0.01)
+    assert m.te_gb == pytest.approx(1.0, abs=0.01)
+    assert {r.token for r in m.flavors} == {"gguf-q8_0", "gguf-q4_k_m"}
+
+
+def test_te_weight_path() -> None:
+    assert is_te_weight_path("text_encoder/model-00001-of-00004.safetensors")
+    assert is_te_weight_path("text_encoder_2/model.safetensors")
+    assert not is_te_weight_path("vae/diffusion_pytorch_model.safetensors")
+    assert not is_te_weight_path("text_encoder")
+
+
+def test_gguf_fit_bounds_klein_shapes() -> None:
+    # Real klein-9b shape: 5.91 gguf, 16.4 TE, ~0.4 other overhead.
+    m = LadderModel(non_denoiser_gb=16.8, te_gb=16.4, diffusers_tree=True,
+                    flavors=(FlavorRow(token="gguf-q4_k_m", size_gb=5.91),))
+    resident, offloaded = gguf_fit_bounds(m, 5.91)
+    assert resident == pytest.approx(5.91 + 0.4 + 8.2, abs=0.01)
+    assert offloaded == pytest.approx(5.91 + 0.4, abs=0.01)
+    # 8GB card: resident bound misses, TE-offload bound serves it — the
+    # 9B-on-8GB story needs the offload relief valve.
+    assert resolve_local_gguf(m, gpu_sm=89, free_vram_gb=7.6) is not None
+    assert resolve_local_gguf(
+        m, gpu_sm=89, free_vram_gb=7.6, allow_te_offload=False) is None
+    # klein-4b shape fits FULLY resident on the same card (TE fp8-halved).
+    m4 = LadderModel(non_denoiser_gb=8.3, te_gb=8.05, diffusers_tree=True,
+                     flavors=(FlavorRow(token="gguf-q4_k_m", size_gb=2.60),))
+    got = resolve_local_gguf(m4, gpu_sm=89, free_vram_gb=7.6,
+                             allow_te_offload=False)
+    assert got is not None and got.flavor == "gguf-q4_k_m" 
+
+
+def _caps(sm: int) -> SimpleNamespace:
+    return SimpleNamespace(gpu_sm=sm, installed_libs=[])
+
+
+def test_local_bindings_rebind_to_gguf_on_8gb() -> None:
+    # sm89, 7.4 GB free: no native rung fits (base 18.2, fp8 cast 13.6) ->
+    # gguf-q4_k_m (5.6 + 1.2) is the pick.
+    out = resolve_local_bindings(
+        {"pipeline": Hub("tensorhub/flux2-klein-9b")},
+        caps=_caps(89), free_vram_gb=7.4,
+        resolver=lambda thref: _resolved_klein(),
+    )
+    assert out["pipeline"].flavor == "gguf-q4_k_m"
+    assert out["pipeline"].storage_dtype == ""
+
+
+def test_local_bindings_prefer_native_fp8_over_gguf() -> None:
+    # A stored #fp8 flavor that fits outranks every gguf rung.
+    out = resolve_local_bindings(
+        {"pipeline": Hub("tensorhub/flux2-klein-9b")},
+        caps=_caps(89), free_vram_gb=10.0,
+        resolver=lambda thref: _resolved_klein(fp8=True),
+    )
+    assert out["pipeline"].flavor == "fp8"
+
+
+def test_local_bindings_no_gguf_on_blackwell() -> None:
+    out = resolve_local_bindings(
+        {"pipeline": Hub("tensorhub/flux2-klein-9b")},
+        caps=_caps(120), free_vram_gb=7.4,
+        resolver=lambda thref: _resolved_klein(),
+    )
+    # nothing fits natively and gguf is refused -> declared binding kept
+    assert out["pipeline"].flavor == ""
+
+
+def test_local_bindings_author_pin_never_laddered() -> None:
+    pinned = Hub("tensorhub/flux2-klein-9b", flavor="fp8")
+    out = resolve_local_bindings(
+        {"pipeline": pinned},
+        caps=_caps(89), free_vram_gb=7.4,
+        resolver=lambda thref: _resolved_klein(),
+    )
+    assert out["pipeline"] is pinned
+
+
+# ---------------------------------------------------------------------------
+# composed snapshot manifest
+# ---------------------------------------------------------------------------
+
+def _flavor_resolved() -> WorkerResolvedRepo:
+    return WorkerResolvedRepo(
+        snapshot_digest="flavordigest111",
+        files=[
+            WorkerResolvedRepoFile(
+                path="flux2-klein-9b-Q4_K_M.gguf",
+                size_bytes=int(5.6 * GB), blake3="99", url="u"),
+            WorkerResolvedRepoFile(path="README.md", size_bytes=10, blake3="98", url="u"),
+        ],
+    )
+
+
+def test_compose_resolved_merges_and_drops_denoiser() -> None:
+    composed, gguf_rel = compose_resolved(_resolved_klein(), _flavor_resolved())
+    paths = {f.path for f in composed.files}
+    assert gguf_rel == "flux2-klein-9b-Q4_K_M.gguf"
+    assert "flux2-klein-9b-Q4_K_M.gguf" in paths
+    assert "model_index.json" in paths
+    assert "transformer/config.json" in paths
+    assert not any(is_denoiser_weight_path(p) for p in paths)
+    assert composed.snapshot_digest == composed_digest("flavordigest111", "basedigest000")
+    assert composed.snapshot_digest not in ("flavordigest111", "basedigest000")
+
+
+def test_compose_resolved_rejects_bad_shapes() -> None:
+    base = _resolved_klein()
+    flavor = _flavor_resolved()
+    two_ggufs = WorkerResolvedRepo(
+        snapshot_digest="x",
+        files=flavor.files + [WorkerResolvedRepoFile(
+            path="second.gguf", size_bytes=1, blake3="97", url="u")],
+    )
+    with pytest.raises(ValueError, match="exactly 1"):
+        compose_resolved(base, two_ggufs)
+    no_index = WorkerResolvedRepo(
+        snapshot_digest="y",
+        files=[f for f in base.files if f.path != "model_index.json"],
+    )
+    with pytest.raises(ValueError, match="model_index"):
+        compose_resolved(no_index, flavor)
+
+
+# ---------------------------------------------------------------------------
+# on-disk detection (marker + structural fallback)
+# ---------------------------------------------------------------------------
+
+def _make_composed_dir(tmp_path: Path, *, marker: bool = True) -> Path:
+    snap = tmp_path / "snap"
+    (snap / "transformer").mkdir(parents=True)
+    (snap / "model_index.json").write_text(json.dumps({
+        "_class_name": "Flux2KleinPipeline",
+        "transformer": ["diffusers", "Flux2Transformer2DModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+    }))
+    (snap / "transformer" / "config.json").write_text("{}")
+    (snap / "flux2-klein-9b-Q4_K_M.gguf").write_bytes(b"GGUF")
+    if marker:
+        write_marker(snap, flavor="gguf-q4_k_m",
+                     gguf_relpath="flux2-klein-9b-Q4_K_M.gguf")
+    return snap
+
+
+def test_marker_roundtrip(tmp_path: Path) -> None:
+    snap = _make_composed_dir(tmp_path)
+    m = read_marker(snap)
+    assert m == {
+        "flavor": "gguf-q4_k_m", "qtype": "q4_k_m",
+        "gguf_path": "flux2-klein-9b-Q4_K_M.gguf",
+    }
+    assert (snap / GGUF_MARKER).exists()
+
+
+def test_detect_gguf_snapshot(tmp_path: Path) -> None:
+    from gen_worker.models.loading import detect_gguf_snapshot
+
+    snap = _make_composed_dir(tmp_path)
+    got = detect_gguf_snapshot(snap)
+    assert got is not None
+    assert got[0].name == "flux2-klein-9b-Q4_K_M.gguf" and got[1] == "q4_k_m"
+
+    # structural fallback: marker lost, sole gguf + model_index still detect
+    (snap / GGUF_MARKER).unlink()
+    got = detect_gguf_snapshot(snap)
+    assert got is not None and got[1] == "q4_k_m"
+
+    # a plain diffusers tree (no gguf) is not the lane
+    (snap / "flux2-klein-9b-Q4_K_M.gguf").unlink()
+    assert detect_gguf_snapshot(snap) is None
+
+
+def test_detect_requires_model_index(tmp_path: Path) -> None:
+    from gen_worker.models.loading import detect_gguf_snapshot
+
+    d = tmp_path / "flavoronly"
+    d.mkdir()
+    (d / "model-Q8_0.gguf").write_bytes(b"GGUF")
+    # a bare denoiser-only flavor snapshot is NOT loadable composition
+    assert detect_gguf_snapshot(d) is None
+
+
+# ---------------------------------------------------------------------------
+# listing probe (fail-open, override only when the ladder would pick gguf)
+# ---------------------------------------------------------------------------
+
+def test_gguf_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gen_worker.cli.listing import _gguf_probe
+    from gen_worker.models import hub_client
+
+    monkeypatch.setattr(hub_client, "resolve_repo",
+                        lambda thref, **kw: _resolved_klein())
+    caps = SimpleNamespace(gpu_sm=89, installed_libs=[])
+    got = _gguf_probe(Hub("tensorhub/flux2-klein-9b"), caps, 7.4)
+    assert got is not None and got["flavor"] == "gguf-q4_k_m"
+    assert got["est_gb"] == pytest.approx(6.3, abs=0.05)
+    assert got["te_offload"] is False
+
+    # Blackwell: never
+    assert _gguf_probe(Hub("tensorhub/flux2-klein-9b"),
+                       SimpleNamespace(gpu_sm=120, installed_libs=[]), 7.4) is None
+    # author-pinned flavor: never
+    assert _gguf_probe(Hub("tensorhub/flux2-klein-9b", flavor="fp8"), caps, 7.4) is None
+    # resolver failure: fail-open
+    def _boom(thref, **kw):
+        raise RuntimeError("down")
+    monkeypatch.setattr(hub_client, "resolve_repo", _boom)
+    assert _gguf_probe(Hub("tensorhub/flux2-klein-9b"), caps, 7.4) is None

--- a/tests/test_no_cpu_inference_veto.py
+++ b/tests/test_no_cpu_inference_veto.py
@@ -37,3 +37,42 @@ def test_offload_allowed_without_veto(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
     result = apply_low_vram_config(_DummyPipeline(), mode="model_offload")
     assert result["mode"] == "model_offload"
+
+
+class _GGUFPipeline:
+    _cozy_gguf_quant = "q4_k_m"
+
+
+def test_gguf_resident_fit_beats_model_offload_under_forbid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # cl#27: ladder picked the rung on its RESIDENT bound; auto placement must
+    # not turn a fitting gguf pipe into a FORBID refusal via the 2GB margin.
+    import gen_worker.models.memory as memory
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 7.3)
+    result = apply_low_vram_config(_GGUFPipeline(), mode="auto", model_size_gb=6.4)
+    assert result["mode"] == "vae_only"
+
+
+def test_gguf_that_truly_does_not_fit_still_refuses_under_forbid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gen_worker.models.memory as memory
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 7.3)
+    with pytest.raises(RuntimeError, match="FORBID_CPU_OFFLOAD"):
+        apply_low_vram_config(_GGUFPipeline(), mode="auto", model_size_gb=7.2)
+
+
+def test_gguf_explicit_model_offload_is_not_overridden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gen_worker.models.memory as memory
+
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 7.3)
+    result = apply_low_vram_config(_GGUFPipeline(), mode="model_offload", model_size_gb=1.0)
+    assert result["mode"] == "model_offload"


### PR DESCRIPTION
The gen-worker half of cl#27 (GGUF revival wave: gw#402 ∥ th#611 → cl#27 → e2e#125).

## What
- **Ladder**: `resolve_local_gguf` — local-only gguf rungs walked ONLY from `resolve_local_bindings` (the cozy-local seam, PR #164) after the native walk refuses. Quality-descending k-quants (`q8_0` … `q2_k`); fit = the flavor's REAL size + the base tree's non-denoiser bytes; refused on fp4-core silicon (SM ≥ 100) and non-diffusers-tree bases. The shared Go/Py `resolve()` spec and conformance vectors are untouched — production resolvers still never pick gguf (`gguf_local_only` stays structural).
- **Composed snapshots** (`models/gguf_local.py`): gguf flavor checkpoints are denoiser-only (th#611 layout contract), so the fetch merges base-manifest-minus-denoiser-weights with the gguf into one snapshot dir (distinct composed digest, blob-level CAS dedupe, `.cozy-gguf.json` marker). ~¼ of the bf16 denoiser transfer.
- **Loader lane** in `load_from_pretrained`: denoiser class from the base `model_index.json`, `from_single_file(gguf, config=<base>/transformer, quantization_config=GGUFQuantizationConfig(bf16))` — the explicit `config=` is also the diffusers #13001 klein shape-init workaround — then `cls.from_pretrained(base, transformer=…)`. Adaptive fp8/nf4 rungs never apply to the lane; the offload ladder clamps at `model_offload` (sequential offload is a known upstream break on gguf params).
- **Surfacing**: `run --list` / `serve --list-functions --json` override emergency/offload verdicts with `fit="gguf_quant"` + `fit_flavor` + honest reduced-quality/no-speedup advisory when the ladder would serve gguf (fail-open probe, one hub resolve).
- **Prefetch** applies the local precision ladder first, so `--prefetch` pulls the flavor setup will actually rebind to (`#fp8`/`#gguf-*`), not the bare bf16.

## Ladder order on an 8GB non-Blackwell card
svdq (if admitted) → stored `#fp8` → fp8 cast → bf16 → **gguf-q8_0 → … → gguf-q4_k_m** → emergency nf4 → offload.

## Tests
31 new (`tests/test_gguf_local.py`): rung ordering/gates (Blackwell-never, diffusers-tree-required, real-size fit math), ladder rebind end-to-end with fake resolver, manifest composition + denoiser exclusion, marker + structural detection, listing probe fail-open. Full suite 968 passed / 17 skipped; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)