### PR TITLE
gw#593 item 2: source_include — explicit source-file selection on clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.38.4 (2026-07-19)
+
+- **gw#593 item 2: `source_include` — explicit source-file selection on the
+  clone request.** `Lightricks/LTX-2.3` bundles dev/distilled/distilled-lora/
+  upscaler checkpoints at repo root; even with item 1's fix, the classifier
+  groups all of them into one bundle (over the 100GB size gate) because it
+  has no way to know which one the caller wants. `source_include` is a new
+  optional clone field, dual-form like the rest of the clone request surface:
+  a compact single glob string, or a structured list of globs, matched
+  against repo-relative paths. When given, only the matching subset ever
+  reaches `classify_repo` — every existing strategy branch keeps working
+  unchanged on the narrowed listing. Every glob MUST match >=1 file; an
+  unmatched glob (typo, stale pattern) is a loud, typed
+  `SourceIncludeError` naming the bad glob and what the other globs matched,
+  never a silent no-op. HuggingFace-only for now (civitai clones raise if
+  given).
+
 ## 0.38.3 (2026-07-19)
 
 - **gw#593: classifier._variant_tag must not match embedded version numbers.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.3"
+version = "0.38.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -16,12 +16,19 @@ them; ``import gen_worker.convert`` stays cheap.
 from __future__ import annotations
 
 from .calibration import CalibrationAction, CalibrationPolicy, resolve_calibration_action
-from .classifier import RepoClassification, RepoRefusal, classify_repo
+from .classifier import (
+    RepoClassification,
+    RepoRefusal,
+    SourceIncludeError,
+    apply_source_include,
+    classify_repo,
+)
 from .clone import (
     CloneResult,
     OutputSpec,
     from_civitai,
     from_huggingface,
+    normalize_source_include,
     run_clone,
 )
 from .component import Component
@@ -80,6 +87,8 @@ __all__ = [
     "ingest_civitai",
     "RepoClassification",
     "RepoRefusal",
+    "SourceIncludeError",
+    "apply_source_include",
     "classify_repo",
     # Clone + publish
     "clone",
@@ -88,6 +97,7 @@ __all__ = [
     "run_clone",
     "from_huggingface",
     "from_civitai",
+    "normalize_source_include",
     "publish_flavors",
     "HubClient",
     "HubPublishError",

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -14,6 +14,7 @@ hierarchy; ``reason`` is a stable machine token.
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from dataclasses import dataclass, field
 from typing import Mapping, Optional, Sequence
@@ -79,6 +80,57 @@ class RepoRefusal(RuntimeError):
         if detail:
             msg += f" ({detail})"
         super().__init__(msg)
+
+
+class SourceIncludeError(ValueError):
+    """gw#593 item 2: one or more ``source_include`` globs matched no file in
+    the source repo's listing. Every glob is a REQUIRED selector (the caller
+    is explicitly pinning a file that must exist) — a typo or stale pattern
+    must fail loud here, not silently narrow the candidate set or fall
+    through to a generic ``missing_safetensors``/``too_large`` refusal that
+    gives no hint which selector was wrong.
+    """
+
+    def __init__(
+        self,
+        unmatched: Sequence[str],
+        *,
+        matched: Mapping[str, Sequence[str]],
+        all_paths: Sequence[str],
+    ) -> None:
+        self.unmatched = list(unmatched)
+        self.matched = {str(k): list(v) for k, v in matched.items()}
+        self.all_paths = list(all_paths)
+        detail = "; ".join(
+            f"{g!r} -> {len(v)} file(s)" for g, v in self.matched.items() if g not in unmatched
+        )
+        super().__init__(
+            f"source_include glob(s) matched no file: {self.unmatched!r} "
+            f"(other globs: {detail or 'none'}; {len(self.all_paths)} file(s) in repo)"
+        )
+
+
+def apply_source_include(paths: Sequence[str], include: Sequence[str]) -> list[str]:
+    """Filter repo-relative paths to only those matching at least one glob in
+    ``include`` (``fnmatch`` against the full repo-relative path, e.g.
+    ``"ltx-2.3-22b-dev.safetensors"`` or ``"text_encoder/**"``).
+
+    Every glob must match >=1 path or the whole call fails loud
+    (:class:`SourceIncludeError`) — see its docstring. An empty/``None``
+    ``include`` is a no-op (today's heuristic keeps running unrestricted).
+    """
+    if not include:
+        return list(paths)
+    matched: dict[str, list[str]] = {}
+    keep: set[str] = set()
+    for pattern in include:
+        hits = [p for p in paths if fnmatch.fnmatch(p, pattern)]
+        matched[pattern] = hits
+        keep.update(hits)
+    unmatched = [g for g, hits in matched.items() if not hits]
+    if unmatched:
+        raise SourceIncludeError(unmatched, matched=matched, all_paths=paths)
+    return sorted(keep)
 
 
 @dataclass(frozen=True)
@@ -442,4 +494,7 @@ def classify_repo(
     raise RepoRefusal("unknown_shape", files_seen=paths)
 
 
-__all__ = ["RepoClassification", "RepoRefusal", "classify_repo"]
+__all__ = [
+    "RepoClassification", "RepoRefusal", "classify_repo",
+    "SourceIncludeError", "apply_source_include",
+]

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -113,6 +113,32 @@ def normalize_destination_ref(value: str) -> str:
     return ref
 
 
+def normalize_source_include(value: Any) -> tuple[str, ...]:
+    """gw#593 item 2: dual-form clone-request field disambiguating a
+    multi-checkpoint-bundle source repo (e.g. Lightricks/LTX-2.3's
+    dev/distilled/lora/upscaler root bundle) — compact form is a single glob
+    string, structured form is a list of globs. Both mean the same thing:
+    an explicit allowlist matched against repo-relative paths, applied
+    before classification (see :func:`gen_worker.convert.classifier.
+    apply_source_include`). ``None``/empty means "today's heuristic,
+    unrestricted" — the default, unchanged behavior.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        v = value.strip()
+        return (v,) if v else ()
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            s = str(item or "").strip()
+            if s and s not in out:
+                out.append(s)
+        return tuple(out)
+    raise ValueError(
+        f"source_include must be a string or a list of strings, got {type(value).__name__}")
+
+
 def normalize_tags(values: Iterable[str] | None) -> list[str]:
     out: list[str] = []
     for raw in values or []:
@@ -791,12 +817,16 @@ def run_clone(
     gguf_quant: str | None = None,
     hf_token: str | None = None,
     civitai_api_key: str | None = None,
+    source_include: Any = None,
 ) -> CloneResult:
     provider = str(provider or "").strip().lower()
     destination = normalize_destination_ref(destination_repo)
     tags = normalize_tags(destination_repo_tags)
     layout_hint = str(target_layout or "diffusers").strip().lower() or "diffusers"
     specs = normalize_outputs(outputs, layout_hint=layout_hint)
+    include = normalize_source_include(source_include)
+    if include and provider != "huggingface":
+        raise ValueError("source_include is only supported for provider='huggingface'")
     # th#901: normalize_outputs collapses "caller asked for nothing" onto a
     # schema default (dtype="bf16") — indistinguishable from an EXPLICIT
     # bf16 request once normalized. Only an explicit request may force a
@@ -842,6 +872,7 @@ def run_clone(
                     dtype_preference=source_dtype_preference,
                     gguf_quant=gguf_quant,
                     hf_token=effective_hf_token,
+                    source_include=include,
                 )
             else:
                 plan = plan_civitai(
@@ -898,6 +929,7 @@ def run_clone(
                 hf_token=effective_hf_token,
                 progress=_dl_progress,
                 plan=plan,
+                source_include=include,
             )
         else:
             source = ingest_civitai(
@@ -1161,6 +1193,7 @@ def from_huggingface(ctx: Any, payload: Any, *, hf_token: str | None = None) -> 
         overwrite_repo=bool(getattr(payload, "overwrite_repo", False)),
         gguf_quant=getattr(payload, "gguf_quant", None),
         hf_token=hf_token,
+        source_include=getattr(payload, "source_include", None),
     )
 
 
@@ -1192,6 +1225,7 @@ __all__ = [
     "from_huggingface",
     "normalize_destination_ref",
     "normalize_outputs",
+    "normalize_source_include",
     "normalize_tags",
     "run_clone",
 ]

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -14,10 +14,10 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional, Sequence
 
 from ..net import hf, install_hf_http_timeouts
-from .classifier import RepoClassification, classify_repo
+from .classifier import RepoClassification, apply_source_include, classify_repo
 from .layout import detect_huggingface_source_layout
 
 logger = logging.getLogger(__name__)
@@ -267,12 +267,25 @@ def plan_huggingface(
     dtype_preference: list[str] | None = None,
     gguf_quant: str | None = None,
     hf_token: str | None = None,
+    source_include: Sequence[str] | None = None,
 ) -> HFSourcePlan:
-    """Resolve + classify one HF repo from metadata alone (no weight bytes)."""
+    """Resolve + classify one HF repo from metadata alone (no weight bytes).
+
+    ``source_include`` (gw#593 item 2): an optional explicit allowlist of
+    globs matched against repo-relative paths. When given, the classifier
+    only ever sees the matching subset — the caller's way of disambiguating
+    a multi-checkpoint-bundle repo (e.g. Lightricks/LTX-2.3's dev/distilled/
+    lora/upscaler root bundle) that today's dtype-variant heuristic cannot
+    resolve on its own. Every glob must match >=1 file (fail loud on a typo).
+    """
     install_hf_http_timeouts()
     repo_id, sha = resolve_hf_identity(source_ref, revision=revision, hf_token=hf_token)
     rev = sha or (str(revision).strip() if revision else None)
     paths, sizes, side, content_ids = _hf_classification_inputs(repo_id, rev, hf_token)
+    if source_include:
+        paths = apply_source_include(paths, source_include)
+        sizes = {p: v for p, v in sizes.items() if p in paths}
+        content_ids = {p: v for p, v in content_ids.items() if p in paths}
     classification = classify_repo(
         paths,
         sizes=sizes,
@@ -384,16 +397,18 @@ def ingest_huggingface(
     hf_token: str | None = None,
     progress: ProgressFn | None = None,
     plan: HFSourcePlan | None = None,
+    source_include: Sequence[str] | None = None,
 ) -> IngestedSource:
     """Classify + selectively download one HF repo into ``dest_dir``.
 
     ``plan`` (from :func:`plan_huggingface`) skips re-doing the metadata
-    calls when the caller already planned this source."""
+    calls when the caller already planned this source. ``source_include`` is
+    ignored when ``plan`` is already given (the plan was built with it)."""
     install_hf_http_timeouts()
     if plan is None:
         plan = plan_huggingface(
             source_ref, revision=revision, dtype_preference=dtype_preference,
-            gguf_quant=gguf_quant, hf_token=hf_token)
+            gguf_quant=gguf_quant, hf_token=hf_token, source_include=source_include)
     repo_id, sha = plan.repo_id, plan.revision
     rev = sha or (str(revision).strip() if revision else None)
     paths, sizes = plan.paths, plan.sizes

--- a/tests/convert/test_source_include.py
+++ b/tests/convert/test_source_include.py
@@ -1,0 +1,249 @@
+"""gw#593 item 2: explicit source-file selection on the clone request.
+
+``Lightricks/LTX-2.3`` bundles dev/distilled/distilled-lora/upscaler
+checkpoints together at repo root; the classifier's dtype-variant heuristic
+has no way to know the caller wants specifically
+``ltx-2.3-22b-dev.safetensors`` (gw#593's item-1 fix makes every file land
+untagged, so they group into one ~147GB bundle and hit the size refusal
+instead of silently publishing the wrong file — a strict improvement, but
+still unclonable). ``source_include`` is the caller's explicit selector:
+dual-form (compact single glob string, or a structured list of globs),
+matched against repo-relative paths, applied BEFORE classification so
+``classify_repo`` only ever sees the caller-approved subset and every
+existing strategy branch keeps working unchanged.
+
+All synthetic file-listing fixtures — no network, no weight downloads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gen_worker.convert.classifier import (
+    SourceIncludeError,
+    apply_source_include,
+    classify_repo,
+)
+from gen_worker.convert.clone import normalize_source_include, run_clone
+from gen_worker.convert.ingest import HFSourcePlan, IngestedSource
+
+# Real Lightricks/LTX-2.3 root listing (2026-07-19 HF tree API; confirmed live
+# via `curl https://huggingface.co/api/models/Lightricks/LTX-2.3/tree/main`).
+_LTX23_FILES = {
+    ".gitattributes": 1571,
+    "LICENSE": 21399,
+    "README.md": 6570,
+    "ltx-2.3-22b-dev.safetensors": 46149344974,
+    "ltx-2.3-22b-distilled-1.1.safetensors": 46149345334,
+    "ltx-2.3-22b-distilled-lora-384-1.1.safetensors": 7605507256,
+    "ltx-2.3-22b-distilled-lora-384.safetensors": 7605507256,
+    "ltx-2.3-22b-distilled.safetensors": 46149345038,
+    "ltx-2.3-spatial-upscaler-x1.5-1.0.safetensors": 1090125794,
+    "ltx-2.3-spatial-upscaler-x2-1.0.safetensors": 995743504,
+    "ltx-2.3-spatial-upscaler-x2-1.1.safetensors": 995743504,
+    "ltx-2.3-temporal-upscaler-x2-1.0.safetensors": 995743504,
+    "ltx2.3-open.png": 2259601,
+}
+
+
+# ---------------------------------------------------------------------------
+# classifier.apply_source_include — pure glob-filter semantics
+# ---------------------------------------------------------------------------
+
+def test_apply_source_include_noop_when_absent() -> None:
+    paths = list(_LTX23_FILES)
+    assert apply_source_include(paths, ()) == paths
+    assert apply_source_include(paths, None) == paths  # type: ignore[arg-type]
+
+
+def test_apply_source_include_single_glob_pins_one_file() -> None:
+    out = apply_source_include(list(_LTX23_FILES), ["ltx-2.3-22b-dev.safetensors"])
+    assert out == ["ltx-2.3-22b-dev.safetensors"]
+
+
+def test_apply_source_include_multiple_globs_union() -> None:
+    out = apply_source_include(
+        list(_LTX23_FILES),
+        ["ltx-2.3-22b-dev.safetensors", "*.md", "LICENSE"],
+    )
+    assert set(out) == {"ltx-2.3-22b-dev.safetensors", "README.md", "LICENSE"}
+
+
+def test_apply_source_include_glob_star_pattern() -> None:
+    out = apply_source_include(list(_LTX23_FILES), ["*dev*"])
+    assert out == ["ltx-2.3-22b-dev.safetensors"]
+
+
+def test_apply_source_include_nested_path_glob() -> None:
+    paths = [
+        "model_index.json",
+        "transformer/diffusion_pytorch_model.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+        "text_encoder/model.safetensors",
+    ]
+    out = apply_source_include(paths, ["transformer/*", "vae/*"])
+    assert set(out) == {
+        "transformer/diffusion_pytorch_model.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+    }
+
+
+def test_apply_source_include_unmatched_glob_fails_loud() -> None:
+    with pytest.raises(SourceIncludeError) as exc:
+        apply_source_include(list(_LTX23_FILES), ["ltx-2.3-22b-dev.safetensors", "*.typo-ext"])
+    err = exc.value
+    assert err.unmatched == ["*.typo-ext"]
+    # The error names the bad glob AND what the good glob(s) matched.
+    assert "*.typo-ext" in str(err)
+    assert "ltx-2.3-22b-dev.safetensors" in str(err)
+    assert err.matched["ltx-2.3-22b-dev.safetensors"] == ["ltx-2.3-22b-dev.safetensors"]
+
+
+def test_apply_source_include_all_globs_unmatched() -> None:
+    with pytest.raises(SourceIncludeError) as exc:
+        apply_source_include(list(_LTX23_FILES), ["nope-1.safetensors", "nope-2.safetensors"])
+    assert set(exc.value.unmatched) == {"nope-1.safetensors", "nope-2.safetensors"}
+
+
+# ---------------------------------------------------------------------------
+# classify_repo end-to-end with the filtered listing (the actual gw#593
+# blocker: pinning JUST the dev checkpoint out of the 147GB root bundle)
+# ---------------------------------------------------------------------------
+
+def test_source_include_resolves_the_ltx23_dev_checkpoint() -> None:
+    filtered = apply_source_include(list(_LTX23_FILES), ["ltx-2.3-22b-dev.safetensors"])
+    sizes = {p: _LTX23_FILES[p] for p in filtered}
+    c = classify_repo(filtered, sizes=sizes)
+    assert c.strategy == "aio_singlefile"
+    assert c.allow_patterns == ["ltx-2.3-22b-dev.safetensors"]
+
+
+def test_without_source_include_the_full_bundle_still_refuses_too_large() -> None:
+    """Guardrail: confirms this fixture is the REAL gw#593 blocker (unrestricted
+    classify_repo still can't resolve it) — source_include is what unblocks it."""
+    from gen_worker.convert.classifier import RepoRefusal
+
+    with pytest.raises(RepoRefusal) as exc:
+        classify_repo(list(_LTX23_FILES), sizes=_LTX23_FILES)
+    assert exc.value.reason == "too_large"
+
+
+# ---------------------------------------------------------------------------
+# clone.normalize_source_include — dual-form input (compact string / list)
+# ---------------------------------------------------------------------------
+
+def test_normalize_source_include_none_is_empty() -> None:
+    assert normalize_source_include(None) == ()
+
+
+def test_normalize_source_include_compact_string_form() -> None:
+    assert normalize_source_include("ltx-2.3-22b-dev.safetensors") == (
+        "ltx-2.3-22b-dev.safetensors",
+    )
+
+
+def test_normalize_source_include_blank_string_is_empty() -> None:
+    assert normalize_source_include("   ") == ()
+
+
+def test_normalize_source_include_structured_list_form() -> None:
+    assert normalize_source_include(
+        ["ltx-2.3-22b-dev.safetensors", "text_encoder/**"]
+    ) == ("ltx-2.3-22b-dev.safetensors", "text_encoder/**")
+
+
+def test_normalize_source_include_dedupes_preserving_order() -> None:
+    assert normalize_source_include(["a/*", "b/*", "a/*"]) == ("a/*", "b/*")
+
+
+def test_normalize_source_include_rejects_other_types() -> None:
+    with pytest.raises(ValueError):
+        normalize_source_include(123)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# run_clone plumbing — source_include reaches plan_huggingface/
+# ingest_huggingface, and provider guard rails.
+# ---------------------------------------------------------------------------
+
+class _Ctx:
+    def __init__(self) -> None:
+        self._file_api_base_url = "http://127.0.0.1:1"
+        self._worker_capability_token = "cap-token"
+        self.owner = "acme"
+        self.request_id = "req-1"
+        self.destination = {"repo": "acme/fallback"}
+
+
+def test_run_clone_threads_source_include_into_plan_and_ingest(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    calls: dict[str, object] = {}
+
+    def fake_plan(source_ref, **kwargs):
+        calls["plan_source_include"] = kwargs.get("source_include")
+        return HFSourcePlan(
+            repo_id=source_ref, revision="sha-1", paths=["ltx-2.3-22b-dev.safetensors"],
+            sizes={"ltx-2.3-22b-dev.safetensors": 64},
+            side={}, classification=classify_repo(
+                ["ltx-2.3-22b-dev.safetensors"], sizes={"ltx-2.3-22b-dev.safetensors": 64}),
+            content_ids={},
+        )
+
+    def fake_ingest(source_ref, dest_dir, **kwargs):
+        calls["ingest_source_include"] = kwargs.get("source_include")
+        dest_dir = Path(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "ltx-2.3-22b-dev.safetensors").write_bytes(b"\x00" * 64)
+        return IngestedSource(
+            provider="huggingface", source_ref=source_ref, source_revision="sha-1",
+            dir=dest_dir, layout="singlefile", model_family="ltx2", model_family_variant="ltx2",
+            classification=SimpleNamespace(strategy="aio_singlefile"),
+            attrs={"dtype": "bf16", "file_layout": "singlefile"},
+            metadata={"source_provider": "huggingface"},
+            repo_spec={"kind": "model", "library_name": ""},
+        )
+
+    monkeypatch.setattr("gen_worker.convert.clone.plan_huggingface", fake_plan)
+    monkeypatch.setattr("gen_worker.convert.clone.ingest_huggingface", fake_ingest)
+
+    class _Hub:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        @staticmethod
+        def from_ctx(ctx):
+            return _Hub()
+
+        def commit(self, **kwargs):
+            return SimpleNamespace(
+                revision_id="rev-1", checkpoint_id="ck-1", uploaded=1,
+                deduped=0, total_bytes=64,
+            )
+
+    monkeypatch.setattr("gen_worker.convert.clone.HubClient", _Hub)
+
+    result = run_clone(
+        _Ctx(),
+        provider="huggingface",
+        source_ref="Lightricks/LTX-2.3",
+        destination_repo="acme/ltx-2.3-dev",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+        source_include="ltx-2.3-22b-dev.safetensors",
+    )
+    assert calls["plan_source_include"] == ("ltx-2.3-22b-dev.safetensors",)
+    assert calls["ingest_source_include"] == ("ltx-2.3-22b-dev.safetensors",)
+    assert result.published
+
+
+def test_run_clone_rejects_source_include_for_civitai() -> None:
+    with pytest.raises(ValueError, match="only supported for provider='huggingface'"):
+        run_clone(
+            _Ctx(),
+            provider="civitai",
+            civitai_model_version_id=1,
+            destination_repo="acme/thing",
+            source_include="*.safetensors",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.3"
+version = "0.38.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Adds `source_include` to the clone request: an optional, dual-form
  (compact glob string / structured list of globs) allowlist matched against
  repo-relative paths, applied before `classify_repo` runs.
- Unblocks `Lightricks/LTX-2.3` (dev/distilled/lora/upscaler bundle at repo
  root): item 1 (regex fix, merged in #329/0.38.3) stopped the silent
  wrong-file publish but left the repo unclonable (all 9 files group into
  one ~147GB bundle, over the size gate). `source_include:
  "ltx-2.3-22b-dev.safetensors"` pins the one checkpoint the e2e#185 lane
  needs.
- Every glob must match >=1 file or the call fails loud with a typed
  `SourceIncludeError` naming the unmatched glob(s) and what the other globs
  matched — no silent narrowing on a typo.
- HuggingFace-only; `run_clone` raises if `source_include` is given for a
  civitai clone.

## Test plan
- [x] `uv run pytest tests/convert/test_source_include.py -q` — 17 passed
  (pure `apply_source_include`/`normalize_source_include` unit tests,
  `classify_repo` end-to-end against the real LTX-2.3 file listing, and a
  `run_clone`-level plumbing test with stubbed ingest/hub).
- [x] `uv run pytest tests/convert -q` — 139 passed / 6 skipped, no
  regressions (1 pre-existing unrelated failure + 6 pre-existing errors from
  a missing `huggingface_hub` module in this sandbox, confirmed present on
  base `master` before this change too).
- [x] `uvx ruff check src/gen_worker/convert` clean.
- [x] `uv run python scripts/lint_http_timeouts.py` clean.