### PR TITLE
th#714: C2PA Content Credentials on generated media — sign at the media-finalize seam (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.17.0 (2026-07-12)
+
+- **th#714: C2PA Content Credentials on generated media (EU AI Act Art. 50).**
+  New `gen_worker.content_credentials`: every media asset saved through
+  `RequestContext.save_bytes` / `save_file` (and therefore `save_image` /
+  `save_audio` / `save_video` / `io.write_image` / `io.write_video`) gets a
+  signed C2PA manifest — `c2pa.created` action with digitalSourceType
+  `trainedAlgorithmicMedia`, generator name/version, model refs, and a
+  request-id **hash** (no user PII). Issuer identity comes from the platform
+  signing cert. Signing is ON iff `GEN_WORKER_C2PA_CERT_PATH` +
+  `GEN_WORKER_C2PA_KEY_PATH` are set (PEM chain + PKCS#8 key, new Settings
+  fields incl. `GEN_WORKER_C2PA_ALG` / `GEN_WORKER_C2PA_TA_URL`);
+  unconfigured no-ops with a loud startup warning; configured-but-broken
+  fails worker startup; a per-request sign failure fails the request rather
+  than shipping an unlabeled asset. Non-media payloads (JSON, checkpoints,
+  tensors) pass through untouched via content sniffing. New `signing` extra
+  (c2pa-python, the official CAI c2pa-rs binding); sign+verify round-trip
+  tests (png/webp/jpeg/mp4) run in CI against an openssl-generated test cert.
+
+
 ## 0.16.0 (2026-07-12)
 
 - **pgw#514: dead-surface + protocol-drift sweep (BREAKING, hard cut).**

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -44,6 +44,23 @@ this page covers the worker itself.
 | `TENSORHUB_URL` | `tensorhub_url` | standalone-CLI resolve base URL |
 | `TENSORHUB_CACHE_DIR` / `TENSORHUB_CAS_DIR` | `tensorhub_cache_dir` / `tensorhub_cas_dir` | move cache/CAS off `/tmp` (cozy local persistence); `CAS_DIR` also isolates the `cli/run.py` standalone CLI in tests |
 
+## C2PA Content Credentials (Settings fields, th#714)
+
+Every generated media asset (png/jpeg/webp/gif, mp4/mov, wav/mp3/flac/m4a)
+gets a signed C2PA provenance manifest at `ctx.save_bytes`/`save_file` time --
+the EU AI Act Art. 50 machine-readable AI-marking. ON iff the cert is
+configured; unconfigured logs a loud startup warning and no-ops;
+configured-but-broken refuses to start.
+
+| Env | Field | Notes |
+|---|---|---|
+| `GEN_WORKER_C2PA_CERT_PATH` | `c2pa_cert_path` | PEM signing-cert chain, leaf first (the ON switch) |
+| `GEN_WORKER_C2PA_KEY_PATH` | `c2pa_key_path` | PKCS#8 PEM private key for the leaf |
+| `GEN_WORKER_C2PA_ALG` | `c2pa_alg` | COSE alg matching the cert key (default `es256`) |
+| `GEN_WORKER_C2PA_TA_URL` | `c2pa_ta_url` | optional RFC3161 timestamp-authority URL |
+
+Needs the `signing` extra (`pip install gen-worker[signing]`, c2pa-python).
+
 ## Removed in the pgw#514 dead-config sweep
 
 These used to be Settings fields backed by env vars. No deployment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.16.0"
+version = "0.17.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"
@@ -72,8 +72,14 @@ video = [
     "av>=12",
     "numpy>=1.24",
 ]
+signing = [
+    # C2PA Content Credentials (th#714) — official CAI binding over c2pa-rs.
+    "c2pa-python>=0.36",
+]
 dev = [
     "av>=12",
+    "c2pa-python>=0.36",
+    "Pillow>=10.0",
     # Real tiny-pipeline residency tests (gw#417) build local diffusers pipes;
     # transformers+accelerate activate the bnb nf4 convert integration test.
     "accelerate>=1.9",

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -44,6 +44,10 @@ _ENV_TO_FIELD: Dict[str, str] = {
     "TENSORHUB_CACHE_DIR": "tensorhub_cache_dir",
     "TENSORHUB_CAS_DIR": "tensorhub_cas_dir",
     "CIVITAI_API_KEY": "civitai_api_key",
+    "GEN_WORKER_C2PA_CERT_PATH": "c2pa_cert_path",
+    "GEN_WORKER_C2PA_KEY_PATH": "c2pa_key_path",
+    "GEN_WORKER_C2PA_ALG": "c2pa_alg",
+    "GEN_WORKER_C2PA_TA_URL": "c2pa_ta_url",
 }
 
 # Secondary env names for a field, consulted only when the primary name is

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -84,3 +84,12 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
 
     # Civitai provider credential (CIVITAI_API_KEY, alias CIVITAI_TOKEN).
     civitai_api_key: str = ""
+
+    # C2PA Content Credentials signing (th#714, EU AI Act Art. 50).
+    # Signing is ON iff cert_path is set: every generated media asset gets a
+    # signed provenance manifest at save time (content_credentials.py).
+    # cert_path = PEM chain (leaf first), key_path = PKCS#8 PEM private key.
+    c2pa_cert_path: str = ""  # GEN_WORKER_C2PA_CERT_PATH
+    c2pa_key_path: str = ""   # GEN_WORKER_C2PA_KEY_PATH
+    c2pa_alg: str = "es256"   # GEN_WORKER_C2PA_ALG (COSE alg matching the cert key)
+    c2pa_ta_url: str = ""     # GEN_WORKER_C2PA_TA_URL (optional RFC3161 TSA)

--- a/src/gen_worker/content_credentials.py
+++ b/src/gen_worker/content_credentials.py
@@ -1,0 +1,377 @@
+"""C2PA Content Credentials — sign generated media at the finalize seam (th#714).
+
+EU AI Act Art. 50 (applies 2026-08-02) requires machine-readable marking of
+AI-generated audio/image/video. We embed a signed C2PA manifest (issuer =
+platform signing cert, ``c2pa.created`` action with digitalSourceType
+``trainedAlgorithmicMedia``, model refs, request-id hash — no user PII) into
+every generated media asset as it passes through ``RequestContext.save_bytes``
+/ ``save_file``, i.e. the last point the bytes touch trusted compute before
+upload.
+
+Config (Settings / env):
+- ``GEN_WORKER_C2PA_CERT_PATH`` — PEM signing-cert chain (leaf first, then
+  intermediates/root). Signing is ON iff this is set.
+- ``GEN_WORKER_C2PA_KEY_PATH``  — PKCS#8 PEM private key for the leaf.
+- ``GEN_WORKER_C2PA_ALG``      — COSE alg (default ``es256``).
+- ``GEN_WORKER_C2PA_TA_URL``   — optional RFC3161 timestamp authority URL.
+
+Policy: default-ON when the cert is configured; configured-but-broken fails
+worker startup (never silently ship unlabeled media believing signing is on);
+unconfigured no-ops with a loud startup warning. A sign failure at request
+time raises — the request fails rather than shipping an unlabeled asset.
+
+Uses c2pa-python (official CAI binding over c2pa-rs; ``signing`` extra).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import io
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+_GENERATOR_NAME = "cozy-gen-worker"
+
+# Formats we sign, by content sniff (magic bytes) with an extension fallback
+# for BMFF/audio containers whose sniff needs an offset. Everything else
+# (JSON payloads, checkpoints, tensors, …) passes through untouched.
+_SIGNABLE_MIMES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/gif",
+        "image/avif",
+        "video/mp4",
+        "video/quicktime",
+        "audio/wav",
+        "audio/mpeg",
+        "audio/flac",
+        "audio/mp4",
+    }
+)
+
+_EXT_TO_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+    ".avif": "image/avif",
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".mov": "video/quicktime",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".m4a": "audio/mp4",
+}
+
+
+class C2paSigningError(RuntimeError):
+    """Signing was configured but failed — the asset must not ship unlabeled."""
+
+
+def sniff_media_mime(head: bytes, ref: str) -> Optional[str]:
+    """Return the signable media MIME for content ``head`` + ref extension, or None."""
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head.startswith(b"GIF87a") or head.startswith(b"GIF89a"):
+        return "image/gif"
+    if len(head) >= 12 and head[0:4] == b"RIFF":
+        if head[8:12] == b"WEBP":
+            return "image/webp"
+        if head[8:12] == b"WAVE":
+            return "audio/wav"
+    if head.startswith(b"fLaC"):
+        return "audio/flac"
+    if len(head) >= 12 and head[4:8] == b"ftyp":
+        # BMFF: mp4 / mov / m4a — disambiguate by extension, default mp4.
+        ext_mime = _ext_mime(ref)
+        if ext_mime in ("video/quicktime", "audio/mp4"):
+            return ext_mime
+        return "video/mp4"
+    if head.startswith(b"ID3") or (len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0):
+        # MP3 (ID3 tag or bare frame sync) — only trust with a matching extension.
+        if _ext_mime(ref) == "audio/mpeg":
+            return "audio/mpeg"
+    mime = _ext_mime(ref)
+    return mime if mime in _SIGNABLE_MIMES else None
+
+
+def _ext_mime(ref: str) -> Optional[str]:
+    dot = ref.rfind(".")
+    if dot < 0:
+        return None
+    return _EXT_TO_MIME.get(ref[dot:].lower())
+
+
+@dataclass(frozen=True)
+class _SignerConfig:
+    cert_pem: bytes
+    key_pem: bytes
+    alg: str
+    ta_url: str
+    generator_version: str
+
+
+_lock = threading.Lock()
+_configured = False
+_config: Optional[_SignerConfig] = None
+
+
+def configure(settings: Any) -> None:
+    """Install (or clear) the process-wide signer from Settings.
+
+    Called once at worker startup. Raises when a cert path is set but the
+    material is unusable — a worker that *thinks* it signs but doesn't is a
+    compliance hole, so it must not come up. Logs a loud warning when no
+    cert is configured (signing disabled).
+    """
+    global _configured, _config
+    cert_path = str(getattr(settings, "c2pa_cert_path", "") or "").strip()
+    key_path = str(getattr(settings, "c2pa_key_path", "") or "").strip()
+    with _lock:
+        if not cert_path:
+            _config = None
+            _configured = True
+            logger.warning(
+                "C2PA content-credential signing DISABLED — GEN_WORKER_C2PA_CERT_PATH is not set. "
+                "Generated media will NOT carry Content Credentials "
+                "(EU AI Act Art. 50 machine-readable AI-marking, th#714)."
+            )
+            return
+        if not key_path:
+            raise C2paSigningError(
+                "GEN_WORKER_C2PA_CERT_PATH is set but GEN_WORKER_C2PA_KEY_PATH is not"
+            )
+        try:
+            cert_pem = open(cert_path, "rb").read()
+            key_pem = open(key_path, "rb").read()
+        except OSError as e:
+            raise C2paSigningError(f"cannot read C2PA signing material: {e}") from e
+        cfg = _SignerConfig(
+            cert_pem=cert_pem,
+            key_pem=key_pem,
+            alg=str(getattr(settings, "c2pa_alg", "") or "es256").strip().lower(),
+            ta_url=str(getattr(settings, "c2pa_ta_url", "") or "").strip(),
+            generator_version=_generator_version(),
+        )
+        # Probe: build a signer now so bad PEM / a missing c2pa wheel fails
+        # startup, not the first request.
+        _build_signer(cfg)
+        _config = cfg
+        _configured = True
+        logger.info(
+            "C2PA content-credential signing ENABLED (alg=%s, cert=%s)", cfg.alg, cert_path
+        )
+
+
+def enabled() -> bool:
+    return _active_config() is not None
+
+
+def sign_media_bytes(
+    data: bytes,
+    *,
+    ref: str,
+    request_id: str = "",
+    models: Iterable[str] = (),
+) -> bytes:
+    """Sign ``data`` in memory if it is signable media and signing is enabled.
+
+    Returns the signed bytes, or ``data`` unchanged when signing is disabled
+    or the payload is not a signable media format. Raises
+    :class:`C2paSigningError` when signing is enabled but fails.
+    """
+    cfg = _active_config()
+    if cfg is None:
+        return data
+    mime = sniff_media_mime(data[:16], ref)
+    if mime is None:
+        return data
+    dst = io.BytesIO()
+    _sign_stream(cfg, mime, io.BytesIO(data), dst, request_id=request_id, models=models)
+    return dst.getvalue()
+
+
+def sign_media_file(
+    src_path: str,
+    *,
+    ref: str,
+    request_id: str = "",
+    models: Iterable[str] = (),
+) -> Optional[str]:
+    """Sign the media file at ``src_path`` into a NamedTemporaryFile.
+
+    Returns the signed temp-file path (caller owns cleanup), or None when
+    signing is disabled or the file is not a signable media format. The
+    source file is never mutated. Raises :class:`C2paSigningError` when
+    signing is enabled but fails.
+    """
+    cfg = _active_config()
+    if cfg is None:
+        return None
+    with open(src_path, "rb") as f:
+        head = f.read(16)
+    mime = sniff_media_mime(head, ref)
+    if mime is None:
+        return None
+    import os
+    import tempfile
+
+    suffix = os.path.splitext(str(src_path))[1] or ".bin"
+    fd, out_path = tempfile.mkstemp(suffix=suffix, prefix="c2pa-")
+    try:
+        with open(src_path, "rb") as src, os.fdopen(fd, "wb") as dst:
+            _sign_stream(cfg, mime, src, dst, request_id=request_id, models=models)
+    except BaseException:
+        try:
+            os.unlink(out_path)
+        except OSError:
+            pass
+        raise
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# internals
+
+
+def _active_config() -> Optional[_SignerConfig]:
+    global _configured, _config
+    if _configured:
+        return _config
+    # Library-standalone path (no worker bring-up called configure()):
+    # resolve lazily from the cached Settings loader. configure() is
+    # idempotent, so a benign race between threads is fine.
+    try:
+        from .config import get_settings
+
+        settings = get_settings()
+    except Exception:
+        with _lock:
+            _config = None
+            _configured = True
+        return None
+    configure(settings)
+    return _config
+
+
+def _generator_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("gen-worker")
+    except Exception:
+        return "unknown"
+
+
+def _build_signer(cfg: _SignerConfig) -> Any:
+    try:
+        import c2pa
+    except ImportError as e:
+        raise C2paSigningError(
+            "C2PA signing is configured but c2pa-python is not installed. "
+            "Install with `pip install gen-worker[signing]`."
+        ) from e
+    # The wrapper's C2paSignerInfo.__init__ rejects ta_url=None and passes
+    # b"" through as an (invalid) empty TSA URL, so build the ctypes struct
+    # directly to get a NULL ta_url when no TSA is configured.
+    info = c2pa.C2paSignerInfo.__new__(c2pa.C2paSignerInfo)
+    ctypes.Structure.__init__(
+        info,
+        cfg.alg.encode(),
+        cfg.cert_pem,
+        cfg.key_pem,
+        cfg.ta_url.encode() if cfg.ta_url else None,
+    )
+    try:
+        return c2pa.Signer.from_info(info)
+    except Exception as e:
+        raise C2paSigningError(f"cannot build C2PA signer: {e}") from e
+
+
+def _manifest_json(cfg: _SignerConfig, request_id: str, models: Iterable[str]) -> str:
+    generator = {"name": _GENERATOR_NAME, "version": cfg.generator_version}
+    cozy: dict[str, Any] = {}
+    if request_id:
+        # Hash, not the raw id: links back to platform records without
+        # exposing request identifiers (and never user PII) in public files.
+        cozy["request_sha256"] = hashlib.sha256(request_id.encode()).hexdigest()
+    model_refs = sorted({str(m) for m in models if str(m).strip()})
+    if model_refs:
+        cozy["models"] = model_refs
+    manifest: dict[str, Any] = {
+        "claim_generator_info": [generator],
+        "assertions": [
+            {
+                "label": "c2pa.actions",
+                "data": {
+                    "actions": [
+                        {
+                            "action": "c2pa.created",
+                            "digitalSourceType": (
+                                "http://cv.iptc.org/newscodes/digitalsourcetype/"
+                                "trainedAlgorithmicMedia"
+                            ),
+                            "softwareAgent": generator,
+                        }
+                    ]
+                },
+            }
+        ],
+    }
+    if cozy:
+        manifest["assertions"].append({"label": "com.cozy.generation", "data": cozy})
+    return json.dumps(manifest, separators=(",", ":"))
+
+
+def _sign_stream(
+    cfg: _SignerConfig,
+    mime: str,
+    src: Any,
+    dst: Any,
+    *,
+    request_id: str,
+    models: Iterable[str],
+) -> None:
+    try:
+        import c2pa
+
+        signer = _build_signer(cfg)
+        settings = c2pa.Settings()
+        # Claim thumbnails add tens of KB per asset for no compliance value.
+        settings.update(json.dumps({"builder": {"thumbnail": {"enabled": False}}}))
+        context = c2pa.ContextBuilder().with_settings(settings).with_signer(signer).build()
+        builder = c2pa.Builder(_manifest_json(cfg, request_id, models), context=context)
+        builder.sign(mime, src, dst)
+    except C2paSigningError:
+        raise
+    except Exception as e:
+        raise C2paSigningError(f"C2PA signing failed for {mime}: {e}") from e
+
+
+def _reset_for_tests() -> None:
+    global _configured, _config
+    with _lock:
+        _configured = False
+        _config = None
+
+
+__all__ = [
+    "C2paSigningError",
+    "configure",
+    "enabled",
+    "sign_media_bytes",
+    "sign_media_file",
+    "sniff_media_mime",
+]

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -214,6 +214,18 @@ def _run_main() -> int:
         logger.error("Settings.orchestrator_public_addr is empty (set ORCHESTRATOR_PUBLIC_ADDR env). Refusing to start worker.")
         return 1
 
+    # C2PA content-credential signing (th#714): ON iff a cert is configured;
+    # logs a loud warning when off, refuses to start when configured-but-broken
+    # (a worker that believes it signs but doesn't is a compliance hole).
+    try:
+        from .content_credentials import configure as _c2pa_configure
+
+        _c2pa_configure(settings)
+    except Exception as e:
+        _log_worker_fatal("c2pa_configure", e, exit_code=1)
+        logger.error(str(e))
+        return 1
+
     logger.info("Starting worker...")
     logger.info("  Orchestrator Public Address: %s", settings.orchestrator_public_addr)
     logger.info("  User Function Modules: %s", user_modules)

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -484,6 +484,33 @@ class RequestContext:
     def log(self, message: str, level: str = "info") -> None:
         self._emit_event("request.log", {"message": message, "level": level})
 
+    def _c2pa_manifest_kwargs(self) -> Dict[str, Any]:
+        model_refs = [str(v) for v in (self._models or {}).values()]
+        model_refs += [
+            str(ov.get("ref", ""))
+            for overlays in (self._loras or {}).values()
+            for ov in overlays
+        ]
+        return {"request_id": self._request_id, "models": model_refs}
+
+    def _c2pa_sign_bytes(self, ref: str, data: bytes) -> bytes:
+        """C2PA-sign media payloads at the finalize seam (th#714).
+
+        Returns ``data`` unchanged when signing is unconfigured or the
+        payload is not a signable media format; raises when signing is
+        configured but fails (an unlabeled asset must not ship silently).
+        """
+        from .. import content_credentials
+
+        return content_credentials.sign_media_bytes(data, ref=ref, **self._c2pa_manifest_kwargs())
+
+    def _c2pa_sign_file(self, ref: str, src: str) -> Optional[str]:
+        """File variant of :meth:`_c2pa_sign_bytes` — returns a signed temp
+        path (caller unlinks) or None when signing doesn't apply."""
+        from .. import content_credentials
+
+        return content_credentials.sign_media_file(src, ref=ref, **self._c2pa_manifest_kwargs())
+
     # Inline-bytes threshold: when the client requested
     # `Prefer: bytes=inline` AND the payload is at or below this many
     # bytes, skip the tensorhub upload and return the bytes directly
@@ -495,8 +522,9 @@ class RequestContext:
         if not isinstance(data, (bytes, bytearray)):
             raise TypeError("save_bytes expects bytes")
         data = bytes(data)
-        _enforce_output_file_size_limit(len(data))
         ref = _normalize_output_ref(ref)
+        data = self._c2pa_sign_bytes(ref, data)
+        _enforce_output_file_size_limit(len(data))
 
         local_path = self._resolve_local_output_path(ref)
         if local_path:
@@ -669,6 +697,21 @@ class RequestContext:
         if not os.path.exists(src):
             raise FileNotFoundError(src)
 
+        # C2PA signing (th#714): media files upload as a signed temp copy;
+        # the caller's file is never mutated. No-op unless signing is
+        # configured and the file is a signable media format.
+        signed_tmp = self._c2pa_sign_file(ref, src)
+        if signed_tmp is not None:
+            try:
+                return self._save_file_inner(ref, signed_tmp)
+            finally:
+                try:
+                    os.unlink(signed_tmp)
+                except OSError:
+                    pass
+        return self._save_file_inner(ref, src)
+
+    def _save_file_inner(self, ref: str, src: str) -> Asset:
         size = int(os.path.getsize(src))
         _enforce_output_file_size_limit(size)
 

--- a/tests/test_content_credentials.py
+++ b/tests/test_content_credentials.py
@@ -1,0 +1,235 @@
+"""C2PA content-credential signing at the media-finalize seam (th#714).
+
+Real sign + verify round trips with a self-signed test cert (openssl-generated
+ES256 chain), through the actual production codepaths: RequestContext.save_image
+-> save_bytes (png) and io.write_video -> save_video -> save_file (mp4).
+Verification uses the c2pa library's Reader.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+c2pa = pytest.importorskip("c2pa")
+PIL_Image = pytest.importorskip("PIL.Image")
+
+from gen_worker import RequestContext, content_credentials
+from gen_worker.config import Settings
+
+
+TRAINED_ALGORITHMIC_MEDIA = (
+    "http://cv.iptc.org/newscodes/digitalsourcetype/trainedAlgorithmicMedia"
+)
+
+
+@pytest.fixture(scope="session")
+def test_cert(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    """Self-signed ES256 chain matching the C2PA cert profile (digitalSignature
+    keyUsage + emailProtection EKU), key in PKCS#8."""
+    d = tmp_path_factory.mktemp("c2pa-certs")
+
+    def run(*args: str) -> None:
+        subprocess.run(args, cwd=d, check=True, capture_output=True)
+
+    run("openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", "ca.key")
+    run(
+        "openssl", "req", "-x509", "-new", "-key", "ca.key", "-sha256", "-days", "365",
+        "-subj", "/O=Cozy Test/CN=Cozy Test C2PA Root",
+        "-addext", "basicConstraints=critical,CA:TRUE",
+        "-addext", "keyUsage=critical,keyCertSign,cRLSign",
+        "-out", "ca.pem",
+    )
+    run("openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout", "-out", "leaf.sec1")
+    run("openssl", "pkcs8", "-topk8", "-nocrypt", "-in", "leaf.sec1", "-out", "leaf.key")
+    run(
+        "openssl", "req", "-new", "-key", "leaf.key",
+        "-subj", "/O=Cozy Test/CN=Cozy Test C2PA Signer", "-out", "leaf.csr",
+    )
+    (d / "leaf.ext").write_text(
+        "basicConstraints=critical,CA:FALSE\n"
+        "keyUsage=critical,digitalSignature\n"
+        "extendedKeyUsage=emailProtection\n"
+    )
+    run(
+        "openssl", "x509", "-req", "-in", "leaf.csr", "-CA", "ca.pem", "-CAkey", "ca.key",
+        "-CAcreateserial", "-days", "365", "-sha256", "-extfile", "leaf.ext", "-out", "leaf.pem",
+    )
+    (d / "chain.pem").write_bytes((d / "leaf.pem").read_bytes() + (d / "ca.pem").read_bytes())
+    return {"cert": str(d / "chain.pem"), "key": str(d / "leaf.key")}
+
+
+@pytest.fixture()
+def signing_on(test_cert: dict[str, str]):
+    content_credentials._reset_for_tests()
+    content_credentials.configure(
+        Settings(c2pa_cert_path=test_cert["cert"], c2pa_key_path=test_cert["key"])
+    )
+    yield
+    content_credentials._reset_for_tests()
+
+
+@pytest.fixture()
+def signing_off():
+    content_credentials._reset_for_tests()
+    content_credentials.configure(Settings())
+    yield
+    content_credentials._reset_for_tests()
+
+
+def _ctx(tmp_path: Path, **kw) -> RequestContext:
+    return RequestContext(
+        request_id="req-c2pa-1",
+        local_output_dir=str(tmp_path / "outputs"),
+        models=kw.pop("models", {"main": "ltx-video-cloud:prod"}),
+        **kw,
+    )
+
+
+def _read_manifest(path: str, mime: str) -> dict:
+    with open(path, "rb") as f:
+        reader = c2pa.Reader(mime, f)
+        report = json.loads(reader.json())
+    assert report.get("validation_state") == "Valid"
+    return report["manifests"][report["active_manifest"]]
+
+
+def _actions(active: dict) -> list[dict]:
+    for a in active["assertions"]:
+        if a["label"].startswith("c2pa.actions"):
+            return a["data"]["actions"]
+    raise AssertionError(f"no c2pa.actions assertion in {active['assertions']}")
+
+
+def test_png_sign_verify_roundtrip_via_save_image(tmp_path: Path, signing_on) -> None:
+    ctx = _ctx(tmp_path)
+    img = PIL_Image.new("RGB", (64, 64), (200, 30, 90))
+    asset = ctx.save_image(img, "outputs/img", format="png")
+    assert asset.local_path and asset.local_path.endswith(".png")
+
+    active = _read_manifest(asset.local_path, "image/png")
+    action = _actions(active)[0]
+    assert action["action"] == "c2pa.created"
+    assert action["digitalSourceType"] == TRAINED_ALGORITHMIC_MEDIA
+    assert active["claim_generator_info"][0]["name"] == "cozy-gen-worker"
+    assert active["signature_info"]["issuer"] == "Cozy Test"
+
+    cozy = [a for a in active["assertions"] if a["label"] == "com.cozy.generation"][0]["data"]
+    assert cozy["request_sha256"] == hashlib.sha256(b"req-c2pa-1").hexdigest()
+    assert cozy["models"] == ["ltx-video-cloud:prod"]
+    # No PII / raw identifiers embedded anywhere in the manifest.
+    assert "req-c2pa-1" not in json.dumps(active)
+
+    # Asset metadata reflects the SIGNED bytes.
+    signed = Path(asset.local_path).read_bytes()
+    assert asset.size_bytes == len(signed)
+    assert asset.sha256 == hashlib.sha256(signed).hexdigest()
+
+
+def test_webp_and_jpeg_sign_via_save_image(tmp_path: Path, signing_on) -> None:
+    ctx = _ctx(tmp_path)
+    img = PIL_Image.new("RGB", (32, 32), (5, 5, 5))
+    for fmt, mime in (("webp", "image/webp"), ("jpeg", "image/jpeg")):
+        asset = ctx.save_image(img, f"outputs/img-{fmt}", format=fmt)
+        active = _read_manifest(asset.local_path, mime)
+        assert _actions(active)[0]["digitalSourceType"] == TRAINED_ALGORITHMIC_MEDIA
+
+
+def test_mp4_sign_verify_roundtrip_via_write_video(tmp_path: Path, signing_on) -> None:
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("av")
+    from gen_worker import io as gw_io
+
+    ctx = _ctx(tmp_path)
+    frames = np.zeros((8, 64, 64, 3), dtype=np.uint8)
+    frames[:, 16:48, 16:48] = 200
+    asset = gw_io.write_video(ctx, "outputs/clip", frames, fps=8.0)
+    assert asset.local_path and asset.local_path.endswith(".mp4")
+
+    active = _read_manifest(asset.local_path, "video/mp4")
+    action = _actions(active)[0]
+    assert action["action"] == "c2pa.created"
+    assert action["digitalSourceType"] == TRAINED_ALGORITHMIC_MEDIA
+    cozy = [a for a in active["assertions"] if a["label"] == "com.cozy.generation"][0]["data"]
+    assert cozy["request_sha256"] == hashlib.sha256(b"req-c2pa-1").hexdigest()
+
+
+def test_save_file_signs_media_without_mutating_source(tmp_path: Path, signing_on) -> None:
+    ctx = _ctx(tmp_path)
+    img = PIL_Image.new("RGB", (16, 16), (1, 2, 3))
+    src = tmp_path / "src.png"
+    img.save(src, format="PNG")
+    original = src.read_bytes()
+
+    asset = ctx.save_file("outputs/copy.png", src)
+    assert src.read_bytes() == original  # caller's file untouched
+    active = _read_manifest(asset.local_path, "image/png")
+    assert _actions(active)[0]["digitalSourceType"] == TRAINED_ALGORITHMIC_MEDIA
+
+
+def test_non_media_bytes_pass_through_unsigned(tmp_path: Path, signing_on) -> None:
+    ctx = _ctx(tmp_path)
+    payload = json.dumps({"result": "ok"}).encode()
+    asset = ctx.save_bytes("outputs/result.json", payload)
+    assert Path(asset.local_path).read_bytes() == payload
+
+
+def test_unconfigured_is_noop_with_loud_warning(
+    tmp_path: Path, signing_off, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level("WARNING", logger="gen_worker.content_credentials"):
+        content_credentials._reset_for_tests()
+        content_credentials.configure(Settings())
+    warned = [r for r in caplog.records if "C2PA" in r.getMessage()]
+    assert warned and "DISABLED" in warned[0].getMessage()
+    assert not content_credentials.enabled()
+
+    ctx = _ctx(tmp_path)
+    img = PIL_Image.new("RGB", (16, 16), (0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    asset = ctx.save_bytes("outputs/plain.png", buf.getvalue())
+    # Bytes unchanged, and no embedded manifest.
+    assert Path(asset.local_path).read_bytes() == buf.getvalue()
+    with pytest.raises(Exception):
+        with open(asset.local_path, "rb") as f:
+            reader = c2pa.Reader("image/png", f)
+            assert json.loads(reader.json())["manifests"] == {}
+
+
+def test_configured_but_broken_fails_startup(tmp_path: Path, test_cert) -> None:
+    content_credentials._reset_for_tests()
+    try:
+        with pytest.raises(content_credentials.C2paSigningError):
+            content_credentials.configure(Settings(c2pa_cert_path="/nonexistent/cert.pem",
+                                                   c2pa_key_path="/nonexistent/key.pem"))
+        with pytest.raises(content_credentials.C2paSigningError):
+            content_credentials.configure(Settings(c2pa_cert_path=test_cert["cert"]))
+        # Garbage PEM fails the probe-signer construction.
+        bad = tmp_path / "bad.pem"
+        bad.write_text("not a pem")
+        with pytest.raises(content_credentials.C2paSigningError):
+            content_credentials.configure(
+                Settings(c2pa_cert_path=str(bad), c2pa_key_path=str(bad))
+            )
+    finally:
+        content_credentials._reset_for_tests()
+
+
+def test_sniff_media_mime() -> None:
+    sniff = content_credentials.sniff_media_mime
+    assert sniff(b"\x89PNG\r\n\x1a\n", "x") == "image/png"
+    assert sniff(b"\xff\xd8\xff\xe0" + b"\0" * 12, "x") == "image/jpeg"
+    assert sniff(b"RIFF\0\0\0\0WEBPVP8 ", "x") == "image/webp"
+    assert sniff(b"RIFF\0\0\0\0WAVEfmt ", "x") == "audio/wav"
+    assert sniff(b"\0\0\0\x20ftypisom\0\0\0\0", "clip.mp4") == "video/mp4"
+    assert sniff(b"\0\0\0\x14ftypqt  \0\0\0\0", "clip.mov") == "video/quicktime"
+    assert sniff(b'{"a": 1}', "result.json") is None
+    assert sniff(b"PK\x03\x04" + b"\0" * 12, "archive.zip") is None
+    # safetensors header must never look like media
+    assert sniff((8).to_bytes(8, "little") + b'{"a":"b"}', "model.safetensors") is None

--- a/uv.lock
+++ b/uv.lock
@@ -220,6 +220,29 @@ wheels = [
 ]
 
 [[package]]
+name = "c2pa-python"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pytest" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "toml" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e8/98cd17ec067226df9fee06a5173a940d44ede0f65a3a077feedea56dc3b0/c2pa_python-0.36.0.tar.gz", hash = "sha256:39fc2202fa5bdfef3eeee30d5ee4b9b0f2060974b01d7814eef79b21fd761284", size = 87369, upload-time = "2026-06-22T22:27:45.676Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/35/bc337a6f6d830f3a1d6ad8046e2f3857c34b071bd0f3914ebcf62d289300/c2pa_python-0.36.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:e14c87144064220a69c9c463110c164cb0344e4fdd3bfa6eeb9d1ed12cc5becb", size = 16513615, upload-time = "2026-06-22T22:27:23.887Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/d5743596f073a10e4bac566ddf8b2c579a917605f66dac64d0d348ddb2e7/c2pa_python-0.36.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:e542466982ac737d96cc43d25204885a078eace1be63c358668791463d81c208", size = 14915298, upload-time = "2026-06-22T22:27:26.877Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/83/b6f5a12a6eb87ad97cfadaa5662203c028e1fee737bcd0a1973c9d568576/c2pa_python-0.36.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e45aa43b6bb477e45122572372232185a71012d4bde32250ddf64a1068e8c26f", size = 14559360, upload-time = "2026-06-22T22:27:29.234Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2b/6f1c44fef1d76fd1be54c8c7512b149371a6783e3a229418eeb7e13c4e6e/c2pa_python-0.36.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d9b9b6680490f4cddf08d6f22d91d6e08c178f2a9d07222da6af0fbbba162e99", size = 14743266, upload-time = "2026-06-22T22:27:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/06/27/6f8c4717ff8838a85a8f6d35336f5ee908c39bba2e377345ed83a95828f9/c2pa_python-0.36.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f059696aab2c7bca1a200ec533458cf0f34ba76b19ddf88656fbeee627ac2b12", size = 15437972, upload-time = "2026-06-22T22:27:35.872Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/19/c06540198d0f70bc6339d17727b8c64da274c6c60d24b499864146f0f03d/c2pa_python-0.36.0-py3-none-win_amd64.whl", hash = "sha256:8939fd8e94b444ecb7ba09108dabc4e5dc248db3aa945f8d5f0a2c3b4f6b5775", size = 90044014, upload-time = "2026-06-22T22:27:39.032Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a5/4b723ffd14fad15b247b5e6cc2ba2ca0d5a5c6193a79a2cb3a0e6f4be462/c2pa_python-0.36.0-py3-none-win_arm64.whl", hash = "sha256:eb7a2d2060ca35d0cb9c161ef50353fe4a0dc91d6e9f7ab4a7d45b19ff24f40c", size = 87544549, upload-time = "2026-06-22T22:27:42.744Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +419,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.7"
 source = { registry = "https://pypi.org/simple" }
@@ -506,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },
@@ -533,9 +606,11 @@ datasets = [
 dev = [
     { name = "accelerate" },
     { name = "av" },
+    { name = "c2pa-python" },
     { name = "diffusers" },
     { name = "grpcio-tools" },
     { name = "mypy" },
+    { name = "pillow" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
@@ -545,6 +620,9 @@ dev = [
 ]
 images = [
     { name = "pillow" },
+]
+signing = [
+    { name = "c2pa-python" },
 ]
 torch = [
     { name = "bitsandbytes", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -569,6 +647,8 @@ requires-dist = [
     { name = "bitsandbytes", marker = "(sys_platform == 'linux' and extra == 'torch') or (sys_platform == 'win32' and extra == 'torch')", specifier = ">=0.45.0" },
     { name = "blake3", specifier = ">=1.0.0" },
     { name = "boto3", specifier = ">=1.41.0" },
+    { name = "c2pa-python", marker = "extra == 'dev'", specifier = ">=0.36" },
+    { name = "c2pa-python", marker = "extra == 'signing'", specifier = ">=0.36" },
     { name = "diffusers", marker = "extra == 'dev'", specifier = ">=0.39.0" },
     { name = "gguf", specifier = ">=0.10.0" },
     { name = "grpcio", specifier = ">=1.80.0" },
@@ -578,6 +658,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "numpy", marker = "extra == 'audio'", specifier = ">=1.24" },
     { name = "numpy", marker = "extra == 'video'", specifier = ">=1.24" },
+    { name = "pillow", marker = "extra == 'dev'", specifier = ">=10.0" },
     { name = "pillow", marker = "extra == 'images'", specifier = ">=10.0" },
     { name = "protobuf", specifier = ">=6.30.0" },
     { name = "psutil", specifier = ">=7.0.0" },
@@ -598,7 +679,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.4.20250913" },
 ]
-provides-extras = ["torch", "vision", "datasets", "images", "audio", "video", "dev"]
+provides-extras = ["torch", "vision", "datasets", "images", "audio", "video", "signing", "dev"]
 
 [[package]]
 name = "gguf"
@@ -1830,6 +1911,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tomli-w"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2044,6 +2134,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
EU AI Act Art. 50 (applies 2026-08-02) requires machine-readable marking of AI-generated audio/image/video. This lands the labeling layer in gen-worker.

## What

- New `gen_worker.content_credentials`: C2PA manifest signing via **c2pa-python 0.36** (official CAI binding over c2pa-rs 0.89), new `signing` extra. Wheels: `py3-none-manylinux_2_28_x86_64` — fine for the py3.12 fleet floor and our Ubuntu-based serve images.
- Hooked at the finalize seam — `RequestContext.save_bytes` / `save_file`, the last point output bytes touch trusted compute — so `save_image`/`save_audio`/`save_video`, `io.write_image`, and `io.write_video` (post-encode, as BMFF signing requires) are all covered with two hooks. Content-sniffed: png/jpeg/webp/gif/avif, mp4/mov, wav/mp3/flac/m4a. JSON/checkpoints/tensors pass through untouched.
- Manifest: `c2pa.created` action with digitalSourceType `trainedAlgorithmicMedia`, `claim_generator_info` = cozy-gen-worker/<version>, `com.cozy.generation` assertion with model refs + sha256(request_id) — **no user PII**; issuer identity comes from the signing cert. Claim thumbnails disabled (~30KB/asset saved; fixed overhead ~13KB).
- Config (Settings + env): `GEN_WORKER_C2PA_CERT_PATH` (PEM chain, the ON switch), `GEN_WORKER_C2PA_KEY_PATH` (PKCS#8), `GEN_WORKER_C2PA_ALG` (default es256), `GEN_WORKER_C2PA_TA_URL` (optional RFC3161 TSA).
- Policy: default-ON when cert configured; unconfigured no-ops with a loud startup warning; configured-but-broken **fails worker startup**; a per-request sign failure fails the request rather than silently shipping an unlabeled asset.

## Tests

`tests/test_content_credentials.py` — real sign+verify round trips through production codepaths with an openssl-generated ES256 test chain (C2PA cert profile: digitalSignature + emailProtection EKU), verified with the library Reader (`validation_state == Valid`): png via `save_image`, webp/jpeg, mp4 via `io.write_video`, `save_file` no-mutation, non-media pass-through, missing-cert startup warning, broken-config startup failure, mime sniffing. Full suite: 939 passed / 17 skipped; mypy clean.

## Notes

- c2pa-python wrapper quirk: `ta_url` must be NULL when no TSA is configured (`b""` is treated as a real empty URL and fails) — worked around with a direct ctypes struct build in `_build_signer`.
- Production signing cert (CAI-conformant identity) is Paul's HUMAN_MUST_DO item; everything here runs against the test cert until it lands in Vault.

th#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)