### PR TITLE
gw#579: reclaim idle checkpoint behind shared pin

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3772,7 +3772,7 @@ class Executor:
                 continue
             rec = owners[0] if owners else None
             if rec is not None:
-                if self._record_in_use(rec):
+                if self._record_in_use(rec, reclaim_ref=ref):
                     continue
                 owned = [
                     held for held in self._record_refs(rec)
@@ -3874,7 +3874,7 @@ class Executor:
                 # residency object; wait for a unique record-owned victim.
                 continue
             rec = owners[0]
-            if self._record_in_use(rec):
+            if self._record_in_use(rec, reclaim_ref=ref):
                 continue
             await self._vacate_record(rec)
             if await asyncio.to_thread(res.make_room, needed):
@@ -4912,16 +4912,29 @@ class Executor:
             if rec.ready and ref in self._record_refs(rec)
         ]
 
-    def _record_in_use(self, rec: _ClassRecord) -> bool:
-        # A job on a rebound spec no longer references the record's held
-        # refs — membership of the job's spec in this record is the honest
-        # "instance in use" signal (gw#494).
+    def _record_in_use(
+        self, rec: _ClassRecord, *, reclaim_ref: Optional[str] = None,
+    ) -> bool:
+        """Whether teardown would disturb live work.
+
+        ``reclaim_ref`` narrows a pressure-driven teardown to the candidate
+        that selected this record. A different held ref can be pinned by an
+        incoming job before its own setup (the common SDXL VAE); that does not
+        make this record's idle checkpoint active. ``_vacate_record`` leaves
+        such a pinned ref resident because ``release_to_disk`` refuses it.
+        Full-record invalidation omits the argument and remains conservative.
+
+        A job on a rebound spec no longer references the record's held refs;
+        membership of the job's spec in this record is the honest instance-use
+        signal (gw#494).
+        """
         for job in self.jobs.values():
             if job.finished or job.superseded or job.spec is None:
                 continue
             if job.spec in rec.specs:
                 return True
-        for ref in self._record_refs(rec):
+        refs = [reclaim_ref] if reclaim_ref is not None else self._record_refs(rec)
+        for ref in refs:
             owners = self._records_holding(ref)
             if (len(owners) == 1 and owners[0] is rec
                     and self.store.residency.in_use(ref)):

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -1451,6 +1451,83 @@ def test_setup_vacates_warm_record_after_vram_make_room(
     asyncio.run(_run())
 
 
+def test_shared_ref_pin_does_not_freeze_sole_idle_record(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """gw#579: an incoming job's shared ref is not use of an old pipeline.
+
+    The cap-3 SDXL revisit pinned the common VAE before setup. VRAM admission
+    then left one idle RAM-tier checkpoint as the VAE's sole ready record.
+    Treating that incidental VAE pin as use of the whole record skipped the
+    only reclaimable pipeline and failed with ``evicted_refs=[]``. Vacating
+    the idle record is safe: Residency retains the pinned VAE object while
+    the checkpoint reaches DISK, and the incoming setup replaces the VAE
+    representative after loading.
+    """
+    from gen_worker.models import disk_gc
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe, vae: _FakePipe) -> None:
+            self.pipeline = pipeline
+            self.vae = vae
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    shared_ref = "acme/shared-vae"
+    old_ref = "acme/old-checkpoint"
+    incoming_ref = "acme/incoming-checkpoint"
+    old_spec = _spec(
+        "old", Endpoint,
+        {"pipeline": HF(old_ref), "vae": HF(shared_ref)},
+    )
+    incoming_spec = _spec(
+        "incoming", Endpoint,
+        {"pipeline": HF(incoming_ref), "vae": HF(shared_ref)},
+    )
+    monkeypatch.setattr(disk_gc, "tree_bytes", lambda _path: 6 * _GiB)
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    pressure = {"active": False}
+    state: dict[str, _ClassRecord | None] = {"old_rec": None}
+
+    async def _run() -> None:
+        ex = _executor(
+            [old_spec, incoming_spec], tmp_path, monkeypatch=monkeypatch,
+        )
+        res = ex.store.residency
+        monkeypatch.setattr(
+            residency_mod,
+            "get_available_ram_gb",
+            lambda: 7.0 if (
+                pressure["active"]
+                and state["old_rec"] is not None
+                and state["old_rec"].instance is not None
+            ) else 24.0,
+        )
+        await ex.ensure_setup(old_spec)
+        old_rec = ex._classes[old_spec.instance_key]
+        state["old_rec"] = old_rec
+        old_pipeline = weakref.ref(old_rec.instance.pipeline)
+        events: list[tuple[str, str]] = []
+        res._on_event = lambda ref, state, *_: events.append((ref, state))
+
+        pressure["active"] = True
+        with res.executing(shared_ref):
+            incoming = await ex.ensure_setup(incoming_spec)
+            assert res.in_use(shared_ref)
+
+        assert isinstance(incoming.pipeline, _FakePipe)
+        assert old_rec.ready is False
+        assert old_rec.instance is None
+        assert old_pipeline() is None
+        assert res.tier(old_ref) is Tier.DISK
+        assert res.tier(shared_ref) is Tier.RAM
+        assert (old_ref, residency_mod.ON_DISK) in events
+        assert (shared_ref, residency_mod.ON_DISK) not in events
+
+    asyncio.run(_run())
+
+
 def test_shared_ref_does_not_pin_idle_record_or_publish_false_disk(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- narrow pressure-driven record-use checks to the checkpoint ref that selected the reclaim candidate
- preserve conservative whole-record checks for stale identity invalidation
- reproduce the cap-3 SDXL sole-owner/shared-VAE pre-pin failure through the production setup, host-admission, and vacate path

## Root cause

The incoming SDXL request pins the common VAE before setup. After VRAM admission demotes one checkpoint and vacates the other, the remaining idle checkpoint can become the VAE's sole ready record. The old record-level check mistakes that unrelated VAE pre-pin for active use of the checkpoint and skips the only RAM victim. The live failure therefore reported `evicted_refs=[]` and unchanged headroom.

Vacating that idle record is safe: the residency state machine refuses to release the pinned VAE itself, while the unrelated checkpoint reaches DISK.

## Tests

- `PYTHONPATH=src /home/fidika/cozy/python-gen-worker/.venv/bin/python -m pytest -q tests/test_ram_admission.py` (30 passed)
- focused production-path + real-CUDA pinned-swap selection (7 passed)
- post-fetch narrow regression (3 passed)
- `ruff check src/gen_worker/executor.py tests/test_ram_admission.py`
- `mypy src/gen_worker/executor.py`
- `git diff --check`

No package release, image build, deployment, or live infrastructure mutation is included.
