### PR TITLE
gw#559: capture image guidance regimes in Forge cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.32.2 (2026-07-16)
+
+- **gw#559 / ie#496: Forge captures every declared image CFG regime.**
+  `Compile.guidance_scales` is an explicit family-cell contract axis carried
+  through producer and local warmup, artifact metadata, and adoption drift
+  checks. SDXL can therefore capture ordinary CFG batch-2 and Turbo/no-CFG
+  batch-1 graphs in one checkpoint-independent `sdxl` cell.
+- **W8A8 exact-byte verification uses the declared quantization-input dtype.**
+  `verify_w8a8_snapshot` can cast immutable source storage to the code-owned
+  producer compute dtype before exact sampled byte/scale recomputation and
+  reports both storage and compute dtypes. This keeps production BF16 input
+  truthful for FP16-stored SDXL checkpoints without weakening exact equality.
+
 ## 0.32.1 (2026-07-16)
 
 - **ie#496: W8A8 production requires the exact compatible Forge cell.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - **gw#559 / ie#496: Forge captures every declared image CFG regime.**
   `Compile.guidance_scales` is an explicit family-cell contract axis carried
   through producer and local warmup, artifact metadata, and adoption drift
-  checks. SDXL can therefore capture ordinary CFG batch-2 and Turbo/no-CFG
-  batch-1 graphs in one checkpoint-independent `sdxl` cell.
+  checks. A compatible family can therefore capture ordinary CFG batch-2 and
+  no-CFG batch-1 graphs in one checkpoint-independent cell when both calls
+  share the same module graph. LoRA-mutated calls remain a separate cell lane.
 - **W8A8 exact-byte verification uses the declared quantization-input dtype.**
   `verify_w8a8_snapshot` can cast immutable source storage to the code-owned
   producer compute dtype before exact sampled byte/scale recomputation and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.32.1"
+version = "0.32.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -173,8 +173,8 @@ class Compile(msgspec.Struct, frozen=True):
     dialect-default shapes until they adopt buckets. CFG is a graph shape
     too: CFG variants trace batch-2 graphs, distilled variants batch-1.
     ``guidance_scales`` declares the image regimes Forge must warm into the
-    same family cell; for example ``(5.0, 0.0)`` captures both ordinary SDXL
-    and its no-CFG Turbo method without making checkpoint-specific cells.
+    same family cell; for example ``(5.0, 0.0)`` captures CFG and no-CFG calls
+    when they share one module graph. A LoRA-mutated graph needs its own lane.
     Empty preserves the pipeline's default. Declaring this does NOT force compilation: the
     worker arms torch.compile only when a verified cache artifact for
     (family, SKU, torch, triton) is seeded — otherwise it stays eager.

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -33,6 +33,7 @@ methods; only weight-sharing forces one class.
 from __future__ import annotations
 
 import inspect
+import math
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple, TypeVar, Union, overload
 
 import msgspec
@@ -170,8 +171,11 @@ class Compile(msgspec.Struct, frozen=True):
     that bucket table — one source of truth, 100% cache coverage of legal
     requests. Endpoints still accepting free width/height use the family's
     dialect-default shapes until they adopt buckets. CFG is a graph shape
-    too: CFG variants trace batch-2 graphs, distilled variants batch-1 —
-    a variant must never cross the boundary (clamp guidance_scale). Declaring this does NOT force compilation: the
+    too: CFG variants trace batch-2 graphs, distilled variants batch-1.
+    ``guidance_scales`` declares the image regimes Forge must warm into the
+    same family cell; for example ``(5.0, 0.0)`` captures both ordinary SDXL
+    and its no-CFG Turbo method without making checkpoint-specific cells.
+    Empty preserves the pipeline's default. Declaring this does NOT force compilation: the
     worker arms torch.compile only when a verified cache artifact for
     (family, SKU, torch, triton) is seeded — otherwise it stays eager.
     See ``gen_worker.compile_cache``.
@@ -180,6 +184,7 @@ class Compile(msgspec.Struct, frozen=True):
     shapes: tuple[tuple[int, ...], ...]
     targets: tuple[str, ...] = ("transformer", "vae.decode")
     family: str = ""
+    guidance_scales: tuple[float, ...] = ()
     # Regional compilation (diffusers compile_repeated_blocks): compile the
     # target's repeated transformer blocks instead of the whole forward.
     # REQUIRED for big fp8 layerwise-cast models (ie#381, measured on LTX
@@ -208,6 +213,15 @@ class Compile(msgspec.Struct, frozen=True):
             raise ValueError("Compile.targets must not be empty")
         force(self, "targets", targets)
         force(self, "family", str(self.family or "").strip())
+        guidance_scales = tuple(float(v) for v in self.guidance_scales)
+        if any(not math.isfinite(v) or v < 0.0 for v in guidance_scales):
+            raise ValueError(
+                "Compile.guidance_scales must contain finite non-negative values, "
+                f"got {self.guidance_scales!r}"
+            )
+        if len(set(guidance_scales)) != len(guidance_scales):
+            raise ValueError("Compile.guidance_scales must not contain duplicates")
+        force(self, "guidance_scales", guidance_scales)
 
 
 class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -23,7 +23,8 @@ are CODE: only the platform's first-party compile job publishes shared ones.
 Artifact = deterministic ``.tar.gz``::
 
     metadata.json      key: family, sku/torch/triton/cuda, shapes, targets,
-                       diffusers/transformers versions (+ source_ref info)
+                       image guidance regimes, diffusers/transformers
+                       versions (+ source_ref info)
     inductor/**        TORCHINDUCTOR_CACHE_DIR contents
     triton/**          TRITON_CACHE_DIR contents
 
@@ -234,6 +235,7 @@ def artifact_metadata(
     source_digest: str = "",
     shapes: Iterable[Tuple[int, ...]] = (),
     targets: Iterable[str] = (),
+    guidance_scales: Iterable[float] = (),
     low_vram_mode: str = "",
     storage_dtype: str = "",
     compile_mode: str = "whole",
@@ -252,7 +254,8 @@ def artifact_metadata(
     ``loading.pipeline_weight_lane`` — "" plain-resident, "fp8-hooks"
     layerwise-cast; the hooks are traced INTO the graphs, ie#381) and is
     parity-checked at :func:`enable` like ``low_vram_mode``. Shape rows are
-    (w, h) or (w, h, frames) — see ``Compile``."""
+    (w, h) or (w, h, frames); ``guidance_scales`` records the image CFG /
+    no-CFG graph regimes captured for every 2-D row — see ``Compile``."""
     return {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
@@ -263,6 +266,7 @@ def artifact_metadata(
         "source_digest": str(source_digest or ""),
         "shapes": [[int(v) for v in s] for s in shapes],
         "targets": list(targets),
+        "guidance_scales": [float(v) for v in guidance_scales],
         "low_vram_mode": str(low_vram_mode or ""),
         "storage_dtype": str(storage_dtype or ""),
         "compile_mode": str(compile_mode or "whole"),
@@ -731,6 +735,13 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     targets = [str(v) for v in getattr(cfg, "targets", ())]
     if meta.get("targets") != targets:
         return f"targets {meta.get('targets')!r} != declared {targets!r}"
+    guidance_scales = [float(v) for v in getattr(cfg, "guidance_scales", ())]
+    cell_guidance_scales = [float(v) for v in (meta.get("guidance_scales") or ())]
+    if cell_guidance_scales != guidance_scales:
+        return (
+            f"guidance_scales {cell_guidance_scales!r} != declared "
+            f"{guidance_scales!r}"
+        )
     signature, weight_contract = execution_contract(pipeline, cfg)
     meta_signature = str(meta.get("graph_signature") or "")
     meta_weights = meta.get("weight_contract") or {}
@@ -1030,6 +1041,7 @@ def _warm_call(
     steps: int,
     prompt: str,
     decode: bool,
+    guidance_scales: Iterable[float] = (),
 ) -> None:
     """One warm-up call for ``shape``. (w, h) is the classic image call;
     (w, h, frames) is a video call (ie#381): the DiT graph keys on the token
@@ -1037,7 +1049,9 @@ def _warm_call(
     serving path (including a two-stage refine, whose latents arrive from an
     upsampler of identical shape) will look up. Video calls force the
     batch-1 no-CFG serving regime (CFG is a graph shape — ``Compile``) and
-    skip decode unless a vae target is declared."""
+    skip decode unless a vae target is declared. Image calls run once per
+    explicitly declared guidance scale, capturing CFG batch-2 and no-CFG
+    batch-1 graphs in one family cell."""
     import inspect
 
     import torch
@@ -1059,7 +1073,24 @@ def _warm_call(
             kwargs["guidance_scale"] = 1.0
         if "audio_guidance_scale" in params:
             kwargs["audio_guidance_scale"] = 1.0
-    pipe(**kwargs)
+        pipe(**kwargs)
+        return
+
+    scales = tuple(float(v) for v in guidance_scales)
+    if not scales:
+        pipe(**kwargs)
+        return
+    params = inspect.signature(type(pipe).__call__).parameters
+    accepts_guidance = "guidance_scale" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+    if not accepts_guidance:
+        raise RuntimeError(
+            f"{type(pipe).__name__} cannot warm declared guidance_scales; "
+            "its call signature has no guidance_scale"
+        )
+    for scale in scales:
+        pipe(**kwargs, guidance_scale=scale)
 
 
 def build(
@@ -1068,6 +1099,7 @@ def build(
     *,
     shapes: Iterable[Tuple[int, ...]],
     targets: Iterable[str] = ("transformer", "vae.decode"),
+    guidance_scales: Iterable[float] = (),
     family: str = "",
     source_ref: str = "",
     source_digest: str = "",
@@ -1111,7 +1143,10 @@ def build(
     if not torch.cuda.is_available():
         raise RuntimeError("compile-cache build requires CUDA")
 
-    cfg = CompileCfg(shapes=tuple(shapes), targets=tuple(targets), regional=bool(regional))
+    cfg = CompileCfg(
+        shapes=tuple(shapes), targets=tuple(targets),
+        guidance_scales=tuple(guidance_scales), regional=bool(regional),
+    )
     pipe = load_from_pretrained(
         DiffusionPipeline, str(model_path), dtype=dtype,
         storage_dtype=storage_dtype,
@@ -1141,7 +1176,10 @@ def build(
     for shape in cfg.shapes:
         torch.cuda.synchronize()
         t = time.monotonic()
-        _warm_call(pipe, shape, steps=int(steps), prompt=prompt, decode=decode)
+        _warm_call(
+            pipe, shape, steps=int(steps), prompt=prompt, decode=decode,
+            guidance_scales=cfg.guidance_scales,
+        )
         torch.cuda.synchronize()
         key = "x".join(str(v) for v in shape)
         timings[key] = round(time.monotonic() - t, 2)
@@ -1160,6 +1198,7 @@ def build(
     meta = artifact_metadata(
         family=family, source_ref=source_ref, source_digest=source_digest,
         shapes=cfg.shapes, targets=cfg.targets,
+        guidance_scales=cfg.guidance_scales,
         low_vram_mode=str(placed.get("mode") or ""),
         storage_dtype=storage_dtype,
         compile_mode="regional" if regional else "whole",

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1207,6 +1207,7 @@ def verify_w8a8_snapshot(
     *,
     sample: int = 16,
     seed: int = 0,
+    source_compute_dtype: str = "storage",
 ) -> dict[str, Any]:
     """Byte-gate a produced w8a8 tree against its source (gw#557 / ie#494).
 
@@ -1218,13 +1219,34 @@ def verify_w8a8_snapshot(
     (b) ``dequant(w_fp8 x scale)`` must sit within fp8-e4m3 format error of
     the source (max row-relative error <= 2**-4 + subnormal floor).
     Raises :class:`ConversionImplementationError` on any failure; returns a
-    report dict for produce logs."""
+    report dict for produce logs. ``source_compute_dtype`` names the exact
+    producer-side quantization input view. For example, an immutable FP16
+    checkpoint loaded as production BF16 is cast to BF16 before exact
+    recomputation; storage and compute dtypes are both reported."""
     import random
 
     import torch
     from safetensors import safe_open
 
     from gen_worker.models.w8a8 import detect_w8a8_artifact
+
+    aliases = {
+        "storage": ("storage", None),
+        "": ("storage", None),
+        "bf16": ("bfloat16", torch.bfloat16),
+        "bfloat16": ("bfloat16", torch.bfloat16),
+        "fp16": ("float16", torch.float16),
+        "float16": ("float16", torch.float16),
+        "fp32": ("float32", torch.float32),
+        "float32": ("float32", torch.float32),
+    }
+    dtype_key = str(source_compute_dtype or "").strip().lower()
+    if dtype_key not in aliases:
+        raise ConversionImplementationError(
+            "byte-gate: source_compute_dtype must be one of storage, bf16, "
+            f"fp16, or fp32; got {source_compute_dtype!r}"
+        )
+    canonical_compute_dtype, cast_dtype = aliases[dtype_key]
 
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     art = detect_w8a8_artifact(out_dir)
@@ -1249,6 +1271,7 @@ def verify_w8a8_snapshot(
     rng = random.Random(seed)
     picked = names if len(names) <= sample else sorted(rng.sample(names, sample))
     max_rel = 0.0
+    source_storage_dtypes: set[str] = set()
     for layer in picked:
         wname, sname = f"{layer}.weight", f"{layer}{_SCALE_SUFFIX}"
         src_file = src_where.get(wname)
@@ -1256,7 +1279,11 @@ def verify_w8a8_snapshot(
             raise ConversionImplementationError(
                 f"byte-gate: quantized layer {wname!r} missing from source")
         with safe_open(str(src_file), framework="pt", device="cpu") as fh:
-            src = fh.get_tensor(wname).float()
+            stored = fh.get_tensor(wname)
+        source_storage_dtypes.add(str(stored.dtype).removeprefix("torch."))
+        if cast_dtype is not None:
+            stored = stored.to(dtype=cast_dtype)
+        src = stored.float()
         with safe_open(str(out_where[wname]), framework="pt", device="cpu") as fh:
             got_q = fh.get_tensor(wname)
         with safe_open(str(out_where[sname]), framework="pt", device="cpu") as fh:
@@ -1287,6 +1314,8 @@ def verify_w8a8_snapshot(
         "sampled": len(picked),
         "byte_exact": True,
         "max_rel_err": max_rel,
+        "source_storage_dtypes": sorted(source_storage_dtypes),
+        "source_compute_dtype": canonical_compute_dtype,
     }
 
 

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -687,6 +687,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
                 "shapes": [[int(v) for v in s] for s in es.compile.shapes],
                 "targets": list(es.compile.targets),
             }
+            if es.compile.guidance_scales:
+                fn["compile"]["guidance_scales"] = list(
+                    es.compile.guidance_scales
+                )
             # ie#381: the primary binding's weight-storage lane (gw#389 fp8
             # layerwise casting) rides along so the hub's cell producer
             # builds from an identically-loaded pipeline — the cast hooks

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -151,6 +151,7 @@ def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2) -> None:
             pipe, shape, steps=steps,
             prompt="cache warm-up: a lighthouse on a cliff at dawn, detailed",
             decode=decode,
+            guidance_scales=getattr(cfg, "guidance_scales", ()),
         )
         torch.cuda.synchronize()
         key = "x".join(str(v) for v in shape)
@@ -186,6 +187,7 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
         source_ref="local-mint",
         shapes=cfg.shapes,
         targets=cfg.targets,
+        guidance_scales=getattr(cfg, "guidance_scales", ()),
         low_vram_mode=low_vram_mode(pipe),
         compile_mode="regional" if getattr(cfg, "regional", False) else "whole",
         weight_lane=pipeline_weight_lane(pipe),

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -241,8 +241,10 @@ def test_unwrap_clears_regional_mods():
 
 
 def test_artifact_metadata_records_compile_mode():
-    meta = cc.artifact_metadata(family="ltx-2.3", shapes=[(960, 544, 241)],
-                                targets=["transformer"], compile_mode="regional")
+    meta = cc.artifact_metadata(
+        family="ltx-2.3", shapes=[(960, 544, 241)],
+        targets=["transformer"], compile_mode="regional",
+    )
     assert meta["compile_mode"] == "regional"
     default = cc.artifact_metadata(family="sd15", shapes=[(768, 768)], targets=["transformer"])
     assert default["compile_mode"] == "whole"
@@ -380,12 +382,22 @@ def test_compile_struct_validation():
     assert c.shapes == ((768, 768), (1024, 1024))
     assert c.targets == ("transformer", "vae.decode")
     assert c.family == "sd15"
+    assert c.guidance_scales == ()
+    assert Compile(
+        shapes=((1024, 1024),), guidance_scales=[5, 0],
+    ).guidance_scales == (5.0, 0.0)
     with pytest.raises(ValueError):
         Compile(shapes=())
     with pytest.raises(ValueError):
         Compile(shapes=((0, 768),))
     with pytest.raises(ValueError):
         Compile(shapes=((768, 768),), targets=())
+    with pytest.raises(ValueError, match="finite non-negative"):
+        Compile(shapes=((768, 768),), guidance_scales=(float("nan"),))
+    with pytest.raises(ValueError, match="finite non-negative"):
+        Compile(shapes=((768, 768),), guidance_scales=(-1.0,))
+    with pytest.raises(ValueError, match="duplicates"):
+        Compile(shapes=((768, 768),), guidance_scales=(5.0, 5.0))
 
 
 def test_compile_struct_video_shapes():
@@ -419,6 +431,51 @@ def test_artifact_metadata_video_shapes_and_storage_dtype():
     assert cc.verify(meta, family="ltx-2.3") == ""
 
 
+def test_guidance_regimes_are_artifact_contract_axis():
+    torch = pytest.importorskip("torch")
+
+    class _Pipe:
+        def __init__(self) -> None:
+            self.transformer = torch.nn.Linear(16, 16)
+
+    cfg = Compile(
+        family="sdxl", shapes=((1024, 1024),), targets=("transformer",),
+        guidance_scales=(5.0, 0.0),
+    )
+    meta = cc.artifact_metadata(
+        family="sdxl", shapes=cfg.shapes, targets=cfg.targets,
+        guidance_scales=cfg.guidance_scales,
+    )
+    assert meta["guidance_scales"] == [5.0, 0.0]
+    assert cc.contract_drift(meta, _Pipe(), cfg) == ""
+    assert "guidance_scales" in cc.contract_drift(
+        dict(meta, guidance_scales=[5.0]), _Pipe(), cfg,
+    )
+
+
+def test_warm_call_captures_cfg_and_no_cfg(monkeypatch):
+    torch = pytest.importorskip("torch")
+    calls = []
+
+    class _Generator:
+        def __init__(self, device=None) -> None:
+            self.device = device
+
+        def manual_seed(self, _seed):
+            return self
+
+    class _Pipe:
+        def __call__(self, *, guidance_scale=7.5, **_kwargs):
+            calls.append(guidance_scale)
+
+    monkeypatch.setattr(torch, "Generator", _Generator)
+    cc._warm_call(
+        _Pipe(), (1024, 1024), steps=2, prompt="warm", decode=False,
+        guidance_scales=(5.0, 0.0),
+    )
+    assert calls == [5.0, 0.0]
+
+
 class In(msgspec.Struct):
     prompt: str = ""
 
@@ -430,7 +487,10 @@ class Out(msgspec.Struct):
 def test_endpoint_compile_reaches_spec():
     import types
 
-    @endpoint(resources=Resources(vram_gb=4), compile=Compile(shapes=((768, 768),)))
+    @endpoint(
+        resources=Resources(vram_gb=4),
+        compile=Compile(shapes=((768, 768),), guidance_scales=(5.0, 0.0)),
+    )
     class Ep:
         def setup(self) -> None:
             pass
@@ -443,6 +503,7 @@ def test_endpoint_compile_reaches_spec():
     assert len(specs) == 1
     assert specs[0].compile is not None
     assert specs[0].compile.shapes == ((768, 768),)
+    assert specs[0].compile.guidance_scales == (5.0, 0.0)
 
     with pytest.raises(TypeError, match="compile="):
         @endpoint(compile="yes")  # type: ignore[arg-type]

--- a/tests/test_discovery_and_decorators.py
+++ b/tests/test_discovery_and_decorators.py
@@ -25,6 +25,7 @@ from typing import Annotated, AsyncIterator, Union
 
 import msgspec
 import pytest
+import gen_worker
 
 from gen_worker import (
     HF, Hub, Model, ModelChoice, ModelDefaults, ModelRef, RequestContext,
@@ -529,7 +530,6 @@ def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
     """ie#381: the lock's compile block carries (w, h, frames) rows verbatim
     and the primary binding's weight-storage lane, so the hub's cell producer
     builds from an identically-loaded (fp8) pipeline."""
-    import gen_worker
     from gen_worker import Compile, Hub
     from gen_worker.discovery.discover import _extract_entries
 
@@ -555,6 +555,7 @@ def test_compile_block_emits_video_shapes_and_storage_dtype() -> None:
     assert entry["compile"]["shapes"] == [[960, 544, 241], [1920, 1088, 241], [1280, 704, 121]]
     assert entry["compile"]["storage_dtype"] == "fp8"
     assert entry["compile"]["targets"] == ["transformer"]
+    assert "guidance_scales" not in entry["compile"]
 
 
 def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
@@ -564,7 +565,10 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
     @endpoint(
         model=Hub("cozy/sdxl-base"),
         resources=Resources(vram_gb=12),
-        compile=Compile(family="sdxl", shapes=((1024, 1024),)),
+        compile=Compile(
+            family="sdxl", shapes=((1024, 1024),),
+            guidance_scales=(5.0, 0.0),
+        ),
     )
     class Gen:
         def setup(self, model: str) -> None:
@@ -577,6 +581,7 @@ def test_compile_block_omits_storage_dtype_for_bf16_bindings() -> None:
 
     (entry,) = _extract_entries(Gen, "testmod")
     assert "storage_dtype" not in entry["compile"]
+    assert entry["compile"]["guidance_scales"] == [5.0, 0.0]
 
 
 def test_binding_emits_family_stamp_from_compile() -> None:

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -28,11 +28,15 @@ def _restore_capture_env(monkeypatch):
 class _Cfg:
     """Stand-in for api.decorators.Compile (duck-typed in local_cells)."""
 
-    def __init__(self, family="fam", shapes=((64, 64),), targets=("transformer",), regional=False):
+    def __init__(
+        self, family="fam", shapes=((64, 64),), targets=("transformer",),
+        regional=False, guidance_scales=(),
+    ):
         self.family = family
         self.shapes = tuple(tuple(s) for s in shapes)
         self.targets = tuple(targets)
         self.regional = regional
+        self.guidance_scales = tuple(guidance_scales)
 
 
 class _Pipe:

--- a/tests/test_w8a8_produce.py
+++ b/tests/test_w8a8_produce.py
@@ -178,6 +178,8 @@ def test_byte_gate_passes_then_catches_tampering(
     report = verify_w8a8_snapshot(tiny_dit, produced, sample=4)
     assert report["byte_exact"] and report["sampled"] == 4
     assert report["max_rel_err"] <= 2 ** -4 + 2 ** -9
+    assert report["source_compute_dtype"] == "storage"
+    assert report["source_storage_dtypes"] == ["bfloat16"]
 
     import shutil
 
@@ -197,6 +199,67 @@ def test_byte_gate_passes_then_catches_tampering(
     save_file(tensors, str(f))
     with pytest.raises(ConversionImplementationError, match="byte-gate"):
         verify_w8a8_snapshot(tiny_dit, bad, sample=len(art.quantized))
+
+
+def _rewrite_component_float_dtype(
+    root: Path, dtype: "torch.dtype", *, inject_fp16_detail: bool = False,
+) -> None:
+    from safetensors.torch import save_file
+
+    component = root / "transformer"
+    files = sorted(component.glob("*.safetensors"))
+    tensors = _load_all(component)
+    for name, value in tensors.items():
+        if value.is_floating_point():
+            converted = value.to(dtype=dtype)
+            if inject_fp16_detail and converted.ndim == 2 and converted.numel():
+                converted = converted.clone()
+                # Exactly representable in FP16, rounded to 1.0 in BF16. Put
+                # it at a row maximum so the declared compute cast changes
+                # both the exact scale and (where applicable) fp8 bytes.
+                converted.reshape(-1)[0] = 1.0009765625
+            tensors[name] = converted
+    for path in files:
+        path.unlink()
+    save_file(tensors, str(component / "diffusion_pytorch_model.safetensors"))
+    index = component / "diffusion_pytorch_model.safetensors.index.json"
+    if index.exists():
+        index.unlink()
+
+
+def test_byte_gate_uses_declared_bf16_quantization_input(
+    tiny_dit: Path, tmp_path: Path,
+) -> None:
+    """A prod#fp16 snapshot is quantized from its production BF16 compute
+    view; exact verification must reproduce that cast, not raw FP16 bytes."""
+    import shutil
+
+    fp16_source = tmp_path / "source-fp16"
+    shutil.copytree(tiny_dit, fp16_source)
+    _rewrite_component_float_dtype(
+        fp16_source, torch.float16, inject_fp16_detail=True,
+    )
+
+    bf16_input = tmp_path / "quant-input-bf16"
+    shutil.copytree(fp16_source, bf16_input)
+    _rewrite_component_float_dtype(bf16_input, torch.bfloat16)
+    candidate = tmp_path / "candidate"
+    streaming_w8a8_snapshot(bf16_input, candidate, file_layout="diffusers")
+
+    with pytest.raises(ConversionImplementationError, match="byte-gate"):
+        verify_w8a8_snapshot(fp16_source, candidate, sample=4)
+
+    report = verify_w8a8_snapshot(
+        fp16_source, candidate, sample=4, source_compute_dtype="bf16",
+    )
+    assert report["byte_exact"] is True
+    assert report["source_storage_dtypes"] == ["float16"]
+    assert report["source_compute_dtype"] == "bfloat16"
+
+    with pytest.raises(ConversionImplementationError, match="source_compute_dtype"):
+        verify_w8a8_snapshot(
+            fp16_source, candidate, source_compute_dtype="float8-e4m3",
+        )
 
 
 def test_dequant_round_trip_reproduces_source(tiny_dit: Path, produced: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.32.1"
+version = "0.32.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the two shared-runtime blockers found during independent review of ie#496.

- adds an explicit image guidance_scales axis to Compile, discovery manifests, Forge warmup, local minting, artifact metadata, and adoption drift checks
- lets one family-scoped cell capture all declared CFG/no-CFG regimes when the calls share the same module graph; LoRA-mutated calls remain an explicitly separate cell lane
- makes exact W8A8 sampled-byte verification reproduce an explicit source compute dtype and report immutable storage dtype separately from quantization compute dtype
- bumps gen-worker to 0.32.2

The SDXL base-family endpoint uses this for its ordinary CFG graph. Turbo is intentionally not claimed by the branchless family cell because its curated LoRA mutates the graph and requires a matching rank-bucketed runtime-LoRA cell.

Validation at signed head e7e9ec85d6b4cb8c90f9243cdec0cd7d6d980c14 on origin/master c7e9d1f9ec3f520bd54d5fe650307031f3e560e0:
- full suite: 1273 passed, 13 skipped
- mypy: zero errors in 122 source files
- source Ruff and HTTP-timeout guard: pass
- package build: 0.32.2 wheel and sdist produced
- focused post-review discovery/compile suite: 59 passed
- protected PR CI passed at the preceding code-equivalent head; current docs-only head is rerunning

No checkpoint-specific cell keys, cloud cell production, or paid GPU work are included. Draft pending independent exact-head review.