### PR TITLE
Release gen-worker v0.36.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.3"
+version = "0.36.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.3"
+version = "0.36.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Tracker: python-gen-worker #571; Tensorhub #867; e2e #178/#179.

Patch release for merged PR #292: causal compile-adoption operation identity, serialized adoption mutations, exact terminal digest evidence, and worker-reported Torch runtime identity.

This PR changes only pyproject.toml and uv.lock from 0.36.3 to 0.36.4. It will be merged normally after exact-head CI; the signed v0.36.4 tag will be cut only from the resulting origin/master commit and the PyPI publish watched to terminal success.