### PR TITLE
fix(discovery): pgw#519 — stamp family on model.choices[].binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.17.2 (2026-07-12)
+
+- **pgw#519: `model.choices[].binding` was missing the `family` stamp.**
+  `_collect_model_placement_key` (discovery/discover.py) emitted each
+  ModelChoice pick's binding without the `family` that top-level `bindings`
+  blocks get from `Compile(family=...)` — tensorhub's th#586 architecture
+  gate rejects `allow_lora=true` bindings lacking a family, so builder-path
+  deploys of ModelChoice endpoints (sdxl) hard-failed. The stamping logic
+  is now one shared helper (`_stamp_lora_family`) applied identically to
+  both the top-level `bindings` block and every `choices[].binding` row —
+  an allow_lora choice binding with no declared `Compile(family=...)` now
+  raises at discovery time instead of silently shipping unstamped.
+
 ## 0.17.1 (2026-07-12)
 
 - **gw#516: hub-visible finalize.** `StateDelta.finalizing_jobs` (field 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.17.1"
+version = "0.17.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -309,6 +309,23 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
     return out
 
 
+def _stamp_lora_family(binding_manifest: Dict[str, Any], compile_family: str, context: str) -> None:
+    """Stamp an ``allow_lora`` binding manifest with the endpoint's
+    ``Compile(family=...)`` so tensorhub's th#586 architecture gate can
+    police adapter targets (the builder rejects ``allow_lora`` bindings
+    lacking a family). Shared by top-level ``bindings`` blocks and
+    ``model.choices[].binding`` rows (pgw#519) so both surfaces stamp
+    identically."""
+    if not binding_manifest.get("allow_lora"):
+        return
+    if not compile_family:
+        raise ValueError(
+            f"{context}: allow_lora bindings require "
+            "Compile(family=...) on the endpoint"
+        )
+    binding_manifest["family"] = compile_family
+
+
 def _model_choice_in(ann: Any) -> Tuple[Optional[type], bool]:
     """Inspect a payload field annotation for a curated ``ModelChoice`` set.
 
@@ -340,7 +357,7 @@ def _model_choice_in(ann: Any) -> Tuple[Optional[type], bool]:
 
 
 def _collect_model_placement_key(
-    payload_type: type, models: Dict[str, Any]
+    payload_type: type, models: Dict[str, Any], compile_family: str = "", name: str = ""
 ) -> Optional[Dict[str, Any]]:
     """The handler's checkpoint placement key (pgw#509), or ``None``.
 
@@ -350,7 +367,13 @@ def _collect_model_placement_key(
     ``hot``/``price`` hints — plus whether the field accepts BYOM and which
     ``models=`` slot the pick swaps into. This is the SDK->tensorhub contract
     (th#761): the scheduler warm-pools per ``choices[].binding`` ref; the
-    catalog/UI renders ``choices[].defaults``."""
+    catalog/UI renders ``choices[].defaults``.
+
+    ``compile_family`` mirrors the endpoint's ``Compile(family=...)`` onto
+    each ``allow_lora`` choice binding via :func:`_stamp_lora_family` —
+    identically to how top-level ``bindings`` blocks are stamped (pgw#519):
+    tensorhub's th#586 gate rejects ``allow_lora`` choice bindings lacking a
+    family just like it does top-level ones."""
     try:
         hints = typing.get_type_hints(payload_type)
     except Exception:
@@ -379,9 +402,17 @@ def _collect_model_placement_key(
     slot = next(iter(models), "")
     choices: List[Dict[str, Any]] = []
     for row in choice_enum.rows():  # type: ignore[attr-defined]
+        binding_manifest = _binding_to_manifest(row.ref, slot)
+        _stamp_lora_family(
+            binding_manifest,
+            compile_family,
+            f"{name}: {payload_type.__name__}.{field_name} choice {row.id!r}"
+            if name
+            else f"{payload_type.__name__}.{field_name} choice {row.id!r}",
+        )
         entry: Dict[str, Any] = {
             "id": row.id,
-            "binding": _binding_to_manifest(row.ref, slot),
+            "binding": binding_manifest,
             "defaults": msgspec.to_builtins(row.defaults),
         }
         if row.hot:
@@ -520,20 +551,17 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         }
         # allow_lora bindings carry the endpoint's architecture family so the
         # hub's th#586 gate can police adapter targets (builder rejects
-        # allow_lora without family).
+        # allow_lora without family). pgw#519: the same stamp applies to
+        # model.choices[].binding rows, not just top-level bindings.
         compile_family = es.compile.family if es.compile is not None else ""
-        for block in bindings_block.values():
-            if block.get("allow_lora"):
-                if not compile_family:
-                    raise ValueError(
-                        f"{es.name}: allow_lora bindings require "
-                        "Compile(family=...) on the endpoint"
-                    )
-                block["family"] = compile_family
+        for key, block in bindings_block.items():
+            _stamp_lora_family(block, compile_family, f"{es.name} binding {key!r}")
 
         input_schema, input_sha = _schema_and_hash(es.payload_type)
         moderation = _collect_payload_moderation_metadata(es.payload_type)
-        model_key = _collect_model_placement_key(es.payload_type, es.models)
+        model_key = _collect_model_placement_key(
+            es.payload_type, es.models, compile_family, es.name
+        )
         output_type = es.output_type
         if output_type is None:
             raise ValueError(

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -429,7 +429,9 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
     """One handler -> one function; a ModelChoice payload field emits the
     `model` block (field + byom + slot + curated choices carrying structured
     ModelRef bindings, typed defaults, and hot/price hints) — the pgw#509
-    SDK->tensorhub (th#761) contract."""
+    SDK->tensorhub (th#761) contract. The wai choice's allow_lora binding
+    also gets the endpoint's Compile(family=...) stamp (pgw#519), same as a
+    top-level allow_lora binding would."""
     from gen_worker.discovery.discover import discover_functions
 
     pkg = tmp_pkg / "ep_model"
@@ -439,7 +441,7 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
         import enum
         from typing import Union
         import msgspec
-        from gen_worker import (Hub, HF, Model, ModelChoice, ModelDefaults,
+        from gen_worker import (Compile, Hub, HF, Model, ModelChoice, ModelDefaults,
                                 ModelRef, RequestContext, Resources, endpoint)
 
         class D(ModelDefaults, frozen=True):
@@ -458,7 +460,8 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
             y: str
 
         @endpoint(models={"pipeline": Hub("o/base"), "vae": Hub("o/vae")},
-                  resources=Resources(vram_gb=12))
+                  resources=Resources(vram_gb=12),
+                  compile=Compile(family="wai-arch", shapes=((512, 512),)))
         class Gen:
             def setup(self, pipeline: object, vae: object) -> None: ...
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
@@ -476,6 +479,7 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
     assert by_id["wai"]["binding"]["provider"] == "tensorhub"
     assert by_id["wai"]["binding"]["ref"] == "o/wai"
     assert by_id["wai"]["binding"]["allow_lora"] is True
+    assert by_id["wai"]["binding"]["family"] == "wai-arch"
     assert by_id["wai"]["defaults"] == {"steps": 28, "guidance": 6.0}
     assert by_id["wai"]["hot"] is True
     assert by_id["pony"]["binding"]["provider"] == "hf"
@@ -591,3 +595,100 @@ def test_allow_lora_without_compile_family_raises() -> None:
 
     with pytest.raises(ValueError, match="allow_lora"):
         _extract_entries(Gen, "testmod")
+
+
+def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) -> None:
+    """pgw#519: model.choices[].binding gets the SAME family stamp that a
+    top-level bindings block gets from Compile(family=...) — tensorhub's
+    th#586 architecture gate polices allow_lora targets on both surfaces
+    identically, so a builder-path deploy of a ModelChoice endpoint (e.g.
+    sdxl) doesn't hard-fail while a plain allow_lora endpoint passes."""
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_choice_family"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent("""
+        import enum
+        from typing import Union
+        import msgspec
+        from gen_worker import (Compile, Hub, HF, Model, ModelChoice, ModelDefaults,
+                                ModelRef, RequestContext, Resources, endpoint)
+
+        class D(ModelDefaults, frozen=True):
+            steps: int = 28
+
+        class M(ModelChoice[D], enum.Enum):
+            A = Model("a", Hub("o/a", allow_lora=True), D(28))
+            B = Model("b", Hub("o/b", allow_lora=True), D(30))
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+            model: Union[M, ModelRef] = M.A
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(models={"pipeline": Hub("o/base", allow_lora=True), "vae": Hub("o/vae")},
+                  resources=Resources(vram_gb=12),
+                  compile=Compile(family="sdxl", shapes=((1024, 1024),)))
+        class Gen:
+            def setup(self, pipeline: object, vae: object) -> None: ...
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="ok")
+    """))
+
+    fns = discover_functions(tmp_pkg, main_module="ep_choice_family.main")
+    (fn,) = fns
+
+    top_level_family = fn["bindings"]["pipeline"]["family"]
+    assert top_level_family == "sdxl"
+    assert "family" not in fn["bindings"]["vae"]      # no allow_lora, no stamp
+
+    by_id = {c["id"]: c for c in fn["model"]["choices"]}
+    assert set(by_id) == {"a", "b"}
+    for choice in by_id.values():
+        assert choice["binding"]["allow_lora"] is True
+        # Choice-binding emission equals top-level emission w.r.t. family.
+        assert choice["binding"]["family"] == top_level_family
+
+
+def test_model_choice_allow_lora_without_compile_family_raises(tmp_pkg: Path) -> None:
+    """Mirrors test_allow_lora_without_compile_family_raises for the
+    choices[].binding surface: a ModelChoice endpoint with an allow_lora
+    choice and no Compile(family=...) must fail loudly at discovery, not
+    silently ship an unstamped binding tensorhub's th#586 gate will reject."""
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_choice_family_missing"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent("""
+        import enum
+        from typing import Union
+        import msgspec
+        from gen_worker import (Hub, Model, ModelChoice, ModelDefaults,
+                                ModelRef, RequestContext, Resources, endpoint)
+
+        class D(ModelDefaults, frozen=True):
+            steps: int = 28
+
+        class M(ModelChoice[D], enum.Enum):
+            A = Model("a", Hub("o/a", allow_lora=True), D(28))
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+            model: Union[M, ModelRef] = M.A
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(models={"pipeline": Hub("o/base")}, resources=Resources(vram_gb=12))
+        class Gen:
+            def setup(self, pipeline: object) -> None: ...
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="ok")
+    """))
+
+    with pytest.raises(ValueError, match="allow_lora"):
+        discover_functions(tmp_pkg, main_module="ep_choice_family_missing.main")


### PR DESCRIPTION
## Summary
- `_collect_model_placement_key` (discovery/discover.py) emitted every `model.choices[].binding` row WITHOUT the `family` stamp that top-level `bindings` blocks get from `Compile(family=...)`. tensorhub's th#586 architecture gate rejects `allow_lora=true` bindings lacking a family, so builder-path deploys of ModelChoice endpoints (sdxl) hard-failed. fc157's e2e proof worked around it by hand-stamping `family:"sdxl"` at registration.
- Factored the stamping logic into one shared helper, `_stamp_lora_family`, applied identically to the top-level `bindings` block and every `choices[].binding` row — the two surfaces can't drift apart again.
- Behavior change: an `allow_lora` choice binding with no declared `Compile(family=...)` on the endpoint now raises `ValueError` at discovery time (matching the existing top-level policy), instead of silently emitting an unstamped binding.
- Bumped to 0.17.2 + CHANGELOG entry.

Fixes pgw#519.

## Test plan
- [x] New test `test_model_choice_binding_family_matches_top_level_binding`: builds a fixture endpoint with `Compile(family="sdxl", ...)` + a 2-choice `ModelChoice` (both `allow_lora=True`), asserts every `choices[].binding["family"]` equals the top-level binding's `family`.
- [x] New test `test_model_choice_allow_lora_without_compile_family_raises`: mirrors the existing top-level test — a ModelChoice endpoint with an `allow_lora` choice and no `Compile(family=...)` fails loudly at discovery.
- [x] Updated `test_manifest_emits_model_placement_key` (encoded the pre-fix bug: an `allow_lora` choice binding with no `Compile(family=...)` — now declares `Compile(family="wai-arch", ...)` and asserts the choice binding carries it.
- [x] `uv run --extra dev python -m mypy src/gen_worker` — 0 errors.
- [x] `uv run --extra dev python -m pytest -m "not integration" -q` — 931 passed, 11 skipped, 13 deselected, 3 pre-existing `GEN_WORKER_FORBID_CPU_OFFLOAD` failures (unrelated to this change, present on master).