### PR TITLE
pgw#505: selective component download — declare-on-binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.22.2 (2026-07-13)
+
+- **pgw#505: selective component download — declare-on-binding.** `Hub`/`HF`
+  gain `components=` (mirrors `files=`): restricts a fetch to the named
+  pipeline component subfolders (+ root config files, e.g.
+  `model_index.json`) instead of the whole repo — the win case is a full
+  pipeline repo bound for exactly ONE component, e.g.
+  `Hub("owner/sdxl-repo", components=("vae",))`. Civitai/modelscope reject
+  it (civitai artifacts aren't component-structured; modelscope already has
+  `files=`). `components=` surfaces on the manifest binding block (tensorhub
+  + huggingface) so the hub's ModelOp DOWNLOAD scoping can read it once
+  built — that platform-side selective CAS resolve is NOT part of this
+  release. Worker-side filtering ships now on two paths that fully own
+  their own resolve+download+materialize loop: the HF downloader (both the
+  production executor and the CLI) narrows `snapshot_download`'s
+  `allow_patterns` to the declared subfolders before the existing
+  flavor-selection logic runs; the CLI's hub-less tensorhub resolve
+  (`cozy run` / `gen-worker run`, th#560) narrows the fetched blob set and
+  keys the materialized snapshot directory by `(digest, components)` so a
+  component-scoped fetch can never collide with — or be mistaken for — the
+  full-repo one. The production executor's orchestrator-resolved snapshot
+  path is deliberately left unfiltered: its residency layer digest-verifies
+  the materialized tree against the orchestrator's full file list, so
+  scoping there is the hub's job, not the worker's.
+- **Rebased onto 0.21.0 (post-#233 `allow_lora` eviction, post-#243 dynamic
+  slot materialization).** This PR's original diff (authored pre-#233) also
+  re-added `allow_lora=` to `ModelRef`/`Hub`/`HF` and an
+  `_binding_to_manifest`/discovery emission path for it — all of that is
+  dropped on rebase; `allow_lora` stays evicted (overlay permission is a
+  slot-policy concern, th#772, not a binding-identity flag). Only the
+  `components=` axis (a genuinely new field, disjoint from `allow_lora`)
+  survives. `binding.py`, `discover.py`, `test_binding.py`, and
+  `test_discovery_and_decorators.py` all had this same shape of conflict;
+  resolved identically in each. No interaction with #243's slot
+  materialization — `components=` is a fetch-scope hint on a fixed binding,
+  orthogonal to which pick gets dispatched.
+
 ## 0.22.1 (2026-07-13)
 
 - **pgw#506: discovery-time lazy-import stubs for heavy deps — the

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -84,13 +84,21 @@ The slot name is the `models={}` key (or, with the single-binding `model=`
 shorthand, the `setup()` parameter name). It is never a constructor argument.
 
 ```python
-HF("owner/repo", revision=..., dtype=..., subfolder=..., files=(...), storage_dtype=...)
-Hub("owner/repo", tag="latest", flavor="", storage_dtype="")  # tensorhub
+HF("owner/repo", revision=..., dtype=..., subfolder=..., files=(...), components=(...), storage_dtype=...)
+Hub("owner/repo", tag="latest", flavor="", components=(...), storage_dtype="")  # tensorhub
 Civitai("123456", version="789")             # civitai model id
 ModelScope("owner/repo", revision=..., files=(...))
 ```
 
 `files` are `snapshot_download` allow-patterns for split-checkpoint repos.
+
+`components` (tensorhub/huggingface only) fetches only the named pipeline
+component subfolders instead of the whole repo — root config files
+(`model_index.json` and other root `*.json`) are always kept alongside. The
+win case: a slot binds a full pipeline repo but only needs ONE component out
+of it, e.g. `Hub("owner/sdxl-repo", components=("vae",))` for a VAE swap —
+`unet`/`text_encoder`/etc. never download. Civitai/modelscope reject it
+(civitai artifacts aren't component-structured; modelscope has `files=`).
 
 `storage_dtype="fp8"` keeps denoiser weights in fp8-E4M3 STORAGE with
 per-layer upcast to the compute `dtype` (diffusers layerwise casting) — half

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.1"
+version = "0.22.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -64,6 +64,15 @@ class ModelRef(msgspec.Struct, frozen=True):
     constructor — they pin ``source`` and apply the per-registry validation
     below (mirrored in ``__post_init__`` so it holds for direct construction
     too, e.g. ``msgspec.structs.replace``).
+
+    ``components`` (pgw#505, tensorhub/huggingface only): restricts the
+    fetch to the named pipeline component subfolders — e.g. a full SDXL repo
+    bound only for its VAE: ``Hub("owner/sdxl-repo", components=("vae",))``.
+    Root config files (``model_index.json`` and other root ``*.json``) are
+    always kept alongside the named subfolders. Empty (default) fetches the
+    whole repo — today's behavior. Civitai/modelscope reject it: civitai
+    artifacts aren't component-structured, and modelscope's ``files=`` glob
+    already covers the split-checkpoint case.
     """
 
     source: ModelSource
@@ -76,6 +85,7 @@ class ModelRef(msgspec.Struct, frozen=True):
     storage_dtype: str = ""
     version: str = ""
     files: tuple[str, ...] = ()
+    components: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         # msgspec.structs.force_setattr, NOT object.__setattr__: the latter
@@ -92,6 +102,7 @@ class ModelRef(msgspec.Struct, frozen=True):
         force(self, "dtype", _clean(self.dtype))
         force(self, "version", _clean(self.version))
         force(self, "files", tuple(_clean(p) for p in self.files if _clean(p)))
+        force(self, "components", tuple(_clean(p) for p in self.components if _clean(p)))
         force(self, "storage_dtype", _clean_storage_dtype(self.storage_dtype))
 
         if self.source == "tensorhub":
@@ -105,9 +116,18 @@ class ModelRef(msgspec.Struct, frozen=True):
         elif self.source == "civitai":
             if not self.path:
                 raise ValueError("Civitai requires a non-empty model id")
+            if self.components:
+                raise ValueError(
+                    "Civitai bindings do not support components= "
+                    "(civitai artifacts aren't component-structured)"
+                )
         elif self.source == "modelscope":
             if "/" not in self.path:
                 raise ValueError(f"ModelScope(id=) must be 'owner/repo', got {self.path!r}")
+            if self.components:
+                raise ValueError(
+                    "ModelScope bindings do not support components= (use files= instead)"
+                )
         else:
             raise ValueError(f"unknown ModelRef source {self.source!r}")
 
@@ -118,11 +138,18 @@ def Hub(
     tag: str = "latest",
     flavor: str = "",
     storage_dtype: str = "",
+    components: tuple[str, ...] = (),
 ) -> ModelRef:
-    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=)``."""
+    """Tensorhub-backed binding: ``Hub("owner/repo", tag=, flavor=, storage_dtype=, components=)``.
+
+    ``components=`` (pgw#505) fetches only the named pipeline component
+    subfolders (+ root config files) instead of the whole repo — e.g. a
+    full SDXL checkpoint bound only for its VAE:
+    ``Hub("owner/sdxl-repo", components=("vae",))``.
+    """
     return ModelRef(
         source="tensorhub", path=ref, tag=tag, flavor=flavor,
-        storage_dtype=storage_dtype,
+        storage_dtype=storage_dtype, components=components,
     )
 
 
@@ -133,20 +160,27 @@ def HF(
     dtype: str = "",
     subfolder: str = "",
     files: tuple[str, ...] = (),
+    components: tuple[str, ...] = (),
     storage_dtype: str = "",
 ) -> ModelRef:
-    """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=, storage_dtype=)``.
+    """HuggingFace-backed binding: ``HF(id, revision=, dtype=, subfolder=, files=, components=, storage_dtype=)``.
 
     ``files`` are ``snapshot_download`` ``allow_patterns`` globs — set them to
     fetch only specific files (ComfyUI / split-checkpoint repos with no
-    ``model_index.json``). ``dtype`` selects the torch COMPUTE precision at
-    load time (``"bf16"`` / ``"fp16"`` / ``"fp32"``). ``storage_dtype="fp8"``
-    keeps denoiser weights in fp8-E4M3 storage with per-layer upcast to the
-    compute dtype (VRAM fit on any card; see ``STORAGE_DTYPES``).
+    ``model_index.json``). ``components=`` (pgw#505) is the diffusers-layout
+    counterpart: name the pipeline component subfolders to fetch (e.g.
+    ``components=("unet", "text_encoder")``); root config files
+    (``model_index.json`` + other root ``*.json``) are always kept. When both
+    are set, ``files=`` is matched within the ``components=``-narrowed
+    listing. ``dtype`` selects the torch COMPUTE precision at load time
+    (``"bf16"`` / ``"fp16"`` / ``"fp32"``). ``storage_dtype="fp8"`` keeps
+    denoiser weights in fp8-E4M3 storage with per-layer upcast to the compute
+    dtype (VRAM fit on any card; see ``STORAGE_DTYPES``).
     """
     return ModelRef(
         source="huggingface", path=ref, revision=revision, dtype=dtype,
-        subfolder=subfolder, files=files, storage_dtype=storage_dtype,
+        subfolder=subfolder, files=files, components=components,
+        storage_dtype=storage_dtype,
     )
 
 

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -35,6 +35,9 @@ def describe_binding(binding: Any) -> Dict[str, Any]:
         files = tuple(getattr(binding, "files", ()) or ())
         if files:
             out["files"] = list(files)
+        components = tuple(getattr(binding, "components", ()) or ())
+        if components:
+            out["components"] = list(components)
         return out
     return {"type": type(binding).__name__}
 

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -290,6 +290,11 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
             out["tag"] = binding.tag
         if binding.flavor:
             out["flavor"] = binding.flavor
+        if binding.components:
+            # pgw#505: the hub's ModelOp DOWNLOAD scoping (platform-side,
+            # not yet built) reads this to resolve only the named pipeline
+            # component subfolders instead of the whole repo.
+            out["components"] = list(binding.components)
     elif binding.source == "huggingface":
         for k in ("revision", "dtype", "subfolder"):
             v = getattr(binding, k)
@@ -297,6 +302,8 @@ def _binding_to_manifest(binding: Binding, param_name: str = "") -> Dict[str, An
                 out[k] = v
         if binding.files:
             out["files"] = list(binding.files)
+        if binding.components:
+            out["components"] = list(binding.components)
     elif binding.source == "civitai":
         if binding.version:
             out["version"] = binding.version
@@ -325,13 +332,15 @@ def _stamp_family(binding_manifest: Dict[str, Any], family: str) -> None:
 
 def _model_ref_to_manifest(ref: Any) -> Dict[str, Any]:
     """``default_checkpoint``/curated-choice ref shape shared by the slots
-    block: ``{source, path, tag?, flavor?}`` — a structured ModelRef
-    (pgw#511)."""
+    block: ``{source, path, tag?, flavor?, components?}`` — a structured
+    ModelRef (pgw#511; ``components`` added pgw#505)."""
     out: Dict[str, Any] = {"source": ref.source, "path": ref.path}
     if ref.tag and ref.tag != "latest":
         out["tag"] = ref.tag
     if ref.flavor:
         out["flavor"] = ref.flavor
+    if ref.components:
+        out["components"] = list(ref.components)
     return out
 
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -767,6 +767,7 @@ class ModelStore:
                         hf_home=self._hf_home,
                         hf_token=self._hf_token,
                         allow_patterns=tuple(getattr(binding, "files", ()) or ()),
+                        components=tuple(getattr(binding, "components", ()) or ()),
                         progress=_progress,
                     )
                     self.residency.track_disk(ref, path)

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -8,10 +9,11 @@ import re
 import shutil
 import threading
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 
 from .cozy_cas import _download_one_file as _download_one_file
 from .cozy_cas import _norm_rel_path
+from .download import components_present, select_component_paths
 from .hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from .refs import TensorhubRef
 from ..capability import InsufficientDiskError
@@ -142,6 +144,36 @@ def _validate_resolved(ref: TensorhubRef, resolved: WorkerResolvedRepo) -> Worke
     return WorkerResolvedRepo(snapshot_digest=snapshot_digest, files=files)
 
 
+def snapshot_dir_key(snapshot_digest: str, components: Sequence[str] = ()) -> str:
+    """On-disk snapshot-directory key (pgw#505): the bare digest normally, or
+    ``<digest>__c<fingerprint>`` when ``components`` narrows the materialized
+    tree to a SUBSET of the digest's full content. Keyed separately so a
+    component-scoped (partial) materialization can never be mistaken for —
+    or collide with — the full one under the same digest."""
+    comps = sorted({c.strip() for c in components if c and str(c).strip()})
+    if not comps:
+        return snapshot_digest
+    fingerprint = hashlib.sha1("+".join(comps).encode()).hexdigest()[:12]
+    return f"{snapshot_digest}__c{fingerprint}"
+
+
+def _filter_resolved_components(
+    ref: TensorhubRef, res: WorkerResolvedRepo, components: Sequence[str],
+) -> WorkerResolvedRepo:
+    """Narrow a validated :class:`WorkerResolvedRepo` to the declared
+    pipeline components (+ root config files) — the tensorhub-source twin of
+    ``download.select_component_paths`` for the HF path."""
+    paths = [f.path for f in res.files]
+    if not components_present(paths, components):
+        raise ValueError(
+            f"components= {list(components)!r} matched nothing in "
+            f"{ref.canonical()} snapshot {res.snapshot_digest[:16]}"
+        )
+    keep = select_component_paths(paths, components)
+    files = [f for f in res.files if f.path in keep]
+    return WorkerResolvedRepo(snapshot_digest=res.snapshot_digest, files=files)
+
+
 # ---------------------------------------------------------------------------
 # Main downloader
 # ---------------------------------------------------------------------------
@@ -151,7 +183,8 @@ class CozySnapshotDownloader:
 
     Layout under <base_dir>:
       blobs/blake3/<aa>/<bb>/<digest>
-      snapshots/<snapshot_digest>/...
+      snapshots/<snapshot_digest>/...            (whole repo)
+      snapshots/<snapshot_digest>__c<fp>/...     (components=-scoped subset, pgw#505)
     """
 
     def __init__(self) -> None:
@@ -164,6 +197,7 @@ class CozySnapshotDownloader:
         *,
         resolved: Optional[WorkerResolvedRepo],
         progress: Optional[ProgressFn] = None,
+        components: Sequence[str] = (),
     ) -> Path:
         blobs_root = base_dir / "blobs"
         snaps_root = base_dir / "snapshots"
@@ -177,10 +211,17 @@ class CozySnapshotDownloader:
                 "cozy snapshot requires orchestrator-resolved URLs (resolved=None)"
             )
         res = _validate_resolved(ref, resolved)
+        if components:
+            res = _filter_resolved_components(ref, res, components)
 
-        snap_dir = snaps_root / res.snapshot_digest
+        # pgw#505: a components=-scoped fetch materializes a NARROWER tree
+        # than the digest's full content, so it is keyed separately (never
+        # under the bare digest — that name is reserved for the complete
+        # snapshot).
+        key = snapshot_dir_key(res.snapshot_digest, components)
+        snap_dir = snaps_root / key
         if snap_dir.exists():
-            _log.info("snapshot_cached digest=%s", res.snapshot_digest[:16])
+            _log.info("snapshot_cached key=%s", key[:24])
             return snap_dir
 
         # Coordinate concurrent builders via threading (works across event loops).
@@ -188,23 +229,23 @@ class CozySnapshotDownloader:
         with _SNAP_LOCK:
             if snap_dir.exists():
                 return snap_dir
-            entry = _SNAP_ENTRIES.get(res.snapshot_digest)
+            entry = _SNAP_ENTRIES.get(key)
             if entry is None:
                 entry = _SnapshotEntry()
-                _SNAP_ENTRIES[res.snapshot_digest] = entry
+                _SNAP_ENTRIES[key] = entry
                 is_builder = True
             else:
                 is_builder = False
 
         if not is_builder:
-            _log.info("snapshot_waiting digest=%s (another builder active)", res.snapshot_digest[:16])
+            _log.info("snapshot_waiting key=%s (another builder active)", key[:24])
             await loop.run_in_executor(None, entry.event.wait)
             if entry.exception is not None:
                 raise RuntimeError("concurrent snapshot build failed") from entry.exception
             return snap_dir
 
         try:
-            _log.info("snapshot_build_start digest=%s files=%d", res.snapshot_digest[:16], len(res.files))
+            _log.info("snapshot_build_start key=%s files=%d", key[:24], len(res.files))
             await self._ensure_blobs(blobs_root, res.files, progress=progress)
             # Materialization copies/concatenates multi-GB trees — strictly
             # off the event loop (gw#407: a loop blocked for the duration of
@@ -213,7 +254,7 @@ class CozySnapshotDownloader:
             await asyncio.to_thread(
                 self._materialize_snapshot, blobs_root, snaps_root, snap_dir, res
             )
-            _log.info("snapshot_build_done digest=%s", res.snapshot_digest[:16])
+            _log.info("snapshot_build_done key=%s", key[:24])
             return snap_dir
         except BaseException as exc:
             entry.exception = exc
@@ -224,8 +265,8 @@ class CozySnapshotDownloader:
             # entry so the next request creates a fresh builder and retries;
             # waiters already holding this entry still see its exception once.
             with _SNAP_LOCK:
-                if _SNAP_ENTRIES.get(res.snapshot_digest) is entry:
-                    del _SNAP_ENTRIES[res.snapshot_digest]
+                if _SNAP_ENTRIES.get(key) is entry:
+                    del _SNAP_ENTRIES[key]
             entry.event.set()
 
     def _materialize_snapshot(
@@ -237,7 +278,7 @@ class CozySnapshotDownloader:
     ) -> None:
         """Blocking build phase (worker thread): reassemble + hardlink into a
         ``.building`` dir, then atomically rename into place."""
-        tmp = snaps_root / f"{res.snapshot_digest}.building"
+        tmp = snaps_root / f"{snap_dir.name}.building"
         if tmp.exists():
             shutil.rmtree(tmp)
         tmp.mkdir(parents=True, exist_ok=True)
@@ -497,6 +538,9 @@ async def ensure_snapshot_async(
     ref: TensorhubRef,
     resolved: Optional[WorkerResolvedRepo],
     progress: Optional[ProgressFn] = None,
+    components: Sequence[str] = (),
 ) -> Path:
     dl = CozySnapshotDownloader()
-    return await dl.ensure_snapshot(base_dir, ref, resolved=resolved, progress=progress)
+    return await dl.ensure_snapshot(
+        base_dir, ref, resolved=resolved, progress=progress, components=components,
+    )

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -195,6 +195,7 @@ async def ensure_local(
     hf_token: Optional[str] = None,
     civitai_api_key: str = "",
     allow_patterns: Sequence[str] = (),
+    components: Sequence[str] = (),
     progress: Optional[ProgressFn] = None,
 ) -> Path:
     """Materialize ``ref`` on disk; return its local path.
@@ -207,6 +208,20 @@ async def ensure_local(
     authoritative and the bytes come from tensorhub-CAS, never the upstream
     registry. Refs without a snapshot fall back to their provider's direct
     download (hf/civitai/modelscope) or fail retryably (tensorhub).
+
+    ``components`` (pgw#505) is honored on the HF direct-download branch.
+    It is deliberately NOT applied to the ``snapshot is not None`` branch:
+    that snapshot is orchestrator-resolved and the executor's residency
+    layer digest-verifies the materialized tree against the FULL
+    ``snapshot.files`` list it was handed (``ModelStore._verify_snapshot_tree``)
+    — filtering what gets written here without the orchestrator also
+    filtering what it verifies would turn every boot into a spurious
+    corruption/quarantine loop. Selective fetch for tensorhub-sourced
+    snapshots is therefore the hub's ModelOp DOWNLOAD scoping (the manifest
+    now carries ``components`` for it to read) — worker-side selective fetch
+    for tensorhub refs lands on the hub-less CLI path instead
+    (``models/provision.py::_fetch_tensorhub_snapshot``), which owns its own
+    resolve+download+materialize loop end to end.
     """
     base = Path(cache_dir) if cache_dir is not None else tensorhub_cas_dir()
     prov = provider or lookup_provider_for_ref(ref)
@@ -240,6 +255,7 @@ async def ensure_local(
             hf_home=hf_home,
             hf_token=hf_token,
             allow_patterns=tuple(allow_patterns),
+            components=tuple(components),
             progress=progress,
         )
 
@@ -360,6 +376,47 @@ def select_hf_files(
     for group in weights_by_dir.values():
         selected.update(_pick(group))
     return selected
+
+
+def select_component_paths(paths: Sequence[str], components: Sequence[str]) -> set[str]:
+    """Narrow a repo file listing to declared pipeline COMPONENTS (pgw#505):
+    every path under a ``<component>/`` subfolder, plus every root-level
+    ``*.json`` (``model_index.json`` and siblings — always kept so
+    downstream component-set introspection / pipeline-class detection still
+    works off the narrowed tree). Empty ``components`` returns every path
+    unchanged (whole-repo, today's default). Shared by the HF downloader and
+    the tensorhub CAS snapshot downloader (``cozy_snapshot.py``) — the ONE
+    filter both sources apply.
+    """
+    comps = {c.strip() for c in components if c and str(c).strip()}
+    if not comps:
+        return set(paths)
+    keep: set[str] = set()
+    for p in paths:
+        if not p:
+            continue
+        if "/" not in p:
+            if p.lower().endswith(".json"):
+                keep.add(p)
+            continue
+        top = p.split("/", 1)[0]
+        if top in comps:
+            keep.add(p)
+    return keep
+
+
+def components_present(paths: Sequence[str], components: Sequence[str]) -> bool:
+    """Whether every declared component names an ACTUAL subfolder in
+    ``paths``. Root config files are always kept by
+    :func:`select_component_paths` regardless of ``components`` — so a
+    typo'd component name can't be detected by an empty result alone (the
+    root jsons keep the selection non-empty); this checks the component
+    NAMES themselves matched something."""
+    comps = {c.strip() for c in components if c and str(c).strip()}
+    if not comps:
+        return True
+    dirs = {p.split("/", 1)[0] for p in paths if p and "/" in p}
+    return bool(dirs & comps)
 
 
 def _match_allow_patterns(repo_files: Sequence[str], patterns: Sequence[str]) -> set[str]:
@@ -489,12 +546,21 @@ def download_hf(
     hf_home: Optional[str] = None,
     hf_token: Optional[str] = None,
     allow_patterns: Sequence[str] = (),
+    components: Sequence[str] = (),
     progress: Optional[ProgressFn] = None,
     local_files_only: bool = False,
 ) -> Path:
     """Blocking HF snapshot download (call via ``ensure_local`` /
     ``asyncio.to_thread``). Transfer, cache, resume and locking are
-    huggingface_hub's; this only plans the file selection."""
+    huggingface_hub's; this only plans the file selection.
+
+    ``components`` (pgw#505) narrows the repo listing to the named pipeline
+    component subfolders (+ root config files, via
+    :func:`select_component_paths`) BEFORE the existing ``files=``/auto
+    variant-selection logic runs — so a component-scoped fetch still gets
+    per-component flavor picking (bf16 > fp16 > untagged), just over a
+    smaller candidate set.
+    """
     from ..net import hf
 
     try:
@@ -510,6 +576,7 @@ def download_hf(
         raise ValueError("empty hf repo_id")
     hf_home = (hf_home or "").strip() or None
     hf_token = (hf_token or "").strip() or None
+    comps = tuple(c.strip() for c in components if c and str(c).strip())
     kwargs: dict[str, Any] = {}
     if hf_home:
         kwargs["cache_dir"] = hf_home
@@ -517,13 +584,25 @@ def download_hf(
         kwargs["token"] = hf_token
 
     if local_files_only:
+        patterns = list(allow_patterns)
+        if comps and not patterns:
+            # No repo listing available offline to narrow precisely — fall
+            # back to component-subfolder + root-json glob patterns.
+            patterns = [f"{c}/" for c in comps] + ["*.json"]
         return Path(snapshot_download(
             repo_id=repo_id, revision=ref.revision, local_files_only=True,
-            allow_patterns=list(allow_patterns) or None, **kwargs,
+            allow_patterns=patterns or None, **kwargs,
         ))
 
     api = HfApi(token=hf_token)
     repo_files = list(api.list_repo_files(repo_id=repo_id, repo_type="model", revision=ref.revision))
+
+    if comps:
+        if not components_present(repo_files, comps):
+            raise ValueError(
+                f"components= {list(comps)!r} matched nothing in {repo_id}"
+            )
+        repo_files = sorted(select_component_paths(repo_files, comps))
 
     selected: Optional[set[str]]
     if allow_patterns:
@@ -540,6 +619,13 @@ def download_hf(
         selected = select_hf_files(repo_files, flavor=ref.flavor)
         if selected is not None:
             kwargs["allow_patterns"] = sorted(selected)
+        elif comps:
+            # components= narrowed the listing but the repo has no
+            # recognized diffusers/root-weights layout for select_hf_files
+            # to specialize further — fetch exactly the components= subset
+            # rather than silently reverting to the whole repo.
+            selected = set(repo_files)
+            kwargs["allow_patterns"] = repo_files
 
     # Best-effort size guard against accidental huge downloads.
     total_hint: Optional[int] = None
@@ -874,6 +960,8 @@ __all__ = [
     "download_hf",
     "download_civitai",
     "select_hf_files",
+    "select_component_paths",
+    "components_present",
     "fetch_civitai_model",
     "fetch_civitai_model_version",
     "parse_civitai_version_id",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -316,6 +316,7 @@ def resolve_bindings(
             ref=wire_ref(binding), provider=binding.source,
             offline=offline, emit=emit,
             allow_patterns=tuple(getattr(binding, "files", ()) or ()),
+            components=tuple(getattr(binding, "components", ()) or ()),
             civitai_version_id=str(getattr(binding, "version", "") or ""),
         )
     return out
@@ -341,16 +342,29 @@ def _remember_hub_ref(cache_dir: Path, thref: Any, digest: str) -> None:
 
 
 def _fetch_tensorhub_snapshot(
-    thref: Any, *, cache_dir: Path, emit: EmitFn,
+    thref: Any, *, cache_dir: Path, emit: EmitFn, components: Tuple[str, ...] = (),
 ) -> str:
     """Resolve a Hub ref via th#560 and download its snapshot into the CAS.
 
     One re-resolve retry on a presigned-URL expiry mid-download (the same
     contract the orchestrator honors on ``url_expired``).
+
+    ``components`` (pgw#505): th#560's resolve route always returns the
+    FULL repo manifest today (selective CAS resolve is the hub-side
+    ModelOp DOWNLOAD scoping — a separate, not-yet-built platform change).
+    Until then this narrows client-side: the worker fully owns this
+    resolve+download+materialize loop (unlike the production executor path,
+    which digest-verifies against an orchestrator-issued file list), so it
+    can safely fetch only the declared components — ``ensure_snapshot_async``
+    keys the materialized directory by ``(digest, components)`` so a partial
+    fetch never collides with a full one of the same ref. NOTE: offline
+    reuse (``--offline`` / the ``_hub_ref_map_path`` tag memory below) only
+    covers the FULL-repo case — a components=-scoped ref must be fetched
+    online at least once per component set.
     """
     import asyncio
 
-    from .cozy_snapshot import ensure_snapshot_async
+    from .cozy_snapshot import ensure_snapshot_async, snapshot_dir_key
     from .errors import UrlExpiredError
     from .hub_client import HubResolveError, resolve_repo
 
@@ -365,10 +379,12 @@ def _fetch_tensorhub_snapshot(
     emit({"kind": "model_fetch.started", "ref": canonical, "provider": "tensorhub"})
     resolved = _resolve()
 
-    # Already materialized under the resolved digest? No download.
-    snap_dir = cache_dir / "snapshots" / resolved.snapshot_digest
+    # Already materialized under the resolved (digest, components) key? No download.
+    key = snapshot_dir_key(resolved.snapshot_digest, components)
+    snap_dir = cache_dir / "snapshots" / key
     if snap_dir.exists():
-        _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
+        if not components:
+            _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
         emit({"kind": "model_fetch.completed", "ref": canonical,
               "provider": "tensorhub", "local_dir": str(snap_dir)})
         return str(snap_dir)
@@ -387,6 +403,7 @@ def _fetch_tensorhub_snapshot(
     async def _download(res: Any) -> Path:
         return await ensure_snapshot_async(
             base_dir=cache_dir, ref=thref, resolved=res, progress=_progress,
+            components=components,
         )
 
     try:
@@ -402,7 +419,8 @@ def _fetch_tensorhub_snapshot(
         raise ModelResolutionError(
             f"failed to download tensorhub snapshot for {canonical}: {e}"
         ) from e
-    _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
+    if not components:
+        _remember_hub_ref(cache_dir, thref, resolved.snapshot_digest)
     emit({"kind": "model_fetch.completed", "ref": canonical,
           "provider": "tensorhub", "local_dir": str(snap)})
     return str(snap)
@@ -411,6 +429,7 @@ def _fetch_tensorhub_snapshot(
 def resolve_local_path(
     *, ref: str, provider: str, offline: bool, emit: EmitFn,
     allow_patterns: Tuple[str, ...] = (),
+    components: Tuple[str, ...] = (),
     civitai_version_id: str = "",
 ) -> str:
     """Resolve one model ref to a local snapshot dir / loader-ready string.
@@ -423,6 +442,10 @@ def resolve_local_path(
          public resolve route (th#560); ``--offline`` stays CAS-only (exit 3).
       5. Civitai refs → model → latest-version lookup (or the pinned
          version), then ``download_civitai``.
+
+    ``components`` (pgw#505) narrows an HF/tensorhub fetch to the named
+    pipeline component subfolders (+ root config files) — see
+    ``download.select_component_paths`` / ``cozy_snapshot.snapshot_dir_key``.
     """
     from .cache_paths import tensorhub_cas_dir
     from .refs import parse_model_ref
@@ -451,6 +474,9 @@ def resolve_local_path(
         if offline:
             # Best-effort: check the HF cache (huggingface_hub manages this
             # itself; a cache hit returns a path, miss raises).
+            patterns = list(allow_patterns)
+            if components and not patterns:
+                patterns = [f"{c}/" for c in components] + ["*.json"]
             try:
                 from ..net import hf
                 p = hf().snapshot_download(
@@ -459,7 +485,7 @@ def resolve_local_path(
                     local_files_only=True,
                     cache_dir=get_settings().hf_home or None,
                     token=get_settings().hf_token or None,
-                    allow_patterns=list(allow_patterns) or None,
+                    allow_patterns=patterns or None,
                 )
                 return str(p)
             except Exception as e:
@@ -478,6 +504,7 @@ def resolve_local_path(
                 hf_home=get_settings().hf_home or None,
                 hf_token=get_settings().hf_token or None,
                 allow_patterns=tuple(allow_patterns),
+                components=components,
             )
         except Exception as e:
             raise ModelResolutionError(
@@ -536,7 +563,7 @@ def resolve_local_path(
                 "snapshot pre-seeded)."
             )
         return _fetch_tensorhub_snapshot(
-            parsed.tensorhub, cache_dir=cache_dir, emit=emit,
+            parsed.tensorhub, cache_dir=cache_dir, emit=emit, components=components,
         )
 
     # Civitai refs: download the model-version files directly. Auth (for gated

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -88,6 +88,23 @@ def test_provider_ref_allow_lora_aliases_retired() -> None:
         HF("owner/repo", allow_lora=True)  # type: ignore[call-arg]
 
 
+def test_components_allowed_on_tensorhub_and_huggingface_only() -> None:
+    hub = Hub("o/r", components=(" vae ", "", "unet"))
+    assert hub.components == ("vae", "unet")
+
+    hf = HF("o/r", components=("vae",))
+    assert hf.components == ("vae",)
+
+    # Civitai()/ModelScope() don't even expose a components= kwarg; direct
+    # ModelRef construction is the only way to hit the validation.
+    from gen_worker.api.binding import ModelRef
+
+    with pytest.raises(ValueError, match="components="):
+        ModelRef(source="civitai", path="123", components=("vae",))
+    with pytest.raises(ValueError, match="components="):
+        ModelRef(source="modelscope", path="o/r", components=("vae",))
+
+
 def test_typed_payload_size_errors_expose_structured_fields() -> None:
     from gen_worker import ValidationError
     from gen_worker.api.errors import OutputTooLargeError

--- a/tests/test_cozy_snapshot.py
+++ b/tests/test_cozy_snapshot.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 import gen_worker.models.cozy_snapshot as snap_mod
-from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async, snapshot_dir_key
 from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from gen_worker.models.refs import TensorhubRef
 
@@ -30,6 +30,27 @@ def _resolved() -> WorkerResolvedRepo:
             blake3="cd" * 32,
             url="http://example.invalid/blob",
         )],
+    )
+
+
+def _resolved_pipeline() -> WorkerResolvedRepo:
+    """A diffusers-shaped snapshot: root model_index.json + two components."""
+    return WorkerResolvedRepo(
+        snapshot_digest=_DIGEST,
+        files=[
+            WorkerResolvedRepoFile(
+                path="model_index.json", size_bytes=2, blake3="a1" * 32,
+                url="http://example.invalid/model_index.json",
+            ),
+            WorkerResolvedRepoFile(
+                path="vae/diffusion_pytorch_model.safetensors", size_bytes=3, blake3="b2" * 32,
+                url="http://example.invalid/vae",
+            ),
+            WorkerResolvedRepoFile(
+                path="unet/diffusion_pytorch_model.safetensors", size_bytes=4, blake3="c3" * 32,
+                url="http://example.invalid/unet",
+            ),
+        ],
     )
 
 
@@ -56,7 +77,58 @@ def test_failed_build_is_evicted_and_retry_succeeds(tmp_path: Path, monkeypatch)
     assert calls["n"] == 2
     assert (out / "model.safetensors").read_bytes() == b"12345"
 
-    # Third call is a pure cache hit — the leaf is not touched again.
-    out2 = asyncio.run(ensure_snapshot_async(base_dir=tmp_path, ref=ref, resolved=_resolved()))
-    assert out2 == out
-    assert calls["n"] == 2
+
+# --- components= scoped snapshots (pgw#505) ----------------------------------
+
+
+def _install_fake_downloader(monkeypatch) -> None:
+    async def _fake_download(url: str, dst: Path, expected_size: int, expected_blake3: str, on_bytes=None) -> None:
+        dst.write_bytes(b"x" * expected_size)
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _fake_download)
+
+
+def test_components_narrows_materialized_files_and_keys_directory_separately(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    _install_fake_downloader(monkeypatch)
+    ref = TensorhubRef(owner="e2e", repo="sdxl-full")
+
+    out = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path, ref=ref, resolved=_resolved_pipeline(), components=("vae",),
+    ))
+
+    assert out.name == snapshot_dir_key(_DIGEST, ("vae",))
+    assert out.name != _DIGEST  # never aliases the full-repo directory name
+    assert (out / "model_index.json").exists()   # root config always kept
+    assert (out / "vae" / "diffusion_pytorch_model.safetensors").exists()
+    assert not (out / "unet").exists()            # narrowed away
+
+
+def test_components_matching_nothing_raises(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_downloader(monkeypatch)
+    ref = TensorhubRef(owner="e2e", repo="sdxl-full")
+
+    with pytest.raises(ValueError, match="components="):
+        asyncio.run(ensure_snapshot_async(
+            base_dir=tmp_path, ref=ref, resolved=_resolved_pipeline(), components=("nope",),
+        ))
+
+
+def test_full_and_component_scoped_fetches_never_collide(tmp_path: Path, monkeypatch) -> None:
+    """A component-scoped fetch and the whole-repo fetch of the SAME digest
+    must materialize under DIFFERENT directories — sharing one would let a
+    partial tree be mistaken for (or silently completed into) the full one."""
+    _install_fake_downloader(monkeypatch)
+    ref = TensorhubRef(owner="e2e", repo="sdxl-full")
+
+    partial = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path, ref=ref, resolved=_resolved_pipeline(), components=("vae",),
+    ))
+    full = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path, ref=ref, resolved=_resolved_pipeline(),
+    ))
+
+    assert partial != full
+    assert not (partial / "unet").exists()
+    assert (full / "unet").exists() and (full / "vae").exists()

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -629,6 +629,52 @@ def test_binding_emits_no_family_when_none_declared() -> None:
     assert "family" not in block
 
 
+def test_components_binding_emits_in_manifest() -> None:
+    """pgw#505: a declared components= subset surfaces on the manifest
+    binding block for both tensorhub and huggingface sources — the hub
+    reads it to scope its ModelOp DOWNLOAD resolve; the worker's own
+    download layer reads it off the binding object directly (not the
+    manifest) on the hub-less/local paths."""
+    from gen_worker import Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(
+        models={
+            "pipeline": Hub("o/sdxl-full", components=("vae",)),
+            "extra": HF("o/hf-repo", components=("unet", "text_encoder")),
+        },
+        resources=Resources(vram_gb=12),
+    )
+    class Gen:
+        def setup(self, pipeline: str, extra: str) -> None:
+            self.pipeline = pipeline
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    (entry,) = _extract_entries(Gen, "testmod")
+    bindings = entry["bindings"]
+    assert bindings["pipeline"]["components"] == ["vae"]
+    assert bindings["extra"]["components"] == ["unet", "text_encoder"]
+
+
+def test_no_components_binding_omits_manifest_key() -> None:
+    from gen_worker import Hub
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(model=Hub("o/whole-repo"), resources=Resources(vram_gb=12))
+    class Gen:
+        def setup(self, model: str) -> None:
+            self.model = model
+
+        def generate(self, ctx: RequestContext, data: _In) -> _Out:
+            return _Out(result="")
+
+    (entry,) = _extract_entries(Gen, "testmod")
+    (block,) = entry["bindings"].values()
+    assert "components" not in block
+
+
 def test_model_choice_binding_family_matches_top_level_binding(tmp_pkg: Path) -> None:
     """pgw#519: model.choices[].binding gets the SAME family stamp that a
     top-level bindings block gets from Compile(family=...) — tensorhub's

--- a/tests/test_hf_selection.py
+++ b/tests/test_hf_selection.py
@@ -12,7 +12,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from gen_worker.models.download import _match_allow_patterns, download_hf, select_hf_files
+from gen_worker.models.download import (
+    _match_allow_patterns,
+    download_hf,
+    select_component_paths,
+    select_hf_files,
+)
 from gen_worker.models.refs import HuggingFaceRef
 
 _DIFFUSERS_REPO = [
@@ -159,6 +164,113 @@ def test_match_allow_patterns() -> None:
     # Trailing slash means the whole directory (huggingface_hub semantics).
     assert _match_allow_patterns(files, ("split_files/",)) == {"split_files/vae/ae.safetensors"}
     assert _match_allow_patterns(files, ("nope.bin",)) == set()
+
+
+# --- components= subset (pgw#505): fetch only named pipeline component
+# subfolders + root config files, not the whole repo -------------------------
+
+
+def test_select_component_paths_keeps_named_dirs_and_root_json() -> None:
+    sel = select_component_paths(_DIFFUSERS_REPO, ("vae",))
+    assert sel == {
+        "model_index.json",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+        "vae/diffusion_pytorch_model.fp16.safetensors",
+    }
+
+
+def test_select_component_paths_empty_components_keeps_everything() -> None:
+    assert select_component_paths(_DIFFUSERS_REPO, ()) == set(_DIFFUSERS_REPO)
+
+
+def test_select_component_paths_root_non_json_dropped() -> None:
+    sel = select_component_paths(_DIFFUSERS_REPO, ("vae",))
+    assert "README.md" not in sel
+
+
+def _stub_hub_diffusers(monkeypatch, tmp_path):
+    """Stub huggingface_hub over the diffusers-shaped repo fixture."""
+    import huggingface_hub
+
+    calls: dict[str, object] = {}
+    sizes = {p: 1024 for p in _DIFFUSERS_REPO}
+
+    class _Api:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, **kw):
+            return list(_DIFFUSERS_REPO)
+
+        def list_repo_tree(self, **kw):
+            return [SimpleNamespace(path=p, size=s) for p, s in sizes.items()]
+
+    def _snap(**kw):
+        calls.update(kw)
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snap)
+    return calls
+
+
+def test_download_hf_components_narrows_to_one_component(monkeypatch, tmp_path) -> None:
+    calls = _stub_hub_diffusers(monkeypatch, tmp_path)
+    download_hf(HuggingFaceRef(repo_id="owner/sdxl-full"), components=("vae",))
+    fetched = set(calls["allow_patterns"])
+    assert fetched <= set(select_component_paths(_DIFFUSERS_REPO, ("vae",)))
+    assert any(p.startswith("vae/") for p in fetched)
+    assert not any(
+        p.startswith("transformer/") or p.startswith("text_encoder/") for p in fetched
+    )
+    # Still applies the normal per-component flavor pick within the subset.
+    assert "vae/diffusion_pytorch_model.fp16.safetensors" in fetched
+    assert "vae/diffusion_pytorch_model.safetensors" not in fetched
+
+
+def test_download_hf_components_matching_nothing_is_a_clear_error(monkeypatch, tmp_path) -> None:
+    _stub_hub_diffusers(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="components="):
+        download_hf(HuggingFaceRef(repo_id="owner/sdxl-full"), components=("nope",))
+
+
+def test_download_hf_components_unrecognized_layout_fetches_narrowed_set(
+    monkeypatch, tmp_path,
+) -> None:
+    """A components= narrowing that doesn't resolve to a recognizable
+    diffusers/root-weights layout still fetches exactly the narrowed set —
+    never silently reverts to the whole repo."""
+    import huggingface_hub
+
+    files = {
+        "notes.txt": 10,
+        "split_files/vae/ae.safetensors": 1000,
+        "split_files/unet/model.safetensors": 2000,
+    }
+    calls: dict[str, object] = {}
+
+    class _Api:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, **kw):
+            return list(files)
+
+        def list_repo_tree(self, **kw):
+            return [SimpleNamespace(path=p, size=s) for p, s in files.items()]
+
+    def _snap(**kw):
+        calls.update(kw)
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snap)
+
+    download_hf(HuggingFaceRef(repo_id="owner/split-repo"), components=("split_files",))
+    assert set(calls["allow_patterns"]) == {
+        "split_files/vae/ae.safetensors", "split_files/unet/model.safetensors",
+    }
 
 
 def _stub_hub(monkeypatch, tmp_path, repo=_T5_REPO):

--- a/tests/test_hub_resolve_and_variants.py
+++ b/tests/test_hub_resolve_and_variants.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pytest
@@ -163,6 +164,58 @@ def test_hub_ref_resolves_and_lands_in_cas(local_hub, monkeypatch, tmp_path):
         ref="root/tiny", provider="tensorhub", offline=False, emit=lambda e: None,
     )
     assert local2 == local
+
+
+def test_hub_ref_components_fetches_only_named_subfolder(local_hub, monkeypatch, tmp_path):
+    """pgw#505: the CLI hub-less path narrows the tensorhub fetch to the
+    declared components — a full pipeline repo bound only for its vae/ never
+    materializes unet/ locally, and lands under a directory keyed separately
+    from the full-repo fetch."""
+    base, state = local_hub
+    _seed(state, {
+        "model_index.json": b"{}",
+        "unet/model.safetensors": b"unet-bytes",
+        "vae/model.safetensors": b"vae-bytes",
+    })
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.delenv("TENSORHUB_TOKEN", raising=False)
+
+    seen, emit = _events()
+    local = prov_mod.resolve_local_path(
+        ref="root/tiny", provider="tensorhub", offline=False, emit=emit,
+        components=("vae",),
+    )
+    snap = Path(local)
+    assert snap.name != state.snapshot_digest  # never aliases the full-repo dir
+    assert (snap / "model_index.json").read_bytes() == b"{}"
+    assert (snap / "vae" / "model.safetensors").read_bytes() == b"vae-bytes"
+    assert not (snap / "unet").exists()
+    # unet's blob was never downloaded — only vae + the root json landed in CAS.
+    unet_digest = blake3(b"unet-bytes").hexdigest()
+    assert not (tmp_path / "blobs" / "blake3" / unet_digest[:2] / unet_digest[2:4] / unet_digest).exists()
+
+    # A subsequent FULL fetch (no components=) of the same ref lands under a
+    # DIFFERENT directory and gets everything, including unet/.
+    full = prov_mod.resolve_local_path(
+        ref="root/tiny", provider="tensorhub", offline=False, emit=lambda e: None,
+    )
+    assert full != local
+    assert (Path(full) / "unet" / "model.safetensors").read_bytes() == b"unet-bytes"
+
+
+def test_hub_ref_components_matching_nothing_is_a_clear_error(local_hub, monkeypatch, tmp_path):
+    base, state = local_hub
+    _seed(state, {"model_index.json": b"{}", "vae/model.safetensors": b"vae-bytes"})
+    monkeypatch.setenv("TENSORHUB_URL", base)
+    monkeypatch.setenv("TENSORHUB_CAS_DIR", str(tmp_path))
+    monkeypatch.delenv("TENSORHUB_TOKEN", raising=False)
+
+    with pytest.raises(prov_mod.ModelResolutionError, match="components="):
+        prov_mod.resolve_local_path(
+            ref="root/tiny", provider="tensorhub", offline=False, emit=lambda e: None,
+            components=("nope",),
+        )
 
 
 def test_hub_token_sent_as_bearer(local_hub, monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Implements pgw#505: a worker fetches only the pipeline weights a slot actually uses, instead of the whole repo. Design (endorsed, tracker pgw#505): **DECLARE-on-binding**, mirroring the existing `files=` — explicit beats inferring from setup wiring.

- `ModelRef` gains `components: tuple[str, ...] = ()` (tensorhub + huggingface only; civitai/modelscope reject it in `__post_init__` — civitai artifacts aren't component-structured, modelscope already has `files=`).
- `Hub(...)` / `HF(...)` gain a `components=` kwarg. Win case: a slot binds a full pipeline repo but needs only ONE component out of it —
  ```python
  Hub("owner/sdxl-repo", components=("vae",))
  ```
- Manifest binding emission (`_binding_to_manifest`, `_model_ref_to_manifest`) carries `components` on both the top-level `bindings` block and the `Slot.default_checkpoint` shape, so tensorhub's future ModelOp DOWNLOAD scoping can read it.
- `cli/listing.py::describe_binding` surfaces it too (`gen-worker run --list`).

### Filter semantics — exactly which files fetch

`select_component_paths(paths, components)` (in `models/download.py`, shared by the HF and tensorhub downloaders): empty `components` = everything (today's behavior, unchanged). Non-empty = every path under a declared `<component>/` subfolder, **plus every root-level `*.json`** (`model_index.json` and siblings — always kept so component-set introspection / pipeline-class detection still works off the narrowed tree). A separate `components_present()` check distinguishes "the declared component names don't exist in this repo" (a real error) from "the filtered set happens to be small" (root jsons alone keep it non-empty, so emptiness alone isn't the right signal).

### What's implemented where (and why not everywhere)

- **HF source, both production (`executor.py` → `models/download.py::ensure_local`) and the CLI hub-less path (`models/provision.py::resolve_local_path`)**: full real filtering. `download_hf()` narrows the `list_repo_files()` listing to the declared components *before* the existing `files=`/auto-flavor-selection logic runs, so a component-scoped fetch still gets per-component flavor picking (bf16 > fp16 > untagged) over the smaller candidate set. Raises if a declared component matches nothing.
- **Tensorhub source, CLI hub-less path only (`models/provision.py::_fetch_tensorhub_snapshot`, `models/cozy_snapshot.py`)**: real filtering, because this path fully owns its own resolve→download→materialize loop end to end (no separate orchestrator-issued file list to stay consistent with). `cozy_snapshot.snapshot_dir_key(digest, components)` keys the materialized directory by `(digest, components)` — never under the bare digest — so a component-scoped fetch can **never collide with or be mistaken for** the full-repo materialization of the same ref. Known limitation: `--offline` tag-memory reuse only covers the full-repo case; a components=-scoped ref needs one online fetch per component set (documented in the code).
- **Tensorhub source, production executor path (orchestrator-resolved snapshots over gRPC): deliberately left unfiltered.** The executor's residency layer (`ModelStore._verify_snapshot_tree`) digest-verifies the materialized tree against the orchestrator's *full* `pb.Snapshot.files` list on every boot; filtering what gets written here without the orchestrator also filtering what it verifies would turn every boot into a spurious corruption/quarantine loop. **This is the tensorhub-side half**: the hub's ModelOp DOWNLOAD scoping needs to read `components` off the manifest and hand the worker an already-scoped file list — that platform change is NOT part of this PR (per lane instructions, tensorhub is not touched here).

### What the manifest now carries

```jsonc
// functions[].bindings.<slot>
{ "kind": "fixed", "provider": "tensorhub", "ref": "owner/sdxl-repo", "components": ["vae"] }
// functions[].slots[].default_checkpoint
{ "source": "huggingface", "path": "owner/repo", "components": ["unet", "text_encoder"] }
```

### Tests

New: `tests/test_binding.py` (components= validation, source restriction), `tests/test_hf_selection.py` (`select_component_paths`, `download_hf(components=)` narrowing + flavor-pick-within-subset + unrecognized-layout fallback + matched-nothing error), `tests/test_cozy_snapshot.py` (directory keying, full-vs-partial never collide, matched-nothing error), `tests/test_discovery_and_decorators.py` (manifest emission with/without components), `tests/test_hub_resolve_and_variants.py` (end-to-end against a real local HTTP hub double — CLI hub-less path only fetches the declared component's blob).

- mypy: 0 errors (`uv run mypy src/` — 110 files)
- ruff: clean on every touched file
- pytest: 955 passed, 8 skipped, 6 deselected (pre-existing environmental failures — this box exports `GEN_WORKER_FORBID_CPU_OFFLOAD=1`; verified identical on `origin/master`)
- Version bumped to **0.20.0** (0.19.0 was claimed mid-task by pgw#524, which merged to master while this was in flight — rebased on top of it)

## Dependency / contention note

Per the lane instructions: checked for an in-flight PR on pgw#523 (ModelRef allow_lora eviction) before starting — none existed yet (worktree present but no commits/PR). **pgw#524 (SDK friction batch, Slot rename) merged to master mid-task** (touching `binding.py`-adjacent `discover.py`/`provision.py` and claiming the 0.19.0 version slot) — this branch has been rebased onto it; the rename (`Slot.default` → `Slot.default_checkpoint`) and this PR's `components=` field compose cleanly (`_model_ref_to_manifest` emits `components` under the renamed `default_checkpoint` key with no further changes needed).

## Test plan

- [x] `uv run mypy src/` — 0 errors
- [x] `uv run ruff check` on all touched files — clean
- [x] `uv run pytest -q` — 955 passed / 8 skipped / 6 pre-existing env failures deselected (reproduced identically on `origin/master`)