### PR TITLE
gw#534: compile-cache cell labels carry the traced weight lane (0.24.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.24.2 (2026-07-14)
+
+- **gw#534: compile-cache cell labels carry the traced weight lane.**
+  `flavor_label(sku, torch, weight_lane)` suffixes non-plain lanes
+  (`-w8a8` for scaled_mm graphs, `-w8a16` for layerwise-cast-hook graphs);
+  plain resident stays unsuffixed. Cells of different lanes are different
+  FX graphs — one label per (family, sku, torch) made a W8A8 cell and a
+  bf16 cell collide in the family repo. `build()` derives the suffix from
+  the loaded pipeline's actual lane. Tensorhub's compilecache.FlavorLabel
+  mirrors byte-compatibly (th#786 companion).
+
 ## 0.24.1 (2026-07-14)
 
 - **gw#534: Fp8ScaledLinear eager quant without fp32 intermediates.** The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.24.1"
+version = "0.24.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -123,11 +123,23 @@ def gen_worker_version() -> str:
         return ""
 
 
-def flavor_label(sku: str, torch_version: str) -> str:
-    """Repo-flavor label for an artifact: ``inductor-rtx-4090-torch2.9``.
-    The full versions live in metadata; the label is for humans + selection."""
+def lane_token(weight_lane: str) -> str:
+    """Label token for a traced weight lane (gw#534): cells of different
+    lanes are DIFFERENT graphs and must not collide on one flavor label.
+    "" (plain resident, incl. bf16-resident) stays unsuffixed."""
+    return {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8"}.get(
+        str(weight_lane or ""), str(weight_lane))
+
+
+def flavor_label(sku: str, torch_version: str, weight_lane: str = "") -> str:
+    """Repo-flavor label for an artifact: ``inductor-rtx-4090-torch2.9`` (+
+    ``-w8a8``/``-w8a16`` for non-plain weight lanes, gw#534). The full
+    versions live in metadata; the label is for humans + selection. MUST stay
+    byte-compatible with tensorhub's compilecache.FlavorLabel."""
     short = ".".join(str(torch_version).split("+")[0].split(".")[:2])
-    return f"inductor-{sku}-torch{short}"
+    label = f"inductor-{sku}-torch{short}"
+    tok = lane_token(weight_lane)
+    return f"{label}-{tok}" if tok else label
 
 
 def system_repo(family: str) -> str:
@@ -906,7 +918,7 @@ def build(
         # have upgraded a requested fp8 cast to bf16-resident on this pod.
         weight_lane=pipeline_weight_lane(pipe),
     )
-    label = flavor_label(meta["sku"], meta["torch"])
+    label = flavor_label(meta["sku"], meta["torch"], meta.get("weight_lane", ""))
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)
     return artifact, meta, timings
 
@@ -930,6 +942,7 @@ __all__ = [
     "gen_worker_version",
     "inductor_counters",
     "is_cache_ref",
+    "lane_token",
     "lane_drift",
     "mode_drift",
     "pack",

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -359,3 +359,15 @@ def test_endpoint_compile_reaches_spec():
         @endpoint(compile="yes")  # type: ignore[arg-type]
         def bad(ctx, p: In) -> Out:
             return Out()
+
+
+def test_flavor_label_carries_weight_lane_gw534() -> None:
+    from gen_worker.compile_cache import flavor_label, is_cache_ref, lane_token
+
+    assert flavor_label("rtx-4090", "2.9.1+cu128") == "inductor-rtx-4090-torch2.9"
+    assert flavor_label("h100-80gb-hbm3", "2.13.0+cu129", "w8a8") == (
+        "inductor-h100-80gb-hbm3-torch2.13-w8a8")
+    assert flavor_label("rtx-4090", "2.9.1", "fp8-hooks") == (
+        "inductor-rtx-4090-torch2.9-w8a16")
+    assert lane_token("") == "" and lane_token("w8a8") == "w8a8"
+    assert is_cache_ref("_system/family-qwen-image#inductor-h100-80gb-hbm3-torch2.13-w8a8")

--- a/uv.lock
+++ b/uv.lock
@@ -579,7 +579,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cells of different weight lanes are different FX graphs — a W8A8-traced cell and a bf16-traced cell for the same (family, sku, torch) collided on one flavor label. `flavor_label` now suffixes non-plain lanes (`-w8a8` scaled_mm graphs / `-w8a16` cast-hook graphs; plain resident unsuffixed, so existing bf16 cell labels are unchanged); `build()` derives the suffix from the loaded pipeline's ACTUAL lane (a w8a8 snapshot auto-loads the scaled_mm lane and stamps `weight_lane`). Worker-side adopt/enable already reject lane drift (#246); the label makes the lanes separately publishable and selectable. Tensorhub `compilecache.FlavorLabel` mirror lands as the th#786 companion; training-endpoints' producer picks the label up from metadata automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)