### PR TITLE
gw#577: honest compile-cell delivery axes + named refusal reasons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.36.9"
+version = "0.36.10"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -349,7 +349,13 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     # Extended runtime axes are exact when a cell records them. Old proven
     # non-W8A8 format-2 cells remain usable; W8A8 requires every field in
     # contract_drift below and therefore never gets this compatibility path.
-    for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+    # cuda_driver is deliberately NOT here (gw#577): inductor/triton artifacts
+    # are keyed by torch/triton/cuda-runtime/SM-arch — triton's disk cache key
+    # is (source, ptxas_version-from-the-wheel, sm arch, options); the host
+    # libcuda build never enters any compiled-artifact key. Pinning it made
+    # cell delivery a host lottery across same-image same-SKU pods. The driver
+    # stays recorded in metadata for observability only.
+    for field in ("sm", "cuda", "image_digest"):
         want, have = str(meta.get(field) or ""), here[field]
         if want and want != have:
             return f"{field} {want!r} != runtime {have!r}"
@@ -822,6 +828,15 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
     SDXL/Pony/Illustrious incompatibility (different module class/shape or
     different scaled-mm exclusion surface) produces a different signature
     and is rejected before adoption.
+
+    The signature hashes ONLY the traced module structure — the resolved
+    targets' module types, paths and tensor schemas — never the wrapping
+    pipeline class (gw#577): torch.compile wraps target callables such as
+    ``transformer.forward``; the pipeline class never enters any traced
+    graph. Conversion producers load via generic ``DiffusionPipeline``
+    (model_index -> e.g. LTX2Pipeline) while serving loads the endpoint's
+    declared wrapper (e.g. LTX2ConditionPipeline) over a byte-identical
+    module tree — proven identical-graph, and must share one cell.
     """
     graph_targets: list[Dict[str, Any]] = []
     quantized: list[Dict[str, Any]] = []
@@ -876,7 +891,6 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
         })
 
     graph = {
-        "pipeline": _type_name(pipeline),
         "targets": graph_targets,
     }
     encoded = json.dumps(graph, sort_keys=True, separators=(",", ":")).encode()
@@ -932,6 +946,23 @@ def execution_contract_digest(pipeline: Any, cfg: Any) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _first_contract_difference(cell: Dict[str, Any], here: Dict[str, Any]) -> str:
+    """Name the first differing weight-contract key with compact values, so a
+    refusal is diagnosable from the reason alone (gw#577)."""
+    for key in sorted(set(cell) | set(here)):
+        want, have = cell.get(key), here.get(key)
+        if want == have:
+            continue
+        if isinstance(want, list) and isinstance(have, list):
+            return (
+                f"{key}: cell has {len(want)} row(s), consumer {len(have)}; "
+                f"first cell-only rows {[r for r in want if r not in have][:2]!r} "
+                f"vs consumer-only {[r for r in have if r not in want][:2]!r}"
+            )
+        return f"{key}: cell {want!r} != consumer {have!r}"
+    return "identical keys, differing encoding"
+
+
 def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     """Mismatch between the cell's declared graph and the loaded consumer."""
     shapes = sorted(
@@ -958,9 +989,15 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     ).startswith("w8a8"):
         return ""  # legacy format-2 non-W8A8 cell
     if meta_signature != signature:
-        return "module graph signature mismatch"
+        return (
+            f"module graph signature: cell {meta_signature[:12]!r} != "
+            f"consumer {signature[:12]!r}"
+        )
     if meta_weights != weight_contract:
-        return "weight-lane artifact schema/exclusion manifest mismatch"
+        return (
+            "weight-lane artifact schema/exclusion manifest mismatch: "
+            + _first_contract_difference(meta_weights, weight_contract)
+        )
     if str(weight_contract.get("lane") or "").startswith("w8a8"):
         activations = weight_contract.get("activation_scaling") or []
         # DYNAMIC only, one homogeneous granularity per graph (gw#564:
@@ -971,7 +1008,8 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
         if not weight_contract.get("quantized"):
             return "W8A8 graph contains no torch._scaled_mm modules"
         here_digest = runtime_key()["image_digest"]
-        for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+        # cuda_driver excluded (gw#577): host-lottery axis, see verify().
+        for field in ("sm", "cuda", "image_digest"):
             if not str(meta.get(field) or ""):
                 if field == "image_digest" and not here_digest:
                     # Bare-metal local runtime (gw#555 self-mint): no image
@@ -1447,8 +1485,14 @@ def enable(
     artifact: Optional[Path] = None,
 ) -> bool:
     """The one consumer entry point (executor + local CLI): seed an explicitly
-    attached verified artifact, then arm compile under the safety policy."""
+    attached verified artifact, then arm compile under the safety policy.
+
+    A W8A8 refusal names its exact cause — the mismatched key axis with the
+    cell-vs-runtime values, the drift verdict, or the missing delivery
+    (gw#577): the raise IS the wire-visible job error, and serve pods expose
+    no logs, so a generic message makes a refused cell undiagnosable."""
     staged: Optional[_StagedArtifact] = None
+    refusal = "no cell artifact delivered"
     if artifact is not None:
         try:
             staged = stage_artifact(
@@ -1456,6 +1500,7 @@ def enable(
                 cache_dir=cache_dir,
             )
         except Exception as exc:
+            refusal = f"cell rejected: {exc}"
             logger.warning("compile-cache: artifact unusable (%s); staying eager", exc)
     try:
         with _SEED_ARM_LOCK:
@@ -1464,12 +1509,14 @@ def enable(
                 meta = staged.metadata
                 drift = artifact_drift(meta, pipeline, cfg)
                 if drift:
+                    refusal = f"cell rejected: {drift}"
                     logger.warning("compile-cache: %s; staying eager", drift)
                     meta = None
                 else:
                     try:
                         _activate_staged(staged)
                     except Exception as exc:
+                        refusal = f"cell activation failed: {exc}"
                         logger.warning(
                             "compile-cache: cache activation failed (%s); "
                             "staying eager", exc)
@@ -1478,9 +1525,11 @@ def enable(
             from .models.loading import pipeline_weight_lane
 
             if pipeline_weight_lane(pipeline).startswith("w8a8") and not armed:
+                if meta is not None:
+                    refusal = "verified cell armed no compile target"
                 raise CompiledLaneUnavailableError(
-                    "W8A8 requires an exact compatible Forge cell; eager/dequantized "
-                    "execution is not a W8A8 production lane"
+                    f"W8A8 requires an exact compatible Forge cell ({refusal}); "
+                    "eager/dequantized execution is not a W8A8 production lane"
                 )
             return armed
     finally:
@@ -1588,6 +1637,17 @@ def build(
     from .models.loading import load_from_pretrained
     from .models.memory import place_pipeline
 
+    if "w8a8" in str(storage_dtype) and not str(serving_image_digest).strip():
+        # gw#577 finding (b): contract_drift requires image_digest identity on
+        # W8A8 cells and verify() pins it exactly. Without the SERVING digest
+        # the artifact stamps the PRODUCER pod's WORKER_IMAGE_DIGEST — every
+        # serving worker then rejects it and W8A8 serves NOTHING
+        # (fail-closed). Refuse loudly before any load or compile.
+        raise RuntimeError(
+            "W8A8 cell mint requires serving_image_digest (the endpoint "
+            "serving image's immutable OCI digest); a cell stamped with the "
+            "producer image identity can never be adopted by the fleet"
+        )
     if not toolchain_present():
         raise RuntimeError(
             "compile-cache build needs a C toolchain (cc/gcc); run in the "

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1637,17 +1637,18 @@ def build(
     from .models.loading import load_from_pretrained
     from .models.memory import place_pipeline
 
+    _W8A8_MINT_NEEDS_DIGEST = (
+        "W8A8 cell mint requires serving_image_digest (the endpoint "
+        "serving image's immutable OCI digest); a cell stamped with the "
+        "producer image identity can never be adopted by the fleet"
+    )
     if "w8a8" in str(storage_dtype) and not str(serving_image_digest).strip():
         # gw#577 finding (b): contract_drift requires image_digest identity on
         # W8A8 cells and verify() pins it exactly. Without the SERVING digest
         # the artifact stamps the PRODUCER pod's WORKER_IMAGE_DIGEST — every
         # serving worker then rejects it and W8A8 serves NOTHING
         # (fail-closed). Refuse loudly before any load or compile.
-        raise RuntimeError(
-            "W8A8 cell mint requires serving_image_digest (the endpoint "
-            "serving image's immutable OCI digest); a cell stamped with the "
-            "producer image identity can never be adopted by the fleet"
-        )
+        raise RuntimeError(_W8A8_MINT_NEEDS_DIGEST)
     if not toolchain_present():
         raise RuntimeError(
             "compile-cache build needs a C toolchain (cc/gcc); run in the "
@@ -1683,6 +1684,15 @@ def build(
     # traced under travels in the metadata for adopt-time parity checks. Run
     # on a pod with the same free-VRAM class as the target workers.
     placed = place_pipeline(pipe)
+    from .models.loading import pipeline_weight_lane as _traced_lane
+
+    if _traced_lane(pipe).startswith("w8a8") and not str(
+        serving_image_digest
+    ).strip():
+        # The lane can materialize as w8a8 from the SOURCE flavor alone
+        # (e.g. storage_dtype="fp8+te" over an fp8-w8a8 checkpoint), so the
+        # authoritative check is on the traced lane, before the compile.
+        raise RuntimeError(_W8A8_MINT_NEEDS_DIGEST)
     # gw#561: branch-bearing cells trace WITH canonical zeroed rank-bucket
     # branches installed — zeroed slots are bit-exact with branchless output
     # (gw#547), so the warm calls render normally while the traced graphs

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -4320,7 +4320,10 @@ class Executor:
                     snapshot_digest,
                     operation_id,
                     target_incarnation_id,
-                    error=f"adopt_failed:{type(exc).__name__.lower()}",
+                    error=(
+                        f"adopt_failed:{type(exc).__name__.lower()}: "
+                        f"{str(exc)[:300]}"
+                    ),
                 )
             ))
 
@@ -4350,6 +4353,15 @@ class Executor:
                 await asyncio.to_thread(staged_artifact.close)
                 staged_artifact = None
             logger.warning("compile-cache adopt %s failed: %s %s", ref, reason, detail)
+            # gw#577: terminal refusals carry the exact mismatch (axis +
+            # cell-vs-runtime values) on the wire — pods expose no logs. The
+            # th#875 transient vocabulary stays bare: the hub re-arm matcher
+            # compares those four statuses EXACTLY.
+            error = f"adopt_failed:{reason}"
+            if detail and reason not in (
+                "model_in_use", "target_not_ready", "target_replaced", "download",
+            ):
+                error = f"{error}: {detail[:300]}"
             await self._send(pb.WorkerMessage(
                 model_event=self._adoption_event(
                     ref,
@@ -4357,7 +4369,7 @@ class Executor:
                     snapshot_digest,
                     operation_id,
                     target_incarnation_id,
-                    error=f"adopt_failed:{reason}",
+                    error=error,
                 )
             ))
 

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -98,10 +98,25 @@ def test_verify_mismatches():
     del other["gen_worker"]
     assert "gen_worker" in cc.verify(other, family="sd15")
 
-    for field in ("sm", "cuda", "cuda_driver", "image_digest"):
+    for field in ("sm", "cuda", "image_digest"):
         other = dict(meta)
         other[field] = "definitely-not-this-runtime"
-        assert field in cc.verify(other, family="sd15")
+        reason = cc.verify(other, family="sd15")
+        # the named-axis contract (gw#577): refusals carry axis + both values
+        assert field in reason and "definitely-not-this-runtime" in reason
+
+
+def test_verify_ignores_cuda_driver_host_lottery():
+    """gw#577: a cell minted on one host must deliver to another same-SKU
+    same-image host running a different driver build. Inductor/triton
+    artifacts are keyed by torch/triton/cuda-runtime/SM arch (triton's disk
+    key is source+ptxas-version+arch, ptxas ships in the wheel); the host
+    libcuda build keys nothing — pinning it made fleet delivery a lottery
+    (2 of 3 fresh B200 pods refused a proven cell, ie#495 flip rollback)."""
+    meta = cc.artifact_metadata(
+        family="sd15", shapes=[(768, 768)], targets=["transformer"])
+    other = dict(meta, cuda_driver="13010")
+    assert cc.verify(other, family="sd15") == ""
 
 
 def test_execution_contract_uses_structure_not_checkpoint_values():
@@ -551,6 +566,142 @@ def test_pipeline_mismatch_never_activates_staged_cache(
 
     assert cc.enable(pipe, cfg, cache_dir, artifact) is False
     assert _tree_snapshot(live) == before
+
+
+# ---------------------------------------------------------------------------
+# gw#577: fleet delivery axes + named refusal reasons
+# ---------------------------------------------------------------------------
+
+
+def _module_tree_pipe(wrapper_name: str):
+    torch = pytest.importorskip("torch")
+
+    class _Tree:
+        def __init__(self):
+            self.transformer = torch.nn.Sequential(
+                torch.nn.Linear(16, 16), torch.nn.SiLU(),
+            )
+
+    return type(wrapper_name, (_Tree,), {})()
+
+
+def test_execution_contract_ignores_pipeline_wrapper_class():
+    """gw#577 axis (c): conversion traces via generic DiffusionPipeline
+    (-> LTX2Pipeline) while serving wraps the SAME module tree in
+    LTX2ConditionPipeline. torch.compile wraps target callables — the
+    pipeline class never enters a traced graph — so the signature must key
+    on the traced module structure only (dual-load probe: identical trees,
+    sig 2625baca vs e0f356f5 under the old class-name hash)."""
+    cfg = Compile(shapes=((1024, 1024),), targets=("transformer",), family="fam")
+    conv_sig, conv_wc = cc.execution_contract(
+        _module_tree_pipe("LTX2Pipeline"), cfg)
+    serve_sig, serve_wc = cc.execution_contract(
+        _module_tree_pipe("LTX2ConditionPipeline"), cfg)
+    assert conv_sig == serve_sig
+    assert conv_wc == serve_wc
+    # genuine structural drift still produces a different signature
+    torch = pytest.importorskip("torch")
+    other = _module_tree_pipe("LTX2Pipeline")
+    other.transformer = torch.nn.Sequential(torch.nn.Linear(32, 32))
+    assert cc.execution_contract(other, cfg)[0] != conv_sig
+
+
+def test_contract_drift_names_signature_values():
+    """A genuine graph mismatch refuses with BOTH digests in the reason —
+    never the bare 'module graph signature mismatch' that cost a raw
+    dual-load probe pod to diagnose."""
+    pipe = _module_tree_pipe("AnyPipeline")
+    cfg = Compile(shapes=((1024, 1024),), targets=("transformer",), family="fam")
+    sig, wc = cc.execution_contract(pipe, cfg)
+    meta = cc.artifact_metadata(
+        family="fam", shapes=cfg.shapes, targets=cfg.targets,
+        graph_signature="0" * 64, weight_contract=wc)
+    reason = cc.contract_drift(meta, pipe, cfg)
+    assert "module graph signature" in reason
+    assert "0" * 12 in reason and sig[:12] in reason
+
+
+def test_w8a8_identity_gate_drops_cuda_driver_keeps_rest(monkeypatch):
+    """W8A8 cells still require sm/cuda/image_digest identity, but not the
+    host-lottery cuda_driver axis (gw#577)."""
+    pytest.importorskip("torch")
+    real_key = cc.runtime_key
+
+    def prod_key():
+        key = dict(real_key())
+        key.update(sm="sm_100", cuda="13.0", cuda_driver="13000",
+                   image_digest="sha256:feedface")
+        return key
+
+    monkeypatch.setattr(cc, "runtime_key", prod_key)
+    pipe = _module_tree_pipe("Serving")
+    pipe.transformer[0]._cozy_w8a8_linear = True
+    pipe.transformer[0].gemm_mode = "rowwise"
+    pipe._cozy_weight_lane = "w8a8"
+    cfg = Compile(shapes=((1024, 1024),), targets=("transformer",), family="fam")
+    sig, wc = cc.execution_contract(pipe, cfg)
+    meta = cc.artifact_metadata(
+        family="fam", shapes=cfg.shapes, targets=cfg.targets,
+        weight_lane="w8a8", graph_signature=sig, weight_contract=wc)
+    meta["cuda_driver"] = ""  # cell minted without the axis: fine
+    assert cc.contract_drift(meta, pipe, cfg) == ""
+    # a cell recording a DIFFERENT driver build still delivers (verify skips)
+    meta["cuda_driver"] = "13010"
+    assert cc.verify(meta, family="fam") == ""
+    assert cc.contract_drift(meta, pipe, cfg) == ""
+    # the honest axes stay fail-closed, with named values
+    for field in ("sm", "cuda", "image_digest"):
+        broken = dict(meta)
+        broken[field] = ""
+        assert field in cc.contract_drift(broken, pipe, cfg)
+
+
+def test_w8a8_enable_refusal_carries_exact_reason(tmp_path, monkeypatch):
+    """gw#577 axis (a): the raised CompiledLaneUnavailableError is the ONLY
+    wire-visible diagnostic on a serve pod — it must carry the exact
+    mismatched axis and values, per refusal cause."""
+    pytest.importorskip("torch")
+    pipe = _module_tree_pipe("Serving")
+    pipe._cozy_weight_lane = "w8a8"
+    cfg = Compile(shapes=((768, 768),), targets=("transformer",), family="fam")
+    cache_dir = tmp_path / "cache"
+
+    # no artifact delivered
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="no cell artifact delivered"):
+        cc.enable(pipe, cfg, cache_dir, artifact=None)
+
+    # key mismatch: the axis and both values appear in the raise
+    sig, wc = cc.execution_contract(pipe, cfg)
+    meta = cc.artifact_metadata(
+        family="fam", shapes=cfg.shapes, targets=cfg.targets,
+        weight_lane="w8a8", graph_signature=sig, weight_contract=wc)
+    meta["torch"] = "0.0.0+fake"
+    source = _capture_tree(tmp_path / "cand")
+    artifact = cc.pack(source, tmp_path / "cell.tar.gz", meta)
+    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+        cc.enable(pipe, cfg, cache_dir, artifact=artifact)
+    assert "torch" in str(exc.value) and "0.0.0+fake" in str(exc.value)
+
+    # contract drift: the drift verdict appears in the raise
+    meta = cc.artifact_metadata(
+        family="fam", shapes=cfg.shapes, targets=cfg.targets,
+        weight_lane="w8a8", graph_signature="1" * 64, weight_contract=wc)
+    source2 = _capture_tree(tmp_path / "cand2")
+    artifact2 = cc.pack(source2, tmp_path / "cell2.tar.gz", meta)
+    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+        cc.enable(pipe, cfg, cache_dir, artifact=artifact2)
+    assert "module graph signature" in str(exc.value)
+    assert "1" * 12 in str(exc.value)
+
+
+def test_build_refuses_w8a8_mint_without_serving_image_digest(tmp_path):
+    """gw#577 finding (b): a w8a8 cell stamped with the PRODUCER image's
+    digest can never be adopted by the fleet — refuse before any work."""
+    with pytest.raises(RuntimeError, match="serving_image_digest"):
+        cc.build(
+            tmp_path, tmp_path / "out", shapes=[(768, 768)],
+            family="fam", storage_dtype="fp8-w8a8",
+        )
 
 
 def test_cache_collision_and_merge_failure_leave_live_tree_unchanged(

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -226,12 +226,27 @@ def _events(sent, state):
             if m.WhichOneof("msg") == "model_event" and m.model_event.state == state]
 
 
+# th#875's hub-side re-arm matcher compares these adopt statuses EXACTLY;
+# the worker must keep them bare (no appended detail) on the wire (gw#577).
+_TRANSIENT_REASONS = (
+    "adopt_failed:model_in_use", "adopt_failed:target_not_ready",
+    "adopt_failed:target_replaced", "adopt_failed:download",
+)
+
+
 def _assert_failed(
     sent, error, digest=DIGEST_A, operation_id=OP_A,
     target_incarnation_id=None,
 ):
     failed = _events(sent, pb.MODEL_STATE_FAILED)
-    assert failed and failed[-1].error == error
+    # gw#577: terminal refusals may carry ": <exact reason>" after the
+    # classified code; the th#875 transient vocabulary must stay bare.
+    assert failed and (
+        failed[-1].error == error
+        or failed[-1].error.startswith(error + ":")
+    )
+    if error in _TRANSIENT_REASONS:
+        assert failed[-1].error == error
     assert failed[-1].snapshot_digest == digest
     assert failed[-1].operation_id == operation_id
     if target_incarnation_id is None:
@@ -549,7 +564,8 @@ def test_adopt_unexpected_failure_echoes_operation_digest(tmp_path, monkeypatch)
 
     failed = _events(sent, pb.MODEL_STATE_FAILED)
     assert len(failed) == 1
-    assert failed[0].error == "adopt_failed:runtimeerror"
+    # gw#577: the unexpected-failure event carries the exception text
+    assert failed[0].error == "adopt_failed:runtimeerror: unexpected"
     assert failed[0].snapshot_digest == DIGEST_B
     assert failed[0].operation_id == OP_A
     assert failed[0].target_incarnation_id == _target_id(ex)

--- a/tests/test_trt_engine.py
+++ b/tests/test_trt_engine.py
@@ -444,7 +444,10 @@ def test_adopt_trt_key_mismatch_stays_eager(tmp_path, monkeypatch):
     monkeypatch.setattr(te, "load_and_wrap", _mismatch)
     _adopt(ex, ref=TRT_REF)
     failed = _events(sent, pb.MODEL_STATE_FAILED)
-    assert len(failed) == 1 and failed[0].error == "adopt_failed:key_mismatch"
+    # gw#577: the wire refusal names the mismatched axis + both values
+    assert len(failed) == 1 and failed[0].error == (
+        "adopt_failed:key_mismatch: trt '10.16.0.14' != runtime '10.15.2.1'"
+    )
     assert failed[0].snapshot_digest == DIGEST_A
     assert failed[0].operation_id == OP_A
     assert not _events(sent, pb.MODEL_STATE_ADOPTED)
@@ -463,7 +466,10 @@ def test_adopt_trt_warmup_must_execute_engine_or_roll_back(tmp_path, monkeypatch
     _adopt(ex, ref=TRT_REF)
     failed = _events(sent, pb.MODEL_STATE_FAILED)
     assert len(failed) == 1
-    assert failed[0].error == "adopt_failed:engine_not_executed"
+    assert failed[0].error == (
+        "adopt_failed:engine_not_executed: "
+        "warmup did not execute the attached TRT engine"
+    )
     assert unwrapped
     target = ex.compile_targets()[0]
     assert target.active_compile_ref == ""

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.36.9"
+version = "0.36.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Fixes the compile-cell delivery host-lottery that rolled back the ie#495 compiled-W8A8 prod flip, at the root, per axis:

1. **Observability**: every cell verify()/adopt refusal now carries the exact mismatched axis + cell-vs-runtime values — in the log, in the raised `CompiledLaneUnavailableError` (the only wire-visible diagnostic on a serve pod), and in adopt `ModelEvent`s (terminal reasons carry detail; th#875's transient vocabulary stays bare because the hub re-arm matcher compares those statuses exactly).
2. **cuda_driver axis dropped from the key**: triton's disk cache key is (source, wheel ptxas version, SM arch, options) — verified against triton 3.6 source; the host libcuda build keys no artifact bytes. Honest constraint = SM arch + cuda runtime + torch/triton + image_digest, all already exact axes. A cell minted on one B200 host now delivers to any same-image B200 host. Driver stays recorded in metadata as observability.
3. **execution_contract hashes the traced module structure, not the pipeline class**: torch.compile wraps target callables (`transformer.forward`); the wrapping pipeline class never enters a traced graph. Conversion's generic `DiffusionPipeline` load (→ LTX2Pipeline) and serving's declared `LTX2ConditionPipeline` share byte-identical module trees (dual-load probe evidence) and must share one cell.
4. **Fail-closed preserved**: sm/cuda/image_digest/torch/triton/gen_worker/libs/lane/contract axes still refuse exactly — now with named reasons. Plus finding (b): `build()` refuses a w8a8 mint without `serving_image_digest` before any load/compile.

Red→green matrix: same-arch/different-driver delivers; different-arch refuses with named axis+values; class-wrap difference delivers; genuine structural/contract mismatch refuses with both digests; W8A8 enable refusals carry the exact cause per failure mode; transient adopt reasons stay bare on the wire.

Full suite: 1401 passed (9 failures pre-exist identically on untouched master — box cgroup RAM-budget environment). mypy clean. Bump 0.36.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)