### PR TITLE
packaging: grpcio floor matches shipped pb stubs (0.17.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.22.5 (2026-07-13)
+
+- **packaging: grpcio floor 1.82.1.** The shipped pb stubs are generated
+  with grpcio-tools 1.82.1 and refuse to import under older grpcio
+  (th#766: conversion image crash-looped on locked 1.81.1).
+
 ## 0.22.4 (2026-07-13)
 
 - **gw: fp8 storage flavors for transformers-BACKBONE snapshots (ie#478).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.4"
+version = "0.22.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"
@@ -21,7 +21,7 @@ classifiers = [
 # a 3.12+ mypy target anyway.
 requires-python = ">=3.12"
 dependencies = [
-    "grpcio>=1.80.0",
+    "grpcio>=1.82.1",
     "msgspec>=0.18.6",
     "protobuf>=6.30.0",
     "requests>=2.32.0",
@@ -84,7 +84,7 @@ dev = [
     # transformers+accelerate activate the bnb nf4 convert integration test.
     "accelerate>=1.9",
     "diffusers>=0.39.0",
-    "grpcio-tools>=1.80.0",
+    "grpcio-tools>=1.82.1",
     # 5.13 floor: the fp8+te writer keys on transformers-5 conversion_mapping /
     # core_model_loading internals; <5.5.2 has the fast-safetensors Gemma
     # key-rename bug. Producer/consumer symmetry with the serve fleet (te#45).

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.4"
+version = "0.22.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },
@@ -651,8 +651,8 @@ requires-dist = [
     { name = "c2pa-python", marker = "extra == 'signing'", specifier = ">=0.36" },
     { name = "diffusers", marker = "extra == 'dev'", specifier = ">=0.39.0" },
     { name = "gguf", specifier = ">=0.10.0" },
-    { name = "grpcio", specifier = ">=1.80.0" },
-    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
+    { name = "grpcio", specifier = ">=1.82.1" },
+    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.82.1" },
     { name = "huggingface-hub", specifier = ">=0.26.0" },
     { name = "msgspec", specifier = ">=0.18.6" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },


### PR DESCRIPTION
Found live on the th#766 calibration re-run: the conversion image (gen-worker 0.17.2 + grpcio 1.81.1, both from training-endpoints conversion/uv.lock) crashloops at import — the wheel's pb stubs are generated with grpcio-tools 1.82.1 and hard-require grpcio>=1.82.1, but pyproject declares >=1.80.0. Every RunPod conversion pod died before dialing the hub (3× 10-min register-timeouts).

Floors: `grpcio>=1.82.1`, dev `grpcio-tools>=1.82.1`. Version 0.17.6. Repro: `docker run tensorhub/endpoints:conversion-src-b5d87d8aa6d6` → RuntimeError at import.

test_serve_sigterm_clean_teardown failed once under box load, passes in isolation and with the change (pre-existing flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)