### PR TITLE
release: 0.37.1 (gw#584 boot-compile-deferral fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.37.1 (2026-07-18)
+
+- **gw#584: defer compile-declared endpoints from eager boot setup.** `Lifecycle.startup()`
+  raced `transport.run()`'s HelloAck handshake: a `spec.compile`-declared function with
+  locally-present weights could reach `ensure_setup` at boot with bare authored refs and
+  `snapshots=None`, silently skipping compile-cell selection while a later HelloAck-driven
+  setup materialized the resolved w8a8 lane — selection and materialization derived from
+  different resolved states, fail-closing `enable()` generically (ie#501 run 17). Compile
+  cells now defer the same way `Slot` picks already do (pgw#532): both arrive only via hub
+  delivery, never a boot default.
+
 ## 0.37.0 (2026-07-18)
 
 - **gw#581 (th#883): worker-owned cell selection.** New `gen_worker.cell_key`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.37.0"
+version = "0.37.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.37.0"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + CHANGELOG for gw#584 (PR #308, merged 923499e): compile-declared
endpoints now defer from eager boot setup instead of racing HelloAck's
precision-ladder rebind.

- pyproject.toml: 0.37.0 -> 0.37.1
- uv.lock relocked (uv lock --python 3.12)
- CHANGELOG entry

## Test plan
- [x] `uv run --python 3.12 pytest tests/test_boot_compile_deferral_gw584.py` 5 passed
- [x] `uv sync --locked --extra dev --python 3.12` clean (no drift)
- [ ] CI