### PR TITLE
gw#557: streaming per-channel-scaled w8a8 producer + byte-gate + fp8+te TE wiring (0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.32.0 (2026-07-16)
+
+- **gw#557 (ie#494 W8A8 productization core): streaming per-channel-scaled
+  fp8 producer + byte-gate + fp8+te TE wiring on the w8a8 lane.**
+  `convert.writer` gains `streaming_w8a8_cast` / `streaming_w8a8_snapshot` —
+  a data-free requant of repeated-block denoiser Linears from the bf16
+  source into the gw#534 `#fp8-w8a8` artifact (fp8-E4M3 weights + F32 [out]
+  per-output-channel `weight_scale` twins; dynamic activation scales at
+  serve time, no calibration; gate-logit projections and everything outside
+  repeated blocks stay at source precision — the ie#494 probe's flip/skip
+  spec). Streaming two-pass per tensor, te#81 pattern: the model is never
+  materialized. `verify_w8a8_snapshot` byte-gates a produced tree against
+  its source (consumer-side detection, sampled recompute-exact quant+scale
+  bytes, dequant within the fp8-e4m3 format error bound).
+  `load_w8a8_pipeline` honors `storage_dtype="fp8+te"`: the gw#460
+  block-window fp8 storage now arms on the TEXT ENCODERS of a w8a8-served
+  pipeline (never its scaled-mm denoiser) via the new `components=` scope
+  override on `apply_fp8_storage`.
+
+
 ## 0.30.2 (2026-07-16)
 
 - **gw#554: clone disk admission follows the resolved work instead of a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.31.0"
+version = "0.32.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -40,7 +40,10 @@ from .writer import (
     streaming_fp8_snapshot,
     streaming_fp8_storage_cast,
     streaming_fp8_te_cast,
+    streaming_w8a8_cast,
+    streaming_w8a8_snapshot,
     te_fp8_castable_keys,
+    verify_w8a8_snapshot,
 )
 
 # `gen_worker.convert.clone` module alias (clone.from_huggingface style).
@@ -63,6 +66,9 @@ __all__ = [
     "streaming_fp8_storage_cast",
     "streaming_fp8_te_cast",
     "te_fp8_castable_keys",
+    "streaming_w8a8_cast",
+    "streaming_w8a8_snapshot",
+    "verify_w8a8_snapshot",
     "FP8_TE_COMPONENTS",
     "CalibrationAction",
     "CalibrationPolicy",

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -599,6 +599,190 @@ def streaming_fp8_storage_cast(
 
 
 # ---------------------------------------------------------------------------
+# W8A8 per-channel-scaled fp8 producer (gw#557 / ie#494) — data-free requant
+# from the bf16 source, streaming. The artifact contract is gw#534's
+# ``#fp8-w8a8`` (consumed by gen_worker.models.w8a8): per quantized Linear a
+# F8_E4M3 ``weight`` plus a F32 [out] ``weight_scale`` DEQUANT twin; excluded
+# layers stay at source precision with NO scale tensor. Activation scales are
+# DYNAMIC at serve time (Paul's settled design — no static calibration), so
+# the producer emits no input_scale.
+# ---------------------------------------------------------------------------
+
+W8A8_QUANT_SCHEME = "fp8-w8a8"  # == gen_worker.models.w8a8.W8A8_FLAVOR (test-guarded)
+
+# The ie#494 probe spec: quantize ONLY repeated-block Linears; MoE-style
+# gate-logit projections stay full precision even when 16-aligned (the probe
+# skipped LTX's 288 ``to_gate_logits`` explicitly).
+W8A8_SKIP_TENSOR_PATTERNS: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS + (
+    "gate_logits",
+)
+
+_W8A8_DIM_ALIGN = 16  # torch._scaled_mm alignment (models.w8a8._DIM_ALIGN)
+_SCALE_SUFFIX = ".weight_scale"
+
+
+def w8a8_cast_eligible(
+    name: str, src_st_dtype: str, shape: list[int],
+    *, skip_patterns: tuple[str, ...] = W8A8_SKIP_TENSOR_PATTERNS,
+) -> bool:
+    """True when a stored tensor becomes a quantized w8a8 Linear weight:
+    a 2-D float ``.weight`` under a repeated-block container, both dims
+    16-aligned, missing every skip pattern. Everything else (embeddings,
+    norms, projections outside blocks, misaligned or conv weights) stays at
+    source precision — mirroring the ie#494 probe's flip/skip list."""
+    if src_st_dtype not in {"F64", "F32", "F16", "BF16"}:
+        return False
+    if len(shape) != 2 or not name.endswith(".weight"):
+        return False
+    if shape[0] % _W8A8_DIM_ALIGN or shape[1] % _W8A8_DIM_ALIGN:
+        return False
+    if not _in_repeated_block(name):
+        return False
+    module_path = name[: -len(".weight")]
+    return not any(re.search(p, module_path) for p in skip_patterns)
+
+
+def streaming_w8a8_cast(
+    input_path: Path,
+    out_dir: Path,
+    *,
+    shard_prefix: str = "model",
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+    skip_patterns: tuple[str, ...] = W8A8_SKIP_TENSOR_PATTERNS,
+) -> dict[str, Any]:
+    """Per-channel-scaled fp8 requant of one weight set, streaming.
+
+    Two passes like :func:`_stream_reencode`, but eligible weights emit TWO
+    output tensors — the fp8 ``weight`` and its F32 [out] ``weight_scale``
+    (``scale = amax(row)/448``, ``q = round(w/scale)`` in fp32; the probe's
+    exact recipe). Peak anonymous memory ~ the largest single tensor.
+    ``.weight`` sorts immediately before ``.weight_scale``, so a weight is
+    always quantized before its scale is due — the scale is cached (tiny)
+    across a shard boundary if the plan splits the pair.
+    """
+    import torch
+    from safetensors import safe_open
+
+    shards_in = _resolve_input_shards(Path(input_path))
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pass 1: header-only walk.
+    metas: list[tuple[str, str, list[int], Optional[Path]]] = []
+    size_map: dict[str, int] = {}
+    source_metadata: dict[str, str] = {}
+    quantized_names: set[str] = set()
+    for shard_path in shards_in:
+        with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            md = f.metadata()
+            if md:
+                source_metadata.update({str(k): str(v) for k, v in md.items()})
+            for name in f.keys():
+                if name.endswith(_SCALE_SUFFIX):
+                    raise ConversionImplementationError(
+                        f"source already carries {name!r} — refusing to "
+                        "re-quantize a w8a8 artifact (requant from the "
+                        "bf16 source instead)")
+                sl = f.get_slice(name)
+                shape = list(sl.get_shape())
+                numel = 1
+                for dim in shape:
+                    numel *= dim
+                if w8a8_cast_eligible(
+                        name, str(sl.get_dtype()), shape,
+                        skip_patterns=skip_patterns):
+                    quantized_names.add(name)
+                    metas.append((name, "F8_E4M3", shape, shard_path))
+                    size_map[name] = numel * _ST_DTYPE_SIZES["F8_E4M3"]
+                    scale_name = name[: -len(".weight")] + _SCALE_SUFFIX
+                    metas.append((scale_name, "F32", [shape[0]], None))
+                    size_map[scale_name] = shape[0] * _ST_DTYPE_SIZES["F32"]
+                else:
+                    metas.append((name, str(sl.get_dtype()), shape, shard_path))
+                    size_map[name] = numel * _ST_DTYPE_SIZES[str(sl.get_dtype())]
+
+    out_metadata = dict(source_metadata)
+    out_metadata.update({
+        "quant_scheme": W8A8_QUANT_SCHEME,
+        "quant_recipe": "w8a8-pcs-dynamic",
+        "calibration_corpus": "",
+        "modelopt_version": "",
+    })
+    plan = plan_shards(size_map, max_shard_bytes=shard_threshold,
+                       shard_prefix=shard_prefix)
+    per_shard: dict[str, list[tuple[str, str, list[int], Optional[Path]]]] = {
+        n: [] for n in plan.shard_names}
+    for row in metas:
+        dest = plan.weight_map.get(row[0])
+        if dest is not None:
+            per_shard[dest].append(row)
+
+    tensor_count = 0
+    pending_scales: dict[str, "torch.Tensor"] = {}
+    handles: dict[Path, Any] = {}
+    try:
+        for shard_name in plan.shard_names:
+            entries = per_shard[shard_name]
+            with IncrementalSafetensorsWriter(
+                out_dir / shard_name, metadata=out_metadata,
+            ) as w:
+                for name, out_dtype, shape, _src in entries:
+                    w.add_tensor_metadata(name, dtype=out_dtype, shape=shape)
+                w.write_header()
+                for name, _out_dtype, _shape, src in entries:
+                    if src is None:  # synthesized weight_scale
+                        w.write_tensor(
+                            name, _tensor_to_bytes(pending_scales.pop(name)))
+                        continue
+                    f = handles.get(src)
+                    if f is None:
+                        f = handles[src] = safe_open(
+                            str(src), framework="pt", device="cpu")
+                    t = f.get_tensor(name)
+                    tensor_count += 1
+                    if name in quantized_names:
+                        wf = t.float()
+                        scale = (wf.abs().amax(dim=1, keepdim=True)
+                                 / _FP8_E4M3_MAX).clamp(min=1e-12)
+                        q = (wf / scale).clamp(
+                            -_FP8_E4M3_MAX, _FP8_E4M3_MAX,
+                        ).to(torch.float8_e4m3fn)
+                        scale_name = name[: -len(".weight")] + _SCALE_SUFFIX
+                        pending_scales[scale_name] = scale.reshape(-1).contiguous()
+                        w.write_tensor(name, _tensor_to_bytes(q))
+                        del wf, q
+                    else:
+                        w.write_tensor(name, _tensor_to_bytes(t))
+                    del t
+    finally:
+        for f in handles.values():
+            try:
+                f.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
+    if pending_scales:
+        raise ConversionImplementationError(
+            f"w8a8 cast left {len(pending_scales)} orphan scale tensor(s) "
+            f"(e.g. {sorted(pending_scales)[:3]})")
+
+    index_path: Optional[Path] = None
+    if len(plan.shard_names) > 1:
+        index_path = out_dir / f"{shard_prefix}.safetensors.index.json"
+        index_path.write_text(
+            json.dumps(build_index(plan), separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+    return {
+        "tensor_count": tensor_count,
+        "converted_count": len(quantized_names),
+        "output_paths": [out_dir / n for n in plan.shard_names],
+        "index_path": index_path,
+        "shard_sizes": dict(plan.shard_sizes),
+        "metadata": out_metadata,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Snapshot-level streaming conversion (whole source tree, per weight group)
 # ---------------------------------------------------------------------------
 
@@ -949,6 +1133,163 @@ def streaming_fp8_snapshot(
             "components": sorted(done), "output_dir": out_dir}
 
 
+def streaming_w8a8_snapshot(
+    source_dir: Path,
+    out_dir: Path,
+    *,
+    file_layout: str,
+    components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
+    te_components: tuple[str, ...] = (),
+    shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
+) -> dict[str, Any]:
+    """Produce the ``#fp8-w8a8`` flavor of a diffusers snapshot, streaming.
+
+    The denoiser (``components``) gets the per-channel-scaled w8a8 requant
+    (:func:`streaming_w8a8_cast`); ``te_components`` ride the SAME fp8+te
+    block-window storage cast the ``#fp8`` flavor uses (scale-free — text
+    encoders serve W8-storage, only the denoiser runs fp8 GEMMs). Every
+    other component passes through untouched. The denoiser's config gains
+    the gw#534 corroborating ``quantization_config`` (the safetensors
+    headers stay authoritative for detection)."""
+    source_dir, out_dir = Path(source_dir), Path(out_dir)
+    if file_layout != "diffusers":
+        raise ConversionImplementationError(
+            "w8a8 flavors need component identity: diffusers layout only")
+    denoiser_set, te_set = set(components), set(te_components)
+    groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
+              if c in denoiser_set | te_set]
+    if not any(c in denoiser_set for c, _ in groups):
+        raise ConversionImplementationError(
+            f"no w8a8-quantizable denoiser found (looked for {sorted(denoiser_set)})")
+    tensor_count = converted = 0
+    done: set[str] = set()
+    quantized_components: list[str] = []
+    for comp, entry in groups:
+        if comp in denoiser_set:
+            result = streaming_w8a8_cast(
+                entry, out_dir / comp,
+                shard_prefix=_group_shard_prefix(entry),
+                shard_threshold=shard_threshold,
+            )
+            if not int(result["converted_count"]):
+                raise ConversionImplementationError(
+                    f"no w8a8-eligible weights in component {comp!r} "
+                    "(nothing 2-D/16-aligned under a repeated-block "
+                    "container missed the skip patterns)")
+            quantized_components.append(comp)
+        else:
+            result = streaming_fp8_te_cast(
+                entry, out_dir / comp,
+                castable_keys=te_fp8_castable_keys(source_dir / comp),
+                shard_prefix=_group_shard_prefix(entry),
+                shard_threshold=shard_threshold,
+            )
+        tensor_count += int(result["tensor_count"])
+        converted += int(result["converted_count"])
+        done.add(comp)
+    copy_non_weight_files(source_dir, out_dir, skip_components=done)
+    for comp in quantized_components:
+        src_cfg = source_dir / comp / "config.json"
+        cfg = json.loads(src_cfg.read_text("utf-8")) if src_cfg.exists() else {}
+        cfg["quantization_config"] = {
+            "quant_method": "modelopt", "quant_algo": "FP8"}
+        dst_cfg = out_dir / comp / "config.json"
+        if dst_cfg.exists():
+            dst_cfg.unlink()  # hardlinked to the source — never write through
+        dst_cfg.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return {"tensor_count": tensor_count, "converted_count": converted,
+            "components": sorted(done), "output_dir": out_dir}
+
+
+def verify_w8a8_snapshot(
+    source_dir: Path,
+    out_dir: Path,
+    *,
+    sample: int = 16,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Byte-gate a produced w8a8 tree against its source (gw#557 / ie#494).
+
+    Detection runs through the CONSUMER's own sniffer
+    (:func:`gen_worker.models.w8a8.detect_w8a8_artifact`), then for a
+    deterministic sample of quantized layers: (a) the recomputed
+    quant+scale bytes must be EXACTLY the artifact's (the recipe is
+    deterministic — any drift is corruption or a recipe change), and
+    (b) ``dequant(w_fp8 x scale)`` must sit within fp8-e4m3 format error of
+    the source (max row-relative error <= 2**-4 + subnormal floor).
+    Raises :class:`ConversionImplementationError` on any failure; returns a
+    report dict for produce logs."""
+    import random
+
+    import torch
+    from safetensors import safe_open
+
+    from gen_worker.models.w8a8 import detect_w8a8_artifact
+
+    source_dir, out_dir = Path(source_dir), Path(out_dir)
+    art = detect_w8a8_artifact(out_dir)
+    if art is None:
+        raise ConversionImplementationError(
+            f"byte-gate: {out_dir} does not detect as a w8a8 artifact")
+
+    def _tensor_map(files: list[Path]) -> dict[str, Path]:
+        where: dict[str, Path] = {}
+        for f in files:
+            with safe_open(str(f), framework="pt", device="cpu") as fh:
+                for k in fh.keys():
+                    where[k] = f
+        return where
+
+    out_where = _tensor_map(list(art.files))
+    src_where = _tensor_map(sorted(
+        p for p in (source_dir / art.component).glob("*.safetensors")
+        if p.is_file()))
+
+    names = list(art.quantized)
+    rng = random.Random(seed)
+    picked = names if len(names) <= sample else sorted(rng.sample(names, sample))
+    max_rel = 0.0
+    for layer in picked:
+        wname, sname = f"{layer}.weight", f"{layer}{_SCALE_SUFFIX}"
+        src_file = src_where.get(wname)
+        if src_file is None:
+            raise ConversionImplementationError(
+                f"byte-gate: quantized layer {wname!r} missing from source")
+        with safe_open(str(src_file), framework="pt", device="cpu") as fh:
+            src = fh.get_tensor(wname).float()
+        with safe_open(str(out_where[wname]), framework="pt", device="cpu") as fh:
+            got_q = fh.get_tensor(wname)
+        with safe_open(str(out_where[sname]), framework="pt", device="cpu") as fh:
+            got_s = fh.get_tensor(sname).float()
+        scale = (src.abs().amax(dim=1, keepdim=True)
+                 / _FP8_E4M3_MAX).clamp(min=1e-12)
+        want_q = (src / scale).clamp(
+            -_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+        if not torch.equal(want_q.view(torch.uint8), got_q.view(torch.uint8)):
+            raise ConversionImplementationError(
+                f"byte-gate: {wname} recomputed fp8 bytes differ from artifact")
+        if not torch.equal(scale.reshape(-1), got_s.reshape(-1)):
+            raise ConversionImplementationError(
+                f"byte-gate: {sname} recomputed scales differ from artifact")
+        deq = got_q.float() * got_s.reshape(-1, 1)
+        row_amax = src.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
+        rel = ((deq - src).abs() / row_amax).max().item()
+        # e4m3 half-ulp relative error at worst 2**-4 for normals, plus the
+        # subnormal quantization floor for near-zero elements.
+        if rel > 2 ** -4 + 2 ** -9:
+            raise ConversionImplementationError(
+                f"byte-gate: {wname} dequant error {rel:.5f} exceeds the "
+                "fp8-e4m3 format bound")
+        max_rel = max(max_rel, rel)
+    return {
+        "component": art.component,
+        "quantized_total": len(names),
+        "sampled": len(picked),
+        "byte_exact": True,
+        "max_rel_err": max_rel,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Raw byte-offset re-shard (no tensor decode)
 # ---------------------------------------------------------------------------
@@ -1143,6 +1484,12 @@ __all__ = [
     "streaming_fp8_storage_cast",
     "streaming_cast_snapshot",
     "streaming_fp8_snapshot",
+    "W8A8_QUANT_SCHEME",
+    "W8A8_SKIP_TENSOR_PATTERNS",
+    "w8a8_cast_eligible",
+    "streaming_w8a8_cast",
+    "streaming_w8a8_snapshot",
+    "verify_w8a8_snapshot",
     "snapshot_weight_groups",
     "copy_non_weight_files",
     "fp8_cast_eligible",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -339,12 +339,16 @@ def _fp8_block_windows_whole(mod: Any) -> List[tuple[str, Any, List[Any]]]:
 
 
 def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
-                      text_encoders: bool = False) -> bool:
+                      text_encoders: bool = False,
+                      components: Optional[tuple[str, ...]] = None) -> bool:
     """fp8-E4M3 weight storage with per-layer upcast to ``compute_dtype``
     (diffusers layerwise casting) on a pipeline's denoiser — or on ``obj``
     itself when it is a bare module (th#546 two-format policy).
     ``text_encoders=True`` (the ``storage_dtype="fp8+te"`` rung) extends the
     cast to the pipeline's text encoders via the transformers-aware path.
+    ``components`` overrides the target component names entirely (gw#557:
+    the w8a8 lane casts ONLY the text encoders — its denoiser holds fp8
+    scaled-mm modules that cast hooks must never touch).
 
     This is the universal VRAM-fit mechanism: fp8 bytes resident, bf16/fp16
     compute, no fp8 silicon required. Also the consumption path for stored
@@ -363,9 +367,10 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
     if compute_dtype is None:
         compute_dtype = torch.bfloat16
 
-    components = _FP8_STORAGE_COMPONENTS
-    if text_encoders:
-        components += _FP8_TEXT_ENCODER_COMPONENTS
+    if components is None:
+        components = _FP8_STORAGE_COMPONENTS
+        if text_encoders:
+            components += _FP8_TEXT_ENCODER_COMPONENTS
     targets: List[tuple[str, Any]] = []
     for name in components:
         mod = getattr(obj, name, None)
@@ -1161,6 +1166,7 @@ def load_from_pretrained(
         return load_w8a8_pipeline(
             cls, Path(path), w8a8_art, compute_dtype=compute,
             components=components,
+            fp8_text_encoders=storage_dtype == "fp8+te",
         )
     gguf_art = detect_gguf_snapshot(Path(path))
     if gguf_art is not None and callable(getattr(cls, "from_pretrained", None)):

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -346,11 +346,15 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
 
 def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
                        compute_dtype: Any = None,
-                       components: Optional[Dict[str, Any]] = None) -> Any:
+                       components: Optional[Dict[str, Any]] = None,
+                       fp8_text_encoders: bool = False) -> Any:
     """Build the pipeline with the w8a8 denoiser wired in (svdq-style
     component injection). Stamps ``_cozy_weight_lane`` ("w8a8" on the
     scaled_mm lane, "bf16-resident" on the dequant lane) — the compile-cache
-    graph key (lane_drift, gw#534)."""
+    graph key (lane_drift, gw#534). ``fp8_text_encoders`` (the
+    ``storage_dtype="fp8+te"`` binding, gw#557) arms the gw#460 block-window
+    fp8 storage on the TEXT ENCODERS ONLY — the denoiser already holds fp8
+    scaled-mm modules that cast hooks must never touch."""
     import torch
 
     compute = compute_dtype or torch.bfloat16
@@ -364,6 +368,18 @@ def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
         pipe._cozy_weight_lane = "w8a8" if mode == "scaled_mm" else "bf16-resident"
     except Exception:
         pass
+    if fp8_text_encoders:
+        from .loading import _FP8_TEXT_ENCODER_COMPONENTS, apply_fp8_storage
+
+        targets = tuple(
+            n for n in _FP8_TEXT_ENCODER_COMPONENTS
+            if hasattr(getattr(pipe, n, None), "parameters"))
+        if targets:
+            apply_fp8_storage(pipe, compute_dtype=compute, components=targets)
+        else:
+            logger.warning(
+                "w8a8: storage_dtype=fp8+te requested but %s has no text "
+                "encoders; serving without TE windows", type(pipe).__name__)
     return pipe
 
 

--- a/tests/test_w8a8_produce.py
+++ b/tests/test_w8a8_produce.py
@@ -1,0 +1,340 @@
+"""gw#557 / ie#494: streaming per-channel-scaled w8a8 producer + byte-gate.
+
+Contract under test: ``streaming_w8a8_snapshot`` requantizes ONLY
+repeated-block denoiser Linears from the bf16 source into fp8-E4M3 weights
+with per-output-channel ``weight_scale`` twins (the gw#534 artifact the
+loader detects by scales presence), leaves everything else at source
+precision, and ``verify_w8a8_snapshot`` byte-gates the result. Plus the
+w8a8-lane fp8+te TE wiring and the gw#547 LoRA-branch composability
+assertion, all CPU-safe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker.convert.writer import (  # noqa: E402
+    ConversionImplementationError,
+    W8A8_QUANT_SCHEME,
+    W8A8_SKIP_TENSOR_PATTERNS,
+    streaming_w8a8_cast,
+    streaming_w8a8_snapshot,
+    verify_w8a8_snapshot,
+    w8a8_cast_eligible,
+)
+from gen_worker.models import w8a8  # noqa: E402
+from gen_worker.models.w8a8 import (  # noqa: E402
+    W8A8_FLAVOR,
+    detect_w8a8_artifact,
+    fp8_scaled_linear_class,
+    load_w8a8_denoiser,
+)
+
+
+def test_flavor_constants_do_not_drift() -> None:
+    assert W8A8_QUANT_SCHEME == W8A8_FLAVOR
+    assert "gate_logits" in W8A8_SKIP_TENSOR_PATTERNS
+
+
+@pytest.mark.parametrize(
+    ("name", "st", "shape", "want"),
+    [
+        # the flip list: block Linears, 16-aligned, float
+        ("transformer_blocks.0.attn1.to_q.weight", "BF16", [32, 32], True),
+        ("transformer_blocks.47.audio_ff.net.2.weight", "F32", [64, 256], True),
+        # the probe's explicit skip: gate logits stay full precision
+        ("transformer_blocks.3.attn1.to_gate_logits.weight", "BF16", [32, 32], False),
+        # outside a repeated-block container
+        ("proj_in.weight", "BF16", [32, 32], False),
+        ("caption_projection.linear_1.weight", "BF16", [64, 64], False),
+        # misaligned dims / not 2-D / not a .weight / norms / already fp8
+        ("transformer_blocks.0.ff.net.0.proj.weight", "BF16", [30, 32], False),
+        ("transformer_blocks.0.norm1.weight", "BF16", [32], False),
+        ("transformer_blocks.0.scale_shift_table", "BF16", [6, 32], False),
+        ("transformer_blocks.0.norm_out.weight", "BF16", [32, 32], False),
+        ("transformer_blocks.0.attn1.to_q.weight", "F8_E4M3", [32, 32], False),
+    ],
+)
+def test_w8a8_cast_eligibility(name: str, st: str, shape: list, want: bool) -> None:
+    assert w8a8_cast_eligible(name, st, shape) is want
+
+
+# ---------------------------------------------------------------------------
+# Streaming snapshot on a REAL tiny DiT (Transformer2DModel: transformer_blocks
+# with 16-aligned Linears — the LTX shape class at toy size).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_dit(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import Transformer2DModel
+
+    root = tmp_path_factory.mktemp("w8a8p") / "src"
+    model = Transformer2DModel(
+        num_attention_heads=2, attention_head_dim=8, in_channels=4,
+        num_layers=2, sample_size=8, norm_num_groups=4,
+    ).to(torch.bfloat16)
+    model.save_pretrained(str(root / "transformer"), safe_serialization=True)
+    (root / "scheduler").mkdir(parents=True)
+    (root / "scheduler" / "scheduler_config.json").write_text("{}")
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "DiTPipeline",
+        "_diffusers_version": "0.39.0",
+        "transformer": ["diffusers", "Transformer2DModel"],
+        "scheduler": ["diffusers", "DDIMScheduler"],
+    }))
+    return root
+
+
+def _expected_quantized(root: Path) -> set[str]:
+    """The spec: every 16-aligned nn.Linear inside transformer_blocks."""
+    import torch.nn as nn
+
+    from diffusers import Transformer2DModel
+
+    model = Transformer2DModel.from_pretrained(str(root / "transformer"))
+    want: set[str] = set()
+    for bi, block in enumerate(model.transformer_blocks):
+        for name, mod in block.named_modules():
+            if (isinstance(mod, nn.Linear)
+                    and mod.in_features % 16 == 0
+                    and mod.out_features % 16 == 0):
+                want.add(f"transformer_blocks.{bi}.{name}")
+    assert want, "fixture must have eligible block Linears"
+    return want
+
+
+def _load_all(component_dir: Path) -> dict[str, "torch.Tensor"]:
+    from safetensors import safe_open
+
+    out: dict[str, torch.Tensor] = {}
+    for f in sorted(component_dir.glob("*.safetensors")):
+        with safe_open(str(f), framework="pt") as fh:
+            for k in fh.keys():
+                out[k] = fh.get_tensor(k)
+    return out
+
+
+@pytest.fixture(scope="module")
+def produced(tiny_dit: Path) -> Path:
+    out = tiny_dit.parent / "w8a8"
+    result = streaming_w8a8_snapshot(tiny_dit, out, file_layout="diffusers")
+    assert result["converted_count"] > 0
+    return out
+
+
+def test_snapshot_quantizes_exactly_the_block_linears(
+    tiny_dit: Path, produced: Path,
+) -> None:
+    art = detect_w8a8_artifact(produced)
+    assert art is not None
+    assert art.component == "transformer"
+    assert not art.static_input_scales  # dynamic activation scales only
+    assert set(art.quantized) == _expected_quantized(tiny_dit)
+
+    src = _load_all(tiny_dit / "transformer")
+    got = _load_all(produced / "transformer")
+    for name in art.quantized:
+        w, s = got[f"{name}.weight"], got[f"{name}.weight_scale"]
+        assert w.dtype == torch.float8_e4m3fn
+        assert s.dtype == torch.float32 and s.shape == (w.shape[0],)
+    # every non-quantized tensor passes through byte-identically
+    quantized_weights = {f"{n}.weight" for n in art.quantized}
+    for name, t in src.items():
+        if name in quantized_weights:
+            continue
+        assert torch.equal(t, got[name]), name
+    assert set(got) == set(src) | {f"{n}.weight_scale" for n in art.quantized}
+
+
+def test_snapshot_stamps_config_without_touching_source(
+    tiny_dit: Path, produced: Path,
+) -> None:
+    out_cfg = json.loads((produced / "transformer" / "config.json").read_text())
+    assert out_cfg["quantization_config"]["quant_algo"] == "FP8"
+    src_cfg = json.loads((tiny_dit / "transformer" / "config.json").read_text())
+    assert "quantization_config" not in src_cfg  # hardlink never written through
+    # passthrough files intact
+    assert (produced / "scheduler" / "scheduler_config.json").exists()
+    assert (produced / "model_index.json").exists()
+
+
+def test_snapshot_refuses_requantizing_w8a8_source(produced: Path, tmp_path: Path) -> None:
+    with pytest.raises(ConversionImplementationError, match="re-quantize"):
+        streaming_w8a8_snapshot(produced, tmp_path / "again", file_layout="diffusers")
+
+
+def test_byte_gate_passes_then_catches_tampering(
+    tiny_dit: Path, produced: Path, tmp_path: Path,
+) -> None:
+    report = verify_w8a8_snapshot(tiny_dit, produced, sample=4)
+    assert report["byte_exact"] and report["sampled"] == 4
+    assert report["max_rel_err"] <= 2 ** -4 + 2 ** -9
+
+    import shutil
+
+    from safetensors.torch import save_file
+
+    bad = tmp_path / "tampered"
+    shutil.copytree(produced, bad)
+    f = sorted((bad / "transformer").glob("*.safetensors"))[0]
+    tensors = _load_all(bad / "transformer")
+    art = detect_w8a8_artifact(produced)
+    assert art is not None
+    scale_name = f"{art.quantized[0]}.weight_scale"
+    tensors[scale_name] = tensors[scale_name] * 2.0
+    for extra in sorted((bad / "transformer").glob("*.safetensors"))[1:]:
+        extra.unlink()
+    f.unlink()
+    save_file(tensors, str(f))
+    with pytest.raises(ConversionImplementationError, match="byte-gate"):
+        verify_w8a8_snapshot(tiny_dit, bad, sample=len(art.quantized))
+
+
+def test_dequant_round_trip_reproduces_source(tiny_dit: Path, produced: Path) -> None:
+    art = detect_w8a8_artifact(produced)
+    assert art is not None
+    model = load_w8a8_denoiser(produced, art, mode="dequant",
+                               compute_dtype=torch.bfloat16)
+    src = _load_all(tiny_dit / "transformer")
+    got = dict(model.state_dict())
+    for name in art.quantized:
+        a = src[f"{name}.weight"].float()
+        b = got[f"{name}.weight"].float()
+        rel = ((a - b).abs() / a.abs().clamp(min=1e-3)).max().item()
+        assert rel < 0.13, name  # e4m3 rounding
+        assert got[f"{name}.weight"].dtype == torch.bfloat16
+
+
+def test_streaming_shards_keep_scale_with_weight(tiny_dit: Path, tmp_path: Path) -> None:
+    """Force multi-shard output: every weight_scale must land (possibly in a
+    later shard) and the index must resolve."""
+    entry = sorted((tiny_dit / "transformer").glob("*.safetensors"))[0]
+    out = tmp_path / "sharded"
+    result = streaming_w8a8_cast(entry, out, shard_threshold=4096)
+    assert len(result["output_paths"]) > 1
+    assert result["index_path"] is not None
+    tensors = _load_all(out)
+    scales = {k for k in tensors if k.endswith(".weight_scale")}
+    assert len(scales) == result["converted_count"] > 0
+    for s in scales:
+        w = tensors[s[: -len(".weight_scale")] + ".weight"]
+        assert w.dtype == torch.float8_e4m3fn
+        assert tensors[s].shape == (w.shape[0],)
+
+
+# ---------------------------------------------------------------------------
+# ie#494(c): LoRA composability — a wrapped Linear carries the additive bf16
+# low-rank branch without breaking the scaled path (gw#547 consumes this).
+# CPU-safe: torch._scaled_mm is patched with its dequant reference.
+# ---------------------------------------------------------------------------
+
+
+def test_wrapped_linear_carries_additive_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _ref_scaled_mm(a, b, *, scale_a, scale_b, bias=None, out_dtype=None):
+        y = (a.float() * scale_a) @ (b.float() * scale_b)
+        if bias is not None:
+            y = y + bias.float()
+        return y.to(out_dtype or torch.float32)
+
+    monkeypatch.setattr(torch, "_scaled_mm", _ref_scaled_mm)
+    torch.manual_seed(7)
+    K, N, rank = 32, 48, 4
+    lin_cls = fp8_scaled_linear_class()
+    mod = lin_cls(K, N, bias=True, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    w = torch.randn(N, K)
+    scale = (w.abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    mod.load_state_dict({
+        "weight": (w / scale).clamp(-448, 448).to(torch.float8_e4m3fn),
+        "weight_scale": scale,
+        "bias": torch.randn(N, dtype=torch.bfloat16),
+    }, assign=True)
+
+    x = torch.randn(3, K, dtype=torch.bfloat16)
+    base = mod(x)
+
+    a = torch.randn(rank, K, dtype=torch.bfloat16)
+    b = torch.randn(N, rank, dtype=torch.bfloat16)
+    mod.lora_a, mod.lora_b = a, b
+    with_branch = mod(x)
+    addend = (x.reshape(-1, K) @ a.t()) @ b.t()
+    assert torch.allclose(with_branch, base + addend, atol=2e-2, rtol=2e-2)
+
+    # branch removal restores the branchless scaled path bit-exactly
+    mod.lora_a = mod.lora_b = None
+    assert torch.equal(mod(x), base)
+
+
+# ---------------------------------------------------------------------------
+# gw#557 TE wiring: storage_dtype="fp8+te" on the w8a8 lane casts ONLY the
+# text encoders; the scaled-mm denoiser is never touched by cast hooks.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_fp8_storage_component_override_scopes_to_te() -> None:
+    transformers = pytest.importorskip("transformers")
+
+    from gen_worker.models.loading import apply_fp8_storage
+
+    cfg = transformers.T5Config(
+        d_model=32, d_ff=64, d_kv=8, num_heads=4,
+        num_layers=1, vocab_size=64, decoder_start_token_id=0,
+    )
+    te = transformers.T5EncoderModel(cfg).to(torch.bfloat16)
+    denoiser = torch.nn.Linear(8, 8)
+    pipe = SimpleNamespace(text_encoder=te, transformer=denoiser)
+
+    assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16,
+                             components=("text_encoder",)) is True
+    assert te._cozy_fp8_storage_applied is True
+    assert any(p.dtype == torch.float8_e4m3fn for p in te.parameters())
+    assert not getattr(denoiser, "_cozy_fp8_storage_applied", False)
+    assert all(p.dtype != torch.float8_e4m3fn for p in denoiser.parameters())
+
+
+def test_load_from_pretrained_threads_te_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.models import loading
+
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    tree = w8a8.quantize_tree_w8a8(root, tmp_path / "w8a8")
+
+    seen: dict = {}
+    real = w8a8.load_w8a8_pipeline
+
+    def spy(cls, path, art, **kwargs):
+        seen.update(kwargs)
+        return real(cls, path, art, **kwargs)
+
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "load_w8a8_pipeline", spy)
+    pipe = loading.load_from_pretrained(DDPMPipeline, tree, storage_dtype="fp8+te")
+    assert seen.get("fp8_text_encoders") is True
+    # no TEs on this pipeline: loud warning path, lane still stamped
+    assert pipe._cozy_weight_lane == "bf16-resident"
+
+    seen.clear()
+    loading.load_from_pretrained(DDPMPipeline, tree)
+    assert seen.get("fp8_text_encoders") is False

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
ie#494's GO verdict (compiled W8A8-pcs fastest on both SKUs) productization, gen-worker side:

- **convert.writer**: `streaming_w8a8_cast` / `streaming_w8a8_snapshot` — data-free per-output-channel requant of repeated-block denoiser Linears from the bf16 source into the frozen gw#534 `#fp8-w8a8` artifact contract (fp8-E4M3 `weight` + F32 `[out]` `weight_scale` twins; DYNAMIC activation scales at serve time — no calibration, per the quantization-policy ruling). Blocks-only scope + gate-logits skip + 16-alignment = the ie#494 probe's 1344-flip/288-skip spec. Streaming two-pass (te#81 pattern): the model is never materialized; peak RAM ~ largest tensor.
- **convert.writer**: `verify_w8a8_snapshot` byte-gate — detection through the consumer's own `detect_w8a8_artifact`, sampled recompute-EXACT quant+scale bytes, dequant(w×scale) within the fp8-e4m3 format error bound.
- **models.w8a8**: `load_w8a8_pipeline(fp8_text_encoders=)` — `storage_dtype="fp8+te"` now arms the gw#460 TE block windows on the w8a8 lane via a new TE-only `components=` scope on `apply_fp8_storage`; the scaled-mm denoiser is never touched by cast hooks. `load_from_pretrained` threads the flag.
- **tests** (CPU-safe): producer round-trip on a real tiny DiT, eligibility spec table, cross-shard scale placement, byte-gate tamper catch, ie#494(c) LoRA additive-branch composability on a wrapped Linear, TE wiring.

Consumer already in place (gw#534/gw#547): detection by scale twins, fail-closed `scaled_mm_supported` probe → dequant lane, compile-cell `-w8a8` lane label, LoRA bf16 side-branch.

Consumers next: te#85 (conversion `w8a8`/`w8a8+te` produce mode), ie#495 (LTX flavor + staging proof; prod flip gated on gw#556).

## Testing
- `pytest tests/` 1247 passed, 33 skipped (full suite, locked venv, py3.12)
- `mypy src/gen_worker` clean; `ruff check` clean