### PR TITLE
Release gen-worker v0.36.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.4"
+version = "0.36.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.4"
+version = "0.36.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the python-gen-worker #572 release gate after PR #294.\n\nThis patch release contains the exact compile-target incarnation, causal W8A8 execution proof, and sticky per-incarnation quarantine contract reviewed at f82748b2.\n\nGates in progress:\n- uv lock --check\n- uv build\n- exact-head CI\n\nNo live, cloud, or paid inference state is changed by this release PR.