### PR TITLE
release: 0.37.4 (gw#586 serving-pipeline-class mints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.37.4 (2026-07-18)
+
+- **gw#586: mints trace through the serving pipeline class.** Traced FX graphs
+  depend on the pipeline's CALL path, not just the module tree: the serving
+  Condition class drives LTX's DiT with per-token timestep/modulation tensors
+  while `build()`'s generic load broadcast them — no generic-load cell ever
+  served a serving-path lookup (pre-proof fleets silently cold-compiled the
+  real graphs at boot). `build(pipeline_class=...)` +
+  `resolve_pipeline_class()` load through the named serving class; unknown
+  names refuse loudly. Class stamped in metadata for observability; the ck1
+  key and graph_signature stay class-agnostic.
+
 ## 0.37.3 (2026-07-18)
 
 - **gw#579: reclaim idle on-disk checkpoint cache under host-RAM pressure.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.37.3"
+version = "0.37.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.37.3"
+version = "0.37.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + CHANGELOG for gw#586 (PR #315, merged 65e58860): mints trace through the serving pipeline class.

- pyproject.toml: 0.37.3 -> 0.37.4
- uv.lock relocked
- CHANGELOG entry

## Test plan
- [x] tests/test_compile_cache.py 58 passed locally
- [ ] CI