### PR TITLE
fix(families): stable schema descriptions across msgspec versions — unblocks the failed v0.18.0 publish

### DIFF
--- a/src/gen_worker/families/base.py
+++ b/src/gen_worker/families/base.py
@@ -39,6 +39,7 @@ family, not an open bag of keys.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
 import msgspec
@@ -113,6 +114,18 @@ def family_for(name: str) -> Optional[Type[FamilyDefaults]]:
     return _REGISTRY.get(str(name or "").strip()) or None
 
 
+def _clean_descriptions(node: Dict[str, Any]) -> None:
+    """Dedent docstring-derived ``description`` values in place.
+
+    msgspec 0.21 emits the RAW class docstring (leading indentation intact);
+    older msgspec dedented it. The exported schema is a stable contract
+    (golden-file-tested), so normalize with ``inspect.cleandoc`` — one
+    output regardless of msgspec's docstring handling."""
+    desc = node.get("description")
+    if isinstance(desc, str):
+        node["description"] = inspect.cleandoc(desc)
+
+
 def export_json_schema(name: str) -> Dict[str, Any]:
     """Standalone JSON Schema (draft 2020-12) for one registered family.
 
@@ -132,6 +145,10 @@ def export_json_schema(name: str) -> Dict[str, Any]:
         # No nested defs (a family with no struct-valued fields): the
         # top-level schema IS the body.
         body = {k: v for k, v in raw.items() if k not in ("$ref", "$defs")}
+    _clean_descriptions(body)
+    for d in defs.values():
+        if isinstance(d, dict):
+            _clean_descriptions(d)
     schema: Dict[str, Any] = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": f"https://schemas.cozy.art/gen-worker/families/{name}.schema.json",


### PR DESCRIPTION
## The bug (v0.18.0 never reached PyPI)

The `v0.18.0` **Publish to PyPI** run ([29218115144](https://github.com/cozy-creator/python-gen-worker/actions/runs/29218115144)) failed at its test gate:

`tests/test_families.py::test_sdxl_schema_export_matches_golden_file`

Root cause: **msgspec 0.21 emits the RAW class docstring** (leading 4-space indentation intact) as a struct schema's `description`; older msgspec dedented it. The golden file `tests/testdata/sdxl.schema.json` holds the dedented form; CI's locked msgspec (0.21.1, per uv.lock) produces the raw-indented form → deterministic mismatch. (The golden file was evidently generated under an environment with different docstring handling than the lock.)

Because the publish gate failed, **0.18.0 is not on PyPI** (latest is 0.17.5) — which blocks the entire th#767/pgw#520 endpoint fan-out: ie#475's sdxl reference migration floors `gen-worker>=0.18.0,<0.19` and its `uv lock` cannot resolve until an 0.18.x publishes.

## The fix

Normalize in the export, not the golden: `export_json_schema` now runs `inspect.cleandoc` over every docstring-derived `description` (body + `$defs`) — one stable output regardless of msgspec's docstring handling. The golden file (which already holds the clean, dedented contract) is unchanged; the dedented form is also what tensorhub should be validating repo metadata against.

## Verification

- `uv run pytest tests/test_families.py -q` → 11 passed (was 1 failing).
- Full suite: same pass set as the pristine v0.18.0 tag on this host (the handful of `test_ram_admission`/`test_content_lanes`/`test_snapshot_corruption` failures reproduce identically on the unmodified tag — host-RAM/env-dependent, pre-existing, and green in CI).
- `uv run mypy src` → clean.

## After merge

Cut **v0.18.1** (version bump + tag) so the publish workflow ships it — then ie#475's branch can `uv lock` and the fleet fan-out proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)