### PR TITLE
Fix discovery and video fallbacks for 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.26.1 (2026-07-14)
+
+- **NVENC per-request fallback recreates the PyAV output container.** A
+  hardware stream that failed during codec open remained attached to the
+  original container, so mux startup retried that orphan and failed even
+  after adding libx264. The fallback now starts with a clean container.
+- **Discovery stubs no longer poison later optional-dependency probes.** A
+  missing heavy module remains usable through its returned stub reference,
+  but is removed from `sys.modules` immediately so `find_spec()` stays honest.
+
 ## 0.26.0 (2026-07-14)
 
 - **Model residency is declarative.** Protocol v3 replaces ordinary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.0"
+version = "0.26.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/discovery/heavy_deps.py
+++ b/src/gen_worker/discovery/heavy_deps.py
@@ -165,6 +165,16 @@ def stub_missing_heavy_deps(extra: Iterable[str] = ()) -> Iterator[frozenset[str
                 sys.meta_path.remove(finder)
             except ValueError:
                 pass
+            # Keep later optional-dependency probes honest. A retained stub
+            # makes find_spec(root) report installed even though package
+            # metadata correctly has no matching distribution.
+            for module_name in [
+                n
+                for n, module in sys.modules.items()
+                if isinstance(module, _HeavyDepStub)
+                and n.split(".", 1)[0] == root
+            ]:
+                del sys.modules[module_name]
 
     builtins.__import__ = _import
     try:

--- a/src/gen_worker/video_encode.py
+++ b/src/gen_worker/video_encode.py
@@ -257,6 +257,14 @@ class StreamingVideoEncoder:
                 "hardware encoder %s failed to open (%s: %s); "
                 "falling back to libx264 for this encode",
                 self._encoder.codec, type(exc).__name__, exc)
+            # add_stream() leaves the failed hardware stream attached. A
+            # second stream in that container makes PyAV retry the orphan
+            # when muxing starts, so the advertised fallback fails too.
+            try:
+                self._container.close()
+            except Exception:
+                logger.debug("failed hardware encoder container close", exc_info=True)
+            self._container = av.open(self._path, mode="w")
             self._encoder = _x264()
             self._stream = self._add_video_stream(self._encoder, width, height)
         if self._sample_rate:

--- a/tests/test_discovery_heavy_deps.py
+++ b/tests/test_discovery_heavy_deps.py
@@ -114,6 +114,9 @@ def test_find_spec_probes_stay_honest() -> None:
     # is find_spec-only) must NOT see a missing dep as installed — a fooled
     # probe unlocks module-scope use of the dep in library code.
     with stub_missing_heavy_deps(extra=(FAKE,)):
+        stub = _stmt_import(f"import {FAKE}")[FAKE]
+        assert isinstance(stub, _HeavyDepStub)
+        assert FAKE not in sys.modules
         assert importlib.util.find_spec(FAKE) is None
         with pytest.raises(ModuleNotFoundError):
             importlib.import_module(FAKE)  # programmatic probe, not stubbed
@@ -147,7 +150,8 @@ def test_stubs_removed_on_exit() -> None:
     before_import = builtins.__import__
     with stub_missing_heavy_deps(extra=(FAKE,)):
         _stmt_import(f"import {FAKE}.nn")
-        assert FAKE in sys.modules
+        assert FAKE not in sys.modules
+        assert f"{FAKE}.nn" not in sys.modules
     assert builtins.__import__ is before_import
     assert FAKE not in sys.modules
     assert f"{FAKE}.nn" not in sys.modules

--- a/tests/test_video_encode.py
+++ b/tests/test_video_encode.py
@@ -89,6 +89,33 @@ def test_hardware_open_failure_falls_back_per_encode(tmp_path, monkeypatch) -> N
     assert _decode_frame_count(str(out)) == 4
 
 
+def test_hardware_stream_open_failure_recreates_container(tmp_path, monkeypatch) -> None:
+    """A stream can be added before NVENC refuses to open. The orphan must
+    not ride into the software fallback container and fail again at mux."""
+    out = tmp_path / "fallback-after-stream.mp4"
+    enc = ve.StreamingVideoEncoder(
+        out,
+        fps=24,
+        encoder=ve.EncoderChoice("h264_nvenc", {}, hardware=True),
+    )
+    containers = []
+    real_add = enc._add_video_stream
+
+    def fail_hardware_then_add_software(choice, width, height):
+        containers.append(enc._container)
+        if choice.hardware:
+            raise RuntimeError("NVENC session exhausted after add_stream")
+        return real_add(choice, width, height)
+
+    monkeypatch.setattr(enc, "_add_video_stream", fail_hardware_then_add_software)
+    enc.add(_frames(count=4))
+    enc.finish()
+
+    assert containers[0] is not containers[1]
+    assert enc.encoder.codec == "libx264"
+    assert _decode_frame_count(str(out)) == 4
+
+
 # ---- streaming encoder -------------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What changed

- recreate the PyAV output container when per-request NVENC open fails before falling back to libx264
- remove transient missing-heavy-dependency stubs from `sys.modules` after each import so later optional `find_spec()` probes stay honest
- release as `gen-worker 0.26.1`

## Root causes

PyAV retained a failed hardware stream in the original container, so mux startup retried it even after a software stream was added. Discovery similarly retained a synthetic `flash_attn` module long enough for Transformers to misclassify it as installed while distribution metadata correctly had no entry.

## Validation

- `uv run --locked --extra dev pytest tests/ -q` — 1075 passed, 23 skipped
- focused video/discovery tests — 40 passed
- `uv run --locked --extra dev mypy src/gen_worker` — 0 errors
- focused Ruff — clean
- `uv build` — wheel and sdist built
- real image-LoRA DiffSynth -> PEFT -> Transformers 5.5.3 discovery — passed on torch 2.13.0+cu130 / CUDA 13.0