### PR TITLE
pgw#517: compile= hard-errors on self-loading endpoints + gen_worker.arm_compile seam (0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.19.1 (2026-07-13)
+
+- **pgw#517: `compile=` is no longer silently inert on self-loading
+  (str/Path-slot) endpoints.** The executor only ever armed
+  `compile=Compile(...)` automatically on a `setup()` slot it loads itself
+  (a pipeline-class annotation) — an endpoint that self-loads from a
+  `str`/`Path` slot declared `compile=` that seeded the manifest/shape
+  contract but never actually armed at request time. Discovery now hard-
+  errors on that combination (was silent). Two fixes, both documented in
+  the error: annotate the slot with the pipeline class so the worker loads
+  it and arms compile automatically, or call the new
+  `gen_worker.arm_compile(pipe)` at the end of `setup()` yourself — same
+  cache-artifact-gated policy as the automatic path, eager otherwise. The
+  arming context (`Compile` spec, cache dir, hub-attached artifact) is
+  carried by a `contextvars.ContextVar` the executor scopes to the
+  `setup()` call, so `arm_compile` needs no `ctx` parameter and cannot be
+  called outside `setup()`. See `docs/compile-cache.md`.
+
 ## 0.19.0 (2026-07-13)
 
 **pgw#524: SDK friction batch (first-Slot-consumer findings).**

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -32,3 +32,38 @@ Family keying: caches key on the traced graph + shapes, not weights — one
 artifact serves every fine-tune of a family. Add a boot `warmup()` that
 renders each declared shape (see examples/flux2-klein-image) so requests
 never see the (cache-served) compile.
+
+## Self-loading (str/Path-slot) endpoints — pgw#517
+
+The arming described above ("At load the worker seeds a VERIFIED artifact
+... then arms guarded `torch.compile`") only happens for a `setup()` slot
+the worker loads itself — a slot annotated with the pipeline class (e.g.
+`pipeline: StableDiffusionXLPipeline`). A `str`/`Path`-annotated slot is
+**self-loading**: the endpoint constructs (and places) the pipeline inside
+its own `setup()`, so the executor never sees the object and has nothing to
+arm compile on. Declaring `compile=Compile(...)` on such an endpoint used to
+be silently inert — the manifest/shape contract still got seeded, but
+nothing ever compiled. Discovery now hard-errors on this combination.
+
+Fix one of:
+
+1. **Annotate the slot with the pipeline class** instead of `str`/`Path` —
+   the worker loads it and arms compile automatically, same as any other
+   endpoint.
+2. **Keep the self-load and arm explicitly.** Call `gen_worker.arm_compile(pipe)`
+   once per pipeline object at the end of `setup()`, after placement:
+
+   ```python
+   def setup(self, pipeline: str) -> None:
+       pipe = _load_pipeline(pipeline, WanPipeline)
+       pipe = _place(pipe)
+       gen_worker.arm_compile(pipe)   # same cache-artifact-gated policy
+       self.pipeline = pipe
+   ```
+
+   `arm_compile` reads the endpoint's own `Compile` spec, cache dir, and any
+   hub-attached artifact from a scope the executor holds open for the
+   duration of `setup()` — no `ctx` parameter needed, and it raises if
+   called anywhere else (compile is a setup-time-only concern). An endpoint
+   with several self-loaded pipelines sharing weights (e.g. one class
+   assembling `self.t2i`/`self.i2v`/`self.v2v`) calls it once per object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.19.0"
+version = "0.19.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -19,6 +19,7 @@ from .api.decorators import Compile, Resources, endpoint
 from .api.model import Model, ModelChoice, ModelDefaults
 from .api.slot import ResolvedSlot, Slot
 from .families import FamilyDefaults
+from .models.provision import arm_compile
 from .api.errors import (
     CanceledError,
     FatalError,
@@ -59,6 +60,7 @@ __all__ = [
     "endpoint",
     "Resources",
     "Compile",
+    "arm_compile",
     "HF",
     "Hub",
     "Civitai",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1521,10 +1521,20 @@ class Executor:
                     spec, setup, paths, server=rec.server,
                     compile_artifact=compile_artifact, snapshots=snapshots)
                 rec.shared_keys.extend(inj.shared_keys)
-                if asyncio.iscoroutinefunction(setup):
-                    await setup(**inj.kwargs)
-                else:
-                    await asyncio.to_thread(setup, **inj.kwargs)
+                # pgw#517: a self-loading (str/Path-slot) endpoint builds its
+                # own pipeline inside setup() and the executor never sees it
+                # to arm compile automatically (the branch above only fires
+                # for class-annotated slots) — hold the arming scope open so
+                # a `gen_worker.arm_compile(pipe)` call from inside setup()
+                # reaches the same cache-artifact-gated policy. No-op when
+                # spec.compile is None.
+                with provision.ArmingScope(
+                    spec.compile, self.store._cache_dir, compile_artifact,
+                ):
+                    if asyncio.iscoroutinefunction(setup):
+                        await setup(**inj.kwargs)
+                    else:
+                        await asyncio.to_thread(setup, **inj.kwargs)
             warmup = getattr(instance, "warmup", None)
             if callable(warmup):
                 from . import compile_cache

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -18,6 +18,7 @@ ModelScope downloads — through the same download layer.
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import time
 from dataclasses import dataclass, field
@@ -182,6 +183,89 @@ def enable_compiled(
                 return True
             artifact = None  # unusable engine: fall through to eager policy
     return compile_cache.enable(pipe, cfg, cache_dir, artifact)
+
+
+# ---------------------------------------------------------------------------
+# pgw#517: the arming seam for SELF-loaded pipelines. `enable_compiled`
+# above is what the executor calls automatically for a worker-loaded
+# (pipeline-class-annotated) setup() slot; a str/Path-annotated slot never
+# builds a `pipe` the executor can see (the endpoint's own setup() does),
+# so that arming call is unreachable for it. `arm_compile` is the same
+# policy exposed to the endpoint itself: an explicit, ctx-less call the
+# author makes at the end of setup(), mirroring `place_pipeline`'s existing
+# "worker-owned policy, endpoint invokes it directly" pattern for self-
+# loaded pipelines (`gen_worker.models.memory.place_pipeline`).
+#
+# The (Compile, cache_dir, compile-artifact) triple `enable_compiled` needs
+# are executor/CLI internals an endpoint has no business constructing
+# itself — a `contextvars.ContextVar` carries them instead, scoped by the
+# caller (executor/CLI) to exactly the `setup()` call, so `arm_compile(pipe)`
+# needs no parameter beyond the pipeline and cannot leak past setup().
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ArmingContext:
+    compile: Any
+    cache_dir: Optional[Path]
+    artifact: Optional[Path]
+
+
+_ARMING_CTX: "contextvars.ContextVar[Optional[_ArmingContext]]" = contextvars.ContextVar(
+    "gen_worker_compile_arming_ctx", default=None
+)
+
+
+class ArmingScope:
+    """Context manager the executor/CLI holds open around one ``setup()``
+    call so ``arm_compile()`` can reach the active ``Compile`` spec, compile
+    cache dir, and any hub-attached artifact. Re-entrant-safe (a nested
+    scope restores the outer one on exit); a no-op when ``compile`` is
+    ``None`` so callers can open it unconditionally."""
+
+    def __init__(
+        self, compile: Any, cache_dir: Optional[Path] = None,
+        artifact: Optional[Path] = None,
+    ) -> None:
+        self._value = (
+            _ArmingContext(compile=compile, cache_dir=cache_dir, artifact=artifact)
+            if compile is not None else None
+        )
+        self._token: Optional["contextvars.Token[Optional[_ArmingContext]]"] = None
+
+    def __enter__(self) -> "ArmingScope":
+        if self._value is not None:
+            self._token = _ARMING_CTX.set(self._value)
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        if self._token is not None:
+            _ARMING_CTX.reset(self._token)
+            self._token = None
+
+
+def arm_compile(pipe: Any) -> bool:
+    """Arm ``@endpoint(compile=Compile(...))`` on a pipeline the endpoint
+    loaded and placed itself (a str/Path-annotated ``setup()`` slot the
+    executor never materializes — pgw#517). Call once per pipeline object,
+    at the end of ``setup()``, after placement. Same cache-artifact-gated
+    policy as the automatic worker-loaded path: arms only when a verified
+    compiled artifact for (family, SKU, torch, triton) is seeded, otherwise
+    stays eager. Returns whether a compiled path was armed.
+
+    Raises ``RuntimeError`` if called with no active arming scope — i.e.
+    outside a ``setup()`` whose endpoint declares ``compile=Compile(...)``.
+    Compile is a setup-time-only concern; there is deliberately no way to
+    call this per-request."""
+    ctx = _ARMING_CTX.get()
+    if ctx is None:
+        raise RuntimeError(
+            "gen_worker.arm_compile() called with no active compile-arming "
+            "scope. It only works inside an endpoint's setup(), and only "
+            "when @endpoint(compile=Compile(...)) is declared on that "
+            "function/class."
+        )
+    return enable_compiled(pipe, ctx.compile, ctx.cache_dir, ctx.artifact)
 
 
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -166,6 +166,58 @@ def _validate_slot_selected_by(
             )
 
 
+def _validate_compile_arms(
+    owner: str,
+    cls: Optional[type],
+    compile: Optional[Compile],
+    models: Dict[str, Binding],
+) -> None:
+    """pgw#517: ``compile=`` only ever arms automatically on a setup() slot
+    the WORKER loads itself (a pipeline-class annotation exposing
+    ``from_pretrained`` — mirrors the executor's annotation branch in
+    ``_injection_kwargs``). An endpoint whose setup() model slots are ALL
+    self-loading (str/Path/other non-pipeline annotations — the endpoint
+    builds its own pipeline) never reaches that arming path: the declared
+    ``compile=`` seeds the manifest/shape contract but never runs, silently.
+    Fail loudly at discovery time unless the endpoint opts into the
+    ``arm_compile()`` seam itself (best-effort source scan — a missing
+    source is never a build blocker, only a missed opt-in detection)."""
+    if compile is None or cls is None or not models:
+        return
+    setup = getattr(cls, "setup", None)
+    if not callable(setup):
+        return
+    try:
+        hints = typing.get_type_hints(setup)
+    except Exception:
+        return
+    worker_loaded = any(
+        isinstance(ann, type) and callable(getattr(ann, "from_pretrained", None))
+        for ann in (hints.get(name) for name in models)
+    )
+    if worker_loaded:
+        return
+    try:
+        source = inspect.getsource(setup)
+    except (OSError, TypeError):
+        return  # can't prove either way; don't block the build on it
+    if "arm_compile" in source:
+        return
+    raise ValueError(
+        f"{owner}: compile=Compile(...) is declared but no setup() model "
+        "slot is annotated with a pipeline class (all slots are self-loading "
+        "str/Path annotations) -- the worker only arms compile on slots it "
+        "loads itself (a class annotation exposing from_pretrained), so "
+        "this compile= block seeds the manifest but never runs at request "
+        "time. Fix one of: (1) annotate the slot with the pipeline class "
+        "(e.g. `pipeline: WanPipeline` instead of `pipeline: str`) so the "
+        "worker loads it and arms compile automatically, or (2) keep the "
+        "self-loading slot and call gen_worker.arm_compile(pipe) yourself "
+        "at the end of setup(), after placement -- same cache-artifact-"
+        "gated policy, eager otherwise."
+    )
+
+
 def _spec_for_handler(
     *,
     fn_name: str,
@@ -196,6 +248,7 @@ def _spec_for_handler(
             f"with a msgspec.Struct (got {payload_type!r})"
         )
     _validate_slot_selected_by(owner, slots, payload_type)
+    _validate_compile_arms(owner, cls, decl.compile, models)
     compile_family = decl.compile.family if decl.compile is not None else ""
     # Compile(family=...) is the explicit, functionally-load-bearing
     # declaration (compile-cache keying) — it wins over a slot's own

--- a/tests/test_arm_compile_pgw517.py
+++ b/tests/test_arm_compile_pgw517.py
@@ -1,0 +1,292 @@
+"""pgw#517: `compile=` is silently inert on self-loading (str-slot)
+endpoints. Two layers under test:
+
+- discovery: `compile=Compile(...)` on an endpoint whose setup() model
+  slots are ALL str/Path-annotated (self-loading) is a build-time hard
+  error, unless the endpoint opts in via `gen_worker.arm_compile(...)`.
+- the arming seam: `gen_worker.arm_compile(pipe)`, called from inside a
+  self-loading setup(), reaches the SAME cache-artifact-gated policy as the
+  automatic worker-loaded path — proven through the real executor
+  ensure_setup() codepath, not a mock of it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import msgspec
+import pytest
+
+import gen_worker
+from gen_worker import Compile, RequestContext, Resources, endpoint
+from gen_worker import compile_cache as cc
+from gen_worker.api.binding import Hub
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models import provision
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec, extract_specs
+
+FAMILY = "wan-2.2-t2v-a14b"
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+# ---------------------------------------------------------------------------
+# discovery: str-slot + compile= is a hard error unless opted in
+# ---------------------------------------------------------------------------
+
+
+def test_compile_on_all_str_slots_is_a_discovery_error() -> None:
+    @endpoint(
+        model=Hub("acme/wan"),
+        resources=Resources(vram_gb=40),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    class SelfLoader:
+        def setup(self, model: str) -> None:
+            self.model = model  # self-load: never reaches _enable_compiled
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    with pytest.raises(ValueError, match="self-loading"):
+        extract_specs(SelfLoader)
+
+
+def test_compile_on_path_slot_is_also_a_discovery_error() -> None:
+    @endpoint(
+        model=Hub("acme/wan"),
+        resources=Resources(vram_gb=40),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    class SelfLoader:
+        def setup(self, model: Path) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    with pytest.raises(ValueError, match="self-loading"):
+        extract_specs(SelfLoader)
+
+
+def test_compile_error_names_both_fixes() -> None:
+    @endpoint(
+        model=Hub("acme/wan"),
+        resources=Resources(vram_gb=40),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    class SelfLoader:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    with pytest.raises(ValueError) as exc_info:
+        extract_specs(SelfLoader)
+    msg = str(exc_info.value)
+    assert "annotate the slot with the pipeline class" in msg
+    assert "gen_worker.arm_compile(pipe)" in msg
+
+
+def test_compile_opts_out_via_arm_compile_call_in_setup() -> None:
+    """The build-time check is a best-effort source scan for the opt-in
+    seam: a `gen_worker.arm_compile(...)` call anywhere in setup() silences
+    the error, matching the wan-2.2 fix path (option 2 in the message)."""
+
+    @endpoint(
+        model=Hub("acme/wan"),
+        resources=Resources(vram_gb=40),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    class SelfLoaderArmed:
+        def setup(self, model: str) -> None:
+            self.model = model
+            gen_worker.arm_compile(self.model)
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    (spec,) = extract_specs(SelfLoaderArmed)
+    assert spec.compile is not None
+
+
+def test_compile_on_class_annotated_slot_never_errors() -> None:
+    """Worker-loaded (pipeline-class-annotated) slots already arm compile
+    automatically — no opt-in needed, no error."""
+
+    class _Pipe:
+        @classmethod
+        def from_pretrained(cls, path, **kw):
+            return cls()
+
+    @endpoint(
+        model=Hub("acme/wan"),
+        resources=Resources(vram_gb=40),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    class WorkerLoaded:
+        def setup(self, model: _Pipe) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    (spec,) = extract_specs(WorkerLoaded)
+    assert spec.compile is not None
+
+
+def test_compile_with_no_models_is_not_this_issue() -> None:
+    """compile= with no setup() model slots at all is out of scope for
+    pgw#517 (nothing here is "self-loading" vs "worker-loaded")."""
+
+    @endpoint(resources=Resources(vram_gb=4), compile=Compile(shapes=((768, 768),)))
+    class NoModels:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out()
+
+    (spec,) = extract_specs(NoModels)
+    assert spec.compile is not None
+
+
+# ---------------------------------------------------------------------------
+# the arming seam: ArmingScope + arm_compile()
+# ---------------------------------------------------------------------------
+
+
+class _StubPipe:
+    pass
+
+
+def test_arm_compile_outside_any_scope_raises() -> None:
+    with pytest.raises(RuntimeError, match="no active compile-arming scope"):
+        provision.arm_compile(_StubPipe())
+
+
+def test_arm_compile_inside_scope_reaches_enable_compiled(monkeypatch, tmp_path) -> None:
+    cfg = Compile(family=FAMILY, shapes=((768, 768),))
+    seen: list = []
+    monkeypatch.setattr(
+        provision, "enable_compiled",
+        lambda pipe, c, cache_dir, artifact: seen.append((pipe, c, cache_dir, artifact)) or True,
+    )
+    pipe = _StubPipe()
+    with provision.ArmingScope(cfg, tmp_path, None):
+        assert provision.arm_compile(pipe) is True
+    assert seen == [(pipe, cfg, tmp_path, None)]
+    # the scope closed: arming outside it raises again
+    with pytest.raises(RuntimeError, match="no active compile-arming scope"):
+        provision.arm_compile(pipe)
+
+
+def test_arming_scope_is_a_noop_when_compile_is_none() -> None:
+    with provision.ArmingScope(None, Path("."), None):
+        with pytest.raises(RuntimeError, match="no active compile-arming scope"):
+            provision.arm_compile(_StubPipe())
+
+
+# ---------------------------------------------------------------------------
+# executor integration: the real ensure_setup() codepath arms a self-loaded
+# pipeline via gen_worker.arm_compile() (test_cast_drop_th737.py pattern —
+# no mock of the executor itself, only the compile_cache.apply leaf).
+# ---------------------------------------------------------------------------
+
+
+def _executor(spec: EndpointSpec, tmp_path: Path, sent: list) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path / "cas", vram_budget_bytes=4 << 30)
+
+    async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+        return tmp_path / "snap"
+
+    store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+    return Executor([spec], _send, store=store)
+
+
+def test_executor_arms_self_loaded_pipeline_via_arm_compile(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+    applied: list[tuple] = []
+
+    def _fake_apply(pipeline, cfg, *, cache_ready, guard=True):
+        applied.append((pipeline, cfg, cache_ready))
+        return True
+
+    monkeypatch.setattr(cc, "apply", _fake_apply)
+
+    class Endpoint:
+        def setup(self, model: str) -> None:
+            self.pipe = _StubPipe()
+            self.armed = gen_worker.arm_compile(self.pipe)
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    compile_cfg = Compile(family=FAMILY, shapes=((768, 768),))
+    spec = EndpointSpec(
+        name="wan-generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"model": Hub("acme/wan")}, resources=Resources(vram_gb=1.0),
+        compile=compile_cfg,
+    )
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, sent)
+        inst = await ex.ensure_setup(spec)
+        assert inst.armed is True
+        assert len(applied) == 1
+        pipeline, cfg, cache_ready = applied[0]
+        assert pipeline is inst.pipe
+        assert cfg is compile_cfg
+        # no hub-attached artifact / no local cache seeded -> stays eager.
+        assert cache_ready is False
+
+    asyncio.run(_go())
+
+
+def test_executor_never_arms_without_an_explicit_call(tmp_path, monkeypatch) -> None:
+    """A self-loading endpoint that DECLARES compile= but never calls
+    arm_compile() stays silently eager at runtime too (this is exactly the
+    pre-pgw#517 bug — discovery now blocks it, but EndpointSpec can still be
+    hand-built like this in a test; the executor must not paper over it by
+    auto-arming something it never saw)."""
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+    applied: list = []
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: applied.append(1) or True)
+
+    class Endpoint:
+        def setup(self, model: str) -> None:
+            self.pipe = _StubPipe()  # never arms
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="wan-generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"model": Hub("acme/wan")}, resources=Resources(vram_gb=1.0),
+        compile=Compile(family=FAMILY, shapes=((768, 768),)),
+    )
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, sent)
+        await ex.ensure_setup(spec)
+        assert applied == []
+
+    asyncio.run(_go())

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -454,6 +454,7 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
         import enum
         from typing import Union
         import msgspec
+        import gen_worker
         from gen_worker import (Compile, Hub, HF, Model, ModelChoice, ModelDefaults,
                                 ModelRef, RequestContext, Resources, endpoint)
 
@@ -476,7 +477,8 @@ def test_manifest_emits_model_placement_key(tmp_pkg: Path) -> None:
                   resources=Resources(vram_gb=12),
                   compile=Compile(family="wai-arch", shapes=((512, 512),)))
         class Gen:
-            def setup(self, pipeline: object, vae: object) -> None: ...
+            def setup(self, pipeline: object, vae: object) -> None:
+                gen_worker.arm_compile(pipeline)  # pgw#517: self-loaded slots
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
                 return Out_(y="ok")
     """))
@@ -527,6 +529,7 @@ def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
     """ie#381: the lock's compile block carries (w, h, frames) rows verbatim
     and the primary binding's weight-storage lane, so the hub's cell producer
     builds from an identically-loaded (fp8) pipeline."""
+    import gen_worker
     from gen_worker import Compile, Hub
     from gen_worker.discovery.discover import _extract_entries
 
@@ -541,7 +544,9 @@ def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
     )
     class Gen:
         def setup(self, model: str) -> None:
+            # self-loading (str) slot: arms compile explicitly (pgw#517).
             self.model = model
+            gen_worker.arm_compile(self.model)
 
         def generate(self, ctx: RequestContext, data: _In) -> _Out:
             return _Out(result="")
@@ -563,7 +568,9 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
     )
     class Gen:
         def setup(self, model: str) -> None:
+            # self-loading (str) slot: arms compile explicitly (pgw#517).
             self.model = model
+            gen_worker.arm_compile(self.model)
 
         def generate(self, ctx: RequestContext, data: _In) -> _Out:
             return _Out(result="")
@@ -573,6 +580,7 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
 
 
 def test_allow_lora_binding_emits_flag_and_family() -> None:
+    import gen_worker
     from gen_worker import Compile, Hub
     from gen_worker.discovery.discover import _extract_entries
 
@@ -583,7 +591,9 @@ def test_allow_lora_binding_emits_flag_and_family() -> None:
     )
     class Gen:
         def setup(self, model: str) -> None:
+            # self-loading (str) slot: arms compile explicitly (pgw#517).
             self.model = model
+            gen_worker.arm_compile(self.model)
 
         def generate(self, ctx: RequestContext, data: _In) -> _Out:
             return _Out(result="")
@@ -625,6 +635,7 @@ def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) ->
         import enum
         from typing import Union
         import msgspec
+        import gen_worker
         from gen_worker import (Compile, Hub, HF, Model, ModelChoice, ModelDefaults,
                                 ModelRef, RequestContext, Resources, endpoint)
 
@@ -646,7 +657,8 @@ def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) ->
                   resources=Resources(vram_gb=12),
                   compile=Compile(family="sdxl", shapes=((1024, 1024),)))
         class Gen:
-            def setup(self, pipeline: object, vae: object) -> None: ...
+            def setup(self, pipeline: object, vae: object) -> None:
+                gen_worker.arm_compile(pipeline)  # pgw#517: self-loaded slots
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
                 return Out_(y="ok")
     """))

--- a/tests/test_slot_discovery.py
+++ b/tests/test_slot_discovery.py
@@ -153,6 +153,7 @@ def test_compile_family_wins_over_slot_fallback_family(tmp_pkg: Path) -> None:
     (pkg / "__init__.py").write_text("")
     (pkg / "main.py").write_text(textwrap.dedent("""
         import msgspec
+        import gen_worker
         from gen_worker import Compile, Hub, RequestContext, Slot, endpoint
         from gen_worker.families import SdxlDefaults
 
@@ -168,7 +169,8 @@ def test_compile_family_wins_over_slot_fallback_family(tmp_pkg: Path) -> None:
             compile=Compile(family="explicit-family", shapes=((512, 512),)),
         )
         class Gen:
-            def setup(self, model: object) -> None: ...
+            def setup(self, model: object) -> None:
+                gen_worker.arm_compile(model)  # pgw#517: self-loaded slot
             def generate(self, ctx: RequestContext, data: In_) -> Out_:
                 return Out_(y="ok")
     """))

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## pgw#517: `compile=` is silently inert on self-loading (str-slot) endpoints

The executor only arms `compile=Compile(...)` automatically on a `setup()` slot it loads itself (a pipeline-class annotation exposing `from_pretrained` — the `_injection_kwargs` branch that ends in `provision.enable_compiled`). A `str`/`Path`-annotated slot never builds a `pipe` the executor can see (the endpoint's own `setup()` does), so a declared `compile=` seeded the manifest/shape contract but **never armed at runtime, silently**. wan-2.2 (all three endpoints) is in this state today.

### 1. Discovery hard-error (was: silent)

`registry._validate_compile_arms`, called from `_spec_for_handler` next to the existing `_validate_slot_selected_by` validation (registry is "the ONE decorator walker — signature inspection lives here and nowhere else", so the check fires at discovery walk, CLI collection, AND executor boot). If `compile=` is declared and **no** setup() model slot carries a pipeline-class annotation, registration raises:

> `{owner}: compile=Compile(...) is declared but no setup() model slot is annotated with a pipeline class (all slots are self-loading str/Path annotations) -- the worker only arms compile on slots it loads itself (a class annotation exposing from_pretrained), so this compile= block seeds the manifest but never runs at request time. Fix one of: (1) annotate the slot with the pipeline class (e.g. `pipeline: WanPipeline` instead of `pipeline: str`) so the worker loads it and arms compile automatically, or (2) keep the self-loading slot and call gen_worker.arm_compile(pipe) yourself at the end of setup(), after placement -- same cache-artifact-gated policy, eager otherwise.`

A best-effort `inspect.getsource(setup)` scan for `arm_compile` recognizes the opt-in (missing source is never a build blocker).

### 2. The arming seam: `gen_worker.arm_compile(pipe)`

Explicit ctx-less helper, NOT an automatic post-setup hook. Rationale:

- **It mirrors the established self-load pattern.** Placement already works exactly this way: str-slot endpoints call `gen_worker.models.memory.place_pipeline` themselves (wan-2.2's `_place`). "Worker-owned policy, endpoint invokes it at the right moment" is the existing contract for self-loaded pipelines; compile arming is the same shape.
- **An automatic hook can't find the pipeline honestly.** wan-2.2's `WanTI2V5B.setup()` builds THREE pipeline objects (`self.t2i`/`self.i2v`/`self.v2v`); attribute-scraping the instance after setup() would need heuristics (which attrs? wrapped objects? shared submodules?) — exactly the silent-magic failure mode this issue exists to kill. One explicit call per pipeline object is unambiguous.
- **Zero plumbing for the author.** The `(Compile, cache_dir, hub-attached artifact)` triple `enable_compiled` needs are executor internals, so a `contextvars.ContextVar` (`provision.ArmingScope`) is held open by the executor around exactly the `setup()` call. `arm_compile(pipe)` takes only the pipeline, works from sync or async setup (contextvars propagate to `asyncio.to_thread`), and raises `RuntimeError` anywhere else — compile is a setup-time-only concern.

Policy is byte-identical to the worker-loaded path: `arm_compile` → `provision.enable_compiled` (TRT-artifact swap, else `compile_cache.enable` — arms only on a verified `(family, SKU, torch, triton)` cell, eager otherwise).

### Out of scope
- **Un-inerting wan-2.2** is an inference-endpoints change: one-line follow-up per endpoint — add `gen_worker.arm_compile(pipe)` after `_place(...)` in the three `setup()`s (ie repo, after the 0.19.1 floor bump).

### Gates
- mypy: 0 errors (109 files)
- Full suite: 952 passed, 7 skipped; 6 failures are the known pre-existing `GEN_WORKER_FORBID_CPU_OFFLOAD` env failures — verified identical on origin/master in the same env (test_content_lanes ×3, test_ram_admission ×2, test_snapshot_corruption ×1)
- New tests (`tests/test_arm_compile_pgw517.py`, 11): discovery error (str + Path + error text), opt-in via arm_compile, class-annotated + no-models endpoints unaffected, ArmingScope no-op/restore semantics, out-of-scope RuntimeError, and executor integration through the REAL `ensure_setup()` path (stub pipeline; asserts the same `compile_cache.apply` leaf the worker-loaded path hits, `cache_ready=False` ⇒ eager)
- Version 0.19.1 + CHANGELOG + `docs/compile-cache.md` section

### Dependency
State dependency with pgw#506 (discovery import machinery): based on current master (622c03b); no overlap materialized — pgw#506's branch has no open PR yet. Rebase before merge if it lands first.

Do NOT merge (per lane instructions).

