### PR TITLE
pgw#524: SDK friction batch — Slot(default_checkpoint=, default_config=) rename + 5 more (0.19.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # --locked (pgw#524 item 6): resolve exactly what uv.lock pins — the
+      # same resolution publish.yml uses on tag push, so PR-CI green
+      # actually implies publish green (fails loudly instead if uv.lock
+      # drifts from pyproject.toml, the 0.18.0 silent-publish-failure root
+      # cause).
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --locked --extra dev
 
       # GATING (gw#497): the tree is mypy-clean (zeroed 2026-07-11 — the
       # #356-era 88-error debt is gone; no baseline, no continue-on-error).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # --locked (pgw#524 item 6): fail loudly if uv.lock drifts from
+      # pyproject.toml instead of silently re-resolving newer dependency
+      # versions than what PR CI (ci.yml, also --locked) validated — the
+      # 0.18.0 root cause: a tag's publish run resolved different versions
+      # than the merged PR did and failed AFTER the tag was already cut.
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --locked --extra dev
 
       # mypy already gates ci.yml on every push/PR to master (gw#497); tags are
       # cut from master after CI passes, so re-running it here is redundant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.19.0 (2026-07-13)
+
+**pgw#524: SDK friction batch (first-Slot-consumer findings).**
+
+- **BREAKING: `Slot(default=, fallback=)` -> `Slot(default_checkpoint=,
+  default_config=)`.** Manifest wire keys `default_ref`/`fallback_defaults`
+  -> `default_checkpoint`/`default_config` in LOCKSTEP with a tensorhub
+  companion PR (`manifest_contract.go`, release hydration, slot resolution).
+  Hard cut, no back-compat alias — `default_config` still LOSES to repo
+  metadata (a recipe of last resort). The `inference-endpoints` sdxl
+  endpoint pins `gen-worker<0.19` and keeps working on the old kwargs until
+  its own floor bump; it is NOT updated by this release (out of scope).
+- **Discovery-time error: a request-branching Slot needs a default.**
+  `Slot(selected_by=..., default_checkpoint=None)` now fails at
+  registration (`extract_specs`/discovery walk) instead of at hub publish
+  — tensorhub already rejected this manifest shape; the SDK now catches it
+  at author time.
+- **`selected_by` field contract widened.** A payload field named by
+  `selected_by` may now type as `str | ModelRef` in addition to plain
+  `str` — the wire already accepts a client-supplied structured `ModelRef`
+  object (BYOM), which the hub resolves before the worker sees it.
+- **`gen_worker.testing.fake_context`/`stub_slots`** — the `ctx.slots`
+  test helper every Slot-declared endpoint's unit tests needed, replacing
+  hand-rolled `FakeCtx`es.
+- **`FamilyDefaults` positional construction confirmed + locked by test.**
+  msgspec's `kw_only=True` on the base only affects the base's own field
+  (`schema_version`); it does not propagate to a subclass's own fields, so
+  `SdxlDefaults("euler_a", 28, 6.0)` already worked — documented loudly on
+  the class (positional order follows field declaration order; msgspec
+  does not type-check plain construction, so prefer keyword args).
+- **CI/publish hardening:** both `ci.yml` and `publish.yml` now run
+  `uv sync --locked`, so a green PR actually implies a green publish (the
+  0.18.0 silent-publish-failure root cause: publish re-resolved different
+  dependency versions than what PR CI validated).
+
 ## 0.18.1 (2026-07-13)
 
 - fix(families): normalize docstring-derived schema descriptions with `inspect.cleandoc`

--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ SomeModelChoice | ModelRef` opens BYOM. Streaming = an async-generator handler.
 Engine-hosted endpoints declare `runtime="vllm"` and get a booted,
 health-checked server subprocess injected into `setup()`.
 
-`Slot(pipeline_cls, selected_by=, default=, fallback=)` is the hub-resolved
-alternative to `ModelChoice`: the model SET lives in platform config, not
-code. `ctx.slots["<name>"]` returns a typed `ResolvedSlot` — repo-metadata
-inference defaults (a `gen_worker.families.FamilyDefaults` vocabulary,
-tensorhub-validated) merged over the endpoint's code `fallback=` preset.
+`Slot(pipeline_cls, selected_by=, default_checkpoint=, default_config=)` is
+the hub-resolved alternative to `ModelChoice`: the model SET lives in
+platform config, not code. `ctx.slots["<name>"]` returns a typed
+`ResolvedSlot` — repo-metadata inference defaults (a
+`gen_worker.families.FamilyDefaults` vocabulary, tensorhub-validated)
+merged over the endpoint's code `default_config=` preset (which LOSES to
+repo metadata — a recipe of last resort).
 
 Full reference: [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
 

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -141,9 +141,9 @@ standalone distilled checkpoint is a separate class/endpoint.
 `ModelChoice` above bakes the curated set into the endpoint image — fine
 for a first-party endpoint that ships its own recipes, but the model SET is
 CATALOG, not code (th#767): adding a checkpoint shouldn't be a software
-release. `Slot(pipeline_cls, selected_by=, default=, fallback=)` is the
-hub-resolved alternative — a `models={}`/`model=` value alongside (or
-instead of) a plain binding:
+release. `Slot(pipeline_cls, selected_by=, default_checkpoint=,
+default_config=)` is the hub-resolved alternative — a `models={}`/`model=`
+value alongside (or instead of) a plain binding:
 
 ```python
 from gen_worker import HF, RequestContext, Slot, endpoint
@@ -152,32 +152,45 @@ from gen_worker.families import SdxlDefaults
 @endpoint(models={
     "pipeline": Slot(
         StableDiffusionXLPipeline,
-        selected_by="model",                                   # payload field that branches this slot
-        default=HF("stabilityai/stable-diffusion-xl-base-1.0"), # hub-less / seed-publish ref
-        fallback=SdxlDefaults(steps=28, guidance=6.0),          # used when the resolved repo has no metadata
+        selected_by="model",                                              # payload field that branches this slot
+        default_checkpoint=HF("stabilityai/stable-diffusion-xl-base-1.0"), # hub-less / seed-publish ref
+        default_config=SdxlDefaults(steps=28, guidance=6.0),               # used when the resolved repo has no metadata
     ),
-    "vae": HF("madebyollin/sdxl-vae-fp16-fix"),   # bare ModelRef: sugar for Slot(default=ref)
+    "vae": HF("madebyollin/sdxl-vae-fp16-fix"),   # bare ModelRef: sugar for Slot(default_checkpoint=ref)
 })
 class Generate:
     def setup(self, pipeline: StableDiffusionXLPipeline, vae) -> None: ...
 
     def generate(self, ctx: RequestContext, p: TextToImage) -> ImageOutput:
-        d = ctx.slots["pipeline"].defaults   # typed SdxlDefaults — repo metadata > fallback
+        d = ctx.slots["pipeline"].defaults   # typed SdxlDefaults — repo metadata > default_config
         steps = p.steps if p.steps is not None else d.steps
 ```
 
-- `selected_by` names a **plain `str`** payload field — validated at
-  registration against that field's presence/type. The hub overlays the
-  live allowed-value enum onto it; the SDK never bakes a curated list.
-- `default` seeds the hub mapping at first publish and is the ONLY
-  resolution source in hub-less mode (`gen-worker run` / `cozy run`); a
-  live hub mapping always wins when present.
-- `fallback` is a typed preset from `gen_worker.families` (a per-family
-  vocabulary struct — see below) used when the resolved repo publishes no
-  inference-defaults metadata of its own.
+- `selected_by` names a payload field typed **plain `str`** (or
+  `str | ModelRef`, the wire's BYOM-open shape — see below) — validated at
+  registration against that field's presence/type, and REQUIRES
+  `default_checkpoint=...` (a request-branching slot with no code-side
+  default has nothing to seed the hub mapping with; the hub rejects it at
+  registration, the SDK fails at author time instead). The hub overlays the
+  live allowed-value enum onto the field; the SDK never bakes a curated
+  list.
+- `default_checkpoint` seeds the hub mapping at first publish and is the
+  ONLY resolution source in hub-less mode (`gen-worker run` / `cozy run`);
+  a live hub mapping always wins when present.
+- `default_config` is a typed preset from `gen_worker.families` (a
+  per-family vocabulary struct — see below) used when the resolved repo
+  publishes no inference-defaults metadata of its own. It LOSES to repo
+  metadata when both are present — a recipe of last resort.
 - No curated list, no family kwarg on the endpoint: compat derives from
-  `pipeline_cls`; family comes from `fallback`'s registration or the
+  `pipeline_cls`; family comes from `default_config`'s registration or the
   endpoint's `Compile(family=...)`.
+
+**`selected_by` field contract**: the payload field is typed plain `str`
+for a curated-only pick, or `str | ModelRef` to also accept a
+client-supplied structured `ModelRef` (bring-your-own-model) — the hub
+resolves either shape to a concrete ref before the worker ever sees the
+request; the SDK schema never bakes the curated-value enum into either
+form.
 
 **Per-family defaults vocabulary** (`gen_worker.families`): a typed,
 versioned, JSON-Schema-exportable struct per architecture — the shape
@@ -196,9 +209,32 @@ class SdxlDefaults(FamilyDefaults, frozen=True):
 
 `gen-worker families export-schemas <dir>` writes `<family>.schema.json`
 per registered family. `ctx.slots["<name>"]` merges repo metadata over the
-`Slot`'s `fallback` (whole-object precedence — a resolved repo either fully
-specifies its family vocabulary or it doesn't); a slot with neither raises
-on first ACCESS, not at dispatch.
+`Slot`'s `default_config` (whole-object precedence — a resolved repo either
+fully specifies its family vocabulary or it doesn't); a slot with neither
+raises on first ACCESS, not at dispatch.
+
+**Positional construction:** `FamilyDefaults`'s own `schema_version` field
+is `kw_only=True` on the BASE class, but msgspec's `kw_only` only affects
+fields declared on the class where it's set — it does not propagate to a
+subclass's own fields. `SdxlDefaults(steps=28, guidance=6.0)` and
+`SdxlDefaults("euler_a", 28, 6.0)` (declaration order) both work; prefer
+keyword args in your own presets — positional order follows FIELD
+DECLARATION order, not intuition, and a stray positional value silently
+lands on the wrong field (msgspec does not type-check plain construction).
+
+**Testing:** `gen_worker.testing` builds a `RequestContext` with stubbed
+`ctx.slots` for handler unit tests, no hand-rolled fake context needed:
+
+```python
+from gen_worker.testing import fake_context
+from gen_worker import HF
+from gen_worker.families import SdxlDefaults
+
+ctx = fake_context(slots={
+    "pipeline": (HF("stabilityai/stable-diffusion-xl-base-1.0"), SdxlDefaults(steps=28)),
+})
+out = Generate().generate(ctx, TextToImage(prompt="a cat"))
+```
 
 ## Lanes: multi-model classes with shared components (gw#479)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.18.1"
+version = "0.19.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -180,9 +180,9 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     resources: Resources = msgspec.field(default_factory=Resources)
     models: Mapping[str, Binding] = msgspec.field(default_factory=dict)
     # Slot-declared entries in `models=`/`model=` (pgw#520): a subset of
-    # `models`' keys, carrying the Slot's selected_by/default/fallback
-    # metadata that `models` (a plain Binding map, for back-compat with
-    # every existing model-injection call site) can't hold.
+    # `models`' keys, carrying the Slot's selected_by/default_checkpoint/
+    # default_config metadata that `models` (a plain Binding map, for
+    # back-compat with every existing model-injection call site) can't hold.
     slots: Mapping[str, Slot] = msgspec.field(default_factory=dict)
     runtime: Optional[str] = None
     name: Optional[str] = None  # function-shaped endpoints only
@@ -230,13 +230,13 @@ def _reject_producer_generator(owner: str, fn: Callable[..., Any], kind: str) ->
 def _split_slot_like(key: str, v: "SlotLike") -> Tuple[Optional[Binding], Optional[Slot]]:
     """One ``models={}``/``model=`` value -> ``(binding_or_None, slot_or_None)``.
 
-    A ``Slot`` contributes its ``default`` (if any) to the plain binding map
-    every existing model-injection call site (executor, CLI, prefetch)
-    already understands, PLUS itself to the slots map the pgw#520 surfaces
-    (discovery emission, the resolution chain) read. A bare binding
+    A ``Slot`` contributes its ``default_checkpoint`` (if any) to the plain
+    binding map every existing model-injection call site (executor, CLI,
+    prefetch) already understands, PLUS itself to the slots map the pgw#520
+    surfaces (discovery emission, the resolution chain) read. A bare binding
     contributes only to the binding map — it carries no Slot metadata."""
     if isinstance(v, Slot):
-        return v.default, v
+        return v.default_checkpoint, v
     if isinstance(v, BINDING_TYPES):
         return v, None
     raise TypeError(
@@ -484,10 +484,10 @@ def endpoint(
 
     ``model=``/``models=`` values are a ``Binding`` (a fixed pick — HF/Hub/
     Civitai/ModelScope) or a :class:`~gen_worker.api.slot.Slot` (a
-    hub-resolved slot: ``selected_by=``, ``default=``, ``fallback=``;
-    pgw#520). A bare binding is sugar for ``Slot(<inferred pipeline class>,
-    default=ref)`` with no hub involvement — both forms can mix in one
-    ``models={}`` dict.
+    hub-resolved slot: ``selected_by=``, ``default_checkpoint=``,
+    ``default_config=``; pgw#520). A bare binding is sugar for
+    ``Slot(<inferred pipeline class>, default_checkpoint=ref)`` with no hub
+    involvement — both forms can mix in one ``models={}`` dict.
     """
     if kind not in KINDS:
         raise ValueError(f"@endpoint kind must be one of {KINDS}, got {kind!r}")

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -13,10 +13,10 @@ per-repo pricing, hot hints) moved to platform config.
         "pipeline": Slot(
             StableDiffusionXLPipeline,
             selected_by="model",
-            default=HF("stabilityai/stable-diffusion-xl-base-1.0"),
-            fallback=SdxlDefaults(steps=28, guidance=6.0),
+            default_checkpoint=HF("stabilityai/stable-diffusion-xl-base-1.0"),
+            default_config=SdxlDefaults(steps=28, guidance=6.0),
         ),
-        "vae": Slot(AutoencoderKL, default=HF("madebyollin/sdxl-vae-fp16-fix")),
+        "vae": Slot(AutoencoderKL, default_checkpoint=HF("madebyollin/sdxl-vae-fp16-fix")),
     })
     class Generate:
         def setup(self, pipeline: StableDiffusionXLPipeline, vae: AutoencoderKL) -> None: ...
@@ -26,8 +26,8 @@ per-repo pricing, hot hints) moved to platform config.
             steps = p.steps if p.steps is not None else resolved.defaults.steps
 
 A bare :class:`~gen_worker.api.binding.ModelRef` value in ``models={}``/
-``model=`` is sugar for ``Slot(<inferred pipeline class>, default=ref)`` —
-the ``@endpoint`` decorator performs that inference from the
+``model=`` is sugar for ``Slot(<inferred pipeline class>, default_checkpoint=ref)``
+— the ``@endpoint`` decorator performs that inference from the
 ``setup()``/handler parameter annotation the same way it always resolved a
 bare ref's slot NAME.
 """
@@ -58,60 +58,62 @@ class Slot(Generic[D]):
     ``str`` (the schema enum of legal values is overlaid live by the hub,
     never baked into the SDK).
 
-    ``default`` seeds the hub mapping at first publish and is the ONLY
-    resolution source in hub-less mode (``cozy run``, hermetic tests) — a
-    live hub mapping always wins when present. ``None`` means this slot has
-    no code-side bootstrap ref: it only resolves against a hub mapping.
+    ``default_checkpoint`` seeds the hub mapping at first publish and is the
+    ONLY resolution source in hub-less mode (``cozy run``, hermetic tests) —
+    a live hub mapping always wins when present. ``None`` means this slot
+    has no code-side bootstrap ref: it only resolves against a hub mapping.
 
-    ``fallback`` is this slot's code-side :class:`FamilyDefaults` preset,
-    used when the resolved repo carries no inference-defaults metadata (the
-    th#767 precedence: payload > repo metadata > this fallback).
+    ``default_config`` is this slot's code-side :class:`FamilyDefaults`
+    preset, used when the resolved repo carries no inference-defaults
+    metadata. It LOSES to repo metadata (th#767 precedence: payload > repo
+    metadata > this default_config — a recipe of last resort).
     """
 
-    __slots__ = ("pipeline_cls", "selected_by", "default", "fallback")
+    __slots__ = ("pipeline_cls", "selected_by", "default_checkpoint", "default_config")
 
     def __init__(
         self,
         pipeline_cls: type,
         *,
         selected_by: str = "",
-        default: Optional[ModelRef] = None,
-        fallback: Optional[D] = None,
+        default_checkpoint: Optional[ModelRef] = None,
+        default_config: Optional[D] = None,
     ) -> None:
         if not isinstance(pipeline_cls, type):
             raise TypeError(
                 f"Slot(pipeline_cls=...) must be a class, got "
                 f"{type(pipeline_cls).__name__}"
             )
-        if default is not None and not isinstance(default, ModelRef):
+        if default_checkpoint is not None and not isinstance(default_checkpoint, ModelRef):
             raise TypeError(
-                f"Slot(default=...) must be a ModelRef (Hub/HF/Civitai/"
-                f"ModelScope), got {type(default).__name__}"
+                f"Slot(default_checkpoint=...) must be a ModelRef (Hub/HF/"
+                f"Civitai/ModelScope), got {type(default_checkpoint).__name__}"
             )
-        if fallback is not None and not isinstance(fallback, FamilyDefaults):
+        if default_config is not None and not isinstance(default_config, FamilyDefaults):
             raise TypeError(
-                f"Slot(fallback=...) must be a FamilyDefaults subclass "
-                f"instance, got {type(fallback).__name__}"
+                f"Slot(default_config=...) must be a FamilyDefaults subclass "
+                f"instance, got {type(default_config).__name__}"
             )
         self.pipeline_cls = pipeline_cls
         self.selected_by = str(selected_by or "").strip()
-        self.default = default
-        self.fallback = fallback
+        self.default_checkpoint = default_checkpoint
+        self.default_config = default_config
 
     @property
     def family(self) -> str:
-        """Family name from ``fallback``'s registration, or ``""`` when this
-        slot has no fallback (the endpoint's ``Compile(family=...)`` is the
-        other source the decorator reconciles against — see
-        ``gen_worker.api.decorators``)."""
-        if self.fallback is None:
+        """Family name from ``default_config``'s registration, or ``""``
+        when this slot has no default_config (the endpoint's
+        ``Compile(family=...)`` is the other source the decorator
+        reconciles against — see ``gen_worker.api.decorators``)."""
+        if self.default_config is None:
             return ""
-        return self.fallback.family
+        return self.default_config.family
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return (
             f"Slot({self.pipeline_cls.__name__}, selected_by={self.selected_by!r}, "
-            f"default={self.default!r}, fallback={self.fallback!r})"
+            f"default_checkpoint={self.default_checkpoint!r}, "
+            f"default_config={self.default_config!r})"
         )
 
 
@@ -143,24 +145,25 @@ def resolve_slot(
     family: str = "",
     raw_metadata_json: str = "",
 ) -> "ResolvedSlot[D]":
-    """Merge repo-metadata inference defaults over ``slot.fallback`` — the
-    pgw#520 resolution chain shared by the production executor and the
-    hub-less CLI path.
+    """Merge repo-metadata inference defaults over ``slot.default_config``
+    — the pgw#520 resolution chain shared by the production executor and
+    the hub-less CLI path.
 
     Precedence: repo metadata (``raw_metadata_json``, when non-empty) wins
-    over ``slot.fallback`` entirely (a repo either fully specifies its
+    over ``slot.default_config`` entirely (a repo either fully specifies its
     family vocabulary or it doesn't — tensorhub validates the whole object
     at metadata-PUT time, so a partial merge would silently hide invalid
-    metadata behind the code default). Missing metadata AND no fallback is a
-    clear error, not a silent empty object.
+    metadata behind the code default). ``default_config`` LOSES to repo
+    metadata — it is a recipe of last resort. Missing metadata AND no
+    default_config is a clear error, not a silent empty object.
     """
     if ref is None:
         raise ValueError(
             f"slot {name!r}: no resolved model ref for this request (no "
-            "Slot(default=...) and no hub resolution)"
+            "Slot(default_checkpoint=...) and no hub resolution)"
         )
     fam = str(family or slot.family or "").strip()
-    defaults_cls = type(slot.fallback) if slot.fallback is not None else (
+    defaults_cls = type(slot.default_config) if slot.default_config is not None else (
         family_for(fam) if fam else None
     )
     raw = (raw_metadata_json or "").strip()
@@ -168,9 +171,9 @@ def resolve_slot(
         if defaults_cls is None:
             raise ValueError(
                 f"slot {name!r}: repo metadata present but no family is "
-                "resolvable (no Slot(fallback=...) and no Compile(family=...) "
-                "on the endpoint) — cannot determine which vocabulary to "
-                "decode it against"
+                "resolvable (no Slot(default_config=...) and no "
+                "Compile(family=...) on the endpoint) — cannot determine "
+                "which vocabulary to decode it against"
             )
         try:
             defaults: Any = msgspec.json.decode(raw.encode("utf-8"), type=defaults_cls)
@@ -180,11 +183,11 @@ def resolve_slot(
                 f"{defaults_cls.__name__} validation: {exc}"
             ) from exc
         return ResolvedSlot(ref=ref, defaults=defaults)
-    if slot.fallback is not None:
-        return ResolvedSlot(ref=ref, defaults=slot.fallback)
+    if slot.default_config is not None:
+        return ResolvedSlot(ref=ref, defaults=slot.default_config)
     raise ValueError(
         f"slot {name!r}: no repo inference-defaults metadata for the "
-        "resolved model and no Slot(fallback=...) on the endpoint — "
+        "resolved model and no Slot(default_config=...) on the endpoint — "
         "nothing to resolve this slot's defaults from"
     )
 

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -328,8 +328,9 @@ def _stamp_lora_family(binding_manifest: Dict[str, Any], compile_family: str, co
 
 
 def _model_ref_to_manifest(ref: Any) -> Dict[str, Any]:
-    """``default_ref``/curated-choice ref shape shared by the slots block:
-    ``{source, path, tag?, flavor?}`` — a structured ModelRef (pgw#511)."""
+    """``default_checkpoint``/curated-choice ref shape shared by the slots
+    block: ``{source, path, tag?, flavor?}`` — a structured ModelRef
+    (pgw#511)."""
     out: Dict[str, Any] = {"source": ref.source, "path": ref.path}
     if ref.tag and ref.tag != "latest":
         out["tag"] = ref.tag
@@ -349,17 +350,17 @@ def _slot_to_manifest(name: str, slot: Slot, *, compile_family: str) -> Dict[str
     }
     if slot.selected_by:
         out["selected_by"] = slot.selected_by
-    if slot.default is not None:
-        out["default_ref"] = _model_ref_to_manifest(slot.default)
+    if slot.default_checkpoint is not None:
+        out["default_checkpoint"] = _model_ref_to_manifest(slot.default_checkpoint)
     # Compile(family=...) is the explicit, functionally-load-bearing
     # declaration (compile-cache keying) — it wins over the slot's own
-    # fallback-preset registration when both are present, mirroring
+    # default_config-preset registration when both are present, mirroring
     # _stamp_lora_family's precedence for the bindings-block stamp below.
     family = compile_family or slot.family
     if family:
         out["family"] = family
-    if slot.fallback is not None:
-        out["fallback_defaults"] = msgspec.to_builtins(slot.fallback)
+    if slot.default_config is not None:
+        out["default_config"] = msgspec.to_builtins(slot.default_config)
     return out
 
 
@@ -591,7 +592,7 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         # allow_lora without family). pgw#519: the same stamp applies to
         # model.choices[].binding rows, not just top-level bindings. pgw#520:
         # a Slot-declared binding with no Compile(family=...) may still carry
-        # a family via its own fallback preset's registration — that's what
+        # a family via its own default_config preset's registration — that's what
         # es.slot_family reconciles (Compile(family=) wins when both exist).
         compile_family = es.compile.family if es.compile is not None else ""
         for key, block in bindings_block.items():

--- a/src/gen_worker/families/base.py
+++ b/src/gen_worker/families/base.py
@@ -63,6 +63,15 @@ class FamilyDefaults(
     ``forbid_unknown_fields=True`` is inherited by every family — the
     exported JSON schema is closed (``additionalProperties: false``): a
     contract, not a suggestion.
+
+    **Positional construction (pgw#524):** this base's own ``kw_only=True``
+    only marks ITS field (``schema_version``) keyword-only — msgspec's
+    ``kw_only`` does not propagate to a subclass's own fields. A preset row
+    like ``SdxlDefaults("euler_a", 28, 6.0)`` (declaration order) works
+    fine; it is NOT a TypeError. Still, prefer keyword args in your own
+    presets — positional order follows field DECLARATION order, and msgspec
+    does not type-check plain construction, so a misordered positional call
+    silently lands values on the wrong field instead of raising.
     """
 
     schema_version: int = 1

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -214,7 +214,7 @@ def resolve_bindings(
     resolve a curated/BYOM pick against, a payload that actually NAMES a
     model (a non-empty ``selected_by`` field value) is a clear usage error
     instead of silently running the slot's default — ``cozy run`` only ever
-    runs a Slot's ``default`` ref locally.
+    runs a Slot's ``default_checkpoint`` ref locally.
     """
     from ..api.binding import ModelRef, wire_ref
 
@@ -229,8 +229,8 @@ def resolve_bindings(
                     f"slot {param_name!r}: payload names model {picked!r} via "
                     f"{selected_by!r}, but no hub is configured — "
                     "hub-less mode (`cozy run` / `gen-worker run`) only runs "
-                    "a Slot's default= ref; configure HUB= (or drop the "
-                    f"{selected_by!r} field) to run against a hub."
+                    "a Slot's default_checkpoint= ref; configure HUB= (or "
+                    f"drop the {selected_by!r} field) to run against a hub."
                 )
         if not isinstance(binding, ModelRef):
             raise ModelResolutionError(

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import msgspec
 
-from .api.binding import Binding
+from .api.binding import Binding, ModelRef
 from .api.decorators import ATTR, Compile, EndpointDecl, Resources
 from .api.slot import Slot
 from .discovery.names import slugify_name
@@ -58,8 +58,8 @@ class EndpointSpec:
     resources: Resources = field(default_factory=Resources)
     models: Dict[str, Binding] = field(default_factory=dict)  # slot -> binding
     # Slot-declared entries in `models` (pgw#520): slot -> Slot metadata
-    # (selected_by/default/fallback). A subset of `models`'s keys — bare
-    # bindings have no entry here.
+    # (selected_by/default_checkpoint/default_config). A subset of
+    # `models`'s keys — bare bindings have no entry here.
     slots: Dict[str, Slot] = field(default_factory=dict)
     # Resolved family name per Slot (slot.family, or the endpoint's
     # Compile(family=...) when the slot declares no fallback preset) —
@@ -105,14 +105,34 @@ def _inspect_return(owner: str, ret: Any) -> tuple[str, Optional[type], Optional
     )
 
 
+def _is_selected_by_annotation(ann: Any) -> bool:
+    """pgw#524 item 5: a ``selected_by`` payload field must type as plain
+    ``str``, or as ``str | ModelRef`` — the wire also accepts a structured
+    :class:`~gen_worker.api.binding.ModelRef` object (a client-supplied
+    BYOM pick), which the hub resolves to a concrete ref before the worker
+    ever sees the request; the SDK never bakes the curated-value enum into
+    either shape."""
+    if ann is str:
+        return True
+    origin = typing.get_origin(ann)
+    if origin in (typing.Union, py_types.UnionType):
+        return frozenset(typing.get_args(ann)) == frozenset((str, ModelRef))
+    return False
+
+
 def _validate_slot_selected_by(
     owner: str, slots: Dict[str, Slot], payload_type: type
 ) -> None:
-    """pgw#520: a Slot's ``selected_by`` must name a plain-``str`` field on
-    THIS handler's payload — validated per-handler (not per-class) because
-    one ``models=`` decl can be shared by methods with different payload
-    types. Fails at spec-construction time (discovery walk / CLI collection
-    / executor boot), never at first invoke."""
+    """pgw#520: a Slot's ``selected_by`` must name a plain-``str`` (or
+    ``str | ModelRef``, pgw#524 item 5) field on THIS handler's payload —
+    validated per-handler (not per-class) because one ``models=`` decl can
+    be shared by methods with different payload types. Also enforces pgw#524
+    item 4: a request-branching slot (``selected_by`` set) with no
+    ``default_checkpoint`` has nothing to seed the hub mapping or bootstrap
+    placement with — tensorhub rejects it at manifest registration
+    (``builder.normalizeManifestSlot``), so fail here at AUTHOR time instead
+    of at publish time. Fails at spec-construction time (discovery walk /
+    CLI collection / executor boot), never at first invoke."""
     if not slots:
         return
     try:
@@ -122,19 +142,27 @@ def _validate_slot_selected_by(
     for slot_name, slot in slots.items():
         if not slot.selected_by:
             continue
+        if slot.default_checkpoint is None:
+            raise ValueError(
+                f"{owner}: Slot({slot_name!r}).selected_by={slot.selected_by!r} "
+                "requires default_checkpoint=... — a request-branching slot "
+                "with no code-side default has nothing to seed the hub "
+                "mapping/bootstrap placement with (the hub rejects this at "
+                "registration; fail here instead)"
+            )
         if slot.selected_by not in hints:
             raise ValueError(
                 f"{owner}: Slot({slot_name!r}).selected_by={slot.selected_by!r} "
                 f"names no field on payload {payload_type.__name__!r}"
             )
         ann = hints[slot.selected_by]
-        if ann is not str:
+        if not _is_selected_by_annotation(ann):
             raise ValueError(
                 f"{owner}: Slot({slot_name!r}).selected_by="
-                f"{slot.selected_by!r} must be a plain str field on "
-                f"{payload_type.__name__!r} (got {ann!r}); the hub overlays "
-                "the live allowed-value enum onto this field, it is never "
-                "baked into the SDK type"
+                f"{slot.selected_by!r} must be a plain str field (or "
+                f"str | ModelRef) on {payload_type.__name__!r} (got {ann!r}); "
+                "the hub overlays the live allowed-value enum onto this "
+                "field, it is never baked into the SDK type"
             )
 
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -253,8 +253,9 @@ class RequestContext:
     def slots(self) -> Mapping[str, "ResolvedSlot[Any]"]:
         """The pgw#520 resolution chain, one entry per ``Slot``-declared
         model slot: ``ctx.slots["pipeline"].ref`` / ``.defaults`` — repo
-        metadata merged over the endpoint's code fallback preset. A slot
-        with no repo metadata and no ``Slot(fallback=...)`` raises on
+        metadata merged over the endpoint's code ``default_config`` preset
+        (which LOSES to repo metadata when both are present). A slot with
+        no repo metadata and no ``Slot(default_config=...)`` raises on
         access (not at dispatch) — read it only when your handler needs it.
         """
         return self._slots

--- a/src/gen_worker/testing/__init__.py
+++ b/src/gen_worker/testing/__init__.py
@@ -1,0 +1,69 @@
+"""Test helpers for authoring gen-worker endpoints (pgw#524 item 3).
+
+Every ``Slot``-declared endpoint needs a ``ctx.slots["<name>"]`` stub to
+unit-test its handler without a live hub — before this module, every
+endpoint hand-rolled its own ``FakeCtx``. :func:`fake_context` builds a real
+:class:`~gen_worker.request_context.RequestContext` (or a producer-kind
+subclass) with ``ctx.slots`` pre-resolved from plain ``(ref, defaults)``
+pairs::
+
+    from gen_worker.testing import fake_context
+    from gen_worker import HF
+    from gen_worker.families import SdxlDefaults
+
+    ctx = fake_context(slots={
+        "pipeline": (HF("stabilityai/stable-diffusion-xl-base-1.0"), SdxlDefaults(steps=28)),
+    })
+    out = Generate().generate(ctx, TextToImage(prompt="a cat"))
+
+Not imported by ``gen_worker`` itself — production code has no reason to
+import test helpers; import ``gen_worker.testing`` explicitly from test
+modules.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Tuple, Type, TypeVar
+
+from ..api.binding import ModelRef
+from ..api.slot import ResolvedSlot
+from ..families.base import FamilyDefaults
+from ..request_context import RequestContext
+
+C = TypeVar("C", bound=RequestContext)
+
+
+def stub_slots(
+    slots: Mapping[str, Tuple[ModelRef, FamilyDefaults]],
+) -> Dict[str, "ResolvedSlot[Any]"]:
+    """``{slot_name: (ref, defaults)}`` -> ``{slot_name: ResolvedSlot}`` —
+    the same shape ``ctx.slots`` hands a handler in production, built
+    directly instead of via the repo-metadata resolution chain."""
+    return {name: ResolvedSlot(ref=ref, defaults=defaults) for name, (ref, defaults) in slots.items()}
+
+
+def fake_context(
+    *,
+    request_id: str = "test-request",
+    slots: Mapping[str, Tuple[ModelRef, FamilyDefaults]] = {},
+    cls: Type[C] = RequestContext,  # type: ignore[assignment]
+    **kwargs: Any,
+) -> C:
+    """Build a :class:`RequestContext` (or ``cls=``, a producer-kind
+    subclass: ``ConversionContext``/``DatasetContext``/``TrainingContext``)
+    for a handler unit test, with ``ctx.slots`` pre-populated.
+
+    ``slots`` maps slot name -> ``(ref, defaults)`` — exactly what a
+    ``Slot``-declared endpoint's handler reads via
+    ``ctx.slots["<name>"].ref`` / ``.defaults``. Every other
+    :class:`RequestContext` constructor kwarg (``owner``, ``timeout_ms``,
+    ``compute``, ...) passes through via ``**kwargs``.
+    """
+    return cls(
+        request_id=request_id,
+        resolved_slots=stub_slots(slots),
+        **kwargs,
+    )
+
+
+__all__ = ["fake_context", "stub_slots"]

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -38,6 +38,20 @@ def test_family_registry_contains_shipped_families() -> None:
     assert reg["sdxl"] is SdxlDefaults
 
 
+def test_positional_construction_works_kw_only_does_not_leak_to_subclass(
+) -> None:
+    """pgw#524 item 2: FamilyDefaults's own `schema_version` field is
+    kw_only=True, but msgspec's kw_only only affects fields declared on the
+    class where it's set — it does NOT propagate to a subclass's own
+    fields. A copy-pasted positional preset row (declaration order) must
+    keep working, not TypeError."""
+    d = SdxlDefaults("euler_a", 28, 6.0)
+    assert d.scheduler == "euler_a"
+    assert d.steps == 28
+    assert d.guidance == 6.0
+    assert d.schema_version == 1  # base's kw_only field: unaffected default
+
+
 def test_duplicate_family_name_raises() -> None:
     with pytest.raises(ValueError, match="already registered"):
         @family("sdxl")

--- a/tests/test_hubless_slot_resolution.py
+++ b/tests/test_hubless_slot_resolution.py
@@ -1,6 +1,6 @@
 """pgw#520 hub-less resolution: ``cozy run`` / ``gen-worker run`` only ever
-runs a Slot's ``default=`` ref (no hub to resolve a curated/BYOM pick
-against); a payload that NAMES a model via the ``selected_by`` field fails
+runs a Slot's ``default_checkpoint=`` ref (no hub to resolve a curated/BYOM
+pick against); a payload that NAMES a model via the ``selected_by`` field fails
 clearly instead of silently running the default. Drives the real
 ``cli.main(["run", ...])`` with ``--offline`` (deterministic cache-miss,
 matching the existing exit-code-matrix test's technique) — no network mock
@@ -35,8 +35,8 @@ def _slot_module(name: str) -> types.ModuleType:
 
     @endpoint(model=Slot(
         object, selected_by="model",
-        default=Hub("test-org/test-repo", flavor="bf16"),
-        fallback=SdxlDefaults(steps=28),
+        default_checkpoint=Hub("test-org/test-repo", flavor="bf16"),
+        default_config=SdxlDefaults(steps=28),
     ))
     class Gen:
         def setup(self, model: object) -> None:
@@ -58,8 +58,8 @@ def _force_cold(monkeypatch) -> None:
 
 def test_hubless_default_only_run_hits_normal_offline_cache_miss(tmp_path, capsys, monkeypatch) -> None:
     """No selected_by value in the payload -> the CLI attempts the Slot's
-    default= ref exactly like a bare binding would (proves the default path
-    is reached, not short-circuited)."""
+    default_checkpoint= ref exactly like a bare binding would (proves the
+    default path is reached, not short-circuited)."""
     _slot_module("_test_slot_default")
     monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path / "empty-cas"))
     rc = cli.main([

--- a/tests/test_resolution_chain.py
+++ b/tests/test_resolution_chain.py
@@ -1,5 +1,5 @@
 """pgw#520 resolution chain: ``resolve_slot``/``resolve_slots`` merge repo-
-metadata inference defaults over an endpoint's code ``Slot(fallback=...)``
+metadata inference defaults over an endpoint's code ``Slot(default_config=...)``
 preset, and ``ctx.slots[name]`` surfaces the result (or a lazy error) to the
 handler."""
 
@@ -17,7 +17,7 @@ _REF = HF("stabilityai/stable-diffusion-xl-base-1.0")
 
 
 def test_no_metadata_uses_fallback_preset() -> None:
-    slot = Slot(object, default=_REF, fallback=SdxlDefaults(steps=28, guidance=6.0))
+    slot = Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28, guidance=6.0))
     resolved = resolve_slot("pipeline", slot, ref=_REF)
     assert resolved.ref is _REF
     assert resolved.defaults.steps == 28
@@ -29,7 +29,7 @@ def test_repo_metadata_wins_over_fallback_wholesale() -> None:
     instance replaces the fallback entirely (tensorhub validates the WHOLE
     object at PUT time, so a partial merge would hide invalid metadata
     behind the code default)."""
-    slot = Slot(object, default=_REF, fallback=SdxlDefaults(steps=28, guidance=6.0))
+    slot = Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28, guidance=6.0))
     raw = msgspec.json.encode(SdxlDefaults(steps=40, scheduler="dpmpp_2m_karras")).decode()
     resolved = resolve_slot("pipeline", slot, ref=_REF, raw_metadata_json=raw)
     assert resolved.defaults.steps == 40
@@ -42,7 +42,7 @@ def test_repo_metadata_wins_over_fallback_wholesale() -> None:
 def test_repo_metadata_with_no_fallback_resolves_via_explicit_family() -> None:
     """A hub-only slot (no code fallback) can still decode repo metadata
     when the endpoint's Compile(family=...) supplies the family name."""
-    slot = Slot(object, default=_REF)  # no fallback
+    slot = Slot(object, default_checkpoint=_REF)  # no default_config
     raw = msgspec.json.encode(SdxlDefaults(steps=22)).decode()
     resolved = resolve_slot("pipeline", slot, ref=_REF, family="sdxl", raw_metadata_json=raw)
     assert isinstance(resolved.defaults, SdxlDefaults)
@@ -50,34 +50,34 @@ def test_repo_metadata_with_no_fallback_resolves_via_explicit_family() -> None:
 
 
 def test_repo_metadata_with_no_resolvable_family_raises() -> None:
-    slot = Slot(object, default=_REF)  # no fallback, no family
+    slot = Slot(object, default_checkpoint=_REF)  # no default_config, no family
     raw = msgspec.json.encode(SdxlDefaults(steps=22)).decode()
     with pytest.raises(ValueError, match="no family is resolvable"):
         resolve_slot("pipeline", slot, ref=_REF, raw_metadata_json=raw)
 
 
 def test_invalid_repo_metadata_raises_clear_validation_error() -> None:
-    slot = Slot(object, default=_REF, fallback=SdxlDefaults(steps=28))
+    slot = Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28))
     with pytest.raises(ValueError, match="validation"):
         resolve_slot("pipeline", slot, ref=_REF, raw_metadata_json='{"steps": "not-an-int"}')
 
 
 def test_no_metadata_and_no_fallback_raises_clear_error() -> None:
-    slot = Slot(object, default=_REF)  # no fallback, no metadata
+    slot = Slot(object, default_checkpoint=_REF)  # no default_config, no metadata
     with pytest.raises(ValueError, match="nothing to resolve"):
         resolve_slot("pipeline", slot, ref=_REF)
 
 
 def test_no_ref_raises_clear_error() -> None:
-    slot = Slot(object, fallback=SdxlDefaults(steps=28))
+    slot = Slot(object, default_config=SdxlDefaults(steps=28))
     with pytest.raises(ValueError, match="no resolved model ref"):
         resolve_slot("pipeline", slot, ref=None)
 
 
 def test_resolve_slots_collects_per_slot_failures_without_raising() -> None:
     slots = {
-        "pipeline": Slot(object, default=_REF, fallback=SdxlDefaults(steps=28)),
-        "vae": Slot(object),  # no fallback, no metadata -> will fail
+        "pipeline": Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28)),
+        "vae": Slot(object),  # no default_config, no metadata -> will fail
     }
     out = resolve_slots(slots, refs={"pipeline": _REF, "vae": _REF})
     assert isinstance(out["pipeline"], ResolvedSlot)
@@ -91,7 +91,7 @@ def test_resolve_slots_collects_per_slot_failures_without_raising() -> None:
 
 def test_ctx_slots_returns_resolved_slot() -> None:
     resolved = resolve_slot(
-        "pipeline", Slot(object, default=_REF, fallback=SdxlDefaults(steps=28)), ref=_REF,
+        "pipeline", Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28)), ref=_REF,
     )
     ctx = RequestContext(request_id="r1", resolved_slots={"pipeline": resolved})
     got = ctx.slots["pipeline"]
@@ -124,7 +124,7 @@ def test_ctx_set_resolved_slots_mutator_used_by_cli() -> None:
     ctx = RequestContext(request_id="r1")
     assert list(ctx.slots) == []
     resolved = resolve_slot(
-        "pipeline", Slot(object, default=_REF, fallback=SdxlDefaults(steps=28)), ref=_REF,
+        "pipeline", Slot(object, default_checkpoint=_REF, default_config=SdxlDefaults(steps=28)), ref=_REF,
     )
     ctx._set_resolved_slots({"pipeline": resolved})
     assert ctx.slots["pipeline"].defaults.steps == 28

--- a/tests/test_slot.py
+++ b/tests/test_slot.py
@@ -32,34 +32,34 @@ def test_slot_requires_a_type_for_pipeline_cls() -> None:
         Slot("not-a-class")  # type: ignore[arg-type]
 
 
-def test_slot_default_must_be_a_model_ref() -> None:
+def test_slot_default_checkpoint_must_be_a_model_ref() -> None:
     with pytest.raises(TypeError, match="ModelRef"):
-        Slot(object, default="o/r")  # type: ignore[arg-type]
+        Slot(object, default_checkpoint="o/r")  # type: ignore[arg-type]
 
 
-def test_slot_fallback_must_be_family_defaults() -> None:
+def test_slot_default_config_must_be_family_defaults() -> None:
     with pytest.raises(TypeError, match="FamilyDefaults"):
-        Slot(object, fallback=object())  # type: ignore[arg-type]
+        Slot(object, default_config=object())  # type: ignore[arg-type]
 
 
-def test_slot_family_from_fallback_registration() -> None:
-    s = Slot(object, default=HF("o/r"), fallback=SdxlDefaults(steps=30))
+def test_slot_family_from_default_config_registration() -> None:
+    s = Slot(object, default_checkpoint=HF("o/r"), default_config=SdxlDefaults(steps=30))
     assert s.family == "sdxl"
 
 
-def test_slot_family_empty_with_no_fallback() -> None:
-    s = Slot(object, default=HF("o/r"))
+def test_slot_family_empty_with_no_default_config() -> None:
+    s = Slot(object, default_checkpoint=HF("o/r"))
     assert s.family == ""
 
 
 def test_bare_modelref_and_slot_coexist_in_models_dict() -> None:
-    """A bare ModelRef is sugar for Slot(<inferred class>, default=ref) —
-    both forms populate the plain binding map every existing model-
-    injection call site understands; only the Slot key also lands in
-    `.slots`."""
+    """A bare ModelRef is sugar for Slot(<inferred class>,
+    default_checkpoint=ref) — both forms populate the plain binding map
+    every existing model-injection call site understands; only the Slot key
+    also lands in `.slots`."""
     @endpoint(models={
-        "pipeline": Slot(object, selected_by="model", default=HF("o/pipeline"),
-                          fallback=SdxlDefaults(steps=28)),
+        "pipeline": Slot(object, selected_by="model", default_checkpoint=HF("o/pipeline"),
+                          default_config=SdxlDefaults(steps=28)),
         "vae": Hub("o/vae"),
     })
     class Gen:
@@ -76,11 +76,12 @@ def test_bare_modelref_and_slot_coexist_in_models_dict() -> None:
     assert s.slot_family == {"pipeline": "sdxl"}
 
 
-def test_slot_with_no_default_omits_the_binding_entry() -> None:
-    """A hub-only Slot (no code-side default) contributes no static binding
-    — there's nothing for the executor's build-time placement/download to
-    pin locally; it only resolves via a live hub mapping."""
-    @endpoint(model=Slot(object, selected_by="model"))
+def test_slot_with_no_selected_by_and_no_default_omits_the_binding_entry() -> None:
+    """A hub-only Slot with no ``selected_by`` (never branches per request)
+    and no code-side default contributes no static binding — there's
+    nothing for the executor's build-time placement/download to pin
+    locally; it only resolves via a live hub mapping."""
+    @endpoint(model=Slot(object))
     class Gen:
         def setup(self, model: object) -> None: ...
 
@@ -90,11 +91,27 @@ def test_slot_with_no_default_omits_the_binding_entry() -> None:
     (s,) = extract_specs(Gen)
     assert list(s.models) == []
     assert list(s.slots) == ["model"]
-    assert s.slots["model"].default is None
+    assert s.slots["model"].default_checkpoint is None
+
+
+def test_slot_selected_by_without_default_checkpoint_errors_at_registration() -> None:
+    """pgw#524 item 4: a request-branching slot (selected_by set) with no
+    default_checkpoint has nothing to seed the hub mapping/bootstrap
+    placement with — tensorhub rejects this at manifest registration, so
+    the SDK fails at author time instead."""
+    with pytest.raises(ValueError, match="requires default_checkpoint"):
+        @endpoint(model=Slot(object, selected_by="model"))
+        class Gen:
+            def setup(self, model: object) -> None: ...
+
+            def generate(self, ctx: RequestContext, data: _In) -> _Out:
+                return _Out(y="ok")
+
+        extract_specs(Gen)
 
 
 def test_model_shorthand_accepts_a_slot() -> None:
-    @endpoint(model=Slot(object, selected_by="model", default=HF("o/r")))
+    @endpoint(model=Slot(object, selected_by="model", default_checkpoint=HF("o/r")))
     class Gen:
         def setup(self, model: object) -> None: ...
 
@@ -109,7 +126,7 @@ def test_model_shorthand_accepts_a_slot() -> None:
 
 def test_selected_by_must_name_an_existing_payload_field() -> None:
     with pytest.raises(ValueError, match="names no field"):
-        @endpoint(model=Slot(object, selected_by="nonexistent", default=HF("o/r")))
+        @endpoint(model=Slot(object, selected_by="nonexistent", default_checkpoint=HF("o/r")))
         class Gen:
             def setup(self, model: object) -> None: ...
 
@@ -121,7 +138,7 @@ def test_selected_by_must_name_an_existing_payload_field() -> None:
 
 def test_selected_by_must_be_plain_str_typed() -> None:
     with pytest.raises(ValueError, match="plain str"):
-        @endpoint(model=Slot(object, selected_by="model", default=HF("o/r")))
+        @endpoint(model=Slot(object, selected_by="model", default_checkpoint=HF("o/r")))
         class Gen:
             def setup(self, model: object) -> None: ...
 
@@ -135,7 +152,7 @@ def test_slot_validated_per_handler_not_per_class() -> None:
     """One models= decl is shared by every method on the class; a Slot's
     selected_by is validated against EACH handler's own payload type
     (methods can have divergent payload structs)."""
-    @endpoint(models={"pipeline": Slot(object, selected_by="model", default=HF("o/r"))})
+    @endpoint(models={"pipeline": Slot(object, selected_by="model", default_checkpoint=HF("o/r"))})
     class Gen:
         def setup(self, pipeline: object) -> None: ...
 
@@ -153,7 +170,7 @@ def test_resources_and_slots_do_not_conflict_in_class_validation() -> None:
     """Slots participate in the setup()-param consumability check the same
     way bare bindings do."""
     with pytest.raises(ValueError, match="pipeline"):
-        @endpoint(models={"pipeline": Slot(object, default=HF("o/r"))},
+        @endpoint(models={"pipeline": Slot(object, default_checkpoint=HF("o/r"))},
                   resources=Resources(vram_gb=8))
         class Bad:
             def setup(self, other_name: object) -> None: ...

--- a/tests/test_slot_discovery.py
+++ b/tests/test_slot_discovery.py
@@ -39,8 +39,8 @@ def test_slot_emits_slots_block_not_model_choices(tmp_pkg: Path) -> None:
             models={
                 "pipeline": Slot(
                     object, selected_by="model",
-                    default=HF("stabilityai/stable-diffusion-xl-base-1.0"),
-                    fallback=SdxlDefaults(steps=28, guidance=6.0),
+                    default_checkpoint=HF("stabilityai/stable-diffusion-xl-base-1.0"),
+                    default_config=SdxlDefaults(steps=28, guidance=6.0),
                 ),
                 "vae": HF("madebyollin/sdxl-vae-fp16-fix"),
             },
@@ -60,13 +60,13 @@ def test_slot_emits_slots_block_not_model_choices(tmp_pkg: Path) -> None:
     assert slot["name"] == "pipeline"
     assert slot["pipeline_class"] == "builtins.object"
     assert slot["selected_by"] == "model"
-    assert slot["default_ref"] == {
+    assert slot["default_checkpoint"] == {
         "source": "huggingface",
         "path": "stabilityai/stable-diffusion-xl-base-1.0",
     }
     assert slot["family"] == "sdxl"
-    assert slot["fallback_defaults"]["steps"] == 28
-    assert slot["fallback_defaults"]["guidance"] == 6.0
+    assert slot["default_config"]["steps"] == 28
+    assert slot["default_config"]["guidance"] == 6.0
 
     # The plain vae binding still emits through the ordinary bindings block
     # (back-compat: bare ModelRef contributes no `slots` entry).
@@ -91,7 +91,7 @@ def test_slot_with_no_selected_by_or_default_emits_minimal_block(tmp_pkg: Path) 
         class Out_(msgspec.Struct):
             y: str
 
-        @endpoint(model=Slot(object, fallback=SdxlDefaults(steps=20)))
+        @endpoint(model=Slot(object, default_config=SdxlDefaults(steps=20)))
         class Gen:
             def setup(self, model: object) -> None: ...
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
@@ -103,8 +103,8 @@ def test_slot_with_no_selected_by_or_default_emits_minimal_block(tmp_pkg: Path) 
     (slot,) = fn["slots"]
     assert slot["name"] == "model"
     assert "selected_by" not in slot
-    assert "default_ref" not in slot
-    assert slot["family"] == "sdxl"  # from the fallback preset's registration
+    assert "default_checkpoint" not in slot
+    assert slot["family"] == "sdxl"  # from the default_config preset's registration
 
 
 def test_slot_allow_lora_family_from_fallback_when_no_compile(tmp_pkg: Path) -> None:
@@ -130,8 +130,8 @@ def test_slot_allow_lora_family_from_fallback_when_no_compile(tmp_pkg: Path) -> 
 
         @endpoint(model=Slot(
             object,
-            default=Hub("o/base", allow_lora=True),
-            fallback=SdxlDefaults(steps=28),
+            default_checkpoint=Hub("o/base", allow_lora=True),
+            default_config=SdxlDefaults(steps=28),
         ))
         class Gen:
             def setup(self, model: object) -> None: ...
@@ -163,8 +163,8 @@ def test_compile_family_wins_over_slot_fallback_family(tmp_pkg: Path) -> None:
             y: str
 
         @endpoint(
-            model=Slot(object, default=Hub("o/base", allow_lora=True),
-                       fallback=SdxlDefaults(steps=28)),
+            model=Slot(object, default_checkpoint=Hub("o/base", allow_lora=True),
+                       default_config=SdxlDefaults(steps=28)),
             compile=Compile(family="explicit-family", shapes=((512, 512),)),
         )
         class Gen:

--- a/tests/test_testing_helpers.py
+++ b/tests/test_testing_helpers.py
@@ -1,0 +1,42 @@
+"""``gen_worker.testing`` (pgw#524 item 3): the ``ctx.slots`` stub helper
+every Slot-declared endpoint's unit tests need, instead of a hand-rolled
+FakeCtx."""
+
+from __future__ import annotations
+
+from gen_worker import HF
+from gen_worker.families import SdxlDefaults
+from gen_worker.request_context import ConversionContext, RequestContext
+from gen_worker.testing import fake_context, stub_slots
+
+_REF = HF("stabilityai/stable-diffusion-xl-base-1.0")
+
+
+def test_fake_context_returns_a_request_context() -> None:
+    ctx = fake_context()
+    assert isinstance(ctx, RequestContext)
+    assert ctx.request_id == "test-request"
+
+
+def test_fake_context_stubs_resolved_slots() -> None:
+    ctx = fake_context(slots={"pipeline": (_REF, SdxlDefaults(steps=28))})
+    resolved = ctx.slots["pipeline"]
+    assert resolved.ref is _REF
+    assert resolved.defaults.steps == 28
+
+
+def test_fake_context_passes_through_kwargs() -> None:
+    ctx = fake_context(request_id="r42", owner="acme")
+    assert ctx.request_id == "r42"
+
+
+def test_fake_context_accepts_a_producer_context_subclass() -> None:
+    ctx = fake_context(cls=ConversionContext, slots={"pipeline": (_REF, SdxlDefaults())})
+    assert isinstance(ctx, ConversionContext)
+    assert ctx.slots["pipeline"].ref is _REF
+
+
+def test_stub_slots_builds_the_ctx_slots_shape() -> None:
+    resolved = stub_slots({"vae": (_REF, SdxlDefaults(steps=20))})
+    assert resolved["vae"].ref is _REF
+    assert resolved["vae"].defaults.steps == 20

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.18.1"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Implements all six items from tracker `pgw#524` (first-Slot-consumer findings + Paul's rename).

1. **BREAKING RENAME:** `Slot(default=, fallback=)` -> `Slot(default_checkpoint=, default_config=)`; manifest wire keys `default_ref`/`fallback_defaults` -> `default_checkpoint`/`default_config`. Hard cut, no back-compat alias. `default_config` still LOSES to repo metadata (a recipe of last resort — preserved in every touched docstring). **Lockstep companion PR:** cozy-creator/tensorhub#… `th524-slot-default-checkpoint-config-rename` (manifest_contract.go parse, release hydration, slot resolution — every layer that reads/writes these wire keys).
   - **inference-endpoints/sdxl coordination note:** its `pyproject.toml` pins `gen-worker>=0.18.0,<0.19`, so it is NOT touched by this release and keeps working on the old `default=`/`fallback=` kwargs until its own floor bump. Follow-up needed there when it's ready to move to `>=0.19`.
2. **FamilyDefaults positional construction** — confirmed already working: msgspec's `kw_only=True` on the `FamilyDefaults` base only marks the base's OWN field (`schema_version`) keyword-only; it does not propagate to a subclass's own fields, so `SdxlDefaults("euler_a", 28, 6.0)` (declaration order) already worked, no TypeError. Documented loudly on the class + endpoint-authoring docs, and locked with a regression test (`test_positional_construction_works_kw_only_does_not_leak_to_subclass`) so a future accidental `kw_only=True` on a shipped family doesn't silently break every existing preset row.
3. **`gen_worker.testing`** — `fake_context()`/`stub_slots()`: the `ctx.slots` stub every Slot-declared endpoint's unit tests needed instead of a hand-rolled `FakeCtx`. Builds a real `RequestContext` (or a producer-kind subclass via `cls=`) with `ctx.slots` pre-resolved from `{name: (ref, defaults)}`.
4. **Discovery-time error for defaultless branching slots:** `Slot(selected_by=..., default_checkpoint=None)` now raises `ValueError` at `extract_specs`/discovery-walk time — tensorhub already rejects this manifest shape at registration (`builder.normalizeManifestSlot`); the SDK now fails at AUTHOR time instead. Scoped to slots that declare `selected_by` (a Slot with no `selected_by` and no default remains valid — it's a pure hub-mapped slot, unchanged).
5. **`selected_by` field contract widened** to accept `str | ModelRef` in addition to plain `str` (the wire already accepts a client-supplied structured `ModelRef` for BYOM, which the hub resolves before the worker sees it). No hub-side change needed — `schemaAllowsType` already recurses into `anyOf`/`oneOf`, confirmed by reading `manifest_contract.go`.
6. **CI/publish hardening:** both `ci.yml` and `publish.yml` now run `uv sync --locked` — the 0.18.0 root cause was publish re-resolving different dependency versions than what PR CI validated on the same unlocked `uv sync --extra dev`.

## Coordination / open dependencies

- **Depends on nothing merged yet** — branched directly off `master` (622c03b).
- **Lockstep with tensorhub:** `th524-slot-default-checkpoint-config-rename` must land (or land first) for the wire contract to match; the two PRs are independent Go/Python changes with no shared file, so either order works, but generation will break between the two landing if only one is deployed (a slot declared with the new SDK emits `default_checkpoint`/`default_config`; an un-rebased tensorhub still expects `default_ref`/`fallback_defaults`).
- **Overlaps with #233 (pgw#523, `pgw523-evict-allow-lora-provider-alias`)** in `src/gen_worker/discovery/discover.py` and `tests/test_slot_discovery.py` — both PRs touch adjacent comment lines near `_stamp_lora_family`/`_slot_to_manifest`; the actual code changes are on different functions/lines, so conflicts (verified via a local test-merge) are shallow/textual, not semantic. Whichever of #233 / this PR lands second should expect a small rebase there. Left unmerged into this branch on purpose to keep this diff surgical and independently reviewable.
- **Version:** this PR bumps `pyproject.toml`/`CHANGELOG.md` to `0.19.0`. #233 independently also bumped to `0.19.0` — whichever PR lands second must rebase and re-bump (e.g. to `0.19.1`) to avoid two releases claiming the same version.
- No known overlap yet with pgw#506 (discovery import machinery / endpoint-authoring docs) or pgw#526 (request_context) — neither has an open PR at time of writing (still in-progress worktrees); rebase this branch against them once they land, particularly `docs/endpoint-authoring.md` (this PR edits the `Slot` section) and `src/gen_worker/request_context/__init__.py` (this PR only touches one docstring there).

## Test plan

- [x] `uv run mypy src/gen_worker` — 0 errors (110 source files)
- [x] `uv run ruff check src/gen_worker` — clean
- [x] `uv run pytest tests/ -q` — 945 passed, 7 skipped; 10 pre-existing failures unrelated to this change (`GEN_WORKER_FORBID_CPU_OFFLOAD=1` env gate on real-model CPU-offload tests, and flaky CLI socket/transport tests) — none touch Slot/families/registry/testing/discovery
- [x] `uv sync --locked --extra dev` — confirms `uv.lock` is currently in sync with `pyproject.toml` (the new CI/publish gate would pass today)
- [x] New tests: `tests/test_testing_helpers.py` (5 tests), `test_positional_construction_works_kw_only_does_not_leak_to_subclass`, `test_slot_selected_by_without_default_checkpoint_errors_at_registration`, plus every existing Slot/discovery/resolution-chain test updated to the new kwarg/manifest-key names

🤖 Generated with [Claude Code](https://claude.com/claude-code)