### PR TITLE
worker: add endpoint-isolated shared CAS tier

### DIFF
--- a/src/gen_worker/models/cache_paths.py
+++ b/src/gen_worker/models/cache_paths.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from ..config import get_settings
 
 
 TENSORHUB_CACHE_DIR = "/tmp/tensorhub-cache"
+
+# RunPod network volumes are attached at pod creation. Tensorhub reserves this
+# mount solely for an endpoint-owned immutable CAS tier; ordinary pod volumes
+# continue using their existing path. This is a provider contract, not an
+# operator-tunable cache knob.
+ENDPOINT_SHARED_CACHE_MOUNT = Path("/tensorhub-endpoint-cache")
 
 
 def tensorhub_cache_dir() -> Path:
@@ -25,3 +32,14 @@ def tensorhub_cache_dir() -> Path:
 def tensorhub_cas_dir() -> Path:
     """Worker CAS root: <TENSORHUB_CACHE_DIR>/cas."""
     return tensorhub_cache_dir() / "cas"
+
+
+def endpoint_shared_cas_dir() -> Path | None:
+    """Return the endpoint-owned shared CAS only when it is really mounted.
+
+    A plain directory in an image or on the container disk must never be
+    mistaken for the endpoint-isolated provider volume.
+    """
+    if os.path.ismount(ENDPOINT_SHARED_CACHE_MOUNT):
+        return ENDPOINT_SHARED_CACHE_MOUNT / "tensorhub-cas-v1"
+    return None

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -8,11 +8,13 @@ import os
 import re
 import shutil
 import threading
+import time
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 
-from .cozy_cas import _download_one_file as _download_one_file
-from .cozy_cas import _norm_rel_path
+from .cozy_cas import _blake3_file, _download_one_file as _download_one_file
+from .cozy_cas import _norm_rel_path, fsync_dir, fsync_file
 from .download import components_present, select_component_paths
 from .hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
 from .refs import TensorhubRef
@@ -195,6 +197,7 @@ class CozySnapshotDownloader:
         base_dir: Path,
         ref: TensorhubRef,
         *,
+        shared_base_dir: Optional[Path] = None,
         resolved: Optional[WorkerResolvedRepo],
         progress: Optional[ProgressFn] = None,
         components: Sequence[str] = (),
@@ -246,7 +249,17 @@ class CozySnapshotDownloader:
 
         try:
             _log.info("snapshot_build_start key=%s files=%d", key[:24], len(res.files))
-            await self._ensure_blobs(blobs_root, res.files, progress=progress)
+            shared_blobs_root = None
+            if shared_base_dir is not None:
+                candidate = Path(shared_base_dir) / "blobs"
+                if candidate.resolve() != blobs_root.resolve():
+                    shared_blobs_root = candidate
+            await self._ensure_blobs(
+                blobs_root,
+                res.files,
+                shared_blobs_root=shared_blobs_root,
+                progress=progress,
+            )
             # Materialization copies/concatenates multi-GB trees — strictly
             # off the event loop (gw#407: a loop blocked for the duration of
             # a snapshot build cannot answer the hub; under page-cache
@@ -310,6 +323,7 @@ class CozySnapshotDownloader:
         blobs_root: Path,
         files: List[WorkerResolvedRepoFile],
         *,
+        shared_blobs_root: Optional[Path] = None,
         progress: Optional[ProgressFn] = None,
     ) -> None:
         # Deduplicate by digest — same blob referenced by multiple paths (e.g.
@@ -377,7 +391,28 @@ class CozySnapshotDownloader:
                     _log.info("blob_shared_inflight path=%s digest=%s (sibling ref downloaded it)",
                               f.path, digest[:16])
                     return
+                if shared_blobs_root is not None:
+                    shared = _blob_path(shared_blobs_root, digest)
+                    started = time.monotonic()
+                    if await asyncio.to_thread(self._copy_verified_blob, shared, dst, f):
+                        _on_bytes(int(f.size_bytes or 0))
+                        _log.info(
+                            "blob_cache_hit source=endpoint_volume digest=%s bytes=%d transfer_ms=%d",
+                            digest[:16], int(f.size_bytes or 0),
+                            int((time.monotonic() - started) * 1000),
+                        )
+                        return
+                    _log.info("blob_cache_miss source=endpoint_volume digest=%s", digest[:16])
                 await _dl_locked(f, digest, dst)
+                if shared_blobs_root is not None:
+                    shared = _blob_path(shared_blobs_root, digest)
+                    published = await asyncio.to_thread(
+                        self._copy_verified_blob, dst, shared, f
+                    )
+                    _log.info(
+                        "blob_cache_publish source=public destination=endpoint_volume digest=%s bytes=%d published=%s",
+                        digest[:16], int(f.size_bytes or 0), published,
+                    )
 
         async def _dl_locked(f: WorkerResolvedRepoFile, digest: str, dst: Path) -> None:
             async with sem:
@@ -409,6 +444,62 @@ class CozySnapshotDownloader:
                 _log.info("blob_download_done path=%s digest=%s", f.path, digest[:16])
 
         await asyncio.gather(*(_dl(f) for f in unique))
+
+    @staticmethod
+    def _copy_verified_blob(
+        src: Path, dst: Path, f: WorkerResolvedRepoFile,
+    ) -> bool:
+        """Copy one immutable blob through a writer-unique atomic stage.
+
+        The final path is digest-only. Readers never observe partial bytes;
+        racing writers may replace the same final name only after each has
+        independently verified the declared size and BLAKE3.
+        """
+        expected_size = int(f.size_bytes or 0)
+        expected_digest = _strip_blake3_prefix(f.blake3)
+        try:
+            if not src.is_file():
+                return False
+            if expected_size and src.stat().st_size != expected_size:
+                _log.warning(
+                    "blob_cache_corrupt source=%s digest=%s reason=size expected=%d actual=%d",
+                    src, expected_digest[:16], expected_size, src.stat().st_size,
+                )
+                return False
+
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            tmp = dst.parent / (
+                f".{dst.name}.writer-{os.getpid()}-{threading.get_ident()}-{uuid.uuid4().hex}"
+            )
+            try:
+                with src.open("rb") as source, tmp.open("xb") as staged:
+                    shutil.copyfileobj(source, staged, length=4 * 1024 * 1024)
+                    staged.flush()
+                    os.fsync(staged.fileno())
+                if expected_size and tmp.stat().st_size != expected_size:
+                    _log.warning(
+                        "blob_cache_corrupt source=%s digest=%s reason=staged_size expected=%d actual=%d",
+                        src, expected_digest[:16], expected_size, tmp.stat().st_size,
+                    )
+                    return False
+                if expected_digest and _blake3_file(tmp).lower() != expected_digest.lower():
+                    _log.warning(
+                        "blob_cache_corrupt source=%s digest=%s reason=blake3",
+                        src, expected_digest[:16],
+                    )
+                    return False
+                os.replace(tmp, dst)
+                fsync_file(dst)
+                fsync_dir(dst.parent)
+                return True
+            finally:
+                tmp.unlink(missing_ok=True)
+        except OSError as exc:
+            _log.warning(
+                "blob_cache_copy_failed source=%s destination=%s digest=%s error=%s",
+                src, dst, expected_digest[:16], exc,
+            )
+            return False
 
     @staticmethod
     def _blob_usable(dst: Path, f: WorkerResolvedRepoFile) -> bool:
@@ -535,6 +626,7 @@ def delete_blobs(base_dir: Path, digests: Any) -> None:
 async def ensure_snapshot_async(
     *,
     base_dir: Path,
+    shared_base_dir: Optional[Path] = None,
     ref: TensorhubRef,
     resolved: Optional[WorkerResolvedRepo],
     progress: Optional[ProgressFn] = None,
@@ -542,5 +634,6 @@ async def ensure_snapshot_async(
 ) -> Path:
     dl = CozySnapshotDownloader()
     return await dl.ensure_snapshot(
-        base_dir, ref, resolved=resolved, progress=progress, components=components,
+        base_dir, ref, shared_base_dir=shared_base_dir,
+        resolved=resolved, progress=progress, components=components,
     )

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -29,7 +29,7 @@ from urllib.parse import parse_qs, urlparse
 
 from ..api.errors import ValidationError
 from ..config import get_settings
-from .cache_paths import tensorhub_cas_dir
+from .cache_paths import endpoint_shared_cas_dir, tensorhub_cas_dir
 from .refs import HuggingFaceRef, TensorhubRef, fold_ref, parse_model_ref
 
 if TYPE_CHECKING:
@@ -232,6 +232,7 @@ async def ensure_local(
 
         return await ensure_snapshot_async(
             base_dir=base,
+            shared_base_dir=endpoint_shared_cas_dir(),
             ref=_snapshot_ref(parsed, ref),
             resolved=snapshot,
             progress=progress,

--- a/tests/test_endpoint_shared_cas.py
+++ b/tests/test_endpoint_shared_cas.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
 from pathlib import Path
+from typing import Any
 
 from blake3 import blake3
 
@@ -34,6 +35,34 @@ def _resolved() -> WorkerResolvedRepo:
 
 def _blob(base: Path) -> Path:
     return base / "blobs" / "blake3" / _BLAKE3[:2] / _BLAKE3[2:4] / _BLAKE3
+
+
+def _copy_blob_process(
+    start: Any,
+    results: Any,
+    source: str,
+    destination: str,
+    size_bytes: int,
+    digest: str,
+) -> None:
+    """Run the production CAS publisher in an independently spawned process."""
+    if not start.wait(10):
+        results.put((False, "start barrier timed out"))
+        return
+    try:
+        copied = CozySnapshotDownloader._copy_verified_blob(
+            Path(source),
+            Path(destination),
+            WorkerResolvedRepoFile(
+                path="model.safetensors",
+                size_bytes=size_bytes,
+                blake3=digest,
+                url="https://tensorhub.invalid/authorized-blob",
+            ),
+        )
+        results.put((copied, ""))
+    except BaseException as exc:  # pragma: no cover - returned to the parent for diagnosis
+        results.put((False, repr(exc)))
 
 
 def test_shared_cache_is_enabled_only_for_real_provider_mount(monkeypatch) -> None:
@@ -114,21 +143,42 @@ def test_corrupt_endpoint_volume_blob_falls_back_and_atomically_repairs(
     assert not list(corrupt.parent.glob(f".{_BLAKE3}.writer-*"))
 
 
-def test_racing_writers_publish_only_complete_verified_blob(tmp_path: Path) -> None:
-    shared = _blob(tmp_path / "endpoint-volume")
-    sources = [tmp_path / "pod-a.blob", tmp_path / "pod-b.blob"]
+def test_spawned_process_writers_publish_only_complete_verified_blob(tmp_path: Path) -> None:
+    payload = _PAYLOAD * 128
+    digest = blake3(payload).hexdigest()
+    shared = (
+        tmp_path / "endpoint-volume" / "blobs" / "blake3" / digest[:2] / digest[2:4]
+        / digest
+    )
+    sources = [tmp_path / f"pod-{i}.blob" for i in range(4)]
     for source in sources:
-        source.write_bytes(_PAYLOAD)
-    file = _resolved().files[0]
+        source.write_bytes(payload)
 
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        results = list(pool.map(
-            lambda source: CozySnapshotDownloader._copy_verified_blob(
-                source, shared, file
-            ),
-            sources,
-        ))
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_copy_blob_process,
+            args=(start, results, str(source), str(shared), len(payload), digest),
+        )
+        for source in sources
+    ]
+    try:
+        for process in processes:
+            process.start()
+        start.set()
+        for process in processes:
+            process.join(20)
+        assert [process.exitcode for process in processes] == [0] * len(processes)
+        outcomes = [results.get(timeout=5) for _ in processes]
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(5)
+        results.close()
 
-    assert results == [True, True]
-    assert shared.read_bytes() == _PAYLOAD
-    assert not list(shared.parent.glob(f".{_BLAKE3}.writer-*"))
+    assert outcomes == [(True, "")] * len(processes)
+    assert shared.read_bytes() == payload
+    assert not list(shared.parent.glob(f".{digest}.writer-*"))

--- a/tests/test_endpoint_shared_cas.py
+++ b/tests/test_endpoint_shared_cas.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from blake3 import blake3
+
+import gen_worker.models.cozy_snapshot as snap_mod
+import gen_worker.models.cache_paths as cache_paths
+from gen_worker.models.cozy_snapshot import CozySnapshotDownloader, ensure_snapshot_async
+from gen_worker.models.hub_client import WorkerResolvedRepo, WorkerResolvedRepoFile
+from gen_worker.models.refs import TensorhubRef
+
+
+_PAYLOAD = b"endpoint-isolated-model-weights" * 1024
+_BLAKE3 = blake3(_PAYLOAD).hexdigest()
+_SNAPSHOT = "a5" * 32
+
+
+def _resolved() -> WorkerResolvedRepo:
+    return WorkerResolvedRepo(
+        snapshot_digest=_SNAPSHOT,
+        files=[
+            WorkerResolvedRepoFile(
+                path="model.safetensors",
+                size_bytes=len(_PAYLOAD),
+                blake3=_BLAKE3,
+                url="https://tensorhub.invalid/authorized-blob",
+            )
+        ],
+    )
+
+
+def _blob(base: Path) -> Path:
+    return base / "blobs" / "blake3" / _BLAKE3[:2] / _BLAKE3[2:4] / _BLAKE3
+
+
+def test_shared_cache_is_enabled_only_for_real_provider_mount(monkeypatch) -> None:
+    monkeypatch.setattr(cache_paths.os.path, "ismount", lambda _path: False)
+    assert cache_paths.endpoint_shared_cas_dir() is None
+
+    monkeypatch.setattr(cache_paths.os.path, "ismount", lambda path: path == cache_paths.ENDPOINT_SHARED_CACHE_MOUNT)
+    assert cache_paths.endpoint_shared_cas_dir() == (
+        cache_paths.ENDPOINT_SHARED_CACHE_MOUNT / "tensorhub-cas-v1"
+    )
+
+
+def test_second_pod_reuses_verified_endpoint_volume_without_public_get(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    calls = 0
+
+    async def _public_get(
+        _url: str, dst: Path, expected_size: int, expected_blake3: str,
+        on_bytes=None,
+    ) -> None:
+        del expected_size, expected_blake3
+        nonlocal calls
+        calls += 1
+        dst.write_bytes(_PAYLOAD)
+        if on_bytes is not None:
+            on_bytes(len(_PAYLOAD))
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _public_get)
+    ref = TensorhubRef(owner="org", repo="model")
+    shared = tmp_path / "endpoint-volume"
+
+    first = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path / "pod-a", shared_base_dir=shared,
+        ref=ref, resolved=_resolved(),
+    ))
+    assert (first / "model.safetensors").read_bytes() == _PAYLOAD
+    assert _blob(shared).read_bytes() == _PAYLOAD
+
+    second = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path / "pod-b", shared_base_dir=shared,
+        ref=ref, resolved=_resolved(),
+    ))
+    assert (second / "model.safetensors").read_bytes() == _PAYLOAD
+    assert calls == 1
+
+
+def test_corrupt_endpoint_volume_blob_falls_back_and_atomically_repairs(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    calls = 0
+
+    async def _public_get(
+        _url: str, dst: Path, expected_size: int, expected_blake3: str,
+        on_bytes=None,
+    ) -> None:
+        del expected_size, expected_blake3
+        nonlocal calls
+        calls += 1
+        dst.write_bytes(_PAYLOAD)
+        if on_bytes is not None:
+            on_bytes(len(_PAYLOAD))
+
+    monkeypatch.setattr(snap_mod, "_download_one_file", _public_get)
+    shared = tmp_path / "endpoint-volume"
+    corrupt = _blob(shared)
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_bytes(b"x" * len(_PAYLOAD))
+
+    out = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path / "pod", shared_base_dir=shared,
+        ref=TensorhubRef(owner="org", repo="model"), resolved=_resolved(),
+    ))
+
+    assert calls == 1
+    assert (out / "model.safetensors").read_bytes() == _PAYLOAD
+    assert corrupt.read_bytes() == _PAYLOAD
+    assert not list(corrupt.parent.glob(f".{_BLAKE3}.writer-*"))
+
+
+def test_racing_writers_publish_only_complete_verified_blob(tmp_path: Path) -> None:
+    shared = _blob(tmp_path / "endpoint-volume")
+    sources = [tmp_path / "pod-a.blob", tmp_path / "pod-b.blob"]
+    for source in sources:
+        source.write_bytes(_PAYLOAD)
+    file = _resolved().files[0]
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(
+            lambda source: CozySnapshotDownloader._copy_verified_blob(
+                source, shared, file
+            ),
+            sources,
+        ))
+
+    assert results == [True, True]
+    assert shared.read_bytes() == _PAYLOAD
+    assert not list(shared.parent.glob(f".{_BLAKE3}.writer-*"))


### PR DESCRIPTION
Implements the worker half of Tensorhub #850.

- detects the fixed endpoint cache mount only when it is a real filesystem mount
- checks worker-local CAS first, then endpoint-shared CAS, then the authorized Tensorhub object path
- validates size and BLAKE3 before publishing with writer-unique staging files, fsync, and atomic replacement
- repairs corrupt shared entries from the authorized source
- emits source/bytes/transfer timing cache telemetry
- adds no environment variables or alternate configuration layer
- replaces the thread-only race test with four independently spawned processes invoking the production CAS publisher against one destination

Rebased on current `origin/master` / python-gen-worker v0.32.1. No cloud resources were mutated.

Validation at signed head `a3894098e346a382ce2c095d900acad90c59eae6`:
- focused shared-CAS suite: 4 passed
- full `pytest tests/ -q`: PASS
- `mypy src/gen_worker`: zero errors in 122 source files
- `ruff check src/gen_worker tests/test_endpoint_shared_cas.py`: PASS
- `python scripts/lint_http_timeouts.py`: PASS
- `uv build`: wheel and sdist PASS
- GitHub CI `test`: PASS
- `git diff --check`: PASS

A fresh local `uv run --extra dev pytest` sync remains blocked before collection by the existing `torch==2.13.0+cu130` wheel hash mismatch. Local tests therefore used the repository virtual environment with this exact worktree forced through `PYTHONPATH`; clean GitHub CI independently passed the locked uv path.