### PR TITLE
gw#529: boot-time CUDA probe — refuse hello on a dead/busy GPU

### DIFF
--- a/src/gen_worker/cuda_probe.py
+++ b/src/gen_worker/cuda_probe.py
@@ -1,0 +1,58 @@
+"""Boot-time CUDA health probe (gw#529).
+
+RunPod occasionally allocates a host whose CUDA device is present but wedged
+("CUDA-capable device(s) is/are busy or unavailable"). Left unchecked, the
+worker says hello, accepts a job, and terminal-fails it at model load —
+burning the invoker's request on a provider fault we could catch first.
+Call ``probe_cuda`` before the orchestrator handshake; on failure the caller
+logs ``CUDA_PROBE_FAILED_MARKER`` and exits nonzero so the pod is replaced.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import msgspec
+
+CUDA_PROBE_FAILED_MARKER = "GEN_WORKER_CUDA_PROBE_FAILED"
+
+
+class CudaProbeResult(msgspec.Struct, frozen=True):
+    ok: bool
+    reason: str = ""
+
+
+def probe_cuda(device_index: int = 0) -> CudaProbeResult:
+    """Allocate, run one op on, sync, and free a tiny tensor on
+    ``device_index``. Never raises — every failure (import, is_available,
+    alloc, op, sync) becomes a typed ``CudaProbeResult(ok=False, reason=...)``.
+    """
+    try:
+        import torch
+    except Exception as e:
+        return CudaProbeResult(ok=False, reason=f"torch unavailable: {e}")
+
+    try:
+        if not torch.cuda.is_available():
+            return CudaProbeResult(ok=False, reason="torch.cuda.is_available() is False")
+        t = torch.ones(2, 2, device=f"cuda:{device_index}")
+        t = t + 1
+        torch.cuda.synchronize(device_index)
+        del t
+        torch.cuda.empty_cache()
+    except Exception as e:
+        return CudaProbeResult(ok=False, reason=f"{type(e).__name__}: {e}")
+
+    return CudaProbeResult(ok=True)
+
+
+def manifest_needs_cuda(manifest: Optional[dict[str, Any]]) -> bool:
+    """True iff any function in the discovery manifest declares
+    ``resources.gpu`` — the only build-time-known signal of whether this
+    worker is a GPU (accelerator=cuda) vs CPU (accelerator=none) deployment."""
+    if not manifest:
+        return False
+    for fn in manifest.get("functions", []) or []:
+        if bool((fn.get("resources") or {}).get("gpu")):
+            return True
+    return False

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 import msgspec
 
 from .config import get_settings
+from .cuda_probe import CUDA_PROBE_FAILED_MARKER, manifest_needs_cuda, probe_cuda
 from .models.cache_paths import tensorhub_cas_dir
 try:
     from .worker import Worker
@@ -209,6 +210,18 @@ def _run_main() -> int:
         _log_worker_fatal("cache_preflight", e, exit_code=1)
         logger.error(str(e))
         return 1
+
+    # Boot-time CUDA probe (gw#529): on a GPU-needing manifest, verify the
+    # device actually works BEFORE we hello the orchestrator and accept a
+    # job — a busy/unavailable GPU (RunPod bad-host fault) must kill this
+    # pod now, not terminal-fail a real request at model load.
+    if manifest_needs_cuda(manifest):
+        probe = probe_cuda()
+        if not probe.ok:
+            logger.error("%s: %s", CUDA_PROBE_FAILED_MARKER, probe.reason)
+            _log_worker_fatal("cuda_probe", RuntimeError(probe.reason), exit_code=1)
+            return 1
+        _log_startup_phase("cuda_probe_ok", status="ok")
 
     if not settings.orchestrator_public_addr:
         logger.error("Settings.orchestrator_public_addr is empty (set ORCHESTRATOR_PUBLIC_ADDR env). Refusing to start worker.")

--- a/tests/test_cuda_probe.py
+++ b/tests/test_cuda_probe.py
@@ -1,0 +1,148 @@
+"""Boot-time CUDA probe (gw#529): a dead/busy GPU must fail startup before
+hello, not terminal-fail a real job at model load. torch is monkeypatched
+throughout — this suite never touches real CUDA regardless of the host."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import msgspec
+import pytest
+import torch
+
+from gen_worker import entrypoint
+from gen_worker.cuda_probe import CUDA_PROBE_FAILED_MARKER, manifest_needs_cuda, probe_cuda
+
+
+class _FakeTensor:
+    def __add__(self, other: Any) -> "_FakeTensor":
+        return self
+
+
+def test_probe_cuda_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch, "ones", lambda *a, **k: _FakeTensor())
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+
+    result = probe_cuda()
+
+    assert result.ok
+    assert result.reason == ""
+
+
+def test_probe_cuda_not_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    result = probe_cuda()
+
+    assert not result.ok
+    assert "is_available" in result.reason
+
+
+def test_probe_cuda_alloc_raises_busy_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    busy = "CUDA error: CUDA-capable device(s) is/are busy or unavailable"
+
+    def _raise(*a: Any, **k: Any) -> None:
+        raise RuntimeError(busy)
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch, "ones", _raise)
+
+    result = probe_cuda()
+
+    assert not result.ok
+    assert busy in result.reason
+
+
+def test_manifest_needs_cuda_true_when_any_function_needs_gpu() -> None:
+    manifest = {
+        "functions": [
+            {"name": "a", "resources": {}},
+            {"name": "b", "resources": {"gpu": True}},
+        ]
+    }
+    assert manifest_needs_cuda(manifest) is True
+
+
+def test_manifest_needs_cuda_false_for_accelerator_none() -> None:
+    manifest = {"functions": [{"name": "a", "resources": {}}]}
+    assert manifest_needs_cuda(manifest) is False
+
+
+def test_manifest_needs_cuda_false_for_missing_manifest() -> None:
+    assert manifest_needs_cuda(None) is False
+    assert manifest_needs_cuda({}) is False
+
+
+def _write_manifest(path: Path, *, gpu: bool) -> None:
+    manifest = {
+        "functions": [
+            {
+                "name": "gen",
+                "module": "fake_mod",
+                "kind": "inference",
+                "resources": {"gpu": True} if gpu else {},
+            }
+        ]
+    }
+    path.write_bytes(msgspec.toml.encode(manifest))
+
+
+def _base_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, manifest_path: Path) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_PUBLIC_ADDR", "orchestrator.local:443")
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("ENDPOINT_LOCK_PATH", str(manifest_path))
+
+
+def test_entrypoint_exits_nonzero_on_cuda_probe_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    manifest_path = tmp_path / "endpoint.lock"
+    _write_manifest(manifest_path, gpu=True)
+    _base_env(monkeypatch, tmp_path, manifest_path)
+
+    from gen_worker.cuda_probe import CudaProbeResult
+
+    monkeypatch.setattr(
+        entrypoint, "probe_cuda", lambda *a, **k: CudaProbeResult(ok=False, reason="busy or unavailable")
+    )
+
+    def _fail_worker(*a: Any, **k: Any) -> None:
+        raise AssertionError("Worker must not be constructed when the CUDA probe fails")
+
+    monkeypatch.setattr(entrypoint, "Worker", _fail_worker)
+
+    with caplog.at_level(logging.ERROR):
+        code = entrypoint._run_main()
+
+    assert code == 1
+    assert any(CUDA_PROBE_FAILED_MARKER in rec.message for rec in caplog.records)
+
+
+def test_entrypoint_skips_probe_when_manifest_has_no_gpu_function(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    manifest_path = tmp_path / "endpoint.lock"
+    _write_manifest(manifest_path, gpu=False)
+    _base_env(monkeypatch, tmp_path, manifest_path)
+
+    def _unexpected_probe(*a: Any, **k: Any) -> None:
+        raise AssertionError("probe_cuda must not run for an accelerator=none manifest")
+
+    monkeypatch.setattr(entrypoint, "probe_cuda", _unexpected_probe)
+
+    class _StubWorker:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def run(self) -> int:
+            return 0
+
+    monkeypatch.setattr(entrypoint, "Worker", _StubWorker)
+
+    code = entrypoint._run_main()
+
+    assert code == 0


### PR DESCRIPTION
## Summary
- RunPod occasionally allocates an H100 host whose CUDA device is present but wedged ("CUDA-capable device(s) is/are busy or unavailable"). Today the worker boots, says hello, accepts the job, and terminal-fails it at model load — burning the invoker's request on a provider fault we can detect before hello.
- `src/gen_worker/cuda_probe.py`: `probe_cuda()` allocates+runs+syncs+frees a tiny tensor on device 0, wrapping every failure (import, `is_available`, alloc, op, sync) into a typed `CudaProbeResult(ok, reason)` — never raises. `manifest_needs_cuda(manifest)` is the only build-time-known GPU signal (any function's `resources.gpu`); no worker-level `accelerator` field exists elsewhere in the manifest/settings.
- Wired into `entrypoint._run_main` right after cache preflight, before the `orchestrator_public_addr` check / hello. On probe failure: logs `GEN_WORKER_CUDA_PROBE_FAILED: <reason>` and returns exit 1 (pod dies, autoscaler replaces it). `accelerator=none` (no GPU function in the manifest) skips the probe entirely.

## Test plan
- [x] `uv run pytest tests/test_cuda_probe.py -v` — 8/8 passed (probe ok/is_available-false/alloc-raises-busy-unavailable, manifest_needs_cuda true/false/none, entrypoint exits 1 + logs marker on probe failure, entrypoint skips probe + runs Worker for accelerator=none)
- [x] `uv run mypy src/gen_worker` — 0 errors (111 files)
- [x] `uv run ruff check src/gen_worker tests/test_cuda_probe.py` — clean
- [x] `uv run pytest tests/ -q` — 992 passed, 6 skipped, 6 failed (content_lanes×3, ram_admission×2, snapshot_corruption×1 — pre-existing `GEN_WORKER_FORBID_CPU_OFFLOAD=1` env-class failures, same tests documented as reproducing identically on origin/master in prior PRs #226/#236/#237 on this box; unrelated to this change)