### PR TITLE
gw#562 follow-up: oversize tensors shard alone instead of failing the cast (0.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.35.1 (2026-07-17)
+
+- **gw#562 follow-up: oversize tensors shard alone instead of failing the
+  cast.** `plan_shards` gave up (`tensor_exceeds_max_shard_bytes`) on any
+  single tensor over the 2GiB shard target — which killed EVERY fp8/w8a8
+  cast of an fp32 tree whose excluded lm_head/embedding exceeds it
+  (hidream-o1's fp32 lm_head = 2.49GB, found live ie#480). HF
+  `split_torch_state_dict_into_shards` semantics now: the oversize tensor
+  rides alone in its own oversized shard.
+
 ## 0.35.0 (2026-07-17)
 
 - **gw#562: w8a8 lane for root-layout (DiffSynth/singlefile) families —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.35.0"
+version = "0.35.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -102,8 +102,11 @@ def plan_shards(
         size = int(tensor_bytes.get(key, 0) or 0)
         if size < 0:
             raise ValueError(f"tensor_size_invalid:{key}")
-        if size > int(max_shard_bytes):
-            raise ValueError(f"tensor_exceeds_max_shard_bytes:{key}")
+        # A tensor larger than max_shard_bytes gets its own oversized shard
+        # (HF split_torch_state_dict_into_shards semantics) — the greedy loop
+        # below already isolates it. Raising here killed every cast of fp32
+        # trees whose excluded lm_head/embedding exceeds 2GiB (hidream-o1,
+        # found live ie#480/gw#562).
         entries.append((key, size))
 
     single = f"{shard_prefix}.safetensors"

--- a/tests/convert/test_writer.py
+++ b/tests/convert/test_writer.py
@@ -51,9 +51,14 @@ class TestPlanShards:
         assert plan.shard_names[0] == "model-00001-of-00003.safetensors"
         assert sum(plan.shard_sizes.values()) == plan.total_size == 180
 
-    def test_tensor_larger_than_cap_raises(self) -> None:
-        with pytest.raises(ValueError, match="tensor_exceeds_max_shard_bytes"):
-            plan_shards({"big": 200}, max_shard_bytes=100)
+    def test_tensor_larger_than_cap_gets_own_oversized_shard(self) -> None:
+        """HF split semantics: an oversize tensor rides alone in its own
+        shard (fp32 lm_head > 2GiB killed every hidream cast, gw#562)."""
+        plan = plan_shards({"a": 60, "big": 200, "z": 60}, max_shard_bytes=100)
+        big_shard = plan.weight_map["big"]
+        assert plan.shard_sizes[big_shard] == 200
+        assert [k for k, s in plan.weight_map.items() if s == big_shard] == ["big"]
+        assert plan.total_size == 320
 
 
 class TestIncrementalWriter:

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.35.0"
+version = "0.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
plan_shards raised tensor_exceeds_max_shard_bytes on any single tensor over the 2GiB shard target — killing every fp8/w8a8 cast of an fp32 tree whose EXCLUDED lm_head/embedding exceeds it (hidream-o1's fp32 lm_head is 2.49GB; this is the ie#480 "0.26.x cast-dtype dies on tensor_exceeds_max_shard_bytes:lm_head.weight" finding, and it blocks the gw#562 hidream #fp8-w8a8 production run).

HF's own split_torch_state_dict_into_shards allows an oversized single-tensor shard; the greedy packer here already isolates such a tensor — only the pre-check raise stood in the way. Removed, with the test flipped to pin the dedicated-oversized-shard behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)