### PR TITLE
gw#534: Fp8ScaledLinear eager quant without fp32 intermediates; measured H100 numbers (0.24.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.24.1 (2026-07-14)
+
+- **gw#534: Fp8ScaledLinear eager quant without fp32 intermediates.** The
+  activation quant now runs in the compute dtype (reciprocal multiply);
+  the fp32 division path doubled eager activation traffic and made eager
+  w8a8 as slow as the cast hooks it replaces. Measured on H100 SXM
+  (qwen-image DiT 20B, 1024² b=1): eager w8a8 306.2 -> 265.4 ms/forward
+  (eager w8a16 prod lane: 304.8; bf16: 211.9). COMPILED (regional
+  per-block, ie#381 — quant ops fuse, GEMMs run fp8-rate): bf16 163.9 |
+  w8a16 250.8 | **w8a8 142.1 ms/forward — 1.77x vs the compiled W8A16 prod
+  lane, 2.15x vs today's eager prod path, 1.15x over compiled bf16**. The
+  cast tax survives compile on the w8a16 lane (hooks run outside the
+  graphs) — W8A8 is the only fix. Quality parity (same-seed
+  FLUX.2-klein-4B, 1024², vs bf16 reference): w8a8 PSNR 25.02 dB ==
+  w8a16 24.87 dB.
+
 ## 0.24.0 (2026-07-13)
 
 - **gw#534: W8A8 fp8-GEMM loader mode — the calibrated-quant serve path.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.24.0"
+version = "0.24.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -189,7 +189,12 @@ def _build_module_class() -> type:
             else:
                 sa = (x2.abs().amax(dim=-1, keepdim=True).float()
                       / _FP8_MAX).clamp(min=1e-12)
-            xq = (x2.float() / sa).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+            # Quantize in the COMPUTE dtype (reciprocal multiply) — fp32
+            # intermediates here doubled the eager activation traffic and made
+            # eager w8a8 as slow as the cast hooks it replaces (H100 measured;
+            # bf16 mantissa loss is irrelevant next to the fp8 target).
+            xq = (x2 * (1.0 / sa).to(x2.dtype)).clamp(
+                -_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
             scaled_mm: Any = torch._scaled_mm
             y = scaled_mm(
                 xq, self.weight.t(), scale_a=sa, scale_b=self.weight_scale.t(),

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Follow-up to #247 with the H100 validation numbers baked in.

- Activation quant now runs in the compute dtype (reciprocal multiply) — the fp32 division path doubled eager activation traffic and made eager w8a8 as slow as the cast hooks it replaces.

Measured (RunPod SECURE H100 SXM, torch 2.13.0+cu129, qwen-image DiT 20B random-init, 1024² b=1, 512 txt tokens — the gw#534 profile methodology; bf16 211.9ms reproduces the profiled 212.4ms control):

| lane | eager | compiled (regional, ie#381) |
|---|---|---|
| bf16 | 211.9 ms | 163.9 ms |
| w8a16 (prod cast hooks) | 304.8 ms | 250.8 ms |
| w8a8 (scaled_mm) | 306.2 → **265.4 ms** (this PR) | **142.1 ms** |

- Compiled w8a8 = **1.77x vs the compiled W8A16 prod lane, 2.15x vs today's eager prod path, 1.15x over compiled bf16** — cast tax eliminated AND the 2x fp8 GEMM rate cashes in.
- The cast tax SURVIVES compile on w8a16 (163.9→250.8, +53%): the hook upcasts run outside the graphs. W8A8 was the only fix.
- Quality parity (same-seed FLUX.2-klein-4B 1024² vs bf16 reference): w8a8 PSNR 25.02 dB == w8a16 24.87 dB, MAE 0.029 both.

Tests: 10/10 test_w8a8.py (incl. sm89 GPU numerics lane); mypy/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)