### PR TITLE
gw#567 follow-up: sync uv.lock to the 0.36.1 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.0"
+version = "0.36.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- PR #286 bumped pyproject.toml to 0.36.1 but the self-referential
  gen-worker entry in uv.lock was left at 0.36.0 (lock not regenerated
  after the version bump landed).
- CI's `uv sync --locked` correctly rejects the drift; \`v0.36.1\` publish
  run failed the same way.
- Fix: \`uv lock\` regeneration only, no dependency changes.

## Test plan
- [x] `uv sync --locked --extra dev` no longer reports lockfile drift
      (fails later on an unrelated local torch/cu130 mirror hash issue —
      confirmed CI's own runners resolved torch fine on the v0.36.0 publish)