### PR TITLE
Fix standalone Diffusers component clone manifests

### DIFF
--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -91,6 +91,13 @@ def _ext(p: str) -> str:
     return "." + base.rsplit(".", 1)[-1] if "." in base else ""
 
 
+def _is_safetensors_index(path: str) -> bool:
+    lower = path.lower()
+    return lower.endswith(".safetensors.index.json") or (
+        ".safetensors.index." in lower and lower.endswith(".json")
+    )
+
+
 def _root(paths: Sequence[str]) -> list[str]:
     return [p for p in paths if "/" not in p]
 
@@ -199,7 +206,7 @@ def classify_repo(
         p for p in paths
         if _ext(p) in {".json", ".txt", ".model", ".jinja", ".yaml", ".yml"}
         and _ext(p) not in _JUNK_EXTS
-        and not p.lower().endswith(".safetensors.index.json")
+        and not _is_safetensors_index(p)
     ]
     always = [p for p in root if p.lower() in _ALWAYS_INCLUDE]
 
@@ -260,7 +267,7 @@ def classify_repo(
         # Sharded-set indexes for the picked weights only.
         picked_set = set(d_weights)
         for p in paths:
-            if p.lower().endswith(".safetensors.index.json"):
+            if _is_safetensors_index(p):
                 stem = p[: -len(".index.json")]
                 tag = _variant_tag(stem)
                 comp = p.split("/", 1)[0] if "/" in p else ""
@@ -301,7 +308,7 @@ def classify_repo(
         )
 
     has_st = any(p.lower().endswith(".safetensors") for p in paths)
-    has_st_index = any(p.lower().endswith(".safetensors.index.json") for p in paths)
+    has_st_index = any(_is_safetensors_index(p) for p in paths)
 
     # 4 pipeline tree (TRELLIS-style: pipeline.json at root composing nested
     # per-model checkpoint pairs, e.g. ckpts/<name>.{json,safetensors}). The
@@ -314,7 +321,7 @@ def classify_repo(
 
     # 5. transformers
     if config_json is not None and "config.json" in root_set and (has_st or has_st_index):
-        t_indexes = [p for p in root if p.lower().endswith(".safetensors.index.json")]
+        t_indexes = [p for p in root if _is_safetensors_index(p)]
         t_weights, t_dtype = _pick_weight_set(
             [p for p in root if p.lower().endswith(".safetensors")], dtype_pref)
         attrs: dict[str, str] = {"file_layout": "singlefile"}

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -45,6 +45,10 @@ _GGUF_QUANT_PREFERENCE = (
 # Full quant token in a gguf FILENAME, incl. unsloth-dynamic ("UD-Q4_K_XL")
 # and i-quant ("IQ4_XS") forms the preference list doesn't name.
 _GGUF_QTYPE_RE = re.compile(r"(?:ud-)?(?:i?q\d[0-9a-z_]*|bf16|f16|f32)")
+_DIFFUSERS_COMPONENT_WEIGHT_RE = re.compile(
+    r"^diffusion_pytorch_model(?:\.([a-z0-9_-]+))?"
+    r"(?:-\d{5}-of-\d{5})?\.safetensors$",
+)
 
 
 class RepoRefusal(RuntimeError):
@@ -67,7 +71,8 @@ class RepoRefusal(RuntimeError):
 class RepoClassification:
     """Result of :func:`classify_repo` + :func:`select_files`."""
 
-    strategy: str          # diffusers | pipeline_tree | transformers | peft |
+    strategy: str          # diffusers | diffusers_component | pipeline_tree |
+                           # transformers | peft |
                            # sentence_transformers | gguf | native_lora | aio_singlefile
     runtime_library: str   # diffusers | trellis2 | transformers | peft |
                            # sentence-transformers | llama-cpp |
@@ -127,6 +132,44 @@ def _pick_weight_set(
     # first preferred-order tag deterministically.
     tag = sorted(by_tag)[0]
     return sorted(by_tag[tag]), _dtype_of_tag(tag)
+
+
+def _pick_diffusers_component_weight_set(
+    root_paths: Sequence[str],
+    dtype_pref: Sequence[str],
+) -> tuple[list[str], list[str], str]:
+    """Pick the canonical weight set for a standalone Diffusers component.
+
+    Component repos can carry convenience aliases beside the loadable
+    ``diffusion_pytorch_model*`` tree (the SDXL fp16-fix VAE carries three
+    same-size aliases). Only the canonical tree belongs in the mirror.
+    """
+    by_tag: dict[str, list[str]] = {}
+    for path in root_paths:
+        match = _DIFFUSERS_COMPONENT_WEIGHT_RE.match(path.lower())
+        if match is not None:
+            by_tag.setdefault(match.group(1) or "", []).append(path)
+    if not by_tag:
+        return [], [], ""
+
+    selected_tag = ""
+    for want in dtype_pref:
+        selected_tag = next(
+            (tag for tag in by_tag if tag and _dtype_of_tag(tag) == want), "")
+        if selected_tag:
+            break
+    if not selected_tag and "" not in by_tag:
+        selected_tag = sorted(by_tag)[0]
+    weights = sorted(by_tag[selected_tag])
+
+    prefix = "diffusion_pytorch_model"
+    index_names = {
+        f"{prefix}.safetensors.index.json" if not selected_tag
+        else f"{prefix}.{selected_tag}.safetensors.index.json",
+        f"{prefix}.safetensors.index.{selected_tag}.json" if selected_tag else "",
+    }
+    indexes = sorted(path for path in root_paths if path.lower() in index_names)
+    return weights, indexes, _dtype_of_tag(selected_tag)
 
 
 def classify_repo(
@@ -232,10 +275,35 @@ def classify_repo(
                         "file_layout": "diffusers"},
                        "model_index.json at root")
 
+    # 3.5 standalone diffusers component. Diffusers ModelMixin repos use a
+    # root config with _class_name plus the canonical
+    # diffusion_pytorch_model* weight set, but no pipeline model_index.json.
+    # They are not transformers models, and convenience root aliases must not
+    # be mirrored as additional logical weights (gw#426).
+    diffusers_class = str((config_json or {}).get("_class_name") or "").strip()
+    component_weights, component_indexes, component_dtype = (
+        _pick_diffusers_component_weight_set(root, dtype_pref)
+    )
+    if diffusers_class and component_weights:
+        component_attrs = {
+            "file_layout": "singlefile",
+            "architecture": diffusers_class,
+        }
+        if component_dtype:
+            component_attrs["dtype"] = component_dtype
+        return _finish(
+            "diffusers_component",
+            "diffusers",
+            component_weights,
+            component_indexes,
+            component_attrs,
+            f"diffusers component config ({diffusers_class})",
+        )
+
     has_st = any(p.lower().endswith(".safetensors") for p in paths)
     has_st_index = any(p.lower().endswith(".safetensors.index.json") for p in paths)
 
-    # 3.5 pipeline tree (TRELLIS-style: pipeline.json at root composing nested
+    # 4 pipeline tree (TRELLIS-style: pipeline.json at root composing nested
     # per-model checkpoint pairs, e.g. ckpts/<name>.{json,safetensors}). The
     # tree is one artifact — every safetensors rides, no dtype-variant pick
     # (mixed per-model dtypes are intentional upstream).
@@ -244,7 +312,7 @@ def classify_repo(
         return _finish("pipeline_tree", "trellis2", pt_weights, [],
                        {"file_layout": "singlefile"}, "pipeline.json at root")
 
-    # 4. transformers
+    # 5. transformers
     if config_json is not None and "config.json" in root_set and (has_st or has_st_index):
         t_indexes = [p for p in root if p.lower().endswith(".safetensors.index.json")]
         t_weights, t_dtype = _pick_weight_set(
@@ -260,7 +328,7 @@ def classify_repo(
         return _finish("transformers", "transformers", t_weights, t_indexes, attrs,
                        "config.json + safetensors")
 
-    # 5. GGUF
+    # 6. GGUF
     gguf_files = [p for p in root if p.lower().endswith(".gguf")]
     if gguf_files:
         def _quant_of(p: str) -> str:
@@ -287,7 +355,7 @@ def classify_repo(
                         "file_type": "gguf", "file_layout": "singlefile"},
                        f"{len(gguf_files)} *.gguf at root")
 
-    # 6/7. root safetensors: native LoRA vs AIO singlefile
+    # 7/8. root safetensors: native LoRA vs AIO singlefile
     st_root = [p for p in root if p.lower().endswith(".safetensors")]
     if st_root:
         md = dict(safetensors_metadata or {})

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -36,6 +36,13 @@ _DTYPE_TAGS: dict[str, tuple[str, ...]] = {
     "fp8": ("fp8", "fp8_e4m3fn", "fp8-e4m3", "fp8_e5m2"),
 }
 _VARIANT_TAG_RE = re.compile(r"\.([a-z0-9_\-]+)\.safetensors$")
+_SHARD_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}$")
+_OFFICIAL_INDEX_VARIANT_RE = re.compile(
+    r"\.safetensors\.index\.([a-z0-9_-]+)\.json$",
+)
+_LEGACY_INDEX_VARIANT_RE = re.compile(
+    r"\.([a-z0-9_-]+)\.safetensors\.index\.json$",
+)
 
 _GGUF_QUANT_PREFERENCE = (
     "q8_0", "q6_k", "q5_k_m", "q5_k_s", "q4_k_m", "q4_k_s", "q4_0",
@@ -103,8 +110,21 @@ def _root(paths: Sequence[str]) -> list[str]:
 
 
 def _variant_tag(path: str) -> str:
-    m = _VARIANT_TAG_RE.search(path.rsplit("/", 1)[-1].lower())
+    name = path.rsplit("/", 1)[-1].lower()
+    if name.endswith(".safetensors"):
+        stem = _SHARD_SUFFIX_RE.sub("", name.removesuffix(".safetensors"))
+        name = stem + ".safetensors"
+    m = _VARIANT_TAG_RE.search(name)
     return m.group(1) if m else ""
+
+
+def _index_variant_tag(path: str) -> str:
+    name = path.rsplit("/", 1)[-1].lower()
+    match = _OFFICIAL_INDEX_VARIANT_RE.search(name)
+    if match is not None:
+        return match.group(1)
+    match = _LEGACY_INDEX_VARIANT_RE.search(name)
+    return match.group(1) if match is not None else ""
 
 
 def _dtype_of_tag(tag: str) -> str:
@@ -262,18 +282,15 @@ def classify_repo(
                 continue
             comp_weights, comp_dtype = _pick_weight_set(group, dtype_pref)
             d_weights.extend(comp_weights)
+            selected_tag = _variant_tag(comp_weights[0]) if comp_weights else ""
+            d_indexes.extend(sorted(
+                p for p in paths
+                if _is_safetensors_index(p)
+                and (p.split("/", 1)[0] if "/" in p else "") == comp
+                and _index_variant_tag(p) == selected_tag
+            ))
             if comp and comp_dtype:
                 resolved[comp] = comp_dtype
-        # Sharded-set indexes for the picked weights only.
-        picked_set = set(d_weights)
-        for p in paths:
-            if _is_safetensors_index(p):
-                stem = p[: -len(".index.json")]
-                tag = _variant_tag(stem)
-                comp = p.split("/", 1)[0] if "/" in p else ""
-                comp_pick = [w for w in picked_set if w.startswith(f"{comp}/")] if comp else list(picked_set)
-                if any(_variant_tag(w) == tag for w in comp_pick):
-                    d_indexes.append(p)
         if not d_weights:
             raise RepoRefusal("missing_safetensors", files_seen=paths)
         dtypes = sorted(set(resolved.values()))

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -46,7 +46,7 @@ _GGUF_QUANT_PREFERENCE = (
 # and i-quant ("IQ4_XS") forms the preference list doesn't name.
 _GGUF_QTYPE_RE = re.compile(r"(?:ud-)?(?:i?q\d[0-9a-z_]*|bf16|f16|f32)")
 _DIFFUSERS_COMPONENT_WEIGHT_RE = re.compile(
-    r"^diffusion_pytorch_model(?:\.([a-z0-9_-]+))?"
+    r"^diffusion_pytorch_model(?:\.([a-z0-9_-]+?))?"
     r"(?:-\d{5}-of-\d{5})?\.safetensors$",
 )
 

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -573,7 +573,7 @@ class CloneDiskSpaceError(RuntimeError):
 _DISK_MARGIN_BYTES = 2 * 1024**3
 _PUBLISH_AS_IS_STRATEGIES = frozenset({
     "transformers", "peft", "sentence_transformers", "gguf", "native_lora",
-    "pipeline_tree",
+    "pipeline_tree", "diffusers_component",
 })
 _DIRECT_GGUF_ENCODINGS = frozenset({"f32", "f16", "bf16", "q8_0"})
 _DTYPE_STORAGE_BITS = {

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1509,6 +1509,10 @@ VARIANT_WEIGHT_NAME_RE = re.compile(
     r"^(?P<base>.+)\.(?P<v>fp16|bf16|fp32)"
     r"(?P<shard>-\d{5}-of-\d{5})?\.safetensors(?P<idx>\.index\.json)?$"
 )
+VARIANT_INDEX_NAME_RE = re.compile(
+    r"^(?P<base>.+)\.safetensors\.index\."
+    r"(?P<v>fp16|bf16|fp32)\.json$"
+)
 
 
 def normalize_variant_filenames(tree: Path) -> None:
@@ -1530,9 +1534,13 @@ def normalize_variant_filenames(tree: Path) -> None:
         renames: dict[str, str] = {}
         for p in sorted(d.iterdir()):
             m = VARIANT_WEIGHT_NAME_RE.match(p.name)
-            if not m:
-                continue
-            new_name = f"{m['base']}{m['shard'] or ''}.safetensors{m['idx'] or ''}"
+            if m:
+                new_name = f"{m['base']}{m['shard'] or ''}.safetensors{m['idx'] or ''}"
+            else:
+                index_match = VARIANT_INDEX_NAME_RE.match(p.name)
+                if index_match is None:
+                    continue
+                new_name = f"{index_match['base']}.safetensors.index.json"
             if (d / new_name).exists():
                 renames.clear()
                 break

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -106,6 +106,31 @@ def test_standalone_diffusers_vae_selects_only_canonical_weight() -> None:
     }
 
 
+def test_standalone_diffusers_component_selects_complete_variant_shard_set() -> None:
+    files = [
+        "config.json",
+        "diffusion_pytorch_model.safetensors",
+        "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+        "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+        "diffusion_pytorch_model.fp16.safetensors.index.json",
+        "vae-copy.safetensors",
+    ]
+    c = classify_repo(
+        files,
+        config_json={"_class_name": "AutoencoderKL"},
+        dtype_pref=("fp16",),
+    )
+
+    assert c.strategy == "diffusers_component"
+    assert c.attrs["dtype"] == "fp16"
+    assert set(c.allow_patterns) == {
+        "config.json",
+        "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+        "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+        "diffusion_pytorch_model.fp16.safetensors.index.json",
+    }
+
+
 def test_transformers_with_sharded_index_and_onnx_excluded() -> None:
     files = [
         "config.json", "generation_config.json", "tokenizer.json",

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -112,7 +112,10 @@ def test_standalone_diffusers_component_selects_complete_variant_shard_set() -> 
         "diffusion_pytorch_model.safetensors",
         "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
         "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
-        "diffusion_pytorch_model.fp16.safetensors.index.json",
+        "diffusion_pytorch_model.safetensors.index.fp16.json",
+        "diffusion_pytorch_model.bf16-00001-of-00002.safetensors",
+        "diffusion_pytorch_model.bf16-00002-of-00002.safetensors",
+        "diffusion_pytorch_model.safetensors.index.bf16.json",
         "vae-copy.safetensors",
     ]
     c = classify_repo(
@@ -127,7 +130,7 @@ def test_standalone_diffusers_component_selects_complete_variant_shard_set() -> 
         "config.json",
         "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
         "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
-        "diffusion_pytorch_model.fp16.safetensors.index.json",
+        "diffusion_pytorch_model.safetensors.index.fp16.json",
     }
 
 

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -72,6 +72,40 @@ def test_diffusers_skips_root_allinone_checkpoints() -> None:
     assert "transformer/diffusion_pytorch_model.fp16.safetensors" in allow
 
 
+def test_standalone_diffusers_vae_selects_only_canonical_weight() -> None:
+    """gw#426: madebyollin's SDXL VAE is a Diffusers component, not a
+    Transformers model, and its A1111 aliases are not extra logical weights."""
+    files = [
+        ".gitattributes",
+        "README.md",
+        "config.json",
+        "diffusion_pytorch_model.bin",
+        "diffusion_pytorch_model.safetensors",
+        "images/vae-fix.jpg",
+        "sdxl.vae.safetensors",
+        "sdxl_vae.safetensors",
+    ]
+    c = classify_repo(
+        files,
+        config_json={
+            "_class_name": "AutoencoderKL",
+            "_diffusers_version": "0.18.0.dev0",
+        },
+    )
+
+    assert c.strategy == "diffusers_component"
+    assert c.runtime_library == "diffusers"
+    assert c.attrs == {
+        "file_layout": "singlefile",
+        "architecture": "AutoencoderKL",
+    }
+    assert set(c.allow_patterns) == {
+        "README.md",
+        "config.json",
+        "diffusion_pytorch_model.safetensors",
+    }
+
+
 def test_transformers_with_sharded_index_and_onnx_excluded() -> None:
     files = [
         "config.json", "generation_config.json", "tokenizer.json",

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -55,6 +55,29 @@ def test_diffusers_dtype_preference_fp16() -> None:
     assert "transformer/diffusion_pytorch_model.bf16.safetensors" not in allow
 
 
+def test_diffusers_pipeline_selects_complete_official_variant_shard_set() -> None:
+    files = [
+        "model_index.json",
+        "unet/config.json",
+        "unet/diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.safetensors.index.fp16.json",
+        "unet/diffusion_pytorch_model.bf16-00001-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.bf16-00002-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.safetensors.index.bf16.json",
+    ]
+    c = classify_repo(files, dtype_pref=("fp16",))
+
+    assert c.strategy == "diffusers"
+    assert set(c.allow_patterns) == {
+        "model_index.json",
+        "unet/config.json",
+        "unet/diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+        "unet/diffusion_pytorch_model.safetensors.index.fp16.json",
+    }
+
+
 def test_diffusers_skips_root_allinone_checkpoints() -> None:
     # SD1.5 shape: the repo ships all-in-one root checkpoints (12GB) on top
     # of the component tree — a diffusers-layout ingest must never pull them

--- a/tests/convert/test_normalize_variant_filenames.py
+++ b/tests/convert/test_normalize_variant_filenames.py
@@ -55,6 +55,33 @@ class TestNormalizeVariantFilenames:
         assert (tmp_path / "text_encoder/model.safetensors").exists()
         assert (tmp_path / "vae/diffusion_pytorch_model.safetensors").exists()
 
+    def test_official_variant_index_and_shards_become_one_canonical_set(
+        self, tmp_path: Path,
+    ) -> None:
+        _mk(tmp_path, "vae/diffusion_pytorch_model.fp16-00001-of-00002.safetensors")
+        _mk(tmp_path, "vae/diffusion_pytorch_model.fp16-00002-of-00002.safetensors")
+        _mk(
+            tmp_path,
+            "vae/diffusion_pytorch_model.safetensors.index.fp16.json",
+            json.dumps({
+                "weight_map": {
+                    "a": "diffusion_pytorch_model.fp16-00001-of-00002.safetensors",
+                    "b": "diffusion_pytorch_model.fp16-00002-of-00002.safetensors",
+                },
+            }).encode(),
+        )
+
+        _normalize_variant_filenames(tmp_path)
+
+        vae = tmp_path / "vae"
+        canonical_index = vae / "diffusion_pytorch_model.safetensors.index.json"
+        assert canonical_index.is_file()
+        assert not list(vae.glob("*.fp16*"))
+        assert json.loads(canonical_index.read_text())["weight_map"] == {
+            "a": "diffusion_pytorch_model-00001-of-00002.safetensors",
+            "b": "diffusion_pytorch_model-00002-of-00002.safetensors",
+        }
+
     def test_canonical_names_untouched(self, tmp_path: Path) -> None:
         _mk(tmp_path, "unet/diffusion_pytorch_model.safetensors")
         _mk(tmp_path, "unet/config.json")

--- a/tests/convert/test_publish.py
+++ b/tests/convert/test_publish.py
@@ -7,13 +7,16 @@ failure / removed on success, and no-publish-cannot-read-as-success.
 
 from __future__ import annotations
 
+import json
+import struct
 from pathlib import Path
 
 import pytest
 
 from gen_worker.convert import ProducedFlavor, publish_flavors
 from gen_worker.convert.clone import run_clone
-from gen_worker.convert.ingest import IngestedSource
+from gen_worker.convert.classifier import classify_repo
+from gen_worker.convert.ingest import HFSourcePlan, IngestedSource
 
 from fake_hub import _FakeHub
 
@@ -152,6 +155,90 @@ def test_run_clone_publishes_clean_tree_and_removes_workdir(
     assert not any(o.startswith(".cache/") for o in ops)
     # success: keyed workdir is gone
     assert list((tmp_path / "work").glob("clone-*")) == []
+
+
+def test_run_clone_publishes_standalone_sdxl_vae_as_diffusers_component(
+    fake_hub, tmp_path: Path, monkeypatch
+) -> None:
+    """Exact small fixture for the production gw#426 failure: exercise the
+    plan -> selective download -> ingest -> publish path without the 335 MB
+    VAE bytes."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    paths = [
+        ".gitattributes",
+        "README.md",
+        "config.json",
+        "diffusion_pytorch_model.bin",
+        "diffusion_pytorch_model.safetensors",
+        "images/vae-fix.jpg",
+        "sdxl.vae.safetensors",
+        "sdxl_vae.safetensors",
+    ]
+    config = {
+        "_class_name": "AutoencoderKL",
+        "_diffusers_version": "0.18.0.dev0",
+        "force_upcast": False,
+    }
+    classification = classify_repo(paths, config_json=config)
+    plan = HFSourcePlan(
+        repo_id="madebyollin/sdxl-vae-fp16-fix",
+        revision="97ea5f13002d40686c2447609d24e5685dac0abb",
+        paths=paths,
+        sizes={path: 128 for path in paths},
+        side={"config_json": config},
+        classification=classification,
+        content_ids={path: f"git:{index:040x}" for index, path in enumerate(paths, 1)},
+    )
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface", lambda *a, **k: plan)
+
+    def fake_download(repo_id, revision, dest_dir, *, allow_patterns, **kwargs):
+        assert repo_id == plan.repo_id
+        assert revision == plan.revision
+        assert set(allow_patterns) == {
+            "README.md",
+            "config.json",
+            "diffusion_pytorch_model.safetensors",
+        }
+        root = Path(dest_dir)
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "README.md").write_text("SDXL VAE fp16 fix", encoding="utf-8")
+        (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        header = json.dumps({
+            "decoder.conv.weight": {
+                "dtype": "F16",
+                "shape": [1],
+                "data_offsets": [0, 2],
+            },
+        }, separators=(",", ":")).encode()
+        (root / "diffusion_pytorch_model.safetensors").write_bytes(
+            struct.pack("<Q", len(header)) + header + b"\0\0"
+        )
+
+    monkeypatch.setattr(
+        "gen_worker.convert.ingest._snapshot_download_with_retries",
+        fake_download,
+    )
+    monkeypatch.setattr("gen_worker.convert.ingest.install_hf_http_timeouts", lambda: None)
+
+    result = run_clone(
+        _Ctx(fake_hub),
+        provider="huggingface",
+        source_ref=plan.repo_id,
+        destination_repo="acme/sdxl-vae-fp16-fix",
+    )
+
+    assert result.published[0]["flavor"] == "fp16"
+    request = _FakeHub.state["commit_request"]
+    assert request["library_name"] == "diffusers"
+    assert request["class_name"] == "AutoencoderKL"
+    assert request["model_family"] == "sdxl"
+    assert request["file_layout"] == "singlefile"
+    assert {op["path"] for op in request["operations"]} == {
+        "README.md",
+        "config.json",
+        "diffusion_pytorch_model.safetensors",
+    }
 
 
 def test_run_clone_failure_cleans_workdir_then_retry_succeeds(


### PR DESCRIPTION
Tracker: cozy-creator/tracker `python-gen-worker#426`

## What changed
- classify root `_class_name` + canonical `diffusion_pytorch_model*` repositories as standalone Diffusers components instead of Transformers
- select one complete canonical weight/index variant, excluding duplicate aliases, pickle weights, and non-selected dtype indexes
- preserve the same complete-shard selection for ordinary `model_index.json` pipelines
- canonicalize official Diffusers variant indexes together with their shards and rewrite the index weight map
- publish the component source tree as-is with the Diffusers repo contract
- add an exact small `madebyollin/sdxl-vae-fp16-fix` plan -> download -> ingest -> Hub commit regression

## Validation
- `uv run --with pytest pytest -q tests/convert/test_classifier.py tests/convert/test_publish.py tests/convert/test_normalize_variant_filenames.py` (41 passed)
- `uv run --with pytest pytest -q tests/convert` (110 passed, 6 skipped)
- `uvx ruff check src/gen_worker/convert/classifier.py src/gen_worker/convert/clone.py src/gen_worker/convert/writer.py tests/convert/test_classifier.py tests/convert/test_publish.py tests/convert/test_normalize_variant_filenames.py`
- `uv run mypy --follow-imports=skip src/gen_worker/convert/classifier.py src/gen_worker/convert/clone.py src/gen_worker/convert/writer.py`
- independent review: APPROVE exact signed head `786fce4e13469cec2ff71ff062a5573b21396e9a`

## Deliberately separate
An existing empty destination repo auto-created by the old classification may still retain `library_name=transformers`. Tensorhub-side reconcile-or-typed-refuse is the remaining tracker task; this worker PR does not mutate live state or weaken manifest validation.