### PR TITLE
pgw#508: ctx.log is the operator diagnostics stream, full stop

### DIFF
--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -340,8 +340,14 @@ At most 15 members:
 | `generator(seed)` | seeded `torch.Generator` on `device` |
 | `deadline`, `time_remaining()` | absolute deadline / seconds left |
 | `cancelled`, `raise_if_cancelled()` | THE cancellation spelling |
-| `progress(fraction, stage=)`, `log(msg, level=)` | events to the caller |
+| `progress(fraction, stage=)` | USER-facing status event (the job card) |
+| `log(msg, level=, **fields)` | PLATFORM/OPERATOR diagnostic, never user-facing (pgw#508) |
 | `save_bytes/file/image/audio/video` | persist outputs → typed `Asset` |
+
+Logging rule of thumb: module-level `logging.getLogger(__name__)` for
+boot-time/cross-request logging; `ctx.log` for anything scoped to THIS
+request you'd want when debugging it; `ctx.progress` for what the human
+watching the job should see.
 
 ## Project config
 

--- a/proto/CONTRACT.md
+++ b/proto/CONTRACT.md
@@ -344,6 +344,39 @@ progress (§1), so subscribers may observe seq gaps; `JobResult` is the
 authoritative output. There is no stream-done/stream-error message: the
 terminal `JobResult` (any status) ends the stream.
 
+**The ctx event lane (pgw#508).** `RequestContext` methods (`ctx.progress`,
+`ctx.log`, checkpoint/warning/training-metric helpers) don't get their own
+wire message — each rides a `JobProgress` chunk whose `content_type` is the
+constant `application/x-request-event+json` (`EVENT_CONTENT_TYPE` in
+executor.py / `RequestEventContentType` in tensorhub's runtimestore) and
+whose `data` is a JSON envelope `{request_id, type, payload, timestamp}`.
+This is a CONTENT-TYPE DISCRIMINATOR inside one wire message, not a second
+message type — O inspects `content_type` before falling back to the generic
+streaming-output path. `type` is one of:
+
+| `type` | audience | O persistence | tolerates shedding |
+|---|---|---|---|
+| `request.progress` | USER-facing (cozy-art job card) | latest-tick only, in-memory (th#737); never a durable row | yes — a dropped mid-run tick is superseded by the next one; only the final state matters |
+| `request.log` | PLATFORM/OPERATOR ONLY, full stop — never user-facing | durable `job.log` row (request_events) | yes — a dropped debug line is an acceptable loss; nothing downstream depends on completeness |
+| `request.checkpoint` | USER-facing | durable `job.checkpoint` row | no — every save is individually meaningful (a training run's checkpoint list must be complete) |
+| `request.warning` | USER-facing | durable `job.warning` row | no — sparse and actionable (e.g. `artifact_upload_failed`) |
+| `request.training_metric` | USER-facing (training job UI) | durable `job.training.metric` row, downsampled to ≥5s apart (final step and any `val_loss` point always persist) | yes between persisted points — the chart only needs the trend, not every tick |
+
+O enforces the `request.log` exception at TWO points, because the live
+`JobProgress` chunk reaches O before the durable row exists: (1) the live
+hub fan-out (`ProgressHub`/SSE `output.delta` path) drops any chunk whose
+decoded `type` is `request.log` outright — it is never wrapped as a generic
+delta and shown to a tenant subscriber; (2) the durable read path
+(`/v1/requests/:id/events`, `/events.bin`) filters `job.log` rows out of
+what it streams to the tenant-scoped SSE routes. There is no operator-facing
+read surface for `job.log` yet — it exists to be queried directly (psql /
+future admin tooling), not to be served over the tenant API.
+
+Every other `type` keeps the base `JobProgress` shedding contract (§1
+send-queue policy: `JobProgress` is the FIRST thing dropped under queue
+overflow) — durability past that point is what the table above's
+"persistence" column adds, not a wire-level delivery guarantee.
+
 ### CancelJob (O → W)
 Sent on client cancel, reconcile cleanup (§1), or O-side abort.
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -43,6 +43,10 @@ class LoraOverlay(TypedDict):
     ref: str
     weight: float
 
+
+LogLevel = Literal["debug", "info", "warning", "error"]
+"""Severity for :meth:`RequestContext.log` (pgw#508's operator stream)."""
+
 from ..api.errors import AuthError
 from ..api.slot import ResolvedSlot
 from ..api.types import (
@@ -516,6 +520,9 @@ class RequestContext:
     ) -> None:
         """Report request progress (best-effort, rides ``request.progress``).
 
+        This is the USER-facing stream — the cozy-art job feed renders it
+        directly. For platform/operator-only diagnostics use :meth:`log`.
+
         ``progress`` is a 0..1 fraction; ``step``/``total`` carry the exact
         step counter when known (e.g. denoise step 5 of 20) so UIs can render
         "5 / 20" instead of a bare percentage.
@@ -550,8 +557,35 @@ class RequestContext:
             payload["size_bytes"] = int(size_bytes)
         self._emit_event("request.checkpoint", payload)
 
-    def log(self, message: str, level: str = "info") -> None:
-        self._emit_event("request.log", {"message": message, "level": level})
+    def log(self, message: str, level: LogLevel = "info", **fields: Any) -> None:
+        """Emit a request-scoped OPERATOR diagnostic (rides ``request.log``).
+
+        pgw#508: this is the PLATFORM/OPERATOR debug stream, full stop —
+        never user-facing. tensorhub persists it under an operator-only event
+        kind and never serves it on a tenant-facing surface (SSE job feed,
+        events.bin, poll); it does not reach the cozy-art job card. See
+        proto/CONTRACT.md § "The ctx event lane" for the wire-level routing
+        contract.
+
+        One-line rule for authors: module-level ``logging.getLogger(__name__)``
+        for boot-time/cross-request logging; ``ctx.log`` for anything scoped
+        to THIS request you'd want when debugging it (resolved model/
+        scheduler choice, retry/degradation detail, malformed-input detail);
+        ``ctx.progress`` for what the human watching the job should see.
+        There is no user-visible counterpart to ``ctx.log`` — a product
+        surface for extra user-facing text would be a deliberate addition,
+        not an overload of this method (YAGNI until a real surface asks).
+
+        ``**fields`` rides the payload as structured JSON extras (e.g.
+        ``ctx.log("OOM retry", level="warning", free_gb=2.1, rung="offload")``)
+        so operators can filter/grep without parsing the message string.
+        Best-effort like every ctx event: dropped silently if unencodable or
+        no emitter is configured.
+        """
+        payload: Dict[str, Any] = {"message": message, "level": level}
+        if fields:
+            payload["fields"] = fields
+        self._emit_event("request.log", payload)
 
     def _c2pa_manifest_kwargs(self) -> Dict[str, Any]:
         model_refs = [str(v) for v in (self._models or {}).values()]

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -37,6 +37,20 @@ def test_progress_and_log_emit_events() -> None:
     kinds = [e["type"] for e in events]
     assert kinds == ["request.progress", "request.log"]
     assert events[0]["payload"] == {"progress": 0.5, "stage": "denoise"}
+    assert events[1]["payload"] == {"message": "hello", "level": "warning"}
+
+
+def test_log_default_level_and_structured_fields() -> None:
+    events = []
+    ctx = RequestContext(request_id="r1", emitter=events.append)
+    ctx.log("plain")
+    ctx.log("OOM retry", level="warning", free_gb=2.1, rung="offload")
+    assert events[0]["payload"] == {"message": "plain", "level": "info"}
+    assert events[1]["payload"] == {
+        "message": "OOM retry",
+        "level": "warning",
+        "fields": {"free_gb": 2.1, "rung": "offload"},
+    }
 
 
 def test_progress_carries_optional_step_and_total() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Redefine `ctx.log` as the PLATFORM/OPERATOR diagnostics stream, full stop — never user-facing (`ctx.progress` stays the user-facing one). Pre-launch hard cut, no `audience=` parameter.
- `log(message, level=, **fields)` — structured JSON extras ride the payload so operators can grep/filter without parsing message strings.
- `proto/CONTRACT.md` gets a new "The ctx event lane" section: the `application/x-request-event+json` content-type discriminator, per-event-type audience/persistence/shedding table, and the tensorhub-side enforcement points (companion PR: cozy-creator/tensorhub#pgw508-log-audiences-operator-routing).
- `docs/endpoint-authoring.md`: fixes the stale "events to the caller" claim for `log()` and adds the one-line module-logger-vs-ctx.log authoring rule.

## Test plan
- [x] `mypy src/gen_worker` — 0 errors
- [x] `pytest tests/` — 925 passed, 7 skipped (6 pre-existing failures unrelated to this change: `GEN_WORKER_FORBID_CPU_OFFLOAD=1` on this shared dev box refuses CPU-offloaded placement in `test_content_lanes.py`/`test_ram_admission.py`/`test_snapshot_corruption.py`, confirmed identical on origin/master)
- [x] New/updated tests in `tests/test_request_context.py` cover default level, structured `**fields`, and the exact payload shape

Companion tensorhub PR routes `request.log` to an operator-only store and closes two live leaks to the tenant-facing SSE surface. Do not merge until that PR is reviewed alongside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)