### PR TITLE
gw#531: request format=files, not stale format=parquet

### DIFF
--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -238,7 +238,7 @@ class DatasetRef(msgspec.Struct):
     """Reserved-name dataset descriptor for transform-kind job payloads.
 
     The executor materializes each ``payload.datasets`` entry into a local
-    parquet snapshot before the handler runs (``ctx.dataset_paths[ref]`` /
+    dataset snapshot before the handler runs (``ctx.dataset_paths[ref]`` /
     ``ctx.resolve_dataset``). Used by calibration-based quant, pruning with
     gradient scoring, distillation, and fine-tuning.
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2773,7 +2773,7 @@ class Executor:
 
     async def _materialize_datasets(self, ctx: Any, payload: Any) -> None:
         """Reserved-datasets contract (gw#425): materialize every
-        ``payload.datasets`` entry (DatasetRef) into a local parquet snapshot
+        ``payload.datasets`` entry (DatasetRef) into a local dataset snapshot
         before the handler runs. Paths land in ``ctx.dataset_paths``."""
         datasets = getattr(payload, "datasets", None)
         if not datasets:

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1374,17 +1374,17 @@ class _PublisherMixin:
         ``payload.datasets[].ref`` at submit and mints the ``read_dataset``
         grant by UUID; a grant-scoped token can't list) — those hit
         materialize directly. ``owner/name`` refs stay for local/dev via the
-        ``?tenant=`` list lookup. Flow (th#642 wire format):
+        ``?tenant=`` list lookup. Flow (th#698 blob-manifest wire format):
 
         1. Slash-less ref → dataset_id verbatim; otherwise
            ``GET /api/v1/datasets?tenant=<owner>`` → the row's ``dataset_id``.
-        2. ``GET /api/v1/datasets/:id/materialize?format=parquet&include_urls=true``
-           → HF-datasets columnar parquet shards (image bytes embedded) with
+        2. ``GET /api/v1/datasets/:id/materialize?format=files&include_urls=true``
+           → a rows.jsonl-style entry index (raw CAS blobs by digest) with
            presigned URLs, sizes and blake3 checksums. A 202 (async snapshot
            build, th#691) is polled until ready within ``budget_s`` (default
            30 min, ≥ the hub's 20-min build budget); a typed
            ``snapshot_build_failed`` raises ``SnapshotBuildFailedError``.
-        3. Stream each shard to disk (bounded memory), digest-verified, with
+        3. Stream each entry to disk (bounded memory), digest-verified, with
            bounded retries. Entries lacking a presigned URL fall back to the
            repo-CAS by-digest reader.
 

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -1,9 +1,10 @@
 """Dataset snapshot materialization against the tensorhub datasets API.
 
 Free functions used by ``_PublisherMixin.resolve_dataset``: look up a dataset
-row by (tenant, name), fetch its parquet materialize manifest (presigned shard
-URLs, th#642 wire format) — polling 202 until the async snapshot build is
-ready (DATASET-V2 contract, gw#457) — and stream each shard to disk with
+row by (tenant, name), fetch its blob manifest (th#698 wire format — a
+rows.jsonl-style entry index with presigned URLs / inline text / raw CAS
+blob digests) — polling 202 until the async snapshot build is ready
+(DATASET-V2 contract, gw#457) — and stream each entry to disk with blake3
 digest verification + bounded retries.
 """
 from __future__ import annotations
@@ -116,7 +117,7 @@ def fetch_materialize_manifest(
     budget_s: float = _MATERIALIZE_BUDGET_S,
     cancelled: Optional[Callable[[], bool]] = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
-    """GET /datasets/:id/materialize?format=parquet&include_urls=true.
+    """GET /datasets/:id/materialize?format=files&include_urls=true.
 
     Authorizes by dataset id + read_dataset grant (or tenant read perm).
     Returns (snapshot_id, entries); entries carry
@@ -134,7 +135,7 @@ def fetch_materialize_manifest(
 
     url = (
         f"{base}/api/v1/datasets/{urllib.parse.quote(dataset_id, safe='')}"
-        "/materialize?format=parquet&include_urls=true"
+        "/materialize?format=files&include_urls=true"
         f"&wait={_MATERIALIZE_WAIT_HINT_S}"
     )
     headers = {"Authorization": f"Bearer {token}"}

--- a/tests/test_dataset_materialization.py
+++ b/tests/test_dataset_materialization.py
@@ -73,6 +73,7 @@ class _FakeHub:
         self.build_failed = False  # 503 typed snapshot_build_failed
         self.materialize_requests = 0
         self.seen_wait: List[str] = []
+        self.seen_format: List[str] = []
         # Rows the list endpoint knows + ids materialize serves. th#641
         # production refs are bare UUIDs the list endpoint never saw.
         self.known_ids = {"ds-1", _DATASET_UUID}
@@ -114,6 +115,7 @@ class _FakeHub:
                     outer.materialize_requests += 1
                     q = urllib.parse.parse_qs(parsed.query)
                     outer.seen_wait.append(q.get("wait", [""])[0])
+                    outer.seen_format.append(q.get("format", [""])[0])
                     if outer.build_failed:
                         self._json({"error": "snapshot_build_failed",
                                     "error_code": "encode_error"}, status=503)
@@ -222,6 +224,8 @@ def test_resolve_dataset_downloads_verified_parquet(hub) -> None:
     _assert_snapshot(root, hub)
     assert ctx.dataset_paths["acme/faces"] == str(root)
     assert hub.seen_auth[0] == "Bearer cap-tok"
+    # gw#531: the worker requests the th#698 blob manifest, not parquet.
+    assert hub.seen_format == ["files"]
     # Second resolve is a cache hit — no extra shard fetch.
     n = hub.shard_requests
     assert ctx.resolve_dataset("acme/faces") == str(root)


### PR DESCRIPTION
## Summary
- resolve_dataset's materialize request sent `?format=parquet` (hub silently mapped it to the th#698 blob manifest); now sends `?format=files` explicitly.
- Rewrote stale docstrings in `_datasets.py`, `resolve_dataset` (`request_context/__init__.py`), and the two adjacent `_materialize_datasets`/`DatasetRef` docstrings that described "parquet shards (image bytes embedded)" — the actual wire is th#698's blob manifest (rows index, presigned URLs, raw CAS blobs by digest, blake3 verification).
- Test now asserts the materialize request carries `format=files`.

## Test plan
- [x] ruff check (touched files)
- [x] mypy (touched files)
- [x] pytest tests/test_dataset_materialization.py — 13 passed
- [x] pytest tests/ -k "dataset or executor" — 87 passed, 2 skipped