### PR TITLE
th#912: watch a Slot's default_checkpoint for late boot setup

### DIFF
--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -467,10 +467,36 @@ class Lifecycle:
                 # pgw#532 (slots) + gw#584 (compile): both a Slot pick and a
                 # compile cell arrive ONLY via hub delivery (HelloAck
                 # resolutions, DesiredResidency, RunJob snapshots) — never a
-                # boot-time default. Eager setup here races HelloAck's rebind
-                # and selects from bare refs with no snapshots (fc157; the
+                # boot-time default. Eager setup HERE (in this same scan,
+                # before any hub round trip) races HelloAck's rebind and
+                # selects from bare refs with no snapshots (fc157; the
                 # ie#501 W8A8 cell-selection miss).
                 dynamic.append(spec.name)
+                if spec.slots:
+                    # th#912: a Slot's declared default_checkpoint is only a
+                    # SEED for the hub's residency plan (pgw#532) — but once
+                    # the hub actually delivers it to disk (th#911 seeds it
+                    # into DesiredResidency.disk_refs), nothing ever ran
+                    # setup for the no-override/default pick, because this
+                    # scan skips Slot functions entirely and the hub sends
+                    # no DesiredInstance/RunJob to a worker it doesn't yet
+                    # consider available. Watch it exactly like a plain
+                    # tensorhub binding (below): the default pick IS the
+                    # spec._effective_spec degenerate case (no per-request
+                    # override), so `ensure_setup(spec)` on the unmodified
+                    # class-table spec is correct once every tensorhub-
+                    # sourced default is locally resolvable. A non-tensorhub
+                    # (raw upstream) default is never eagerly fetched here —
+                    # mirror-first (gw#465) still applies; that case is left
+                    # to per-dispatch resolution as before.
+                    missing = sorted({
+                        wire_ref(binding) for slot in spec.slots
+                        if (binding := spec.models.get(slot)) is not None
+                        and binding.source == "tensorhub"
+                        and self.executor.store.local_path(wire_ref(binding)) is None
+                    })
+                    if missing:
+                        awaiting_hub[spec.name] = missing
                 continue
             missing = sorted({
                 wire_ref(b) for b in spec.models.values()

--- a/tests/test_slot_boot_setup_th912.py
+++ b/tests/test_slot_boot_setup_th912.py
@@ -1,0 +1,153 @@
+"""th#912: a Slot's default_checkpoint is a SEED for the hub's residency plan
+(pgw#532) — the hub can deliver it to disk (th#911 seeds `DesiredResidency`
+with a dynamic slot's default), but boot's startup scan skips every Slot
+function outright ("set up on delivery, not at boot") and, unlike a plain
+tensorhub binding, gw#591's `_setup_awaiting_functions` watcher never covered
+it either. Live effect (e2e#188 run 15): both workers reached on-disk
+residency for the slot's default checkpoint and then sat at 0% GPU forever —
+no watcher ever ran `ensure_setup` for the default (no-override) pick, so the
+worker never resolved this dispatch-eligibility gap on its own.
+
+Covers:
+  (a) boot never eagerly fetches/sets up a Slot whose default isn't local yet
+      (unchanged pgw#532 invariant — no regression).
+  (b) once the default's snapshot lands on disk (the watcher's poll observes
+      `store.local_path` succeed), the watcher runs `ensure_setup` for the
+      declared (no-override) pick and pushes a StateDelta.
+  (c) a Slot whose default is a RAW upstream ref (non-tensorhub) is never
+      queued onto the watcher (mirror-first, gw#465 — unchanged).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import List, Tuple
+
+import msgspec
+
+from gen_worker.api.binding import HF, Hub
+from gen_worker.api.slot import Slot
+from gen_worker.config.settings import Settings
+from gen_worker.executor import Executor
+from gen_worker.lifecycle import Lifecycle
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+
+class _In(msgspec.Struct):
+    model: str = ""
+
+
+class _Out(msgspec.Struct):
+    pipeline_path: str
+
+
+def _slot_spec(name: str, setup_calls: List[Tuple[str, str]], default_checkpoint) -> EndpointSpec:
+    class Endpoint:
+        def setup(self, pipeline: str) -> None:
+            self.pipeline_path = pipeline
+            setup_calls.append((name, pipeline))
+
+        def generate(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out(pipeline_path=self.pipeline_path)
+
+    return EndpointSpec(
+        name=name, method=Endpoint.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="generate",
+        models={"pipeline": default_checkpoint},
+        slots={"pipeline": Slot(str, selected_by="model", default_checkpoint=default_checkpoint)},
+    )
+
+
+def _hardware() -> dict:
+    return {"gpu_count": 1, "gpu_total_mem": 32 * 1024**3,
+            "gpu_free_mem": 30 * 1024**3, "gpu_sm": "90", "installed_libs": []}
+
+
+async def _noop_send(msg: pb.WorkerMessage) -> None:
+    pass
+
+
+def test_boot_never_eagerly_sets_up_a_slot_default_not_yet_local(caplog) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    spec = _slot_spec("generate", setup_calls, Hub("th912-fixture/slot-default", tag="prod"))
+    ex = Executor([spec], _noop_send)
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = _hardware()
+
+    with caplog.at_level(logging.WARNING, logger="gen_worker.lifecycle"):
+        asyncio.run(lc.startup())
+
+    assert setup_calls == [], f"boot eagerly set up a not-yet-local Slot default: {setup_calls}"
+    # Slot functions always advertise available (pgw#532 — serveability is
+    # per-dispatch), so this alone would never surface the deadlock; the
+    # watcher's own diagnostic log is what makes it visible.
+    assert ex.available_functions() == ["generate"]
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(
+        "generate" in m and "th912-fixture/slot-default:prod" in m and "DesiredResidency" in m
+        for m in msgs
+    ), msgs
+
+
+def test_boot_setup_completes_once_slot_default_snapshot_lands(tmp_path, monkeypatch) -> None:
+    import gen_worker.lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(lifecycle_mod, "_BOOT_SETUP_WATCH_INTERVAL_S", 0.02)
+
+    setup_calls: List[Tuple[str, str]] = []
+    spec = _slot_spec("generate", setup_calls, Hub("th912-fixture/slot-default", tag="prod"))
+    ex = Executor([spec], _noop_send)
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = _hardware()
+
+    deltas: List[bool] = []
+
+    async def _fake_delta(**kwargs):
+        deltas.append(True)
+
+    monkeypatch.setattr(lc, "maybe_send_state_delta", _fake_delta)
+
+    ran: List[str] = []
+
+    async def _fake_setup(s, snapshots=None):
+        ran.append(s.name)
+        rec = ex._classes[s.instance_key]
+        rec.ready = True
+        return None
+
+    monkeypatch.setattr(ex, "ensure_setup", _fake_setup)
+
+    async def _scenario() -> None:
+        await lc.startup()
+        # Not local yet: the fake `ensure_setup` must not have run.
+        assert ran == []
+        # The hub's disk plan (th#911) lands the default checkpoint's bytes.
+        monkeypatch.setattr(ex.store, "local_path", lambda ref: tmp_path)
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if ran:
+                break
+        assert ran == ["generate"], "watcher never ran ensure_setup for the Slot default"
+        assert deltas, "StateDelta push expected after late Slot boot setup"
+
+    asyncio.run(_scenario())
+
+
+def test_raw_upstream_slot_default_never_queued_on_watcher() -> None:
+    """gw#465/mirror-first: a Slot default that ISN'T a tensorhub ref must
+    never be watched for local disk arrival (nothing will ever place a raw
+    upstream ref via DesiredResidency) — unchanged from before th#912."""
+    setup_calls: List[Tuple[str, str]] = []
+    spec = _slot_spec("generate", setup_calls, HF("th912-fixture/raw-model"))
+    ex = Executor([spec], _noop_send)
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = _hardware()
+
+    asyncio.run(lc.startup())
+
+    assert lc._boot_setup_watch is None, "a raw-upstream Slot default must not spawn a boot-setup watcher"
+    assert setup_calls == []


### PR DESCRIPTION
## Summary
- Slot-bearing functions (pgw#532) were fully excluded from eager boot setup AND gw#591's `_setup_awaiting_functions` watcher — commented "set up on delivery", but no delivery-triggered setup existed anywhere.
- th#911 now seeds a dynamic slot's `default_checkpoint` into the very first HelloAck's disk residency; the snapshot lands on disk but the function still never runs `setup()` — worker idles at 0% GPU forever (e2e#188 run 15, both connected workers stuck `on_disk` for 20+ minutes, zero dispatch).
- Fix: track each Slot's tensorhub-sourced `default_checkpoint` refs the same way gw#591 tracks a plain binding; once locally resolvable, run `ensure_setup(spec)` on the unmodified class-table spec (the exact degenerate case `_effective_spec` returns for a request with no per-slot override) and push a StateDelta. A raw-upstream (non-tensorhub) default is never queued — mirror-first (gw#465) unchanged.

## Test plan
- [x] New `tests/test_slot_boot_setup_th912.py`: boot never eagerly sets up a not-yet-local Slot default; watcher completes setup once the snapshot lands (fake delivery event, no GPU/downloads); a raw-upstream default never spawns a watcher.
- [x] `tests/test_startup_hub_snapshot_wait.py`, `tests/test_dynamic_slot_materialization_pgw532.py`, `tests/test_boot_compile_deferral_gw584.py`, `tests/test_drain_flush.py`, `tests/test_fn_degraded_emission.py`, `tests/test_declarative_residency.py`, `tests/test_oom_degraded_ladder.py`, `tests/test_media_transfer.py`, `tests/test_executor_adopt.py`, `tests/test_ram_admission.py` all green (162 passed).
- [x] Full suite (`pytest tests/`): 1528 passed, 9 pre-existing failures (confirmed identical on unmodified base commit — a stale `blake3/transfer` snapshot-validation fixture issue in `test_content_lanes.py`/`test_executor_residency.py`/`test_lane_gate_gw551.py`, unrelated to this change), 17 skipped.
- [ ] Live proof: relaunch e2e#188's `TestJHeldout_EvalCampaign` against this fix (in progress).