### PR TITLE
gw#564: sm_89 W8A8 inference lane — per-tensor fp8 GEMM + per-channel epilogue rescale (0.36.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.36.0 (2026-07-17)
+
+- **gw#564: sm_89 W8A8 inference lane — per-tensor fp8 GEMM + per-channel
+  epilogue rescale (4090/L40S).** ie#498 measured rowwise-scaled
+  `_scaled_mm` W8A8 as NO-GO on sm_89 (+79% compiled): torch's fast
+  rowwise kernels are CUTLASS sm_90+ and Ada falls to a ~half-rate
+  fallback — a kernel gap, not silicon. `Fp8ScaledLinear` gains a second
+  dispatch branch chosen ONCE at load by SKU: `gemm_mode="pertensor"`
+  runs a scalar-scaled fp8 GEMM (cuBLASLt's Ada fast path, per-TENSOR
+  dynamic activation scale) and applies the SAME per-channel
+  `weight_scale` vector as a post-GEMM column-multiply epilogue (bias
+  after the rescale; fuses under inductor) — mathematically identical to
+  the rowwise lane, ONE weight artifact serves both (no new producer or
+  flavor). The capability probe is replaced by `w8a8_gemm_mode()`:
+  candidates per SKU class arm only when the kernel call succeeds AND a
+  load-time micro-benchmark GEMM beats the bf16 reference (probe-pass ≠
+  profitable, the ie#498 lesson — generalizes the gate for every future
+  SKU); `scaled_mm_supported()` is gone, loader modes are now
+  `rowwise`/`pertensor`/`dequant`. The gw#558 additive LoRA branch rides
+  the epilogue lane unchanged; lane stamp stays `w8a8` for both GEMM
+  branches (cells are per-SKU keyed). Root-layout swaps
+  (`swap_w8a8_linears`) thread `gemm_mode` identically.
+
 ## 0.35.2 (2026-07-17)
 
 - **gw#565: publish `/complete` survives edge-masked 5xx during a long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.35.2"
+version = "0.36.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -746,10 +746,14 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
                 "out_features": int(out_features),
             }
             if bool(getattr(module, "_cozy_w8a8_linear", False)):
-                row["activation"] = (
-                    "static" if getattr(module, "input_scale", None) is not None
-                    else "dynamic-per-row"
-                )
+                # gw#564: the activation-scale granularity is a graph property
+                # (per-row rowwise sm_90+, per-tensor epilogue sm_89).
+                if getattr(module, "input_scale", None) is not None:
+                    row["activation"] = "static"
+                elif getattr(module, "gemm_mode", "") == "pertensor":
+                    row["activation"] = "dynamic-per-tensor"
+                else:
+                    row["activation"] = "dynamic-per-row"
                 quantized.append(row)
             else:
                 row["type"] = _type_name(module)
@@ -811,12 +815,22 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
         return "weight-lane artifact schema/exclusion manifest mismatch"
     if str(weight_contract.get("lane") or "").startswith("w8a8"):
         activations = weight_contract.get("activation_scaling") or []
-        if activations != ["dynamic-per-row"]:
-            return f"W8A8 activation scaling must be dynamic-per-row, got {activations!r}"
+        # DYNAMIC only, one homogeneous granularity per graph (gw#564:
+        # per-row = rowwise sm_90+, per-tensor = the sm_89 epilogue lane).
+        if activations not in (["dynamic-per-row"], ["dynamic-per-tensor"]):
+            return (f"W8A8 activation scaling must be dynamic "
+                    f"(per-row or per-tensor), got {activations!r}")
         if not weight_contract.get("quantized"):
             return "W8A8 graph contains no torch._scaled_mm modules"
+        here_digest = runtime_key()["image_digest"]
         for field in ("sm", "cuda", "cuda_driver", "image_digest"):
             if not str(meta.get(field) or ""):
+                if field == "image_digest" and not here_digest:
+                    # Bare-metal local runtime (gw#555 self-mint): no image
+                    # identity axis exists on either side. Production images
+                    # always carry WORKER_IMAGE_DIGEST, so fleet cells stay
+                    # fully pinned.
+                    continue
                 return f"W8A8 cell missing {field} identity"
     return ""
 

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -182,6 +182,10 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
     from .models.loading import pipeline_weight_lane
     from .models.memory import low_vram_mode
 
+    # gw#564: record the execution contract exactly like the production
+    # build — w8a8 cells are contract_drift-gated on the graph signature and
+    # weight-lane manifest, so a mint without them can never re-adopt.
+    graph_signature, weight_contract = cc.execution_contract(pipe, cfg)
     meta = cc.artifact_metadata(
         family=family,
         source_ref="local-mint",
@@ -192,6 +196,8 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
         compile_mode="regional" if getattr(cfg, "regional", False) else "whole",
         weight_lane=pipeline_weight_lane(pipe),
         lora_bucket=int(getattr(cfg, "lora_bucket", 0) or 0),
+        graph_signature=graph_signature,
+        weight_contract=weight_contract,
     )
     tmp = target.with_suffix(".part")
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -205,6 +205,21 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
     return target
 
 
+def _fail_closed(pipe: Any, reason: str) -> bool:
+    """The production w8a8 policy re-asserted at the local exits: a w8a8
+    pipeline never silently serves the slow eager GEMM path — when the local
+    mint cannot produce a cell either, the refusal stays TYPED (the same
+    CompiledLaneUnavailableError the executor maps). Plain lanes keep the
+    gw#555 never-raise miss policy (eager)."""
+    from .models.loading import pipeline_weight_lane
+
+    if pipeline_weight_lane(pipe).startswith("w8a8"):
+        raise cc.CompiledLaneUnavailableError(
+            f"W8A8 requires a compile cell and the local mint is "
+            f"unavailable ({reason})")
+    return False
+
+
 def enable_compiled(
     pipe: Any, cfg: Any, cache_dir: Optional[Path] = None,
     artifact: Optional[Path] = None,
@@ -213,19 +228,32 @@ def enable_compiled(
     policy, incl. TRT and the manual GEN_WORKER_COMPILE_CACHE overrides),
     then the local cell store — adopt a matching stored cell, or mint one.
 
-    Never raises: any store or mint failure logs and serves eager, exactly
-    like the production miss policy.
+    Store/mint failures log and serve eager (the production miss policy) —
+    EXCEPT on w8a8 lanes, whose fail-closed refusal stays typed
+    (:func:`_fail_closed`): production raises CompiledLaneUnavailableError
+    when no cell can arm, and the local runtime only downgrades that to a
+    mint attempt, never to silent slow eager (gw#564 found the raise
+    aborting the mint path live on a 4090).
     """
     from .models import provision
 
     family = str(getattr(cfg, "family", "") or "")
-    if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
-        return True
+    try:
+        if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
+            return True
+    except cc.CompiledLaneUnavailableError:
+        # No delivered w8a8 cell => production would refuse here. The LOCAL
+        # runtime's whole purpose is minting that cell (gw#555): fall
+        # through to the store/mint path — the typed refusal re-asserts at
+        # every exit that cannot produce one.
+        logger.info(
+            "local-cells: no delivered w8a8 cell; trying the local store/mint")
     if not family:
         logger.info("local-cells: Compile decl has no family; staying eager")
-        return False
+        return _fail_closed(pipe, "Compile decl has no family")
     if not _cuda_ready():
-        return False  # apply() already logged; nothing to mint for
+        # apply() already logged; nothing to mint for
+        return _fail_closed(pipe, "CUDA unavailable")
 
     from .models.loading import pipeline_weight_lane
 
@@ -241,10 +269,13 @@ def enable_compiled(
         reason = store_verdict(target, family, pipe, cfg)
         if not reason:
             # the exact delivered-cell consumer path (verify + drift + arm)
-            if cc.enable(pipe, cfg, cache_dir, artifact=target):
-                _say(f"local-cells: adopted stored cell {target.name}")
-                return True
-            reason = "seed/arm failed"
+            try:
+                if cc.enable(pipe, cfg, cache_dir, artifact=target):
+                    _say(f"local-cells: adopted stored cell {target.name}")
+                    return True
+                reason = "seed/arm failed"
+            except cc.CompiledLaneUnavailableError:
+                reason = "seed/arm failed (w8a8 fail-closed)"
         _say(f"local-cells: stored cell no longer matches ({reason}); re-minting")
 
     if not cc.toolchain_present():
@@ -255,7 +286,7 @@ def enable_compiled(
         )
         if bucket:
             cc.drop_lora_lane(pipe)
-        return False
+        return _fail_closed(pipe, "no C compiler for the one-time local mint")
     _say(
         f"local-cells: no compile cell for this GPU/torch yet — compiling "
         f"{len(tuple(cfg.shapes))} graph shape(s) once "
@@ -269,17 +300,23 @@ def enable_compiled(
         cc.unwrap(pipe)
         if bucket:
             cc.drop_lora_lane(pipe)
-        return False
+        return _fail_closed(pipe, f"local mint failed: {exc}")
     # Adopt the just-saved cell through the delivered-cell path (drops the
     # unguarded mint wrappers; re-traces hit the captured FX cache). This
     # also proves the saved artifact round-trips before we rely on it.
     cc.unwrap(pipe)
-    if cc.enable(pipe, cfg, cache_dir, artifact=target):
-        return True
+    try:
+        if cc.enable(pipe, cfg, cache_dir, artifact=target):
+            return True
+    except cc.CompiledLaneUnavailableError as exc:
+        logger.warning("local-cells: minted cell failed re-adoption (%s)", exc)
+        if bucket:
+            cc.drop_lora_lane(pipe)
+        raise
     logger.warning("local-cells: minted cell failed re-adoption; serving eager")
     if bucket:
         cc.drop_lora_lane(pipe)
-    return False
+    return _fail_closed(pipe, "minted cell failed re-adoption")
 
 
 __all__ = [

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -18,10 +18,14 @@ gw#534, consumed verbatim by the conversion side):
 Execution: quantized Linears become :class:`Fp8ScaledLinear` —
 ``torch._scaled_mm`` over RESIDENT fp8 weights (no per-layer upcast: the
 whole point, gw#534 measured the cast tax at +44% H100 / +73% B200), dynamic
-per-row activation quant by default, the static scale when present. Hosts
-without usable scaled_mm (pre-sm89 or missing kernels) DEQUANT once at load
-into plain bf16-resident weights — same numerics, no speed win, never a
-refusal.
+activation quant by default, the static scale when present. TWO dispatch
+branches over the ONE artifact, chosen once at load by :func:`w8a8_gemm_mode`
+(gw#564): "rowwise" (scale vectors inside the GEMM — CUTLASS fast, sm_90+)
+and "pertensor" (scalar-scaled cuBLASLt GEMM + per-channel epilogue rescale —
+the Ada/sm_89 fast path; torch's rowwise kernels fall back to ~half rate
+there, ie#498). Hosts where no branch wins the load-time micro-benchmark
+DEQUANT once at load into plain bf16-resident weights — same numerics, no
+speed win, never a refusal.
 """
 
 from __future__ import annotations
@@ -40,6 +44,9 @@ logger = logging.getLogger(__name__)
 W8A8_FLAVOR = "fp8-w8a8"
 # torch._scaled_mm needs fp8 tensor cores (sm_89 Ada +) and 16-aligned dims.
 W8A8_MIN_SM = 89
+# torch's fast ROWWISE-scaled kernels are CUTLASS sm_90+; sm_89 runs rowwise
+# on a ~half-rate fallback (ie#498) and takes the pertensor branch instead.
+W8A8_ROWWISE_MIN_SM = 90
 _FP8_MAX = 448.0
 _DIM_ALIGN = 16
 _MAX_HEADER_BYTES = 100 << 20
@@ -148,33 +155,149 @@ def detect_w8a8_artifact(model_path: Path) -> Optional[W8a8Artifact]:
     return None
 
 
-@functools.lru_cache(maxsize=1)
-def scaled_mm_supported() -> bool:
-    """Live probe: does THIS device run a rowwise-scaled fp8 GEMM? sm gate
-    first (fail-fast on old silicon), then one 16x16 kernel call — torch's
-    scaled-mm backends vary by (torch, cuda, arch), so trusting a version
-    table instead of the device is how mixed fleets break."""
-    try:
-        import torch
-    except ImportError:
-        return False
-    if not torch.cuda.is_available() or not hasattr(torch, "float8_e4m3fn"):
-        return False
-    major, minor = torch.cuda.get_device_capability()
-    if major * 10 + minor < W8A8_MIN_SM:
-        return False
+def _probe_scales(mode: str, m: int, n: int, device: str = "cuda") -> tuple:
+    """(scale_a, scale_b) for one ``torch._scaled_mm`` call in ``mode``:
+    rowwise = [m,1]x[1,n] vectors consumed inside the GEMM; pertensor =
+    scalar [1,1]x[1,1] (the cuBLASLt tensorwise path — per-channel weight
+    scales are applied OUTSIDE as the epilogue rescale, gw#564)."""
+    import torch
+
+    if mode == "rowwise":
+        return (torch.ones(m, 1, device=device),
+                torch.ones(1, n, device=device))
+    return (torch.ones(1, 1, device=device),
+            torch.ones(1, 1, device=device))
+
+
+def _gemm_call_ok(mode: str) -> bool:
+    """One tiny kernel call in ``mode``'s scale shape — torch's scaled-mm
+    backends vary by (torch, cuda, arch), so trusting a version table
+    instead of the device is how mixed fleets break."""
+    import torch
+
     try:
         n = _DIM_ALIGN
         a = torch.randn(n, n, device="cuda").to(torch.float8_e4m3fn)
         b = torch.randn(n, n, device="cuda").to(torch.float8_e4m3fn)
-        sa = torch.ones(n, 1, device="cuda")
-        sb = torch.ones(1, n, device="cuda")
+        sa, sb = _probe_scales(mode, n, n)
         torch._scaled_mm(a, b.t(), scale_a=sa, scale_b=sb,
                          out_dtype=torch.bfloat16)
         return True
-    except Exception as exc:  # noqa: BLE001 — any kernel gap => dequant lane
-        logger.warning("w8a8: scaled_mm probe failed (%s); dequant lane", exc)
+    except Exception as exc:  # noqa: BLE001 — any kernel gap => next candidate
+        logger.warning("w8a8: %s scaled_mm probe failed (%s)", mode, exc)
         return False
+
+
+_BENCH_DIM = 4096      # square GEMM; big enough that tensor-core rate dominates
+_BENCH_WARMUP = 3
+_BENCH_ITERS = 10
+# A candidate arms only when the fp8 GEMM beats the bf16 kernel by a real
+# margin. Genuinely fast paths measure ~1.5-2x here; the sm_89 rowwise
+# fallback measures ~0.5x (ie#498's +79% compiled loss) — 1.10 separates
+# them with headroom against timer noise.
+_BENCH_MIN_SPEEDUP = 1.10
+
+
+def _median_ms(fn: Any) -> float:
+    import torch
+
+    for _ in range(_BENCH_WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(_BENCH_ITERS):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+    times.sort()
+    return times[len(times) // 2]
+
+
+def _bench_gemm_pair(mode: str) -> tuple[float, float]:
+    """(fp8_ms, bf16_ms) medians for one representative square GEMM. The
+    activations are PRE-quantized — dynamic-quant overhead fuses away under
+    inductor (verdicts are on compiled arms), so the gate times the KERNEL,
+    which is exactly what ie#498 showed can silently be a half-rate
+    fallback. The pertensor arm includes its per-channel epilogue multiply."""
+    import torch
+
+    m = n = k = _BENCH_DIM
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    xq = x.clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+    wq = w.clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+    sa, sb = _probe_scales(mode, m, n)
+    ws_t = torch.full((1, n), 0.01, device="cuda", dtype=torch.bfloat16)
+
+    def fp8_op() -> Any:
+        y = torch._scaled_mm(xq, wq.t(), scale_a=sa, scale_b=sb,
+                             out_dtype=torch.bfloat16)
+        return y * ws_t if mode == "pertensor" else y
+
+    def bf16_op() -> Any:
+        return x @ w.t()
+
+    return _median_ms(fp8_op), _median_ms(bf16_op)
+
+
+def _gemm_profitable(mode: str) -> bool:
+    """Load-time micro-benchmark gate (gw#564): the probe must verify the
+    fast path ENGAGES, not that the call succeeds — ie#498 measured sm_89
+    rowwise probe-pass at ~half the bf16 rate (+79% compiled)."""
+    fp8_ms, bf16_ms = _bench_gemm_pair(mode)
+    speedup = bf16_ms / max(fp8_ms, 1e-9)
+    logger.info(
+        "w8a8 gemm gate: mode=%s fp8=%.3fms bf16=%.3fms speedup=%.2fx "
+        "(min %.2fx)", mode, fp8_ms, bf16_ms, speedup, _BENCH_MIN_SPEEDUP)
+    return speedup >= _BENCH_MIN_SPEEDUP
+
+
+def _choose_gemm_mode(sm: int) -> str:
+    """Candidate branches in preference order for this SKU class; each must
+    both CALL successfully and WIN the micro-benchmark to arm. sm_90+ keeps
+    the shipped rowwise-in-GEMM lane first; sm_89 (Ada: 4090/L40S) prefers
+    the per-tensor cuBLASLt path + epilogue rescale. The non-preferred
+    candidate stays listed so a future stack that flips the kernel story
+    arms the right branch without a code change — the bench decides."""
+    if sm < W8A8_MIN_SM:
+        return ""
+    candidates = (("rowwise", "pertensor") if sm >= W8A8_ROWWISE_MIN_SM
+                  else ("pertensor", "rowwise"))
+    for mode in candidates:
+        if not _gemm_call_ok(mode):
+            continue
+        try:
+            if _gemm_profitable(mode):
+                return mode
+        except Exception as exc:  # noqa: BLE001 — bench failure => next lane
+            logger.warning("w8a8: %s micro-benchmark failed (%s)", mode, exc)
+    logger.warning(
+        "w8a8: no fp8 GEMM branch engages a real win on this device (sm_%d); "
+        "dequant lane", sm)
+    return ""
+
+
+@functools.lru_cache(maxsize=1)
+def w8a8_gemm_mode() -> str:
+    """The fp8 GEMM dispatch for THIS device, chosen once per process:
+    ``"rowwise"`` (scale vectors consumed inside ``_scaled_mm`` — CUTLASS
+    fast kernels, sm_90+), ``"pertensor"`` (scalar-scaled cuBLASLt GEMM +
+    per-channel epilogue rescale — the Ada/sm_89 fast path, gw#564), or
+    ``""`` (dequant lane). Live-probed AND micro-benchmarked: a branch arms
+    only when its kernel call succeeds and beats the bf16 reference —
+    probe-pass ≠ profitable (ie#498)."""
+    try:
+        import torch
+    except ImportError:
+        return ""
+    if not torch.cuda.is_available() or not hasattr(torch, "float8_e4m3fn"):
+        return ""
+    major, minor = torch.cuda.get_device_capability()
+    return _choose_gemm_mode(major * 10 + minor)
 
 
 def _build_module_class() -> type:
@@ -187,10 +310,23 @@ def _build_module_class() -> type:
         """fp8 weights RESIDENT; y = scaled_mm(quant(x), W^T) + bias.
 
         ``weight_scale`` is the [out, 1] dequant multiplier (per-tensor
-        scalars are expanded at load). Activation quant is per-row dynamic
-        (amax/448) unless a static ``input_scale`` was calibrated. NOTE:
-        never ``.to(dtype=...)`` this module — a dtype cast would upcast the
-        fp8 buffer (device moves are fine).
+        scalars are expanded at load). Two GEMM dispatch branches, chosen
+        ONCE at load by SKU (gw#564; ONE weight artifact serves both):
+
+        - ``gemm_mode="rowwise"`` (sm_90+): scale vectors consumed inside
+          ``_scaled_mm`` (per-row dynamic activation scale x per-channel
+          weight scale), bias fused into the GEMM.
+        - ``gemm_mode="pertensor"`` (sm_89 Ada): scalar-scaled GEMM (the
+          cuBLASLt fast path) with the SAME per-channel ``weight_scale``
+          applied as a post-GEMM column-multiply epilogue (one broadcast
+          multiply — fuses under inductor), bias added after the rescale.
+          Activation scale is per-TENSOR dynamic. Mathematically identical
+          to rowwise up to activation-quant granularity + one bf16 rounding.
+
+        Activation quant is DYNAMIC (amax/448) unless a static
+        ``input_scale`` was calibrated. NOTE: never ``.to(dtype=...)`` this
+        module — a dtype cast would upcast the fp8 buffer (device moves are
+        fine).
 
         Optional LoRA side-branch (gw#547): ``lora_a`` [bucket, in] /
         ``lora_b`` [out, bucket] compute-dtype buffers, rank-padded to a
@@ -210,8 +346,12 @@ def _build_module_class() -> type:
 
         def __init__(self, in_features: int, out_features: int, *,
                      bias: bool, compute_dtype: Any,
-                     static_input_scale: bool) -> None:
+                     static_input_scale: bool,
+                     gemm_mode: str = "rowwise") -> None:
             super().__init__()
+            if gemm_mode not in ("rowwise", "pertensor"):
+                raise ValueError(f"invalid gemm_mode {gemm_mode!r}")
+            self.gemm_mode = gemm_mode
             self.in_features = int(in_features)
             self.out_features = int(out_features)
             meta = torch.device("meta")
@@ -239,8 +379,15 @@ def _build_module_class() -> type:
         def forward(self, x: Any) -> Any:
             shape = x.shape
             x2 = x.reshape(-1, self.in_features).contiguous()
+            pertensor = self.gemm_mode == "pertensor"
             if self.input_scale is not None:
-                sa = self.input_scale.expand(x2.shape[0], 1).contiguous()
+                # Static scales are per-tensor scalars already — the
+                # pertensor GEMM consumes [1,1] directly.
+                sa = (self.input_scale if pertensor else
+                      self.input_scale.expand(x2.shape[0], 1).contiguous())
+            elif pertensor:
+                sa = (x2.abs().amax().float()
+                      / _FP8_MAX).clamp(min=1e-12).reshape(1, 1)
             else:
                 sa = (x2.abs().amax(dim=-1, keepdim=True).float()
                       / _FP8_MAX).clamp(min=1e-12)
@@ -251,10 +398,23 @@ def _build_module_class() -> type:
             xq = (x2 * (1.0 / sa).to(x2.dtype)).clamp(
                 -_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
             scaled_mm: Any = torch._scaled_mm
-            y = scaled_mm(
-                xq, self.weight.t(), scale_a=sa, scale_b=self.weight_scale.t(),
-                bias=self.bias, out_dtype=x.dtype,
-            )
+            if pertensor:
+                # Scalar-scaled GEMM (cuBLASLt's Ada fast path, gw#564); the
+                # per-channel weight_scale rides as a post-GEMM column
+                # multiply — bias joins AFTER the rescale, never inside.
+                y = scaled_mm(
+                    xq, self.weight.t(), scale_a=sa,
+                    scale_b=torch.ones_like(sa), out_dtype=x.dtype,
+                )
+                y = y * self.weight_scale.t().to(y.dtype)
+                if self.bias is not None:
+                    y = y + self.bias
+            else:
+                y = scaled_mm(
+                    xq, self.weight.t(), scale_a=sa,
+                    scale_b=self.weight_scale.t(),
+                    bias=self.bias, out_dtype=x.dtype,
+                )
             if self.lora_a is not None:
                 y = y + self._lora_addend(x2)
             return y.reshape(*shape[:-1], self.out_features)
@@ -263,6 +423,7 @@ def _build_module_class() -> type:
             return (f"in_features={self.in_features}, "
                     f"out_features={self.out_features}, "
                     f"bias={self.bias is not None}, "
+                    f"gemm_mode={self.gemm_mode}, "
                     f"static_input_scale={self.input_scale is not None}")
 
     return _Fp8ScaledLinear
@@ -306,16 +467,16 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
                        compute_dtype: Any = None, mode: str = "") -> Any:
     """Materialize the quantized denoiser: skeleton on meta, quantized
     Linears swapped for Fp8ScaledLinear, tensors assigned from the shards.
-    ``mode`` "scaled_mm" | "dequant" (default: probe). Layers whose dims
-    break scaled_mm's 16-alignment are dequantized individually."""
+    ``mode`` "rowwise" | "pertensor" | "dequant" (default: probe). Layers
+    whose dims break scaled_mm's 16-alignment are dequantized individually."""
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
     from safetensors.torch import load_file
 
     compute = compute_dtype or torch.bfloat16
-    if mode not in ("scaled_mm", "dequant"):
-        mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+    if mode not in ("rowwise", "pertensor", "dequant"):
+        mode = w8a8_gemm_mode() or "dequant"
 
     cls = _denoiser_class(root, art.component)
     cfg = dict(cls.load_config(str(root / art.component)))
@@ -333,7 +494,7 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
         w = sd[f"{name}.weight"]
         scale = sd[f"{name}.weight_scale"]
         out_f, in_f = int(w.shape[0]), int(w.shape[1])
-        eligible = (mode == "scaled_mm"
+        eligible = (mode != "dequant"
                     and in_f % _DIM_ALIGN == 0 and out_f % _DIM_ALIGN == 0)
         try:
             parent_path, _, leaf = name.rpartition(".")
@@ -346,7 +507,8 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
         if eligible and isinstance(old, nn.Linear):
             has_static = f"{name}.input_scale" in sd
             new = lin_cls(in_f, out_f, bias=old.bias is not None,
-                          compute_dtype=compute, static_input_scale=has_static)
+                          compute_dtype=compute, static_input_scale=has_static,
+                          gemm_mode=mode)
             setattr(parent, leaf, new)
             sd[f"{name}.weight_scale"] = _scale_2d(scale, out_f)
             if has_static:
@@ -398,14 +560,14 @@ def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
     import torch
 
     compute = compute_dtype or torch.bfloat16
-    mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+    mode = w8a8_gemm_mode() or "dequant"
     denoiser = load_w8a8_denoiser(
         path, art, compute_dtype=compute, mode=mode)
     kwargs: Dict[str, Any] = dict(components or {})
     kwargs[art.component] = denoiser
     pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
     try:
-        pipe._cozy_weight_lane = "w8a8" if mode == "scaled_mm" else "bf16-resident"
+        pipe._cozy_weight_lane = "w8a8" if mode != "dequant" else "bf16-resident"
     except Exception:
         pass
     if fp8_text_encoders:
@@ -465,15 +627,17 @@ def swap_w8a8_linears(
     *,
     compute_dtype: Any = None,
     key_map: Optional[Any] = None,
+    gemm_mode: str = "rowwise",
 ) -> int:
     """Swap the artifact's quantized Linears in an ALREADY-CONSTRUCTED model
-    onto :class:`Fp8ScaledLinear`, assigning fp8 weight + scale from the
-    artifact shards (whatever the constructing loader materialized there is
-    replaced). ``key_map`` maps an artifact layer name to its module path
-    (identity default; converter-renamed families pass their own — e.g.
-    anima's DiffSynth converter strips ``net.``). Layers whose dims break
-    scaled_mm's 16-alignment, or whose owner is not a plain Linear, keep
-    their dequantized weights. Returns the number of swapped modules."""
+    onto :class:`Fp8ScaledLinear` in ``gemm_mode``, assigning fp8 weight +
+    scale from the artifact shards (whatever the constructing loader
+    materialized there is replaced). ``key_map`` maps an artifact layer name
+    to its module path (identity default; converter-renamed families pass
+    their own — e.g. anima's DiffSynth converter strips ``net.``). Layers
+    whose dims break scaled_mm's 16-alignment, or whose owner is not a plain
+    Linear, keep their dequantized weights. Returns the number of swapped
+    modules."""
     import torch
     import torch.nn as nn
     from safetensors import safe_open
@@ -525,7 +689,8 @@ def swap_w8a8_linears(
             has_static = f"{layer}.input_scale" in where
             dev = old.weight.device
             new = lin_cls(in_f, out_f, bias=old.bias is not None,
-                          compute_dtype=compute, static_input_scale=has_static)
+                          compute_dtype=compute, static_input_scale=has_static,
+                          gemm_mode=gemm_mode)
             new.weight = w.contiguous().to(dev)
             new.weight_scale = _scale_2d(_tensor(f"{layer}.weight_scale"),
                                          out_f).to(dev)
@@ -572,18 +737,19 @@ def load_w8a8_root_pipeline(
     import torch
 
     compute = compute_dtype or torch.bfloat16
-    mode = "scaled_mm" if scaled_mm_supported() else "dequant"
+    mode = w8a8_gemm_mode() or "dequant"
     pipe = cls.from_pretrained(str(path), torch_dtype=compute)
     denoiser = _root_denoiser(pipe)
-    if mode == "scaled_mm":
-        if not swap_w8a8_linears(denoiser, art, compute_dtype=compute):
+    if mode != "dequant":
+        if not swap_w8a8_linears(denoiser, art, compute_dtype=compute,
+                                 gemm_mode=mode):
             raise W8a8SnapshotError(
                 "scaled_mm host but no quantized Linear swapped — artifact "
                 f"keys do not match {type(denoiser).__name__} modules")
     try:
         denoiser._cozy_w8a8_mode = mode
         pipe._cozy_weight_lane = (
-            "w8a8" if mode == "scaled_mm" else "bf16-resident")
+            "w8a8" if mode != "dequant" else "bf16-resident")
     except Exception:
         pass
     logger.info("w8a8 root lane: %s (%d quantized layers, component root)",
@@ -673,6 +839,6 @@ __all__ = [
     "load_w8a8_root_pipeline",
     "quantize_tree_w8a8",
     "sanitize_w8a8_state_dict",
-    "scaled_mm_supported",
+    "w8a8_gemm_mode",
     "swap_w8a8_linears",
 ]

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -82,8 +82,10 @@ def branch_target(pipe: Any) -> Optional[Any]:
 
 def branch_lane(model: Any) -> str:
     """The denoiser's base weight lane for branch policy/stamping:
-    ``"w8a8"`` | ``"fp8-hooks"`` | ``""`` (plain resident)."""
-    if getattr(model, "_cozy_w8a8_mode", "") == "scaled_mm":
+    ``"w8a8"`` | ``"fp8-hooks"`` | ``""`` (plain resident). Both fp8 GEMM
+    dispatch branches (rowwise sm_90+, pertensor sm_89 — gw#564) are the
+    w8a8 lane; the additive LoRA branch is orthogonal to the scaling mode."""
+    if getattr(model, "_cozy_w8a8_mode", "") in ("rowwise", "pertensor"):
         return "w8a8"
     if getattr(model, "_cozy_fp8_storage_applied", False):
         return "fp8-hooks"

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -333,6 +333,93 @@ def test_plain_lane_miss_policy_unchanged(_local_env, monkeypatch):
     assert lc.enable_compiled(_Pipe(), _Cfg()) is False
 
 
+def _quantized_pipe(gemm_mode: str):
+    """A w8a8-lane pipeline with one REAL Fp8ScaledLinear denoiser child."""
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    from gen_worker.models.w8a8 import fp8_scaled_linear_class
+
+    lin_cls = fp8_scaled_linear_class()
+    mod = lin_cls(16, 16, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=False, gemm_mode=gemm_mode)
+    w = torch.randn(16, 16)
+    scale = (w.abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    mod.load_state_dict({
+        "weight": (w / scale).clamp(-448, 448).to(torch.float8_e4m3fn),
+        "weight_scale": scale,
+    }, assign=True)
+
+    class _Denoiser(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = mod
+
+        def forward(self, x):
+            return self.proj(x)
+
+    pipe = _W8a8Pipe()
+    pipe.unet = _Denoiser()
+    return pipe
+
+
+def test_w8a8_mint_records_execution_contract(_w8a8_env, monkeypatch):
+    """gw#564 live find (run sdxl4090-3): a mint without graph_signature/
+    weight_contract can NEVER re-adopt — contract_drift rejects the empty
+    signature on w8a8 lanes. The mint must record the contract exactly like
+    the production build; a bare-metal runtime (no WORKER_IMAGE_DIGEST)
+    must still pass the identity gate."""
+    pytest.importorskip("torch")
+    import json
+    import tarfile
+
+    real_key = cc.runtime_key
+
+    def filled_key():
+        key = dict(real_key())
+        key.update(sm="sm_89", cuda="13.0", cuda_driver="13000")
+        return key
+
+    monkeypatch.setattr(cc, "runtime_key", filled_key)
+    monkeypatch.setattr(lc, "_compile_and_warm", _fake_compile_and_warm)
+    pipe, cfg = _quantized_pipe("pertensor"), _Cfg(targets=("unet",))
+    target = lc.cell_path("fam", "w8a8")
+    lc._mint(pipe, cfg, target, "fam")
+
+    with tarfile.open(target) as tar:
+        meta = json.loads(tar.extractfile(cc.METADATA_NAME).read())
+    assert len(meta["graph_signature"]) == 64
+    wc = meta["weight_contract"]
+    assert wc["lane"] == "w8a8"
+    assert wc["activation_scaling"] == ["dynamic-per-tensor"]
+    assert wc["quantized"]
+    # the exact consumer gate: no drift, incl. the empty-image_digest case
+    assert meta.get("image_digest") == ""
+    assert cc.contract_drift(meta, pipe, cfg) == ""
+
+
+def test_w8a8_production_cell_still_requires_image_digest(monkeypatch):
+    """Fleet strictness preserved: when the RUNTIME carries an image digest
+    (every production worker), a digestless w8a8 cell is rejected."""
+    pytest.importorskip("torch")
+    real_key = cc.runtime_key
+
+    def prod_key():
+        key = dict(real_key())
+        key.update(sm="sm_89", cuda="13.0", cuda_driver="13000",
+                   image_digest="sha256:deadbeef")
+        return key
+
+    monkeypatch.setattr(cc, "runtime_key", prod_key)
+    pipe, cfg = _quantized_pipe("pertensor"), _Cfg(targets=("unet",))
+    sig, wc = cc.execution_contract(pipe, cfg)
+    meta = cc.artifact_metadata(
+        family="fam", shapes=cfg.shapes, targets=cfg.targets,
+        weight_lane="w8a8", graph_signature=sig, weight_contract=wc)
+    meta["image_digest"] = ""
+    assert "image_digest" in cc.contract_drift(meta, pipe, cfg)
+
+
 # ---------------------------------------------------------------------------
 # trust boundary: no publish path exists, structurally
 # ---------------------------------------------------------------------------

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -255,6 +255,85 @@ def test_no_family_no_mint(_local_env):
 
 
 # ---------------------------------------------------------------------------
+# gw#564: w8a8 fail-closed x local mint. Production's no-delivered-cell
+# refusal (CompiledLaneUnavailableError) must fall through to the LOCAL
+# store/mint path — found live on a 4090 where the raise aborted the mint —
+# and every exit that cannot produce a cell keeps the refusal TYPED.
+# ---------------------------------------------------------------------------
+
+
+class _W8a8Pipe(_Pipe):
+    _cozy_weight_lane = "w8a8"
+
+
+@pytest.fixture()
+def _w8a8_env(_local_env, monkeypatch):
+    """The live-bug trigger: the delivered-artifact leg RAISES the w8a8
+    fail-closed refusal (no cell anywhere) instead of returning False."""
+    from gen_worker.models import provision
+
+    def refuse(*a, **k):
+        raise cc.CompiledLaneUnavailableError("no delivered w8a8 cell")
+
+    monkeypatch.setattr(provision, "enable_compiled", refuse)
+    return _local_env
+
+
+def test_w8a8_delivered_refusal_falls_through_to_mint(_w8a8_env, monkeypatch):
+    pipe, cfg = _W8a8Pipe(), _Cfg()
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(lc, "_compile_and_warm", _fake_compile_and_warm)
+    monkeypatch.setattr(cc, "enable", lambda *a, **k: True)
+
+    assert lc.enable_compiled(pipe, cfg) is True
+    target = lc.cell_path("fam", "w8a8")
+    assert target.exists()
+    assert "-w8a8" in target.name  # epilogue/rowwise lanes share the token
+
+
+def test_w8a8_no_toolchain_refusal_stays_typed(_w8a8_env, monkeypatch):
+    monkeypatch.setattr(cc, "toolchain_present", lambda: False)
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="C compiler"):
+        lc.enable_compiled(_W8a8Pipe(), _Cfg())
+
+
+def test_w8a8_mint_failure_refusal_stays_typed(_w8a8_env, monkeypatch):
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+
+    def boom(pipe, cfg, **kw):
+        raise RuntimeError("compile exploded")
+
+    monkeypatch.setattr(lc, "_compile_and_warm", boom)
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="mint failed"):
+        lc.enable_compiled(_W8a8Pipe(), _Cfg())
+    assert not lc.cell_path("fam", "w8a8").exists()
+
+
+def test_w8a8_stored_cell_adopts_after_delivered_refusal(_w8a8_env, monkeypatch):
+    pipe, cfg = _W8a8Pipe(), _Cfg()
+    _make_cell(lc.cell_path("fam", "w8a8"), weight_lane="w8a8")
+    calls = {}
+
+    def fake_enable(p, c, cache_dir=None, artifact=None):
+        calls["artifact"] = artifact
+        return True
+
+    monkeypatch.setattr(cc, "enable", fake_enable)
+    minted = []
+    monkeypatch.setattr(lc, "_mint", lambda *a, **k: minted.append(a))
+
+    assert lc.enable_compiled(pipe, cfg) is True
+    assert calls["artifact"] == lc.cell_path("fam", "w8a8")
+    assert minted == []
+
+
+def test_plain_lane_miss_policy_unchanged(_local_env, monkeypatch):
+    """Plain lanes keep the never-raise eager fallback."""
+    monkeypatch.setattr(cc, "toolchain_present", lambda: False)
+    assert lc.enable_compiled(_Pipe(), _Cfg()) is False
+
+
+# ---------------------------------------------------------------------------
 # trust boundary: no publish path exists, structurally
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -47,7 +47,7 @@ def w8a8_pipe(w8a8_tree: Path) -> Any:
         pass
 
     pipe = _Pipe()
-    pipe.unet = load_w8a8_denoiser(w8a8_tree, art, mode="scaled_mm")
+    pipe.unet = load_w8a8_denoiser(w8a8_tree, art, mode="rowwise")
     pipe._cozy_weight_lane = "w8a8"
     return pipe
 

--- a/tests/test_w8a8.py
+++ b/tests/test_w8a8.py
@@ -95,7 +95,7 @@ def test_dequant_lane_round_trips_weights(
     source to fp8 rounding, lane stamps bf16-resident."""
     from diffusers import DDPMPipeline, UNet2DModel
 
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "")
     pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
     assert pipe._cozy_weight_lane == "bf16-resident"
     assert pipeline_weight_lane(pipe) == ""
@@ -118,7 +118,7 @@ def test_full_dequant_pipeline_runs_on_cpu(
 ) -> None:
     from diffusers import DDPMPipeline
 
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "")
     # fp32 compute: DDPM's output path numpy-converts (no bf16 support there).
     pipe = load_from_pretrained(DDPMPipeline, w8a8_tree, dtype="fp32")
     out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
@@ -178,9 +178,17 @@ gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor
 
 
 @gpu
-def test_scaled_mm_probe_true_on_capable_gpu() -> None:
-    w8a8.scaled_mm_supported.cache_clear()
-    assert w8a8.scaled_mm_supported() is True
+def test_gemm_mode_probe_arms_a_branch_on_capable_gpu() -> None:
+    """On real fp8 silicon one branch must win the micro-benchmark gate:
+    rowwise on sm_90+, pertensor on sm_89 (Ada) — '' would mean the gate
+    wrongly demoted a capable card to the dequant lane."""
+    w8a8.w8a8_gemm_mode.cache_clear()
+    mode = w8a8.w8a8_gemm_mode()
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor >= w8a8.W8A8_ROWWISE_MIN_SM:
+        assert mode == "rowwise"
+    else:
+        assert mode == "pertensor"
 
 
 @gpu
@@ -208,7 +216,7 @@ def test_fp8_scaled_linear_matches_dequant_reference() -> None:
 def test_w8a8_pipeline_serves_on_scaled_mm_lane(w8a8_tree: Path) -> None:
     from diffusers import DDPMPipeline
 
-    w8a8.scaled_mm_supported.cache_clear()
+    w8a8.w8a8_gemm_mode.cache_clear()
     art = detect_w8a8_artifact(w8a8_tree)
     assert art is not None
     # fp16 compute: DDPM's output path numpy-converts (no bf16 support there).

--- a/tests/test_w8a8_lora.py
+++ b/tests/test_w8a8_lora.py
@@ -77,7 +77,7 @@ def denoiser(w8a8_tree: Path) -> Any:
     forward needs the GPU kernel)."""
     art = detect_w8a8_artifact(w8a8_tree)
     assert art is not None
-    return load_w8a8_denoiser(w8a8_tree, art, mode="scaled_mm")
+    return load_w8a8_denoiser(w8a8_tree, art, mode="rowwise")
 
 
 def _kohya_sd(paths: Dict[str, Any], rank: int, alpha: float,
@@ -402,7 +402,7 @@ def test_dequant_lane_is_branch_capable_plain(w8a8_tree: Path,
     (pre-gw#558 they fell back to peft)."""
     from diffusers import DDPMPipeline
 
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "")
     from gen_worker.models.loading import load_from_pretrained
 
     pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
@@ -457,7 +457,7 @@ def test_gpu_forward_matches_dequant_reference_plus_addend(denoiser: Any) -> Non
 def test_gpu_full_pipeline_with_branch_runs(w8a8_tree: Path) -> None:
     from diffusers import DDPMPipeline
 
-    w8a8.scaled_mm_supported.cache_clear()
+    w8a8.w8a8_gemm_mode.cache_clear()
     art = detect_w8a8_artifact(w8a8_tree)
     assert art is not None
     pipe = load_w8a8_pipeline(DDPMPipeline, w8a8_tree, art,

--- a/tests/test_w8a8_produce.py
+++ b/tests/test_w8a8_produce.py
@@ -391,7 +391,7 @@ def test_load_from_pretrained_threads_te_flag(
         seen.update(kwargs)
         return real(cls, path, art, **kwargs)
 
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "")
     monkeypatch.setattr(w8a8, "load_w8a8_pipeline", spy)
     pipe = loading.load_from_pretrained(DDPMPipeline, tree, storage_dtype="fp8+te")
     assert seen.get("fp8_text_encoders") is True

--- a/tests/test_w8a8_root.py
+++ b/tests/test_w8a8_root.py
@@ -173,7 +173,7 @@ def test_scale_free_root_fp8_never_detects(source_root: Path, tmp_path: Path) ->
 def test_dequant_lane_constructs_correct_weights(
     source_root: Path, w8a8_root: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: False)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "")
     pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
     assert pipe._cozy_weight_lane == "bf16-resident"
     assert pipeline_weight_lane(pipe) == ""
@@ -196,7 +196,7 @@ def test_swap_puts_block_linears_on_fp8(
 ) -> None:
     """scaled_mm host: worker swap replaces exactly the quantized Linears
     (module surgery is device-agnostic; forward needs the GPU lane below)."""
-    monkeypatch.setattr(w8a8, "scaled_mm_supported", lambda: True)
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "rowwise")
     pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
     assert pipe._cozy_weight_lane == "w8a8"
     assert pipeline_weight_lane(pipe) == "w8a8"
@@ -266,7 +266,7 @@ gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor
 def test_root_pipeline_serves_on_scaled_mm_lane(
     source_root: Path, w8a8_root: Path,
 ) -> None:
-    w8a8.scaled_mm_supported.cache_clear()
+    w8a8.w8a8_gemm_mode.cache_clear()
     pipe = load_from_pretrained(_TinyRootPipeline, w8a8_root)
     assert pipe._cozy_weight_lane == "w8a8"
     model = pipe.transformer.to("cuda")

--- a/tests/test_w8a8_sm89.py
+++ b/tests/test_w8a8_sm89.py
@@ -1,0 +1,435 @@
+"""sm_89 W8A8 inference lane (gw#564): per-tensor fp8 GEMM + per-channel
+epilogue rescale.
+
+CPU lane: dispatch selection matrix (SKU x call-ok x micro-benchmark gate),
+rowwise-vs-pertensor output equivalence against the exact dequant reference
+(torch._scaled_mm patched), bias-after-rescale placement, LoRA additive-branch
+composition on the epilogue lane, and loader/swap gemm_mode threading.
+GPU lane (sm_89+): pertensor numerics vs the dequant reference and
+rowwise parity on real kernels.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.models import w8a8, w8a8_lora
+from gen_worker.models.w8a8 import (
+    W8a8Artifact,
+    fp8_scaled_linear_class,
+    load_w8a8_denoiser,
+    swap_w8a8_linears,
+)
+
+
+def _cuda_sm89() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 89
+
+
+# ---------------------------------------------------------------------------
+# Dispatch selection matrix — _choose_gemm_mode is pure given the two
+# injectable gates (kernel-call probe + micro-benchmark).
+# ---------------------------------------------------------------------------
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, ok: Dict[str, bool],
+          wins: Dict[str, bool]) -> List[str]:
+    benched: List[str] = []
+    monkeypatch.setattr(w8a8, "_gemm_call_ok", lambda m: ok.get(m, False))
+
+    def _prof(mode: str) -> bool:
+        benched.append(mode)
+        return wins.get(mode, False)
+
+    monkeypatch.setattr(w8a8, "_gemm_profitable", _prof)
+    return benched
+
+
+def test_sm90_prefers_rowwise(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(monkeypatch, {"rowwise": True, "pertensor": True},
+          {"rowwise": True, "pertensor": True})
+    assert w8a8._choose_gemm_mode(90) == "rowwise"
+    assert w8a8._choose_gemm_mode(100) == "rowwise"
+    assert w8a8._choose_gemm_mode(120) == "rowwise"
+
+
+def test_sm89_prefers_pertensor(monkeypatch: pytest.MonkeyPatch) -> None:
+    benched = _wire(monkeypatch, {"rowwise": True, "pertensor": True},
+                    {"rowwise": False, "pertensor": True})
+    assert w8a8._choose_gemm_mode(89) == "pertensor"
+    assert benched == ["pertensor"]  # rowwise never even benched
+
+
+def test_probe_pass_is_not_profitable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ie#498 lesson: every kernel CALL succeeds but nothing wins the
+    micro-benchmark — the host must take the dequant lane, not a slow GEMM."""
+    benched = _wire(monkeypatch, {"rowwise": True, "pertensor": True},
+                    {"rowwise": False, "pertensor": False})
+    assert w8a8._choose_gemm_mode(89) == ""
+    assert benched == ["pertensor", "rowwise"]  # both candidates got a chance
+
+
+def test_bench_decides_not_the_sm_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The non-preferred candidate arms when the preferred one is broken —
+    a future stack that flips the kernel story needs no code change."""
+    _wire(monkeypatch, {"rowwise": False, "pertensor": True},
+          {"pertensor": True})
+    assert w8a8._choose_gemm_mode(90) == "pertensor"
+    _wire(monkeypatch, {"rowwise": True, "pertensor": False},
+          {"rowwise": True})
+    assert w8a8._choose_gemm_mode(89) == "rowwise"
+
+
+def test_old_silicon_never_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(mode: str) -> bool:
+        raise AssertionError("probe must not run below W8A8_MIN_SM")
+
+    monkeypatch.setattr(w8a8, "_gemm_call_ok", _boom)
+    assert w8a8._choose_gemm_mode(86) == ""
+    assert w8a8._choose_gemm_mode(75) == ""
+
+
+def test_bench_failure_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(w8a8, "_gemm_call_ok", lambda m: True)
+
+    def _prof(mode: str) -> bool:
+        if mode == "pertensor":
+            raise RuntimeError("cuda OOM mid-bench")
+        return True
+
+    monkeypatch.setattr(w8a8, "_gemm_profitable", _prof)
+    assert w8a8._choose_gemm_mode(89) == "rowwise"
+
+
+def test_gate_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    pairs = {"win": (1.0, 2.0), "marginal": (1.0, 1.05), "exact": (1.0, 1.10)}
+    for name, (fp8_ms, bf16_ms) in pairs.items():
+        monkeypatch.setattr(w8a8, "_bench_gemm_pair",
+                            lambda m, p=(fp8_ms, bf16_ms): p)
+        assert w8a8._gemm_profitable("pertensor") is (name != "marginal"), name
+
+
+def test_invalid_gemm_mode_rejected() -> None:
+    lin_cls = fp8_scaled_linear_class()
+    with pytest.raises(ValueError, match="gemm_mode"):
+        lin_cls(16, 16, bias=False, compute_dtype=torch.bfloat16,
+                static_input_scale=False, gemm_mode="colwise")
+
+
+# ---------------------------------------------------------------------------
+# Epilogue correctness — CPU, torch._scaled_mm patched with the exact
+# dequant reference. Recording fake: asserts the scale SHAPES each branch
+# hands the GEMM, and that the pertensor branch never fuses bias.
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(self, a: Any, b: Any, *, scale_a: Any, scale_b: Any,
+                 bias: Any = None, out_dtype: Any = None) -> Any:
+        self.calls.append({
+            "scale_a_shape": tuple(scale_a.shape),
+            "scale_b_shape": tuple(scale_b.shape),
+            "scale_b": scale_b.detach().clone(),
+            "bias": bias,
+        })
+        y = (a.float() * scale_a) @ (b.float() * scale_b)
+        if bias is not None:
+            y = y + bias.float()
+        return y.to(out_dtype or torch.float32)
+
+
+def _quantized_module(gemm_mode: str, K: int = 32, N: int = 48, *,
+                      bias: bool = True, seed: int = 11) -> Any:
+    torch.manual_seed(seed)
+    lin_cls = fp8_scaled_linear_class()
+    mod = lin_cls(K, N, bias=bias, compute_dtype=torch.bfloat16,
+                  static_input_scale=False, gemm_mode=gemm_mode)
+    w = torch.randn(N, K)
+    scale = (w.abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    sd = {
+        "weight": (w / scale).clamp(-448, 448).to(torch.float8_e4m3fn),
+        "weight_scale": scale,
+    }
+    if bias:
+        sd["bias"] = torch.randn(N, dtype=torch.bfloat16)
+    mod.load_state_dict(sd, assign=True)
+    return mod
+
+
+def _row_uniform_amax_input(M: int, K: int) -> Any:
+    """Activations whose per-row amax equals the global amax — the per-row
+    and per-tensor dynamic scales coincide, isolating the epilogue math."""
+    x = torch.randn(M, K, dtype=torch.bfloat16).clamp(-4, 4)
+    x[:, 0] = 8.0
+    return x
+
+
+def test_pertensor_matches_rowwise_on_uniform_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(torch, "_scaled_mm", rec)
+    M, K, N = 5, 32, 48
+    row = _quantized_module("rowwise", K, N)
+    per = _quantized_module("pertensor", K, N)
+    per.load_state_dict(row.state_dict(), assign=True)
+    x = _row_uniform_amax_input(M, K)
+
+    y_row = row(x)
+    y_per = per(x)
+    assert y_row.shape == y_per.shape == (M, N)
+    assert torch.allclose(y_per.float(), y_row.float(), atol=2e-2, rtol=2e-2)
+
+    # dispatch shapes: rowwise hands vectors to the GEMM, pertensor scalars
+    assert rec.calls[0]["scale_a_shape"] == (M, 1)
+    assert rec.calls[0]["scale_b_shape"] == (1, N)
+    assert rec.calls[0]["bias"] is not None
+    assert rec.calls[1]["scale_a_shape"] == (1, 1)
+    assert rec.calls[1]["scale_b_shape"] == (1, 1)
+    assert torch.equal(rec.calls[1]["scale_b"], torch.ones(1, 1))
+    assert rec.calls[1]["bias"] is None  # bias joins AFTER the rescale
+
+
+def test_pertensor_matches_dequant_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """General activations (per-row != per-tensor scale): the epilogue lane
+    must still land on F.linear(x, dequant(W), b) within activation-quant
+    error."""
+    monkeypatch.setattr(torch, "_scaled_mm", _Recorder())
+    K, N = 32, 48
+    per = _quantized_module("pertensor", K, N)
+    x = torch.randn(7, K, dtype=torch.bfloat16)
+    y = per(x)
+    w_deq = (per.weight.float() * per.weight_scale).to(torch.bfloat16)
+    ref = torch.nn.functional.linear(x, w_deq, per.bias)
+    rel = ((y - ref).abs().max() / ref.abs().max()).item()
+    assert rel < 0.08  # per-tensor dynamic activation quant error only
+
+
+def test_bias_rides_after_the_epilogue_rescale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With weight_scale == 2 everywhere, a bias fused INSIDE the GEMM would
+    come out doubled — the reference comparison pins the ordering."""
+    monkeypatch.setattr(torch, "_scaled_mm", _Recorder())
+    K, N = 16, 16
+    lin_cls = fp8_scaled_linear_class()
+    mod = lin_cls(K, N, bias=True, compute_dtype=torch.bfloat16,
+                  static_input_scale=False, gemm_mode="pertensor")
+    w = torch.full((N, K), 4.0)
+    mod.load_state_dict({
+        "weight": (w / 2.0).to(torch.float8_e4m3fn),
+        "weight_scale": torch.full((N, 1), 2.0),
+        "bias": torch.full((N,), 3.0, dtype=torch.bfloat16),
+    }, assign=True)
+    x = torch.ones(2, K, dtype=torch.bfloat16)
+    ref = torch.nn.functional.linear(
+        x, w.to(torch.bfloat16), torch.full((N,), 3.0, dtype=torch.bfloat16))
+    assert torch.allclose(mod(x).float(), ref.float(), atol=2e-2, rtol=2e-2)
+
+
+def test_static_input_scale_feeds_pertensor_gemm_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(torch, "_scaled_mm", rec)
+    K, N = 16, 16
+    lin_cls = fp8_scaled_linear_class()
+    mod = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=True, gemm_mode="pertensor")
+    mod.load_state_dict({
+        "weight": torch.randn(N, K).clamp(-4, 4).to(torch.float8_e4m3fn),
+        "weight_scale": torch.full((N, 1), 0.5),
+        "input_scale": torch.full((1, 1), 0.25),
+    }, assign=True)
+    mod(torch.randn(3, K, dtype=torch.bfloat16))
+    assert rec.calls[0]["scale_a_shape"] == (1, 1)  # [1,1] static, no expand
+
+
+# ---------------------------------------------------------------------------
+# LoRA composability (gw#558/gw#547): the additive branch rides identically
+# on the epilogue lane — orthogonal to the GEMM scaling mode.
+# ---------------------------------------------------------------------------
+
+
+def test_pertensor_carries_additive_lora_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(torch, "_scaled_mm", _Recorder())
+    K, N, rank = 32, 48, 4
+    mod = _quantized_module("pertensor", K, N, seed=7)
+    x = torch.randn(3, K, dtype=torch.bfloat16)
+    base = mod(x)
+
+    a = torch.randn(rank, K, dtype=torch.bfloat16)
+    b = torch.randn(N, rank, dtype=torch.bfloat16)
+    mod.lora_a, mod.lora_b = a, b
+    with_branch = mod(x)
+    addend = (x.reshape(-1, K) @ a.t()) @ b.t()
+    assert torch.allclose(with_branch, base + addend, atol=2e-2, rtol=2e-2)
+
+    # branch removal restores the branchless epilogue path bit-exactly
+    mod.lora_a = mod.lora_b = None
+    assert torch.equal(mod(x), base)
+
+
+def test_branch_lane_covers_both_gemm_modes() -> None:
+    class _M:
+        pass
+
+    for mode in ("rowwise", "pertensor"):
+        m = _M()
+        m._cozy_w8a8_mode = mode
+        assert w8a8_lora.branch_lane(m) == "w8a8"
+    m = _M()
+    m._cozy_w8a8_mode = "dequant"
+    assert w8a8_lora.branch_lane(m) == ""
+
+
+# ---------------------------------------------------------------------------
+# Loader / swap threading: the mode chosen once at load lands on every
+# constructed module, and the lane stamp stays "w8a8" for both GEMM branches
+# (cells are per-SKU keyed — one lane token, per-SKU graphs).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    pytest.importorskip("diffusers")
+    pytest.importorskip("accelerate")
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    from gen_worker.models.w8a8 import quantize_tree_w8a8
+
+    root = tmp_path_factory.mktemp("w8a8-sm89") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return quantize_tree_w8a8(root, root.parent / "w8a8")
+
+
+def test_loader_threads_pertensor_onto_every_module(w8a8_tree: Path) -> None:
+    from gen_worker.models.w8a8 import detect_w8a8_artifact
+
+    art = detect_w8a8_artifact(w8a8_tree)
+    assert art is not None
+    model = load_w8a8_denoiser(w8a8_tree, art, mode="pertensor")
+    assert model._cozy_w8a8_mode == "pertensor"
+    lin_cls = fp8_scaled_linear_class()
+    swapped = [m for m in model.modules() if isinstance(m, lin_cls)]
+    assert swapped
+    assert all(m.gemm_mode == "pertensor" for m in swapped)
+    assert w8a8_lora.branch_lane(model) == "w8a8"
+
+
+def test_pipeline_lane_stamp_is_w8a8_on_pertensor(
+    w8a8_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from diffusers import DDPMPipeline
+
+    from gen_worker.models.loading import load_from_pretrained, pipeline_weight_lane
+
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "pertensor")
+    pipe = load_from_pretrained(DDPMPipeline, w8a8_tree)
+    assert pipe._cozy_weight_lane == "w8a8"
+    assert pipeline_weight_lane(pipe) == "w8a8"
+    assert pipe.unet._cozy_w8a8_mode == "pertensor"
+
+
+def test_swap_threads_gemm_mode(tmp_path: Path) -> None:
+    import torch.nn as nn
+    from safetensors.torch import save_file
+
+    class _Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = nn.Linear(16, 16)
+
+    w = torch.randn(16, 16)
+    scale = (w.abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    shard = tmp_path / "model.safetensors"
+    save_file({
+        "proj.weight": (w / scale).clamp(-448, 448).to(torch.float8_e4m3fn),
+        "proj.weight_scale": scale.reshape(-1),
+    }, str(shard))
+    art = W8a8Artifact(component="", files=(shard,),
+                       quantized=("proj",), static_input_scales=False)
+    model = _Tiny()
+    assert swap_w8a8_linears(model, art, gemm_mode="pertensor") == 1
+    assert model.proj.gemm_mode == "pertensor"
+    assert model.proj.weight.dtype == torch.float8_e4m3fn
+
+
+# ---------------------------------------------------------------------------
+# GPU lane (sm_89+): real kernels. Tiny tensors only.
+# ---------------------------------------------------------------------------
+
+gpu = pytest.mark.skipif(not _cuda_sm89(), reason="needs CUDA sm_89+ (fp8 tensor cores)")
+
+
+@gpu
+def test_pertensor_gemm_call_ok_on_real_silicon() -> None:
+    assert w8a8._gemm_call_ok("pertensor") is True
+
+
+@gpu
+def test_pertensor_matches_dequant_reference_on_gpu() -> None:
+    torch.manual_seed(0)
+    lin_cls = fp8_scaled_linear_class()
+    M, K, N = 64, 128, 96
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(N, device="cuda", dtype=torch.bfloat16)
+    scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+
+    mod = lin_cls(K, N, bias=True, compute_dtype=torch.bfloat16,
+                  static_input_scale=False, gemm_mode="pertensor")
+    mod.load_state_dict(
+        {"weight": wq, "weight_scale": scale, "bias": bias}, assign=True)
+    y = mod(x)
+    ref = torch.nn.functional.linear(x, (wq.float() * scale).to(torch.bfloat16), bias)
+    rel = ((y - ref).abs().max() / ref.abs().max()).item()
+    assert rel < 0.08  # per-tensor dynamic activation quant error only
+
+
+@gpu
+def test_rowwise_and_pertensor_agree_on_gpu() -> None:
+    """Same weights, same input: the two dispatch branches are the same math
+    up to activation-quant granularity + one bf16 epilogue rounding."""
+    torch.manual_seed(1)
+    lin_cls = fp8_scaled_linear_class()
+    M, K, N = 32, 64, 48
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    scale = (w.float().abs().amax(dim=1, keepdim=True) / 448.0).clamp(min=1e-12)
+    wq = (w.float() / scale).clamp(-448, 448).to(torch.float8_e4m3fn)
+    sd = {"weight": wq, "weight_scale": scale}
+
+    mods = {}
+    for mode in ("rowwise", "pertensor"):
+        m = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                    static_input_scale=False, gemm_mode=mode)
+        m.load_state_dict(sd, assign=True)
+        mods[mode] = m
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    y_row = mods["rowwise"](x)
+    y_per = mods["pertensor"](x)
+    rel = ((y_row - y_per).abs().max() / y_row.abs().max()).item()
+    assert rel < 0.08

--- a/tests/test_w8a8_sm89.py
+++ b/tests/test_w8a8_sm89.py
@@ -285,6 +285,40 @@ def test_pertensor_carries_additive_lora_branch(
     assert torch.equal(mod(x), base)
 
 
+def test_execution_contract_records_activation_granularity() -> None:
+    """gw#564: the activation-scale granularity is a graph property — the
+    contract must distinguish the per-tensor epilogue lane from rowwise."""
+    import torch.nn as nn
+
+    from gen_worker import compile_cache as cc
+
+    class _Cfg:
+        shapes = ((64, 64),)
+        targets = ("unet",)
+        guidance_scales = ()
+
+    contracts = {}
+    for mode in ("rowwise", "pertensor"):
+        mod = _quantized_module(mode, 16, 16, bias=False)
+
+        class _Denoiser(nn.Module):
+            def __init__(self, m) -> None:
+                super().__init__()
+                self.proj = m
+
+        class _P:
+            _cozy_weight_lane = "w8a8"
+
+        pipe = _P()
+        pipe.unet = _Denoiser(mod)
+        _sig, wc = cc.execution_contract(pipe, _Cfg())
+        contracts[mode] = wc
+    assert contracts["rowwise"]["activation_scaling"] == ["dynamic-per-row"]
+    assert contracts["pertensor"]["activation_scaling"] == ["dynamic-per-tensor"]
+    # cross-lane adoption is structurally impossible: the manifests differ
+    assert contracts["rowwise"] != contracts["pertensor"]
+
+
 def test_branch_lane_covers_both_gemm_modes() -> None:
     class _M:
         pass

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.35.2"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Implements the gw#564 sm_89 (Ada: 4090/L40S) W8A8 dispatch lane. ONE weight artifact, dispatch fork only (gw#563 design clarification — no second producer/flavor).

- **Second dispatch branch in `Fp8ScaledLinear`**, chosen once at load by SKU: sm_90+ keeps rowwise-in-GEMM; sm_89 gets `gemm_mode="pertensor"` — scalar-scaled fp8 GEMM (cuBLASLt's Ada fast path) + the SAME per-channel `weight_scale` applied as a post-GEMM column-multiply epilogue (bias joins after the rescale; one broadcast multiply, fuses under inductor).
- **Dynamic activation scales in both branches** (per-row rowwise, per-tensor epilogue lane; static `input_scale` feeds the pertensor GEMM directly) — never static calibration.
- **Probe upgrade**: `scaled_mm_supported()` → `w8a8_gemm_mode()` — a candidate branch arms only when its kernel call succeeds AND a load-time micro-benchmark GEMM (pre-quantized activations: times the KERNEL, the part compile can't fix) beats the bf16 reference by ≥1.10x. The ie#498 probe-pass≠profitable lesson, generalized for every future SKU; candidates are preference-ordered per SKU class and the bench decides.
- **LoRA composability** (gw#558/gw#547): the additive branch rides the epilogue lane unchanged; `branch_lane` covers both GEMM modes; composition + bit-exact-removal tests extended.
- Loader modes are now `rowwise`/`pertensor`/`dequant`; lane stamp stays `w8a8` for both GEMM branches (cells per-SKU keyed); root-layout `swap_w8a8_linears` threads `gemm_mode`.

Tests: new `tests/test_w8a8_sm89.py` (dispatch selection matrix, epilogue correctness vs rowwise + dequant reference, bias-ordering, micro-benchmark gate behavior, LoRA composition, loader/swap threading, GPU-marked sm_89 numerics). Full suite 1311 passed / 36 skipped; mypy 122 files clean; ruff clean.

Live 4090 proof (compiled three-way A/B: epilogue-W8A8 vs upcast-once-bf16 vs fp8-storage-hooks; quality vs sm_90 rowwise; gw#555 self-mint check) lands on this PR before undraft — tracker gw#564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)