### PR TITLE
release: 0.37.2 (gw#579 shared-ref RAM reclaim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.37.2 (2026-07-18)
+
+- **gw#579: reclaim idle checkpoints behind shared-reference pins.** Host-RAM
+  admission now tests whether the checkpoint selected for eviction is in use,
+  so an incoming job's pin on a shared VAE no longer freezes an unrelated idle
+  pipeline. Vacating the idle record still preserves the pinned shared asset.
+
 ## 0.37.1 (2026-07-18)
 
 - **gw#584: defer compile-declared endpoints from eager boot setup.** `Lifecycle.startup()`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.37.1"
+version = "0.37.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.37.1"
+version = "0.37.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump and changelog for gw#579, merged through PR #309 at `9c582984c7e8d65ee5e6970d1ea39aea30fff1f8`. The patch lets host-RAM admission reclaim an idle checkpoint even when an incoming job pre-pins a shared VAE, while preserving the pinned shared asset during vacate.

- pyproject.toml: 0.37.1 -> 0.37.2
- uv.lock relocked with Python 3.12
- concise changelog entry

## Test plan
- [x] `uv run --no-sync pytest -q tests/test_ram_admission.py` — 29 passed, 1 skipped (no compatible local CUDA driver)
- [x] `uv run --no-sync ruff check src/gen_worker/executor.py tests/test_ram_admission.py`
- [x] `uv run --no-sync mypy src/gen_worker/executor.py`
- [x] `uv sync --locked --extra dev --python 3.12`
- [x] `uv build` — wheel and sdist both identify 0.37.2
- [x] pyproject / lock / changelog agree on 0.37.2; anticipated `v0.37.2` tag is absent
- [x] CI