### PR TITLE
gw#588: reconcile resident low-VRAM prep mode to the cell's traced mode

### DIFF
--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1456,6 +1456,21 @@ def unwrap(pipeline: Any) -> bool:
     return True
 
 
+def _reconcile_resident_mode(meta: Optional[Dict[str, Any]], pipeline: Any) -> None:
+    """gw#588: 'off' and 'vae_only' are both fully-resident preps differing
+    only in flag groups — converge the pipeline to the cell's traced mode so
+    an honest :func:`mode_drift` passes. Offload drift keeps refusing."""
+    if not meta:
+        return
+    want = str(meta.get("low_vram_mode") or "")
+    from .models.memory import low_vram_mode, reconcile_resident_mode
+
+    resident = ("off", "vae_only")
+    have = low_vram_mode(pipeline)
+    if want != have and want in resident and have in resident:
+        reconcile_resident_mode(pipeline, want)
+
+
 def artifact_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     """The complete pipeline/config compatibility verdict for one cell."""
     drift = (
@@ -1488,6 +1503,7 @@ def arm_staged_artifact(
     try:
         with _SEED_ARM_LOCK:
             meta = staged.metadata
+            _reconcile_resident_mode(meta, pipeline)
             drift = artifact_drift(meta, pipeline, cfg)
             if drift:
                 raise AdoptError("key_mismatch", drift)
@@ -1554,6 +1570,7 @@ def enable(
                         self_key = want.digest
                 except Exception:
                     self_key = ""
+                _reconcile_resident_mode(meta, pipeline)
                 drift = artifact_drift(meta, pipeline, cfg)
                 if drift:
                     # low_vram prep mode is DYNAMIC (free-VRAM placement at

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -1166,9 +1166,39 @@ def low_vram_mode(pipeline: Any) -> str:
     return str(getattr(pipeline, _COZY_MODE_ATTR, "") or "")
 
 
+_RESIDENT_MODES = ("off", "vae_only")
+
+
+def reconcile_resident_mode(pipeline: Any, want: str) -> bool:
+    """Converge a fully-CUDA-resident pipeline between 'off' and 'vae_only' by
+    toggling the slicing/tiling flag groups (gw#588). Any other mode pair is
+    untouched: offload rungs trace genuinely different graphs and residency."""
+    have = low_vram_mode(pipeline)
+    if want not in _RESIDENT_MODES or have not in _RESIDENT_MODES:
+        return False
+    if have == want:
+        return True
+    _LOG.info(
+        "low_vram: reconciling resident mode %r -> %r (free VRAM %.1f GB)",
+        have, want, get_available_vram_gb(),
+    )
+    if want == "vae_only":
+        _apply_vae_and_attention(pipeline, {})
+    else:
+        vae = getattr(pipeline, "vae", None)
+        if not _call_if_present(pipeline, "disable_vae_slicing") and vae is not None:
+            _call_if_present(vae, "disable_slicing")
+        if not _call_if_present(pipeline, "disable_vae_tiling") and vae is not None:
+            _call_if_present(vae, "disable_tiling")
+        _call_if_present(pipeline, "disable_attention_slicing")
+    setattr(pipeline, _COZY_MODE_ATTR, want)
+    return True
+
+
 __all__ = [
     "apply_low_vram_config",
     "low_vram_mode",
+    "reconcile_resident_mode",
     "rearm_offload",
     "place_pipeline",
     "next_offload_rung",

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1026,3 +1026,170 @@ def test_resolve_pipeline_class_gw586() -> None:
     # A diffusers attribute that is not a loadable pipeline class refuses too.
     with pytest.raises(RuntimeError, match="wrong call path"):
         resolve_pipeline_class("__version__")
+
+
+# ---------------------------------------------------------------------------
+# gw#588: resident prep-mode drift (off <-> vae_only) converges to the cell
+# ---------------------------------------------------------------------------
+
+
+def _resident_pipe(mode: str):
+    """A pipeline with the three resident flag groups and a compile target.
+    Flags start matching ``mode`` ('vae_only' = all on, 'off'/other = off)."""
+    torch = pytest.importorskip("torch")
+
+    class _Pipe:
+        def __init__(self):
+            self.transformer = torch.nn.Sequential(
+                torch.nn.Linear(16, 16), torch.nn.SiLU(),
+            )
+            on = mode == "vae_only"
+            self.flags = {
+                "vae_slicing": on, "vae_tiling": on, "attention_slicing": on,
+            }
+            if mode:
+                self._cozy_low_vram_mode = mode
+
+        def enable_vae_slicing(self):
+            self.flags["vae_slicing"] = True
+
+        def disable_vae_slicing(self):
+            self.flags["vae_slicing"] = False
+
+        def enable_vae_tiling(self):
+            self.flags["vae_tiling"] = True
+
+        def disable_vae_tiling(self):
+            self.flags["vae_tiling"] = False
+
+        def enable_attention_slicing(self):
+            self.flags["attention_slicing"] = True
+
+        def disable_attention_slicing(self):
+            self.flags["attention_slicing"] = False
+
+    return _Pipe()
+
+
+def _resident_cell(tmp_path, pipe, cfg, *, low_vram_mode, weight_lane=""):
+    sig, wc = cc.execution_contract(pipe, cfg)
+    meta = cc.artifact_metadata(
+        family=cfg.family, shapes=cfg.shapes, targets=cfg.targets,
+        weight_lane=weight_lane, low_vram_mode=low_vram_mode,
+        graph_signature=sig, weight_contract=wc)
+    source = _capture_tree(tmp_path / "cand")
+    return cc.pack(source, tmp_path / "cell.tar.gz", meta)
+
+
+def _pin_w8a8_identity(monkeypatch):
+    """W8A8 contract requires sm/cuda/image_digest; pin fakes on a GPU-less
+    test host (both mint and verify see the same monkeypatched key)."""
+    real_key = cc.runtime_key
+
+    def prod_key():
+        key = dict(real_key())
+        key.update(sm="sm_90", cuda="12.8", image_digest="sha256:gw588")
+        return key
+
+    monkeypatch.setattr(cc, "runtime_key", prod_key)
+
+
+def test_enable_reconciles_vae_only_pipeline_to_off_cell(tmp_path, monkeypatch):
+    """ie#501 run 18: producer minted alone ('off'), serve worker's multi-lane
+    load landed 'vae_only'. Both fully resident — the consumer converges to
+    the cell's traced mode and ARMS instead of starving the w8a8 lane."""
+    _pin_w8a8_identity(monkeypatch)
+    pipe = _resident_pipe("vae_only")
+    pipe.transformer[0]._cozy_w8a8_linear = True
+    pipe.transformer[0].gemm_mode = "rowwise"
+    pipe._cozy_weight_lane = "w8a8"
+    cfg = Compile(shapes=((768, 768),), targets=("transformer",), family="fam")
+    artifact = _resident_cell(
+        tmp_path, pipe, cfg, low_vram_mode="off", weight_lane="w8a8")
+    monkeypatch.setattr(
+        cc, "apply", lambda pipeline, cfg, **kw: kw.get("cache_ready", False))
+
+    assert cc.enable(pipe, cfg, tmp_path / "cache", artifact) is True
+    assert pipe._cozy_low_vram_mode == "off"
+    assert pipe.flags == {
+        "vae_slicing": False, "vae_tiling": False, "attention_slicing": False,
+    }
+
+
+def test_arm_staged_artifact_reconciles_resident_drift(tmp_path, monkeypatch):
+    """Hot adopt: the same resident convergence, no AdoptError."""
+    pipe = _resident_pipe("vae_only")
+    cfg = Compile(shapes=((768, 768),), targets=("transformer",), family="fam")
+    artifact = _resident_cell(tmp_path, pipe, cfg, low_vram_mode="off")
+    monkeypatch.setattr(cc, "apply", lambda *a, **kw: True)
+
+    staged = cc.stage_artifact(artifact, "fam", cache_dir=tmp_path / "cache")
+    meta = cc.arm_staged_artifact(pipe, cfg, staged)
+    assert meta["low_vram_mode"] == "off"
+    assert pipe._cozy_low_vram_mode == "off"
+    assert not any(pipe.flags.values())
+
+
+def test_enable_reconciles_off_pipeline_to_vae_only_cell(tmp_path, monkeypatch):
+    pipe = _resident_pipe("off")
+    cfg = Compile(shapes=((768, 768),), targets=("transformer",), family="fam")
+    artifact = _resident_cell(tmp_path, pipe, cfg, low_vram_mode="vae_only")
+    monkeypatch.setattr(
+        cc, "apply", lambda pipeline, cfg, **kw: kw.get("cache_ready", False))
+
+    assert cc.enable(pipe, cfg, tmp_path / "cache", artifact) is True
+    assert pipe._cozy_low_vram_mode == "vae_only"
+    assert pipe.flags == {
+        "vae_slicing": True, "vae_tiling": True, "attention_slicing": True,
+    }
+
+
+def test_offload_mode_drift_still_refuses(tmp_path, monkeypatch):
+    """model_offload traces genuinely different graphs: enable() on a w8a8
+    lane raises the named refusal; hot adopt classifies key_mismatch."""
+    pipe = _resident_pipe("model_offload")
+    pipe._cozy_weight_lane = "w8a8"
+    cfg = Compile(shapes=((768, 768),), targets=("transformer",), family="fam")
+    artifact = _resident_cell(
+        tmp_path, pipe, cfg, low_vram_mode="off", weight_lane="w8a8")
+    monkeypatch.setattr(
+        cc, "apply", lambda pipeline, cfg, **kw: kw.get("cache_ready", False))
+
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="low_vram_mode"):
+        cc.enable(pipe, cfg, tmp_path / "cache", artifact)
+    assert pipe._cozy_low_vram_mode == "model_offload"
+
+    staged = cc.stage_artifact(artifact, "fam", cache_dir=tmp_path / "cache")
+    with pytest.raises(cc.AdoptError, match="low_vram_mode") as exc:
+        cc.arm_staged_artifact(pipe, cfg, staged)
+    assert exc.value.reason == "key_mismatch"
+    assert pipe._cozy_low_vram_mode == "model_offload"
+
+
+def test_reconcile_resident_mode_unit():
+    from gen_worker.models.memory import reconcile_resident_mode
+
+    # unset current mode: refuse, never stamp
+    pipe = _resident_pipe("")
+    assert reconcile_resident_mode(pipe, "off") is False
+    assert not hasattr(pipe, "_cozy_low_vram_mode")
+
+    # offload current or offload target: refuse, untouched
+    pipe = _resident_pipe("model_offload")
+    assert reconcile_resident_mode(pipe, "off") is False
+    assert pipe._cozy_low_vram_mode == "model_offload"
+    pipe = _resident_pipe("off")
+    assert reconcile_resident_mode(pipe, "group_offload") is False
+    assert pipe._cozy_low_vram_mode == "off"
+
+    # resident <-> resident converges both ways
+    pipe = _resident_pipe("off")
+    assert reconcile_resident_mode(pipe, "vae_only") is True
+    assert pipe._cozy_low_vram_mode == "vae_only"
+    assert all(pipe.flags.values())
+    assert reconcile_resident_mode(pipe, "off") is True
+    assert pipe._cozy_low_vram_mode == "off"
+    assert not any(pipe.flags.values())
+
+    # already converged: True, no-op
+    assert reconcile_resident_mode(pipe, "off") is True

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -398,15 +398,33 @@ def test_endpoint_without_warmup_exposes_no_adopt_target(tmp_path, monkeypatch):
     assert not _events(sent, pb.MODEL_STATE_ADOPTED)
 
 
-def test_adopt_prep_mode_drift_rejected(tmp_path, monkeypatch):
-    """gw#391: the producer's low-VRAM prep mode is part of the graph key — a
-    pipeline prepped under a different mode can only miss, so adoption rejects
-    it deterministically (key_mismatch) before any wrap or warmup."""
+def test_adopt_resident_prep_mode_drift_converges(tmp_path, monkeypatch):
+    """gw#588: 'off' and 'vae_only' are both fully-resident preps — hot adopt
+    converges the pipeline to the cell's traced mode and adopts instead of
+    refusing (ie#501 run 18)."""
     _artifact(tmp_path, low_vram_mode="off")
     spec = _spec()
     ex, sent = _wire_executor(spec, tmp_path)
     obj = ex.store.residency.obj(wire_ref(spec.models["pipeline"]))
     obj._cozy_low_vram_mode = "vae_only"
+    monkeypatch.setattr(cc, "apply", _guarded_apply)
+    _fake_counters(monkeypatch, hits=2, misses=0)
+
+    _adopt(ex)
+    assert len(_events(sent, pb.MODEL_STATE_ADOPTED)) == 1
+    assert not _events(sent, pb.MODEL_STATE_FAILED)
+    assert obj._cozy_low_vram_mode == "off"
+
+
+def test_adopt_offload_prep_mode_drift_rejected(tmp_path, monkeypatch):
+    """gw#391: an offload prep mode traces genuinely different graphs — a
+    pipeline prepped under one can only miss, so adoption still rejects it
+    deterministically (key_mismatch) before any wrap or warmup."""
+    _artifact(tmp_path, low_vram_mode="off")
+    spec = _spec()
+    ex, sent = _wire_executor(spec, tmp_path)
+    obj = ex.store.residency.obj(wire_ref(spec.models["pipeline"]))
+    obj._cozy_low_vram_mode = "model_offload"
     applied: list = []
     monkeypatch.setattr(cc, "apply", lambda *a, **k: applied.append(1) or True)
 
@@ -414,6 +432,7 @@ def test_adopt_prep_mode_drift_rejected(tmp_path, monkeypatch):
     _assert_failed(sent, "adopt_failed:key_mismatch")
     assert not _events(sent, pb.MODEL_STATE_ADOPTED)
     assert not applied  # rejected before the wrap
+    assert obj._cozy_low_vram_mode == "model_offload"
 
 
 def test_adopt_failed_warmup_reports_reason(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ie#501 run 18: producer minted alone on an empty H100 ('off'); the serve worker's multi-lane load landed 'vae_only' — three pods churned on `cell rejected: low_vram_mode 'off' != pipeline 'vae_only'` and the mandatory w8a8 lane starved.
- Both modes are fully-CUDA-resident, differing only in the vae-slicing/vae-tiling/attention-slicing flag groups. New `memory.reconcile_resident_mode(pipeline, want)` flips the three flag groups and restamps; it refuses anything outside {'off','vae_only'} (including an unset mode).
- Both consumer arm paths — `enable()` and `arm_staged_artifact()` (hot adopt) — converge the pipeline to the cell's traced mode before the drift check, inside the already-held `_SEED_ARM_LOCK`. `mode_drift()` itself is untouched; offload-mode drift (model/group/sequential) keeps refusing. Completes gw#581's dynamic-axis design consumer-side.

## Tests
- run-18 scenario: 'vae_only' pipeline + 'off' w8a8 cell arms via `enable()` (revert-turns-red verified), same via `arm_staged_artifact`, reverse direction, offload drift still refuses (named `CompiledLaneUnavailableError` / `AdoptError key_mismatch`), plus `reconcile_resident_mode` unit behavior.
- Updated `test_adopt_prep_mode_drift_rejected` to the new contract: resident drift converges and adopts; offload drift still rejects.
- Full suite: 1445 passed, 37 skipped. mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)