### PR TITLE
Fix duplicate Civitai weight selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.1"
+version = "0.26.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -788,8 +788,10 @@ def _civitai_select_files(
 ) -> list[dict[str, Any]]:
     """Downloadable weight files of a model version, primary first.
 
-    Safetensors files win when present (unchanged behavior). GGUF-only
-    versions (th#611: klein/qwen fine-tunes published only as quants)
+    Safetensors files win when present. Civitai may publish alternative
+    precisions under the same filename; keep the primary/first alternative
+    once so a later variant cannot overwrite it on disk. GGUF-only versions
+    (th#611: klein/qwen fine-tunes published only as quants)
     select exactly ONE gguf — civitai reuses a single filename across
     quantType variants, so downloading several would collide on disk:
     ``gguf_quant`` picks it explicitly, else the preference order applies.
@@ -809,7 +811,10 @@ def _civitai_select_files(
             gg.append(entry)
     if st:
         st.sort(key=lambda f: (0 if f["primary"] else 1, f["id"], f["name"]))
-        return st
+        unique: dict[str, dict[str, Any]] = {}
+        for f in st:
+            unique.setdefault(f["name"], f)
+        return list(unique.values())
     if not gg:
         return []
     gg.sort(key=lambda f: (f["id"], f["name"]))

--- a/tests/convert/test_civitai_gguf_select.py
+++ b/tests/convert/test_civitai_gguf_select.py
@@ -35,6 +35,18 @@ def test_safetensors_win_over_gguf():
     assert [f["name"] for f in files] == ["model.safetensors"]
 
 
+def test_safetensors_same_name_keeps_primary_without_dropping_distinct_files():
+    files = _civitai_select_files({"files": [
+        _f("model.safetensors", id=2),
+        _f("text_encoder.safetensors", id=3),
+        _f("model.safetensors", id=1, primary=True),
+    ]})
+    assert [(f["id"], f["name"]) for f in files] == [
+        (1, "model.safetensors"),
+        (3, "text_encoder.safetensors"),
+    ]
+
+
 def test_gguf_only_picks_one_by_preference():
     files = _civitai_select_files({"files": [
         _f("m.gguf", id=1, quant="Q5_K_M"),

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What changed

- De-duplicate Civitai safetensors entries that share a destination filename, preserving primary-first selection.
- Preserve distinct filenames for genuine multi-file bundles.
- Add regression coverage and bump the package to 0.26.2.

## Why

Civitai model version 2884631 advertises an fp16 primary and fp32 alternative under the same filename. The worker planned and downloaded both, overwrote the first with the second, and inflated disk preflight from about 18.2 GiB to 50.5 GiB. This made the live recovery ingest fail on a 10 GiB CPU pod before any CAS publish.

## Validation

- `uv run --no-sync pytest -q tests/convert/test_civitai_gguf_select.py -k 'not ingest_civitai_gguf_classification' tests/convert/test_download_skip.py` — 20 passed, 1 deselected.
- Live Civitai metadata for model version 2884631 selects one primary file: 6,938,041,288 bytes.
- Ruff on both touched Python files, HTTP-timeout guard, `git diff --check`, and `uv build --offline` pass.

## Existing baseline failures

Untouched `origin/master` already has one GGUF fixture failure, five mypy errors, and `uv sync --locked --extra dev` currently fails because the mutable `torch==2.13.0+cu130` wheel no longer matches the hashes recorded in `uv.lock`. This PR does not touch those paths or dependency hashes.