### PR TITLE
Release residency identity protocol as v0.36.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.2"
+version = "0.36.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.2"
+version = "0.36.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the release portion of tracker pgw#568 after #288 merged.

This is intentionally mechanical and narrow:
- bump pyproject.toml from 0.36.2 to 0.36.3
- regenerate uv.lock so the local editable package is 0.36.3

No runtime code or dependency versions change. The tag and PyPI publish remain blocked until this exact head passes protected CI and independent review.