### PR TITLE
release: gen-worker 0.37.3 (gw#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.37.3 (2026-07-18)
+
+- **gw#579: reclaim idle on-disk checkpoint cache under host-RAM pressure.**
+  When prior rotations have already moved every old pipeline to DISK, admission
+  now advises clean pages from the oldest immutable snapshots out of the file
+  cache one ref at a time and re-probes exact headroom after each. Incoming,
+  loaded, executing, and shared inodes remain protected; model bytes stay local.
+
 ## 0.37.2 (2026-07-18)
 
 - **gw#579: reclaim idle checkpoints behind shared-reference pins.** Host-RAM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.37.2"
+version = "0.37.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.37.2"
+version = "0.37.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Release the merged gw#579 already-DISK immutable page-cache reclaim as gen-worker 0.37.3. This PR changes only CHANGELOG.md, pyproject.toml, and the root package version in uv.lock.

## Verification

- uv lock --check
- uv build --out-dir /home/fidika/cozy/.build-artifacts/python-gen-worker/0.37.3
- wheel ZIP integrity and METADATA Name/Version verified
- sdist tar integrity and PKG-INFO Name/Version verified
- isolated no-deps wheel install reports gen-worker 0.37.3
- local wheel SHA-256: 6934219cf063aa0b0bf390ded97571ecfb91f00b76e494270ef689d6e15f4490
- local sdist SHA-256: 5deebbca311a3a2748082b264bd62b546dca0145ceb1274e1a6b97584e9d53ef
- git diff --check

The code PR #313 passed full CI run 29645022267 and merged at 0dd0d430424152ad62e4b2016632713a056ad563.