### PR TITLE
gw#569: make W8A8 verification device-stable

### DIFF
--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1244,11 +1244,13 @@ def verify_w8a8_snapshot(
 
     Detection runs through the CONSUMER's own sniffer
     (:func:`gen_worker.models.w8a8.detect_w8a8_artifact`), then for a
-    deterministic sample of quantized layers: (a) the recomputed
-    quant+scale bytes must be EXACTLY the artifact's (the recipe is
-    deterministic — any drift is corruption or a recipe change), and
-    (b) ``dequant(w_fp8 x scale)`` must sit within fp8-e4m3 format error of
-    the source (max row-relative error <= 2**-4 + subnormal floor).
+    deterministic sample of quantized layers: (a) recomputing the FP8 weight
+    with the artifact's recorded scale must reproduce its bytes EXACTLY,
+    (b) that scale must be the source-derived per-row amax/448 value within
+    one FP32 ULP (CUDA and CPU division legitimately choose adjacent FP32
+    values), and (c) ``dequant(w_fp8 x scale)`` must sit within fp8-e4m3
+    format error of the source (max row-relative error <= 2**-4 + subnormal
+    floor).
     Raises :class:`ConversionImplementationError` on any failure; returns a
     report dict for produce logs. ``source_compute_dtype`` names the exact
     producer-side quantization input view. For example, an immutable FP16
@@ -1302,6 +1304,7 @@ def verify_w8a8_snapshot(
     rng = random.Random(seed)
     picked = names if len(names) <= sample else sorted(rng.sample(names, sample))
     max_rel = 0.0
+    max_scale_ulp = 0
     source_storage_dtypes: set[str] = set()
     for layer in picked:
         wname, sname = f"{layer}.weight", f"{layer}{_SCALE_SUFFIX}"
@@ -1319,17 +1322,39 @@ def verify_w8a8_snapshot(
             got_q = fh.get_tensor(wname)
         with safe_open(str(out_where[sname]), framework="pt", device="cpu") as fh:
             got_s = fh.get_tensor(sname).float()
-        scale = (src.abs().amax(dim=1, keepdim=True)
-                 / _FP8_E4M3_MAX).clamp(min=1e-12)
-        want_q = (src / scale).clamp(
+        expected_scale = (src.abs().amax(dim=1)
+                          / _FP8_E4M3_MAX).clamp(min=1e-12)
+        artifact_scale = got_s.reshape(-1)
+        if artifact_scale.numel() != expected_scale.numel():
+            raise ConversionImplementationError(
+                f"byte-gate: {sname} has {artifact_scale.numel()} values for "
+                f"{expected_scale.numel()} source rows")
+        if not bool(torch.isfinite(artifact_scale).all()) or not bool(
+            (artifact_scale > 0).all()
+        ):
+            raise ConversionImplementationError(
+                f"byte-gate: {sname} contains non-finite/non-positive values")
+
+        # ModelOpt derives the scale on CUDA while this portable verifier reads
+        # the immutable source on CPU.  FP32 division by 448 differs by one ULP
+        # for some rows across those devices.  Compare the positive FP32 bit
+        # patterns directly: this admits only the two valid adjacent results,
+        # rather than an arbitrary numerical epsilon.
+        expected_bits = expected_scale.contiguous().view(torch.int32).to(torch.int64)
+        artifact_bits = artifact_scale.contiguous().view(torch.int32).to(torch.int64)
+        scale_ulp = (expected_bits - artifact_bits).abs()
+        layer_max_scale_ulp = int(scale_ulp.max().item())
+        if layer_max_scale_ulp > 1:
+            raise ConversionImplementationError(
+                f"byte-gate: {sname} differs from source-derived amax/448 by "
+                f"{layer_max_scale_ulp} FP32 ULPs (maximum 1)")
+
+        want_q = (src / artifact_scale.reshape(-1, 1)).clamp(
             -_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
         if not torch.equal(want_q.view(torch.uint8), got_q.view(torch.uint8)):
             raise ConversionImplementationError(
                 f"byte-gate: {wname} recomputed fp8 bytes differ from artifact")
-        if not torch.equal(scale.reshape(-1), got_s.reshape(-1)):
-            raise ConversionImplementationError(
-                f"byte-gate: {sname} recomputed scales differ from artifact")
-        deq = got_q.float() * got_s.reshape(-1, 1)
+        deq = got_q.float() * artifact_scale.reshape(-1, 1)
         row_amax = src.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
         rel = ((deq - src).abs() / row_amax).max().item()
         # e4m3 half-ulp relative error at worst 2**-4 for normals, plus the
@@ -1339,11 +1364,13 @@ def verify_w8a8_snapshot(
                 f"byte-gate: {wname} dequant error {rel:.5f} exceeds the "
                 "fp8-e4m3 format bound")
         max_rel = max(max_rel, rel)
+        max_scale_ulp = max(max_scale_ulp, layer_max_scale_ulp)
     return {
         "component": art.component,
         "quantized_total": len(names),
         "sampled": len(picked),
         "byte_exact": True,
+        "max_scale_ulp": max_scale_ulp,
         "max_rel_err": max_rel,
         "source_storage_dtypes": sorted(source_storage_dtypes),
         "source_compute_dtype": canonical_compute_dtype,

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -18,6 +18,7 @@ torch/safetensors imports are deferred so importing gen_worker.convert stays che
 from __future__ import annotations
 
 import json
+import math
 import re
 import shutil
 import struct
@@ -1318,12 +1319,18 @@ def verify_w8a8_snapshot(
         if cast_dtype is not None:
             stored = stored.to(dtype=cast_dtype)
         src = stored.float()
+        if not bool(torch.isfinite(src).all()):
+            raise ConversionImplementationError(
+                f"byte-gate: source tensor {wname} contains non-finite values")
         with safe_open(str(out_where[wname]), framework="pt", device="cpu") as fh:
             got_q = fh.get_tensor(wname)
         with safe_open(str(out_where[sname]), framework="pt", device="cpu") as fh:
             got_s = fh.get_tensor(sname).float()
         expected_scale = (src.abs().amax(dim=1)
                           / _FP8_E4M3_MAX).clamp(min=1e-12)
+        if not bool(torch.isfinite(expected_scale).all()):
+            raise ConversionImplementationError(
+                f"byte-gate: source-derived scale for {sname} is non-finite")
         artifact_scale = got_s.reshape(-1)
         if artifact_scale.numel() != expected_scale.numel():
             raise ConversionImplementationError(
@@ -1357,6 +1364,9 @@ def verify_w8a8_snapshot(
         deq = got_q.float() * artifact_scale.reshape(-1, 1)
         row_amax = src.abs().amax(dim=1, keepdim=True).clamp(min=1e-12)
         rel = ((deq - src).abs() / row_amax).max().item()
+        if not math.isfinite(rel):
+            raise ConversionImplementationError(
+                f"byte-gate: {wname} dequant error is non-finite")
         # e4m3 half-ulp relative error at worst 2**-4 for normals, plus the
         # subnormal quantization floor for near-zero elements.
         if rel > 2 ** -4 + 2 ** -9:

--- a/tests/test_w8a8_produce.py
+++ b/tests/test_w8a8_produce.py
@@ -255,6 +255,51 @@ def test_byte_gate_accepts_only_cpu_cuda_one_ulp_scale_envelope(
         verify_w8a8_snapshot(tiny_dit, outside, sample=1000)
 
 
+def test_byte_gate_rejects_nonfinite_source_at_fp32_ulp_boundary(
+    tiny_dit: Path, produced: Path, tmp_path: Path,
+) -> None:
+    """+Inf is one FP32 bit above max-finite; it is not a valid ULP neighbor."""
+    import shutil
+
+    from safetensors.torch import save_file
+
+    source = tmp_path / "nonfinite-source"
+    candidate = tmp_path / "nonfinite-candidate"
+    shutil.copytree(tiny_dit, source)
+    shutil.copytree(produced, candidate)
+    art = detect_w8a8_artifact(candidate)
+    assert art is not None
+    layer = art.quantized[0]
+    weight_name = f"{layer}.weight"
+    scale_name = f"{layer}.weight_scale"
+
+    source_component = source / art.component
+    source_tensors = _load_all(source_component)
+    source_weight = source_tensors[weight_name].clone()
+    source_weight[0, 0] = torch.inf
+    source_tensors[weight_name] = source_weight
+    for path in source_component.glob("*.safetensors"):
+        path.unlink()
+    save_file(source_tensors, str(source_component / "model.safetensors"))
+
+    candidate_component = candidate / art.component
+    candidate_tensors = _load_all(candidate_component)
+    scale = candidate_tensors[scale_name].clone()
+    scale[0] = torch.finfo(torch.float32).max
+    candidate_tensors[scale_name] = scale
+    candidate_tensors[weight_name] = (
+        (source_weight.float() / scale.reshape(-1, 1))
+        .clamp(-448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+    )
+    for path in candidate_component.glob("*.safetensors"):
+        path.unlink()
+    save_file(candidate_tensors, str(candidate_component / "model.safetensors"))
+
+    with pytest.raises(ConversionImplementationError, match="source tensor.*non-finite"):
+        verify_w8a8_snapshot(source, candidate, sample=1000)
+
+
 def _rewrite_component_float_dtype(
     root: Path, dtype: "torch.dtype", *, inject_fp16_detail: bool = False,
 ) -> None:

--- a/tests/test_w8a8_produce.py
+++ b/tests/test_w8a8_produce.py
@@ -201,6 +201,60 @@ def test_byte_gate_passes_then_catches_tampering(
         verify_w8a8_snapshot(tiny_dit, bad, sample=len(art.quantized))
 
 
+def _candidate_with_shifted_scales(
+    source: Path, candidate: Path, destination: Path, *, ulps: int,
+) -> Path:
+    """Model a valid CUDA export whose /448 result neighbors CPU's value."""
+    import shutil
+
+    from safetensors.torch import save_file
+
+    shutil.copytree(candidate, destination)
+    art = detect_w8a8_artifact(candidate)
+    assert art is not None
+    source_tensors = _load_all(source / art.component)
+    candidate_tensors = _load_all(destination / art.component)
+    for layer in art.quantized:
+        weight_name = f"{layer}.weight"
+        scale_name = f"{layer}.weight_scale"
+        source_weight = source_tensors[weight_name].float()
+        scale = source_weight.abs().amax(dim=1) / 448.0
+        for _ in range(ulps):
+            scale = torch.nextafter(scale, torch.full_like(scale, torch.inf))
+        candidate_tensors[scale_name] = scale
+        candidate_tensors[weight_name] = (
+            (source_weight / scale.reshape(-1, 1))
+            .clamp(-448.0, 448.0)
+            .to(torch.float8_e4m3fn)
+        )
+
+    component = destination / art.component
+    for path in component.glob("*.safetensors"):
+        path.unlink()
+    index = component / "diffusion_pytorch_model.safetensors.index.json"
+    if index.exists():
+        index.unlink()
+    save_file(candidate_tensors, str(component / "diffusion_pytorch_model.safetensors"))
+    return destination
+
+
+def test_byte_gate_accepts_only_cpu_cuda_one_ulp_scale_envelope(
+    tiny_dit: Path, produced: Path, tmp_path: Path,
+) -> None:
+    adjacent = _candidate_with_shifted_scales(
+        tiny_dit, produced, tmp_path / "adjacent", ulps=1,
+    )
+    report = verify_w8a8_snapshot(tiny_dit, adjacent, sample=1000)
+    assert report["byte_exact"] is True
+    assert report["max_scale_ulp"] == 1
+
+    outside = _candidate_with_shifted_scales(
+        tiny_dit, produced, tmp_path / "outside", ulps=2,
+    )
+    with pytest.raises(ConversionImplementationError, match="maximum 1"):
+        verify_w8a8_snapshot(tiny_dit, outside, sample=1000)
+
+
 def _rewrite_component_float_dtype(
     root: Path, dtype: "torch.dtype", *, inject_fp16_detail: bool = False,
 ) -> None:


### PR DESCRIPTION
Fix the SDXL W8A8 producer gate false-negative caused by one-ULP CPU/CUDA differences in FP32 amax/448 division. Quantized weights remain byte-exact against the artifact scale; scales are source-bound to the only valid adjacent FP32 representation, and numerical bounds remain fail-closed.

Tracker: python-gen-worker #569; inference-endpoints #496.

Current gates: 31 focused tests pass, Ruff clean, focused mypy clean. Full suite and independent review are pending before readiness.