### PR TITLE
gw#558: lane-general runtime LoRA — additive branch on bf16 + fp8-storage lanes (0.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.33.0 (2026-07-17)
+
+- **gw#558 (ie#388 dynamic-LoRA primary path): lane-general runtime LoRA
+  additive branches.** The gw#547 w8a8 side-branch generalizes to every
+  serve lane: plain `nn.Linear` denoisers (bf16-resident lane) and
+  layerwise-cast denoisers (the fp8-storage `fp8+te` lane) carry the same
+  `y += B(A @ x)` compute-dtype branch through an idempotent instance-forward
+  wrap — never peft module wrapping (ie#374), never a weight mutation, and
+  removal is bit-exact. Branch tensors on cast lanes live in the module
+  `__dict__` so the cast hooks can never fp8-round-trip them (verdict: the
+  branch COMPOSES with diffusers layerwise casting — the ie#374
+  incompatibility was peft-implementation-level, as ruled). Adapter state
+  dicts normalize through the pipeline class's own `lora_state_dict`
+  converter first (te#81's zero-drift pattern) with the existing
+  diffusers/peft/kohya grammar as fallback. Denoiser halves ALWAYS ride the
+  branch; text-encoder halves keep peft on uncast TEs and are refused typed
+  (`RefCompatibilitySurprise`) on cast TEs; unmappable adapters (conv-
+  targeting LoCon-class) on the plain lane fall back to whole-adapter peft.
+  Lane stamps compose as `<base>-lora<bucket>` (`w8a8-lora32`,
+  `fp8-hooks-lora32`, `lora32`), keeping branch-bearing pipelines and
+  branchless compile cells apart under the symmetric `lane_drift` guard;
+  compiled pipelines still refuse bucket resizes (no recompile at swap).
+
 ## 0.32.2 (2026-07-16)
 
 - **gw#559 / ie#496: Forge captures every declared image CFG regime.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.32.2"
+version = "0.33.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -69,14 +69,13 @@ def branch_target(pipe: Any) -> Optional[Any]:
     """The pipeline's denoiser when it is branch-capable (gw#558: every
     lane — w8a8 scaled_mm, fp8-storage layerwise-cast, plain resident), else
     None (no discoverable denoiser module — such pipelines keep the whole
-    peft path)."""
+    peft path). Deliberately NO module scan here: this runs on every demote
+    (residency.pre_demote -> detach) — adapters that map onto no Linear
+    fail typed in :func:`map_adapter` (with the plain-lane peft fallback in
+    AdapterResidency.activate)."""
     for name in ("transformer", "unet"):
         denoiser = getattr(pipe, name, None)
-        if denoiser is None or not hasattr(denoiser, "named_modules"):
-            continue
-        if getattr(denoiser, "_cozy_w8a8_mode", "") == "scaled_mm":
-            return denoiser
-        if branch_modules(denoiser):
+        if denoiser is not None and hasattr(denoiser, "named_modules"):
             return denoiser
     return None
 

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -333,9 +333,14 @@ def _install_branch_forward(mod: Any) -> None:
         if a.device != x.device:
             # Self-heal after a host-resident alloc (block-offload lane):
             # branch tensors are tiny; pin them to the execution device.
-            a = a.to(x.device)
-            b = b.to(x.device)
-            mod.lora_a, mod.lora_b = a, b
+            # Rebind ONLY if the module still holds the exact pair we read —
+            # a concurrent realloc must never be clobbered with stale copies
+            # (the compute below uses the consistent local pair either way).
+            a2, b2 = a.to(x.device), b.to(x.device)
+            if (mod.__dict__.get("lora_a") is a
+                    and mod.__dict__.get("lora_b") is b):
+                mod.lora_a, mod.lora_b = a2, b2
+            a, b = a2, b2
         x2 = x.reshape(-1, x.shape[-1])
         if x2.dtype != a.dtype:
             x2 = x2.to(a.dtype)

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -1,21 +1,32 @@
-"""Runtime LoRA on the w8a8 serve lane (gw#547).
+"""Runtime LoRA additive branches (gw#547 w8a8; gw#558 lane-general).
 
-Fp8ScaledLinear holds fp8 buffers + torch._scaled_mm — peft can't target it,
-so adapters ride a bf16 SIDE-BRANCH instead: ``y += B(A @ x)`` reading the
-original bf16 activation and adding onto the bf16 output. Quantized weights
-are never touched; there is no upcast/requant round-trip.
+Denoiser adapter halves ride a compute-dtype SIDE-BRANCH — ``y += B(A @ x)``
+reading the original activation and adding onto the output — never peft
+module wrapping (ie#374: peft fights the layerwise-cast hooks) and never a
+weight mutation. Three lanes are branch-capable:
 
-Graph stability: every quantized Linear gets a branch (canonical placement —
-zeroed slots for layers an adapter doesn't cover), and the concatenated rank
-of the active adapter set is padded to a fixed bucket (:data:`RANK_BUCKETS`).
-Every adapter set inside one bucket shares ONE traced graph; hot-swap is a
-buffer copy. Multiple active adapters rank-concat into one A/B pair (the
-gw#430 svdq trick); per-adapter scale (alpha/rank x user weight) is folded
-into the B copy.
+- **w8a8 scaled_mm** (gw#547): Fp8ScaledLinear reads ``lora_a``/``lora_b``
+  non-persistent buffers natively in its forward.
+- **fp8-storage layerwise-cast** (gw#558): plain ``nn.Linear`` under
+  diffusers cast hooks gets an idempotent instance-forward wrap; branch
+  tensors live in the module ``__dict__`` (plain attrs) so ``.to(dtype)``
+  cast hooks never round-trip them through fp8.
+- **plain bf16/fp16 resident** (gw#558): same wrap; removal restores the
+  original forward path bit-exactly.
 
-The branch-bearing pipeline stamps ``_cozy_weight_lane = "w8a8-lora<bucket>"``
-so the existing SYMMETRIC ``compile_cache.lane_drift`` guard keeps LoRA-bearing
-pipelines and branchless compile cells apart in both directions.
+Graph stability: every branch-capable Linear gets a branch under canonical
+placement (zeroed slots for layers an adapter doesn't cover), and the
+concatenated rank of the active adapter set is padded to a fixed bucket
+(:data:`RANK_BUCKETS`). Every adapter set inside one bucket shares ONE traced
+graph; hot-swap is a buffer copy. Multiple active adapters rank-concat into
+one A/B pair (the gw#430 svdq trick); per-adapter scale (alpha/rank x user
+weight) is folded into the B copy.
+
+The branch-bearing pipeline stamps ``_cozy_weight_lane =
+"<base-lane>-lora<bucket>"`` (``w8a8-lora32``, ``fp8-hooks-lora32``,
+``lora32`` for plain bf16) so the SYMMETRIC ``compile_cache.lane_drift``
+guard keeps LoRA-bearing pipelines and branchless compile cells apart in
+both directions.
 """
 
 from __future__ import annotations
@@ -55,13 +66,29 @@ def rank_bucket(total_rank: int) -> int:
 
 
 def branch_target(pipe: Any) -> Optional[Any]:
-    """The pipeline's denoiser when it serves on the scaled_mm w8a8 lane
-    (branch-capable), else None (plain/dequant pipelines keep the peft path)."""
+    """The pipeline's denoiser when it is branch-capable (gw#558: every
+    lane — w8a8 scaled_mm, fp8-storage layerwise-cast, plain resident), else
+    None (no discoverable denoiser module — such pipelines keep the whole
+    peft path)."""
     for name in ("transformer", "unet"):
         denoiser = getattr(pipe, name, None)
-        if denoiser is not None and getattr(denoiser, "_cozy_w8a8_mode", "") == "scaled_mm":
+        if denoiser is None or not hasattr(denoiser, "named_modules"):
+            continue
+        if getattr(denoiser, "_cozy_w8a8_mode", "") == "scaled_mm":
+            return denoiser
+        if branch_modules(denoiser):
             return denoiser
     return None
+
+
+def branch_lane(model: Any) -> str:
+    """The denoiser's base weight lane for branch policy/stamping:
+    ``"w8a8"`` | ``"fp8-hooks"`` | ``""`` (plain resident)."""
+    if getattr(model, "_cozy_w8a8_mode", "") == "scaled_mm":
+        return "w8a8"
+    if getattr(model, "_cozy_fp8_storage_applied", False):
+        return "fp8-hooks"
+    return ""
 
 
 def quantized_modules(model: Any) -> Dict[str, Any]:
@@ -72,15 +99,33 @@ def quantized_modules(model: Any) -> Dict[str, Any]:
     return {n: m for n, m in model.named_modules() if isinstance(m, cls)}
 
 
+def branch_modules(model: Any) -> Dict[str, Any]:
+    """name -> branch-capable Linear (Fp8ScaledLinear or plain nn.Linear)
+    for the denoiser. Convs and other module kinds are not branch targets —
+    adapters that name them fail loud in :func:`map_adapter`."""
+    import torch.nn as nn
+
+    from .w8a8 import fp8_scaled_linear_class
+
+    fp8_cls = fp8_scaled_linear_class()
+    return {
+        n: m for n, m in model.named_modules()
+        if isinstance(m, fp8_cls) or type(m) is nn.Linear
+    }
+
+
 def branch_bucket(model: Any) -> int:
     """The enabled bucket, 0 when branches are not enabled."""
     return int(getattr(model, _BUCKET_ATTR, 0) or 0)
 
 
-def lora_lane(bucket: int, sparse: bool = False) -> str:
+def lora_lane(bucket: int, sparse: bool = False, base: str = "w8a8") -> str:
     # Sparse (eager-only) placement is a different graph per coverage
     # pattern — the "-sparse" suffix can never match a produced cell label.
-    return f"w8a8-lora{int(bucket)}" + ("-sparse" if sparse else "")
+    # ``base`` is the branchless lane the branch rides on ("w8a8",
+    # "fp8-hooks", or "" for plain resident).
+    prefix = f"{base}-" if base else ""
+    return f"{prefix}lora{int(bucket)}" + ("-sparse" if sparse else "")
 
 
 def split_state_dict(sd: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -182,7 +227,7 @@ def map_adapter(
     SDXL sd-scripts). Any key that does not land on a branch-capable module
     is a hard error — a silently-dropped block would change the adapter's
     output."""
-    mods = quantized_modules(model)
+    mods = branch_modules(model)
     groups, unresolved = _group_keys(den_sd, mods)
     if unresolved and any(
             p in k for k in den_sd
@@ -192,9 +237,10 @@ def map_adapter(
             groups, unresolved = _group_keys(converted, mods)
     if unresolved:
         raise RefCompatibilitySurprise(
-            f"{len(unresolved)} adapter key(s) target no w8a8-quantized module "
-            f"(e.g. {', '.join(sorted(unresolved)[:3])}) — the w8a8 branch "
-            "cannot apply this adapter without changing its output",
+            f"{len(unresolved)} adapter key(s) target no branch-capable "
+            f"Linear (e.g. {', '.join(sorted(unresolved)[:3])}) — the "
+            "additive branch cannot apply this adapter without changing "
+            "its output",
             ref=ref, axis="state_dict",
         )
 
@@ -260,24 +306,84 @@ def _stage_adapter(mapped: Dict[str, Tuple[Any, Any, float]]) -> Dict[str, Any]:
     return {"ranks": ranks, "flat": flat, "index": index}
 
 
+_WRAP_ATTR = "_cozy_lora_wrapped"
+
+
+def _is_scaled_linear(mod: Any) -> bool:
+    from .w8a8 import fp8_scaled_linear_class
+
+    return isinstance(mod, fp8_scaled_linear_class())
+
+
+def _install_branch_forward(mod: Any) -> None:
+    """Idempotent instance-forward wrap for a plain ``nn.Linear``:
+    ``y = orig(x) + (x @ A.T) @ B.T``. Branch tensors are read from the
+    module ``__dict__`` so layerwise-cast hooks (``.to(dtype)``) never see
+    them (gw#558 / ie#374). With no branch installed the wrap is a pure
+    pass-through — removal is bit-exact."""
+    if getattr(mod, _WRAP_ATTR, False):
+        return
+    orig = mod.forward
+
+    def _forward_with_branch(x: Any, *args: Any, **kwargs: Any) -> Any:
+        y = orig(x, *args, **kwargs)
+        a = mod.__dict__.get("lora_a")
+        b = mod.__dict__.get("lora_b")
+        if a is None or b is None:
+            return y
+        if a.device != x.device:
+            # Self-heal after a host-resident alloc (block-offload lane):
+            # branch tensors are tiny; pin them to the execution device.
+            a = a.to(x.device)
+            b = b.to(x.device)
+            mod.lora_a, mod.lora_b = a, b
+        x2 = x.reshape(-1, x.shape[-1])
+        if x2.dtype != a.dtype:
+            x2 = x2.to(a.dtype)
+        addend = (x2 @ a.t()) @ b.t()
+        return y + addend.reshape(*x.shape[:-1], b.shape[0]).to(y.dtype)
+
+    mod._cozy_lora_orig_forward = orig
+    mod.forward = _forward_with_branch
+    setattr(mod, _WRAP_ATTR, True)
+
+
 def alloc_branch_buffers(mod: Any, bucket: int) -> None:
-    """Zeroed A/B buffers on one Fp8ScaledLinear (persistent=False — they
-    move with the module, never enter state_dict)."""
+    """Zeroed A/B branch tensors on one branch-capable Linear.
+
+    Fp8ScaledLinear registers non-persistent buffers (they move with the
+    module and its forward reads them natively; the w8a8 denoiser carries
+    no cast hooks). Plain ``nn.Linear`` gets a forward wrap + plain
+    ``__dict__`` attrs instead — registered buffers would be round-tripped
+    bf16->fp8->bf16 by the layerwise-cast hooks on the fp8-storage lane."""
     import torch
 
     dev = mod.weight.device
-    dtype = mod.bias.dtype if mod.bias is not None else torch.bfloat16
+    # Branch tensors compute in the module's COMPUTE dtype — never its
+    # storage dtype (on the fp8-storage lane weight AND bias rest in fp8).
+    _compute = (torch.float16, torch.bfloat16, torch.float32)
+    dtype = torch.bfloat16
+    for cand in (mod.weight.dtype if not _is_scaled_linear(mod) else None,
+                 mod.bias.dtype if mod.bias is not None else None):
+        if cand in _compute:
+            dtype = cand
+            break
     for name in ("lora_a", "lora_b"):
         mod._buffers.pop(name, None)
         mod.__dict__.pop(name, None)
-    mod.register_buffer("lora_a", torch.zeros(
-        bucket, mod.in_features, dtype=dtype, device=dev), persistent=False)
-    mod.register_buffer("lora_b", torch.zeros(
-        mod.out_features, bucket, dtype=dtype, device=dev), persistent=False)
+    a = torch.zeros(bucket, mod.in_features, dtype=dtype, device=dev)
+    b = torch.zeros(mod.out_features, bucket, dtype=dtype, device=dev)
+    if _is_scaled_linear(mod):
+        mod.register_buffer("lora_a", a, persistent=False)
+        mod.register_buffer("lora_b", b, persistent=False)
+        return
+    _install_branch_forward(mod)
+    mod.lora_a = a
+    mod.lora_b = b
 
 
 def enable_lora_branches(model: Any, bucket: int) -> None:
-    """Allocate branch buffers on EVERY quantized Linear (canonical
+    """Allocate branch buffers on EVERY branch-capable Linear (canonical
     placement — one traced graph over all coverage patterns; the compiled
     lane). Idempotent at the same bucket; a different bucket reallocates
     (a new graph family)."""
@@ -285,7 +391,7 @@ def enable_lora_branches(model: Any, bucket: int) -> None:
         raise ValidationError(f"invalid lora rank bucket {bucket} (valid: {RANK_BUCKETS})")
     if branch_bucket(model) == bucket and not getattr(model, _SPARSE_ATTR, False):
         return
-    for mod in quantized_modules(model).values():
+    for mod in branch_modules(model).values():
         alloc_branch_buffers(mod, bucket)
     setattr(model, _BUCKET_ATTR, int(bucket))
     setattr(model, _SPARSE_ATTR, False)
@@ -295,7 +401,7 @@ def enable_lora_branches(model: Any, bucket: int) -> None:
 def disable_lora_branches(model: Any) -> None:
     """Drop the branch buffers entirely (back to the branchless graph
     family). Used on demote/teardown, never between requests."""
-    for mod in quantized_modules(model).values():
+    for mod in branch_modules(model).values():
         for name in ("lora_a", "lora_b"):
             mod._buffers.pop(name, None)
             mod.__dict__.pop(name, None)
@@ -317,7 +423,7 @@ def clear_branch_adapters(model: Any) -> None:
     if getattr(model, _SPARSE_ATTR, False):
         disable_lora_branches(model)
         return
-    for mod in quantized_modules(model).values():
+    for mod in branch_modules(model).values():
         if getattr(mod, "lora_b", None) is not None:
             mod.lora_b.zero_()
     setattr(model, _ACTIVE_ATTR, False)
@@ -393,7 +499,7 @@ def apply_branch_adapters(
         covered_paths: set[str] = set()
         for entry, _w, _ref in mapped:
             covered_paths.update(entry["ranks"])
-        for path, mod in quantized_modules(model).items():
+        for path, mod in branch_modules(model).items():
             if path in covered_paths:
                 if (getattr(mod, "lora_a", None) is None
                         or int(mod.lora_a.shape[0]) != bucket):
@@ -409,7 +515,7 @@ def apply_branch_adapters(
 
     copied = 0
     covered = 0
-    mods = quantized_modules(model)
+    mods = branch_modules(model)
     with torch.no_grad():
         # One H2D transfer per adapter of its CACHED flat staging buffer
         # (pinned when small enough), then index-addressed device-side
@@ -476,19 +582,83 @@ def apply_branch_adapters(
 
 def stamp_lane(pipe: Any, model: Any) -> None:
     """Keep the compile-cache graph key honest: branch-bearing pipelines are
-    a different graph family per bucket (lane_drift guards both directions)."""
+    a different graph family per (base lane, bucket) — lane_drift guards
+    both directions. The branchless base lane is remembered on first stamp
+    so clearing the branch restores it exactly."""
     bucket = branch_bucket(model)
     sparse = bool(getattr(model, _SPARSE_ATTR, False))
+    base = getattr(pipe, "_cozy_lora_base_lane", None)
+    if base is None:
+        from .loading import pipeline_weight_lane
+
+        # The loader stamps _cozy_weight_lane on real pipelines; the
+        # denoiser's own lane markers are the fallback authority.
+        base = pipeline_weight_lane(pipe) or branch_lane(model)
+        try:
+            pipe._cozy_lora_base_lane = base
+        except Exception:
+            return
     try:
-        pipe._cozy_weight_lane = lora_lane(bucket, sparse) if bucket else "w8a8"
+        pipe._cozy_weight_lane = lora_lane(bucket, sparse, base=base) if bucket else base
     except Exception:
         pass
+
+
+def normalize_adapter_state_dict(
+    pipe: Any, sd: Dict[str, Any], *, ref: str = ""
+) -> Dict[str, Any]:
+    """Normalize a raw adapter through the pipeline class's own
+    ``lora_state_dict`` converter (te#81's zero-drift pattern: byte-identical
+    key handling with the boot-time ``load_lora_weights`` path). Falls back
+    to the raw dict when the class has no converter or it fails — the
+    :func:`map_adapter` grammar (diffusers/peft/kohya) then applies as
+    before. sdxl-class converters receive ``unet_config`` for SGM block
+    remapping of kohya adapters. Returned ``network_alphas`` fold back in as
+    ``<module>.alpha`` entries."""
+    import inspect
+
+    fn = getattr(type(pipe), "lora_state_dict", None)
+    if fn is None:
+        return sd
+    kwargs: Dict[str, Any] = {}
+    unet = getattr(pipe, "unet", None)
+    if unet is not None and hasattr(unet, "config"):
+        try:
+            if "unet_config" in inspect.signature(fn).parameters:
+                kwargs["unet_config"] = unet.config
+        except (TypeError, ValueError):
+            pass
+    try:
+        converted = fn(dict(sd), **kwargs)
+    except Exception:
+        logger.warning(
+            "lora_state_dict normalization failed for %s; using raw keys",
+            ref, exc_info=True,
+        )
+        return sd
+    alphas: Dict[str, Any] = {}
+    if isinstance(converted, tuple):
+        if len(converted) != 2:
+            logger.warning(
+                "%s.lora_state_dict returned a %d-tuple; using raw keys",
+                type(pipe).__name__, len(converted),
+            )
+            return sd
+        converted, raw_alphas = converted
+        alphas = dict(raw_alphas or {})
+    out = dict(converted)
+    for k, v in alphas.items():
+        key = k if k.endswith(".alpha") else f"{k}.alpha"
+        out.setdefault(key, v)
+    return out
 
 
 __all__ = [
     "RANK_BUCKETS",
     "apply_branch_adapters",
     "branch_bucket",
+    "branch_lane",
+    "branch_modules",
     "branch_target",
     "branches_active",
     "clear_branch_adapters",
@@ -496,6 +666,7 @@ __all__ = [
     "enable_lora_branches",
     "lora_lane",
     "map_adapter",
+    "normalize_adapter_state_dict",
     "quantized_modules",
     "rank_bucket",
     "split_state_dict",

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -408,9 +408,13 @@ class AdapterResidency:
                     w8a8_lora.clear_branch_adapters(denoiser)
                     w8a8_lora.stamp_lane(pipe, denoiser)
                 if denoiser is not None and not adapters:
-                    # No peft half — make sure a previous request's TE
-                    # adapters are off, then we're done.
-                    if hasattr(pipe, "disable_lora"):
+                    # No peft half — make sure a previous request's peft
+                    # adapters are off, then we're done. Only touch the peft
+                    # surface when THIS registry attached something there:
+                    # diffusers' disable_lora raises on peft-less images
+                    # (the LTX serving image ships no peft — ie#493), and a
+                    # branch-only pipeline never needs it.
+                    if st.attached and hasattr(pipe, "disable_lora"):
                         pipe.disable_lora()
                     st.active = True
                     return
@@ -487,7 +491,12 @@ class AdapterResidency:
                     exc_info=True,
                 )
             try:
-                if hasattr(pipe, "disable_lora"):
+                # Peft-surface teardown only when peft attachments exist —
+                # diffusers raises "PEFT backend is required" otherwise on
+                # peft-less serving images (branch-only lanes, ie#493).
+                if not st.attached:
+                    pass
+                elif hasattr(pipe, "disable_lora"):
                     pipe.disable_lora()
                 elif hasattr(pipe, "unload_lora_weights"):
                     pipe.unload_lora_weights()

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -121,9 +121,10 @@ def _denoiser_fingerprint(pipe: Any) -> str:
     for name in ("unet", "transformer"):
         cfg = getattr(getattr(pipe, name, None), "config", None)
         if cfg is not None:
-            return str(getattr(cfg, "down_block_types", "")) + str(
-                getattr(cfg, "block_out_channels", "")) + str(
-                getattr(cfg, "num_layers", ""))
+            return "|".join(
+                str(getattr(cfg, k, ""))
+                for k in ("down_block_types", "block_out_channels",
+                          "layers_per_block", "num_layers"))
     return ""
 
 

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -90,16 +90,41 @@ class PreparedAdapter:
     parse_ms: int = 0   # safetensors read + validation (0 on cache hit)
 
 
-# Normalized+split adapter halves, keyed by (pipeline class, cache_key).
-# The cached den_sd OBJECT is reused across requests so the branch layer's
-# staging cache (keyed on id(sd)) hits — repeat swaps skip key-mapping AND
-# the CPU flatten. Split tensors alias the AdapterCache entries (converters
-# rename keys, they don't copy data), but the cap stays small so this cache
-# can never pin many evicted adapters by itself.
+# Normalized+split adapter halves, keyed by (pipeline class, denoiser-config
+# fingerprint, cache_key). The cached den_sd OBJECT is reused across requests
+# so the branch layer's staging cache (keyed on id(sd)) hits — repeat swaps
+# skip key-mapping AND the CPU flatten. Split tensors alias the AdapterCache
+# entries (converters rename keys, they don't copy data), but the cap stays
+# small so this cache can never pin many evicted adapters by itself.
+# Guarded by its own lock: activate() calls this BEFORE taking the residency
+# lock, and multi-slot workers activate from several threads.
 _SPLIT_CACHE: "OrderedDict[tuple, tuple]" = OrderedDict()
 _SPLIT_CACHE_MAX = 8
-_TE_KEY_PREFIXES = ("text_encoder", "lora_te", "te1.", "te2.")
-_TE_COMPONENTS = ("text_encoder", "text_encoder_2", "text_encoder_3")
+_SPLIT_CACHE_LOCK = threading.Lock()
+# Component prefix -> pipe attribute, for both normalized and kohya-flat key
+# grammars. Kohya te1/te2 numbering follows diffusers' convention.
+_TE_PREFIX_TO_COMPONENT = (
+    ("text_encoder_3", "text_encoder_3"),
+    ("text_encoder_2", "text_encoder_2"),
+    ("text_encoder", "text_encoder"),
+    ("lora_te3_", "text_encoder_3"),
+    ("lora_te2_", "text_encoder_2"),
+    ("lora_te1_", "text_encoder"),
+    ("lora_te_", "text_encoder"),
+)
+
+
+def _denoiser_fingerprint(pipe: Any) -> str:
+    """Kohya/SGM normalization consults the denoiser's config — two
+    checkpoints sharing a pipeline class but differing in block layout must
+    not share a normalized-split cache entry."""
+    for name in ("unet", "transformer"):
+        cfg = getattr(getattr(pipe, name, None), "config", None)
+        if cfg is not None:
+            return str(getattr(cfg, "down_block_types", "")) + str(
+                getattr(cfg, "block_out_channels", "")) + str(
+                getattr(cfg, "num_layers", ""))
+    return ""
 
 
 def _split_adapters(
@@ -116,21 +141,27 @@ def _split_adapters(
 
     from ..models import w8a8_lora
 
+    fp = _denoiser_fingerprint(pipe)
     peft: List[PreparedAdapter] = []
     branch: List[tuple] = []
     for a in adapters:
-        key = (type(pipe).__qualname__, a.cache_key)
-        cached = _SPLIT_CACHE.get(key)
+        key = (type(pipe).__qualname__, fp, a.cache_key)
+        with _SPLIT_CACHE_LOCK:
+            cached = _SPLIT_CACHE.get(key)
+            if cached is not None:
+                _SPLIT_CACHE.move_to_end(key)
         if cached is None:
             sd = w8a8_lora.normalize_adapter_state_dict(
                 pipe, a.state_dict, ref=a.ref
             )
             cached = w8a8_lora.split_state_dict(sd)
-            _SPLIT_CACHE[key] = cached
-            while len(_SPLIT_CACHE) > _SPLIT_CACHE_MAX:
-                _SPLIT_CACHE.popitem(last=False)
-        else:
-            _SPLIT_CACHE.move_to_end(key)
+            with _SPLIT_CACHE_LOCK:
+                # A racing thread may have inserted the same key — keep the
+                # FIRST entry so every caller shares one den_sd object (the
+                # branch staging cache keys on its id).
+                cached = _SPLIT_CACHE.setdefault(key, cached)
+                while len(_SPLIT_CACHE) > _SPLIT_CACHE_MAX:
+                    _SPLIT_CACHE.popitem(last=False)
         den, rest = cached
         if den:
             branch.append((den, a.weight, a.ref))
@@ -142,25 +173,30 @@ def _split_adapters(
 def _reject_te_keys_on_cast_te(
     pipe: Any, adapters: Sequence["PreparedAdapter"],
 ) -> None:
-    """Typed refusal for text-encoder adapter halves on a cast TE (the
-    ``fp8+te`` lane): peft module wrapping under the block-window/layerwise
-    cast is the exact ie#374 breakage — fail loud, never fight the hooks."""
-    cast = [
-        name for name in _TE_COMPONENTS
-        if getattr(getattr(pipe, name, None), "_cozy_fp8_storage_applied", False)
-    ]
-    if not cast:
-        return
+    """Typed refusal for text-encoder adapter halves TARGETING a cast TE
+    (the ``fp8+te`` lane): peft module wrapping under the block-window/
+    layerwise cast is the exact ie#374 breakage — fail loud, never fight
+    the hooks. Keys targeting an UNCAST encoder in a mixed setup stay on
+    the peft path."""
+    def component_of(key: str) -> str:
+        for prefix, comp in _TE_PREFIX_TO_COMPONENT:
+            if key.startswith(prefix):
+                return comp
+        return ""
+
     for a in adapters:
-        te_keys = [k for k in a.state_dict if k.startswith(_TE_KEY_PREFIXES)]
-        if te_keys:
-            raise RefCompatibilitySurprise(
-                f"adapter carries {len(te_keys)} text-encoder key(s) (e.g. "
-                f"{sorted(te_keys)[0]}) but this pipeline serves its text "
-                f"encoder(s) fp8-cast ({', '.join(cast)}) — text-encoder "
-                "adapters are unsupported on the fp8+te lane",
-                ref=a.ref, axis="state_dict",
-            )
+        for k in a.state_dict:
+            comp = component_of(k)
+            if not comp:
+                continue
+            te = getattr(pipe, comp, None)
+            if te is not None and getattr(te, "_cozy_fp8_storage_applied", False):
+                raise RefCompatibilitySurprise(
+                    f"adapter targets {comp} (e.g. {k}) but this pipeline "
+                    f"serves {comp} fp8-cast — text-encoder adapters are "
+                    "unsupported on the fp8+te lane",
+                    ref=a.ref, axis="state_dict",
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -528,11 +564,13 @@ class AdapterResidency:
                 from ..models import w8a8_lora
 
                 denoiser = w8a8_lora.branch_target(pipe)
-                if denoiser is not None:
+                # branch_bucket guard: never-lora pipelines skip the module
+                # walk entirely — this runs on EVERY demote (gw#551 swaps).
+                if denoiser is not None and w8a8_lora.branch_bucket(denoiser):
                     w8a8_lora.disable_lora_branches(denoiser)
                     w8a8_lora.stamp_lane(pipe, denoiser)
             except Exception:
-                logger.warning("w8a8 lora branch drop on demote failed for %s",
+                logger.warning("lora branch drop on demote failed for %s",
                                ref, exc_info=True)
             if st is None or not st.attached or st.pipe_id != id(pipe):
                 return

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -93,9 +93,11 @@ class PreparedAdapter:
 # Normalized+split adapter halves, keyed by (pipeline class, cache_key).
 # The cached den_sd OBJECT is reused across requests so the branch layer's
 # staging cache (keyed on id(sd)) hits — repeat swaps skip key-mapping AND
-# the CPU flatten.
+# the CPU flatten. Split tensors alias the AdapterCache entries (converters
+# rename keys, they don't copy data), but the cap stays small so this cache
+# can never pin many evicted adapters by itself.
 _SPLIT_CACHE: "OrderedDict[tuple, tuple]" = OrderedDict()
-_SPLIT_CACHE_MAX = 16
+_SPLIT_CACHE_MAX = 8
 _TE_KEY_PREFIXES = ("text_encoder", "lora_te", "te1.", "te2.")
 _TE_COMPONENTS = ("text_encoder", "text_encoder_2", "text_encoder_3")
 

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -90,12 +90,26 @@ class PreparedAdapter:
     parse_ms: int = 0   # safetensors read + validation (0 on cache hit)
 
 
-def _split_for_w8a8(
-    adapters: Sequence["PreparedAdapter"],
+# Normalized+split adapter halves, keyed by (pipeline class, cache_key).
+# The cached den_sd OBJECT is reused across requests so the branch layer's
+# staging cache (keyed on id(sd)) hits — repeat swaps skip key-mapping AND
+# the CPU flatten.
+_SPLIT_CACHE: "OrderedDict[tuple, tuple]" = OrderedDict()
+_SPLIT_CACHE_MAX = 16
+_TE_KEY_PREFIXES = ("text_encoder", "lora_te", "te1.", "te2.")
+_TE_COMPONENTS = ("text_encoder", "text_encoder_2", "text_encoder_3")
+
+
+def _split_adapters(
+    pipe: Any, adapters: Sequence["PreparedAdapter"],
 ) -> tuple[List["PreparedAdapter"], List[tuple]]:
     """(peft-path adapters with denoiser keys stripped, branch set) for a
-    w8a8-lane pipeline. Branch entries are (state_dict, weight, ref) —
-    the models.w8a8_lora.apply_branch_adapters contract."""
+    branch-capable pipeline. Each adapter is first normalized through the
+    pipeline class's own ``lora_state_dict`` converter (zero drift with the
+    boot-time path, te#81 pattern), then split: denoiser keys ride the
+    additive branch, the rest (text-encoder halves) keep peft. Branch
+    entries are (state_dict, weight, ref) — the
+    models.w8a8_lora.apply_branch_adapters contract."""
     from dataclasses import replace
 
     from ..models import w8a8_lora
@@ -103,12 +117,48 @@ def _split_for_w8a8(
     peft: List[PreparedAdapter] = []
     branch: List[tuple] = []
     for a in adapters:
-        den, rest = w8a8_lora.split_state_dict(a.state_dict)
+        key = (type(pipe).__qualname__, a.cache_key)
+        cached = _SPLIT_CACHE.get(key)
+        if cached is None:
+            sd = w8a8_lora.normalize_adapter_state_dict(
+                pipe, a.state_dict, ref=a.ref
+            )
+            cached = w8a8_lora.split_state_dict(sd)
+            _SPLIT_CACHE[key] = cached
+            while len(_SPLIT_CACHE) > _SPLIT_CACHE_MAX:
+                _SPLIT_CACHE.popitem(last=False)
+        else:
+            _SPLIT_CACHE.move_to_end(key)
+        den, rest = cached
         if den:
             branch.append((den, a.weight, a.ref))
         if rest:
             peft.append(replace(a, state_dict=rest))
     return peft, branch
+
+
+def _reject_te_keys_on_cast_te(
+    pipe: Any, adapters: Sequence["PreparedAdapter"],
+) -> None:
+    """Typed refusal for text-encoder adapter halves on a cast TE (the
+    ``fp8+te`` lane): peft module wrapping under the block-window/layerwise
+    cast is the exact ie#374 breakage — fail loud, never fight the hooks."""
+    cast = [
+        name for name in _TE_COMPONENTS
+        if getattr(getattr(pipe, name, None), "_cozy_fp8_storage_applied", False)
+    ]
+    if not cast:
+        return
+    for a in adapters:
+        te_keys = [k for k in a.state_dict if k.startswith(_TE_KEY_PREFIXES)]
+        if te_keys:
+            raise RefCompatibilitySurprise(
+                f"adapter carries {len(te_keys)} text-encoder key(s) (e.g. "
+                f"{sorted(te_keys)[0]}) but this pipeline serves its text "
+                f"encoder(s) fp8-cast ({', '.join(cast)}) — text-encoder "
+                "adapters are unsupported on the fp8+te lane",
+                ref=a.ref, axis="state_dict",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -299,15 +349,21 @@ class AdapterResidency:
         """Make exactly *adapters* the pipeline's active set. Attach failure
         rolls back to a fully-deactivated pipeline.
 
-        w8a8 pipelines (gw#547): denoiser keys go to the bf16 side-branch on
-        Fp8ScaledLinear (peft can't target it); text-encoder keys keep the
-        peft path below."""
+        Branch-capable pipelines (gw#547 w8a8, gw#558 all lanes): denoiser
+        keys go to the additive side-branch (peft can't target
+        Fp8ScaledLinear and fights the layerwise-cast hooks — ie#374);
+        text-encoder keys keep the peft path below. Plain-bf16 pipelines
+        whose adapter cannot map onto branch-capable Linears (e.g. conv-
+        targeting LoCon) fall back to the whole-adapter peft path when the
+        pipeline supports it — capability preserved, branch primary."""
         from ..models import w8a8_lora
 
+        all_adapters = list(adapters)
         denoiser = w8a8_lora.branch_target(pipe)
         branch_set: List[tuple] = []
         if denoiser is not None:
-            adapters, branch_set = _split_for_w8a8(adapters)
+            adapters, branch_set = _split_adapters(pipe, adapters)
+            _reject_te_keys_on_cast_te(pipe, adapters)
         if adapters and not isinstance(pipe, LoraCapablePipeline):
             raise ValidationError(
                 "model slot does not support LoRA adapters "
@@ -316,25 +372,46 @@ class AdapterResidency:
         with self._lock:
             st = self._state(ref, pipe)
             try:
-                if denoiser is not None:
+                if denoiser is not None and branch_set:
                     # Compiled pipelines keep canonical placement and ONE
                     # traced bucket (a resize would mean a recompile at swap
                     # time — never allowed in prod); eager pipelines use
                     # sparse placement (branch kernels only where covered).
                     compiled = getattr(pipe, "_cozy_compile", None) is not None
-                    w8a8_lora.apply_branch_adapters(
-                        denoiser, branch_set,
-                        allow_resize=not compiled, uniform=compiled,
-                        request_id=request_id,
-                    )
+                    try:
+                        w8a8_lora.apply_branch_adapters(
+                            denoiser, branch_set,
+                            allow_resize=not compiled, uniform=compiled,
+                            request_id=request_id,
+                        )
+                    except RefCompatibilitySurprise:
+                        if (w8a8_lora.branch_lane(denoiser) == ""
+                                and not compiled
+                                and isinstance(pipe, LoraCapablePipeline)):
+                            logger.info(
+                                "[request_id=%s] adapter set does not map onto "
+                                "branch Linears; falling back to the peft path "
+                                "(plain lane)", request_id,
+                            )
+                            w8a8_lora.clear_branch_adapters(denoiser)
+                            w8a8_lora.stamp_lane(pipe, denoiser)
+                            adapters = all_adapters
+                        else:
+                            raise
+                    else:
+                        w8a8_lora.stamp_lane(pipe, denoiser)
+                elif denoiser is not None:
+                    # Adapter set has no denoiser half: make sure a previous
+                    # request's branches are off.
+                    w8a8_lora.clear_branch_adapters(denoiser)
                     w8a8_lora.stamp_lane(pipe, denoiser)
-                    if not adapters:
-                        # No peft half — make sure a previous request's TE
-                        # adapters are off, then we're done.
-                        if hasattr(pipe, "disable_lora"):
-                            pipe.disable_lora()
-                        st.active = True
-                        return
+                if denoiser is not None and not adapters:
+                    # No peft half — make sure a previous request's TE
+                    # adapters are off, then we're done.
+                    if hasattr(pipe, "disable_lora"):
+                        pipe.disable_lora()
+                    st.active = True
+                    return
                 load_ms = 0
                 attached_now: List[str] = []
                 for a in adapters:
@@ -401,15 +478,16 @@ class AdapterResidency:
                 denoiser = w8a8_lora.branch_target(pipe)
                 if denoiser is not None:
                     w8a8_lora.clear_branch_adapters(denoiser)
+                    w8a8_lora.stamp_lane(pipe, denoiser)
             except Exception:
                 logger.warning(
-                    "[request_id=%s] w8a8 lora branch clear failed", request_id,
+                    "[request_id=%s] lora branch clear failed", request_id,
                     exc_info=True,
                 )
             try:
                 if hasattr(pipe, "disable_lora"):
                     pipe.disable_lora()
-                else:
+                elif hasattr(pipe, "unload_lora_weights"):
                     pipe.unload_lora_weights()
                     st.attached.clear()
                 st.active = False

--- a/tests/test_runtime_lora.py
+++ b/tests/test_runtime_lora.py
@@ -348,3 +348,43 @@ def test_bf16_residency_branch_roundtrip_restores_output(bf16_unet: Any) -> None
         restored = unet(x, t).sample
     assert torch.equal(restored, base)
     assert pipe._cozy_weight_lane == ""  # type: ignore[attr-defined]
+
+
+class _PeftlessPipe:
+    """LTX-image shape (ie#493): the pipeline class EXPOSES the diffusers
+    lora surface but the image ships no peft — every peft call raises."""
+
+    def __init__(self, unet: Any) -> None:
+        self.unet = unet
+
+    def load_lora_weights(self, *a: Any, **k: Any) -> None:
+        raise ValueError("PEFT backend is required for this method.")
+
+    def set_adapters(self, *a: Any, **k: Any) -> None:
+        raise ValueError("PEFT backend is required for this method.")
+
+    def unload_lora_weights(self) -> None:
+        raise ValueError("PEFT backend is required for this method.")
+
+    def disable_lora(self) -> None:
+        raise ValueError("PEFT backend is required for this method.")
+
+
+def test_branch_only_attach_never_touches_peft_surface(bf16_unet: Any) -> None:
+    """gw#558 live find (ie#497 H100 run 3): denoiser-only adapters on a
+    peft-less image must attach/detach through the branch without ever
+    calling the diffusers peft surface."""
+    unet = _fresh(bf16_unet)
+    pipe = _PeftlessPipe(unet)
+    res = lora_util.AdapterResidency()
+    res.activate("m", pipe, [_prepared(_adapter_for(unet), "t/peftless")],
+                 request_id="r1")
+    assert w8a8_lora.branches_active(unet)
+    res.deactivate("m", pipe, request_id="r1")
+    assert not w8a8_lora.branches_active(unet)
+    # repeat attach after deactivate (the warm-swap path)
+    res.activate("m", pipe, [_prepared(_adapter_for(unet), "t/peftless")],
+                 request_id="r2")
+    assert w8a8_lora.branches_active(unet)
+    res.detach("m", pipe)
+    assert w8a8_lora.branch_bucket(unet) == 0

--- a/tests/test_runtime_lora.py
+++ b/tests/test_runtime_lora.py
@@ -1,0 +1,350 @@
+"""Lane-general runtime LoRA branches (gw#558).
+
+The gw#547 additive branch generalizes beyond Fp8ScaledLinear: plain
+``nn.Linear`` denoisers (bf16-resident lane) and layerwise-cast denoisers
+(the fp8-storage lane, where peft module wrapping breaks — ie#374) carry the
+same ``y += B(A @ x)`` branch through an instance-forward wrap, with
+bit-exact removal. CPU-safe throughout.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker.api.errors import RefCompatibilitySurprise  # noqa: E402
+from gen_worker.models import w8a8_lora  # noqa: E402
+from gen_worker.models.w8a8_lora import (  # noqa: E402
+    apply_branch_adapters,
+    branch_lane,
+    branch_modules,
+    branch_target,
+    clear_branch_adapters,
+    map_adapter,
+    normalize_adapter_state_dict,
+    stamp_lane,
+)
+from gen_worker.utils import lora as lora_util  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def bf16_unet() -> Any:
+    from diffusers import UNet2DModel
+
+    torch.manual_seed(11)
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    ).to(torch.bfloat16).eval()
+    return unet
+
+
+def _fresh(unet: Any) -> Any:
+    # Branch state is per-test: drop any leftover branches.
+    w8a8_lora.disable_lora_branches(unet)
+    return unet
+
+
+def _sample() -> tuple[Any, Any]:
+    torch.manual_seed(3)
+    return torch.randn(1, 3, 8, 8, dtype=torch.bfloat16), torch.tensor([4])
+
+
+def _adapter_for(unet: Any, n: int = 2, rank: int = 4,
+                 dotted: bool = True) -> Dict[str, Any]:
+    torch.manual_seed(5)
+    sd: Dict[str, Any] = {}
+    for path, mod in sorted(branch_modules(unet).items())[:n]:
+        base = f"unet.{path}" if dotted else "lora_unet_" + path.replace(".", "_")
+        sd[f"{base}.lora_down.weight"] = torch.randn(rank, mod.in_features)
+        sd[f"{base}.lora_up.weight"] = torch.randn(mod.out_features, rank)
+        sd[f"{base}.alpha"] = torch.tensor(float(rank))
+    return sd
+
+
+# ---------------------------------------------------------------------------
+# Plain bf16 lane
+# ---------------------------------------------------------------------------
+
+
+def test_bf16_linear_branch_applies_and_removes_bit_exact(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+    x, t = _sample()
+    with torch.no_grad():
+        base = unet(x, t).sample.clone()
+
+    sd = _adapter_for(unet)
+    apply_branch_adapters(unet, [(sd, 1.0, "t/bf16")])
+    assert w8a8_lora.branches_active(unet)
+    with torch.no_grad():
+        with_branch = unet(x, t).sample.clone()
+    assert not torch.equal(with_branch, base)
+
+    # Sparse (eager) clear drops the branch tensors -> the wrapped forward
+    # is a pure pass-through: bit-exact restore.
+    clear_branch_adapters(unet)
+    with torch.no_grad():
+        restored = unet(x, t).sample
+    assert torch.equal(restored, base)
+
+
+def test_bf16_branch_math_matches_manual_addend(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+    path, mod = sorted(branch_modules(unet).items())[0]
+    rank = 4
+    torch.manual_seed(7)
+    a = torch.randn(rank, mod.in_features)
+    b = torch.randn(mod.out_features, rank)
+    sd = {
+        f"unet.{path}.lora_down.weight": a,
+        f"unet.{path}.lora_up.weight": b,
+        f"unet.{path}.alpha": torch.tensor(float(rank)),
+    }
+    apply_branch_adapters(unet, [(sd, 0.5, "t/one")])
+    x = torch.randn(3, mod.in_features, dtype=torch.bfloat16)
+    with torch.no_grad():
+        y = mod(x)
+        expected = mod._cozy_lora_orig_forward(x) + 0.5 * (
+            (x @ a.to(torch.bfloat16).t()) @ b.to(torch.bfloat16).t()
+        )
+    assert torch.allclose(y.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+
+def test_bf16_lane_stamp_composes_on_plain_base(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+    pipe = SimpleNamespace(unet=unet)
+    assert branch_target(pipe) is unet
+    assert branch_lane(unet) == ""
+    apply_branch_adapters(unet, [(_adapter_for(unet), 1.0, "t/l")])
+    stamp_lane(pipe, unet)
+    assert pipe._cozy_weight_lane == "lora16-sparse"
+    clear_branch_adapters(unet)
+    stamp_lane(pipe, unet)
+    assert pipe._cozy_weight_lane == ""
+
+
+# ---------------------------------------------------------------------------
+# fp8-storage layerwise-cast lane (the ie#374 hook-fight experiment)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def cast_pipe() -> Any:
+    from diffusers import UNet2DModel
+
+    from gen_worker.models.loading import apply_fp8_storage
+
+    torch.manual_seed(11)
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    ).to(torch.bfloat16).eval()
+    pipe = SimpleNamespace(unet=unet)
+    assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16) is True
+    assert unet._cozy_fp8_storage_applied is True
+    return pipe
+
+
+def test_cast_lane_branch_composes_with_hooks_and_removes_bit_exact(
+    cast_pipe: Any,
+) -> None:
+    """The gw#558 verdict experiment: the additive branch must compose with
+    diffusers layerwise-cast hooks (fp8 weights at rest, per-module bf16
+    upcast) — the exact regime where peft module wrapping breaks (ie#374)."""
+    unet = _fresh(cast_pipe.unet)
+    assert branch_lane(unet) == "fp8-hooks"
+    assert any(p.dtype == torch.float8_e4m3fn for p in unet.parameters())
+
+    x, t = _sample()
+    with torch.no_grad():
+        base = unet(x, t).sample.clone()
+
+    sd = _adapter_for(unet, dotted=False)  # kohya-flat resolves too
+    apply_branch_adapters(unet, [(sd, 1.0, "t/cast")])
+    with torch.no_grad():
+        y1 = unet(x, t).sample.clone()
+        y2 = unet(x, t).sample.clone()
+    assert not torch.equal(y1, base)
+    # Deterministic across calls AND the branch tensors were never
+    # round-tripped through the fp8 cast (they live outside the hooks'
+    # reach in the module __dict__).
+    assert torch.equal(y1, y2)
+    for mod in branch_modules(unet).values():
+        a = mod.__dict__.get("lora_a")
+        if a is not None:
+            assert a.dtype == torch.bfloat16
+
+    clear_branch_adapters(unet)
+    with torch.no_grad():
+        restored = unet(x, t).sample
+    assert torch.equal(restored, base)
+
+
+def test_cast_lane_stamp(cast_pipe: Any) -> None:
+    unet = _fresh(cast_pipe.unet)
+    pipe = cast_pipe
+    for attr in ("_cozy_lora_base_lane", "_cozy_weight_lane"):
+        if hasattr(pipe, attr):
+            delattr(pipe, attr)
+    apply_branch_adapters(unet, [(_adapter_for(unet), 1.0, "t/c")])
+    stamp_lane(pipe, unet)
+    assert pipe._cozy_weight_lane == "fp8-hooks-lora16-sparse"
+    clear_branch_adapters(unet)
+    stamp_lane(pipe, unet)
+    assert pipe._cozy_weight_lane == "fp8-hooks"
+
+
+# ---------------------------------------------------------------------------
+# lora_state_dict normalization (te#81 zero-drift pattern)
+# ---------------------------------------------------------------------------
+
+
+class _ConverterPipe:
+    """Pipeline class exposing a lora_state_dict converter (the LTX2/sdxl
+    shape): renames vendor keys to diffusers format, returns network_alphas
+    separately."""
+
+    def __init__(self, unet: Any) -> None:
+        self.unet = unet
+
+    @classmethod
+    def lora_state_dict(cls, sd: Dict[str, Any]) -> tuple:
+        converted = {
+            k.replace("vendor_prefix.", "unet."): v
+            for k, v in sd.items() if not k.endswith(".alpha")
+        }
+        alphas = {
+            k.replace("vendor_prefix.", "unet.")[: -len(".alpha")]: float(v)
+            for k, v in sd.items() if k.endswith(".alpha")
+        }
+        return converted, alphas
+
+
+def test_normalize_via_pipeline_class_converter(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+    pipe = _ConverterPipe(unet)
+    path, mod = sorted(branch_modules(unet).items())[0]
+    rank = 4
+    raw = {
+        f"vendor_prefix.{path}.lora_down.weight": torch.randn(rank, mod.in_features),
+        f"vendor_prefix.{path}.lora_up.weight": torch.randn(mod.out_features, rank),
+        f"vendor_prefix.{path}.alpha": torch.tensor(2.0),
+    }
+    out = normalize_adapter_state_dict(pipe, raw, ref="t/n")
+    assert f"unet.{path}.lora_down.weight" in out
+    assert f"unet.{path}.alpha" in out  # network_alphas folded back in
+    mapped = map_adapter(
+        {k: v for k, v in out.items()}, unet, ref="t/n",
+    )
+    # alpha_scale = alpha/rank = 0.5
+    assert mapped[path][2] == pytest.approx(0.5)
+
+
+def test_normalize_without_converter_passes_through(bf16_unet: Any) -> None:
+    pipe = SimpleNamespace(unet=bf16_unet)
+    sd = {"unet.x.lora_down.weight": torch.zeros(1, 1)}
+    assert normalize_adapter_state_dict(pipe, sd, ref="t/p") is sd
+
+
+# ---------------------------------------------------------------------------
+# AdapterResidency routing (typed errors + fallback)
+# ---------------------------------------------------------------------------
+
+
+def _prepared(sd: Dict[str, Any], ref: str, weight: float = 1.0) -> Any:
+    return lora_util.PreparedAdapter(
+        slot="pipeline", ref=ref, cache_key=f"{ref}@{abs(hash(ref)):x}",
+        name=lora_util.adapter_name(ref), weight=weight, state_dict=sd,
+    )
+
+
+class _PeftRecordingPipe:
+    def __init__(self, unet: Any) -> None:
+        self.unet = unet
+        self.loaded: list = []
+        self.active: list = []
+
+    def load_lora_weights(self, sd: Any, adapter_name: str = "") -> None:
+        self.loaded.append((dict(sd), adapter_name))
+
+    def set_adapters(self, names: Any, adapter_weights: Any = None) -> None:
+        self.active = list(names)
+
+    def unload_lora_weights(self) -> None:
+        self.loaded.clear()
+
+    def disable_lora(self) -> None:
+        self.active = []
+
+    def enable_lora(self) -> None:
+        pass
+
+    def delete_adapters(self, name: str) -> None:
+        pass
+
+
+def test_te_keys_on_cast_te_fail_typed(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+    te = torch.nn.Linear(4, 4)
+    te._cozy_fp8_storage_applied = True  # type: ignore[attr-defined]
+    pipe = _PeftRecordingPipe(unet)
+    pipe.text_encoder = te  # type: ignore[attr-defined]
+    sd = _adapter_for(unet)
+    sd["text_encoder.layers.0.q_proj.lora_A.weight"] = torch.randn(4, 4)
+    sd["text_encoder.layers.0.q_proj.lora_B.weight"] = torch.randn(4, 4)
+    res = lora_util.AdapterResidency()
+    with pytest.raises(RefCompatibilitySurprise, match="fp8\\+te lane"):
+        res.activate("m", pipe, [_prepared(sd, "t/te-cast")])
+    assert not w8a8_lora.branches_active(unet)  # rollback left nothing active
+
+
+def test_unmappable_plain_lane_adapter_falls_back_to_peft(bf16_unet: Any) -> None:
+    """Conv-targeting adapters (LoCon-class) cannot ride the Linear branch;
+    on the PLAIN lane with a peft-capable pipeline they fall back to the
+    whole-adapter peft path instead of failing (capability preserved)."""
+    unet = _fresh(bf16_unet)
+    pipe = _PeftRecordingPipe(unet)
+    sd = {
+        "unet.conv_in.lora_down.weight": torch.randn(4, 3, 3, 3),
+        "unet.conv_in.lora_up.weight": torch.randn(32, 4, 1, 1),
+    }
+    res = lora_util.AdapterResidency()
+    res.activate("m", pipe, [_prepared(sd, "t/conv")], request_id="r1")
+    assert len(pipe.loaded) == 1
+    assert set(pipe.loaded[0][0]) == set(sd)  # WHOLE adapter went to peft
+    assert not w8a8_lora.branches_active(unet)
+
+
+def test_bf16_residency_branch_roundtrip_restores_output(bf16_unet: Any) -> None:
+    unet = _fresh(bf16_unet)
+
+    class _BarePipe:
+        def __init__(self, d: Any) -> None:
+            self.unet = d
+
+    pipe = _BarePipe(unet)
+    x, t = _sample()
+    with torch.no_grad():
+        base = unet(x, t).sample.clone()
+    res = lora_util.AdapterResidency()
+    res.activate("m", pipe, [_prepared(_adapter_for(unet), "t/rt")])
+    assert w8a8_lora.branches_active(unet)
+    with torch.no_grad():
+        changed = unet(x, t).sample
+    assert not torch.equal(changed, base)
+    res.deactivate("m", pipe)
+    with torch.no_grad():
+        restored = unet(x, t).sample
+    assert torch.equal(restored, base)
+    assert pipe._cozy_weight_lane == ""  # type: ignore[attr-defined]

--- a/tests/test_runtime_lora.py
+++ b/tests/test_runtime_lora.py
@@ -388,3 +388,58 @@ def test_branch_only_attach_never_touches_peft_surface(bf16_unet: Any) -> None:
     assert w8a8_lora.branches_active(unet)
     res.detach("m", pipe)
     assert w8a8_lora.branch_bucket(unet) == 0
+
+
+def test_split_cache_thread_safety(bf16_unet: Any) -> None:
+    """Review finding 1: _split_adapters races the module-level LRU from
+    concurrent worker threads — hammer it with distinct keys under the cap
+    churn and assert no corruption and stable results."""
+    import threading
+
+    unet = _fresh(bf16_unet)
+    pipe = SimpleNamespace(unet=unet)
+    sds = [_adapter_for(unet) for _ in range(12)]
+    errors: list = []
+
+    def worker(i: int) -> None:
+        try:
+            for j in range(30):
+                a = _prepared(sds[(i * 7 + j) % len(sds)], f"t/th-{(i * 7 + j) % len(sds)}")
+                peft, branch = lora_util._split_adapters(pipe, [a])
+                assert branch and not peft
+        except Exception as e:  # pragma: no cover - failure surface
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, errors
+
+
+def test_split_cache_keys_on_denoiser_config(bf16_unet: Any) -> None:
+    """Review finding 2: two checkpoints sharing one pipeline class but
+    differing in denoiser architecture must not share a normalized-split
+    entry (the SGM/kohya remap consults the config)."""
+    from diffusers import UNet2DModel
+
+    unet = _fresh(bf16_unet)
+    other = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(16, 16), layers_per_block=2,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    ).to(torch.bfloat16)
+    fp_a = lora_util._denoiser_fingerprint(SimpleNamespace(unet=unet))
+    fp_b = lora_util._denoiser_fingerprint(SimpleNamespace(unet=other))
+    assert fp_a and fp_b and fp_a != fp_b
+    # Same class + same adapter key, different config -> distinct cache rows
+    sd = _adapter_for(unet)
+    a = _prepared(sd, "t/fp")
+    lora_util._split_adapters(SimpleNamespace(unet=unet), [a])
+    keys = [k for k in lora_util._SPLIT_CACHE if k[2] == a.cache_key]
+    lora_util._split_adapters(SimpleNamespace(unet=other), [a])
+    keys2 = [k for k in lora_util._SPLIT_CACHE if k[2] == a.cache_key]
+    assert len(keys2) > len(keys) or keys2 != keys

--- a/tests/test_w8a8_lora.py
+++ b/tests/test_w8a8_lora.py
@@ -243,7 +243,7 @@ def test_bucket_growth_and_compiled_resize_refusal(denoiser: Any) -> None:
 
 
 def test_unresolved_and_misshaped_keys_fail_loud(denoiser: Any) -> None:
-    with pytest.raises(RefCompatibilitySurprise, match="no w8a8-quantized module"):
+    with pytest.raises(RefCompatibilitySurprise, match="no branch-capable Linear"):
         map_adapter({"lora_unet_no_such_block.lora_down.weight": torch.zeros(4, 8)},
                     denoiser, ref="t/x")
     picked = _pick(denoiser, 1)
@@ -395,17 +395,20 @@ def test_residency_refuses_resize_on_compiled_pipe(denoiser: Any) -> None:
     assert not w8a8_lora.branches_active(denoiser)
 
 
-def test_dequant_lane_keeps_peft_path(w8a8_tree: Path,
-                                      monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dequant_lane_is_branch_capable_plain(w8a8_tree: Path,
+                                              monkeypatch: pytest.MonkeyPatch) -> None:
     """On hosts without scaled_mm the denoiser is plain bf16 Linears —
-    branch_target must be None so the normal peft path applies."""
+    gw#558: those ride the additive branch too, on the PLAIN base lane
+    (pre-gw#558 they fell back to peft)."""
     from diffusers import DDPMPipeline
 
     monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
     from gen_worker.models.loading import load_from_pretrained
 
     pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
-    assert branch_target(pipe) is None
+    den = branch_target(pipe)
+    assert den is pipe.unet
+    assert w8a8_lora.branch_lane(den) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.32.2"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
ie#388 ruling (Paul, 2026-07-16): dynamic LoRAs are the PRIMARY serving path. This generalizes the gw#547 w8a8 side-branch to every serve lane so the LTX fp8+te lane (and any bf16-resident lane) can attach/detach adapters per request without peft module wrapping.

- `branch_target`/`branch_modules` generalize: Fp8ScaledLinear (w8a8) + plain `nn.Linear` (bf16-resident, fp8-storage layerwise-cast) are branch-capable; denoiser adapter halves ALWAYS ride the additive `y += B(A @ x)` branch.
- Plain Linears get an idempotent instance-forward wrap; branch tensors live in the module `__dict__` so cast hooks can never fp8-round-trip them. Removal is bit-exact (torch.equal-proven on both new lanes).
- **fp8-storage verdict: COMPOSES.** Real `apply_fp8_storage` (diffusers layerwise-cast hooks) + branch: numeric effect, deterministic, branch dtype preserved, bit-exact restore. The ie#374 breakage was peft-implementation-level, as ruled — no typed exclusion needed.
- Adapter normalization: pipeline class's own `lora_state_dict` converter FIRST (te#81 zero-drift pattern), existing diffusers/peft/kohya grammar as fallback; `network_alphas` folded back in.
- Typed errors: TE-targeting adapter halves on cast TEs (`fp8+te`) refuse with `RefCompatibilitySurprise`; conv-targeting (LoCon-class) adapters on the PLAIN lane fall back to whole-adapter peft (capability preserved), on quant/cast lanes they stay fail-loud.
- Lane stamps compose: `w8a8-lora32` / `fp8-hooks-lora32` / `lora32` (+`-sparse` eager), symmetric `lane_drift` keeps branch graphs and branchless cells apart; compiled pipelines still refuse bucket resizes at swap.

Tests: `tests/test_runtime_lora.py` (bf16 branch math + bit-exact removal, cast-lane hook composition experiment, lane stamps, lora_state_dict normalization, cast-TE typed error, peft fallback, residency roundtrip); full suite 1263 passed / 33 skipped locally (py3.12 locked env), mypy 122 files clean, ruff clean.

Consumer: ie#497 (LTX `loras` payload surface + three-way A/B live proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)