### PR TITLE
gw#534: fp8 download, bf16 resident — W8A16 cast never voluntary; compile-cache weight_lane parity (0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.23.0 (2026-07-13)
+
+- **gw#534: fp8 download, bf16 resident — W8A16 layerwise casting is never
+  voluntary.** The measured per-forward cast tax of the fp8-storage lane is
+  +44% wall on H100 / +73% on B200 vs bf16-resident (gw#534 profiles). A
+  planned fp8 storage lane (stored `#fp8` flavor or resolved `storage_dtype`
+  cast) is now UPGRADED at load to plain bf16-resident weights whenever the
+  snapshot fits free VRAM with headroom (`bf16_resident_fits`, 4GB activation
+  margin; fp8-stored cast targets counted at 2x for the upcast): the fp8
+  artifact stays the small download, `from_pretrained`'s torch_dtype upcasts
+  once, and the per-layer cast hooks are skipped. Hooks remain only when bf16
+  does not fit (involuntary W8A16). Compile-cache: cells record
+  `weight_lane` — the lane the built pipeline ACTUALLY traced under
+  ("" plain-resident / "fp8-hooks") — and `enable()` + the executor adopt
+  path reject lane drift symmetrically (a bf16-resident pipeline must never
+  adopt hook-cast-traced graphs and vice versa; both are guaranteed FX-graph
+  misses that would serve eager while reporting adopted).
 ## 0.22.6 (2026-07-13)
 
 - convert/layout: HiDream-O1 family hint — `HiDream-ai/HiDream-O1-Image*`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.22.6"
+version = "0.23.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -179,6 +179,7 @@ def artifact_metadata(
     low_vram_mode: str = "",
     storage_dtype: str = "",
     compile_mode: str = "whole",
+    weight_lane: str = "",
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
@@ -186,9 +187,12 @@ def artifact_metadata(
     ``low_vram_mode`` is the prep mode the producer pipeline was traced under
     (gw#391): its flags are traced into the graphs, so a consumer prepped in a
     different mode must reject the cell. ``storage_dtype`` records the weight
-    storage the graphs were traced under (fp8 layerwise-cast hooks are traced
-    INTO the graphs — ie#381); informational, a drift is a cache miss, never
-    an error. Shape rows are (w, h) or (w, h, frames) — see ``Compile``."""
+    storage the binding REQUESTED — informational only. ``weight_lane`` is the
+    lane the built pipeline ACTUALLY traced under (gw#534:
+    ``loading.pipeline_weight_lane`` — "" plain-resident, "fp8-hooks"
+    layerwise-cast; the hooks are traced INTO the graphs, ie#381) and is
+    parity-checked at :func:`enable` like ``low_vram_mode``. Shape rows are
+    (w, h) or (w, h, frames) — see ``Compile``."""
     return {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
@@ -202,6 +206,7 @@ def artifact_metadata(
         "low_vram_mode": str(low_vram_mode or ""),
         "storage_dtype": str(storage_dtype or ""),
         "compile_mode": str(compile_mode or "whole"),
+        "weight_lane": str(weight_lane or ""),
         "libs": _lib_versions(),
     }
 
@@ -428,6 +433,21 @@ def mode_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     have = low_vram_mode(pipeline)
     if want != have:
         return f"low_vram_mode {want!r} != pipeline {have!r}"
+    return ""
+
+
+def lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:
+    """'' when the cell's traced weight lane matches this pipeline's, else the
+    mismatch (gw#534). Enforced SYMMETRICALLY (unlike ``mode_drift``): a
+    bf16-resident pipeline must never adopt hook-cast-traced graphs and vice
+    versa — both directions are guaranteed FX-graph misses that would serve
+    eager while reporting adopted (the gw#391 bug class)."""
+    want = str(meta.get("weight_lane") or "")
+    from .models.loading import pipeline_weight_lane
+
+    have = pipeline_weight_lane(pipeline)
+    if want != have:
+        return f"weight_lane {want!r} != pipeline {have!r}"
     return ""
 
 
@@ -730,7 +750,7 @@ def enable(
         getattr(cfg, "family", "") or "", cache_dir=cache_dir, artifact=artifact
     )
     if meta is not None:
-        drift = mode_drift(meta, pipeline)
+        drift = mode_drift(meta, pipeline) or lane_drift(meta, pipeline)
         if drift:
             logger.warning("compile-cache: %s; staying eager", drift)
             meta = None
@@ -874,12 +894,17 @@ def build(
             "was inductor already latched to another dir in this process?"
         )
 
+    from .models.loading import pipeline_weight_lane
+
     meta = artifact_metadata(
         family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
         low_vram_mode=str(placed.get("mode") or ""),
         storage_dtype=storage_dtype,
         compile_mode="regional" if regional else "whole",
+        # gw#534: the lane the pipeline ACTUALLY traced under — the loader may
+        # have upgraded a requested fp8 cast to bf16-resident on this pod.
+        weight_lane=pipeline_weight_lane(pipe),
     )
     label = flavor_label(meta["sku"], meta["torch"])
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)
@@ -905,6 +930,7 @@ __all__ = [
     "gen_worker_version",
     "inductor_counters",
     "is_cache_ref",
+    "lane_drift",
     "mode_drift",
     "pack",
     "prepare",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2419,7 +2419,8 @@ class Executor:
                         # prep mode is traced into the cells — a drifted
                         # pipeline can only miss, so reject deterministically
                         # instead of paying a warmup to find out.
-                        drift = compile_cache.mode_drift(meta, obj)
+                        drift = (compile_cache.mode_drift(meta, obj)
+                                 or compile_cache.lane_drift(meta, obj))
                         if drift:
                             return await fail("key_mismatch", drift)
                         # Re-adoption of a re-published cell: drop the previous

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -645,6 +645,65 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
     return merged
 
 
+# --- fp8 download, bf16 resident (gw#534 rung 2) ----------------------------
+# W8A16 layerwise casting is never chosen voluntarily (Paul 2026-07-13: the
+# per-forward cast tax measured +44% H100 / +73% B200 wall). A planned fp8
+# storage lane (stored #fp8 flavor or resolved cast) is UPGRADED to plain
+# bf16-resident weights when the whole snapshot fits free VRAM with headroom:
+# the fp8 artifact stays the small download, the upcast happens ONCE at load
+# (from_pretrained's torch_dtype already does it — we simply skip the hooks
+# that would re-cast down). Hooks remain only when bf16 does not fit.
+BF16_RESIDENT_MARGIN_GB = 4.0  # activations + allocator headroom
+
+# The pipeline's weight lane, part of the compile-cache graph key (gw#534):
+# "" = plain resident weights (incl. the bf16-resident upcast), "fp8-hooks" =
+# layerwise-cast hooks armed (the hooks are traced into the FX graphs).
+_WEIGHT_LANE_ATTR = "_cozy_weight_lane"
+
+
+def pipeline_weight_lane(pipeline: Any) -> str:
+    lane = str(getattr(pipeline, _WEIGHT_LANE_ATTR, "") or "")
+    if lane == "bf16-resident":
+        return ""  # traces identically to plain bf16
+    if lane:
+        return lane
+    for name in _FP8_STORAGE_COMPONENTS:
+        if getattr(getattr(pipeline, name, None), "_cozy_fp8_storage_applied", False):
+            return "fp8-hooks"
+    if getattr(pipeline, "_cozy_fp8_storage_applied", False):
+        return "fp8-hooks"
+    return ""
+
+
+def bf16_resident_fits(
+    path: Path, *, text_encoders: bool = False, free_gb: Optional[float] = None
+) -> bool:
+    """True when the snapshot can serve fully bf16-RESIDENT within free VRAM
+    minus :data:`BF16_RESIDENT_MARGIN_GB` (fp8-stored cast targets doubled for
+    the upcast). False on CPU-only hosts or unreadable snapshots — the caller
+    keeps today's hook path."""
+    if free_gb is None:
+        from .memory import get_available_vram_gb
+
+        free_gb = get_available_vram_gb()
+    if free_gb <= 0:
+        return False
+    comp = snapshot_component_weight_bytes(Path(path))
+    total = sum(comp.values())
+    if total <= 0:
+        return False
+    targets = set(_FP8_STORAGE_COMPONENTS)
+    if text_encoders:
+        targets |= set(_FP8_TEXT_ENCODER_COMPONENTS)
+    upcast_extra = 0
+    for name, nbytes in comp.items():
+        probe = Path(path) / name if name else Path(path)
+        if (name in targets or not name) and detect_on_disk_dtype(probe) == "fp8":
+            upcast_extra += nbytes
+    resident_gb = (total + upcast_extra) / float(1 << 30)
+    return resident_gb <= float(free_gb) - BF16_RESIDENT_MARGIN_GB
+
+
 # --- Runtime fit rungs (th#546 emergency lane + th#683 fp8 storage) --------
 # Fit ladder: bf16 -> #fp8 flavor -> #nvfp4 (Blackwell) -> runtime fp8-E4M3
 # storage -> EMERGENCY nf4 -> CPU offload. When even the downloaded flavor
@@ -992,6 +1051,18 @@ def load_from_pretrained(
                 pass
     fp8_storage = storage_dtype in ("fp8", "fp8+te") or sniffed == "fp8"
     fp8_text_encoders = storage_dtype == "fp8+te"
+    bf16_resident = False
+    if fp8_storage and bf16_resident_fits(Path(path), text_encoders=fp8_text_encoders):
+        # gw#534 rung 2: fp8 download, bf16 resident — skip the cast hooks
+        # (never voluntary W8A16); from_pretrained's torch_dtype upcasts once.
+        fp8_storage = False
+        fp8_text_encoders = False
+        bf16_resident = True
+        logger.info(
+            "RESIDENT_UPCAST model=%s: fp8 storage lane upgraded to "
+            "bf16-resident weights (fits with headroom); layerwise-cast "
+            "hooks skipped", path,
+        )
     adaptive_rung = ""  # gw#491: load-time rung engagement, stamped on the pipe
     if not read_on_disk_quant_config(Path(path)):
         qc = synthesize_quantization_config(attrs)
@@ -1031,6 +1102,13 @@ def load_from_pretrained(
         try:
             pipe._cozy_fp8_storage_requested = True
             pipe._cozy_fp8_storage_ok = bool(applied)
+            if applied:
+                setattr(pipe, _WEIGHT_LANE_ATTR, "fp8-hooks")
+        except Exception:
+            pass
+    elif bf16_resident:
+        try:
+            setattr(pipe, _WEIGHT_LANE_ATTR, "bf16-resident")
         except Exception:
             pass
     if adaptive_rung == "nf4":
@@ -1065,7 +1143,9 @@ __all__ = [
     "synthesize_quantization_config",
     "apply_fp8_storage",
     "apply_block_window_offload",
+    "bf16_resident_fits",
     "block_offload_active",
+    "pipeline_weight_lane",
     "emergency_quant_enabled",
     "bitsandbytes_available",
     "runtime_fp8_storage_supported",

--- a/tests/test_bf16_resident_upcast.py
+++ b/tests/test_bf16_resident_upcast.py
@@ -1,0 +1,188 @@
+"""gw#534 rung 2 — "fp8 download, bf16 resident".
+
+W8A16 layerwise casting is never voluntary: a planned fp8 storage lane
+(stored #fp8 flavor or resolved cast) is upgraded to plain bf16-resident
+weights when the snapshot fits free VRAM with headroom. Hooks remain only
+when bf16 does not fit. The traced weight lane keys the compile cache
+(lane_drift): bf16-resident pipelines must never adopt hook-cast graphs.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.compile_cache import artifact_metadata, lane_drift
+from gen_worker.models.loading import (
+    bf16_resident_fits,
+    load_from_pretrained,
+    pipeline_weight_lane,
+)
+
+
+class _FakeDenoiser:
+    def __init__(self) -> None:
+        self.casting_calls: list = []
+
+    def parameters(self):
+        return iter(())
+
+    def enable_layerwise_casting(self, *, storage_dtype: Any, compute_dtype: Any) -> None:
+        self.casting_calls.append((storage_dtype, compute_dtype))
+
+
+class _Pipe:
+    calls: list = []
+
+    def __init__(self) -> None:
+        self.transformer = _FakeDenoiser()
+        self.text_encoder = _FakeDenoiser()
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs: Any) -> Any:
+        cls.calls.append(kwargs)
+        return cls()
+
+
+def _write_safetensors(path: Path, dtype: str, nbytes: int) -> None:
+    header = json.dumps(
+        {"w": {"dtype": dtype, "shape": [nbytes], "data_offsets": [0, nbytes]}}
+    ).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def _snapshot(tmp_path: Path, dtype: str = "F8_E4M3", nbytes: int = 1024,
+              te_dtype: str = "", te_nbytes: int = 0) -> Path:
+    index: dict = {"_class_name": "Pipe", "transformer": ["diffusers", "X"]}
+    if te_nbytes:
+        index["text_encoder"] = ["transformers", "Y"]
+    (tmp_path / "model_index.json").write_text(json.dumps(index))
+    (tmp_path / "transformer").mkdir(exist_ok=True)
+    _write_safetensors(
+        tmp_path / "transformer" / "diffusion_pytorch_model.safetensors",
+        dtype, nbytes)
+    if te_nbytes:
+        (tmp_path / "text_encoder").mkdir(exist_ok=True)
+        _write_safetensors(
+            tmp_path / "text_encoder" / "model.safetensors", te_dtype, te_nbytes)
+    return tmp_path
+
+
+@pytest.fixture
+def vram(monkeypatch: pytest.MonkeyPatch):
+    def _set(gb: float) -> None:
+        import torch
+
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: gb > 0)
+        from gen_worker.models import memory
+
+        monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: gb)
+
+    return _set
+
+
+def test_stored_fp8_upgrades_to_bf16_resident(vram, tmp_path: Path) -> None:
+    """A stored #fp8 flavor on a roomy card serves bf16-RESIDENT: the small
+    download stays, the cast hooks (the +44%/+73% per-forward tax) do not."""
+    import torch
+
+    vram(24.0)
+    snap = _snapshot(tmp_path, "F8_E4M3", 2 << 30)
+    _Pipe.calls = []
+    pipe = load_from_pretrained(_Pipe, snap)
+    (kwargs,) = _Pipe.calls
+    assert kwargs["torch_dtype"] is torch.bfloat16
+    assert pipe.transformer.casting_calls == []
+    assert pipe._cozy_weight_lane == "bf16-resident"
+    assert pipeline_weight_lane(pipe) == ""  # traces as plain bf16
+
+
+def test_stored_fp8_keeps_hooks_when_bf16_cannot_fit(vram, tmp_path: Path) -> None:
+    """8GB fp8 weights on a 10GB-free card: bf16-resident would be ~16GB —
+    the involuntary W8A16 rung keeps fp8 bytes resident via hooks."""
+    import torch
+
+    vram(10.0)
+    snap = _snapshot(tmp_path, "F8_E4M3", 8 << 30)
+    _Pipe.calls = []
+    pipe = load_from_pretrained(_Pipe, snap)
+    ((storage, _compute),) = pipe.transformer.casting_calls
+    assert storage is torch.float8_e4m3fn
+    assert pipeline_weight_lane(pipe) == "fp8-hooks"
+
+
+def test_requested_cast_upgrades_on_roomy_card(vram, tmp_path: Path) -> None:
+    """An explicit storage_dtype="fp8" over a small bf16 snapshot is upgraded
+    too — the cast is a fit lever, never a preference (Paul 2026-07-13)."""
+    vram(24.0)
+    snap = _snapshot(tmp_path, "BF16", 2 << 30)
+    _Pipe.calls = []
+    pipe = load_from_pretrained(_Pipe, snap, dtype="bf16", storage_dtype="fp8")
+    assert pipe.transformer.casting_calls == []
+    assert pipe._cozy_weight_lane == "bf16-resident"
+    assert not getattr(pipe, "_cozy_fp8_storage_requested", False)
+
+
+def test_no_cuda_keeps_todays_path(vram, tmp_path: Path) -> None:
+    vram(0.0)
+    snap = _snapshot(tmp_path, "F8_E4M3", 1 << 20)
+    _Pipe.calls = []
+    pipe = load_from_pretrained(_Pipe, snap)
+    assert len(pipe.transformer.casting_calls) == 1
+    assert pipeline_weight_lane(pipe) == "fp8-hooks"
+
+
+def test_fp8_te_counts_text_encoders_in_the_estimate(vram, tmp_path: Path) -> None:
+    """fp8+te: the upcast estimate covers the text encoders too — 4+2GB fp8
+    doubles to 12GB resident, over a 13GB card's 9GB budget -> hooks stay."""
+    vram(13.0)
+    snap = _snapshot(tmp_path, "F8_E4M3", 4 << 30, te_dtype="F8_E4M3",
+                     te_nbytes=2 << 30)
+    _Pipe.calls = []
+    pipe = load_from_pretrained(_Pipe, snap, storage_dtype="fp8+te")
+    assert len(pipe.transformer.casting_calls) == 1
+    assert len(pipe.text_encoder.casting_calls) == 1
+    assert bf16_resident_fits(snap, text_encoders=True, free_gb=13.0) is False
+    assert bf16_resident_fits(snap, text_encoders=True, free_gb=17.0) is True
+
+
+def test_bf16_resident_fits_boundaries(tmp_path: Path) -> None:
+    snap = _snapshot(tmp_path, "F8_E4M3", 2 << 30)  # 2GB fp8 -> 4GB resident
+    assert bf16_resident_fits(snap, free_gb=0.0) is False
+    assert bf16_resident_fits(snap, free_gb=7.9) is False  # 4 > 7.9 - 4
+    assert bf16_resident_fits(snap, free_gb=8.1) is True
+    (tmp_path / "b").mkdir()
+    bf16 = _snapshot(tmp_path / "b", "BF16", 2 << 30)
+    assert bf16_resident_fits(bf16, free_gb=6.5) is True  # no doubling
+
+
+# --------------------------------------------------------------------------
+# compile-cache lane parity (gw#534)
+# --------------------------------------------------------------------------
+
+
+def test_lane_drift_is_symmetric() -> None:
+    hooked = _Pipe()
+    hooked.transformer._cozy_fp8_storage_applied = True
+    plain = _Pipe()
+    bf16_meta = artifact_metadata(family="f")
+    hook_meta = artifact_metadata(family="f", weight_lane="fp8-hooks")
+    assert bf16_meta["weight_lane"] == ""
+    assert lane_drift(bf16_meta, plain) == ""
+    assert lane_drift(hook_meta, hooked) == ""
+    assert "weight_lane" in lane_drift(bf16_meta, hooked)
+    assert "weight_lane" in lane_drift(hook_meta, plain)
+
+
+def test_lane_drift_bf16_resident_matches_plain_cells() -> None:
+    pipe = _Pipe()
+    pipe._cozy_weight_lane = "bf16-resident"
+    assert lane_drift(artifact_metadata(family="f"), pipe) == ""
+    assert "weight_lane" in lane_drift(
+        artifact_metadata(family="f", weight_lane="fp8-hooks"), pipe)

--- a/tests/test_cast_drop_th737.py
+++ b/tests/test_cast_drop_th737.py
@@ -97,7 +97,11 @@ def _snapshot(tmp_path: Path, components: dict) -> Path:
     return tmp_path
 
 
-def test_load_stamps_cast_ok(tmp_path: Path) -> None:
+def test_load_stamps_cast_ok(tmp_path: Path, monkeypatch) -> None:
+    # gw#534: pin the involuntary-cast path (a roomy card upgrades to
+    # bf16-resident instead — covered in test_bf16_resident_upcast.py).
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
     snap = _snapshot(tmp_path, {"transformer": ["x", "y"]})
     pipe = load_from_pretrained(_DenoiserPipe, snap, dtype="bf16",
                                 storage_dtype="fp8")
@@ -106,7 +110,9 @@ def test_load_stamps_cast_ok(tmp_path: Path) -> None:
     assert len(pipe.transformer.casting_calls) == 1
 
 
-def test_load_stamps_cast_failure(tmp_path: Path) -> None:
+def test_load_stamps_cast_failure(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
     snap = _snapshot(tmp_path, {"latent_upsampler": ["x", "y"]})
     pipe = load_from_pretrained(_NoSurfacePipe, snap, dtype="bf16",
                                 storage_dtype="fp8")
@@ -198,6 +204,8 @@ class _DenoiserShim(_DenoiserPipe):
 
 def test_executor_keeps_cast_on_denoiser_snapshot(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "0")
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
 
     class Endpoint:
         def setup(self, m: _DenoiserShim) -> None:

--- a/tests/test_fp8_and_emergency_loading.py
+++ b/tests/test_fp8_and_emergency_loading.py
@@ -135,9 +135,13 @@ def test_apply_fp8_storage_on_bare_module_defaults_bf16() -> None:
     assert compute is torch.bfloat16
 
 
-def test_binding_storage_dtype_applies_fp8(tmp_path: Path) -> None:
+def test_binding_storage_dtype_applies_fp8(tmp_path: Path, monkeypatch) -> None:
+    # gw#534: the cast is involuntary now — pin the doesn't-fit-bf16 path
+    # (the roomy-card upgrade lives in test_bf16_resident_upcast.py).
     import torch
 
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
     _Pipe.calls = []
     pipe = load_from_pretrained(_Pipe, _snapshot(tmp_path), dtype="bf16",
                                 storage_dtype="fp8")
@@ -149,11 +153,13 @@ def test_binding_storage_dtype_applies_fp8(tmp_path: Path) -> None:
     assert compute is torch.bfloat16
 
 
-def test_fp8_stored_flavor_auto_preserved(tmp_path: Path) -> None:
-    """An #fp8 flavor snapshot loads at bf16 compute and gets its storage
-    precision restored — never silently upcast into 2x the VRAM."""
+def test_fp8_stored_flavor_auto_preserved(tmp_path: Path, monkeypatch) -> None:
+    """An #fp8 flavor snapshot that does NOT fit bf16-resident loads at bf16
+    compute and gets its storage precision restored (involuntary W8A16)."""
     import torch
 
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
     _Pipe.calls = []
     pipe = load_from_pretrained(_Pipe, _snapshot(tmp_path, "F8_E4M3"))
     (kwargs,) = _Pipe.calls

--- a/tests/test_fp8_transformers_te.py
+++ b/tests/test_fp8_transformers_te.py
@@ -178,10 +178,15 @@ def test_binding_accepts_fp8_te() -> None:
         Hub("o/r", storage_dtype="fp8+vae")
 
 
-def test_load_from_pretrained_fp8_te(tmp_path) -> None:
-    """The executor path: storage_dtype="fp8+te" reaches the TE component."""
+def test_load_from_pretrained_fp8_te(tmp_path, monkeypatch) -> None:
+    """The executor path: storage_dtype="fp8+te" reaches the TE component
+    (gw#534: pinned to the involuntary path — a roomy card upgrades to
+    bf16-resident instead)."""
     import json as _json
     import struct as _struct
+
+    monkeypatch.setattr(
+        "gen_worker.models.loading.bf16_resident_fits", lambda *a, **k: False)
 
     from gen_worker.models.loading import load_from_pretrained
 

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.22.6"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Part 1 of gw#534 (W8A8 fp8-GEMM program). Policy: W8A16 layerwise casting is never chosen voluntarily — the measured per-forward cast tax is +44% wall on H100 / +73% on B200 vs bf16-resident (gw#534 profiler evidence, qwen-image DiT 1024²).

- A planned fp8 storage lane (stored `#fp8` flavor or resolved `storage_dtype` cast) is upgraded at load to bf16-RESIDENT weights when the snapshot fits free VRAM with headroom (`bf16_resident_fits`, 4GB margin, fp8 cast targets counted 2x for the upcast). The fp8 artifact stays the small download; `from_pretrained` torch_dtype upcasts once; the cast hooks are skipped. Hooks remain only when bf16 does not fit (involuntary W8A16). Not reported as degradation — quality upgrade, fit-checked.
- Compile cache (ie#381/gw#391 parity): cells record `weight_lane` — the lane the built pipeline ACTUALLY traced under ("" plain-resident / "fp8-hooks") — and `enable()` + the executor adopt path reject lane drift symmetrically. A bf16-resident pipeline must never adopt hook-cast-traced graphs and vice versa (guaranteed FX-graph misses that would serve eager while reporting adopted).
- Tests: new tests/test_bf16_resident_upcast.py (upgrade on roomy card, hooks kept on tight fit, fp8+te estimate, lane-drift symmetry); voluntary-cast-era tests pinned to the involuntary path.

Suite: 1043 passed locally; the 5 remaining failures are pre-existing on master on this box (verified via stash run: content-lanes/ram-admission/snapshot-corruption env-dependent). mypy clean on touched files; ruff findings all pre-existing.

Next (same issue): W8A8 fp8-GEMM serve path (torch._scaled_mm) per the artifact contract in gw#534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)