### PR TITLE
convert: pipeline_tree ingest for TRELLIS-style repos (0.17.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.17.4"
+version = "0.17.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -67,10 +67,11 @@ class RepoRefusal(RuntimeError):
 class RepoClassification:
     """Result of :func:`classify_repo` + :func:`select_files`."""
 
-    strategy: str          # diffusers | transformers | peft | sentence_transformers |
-                           # gguf | native_lora | aio_singlefile
-    runtime_library: str   # diffusers | transformers | peft | sentence-transformers |
-                           # llama-cpp | diffusers-single-file | diffusers-lora
+    strategy: str          # diffusers | pipeline_tree | transformers | peft |
+                           # sentence_transformers | gguf | native_lora | aio_singlefile
+    runtime_library: str   # diffusers | trellis2 | transformers | peft |
+                           # sentence-transformers | llama-cpp |
+                           # diffusers-single-file | diffusers-lora
     allow_patterns: list[str]
     attrs: dict[str, str] = field(default_factory=dict)
     detection_reason: str = ""
@@ -233,6 +234,15 @@ def classify_repo(
 
     has_st = any(p.lower().endswith(".safetensors") for p in paths)
     has_st_index = any(p.lower().endswith(".safetensors.index.json") for p in paths)
+
+    # 3.5 pipeline tree (TRELLIS-style: pipeline.json at root composing nested
+    # per-model checkpoint pairs, e.g. ckpts/<name>.{json,safetensors}). The
+    # tree is one artifact — every safetensors rides, no dtype-variant pick
+    # (mixed per-model dtypes are intentional upstream).
+    if "pipeline.json" in root_set and has_st:
+        pt_weights = sorted(p for p in paths if p.lower().endswith(".safetensors"))
+        return _finish("pipeline_tree", "trellis2", pt_weights, [],
+                       {"file_layout": "singlefile"}, "pipeline.json at root")
 
     # 4. transformers
     if config_json is not None and "config.json" in root_set and (has_st or has_st_index):

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -750,6 +750,7 @@ def run_clone(
         strategy = source.classification.strategy if source.classification is not None else ""
         publish_as_is = strategy in {
             "transformers", "peft", "sentence_transformers", "gguf", "native_lora",
+            "pipeline_tree",
         }
 
         for i, spec in enumerate(specs):

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -420,6 +420,9 @@ def ingest_huggingface(
         "diffusers-single-file": "diffusers",
         "diffusers-lora": "diffusers",
         "llama-cpp": "llama.cpp",
+        # No hub-recognized loader library for TRELLIS-style pipeline trees:
+        # publish with library_name unset (validator opt-out, e2e #112).
+        "trellis2": "",
     }.get(library, library)
     repo_spec = {
         "kind": "adapter" if library in {"peft", "diffusers-lora"} else "model",

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -224,3 +224,33 @@ def test_gguf_ud_and_iquant_tokens_labeled() -> None:
     assert c.attrs["dtype"] == "gguf:ud-q4_k_xl"
     c2 = classify_repo(["model-IQ4_XS.gguf"])
     assert c2.attrs["dtype"] == "gguf:iq4_xs"
+
+
+def test_pipeline_tree_trellis_shape() -> None:
+    files = [
+        "pipeline.json",
+        "README.md",
+        "assets/teaser.png",
+        "ckpts/ss_flow_img_dit_1_3B_64_bf16.json",
+        "ckpts/ss_flow_img_dit_1_3B_64_bf16.safetensors",
+        "ckpts/shape_dec_next_dc_f16c32_fp16.json",
+        "ckpts/shape_dec_next_dc_f16c32_fp16.safetensors",
+        "ckpts/tex_dec_next_dc_f16c32_fp16.json",
+        "ckpts/tex_dec_next_dc_f16c32_fp16.safetensors",
+    ]
+    c = classify_repo(files)
+    assert c.strategy == "pipeline_tree"
+    assert c.runtime_library == "trellis2"
+    allow = set(c.allow_patterns)
+    # EVERY safetensors rides — mixed per-model dtypes are intentional, no
+    # dtype-variant pick.
+    for p in files:
+        if p.endswith((".safetensors", ".json")):
+            assert p in allow, p
+    assert "assets/teaser.png" not in allow
+    assert c.attrs["file_layout"] == "singlefile"
+
+
+def test_pipeline_tree_without_weights_falls_through() -> None:
+    with pytest.raises(RepoRefusal):
+        classify_repo(["pipeline.json", "README.md"])


### PR DESCRIPTION
ie#392 (trellis-3d serving): \`microsoft/TRELLIS.2-4B\` is a pipeline.json-rooted tree (\`pipeline.json\` + \`ckpts/*.{json,safetensors}\`, nothing at root) — \`classify_repo\` fell through to \`RepoRefusal("unknown_shape")\`, so the mirror ingest owed by ie#392 was impossible.

- classifier: new branch 3.5 \`pipeline_tree\` (pipeline.json at root + any safetensors) — ALL safetensors ride, no dtype-variant pick (TRELLIS ships mixed bf16 flows / fp16 decoders deliberately)
- clone: \`pipeline_tree\` joins the publish-as-is set (tree published untouched, flavor label = detected on-disk dtype)
- ingest: \`trellis2\` maps to empty \`library_name\` (tensorhub NormalizeLibraryName has no trellis entry; empty = validator opt-out, same as the chatterbox multi-weight bundle, e2e #112)
- version 0.17.5; convert suite 174 passed, mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)