### PR TITLE
Reclaim idle disk cache under host RAM pressure (gw#579)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -889,6 +889,17 @@ class ModelStore:
             else:
                 self._index.remove(ref)
 
+    def lru_disk_refs(self, *, exclude: Tuple[str, ...] = ()) -> List[str]:
+        """Idle DISK refs in persisted last-use order, oldest first."""
+        excluded = set(exclude)
+        candidates = [
+            (self._index.last_used(ref), ref)
+            for ref in self.residency.refs_in(residency_mod.Tier.DISK)
+            if ref not in excluded and not self.residency.in_use(ref)
+        ]
+        candidates.sort()
+        return [ref for _last_used, ref in candidates]
+
     def gc_disk(self, target_free_bytes: int, *, exclude: Tuple[str, ...] = ()) -> None:
         """Evict LRU disk-tier refs until free disk reaches the target.
         Non-keep refs go first (grace-honoring, then grace-ignoring); under
@@ -3668,16 +3679,18 @@ class Executor:
                 for event in [*failures, *progress]
             ]
 
-    async def _reclaim_released_file_cache(
-        self, released_refs: List[str], incoming_paths: List[Path],
+    async def _reclaim_disk_file_cache(
+        self, candidate_refs: List[str], incoming_paths: List[Path],
     ) -> int:
-        """Advise only pressure-evicted immutable snapshots out of file cache.
+        """Advise only idle immutable snapshots out of file cache.
 
         A DISK transition preserves model bytes, but recently-read clean pages
         can still fill the pod cgroup and make the following load look
         impossible.  Protect the incoming snapshot and every still-loaded or
-        executing ref by inode; then advise only refs that truthfully reached
-        DISK.  The caller always re-probes measured headroom afterward.
+        executing ref by inode; then advise only candidate refs that truthfully
+        reached DISK.  Candidates may have been evicted during this admission
+        or during an earlier rotation.  The caller always re-probes measured
+        headroom afterward.
 
         This runs inside ``_setup_locked``'s process-wide load lock.  Every
         setup and ordinary RAM->VRAM promotion takes that same lock, so a DISK
@@ -3700,7 +3713,7 @@ class Executor:
 
         advised = 0
         seen_paths: set[Path] = set()
-        for ref in dict.fromkeys(released_refs):
+        for ref in dict.fromkeys(candidate_refs):
             if res.tier(ref) is not residency_mod.Tier.DISK or res.in_use(ref):
                 continue
             local = res.local_path(ref)
@@ -3814,7 +3827,7 @@ class Executor:
             await self._observe_host_ram_progress(released)
             if after.sufficient:
                 return
-            advised = await self._reclaim_released_file_cache(
+            advised = await self._reclaim_disk_file_cache(
                 released, [Path(p) for p in paths.values()],
             )
             if advised:
@@ -3827,6 +3840,41 @@ class Executor:
             await self._observe_host_ram_progress(released)
             if after.sufficient:
                 return
+
+        # A prior rotation may already have truthfully moved every old model
+        # to DISK.  In that state there is no RAM-tier victim above, but clean
+        # pages from loading those immutable snapshots can still occupy the
+        # conservative cgroup working set (active_file is deliberately not
+        # counted as immediately available).  Chill the oldest idle DISK refs
+        # before declaring the host incapable.  This does not delete model
+        # bytes and the inode-preservation gate above protects the incoming
+        # model plus every loaded/executing component.
+        incoming_ref_set = set(incoming_refs)
+        disk_refs = self.store.lru_disk_refs(
+            exclude=tuple(incoming_ref_set),
+        )
+        advised = 0
+        for ref in disk_refs:
+            advised += await self._reclaim_disk_file_cache(
+                [ref], [Path(p) for p in paths.values()],
+            )
+            after = await asyncio.to_thread(res.host_ram_headroom, incoming)
+            await self._observe_host_ram_progress([])
+            if after.sufficient:
+                if advised:
+                    logger.info(
+                        "host-RAM admission advised %d already-DISK immutable "
+                        "snapshot bytes out of file cache for %s",
+                        advised, spec.name,
+                    )
+                return
+        if advised:
+            logger.info(
+                "host-RAM admission advised %d already-DISK immutable "
+                "snapshot bytes out of file cache for %s without reaching "
+                "required headroom",
+                advised, spec.name,
+            )
 
         error = InsufficientHostRamError(
             spec.name,

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -645,7 +645,7 @@ def test_pressure_pinned_release_runs_after_owner_teardown_and_stops_eviction(
     monkeypatch.setattr(
         executor_mod, "release_unused_pinned_host_cache", _release_pinned,
     )
-    ex._reclaim_released_file_cache = _unexpected_file_advice  # type: ignore[method-assign]
+    ex._reclaim_disk_file_cache = _unexpected_file_advice  # type: ignore[method-assign]
 
     async def _run() -> None:
         await ex._record_host_ram_failure(

--- a/tests/test_ram_admission.py
+++ b/tests/test_ram_admission.py
@@ -464,6 +464,101 @@ def test_pressure_eviction_reclaims_real_snapshot_cache_and_protects_shared_inod
     assert vae_file.read_bytes() == b"a" * vae_file.stat().st_size
 
 
+def test_pressure_reclaims_already_disk_snapshot_cache_without_ram_victim(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#579: an earlier DISK transition must remain reclaimable later.
+
+    The live 16-checkpoint canary reached a state with every prior checkpoint
+    already ON_DISK and no RAM-tier victim, while their recently-read clean
+    pages still occupied the conservative cgroup working set.  Exercise the
+    production admission and file-advice paths against real page-cache state:
+    the old snapshot is chilled, the incoming snapshot stays hot, and no model
+    bytes are deleted.
+    """
+    if not hasattr(os, "posix_fadvise"):
+        pytest.skip("real page-cache test requires os.posix_fadvise")
+
+    old_dir = tmp_path / "already-disk"
+    recent_dir = tmp_path / "recently-used-disk"
+    incoming_dir = tmp_path / "incoming"
+    old_dir.mkdir()
+    recent_dir.mkdir()
+    incoming_dir.mkdir()
+    old_file = old_dir / "weights.bin"
+    recent_file = recent_dir / "weights.bin"
+    incoming_file = incoming_dir / "weights.bin"
+    old_file.write_bytes(b"o" * (32 * 1024 * 1024))
+    recent_file.write_bytes(b"r" * (8 * 1024 * 1024))
+    incoming_file.write_bytes(b"n" * (8 * 1024 * 1024))
+    for file_path in (old_file, recent_file, incoming_file):
+        with file_path.open("rb") as stream:
+            os.fsync(stream.fileno())
+        fd = os.open(file_path, os.O_RDONLY)
+        try:
+            os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+        finally:
+            os.close(fd)
+        _warm_file(file_path)
+
+    old_size = old_file.stat().st_size
+    recent_size = recent_file.stat().st_size
+    incoming_size = incoming_file.stat().st_size
+    assert _resident_file_bytes(old_file) >= old_size
+    assert _resident_file_bytes(recent_file) >= recent_size
+    assert _resident_file_bytes(incoming_file) >= incoming_size
+
+    class Endpoint:
+        def setup(self, pipeline: _FakePipe) -> None:
+            self.pipeline = pipeline
+
+        def run(self, ctx, payload: _In):  # pragma: no cover
+            return payload
+
+    old_ref = "tensorhub/a-already-disk"
+    recent_ref = "tensorhub/z-recently-used-disk"
+    incoming_spec = _spec(
+        "incoming", Endpoint, {"pipeline": HF("tensorhub/incoming")},
+    )
+    ex = _executor([incoming_spec], tmp_path / "cache")
+    res = ex.store.residency
+    res.track_disk(old_ref, old_dir)
+    res.track_disk(recent_ref, recent_dir)
+    ex.store._index.record(old_ref, old_dir, old_size)
+    ex.store._index.record(recent_ref, recent_dir, recent_size)
+
+    floor = 8 * 1024 * 1024
+    baseline = 4 * 1024 * 1024
+
+    def _headroom(needed: int) -> HostRamHeadroom:
+        reclaimed = old_size - min(old_size, _resident_file_bytes(old_file))
+        return HostRamHeadroom(
+            available_bytes=baseline + reclaimed,
+            floor_bytes=floor,
+            required_bytes=int(needed) + floor,
+        )
+
+    monkeypatch.setattr(res, "host_ram_headroom", _headroom)
+
+    async def _run() -> None:
+        async with ex._load_lock:
+            await ex._ensure_host_ram_for(
+                incoming_spec, {"pipeline": str(incoming_dir)},
+            )
+
+    asyncio.run(_run())
+    assert res.tier(old_ref) is Tier.DISK
+    assert res.tier(recent_ref) is Tier.DISK
+    assert _resident_file_bytes(old_file) < old_size // 4
+    # Re-probing after the oldest ref reaches the exact requirement stops the
+    # scan before it needlessly chills a hotter local checkpoint.
+    assert _resident_file_bytes(recent_file) >= recent_size
+    assert _resident_file_bytes(incoming_file) >= incoming_size
+    assert old_file.read_bytes() == b"o" * old_size
+    assert recent_file.read_bytes() == b"r" * recent_size
+    assert incoming_file.read_bytes() == b"n" * incoming_size
+
+
 @pytest.mark.parametrize("owned_by_record", [True, False])
 def test_pressure_pinned_release_runs_after_owner_teardown_and_stops_eviction(
     tmp_path: Path, monkeypatch, owned_by_record: bool,


### PR DESCRIPTION
## Summary

- reclaim clean page-cache pages from the oldest idle, already-DISK immutable snapshots when host-RAM admission has no RAM-tier victim
- preserve incoming, loaded, executing, and shared inodes; retain every model byte on disk
- re-probe exact measured headroom after each snapshot and stop as soon as the load fits

## Live cause

The SDXL cap-1 canary completed 13 distinct checkpoints on one L4, then the next checkpoint failed with required_bytes=15529727980, available_after_bytes=14461853696, evicted_refs=[], and prior RSS 2.342 GiB. PR #309 was present in v0.37.2; the remaining gap was that file advice only ran for a ref vacated during the current admission. When all prior refs were already ON_DISK, no reclaim path ran.

## Tests

- .venv/bin/python -m pytest tests/test_ram_admission.py -q (29 passed, 2 CUDA skips)
- .venv/bin/python -m pytest tests/test_ram_budget.py -q (14 passed)
- real-mincore already-DISK regression repeated 3 times
- .venv/bin/ruff check src/gen_worker/executor.py tests/test_ram_admission.py
- git diff --check

The locked full dev-extra bootstrap is independently blocked by an upstream torch 2.13.0+cu130 wheel hash mismatch; no dependency files were changed.