### PR TITLE
gw#555: self-minted local compile cells for the cozy-local runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.30.2"
+version = "0.31.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -612,9 +612,14 @@ def _load_injected_model(
         return sl.obj
     compile_cfg = getattr(decl, "compile", None) if decl is not None else None
     if compile_cfg is not None and device.strip().lower() != "cpu":
+        from ..local_cells import enable_compiled as enable_compiled_local
         from ..models.cache_paths import tensorhub_cas_dir
 
-        provision.enable_compiled(sl.obj, compile_cfg, Path(tensorhub_cas_dir()))
+        # Local runtime (gw#555): delivered/env artifacts first, then the
+        # user's local cell store — adopt a stored self-minted cell or mint
+        # one. This call-site is the ONLY entry to local minting; the
+        # production executor arms compile via hub-delivered cells only.
+        enable_compiled_local(sl.obj, compile_cfg, Path(tensorhub_cas_dir()))
     _INJECTED_CACHE[key] = sl.obj
     return sl.obj
 

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -232,7 +232,7 @@ def enable_compiled(
         if not reason:
             # the exact delivered-cell consumer path (verify + drift + arm)
             if cc.enable(pipe, cfg, cache_dir, artifact=target):
-                logger.info("local-cells: adopted stored cell %s", target)
+                _say(f"local-cells: adopted stored cell {target.name}")
                 return True
             reason = "seed/arm failed"
         _say(f"local-cells: stored cell no longer matches ({reason}); re-minting")

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -1,0 +1,275 @@
+"""Self-minted local compile cells for the cozy-local runtime (gw#555).
+
+Production compile cells are minted by the platform's first-party compile
+job and DELIVERED to workers (#384/#569); a production worker that has no
+cell stays eager — it never compiles and never publishes. cozy-local users
+run on GPUs the platform may never have compiled for (an RTX 5080, say), so
+the LOCAL runtime is allowed to mint its own cell: when a compile-enabled
+endpoint loads and no stored cell matches this runtime, compile once (the
+endpoint's own ``Compile`` recipe — same shapes/targets/regional mode the
+production producer uses), pack the result with the production artifact
+format, and save it in the user's cozy directory. Subsequent boots adopt it
+through the exact delivered-cell code path.
+
+TRUST BOUNDARY — local cells are never uploaded or shared. A compile cell
+is user-generated EXECUTABLE code (compiled kernels + generated C++/Triton
+sources); accepting one from a user machine into shared storage would let
+any user ship arbitrary code into other people's GPU workers. Enforcement
+is structural, not a flag:
+
+* this module has no publish path — it is not a CAS client, imports no
+  upload/transport machinery, and writes only under the local store root;
+* only the local CLI serve path (``cli/run.py``) calls into it — the
+  production executor arms compile exclusively through hub-DELIVERED
+  artifacts (``executor._enable_compiled``) and never imports this module.
+
+Key discipline is unchanged from production: adoption reuses
+``compile_cache.verify()`` EXACT semantics verbatim (artifact format, SKU,
+torch, triton, gen-worker version, lib versions, family) plus the same
+``mode_drift``/``lane_drift``/``compile_mode`` parity checks. Any mismatch
+re-mints and atomically replaces the stored cell — stale kernels are never
+served.
+
+Store layout (one cell per (family, SKU/torch/lane) key)::
+
+    <store>/<family>/<flavor_label>.tar.gz     # production artifact format
+    <store>/.mint/*                            # in-progress capture dirs
+
+The store root is ``$GEN_WORKER_LOCAL_CELLS_DIR`` (exported by cozy-local's
+``workerEnv``, cozy-local #47), defaulting to ``~/.cache/cozy/compile-cells``
+— a path relocation like ``TENSORHUB_CACHE_DIR``, not a behavior knob.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sys
+import tarfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from . import compile_cache as cc
+
+logger = logging.getLogger(__name__)
+
+ENV_STORE_DIR = "GEN_WORKER_LOCAL_CELLS_DIR"
+_MINT_DIR = ".mint"
+_STALE_MINT_S = 24 * 3600
+
+
+def store_root() -> Path:
+    env = os.environ.get(ENV_STORE_DIR, "").strip()
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".cache" / "cozy" / "compile-cells"
+
+
+def cell_path(family: str, weight_lane: str = "", root: Optional[Path] = None) -> Path:
+    """Where this runtime's cell for ``family`` lives in the local store."""
+    key = cc.runtime_key()
+    label = cc.flavor_label(key["sku"], key["torch"], weight_lane)
+    return (root or store_root()) / family / f"{label}.tar.gz"
+
+
+def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
+    """'' when the stored cell is adoptable by this runtime + pipeline, else
+    the mismatch reason (production verify() + drift parity, verbatim)."""
+    try:
+        with tarfile.open(artifact, mode="r:*") as tar:  # metadata only
+            member = tar.extractfile(cc.METADATA_NAME)
+            if member is None:
+                return "no metadata.json"
+            meta = json.loads(member.read().decode())
+    except Exception as exc:  # noqa: BLE001 — any unreadable cell re-mints
+        return f"unreadable artifact ({exc})"
+    reason = cc.verify(meta, family=family)
+    if reason:
+        return reason
+    reason = cc.mode_drift(meta, pipe) or cc.lane_drift(meta, pipe)
+    if reason:
+        return reason
+    want = "regional" if getattr(cfg, "regional", False) else "whole"
+    have = str(meta.get("compile_mode") or "whole")
+    if have != want:
+        return f"compile_mode {have!r} != declared {want!r}"
+    return ""
+
+
+def _estimate_minutes(cfg: Any) -> int:
+    """Rough one-time compile estimate: ~45s per image shape, ~3min per
+    video (w, h, frames) shape — order-of-magnitude UX, not a promise."""
+    mins = 0.0
+    for shape in getattr(cfg, "shapes", ()) or ():
+        mins += 3.0 if len(shape) >= 3 else 0.75
+    return max(1, round(mins))
+
+
+def _cuda_ready() -> bool:
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:
+        return False
+
+
+def _say(msg: str) -> None:
+    logger.info("%s", msg)
+    print(msg, file=sys.stderr)
+
+
+def _sweep_stale_mints(root: Path) -> None:
+    base = root / _MINT_DIR
+    if not base.is_dir():
+        return
+    now = time.time()
+    for d in base.iterdir():
+        try:
+            if now - d.stat().st_mtime > _STALE_MINT_S:
+                shutil.rmtree(d, ignore_errors=True)
+        except OSError:
+            continue
+
+
+def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2) -> None:
+    """Cold-compile ``pipe`` over the declared shape table (the only part of
+    a mint that needs CUDA + a toolchain). ``guard=False``: a failing warm
+    call must fail the mint — a silently-eager capture must never be saved."""
+    if not cc.apply(pipe, cfg, cache_ready=False, guard=False, allow_cold=True):
+        raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
+    import torch
+
+    decode = any(t.startswith("vae") for t in cfg.targets)
+    for shape in cfg.shapes:
+        torch.cuda.synchronize()
+        t0 = time.monotonic()
+        cc._warm_call(
+            pipe, shape, steps=steps,
+            prompt="cache warm-up: a lighthouse on a cliff at dawn, detailed",
+            decode=decode,
+        )
+        torch.cuda.synchronize()
+        key = "x".join(str(v) for v in shape)
+        _say(f"  compiled {key} in {time.monotonic() - t0:.0f}s")
+
+
+def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
+    """Compile this pipeline once and save the cell atomically at ``target``.
+
+    The capture uses the production artifact recipe end to end
+    (``capture_env`` -> warm the shape table -> ``artifact_metadata`` ->
+    deterministic ``pack``), so the saved cell is byte-compatible with a
+    delivered one and adopts through the identical code path.
+    """
+    root = store_root()
+    _sweep_stale_mints(root)
+    capture = root / _MINT_DIR / f"{target.name[: -len('.tar.gz')]}-{os.getpid()}"
+    cc.capture_env(capture)
+    started = time.monotonic()
+
+    _compile_and_warm(pipe, cfg)
+
+    captured = [p for p in (capture / "inductor").rglob("*") if p.is_file()]
+    if not captured:
+        raise RuntimeError(
+            "compile warm-up captured nothing under TORCHINDUCTOR_CACHE_DIR"
+        )
+    from .models.loading import pipeline_weight_lane
+    from .models.memory import low_vram_mode
+
+    meta = cc.artifact_metadata(
+        family=family,
+        source_ref="local-mint",
+        shapes=cfg.shapes,
+        targets=cfg.targets,
+        low_vram_mode=low_vram_mode(pipe),
+        compile_mode="regional" if getattr(cfg, "regional", False) else "whole",
+        weight_lane=pipeline_weight_lane(pipe),
+    )
+    tmp = target.with_suffix(".part")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    cc.pack(capture, tmp, meta)
+    os.replace(tmp, target)
+    _say(
+        f"compile cell saved: {target} "
+        f"({target.stat().st_size / 1e6:.1f} MB, {time.monotonic() - started:.0f}s total); "
+        "future loads reuse it with no compile"
+    )
+    return target
+
+
+def enable_compiled(
+    pipe: Any, cfg: Any, cache_dir: Optional[Path] = None,
+    artifact: Optional[Path] = None,
+) -> bool:
+    """Local-CLI compile arming: delivered/env artifacts first (production
+    policy, incl. TRT and the manual GEN_WORKER_COMPILE_CACHE overrides),
+    then the local cell store — adopt a matching stored cell, or mint one.
+
+    Never raises: any store or mint failure logs and serves eager, exactly
+    like the production miss policy.
+    """
+    from .models import provision
+
+    family = str(getattr(cfg, "family", "") or "")
+    if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
+        return True
+    if not family:
+        logger.info("local-cells: Compile decl has no family; staying eager")
+        return False
+    if not _cuda_ready():
+        return False  # apply() already logged; nothing to mint for
+
+    from .models.loading import pipeline_weight_lane
+
+    target = cell_path(family, pipeline_weight_lane(pipe))
+    if target.exists():
+        reason = store_verdict(target, family, pipe, cfg)
+        if not reason:
+            # the exact delivered-cell consumer path (verify + drift + arm)
+            if cc.enable(pipe, cfg, cache_dir, artifact=target):
+                logger.info("local-cells: adopted stored cell %s", target)
+                return True
+            reason = "seed/arm failed"
+        _say(f"local-cells: stored cell no longer matches ({reason}); re-minting")
+
+    if not cc.toolchain_present():
+        _say(
+            "local-cells: this endpoint supports torch.compile but no C "
+            "compiler is installed (need cc/gcc/clang); serving eager. "
+            "Install one to let cozy compile once and cache the result."
+        )
+        return False
+    _say(
+        f"local-cells: no compile cell for this GPU/torch yet — compiling "
+        f"{len(tuple(cfg.shapes))} graph shape(s) once "
+        f"(~{_estimate_minutes(cfg)} min). The cell will be saved to "
+        f"{target} and reused forever."
+    )
+    try:
+        _mint(pipe, cfg, target, family)
+    except Exception as exc:  # noqa: BLE001 — mint failure => eager, never fatal
+        logger.warning("local-cells: mint failed (%s); serving eager", exc)
+        cc.unwrap(pipe)
+        return False
+    # Adopt the just-saved cell through the delivered-cell path (drops the
+    # unguarded mint wrappers; re-traces hit the captured FX cache). This
+    # also proves the saved artifact round-trips before we rely on it.
+    cc.unwrap(pipe)
+    if cc.enable(pipe, cfg, cache_dir, artifact=target):
+        return True
+    logger.warning("local-cells: minted cell failed re-adoption; serving eager")
+    return False
+
+
+__all__ = [
+    "ENV_STORE_DIR",
+    "cell_path",
+    "enable_compiled",
+    "store_root",
+    "store_verdict",
+]

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -1,0 +1,311 @@
+"""gw#555: self-minted local compile cells — store key discipline, mismatch
+re-mint, save/load round-trip, and the structural no-publish trust boundary.
+
+The torch.compile capture itself needs a GPU + toolchain and is proven live
+on a pod (tracker gw#555); these tests exercise everything around it through
+the real pack/verify/seed machinery."""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from gen_worker import compile_cache as cc
+from gen_worker import local_cells as lc
+
+
+@pytest.fixture(autouse=True)
+def _restore_capture_env(monkeypatch):
+    """capture_env mutates these in-process; register them with monkeypatch
+    so each test leaves the process env as it found it."""
+    for key in ("TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR"):
+        monkeypatch.setenv(key, os.environ.get(key, ""))
+
+
+class _Cfg:
+    """Stand-in for api.decorators.Compile (duck-typed in local_cells)."""
+
+    def __init__(self, family="fam", shapes=((64, 64),), targets=("transformer",), regional=False):
+        self.family = family
+        self.shapes = tuple(tuple(s) for s in shapes)
+        self.targets = tuple(targets)
+        self.regional = regional
+
+
+class _Pipe:
+    _cozy_low_vram_mode = "off"
+
+
+def _make_cell(path: Path, **overrides) -> Path:
+    """A real packed artifact whose metadata matches THIS runtime (so
+    verify() passes), with optional key overrides to force mismatches."""
+    meta = cc.artifact_metadata(
+        family="fam", shapes=[(64, 64)], targets=["transformer"],
+        low_vram_mode="off",
+    )
+    meta.update(overrides)
+    capture = path.parent / f".capture-{path.name}"
+    (capture / "inductor").mkdir(parents=True, exist_ok=True)
+    (capture / "inductor" / "kernel.bin").write_bytes(b"fake-kernel")
+    (capture / "triton").mkdir(parents=True, exist_ok=True)
+    (capture / "triton" / "launcher.json").write_bytes(b"{}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return cc.pack(capture, path, meta)
+
+
+# ---------------------------------------------------------------------------
+# store paths + key
+# ---------------------------------------------------------------------------
+
+
+def test_store_root_env_and_default(monkeypatch):
+    monkeypatch.delenv(lc.ENV_STORE_DIR, raising=False)
+    assert lc.store_root() == Path.home() / ".cache" / "cozy" / "compile-cells"
+    monkeypatch.setenv(lc.ENV_STORE_DIR, "/tmp/cells-here")
+    assert lc.store_root() == Path("/tmp/cells-here")
+
+
+def test_cell_path_keys_on_family_and_runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv(lc.ENV_STORE_DIR, str(tmp_path))
+    p = lc.cell_path("ltx-2.3")
+    key = cc.runtime_key()
+    assert p == tmp_path / "ltx-2.3" / f"{cc.flavor_label(key['sku'], key['torch'])}.tar.gz"
+    # weight lane is part of the key: different lane, different cell file
+    assert lc.cell_path("ltx-2.3", "fp8-hooks") != p
+
+
+# ---------------------------------------------------------------------------
+# verdict: production verify() semantics verbatim + drift parity
+# ---------------------------------------------------------------------------
+
+
+def test_store_verdict_hit(tmp_path):
+    cell = _make_cell(tmp_path / "cell.tar.gz")
+    assert lc.store_verdict(cell, "fam", _Pipe(), _Cfg()) == ""
+
+
+@pytest.mark.parametrize(
+    "overrides, expect",
+    [
+        ({"torch": "0.0.0+nope"}, "torch"),
+        ({"gen_worker": "0.0.0-not-this"}, "gen_worker"),
+        ({"sku": "not-this-gpu"}, "sku"),
+        ({"format": 99}, "format"),
+        ({"weight_lane": "fp8-hooks"}, "weight_lane"),   # lane drift, symmetric
+        ({"compile_mode": "regional"}, "compile_mode"),
+        ({"low_vram_mode": "vae_only"}, "low_vram_mode"),
+    ],
+)
+def test_store_verdict_mismatches(tmp_path, overrides, expect):
+    cell = _make_cell(tmp_path / "cell.tar.gz", **overrides)
+    assert expect in lc.store_verdict(cell, "fam", _Pipe(), _Cfg())
+
+
+def test_store_verdict_family_mismatch(tmp_path):
+    cell = _make_cell(tmp_path / "cell.tar.gz")
+    assert "family" in lc.store_verdict(cell, "other-family", _Pipe(), _Cfg())
+
+
+def test_store_verdict_garbage_artifact(tmp_path):
+    bad = tmp_path / "cell.tar.gz"
+    bad.write_bytes(b"not a tarball")
+    assert "unreadable" in lc.store_verdict(bad, "fam", _Pipe(), _Cfg())
+
+
+# ---------------------------------------------------------------------------
+# mint: save/load round-trip through the real pack/unpack/seed machinery
+# ---------------------------------------------------------------------------
+
+
+def _fake_compile_and_warm(pipe, cfg, **kw):
+    """Stand-in for the GPU-only capture: write files where the ACTIVE
+    TORCHINDUCTOR/TRITON cache env points (what inductor would do)."""
+    Path(os.environ["TORCHINDUCTOR_CACHE_DIR"], "graph.so").write_bytes(b"\x7fELF-ish")
+    Path(os.environ["TRITON_CACHE_DIR"], "kern.cubin").write_bytes(b"cubin")
+
+
+def test_mint_saves_atomically_and_roundtrips(monkeypatch, tmp_path):
+    monkeypatch.setenv(lc.ENV_STORE_DIR, str(tmp_path))
+    monkeypatch.setattr(lc, "_compile_and_warm", _fake_compile_and_warm)
+    pipe, cfg = _Pipe(), _Cfg()
+    target = lc.cell_path("fam")
+
+    saved = lc._mint(pipe, cfg, target, "fam")
+
+    assert saved == target and target.exists()
+    assert not list(target.parent.glob("*.part"))  # atomic: no partials left
+    # the saved cell is adoptable by this same runtime (the re-boot path)
+    assert lc.store_verdict(target, "fam", pipe, cfg) == ""
+    # and unpacks through the production consumer machinery
+    meta = cc.unpack(target, tmp_path / "seed-root")
+    assert meta["family"] == "fam"
+    assert meta["source_ref"] == "local-mint"
+    assert (tmp_path / "seed-root" / "inductor" / "graph.so").exists()
+    assert cc.verify(meta, family="fam") == ""
+
+
+def test_mint_refuses_empty_capture(monkeypatch, tmp_path):
+    monkeypatch.setenv(lc.ENV_STORE_DIR, str(tmp_path))
+    monkeypatch.setattr(lc, "_compile_and_warm", lambda pipe, cfg, **kw: None)
+    with pytest.raises(RuntimeError, match="captured nothing"):
+        lc._mint(_Pipe(), _Cfg(), lc.cell_path("fam"), "fam")
+    assert not lc.cell_path("fam").exists()  # nothing saved on failure
+
+
+# ---------------------------------------------------------------------------
+# enable_compiled orchestration: hit adopts, mismatch re-mints, miss mints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _local_env(monkeypatch, tmp_path):
+    monkeypatch.setenv(lc.ENV_STORE_DIR, str(tmp_path / "store"))
+    monkeypatch.delenv(cc.ENV_CACHE_PATH, raising=False)
+    monkeypatch.delenv(cc.ENV_CACHE_URL, raising=False)
+    monkeypatch.delenv(cc.ENV_ALLOW_COLD, raising=False)
+    monkeypatch.setattr(lc, "_cuda_ready", lambda: True)
+    # keep the delivered-artifact leg deterministic on GPU-less CI
+    from gen_worker.models import provision
+
+    monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: False)
+    return tmp_path / "store"
+
+
+def test_stored_cell_adopts_through_production_path(_local_env, monkeypatch):
+    pipe, cfg = _Pipe(), _Cfg()
+    _make_cell(lc.cell_path("fam"))
+    calls = {}
+
+    def fake_enable(p, c, cache_dir=None, artifact=None):
+        calls["artifact"] = artifact
+        return True
+
+    monkeypatch.setattr(cc, "enable", fake_enable)
+    minted = []
+    monkeypatch.setattr(lc, "_mint", lambda *a, **k: minted.append(a))
+
+    assert lc.enable_compiled(pipe, cfg) is True
+    assert calls["artifact"] == lc.cell_path("fam")  # delivered-cell code path
+    assert minted == []                              # no re-mint on a hit
+
+
+def test_key_mismatch_remints_and_replaces(_local_env, monkeypatch):
+    pipe, cfg = _Pipe(), _Cfg()
+    target = lc.cell_path("fam")
+    _make_cell(target, gen_worker="0.0.0-stale")     # stale-key cell in store
+    stale_bytes = target.read_bytes()
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+
+    def fake_mint(p, c, tgt, family):
+        _make_cell(tgt)                              # fresh, matching cell
+        return tgt
+
+    monkeypatch.setattr(lc, "_mint", fake_mint)
+    enables = []
+
+    def fake_enable(p, c, cache_dir=None, artifact=None):
+        enables.append(artifact)
+        return True
+
+    monkeypatch.setattr(cc, "enable", fake_enable)
+
+    assert lc.enable_compiled(pipe, cfg) is True
+    assert target.read_bytes() != stale_bytes        # stale cell replaced
+    assert lc.store_verdict(target, "fam", pipe, cfg) == ""
+    assert enables == [target]                       # armed from the NEW cell
+
+
+def test_miss_mints_once(_local_env, monkeypatch):
+    pipe, cfg = _Pipe(), _Cfg()
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(lc, "_compile_and_warm", _fake_compile_and_warm)
+    monkeypatch.setattr(cc, "enable", lambda *a, **k: True)
+
+    assert lc.enable_compiled(pipe, cfg) is True
+    assert lc.cell_path("fam").exists()
+
+
+def test_no_toolchain_stays_eager(_local_env, monkeypatch, capsys):
+    monkeypatch.setattr(cc, "toolchain_present", lambda: False)
+    assert lc.enable_compiled(_Pipe(), _Cfg()) is False
+    assert not lc.cell_path("fam").exists()
+    assert "no C compiler" in capsys.readouterr().err
+
+
+def test_mint_failure_serves_eager(_local_env, monkeypatch):
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+
+    def boom(pipe, cfg, **kw):
+        raise RuntimeError("compile exploded")
+
+    monkeypatch.setattr(lc, "_compile_and_warm", boom)
+    assert lc.enable_compiled(_Pipe(), _Cfg()) is False
+    assert not lc.cell_path("fam").exists()
+
+
+def test_no_family_no_mint(_local_env):
+    assert lc.enable_compiled(_Pipe(), _Cfg(family="")) is False
+
+
+# ---------------------------------------------------------------------------
+# trust boundary: no publish path exists, structurally
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_IMPORTS = {
+    "gen_worker.s3_transfer", "gen_worker.presigned_upload",
+    "gen_worker._upload_transport", "gen_worker.media_transfer",
+    "gen_worker.net", "gen_worker.callout", "gen_worker.transport",
+    "urllib", "urllib.request", "requests", "httpx", "boto3", "aiohttp",
+}
+
+
+def test_local_cells_has_no_publish_path():
+    """local cells are user-generated executable artifacts (supply-chain
+    boundary): the store module must have no network/upload machinery."""
+    src = Path(lc.__file__).read_text()
+    tree = ast.parse(src)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            base = f"gen_worker.{mod.lstrip('.')}" if node.level else mod
+            imported.add(base)
+            imported.update(f"{base}.{a.name}" for a in node.names)
+    hits = {
+        i for i in imported
+        if i in _FORBIDDEN_IMPORTS or any(i.startswith(f + ".") for f in _FORBIDDEN_IMPORTS)
+    }
+    assert not hits, f"local_cells must never grow a publish path: {hits}"
+    idents = {
+        n.id.lower() for n in ast.walk(tree) if isinstance(n, ast.Name)
+    } | {
+        n.attr.lower() for n in ast.walk(tree) if isinstance(n, ast.Attribute)
+    } | {
+        n.name.lower() for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+    for word in ("upload", "publish", "presign", "put_object", "post"):
+        bad = {i for i in idents if word in i}
+        assert not bad, f"local_cells code references {bad}"
+
+
+def test_production_executor_never_reaches_local_cells():
+    """The mint entry is the local CLI only: the production executor and
+    lifecycle must not reference local_cells (fetch-only stays fetch-only)."""
+    root = Path(lc.__file__).parent
+    for name in ("executor.py", "lifecycle.py", "worker.py", "entrypoint.py"):
+        assert "local_cells" not in (root / name).read_text(), name
+
+
+def test_local_cli_is_the_only_mint_caller():
+    root = Path(lc.__file__).parent
+    callers = [
+        p for p in root.rglob("*.py")
+        if p.name != "local_cells.py" and "local_cells" in p.read_text()
+    ]
+    assert {p.relative_to(root).as_posix() for p in callers} == {"cli/run.py"}

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.30.2"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Paul-directed: cozy-local users self-mint compile cells locally (never on production).

- NEW `gen_worker/local_cells.py`: local cell store (`~/.cache/cozy/compile-cells`, `GEN_WORKER_LOCAL_CELLS_DIR`); on load, adopt a stored cell via the exact delivered-cell path (`compile_cache.enable`), else mint once (cold compile over the endpoint's own `Compile` shapes/targets/regional recipe, deterministic `pack`, atomic save), then re-adopt the just-saved cell (round-trip proven at mint time).
- Key discipline unchanged: `verify()` EXACT (format/sku/torch/triton/gen_worker/libs/family) + `mode_drift`/`lane_drift`/`compile_mode` parity; any mismatch re-mints and replaces — stale kernels never served.
- Trust boundary structural: no publish path in the module (not a CAS client, no upload/network imports — test-asserted); only `cli/run.py` (the cozy-local seam) calls it; executor/production stays fetch-only.
- First-load UX: one-time compile message with shape count + minute estimate + landing path.
- Tests: store verdict matrix (every key half), mismatch re-mint replaces, save/load round-trip through real pack/unpack/verify, mint-failure => eager, no-publish-path + only-caller structural assertions.

Live mint proof on a community GPU pod running the cozy-local runtime: tracked in gw#555 (cl#47 sibling PR adds paths + workerEnv export + `cozy cells`).

Coordination: does NOT touch `compile_cache.py`, the producer, or executor delivery/adoption (ie#381 lane untouched).

Tracker: gw#555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)