### PR TITLE
gw#595: qwen producer guidance-kwarg parity + per-object warmup provability (0.38.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.39.1 (2026-07-19)
+
+- **gw#595: qwen compiled serve — producer guidance-kwarg parity +
+  per-object warmup provability (ie#501 run 19).** Two coupled defects:
+  (a) `compile_cache._warm_call` warmed every declared guidance scale
+  through `guidance_scale=` — on classes exposing `true_cfg_scale` (qwen)
+  that is the distilled-guidance embed no-op and classic CFG rides
+  `true_cfg_scale` + a non-None `negative_prompt`, so the minted "cfg 4.0"
+  pass traced the SAME unconditioned graph as the 1.0 pass and the serving
+  CFG lookup could never hit (the gw#586 class, call-KWARG axis). The warm
+  call now uses the true-CFG convention when the signature declares it
+  (also inherited by 0.39.0's shared mint brain `mint_artifact`, so fleet
+  self-mints trace the real CFG graphs too).
+  (b) The post-arm warmup proof required EVERY armed compile object to
+  serve its own cache hit, but a merged multi-lane endpoint (qwen t2i +
+  edit on one family cell) has objects the declared warmup structurally
+  cannot exercise (edit needs an input image) — mandatory-W8A8 setup
+  fail-closed forever. The proof now scopes per object: an EXERCISED
+  object (calls>0) must hit or the cell is disproven and fails closed
+  exactly as before; an unexercised object (calls=0) with a proven sibling
+  stays armed unproven on mandatory lanes (logged:
+  "armed unproven: no warmup modality") or unwraps to eager on optional
+  lanes; zero proven objects still fails closed (the gw#586 hole stays
+  shut). Hot adopt gains the distinct `no_warmup_modality` refusal so an
+  unprovable target is named as such instead of `cache_miss`.
+
 ## 0.39.0 (2026-07-19)
 
 - **gw#587: fleet worker self-mint — the serving worker compiles its own
@@ -22,6 +48,8 @@
   attestation basis; absent ⇒ publish refused, harmless for old workers
   which never call the route). A hub delivery without a cell no longer
   tears down a worker's own armed, proven target (worker-owned cells).
+
+## 0.38.7 (2026-07-19)
 
 - **pgw#594: second reserved model-input field, `text_encoder`, for producer
   payloads (te#70 Gemma-TE video-LoRA training).** `source`/`destination`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.39.0"
+version = "0.39.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1683,8 +1683,15 @@ def _warm_call(
     upsampler of identical shape) will look up. Video calls force the
     batch-1 no-CFG serving regime (CFG is a graph shape — ``Compile``) and
     skip decode unless a vae target is declared. Image calls run once per
-    explicitly declared guidance scale, capturing CFG batch-2 and no-CFG
-    batch-1 graphs in one family cell."""
+    explicitly declared guidance scale, capturing CFG and no-CFG graphs in
+    one family cell.
+
+    Guidance-kwarg convention (gw#595, the gw#586 class one axis over): on
+    classes exposing ``true_cfg_scale`` (qwen-style), ``guidance_scale`` is
+    the distilled-guidance embed no-op and classic CFG rides
+    ``true_cfg_scale`` + a non-None ``negative_prompt`` — warming through
+    ``guidance_scale`` there traces the SAME unconditioned graph for every
+    declared scale and the serving CFG lookup can never hit."""
     import inspect
 
     import torch
@@ -1714,6 +1721,16 @@ def _warm_call(
         pipe(**kwargs)
         return
     params = inspect.signature(type(pipe).__call__).parameters
+    if "true_cfg_scale" in params:
+        # Serving parity with the endpoint call: true_cfg_scale always
+        # passed; negative_prompt only when CFG is on (scale > 1), matching
+        # the CFG-off batch-1 graph exactly (no uncond pass).
+        for scale in scales:
+            call = dict(kwargs, true_cfg_scale=scale)
+            if scale > 1.0:
+                call["negative_prompt"] = " "
+            pipe(**call)
+        return
     accepts_guidance = "guidance_scale" in params or any(
         p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
     )

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3310,7 +3310,16 @@ class Executor:
             else:
                 warmed, function_proofs = await run_warmup()
             if proves_inductor:
-                unproven: list[_CompileObjectCandidate] = []
+                # gw#595 per-object provability: the proof scopes to objects
+                # the warmup actually EXERCISED (calls>0). An exercised object
+                # must serve its own cache hit or it disproves the cell. An
+                # unexercised object (the warmup has no modality for it, e.g.
+                # an edit lane needing an input image) neither proves nor
+                # disproves — with a proven sibling it must not block
+                # adoption. Zero proven objects still fails closed (gw#586).
+                disproven: list[_CompileObjectCandidate] = []
+                unexercised: list[_CompileObjectCandidate] = []
+                proven = 0
                 hits = 0
                 misses = 0
                 for candidate in inj.compile_objects:
@@ -3323,10 +3332,18 @@ class Executor:
                     pipe_misses = compile_cache.cache_miss_count(pipe) - before[1]
                     hits += max(0, pipe_hits)
                     misses += max(0, pipe_misses)
-                    if not warmed or calls <= 0 or pipe_hits <= 0:
-                        unproven.append(candidate)
-                    elif callable(warmup):
-                        function_proofs[id(pipe)] = {spec.name}
+                    if not warmed or calls <= 0:
+                        unexercised.append(candidate)
+                    elif pipe_hits <= 0:
+                        disproven.append(candidate)
+                    else:
+                        proven += 1
+                        if callable(warmup):
+                            function_proofs[id(pipe)] = {spec.name}
+                unproven = list(disproven)
+                if not proven:
+                    unproven.extend(unexercised)
+                    unexercised = []
                 if unproven:
                     from .models.loading import pipeline_weight_lane
 
@@ -3351,6 +3368,32 @@ class Executor:
                     if quant_lane:
                         raise compile_cache.CompiledLaneUnavailableError(detail)
                     logger.warning("%s; serving eager", detail)
+                if unexercised:
+                    from .models.loading import pipeline_weight_lane
+                for candidate in unexercised:
+                    pipe = candidate.pipeline
+                    mandatory = pipeline_weight_lane(pipe).startswith(
+                        _MANDATORY_LANES)
+                    if mandatory:
+                        # Eager is not a lane for it and a proven sibling
+                        # vouches for the cell: stays armed unproven. Its
+                        # own graphs, absent from the cell by design, fail
+                        # loud at first use instead of at every boot.
+                        logger.warning(
+                            "compile object (slots=%s) armed unproven: no "
+                            "warmup modality exercised it (calls=0); the "
+                            "proof covers only its exercised siblings",
+                            sorted(candidate.slots))
+                        continue
+                    logger.warning(
+                        "compile object (slots=%s) unproven (no warmup "
+                        "modality, calls=0); serving eager",
+                        sorted(candidate.slots))
+                    function_proofs[id(pipe)] = set()
+                    compile_cache.unwrap(pipe)
+                    if int(getattr(spec.compile, "lora_bucket", 0) or 0):
+                        compile_cache.drop_lora_lane(pipe)
+                    inj.active_compile_artifacts.pop(id(pipe), None)
             if compile_selection and trt_engine.is_engine_ref(compile_selection.ref):
                 trt_candidates = [
                     candidate for candidate in inj.compile_objects
@@ -4942,7 +4985,17 @@ class Executor:
                         return await fail(
                             "no_warmup",
                             "target defines no runnable warmup; cache hits unprovable")
-                    if calls <= 0 or hits <= 0:
+                    if calls <= 0:
+                        # gw#595: distinct from a genuine miss — the warmup
+                        # has no modality that exercises this object at all,
+                        # so the cell is unprovable on this target rather
+                        # than disproven.
+                        await rollback()
+                        return await fail("no_warmup_modality", (
+                            "no warmup modality exercises this object "
+                            f"(calls=0, warmup={warmup_s}s); cell unprovable "
+                            "on this target"))
+                    if hits <= 0:
                         await rollback()
                         return await fail("cache_miss", (
                             "exact target warmup did not execute a cache-hit "

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -490,10 +490,11 @@ class Lifecycle:
                     # mirror-first (gw#465) still applies; that case is left
                     # to per-dispatch resolution as before.
                     missing = sorted({
-                        wire_ref(binding) for slot in spec.slots
-                        if (binding := spec.models.get(slot)) is not None
-                        and binding.source == "tensorhub"
-                        and self.executor.store.local_path(wire_ref(binding)) is None
+                        wire_ref(slot_binding) for slot in spec.slots
+                        if (slot_binding := spec.models.get(slot)) is not None
+                        and slot_binding.source == "tensorhub"
+                        and self.executor.store.local_path(
+                            wire_ref(slot_binding)) is None
                     })
                     if missing:
                         awaiting_hub[spec.name] = missing

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -963,6 +963,48 @@ def test_warm_call_captures_cfg_and_no_cfg(monkeypatch):
     assert calls == [5.0, 0.0]
 
 
+def test_warm_call_true_cfg_convention(monkeypatch):
+    """gw#595 mint-vs-serve guidance parity: on classes exposing
+    ``true_cfg_scale`` (qwen), classic CFG rides true_cfg_scale +
+    negative_prompt; ``guidance_scale`` is the distilled-guidance embed
+    no-op. Warming through guidance_scale would trace the unconditioned
+    graph for every declared scale and the serving CFG lookup could never
+    hit (ie#501 run 19)."""
+    torch = pytest.importorskip("torch")
+    calls = []
+    cfg_traces = []
+
+    class _Generator:
+        def __init__(self, device=None) -> None:
+            self.device = device
+
+        def manual_seed(self, _seed):
+            return self
+
+    class _TrueCfgPipe:
+        def __call__(
+            self, *, prompt=None, num_inference_steps=None, width=None,
+            height=None, generator=None, guidance_scale=1.0,
+            true_cfg_scale=4.0, negative_prompt=None, **_kwargs,
+        ):
+            calls.append((true_cfg_scale, negative_prompt, guidance_scale))
+            # diffusers' do_true_cfg gate: the CFG graph only exists when
+            # BOTH are supplied — the exact drift the mint must not repeat.
+            if true_cfg_scale > 1 and negative_prompt is not None:
+                cfg_traces.append(true_cfg_scale)
+
+    monkeypatch.setattr(torch, "Generator", _Generator)
+    cc._warm_call(
+        _TrueCfgPipe(), (1328, 1328), steps=2, prompt="warm", decode=False,
+        guidance_scales=(1.0, 4.0),
+    )
+    assert [c[0] for c in calls] == [1.0, 4.0]
+    assert calls[0][1] is None  # CFG off: no uncond pass, batch-1 graph
+    assert calls[1][1] is not None  # CFG regime carries a negative prompt
+    assert all(c[2] == 1.0 for c in calls)  # embed knob left at default
+    assert cfg_traces == [4.0]  # the true-CFG graph was actually traced
+
+
 class In(msgspec.Struct):
     prompt: str = ""
 

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1727,6 +1727,136 @@ def test_w8a8_partial_handler_proof_fails_loud_without_disabling_skipped_turbo(
     assert ex.compile_targets() == []
 
 
+def _merged_lane_endpoint(record_warm):
+    """Two w8a8 lane pipes behind ONE handler (the qwen merged shape): the
+    declared warmup can only exercise the t2i lane — edit needs an input
+    image, so its object has no warmup modality by design (gw#595)."""
+
+    @endpoint(
+        models={
+            "t2i": Hub("acme/qwen-image", flavor="fp8-w8a8"),
+            "edit": Hub("acme/qwen-image-edit", flavor="fp8-w8a8"),
+        },
+        resources=Resources(vram_gb=48),
+        compile=Compile(shapes=((1328, 1328),), family="qwen-image"),
+        warmup={"generate": {"prompt": "warmup"}},
+    )
+    class _MergedEndpoint:
+        def setup(self, t2i: _LoadablePipe, edit: _LoadablePipe) -> None:
+            self.t2i = t2i
+            self.edit = edit
+
+        def generate(self, ctx, payload: _In) -> _Out:
+            record_warm(self)
+            return _Out(y="ok")
+
+    return _MergedEndpoint
+
+
+def _wire_merged_lane(ex_cls_specs, tmp_path, monkeypatch):
+    import gen_worker.executor as executor_mod
+
+    family = "qwen-image"
+    cell_ref = f"_system/family-{family}#inductor-rtx-4090-torch2.9-w8a8"
+    artifact = _artifact(tmp_path, family=family)
+    model_dir = tmp_path / "merged-lane-model"
+    model_dir.mkdir(exist_ok=True)
+    pipes = {"t2i": _LoadablePipe(), "edit": _LoadablePipe()}
+    for pipe in pipes.values():
+        setattr(pipe, "_cozy_weight_lane", "w8a8")
+
+    async def _send(_msg):
+        return None
+
+    ex = Executor(ex_cls_specs, _send)
+    ex.store._cache_dir = tmp_path / "cas"
+
+    async def _download(ref, **kwargs):
+        return artifact.parent if ref == cell_ref else model_dir
+
+    monkeypatch.setattr(executor_mod, "ensure_local", _download)
+    monkeypatch.setattr(
+        provision,
+        "load_slot",
+        lambda *args, **kwargs: provision.SlotLoad(
+            obj=pipes[kwargs["slot"]], is_pipeline=True),
+    )
+    monkeypatch.setattr(ex, "_enable_compiled", _guarded_enable)
+    return ex, pipes, cell_ref
+
+
+def test_w8a8_unexercised_sibling_stays_armed_unproven(
+    tmp_path, monkeypatch, caplog,
+):
+    """gw#595(b): an armed MANDATORY-lane object the warmup has no modality
+    to exercise must not block adoption by the sibling that proves; it stays
+    armed unproven and is logged explicitly."""
+    cls = _merged_lane_endpoint(lambda self: _record_fake_warm(self.t2i))
+    specs = extract_specs(cls)
+    (generate,) = specs
+    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(ex.ensure_setup(generate, {
+            wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
+            wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
+            cell_ref: pb.Snapshot(digest=DIGEST_A),
+        }))
+
+    targets = {t.model_bindings[0].slot: t for t in ex.compile_targets()}
+    assert set(targets) == {"t2i", "edit"}
+    assert targets["t2i"].active_compile_ref == cell_ref
+    assert targets["t2i"].active_compile_snapshot_digest == DIGEST_A
+    # The edit lane is armed (eager is not a w8a8 lane) but unproven.
+    assert targets["edit"].active_compile_ref == cell_ref
+    assert "armed unproven: no warmup modality" in caplog.text
+    assert generate.name not in ex.unavailable
+
+
+def test_w8a8_exercised_miss_fails_closed_despite_unexercised_sibling(
+    tmp_path, monkeypatch,
+):
+    """gw#595(b) keeps gw#586 shut: an EXERCISED object that misses its own
+    warmup graph disproves the cell and fails closed — the unexercised
+    sibling exemption never launders a genuine parity defect."""
+    cls = _merged_lane_endpoint(
+        lambda self: _record_fake_warm(self.t2i, hits=0, misses=2))
+    specs = extract_specs(cls)
+    (generate,) = specs
+    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+
+    with pytest.raises(
+        cc.CompiledLaneUnavailableError,
+        match="did not serve their own warmup graph",
+    ):
+        asyncio.run(ex.ensure_setup(generate, {
+            wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
+            wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
+            cell_ref: pb.Snapshot(digest=DIGEST_A),
+        }))
+    assert ex.compile_targets() == []
+
+
+def test_w8a8_all_objects_unexercised_fails_closed(tmp_path, monkeypatch):
+    """gw#595(b): with ZERO proven objects the cell is entirely unverified —
+    a warmup that exercises nothing cannot arm anything."""
+    cls = _merged_lane_endpoint(lambda self: None)
+    specs = extract_specs(cls)
+    (generate,) = specs
+    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+
+    with pytest.raises(
+        cc.CompiledLaneUnavailableError,
+        match="did not serve their own warmup graph",
+    ):
+        asyncio.run(ex.ensure_setup(generate, {
+            wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
+            wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
+            cell_ref: pb.Snapshot(digest=DIGEST_A),
+        }))
+    assert ex.compile_targets() == []
+
+
 def test_production_w8a8_ignores_legacy_compile_environment_fallbacks(
     tmp_path, monkeypatch,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.39.0"
+version = "0.39.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Fixes the two coupled defects behind ie#501 run 19's adoption refusal (`2 attached compile object(s) did not serve their own warmup graph`):

**(a) Producer guidance-kwarg parity (the gw#586 class, call-KWARG axis).** `compile_cache._warm_call` warmed every declared guidance scale through `guidance_scale=` — on classes exposing `true_cfg_scale` (qwen) that is the distilled-guidance embed no-op; classic CFG rides `true_cfg_scale` + a non-None `negative_prompt`. The minted "cfg 4.0" pass traced the SAME unconditioned graph as the 1.0 pass, so the serving CFG lookup could never hit. The warm call now uses the true-CFG convention when the signature declares it (scale>1 carries `negative_prompt=" "`, matching the endpoint's normalization; scale<=1 stays batch-1 no-uncond). Audited `max_sequence_length`: pinned diffusers `QwenImagePipeline.__call__` default IS 512 == the endpoint pin — parity already holds.

**(b) Per-object warmup provability.** The proof required EVERY armed compile object to serve its own cache hit, but a merged multi-lane endpoint (qwen t2i + edit armed from one family cell) has objects the declared warmup structurally cannot exercise (edit needs an input image) — mandatory-W8A8 setup fail-closed forever. New contract, general (no qwen special-case):
- exercised (calls>0) + hit → proven, armed
- exercised + no hit → disproven → fail closed exactly as before (mandatory lanes raise)
- unexercised (calls=0) + a proven sibling → mandatory lane: stays **armed unproven** (eager is not a lane for it; logged `armed unproven: no warmup modality`); optional lane: unwraps to eager (existing behavior)
- zero proven objects → fail closed (the gw#586 silent-eager hole stays shut)

Hot adopt names the unprovable case with a distinct `no_warmup_modality` refusal instead of `cache_miss`.

Tests (revert-turns-red verified): `test_warm_call_true_cfg_convention`, `test_w8a8_unexercised_sibling_stays_armed_unproven`; plus fail-closed guards `test_w8a8_exercised_miss_fails_closed_despite_unexercised_sibling`, `test_w8a8_all_objects_unexercised_fails_closed`. Full suite + mypy + ruff green locally.

gw#587 self-mint remains the structural end state; it is a cross-repo redesign, so this ships the direct fix now.

Tracker: cozy-creator-tracker python-gen-worker #595 / inference-endpoints #501.