### PR TITLE
gw#540: W4A4 nvfp4 serve lane — blockwise fp4 scaled_mm on Blackwell (nvfp4-w4a4)

### DIFF
--- a/scripts/w4a4_parity.py
+++ b/scripts/w4a4_parity.py
@@ -1,0 +1,223 @@
+"""W4A4 quality-parity + speed harness (gw#540).
+
+Same-seed renders of ONE model on the current GPU across lanes:
+  bf16  — plain bf16-resident (the quality reference)
+  w8a8  — data-free fp8-w8a8 artifact on torch._scaled_mm (gw#534 lane)
+  w4a4  — data-free nvfp4-w4a4 artifact on blockwise fp4 scaled_mm
+
+Reports pixel deltas (MAE/PSNR, + LPIPS when installed) vs bf16, denoise
+wall per lane (eager and, with --compiled, regional-compiled), and the
+denoiser's resident VRAM per lane (expect ~quarter of bf16 on w4a4).
+Proves the SERVE path — calibrated production artifacts + the degradation
+gate are the conversion side's (te#79/te#80).
+
+Run on a rented SECURE Blackwell pod (never a dev box):
+  uv run python scripts/w4a4_parity.py --model black-forest-labs/FLUX.2-klein-4B \
+      --steps 8 --size 1024 --compiled --out /tmp/parity
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import time
+from pathlib import Path
+
+
+def _mae_psnr(a, b):
+    import numpy as np
+
+    a = a.astype("float32") / 255.0
+    b = b.astype("float32") / 255.0
+    mae = float(np.abs(a - b).mean())
+    mse = float(((a - b) ** 2).mean())
+    psnr = float("inf") if mse == 0 else 10.0 * float(np.log10(1.0 / mse))
+    return mae, psnr
+
+
+def _lpips(a, b):
+    try:
+        import lpips
+        import numpy as np
+        import torch
+    except ImportError:
+        return None
+    loss = lpips.LPIPS(net="alex", verbose=False).cuda()
+
+    def t(x):
+        v = torch.from_numpy(np.asarray(x)).float().permute(2, 0, 1) / 127.5 - 1.0
+        return v.unsqueeze(0).cuda()
+
+    with torch.no_grad():
+        return float(loss(t(a), t(b)).item())
+
+
+def _denoiser(pipe):
+    for name in ("transformer", "unet"):
+        mod = getattr(pipe, name, None)
+        if mod is not None:
+            return mod
+    raise SystemExit("pipeline has no transformer/unet")
+
+
+def _module_bytes(mod) -> int:
+    seen, total = set(), 0
+    for t in list(mod.parameters()) + list(mod.buffers()):
+        if t.data_ptr() not in seen:
+            seen.add(t.data_ptr())
+            total += t.numel() * t.element_size()
+    return total
+
+
+def _render(pipe, *, prompt: str, seed: int, steps: int, size: int):
+    import numpy as np
+    import torch
+
+    if callable(getattr(pipe, "set_progress_bar_config", None)):
+        pipe.set_progress_bar_config(disable=True)
+    kwargs = dict(prompt=prompt, num_inference_steps=steps,
+                  width=size, height=size,
+                  generator=torch.Generator(device="cuda").manual_seed(seed))
+    pipe(**{**kwargs, "num_inference_steps": 1})  # warmup (allocs, autotune)
+    torch.cuda.synchronize()
+    t0 = time.monotonic()
+    image = pipe(**kwargs).images[0]
+    torch.cuda.synchronize()
+    wall = time.monotonic() - t0
+    return np.asarray(image.convert("RGB")), wall
+
+
+def _compiled_wall(pipe, *, prompt: str, seed: int, steps: int, size: int):
+    """Regional compile (ie#381's prod serve mode) timing for the same call."""
+    import torch
+
+    den = _denoiser(pipe)
+    if not callable(getattr(den, "compile_repeated_blocks", None)):
+        print("denoiser has no compile_repeated_blocks; skipping compiled arm")
+        return None
+    den.compile_repeated_blocks(fullgraph=True)
+    kwargs = dict(prompt=prompt, num_inference_steps=steps,
+                  width=size, height=size,
+                  generator=torch.Generator(device="cuda").manual_seed(seed))
+    for _ in range(2):  # compile + settle
+        pipe(**{**kwargs, "num_inference_steps": 2})
+    torch.cuda.synchronize()
+    t0 = time.monotonic()
+    pipe(**kwargs)
+    torch.cuda.synchronize()
+    return time.monotonic() - t0
+
+
+def _free(pipe):
+    import torch
+
+    del pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="HF repo id or local diffusers tree")
+    ap.add_argument("--out", default="/tmp/w4a4-parity")
+    ap.add_argument("--steps", type=int, default=8)
+    ap.add_argument("--size", type=int, default=1024)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--prompt", default=(
+        "a photo of a red fox standing in a snowy forest clearing, golden hour"))
+    ap.add_argument("--lanes", default="bf16,w8a8,w4a4")
+    ap.add_argument("--compiled", action="store_true",
+                    help="also time each lane under regional compile")
+    args = ap.parse_args()
+
+    import torch
+    from diffusers import DiffusionPipeline
+
+    from gen_worker.models.loading import load_from_pretrained
+    from gen_worker.models.w4a4 import quantize_tree_w4a4, w4a4_gemm_mode
+    from gen_worker.models.w8a8 import quantize_tree_w8a8, w8a8_gemm_mode
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    src = Path(args.model)
+    if not src.is_dir():
+        from huggingface_hub import snapshot_download
+
+        src = Path(snapshot_download(args.model))
+    print(f"snapshot: {src}")
+    print(f"w8a8_gemm_mode: {w8a8_gemm_mode()!r}  w4a4_gemm_mode: {w4a4_gemm_mode()!r}")
+
+    lanes = [x.strip() for x in args.lanes.split(",") if x.strip()]
+    images: dict = {}
+    walls: dict = {}
+    compiled_walls: dict = {}
+    denoiser_gb: dict = {}
+
+    for lane in lanes:
+        print(f"--- lane {lane}")
+        if lane == "bf16":
+            pipe = DiffusionPipeline.from_pretrained(
+                str(src), torch_dtype=torch.bfloat16)
+        elif lane in ("w8a8", "w4a4"):
+            tree = out / f"{lane}-tree"
+            if not tree.exists():
+                (quantize_tree_w8a8 if lane == "w8a8"
+                 else quantize_tree_w4a4)(src, tree)
+            pipe = load_from_pretrained(DiffusionPipeline, tree)
+            lane_attr = getattr(pipe, "_cozy_weight_lane", "")
+            print(f"{lane} weight lane: {lane_attr!r}")
+            assert lane_attr == lane, f"{lane} scaled_mm lane did not engage"
+        else:
+            raise SystemExit(f"unknown lane {lane}")
+        pipe.to("cuda")
+        denoiser_gb[lane] = round(_module_bytes(_denoiser(pipe)) / 2**30, 3)
+        print(f"{lane} denoiser resident: {denoiser_gb[lane]} GiB")
+        img, wall = _render(pipe, prompt=args.prompt, seed=args.seed,
+                            steps=args.steps, size=args.size)
+        images[lane] = img
+        walls[lane] = wall
+        from PIL import Image
+
+        Image.fromarray(img).save(out / f"{lane}.png")
+        print(f"{lane} eager: {wall:.2f}s for {args.steps} steps "
+              f"({wall / args.steps * 1000:.0f} ms/step)")
+        if args.compiled:
+            cw = _compiled_wall(pipe, prompt=args.prompt, seed=args.seed,
+                                steps=args.steps, size=args.size)
+            if cw is not None:
+                compiled_walls[lane] = cw
+                print(f"{lane} compiled: {cw:.2f}s "
+                      f"({cw / args.steps * 1000:.0f} ms/step)")
+        _free(pipe)
+
+    report: dict = {"model": args.model, "steps": args.steps, "size": args.size,
+                    "seed": args.seed, "walls_s": walls,
+                    "compiled_walls_s": compiled_walls,
+                    "denoiser_resident_gib": denoiser_gb, "deltas": {}}
+    ref = images.get("bf16")
+    for lane, img in images.items():
+        if ref is None or lane == "bf16":
+            continue
+        mae, psnr = _mae_psnr(ref, img)
+        d = {"mae": round(mae, 5), "psnr_db": round(psnr, 2)}
+        lp = _lpips(ref, img)
+        if lp is not None:
+            d["lpips"] = round(lp, 4)
+        report["deltas"][lane] = d
+        print(f"{lane} vs bf16: {d}")
+    for a, b in (("w8a8", "w4a4"), ("bf16", "w4a4")):
+        if a in walls and b in walls:
+            key = f"speedup_{b}_vs_{a}_eager"
+            report[key] = round(walls[a] / walls[b], 3)
+            print(f"{key}: {report[key]}x")
+        if a in compiled_walls and b in compiled_walls:
+            key = f"speedup_{b}_vs_{a}_compiled"
+            report[key] = round(compiled_walls[a] / compiled_walls[b], 3)
+            print(f"{key}: {report[key]}x")
+    (out / "report.json").write_text(json.dumps(report, indent=2))
+    print(f"report: {out / 'report.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -180,7 +180,8 @@ def lane_token(weight_lane: str) -> str:
     ``w8a16-lora32``, ``lora32`` -> ``lora32`` — one graph family per
     (base lane, rank bucket)."""
     base, bucket = lane_bucket(str(weight_lane or ""))
-    tok = {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8"}.get(base, base)
+    tok = {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8",
+           "w4a4": "w4a4"}.get(base, base)
     if bucket:
         return f"{tok}-lora{bucket}" if tok else f"lora{bucket}"
     return tok
@@ -198,7 +199,7 @@ def compile_target_lane_error(weight_lane: str, lora_bucket: int) -> str:
     lane = str(weight_lane or "")
     declared = int(lora_bucket or 0)
     base, observed = lane_bucket(lane)
-    if base not in ("", "fp8-hooks", "w8a16", "w8a8"):
+    if base not in ("", "fp8-hooks", "w8a16", "w8a8", "w4a4"):
         return f"unsupported pipeline_weight_lane {lane!r}"
     from .models.w8a8_lora import RANK_BUCKETS
 
@@ -909,6 +910,15 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
                 else:
                     row["activation"] = "dynamic-per-row"
                 quantized.append(row)
+            elif bool(getattr(module, "_cozy_w4a4_linear", False)):
+                # gw#540: block scales are always dynamic per-16-block; the
+                # graph property is the second-level activation scale mode.
+                row["activation"] = (
+                    "static" if getattr(module, "input_scale", None)
+                    is not None else "dynamic-per-tensor")
+                if getattr(module, "pre_quant_scale", None) is not None:
+                    row["pre_quant_scale"] = True
+                quantized.append(row)
             else:
                 row["type"] = _type_name(module)
                 excluded.append(row)
@@ -924,12 +934,15 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
 
     lane = pipeline_weight_lane(pipeline)
     weight_contract: Dict[str, Any] = {"lane": lane}
-    if lane.startswith("w8a8"):
+    if lane.startswith(("w8a8", "w4a4")):
         activations = sorted({str(r["activation"]) for r in quantized})
         weight_contract.update({
-            "artifact_schema": "fp8-w8a8-v1",
+            "artifact_schema": (
+                "nvfp4-w4a4-v1" if lane.startswith("w4a4") else "fp8-w8a8-v1"),
             "operator": "torch._scaled_mm",
-            "weight_scaling": "per-output-channel",
+            "weight_scaling": (
+                "per-16-block+per-tensor" if lane.startswith("w4a4")
+                else "per-output-channel"),
             "activation_scaling": activations,
             "quantized": sorted(quantized, key=lambda r: str(r["path"])),
             "excluded": sorted(excluded, key=lambda r: str(r["path"])),
@@ -1012,8 +1025,8 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     meta_weights = meta.get("weight_contract") or {}
     if not meta_signature and not meta_weights and not str(
         weight_contract.get("lane") or ""
-    ).startswith("w8a8"):
-        return ""  # legacy format-2 non-W8A8 cell
+    ).startswith(("w8a8", "w4a4")):
+        return ""  # legacy format-2 non-quantized-lane cell
     if meta_signature != signature:
         return (
             f"module graph signature: cell {meta_signature[:12]!r} != "
@@ -1024,15 +1037,24 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
             "weight-lane artifact schema/exclusion manifest mismatch: "
             + _first_contract_difference(meta_weights, weight_contract)
         )
-    if str(weight_contract.get("lane") or "").startswith("w8a8"):
+    cell_lane_base = str(weight_contract.get("lane") or "")
+    if cell_lane_base.startswith(("w8a8", "w4a4")):
         activations = weight_contract.get("activation_scaling") or []
-        # DYNAMIC only, one homogeneous granularity per graph (gw#564:
-        # per-row = rowwise sm_90+, per-tensor = the sm_89 epilogue lane).
-        if activations not in (["dynamic-per-row"], ["dynamic-per-tensor"]):
-            return (f"W8A8 activation scaling must be dynamic "
-                    f"(per-row or per-tensor), got {activations!r}")
+        if cell_lane_base.startswith("w8a8"):
+            # DYNAMIC only, one homogeneous granularity per graph (gw#564:
+            # per-row = rowwise sm_90+, per-tensor = the sm_89 epilogue lane).
+            if activations not in (["dynamic-per-row"], ["dynamic-per-tensor"]):
+                return (f"W8A8 activation scaling must be dynamic "
+                        f"(per-row or per-tensor), got {activations!r}")
+        else:
+            # gw#540: one homogeneous second-level activation scale mode per
+            # graph (static = calibrated input_scale, the production mode).
+            if activations not in (["static"], ["dynamic-per-tensor"]):
+                return (f"W4A4 activation scaling must be homogeneous "
+                        f"static or dynamic-per-tensor, got {activations!r}")
         if not weight_contract.get("quantized"):
-            return "W8A8 graph contains no torch._scaled_mm modules"
+            return (f"{cell_lane_base[:4].upper()} graph contains no "
+                    "torch._scaled_mm modules")
         here_digest = runtime_key()["image_digest"]
         # cuda_driver excluded (gw#577): host-lottery axis, see verify().
         for field in ("sm", "cuda", "image_digest"):
@@ -1043,7 +1065,7 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
                     # always carry WORKER_IMAGE_DIGEST, so fleet cells stay
                     # fully pinned.
                     continue
-                return f"W8A8 cell missing {field} identity"
+                return f"quantized-lane cell missing {field} identity"
     return ""
 
 
@@ -1307,7 +1329,7 @@ def apply(
     regional = bool(getattr(cfg, "regional", False))
     from .models.loading import pipeline_weight_lane
 
-    fail_closed = pipeline_weight_lane(pipeline).startswith("w8a8")
+    fail_closed = pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
     failure_signal: Dict[str, Any] = {
         "callback": None,
         "lock": threading.Lock(),
@@ -1584,12 +1606,15 @@ def enable(
                 )
             from .models.loading import pipeline_weight_lane
 
-            if pipeline_weight_lane(pipeline).startswith("w8a8") and not armed:
+            quant_lane = pipeline_weight_lane(pipeline)
+            if quant_lane.startswith(("w8a8", "w4a4")) and not armed:
                 if meta is not None:
                     refusal = "verified cell armed no compile target"
+                lane_name = quant_lane[:4].upper()
                 raise CompiledLaneUnavailableError(
-                    f"W8A8 requires an exact compatible Forge cell ({refusal}); "
-                    "eager/dequantized execution is not a W8A8 production lane"
+                    f"{lane_name} requires an exact compatible Forge cell "
+                    f"({refusal}); eager/dequantized execution is not a "
+                    f"{lane_name} production lane"
                 )
             return armed
     finally:
@@ -1739,7 +1764,8 @@ def build(
         "serving image's immutable OCI digest); a cell stamped with the "
         "producer image identity can never be adopted by the fleet"
     )
-    if "w8a8" in str(storage_dtype) and not str(serving_image_digest).strip():
+    if (("w8a8" in str(storage_dtype) or "w4a4" in str(storage_dtype))
+            and not str(serving_image_digest).strip()):
         # gw#577 finding (b): contract_drift requires image_digest identity on
         # W8A8 cells and verify() pins it exactly. Without the SERVING digest
         # the artifact stamps the PRODUCER pod's WORKER_IMAGE_DIGEST — every
@@ -1787,10 +1813,10 @@ def build(
     placed = place_pipeline(pipe)
     from .models.loading import pipeline_weight_lane as _traced_lane
 
-    if _traced_lane(pipe).startswith("w8a8") and not str(
+    if _traced_lane(pipe).startswith(("w8a8", "w4a4")) and not str(
         serving_image_digest
     ).strip():
-        # The lane can materialize as w8a8 from the SOURCE flavor alone
+        # The lane can materialize as w8a8/w4a4 from the SOURCE flavor alone
         # (e.g. storage_dtype="fp8+te" over an fp8-w8a8 checkpoint), so the
         # authoritative check is on the traced lane, before the compile.
         raise RuntimeError(_W8A8_MINT_NEEDS_DIGEST)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -385,11 +385,16 @@ def _snapshot_to_resolved(snap: pb.Snapshot) -> "WorkerResolvedRepo":
     )
 
 
+#: Traced weight lanes a stored flavor MANDATES (fail-closed serving):
+#: `#fp8-w8a8` -> "w8a8" (gw#534), `#nvfp4-w4a4` -> "w4a4" (gw#540).
+_MANDATORY_LANES = ("w8a8", "w4a4")
+
+
 def _cell_lane_matches(
     ref: str,
     family: str,
     *,
-    wants_w8a8: bool,
+    want_lane: str,
     want_bucket: int,
     candidate_keys: typing.AbstractSet[str] = frozenset(),
 ) -> bool:
@@ -410,21 +415,37 @@ def _cell_lane_matches(
     base, bucket = compile_cache.lane_bucket(compile_cache.cell_lane(ref))
     if bucket != int(want_bucket or 0):
         return False
-    return base == "w8a8" if wants_w8a8 else base != "w8a8"
+    if want_lane:
+        return base == want_lane
+    return base not in _MANDATORY_LANES
 
 
-def _ref_wants_w8a8(ref: str) -> bool:
-    """Whether one canonical Tensorhub model ref selects a W8A8 flavor."""
+def _ref_mandatory_lane(ref: str) -> str:
+    """The traced weight lane one canonical Tensorhub model ref MANDATES:
+    "w8a8" for `#fp8-w8a8` flavors, "w4a4" for `#nvfp4-w4a4`, "" otherwise."""
     from .models.refs import parse_model_ref
 
     try:
         parsed = parse_model_ref(ref).tensorhub
     except ValueError:
-        return False
+        return ""
     if parsed is None or parsed.owner == "_system":
-        return False
+        return ""
     flavor = parsed.flavor or ""
-    return flavor == "fp8-w8a8" or flavor.startswith("fp8-w8a8-")
+    if flavor == "fp8-w8a8" or flavor.startswith("fp8-w8a8-"):
+        return "w8a8"
+    if flavor == "nvfp4-w4a4" or flavor.startswith("nvfp4-w4a4-"):
+        return "w4a4"
+    return ""
+
+
+def _mandatory_lane_of(refs: typing.Iterable[str]) -> str:
+    """The single mandatory lane a binding set selects ("" when none)."""
+    for ref in refs:
+        lane = _ref_mandatory_lane(ref)
+        if lane:
+            return lane
+    return ""
 
 
 def _model_failure_vocab(exc: BaseException) -> str:
@@ -2077,14 +2098,15 @@ class Executor:
             target.active_compile_ref = ""
             target.active_compile_snapshot_digest = ""
             target.active_adoption_operation_id = ""
-            mandatory_w8a8 = target.pipeline_weight_lane.startswith("w8a8")
-            if mandatory_w8a8:
+            mandatory_quant = target.pipeline_weight_lane.startswith(
+                _MANDATORY_LANES)
+            if mandatory_quant:
                 # Keep the same incarnation visible with an empty active
                 # identity until declarative reconciliation replaces it.
                 # RequiredCompileExecution then fails closed locally while
                 # Tensorhub can correlate the causal FAILED to this row.
                 rec.stale = True
-        if mandatory_w8a8:
+        if mandatory_quant:
             self._mark_compile_target_unavailable(rec, target, detail)
         logger.warning(
             "compile target %s runtime guard tripped; compiled proof revoked: %s",
@@ -2237,9 +2259,8 @@ class Executor:
             else _CompileObjectCandidate(item, set(all_slots))
             for item in objects
         ]
-        requested_w8a8 = any(
-            _ref_wants_w8a8(wire_ref(spec.models[slot]))
-            for slot in self._setup_slots(spec)
+        requested_lane = _mandatory_lane_of(
+            wire_ref(spec.models[slot]) for slot in self._setup_slots(spec)
         )
         active_artifacts = active_artifacts or {}
         function_proofs = function_proofs or {}
@@ -2314,16 +2335,18 @@ class Executor:
             expected_names = compatible_names & required_names
             target.function_names = tuple(sorted(
                 compatible_names & permitted_names))
-            mandatory_w8a8 = target.pipeline_weight_lane.startswith("w8a8")
-            candidate_requested_w8a8 = any(
-                _ref_wants_w8a8(ref) for _slot, ref, _digest in bindings
-            )
+            target_quant_lane = next(
+                (lane for lane in _MANDATORY_LANES
+                 if target.pipeline_weight_lane.startswith(lane)), "")
+            candidate_requested_lane = _mandatory_lane_of(
+                ref for _slot, ref, _digest in bindings)
+            mandatory_quant = bool(target_quant_lane)
             if (
-                (mandatory_w8a8 or candidate_requested_w8a8)
+                (mandatory_quant or candidate_requested_lane)
                 and set(target.function_names) != expected_names
             ):
                 raise compile_cache.CompiledLaneUnavailableError(
-                    "mandatory W8A8 function proof incomplete "
+                    "mandatory quantized-lane function proof incomplete "
                     f"(expected={sorted(expected_names)!r} "
                     f"proven={list(target.function_names)!r})"
                 )
@@ -2336,21 +2359,23 @@ class Executor:
                 logger.warning(
                     "compile target omitted for %s: %s", spec.name, detail,
                 )
-                if mandatory_w8a8 or candidate_requested_w8a8:
+                if mandatory_quant or candidate_requested_lane:
                     raise compile_cache.CompiledLaneUnavailableError(detail)
                 continue
             lane_error = compile_cache.compile_target_lane_error(
                 target.pipeline_weight_lane, target.lora_bucket)
             if lane_error:
-                if mandatory_w8a8 or candidate_requested_w8a8:
+                if mandatory_quant or candidate_requested_lane:
                     raise compile_cache.CompiledLaneUnavailableError(lane_error)
                 logger.warning(
                     "compile target omitted for %s: %s", spec.name, lane_error)
                 continue
-            if candidate_requested_w8a8 and not mandatory_w8a8:
+            if (candidate_requested_lane
+                    and target_quant_lane != candidate_requested_lane):
                 raise compile_cache.CompiledLaneUnavailableError(
-                    f"W8A8 binding for {spec.name!r} materialized a non-W8A8 "
-                    f"pipeline lane {target.pipeline_weight_lane!r}"
+                    f"{candidate_requested_lane.upper()} binding for "
+                    f"{spec.name!r} materialized pipeline lane "
+                    f"{target.pipeline_weight_lane!r}"
                 )
             active_ref = active_selection.ref if active_selection else ""
             active_digest = (
@@ -2362,13 +2387,13 @@ class Executor:
                     spec.name, active_ref, active_digest,
                 )
                 continue
-            if mandatory_w8a8 and not active_ref:
-                # A W8A8 object without a proven exact cell is not a READY
-                # serving target. The loader normally raises earlier; keep
-                # this final wire-state invariant fail closed too.
+            if mandatory_quant and not active_ref:
+                # A quantized-lane object without a proven exact cell is not
+                # a READY serving target. The loader normally raises earlier;
+                # keep this final wire-state invariant fail closed too.
                 raise compile_cache.CompiledLaneUnavailableError(
-                    f"W8A8 compile target for {spec.name!r} has no proven "
-                    "active Forge artifact"
+                    f"{target_quant_lane.upper()} compile target for "
+                    f"{spec.name!r} has no proven active Forge artifact"
                 )
             with target.state_lock:
                 target.active_compile_ref = active_ref
@@ -2381,19 +2406,19 @@ class Executor:
                 with target.state_lock:
                     target.active_compile_ref = ""
                     target.active_compile_snapshot_digest = ""
-                if mandatory_w8a8:
+                if mandatory_quant:
                     raise compile_cache.CompiledLaneUnavailableError(
-                        f"W8A8 compile target for {spec.name!r} has no "
-                        "runtime guard revocation signal"
+                        f"{target_quant_lane.upper()} compile target for "
+                        f"{spec.name!r} has no runtime guard revocation signal"
                     )
                 logger.warning(
                     "compile target %s has no runtime guard revocation signal; "
                     "advertising eager", incarnation_id,
                 )
-        if requested_w8a8 and not rec.compile_targets:
+        if requested_lane and not rec.compile_targets:
             raise compile_cache.CompiledLaneUnavailableError(
-                f"W8A8 setup for {spec.name!r} produced no addressable "
-                "compile-capable pipeline target"
+                f"{requested_lane.upper()} setup for {spec.name!r} produced "
+                "no addressable compile-capable pipeline target"
             )
 
     def compile_targets(self) -> List[pb.CompileTarget]:
@@ -2455,11 +2480,10 @@ class Executor:
                 if cfg is None or not family:
                     continue
                 bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
-                wants_w8a8 = any(
-                    _ref_wants_w8a8(wire_ref(binding))
-                    for binding in spec.models.values()
+                want_lane = _mandatory_lane_of(
+                    wire_ref(binding) for binding in spec.models.values()
                 )
-                lanes = ("w8a8",) if wants_w8a8 else ("", "fp8-hooks")
+                lanes = (want_lane,) if want_lane else ("", "fp8-hooks")
                 for lane in lanes:
                     try:
                         digest = cell_key.compute(
@@ -2497,15 +2521,14 @@ class Executor:
         than execute on a merely same-family pipeline.
         """
         setup_slots = self._setup_slots(spec)
-        wants_w8a8 = any(
-            _ref_wants_w8a8(wire_ref(spec.models[slot]))
-            for slot in setup_slots
+        want_lane = _mandatory_lane_of(
+            wire_ref(spec.models[slot]) for slot in setup_slots
         )
         if not run.HasField("required_compile"):
-            if wants_w8a8:
+            if want_lane:
                 raise RetryableError(
-                    "required_compile_missing: W8A8 dispatch requires an "
-                    "exact active compile incarnation"
+                    f"required_compile_missing: {want_lane.upper()} dispatch "
+                    "requires an exact active compile incarnation"
                 )
             return
         required = run.required_compile
@@ -2536,10 +2559,11 @@ class Executor:
                 target.contract_digest,
             )
             target_bindings = target.model_bindings
-        if wants_w8a8 and not target_lane.startswith("w8a8"):
+        if want_lane and not target_lane.startswith(want_lane):
             raise RetryableError(
-                "required_compile_lane_mismatch: W8A8 dispatch selected a "
-                "non-W8A8 live pipeline"
+                f"required_compile_lane_mismatch: {want_lane.upper()} "
+                "dispatch selected a live pipeline on lane "
+                f"{target_lane!r}"
             )
         if spec.name not in target_functions:
             raise RetryableError(
@@ -2838,8 +2862,8 @@ class Executor:
                         rec.stale = True
                         break
             if rec.ready and not rec.stale and spec.compile is not None:
-                mandatory_w8a8 = any(
-                    _ref_wants_w8a8(wire_ref(spec.models[slot]))
+                mandatory_lane = _mandatory_lane_of(
+                    wire_ref(spec.models[slot])
                     for slot in self._setup_slots(spec)
                 )
                 from . import compile_cache
@@ -2848,7 +2872,7 @@ class Executor:
                     desired_cell = await self._fetch_compile_snapshot(
                         spec, snapshots)
                 except compile_cache.CompiledLaneUnavailableError as exc:
-                    if mandatory_w8a8:
+                    if mandatory_lane:
                         # Desired state no longer supplies a mandatory exact
                         # cell. Remove the old READY incarnation before
                         # reporting the state-driven failure; it must not keep
@@ -3304,8 +3328,9 @@ class Executor:
                 if unproven:
                     from .models.loading import pipeline_weight_lane
 
-                    w8a8 = any(
-                        pipeline_weight_lane(candidate.pipeline).startswith("w8a8")
+                    quant_lane = any(
+                        pipeline_weight_lane(
+                            candidate.pipeline).startswith(_MANDATORY_LANES)
                         for candidate in unproven
                     )
                     for candidate in unproven:
@@ -3321,7 +3346,7 @@ class Executor:
                         f"(warmups={warmed}, cache_hits={hits}, "
                         f"cache_misses={misses})"
                     )
-                    if w8a8:
+                    if quant_lane:
                         raise compile_cache.CompiledLaneUnavailableError(detail)
                     logger.warning("%s; serving eager", detail)
             if compile_selection and trt_engine.is_engine_ref(compile_selection.ref):
@@ -3995,7 +4020,7 @@ class Executor:
         # checkpoints. Snapshot maps also contain attached cells and may carry
         # unrelated/prepositioned models, so they must not choose the lane.
         model_refs = [wire_ref(binding) for binding in spec.models.values()]
-        wants_w8a8 = any(_ref_wants_w8a8(ref) for ref in model_refs)
+        want_lane = _mandatory_lane_of(model_refs)
         want_bucket = int(getattr(spec.compile, "lora_bucket", 0) or 0)
         # th#883 pull-by-key: a key-flavored cell is selected only when its
         # key is one this runtime computed for itself (the same candidates
@@ -4003,7 +4028,7 @@ class Executor:
         from . import cell_key
 
         candidate_keys: set[str] = set()
-        for lane in (("w8a8",) if wants_w8a8 else ("", "fp8-hooks")):
+        for lane in ((want_lane,) if want_lane else ("", "fp8-hooks")):
             try:
                 candidate_keys.add(cell_key.compute(
                     family, lane, want_bucket,
@@ -4011,14 +4036,14 @@ class Executor:
                 ).digest)
             except Exception:
                 continue
-        if wants_w8a8:
+        if want_lane:
             # TensorRT cells currently expose only their plain fp16 contract.
-            # The existing Forge's -w8a8 Inductor cell is the sole artifact
-            # proven to preserve Fp8ScaledLinear/torch._scaled_mm semantics.
+            # A Forge Inductor cell of the mandated lane is the sole artifact
+            # proven to preserve the scaled_mm semantics (gw#534/gw#540).
             candidates = [
                 (ref, snap) for ref, snap in snapshots.items()
                 if _cell_lane_matches(
-                    ref, family, wants_w8a8=True, want_bucket=want_bucket,
+                    ref, family, want_lane=want_lane, want_bucket=want_bucket,
                     candidate_keys=candidate_keys)
             ]
         else:
@@ -4029,7 +4054,7 @@ class Executor:
             inductor_candidates = [
                 (ref, snap) for ref, snap in snapshots.items()
                 if _cell_lane_matches(
-                    ref, family, wants_w8a8=False, want_bucket=want_bucket,
+                    ref, family, want_lane="", want_bucket=want_bucket,
                     candidate_keys=candidate_keys)
             ]
             # Explicit kind policy, then uniqueness within that kind. A map's
@@ -4037,20 +4062,20 @@ class Executor:
             # measured plain-lane TRT preference remains intact.
             candidates = trt_candidates or inductor_candidates
         candidates = sorted(candidates, key=lambda item: item[0])
-        if wants_w8a8 and not candidates:
+        if want_lane and not candidates:
             raise compile_cache.CompiledLaneUnavailableError(
-                f"no exact W8A8 Forge cell attached for family={family!r} "
-                f"lora_bucket={want_bucket}"
+                f"no exact {want_lane.upper()} Forge cell attached for "
+                f"family={family!r} lora_bucket={want_bucket}"
             )
         if len(candidates) > 1:
             refs = ", ".join(ref for ref, _snap in candidates)
             detail = (
                 "multiple compatible compiled artifacts were attached for "
-                f"family={family!r} lane={'w8a8' if wants_w8a8 else 'plain'}: "
+                f"family={family!r} lane={want_lane or 'plain'}: "
                 f"{refs}; refusing map-order selection"
             )
-            if wants_w8a8:
-                # W8A8 has no eager-compatible fallback: setup's mandatory
+            if want_lane:
+                # Mandated lanes have no eager-compatible fallback: setup's
                 # lane gate must surface this as retryable before GPU load.
                 raise compile_cache.CompiledLaneUnavailableError(detail)
             logger.warning("%s; serving eager", detail)
@@ -4060,7 +4085,7 @@ class Executor:
             digest = str(snap.digest or "").strip()
             if not digest:
                 detail = f"compiled-artifact snapshot {ref!r} has no immutable digest"
-                if wants_w8a8:
+                if want_lane:
                     raise compile_cache.CompiledLaneUnavailableError(detail)
                 logger.warning("%s; serving eager", detail)
                 return None
@@ -4068,9 +4093,10 @@ class Executor:
                 local = await self.store.ensure_local(ref, snap)
                 artifact = compile_cache.find_artifact(local)
                 if artifact is None:
-                    if wants_w8a8:
+                    if want_lane:
                         raise compile_cache.CompiledLaneUnavailableError(
-                            f"W8A8 Forge snapshot {ref!r} contains no artifact")
+                            f"{want_lane.upper()} Forge snapshot {ref!r} "
+                            "contains no artifact")
                     logger.warning(
                         "compiled-artifact snapshot %s contains no artifact; "
                         "serving eager", ref)
@@ -4078,13 +4104,14 @@ class Executor:
                 return _CompileArtifactSelection(
                     path=artifact, ref=ref, snapshot_digest=digest)
             except Exception as exc:
-                if wants_w8a8 and isinstance(
+                if want_lane and isinstance(
                     exc, compile_cache.CompiledLaneUnavailableError
                 ):
                     raise
-                if wants_w8a8:
+                if want_lane:
                     raise compile_cache.CompiledLaneUnavailableError(
-                        f"W8A8 Forge snapshot {ref!r} is unusable: {exc}") from exc
+                        f"{want_lane.upper()} Forge snapshot {ref!r} is "
+                        f"unusable: {exc}") from exc
                 logger.warning(
                     "compiled-artifact snapshot %s unusable (%s); serving eager", ref, exc
                 )
@@ -4331,9 +4358,10 @@ class Executor:
                         ))
                         from .models.loading import pipeline_weight_lane
 
-                        if pipeline_weight_lane(pipe).startswith("w8a8"):
-                            # W8A8 stays fail-closed: surface as the
-                            # retryable lane refusal, cause preserved.
+                        if pipeline_weight_lane(pipe).startswith(
+                                _MANDATORY_LANES):
+                            # Quantized lanes stay fail-closed: surface as
+                            # the retryable lane refusal, cause preserved.
                             raise compile_cache.CompiledLaneUnavailableError(
                                 f"cell_selection_bug: {exc}") from exc
                         armed = False

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -230,17 +230,18 @@ def _mint(pipe: Any, cfg: Any, target: Path, family: str) -> Path:
 
 
 def _fail_closed(pipe: Any, reason: str) -> bool:
-    """The production w8a8 policy re-asserted at the local exits: a w8a8
-    pipeline never silently serves the slow eager GEMM path — when the local
-    mint cannot produce a cell either, the refusal stays TYPED (the same
-    CompiledLaneUnavailableError the executor maps). Plain lanes keep the
-    gw#555 never-raise miss policy (eager)."""
+    """The production quantized-lane policy re-asserted at the local exits:
+    a w8a8/w4a4 pipeline never silently serves the slow eager GEMM path —
+    when the local mint cannot produce a cell either, the refusal stays
+    TYPED (the same CompiledLaneUnavailableError the executor maps). Plain
+    lanes keep the gw#555 never-raise miss policy (eager)."""
     from .models.loading import pipeline_weight_lane
 
-    if pipeline_weight_lane(pipe).startswith("w8a8"):
+    lane = pipeline_weight_lane(pipe)
+    if lane.startswith(("w8a8", "w4a4")):
         raise cc.CompiledLaneUnavailableError(
-            f"W8A8 requires a compile cell and the local mint is "
-            f"unavailable ({reason})")
+            f"{lane[:4].upper()} requires a compile cell and the local mint "
+            f"is unavailable ({reason})")
     return False
 
 
@@ -305,7 +306,7 @@ def enable_compiled(
                 _say(f"local-cells: cell_selection_bug: {exc}")
                 reason = f"cell_selection_bug: {exc}"
             except cc.CompiledLaneUnavailableError:
-                reason = "seed/arm failed (w8a8 fail-closed)"
+                reason = "seed/arm failed (quantized-lane fail-closed)"
         _say(f"local-cells: stored cell no longer matches ({reason}); re-minting")
 
     if not cc.toolchain_present():

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -28,6 +28,10 @@ CLASS_FP8 = "fp8"  # fp8-E4M3 storage; universal (bf16-upcast path needs no fp8 
 CLASS_SVDQ_FP4 = "svdq-fp4"  # nunchaku SVDQuant fp4 — consumer Blackwell only
 CLASS_SVDQ_INT4 = "svdq-int4"  # nunchaku SVDQuant int4 — sm_75-89
 CLASS_NVFP4 = "nvfp4"  # plain nvfp4 artifact — Blackwell datacenter, TRT lane (not a diffusers rung)
+# Calibrated nvfp4 with two-level scales (gw#540): torch fp4 blockwise
+# scaled_mm serve lane. Blackwell-only (sm_100+ incl. sm_120 consumer) —
+# no fp4 silicon below, and the 4x dequant blow-up erases the fit story.
+CLASS_NVFP4_W4A4 = "nvfp4-w4a4"
 
 _BASE_TOKENS = ("", "bf16", "fp16", "fp32")
 
@@ -61,6 +65,8 @@ def classify_flavor_token(flavor: str) -> str:
         return CLASS_SVDQ_INT4
     if token == "fp8" or token.startswith("fp8-"):
         return CLASS_FP8
+    if token == "nvfp4-w4a4" or token.startswith("nvfp4-w4a4-"):
+        return CLASS_NVFP4_W4A4
     if token == "nvfp4" or token.startswith("nvfp4-"):
         return CLASS_NVFP4
     return ""
@@ -77,6 +83,8 @@ def default_placement(precision_class: str) -> Optional[Placement]:
         return Placement(CLASS_SVDQ_FP4, sm_allowed=tuple(SVDQ_FP4_SMS), engines=("nunchaku",))
     if precision_class == CLASS_SVDQ_INT4:
         return Placement(CLASS_SVDQ_INT4, sm_allowed=tuple(SVDQ_INT4_SMS), engines=("nunchaku",))
+    if precision_class == CLASS_NVFP4_W4A4:
+        return Placement(CLASS_NVFP4_W4A4, sm_min=100)
     if precision_class == CLASS_NVFP4:
         return Placement(CLASS_NVFP4, sm_min=100)
     return None
@@ -139,6 +147,7 @@ __all__ = [
     "CLASS_BASE",
     "CLASS_FP8",
     "CLASS_NVFP4",
+    "CLASS_NVFP4_W4A4",
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
     "EMERGENCY_NF4_VRAM_FACTOR",

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1184,6 +1184,38 @@ def load_from_pretrained(
             components=components,
             fp8_text_encoders=storage_dtype == "fp8+te",
         )
+    # W4A4 nvfp4 flavors (gw#540): packed fp4 weights WITH two-level scales
+    # take the blockwise fp4 scaled_mm lane on Blackwell (sm_100+); other
+    # qualifying hosts dequant once to bf16-resident. Disjoint from w8a8
+    # detection (uint8 vs e4m3 weights) and from scale-free trees.
+    from .w4a4 import (
+        detect_w4a4_artifact,
+        load_w4a4_pipeline,
+        load_w4a4_root_pipeline,
+    )
+
+    w4a4_art = detect_w4a4_artifact(Path(path))
+    if w4a4_art is not None and callable(getattr(cls, "from_pretrained", None)):
+        compute = None
+        if dtype:
+            try:
+                compute = get_torch_dtype(dtype)
+            except ImportError:
+                pass
+        if storage_dtype == "fp8+te":
+            logger.warning(
+                "storage_dtype=fp8+te ignored on the w4a4 lane (gw#540 v1: "
+                "denoiser-only quantization)")
+        if not w4a4_art.component:
+            if components:
+                logger.warning(
+                    "preloaded components ignored on the root w4a4 lane")
+            return load_w4a4_root_pipeline(
+                cls, Path(path), w4a4_art, compute_dtype=compute)
+        return load_w4a4_pipeline(
+            cls, Path(path), w4a4_art, compute_dtype=compute,
+            components=components,
+        )
     gguf_art = detect_gguf_snapshot(Path(path))
     if gguf_art is not None and callable(getattr(cls, "from_pretrained", None)):
         gguf_file, qtype = gguf_art

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -203,8 +203,11 @@ def cast_e2m1(t: Any) -> Any:
 
 def pack_e2m1(codes: Any) -> Any:
     """[..., K] nibble codes -> [..., K/2] packed uint8 (element 2j in the
-    LOW nibble — torch.float4_e2m1fn_x2 / modelopt convention)."""
-    return (codes[..., 1::2] << 4) | codes[..., 0::2]
+    LOW nibble — torch.float4_e2m1fn_x2 / modelopt convention). Explicitly
+    contiguous: cuBLASLt refuses strided fp4 operands
+    (CUBLAS_STATUS_NOT_SUPPORTED, found live on B200), and TensorIterator
+    may propagate the slice strides into the packed output."""
+    return ((codes[..., 1::2] << 4) | codes[..., 0::2]).contiguous()
 
 
 def unpack_e2m1(packed: Any) -> Any:

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -1,0 +1,919 @@
+"""W4A4 nvfp4 loader mode (gw#540) — the gw#534 W8A8 pattern one tier down.
+
+A ``#nvfp4-w4a4`` flavor is a normal diffusers tree whose denoiser holds
+calibrated nvfp4 weights WITH two-level scales — the artifact contract
+(frozen in gw#540, consumed verbatim by the conversion side):
+
+- per quantized Linear ``L`` (modelopt export_hf_checkpoint shapes):
+  ``L.weight`` (uint8 [out, in/2]: packed e2m1 nibble pairs, element 2j in
+  the LOW nibble — torch.float4_e2m1fn_x2 convention), ``L.weight_scale``
+  (float8_e4m3fn [out, in/16]: per-16-block scales, FLAT row-major),
+  ``L.weight_scale_2`` (float32 scalar per-tensor second-level scale),
+  optional ``L.input_scale`` (float32 scalar static activation second-level
+  scale — nvfp4 calibrates unconditionally, te#80), optional
+  ``L.pre_quant_scale`` (float [in], AWQ-lite smoothing: x *= it before
+  activation quant), ``L.bias`` unquantized;
+- excluded layers carry NO scale tensors — detection is per-layer by the
+  (uint8 weight + e4m3 weight_scale + weight_scale_2) triple, never by name
+  lists. The triple also disambiguates from w8a8 (whose weight IS e4m3).
+
+Dequant: W ≈ e2m1(weight) * weight_scale.float() * weight_scale_2.
+
+Execution: quantized Linears become :class:`W4A4Linear` — blockwise
+``torch._scaled_mm`` over RESIDENT packed fp4 weights (Blackwell fp4 tensor
+cores, ~2x the fp8 rate: 4378 TFLOPS / 3.07x bf16 measured on B200, gw#540
+DP1). Activations are quantized per call: static per-tensor second-level
+scale from calibration (dynamic amax fallback), per-16-block e4m3 scales
+computed dynamically. torch's blockwise scaled_mm consumes scales in the
+cuBLAS 2-D tiled ("blocked") layout — weight scales are swizzled ONCE at
+load, activation scales per call (a reshape/permute that fuses under
+inductor). SM >= 100 only (sm_100/103 datacenter + sm_120/121 consumer
+Blackwell); the hub never schedules the flavor below that. Hosts of a
+qualifying arch whose kernel probe, micro-benchmark, or numerics self-check
+fails DEQUANT once at load into plain bf16-resident weights — same
+numerics, no speed win, never a refusal.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import json
+import logging
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+W4A4_FLAVOR = "nvfp4-w4a4"
+# Blackwell fp4 tensor cores: sm_100/103 (B200/B300) + sm_120/121 (RTX 50xx).
+W4A4_MIN_SM = 100
+_E2M1_MAX = 6.0
+_FP8_MAX = 448.0
+_SCALE_MIN = 2.0 ** -9  # e4m3 underflow guard (modelopt clamp)
+_BLOCK = 16
+# torch fp4 scaled_mm operand checks: packed K/2 % 16 == 0 and both mat2
+# dims % 16 == 0 => in_features % 32 == 0, out_features % 16 == 0.
+_K_ALIGN = 32
+_N_ALIGN = 16
+_MAX_HEADER_BYTES = 100 << 20
+_COMPONENT_DIRS = ("transformer", "unet")
+_AUX_SUFFIXES = (".weight_scale", ".weight_scale_2", ".input_scale",
+                 ".pre_quant_scale")
+
+
+class W4a4Error(RuntimeError):
+    """Typed w4a4 loader-mode failure."""
+
+
+class W4a4SnapshotError(W4a4Error):
+    """The flavor snapshot violates the artifact contract."""
+
+
+@dataclass(frozen=True)
+class W4a4Artifact:
+    # Denoiser dir name ("transformer"/"unet") for diffusers trees; "" for a
+    # root-layout snapshot whose weight set IS the denoiser (gw#562).
+    component: str
+    files: tuple[Path, ...]
+    quantized: tuple[str, ...]  # module names with the contract triple
+    static_input_scales: bool
+
+
+def _read_header(path: Path) -> dict:
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(8)
+            if len(raw) < 8:
+                return {}
+            (n,) = struct.unpack("<Q", raw)
+            if n <= 0 or n > _MAX_HEADER_BYTES:
+                return {}
+            header = json.loads(f.read(n))
+    except (OSError, ValueError):
+        return {}
+    return header if isinstance(header, dict) else {}
+
+
+def _quantized_layers(files: tuple[Path, ...]) -> tuple[tuple[str, ...], bool]:
+    dtypes: Dict[str, str] = {}
+    for f in files:
+        for name, info in _read_header(f).items():
+            if isinstance(info, dict) and "dtype" in info:
+                dtypes[name] = str(info["dtype"])
+    quantized = tuple(sorted(
+        key[: -len(".weight_scale_2")]
+        for key in dtypes
+        if key.endswith(".weight_scale_2")
+        and dtypes.get(key[: -len(".weight_scale_2")] + ".weight") == "U8"
+        and dtypes.get(
+            key[: -len(".weight_scale_2")] + ".weight_scale") == "F8_E4M3"
+    ))
+    static = any(f"{n}.input_scale" in dtypes for n in quantized)
+    return quantized, static
+
+
+def _root_weight_files(d: Path) -> tuple[Path, ...]:
+    sharded: set[str] = set()
+    for idx in sorted(d.glob("*.safetensors.index.json")):
+        try:
+            weight_map = json.loads(idx.read_text("utf-8")).get("weight_map") or {}
+            sharded.update(str(v) for v in weight_map.values())
+        except (OSError, ValueError):
+            continue
+    files = [d / s for s in sorted(sharded) if (d / s).is_file()]
+    files += [p for p in sorted(d.glob("*.safetensors"))
+              if p.is_file() and p.name not in sharded]
+    return tuple(dict.fromkeys(files))
+
+
+def detect_w4a4_artifact(model_path: Path) -> Optional[W4a4Artifact]:
+    """Header-sniff a snapshot for the w4a4 contract triple. A w8a8 tree
+    (e4m3 weights) or a scale-free tree never matches. Cheap: header reads
+    only."""
+    root = Path(model_path)
+    if not root.is_dir():
+        return None
+    if (root / "model_index.json").exists():
+        for comp in _COMPONENT_DIRS:
+            comp_dir = root / comp
+            if not comp_dir.is_dir():
+                continue
+            files = tuple(sorted(
+                p for p in comp_dir.glob("*.safetensors") if p.is_file()))
+            if not files:
+                continue
+            quantized, static = _quantized_layers(files)
+            if quantized:
+                return W4a4Artifact(
+                    component=comp, files=files, quantized=quantized,
+                    static_input_scales=static,
+                )
+        return None
+    files = _root_weight_files(root)
+    if files:
+        quantized, static = _quantized_layers(files)
+        if quantized:
+            return W4a4Artifact(
+                component="", files=files, quantized=quantized,
+                static_input_scales=static,
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# e2m1 quantize/dequantize + the cuBLAS blocked-scale swizzle (pure torch —
+# used by the producer, the dequant lane, and W4A4Linear's activation quant).
+# ---------------------------------------------------------------------------
+
+
+def _e2m1_lut(device: Any) -> Any:
+    import torch
+
+    return torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device=device, dtype=torch.float32)
+
+
+def _e2m1_bounds(device: Any) -> Any:
+    import torch
+
+    return torch.tensor(
+        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
+        device=device, dtype=torch.float32)
+
+
+def cast_e2m1(t: Any) -> Any:
+    """Float tensor -> e2m1 nibble codes (uint8, values 0-15). Round-to-
+    nearest with ties at the odd bounds (0.75/1.75/2.5) rounding UP —
+    byte-identical to modelopt's NVFP4QTensor._cast_fp4."""
+    import torch
+
+    v = t.float()
+    sign = (v < 0).to(torch.uint8)
+    a = v.abs()
+    ord_ = torch.searchsorted(
+        _e2m1_bounds(v.device), a.contiguous(), out_int32=True).to(torch.uint8)
+    tie = ((a == 0.75) | (a == 1.75) | (a == 2.5)).to(torch.uint8)
+    return (sign << 3) + ord_ + tie
+
+
+def pack_e2m1(codes: Any) -> Any:
+    """[..., K] nibble codes -> [..., K/2] packed uint8 (element 2j in the
+    LOW nibble — torch.float4_e2m1fn_x2 / modelopt convention)."""
+    return (codes[..., 1::2] << 4) | codes[..., 0::2]
+
+
+def unpack_e2m1(packed: Any) -> Any:
+    """[..., K/2] packed uint8 -> [..., K] float32 e2m1 values."""
+    import torch
+
+    lut = _e2m1_lut(packed.device)
+    shape = list(packed.shape)
+    shape[-1] = shape[-1] * 2
+    out = torch.empty(shape, dtype=torch.float32, device=packed.device)
+    out[..., 0::2] = lut[(packed & 0x0F).long()]
+    out[..., 1::2] = lut[(packed >> 4).long()]
+    return out
+
+
+def to_blocked_scales(scales: Any) -> Any:
+    """Flat per-block scales [rows, k_blocks] (e4m3) -> the cuBLAS 2-D tiled
+    layout torch's blockwise scaled_mm consumes: rows padded to 128, block
+    columns padded to 4, 128x4 tiles rearranged (32, 4, 4) — returned as a
+    contiguous 1-D e4m3 tensor (the kernel checks numel + contiguity only).
+    Same rearrangement as modelopt's swizzle_nvfp4_scales / torchao's
+    to_blocked."""
+    import torch
+
+    rows, cols = scales.shape
+    nrb = (rows + 127) // 128
+    ncb = (cols + 3) // 4
+    # fp8 has no pad/zeros kernels everywhere — swizzle a uint8 view.
+    raw = scales.view(torch.uint8)
+    padded = raw.new_zeros(nrb * 128, ncb * 4)
+    padded[:rows, :cols] = raw
+    blocks = padded.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
+    out = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1)
+    return out.contiguous().view(torch.float8_e4m3fn)
+
+
+def quantize_nvfp4_tensor(w: Any) -> tuple[Any, Any, Any]:
+    """Quantize a 2-D float tensor to the contract triple:
+    (packed uint8 [out, in/2], weight_scale e4m3 [out, in/16],
+    weight_scale_2 fp32 scalar). modelopt-identical math."""
+    import torch
+
+    wf = w.float()
+    out_f, in_f = wf.shape
+    ws2 = (wf.abs().amax() / (_E2M1_MAX * _FP8_MAX)).clamp(min=1e-12)
+    blocks = wf.reshape(out_f, in_f // _BLOCK, _BLOCK)
+    bmax = blocks.abs().amax(dim=-1)
+    bs = bmax / (_E2M1_MAX * ws2)
+    bs[bs == 0] = 1.0
+    bs_fp8 = bs.clamp(min=_SCALE_MIN, max=_FP8_MAX).to(torch.float8_e4m3fn)
+    q = blocks / (bs_fp8.float().unsqueeze(-1) * ws2)
+    codes = cast_e2m1(q.reshape(out_f, in_f))
+    return pack_e2m1(codes), bs_fp8, ws2
+
+
+def dequantize_nvfp4_tensor(packed: Any, weight_scale: Any,
+                            weight_scale_2: Any) -> Any:
+    """Contract triple -> float32 [out, in]. The dequant-lane inverse of
+    :func:`quantize_nvfp4_tensor` (and of the modelopt export)."""
+    vals = unpack_e2m1(packed)
+    out_f, in_f = vals.shape
+    scales = weight_scale.float().reshape(out_f, in_f // _BLOCK, 1)
+    return (vals.reshape(out_f, in_f // _BLOCK, _BLOCK)
+            * scales * weight_scale_2.float()).reshape(out_f, in_f)
+
+
+# ---------------------------------------------------------------------------
+# Device qualification: kernel probe + numerics self-check + micro-benchmark.
+# ---------------------------------------------------------------------------
+
+
+def _fp4_dtype() -> Any:
+    import torch
+
+    return getattr(torch, "float4_e2m1fn_x2", None)
+
+
+def _gemm_w4a4(xq: Any, wq: Any, sa_blocked: Any, sb_blocked: Any,
+               out_dtype: Any) -> Any:
+    import torch
+
+    fp4 = _fp4_dtype()
+    return torch._scaled_mm(
+        xq.view(fp4), wq.view(fp4).t(), scale_a=sa_blocked,
+        scale_b=sb_blocked, out_dtype=out_dtype)
+
+
+def _numerics_ok() -> bool:
+    """Quantize a real probe pair, run the blocked-layout scaled_mm, and
+    compare against the dequant fp32 reference. torch 2.13's operator
+    validates only scale NUMEL — a wrong layout returns silent garbage, so
+    the lane arms only when the kernel's numerics match our swizzle."""
+    import torch
+
+    m, k, n = 128, 256, 128
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device="cuda")
+    w = torch.randn(n, k, device="cuda")
+    xq, xs, xs2 = quantize_nvfp4_tensor(x)
+    wq, ws, ws2 = quantize_nvfp4_tensor(w)
+    try:
+        y = _gemm_w4a4(xq, wq, to_blocked_scales(xs), to_blocked_scales(ws),
+                       torch.bfloat16)
+    except Exception as exc:  # noqa: BLE001 — any kernel gap => dequant lane
+        logger.warning("w4a4: blockwise scaled_mm probe failed (%s)", exc)
+        return False
+    y = y.float() * (xs2 * ws2)
+    ref = dequantize_nvfp4_tensor(xq, xs, xs2) @ dequantize_nvfp4_tensor(
+        wq, ws, ws2).t()
+    rel = ((y - ref).norm() / ref.norm().clamp(min=1e-9)).item()
+    ok = rel < 2e-2  # identical quantized operands; bf16 accumulation only
+    if not ok:
+        logger.warning(
+            "w4a4: scaled_mm numerics self-check failed (rel err %.4f) — "
+            "scale-layout mismatch on this stack; dequant lane", rel)
+    return ok
+
+
+_BENCH_DIM = 4096
+_BENCH_WARMUP = 3
+_BENCH_ITERS = 10
+# fp4 must beat the bf16 GEMM by a real margin to arm (B200 measured 3.07x;
+# a fallback/emulated path measures well under 1).
+_BENCH_MIN_SPEEDUP = 1.10
+
+
+def _median_ms(fn: Any) -> float:
+    import torch
+
+    for _ in range(_BENCH_WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(_BENCH_ITERS):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times.append(start.elapsed_time(end))
+    times.sort()
+    return times[len(times) // 2]
+
+
+def _gemm_profitable() -> bool:
+    import torch
+
+    m = n = k = _BENCH_DIM
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    xq = torch.randint(0, 255, (m, k // 2), device="cuda", dtype=torch.uint8)
+    wq = torch.randint(0, 255, (n, k // 2), device="cuda", dtype=torch.uint8)
+    ones = torch.ones(m, k // _BLOCK, device="cuda")
+    sa = to_blocked_scales(ones.to(torch.float8_e4m3fn))
+    sb = to_blocked_scales(torch.ones(
+        n, k // _BLOCK, device="cuda").to(torch.float8_e4m3fn))
+
+    def fp4_op() -> Any:
+        return _gemm_w4a4(xq, wq, sa, sb, torch.bfloat16) * 1.0
+
+    def bf16_op() -> Any:
+        return x @ w.t()
+
+    fp4_ms, bf16_ms = _median_ms(fp4_op), _median_ms(bf16_op)
+    speedup = bf16_ms / max(fp4_ms, 1e-9)
+    logger.info(
+        "w4a4 gemm gate: fp4=%.3fms bf16=%.3fms speedup=%.2fx (min %.2fx)",
+        fp4_ms, bf16_ms, speedup, _BENCH_MIN_SPEEDUP)
+    return speedup >= _BENCH_MIN_SPEEDUP
+
+
+@functools.lru_cache(maxsize=1)
+def w4a4_gemm_mode() -> str:
+    """The fp4 GEMM dispatch for THIS device, chosen once per process:
+    ``"blockwise"`` or ``""`` (dequant lane). Arms only when the arch
+    qualifies (sm >= 100), the fp4 dtype + kernel exist, the numerics
+    self-check passes (scale-layout truth), and the micro-benchmark beats
+    bf16 — probe-pass != profitable (the gw#564 lesson)."""
+    try:
+        import torch
+    except ImportError:
+        return ""
+    if not torch.cuda.is_available() or _fp4_dtype() is None:
+        return ""
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < W4A4_MIN_SM:
+        return ""
+    try:
+        if not _numerics_ok():
+            return ""
+        if not _gemm_profitable():
+            logger.warning(
+                "w4a4: fp4 GEMM shows no real win on this device; dequant lane")
+            return ""
+    except Exception as exc:  # noqa: BLE001 — bench failure => dequant lane
+        logger.warning("w4a4: qualification failed (%s); dequant lane", exc)
+        return ""
+    return "blockwise"
+
+
+# ---------------------------------------------------------------------------
+# The module.
+# ---------------------------------------------------------------------------
+
+
+def _build_module_class() -> type:
+    import torch
+    import torch.nn as nn
+
+    class _W4A4Linear(nn.Module):
+        """Packed nvfp4 weights RESIDENT; y = blockwise scaled_mm + epilogue.
+
+        Per call: optional AWQ-lite smoothing (``x *= pre_quant_scale``),
+        per-tensor activation second-level scale (static ``input_scale``
+        from calibration, else dynamic amax/(6*448)), dynamic per-16-block
+        e4m3 scales, e2m1 cast + nibble pack, blockwise ``torch._scaled_mm``
+        (weight scales pre-swizzled at load, activation scales swizzled per
+        call), then the fp32 second-level epilogue ``y *= s2_act * s2_w``
+        and bias. The quantize/pack ops fuse under inductor — the win lives
+        in the compiled lane (gw#534's lesson holds one tier down). NOTE:
+        never ``.to(dtype=...)`` this module (device moves are fine)."""
+
+        weight: Any        # uint8 [out, in/2] packed e2m1 pairs
+        weight_scale: Any  # e4m3 1-D, cuBLAS blocked layout (swizzled at load)
+        weight_scale_2: Any  # fp32 [1, 1]
+        # Structural marker consumed by compile_cache.execution_contract.
+        _cozy_w4a4_linear = True
+
+        def __init__(self, in_features: int, out_features: int, *,
+                     bias: bool, compute_dtype: Any,
+                     static_input_scale: bool,
+                     pre_quant_scale: bool = False) -> None:
+            super().__init__()
+            self.in_features = int(in_features)
+            self.out_features = int(out_features)
+            if in_features % _K_ALIGN or out_features % _N_ALIGN:
+                raise W4a4SnapshotError(
+                    f"W4A4Linear dims [{out_features}, {in_features}] break "
+                    f"fp4 scaled_mm alignment (in%{_K_ALIGN}, out%{_N_ALIGN})")
+            meta = torch.device("meta")
+            self.register_buffer("weight", torch.empty(
+                out_features, in_features // 2, dtype=torch.uint8, device=meta))
+            nrb = (out_features + 127) // 128
+            ncb = (in_features // _BLOCK + 3) // 4
+            self.register_buffer("weight_scale", torch.empty(
+                nrb * 128 * ncb * 4, dtype=torch.float8_e4m3fn, device=meta))
+            self.register_buffer("weight_scale_2", torch.empty(
+                1, 1, dtype=torch.float32, device=meta))
+            if static_input_scale:
+                self.register_buffer("input_scale", torch.empty(
+                    1, 1, dtype=torch.float32, device=meta))
+            else:
+                self.input_scale = None
+            if pre_quant_scale:
+                self.register_buffer("pre_quant_scale", torch.empty(
+                    in_features, dtype=compute_dtype, device=meta))
+            else:
+                self.pre_quant_scale = None
+            if bias:
+                self.bias: Optional[nn.Parameter] = nn.Parameter(torch.empty(
+                    out_features, dtype=compute_dtype, device=meta))
+            else:
+                self.bias = None
+
+        def forward(self, x: Any) -> Any:
+            shape = x.shape
+            x2 = x.reshape(-1, self.in_features)
+            if self.pre_quant_scale is not None:
+                x2 = x2 * self.pre_quant_scale
+            if self.input_scale is not None:
+                s2 = self.input_scale.reshape(())
+            else:
+                s2 = (x2.abs().amax().float()
+                      / (_E2M1_MAX * _FP8_MAX)).clamp(min=1e-12)
+            xb = x2.reshape(-1, self.in_features // _BLOCK, _BLOCK).float()
+            bmax = xb.abs().amax(dim=-1)
+            sa = (bmax / (_E2M1_MAX * s2)).clamp(
+                min=_SCALE_MIN, max=_FP8_MAX).to(torch.float8_e4m3fn)
+            q = xb / (sa.float().unsqueeze(-1) * s2)
+            codes = cast_e2m1(q.reshape(-1, self.in_features))
+            xq = pack_e2m1(codes)
+            y = _gemm_w4a4(
+                xq, self.weight, to_blocked_scales(sa), self.weight_scale,
+                x.dtype)
+            y = y * (s2 * self.weight_scale_2.reshape(())).to(y.dtype)
+            if self.bias is not None:
+                y = y + self.bias
+            return y.reshape(*shape[:-1], self.out_features)
+
+        def extra_repr(self) -> str:
+            return (f"in_features={self.in_features}, "
+                    f"out_features={self.out_features}, "
+                    f"bias={self.bias is not None}, "
+                    f"static_input_scale={self.input_scale is not None}, "
+                    f"pre_quant_scale={self.pre_quant_scale is not None}")
+
+    return _W4A4Linear
+
+
+@functools.lru_cache(maxsize=1)
+def w4a4_linear_class() -> type:
+    return _build_module_class()
+
+
+# ---------------------------------------------------------------------------
+# Loaders.
+# ---------------------------------------------------------------------------
+
+
+def _denoiser_class(root: Path, component: str) -> Any:
+    index = json.loads((root / "model_index.json").read_text("utf-8"))
+    entry = index.get(component)
+    if not (isinstance(entry, list) and len(entry) == 2):
+        raise W4a4SnapshotError(
+            f"model_index.json has no [library, class] entry for {component!r}")
+    lib, name = str(entry[0]), str(entry[1])
+    try:
+        mod = importlib.import_module(lib)
+    except ImportError:
+        mod = importlib.import_module("diffusers")
+    cls = getattr(mod, name, None)
+    if cls is None:
+        raise W4a4SnapshotError(f"{lib} has no model class {name!r}")
+    return cls
+
+
+def _dequant_into(sd: Dict[str, Any], name: str, compute: Any) -> None:
+    """Replace one quantized layer's tensors with a dequantized weight.
+    AWQ-lite smoothing folds BACK into the weight: serve-time applies
+    ``x *= pre_quant_scale``, so the stored weight carries its inverse —
+    an unfolded dequant would silently mis-scale every in-channel."""
+    w = dequantize_nvfp4_tensor(
+        sd[f"{name}.weight"], sd[f"{name}.weight_scale"],
+        sd[f"{name}.weight_scale_2"])
+    pqs = sd.get(f"{name}.pre_quant_scale")
+    if pqs is not None:
+        w = w * pqs.float().reshape(1, -1)
+    sd[f"{name}.weight"] = w.to(compute)
+    for suffix in _AUX_SUFFIXES:
+        sd.pop(f"{name}{suffix}", None)
+
+
+def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
+                       compute_dtype: Any = None, mode: str = "") -> Any:
+    """Materialize the quantized denoiser: skeleton on meta, quantized
+    Linears swapped for W4A4Linear, tensors assigned from the shards.
+    ``mode`` "blockwise" | "dequant" (default: probe). Layers whose dims
+    break fp4 scaled_mm alignment are dequantized individually (AWQ-lite
+    ``pre_quant_scale`` folds back into the dequantized weight)."""
+    import torch
+    import torch.nn as nn
+    from accelerate import init_empty_weights
+    from safetensors.torch import load_file
+
+    compute = compute_dtype or torch.bfloat16
+    if mode not in ("blockwise", "dequant"):
+        mode = w4a4_gemm_mode() or "dequant"
+
+    cls = _denoiser_class(root, art.component)
+    cfg = dict(cls.load_config(str(root / art.component)))
+    cfg.pop("quantization_config", None)
+    with init_empty_weights():
+        model = cls.from_config(cfg)
+
+    sd: Dict[str, Any] = {}
+    for f in art.files:
+        sd.update(load_file(str(f)))
+
+    lin_cls = w4a4_linear_class()
+    swapped = 0
+    for name in art.quantized:
+        w = sd[f"{name}.weight"]
+        out_f, in_f = int(w.shape[0]), int(w.shape[1]) * 2
+        try:
+            parent_path, _, leaf = name.rpartition(".")
+            parent = model.get_submodule(parent_path) if parent_path else model
+            old = getattr(parent, leaf)
+        except AttributeError as exc:
+            raise W4a4SnapshotError(
+                f"quantized tensor {name!r} has no module in "
+                f"{type(model).__name__}") from exc
+        has_pqs = f"{name}.pre_quant_scale" in sd
+        eligible = (mode != "dequant" and isinstance(old, nn.Linear)
+                    and in_f % _K_ALIGN == 0 and out_f % _N_ALIGN == 0)
+        if eligible:
+            has_static = f"{name}.input_scale" in sd
+            new = lin_cls(in_f, out_f, bias=old.bias is not None,
+                          compute_dtype=compute, static_input_scale=has_static,
+                          pre_quant_scale=has_pqs)
+            setattr(parent, leaf, new)
+            sd[f"{name}.weight_scale"] = to_blocked_scales(
+                sd[f"{name}.weight_scale"])
+            sd[f"{name}.weight_scale_2"] = (
+                sd[f"{name}.weight_scale_2"].float().reshape(1, 1))
+            if has_static:
+                sd[f"{name}.input_scale"] = (
+                    sd[f"{name}.input_scale"].float().reshape(1, 1))
+            if has_pqs:
+                sd[f"{name}.pre_quant_scale"] = (
+                    sd[f"{name}.pre_quant_scale"].to(compute).reshape(-1))
+            swapped += 1
+        else:
+            _dequant_into(sd, name, compute)
+
+    for key, value in list(sd.items()):
+        if (value.is_floating_point()
+                and value.dtype != torch.float8_e4m3fn
+                and not key.endswith(_AUX_SUFFIXES)):
+            sd[key] = value.to(compute)
+
+    result = model.load_state_dict(sd, strict=False, assign=True)
+    if result.missing_keys or result.unexpected_keys:
+        raise W4a4SnapshotError(
+            f"w4a4 state dict mismatch: missing={list(result.missing_keys)[:5]} "
+            f"unexpected={list(result.unexpected_keys)[:5]}")
+    model.eval()
+    model._cozy_w4a4_mode = mode
+    logger.info(
+        "w4a4 loader mode: %s — %d/%d quantized Linears on fp4 scaled_mm "
+        "(component %s, static input scales: %s)",
+        mode, swapped, len(art.quantized), art.component,
+        art.static_input_scales,
+    )
+    return model
+
+
+def load_w4a4_pipeline(cls: Any, path: Path, art: W4a4Artifact, *,
+                       compute_dtype: Any = None,
+                       components: Optional[Dict[str, Any]] = None) -> Any:
+    """Build the pipeline with the w4a4 denoiser wired in (svdq-style
+    component injection). Stamps ``_cozy_weight_lane`` ("w4a4" on the fp4
+    scaled_mm lane, "bf16-resident" on the dequant lane) — the compile-cache
+    graph key (lane_drift, gw#534/gw#540)."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    mode = w4a4_gemm_mode() or "dequant"
+    denoiser = load_w4a4_denoiser(path, art, compute_dtype=compute, mode=mode)
+    kwargs: Dict[str, Any] = dict(components or {})
+    kwargs[art.component] = denoiser
+    pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
+    try:
+        pipe._cozy_weight_lane = (
+            "w4a4" if mode != "dequant" else "bf16-resident")
+    except Exception:
+        pass
+    return pipe
+
+
+def sanitize_w4a4_state_dict(
+    state_dict: Dict[str, Any], compute_dtype: Any = None,
+) -> Dict[str, Any]:
+    """Dequantize w4a4 tensors in a raw state dict: contract triples become
+    compute-dtype weights, aux tensors drop. A non-matching dict passes
+    through unchanged, so manual snapshot loaders can call it
+    unconditionally."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    out: Dict[str, Any] = {}
+    quantized = {
+        key[: -len(".weight_scale_2")]
+        for key in state_dict
+        if key.endswith(".weight_scale_2")
+        and isinstance(state_dict.get(
+            key[: -len(".weight_scale_2")] + ".weight"), torch.Tensor)
+        and state_dict[
+            key[: -len(".weight_scale_2")] + ".weight"].dtype == torch.uint8
+        and f"{key[: -len('.weight_scale_2')]}.weight_scale" in state_dict
+    }
+    for key, t in state_dict.items():
+        layer = key[: -len(".weight")] if key.endswith(".weight") else ""
+        if layer in quantized:
+            w = dequantize_nvfp4_tensor(
+                t, state_dict[f"{layer}.weight_scale"],
+                state_dict[f"{layer}.weight_scale_2"])
+            pqs = state_dict.get(f"{layer}.pre_quant_scale")
+            if pqs is not None:
+                w = w * pqs.float().reshape(1, -1)
+            out[key] = w.to(compute)
+            continue
+        if any(key.endswith(s) and key[: -len(s)] in quantized
+               for s in _AUX_SUFFIXES):
+            continue
+        out[key] = t
+    return out
+
+
+def swap_w4a4_linears(
+    model: Any,
+    art: W4a4Artifact,
+    *,
+    compute_dtype: Any = None,
+    key_map: Optional[Any] = None,
+) -> int:
+    """Swap the artifact's quantized Linears in an ALREADY-CONSTRUCTED model
+    onto :class:`W4A4Linear`, assigning packed weights + scales from the
+    shards (the root-layout lane, gw#562 pattern). Misaligned or non-Linear
+    layers keep their dequantized weights. Returns swapped count."""
+    import torch
+    import torch.nn as nn
+    from safetensors import safe_open
+
+    compute = compute_dtype or torch.bfloat16
+    lin_cls = w4a4_linear_class()
+    where: Dict[str, Path] = {}
+    for f in art.files:
+        for name in _read_header(f):
+            if name != "__metadata__":
+                where[name] = f
+    handles: Dict[Path, Any] = {}
+
+    def _tensor(name: str) -> Any:
+        src = where.get(name)
+        if src is None:
+            raise W4a4SnapshotError(f"artifact tensor {name!r} missing from shards")
+        fh = handles.get(src)
+        if fh is None:
+            fh = handles[src] = safe_open(str(src), framework="pt", device="cpu")
+        return fh.get_tensor(name)
+
+    swapped = 0
+    try:
+        for layer in art.quantized:
+            target = str(key_map(layer)) if key_map is not None else layer
+            parent_path, _, leaf = target.rpartition(".")
+            try:
+                parent = (model.get_submodule(parent_path)
+                          if parent_path else model)
+                old = getattr(parent, leaf)
+            except AttributeError as exc:
+                raise W4a4SnapshotError(
+                    f"quantized layer {layer!r} has no module {target!r} in "
+                    f"{type(model).__name__} — wrong key_map?") from exc
+            if not isinstance(old, nn.Linear) or type(old) is not nn.Linear:
+                logger.warning(
+                    "w4a4 swap: %s is %s, not a plain Linear; layer stays "
+                    "dequantized", target, type(old).__name__)
+                continue
+            w = _tensor(f"{layer}.weight")
+            out_f, in_f = int(w.shape[0]), int(w.shape[1]) * 2
+            if (out_f, in_f) != (int(old.out_features), int(old.in_features)):
+                raise W4a4SnapshotError(
+                    f"quantized layer {layer!r} shape [{out_f}, {in_f}] != "
+                    f"module {target!r} [{old.out_features}, {old.in_features}]")
+            if in_f % _K_ALIGN or out_f % _N_ALIGN:
+                continue
+            has_static = f"{layer}.input_scale" in where
+            has_pqs = f"{layer}.pre_quant_scale" in where
+            dev = old.weight.device
+            new = lin_cls(in_f, out_f, bias=old.bias is not None,
+                          compute_dtype=compute, static_input_scale=has_static,
+                          pre_quant_scale=has_pqs)
+            new.weight = w.contiguous().to(dev)
+            new.weight_scale = to_blocked_scales(
+                _tensor(f"{layer}.weight_scale")).to(dev)
+            new.weight_scale_2 = _tensor(
+                f"{layer}.weight_scale_2").float().reshape(1, 1).to(dev)
+            if has_static:
+                new.input_scale = _tensor(
+                    f"{layer}.input_scale").float().reshape(1, 1).to(dev)
+            if has_pqs:
+                new.pre_quant_scale = _tensor(
+                    f"{layer}.pre_quant_scale").to(compute).reshape(-1).to(dev)
+            if old.bias is not None:
+                new.bias = nn.Parameter(
+                    old.bias.detach().to(compute), requires_grad=False)
+            setattr(parent, leaf, new)
+            swapped += 1
+    finally:
+        for fh in handles.values():
+            try:
+                fh.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
+    logger.info("w4a4 swap: %d/%d quantized Linears on fp4 scaled_mm",
+                swapped, len(art.quantized))
+    return swapped
+
+
+def _root_denoiser(pipe: Any) -> Any:
+    import torch.nn as nn
+
+    for name in ("transformer", "unet", "dit"):
+        mod = getattr(pipe, name, None)
+        if isinstance(mod, nn.Module):
+            return mod
+    if isinstance(pipe, nn.Module):
+        return pipe
+    raise W4a4SnapshotError(
+        f"{type(pipe).__name__} exposes no denoiser module "
+        "(transformer/unet/dit) for the root w4a4 lane")
+
+
+def load_w4a4_root_pipeline(
+    cls: Any, path: Path, art: W4a4Artifact, *, compute_dtype: Any = None,
+) -> Any:
+    """Serve a root-layout w4a4 snapshot through the pipeline class's own
+    ``from_pretrained`` (whose loader must run sanitize_w4a4_state_dict),
+    then swap the denoiser's quantized Linears when the host qualifies."""
+    import torch
+
+    compute = compute_dtype or torch.bfloat16
+    mode = w4a4_gemm_mode() or "dequant"
+    pipe = cls.from_pretrained(str(path), torch_dtype=compute)
+    denoiser = _root_denoiser(pipe)
+    if mode != "dequant":
+        if not swap_w4a4_linears(denoiser, art, compute_dtype=compute):
+            raise W4a4SnapshotError(
+                "fp4 scaled_mm host but no quantized Linear swapped — "
+                f"artifact keys do not match {type(denoiser).__name__} modules")
+    try:
+        denoiser._cozy_w4a4_mode = mode
+        pipe._cozy_weight_lane = (
+            "w4a4" if mode != "dequant" else "bf16-resident")
+    except Exception:
+        pass
+    logger.info("w4a4 root lane: %s (%d quantized layers, component root)",
+                mode, len(art.quantized))
+    return pipe
+
+
+# ---------------------------------------------------------------------------
+# Data-free producer — contract round-trips in tests + the parity harness.
+# Production calibrated artifacts come from the conversion side (modelopt,
+# te#79/te#80: nvfp4 calibrates unconditionally); this writes the identical
+# on-disk contract with dynamic per-tensor activation scales.
+# ---------------------------------------------------------------------------
+
+
+def quantize_tree_w4a4(
+    src_tree: Path,
+    out_tree: Path,
+    *,
+    exclude: tuple[str, ...] = ("embed", "norm"),
+) -> Path:
+    """Copy a diffusers tree, rewriting the denoiser's eligible 2D weights
+    to the gw#540 contract triple. Eligible: ``*.weight``, 2D, float,
+    in %% 32 == 0, out %% 16 == 0, name not matching ``exclude``."""
+    import shutil
+
+    import torch
+    from safetensors.torch import load_file, save_file
+
+    src_tree, out_tree = Path(src_tree), Path(out_tree)
+    comp = next((c for c in _COMPONENT_DIRS if (src_tree / c).is_dir()), None)
+    if comp is None or not (src_tree / "model_index.json").exists():
+        raise W4a4SnapshotError(f"{src_tree} is not a diffusers tree with a denoiser")
+    if out_tree.exists():
+        shutil.rmtree(out_tree)
+    shutil.copytree(src_tree, out_tree,
+                    ignore=shutil.ignore_patterns("*.safetensors"))
+    for f in sorted(src_tree.rglob("*.safetensors")):
+        rel = f.relative_to(src_tree)
+        dst = out_tree / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if rel.parts[0] != comp:
+            shutil.copy2(f, dst)
+            continue
+        tensors = load_file(str(f))
+        out: Dict[str, Any] = {}
+        quantized = 0
+        for name, t in tensors.items():
+            layer = name[: -len(".weight")] if name.endswith(".weight") else ""
+            if (layer and t.ndim == 2 and t.is_floating_point()
+                    and t.dtype != torch.float8_e4m3fn
+                    and t.shape[0] % _N_ALIGN == 0
+                    and t.shape[1] % _K_ALIGN == 0
+                    and not any(x in layer for x in exclude)):
+                packed, bs, ws2 = quantize_nvfp4_tensor(t)
+                out[name] = packed
+                out[f"{layer}.weight_scale"] = bs
+                out[f"{layer}.weight_scale_2"] = ws2.reshape(())
+                quantized += 1
+            else:
+                out[name] = t
+        save_file(out, str(dst), metadata={
+            "quant_scheme": W4A4_FLAVOR, "calibration_corpus": "",
+            "modelopt_version": "",
+        })
+        logger.info("w4a4 producer: %s — %d layers quantized", rel, quantized)
+    cfg_path = out_tree / comp / "config.json"
+    cfg = json.loads(cfg_path.read_text("utf-8")) if cfg_path.exists() else {}
+    cfg["quantization_config"] = {
+        "quant_method": "modelopt", "quant_algo": "NVFP4"}
+    cfg_path.write_text(json.dumps(cfg, indent=2))
+    return out_tree
+
+
+__all__ = [
+    "W4A4_FLAVOR",
+    "W4A4_MIN_SM",
+    "W4a4Artifact",
+    "W4a4Error",
+    "W4a4SnapshotError",
+    "cast_e2m1",
+    "dequantize_nvfp4_tensor",
+    "detect_w4a4_artifact",
+    "load_w4a4_denoiser",
+    "load_w4a4_pipeline",
+    "load_w4a4_root_pipeline",
+    "pack_e2m1",
+    "quantize_nvfp4_tensor",
+    "quantize_tree_w4a4",
+    "sanitize_w4a4_state_dict",
+    "swap_w4a4_linears",
+    "to_blocked_scales",
+    "unpack_e2m1",
+    "w4a4_gemm_mode",
+    "w4a4_linear_class",
+]

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -861,6 +861,7 @@ def quantize_tree_w4a4(
         shutil.rmtree(out_tree)
     shutil.copytree(src_tree, out_tree,
                     ignore=shutil.ignore_patterns("*.safetensors"))
+    total_quantized = 0
     for f in sorted(src_tree.rglob("*.safetensors")):
         rel = f.relative_to(src_tree)
         dst = out_tree / rel
@@ -889,7 +890,15 @@ def quantize_tree_w4a4(
             "quant_scheme": W4A4_FLAVOR, "calibration_corpus": "",
             "modelopt_version": "",
         })
+        total_quantized += quantized
         logger.info("w4a4 producer: %s — %d layers quantized", rel, quantized)
+    if not total_quantized:
+        # A pickle-only tree (no denoiser safetensors) or one with zero
+        # eligible Linears must refuse: writing quantization_config onto an
+        # unquantized copy poisons every downstream loader (te#44 shape).
+        shutil.rmtree(out_tree)
+        raise W4a4SnapshotError(
+            f"{src_tree} has no quantizable denoiser safetensors weights")
     cfg_path = out_tree / comp / "config.json"
     cfg = json.loads(cfg_path.read_text("utf-8")) if cfg_path.exists() else {}
     cfg["quantization_config"] = {

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -116,15 +116,15 @@ def test_cell_lane_matcher_uses_candidate_keys():
     key = ck.from_axes(_AXES).digest
     ref = f"_system/family-ltx-2.3#{key}"
     assert _cell_lane_matches(
-        ref, "ltx-2.3", wants_w8a8=True, want_bucket=0,
+        ref, "ltx-2.3", want_lane="w8a8", want_bucket=0,
         candidate_keys={key})
     assert not _cell_lane_matches(
-        ref, "ltx-2.3", wants_w8a8=True, want_bucket=0,
+        ref, "ltx-2.3", want_lane="w8a8", want_bucket=0,
         candidate_keys={"ck1-" + "0" * 56})
     # legacy labels keep the lane-parse policy
     assert _cell_lane_matches(
         "_system/family-ltx-2.3#inductor-b200-torch2.13-w8a8",
-        "ltx-2.3", wants_w8a8=True, want_bucket=0)
+        "ltx-2.3", want_lane="w8a8", want_bucket=0)
 
 
 class _Target:

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1688,7 +1688,7 @@ def test_w8a8_partial_handler_proof_fails_loud_without_disabling_skipped_turbo(
 
     with pytest.raises(
         cc.CompiledLaneUnavailableError,
-        match="mandatory W8A8 function proof incomplete",
+        match="mandatory quantized-lane function proof incomplete",
     ):
         asyncio.run(ex.ensure_setup(generate, {
             model_ref: pb.Snapshot(digest=MODEL_DIGEST),
@@ -1770,7 +1770,7 @@ def test_w8a8_binding_cannot_advertise_plain_materialized_pipeline(tmp_path):
         "snapshot_digest": DIGEST_A,
         "path": tmp_path / "cell.tar.gz",
     })()
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="non-W8A8"):
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="materialized pipeline lane"):
         ex._install_compile_targets(
             rec, spec, [pipe], {id(pipe): selection}, {id(pipe): {spec.name}},
         )

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -174,7 +174,7 @@ def test_cell_pick_is_lane_and_bucket_exact() -> None:
     plain_l32 = f"_system/family-{fam}#inductor-h100-sxm-torch2.13-lora32"
 
     def pick(ref: str, *, w8a8_lane: bool, bucket: int) -> bool:
-        return _cell_lane_matches(ref, fam, wants_w8a8=w8a8_lane, want_bucket=bucket)
+        return _cell_lane_matches(ref, fam, want_lane="w8a8" if w8a8_lane else "", want_bucket=bucket)
 
     # branchless w8a8 endpoint: exactly the branchless w8a8 cell
     assert pick(w8a8, w8a8_lane=True, bucket=0)
@@ -191,7 +191,14 @@ def test_cell_pick_is_lane_and_bucket_exact() -> None:
     assert not pick(plain, w8a8_lane=False, bucket=32)
     # wrong family never matches
     assert not _cell_lane_matches(
-        w8a8_l128, "sdxl", wants_w8a8=True, want_bucket=128)
+        w8a8_l128, "sdxl", want_lane="w8a8", want_bucket=128)
+    # w4a4 (gw#540): mandated-lane exactness, and plain endpoints never
+    # fetch a quantized-lane cell
+    w4a4 = f"_system/family-{fam}#inductor-rtx-5090-torch2.13-w4a4"
+    assert _cell_lane_matches(w4a4, fam, want_lane="w4a4", want_bucket=0)
+    assert not _cell_lane_matches(w4a4, fam, want_lane="w8a8", want_bucket=0)
+    assert not _cell_lane_matches(w4a4, fam, want_lane="", want_bucket=0)
+    assert not _cell_lane_matches(w8a8, fam, want_lane="w4a4", want_bucket=0)
 
 
 def test_rank_buckets_cover_declared_cells() -> None:

--- a/tests/test_w4a4.py
+++ b/tests/test_w4a4.py
@@ -1,0 +1,286 @@
+"""W4A4 nvfp4 loader mode (gw#540) — contract round-trip against a REAL
+tiny diffusers pipeline (no network), detection negatives (incl. cross-lane
+w8a8 disambiguation), e2m1 helper exactness, lane stamps, and ladder/compile
+classification. The fp4 scaled_mm lane itself is GPU-gated in
+test_w4a4_sm100.py (Blackwell only).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker.models import w4a4
+from gen_worker.models.loading import load_from_pretrained, pipeline_weight_lane
+from gen_worker.models.w4a4 import (
+    W4A4_FLAVOR,
+    cast_e2m1,
+    dequantize_nvfp4_tensor,
+    detect_w4a4_artifact,
+    pack_e2m1,
+    quantize_nvfp4_tensor,
+    quantize_tree_w4a4,
+    sanitize_w4a4_state_dict,
+    unpack_e2m1,
+)
+
+
+@pytest.fixture(scope="module")
+def tiny_ddpm(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("w4a4") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w4a4_tree(tiny_ddpm: Path) -> Path:
+    return quantize_tree_w4a4(tiny_ddpm, tiny_ddpm.parent / "w4a4")
+
+
+# ---------------------------------------------------------------------------
+# e2m1 helpers: modelopt-identical math.
+# ---------------------------------------------------------------------------
+
+
+def test_e2m1_cast_is_exact_on_grid_and_rounds_ties_up() -> None:
+    grid = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+    codes = cast_e2m1(torch.cat([grid, -grid]))
+    vals = unpack_e2m1(pack_e2m1(codes))
+    assert torch.equal(vals, torch.cat([grid, -grid]))
+    # modelopt tie behavior: 0.75/1.75/2.5 round UP; 5.0 rounds DOWN to 4
+    # (round-half-to-even on the e2m1 grid — byte-identical to _cast_fp4)
+    ties = cast_e2m1(torch.tensor([0.75, 1.75, 2.5, 5.0]))
+    assert torch.equal(unpack_e2m1(pack_e2m1(ties)),
+                       torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    # clamp behavior beyond the grid
+    big = cast_e2m1(torch.tensor([7.0, -9.0]))
+    assert torch.equal(unpack_e2m1(pack_e2m1(big)),
+                       torch.tensor([6.0, -6.0]))
+
+
+def test_pack_unpack_nibble_order() -> None:
+    codes = torch.tensor([[1, 2, 3, 4]], dtype=torch.uint8)
+    packed = pack_e2m1(codes)
+    # element 0 in the LOW nibble (torch.float4_e2m1fn_x2 convention)
+    assert packed.tolist() == [[0x21, 0x43]]
+    vals = unpack_e2m1(packed)
+    assert vals.tolist() == [[0.5, 1.0, 1.5, 2.0]]
+
+
+def test_quantize_dequantize_round_trip_snr() -> None:
+    torch.manual_seed(0)
+    w = torch.randn(64, 128)
+    packed, bs, ws2 = quantize_nvfp4_tensor(w)
+    assert packed.shape == (64, 64) and packed.dtype == torch.uint8
+    assert bs.shape == (64, 8) and bs.dtype == torch.float8_e4m3fn
+    assert ws2.numel() == 1 and ws2.dtype == torch.float32
+    got = dequantize_nvfp4_tensor(packed, bs, ws2)
+    rel = ((w - got).norm() / w.norm()).item()
+    assert rel < 0.25  # e2m1 + two-level-scale rounding on gaussian weights
+
+
+# ---------------------------------------------------------------------------
+# Detection: the contract triple, and nothing else.
+# ---------------------------------------------------------------------------
+
+
+def test_detects_contract_artifact(w4a4_tree: Path) -> None:
+    art = detect_w4a4_artifact(w4a4_tree)
+    assert art is not None
+    assert art.component == "unet"
+    assert len(art.quantized) > 0
+    assert not art.static_input_scales  # data-free producer = dynamic
+    assert all("norm" not in n and "embed" not in n for n in art.quantized)
+    cfg = json.loads((w4a4_tree / "unet" / "config.json").read_text())
+    assert cfg["quantization_config"]["quant_algo"] == "NVFP4"
+
+
+def test_plain_and_w8a8_trees_never_detect(
+    tiny_ddpm: Path, tmp_path: Path,
+) -> None:
+    """Cross-lane disambiguation: a w8a8 tree (e4m3 weights + scales) and a
+    plain tree must not take the w4a4 lane, and a w4a4 tree must not take
+    the w8a8 lane — the weight dtype in the triple is the distinguisher."""
+    from gen_worker.models.w8a8 import detect_w8a8_artifact, quantize_tree_w8a8
+
+    assert detect_w4a4_artifact(tiny_ddpm) is None
+    w8a8_tree = quantize_tree_w8a8(tiny_ddpm, tmp_path / "w8a8")
+    assert detect_w4a4_artifact(w8a8_tree) is None
+    w4a4_tree = quantize_tree_w4a4(tiny_ddpm, tmp_path / "w4a4")
+    assert detect_w8a8_artifact(w4a4_tree) is None
+    assert detect_w4a4_artifact(w4a4_tree) is not None
+
+
+def test_static_input_scale_and_pre_quant_scale_detection(
+    tiny_ddpm: Path, tmp_path: Path,
+) -> None:
+    from safetensors.torch import load_file, save_file
+
+    tree = quantize_tree_w4a4(tiny_ddpm, tmp_path / "calibrated")
+    art = detect_w4a4_artifact(tree)
+    assert art is not None
+    f = art.files[0]
+    tensors = load_file(str(f))
+    layer = art.quantized[0]
+    in_f = tensors[f"{layer}.weight"].shape[1] * 2
+    tensors[f"{layer}.input_scale"] = torch.tensor(0.01)
+    tensors[f"{layer}.pre_quant_scale"] = torch.ones(in_f)
+    save_file(tensors, str(f))
+    art2 = detect_w4a4_artifact(tree)
+    assert art2 is not None and art2.static_input_scales
+
+
+# ---------------------------------------------------------------------------
+# Dequant lane (CPU): numerics + lane stamps + a real pipeline call.
+# ---------------------------------------------------------------------------
+
+
+def test_dequant_lane_round_trips_weights(
+    tiny_ddpm: Path, w4a4_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from diffusers import DDPMPipeline, UNet2DModel
+
+    monkeypatch.setattr(w4a4, "w4a4_gemm_mode", lambda: "")
+    pipe = load_from_pretrained(DDPMPipeline, w4a4_tree)
+    assert pipe._cozy_weight_lane == "bf16-resident"
+    assert pipeline_weight_lane(pipe) == ""
+    assert pipe.unet._cozy_w4a4_mode == "dequant"
+
+    ref = UNet2DModel.from_pretrained(str(tiny_ddpm / "unet"))
+    art = detect_w4a4_artifact(w4a4_tree)
+    assert art is not None
+    name = art.quantized[0] + ".weight"
+    a = ref.state_dict()[name].float()
+    b = pipe.unet.state_dict()[name].float()
+    rel = ((a - b).norm() / a.norm()).item()
+    assert rel < 0.25  # e2m1 rounding, norm-level (per-element is coarse)
+    assert pipe.unet.state_dict()[name].dtype == torch.bfloat16
+
+
+def test_full_dequant_pipeline_runs_on_cpu(
+    w4a4_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from diffusers import DDPMPipeline
+
+    monkeypatch.setattr(w4a4, "w4a4_gemm_mode", lambda: "")
+    pipe = load_from_pretrained(DDPMPipeline, w4a4_tree, dtype="fp32")
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)
+
+
+def test_sanitize_state_dict_dequants_and_folds_pre_quant_scale() -> None:
+    torch.manual_seed(1)
+    w = torch.randn(32, 64)
+    pqs = torch.rand(64) + 0.5
+    packed, bs, ws2 = quantize_nvfp4_tensor(w / pqs.reshape(1, -1))
+    sd = {
+        "lin.weight": packed,
+        "lin.weight_scale": bs,
+        "lin.weight_scale_2": ws2,
+        "lin.input_scale": torch.tensor(0.02),
+        "lin.pre_quant_scale": pqs,
+        "other.weight": torch.randn(4, 4),
+    }
+    out = sanitize_w4a4_state_dict(sd, compute_dtype=torch.float32)
+    assert set(out) == {"lin.weight", "other.weight"}
+    rel = ((out["lin.weight"] - w).norm() / w.norm()).item()
+    assert rel < 0.25  # smoothing folded back, quant rounding only
+    # a non-matching dict passes through untouched
+    plain = {"a.weight": torch.randn(2, 2)}
+    assert sanitize_w4a4_state_dict(plain) == plain
+
+
+# ---------------------------------------------------------------------------
+# Ladder + compile-cache classification.
+# ---------------------------------------------------------------------------
+
+
+def test_ladder_classifies_w4a4_blackwell_only() -> None:
+    from gen_worker.models.ladder import (
+        CLASS_NVFP4,
+        CLASS_NVFP4_W4A4,
+        classify_flavor_token,
+        placement_for_flavor,
+    )
+
+    assert classify_flavor_token(W4A4_FLAVOR) == CLASS_NVFP4_W4A4
+    assert classify_flavor_token("nvfp4") == CLASS_NVFP4  # TRT lane unchanged
+    p = placement_for_flavor(W4A4_FLAVOR)
+    assert p is not None and p.sm_min == 100
+    assert p.admits_sm(100) and p.admits_sm(103) and p.admits_sm(120)
+    assert not p.admits_sm(89) and not p.admits_sm(90)
+
+
+def test_variant_fit_gates_w4a4_on_blackwell() -> None:
+    from gen_worker.api import Resources
+    from gen_worker.models.hub_policy import (
+        FIT_INCOMPATIBLE,
+        FIT_NVFP4,
+        TensorhubWorkerCapabilities,
+        variant_fit,
+    )
+
+    class _B:
+        flavor = W4A4_FLAVOR
+
+    hopper = TensorhubWorkerCapabilities(
+        cuda_version="12.9", gpu_sm=90, torch_version="2.13", installed_libs=[])
+    fit, _ = variant_fit(Resources(vram_gb=1.0), hopper, 20.0, binding=_B())
+    assert fit == FIT_INCOMPATIBLE
+    blackwell = TensorhubWorkerCapabilities(
+        cuda_version="12.9", gpu_sm=120, torch_version="2.13", installed_libs=[])
+    fit, _ = variant_fit(Resources(vram_gb=1.0), blackwell, 20.0, binding=_B())
+    assert fit == FIT_NVFP4
+
+
+def test_compile_lane_key_separates_w4a4() -> None:
+    from gen_worker.compile_cache import (
+        artifact_metadata,
+        compile_target_lane_error,
+        flavor_label,
+        lane_drift,
+        lane_token,
+    )
+
+    class _P:
+        pass
+
+    w4a4_pipe = _P()
+    w4a4_pipe._cozy_weight_lane = "w4a4"
+    w8a8_pipe = _P()
+    w8a8_pipe._cozy_weight_lane = "w8a8"
+    assert lane_drift(
+        artifact_metadata(family="f", weight_lane="w4a4"), w4a4_pipe) == ""
+    assert "weight_lane" in lane_drift(
+        artifact_metadata(family="f"), w4a4_pipe)
+    assert "weight_lane" in lane_drift(
+        artifact_metadata(family="f", weight_lane="w4a4"), w8a8_pipe)
+    assert lane_token("w4a4") == "w4a4"
+    assert flavor_label("rtx-5090", "2.13.0+cu130", "w4a4").endswith("-w4a4")
+    assert compile_target_lane_error("w4a4", 0) == ""
+
+
+def test_executor_ref_mandatory_lane() -> None:
+    from gen_worker.executor import _ref_mandatory_lane
+
+    assert _ref_mandatory_lane("tensorhub/qwen-image:prod#fp8-w8a8") == "w8a8"
+    assert _ref_mandatory_lane("tensorhub/klein-4b:prod#nvfp4-w4a4") == "w4a4"
+    assert _ref_mandatory_lane("tensorhub/klein-4b:prod") == ""
+    assert _ref_mandatory_lane("tensorhub/klein-4b:prod#fp8") == ""
+    assert _ref_mandatory_lane("tensorhub/klein-4b:prod#nvfp4") == ""
+    assert _ref_mandatory_lane("not a ref !!") == ""

--- a/tests/test_w4a4_sm100.py
+++ b/tests/test_w4a4_sm100.py
@@ -1,0 +1,141 @@
+"""W4A4 fp4 scaled_mm lane on real Blackwell silicon (sm_100+) — skip-clean
+everywhere else. Mirrors the w8a8 sm_89 GPU suite: probe verdict, module
+numerics vs the dequant reference, and a real pipeline on the fp4 lane."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+from gen_worker.models import w4a4
+from gen_worker.models.loading import pipeline_weight_lane
+from gen_worker.models.w4a4 import (
+    detect_w4a4_artifact,
+    load_w4a4_pipeline,
+    quantize_nvfp4_tensor,
+    quantize_tree_w4a4,
+    to_blocked_scales,
+    w4a4_linear_class,
+)
+
+
+def _cuda_sm100() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor >= 100
+
+
+gpu = pytest.mark.skipif(
+    not _cuda_sm100(), reason="needs CUDA sm_100+ (Blackwell fp4 tensor cores)")
+
+
+@pytest.fixture(scope="module")
+def w4a4_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("w4a4gpu") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return quantize_tree_w4a4(root, root.parent / "w4a4")
+
+
+@gpu
+def test_gemm_mode_probe_arms_blockwise_on_blackwell() -> None:
+    """On real fp4 silicon the blockwise lane must arm — '' would mean the
+    numerics self-check or micro-benchmark wrongly demoted a capable card
+    to the dequant lane."""
+    w4a4.w4a4_gemm_mode.cache_clear()
+    assert w4a4.w4a4_gemm_mode() == "blockwise"
+
+
+@gpu
+def test_w4a4_linear_matches_dequant_reference() -> None:
+    torch.manual_seed(0)
+    lin_cls = w4a4_linear_class()
+    M, K, N = 64, 128, 96
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(N, device="cuda", dtype=torch.bfloat16)
+    packed, bs, ws2 = quantize_nvfp4_tensor(w)
+
+    mod = lin_cls(K, N, bias=True, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    mod.load_state_dict({
+        "weight": packed,
+        "weight_scale": to_blocked_scales(bs),
+        "weight_scale_2": ws2.reshape(1, 1),
+        "bias": bias,
+    }, assign=True)
+    y = mod(x)
+    from gen_worker.models.w4a4 import dequantize_nvfp4_tensor
+
+    w_deq = dequantize_nvfp4_tensor(packed.cpu(), bs.cpu(), ws2.cpu()).to(
+        "cuda", torch.bfloat16)
+    ref = torch.nn.functional.linear(x, w_deq, bias)
+    rel = ((y - ref).norm() / ref.norm().clamp(min=1e-9)).item()
+    # weight quant identical on both sides; activation fp4 quant error only
+    assert rel < 0.25
+
+
+@gpu
+def test_static_input_scale_branch_matches() -> None:
+    torch.manual_seed(1)
+    lin_cls = w4a4_linear_class()
+    M, K, N = 32, 64, 32
+    w = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    packed, bs, ws2 = quantize_nvfp4_tensor(w)
+    s2 = (x.abs().amax().float() / (6.0 * 448.0)).reshape(1, 1)
+
+    mod = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=True)
+    mod.load_state_dict({
+        "weight": packed,
+        "weight_scale": to_blocked_scales(bs),
+        "weight_scale_2": ws2.reshape(1, 1),
+        "input_scale": s2.cpu(),
+    }, assign=True)
+    mod.to("cuda")
+    dyn = lin_cls(K, N, bias=False, compute_dtype=torch.bfloat16,
+                  static_input_scale=False)
+    dyn.load_state_dict({
+        "weight": packed,
+        "weight_scale": to_blocked_scales(bs),
+        "weight_scale_2": ws2.reshape(1, 1),
+    }, assign=True)
+    # static scale == the amax the dynamic path derives for this x
+    y_static, y_dyn = mod(x), dyn(x)
+    rel = ((y_static - y_dyn).norm() / y_dyn.norm().clamp(min=1e-9)).item()
+    assert rel < 1e-3
+
+
+@gpu
+def test_w4a4_pipeline_serves_on_fp4_lane(w4a4_tree: Path) -> None:
+    from diffusers import DDPMPipeline
+
+    w4a4.w4a4_gemm_mode.cache_clear()
+    art = detect_w4a4_artifact(w4a4_tree)
+    assert art is not None
+    pipe = load_w4a4_pipeline(DDPMPipeline, w4a4_tree, art,
+                              compute_dtype=torch.float16)
+    assert pipe._cozy_weight_lane == "w4a4"
+    assert pipeline_weight_lane(pipe) == "w4a4"
+    lin_cls = w4a4_linear_class()
+    swapped = [m for m in pipe.unet.modules() if isinstance(m, lin_cls)]
+    assert swapped, "no W4A4Linear modules in the denoiser"
+    assert all(m.weight.dtype == torch.uint8 for m in swapped)
+    pipe.to("cuda")
+    out = pipe(batch_size=1, num_inference_steps=2, output_type="np")
+    assert out.images.shape[-3:] == (8, 8, 3)


### PR DESCRIPTION
Implements the gw#540 serve lane: the gw#534 W8A8 pattern one tier down.

## Contract (frozen in tracker gw#540)
A `nvfp4-w4a4` flavor is a normal diffusers tree; per quantized Linear:
`weight` (uint8 [out,in/2] packed e2m1), `weight_scale` (e4m3 [out,in/16] flat),
`weight_scale_2` (fp32 scalar), optional `input_scale` (fp32 scalar, calibrated —
production always carries it, te#80: nvfp4 calibrates unconditionally), optional
`pre_quant_scale` (AWQ-lite rescue rung). Exclusion-by-absence; the triple
disambiguates from w8a8 (e4m3 weights) and scale-free casts.

## Serve lane
- `W4A4Linear`: packed fp4 resident, blockwise `torch._scaled_mm` (DP1: 4378
  TFLOPS / 3.07x bf16 on B200 stock torch 2.13), dynamic per-16-block activation
  scales + static/dynamic per-tensor second level, cuBLAS blocked-scale swizzle
  (weights once at load, activations per call — fuses under inductor).
- `w4a4_gemm_mode()`: sm>=100 AND kernel probe AND numerics self-check (torch
  validates scale NUMEL only — layout truth is on us) AND micro-benchmark vs
  bf16; anything else dequants once to bf16-resident (never a refusal).
- Ladder: `nvfp4-w4a4` -> `CLASS_NVFP4_W4A4`, placement `sm_min=100` — never
  admitted below Blackwell (no fp4 silicon + 4x dequant blow-up kills the fit
  story there). Plain `nvfp4` (TRT lane) unchanged.
- Compile cells: lane token `w4a4`, `-w4a4` flavor labels, `nvfp4-w4a4-v1`
  execution contract, lane_drift parity, fail-closed compiled lane (the gw#534
  lesson: the win lives compiled).
- Executor: `_ref_wants_w8a8` generalized to `_ref_mandatory_lane` ("w8a8" |
  "w4a4" | "") — the mandatory-lane machinery (cell selection, required-compile
  fencing, fail-closed rails) is now lane-generic with w8a8 behavior unchanged.

## Tests
- CPU: contract round-trip on a real tiny diffusers pipeline, e2m1 helper
  exactness (modelopt-identical incl. tie behavior), cross-lane detection
  negatives, dequant-lane numerics + full CPU pipeline call, ladder/compile/
  executor classification.
- GPU (sm_100-gated, skip-clean elsewhere): probe verdict, W4A4Linear vs
  dequant reference, static-scale branch, real pipeline on the fp4 lane.
- `scripts/w4a4_parity.py`: same-seed bf16/w8a8/w4a4 parity + VRAM + eager/
  compiled walls (Blackwell pod harness).

Follow-ups (tracked in gw#540): te producer flavor flip (`nvfp4` ->
`nvfp4-w4a4`, calibration mandatory), th resolver mirror + ladder vectors,
one real gated klein-4b artifact, RunPod 5090 serve proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)