### PR TITLE
gw#490: Resources gains ram_gb + vcpus — per-function host-resource ask (0.17.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.17.3 (2026-07-12)
+
+- **gw#490: host-resource requirements vocabulary.** `Resources()` gains
+  `ram_gb` and `vcpus` — the per-function HOST ask (video-class endpoints:
+  pinned TE park + CPU-heavy encode need ~64 GB / 16 vCPU). Discovery emits
+  them in `endpoint.lock` (same `msgspec.to_builtins` path as `vram_gb`);
+  tensorhub's builder maps them to `min_ram_gb`/`min_vcpus` in the release
+  requirement payload and folds them into pod-creation minimums
+  (`CreatePodRequest.MinMemoryGB`/`MinVCPUCount`, th#740
+  read-back-and-reject). Host asks never imply `gpu=True`.
+
 ## 0.17.2 (2026-07-12)
 
 - **pgw#519: `model.choices[].binding` was missing the `family` stamp.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.17.2"
+version = "0.17.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -47,7 +47,7 @@ RESERVED_METHODS = frozenset({"setup", "warmup", "shutdown"})
 
 class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     """Hardware envelope for one function: ``Resources(gpu, vram_gb,
-    compute_capability, libraries)``.
+    compute_capability, libraries, ram_gb, vcpus)``.
 
     ``vram_gb`` is the recommended minimum CARD size: the total VRAM (GB) of
     the smallest card the function targets — ``vram_gb=24`` means "runs on a
@@ -68,6 +68,12 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     then refuses the CPU-touching rungs (offload / cpu) outright instead of
     serving slowly. The on-GPU rungs (fp8 storage, emergency 4-bit) remain
     available under ``strict_vram``.
+
+    ``ram_gb`` / ``vcpus`` (gw#490) declare the HOST-side ask: minimum host
+    RAM (GB) and vCPU count the pod must be created with. Video-class
+    endpoints need both (pinned TE park + CPU-heavy encode); the hub maps
+    them to provider pod-creation minimums (th#740) and destroys
+    under-allocated pods at create. Host asks do not imply ``gpu=True``.
     """
 
     gpu: bool = False
@@ -75,6 +81,8 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
     compute_capability: float | None = None
     libraries: tuple[str, ...] = ()
     strict_vram: bool = False
+    ram_gb: float | None = None
+    vcpus: int | None = None
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -94,6 +102,16 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
             ))
         if self.vram_gb is not None or self.compute_capability is not None:
             force(self, "gpu", True)
+        if self.ram_gb is not None:
+            r = float(self.ram_gb)
+            if r <= 0:
+                raise ValueError(f"ram_gb must be positive, got {r}")
+            force(self, "ram_gb", r)
+        if self.vcpus is not None:
+            n = int(self.vcpus)
+            if n <= 0:
+                raise ValueError(f"vcpus must be positive, got {n}")
+            force(self, "vcpus", n)
 
 
 class Compile(msgspec.Struct, frozen=True):

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -261,6 +261,19 @@ def test_resources_vram_implies_gpu() -> None:
         Resources(compute_capability=-1)
 
 
+def test_resources_host_ask_gw490() -> None:
+    r = Resources(ram_gb=64, vcpus=16)
+    assert r.ram_gb == 64.0 and r.vcpus == 16
+    assert r.gpu is False  # host asks never imply a GPU
+    raw = msgspec.to_builtins(r)
+    assert raw["ram_gb"] == 64.0 and raw["vcpus"] == 16
+    assert "ram_gb" not in msgspec.to_builtins(Resources())  # omit_defaults
+    with pytest.raises(ValueError):
+        Resources(ram_gb=0)
+    with pytest.raises(ValueError):
+        Resources(vcpus=-2)
+
+
 # --------------------------------------------------------------------------- #
 # 6. msgspec.Meta bounds compile into the discovered schema                     #
 # --------------------------------------------------------------------------- #

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.17.1"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Part of th#762 (round-trip budget) item 3 / gw#476 item 4.

- `Resources()` gains `ram_gb: float | None` and `vcpus: int | None` with positivity validation; neither implies `gpu=True` (host asks are pure pod sizing, never a compute-class axis).
- Discovery emits them automatically (`msgspec.to_builtins`, `omit_defaults`) into `endpoint.lock` — same path as `vram_gb`.
- Hub side (tensorhub th762-roundtrip branch): builder maps `ram_gb`/`vcpus` → `min_ram_gb`/`min_vcpus` in the requirement payload; release resolver folds the per-function max into `Resources.MemoryGB/CPUCores` → `CreatePodRequest.MinMemoryGB/MinVCPUCount` → th#740 read-back-and-reject (already live: `worker_pod_lifecycle.go` destroys under-provisioned pods, `pod_events class=host_resources_insufficient`).
- Tests: `test_resources_host_ask_gw490` (validation + emission + omit-defaults). Full suite 760 passed.

Residual (ie-side): declare `Resources(ram_gb=64, vcpus=16)` on the LTX video endpoints (rides ie#472 or a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)