### PR TITLE
Fix shared model residency ownership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.6"
+version = "0.26.7"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -978,6 +978,10 @@ class _ClassRecord:
     # possibly-rebound spec.models), so booking and clearing are provably
     # the same key space.
     held_refs: List[str] = dc_field(default_factory=list)
+    # The per-record object behind each booking. Residency has one entry per
+    # wire ref, so a multiply-held ref needs this map to transfer its strong
+    # representative when the latest owner leaves.
+    held_objects: Dict[str, Any] = dc_field(default_factory=dict)
     # gw#494: a resolution re-pick moved the specs' bindings away from
     # held_refs; the instance serves the OLD pick and must be vacated.
     stale: bool = False
@@ -1799,6 +1803,11 @@ class Executor:
                 lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes,
                 slot_refs=slot_refs)
             rec.held_refs = sorted(set(slot_refs.values()))
+            rec.held_objects = {}
+            for slot, ref in slot_refs.items():
+                obj = inj.loaded.get(slot, (None, 0))[0]
+                if obj is not None or ref not in rec.held_objects:
+                    rec.held_objects[ref] = obj
             rec.stale = False
         return instance
 
@@ -1953,7 +1962,12 @@ class Executor:
             # ref that appeared in the snapshot of LRU candidates.
             if res.tier(ref) is not residency_mod.Tier.RAM:
                 continue
-            rec = self._record_holding(ref)
+            owners = self._records_holding(ref)
+            if len(owners) > 1:
+                # A ref shared by several endpoint instances is not an
+                # ownership key. Their unique refs drive record teardown.
+                continue
+            rec = owners[0] if owners else None
             if rec is not None:
                 if self._record_in_use(rec):
                     continue
@@ -2029,8 +2043,13 @@ class Executor:
         # Movable demotions weren't enough: tear down idle records holding
         # non-movable LRU victims (tenant-loaded refs).
         for ref in res.lru_vram_victims():
-            rec = self._record_holding(ref)
-            if rec is None or self._record_in_use(rec):
+            owners = self._records_holding(ref)
+            if len(owners) != 1:
+                # Shared refs cannot identify which instance owns the
+                # residency object; wait for a unique record-owned victim.
+                continue
+            rec = owners[0]
+            if self._record_in_use(rec):
                 continue
             await self._vacate_record(rec)
             if await asyncio.to_thread(res.make_room, needed):
@@ -2595,14 +2614,6 @@ class Executor:
         await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
             ref=ref, state=pb.MODEL_STATE_ADOPTED, duration_ms=duration_ms)))
 
-    def _ref_in_use(self, ref: str) -> bool:
-        for job in self.jobs.values():
-            if job.finished or job.superseded or job.spec is None:
-                continue
-            if ref in (wire_ref(b) for b in job.spec.models.values()):
-                return True
-        return False
-
     def _record_refs(self, rec: _ClassRecord) -> List[str]:
         """The wire refs a record's instance holds: the load-time booking
         keys when stamped (gw#494), else the current binding derivation
@@ -2611,13 +2622,11 @@ class Executor:
             return list(rec.held_refs)
         return [wire_ref(b) for s in rec.specs for b in s.models.values()]
 
-    def _record_holding(self, ref: str) -> Optional[_ClassRecord]:
-        for rec in self._classes.values():
-            if not rec.ready:
-                continue
-            if ref in self._record_refs(rec):
-                return rec
-        return None
+    def _records_holding(self, ref: str) -> List[_ClassRecord]:
+        return [
+            rec for rec in self._classes.values()
+            if rec.ready and ref in self._record_refs(rec)
+        ]
 
     def _record_in_use(self, rec: _ClassRecord) -> bool:
         # A job on a rebound spec no longer references the record's held
@@ -2629,13 +2638,16 @@ class Executor:
             if job.spec in rec.specs:
                 return True
         for ref in self._record_refs(rec):
-            if self._ref_in_use(ref) or self.store.residency.in_use(ref):
+            owners = self._records_holding(ref)
+            if (len(owners) == 1 and owners[0] is rec
+                    and self.store.residency.in_use(ref)):
                 return True
         return False
 
     async def _vacate_record(self, rec: _ClassRecord) -> None:
-        """Tear an instance down and book every ref it held back to disk —
-        registry state and instance state move together (#369)."""
+        """Tear an instance down; publish refs with no remaining owner."""
+        held_refs = self._record_refs(rec)
+        held_objects = rec.held_objects
         inst, rec.instance, rec.ready = rec.instance, None, False
         shutdown = getattr(inst, "shutdown", None)
         if inst is not None and callable(shutdown):
@@ -2655,12 +2667,29 @@ class Executor:
                 await asyncio.to_thread(torch.cuda.empty_cache)
             except Exception:
                 pass
-        # gw#494: release exactly what the instance BOOKED (held_refs) —
-        # re-deriving from spec.models would release the wrong keys after a
-        # resolution rebind, leaving the old entries' VRAM booked forever.
-        for ref in self._record_refs(rec):
+        # gw#494: inspect exactly what the instance BOOKED (held_refs) —
+        # re-deriving from spec.models would inspect the wrong keys after a
+        # resolution rebind. A multiply-held ref stays resident until its last
+        # ready record owner leaves.
+        for ref in held_refs:
+            owners = self._records_holding(ref)
+            if owners:
+                # Residency keeps one representative object per wire ref. If
+                # it points at the departing record, transfer it to a survivor
+                # so the old pipeline can actually be collected. This is an
+                # ownership handoff, not an ON_DISK transition.
+                old_obj = held_objects.get(ref)
+                if old_obj is not None and self.store.residency.obj(ref) is old_obj:
+                    replacement = next(
+                        (owner.held_objects.get(ref) for owner in reversed(owners)
+                         if owner.held_objects.get(ref) is not None),
+                        None,
+                    )
+                    self.store.residency.replace_object(ref, replacement)
+                continue
             self.store.residency.release_to_disk(ref)
         rec.held_refs = []
+        rec.held_objects = {}
         rec.stale = False
         if rec.shared_keys:
             # Drop this record's holds on content-keyed shared components

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -235,6 +235,20 @@ class Residency:
             e = self._entries.get(ref)
             return e.obj if e else None
 
+    def replace_object(self, ref: str, obj: Any) -> bool:
+        """Replace a resident ref's bookkeeping object without a state event.
+
+        Record-owner handoff can change the representative object while the
+        same logical ref remains resident. In particular, ``None`` releases a
+        departed typed object when the surviving owner is tenant-loaded.
+        """
+        with self._lock:
+            e = self._entries.get(ref)
+            if e is None:
+                return False
+            e.obj = obj
+            return True
+
     def vram_bytes(self, ref: str) -> int:
         with self._lock:
             e = self._entries.get(ref)

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -11,6 +11,7 @@ and a load that still cannot fit fails RETRYABLE instead of thrashing.
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 import time
 import weakref
@@ -22,7 +23,7 @@ import pytest
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
 from gen_worker.capability import InsufficientHostRamError
-from gen_worker.executor import Executor, ModelStore
+from gen_worker.executor import Executor, ModelStore, _Job
 from gen_worker.models import residency as residency_mod
 from gen_worker.models.residency import Residency, Tier
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -123,6 +124,9 @@ class _FakePipe:
 
     def to(self, device: str) -> "_FakePipe":
         return self
+
+    def enable_model_cpu_offload(self) -> None:
+        pass
 
 
 def _spec(
@@ -260,7 +264,11 @@ def test_setup_vacates_warm_record_after_vram_make_room(
                 on_disk.append(rec_a.instance is None)
 
         res._on_event = _event
-        inst_b = await ex.ensure_setup(spec_b)
+        # _run_job pins refs before setup. The pre-existing shared entry is
+        # therefore execution-pinned here, but that incidental pin still must
+        # not make either older record the incoming job's active instance.
+        with res.executing("acme/shared-vae"):
+            inst_b = await ex.ensure_setup(spec_b)
         assert isinstance(inst_b.m, _FakePipe)
         assert res.tier("acme/a") is Tier.DISK
         assert rec_a.ready is False
@@ -268,6 +276,100 @@ def test_setup_vacates_warm_record_after_vram_make_room(
         await asyncio.sleep(0)
         assert pipeline() is None
         assert on_disk == [True]
+
+    asyncio.run(_run())
+
+
+def test_shared_ref_does_not_pin_idle_record_or_publish_false_disk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """pgw#542: a job's shared VAE is not ownership of every old pipeline."""
+    from gen_worker.models import disk_gc
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe, vae: _FakePipe) -> None:
+            self.pipeline = pipeline
+            self.vae = vae
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    shared = HF("acme/shared-vae")
+    spec_a = _spec(
+        "a", Endpoint, {"pipeline": HF("acme/a"), "vae": shared})
+    spec_b = _spec(
+        "b", Endpoint, {"pipeline": HF("acme/b"), "vae": shared})
+    spec_c = _spec(
+        "c", Endpoint, {"pipeline": HF("acme/c"), "vae": shared})
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda p: 6 * _GiB)
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+
+    async def _run() -> None:
+        ex = _executor([spec_a, spec_b, spec_c], tmp_path)
+        res = ex.store.residency
+        monkeypatch.setattr(
+            residency_mod, "get_available_ram_gb", lambda: 24.0)
+        await ex.ensure_setup(spec_a)
+        await ex.ensure_setup(spec_c)
+        rec_a = ex._classes[spec_a.instance_key]
+        rec_c = ex._classes[spec_c.instance_key]
+
+        async def _cached_local(ref, snapshot=None, *, binding=None) -> Path:
+            if res.local_path(ref) is None:
+                res.track_disk(ref, tmp_path)
+            return tmp_path
+
+        ex.store.ensure_local = _cached_local  # type: ignore[method-assign]
+
+        # This is the production ordering: handle_run_job installs B before
+        # its setup begins. B's shared VAE must not make A or C look active.
+        ex.jobs[("incoming", 1)] = _Job("incoming", 1, spec_b)
+        monkeypatch.setattr(
+            residency_mod,
+            "get_available_ram_gb",
+            lambda: 20.0 if rec_a.instance is None else 8.0,
+        )
+        events: list[tuple[str, str]] = []
+        res._on_event = lambda ref, state, *_: events.append((ref, state))
+        sent: list[pb.WorkerMessage] = []
+
+        async def _capture(message: pb.WorkerMessage) -> None:
+            sent.append(message)
+
+        ex._send = _capture
+
+        inst_b = await ex.ensure_setup(spec_b)
+
+        assert isinstance(inst_b.pipeline, _FakePipe)
+        assert rec_a.ready is False
+        assert rec_a.instance is None
+        assert rec_c.ready is True
+        assert res.tier("acme/a") is Tier.DISK
+        assert res.tier("acme/shared-vae") is Tier.RAM
+        assert ("acme/a", residency_mod.ON_DISK) in events
+        assert ("acme/shared-vae", residency_mod.ON_DISK) not in events
+        assert not any(
+            message.WhichOneof("msg") == "model_event"
+            and message.model_event.state == pb.MODEL_STATE_FAILED
+            for message in sent
+        )
+
+        # The latest-loaded B owns Residency.obj(shared). Removing B while C
+        # survives must transfer that strong reference to C, not retain B's
+        # VAE or falsely publish shared as ON_DISK.
+        rec_b = ex._classes[spec_b.instance_key]
+        b_vae = weakref.ref(inst_b.vae)
+        c_vae = rec_c.instance.vae
+        ex.jobs.pop(("incoming", 1))
+        events.clear()
+        del inst_b
+        await ex._vacate_record(rec_b)
+        gc.collect()
+
+        assert b_vae() is None
+        assert res.obj("acme/shared-vae") is c_vae
+        assert res.tier("acme/shared-vae") is Tier.RAM
+        assert not [event for event in events if event[0] == "acme/shared-vae"]
 
     asyncio.run(_run())
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.6"
+version = "0.26.7"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- make host-RAM eviction choose endpoint records by unambiguous ownership instead of treating a multiply-held shared model ref as the record owner
- scope active-use decisions to the actual endpoint record while preserving unique-ref execution pins
- keep shared-ref residency truthful through last-owner publication and state-neutral representative-object handoff
- bump the package version to 0.26.7 for the post-merge release

## Validation

- `tests/test_ram_admission.py`: 9 passed
- #542 regression: 25/25 fresh-process stress repetitions
- CPU/CI-equivalent full suite: 1,074 passed, 24 skipped
- mypy: zero issues in 114 source files
- Ruff: passed
- HTTP timeout lint: passed
- `uv lock --check --offline`: passed
- CUDA-enabled full suite: 1,084 passed, 13 skipped, with one unrelated lane-swap assertion failure reproduced unchanged on clean `origin/master`
