### PR TITLE
Release gen-worker v0.36.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.5"
+version = "0.36.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.5"
+version = "0.36.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
gw#574 fix release: rank-aware vae channels_last gate (rank-5 causal VAEs no longer crash compile arm — unblocks the ie#501 qwen w8a8-lora128 cell producer and consumer). Version + lock bump only.