### PR TITLE
gw#590: root w8a8 generality — nested multi-set layouts, weight-set selector, pipeline-class key_map hook

### DIFF
--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1137,6 +1137,35 @@ def streaming_fp8_snapshot(
             "components": sorted(done), "output_dir": out_dir}
 
 
+def _nested_weight_sets(d: Path) -> list[tuple[str, Path, tuple[Path, ...]]]:
+    """(rel entry, entry path, member files) per weight set, at the root
+    and under nested dirs (split-checkpoint layouts). entry is the shard
+    index for sharded sets, else the safetensors file; members are the
+    set's on-disk files (index + shards, or the single file). Hidden dirs
+    (``.cache`` download metadata) are skipped."""
+    sets: list[tuple[str, Path, tuple[Path, ...]]] = []
+    dirs = [d] + sorted(
+        p for p in d.rglob("*")
+        if p.is_dir()
+        and not any(part.startswith(".") for part in p.relative_to(d).parts))
+    for sub in dirs:
+        sharded: set[str] = set()
+        for idx in sorted(sub.glob("*.safetensors.index.json")):
+            members: list[Path] = [idx]
+            try:
+                weight_map = json.loads(idx.read_text("utf-8")).get("weight_map") or {}
+            except (OSError, ValueError):
+                continue
+            sharded.update(str(v) for v in weight_map.values())
+            members += [sub / s for s in sorted(set(weight_map.values()))
+                        if (sub / s).is_file()]
+            sets.append((str(idx.relative_to(d)), idx, tuple(members)))
+        for f in sorted(sub.glob("*.safetensors")):
+            if f.is_file() and f.name not in sharded:
+                sets.append((str(f.relative_to(d)), f, (f,)))
+    return sets
+
+
 def streaming_w8a8_snapshot(
     source_dir: Path,
     out_dir: Path,
@@ -1144,6 +1173,7 @@ def streaming_w8a8_snapshot(
     file_layout: str,
     components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
     te_components: tuple[str, ...] = (),
+    weight_set_patterns: tuple[str, ...] = (),
     shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
 ) -> dict[str, Any]:
     """Produce the ``#fp8-w8a8`` flavor of a diffusers snapshot, streaming.
@@ -1156,37 +1186,77 @@ def streaming_w8a8_snapshot(
     the gw#534 corroborating ``quantization_config`` (the safetensors
     headers stay authoritative for detection).
 
-    Non-diffusers layouts (gw#562) require a SINGLE root weight set — the
-    sharded-transformers/singlefile trees the DiffSynth families mirror,
-    where that weight set IS the denoiser. It gets the same requant; no
-    component config exists, so the headers alone carry detection."""
+    Non-diffusers layouts (gw#562) scan the WHOLE tree for weight sets
+    (root and nested — split-checkpoint layouts keep component files under
+    subdirs). Exactly the denoiser set(s) get the requant: a single
+    discovered set is unambiguous; with several, ``weight_set_patterns``
+    (globs over each set's rel entry path) must select — other sets pass
+    through byte-identical, so text encoders/VAEs never grow scale twins
+    (their quantized keys could never resolve in the denoiser at swap
+    time). No component config exists; the headers alone carry
+    detection."""
+    from fnmatch import fnmatch
+
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     if file_layout != "diffusers":
         if te_components:
             raise ConversionImplementationError(
                 "te_components need a diffusers layout (no component "
                 f"identity in {file_layout!r})")
-        root_groups = snapshot_weight_groups(source_dir, file_layout)
-        if len(root_groups) != 1 or root_groups[0][0] != "":
+        sets = _nested_weight_sets(source_dir)
+        if not sets:
             raise ConversionImplementationError(
-                "w8a8 flavors need component identity: a diffusers layout, "
-                "or a single root weight set — found "
-                f"{len(root_groups)} weight set(s) in {file_layout!r} layout")
-        entry = root_groups[0][1]
-        result = streaming_w8a8_cast(
-            entry, out_dir,
-            shard_prefix=_group_shard_prefix(entry),
-            shard_threshold=shard_threshold,
-        )
-        if not int(result["converted_count"]):
+                f"no safetensors weight sets found in {file_layout!r} layout")
+        rels = [rel for rel, _e, _m in sets]
+        if weight_set_patterns:
+            selected = [s for s in sets
+                        if any(fnmatch(s[0], p) for p in weight_set_patterns)]
+            if not selected:
+                raise ConversionImplementationError(
+                    f"weight_set_patterns {list(weight_set_patterns)} match "
+                    f"none of the discovered weight sets {rels}")
+        elif len(sets) == 1:
+            selected = sets
+        else:
             raise ConversionImplementationError(
-                "no w8a8-eligible weights in the root weight set (nothing "
-                "2-D/16-aligned under a repeated-block container missed "
-                "the skip patterns)")
-        copy_non_weight_files(source_dir, out_dir, skip_components={""})
-        return {"tensor_count": int(result["tensor_count"]),
-                "converted_count": int(result["converted_count"]),
-                "components": [""], "output_dir": out_dir}
+                f"{len(sets)} weight sets in {file_layout!r} layout "
+                f"({rels}) — pass weight_set_patterns to select the "
+                "denoiser set(s); the rest pass through byte-identical")
+        tensor_count = converted = 0
+        skip_rel: set[str] = set()
+        for rel, entry, members in selected:
+            result = streaming_w8a8_cast(
+                entry, out_dir / Path(rel).parent,
+                shard_prefix=_group_shard_prefix(entry),
+                shard_threshold=shard_threshold,
+            )
+            tensor_count += int(result["tensor_count"])
+            converted += int(result["converted_count"])
+            skip_rel |= {str(m.relative_to(source_dir)) for m in members}
+        if not converted:
+            raise ConversionImplementationError(
+                "no w8a8-eligible weights in the selected weight set(s) "
+                "(nothing 2-D/16-aligned under a repeated-block container "
+                "missed the skip patterns)")
+        # Passthrough: every other file hardlinks byte-identical (unselected
+        # weight sets dedup against the source mirror in CAS).
+        for f in sorted(source_dir.rglob("*")):
+            if not f.is_file():
+                continue
+            rel_path = f.relative_to(source_dir)
+            if rel_path.parts[:2] == (".cache", "huggingface"):
+                continue
+            if f.name == ".civitai.json" or str(rel_path) in skip_rel:
+                continue
+            _link_or_copy(f, out_dir / rel_path)
+        return {"tensor_count": tensor_count,
+                "converted_count": converted,
+                "components": sorted(rel for rel, _e, _m in selected),
+                "output_dir": out_dir}
+    if weight_set_patterns:
+        raise ConversionImplementationError(
+            "weight_set_patterns applies to non-diffusers layouts only "
+            "(diffusers selection is by component name)")
     denoiser_set, te_set = set(components), set(te_components)
     groups = [(c, e) for c, e in snapshot_weight_groups(source_dir, "diffusers")
               if c in denoiser_set | te_set]
@@ -1297,9 +1367,17 @@ def verify_w8a8_snapshot(
         return where
 
     out_where = _tensor_map(list(art.files))
-    src_where = _tensor_map(sorted(
-        p for p in (source_dir / art.component).glob("*.safetensors")
-        if p.is_file()))
+    if art.component:
+        src_files = sorted(
+            p for p in (source_dir / art.component).glob("*.safetensors")
+            if p.is_file())
+    else:
+        # Root layout: nested split-checkpoint trees carry the weight sets
+        # under subdirs — reuse the detector's own file discovery.
+        from gen_worker.models.w8a8 import _root_weight_files
+
+        src_files = [p for p in _root_weight_files(source_dir) if p.is_file()]
+    src_where = _tensor_map(src_files)
 
     names = list(art.quantized)
     rng = random.Random(seed)

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -104,17 +104,26 @@ def _quantized_layers(files: tuple[Path, ...]) -> tuple[tuple[str, ...], bool]:
 
 
 def _root_weight_files(d: Path) -> tuple[Path, ...]:
-    """Root weight set: index-mapped shards plus loose safetensors."""
-    sharded: set[str] = set()
-    for idx in sorted(d.glob("*.safetensors.index.json")):
-        try:
-            weight_map = json.loads(idx.read_text("utf-8")).get("weight_map") or {}
-            sharded.update(str(v) for v in weight_map.values())
-        except (OSError, ValueError):
-            continue
-    files = [d / s for s in sorted(sharded) if (d / s).is_file()]
-    files += [p for p in sorted(d.glob("*.safetensors"))
-              if p.is_file() and p.name not in sharded]
+    """Root weight set: index-mapped shards plus loose safetensors, at the
+    root and under nested dirs (split-checkpoint layouts keep component
+    files under subdirs). Hidden dirs (``.cache`` download metadata) are
+    skipped."""
+    dirs = [d] + sorted(
+        p for p in d.rglob("*")
+        if p.is_dir()
+        and not any(part.startswith(".") for part in p.relative_to(d).parts))
+    files: list[Path] = []
+    for sub in dirs:
+        sharded: set[str] = set()
+        for idx in sorted(sub.glob("*.safetensors.index.json")):
+            try:
+                weight_map = json.loads(idx.read_text("utf-8")).get("weight_map") or {}
+                sharded.update(str(v) for v in weight_map.values())
+            except (OSError, ValueError):
+                continue
+        files += [sub / s for s in sorted(sharded) if (sub / s).is_file()]
+        files += [p for p in sorted(sub.glob("*.safetensors"))
+                  if p.is_file() and p.name not in sharded]
     return tuple(dict.fromkeys(files))
 
 
@@ -733,16 +742,22 @@ def load_w8a8_root_pipeline(
     """Serve a root-layout w8a8 snapshot through the pipeline class's own
     ``from_pretrained`` (which must sanitize — see module docstring), then
     swap the denoiser's quantized Linears onto scaled_mm when the host
-    qualifies. Stamps ``_cozy_weight_lane`` like the diffusers lane."""
+    qualifies. Stamps ``_cozy_weight_lane`` like the diffusers lane.
+
+    Converter-renamed families declare ``_cozy_w8a8_key_map`` on the
+    pipeline class (a ``staticmethod`` mapping an artifact layer name to
+    its module path) — forwarded to :func:`swap_w8a8_linears`."""
     import torch
 
     compute = compute_dtype or torch.bfloat16
     mode = w8a8_gemm_mode() or "dequant"
     pipe = cls.from_pretrained(str(path), torch_dtype=compute)
     denoiser = _root_denoiser(pipe)
+    key_map = (getattr(pipe, "_cozy_w8a8_key_map", None)
+               or getattr(cls, "_cozy_w8a8_key_map", None))
     if mode != "dequant":
         if not swap_w8a8_linears(denoiser, art, compute_dtype=compute,
-                                 gemm_mode=mode):
+                                 key_map=key_map, gemm_mode=mode):
             raise W8a8SnapshotError(
                 "scaled_mm host but no quantized Linear swapped — artifact "
                 f"keys do not match {type(denoiser).__name__} modules")

--- a/tests/test_w8a8_root.py
+++ b/tests/test_w8a8_root.py
@@ -120,7 +120,7 @@ def source_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def w8a8_root(source_root: Path) -> Path:
     out = source_root.parent / "w8a8"
     result = streaming_w8a8_snapshot(source_root, out, file_layout="singlefile")
-    assert result["components"] == [""]
+    assert result["components"] == ["model.safetensors"]
     return out
 
 
@@ -240,6 +240,98 @@ def test_swap_with_key_map_reaches_renamed_modules(
         model, art, compute_dtype=torch.bfloat16,
         key_map=lambda k: k[len("net."):])
     assert swapped == len(_QUANTIZED_LAYERS)
+
+
+class _TinyNestedPipeline:
+    """Split-checkpoint-shaped (anima class): DiT under a nested dir with a
+    converter-renamed (``net.``-prefixed) key space, a second passthrough
+    weight set beside it. Declares the swap key_map on the class."""
+
+    _cozy_w8a8_key_map = staticmethod(lambda k: k[len("net."):])
+
+    def __init__(self) -> None:
+        self.transformer: nn.Module | None = None
+
+    @classmethod
+    def from_pretrained(cls, path: str, torch_dtype=None, **_) -> "_TinyNestedPipeline":
+        dtype = torch_dtype or torch.bfloat16
+        dit_file = next(Path(path).rglob("dit.safetensors"))
+        sd = sanitize_w8a8_state_dict(load_file(str(dit_file)), dtype)
+        sd = {k[len("net."):]: v.to(dtype) for k, v in sd.items()}
+        model = _TinyDiT()
+        model.load_state_dict(sd, assign=True)
+        model.eval()
+        pipe = cls()
+        pipe.transformer = model
+        return pipe
+
+
+def _nested_source(tmp_path: Path) -> Path:
+    torch.manual_seed(11)
+    src = tmp_path / "nested-src"
+    (src / "models" / "dit").mkdir(parents=True)
+    (src / "models" / "te").mkdir(parents=True)
+    dit_sd = {f"net.{k}": v.detach().to(torch.bfloat16).contiguous()
+              for k, v in _TinyDiT().state_dict().items()}
+    save_file(dit_sd, str(src / "models" / "dit" / "dit.safetensors"))
+    # The passthrough set ALSO carries w8a8-eligible-looking tensors
+    # (repeated-block 2-D 16-aligned) — the ambiguity the selector exists for.
+    te_sd = {
+        "model.layers.0.mlp.up.weight":
+            torch.randn(64, 32, dtype=torch.bfloat16),
+        "model.layers.1.mlp.up.weight":
+            torch.randn(64, 32, dtype=torch.bfloat16),
+    }
+    save_file(te_sd, str(src / "models" / "te" / "te.safetensors"))
+    (src / "config.json").write_text(json.dumps({"model_type": "tiny_split"}))
+    return src
+
+
+def test_nested_multiset_needs_selector_and_passes_rest_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    src = _nested_source(tmp_path)
+    with pytest.raises(ConversionImplementationError, match="weight_set_patterns"):
+        streaming_w8a8_snapshot(src, tmp_path / "o1", file_layout="singlefile")
+    with pytest.raises(ConversionImplementationError, match="match none"):
+        streaming_w8a8_snapshot(
+            src, tmp_path / "o2", file_layout="singlefile",
+            weight_set_patterns=("nope/*",))
+
+    out = tmp_path / "w8a8"
+    result = streaming_w8a8_snapshot(
+        src, out, file_layout="singlefile",
+        weight_set_patterns=("models/dit/*",))
+    assert result["components"] == ["models/dit/dit.safetensors"]
+
+    # Selected set requanted in place (rel dir preserved), TE byte-identical.
+    te_src = (src / "models" / "te" / "te.safetensors").read_bytes()
+    te_out = (out / "models" / "te" / "te.safetensors").read_bytes()
+    assert te_out == te_src
+    assert (out / "config.json").exists()
+
+    art = detect_w8a8_artifact(out)
+    assert art is not None and art.component == ""
+    assert art.quantized == tuple(f"net.{n}" for n in _QUANTIZED_LAYERS)
+    verify_w8a8_snapshot(src, out)
+
+    # Serve: worker constructs via the class loader, swaps through the
+    # class-declared key_map hook (module surgery is device-agnostic).
+    monkeypatch.setattr(w8a8, "w8a8_gemm_mode", lambda: "rowwise")
+    pipe = load_from_pretrained(_TinyNestedPipeline, out)
+    assert pipe._cozy_weight_lane == "w8a8"
+    lin_cls = fp8_scaled_linear_class()
+    for layer in _QUANTIZED_LAYERS:
+        assert isinstance(pipe.transformer.get_submodule(layer), lin_cls), layer
+    assert type(pipe.transformer.patch_embed) is nn.Linear
+
+
+def test_diffusers_layout_refuses_weight_set_patterns(tmp_path: Path) -> None:
+    (tmp_path / "model_index.json").write_text("{}")
+    with pytest.raises(ConversionImplementationError, match="non-diffusers"):
+        streaming_w8a8_snapshot(
+            tmp_path, tmp_path / "o", file_layout="diffusers",
+            weight_set_patterns=("x/*",))
 
 
 def test_sanitize_passes_scale_free_dicts_through(source_root: Path) -> None:


### PR DESCRIPTION
gw#562's root w8a8 lane assumed a single root-level weight set. Split-checkpoint mirrors (comfy layouts) nest several weight sets under subdirs, and more than one can carry w8a8-eligible tensors (a qwen3-class TE has ~196), so the denoiser identity must be explicit.

Three nameless mechanisms (model-specific data flows from the conversion invoke / the endpoint, never this repo):

- `streaming_w8a8_snapshot` (non-diffusers): recursive weight-set discovery; `weight_set_patterns` globs select the denoiser set(s) (required when >1 set exists, fail-loud otherwise); unselected sets hardlink through byte-identical so they CAS-dedup against the source mirror and never grow scale twins.
- `detect_w8a8_artifact` / `verify_w8a8_snapshot`: root lane scans nested dirs the same way.
- `load_w8a8_root_pipeline`: forwards a pipeline-class-declared `_cozy_w8a8_key_map` (staticmethod) into the existing `swap_w8a8_linears(key_map=)` for converter-renamed families (e.g. a DiffSynth converter that strips a checkpoint prefix).

Tests: tests/test_w8a8_root.py grows a nested/multi-set + selector + passthrough + key_map-hook round trip (producer -> detect -> byte-gate -> construct -> swap). Full suite 1446 passed / 37 skipped; mypy 123 files clean; ruff clean.

Consumer halves: te#102 (cast_dtype passthrough field), ie#519 (anima endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)