### PR TITLE
gw#593: classifier._variant_tag must not match embedded version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.38.3 (2026-07-19)
+
+- **gw#593: classifier._variant_tag must not match embedded version numbers.**
+  A repo whose root safetensors filenames carry their own dotted version
+  number (`ltx-2.3-22b-dev.safetensors`) had that number misread as a
+  diffusers dtype-variant suffix, silently excluding the real checkpoint from
+  a multi-file bundle in favor of an unrelated smaller file. Now only a
+  recognized dtype token (bf16/fp16/fp32/fp8/...) counts as a variant tag;
+  everything else is untagged. Turns a silent wrong-file publish into a loud
+  refusal for oversized bundles instead.
+
 ## 0.38.2 (2026-07-19)
 
 - **gw#592: LTX-2.3 family detection + native publish routing.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.2"
+version = "0.38.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -36,6 +36,13 @@ _DTYPE_TAGS: dict[str, tuple[str, ...]] = {
     "fp8": ("fp8", "fp8_e4m3fn", "fp8-e4m3", "fp8_e5m2"),
 }
 _VARIANT_TAG_RE = re.compile(r"\.([a-z0-9_\-]+)\.safetensors$")
+# gw#593: _VARIANT_TAG_RE alone also matches a plain dotted version number
+# embedded in a filename ("ltx-2.3-22b-dev.safetensors" -> falsely captures
+# "3-22b-dev") — real repos outside the diffusers convention (Lightricks
+# LTX-2.3's root bundle: dev/distilled/distilled-lora/upscaler checkpoints,
+# each with its own "2.3"/"1.0"/"1.1" version token) hit this. Only a KNOWN
+# dtype token is a real variant suffix; every _DTYPE_TAGS value is one.
+_KNOWN_VARIANT_TAGS = frozenset(t for tags in _DTYPE_TAGS.values() for t in tags)
 _SHARD_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}$")
 _OFFICIAL_INDEX_VARIANT_RE = re.compile(
     r"\.safetensors\.index\.([a-z0-9_-]+)\.json$",
@@ -115,16 +122,26 @@ def _variant_tag(path: str) -> str:
         stem = _SHARD_SUFFIX_RE.sub("", name.removesuffix(".safetensors"))
         name = stem + ".safetensors"
     m = _VARIANT_TAG_RE.search(name)
-    return m.group(1) if m else ""
+    if m is None:
+        return ""
+    tag = m.group(1)
+    # gw#593: reject anything that isn't a recognized dtype token — a bare
+    # regex match also fires on a filename's own dotted version number.
+    return tag if tag in _KNOWN_VARIANT_TAGS else ""
 
 
 def _index_variant_tag(path: str) -> str:
     name = path.rsplit("/", 1)[-1].lower()
+    tag = ""
     match = _OFFICIAL_INDEX_VARIANT_RE.search(name)
     if match is not None:
-        return match.group(1)
-    match = _LEGACY_INDEX_VARIANT_RE.search(name)
-    return match.group(1) if match is not None else ""
+        tag = match.group(1)
+    else:
+        match = _LEGACY_INDEX_VARIANT_RE.search(name)
+        if match is not None:
+            tag = match.group(1)
+    # gw#593: same guard as _variant_tag — only a recognized dtype token.
+    return tag if tag in _KNOWN_VARIANT_TAGS else ""
 
 
 def _dtype_of_tag(tag: str) -> str:

--- a/tests/convert/test_classifier.py
+++ b/tests/convert/test_classifier.py
@@ -364,3 +364,69 @@ def test_pipeline_tree_trellis_shape() -> None:
 def test_pipeline_tree_without_weights_falls_through() -> None:
     with pytest.raises(RepoRefusal):
         classify_repo(["pipeline.json", "README.md"])
+
+
+def test_variant_tag_ignores_embedded_version_numbers() -> None:
+    """gw#593: a real HF repo's root safetensors bundle, each name carrying
+    its own dotted version number (not a diffusers dtype-variant suffix).
+    Real Lightricks/LTX-2.3 filenames + sizes (2026-07-19 tree API). Before
+    the fix, _variant_tag misread "2.3"/"1.0"/"1.1" as variant tags, split
+    every file into its own bogus group, and the alphabetically-first
+    fallback group happened to be the 3 upscaler files ONLY — SILENTLY
+    excluding the actual 22B DiT checkpoint entirely (found live: e2e#185's
+    clone published a mirror with zero base-model weights, gw#593).
+
+    After the fix every file lands untagged (no false dtype match), so they
+    group into ONE ~147GB bundle spanning dev+distilled+lora+upscaler
+    checkpoints — a real refusal (`too_large`, over the 100GB gate) instead
+    of a silent wrong-file publish. This is the correct interim behavior:
+    fail loud, not fail silently wrong. Actually selecting the ONE intended
+    checkpoint (`ltx-2.3-22b-dev.safetensors`) needs an explicit
+    caller-supplied selector — gw#593 item 2, deliberately not attempted
+    here (a real API-surface change, not a regex fix)."""
+    files_sizes = {
+        ".gitattributes": 1571,
+        "LICENSE": 21399,
+        "README.md": 6570,
+        "ltx-2.3-22b-dev.safetensors": 46149344974,
+        "ltx-2.3-22b-distilled-1.1.safetensors": 46149345334,
+        "ltx-2.3-22b-distilled-lora-384-1.1.safetensors": 7605507256,
+        "ltx-2.3-22b-distilled-lora-384.safetensors": 7605507256,
+        "ltx-2.3-22b-distilled.safetensors": 46149345038,
+        "ltx-2.3-spatial-upscaler-x1.5-1.0.safetensors": 1090125794,
+        "ltx-2.3-spatial-upscaler-x2-1.0.safetensors": 995743504,
+        "ltx-2.3-spatial-upscaler-x2-1.1.safetensors": 995743504,
+        "ltx-2.3-temporal-upscaler-x2-1.0.safetensors": 995743504,
+        "ltx2.3-open.png": 1000,
+    }
+    with pytest.raises(RepoRefusal) as exc:
+        classify_repo(list(files_sizes), sizes=files_sizes)
+    assert exc.value.reason == "too_large"
+
+
+def test_variant_tag_no_longer_silently_drops_base_checkpoint() -> None:
+    """Narrower proof of the gw#593 false-positive fix in isolation, without
+    the too_large refusal: a small subset (dev + one upscaler only, sizes
+    that fit under the gate) must group TOGETHER (both untagged), never
+    excluding the dev checkpoint the way the buggy regex did."""
+    files_sizes = {
+        "ltx-2.3-22b-dev.safetensors": 5_000_000_000,
+        "ltx-2.3-spatial-upscaler-x2-1.0.safetensors": 995_743_504,
+    }
+    c = classify_repo(list(files_sizes), sizes=files_sizes)
+    assert c.strategy == "aio_singlefile"
+    assert set(c.allow_patterns) == set(files_sizes)
+
+
+def test_variant_tag_still_recognizes_real_dtype_suffixes() -> None:
+    """Guardrail: gw#593's fix must not break the genuine diffusers
+    dtype-variant convention it was designed for."""
+    from gen_worker.convert.classifier import _variant_tag
+
+    assert _variant_tag("diffusion_pytorch_model.fp16.safetensors") == "fp16"
+    assert _variant_tag("diffusion_pytorch_model.bf16.safetensors") == "bf16"
+    assert _variant_tag("model.fp8_e4m3fn.safetensors") == "fp8_e4m3fn"
+    # The gw#593 false positives: version numbers are NOT dtype tags.
+    assert _variant_tag("ltx-2.3-22b-dev.safetensors") == ""
+    assert _variant_tag("ltx-2.3-22b-distilled-1.1.safetensors") == ""
+    assert _variant_tag("model-v1.0.safetensors") == ""

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.2"
+version = "0.38.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Found live during e2e#185's ltx-disney green-proof run (after gw#592 and th#906 both proved green — a real GPU training pod, real cost): `FileNotFoundError: no LTX-2 weights under [...]: expected transformer.safetensors (repackage layout) or a monolithic ltx-2*.safetensors`.
- Root cause, confirmed by local simulation against the REAL `Lightricks/LTX-2.3` file listing (HF tree API, no download): `classifier.py`'s `_VARIANT_TAG_RE` matches ANY `.X.safetensors` suffix — including one produced by a plain dotted version number embedded in the filename (`ltx-2.3-22b-dev.safetensors` → falsely captured tag `"3-22b-dev"`). Every one of the repo's 9 root safetensors files (dev/distilled/distilled-lora/upscaler checkpoints) got a DIFFERENT bogus tag from its own version token, so none landed in the `""` (untagged) bucket; the fallback `sorted(by_tag)[0]` alphabetically picked the group containing only the 3 upscaler files — silently excluding the actual 22B DiT checkpoint. The mirror published with zero base-model weights.
- Fix: `_variant_tag` / `_index_variant_tag` only recognize a captured suffix that is a KNOWN dtype token (from `_DTYPE_TAGS`'s value tuples) — anything else is untagged.
- This is NOT a full fix for LTX-2.3's clone — even fixed, all 9 files group into one ~147GB bundle (dev+distilled+lora+upscaler are genuinely different checkpoints, not dtype variants of one model) and now hit a loud `too_large` refusal instead of a silent wrong-file publish. Actually selecting the ONE intended checkpoint needs an explicit caller-supplied file selector — a real API-surface change across gen-worker AND the e2e harness's clone-request schema, tracked separately as gw#593 item 2 (not attempted here).

## Test plan
- [x] `uv run pytest tests/convert/test_classifier.py -q` — 29 passed, including a regression test built from the REAL Lightricks/LTX-2.3 filenames/sizes (proves the too_large refusal fires instead of the silent upscaler-only selection) and a guardrail test proving genuine dtype suffixes (`.fp16.`, `.bf16.`) still work
- [x] `uv run pytest tests/convert -q` — 129 passed, 6 skipped, no regressions
- [x] `uv run ruff check` clean on touched files