### PR TITLE
gw#565: publish /complete survives edge-masked 5xx during long server-side verify (0.35.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.35.2 (2026-07-17)
+
+- **gw#565: publish `/complete` survives edge-masked 5xx during a long
+  server-side verify.** tensorhub's `/complete` streams the shard back from
+  R2 and hashes it synchronously; on a degraded hub link a 2GB shard verify
+  runs 10+ minutes, the tunnel in front (ngrok) times out first and answers
+  the pod 503 HTML. The bounded inner retry (5 attempts, ~2 min) then
+  RETURNED the 503 and the commit died fatal — while the hub finished the
+  verify anyway (found live, te#89: a gate-PASSED flavor lost at the seal).
+  A returned >=500 now joins the same patient re-POST clock as a severed
+  connection (`_COMPLETE_NETWORK_MAX_WAIT_S`); the idempotent Finalized
+  fast path answers the catch-up POST.
+
 ## 0.35.1 (2026-07-17)
 
 - **gw#562 follow-up: oversize tensors shard alone instead of failing the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.35.1"
+version = "0.35.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -298,6 +298,19 @@ class HubClient:
                     return resp
                 time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
                 continue
+            if resp.status_code >= 500:
+                # gw#565: an edge/tunnel in front of tensorhub (ngrok) times
+                # out DURING the synchronous verify and answers 5xx while the
+                # server is still working. A returned 5xx is the same case as
+                # a severed connection — re-POST on the patient clock; the
+                # sess.Finalized fast path answers the catch-up POST.
+                if time.monotonic() >= deadline:
+                    return resp
+                logger.warning(
+                    "POST %s returned %d (edge-masked verify?); re-POSTing (idempotent complete)",
+                    complete_path, resp.status_code)
+                time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
+                continue
             return resp
 
     def _reopen_upload(self, repo_path: str, revision_id: str, path: str) -> dict[str, Any]:

--- a/tests/convert/test_hub.py
+++ b/tests/convert/test_hub.py
@@ -322,3 +322,44 @@ def test_commit_sanitizes_colon_dtype_and_flavor_tokens(fake_hub, tmp_path: Path
     assert body["default_flavor"] == "gguf-ud-q4_k_xl"
     assert body["dtype"] == "gguf-ud-q4_k_xl"
     assert body["tags"] == [{"tag": "prod", "default_flavor": "gguf-ud-q4_k_xl"}]
+
+
+def test_complete_survives_edge_masked_5xx_storm(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """gw#565 (te#89 live): an edge/tunnel in front of tensorhub answers 5xx
+    while the synchronous shard verify is still running server-side. A 5xx
+    storm LONGER than the bounded inner retry (5 attempts) must join the
+    patient re-POST clock instead of failing the commit — the hub finishes
+    the verify and the catch-up POST lands on the Finalized fast path."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["fail_completes"] = 7  # > _RETRY_ATTEMPTS: inner retry alone loses
+    _FakeHub.state["finalize_calls"] = 1
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x06" * 48)
+    result = _client(fake_hub).commit(
+        destination_repo="acme/my-model",
+        files=[CommitFile(path="model.safetensors", local_path=f)],
+    )
+    assert result.revision_id == "rev-1"
+    assert result.uploaded == 1
+    assert list(_FakeHub.state["put_bytes"].values()) == [b"\x06" * 48]
+
+
+def test_complete_5xx_still_fatal_after_patient_deadline(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """A hub that answers 5xx forever must still fail loudly once the patient
+    clock expires — no infinite re-POST."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    monkeypatch.setattr("gen_worker.convert.hub._COMPLETE_NETWORK_MAX_WAIT_S", 0.0)
+    _FakeHub.state["fail_completes"] = 10_000
+
+    f = tmp_path / "model.safetensors"
+    f.write_bytes(b"\x07" * 48)
+    with pytest.raises(HubPublishError, match="upload complete failed \\(50"):
+        _client(fake_hub).commit(
+            destination_repo="acme/my-model",
+            files=[CommitFile(path="model.safetensors", local_path=f)],
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.35.1"
+version = "0.35.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Found live by the te#89 fleet batch: a gate-PASSED `#fp8-w8a8` flavor died at the publish seal.

tensorhub's `/complete` verifies the whole shard synchronously (streams from R2 + hashes). On a degraded hub link a 2.1GB shard verify runs 10-12 min (hub log: 200s at 10m0s/11m10s/11m40s); the ngrok edge times out first and answers the pod **503 HTML**. `_send_with_retries` retries 5x in ~2 min, RETURNS the last 503, `_check_complete` raises fatal — the patient network-severed clock (`_COMPLETE_NETWORK_MAX_WAIT_S=1800`) never engages because a returned 5xx is not an exception. The hub finishes the verify anyway.

Fix: a returned >=500 in `_post_complete` joins the same patient re-POST loop as a severed connection; the idempotent `sess.Finalized` fast path answers the catch-up POST. Deadline expiry still fails loudly.

Tests: 5xx storm (7 > inner 5) resolves; permanent 5xx still fatal after the deadline. `tests/convert`: 191 passed / 2 skipped; ruff + mypy clean.

Unblocks: te#89, te#92 (hidream), ie#495, ie#498 publishes on the current link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)