### PR TITLE
Account for reclaimable cgroup page cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.7"
+version = "0.26.8"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -260,6 +260,38 @@ def cgroup_memory_current_bytes(
     return _read_cgroup_int(root / "memory" / "memory.usage_in_bytes")
 
 
+def _read_cgroup_stat(path: Path) -> Optional[Dict[str, int]]:
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return None
+    values: Dict[str, int] = {}
+    for line in lines:
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            value = int(parts[1])
+        except ValueError:
+            continue
+        if value >= 0:
+            values[parts[0]] = value
+    return values
+
+
+def _cgroup_inactive_file_bytes(
+    root: Path = _CGROUP_ROOT,
+    proc_self_cgroup: Path = _PROC_SELF_CGROUP,
+) -> int:
+    """Kernel-reclaimable inactive-file bytes used by cgroup working set."""
+    for node in reversed(_v2_cgroup_nodes(root, proc_self_cgroup)):
+        stats = _read_cgroup_stat(node / "memory.stat")
+        if stats is not None:
+            return stats.get("inactive_file", 0)
+    stats = _read_cgroup_stat(root / "memory" / "memory.stat") or {}
+    return stats.get("total_inactive_file", stats.get("inactive_file", 0))
+
+
 def probe_host_ram(
     *,
     root: Path = _CGROUP_ROOT,
@@ -287,7 +319,15 @@ def probe_host_ram(
         )
     limit_gb = float(limit) / float(_GIB)
     current = cgroup_memory_current_bytes(root, proc_self_cgroup)
-    cg_avail_gb = max(0.0, float(limit - (current or 0)) / float(_GIB))
+    # #543: memory.current includes filesystem page cache. Repeated model
+    # downloads/loads can fill a pod's cgroup with inactive file page cache
+    # even after the corresponding pipeline objects are gone. The kernel
+    # reclaims pages on the inactive file LRU under pressure; count the same
+    # conservative working set used by production container schedulers instead
+    # of treating those pages as anonymous model memory.
+    inactive_file = _cgroup_inactive_file_bytes(root, proc_self_cgroup)
+    working_set = max(0, (current or 0) - inactive_file)
+    cg_avail_gb = max(0.0, float(limit - working_set) / float(_GIB))
     total = min(meminfo_total, limit_gb) if meminfo_total > 0 else limit_gb
     avail = min(meminfo_available, cg_avail_gb) if meminfo_available > 0 else cg_avail_gb
     constrained = meminfo_total <= 0 or limit_gb < meminfo_total

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -16,14 +16,19 @@ import logging
 import time
 import weakref
 from pathlib import Path
+from types import SimpleNamespace
 
 import msgspec
+import psutil
 import pytest
 
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
+from gen_worker.api.slot import Slot
 from gen_worker.capability import InsufficientHostRamError
 from gen_worker.executor import Executor, ModelStore, _Job
+from gen_worker.lifecycle import Lifecycle
+from gen_worker.models import memory as memory_mod
 from gen_worker.models import residency as residency_mod
 from gen_worker.models.residency import Residency, Tier
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -370,6 +375,137 @@ def test_shared_ref_does_not_pin_idle_record_or_publish_false_disk(
         assert res.obj("acme/shared-vae") is c_vae
         assert res.tier("acme/shared-vae") is Tier.RAM
         assert not [event for event in events if event[0] == "acme/shared-vae"]
+
+    asyncio.run(_run())
+
+
+def test_declarative_ninth_sdxl_load_uses_reclaimable_cgroup_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#543: inactive file cache must not look like live SDXL pipeline RAM.
+
+    The injected cgroup observation stays at its byte limit while anonymous
+    pipeline memory is replaced by inactive model-file cache.  Raw
+    ``memory.current`` therefore never falls, exactly the false admission
+    signal seen by e2e #170.  The production DesiredResidency reconciler must
+    use reclaimable working-set headroom, vacate the minimum idle records, and
+    load model nine without a timer or retry loop.
+    """
+    from gen_worker.models import disk_gc
+
+    live: weakref.WeakSet[object] = weakref.WeakSet()
+
+    def _load(cls, path, **kwargs):
+        obj = cls()
+        live.add(obj)
+        return obj
+
+    monkeypatch.setattr(_FakePipe, "from_pretrained", classmethod(_load))
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe, vae: _FakePipe) -> None:
+            self.pipeline = pipeline
+            self.vae = vae
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    base_pipeline = HF("acme/sdxl-0")
+    shared_vae = HF("acme/sdxl-vae")
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="run", models={"pipeline": base_pipeline, "vae": shared_vae},
+        slots={
+            "pipeline": Slot(_FakePipe, default_checkpoint=base_pipeline),
+            "vae": Slot(_FakePipe, default_checkpoint=shared_vae),
+        },
+        resources=Resources(vram_gb=12),
+    )
+    ex = _executor([spec], tmp_path)
+    sent: list[pb.WorkerMessage] = []
+
+    async def _capture(message: pb.WorkerMessage) -> None:
+        sent.append(message)
+
+    ex._send = _capture
+    lifecycle = Lifecycle(
+        SimpleNamespace(worker_jwt="", worker_id="worker", runpod_pod_id=""),
+        ex,
+    )
+    model_bytes = 6_941_377_969
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda path: model_bytes)
+
+    root = tmp_path / "cgroup"
+    root.mkdir(exist_ok=True)
+    proc = tmp_path / "proc-self-cgroup"
+    proc.write_text("0::/\n")
+    limit = 31 * _GiB
+    (root / "memory.max").write_text(str(limit))
+    (root / "memory.current").write_text(str(limit))
+    pressure = False
+    object_bytes = 7 * _GiB // 5  # 1.4GiB per pipeline/VAE object
+
+    monkeypatch.setattr(
+        psutil, "virtual_memory",
+        lambda: SimpleNamespace(total=125 * _GiB, available=125 * _GiB),
+    )
+
+    def _ram() -> memory_mod.HostRam:
+        if not pressure:
+            inactive = limit
+        else:
+            working = len(live) * object_bytes
+            inactive = max(0, limit - working)
+        (root / "memory.stat").write_text(f"inactive_file {inactive}\n")
+        return memory_mod.probe_host_ram(root=root, proc_self_cgroup=proc)
+
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(
+        residency_mod, "get_available_ram_gb",
+        lambda: 31.0 if not pressure else _ram().available_gb,
+    )
+
+    async def _apply(generation: int, pipeline_ref: str) -> None:
+        await lifecycle.on_hello_ack(pb.HelloAck(
+            desired_residency=pb.DesiredResidency(
+                generation=generation,
+                hot=[pb.DesiredInstance(
+                    function_name="generate",
+                    models=[
+                        pb.ModelBinding(slot="pipeline", ref=pipeline_ref),
+                        pb.ModelBinding(slot="vae", ref="tensorhub/sdxl-vae:prod"),
+                    ],
+                )],
+            ),
+        ))
+        task = lifecycle._residency_task
+        assert task is not None
+        await asyncio.wait_for(asyncio.shield(task), 2)
+
+    async def _run() -> None:
+        nonlocal pressure
+        for i in range(8):
+            await _apply(i + 1, f"tensorhub/sdxl-{i}:prod")
+        assert len(live) == 16
+        old_records = [rec for rec in ex._classes.values() if rec.ready]
+
+        pressure = True
+        await _apply(9, "tensorhub/sdxl-8:prod")
+
+        ninth = next(
+            rec for rec in ex._classes.values()
+            if rec.ready and "tensorhub/sdxl-8:prod" in ex._record_refs(rec)
+        )
+        assert ninth.instance is not None
+        assert sum(not rec.ready for rec in old_records) == 2
+        assert len(live) == 14
+        assert not [
+            msg for msg in sent
+            if msg.WhichOneof("msg") == "model_event"
+            and msg.model_event.state == pb.MODEL_STATE_FAILED
+        ]
+        lifecycle._cancel_residency_reconcile()
 
     asyncio.run(_run())
 

--- a/tests/test_ram_budget.py
+++ b/tests/test_ram_budget.py
@@ -107,6 +107,54 @@ def test_probe_caps_meminfo_at_cgroup_limit(tmp_path: Path) -> None:
     assert ram.meminfo_total_gb > 4.0
 
 
+def test_probe_counts_inactive_file_as_reclaimable_headroom(tmp_path: Path) -> None:
+    """#543: model reads may fill a cgroup's inactive file page cache.
+
+    ``memory.current`` includes that cache, but the kernel can reclaim pages on
+    the inactive file LRU for the next tensor allocation.  Admission therefore
+    uses cgroup working set, not raw usage.
+    """
+    root, proc = _fake_cgroup(
+        tmp_path,
+        files={
+            "memory.max": str(4 * _GiB),
+            "memory.current": str(3 * _GiB),
+            "memory.stat": f"anon {_GiB}\ninactive_file {2 * _GiB}\n",
+        },
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert ram.available_gb == pytest.approx(3.0)
+
+
+def test_probe_keeps_active_file_in_cgroup_working_set(tmp_path: Path) -> None:
+    """Only the kernel's inactive file list is treated as ready headroom."""
+    root, proc = _fake_cgroup(
+        tmp_path,
+        files={
+            "memory.max": str(4 * _GiB),
+            "memory.current": str(3 * _GiB),
+            "memory.stat": (
+                f"inactive_file {_GiB}\nactive_file {_GiB}\n"
+            ),
+        },
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert ram.available_gb == pytest.approx(2.0)
+
+
+def test_probe_uses_v1_hierarchical_inactive_file(tmp_path: Path) -> None:
+    root, proc = _fake_cgroup(
+        tmp_path,
+        files={
+            "memory/memory.limit_in_bytes": str(4 * _GiB),
+            "memory/memory.usage_in_bytes": str(3 * _GiB),
+            "memory/memory.stat": f"total_inactive_file {2 * _GiB}\n",
+        },
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert ram.available_gb == pytest.approx(3.0)
+
+
 def test_probe_without_cgroup_is_meminfo_passthrough(tmp_path: Path) -> None:
     root, proc = _fake_cgroup(tmp_path, files={})
     ram = probe_host_ram(root=root, proc_self_cgroup=proc)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.7"
+version = "0.26.8"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What changed

- compute cgroup RAM headroom from `memory.current - inactive_file`
- support cgroup v2 `inactive_file` and v1 `total_inactive_file`
- preserve the existing conservative behavior when `memory.stat` is absent or malformed
- add a production-shaped DesiredResidency regression covering eight resident SDXL records plus a ninth load
- bump the publishable worker release from `0.26.7` to `0.26.8`

## Root cause and live evidence

During e2e tracker #170, RunPod worker `q3narhpnlx8gut` (RTX 3090, 31 GiB cgroup limit) successfully served eight distinct approximately 6.94 GB SDXL pipelines. The ninth request, `de175637-30c9-46fc-be12-1a2ec76bc3d9` for `tensorhub/nova-furry-xl:prod`, reached ON_DISK but failed admission three times with `insufficient_host_ram`.

The worker had vacated the older endpoint records, but raw `memory.current` stayed at the cgroup limit because it includes inactive model-file page cache. The kernel can reclaim those inactive-file pages under pressure, so treating the raw counter as live anonymous pipeline memory produced false zero headroom.

This change uses the standard cgroup working-set signal while retaining `min(meminfo.available, cgroup_available)` as the global safety cap. It adds no configuration, environment variables, timers, dependencies, imperative model commands, or malloc trimming.

## Validation

- `tests/test_ram_budget.py tests/test_ram_admission.py`: 24 passed
- selective declarative residency / worker gRPC gate: 32 passed, 17 deselected
- full suite: 1,088 passed, 13 skipped, 1 failed
  - the one lane-swap failure reproduces identically on clean `origin/master` and is unrelated CUDA-shaped baseline behavior
- full source mypy: passed
- Ruff on changed source/tests: passed
- HTTP-timeout lint: passed
- `uv lock --check`: passed
- `uv sync --locked --extra dev --dry-run`: passed
- `uv build`: produced `gen_worker-0.26.8` wheel and sdist with matching metadata
- `git diff --check`: passed
- zero conflict markers
- the new regression failed before the source fix and passes after it

A full local `uv run --extra dev` dependency synchronization is currently blocked by an external `torch==2.13.0+cu130` artifact hash mismatch. Tests used the clean repository's prepared virtualenv with `PYTHONPATH=src`; neither torch pins nor dependency hashes were changed.

## Known pre-existing caveat

The existing probe selects the tightest cgroup ancestor limit but reads current/stat from the deepest node. A sibling-constrained ancestor can therefore overstate headroom. That hierarchy pairing issue is intentionally excluded from this narrow RunPod leaf-cgroup fix and is tracked separately as #544.