### PR TITLE
gw#470: boot warmup default-on — schema-synthesized pre-READY warmup (0.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.28.0 (2026-07-16)
+
+- **gw#470 boot warmup default-on.** GPU inference endpoints now warm before
+  READY with zero author code: the worker synthesizes one minimal request per
+  handler from its typed payload schema (defaults kept; required `str` fields
+  fill `"warmup"`; required `ImageAsset`/`AudioAsset` fields get a tiny
+  generated PNG/WAV; nested structs/lists synthesize recursively) and runs it
+  post-`setup()` under the load lock. Output is discarded (no emitter, no
+  capability token, throwaway `local_output_dir`) — never billing/outputs/CAS.
+  - Fallback: `@endpoint(warmup={"method": {...}})` declares per-method
+    payloads (validated against the schema at decoration/walk time);
+    `{"method": None}` skips a method.
+  - A class-defined `warmup()` method still wins outright (the LTX path).
+  - Opt-out: `@endpoint(warmup=NoWarmup("reason"))` — in code, recorded, no
+    env knob.
+  - Enforcement: a GPU inference class with no warmable path and no explicit
+    declaration fails at decoration/walk time, not at first request.
+  - `ctx.boot_warmup` lets a handler cheapen its warmup run (e.g.
+    `steps = 1 if ctx.boot_warmup else steps` — the allocator peak is
+    shape-driven, not step-driven).
+  - A warmup CUDA OOM defers to the gw#521 runtime fit ladder (warn + READY)
+    instead of hard-failing the function; other warmup errors remain load
+    failures (loud, th#581 rails). Cancel/drain-safe on the existing
+    `_to_thread_complete` rails.
+
+
 ## 0.27.0 (2026-07-16)
 
 - **th#826 call-out primitive (workflows-as-endpoints).** Functions declared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.27.0"
+version = "0.28.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -15,7 +15,7 @@ subclass from ``@endpoint(kind=...)`` before dispatch.
 
 from . import io
 from .api.binding import Civitai, HF, Hub, ModelRef, ModelScope
-from .api.decorators import Compile, Resources, endpoint
+from .api.decorators import Compile, NoWarmup, Resources, endpoint
 from .api.model import Model, ModelChoice, ModelDefaults
 from .api.slot import ResolvedSlot, Slot
 from .families import FamilyDefaults
@@ -66,6 +66,7 @@ __all__ = [
     "endpoint",
     "Resources",
     "Compile",
+    "NoWarmup",
     "arm_compile",
     "HF",
     "Hub",

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -116,6 +116,43 @@ class Resources(msgspec.Struct, frozen=True, omit_defaults=True):
             force(self, "vcpus", n)
 
 
+class NoWarmup(msgspec.Struct, frozen=True):
+    """Opt a class out of the default boot warmup (gw#470) with a recorded
+    reason: ``@endpoint(warmup=NoWarmup("engine captures CUDA graphs at
+    boot"))``. Warmup is behavior — the opt-out lives in code, never in an
+    env knob."""
+
+    reason: str
+
+    def __post_init__(self) -> None:
+        reason = str(self.reason or "").strip()
+        if not reason:
+            raise ValueError("NoWarmup requires a non-empty reason")
+        msgspec.structs.force_setattr(self, "reason", reason)
+
+
+WarmupDecl = Union[NoWarmup, Mapping[str, Any]]
+
+
+def _validate_warmup_decl(owner: str, warmup: Optional[WarmupDecl]) -> Optional[WarmupDecl]:
+    if warmup is None or isinstance(warmup, NoWarmup):
+        return warmup
+    if isinstance(warmup, Mapping):
+        for key in warmup:
+            k = str(key or "").strip()
+            if not k or not k.isidentifier():
+                raise ValueError(
+                    f"@endpoint {owner}: warmup= key {key!r} must be a handler "
+                    "method name"
+                )
+        return dict(warmup)
+    raise TypeError(
+        f"@endpoint {owner}: warmup= must be a "
+        "{method_name: payload} mapping or NoWarmup(reason), got "
+        f"{type(warmup).__name__}"
+    )
+
+
 class Compile(msgspec.Struct, frozen=True):
     """Opt-in torch.compile over pre-built per-SKU cache artifacts (#384).
 
@@ -192,6 +229,10 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     # child calls (ctx.call_endpoint / ctx.workflow_checkpoint). The hub
     # mints the invoke_child credential ONLY for declaring functions.
     child_calls: bool = False
+    # gw#470 boot warmup: None = auto-synthesize from each handler's payload
+    # schema; {method: payload-or-None} = declared warmup payloads (None
+    # skips that method); NoWarmup(reason) = class-level opt-out.
+    warmup: Optional[WarmupDecl] = None
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -395,6 +436,7 @@ def _decorate_class(
     runtime: Optional[str],
     compile: Optional[Compile] = None,
     child_calls: bool = False,
+    warmup: Optional[WarmupDecl] = None,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -411,9 +453,16 @@ def _decorate_class(
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models, slots=slots,
         runtime=runtime, compile=compile, child_calls=child_calls,
+        warmup=_validate_warmup_decl(cls.__name__, warmup),
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
+    # gw#470: default-on boot warmup — fail unwarmable GPU inference classes
+    # at import when type hints resolve here (walk time re-checks). Lazy
+    # import: warmup.py imports this module.
+    from ..warmup import validate_at_decoration
+
+    validate_at_decoration(cls, decl)
     return cls
 
 
@@ -428,6 +477,7 @@ def _decorate_function(
     name: Optional[str],
     compile: Optional[Compile] = None,
     child_calls: bool = False,
+    warmup: Optional[WarmupDecl] = None,
 ) -> Callable[..., Any]:
     _validate_handler_shape(fn.__name__, fn, is_method=False)
     _reject_producer_generator(fn.__name__, fn, kind)
@@ -448,6 +498,11 @@ def _decorate_function(
         raise ValueError(
             f"@endpoint function {fn.__name__!r}: runtime= requires a class "
             "with setup() (the engine server outlives single calls)."
+        )
+    if warmup is not None:
+        raise ValueError(
+            f"@endpoint function {fn.__name__!r}: warmup= requires a class "
+            "with setup() (stateless functions hold nothing to warm)."
         )
     decl = EndpointDecl(
         kind=kind, resources=resources, models=models, slots=slots,
@@ -473,6 +528,7 @@ def endpoint(
     name: Optional[str] = ...,
     compile: Optional[Compile] = ...,
     child_calls: bool = ...,
+    warmup: Optional[WarmupDecl] = ...,
 ) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
@@ -487,6 +543,7 @@ def endpoint(
     name: Optional[str] = None,
     compile: Optional[Compile] = None,
     child_calls: bool = False,
+    warmup: Optional[WarmupDecl] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes.
 
@@ -518,13 +575,13 @@ def endpoint(
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, compile=compile,
-                child_calls=child_calls,
+                child_calls=child_calls, warmup=warmup,
             )
         if inspect.isfunction(obj):
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, name=name, compile=compile,
-                child_calls=child_calls,
+                child_calls=child_calls, warmup=warmup,
             )
         raise TypeError(
             f"@endpoint requires a function or class, got {type(obj).__name__}"
@@ -535,4 +592,4 @@ def endpoint(
     return apply
 
 
-__all__ = ["Compile", "EndpointDecl", "Resources", "SlotLike", "endpoint"]
+__all__ = ["Compile", "EndpointDecl", "NoWarmup", "Resources", "SlotLike", "WarmupDecl", "endpoint"]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import shutil
+import tempfile
 import threading
 import time
 import typing
@@ -205,7 +206,7 @@ def _capability_job_id(token: str) -> Optional[str]:
         return None
 
 
-def _resolve_slots_kwargs(spec: EndpointSpec, run: "pb.RunJob") -> Dict[str, Any]:
+def _resolve_slots_kwargs(spec: EndpointSpec, run: "Optional[pb.RunJob]") -> Dict[str, Any]:
     """``ctx.slots`` resolution chain (pgw#520 / pgw#516): merge each
     Slot-declared slot's repo-metadata ``ModelBinding.inference_defaults``
     over its code fallback preset, then apply each riding lora's
@@ -219,10 +220,11 @@ def _resolve_slots_kwargs(spec: EndpointSpec, run: "pb.RunJob") -> Dict[str, Any
         return {"resolved_slots": {}, "slot_errors": {}}
     from .api.slot import resolve_slot
 
-    raw_defaults = {b.slot: b.inference_defaults for b in run.models if b.inference_defaults}
+    run_models = list(run.models) if run is not None else []
+    raw_defaults = {b.slot: b.inference_defaults for b in run_models if b.inference_defaults}
     lora_defaults = {
         b.slot: tuple(lo.inference_defaults for lo in b.loras if lo.inference_defaults)
-        for b in run.models if b.loras
+        for b in run_models if b.loras
     }
     resolved: Dict[str, Any] = {}
     errors: Dict[str, str] = {}
@@ -1736,6 +1738,95 @@ class Executor:
             self._on_state_change()
             return instance
 
+    async def _run_synthesized_warmup(
+        self, spec: EndpointSpec, rec: _ClassRecord, instance: Any,
+        snapshots: Optional[Dict[str, pb.Snapshot]],
+    ) -> None:
+        """gw#470 default boot warmup: one synthesized (or `warmup=`-declared)
+        request per GPU inference handler of this instance group, run
+        post-setup pre-READY under the load lock. Output is discarded — the
+        ctx has no emitter/capability token and writes to a throwaway
+        local_output_dir, so nothing touches billing/outputs/CAS. A failure
+        propagates as a load failure."""
+        if spec.kind != "inference" or spec.cls is None:
+            return
+        from . import warmup as warmup_mod
+        from .api.decorators import ATTR as _DECL_ATTR
+
+        decl = getattr(spec.cls, _DECL_ATTR, None)
+        if decl is None:
+            # Not an @endpoint class (internally-constructed spec): no
+            # declaration surface exists, so no synthesized warmup either.
+            return
+        # Instance group = every spec sharing this instance: the code-table
+        # siblings (matching instance_key) plus whatever this record has
+        # already seen (covers pgw#532 derived per-pick specs).
+        siblings: Dict[str, EndpointSpec] = {
+            s.name: s for s in self.specs.values()
+            if s.cls is spec.cls and s.instance_key == spec.instance_key
+        }
+        for s in rec.specs:
+            siblings[s.name] = s
+        siblings[spec.name] = spec
+        jobs, skips = warmup_mod.plan(
+            siblings.values(),
+            decl_warmup=decl.warmup,
+            has_warmup_method=False,
+        )
+        for skip in skips:
+            logger.info("boot warmup skipped for %s: %s", skip.spec.name, skip.reason)
+        for wj in jobs:
+            handler_kwargs = await self._handler_kwargs(wj.spec, snapshots or {})
+            t0 = time.monotonic()
+            with tempfile.TemporaryDirectory(prefix="gw-warmup-") as tmp:
+                payload = wj.build(tmp)
+                ctx = RequestContext(
+                    request_id=f"boot-warmup-{wj.spec.name}",
+                    local_output_dir=tmp,
+                    models={slot: wire_ref(b) for slot, b in wj.spec.models.items()},
+                    **_resolve_slots_kwargs(wj.spec, None),
+                    boot_warmup=True,
+                )
+                try:
+                    await self._invoke_warmup(wj.spec, instance, ctx, payload, handler_kwargs)
+                except Exception as exc:
+                    if not is_cuda_oom(exc):
+                        raise
+                    # A warmup OOM must not take the function down: the
+                    # runtime fit ladder (gw#521) still serves it degraded
+                    # on the first real request. Flush and stop warming.
+                    logger.warning(
+                        "boot warmup %s OOMed (%s) — skipping remaining "
+                        "warmups; the first-request fit ladder owns this",
+                        wj.spec.name, exc)
+                    if torch is not None and torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    return
+            logger.info(
+                "boot warmup %s (%s): %.1fs",
+                wj.spec.name, "declared" if wj.declared else "synthesized",
+                time.monotonic() - t0)
+
+    async def _invoke_warmup(
+        self, spec: EndpointSpec, instance: Any, ctx: "RequestContext",
+        payload: Any, kwargs: Dict[str, Any],
+    ) -> None:
+        bound = getattr(instance, spec.attr_name)
+        call_kwargs = {spec.ctx_param: ctx, spec.payload_param: payload, **kwargs}
+        if spec.is_async_gen:
+            async for _ in bound(**call_kwargs):
+                pass
+        elif spec.is_async:
+            await bound(**call_kwargs)
+        else:
+            def _consume() -> None:
+                out = bound(**call_kwargs)
+                if spec.output_mode == "stream":
+                    for _ in out:
+                        pass
+
+            await _to_thread_complete(_consume)
+
     def _mark_setup_failed(self, rec: _ClassRecord, exc: BaseException) -> None:
         if isinstance(exc, (InsufficientDiskError, RetryableError, MissingSnapshotError)):
             # Transient pressure (disk GC frees space / warm-tier RAM drains /
@@ -1826,6 +1917,12 @@ class Executor:
                         stats.get("fxgraph_cache_hit", 0),
                         stats.get("fxgraph_cache_miss", 0),
                         time.monotonic() - warm_t0)
+            else:
+                # gw#470: no custom warmup() — run the synthesized boot
+                # warmup for every GPU inference handler of this instance
+                # group, still pre-READY under the load lock. A failure
+                # propagates as a load failure (loud, th#581 rails).
+                await self._run_synthesized_warmup(spec, rec, instance, snapshots)
             vram_delta = max(0, self._vram_allocated() - vram_before)
             if rec.server is not None:
                 # Engine subprocess VRAM is invisible to torch's allocator;

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -333,6 +333,11 @@ def extract_specs(obj: Any, *, walked_module: str = "") -> List[EndpointSpec]:
             slots=dict(decl.slots),
             resources=decl.resources, walked_module=walked,
         ))
+    # gw#470: boot warmup is default-on for GPU inference classes — fail at
+    # walk time (discovery/CI/boot), never at first request.
+    from .warmup import validate_class_warmup
+
+    validate_class_warmup(cls, decl, out)
     return out
 
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -156,6 +156,7 @@ class RequestContext:
         loras: Optional[Dict[str, Any]] = None,
         resolved_slots: Optional[Mapping[str, "ResolvedSlot[Any]"]] = None,
         slot_errors: Optional[Mapping[str, str]] = None,
+        boot_warmup: bool = False,
     ) -> None:
         self._request_id = str(request_id or "").strip()
         self._job_id = str(job_id or "").strip() or None
@@ -171,6 +172,7 @@ class RequestContext:
         if timeout_ms is not None and timeout_ms > 0:
             self._deadline = self._started_at + (timeout_ms / 1000.0)
         self._canceled = False
+        self._boot_warmup = bool(boot_warmup)
         self._cancel_event = threading.Event()
         self._emitter = emitter
         self._cached_repo_job_scope: Optional[tuple[str, str, str]] = None
@@ -200,6 +202,14 @@ class RequestContext:
     @property
     def request_id(self) -> str:
         return self._request_id
+
+    @property
+    def boot_warmup(self) -> bool:
+        """True when this call is the worker's boot-time synthetic warmup
+        (gw#470): the output is discarded, so a handler MAY cheapen the run
+        (e.g. ``steps = 1 if ctx.boot_warmup else steps``) — the allocator
+        peak is shape-driven, not step-driven."""
+        return self._boot_warmup
 
     @property
     def deadline(self) -> Optional[float]:

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -1,0 +1,363 @@
+"""Boot-time synthetic warmup planning (gw#470).
+
+First-call tax on a fresh worker is EAGER cost — allocator-pool growth to
+the activation peak plus cuBLAS/cuDNN heuristic selection (measured 216s vs
+63s warm on LTX/H100 pre-expandable-segments; 0-152s host lottery on B200).
+The worker therefore runs one synthetic request per GPU inference function
+after ``setup()``, BEFORE the function reports READY. Output is discarded
+(never billing/outputs/CAS); a failure is a load failure (loud).
+
+Author surface, smallest first (Paul ruling 2026-07-16):
+
+1. DEFAULT — nothing. The payload is synthesized from the handler's typed
+   msgspec schema: defaulted fields keep their defaults, required ``str``
+   fields fill ``"warmup"``, required ``ImageAsset``/``AudioAsset`` fields
+   get a tiny generated PNG/WAV, nested structs and lists synthesize
+   recursively. A function whose schema cannot synthesize (e.g. required
+   video input) is skipped with a logged reason.
+2. ``@endpoint(warmup={"method": {...}})`` — declarative per-method payload
+   overriding synthesis (e.g. to warm the largest preset when the schema
+   default is not the allocator peak). ``{"method": None}`` skips a method.
+3. A class-defined ``warmup()`` method wins outright (fully custom — the
+   LTX two-stage synthetic).
+4. ``@endpoint(warmup=NoWarmup("reason"))`` — class-level opt-out, reason
+   recorded in code. Never an env knob.
+
+A GPU inference class with NO warmable path and no opt-out fails at spec
+construction time (discovery walk / CI), not at first request.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import struct
+import types as py_types
+import typing
+import wave
+import zlib
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import msgspec
+
+from .api.decorators import ATTR, EndpointDecl, NoWarmup
+from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from .registry import EndpointSpec
+
+WARMUP_TEXT = "warmup"
+_IMAGE_SIDE = 512
+_AUDIO_SECONDS = 2.0
+_AUDIO_RATE = 48_000
+_MAX_DEPTH = 4
+
+# factory(tmp_dir) -> field value; tmp_dir hosts any synthetic asset files.
+_Factory = Callable[[str], Any]
+
+
+def synthetic_png(dir_path: str) -> str:
+    """Write a mid-gray RGB PNG (stdlib only) and return its path."""
+    path = os.path.join(dir_path, "warmup.png")
+    side = _IMAGE_SIDE
+    row = b"\x00" + b"\x80" * (side * 3)  # filter 0 + gray pixels
+    idat = zlib.compress(row * side, 6)
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data)) + tag + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
+    with open(path, "wb") as f:
+        f.write(b"\x89PNG\r\n\x1a\n")
+        f.write(chunk(b"IHDR", ihdr))
+        f.write(chunk(b"IDAT", idat))
+        f.write(chunk(b"IEND", b""))
+    return path
+
+
+def synthetic_wav(dir_path: str) -> str:
+    """Write a short stereo silence WAV (stdlib only) and return its path."""
+    path = os.path.join(dir_path, "warmup.wav")
+    with wave.open(path, "wb") as w:
+        w.setnchannels(2)
+        w.setsampwidth(2)
+        w.setframerate(_AUDIO_RATE)
+        w.writeframes(b"\x00\x00" * 2 * int(_AUDIO_RATE * _AUDIO_SECONDS))
+    return path
+
+
+def _image_asset(dir_path: str) -> ImageAsset:
+    return ImageAsset(
+        ref="boot-warmup.png", local_path=synthetic_png(dir_path),
+        mime_type="image/png",
+    )
+
+
+def _audio_asset(dir_path: str) -> AudioAsset:
+    return AudioAsset(
+        ref="boot-warmup.wav", local_path=synthetic_wav(dir_path),
+        mime_type="audio/wav",
+    )
+
+
+def _unwrap(t: Any) -> Any:
+    while typing.get_origin(t) is typing.Annotated:
+        t = typing.get_args(t)[0]
+    return t
+
+
+def _is_struct(t: Any) -> bool:
+    return isinstance(t, type) and issubclass(t, msgspec.Struct)
+
+
+def _field_factory(t: Any, depth: int) -> Tuple[Optional[_Factory], str]:
+    """-> (factory, blocked_reason). Exactly one side is meaningful."""
+    t = _unwrap(t)
+    if depth > _MAX_DEPTH:
+        return None, f"nesting deeper than {_MAX_DEPTH}"
+    origin = typing.get_origin(t)
+    if origin in (typing.Union, py_types.UnionType):
+        args = typing.get_args(t)
+        if type(None) in args:
+            return (lambda d: None), ""
+        for arm in args:
+            factory, _ = _field_factory(arm, depth + 1)
+            if factory is not None:
+                return factory, ""
+        return None, f"no synthesizable union arm in {t!r}"
+    if t is str:
+        return (lambda d: WARMUP_TEXT), ""
+    if isinstance(t, type):
+        # Asset ordering matters: check concrete media kinds before the
+        # ambiguous bases.
+        if issubclass(t, ImageAsset):
+            return _image_asset, ""
+        if issubclass(t, AudioAsset):
+            return _audio_asset, ""
+        if issubclass(t, VideoAsset):
+            return None, "required video input is not synthesizable"
+        if issubclass(t, Asset):
+            return None, f"required {t.__name__} input is not synthesizable"
+        if issubclass(t, enum.Enum):
+            members = list(t)
+            if members:
+                first = members[0]
+                return (lambda d: first), ""
+            return None, f"enum {t.__name__} has no members"
+        if issubclass(t, msgspec.Struct):
+            return _struct_factory(t, depth + 1)
+    if origin in (list, typing.List, Sequence, typing.Sequence, tuple, typing.Tuple):
+        args = tuple(a for a in typing.get_args(t) if a is not Ellipsis)
+        if len(args) == 1:
+            inner, reason = _field_factory(args[0], depth + 1)
+            if inner is None:
+                return None, reason
+            if origin in (tuple, typing.Tuple):
+                return (lambda d: (inner(d),)), ""
+            return (lambda d: [inner(d)]), ""
+        return None, f"unsupported sequence shape {t!r}"
+    return None, f"required field type {t!r} is not synthesizable"
+
+
+def _struct_factory(payload_type: type, depth: int = 0) -> Tuple[Optional[_Factory], str]:
+    field_factories: List[Tuple[str, _Factory]] = []
+    for f in msgspec.structs.fields(payload_type):
+        if not f.required:
+            continue
+        factory, reason = _field_factory(f.type, depth)
+        if factory is None:
+            return None, (
+                f"required field {f.name!r}: {reason}"
+                if reason else f"required field {f.name!r} is not synthesizable"
+            )
+        field_factories.append((f.name, factory))
+
+    def build(dir_path: str) -> Any:
+        return payload_type(**{name: fac(dir_path) for name, fac in field_factories})
+
+    return build, ""
+
+
+def synthesize_factory(payload_type: type) -> Tuple[Optional[_Factory], str]:
+    """Payload factory for one handler's input struct, or (None, reason)."""
+    return _struct_factory(payload_type, 0)
+
+
+@dataclass(frozen=True)
+class WarmupJob:
+    """One planned synthetic invocation: ``build(tmp_dir)`` -> payload."""
+
+    spec: "EndpointSpec"
+    build: _Factory
+    declared: bool  # True when the payload came from `warmup=`
+
+
+@dataclass(frozen=True)
+class WarmupSkip:
+    spec: "EndpointSpec"
+    reason: str
+
+
+def _declared_factory(owner: str, attr: str, payload_type: type, value: Any) -> _Factory:
+    """Validate a declared warmup payload against the handler's schema NOW
+    (decoration/walk time), returning a factory that rebuilds it fresh."""
+    if isinstance(value, payload_type):
+        builtins_value = msgspec.to_builtins(value)
+    elif isinstance(value, Mapping):
+        builtins_value = dict(value)
+    else:
+        raise TypeError(
+            f"{owner}: warmup[{attr!r}] must be a dict or "
+            f"{payload_type.__name__} instance, got {type(value).__name__}"
+        )
+    try:
+        msgspec.convert(builtins_value, type=payload_type, strict=False)
+    except msgspec.ValidationError as exc:
+        raise TypeError(
+            f"{owner}: warmup[{attr!r}] is not a valid "
+            f"{payload_type.__name__}: {exc}"
+        ) from exc
+    return lambda d: msgspec.convert(builtins_value, type=payload_type, strict=False)
+
+
+def _plan_pairs(
+    owner: str,
+    pairs: Sequence[Tuple[str, type]],
+    decl_warmup: Any,
+) -> Tuple[List[Tuple[str, _Factory, bool]], List[Tuple[str, str]]]:
+    """Core planner over (attr_name, payload_type) pairs ->
+    (jobs=[(attr, factory, declared)], skips=[(attr, reason)])."""
+    if isinstance(decl_warmup, NoWarmup):
+        return [], [(a, f"NoWarmup: {decl_warmup.reason}") for a, _ in pairs]
+    declared: Mapping[str, Any] = decl_warmup if isinstance(decl_warmup, Mapping) else {}
+    known = {a for a, _ in pairs}
+    unknown = set(declared) - known
+    if unknown:
+        raise TypeError(
+            f"{owner}: warmup= names unknown or non-GPU handler method(s) "
+            f"{sorted(unknown)!r} (known: {sorted(known)!r})"
+        )
+    jobs: List[Tuple[str, _Factory, bool]] = []
+    skips: List[Tuple[str, str]] = []
+    for attr, payload_type in pairs:
+        if attr in declared:
+            value = declared[attr]
+            if value is None:
+                skips.append((attr, "declared skip (warmup={...: None})"))
+                continue
+            jobs.append((attr, _declared_factory(owner, attr, payload_type, value), True))
+            continue
+        factory, reason = synthesize_factory(payload_type)
+        if factory is None:
+            skips.append((attr, f"not auto-synthesizable: {reason}"))
+        else:
+            jobs.append((attr, factory, False))
+    return jobs, skips
+
+
+def plan(
+    specs: Iterable["EndpointSpec"],
+    *,
+    decl_warmup: Any = None,
+    has_warmup_method: bool = False,
+) -> Tuple[List[WarmupJob], List[WarmupSkip]]:
+    """Warmup plan for the GPU inference handlers of ONE instance group.
+
+    Declared ``warmup=`` payloads override synthesis per method; methods the
+    mapping does not name still auto-synthesize. Raises TypeError for
+    declarations that name unknown methods or fail schema validation.
+    """
+    eligible = [
+        s for s in specs
+        if s.cls is not None and s.kind == "inference" and s.needs_gpu
+    ]
+    if has_warmup_method or not eligible:
+        return [], []
+    cls0 = eligible[0].cls
+    assert cls0 is not None  # eligible filters cls None
+    owner = cls0.__name__
+    by_attr = {s.attr_name: s for s in eligible}
+    raw_jobs, raw_skips = _plan_pairs(
+        owner, [(s.attr_name, s.payload_type) for s in eligible], decl_warmup)
+    jobs = [WarmupJob(by_attr[a], f, d) for a, f, d in raw_jobs]
+    skips = [WarmupSkip(by_attr[a], r) for a, r in raw_skips]
+    return jobs, skips
+
+
+def validate_at_decoration(cls: type, decl: EndpointDecl) -> None:
+    """Best-effort decoration-time enforcement (fails at import, the
+    earliest possible moment). Unresolvable type hints defer silently to
+    the authoritative walk-time check (``validate_class_warmup``)."""
+    import inspect
+
+    if decl.kind != "inference" or not decl.resources.gpu:
+        return
+    if callable(getattr(cls, "warmup", None)) or isinstance(decl.warmup, NoWarmup):
+        return
+    pairs: List[Tuple[str, type]] = []
+    for attr, method in getattr(cls, "__gen_worker_handlers__", []) or []:
+        try:
+            hints = typing.get_type_hints(method)
+        except Exception:
+            return  # forward refs unresolvable here — walk time will check
+        params = [p for p in inspect.signature(method).parameters if p != "self"]
+        if len(params) < 2:
+            return
+        pt = hints.get(params[1])
+        if not (isinstance(pt, type) and issubclass(pt, msgspec.Struct)):
+            return  # walk time raises its own, clearer error
+        pairs.append((attr, pt))
+    jobs, skips = _plan_pairs(cls.__name__, pairs, decl.warmup)
+    # A present `warmup=` mapping is itself an explicit in-code decision
+    # (per-method None = declared skip) — enforcement targets only classes
+    # whose author never engaged with warmup at all.
+    if pairs and not jobs and decl.warmup is None:
+        _raise_unwarmable(cls.__name__, skips)
+
+
+def _raise_unwarmable(owner: str, skips: Sequence[Tuple[str, str]]) -> None:
+    detail = "; ".join(f"{a}: {r}" for a, r in skips) or "no handlers"
+    raise TypeError(
+        f"@endpoint class {owner!r}: boot warmup is default-on for GPU "
+        f"inference endpoints but no handler is warmable ({detail}). Declare "
+        "warmup={method: payload} with a self-contained payload, define a "
+        "warmup() method, or opt out with warmup=NoWarmup(\"reason\")."
+    )
+
+
+def plan_for_class(cls: type) -> Tuple[List[WarmupJob], List[WarmupSkip]]:
+    """Plan from a decorated class (endpoint CPU-stub tests use this)."""
+    from .registry import extract_specs
+
+    decl: Optional[EndpointDecl] = getattr(cls, ATTR, None)
+    if decl is None:
+        raise TypeError(f"{cls.__name__} is not an @endpoint class")
+    return plan(
+        extract_specs(cls),
+        decl_warmup=decl.warmup,
+        has_warmup_method=callable(getattr(cls, "warmup", None)),
+    )
+
+
+def validate_class_warmup(cls: type, decl: EndpointDecl, specs: List["EndpointSpec"]) -> None:
+    """Spec-construction-time enforcement: a GPU inference class must have a
+    warmable path — a custom ``warmup()``, at least one auto/declared
+    warmup job, or an explicit ``NoWarmup(reason)``."""
+    eligible = [
+        s for s in specs
+        if s.cls is not None and s.kind == "inference" and s.needs_gpu
+    ]
+    if not eligible:
+        return
+    if callable(getattr(cls, "warmup", None)):
+        return
+    if isinstance(decl.warmup, NoWarmup):
+        return
+    jobs, skips = plan(specs, decl_warmup=decl.warmup, has_warmup_method=False)
+    if jobs or decl.warmup is not None:
+        return
+    _raise_unwarmable(cls.__name__, [(s.spec.attr_name, s.reason) for s in skips])

--- a/tests/test_warmup_synthesis.py
+++ b/tests/test_warmup_synthesis.py
@@ -1,0 +1,418 @@
+"""gw#470 default-on boot warmup: schema synthesis, the `warmup=` declarative
+fallback, NoWarmup opt-out, walk-time enforcement, and the executor running
+the synthesized job post-setup / pre-READY on the load-failure + drain rails."""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import tempfile
+import threading
+from typing import Iterator, Optional
+
+import msgspec
+import pytest
+
+from gen_worker import NoWarmup, Resources, endpoint
+from gen_worker import warmup as warmup_mod
+from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
+from gen_worker.executor import Executor
+from gen_worker.registry import extract_specs
+
+
+class _Out(msgspec.Struct):
+    y: str = ""
+
+
+# ---------------------------------------------------------------------------
+# schema synthesis
+# ---------------------------------------------------------------------------
+
+
+class _Size(enum.Enum):
+    SMALL = "small"
+    LARGE = "large"
+
+
+def _build(payload_type: type):
+    factory, reason = warmup_mod.synthesize_factory(payload_type)
+    assert factory is not None, reason
+    with tempfile.TemporaryDirectory() as tmp:
+        return factory(tmp)
+
+
+def test_synthesis_defaults_and_required_str():
+    class In(msgspec.Struct):
+        prompt: str
+        steps: int = 4
+
+    p = _build(In)
+    assert p.prompt == warmup_mod.WARMUP_TEXT and p.steps == 4
+
+
+def test_synthesis_optional_required_fills_none():
+    class In(msgspec.Struct):
+        image: Optional[ImageAsset]
+        prompt: str = ""
+
+    assert _build(In).image is None
+
+
+def test_synthesis_enum_picks_first_member():
+    class In(msgspec.Struct):
+        size: _Size
+
+    assert _build(In).size is _Size.SMALL
+
+
+def test_synthesis_media_assets_have_readable_files():
+    class In(msgspec.Struct):
+        image: ImageAsset
+        audio: AudioAsset
+
+    factory, reason = warmup_mod.synthesize_factory(In)
+    assert factory is not None, reason
+    with tempfile.TemporaryDirectory() as tmp:
+        p = factory(tmp)
+        with open(p.image, "rb") as f:
+            assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+        with open(p.audio, "rb") as f:
+            assert f.read(4) == b"RIFF"
+
+
+class _NestedItem(msgspec.Struct):
+    image: ImageAsset
+    id: str = ""
+
+
+class _NestedIn(msgspec.Struct):
+    items: list[_NestedItem]
+
+
+def test_synthesis_nested_list_of_structs():
+    p = _build(_NestedIn)
+    assert len(p.items) == 1 and p.items[0].image.local_path
+
+
+def test_synthesis_video_input_blocks():
+    class In(msgspec.Struct):
+        video: VideoAsset
+        prompt: str = ""
+
+    factory, reason = warmup_mod.synthesize_factory(In)
+    assert factory is None and "video" in reason
+
+
+# ---------------------------------------------------------------------------
+# decorator surface + walk-time enforcement
+# ---------------------------------------------------------------------------
+
+
+class _VideoIn(msgspec.Struct):
+    video: VideoAsset
+
+
+class _PromptIn(msgspec.Struct):
+    prompt: str
+    steps: int = 2
+
+
+def test_nowarmup_requires_reason():
+    with pytest.raises(ValueError):
+        NoWarmup("  ")
+
+
+def test_warmup_on_function_endpoint_rejected():
+    with pytest.raises(ValueError, match="requires a class"):
+        @endpoint(warmup={"x": None})
+        def fn(ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+
+def test_gpu_class_with_unwarmable_payload_fails_at_decoration():
+    with pytest.raises(TypeError, match="default-on"):
+        @endpoint(resources=Resources(vram_gb=8))
+        class Ep:
+            def generate(self, ctx, payload: _VideoIn) -> _Out:  # pragma: no cover
+                return _Out()
+
+
+def test_gpu_class_opts_out_with_reason():
+    @endpoint(resources=Resources(vram_gb=8), warmup=NoWarmup("needs user video"))
+    class Ep:
+        def generate(self, ctx, payload: _VideoIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+    jobs, skips = warmup_mod.plan_for_class(Ep)
+    assert not jobs and skips[0].reason == "NoWarmup: needs user video"
+
+
+def test_gpu_class_with_custom_warmup_method_passes():
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def warmup(self) -> None:  # pragma: no cover
+            pass
+
+        def generate(self, ctx, payload: _VideoIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+    jobs, skips = warmup_mod.plan_for_class(Ep)
+    assert not jobs and not skips  # method path: executor calls warmup()
+
+
+def test_declared_payload_overrides_and_validates():
+    @endpoint(
+        resources=Resources(vram_gb=8),
+        warmup={"generate": {"prompt": "big", "steps": 1}},
+    )
+    class Ep:
+        def generate(self, ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+        def other(self, ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+    jobs, skips = warmup_mod.plan_for_class(Ep)
+    assert not skips and len(jobs) == 2
+    by_attr = {j.spec.attr_name: j for j in jobs}
+    assert by_attr["generate"].declared and not by_attr["other"].declared
+    with tempfile.TemporaryDirectory() as tmp:
+        assert by_attr["generate"].build(tmp).prompt == "big"
+        assert by_attr["other"].build(tmp).prompt == warmup_mod.WARMUP_TEXT
+
+
+def test_declared_none_skips_method():
+    @endpoint(resources=Resources(vram_gb=8), warmup={"generate": None})
+    class Ep:
+        def generate(self, ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+    jobs, skips = warmup_mod.plan_for_class(Ep)
+    assert not jobs and "declared skip" in skips[0].reason
+
+
+def test_declared_unknown_method_fails():
+    with pytest.raises(TypeError, match="unknown"):
+        @endpoint(resources=Resources(vram_gb=8), warmup={"nope": {"prompt": "x"}})
+        class Ep:
+            def generate(self, ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+                return _Out()
+
+
+def test_declared_invalid_payload_fails():
+    with pytest.raises(TypeError, match="not a valid"):
+        @endpoint(resources=Resources(vram_gb=8), warmup={"generate": {"steps": "NaN-ish"}})
+        class Ep:
+            def generate(self, ctx, payload: _PromptIn) -> _Out:  # pragma: no cover
+                return _Out()
+
+
+def test_cpu_class_needs_no_warmup():
+    @endpoint(resources=Resources(vcpus=2))
+    class Ep:
+        def crunch(self, ctx, payload: _VideoIn) -> _Out:  # pragma: no cover
+            return _Out()
+
+    jobs, skips = warmup_mod.plan_for_class(Ep)
+    assert not jobs and not skips
+
+
+# ---------------------------------------------------------------------------
+# executor: synthesized warmup runs post-setup, pre-READY
+# ---------------------------------------------------------------------------
+
+
+async def _noop_send(msg) -> None:
+    pass
+
+
+def _ensure_setup(cls):
+    specs = extract_specs(cls)
+    ex = Executor(specs, _noop_send)
+    asyncio.run(ex.ensure_setup(specs[0]))
+    return ex, specs
+
+
+def test_executor_runs_synthesized_warmup_pre_ready():
+    calls: list[tuple[bool, str, bool]] = []
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        ready_at_call: list[bool] = []
+
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            calls.append((ctx.boot_warmup, payload.prompt, ctx.cancelled))
+            return _Out(y="ok")
+
+        def generate_turbo(self, ctx, payload: _PromptIn) -> _Out:
+            calls.append((ctx.boot_warmup, payload.prompt, ctx.cancelled))
+            return _Out(y="ok")
+
+    ex, specs = _ensure_setup(Ep)
+    # Both handlers of the instance group warmed exactly once, as warmup.
+    assert calls == [(True, "warmup", False), (True, "warmup", False)]
+    assert ex._classes[specs[0].instance_key].ready
+
+
+def test_executor_custom_warmup_method_suppresses_synthesis():
+    state = {"warmups": 0, "handler": 0}
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def warmup(self) -> None:
+            state["warmups"] += 1
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            state["handler"] += 1
+            return _Out()
+
+    _ensure_setup(Ep)
+    assert state == {"warmups": 1, "handler": 0}
+
+
+def test_executor_nowarmup_skips():
+    state = {"handler": 0}
+
+    @endpoint(resources=Resources(vram_gb=8), warmup=NoWarmup("engine self-warms"))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            state["handler"] += 1
+            return _Out()
+
+    _ensure_setup(Ep)
+    assert state["handler"] == 0
+
+
+def test_executor_warmup_failure_is_load_failure():
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            raise RuntimeError("cuda exploded")
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _noop_send)
+    with pytest.raises(RuntimeError, match="cuda exploded"):
+        asyncio.run(ex.ensure_setup(specs[0]))
+    rec = ex._classes[specs[0].instance_key]
+    assert not rec.ready and rec.failed is not None
+
+
+def test_executor_warmup_oom_defers_to_fit_ladder():
+    """A warmup CUDA OOM must NOT take the function down — the gw#521
+    runtime fit ladder still serves it degraded on the first real request."""
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            raise RuntimeError("CUDA out of memory. Tried to allocate 20.00 GiB")
+
+    ex, specs = _ensure_setup(Ep)
+    rec = ex._classes[specs[0].instance_key]
+    assert rec.ready and rec.failed is None
+
+
+def test_executor_undecorated_spec_skips_synthesized_warmup():
+    """Internally-constructed EndpointSpecs (no @endpoint decl) have no
+    declaration surface — the synthesized warmup must not fire."""
+    from gen_worker.registry import EndpointSpec
+
+    calls = {"n": 0}
+
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            calls["n"] += 1
+            return _Out()
+
+    spec = EndpointSpec(
+        name="ep", method=Ep.generate, kind="inference", payload_type=_PromptIn,
+        output_mode="single", cls=Ep, attr_name="generate",
+        resources=Resources(vram_gb=8),
+    )
+    ex = Executor([spec], _noop_send)
+    asyncio.run(ex.ensure_setup(spec))
+    assert calls["n"] == 0 and ex._classes[spec.instance_key].ready
+
+
+def test_executor_stream_handler_warmup_consumed():
+    state = {"yields": 0}
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> Iterator[_Out]:
+            for _ in range(3):
+                state["yields"] += 1
+                yield _Out()
+
+    _ensure_setup(Ep)
+    assert state["yields"] == 3
+
+
+def test_executor_warmup_output_stays_local():
+    seen: dict[str, str] = {}
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            import os
+            src = os.path.join(tempfile.gettempdir(), "gw-warmup-src.bin")
+            with open(src, "wb") as f:
+                f.write(b"x")
+            asset = ctx.save_file("out.bin", src)
+            seen["path"] = asset.local_path or ""
+            return _Out()
+
+    _ensure_setup(Ep)
+    assert "gw-warmup-" in seen["path"]  # discarded tempdir, never an upload
+
+
+def test_executor_drain_during_warmup_cancels_cleanly():
+    entered = threading.Event()
+    release = threading.Event()
+
+    @endpoint(resources=Resources(vram_gb=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _PromptIn) -> _Out:
+            entered.set()
+            release.wait(timeout=10)
+            return _Out()
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _noop_send)
+
+    async def scenario() -> None:
+        task = asyncio.create_task(ex.ensure_setup(specs[0]))
+        await asyncio.to_thread(entered.wait, 10)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+    assert not ex._classes[specs[0].instance_key].ready

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Implements the synthesized-default half of gw#470 (Paul directive 2026-07-15/16: warmup is default-on behavior, fully automatic, opt-out in code — no env knobs). Fleet adoption tracked as inference-endpoints ie#491.

## What

- **Auto-synthesis (zero author code):** the executor runs one synthetic request per GPU inference handler post-`setup()`, pre-READY, under the load lock. Payloads synthesize from the handler's typed msgspec schema: defaults kept, required `str` → `"warmup"`, required `ImageAsset`/`AudioAsset` → tiny generated PNG/WAV (stdlib-only writers), nested structs/lists recurse, `Optional` required fields → `None`, enums → first member.
- **Declarative fallback:** `@endpoint(warmup={"method": {...}})` — per-method payload validated against the schema at decoration+walk time; `{"method": None}` = declared per-method skip.
- **Custom `warmup()` method wins** (LTX two-stage synthetic unchanged).
- **Opt-out:** `@endpoint(warmup=NoWarmup("reason"))` — recorded in code.
- **Enforcement:** GPU inference class with no warmable path and no explicit declaration fails at decoration (best-effort) and walk time (authoritative) — CI, not first request.
- **`ctx.boot_warmup`:** handlers may cheapen the warmup run (`steps = 1 if ctx.boot_warmup else steps`); the allocator peak is shape-driven, not step-driven.
- Warmup output is discarded: null-emitter `RequestContext`, no capability token, throwaway `local_output_dir` tempdir — never billing/outputs/CAS.
- **OOM semantics:** a warmup CUDA OOM warns and defers to the gw#521 runtime fit ladder (function still serves degraded) instead of hard-failing; any other warmup exception is a load failure on the th#581 rails. Drain/cancel during warmup propagates on the existing `_to_thread_complete` join rails.
- Internally-constructed `EndpointSpec`s (no `@endpoint` decl) skip synthesis — no declaration surface exists.

## Tests

- `tests/test_warmup_synthesis.py` (25 tests): synthesis matrix, decorator surface, decoration-time enforcement, executor pre-READY run for every handler of the instance group, custom-method suppression, NoWarmup, load-failure propagation, OOM-defer, stream consumption, local-only output, drain-cancel safety.
- Full suite: 1167+ passed; remaining failures reproduced on master before this change (test_content_lanes swap test + hf-network convert integration tests) — pre-existing, unrelated.
- mypy clean (117 files), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)