### PR TITLE
gw#562: w8a8 lane for root-layout (DiffSynth/singlefile) families — hidream-o1 + anima (0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.35.0 (2026-07-17)
+
+- **gw#562: w8a8 lane for root-layout (DiffSynth/singlefile) families —
+  hidream-o1 + anima.** The `#fp8-w8a8` path drops its diffusers-tree
+  assumption end to end. Producer: `streaming_w8a8_snapshot` accepts any
+  non-diffusers layout with a single root weight set (hidream-o1's
+  sharded-transformers root) — same per-channel requant, byte-gate
+  unchanged. Detector: `detect_w8a8_artifact` header-sniffs root shard
+  sets (index-aware) when no `model_index.json` exists; artifact
+  `component=""` marks the root layout. Serve: pipeline classes that
+  construct their own model (DiffSynth `from_pretrained` wrappers) call
+  `sanitize_w8a8_state_dict` while reading shards — quantized weights
+  dequant correctly on ANY host (never an unscaled fp8 upcast) — and
+  `load_from_pretrained` then swaps the constructed denoiser's quantized
+  Linears onto `Fp8ScaledLinear` in place (`swap_w8a8_linears`, module
+  path = tensor key, `key_map` hook for converter-renamed checkpoints
+  like anima's `net.` strip). Lane stamps (`w8a8`/`bf16-resident`),
+  scale-presence exclusion, and skip patterns are identical to the
+  diffusers lane. DiffSynth families have no compile cells yet — the
+  root lane serves eager w8a8.
+
 ## 0.34.0 (2026-07-17)
 
 - **gw#561 (gw#547 remainder; ie#488 turbo critical path): lora-bucket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.34.0"
+version = "0.35.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1150,11 +1150,39 @@ def streaming_w8a8_snapshot(
     encoders serve W8-storage, only the denoiser runs fp8 GEMMs). Every
     other component passes through untouched. The denoiser's config gains
     the gw#534 corroborating ``quantization_config`` (the safetensors
-    headers stay authoritative for detection)."""
+    headers stay authoritative for detection).
+
+    Non-diffusers layouts (gw#562) require a SINGLE root weight set — the
+    sharded-transformers/singlefile trees the DiffSynth families mirror,
+    where that weight set IS the denoiser. It gets the same requant; no
+    component config exists, so the headers alone carry detection."""
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     if file_layout != "diffusers":
-        raise ConversionImplementationError(
-            "w8a8 flavors need component identity: diffusers layout only")
+        if te_components:
+            raise ConversionImplementationError(
+                "te_components need a diffusers layout (no component "
+                f"identity in {file_layout!r})")
+        root_groups = snapshot_weight_groups(source_dir, file_layout)
+        if len(root_groups) != 1 or root_groups[0][0] != "":
+            raise ConversionImplementationError(
+                "w8a8 flavors need component identity: a diffusers layout, "
+                "or a single root weight set — found "
+                f"{len(root_groups)} weight set(s) in {file_layout!r} layout")
+        entry = root_groups[0][1]
+        result = streaming_w8a8_cast(
+            entry, out_dir,
+            shard_prefix=_group_shard_prefix(entry),
+            shard_threshold=shard_threshold,
+        )
+        if not int(result["converted_count"]):
+            raise ConversionImplementationError(
+                "no w8a8-eligible weights in the root weight set (nothing "
+                "2-D/16-aligned under a repeated-block container missed "
+                "the skip patterns)")
+        copy_non_weight_files(source_dir, out_dir, skip_components={""})
+        return {"tensor_count": int(result["tensor_count"]),
+                "converted_count": int(result["converted_count"]),
+                "components": [""], "output_dir": out_dir}
     denoiser_set, te_set = set(components), set(te_components)
     groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
               if c in denoiser_set | te_set]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1153,7 +1153,11 @@ def load_from_pretrained(
     # scaled-mm lane (fp8 resident, no per-layer cast); hosts without usable
     # scaled_mm dequant once to bf16-resident. Precedes the storage-cast
     # rungs — a scale-free fp8 tree never detects here.
-    from .w8a8 import detect_w8a8_artifact, load_w8a8_pipeline
+    from .w8a8 import (
+        detect_w8a8_artifact,
+        load_w8a8_pipeline,
+        load_w8a8_root_pipeline,
+    )
 
     w8a8_art = detect_w8a8_artifact(Path(path))
     if w8a8_art is not None and callable(getattr(cls, "from_pretrained", None)):
@@ -1163,6 +1167,18 @@ def load_from_pretrained(
                 compute = get_torch_dtype(dtype)
             except ImportError:
                 pass
+        if not w8a8_art.component:
+            # Root layout (gw#562): the pipeline class's own loader
+            # constructs; the worker swaps post-construction.
+            if components:
+                logger.warning(
+                    "preloaded components ignored on the root w8a8 lane")
+            if storage_dtype == "fp8+te":
+                logger.warning(
+                    "storage_dtype=fp8+te ignored on the root w8a8 lane "
+                    "(no component identity)")
+            return load_w8a8_root_pipeline(
+                cls, Path(path), w8a8_art, compute_dtype=compute)
         return load_w8a8_pipeline(
             cls, Path(path), w8a8_art, compute_dtype=compute,
             components=components,

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -56,8 +56,11 @@ class W8a8SnapshotError(W8a8Error):
 
 @dataclass(frozen=True)
 class W8a8Artifact:
-    component: str            # denoiser dir name ("transformer"/"unet")
-    files: tuple[Path, ...]   # the component's safetensors shards
+    # Denoiser dir name ("transformer"/"unet") for diffusers trees; "" for a
+    # root-layout snapshot (singlefile/sharded-transformers, gw#562) whose
+    # weight set IS the denoiser.
+    component: str
+    files: tuple[Path, ...]   # the weight set's safetensors shards
     quantized: tuple[str, ...]  # module names with weight+weight_scale pairs
     static_input_scales: bool
 
@@ -77,36 +80,69 @@ def _read_header(path: Path) -> dict:
     return header if isinstance(header, dict) else {}
 
 
+def _quantized_layers(files: tuple[Path, ...]) -> tuple[tuple[str, ...], bool]:
+    dtypes: Dict[str, str] = {}
+    for f in files:
+        for name, info in _read_header(f).items():
+            if isinstance(info, dict) and "dtype" in info:
+                dtypes[name] = str(info["dtype"])
+    quantized = tuple(sorted(
+        key[: -len(".weight_scale")]
+        for key in dtypes
+        if key.endswith(".weight_scale")
+        and dtypes.get(key[: -len(".weight_scale")] + ".weight") == "F8_E4M3"
+    ))
+    static = any(f"{n}.input_scale" in dtypes for n in quantized)
+    return quantized, static
+
+
+def _root_weight_files(d: Path) -> tuple[Path, ...]:
+    """Root weight set: index-mapped shards plus loose safetensors."""
+    sharded: set[str] = set()
+    for idx in sorted(d.glob("*.safetensors.index.json")):
+        try:
+            weight_map = json.loads(idx.read_text("utf-8")).get("weight_map") or {}
+            sharded.update(str(v) for v in weight_map.values())
+        except (OSError, ValueError):
+            continue
+    files = [d / s for s in sorted(sharded) if (d / s).is_file()]
+    files += [p for p in sorted(d.glob("*.safetensors"))
+              if p.is_file() and p.name not in sharded]
+    return tuple(dict.fromkeys(files))
+
+
 def detect_w8a8_artifact(model_path: Path) -> Optional[W8a8Artifact]:
-    """Header-sniff a snapshot for the w8a8 contract: any denoiser-dir layer
-    with an F8_E4M3 ``weight`` AND a ``weight_scale`` twin. A scale-FREE fp8
-    tree (the storage-cast ``#fp8`` flavor) never matches — the scales are
-    the distinguisher. Cheap: header reads only."""
+    """Header-sniff a snapshot for the w8a8 contract: any denoiser layer with
+    an F8_E4M3 ``weight`` AND a ``weight_scale`` twin. A scale-FREE fp8 tree
+    (the storage-cast ``#fp8`` flavor) never matches — the scales are the
+    distinguisher. Diffusers trees scan the denoiser component dirs;
+    everything else scans the root weight set (singlefile/sharded-
+    transformers layouts, gw#562). Cheap: header reads only."""
     root = Path(model_path)
-    if not root.is_dir() or not (root / "model_index.json").exists():
+    if not root.is_dir():
         return None
-    for comp in _COMPONENT_DIRS:
-        comp_dir = root / comp
-        if not comp_dir.is_dir():
-            continue
-        files = tuple(sorted(p for p in comp_dir.glob("*.safetensors") if p.is_file()))
-        if not files:
-            continue
-        dtypes: Dict[str, str] = {}
-        for f in files:
-            for name, info in _read_header(f).items():
-                if isinstance(info, dict) and "dtype" in info:
-                    dtypes[name] = str(info["dtype"])
-        quantized = tuple(sorted(
-            key[: -len(".weight_scale")]
-            for key in dtypes
-            if key.endswith(".weight_scale")
-            and dtypes.get(key[: -len(".weight_scale")] + ".weight") == "F8_E4M3"
-        ))
+    if (root / "model_index.json").exists():
+        for comp in _COMPONENT_DIRS:
+            comp_dir = root / comp
+            if not comp_dir.is_dir():
+                continue
+            files = tuple(sorted(
+                p for p in comp_dir.glob("*.safetensors") if p.is_file()))
+            if not files:
+                continue
+            quantized, static = _quantized_layers(files)
+            if quantized:
+                return W8a8Artifact(
+                    component=comp, files=files, quantized=quantized,
+                    static_input_scales=static,
+                )
+        return None
+    files = _root_weight_files(root)
+    if files:
+        quantized, static = _quantized_layers(files)
         if quantized:
-            static = any(f"{n}.input_scale" in dtypes for n in quantized)
             return W8a8Artifact(
-                component=comp, files=files, quantized=quantized,
+                component="", files=files, quantized=quantized,
                 static_input_scales=static,
             )
     return None
@@ -388,6 +424,174 @@ def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
 
 
 # ---------------------------------------------------------------------------
+# Root-layout serve path (gw#562): pipelines the worker does not assemble
+# (DiffSynth families — hidream-o1's sharded-transformers root, anima's
+# split checkpoint). The pipeline class's OWN from_pretrained constructs the
+# model; its loader runs sanitize_w8a8_state_dict so a quantized snapshot
+# lands correct dequantized weights on ANY host, and scaled_mm hosts then
+# swap the quantized Linears onto fp8 GEMM in place.
+# ---------------------------------------------------------------------------
+
+
+def sanitize_w8a8_state_dict(
+    state_dict: Dict[str, Any], compute_dtype: Any = None,
+) -> Dict[str, Any]:
+    """Dequantize w8a8 tensors in a raw state dict: fp8 weights with a
+    ``weight_scale`` twin become compute-dtype weights, scale tensors drop.
+    A scale-free dict passes through unchanged, so loaders that read
+    snapshots manually can call it unconditionally. Never ``.to(dtype)`` an
+    fp8 tensor before this — an unscaled upcast is silent garbage."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    out: Dict[str, Any] = {}
+    for key, t in state_dict.items():
+        if key.endswith((".weight_scale", ".input_scale")):
+            continue
+        if (key.endswith(".weight") and isinstance(t, torch.Tensor)
+                and t.dtype == torch.float8_e4m3fn
+                and f"{key[: -len('.weight')]}.weight_scale" in state_dict):
+            layer = key[: -len(".weight")]
+            scale = _scale_2d(state_dict[f"{layer}.weight_scale"], int(t.shape[0]))
+            out[key] = (t.float() * scale).to(compute)
+        else:
+            out[key] = t
+    return out
+
+
+def swap_w8a8_linears(
+    model: Any,
+    art: W8a8Artifact,
+    *,
+    compute_dtype: Any = None,
+    key_map: Optional[Any] = None,
+) -> int:
+    """Swap the artifact's quantized Linears in an ALREADY-CONSTRUCTED model
+    onto :class:`Fp8ScaledLinear`, assigning fp8 weight + scale from the
+    artifact shards (whatever the constructing loader materialized there is
+    replaced). ``key_map`` maps an artifact layer name to its module path
+    (identity default; converter-renamed families pass their own — e.g.
+    anima's DiffSynth converter strips ``net.``). Layers whose dims break
+    scaled_mm's 16-alignment, or whose owner is not a plain Linear, keep
+    their dequantized weights. Returns the number of swapped modules."""
+    import torch
+    import torch.nn as nn
+    from safetensors import safe_open
+
+    compute = compute_dtype or torch.bfloat16
+    lin_cls = fp8_scaled_linear_class()
+    where: Dict[str, Path] = {}
+    for f in art.files:
+        for name in _read_header(f):
+            if name != "__metadata__":
+                where[name] = f
+    handles: Dict[Path, Any] = {}
+
+    def _tensor(name: str) -> Any:
+        src = where.get(name)
+        if src is None:
+            raise W8a8SnapshotError(f"artifact tensor {name!r} missing from shards")
+        fh = handles.get(src)
+        if fh is None:
+            fh = handles[src] = safe_open(str(src), framework="pt", device="cpu")
+        return fh.get_tensor(name)
+
+    swapped = 0
+    try:
+        for layer in art.quantized:
+            target = str(key_map(layer)) if key_map is not None else layer
+            parent_path, _, leaf = target.rpartition(".")
+            try:
+                parent = (model.get_submodule(parent_path)
+                          if parent_path else model)
+                old = getattr(parent, leaf)
+            except AttributeError as exc:
+                raise W8a8SnapshotError(
+                    f"quantized layer {layer!r} has no module {target!r} in "
+                    f"{type(model).__name__} — wrong key_map?") from exc
+            if not isinstance(old, nn.Linear) or type(old) is not nn.Linear:
+                logger.warning(
+                    "w8a8 swap: %s is %s, not a plain Linear; layer stays "
+                    "dequantized", target, type(old).__name__)
+                continue
+            w = _tensor(f"{layer}.weight")
+            out_f, in_f = int(w.shape[0]), int(w.shape[1])
+            if (out_f, in_f) != (int(old.out_features), int(old.in_features)):
+                raise W8a8SnapshotError(
+                    f"quantized layer {layer!r} shape [{out_f}, {in_f}] != "
+                    f"module {target!r} [{old.out_features}, {old.in_features}]")
+            if in_f % _DIM_ALIGN or out_f % _DIM_ALIGN:
+                continue  # scaled_mm alignment; dequant weights stay
+            has_static = f"{layer}.input_scale" in where
+            dev = old.weight.device
+            new = lin_cls(in_f, out_f, bias=old.bias is not None,
+                          compute_dtype=compute, static_input_scale=has_static)
+            new.weight = w.contiguous().to(dev)
+            new.weight_scale = _scale_2d(_tensor(f"{layer}.weight_scale"),
+                                         out_f).to(dev)
+            if has_static:
+                new.input_scale = (
+                    _tensor(f"{layer}.input_scale").float().reshape(1, 1).to(dev))
+            if old.bias is not None:
+                new.bias = nn.Parameter(
+                    old.bias.detach().to(compute), requires_grad=False)
+            setattr(parent, leaf, new)
+            swapped += 1
+    finally:
+        for fh in handles.values():
+            try:
+                fh.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
+    logger.info("w8a8 swap: %d/%d quantized Linears on scaled_mm",
+                swapped, len(art.quantized))
+    return swapped
+
+
+def _root_denoiser(pipe: Any) -> Any:
+    import torch.nn as nn
+
+    for name in ("transformer", "unet", "dit"):
+        mod = getattr(pipe, name, None)
+        if isinstance(mod, nn.Module):
+            return mod
+    if isinstance(pipe, nn.Module):
+        return pipe
+    raise W8a8SnapshotError(
+        f"{type(pipe).__name__} exposes no denoiser module "
+        "(transformer/unet/dit) for the root w8a8 lane")
+
+
+def load_w8a8_root_pipeline(
+    cls: Any, path: Path, art: W8a8Artifact, *, compute_dtype: Any = None,
+) -> Any:
+    """Serve a root-layout w8a8 snapshot through the pipeline class's own
+    ``from_pretrained`` (which must sanitize — see module docstring), then
+    swap the denoiser's quantized Linears onto scaled_mm when the host
+    qualifies. Stamps ``_cozy_weight_lane`` like the diffusers lane."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+    pipe = cls.from_pretrained(str(path), torch_dtype=compute)
+    denoiser = _root_denoiser(pipe)
+    if mode == "scaled_mm":
+        if not swap_w8a8_linears(denoiser, art, compute_dtype=compute):
+            raise W8a8SnapshotError(
+                "scaled_mm host but no quantized Linear swapped — artifact "
+                f"keys do not match {type(denoiser).__name__} modules")
+    try:
+        denoiser._cozy_w8a8_mode = mode
+        pipe._cozy_weight_lane = (
+            "w8a8" if mode == "scaled_mm" else "bf16-resident")
+    except Exception:
+        pass
+    logger.info("w8a8 root lane: %s (%d quantized layers, component root)",
+                mode, len(art.quantized))
+    return pipe
+
+
+# ---------------------------------------------------------------------------
 # Data-free producer — contract round-trips in tests + the parity harness.
 # Production calibrated artifacts come from the conversion side (modelopt,
 # te#79); this writes the identical on-disk contract with per-out-channel
@@ -466,6 +670,9 @@ __all__ = [
     "fp8_scaled_linear_class",
     "load_w8a8_denoiser",
     "load_w8a8_pipeline",
+    "load_w8a8_root_pipeline",
     "quantize_tree_w8a8",
+    "sanitize_w8a8_state_dict",
     "scaled_mm_supported",
+    "swap_w8a8_linears",
 ]

--- a/tests/test_w8a8_root.py
+++ b/tests/test_w8a8_root.py
@@ -1,0 +1,279 @@
+"""Root-layout w8a8 lane (gw#562) — the DiffSynth/singlefile families.
+
+Contract round-trip against a tiny DiffSynth-class pipeline: a root shard
+set (no model_index.json), a pipeline class that constructs its own model
+from the shards (sanitize at read), and the worker's post-construction
+Linear swap. CPU lane proves producer -> detect -> sanitize-construct ->
+dequant numerics and the swap's module surgery; the sm_89+ lane proves
+scaled_mm forward parity.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+import torch.nn as nn  # noqa: E402
+from safetensors.torch import load_file, save_file  # noqa: E402
+
+from gen_worker.convert.writer import (  # noqa: E402
+    ConversionImplementationError,
+    streaming_w8a8_snapshot,
+    verify_w8a8_snapshot,
+)
+from gen_worker.models import w8a8  # noqa: E402
+from gen_worker.models.loading import (  # noqa: E402
+    load_from_pretrained,
+    pipeline_weight_lane,
+)
+from gen_worker.models.w8a8 import (  # noqa: E402
+    detect_w8a8_artifact,
+    fp8_scaled_linear_class,
+    sanitize_w8a8_state_dict,
+    swap_w8a8_linears,
+)
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attn_q = nn.Linear(32, 32)
+        self.mlp_in = nn.Linear(32, 64)
+        self.mlp_out = nn.Linear(64, 32)
+        self.norm = nn.LayerNorm(32)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.norm(x)
+        h = self.attn_q(h)
+        h = self.mlp_out(torch.nn.functional.gelu(self.mlp_in(h)))
+        return x + h
+
+
+class _TinyDiT(nn.Module):
+    """Root-keyed module: ``blocks.N.*`` Linears quantize, the rest stay."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.patch_embed = nn.Linear(16, 32)
+        self.blocks = nn.ModuleList([_Block() for _ in range(2)])
+        self.norm_out = nn.LayerNorm(32)
+        self.proj_out = nn.Linear(32, 16)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.patch_embed(x)
+        for b in self.blocks:
+            h = b(h)
+        return self.proj_out(self.norm_out(h))
+
+
+_QUANTIZED_LAYERS = tuple(sorted(
+    f"blocks.{i}.{n}" for i in range(2) for n in ("attn_q", "mlp_in", "mlp_out")
+))
+
+
+class _TinyRootPipeline:
+    """DiffSynth-shaped: reads root shards itself, sanitizes, aliases the
+    denoiser at ``.transformer`` (the worker-facing convention)."""
+
+    def __init__(self) -> None:
+        self.transformer: nn.Module | None = None
+
+    @classmethod
+    def from_pretrained(cls, path: str, torch_dtype=None, **_) -> "_TinyRootPipeline":
+        dtype = torch_dtype or torch.bfloat16
+        sd: dict[str, torch.Tensor] = {}
+        for f in sorted(Path(path).glob("*.safetensors")):
+            sd.update(load_file(str(f)))
+        sd = sanitize_w8a8_state_dict(sd, dtype)
+        sd = {k: v.to(dtype) for k, v in sd.items()}
+        model = _TinyDiT()
+        model.load_state_dict(sd, assign=True)
+        model.eval()
+        pipe = cls()
+        pipe.transformer = model
+        return pipe
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        assert self.transformer is not None
+        return self.transformer(x)
+
+
+@pytest.fixture(scope="module")
+def source_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    torch.manual_seed(7)
+    root = tmp_path_factory.mktemp("w8a8root") / "src"
+    root.mkdir()
+    model = _TinyDiT()
+    sd = {k: v.detach().to(torch.bfloat16).contiguous()
+          for k, v in model.state_dict().items()}
+    save_file(sd, str(root / "model.safetensors"))
+    (root / "config.json").write_text(json.dumps({"model_type": "tiny_dit"}))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w8a8_root(source_root: Path) -> Path:
+    out = source_root.parent / "w8a8"
+    result = streaming_w8a8_snapshot(source_root, out, file_layout="singlefile")
+    assert result["components"] == [""]
+    return out
+
+
+def test_producer_quantizes_block_linears_only(
+    source_root: Path, w8a8_root: Path,
+) -> None:
+    tensors: dict[str, torch.Tensor] = {}
+    for f in sorted(w8a8_root.glob("*.safetensors")):
+        tensors.update(load_file(str(f)))
+    scales = sorted(
+        k[: -len(".weight_scale")] for k in tensors if k.endswith(".weight_scale"))
+    assert tuple(scales) == _QUANTIZED_LAYERS
+    for layer in _QUANTIZED_LAYERS:
+        assert tensors[f"{layer}.weight"].dtype == torch.float8_e4m3fn
+    assert tensors["patch_embed.weight"].dtype == torch.bfloat16
+    assert tensors["proj_out.weight"].dtype == torch.bfloat16
+    assert (w8a8_root / "config.json").exists()  # passthrough
+    verify_w8a8_snapshot(source_root, w8a8_root)
+
+
+def test_producer_refuses_te_components_on_root_layout(
+    source_root: Path, tmp_path: Path,
+) -> None:
+    with pytest.raises(ConversionImplementationError, match="te_components"):
+        streaming_w8a8_snapshot(
+            source_root, tmp_path / "o", file_layout="singlefile",
+            te_components=("text_encoder",))
+
+
+def test_detects_root_artifact(w8a8_root: Path, source_root: Path) -> None:
+    art = detect_w8a8_artifact(w8a8_root)
+    assert art is not None
+    assert art.component == ""
+    assert art.quantized == _QUANTIZED_LAYERS
+    assert not art.static_input_scales
+    assert detect_w8a8_artifact(source_root) is None  # plain bf16 root
+
+
+def test_scale_free_root_fp8_never_detects(source_root: Path, tmp_path: Path) -> None:
+    cast = tmp_path / "cast"
+    cast.mkdir()
+    tensors = {
+        k: (v.to(torch.float8_e4m3fn) if v.ndim == 2 else v)
+        for k, v in load_file(str(source_root / "model.safetensors")).items()
+    }
+    save_file(tensors, str(cast / "model.safetensors"))
+    assert detect_w8a8_artifact(cast) is None
+
+
+def test_dequant_lane_constructs_correct_weights(
+    source_root: Path, w8a8_root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
+    assert pipe._cozy_weight_lane == "bf16-resident"
+    assert pipeline_weight_lane(pipe) == ""
+    assert pipe.transformer._cozy_w8a8_mode == "dequant"
+
+    src = load_file(str(source_root / "model.safetensors"))
+    got = pipe.transformer.state_dict()
+    for layer in _QUANTIZED_LAYERS:
+        a = src[f"{layer}.weight"].float()
+        b = got[f"{layer}.weight"].float()
+        rel = ((a - b).abs() / a.abs().clamp(min=1e-3)).max().item()
+        assert rel < 0.13, layer  # e4m3 rounding only
+        assert got[f"{layer}.weight"].dtype == torch.bfloat16
+    out = pipe(torch.randn(2, 16, dtype=torch.bfloat16))
+    assert out.shape == (2, 16)
+
+
+def test_swap_puts_block_linears_on_fp8(
+    w8a8_root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """scaled_mm host: worker swap replaces exactly the quantized Linears
+    (module surgery is device-agnostic; forward needs the GPU lane below)."""
+    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: True)
+    pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
+    assert pipe._cozy_weight_lane == "w8a8"
+    assert pipeline_weight_lane(pipe) == "w8a8"
+    lin_cls = fp8_scaled_linear_class()
+    model = pipe.transformer
+    for layer in _QUANTIZED_LAYERS:
+        mod = model.get_submodule(layer)
+        assert isinstance(mod, lin_cls), layer
+        assert mod.weight.dtype == torch.float8_e4m3fn
+        assert mod.weight_scale.shape == (mod.out_features, 1)
+        assert mod.bias is not None and mod.bias.dtype == torch.bfloat16
+    assert type(model.patch_embed) is nn.Linear
+    assert type(model.proj_out) is nn.Linear
+
+
+def test_swap_with_key_map_reaches_renamed_modules(
+    source_root: Path, tmp_path: Path,
+) -> None:
+    """Converter-renamed checkpoints (anima's ``net.`` strip): the artifact
+    keys carry the prefix, the module tree does not — key_map bridges."""
+    prefixed_src = tmp_path / "src"
+    prefixed_src.mkdir()
+    sd = load_file(str(source_root / "model.safetensors"))
+    save_file({f"net.{k}": v for k, v in sd.items()},
+              str(prefixed_src / "model.safetensors"))
+    out = tmp_path / "w8a8"
+    streaming_w8a8_snapshot(prefixed_src, out, file_layout="singlefile")
+    art = detect_w8a8_artifact(out)
+    assert art is not None and art.component == ""
+    assert all(n.startswith("net.") for n in art.quantized)
+
+    raw: dict[str, torch.Tensor] = {}
+    for f in art.files:
+        raw.update(load_file(str(f)))
+    clean = sanitize_w8a8_state_dict(raw, torch.bfloat16)
+    model = _TinyDiT()
+    model.load_state_dict(
+        {k[len("net."):]: v.to(torch.bfloat16) for k, v in clean.items()},
+        assign=True)
+    swapped = swap_w8a8_linears(
+        model, art, compute_dtype=torch.bfloat16,
+        key_map=lambda k: k[len("net."):])
+    assert swapped == len(_QUANTIZED_LAYERS)
+
+
+def test_sanitize_passes_scale_free_dicts_through(source_root: Path) -> None:
+    sd = load_file(str(source_root / "model.safetensors"))
+    assert sanitize_w8a8_state_dict(dict(sd), torch.bfloat16).keys() == sd.keys()
+
+
+# ---------------------------------------------------------------------------
+# GPU lane (sm_89+)
+# ---------------------------------------------------------------------------
+
+
+def _cuda_sm89() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 89
+
+
+gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor cores)")
+
+
+@gpu
+def test_root_pipeline_serves_on_scaled_mm_lane(
+    source_root: Path, w8a8_root: Path,
+) -> None:
+    w8a8.scaled_mm_supported.cache_clear()
+    pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
+    assert pipe._cozy_weight_lane == "w8a8"
+    model = pipe.transformer.to("cuda")
+    x = torch.randn(4, 16, dtype=torch.bfloat16, device="cuda")
+    y = model(x)
+
+    ref_pipe = _TinyRootPipeline.from_pretrained(str(source_root))
+    ref = ref_pipe.transformer.to("cuda")(x)
+    rel = ((y - ref).abs().max() / ref.abs().max().clamp(min=1e-6)).item()
+    assert rel < 0.25  # fp8 weight rounding + dynamic activation quant

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Tracker: gw#562 (filed by the te#89 fleet batch). The #fp8-w8a8 path assumed a diffusers tree at every stage; the two DiffSynth-lane families (hidream-o1-image[-full]: sharded-transformers singlefile root; anima: split checkpoint) had no producer, no detector, no serve lane.

## Producer
`streaming_w8a8_snapshot` accepts non-diffusers layouts with a SINGLE root weight set (mirrors the fp8-storage branch): same `streaming_w8a8_cast` per-channel requant, same skip patterns/repeated-block scope, byte-gate (`verify_w8a8_snapshot`) works on the root component unchanged. `te_components` on a root layout is refused (no component identity).

## Detector
`detect_w8a8_artifact` header-sniffs the root shard set (index-aware) when no `model_index.json` exists → `W8a8Artifact(component="")`. Scale-presence stays the distinguisher: a scale-free `#fp8` root cast never detects.

## Serve
- `sanitize_w8a8_state_dict(sd, compute)`: loaders that read shards themselves (DiffSynth `from_pretrained` wrappers) call this — fp8+scale pairs dequant to compute dtype, scale keys drop, scale-free dicts pass through. Construction lands CORRECT weights on any host (an unscaled fp8 `.to(dtype)` upcast is silent garbage).
- `swap_w8a8_linears(model, art, key_map=)`: post-construction surgery on ANY constructed nn.Module — quantized Linears become `Fp8ScaledLinear` with fp8 weight + [out,1] scale assigned from the artifact shards; `key_map` bridges converter-renamed checkpoints (anima's DiffSynth converter strips `net.`). Misaligned/non-plain-Linear layers keep dequant weights (same per-layer fallback as the diffusers loader).
- `load_from_pretrained` routes `component==""` artifacts through `load_w8a8_root_pipeline`: endpoint's own `from_pretrained` constructs, worker swaps on scaled_mm hosts, stamps `_cozy_weight_lane` = `w8a8`/`bf16-resident` exactly like the diffusers lane. A scaled_mm host where zero Linears swap raises (never a silent dequant serve stamped w8a8).

Compile cells: DiffSynth families have none yet — the root lane serves eager w8a8 (honest lane stamp; cells are follow-up producer work).

## Tests
`tests/test_w8a8_root.py`: tiny DiffSynth-class pipeline (root shards, self-constructing `from_pretrained` + `.transformer` alias) through produce → byte-gate → detect → dequant-lane CPU forward parity → swap surgery → key_map path, plus an sm_89-gated GPU parity test. Full suite green (3 load-flaky subprocess tests pass in isolation, fail-prone under box load 60+; also flaky on clean base).

Consumers (separate PRs): hidream-o1-image endpoint sanitize+pool-bypass (inference-endpoints), hidream production quant via te#89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)