### PR TITLE
gw#534: W8A8 fp8-GEMM loader mode — Fp8ScaledLinear on torch._scaled_mm; dequant fallback; parity harness (0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.24.0 (2026-07-13)
+
+- **gw#534: W8A8 fp8-GEMM loader mode — the calibrated-quant serve path.**
+  A `#fp8-w8a8` flavor (fp8-E4M3 weights WITH scales; per-Linear
+  `weight` / `weight_scale` / optional static `input_scale`; exclusion by
+  absence — the gw#534 artifact contract) is detected by header sniff and
+  served with quantized Linears swapped for `Fp8ScaledLinear`:
+  `torch._scaled_mm` over RESIDENT fp8 weights, per-row dynamic activation
+  quant (static calibrated scale when present), bias fused, no per-layer
+  upcast. Hosts without usable scaled_mm (pre-sm89 / missing kernels — live
+  device probe, never a version table) dequant once at load to bf16-resident:
+  same numerics, never a refusal. Scale-FREE fp8 trees (the storage-cast
+  `#fp8` flavor) never match — the scales are the distinguisher. Pipelines
+  stamp `_cozy_weight_lane="w8a8"`, keying the compile cache (lane_drift):
+  W8A8 pipelines never adopt W8A16/bf16-traced graphs and vice versa.
+  `models/w8a8.py` also ships the data-free producer (`quantize_tree_w8a8`,
+  per-out-channel amax scales) used by tests and `scripts/w8a8_parity.py`
+  (same-seed bf16 / w8a16 / w8a8 quality + speed harness); calibrated
+  production artifacts come from the conversion side (te#79).
+
 ## 0.23.0 (2026-07-13)
 
 - **gw#534: fp8 download, bf16 resident — W8A16 layerwise casting is never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.23.0"
+version = "0.24.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/scripts/w8a8_parity.py
+++ b/scripts/w8a8_parity.py
@@ -1,0 +1,166 @@
+"""W8A8 quality-parity + speed harness (gw#534).
+
+Same-seed renders of ONE model three ways on the current GPU:
+  bf16      — plain bf16-resident (the quality reference)
+  w8a16     — fp8-E4M3 storage + per-layer bf16 upcast hooks (today's #fp8 lane)
+  w8a8      — data-free fp8-w8a8 artifact served on torch._scaled_mm
+
+Reports pixel-space deltas (MAE / PSNR, + LPIPS when installed) vs the bf16
+reference and the denoise wall per lane. Proves the SERVE path — the
+conversion-time degradation gate is te#79's, on calibrated artifacts.
+
+Run on a rented SECURE pod (never a dev box):
+  uv run python scripts/w8a8_parity.py --model black-forest-labs/FLUX.2-klein-4B \
+      --steps 8 --size 1024 --out /tmp/parity
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import time
+from pathlib import Path
+
+
+def _mae_psnr(a, b):
+    import numpy as np
+
+    a = a.astype("float32") / 255.0
+    b = b.astype("float32") / 255.0
+    mae = float(np.abs(a - b).mean())
+    mse = float(((a - b) ** 2).mean())
+    psnr = float("inf") if mse == 0 else 10.0 * float(np.log10(1.0 / mse))
+    return mae, psnr
+
+
+def _lpips(a, b):
+    try:
+        import lpips
+        import numpy as np
+        import torch
+    except ImportError:
+        return None
+    loss = lpips.LPIPS(net="alex", verbose=False).cuda()
+    def t(x):
+        v = torch.from_numpy(np.asarray(x)).float().permute(2, 0, 1) / 127.5 - 1.0
+        return v.unsqueeze(0).cuda()
+    with torch.no_grad():
+        return float(loss(t(a), t(b)).item())
+
+
+def _render(pipe, *, prompt: str, seed: int, steps: int, size: int):
+    import numpy as np
+    import torch
+
+    if callable(getattr(pipe, "set_progress_bar_config", None)):
+        pipe.set_progress_bar_config(disable=True)
+    kwargs = dict(prompt=prompt, num_inference_steps=steps,
+                  width=size, height=size,
+                  generator=torch.Generator(device="cuda").manual_seed(seed))
+    pipe(**{**kwargs, "num_inference_steps": 1})  # warmup (allocs, autotune)
+    torch.cuda.synchronize()
+    t0 = time.monotonic()
+    image = pipe(**kwargs).images[0]
+    torch.cuda.synchronize()
+    wall = time.monotonic() - t0
+    return np.asarray(image.convert("RGB")), wall
+
+
+def _free(pipe):
+    import torch
+
+    del pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="HF repo id or local diffusers tree")
+    ap.add_argument("--out", default="/tmp/w8a8-parity")
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--size", type=int, default=1024)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--prompt", default=(
+        "a photo of a red fox standing in a snowy forest clearing, golden hour"))
+    ap.add_argument("--lanes", default="bf16,w8a16,w8a8")
+    args = ap.parse_args()
+
+    import torch
+    from diffusers import DiffusionPipeline
+
+    from gen_worker.models.loading import apply_fp8_storage, load_from_pretrained
+    from gen_worker.models.w8a8 import quantize_tree_w8a8, scaled_mm_supported
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    src = Path(args.model)
+    if not src.is_dir():
+        from huggingface_hub import snapshot_download
+
+        src = Path(snapshot_download(args.model))
+    print(f"snapshot: {src}")
+    print(f"scaled_mm_supported: {scaled_mm_supported()}")
+
+    lanes = [x.strip() for x in args.lanes.split(",") if x.strip()]
+    images: dict = {}
+    walls: dict = {}
+
+    for lane in lanes:
+        print(f"--- lane {lane}")
+        if lane == "bf16":
+            pipe = DiffusionPipeline.from_pretrained(
+                str(src), torch_dtype=torch.bfloat16).to("cuda")
+        elif lane == "w8a16":
+            pipe = DiffusionPipeline.from_pretrained(
+                str(src), torch_dtype=torch.bfloat16)
+            assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16)
+            pipe.to("cuda")
+        elif lane == "w8a8":
+            tree = out / "w8a8-tree"
+            if not tree.exists():
+                quantize_tree_w8a8(src, tree)
+            pipe = load_from_pretrained(DiffusionPipeline, tree)
+            lane_attr = getattr(pipe, "_cozy_weight_lane", "")
+            print(f"w8a8 weight lane: {lane_attr!r}")
+            assert lane_attr == "w8a8", "scaled_mm lane did not engage"
+            pipe.to("cuda")
+        else:
+            raise SystemExit(f"unknown lane {lane}")
+        img, wall = _render(pipe, prompt=args.prompt, seed=args.seed,
+                            steps=args.steps, size=args.size)
+        images[lane] = img
+        walls[lane] = wall
+        from PIL import Image
+
+        Image.fromarray(img).save(out / f"{lane}.png")
+        print(f"{lane}: {wall:.2f}s for {args.steps} steps "
+              f"({wall / args.steps * 1000:.0f} ms/step)")
+        _free(pipe)
+
+    report: dict = {"model": args.model, "steps": args.steps, "size": args.size,
+                    "seed": args.seed, "walls_s": walls, "deltas": {}}
+    ref = images.get("bf16")
+    for lane, img in images.items():
+        if ref is None or lane == "bf16":
+            continue
+        mae, psnr = _mae_psnr(ref, img)
+        d = {"mae": round(mae, 5), "psnr_db": round(psnr, 2)}
+        lp = _lpips(ref, img)
+        if lp is not None:
+            d["lpips"] = round(lp, 4)
+        report["deltas"][lane] = d
+        print(f"{lane} vs bf16: {d}")
+    if "w8a16" in walls and "w8a8" in walls:
+        report["speedup_w8a8_vs_w8a16"] = round(walls["w8a16"] / walls["w8a8"], 3)
+        print(f"speedup w8a8 vs w8a16: {report['speedup_w8a8_vs_w8a16']}x")
+    if "bf16" in walls and "w8a8" in walls:
+        report["speedup_w8a8_vs_bf16"] = round(walls["bf16"] / walls["w8a8"], 3)
+        print(f"speedup w8a8 vs bf16: {report['speedup_w8a8_vs_bf16']}x")
+    (out / "report.json").write_text(json.dumps(report, indent=2))
+    print(f"report: {out / 'report.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1021,6 +1021,24 @@ def load_from_pretrained(
         if components:
             logger.warning("preloaded components ignored on the svdq lane")
         return load_svdq_pipeline(cls, Path(path), svdq_art)
+    # W8A8 fp8-GEMM flavors (gw#534): fp8 weights WITH scales take the
+    # scaled-mm lane (fp8 resident, no per-layer cast); hosts without usable
+    # scaled_mm dequant once to bf16-resident. Precedes the storage-cast
+    # rungs — a scale-free fp8 tree never detects here.
+    from .w8a8 import detect_w8a8_artifact, load_w8a8_pipeline
+
+    w8a8_art = detect_w8a8_artifact(Path(path))
+    if w8a8_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        compute = None
+        if dtype:
+            try:
+                compute = get_torch_dtype(dtype)
+            except ImportError:
+                pass
+        return load_w8a8_pipeline(
+            cls, Path(path), w8a8_art, compute_dtype=compute,
+            components=components,
+        )
     kwargs: Dict[str, Any] = {}
     if components:
         kwargs.update(components)

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -1,0 +1,429 @@
+"""W8A8 fp8-GEMM loader mode (gw#534).
+
+A ``#fp8-w8a8`` flavor is a normal diffusers tree whose denoiser holds
+calibrated fp8-E4M3 weights WITH scales — the artifact contract (frozen in
+gw#534, consumed verbatim by the conversion side):
+
+- per quantized Linear ``L``: ``L.weight`` (F8_E4M3, [out, in]),
+  ``L.weight_scale`` (F32 DEQUANT multiplier — scalar or [out]/[out, 1]
+  per-out-channel), optional ``L.input_scale`` (F32 scalar static activation
+  scale), ``L.bias`` unquantized;
+- excluded layers are stored at full precision with NO scale tensor —
+  detection is per-layer by (fp8 dtype + ``weight_scale`` present), never by
+  name lists;
+- the denoiser's config.json carries
+  ``quantization_config {"quant_method": "modelopt", "quant_algo": "FP8"}``
+  (corroborating; the header evidence above is authoritative).
+
+Execution: quantized Linears become :class:`Fp8ScaledLinear` —
+``torch._scaled_mm`` over RESIDENT fp8 weights (no per-layer upcast: the
+whole point, gw#534 measured the cast tax at +44% H100 / +73% B200), dynamic
+per-row activation quant by default, the static scale when present. Hosts
+without usable scaled_mm (pre-sm89 or missing kernels) DEQUANT once at load
+into plain bf16-resident weights — same numerics, no speed win, never a
+refusal.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import json
+import logging
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+W8A8_FLAVOR = "fp8-w8a8"
+# torch._scaled_mm needs fp8 tensor cores (sm_89 Ada +) and 16-aligned dims.
+W8A8_MIN_SM = 89
+_FP8_MAX = 448.0
+_DIM_ALIGN = 16
+_MAX_HEADER_BYTES = 100 << 20
+_COMPONENT_DIRS = ("transformer", "unet")
+
+
+class W8a8Error(RuntimeError):
+    """Typed w8a8 loader-mode failure."""
+
+
+class W8a8SnapshotError(W8a8Error):
+    """The flavor snapshot violates the artifact contract."""
+
+
+@dataclass(frozen=True)
+class W8a8Artifact:
+    component: str            # denoiser dir name ("transformer"/"unet")
+    files: tuple[Path, ...]   # the component's safetensors shards
+    quantized: tuple[str, ...]  # module names with weight+weight_scale pairs
+    static_input_scales: bool
+
+
+def _read_header(path: Path) -> dict:
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(8)
+            if len(raw) < 8:
+                return {}
+            (n,) = struct.unpack("<Q", raw)
+            if n <= 0 or n > _MAX_HEADER_BYTES:
+                return {}
+            header = json.loads(f.read(n))
+    except (OSError, ValueError):
+        return {}
+    return header if isinstance(header, dict) else {}
+
+
+def detect_w8a8_artifact(model_path: Path) -> Optional[W8a8Artifact]:
+    """Header-sniff a snapshot for the w8a8 contract: any denoiser-dir layer
+    with an F8_E4M3 ``weight`` AND a ``weight_scale`` twin. A scale-FREE fp8
+    tree (the storage-cast ``#fp8`` flavor) never matches — the scales are
+    the distinguisher. Cheap: header reads only."""
+    root = Path(model_path)
+    if not root.is_dir() or not (root / "model_index.json").exists():
+        return None
+    for comp in _COMPONENT_DIRS:
+        comp_dir = root / comp
+        if not comp_dir.is_dir():
+            continue
+        files = tuple(sorted(p for p in comp_dir.glob("*.safetensors") if p.is_file()))
+        if not files:
+            continue
+        dtypes: Dict[str, str] = {}
+        for f in files:
+            for name, info in _read_header(f).items():
+                if isinstance(info, dict) and "dtype" in info:
+                    dtypes[name] = str(info["dtype"])
+        quantized = tuple(sorted(
+            key[: -len(".weight_scale")]
+            for key in dtypes
+            if key.endswith(".weight_scale")
+            and dtypes.get(key[: -len(".weight_scale")] + ".weight") == "F8_E4M3"
+        ))
+        if quantized:
+            static = any(f"{n}.input_scale" in dtypes for n in quantized)
+            return W8a8Artifact(
+                component=comp, files=files, quantized=quantized,
+                static_input_scales=static,
+            )
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def scaled_mm_supported() -> bool:
+    """Live probe: does THIS device run a rowwise-scaled fp8 GEMM? sm gate
+    first (fail-fast on old silicon), then one 16x16 kernel call — torch's
+    scaled-mm backends vary by (torch, cuda, arch), so trusting a version
+    table instead of the device is how mixed fleets break."""
+    try:
+        import torch
+    except ImportError:
+        return False
+    if not torch.cuda.is_available() or not hasattr(torch, "float8_e4m3fn"):
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < W8A8_MIN_SM:
+        return False
+    try:
+        n = _DIM_ALIGN
+        a = torch.randn(n, n, device="cuda").to(torch.float8_e4m3fn)
+        b = torch.randn(n, n, device="cuda").to(torch.float8_e4m3fn)
+        sa = torch.ones(n, 1, device="cuda")
+        sb = torch.ones(1, n, device="cuda")
+        torch._scaled_mm(a, b.t(), scale_a=sa, scale_b=sb,
+                         out_dtype=torch.bfloat16)
+        return True
+    except Exception as exc:  # noqa: BLE001 — any kernel gap => dequant lane
+        logger.warning("w8a8: scaled_mm probe failed (%s); dequant lane", exc)
+        return False
+
+
+def _build_module_class() -> type:
+    """Define the nn.Module lazily so importing this module never needs
+    torch (discovery/CPU tools)."""
+    import torch
+    import torch.nn as nn
+
+    class _Fp8ScaledLinear(nn.Module):
+        """fp8 weights RESIDENT; y = scaled_mm(quant(x), W^T) + bias.
+
+        ``weight_scale`` is the [out, 1] dequant multiplier (per-tensor
+        scalars are expanded at load). Activation quant is per-row dynamic
+        (amax/448) unless a static ``input_scale`` was calibrated. NOTE:
+        never ``.to(dtype=...)`` this module — a dtype cast would upcast the
+        fp8 buffer (device moves are fine)."""
+
+        weight: Any  # fp8 buffer (annotated: Module.__getattr__ unions confuse mypy)
+        weight_scale: Any
+
+        def __init__(self, in_features: int, out_features: int, *,
+                     bias: bool, compute_dtype: Any,
+                     static_input_scale: bool) -> None:
+            super().__init__()
+            self.in_features = int(in_features)
+            self.out_features = int(out_features)
+            meta = torch.device("meta")
+            self.register_buffer("weight", torch.empty(
+                out_features, in_features, dtype=torch.float8_e4m3fn, device=meta))
+            self.register_buffer("weight_scale", torch.empty(
+                out_features, 1, dtype=torch.float32, device=meta))
+            if static_input_scale:
+                self.register_buffer("input_scale", torch.empty(
+                    1, 1, dtype=torch.float32, device=meta))
+            else:
+                self.input_scale = None
+            if bias:
+                self.bias: Optional[nn.Parameter] = nn.Parameter(torch.empty(
+                    out_features, dtype=compute_dtype, device=meta))
+            else:
+                self.bias = None
+
+        def forward(self, x: Any) -> Any:
+            shape = x.shape
+            x2 = x.reshape(-1, self.in_features).contiguous()
+            if self.input_scale is not None:
+                sa = self.input_scale.expand(x2.shape[0], 1).contiguous()
+            else:
+                sa = (x2.abs().amax(dim=-1, keepdim=True).float()
+                      / _FP8_MAX).clamp(min=1e-12)
+            xq = (x2.float() / sa).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+            scaled_mm: Any = torch._scaled_mm
+            y = scaled_mm(
+                xq, self.weight.t(), scale_a=sa, scale_b=self.weight_scale.t(),
+                bias=self.bias, out_dtype=x.dtype,
+            )
+            return y.reshape(*shape[:-1], self.out_features)
+
+        def extra_repr(self) -> str:
+            return (f"in_features={self.in_features}, "
+                    f"out_features={self.out_features}, "
+                    f"bias={self.bias is not None}, "
+                    f"static_input_scale={self.input_scale is not None}")
+
+    return _Fp8ScaledLinear
+
+
+@functools.lru_cache(maxsize=1)
+def fp8_scaled_linear_class() -> type:
+    return _build_module_class()
+
+
+def _scale_2d(scale: Any, out_features: int) -> Any:
+    """Normalize an on-disk weight_scale (scalar / [out] / [out,1]) to the
+    module's [out, 1] float32 buffer shape."""
+    s = scale.float()
+    if s.numel() == 1:
+        return s.reshape(1, 1).expand(out_features, 1).contiguous()
+    if s.numel() != out_features:
+        raise W8a8SnapshotError(
+            f"weight_scale has {s.numel()} values for {out_features} out-channels")
+    return s.reshape(out_features, 1).contiguous()
+
+
+def _denoiser_class(root: Path, component: str) -> Any:
+    index = json.loads((root / "model_index.json").read_text("utf-8"))
+    entry = index.get(component)
+    if not (isinstance(entry, list) and len(entry) == 2):
+        raise W8a8SnapshotError(
+            f"model_index.json has no [library, class] entry for {component!r}")
+    lib, name = str(entry[0]), str(entry[1])
+    try:
+        mod = importlib.import_module(lib)
+    except ImportError:
+        mod = importlib.import_module("diffusers")
+    cls = getattr(mod, name, None)
+    if cls is None:
+        raise W8a8SnapshotError(f"{lib} has no model class {name!r}")
+    return cls
+
+
+def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
+                       compute_dtype: Any = None, mode: str = "") -> Any:
+    """Materialize the quantized denoiser: skeleton on meta, quantized
+    Linears swapped for Fp8ScaledLinear, tensors assigned from the shards.
+    ``mode`` "scaled_mm" | "dequant" (default: probe). Layers whose dims
+    break scaled_mm's 16-alignment are dequantized individually."""
+    import torch
+    import torch.nn as nn
+    from accelerate import init_empty_weights
+    from safetensors.torch import load_file
+
+    compute = compute_dtype or torch.bfloat16
+    if mode not in ("scaled_mm", "dequant"):
+        mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+
+    cls = _denoiser_class(root, art.component)
+    cfg = dict(cls.load_config(str(root / art.component)))
+    cfg.pop("quantization_config", None)
+    with init_empty_weights():
+        model = cls.from_config(cfg)
+
+    sd: Dict[str, Any] = {}
+    for f in art.files:
+        sd.update(load_file(str(f)))
+
+    lin_cls = fp8_scaled_linear_class()
+    swapped = 0
+    for name in art.quantized:
+        w = sd[f"{name}.weight"]
+        scale = sd[f"{name}.weight_scale"]
+        out_f, in_f = int(w.shape[0]), int(w.shape[1])
+        eligible = (mode == "scaled_mm"
+                    and in_f % _DIM_ALIGN == 0 and out_f % _DIM_ALIGN == 0)
+        try:
+            parent_path, _, leaf = name.rpartition(".")
+            parent = model.get_submodule(parent_path) if parent_path else model
+            old = getattr(parent, leaf)
+        except AttributeError as exc:
+            raise W8a8SnapshotError(
+                f"quantized tensor {name!r} has no module in "
+                f"{type(model).__name__}") from exc
+        if eligible and isinstance(old, nn.Linear):
+            has_static = f"{name}.input_scale" in sd
+            new = lin_cls(in_f, out_f, bias=old.bias is not None,
+                          compute_dtype=compute, static_input_scale=has_static)
+            setattr(parent, leaf, new)
+            sd[f"{name}.weight_scale"] = _scale_2d(scale, out_f)
+            if has_static:
+                sd[f"{name}.input_scale"] = (
+                    sd[f"{name}.input_scale"].float().reshape(1, 1))
+            swapped += 1
+        else:
+            # Per-layer dequant: misaligned dims, non-Linear owner, or the
+            # host-wide dequant lane. Same numerics as the artifact.
+            sd[f"{name}.weight"] = (
+                w.float() * _scale_2d(scale, out_f)).to(compute)
+            del sd[f"{name}.weight_scale"]
+            sd.pop(f"{name}.input_scale", None)
+
+    for key, value in list(sd.items()):
+        if value.is_floating_point() and value.dtype not in (
+                torch.float8_e4m3fn,) and not key.endswith(
+                (".weight_scale", ".input_scale")):
+            sd[key] = value.to(compute)
+
+    result = model.load_state_dict(sd, strict=False, assign=True)
+    missing = [k for k in result.missing_keys]
+    if missing or result.unexpected_keys:
+        raise W8a8SnapshotError(
+            f"w8a8 state dict mismatch: missing={missing[:5]} "
+            f"unexpected={list(result.unexpected_keys)[:5]}")
+    model.eval()
+    model._cozy_w8a8_mode = mode
+    logger.info(
+        "w8a8 loader mode: %s — %d/%d quantized Linears on scaled_mm "
+        "(component %s, static input scales: %s)",
+        mode, swapped, len(art.quantized), art.component,
+        art.static_input_scales,
+    )
+    return model
+
+
+def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
+                       compute_dtype: Any = None,
+                       components: Optional[Dict[str, Any]] = None) -> Any:
+    """Build the pipeline with the w8a8 denoiser wired in (svdq-style
+    component injection). Stamps ``_cozy_weight_lane`` ("w8a8" on the
+    scaled_mm lane, "bf16-resident" on the dequant lane) — the compile-cache
+    graph key (lane_drift, gw#534)."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+    denoiser = load_w8a8_denoiser(
+        path, art, compute_dtype=compute, mode=mode)
+    kwargs: Dict[str, Any] = dict(components or {})
+    kwargs[art.component] = denoiser
+    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    try:
+        pipe._cozy_weight_lane = "w8a8" if mode == "scaled_mm" else "bf16-resident"
+    except Exception:
+        pass
+    return pipe
+
+
+# ---------------------------------------------------------------------------
+# Data-free producer — contract round-trips in tests + the parity harness.
+# Production calibrated artifacts come from the conversion side (modelopt,
+# te#79); this writes the identical on-disk contract with per-out-channel
+# amax scales and no calibration.
+# ---------------------------------------------------------------------------
+
+
+def quantize_tree_w8a8(
+    src_tree: Path,
+    out_tree: Path,
+    *,
+    exclude: tuple[str, ...] = ("embed", "norm"),
+) -> Path:
+    """Copy a diffusers tree, rewriting the denoiser's eligible 2D weights to
+    fp8 + per-out-channel ``weight_scale`` per the gw#534 contract. Eligible:
+    ``*.weight``, 2D, bf16/fp16/fp32, both dims 16-aligned, name not matching
+    ``exclude`` substrings."""
+    import shutil
+
+    import torch
+    from safetensors.torch import load_file, save_file
+
+    src_tree, out_tree = Path(src_tree), Path(out_tree)
+    comp = next((c for c in _COMPONENT_DIRS if (src_tree / c).is_dir()), None)
+    if comp is None or not (src_tree / "model_index.json").exists():
+        raise W8a8SnapshotError(f"{src_tree} is not a diffusers tree with a denoiser")
+    if out_tree.exists():
+        shutil.rmtree(out_tree)
+    shutil.copytree(src_tree, out_tree,
+                    ignore=shutil.ignore_patterns("*.safetensors"))
+    for f in sorted(src_tree.rglob("*.safetensors")):
+        rel = f.relative_to(src_tree)
+        dst = out_tree / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if rel.parts[0] != comp:
+            shutil.copy2(f, dst)
+            continue
+        tensors = load_file(str(f))
+        out: Dict[str, Any] = {}
+        quantized = 0
+        for name, t in tensors.items():
+            layer = name[: -len(".weight")] if name.endswith(".weight") else ""
+            if (layer and t.ndim == 2 and t.is_floating_point()
+                    and t.dtype != torch.float8_e4m3fn
+                    and t.shape[0] % _DIM_ALIGN == 0
+                    and t.shape[1] % _DIM_ALIGN == 0
+                    and not any(x in layer for x in exclude)):
+                w = t.float()
+                scale = (w.abs().amax(dim=1, keepdim=True)
+                         / _FP8_MAX).clamp(min=1e-12)
+                out[name] = (w / scale).clamp(
+                    -_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+                out[f"{layer}.weight_scale"] = scale.reshape(-1)
+                quantized += 1
+            else:
+                out[name] = t
+        save_file(out, str(dst), metadata={
+            "quant_scheme": W8A8_FLAVOR, "calibration_corpus": "",
+            "modelopt_version": "",
+        })
+        logger.info("w8a8 producer: %s — %d layers quantized", rel, quantized)
+    cfg_path = out_tree / comp / "config.json"
+    cfg = json.loads(cfg_path.read_text("utf-8")) if cfg_path.exists() else {}
+    cfg["quantization_config"] = {"quant_method": "modelopt", "quant_algo": "FP8"}
+    cfg_path.write_text(json.dumps(cfg, indent=2))
+    return out_tree
+
+
+__all__ = [
+    "W8A8_FLAVOR",
+    "W8A8_MIN_SM",
+    "W8a8Artifact",
+    "W8a8Error",
+    "W8a8SnapshotError",
+    "detect_w8a8_artifact",
+    "fp8_scaled_linear_class",
+    "load_w8a8_denoiser",
+    "load_w8a8_pipeline",
+    "quantize_tree_w8a8",
+    "scaled_mm_supported",
+]

--- a/tests/test_w8a8.py
+++ b/tests/test_w8a8.py
@@ -1,0 +1,225 @@
+"""W8A8 fp8-GEMM loader mode (gw#534) — contract round-trip against a REAL
+tiny diffusers pipeline (no network), detection negatives, lane stamps, and
+scaled_mm numerics on capable GPUs.
+
+CPU lane: the data-free producer writes the exact artifact contract, the
+loader dequants to bf16-resident and must reproduce the source weights to
+fp8 rounding. GPU lane (sm_89+): Fp8ScaledLinear vs the dequant reference,
+and a full pipeline load on the scaled_mm lane.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker.models import w8a8
+from gen_worker.models.loading import load_from_pretrained, pipeline_weight_lane
+from gen_worker.models.w8a8 import (
+    W8A8_FLAVOR,
+    detect_w8a8_artifact,
+    fp8_scaled_linear_class,
+    load_w8a8_pipeline,
+    quantize_tree_w8a8,
+)
+
+
+def _cuda_sm89() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 89
+
+
+@pytest.fixture(scope="module")
+def tiny_ddpm(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("w8a8") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tiny_ddpm: Path) -> Path:
+    return quantize_tree_w8a8(tiny_ddpm, tiny_ddpm.parent / "w8a8")
+
+
+def test_detects_contract_artifact(w8a8_tree: Path) -> None:
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    assert art.component == "unet"
+    assert len(art.quantized) > 0
+    assert all("norm" not in n and "embed" not in n for n in art.quantized)
+    # config corroboration written by the producer
+    cfg = json.loads((w8a8_tree / "unet" / "config.json").read_text())
+    assert cfg["quantization_config"]["quant_algo"] == "FP8"
+
+
+def test_scale_free_fp8_tree_never_detects(tiny_ddpm: Path, tmp_path: Path) -> None:
+    """The storage-cast #fp8 flavor (fp8 bytes, NO scales) must not take the
+    w8a8 lane — the scales are the distinguisher."""
+    import shutil
+
+    from safetensors.torch import load_file, save_file
+
+    cast = tmp_path / "cast"
+    shutil.copytree(tiny_ddpm, cast)
+    for f in (cast / "unet").glob("*.safetensors"):
+        tensors = {
+            k: (v.to(torch.float8_e4m3fn) if v.ndim == 2 and v.is_floating_point() else v)
+            for k, v in load_file(str(f)).items()
+        }
+        save_file(tensors, str(f))
+    assert detect_w8a8_artifact(cast) is None
+    assert detect_w8a8_artifact(tiny_ddpm) is None  # plain bf16/fp32 tree
+
+
+def test_dequant_lane_round_trips_weights(
+    tiny_ddpm: Path, w8a8_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dequant lane (host without scaled_mm): loaded weights reproduce the
+    source to fp8 rounding, lane stamps bf16-resident."""
+    from diffusers import DDPMPipeline, UNet2DModel
+
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
+    assert pipe._cozy_weight_lane == "bf16-resident"
+    assert pipeline_weight_lane(pipe) == ""
+    assert pipe.unet._cozy_w8a8_mode == "dequant"
+
+    ref = UNet2DModel.from_pretrained(str(tiny_ddpm / "unet"))
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    ref_sd = ref.state_dict()
+    got_sd = pipe.unet.state_dict()
+    name = art.quantized[0] + ".weight"
+    a, b = ref_sd[name].float(), got_sd[name].float()
+    rel = ((a - b).abs() / a.abs().clamp(min=1e-3)).max().item()
+    assert rel < 0.13  # e4m3 rounding
+    assert got_sd[name].dtype == torch.bfloat16
+
+
+def test_full_dequant_pipeline_runs_on_cpu(
+    w8a8_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from diffusers import DDPMPipeline
+
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    # fp32 compute: DDPM's output path numpy-converts (no bf16 support there).
+    pipe = load_from_pretrained(DDPMPipeline, w8a8_tree, dtype="fp32")
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)
+
+
+def test_ladder_classifies_w8a8_as_universal_fp8() -> None:
+    from gen_worker.models.ladder import (
+        CLASS_FP8,
+        classify_flavor_token,
+        placement_for_flavor,
+    )
+
+    assert classify_flavor_token(W8A8_FLAVOR) == CLASS_FP8
+    p = placement_for_flavor(W8A8_FLAVOR)
+    assert p is not None
+    assert p.admits_sm(75) and p.admits_sm(89) and p.admits_sm(120)
+
+
+def test_variant_fit_never_refuses_w8a8_on_sm() -> None:
+    from gen_worker.api import Resources
+    from gen_worker.models.hub_policy import (
+        FIT_FP8,
+        TensorhubWorkerCapabilities,
+        variant_fit,
+    )
+
+    class _B:
+        flavor = W8A8_FLAVOR
+
+    caps = TensorhubWorkerCapabilities(
+        cuda_version="12.9", gpu_sm=75, torch_version="2.13", installed_libs=[])
+    fit, _ = variant_fit(Resources(vram_gb=1.0), caps, 20.0, binding=_B())
+    assert fit == FIT_FP8
+
+
+def test_compile_lane_key_separates_w8a8() -> None:
+    from gen_worker.compile_cache import artifact_metadata, lane_drift
+
+    class _P:
+        pass
+
+    w8a8_pipe = _P()
+    w8a8_pipe._cozy_weight_lane = "w8a8"
+    plain = _P()
+    assert lane_drift(artifact_metadata(family="f", weight_lane="w8a8"), w8a8_pipe) == ""
+    assert "weight_lane" in lane_drift(artifact_metadata(family="f"), w8a8_pipe)
+    assert "weight_lane" in lane_drift(
+        artifact_metadata(family="f", weight_lane="w8a8"), plain)
+
+
+# ---------------------------------------------------------------------------
+# GPU lane (sm_89+): numerics + the scaled_mm serve path. Tiny tensors only.
+# ---------------------------------------------------------------------------
+
+gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor cores)")
+
+
+@gpu
+def test_scaled_mm_probe_true_on_capable_gpu() -> None:
+    w8a8.scaled_mm_supported.cache_clear()
+    assert w8a8.scaled_mm_supported() is True
+
+
+@gpu
+def test_fp8_scaled_linear_matches_dequant_reference() -> None:
+    torch.manual_seed(0)
+    lin_cls = fp8_scaled_linear_class()
+    M, K, N = 64, 128, 96
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(N, device="cuda", dtype=torch.bfloat16)
+    scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+
+    mod = lin_cls(K, N, bias=True, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    mod.load_state_dict(
+        {"weight": wq, "weight_scale": scale, "bias": bias}, assign=True)
+    y = mod(x)
+    ref = torch.nn.functional.linear(x, (wq.float() * scale).to(torch.bfloat16), bias)
+    rel = ((y - ref).abs().max() / ref.abs().max()).item()
+    assert rel < 0.06  # dynamic per-row activation quant error only
+
+
+@gpu
+def test_w8a8_pipeline_serves_on_scaled_mm_lane(w8a8_tree: Path) -> None:
+    from diffusers import DDPMPipeline
+
+    w8a8.scaled_mm_supported.cache_clear()
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    # fp16 compute: DDPM's output path numpy-converts (no bf16 support there).
+    pipe = load_w8a8_pipeline(DDPMPipeline, w8a8_tree, art,
+                              compute_dtype=torch.float16)
+    assert pipe._cozy_weight_lane == "w8a8"
+    assert pipeline_weight_lane(pipe) == "w8a8"
+    lin_cls = fp8_scaled_linear_class()
+    swapped = [m for m in pipe.unet.modules() if isinstance(m, lin_cls)]
+    assert swapped, "no Fp8ScaledLinear modules in the denoiser"
+    assert all(m.weight.dtype == torch.float8_e4m3fn for m in swapped)
+    pipe.to("cuda")
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Part 2 of gw#534 — the calibrated-quant serve path (te#79 unblocks on this).

- `models/w8a8.py`: `detect_w8a8_artifact` header-sniffs the frozen gw#534 contract — per-Linear `weight` (F8_E4M3) + `weight_scale` (dequant multiplier, scalar or per-out-channel) + optional static `input_scale`; exclusion by absence. Scale-FREE fp8 trees (the storage-cast `#fp8` flavor) never match.
- `Fp8ScaledLinear`: fp8 weights RESIDENT, `torch._scaled_mm` rowwise (per-row dynamic activation quant; static calibrated scale when present; bias fused). No per-layer upcast — the +44%/+73% cast tax (gw#534 profiles) does not exist on this lane.
- Live device probe (`scaled_mm_supported`, sm_89 gate + one kernel call) decides scaled_mm vs dequant-to-bf16-resident at load; per-layer dequant for 16-misaligned dims. Never a refusal — mixed fleets stay safe.
- `load_w8a8_pipeline`: denoiser built from config on meta, Linears swapped, tensors assigned, injected into the pipeline svdq-style. Wired into `load_from_pretrained` after the svdq lane.
- Compile-cache keying: pipelines stamp `_cozy_weight_lane="w8a8"`; the #246 `lane_drift` parity check keeps W8A8 pipelines off W8A16/bf16-traced graphs (and vice versa) at enable() and executor adoption.
- Data-free producer `quantize_tree_w8a8` (per-out-channel amax scales) — contract round-trip in tests + `scripts/w8a8_parity.py` (same-seed bf16/w8a16/w8a8 quality + speed harness). Calibrated production artifacts stay the conversion/modelopt lane (te#79).
- Tests (`tests/test_w8a8.py`, real tiny DDPM pipeline, no network): contract round-trip through the dequant lane (weights reproduce source to fp8 rounding), detection negatives, ladder/placement pins (`fp8-w8a8` -> CLASS_FP8, universal), compile lane key; GPU lane (skip-clean below sm_89): scaled_mm numerics vs dequant reference, full pipeline render on the scaled_mm lane — verified locally on sm_89.

Suite: 1055 passed; the failing content-lanes/ram-admission/snapshot-corruption tests are pre-existing on master on this box (verified on detached origin/master). mypy/ruff clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)