### PR TITLE
Fix owner-aware host RAM eviction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.5"
+version = "0.26.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/capability.py
+++ b/src/gen_worker/capability.py
@@ -1,11 +1,14 @@
-"""Hardware capability error types for the worker's self-disable signaling.
+"""Typed worker capacity errors.
 
-Raised on the worker's boot-time self-advertise gate and runtime resource
-checks; they flow upstream as ``WorkerFunctionUnavailableSignal`` payloads so
-the orchestrator narrows subsequent dispatches to suitable workers.
+Static hardware gates flow upstream as ``WorkerFunctionUnavailableSignal``
+payloads so the orchestrator narrows subsequent dispatches to suitable
+workers. Transient capacity pressure remains retryable and does not disable a
+function on the worker.
 """
 
 from __future__ import annotations
+
+from .api.errors import RetryableError
 
 
 class HardwareUnmetError(RuntimeError):
@@ -57,7 +60,61 @@ class InsufficientDiskError(HardwareUnmetError):
         return out
 
 
+class InsufficientHostRamError(RetryableError):
+    """A worker cannot stage a model without crossing its host-RAM floor.
+
+    Unlike a static hardware gate, this is transient: another worker may have
+    room and this worker may recover after an idle record is evicted.  Keep the
+    measured capacity facts typed so the scheduler can distinguish local
+    pressure from a corrupt model load.
+    """
+
+    reason = "insufficient_host_ram"
+
+    def __init__(
+        self,
+        function_name: str,
+        *,
+        incoming_bytes: int,
+        floor_bytes: int,
+        required_bytes: int,
+        available_before_bytes: int,
+        available_after_bytes: int,
+        evicted_refs: tuple[str, ...] = (),
+    ) -> None:
+        self.function_name = str(function_name)
+        self.incoming_bytes = int(incoming_bytes)
+        self.floor_bytes = int(floor_bytes)
+        self.required_bytes = int(required_bytes)
+        self.available_before_bytes = int(available_before_bytes)
+        self.available_after_bytes = int(available_after_bytes)
+        self.evicted_refs = tuple(evicted_refs)
+
+        gib = float(1024**3)
+        evicted = ",".join(self.evicted_refs) or "none"
+        super().__init__(
+            f"insufficient host RAM to load {self.function_name}: "
+            f"~{self.incoming_bytes / gib:.1f}GiB incoming + "
+            f"{self.floor_bytes / gib:.1f}GiB safety floor = "
+            f"{self.required_bytes / gib:.1f}GiB required; "
+            f"{self.available_before_bytes / gib:.1f}GiB available before eviction, "
+            f"{self.available_after_bytes / gib:.1f}GiB after; "
+            f"evicted_refs={evicted}"
+        )
+
+    def axes(self) -> dict[str, str]:
+        return {
+            "incoming_bytes": str(self.incoming_bytes),
+            "floor_bytes": str(self.floor_bytes),
+            "required_bytes": str(self.required_bytes),
+            "available_before_bytes": str(self.available_before_bytes),
+            "available_after_bytes": str(self.available_after_bytes),
+            "evicted_refs": ",".join(self.evicted_refs),
+        }
+
+
 __all__ = [
     "HardwareUnmetError",
     "InsufficientDiskError",
+    "InsufficientHostRamError",
 ]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -42,7 +42,11 @@ from .api.streaming import (
     TokenUsage,
 )
 from .api.types import Asset
-from .capability import HardwareUnmetError, InsufficientDiskError
+from .capability import (
+    HardwareUnmetError,
+    InsufficientDiskError,
+    InsufficientHostRamError,
+)
 from .input_assets import cleanup_input_assets, materialize_input_assets
 from .models import disk_gc
 from .models import provision
@@ -53,7 +57,6 @@ from .models.memory import (
     estimate_cuda_resident_gb,
     estimate_pipeline_size_gb,
     flush_memory,
-    get_available_ram_gb,
     get_available_vram_gb,
     is_cuda_oom,
     low_vram_mode,
@@ -1729,8 +1732,11 @@ class Executor:
         # Loads serialize: concurrent setups would cross-contaminate each
         # other's allocator deltas and place_pipeline's free-VRAM reads.
         async with self._load_lock:
-            await self._ensure_host_ram_for(spec, paths)
             await self._make_room_for(spec, setup_slots)
+            # VRAM make-room may demote the old pipeline into host RAM. Admit
+            # the incoming load only AFTER that transition so the probe sees
+            # the actual post-demotion pressure (pgw#541).
+            await self._ensure_host_ram_for(spec, paths)
             instance = spec.cls()
             setup = getattr(instance, "setup", None)
             inj = _InjectionResult(kwargs={}, loaded={})
@@ -1893,13 +1899,19 @@ class Executor:
         }
 
     async def _ensure_host_ram_for(self, spec: EndpointSpec, paths: Dict[str, str]) -> None:
-        """Load-size-aware host-RAM admission (gw#407). ``from_pretrained``
+        """Owner-aware host-RAM admission (gw#407/pgw#541). ``from_pretrained``
         stages the full weight set in host RAM before placement; loading into
         a nearly-full host pushes it into reclaim-thrash that stalls the whole
         process — including gRPC keepalive acks — so the hub disconnects and
-        requeues in a livelock (J17: 16 SDXL variants on a 31GB host). Free
-        warm RAM-tier LRU pipelines first; when even that cannot cover the
-        incoming bytes plus the floor, fail RETRYABLE instead of thrashing.
+        requeues in a livelock (J17: 16 SDXL variants on a 31GB host).
+
+        A warm pipeline is owned by both Residency and its endpoint
+        ``_ClassRecord``. Clearing only the Residency reference reports
+        ON_DISK while ``record.instance`` still owns every tensor. Evict
+        record-owned victims through ``_vacate_record``; only ownerless
+        entries may use ``release_to_disk`` directly. Re-probe observed RAM
+        after every teardown and fail RETRYABLE if the real headroom still
+        cannot cover the incoming bytes plus the derived floor.
 
         Only worker-loaded (pipeline-typed) slots count: tenant-owned and
         engine-runtime slots do not stage full weight sets in host RAM.
@@ -1919,13 +1931,57 @@ class Executor:
                 incoming = max(incoming, slot_bytes)
         if incoming <= 0:
             return
-        if await asyncio.to_thread(self.store.residency.make_room_ram, incoming):
+        res = self.store.residency
+        before = await asyncio.to_thread(res.host_ram_headroom, incoming)
+        if before.sufficient:
             return
-        avail = get_available_ram_gb()
-        raise RetryableError(
-            f"insufficient host RAM to load {spec.name}: "
-            f"~{incoming / _GiB:.1f}GiB incoming, {avail:.1f}GiB available "
-            "after releasing the warm tier"
+
+        evicted: List[str] = []
+        after = before
+        for ref in res.lru_ram_victims():
+            # A previous record teardown may already have transitioned every
+            # ref that appeared in the snapshot of LRU candidates.
+            if res.tier(ref) is not residency_mod.Tier.RAM:
+                continue
+            rec = self._record_holding(ref)
+            if rec is not None:
+                if self._record_in_use(rec):
+                    continue
+                owned = [
+                    held for held in self._record_refs(rec)
+                    if res.tier(held) in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+                ]
+                await self._vacate_record(rec)
+                evicted.extend(owned)
+                logger.info(
+                    "host-RAM admission vacated warm record refs=%s for %s",
+                    owned, spec.name,
+                )
+            elif await asyncio.to_thread(res.release_to_disk, ref):
+                evicted.append(ref)
+                logger.info(
+                    "host-RAM admission released ownerless warm ref=%s for %s",
+                    ref, spec.name,
+                )
+            else:
+                continue
+
+            # Let completed demotion/to_thread frames release their arguments,
+            # then collect after the record owner is gone before observing RAM.
+            await asyncio.sleep(0)
+            await asyncio.to_thread(flush_memory)
+            after = await asyncio.to_thread(res.host_ram_headroom, incoming)
+            if after.sufficient:
+                return
+
+        raise InsufficientHostRamError(
+            spec.name,
+            incoming_bytes=incoming,
+            floor_bytes=after.floor_bytes,
+            required_bytes=after.required_bytes,
+            available_before_bytes=before.available_bytes,
+            available_after_bytes=after.available_bytes,
+            evicted_refs=tuple(dict.fromkeys(evicted)),
         )
 
     async def _make_room_for(self, spec: EndpointSpec, setup_slots: List[str]) -> None:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1630,11 +1630,15 @@ class Executor:
         try:
             await self.ensure_setup(effective, snapshots)
         except Exception as exc:
-            error = _model_failure_vocab(exc)
-            for ref in dict.fromkeys(bindings.values()):
-                await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
-                    ref=ref, state=pb.MODEL_STATE_FAILED, error=error,
-                )))
+            # Host-RAM admission already emitted the precise largest staged
+            # ref(s) that caused the capacity failure. Do not overwrite that
+            # signal by failing smaller shared refs such as an SDXL VAE.
+            if not isinstance(exc, InsufficientHostRamError):
+                error = _model_failure_vocab(exc)
+                for ref in dict.fromkeys(bindings.values()):
+                    await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                        ref=ref, state=pb.MODEL_STATE_FAILED, error=error,
+                    )))
             raise
 
     def _class_record(self, spec: EndpointSpec) -> _ClassRecord:
@@ -1925,10 +1929,16 @@ class Executor:
         if not paths or not slots:
             return
         incoming = 0
+        incoming_refs: List[str] = []
         for slot, p in paths.items():
             if slot in slots:
                 slot_bytes = await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
-                incoming = max(incoming, slot_bytes)
+                ref = wire_ref(spec.models[slot])
+                if slot_bytes > incoming:
+                    incoming = slot_bytes
+                    incoming_refs = [ref]
+                elif slot_bytes == incoming and slot_bytes > 0:
+                    incoming_refs.append(ref)
         if incoming <= 0:
             return
         res = self.store.residency
@@ -1974,7 +1984,7 @@ class Executor:
             if after.sufficient:
                 return
 
-        raise InsufficientHostRamError(
+        error = InsufficientHostRamError(
             spec.name,
             incoming_bytes=incoming,
             floor_bytes=after.floor_bytes,
@@ -1983,6 +1993,16 @@ class Executor:
             available_after_bytes=after.available_bytes,
             evicted_refs=tuple(dict.fromkeys(evicted)),
         )
+        # th#807: model-failure state is the scheduler's typed capacity seam.
+        # Only the largest sequentially staged ref(s) caused this admission
+        # decision; failing a smaller shared VAE would poison unrelated jobs.
+        for ref in dict.fromkeys(incoming_refs):
+            await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                ref=ref,
+                state=pb.MODEL_STATE_FAILED,
+                error=error.reason,
+            )))
+        raise error
 
     async def _make_room_for(self, spec: EndpointSpec, setup_slots: List[str]) -> None:
         """Evict idle LRU pipelines before loading instead of degrading the

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -76,6 +76,19 @@ class Tier(str, Enum):
     DISK = "DISK"
 
 
+@dataclass(frozen=True)
+class HostRamHeadroom:
+    """One observed host-RAM admission decision."""
+
+    available_bytes: int
+    floor_bytes: int
+    required_bytes: int
+
+    @property
+    def sufficient(self) -> bool:
+        return self.available_bytes >= self.required_bytes
+
+
 @dataclass
 class _Entry:
     ref: str
@@ -195,6 +208,15 @@ class Residency:
         if self._free_vram_fn is not None:
             return int(self._free_vram_fn())
         return _default_free_vram_bytes()
+
+    def host_ram_headroom(self, needed_bytes: int) -> HostRamHeadroom:
+        """Observed capacity for one incoming host-staged model load."""
+        floor = int(_effective_ram_floor_gb() * _GiB)
+        return HostRamHeadroom(
+            available_bytes=int(get_available_ram_gb() * _GiB),
+            floor_bytes=floor,
+            required_bytes=max(0, int(needed_bytes)) + floor,
+        )
 
     # ---- queries ---------------------------------------------------------------
 
@@ -580,32 +602,6 @@ class Residency:
             candidates.sort(key=lambda e: e.last_used)
             return [e.ref for e in candidates]
 
-    def make_room_ram(self, needed_bytes: int) -> bool:
-        """Host-RAM admission for an incoming load of ``needed_bytes`` (gw#407):
-        release warm RAM-tier LRU entries to disk until available host RAM
-        covers the load plus the RAM floor. False means even an empty warm
-        tier cannot make the load safe — the caller must refuse the load
-        (RETRYABLE) instead of thrashing the host into the keepalive-stall
-        livelock (J17: 16 SDXL variants on a 31GB host)."""
-        floor_bytes = int(_effective_ram_floor_gb() * _GiB)
-        target = int(needed_bytes) + floor_bytes
-
-        def _avail() -> int:
-            return int(get_available_ram_gb() * _GiB)
-
-        if _avail() >= target:
-            return True
-        for ref in self.lru_ram_victims():
-            if not self.release_to_disk(ref):
-                continue
-            logger.info(
-                "residency: released warm %s to disk for %d bytes of host-RAM headroom",
-                ref, needed_bytes,
-            )
-            if _avail() >= target:
-                return True
-        return _avail() >= target
-
     # ---- shared components (#335, folded in) -----------------------------------
 
     def acquire_shared(
@@ -808,6 +804,7 @@ class LoadedComponentKey:
 __all__ = [
     "Residency",
     "Tier",
+    "HostRamHeadroom",
     "LoadedComponentKey",
     "content_set_digest",
     "ON_DISK", "IN_RAM", "IN_VRAM", "EVICTED",

--- a/tests/e2e_endpoints.py
+++ b/tests/e2e_endpoints.py
@@ -108,3 +108,33 @@ class BrokenSetupEndpoint:
     def broken_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
         weights = Path(self.model_path) / "model.safetensors"
         return EchoOut(response=weights.read_text())
+
+
+class _RamPressurePipeline:
+    """Pipeline-shaped annotation for the host-RAM admission wire test."""
+
+    @classmethod
+    def from_pretrained(cls, path: str, **kwargs: object) -> "_RamPressurePipeline":
+        return cls()
+
+    def to(self, device: str) -> "_RamPressurePipeline":
+        return self
+
+
+@endpoint(models={
+    "pipeline": Hub("e2e/ram-pressure-pipeline"),
+    "vae": Hub("e2e/ram-pressure-shared-vae"),
+})
+class RamPressureEndpoint:
+    """Two staged refs: only the larger pipeline may fail RAM admission."""
+
+    def setup(
+        self,
+        pipeline: _RamPressurePipeline,
+        vae: _RamPressurePipeline,
+    ) -> None:
+        self.pipeline = pipeline
+        self.vae = vae
+
+    def ram_pressure(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        return EchoOut(response="unexpectedly loaded")

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -4,8 +4,8 @@ J17 livelock: 16 SDXL variants on a 31GB host — every load/demote grew the
 warm RAM tier until the host entered reclaim-thrash, which stalled the whole
 process (including gRPC keepalive acks), so the hub disconnected, requeued the
 same job, and the cycle repeated. The RAM tier is now admission-controlled:
-demote is size-aware, loads free the warm tier first via make_room_ram, and a
-load that still cannot fit fails RETRYABLE instead of thrashing.
+demote is size-aware, loads vacate warm endpoint records through their owner,
+and a load that still cannot fit fails RETRYABLE instead of thrashing.
 """
 
 from __future__ import annotations
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import weakref
 from pathlib import Path
 
 import msgspec
@@ -20,7 +21,7 @@ import pytest
 
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
-from gen_worker.api.errors import RetryableError
+from gen_worker.capability import InsufficientHostRamError
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.models import residency as residency_mod
 from gen_worker.models.residency import Residency, Tier
@@ -81,42 +82,29 @@ def test_ram_floor_adapts_to_small_hosts(monkeypatch) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# make_room_ram: warm-tier LRU release under host-RAM pressure
+# Host-RAM headroom and warm-tier victim selection
 # --------------------------------------------------------------------------- #
 
 
-def test_make_room_ram_releases_lru_until_headroom(tmp_path: Path, monkeypatch) -> None:
+def test_host_ram_headroom_includes_derived_floor(monkeypatch) -> None:
     monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 7.3)
     res = _res()
-    sizes = {"m/a": 6.0, "m/b": 6.0}
-
-    def _avail() -> float:
-        # Warm entries eat their size; releases give it back.
-        used = sum(gb for ref, gb in sizes.items() if res.tier(ref) is Tier.RAM)
-        return 19.0 - used
-
-    monkeypatch.setattr(residency_mod, "get_available_ram_gb", _avail)
-    res.track_ram("m/a", _Pipe(), path=tmp_path)
-    res.touch("m/a")
-    res.track_ram("m/b", _Pipe(), path=tmp_path)
-
-    # Incoming 6GiB load: available 7, target 6 + 6.2 floor -> release LRU (a).
-    assert res.make_room_ram(6 * _GiB) is True
-    assert res.tier("m/a") is Tier.DISK
-    assert res.tier("m/b") is Tier.RAM  # only as much as needed was released
+    headroom = res.host_ram_headroom(6 * _GiB)
+    assert headroom.floor_bytes == pytest.approx(6.2 * _GiB, rel=1e-6)
+    assert headroom.required_bytes == 6 * _GiB + headroom.floor_bytes
+    assert headroom.available_bytes == pytest.approx(7.3 * _GiB, rel=1e-6)
+    assert headroom.sufficient is False
 
 
-def test_make_room_ram_skips_pinned_and_executing(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
-    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 2.0)
+def test_lru_ram_victims_skip_pinned_and_executing(tmp_path: Path) -> None:
     res = _res()
     res.track_ram("m/pinned", _Pipe(), path=tmp_path)
     res._entries["m/pinned"].pinned = True
     res.track_ram("m/busy", _Pipe(), path=tmp_path)
+    res.track_ram("m/idle", _Pipe(), path=tmp_path)
     with res.executing("m/busy"):
-        assert res.make_room_ram(6 * _GiB) is False
-        assert res.tier("m/pinned") is Tier.RAM
-        assert res.tier("m/busy") is Tier.RAM
+        assert res.lru_ram_victims() == ["m/idle"]
 
 
 # --------------------------------------------------------------------------- #
@@ -137,11 +125,13 @@ class _FakePipe:
         return self
 
 
-def _spec(name: str, cls: type, models: dict) -> EndpointSpec:
+def _spec(
+    name: str, cls: type, models: dict, *, vram_gb: float | None = None,
+) -> EndpointSpec:
     return EndpointSpec(
         name=name, method=cls.run, kind="inference", payload_type=_In,
         output_mode="single", cls=cls, attr_name="run", models=models,
-        resources=Resources(),
+        resources=Resources(vram_gb=vram_gb),
     )
 
 
@@ -176,8 +166,17 @@ def test_setup_refused_retryable_when_host_ram_insufficient(tmp_path: Path, monk
 
     async def _run() -> None:
         ex = _executor([spec], tmp_path)
-        with pytest.raises(RetryableError, match="insufficient host RAM"):
+        with pytest.raises(InsufficientHostRamError, match="insufficient host RAM") as caught:
             await ex.ensure_setup(spec)
+        err = caught.value
+        assert err.incoming_bytes == 6 * _GiB
+        assert err.floor_bytes == pytest.approx(6.2 * _GiB, rel=1e-6)
+        assert err.required_bytes == err.incoming_bytes + err.floor_bytes
+        assert err.available_before_bytes == 8 * _GiB
+        assert err.available_after_bytes == 8 * _GiB
+        assert err.evicted_refs == ()
+        assert "6.0GiB incoming + 6.2GiB safety floor = 12.2GiB required" in str(err)
+        assert "8.0GiB available before eviction, 8.0GiB after" in str(err)
         # Transient pressure: the function is NOT disabled and not failed.
         assert "ep" not in ex.unavailable
         assert ex._classes[spec.instance_key].failed is None
@@ -190,7 +189,16 @@ def test_setup_refused_retryable_when_host_ram_insufficient(tmp_path: Path, monk
     asyncio.run(_run())
 
 
-def test_setup_frees_warm_tier_before_refusing(tmp_path: Path, monkeypatch) -> None:
+def test_setup_vacates_warm_record_after_vram_make_room(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """pgw#541: VRAM make-room can put the old pipeline into host RAM.
+
+    Admission must observe that post-demotion pressure, tear down the owning
+    endpoint record, and only then publish ON_DISK. Clearing Residency alone
+    leaves ``record.instance`` strongly owning the pipeline and cannot reclaim
+    the 6GiB represented by this deterministic probe.
+    """
     from gen_worker.models import disk_gc
 
     class A:
@@ -208,29 +216,58 @@ def test_setup_frees_warm_tier_before_refusing(tmp_path: Path, monkeypatch) -> N
             return payload
 
     spec_a = _spec("a", A, {"m": HF("acme/a")})
-    spec_b = _spec("b", B, {"m": HF("acme/b")})
+    spec_b = _spec("b", B, {"m": HF("acme/b")}, vram_gb=18)
     monkeypatch.setattr(disk_gc, "tree_bytes", lambda p: 6 * _GiB)
     monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
 
     async def _run() -> None:
         ex = _executor([spec_a, spec_b], tmp_path)
         res = ex.store.residency
+        from gen_worker import executor as executor_mod
+
+        if executor_mod.torch is None:
+            pytest.skip("torch is required for the VRAM-admission ordering check")
+        cuda_enabled = {"value": False}
+        monkeypatch.setattr(executor_mod.torch.cuda, "is_available", lambda: cuda_enabled["value"])
 
         monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 24.0)
         await ex.ensure_setup(spec_a)
-        # CPU-only harness: the loaded pipeline books straight into the warm
-        # RAM tier — exactly the tier make_room_ram drains.
-        assert res.tier("acme/a") is Tier.RAM
+        rec_a = ex._classes[spec_a.instance_key]
+        pipeline = weakref.ref(rec_a.instance.m)
+        # Model the first successful SDXL request: its ~6GiB pipeline is in
+        # VRAM, and a 24GiB card needs to demote it before loading B.
+        res.track_vram("acme/a", rec_a.instance.m, vram_bytes=6 * _GiB)
 
-        # B's load: 7GiB available < 6 + 6.2 floor, but releasing warm A
-        # (6GiB) makes room -> the load proceeds, A lands on disk.
+        cuda_enabled["value"] = True
+        make_room = ex._make_room_for
+
+        async def _make_room_then_use_cpu(spec, slots):
+            await make_room(spec, slots)
+            cuda_enabled["value"] = False
+
+        monkeypatch.setattr(ex, "_make_room_for", _make_room_then_use_cpu)
+
         def _avail() -> float:
-            return 7.0 + (6.0 if res.tier("acme/a") is not Tier.RAM else 0.0)
+            if res.tier("acme/a") is Tier.VRAM:
+                return 13.0
+            return 13.0 if rec_a.instance is None else 7.0
 
         monkeypatch.setattr(residency_mod, "get_available_ram_gb", _avail)
+        on_disk: list[bool] = []
+
+        def _event(ref: str, state: str, _vram: int, _duration: int = 0) -> None:
+            if ref == "acme/a" and state == residency_mod.ON_DISK:
+                on_disk.append(rec_a.instance is None)
+
+        res._on_event = _event
         inst_b = await ex.ensure_setup(spec_b)
         assert isinstance(inst_b.m, _FakePipe)
         assert res.tier("acme/a") is Tier.DISK
+        assert rec_a.ready is False
+        assert rec_a.instance is None
+        await asyncio.sleep(0)
+        assert pipeline() is None
+        assert on_disk == [True]
 
     asyncio.run(_run())
 

--- a/tests/test_worker_grpc_e2e.py
+++ b/tests/test_worker_grpc_e2e.py
@@ -888,6 +888,112 @@ def test_desired_residency_downloads_and_warms_round_trip(tmp_path, monkeypatch)
 
 
 # ---------------------------------------------------------------------------
+# Host-RAM admission failure crosses the real worker transport before the
+# retry result. Only the largest staged ref fails; the smaller shared VAE
+# remains usable by other functions (th#807).
+# ---------------------------------------------------------------------------
+
+
+def test_host_ram_failure_precedes_retryable_result_on_wire(tmp_path, monkeypatch) -> None:
+    import http.server
+
+    from blake3 import blake3
+
+    from gen_worker.models import disk_gc
+    from gen_worker.models import residency as residency_mod
+
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(tmp_path / "hub-cache"))
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 8.0)
+
+    pipeline_payload = b"large-pipeline"
+    vae_payload = b"small-shared-vae"
+    serve_dir = tmp_path / "www"
+    serve_dir.mkdir()
+    (serve_dir / "pipeline").write_bytes(pipeline_payload)
+    (serve_dir / "vae").write_bytes(vae_payload)
+
+    class _Quiet(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(serve_dir), **kwargs)
+
+        def log_message(self, *args):
+            pass
+
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Quiet)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base_url = f"http://127.0.0.1:{httpd.server_address[1]}"
+
+    def _snapshot(payload: bytes, name: str) -> pb.Snapshot:
+        return pb.Snapshot(
+            digest=f"ram-pressure-{name}",
+            files=[pb.SnapshotFile(
+                path="model.safetensors",
+                size_bytes=len(payload),
+                blake3=blake3(payload).hexdigest(),
+                url=f"{base_url}/{name}",
+            )],
+        )
+
+    def _tree_bytes(path) -> int:
+        payload = (path / "model.safetensors").read_bytes()
+        return (6 if payload == pipeline_payload else 1) * 1024**3
+
+    monkeypatch.setattr(disk_gc, "tree_bytes", _tree_bytes)
+
+    pipeline_ref = "e2e/ram-pressure-pipeline"
+    vae_ref = "e2e/ram-pressure-shared-vae"
+    scheduler = FakeScheduler()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=8))
+    pb_grpc.add_WorkerSchedulerServicer_to_server(scheduler, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    harness = _Harness(scheduler, port)
+    harness.start()
+    try:
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(
+            lambda message: message.WhichOneof("msg") == "state_delta"
+            and message.state_delta.phase == pb.WORKER_PHASE_READY
+        )
+        conn.send(run_job=pb.RunJob(
+            request_id="r-host-ram",
+            attempt=1,
+            function_name="ram-pressure",
+            input_payload=_msgpack("marco"),
+            snapshots={
+                pipeline_ref: _snapshot(pipeline_payload, "pipeline"),
+                vae_ref: _snapshot(vae_payload, "vae"),
+            },
+        ))
+        result = conn.wait_for(_is_result_for("r-host-ram")).job_result
+        assert result.status == pb.JOB_STATUS_RETRYABLE
+
+        with conn._recv_cond:
+            received = list(conn.received)
+        failed = [
+            (index, message.model_event)
+            for index, message in enumerate(received)
+            if message.WhichOneof("msg") == "model_event"
+            and message.model_event.state == pb.MODEL_STATE_FAILED
+        ]
+        assert [
+            (event.ref, event.error) for _, event in failed
+        ] == [(pipeline_ref, "insufficient_host_ram")]
+        result_index = next(
+            index for index, message in enumerate(received)
+            if message.WhichOneof("msg") == "job_result"
+            and message.job_result.request_id == "r-host-ram"
+        )
+        assert failed[0][0] < result_index
+        assert all(event.ref != vae_ref for _, event in failed)
+    finally:
+        harness.stop()
+        server.stop(grace=0)
+        httpd.shutdown()
+
+
+# ---------------------------------------------------------------------------
 # Setup failure surfaces FnUnavailable (th#581 worker-side / ernie roster
 # find): a function whose pipeline setup raises must NOT sit in
 # loading_functions forever under a READY phase — it leaves BOTH lists and a

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.5"
+version = "0.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- run host-RAM admission after VRAM make-room, so admission sees RAM consumed by a demoted pipeline
- evict warm, idle models through their owning endpoint record and re-measure observed RAM after teardown
- keep `ON_DISK` truthful by clearing the record owner before publishing the residency transition
- report typed incoming, floor, required, pre-eviction, and post-eviction capacity facts
- emit the existing protocol-v3 `ModelEvent{FAILED, error: "insufficient_host_ram"}` before the retry result so Tensorhub can state-fence the worker/ref

## Root cause

VRAM make-room could demote an old model after the host-RAM check had already passed. The subsequent RAM eviction cleared only the residency registry's object, while `_ClassRecord.instance` retained the actual pipeline. Tensorhub therefore observed `ON_DISK`, but the process retained the tensors and the incoming SDXL load retried under unchanged host pressure.

The RETRYABLE result also carried no typed per-model capacity state. Tensorhub could retry the same worker/ref without knowing which staged model caused admission to fail.

## Tensorhub #807 contract

- emit one failure for each unique effective setup ref tied at the largest observed sequential staging size
- do not fail smaller shared refs such as the SDXL VAE
- await every model failure before sending the RETRYABLE `JobResult`
- use the exact existing `insufficient_host_ram` error token; do not parse or encode `safe_message`, add a proto field, or change protocol v3
- desired-residency warming uses the same signal without duplicating or broadening it to unrelated refs

## Validation

- `51 passed` across host-RAM admission, the full real-gRPC worker transport suite, declarative residency, dynamic slots, download failures, and executor residency
- the real-gRPC regression uses a 6 GiB pipeline plus 1 GiB shared VAE and proves only the pipeline emits `FAILED/insufficient_host_ram`, before the RETRYABLE result
- `1082 passed, 13 skipped` in the prior full suite; the sole failure, `test_lane_swap_moves_only_the_exclusive_module`, reproduces identically on untouched `origin/master` in this GPU environment
- `mypy src/gen_worker`: success in 114 source files
- `ruff check src/gen_worker` and all changed tests: passed
- `scripts/lint_http_timeouts.py`: passed
- `git diff --check`: passed

A whole-`tests/` Ruff scan reports ten pre-existing issues in unrelated test files; none is in this PR's changed files. The fresh worktree's `uv run --extra dev` dependency sync is currently blocked by the existing torch 2.13.0+cu130 lock hash mismatch, so the gates above used the repository's existing clean Python 3.13 virtualenv against this worktree's source.

## Scope

This does not add a lifecycle timeout, configuration knob, new protocol token, or protocol field. Capacity pressure remains retryable and does not disable the function on the worker. No package or release is produced by this PR.
