### PR TITLE
pgw#594: second reserved model-input field text_encoder for producer payloads (0.38.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.38.7 (2026-07-19)
+
+- **pgw#594: second reserved model-input field, `text_encoder`, for producer
+  payloads (te#70 Gemma-TE video-LoRA training).** `source`/`destination`
+  were reserved-name `SourceRepo`/`DestinationRepo` fields special-cased by
+  literal name in the executor; any producer (training/conversion) payload
+  can now also declare `text_encoder: SourceRepo | None = None` and get it
+  materialized the same way as `source` — into `ctx.text_encoder_path`
+  (`ctx.text_encoder` for the raw dict), fully independent of
+  `ctx.source_path`. Generic mechanism: gen-worker has no ltx2/Gemma
+  awareness. Absent field (every existing endpoint) is byte-for-byte
+  unchanged — no extra `ensure_local` call, `ctx.text_encoder_path` stays
+  `None`.
+
 ## 0.38.6 (2026-07-19)
 
 - **gw#593 companion: publish_as_is's zero-cost passthrough never resharded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.6"
+version = "0.38.7"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/types.py
+++ b/src/gen_worker/api/types.py
@@ -206,6 +206,11 @@ class SourceRepo(msgspec.Struct):
     conversion or training job. Endpoints embed this type in their Input struct
     as the reserved-name field ``source``.
 
+    Also reused verbatim (pgw#594) for the second, independent reserved
+    field ``text_encoder`` — e.g. a text-encoder repo wholly separate from
+    the primary ``source`` model. Materialized the same way, into
+    ``ctx.text_encoder_path``.
+
     Fields:
       - ref: "owner/repo" | "owner/repo:tag[#flavor...]" | "owner/repo@<checkpoint-id>"
       - checkpoint_id: explicit content-addressed checkpoint id; highest-priority selector

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -166,8 +166,9 @@ def _sanitize(message: str) -> str:
 
 
 def _reserved_repo_info(payload: Any, field_name: str) -> Dict[str, Any]:
-    """``payload.source`` / ``payload.destination`` as a plain dict ({} when
-    absent). Producer payloads carry these reserved-name structs (#376)."""
+    """``payload.source`` / ``payload.destination`` / ``payload.text_encoder``
+    as a plain dict ({} when absent). Producer payloads carry these
+    reserved-name structs (#376, pgw#594)."""
     obj = getattr(payload, field_name, None)
     if obj is None:
         return {}
@@ -5248,6 +5249,10 @@ class Executor:
         producer = spec.kind != "inference"
         source_info = _reserved_repo_info(payload, "source") if producer else {}
         destination_info = _reserved_repo_info(payload, "destination") if producer else {}
+        # pgw#594/te#70: a second, wholly independent reserved model input
+        # (e.g. a text-encoder repo separate from the primary `source` DiT).
+        # Absent on every existing payload struct — stays {} and is a no-op.
+        text_encoder_info = _reserved_repo_info(payload, "text_encoder") if producer else {}
 
         # gw#453: arm repo-CAS checkpoint routing for producer jobs. Without
         # kind/destination_repo/job_id the ctx's _repo_job_upload_scope() is
@@ -5270,6 +5275,7 @@ class Executor:
             producer_kwargs = dict(
                 source_info=source_info,
                 destination_info=destination_info,
+                text_encoder_info=text_encoder_info,
                 hf_token=getattr(self._settings, "hf_token", "") or "",
             )
 
@@ -5328,6 +5334,11 @@ class Executor:
             ctx.raise_if_cancelled("canceled")
             if source_info:
                 await self._materialize_source(ctx, source_info, snapshots)
+            if text_encoder_info:
+                await self._materialize_source(
+                    ctx, text_encoder_info, snapshots,
+                    set_path=ctx._set_text_encoder_path, field_name="text_encoder",
+                )
             if producer:
                 await self._materialize_datasets(ctx, payload)
             instance = await self.ensure_setup(spec, snapshots, promote_slots=routed)
@@ -5512,16 +5523,24 @@ class Executor:
             self._maybe_idle()
 
     async def _materialize_source(
-        self, ctx: Any, info: Dict[str, Any], snapshots: Dict[str, pb.Snapshot]
+        self,
+        ctx: Any,
+        info: Dict[str, Any],
+        snapshots: Dict[str, pb.Snapshot],
+        *,
+        set_path: Optional[Callable[[str], None]] = None,
+        field_name: str = "source",
     ) -> None:
-        """Reserved-source contract (#376): materialize ``payload.source``
-        locally before the handler runs. Same ModelStore path as model
-        bindings — identical retry/classification and ModelEvent emission."""
+        """Reserved repo-field contract (#376, generalized pgw#594):
+        materialize a reserved ``SourceRepo``-shaped payload field (default
+        ``payload.source``, also used for ``payload.text_encoder``) locally
+        before the handler runs. Same ModelStore path as model bindings —
+        identical retry/classification and ModelEvent emission."""
         ref = str(info.get("ref") or "").strip()
         if not ref:
-            raise ValidationError("payload.source.ref must be a non-empty repo ref")
+            raise ValidationError(f"payload.{field_name}.ref must be a non-empty repo ref")
         path = await self.store.ensure_local(ref, snapshots.get(ref))
-        ctx._set_source_path(str(path))
+        (set_path or ctx._set_source_path)(str(path))
 
     async def _materialize_datasets(self, ctx: Any, payload: Any) -> None:
         """Reserved-datasets contract (gw#425): materialize every

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -971,9 +971,9 @@ class _PublisherMixin:
     ``_get_worker_capability_token``).
 
     Producer-only STATE lives here too (pgw#526): the reserved
-    ``source``/``destination`` payload structs, the hf token, and the repo
-    spec for checkpoint commits initialize in this ``__init__`` — a plain
-    inference ``RequestContext`` never carries them.
+    ``source``/``destination``/``text_encoder`` payload structs, the hf
+    token, and the repo spec for checkpoint commits initialize in this
+    ``__init__`` — a plain inference ``RequestContext`` never carries them.
 
     Not a public surface: tenants should never import this directly.
     """
@@ -983,6 +983,7 @@ class _PublisherMixin:
         *args: Any,
         source_info: Optional[Dict[str, Any]] = None,
         destination_info: Optional[Dict[str, Any]] = None,
+        text_encoder_info: Optional[Dict[str, Any]] = None,
         hf_token: str = "",
         **kwargs: Any,
     ) -> None:
@@ -994,6 +995,8 @@ class _PublisherMixin:
         self._source_info = dict(source_info or {})
         self._destination_info = dict(destination_info or {})
         self._source_path: Optional[str] = None
+        self._text_encoder_info = dict(text_encoder_info or {})
+        self._text_encoder_path: Optional[str] = None
         self._hf_token = (hf_token or "").strip()
         # Repo fields declared by the ingest pipeline before the first
         # checkpoint commit. Sent in the /commits body so tensorhub can
@@ -1057,6 +1060,22 @@ class _PublisherMixin:
     def _set_source_path(self, path: str) -> None:
         """Library-internal: called after source materialization."""
         self._source_path = str(path) if path else None
+
+    # Second reserved-name model input (pgw#594, te#70): a wholly independent
+    # repo from `source`, materialized the same way. Absent for every
+    # existing producer payload — `text_encoder`/`text_encoder_path` stay
+    # empty/None and no behavior changes.
+    @property
+    def text_encoder(self) -> dict[str, Any]:
+        return dict(self._text_encoder_info)
+
+    @property
+    def text_encoder_path(self) -> Optional[str]:
+        return self._text_encoder_path
+
+    def _set_text_encoder_path(self, path: str) -> None:
+        """Library-internal: called after text_encoder materialization."""
+        self._text_encoder_path = str(path) if path else None
 
     def set_repo_spec(
         self,

--- a/tests/test_executor_text_encoder_materialization.py
+++ b/tests/test_executor_text_encoder_materialization.py
@@ -1,0 +1,197 @@
+"""pgw#594/te#70: second reserved model-input materialization.
+
+Producer-kind payloads carrying the reserved ``text_encoder`` struct (same
+``SourceRepo`` type as ``source``) get a materialized local snapshot at
+``ctx.text_encoder_path``, independent of and never clobbering ``source`` /
+``ctx.source_path``. Absent field is a no-op — every existing endpoint that
+doesn't declare ``text_encoder`` sees no behavior change."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import List, Optional
+
+import msgspec
+
+from gen_worker.api.types import SourceRepo
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _TrainIn(msgspec.Struct):
+    source: Optional[SourceRepo] = None
+    text_encoder: Optional[SourceRepo] = None
+    dtype: str = "bf16"
+
+
+class _Out(msgspec.Struct):
+    source_path: str
+    source_ref: str
+    text_encoder_path: str
+    text_encoder_ref: str
+
+
+def _train(ctx, payload: _TrainIn) -> _Out:
+    return _Out(
+        source_path=str(ctx.source_path or ""),
+        source_ref=str((ctx.source or {}).get("ref") or ""),
+        text_encoder_path=str(ctx.text_encoder_path or ""),
+        text_encoder_ref=str((ctx.text_encoder or {}).get("ref") or ""),
+    )
+
+
+def _spec() -> EndpointSpec:
+    return EndpointSpec(
+        name="video-lora-train", method=_train, kind="training",
+        payload_type=_TrainIn, output_mode="single",
+    )
+
+
+class _Harness:
+    """Returns a distinct local path per ref, so tests can assert `source`
+    and `text_encoder` land in genuinely separate locations."""
+
+    def __init__(self, tmp_path: Path, *, fail_with: Optional[BaseException] = None) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.ensured: List[str] = []
+        self.tmp_path = tmp_path
+        self.fail_with = fail_with
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        self.executor = Executor([_spec()], _send)
+
+        async def _fake_ensure_local(ref, snapshot=None, *, binding=None) -> Path:
+            self.ensured.append(ref)
+            if self.fail_with is not None:
+                raise self.fail_with
+            out = self.tmp_path / ref.replace("/", "_").replace(":", "_")
+            out.mkdir(parents=True, exist_ok=True)
+            return out
+
+        self.executor.store.ensure_local = _fake_ensure_local  # type: ignore[method-assign]
+
+    async def run(self, payload: _TrainIn) -> pb.JobResult:
+        await self.executor.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="video-lora-train",
+            input_payload=msgspec.msgpack.encode(payload)))
+        job = self.executor.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        results = [m.job_result for m in self.sent if m.WhichOneof("msg") == "job_result"]
+        assert results, f"no job_result; sent={self.sent}"
+        return results[-1]
+
+
+def test_text_encoder_materialized_independent_of_source(tmp_path) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path)
+        res = await h.run(_TrainIn(
+            source=SourceRepo(ref="acme/ltx2-dit:prod"),
+            text_encoder=SourceRepo(ref="google/gemma-3-12b"),
+        ))
+        assert res.status == pb.JOB_STATUS_OK
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.source_ref == "acme/ltx2-dit:prod"
+        assert out.text_encoder_ref == "google/gemma-3-12b"
+        assert out.source_path and out.text_encoder_path
+        assert out.source_path != out.text_encoder_path
+        assert set(h.ensured) == {"acme/ltx2-dit:prod", "google/gemma-3-12b"}
+
+    asyncio.run(_run())
+
+
+def test_missing_text_encoder_is_noop(tmp_path) -> None:
+    """The common case: every existing endpoint that never declares
+    `text_encoder` sees byte-for-byte unchanged behavior — no ensure_local
+    call for it, ctx.text_encoder_path stays empty."""
+    async def _run() -> None:
+        h = _Harness(tmp_path)
+        res = await h.run(_TrainIn(source=SourceRepo(ref="acme/ltx2-dit:prod")))
+        assert res.status == pb.JOB_STATUS_OK
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.source_path
+        assert out.text_encoder_path == ""
+        assert out.text_encoder_ref == ""
+        assert h.ensured == ["acme/ltx2-dit:prod"]
+
+    asyncio.run(_run())
+
+
+def test_missing_both_reserved_fields_is_noop(tmp_path) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path)
+        res = await h.run(_TrainIn())
+        assert res.status == pb.JOB_STATUS_OK
+        out = msgspec.msgpack.decode(res.inline, type=_Out)
+        assert out.source_path == ""
+        assert out.text_encoder_path == ""
+        assert h.ensured == []
+
+    asyncio.run(_run())
+
+
+def test_empty_text_encoder_ref_is_invalid(tmp_path) -> None:
+    async def _run() -> None:
+        h = _Harness(tmp_path)
+        res = await h.run(_TrainIn(
+            source=SourceRepo(ref="acme/ltx2-dit:prod"),
+            text_encoder=SourceRepo(ref="  "),
+        ))
+        assert res.status == pb.JOB_STATUS_INVALID
+
+    asyncio.run(_run())
+
+
+def test_text_encoder_download_failure_classifies_like_source(tmp_path) -> None:
+    from gen_worker.api.errors import RetryableError
+
+    async def _run() -> None:
+        h = _Harness(tmp_path, fail_with=RetryableError("snapshot not provided"))
+        res = await h.run(_TrainIn(
+            source=SourceRepo(ref="acme/ltx2-dit:prod"),
+            text_encoder=SourceRepo(ref="google/gemma-3-12b"),
+        ))
+        assert res.status == pb.JOB_STATUS_RETRYABLE
+
+    asyncio.run(_run())
+
+
+def test_inference_kind_ignores_reserved_text_encoder(tmp_path) -> None:
+    class _InfOut(msgspec.Struct):
+        ok: bool
+
+    def _infer(ctx, payload: _TrainIn) -> _InfOut:
+        return _InfOut(ok=not hasattr(ctx, "text_encoder_path"))
+
+    spec = EndpointSpec(
+        name="infer", method=_infer, kind="inference",
+        payload_type=_TrainIn, output_mode="single",
+    )
+
+    async def _run() -> None:
+        sent: List[pb.WorkerMessage] = []
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            sent.append(msg)
+
+        ex = Executor([spec], _send)
+
+        async def _boom(ref, snapshot=None, *, binding=None) -> Path:
+            raise AssertionError("inference must not materialize text_encoder")
+
+        ex.store.ensure_local = _boom  # type: ignore[method-assign]
+        await ex.handle_run_job(pb.RunJob(
+            request_id="r1", attempt=1, function_name="infer",
+            input_payload=msgspec.msgpack.encode(
+                _TrainIn(text_encoder=SourceRepo(ref="google/gemma-3-12b")))))
+        job = ex.jobs[("r1", 1)]
+        assert job.task is not None
+        await job.task
+        results = [m.job_result for m in sent if m.WhichOneof("msg") == "job_result"]
+        assert results[-1].status == pb.JOB_STATUS_OK
+
+    asyncio.run(_run())

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -108,9 +108,11 @@ def test_models_property_copies() -> None:
 def test_inference_ctx_carries_no_producer_state() -> None:
     ctx = _ctx()
     for attr in ("_source_info", "_destination_info", "_source_path",
+                 "_text_encoder_info", "_text_encoder_path",
                  "_hf_token", "_repo_spec"):
         assert not hasattr(ctx, attr), attr
     for surface in ("hf_token", "source", "destination", "source_path",
+                    "text_encoder", "text_encoder_path",
                     "set_repo_spec", "save_checkpoint", "checkpoint_dir",
                     "compute"):
         assert not hasattr(ctx, surface), surface
@@ -133,6 +135,34 @@ def test_producer_ctx_carries_producer_state() -> None:
     assert ctx.source_path == "/models/base"
     ctx.set_repo_spec(kind="lora", model_family="sdxl")
     assert ctx._repo_spec == {"kind": "lora", "model_family": "sdxl"}
+
+
+def test_producer_ctx_carries_text_encoder_state() -> None:
+    """pgw#594/te#70: second reserved model input, independent of `source`."""
+    from gen_worker.request_context import TrainingContext
+
+    ctx = TrainingContext(
+        request_id="r1",
+        source_info={"ref": "o/dit-base"},
+        text_encoder_info={"ref": "o/gemma-3-12b"},
+    )
+    assert ctx.text_encoder == {"ref": "o/gemma-3-12b"}
+    assert ctx.text_encoder_path is None
+    ctx._set_text_encoder_path("/models/text-encoder")
+    assert ctx.text_encoder_path == "/models/text-encoder"
+    # Independent of `source` — setting one never clobbers the other.
+    assert ctx.source_path is None
+    ctx._set_source_path("/models/dit-base")
+    assert ctx.source_path == "/models/dit-base"
+    assert ctx.text_encoder_path == "/models/text-encoder"
+
+
+def test_producer_ctx_text_encoder_defaults_empty() -> None:
+    from gen_worker.request_context import TrainingContext
+
+    ctx = TrainingContext(request_id="r1", source_info={"ref": "o/base"})
+    assert ctx.text_encoder == {}
+    assert ctx.text_encoder_path is None
 
 
 def test_producer_kwargs_rejected_on_inference_ctx() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.6"
+version = "0.38.7"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Generalizes the existing `source`/`destination` reserved-name producer-payload mechanism with a second, independent field: `text_encoder: SourceRepo | None = None`.
- Materialized the same way `source` is (same ModelStore path, retry/classification, ModelEvent emission) into `ctx.text_encoder_path` / `ctx.text_encoder`, fully independent of `ctx.source_path`.
- Generic mechanism — gen-worker has no ltx2/Gemma awareness. Needed by te#70 (LTX-2.3 video-LoRA training: a Gemma-3-12B text encoder lives in a wholly separate repo from the LTX-2.3 DiT `source`).
- Absent field (every existing endpoint today) is byte-for-byte unchanged — no extra `ensure_local` call, `ctx.text_encoder_path` stays `None`.

## Test plan
- [x] `uv run pytest tests/ -q` — 1509 passed, 41 skipped (0:03:35)
- [x] `uv run ruff check` on all touched files — clean (repo-wide ruff has 25 pre-existing errors in unrelated test files, confirmed present on origin/master, not touched by this diff)
- [x] New test: `tests/test_executor_text_encoder_materialization.py` — payload with `text_encoder` set materializes into a distinct local path from `source`; absent field is a clean no-op