### PR TITLE
Fix warmup for dynamically rebound handler groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.6"
+version = "0.36.7"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -228,13 +228,22 @@ def _plan_pairs(
     owner: str,
     pairs: Sequence[Tuple[str, type]],
     decl_warmup: Any,
+    *,
+    known_attrs: Optional[Iterable[str]] = None,
 ) -> Tuple[List[Tuple[str, _Factory, bool]], List[Tuple[str, str]]]:
     """Core planner over (attr_name, payload_type) pairs ->
-    (jobs=[(attr, factory, declared)], skips=[(attr, reason)])."""
+    (jobs=[(attr, factory, declared)], skips=[(attr, reason)]).
+
+    ``pairs`` is the active instance group to plan. ``known_attrs`` is the
+    class-wide handler vocabulary used only to validate ``warmup=`` keys.
+    They differ after a dynamic Slot pick splits one handler off from its
+    authored siblings into a distinct instance group.
+    """
     if isinstance(decl_warmup, NoWarmup):
         return [], [(a, f"NoWarmup: {decl_warmup.reason}") for a, _ in pairs]
     declared: Mapping[str, Any] = decl_warmup if isinstance(decl_warmup, Mapping) else {}
-    known = {a for a, _ in pairs}
+    pair_attrs = {a for a, _ in pairs}
+    known = set(known_attrs) if known_attrs is not None else pair_attrs
     unknown = set(declared) - known
     if unknown:
         raise TypeError(
@@ -268,8 +277,10 @@ def plan(
     """Warmup plan for the GPU inference handlers of ONE instance group.
 
     Declared ``warmup=`` payloads override synthesis per method; methods the
-    mapping does not name still auto-synthesize. Raises TypeError for
-    declarations that name unknown methods or fail schema validation.
+    mapping does not name still auto-synthesize. The declaration belongs to
+    the class, while this plan may cover only one dynamically rebound subset
+    of its handlers. Raises TypeError for declarations that name methods
+    unknown to the full class or fail schema validation.
     """
     eligible = [
         s for s in specs
@@ -281,8 +292,22 @@ def plan(
     assert cls0 is not None  # eligible filters cls None
     owner = cls0.__name__
     by_attr = {s.attr_name: s for s in eligible}
+    # A request-time Slot pick can split one handler away from its authored
+    # siblings by changing instance_key. Validate the class-level declaration
+    # against every authored handler, but apply it only to this active group.
+    # Otherwise a valid explicit skip for a sibling (for example SDXL Turbo)
+    # becomes an "unknown method" setup fatal when ordinary generate rebinds.
+    known_attrs = {
+        attr for attr, _method in (
+            getattr(cls0, "__gen_worker_handlers__", []) or []
+        )
+    } | set(by_attr)
     raw_jobs, raw_skips = _plan_pairs(
-        owner, [(s.attr_name, s.payload_type) for s in eligible], decl_warmup)
+        owner,
+        [(s.attr_name, s.payload_type) for s in eligible],
+        decl_warmup,
+        known_attrs=known_attrs,
+    )
     jobs = [WarmupJob(by_attr[a], f, d) for a, f, d in raw_jobs]
     skips = [WarmupSkip(by_attr[a], r) for a, r in raw_skips]
     return jobs, skips

--- a/tests/test_warmup_synthesis.py
+++ b/tests/test_warmup_synthesis.py
@@ -13,10 +13,11 @@ from typing import Iterator, Optional
 import msgspec
 import pytest
 
-from gen_worker import NoWarmup, Resources, endpoint
+from gen_worker import Hub, NoWarmup, Resources, Slot, endpoint
 from gen_worker import warmup as warmup_mod
 from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
-from gen_worker.executor import Executor
+from gen_worker.executor import Executor, _MaterializedLocal
+from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import extract_specs
 
 
@@ -115,6 +116,12 @@ class _VideoIn(msgspec.Struct):
 class _PromptIn(msgspec.Struct):
     prompt: str
     steps: int = 2
+
+
+class _SlotPromptIn(msgspec.Struct):
+    prompt: str
+    steps: int = 2
+    model: str = ""
 
 
 def test_nowarmup_requires_reason():
@@ -255,6 +262,84 @@ def test_executor_runs_synthesized_warmup_pre_ready():
     # Both handlers of the instance group warmed exactly once, as warmup.
     assert calls == [(True, "warmup", False), (True, "warmup", False)]
     assert ex._classes[specs[0].instance_key].ready
+
+
+def test_executor_warmup_handles_dynamic_slot_split(tmp_path) -> None:
+    """A request-time Slot pick can split one method into a new instance key.
+
+    ``warmup=`` is still a class-wide declaration: a skip for the authored
+    Turbo sibling remains valid even when this picked instance contains only
+    ordinary generate. This is the SDXL release-06b6 production failure.
+    """
+    calls: list[str] = []
+
+    class _Pipeline:
+        pass
+
+    @endpoint(
+        models={
+            "pipeline": Slot(
+                _Pipeline,
+                selected_by="model",
+                default_checkpoint=Hub("acme/default", tag="prod"),
+            ),
+        },
+        resources=Resources(vram_gb=8),
+        warmup={
+            "generate": {"prompt": "warmup", "steps": 1},
+            "generate_turbo": None,
+        },
+    )
+    class Ep:
+        def setup(self, pipeline: str) -> None:
+            self.pipeline = pipeline
+
+        def generate(self, ctx, payload: _SlotPromptIn) -> _Out:
+            calls.append(payload.prompt)
+            return _Out()
+
+        def generate_turbo(self, ctx, payload: _SlotPromptIn) -> _Out:
+            calls.append("turbo")
+            return _Out()
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _noop_send)
+    generate = next(spec for spec in specs if spec.attr_name == "generate")
+    picked = ex._effective_spec(
+        generate,
+        pb.RunJob(
+            models=[
+                pb.ModelBinding(slot="pipeline", ref="acme/babes-pony:prod"),
+            ],
+        ),
+    )
+    assert picked.instance_key != generate.instance_key
+
+    async def _materialize_local(ref, snapshot=None, *, binding=None):
+        return _MaterializedLocal(path=tmp_path, identity=("", 0))
+
+    ex.store._materialize_local = _materialize_local  # type: ignore[method-assign]
+    asyncio.run(ex.ensure_setup(picked))
+
+    assert calls == ["warmup"]
+    assert ex._classes[picked.instance_key].ready
+
+    # The opposite split is equally important: the Turbo-only group keeps
+    # its explicit skip and must not synthesize a Turbo request merely because
+    # ordinary generate lives in another instance group.
+    turbo = next(spec for spec in specs if spec.attr_name == "generate_turbo")
+    turbo_picked = ex._effective_spec(
+        turbo,
+        pb.RunJob(
+            models=[
+                pb.ModelBinding(slot="pipeline", ref="acme/other-pony:prod"),
+            ],
+        ),
+    )
+    asyncio.run(ex.ensure_setup(turbo_picked))
+
+    assert calls == ["warmup"]
+    assert ex._classes[turbo_picked.instance_key].ready
 
 
 def test_executor_custom_warmup_method_suppresses_synthesis():

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.6"
+version = "0.36.7"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Root cause

A request-time Slot pick can split one method away from its authored siblings by changing the runtime instance key. The synthesized-warmup planner then planned only that active subgroup, but incorrectly revalidated the class-wide warmup declaration against the subgroup. SDXL therefore rejected the valid generate_turbo skip when only generate had rebound.

## Fix

Validate warmup declaration names against the full decorated class handler set, while applying warmup jobs and skips only to the current runtime instance group. This preserves both sides of the contract:

- a generate-only picked group warms generate;
- a Turbo-only picked group honors its explicit skip and does not synthesize Turbo.

This draft also prepares version 0.36.7. Do not tag or publish until this PR passes normal review and CI.

## Focused validation

- 41 passed: warmup synthesis, dynamic Slot materialization, declarative residency
- Ruff passes on changed source/tests
- Mypy passes for src/gen_worker/warmup.py
- uv lock --check passes

No live stack or endpoint was touched.
