### PR TITLE
release: 0.38.0 (gw#590 root w8a8 generality)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.38.0 (2026-07-18)
+
+- **gw#590: root w8a8 generality — nested multi-set layouts, weight-set
+  selector, pipeline-class key_map hook.** Non-diffusers w8a8 sources scan
+  the whole tree for weight sets (split-checkpoint layouts nest component
+  files); `streaming_w8a8_snapshot(weight_set_patterns=)` selects the
+  denoiser set(s) when several exist and the rest pass through
+  byte-identical (CAS-dedup against the source mirror, no stray scale
+  twins). `detect_w8a8_artifact`/`verify_w8a8_snapshot` recurse the same
+  way. `load_w8a8_root_pipeline` forwards a pipeline-class-declared
+  `_cozy_w8a8_key_map` (staticmethod) to `swap_w8a8_linears` for
+  converter-renamed families. Root-lane produce results now report the
+  selected weight-set rel paths in `components` (was `[""]`).
+
 ## 0.37.5 (2026-07-18)
 
 - **gw#589/th#901: publish_as_is clone strategies cast an explicitly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.37.5"
+version = "0.38.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.37.5"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + changelog for the gw#590 mechanisms (nested multi-set root w8a8, weight_set_patterns selector, pipeline-class key_map hook). Tag v0.38.0 after merge publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)