### PR TITLE
gw#574: gate vae channels_last on rank-4 weights (rank-5 causal VAEs crashed compile arm)

### DIFF
--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1174,6 +1174,16 @@ def _guarded_regional(
     return wrapper
 
 
+def _vae_supports_channels_last(vae: Any) -> bool:
+    """True only when every VAE weight is rank<=4 (2D convs). channels_last
+    is a rank-4 memory format; rank-5 Conv3d weights (causal/video VAEs)
+    raise on it (gw#574)."""
+    try:
+        return all(p.dim() <= 4 for p in vae.parameters())
+    except Exception:
+        return False
+
+
 def apply(
     pipeline: Any,
     cfg: Any,
@@ -1278,9 +1288,13 @@ def apply(
         if target.startswith("vae"):
             # channels_last + compiled decode is the measured win combo (#382);
             # memory format changes strides, so it is part of the cache key —
-            # producer and consumer both come through here.
+            # producer and consumer both come through here. channels_last is a
+            # RANK-4 format: causal/video VAEs (Conv3d, rank-5 weights — qwen,
+            # LTX) crash on it (gw#574), so gate on the actual weight ranks.
+            # The gate is deterministic per model class, so producer and
+            # consumer always agree on the resulting strides.
             vae = getattr(pipeline, "vae", None)
-            if vae is not None:
+            if vae is not None and _vae_supports_channels_last(vae):
                 vae.to(memory_format=torch.channels_last)
         compiled = torch.compile(fn, dynamic=False)
         setattr(owner, attr, _guarded(

--- a/tests/test_vae_channels_last_gw574.py
+++ b/tests/test_vae_channels_last_gw574.py
@@ -1,0 +1,42 @@
+"""gw#574: compile arm() must not apply channels_last to rank-5 (causal/
+video) VAEs — qwen's AutoencoderKLQwenImage crashed the ie#501 cell
+producer with "required rank 4 tensor to use channels_last format"."""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402
+
+from gen_worker.compile_cache import _vae_supports_channels_last  # noqa: E402
+
+
+class _Vae2D(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, 3)
+
+
+class _Vae3D(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv3d(3, 8, 3)
+
+
+def test_rank4_vae_supports_channels_last() -> None:
+    assert _vae_supports_channels_last(_Vae2D())
+
+
+def test_rank5_vae_refuses_channels_last() -> None:
+    assert not _vae_supports_channels_last(_Vae3D())
+
+
+def test_gate_is_load_bearing_rank5_to_channels_last_raises() -> None:
+    # The exact production crash the gate prevents.
+    with pytest.raises(RuntimeError, match="rank 4"):
+        _Vae3D().to(memory_format=torch.channels_last)
+
+
+def test_non_module_is_refused_not_crashed() -> None:
+    assert not _vae_supports_channels_last(object())


### PR DESCRIPTION
Found live in ie#501 run 9: the qwen `w8a8-lora128` cell producer died on H100 with `RuntimeError: required rank 4 tensor to use channels_last format`.

`compile_cache.apply()`'s vae branch applies `vae.to(memory_format=torch.channels_last)` unconditionally for any `vae*` target (#382's measured decode win). channels_last is a rank-4 memory format; `AutoencoderKLQwenImage` (causal/video VAE, Conv3d) has rank-5 weights and `.to(memory_format=...)` raises. The consumer serve worker would hit the identical crash when arming an adopted cell.

Fix: `_vae_supports_channels_last` — apply only when every VAE weight is rank<=4. The gate is deterministic per model class, so producer and consumer always agree on the resulting strides (memory format stays part of the cache key contract, unchanged for rank-4 VAEs).

Tests: new `tests/test_vae_channels_last_gw574.py` (rank-4 → applied, rank-5 → refused, the exact production crash pinned as load-bearing, non-module refused). Focused compile suites green (58 passed); full suite failure set byte-identical to base (pre-existing local-env misses). mypy clean on the touched file.

Note: a lock-only issue exists on this box — the cu130 torch wheel was re-published upstream and `uv.lock`'s hash no longer matches the index (`uv sync --locked --extra dev` fails to download torch). Not touched here; will bite the next lock-verified CI run.