### PR TITLE
gw#591: finish boot setup when hub-delivered snapshots arrive (cold-boot deadlock)

### DIFF
--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 _VRAM_QUANTUM_FRACTION = 0.05  # quantize free-VRAM deltas to 5% of total
 
+# gw#591 boot-setup watcher: poll cadence for hub-delivered snapshots of
+# functions the startup scan left awaiting (store lookups are local + cheap).
+_BOOT_SETUP_WATCH_INTERVAL_S = 2.0
+
 
 def probe_hardware() -> Dict[str, Any]:
     """Static hardware facts + gate inputs. torch is optional."""
@@ -96,6 +100,7 @@ class Lifecycle:
         # mere membership) so a runtime ladder demotion (gw#463) re-emits.
         self._emitted_degraded: dict[str, str] = {}
         self._drain_task: Optional[asyncio.Task] = None
+        self._boot_setup_watch: Optional[asyncio.Task] = None
         self._drain_deadline_at: Optional[float] = None
         self._desired_residency: Optional[pb.DesiredResidency] = None
         self._residency_task: Optional[asyncio.Task] = None
@@ -486,8 +491,45 @@ class Lifecycle:
                 "check that the release has resolved desired bindings for these refs",
                 "; ".join(f"{fn} <- {', '.join(refs)}" for fn, refs in sorted(awaiting_hub.items())),
             )
+            # gw#591: the hub's desired-disk plan delivers those snapshots
+            # seconds later, but nothing re-ran setup — the function sat in
+            # loading_functions forever while the hub dispatches only to
+            # advertised functions (each side waiting on the other; found
+            # live, ie#519). Finish boot setup the moment the refs land.
+            self._boot_setup_watch = asyncio.create_task(
+                self._setup_awaiting_functions(awaiting_hub),
+                name="boot-setup-watch")
 
         await self.set_phase(pb.WORKER_PHASE_READY)
+
+    async def _setup_awaiting_functions(
+        self, awaiting: Dict[str, List[str]]
+    ) -> None:
+        """Complete boot setup for functions whose tensorhub snapshots arrive
+        via hub delivery after the startup scan (gw#591), then push a
+        StateDelta so ``available_functions`` advertises them."""
+        pending = {fn: list(refs) for fn, refs in awaiting.items()}
+        while pending and not self.draining:
+            for fn in sorted(pending):
+                left = [r for r in pending[fn]
+                        if self.executor.store.local_path(r) is None]
+                if left:
+                    pending[fn] = left
+                    continue
+                del pending[fn]
+                spec = self.executor.specs.get(fn)
+                if spec is None or fn in self.executor.unavailable:
+                    continue
+                try:
+                    await self.executor.ensure_setup(spec)
+                    logger.info(
+                        "boot setup of %s completed after hub snapshot "
+                        "delivery (gw#591)", fn)
+                except Exception as exc:
+                    logger.error("startup setup of %s failed: %s", fn, exc)
+                await self.maybe_send_state_delta()
+            if pending:
+                await asyncio.sleep(_BOOT_SETUP_WATCH_INTERVAL_S)
 
     # ---- drain -------------------------------------------------------------------
 

--- a/tests/test_startup_hub_snapshot_wait.py
+++ b/tests/test_startup_hub_snapshot_wait.py
@@ -101,3 +101,65 @@ def test_startup_does_not_log_when_nothing_waits_on_hub(caplog, tmp_path, monkey
 
     msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
     assert not any("waiting on hub-supplied snapshots" in m for m in msgs), msgs
+
+
+def test_boot_setup_completes_when_hub_snapshots_arrive(tmp_path, monkeypatch) -> None:
+    """gw#591 (found live, ie#519): the hub's desired-disk plan delivers the
+    awaited snapshots seconds after the startup scan; the watcher must finish
+    setup then, advertise the function, and push a StateDelta — without it the
+    worker sits at fns=[] loading=[fn] forever while the hub dispatches only
+    to advertised functions."""
+    import gen_worker.lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_BOOT_SETUP_WATCH_INTERVAL_S", 0.02)
+
+    ran: list[str] = []
+
+    class Endpoint:
+        def setup(self, model: str) -> None:
+            ran.append("setup")
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out(y=payload.x)
+
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="run", models={"model": Hub("tensorhub/anima")},
+    )
+    ex = Executor([spec], _noop_send)
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = {"gpu_count": 1, "gpu_total_mem": 32 * 1024**3,
+                   "gpu_free_mem": 30 * 1024**3, "gpu_sm": "90", "installed_libs": []}
+
+    deltas: list[bool] = []
+
+    async def _fake_delta(**kwargs):  # noqa: ANN003
+        deltas.append(True)
+
+    monkeypatch.setattr(lc, "maybe_send_state_delta", _fake_delta)
+
+    async def _fake_setup(s, snapshots=None):  # noqa: ANN001
+        ran.append(f"ensure_setup:{s.name}")
+        rec = ex._classes[s.instance_key]
+        rec.ready = True
+        return None
+
+    monkeypatch.setattr(ex, "ensure_setup", _fake_setup)
+
+    async def _scenario() -> None:
+        await lc.startup()
+        # Still waiting: the ref is not local, setup has not run.
+        assert ex.loading_functions() == ["generate"]
+        assert ran == []
+        # The hub's disk plan lands the snapshot.
+        monkeypatch.setattr(ex.store, "local_path", lambda ref: tmp_path)
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if ex.available_functions() == ["generate"]:
+                break
+        assert ex.available_functions() == ["generate"]
+        assert "ensure_setup:generate" in ran
+        assert deltas, "StateDelta push expected after late boot setup"
+
+    asyncio.run(_scenario())


### PR DESCRIPTION
Found live in ie#519's serve journey, reproduced against two hub builds: a class+models endpoint whose tensorhub snapshots arrive via the hub's desired-disk plan never leaves `loading_functions`. The startup scan (correctly) defers setup while refs are missing, but nothing re-runs it on delivery; the worker never advertises the function; the hub's dispatch requires either an advertised function or the loading-fn disk exception that in practice never fired — each side waiting on the other (worker at fns=[] loading=[generate] with all 4 refs tier=disk, digests matching desired, request queued 10h, 0% GPU).

Fix: a boot watcher (`_setup_awaiting_functions`) polls the local store for the awaited refs (2s cadence, local lookups), finishes `ensure_setup` when they land, and pushes a StateDelta so `available_functions` advertises the function to any hub build.

Tests: new gw#591 regression in tests/test_startup_hub_snapshot_wait.py (late snapshot arrival -> setup runs -> advertised -> delta pushed); existing ie#455 waits/logging behavior unchanged. Full suite 1466 passed / 41 skipped; mypy 124 files; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)