### PR TITLE
Fix OOM quarantine for component models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.9"
+version = "0.26.10"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3179,16 +3179,25 @@ class Executor:
             return
         if spec.output_mode == "stream":
             return  # chunks already emitted; a replay would duplicate them
+        # Diffusers component models expose some pipeline offload methods too
+        # (notably AutoencoderKL via ModelMixin). Exclude only that known
+        # component base, then retain the capability check below so custom
+        # duck-typed pipeline owners continue to work.
+        diffusers_component_type: Any = ()
+        try:
+            from diffusers import ModelMixin
+
+            diffusers_component_type = ModelMixin
+        except ImportError:
+            pass
         transitions: List[Tuple[str, str, str, float]] = []
         for slot in spec.models:
             ref = wire_ref(spec.models[slot])
             obj = self.store.residency.obj(ref)
             if obj is None:
                 continue
-            # Component modules (for example a separately injected VAE) do
-            # not own a Diffusers offload surface. The enclosing pipeline is
-            # the transition owner; assigning a fake floor to the component
-            # would only poison its next load.
+            if diffusers_component_type and isinstance(obj, diffusers_component_type):
+                continue
             if not any(callable(getattr(obj, name, None)) for name in (
                 "enable_model_cpu_offload",
                 "enable_group_offload",

--- a/tests/test_oom_degraded_ladder.py
+++ b/tests/test_oom_degraded_ladder.py
@@ -19,7 +19,7 @@ import pytest
 torch = pytest.importorskip("torch")
 diffusers = pytest.importorskip("diffusers")
 
-from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+from diffusers import AutoencoderKL, DDPMPipeline, DDPMScheduler, UNet2DModel
 
 from gen_worker.api.binding import HF
 from gen_worker.api.decorators import Resources
@@ -307,6 +307,75 @@ def test_inference_oom_quarantines_then_reloads_on_retry(
         pipe = ex.store.residency.obj("acme/tiny")
         assert pipe is not old_pipe
         assert memory.low_vram_mode(pipe) == "model_offload"
+
+    asyncio.run(_go())
+
+
+def test_inference_oom_floor_excludes_component_and_preserves_duck_owner(
+        shim_env, tmp_path) -> None:
+    """AutoencoderKL exposes ``enable_group_offload`` through ModelMixin, but
+    it is a component, not the owner of the pipeline's offload hooks. A floor
+    learned for the VAE reloads it on CPU and poisons later CUDA pipelines.
+    Custom duck-typed pipeline owners remain supported."""
+    class ShimVAE(AutoencoderKL):
+        def __init__(self) -> None:
+            # The quarantine test needs ModelMixin's real method surface, not
+            # AutoencoderKL weights.
+            torch.nn.Module.__init__(self)
+            self._cozy_low_vram_mode = "vae_only"
+
+    class DuckPipe:
+        _cozy_low_vram_mode = "vae_only"
+
+        def enable_model_cpu_offload(self) -> None:  # pragma: no cover
+            pass
+
+    class Endpoint:
+        def setup(self, pipeline: ShimPipe, vae: ShimVAE, custom: DuckPipe) -> None:
+            self.pipeline = pipeline
+            self.vae = vae
+            self.custom = custom
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="fn", method=Endpoint.run, kind="inference", payload_type=_In,
+        output_mode="single", cls=Endpoint, attr_name="run",
+        models={
+            "pipeline": HF("acme/pipeline"),
+            "vae": HF("acme/vae"),
+            "custom": HF("acme/custom-pipeline"),
+        },
+        resources=Resources(vram_gb=1.0),
+    )
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, shim_env, sent)
+        ShimPipe.reset(oom_on_cuda=False)
+        pipe = ShimPipe.from_pretrained(str(shim_env))
+        pipe._cozy_low_vram_mode = "vae_only"
+        vae = ShimVAE()
+        assert callable(getattr(vae, "enable_group_offload", None))
+        assert memory.low_vram_mode(vae) == "vae_only"
+        ex.store.residency.track_vram("acme/pipeline", pipe, vram_bytes=1)
+        ex.store.residency.track_vram("acme/vae", vae, vram_bytes=1)
+        ex.store.residency.track_vram(
+            "acme/custom-pipeline", DuckPipe(), vram_bytes=1)
+        rec = ex._classes[spec.instance_key]
+        rec.instance, rec.ready = Endpoint(), True
+
+        ctx = type("Ctx", (), {"cancelled": False, "log": lambda *a, **k: None})()
+        await ex._quarantine_for_oom(
+            spec, ctx, OOM("CUDA out of memory (injected mid-inference)"))
+
+        assert ex.degraded_floor == {
+            "acme/pipeline": "model_offload",
+            "acme/custom-pipeline": "model_offload",
+        }
+        assert "acme/vae" not in ex.degraded_floor
+        assert rec.stale
 
     asyncio.run(_go())
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.9"
+version = "0.26.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Root cause

The real SDXL soak exposed a CUDA OOM recovery bug: `AutoencoderKL` inherits Diffusers `ModelMixin.enable_group_offload`, so the worker treated the separately injected VAE as a pipeline offload owner. The learned `model_offload` floor reloaded VAE weights on CPU and injected them into a CUDA pipeline, producing repeatable HalfTensor device mismatches.

## Fix

- Exclude Diffusers `ModelMixin` components from reactive pipeline offload-floor learning.
- Preserve the existing capability seam for real Diffusers pipelines and custom duck-typed pipeline owners.
- Add a real `AutoencoderKL` regression and bump the package to 0.26.10.
- No protocol, scheduler, timeout, lifecycle, environment, or configuration changes.

## Validation

- focused OOM file: 14 passed
- OOM/declarative/dynamic-slot/gRPC integration set: 54 passed, 1 deselected
- full suite: 1,090 passed, 13 skipped, with one unrelated failure reproduced on exact origin/master
- mypy: 114 files clean
- changed-file Ruff, lock check, diff check, package build: pass
- signed commit independently reviewed with no blocking findings

Live evidence: e2e #170 run `e2e170-sdxl170c-20260715T193744Z` completed 46 requests before two identical recovery failures; failed reservations released correctly and the fleet naturally reached zero.