### PR TITLE
gw#570: publish survives upload_session_expired — per-file session reopen (0.36.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.1"
+version = "0.36.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -406,6 +406,15 @@ class HubClient:
                         u, data=b, timeout=(_CONNECT_TIMEOUT_S, self.timeout_s * 5))
 
                 resp = _send_with_retries(f"part PUT {entry.get('path')!r} #{i + 1}", _put)
+                if resp.status_code == 403:
+                    # gw#570: presigned part URLs share the session's fixed
+                    # expiry; on a long publish a later file's URLs are stale
+                    # before its first byte moves (S3 signals expiry as 403).
+                    # Re-open for fresh URLs — bounded by _REUPLOAD_ATTEMPTS,
+                    # so a genuine auth failure still fails typed.
+                    raise _StagingLostError(
+                        f"part PUT for {entry.get('path')!r} part #{i + 1} "
+                        f"rejected (403 — presigned URL likely expired)")
                 if resp.status_code < 200 or resp.status_code >= 300:
                     raise HubPublishError(
                         f"part PUT failed ({resp.status_code}) for {entry.get('path')!r} "
@@ -426,6 +435,15 @@ class HubClient:
             raise _StagingLostError(
                 f"staged bytes for {path_label!r} are gone server-side "
                 f"(409 staging_object_missing)")
+        if resp.status_code == 410 and _error_code_of(resp) == "upload_session_expired":
+            # gw#570: commit-create mints every file's session up-front with a
+            # fixed expiry; a long publish (slow uplink, many shards) outlives
+            # it for later files. The session is unusable but nothing is wrong
+            # with the bytes — re-open for a fresh session and re-send just
+            # this file, same as staging loss.
+            raise _StagingLostError(
+                f"upload session for {path_label!r} expired server-side "
+                f"(410 upload_session_expired)")
         raise HubPublishError(
             f"upload complete failed ({resp.status_code}) for {path_label!r} "
             f"after {_RETRY_ATTEMPTS} attempts: {resp.text[:500]}")

--- a/tests/convert/fake_hub.py
+++ b/tests/convert/fake_hub.py
@@ -167,6 +167,15 @@ class _FakeHub(BaseHTTPRequestHandler):
                 self._send(409, {"error": {"code": "staging_object_missing",
                                            "message": "verify: get staging object: NoSuchKey"}})
                 return
+            expired = st.get("session_expired") or {}
+            if expired.get(path_label, 0) > 0:
+                # gw#570: the up-front-minted session outlived its fixed
+                # expiry mid-publish; only a re-open can mint a fresh one.
+                expired[path_label] -= 1
+                st.setdefault("session_expired_hits", []).append(uid)
+                self._send(410, {"error": {"code": "upload_session_expired",
+                                           "message": "upload session expired"}})
+                return
             if st.get("complete_race_count", 0) > 0:
                 # Simulates a still-finalizing concurrent attempt (tensorhub
                 # verifies large single files synchronously and can outlast
@@ -212,6 +221,14 @@ class _FakeHub(BaseHTTPRequestHandler):
             else:
                 st["fail_puts"] -= 1
             self.send_response(500)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        expired_puts = st.get("expired_put_paths") or {}
+        if expired_puts.get(self.path, 0) > 0:
+            # gw#570: S3 answers 403 for an expired presigned URL.
+            expired_puts[self.path] -= 1
+            self.send_response(403)
             self.send_header("Content-Length", "0")
             self.end_headers()
             return

--- a/tests/convert/test_publish_resilience.py
+++ b/tests/convert/test_publish_resilience.py
@@ -78,6 +78,57 @@ def test_staging_missing_reopen_dedup_hit_short_circuits(fake_hub, tmp_path: Pat
     assert sum(st["put_counts"].values()) == 2
 
 
+def test_session_expired_reopens_and_completes(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    """gw#570: 410 upload_session_expired at /complete costs one file's
+    re-open + re-upload, never the job."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["session_expired"] = {"shard-00004.safetensors": 1}
+
+    result = _client(fake_hub).commit(
+        destination_repo="acme/qwen-image",
+        files=files_from_tree(_tree(tmp_path)),
+    )
+    assert result.uploaded == 2
+
+    st = _FakeHub.state
+    assert st["reopens"] == ["shard-00004.safetensors"]
+    # Original PUTs (2 files) + one re-upload of the expired file.
+    assert sum(st["put_counts"].values()) == 3
+    assert st["session_expired_hits"]
+
+
+def test_session_expired_is_bounded_then_typed(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    _FakeHub.state["session_expired"] = {"shard-00004.safetensors": 10_000}
+
+    with pytest.raises(HubPublishError, match=r"staged bytes lost server-side"):
+        _client(fake_hub).commit(
+            destination_repo="acme/qwen-image",
+            files=files_from_tree(_tree(tmp_path)),
+        )
+    assert _FakeHub.state["reopen_count"] == _REUPLOAD_ATTEMPTS
+
+
+def test_expired_part_url_403_reopens_and_completes(fake_hub, tmp_path: Path, monkeypatch) -> None:
+    """gw#570: a 403 on a part PUT (expired presigned URL) re-opens the file's
+    session for fresh URLs instead of failing the job."""
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    # Single-add commit: the fake's original part URL is /put/up-0/1.
+    (tmp_path / "weights.bin").write_bytes(b"\xab" * 90)
+    _FakeHub.state["expired_put_paths"] = {"/put/up-0/1": 1}
+
+    result = _client(fake_hub).commit(
+        destination_repo="acme/qwen-image",
+        files=files_from_tree(tmp_path),
+    )
+    assert result.uploaded == 1
+    st = _FakeHub.state
+    assert st["reopens"] == ["weights.bin"]
+    counts = st["put_counts"]
+    assert counts["/put/up-0/1"] == 1  # the expired attempt
+    assert sum(n for p, n in counts.items() if "/re-1/" in p) == 1
+
+
 def test_finalize_503s_then_succeeds(fake_hub, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr("time.sleep", lambda *_: None)
     _FakeHub.state["fail_finalizes"] = 3

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.1"
+version = "0.36.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Problem
Commit-create mints ALL upload sessions up-front with a fixed 2h expiry (tensorhub `presignExpiryForCaller`). On a slow/contended uplink the hub-side seal runs 3-6 min/file, so a many-shard publish outlives the expiry for later files: `/complete` returns **410 upload_session_expired** and the worker fails the whole job — after gw#565's patience loop worked perfectly for ~1.9h. Live evidence: ie#495 produce runs 12d10456 and 1ac4f14c both died exactly this way at shard 00007/00010.

## Fix
- `_check_complete`: 410/`upload_session_expired` raises the same reopen class as th#699 staging loss → `_reopen_upload` mints a fresh session for that one file and re-sends it (bounded by `_REUPLOAD_ATTEMPTS`).
- part PUT 403 (how S3 signals an expired presigned URL) → same reopen path, so files whose upload *starts* after expiry also recover. A genuine auth 403 still fails typed after the bounded reopens.

## Tests
Fake-hub seams for 410-at-complete and 403-at-part-PUT; three new tests: reopen-and-complete (one file's re-upload, never the job), bounded-then-typed, and expired-part-URL recovery. `tests/convert/test_publish_resilience.py` + `test_hub.py`: 24 passed. Pre-existing `test_clone_network_timeouts` errors reproduce on clean master (unrelated).

Version → 0.36.2 (uv.lock self-reference updated — the 0.36.1 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)