### PR TITLE
loading: per-tensor fp8 byte accounting in the bf16-resident fit check (ie#381 fix 2, 0.28.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.30.1 (2026-07-16)
+
+- **ie#381 fix 2: the bf16-resident fit check counts fp8 bytes per TENSOR,
+  not per component majority label.** Produced fp8 flavors store scales and
+  norms in bf16, so a shard is majority-BF16 by tensor count while its
+  weight bytes are fp8 (LTX DiT: 247 bf16 vs 137 fp8 tensors, fp8 = 3x the
+  bytes) — `detect_on_disk_dtype`'s majority gate counted the upcast as
+  ZERO, neutering both the weights-margin rule and 0.28.1's declared-VRAM
+  envelope term, and the upgrade proceeded into the activation budget.
+  `snapshot_component_fp8_bytes` sums F8_E4M3 tensor bytes from the
+  safetensors headers; `bf16_resident_fits` doubles exactly those.
+
+
 ## 0.30.0 (2026-07-16)
 
 - **gw#551: demoted lanes serve instead of crashing — swap-per-request for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.30.0"
+version = "0.30.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -766,10 +766,14 @@ def bf16_resident_fits(
     targets = set(_FP8_STORAGE_COMPONENTS)
     if text_encoders:
         targets |= set(_FP8_TEXT_ENCODER_COMPONENTS)
+    # Per-TENSOR fp8 byte accounting (ie#381 fix 2): the majority-dtype
+    # component gate returned "bf16" for produced fp8 flavors whose scale/
+    # norm tensors outnumber the (much larger) fp8 weight tensors, counting
+    # the upcast as ZERO and letting the upgrade eat the activation budget.
+    fp8 = snapshot_component_fp8_bytes(Path(path))
     upcast_extra = 0
-    for name, nbytes in comp.items():
-        probe = Path(path) / name if name else Path(path)
-        if (name in targets or not name) and detect_on_disk_dtype(probe) == "fp8":
+    for name, nbytes in fp8.items():
+        if name in targets or not name:
             upcast_extra += nbytes
     resident_gb = (total + upcast_extra) / float(1 << 30)
     if resident_gb > float(free_gb) - BF16_RESIDENT_MARGIN_GB:
@@ -853,6 +857,47 @@ def _safetensors_data_bytes(p: Path) -> int:
             s, e = value["data_offsets"]
             total += int(e) - int(s)
     return total
+
+
+def _safetensors_fp8_bytes(p: Path) -> int:
+    """Bytes of F8_E4M3-stored tensors in one safetensors file (header-only)."""
+    import struct
+
+    with open(p, "rb") as f:
+        raw = f.read(8)
+        if len(raw) < 8:
+            return 0
+        (n,) = struct.unpack("<Q", raw)
+        if n <= 0 or n > _MAX_SAFETENSORS_HEADER_BYTES:
+            return 0
+        header = json.loads(f.read(n))
+    total = 0
+    for value in header.values():
+        if (isinstance(value, dict) and value.get("dtype") == "F8_E4M3"
+                and "data_offsets" in value):
+            s_, e_ = value["data_offsets"]
+            total += int(e_) - int(s_)
+    return total
+
+
+def snapshot_component_fp8_bytes(model_path: Path) -> Dict[str, int]:
+    """F8_E4M3 tensor bytes per top-level component dir. These are the bytes
+    a bf16-resident upcast DOUBLES — counted per tensor, not per component
+    majority label: a produced fp8 flavor stores scales/norms in bf16, so a
+    shard can be majority-BF16 by tensor COUNT while its weight bytes are
+    fp8 (LTX fp8 DiT: 247 bf16 vs 137 fp8 tensors per shard, but the fp8
+    tensors are ~3x the bytes — the majority-dtype gate undercounted the
+    upcast to zero, ie#381/gw#553)."""
+    out: Dict[str, int] = {}
+    root = Path(model_path)
+    try:
+        for p in sorted(root.rglob("*.safetensors")):
+            rel = p.relative_to(root)
+            comp = rel.parts[0] if len(rel.parts) > 1 else ""
+            out[comp] = out.get(comp, 0) + _safetensors_fp8_bytes(p)
+    except (OSError, ValueError):
+        return {}
+    return {k: v for k, v in out.items() if v > 0}
 
 
 def snapshot_component_weight_bytes(model_path: Path) -> Dict[str, int]:

--- a/tests/test_bf16_resident_upcast.py
+++ b/tests/test_bf16_resident_upcast.py
@@ -217,3 +217,45 @@ def test_load_honors_declared_vram(vram, tmp_path: Path, monkeypatch) -> None:
     pipe2 = load_from_pretrained(
         _Pipe, snap, storage_dtype="fp8+te", declared_vram_gb=20.0)
     assert pipeline_weight_lane(pipe2) == ""  # upgraded: 20 + ~0 <= 79
+
+
+def _write_mixed_safetensors(path: Path, fp8_bytes: int, bf16_tensors: int,
+                             bf16_bytes_each: int) -> None:
+    """One shard: a single big F8_E4M3 weight + many small BF16 scale/norm
+    tensors (majority by COUNT is bf16, majority by BYTES is fp8 — the
+    produced-flavor layout, ie#381)."""
+    entries = {"w": {"dtype": "F8_E4M3", "shape": [fp8_bytes],
+                     "data_offsets": [0, fp8_bytes]}}
+    off = fp8_bytes
+    for i in range(bf16_tensors):
+        entries[f"s{i}"] = {"dtype": "BF16", "shape": [bf16_bytes_each],
+                            "data_offsets": [off, off + bf16_bytes_each]}
+        off += bf16_bytes_each
+    header = json.dumps(entries).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+
+
+def test_mixed_dtype_fp8_bytes_still_count(tmp_path: Path) -> None:
+    """ie#381 fix 2: a produced fp8 flavor stores scales/norms in bf16 —
+    majority-by-COUNT says "bf16" but the upcast doubles the fp8 WEIGHT
+    bytes. The fits check must count them (the majority-dtype gate counted
+    zero and upgraded LTX into its own activation budget)."""
+    from gen_worker.models.loading import snapshot_component_fp8_bytes
+
+    snap = tmp_path
+    (snap / "model_index.json").write_text(json.dumps(
+        {"_class_name": "Pipe", "transformer": ["diffusers", "X"]}))
+    (snap / "transformer").mkdir()
+    _write_mixed_safetensors(
+        snap / "transformer" / "diffusion_pytorch_model.safetensors",
+        fp8_bytes=3 << 30, bf16_tensors=200, bf16_bytes_each=1 << 20)
+    # majority label is bf16 (200 tensors vs 1) yet fp8 bytes = 3GB
+    fp8 = snapshot_component_fp8_bytes(snap)
+    assert fp8.get("transformer", 0) == 3 << 30
+    # total ~3.2GB + upcast 3GB = ~6.2GB: fits at 12GB free, not at 9.9GB
+    assert bf16_resident_fits(snap, free_gb=12.0) is True
+    assert bf16_resident_fits(snap, free_gb=9.9) is False
+    # envelope term composes: declared 8 + upcast 3 = 11 > 10.5 free
+    assert bf16_resident_fits(snap, free_gb=10.5, declared_vram_gb=8) is False

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.30.0"
+version = "0.30.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Second half of gw#553 (first: #271). The upcast estimate used `detect_on_disk_dtype`'s MAJORITY-BY-COUNT label per component — produced fp8 flavors store scales/norms in bf16, so the LTX fp8 DiT shard reads 247 BF16 vs 137 F8_E4M3 tensors (majority bf16) while the fp8 tensors are ~3x the bytes. `upcast_extra` came out ZERO, which neutered both the weights-margin rule and #271's declared-VRAM envelope term (`free >= declared + 0` always passes on an 80 GB card) — live-reproduced on the fully-plumbed 0.28.1 producer (VRAM OOM loop) after the vram_gb passthrough (th #418 / te #131) was verified end-to-end.

Fix: `snapshot_component_fp8_bytes` sums F8_E4M3 tensor bytes straight from the safetensors headers; `bf16_resident_fits` doubles exactly those bytes. With real numbers: LTX upcast ≈ 25 GiB → H100-80 (79.1 free) < 78 declared + 25 → hooks kept (designed recipe); B200-178 ≥ 140 + 25 → upgrade stands.

Tests: mixed-dtype shard fixture (majority-count bf16 / majority-bytes fp8) + margin & envelope compositions; full upcast suite 11 passed; fp8/compile suites green; mypy/ruff clean. 0.28.2 + CHANGELOG + relock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)