### PR TITLE
loading: rung-2 bf16-resident upgrade respects the declared VRAM envelope (ie#381, 0.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.28.1 (2026-07-16)
+
+- **ie#381: the gw#534 rung-2 bf16-resident upgrade now respects the
+  function's declared VRAM envelope.** The weights-only fit check upgraded
+  LTX-22B's fp8+te lane to bf16-resident on 80 GB cards, silently consuming
+  the activation budget the envelope was measured around — every >=10 s
+  1080p request then served through the DEGRADED tiled-refine rung (slower
+  than the stored-fp8 recipe AND quality-taxed), while the compile-cell
+  producer traced the opposite weight lane. `bf16_resident_fits` gains a
+  `declared_vram_gb` term (upgrade only when `free >= declared +
+  upcast_extra`), plumbed from `Resources.vram_gb` through
+  `load_slot`/`load_from_pretrained`, and `compile_cache.build()` accepts
+  the same value so producer and serving worker decide the lane from the
+  same inputs (gw#391 parity). Declared-unknown loads (local CLI) keep the
+  old margin-only rule.
+
+
 ## 0.28.0 (2026-07-16)
 
 - **gw#470 boot warmup default-on.** GPU inference endpoints now warm before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.28.0"
+version = "0.28.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -837,6 +837,7 @@ def build(
     regional: bool = False,
     steps: int = 2,
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
+    declared_vram_gb: float = 0.0,
 ) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
     """Compile a diffusers pipeline over ``shapes`` and package the resulting
     inductor+triton caches as a per-SKU artifact.
@@ -873,7 +874,12 @@ def build(
     cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets), regional=bool(regional))
     pipe = load_from_pretrained(
         DiffusionPipeline, str(model_path), dtype=dtype,
-        storage_dtype=storage_dtype)
+        storage_dtype=storage_dtype,
+        # Producer/consumer LANE parity (ie#381): the serving worker decides
+        # the bf16-resident upgrade against its function's declared envelope;
+        # the producer must decide with the same input or it traces the
+        # other lane and the cell never adopts.
+        declared_vram_gb=declared_vram_gb)
     # Producer/consumer graph parity (gw#391): the worker prepares pipelines
     # with place_pipeline (placement + vae/attention low-VRAM flags), and
     # those flags are traced INTO the graphs — the FX-graph cache key. A cell

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2576,6 +2576,8 @@ class Executor:
                     sl = await _to_thread_complete(
                         provision.load_slot, ann, path, binding=binding,
                         slot=slot, ref=ref, mode=mode, components=injected,
+                        declared_vram_gb=float(
+                            getattr(spec.resources, "vram_gb", 0) or 0),
                     )
                 except Exception as exc:
                     # Corruption-shaped load failure (gw#408): digest-verify
@@ -2598,6 +2600,8 @@ class Executor:
                     sl = await _to_thread_complete(
                         provision.load_slot, ann, path, binding=binding,
                         slot=slot, ref=ref, mode=mode, components=injected,
+                        declared_vram_gb=float(
+                            getattr(spec.resources, "vram_gb", 0) or 0),
                     )
                 pipe = sl.obj
                 # Reconcile the load outcomes into ServePlan/FnDegraded via

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -734,12 +734,25 @@ def pipeline_weight_lane(pipeline: Any) -> str:
 
 
 def bf16_resident_fits(
-    path: Path, *, text_encoders: bool = False, free_gb: Optional[float] = None
+    path: Path, *, text_encoders: bool = False, free_gb: Optional[float] = None,
+    declared_vram_gb: float = 0.0,
 ) -> bool:
     """True when the snapshot can serve fully bf16-RESIDENT within free VRAM
     minus :data:`BF16_RESIDENT_MARGIN_GB` (fp8-stored cast targets doubled for
     the upcast). False on CPU-only hosts or unreadable snapshots — the caller
-    keeps today's hook path."""
+    keeps today's hook path.
+
+    ``declared_vram_gb`` is the function's declared card envelope
+    (``Resources.vram_gb``) when known. The declaration was measured under
+    the STORED lane (fp8 weights + activation peak + margin); the upcast
+    steals exactly its extra weight bytes from that activation budget, so
+    the upgrade additionally requires the card to have that many GB SPARE
+    over the declaration: ``free >= declared + upcast_extra``. Without this
+    term (ie#381 discovery), a weights-only check upgraded LTX-22B on an
+    80 GB card and every >=10 s 1080p request silently fell to the DEGRADED
+    tiled-refine rung — slower AND quality-taxed, defeating the fp8+te
+    recipe the envelope was designed around. 0 = unknown (local CLI, plain
+    loads): the weights-margin rule alone applies, as before."""
     if free_gb is None:
         from .memory import get_available_vram_gb
 
@@ -759,7 +772,13 @@ def bf16_resident_fits(
         if (name in targets or not name) and detect_on_disk_dtype(probe) == "fp8":
             upcast_extra += nbytes
     resident_gb = (total + upcast_extra) / float(1 << 30)
-    return resident_gb <= float(free_gb) - BF16_RESIDENT_MARGIN_GB
+    if resident_gb > float(free_gb) - BF16_RESIDENT_MARGIN_GB:
+        return False
+    if declared_vram_gb and declared_vram_gb > 0:
+        upcast_gb = upcast_extra / float(1 << 30)
+        if float(free_gb) < float(declared_vram_gb) + upcast_gb:
+            return False
+    return True
 
 
 # --- Runtime fit rungs (th#546 emergency lane + th#683 fp8 storage) --------
@@ -1051,6 +1070,7 @@ def load_from_pretrained(
     attrs: Optional[Dict[str, str]] = None,
     storage_dtype: str = "",
     components: Optional[Dict[str, Any]] = None,
+    declared_vram_gb: float = 0.0,
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
@@ -1139,7 +1159,9 @@ def load_from_pretrained(
     fp8_storage = storage_dtype in ("fp8", "fp8+te") or sniffed == "fp8"
     fp8_text_encoders = storage_dtype == "fp8+te"
     bf16_resident = False
-    if fp8_storage and bf16_resident_fits(Path(path), text_encoders=fp8_text_encoders):
+    if fp8_storage and bf16_resident_fits(
+            Path(path), text_encoders=fp8_text_encoders,
+            declared_vram_gb=declared_vram_gb):
         # gw#534 rung 2: fp8 download, bf16 resident — skip the cast hooks
         # (never voluntary W8A16); from_pretrained's torch_dtype upcasts once.
         fp8_storage = False

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -83,6 +83,7 @@ def load_slot(
     mode: str = "auto",
     components: Optional[Dict[str, Any]] = None,
     device: str = "",
+    declared_vram_gb: float = 0.0,
 ) -> SlotLoad:
     """Typed slot injection: the slot receives exactly what its ``setup``
     annotation says — a ``str``/``Path`` local path, or a constructed
@@ -129,7 +130,7 @@ def load_slot(
 
     pipe = load_from_pretrained(
         annotation, path, dtype=dtype, storage_dtype=storage_dtype,
-        components=components or None,
+        components=components or None, declared_vram_gb=declared_vram_gb,
     )
     out.obj = pipe
 

--- a/tests/test_bf16_resident_upcast.py
+++ b/tests/test_bf16_resident_upcast.py
@@ -186,3 +186,34 @@ def test_lane_drift_bf16_resident_matches_plain_cells() -> None:
     assert lane_drift(artifact_metadata(family="f"), pipe) == ""
     assert "weight_lane" in lane_drift(
         artifact_metadata(family="f", weight_lane="fp8-hooks"), pipe)
+
+
+def test_declared_envelope_gates_the_upgrade(tmp_path: Path) -> None:
+    """ie#381: the upgrade must leave the DECLARED activation envelope
+    intact — free must exceed declared_vram + the upcast's extra weight
+    bytes, or the model that fit by design starts serving degraded."""
+    snap = _snapshot(tmp_path, "F8_E4M3", 2 << 30)  # 2GB fp8 -> +2GB upcast
+    # weights-margin alone passes at 79 GB free (4GB resident + 4 <= 79)…
+    assert bf16_resident_fits(snap, free_gb=79.0) is True
+    # …but a 78GB declared envelope needs 78 + 2 = 80 free: refuse.
+    assert bf16_resident_fits(snap, free_gb=79.0, declared_vram_gb=78) is False
+    # roomy card (B200-class): 140 + 2 <= 178 — upgrade stands.
+    assert bf16_resident_fits(snap, free_gb=178.0, declared_vram_gb=140) is True
+    # declared unknown (0): old rule only.
+    assert bf16_resident_fits(snap, free_gb=79.0, declared_vram_gb=0) is True
+
+
+def test_load_honors_declared_vram(vram, tmp_path: Path, monkeypatch) -> None:
+    """load_from_pretrained(declared_vram_gb=…) reaches the fits check: an
+    fp8+te load that would upgrade on a roomy card keeps hooks when the
+    declared envelope forbids it."""
+    snap = _snapshot(tmp_path, "F8_E4M3", 1 << 20, te_dtype="F8_E4M3",
+                     te_nbytes=1 << 20)
+    vram(79.0)
+    _Pipe.calls.clear()
+    pipe = load_from_pretrained(
+        _Pipe, snap, storage_dtype="fp8+te", declared_vram_gb=200.0)
+    assert pipeline_weight_lane(pipe) == "fp8-hooks"
+    pipe2 = load_from_pretrained(
+        _Pipe, snap, storage_dtype="fp8+te", declared_vram_gb=20.0)
+    assert pipeline_weight_lane(pipe2) == ""  # upgraded: 20 + ~0 <= 79

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The regression (found live during the ie#381 compile-cell mint)

gw#534 rung 2 upgrades a planned fp8 storage lane to bf16-resident when the snapshot's WEIGHTS fit free VRAM − 4 GB. For LTX-22B fp8+te on H100-80 this is a net loss the check cannot see:

- weights 40 GiB (fp8) → ~67-70 GiB (bf16-resident) — "fits" by the weights rule
- but the endpoint's envelope (`vram_gb=78`) was measured around the STORED lane: fp8 weights + ~32 GiB activation peak
- after the upgrade the activation budget is gone → **every ≥10 s 1080p request silently serves through the DEGRADED tiled-refine rung** — live evidence from the ie#481 battery DB: `RESIDENT_UPCAST` loads, flat 70.0 GiB peaks, `DEGRADED_MODE rung=?->tiled_refine` + "TE parked for 241f denoise" on EVERY flagship, warm computes 82-124 s vs the designed 61-74 s (§8g) — slower than the cast lane it was meant to beat, plus the chunk-crossfade quality tax
- the compile-cell producer (roomy pod, no declared envelope) makes the same upgrade and traces the OTHER weight lane → its cells can never adopt (lane_drift), and on the producer the un-fittable long rows OOM-loop (observed: 5 attempts, terminal "out of memory")

## Fix

`bf16_resident_fits` gains `declared_vram_gb`: the upgrade additionally requires `free >= declared + upcast_extra` — the card must have the upcast's extra weight bytes SPARE over the declared envelope. Plumbed from `Resources.vram_gb` through `executor → provision.load_slot → load_from_pretrained`; `compile_cache.build()` accepts the same value so producer and serving worker decide the lane from identical inputs (gw#391 parity). Declared-unknown loads (local CLI) keep the old margin-only rule.

H100-80/LTX: 79.19 < 78 + ~29 → hooks kept (designed recipe restored). B200-178/LTX: 178 ≥ 140 + ~29 → upgrade stands (everything incl. 4K fits bf16-resident; live-verified today — the B200 cell built lane-less and adopted).

## Tests
`test_bf16_resident_upcast.py`: declared-envelope boundary cases + load-path plumbing (hooks kept at 79 GB free w/ declared 200(sic: forbids), upgraded w/ declared 20). 32 passed + adjacent fp8/cast suites 29 passed; mypy + ruff clean.

Version 0.28.1 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)