### PR TITLE
gw#592: LTX-2.3 family detection + native publish routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.38.2 (2026-07-19)
+
+- **gw#592: LTX-2.3 family detection + native publish routing.**
+  `Lightricks/LTX-2.3` (monolith or DiffSynth-Studio repackage layout) has no
+  diffusers pipeline manifest, so family detection stamped 'unknown' and a
+  requested `{dtype bf16, layout diffusers}` clone died "no publishable
+  flavor" trying to repackage into a diffusers layout that doesn't exist for
+  this family. Now detects `model_family='ltx2'` (filename hint + a
+  repo-structure sentinel for the repackage layout) and routes it through
+  the existing publish_as_is/th#901 dtype-cast path — the te#70 trainer
+  resolves the native singlefile snapshot directly, so no repackager is
+  built. Other aio_singlefile families (sd15/sdxl/flux/zimage) unaffected.
+
 ## 0.38.1 (2026-07-19)
 
 - **gw#591: finish boot setup when hub-delivered snapshots arrive.** The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.1"
+version = "0.38.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -919,7 +919,17 @@ def run_clone(
         # Non-diffusers-class sources publish as-is; extra output specs that
         # would need conversion are refused per-flavor, not per-job.
         strategy = source.classification.strategy if source.classification is not None else ""
-        publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES
+        # gw#592: LTX-2 (monolith or DiffSynth-Studio repackage layout) has
+        # no diffusers pipeline to repackage into — the te#70 trainer resolves
+        # the native singlefile snapshot directly — so route it through
+        # publish-as-is instead of build_flavor_tree's singlefile->diffusers
+        # repackager (which has no rule for this family and never should:
+        # nobody consumes an "ltx2 diffusers layout"). classify_repo has no
+        # dedicated LTX-2 strategy (it lands in the generic aio_singlefile
+        # bucket alongside any other bare single/multi-root safetensors repo),
+        # so this is gated on the detected family, not the strategy alone.
+        ltx2_native = strategy == "aio_singlefile" and source.model_family == "ltx2"
+        publish_as_is = strategy in _PUBLISH_AS_IS_STRATEGIES or ltx2_native
 
         for i, spec in enumerate(specs):
             flavor_label = spec.dtype
@@ -937,7 +947,8 @@ def run_clone(
                         attrs = dict(source.attrs)
                         flavor_label = source_dtype or spec.dtype
                     elif i == 0 and spec.file_type == "safetensors" \
-                            and strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES:
+                            and (strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES
+                                 or ltx2_native):
                         # th#901: an EXPLICITLY mismatched requested dtype is
                         # real, in-line-castable work for these strategies
                         # (ordinary dense safetensors trees) —

--- a/src/gen_worker/convert/layout.py
+++ b/src/gen_worker/convert/layout.py
@@ -69,6 +69,8 @@ def canonical_model_family_from_variant(variant: str) -> str:
         return "auraflow"
     if raw == "hidream_o1":
         return "hidream-o1"
+    if raw == "ltx2":
+        return "ltx2"
     if raw == "sdxl":
         return "sdxl"
     if raw == "sd15":
@@ -93,6 +95,12 @@ def infer_model_family_variant_from_hint(value: str | None) -> str:
         return "wan22"
     if "hidreamo1" in normalized:
         return "hidream_o1"
+    if "ltx2" in normalized:
+        # gw#592: "ltx-2", "ltx2", "ltx-2.3" all normalize to a string
+        # containing "ltx2" once punctuation is stripped. Deliberately
+        # narrower than "ltx" alone — LTX-Video (v1) is a distinct diffusers
+        # family and must not be misdetected here.
+        return "ltx2"
     if "qwenimage" in normalized:
         return "qwen_image"
     if "zimage" in normalized:
@@ -223,6 +231,23 @@ def _detect_family_variant_from_singlefile_paths(paths: list[str]) -> str:
     return "unknown"
 
 
+# gw#592: DiffSynth-Studio/LTX-2.3-Repackage per-submodule root layout has no
+# "ltx" token in any single filename (transformer.safetensors,
+# video_vae_encoder.safetensors, ...), so the per-path hint scan above misses
+# it. Mirrors the te#70 trainer's own sentinel check
+# (image_lora_finetuner.families.ltx2.snapshot_model_paths /
+# families.__init__._is_ltx2_snapshot) so both sides agree on what counts as
+# an LTX-2 snapshot.
+_LTX2_REPACKAGE_SENTINEL_FILES = frozenset({
+    "video_vae_encoder.safetensors", "text_encoder_post_modules.safetensors",
+})
+
+
+def _is_ltx2_repackage_layout(paths: list[str]) -> bool:
+    root_lower = {p.lower() for p in paths if "/" not in p}
+    return _LTX2_REPACKAGE_SENTINEL_FILES.issubset(root_lower)
+
+
 def detect_huggingface_source_layout(*, repo_dir: Path, files: list[str]) -> SourceLayoutInfo:
     """Tagging-only metadata: detect diffusers-vs-singlefile shape + family variant.
 
@@ -246,6 +271,8 @@ def detect_huggingface_source_layout(*, repo_dir: Path, files: list[str]) -> Sou
         model_family_variant = _detect_family_variant_from_components(normalized)
     if model_family_variant == "unknown" and source_layout == "singlefile":
         model_family_variant = _detect_family_variant_from_singlefile_paths(normalized)
+    if model_family_variant == "unknown" and _is_ltx2_repackage_layout(normalized):
+        model_family_variant = "ltx2"
     model_family = canonical_model_family_from_variant(model_family_variant)
     if model_family == "unknown":
         model_family = infer_model_family_from_hint(" ".join(normalized[:64]))

--- a/tests/convert/test_clone_ltx2_routing.py
+++ b/tests/convert/test_clone_ltx2_routing.py
@@ -1,0 +1,173 @@
+"""gw#592: LTX-2.3 output routing.
+
+Lightricks/LTX-2.3 classifies strategy="aio_singlefile" (classify_repo has no
+dedicated LTX-2 bucket — it's a bare root safetensors repo like any other).
+Before this fix, run_clone's non-publish_as_is branch (build_flavor_tree) hit
+the layout-repackage guard whenever the caller requested file_layout=
+"diffusers" (the historical default), and family="unknown" (pre gw#592) or
+family="ltx2" (post) is not in `_REPACKAGE_NORMALIZED_FAMILIES` — died
+"clone produced no publishable flavor". The te#70 trainer resolves the
+native singlefile/repackage snapshot directly (no diffusers pipeline exists
+for LTX-2), so the fix routes ltx2's aio_singlefile source through the
+publish_as_is path instead of building a repackager nobody needs.
+
+Same "real run_clone orchestration, stubbed tensor math" convention as
+tests/convert/test_publish_as_is_dtype.py (th#901).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from gen_worker.convert.clone import run_clone
+from gen_worker.convert.ingest import IngestedSource
+
+from fake_hub import _FakeHub
+
+
+class _Ctx:
+    def __init__(self, server) -> None:
+        self._file_api_base_url = f"http://127.0.0.1:{server.server_port}"
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+        self.request_id = "req-1"
+        self.destination = {"repo": "acme/fallback"}
+
+
+def _ltx2_source(dest_dir: Path, *, dtype: str = "bf16") -> IngestedSource:
+    """A monolith LTX-2.3 singlefile source: strategy=aio_singlefile,
+    model_family=ltx2 (as detected by layout.detect_huggingface_source_layout
+    post gw#592), no model_index.json / no diffusers pipeline."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "ltx-2.3-13b-dev.safetensors").write_bytes(b"\x00" * 64)
+    return IngestedSource(
+        provider="huggingface",
+        source_ref="Lightricks/LTX-2.3",
+        source_revision="sha-1",
+        dir=dest_dir,
+        layout="singlefile",
+        model_family="ltx2",
+        model_family_variant="ltx2",
+        classification=SimpleNamespace(strategy="aio_singlefile"),
+        attrs={"dtype": dtype, "file_layout": "singlefile"},
+        metadata={"source_provider": "huggingface"},
+        repo_spec={"kind": "model", "library_name": ""},
+    )
+
+
+def _install_fake_ingest(monkeypatch, source: IngestedSource):
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        return source
+
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+
+def _stub_build_flavor_tree(monkeypatch, calls: list):
+    def fake_build_flavor_tree(source, spec, out_dir, *, quantize_components=None):
+        calls.append({
+            "dtype": spec.dtype, "file_layout": spec.file_layout,
+            "file_type": spec.file_type,
+        })
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "model.safetensors").write_bytes(b"\x01" * 32)
+        attrs = {"dtype": spec.dtype, "file_layout": spec.file_layout,
+                 "file_type": spec.file_type}
+        return out_dir, attrs
+
+    monkeypatch.setattr("gen_worker.convert.clone.build_flavor_tree", fake_build_flavor_tree)
+
+
+def test_ltx2_diffusers_layout_request_publishes_native_singlefile_not_repackage(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """The historical bug: requesting layout='diffusers' against an ltx2
+    source must NOT reach build_flavor_tree's repackage guard (which has no
+    rule for ltx2 and would raise 'clone produced no publishable flavor').
+    It must publish the native singlefile snapshot instead."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    source = _ltx2_source(tmp_path / "source", dtype="bf16")
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="Lightricks/LTX-2.3",
+        destination_repo="acme/ltx-2.3-dev",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(result.published) == 1
+    assert result.published[0]["flavor"] == "bf16"
+    req = _FakeHub.state["commit_request"]
+    assert req["dtype"] == "bf16"
+    # publish_as_is is organizationally honest: the source's OWN native
+    # layout ships, never the caller's requested (nonexistent) diffusers one.
+    assert req["file_layout"] == "singlefile"
+
+
+def test_ltx2_mismatched_dtype_casts_inline_not_silent_passthrough(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """th#901 precedent applies to ltx2 too: an explicitly mismatched dtype
+    is real castable work, not a silent republish under the wrong label."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    source = _ltx2_source(tmp_path / "source", dtype="fp32")
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="Lightricks/LTX-2.3",
+        destination_repo="acme/ltx-2.3-dev",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(result.published) == 1
+    assert result.published[0]["flavor"] == "bf16"
+    assert len(calls) == 1
+    assert calls[0]["dtype"] == "bf16"
+    assert calls[0]["file_layout"] == "singlefile"
+
+
+def test_non_ltx2_aio_singlefile_is_unaffected(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """Guardrail: the routing must be gated on family, not just strategy —
+    an ordinary (non-ltx2) aio_singlefile source (e.g. a bare SD1.5 ckpt)
+    must still go through build_flavor_tree, since THOSE families have a
+    real singlefile->diffusers repackager other tenants rely on."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    dest = tmp_path / "source"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "v1-5-pruned.safetensors").write_bytes(b"\x00" * 64)
+    source = IngestedSource(
+        provider="huggingface", source_ref="org/sd15-ckpt", source_revision="sha-1",
+        dir=dest, layout="singlefile", model_family="sd15_sd2", model_family_variant="sd15",
+        classification=SimpleNamespace(strategy="aio_singlefile"),
+        attrs={"dtype": "fp32", "file_layout": "singlefile"},
+        metadata={}, repo_spec={},
+    )
+    _install_fake_ingest(monkeypatch, source)
+    calls: list = []
+    _stub_build_flavor_tree(monkeypatch, calls)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="org/sd15-ckpt",
+        destination_repo="acme/dest",
+        outputs=[{"dtype": "fp32", "file_layout": "singlefile", "file_type": "safetensors"}],
+    )
+
+    # build_flavor_tree ran at all (proves this took the non-publish_as_is
+    # branch) — a real fp32-source/fp32-request call would internally no-op
+    # via build_flavor_tree's own passthrough branch, but that internal
+    # short-circuit isn't observable through the stub; what matters here is
+    # WHICH branch of run_clone dispatched to it.
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(calls) == 1
+    assert calls[0]["file_layout"] == "singlefile"

--- a/tests/convert/test_layout_ltx2.py
+++ b/tests/convert/test_layout_ltx2.py
@@ -1,0 +1,100 @@
+"""gw#592: LTX-2.3 family detection.
+
+Lightricks/LTX-2.3 has no model_index.json / config.json — it publishes
+either one monolithic ``ltx-2*.safetensors`` at root, or the DiffSynth-Studio
+LTX-2.3-Repackage per-submodule layout (transformer.safetensors,
+video_vae_encoder.safetensors, ...). Neither carries a diffusers pipeline
+manifest, so ``detect_huggingface_source_layout`` fell through to
+model_family="unknown" and the clone's singlefile->diffusers repackage step
+refused it. These tests are synthetic file-listing fixtures only — no real
+LTX-2 weights are downloaded (this box never fetches real weights locally).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.convert.layout import (
+    canonical_model_family_from_variant,
+    detect_huggingface_source_layout,
+    infer_model_family_variant_from_hint,
+)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "ltx-2.3-13b-dev.safetensors",
+        "ltx-2.3-i2v-13b-dev.safetensors",
+        "LTX-2.3-distilled.safetensors",
+        "ltx2-13b.safetensors",
+    ],
+)
+def test_hint_detects_ltx2_from_monolith_filename(filename: str) -> None:
+    assert infer_model_family_variant_from_hint(filename) == "ltx2"
+
+
+def test_hint_does_not_confuse_ltx_video_v1_with_ltx2() -> None:
+    # LTX-Video (v1) is a distinct, already-diffusers-native family — must
+    # never be misdetected as ltx2 by a bare "ltx" substring match.
+    assert infer_model_family_variant_from_hint("ltx-video-2b-v0.9.safetensors") == "unknown"
+
+
+def test_canonical_family_from_ltx2_variant() -> None:
+    assert canonical_model_family_from_variant("ltx2") == "ltx2"
+
+
+def test_detect_layout_stamps_ltx2_for_monolith_singlefile(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    files = ["ltx-2.3-13b-dev.safetensors", "README.md"]
+    for f in files:
+        (repo_dir / f).write_bytes(b"\x00")
+
+    info = detect_huggingface_source_layout(repo_dir=repo_dir, files=files)
+
+    assert info.source_layout == "singlefile"
+    assert info.model_family == "ltx2"
+    assert info.model_family_variant == "ltx2"
+
+
+def test_detect_layout_stamps_ltx2_for_repackage_layout(tmp_path: Path) -> None:
+    """DiffSynth-Studio/LTX-2.3-Repackage: per-submodule ROOT files, none of
+    which carry an "ltx" token individually — must be detected from repo
+    structure (mirrors the te#70 trainer's own sentinel check). Root-only:
+    classify_repo's current "multiple root safetensors" selection only scans
+    top-level paths, so a real ingested repackage snapshot never carries the
+    text_encoder/ subdir at this point either (a separate, out-of-scope gap)."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    files = [
+        "transformer.safetensors",
+        "video_vae_encoder.safetensors",
+        "video_vae_decoder.safetensors",
+        "audio_vae_decoder.safetensors",
+        "audio_vocoder.safetensors",
+        "text_encoder_post_modules.safetensors",
+    ]
+    for f in files:
+        (repo_dir / f).write_bytes(b"\x00")
+
+    info = detect_huggingface_source_layout(repo_dir=repo_dir, files=files)
+
+    assert info.source_layout == "singlefile"
+    assert info.model_family == "ltx2"
+
+
+def test_detect_layout_repackage_requires_both_sentinel_files(tmp_path: Path) -> None:
+    """A repo with only ONE of the two sentinel files (e.g. a lone VAE
+    component repo) must not be misdetected as a full LTX-2 snapshot."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    files = ["video_vae_encoder.safetensors", "config.json"]
+    for f in files:
+        (repo_dir / f).write_bytes(b"\x00")
+
+    info = detect_huggingface_source_layout(repo_dir=repo_dir, files=files)
+
+    assert info.model_family != "ltx2"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.1"
+version = "0.38.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- `Lightricks/LTX-2.3` (monolith or DiffSynth-Studio repackage layout) has no diffusers pipeline manifest, so family detection stamped `unknown`; a `{dtype bf16, layout diffusers}` clone died "clone produced no publishable flavor" trying to repackage into a diffusers layout that doesn't exist for this family.
- Checked what the te#70 trainer actually wants first (`image_lora_finetuner/families/ltx2.py::snapshot_model_paths`): it resolves the native monolith/repackage singlefile snapshot directly — no diffusers layout is ever consumed. So the right fix is family detection + native publish routing, not a singlefile->diffusers repackager.
- `layout.py`: stamp `model_family='ltx2'` via filename hint (ie#478 pattern: `ltx-2`/`ltx2`/`ltx-2.3` all normalize to contain `ltx2`, deliberately excluding plain `ltx`/LTX-Video v1) plus a repo-structure sentinel check for the repackage layout (mirrors the trainer's own `_is_ltx2_snapshot`).
- `clone.py`: route `strategy=="aio_singlefile" and model_family=="ltx2"` through the existing publish_as_is path (th#901 dtype-cast precedent) instead of `build_flavor_tree`'s repackage guard. Other aio_singlefile families (sd15/sdxl/flux/zimage) are untouched — gated on family, not just strategy.
- Version bump 0.38.1 -> 0.38.2 per repo release convention.

## Test plan
- [x] `uv run pytest tests/convert/test_layout_ltx2.py tests/convert/test_clone_ltx2_routing.py tests/convert/test_publish_as_is_dtype.py tests/convert/test_classifier.py -q` — 42 passed (synthetic file-listing/IngestedSource fixtures only, no real LTX-2 weights downloaded)
- [x] `uv run pytest tests/convert -q` — 126 passed, 6 skipped (no regressions)
- [x] `uv run ruff check` on touched files — clean