### PR TITLE
pgw#523: evict allow_lora from ModelRef; retire .provider/.ref aliases (0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.20.0 (2026-07-13)
+
+**BREAKING — pgw#523: `ModelRef` is pure identity + fetch scope; `.provider`/`.ref` aliases retired.**
+
+- **Part A — evict `allow_lora` (identity != permission).** Deleted `allow_lora` from
+  `ModelRef` and the `Hub(...)`/`HF(...)` kwargs. th#772 moved overlay permission to the
+  slot-policy `loras` axis; the th#586 architecture gate has always keyed off the declared
+  binding/slot FAMILY (`EffectiveBindingFamily`), never this flag, so it never gated
+  anything at runtime — only a registration-time co-occurrence check (allow_lora=true
+  requires family), which tensorhub also retires this release. `_stamp_lora_family` ->
+  `_stamp_family`: family stamping is now unconditional-when-known on every binding
+  (top-level `bindings` blocks and `model.choices[].binding` rows alike), not
+  allow_lora-triggered.
+- **Part B — retire the `.provider`/`.ref` back-compat aliases.** `ModelRef` now exposes
+  only `.source`/`.path`. Every in-repo consumer (discovery manifest emission, executor
+  prefetch/download plumbing, residency cache-key labeling, the CLI's list/prefetch
+  commands) repoints at `.source`/`.path`. The manifest `bindings.<slot>.provider` wire
+  field now carries the pgw#511 vocabulary directly (`"huggingface"`/`"modelscope"`, not
+  the old `"hf"` short form) — requires tensorhub's widened `provider` DB CHECK deployed
+  first (th#523 companion PR). `models/refs.py::parse_model_ref` accepts both `"hf"` and
+  `"huggingface"` as input and keeps normalizing to the internal `"hf"` token, so the
+  ref-grammar module and every `parsed.provider == "hf"` comparison downstream (download/
+  provision) are unaffected.
+- Hard cut, no back-compat: constructing `Hub(..., allow_lora=True)` or reading
+  `ref.provider`/`ref.ref` now fails immediately (`TypeError`/`AttributeError`).
+
 ## 0.19.1 (2026-07-13)
 
 - **pgw#517: `compile=` is no longer silently inert on self-loading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.19.1"
+version = "0.20.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -52,23 +52,18 @@ def _clean_storage_dtype(v: object) -> str:
 
 class ModelRef(msgspec.Struct, frozen=True):
     """ONE structured model reference (pgw#511): ``source`` is explicit, never
-    inferred from shape or which factory built the value.
+    inferred from shape or which factory built the value. Pure identity +
+    fetch scope — no permission fields live here (pgw#523: overlay
+    permission is a slot-policy concern, not an identity-struct flag).
 
     Carries the union of every registry's per-source fields (tensorhub:
-    ``tag``/``flavor``/``allow_lora``; huggingface: ``revision``/``dtype``/
-    ``subfolder``/``files``; civitai: ``version``; modelscope: ``revision``/
-    ``files``). ``storage_dtype`` is shared by tensorhub/huggingface. Build
-    one via ``Hub``/``HF``/``Civitai``/``ModelScope`` rather than the raw
+    ``tag``/``flavor``; huggingface: ``revision``/``dtype``/``subfolder``/
+    ``files``; civitai: ``version``; modelscope: ``revision``/``files``).
+    ``storage_dtype`` is shared by tensorhub/huggingface. Build one via
+    ``Hub``/``HF``/``Civitai``/``ModelScope`` rather than the raw
     constructor — they pin ``source`` and apply the per-registry validation
     below (mirrored in ``__post_init__`` so it holds for direct construction
     too, e.g. ``msgspec.structs.replace``).
-
-    ``.provider`` and ``.ref`` are back-compat aliases for call sites that
-    predate the explicit ``source``/``path`` fields: ``.provider`` returns
-    the OLDER, narrower vocabulary (``"hf"`` not ``"huggingface"``; no
-    ``"modelscope"``) that tensorhub's build-manifest ``bindings.<slot>.provider``
-    column is DB-CHECK-constrained to — do not repoint manifest/download code
-    at ``.source`` without also widening that constraint.
     """
 
     source: ModelSource
@@ -81,7 +76,6 @@ class ModelRef(msgspec.Struct, frozen=True):
     storage_dtype: str = ""
     version: str = ""
     files: tuple[str, ...] = ()
-    allow_lora: bool = False
 
     def __post_init__(self) -> None:
         # msgspec.structs.force_setattr, NOT object.__setattr__: the latter
@@ -99,7 +93,6 @@ class ModelRef(msgspec.Struct, frozen=True):
         force(self, "version", _clean(self.version))
         force(self, "files", tuple(_clean(p) for p in self.files if _clean(p)))
         force(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
-        force(self, "allow_lora", bool(self.allow_lora))
 
         if self.source == "tensorhub":
             if not self.tag:
@@ -118,20 +111,6 @@ class ModelRef(msgspec.Struct, frozen=True):
         else:
             raise ValueError(f"unknown ModelRef source {self.source!r}")
 
-    @property
-    def provider(self) -> str:
-        """Back-compat alias, OLD narrower vocabulary: ``"hf"`` (not
-        ``"huggingface"``) for huggingface refs, ``source`` verbatim
-        otherwise. This is what tensorhub's build-manifest
-        ``bindings.<slot>.provider`` column expects — use ``.source`` for
-        anything new (pgw#511 wire vocabulary)."""
-        return "hf" if self.source == "huggingface" else self.source
-
-    @property
-    def ref(self) -> str:
-        """Back-compat alias for ``.path``."""
-        return self.path
-
 
 def Hub(
     ref: str,
@@ -139,18 +118,11 @@ def Hub(
     tag: str = "latest",
     flavor: str = "",
     storage_dtype: str = "",
-    allow_lora: bool = False,
 ) -> ModelRef:
-    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=, allow_lora=)``.
-
-    ``allow_lora=True`` opts the slot into per-request LoRA overlays
-    (``_models.<slot>.loras``, ie#358) — the endpoint must also declare
-    ``Compile(family=...)`` so the hub's architecture gate can police
-    adapter targets.
-    """
+    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=)``."""
     return ModelRef(
         source="tensorhub", path=ref, tag=tag, flavor=flavor,
-        storage_dtype=storage_dtype, allow_lora=allow_lora,
+        storage_dtype=storage_dtype,
     )
 
 
@@ -162,7 +134,6 @@ def HF(
     subfolder: str = "",
     files: tuple[str, ...] = (),
     storage_dtype: str = "",
-    allow_lora: bool = False,
 ) -> ModelRef:
     """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=, storage_dtype=)``.
 
@@ -176,7 +147,6 @@ def HF(
     return ModelRef(
         source="huggingface", path=ref, revision=revision, dtype=dtype,
         subfolder=subfolder, files=files, storage_dtype=storage_dtype,
-        allow_lora=allow_lora,
     )
 
 

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -26,15 +26,12 @@ def describe_binding(binding: Any) -> Dict[str, Any]:
     if isinstance(binding, ModelRef):
         out: Dict[str, Any] = {
             "type": binding.source,
-            "provider": binding.provider,
-            "ref": binding.ref,
+            "ref": binding.path,
         }
         for key in ("tag", "flavor", "revision", "dtype", "subfolder", "version", "storage_dtype"):
             v = getattr(binding, key, "")
             if v:
                 out[key] = v
-        if getattr(binding, "allow_lora", False):
-            out["allow_lora"] = True
         files = tuple(getattr(binding, "files", ()) or ())
         if files:
             out["files"] = list(files)

--- a/src/gen_worker/cli/prefetch.py
+++ b/src/gen_worker/cli/prefetch.py
@@ -92,7 +92,7 @@ def _handle_prefetch(args: argparse.Namespace) -> int:
         for param_name, binding in c.bindings.items():
             try:
                 if isinstance(binding, ModelRef):
-                    ref, provider = wire_ref(binding), binding.provider
+                    ref, provider = wire_ref(binding), str(binding.source)
                     ap = tuple(getattr(binding, "files", ()) or ())
                     jobs[(ref, provider)] = (ref, provider, ap)
             except Exception as e:

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -276,9 +276,9 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
     """
     out: Dict[str, Any] = {
         "kind": "fixed",
-        "provider": binding.provider,
+        "provider": binding.source,
         "slot_name": param_name,
-        "ref": binding.ref,
+        "ref": binding.path,
     }
     if binding.source == "tensorhub":
         # Normal form (gw#492): the default tag ('latest') is elided at the
@@ -288,8 +288,6 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
             out["tag"] = binding.tag
         if binding.flavor:
             out["flavor"] = binding.flavor
-        if binding.allow_lora:
-            out["allow_lora"] = True
     elif binding.source == "huggingface":
         for k in ("revision", "dtype", "subfolder"):
             v = getattr(binding, k)
@@ -297,8 +295,6 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
                 out[k] = v
         if binding.files:
             out["files"] = list(binding.files)
-        if binding.allow_lora:
-            out["allow_lora"] = True
     elif binding.source == "civitai":
         if binding.version:
             out["version"] = binding.version
@@ -310,21 +306,19 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
     return out
 
 
-def _stamp_lora_family(binding_manifest: Dict[str, Any], compile_family: str, context: str) -> None:
-    """Stamp an ``allow_lora`` binding manifest with the endpoint's
-    ``Compile(family=...)`` so tensorhub's th#586 architecture gate can
-    police adapter targets (the builder rejects ``allow_lora`` bindings
-    lacking a family). Shared by top-level ``bindings`` blocks and
-    ``model.choices[].binding`` rows (pgw#519) so both surfaces stamp
-    identically."""
-    if not binding_manifest.get("allow_lora"):
+def _stamp_family(binding_manifest: Dict[str, Any], family: str) -> None:
+    """Stamp a binding manifest with the endpoint's architecture family
+    (pgw#523: unconditional-when-known, not ``allow_lora``-triggered) so
+    tensorhub's th#586 gate can family-police any LoRA overlay attached at
+    this slot. Identity (the binding) and permission (whether a LoRA may
+    attach here — the slot-policy ``loras`` axis, th#772) are separate
+    concerns; this only carries the family fact through. Shared by
+    top-level ``bindings`` blocks and ``model.choices[].binding`` rows
+    (pgw#519) so both surfaces stamp identically. No-op when the family
+    isn't known — nothing to police."""
+    if not family:
         return
-    if not compile_family:
-        raise ValueError(
-            f"{context}: allow_lora bindings require "
-            "Compile(family=...) on the endpoint"
-        )
-    binding_manifest["family"] = compile_family
+    binding_manifest["family"] = family
 
 
 def _model_ref_to_manifest(ref: Any) -> Dict[str, Any]:
@@ -355,7 +349,7 @@ def _slot_to_manifest(name: str, slot: Slot, *, compile_family: str) -> Dict[str
     # Compile(family=...) is the explicit, functionally-load-bearing
     # declaration (compile-cache keying) — it wins over the slot's own
     # default_config-preset registration when both are present, mirroring
-    # _stamp_lora_family's precedence for the bindings-block stamp below.
+    # _stamp_family's precedence for the bindings-block stamp below.
     family = compile_family or slot.family
     if family:
         out["family"] = family
@@ -408,10 +402,9 @@ def _collect_model_placement_key(
     catalog/UI renders ``choices[].defaults``.
 
     ``compile_family`` mirrors the endpoint's ``Compile(family=...)`` onto
-    each ``allow_lora`` choice binding via :func:`_stamp_lora_family` —
-    identically to how top-level ``bindings`` blocks are stamped (pgw#519):
-    tensorhub's th#586 gate rejects ``allow_lora`` choice bindings lacking a
-    family just like it does top-level ones."""
+    each choice binding via :func:`_stamp_family` — identically to how
+    top-level ``bindings`` blocks are stamped (pgw#519), unconditionally
+    when known (pgw#523)."""
     try:
         hints = typing.get_type_hints(payload_type)
     except Exception:
@@ -441,13 +434,7 @@ def _collect_model_placement_key(
     choices: List[Dict[str, Any]] = []
     for row in choice_enum.rows():  # type: ignore[attr-defined]
         binding_manifest = _binding_to_manifest(row.ref, slot)
-        _stamp_lora_family(
-            binding_manifest,
-            compile_family,
-            f"{name}: {payload_type.__name__}.{field_name} choice {row.id!r}"
-            if name
-            else f"{payload_type.__name__}.{field_name} choice {row.id!r}",
-        )
+        _stamp_family(binding_manifest, compile_family)
         entry: Dict[str, Any] = {
             "id": row.id,
             "binding": binding_manifest,
@@ -587,9 +574,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             key: _binding_to_manifest(binding, key)
             for key, binding in es.models.items()
         }
-        # allow_lora bindings carry the endpoint's architecture family so the
-        # hub's th#586 gate can police adapter targets (builder rejects
-        # allow_lora without family). pgw#519: the same stamp applies to
+        # Every binding carries the endpoint's architecture family, when
+        # known, so the hub's th#586 gate can family-police any LoRA
+        # overlay attached at that slot (pgw#523: unconditional-when-known,
+        # not allow_lora-triggered). pgw#519: the same stamp applies to
         # model.choices[].binding rows, not just top-level bindings. pgw#520:
         # a Slot-declared binding with no Compile(family=...) may still carry
         # a family via its own default_config preset's registration — that's what
@@ -597,9 +585,7 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         compile_family = es.compile.family if es.compile is not None else ""
         for key, block in bindings_block.items():
             slot_family = es.slot_family.get(key, "") if es.slot_family else ""
-            _stamp_lora_family(
-                block, compile_family or slot_family, f"{es.name} binding {key!r}"
-            )
+            _stamp_family(block, compile_family or slot_family)
 
         slots_block = [
             _slot_to_manifest(name, slot, compile_family=compile_family)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -696,7 +696,7 @@ class ModelStore:
                 # Confident classification only (binding / boot provider
                 # index) — unknown refs still flow to the download layer's
                 # dispatch, which raises the same typed error terminally.
-                prov = (getattr(binding, "provider", None)
+                prov = (getattr(binding, "source", None)
                         or lookup_provider_for_ref(ref, default=""))
                 if prov == "tensorhub":
                     # The worker cannot resolve tensorhub-CAS refs itself
@@ -737,7 +737,7 @@ class ModelStore:
                         resolved = _snapshot_to_resolved(snapshot)
                     path = await ensure_local(
                         ref,
-                        provider=getattr(binding, "provider", None),
+                        provider=getattr(binding, "source", None),
                         snapshot=resolved,
                         cache_dir=self._cache_dir,
                         hf_home=self._hf_home,
@@ -1741,7 +1741,7 @@ class Executor:
         missing: set = set()
         for slot in self._setup_slots(spec):
             binding = spec.models[slot]
-            if getattr(binding, "provider", "tensorhub") != "tensorhub":
+            if getattr(binding, "source", "tensorhub") != "tensorhub":
                 continue
             r = wire_ref(binding)
             if (self.store.local_path(r) is None

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -273,7 +273,7 @@ class Lifecycle:
                 continue
             for binding in spec.models.values():
                 ref = wire_ref(binding)
-                if binding.provider != "tensorhub" and ref not in prefetch_refs:
+                if binding.source != "tensorhub" and ref not in prefetch_refs:
                     # hf/civitai refs need no orchestrator snapshot; tensorhub
                     # refs arrive via ModelOp{DOWNLOAD} after HelloAck (§7).
                     prefetch_refs.append(ref)
@@ -293,7 +293,7 @@ class Lifecycle:
                 continue
             missing = sorted({
                 wire_ref(b) for b in spec.models.values()
-                if b.provider == "tensorhub"
+                if b.source == "tensorhub"
                 and self.executor.store.local_path(wire_ref(b)) is None
             })
             if missing:

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -313,7 +313,7 @@ def resolve_bindings(
                 f"{type(binding).__name__}"
             )
         out[param_name] = resolve_local_path(
-            ref=wire_ref(binding), provider=binding.provider,
+            ref=wire_ref(binding), provider=binding.source,
             offline=offline, emit=emit,
             allow_patterns=tuple(getattr(binding, "files", ()) or ()),
             civitai_version_id=str(getattr(binding, "version", "") or ""),

--- a/src/gen_worker/models/refs.py
+++ b/src/gen_worker/models/refs.py
@@ -128,12 +128,19 @@ def parse_model_ref(raw: str, *, provider: str = "tensorhub") -> ParsedModelRef:
     keyword argument (default ``"tensorhub"``). No string prefixes are
     accepted — callers must split prefix/payload upstream and pass them
     in explicitly.
+
+    Accepts either spelling of the huggingface provider — the short
+    internal form ``"hf"`` and the pgw#511 wire form ``"huggingface"``
+    (``ModelRef.source``, since pgw#523 deleted the ``.provider`` alias
+    that used to narrow it before callers got here) — and always returns
+    ``ParsedModelRef(provider="hf", ...)`` so every existing ``== "hf"``
+    comparison downstream keeps working unchanged.
     """
     s = (raw or "").strip()
     if not s:
         raise ValueError("empty model ref")
 
-    if provider == "hf":
+    if provider in ("hf", "huggingface"):
         repo = s
         # Issue #17: runtime wire format carries flavor in the ref string
         # (e.g. "owner/repo#bf16") to identify which variant of an HF

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -777,7 +777,7 @@ class LoadedComponentKey:
             dtype = dtype or str(getattr(binding, "dtype", "") or "")
             quantization = quantization or str(getattr(binding, "storage_dtype", "") or "")
             if not label:
-                ref = str(getattr(binding, "ref", "") or "")
+                ref = str(getattr(binding, "path", "") or "")
                 label = f"{ref}/{component}" if ref else component
         return cls(
             content_digest=str(content_digest or "").strip(),

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -9,11 +9,11 @@ from gen_worker import HF, Civitai, Hub, ModelScope
 from gen_worker.api.binding import wire_ref
 
 
-def test_construction_provider_and_invalid_ref_rejection() -> None:
-    assert Hub("owner/repo").provider == "tensorhub"
-    assert HF("owner/repo").provider == "hf"
-    assert Civitai("123456").provider == "civitai"
-    assert ModelScope("owner/repo").provider == "modelscope"
+def test_construction_source_and_invalid_ref_rejection() -> None:
+    assert Hub("owner/repo").source == "tensorhub"
+    assert HF("owner/repo").source == "huggingface"
+    assert Civitai("123456").source == "civitai"
+    assert ModelScope("owner/repo").source == "modelscope"
 
     with pytest.raises(ValueError):
         Hub("")
@@ -28,7 +28,7 @@ def test_construction_provider_and_invalid_ref_rejection() -> None:
 def test_kw_metadata_normalized_and_frozen() -> None:
     b = HF(" owner/repo ", revision=" main ", dtype=" bf16 ", subfolder=" te ",
            files=(" a/*.safetensors ", ""))
-    assert b.ref == "owner/repo"
+    assert b.path == "owner/repo"
     assert b.revision == "main"
     assert b.dtype == "bf16"
     assert b.subfolder == "te"
@@ -71,6 +71,21 @@ def test_wire_ref_encoding() -> None:
     # load-time metadata never enters the ref
     assert wire_ref(HF("o/r", dtype="bf16", subfolder="te")) == "o/r"
     assert wire_ref(Civitai("123", version="456")) == "123"
+
+
+def test_provider_ref_allow_lora_aliases_retired() -> None:
+    """pgw#523 hard cut: ModelRef is pure identity + fetch scope. The old
+    `.provider`/`.ref` back-compat aliases and the `allow_lora` permission
+    flag are gone — use `.source`/`.path`; overlay permission lives on the
+    slot policy, not this struct."""
+    ref = Hub("owner/repo")
+    assert not hasattr(ref, "provider")
+    assert not hasattr(ref, "ref")
+    assert not hasattr(ref, "allow_lora")
+    with pytest.raises(TypeError):
+        Hub("owner/repo", allow_lora=True)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        HF("owner/repo", allow_lora=True)  # type: ignore[call-arg]
 
 
 def test_typed_payload_size_errors_expose_structured_fields() -> None:

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -442,9 +442,9 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
     """One handler -> one function; a ModelChoice payload field emits the
     `model` block (field + byom + slot + curated choices carrying structured
     ModelRef bindings, typed defaults, and hot/price hints) — the pgw#509
-    SDK->tensorhub (th#761) contract. The wai choice's allow_lora binding
-    also gets the endpoint's Compile(family=...) stamp (pgw#519), same as a
-    top-level allow_lora binding would."""
+    SDK->tensorhub (th#761) contract. Every choice binding gets the
+    endpoint's Compile(family=...) stamp (pgw#519), unconditionally when
+    known (pgw#523: family stamping is no longer allow_lora-triggered)."""
     from gen_worker.discovery.discover import discover_functions
 
     pkg = tmp_pkg / "ep_model"
@@ -463,7 +463,7 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
             guidance: float = 5.0
 
         class M(ModelChoice[D], enum.Enum):
-            WAI = Model("wai", Hub("o/wai", allow_lora=True), D(28, 6.0), hot=True)
+            WAI = Model("wai", Hub("o/wai"), D(28, 6.0), hot=True)
             PONY = Model("pony", HF("o/pony"), D(30), price=2.0)
 
         class In_(msgspec.Struct):
@@ -493,11 +493,11 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
     assert set(by_id) == {"wai", "pony"}
     assert by_id["wai"]["binding"]["provider"] == "tensorhub"
     assert by_id["wai"]["binding"]["ref"] == "o/wai"
-    assert by_id["wai"]["binding"]["allow_lora"] is True
     assert by_id["wai"]["binding"]["family"] == "wai-arch"
     assert by_id["wai"]["defaults"] == {"steps": 28, "guidance": 6.0}
     assert by_id["wai"]["hot"] is True
-    assert by_id["pony"]["binding"]["provider"] == "hf"
+    assert by_id["pony"]["binding"]["provider"] == "huggingface"
+    assert by_id["pony"]["binding"]["family"] == "wai-arch"
     assert by_id["pony"]["price"] == 2.0
     assert "hot" not in by_id["pony"]      # false hint omitted
 
@@ -517,11 +517,11 @@ def test_model_shorthand_skips_server_handle_setup_param() -> None:
 
     (s,) = extract_specs(Chat)
     assert list(s.models) == ["model"]
-    assert s.models["model"].ref == "o/llm"
+    assert s.models["model"].path == "o/llm"
 
 
 # --------------------------------------------------------------------------- #
-# 8. allow_lora bindings (ie#358)                                               #
+# 8. binding family stamping (ie#358 / pgw#523)                                #
 # --------------------------------------------------------------------------- #
 
 
@@ -579,13 +579,16 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
     assert "storage_dtype" not in entry["compile"]
 
 
-def test_allow_lora_binding_emits_flag_and_family() -> None:
-    import gen_worker
+def test_binding_emits_family_stamp_from_compile() -> None:
+    """pgw#523: family stamping is unconditional-when-known — no allow_lora
+    flag gates it, and ModelRef carries no such flag any more (identity !=
+    permission; overlay permission lives on the slot-policy loras axis,
+    th#772)."""
     from gen_worker import Compile, Hub
     from gen_worker.discovery.discover import _extract_entries
 
     @endpoint(
-        model=Hub("cozy/sdxl-base", allow_lora=True),
+        model=Hub("cozy/sdxl-base"),
         resources=Resources(vram_gb=12),
         compile=Compile(family="sdxl", shapes=((1024, 1024),)),
     )
@@ -600,15 +603,20 @@ def test_allow_lora_binding_emits_flag_and_family() -> None:
 
     (entry,) = _extract_entries(Gen, "testmod")
     (block,) = entry["bindings"].values()
-    assert block["allow_lora"] is True
+    assert "allow_lora" not in block
     assert block["family"] == "sdxl"
 
 
-def test_allow_lora_without_compile_family_raises() -> None:
+def test_binding_emits_no_family_when_none_declared() -> None:
+    """pgw#523: with no Compile(family=...) and no fallback-preset family,
+    a binding simply carries no `family` key — this used to hard-fail when
+    allow_lora=True lacked a family (th#586's gate rekeyed off the binding/
+    slot family directly, not that flag, so the co-occurrence requirement
+    is gone too)."""
     from gen_worker import Hub
     from gen_worker.discovery.discover import _extract_entries
 
-    @endpoint(model=Hub("cozy/sdxl-base", allow_lora=True), resources=Resources(vram_gb=12))
+    @endpoint(model=Hub("cozy/sdxl-base"), resources=Resources(vram_gb=12))
     class Gen:
         def setup(self, model: str) -> None:
             self.model = model
@@ -616,16 +624,18 @@ def test_allow_lora_without_compile_family_raises() -> None:
         def generate(self, ctx: RequestContext, data: _In) -> _Out:
             return _Out(result="")
 
-    with pytest.raises(ValueError, match="allow_lora"):
-        _extract_entries(Gen, "testmod")
+    (entry,) = _extract_entries(Gen, "testmod")
+    (block,) = entry["bindings"].values()
+    assert "family" not in block
 
 
 def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) -> None:
     """pgw#519: model.choices[].binding gets the SAME family stamp that a
     top-level bindings block gets from Compile(family=...) — tensorhub's
-    th#586 architecture gate polices allow_lora targets on both surfaces
-    identically, so a builder-path deploy of a ModelChoice endpoint (e.g.
-    sdxl) doesn't hard-fail while a plain allow_lora endpoint passes."""
+    th#586 architecture gate polices LoRA targets against it on both
+    surfaces identically. pgw#523: the stamp is unconditional-when-known,
+    so EVERY binding under the endpoint (including "vae", which carries no
+    permission flag of any kind any more) gets it, not just some subset."""
     from gen_worker.discovery.discover import discover_functions
 
     pkg = tmp_pkg / "ep_choice_family"
@@ -643,8 +653,8 @@ def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) ->
             steps: int = 28
 
         class M(ModelChoice[D], enum.Enum):
-            A = Model("a", Hub("o/a", allow_lora=True), D(28))
-            B = Model("b", Hub("o/b", allow_lora=True), D(30))
+            A = Model("a", Hub("o/a"), D(28))
+            B = Model("b", Hub("o/b"), D(30))
 
         class In_(msgspec.Struct):
             prompt: str = ""
@@ -653,7 +663,7 @@ def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) ->
         class Out_(msgspec.Struct):
             y: str
 
-        @endpoint(models={"pipeline": Hub("o/base", allow_lora=True), "vae": Hub("o/vae")},
+        @endpoint(models={"pipeline": Hub("o/base"), "vae": Hub("o/vae")},
                   resources=Resources(vram_gb=12),
                   compile=Compile(family="sdxl", shapes=((1024, 1024),)))
         class Gen:
@@ -668,21 +678,21 @@ def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) ->
 
     top_level_family = fn["bindings"]["pipeline"]["family"]
     assert top_level_family == "sdxl"
-    assert "family" not in fn["bindings"]["vae"]      # no allow_lora, no stamp
+    assert fn["bindings"]["vae"]["family"] == "sdxl"  # stamped unconditionally now
 
     by_id = {c["id"]: c for c in fn["model"]["choices"]}
     assert set(by_id) == {"a", "b"}
     for choice in by_id.values():
-        assert choice["binding"]["allow_lora"] is True
+        assert "allow_lora" not in choice["binding"]
         # Choice-binding emission equals top-level emission w.r.t. family.
         assert choice["binding"]["family"] == top_level_family
 
 
-def test_model_choice_allow_lora_without_compile_family_raises(tmp_pkg: Path) -> None:
-    """Mirrors test_allow_lora_without_compile_family_raises for the
-    choices[].binding surface: a ModelChoice endpoint with an allow_lora
-    choice and no Compile(family=...) must fail loudly at discovery, not
-    silently ship an unstamped binding tensorhub's th#586 gate will reject."""
+def test_model_choice_binding_emits_no_family_when_none_declared(tmp_pkg: Path) -> None:
+    """Mirrors test_binding_emits_no_family_when_none_declared for the
+    choices[].binding surface: with no Compile(family=...) a choice binding
+    simply carries no `family` key — discovery no longer hard-fails here
+    (pgw#523 retired the allow_lora-requires-family co-occurrence check)."""
     from gen_worker.discovery.discover import discover_functions
 
     pkg = tmp_pkg / "ep_choice_family_missing"
@@ -699,7 +709,7 @@ def test_model_choice_allow_lora_without_compile_family_raises(tmp_pkg: Path) ->
             steps: int = 28
 
         class M(ModelChoice[D], enum.Enum):
-            A = Model("a", Hub("o/a", allow_lora=True), D(28))
+            A = Model("a", Hub("o/a"), D(28))
 
         class In_(msgspec.Struct):
             prompt: str = ""
@@ -715,5 +725,7 @@ def test_model_choice_allow_lora_without_compile_family_raises(tmp_pkg: Path) ->
                 return Out_(y="ok")
     """))
 
-    with pytest.raises(ValueError, match="allow_lora"):
-        discover_functions(tmp_pkg, main_module="ep_choice_family_missing.main")
+    fns = discover_functions(tmp_pkg, main_module="ep_choice_family_missing.main")
+    (fn,) = fns
+    (choice,) = fn["model"]["choices"]
+    assert "family" not in choice["binding"]

--- a/tests/test_executor_prefetch_binding.py
+++ b/tests/test_executor_prefetch_binding.py
@@ -75,7 +75,7 @@ def test_model_op_download_applies_binding_files(monkeypatch, tmp_path) -> None:
     asyncio.run(_run())
     assert len(calls) == 1
     assert calls[0]["ref"] == _REF
-    assert calls[0]["provider"] == "hf"
+    assert calls[0]["provider"] == "huggingface"
     assert calls[0]["allow_patterns"] == _BINDING.files
 
 
@@ -89,7 +89,7 @@ def test_bare_ref_store_ensure_local_applies_binding_files(monkeypatch, tmp_path
         await ex.store.ensure_local(_REF)
 
     asyncio.run(_run())
-    assert calls[0]["provider"] == "hf"
+    assert calls[0]["provider"] == "huggingface"
     assert calls[0]["allow_patterns"] == _BINDING.files
 
 

--- a/tests/test_slot_discovery.py
+++ b/tests/test_slot_discovery.py
@@ -71,7 +71,7 @@ def test_slot_emits_slots_block_not_model_choices(tmp_pkg: Path) -> None:
     # The plain vae binding still emits through the ordinary bindings block
     # (back-compat: bare ModelRef contributes no `slots` entry).
     assert "vae" not in {s["name"] for s in fn["slots"]}
-    assert fn["bindings"]["vae"]["provider"] == "hf"
+    assert fn["bindings"]["vae"]["provider"] == "huggingface"
 
 
 def test_slot_with_no_selected_by_or_default_emits_minimal_block(tmp_pkg: Path) -> None:
@@ -107,11 +107,12 @@ def test_slot_with_no_selected_by_or_default_emits_minimal_block(tmp_pkg: Path) 
     assert slot["family"] == "sdxl"  # from the default_config preset's registration
 
 
-def test_slot_allow_lora_family_from_fallback_when_no_compile(tmp_pkg: Path) -> None:
-    """pgw#520 reconciliation of pgw#519's _stamp_lora_family: a Slot-
-    declared allow_lora binding with no Compile(family=...) resolves its
-    family stamp from the Slot's own fallback-preset registration instead
-    of hard-failing."""
+def test_slot_family_from_fallback_when_no_compile(tmp_pkg: Path) -> None:
+    """pgw#520 reconciliation of pgw#519's family stamping (pgw#523: the
+    stamp function is now unconditional-when-known, not allow_lora-
+    triggered): a Slot-declared binding with no Compile(family=...)
+    resolves its family stamp from the Slot's own fallback-preset
+    registration."""
     from gen_worker.discovery.discover import discover_functions
 
     pkg = tmp_pkg / "ep_slot_lora"
@@ -130,7 +131,7 @@ def test_slot_allow_lora_family_from_fallback_when_no_compile(tmp_pkg: Path) -> 
 
         @endpoint(model=Slot(
             object,
-            default_checkpoint=Hub("o/base", allow_lora=True),
+            default_checkpoint=Hub("o/base"),
             default_config=SdxlDefaults(steps=28),
         ))
         class Gen:
@@ -141,7 +142,7 @@ def test_slot_allow_lora_family_from_fallback_when_no_compile(tmp_pkg: Path) -> 
 
     fns = discover_functions(tmp_pkg, main_module="ep_slot_lora.main")
     (fn,) = fns
-    assert fn["bindings"]["model"]["allow_lora"] is True
+    assert "allow_lora" not in fn["bindings"]["model"]
     assert fn["bindings"]["model"]["family"] == "sdxl"
 
 
@@ -164,7 +165,7 @@ def test_compile_family_wins_over_slot_fallback_family(tmp_pkg: Path) -> None:
             y: str
 
         @endpoint(
-            model=Slot(object, default_checkpoint=Hub("o/base", allow_lora=True),
+            model=Slot(object, default_checkpoint=Hub("o/base"),
                        default_config=SdxlDefaults(steps=28)),
             compile=Compile(family="explicit-family", shapes=((512, 512),)),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Implements both independently-shippable parts of pgw#523 (SDK half).

**Part A — evict `allow_lora` (identity != permission).** th#772 moved overlay
permission to the slot-policy `loras` axis. The th#586 architecture gate has
always keyed off the declared binding/slot **family** (`EffectiveBindingFamily`
on the tensorhub side) — never `allow_lora` — so the flag never gated anything
at runtime; it only drove a registration-time co-occurrence check
(`allow_lora=true` requires `family`), which the companion tensorhub PR also
retires. This PR deletes `allow_lora` from `ModelRef` and the `Hub(...)`/
`HF(...)` kwargs. `_stamp_lora_family` -> `_stamp_family`: family stamping is
now **unconditional-when-known** on every binding (top-level `bindings` blocks
and `model.choices[].binding` rows alike), not `allow_lora`-triggered — this
is a real behavior change (e.g. a "vae" binding with no lora flag now also
gets the endpoint's `Compile(family=...)` stamp).

**Part B — retire `.provider`/`.ref` back-compat aliases.** pgw#511 left these
on `ModelRef` as narrow-vocabulary shims (`.provider` returned `"hf"` not
`"huggingface"`; no `"modelscope"`). Deleted both; every in-repo consumer
repoints at `.source`/`.path`:
- `discovery/discover.py::_binding_to_manifest` (manifest `provider`/`ref` wire fields)
- `executor.py` (prefetch/download provider dispatch, x3 call sites — two were
  `getattr(binding, "provider", ...)` which would have silently degraded to the
  default instead of erroring)
- `models/residency.py` (cache-key label — same silent-degrade risk)
- `models/provision.py::resolve_bindings`
- `lifecycle.py` (startup prefetch provider checks)
- `cli/prefetch.py`, `cli/listing.py`

The `bindings.<slot>.provider` wire field now carries the pgw#511 vocabulary
directly (`"huggingface"`/`"modelscope"`, not the old `"hf"` short form).
**This PR requires the companion tensorhub PR (widened `provider` DB CHECK +
tolerant manifest parsing) deployed first**, or registration of HF/ModelScope
bindings will start failing tensorhub's provider validation.

`models/refs.py::parse_model_ref` accepts both `"hf"` and `"huggingface"` as
input and keeps normalizing to the internal `"hf"` token, so the ref-grammar
module (`ParsedModelRef`, `wire_ref`, cache/residency keys) and every
`parsed.provider == "hf"` comparison downstream (download.py/provision.py)
are untouched.

Hard cut, no back-compat: `Hub(..., allow_lora=True)` now raises `TypeError`;
`ref.provider`/`ref.ref` now raise `AttributeError`.

## Endpoint follow-ups found (not fixed here, per instructions to stay out of that repo)

- `inference-endpoints/sdxl/src/sdxl/main.py:250` — a design-rationale comment
  describing the `_models.<slot>.loras` / `allow_lora=True` mechanism, which is
  now stale (the `_models` wire channel and `allow_lora` are both gone). No
  functional impact (it's a comment), but worth a follow-up cleanup pass.
- `e2e/scenarios/j15_lazy_ingest_test.go`, `j16_byom_lora_test.go`,
  `j17_juggle_burst_test.go` — hand-construct manifest JSON containing
  `"allow_lora": true`. Still parses fine (tensorhub is parse-tolerant of the
  retired key), so these are not broken, but they're now testing/documenting
  vestigial wire shape.

## Test plan
- [x] `uv run --extra dev mypy src/gen_worker` — 0 new errors (15 baseline-identical,
      pre-existing: missing `requests`/`yaml` stubs, one unrelated redef, etc.)
- [x] `uv run --extra dev ruff check src/gen_worker tests` — 0 new findings (8
      pre-existing findings, all in files this PR never touches)
- [x] `uv run --extra dev pytest` — 942 passed / 7 skipped / 1 deselected
      (pgw#503, pre-existing gpu-ci flake) / 5 failed — all 5 failures are the
      known `GEN_WORKER_FORBID_CPU_OFFLOAD=1` dev-box veto on CPU-offload
      placement paths, in files this PR does not touch
      (`test_content_lanes.py`, `test_ram_admission.py`,
      `test_snapshot_corruption.py`)
- [x] Version bumped 0.19.0 -> 0.20.0 (breaking); CHANGELOG updated

## Deploy order
1. tensorhub companion PR (widened provider CHECK + tolerant manifest parsing) — deploy first.
2. This PR / PyPI release.

DO NOT MERGE — for review only per task instructions.
