### PR TITLE
gw#521 + gw#522: emergency-quant rung actually works; canonical publish names on every path

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
-import json
 import logging
 import os
 import re
@@ -35,9 +34,12 @@ from .ingest import (
     plan_huggingface,
 )
 from .writer import (
+    CAST_NORMALIZE_DTYPES as _CAST_NORMALIZE_DTYPES,
     FP8_DEFAULT_COMPONENTS,
     MAX_SAFETENSORS_SHARD_BYTES,
+    VARIANT_WEIGHT_NAME_RE as _VARIANT_WEIGHT_NAME_RE,
     copy_non_weight_files,
+    normalize_variant_filenames as _normalize_variant_filenames,
     shard_safetensors_by_offset,
     snapshot_weight_groups,
 )
@@ -155,62 +157,6 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
 # ---------------------------------------------------------------------------
 # Flavor tree construction
 # ---------------------------------------------------------------------------
-
-_CAST_NORMALIZE_DTYPES = {"fp16", "bf16", "fp32", "f16", "f32"}
-
-_VARIANT_WEIGHT_NAME_RE = re.compile(
-    r"^(?P<base>.+)\.(?P<v>fp16|bf16|fp32)"
-    r"(?P<shard>-\d{5}-of-\d{5})?\.safetensors(?P<idx>\.index\.json)?$"
-)
-
-
-def _normalize_variant_filenames(tree: Path) -> None:
-    """Strip dtype-variant tokens from published weight filenames.
-
-    dtype is a checkpoint axis (flavor) in repo-cas — one dtype per tree — so
-    HF variant suffixes are redundant, and the resharder composes an index
-    name diffusers cannot find (J23 live: juggernaut-xl published
-    "diffusion_pytorch_model.fp16.safetensors.index.json" where diffusers'
-    _add_variant expects "diffusion_pytorch_model.safetensors.index.fp16.json";
-    variant=fp16 serve setup died). Canonical names sidestep the class.
-    A directory whose canonical twin already exists is left untouched
-    (dual-dtype upstream trees must not collide). Quant flavors (fp8/int4/…)
-    are never normalized — their names carry loader semantics."""
-    dirs = sorted({p.parent for p in tree.rglob("*.safetensors*") if p.is_file()})
-    for d in dirs:
-        renames: dict[str, str] = {}
-        for p in sorted(d.iterdir()):
-            m = _VARIANT_WEIGHT_NAME_RE.match(p.name)
-            if not m:
-                continue
-            new_name = f"{m['base']}{m['shard'] or ''}.safetensors{m['idx'] or ''}"
-            if (d / new_name).exists():
-                renames.clear()
-                break
-            renames[p.name] = new_name
-        for old_name, new_name in renames.items():
-            (d / old_name).rename(d / new_name)
-        if not renames:
-            continue
-        for idx in d.glob("*.safetensors.index.json"):
-            try:
-                payload = json.loads(idx.read_text(encoding="utf-8"))
-            except Exception:  # noqa: BLE001
-                continue
-            weight_map = payload.get("weight_map")
-            if not isinstance(weight_map, dict):
-                continue
-            changed = False
-            for key, shard in weight_map.items():
-                if shard in renames:
-                    weight_map[key] = renames[shard]
-                    changed = True
-            if changed:
-                idx.write_text(
-                    json.dumps(payload, separators=(",", ":"), sort_keys=True),
-                    encoding="utf-8",
-                )
-
 
 def _stage_oversize_safetensors(tree: Path) -> None:
     """Replace any >5 GB safetensors in the tree with HF-convention byte-offset
@@ -414,6 +360,20 @@ def _publish_from_bank(
                 "download-skip bank miss for %s:%s spec=%s (found=%s ready=%s)",
                 provider, plan.source_ref, spec.label,
                 bool(r.get("found")), bool(r.get("ready")))
+            return None
+        # gw#522: manifests banked before the canonical-naming pass carry
+        # variant-token filenames diffusers cannot load (old-convention
+        # sharded index); replaying them republishes the breakage forever.
+        # Treat as a miss — the full clone re-creates canonical names.
+        stale = [
+            str(f.get("path") or "") for f in payload["files"]
+            if _VARIANT_WEIGHT_NAME_RE.match(Path(str(f.get("path") or "")).name)
+        ]
+        if stale:
+            logger.warning(
+                "download-skip bank entry for %s:%s spec=%s predates canonical "
+                "naming (e.g. %s); full clone republishes canonical names",
+                provider, plan.source_ref, spec.label, stale[0])
             return None
         payloads[spec.label] = payload
 
@@ -805,6 +765,12 @@ def run_clone(
                     "file_type": spec.file_type, "reason": str(exc),
                 })
                 continue
+
+            # gw#522: EVERY publish path emits canonical filenames — this
+            # seam also covers the publish-as-is lane build_flavor_tree
+            # never touches. Idempotent on already-normalized trees.
+            if spec.file_type != "gguf" and flavor_label in _CAST_NORMALIZE_DTYPES:
+                _normalize_variant_filenames(Path(tree))
 
             files = files_from_tree(tree)
             if not files:

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -18,6 +18,7 @@ torch/safetensors imports are deferred so importing gen_worker.convert stays che
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import struct
 from dataclasses import dataclass
@@ -1014,9 +1015,74 @@ def shard_safetensors_by_offset(
         os.close(fd)
 
 
+# ---------------------------------------------------------------------------
+# Canonical published filenames (gw#466 / gw#522)
+# ---------------------------------------------------------------------------
+
+CAST_NORMALIZE_DTYPES = {"fp16", "bf16", "fp32", "f16", "f32"}
+
+VARIANT_WEIGHT_NAME_RE = re.compile(
+    r"^(?P<base>.+)\.(?P<v>fp16|bf16|fp32)"
+    r"(?P<shard>-\d{5}-of-\d{5})?\.safetensors(?P<idx>\.index\.json)?$"
+)
+
+
+def normalize_variant_filenames(tree: Path) -> None:
+    """Strip dtype-variant tokens from published weight filenames — the ONE
+    canonical-naming pass every publish path runs (gw#466, unified by gw#522).
+
+    dtype is a checkpoint axis (flavor) in repo-cas — one dtype per tree — so
+    HF variant suffixes are redundant, and the resharder composes an index
+    name diffusers cannot find (live twice: J23 juggernaut-xl, gw#522
+    sdxl-base — "diffusion_pytorch_model.fp16.safetensors.index.json" where
+    diffusers' _add_variant expects
+    "diffusion_pytorch_model.safetensors.index.fp16.json"; loads died).
+    Canonical names sidestep the class. A directory whose canonical twin
+    already exists is left untouched (dual-dtype upstream trees must not
+    collide). Quant flavors (fp8/int4/…) are never normalized — their names
+    carry loader semantics. Idempotent."""
+    dirs = sorted({p.parent for p in Path(tree).rglob("*.safetensors*") if p.is_file()})
+    for d in dirs:
+        renames: dict[str, str] = {}
+        for p in sorted(d.iterdir()):
+            m = VARIANT_WEIGHT_NAME_RE.match(p.name)
+            if not m:
+                continue
+            new_name = f"{m['base']}{m['shard'] or ''}.safetensors{m['idx'] or ''}"
+            if (d / new_name).exists():
+                renames.clear()
+                break
+            renames[p.name] = new_name
+        for old_name, new_name in renames.items():
+            (d / old_name).rename(d / new_name)
+        if not renames:
+            continue
+        for idx in d.glob("*.safetensors.index.json"):
+            try:
+                payload = json.loads(idx.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001
+                continue
+            weight_map = payload.get("weight_map")
+            if not isinstance(weight_map, dict):
+                continue
+            changed = False
+            for key, shard in weight_map.items():
+                if shard in renames:
+                    weight_map[key] = renames[shard]
+                    changed = True
+            if changed:
+                idx.write_text(
+                    json.dumps(payload, separators=(",", ":"), sort_keys=True),
+                    encoding="utf-8",
+                )
+
+
 __all__ = [
     "ConversionImplementationError",
+    "CAST_NORMALIZE_DTYPES",
     "MAX_SAFETENSORS_SHARD_BYTES",
+    "VARIANT_WEIGHT_NAME_RE",
+    "normalize_variant_filenames",
     "ShardPlan",
     "plan_shards",
     "build_index",

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -127,6 +127,12 @@ FP8_COMPUTE_MIN_SM = 89
 
 EMERGENCY_NF4_VRAM_FACTOR = 0.45  # nf4 denoiser, encoders/VAE at compute dtype
 
+# Per-component resident-bytes factor for a bnb-nf4 quantized module vs its
+# bf16/fp16 stored bytes (4-bit packed + double-quant + quant-state overhead).
+# Used by the load-time fit ladder's per-component estimate (gw#521); the
+# whole-model EMERGENCY_NF4_VRAM_FACTOR above stays the hub-side coarse spec.
+NF4_WEIGHT_BYTES_FACTOR = 0.30
+
 
 __all__ = [
     "FP8_COMPUTE_MIN_SM",
@@ -136,6 +142,7 @@ __all__ = [
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
     "EMERGENCY_NF4_VRAM_FACTOR",
+    "NF4_WEIGHT_BYTES_FACTOR",
     "Placement",
     "classify_flavor_token",
     "default_placement",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .ladder import EMERGENCY_NF4_VRAM_FACTOR
+from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
 
 logger = logging.getLogger(__name__)
 
@@ -688,29 +688,57 @@ def runtime_fp8_storage_supported() -> bool:
         return False
 
 
+def model_index_components(path: str | Path) -> set:
+    """Component names the snapshot's model_index.json declares. Empty set
+    when there is no readable model_index.json (single-file checkpoints,
+    transformers layouts)."""
+    try:
+        with open(Path(path) / "model_index.json", "r", encoding="utf-8") as f:
+            index = json.load(f)
+        return {k for k in index if not k.startswith("_")}
+    except Exception:
+        return set()
+
+
+def _safetensors_data_bytes(p: Path) -> int:
+    import struct
+
+    with open(p, "rb") as f:
+        raw = f.read(8)
+        if len(raw) < 8:
+            return 0
+        (n,) = struct.unpack("<Q", raw)
+        if n <= 0 or n > _MAX_SAFETENSORS_HEADER_BYTES:
+            return 0
+        header = json.loads(f.read(n))
+    total = 0
+    for value in header.values():
+        if isinstance(value, dict) and "data_offsets" in value:
+            s, e = value["data_offsets"]
+            total += int(e) - int(s)
+    return total
+
+
+def snapshot_component_weight_bytes(model_path: Path) -> Dict[str, int]:
+    """Tensor bytes per top-level component dir (header-declared data ranges;
+    no tensor reads). Root-level files book under ``""``. Empty dict when
+    undetectable."""
+    out: Dict[str, int] = {}
+    root = Path(model_path)
+    try:
+        for p in sorted(root.rglob("*.safetensors")):
+            rel = p.relative_to(root)
+            comp = rel.parts[0] if len(rel.parts) > 1 else ""
+            out[comp] = out.get(comp, 0) + _safetensors_data_bytes(p)
+    except (OSError, ValueError):
+        return {}
+    return {k: v for k, v in out.items() if v > 0}
+
+
 def snapshot_weight_bytes(model_path: Path) -> int:
     """Total tensor bytes across the snapshot's safetensors (header-declared
     data ranges; no tensor reads). 0 when undetectable."""
-    import struct
-
-    total = 0
-    try:
-        for p in sorted(Path(model_path).rglob("*.safetensors")):
-            with open(p, "rb") as f:
-                raw = f.read(8)
-                if len(raw) < 8:
-                    continue
-                (n,) = struct.unpack("<Q", raw)
-                if n <= 0 or n > _MAX_SAFETENSORS_HEADER_BYTES:
-                    continue
-                header = json.loads(f.read(n))
-            for value in header.values():
-                if isinstance(value, dict) and "data_offsets" in value:
-                    s, e = value["data_offsets"]
-                    total += int(e) - int(s)
-    except (OSError, ValueError):
-        return 0
-    return total
+    return sum(snapshot_component_weight_bytes(model_path).values())
 
 
 def bitsandbytes_available() -> bool:
@@ -729,9 +757,18 @@ def bitsandbytes_available() -> bool:
         return False
 
 
-def emergency_quantization_config(cls: Any) -> Optional[Any]:
-    """Denoiser-scoped bnb-nf4 config for the emergency rung. None (with a
-    warning) when the stack can't do it — the offload ladder then carries it."""
+def emergency_quantization_config(
+    cls: Any,
+    *,
+    components: Optional[List[str]] = None,
+    compute_dtype: Any = None,
+) -> Optional[Any]:
+    """bnb-nf4 config for the emergency rung, scoped to ``components`` (the
+    snapshot's REAL denoiser/text-encoder names — gw#521: a config naming
+    absent components is silently ignored by diffusers, so the caller derives
+    the list from the tree and this function refuses an empty one). None
+    (with a warning) when the stack can't do it — the offload ladder then
+    carries it."""
     if not bitsandbytes_available():
         logger.warning(
             "emergency nf4 unavailable (bitsandbytes not installed in this "
@@ -751,31 +788,71 @@ def emergency_quantization_config(cls: Any) -> Optional[Any]:
     kwargs: Dict[str, Any] = {
         "load_in_4bit": True,
         "bnb_4bit_quant_type": "nf4",
-        "bnb_4bit_compute_dtype": torch.bfloat16,
+        "bnb_4bit_compute_dtype": compute_dtype or torch.bfloat16,
         "bnb_4bit_use_double_quant": True,
     }
     if isinstance(cls, type) and issubclass(cls, diffusers.DiffusionPipeline):
-        return PipelineQuantizationConfig(
-            quant_backend="bitsandbytes_4bit",
-            quant_kwargs=kwargs,
-            components_to_quantize=list(_FP8_STORAGE_COMPONENTS),
-        )
+        targets = list(_FP8_STORAGE_COMPONENTS) if components is None else list(components)
+        if not targets:
+            logger.warning(
+                "emergency nf4 skipped: no quantizable component in the "
+                "snapshot (denoiser-less tree); the offload ladder carries it"
+            )
+            return None
+        try:
+            return PipelineQuantizationConfig(
+                quant_backend="bitsandbytes_4bit",
+                quant_kwargs=kwargs,
+                components_to_quantize=targets,
+            )
+        except ValueError as exc:
+            # diffusers validates the bnb config signature against BOTH
+            # libraries; a diffusers/transformers skew raises here — skip the
+            # rung instead of killing the load.
+            logger.warning("emergency nf4 unavailable (%s); falling to offload", exc)
+            return None
     from diffusers.quantizers.quantization_config import BitsAndBytesConfig
 
     return BitsAndBytesConfig(**kwargs)
 
 
+def _bnb_quantized_components(pipe: Any, targets: List[str]) -> List[str]:
+    """The subset of ``targets`` whose modules actually hold bnb 4-bit layers
+    after the load — the gw#521 no-op detector (diffusers silently ignores
+    config components absent from the pipeline)."""
+    landed: List[str] = []
+    for name in targets:
+        mod = getattr(pipe, name, None)
+        if mod is None or not hasattr(mod, "modules"):
+            continue
+        try:
+            for m in mod.modules():
+                if type(m).__name__ in ("Linear4bit", "LinearNF4", "LinearFP4"):
+                    landed.append(name)
+                    break
+        except Exception:  # noqa: BLE001
+            continue
+    return landed
+
+
 def _adaptive_fit_rung(
-    cls: Any, path: Path, *, fp8_planned: bool
+    cls: Any, path: Path, *, fp8_planned: bool, compute_dtype: Any = None
 ) -> tuple[str, Optional[Any]]:
     """Serve-time fit ladder at load (th#683 P3): when the snapshot's
     estimated resident bytes (after any planned fp8 storage) exceed free
-    VRAM, engage the cheapest-quality-loss runtime lever that fits:
-    fp8-E4M3 storage first (bf16/fp16 weights ~halve, quality ~= a stored
-    #fp8 flavor), then the nf4 emergency rung. Returns ``(mode, config)``:
-    ``("", None)`` fits as planned; ``("fp8", None)`` engage fp8 storage;
-    ``("nf4", qc)`` emergency-quantize (qc None when the stack can't — the
-    offload ladder then carries it)."""
+    VRAM, engage the cheapest-quality-loss runtime lever that FITS:
+    fp8-E4M3 storage first (denoiser weights ~halve, quality ~= a stored
+    #fp8 flavor), then the nf4 emergency rung — denoiser first, text
+    encoders joining only when the denoiser alone isn't enough. Targets are
+    the snapshot's REAL component names (gw#521: a config naming absent
+    components is silently ignored by diffusers — the rung must never be a
+    hard-coded archetype guess). When even nf4 cannot fit, the rung is
+    SKIPPED (full-precision weights preserved; the offload ladder carries
+    it) instead of paying the quality cost for nothing.
+
+    Returns ``(mode, config)``: ``("", None)`` fits as planned (or no rung
+    helps); ``("fp8", None)`` engage fp8 storage; ``("nf4", qc)``
+    emergency-quantize."""
     if not emergency_quant_enabled():
         return "", None
     from .memory import get_available_vram_gb
@@ -783,34 +860,68 @@ def _adaptive_fit_rung(
     free_gb = get_available_vram_gb()
     if free_gb <= 0:
         return "", None
-    disk = snapshot_weight_bytes(path)
-    if disk <= 0:
+    comp_bytes = snapshot_component_weight_bytes(path)
+    total = sum(comp_bytes.values())
+    if total <= 0:
         return "", None
-    resident_gb = disk / float(1 << 30)
-    if fp8_planned and detect_on_disk_dtype(path) != "fp8":
-        resident_gb *= 0.5  # bf16/fp16 snapshot halved by fp8 storage
-    budget_gb = max(0.0, free_gb - _EMERGENCY_MARGIN_GB)
-    if resident_gb <= budget_gb:
+    budget = max(0.0, free_gb - _EMERGENCY_MARGIN_GB) * float(1 << 30)
+
+    named = model_index_components(path) or set(comp_bytes)
+    denoisers = [c for c in _FP8_STORAGE_COMPONENTS
+                 if c in named and comp_bytes.get(c, 0) > 0]
+    encoders = [c for c in _FP8_TEXT_ENCODER_COMPONENTS
+                if c in named and comp_bytes.get(c, 0) > 0]
+    denoiser_bytes = sum(comp_bytes[c] for c in denoisers)
+
+    on_disk = detect_on_disk_dtype(path)
+    resident = float(total)
+    if fp8_planned and on_disk != "fp8":
+        resident -= 0.5 * denoiser_bytes  # fp8 storage halves the denoiser
+    total_gb = total / float(1 << 30)
+    if resident <= budget:
         return "", None
     # fp8-storage rung: only for un-quantized bf16/fp16 snapshots (an already
     # quantized flavor can't be halved again) when the halved estimate fits.
-    if not fp8_planned and detect_on_disk_dtype(path) in ("bf16", "fp16") \
+    if not fp8_planned and on_disk in ("bf16", "fp16") and denoisers \
             and runtime_fp8_storage_supported() \
-            and resident_gb * 0.5 <= budget_gb:
+            and total - 0.5 * denoiser_bytes <= budget:
         logger.warning(
             "fp8-E4M3 emergency weight storage engaged for %s (%.1f GB "
             "weights, %.1f GB free) — near-native quality; a stored #fp8 "
             "flavor of this model would serve natively here.",
-            path, resident_gb, free_gb,
+            path, total_gb, free_gb,
         )
         return "fp8", None
-    qc = emergency_quantization_config(cls)
+    if not denoisers:
+        logger.warning(
+            "emergency nf4 skipped for %s: no denoiser component in the "
+            "snapshot (components: %s); the offload ladder carries it",
+            path, sorted(named),
+        )
+        return "", None
+    # nf4 rung: denoiser first; text encoders join only when needed.
+    targets = list(denoisers)
+    est = total - denoiser_bytes * (1.0 - NF4_WEIGHT_BYTES_FACTOR)
+    if est > budget and encoders:
+        targets += encoders
+        est -= sum(comp_bytes[c] for c in encoders) * (1.0 - NF4_WEIGHT_BYTES_FACTOR)
+    if est > budget:
+        logger.warning(
+            "emergency nf4 skipped for %s: even 4-bit weights (~%.1f GB) "
+            "exceed the %.1f GB budget; keeping full precision — the "
+            "offload ladder carries it",
+            path, est / float(1 << 30), budget / float(1 << 30),
+        )
+        return "", None
+    qc = emergency_quantization_config(
+        cls, components=targets, compute_dtype=compute_dtype)
     if qc is not None:
         logger.warning(
-            "EMERGENCY 4-bit quantization engaged for %s (%.1f GB weights, "
-            "%.1f GB free) — quality below platform standards; a larger card "
-            "or Blackwell SKU would serve stored flavors instead.",
-            path, resident_gb, free_gb,
+            "EMERGENCY 4-bit quantization engaged for %s (components %s; "
+            "%.1f GB weights, %.1f GB free) — quality below platform "
+            "standards; a larger card or Blackwell SKU would serve stored "
+            "flavors instead.",
+            path, targets, total_gb, free_gb,
         )
     return "nf4", qc
 
@@ -885,7 +996,10 @@ def load_from_pretrained(
     if not read_on_disk_quant_config(Path(path)):
         qc = synthesize_quantization_config(attrs)
         if qc is None:
-            mode, eqc = _adaptive_fit_rung(cls, Path(path), fp8_planned=fp8_storage)
+            mode, eqc = _adaptive_fit_rung(
+                cls, Path(path), fp8_planned=fp8_storage,
+                compute_dtype=kwargs.get("torch_dtype"),
+            )
             if mode == "fp8":
                 fp8_storage = True  # runtime fp8-E4M3 storage rung (th#683)
                 adaptive_rung = "fp8"
@@ -919,6 +1033,19 @@ def load_from_pretrained(
             pipe._cozy_fp8_storage_ok = bool(applied)
         except Exception:
             pass
+    if adaptive_rung == "nf4":
+        # gw#521: verify the quant actually LANDED — a config whose component
+        # names miss the pipeline is silently ignored by diffusers, and a
+        # full-precision pipeline stamped "nf4" lies to placement and billing.
+        targets = list(getattr(
+            kwargs.get("quantization_config"), "components_to_quantize", None) or [])
+        if targets and not _bnb_quantized_components(pipe, targets):
+            logger.error(
+                "EMERGENCY nf4 did NOT land on %s (targets %s, pipeline %s) — "
+                "serving full precision; the offload ladder carries it",
+                path, targets, type(pipe).__name__,
+            )
+            adaptive_rung = ""
     if adaptive_rung:
         # gw#491: a silently-engaged emergency rung is the th#736 bug class —
         # the executor reconciles this stamp into ServePlan.ran / FnDegraded.
@@ -943,6 +1070,8 @@ __all__ = [
     "bitsandbytes_available",
     "runtime_fp8_storage_supported",
     "emergency_quantization_config",
+    "model_index_components",
+    "snapshot_component_weight_bytes",
     "snapshot_weight_bytes",
     "load_from_pretrained",
 ]

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -535,21 +535,25 @@ def select_auto_mode(
         requirement = max(model_gb, float(peak_vram_gb))
     margin = _DEFAULT_SAFETY_MARGIN_GB
 
-    # Very low free VRAM: even a fitting model needs aggressive help for activations.
-    if avail <= _DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB:
-        return "group_offload"
-
     if requirement > 0.0:
         usable = max(0.0, avail - margin)
-        if requirement > usable:
-            return "model_offload"
-        # Fits. With generous FREE headroom run fully unoptimized; on a tighter
-        # card keep the cheap vae_only guard for VAE-decode spikes.
-        if (usable - requirement) >= _DEFAULT_OFF_HEADROOM_GB:
-            return "off"
-        return "vae_only"
+        # Fits (measured weights + margin — a quantized pipeline measures its
+        # REAL post-quant size): resident, never offloaded. gw#521: the old
+        # absolute low-free-VRAM rule group-offloaded pipelines the emergency
+        # rung had just shrunk to fit, making the rung pointless on exactly
+        # the cards it exists for.
+        if requirement <= usable:
+            if (usable - requirement) >= _DEFAULT_OFF_HEADROOM_GB:
+                return "off"
+            return "vae_only"
+        # Doesn't fit: very low free VRAM needs the aggressive rung.
+        if avail <= _DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB:
+            return "group_offload"
+        return "model_offload"
 
     # Unknown model size: conservative free-VRAM thresholds.
+    if avail <= _DEFAULT_GROUP_OFFLOAD_THRESHOLD_GB:
+        return "group_offload"
     if avail <= _DEFAULT_MODEL_OFFLOAD_THRESHOLD_GB:
         return "model_offload"
     return "vae_only"
@@ -650,6 +654,9 @@ def _apply_group_offload(
     *,
     offload_to_disk_path: Optional[str],
 ) -> bool:
+    # Mechanism-level guard (gw#521): every offload entry point refuses under
+    # the kill-switch, not just the apply_low_vram_config policy layer.
+    _forbid_cpu_inference("group offload (weights stream from CPU/disk)")
     try:
         import torch
     except Exception:
@@ -897,6 +904,7 @@ def apply_low_vram_config(
             )
 
     if effective_mode == "model_offload":
+        _forbid_cpu_inference("model CPU offload")  # mechanism guard (gw#521)
         _pin_fragile_vae(pipeline, applied, log)
         ok = _call_if_present(pipeline, "enable_model_cpu_offload")
         if not ok:
@@ -917,6 +925,7 @@ def apply_low_vram_config(
             effective_mode = "sequential"
 
     if effective_mode == "sequential":
+        _forbid_cpu_inference("sequential CPU offload")  # mechanism guard (gw#521)
         _pin_fragile_vae(pipeline, applied, log)
         _move_pipeline_to_cpu(pipeline)
         flush_memory()

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -18,7 +18,6 @@ ModelScope downloads — through the same download layer.
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -26,6 +25,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
 from ..config import get_settings
+from .loading import model_index_components
+
+__all__ = ["model_index_components"]  # re-export: single source in loading.py (gw#521)
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +41,6 @@ class ModelResolutionError(Exception):
 # ---------------------------------------------------------------------------
 # Shared load + place + compile (executor and CLI)
 # ---------------------------------------------------------------------------
-
-
-def model_index_components(path: str | Path) -> set:
-    """Component names the snapshot's model_index.json declares — the
-    only names safe to pass as preloaded modules to from_pretrained."""
-    try:
-        with open(Path(path) / "model_index.json", "r", encoding="utf-8") as f:
-            index = json.load(f)
-        return {k for k in index if not k.startswith("_")}
-    except Exception:
-        return set()
 
 
 @dataclass

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -127,6 +127,19 @@ def _obj_manages_own_device(obj: Any) -> bool:
     )
 
 
+def _obj_offload_hooked(obj: Any) -> bool:
+    """Any offload arming that parks weights in host RAM (gw#521): the
+    diffusers CPU-offload modes plus the ie#468 block-window rung."""
+    if _obj_manages_own_device(obj):
+        return True
+    try:
+        from .loading import block_offload_active
+
+        return bool(block_offload_active(obj))
+    except Exception:
+        return False
+
+
 def _move_obj(obj: Any, device: str) -> None:
     """Whole-object ``.to(device)``. Raises on failure — the caller
     (:meth:`Residency._move_verified`) owns rollback; swallowing a mid-move
@@ -271,7 +284,32 @@ class Residency:
     ) -> None:
         """Register a VRAM-resident object with its MEASURED footprint
         (``torch.cuda.memory_allocated`` delta across the load, or
-        :func:`~gen_worker.models.memory.estimate_cuda_resident_gb`)."""
+        :func:`~gen_worker.models.memory.estimate_cuda_resident_gb`).
+
+        Offload-hooked pipelines (diffusers CPU-offload modes, block-window
+        offload) are booked in the RAM tier instead (gw#521): their weights
+        rest in host RAM and the allocator delta across such a load is noise
+        (0.03GB registered live), so a VRAM booking would be a lie in both
+        tier and size."""
+        if obj is not None and _obj_offload_hooked(obj):
+            logger.info(
+                "residency: %s is offload-hooked; booking RAM tier "
+                "(VRAM unmeasurable under offload hooks)", ref,
+            )
+            hint = int(estimate_pipeline_size_gb(obj) * _GiB)
+            with self._lock:
+                e = self._entries.setdefault(ref, _Entry(ref=ref, tier=Tier.RAM))
+                e.tier = Tier.RAM
+                e.obj = obj
+                if path is not None:
+                    e.path = Path(path)
+                e.vram_bytes = 0
+                e.vram_hint = max(e.vram_hint, hint)
+                if pinned:
+                    e.pinned = True
+                e.last_used = time.monotonic()
+            self._emit(ref, IN_RAM)
+            return
         measured = int(vram_bytes)
         if measured <= 0 and obj is not None:
             measured = int(estimate_cuda_resident_gb(obj) * _GiB)

--- a/tests/convert/test_variant_index_load_gw522.py
+++ b/tests/convert/test_variant_index_load_gw522.py
@@ -1,0 +1,202 @@
+"""gw#522: sharded-variant index names must be loadable by REAL diffusers.
+
+The mirror producer composed the sharded index as
+``diffusion_pytorch_model.fp16.safetensors.index.json`` (variant token before
+the extension); diffusers >=0.28 ``_add_variant`` looks for
+``diffusion_pytorch_model.safetensors.index.fp16.json``, falls through
+safetensors, then dies on ``no file named diffusion_pytorch_model.fp16.bin``
+(verified live: tensorhub/sdxl-base fp16, snapshot 02fea340). The canonical-
+naming pass (gw#466, unified across ALL publish paths here) strips variant
+tokens entirely, which sidesteps the convention split.
+
+These tests build the exact broken tree shape with the real resharder, prove
+real diffusers rejects it, and prove the canonical tree loads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import gen_worker.convert.clone as clone_mod
+from gen_worker.convert.clone import OutputSpec, _publish_from_bank
+from gen_worker.convert.writer import normalize_variant_filenames
+
+diffusers = pytest.importorskip("diffusers")
+torch = pytest.importorskip("torch")
+
+
+def _tiny_unet_fp16_tree(tmp_path: Path) -> Path:
+    """A snapshot tree whose unet is a single fp16-variant safetensors."""
+    from diffusers import UNet2DConditionModel
+
+    unet = UNet2DConditionModel(
+        block_out_channels=(4, 8), layers_per_block=1, sample_size=8,
+        in_channels=4, out_channels=4, norm_num_groups=2,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+        attention_head_dim=2, cross_attention_dim=8,
+    ).to(torch.float16)
+    unet.save_pretrained(tmp_path / "unet", safe_serialization=True, variant="fp16")
+    assert (tmp_path / "unet" / "diffusion_pytorch_model.fp16.safetensors").exists()
+    return tmp_path
+
+
+def _reshard_old_convention(tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the REAL resharder with a tiny threshold — this is exactly how the
+    live mirrors got their old-convention index names."""
+    from gen_worker.convert.writer import shard_safetensors_by_offset
+
+    monkeypatch.setattr(clone_mod, "MAX_SAFETENSORS_SHARD_BYTES", 16 * 1024)
+    monkeypatch.setattr(
+        clone_mod, "shard_safetensors_by_offset",
+        lambda f, stage, **kw: shard_safetensors_by_offset(
+            f, stage, max_shard_bytes=16 * 1024, **kw),
+    )
+    clone_mod._stage_oversize_safetensors(tree)
+
+
+class TestShardedVariantIndex:
+    def test_old_convention_tree_is_unloadable_by_real_diffusers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Negative control: the pre-fix tree shape dies exactly like the
+        live sdxl-base mirror did."""
+        tree = _tiny_unet_fp16_tree(tmp_path)
+        _reshard_old_convention(tree, monkeypatch)
+        old_idx = tree / "unet" / "diffusion_pytorch_model.fp16.safetensors.index.json"
+        assert old_idx.exists(), "resharder no longer composes the old name?"
+
+        from diffusers import UNet2DConditionModel
+
+        with pytest.raises(OSError, match="fp16"):
+            UNet2DConditionModel.from_pretrained(tree / "unet", variant="fp16")
+
+    def test_canonical_tree_loads_with_real_diffusers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tree = _tiny_unet_fp16_tree(tmp_path)
+        _reshard_old_convention(tree, monkeypatch)
+        normalize_variant_filenames(tree)
+
+        unet_dir = tree / "unet"
+        assert (unet_dir / "diffusion_pytorch_model.safetensors.index.json").exists()
+        assert not list(unet_dir.glob("*.fp16.*"))
+
+        from diffusers import UNet2DConditionModel
+
+        # torch_dtype as the serve path passes it after on-disk dtype sniffing.
+        loaded = UNet2DConditionModel.from_pretrained(
+            unet_dir, torch_dtype=torch.float16)
+        assert loaded.dtype == torch.float16
+        assert sum(p.numel() for p in loaded.parameters()) > 0
+
+
+# ---------------------------------------------------------------------------
+# th#592 bank replay: manifests banked before canonical naming must MISS
+# ---------------------------------------------------------------------------
+
+
+class _FakePlan:
+    source_ref = "acme/sdxl"
+    revision = "deadbeef"
+
+    def bank_files(self):
+        return [("unet/diffusion_pytorch_model.fp16.safetensors.index.json", 10, "b3")]
+
+
+class _FakeHub:
+    def __init__(self, payload_files: list) -> None:
+        self._files = payload_files
+        self.commits: list = []
+
+    def lookup_clone_manifests(self, destination: str, keys: list) -> dict:
+        return {
+            k: {
+                "found": True,
+                "ready": True,
+                "payload": {
+                    "files": self._files,
+                    "flavor": "fp16",
+                    "metadata": {},
+                    "repo_spec": {},
+                },
+            }
+            for k in keys
+        }
+
+    def commit(self, **kwargs: Any) -> Any:  # pragma: no cover — must not run
+        self.commits.append(kwargs)
+        raise AssertionError("bank publish must not replay old-convention names")
+
+
+def test_bank_entries_with_old_convention_names_miss(caplog: Any) -> None:
+    hub = _FakeHub([
+        {"path": "unet/diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+         "size_bytes": 5, "blake3": "x"},
+        {"path": "unet/diffusion_pytorch_model.fp16.safetensors.index.json",
+         "size_bytes": 5, "blake3": "y"},
+    ])
+    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    result = _publish_from_bank(
+        hub, plan=_FakePlan(), provider="huggingface", specs=[spec],
+        bank_keys={spec.label: "k1"}, destination="acme/sdxl", tags=[],
+        mode="merge", progress=None,
+    )
+    assert result is None
+    assert hub.commits == []
+
+
+def test_bank_entries_with_canonical_names_replay() -> None:
+    """Canonical banked manifests still take the download-skip path."""
+    files = [
+        {"path": "unet/diffusion_pytorch_model-00001-of-00002.safetensors",
+         "size_bytes": 5, "blake3": "x"},
+        {"path": "unet/diffusion_pytorch_model.safetensors.index.json",
+         "size_bytes": 5, "blake3": "y"},
+    ]
+
+    class _Hub(_FakeHub):
+        def commit(self, **kwargs: Any) -> Any:
+            self.commits.append(kwargs)
+
+            class _C:
+                revision_id = "r1"
+                checkpoint_id = "c1"
+                uploaded = 0
+                deduped = 2
+                total_bytes = 10
+
+            return _C()
+
+    hub = _Hub(files)
+    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    result = _publish_from_bank(
+        hub, plan=_FakePlan(), provider="huggingface", specs=[spec],
+        bank_keys={spec.label: "k1"}, destination="acme/sdxl", tags=[],
+        mode="merge", progress=None,
+    )
+    assert result is not None
+    assert len(hub.commits) == 1
+
+
+# ---------------------------------------------------------------------------
+# publish seam: the as-is lane gets canonical names too
+# ---------------------------------------------------------------------------
+
+
+def test_publish_seam_normalizes_any_cast_tree(tmp_path: Path) -> None:
+    """The run_clone seam covers trees build_flavor_tree never touched
+    (publish-as-is lane): variant-token names come out canonical."""
+    d = tmp_path / "text_encoder"
+    d.mkdir()
+    (d / "model.fp16.safetensors").write_bytes(b"x")
+    idx = {"metadata": {}, "weight_map": {"w": "model.fp16.safetensors"}}
+    (d / "model.fp16.safetensors.index.json").write_text(json.dumps(idx))
+    normalize_variant_filenames(tmp_path)
+    assert (d / "model.safetensors").exists()
+    assert (d / "model.safetensors.index.json").exists()
+    wm = json.loads((d / "model.safetensors.index.json").read_text())["weight_map"]
+    assert wm == {"w": "model.safetensors"}

--- a/tests/test_adaptive_fit_ladder_gw521.py
+++ b/tests/test_adaptive_fit_ladder_gw521.py
@@ -1,0 +1,210 @@
+"""gw#521: the emergency-quant rung targets the snapshot's REAL components.
+
+Root-caused on the 4070 dogfood: the rung's PipelineQuantizationConfig named
+components the pipeline didn't have, diffusers silently ignored them, and the
+"EMERGENCY 4-bit quantization engaged" line was a lie on every model — the
+worker then fell to (forbidden) CPU offload. These tests pin the ladder-core
+contract with fakes; tests/test_emergency_quant_lands_gw521.py proves the
+quant lands on real tiny pipelines of both archetypes (CUDA + bnb).
+
+Also here: offload-hooked pipelines book RAM tier in residency (the 0.03GB
+bogus-VRAM registration facet).
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker.models.loading import (
+    _adaptive_fit_rung,
+    emergency_quantization_config,
+    model_index_components,
+    snapshot_component_weight_bytes,
+)
+
+_GiB = 1 << 30
+
+
+class _FakeDiffusionPipeline:
+    pass
+
+
+class _Pipe(_FakeDiffusionPipeline):
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs: Any) -> Any:
+        return cls()
+
+
+class _FakePipelineQuantizationConfig:
+    def __init__(self, quant_backend: str, quant_kwargs: Dict[str, Any],
+                 components_to_quantize: list) -> None:
+        self.quant_backend = quant_backend
+        self.quant_kwargs = quant_kwargs
+        self.components_to_quantize = components_to_quantize
+
+
+@pytest.fixture
+def fake_diffusers(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    root = types.ModuleType("diffusers")
+    quantizers = types.ModuleType("diffusers.quantizers")
+    qc_mod = types.ModuleType("diffusers.quantizers.quantization_config")
+    root.DiffusionPipeline = _FakeDiffusionPipeline
+    quantizers.PipelineQuantizationConfig = _FakePipelineQuantizationConfig
+    qc_mod.BitsAndBytesConfig = lambda **kw: ("bnb", kw)
+    root.quantizers = quantizers
+    quantizers.quantization_config = qc_mod
+    monkeypatch.setitem(sys.modules, "diffusers", root)
+    monkeypatch.setitem(sys.modules, "diffusers.quantizers", quantizers)
+    monkeypatch.setitem(sys.modules, "diffusers.quantizers.quantization_config", qc_mod)
+    monkeypatch.setitem(sys.modules, "bitsandbytes", types.ModuleType("bitsandbytes"))
+    return root
+
+
+@pytest.fixture
+def cuda_10gb_free(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CUDA host with 10GB free -> an 8GB emergency budget (2GB margin)."""
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 10.0)
+
+
+def _write_safetensors(path: Path, dtype: str, nbytes: int) -> None:
+    header = json.dumps(
+        {"w": {"dtype": dtype, "shape": [nbytes], "data_offsets": [0, nbytes]}}
+    ).encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def _tree(tmp_path: Path, components: Dict[str, int], dtype: str = "BF16") -> Path:
+    index: Dict[str, Any] = {"_class_name": "Pipe"}
+    for name, nbytes in components.items():
+        index[name] = ["diffusers", "X"]
+        _write_safetensors(
+            tmp_path / name / "diffusion_pytorch_model.safetensors", dtype, nbytes)
+    (tmp_path / "model_index.json").write_text(json.dumps(index))
+    return tmp_path
+
+
+# --------------------------------------------------------------------------
+# target derivation: the snapshot's real names, never an archetype guess
+# --------------------------------------------------------------------------
+
+
+def test_unet_archetype_targets_unet(
+    fake_diffusers: Any, cuda_10gb_free: None, tmp_path: Path,
+) -> None:
+    # SDXL shape: 20GB unet + 1GB TE. nf4(unet) = 21 - 14 = 7GB <= 8GB budget.
+    snap = _tree(tmp_path, {"unet": 20 * _GiB, "text_encoder": 1 * _GiB})
+    mode, qc = _adaptive_fit_rung(_Pipe, snap, fp8_planned=True)
+    assert mode == "nf4"
+    assert qc.components_to_quantize == ["unet"]
+
+
+def test_transformer_archetype_targets_transformer(
+    fake_diffusers: Any, cuda_10gb_free: None, tmp_path: Path,
+) -> None:
+    snap = _tree(tmp_path, {"transformer": 20 * _GiB, "text_encoder": 1 * _GiB})
+    mode, qc = _adaptive_fit_rung(_Pipe, snap, fp8_planned=True)
+    assert mode == "nf4"
+    assert qc.components_to_quantize == ["transformer"]
+
+
+def test_text_encoders_join_only_when_denoiser_alone_is_not_enough(
+    fake_diffusers: Any, cuda_10gb_free: None, tmp_path: Path,
+) -> None:
+    # klein shape: 9GB transformer + 7GB TE. nf4(denoiser) = 16 - 6.3 = 9.7GB
+    # > 8GB budget; +TE = 9.7 - 4.9 = 4.8GB fits -> both quantized.
+    snap = _tree(tmp_path, {"transformer": 9 * _GiB, "text_encoder": 7 * _GiB})
+    mode, qc = _adaptive_fit_rung(_Pipe, snap, fp8_planned=True)
+    assert mode == "nf4"
+    assert qc.components_to_quantize == ["transformer", "text_encoder"]
+
+
+def test_rung_skipped_when_even_nf4_cannot_fit(
+    fake_diffusers: Any, cuda_10gb_free: None, tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # 30GB denoiser: nf4 est 9GB > 8GB budget -> keep full precision (the
+    # offload ladder carries it) instead of paying quality for nothing.
+    snap = _tree(tmp_path, {"transformer": 30 * _GiB})
+    with caplog.at_level("WARNING"):
+        mode, qc = _adaptive_fit_rung(_Pipe, snap, fp8_planned=True)
+    assert (mode, qc) == ("", None)
+    assert "even 4-bit weights" in caplog.text
+
+
+def test_rung_skipped_on_denoiser_less_tree(
+    fake_diffusers: Any, cuda_10gb_free: None, tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    snap = _tree(tmp_path, {"vae": 20 * _GiB})
+    with caplog.at_level("WARNING"):
+        mode, qc = _adaptive_fit_rung(_Pipe, snap, fp8_planned=True)
+    assert (mode, qc) == ("", None)
+    assert "no denoiser" in caplog.text
+
+
+def test_emergency_config_refuses_empty_components(
+    fake_diffusers: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert emergency_quantization_config(_Pipe, components=[]) is None
+
+
+def test_component_helpers_read_the_tree(tmp_path: Path) -> None:
+    snap = _tree(tmp_path, {"unet": 4096, "vae": 1024})
+    assert model_index_components(snap) == {"unet", "vae"}
+    assert snapshot_component_weight_bytes(snap) == {"unet": 4096, "vae": 1024}
+
+
+# --------------------------------------------------------------------------
+# residency: offload-hooked pipelines never book bogus VRAM (0.03GB live)
+# --------------------------------------------------------------------------
+
+
+class _HookedPipe:
+    _cozy_low_vram_mode = "group_offload"
+
+    def to(self, *a: Any, **k: Any) -> "_HookedPipe":
+        return self
+
+
+def test_track_vram_books_hooked_pipeline_in_ram_tier() -> None:
+    from gen_worker.models.residency import IN_RAM, Residency, Tier
+
+    events: list = []
+    res = Residency(on_event=lambda *e: events.append(e))
+    res.track_vram("acme/model", _HookedPipe(), vram_bytes=32 << 20)  # 0.03GB lie
+    assert res.tier("acme/model") is Tier.RAM
+    assert res.vram_bytes("acme/model") == 0
+    assert events[-1][:3] == ("acme/model", IN_RAM, 0)
+
+
+def test_track_vram_unhooked_still_books_vram() -> None:
+    from gen_worker.models.residency import IN_VRAM, Residency, Tier
+
+    class _Plain:
+        def to(self, *a: Any, **k: Any) -> "_Plain":
+            return self
+
+    events: list = []
+    res = Residency(on_event=lambda *e: events.append(e))
+    res.track_vram("acme/model", _Plain(), vram_bytes=3 << 30)
+    assert res.tier("acme/model") is Tier.VRAM
+    assert res.vram_bytes("acme/model") == 3 << 30
+    assert events[-1][:3] == ("acme/model", IN_VRAM, 3 << 30)

--- a/tests/test_emergency_quant_lands_gw521.py
+++ b/tests/test_emergency_quant_lands_gw521.py
@@ -1,0 +1,277 @@
+"""gw#521 integration: the emergency nf4 rung ACTUALLY LANDS on real tiny
+pipelines of both archetypes (unet: SDXL-shaped; transformer: Flux-shaped).
+
+The 4070 dogfood proved the failure mode is silent: a quant config whose
+component names miss the pipeline is ignored by diffusers, "EMERGENCY 4-bit
+quantization engaged" logs anyway, and the worker falls to CPU offload. These
+tests make that no-op impossible to reintroduce: they assert the quantized
+module CLASS is present on the correct component (bnb Linear4bit) and that
+the rung stamp is CLEARED when a bad config no-ops.
+
+CUDA + bitsandbytes only (skipped in CPU CI; runs on dev GPUs + the nightly
+GPU lane). Tiny models only — a few MB of VRAM.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+diffusers = pytest.importorskip("diffusers")
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+    pytest.mark.skipif(
+        importlib.util.find_spec("bitsandbytes") is None,
+        reason="needs bitsandbytes"),
+]
+
+from gen_worker.models import loading as loading_mod  # noqa: E402
+
+_GiB = float(1 << 30)
+
+
+def _tiny_sdxl(dtype: torch.dtype = torch.float32):
+    from diffusers import (
+        AutoencoderKL,
+        EulerDiscreteScheduler,
+        StableDiffusionXLPipeline,
+        UNet2DConditionModel,
+    )
+    from transformers import CLIPTextConfig, CLIPTextModel, CLIPTextModelWithProjection
+
+    unet = UNet2DConditionModel(
+        block_out_channels=(32, 64),
+        layers_per_block=2,
+        sample_size=32,
+        in_channels=4,
+        out_channels=4,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+        attention_head_dim=(2, 4),
+        use_linear_projection=True,
+        addition_embed_type="text_time",
+        addition_time_embed_dim=8,
+        transformer_layers_per_block=(1, 2),
+        projection_class_embeddings_input_dim=80,
+        cross_attention_dim=64,
+    )
+    vae = AutoencoderKL(
+        block_out_channels=[32, 64],
+        in_channels=3,
+        out_channels=3,
+        down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D"],
+        up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D"],
+        latent_channels=4,
+        sample_size=64,
+        force_upcast=True,  # the SDXL dtype-fragile VAE (gw#441/gw#463)
+    )
+    cfg = CLIPTextConfig(
+        bos_token_id=0, eos_token_id=2, hidden_size=32, intermediate_size=37,
+        layer_norm_eps=1e-05, num_attention_heads=4, num_hidden_layers=5,
+        pad_token_id=1, vocab_size=1000, hidden_act="gelu", projection_dim=32,
+    )
+    pipe = StableDiffusionXLPipeline(
+        unet=unet,
+        vae=vae,
+        text_encoder=CLIPTextModel(cfg),
+        text_encoder_2=CLIPTextModelWithProjection(cfg),
+        tokenizer=None,
+        tokenizer_2=None,
+        scheduler=EulerDiscreteScheduler(
+            beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear"),
+    )
+    return pipe.to(dtype)
+
+
+def _tiny_flux(dtype: torch.dtype = torch.float32):
+    from diffusers import (
+        AutoencoderKL,
+        FlowMatchEulerDiscreteScheduler,
+        FluxPipeline,
+        FluxTransformer2DModel,
+    )
+    from transformers import (
+        CLIPTextConfig,
+        CLIPTextModel,
+        T5Config,
+        T5EncoderModel,
+    )
+
+    transformer = FluxTransformer2DModel(
+        patch_size=1,
+        in_channels=4,
+        num_layers=1,
+        num_single_layers=1,
+        attention_head_dim=16,
+        num_attention_heads=2,
+        joint_attention_dim=32,
+        pooled_projection_dim=32,
+        axes_dims_rope=[4, 4, 8],
+    )
+    vae = AutoencoderKL(
+        block_out_channels=[32],
+        in_channels=3,
+        out_channels=3,
+        down_block_types=["DownEncoderBlock2D"],
+        up_block_types=["UpDecoderBlock2D"],
+        latent_channels=1,
+        sample_size=32,
+    )
+    clip_cfg = CLIPTextConfig(
+        bos_token_id=0, eos_token_id=2, hidden_size=32, intermediate_size=37,
+        layer_norm_eps=1e-05, num_attention_heads=4, num_hidden_layers=2,
+        pad_token_id=1, vocab_size=1000, hidden_act="gelu", projection_dim=32,
+    )
+    t5_cfg = T5Config(
+        vocab_size=100, d_model=32, d_ff=37, num_layers=2, num_heads=4, d_kv=8,
+    )
+    pipe = FluxPipeline(
+        scheduler=FlowMatchEulerDiscreteScheduler(),
+        vae=vae,
+        text_encoder=CLIPTextModel(clip_cfg),
+        tokenizer=_tiny_tokenizer(),
+        text_encoder_2=T5EncoderModel(t5_cfg),
+        tokenizer_2=_tiny_tokenizer(),
+        transformer=transformer,
+    )
+    return pipe.to(dtype)
+
+
+def _tiny_tokenizer():
+    """Offline stand-in tokenizer (never invoked — loading-path tests only)."""
+    from tokenizers import Tokenizer, models
+    from transformers import PreTrainedTokenizerFast
+
+    tok = Tokenizer(models.WordLevel({"<pad>": 0, "a": 1}, unk_token="<pad>"))
+    return PreTrainedTokenizerFast(tokenizer_object=tok, pad_token="<pad>")
+
+
+def _force_nf4_budget(monkeypatch: pytest.MonkeyPatch, tree: Path, denoiser: str) -> None:
+    """Free-VRAM probe tuned so the stored tree does NOT fit but its
+    nf4(denoiser) estimate does — the rung must engage and must be enough."""
+    comp = loading_mod.snapshot_component_weight_bytes(tree)
+    total = float(sum(comp.values()))
+    est = total - comp[denoiser] * (1.0 - loading_mod.NF4_WEIGHT_BYTES_FACTOR)
+    budget = (est + total) / 2.0
+    free_gb = budget / _GiB + loading_mod._EMERGENCY_MARGIN_GB
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: free_gb)
+
+
+def _bnb_linear_count(mod) -> int:
+    return sum(1 for m in mod.modules() if type(m).__name__ == "Linear4bit")
+
+
+@pytest.mark.parametrize("archetype", ["unet", "transformer"])
+def test_emergency_nf4_lands_on_real_pipelines(
+    archetype: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build, pipe_cls_name = {
+        "unet": (_tiny_sdxl, "StableDiffusionXLPipeline"),
+        "transformer": (_tiny_flux, "FluxPipeline"),
+    }[archetype]
+    pipe = build()
+    pipe.save_pretrained(tmp_path, safe_serialization=True)
+    del pipe
+
+    _force_nf4_budget(monkeypatch, tmp_path, archetype)
+    pipe_cls = getattr(diffusers, pipe_cls_name)
+    loaded = loading_mod.load_from_pretrained(pipe_cls, tmp_path)
+
+    # The rung engaged, the stamp is honest, and the quant LANDED: the
+    # denoiser's Linear layers are bnb Linear4bit with uint8 storage — a
+    # silent no-op (the gw#521 bug class) cannot pass this.
+    assert getattr(loaded, "_cozy_adaptive_rung", "") == "nf4"
+    denoiser = getattr(loaded, archetype)
+    assert _bnb_linear_count(denoiser) > 0
+    quantized = [
+        p for m in denoiser.modules() if type(m).__name__ == "Linear4bit"
+        for p in m.parameters(recurse=False)
+    ]
+    assert any(p.dtype == torch.uint8 for p in quantized)
+
+
+def test_wrong_component_config_is_detected_not_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The exact 4070 failure shape: a config naming 'transformer' on a unet
+    pipeline. diffusers ignores it — the loader must detect the no-op, log
+    loudly, and CLEAR the rung stamp instead of lying."""
+    pipe = _tiny_sdxl()
+    pipe.save_pretrained(tmp_path, safe_serialization=True)
+    del pipe
+
+    _force_nf4_budget(monkeypatch, tmp_path, "unet")
+    real = loading_mod.emergency_quantization_config
+
+    def _inverted(cls, *, components=None, compute_dtype=None):
+        return real(cls, components=["transformer"], compute_dtype=compute_dtype)
+
+    monkeypatch.setattr(loading_mod, "emergency_quantization_config", _inverted)
+    from diffusers import StableDiffusionXLPipeline
+
+    with caplog.at_level("ERROR"):
+        loaded = loading_mod.load_from_pretrained(StableDiffusionXLPipeline, tmp_path)
+    assert getattr(loaded, "_cozy_adaptive_rung", "") == ""
+    assert _bnb_linear_count(loaded.unet) == 0
+    assert "did NOT land" in caplog.text
+
+
+def test_fragile_vae_stays_resident_and_decode_is_dtype_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of the 4070 crash: a group-offloaded force_upcast VAE
+    decodes fp32 latents against hook-restored fp16 weights ("Input type
+    (float) and bias type (c10::Half)"). The fragile VAE must stay resident
+    under EVERY offload rung and the SDXL upcast+decode path must work."""
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+    from gen_worker.models.memory import apply_low_vram_config
+
+    pipe = _tiny_sdxl(torch.float16)
+    applied = apply_low_vram_config(pipe, mode="group_offload")
+    assert applied["group_offload"] or applied["sequential_offload"]
+    assert applied["vae_resident"]
+
+    # The SDXL __call__ decode sequence under force_upcast.
+    assert pipe.vae.config.force_upcast
+    pipe.upcast_vae()
+    latents = torch.randn(
+        1, 4, 16, 16, device="cuda",
+        dtype=next(iter(pipe.vae.post_quant_conv.parameters())).dtype,
+    )
+    image = pipe.vae.decode(latents / pipe.vae.config.scaling_factor).sample
+    assert image.shape[-1] == 32  # 16x16 latents, one 2x upsample
+    assert torch.isfinite(image).all()
+
+
+def test_quantized_pipeline_places_resident_not_offloaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """select_auto_mode (gw#521): a pipeline the nf4 rung just shrank to fit
+    must place resident — the old absolute low-free-VRAM rule group-offloaded
+    it (or hit the FORBID guard), making the salvation rung pointless."""
+    pipe = _tiny_sdxl()
+    pipe.save_pretrained(tmp_path, safe_serialization=True)
+    del pipe
+
+    _force_nf4_budget(monkeypatch, tmp_path, "unet")
+    from diffusers import StableDiffusionXLPipeline
+
+    loaded = loading_mod.load_from_pretrained(StableDiffusionXLPipeline, tmp_path)
+    assert getattr(loaded, "_cozy_adaptive_rung", "") == "nf4"
+
+    # 4.4GB free (the live 4070 number): the quantized tiny pipe FITS, so
+    # placement must not pick a CPU-offload rung (FORBID=1 stays enforced —
+    # resident placement never trips it).
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    from gen_worker.models import memory
+
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 4.4)
+    placed = memory.place_pipeline(loaded, ref="tiny/sdxl")
+    assert placed["mode"] in ("off", "vae_only")

--- a/tests/test_fp8_and_emergency_loading.py
+++ b/tests/test_fp8_and_emergency_loading.py
@@ -94,8 +94,15 @@ def _write_safetensors(path: Path, dtype: str, nbytes: int) -> None:
 
 
 def _snapshot(tmp_path: Path, dtype: str = "BF16", nbytes: int = 1024) -> Path:
-    (tmp_path / "model_index.json").write_text('{"_class_name": "Pipe"}')
-    _write_safetensors(tmp_path / "diffusion_pytorch_model.safetensors", dtype, nbytes)
+    """Realistic component layout (gw#521): the fit ladder derives quant
+    targets from the tree's REAL component names, so the denoiser weights
+    live under transformer/ and model_index.json declares it."""
+    (tmp_path / "model_index.json").write_text(
+        '{"_class_name": "Pipe", "transformer": ["diffusers", "X"]}')
+    (tmp_path / "transformer").mkdir(exist_ok=True)
+    _write_safetensors(
+        tmp_path / "transformer" / "diffusion_pytorch_model.safetensors",
+        dtype, nbytes)
     return tmp_path
 
 
@@ -195,9 +202,9 @@ def test_emergency_rung_engages_when_flavor_cannot_fit(
     fake_diffusers: Any, emergency_on: None, tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The canonical case: a 27GB fp8 flavor on a 10GB-free card — the rung
+    """The canonical case: a 24GB fp8 flavor on a 10GB-free card — the rung
     quantizes the denoiser to nf4 with the loud warning."""
-    snap = _snapshot(tmp_path, "F8_E4M3", 27 << 30)
+    snap = _snapshot(tmp_path, "F8_E4M3", 24 << 30)
     _Pipe.calls = []
     with caplog.at_level("WARNING"):
         pipe = load_from_pretrained(_Pipe, snap)
@@ -206,6 +213,8 @@ def test_emergency_rung_engages_when_flavor_cannot_fit(
     assert isinstance(qc, _FakePipelineQuantizationConfig)
     assert qc.quant_backend == "bitsandbytes_4bit"
     assert qc.quant_kwargs["bnb_4bit_quant_type"] == "nf4"
+    # gw#521: the target is the snapshot's REAL denoiser, never a guess.
+    assert qc.components_to_quantize == ["transformer"]
     assert "EMERGENCY 4-bit quantization" in caplog.text
     assert "below platform standards" in caplog.text
     # nf4 supersedes the fp8-storage rung — no layerwise casting on top

--- a/tests/test_inference_memory_select.py
+++ b/tests/test_inference_memory_select.py
@@ -48,9 +48,17 @@ def test_big_model_fits_on_big_card_no_offload():
     assert _mode(24.0, 6.9) == "off"
 
 
-def test_very_low_vram_is_aggressive_even_for_small_models():
-    # <=6GB total: even a fitting model gets aggressive group offload.
-    assert _mode(4.0, 1.5) == "group_offload"
+def test_fitting_model_stays_resident_at_low_free_vram():
+    # gw#521: a model that FITS (e.g. one the emergency nf4 rung just shrank)
+    # must never be thrown to group offload by an absolute free-VRAM rule —
+    # that made the salvation rung pointless on exactly the cards it exists
+    # for (nf4 SDXL ~2.5GB group-offloaded on a 4070 at 4.4GB free).
+    assert _mode(4.0, 1.5) == "vae_only"
+
+
+def test_very_low_vram_is_aggressive_when_model_does_not_fit():
+    # <=6GB free AND the model doesn't fit -> the aggressive rung.
+    assert _mode(4.0, 3.5) == "group_offload"
 
 
 def test_unknown_model_size_falls_back_to_conservative_threshold():

--- a/tests/test_no_cpu_inference_veto.py
+++ b/tests/test_no_cpu_inference_veto.py
@@ -37,3 +37,33 @@ def test_offload_allowed_without_veto(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
     result = apply_low_vram_config(_DummyPipeline(), mode="model_offload")
     assert result["mode"] == "model_offload"
+
+
+# --- gw#521: mechanism-level coverage — every offload ENTRY POINT refuses, ---
+# --- not just the apply_low_vram_config policy layer.                      ---
+
+
+def test_group_offload_mechanism_refuses_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.models.memory import _apply_group_offload
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    with pytest.raises(RuntimeError, match="FORBID_CPU_OFFLOAD"):
+        _apply_group_offload(_DummyPipeline(), {}, offload_to_disk_path=None)
+
+
+def test_block_window_offload_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gen_worker.models.loading import apply_block_window_offload
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    with pytest.raises(RuntimeError, match="FORBID_CPU_OFFLOAD"):
+        apply_block_window_offload(_DummyPipeline())
+
+
+def test_demote_pipeline_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gen_worker.models.memory import demote_pipeline
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    with pytest.raises(RuntimeError, match="FORBID_CPU_OFFLOAD"):
+        demote_pipeline(_DummyPipeline())


### PR DESCRIPTION
## gw#521 — the 8GB salvation rung never worked end-to-end

Root-caused from the 4070 dogfood serve log. Three compounding failures:

1. **Quant targets were a fixed list, not the tree's components.** Every release passed both `('transformer','unet')`; diffusers' warning prints only the *missing* subset (hence the "inverted map" reading). Targets now derive from the snapshot's `model_index.json` + per-component weight bytes: denoiser first, text encoders join only when the denoiser alone isn't enough (the klein-4b case), rung **skipped** when even nf4 can't fit (full precision preserved for the offload ladder — no quality cost for nothing).
2. **Post-load verification:** the `nf4` stamp is cleared with a loud error unless bnb `Linear4bit` modules actually landed on a target. A silent no-op is now structurally impossible.
3. **`select_auto_mode` threw fitting pipelines to group offload below 6GB free** — exactly the cards the emergency rung exists for. The fit check now wins over the absolute threshold: a freshly-quantized pipeline places resident.

Also:
- **FORBID_CPU_OFFLOAD mechanism-level guards** on `_apply_group_offload` and the model/sequential engagement points — no call path can bypass the policy layer again (the live sdxl lane ran 0.12.3's pre-pgw#515 forked CLI placement, which had neither the guard nor the gw#463 fragile-VAE pinning → the fp32/fp16 VAE-decode crash).
- **Residency truth under hooks:** offload-hooked pipelines book **RAM tier** — the allocator delta under hooks is noise (`vram=0.03GB` registered live for SDXLBase).
- `model_index_components` single-sourced in `loading.py` (provision re-exports).

## gw#522 — sharded-variant index names unloadable by diffusers ≥0.28

The resharder composed `diffusion_pytorch_model.fp16.safetensors.index.json`; `_add_variant` wants `…safetensors.index.fp16.json` → mirrors die with "no file named diffusion_pytorch_model.fp16.bin" (live: tensorhub/sdxl-base fp16, snapshot 02fea340).

- `normalize_variant_filenames` hoisted to `writer.py` as **the one canonical-naming function**; `run_clone` applies it at the publish seam for every cast-dtype flavor — including the publish-as-is lane gw#466 missed. Idempotent.
- **th#592 bank guard:** manifests banked before canonical naming (variant-token file names) read as a bank **miss**, so the full clone republishes canonical names instead of replaying the breakage forever.
- diffusers/transformers bnb signature skew in `PipelineQuantizationConfig` construction now degrades to offload instead of killing the load.

## R2 mirror audit (all 172 repo roots)

- **Needs repair** (serving selectors): `sdxl-base` cids `02fea340…` (latest/prod #fp16) and `a2e30c88…` (latest/prod bare+bf16), tenant `019f4ab5…` — filed as **gw#528** with the by-reference metadata-only repair recipe (stored hub tokens are stale; live catalog is mid-dogfood).
- Old-convention but **untagged** (nothing serves them): dreamshaper-xl `2cddab1e…`, juggernaut-xl `9fd6a471…`.
- Cosmetic variant-suffix names (loadable): 4 checkpoints.

## Tests

- CPU: ladder-core contract (target derivation, TE join, can't-fit skip, denoiser-less skip), residency RAM-tier booking under hooks, mechanism-level FORBID guards, bank hit/miss, canonical-vs-old-convention naming.
- CUDA+bnb (skipped in CPU CI, runs on GPU hosts / nightly lane): **real tiny pipelines of BOTH archetypes** assert `Linear4bit` + uint8 storage actually present on the correct component; the inverted-config no-op is detected and the stamp cleared; fragile-VAE decode is dtype-safe under group offload; a quantized pipeline places resident at 4.4GB free with FORBID=1 enforced.
- Real-diffusers gw#522 regression: the resharder-composed old-convention tree is proven unloadable (the exact live error) and the canonicalized tree loads.

Full suite on this GPU box: 965 passed; the 6 failures (content_lanes/ram_admission/snapshot_corruption) reproduce identically on pure master here — pre-existing CUDA-host flakes (gw#417/gw#429 class), zero new failures from this branch. mypy/ruff/http-timeout gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)