### PR TITLE
release: gen-worker 0.39.0 (gw#587 fleet worker self-mint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.39.0 (2026-07-19)
 
 - **gw#587: fleet worker self-mint — the serving worker compiles its own
   cell on a store miss, serves compiled immediately, and publishes it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.38.7"
+version = "0.39.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.38.7"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + changelog date + uv.lock refresh for the gw#587 self-mint release (PR #335). Tag v0.39.0 follows the merge to trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)