### PR TITLE
release: 0.38.1 (gw#588 resident-mode reconcile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.38.1 (2026-07-19)
+
+- **gw#588: reconcile resident low-VRAM prep mode to the cell's traced
+  mode.** `off` and `vae_only` are both fully-CUDA-resident preps differing
+  only in the vae-slicing/vae-tiling/attention-slicing flag groups. When a
+  delivered cell's `low_vram_mode` and the pipeline's current mode are both
+  resident and differ, both consumer arm paths (`enable()` + hot adopt) now
+  converge the pipeline to the cell's traced mode before the drift check
+  instead of refusing — the ie#501 run-18 mandatory-w8a8 starvation
+  (producer mints alone → 'off'; multi-lane serve load → 'vae_only').
+  Offload-mode drift keeps refusing: genuinely different graphs/residency.
+
 ## 0.38.0 (2026-07-18)
 
 - **gw#590: root w8a8 generality — nested multi-set layouts, weight-set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.0"
+version = "0.38.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.0"
+version = "0.38.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + CHANGELOG for gw#588 (PR #317, merged 05efd94): consumer arm paths
converge resident low-VRAM prep mode (off<->vae_only) to the cell's traced mode
instead of refusing — unblocks the ie#501 mandatory-w8a8 serve lane.

- pyproject.toml: 0.38.0 -> 0.38.1
- uv.lock relocked (uv lock --python 3.12)
- CHANGELOG entry

## Test plan
- [x] `uv run pytest tests/test_compile_cache.py` 62 passed on the locked tree
- [x] `uv sync --locked --extra dev --python 3.12` clean
- [ ] CI