### PR TITLE
Release pinned host cache under RAM pressure (#579)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.8"
+version = "0.36.9"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3640,6 +3640,7 @@ class Executor:
                     released_pinned, released, spec.name,
                 )
             after = await asyncio.to_thread(res.host_ram_headroom, incoming)
+            await self._observe_host_ram_progress(released)
             if after.sufficient:
                 return
             advised = await self._reclaim_released_file_cache(
@@ -3652,8 +3653,7 @@ class Executor:
                     advised, spec.name,
                 )
             after = await asyncio.to_thread(res.host_ram_headroom, incoming)
-            if rec is None:
-                await self._observe_host_ram_progress(released)
+            await self._observe_host_ram_progress(released)
             if after.sufficient:
                 return
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -65,6 +65,7 @@ from .models.memory import (
     is_cuda_oom,
     low_vram_mode,
     next_offload_rung,
+    release_unused_pinned_host_cache,
 )
 from .models.cache_paths import tensorhub_cas_dir
 from .models.download import ensure_local, lookup_provider_for_ref
@@ -3623,13 +3624,24 @@ class Executor:
                 continue
 
             # Let completed demotion/to_thread frames release their arguments,
-            # then collect after the record owner is gone.  Under this already-
-            # measured pressure only, drop clean pages for refs that truthfully
-            # reached DISK; this keeps every snapshot local while avoiding the
-            # live J17 failure where two 6.9GiB records were vacated but their
-            # active file cache returned only 5MB of cgroup headroom (#579).
+            # then collect after the record owner is gone.  Pinned swap returns
+            # dead tensors to PyTorch's process-wide host cache, not the OS, so
+            # release its unused blocks first and re-probe.  Only if that is
+            # still insufficient do we chill clean snapshot pages for refs
+            # that truthfully reached DISK; every model byte stays local.
             await asyncio.sleep(0)
             await asyncio.to_thread(flush_memory)
+            released_pinned = await asyncio.to_thread(
+                release_unused_pinned_host_cache)
+            if released_pinned:
+                logger.info(
+                    "host-RAM admission released %d unused pinned-host bytes "
+                    "after vacating refs=%s for %s",
+                    released_pinned, released, spec.name,
+                )
+            after = await asyncio.to_thread(res.host_ram_headroom, incoming)
+            if after.sufficient:
+                return
             advised = await self._reclaim_released_file_cache(
                 released, [Path(p) for p in paths.values()],
             )

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -528,6 +528,56 @@ def flush_memory() -> None:
         pass
 
 
+def release_unused_pinned_host_cache() -> int:
+    """Return unused PyTorch pinned-host blocks to the OS, best effort.
+
+    Pinned swap keeps live RAM-tier weights checked out from PyTorch's host
+    allocator.  Once an owner is torn down those tensors are gone, but the
+    allocator caches their blocks process-wide; ordinary ``gc.collect()`` and
+    ``torch.cuda.empty_cache()`` release neither.  Under measured host-memory
+    pressure callers may use this after dropping every object owner.  Active
+    blocks (including surviving RAM-tier models) remain owned and untouched.
+
+    The result is the allocator's observed decrease in owned host bytes.  Zero
+    means no bytes were released or the installed PyTorch lacks this API.
+    """
+    try:
+        gc.collect()
+        import torch
+
+        if not torch.cuda.is_available():
+            return 0
+        # Pinned frees can remain stream-dependent.  Finish prior CUDA work so
+        # the host allocator can distinguish inactive blocks before flushing.
+        torch.cuda.synchronize()
+        try:
+            before = int(torch.cuda.memory.host_memory_stats().get(
+                "allocated_bytes.current", 0))
+        except Exception:
+            before = 0
+
+        accelerator = getattr(torch, "accelerator", None)
+        accelerator_memory = getattr(accelerator, "memory", None)
+        empty_host_cache = getattr(
+            accelerator_memory, "empty_host_cache", None)
+        if not callable(empty_host_cache):
+            # PyTorch exposed the same allocator operation privately before
+            # torch.accelerator.memory.empty_host_cache became public.
+            empty_host_cache = getattr(
+                getattr(torch, "_C", None), "_host_emptyCache", None)
+        if not callable(empty_host_cache):
+            return 0
+        empty_host_cache()
+        try:
+            after = int(torch.cuda.memory.host_memory_stats().get(
+                "allocated_bytes.current", before))
+        except Exception:
+            return 0
+        return max(0, before - after)
+    except Exception:
+        return 0
+
+
 # ---------------------------------------------------------------------------
 # Mode selection (auto) — the ONE low-VRAM decider, free-VRAM inputs only
 # ---------------------------------------------------------------------------
@@ -1139,4 +1189,5 @@ __all__ = [
     "get_available_ram_gb",
     "get_total_ram_gb",
     "flush_memory",
+    "release_unused_pinned_host_cache",
 ]

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -396,6 +396,126 @@ def test_pressure_eviction_reclaims_real_snapshot_cache_and_protects_shared_inod
     assert vae_file.read_bytes() == b"a" * vae_file.stat().st_size
 
 
+@pytest.mark.parametrize("owned_by_record", [True, False])
+def test_pressure_pinned_release_runs_after_owner_teardown_and_stops_eviction(
+    tmp_path: Path, monkeypatch, owned_by_record: bool,
+) -> None:
+    """#579: production admission must wire host-cache release in order.
+
+    The controlled release is the only operation that can satisfy measured
+    headroom.  Removing it, moving it before owner teardown, skipping the
+    immediate re-probe, or falling through to file advice must fail here.
+    Record-owned and ownerless residency entries share the same contract.
+    """
+    from gen_worker.models import disk_gc
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe) -> None:
+            self.pipeline = pipeline
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    victim_ref = "tensorhub/pinned-victim"
+    survivor_ref = "tensorhub/warm-survivor"
+    victim_spec = _spec("victim", Endpoint, {"pipeline": HF(victim_ref)})
+    survivor_spec = _spec(
+        "survivor", Endpoint, {"pipeline": HF(survivor_ref)},
+    )
+    incoming_spec = _spec(
+        "incoming", Endpoint, {"pipeline": HF("tensorhub/incoming")},
+    )
+    sent: list[pb.WorkerMessage] = []
+    ex = _executor(
+        [victim_spec, survivor_spec, incoming_spec], tmp_path, sent,
+    )
+    res = ex.store.residency
+    victim_dir = tmp_path / "victim"
+    incoming_dir = tmp_path / "incoming"
+    victim_dir.mkdir()
+    incoming_dir.mkdir()
+
+    victim = _FakePipe()
+    victim_weak = weakref.ref(victim)
+    survivor = _FakePipe()
+    res.track_ram(victim_ref, victim, path=victim_dir)
+    res.track_ram(survivor_ref, survivor, path=tmp_path / "survivor")
+    victim_record = ex._classes[victim_spec.instance_key]
+    if owned_by_record:
+        victim_record.instance = SimpleNamespace(pipeline=victim)
+        victim_record.ready = True
+        victim_record.held_refs = [victim_ref]
+        victim_record.held_objects = {victim_ref: victim}
+    survivor_record = ex._classes[survivor_spec.instance_key]
+    survivor_record.instance = SimpleNamespace(pipeline=survivor)
+    survivor_record.ready = True
+    survivor_record.held_refs = [survivor_ref]
+    survivor_record.held_objects = {survivor_ref: survivor}
+    del victim
+
+    released = {"host_cache": False}
+
+    def _headroom(needed: int) -> HostRamHeadroom:
+        available = 32 * _GiB if released["host_cache"] else 1 * _GiB
+        return HostRamHeadroom(
+            available_bytes=available,
+            floor_bytes=4 * _GiB,
+            required_bytes=int(needed) + 4 * _GiB,
+        )
+
+    def _release_pinned() -> int:
+        assert res.tier(victim_ref) is Tier.DISK
+        assert res.obj(victim_ref) is None
+        if owned_by_record:
+            assert victim_record.ready is False
+            assert victim_record.instance is None
+            assert victim_record.held_objects == {}
+        assert victim_weak() is None
+        released["host_cache"] = True
+        return 9 * _GiB
+
+    async def _unexpected_file_advice(*_args, **_kwargs) -> int:
+        raise AssertionError("sufficient pinned release must skip file advice")
+
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda _path: 4 * _GiB)
+    monkeypatch.setattr(res, "host_ram_headroom", _headroom)
+    monkeypatch.setattr(
+        executor_mod, "release_unused_pinned_host_cache", _release_pinned,
+    )
+    ex._reclaim_released_file_cache = _unexpected_file_advice  # type: ignore[method-assign]
+
+    async def _run() -> None:
+        await ex._record_host_ram_failure(
+            ["tensorhub/blocked"],
+            InsufficientHostRamError(
+                "incoming",
+                incoming_bytes=4 * _GiB,
+                floor_bytes=4 * _GiB,
+                required_bytes=8 * _GiB,
+                available_before_bytes=1 * _GiB,
+                available_after_bytes=1 * _GiB,
+            ),
+        )
+        async with ex._load_lock:
+            await ex._ensure_host_ram_for(
+                incoming_spec, {"pipeline": str(incoming_dir)},
+            )
+
+    asyncio.run(_run())
+    assert released["host_cache"] is True
+    assert res.tier(survivor_ref) is Tier.RAM
+    assert survivor_record.ready is True
+    progress = [
+        message.model_event for message in sent
+        if message.WhichOneof("msg") == "model_event"
+        and message.model_event.state == pb.MODEL_STATE_HOST_CAPACITY_PROGRESS
+    ]
+    assert len(progress) == 1
+    assert progress[0].host_ram_available_before_bytes == 1 * _GiB
+    assert progress[0].host_ram_available_after_bytes == 32 * _GiB
+    assert list(progress[0].host_ram_evicted_refs) == [victim_ref]
+
+
 def test_capacity_progress_requires_measured_owner_release(
     tmp_path: Path, monkeypatch,
 ) -> None:

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -44,6 +44,40 @@ from gen_worker.transport import Transport
 _GiB = 1024 ** 3
 
 
+def test_pressure_release_returns_real_unused_pinned_blocks_to_os() -> None:
+    """#579: Python GC/device empty-cache do not flush the host allocator."""
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("real pinned-host allocator test requires CUDA")
+    if not callable(getattr(torch.cuda.memory, "host_memory_stats", None)):
+        pytest.skip("installed PyTorch does not expose host allocator stats")
+
+    # Start from an empty reusable pool so this allocation cannot hide inside
+    # a block left by another CUDA test in the same process.
+    memory_mod.release_unused_pinned_host_cache()
+    baseline = int(torch.cuda.memory.host_memory_stats().get(
+        "allocated_bytes.current", 0))
+    block = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, pin_memory=True)
+    block.fill_(1)  # fault every pinned page into this process's working set
+    torch.cuda.synchronize()
+    live = int(torch.cuda.memory.host_memory_stats().get(
+        "allocated_bytes.current", 0))
+    assert live >= baseline + block.numel()
+
+    del block
+    gc.collect()
+    torch.cuda.synchronize()
+    cached = int(torch.cuda.memory.host_memory_stats().get(
+        "allocated_bytes.current", 0))
+    assert cached >= live  # freed tensor is still owned by the host cache
+
+    released = memory_mod.release_unused_pinned_host_cache()
+    after = int(torch.cuda.memory.host_memory_stats().get(
+        "allocated_bytes.current", 0))
+    assert released >= cached - after > 0
+    assert after <= baseline
+
+
 def _resident_file_bytes(path: Path) -> int:
     """Kernel page-cache residency without faulting file contents."""
     if os.name != "posix" or not hasattr(os, "POSIX_FADV_DONTNEED"):

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.8"
+version = "0.36.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- release only unused PyTorch pinned-host allocator blocks after a pressure-selected victim has truthfully reached DISK and all record owners are gone
- immediately re-probe observed host headroom, preserve active/surviving pinned tensors, and skip file advice plus further victims once sufficient
- commit state-driven host-capacity progress before the early return for both record-owned and ownerless victims

## Live root cause

The current-master SDXL campaign gained about 9.25 GB process RSS per demoted checkpoint. Three owner-correct DISK transitions improved cgroup headroom by only 1.82 MB because Python GC and `torch.cuda.empty_cache()` do not release PyTorch's separate pinned-host cache. A real CUDA probe retained 536,870,912 allocator-owned bytes after tensor deletion/GC and returned them to zero only through the host-cache primitive.

## Verification

- RAM-admission suite: 28/28, including a real CUDA pinned-allocation test
- production-path mutation: removing the helper fails both owner shapes at forbidden file advice
- ordering mutation: moving it before teardown fails both owner shapes while the victim is still RAM
- Ruff, targeted mypy, `uv lock --check`, `uv build`, diff check, and conflict-marker check pass
- independent review approved exact follow-up `a309e0b8c9f973dd9839b52ac6a6b18e0cb1c6e7`

No timer, environment option, lifecycle kill policy, or model-byte deletion is introduced.