### PR TITLE
fix: preserve provider pins in slot defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.25.0"
+version = "0.25.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -332,8 +332,8 @@ def _stamp_family(binding_manifest: Dict[str, Any], family: str) -> None:
 
 def _model_ref_to_manifest(ref: Any) -> Dict[str, Any]:
     """``default_checkpoint``/curated-choice ref shape shared by the slots
-    block: ``{source, path, tag?, flavor?, components?}`` — a structured
-    ModelRef (pgw#511; ``components`` added pgw#505)."""
+    block: ``{source, path, tag?, flavor?, revision?, version?, components?}``
+    — a structured ModelRef (pgw#511; ``components`` added pgw#505)."""
     out: Dict[str, Any] = {"source": ref.source, "path": ref.path}
     if ref.tag and ref.tag != "latest":
         out["tag"] = ref.tag
@@ -341,6 +341,10 @@ def _model_ref_to_manifest(ref: Any) -> Dict[str, Any]:
         out["flavor"] = ref.flavor
     if ref.components:
         out["components"] = list(ref.components)
+    if ref.source in ("huggingface", "modelscope") and ref.revision:
+        out["revision"] = ref.revision
+    if ref.source == "civitai" and ref.version:
+        out["version"] = ref.version
     return out
 
 

--- a/tests/test_slot_discovery.py
+++ b/tests/test_slot_discovery.py
@@ -74,6 +74,47 @@ def test_slot_emits_slots_block_not_model_choices(tmp_pkg: Path) -> None:
     assert fn["bindings"]["vae"]["provider"] == "huggingface"
 
 
+def test_slot_preserves_provider_pins_in_binding_and_default(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_slot_pins"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent("""
+        import msgspec
+        from gen_worker import Civitai, HF, ModelScope, RequestContext, Slot, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(models={
+            "pipeline": Slot(object, default_checkpoint=Civitai("827184", version="2883731")),
+            "hf": Slot(object, default_checkpoint=HF("owner/repo", revision="deadbeef")),
+            "modelscope": Slot(object, default_checkpoint=ModelScope("owner/repo", revision="v1")),
+        })
+        class Gen:
+            def setup(self, pipeline: object, hf: object, modelscope: object) -> None: ...
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="ok")
+    """))
+
+    (fn,) = discover_functions(tmp_pkg, main_module="ep_slot_pins.main")
+    slots = {slot["name"]: slot for slot in fn["slots"]}
+
+    assert fn["bindings"]["pipeline"]["ref"] == "827184"
+    assert fn["bindings"]["pipeline"]["version"] == "2883731"
+    assert slots["pipeline"]["default_checkpoint"] == {
+        "source": "civitai", "path": "827184", "version": "2883731",
+    }
+    assert fn["bindings"]["hf"]["revision"] == "deadbeef"
+    assert slots["hf"]["default_checkpoint"]["revision"] == "deadbeef"
+    assert fn["bindings"]["modelscope"]["revision"] == "v1"
+    assert slots["modelscope"]["default_checkpoint"]["revision"] == "v1"
+
+
 def test_slot_with_no_selected_by_or_default_emits_minimal_block(tmp_pkg: Path) -> None:
     from gen_worker.discovery.discover import discover_functions
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What changed

- Preserve Civitai `version` in `slots[].default_checkpoint`.
- Preserve Hugging Face and ModelScope `revision` in `slots[].default_checkpoint`.
- Add an end-to-end discovery contract test covering the binding and slot-default representations.
- Bump `gen-worker` to 0.25.1.

## Why

The binding serializer already emitted provider-specific immutable pins, but the slot-default serializer dropped them. Tensorhub therefore received a pinned function binding alongside an unpinned default checkpoint, which could mirror or resolve a different upstream model version.

## Impact

First-publish slot seeding and runtime fallback now refer to the same immutable upstream artifact.

## Validation

- `uv lock --check`
- `mypy src/gen_worker` — 114 files clean
- `pytest tests/test_slot_discovery.py tests/test_drain_flush.py -q` — 10 passed
- CPU-equivalent full suite — 1,057 passed, 26 skipped
- `uv build` — sdist and wheel built successfully