### PR TITLE
Reclaim evicted snapshot cache under RAM pressure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.7"
+version = "0.36.8"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3496,6 +3496,52 @@ class Executor:
                 for event in [*failures, *progress]
             ]
 
+    async def _reclaim_released_file_cache(
+        self, released_refs: List[str], incoming_paths: List[Path],
+    ) -> int:
+        """Advise only pressure-evicted immutable snapshots out of file cache.
+
+        A DISK transition preserves model bytes, but recently-read clean pages
+        can still fill the pod cgroup and make the following load look
+        impossible.  Protect the incoming snapshot and every still-loaded or
+        executing ref by inode; then advise only refs that truthfully reached
+        DISK.  The caller always re-probes measured headroom afterward.
+
+        This runs inside ``_setup_locked``'s process-wide load lock.  Every
+        setup and ordinary RAM->VRAM promotion takes that same lock, so a DISK
+        ref cannot be reloaded or promoted between this tier check and the
+        blocking file-advice scan.
+        """
+        if not self._load_lock.locked():
+            raise RuntimeError("snapshot file-cache reclaim requires the load lock")
+        res = self.store.residency
+        preserve = list(incoming_paths)
+        for live_ref, tier, _vram_bytes in res.snapshot():
+            if (
+                tier not in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+                and not res.in_use(live_ref)
+            ):
+                continue
+            local = res.local_path(live_ref)
+            if local is not None:
+                preserve.append(local)
+
+        advised = 0
+        seen_paths: set[Path] = set()
+        for ref in dict.fromkeys(released_refs):
+            if res.tier(ref) is not residency_mod.Tier.DISK or res.in_use(ref):
+                continue
+            local = res.local_path(ref)
+            if local is None or local in seen_paths:
+                continue
+            seen_paths.add(local)
+            advised += await asyncio.to_thread(
+                disk_gc.reclaim_file_cache,
+                local,
+                preserve_paths=tuple(preserve),
+            )
+        return advised
+
     async def _ensure_host_ram_for(self, spec: EndpointSpec, paths: Dict[str, str]) -> None:
         """Owner-aware host-RAM admission (gw#407/pgw#541). ``from_pretrained``
         stages the full weight set in host RAM before placement; loading into
@@ -3577,9 +3623,22 @@ class Executor:
                 continue
 
             # Let completed demotion/to_thread frames release their arguments,
-            # then collect after the record owner is gone before observing RAM.
+            # then collect after the record owner is gone.  Under this already-
+            # measured pressure only, drop clean pages for refs that truthfully
+            # reached DISK; this keeps every snapshot local while avoiding the
+            # live J17 failure where two 6.9GiB records were vacated but their
+            # active file cache returned only 5MB of cgroup headroom (#579).
             await asyncio.sleep(0)
             await asyncio.to_thread(flush_memory)
+            advised = await self._reclaim_released_file_cache(
+                released, [Path(p) for p in paths.values()],
+            )
+            if advised:
+                logger.info(
+                    "host-RAM admission advised %d immutable snapshot bytes "
+                    "out of file cache for %s",
+                    advised, spec.name,
+                )
             after = await asyncio.to_thread(res.host_ram_headroom, incoming)
             if rec is None:
                 await self._observe_host_ram_progress(released)

--- a/src/gen_worker/models/disk_gc.py
+++ b/src/gen_worker/models/disk_gc.py
@@ -13,10 +13,11 @@ import json
 import logging
 import os
 import shutil
+import stat
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Iterator, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,82 @@ def tree_bytes(path: Path) -> int:
         return 0
 
 
+def _regular_files(path: Path) -> Iterator[Tuple[Path, os.stat_result]]:
+    """Regular files reachable from ``path`` without following directories.
+
+    Snapshot files may be hardlinks or Hugging Face-style symlinks into an
+    immutable blob store.  Following a file symlink is safe here: file advice
+    changes only page-cache residency, never bytes or metadata.
+    """
+    root = Path(path)
+    candidates: Iterable[Path]
+    if root.is_dir():
+        candidates = (
+            Path(dirpath) / name
+            for dirpath, _dirs, names in os.walk(root, followlinks=False)
+            for name in names
+        )
+    else:
+        candidates = iter((root,))
+    for candidate in candidates:
+        try:
+            info = candidate.stat()
+        except OSError:
+            continue
+        if stat.S_ISREG(info.st_mode):
+            yield candidate, info
+
+
+def reclaim_file_cache(
+    path: Path, *, preserve_paths: Iterable[Path] = (),
+) -> int:
+    """Drop clean cached pages for an immutable local snapshot, best effort.
+
+    ``POSIX_FADV_DONTNEED`` keeps every model byte on disk while returning
+    recently-read file pages to the kernel under host-RAM pressure.  Inodes
+    reachable from ``preserve_paths`` are skipped, including hardlinks: a
+    shared VAE or current request therefore cannot be chilled through another
+    snapshot tree.  Unsupported platforms simply return zero.
+
+    The return value is bytes successfully advised, not claimed reclaimed
+    memory.  Callers must re-probe real cgroup headroom before proceeding.
+    """
+    advise = getattr(os, "posix_fadvise", None)
+    dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+    if advise is None or dontneed is None:
+        return 0
+
+    protected: set[Tuple[int, int]] = set()
+    for protected_path in preserve_paths:
+        for _file, info in _regular_files(Path(protected_path)):
+            protected.add((int(info.st_dev), int(info.st_ino)))
+
+    advised = 0
+    seen: set[Tuple[int, int]] = set()
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    for file_path, info in _regular_files(Path(path)):
+        key = (int(info.st_dev), int(info.st_ino))
+        if key in seen or key in protected:
+            continue
+        seen.add(key)
+        try:
+            fd = os.open(file_path, flags)
+        except OSError:
+            continue
+        try:
+            current = os.fstat(fd)
+            current_key = (int(current.st_dev), int(current.st_ino))
+            if current_key in protected or not stat.S_ISREG(current.st_mode):
+                continue
+            advise(fd, 0, 0, dontneed)
+            advised += int(current.st_size)
+        except OSError:
+            continue
+        finally:
+            os.close(fd)
+    return advised
+
+
 def _retention_unit(path: Path, cas_dir: Path) -> Path:
     """The directory/file that must be deleted to reclaim a ref's bytes:
     the snapshot dir for CAS refs, the ``models--*`` repo dir for HF refs,
@@ -156,4 +233,10 @@ def sweep_orphan_blobs(cas_dir: Path) -> int:
     return freed
 
 
-__all__ = ["RefIndex", "tree_bytes", "delete_ref_bytes", "sweep_orphan_blobs"]
+__all__ = [
+    "RefIndex",
+    "tree_bytes",
+    "reclaim_file_cache",
+    "delete_ref_bytes",
+    "sweep_orphan_blobs",
+]

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -11,9 +11,12 @@ and a load that still cannot fit fails RETRYABLE instead of thrashing.
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import gc
 import inspect
 import logging
+import mmap
+import os
 import time
 import weakref
 from pathlib import Path
@@ -33,12 +36,52 @@ from gen_worker.executor import Executor, ModelStore, _ClassRecord, _Job
 from gen_worker.lifecycle import Lifecycle
 from gen_worker.models import memory as memory_mod
 from gen_worker.models import residency as residency_mod
-from gen_worker.models.residency import LoadedComponentKey, Residency, Tier
+from gen_worker.models.residency import HostRamHeadroom, LoadedComponentKey, Residency, Tier
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
 from gen_worker.transport import Transport
 
 _GiB = 1024 ** 3
+
+
+def _resident_file_bytes(path: Path) -> int:
+    """Kernel page-cache residency without faulting file contents."""
+    if os.name != "posix" or not hasattr(os, "POSIX_FADV_DONTNEED"):
+        pytest.skip("real page-cache test requires POSIX file advice")
+    size = path.stat().st_size
+    if size <= 0:
+        return 0
+    page_size = int(os.sysconf("SC_PAGE_SIZE"))
+    pages = (size + page_size - 1) // page_size
+    libc = ctypes.CDLL(None, use_errno=True)
+    mincore = getattr(libc, "mincore", None)
+    if mincore is None:
+        pytest.skip("real page-cache test requires mincore")
+    mincore.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_ubyte),
+    ]
+    mincore.restype = ctypes.c_int
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        mapping = mmap.mmap(fd, size, access=mmap.ACCESS_COPY)
+        try:
+            states = (ctypes.c_ubyte * pages)()
+            address = ctypes.addressof(ctypes.c_char.from_buffer(mapping))
+            if mincore(address, size, states) != 0:
+                raise OSError(ctypes.get_errno(), "mincore failed")
+            return sum(bool(state & 1) for state in states) * page_size
+        finally:
+            mapping.close()
+    finally:
+        os.close(fd)
+
+
+def _warm_file(path: Path) -> None:
+    with path.open("rb", buffering=0) as stream:
+        while stream.read(1024 * 1024):
+            pass
 
 
 def _res(events: list | None = None, budget_gb: int = 24) -> Residency:
@@ -221,6 +264,112 @@ def test_setup_refused_retryable_when_host_ram_insufficient(tmp_path: Path, monk
         assert isinstance(inst.m, _FakePipe)
 
     asyncio.run(_run())
+
+
+def test_pressure_eviction_reclaims_real_snapshot_cache_and_protects_shared_inode(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#579: exercise the real owner-teardown and kernel file-advice path.
+
+    Cgroup-equivalent headroom is derived from real ``mincore`` residency, not
+    fake object reachability.  Without ``POSIX_FADV_DONTNEED`` the old snapshot
+    stays hot, admission remains below the exact requirement, and this test
+    raises ``InsufficientHostRamError``.  A shared VAE hardlink proves that an
+    active owner's inode is protected even when reachable through the victim
+    tree.
+    """
+    if not hasattr(os, "posix_fadvise"):
+        pytest.skip("real page-cache test requires os.posix_fadvise")
+
+    victim_dir = tmp_path / "victim"
+    vae_dir = tmp_path / "shared-vae"
+    incoming_dir = tmp_path / "incoming"
+    for directory in (victim_dir, vae_dir, incoming_dir):
+        directory.mkdir()
+    victim_file = victim_dir / "weights.bin"
+    vae_file = vae_dir / "vae.bin"
+    incoming_file = incoming_dir / "weights.bin"
+    victim_file.write_bytes(b"v" * (32 * 1024 * 1024))
+    vae_file.write_bytes(b"a" * (8 * 1024 * 1024))
+    incoming_file.write_bytes(b"n" * (8 * 1024 * 1024))
+    os.link(vae_file, victim_dir / "shared-vae.bin")
+    for file_path in (victim_file, vae_file, incoming_file):
+        with file_path.open("rb") as stream:
+            os.fsync(stream.fileno())
+        fd = os.open(file_path, os.O_RDONLY)
+        try:
+            os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+        finally:
+            os.close(fd)
+        _warm_file(file_path)
+
+    victim_size = victim_file.stat().st_size
+    assert _resident_file_bytes(victim_file) >= victim_size
+    assert _resident_file_bytes(vae_file) >= vae_file.stat().st_size
+    assert _resident_file_bytes(incoming_file) >= incoming_file.stat().st_size
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe) -> None:
+            self.pipeline = pipeline
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    old_ref = "tensorhub/old"
+    vae_ref = "tensorhub/shared-vae"
+    old_spec = _spec("old", Endpoint, {"pipeline": HF(old_ref)})
+    incoming_spec = _spec(
+        "incoming", Endpoint, {"pipeline": HF("tensorhub/incoming")},
+    )
+    ex = _executor([old_spec, incoming_spec], tmp_path / "cache")
+    res = ex.store.residency
+    old_pipeline = _FakePipe()
+    old_vae = _FakePipe()
+    survivor_vae = _FakePipe()
+    res.track_ram(old_ref, old_pipeline, path=victim_dir)
+    res.track_ram(vae_ref, survivor_vae, path=vae_dir)
+
+    old_record = ex._classes[old_spec.instance_key]
+    old_record.instance = SimpleNamespace(pipeline=old_pipeline, vae=old_vae)
+    old_record.ready = True
+    old_record.held_refs = [old_ref, vae_ref]
+    old_record.held_objects = {old_ref: old_pipeline, vae_ref: old_vae}
+    ex._classes["shared-vae-survivor"] = _ClassRecord(
+        cls=Endpoint,
+        instance=SimpleNamespace(vae=survivor_vae),
+        ready=True,
+        held_refs=[vae_ref],
+        held_objects={vae_ref: survivor_vae},
+    )
+
+    floor = 8 * 1024 * 1024
+    baseline = 4 * 1024 * 1024
+
+    def _headroom(needed: int) -> HostRamHeadroom:
+        reclaimed = victim_size - min(victim_size, _resident_file_bytes(victim_file))
+        return HostRamHeadroom(
+            available_bytes=baseline + reclaimed,
+            floor_bytes=floor,
+            required_bytes=int(needed) + floor,
+        )
+
+    monkeypatch.setattr(res, "host_ram_headroom", _headroom)
+
+    async def _run() -> None:
+        async with ex._load_lock:
+            await ex._ensure_host_ram_for(
+                incoming_spec, {"pipeline": str(incoming_dir)},
+            )
+
+    asyncio.run(_run())
+    assert old_record.ready is False
+    assert res.tier(old_ref) is Tier.DISK
+    assert res.tier(vae_ref) is Tier.RAM
+    assert _resident_file_bytes(victim_file) < victim_size // 4
+    assert _resident_file_bytes(vae_file) >= vae_file.stat().st_size
+    assert _resident_file_bytes(incoming_file) >= incoming_file.stat().st_size
+    assert victim_file.read_bytes() == b"v" * victim_size
+    assert vae_file.read_bytes() == b"a" * vae_file.stat().st_size
 
 
 def test_capacity_progress_requires_measured_owner_release(

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.7"
+version = "0.36.8"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Why

During the 16-checkpoint SDXL campaign, idle pipelines transitioned to DISK but their recently-read immutable snapshot pages stayed charged to the worker cgroup. The next checkpoint therefore failed host-RAM admission after reclaiming only about 5 MB.

## What changed

- best-effort POSIX_FADV_DONTNEED for immutable snapshot files only after an idle ref reaches DISK under measured pressure
- protect incoming, current, in-use, and shared-owner files by inode
- re-probe real cgroup headroom after teardown and cache advice
- preserve all model bytes and disk-local residency; add no timer or configuration knob
- add a real-file/mincore production-path regression
- bump gen-worker to 0.36.8

## Validation

- new real-file/mincore regression: pass
- tests/test_ram_admission.py: 26 passed
- tests/test_disk_gc.py + tests/test_ram_admission.py: 34 passed
- Ruff on changed Python files: pass
- targeted mypy for disk_gc: pass
- git diff --check: pass
- uv lock --check: pass
- uv build: pass

Artifacts built locally:

- gen_worker-0.36.8.tar.gz sha256 a03889b66a3ef5e78dea0337d9e185dbf9b92d81300a019a505db13499b40399
- gen_worker-0.36.8-py3-none-any.whl sha256 b1ede5c9bc8918397121d076d51c3222aa0b1fd790b98f6a7e914abda85b662a

No package was published and no live worker or cloud resource was changed.