### PR TITLE
fix: quarantine OOM model residency transitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.4"
+version = "0.26.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -56,6 +56,8 @@ from .models.memory import (
     get_available_ram_gb,
     get_available_vram_gb,
     is_cuda_oom,
+    low_vram_mode,
+    next_offload_rung,
 )
 from .models.cache_paths import tensorhub_cas_dir
 from .models.download import ensure_local, lookup_provider_for_ref
@@ -1143,6 +1145,10 @@ class Executor:
         # th#683 P3: how each serveable function will run on the actual card
         # (native / emergency / offload / cpu) + honest-guidance advisory.
         self.serve_plans: Dict[str, "ServePlan"] = {}
+        # Gate-time placement is immutable between hardware re-gates. Runtime
+        # degradation updates serve_plans for FnDegraded telemetry, but must
+        # not force an unrelated dynamic model pick down the same rung.
+        self._gate_serve_plans: Dict[str, "ServePlan"] = {}
         # gw#463: learned degraded floor per model ref — "this model+GPU
         # needed offload mode X". In-process only; consulted at every load so
         # a doomed fully-resident attempt is never paid twice (ie#369).
@@ -1348,6 +1354,7 @@ class Executor:
             primary = next(iter(spec.models.values()), None)
             plan = plan_serve(r, caps, free_vram_gb, binding=primary)
             self.serve_plans[name] = plan
+            self._gate_serve_plans[name] = plan
             if not plan.serveable:
                 if plan.run_mode in (RUN_CPU, RUN_OFFLOAD):
                     # The author's strict_vram opt-out of the CPU-touching
@@ -1927,10 +1934,18 @@ class Executor:
         from a prior load, else the endpoint's declared vram_gb."""
         res = self.store.residency
         refs = [wire_ref(spec.models[s]) for s in setup_slots]
-        needed = sum(res.vram_hint(r) for r in refs)
-        if needed <= 0 and spec.resources.vram_gb:
-            needed = int(float(spec.resources.vram_gb) * _GiB)
+        hints = [res.vram_hint(r) for r in refs]
+        needed = sum(hints)
+        # A partially-known set is still an unknown load. Live SDXL exposed
+        # the old sum-only bug: the fixed VAE had a small prior hint while a
+        # never-seen checkpoint had none, so admission reserved only the VAE
+        # and loaded a ~10GiB pipeline into an occupied 24GiB card.
+        if any(h <= 0 for h in hints) and spec.resources.vram_gb:
+            needed = max(needed, int(float(spec.resources.vram_gb) * _GiB))
         if needed <= 0:
+            return
+        # CPU-only workers do not have a VRAM tier to admit against.
+        if torch is None or not torch.cuda.is_available():
             return
         if await asyncio.to_thread(res.make_room, needed):
             self._on_state_change()
@@ -1943,8 +1958,31 @@ class Executor:
                 continue
             await self._vacate_record(rec)
             if await asyncio.to_thread(res.make_room, needed):
-                break
+                self._on_state_change()
+                return
+        # No arbitrary refusal at the recommendation boundary: vram_gb names
+        # a target card, not a hard free-byte requirement. If pinned work
+        # prevents full headroom, the freshly materialized pipeline's exact
+        # size drives place_pipeline's offload decision before any CUDA move.
         self._on_state_change()
+
+    def _placement_mode(self, spec: EndpointSpec, ref: str) -> str:
+        """Placement for one concrete model ref on this worker.
+
+        The hardware gate is function-wide and stable. Reactive OOM floors
+        are ref-specific: one large or malformed dynamic pick must never
+        spill every sibling pick to CPU offload.
+        """
+        from .models.serve_fit import RUN_OFFLOAD
+
+        plan = self._gate_serve_plans.get(spec.name)
+        mode = "model_offload" if (
+            plan is not None and plan.run_mode == RUN_OFFLOAD
+        ) else "auto"
+        floor = self.degraded_floor.get(ref, "")
+        if floor:
+            mode = deeper_offload_mode("" if mode == "auto" else mode, floor)
+        return mode
 
     @staticmethod
     def _setup_slots(spec: EndpointSpec) -> List[str]:
@@ -2105,16 +2143,8 @@ class Executor:
                 # pick the starting rung so a doomed fully-resident attempt
                 # is never paid (gw#463 / ie#369); a CUDA OOM inside is a
                 # ladder transition, not a failure.
-                from .models.serve_fit import RUN_OFFLOAD
-
                 ref = wire_ref(binding) if binding is not None else ""
-                plan = self.serve_plans.get(spec.name)
-                mode = "model_offload" if (
-                    plan is not None and plan.run_mode == RUN_OFFLOAD
-                ) else "auto"
-                floor = self.degraded_floor.get(ref, "")
-                if floor:
-                    mode = deeper_offload_mode("" if mode == "auto" else mode, floor)
+                mode = self._placement_mode(spec, ref)
                 slot_share = dict((share_plan or {}).get(slot) or {})
                 if slot_share and mode != "auto":
                     # Offload hooks on a shared module would poison sibling
@@ -2827,13 +2857,11 @@ class Executor:
                         output = await self._execute(job, spec, instance, ctx, payload, kwargs,
                                                      timeout_ms=timeout_ms, gpu_index=gpu_index)
                     except BaseException as exc:
-                        # Mid-inference CUDA OOM is a ladder transition, not a
-                        # request killer (gw#463): demote to the offload rung
-                        # and retry this request ONCE in degraded mode.
-                        if not await self._enter_degraded_for_oom(spec, ctx, exc):
-                            raise
-                        output = await self._execute(job, spec, instance, ctx, payload, kwargs,
-                                                     timeout_ms=timeout_ms, gpu_index=gpu_index)
+                        # A mid-inference CUDA OOM learns a per-ref floor, but
+                        # the live object is quarantined. The hub retries only
+                        # after ensure_setup reloads it cleanly at that rung.
+                        await self._quarantine_for_oom(spec, ctx, exc)
+                        raise
                 finally:
                     # Guaranteed-inactive on every exit (OK / cancel /
                     # deadline / handler error); attachments stay resident.
@@ -3024,76 +3052,76 @@ class Executor:
             )
         return pipe
 
-    async def _enter_degraded_for_oom(
+    async def _quarantine_for_oom(
         self, spec: EndpointSpec, ctx: RequestContext, exc: BaseException,
-    ) -> bool:
-        """Mid-inference CUDA OOM -> degraded-mode ladder transition (gw#463).
+    ) -> None:
+        """Quarantine an OOM'd instance and learn its next placement rung.
 
-        Flushes the CUDA cache, demotes this function's worker-owned resident
-        pipelines one offload rung (sticky until reload), records + reports
-        the demotion. True when the request should retry once in degraded
-        mode; False re-raises the original failure.
+        Diffusers offload hooks are setup-time state. Attaching them to a
+        fully resident pipeline after a mid-denoise OOM can leave CPU/CUDA
+        tensors mixed while Residency still advertises VRAM. Do not reuse or
+        retry that object in-process: mark its record stale, let the current
+        OOM return RETRYABLE, then reload cleanly at the learned per-ref rung
+        when the hub dispatches the retry.
+
         """
         if not is_cuda_oom(exc) or getattr(ctx, "cancelled", False):
-            return False
+            return
         if spec.kind != "inference":
             # Producer jobs (training/conversion) must surface RETRYABLE to
             # the hub — an in-process whole-job replay would redo hours of
             # work the hub can resume from a checkpoint instead.
-            return False
+            return
         if spec.output_mode == "stream":
-            return False  # chunks already emitted; a replay would duplicate them
-        pipes: List[Tuple[str, Any]] = []
+            return  # chunks already emitted; a replay would duplicate them
+        transitions: List[Tuple[str, str, str, float]] = []
         for slot in spec.models:
             ref = wire_ref(spec.models[slot])
             obj = self.store.residency.obj(ref)
-            if obj is not None:
-                pipes.append((ref, obj))
-        demotions = await asyncio.to_thread(self._demote_pipelines, pipes)
-        if pipes and not demotions:
-            return False  # every pipeline already terminal — degraded failed too
-        for ref, from_mode, to_mode, needed_gb in demotions:
+            if obj is None:
+                continue
+            # Component modules (for example a separately injected VAE) do
+            # not own a Diffusers offload surface. The enclosing pipeline is
+            # the transition owner; assigning a fake floor to the component
+            # would only poison its next load.
+            if not any(callable(getattr(obj, name, None)) for name in (
+                "enable_model_cpu_offload",
+                "enable_group_offload",
+                "enable_sequential_cpu_offload",
+            )):
+                continue
+            before = low_vram_mode(obj)
+            after = next_offload_rung(before)
+            if after is not None:
+                transitions.append(
+                    (ref, before, after, estimate_pipeline_size_gb(obj))
+                )
+        for ref, from_mode, to_mode, needed_gb in transitions:
             self._record_demotion(
                 spec, ref=ref, phase="inference",
                 from_rung=from_mode or "resident", to_rung=to_mode,
                 needed_gb=needed_gb,
                 detail=f"CUDA OOM mid-inference ({type(exc).__name__}); "
-                       "retrying this request once offloaded",
+                       "quarantining this instance for a clean offloaded reload",
             )
-        if not demotions:
+        flush_memory()
+        rec = self._classes.get(spec.instance_key)
+        if rec is not None and rec.ready:
+            rec.stale = True
+        if not transitions:
             logger.warning(degraded_log_line(
                 event="engaged", fn=spec.name, phase="inference",
                 free_gb=get_available_vram_gb(),
-                detail="CUDA OOM with no worker-owned pipeline to demote; "
-                       "flushed CUDA cache, retrying this request once"))
+                detail="CUDA OOM with no worker-owned pipeline rung; "
+                       "returning retryable without reusing the instance"))
         try:
-            # Platform-visible request event (the ie#369 bar): pod log AND
-            # hub event stream both say degraded mode engaged.
             ctx.log(
-                f"DEGRADED_MODE=engaged fn={spec.name}: CUDA OOM; retrying "
-                "once with CPU offload (slower). Sticky for this worker.",
+                f"DEGRADED_MODE=engaged fn={spec.name}: CUDA OOM; quarantining "
+                "this instance and reloading offloaded on retry.",
                 level="warning",
             )
         except Exception:
             pass
-        return True
-
-    @staticmethod
-    def _demote_pipelines(
-        pipes: List[Tuple[str, Any]],
-    ) -> List[Tuple[str, str, str, float]]:
-        """Sync half (thread): flush, then one ladder rung down per pipeline.
-        Returns (ref, from_mode, to_mode, needed_gb) per demoted pipeline."""
-        from .models.memory import demote_pipeline, low_vram_mode
-
-        flush_memory()
-        out: List[Tuple[str, str, str, float]] = []
-        for ref, pipe in pipes:
-            before = low_vram_mode(pipe)
-            after = demote_pipeline(pipe, logger=logger)
-            if after:
-                out.append((ref, before, after, estimate_pipeline_size_gb(pipe)))
-        return out
 
     async def _execute(
         self,

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -68,8 +68,9 @@ def effective_vram_requirement_gb(recommended_gb: float) -> float:
 _CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
 
 # The reactive (degraded-mode) half of the fit ladder, shallowest first
-# (gw#463). A CUDA OOM — at load OR mid-inference — demotes a pipeline one
-# rung at a time; the terminal rung is sequential offload.
+# (gw#463). A load-time CUDA OOM rolls back and retries one rung lower. A
+# mid-inference OOM records the next rung, quarantines the live object, and
+# applies that rung only during a clean reload.
 OFFLOAD_LADDER: tuple[str, ...] = _CPU_OFFLOAD_MODES
 
 
@@ -799,6 +800,17 @@ def place_pipeline(
             nxt = next_offload_rung(effective)
             if nxt is None:
                 raise
+            # ``pipeline.to('cuda')`` may have moved only a prefix of the
+            # component graph before the allocator raised. Offload hooks must
+            # start from a coherent CPU object; attaching them to that partial
+            # move creates the mixed-device fatal seen on live SDXL.
+            _move_pipeline_to_cpu(pipeline)
+            missed = repair_device_placement(pipeline, "cpu")
+            if missed:
+                raise RuntimeError(
+                    "CUDA OOM left the pipeline mixed-device and CPU rollback "
+                    f"failed ({missed[:5]!r})"
+                ) from exc
             flush_memory()
             log.warning(degraded_log_line(
                 event="engaged", model=ref, phase="load",
@@ -809,23 +821,6 @@ def place_pipeline(
             ))
             demotions += 1
             effective = nxt
-
-
-def demote_pipeline(pipeline: Any, *, logger: Optional[logging.Logger] = None) -> Optional[str]:
-    """Runtime ladder transition (gw#463): move an already-placed pipeline one
-    offload rung deeper after a mid-inference CUDA OOM. Returns the new mode,
-    or None when already terminal (sequential). Sticky: the applied mode is
-    recorded on the pipeline, so it stays degraded until reload."""
-    log = logger or _LOG
-    nxt = next_offload_rung(low_vram_mode(pipeline))
-    if nxt is None:
-        return None
-    try:
-        delattr(pipeline, _COZY_MODE_ATTR)
-    except AttributeError:
-        pass
-    apply_low_vram_config(pipeline, mode=nxt, logger=log)
-    return nxt
 
 
 def apply_low_vram_config(
@@ -1064,7 +1059,6 @@ __all__ = [
     "apply_low_vram_config",
     "low_vram_mode",
     "place_pipeline",
-    "demote_pipeline",
     "next_offload_rung",
     "deeper_offload_mode",
     "is_cuda_oom",

--- a/tests/test_oom_degraded_ladder.py
+++ b/tests/test_oom_degraded_ladder.py
@@ -52,12 +52,14 @@ class ShimPipe(DDPMPipeline):
 
     oom_on_cuda = True
     to_cuda_attempts = 0
+    to_cpu_attempts = 0
     offload_calls: list = []
 
     @classmethod
     def reset(cls, *, oom_on_cuda: bool = True) -> None:
         cls.oom_on_cuda = oom_on_cuda
         cls.to_cuda_attempts = 0
+        cls.to_cpu_attempts = 0
         cls.offload_calls = []
 
     def to(self, *args, **kwargs):
@@ -66,6 +68,8 @@ class ShimPipe(DDPMPipeline):
             type(self).to_cuda_attempts += 1
             if type(self).oom_on_cuda:
                 raise OOM("CUDA out of memory (injected, gw#463 test)")
+        else:
+            type(self).to_cpu_attempts += 1
         return self
 
     def enable_model_cpu_offload(self, *a, **k):
@@ -144,6 +148,7 @@ def test_load_oom_demotes_to_model_offload(shim_env, caplog) -> None:
     assert applied["mode"] == "model_offload"
     assert applied["oom_demotions"] == 1
     assert ShimPipe.to_cuda_attempts == 1
+    assert ShimPipe.to_cpu_attempts == 1  # partial CUDA move rolled back first
     assert ShimPipe.offload_calls == ["model_offload"]
     assert memory.low_vram_mode(pipe) == "model_offload"
     line = next(r.message for r in caplog.records if "DEGRADED_MODE" in r.message)
@@ -169,15 +174,6 @@ def test_planned_offload_skips_doomed_resident_attempt(shim_env) -> None:
     assert applied["mode"] == "model_offload"
     assert "oom_demotions" not in applied
     assert ShimPipe.to_cuda_attempts == 0  # ie#369: no doomed resident attempt
-
-
-def test_demote_pipeline_walks_and_terminates(shim_env) -> None:
-    pipe = ShimPipe.from_pretrained(str(shim_env))
-    assert memory.demote_pipeline(pipe) == "model_offload"
-    assert memory.demote_pipeline(pipe) == "group_offload"
-    assert memory.demote_pipeline(pipe) == "sequential"
-    assert memory.demote_pipeline(pipe) is None  # terminal rung: stays put
-    assert memory.low_vram_mode(pipe) == "sequential"
 
 
 # --------------------------------------------------------------------------- #
@@ -267,7 +263,8 @@ def test_setup_oom_learns_floor_and_skips_resident_on_reload(
     asyncio.run(_go())
 
 
-def test_inference_oom_demotes_and_retries_once(shim_env, tmp_path, caplog) -> None:
+def test_inference_oom_quarantines_then_reloads_on_retry(
+        shim_env, tmp_path, caplog) -> None:
     calls = {"n": 0}
 
     class Endpoint:
@@ -288,10 +285,11 @@ def test_inference_oom_demotes_and_retries_once(shim_env, tmp_path, caplog) -> N
         ex = _executor(spec, tmp_path, shim_env, sent)
         with caplog.at_level(logging.WARNING):
             await _run_job(ex, "r1")
-        assert _result(sent, "r1").status == pb.JOB_STATUS_OK
-        assert calls["n"] == 2  # retried exactly once, in degraded mode
-        pipe = ex.store.residency.obj("acme/tiny")
-        assert memory.low_vram_mode(pipe) == "model_offload"
+        assert _result(sent, "r1").status == pb.JOB_STATUS_RETRYABLE
+        assert calls["n"] == 1  # unsafe live-object replay is forbidden
+        old_pipe = ex.store.residency.obj("acme/tiny")
+        assert memory.low_vram_mode(old_pipe) == "off"
+        assert ex._classes[spec.instance_key].stale
         assert ex.degraded_floor["acme/tiny"] == "model_offload"
         assert ex.serve_plans["fn"].ran == "offload:model_offload"
         assert any("DEGRADED_MODE=engaged" in r.message and "phase=inference" in r.message
@@ -301,9 +299,13 @@ def test_inference_oom_demotes_and_retries_once(shim_env, tmp_path, caplog) -> N
             m.WhichOneof("msg") == "job_progress"
             and b"DEGRADED_MODE=engaged" in m.job_progress.data
             for m in sent)
-        # Sticky: the next request stays degraded — no rung flapping.
+        # Hub retry: stale resident is discarded, then rebuilt cleanly at the
+        # learned ref-specific floor.
         await _run_job(ex, "r2")
         assert _result(sent, "r2").status == pb.JOB_STATUS_OK
+        assert calls["n"] == 2
+        pipe = ex.store.residency.obj("acme/tiny")
+        assert pipe is not old_pipe
         assert memory.low_vram_mode(pipe) == "model_offload"
 
     asyncio.run(_go())
@@ -327,16 +329,14 @@ def test_inference_oom_in_degraded_mode_fails_retryable(shim_env, tmp_path) -> N
     async def _go() -> None:
         ex = _executor(spec, tmp_path, shim_env, sent)
         await _run_job(ex, "r1")
-        # One degraded retry, then the mapped status — RETRYABLE, never FATAL
-        # (a bigger card can serve it); the ladder floor deepened.
-        assert calls["n"] == 2
+        # No in-process replay: the hub retries after a clean reload.
+        assert calls["n"] == 1
         assert _result(sent, "r1").status == pb.JOB_STATUS_RETRYABLE
         assert _result(sent, "r1").safe_message == "out of memory"
         assert ex.degraded_floor["acme/tiny"] == "model_offload"
-        # Next request: demotes one MORE rung (group_offload), retries, fails
-        # RETRYABLE again — walking, not flapping.
+        # Next hub attempt reloads at model_offload, then learns the next rung.
         await _run_job(ex, "r2")
-        assert calls["n"] == 4
+        assert calls["n"] == 2
         assert _result(sent, "r2").status == pb.JOB_STATUS_RETRYABLE
         assert ex.degraded_floor["acme/tiny"] == "group_offload"
 
@@ -388,6 +388,36 @@ def test_runtime_demotion_reemits_fn_degraded(shim_env, tmp_path) -> None:
         assert len([m for m in tp.sent if m.WhichOneof("msg") == "fn_degraded"]) == 2
 
     asyncio.run(_go())
+
+
+def test_runtime_floor_is_per_ref_not_all_dynamic_picks(
+        shim_env, tmp_path) -> None:
+    """One oversized pick may degrade function telemetry, but placement for
+    a different concrete pick still starts from the hardware-gate plan."""
+    class Endpoint:
+        def setup(self, m: ShimPipe) -> None:
+            self.m = m
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = _spec(Endpoint)
+    ex = _executor(spec, tmp_path, shim_env, [])
+    native = ServePlan(
+        serveable=True, run_mode="native", fit="fits",
+        wanted="bf16", ran="bf16",
+    )
+    ex.serve_plans["fn"] = native
+    ex._gate_serve_plans["fn"] = native
+
+    ex._record_demotion(
+        spec, ref="acme/oversized", phase="inference",
+        from_rung="resident", to_rung="model_offload",
+    )
+
+    assert ex.serve_plans["fn"].run_mode == RUN_OFFLOAD  # telemetry
+    assert ex._placement_mode(spec, "acme/oversized") == "model_offload"
+    assert ex._placement_mode(spec, "acme/sibling") == "auto"
 
 
 def test_plan_serve_offload_rung_unchanged_by_reactive_path() -> None:

--- a/tests/test_vram_admission.py
+++ b/tests/test_vram_admission.py
@@ -1,0 +1,88 @@
+"""VRAM admission for cold dynamic model picks.
+
+Live SDXL loaded WAI, Cyber and Nova before a never-seen Realism pick. The
+fixed VAE had a small prior hint, so the old sum-only estimate admitted the
+unknown checkpoint as though only that VAE were incoming. Admission must use
+the endpoint's full declared requirement whenever any setup ref is unknown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import msgspec
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.api.binding import HF
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.models import residency as residency_mod
+from gen_worker.models.residency import Tier
+from gen_worker.registry import EndpointSpec
+
+_GiB = 1024 ** 3
+
+
+class _In(msgspec.Struct):
+    prompt: str = "test"
+
+
+class _Pipe:
+    def to(self, device: str) -> "_Pipe":
+        return self
+
+
+class _Endpoint:
+    def setup(self, pipeline: _Pipe, vae: _Pipe) -> None:  # pragma: no cover
+        self.pipeline = pipeline
+        self.vae = vae
+
+    def run(self, ctx, payload: _In):  # pragma: no cover
+        return payload
+
+
+def _spec() -> EndpointSpec:
+    return EndpointSpec(
+        name="generate", method=_Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=_Endpoint,
+        attr_name="run",
+        models={"pipeline": HF("tensorhub/realism"),
+                "vae": HF("madebyollin/sdxl-vae-fp16-fix")},
+        resources=Resources(vram_gb=12),
+    )
+
+
+def _executor(spec: EndpointSpec, tmp_path) -> Executor:
+    async def _send(message) -> None:
+        return None
+
+    store = ModelStore(
+        _send, cache_dir=tmp_path, vram_budget_bytes=24 * _GiB,
+    )
+    return Executor([spec], _send, store=store)
+
+
+def test_partial_hint_uses_full_declared_requirement(
+        tmp_path, monkeypatch) -> None:
+    spec = _spec()
+    ex = _executor(spec, tmp_path)
+    res = ex.store.residency
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 128.0)
+
+    # Three warm picks plus the known companion VAE leave only 5GiB free.
+    # A 1GiB-only ask would fit; the honest 12GiB + margin ask must evict.
+    for ref in ("tensorhub/wai", "tensorhub/cyber", "tensorhub/nova"):
+        res.track_vram(ref, _Pipe(), vram_bytes=6 * _GiB)
+    res.track_vram(
+        "madebyollin/sdxl-vae-fp16-fix", _Pipe(), vram_bytes=1 * _GiB,
+    )
+
+    asyncio.run(ex._make_room_for(spec, ["pipeline", "vae"]))
+
+    assert res.tier("tensorhub/wai") is Tier.RAM
+    assert res.tier("tensorhub/cyber") is Tier.RAM
+    assert res.tier("tensorhub/nova") is Tier.VRAM
+    assert res.tier("madebyollin/sdxl-vae-fp16-fix") is Tier.VRAM

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.4"
+version = "0.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- reserve the full declared VRAM envelope when any setup ref has no learned hint, so a known companion model cannot hide an unknown checkpoint load
- separate immutable gate-time placement from per-ref reactive degradation, preventing one dynamic pick from forcing sibling picks into offload
- quarantine OOM’d instances and reload cleanly at the learned rung instead of mutating live Diffusers hooks in place
- roll partial CUDA placement back to a verified CPU state before applying load-time offload hooks
- release gen-worker 0.26.5

## Validation
- 1,082 passed, 13 skipped; sole CUDA lane-swap failure reproduced unchanged on origin/master
- 47 focused pressure/residency tests passed before final hard-cut; final focused set: 32 passed
- mypy: success across 114 source files
- Ruff: changed files clean (full-repo has 11 unrelated pre-existing findings)
- HTTP timeout guard clean
- uv lock --check clean
- wheel and sdist built successfully