### PR TITLE
convert/layout: hidream-o1 family hint (0.22.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.22.6 (2026-07-13)
+
+- convert/layout: HiDream-O1 family hint — `HiDream-ai/HiDream-O1-Image*`
+  repos stamp `model_family="hidream-o1"` at ingest, so the mirror's th#767
+  inference-defaults PUT has a family to key on (ie#478).
+
 ## 0.22.5 (2026-07-13)
 
 - **packaging: grpcio floor 1.82.1.** The shipped pb stubs are generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.5"
+version = "0.22.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/layout.py
+++ b/src/gen_worker/convert/layout.py
@@ -67,6 +67,8 @@ def canonical_model_family_from_variant(variant: str) -> str:
         return "wan"
     if raw in {"auraflow"}:
         return "auraflow"
+    if raw == "hidream_o1":
+        return "hidream-o1"
     if raw == "sdxl":
         return "sdxl"
     if raw == "sd15":
@@ -89,6 +91,8 @@ def infer_model_family_variant_from_hint(value: str | None) -> str:
         return "wan21"
     if "wan" in normalized and any(tok in normalized for tok in ("video", "i2v", "t2v", "vace")):
         return "wan22"
+    if "hidreamo1" in normalized:
+        return "hidream_o1"
     if "qwenimage" in normalized:
         return "qwen_image"
     if "zimage" in normalized:

--- a/tests/convert/test_repackage_families.py
+++ b/tests/convert/test_repackage_families.py
@@ -271,3 +271,19 @@ def test_multi_weight_bundle_detection(tmp_path) -> None:
     (d / "qwen_image_vae.safetensors").write_bytes(b"x")
     assert _is_multi_weight_bundle(d)
 
+
+
+def test_hidream_o1_family_hint() -> None:
+    """ie#478: HiDream-O1 repos stamp model_family=hidream-o1 at ingest so
+    the mirror's inference-defaults PUT (th#767) has a family to key on."""
+    from gen_worker.convert.layout import (
+        canonical_model_family_from_variant,
+        infer_model_family_from_hint,
+        infer_model_family_variant_from_hint,
+    )
+
+    for hint in ("HiDream-ai/HiDream-O1-Image-Dev", "HiDream-ai/HiDream-O1-Image",
+                 "hidream-o1-image-full"):
+        assert infer_model_family_variant_from_hint(hint) == "hidream_o1"
+        assert infer_model_family_from_hint(hint) == "hidream-o1"
+    assert canonical_model_family_from_variant("hidream_o1") == "hidream-o1"

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.5"
+version = "0.22.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
HiDream-ai/HiDream-O1-Image* ingests stamp model_family=hidream-o1 so the mirror's th#767 inference-defaults PUT (full-model recipe: steps 50 / cfg 5.0 / shift 3.0) has a family to key on. Companion to tensorhub #328. ie#478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)