### PR TITLE
gw#589/th#901: cast explicit dtype mismatch on publish_as_is clone strategies

### DIFF
--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -575,6 +575,16 @@ _PUBLISH_AS_IS_STRATEGIES = frozenset({
     "transformers", "peft", "sentence_transformers", "gguf", "native_lora",
     "pipeline_tree", "diffusers_component",
 })
+# th#901: publish_as_is strategies whose weight set is an ordinary dense
+# safetensors tree (not a binary quant container like gguf, and not a
+# mixed-dtype multi-checkpoint bundle like pipeline_tree) — a genuinely
+# mismatched requested dtype is real, in-line-castable work via
+# build_flavor_tree, not something to silently swallow or unconditionally
+# refuse.
+_CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES = frozenset({
+    "transformers", "peft", "sentence_transformers", "native_lora",
+    "diffusers_component",
+})
 _DIRECT_GGUF_ENCODINGS = frozenset({"f32", "f16", "bf16", "q8_0"})
 _DTYPE_STORAGE_BITS = {
     "fp32": 32, "f32": 32, "float32": 32,
@@ -787,6 +797,13 @@ def run_clone(
     tags = normalize_tags(destination_repo_tags)
     layout_hint = str(target_layout or "diffusers").strip().lower() or "diffusers"
     specs = normalize_outputs(outputs, layout_hint=layout_hint)
+    # th#901: normalize_outputs collapses "caller asked for nothing" onto a
+    # schema default (dtype="bf16") — indistinguishable from an EXPLICIT
+    # bf16 request once normalized. Only an explicit request may force a
+    # publish_as_is source through a real conversion; an unspecified request
+    # keeps mirroring the source's own dtype untouched (no cast nobody asked
+    # for).
+    explicit_outputs = bool(outputs)
     effective_hf_token = str(hf_token or "").strip() or str(getattr(ctx, "hf_token", "") or "").strip()
 
     def _progress(p: float, stage: str) -> None:
@@ -909,18 +926,58 @@ def run_clone(
             try:
                 if publish_as_is:
                     source_dtype = str(source.attrs.get("dtype") or "").strip().lower()
-                    if i > 0 or (source_dtype and spec.dtype != source_dtype and spec.dtype != "bf16"):
+                    dtype_matches = (not source_dtype) or spec.dtype == source_dtype
+                    if dtype_matches or not explicit_outputs:
+                        # Already satisfied, OR nobody actually asked for a
+                        # specific dtype (normalize_outputs' schema default
+                        # just landed on bf16) — mirror the source's own
+                        # dtype untouched rather than force a cast nobody
+                        # requested.
+                        tree = source.dir
+                        attrs = dict(source.attrs)
+                        flavor_label = source_dtype or spec.dtype
+                    elif i == 0 and spec.file_type == "safetensors" \
+                            and strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES:
+                        # th#901: an EXPLICITLY mismatched requested dtype is
+                        # real, in-line-castable work for these strategies
+                        # (ordinary dense safetensors trees) —
+                        # build_flavor_tree already knows how to cast a
+                        # single/few-weight-set tree. Never silently
+                        # republish the source's own dtype under the
+                        # requested flavor's label. These strategies publish
+                        # as-is ORGANIZATIONALLY too — no layout repackage is
+                        # attempted here (that stays a separate job) — so the
+                        # cast targets the source's own on-disk layout, only
+                        # the dtype changes.
+                        effective_layout = (
+                            source.layout if source.layout in _KNOWN_FILE_LAYOUTS
+                            else "singlefile"
+                        )
+                        cast_spec = OutputSpec(
+                            dtype=spec.dtype, file_layout=effective_layout,
+                            file_type=spec.file_type,
+                        )
+                        flavor_dir = workdir / f"flavor-{spec.label}"
+                        shutil.rmtree(flavor_dir, ignore_errors=True)
+                        shutil.rmtree(workdir / f"flavor-{spec.label}.__repack__",
+                                      ignore_errors=True)
+                        tree, attrs = build_flavor_tree(
+                            source, cast_spec, flavor_dir,
+                            quantize_components=quantize_components,
+                        )
+                        flavor_label = str(attrs.get("dtype") or spec.dtype)
+                    else:
                         # Only the source's own flavor is published for
-                        # non-diffusers classes (quant runs as a separate job).
-                        if spec.dtype != source_dtype:
-                            raise InlineConversionNotPossible(
-                                reason=f"{strategy} sources publish as-is; "
-                                       f"run a conversion job for {spec.dtype}",
-                                target_dtype=spec.dtype,
-                            )
-                    tree = source.dir
-                    attrs = dict(source.attrs)
-                    flavor_label = source_dtype or spec.dtype
+                        # classes this worker cannot cast in-line (quant/gguf
+                        # containers, mixed-dtype multi-checkpoint bundles —
+                        # those run as a separate job) or for i>0 extra
+                        # specs. Fail loud instead of silently republishing
+                        # under the wrong flavor label.
+                        raise InlineConversionNotPossible(
+                            reason=f"{strategy} sources publish as-is; "
+                                   f"run a conversion job for {spec.dtype}",
+                            target_dtype=spec.dtype,
+                        )
                 else:
                     # Wipe any partial flavor tree from a prior failed run —
                     # only the downloaded source is resumable.

--- a/tests/convert/test_integration.py
+++ b/tests/convert/test_integration.py
@@ -89,6 +89,62 @@ def test_cast_direction_fp16(tiny_llama, tmp_path: Path) -> None:
     assert all(t.dtype == torch.float16 for t in loaded.values() if t.is_floating_point())
 
 
+def test_th901_publish_as_is_mismatched_dtype_runs_real_conversion(
+    tiny_llama, tmp_path: Path, monkeypatch, fake_hub,
+) -> None:
+    """th#901 end-to-end proof: a 'transformers'-strategy source (the same
+    shape as HiDream-O1's UiT backbone) is fp32; requesting bf16 through the
+    real run_clone/publish path must produce a REAL bf16 checkpoint, not
+    silently republish the fp32 source under the bf16 label. This is the
+    live bug's exact reproduction, minus the network-huge weights."""
+    from fake_hub import _FakeHub
+    from gen_worker.convert.clone import run_clone
+    from gen_worker.convert.hub import blake3_file
+
+    class _Ctx:
+        def __init__(self, server) -> None:
+            self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+            self._worker_capability_token = "cap-token"
+            self.owner = "acme"
+            self.request_id = "req-901"
+            self.destination = {"repo": "acme/dest"}
+
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.ingest_huggingface",
+        lambda source_ref, dest_dir, **kwargs: tiny_llama,
+    )
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref=_TINY_LLAMA,
+        destination_repo="acme/dest",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert result.published[0]["flavor"] == "bf16"
+    req = _FakeHub.state["commit_request"]
+    assert req["flavor"] == "bf16" and req["dtype"] == "bf16"
+    weight_op = next(op for op in req["operations"] if op["path"].endswith(".safetensors"))
+    assert weight_op["blake3"] != blake3_file(tiny_llama.dir / "model.safetensors"), (
+        "uploaded blob must differ from the untouched fp32 source — a real cast ran"
+    )
+    # the fake hub actually received PUT bytes for THIS weight's upload_id
+    # (real upload, not a CAS dedup hit against the fp32 source) — load them
+    # and assert the real on-disk dtype.
+    uid = next(
+        u for u, path in _FakeHub.state.get("upload_paths", {}).items()
+        if path == weight_op["path"]
+    )
+    put_bytes = _FakeHub.state.get("put_bytes", {})
+    uploaded = put_bytes[f"/put/{uid}/1"]
+    out = tmp_path / "uploaded.safetensors"
+    out.write_bytes(uploaded)
+    loaded = load_file(str(out))
+    assert all(t.dtype == torch.bfloat16 for t in loaded.values() if t.is_floating_point())
+
+
 def test_ingest_diffusers_pipe(tiny_sdxl) -> None:
     src = tiny_sdxl
     assert src.classification.strategy == "diffusers"

--- a/tests/convert/test_publish_as_is_dtype.py
+++ b/tests/convert/test_publish_as_is_dtype.py
@@ -1,0 +1,209 @@
+"""th#901 regression: a publish_as_is source (single dense weight-set
+strategies — transformers / diffusers_component / peft / sentence_transformers /
+native_lora) must not silently republish its own on-disk dtype when the
+caller explicitly requested a DIFFERENT one.
+
+Live bug (HiDream-O1-Image, ~35GB fp32 UiT backbone, classifies
+strategy="transformers"): `outputs=[{"dtype": "bf16", "file_layout":
+"diffusers"}]` against an fp32 source resolved onto the identical
+pre-existing fp32 checkpoint — no bf16 flavor was ever produced, and no
+error surfaced. Root cause: `run_clone`'s publish_as_is branch special-cased
+`spec.dtype == "bf16"` to skip its own mismatch check, then fell through to
+publishing `source.dir` unchanged under `flavor_label = source_dtype`.
+
+These tests exercise the REAL run_clone orchestration (real fake-tensorhub
+HTTP server, real workdir/lock lifecycle, real commit wire body) — only
+`build_flavor_tree`'s tensor-casting internals (torch/safetensors) are
+stubbed, matching this repo's "no GPU, no weight downloads" unit-test
+convention for decision logic. `tests/convert/test_integration.py` covers a
+real end-to-end cast against a real tiny HF model separately.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gen_worker.convert.clone import run_clone
+from gen_worker.convert.ingest import IngestedSource
+
+from fake_hub import _FakeHub
+
+
+class _Ctx:
+    def __init__(self, server) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+        self.request_id = "req-1"
+        self.destination = {"repo": "acme/fallback"}
+
+
+def _transformers_source(dest_dir: Path, *, dtype: str = "fp32") -> IngestedSource:
+    """A single-root-weight-set 'transformers backbone' source, HiDream-O1's
+    UiT shape: config.json + root safetensors, no model_index.json."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "config.json").write_text('{"architectures": ["FakeBackbone"]}')
+    (dest_dir / "model.safetensors").write_bytes(b"\x00" * 64)
+    return IngestedSource(
+        provider="huggingface",
+        source_ref="org/hidream-like",
+        source_revision="sha-1",
+        dir=dest_dir,
+        layout="singlefile",
+        model_family="hidream",
+        model_family_variant="",
+        classification=SimpleNamespace(strategy="transformers"),
+        attrs={"dtype": dtype, "file_layout": "singlefile"},
+        metadata={"source_provider": "huggingface"},
+        repo_spec={"kind": "model", "library_name": "transformers"},
+    )
+
+
+def _install_fake_ingest(monkeypatch, source: IngestedSource):
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        return source
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+
+def _stub_build_flavor_tree(monkeypatch, calls: list):
+    """Replace the real (torch-backed) cast with a cheap stand-in that still
+    exercises run_clone's real control flow and real commit wire body —
+    proves the DECISION to cast fires, without paying for tensor math."""
+
+    def fake_build_flavor_tree(source, spec, out_dir, *, quantize_components=None):
+        calls.append({
+            "dtype": spec.dtype, "file_layout": spec.file_layout,
+            "file_type": spec.file_type,
+        })
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "model.safetensors").write_bytes(b"\x01" * 32)  # "cast" bytes
+        attrs = {"dtype": spec.dtype, "file_layout": spec.file_layout,
+                 "file_type": spec.file_type}
+        return out_dir, attrs
+
+    monkeypatch.setattr("gen_worker.convert.clone.build_flavor_tree", fake_build_flavor_tree)
+
+
+def test_mismatched_dtype_runs_real_conversion_not_silent_passthrough(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """th#901 core regression: bf16 requested against an fp32 'transformers'
+    source must invoke the cast path and publish flavor=bf16 — never
+    silently republish the fp32 source under the requested label."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    source = _transformers_source(tmp_path / "source", dtype="fp32")
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="org/hidream-like",
+        destination_repo="acme/dest",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(result.published) == 1
+    assert result.published[0]["flavor"] == "bf16"
+    # the cast really ran (not a passthrough of the fp32 tree)
+    assert len(calls) == 1
+    assert calls[0]["dtype"] == "bf16"
+    # organizational layout is never repackaged inline for these strategies —
+    # the cast targets the source's OWN on-disk layout (singlefile), not the
+    # caller's requested "diffusers" layout. The commit is honest about it.
+    assert calls[0]["file_layout"] == "singlefile"
+    req = _FakeHub.state["commit_request"]
+    assert req["flavor"] == "bf16"
+    assert req["dtype"] == "bf16"
+    assert req["file_layout"] == "singlefile"
+
+
+def test_matching_dtype_still_passes_through_without_casting(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """No regression: a request that already matches the source's own dtype
+    is genuinely zero-work and must NOT call build_flavor_tree."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    source = _transformers_source(tmp_path / "source", dtype="fp32")
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="org/hidream-like",
+        destination_repo="acme/dest",
+        outputs=[{"dtype": "fp32", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors
+    assert len(result.published) == 1
+    assert result.published[0]["flavor"] == "fp32"
+    assert calls == []  # no cast attempted — already had it
+
+
+def test_mismatched_dtype_on_gguf_source_fails_loud_not_silent(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """Non-cast-eligible publish_as_is strategies (gguf: binary quant
+    container, not a dense safetensors tree) still refuse a mismatched
+    dtype loudly instead of silently republishing under the wrong label —
+    the th#901 fix must not weaken this existing protection."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    dest = tmp_path / "source"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "model.q4_k_m.gguf").write_bytes(b"\x00" * 32)
+    source = IngestedSource(
+        provider="huggingface", source_ref="org/gguf-src", source_revision="sha-1",
+        dir=dest, layout="singlefile", model_family="", model_family_variant="",
+        classification=SimpleNamespace(strategy="gguf"),
+        attrs={"dtype": "q4_k_m", "file_layout": "singlefile"},
+        metadata={}, repo_spec={},
+    )
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    with pytest.raises(RuntimeError, match="publish as-is"):
+        run_clone(
+            _Ctx(fake_hub), provider="huggingface", source_ref="org/gguf-src",
+            destination_repo="acme/dest",
+            outputs=[{"dtype": "q8_0", "file_layout": "singlefile", "file_type": "gguf"}],
+        )
+
+    assert calls == []  # never silently cast a binary quant container
+
+
+def test_second_spec_on_publish_as_is_source_still_refused(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """i>0 stays refused even for a cast-eligible strategy: only the first
+    (primary) output spec runs inline conversion — extra flavors are still
+    a separate job, unchanged by th#901."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    source = _transformers_source(tmp_path / "source", dtype="fp32")
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="org/hidream-like",
+        destination_repo="acme/dest",
+        outputs=[
+            {"dtype": "fp32", "file_layout": "diffusers", "file_type": "safetensors"},
+            {"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"},
+        ],
+    )
+
+    assert len(result.published) == 1
+    assert result.published[0]["flavor"] == "fp32"
+    assert len(result.failed_flavors) == 1
+    assert result.failed_flavors[0]["dtype"] == "bf16"
+    assert calls == []


### PR DESCRIPTION
## Summary
- `run_clone`'s publish_as_is branch (transformers/diffusers_component/peft/sentence_transformers/native_lora/gguf/pipeline_tree) special-cased `spec.dtype != "bf16"`, making an *explicit* bf16 request indistinguishable from `normalize_outputs`' unspecified-request default. An explicit bf16 ask against a non-bf16 source (HiDream-O1's UiT backbone, strategy="transformers", ships fp32) silently republished the source untouched — no bf16 flavor was ever produced, no error surfaced (th#901).
- Fix: thread `explicit_outputs=bool(outputs)` through `run_clone`. Passthrough (no cast) now only fires when the request already matches the source dtype OR was genuinely unspecified. An explicit mismatch on a cast-eligible dense-safetensors strategy runs a real cast via the existing `build_flavor_tree` machinery (targeting the source's own on-disk layout, so `file_layout` metadata stays honest); any other mismatch still fails loud (`InlineConversionNotPossible`) instead of silently republishing under the wrong label.
- Confirmed NOT a hub-side dedup bug — th#592's download-skip bank (`tensorhub.clone_manifests`) is already a tenant-scoped, output-spec-aware durable ledger with CAS liveness verification; it correctly missed for the never-before-published bf16 flavor. This bug was downstream of that miss.

## Test plan
- [x] `uv run mypy src/gen_worker` clean
- [x] `uv run ruff check` clean on touched files
- [x] `uv run python scripts/lint_http_timeouts.py` clean
- [x] `uv run pytest tests/convert/` — 203 passed / 2 skipped, zero regressions (including the existing fp16-passthrough-on-unspecified-outputs test, which is exactly the "nobody asked for a dtype" case `explicit_outputs` preserves)
- [x] New hermetic decision-logic tests (`tests/convert/test_publish_as_is_dtype.py`): explicit mismatch on castable strategy casts + publishes; matching dtype still passes through with zero cast calls; explicit mismatch on `gguf` (non-castable) still fails loud; `i>0` extra spec still refused
- [x] New real end-to-end proof (`tests/convert/test_integration.py`, network+torch): a real tiny HF `transformers`-strategy fp32 model, requesting bf16 through the real `run_clone`→`build_flavor_tree`→fake-tensorhub commit path, produces genuinely different uploaded bytes that load back as real `torch.bfloat16` tensors
- [ ] `uv run pytest tests/ -q` full suite (running)