### PR TITLE
pgw#532: worker-side dynamic slot materialization — load the RESOLVED pick, never the raw default (0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.21.0 (2026-07-13)
+
+**BREAKING(-ish) — pgw#532: worker-side dynamic slot materialization (the last th#767
+piece).** A hub-connected worker no longer materializes a declared `Slot`'s
+`default_checkpoint` from its raw upstream — the fc157 live failure where a Civitai
+default hit `civitai_not_found` at boot setup and cascaded `load_failed` onto every
+healthy hub binding.
+
+- **Materialization precedence per declared Slot** (executor `_slot_dispatch_binding`):
+  the hub-resolved pick from `RunJob.models[slot]` (a tensorhub-CAS ref; snapshots ride
+  the dispatch / earlier ModelOps, th#763 re-mint covers cold refs) > the code-declared
+  `default_checkpoint` when it is itself a `Hub(...)` CAS ref > **fail RETRYABLE** —
+  never a raw Civitai/HF/ModelScope self-fetch (mirror-first, gw#465). Hub-less
+  (`cozy run` / `gen-worker run`) resolution of the raw default is unchanged
+  (`models/provision.resolve_bindings`).
+- **Boot**: `lifecycle.startup()` no longer prefetches Slot seeds from upstream and no
+  longer eagerly sets up Slot-declared endpoints with the code seed; dynamic-slot
+  functions advertise available once hardware-gated and materialize per dispatch.
+- **Instance-per-pick**: `_effective_spec` rebinds every declared Slot to the dispatch's
+  resolved pick; the derived binding set derives a new `instance_key`, so `setup()` runs
+  once per (class, resolved pick), `self.pipeline`-style setup-held state stays coherent
+  per checkpoint, multiple picks stay warm side by side, and the existing residency/LRU
+  machinery evicts whole instances. `ModelOp{LOAD}` now also matches per-pick derived
+  records (promote/re-set-up a previously-dispatched pick); a LOAD for a never-dispatched
+  pick banks bytes+snapshot and reports `load_failed` (pre-warm degrades to a download).
+- **`ctx.slots[name].ref` is the resolved pick** (not the code default);
+  `.defaults` still merges the wire's `inference_defaults` over the code preset.
+- `gen_worker.testing` helpers unchanged (the `ctx.slots` stub shape is identical).
+
 ## 0.20.0 (2026-07-13)
 
 **BREAKING — pgw#523: `ModelRef` is pure identity + fetch scope; `.provider`/`.ref` aliases retired.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.20.0"
+version = "0.21.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -17,14 +17,14 @@ import shutil
 import threading
 import time
 import typing
-from dataclasses import dataclass, field as dc_field
+from dataclasses import dataclass, field as dc_field, replace as dc_replace
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 
 import msgspec
 
-from .api.binding import wire_ref
+from .api.binding import ModelRef, wire_ref
 from .api.errors import (
     ArtifactTransferError,
     CanceledError,
@@ -205,6 +205,30 @@ def _resolve_slots_kwargs(spec: EndpointSpec, run: "pb.RunJob") -> Dict[str, Any
         except ValueError as exc:
             errors[name] = str(exc)
     return {"resolved_slots": resolved, "slot_errors": errors}
+
+
+def _hub_binding_for_wire_ref(ref: str) -> ModelRef:
+    """A tensorhub-source binding for a hub-named wire ref (pgw#532).
+
+    ``RunJob.models`` / ModelOp refs name hub-CAS repos in the canonical
+    ``owner/repo[:tag][#flavor]`` grammar; this mints the binding the
+    executor materializes them through (``ensure_local`` then follows the
+    tensorhub lane: orchestrator snapshots or the th#763 missing_snapshot
+    re-mint — never an upstream self-fetch). Raises ``ValueError`` when
+    ``ref`` does not parse under that grammar (e.g. a raw upstream id the
+    hub stamped for an unmirrored slot default)."""
+    from .models.refs import parse_model_ref
+
+    parsed = parse_model_ref(ref)
+    th = parsed.tensorhub
+    if th is None:  # pragma: no cover - parse_model_ref(tensorhub) guarantees it
+        raise ValueError(f"{ref!r} is not a tensorhub ref")
+    return ModelRef(
+        source="tensorhub",
+        path=f"{th.owner}/{th.repo}",
+        tag=th.tag or "latest",
+        flavor=th.flavor or "",
+    )
 
 
 def _map_exception(exc: BaseException) -> Tuple["pb.JobStatus", str]:
@@ -1017,6 +1041,10 @@ class Executor:
         self._declared_models: Dict[str, Dict[str, Any]] = {
             s.name: dict(s.models) for s in specs
         }
+        # pgw#532: hub-named ref -> the ONE tensorhub binding object minted
+        # for it. Identity-stable so equal picks across requests derive equal
+        # instance keys (one resident instance per (class, resolved pick)).
+        self._hub_bindings: Dict[str, ModelRef] = {}
         self._gpu_semaphore = asyncio.Semaphore(max(1, gpu_slots))
         # Model loads/promotions serialize so allocator-delta measurements
         # and free-VRAM reads don't cross-contaminate (#369).
@@ -1368,6 +1396,14 @@ class Executor:
             if spec.cls is None:
                 out.append(name)
                 continue
+            if spec.slots:
+                # pgw#532 dynamic slots: the hub owns the slot's model set —
+                # serveability is per-dispatch (RunJob carries the resolved
+                # refs + snapshots; setup materializes THEM, never the code
+                # seed). Gate only on hardware/setup failures, never on a
+                # resident instance the worker cannot create by itself.
+                out.append(name)
+                continue
             rec = self._classes[spec.instance_key]
             if rec.ready or (not spec.models and rec.failed is None):
                 out.append(name)
@@ -1378,7 +1414,7 @@ class Executor:
         return sorted(
             name for name, spec in self.specs.items()
             if name not in avail and name not in self.unavailable
-            and spec.cls is not None
+            and spec.cls is not None and not spec.slots
             and self._classes[spec.instance_key].failed is None
         )
 
@@ -1425,6 +1461,90 @@ class Executor:
                 pass
         self._on_state_change()
 
+    # ---- dynamic slot materialization (pgw#532 / th#767) --------------------
+
+    def _hub_binding(self, ref: str) -> ModelRef:
+        """The one binding object for a hub-named wire ref (raises
+        ``ValueError`` on non-CAS grammar). Registered with the store so
+        provider classification stays confident on bare-ref paths."""
+        binding = self._hub_bindings.get(ref)
+        if binding is None:
+            binding = self._hub_bindings.setdefault(ref, _hub_binding_for_wire_ref(ref))
+            self.store.register_binding(wire_ref(binding), binding)
+        return binding
+
+    def _slot_dispatch_binding(
+        self, spec: EndpointSpec, slot: str, run_ref: str
+    ) -> ModelRef:
+        """The binding a declared Slot materializes for THIS dispatch.
+
+        Precedence (pgw#532): the hub-resolved pick from
+        ``RunJob.models[slot]`` > the code-declared ``default_checkpoint``
+        when it is itself a CAS ref. A hub-connected worker NEVER
+        materializes a Slot's raw upstream default (mirror-first, gw#465):
+        when neither source yields a CAS ref the dispatch fails RETRYABLE —
+        the hub must resolve the slot to a ref this worker can load, not
+        the worker self-fetching Civitai/HF.
+        """
+        declared = spec.models.get(slot)
+        if run_ref:
+            if (
+                declared is not None
+                and declared.source == "tensorhub"
+                and run_ref == wire_ref(declared)
+            ):
+                return declared
+            try:
+                return self._hub_binding(run_ref)
+            except ValueError:
+                logger.warning(
+                    "slot %r of %s: resolved_models ref %r is not a CAS ref; "
+                    "falling back to the declared default", slot, spec.name, run_ref)
+        if declared is not None and declared.source == "tensorhub":
+            return declared
+        raise RetryableError(
+            f"slot {slot!r} of {spec.name!r} has no loadable hub ref for this "
+            f"request (resolved_models[{slot!r}]={run_ref!r}, declared "
+            f"default source={getattr(declared, 'source', None)!r}); a "
+            "hub-connected worker never fetches a Slot's raw upstream "
+            "default (pgw#532/gw#465) — the hub must resolve the slot to a "
+            "tensorhub-CAS ref"
+        )
+
+    def _effective_spec(self, spec: EndpointSpec, run: "pb.RunJob") -> EndpointSpec:
+        """The spec THIS dispatch runs (pgw#532): every declared Slot rebound
+        to the hub-resolved pick in ``RunJob.models``. A pick that differs
+        from the declared binding derives a NEW instance key — one resident
+        instance per (class, resolved binding set), so ``setup()`` re-runs
+        for the pick and setup-held state (``self.pipeline``) stays coherent
+        per checkpoint while the LRU machinery evicts whole instances.
+        Function-shaped (``cls=None``) specs rebind too — their slots inject
+        via ``_handler_kwargs``, which reads the same ``spec.models``."""
+        if not spec.slots:
+            return spec
+        run_refs = {
+            b.slot: b.ref.strip() for b in run.models if b.slot and b.ref.strip()
+        }
+        effective = dict(spec.models)
+        for slot in spec.slots:
+            effective[slot] = self._slot_dispatch_binding(
+                spec, slot, run_refs.get(slot, ""))
+        if effective == spec.models:
+            return spec
+        return dc_replace(spec, models=effective)
+
+    def _class_record(self, spec: EndpointSpec) -> _ClassRecord:
+        """Instance-group record for ``spec``, created on first sight for
+        DERIVED (per-pick) specs. Never removed: records are tiny and the
+        distinct-pick set a worker sees is bounded by its disk anyway."""
+        assert spec.cls is not None
+        rec = self._classes.get(spec.instance_key)
+        if rec is None:
+            rec = self._classes.setdefault(spec.instance_key, _ClassRecord(cls=spec.cls))
+        if not any(s is spec or s == spec for s in rec.specs):
+            rec.specs.append(spec)
+        return rec
+
     # ---- setup -------------------------------------------------------------
 
     async def ensure_setup(
@@ -1436,7 +1556,7 @@ class Executor:
         if spec.cls is None:
             return None  # function-shaped endpoint: no instance, no setup
         self.store.bind_loop()
-        rec = self._classes[spec.instance_key]
+        rec = self._class_record(spec)
         async with rec.lock:
             if rec.ready and rec.stale:
                 # gw#494: the instance was loaded for a superseded pick —
@@ -2127,11 +2247,32 @@ class Executor:
                 specs = [s for s in self.specs.values()
                          if ref in (wire_ref(b) for b in s.models.values())]
                 if not specs:
-                    # No endpoint binds this ref; nothing owns a VRAM load for it.
+                    # pgw#532: derived (per-pick) specs bind refs the static
+                    # decls never name — a LOAD for a pick this worker has
+                    # dispatched before must promote/re-set-up its instance.
+                    seen: set = set()
+                    for rec in self._classes.values():
+                        if id(rec) in seen:
+                            continue
+                        seen.add(id(rec))
+                        for s in rec.specs:
+                            if s not in specs and ref in (
+                                    wire_ref(b) for b in s.models.values()):
+                                specs.append(s)
+                if not specs:
+                    # No endpoint binds this ref; nothing owns a VRAM load
+                    # for it. (For a Slot-declared endpoint the bytes+snapshot
+                    # ARE banked above, so the next dispatch naming this pick
+                    # materializes instantly — the pre-warm degrades to a
+                    # download, never to an upstream fetch.)
                     await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
                         ref=ref, state=pb.MODEL_STATE_FAILED, error="load_failed")))
                     return
-                ready = [s for s in specs if self._classes[s.instance_key].ready]
+                ready = [
+                    s for s in specs
+                    if (owner := self._classes.get(s.instance_key)) is not None
+                    and owner.ready
+                ]
                 if ready:
                     # A resident instance already owns the ref: promote/touch it.
                     # Never cold-set-up the OTHER specs sharing the ref — a
@@ -2512,6 +2653,16 @@ class Executor:
             payload: Any = msgspec.msgpack.decode(run.input_payload, type=spec.payload_type)
         except (msgspec.ValidationError, msgspec.DecodeError) as exc:
             await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
+            return
+        try:
+            # pgw#532: rebind declared Slots to the hub-resolved picks for
+            # THIS dispatch (instance-per-pick). The derived spec drives the
+            # whole job — pins, setup, adapters, ctx.slots — so every
+            # downstream consumer sees the pick, never the code seed.
+            spec = job.spec = self._effective_spec(spec, run)
+        except Exception as exc:
+            status, msg = _map_exception(exc)
+            await self._finish(job, status, safe_message=msg)
             return
         routed = list(spec.models)
         # Pin this job's model refs for its WHOLE lifetime (gw#409): the gap

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -271,7 +271,16 @@ class Lifecycle:
         for spec in self.executor.specs.values():
             if spec.name in self.executor.unavailable:
                 continue
-            for binding in spec.models.values():
+            for slot, binding in spec.models.items():
+                if slot in spec.slots:
+                    # pgw#532: a declared Slot's default_checkpoint is a SEED
+                    # for the hub mapping, not a load instruction — the hub
+                    # resolves the slot (registered binding / per-request
+                    # pick) and drives DOWNLOADs itself. A hub-connected
+                    # worker never self-fetches the raw upstream default
+                    # (mirror-first, gw#465 — the fc157 civitai_not_found
+                    # boot failure).
+                    continue
                 ref = wire_ref(binding)
                 if binding.source != "tensorhub" and ref not in prefetch_refs:
                     # hf/civitai refs need no orchestrator snapshot; tensorhub
@@ -288,8 +297,18 @@ class Lifecycle:
 
         await self.set_phase(pb.WORKER_PHASE_LOADING_PIPELINES)
         awaiting_hub: Dict[str, List[str]] = {}
+        dynamic: List[str] = []
         for spec in list(self.executor.specs.values()):
             if spec.name in self.executor.unavailable:
+                continue
+            if spec.slots:
+                # pgw#532: dynamic slots materialize the HUB-resolved ref
+                # (ModelOp pre-drives / RunJob resolved_models + snapshots),
+                # per dispatch, instance-per-pick. Setting up eagerly here
+                # would load the code seed — the exact fc157 setup-failure
+                # bug (raw civitai default -> civitai_not_found -> every
+                # function load_failed).
+                dynamic.append(spec.name)
                 continue
             missing = sorted({
                 wire_ref(b) for b in spec.models.values()
@@ -309,6 +328,10 @@ class Lifecycle:
                 await self.executor.ensure_setup(spec)
             except Exception as exc:
                 logger.error("startup setup of %s failed: %s", spec.name, exc)
+        if dynamic:
+            logger.info(
+                "dynamic-slot functions serve hub-resolved picks per dispatch "
+                "(pgw#532; no boot-time setup): %s", ", ".join(sorted(dynamic)))
         if awaiting_hub:
             logger.warning(
                 "functions waiting on hub-supplied snapshots (ModelOp{DOWNLOAD}, "

--- a/tests/test_dynamic_slot_materialization_pgw532.py
+++ b/tests/test_dynamic_slot_materialization_pgw532.py
@@ -1,0 +1,420 @@
+"""pgw#532: worker-side dynamic slot materialization (the last th#767 piece).
+
+The fc157 live failure: a hub-connected worker materialized a declared
+``Slot``'s ``default_checkpoint`` from its RAW upstream (Civitai 827184) at
+setup -> ``civitai_not_found`` -> setup failed -> every function unavailable,
+cascading ``load_failed`` onto the healthy hub-binding refs. Independently,
+``resolved_models[slot]`` (the hub-resolved pick the scheduler routed and
+pre-drove) was never injected — a pick would silently have run the default's
+weights.
+
+Covered here:
+  1. boot: a hub-connected worker NEVER touches a Slot's raw upstream
+     default (no Civitai/HF fetch, no eager setup); the function still
+     advertises available (dispatch materializes the hub-resolved ref).
+  2. dispatch pick != default: the executor loads the PICKED checkpoint and
+     ``ctx.slots[name].ref`` reflects the pick, not the code default.
+  3. instance-per-pick residency: two picks = two resident instances (one
+     ``setup()`` per (class, resolved pick)); UNLOAD evicts one whole
+     instance while the other stays warm; a later LOAD for the evicted pick
+     matches its derived record and re-sets it up.
+  4. default-only path with a CAS default_checkpoint: unchanged (one
+     instance, base record, ctx.slots ref = declared default).
+  5. an unusable (non-CAS) resolved_models stamp with a raw upstream
+     default fails the job RETRYABLE — never an upstream self-fetch.
+  6. hub-less (`cozy run`) path: the raw default_checkpoint still resolves
+     through its upstream provider, unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import msgspec
+
+from gen_worker.api.binding import HF, Civitai, Hub, ModelRef
+from gen_worker.api.slot import Slot
+from gen_worker.config.settings import Settings
+from gen_worker.executor import Executor
+from gen_worker.families.base import FamilyDefaults, family
+from gen_worker.lifecycle import Lifecycle
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+@family("pgw532-testfam")
+class _Fam(FamilyDefaults):
+    steps: int = 7
+
+
+class _StubPipeline:
+    """Slot compat class only — setup() slots are str-annotated so the
+    executor injects local PATHS (no torch / placement machinery)."""
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    model: str = ""
+
+
+class _Out(msgspec.Struct):
+    slot_ref: str
+    pipeline_path: str
+
+
+PIPE_DEFAULT_RAW = Civitai("827184", version="2883731")   # WAI-Illustrious (raw upstream)
+VAE_DEFAULT_RAW = HF("madebyollin/sdxl-vae-fp16-fix")     # raw upstream
+PIPE_DEFAULT_CAS = Hub("acme/default-model", tag="prod")  # CAS-declared default
+
+PICK_A = "tensorhub/cyberrealistic-pony:prod"
+PICK_B = "tensorhub/wai-illustrious:prod"
+VAE_MIRROR = "tensorhub/sdxl-vae-fp16-fix:prod"
+
+
+def _slot_spec(
+    name: str,
+    setup_calls: List[Tuple[str, str]],
+    *,
+    pipe_default: ModelRef = PIPE_DEFAULT_RAW,
+    vae_default: ModelRef = VAE_DEFAULT_RAW,
+) -> EndpointSpec:
+    class Endpoint:
+        def setup(self, pipeline: str, vae: str) -> None:
+            # setup-held state, exactly the sdxl template's shape: the
+            # instance binds whatever THIS setup received, forever.
+            self.pipeline_path = pipeline
+            setup_calls.append((name, pipeline))
+
+        def generate(self, ctx: Any, payload: _In) -> _Out:
+            resolved = ctx.slots["pipeline"]
+            ref = resolved.ref
+            return _Out(
+                slot_ref=f"{ref.source}:{ref.path}:{ref.tag}",
+                pipeline_path=self.pipeline_path,
+            )
+
+    slots = {
+        "pipeline": Slot(
+            _StubPipeline, selected_by="model",
+            default_checkpoint=pipe_default, default_config=_Fam(),
+        ),
+        "vae": Slot(_StubPipeline, default_checkpoint=vae_default,
+                    default_config=_Fam()),
+    }
+    return EndpointSpec(
+        name=name, method=Endpoint.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="generate",
+        models={"pipeline": pipe_default, "vae": vae_default},
+        slots=slots,
+        slot_family={"pipeline": "pgw532-testfam", "vae": "pgw532-testfam"},
+    )
+
+
+def _snapshot(digest: str = "ab" * 32) -> pb.Snapshot:
+    return pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
+        path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+        url="http://r2.invalid/presigned")])
+
+
+def _harness(tmp_path: Path, monkeypatch, setup_calls: List[Tuple[str, str]]):
+    """Executor over the REAL ModelStore/dispatch orchestration; only the
+    network download primitive is faked, and it REFUSES raw-upstream refs —
+    the gw#465 invariant under test."""
+    sent: List[pb.WorkerMessage] = []
+    downloads: List[Dict[str, Any]] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor([_slot_spec("generate", setup_calls)], _send)
+
+    async def _fake_download(ref: str, **kwargs: Any) -> Path:
+        provider = kwargs.get("provider")
+        assert provider in (None, "tensorhub"), (
+            f"hub-connected worker attempted an UPSTREAM fetch: "
+            f"ref={ref!r} provider={provider!r}")
+        assert "827184" not in ref and "madebyollin" not in ref, (
+            f"raw upstream default leaked into the hub-connected path: {ref!r}")
+        downloads.append({"ref": ref, **kwargs})
+        p = tmp_path / ref.replace("/", "_").replace(":", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import gen_worker.executor as ex_mod
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+    monkeypatch.setattr(ex_mod, "_MISSING_SNAPSHOT_WAIT_S", 0.2)
+    return ex, sent, downloads
+
+
+def _run_job(rid: str, *, model: str = "", models: List[pb.ModelBinding],
+             snapshots: Dict[str, pb.Snapshot] = {}) -> pb.RunJob:
+    return pb.RunJob(
+        request_id=rid, attempt=1, function_name="generate",
+        input_payload=msgspec.msgpack.encode(_In(prompt="a cat", model=model)),
+        models=models, snapshots=snapshots,
+    )
+
+
+async def _dispatch(ex: Executor, sent: List[pb.WorkerMessage], run: pb.RunJob) -> pb.JobResult:
+    await ex.handle_run_job(run)
+    job = ex.jobs[(run.request_id, run.attempt)]
+    assert job.task is not None
+    await job.task
+    results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"
+               and m.job_result.request_id == run.request_id]
+    assert results, f"no job_result for {run.request_id}"
+    return results[-1]
+
+
+def _ready_records(ex: Executor) -> List[Any]:
+    seen: set = set()
+    out = []
+    for rec in ex._classes.values():
+        if id(rec) in seen:
+            continue
+        seen.add(id(rec))
+        if rec.ready:
+            out.append(rec)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. boot: never touch the raw upstream default; function still advertises
+# ---------------------------------------------------------------------------
+
+
+def test_boot_never_fetches_raw_default_and_advertises(tmp_path, monkeypatch, caplog) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, downloads = _harness(tmp_path, monkeypatch, setup_calls)
+
+    ensured: List[str] = []
+    orig = ex.store.ensure_local
+
+    async def _spy(ref: str, *a: Any, **kw: Any) -> Path:
+        ensured.append(ref)
+        return await orig(ref, *a, **kw)
+
+    monkeypatch.setattr(ex.store, "ensure_local", _spy)
+
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = {"gpu_count": 1, "gpu_total_mem": 32 * 1024**3,
+                   "gpu_free_mem": 30 * 1024**3, "gpu_sm": "90", "installed_libs": []}
+    with caplog.at_level(logging.INFO, logger="gen_worker.lifecycle"):
+        asyncio.run(lc.startup())
+
+    assert ensured == [], f"boot materialized Slot seeds: {ensured}"
+    assert setup_calls == [], f"boot eagerly set up a dynamic-slot spec: {setup_calls}"
+    assert ex.available_functions() == ["generate"]
+    assert ex.loading_functions() == []
+    assert "generate" not in ex.unavailable
+    failed = [m.model_event for m in sent if m.WhichOneof("msg") == "model_event"
+              and m.model_event.state == pb.MODEL_STATE_FAILED]
+    assert not failed, f"boot emitted failures: {failed}"
+
+
+# ---------------------------------------------------------------------------
+# 2. dispatch pick != default loads the PICKED weights; ctx.slots shows it
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_pick_loads_picked_checkpoint(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, downloads = _harness(tmp_path, monkeypatch, setup_calls)
+
+    async def _run() -> pb.JobResult:
+        return await _dispatch(ex, sent, _run_job(
+            "r1", model="cyberrealistic-pony",
+            models=[pb.ModelBinding(slot="pipeline", ref=PICK_A),
+                    pb.ModelBinding(slot="vae", ref=VAE_MIRROR)],
+            snapshots={PICK_A: _snapshot("aa" * 32), VAE_MIRROR: _snapshot("bb" * 32)},
+        ))
+
+    res = asyncio.run(_run())
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    out = msgspec.msgpack.decode(res.inline, type=_Out)
+    # ctx.slots reflects the RESOLVED pick, not the code default.
+    assert out.slot_ref == "tensorhub:tensorhub/cyberrealistic-pony:prod"
+    # setup() received the PICK's materialized path.
+    assert "cyberrealistic-pony" in out.pipeline_path
+    assert setup_calls == [("generate", out.pipeline_path)]
+    assert {d["ref"] for d in downloads} == {PICK_A, VAE_MIRROR}
+
+
+# ---------------------------------------------------------------------------
+# 3. instance-per-pick: two picks = two instances; UNLOAD evicts one whole
+#    instance; LOAD re-materializes the evicted pick's derived record
+# ---------------------------------------------------------------------------
+
+
+def test_two_picks_two_instances_then_lru_evicts_whole_instance(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, downloads = _harness(tmp_path, monkeypatch, setup_calls)
+
+    async def _run() -> None:
+        r1 = await _dispatch(ex, sent, _run_job(
+            "r1", model="a",
+            models=[pb.ModelBinding(slot="pipeline", ref=PICK_A),
+                    pb.ModelBinding(slot="vae", ref=VAE_MIRROR)],
+            snapshots={PICK_A: _snapshot("aa" * 32), VAE_MIRROR: _snapshot("bb" * 32)}))
+        assert r1.status == pb.JOB_STATUS_OK, r1.safe_message
+        r2 = await _dispatch(ex, sent, _run_job(
+            "r2", model="b",
+            models=[pb.ModelBinding(slot="pipeline", ref=PICK_B),
+                    pb.ModelBinding(slot="vae", ref=VAE_MIRROR)],
+            snapshots={PICK_B: _snapshot("cc" * 32), VAE_MIRROR: _snapshot("bb" * 32)}))
+        assert r2.status == pb.JOB_STATUS_OK, r2.safe_message
+
+        # setup() ran once per (class, resolved pick) — setup-held state
+        # (self.pipeline_path) is coherent per instance.
+        assert len(setup_calls) == 2
+        picked_paths = [p for _, p in setup_calls]
+        assert any("cyberrealistic-pony" in p for p in picked_paths)
+        assert any("wai-illustrious" in p for p in picked_paths)
+        assert len(_ready_records(ex)) == 2, "two picks must be two resident instances"
+
+        # Same pick again: the resident instance serves — NO third setup.
+        r3 = await _dispatch(ex, sent, _run_job(
+            "r3", model="a",
+            models=[pb.ModelBinding(slot="pipeline", ref=PICK_A),
+                    pb.ModelBinding(slot="vae", ref=VAE_MIRROR)]))
+        assert r3.status == pb.JOB_STATUS_OK, r3.safe_message
+        assert len(setup_calls) == 2, "resident pick must not re-run setup()"
+
+        # Hub-directed UNLOAD of pick A vacates THAT instance only.
+        await ex.handle_model_op(pb.ModelOp(op=pb.MODEL_OP_KIND_UNLOAD, ref=PICK_A))
+        ready = _ready_records(ex)
+        assert len(ready) == 1, "UNLOAD must evict exactly one pick's instance"
+        held = {r for rec in ready for r in rec.held_refs}
+        assert PICK_B in held and PICK_A not in held
+
+        # LOAD for the evicted pick matches its derived record and re-sets up.
+        await ex.handle_model_op(pb.ModelOp(
+            op=pb.MODEL_OP_KIND_LOAD, ref=PICK_A, snapshot=_snapshot("aa" * 32)))
+        assert len(setup_calls) == 3
+        assert len(_ready_records(ex)) == 2
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 4. default-only path with a CAS default_checkpoint: unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_cas_default_dispatch_uses_declared_binding(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    sent: List[pb.WorkerMessage] = []
+    downloads: List[Dict[str, Any]] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    spec = _slot_spec("generate", setup_calls,
+                      pipe_default=PIPE_DEFAULT_CAS,
+                      vae_default=Hub("acme/vae", tag="prod"))
+    ex = Executor([spec], _send)
+
+    async def _fake_download(ref: str, **kwargs: Any) -> Path:
+        downloads.append({"ref": ref})
+        p = tmp_path / ref.replace("/", "_").replace(":", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import gen_worker.executor as ex_mod
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+
+    async def _run() -> pb.JobResult:
+        # The hub stamps the declared default for a no-pick request.
+        return await _dispatch(ex, sent, _run_job(
+            "r1",
+            models=[pb.ModelBinding(slot="pipeline", ref="acme/default-model:prod"),
+                    pb.ModelBinding(slot="vae", ref="acme/vae:prod")],
+            snapshots={"acme/default-model:prod": _snapshot("aa" * 32),
+                       "acme/vae:prod": _snapshot("bb" * 32)}))
+
+    res = asyncio.run(_run())
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    out = msgspec.msgpack.decode(res.inline, type=_Out)
+    assert out.slot_ref == "tensorhub:acme/default-model:prod"
+    assert len(setup_calls) == 1
+    # The declared binding was reused: the base record, no derived sibling.
+    assert _ready_records(ex)[0] is ex._classes[spec.instance_key]
+
+
+# ---------------------------------------------------------------------------
+# 5. unusable (non-CAS) stamp over a raw default: RETRYABLE, no upstream fetch
+# ---------------------------------------------------------------------------
+
+
+def test_raw_stamp_over_raw_default_fails_retryable_without_fetch(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, downloads = _harness(tmp_path, monkeypatch, setup_calls)
+
+    async def _run() -> pb.JobResult:
+        # The hub stamped the UNMIRRORED raw default (a bare civitai id —
+        # not CAS grammar). The worker must refuse, retryably.
+        return await _dispatch(ex, sent, _run_job(
+            "r1",
+            models=[pb.ModelBinding(slot="pipeline", ref="827184"),
+                    pb.ModelBinding(slot="vae", ref=VAE_MIRROR)],
+            snapshots={VAE_MIRROR: _snapshot("bb" * 32)}))
+
+    res = asyncio.run(_run())
+    assert res.status == pb.JOB_STATUS_RETRYABLE, res.safe_message
+    assert "pipeline" in res.safe_message
+    assert setup_calls == []
+    assert downloads == [], f"a refused dispatch must not download: {downloads}"
+    assert "generate" not in ex.unavailable, "a per-request refusal must not disable the function"
+
+
+# ---------------------------------------------------------------------------
+# LOAD for a never-dispatched pick: bytes banked, typed failure, no setup
+# ---------------------------------------------------------------------------
+
+
+def test_load_of_unknown_pick_banks_bytes_and_fails_typed(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, downloads = _harness(tmp_path, monkeypatch, setup_calls)
+
+    asyncio.run(ex.handle_model_op(pb.ModelOp(
+        op=pb.MODEL_OP_KIND_LOAD, ref=PICK_A, snapshot=_snapshot("aa" * 32))))
+
+    # Pre-warm degraded to a download: bytes + snapshot banked for the next
+    # dispatch, no instance guessed into existence, typed failure reported.
+    assert {d["ref"] for d in downloads} == {PICK_A}
+    assert ex.store.has_snapshot(PICK_A)
+    assert setup_calls == []
+    failed = [m.model_event for m in sent if m.WhichOneof("msg") == "model_event"
+              and m.model_event.state == pb.MODEL_STATE_FAILED]
+    assert [(e.ref, e.error) for e in failed] == [(PICK_A, "load_failed")]
+
+
+# ---------------------------------------------------------------------------
+# 6. hub-less path: default_checkpoint raw source resolves upstream, unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_hubless_default_path_unchanged(monkeypatch, tmp_path) -> None:
+    from gen_worker.models import provision
+
+    resolved: List[Tuple[str, str]] = []
+
+    def _fake_resolve(*, ref: str, provider: str, **kw: Any) -> str:
+        resolved.append((ref, provider))
+        return str(tmp_path)
+
+    monkeypatch.setattr(provision, "resolve_local_path", _fake_resolve)
+    paths = provision.resolve_bindings(
+        {"pipeline": PIPE_DEFAULT_RAW, "vae": VAE_DEFAULT_RAW},
+        offline=False, emit=lambda e: None,
+        slots={"pipeline": Slot(_StubPipeline, selected_by="model",
+                                default_checkpoint=PIPE_DEFAULT_RAW)},
+        payload=_In(prompt="x"),
+    )
+    assert paths == {"pipeline": str(tmp_path), "vae": str(tmp_path)}
+    assert ("827184", "civitai") in resolved
+    assert ("madebyollin/sdxl-vae-fp16-fix", "huggingface") in resolved

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## pgw#532 — worker-side dynamic slot materialization (the last th#767 piece)

**The live failure this fixes (fc157, request f99f81bd):** a hub-connected worker
materialized `Slot.default_checkpoint` from its RAW upstream (Civitai id 827184) at setup →
`civitai_not_found` (no key in-pod; mirror-first forbids upstream self-fetch anyway, gw#465)
→ setup failed → every function unavailable, cascading `load_failed` onto the healthy
hub-binding refs. Independently: `resolved_models[slot]` — the pick the hub resolved,
routed on, and pre-drove (`LOAD tensorhub/cyberrealistic-pony:prod`) — was never injected;
a pick would silently have run the default's weights.

### Materialization precedence (per declared Slot, hub-connected)

`executor._slot_dispatch_binding` (src/gen_worker/executor.py):

1. **`RunJob.models[slot]`** — the hub-resolved pick, minted into a tensorhub-source
   binding (`_hub_binding_for_wire_ref`). Bytes come from the dispatch's snapshots, the
   store's banked ModelOp snapshots, or the th#763 `missing_snapshot` re-mint — never an
   upstream fetch.
2. **The declared `default_checkpoint`, only when it is itself a `Hub(...)` CAS ref.**
3. **Fail RETRYABLE** — a raw Civitai/HF/ModelScope default is a SEED for the hub mapping,
   never a load instruction on a hub-connected worker.

Boot side (`lifecycle.startup`): Slot seeds are excluded from the upstream prefetch loop,
and Slot-declared specs are never eagerly set up — the exact two boot-time leak sites of
the fc157 failure. Dynamic-slot functions advertise available once hardware-gated
(avoids the th#651 loading-fn dispatch deadlock class); materialization happens per
dispatch against hub-named refs.

### Seam decision: (i) instance-per-(class, resolved pick)

`_effective_spec` derives the dispatch's spec with every declared Slot rebound to the
resolved pick; a differing pick derives a new `instance_key`, and `_class_record` creates
per-pick `_ClassRecord`s on first sight. Chosen over (ii) mutable slot proxy and (iii)
handlers-fetch-per-request because:

- `setup()` runs once per (class, resolved pick) → `self.pipeline = _tune(pipeline)` is
  coherent BY CONSTRUCTION — no spooky repointing, no template migration.
- It matches residency semantics exactly: multiple picks stay warm as separate instances,
  the EXISTING load-lock/make_room/`_vacate_record` LRU machinery evicts whole instances,
  `ModelOp{UNLOAD}` tears down exactly one pick, `ModelOp{LOAD}` now also matches derived
  records and re-sets-up an evicted pick.
- It is how ModelChoice-era placement warmed per checkpoint — the hub already thinks in
  (function, resolved ref) warm pools.

VRAM behavior rides the unchanged place/evict core (`models/provision.load_slot` +
`_make_room_for` + residency LRU) — a second pick's setup demotes/evicts idle instances
exactly like a second endpoint's always has.

### `ctx.slots[name].ref` is the pick

`_resolve_slots_kwargs` runs on the derived spec, so `.ref` is the resolved pick;
`.defaults` still merges the wire's `inference_defaults` over the code preset.

### Endpoint-template impact: NONE

Verified against `inference-endpoints/sdxl/src/sdxl/main.py`: `setup()` stores
`self.pipeline = _tune_pipeline(pipeline)`; handlers run `self.pipeline(...)` and read
`ctx.slots["pipeline"]`. With instance-per-pick, setup re-runs per pick, so
`self.pipeline` IS the pick's pipeline — no code change, just a rebuild on the 0.21.0
release.

### Known limitations / hub follow-ups (worker cannot fix these)

- **Default-pick stamps are raw upstream today**: tensorhub's `stampSlotDefault`
  (internal/orchestrator/http/slot_resolution.go) stamps `slot.DefaultCheckpoint` verbatim
  — for fc157's Civitai-native default, `RunJob.models[pipeline].ref="827184"`. The worker
  now fails such dispatches RETRYABLE with a message naming the gap instead of dying at
  boot. Hub follow-up: the default path should stamp the RELEASE BINDING ref (the
  registered mirror, e.g. `tensorhub/wai-illustrious:prod`) — the same ref placement
  routes on and the scheduler pre-drives.
- **Cold pre-warm `LOAD` of a never-dispatched pick** degrades to a download: bytes +
  snapshot are banked (next dispatch materializes instantly) but the op answers
  `load_failed` — `ModelOp` carries no slot name, and guessing which slot a bare ref
  belongs to would risk loading wrong weights. Hub follow-up if full pre-warm is wanted:
  add slot attribution to `ModelOp` (or accept the one-time dispatch-time VRAM load).
- A genuinely broken pick's setup failure marks the function unavailable (existing
  `_mark_setup_failed` semantics); the hub's LOAD-retry recovery path lifts it.

### Test evidence (tests/test_dynamic_slot_materialization_pgw532.py)

1. **hub-connected never touches raw upstream**: boot with a Civitai default — zero
   `ensure_local` calls, zero setups, no FAILED events, function advertised; the download
   fake ASSERTS on any civitai/hf provider or raw-ref fetch across every test.
2. **pick ≠ default loads picked weights**: dispatch with
   `models=[pipeline→tensorhub/cyberrealistic-pony:prod]` → setup receives the pick's
   materialized path; `ctx.slots["pipeline"].ref == tensorhub:tensorhub/cyberrealistic-pony:prod`.
3. **instance-per-pick residency**: two picks → two `setup()` runs, two resident records;
   a repeat pick does NOT re-setup; `UNLOAD(pickA)` vacates exactly that instance;
   `LOAD(pickA)` re-materializes it via its derived record.
4. **default-only unchanged**: CAS-declared default + default stamp → declared binding
   reused, base record, one instance.
5. **raw stamp over raw default** → `JOB_STATUS_RETRYABLE`, zero downloads, function NOT
   disabled.
6. **hub-less default path unchanged**: `provision.resolve_bindings` still resolves the
   raw `default_checkpoint` through its upstream provider (`civitai`/`huggingface`).

### Gates

- mypy: 0 errors (110 files)
- ruff: clean
- pytest: 999 passed, 6 failed — the 6 pre-existing `GEN_WORKER_FORBID_CPU_OFFLOAD` env
  failures (content_lanes×3, ram_admission×2, snapshot_corruption), verified byte-identical
  on origin/master in the same env
- version 0.21.0 + CHANGELOG

Remaining #532 tasks (NOT this PR): sdxl image rebuild on 0.21.0 + fc157 proof re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
