### PR TITLE
Serialize model loads across reconcile cancellation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.3"
+version = "0.26.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -86,6 +86,25 @@ _CONTEXT_BY_KIND: Dict[str, type] = {
 logger = logging.getLogger(__name__)
 
 INLINE_RESULT_MAX_BYTES = 64 * 1024
+
+
+async def _to_thread_complete(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Join after cancellation: ``to_thread`` itself cannot be cancelled.
+
+    Diffusers/Accelerate mutate process-global meta-device hooks while loading,
+    so a surrounding model-load lock must outlive the worker thread.
+    """
+    work = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+    try:
+        return await asyncio.shield(work)
+    except asyncio.CancelledError:
+        try:
+            await work
+        except BaseException:
+            pass
+        raise
+
+
 # ctx.progress/log/checkpoint events ride the JobProgress stream; the hub fans
 # them to /v1/requests/:id/events SSE as output.delta envelopes whose
 # payload.delta carries this JSON verbatim (th#640).
@@ -1729,7 +1748,7 @@ class Executor:
                     if asyncio.iscoroutinefunction(setup):
                         await setup(**inj.kwargs)
                     else:
-                        await asyncio.to_thread(setup, **inj.kwargs)
+                        await _to_thread_complete(setup, **inj.kwargs)
             warmup = getattr(instance, "warmup", None)
             if callable(warmup):
                 from . import compile_cache
@@ -1739,7 +1758,7 @@ class Executor:
                 if asyncio.iscoroutinefunction(warmup):
                     await warmup()
                 else:
-                    await asyncio.to_thread(warmup)
+                    await _to_thread_complete(warmup)
                 if spec.compile is not None:
                     stats = compile_cache.counters_delta(
                         counters_before, compile_cache.inductor_counters())
@@ -2124,10 +2143,10 @@ class Executor:
                     excl_bytes = sum(
                         b for comp, b in sizes.items() if comp not in injected)
                     if excl_bytes > 0:
-                        await asyncio.to_thread(res.make_room, excl_bytes)
+                        await _to_thread_complete(res.make_room, excl_bytes)
                 before = self._vram_allocated()
                 try:
-                    sl = await asyncio.to_thread(
+                    sl = await _to_thread_complete(
                         provision.load_slot, ann, path, binding=binding,
                         slot=slot, ref=ref, mode=mode, components=injected,
                     )
@@ -2149,7 +2168,7 @@ class Executor:
                     )
                     path = str(fresh)
                     paths[slot] = path
-                    sl = await asyncio.to_thread(
+                    sl = await _to_thread_complete(
                         provision.load_slot, ann, path, binding=binding,
                         slot=slot, ref=ref, mode=mode, components=injected,
                     )
@@ -2189,7 +2208,7 @@ class Executor:
                     # a TRT engine (#390, refit with this pipeline's weights)
                     # or an inductor cache (#384). No verified artifact =>
                     # stays eager. ``compile_artifact`` is hub-attached (#569).
-                    await asyncio.to_thread(
+                    await _to_thread_complete(
                         self._enable_compiled, pipe, spec.compile, compile_artifact,
                     )
                 delta = max(0, self._vram_allocated() - before)

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1180,6 +1180,14 @@ def load_from_pretrained(
             kwargs.pop("variant", None)
             kwargs.pop("quantization_config", None)
             pipe = cls.from_pretrained(path, **kwargs)
+    from .memory import meta_tensors
+
+    unmaterialized = meta_tensors(pipe)
+    if unmaterialized:
+        raise RuntimeError(
+            f"{type(pipe).__name__} load left {len(unmaterialized)} "
+            f"unmaterialized meta tensors (e.g. {unmaterialized[:3]})"
+        )
     if fp8_storage and "quantization_config" not in kwargs:
         applied = apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"),
                                     text_encoders=fp8_text_encoders)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -394,6 +394,15 @@ def device_mismatches(obj: Any, device: str) -> List[tuple[str, str, str]]:
     return out
 
 
+def meta_tensors(obj: Any) -> List[tuple[str, str]]:
+    """Parameters/buffers left unmaterialized by a failed low-memory load."""
+    return [
+        (component, name)
+        for component, name, device in device_mismatches(obj, "cpu")
+        if device == "meta"
+    ]
+
+
 def repair_device_placement(obj: Any, device: str) -> List[tuple[str, str, str]]:
     """Targeted ``.to(device)`` on each component holding off-device tensors,
     then re-walk. Returns the remaining mismatches ([] = fully repaired)."""
@@ -778,12 +787,7 @@ def place_pipeline(
     while True:
         try:
             if effective in ("off", "vae_only") and callable(getattr(pipeline, "to", None)):
-                try:
-                    pipeline.to("cuda")
-                except BaseException as exc:
-                    if is_cuda_oom(exc):
-                        raise
-                    log.warning("place_pipeline: .to('cuda') failed: %s", exc)
+                pipeline.to("cuda")
             applied = apply_low_vram_config(pipeline, mode=effective, logger=log)
             if demotions:
                 applied["oom_demotions"] = demotions

--- a/tests/test_declarative_residency.py
+++ b/tests/test_declarative_residency.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import threading
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from gen_worker.api.slot import Slot
 from gen_worker.executor import Executor
 from gen_worker.families.base import FamilyDefaults, family
 from gen_worker.lifecycle import Lifecycle
+from gen_worker.models import provision
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
 
@@ -26,7 +28,9 @@ class _Defaults(FamilyDefaults):
 
 
 class _Pipeline:
-    pass
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs: Any) -> "_Pipeline":
+        return cls()
 
 
 class _Input(msgspec.Struct):
@@ -37,7 +41,7 @@ def _spec() -> EndpointSpec:
     default = Civitai("827184", version="2883731")
 
     class Endpoint:
-        def setup(self, pipeline: str) -> None:  # pragma: no cover - replaced in tests
+        def setup(self, pipeline: _Pipeline) -> None:  # pragma: no cover - replaced in tests
             self.pipeline = pipeline
 
         def generate(self, ctx: Any, payload: _Input) -> dict:  # pragma: no cover
@@ -298,5 +302,79 @@ def test_run_job_preempts_then_resumes_current_desired_state(monkeypatch) -> Non
         executor._idle.set()
         await resumed.wait()
         assert calls == 2, "current desired state must resume after the job becomes idle"
+
+    asyncio.run(run())
+
+
+def test_run_job_cancellation_waits_for_model_load_thread(monkeypatch, tmp_path: Path) -> None:
+    async def run() -> None:
+        lifecycle, executor, _ = _lifecycle()
+        load_started = threading.Event()
+        release_load = threading.Event()
+        second_load_done = threading.Event()
+        counter_lock = threading.Lock()
+        active = 0
+        max_active = 0
+        calls = 0
+
+        async def ensure_local(ref: str, snapshot=None, *, binding=None):
+            return tmp_path
+
+        def load_slot(*args, **kwargs):
+            nonlocal active, max_active, calls
+            with counter_lock:
+                active += 1
+                max_active = max(max_active, active)
+                calls += 1
+                call = calls
+            try:
+                load_started.set()
+                assert release_load.wait(2), "test model load was never released"
+                return provision.SlotLoad(
+                    obj=_Pipeline(), is_pipeline=True, placed={"mode": "cpu"}
+                )
+            finally:
+                with counter_lock:
+                    active -= 1
+                if call == 2:
+                    second_load_done.set()
+
+        request_acquired_load_lock = asyncio.Event()
+
+        async def handle_run_job(run_job: pb.RunJob) -> None:
+            async with executor._load_lock:
+                request_acquired_load_lock.set()
+
+        monkeypatch.setattr(executor.store, "ensure_local", ensure_local)
+        monkeypatch.setattr(executor, "handle_run_job", handle_run_job)
+        monkeypatch.setattr(provision, "load_slot", load_slot)
+
+        picked = "tensorhub/cyberrealistic-pony:prod"
+        await lifecycle.on_hello_ack(pb.HelloAck(
+            desired_residency=pb.DesiredResidency(
+                generation=1,
+                hot=[pb.DesiredInstance(
+                    function_name="generate",
+                    models=[pb.ModelBinding(slot="pipeline", ref=picked)],
+                )],
+            )
+        ))
+        assert await asyncio.to_thread(load_started.wait, 2)
+
+        request = asyncio.create_task(lifecycle.on_message(pb.SchedulerMessage(
+            run_job=pb.RunJob(
+                request_id="request", attempt=1, function_name="generate",
+                models=[pb.ModelBinding(slot="pipeline", ref=picked)],
+            )
+        )))
+        await asyncio.sleep(0.05)
+        assert not request_acquired_load_lock.is_set()
+
+        release_load.set()
+        await asyncio.wait_for(request, 2)
+        assert request_acquired_load_lock.is_set()
+        assert await asyncio.to_thread(second_load_done.wait, 2)
+        assert max_active == 1
+        lifecycle._cancel_residency_reconcile()
 
     asyncio.run(run())

--- a/tests/test_gate_and_single_file.py
+++ b/tests/test_gate_and_single_file.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import msgspec
+import pytest
 
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
@@ -186,6 +187,27 @@ def test_load_from_pretrained_routes_single_file(tmp_path: Path) -> None:
     assert isinstance(out, FakePipeline)
     assert calls["path"] == str(ckpt)
     assert "variant" not in calls["kwargs"]
+
+
+def test_single_file_load_rejects_unmaterialized_meta_tensors(tmp_path: Path) -> None:
+    torch = pytest.importorskip("torch")
+    ckpt = tmp_path / "model.safetensors"
+    ckpt.write_bytes(b"stub")
+
+    class FakePipeline:
+        def __init__(self):
+            self.components = {"unet": torch.nn.Linear(1, 1, device="meta")}
+
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):  # pragma: no cover
+            raise AssertionError("single-file snapshot must not use from_pretrained")
+
+        @classmethod
+        def from_single_file(cls, path, **kwargs):
+            return cls()
+
+    with pytest.raises(RuntimeError, match="unmaterialized meta tensors"):
+        load_from_pretrained(FakePipeline, tmp_path, dtype="fp16")
 
 
 def test_load_from_pretrained_still_uses_pretrained_for_layouts(tmp_path: Path) -> None:

--- a/tests/test_oom_degraded_ladder.py
+++ b/tests/test_oom_degraded_ladder.py
@@ -152,6 +152,17 @@ def test_load_oom_demotes_to_model_offload(shim_env, caplog) -> None:
     assert "needed_gb=" in line and "free_gb=" in line
 
 
+def test_load_non_oom_placement_failure_propagates(shim_env, monkeypatch) -> None:
+    pipe = ShimPipe.from_pretrained(str(shim_env))
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("Cannot copy out of meta tensor; no data!")
+
+    monkeypatch.setattr(pipe, "to", fail)
+    with pytest.raises(RuntimeError, match="meta tensor"):
+        memory.place_pipeline(pipe, ref="acme/broken")
+
+
 def test_planned_offload_skips_doomed_resident_attempt(shim_env) -> None:
     pipe = ShimPipe.from_pretrained(str(shim_env))
     applied = memory.place_pipeline(pipe, mode="model_offload", ref="acme/tiny")

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.3"
+version = "0.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What changed

- wait for blocking model-load, synchronous setup, warmup, and compile threads to finish before cancellation can release the serialized load lane
- reject pipelines that still contain unmaterialized `meta` parameters or buffers
- propagate non-OOM CUDA placement failures instead of advertising the pipeline ready
- bump `gen-worker` to 0.26.4

## Root cause

Cancelling declarative hot-residency reconciliation cancelled only the awaiting coroutine; `asyncio.to_thread()` kept the Diffusers load running after `_load_lock` was released. A request could then start a second load concurrently. Diffusers/Accelerate mutate process-global meta-device hooks while constructing models, so the overlap left tensors on `meta`. Placement then swallowed the resulting non-OOM `.to("cuda")` exception and registered the broken pipeline as ready.

## Impact

Tenant requests wait for an already-started background load thread to leave the critical section before loading. A partially materialized pipeline can no longer be reported ready.

## Validation

- focused regressions: 32 passed
- `mypy src/gen_worker`: clean (114 modules)
- `ruff check src/gen_worker`: passed
- HTTP timeout guard: passed
- `uv build`: built 0.26.4 sdist and wheel
- full local suite: 1081 passed, 13 skipped; the sole failure is an existing CUDA-only content-lane budget assertion that also fails unchanged on `origin/master` on this host