### PR TITLE
Make model setup ownership transactional

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2771,9 +2771,31 @@ class Executor:
             if rec.ready:
                 await self._promote_setup_refs(spec, promote_slots, rec=rec)
                 return rec.instance
+            if self._record_has_setup_ownership(rec):
+                # A prior process-local cancellation/failure may have reached
+                # tenant setup before this worker version could roll it back.
+                # Never layer a fresh instance over uncertain ownership.
+                logger.warning(
+                    "clearing incomplete setup ownership before retrying %s",
+                    spec.name,
+                )
+                await self._rollback_failed_setup(rec)
             try:
                 instance = await self._setup_locked(spec, rec, snapshots)
-            except Exception as exc:
+            except BaseException as exc:
+                # Setup is a transaction: endpoint construction, tenant
+                # setup/warmup, residency registration, and compile-target
+                # publication either all reach READY or all ownership is
+                # removed through the ordinary record-vacate path. Include
+                # cancellation — _to_thread_complete has already joined any
+                # tenant thread before it propagates CancelledError here.
+                try:
+                    await self._rollback_failed_setup(rec)
+                except BaseException:
+                    logger.exception(
+                        "failed to roll back incomplete setup for %s", spec.name)
+                if not isinstance(exc, Exception):
+                    raise
                 # Honest failure (th#581): a function whose model download /
                 # pipeline setup fails must surface a terminal per-function
                 # error to the hub, not sit in loading_functions forever
@@ -2957,6 +2979,40 @@ class Executor:
             self.unavailable[s.name] = (reason, detail, axes)
         self._on_state_change()
 
+    @staticmethod
+    def _record_has_setup_ownership(rec: _ClassRecord) -> bool:
+        """Whether a non-READY record owns anything that needs teardown."""
+        return bool(
+            rec.instance is not None
+            or rec.server is not None
+            or rec.held_refs
+            or rec.held_objects
+            or rec.shared_keys
+            or rec.compile_targets
+        )
+
+    async def _rollback_failed_setup(self, rec: _ClassRecord) -> None:
+        """Remove every provisional owner left by an incomplete setup.
+
+        The normal vacate path is the single teardown implementation: it
+        invokes endpoint shutdown, stops an engine server, releases loaded
+        residency objects and shared-component holds, clears compile targets,
+        and emits the resulting state. Failed setup can also leave freed
+        staging buffers in PyTorch's pinned-host cache, so return those unused
+        blocks after the owners have gone.
+        """
+        if not self._record_has_setup_ownership(rec):
+            return
+        async with self._load_lock:
+            released = await self._vacate_record(rec)
+        released_pinned = await asyncio.to_thread(
+            release_unused_pinned_host_cache)
+        logger.info(
+            "rolled back incomplete setup refs=%s pinned_host_bytes=%d",
+            released,
+            released_pinned,
+        )
+
     async def _setup_locked(
         self, spec: EndpointSpec, rec: _ClassRecord,
         snapshots: Optional[Dict[str, pb.Snapshot]],
@@ -2991,6 +3047,25 @@ class Executor:
             # the actual post-demotion pressure (pgw#541).
             await self._ensure_host_ram_for(spec, paths)
             instance = spec.cls()
+            # Stamp provisional ownership BEFORE tenant setup/warmup. The
+            # record is not advertised until rec.ready becomes true, but an
+            # exception or cancellation can now tear down the exact instance
+            # and exact resolved refs instead of losing them in stack locals.
+            rec.instance = instance
+            rec.held_refs = sorted(set(slot_refs.values()))
+            rec.held_snapshot_digests = {
+                slot_refs[slot]: identity[0]
+                for slot, identity in slot_identities.items()
+                if slot in slot_refs and identity[0]
+            }
+            rec.held_bindings = sorted(
+                (
+                    slot,
+                    ref,
+                    rec.held_snapshot_digests.get(ref, ""),
+                )
+                for slot, ref in slot_refs.items()
+            )
             setup = getattr(instance, "setup", None)
             inj = _InjectionResult(kwargs={}, loaded={})
             from . import compile_cache, trt_engine
@@ -3165,20 +3240,6 @@ class Executor:
                 spec, setup_slots, inj.loaded, vram_delta,
                 lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes,
                 slot_refs=slot_refs, slot_identities=slot_identities)
-            rec.held_refs = sorted(set(slot_refs.values()))
-            rec.held_snapshot_digests = {
-                slot_refs[slot]: identity[0]
-                for slot, identity in slot_identities.items()
-                if slot in slot_refs and identity[0]
-            }
-            rec.held_bindings = sorted(
-                (
-                    slot,
-                    ref,
-                    rec.held_snapshot_digests.get(ref, ""),
-                )
-                for slot, ref in slot_refs.items()
-            )
             # gw#551: call-time-owned refs. Any record holding 2+ worker-
             # constructed pipelines can overcommit VRAM (content-keyed lanes
             # AND monolithic siblings alike) — those swap per use via the
@@ -4739,9 +4800,9 @@ class Executor:
                 if old_obj is not None:
                     released_refs.append(ref)
                 continue
-            if self.store.residency.release_to_disk(ref) and (
-                old_obj is not None
-                or tier_before in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+            if (
+                tier_before in (residency_mod.Tier.RAM, residency_mod.Tier.VRAM)
+                and self.store.residency.release_to_disk(ref)
             ):
                 released_refs.append(ref)
         rec.held_refs = []

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -250,6 +250,74 @@ def _host_ram_error(
     )
 
 
+def test_failed_setup_rolls_back_exact_ownership_before_fresh_reload(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A failure after residency registration cannot leak a stale instance.
+
+    This uses the real setup, typed injection, residency registration,
+    compile-target publication seam, rollback, and retry path. Only the tiny
+    local pipeline and hardware probes are deterministic substitutes.
+    """
+    shutdown_markers: list[int] = []
+    constructed = 0
+
+    class Endpoint:
+        def __init__(self) -> None:
+            nonlocal constructed
+            constructed += 1
+            self.marker = constructed
+
+        def setup(self, pipeline: _FakePipe) -> None:
+            self.pipeline = pipeline
+
+        def shutdown(self) -> None:
+            shutdown_markers.append(self.marker)
+
+        def run(self, ctx, payload: _In) -> _In:  # pragma: no cover
+            return payload
+
+    ref = "acme/reload"
+    spec = _spec("generate", Endpoint, {"pipeline": HF(ref)})
+    ex = _executor([spec], tmp_path, monkeypatch=monkeypatch)
+    install = ex._install_compile_targets
+    attempts = 0
+
+    def fail_first_publish(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("injected post-registration failure")
+        return install(*args, **kwargs)
+
+    monkeypatch.setattr(ex, "_install_compile_targets", fail_first_publish)
+
+    async def _run() -> None:
+        with pytest.raises(RuntimeError, match="post-registration"):
+            await ex.ensure_setup(spec)
+
+        rec = ex._classes[spec.instance_key]
+        assert not rec.ready
+        assert rec.instance is None
+        assert rec.server is None
+        assert rec.held_refs == []
+        assert rec.held_objects == {}
+        assert rec.shared_keys == []
+        assert rec.compile_targets == {}
+        assert ex.store.residency.tier(ref) is Tier.DISK
+        assert shutdown_markers == [1]
+
+        fresh = await ex.ensure_setup(spec)
+        assert fresh.marker == 2
+        assert fresh is rec.instance
+        assert rec.ready
+        assert rec.held_refs == [ref]
+        assert ex.store.residency.obj(ref) is fresh.pipeline
+        assert shutdown_markers == [1]
+
+    asyncio.run(_run())
+
+
 def test_setup_refused_retryable_when_host_ram_insufficient(tmp_path: Path, monkeypatch) -> None:
     from gen_worker.models import disk_gc
 
@@ -1689,6 +1757,8 @@ def test_runjob_sixteen_model_cgroup_swap_stress(
     async def _run() -> None:
         observed_before: list[int] = []
         ready_after: list[int] = []
+        first_record: _ClassRecord | None = None
+        first_instance: weakref.ReferenceType[object] | None = None
         for i in range(16):
             observed_before.append(int(_ram().available_gb * _GiB))
             pipeline_ref = f"tensorhub/sdxl-{i}:prod"
@@ -1719,6 +1789,12 @@ def test_runjob_sixteen_model_cgroup_swap_stress(
                 and message.job_result.request_id == run.request_id
             )
             assert result.status == pb.JOB_STATUS_OK, result.safe_message
+            if i == 0:
+                first_record = next(
+                    rec for rec in ex._classes.values()
+                    if rec.ready and pipeline_ref in ex._record_refs(rec)
+                )
+                first_instance = weakref.ref(first_record.instance)
             ready_after.append(len({
                 id(rec) for rec in ex._classes.values() if rec.ready
             }))
@@ -1726,11 +1802,51 @@ def test_runjob_sixteen_model_cgroup_swap_stress(
         required = model_bytes + int(31.0 * 0.2 * _GiB)
         assert any(available < required for available in observed_before[8:])
         assert max(ready_after) <= 8
+        assert first_record is not None and first_instance is not None
+        assert not first_record.ready
+        assert first_record.instance is None
+        assert first_record.held_refs == []
+
+        # Revisit an actually evicted pick. The same record identity is
+        # intentionally reusable, but it must own a newly constructed
+        # endpoint/pipeline and rebind Residency to that exact object.
+        replay_ref = "tensorhub/sdxl-0:prod"
+        vae_ref = "tensorhub/sdxl-vae:prod"
+        replay = pb.RunJob(
+            request_id="swap-reload-0",
+            attempt=1,
+            function_name="generate",
+            input_payload=msgspec.msgpack.encode(_In(x="replay-0")),
+            models=[
+                pb.ModelBinding(slot="pipeline", ref=replay_ref),
+                pb.ModelBinding(slot="vae", ref=vae_ref),
+            ],
+            snapshots={
+                replay_ref: pb.Snapshot(digest="blake3:" + f"{1:064x}"),
+                vae_ref: pb.Snapshot(digest="blake3:" + "f" * 64),
+            },
+        )
+        await ex.handle_run_job(replay)
+        replay_job = ex.jobs[(replay.request_id, replay.attempt)]
+        assert replay_job.task is not None
+        await replay_job.task
+        replay_result = next(
+            message.job_result for message in reversed(sent)
+            if message.WhichOneof("msg") == "job_result"
+            and message.job_result.request_id == replay.request_id
+        )
+        assert replay_result.status == pb.JOB_STATUS_OK, replay_result.safe_message
+        reloaded = first_record.instance
+        assert first_record.ready and reloaded is not None
+        previous = first_instance()
+        assert previous is None or reloaded is not previous
+        assert set(first_record.held_refs) == {replay_ref, vae_ref}
+        assert ex.store.residency.obj(replay_ref) is reloaded.pipeline
         assert len(live) <= 16
         assert len([
             message for message in sent
             if message.WhichOneof("msg") == "job_result"
-        ]) == 16
+        ]) == 17
         assert not [
             message for message in sent
             if message.WhichOneof("msg") == "model_event"

--- a/tests/test_warmup_synthesis.py
+++ b/tests/test_warmup_synthesis.py
@@ -480,11 +480,15 @@ def test_executor_warmup_output_stays_local():
 def test_executor_drain_during_warmup_cancels_cleanly():
     entered = threading.Event()
     release = threading.Event()
+    shutdowns: list[str] = []
 
     @endpoint(resources=Resources(vram_gb=8))
     class Ep:
         def setup(self) -> None:
             pass
+
+        def shutdown(self) -> None:
+            shutdowns.append("shutdown")
 
         def generate(self, ctx, payload: _PromptIn) -> _Out:
             entered.set()
@@ -503,4 +507,8 @@ def test_executor_drain_during_warmup_cancels_cleanly():
             await task
 
     asyncio.run(scenario())
-    assert not ex._classes[specs[0].instance_key].ready
+    rec = ex._classes[specs[0].instance_key]
+    assert not rec.ready
+    assert rec.instance is None
+    assert rec.held_refs == []
+    assert shutdowns == ["shutdown"]


### PR DESCRIPTION
Closes tracker python-gen-worker #580.

- stamps exact provisional instance/ref ownership before tenant setup and warmup
- rolls incomplete setup back through the normal vacate path on errors and cancellation
- releases unused pinned-host cache blocks after failed setup teardown
- proves post-registration failure -> fresh instance recovery
- extends the 16-pick cgroup stress to evict and reload the first pick

Focused validation:
- `uv run --with pytest python -m pytest -q tests/test_ram_admission.py tests/test_executor_residency.py tests/test_warmup_synthesis.py tests/test_declarative_residency.py` (60 passed, 3 skipped)
- `uv run --with ruff ruff check src/gen_worker/executor.py tests/test_ram_admission.py tests/test_warmup_synthesis.py`

Live e2e #186 remains required before merge/release.