### PR TITLE
gw#593 companion: reshard oversized monoliths in publish_as_is passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.38.6 (2026-07-19)
+
+- **gw#593 companion: publish_as_is's zero-cost passthrough never resharded
+  an oversized monolithic weight file.** `run_clone`'s `tree = source.dir`
+  shortcut (dtype already matches, no cast needed) bypasses
+  `build_flavor_tree` entirely — every one of ITS branches ends in
+  `_stage_oversize_safetensors` — so a source shipping ONE oversized
+  safetensors file with no HF-convention shards to begin with (exactly
+  `Lightricks/LTX-2.3`'s 46GB `ltx-2.3-22b-dev.safetensors`) was published
+  raw, and Tensorhub's commit API rejected it (`request_too_large: file
+  exceeds max_bytes_per_file`). Found live: e2e#185 ltx-firstlight run 8.
+  Now hardlinks into a scratch tree and reshards only when something is
+  actually oversize — the common case (already-sharded sources) stays the
+  zero-cost passthrough.
+
 ## 0.38.5 (2026-07-19)
 
 - **gw#592/gw#593 companion: disk preflight didn't know about LTX-2's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.5"
+version = "0.38.6"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -1008,6 +1008,30 @@ def run_clone(
                         tree = source.dir
                         attrs = dict(source.attrs)
                         flavor_label = source_dtype or spec.dtype
+                        # gw#593 companion: this passthrough bypasses
+                        # build_flavor_tree entirely (every one of ITS
+                        # branches ends in _stage_oversize_safetensors), so a
+                        # source shipping one oversized MONOLITHIC
+                        # safetensors file with no HF-convention shards (no
+                        # sharding at all to reshard around — e.g. LTX-2.3's
+                        # 46GB ltx-2.3-22b-dev.safetensors) was published raw
+                        # and tensorhub's commit API rejected it
+                        # (request_too_large: file exceeds
+                        # max_bytes_per_file). Found live: e2e#185
+                        # ltx-firstlight run 8. Hardlink into a scratch tree
+                        # and reshard only when something is actually
+                        # oversize — the common case (already-sharded
+                        # sources) stays the zero-cost passthrough.
+                        if spec.file_type == "safetensors" and any(
+                            f.is_file() and f.stat().st_size > MAX_SAFETENSORS_SHARD_BYTES
+                            for f in Path(tree).rglob("*.safetensors")
+                        ):
+                            reshard_dir = workdir / f"flavor-{spec.label}.__reshard__"
+                            shutil.rmtree(reshard_dir, ignore_errors=True)
+                            reshard_dir.mkdir(parents=True, exist_ok=True)
+                            copy_non_weight_files(Path(tree), reshard_dir, skip_components=set())
+                            _stage_oversize_safetensors(reshard_dir)
+                            tree = reshard_dir
                     elif i == 0 and spec.file_type == "safetensors" \
                             and (strategy in _CAST_ELIGIBLE_PUBLISH_AS_IS_STRATEGIES
                                  or ltx2_native):

--- a/tests/convert/test_clone_ltx2_routing.py
+++ b/tests/convert/test_clone_ltx2_routing.py
@@ -171,3 +171,57 @@ def test_non_ltx2_aio_singlefile_is_unaffected(
     assert not result.failed_flavors, result.failed_flavors
     assert len(calls) == 1
     assert calls[0]["file_layout"] == "singlefile"
+
+
+def test_ltx2_oversized_monolith_reshards_before_publish(
+    fake_hub, tmp_path: Path, monkeypatch,
+) -> None:
+    """gw#593 companion: the publish_as_is passthrough branch (dtype
+    matches, no cast needed) bypasses build_flavor_tree entirely — every ONE
+    of build_flavor_tree's own branches ends in
+    _stage_oversize_safetensors, so a source shipping a single oversized
+    MONOLITHIC safetensors file (no HF-convention shards to begin with --
+    exactly LTX-2.3's real 46GB ltx-2.3-22b-dev.safetensors) was published
+    raw. tensorhub's commit API rejects an over-cap single file
+    (request_too_large: file exceeds max_bytes_per_file) -- found live,
+    e2e#185 ltx-firstlight run 8. Threshold monkeypatched tiny so the test
+    stays byte-sized; asserts the reshard step actually ran (not the
+    original source.dir) and non-weight files still ride along."""
+    _FakeHub.state["finalize_calls"] = 1
+    monkeypatch.setenv("COZY_CONVERT_WORKDIR", str(tmp_path / "work"))
+    monkeypatch.setattr("gen_worker.convert.clone.MAX_SAFETENSORS_SHARD_BYTES", 16)
+
+    reshard_calls: list = []
+    import gen_worker.convert.clone as clone_mod
+
+    real_stage = clone_mod._stage_oversize_safetensors
+
+    def spy_stage(tree, **kwargs):
+        # Capture path + contents NOW — run_clone's cleanup rmtrees the
+        # whole workdir (incl. this scratch dir) once the clone succeeds.
+        reshard_calls.append((Path(tree), sorted(p.name for p in Path(tree).iterdir())))
+        return real_stage(tree, **kwargs)
+
+    monkeypatch.setattr("gen_worker.convert.clone._stage_oversize_safetensors", spy_stage)
+
+    source_dir = tmp_path / "source"
+    source = _ltx2_source(source_dir, dtype="bf16")
+    (source_dir / "README.md").write_text("license text")
+    _install_fake_ingest(monkeypatch, source)
+
+    result = run_clone(
+        _Ctx(fake_hub), provider="huggingface", source_ref="Lightricks/LTX-2.3",
+        destination_repo="acme/ltx-2.3-dev",
+        outputs=[{"dtype": "bf16", "file_layout": "diffusers", "file_type": "safetensors"}],
+    )
+
+    assert not result.failed_flavors, result.failed_flavors
+    assert len(result.published) == 1
+    # The oversize check fired and staged into a NEW tree, not source.dir.
+    assert reshard_calls, "expected _stage_oversize_safetensors to run"
+    reshard_dir, reshard_contents = reshard_calls[0]
+    assert reshard_dir != source_dir
+    assert reshard_dir.is_relative_to(tmp_path / "work")  # scratch workdir, not source
+    # Non-weight files still ride along (hardlinked before the reshard).
+    assert "README.md" in reshard_contents
+    assert "ltx-2.3-13b-dev.safetensors" in reshard_contents

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.5"
+version = "0.38.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- `run_clone`'s `tree = source.dir` shortcut (publish_as_is, dtype already
  matches) bypasses `build_flavor_tree` entirely — every one of its own
  branches ends in `_stage_oversize_safetensors` — so a source shipping ONE
  oversized monolithic safetensors file with no shards to begin with
  (`Lightricks/LTX-2.3`'s real 46GB `ltx-2.3-22b-dev.safetensors`) was
  published raw. Tensorhub's commit API rejects that
  (`request_too_large: file exceeds max_bytes_per_file`).
- Found live: e2e#185 ltx-firstlight run 8.
- Fix checks for an oversized safetensors file before taking the shortcut;
  when found, hardlinks into a scratch tree and reshards (same pattern
  `build_flavor_tree`'s own "source" dtype branch uses). The common case
  (nothing oversize) stays the zero-cost passthrough.

## Test plan
- [x] `uv run pytest tests/convert/test_clone_ltx2_routing.py -q` — 4 passed
  (new: oversized monolith reshards into a scratch tree, non-weight files
  ride along; existing 3 routing tests unaffected)
- [x] `uv run pytest tests/convert -q` — 142 passed/6 skipped, no
  regressions (same pre-existing unrelated failures as base master)
- [x] `ruff check` clean