### PR TITLE
ie#496: require exact Forge cells for W8A8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.32.1 (2026-07-16)
+
+- **ie#496: W8A8 production requires the exact compatible Forge cell.**
+  Workers select the family cell's `-w8a8` lane instead of the first attached
+  family artifact, and cell metadata binds the loaded module/tensor graph,
+  dynamic-scaled-mm/excluded-layer schema, shape table, GPU SM, CUDA driver,
+  compiler stack, and serving-image digest. The signature deliberately omits
+  checkpoint refs, digests, and tensor values, so graph-compatible SDXL, Pony,
+  and Illustrious weights share one cell. Missing/mismatched cells and runtime
+  graph failures are retryable lane failures; they never silently claim W8A8
+  while serving eager or dequantized compute.
+
 ## 0.32.0 (2026-07-16)
 
 - **gw#557 (ie#494 W8A8 productization core): streaming per-channel-scaled

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -33,7 +33,7 @@ this page covers the worker itself.
 | `WORKER_ID` | `worker_id` | per-pod identity |
 | `ENDPOINT_LOCK_PATH` | `endpoint_lock_path` | discovery manifest path (baked default in images) |
 | `RUNPOD_POD_ID` | `runpod_pod_id` | set by the RunPod runtime |
-| `WORKER_IMAGE_DIGEST` | `worker_image_digest` | provenance stamped by the image build — currently no launcher sets it (pgw#514/P4); kept for a future tensorhub stamp |
+| `WORKER_IMAGE_DIGEST` | `worker_image_digest` | immutable provenance stamped by Tensorhub from the selected release image variant |
 
 ## Tuning knobs (Settings fields)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.32.0"
+version = "0.32.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -8,9 +8,11 @@ inductor+triton cache dirs as a repo flavor; workers that opt in via
 ``@endpoint(compile=Compile(...))`` seed those dirs before load and hit the
 cache with no compiler and no stall.
 
-Policy: cache miss / key mismatch / no artifact => eager, never a boot stall
-or a runtime compile attempt in prod. The compile job itself opts into cold
-compilation with ``GEN_WORKER_COMPILE_ALLOW_COLD=1`` (requires a toolchain).
+Policy: cache miss / key mismatch / no artifact leaves ordinary lanes eager,
+never causing a boot stall or a runtime compile attempt in prod. A declared
+W8A8 lane instead fails retryably: eager/dequantized execution cannot claim
+W8A8. The compile job itself opts into cold compilation with
+``GEN_WORKER_COMPILE_ALLOW_COLD=1`` (requires a toolchain).
 
 Artifacts are FAMILY-keyed (settled 2026-07-06): torch.compile caches key on
 the traced graph + shapes, not the weights, so one artifact serves every
@@ -842,9 +844,10 @@ def apply(
     env var, read raw — not a Settings field, see ``prepare()``). Anything
     else is a logged no-op — eager, never a stall.
 
-    ``guard=True`` (consumer): a failing compiled call permanently unwraps to
-    eager. ``guard=False`` (compile job): failures must raise, a silently
-    eager warm-up would publish an empty artifact as success.
+    ``guard=True`` (consumer): a failing ordinary compiled call permanently
+    unwraps to eager; W8A8 fails closed. ``guard=False`` (compile job): all
+    failures raise, because a silently eager warm-up would publish an empty
+    artifact as success.
     """
     if getattr(pipeline, _MARKER_ATTR, None) is not None:
         return True

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -38,6 +38,7 @@ compiled from — informational, never part of the match.
 
 from __future__ import annotations
 
+import ctypes
 import functools
 import gzip
 import hashlib
@@ -52,6 +53,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
+from .api.errors import RetryableError
+
 logger = logging.getLogger(__name__)
 
 ENV_CACHE_PATH = "GEN_WORKER_COMPILE_CACHE"       # local artifact (tar) or seeded dir
@@ -59,8 +62,10 @@ ENV_CACHE_URL = "GEN_WORKER_COMPILE_CACHE_URL"    # http(s) URL to the artifact
 ENV_ALLOW_COLD = "GEN_WORKER_COMPILE_ALLOW_COLD"  # compile without an artifact (needs cc)
 
 METADATA_NAME = "metadata.json"
-# 2 (gw#391): key gained the producer gen-worker version; format-1 cells
-# (gw#384 era) demonstrably miss the FX-graph cache on current code.
+# 2 (gw#391): key gained the producer gen-worker version. ie#496 extends its
+# metadata with the canonical module graph, shape/target table and weight-lane
+# schema without gratuitously invalidating proven non-W8A8 cells. New W8A8
+# consumers require those fields; checkpoint bytes remain deliberately absent.
 ARTIFACT_FORMAT = 2
 _MARKER_ATTR = "_cozy_compile"
 _JUNK_SUFFIXES = (".lock", ".tmp", ".pid")
@@ -83,9 +88,25 @@ def sku_slug(gpu_name: str) -> str:
     return out
 
 
+def _cuda_driver_version() -> str:
+    """CUDA driver API version without shelling out to provider tooling."""
+    try:
+        lib = ctypes.CDLL("libcuda.so.1")
+        value = ctypes.c_int()
+        if lib.cuInit(0) != 0 or lib.cuDriverGetVersion(ctypes.byref(value)) != 0:
+            return ""
+        return str(int(value.value))
+    except Exception:
+        return ""
+
+
 def runtime_key() -> Dict[str, str]:
     """The consumer-side half of the cache key, probed from this process."""
-    key = {"sku": "", "torch": "", "triton": "", "cuda": ""}
+    key = {
+        "sku": "", "sm": "", "torch": "", "triton": "", "cuda": "",
+        "cuda_driver": "", "image_digest": os.environ.get(
+            "WORKER_IMAGE_DIGEST", "").strip(),
+    }
     try:
         import torch
 
@@ -93,6 +114,11 @@ def runtime_key() -> Dict[str, str]:
         key["cuda"] = str(torch.version.cuda or "")
         if torch.cuda.is_available():
             key["sku"] = sku_slug(torch.cuda.get_device_name(0))
+            major, minor = torch.cuda.get_device_capability(0)
+            key["sm"] = f"sm_{major}{minor}"
+            # CUDA's integer encoding (e.g. 13000), obtained from libcuda
+            # rather than provider-specific nvidia-smi output.
+            key["cuda_driver"] = _cuda_driver_version()
     except Exception:
         pass
     try:
@@ -168,6 +194,22 @@ def parse_cell_ref(ref: str) -> Tuple[str, str]:
     return th.repo[len("family-"):], th.flavor or ""
 
 
+def cell_lane(ref: str) -> str:
+    """The compiled weight-lane token encoded in a system-cell ref.
+
+    The flavor is human/routing metadata; artifact metadata remains the
+    authority. This narrow parser exists so a worker presented several cells
+    for one family tries the exact lane instead of whichever mapping entry
+    happened to arrive first (ie#496).
+    """
+    _family, flavor = parse_cell_ref(ref)
+    _prefix, sep, suffix = flavor.partition("-torch")
+    if not sep:
+        return ""
+    _version, sep, lane = suffix.partition("-")
+    return lane if sep else ""
+
+
 def family_from_ref(ref: str) -> str:
     """Family encoded in a compile-cache ref; '' when the ref is not a
     system-family cell ref."""
@@ -194,6 +236,8 @@ def artifact_metadata(
     storage_dtype: str = "",
     compile_mode: str = "whole",
     weight_lane: str = "",
+    graph_signature: str = "",
+    weight_contract: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
@@ -221,6 +265,8 @@ def artifact_metadata(
         "storage_dtype": str(storage_dtype or ""),
         "compile_mode": str(compile_mode or "whole"),
         "weight_lane": str(weight_lane or ""),
+        "graph_signature": str(graph_signature or ""),
+        "weight_contract": dict(weight_contract or {}),
         "libs": _lib_versions(),
     }
 
@@ -236,6 +282,13 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     for field in ("sku", "torch", "triton"):
         want, have = str(meta.get(field) or ""), here[field]
         if want != have:
+            return f"{field} {want!r} != runtime {have!r}"
+    # Extended runtime axes are exact when a cell records them. Old proven
+    # non-W8A8 format-2 cells remain usable; W8A8 requires every field in
+    # contract_drift below and therefore never gets this compatibility path.
+    for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+        want, have = str(meta.get(field) or ""), here[field]
+        if want and want != have:
             return f"{field} {want!r} != runtime {have!r}"
     want_gw, have_gw = str(meta.get("gen_worker") or ""), gen_worker_version()
     if want_gw != have_gw:
@@ -406,6 +459,10 @@ class AdoptError(RuntimeError):
         super().__init__(detail or reason)
 
 
+class CompiledLaneUnavailableError(RetryableError):
+    """A precision lane whose production contract requires a cell is unsafe."""
+
+
 def find_artifact(root: Path) -> Optional[Path]:
     """The compile-cache tarball inside a downloaded snapshot dir (or the
     file itself)."""
@@ -556,19 +613,169 @@ def _resolve_target(pipeline: Any, target: str) -> Optional[Tuple[Any, str, Call
     return None
 
 
-def _guarded(original: Callable[..., Any], compiled: Callable[..., Any], label: str) -> Callable[..., Any]:
-    """Never fail a request on compile problems: first error permanently
-    unwraps to eager (prod images can't compile uncached shapes)."""
-    state = {"failed": False}
+def _type_name(value: Any) -> str:
+    cls = type(value)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _direct_tensor_schema(module: Any) -> list[list[Any]]:
+    """Names/shapes/dtypes only; tensor values and checkpoint IDs stay out."""
+    rows: list[list[Any]] = []
+    for kind, method in (
+        ("parameter", getattr(module, "named_parameters", None)),
+        ("buffer", getattr(module, "named_buffers", None)),
+    ):
+        if not callable(method):
+            continue
+        try:
+            tensors = method(recurse=False)
+        except TypeError:
+            tensors = method()
+        for name, tensor in tensors:
+            rows.append([
+                kind, str(name), [int(v) for v in getattr(tensor, "shape", ())],
+                str(getattr(tensor, "dtype", "")),
+            ])
+    return sorted(rows)
+
+
+def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
+    """Canonical family-graph and weight-lane contract for one loaded model.
+
+    Fine-tunes with the same module graph produce the same result: no ref,
+    tag, source/checkpoint digest or tensor value is read. A structural
+    SDXL/Pony/Illustrious incompatibility (different module class/shape or
+    different scaled-mm exclusion surface) produces a different signature
+    and is rejected before adoption.
+    """
+    graph_targets: list[Dict[str, Any]] = []
+    quantized: list[Dict[str, Any]] = []
+    excluded: list[Dict[str, Any]] = []
+    seen_modules: set[int] = set()
+
+    for target in tuple(getattr(cfg, "targets", ()) or ()):
+        resolved = _resolve_target(pipeline, str(target))
+        if resolved is None:
+            graph_targets.append({"target": str(target), "missing": True})
+            continue
+        owner, attr, _fn = resolved
+        modules: list[Dict[str, Any]] = []
+        named = getattr(owner, "named_modules", None)
+        module_rows = list(named()) if callable(named) else [("", owner)]
+        for name, module in module_rows:
+            path = f"{target}:{name}" if name else str(target)
+            modules.append({
+                "path": path,
+                "type": _type_name(module),
+                "tensors": _direct_tensor_schema(module),
+            })
+            # A target such as vae.decode can overlap another declaration;
+            # record each module once in the W8A8 manifest.
+            if id(module) in seen_modules:
+                continue
+            seen_modules.add(id(module))
+            in_features = getattr(module, "in_features", None)
+            out_features = getattr(module, "out_features", None)
+            if not isinstance(in_features, int) or not isinstance(out_features, int):
+                continue
+            row = {
+                "path": path,
+                "in_features": int(in_features),
+                "out_features": int(out_features),
+            }
+            if bool(getattr(module, "_cozy_w8a8_linear", False)):
+                row["activation"] = (
+                    "static" if getattr(module, "input_scale", None) is not None
+                    else "dynamic-per-row"
+                )
+                quantized.append(row)
+            else:
+                row["type"] = _type_name(module)
+                excluded.append(row)
+        graph_targets.append({
+            "target": str(target), "attr": str(attr), "modules": modules,
+        })
+
+    graph = {
+        "pipeline": _type_name(pipeline),
+        "targets": graph_targets,
+    }
+    encoded = json.dumps(graph, sort_keys=True, separators=(",", ":")).encode()
+    from .models.loading import pipeline_weight_lane
+
+    lane = pipeline_weight_lane(pipeline)
+    weight_contract: Dict[str, Any] = {"lane": lane}
+    if lane.startswith("w8a8"):
+        activations = sorted({str(r["activation"]) for r in quantized})
+        weight_contract.update({
+            "artifact_schema": "fp8-w8a8-v1",
+            "operator": "torch._scaled_mm",
+            "weight_scaling": "per-output-channel",
+            "activation_scaling": activations,
+            "quantized": sorted(quantized, key=lambda r: str(r["path"])),
+            "excluded": sorted(excluded, key=lambda r: str(r["path"])),
+        })
+    return hashlib.sha256(encoded).hexdigest(), weight_contract
+
+
+def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
+    """Mismatch between the cell's declared graph and the loaded consumer."""
+    shapes = sorted(
+        [int(v) for v in row] for row in getattr(cfg, "shapes", ()))
+    cell_shapes = sorted(
+        [int(v) for v in row] for row in (meta.get("shapes") or ()))
+    if cell_shapes != shapes:
+        return f"shapes {cell_shapes!r} != declared {shapes!r}"
+    targets = [str(v) for v in getattr(cfg, "targets", ())]
+    if meta.get("targets") != targets:
+        return f"targets {meta.get('targets')!r} != declared {targets!r}"
+    signature, weight_contract = execution_contract(pipeline, cfg)
+    meta_signature = str(meta.get("graph_signature") or "")
+    meta_weights = meta.get("weight_contract") or {}
+    if not meta_signature and not meta_weights and not str(
+        weight_contract.get("lane") or ""
+    ).startswith("w8a8"):
+        return ""  # legacy format-2 non-W8A8 cell
+    if meta_signature != signature:
+        return "module graph signature mismatch"
+    if meta_weights != weight_contract:
+        return "weight-lane artifact schema/exclusion manifest mismatch"
+    if str(weight_contract.get("lane") or "").startswith("w8a8"):
+        activations = weight_contract.get("activation_scaling") or []
+        if activations != ["dynamic-per-row"]:
+            return f"W8A8 activation scaling must be dynamic-per-row, got {activations!r}"
+        if not weight_contract.get("quantized"):
+            return "W8A8 graph contains no torch._scaled_mm modules"
+        for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+            if not str(meta.get(field) or ""):
+                return f"W8A8 cell missing {field} identity"
+    return ""
+
+
+def _guarded(
+    original: Callable[..., Any], compiled: Callable[..., Any], label: str,
+    *, fail_closed: bool = False,
+) -> Callable[..., Any]:
+    """Guard a compiled call; W8A8 cannot silently become eager compute."""
+    state: Dict[str, Any] = {"failed": False, "detail": ""}
 
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if state["failed"]:
+            if fail_closed:
+                raise CompiledLaneUnavailableError(state["detail"])
             return original(*args, **kwargs)
         try:
             return compiled(*args, **kwargs)
         except Exception as exc:  # noqa: BLE001 — any compile failure => eager
             state["failed"] = True
+            state["detail"] = (
+                f"compiled W8A8 target {label} failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            if fail_closed:
+                logger.error("compile-cache: %s", state["detail"])
+                raise CompiledLaneUnavailableError(state["detail"]) from exc
             logger.warning(
                 "compile-cache: compiled %s failed (%s: %s); eager for the rest "
                 "of this process", label, type(exc).__name__, exc,
@@ -585,10 +792,12 @@ def _clear_regional(mod: Any) -> None:
             m._compiled_call_impl = None
 
 
-def _guarded_regional(mod: Any, original: Callable[..., Any], label: str) -> Callable[..., Any]:
+def _guarded_regional(
+    mod: Any, original: Callable[..., Any], label: str, *, fail_closed: bool = False,
+) -> Callable[..., Any]:
     """Regional analogue of :func:`_guarded`: blocks are compiled in place,
     so eager fallback must first CLEAR the block compilations, then retry."""
-    state = {"failed": False}
+    state: Dict[str, Any] = {"failed": False, "detail": ""}
 
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -597,11 +806,21 @@ def _guarded_regional(mod: Any, original: Callable[..., Any], label: str) -> Cal
                 return original(*args, **kwargs)
             except Exception as exc:  # noqa: BLE001 — any compile failure => eager
                 state["failed"] = True
+                state["detail"] = (
+                    f"regional compiled W8A8 target {label} failed: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                if fail_closed:
+                    _clear_regional(mod)
+                    logger.error("compile-cache: %s", state["detail"])
+                    raise CompiledLaneUnavailableError(state["detail"]) from exc
                 logger.warning(
                     "compile-cache: regional-compiled %s failed (%s: %s); eager "
                     "for the rest of this process", label, type(exc).__name__, exc,
                 )
                 _clear_regional(mod)
+        if fail_closed:
+            raise CompiledLaneUnavailableError(state["detail"])
         return original(*args, **kwargs)
 
     return wrapper
@@ -666,6 +885,9 @@ def apply(
         logger.debug("compile-cache: could not raise recompile limit", exc_info=True)
 
     regional = bool(getattr(cfg, "regional", False))
+    from .models.loading import pipeline_weight_lane
+
+    fail_closed = pipeline_weight_lane(pipeline).startswith("w8a8")
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
     regional_mods: list[Any] = []
@@ -685,7 +907,8 @@ def apply(
             # place; the guard wrapper clears them on the first failure.
             owner.compile_repeated_blocks(dynamic=False)
             if guard:
-                setattr(owner, attr, _guarded_regional(owner, fn, target))
+                setattr(owner, attr, _guarded_regional(
+                    owner, fn, target, fail_closed=fail_closed))
                 originals.append((owner, attr, fn))
             regional_mods.append(owner)
             applied.append(target)
@@ -702,7 +925,8 @@ def apply(
             if vae is not None:
                 vae.to(memory_format=torch.channels_last)
         compiled = torch.compile(fn, dynamic=False)
-        setattr(owner, attr, _guarded(fn, compiled, target) if guard else compiled)
+        setattr(owner, attr, _guarded(
+            fn, compiled, target, fail_closed=fail_closed) if guard else compiled)
         applied.append(target)
         originals.append((owner, attr, fn))
     if not applied:
@@ -764,7 +988,11 @@ def enable(
         getattr(cfg, "family", "") or "", cache_dir=cache_dir, artifact=artifact
     )
     if meta is not None:
-        drift = mode_drift(meta, pipeline) or lane_drift(meta, pipeline)
+        drift = (
+            mode_drift(meta, pipeline)
+            or lane_drift(meta, pipeline)
+            or contract_drift(meta, pipeline, cfg)
+        )
         if drift:
             logger.warning("compile-cache: %s; staying eager", drift)
             meta = None
@@ -776,7 +1004,15 @@ def enable(
                 "compile-cache: cell compile_mode %r != declared %r; staying "
                 "eager (graphs would miss)", have, want)
             meta = None
-    return apply(pipeline, cfg, cache_ready=meta is not None)
+    armed = apply(pipeline, cfg, cache_ready=meta is not None)
+    from .models.loading import pipeline_weight_lane
+
+    if pipeline_weight_lane(pipeline).startswith("w8a8") and not armed:
+        raise CompiledLaneUnavailableError(
+            "W8A8 requires an exact compatible Forge cell; eager/dequantized "
+            "execution is not a W8A8 production lane"
+        )
+    return armed
 
 
 # ---------------------------------------------------------------------------
@@ -838,6 +1074,7 @@ def build(
     steps: int = 2,
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
     declared_vram_gb: float = 0.0,
+    serving_image_digest: str = "",
 ) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
     """Compile a diffusers pipeline over ``shapes`` and package the resulting
     inductor+triton caches as a per-SKU artifact.
@@ -916,6 +1153,7 @@ def build(
 
     from .models.loading import pipeline_weight_lane
 
+    graph_signature, weight_contract = execution_contract(pipe, cfg)
     meta = artifact_metadata(
         family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
@@ -925,7 +1163,15 @@ def build(
         # gw#534: the lane the pipeline ACTUALLY traced under — the loader may
         # have upgraded a requested fp8 cast to bf16-resident on this pod.
         weight_lane=pipeline_weight_lane(pipe),
+        graph_signature=graph_signature,
+        weight_contract=weight_contract,
     )
+    if serving_image_digest:
+        # The producer image contains a compiler; the graph is consumed by
+        # the endpoint's serving image. Tensorhub supplies that immutable OCI
+        # digest from the release, so it—not the producer container—is the
+        # identity the worker must match.
+        meta["image_digest"] = str(serving_image_digest).strip()
     label = flavor_label(meta["sku"], meta["torch"], meta.get("weight_lane", ""))
     artifact = pack(capture_root, out_dir / f"{label}.tar.gz", meta)
     return artifact, meta, timings
@@ -934,6 +1180,7 @@ def build(
 __all__ = [
     "ARTIFACT_FORMAT",
     "AdoptError",
+    "CompiledLaneUnavailableError",
     "build",
     "ENV_ALLOW_COLD",
     "ENV_CACHE_PATH",
@@ -941,8 +1188,11 @@ __all__ = [
     "apply",
     "artifact_metadata",
     "capture_env",
+    "cell_lane",
+    "contract_drift",
     "counters_delta",
     "enable",
+    "execution_contract",
     "family_from_ref",
     "parse_cell_ref",
     "find_artifact",

--- a/src/gen_worker/config/settings.py
+++ b/src/gen_worker/config/settings.py
@@ -51,12 +51,8 @@ class Settings(msgspec.Struct, frozen=True, kw_only=True):
     # Runtime introspection (set by the RunPod runtime; not configuration).
     runpod_pod_id: str = ""
 
-    # Provenance stamped into WorkerResources by the image build / launcher.
-    # TODO(pgw#514/P4): nothing produces WORKER_IMAGE_DIGEST today (verified
-    # against gen-orchestrator/tensorhub/e2e — no launcher sets it), so this
-    # is always "" in production and the Go scaling-profile key that reads
-    # it (profiles.go) always sees an empty digest. Kept because tensorhub
-    # may start stamping it at pod-launch time; drop if that never lands.
+    # Immutable image provenance stamped by Tensorhub from the release image
+    # variant it selected for this pod.
     worker_image_digest: str = ""  # WORKER_IMAGE_DIGEST
 
     # tensorhub access for standalone clients (run/serve/prefetch). Production

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2453,15 +2453,40 @@ class Executor:
         if spec.compile is None or not snapshots:
             return None
         from . import compile_cache, trt_engine
+        from .models.refs import parse_model_ref
 
         family = getattr(spec.compile, "family", "") or ""
-        candidates = [
-            (ref, snap) for ref, snap in snapshots.items()
-            if trt_engine.is_engine_ref(ref, family)
-        ] + [
-            (ref, snap) for ref, snap in snapshots.items()
-            if compile_cache.is_cache_ref(ref, family)
-        ]
+        model_refs = list(snapshots)
+        model_refs.extend(wire_ref(binding) for binding in spec.models.values())
+        wants_w8a8 = False
+        for model_ref in model_refs:
+            try:
+                parsed = parse_model_ref(model_ref).tensorhub
+            except ValueError:
+                continue
+            if (
+                parsed is not None and parsed.owner != "_system"
+                and parsed.flavor == "fp8-w8a8"
+            ):
+                wants_w8a8 = True
+                break
+        if wants_w8a8:
+            # TensorRT cells currently expose only their plain fp16 contract.
+            # The existing Forge's -w8a8 Inductor cell is the sole artifact
+            # proven to preserve Fp8ScaledLinear/torch._scaled_mm semantics.
+            candidates = [
+                (ref, snap) for ref, snap in snapshots.items()
+                if compile_cache.is_cache_ref(ref, family)
+                and compile_cache.cell_lane(ref) == "w8a8"
+            ]
+        else:
+            candidates = [
+                (ref, snap) for ref, snap in snapshots.items()
+                if trt_engine.is_engine_ref(ref, family)
+            ] + [
+                (ref, snap) for ref, snap in snapshots.items()
+                if compile_cache.is_cache_ref(ref, family)
+            ]
         for ref, snap in candidates:
             try:
                 local = await self.store.ensure_local(ref, snap)
@@ -2929,8 +2954,11 @@ class Executor:
                         # prep mode is traced into the cells — a drifted
                         # pipeline can only miss, so reject deterministically
                         # instead of paying a warmup to find out.
-                        drift = (compile_cache.mode_drift(meta, obj)
-                                 or compile_cache.lane_drift(meta, obj))
+                        drift = (
+                            compile_cache.mode_drift(meta, obj)
+                            or compile_cache.lane_drift(meta, obj)
+                            or compile_cache.contract_drift(meta, obj, s.compile)
+                        )
                         if drift:
                             return await fail("key_mismatch", drift)
                         # Re-adoption of a re-published cell: drop the previous
@@ -3446,6 +3474,17 @@ class Executor:
             await self._finish(job, pb.JOB_STATUS_FATAL, safe_message="deadline exceeded",
                                metrics=metrics)
         except BaseException as exc:
+            from .compile_cache import CompiledLaneUnavailableError
+
+            if isinstance(exc, CompiledLaneUnavailableError):
+                # A seeded W8A8 graph failing at call time is a genuine lane
+                # failure, not an invitation to retry eager under the same
+                # advertised function. Remove this worker/function pair from
+                # dispatch until a fresh setup with a compatible cell.
+                self.unavailable[spec.name] = (
+                    "compile_cell_failed", _sanitize(str(exc)), {},
+                )
+                self._on_state_change()
             status, msg = _map_exception(exc)
             if status == pb.JOB_STATUS_FATAL:
                 logger.exception("handler %s failed", spec.name)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2457,17 +2457,23 @@ class Executor:
         from .models.refs import parse_model_ref
 
         family = getattr(spec.compile, "family", "") or ""
-        model_refs = list(snapshots)
-        model_refs.extend(wire_ref(binding) for binding in spec.models.values())
+        # The effective spec is already rebound to this RunJob's selected
+        # checkpoints. Snapshot maps also contain attached cells and may carry
+        # unrelated/prepositioned models, so they must not choose the lane.
+        model_refs = [wire_ref(binding) for binding in spec.models.values()]
         wants_w8a8 = False
         for model_ref in model_refs:
             try:
                 parsed = parse_model_ref(model_ref).tensorhub
             except ValueError:
                 continue
+            flavor = (parsed.flavor or "") if parsed is not None else ""
             if (
                 parsed is not None and parsed.owner != "_system"
-                and parsed.flavor == "fp8-w8a8"
+                and (
+                    flavor == "fp8-w8a8"
+                    or flavor.startswith("fp8-w8a8-")
+                )
             ):
                 wants_w8a8 = True
                 break

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2448,8 +2448,9 @@ class Executor:
         """Hub-attached compiled-artifact snapshot for this endpoint's family
         (#569 boot-attach, opt-in hub-side): a TRT engine cell (#390,
         preferred — bigger measured win) or an inductor cache cell. Returns
-        the local artifact path, or None — missing/unusable snapshots mean
-        eager, never an error."""
+        the local artifact path, or None. A plain lane may continue eager;
+        W8A8 setup subsequently fails retryably unless this returns an exact
+        W8A8 Forge cell."""
         if spec.compile is None or not snapshots:
             return None
         from . import compile_cache, trt_engine
@@ -2486,6 +2487,7 @@ class Executor:
             ] + [
                 (ref, snap) for ref, snap in snapshots.items()
                 if compile_cache.is_cache_ref(ref, family)
+                and compile_cache.cell_lane(ref) != "w8a8"
             ]
         for ref, snap in candidates:
             try:

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -167,6 +167,10 @@ def _build_module_class() -> type:
         weight_scale: Any
         lora_a: Any  # None, or [bucket, in] bf16 branch buffer (gw#547)
         lora_b: Any  # None, or [out, bucket] with scale folded in
+        # Structural marker consumed by compile_cache.execution_contract.
+        # Unlike a class-name check it survives refactors and records no
+        # checkpoint-specific data.
+        _cozy_w8a8_linear = True
 
         def __init__(self, in_features: int, out_features: int, *,
                      bias: bool, compute_dtype: Any,

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -30,6 +30,16 @@ def test_flavor_label():
     assert cc.flavor_label("h100-80gb-hbm3", "2.11.0") == "inductor-h100-80gb-hbm3-torch2.11"
 
 
+def test_cell_lane_is_exact_and_checkpoint_free():
+    assert cc.cell_lane(
+        "_system/family-sdxl#inductor-rtx-4090-torch2.13-w8a8"
+    ) == "w8a8"
+    assert cc.cell_lane(
+        "_system/family-sdxl#inductor-rtx-4090-torch2.13"
+    ) == ""
+    assert cc.cell_lane("owner/checkpoint#fp8-w8a8") == ""
+
+
 def test_verify_mismatches():
     meta = cc.artifact_metadata(family="sd15", shapes=[(768, 768)], targets=["transformer"])
     assert cc.verify(meta, family="sd15") == ""
@@ -54,6 +64,85 @@ def test_verify_mismatches():
     other = dict(meta)
     del other["gen_worker"]
     assert "gen_worker" in cc.verify(other, family="sd15")
+
+    for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+        other = dict(meta)
+        other[field] = "definitely-not-this-runtime"
+        assert field in cc.verify(other, family="sd15")
+
+
+def test_execution_contract_uses_structure_not_checkpoint_values():
+    torch = pytest.importorskip("torch")
+
+    class _Pipe:
+        def __init__(self, hidden: int, fill: float) -> None:
+            self.transformer = torch.nn.Sequential(
+                torch.nn.Linear(hidden, hidden), torch.nn.SiLU(),
+            )
+            with torch.no_grad():
+                self.transformer[0].weight.fill_(fill)
+
+    cfg = Compile(shapes=((1024, 1024),), targets=("transformer",), family="sdxl")
+    a_sig, a_weights = cc.execution_contract(_Pipe(16, 1.0), cfg)
+    b_sig, b_weights = cc.execution_contract(_Pipe(16, 9.0), cfg)
+    c_sig, _ = cc.execution_contract(_Pipe(32, 1.0), cfg)
+    assert a_sig == b_sig
+    assert a_weights == b_weights == {"lane": ""}
+    assert c_sig != a_sig
+
+
+def test_execution_contract_records_dynamic_w8a8_exclusions():
+    torch = pytest.importorskip("torch")
+
+    class _Scaled(torch.nn.Module):
+        _cozy_w8a8_linear = True
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.in_features = self.out_features = 16
+            self.register_buffer("weight", torch.empty(
+                16, 16, dtype=getattr(torch, "float8_e4m3fn")))
+            self.register_buffer("weight_scale", torch.ones(16, 1))
+            self.input_scale = None
+
+        def forward(self, x):
+            return x
+
+    class _Target(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fast = _Scaled()
+            self.sensitive = torch.nn.Linear(16, 16)
+
+    class _Pipe:
+        def __init__(self) -> None:
+            self.transformer = _Target()
+            self._cozy_weight_lane = "w8a8"
+
+    cfg = Compile(shapes=((1024, 1024),), targets=("transformer",), family="sdxl")
+    _signature, contract = cc.execution_contract(_Pipe(), cfg)
+    assert contract["operator"] == "torch._scaled_mm"
+    assert contract["activation_scaling"] == ["dynamic-per-row"]
+    assert [r["path"] for r in contract["quantized"]] == ["transformer:fast"]
+    assert [r["path"] for r in contract["excluded"]] == ["transformer:sensitive"]
+
+
+def test_w8a8_guard_never_retries_eager():
+    calls = {"eager": 0}
+
+    def eager(value):
+        calls["eager"] += 1
+        return value
+
+    def broken(_value):
+        raise RuntimeError("graph miss")
+
+    guarded = cc._guarded(eager, broken, "transformer", fail_closed=True)
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="graph miss"):
+        guarded(1)
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="graph miss"):
+        guarded(2)
+    assert calls["eager"] == 0
 
 
 def test_mode_drift():

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -432,6 +432,7 @@ def test_fetch_compile_snapshot_plain_lane_ignores_w8a8_cell(tmp_path):
     snapshots = {
         w8a8_ref: pb.Snapshot(),
         plain_ref: pb.Snapshot(),
+        "acme/unselected#fp8-w8a8": pb.Snapshot(),
     }
     got = asyncio.run(ex._fetch_compile_snapshot(spec, snapshots))
     assert got == wanted

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -410,6 +410,34 @@ def test_fetch_compile_snapshot_selects_exact_w8a8_lane(tmp_path):
     assert seen == [w8a8_ref]
 
 
+def test_fetch_compile_snapshot_plain_lane_ignores_w8a8_cell(tmp_path):
+    spec = _spec()
+    ex, _sent = _wire_executor(spec, tmp_path)
+    plain = tmp_path / "plain"
+    w8a8 = tmp_path / "w8a8"
+    plain.mkdir()
+    w8a8.mkdir()
+    wanted = plain / "plain.tar.gz"
+    wanted.write_bytes(b"plain")
+    (w8a8 / "w8a8.tar.gz").write_bytes(b"w8a8")
+    seen: list[str] = []
+
+    async def _ensure(ref, snapshot=None, *, binding=None):
+        seen.append(ref)
+        return w8a8 if ref.endswith("-w8a8") else plain
+
+    ex.store.ensure_local = _ensure  # type: ignore[method-assign]
+    plain_ref = f"_system/family-{FAMILY}#inductor-rtx-4090-torch2.9"
+    w8a8_ref = plain_ref + "-w8a8"
+    snapshots = {
+        w8a8_ref: pb.Snapshot(),
+        plain_ref: pb.Snapshot(),
+    }
+    got = asyncio.run(ex._fetch_compile_snapshot(spec, snapshots))
+    assert got == wanted
+    assert seen == [plain_ref]
+
+
 def test_prepare_with_explicit_artifact_seeds(tmp_path, monkeypatch):
     monkeypatch.delenv(cc.ENV_CACHE_PATH, raising=False)
     monkeypatch.delenv(cc.ENV_CACHE_URL, raising=False)

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -6,6 +6,7 @@ a compile-cache snapshot on RunJob.snapshots reaches compile_cache.enable."""
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from pathlib import Path
 
 import msgspec
@@ -63,7 +64,12 @@ def _artifact(tmp_path: Path, **meta_overrides) -> Path:
     (cap / "inductor" / "g").mkdir(parents=True)
     (cap / "inductor" / "g" / "code.py").write_text("x")
     (cap / "triton").mkdir()
-    meta = cc.artifact_metadata(family=FAMILY, shapes=[(768, 768)], targets=["transformer"])
+    cfg = Compile(shapes=((768, 768),), family=FAMILY)
+    signature, weight_contract = cc.execution_contract(_Pipe(), cfg)
+    meta = cc.artifact_metadata(
+        family=FAMILY, shapes=cfg.shapes, targets=cfg.targets,
+        graph_signature=signature, weight_contract=weight_contract,
+    )
     meta.update(meta_overrides)
     snapdir = tmp_path / "snap"
     snapdir.mkdir(exist_ok=True)
@@ -370,6 +376,38 @@ def test_fetch_compile_snapshot_ignores_other_families(tmp_path):
     snapshots = {"_system/family-sdxl#inductor-rtx-4090-torch2.9": pb.Snapshot()}
     assert asyncio.run(ex._fetch_compile_snapshot(spec, snapshots)) is None
     assert asyncio.run(ex._fetch_compile_snapshot(spec, None)) is None
+
+
+def test_fetch_compile_snapshot_selects_exact_w8a8_lane(tmp_path):
+    spec = replace(
+        _spec(), models={"pipeline": Hub(
+            "acme/klein-finetune", flavor="fp8-w8a8")},
+    )
+    ex, _sent = _wire_executor(spec, tmp_path)
+    plain = tmp_path / "plain"
+    w8a8 = tmp_path / "w8a8"
+    plain.mkdir()
+    w8a8.mkdir()
+    (plain / "plain.tar.gz").write_bytes(b"plain")
+    wanted = w8a8 / "w8a8.tar.gz"
+    wanted.write_bytes(b"w8a8")
+    seen: list[str] = []
+
+    async def _ensure(ref, snapshot=None, *, binding=None):
+        seen.append(ref)
+        return w8a8 if ref.endswith("-w8a8") else plain
+
+    ex.store.ensure_local = _ensure  # type: ignore[method-assign]
+    plain_ref = f"_system/family-{FAMILY}#inductor-rtx-4090-torch2.9"
+    w8a8_ref = plain_ref + "-w8a8"
+    snapshots = {
+        plain_ref: pb.Snapshot(),
+        w8a8_ref: pb.Snapshot(),
+        "acme/klein-finetune#fp8-w8a8": pb.Snapshot(),
+    }
+    got = asyncio.run(ex._fetch_compile_snapshot(spec, snapshots))
+    assert got == wanted
+    assert seen == [w8a8_ref]
 
 
 def test_prepare_with_explicit_artifact_seeds(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.32.0"
+version = "0.32.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- select the exact existing Forge -w8a8 cell instead of the first attached family artifact
- bind new W8A8 cells to checkpoint-independent module and weight-lane structure plus shape, SM, CUDA and driver, compiler/runtime, and serving-image identity
- require dynamic per-row activation scaling and real scaled-mm modules; reject static-scale, missing, mismatched, eager, and dequantized lanes
- keep graph-compatible SDXL, Pony, and Illustrious checkpoints on one family cell because refs, checkpoint digests, tensor bytes, and values are intentionally excluded
- fail a runtime graph break as a retryable lane failure and withdraw the affected worker/function instead of silently retrying eager

Depends on training-endpoints #136 for serving-image provenance in the existing Forge producer.

## Tests
- 1265 passed, 13 skipped in the full suite
- 89 passed in the focused compile, adoption, and W8A8 suite after final compatibility changes
- ruff clean
- mypy clean for all 3 changed source modules
- HTTP timeout lint clean