### PR TITLE
Make clone disk admission operation-aware (0.30.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.30.2 (2026-07-16)
+
+- **gw#554: clone disk admission follows the resolved work instead of a
+  configurable source-size multiplier.** Pure source mirrors account for
+  hardlinks and only the safetensors files that must be resharded; plan-known
+  conversions account for materialized output, layout-repack, and intermediate
+  GGUF trees. Hugging Face ingest records the observed on-disk dtype, and
+  existing HF shard groups are resharded with one valid index. This admits the
+  immutable 19.1 GiB Z-Image source mirror on the standard 40 GiB CPU worker
+  disk while retaining fail-fast bounds for real conversions. Repack tools may
+  still reject provider-fetched base components that were absent from the
+  source plan. The `COZY_CONVERT_DISK_HEADROOM` override is removed.
+
+
 ## 0.30.1 (2026-07-16)
 
 - **ie#381 fix 2: the bf16-resident fit check counts fp8 bytes per TENSOR,

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -114,6 +114,9 @@ production launcher ever populated them through Settings either.
 - `COZY_CIVITAI_DOWNLOAD_ATTEMPTS`, `COZY_CLONE_DOWNLOAD_ATTEMPTS` —
   per-call test-tunable retry counts (`models/download.py`,
   `convert/ingest.py`).
-- `COZY_CONVERT_WORKDIR` / `_DISK_HEADROOM` / `_SCRATCH_TTL_S` /
-  `_RETAIN_WORKDIR` — convert-job scratch knobs set by the invoking harness
-  (`convert/clone.py`).
+- `COZY_CONVERT_WORKDIR` / `_SCRATCH_TTL_S` / `_RETAIN_WORKDIR` —
+  convert-job scratch knobs set by the invoking harness (`convert/clone.py`).
+  Clone disk admission itself is derived from the resolved source and output
+  operations and cannot be weakened by an environment override. The preflight
+  covers plan-known files; repackage tools fail normally if they later fetch
+  missing base components that exceed the remaining disk.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.30.1"
+version = "0.30.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -239,9 +239,11 @@ def _reshard_indexed_safetensors(index_path: Path, max_shard_bytes: int) -> None
 
 
 def _stage_oversize_safetensors(
-    tree: Path, *, max_shard_bytes: int = MAX_SAFETENSORS_SHARD_BYTES,
+    tree: Path, *, max_shard_bytes: int | None = None,
 ) -> None:
     """Reshard oversized safetensors by logical HF weight group."""
+    if max_shard_bytes is None:
+        max_shard_bytes = MAX_SAFETENSORS_SHARD_BYTES
     indexed_members: set[Path] = set()
     for index_path in sorted(tree.rglob("*.safetensors.index.json")):
         _reshard_indexed_safetensors(index_path, max_shard_bytes)

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
+import json
 import logging
 import os
 import re
@@ -158,16 +159,104 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
 # Flavor tree construction
 # ---------------------------------------------------------------------------
 
-def _stage_oversize_safetensors(tree: Path) -> None:
-    """Replace any >5 GB safetensors in the tree with HF-convention byte-offset
-    shards + index (raw copy, no decode)."""
+def _reshard_indexed_safetensors(index_path: Path, max_shard_bytes: int) -> None:
+    """Reshard one existing HF shard group without invalidating its index."""
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"invalid safetensors index: {index_path}")
+    member_names = sorted({str(name) for name in weight_map.values()})
+    if any(Path(name).name != name for name in member_names):
+        raise ValueError(f"safetensors index member must be a basename: {index_path}")
+    members = [index_path.parent / name for name in member_names]
+    if not all(member.is_file() for member in members):
+        raise ValueError(f"safetensors index references a missing shard: {index_path}")
+    if not any(member.stat().st_size > max_shard_bytes for member in members):
+        return
+
+    prefix = index_path.name.removesuffix(".safetensors.index.json")
+    stage = index_path.parent / f".__reshard__{prefix}"
+    shutil.rmtree(stage, ignore_errors=True)
+    stage.mkdir()
+    pieces: list[tuple[Path, set[str]]] = []
+    try:
+        for member_number, (member_name, member) in enumerate(
+            zip(member_names, members), start=1,
+        ):
+            expected = {str(tensor) for tensor, shard in weight_map.items()
+                        if str(shard) == member_name}
+            if member.stat().st_size <= max_shard_bytes:
+                linked = stage / f"part-{member_number:05d}.safetensors"
+                os.link(member, linked)
+                pieces.append((linked, expected))
+                continue
+
+            shard_paths, nested_index, _ = shard_safetensors_by_offset(
+                member,
+                stage / f"part-{member_number:05d}",
+                max_shard_bytes=max_shard_bytes,
+                shard_prefix=f"part-{member_number:05d}",
+            )
+            nested_map = json.loads(nested_index.read_text(encoding="utf-8")).get(
+                "weight_map")
+            if not isinstance(nested_map, dict) or set(map(str, nested_map)) != expected:
+                raise ValueError(f"reshard tensor map disagrees with {index_path}")
+            for shard_path in shard_paths:
+                tensors = {str(tensor) for tensor, shard in nested_map.items()
+                           if str(shard) == shard_path.name}
+                pieces.append((shard_path, tensors))
+
+        new_weight_map: dict[str, str] = {}
+        final_pieces: list[tuple[Path, str]] = []
+        total = len(pieces)
+        for number, (piece, tensors) in enumerate(pieces, start=1):
+            name = f"{prefix}-{number:05d}-of-{total:05d}.safetensors"
+            destination = index_path.parent / name
+            if destination.exists() and destination not in members:
+                raise ValueError(f"reshard destination already exists: {destination}")
+            staged = stage / name
+            piece.rename(staged)
+            final_pieces.append((staged, name))
+            for tensor in tensors:
+                new_weight_map[tensor] = name
+        if set(new_weight_map) != set(map(str, weight_map)):
+            raise ValueError(f"reshard lost tensors from {index_path}")
+
+        new_payload = dict(payload)
+        new_payload["weight_map"] = new_weight_map
+        staged_index = stage / index_path.name
+        staged_index.write_text(
+            json.dumps(new_payload, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        for member in members:
+            member.unlink()
+        for staged, name in final_pieces:
+            staged.replace(index_path.parent / name)
+        staged_index.replace(index_path)
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+
+def _stage_oversize_safetensors(
+    tree: Path, *, max_shard_bytes: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> None:
+    """Reshard oversized safetensors by logical HF weight group."""
+    indexed_members: set[Path] = set()
+    for index_path in sorted(tree.rglob("*.safetensors.index.json")):
+        _reshard_indexed_safetensors(index_path, max_shard_bytes)
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+        weight_map = payload.get("weight_map")
+        if isinstance(weight_map, dict):
+            indexed_members.update(
+                index_path.parent / str(name) for name in weight_map.values())
     for f in sorted(tree.rglob("*.safetensors")):
-        if not f.is_file() or f.stat().st_size <= MAX_SAFETENSORS_SHARD_BYTES:
+        if f in indexed_members or not f.is_file() or f.stat().st_size <= max_shard_bytes:
             continue
         stem = f.stem
         stage = f.parent / f".__shard__{stem}"
         shard_paths, index_path, _ = shard_safetensors_by_offset(
-            f, stage, shard_prefix=stem)
+            f, stage, max_shard_bytes=max_shard_bytes, shard_prefix=stem)
         if len(shard_paths) > 1:
             f.unlink()
             for sp in shard_paths:
@@ -481,36 +570,133 @@ class CloneDiskSpaceError(RuntimeError):
     actionably instead of ENOSPC minutes into a 40GB download (gw#462)."""
 
 
-# Free space required = source_bytes x headroom: the source snapshot and each
-# converted flavor tree (+ repack temp) coexist on disk during publish.
-_DISK_HEADROOM_DEFAULT = 2.5
 _DISK_MARGIN_BYTES = 2 * 1024**3
+_PUBLISH_AS_IS_STRATEGIES = frozenset({
+    "transformers", "peft", "sentence_transformers", "gguf", "native_lora",
+    "pipeline_tree",
+})
+_DIRECT_GGUF_ENCODINGS = frozenset({"f32", "f16", "bf16", "q8_0"})
+_DTYPE_STORAGE_BITS = {
+    "fp32": 32, "f32": 32, "float32": 32,
+    "bf16": 16, "fp16": 16, "f16": 16, "float16": 16,
+    "fp8": 8, "fp8:e5m2": 8, "q8_0": 8,
+    "q6_k": 6,
+    "q5_k_m": 5, "q5_k_s": 5,
+    "nvfp4": 4, "int4": 4, "int4:nf4": 4, "int4:fp4": 4,
+    "nf4": 4, "fp4": 4, "q4_k_m": 4, "q4_k_s": 4, "q4_0": 4,
+    "q4_1": 4,
+    "q3_k_m": 3, "q3_k_s": 3,
+    "q2_k": 2,
+}
 
 
-def _preflight_disk(workdir: Path, plan: Any) -> None:
+def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
     """Fail fast when the disk cannot fit the clone. The source plan knows
     every selected file's size before a byte is downloaded (HF list_repo_tree
-    / civitai version API); no plan (metadata fetch failed) skips the check
-    (fail-open — the download surfaces its own error)."""
+    / civitai version API). The bound covers plan-known files; a repackage
+    tool that fetches missing base components can still fail on its provider
+    download. An unavailable plan skips the check (fail-open)."""
     if plan is None:
         return
     try:
-        source_bytes = sum(int(size) for _, size, _ in plan.bank_files())
+        files = [(str(path), int(size)) for path, size, _ in plan.bank_files()]
+        source_bytes = sum(size for _, size in files)
+        provider = str(getattr(plan, "provider", "") or "").strip().lower()
+        classification = getattr(plan, "classification", None)
+        strategy = str(getattr(classification, "strategy", "") or "").strip().lower()
+        raw_attrs = getattr(classification, "attrs", None)
+        attrs = {
+            str(k): str(v).strip().lower()
+            for k, v in (raw_attrs.items() if isinstance(raw_attrs, dict) else ())
+        }
+        if classification is None and provider == "civitai":
+            source_type = (
+                "gguf" if files and all(path.lower().endswith(".gguf")
+                                        for path, _ in files)
+                else "safetensors"
+            )
+            attrs = {"file_layout": "singlefile", "file_type": source_type}
+            if source_type == "gguf":
+                strategy = "gguf"
     except Exception:  # noqa: BLE001 — preflight is best-effort on odd plans
         return
     if source_bytes <= 0:
         return
-    headroom = float(os.environ.get("COZY_CONVERT_DISK_HEADROOM", "") or _DISK_HEADROOM_DEFAULT)
-    required = int(source_bytes * headroom) + _DISK_MARGIN_BYTES
+
+    if strategy in _PUBLISH_AS_IS_STRATEGIES:
+        required = source_bytes + _DISK_MARGIN_BYTES
+        operation = f"{strategy} publishes the source tree directly"
+    else:
+        source_layout = attrs.get("file_layout", "")
+        source_dtype = attrs.get("dtype", "")
+        source_type = attrs.get("file_type", "") or (
+            "gguf" if any(path.lower().endswith(".gguf") for path, _ in files)
+            else "safetensors"
+        )
+        passthrough = [
+            spec for spec in specs
+            if source_layout and spec.file_layout == source_layout
+            and spec.file_type == source_type
+            and (spec.dtype == "source" or (source_dtype and spec.dtype == source_dtype))
+        ]
+        materialized = [spec for spec in specs if spec not in passthrough]
+        resharded_bytes = len(passthrough) * sum(
+            size for path, size in files
+            if path.lower().endswith(".safetensors")
+            and size > MAX_SAFETENSORS_SHARD_BYTES
+        )
+        # Untagged safetensors may still be a packed 4-bit tree. Mirrors do
+        # not use this estimate; explicit widening conversions do.
+        source_bits = _DTYPE_STORAGE_BITS.get(source_dtype, 4)
+        output_sizes = [
+            source_bytes if _DTYPE_STORAGE_BITS.get(spec.dtype, source_bits) <= source_bits
+            else (
+                source_bytes * _DTYPE_STORAGE_BITS[spec.dtype] + source_bits - 1
+            ) // source_bits
+            for spec in materialized
+        ]
+        gguf_intermediate = max(
+            (
+                (source_bytes * 16 + source_bits - 1) // source_bits
+                for spec in materialized
+                if spec.file_type == "gguf"
+                and spec.dtype not in _DIRECT_GGUF_ENCODINGS
+            ),
+            default=0,
+        )
+        repack = max(
+            (
+                size for spec, size in zip(materialized, output_sizes)
+                if spec.file_type != "gguf"
+                and source_layout and spec.file_layout != source_layout
+            ),
+            default=0,
+        )
+        required = (
+            source_bytes + sum(output_sizes) + gguf_intermediate
+            + resharded_bytes + repack + _DISK_MARGIN_BYTES
+        )
+        parts = []
+        if passthrough:
+            parts.append("hardlink passthrough")
+        if materialized:
+            parts.append(f"{len(materialized)} materialized output tree(s)")
+        if resharded_bytes:
+            parts.append("oversize-safetensors reshard output")
+        if gguf_intermediate:
+            parts.append("one intermediate F16 GGUF tree")
+        if repack:
+            parts.append("one layout-repack tree")
+        operation = ", ".join(parts) or "source tree"
+
     free = shutil.disk_usage(workdir).free
     if free < required:
         gib = float(1024**3)
         raise CloneDiskSpaceError(
             f"not enough disk for clone: need ~{required / gib:.1f} GiB free "
-            f"(source {source_bytes / gib:.1f} GiB x {headroom:g} headroom "
-            f"+ {_DISK_MARGIN_BYTES / gib:.0f} GiB margin), have {free / gib:.1f} GiB "
+            f"(source {source_bytes / gib:.1f} GiB; {operation}; "
+            f"{_DISK_MARGIN_BYTES / gib:.0f} GiB margin), have {free / gib:.1f} GiB "
             f"at {workdir}")
-
 
 def _sweep_stale_workdirs(base: Path, *, keep: Optional[Path] = None) -> None:
     """Remove clone scratch left by crashed predecessors: dirs whose flock is
@@ -676,7 +862,7 @@ def run_clone(
 
         # gw#462: the plan already knows every selected file's size — fail
         # fast on an undersized disk instead of ENOSPC mid-download.
-        _preflight_disk(workdir, plan)
+        _preflight_disk(workdir, plan, specs)
 
         _progress(0.05, "clone.ingest")
         dl_bytes = {"done": 0}
@@ -716,10 +902,7 @@ def run_clone(
         # Non-diffusers-class sources publish as-is; extra output specs that
         # would need conversion are refused per-flavor, not per-job.
         strategy = source.classification.strategy if source.classification is not None else ""
-        publish_as_is = strategy in {
-            "transformers", "peft", "sentence_transformers", "gguf", "native_lora",
-            "pipeline_tree",
-        }
+        publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES
 
         for i, spec in enumerate(specs):
             flavor_label = spec.dtype

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -239,11 +239,9 @@ def _reshard_indexed_safetensors(index_path: Path, max_shard_bytes: int) -> None
 
 
 def _stage_oversize_safetensors(
-    tree: Path, *, max_shard_bytes: int | None = None,
+    tree: Path, *, max_shard_bytes: int = MAX_SAFETENSORS_SHARD_BYTES,
 ) -> None:
     """Reshard oversized safetensors by logical HF weight group."""
-    if max_shard_bytes is None:
-        max_shard_bytes = MAX_SAFETENSORS_SHARD_BYTES
     indexed_members: set[Path] = set()
     for index_path in sorted(tree.rglob("*.safetensors.index.json")):
         _reshard_indexed_safetensors(index_path, max_shard_bytes)

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -30,6 +30,7 @@ endpoint.
 from __future__ import annotations
 
 import logging
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -746,6 +747,11 @@ def _run_gguf_inline(
             )
         if not final_path.exists() or final_path.stat().st_size <= 0:
             raise RuntimeError(f"llama-quantize produced no output for {dtype}")
+
+    # Scratch is part of the peak working set, never part of the published
+    # flavor tree. A cleanup failure must fail the flavor rather than leak an
+    # F16 intermediate and tool sidecars into Tensorhub.
+    shutil.rmtree(work_dir)
 
     attrs = {
         "dtype": f"gguf:{dtype}",

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -431,6 +431,9 @@ def ingest_huggingface(
         "class_name": str(classification.attrs.get("architecture") or ""),
     }
     attrs = dict(classification.attrs)
+    on_disk_dtype = _detect_snapshot_dtype(dest_dir)
+    if on_disk_dtype:
+        attrs["dtype"] = on_disk_dtype
     attrs.setdefault("runtime_library", library)
     metadata = {
         "source_provider": "huggingface",

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import struct
+
 import pytest
 
 from gen_worker.convert.classifier import RepoRefusal, classify_repo
@@ -188,13 +191,35 @@ def test_hf_multi_weight_bundle_opts_out_of_layout_contract(tmp_path, monkeypatc
 
     def fake_dl(repo_id, rev, dest, *, allow_patterns, **kw):
         for p in allow_patterns:
-            (Path(dest) / p).write_bytes(b"x")
+            target = Path(dest) / p
+            if p.endswith(".safetensors"):
+                header = json.dumps({
+                    "weight": {
+                        "dtype": "BF16",
+                        "shape": [1],
+                        "data_offsets": [0, 2],
+                    },
+                }, separators=(",", ":")).encode()
+                target.write_bytes(struct.pack("<Q", len(header)) + header + b"\0\0")
+            else:
+                target.write_bytes(b"x")
 
     monkeypatch.setattr(ing, "_snapshot_download_with_retries", fake_dl)
     monkeypatch.setattr(ing, "install_hf_http_timeouts", lambda: None)
     src = ing.ingest_huggingface("ResembleAI/chatterbox", tmp_path / "d", plan=plan)
     assert src.repo_spec["library_name"] == ""
     assert src.metadata["multi_weight_bundle"] == "true"
+    assert src.attrs["dtype"] == "bf16"
+
+    from gen_worker.convert.clone import OutputSpec, build_flavor_tree
+
+    tree, attrs = build_flavor_tree(
+        src,
+        OutputSpec(dtype="source", file_layout="singlefile", file_type="safetensors"),
+        tmp_path / "source-flavor",
+    )
+    assert attrs["dtype"] == "bf16"
+    assert len(list(tree.glob("*.safetensors"))) == 3
 
 
 def test_gguf_multiquant_repo_size_gate_on_selected_set() -> None:

--- a/tests/convert/test_clone_hygiene.py
+++ b/tests/convert/test_clone_hygiene.py
@@ -7,9 +7,13 @@ no preflight, and failed-clone workdirs accumulated forever.
 from __future__ import annotations
 
 import fcntl
+import importlib.util
+import json
 import os
+import struct
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,17 +21,77 @@ from gen_worker.convert.clone import (
     CloneDiskSpaceError,
     _clone_workdir,
     _preflight_disk,
+    _stage_oversize_safetensors,
     _sweep_stale_workdirs,
+    normalize_outputs,
     run_clone,
 )
 
 
 class _Plan:
-    def __init__(self, sizes: list[int]) -> None:
+    def __init__(
+        self,
+        sizes: list[int],
+        *,
+        strategy: str = "",
+        attrs: dict[str, str] | None = None,
+        paths: list[str] | None = None,
+    ) -> None:
         self._sizes = sizes
+        self._paths = paths or [f"f{i}.safetensors" for i in range(len(sizes))]
+        self.classification = SimpleNamespace(strategy=strategy, attrs=attrs or {})
 
     def bank_files(self):
-        return [(f"f{i}", s, f"cid{i}") for i, s in enumerate(self._sizes)]
+        return [
+            (path, size, f"cid{i}") for i, (path, size) in enumerate(zip(self._paths, self._sizes))
+        ]
+
+
+def _specs(
+    dtype: str = "bf16",
+    layout: str = "diffusers",
+    file_type: str = "safetensors",
+):
+    return normalize_outputs(
+        [
+            {
+                "dtype": dtype,
+                "file_layout": layout,
+                "file_type": file_type,
+            }
+        ]
+    )
+
+
+def _z_image_plan() -> _Plan:
+    files = [
+        ("README.md", 6_015),
+        ("model_index.json", 467),
+        ("scheduler/scheduler_config.json", 173),
+        ("text_encoder/config.json", 726),
+        ("text_encoder/generation_config.json", 239),
+        ("text_encoder/model-00001-of-00003.safetensors", 3_957_900_840),
+        ("text_encoder/model-00002-of-00003.safetensors", 3_987_450_520),
+        ("text_encoder/model-00003-of-00003.safetensors", 99_630_640),
+        ("text_encoder/model.safetensors.index.json", 32_819),
+        ("tokenizer/merges.txt", 1_671_853),
+        ("tokenizer/tokenizer.json", 11_422_654),
+        ("tokenizer/tokenizer_config.json", 9_732),
+        ("tokenizer/vocab.json", 2_776_833),
+        ("transformer/config.json", 500),
+        ("transformer/diffusion_pytorch_model-00001-of-00002.safetensors", 9_973_727_144),
+        ("transformer/diffusion_pytorch_model-00002-of-00002.safetensors", 2_336_146_728),
+        ("transformer/diffusion_pytorch_model.safetensors.index.json", 48_969),
+        ("vae/config.json", 820),
+        ("vae/diffusion_pytorch_model.safetensors", 167_666_902),
+    ]
+    assert sum(size for _, size in files) == 20_538_494_574
+    return _Plan(
+        [size for _, size in files],
+        strategy="diffusers",
+        attrs={"dtype": "", "file_layout": "diffusers"},
+        paths=[path for path, _ in files],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -37,27 +101,237 @@ class _Plan:
 def test_preflight_rejects_oversized_source_with_actionable_message(tmp_path: Path) -> None:
     # 10 PiB source cannot fit any real test filesystem.
     with pytest.raises(CloneDiskSpaceError, match=r"need ~.* GiB free .*have .* GiB"):
-        _preflight_disk(tmp_path, _Plan([10 * 1024**5]))
+        _preflight_disk(tmp_path, _Plan([10 * 1024**5]), _specs())
 
 
 def test_preflight_passes_tiny_source(tmp_path: Path) -> None:
-    _preflight_disk(tmp_path, _Plan([1024]))  # must not raise
+    _preflight_disk(tmp_path, _Plan([1024]), _specs())  # must not raise
 
 
 def test_preflight_skips_when_plan_unavailable(tmp_path: Path) -> None:
-    _preflight_disk(tmp_path, None)  # fail-open: download surfaces its own error
+    _preflight_disk(tmp_path, None, _specs())  # fail-open: download surfaces its own error
 
 
-def test_preflight_headroom_is_tunable(tmp_path: Path, monkeypatch) -> None:
+def test_preflight_has_no_environment_headroom_override(tmp_path: Path, monkeypatch) -> None:
     free = os.statvfs(tmp_path).f_bavail * os.statvfs(tmp_path).f_frsize
-    # A source about half the free space passes at 1x headroom but must fail
-    # at an absurd multiplier.
-    source = max(free // 2, 1)
+    source = max((free - 2 * 1024**3) // 2, 1)
     monkeypatch.setenv("COZY_CONVERT_DISK_HEADROOM", "1000000")
-    with pytest.raises(CloneDiskSpaceError):
-        _preflight_disk(tmp_path, _Plan([source]))
+    _preflight_disk(
+        tmp_path,
+        _Plan([source], strategy="transformers"),
+        _specs(dtype="source", layout="singlefile"),
+    )
     monkeypatch.setenv("COZY_CONVERT_DISK_HEADROOM", "0.000001")
-    _preflight_disk(tmp_path, _Plan([source]))
+    with pytest.raises(CloneDiskSpaceError):
+        _preflight_disk(
+            tmp_path,
+            _Plan([10 * 1024**5], strategy="transformers"),
+            _specs(dtype="source", layout="singlefile"),
+        )
+
+
+def test_z_image_source_mirror_fits_real_runpod_cpu_disk(tmp_path: Path, monkeypatch) -> None:
+    # Exact selected paths and sizes from immutable
+    # Tongyi-MAI/Z-Image@04cc4abb...3021. Four existing HF shard members are
+    # above Tensorhub's 2 GiB transfer limit and must be resharded together.
+    plan = _z_image_plan()
+    specs = _specs(dtype="source")
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=40 * 1024**3),
+    )
+    _preflight_disk(tmp_path, plan, specs)
+
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=30 * 1024**3),
+    )
+    with pytest.raises(
+        CloneDiskSpaceError,
+        match=r"hardlink passthrough.*oversize-safetensors reshard output",
+    ):
+        _preflight_disk(tmp_path, plan, specs)
+
+
+def test_untyped_z_image_bf16_conversion_does_not_assume_passthrough(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    plan = _Plan(
+        [20_538_494_574],
+        strategy="diffusers",
+        attrs={"dtype": "", "file_layout": "diffusers"},
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=40 * 1024**3),
+    )
+    with pytest.raises(CloneDiskSpaceError, match="materialized output tree"):
+        _preflight_disk(tmp_path, plan, _specs(dtype="bf16"))
+
+
+def test_civitai_plan_preserves_standard_cpu_clone_admission(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from gen_worker.convert.ingest import CivitaiSourcePlan
+
+    source_bytes = 6_900_000_000
+    plan = CivitaiSourcePlan(
+        version_id=1,
+        payload={"model": {"type": "Checkpoint"}},
+        files=[{
+            "name": "model.safetensors",
+            "size_bytes": source_bytes,
+            "sha256": "a" * 64,
+        }],
+        revision="sha256:" + "b" * 64,
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=40 * 1024**3),
+    )
+    _preflight_disk(tmp_path, plan, _specs(dtype="bf16", layout="singlefile"))
+
+
+def test_source_mirrors_account_for_every_oversized_safetensors(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    gib = 1024**3
+    plan = _Plan(
+        [6 * gib, 6 * gib],
+        strategy="diffusers",
+        attrs={"dtype": "bf16", "file_layout": "diffusers"},
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=32 * gib),
+    )
+    with pytest.raises(CloneDiskSpaceError, match="oversize-safetensors reshard output"):
+        _preflight_disk(
+            tmp_path,
+            plan,
+            _specs(dtype="source") + _specs(dtype="bf16"),
+        )
+
+
+def test_layout_repackage_accounts_for_output_and_temporary_tree(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    gib = 1024**3
+    plan = _Plan(
+        [20 * gib],
+        strategy="diffusers",
+        attrs={"dtype": "bf16", "file_layout": "diffusers"},
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=60 * gib),
+    )
+    with pytest.raises(CloneDiskSpaceError, match="layout-repack tree"):
+        _preflight_disk(tmp_path, plan, _specs(dtype="bf16", layout="singlefile"))
+
+
+def test_non_direct_gguf_accounts_for_f16_intermediate(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    gib = 1024**3
+    plan = _Plan(
+        [10 * gib],
+        strategy="diffusers",
+        attrs={"dtype": "bf16", "file_layout": "diffusers"},
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=31 * gib),
+    )
+    with pytest.raises(CloneDiskSpaceError, match="intermediate F16 GGUF"):
+        _preflight_disk(
+            tmp_path,
+            plan,
+            _specs(dtype="q4_k_m", layout="diffusers", file_type="gguf"),
+        )
+
+
+def test_multiple_gguf_outputs_share_one_intermediate_peak(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    gib = 1024**3
+    plan = _Plan(
+        [10 * gib],
+        strategy="diffusers",
+        attrs={"dtype": "bf16", "file_layout": "diffusers"},
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=45 * gib),
+    )
+    _preflight_disk(
+        tmp_path,
+        plan,
+        _specs(dtype="q4_k_m", layout="diffusers", file_type="gguf")
+        + _specs(dtype="q5_k_m", layout="diffusers", file_type="gguf"),
+    )
+
+
+def _write_raw_safetensors(path: Path, tensors: dict[str, int]) -> None:
+    offset = 0
+    header = {}
+    for name, size in tensors.items():
+        header[name] = {
+            "dtype": "F16",
+            "shape": [size // 2],
+            "data_offsets": [offset, offset + size],
+        }
+        offset += size
+    body = json.dumps(header, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(body)) + body + bytes(offset))
+
+
+def test_existing_hf_shard_group_remains_loadable_after_reshard(tmp_path: Path) -> None:
+    component = tmp_path / "transformer"
+    component.mkdir()
+    first = component / "model-00001-of-00002.safetensors"
+    second = component / "model-00002-of-00002.safetensors"
+    _write_raw_safetensors(first, {"a": 180, "b": 180})
+    _write_raw_safetensors(second, {"c": 80})
+    index = component / "model.safetensors.index.json"
+    index.write_text(json.dumps({
+        "metadata": {"total_size": 440},
+        "weight_map": {
+            "a": first.name,
+            "b": first.name,
+            "c": second.name,
+        },
+    }))
+
+    _stage_oversize_safetensors(tmp_path, max_shard_bytes=200)
+
+    payload = json.loads(index.read_text())
+    assert set(payload["weight_map"]) == {"a", "b", "c"}
+    assert not first.exists() and not second.exists()
+    for tensor, shard_name in payload["weight_map"].items():
+        shard = component / shard_name
+        assert shard.is_file()
+        raw = shard.read_bytes()
+        header_len = struct.unpack("<Q", raw[:8])[0]
+        header = json.loads(raw[8:8 + header_len])
+        assert tensor in header
+
+    if importlib.util.find_spec("safetensors") and importlib.util.find_spec("numpy"):
+        from safetensors import safe_open
+
+        loaded = set()
+        for shard_name in set(payload["weight_map"].values()):
+            with safe_open(str(component / shard_name), framework="numpy") as handle:
+                loaded.update(handle.keys())
+                for name in handle.keys():
+                    handle.get_tensor(name)
+        assert loaded == {"a", "b", "c"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/convert/test_integration.py
+++ b/tests/convert/test_integration.py
@@ -161,6 +161,7 @@ def test_gguf_direction(tiny_llama, tmp_path: Path) -> None:
         source_repo_dir=tiny_llama.dir,
     )
     assert result.output_paths and result.output_paths[0].suffix == ".gguf"
+    assert not (tmp_path / "gguf" / "_gguf_work").exists()
 
 
 def test_calibrated_dtype_refused(tiny_llama, tmp_path: Path) -> None:

--- a/tests/convert/test_variant_index_load_gw522.py
+++ b/tests/convert/test_variant_index_load_gw522.py
@@ -44,28 +44,20 @@ def _tiny_unet_fp16_tree(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _reshard_old_convention(tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _reshard_old_convention(tree: Path) -> None:
     """Run the REAL resharder with a tiny threshold — this is exactly how the
     live mirrors got their old-convention index names."""
-    from gen_worker.convert.writer import shard_safetensors_by_offset
-
-    monkeypatch.setattr(clone_mod, "MAX_SAFETENSORS_SHARD_BYTES", 16 * 1024)
-    monkeypatch.setattr(
-        clone_mod, "shard_safetensors_by_offset",
-        lambda f, stage, **kw: shard_safetensors_by_offset(
-            f, stage, max_shard_bytes=16 * 1024, **kw),
-    )
-    clone_mod._stage_oversize_safetensors(tree)
+    clone_mod._stage_oversize_safetensors(tree, max_shard_bytes=16 * 1024)
 
 
 class TestShardedVariantIndex:
     def test_old_convention_tree_is_unloadable_by_real_diffusers(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self, tmp_path: Path,
     ) -> None:
         """Negative control: the pre-fix tree shape dies exactly like the
         live sdxl-base mirror did."""
         tree = _tiny_unet_fp16_tree(tmp_path)
-        _reshard_old_convention(tree, monkeypatch)
+        _reshard_old_convention(tree)
         old_idx = tree / "unet" / "diffusion_pytorch_model.fp16.safetensors.index.json"
         assert old_idx.exists(), "resharder no longer composes the old name?"
 
@@ -75,10 +67,10 @@ class TestShardedVariantIndex:
             UNet2DConditionModel.from_pretrained(tree / "unet", variant="fp16")
 
     def test_canonical_tree_loads_with_real_diffusers(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self, tmp_path: Path,
     ) -> None:
         tree = _tiny_unet_fp16_tree(tmp_path)
-        _reshard_old_convention(tree, monkeypatch)
+        _reshard_old_convention(tree)
         normalize_variant_filenames(tree)
 
         unet_dir = tree / "unet"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.30.1"
+version = "0.30.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What

- replace the fixed clone-disk multiplier with operation-aware admission derived from the actual conversion plan
- preserve and atomically reshard existing indexed safetensors groups while recording observed source dtype
- account for Civitai single-file ingestion, dtype-preserving mirrors, explicit conversions, and sequential GGUF scratch accurately
- remove GGUF scratch before publishing and document the remaining external-component repack boundary
- release as gen-worker 0.30.2

## Why

The fixed multiplier rejected the immutable 19.1 GiB Z-Image repository on a 40 GiB conversion worker even though its real source plus reshard peak fits. The production mirror path also lacked observed safetensors dtype and could treat members of an already-sharded checkpoint as independent files, producing an invalid index. Raising a disk knob would only hide those correctness problems.

## Impact

Z-Image Base and Turbo can use the normal Tensorhub conversion path without an environment override. Admission remains conservative for plan-known work, indexed checkpoint groups remain loadable, and non-direct GGUF work is bounded to one sequential peak intermediate.

## Checks

- independent review: GO on exact pre-commit diff `376202f4cdf8b22c2a5b848c5a6f70937aec98dcd414ee2792a4fccaa0dbd4f5`
- focused production-path classifier/hygiene suite: 39 passed
- broader conversion suite: 100 passed, 6 skipped
- synthetic resharded HF group loaded with `safetensors.safe_open`
- Ruff: passed
- mypy: passed
- `uv lock --check`: passed
- `git diff --check`: passed

The full local suite could not collect because the optional Torch dependency is absent; the repository's normal PR CI is the authoritative full environment gate.

Tracker: python-gen-worker #554; unblocks training-endpoints #83.