### PR TITLE
gw#592/gw#593 companion: LTX-2 disk-preflight publish_as_is carve-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.38.5 (2026-07-19)
+
+- **gw#592/gw#593 companion: disk preflight didn't know about LTX-2's
+  publish_as_is routing.** `run_clone` routes `strategy="aio_singlefile"`
+  LTX-2 sources through publish_as_is regardless of the requested output
+  layout (gw#592 — no diffusers pipeline exists for the family), but
+  `_preflight_disk` only sees the pre-download classification and had no
+  equivalent carve-out, so it budgeted a full layout-repack +
+  materialized-dtype-tree estimate (388GB for a 43GB source) for a clone
+  that only ever needs the source bytes + margin. Preflight now derives the
+  same LTX-2 hint from the pre-download file listing
+  (`layout.infer_model_family_variant_from_hint` on each path — the
+  filename itself carries the "ltx2" token) and applies the
+  publish-as-is budget. Found live: e2e#185 ltx-firstlight run 7,
+  `CloneDiskSpaceError` on a real 43GB LTX-2.3 dev-checkpoint clone.
+
 ## 0.38.4 (2026-07-19)
 
 - **gw#593 item 2: `source_include` — explicit source-file selection on the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.4"
+version = "0.38.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -626,6 +626,22 @@ _DTYPE_STORAGE_BITS = {
 }
 
 
+def _hf_plan_looks_like_ltx2(plan: Any) -> bool:
+    """Pre-download family hint mirroring run_clone's post-download
+    ``ltx2_native`` check (gw#592), using ONLY the file-listing paths
+    ``plan_huggingface`` already has (no bytes fetched yet). LTX-2 root
+    checkpoint filenames (``ltx-2.3-22b-dev.safetensors``) carry the "ltx2"
+    token themselves, so :func:`layout.infer_model_family_variant_from_hint`
+    resolves it from paths alone — the same signal
+    ``detect_huggingface_source_layout`` uses post-download."""
+    from .layout import infer_model_family_variant_from_hint
+
+    for p in getattr(plan, "paths", None) or ():
+        if infer_model_family_variant_from_hint(str(p)) == "ltx2":
+            return True
+    return False
+
+
 def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
     """Fail fast when the disk cannot fit the clone. The source plan knows
     every selected file's size before a byte is downloaded (HF list_repo_tree
@@ -654,12 +670,26 @@ def _preflight_disk(workdir: Path, plan: Any, specs: list[OutputSpec]) -> None:
             attrs = {"file_layout": "singlefile", "file_type": source_type}
             if source_type == "gguf":
                 strategy = "gguf"
+        # gw#592/gw#593: run_clone routes strategy="aio_singlefile" LTX-2
+        # sources through publish_as_is (no diffusers pipeline exists for the
+        # family; the te#70 trainer resolves the native singlefile snapshot
+        # directly) regardless of the requested output layout — but this
+        # preflight only sees the pre-download classification, which has no
+        # ltx2_native concept, so it was estimating a full layout-repack +
+        # materialized-dtype-tree budget (388GB for a 43GB source) for a
+        # clone that actually only ever needs the source bytes + margin.
+        # Found live: e2e#185 ltx-firstlight run 7, CloneDiskSpaceError on a
+        # 200GB pod for a 43GB LTX-2.3 dev-checkpoint clone.
+        ltx2_native = (
+            strategy == "aio_singlefile" and provider == "huggingface"
+            and _hf_plan_looks_like_ltx2(plan)
+        )
     except Exception:  # noqa: BLE001 — preflight is best-effort on odd plans
         return
     if source_bytes <= 0:
         return
 
-    if strategy in _PUBLISH_AS_IS_STRATEGIES:
+    if strategy in _PUBLISH_AS_IS_STRATEGIES or ltx2_native:
         required = source_bytes + _DISK_MARGIN_BYTES
         operation = f"{strategy} publishes the source tree directly"
     else:

--- a/tests/convert/test_clone_hygiene.py
+++ b/tests/convert/test_clone_hygiene.py
@@ -36,10 +36,13 @@ class _Plan:
         strategy: str = "",
         attrs: dict[str, str] | None = None,
         paths: list[str] | None = None,
+        provider: str = "",
     ) -> None:
         self._sizes = sizes
         self._paths = paths or [f"f{i}.safetensors" for i in range(len(sizes))]
         self.classification = SimpleNamespace(strategy=strategy, attrs=attrs or {})
+        self.provider = provider
+        self.paths = self._paths
 
     def bank_files(self):
         return [
@@ -110,6 +113,58 @@ def test_preflight_passes_tiny_source(tmp_path: Path) -> None:
 
 def test_preflight_skips_when_plan_unavailable(tmp_path: Path) -> None:
     _preflight_disk(tmp_path, None, _specs())  # fail-open: download surfaces its own error
+
+
+def test_preflight_ltx2_singlefile_needs_only_source_plus_margin(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """gw#592/gw#593 companion: run_clone routes strategy='aio_singlefile'
+    LTX-2 sources through publish_as_is regardless of the requested output
+    layout (no diffusers pipeline exists for the family) -- but without this
+    fix, preflight had no ltx2_native concept and budgeted a full
+    layout-repack + materialized-dtype tree for a clone that only ever needs
+    the source bytes. Found live: e2e#185 run 7, CloneDiskSpaceError
+    (need ~388.8 GiB) on a real 43GB LTX-2.3 dev-checkpoint clone that
+    should only need ~45GB. Real filename (source_include-narrowed to the
+    ONE checkpoint) + real size."""
+    source_bytes = 46_149_344_974  # real ltx-2.3-22b-dev.safetensors size
+    plan = _Plan(
+        [source_bytes],
+        strategy="aio_singlefile",
+        attrs={"file_layout": "singlefile", "dtype": "bf16"},
+        paths=["ltx-2.3-22b-dev.safetensors"],
+        provider="huggingface",
+    )
+    # Requested {dtype bf16, layout diffusers} -- mismatched layout from the
+    # singlefile source, which (absent the ltx2_native carve-out) would send
+    # this down the materialized/repack disk-budget branch.
+    specs = _specs(dtype="bf16", layout="diffusers")
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=60 * 1024**3),  # fits source+margin, NOT the repack budget
+    )
+    _preflight_disk(tmp_path, plan, specs)  # must not raise
+
+
+def test_preflight_non_ltx2_singlefile_still_budgets_the_repack(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Guardrail: the ltx2 carve-out must not swallow the general singlefile
+    ->diffusers repack case (e.g. sdxl/flux/zimage) -- those genuinely need
+    the wider budget."""
+    plan = _Plan(
+        [50 * 1024**3],
+        strategy="aio_singlefile",
+        attrs={"file_layout": "singlefile", "dtype": "bf16"},
+        paths=["some-checkpoint-v1.safetensors"],
+        provider="huggingface",
+    )
+    monkeypatch.setattr(
+        "gen_worker.convert.clone.shutil.disk_usage",
+        lambda _: SimpleNamespace(free=60 * 1024**3),  # fits source+margin, NOT the repack budget
+    )
+    with pytest.raises(CloneDiskSpaceError):
+        _preflight_disk(tmp_path, plan, _specs(dtype="bf16", layout="diffusers"))
 
 
 def test_preflight_has_no_environment_headroom_override(tmp_path: Path, monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.4"
+version = "0.38.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- `run_clone` routes `strategy="aio_singlefile"` LTX-2 sources through
  publish_as_is regardless of the requested output layout (gw#592 — no
  diffusers pipeline exists for the family), but `_preflight_disk` had no
  equivalent carve-out and budgeted a full layout-repack +
  materialized-dtype-tree estimate for a clone that only ever needs the
  source bytes + margin — 388GB estimated for a real 43GB LTX-2.3
  dev-checkpoint clone.
- Fix derives the same LTX-2 hint from the pre-download file listing
  (`layout.infer_model_family_variant_from_hint` per path — the filename
  itself carries the "ltx2" token, no bytes needed) and applies the
  publish-as-is disk budget.
- Found live: e2e#185 ltx-firstlight run 7, `CloneDiskSpaceError` on a real
  43GB clone (200GB pod, needed only ~45GB).

## Test plan
- [x] `uv run pytest tests/convert/test_clone_hygiene.py -q` — 18 passed
  (new: LTX-2 singlefile preflight fits source+margin; guardrail proves a
  non-LTX-2 singlefile source still budgets the full repack)
- [x] `uv run pytest tests/convert -q` — 141 passed/6 skipped (same
  pre-existing unrelated failures as base master, no regressions)
- [x] `ruff check` clean