### PR TITLE
gw: th#826 call-out primitive SDK — ctx.call_endpoint + ctx.workflow_checkpoint (0.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.27.0 (2026-07-16)
+
+- **th#826 call-out primitive (workflows-as-endpoints).** Functions declared
+  `@endpoint(child_calls=True)` may call other endpoints as attributed,
+  bounded, cancellable child requests:
+  - `ctx.call_endpoint(endpoint, function, payload, *, tag, wait, timeout_s,
+    tier)` — sync-await (returns output items) or `wait=False` for a
+    `ChildRequest` handle (`.status()` / `.result()` / `.cancel()`).
+  - `ctx.workflow_checkpoint(key, fn)` — step-result memoization under the
+    invocation (crash-resume by fast-forward; WORKFLOW-DESIGN.md §4).
+  - Typed errors: `ChildCallRefusedError` (depth/cycle/budget/tier/parent
+    refusals + `child_calls_not_declared`), `ChildRequestFailedError`,
+    `ChildRequestCanceledError`, `ChildCallTimeoutError`.
+  - Discovery emits `child_calls = true`; the hub mints the `invoke_child`
+    capability grant only for declaring functions. Children bill the parent
+    request's payer, inherit its availability tier, and die with the tree on
+    parent cancel.
+
+
 ## 0.26.9 (2026-07-15)
 
 - hub_policy: probe `modelopt` in the known optional-libs list (te#79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.26.11"
+version = "0.27.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -22,10 +22,16 @@ from .families import FamilyDefaults
 from .models.provision import arm_compile
 from .api.errors import (
     CanceledError,
+    ChildCallError,
+    ChildCallRefusedError,
+    ChildCallTimeoutError,
+    ChildRequestCanceledError,
+    ChildRequestFailedError,
     FatalError,
     RetryableError,
     ValidationError,
 )
+from .callout import ChildRequest
 from .api.progress import diffusers_step_callback
 from .api.streaming import (
     BatchItemDelta,
@@ -89,6 +95,13 @@ __all__ = [
     "RetryableError",
     "ValidationError",
     "FatalError",
+    # th#826 call-out primitive (ctx.call_endpoint / ctx.workflow_checkpoint).
+    "ChildRequest",
+    "ChildCallError",
+    "ChildCallRefusedError",
+    "ChildCallTimeoutError",
+    "ChildRequestCanceledError",
+    "ChildRequestFailedError",
     # Streaming signals.
     "BatchItemDelta",
     "Done",

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -188,6 +188,10 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     name: Optional[str] = None  # function-shaped endpoints only
     is_function: bool = False
     compile: Optional[Compile] = None
+    # th#826 call-out primitive: the function makes endpoint-to-endpoint
+    # child calls (ctx.call_endpoint / ctx.workflow_checkpoint). The hub
+    # mints the invoke_child credential ONLY for declaring functions.
+    child_calls: bool = False
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -390,6 +394,7 @@ def _decorate_class(
     slots: Dict[str, Slot],
     runtime: Optional[str],
     compile: Optional[Compile] = None,
+    child_calls: bool = False,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -405,7 +410,7 @@ def _decorate_class(
 
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models, slots=slots,
-        runtime=runtime, compile=compile,
+        runtime=runtime, compile=compile, child_calls=child_calls,
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
@@ -422,6 +427,7 @@ def _decorate_function(
     runtime: Optional[str],
     name: Optional[str],
     compile: Optional[Compile] = None,
+    child_calls: bool = False,
 ) -> Callable[..., Any]:
     _validate_handler_shape(fn.__name__, fn, is_method=False)
     _reject_producer_generator(fn.__name__, fn, kind)
@@ -446,7 +452,7 @@ def _decorate_function(
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models, slots=slots,
         runtime=None, name=(name or fn.__name__), is_function=True,
-        compile=compile,
+        compile=compile, child_calls=child_calls,
     )
     setattr(fn, ATTR, decl)
     return fn
@@ -466,6 +472,7 @@ def endpoint(
     runtime: Optional[str] = ...,
     name: Optional[str] = ...,
     compile: Optional[Compile] = ...,
+    child_calls: bool = ...,
 ) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
@@ -479,6 +486,7 @@ def endpoint(
     runtime: Optional[str] = None,
     name: Optional[str] = None,
     compile: Optional[Compile] = None,
+    child_calls: bool = False,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes.
 
@@ -510,11 +518,13 @@ def endpoint(
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, compile=compile,
+                child_calls=child_calls,
             )
         if inspect.isfunction(obj):
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, name=name, compile=compile,
+                child_calls=child_calls,
             )
         raise TypeError(
             f"@endpoint requires a function or class, got {type(obj).__name__}"

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -119,3 +119,57 @@ class RefCompatibilitySurprise(ValidationError):
         if ref:
             detail = f"{detail} (ref={ref})"
         super().__init__(detail)
+
+
+class ChildCallError(WorkerError):
+    """Base class for th#826 call-out primitive failures (ctx.call_endpoint)."""
+
+
+class ChildCallRefusedError(ChildCallError):
+    """The hub refused the child-call admission (typed, deterministic).
+
+    ``code`` is the platform refusal code: ``call_depth_exceeded``,
+    ``call_cycle_detected``, ``tree_budget_exceeded``,
+    ``tier_escalation_denied``, ``parent_not_running``, ``budget_not_root``,
+    or ``child_calls_not_declared`` (this invocation's function did not
+    declare ``child_calls=True``, so it holds no child-call credential).
+    """
+
+    def __init__(self, code: str, message: str = "") -> None:
+        self.code = str(code or "").strip()
+        super().__init__(message or self.code)
+
+
+class ChildRequestFailedError(ChildCallError):
+    """The child request reached ``failed``."""
+
+    def __init__(self, request_id: str, error_type: str = "", error_message: str = "") -> None:
+        self.request_id = str(request_id or "")
+        self.error_type = str(error_type or "")
+        self.error_message = str(error_message or "")
+        detail = f"child request {self.request_id} failed"
+        if self.error_type:
+            detail += f" ({self.error_type})"
+        if self.error_message:
+            detail += f": {self.error_message}"
+        super().__init__(detail)
+
+
+class ChildRequestCanceledError(ChildCallError):
+    """The child request reached ``canceled`` (e.g. a tree cancel)."""
+
+    def __init__(self, request_id: str) -> None:
+        self.request_id = str(request_id or "")
+        super().__init__(f"child request {self.request_id} was canceled")
+
+
+class ChildCallTimeoutError(ChildCallError):
+    """The caller's wait budget ran out. The child keeps running — the caller
+    may ``cancel()`` it or keep polling via the handle."""
+
+    def __init__(self, request_id: str, timeout_s: float) -> None:
+        self.request_id = str(request_id or "")
+        self.timeout_s = float(timeout_s)
+        super().__init__(
+            f"child request {self.request_id} did not finish within {self.timeout_s:.0f}s"
+        )

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -1,0 +1,280 @@
+"""Endpoint-to-endpoint call-out client (th#826, the workflow primitive).
+
+The SDK half of the platform's call-out primitive: a function declared with
+``@endpoint(child_calls=True)`` receives an ``invoke_child`` grant on its
+per-job capability token; this module submits/polls/cancels child requests
+and reads/writes the invocation's workflow checkpoints through the ordinary
+platform HTTP API using that token as the bearer.
+
+Depth caps, cycle detection, tree budgets, tier inheritance, payer
+attribution, and tree cancellation are all enforced HUB-side (the token is
+proof of possession only) — this client just surfaces the typed refusals.
+
+Wire contract: tensorhub docs/callout.md.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import quote
+
+from .api.errors import (
+    CanceledError,
+    ChildCallError,
+    ChildCallRefusedError,
+    ChildCallTimeoutError,
+    ChildRequestCanceledError,
+    ChildRequestFailedError,
+)
+
+_REFUSAL_CODES = frozenset(
+    {
+        "call_depth_exceeded",
+        "call_cycle_detected",
+        "tree_budget_exceeded",
+        "tier_escalation_denied",
+        "parent_not_running",
+        "budget_not_root",
+    }
+)
+
+# Route-scope denials for a capability token WITHOUT the invoke_child grant —
+# the function didn't declare child_calls=True.
+_NOT_DECLARED_CODES = frozenset({"forbidden", "insufficient_scope", "unauthorized"})
+
+DEFAULT_POLL_INTERVAL_S = 2.0
+_HTTP_TIMEOUT_S = 60.0
+
+
+def _parse_error_body(text: str) -> tuple[str, str]:
+    """Best-effort (code, message) from a platform error response body."""
+    try:
+        doc = json.loads(text or "{}")
+    except ValueError:
+        return "", (text or "")[:256]
+    err = doc.get("error")
+    if isinstance(err, dict):
+        return str(err.get("code") or ""), str(err.get("message") or "")
+    if isinstance(err, str):
+        return "", err[:256]
+    return "", (text or "")[:256]
+
+
+class CalloutClient:
+    """HTTP client for one invocation's child calls + checkpoints.
+
+    Constructed by :class:`~gen_worker.request_context.RequestContext` —
+    tenant code uses ``ctx.call_endpoint`` / ``ctx.workflow_checkpoint``.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        parent_request_id: str,
+        get_token: Callable[[], str],
+        cancel_event: Optional[threading.Event] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._parent_request_id = parent_request_id
+        self._get_token = get_token
+        self._cancel_event = cancel_event
+
+    # -- low-level ---------------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        token = self._get_token()
+        if not token:
+            raise ChildCallRefusedError(
+                "child_calls_not_declared",
+                "no capability token in this invocation context; declare "
+                "@endpoint(child_calls=True) and run under the platform",
+            )
+        return {"Authorization": f"Bearer {token}"}
+
+    def _raise_for_error(self, status_code: int, text: str) -> None:
+        code, message = _parse_error_body(text)
+        if code in _REFUSAL_CODES:
+            raise ChildCallRefusedError(code, message)
+        if status_code in (401, 403) and (code in _NOT_DECLARED_CODES or not code):
+            raise ChildCallRefusedError(
+                "child_calls_not_declared",
+                message
+                or "the platform refused this credential for child calls; "
+                "declare @endpoint(child_calls=True)",
+            )
+        raise ChildCallError(
+            f"child call failed ({status_code}{', ' + code if code else ''}): "
+            f"{message or text[:256]}"
+        )
+
+    # -- submit / poll / cancel --------------------------------------------
+
+    def submit(
+        self,
+        endpoint: str,
+        function: str,
+        payload: Dict[str, Any],
+        *,
+        tag: str = "prod",
+        tier: Optional[str] = None,
+    ) -> str:
+        """Submit one child request; returns its request id."""
+        import requests
+
+        endpoint = (endpoint or "").strip().strip("/")
+        if "/" not in endpoint:
+            raise ValueError(
+                f"endpoint must be 'owner/name' (e.g. 'tensorhub/music-analysis'), got {endpoint!r}"
+            )
+        function = (function or "").strip()
+        if not function:
+            raise ValueError("function is required")
+        body = dict(payload or {})
+        if tier:
+            body["availability_tier"] = tier
+        url = f"{self._base_url}/{endpoint}/{function}:{(tag or 'prod').strip()}"
+        resp = requests.post(url, headers=self._headers(), json=body, timeout=_HTTP_TIMEOUT_S)
+        if resp.status_code >= 300:
+            self._raise_for_error(resp.status_code, resp.text)
+        doc = resp.json() if resp.text else {}
+        request_id = str(doc.get("request_id") or "")
+        if not request_id:
+            raise ChildCallError(f"submit returned no request_id: {resp.text[:256]}")
+        return request_id
+
+    def get(self, request_id: str) -> Dict[str, Any]:
+        import requests
+
+        resp = requests.get(
+            f"{self._base_url}/v1/requests/{quote(request_id, safe='')}",
+            headers=self._headers(),
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        if resp.status_code >= 300:
+            self._raise_for_error(resp.status_code, resp.text)
+        doc = resp.json()
+        if not isinstance(doc, dict):
+            raise ChildCallError("malformed request read")
+        return doc
+
+    def cancel(self, request_id: str) -> None:
+        """Cancel a child (idempotent: an already-terminal child is a no-op)."""
+        import requests
+
+        resp = requests.post(
+            f"{self._base_url}/v1/requests/{quote(request_id, safe='')}/cancel",
+            headers=self._headers(),
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        if resp.status_code in (200, 404):
+            return
+        self._raise_for_error(resp.status_code, resp.text)
+
+    def wait(
+        self,
+        request_id: str,
+        *,
+        timeout_s: Optional[float],
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    ) -> List[Any]:
+        """Poll to a terminal state; return the child's output items.
+
+        Cooperative with parent cancellation: when this invocation is
+        cancelled (the hub is cascading to the children anyway), the wait
+        raises :class:`CanceledError` promptly.
+        """
+        deadline = time.monotonic() + timeout_s if timeout_s and timeout_s > 0 else None
+        while True:
+            doc = self.get(request_id)
+            status = str(doc.get("status") or "")
+            if status == "completed":
+                out = doc.get("output")
+                return out if isinstance(out, list) else []
+            if status == "failed":
+                err = doc.get("error") or {}
+                if not isinstance(err, dict):
+                    err = {"message": str(err)}
+                raise ChildRequestFailedError(
+                    request_id,
+                    error_type=str(err.get("type") or err.get("code") or ""),
+                    error_message=str(err.get("message") or ""),
+                )
+            if status == "canceled":
+                raise ChildRequestCanceledError(request_id)
+            if deadline is not None and time.monotonic() >= deadline:
+                raise ChildCallTimeoutError(request_id, timeout_s or 0.0)
+            if self._cancel_event is not None:
+                if self._cancel_event.wait(poll_interval_s):
+                    raise CanceledError("canceled")
+            else:
+                time.sleep(poll_interval_s)
+
+    # -- checkpoints ---------------------------------------------------------
+
+    def checkpoint_get(self, key: str) -> tuple[Any, bool]:
+        import requests
+
+        resp = requests.get(
+            self._checkpoint_url(key), headers=self._headers(), timeout=_HTTP_TIMEOUT_S
+        )
+        if resp.status_code == 404:
+            return None, False
+        if resp.status_code >= 300:
+            self._raise_for_error(resp.status_code, resp.text)
+        return resp.json(), True
+
+    def checkpoint_put(self, key: str, value: Any) -> None:
+        import requests
+
+        body = json.dumps(value).encode("utf-8")
+        resp = requests.put(
+            self._checkpoint_url(key),
+            headers={**self._headers(), "Content-Type": "application/json"},
+            data=body,
+            timeout=_HTTP_TIMEOUT_S,
+        )
+        if resp.status_code >= 300:
+            self._raise_for_error(resp.status_code, resp.text)
+
+    def _checkpoint_url(self, key: str) -> str:
+        key = (key or "").strip()
+        if not key:
+            raise ValueError("checkpoint key is required")
+        return (
+            f"{self._base_url}/v1/requests/"
+            f"{quote(self._parent_request_id, safe='')}/checkpoints/{quote(key, safe='')}"
+        )
+
+
+class ChildRequest:
+    """Handle for one submitted child request (``wait=False`` variant)."""
+
+    def __init__(self, client: CalloutClient, request_id: str) -> None:
+        self._client = client
+        self._request_id = request_id
+
+    @property
+    def request_id(self) -> str:
+        return self._request_id
+
+    def status(self) -> str:
+        """One status read: queued | in_progress | completed | failed | canceled."""
+        return str(self._client.get(self._request_id).get("status") or "")
+
+    def result(
+        self,
+        timeout_s: Optional[float] = None,
+        *,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    ) -> List[Any]:
+        """Poll to terminal; return output items or raise the typed error."""
+        return self._client.wait(
+            self._request_id, timeout_s=timeout_s, poll_interval_s=poll_interval_s
+        )
+
+    def cancel(self) -> None:
+        """Cancel this child (and, hub-side, its own descendants)."""
+        self._client.cancel(self._request_id)

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -668,6 +668,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
             "is_async": es.is_async,
             "timeout_ms": es.timeout_ms,
         }
+        # th#826: the child-call declaration — the hub mints the invoke_child
+        # capability grant only for declaring functions. Omitted when false.
+        if es.child_calls:
+            fn["child_calls"] = True
         if model_key is not None:
             fn["model"] = model_key
         if slots_block:

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -68,6 +68,9 @@ class EndpointSpec:
     timeout_ms: Optional[int] = None
     runtime: Optional[str] = None
     compile: Optional[Compile] = None  # opt-in torch.compile spec (#384)
+    # th#826: the function makes endpoint-to-endpoint child calls; emitted
+    # into the discovery manifest so the hub mints the invoke_child grant.
+    child_calls: bool = False
     module: str = ""              # declaring module
     walked_module: str = ""       # top-level package the object was found under
 
@@ -291,6 +294,7 @@ def _spec_for_handler(
         slot_family=slot_family,
         runtime=decl.runtime,
         compile=decl.compile,
+        child_calls=decl.child_calls,
         module=getattr(cls or method, "__module__", "") or "",
         walked_module=walked_module,
     )

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:  # heavy deps stay import-time-free; methods import lazily
     from PIL import Image
 
     from ._concurrent_upload import BudgetGate
+    from ..callout import CalloutClient
 
 
 class LoraOverlay(TypedDict):
@@ -419,6 +420,84 @@ class RequestContext:
             self._canceled = True
             self._cancel_event.set()
             logger.info("request %s marked for cancellation.", self.request_id)
+
+    # -- th#826 call-out primitive ------------------------------------------
+
+    def _callout_client(self) -> "CalloutClient":
+        from ..callout import CalloutClient
+
+        if not self._file_api_base_url:
+            from ..api.errors import ChildCallError
+
+            raise ChildCallError(
+                "no platform base URL in this invocation context; child calls "
+                "require running under the platform (or cozy-local)"
+            )
+        return CalloutClient(
+            base_url=self._file_api_base_url,
+            parent_request_id=self._request_id,
+            get_token=lambda: self._worker_capability_token or "",
+            cancel_event=self._cancel_event,
+        )
+
+    def call_endpoint(
+        self,
+        endpoint: str,
+        function: str,
+        payload: Dict[str, Any],
+        *,
+        tag: str = "prod",
+        wait: bool = True,
+        timeout_s: Optional[float] = 3600.0,
+        tier: Optional[str] = None,
+        poll_interval_s: float = 2.0,
+    ) -> Any:
+        """Call another endpoint's function as a CHILD request (th#826).
+
+        The function must be declared ``@endpoint(child_calls=True)`` — the
+        platform then scopes this invocation's credential for child calls.
+        Children bill the parent request's payer, inherit its availability
+        tier (``tier=`` may name a CHEAPER class, never escalate), count
+        against the tree's depth/budget ceilings, and die with the parent
+        when the tree is cancelled.
+
+        ``wait=True`` (default) blocks to a terminal state and returns the
+        child's output items (asset refs stay refs — pass them straight into
+        the next call's payload). ``wait=False`` returns a
+        :class:`~gen_worker.callout.ChildRequest` handle
+        (``.status()`` / ``.result()`` / ``.cancel()``).
+
+        Raises ``ChildCallRefusedError`` (typed admission refusals),
+        ``ChildRequestFailedError`` / ``ChildRequestCanceledError``,
+        ``ChildCallTimeoutError``, and ``CanceledError`` when this invocation
+        itself is cancelled mid-wait.
+        """
+        self.raise_if_cancelled()
+        client = self._callout_client()
+        request_id = client.submit(endpoint, function, payload, tag=tag, tier=tier)
+        from ..callout import ChildRequest
+
+        handle = ChildRequest(client, request_id)
+        if not wait:
+            return handle
+        return handle.result(timeout_s, poll_interval_s=poll_interval_s)
+
+    def workflow_checkpoint(self, key: str, fn: Callable[[], Any]) -> Any:
+        """Memoize one workflow step's result under this request (th#826).
+
+        Durability-by-memoization (WORKFLOW-DESIGN.md §4): the first call
+        computes ``fn()`` and stores its JSON-serializable result under
+        ``key``; a re-run of this invocation (worker death, retry attempt)
+        returns the stored value without recomputing. Values are small JSON
+        (step output refs, not media; 64KB cap).
+        """
+        client = self._callout_client()
+        value, found = client.checkpoint_get(key)
+        if found:
+            return value
+        value = fn()
+        client.checkpoint_put(key, value)
+        return value
 
     @contextmanager
     def _gpu_slot_yielded(self) -> "Iterator[None]":

--- a/tests/test_callout.py
+++ b/tests/test_callout.py
@@ -1,0 +1,299 @@
+"""th#826 call-out primitive: SDK client + ctx surface against a fake hub."""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gen_worker.api.errors import (
+    CanceledError,
+    ChildCallRefusedError,
+    ChildCallTimeoutError,
+    ChildRequestCanceledError,
+    ChildRequestFailedError,
+)
+from gen_worker.callout import CalloutClient, ChildRequest
+from gen_worker.request_context import RequestContext
+
+PARENT_ID = "req-parent-1"
+TOKEN = "cap-token-1"
+
+
+class _FakeHub(BaseHTTPRequestHandler):
+    """Scriptable fake of the platform surface the callout client speaks to."""
+
+    state: Dict[str, Any] = {}
+
+    def log_message(self, *args: Any) -> None:  # silence
+        pass
+
+    def _json(self, code: int, doc: Any) -> None:
+        body = json.dumps(doc).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _authed(self) -> bool:
+        return self.headers.get("Authorization") == f"Bearer {TOKEN}"
+
+    def do_POST(self) -> None:  # noqa: N802
+        st = _FakeHub.state
+        if not self._authed():
+            self._json(401, {"error": {"code": "unauthorized", "message": "no token"}})
+            return
+        if self.path.endswith("/cancel"):
+            rid = self.path.split("/")[-2]
+            st.setdefault("cancels", []).append(rid)
+            self._json(200, {"ok": True})
+            return
+        # invoke: /{owner}/{endpoint}/{function}:{tag}
+        length = int(self.headers.get("Content-Length") or 0)
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        st.setdefault("submits", []).append({"path": self.path, "payload": payload})
+        refusal = st.get("refusal")
+        if refusal:
+            self._json(refusal["status"], {"error": {"code": refusal["code"], "message": refusal.get("message", "")}})
+            return
+        self._json(200, {"request_id": st.get("next_request_id", "child-1"), "status": "queued"})
+
+    def do_GET(self) -> None:  # noqa: N802
+        st = _FakeHub.state
+        if not self._authed():
+            self._json(401, {"error": {"code": "unauthorized", "message": "no token"}})
+            return
+        if "/checkpoints/" in self.path:
+            key = self.path.rsplit("/", 1)[-1]
+            ckpts = st.setdefault("checkpoints", {})
+            if key in ckpts:
+                self._json(200, ckpts[key])
+            else:
+                self._json(404, {"error": {"code": "not_found", "message": "checkpoint not found"}})
+            return
+        # /v1/requests/{id}
+        rid = self.path.rsplit("/", 1)[-1]
+        polls = st.setdefault("polls", {})
+        n = polls.get(rid, 0)
+        polls[rid] = n + 1
+        seq = st.get("statuses", ["completed"])
+        doc = seq[min(n, len(seq) - 1)]
+        self._json(200, {"id": rid, **doc})
+
+    def do_PUT(self) -> None:  # noqa: N802
+        st = _FakeHub.state
+        if not self._authed():
+            self._json(401, {"error": {"code": "unauthorized", "message": "no token"}})
+            return
+        key = self.path.rsplit("/", 1)[-1]
+        length = int(self.headers.get("Content-Length") or 0)
+        value = json.loads(self.rfile.read(length) or b"null")
+        st.setdefault("checkpoints", {})[key] = value
+        st.setdefault("checkpoint_puts", []).append(key)
+        self.send_response(204)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+@pytest.fixture()
+def hub():
+    _FakeHub.state = {}
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeHub)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}", _FakeHub.state
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+def _client(base: str, cancel_event: Optional[threading.Event] = None) -> CalloutClient:
+    return CalloutClient(
+        base_url=base,
+        parent_request_id=PARENT_ID,
+        get_token=lambda: TOKEN,
+        cancel_event=cancel_event,
+    )
+
+
+def _ctx(base: str) -> RequestContext:
+    return RequestContext(
+        request_id=PARENT_ID,
+        file_api_base_url=base,
+        worker_capability_token=TOKEN,
+    )
+
+
+def test_submit_and_wait_returns_output(hub):
+    base, state = hub
+    state["statuses"] = [
+        {"status": "queued", "output": []},
+        {"status": "in_progress", "output": []},
+        {"status": "completed", "output": [{"type": "video", "ref": "media/abc.mp4"}]},
+    ]
+    out = _ctx(base).call_endpoint(
+        "tensorhub/music-analysis", "analyze-quick", {"audio": "ref-1"},
+        poll_interval_s=0.01,
+    )
+    assert out == [{"type": "video", "ref": "media/abc.mp4"}]
+    sub = state["submits"][0]
+    assert sub["path"] == "/tensorhub/music-analysis/analyze-quick:prod"
+    assert sub["payload"] == {"audio": "ref-1"}
+
+
+def test_submit_carries_cheaper_tier_and_tag(hub):
+    base, state = hub
+    state["statuses"] = [{"status": "completed", "output": []}]
+    _ctx(base).call_endpoint(
+        "tensorhub/ltx-video-2.3", "audio-reactive", {"p": 1},
+        tag="dev", tier="flex", poll_interval_s=0.01,
+    )
+    sub = state["submits"][0]
+    assert sub["path"] == "/tensorhub/ltx-video-2.3/audio-reactive:dev"
+    assert sub["payload"]["availability_tier"] == "flex"
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "call_depth_exceeded",
+        "call_cycle_detected",
+        "tree_budget_exceeded",
+        "tier_escalation_denied",
+        "parent_not_running",
+        "budget_not_root",
+    ],
+)
+def test_typed_admission_refusals(hub, code):
+    base, state = hub
+    state["refusal"] = {"status": 403, "code": code, "message": "refused"}
+    with pytest.raises(ChildCallRefusedError) as exc:
+        _ctx(base).call_endpoint("tensorhub/some-ep", "step", {})
+    assert exc.value.code == code
+
+
+def test_undeclared_child_calls_maps_to_typed_refusal(hub):
+    base, state = hub
+    state["refusal"] = {"status": 403, "code": "insufficient_scope", "message": "forbidden"}
+    with pytest.raises(ChildCallRefusedError) as exc:
+        _ctx(base).call_endpoint("tensorhub/some-ep", "step", {})
+    assert exc.value.code == "child_calls_not_declared"
+
+
+def test_missing_token_is_typed_refusal():
+    ctx = RequestContext(request_id=PARENT_ID, file_api_base_url="http://127.0.0.1:9")
+    with pytest.raises(ChildCallRefusedError) as exc:
+        ctx.call_endpoint("tensorhub/some-ep", "step", {})
+    assert exc.value.code == "child_calls_not_declared"
+
+
+def test_wait_false_returns_handle_and_cancel(hub):
+    base, state = hub
+    state["next_request_id"] = "child-9"
+    state["statuses"] = [{"status": "in_progress", "output": []}]
+    handle = _ctx(base).call_endpoint("tensorhub/some-ep", "step", {}, wait=False)
+    assert isinstance(handle, ChildRequest)
+    assert handle.request_id == "child-9"
+    assert handle.status() == "in_progress"
+    handle.cancel()
+    assert state["cancels"] == ["child-9"]
+
+
+def test_child_failure_and_cancel_raise_typed(hub):
+    base, state = hub
+    state["statuses"] = [
+        {"status": "failed", "error": {"type": "oom", "message": "boom"}},
+    ]
+    with pytest.raises(ChildRequestFailedError) as exc:
+        _ctx(base).call_endpoint("tensorhub/some-ep", "step", {}, poll_interval_s=0.01)
+    assert exc.value.error_type == "oom"
+    assert exc.value.error_message == "boom"
+
+    state["polls"] = {}
+    state["statuses"] = [{"status": "canceled"}]
+    with pytest.raises(ChildRequestCanceledError):
+        _ctx(base).call_endpoint("tensorhub/some-ep", "step", {}, poll_interval_s=0.01)
+
+
+def test_wait_timeout_raises_and_child_keeps_running(hub):
+    base, state = hub
+    state["statuses"] = [{"status": "in_progress", "output": []}]
+    with pytest.raises(ChildCallTimeoutError):
+        _ctx(base).call_endpoint(
+            "tensorhub/some-ep", "step", {}, timeout_s=0.05, poll_interval_s=0.01
+        )
+
+
+def test_parent_cancellation_interrupts_wait(hub):
+    base, state = hub
+    state["statuses"] = [{"status": "in_progress", "output": []}]
+    ctx = _ctx(base)
+    handle = ctx.call_endpoint("tensorhub/some-ep", "step", {}, wait=False)
+
+    timer = threading.Timer(0.1, ctx._cancel)
+    timer.start()
+    try:
+        with pytest.raises(CanceledError):
+            handle.result(timeout_s=30, poll_interval_s=0.5)
+    finally:
+        timer.cancel()
+
+
+def test_workflow_checkpoint_memoizes(hub):
+    base, state = hub
+    ctx = _ctx(base)
+    calls = {"n": 0}
+
+    def step() -> Dict[str, Any]:
+        calls["n"] += 1
+        return {"clip": "media/clip-1.mp4", "score": 0.97}
+
+    first = ctx.workflow_checkpoint("scene-1", step)
+    second = ctx.workflow_checkpoint("scene-1", step)
+    assert first == second == {"clip": "media/clip-1.mp4", "score": 0.97}
+    assert calls["n"] == 1
+    assert state["checkpoint_puts"] == ["scene-1"]
+    # A different key computes independently.
+    other = ctx.workflow_checkpoint("scene-2", lambda: {"clip": "media/clip-2.mp4"})
+    assert other == {"clip": "media/clip-2.mp4"}
+
+
+def test_bad_endpoint_shape_rejected(hub):
+    base, _ = hub
+    with pytest.raises(ValueError):
+        _ctx(base).call_endpoint("music-analysis", "step", {})
+
+
+import msgspec
+
+
+class _Out(msgspec.Struct):
+    ok: bool
+
+
+class _In(msgspec.Struct):
+    x: int
+
+
+def test_child_calls_declaration_reaches_manifest():
+    from gen_worker import RequestContext as Ctx  # noqa: F401 (import sanity)
+    from gen_worker.api.decorators import ATTR, endpoint
+    from gen_worker.discovery.discover import _extract_entries
+
+    @endpoint(kind="inference", child_calls=True)
+    def workflow(ctx: RequestContext, payload: _In) -> _Out:  # pragma: no cover
+        return _Out(ok=True)
+
+    @endpoint(kind="inference")
+    def plain(ctx: RequestContext, payload: _In) -> _Out:  # pragma: no cover
+        return _Out(ok=True)
+
+    assert getattr(workflow, ATTR).child_calls is True
+    assert getattr(plain, ATTR).child_calls is False
+
+    wf_entry = _extract_entries(workflow, "tests.test_callout")[0]
+    assert wf_entry["child_calls"] is True
+    plain_entry = _extract_entries(plain, "tests.test_callout")[0]
+    assert "child_calls" not in plain_entry

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.26.11"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
SDK half of tensorhub#826 (workflows are endpoints that call endpoints; contract: tensorhub docs/callout.md):

- `@endpoint(child_calls=True)` declaration → discovery manifest `child_calls` (the hub mints the `invoke_child` capability grant only for declaring functions).
- `ctx.call_endpoint(endpoint, function, payload, *, tag="prod", wait=True, timeout_s, tier, poll_interval_s)` — sync-await returns the child's output items (asset refs stay refs for chaining); `wait=False` returns a `ChildRequest` handle (`.status()` / `.result()` / `.cancel()`). Polling is parent-cancel-aware (raises `CanceledError` promptly when the tree is being cancelled).
- `ctx.workflow_checkpoint(key, fn)` — step-result memoization under the invocation (WORKFLOW-DESIGN.md §4 durability pattern). Lives in gen-worker core, not a separate package (needs ctx internals; cozy-local reuses the same SDK — recorded verdict for the spec's open question).
- Typed errors: `ChildCallRefusedError(code)` for the platform refusal taxonomy (`call_depth_exceeded`, `call_cycle_detected`, `tree_budget_exceeded`, `tier_escalation_denied`, `parent_not_running`, `budget_not_root`, `child_calls_not_declared`), `ChildRequestFailedError`, `ChildRequestCanceledError`, `ChildCallTimeoutError`.

Tests: fake-hub HTTP suite (17 cases); full suite 1154 passed (1 pre-existing env-dependent failure on master excluded: test_content_lanes cgroup RAM sizing); mypy green; version 0.27.0 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)