### PR TITLE
hub_policy: probe modelopt in the known optional-libs list (0.26.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.26.9 (2026-07-15)
+
+- hub_policy: probe `modelopt` in the known optional-libs list (te#79
+  regression: `Resources(libraries=("modelopt",))` functions were
+  structurally unavailable — the executor's find_spec fallback passed but
+  plan_serve re-checked installed_libs, which never probed modelopt).
+
+
 ## 0.26.1 (2026-07-14)
 
 - **NVENC per-request fallback recreates the PyAV output container.** A

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.8"
+version = "0.26.9"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -41,7 +41,7 @@ def detect_worker_capabilities(*, extra_libs: Optional[List[str]] = None) -> Ten
     # Known optional libs that affect artifact compatibility.
     # Keep this hardcoded (no env config), per Cozy design.
     known = ["bitsandbytes", "torchao", "transformer_engine", "tensorrt",
-             "nunchaku", "deepcompressor"]
+             "nunchaku", "deepcompressor", "modelopt"]
     if extra_libs:
         known.extend(extra_libs)
     for name in known:

--- a/tests/test_serve_fit.py
+++ b/tests/test_serve_fit.py
@@ -176,3 +176,15 @@ def test_stored_flavor_that_does_not_fit_offloads_not_requants() -> None:
         binding=_Binding(flavor="fp8"),
     )
     assert plan.serveable and plan.run_mode == RUN_OFFLOAD
+
+
+def test_detect_probes_modelopt(monkeypatch):
+    """te#79 regression: `Resources(libraries=("modelopt",))` functions were
+    structurally unavailable — the executor's find_spec fallback passed but
+    plan_serve re-checked against installed_libs, which never probed
+    modelopt. The known-libs list must include it."""
+    from gen_worker.models import hub_policy
+
+    monkeypatch.setattr(hub_policy, "_is_importable", lambda name: True)
+    caps = hub_policy.detect_worker_capabilities()
+    assert "modelopt" in caps.installed_libs

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.8"
+version = "0.26.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Found live during te#79's qwen fp8-w8a8 production run (first `modelopt-quantization` dispatch on the 0.26.x fleet):

- The executor's function gate checks declared `Resources.libraries` with an `importlib.util.find_spec` fallback — `modelopt` passes.
- But `plan_serve` -> `variant_fit` re-validates against `detect_worker_capabilities().installed_libs`, whose hardcoded known-libs probe list (`bitsandbytes, torchao, transformer_engine, tensorrt, nunchaku, deepcompressor`) never probed `modelopt`, and `lifecycle.py` passes no `extra_libs`.
- Net effect: every function declaring `libraries=("modelopt",)` is FIT_INCOMPATIBLE on every 0.26.x worker (`worker_function_unavailable ... detail="missing libraries: modelopt"`), the request queue never drains, and the autoscaler loops creating pods (observed: 3 idle H100s for one queued quant).

Fix: add `modelopt` to the known optional-libs list — it gates artifact compatibility exactly like the other entries. Regression test pins that the list probes it.

Full suite: 1089 passed / 13 skipped; the one `test_content_lanes` failure pre-exists on master in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)