### PR TITLE
pgw#506: discovery-time lazy-import stubs for heavy deps + hard-fail walker (0.18.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.22.1 (2026-07-13)
+
+- **pgw#506: discovery-time lazy-import stubs for heavy deps — the
+  defer-`import torch`-into-handlers convention is retired.** Build-time
+  discovery (`python -m gen_worker.discovery` / `discover_functions`) arms
+  `gen_worker.discovery.heavy_deps.stub_missing_heavy_deps`: when an
+  allowlisted heavy root (torch, torchvision, torchaudio, triton, xformers,
+  flash_attn, bitsandbytes; extend via `[tool.gen_worker]
+  discovery_heavy_deps = [...]`) is MISSING from the environment, a stub is
+  served for it (and any submodule) so module-top `import torch` succeeds and
+  schemas still build — while every attribute TOUCH on the stub raises an
+  actionable `HeavyDepStubError` naming the fix (move module-scope use into
+  `setup()`/the handler, or install the dep). When the dep IS installed
+  (in-image discovery), nothing changes.
+- **Discovery hard-fails on endpoint module import errors.** `find_endpoints`
+  no longer logs-and-continues when a module or submodule fails to import —
+  that silently shipped endpoint.locks (and live route tables) missing
+  functions. Any non-heavy-dep ImportError/SyntaxError now raises
+  `EndpointImportError` with the original exception chained; the discovery
+  CLI prints the full traceback and fails the build.
+- docs: endpoint-authoring guide — module-top imports are the rule; the
+  defer-imports convention is deleted.
+- **Rebased onto 0.21.0 (pgw#523 provider/ref alias retirement, pgw#517
+  compile= hard-error, pgw#524 SDK friction batch).** No functional overlap:
+  the heavy-dep stub seam and the hard-fail-on-import-error walk both operate
+  purely at `find_endpoints`/`discover_functions` time, before any
+  Slot/ModelRef emission logic runs; those PRs' changes to manifest/binding
+  emission are downstream of a successful discovery walk and untouched here.
+
 ## 0.22.0 (2026-07-13)
 
 **pgw#526 + pgw#527 — ctx hierarchy honesty + dead-surface cuts (BREAKING).**

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -57,6 +57,27 @@ annotation (`FluxPipeline` → `from_pretrained`; `str`/`Path` → the local
 snapshot dir), and owns device placement and low-VRAM offload. Endpoint code
 never calls `.to("cuda")`, `enable_model_cpu_offload()`, or `empty_cache()`.
 
+## Imports go at module top — including torch
+
+Write `import torch` (and every other heavy dep) at module top like any
+normal Python. Build-time discovery imports your module to read `@endpoint`
+metadata; when a heavy dep isn't installed in the discovery environment, the
+SDK stubs it (allowlist: torch, torchvision, torchaudio, triton, xformers,
+flash_attn, bitsandbytes — extend via
+`[tool.gen_worker] discovery_heavy_deps = ["my_heavy_lib"]`), so the import
+costs nothing. The old convention of deferring `import torch` into handler
+bodies is retired — don't do it.
+
+The one boundary: don't EXECUTE heavy-dep code at module scope
+(`DTYPE = torch.bfloat16`, `torch.cuda.is_available()` at import time).
+Under a stub that fails discovery loudly with a message naming the fix —
+move the code into `setup()` or the handler.
+
+Discovery also hard-fails when any module in your package fails to import
+for any OTHER reason (missing non-heavy dep, SyntaxError): a broken
+submodule fails the build with the real traceback instead of silently
+dropping its functions from the manifest.
+
 ## Bindings
 
 The slot name is the `models={}` key (or, with the single-binding `model=`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.0"
+version = "0.22.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/discovery/__init__.py
+++ b/src/gen_worker/discovery/__init__.py
@@ -1,5 +1,6 @@
 """Build-time function and endpoint discovery."""
 
+from .heavy_deps import DEFAULT_HEAVY_ROOTS, HeavyDepStubError, stub_missing_heavy_deps
 from .names import slugify_name
 from .project import ProjectConfig, load_project_config
 from .validation import (
@@ -8,8 +9,13 @@ from .validation import (
     validate_endpoint,
     validate_endpoint_lock,
 )
+from .walk import EndpointImportError
 
 __all__ = [
+    "DEFAULT_HEAVY_ROOTS",
+    "EndpointImportError",
+    "HeavyDepStubError",
+    "stub_missing_heavy_deps",
     "slugify_name",
     "ProjectConfig",
     "load_project_config",

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -6,6 +6,7 @@ manifest as TOML on stdout. Run as ``python -m gen_worker.discovery``.
 import hashlib
 import json
 import sys
+import traceback
 import typing
 import types as py_types
 from pathlib import Path
@@ -25,9 +26,10 @@ from gen_worker.api.types import (
     Tensors,
     VideoAsset,
 )
+from gen_worker.discovery.heavy_deps import stub_missing_heavy_deps
 from gen_worker.discovery.names import slugify_name
 from gen_worker.discovery.project import load_project_config
-from gen_worker.discovery.walk import find_endpoints
+from gen_worker.discovery.walk import EndpointImportError, find_endpoints
 
 
 def _type_id(t: type) -> Dict[str, str]:
@@ -504,9 +506,21 @@ def _assert_unique_function_names(functions: List[Dict[str, Any]]) -> None:
     )
 
 
-def discover_functions(root: Optional[Path] = None, *, main_module: str | None = None) -> List[Dict[str, Any]]:
+def discover_functions(
+    root: Optional[Path] = None,
+    *,
+    main_module: str | None = None,
+    extra_heavy_deps: Tuple[str, ...] = (),
+) -> List[Dict[str, Any]]:
     """Discover every @endpoint object under ``main_module``'s top-level
-    package and return the manifest ``functions`` entries."""
+    package and return the manifest ``functions`` entries.
+
+    Build-time discovery arms :func:`stub_missing_heavy_deps` around the walk:
+    heavy roots (torch, ...) missing from the environment are stubbed so
+    module-top ``import torch`` costs nothing, while any code that actually
+    USES the dep at import time fails loudly. ``extra_heavy_deps`` extends the
+    default allowlist (``[tool.gen_worker] discovery_heavy_deps``).
+    """
     if root is None:
         root = Path.cwd()
     root = root.resolve()
@@ -523,30 +537,31 @@ def discover_functions(root: Optional[Path] = None, *, main_module: str | None =
         sys.path.insert(0, src_str)
 
     top_level = main_module.split(".", 1)[0]
-    try:
-        found = find_endpoints([top_level])
-    except Exception as e:
-        raise ValueError(
-            f"failed to walk endpoint package {top_level!r} (derived from "
-            f"[tool.gen_worker] main={main_module!r}): {e}"
-        ) from e
+    with stub_missing_heavy_deps(extra_heavy_deps):
+        try:
+            found = find_endpoints([top_level])
+        except Exception as e:
+            raise ValueError(
+                f"failed to walk endpoint package {top_level!r} (derived from "
+                f"[tool.gen_worker] main={main_module!r}): {e}"
+            ) from e
 
-    functions: List[Dict[str, Any]] = []
-    seen: Set[Tuple[str, str, str, str]] = set()
-    for f in found:
-        for entry in _extract_entries(f.obj, f.walked_module):
-            # (module, class, python_name, name) dedups objects re-found under
-            # multiple walked packages; name is one handler per method now.
-            key = (
-                entry.get("declared_module", entry.get("module", "")),
-                entry.get("class_name", ""),
-                entry.get("python_name", ""),
-                entry.get("name", ""),
-            )
-            if key in seen:
-                continue
-            seen.add(key)
-            functions.append(entry)
+        functions: List[Dict[str, Any]] = []
+        seen: Set[Tuple[str, str, str, str]] = set()
+        for f in found:
+            for entry in _extract_entries(f.obj, f.walked_module):
+                # (module, class, python_name, name) dedups objects re-found under
+                # multiple walked packages; name is one handler per method now.
+                key = (
+                    entry.get("declared_module", entry.get("module", "")),
+                    entry.get("class_name", ""),
+                    entry.get("python_name", ""),
+                    entry.get("name", ""),
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                functions.append(entry)
 
     _assert_unique_function_names(functions)
     return functions
@@ -686,7 +701,9 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
 
     cfg = load_project_config(root)
 
-    functions = discover_functions(root, main_module=cfg.main)
+    functions = discover_functions(
+        root, main_module=cfg.main, extra_heavy_deps=cfg.discovery_heavy_deps
+    )
 
     seen_fn: Dict[str, str] = {}
     for fn in functions:
@@ -728,6 +745,14 @@ def main() -> None:
     try:
         manifest = discover_manifest()
     except Exception as e:
+        # A broken endpoint module fails the BUILD, with the real import
+        # traceback — never a log-and-continue that ships an endpoint.lock
+        # silently missing functions.
+        cause: Optional[BaseException] = e
+        while cause is not None and not isinstance(cause, EndpointImportError):
+            cause = cause.__cause__
+        if cause is not None:
+            traceback.print_exc(file=sys.stderr)
         print(f"error: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/src/gen_worker/discovery/heavy_deps.py
+++ b/src/gen_worker/discovery/heavy_deps.py
@@ -1,0 +1,179 @@
+"""Fail-loud lazy-import stubs for heavy deps during build-time discovery.
+
+Discovery imports every endpoint module to read its ``@endpoint`` metadata
+(live ``typing.get_type_hints`` on payload structs requires real imports).
+That metadata is torch-free by design, but discovery may run in environments
+where torch/CUDA isn't installed (manifest builds, CI). Instead of forcing
+authors to defer ``import torch`` into handler bodies,
+``stub_missing_heavy_deps`` wraps ``builtins.__import__``: an ``import``
+statement targeting an allowlisted heavy root that is genuinely ABSENT from
+the environment resolves to a stub whose EVERY attribute access raises
+:class:`HeavyDepStubError` naming the real dependency and the fix.
+
+* Root INSTALLED → nothing changes; the real module is used.
+* Root MISSING → ``import torch`` / ``import torch.nn.functional`` /
+  ``from torch import nn`` all succeed with stubs; schemas still build; any
+  code that actually EXECUTES the dep at import time (``DTYPE =
+  torch.bfloat16``, ``torch.cuda.is_available()``) fails fast, actionably.
+
+Injection point rationale: a permanently-armed ``sys.meta_path`` finder
+would make ``importlib.util.find_spec("torchvision")`` return a spec for a
+missing package, fooling the availability probes third-party libraries gate
+their optional surfaces on (e.g. transformers' ``is_torchvision_available``
+is find_spec-only — a stubbed answer crashes its module-scope torchvision
+use). Wrapping ``__import__`` serves only real ``import`` statements; the
+helper finder is armed transiently inside the retry, so probe results stay
+honest. ``HeavyDepStubError`` subclasses ``AttributeError`` so defaulted
+``getattr(mod, "__version__", ...)`` probes on a stub degrade gracefully.
+
+Extension point: the allowlist is ``DEFAULT_HEAVY_ROOTS`` plus per-project
+``[tool.gen_worker] discovery_heavy_deps = ["my_heavy_lib"]`` entries
+(merged, never replacing the defaults).
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from contextlib import contextmanager
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+# Known-heavy import roots: importing any of these pays seconds of load time
+# (torch/CUDA init, kernel registration) that endpoint METADATA never needs.
+# Deliberately small; diffusers/transformers are NOT here — they import
+# cheaply without torch and their classes must be real for slot annotations.
+DEFAULT_HEAVY_ROOTS: tuple[str, ...] = (
+    "torch",
+    "torchvision",
+    "torchaudio",
+    "triton",
+    "xformers",
+    "flash_attn",
+    "bitsandbytes",
+)
+
+
+class HeavyDepStubError(AttributeError):
+    """A discovery stub for a missing heavy dependency was actually USED.
+
+    Subclasses ``AttributeError`` so ``hasattr``/defaulted-``getattr`` probes
+    and the ``from torch import nn`` submodule fallback in the import
+    machinery keep working; any other attribute touch surfaces this loudly.
+    """
+
+
+class _HeavyDepStub(types.ModuleType):
+    """Module whose every (missing-)attribute access raises HeavyDepStubError."""
+
+    def __getattr__(self, attr: str) -> Any:
+        root = self.__name__.split(".", 1)[0]
+        raise HeavyDepStubError(
+            f"'{self.__name__}.{attr}' was touched during discovery, but "
+            f"{root!r} is not installed in this environment. Discovery stubs "
+            f"missing heavy dependencies so a module-top `import {root}` is "
+            f"free — but EXECUTING {root} code at import time (e.g. "
+            f"`DTYPE = {root}.bfloat16` or `{root}.cuda.is_available()` at "
+            f"module scope) is not. Move that code into setup() or the "
+            f"handler body, or install {root!r} to run discovery against the "
+            f"real module."
+        )
+
+
+class _HeavyDepStubFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Serves stub modules for missing heavy roots (and their submodules).
+
+    Only ever armed transiently, inside the ``__import__`` retry — never left
+    on ``sys.meta_path`` where ``find_spec`` probes would see it.
+    """
+
+    def __init__(self, missing_roots: frozenset[str]) -> None:
+        self.missing_roots = missing_roots
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: types.ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname.split(".", 1)[0] in self.missing_roots:
+            # is_package=True so `import torch.nn.functional` resolves
+            # through this same finder instead of "'torch' is not a package".
+            return importlib.util.spec_from_loader(fullname, self, is_package=True)
+        return None
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> types.ModuleType:
+        return _HeavyDepStub(spec.name)
+
+    def exec_module(self, module: types.ModuleType) -> None:
+        pass
+
+
+def _root_installed(root: str) -> bool:
+    if root in sys.modules and not isinstance(sys.modules[root], _HeavyDepStub):
+        return True
+    try:
+        return importlib.util.find_spec(root) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+@contextmanager
+def stub_missing_heavy_deps(extra: Iterable[str] = ()) -> Iterator[frozenset[str]]:
+    """Arm fail-loud import stubs for every allowlisted heavy root NOT installed.
+
+    Yields the set of absent roots eligible for stubbing (empty when
+    everything is installed — the normal in-image case, where imports behave
+    exactly as without this context). On exit the ``__import__`` wrapper and
+    every stub placed in ``sys.modules`` are removed; endpoint modules
+    imported meanwhile keep their references, so later real USE of a stub
+    still fails loudly.
+    """
+    roots = dict.fromkeys((*DEFAULT_HEAVY_ROOTS, *extra))
+    missing = frozenset(r for r in roots if r and not _root_installed(r))
+    if not missing:
+        yield frozenset()
+        return
+
+    finder = _HeavyDepStubFinder(missing)
+    original_import = builtins.__import__
+
+    def _import(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: Sequence[str] | None = (),
+        level: int = 0,
+    ) -> types.ModuleType:
+        # Arm the stub finder ONLY while importing an absent heavy root (or a
+        # submodule of one) — this one __import__ call covers `import torch`,
+        # `import torch.nn.functional`, and the `from torch import nn`
+        # submodule fallback. Every other import (including a genuinely
+        # missing non-heavy dep, a SyntaxError, a relative import) runs the
+        # untouched machinery.
+        root = name.split(".", 1)[0] if level == 0 else ""
+        if root not in missing:
+            return original_import(name, globals, locals, fromlist, level)
+        sys.meta_path.append(finder)
+        try:
+            return original_import(name, globals, locals, fromlist, level)
+        finally:
+            try:
+                sys.meta_path.remove(finder)
+            except ValueError:
+                pass
+
+    builtins.__import__ = _import
+    try:
+        yield missing
+    finally:
+        if builtins.__import__ is _import:
+            builtins.__import__ = original_import
+        for name in [
+            n for n, m in sys.modules.items()
+            if isinstance(m, _HeavyDepStub) and n.split(".", 1)[0] in missing
+        ]:
+            del sys.modules[name]

--- a/src/gen_worker/discovery/project.py
+++ b/src/gen_worker/discovery/project.py
@@ -5,6 +5,9 @@ The one meaningful config value is ``main`` — the module that declares the
 
     [tool.gen_worker]
     main = "my_endpoint.main"
+    # optional: EXTRA heavy import roots discovery stubs when missing
+    # (merged with gen_worker.discovery.heavy_deps.DEFAULT_HEAVY_ROOTS)
+    discovery_heavy_deps = ["nunchaku"]
 """
 
 from __future__ import annotations
@@ -19,6 +22,9 @@ class ProjectConfig:
     root: Path
     name: str   # [project].name (may be empty)
     main: str   # [tool.gen_worker].main
+    # [tool.gen_worker].discovery_heavy_deps — extra heavy import roots to
+    # stub during build-time discovery when not installed.
+    discovery_heavy_deps: tuple[str, ...] = ()
 
 
 def load_project_config(path: str | Path | None = None) -> ProjectConfig:
@@ -44,6 +50,16 @@ def load_project_config(path: str | Path | None = None) -> ProjectConfig:
             f"{pyproject}: missing [tool.gen_worker] main. Add:\n"
             '    [tool.gen_worker]\n    main = "your_package.main"'
         )
+    raw_heavy = (gw or {}).get("discovery_heavy_deps") if isinstance(gw, dict) else None
+    if raw_heavy is None:
+        heavy: tuple[str, ...] = ()
+    elif isinstance(raw_heavy, list) and all(isinstance(v, str) for v in raw_heavy):
+        heavy = tuple(v.strip() for v in raw_heavy if v.strip())
+    else:
+        raise ValueError(
+            f"{pyproject}: [tool.gen_worker] discovery_heavy_deps must be a "
+            "list of import-root strings"
+        )
     project = data.get("project") if isinstance(data, dict) else None
     name = str((project or {}).get("name") or "").strip() if isinstance(project, dict) else ""
-    return ProjectConfig(root=root, name=name, main=main)
+    return ProjectConfig(root=root, name=name, main=main, discovery_heavy_deps=heavy)

--- a/src/gen_worker/discovery/walk.py
+++ b/src/gen_worker/discovery/walk.py
@@ -11,6 +11,13 @@ Invariants:
   skipped (third-party re-exports stay out).
 * Each object is yielded exactly once even when re-exported into multiple
   namespaces (dedup by ``id``).
+* A module that fails to IMPORT is a HARD failure
+  (:class:`EndpointImportError`), never log-and-continue — a silently
+  skipped submodule means an endpoint.lock (or live route table) silently
+  missing functions. A missing heavy dep is not an excuse: build-time
+  discovery arms :mod:`gen_worker.discovery.heavy_deps` stubs first, so
+  module-top ``import torch`` succeeds without torch installed; any other
+  ImportError/SyntaxError fails the walk with the original traceback chained.
 """
 
 from __future__ import annotations
@@ -25,6 +32,15 @@ from typing import Any
 from ..api.decorators import ATTR
 
 logger = logging.getLogger(__name__)
+
+
+class EndpointImportError(ImportError):
+    """An endpoint module (or one of its submodules) failed to import.
+
+    Raised instead of skipping so a broken module can never silently drop
+    functions from the manifest or the worker's route table. The original
+    exception is chained (``__cause__``) so builds see the real traceback.
+    """
 
 
 @dataclass(frozen=True)
@@ -47,12 +63,10 @@ def find_endpoints(module_names: list[str]) -> list[FoundEndpoint]:
         try:
             top_module = importlib.import_module(top_name)
         except Exception as exc:
-            logger.exception(
-                "Could not import user module '%s': %s. "
-                "Walker will return no endpoints from this module.",
-                top_name, exc,
-            )
-            continue
+            raise EndpointImportError(
+                f"could not import endpoint module {top_name!r}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
 
         modules_to_scan: list[Any] = [top_module]
         if hasattr(top_module, "__path__"):
@@ -61,10 +75,10 @@ def find_endpoints(module_names: list[str]) -> list[FoundEndpoint]:
                 try:
                     modules_to_scan.append(importlib.import_module(sub.name))
                 except Exception as exc:
-                    logger.warning(
-                        "Skipping submodule '%s' — import failed: %s.",
-                        sub.name, exc,
-                    )
+                    raise EndpointImportError(
+                        f"could not import endpoint submodule {sub.name!r} "
+                        f"(walking {top_name!r}): {type(exc).__name__}: {exc}"
+                    ) from exc
 
         package_prefix = top_module.__name__ + "."
         for scan_module in modules_to_scan:

--- a/tests/test_discovery_heavy_deps.py
+++ b/tests/test_discovery_heavy_deps.py
@@ -1,0 +1,270 @@
+"""pgw#506: fail-loud lazy-import stubs for heavy deps + hard-fail walker.
+
+Covers both halves of the issue:
+
+* ``stub_missing_heavy_deps`` — a missing allowlisted heavy root imports as
+  a stub (module-top ``import torch`` is free during discovery), while any
+  attribute TOUCH raises an actionable ``HeavyDepStubError``; installed
+  roots are never stubbed; stubs are removed on exit.
+* ``find_endpoints`` hard-fails on ANY other module import error (a broken
+  submodule can no longer be silently skipped out of the endpoint.lock).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gen_worker.discovery.heavy_deps import (
+    DEFAULT_HEAVY_ROOTS,
+    HeavyDepStubError,
+    _HeavyDepStub,
+    stub_missing_heavy_deps,
+)
+from gen_worker.discovery.walk import EndpointImportError, find_endpoints
+
+# Guaranteed-absent import root standing in for torch in a torch-less env —
+# the stub path is identical (find_spec miss -> meta-path stub), only the name
+# differs.
+FAKE = "gw_fake_heavy_dep"
+
+
+@pytest.fixture()
+def tmp_pkg(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return tmp_path
+
+
+def _endpoint_src(heavy_import_lines: str = "") -> str:
+    return heavy_import_lines + textwrap.dedent("""\
+        import msgspec
+        from gen_worker import RequestContext, endpoint
+
+        class In_(msgspec.Struct):
+            text: str = ""
+
+        class Out_(msgspec.Struct):
+            reply: str
+
+        @endpoint
+        class Gen:
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(reply=data.text)
+    """)
+
+
+# --------------------------------------------------------------------------- #
+# the shim                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _stmt_import(src: str) -> dict:
+    """Run real ``import`` STATEMENTS (the surface the shim serves —
+    ``importlib.import_module`` deliberately bypasses it)."""
+    ns: dict = {}
+    exec(src, ns)
+    return ns
+
+
+def test_installed_roots_are_never_stubbed() -> None:
+    # msgspec is installed -> not in the stubbed set; the real module is used.
+    with stub_missing_heavy_deps(extra=("msgspec", FAKE)) as stubbed:
+        assert "msgspec" not in stubbed
+        assert FAKE in stubbed
+        import msgspec
+
+        assert not isinstance(msgspec, _HeavyDepStub)
+        assert callable(msgspec.json.encode)  # attribute use works: real module
+
+
+def test_no_op_when_all_installed(monkeypatch) -> None:
+    # With every allowlisted root "installed", the context changes nothing:
+    # no __import__ wrapper, no meta-path finder.
+    monkeypatch.setattr(
+        "gen_worker.discovery.heavy_deps._root_installed", lambda root: True
+    )
+    import builtins
+
+    before_import = builtins.__import__
+    before_meta = list(sys.meta_path)
+    with stub_missing_heavy_deps() as stubbed:
+        assert stubbed == frozenset()
+        assert builtins.__import__ is before_import
+        assert sys.meta_path == before_meta
+
+
+def test_missing_root_imports_as_stub_including_submodules() -> None:
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        ns = _stmt_import(
+            f"import {FAKE}\n"
+            f"import {FAKE}.nn.functional as F\n"
+            f"from {FAKE} import nn\n"
+        )
+        assert isinstance(ns[FAKE], _HeavyDepStub)
+        assert isinstance(ns["F"], _HeavyDepStub)
+        assert isinstance(ns["nn"], _HeavyDepStub)
+
+
+def test_find_spec_probes_stay_honest() -> None:
+    # Third-party availability probes (transformers is_torchvision_available
+    # is find_spec-only) must NOT see a missing dep as installed — a fooled
+    # probe unlocks module-scope use of the dep in library code.
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        assert importlib.util.find_spec(FAKE) is None
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(FAKE)  # programmatic probe, not stubbed
+
+
+def test_attribute_touch_raises_actionable_error() -> None:
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        mod = _stmt_import(f"import {FAKE}")[FAKE]
+        with pytest.raises(HeavyDepStubError) as ei:
+            _ = mod.bfloat16
+        msg = str(ei.value)
+        assert f"{FAKE}.bfloat16" in msg
+        assert "not installed" in msg
+        assert "setup()" in msg          # names the fix
+        assert f"install {FAKE!r}" in msg
+
+
+def test_defaulted_getattr_probes_degrade_gracefully() -> None:
+    # getattr(mod, "__version__", "N/A") style probes (transformers' package
+    # fallback) must get the default, not an explosion: HeavyDepStubError is
+    # an AttributeError.
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        mod = _stmt_import(f"import {FAKE}")[FAKE]
+        assert getattr(mod, "__version__", "N/A") == "N/A"
+        assert not hasattr(mod, "__file__")
+
+
+def test_stubs_removed_on_exit() -> None:
+    import builtins
+
+    before_import = builtins.__import__
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        _stmt_import(f"import {FAKE}.nn")
+        assert FAKE in sys.modules
+    assert builtins.__import__ is before_import
+    assert FAKE not in sys.modules
+    assert f"{FAKE}.nn" not in sys.modules
+    with pytest.raises(ModuleNotFoundError):
+        _stmt_import(f"import {FAKE}")
+
+
+def test_non_heavy_import_errors_pass_through() -> None:
+    with stub_missing_heavy_deps(extra=(FAKE,)):
+        with pytest.raises(ModuleNotFoundError):
+            _stmt_import("import definitely_not_a_real_package_xyz")
+
+
+def test_torch_is_on_the_default_allowlist() -> None:
+    assert "torch" in DEFAULT_HEAVY_ROOTS
+    assert "torchvision" in DEFAULT_HEAVY_ROOTS
+
+
+# --------------------------------------------------------------------------- #
+# discovery integration: module-top heavy import in a dep-less env            #
+# --------------------------------------------------------------------------- #
+
+
+def test_discovery_with_top_level_heavy_import_in_bare_env(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_heavy"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_endpoint_src(
+        f"import {FAKE}\nfrom {FAKE} import nn\n"
+    ))
+
+    fns = discover_functions(
+        tmp_pkg, main_module="ep_heavy.main", extra_heavy_deps=(FAKE,)
+    )
+    assert [f["name"] for f in fns] == ["generate"]
+    assert fns[0]["input_schema"]  # schemas still build against the stubs
+
+
+def test_discovery_module_scope_use_of_missing_heavy_dep_fails_loud(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_heavy_use"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_endpoint_src(
+        f"import {FAKE}\nDTYPE = {FAKE}.bfloat16\n"
+    ))
+
+    with pytest.raises(ValueError) as ei:
+        discover_functions(
+            tmp_pkg, main_module="ep_heavy_use.main", extra_heavy_deps=(FAKE,)
+        )
+    # The chain surfaces the actionable stub error, not a bare AttributeError.
+    assert f"{FAKE}.bfloat16" in str(ei.value)
+    cause: BaseException | None = ei.value
+    while cause is not None and not isinstance(cause, HeavyDepStubError):
+        cause = cause.__cause__
+    assert isinstance(cause, HeavyDepStubError)
+
+
+# --------------------------------------------------------------------------- #
+# hard-fail on submodule import errors (the pgw#506 sharpening)                #
+# --------------------------------------------------------------------------- #
+
+
+def test_broken_submodule_hard_fails_the_walk(tmp_pkg: Path) -> None:
+    pkg = tmp_pkg / "ep_broken_sub"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_endpoint_src())
+    (pkg / "broken.py").write_text("import definitely_not_a_real_package_xyz\n")
+
+    with pytest.raises(EndpointImportError) as ei:
+        find_endpoints(["ep_broken_sub"])
+    assert "ep_broken_sub.broken" in str(ei.value)
+    assert isinstance(ei.value.__cause__, ModuleNotFoundError)
+
+
+def test_syntax_error_in_submodule_hard_fails(tmp_pkg: Path) -> None:
+    pkg = tmp_pkg / "ep_syntax"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_endpoint_src())
+    (pkg / "oops.py").write_text("def broken(:\n")
+
+    with pytest.raises(EndpointImportError) as ei:
+        find_endpoints(["ep_syntax"])
+    assert "ep_syntax.oops" in str(ei.value)
+    assert isinstance(ei.value.__cause__, SyntaxError)
+
+
+def test_top_level_import_error_hard_fails(tmp_pkg: Path) -> None:
+    pkg = tmp_pkg / "ep_top_broken"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("raise RuntimeError('boom at import')\n")
+
+    with pytest.raises(EndpointImportError) as ei:
+        find_endpoints(["ep_top_broken"])
+    assert "ep_top_broken" in str(ei.value)
+    assert "boom at import" in str(ei.value)
+
+
+def test_discover_functions_wraps_walk_failure_with_context(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_wrap"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(_endpoint_src())
+    (pkg / "dead.py").write_text("import definitely_not_a_real_package_xyz\n")
+
+    with pytest.raises(ValueError) as ei:
+        discover_functions(tmp_pkg, main_module="ep_wrap.main")
+    assert "ep_wrap" in str(ei.value)
+    cause: BaseException | None = ei.value
+    while cause is not None and not isinstance(cause, EndpointImportError):
+        cause = cause.__cause__
+    assert isinstance(cause, EndpointImportError)

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the pgw#506 lane: retire the defer-`import torch`-into-handler-bodies convention, and its sharpening — discovery must hard-fail on submodule import errors instead of log-and-continue.

## 1. Fail-loud lazy-import shim (`discovery/heavy_deps.py`)

Build-time discovery (`python -m gen_worker.discovery` / `discover_functions`) arms `stub_missing_heavy_deps(...)` around the walk:

- **Allowlist** (`DEFAULT_HEAVY_ROOTS`): `torch, torchvision, torchaudio, triton, xformers, flash_attn, bitsandbytes`. Deliberately small; diffusers/transformers are NOT on it — they import cheaply without torch and their classes must stay real for slot annotations. **Extension point**: `[tool.gen_worker] discovery_heavy_deps = ["my_heavy_lib"]` (merged with the defaults, never replacing them).
- **Injection point**: a `builtins.__import__` wrapper — when an `import` statement targets an allowlisted root that is genuinely ABSENT (`find_spec` miss), a transient meta-path finder serves a stub for it and any submodule (`import torch`, `import torch.nn.functional`, `from torch import nn` all resolve). When the dep IS installed, nothing changes — real module, identical to today.
- **Why not a standing meta-path finder** (first implementation, rejected by the sdxl proof): it makes `importlib.util.find_spec("torchvision")` return a spec for a missing package, fooling third-party availability probes — transformers' `is_torchvision_available` is find_spec-only, and the fooled probe unlocked module-scope torchvision use that crashed discovery *even with torch installed*. The `__import__` wrapper serves only real import statements; probes stay honest.
- **Error text** (`HeavyDepStubError`, an `AttributeError` subclass so `hasattr`/defaulted-`getattr` probes degrade gracefully):
  > `'torch.bfloat16' was touched during discovery, but 'torch' is not installed in this environment. Discovery stubs missing heavy dependencies so a module-top `import torch` is free — but EXECUTING torch code at import time (e.g. `DTYPE = torch.bfloat16` or `torch.cuda.is_available()` at module scope) is not. Move that code into setup() or the handler body, or install 'torch' to run discovery against the real module.`

## 2. Hard-fail on module import errors (the sharpening)

`find_endpoints` no longer logs-and-continues when a top module or submodule fails to import — that silently shipped endpoint.locks (and live worker route tables; the walker is shared) missing functions. Now: `EndpointImportError` with the original exception chained; the discovery CLI prints the full traceback and exits 1. What used to be silently skipped and is now rejected: a submodule with a missing **non-heavy** dep, a SyntaxError, any exception at module scope. A missing heavy dep is NOT an import failure (the shim absorbs it); everything else fails the build.

## 3. Docs

`docs/endpoint-authoring.md`: new "Imports go at module top — including torch" section; the defer convention is deleted from guidance.

## Demonstrated on sdxl (cozy-creator/inference-endpoints#74)

Real `python -m gen_worker.discovery` against the migrated endpoint (module-top `import torch`):
- **torch installed** (package venv, torch 2.13.0+cu129): exit 0, 2 functions, real diffusers classes (~50s — the torch load the in-image build pays anyway).
- **torch absent** (bare venv): exit 0, same 2 functions (~10s). Lock byte-identical except `slots[].pipeline_class`, which resolves to `diffusers.utils.dummy_*` paths — diffusers swaps its own classes without torch (upstream artifact, not the shim; production locks build in-image).
- **fail-loud**: `_X = torch.bfloat16` at module scope → exit 1 with the actionable error above.

## Gates

- mypy: 0 errors (blocking gate stays green).
- ruff: clean.
- Suite: 958 passed, 6 failed — all 6 verified byte-identical on `origin/master` in this env (3 `test_content_lanes` FORBID_CPU_OFFLOAD + 2 `test_ram_admission` + 1 `test_snapshot_corruption`, shared-box env failures).
- New tests (`tests/test_discovery_heavy_deps.py`, 15): stub only-when-missing; submodule/fromlist stubbing; find_spec/import_module probe honesty; actionable attribute-touch error; graceful defaulted-getattr; clean unwind on exit; discovery integration with a top-level heavy import in a bare env; module-scope-use fail-loud; hard-fail on broken submodule / SyntaxError / broken top module.

Version: **0.18.3** (0.18.2 is claimed by the in-flight pgw#517 branch). sdxl's `>=0.18.0,<0.19` pin admits it without churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)