### PR TITLE
gw#561: lora-bucket compile cells — Compile.lora_bucket, branch-bearing build, lane-exact pick + boot branch-enable (0.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.34.0 (2026-07-17)
+
+- **gw#561 (gw#547 remainder; ie#488 turbo critical path): lora-bucket
+  compile cells.** `Compile(lora_bucket=N)` declares a dynamic-LoRA
+  endpoint's traced rank bucket: the worker enables canonical zeroed
+  rank-N branches after load/placement and BEFORE compile arming, so the
+  pipeline traces (and only adopts) the `<lane>-lora<bucket>` graph family;
+  staying eager rolls the branches back (canonical zeroed slots measured
+  +21-32% eager in gw#547). `compile_cache.build(lora_bucket=N)` produces
+  branch-bearing cells the same way — labels/metadata inherit the lane
+  (`inductor-<sku>-torch<mm>-w8a8-lora128`), plus a `lora_bucket` metadata
+  field. Cell pick at boot is lane-AND-bucket exact (a branchless endpoint
+  never fetches a lora cell and vice versa — both would lane_drift and
+  shadow the right cell); hub-pushed runtime adoption re-applies the
+  declared lane before the drift check and rolls it back on failure.
+  TRT engines never serve lora buckets. Discovery carries
+  `compile.lora_bucket` for the hub's producer reconciler (th#854/te#88).
+  Local cells (cozy-local self-mint) key, mint and adopt lora-bucket cells
+  through the same seam.
+
 ## 0.33.0 (2026-07-17)
 
 - **gw#558 (ie#388 dynamic-LoRA primary path): lane-general runtime LoRA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.33.0"
+version = "0.34.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -194,6 +194,12 @@ class Compile(msgspec.Struct, frozen=True):
     # graph per shape, reused across blocks). Cells record the mode — a
     # mode drift consumer stays eager (cache would miss anyway).
     regional: bool = False
+    # gw#561: dynamic-LoRA endpoints declare the traced rank bucket. The
+    # worker then serves the branch-bearing graph family: canonical zeroed
+    # rank-<bucket> branches enabled at load (gw#547 compiled-lane
+    # contract), only `<lane>-lora<bucket>` cells adopt, and adapter swaps
+    # stay buffer copies — never a recompile. 0 = branchless (today).
+    lora_bucket: int = 0
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -222,6 +228,16 @@ class Compile(msgspec.Struct, frozen=True):
         if len(set(guidance_scales)) != len(guidance_scales):
             raise ValueError("Compile.guidance_scales must not contain duplicates")
         force(self, "guidance_scales", guidance_scales)
+        bucket = int(self.lora_bucket or 0)
+        if bucket:
+            from ..models.w8a8_lora import RANK_BUCKETS
+
+            if bucket not in RANK_BUCKETS:
+                raise ValueError(
+                    f"Compile.lora_bucket must be 0 or one of {RANK_BUCKETS}, "
+                    f"got {self.lora_bucket!r}"
+                )
+        force(self, "lora_bucket", bucket)
 
 
 class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -49,6 +49,7 @@ import io
 import json
 import logging
 import os
+import re
 import shutil
 import tarfile
 import time
@@ -152,14 +153,31 @@ def gen_worker_version() -> str:
         return ""
 
 
+def lane_bucket(lane: str) -> Tuple[str, int]:
+    """(base lane, rank bucket) for a weight lane in stamp OR label-token
+    form: ``"w8a8-lora128"`` -> ``("w8a8", 128)``, ``"lora32"`` -> ``("", 32)``,
+    ``"w8a8"`` -> ``("w8a8", 0)``. Sparse stamps (eager-only, never cells)
+    do not parse as bucketed — they pass through as their whole string."""
+    m = re.search(r"(?:^|-)lora(\d+)$", str(lane or ""))
+    if m is None:
+        return str(lane or ""), 0
+    base = lane[: m.start()]
+    return base, int(m.group(1))
+
+
 def lane_token(weight_lane: str) -> str:
     """Label token for a traced weight lane (gw#534): cells of different
     lanes are DIFFERENT graphs and must not collide on one flavor label.
     "" (plain resident, incl. bf16-resident) stays unsuffixed. LoRA-branch
-    lanes (``w8a8-lora<bucket>``, gw#547) pass through — one graph family
-    per rank bucket."""
-    return {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8"}.get(
-        str(weight_lane or ""), str(weight_lane))
+    lanes (gw#547/gw#561) keep their base lane's token + the bucket suffix:
+    ``w8a8-lora128`` -> ``w8a8-lora128``, ``fp8-hooks-lora32`` ->
+    ``w8a16-lora32``, ``lora32`` -> ``lora32`` — one graph family per
+    (base lane, rank bucket)."""
+    base, bucket = lane_bucket(str(weight_lane or ""))
+    tok = {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8"}.get(base, base)
+    if bucket:
+        return f"{tok}-lora{bucket}" if tok else f"lora{bucket}"
+    return tok
 
 
 def flavor_label(sku: str, torch_version: str, weight_lane: str = "") -> str:
@@ -240,6 +258,7 @@ def artifact_metadata(
     storage_dtype: str = "",
     compile_mode: str = "whole",
     weight_lane: str = "",
+    lora_bucket: int = 0,
     graph_signature: str = "",
     weight_contract: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -271,6 +290,7 @@ def artifact_metadata(
         "storage_dtype": str(storage_dtype or ""),
         "compile_mode": str(compile_mode or "whole"),
         "weight_lane": str(weight_lane or ""),
+        "lora_bucket": int(lora_bucket or 0),
         "graph_signature": str(graph_signature or ""),
         "weight_contract": dict(weight_contract or {}),
         "libs": _lib_versions(),
@@ -511,6 +531,42 @@ def mode_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     if want != have:
         return f"low_vram_mode {want!r} != pipeline {have!r}"
     return ""
+
+
+def apply_lora_lane(pipeline: Any, bucket: int) -> bool:
+    """Put the pipeline on the branch-bearing graph family for ``bucket``
+    (gw#561): canonical zeroed rank-``bucket`` branches on every
+    branch-capable denoiser Linear (the gw#547 compiled-lane contract) + the
+    ``<base>-lora<bucket>`` lane stamp, so :func:`lane_drift` admits exactly
+    the matching lora cells. Raises when the pipeline has no branch-capable
+    denoiser — a declared bucket that cannot trace must fail loud, not
+    publish/adopt the wrong graph."""
+    if not bucket:
+        return False
+    from .models import w8a8_lora
+
+    denoiser = w8a8_lora.branch_target(pipeline)
+    if denoiser is None:
+        raise RuntimeError(
+            "Compile.lora_bucket declared but the pipeline has no "
+            "branch-capable denoiser (transformer/unet)"
+        )
+    w8a8_lora.enable_lora_branches(denoiser, int(bucket))
+    w8a8_lora.stamp_lane(pipeline, denoiser)
+    return True
+
+
+def drop_lora_lane(pipeline: Any) -> None:
+    """Undo :func:`apply_lora_lane`: drop the branch buffers and restore the
+    branchless lane stamp (the eager rollback — canonical zeroed branches
+    cost +21-32% eager, gw#547)."""
+    from .models import w8a8_lora
+
+    denoiser = w8a8_lora.branch_target(pipeline)
+    if denoiser is None:
+        return
+    w8a8_lora.disable_lora_branches(denoiser)
+    w8a8_lora.stamp_lane(pipeline, denoiser)
 
 
 def lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:
@@ -1110,6 +1166,7 @@ def build(
     prompt: str = "cache warm-up: a lighthouse on a cliff at dawn, detailed",
     declared_vram_gb: float = 0.0,
     serving_image_digest: str = "",
+    lora_bucket: int = 0,
 ) -> Tuple[Path, Dict[str, Any], Dict[str, float]]:
     """Compile a diffusers pipeline over ``shapes`` and package the resulting
     inductor+triton caches as a per-SKU artifact.
@@ -1163,6 +1220,11 @@ def build(
     # traced under travels in the metadata for adopt-time parity checks. Run
     # on a pod with the same free-VRAM class as the target workers.
     placed = place_pipeline(pipe)
+    # gw#561: branch-bearing cells trace WITH canonical zeroed rank-bucket
+    # branches installed — zeroed slots are bit-exact with branchless output
+    # (gw#547), so the warm calls render normally while the traced graphs
+    # carry the branch GEMMs.
+    apply_lora_lane(pipe, int(lora_bucket))
     if callable(getattr(pipe, "set_progress_bar_config", None)):
         pipe.set_progress_bar_config(disable=True)
     # Child processes (inductor compile workers) inherit the opt-in; this
@@ -1205,6 +1267,7 @@ def build(
         # gw#534: the lane the pipeline ACTUALLY traced under — the loader may
         # have upgraded a requested fp8 cast to bf16-resident on this pod.
         weight_lane=pipeline_weight_lane(pipe),
+        lora_bucket=int(lora_bucket or 0),
         graph_signature=graph_signature,
         weight_contract=weight_contract,
     )
@@ -1228,8 +1291,10 @@ __all__ = [
     "ENV_CACHE_PATH",
     "ENV_CACHE_URL",
     "apply",
+    "apply_lora_lane",
     "artifact_metadata",
     "capture_env",
+    "drop_lora_lane",
     "cell_lane",
     "contract_drift",
     "counters_delta",
@@ -1242,6 +1307,7 @@ __all__ = [
     "gen_worker_version",
     "inductor_counters",
     "is_cache_ref",
+    "lane_bucket",
     "lane_token",
     "lane_drift",
     "mode_drift",

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -702,6 +702,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
                 fn["compile"]["storage_dtype"] = storage
             if getattr(es.compile, "regional", False):
                 fn["compile"]["regional"] = True
+            # gw#561: dynamic-LoRA endpoints trace the branch-bearing graph
+            # family; the hub's producer must build `-lora<bucket>` cells.
+            if getattr(es.compile, "lora_bucket", 0):
+                fn["compile"]["lora_bucket"] = int(es.compile.lora_bucket)
         out.append(fn)
 
     return out

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -371,6 +371,25 @@ def _snapshot_to_resolved(snap: pb.Snapshot) -> "WorkerResolvedRepo":
     )
 
 
+def _cell_lane_matches(
+    ref: str, family: str, *, wants_w8a8: bool, want_bucket: int
+) -> bool:
+    """Whether an inductor cell ref serves this endpoint's graph family
+    (gw#561): the declared rank bucket is half of the identity — a
+    lora_bucket endpoint needs exactly a ``-lora<bucket>`` cell of its base
+    lane, and a branchless endpoint must never fetch one (either mismatch is
+    a guaranteed lane_drift that would shadow the right cell and serve
+    eager)."""
+    from . import compile_cache
+
+    if not compile_cache.is_cache_ref(ref, family):
+        return False
+    base, bucket = compile_cache.lane_bucket(compile_cache.cell_lane(ref))
+    if bucket != int(want_bucket or 0):
+        return False
+    return base == "w8a8" if wants_w8a8 else base != "w8a8"
+
+
 def _model_failure_vocab(exc: BaseException) -> str:
     """Contract §9 ModelEvent.error vocabulary for residency failures."""
     if is_cuda_oom(exc):
@@ -2477,23 +2496,24 @@ class Executor:
             ):
                 wants_w8a8 = True
                 break
+        want_bucket = int(getattr(spec.compile, "lora_bucket", 0) or 0)
         if wants_w8a8:
             # TensorRT cells currently expose only their plain fp16 contract.
             # The existing Forge's -w8a8 Inductor cell is the sole artifact
             # proven to preserve Fp8ScaledLinear/torch._scaled_mm semantics.
             candidates = [
                 (ref, snap) for ref, snap in snapshots.items()
-                if compile_cache.is_cache_ref(ref, family)
-                and compile_cache.cell_lane(ref) == "w8a8"
+                if _cell_lane_matches(
+                    ref, family, wants_w8a8=True, want_bucket=want_bucket)
             ]
         else:
-            candidates = [
+            candidates = ([
                 (ref, snap) for ref, snap in snapshots.items()
                 if trt_engine.is_engine_ref(ref, family)
-            ] + [
+            ] if not want_bucket else []) + [
                 (ref, snap) for ref, snap in snapshots.items()
-                if compile_cache.is_cache_ref(ref, family)
-                and compile_cache.cell_lane(ref) != "w8a8"
+                if _cell_lane_matches(
+                    ref, family, wants_w8a8=False, want_bucket=want_bucket)
             ]
         for ref, snap in candidates:
             try:
@@ -2940,12 +2960,30 @@ class Executor:
         async with self._gpu_semaphore:
             adopted: List[Tuple[_ClassRecord, EndpointSpec]] = []
             wrapped_objs: List[Any] = []
+            lane_objs: List[Any] = []
+
+            async def rollback() -> None:
+                for obj in wrapped_objs:
+                    compile_cache.unwrap(obj)
+                for obj in lane_objs:
+                    compile_cache.drop_lora_lane(obj)
+
             for rec, s in resident.values():
                 applied = False
                 for slot in self._setup_slots(s):
                     obj = self.store.residency.obj(wire_ref(s.models[slot]))
                     if obj is None:
                         continue
+                    # gw#561: a lora_bucket endpoint that stayed eager at boot
+                    # rolled its branches back; re-apply the declared graph
+                    # family so the pushed lora cell's lane can match.
+                    bucket = int(getattr(s.compile, "lora_bucket", 0) or 0)
+                    if bucket and not is_trt:
+                        try:
+                            compile_cache.apply_lora_lane(obj, bucket)
+                            lane_objs.append(obj)
+                        except Exception as exc:
+                            return await fail("lane_apply", str(exc))
                     if is_trt:
                         try:
                             await asyncio.to_thread(
@@ -2968,6 +3006,7 @@ class Executor:
                             or compile_cache.contract_drift(meta, obj, s.compile)
                         )
                         if drift:
+                            await rollback()
                             return await fail("key_mismatch", drift)
                         # Re-adoption of a re-published cell: drop the previous
                         # wrap + dynamo's in-memory code so warmup re-traces
@@ -2981,11 +3020,8 @@ class Executor:
                 if applied:
                     adopted.append((rec, s))
             if not adopted:
+                await rollback()
                 return await fail("no_target")
-
-            async def rollback() -> None:
-                for obj in wrapped_objs:
-                    compile_cache.unwrap(obj)
 
             counters_before = compile_cache.inductor_counters()
             warm_t0 = time.monotonic()

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -191,6 +191,7 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
         low_vram_mode=low_vram_mode(pipe),
         compile_mode="regional" if getattr(cfg, "regional", False) else "whole",
         weight_lane=pipeline_weight_lane(pipe),
+        lora_bucket=int(getattr(cfg, "lora_bucket", 0) or 0),
     )
     tmp = target.with_suffix(".part")
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -228,6 +229,13 @@ def enable_compiled(
 
     from .models.loading import pipeline_weight_lane
 
+    # gw#561: the eager-miss rollback in provision.enable_compiled dropped
+    # the branch lane; local store/mint must key + trace the DECLARED graph
+    # family, so re-apply it for the rest of this arming attempt.
+    bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
+    if bucket:
+        cc.apply_lora_lane(pipe, bucket)
+
     target = cell_path(family, pipeline_weight_lane(pipe))
     if target.exists():
         reason = store_verdict(target, family, pipe, cfg)
@@ -245,6 +253,8 @@ def enable_compiled(
             "compiler is installed (need cc/gcc/clang); serving eager. "
             "Install one to let cozy compile once and cache the result."
         )
+        if bucket:
+            cc.drop_lora_lane(pipe)
         return False
     _say(
         f"local-cells: no compile cell for this GPU/torch yet — compiling "
@@ -257,6 +267,8 @@ def enable_compiled(
     except Exception as exc:  # noqa: BLE001 — mint failure => eager, never fatal
         logger.warning("local-cells: mint failed (%s); serving eager", exc)
         cc.unwrap(pipe)
+        if bucket:
+            cc.drop_lora_lane(pipe)
         return False
     # Adopt the just-saved cell through the delivered-cell path (drops the
     # unguarded mint wrappers; re-traces hit the captured FX cache). This
@@ -265,6 +277,8 @@ def enable_compiled(
     if cc.enable(pipe, cfg, cache_dir, artifact=target):
         return True
     logger.warning("local-cells: minted cell failed re-adoption; serving eager")
+    if bucket:
+        cc.drop_lora_lane(pipe)
     return False
 
 

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -171,10 +171,21 @@ def enable_compiled(
     """Arm the best available compiled path for a freshly loaded pipeline:
     a TRT engine artifact swaps the module (fail-soft), anything else goes
     through the torch.compile cache policy (which also covers the no-
-    artifact and ALLOW_COLD lanes)."""
+    artifact and ALLOW_COLD lanes).
+
+    ``Compile.lora_bucket`` (gw#561) puts the pipeline on the branch-bearing
+    graph family BEFORE arming, so only matching ``-lora<bucket>`` cells
+    adopt. Staying eager rolls the branches back — canonical zeroed slots
+    cost +21-32% eager (gw#547); the eager adapter path re-enables sparse
+    placement per request."""
     from .. import compile_cache, trt_engine
 
-    if artifact is not None:
+    bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
+    if bucket:
+        compile_cache.apply_lora_lane(pipe, bucket)
+    if artifact is not None and not bucket:
+        # TRT engines expose only their plain contract — a lora_bucket
+        # declaration always rides the inductor lane.
         try:
             meta = trt_engine.unpack_metadata(Path(artifact))
         except Exception:
@@ -183,7 +194,10 @@ def enable_compiled(
             if trt_engine.enable(pipe, cfg, cache_dir, artifact):
                 return True
             artifact = None  # unusable engine: fall through to eager policy
-    return compile_cache.enable(pipe, cfg, cache_dir, artifact)
+    armed = compile_cache.enable(pipe, cfg, cache_dir, artifact)
+    if bucket and not armed:
+        compile_cache.drop_lora_lane(pipe)
+    return armed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -17,7 +17,7 @@ pytest.importorskip("accelerate")
 from gen_worker import compile_cache
 from gen_worker.api.decorators import Compile
 from gen_worker.executor import _cell_lane_matches
-from gen_worker.models import provision, w8a8_lora
+from gen_worker.models import provision
 from gen_worker.models.w8a8 import detect_w8a8_artifact, load_w8a8_denoiser, quantize_tree_w8a8
 from gen_worker.models.w8a8_lora import RANK_BUCKETS, branch_bucket
 

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -1,0 +1,210 @@
+"""Lora-bucket compile cells (gw#561): Compile.lora_bucket declaration, lane
+parsing/labels, branch-bearing lane apply/rollback through the real arming
+path, and the lane-exact cell pick — all against real modules (CPU; the
+GPU build/adopt/tax proof runs on the pod rig)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker import compile_cache
+from gen_worker.api.decorators import Compile
+from gen_worker.executor import _cell_lane_matches
+from gen_worker.models import provision, w8a8_lora
+from gen_worker.models.w8a8 import detect_w8a8_artifact, load_w8a8_denoiser, quantize_tree_w8a8
+from gen_worker.models.w8a8_lora import RANK_BUCKETS, branch_bucket
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("loracells") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return quantize_tree_w8a8(root, root.parent / "w8a8")
+
+
+@pytest.fixture()
+def w8a8_pipe(w8a8_tree: Path) -> Any:
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+
+    class _Pipe:
+        pass
+
+    pipe = _Pipe()
+    pipe.unet = load_w8a8_denoiser(w8a8_tree, art, mode="scaled_mm")
+    pipe._cozy_weight_lane = "w8a8"
+    return pipe
+
+
+@pytest.fixture()
+def plain_pipe() -> Any:
+    class _Pipe:
+        pass
+
+    class _Denoiser(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = torch.nn.Linear(16, 16)
+
+    pipe = _Pipe()
+    pipe.unet = _Denoiser()
+    return pipe
+
+
+# ---------------------------------------------------------------------------
+# Declaration + lane grammar
+# ---------------------------------------------------------------------------
+
+
+def test_compile_lora_bucket_validation() -> None:
+    cfg = Compile(shapes=((64, 64),), family="f", lora_bucket=32)
+    assert cfg.lora_bucket == 32
+    assert Compile(shapes=((64, 64),), family="f").lora_bucket == 0
+    for bad in (-1, 8, 17, 256):
+        with pytest.raises(ValueError):
+            Compile(shapes=((64, 64),), family="f", lora_bucket=bad)
+
+
+def test_lane_bucket_parses_stamp_and_token_forms() -> None:
+    assert compile_cache.lane_bucket("") == ("", 0)
+    assert compile_cache.lane_bucket("w8a8") == ("w8a8", 0)
+    assert compile_cache.lane_bucket("w8a8-lora128") == ("w8a8", 128)
+    assert compile_cache.lane_bucket("w8a16-lora32") == ("w8a16", 32)
+    assert compile_cache.lane_bucket("fp8-hooks-lora64") == ("fp8-hooks", 64)
+    assert compile_cache.lane_bucket("lora32") == ("", 32)
+    # sparse stamps are eager-only and never parse as a cell bucket
+    assert compile_cache.lane_bucket("w8a8-lora32-sparse") == ("w8a8-lora32-sparse", 0)
+
+
+def test_lane_token_and_label_carry_bucket() -> None:
+    assert compile_cache.lane_token("w8a8-lora128") == "w8a8-lora128"
+    assert compile_cache.lane_token("fp8-hooks-lora32") == "w8a16-lora32"
+    assert compile_cache.lane_token("lora32") == "lora32"
+    assert compile_cache.flavor_label("h100-sxm", "2.13.0+cu130", "w8a8-lora128") == (
+        "inductor-h100-sxm-torch2.13-w8a8-lora128")
+    assert compile_cache.flavor_label("rtx-4090", "2.13.0", "lora32") == (
+        "inductor-rtx-4090-torch2.13-lora32")
+
+
+def test_cell_lane_roundtrip_through_ref() -> None:
+    ref = "_system/family-qwen-image#inductor-h100-sxm-torch2.13-w8a8-lora128"
+    assert compile_cache.cell_lane(ref) == "w8a8-lora128"
+    assert compile_cache.lane_bucket(compile_cache.cell_lane(ref)) == ("w8a8", 128)
+
+
+# ---------------------------------------------------------------------------
+# Lane apply/rollback (real w8a8 + plain denoisers)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_lora_lane_stamps_and_allocates(w8a8_pipe: Any) -> None:
+    assert compile_cache.apply_lora_lane(w8a8_pipe, 128)
+    assert branch_bucket(w8a8_pipe.unet) == 128
+    assert w8a8_pipe._cozy_weight_lane == "w8a8-lora128"
+    meta = compile_cache.artifact_metadata(
+        family="f", weight_lane="w8a8-lora128", lora_bucket=128)
+    assert compile_cache.lane_drift(meta, w8a8_pipe) == ""
+    assert meta["lora_bucket"] == 128
+    # branchless cells refuse the branch-bearing pipeline (symmetric guard)
+    assert "weight_lane" in compile_cache.lane_drift(
+        compile_cache.artifact_metadata(family="f", weight_lane="w8a8"), w8a8_pipe)
+    compile_cache.drop_lora_lane(w8a8_pipe)
+    assert branch_bucket(w8a8_pipe.unet) == 0
+    assert w8a8_pipe._cozy_weight_lane == "w8a8"
+
+
+def test_apply_lora_lane_zero_bucket_is_noop(w8a8_pipe: Any) -> None:
+    assert compile_cache.apply_lora_lane(w8a8_pipe, 0) is False
+    assert branch_bucket(w8a8_pipe.unet) == 0
+
+
+def test_apply_lora_lane_requires_denoiser() -> None:
+    class _NoDenoiser:
+        pass
+
+    with pytest.raises(RuntimeError, match="branch-capable"):
+        compile_cache.apply_lora_lane(_NoDenoiser(), 32)
+
+
+def test_enable_compiled_rolls_back_branches_when_eager(plain_pipe: Any) -> None:
+    """No cell + no CUDA => stays eager; the declared branch lane must not
+    leak into eager serving (canonical zeroed slots cost +21-32% eager)."""
+    cfg = Compile(shapes=((64, 64),), family="loracells-test", lora_bucket=32)
+    armed = provision.enable_compiled(plain_pipe, cfg, cache_dir=None, artifact=None)
+    assert armed is False
+    assert branch_bucket(plain_pipe.unet) == 0
+    from gen_worker.models.loading import pipeline_weight_lane
+
+    assert pipeline_weight_lane(plain_pipe) == ""
+
+
+def test_enable_compiled_w8a8_fail_closed_keeps_contract(w8a8_pipe: Any) -> None:
+    cfg = Compile(shapes=((64, 64),), family="loracells-test", lora_bucket=128)
+    with pytest.raises(compile_cache.CompiledLaneUnavailableError):
+        provision.enable_compiled(w8a8_pipe, cfg, cache_dir=None, artifact=None)
+
+
+# ---------------------------------------------------------------------------
+# Lane-exact cell pick (the boot-attach filter)
+# ---------------------------------------------------------------------------
+
+
+def test_cell_pick_is_lane_and_bucket_exact() -> None:
+    fam = "qwen-image"
+    plain = f"_system/family-{fam}#inductor-h100-sxm-torch2.13"
+    w8a8 = f"_system/family-{fam}#inductor-h100-sxm-torch2.13-w8a8"
+    w8a8_l128 = f"_system/family-{fam}#inductor-h100-sxm-torch2.13-w8a8-lora128"
+    w8a8_l32 = f"_system/family-{fam}#inductor-h100-sxm-torch2.13-w8a8-lora32"
+    plain_l32 = f"_system/family-{fam}#inductor-h100-sxm-torch2.13-lora32"
+
+    def pick(ref: str, *, w8a8_lane: bool, bucket: int) -> bool:
+        return _cell_lane_matches(ref, fam, wants_w8a8=w8a8_lane, want_bucket=bucket)
+
+    # branchless w8a8 endpoint: exactly the branchless w8a8 cell
+    assert pick(w8a8, w8a8_lane=True, bucket=0)
+    assert not pick(w8a8_l128, w8a8_lane=True, bucket=0)
+    assert not pick(plain, w8a8_lane=True, bucket=0)
+    # lora128 w8a8 endpoint: exactly the lora128 w8a8 cell
+    assert pick(w8a8_l128, w8a8_lane=True, bucket=128)
+    assert not pick(w8a8, w8a8_lane=True, bucket=128)
+    assert not pick(w8a8_l32, w8a8_lane=True, bucket=128)
+    assert not pick(plain_l32, w8a8_lane=True, bucket=128)
+    # plain lora32 endpoint: never a w8a8 cell, never branchless
+    assert pick(plain_l32, w8a8_lane=False, bucket=32)
+    assert not pick(w8a8_l32, w8a8_lane=False, bucket=32)
+    assert not pick(plain, w8a8_lane=False, bucket=32)
+    # wrong family never matches
+    assert not _cell_lane_matches(
+        w8a8_l128, "sdxl", wants_w8a8=True, want_bucket=128)
+
+
+def test_rank_buckets_cover_declared_cells() -> None:
+    # The produced buckets (32 civitai-common, 128 Lightning) are declared
+    # RANK_BUCKETS members — the survey-tuned contract.
+    assert 32 in RANK_BUCKETS and 128 in RANK_BUCKETS
+
+
+def test_discovery_carries_lora_bucket() -> None:
+    cfg = Compile(shapes=((64, 64),), family="f", lora_bucket=64)
+    assert cfg.lora_bucket == 64
+    # metadata parity: producer meta records the bucket beside the lane
+    meta = compile_cache.artifact_metadata(
+        family="f", weight_lane="w8a8-lora64", lora_bucket=64)
+    assert meta["weight_lane"] == "w8a8-lora64"
+    assert meta["lora_bucket"] == 64

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
gw#547's integration remainder (critical path for ie#488 turbo 3-4s and BYOM LoRAs at w8a8 speed).

- `Compile(lora_bucket=N)` (0 or RANK_BUCKETS): endpoint declares the traced rank bucket. `provision.enable_compiled` enables canonical zeroed rank-N branches (gw#547 compiled-lane contract) + stamps `<lane>-lora<bucket>` BEFORE arming, so only matching lora cells adopt; staying eager rolls the branches back (canonical zeroed slots cost +21-32% eager).
- `compile_cache.build(lora_bucket=N)`: branch-bearing producer path — labels/metadata inherit the lane (`inductor-<sku>-torch<mm>-w8a8-lora128`), `lora_bucket` metadata field, `lane_bucket()`/`apply_lora_lane()`/`drop_lora_lane()` helpers; `lane_token` maps the base lane through the existing table (`fp8-hooks-lora32` -> `w8a16-lora32`).
- Boot cell pick is lane-AND-bucket exact (`_cell_lane_matches`): a branchless endpoint never fetches a lora cell and vice versa — either mismatch is a guaranteed lane_drift that would shadow the right cell and serve eager. TRT never serves lora buckets.
- Hub-pushed runtime adoption (`_adopt_compile_cache`) re-applies the declared lane before the drift check; every failure path rolls both the wrap and the lane back.
- Discovery carries `compile.lora_bucket` (hub producer reconciler = th#854; conversion payload = te#88).
- local_cells parity: mint/adopt lora-bucket cells through the same seam.

Tests: tests/test_lora_cells.py (12) — declaration validation, lane grammar/labels, apply/rollback through the real arming path on a real scaled_mm denoiser, w8a8 fail-closed preserved, lane+bucket-exact pick matrix. Full suite 1285 passed / 33 skipped; mypy 122 files clean; ruff clean.

GPU proof (RunPod SECURE): compiled branch-tax table per bucket + adopt/swap zero-recompile — landing in gw#561 tracker after this merges (rig ready).

Cross-refs: gw#547 (PR #266), gw#558 (0.33.0), te#88, th#854, ie#488, te PR #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)