### PR TITLE
gw: fp8 storage flavors for transformers-backbone snapshots (0.22.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.22.4 (2026-07-13)
+
+- **gw: fp8 storage flavors for transformers-BACKBONE snapshots (ie#478).**
+  `streaming_fp8_snapshot` / the clone `build_flavor_tree` fp8 lane now
+  accept a non-diffusers layout when the snapshot is exactly ONE root
+  weight set (sharded-transformers backbone — the whole checkpoint IS the
+  denoiser, e.g. HiDream-O1's pixel-space UiT). The cast is BLOCK-SCOPED:
+  eligible weights must live under a repeated-block container (`.<idx>.`
+  path segment) in addition to the existing skip patterns, keeping the
+  stored fp8 set a strict subset of the runtime block-window walk
+  (`_fp8_block_windows`) so every stored-fp8 tensor is re-armed by any
+  consumer. Zero-cast outputs refuse loudly (never a silently-uncast
+  "fp8" flavor). Multi-set singlefile bundles still refuse — component
+  identity is ambiguous there. New `run_inline_conversion(...,
+  fp8_block_scope=)` / `streaming_fp8_storage_cast(..., block_scope=)`
+  pass-throughs.
+
 ## 0.22.3 (2026-07-13)
 
 - **pgw#516 (settled foundation): LoRA-kind family vocabulary + FIELD-LEVEL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.3"
+version = "0.22.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -274,10 +274,18 @@ def build_flavor_tree(
     # Dtype conversion per weight set.
     groups = snapshot_weight_groups(work_root, work_layout)
     is_fp8 = spec.dtype == "fp8"
+    fp8_block_scope = False
     if is_fp8 and work_layout != "diffusers":
-        raise ValueError(
-            "fp8 storage flavors are component-scoped; request "
-            'file_layout="diffusers" (repackage first for singlefile sources)')
+        # One root weight set = a transformers backbone (the whole checkpoint
+        # IS the denoiser, e.g. HiDream-O1's UiT): block-scoped fp8 cast.
+        # Multi-set singlefile bundles still refuse — component identity is
+        # ambiguous there.
+        if len(groups) != 1 or groups[0][0] != "":
+            raise ValueError(
+                "fp8 storage flavors need component identity: a diffusers "
+                "layout, or a single root weight set (transformers "
+                f"backbone) — found {len(groups)} weight set(s)")
+        fp8_block_scope = True
     if quantize_components:
         target_names = set(quantize_components)
     elif is_fp8:
@@ -305,7 +313,7 @@ def build_flavor_tree(
         result = run_inline_conversion(
             source_path=entry, out_dir=dest, target_dtype=spec.dtype,
             target_file_type="safetensors", shard_prefix=stem or "model",
-            source_repo_dir=comp_dir,
+            source_repo_dir=comp_dir, fp8_block_scope=fp8_block_scope,
         )
         attrs.update({k: v for k, v in result.attributes.items() if k not in attrs})
         converted.add(comp)

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -212,6 +212,7 @@ def run_inline_conversion(
     target_file_type: str = "safetensors",
     shard_prefix: str = "model",
     source_repo_dir: Path | None = None,
+    fp8_block_scope: bool = False,
 ) -> InlineConversionResult:
     """Run the appropriate inline conversion for the requested target_dtype.
 
@@ -271,6 +272,7 @@ def run_inline_conversion(
             source_path=source_path,
             out_dir=out_dir,
             shard_prefix=shard_prefix,
+            block_scope=fp8_block_scope,
         )
 
     # bitsandbytes nf4 / fp4 — runs on CPU for the quant pass; save_pretrained
@@ -354,15 +356,19 @@ def _run_fp8_storage_inline(
     source_path: Path,
     out_dir: Path,
     shard_prefix: str,
+    block_scope: bool = False,
 ) -> InlineConversionResult:
     """fp8-E4M3 storage cast of one weight set (the ``#fp8`` flavor),
     streaming per-tensor. Layerwise-casting skip patterns are honored so a
     consumer's ``apply_fp8_storage`` reproduces the runtime fp8-storage lane
-    exactly. Stamps dtype ``fp8`` — the detector keys on F8_E4M3 headers."""
+    exactly. Stamps dtype ``fp8`` — the detector keys on F8_E4M3 headers.
+    ``block_scope=True`` = the transformers-backbone lane (repeated-block
+    params only)."""
     from .writer import streaming_fp8_storage_cast
 
     result = streaming_fp8_storage_cast(
         Path(source_path), Path(out_dir), shard_prefix=shard_prefix,
+        block_scope=block_scope,
     )
     index_path = result.get("index_path")
     attrs = {

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -542,6 +542,21 @@ def fp8_cast_eligible(
     return not any(re.search(p, module_path) for p in skip_patterns)
 
 
+# ``.<block-list>.<idx>.`` segment — a param living under a repeated-block
+# container (nn.ModuleList child). The transformers-backbone fp8 lane casts
+# ONLY these, mirroring the runtime block-window walk
+# (gen_worker.models.loading._fp8_block_windows): params outside repeated
+# blocks (embeddings, final norms, heads) stay at source precision, so the
+# stored flavor is a strict subset of what any consumer re-arms.
+_FP8_BLOCK_SCOPE_RE = r"\.\d+\."
+
+
+def _in_repeated_block(name: str) -> bool:
+    import re
+
+    return re.search(_FP8_BLOCK_SCOPE_RE, name) is not None
+
+
 def streaming_fp8_storage_cast(
     input_path: Path,
     out_dir: Path,
@@ -549,16 +564,24 @@ def streaming_fp8_storage_cast(
     shard_prefix: str = "model",
     shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
     skip_patterns: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS,
+    block_scope: bool = False,
 ) -> dict[str, Any]:
     """Produce the fp8-E4M3 storage flavor of one weight set, streaming.
 
     Eligible weights are clamped to ±448 and stored as F8_E4M3; everything
     else keeps its source dtype. Scale-free by design: consumption is
     diffusers layerwise casting (fp8 bytes resident, bf16/fp16 compute).
+
+    ``block_scope=True`` (the transformers-backbone lane) additionally
+    requires an eligible weight to live under a repeated-block container
+    (``.<idx>.`` path segment) — the stored set stays a strict subset of the
+    runtime block-window walk.
     """
     import torch
 
     def out_st_dtype_for(name: str, src_st: str, shape: list[int]) -> str:
+        if block_scope and not _in_repeated_block(name):
+            return src_st
         if fp8_cast_eligible(name, src_st, shape, skip_patterns=skip_patterns):
             return "F8_E4M3"
         return src_st
@@ -864,14 +887,37 @@ def streaming_fp8_snapshot(
     ``te_components`` (the ``fp8+te`` rung, gw#460 — pass
     :data:`FP8_TE_COMPONENTS`) get the transformers block-window cast whose
     eligible set is derived from the loader itself. Every other component
-    passes through untouched. Refuses singlefile layouts — fp8 storage is
-    component-scoped and single-file keyspaces don't name components
-    reliably."""
-    if file_layout != "diffusers":
-        raise ConversionImplementationError(
-            "fp8 storage flavors are produced from diffusers layouts only "
-            "(component-scoped); repackage singlefile sources first")
+    passes through untouched.
+
+    Non-diffusers layouts are supported for exactly ONE shape: a single
+    root weight set (sharded-transformers backbone — the whole checkpoint
+    IS the denoiser, e.g. a UiT like HiDream-O1). That set gets the
+    block-scoped fp8 cast; multi-set singlefile bundles still refuse
+    (component identity is ambiguous there)."""
     source_dir, out_dir = Path(source_dir), Path(out_dir)
+    if file_layout != "diffusers":
+        root_groups = snapshot_weight_groups(source_dir, file_layout)
+        if len(root_groups) != 1 or root_groups[0][0] != "":
+            raise ConversionImplementationError(
+                "fp8 storage flavors need component identity: a diffusers "
+                "layout, or a single root weight set (transformers "
+                f"backbone) — found {len(root_groups)} weight set(s) in "
+                f"{file_layout!r} layout")
+        entry = root_groups[0][1]
+        result = streaming_fp8_storage_cast(
+            entry, out_dir,
+            shard_prefix=_group_shard_prefix(entry),
+            shard_threshold=shard_threshold,
+            block_scope=True,
+        )
+        if not int(result["converted_count"]):
+            raise ConversionImplementationError(
+                "no fp8-castable weights in the root weight set (nothing "
+                "under a repeated-block container missed the skip patterns)")
+        copy_non_weight_files(source_dir, out_dir, skip_components={""})
+        return {"tensor_count": int(result["tensor_count"]),
+                "converted_count": int(result["converted_count"]),
+                "components": [""], "output_dir": out_dir}
     denoiser_set, te_set = set(components), set(te_components)
     groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
               if c in denoiser_set | te_set]

--- a/tests/convert/test_streaming_convert.py
+++ b/tests/convert/test_streaming_convert.py
@@ -282,13 +282,21 @@ def test_streaming_fp8_snapshot_denoiser_only(tmp_path: Path) -> None:
     assert (out / "model_index.json").is_file()
 
 
-def test_streaming_fp8_snapshot_refuses_singlefile(tmp_path: Path) -> None:
+def test_streaming_fp8_snapshot_singlefile_needs_block_weights(tmp_path: Path) -> None:
+    """A single root weight set is the transformers-backbone lane (ie#478):
+    block-scoped cast. With nothing under a repeated-block container it
+    still refuses — never a silently-uncast 'fp8' flavor."""
     from gen_worker.convert.writer import ConversionImplementationError
 
     (tmp_path / "src").mkdir()
     save_file({"w": torch.randn(4, 4)}, str(tmp_path / "src" / "model.safetensors"))
     with pytest.raises(ConversionImplementationError):
         streaming_fp8_snapshot(tmp_path / "src", tmp_path / "out", file_layout="singlefile")
+
+    save_file({"blocks.0.attn.weight": torch.randn(4, 4)},
+              str(tmp_path / "src" / "model.safetensors"))
+    stats = streaming_fp8_snapshot(tmp_path / "src", tmp_path / "out2", file_layout="singlefile")
+    assert stats["converted_count"] == 1
 
 
 def test_clone_normalizes_fp8_spellings() -> None:

--- a/tests/test_fp8_backbone_writer.py
+++ b/tests/test_fp8_backbone_writer.py
@@ -1,0 +1,148 @@
+"""fp8 storage flavors for transformers-BACKBONE snapshots (ie#478).
+
+A sharded-transformers repo whose single root weight set IS the model
+(pixel-space UiT like HiDream-O1: no VAE, no external text encoders) gets a
+block-scoped fp8-E4M3 cast: only >=2-D ``.weight`` tensors living under a
+repeated-block container (``.<idx>.`` path segment) that miss the skip
+patterns are cast — a strict subset of the runtime block-window walk, so
+everything stored fp8 is re-armed by any consumer. Multi-set singlefile
+bundles still refuse (component identity is ambiguous).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+safetensors = pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file  # noqa: E402
+
+from gen_worker.convert.convert import run_inline_conversion  # noqa: E402
+from gen_worker.convert.writer import (  # noqa: E402
+    ConversionImplementationError,
+    streaming_fp8_snapshot,
+)
+
+
+def _backbone_snapshot(tmp_path: Path) -> Path:
+    """Two root shards + index + config/tokenizer sidecars, HiDream-O1 shape."""
+    src = tmp_path / "src"
+    src.mkdir(parents=True)
+
+    shard1 = {
+        "model.embed_tokens.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "model.layers.0.mlp.down_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "model.layers.0.input_layernorm.weight": torch.randn(8, dtype=torch.bfloat16),
+    }
+    shard2 = {
+        "model.layers.1.self_attn.q_proj.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        "model.norm.weight": torch.randn(8, dtype=torch.bfloat16),
+        # 2-D, misses every skip pattern, but OUTSIDE any repeated block:
+        # block scoping must keep it at source precision.
+        "lm_head.weight": torch.randn(16, 8, dtype=torch.bfloat16),
+    }
+    save_file(shard1, src / "model-00001-of-00002.safetensors")
+    save_file(shard2, src / "model-00002-of-00002.safetensors")
+    weight_map = {k: "model-00001-of-00002.safetensors" for k in shard1}
+    weight_map |= {k: "model-00002-of-00002.safetensors" for k in shard2}
+    (src / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map}))
+    (src / "config.json").write_text(json.dumps({"architectures": ["FakeUiT"]}))
+    (src / "tokenizer_config.json").write_text("{}")
+    return src
+
+
+def _stored_dtypes(out_dir: Path) -> dict[str, str]:
+    from safetensors import safe_open
+
+    dtypes: dict[str, str] = {}
+    for f in sorted(out_dir.glob("*.safetensors")):
+        with open(f, "rb") as fh:
+            import struct
+
+            n = struct.unpack("<Q", fh.read(8))[0]
+            header = json.loads(fh.read(n))
+        for k, v in header.items():
+            if k != "__metadata__":
+                dtypes[k] = v["dtype"]
+    return dtypes
+
+
+CAST = {
+    "model.layers.0.self_attn.q_proj.weight",
+    "model.layers.0.mlp.down_proj.weight",
+    "model.layers.1.self_attn.q_proj.weight",
+}
+KEPT = {
+    "model.embed_tokens.weight",          # skip pattern: embed
+    "model.layers.0.input_layernorm.weight",  # 1-D + norm
+    "model.norm.weight",                  # 1-D + norm
+    "lm_head.weight",                     # outside repeated blocks
+}
+
+
+def test_backbone_snapshot_block_scoped_cast(tmp_path: Path) -> None:
+    src = _backbone_snapshot(tmp_path)
+    out = tmp_path / "out"
+
+    stats = streaming_fp8_snapshot(src, out, file_layout="singlefile")
+
+    dtypes = _stored_dtypes(out)
+    assert set(dtypes) == CAST | KEPT
+    assert {k for k, v in dtypes.items() if v == "F8_E4M3"} == CAST
+    for k in KEPT:
+        assert dtypes[k] == "BF16"
+    assert stats["converted_count"] == len(CAST)
+    # Sidecars ride along; the source index is superseded by the re-shard.
+    assert (out / "config.json").is_file()
+    assert (out / "tokenizer_config.json").is_file()
+
+
+def test_multi_weight_set_still_refuses(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    save_file({"a.0.weight": torch.randn(4, 4, dtype=torch.bfloat16)},
+              src / "diffusion_model.safetensors")
+    save_file({"b.0.weight": torch.randn(4, 4, dtype=torch.bfloat16)},
+              src / "text_encoder.safetensors")
+
+    with pytest.raises(ConversionImplementationError, match="weight set"):
+        streaming_fp8_snapshot(src, tmp_path / "out", file_layout="singlefile")
+
+
+def test_diffusers_lane_unchanged(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "transformer").mkdir(parents=True)
+    save_file(
+        {
+            "blocks.0.attn.to_q.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+            "proj_out.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+        },
+        src / "transformer" / "diffusion_pytorch_model.safetensors",
+    )
+    (src / "model_index.json").write_text("{}")
+
+    streaming_fp8_snapshot(src, tmp_path / "out", file_layout="diffusers")
+    dtypes = _stored_dtypes(tmp_path / "out" / "transformer")
+    assert dtypes["blocks.0.attn.to_q.weight"] == "F8_E4M3"
+    assert dtypes["proj_out.weight"] == "BF16"
+
+
+def test_run_inline_conversion_block_scope_flag(tmp_path: Path) -> None:
+    src = _backbone_snapshot(tmp_path)
+    out = tmp_path / "out"
+
+    result = run_inline_conversion(
+        source_path=src / "model.safetensors.index.json",
+        out_dir=out, target_dtype="fp8", fp8_block_scope=True,
+    )
+
+    assert result.attributes["dtype"] == "fp8"
+    dtypes = _stored_dtypes(out)
+    assert {k for k, v in dtypes.items() if v == "F8_E4M3"} == CAST
+    assert dtypes["lm_head.weight"] == "BF16"

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.3"
+version = "0.22.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
The fp8 flavor lane was diffusers-component-scoped only; HiDream-O1 (ie#478) is a sharded-transformers repo whose single root weight set IS the denoiser (8B pixel-space UiT — no VAE, no external text encoders), so its `#fp8` default serve lane had no producer.

- `streaming_fp8_snapshot` + clone `build_flavor_tree`: accept non-diffusers layouts iff the snapshot has exactly ONE root weight set; multi-set singlefile bundles still refuse (component identity is ambiguous).
- The backbone cast is BLOCK-SCOPED: eligible = >=2-D `.weight` under a repeated-block container (`.<idx>.` segment) that misses the skip patterns — a strict subset of the runtime `_fp8_block_windows` walk, so every stored-fp8 tensor gets re-armed by any consumer.
- Zero-cast outputs refuse loudly (never a silently-uncast "fp8" flavor).
- `run_inline_conversion(fp8_block_scope=)` / `streaming_fp8_storage_cast(block_scope=)` pass-throughs; diffusers lane byte-identical to before.

## Tests
- New `tests/test_fp8_backbone_writer.py` (4): block-scoped cast set exactness (lm_head/embeds/norms kept), multi-set refusal, diffusers lane unchanged, inline-conversion flag.
- Updated the stale singlefile-refusal test to the new contract.
- Full `tests/convert/` + fp8 writer suites: 188 passed, 2 skipped.

Release: tag v0.22.4 after merge (publish.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)