### PR TITLE
gw#547: runtime LoRA on the w8a8 serve lane (bf16 side-branch, rank-bucketed hot-swap)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.10"
+version = "0.26.11"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/scripts/w8a8_lora_bench.py
+++ b/scripts/w8a8_lora_bench.py
@@ -1,0 +1,302 @@
+"""W8A8 runtime-LoRA branch bench + quality A/B (gw#547).
+
+perf mode (no downloads): SDXL-class Fp8ScaledLinear GEMM stack on the
+current GPU — branch tax per rank bucket vs branchless, hot-swap latency,
+and dynamo recompile counters across swaps on a compiled stack.
+
+quality mode: same-seed A/B of real LoRAs on a real base — LoRA-on-w8a8
+(bf16 side-branch) vs LoRA-on-bf16 (today's peft serving path), plus the
+base-vs-base fp8 noise floor at the same seeds. Reports MAE / PSNR / LPIPS.
+
+Run on a rented SECURE pod (never a dev box):
+  python scripts/w8a8_lora_bench.py --mode perf --out /tmp/lora-bench
+  python scripts/w8a8_lora_bench.py --mode quality --base stabilityai/stable-diffusion-xl-base-1.0 \
+      --lora nerijs/pixel-art-xl --lora CiroN2022/toy-face --steps 20 --out /tmp/lora-bench
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+BUCKETS = (16, 32, 64, 128)
+# (rows, in, out) SDXL-class UNet GEMMs at 1024px: down/mid attn qkv/out + ff.
+STACK = [
+    (4096, 640, 640), (4096, 640, 640), (4096, 640, 640), (4096, 640, 640),
+    (4096, 640, 5120), (4096, 2560, 640),
+    (1024, 1280, 1280), (1024, 1280, 1280), (1024, 1280, 1280), (1024, 1280, 1280),
+    (1024, 1280, 10240), (1024, 5120, 1280),
+]
+
+
+def _build_stack(bucket: int = 0):
+    import torch
+
+    from gen_worker.models.w8a8 import fp8_scaled_linear_class
+    from gen_worker.models.w8a8_lora import alloc_branch_buffers
+
+    cls = fp8_scaled_linear_class()
+    mods = []
+    for _rows, k, n in STACK:
+        w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+        scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+        wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+        m = cls(k, n, bias=False, compute_dtype=torch.bfloat16,
+                static_input_scale=False)
+        m.load_state_dict({"weight": wq, "weight_scale": scale}, assign=True)
+        if bucket:
+            alloc_branch_buffers(m, bucket)
+            m.lora_a.normal_()
+            m.lora_b.normal_(std=0.01)
+        mods.append(m)
+    return mods
+
+
+def _time_stack(mods, iters: int = 50) -> float:
+    import torch
+
+    xs = [torch.randn(rows, k, device="cuda", dtype=torch.bfloat16)
+          for (rows, k, _n) in STACK]
+    for m, x in zip(mods, xs):
+        m(x)
+    torch.cuda.synchronize()
+    t0 = time.monotonic()
+    for _ in range(iters):
+        for m, x in zip(mods, xs):
+            m(x)
+    torch.cuda.synchronize()
+    return (time.monotonic() - t0) / iters * 1000.0
+
+
+def run_perf(out: Path) -> dict:
+    import torch
+
+    base_ms = _time_stack(_build_stack(0))
+    report: dict = {"branchless_ms": round(base_ms, 3), "buckets": {}}
+    for b in BUCKETS:
+        mods = _build_stack(b)
+        ms = _time_stack(mods)
+        # hot-swap latency: copy a full adapter set into the resident buffers
+        news = [(torch.randn_like(m.lora_a), torch.randn_like(m.lora_b)) for m in mods]
+        torch.cuda.synchronize()
+        t0 = time.monotonic()
+        for m, (a, bb) in zip(mods, news):
+            m.lora_a.copy_(a)
+            m.lora_b.copy_(bb)
+        torch.cuda.synchronize()
+        swap_ms = (time.monotonic() - t0) * 1000.0
+        report["buckets"][b] = {
+            "stack_ms": round(ms, 3),
+            "tax_pct": round((ms / base_ms - 1.0) * 100.0, 2),
+            "swap_ms_device": round(swap_ms, 2),
+        }
+        print(f"bucket {b}: {ms:.3f}ms vs {base_ms:.3f}ms "
+              f"(+{report['buckets'][b]['tax_pct']}%), swap {swap_ms:.2f}ms")
+
+    # no-recompile proof on a compiled member of the stack
+    import torch._dynamo as dynamo
+
+    dynamo.reset()
+    mods = _build_stack(16)
+    m = mods[0]
+    cm = torch.compile(m)
+    x = torch.randn(STACK[0][0], STACK[0][1], device="cuda", dtype=torch.bfloat16)
+    cm(x)
+    before = dynamo.utils.counters["stats"]["unique_graphs"]
+    swaps = []
+    for _ in range(6):
+        a, bb = torch.randn_like(m.lora_a), torch.randn_like(m.lora_b)
+        torch.cuda.synchronize()
+        t0 = time.monotonic()
+        m.lora_a.copy_(a)
+        m.lora_b.copy_(bb)
+        cm(x)
+        torch.cuda.synchronize()
+        swaps.append((time.monotonic() - t0) * 1000.0)
+    after = dynamo.utils.counters["stats"]["unique_graphs"]
+    report["compiled_swap"] = {
+        "unique_graphs_before": before, "unique_graphs_after": after,
+        "recompiled": after != before,
+        "swap_plus_forward_ms": [round(s, 2) for s in swaps],
+    }
+    print(f"compiled swaps: graphs {before}->{after} recompiled={after != before}")
+    return report
+
+
+def _mae_psnr(a, b):
+    import numpy as np
+
+    a = np.asarray(a).astype("float32") / 255.0
+    b = np.asarray(b).astype("float32") / 255.0
+    mae = float(np.abs(a - b).mean())
+    mse = float(((a - b) ** 2).mean())
+    psnr = float("inf") if mse == 0 else 10.0 * float(np.log10(1.0 / mse))
+    return mae, psnr
+
+
+def _lpips_fn():
+    try:
+        import lpips
+        import numpy as np
+        import torch
+    except ImportError:
+        return None
+    loss = lpips.LPIPS(net="alex", verbose=False).cuda()
+
+    def f(a, b):
+        def t(x):
+            v = torch.from_numpy(np.asarray(x)).float().permute(2, 0, 1) / 127.5 - 1.0
+            return v.unsqueeze(0).cuda()
+
+        with torch.no_grad():
+            return float(loss(t(a), t(b)).item())
+
+    return f
+
+
+PROMPTS = [
+    "portrait of a woman in a forest, golden hour, detailed face",
+    "a red sports car on a coastal road, dramatic clouds",
+    "isometric cozy coffee shop interior, warm lighting",
+    "a knight standing on a cliff, stormy sea below",
+]
+
+
+def _render(pipe, prompt: str, seed: int, steps: int):
+    import torch
+
+    g = torch.Generator("cuda").manual_seed(seed)
+    return pipe(prompt=prompt, num_inference_steps=steps, generator=g,
+                output_type="np").images[0]
+
+
+def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
+    import numpy as np  # noqa: F401
+    import torch
+    from diffusers import StableDiffusionXLPipeline
+    from huggingface_hub import hf_hub_download, snapshot_download
+    from safetensors.torch import load_file
+
+    from gen_worker.models.w8a8 import (
+        detect_w8a8_artifact, load_w8a8_pipeline, quantize_tree_w8a8,
+    )
+    from gen_worker.models import w8a8_lora
+
+    lp = _lpips_fn()
+    src = Path(snapshot_download(base))
+    tree = out / "w8a8-tree"
+    if not (tree / "model_index.json").exists():
+        quantize_tree_w8a8(src, tree)
+
+    lora_sds = {}
+    for ref in loras:
+        f = None
+        try:
+            from huggingface_hub import list_repo_files
+
+            files = [x for x in list_repo_files(ref) if x.endswith(".safetensors")]
+            f = hf_hub_download(ref, sorted(files)[0])
+        except Exception as exc:
+            print(f"skip {ref}: {exc}")
+            continue
+        lora_sds[ref] = load_file(f)
+
+    def render_lane(w8a8_lane: bool) -> dict:
+        imgs: dict = {}
+        if w8a8_lane:
+            art = detect_w8a8_artifact(tree)
+            assert art is not None
+            pipe = load_w8a8_pipeline(
+                StableDiffusionXLPipeline, tree, art,
+                compute_dtype=torch.bfloat16)
+        else:
+            pipe = StableDiffusionXLPipeline.from_pretrained(
+                str(src), torch_dtype=torch.bfloat16)
+        pipe.to("cuda")
+        pipe.set_progress_bar_config(disable=True)
+        # base (no lora)
+        t0 = time.monotonic()
+        imgs[("base", 0)] = _render(pipe, PROMPTS[0], 1234, steps)
+        imgs[("base_wall_s", 0)] = time.monotonic() - t0
+        for i, p in enumerate(PROMPTS[1:], 1):
+            imgs[("base", i)] = _render(pipe, p, 1234 + i, steps)
+        swap_stats = []
+        for ref, sd in lora_sds.items():
+            if w8a8_lane:
+                den = w8a8_lora.branch_target(pipe)
+                dsd, rest = w8a8_lora.split_state_dict(sd)
+                t0 = time.monotonic()
+                st = w8a8_lora.apply_branch_adapters(den, [(dsd, 1.0, ref)])
+                swap_stats.append({"ref": ref, **st})
+                if rest:
+                    pipe.load_lora_weights(dict(rest), adapter_name="te")
+                    pipe.set_adapters(["te"], adapter_weights=[1.0])
+            else:
+                pipe.load_lora_weights(dict(sd), adapter_name=ref.replace("/", "-"))
+                pipe.set_adapters([ref.replace("/", "-")], adapter_weights=[1.0])
+            for i, p in enumerate(PROMPTS):
+                imgs[(ref, i)] = _render(pipe, p, 4321 + i, steps)
+            if w8a8_lane:
+                w8a8_lora.clear_branch_adapters(w8a8_lora.branch_target(pipe))
+                if hasattr(pipe, "disable_lora"):
+                    try:
+                        pipe.disable_lora()
+                    except Exception:
+                        pass
+            else:
+                pipe.disable_lora()
+        imgs["swap_stats"] = swap_stats
+        del pipe
+        torch.cuda.empty_cache()
+        return imgs
+
+    ref_imgs = render_lane(False)
+    cand_imgs = render_lane(True)
+
+    report: dict = {"base": base, "steps": steps, "loras": list(lora_sds),
+                    "swap_stats": cand_imgs.pop("swap_stats"),
+                    "rows": []}
+    ref_imgs.pop("swap_stats", None)
+    from PIL import Image
+
+    for key in [k for k in ref_imgs if isinstance(k, tuple) and k[0] != "base_wall_s"]:
+        name, i = key
+        a = (ref_imgs[key] * 255).clip(0, 255).astype("uint8")
+        b = (cand_imgs[key] * 255).clip(0, 255).astype("uint8")
+        mae, psnr = _mae_psnr(a, b)
+        row = {"lora": name, "prompt": i, "mae": round(mae, 5),
+               "psnr": round(psnr, 2)}
+        if lp is not None:
+            row["lpips"] = round(lp(a, b), 4)
+        report["rows"].append(row)
+        tag = f"{str(name).replace('/', '-')}-{i}"
+        Image.fromarray(a).save(out / f"bf16-{tag}.png")
+        Image.fromarray(b).save(out / f"w8a8-{tag}.png")
+        print(row)
+    return report
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=("perf", "quality", "all"), default="perf")
+    ap.add_argument("--base", default="stabilityai/stable-diffusion-xl-base-1.0")
+    ap.add_argument("--lora", action="append", default=[])
+    ap.add_argument("--steps", type=int, default=20)
+    ap.add_argument("--out", default="/tmp/w8a8-lora-bench")
+    args = ap.parse_args()
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report: dict = {}
+    if args.mode in ("perf", "all"):
+        report["perf"] = run_perf(out)
+    if args.mode in ("quality", "all"):
+        loras = args.lora or ["nerijs/pixel-art-xl", "CiroN2022/toy-face"]
+        report["quality"] = run_quality(args.base, loras, args.steps, out)
+    (out / "report.json").write_text(json.dumps(report, indent=2))
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/w8a8_lora_bench.py
+++ b/scripts/w8a8_lora_bench.py
@@ -238,9 +238,13 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
                 if rest:
                     pipe.load_lora_weights(dict(rest), adapter_name="te")
                     pipe.set_adapters(["te"], adapter_weights=[1.0])
+                    pipe.enable_lora()
             else:
                 pipe.load_lora_weights(dict(sd), adapter_name=ref.replace("/", "-"))
                 pipe.set_adapters([ref.replace("/", "-")], adapter_weights=[1.0])
+                # set_adapters does NOT clear a prior disable_lora flag — the
+                # same pitfall production lora_util handles with enable_lora.
+                pipe.enable_lora()
             for i, p in enumerate(PROMPTS):
                 imgs[(ref, i)] = _render(pipe, p, 4321 + i, steps)
             if w8a8_lane:

--- a/scripts/w8a8_lora_bench.py
+++ b/scripts/w8a8_lora_bench.py
@@ -185,7 +185,11 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
     from gen_worker.models import w8a8_lora
 
     lp = _lpips_fn()
-    src = Path(snapshot_download(base))
+    # fp16-variant weights only — the stock SDXL repo is ~40GB with all
+    # variants; pods don't have the disk for that.
+    src = Path(snapshot_download(base, allow_patterns=[
+        "*.json", "**/*.json", "**/*.txt", "**/*.model",
+        "**/*.fp16.safetensors"]))
     tree = out / "w8a8-tree"
     if not (tree / "model_index.json").exists():
         quantize_tree_w8a8(src, tree)
@@ -210,10 +214,11 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
             assert art is not None
             pipe = load_w8a8_pipeline(
                 StableDiffusionXLPipeline, tree, art,
-                compute_dtype=torch.bfloat16)
+                compute_dtype=torch.bfloat16,
+                components={"variant": "fp16"})
         else:
             pipe = StableDiffusionXLPipeline.from_pretrained(
-                str(src), torch_dtype=torch.bfloat16)
+                str(src), torch_dtype=torch.bfloat16, variant="fp16")
         pipe.to("cuda")
         pipe.set_progress_bar_config(disable=True)
         # base (no lora)

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -126,7 +126,9 @@ def gen_worker_version() -> str:
 def lane_token(weight_lane: str) -> str:
     """Label token for a traced weight lane (gw#534): cells of different
     lanes are DIFFERENT graphs and must not collide on one flavor label.
-    "" (plain resident, incl. bf16-resident) stays unsuffixed."""
+    "" (plain resident, incl. bf16-resident) stays unsuffixed. LoRA-branch
+    lanes (``w8a8-lora<bucket>``, gw#547) pass through — one graph family
+    per rank bucket."""
     return {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8"}.get(
         str(weight_lane or ""), str(weight_lane))
 

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -154,10 +154,19 @@ def _build_module_class() -> type:
         scalars are expanded at load). Activation quant is per-row dynamic
         (amax/448) unless a static ``input_scale`` was calibrated. NOTE:
         never ``.to(dtype=...)`` this module — a dtype cast would upcast the
-        fp8 buffer (device moves are fine)."""
+        fp8 buffer (device moves are fine).
+
+        Optional LoRA side-branch (gw#547): ``lora_a`` [bucket, in] /
+        ``lora_b`` [out, bucket] compute-dtype buffers, rank-padded to a
+        fixed bucket so every adapter in the bucket shares one traced graph.
+        The branch reads the ORIGINAL bf16 activation and adds onto the bf16
+        output — quantized weights are never touched; hot-swap is a buffer
+        copy (see models.w8a8_lora)."""
 
         weight: Any  # fp8 buffer (annotated: Module.__getattr__ unions confuse mypy)
         weight_scale: Any
+        lora_a: Any  # None, or [bucket, in] bf16 branch buffer (gw#547)
+        lora_b: Any  # None, or [out, bucket] with scale folded in
 
         def __init__(self, in_features: int, out_features: int, *,
                      bias: bool, compute_dtype: Any,
@@ -180,6 +189,12 @@ def _build_module_class() -> type:
                     out_features, dtype=compute_dtype, device=meta))
             else:
                 self.bias = None
+            self.lora_a = None
+            self.lora_b = None
+
+        def _lora_addend(self, x2: Any) -> Any:
+            # Per-adapter scale is folded into lora_b at copy time.
+            return (x2 @ self.lora_a.t()) @ self.lora_b.t()
 
         def forward(self, x: Any) -> Any:
             shape = x.shape
@@ -200,6 +215,8 @@ def _build_module_class() -> type:
                 xq, self.weight.t(), scale_a=sa, scale_b=self.weight_scale.t(),
                 bias=self.bias, out_dtype=x.dtype,
             )
+            if self.lora_a is not None:
+                y = y + self._lora_addend(x2)
             return y.reshape(*shape[:-1], self.out_features)
 
         def extra_repr(self) -> str:

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -34,6 +34,9 @@ RANK_BUCKETS = (16, 32, 64, 128)
 
 _BUCKET_ATTR = "_cozy_lora_bucket"
 _ACTIVE_ATTR = "_cozy_lora_active"
+_SPARSE_ATTR = "_cozy_lora_sparse"
+_MAPCACHE_ATTR = "_cozy_lora_mapcache"
+_MAPCACHE_MAX = 8
 _DENOISER_PREFIXES = ("unet.", "transformer.", "lora_unet_", "lora_transformer_")
 # (normalized suffix marker, is_down) — dotted forms after key normalization.
 _DOWN_SUFFIXES = (".lora_down.weight", ".lora.down.weight", ".lora_A.weight")
@@ -74,8 +77,10 @@ def branch_bucket(model: Any) -> int:
     return int(getattr(model, _BUCKET_ATTR, 0) or 0)
 
 
-def lora_lane(bucket: int) -> str:
-    return f"w8a8-lora{int(bucket)}"
+def lora_lane(bucket: int, sparse: bool = False) -> str:
+    # Sparse (eager-only) placement is a different graph per coverage
+    # pattern — the "-sparse" suffix can never match a produced cell label.
+    return f"w8a8-lora{int(bucket)}" + ("-sparse" if sparse else "")
 
 
 def split_state_dict(sd: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -110,17 +115,25 @@ def _base_and_kind(key: str) -> Tuple[str, str]:
     return "", ""
 
 
-def _kohya_to_diffusers(sd: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Normalize a kohya/sd-scripts adapter (incl. LDM block naming) through
-    diffusers' own converter — the exact mapping the bf16 peft path uses.
-    None when the converter can't handle it (caller falls back / fails)."""
+def _kohya_to_diffusers(sd: Dict[str, Any], model: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a kohya/sd-scripts adapter (incl. SGM/LDM block naming)
+    through diffusers' own converters — the exact mapping the bf16 peft
+    path uses (lora_pipeline.lora_state_dict order: SGM block rename with
+    the real unet config, then the non-diffusers conversion). None when the
+    converters can't handle it (caller falls back / fails)."""
     try:
         from diffusers.loaders.lora_conversion_utils import (
             _convert_non_diffusers_lora_to_diffusers,
+            _maybe_map_sgm_blocks_to_diffusers,
         )
 
-        converted, alphas = _convert_non_diffusers_lora_to_diffusers(dict(sd))
+        sd = dict(sd)
+        if any(p in k for k in sd for p in
+               ("input_blocks", "middle_block", "output_blocks")):
+            sd = _maybe_map_sgm_blocks_to_diffusers(sd, model.config)
+        converted, alphas = _convert_non_diffusers_lora_to_diffusers(sd)
     except Exception:
+        logger.warning("w8a8 lora: kohya->diffusers conversion failed", exc_info=True)
         return None
     out = dict(converted)
     out.update(alphas or {})  # "<base>.alpha" -> float
@@ -170,7 +183,7 @@ def map_adapter(
     mods = quantized_modules(model)
     groups, unresolved = _group_keys(den_sd, mods)
     if unresolved and any(k.startswith("lora_unet_") for k in den_sd):
-        converted = _kohya_to_diffusers(den_sd)
+        converted = _kohya_to_diffusers(den_sd, model)
         if converted is not None:
             groups, unresolved = _group_keys(converted, mods)
     if unresolved:
@@ -222,15 +235,17 @@ def alloc_branch_buffers(mod: Any, bucket: int) -> None:
 
 def enable_lora_branches(model: Any, bucket: int) -> None:
     """Allocate branch buffers on EVERY quantized Linear (canonical
-    placement). Idempotent at the same bucket; a different bucket
-    reallocates (a new graph family)."""
+    placement — one traced graph over all coverage patterns; the compiled
+    lane). Idempotent at the same bucket; a different bucket reallocates
+    (a new graph family)."""
     if bucket not in RANK_BUCKETS:
         raise ValidationError(f"invalid lora rank bucket {bucket} (valid: {RANK_BUCKETS})")
-    if branch_bucket(model) == bucket:
+    if branch_bucket(model) == bucket and not getattr(model, _SPARSE_ATTR, False):
         return
     for mod in quantized_modules(model).values():
         alloc_branch_buffers(mod, bucket)
     setattr(model, _BUCKET_ATTR, int(bucket))
+    setattr(model, _SPARSE_ATTR, False)
     setattr(model, _ACTIVE_ATTR, False)
 
 
@@ -245,13 +260,19 @@ def disable_lora_branches(model: Any) -> None:
         mod.lora_b = None
     if hasattr(model, _BUCKET_ATTR):
         delattr(model, _BUCKET_ATTR)
+    setattr(model, _SPARSE_ATTR, False)
     setattr(model, _ACTIVE_ATTR, False)
 
 
 def clear_branch_adapters(model: Any) -> None:
-    """Zero the active set (B only — the addend is exactly 0). Buffers and
-    the traced graph stay; the next swap is still just a copy."""
+    """Deactivate. Canonical (compiled) placement zeroes B — the addend is
+    exactly 0 and the traced graph stays. Sparse (eager) placement DROPS the
+    buffers instead: eager pays per-kernel launch cost even for zeroed
+    branches, so bare requests go back to exactly branchless speed."""
     if not branch_bucket(model):
+        return
+    if getattr(model, _SPARSE_ATTR, False):
+        disable_lora_branches(model)
         return
     for mod in quantized_modules(model).values():
         if getattr(mod, "lora_b", None) is not None:
@@ -268,14 +289,21 @@ def apply_branch_adapters(
     adapters: Sequence[Tuple[Dict[str, Any], float, str]],
     *,
     allow_resize: bool = True,
+    uniform: bool = False,
     request_id: str = "",
 ) -> Dict[str, Any]:
     """Make exactly ``adapters`` (state_dict, user weight, ref) the denoiser's
     active branch set. Rank-concat across adapters, pad to the bucket, fold
     ``alpha/rank * weight`` into the B copy. Returns swap stats.
 
-    ``allow_resize=False`` (compiled pipelines) refuses bucket changes —
-    a resize is a new graph family, and prod never compiles at runtime."""
+    ``uniform=True`` (compiled pipelines) keeps canonical placement — every
+    quantized Linear carries a branch, zeroed slots for uncovered layers,
+    never shrinking the bucket; ``allow_resize=False`` additionally refuses
+    bucket changes (a resize is a new graph family, and prod never compiles
+    at runtime). ``uniform=False`` (eager) allocates branches ONLY on
+    covered layers and drops stale ones — eager pays a per-kernel launch
+    tax even for zeroed slots, so sparse placement keeps uncovered layers
+    at exactly branchless speed."""
     import torch
 
     t0 = time.monotonic()
@@ -283,7 +311,21 @@ def apply_branch_adapters(
         clear_branch_adapters(model)
         return {"bucket": branch_bucket(model), "resized": False, "covered": 0,
                 "modules": 0, "copied_bytes": 0, "swap_ms": 0}
-    mapped = [(map_adapter(sd, model, ref=ref), w, ref) for sd, w, ref in adapters]
+    # Mapping is pure in the state dict; repeat swaps of a resident adapter
+    # (the AdapterCache serves the SAME dict object) skip the key-mapping /
+    # kohya-conversion pass entirely.
+    cache: Dict[Any, Any] = getattr(model, _MAPCACHE_ATTR, None) or {}
+    mapped = []
+    for sd, w, ref in adapters:
+        key = (ref, id(sd), len(sd))
+        m = cache.get(key)
+        if m is None:
+            m = map_adapter(sd, model, ref=ref)
+            cache[key] = m
+            while len(cache) > _MAPCACHE_MAX:
+                cache.pop(next(iter(cache)))
+        mapped.append((m, w, ref))
+    setattr(model, _MAPCACHE_ATTR, cache)
     per_layer: Dict[str, int] = {}
     for m, _w, _ref in mapped:
         for path, (a, _b, _s) in m.items():
@@ -291,22 +333,48 @@ def apply_branch_adapters(
     needed = max(per_layer.values(), default=0)
     bucket = rank_bucket(max(needed, 1))
     current = branch_bucket(model)
-    if current >= bucket and current:
-        bucket = current  # never shrink — stay on the already-traced graph
-    if current != bucket:
-        if not allow_resize:
-            raise ValidationError(
-                f"active LoRA set needs rank bucket {bucket} but the compiled "
-                f"pipeline traced bucket {current or 'none'} — recompile at "
-                "swap time is never allowed; publish a matching lora cell"
-            )
-        enable_lora_branches(model, bucket)
+    was_sparse = bool(getattr(model, _SPARSE_ATTR, False))
+    if uniform:
+        if current >= bucket and current and not was_sparse:
+            bucket = current  # never shrink — stay on the already-traced graph
+        if current != bucket or was_sparse:
+            if not allow_resize:
+                raise ValidationError(
+                    f"active LoRA set needs rank bucket {bucket} but the compiled "
+                    f"pipeline traced bucket {current or 'none'} — recompile at "
+                    "swap time is never allowed; publish a matching lora cell"
+                )
+            enable_lora_branches(model, bucket)
+    else:
+        covered_paths = set()
+        for m, _w, _ref in mapped:
+            covered_paths.update(m)
+        for path, mod in quantized_modules(model).items():
+            if path in covered_paths:
+                if (getattr(mod, "lora_a", None) is None
+                        or int(mod.lora_a.shape[0]) != bucket):
+                    alloc_branch_buffers(mod, bucket)
+            elif getattr(mod, "lora_a", None) is not None:
+                for name in ("lora_a", "lora_b"):
+                    mod._buffers.pop(name, None)
+                    mod.__dict__.pop(name, None)
+                mod.lora_a = None
+                mod.lora_b = None
+        setattr(model, _BUCKET_ATTR, int(bucket))
+        setattr(model, _SPARSE_ATTR, True)
 
     copied = 0
     covered = 0
     mods = quantized_modules(model)
     with torch.no_grad():
+        # Stage on CPU, ship in ONE H2D transfer, then device-side slice
+        # copies — 2x739 individual pageable copies measured seconds at SDXL
+        # scale; one flat transfer is tens of ms.
+        plan: List[Tuple[Any, Any, Any]] = []
+        stage_dtype = None
         for path, mod in mods.items():
+            if getattr(mod, "lora_a", None) is None:
+                continue  # sparse placement: uncovered layer has no branch
             rows: List[Any] = []
             cols: List[Any] = []
             for m, weight, _ref in mapped:
@@ -314,26 +382,40 @@ def apply_branch_adapters(
                 if hit is None:
                     continue
                 a, b, alpha_scale = hit
-                rows.append(a.to(dtype=mod.lora_a.dtype))
-                cols.append(b.to(dtype=mod.lora_b.dtype) * (alpha_scale * weight))
+                rows.append(a)
+                cols.append(b.float() * (alpha_scale * weight))
             if not rows:
                 mod.lora_b.zero_()
                 continue
-            a_cat = torch.cat(rows, dim=0)
-            b_cat = torch.cat(cols, dim=1)
-            r = int(a_cat.shape[0])
-            mod.lora_a.zero_()
-            mod.lora_b.zero_()
-            mod.lora_a[:r].copy_(a_cat.to(mod.lora_a.device), non_blocking=True)
-            mod.lora_b[:, :r].copy_(b_cat.to(mod.lora_b.device), non_blocking=True)
-            copied += a_cat.numel() * a_cat.element_size()
-            copied += b_cat.numel() * b_cat.element_size()
+            if stage_dtype is None:
+                stage_dtype = mod.lora_a.dtype
+            a_cat = torch.cat(rows, dim=0).to(stage_dtype)
+            b_cat = torch.cat(cols, dim=1).to(stage_dtype)
+            plan.append((mod, a_cat, b_cat))
             covered += 1
+        if plan:
+            device = plan[0][0].lora_a.device
+            flat = torch.cat(
+                [t.reshape(-1) for _mod, a, b in plan for t in (a, b)])
+            copied = flat.numel() * flat.element_size()
+            flat = flat.to(device, non_blocking=True)
+            off = 0
+            for mod, a, b in plan:
+                r = int(a.shape[0])
+                mod.lora_a.zero_()
+                mod.lora_b.zero_()
+                n = a.numel()
+                mod.lora_a[:r].copy_(flat[off:off + n].view_as(a))
+                off += n
+                n = b.numel()
+                mod.lora_b[:, :r].copy_(flat[off:off + n].view_as(b))
+                off += n
         if torch.cuda.is_available():
             torch.cuda.synchronize()
     setattr(model, _ACTIVE_ATTR, True)
     stats = {
-        "bucket": bucket, "resized": current != bucket, "covered": covered,
+        "bucket": bucket, "resized": current != bucket,
+        "sparse": not uniform, "covered": covered,
         "modules": len(mods), "copied_bytes": copied,
         "swap_ms": int((time.monotonic() - t0) * 1000),
     }
@@ -350,8 +432,9 @@ def stamp_lane(pipe: Any, model: Any) -> None:
     """Keep the compile-cache graph key honest: branch-bearing pipelines are
     a different graph family per bucket (lane_drift guards both directions)."""
     bucket = branch_bucket(model)
+    sparse = bool(getattr(model, _SPARSE_ATTR, False))
     try:
-        pipe._cozy_weight_lane = lora_lane(bucket) if bucket else "w8a8"
+        pipe._cozy_weight_lane = lora_lane(bucket, sparse) if bucket else "w8a8"
     except Exception:
         pass
 

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -1,0 +1,374 @@
+"""Runtime LoRA on the w8a8 serve lane (gw#547).
+
+Fp8ScaledLinear holds fp8 buffers + torch._scaled_mm — peft can't target it,
+so adapters ride a bf16 SIDE-BRANCH instead: ``y += B(A @ x)`` reading the
+original bf16 activation and adding onto the bf16 output. Quantized weights
+are never touched; there is no upcast/requant round-trip.
+
+Graph stability: every quantized Linear gets a branch (canonical placement —
+zeroed slots for layers an adapter doesn't cover), and the concatenated rank
+of the active adapter set is padded to a fixed bucket (:data:`RANK_BUCKETS`).
+Every adapter set inside one bucket shares ONE traced graph; hot-swap is a
+buffer copy. Multiple active adapters rank-concat into one A/B pair (the
+gw#430 svdq trick); per-adapter scale (alpha/rank x user weight) is folded
+into the B copy.
+
+The branch-bearing pipeline stamps ``_cozy_weight_lane = "w8a8-lora<bucket>"``
+so the existing SYMMETRIC ``compile_cache.lane_drift`` guard keeps LoRA-bearing
+pipelines and branchless compile cells apart in both directions.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..api.errors import RefCompatibilitySurprise, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# Padded-rank buckets: one traced graph per bucket. 16/32 cover the bulk of
+# the civitai catalog; 64/128 the high-rank tail (survey follow-up in gw#547).
+RANK_BUCKETS = (16, 32, 64, 128)
+
+_BUCKET_ATTR = "_cozy_lora_bucket"
+_ACTIVE_ATTR = "_cozy_lora_active"
+_DENOISER_PREFIXES = ("unet.", "transformer.", "lora_unet_", "lora_transformer_")
+# (normalized suffix marker, is_down) — dotted forms after key normalization.
+_DOWN_SUFFIXES = (".lora_down.weight", ".lora.down.weight", ".lora_A.weight")
+_UP_SUFFIXES = (".lora_up.weight", ".lora.up.weight", ".lora_B.weight")
+
+
+def rank_bucket(total_rank: int) -> int:
+    """Smallest bucket covering ``total_rank``."""
+    for b in RANK_BUCKETS:
+        if total_rank <= b:
+            return b
+    raise RefCompatibilitySurprise(
+        f"active LoRA set needs rank {total_rank} > max bucket {RANK_BUCKETS[-1]}",
+        axis="state_dict",
+    )
+
+
+def branch_target(pipe: Any) -> Optional[Any]:
+    """The pipeline's denoiser when it serves on the scaled_mm w8a8 lane
+    (branch-capable), else None (plain/dequant pipelines keep the peft path)."""
+    for name in ("transformer", "unet"):
+        denoiser = getattr(pipe, name, None)
+        if denoiser is not None and getattr(denoiser, "_cozy_w8a8_mode", "") == "scaled_mm":
+            return denoiser
+    return None
+
+
+def quantized_modules(model: Any) -> Dict[str, Any]:
+    """name -> Fp8ScaledLinear for every quantized Linear in the denoiser."""
+    from .w8a8 import fp8_scaled_linear_class
+
+    cls = fp8_scaled_linear_class()
+    return {n: m for n, m in model.named_modules() if isinstance(m, cls)}
+
+
+def branch_bucket(model: Any) -> int:
+    """The enabled bucket, 0 when branches are not enabled."""
+    return int(getattr(model, _BUCKET_ATTR, 0) or 0)
+
+
+def lora_lane(bucket: int) -> str:
+    return f"w8a8-lora{int(bucket)}"
+
+
+def split_state_dict(sd: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """(denoiser keys, everything else). Text-encoder halves stay on the
+    peft path — TEs are not quantized."""
+    den: Dict[str, Any] = {}
+    rest: Dict[str, Any] = {}
+    for k, v in sd.items():
+        (den if k.startswith(_DENOISER_PREFIXES) else rest)[k] = v
+    return den, rest
+
+
+def _base_and_kind(key: str) -> Tuple[str, str]:
+    """(base module name, 'down'|'up'|'alpha'|'') for one adapter key.
+    Handles adapter-scoped peft keys (``.lora_A.<name>.weight``)."""
+    if key.endswith(".alpha"):
+        return key[: -len(".alpha")], "alpha"
+    for suf in _DOWN_SUFFIXES:
+        if key.endswith(suf):
+            return key[: -len(suf)], "down"
+    for suf in _UP_SUFFIXES:
+        if key.endswith(suf):
+            return key[: -len(suf)], "up"
+    # adapter-scoped peft: ...lora_A.<adapter>.weight
+    if key.endswith(".weight"):
+        stem = key[: -len(".weight")]
+        head, _, _scope = stem.rpartition(".")
+        if head.endswith(".lora_A"):
+            return head[: -len(".lora_A")], "down"
+        if head.endswith(".lora_B"):
+            return head[: -len(".lora_B")], "up"
+    return "", ""
+
+
+def _kohya_to_diffusers(sd: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize a kohya/sd-scripts adapter (incl. LDM block naming) through
+    diffusers' own converter — the exact mapping the bf16 peft path uses.
+    None when the converter can't handle it (caller falls back / fails)."""
+    try:
+        from diffusers.loaders.lora_conversion_utils import (
+            _convert_non_diffusers_lora_to_diffusers,
+        )
+
+        converted, alphas = _convert_non_diffusers_lora_to_diffusers(dict(sd))
+    except Exception:
+        return None
+    out = dict(converted)
+    out.update(alphas or {})  # "<base>.alpha" -> float
+    return out
+
+
+def _group_keys(
+    den_sd: Dict[str, Any], mods: Dict[str, Any]
+) -> Tuple[Dict[str, Dict[str, Any]], List[str]]:
+    flat = {p.replace(".", "_"): p for p in mods}
+
+    def resolve(base: str) -> str:
+        for pref in ("unet.", "transformer."):
+            if base.startswith(pref) and base[len(pref):] in mods:
+                return base[len(pref):]
+        for pref in ("lora_unet_", "lora_transformer_"):
+            if base.startswith(pref) and base[len(pref):] in flat:
+                return flat[base[len(pref):]]
+        if base in mods:
+            return base
+        return ""
+
+    groups: Dict[str, Dict[str, Any]] = {}
+    unresolved: List[str] = []
+    for key, tensor in den_sd.items():
+        base, kind = _base_and_kind(key)
+        path = resolve(base) if kind else ""
+        if not path:
+            unresolved.append(key)
+            continue
+        groups.setdefault(path, {})[kind] = tensor
+    return groups, unresolved
+
+
+def map_adapter(
+    den_sd: Dict[str, Any], model: Any, *, ref: str = ""
+) -> Dict[str, Tuple[Any, Any, float]]:
+    """Resolve one adapter's denoiser keys onto the model's quantized
+    modules: module path -> (A [r, in], B [out, r], alpha_scale).
+
+    Dotted diffusers/peft names resolve after stripping the component
+    prefix; kohya flattened names resolve against the model's own module
+    paths, falling back to diffusers' kohya converter (LDM block naming,
+    SDXL sd-scripts). Any key that does not land on a branch-capable module
+    is a hard error — a silently-dropped block would change the adapter's
+    output."""
+    mods = quantized_modules(model)
+    groups, unresolved = _group_keys(den_sd, mods)
+    if unresolved and any(k.startswith("lora_unet_") for k in den_sd):
+        converted = _kohya_to_diffusers(den_sd)
+        if converted is not None:
+            groups, unresolved = _group_keys(converted, mods)
+    if unresolved:
+        raise RefCompatibilitySurprise(
+            f"{len(unresolved)} adapter key(s) target no w8a8-quantized module "
+            f"(e.g. {', '.join(sorted(unresolved)[:3])}) — the w8a8 branch "
+            "cannot apply this adapter without changing its output",
+            ref=ref, axis="state_dict",
+        )
+
+    out: Dict[str, Tuple[Any, Any, float]] = {}
+    for path, g in groups.items():
+        a, b = g.get("down"), g.get("up")
+        if a is None or b is None:
+            raise RefCompatibilitySurprise(
+                f"adapter is missing the down/up pair for {path!r}",
+                ref=ref, axis="state_dict",
+            )
+        rank = int(a.shape[0])
+        mod = mods[path]
+        if int(a.shape[1]) != mod.in_features or int(b.shape[0]) != mod.out_features:
+            raise RefCompatibilitySurprise(
+                f"adapter shapes for {path!r} do not match the base "
+                f"({tuple(a.shape)}/{tuple(b.shape)} vs "
+                f"in={mod.in_features} out={mod.out_features})",
+                ref=ref, axis="state_dict",
+            )
+        alpha = g.get("alpha")
+        alpha_scale = (float(alpha) / rank) if alpha is not None else 1.0
+        out[path] = (a, b, alpha_scale)
+    return out
+
+
+def alloc_branch_buffers(mod: Any, bucket: int) -> None:
+    """Zeroed A/B buffers on one Fp8ScaledLinear (persistent=False — they
+    move with the module, never enter state_dict)."""
+    import torch
+
+    dev = mod.weight.device
+    dtype = mod.bias.dtype if mod.bias is not None else torch.bfloat16
+    for name in ("lora_a", "lora_b"):
+        mod._buffers.pop(name, None)
+        mod.__dict__.pop(name, None)
+    mod.register_buffer("lora_a", torch.zeros(
+        bucket, mod.in_features, dtype=dtype, device=dev), persistent=False)
+    mod.register_buffer("lora_b", torch.zeros(
+        mod.out_features, bucket, dtype=dtype, device=dev), persistent=False)
+
+
+def enable_lora_branches(model: Any, bucket: int) -> None:
+    """Allocate branch buffers on EVERY quantized Linear (canonical
+    placement). Idempotent at the same bucket; a different bucket
+    reallocates (a new graph family)."""
+    if bucket not in RANK_BUCKETS:
+        raise ValidationError(f"invalid lora rank bucket {bucket} (valid: {RANK_BUCKETS})")
+    if branch_bucket(model) == bucket:
+        return
+    for mod in quantized_modules(model).values():
+        alloc_branch_buffers(mod, bucket)
+    setattr(model, _BUCKET_ATTR, int(bucket))
+    setattr(model, _ACTIVE_ATTR, False)
+
+
+def disable_lora_branches(model: Any) -> None:
+    """Drop the branch buffers entirely (back to the branchless graph
+    family). Used on demote/teardown, never between requests."""
+    for mod in quantized_modules(model).values():
+        for name in ("lora_a", "lora_b"):
+            mod._buffers.pop(name, None)
+            mod.__dict__.pop(name, None)
+        mod.lora_a = None
+        mod.lora_b = None
+    if hasattr(model, _BUCKET_ATTR):
+        delattr(model, _BUCKET_ATTR)
+    setattr(model, _ACTIVE_ATTR, False)
+
+
+def clear_branch_adapters(model: Any) -> None:
+    """Zero the active set (B only — the addend is exactly 0). Buffers and
+    the traced graph stay; the next swap is still just a copy."""
+    if not branch_bucket(model):
+        return
+    for mod in quantized_modules(model).values():
+        if getattr(mod, "lora_b", None) is not None:
+            mod.lora_b.zero_()
+    setattr(model, _ACTIVE_ATTR, False)
+
+
+def branches_active(model: Any) -> bool:
+    return bool(getattr(model, _ACTIVE_ATTR, False))
+
+
+def apply_branch_adapters(
+    model: Any,
+    adapters: Sequence[Tuple[Dict[str, Any], float, str]],
+    *,
+    allow_resize: bool = True,
+    request_id: str = "",
+) -> Dict[str, Any]:
+    """Make exactly ``adapters`` (state_dict, user weight, ref) the denoiser's
+    active branch set. Rank-concat across adapters, pad to the bucket, fold
+    ``alpha/rank * weight`` into the B copy. Returns swap stats.
+
+    ``allow_resize=False`` (compiled pipelines) refuses bucket changes —
+    a resize is a new graph family, and prod never compiles at runtime."""
+    import torch
+
+    t0 = time.monotonic()
+    if not adapters:
+        clear_branch_adapters(model)
+        return {"bucket": branch_bucket(model), "resized": False, "covered": 0,
+                "modules": 0, "copied_bytes": 0, "swap_ms": 0}
+    mapped = [(map_adapter(sd, model, ref=ref), w, ref) for sd, w, ref in adapters]
+    per_layer: Dict[str, int] = {}
+    for m, _w, _ref in mapped:
+        for path, (a, _b, _s) in m.items():
+            per_layer[path] = per_layer.get(path, 0) + int(a.shape[0])
+    needed = max(per_layer.values(), default=0)
+    bucket = rank_bucket(max(needed, 1))
+    current = branch_bucket(model)
+    if current >= bucket and current:
+        bucket = current  # never shrink — stay on the already-traced graph
+    if current != bucket:
+        if not allow_resize:
+            raise ValidationError(
+                f"active LoRA set needs rank bucket {bucket} but the compiled "
+                f"pipeline traced bucket {current or 'none'} — recompile at "
+                "swap time is never allowed; publish a matching lora cell"
+            )
+        enable_lora_branches(model, bucket)
+
+    copied = 0
+    covered = 0
+    mods = quantized_modules(model)
+    with torch.no_grad():
+        for path, mod in mods.items():
+            rows: List[Any] = []
+            cols: List[Any] = []
+            for m, weight, _ref in mapped:
+                hit = m.get(path)
+                if hit is None:
+                    continue
+                a, b, alpha_scale = hit
+                rows.append(a.to(dtype=mod.lora_a.dtype))
+                cols.append(b.to(dtype=mod.lora_b.dtype) * (alpha_scale * weight))
+            if not rows:
+                mod.lora_b.zero_()
+                continue
+            a_cat = torch.cat(rows, dim=0)
+            b_cat = torch.cat(cols, dim=1)
+            r = int(a_cat.shape[0])
+            mod.lora_a.zero_()
+            mod.lora_b.zero_()
+            mod.lora_a[:r].copy_(a_cat.to(mod.lora_a.device), non_blocking=True)
+            mod.lora_b[:, :r].copy_(b_cat.to(mod.lora_b.device), non_blocking=True)
+            copied += a_cat.numel() * a_cat.element_size()
+            copied += b_cat.numel() * b_cat.element_size()
+            covered += 1
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+    setattr(model, _ACTIVE_ATTR, True)
+    stats = {
+        "bucket": bucket, "resized": current != bucket, "covered": covered,
+        "modules": len(mods), "copied_bytes": copied,
+        "swap_ms": int((time.monotonic() - t0) * 1000),
+    }
+    logger.info(
+        "[request_id=%s] w8a8 lora branch swap: adapters=%d bucket=%d "
+        "covered=%d/%d copied_bytes=%d resized=%s swap_ms=%d",
+        request_id, len(adapters), bucket, covered, len(mods), copied,
+        stats["resized"], stats["swap_ms"],
+    )
+    return stats
+
+
+def stamp_lane(pipe: Any, model: Any) -> None:
+    """Keep the compile-cache graph key honest: branch-bearing pipelines are
+    a different graph family per bucket (lane_drift guards both directions)."""
+    bucket = branch_bucket(model)
+    try:
+        pipe._cozy_weight_lane = lora_lane(bucket) if bucket else "w8a8"
+    except Exception:
+        pass
+
+
+__all__ = [
+    "RANK_BUCKETS",
+    "apply_branch_adapters",
+    "branch_bucket",
+    "branch_target",
+    "branches_active",
+    "clear_branch_adapters",
+    "disable_lora_branches",
+    "enable_lora_branches",
+    "lora_lane",
+    "map_adapter",
+    "quantized_modules",
+    "rank_bucket",
+    "split_state_dict",
+    "stamp_lane",
+]

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -371,49 +371,58 @@ def apply_branch_adapters(
     covered = 0
     mods = quantized_modules(model)
     with torch.no_grad():
-        # Stage on CPU, ship in ONE H2D transfer, then device-side slice
-        # copies — 2x739 individual pageable copies measured seconds at SDXL
-        # scale; one flat transfer is tens of ms.
-        plan: List[Tuple[Any, Any, Any]] = []
-        stage_dtype = None
+        # Ship RAW adapter tensors in ONE flat H2D transfer, then cast /
+        # scale-fold / place on DEVICE — per-layer CPU cat+cast+scale over
+        # hundreds of layers measured ~1s at SDXL scale, and 2x739
+        # individual pageable copies measured seconds.
+        plan: List[Tuple[Any, List[Any], List[Any]]] = []
+        pieces: List[Any] = []
         for path, mod in mods.items():
             if getattr(mod, "lora_a", None) is None:
                 continue  # sparse placement: uncovered layer has no branch
-            rows: List[Any] = []
-            cols: List[Any] = []
-            for m, weight, _ref in mapped:
-                hit = m.get(path)
-                if hit is None:
-                    continue
-                a, b, alpha_scale = hit
-                rows.append(a)
-                cols.append(b.float() * (alpha_scale * weight))
-            if not rows:
+            layer_hits = [(m[path], weight)
+                          for m, weight, _ref in mapped if path in m]
+            if not layer_hits:
                 mod.lora_b.zero_()
                 continue
-            if stage_dtype is None:
-                stage_dtype = mod.lora_a.dtype
-            a_cat = torch.cat(rows, dim=0).to(stage_dtype)
-            b_cat = torch.cat(cols, dim=1).to(stage_dtype)
-            plan.append((mod, a_cat, b_cat))
+            plan.append((mod, [h for h, _w in layer_hits],
+                         [w for _h, w in layer_hits]))
+            for (a, b, _s), _w in layer_hits:
+                pieces.append(a.reshape(-1))
+                pieces.append(b.reshape(-1))
             covered += 1
         if plan:
             device = plan[0][0].lora_a.device
-            flat = torch.cat(
-                [t.reshape(-1) for _mod, a, b in plan for t in (a, b)])
-            copied = flat.numel() * flat.element_size()
-            flat = flat.to(device, non_blocking=True)
-            off = 0
-            for mod, a, b in plan:
-                r = int(a.shape[0])
+            # mixed dtypes across adapters are possible; stage each dtype run
+            # contiguously in its own flat tensor
+            flats: Dict[Any, Any] = {}
+            offsets: Dict[Any, int] = {}
+            for dt in {p.dtype for p in pieces}:
+                flats[dt] = torch.cat([p for p in pieces if p.dtype == dt]).to(
+                    device, non_blocking=True)
+                offsets[dt] = 0
+                copied += flats[dt].numel() * flats[dt].element_size()
+
+            def take(t: Any) -> Any:
+                dt = t.dtype
+                n = t.numel()
+                out = flats[dt][offsets[dt]:offsets[dt] + n].view(t.shape)
+                offsets[dt] += n
+                return out
+
+            for mod, hits, weights in plan:
                 mod.lora_a.zero_()
                 mod.lora_b.zero_()
-                n = a.numel()
-                mod.lora_a[:r].copy_(flat[off:off + n].view_as(a))
-                off += n
-                n = b.numel()
-                mod.lora_b[:, :r].copy_(flat[off:off + n].view_as(b))
-                off += n
+                r0 = 0
+                for (a, b, alpha_scale), w in zip(hits, weights):
+                    r = int(a.shape[0])
+                    dev_a, dev_b = take(a), take(b)
+                    mod.lora_a[r0:r0 + r].copy_(dev_a)  # device-side cast
+                    mod.lora_b[:, r0:r0 + r].copy_(dev_b)
+                    scale = float(alpha_scale) * float(w)
+                    if scale != 1.0:
+                        mod.lora_b[:, r0:r0 + r].mul_(scale)
+                    r0 += r
         if torch.cuda.is_available():
             torch.cuda.synchronize()
     setattr(model, _ACTIVE_ATTR, True)

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -127,10 +127,19 @@ def _kohya_sgm_normalize(sd: Dict[str, Any], model: Any) -> Optional[Dict[str, A
             _maybe_map_sgm_blocks_to_diffusers,
         )
 
-        return _maybe_map_sgm_blocks_to_diffusers(dict(sd), model.config)
+        mapped = _maybe_map_sgm_blocks_to_diffusers(dict(sd), model.config)
     except Exception:
         logger.warning("w8a8 lora: SGM block normalization failed", exc_info=True)
         return None
+    # The SGM pass renumbers blocks but keeps the sgm family names; the
+    # family rename is _convert_unet_lora_key's job in diffusers — do just
+    # that part here.
+    return {
+        k.replace("input_blocks", "down_blocks")
+         .replace("middle_block", "mid_block")
+         .replace("output_blocks", "up_blocks"): v
+        for k, v in mapped.items()
+    }
 
 
 def _group_keys(

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -115,29 +115,22 @@ def _base_and_kind(key: str) -> Tuple[str, str]:
     return "", ""
 
 
-def _kohya_to_diffusers(sd: Dict[str, Any], model: Any) -> Optional[Dict[str, Any]]:
-    """Normalize a kohya/sd-scripts adapter (incl. SGM/LDM block naming)
-    through diffusers' own converters — the exact mapping the bf16 peft
-    path uses (lora_pipeline.lora_state_dict order: SGM block rename with
-    the real unet config, then the non-diffusers conversion). None when the
-    converters can't handle it (caller falls back / fails)."""
+def _kohya_sgm_normalize(sd: Dict[str, Any], model: Any) -> Optional[Dict[str, Any]]:
+    """Rename SGM/LDM block indices (input_blocks_4_1 ...) to diffusers block
+    paths using the REAL unet config — diffusers' own pre-pass, the same one
+    the bf16 peft path runs. Keys stay kohya-flat afterwards and resolve
+    against the model's module paths directly (down/up/alpha handled
+    natively; the full non-diffusers converter is NOT used — it emits legacy
+    attn-processor names that match no real module)."""
     try:
         from diffusers.loaders.lora_conversion_utils import (
-            _convert_non_diffusers_lora_to_diffusers,
             _maybe_map_sgm_blocks_to_diffusers,
         )
 
-        sd = dict(sd)
-        if any(p in k for k in sd for p in
-               ("input_blocks", "middle_block", "output_blocks")):
-            sd = _maybe_map_sgm_blocks_to_diffusers(sd, model.config)
-        converted, alphas = _convert_non_diffusers_lora_to_diffusers(sd)
+        return _maybe_map_sgm_blocks_to_diffusers(dict(sd), model.config)
     except Exception:
-        logger.warning("w8a8 lora: kohya->diffusers conversion failed", exc_info=True)
+        logger.warning("w8a8 lora: SGM block normalization failed", exc_info=True)
         return None
-    out = dict(converted)
-    out.update(alphas or {})  # "<base>.alpha" -> float
-    return out
 
 
 def _group_keys(
@@ -182,8 +175,10 @@ def map_adapter(
     output."""
     mods = quantized_modules(model)
     groups, unresolved = _group_keys(den_sd, mods)
-    if unresolved and any(k.startswith("lora_unet_") for k in den_sd):
-        converted = _kohya_to_diffusers(den_sd, model)
+    if unresolved and any(
+            p in k for k in den_sd
+            for p in ("input_blocks", "middle_block", "output_blocks")):
+        converted = _kohya_sgm_normalize(den_sd, model)
         if converted is not None:
             groups, unresolved = _group_keys(converted, mods)
     if unresolved:

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -346,7 +346,7 @@ def apply_branch_adapters(
                 )
             enable_lora_branches(model, bucket)
     else:
-        covered_paths = set()
+        covered_paths: set[str] = set()
         for m, _w, _ref in mapped:
             covered_paths.update(m)
         for path, mod in quantized_modules(model).items():

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -221,6 +221,45 @@ def map_adapter(
     return out
 
 
+# Flat staging buffers above this size stay pageable — pinned host memory is
+# a shared, non-swappable resource and the cache holds up to _MAPCACHE_MAX.
+_PIN_MAX_BYTES = 512 << 20
+
+
+def _stage_adapter(mapped: Dict[str, Tuple[Any, Any, float]]) -> Dict[str, Any]:
+    """One adapter's swap-ready form: per-dtype flat CPU staging tensors
+    (pinned when small enough on CUDA hosts) + an index of every layer's
+    (dtype, offset, shape) slices. Built once per resident adapter; hot-swaps
+    then pay only one H2D transfer + device-side placement."""
+    import torch
+
+    by_dtype: Dict[Any, List[Tuple[str, str, Any]]] = {}
+    for path in sorted(mapped):
+        a, b, _alpha = mapped[path]
+        by_dtype.setdefault(a.dtype, []).append((path, "a", a))
+        by_dtype.setdefault(b.dtype, []).append((path, "b", b))
+    flat: Dict[Any, Any] = {}
+    slices: Dict[Tuple[str, str], Tuple[Any, int, Tuple[int, ...]]] = {}
+    for dt, items in by_dtype.items():
+        total = sum(t.numel() for _p, _tag, t in items)
+        pin = (torch.cuda.is_available()
+               and total * items[0][2].element_size() <= _PIN_MAX_BYTES)
+        buf = torch.empty(total, dtype=dt, pin_memory=pin)
+        off = 0
+        for path, tag, t in items:
+            n = t.numel()
+            buf[off:off + n].copy_(t.reshape(-1))
+            slices[(path, tag)] = (dt, off, tuple(t.shape))
+            off += n
+        flat[dt] = buf
+    index = {
+        path: (slices[(path, "a")], slices[(path, "b")], float(alpha))
+        for path, (_a, _b, alpha) in mapped.items()
+    }
+    ranks = {path: int(a.shape[0]) for path, (a, _b, _al) in mapped.items()}
+    return {"ranks": ranks, "flat": flat, "index": index}
+
+
 def alloc_branch_buffers(mod: Any, bucket: int) -> None:
     """Zeroed A/B buffers on one Fp8ScaledLinear (persistent=False — they
     move with the module, never enter state_dict)."""
@@ -315,25 +354,26 @@ def apply_branch_adapters(
         clear_branch_adapters(model)
         return {"bucket": branch_bucket(model), "resized": False, "covered": 0,
                 "modules": 0, "copied_bytes": 0, "swap_ms": 0}
-    # Mapping is pure in the state dict; repeat swaps of a resident adapter
-    # (the AdapterCache serves the SAME dict object) skip the key-mapping /
-    # kohya-conversion pass entirely.
+    # Mapping and flat staging are pure in the state dict; repeat swaps of a
+    # resident adapter (the AdapterCache serves the SAME dict object) skip
+    # the key-mapping pass AND the CPU flatten — the flatten measured ~700ms
+    # at SDXL scale, the actual H2D+device placement ~130ms.
     cache: Dict[Any, Any] = getattr(model, _MAPCACHE_ATTR, None) or {}
     mapped = []
     for sd, w, ref in adapters:
         key = (ref, id(sd), len(sd))
-        m = cache.get(key)
-        if m is None:
-            m = map_adapter(sd, model, ref=ref)
-            cache[key] = m
+        entry = cache.get(key)
+        if entry is None:
+            entry = _stage_adapter(map_adapter(sd, model, ref=ref))
+            cache[key] = entry
             while len(cache) > _MAPCACHE_MAX:
                 cache.pop(next(iter(cache)))
-        mapped.append((m, w, ref))
+        mapped.append((entry, w, ref))
     setattr(model, _MAPCACHE_ATTR, cache)
     per_layer: Dict[str, int] = {}
-    for m, _w, _ref in mapped:
-        for path, (a, _b, _s) in m.items():
-            per_layer[path] = per_layer.get(path, 0) + int(a.shape[0])
+    for entry, _w, _ref in mapped:
+        for path, r in entry["ranks"].items():
+            per_layer[path] = per_layer.get(path, 0) + r
     needed = max(per_layer.values(), default=0)
     bucket = rank_bucket(max(needed, 1))
     current = branch_bucket(model)
@@ -351,8 +391,8 @@ def apply_branch_adapters(
             enable_lora_branches(model, bucket)
     else:
         covered_paths: set[str] = set()
-        for m, _w, _ref in mapped:
-            covered_paths.update(m)
+        for entry, _w, _ref in mapped:
+            covered_paths.update(entry["ranks"])
         for path, mod in quantized_modules(model).items():
             if path in covered_paths:
                 if (getattr(mod, "lora_a", None) is None
@@ -371,58 +411,51 @@ def apply_branch_adapters(
     covered = 0
     mods = quantized_modules(model)
     with torch.no_grad():
-        # Ship RAW adapter tensors in ONE flat H2D transfer, then cast /
-        # scale-fold / place on DEVICE — per-layer CPU cat+cast+scale over
-        # hundreds of layers measured ~1s at SDXL scale, and 2x739
-        # individual pageable copies measured seconds.
-        plan: List[Tuple[Any, List[Any], List[Any]]] = []
-        pieces: List[Any] = []
+        # One H2D transfer per adapter of its CACHED flat staging buffer
+        # (pinned when small enough), then index-addressed device-side
+        # cast/scale-fold/placement — the per-swap CPU flatten measured
+        # ~700ms at SDXL scale; staged warm swaps pay only transfer+place.
+        device = None
+        for mod in mods.values():
+            if getattr(mod, "lora_a", None) is not None:
+                device = mod.lora_a.device
+                break
+        dev_flats: List[Dict[Any, Any]] = []
+        for entry, _w, _ref in mapped:
+            df = {dt: t.to(device, non_blocking=t.is_pinned())
+                  for dt, t in entry["flat"].items()}
+            dev_flats.append(df)
+            copied += sum(t.numel() * t.element_size()
+                          for t in entry["flat"].values())
         for path, mod in mods.items():
             if getattr(mod, "lora_a", None) is None:
                 continue  # sparse placement: uncovered layer has no branch
-            layer_hits = [(m[path], weight)
-                          for m, weight, _ref in mapped if path in m]
-            if not layer_hits:
-                mod.lora_b.zero_()
-                continue
-            plan.append((mod, [h for h, _w in layer_hits],
-                         [w for _h, w in layer_hits]))
-            for (a, b, _s), _w in layer_hits:
-                pieces.append(a.reshape(-1))
-                pieces.append(b.reshape(-1))
-            covered += 1
-        if plan:
-            device = plan[0][0].lora_a.device
-            # mixed dtypes across adapters are possible; stage each dtype run
-            # contiguously in its own flat tensor
-            flats: Dict[Any, Any] = {}
-            offsets: Dict[Any, int] = {}
-            for dt in {p.dtype for p in pieces}:
-                flats[dt] = torch.cat([p for p in pieces if p.dtype == dt]).to(
-                    device, non_blocking=True)
-                offsets[dt] = 0
-                copied += flats[dt].numel() * flats[dt].element_size()
-
-            def take(t: Any) -> Any:
-                dt = t.dtype
-                n = t.numel()
-                out = flats[dt][offsets[dt]:offsets[dt] + n].view(t.shape)
-                offsets[dt] += n
-                return out
-
-            for mod, hits, weights in plan:
-                mod.lora_a.zero_()
-                mod.lora_b.zero_()
-                r0 = 0
-                for (a, b, alpha_scale), w in zip(hits, weights):
-                    r = int(a.shape[0])
-                    dev_a, dev_b = take(a), take(b)
-                    mod.lora_a[r0:r0 + r].copy_(dev_a)  # device-side cast
-                    mod.lora_b[:, r0:r0 + r].copy_(dev_b)
-                    scale = float(alpha_scale) * float(w)
-                    if scale != 1.0:
-                        mod.lora_b[:, r0:r0 + r].mul_(scale)
-                    r0 += r
+            hit_any = False
+            r0 = 0
+            for (entry, w, _ref), df in zip(mapped, dev_flats):
+                idx = entry["index"].get(path)
+                if idx is None:
+                    continue
+                if not hit_any:
+                    mod.lora_a.zero_()
+                    mod.lora_b.zero_()
+                    hit_any = True
+                (dt_a, off_a, shp_a), (dt_b, off_b, shp_b), alpha_scale = idx
+                r = shp_a[0]
+                n_a = shp_a[0] * shp_a[1]
+                n_b = shp_b[0] * shp_b[1]
+                mod.lora_a[r0:r0 + r].copy_(
+                    df[dt_a][off_a:off_a + n_a].view(shp_a))
+                mod.lora_b[:, r0:r0 + r].copy_(
+                    df[dt_b][off_b:off_b + n_b].view(shp_b))
+                scale = alpha_scale * float(w)
+                if scale != 1.0:
+                    mod.lora_b[:, r0:r0 + r].mul_(scale)
+                r0 += r
+            if hit_any:
+                covered += 1
+            else:
+                mod.lora_b.zero_()  # canonical zeroed slot (uniform)
         if torch.cuda.is_available():
             torch.cuda.synchronize()
     setattr(model, _ACTIVE_ATTR, True)

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -317,11 +317,14 @@ class AdapterResidency:
             st = self._state(ref, pipe)
             try:
                 if denoiser is not None:
-                    # A compiled pipeline traced ONE bucket; a resize would
-                    # mean a recompile at swap time — never allowed in prod.
+                    # Compiled pipelines keep canonical placement and ONE
+                    # traced bucket (a resize would mean a recompile at swap
+                    # time — never allowed in prod); eager pipelines use
+                    # sparse placement (branch kernels only where covered).
+                    compiled = getattr(pipe, "_cozy_compile", None) is not None
                     w8a8_lora.apply_branch_adapters(
                         denoiser, branch_set,
-                        allow_resize=getattr(pipe, "_cozy_compile", None) is None,
+                        allow_resize=not compiled, uniform=compiled,
                         request_id=request_id,
                     )
                     w8a8_lora.stamp_lane(pipe, denoiser)

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -90,6 +90,27 @@ class PreparedAdapter:
     parse_ms: int = 0   # safetensors read + validation (0 on cache hit)
 
 
+def _split_for_w8a8(
+    adapters: Sequence["PreparedAdapter"],
+) -> tuple[List["PreparedAdapter"], List[tuple]]:
+    """(peft-path adapters with denoiser keys stripped, branch set) for a
+    w8a8-lane pipeline. Branch entries are (state_dict, weight, ref) —
+    the models.w8a8_lora.apply_branch_adapters contract."""
+    from dataclasses import replace
+
+    from ..models import w8a8_lora
+
+    peft: List[PreparedAdapter] = []
+    branch: List[tuple] = []
+    for a in adapters:
+        den, rest = w8a8_lora.split_state_dict(a.state_dict)
+        if den:
+            branch.append((den, a.weight, a.ref))
+        if rest:
+            peft.append(replace(a, state_dict=rest))
+    return peft, branch
+
+
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
@@ -276,8 +297,18 @@ class AdapterResidency:
         request_id: str = "",
     ) -> None:
         """Make exactly *adapters* the pipeline's active set. Attach failure
-        rolls back to a fully-deactivated pipeline."""
-        if not isinstance(pipe, LoraCapablePipeline):
+        rolls back to a fully-deactivated pipeline.
+
+        w8a8 pipelines (gw#547): denoiser keys go to the bf16 side-branch on
+        Fp8ScaledLinear (peft can't target it); text-encoder keys keep the
+        peft path below."""
+        from ..models import w8a8_lora
+
+        denoiser = w8a8_lora.branch_target(pipe)
+        branch_set: List[tuple] = []
+        if denoiser is not None:
+            adapters, branch_set = _split_for_w8a8(adapters)
+        if adapters and not isinstance(pipe, LoraCapablePipeline):
             raise ValidationError(
                 "model slot does not support LoRA adapters "
                 "(pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)"
@@ -285,6 +316,22 @@ class AdapterResidency:
         with self._lock:
             st = self._state(ref, pipe)
             try:
+                if denoiser is not None:
+                    # A compiled pipeline traced ONE bucket; a resize would
+                    # mean a recompile at swap time — never allowed in prod.
+                    w8a8_lora.apply_branch_adapters(
+                        denoiser, branch_set,
+                        allow_resize=getattr(pipe, "_cozy_compile", None) is None,
+                        request_id=request_id,
+                    )
+                    w8a8_lora.stamp_lane(pipe, denoiser)
+                    if not adapters:
+                        # No peft half — make sure a previous request's TE
+                        # adapters are off, then we're done.
+                        if hasattr(pipe, "disable_lora"):
+                            pipe.disable_lora()
+                        st.active = True
+                        return
                 load_ms = 0
                 attached_now: List[str] = []
                 for a in adapters:
@@ -346,6 +393,17 @@ class AdapterResidency:
                 return
             t0 = time.monotonic()
             try:
+                from ..models import w8a8_lora
+
+                denoiser = w8a8_lora.branch_target(pipe)
+                if denoiser is not None:
+                    w8a8_lora.clear_branch_adapters(denoiser)
+            except Exception:
+                logger.warning(
+                    "[request_id=%s] w8a8 lora branch clear failed", request_id,
+                    exc_info=True,
+                )
+            try:
                 if hasattr(pipe, "disable_lora"):
                     pipe.disable_lora()
                 else:
@@ -374,6 +432,16 @@ class AdapterResidency:
         the AdapterCache re-attaches lazily on next use. Never raises."""
         with self._lock:
             st = self._pipes.pop(ref, None)
+            try:
+                from ..models import w8a8_lora
+
+                denoiser = w8a8_lora.branch_target(pipe)
+                if denoiser is not None:
+                    w8a8_lora.disable_lora_branches(denoiser)
+                    w8a8_lora.stamp_lane(pipe, denoiser)
+            except Exception:
+                logger.warning("w8a8 lora branch drop on demote failed for %s",
+                               ref, exc_info=True)
             if st is None or not st.attached or st.pipe_id != id(pipe):
                 return
             try:

--- a/tests/test_w8a8_lora.py
+++ b/tests/test_w8a8_lora.py
@@ -134,6 +134,7 @@ def test_apply_kohya_folds_scale_into_b(denoiser: Any) -> None:
     sd = _kohya_sd(picked, rank=4, alpha=2.0)
     stats = apply_branch_adapters(denoiser, [(sd, 0.5, "t/a")])
     assert stats["bucket"] == 16 and stats["covered"] == 2
+    assert stats["sparse"] is True
     mods = quantized_modules(denoiser)
     for path, mod in mods.items():
         if path in picked:
@@ -146,7 +147,19 @@ def test_apply_kohya_folds_scale_into_b(denoiser: Any) -> None:
             assert mod.lora_a[4:].abs().sum() == 0
             assert mod.lora_b[:, 4:].abs().sum() == 0
         else:
-            assert mod.lora_b.abs().sum() == 0  # canonical zeroed slot
+            # sparse (eager) placement: uncovered layers carry NO branch
+            assert mod.lora_a is None and mod.lora_b is None
+
+
+def test_apply_uniform_keeps_canonical_zeroed_slots(denoiser: Any) -> None:
+    picked = _pick(denoiser, 1)
+    sd = _kohya_sd(picked, rank=4, alpha=4.0)
+    stats = apply_branch_adapters(denoiser, [(sd, 1.0, "t/a")], uniform=True)
+    assert stats["sparse"] is False
+    for path, mod in quantized_modules(denoiser).items():
+        assert mod.lora_a is not None  # canonical placement everywhere
+        if path not in picked:
+            assert mod.lora_b.abs().sum() == 0  # zeroed slot, same graph
 
 
 def test_peft_and_scoped_key_forms_resolve(denoiser: Any) -> None:
@@ -187,7 +200,7 @@ def test_rank_concat_addend_matches_sum_of_adapters(denoiser: Any) -> None:
     assert torch.allclose(got, want, rtol=0.05, atol=0.05)  # bf16 accumulation
 
 
-def test_swap_is_copy_only_and_clear_zeroes(denoiser: Any) -> None:
+def test_swap_is_copy_only_and_clear_semantics(denoiser: Any) -> None:
     picked = _pick(denoiser, 2)
     apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
     ids = [id(m.lora_a) for m in quantized_modules(denoiser).values()]
@@ -196,24 +209,37 @@ def test_swap_is_copy_only_and_clear_zeroes(denoiser: Any) -> None:
     assert stats["resized"] is False
     assert ids == [id(m.lora_a) for m in quantized_modules(denoiser).values()]
     assert w8a8_lora.branches_active(denoiser)
+    # sparse clear DROPS buffers — bare eager requests are exactly branchless
     clear_branch_adapters(denoiser)
     assert not w8a8_lora.branches_active(denoiser)
+    assert branch_bucket(denoiser) == 0
     for mod in quantized_modules(denoiser).values():
-        assert mod.lora_b.abs().sum() == 0
-    assert branch_bucket(denoiser) == 16  # graph family stays
+        assert mod.lora_a is None
+    # canonical clear ZEROES and keeps the graph family
+    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")],
+                          uniform=True)
+    clear_branch_adapters(denoiser)
+    assert branch_bucket(denoiser) == 16
+    for mod in quantized_modules(denoiser).values():
+        assert mod.lora_b is not None and mod.lora_b.abs().sum() == 0
 
 
 def test_bucket_growth_and_compiled_resize_refusal(denoiser: Any) -> None:
     picked = _pick(denoiser, 1)
-    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    enable_lora_branches(denoiser, 16)
     big = _kohya_sd(picked, 24, 24.0)
     with pytest.raises(ValidationError):
-        apply_branch_adapters(denoiser, [(big, 1.0, "t/big")], allow_resize=False)
-    stats = apply_branch_adapters(denoiser, [(big, 1.0, "t/big")])
+        apply_branch_adapters(denoiser, [(big, 1.0, "t/big")],
+                              uniform=True, allow_resize=False)
+    stats = apply_branch_adapters(denoiser, [(big, 1.0, "t/big")], uniform=True)
     assert stats["bucket"] == 32 and stats["resized"] is True
-    # never shrink back — stay on the already-traced graph
-    stats = apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    # canonical placement never shrinks — stay on the already-traced graph
+    stats = apply_branch_adapters(
+        denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")], uniform=True)
     assert stats["bucket"] == 32 and stats["resized"] is False
+    # sparse placement resizes freely (eager: no traced graph to protect)
+    stats = apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    assert stats["bucket"] == 16 and stats["sparse"] is True
 
 
 def test_unresolved_and_misshaped_keys_fail_loud(denoiser: Any) -> None:
@@ -333,12 +359,12 @@ def test_residency_routes_denoiser_to_branch_and_te_to_peft(denoiser: Any) -> No
     assert len(pipe.loaded) == 1
     assert set(pipe.loaded[0][0]) == {te_key}
     assert w8a8_lora.branches_active(denoiser)
-    assert pipe._cozy_weight_lane == "w8a8-lora16"
+    assert pipe._cozy_weight_lane == "w8a8-lora16-sparse"
     assert res.needs_deactivation("m")
     res.deactivate("m", pipe, request_id="r1")
     assert not w8a8_lora.branches_active(denoiser)
-    for mod in quantized_modules(denoiser).values():
-        assert mod.lora_b.abs().sum() == 0
+    # eager pipe: deactivation drops the branches entirely
+    assert branch_bucket(denoiser) == 0
 
 
 def test_residency_branch_only_pipe_needs_no_peft_surface(denoiser: Any) -> None:
@@ -364,6 +390,7 @@ def test_residency_refuses_resize_on_compiled_pipe(denoiser: Any) -> None:
     res = lora_util.AdapterResidency()
     with pytest.raises(ValidationError, match="recompile at swap"):
         res.activate("m", pipe, [_prepared(_kohya_sd(picked, 24, 24.0), "t/big")])
+    assert branch_bucket(denoiser) == 16  # canonical graph family untouched
     # rollback left nothing active
     assert not w8a8_lora.branches_active(denoiser)
 
@@ -438,7 +465,7 @@ def test_gpu_full_pipeline_with_branch_runs(w8a8_tree: Path) -> None:
     picked = _pick(denoiser, 2)
     apply_branch_adapters(denoiser, [(_kohya_sd(picked, 8, 8.0), 0.5, "t/a")])
     w8a8_lora.stamp_lane(pipe, denoiser)
-    assert pipe._cozy_weight_lane == "w8a8-lora16"
+    assert pipe._cozy_weight_lane == "w8a8-lora16-sparse"
     out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
     assert out.images.shape[-3:] == (8, 8, 3)
     # swap without touching graphs, then clear back to the zeroed set

--- a/tests/test_w8a8_lora.py
+++ b/tests/test_w8a8_lora.py
@@ -1,0 +1,478 @@
+"""Runtime LoRA on the w8a8 lane (gw#547) — branch buffers, key mapping,
+rank-concat + bucket padding, residency routing, and lane parity against a
+REAL tiny diffusers pipeline (no network, no mocks of our own code).
+
+CPU lane: module assembly, buffer copy semantics, addend math, and the
+AdapterResidency w8a8 split (forced scaled_mm module build — forward never
+runs). GPU lane (sm_89+): forward parity with an explicit reference addend,
+exact zero-slot equality, swap latency, and no-recompile-at-swap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker.api.errors import RefCompatibilitySurprise, ValidationError
+from gen_worker.models import w8a8, w8a8_lora
+from gen_worker.models.w8a8 import (
+    detect_w8a8_artifact,
+    fp8_scaled_linear_class,
+    load_w8a8_denoiser,
+    load_w8a8_pipeline,
+    quantize_tree_w8a8,
+)
+from gen_worker.models.w8a8_lora import (
+    apply_branch_adapters,
+    branch_bucket,
+    branch_target,
+    clear_branch_adapters,
+    disable_lora_branches,
+    enable_lora_branches,
+    map_adapter,
+    quantized_modules,
+    rank_bucket,
+    split_state_dict,
+)
+from gen_worker.utils import lora as lora_util
+
+
+def _cuda_sm89() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 89
+
+
+@pytest.fixture(scope="module")
+def tiny_ddpm(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("w8a8l") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tiny_ddpm: Path) -> Path:
+    return quantize_tree_w8a8(tiny_ddpm, tiny_ddpm.parent / "w8a8")
+
+
+@pytest.fixture()
+def denoiser(w8a8_tree: Path) -> Any:
+    """Fresh scaled_mm-lane denoiser per test (CPU: modules assemble, only
+    forward needs the GPU kernel)."""
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    return load_w8a8_denoiser(w8a8_tree, art, mode="scaled_mm")
+
+
+def _kohya_sd(paths: Dict[str, Any], rank: int, alpha: float,
+              prefix: str = "lora_unet_") -> Dict[str, Any]:
+    """Synthetic kohya-format adapter over real module shapes."""
+    sd: Dict[str, Any] = {}
+    for path, mod in paths.items():
+        flat = prefix + path.replace(".", "_")
+        sd[f"{flat}.lora_down.weight"] = torch.randn(rank, mod.in_features)
+        sd[f"{flat}.lora_up.weight"] = torch.randn(mod.out_features, rank)
+        sd[f"{flat}.alpha"] = torch.tensor(float(alpha))
+    return sd
+
+
+def _pick(denoiser: Any, n: int) -> Dict[str, Any]:
+    mods = quantized_modules(denoiser)
+    return dict(list(sorted(mods.items()))[:n])
+
+
+# ---------------------------------------------------------------------------
+# CPU lane
+# ---------------------------------------------------------------------------
+
+
+def test_rank_bucket_ladder() -> None:
+    assert rank_bucket(1) == 16
+    assert rank_bucket(16) == 16
+    assert rank_bucket(17) == 32
+    assert rank_bucket(64) == 64
+    assert rank_bucket(128) == 128
+    with pytest.raises(RefCompatibilitySurprise):
+        rank_bucket(129)
+
+
+def test_enable_allocates_uniform_zeroed_branches(denoiser: Any) -> None:
+    mods = quantized_modules(denoiser)
+    assert mods, "tiny unet must have quantized Linears"
+    enable_lora_branches(denoiser, 16)
+    assert branch_bucket(denoiser) == 16
+    for mod in mods.values():
+        assert mod.lora_a.shape == (16, mod.in_features)
+        assert mod.lora_b.shape == (mod.out_features, 16)
+        assert mod.lora_a.abs().sum() == 0 and mod.lora_b.abs().sum() == 0
+        # non-persistent: swaps never leak into state_dict round-trips
+        assert "lora_a" not in mod.state_dict()
+    # idempotent at the same bucket: no reallocation (same traced graph)
+    ids = [id(m.lora_a) for m in mods.values()]
+    enable_lora_branches(denoiser, 16)
+    assert ids == [id(m.lora_a) for m in quantized_modules(denoiser).values()]
+
+
+def test_apply_kohya_folds_scale_into_b(denoiser: Any) -> None:
+    picked = _pick(denoiser, 2)
+    sd = _kohya_sd(picked, rank=4, alpha=2.0)
+    stats = apply_branch_adapters(denoiser, [(sd, 0.5, "t/a")])
+    assert stats["bucket"] == 16 and stats["covered"] == 2
+    mods = quantized_modules(denoiser)
+    for path, mod in mods.items():
+        if path in picked:
+            flat = "lora_unet_" + path.replace(".", "_")
+            a = sd[f"{flat}.lora_down.weight"].to(mod.lora_a.dtype)
+            b = sd[f"{flat}.lora_up.weight"].to(mod.lora_b.dtype)
+            assert torch.equal(mod.lora_a[:4], a)
+            # alpha/rank * user weight = 2/4 * 0.5 = 0.25, folded into B
+            assert torch.allclose(mod.lora_b[:, :4], b * 0.25)
+            assert mod.lora_a[4:].abs().sum() == 0
+            assert mod.lora_b[:, 4:].abs().sum() == 0
+        else:
+            assert mod.lora_b.abs().sum() == 0  # canonical zeroed slot
+
+
+def test_peft_and_scoped_key_forms_resolve(denoiser: Any) -> None:
+    picked = _pick(denoiser, 1)
+    path, mod = next(iter(picked.items()))
+    for down, up in (
+        (f"unet.{path}.lora_A.weight", f"unet.{path}.lora_B.weight"),
+        (f"unet.{path}.lora_A.default.weight", f"unet.{path}.lora_B.default.weight"),
+        (f"unet.{path}.lora.down.weight", f"unet.{path}.lora.up.weight"),
+    ):
+        sd = {
+            down: torch.randn(8, mod.in_features),
+            up: torch.randn(mod.out_features, 8),
+        }
+        mapped = map_adapter(sd, denoiser)
+        assert set(mapped) == {path}
+        a, b, alpha_scale = mapped[path]
+        assert a.shape[0] == 8 and alpha_scale == 1.0
+
+
+def test_rank_concat_addend_matches_sum_of_adapters(denoiser: Any) -> None:
+    picked = _pick(denoiser, 1)
+    path, mod = next(iter(picked.items()))
+    sd1 = _kohya_sd({path: mod}, rank=4, alpha=4.0)
+    sd2 = _kohya_sd({path: mod}, rank=8, alpha=2.0)
+    apply_branch_adapters(denoiser, [(sd1, 1.0, "t/a"), (sd2, -0.5, "t/b")])
+    assert branch_bucket(denoiser) == 16
+    flat = "lora_unet_" + path.replace(".", "_")
+    x = torch.randn(5, mod.in_features, dtype=mod.lora_a.dtype)
+
+    def ref(sd: Dict[str, Any], w: float, alpha: float, r: int) -> Any:
+        a = sd[f"{flat}.lora_down.weight"].to(x.dtype)
+        b = sd[f"{flat}.lora_up.weight"].to(x.dtype)
+        return (x @ a.t()) @ b.t() * (alpha / r * w)
+
+    want = ref(sd1, 1.0, 4.0, 4) + ref(sd2, -0.5, 2.0, 8)
+    got = mod._lora_addend(x)
+    assert torch.allclose(got, want, rtol=0.05, atol=0.05)  # bf16 accumulation
+
+
+def test_swap_is_copy_only_and_clear_zeroes(denoiser: Any) -> None:
+    picked = _pick(denoiser, 2)
+    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    ids = [id(m.lora_a) for m in quantized_modules(denoiser).values()]
+    # swap to a different adapter in the same bucket: buffers must be reused
+    stats = apply_branch_adapters(denoiser, [(_kohya_sd(picked, 8, 8.0), 1.0, "t/b")])
+    assert stats["resized"] is False
+    assert ids == [id(m.lora_a) for m in quantized_modules(denoiser).values()]
+    assert w8a8_lora.branches_active(denoiser)
+    clear_branch_adapters(denoiser)
+    assert not w8a8_lora.branches_active(denoiser)
+    for mod in quantized_modules(denoiser).values():
+        assert mod.lora_b.abs().sum() == 0
+    assert branch_bucket(denoiser) == 16  # graph family stays
+
+
+def test_bucket_growth_and_compiled_resize_refusal(denoiser: Any) -> None:
+    picked = _pick(denoiser, 1)
+    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    big = _kohya_sd(picked, 24, 24.0)
+    with pytest.raises(ValidationError):
+        apply_branch_adapters(denoiser, [(big, 1.0, "t/big")], allow_resize=False)
+    stats = apply_branch_adapters(denoiser, [(big, 1.0, "t/big")])
+    assert stats["bucket"] == 32 and stats["resized"] is True
+    # never shrink back — stay on the already-traced graph
+    stats = apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/a")])
+    assert stats["bucket"] == 32 and stats["resized"] is False
+
+
+def test_unresolved_and_misshaped_keys_fail_loud(denoiser: Any) -> None:
+    with pytest.raises(RefCompatibilitySurprise, match="no w8a8-quantized module"):
+        map_adapter({"lora_unet_no_such_block.lora_down.weight": torch.zeros(4, 8)},
+                    denoiser, ref="t/x")
+    picked = _pick(denoiser, 1)
+    path, mod = next(iter(picked.items()))
+    flat = "lora_unet_" + path.replace(".", "_")
+    with pytest.raises(RefCompatibilitySurprise, match="do not match the base"):
+        map_adapter({
+            f"{flat}.lora_down.weight": torch.zeros(4, mod.in_features + 1),
+            f"{flat}.lora_up.weight": torch.zeros(mod.out_features, 4),
+        }, denoiser, ref="t/x")
+    with pytest.raises(RefCompatibilitySurprise, match="down/up pair"):
+        map_adapter({f"{flat}.lora_down.weight": torch.zeros(4, mod.in_features)},
+                    denoiser, ref="t/x")
+
+
+def test_split_state_dict_routes_te_to_peft() -> None:
+    den, rest = split_state_dict({
+        "lora_unet_x.lora_down.weight": 1,
+        "unet.y.lora_A.weight": 2,
+        "transformer.z.lora_A.weight": 3,
+        "lora_te1_text_model.lora_down.weight": 4,
+        "text_encoder.q.lora_A.weight": 5,
+    })
+    assert set(den) == {"lora_unet_x.lora_down.weight", "unet.y.lora_A.weight",
+                        "transformer.z.lora_A.weight"}
+    assert set(rest) == {"lora_te1_text_model.lora_down.weight",
+                         "text_encoder.q.lora_A.weight"}
+
+
+def test_disable_returns_to_branchless(denoiser: Any) -> None:
+    enable_lora_branches(denoiser, 16)
+    disable_lora_branches(denoiser)
+    assert branch_bucket(denoiser) == 0
+    for mod in quantized_modules(denoiser).values():
+        assert mod.lora_a is None and mod.lora_b is None
+
+
+def test_lane_stamp_and_compile_cell_parity(denoiser: Any) -> None:
+    from gen_worker.compile_cache import artifact_metadata, flavor_label, lane_drift
+
+    class _P:
+        pass
+
+    pipe = _P()
+    pipe._cozy_weight_lane = "w8a8"
+    enable_lora_branches(denoiser, 16)
+    w8a8_lora.stamp_lane(pipe, denoiser)
+    assert pipe._cozy_weight_lane == "w8a8-lora16"
+    assert flavor_label("rtx-4090", "2.9.0+cu129", "w8a8-lora16") == (
+        "inductor-rtx-4090-torch2.9-w8a8-lora16")
+    # SYMMETRIC adopt guard: branchless cells never adopt onto a LoRA-bearing
+    # pipeline and vice versa.
+    assert "weight_lane" in lane_drift(
+        artifact_metadata(family="f", weight_lane="w8a8"), pipe)
+    lora_pipe_meta = artifact_metadata(family="f", weight_lane="w8a8-lora16")
+    assert lane_drift(lora_pipe_meta, pipe) == ""
+    disable_lora_branches(denoiser)
+    w8a8_lora.stamp_lane(pipe, denoiser)
+    assert pipe._cozy_weight_lane == "w8a8"
+    assert "weight_lane" in lane_drift(lora_pipe_meta, pipe)
+
+
+# ---------------------------------------------------------------------------
+# Residency routing (integration through AdapterResidency, CPU)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPipe:
+    """Real w8a8 denoiser + recording peft surface (the TE half)."""
+
+    def __init__(self, denoiser: Any) -> None:
+        self.unet = denoiser
+        self.loaded: list = []
+        self.set_calls: list = []
+        self.disabled = 0
+
+    def load_lora_weights(self, sd: Any, adapter_name: str = "") -> None:
+        self.loaded.append((dict(sd), adapter_name))
+
+    def set_adapters(self, names: Any, adapter_weights: Any = None) -> None:
+        self.set_calls.append((list(names), list(adapter_weights or [])))
+
+    def unload_lora_weights(self) -> None:
+        self.loaded.clear()
+
+    def disable_lora(self) -> None:
+        self.disabled += 1
+
+    def enable_lora(self) -> None:
+        pass
+
+    def delete_adapters(self, name: str) -> None:
+        pass
+
+
+def _prepared(sd: Dict[str, Any], ref: str, weight: float = 1.0) -> Any:
+    key = f"{ref}@d"
+    return lora_util.PreparedAdapter(
+        slot="model", ref=ref, cache_key=key,
+        name=lora_util.adapter_name(key), weight=weight, state_dict=sd)
+
+
+def test_residency_routes_denoiser_to_branch_and_te_to_peft(denoiser: Any) -> None:
+    pipe = _RecordingPipe(denoiser)
+    assert branch_target(pipe) is denoiser
+    picked = _pick(denoiser, 1)
+    sd = _kohya_sd(picked, rank=4, alpha=4.0)
+    te_key = "text_encoder.text_model.encoder.layers.0.self_attn.q_proj.lora_A.weight"
+    sd[te_key] = torch.randn(4, 8)
+    res = lora_util.AdapterResidency()
+    res.activate("m", pipe, [_prepared(sd, "t/mixed", 0.5)], request_id="r1")
+    # TE half went to peft, denoiser half did NOT
+    assert len(pipe.loaded) == 1
+    assert set(pipe.loaded[0][0]) == {te_key}
+    assert w8a8_lora.branches_active(denoiser)
+    assert pipe._cozy_weight_lane == "w8a8-lora16"
+    assert res.needs_deactivation("m")
+    res.deactivate("m", pipe, request_id="r1")
+    assert not w8a8_lora.branches_active(denoiser)
+    for mod in quantized_modules(denoiser).values():
+        assert mod.lora_b.abs().sum() == 0
+
+
+def test_residency_branch_only_pipe_needs_no_peft_surface(denoiser: Any) -> None:
+    class _BarePipe:
+        def __init__(self, d: Any) -> None:
+            self.unet = d
+
+    pipe = _BarePipe(denoiser)
+    picked = _pick(denoiser, 1)
+    res = lora_util.AdapterResidency()
+    res.activate("m", pipe, [_prepared(_kohya_sd(picked, 4, 4.0), "t/a")])
+    assert w8a8_lora.branches_active(denoiser)
+    res.detach("m", pipe)  # demote: buffers drop, lane returns branchless
+    assert branch_bucket(denoiser) == 0
+    assert pipe._cozy_weight_lane == "w8a8"
+
+
+def test_residency_refuses_resize_on_compiled_pipe(denoiser: Any) -> None:
+    pipe = _RecordingPipe(denoiser)
+    enable_lora_branches(denoiser, 16)
+    pipe._cozy_compile = {"cells": 1}
+    picked = _pick(denoiser, 1)
+    res = lora_util.AdapterResidency()
+    with pytest.raises(ValidationError, match="recompile at swap"):
+        res.activate("m", pipe, [_prepared(_kohya_sd(picked, 24, 24.0), "t/big")])
+    # rollback left nothing active
+    assert not w8a8_lora.branches_active(denoiser)
+
+
+def test_dequant_lane_keeps_peft_path(w8a8_tree: Path,
+                                      monkeypatch: pytest.MonkeyPatch) -> None:
+    """On hosts without scaled_mm the denoiser is plain bf16 Linears —
+    branch_target must be None so the normal peft path applies."""
+    from diffusers import DDPMPipeline
+
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    from gen_worker.models.loading import load_from_pretrained
+
+    pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
+    assert branch_target(pipe) is None
+
+
+# ---------------------------------------------------------------------------
+# GPU lane (sm_89+)
+# ---------------------------------------------------------------------------
+
+gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor cores)")
+
+
+@gpu
+def test_gpu_zero_branch_is_bit_exact_with_branchless() -> None:
+    torch.manual_seed(0)
+    lin_cls = fp8_scaled_linear_class()
+    M, K, N = 64, 128, 96
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+    mod = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    mod.load_state_dict({"weight": wq, "weight_scale": scale}, assign=True)
+    y0 = mod(x)
+    w8a8_lora.alloc_branch_buffers(mod, 16)
+    assert torch.equal(mod(x), y0)
+
+
+@gpu
+def test_gpu_forward_matches_dequant_reference_plus_addend(denoiser: Any) -> None:
+    denoiser.to("cuda")
+    picked = _pick(denoiser, 2)
+    sd = _kohya_sd(picked, rank=8, alpha=8.0)
+    apply_branch_adapters(denoiser, [(sd, 0.7, "t/a")])
+    path, mod = next(iter(picked.items()))
+    x = torch.randn(32, mod.in_features, device="cuda", dtype=torch.bfloat16)
+    y = mod(x)
+    wdq = (mod.weight.float() * mod.weight_scale).to(torch.bfloat16)
+    flat = "lora_unet_" + path.replace(".", "_")
+    a = sd[f"{flat}.lora_down.weight"].to("cuda", torch.bfloat16)
+    b = sd[f"{flat}.lora_up.weight"].to("cuda", torch.bfloat16)
+    ref = torch.nn.functional.linear(x, wdq, mod.bias) + ((x @ a.t()) @ b.t()) * 0.7
+    rel = ((y - ref).abs().max() / ref.abs().max().clamp(min=1e-6)).item()
+    assert rel < 0.08  # activation-quant error only; branch itself is exact bf16
+
+
+@gpu
+def test_gpu_full_pipeline_with_branch_runs(w8a8_tree: Path) -> None:
+    from diffusers import DDPMPipeline
+
+    w8a8.scaled_mm_supported.cache_clear()
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    pipe = load_w8a8_pipeline(DDPMPipeline, w8a8_tree, art,
+                              compute_dtype=torch.float16)
+    pipe.to("cuda")
+    denoiser = branch_target(pipe)
+    assert denoiser is not None
+    picked = _pick(denoiser, 2)
+    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 8, 8.0), 0.5, "t/a")])
+    w8a8_lora.stamp_lane(pipe, denoiser)
+    assert pipe._cozy_weight_lane == "w8a8-lora16"
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)
+    # swap without touching graphs, then clear back to the zeroed set
+    apply_branch_adapters(denoiser, [(_kohya_sd(picked, 4, 4.0), 1.0, "t/b")])
+    clear_branch_adapters(denoiser)
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)
+
+
+@gpu
+def test_gpu_swap_never_recompiles() -> None:
+    """Compile a branch-bearing module, then hot-swap adapters in the same
+    bucket: dynamo must not re-trace (swap = buffer copy, the gw#547
+    contract)."""
+    import torch._dynamo as dynamo
+
+    torch.manual_seed(0)
+    lin_cls = fp8_scaled_linear_class()
+    K, N = 128, 96
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+    mod = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    mod.load_state_dict({"weight": wq, "weight_scale": scale}, assign=True)
+    w8a8_lora.alloc_branch_buffers(mod, 16)
+    dynamo.reset()
+    compiled = torch.compile(mod)
+    x = torch.randn(32, K, device="cuda", dtype=torch.bfloat16)
+    y0 = compiled(x)
+    before = dynamo.utils.counters["stats"]["unique_graphs"]
+    for _ in range(4):  # hot-swaps: same bucket, new tensors
+        mod.lora_a.copy_(torch.randn_like(mod.lora_a))
+        mod.lora_b.copy_(torch.randn_like(mod.lora_b))
+        y = compiled(x)
+    assert dynamo.utils.counters["stats"]["unique_graphs"] == before
+    assert not torch.equal(y, y0)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.10"
+version = "0.26.11"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Implements the runtime half of the BYOM-LoRA-on-w8a8 unlock (ie#488 ruling (b), tracker gw#547). Approved direction: hot-swap LoRAs at w8a8 speed for the civitai/BYOM catalog.

## Design
- **bf16 side-branch on Fp8ScaledLinear**: `y = scaled_mm(W_fp8, quant(x)) + B(A@x)` — branch reads the original bf16 activation, computes in bf16, adds onto the bf16 output. No weight mutation, no upcast/requant round-trip. LoRAs stay unrouted.
- **Rank buckets (16/32/64/128)**: concatenated active rank pads to a fixed bucket; one traced graph per bucket; multi-adapter sets rank-concat into one A/B pair (gw#430 trick) with alpha/rank x weight folded in on-device.
- **Two placements, two graph families**:
  - *Canonical* (compiled lane): every quantized Linear carries a branch, zeroed slots for uncovered layers; lane stamps `w8a8-lora<bucket>`; the existing symmetric `lane_drift` guard separates LoRA cells from branchless cells in both directions; bucket resizes are refused on compiled pipelines (no recompile at swap time, ever).
  - *Sparse* (eager): measured on a real SDXL w8a8 UNet on a 4090, eager zeroed uniform branches cost 21-32% of denoiser forward (kernel-launch-bound, flat across buckets) — so eager pipelines place branches only on covered layers and drop them on deactivate; bare requests run exactly branchless. Sparse stamps `-sparse` and can never adopt a produced cell.
- **Swap path**: per resident adapter, a cached swap-ready flat staging buffer (pinned <=512MB); hot-swap = one H2D transfer + index-addressed device-side cast/scale/placement.
- **Routing**: AdapterResidency splits w8a8-lane adapters — denoiser keys to the branch, TE keys stay on peft (TEs are not quantized). Dequant-lane (pre-sm89) pipelines keep the plain peft path. Kohya SGM/LDM block names normalize via diffusers' `_maybe_map_sgm_blocks_to_diffusers` against the real unet config; unresolvable keys fail loud (`ref_compatibility_surprise`).

## Validation (RunPod SECURE 4090, torch 2.13.0+cu130 = fleet floor)
Tests: 30/30 on the pod (CPU contract lane + sm_89 GPU lane), 55/55 locally incl. executor suites; ruff+mypy clean.

Perf (real SDXL w8a8 UNet, 739 quantized Linears, 1024px latents, batch 2):
| metric | value |
|---|---|
| branchless forward | ~210-215ms |
| eager zeroed uniform branch tax (any bucket) | +21-32% (launch-bound -> sparse eager placement; compiled cells fuse it) |
| hot-swap, warm (resident adapter, rank-32 full-coverage 345MB fp32) | **66ms** |
| hot-swap, cold (first attach: map + stage build) | ~1.0s, once per adapter |
| recompiles at swap (compiled module, 6 swaps) | **0** (dynamo unique_graphs flat) |
| zeroed branch vs branchless output | bit-exact |

Quality A/B (sdxl-base fp16-variant, data-free w8a8 artifact, 2 real civitai LoRAs, same-seed 20 steps, 4 prompts, LoRA-on-w8a8+branch vs LoRA-on-bf16+peft):
| lane | MAE range | PSNR range |
|---|---|---|
| base (no LoRA — fp8 noise floor) | 0.011-0.026 | 26.5-36.4 |
| nerijs/pixel-art-xl (rank 32, a=32) | 0.011-0.024 | 25.8-34.3 |
| CiroN2022/toy-face (rank 32, a=16) | 0.010-0.044 | 21.8-35.0 |
Adapter deltas sit at the fp8 base noise floor (one prompt slightly above); visual pairs are same style/composition with trajectory-level detail drift — no adapter-specific degradation from the branch. (Production calibrated artifacts + the te#79 gate apply on top; this proves the serve path.)

Known v1 limits (tracked in gw#547): LoCon/LyCORIS conv-targeting adapters are rejected fail-loud; compiled-lane fused branch tax needs lora compile cells (endpoint follow-up); torch 2.8 rowwise scaled_mm is bf16-out-only (pre-existing; fleet floor unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
