### PR TITLE
gw#587: runtime assertion — store-served boot must pay ~0 compile time

### DIFF
--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -532,6 +532,24 @@ def counters_delta(before: Dict[str, int], after: Dict[str, int]) -> Dict[str, i
     return {k: int(after.get(k, 0)) - int(before.get(k, 0)) for k in after}
 
 
+def compile_wall_seconds() -> float:
+    """This process's cumulative torch.compile wall time (monotonic, seconds).
+
+    gw#587: the store-served-boot runtime assertion samples this before/after
+    a boot warmup window to measure the actual inductor compile wall (not
+    just a hit/miss count) — a delivered cell should cost ~0 here. Mirrors
+    ``inductor_counters()``: process-global, so callers must scope the
+    before/after sample to a window where no OTHER boot is compiling
+    concurrently (the executor already holds the exclusive GPU permit for
+    exactly this reason)."""
+    try:
+        from torch._dynamo.utils import calculate_time_spent
+
+        return float(calculate_time_spent().get("total_wall_time", 0.0))
+    except Exception:
+        return 0.0
+
+
 def toolchain_present() -> bool:
     return any(shutil.which(c) for c in ("cc", "gcc", "g++", "clang"))
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -135,6 +135,14 @@ _GiB = 1024 ** 3
 _DISK_GC_MARGIN_BYTES = 2 * _GiB
 # Refs used within the grace window are not disk-GC candidates.
 _DISK_GC_GRACE_S = 300.0
+# gw#587: a store-served boot (a compile cell was ATTACHED, not self-minted)
+# must pay ~0 inductor compile wall time — the whole point of a delivered
+# cell is that the graph is already compiled. This is seconds, not ms: a
+# trivial guard recompile is noise, a real cold compile burns the economic
+# claim the cell system exists to avoid (see gw#587's boot-to-ready value
+# proposition). Fixed floor rather than a learned per-fleet baseline —
+# simple, robust, and every real cold compile clears it by a wide margin.
+_STORE_SERVED_COMPILE_ALARM_S = 30.0
 
 try:  # torch is optional at import time; the executor works without it.
     import torch
@@ -3302,6 +3310,8 @@ class Executor:
                 )
                 return evidence.count, evidence.functions_by_object
 
+            compile_seconds_before = (
+                compile_cache.compile_wall_seconds() if proves_inductor else 0.0)
             if inj.active_compile_artifacts:
                 # Cache-hit counters are process-global. Hold every GPU permit
                 # so each exact guard window can belong to only this warmup.
@@ -3309,6 +3319,9 @@ class Executor:
                     warmed, function_proofs = await run_warmup()
             else:
                 warmed, function_proofs = await run_warmup()
+            compile_seconds = (
+                compile_cache.compile_wall_seconds() - compile_seconds_before
+                if proves_inductor else 0.0)
             if proves_inductor:
                 # gw#595 per-object provability: the proof scopes to objects
                 # the warmup actually EXERCISED (calls>0). An exercised object
@@ -3394,6 +3407,43 @@ class Executor:
                     if int(getattr(spec.compile, "lora_bucket", 0) or 0):
                         compile_cache.drop_lora_lane(pipe)
                     inj.active_compile_artifacts.pop(id(pipe), None)
+                if proven and compile_seconds >= _STORE_SERVED_COMPILE_ALARM_S:
+                    # gw#587 runtime assertion: this boot ATTACHED a cell
+                    # (compile_selection is set — store-served, never a
+                    # self-mint) and at least one candidate proved a warm
+                    # cache hit, yet the process burned real inductor compile
+                    # wall time getting there. A delivered cell should cost
+                    # ~0 here; this is the gw#586 defect class generalized —
+                    # a cell that claims to serve while the boot silently
+                    # recompiles (stale/shape-mismatched artifact, or the
+                    # wrong cell attested through th#910). Loud, greppable,
+                    # and mirrored onto the wire via the existing ADOPTED
+                    # ModelEvent shape (gw#391) so it is visible hub-side —
+                    # boot-attached cells never sent this event before;
+                    # duration_ms carries the measured compile wall here
+                    # specifically (not the ordinary hot-adopt op-wall
+                    # meaning) since this call site only fires on alarm.
+                    family = str(getattr(spec.compile, "family", "") or "")
+                    ref = compile_selection.ref if compile_selection else ""
+                    digest = (
+                        compile_selection.snapshot_digest
+                        if compile_selection else "")
+                    logger.error(
+                        "compile-cache: STORE_SERVED_BOOT_COMPILED family=%s "
+                        "cell=%s digest=%s compile_seconds=%.1fs (>= alarm "
+                        "threshold %.1fs) — a store-served boot should pay "
+                        "~0 compile time (cache_hits=%d cache_misses=%d)",
+                        family, ref, digest, compile_seconds,
+                        _STORE_SERVED_COMPILE_ALARM_S, hits, misses,
+                    )
+                    await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
+                        ref=ref,
+                        state=pb.MODEL_STATE_ADOPTED,
+                        snapshot_digest=digest,
+                        cache_hits=hits,
+                        cache_misses=misses,
+                        duration_ms=int(compile_seconds * 1000),
+                    )))
             if compile_selection and trt_engine.is_engine_ref(compile_selection.ref):
                 trt_candidates = [
                     candidate for candidate in inj.compile_objects

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1014,6 +1014,127 @@ def test_production_setup_stamps_cold_active_identity_after_warmup(
     assert target.contract_digest == cc.execution_contract_digest(pipe, spec.compile)
 
 
+def test_store_served_boot_with_clean_hits_raises_no_compile_alarm(
+    tmp_path, monkeypatch,
+):
+    """gw#587 runtime assertion: a store-served boot (cell delivered, not
+    self-minted) that proves clean cache hits must NOT alarm — the whole
+    point of a delivered cell is ~0 compile wall time at boot."""
+    import gen_worker.executor as executor_mod
+
+    artifact = _artifact(tmp_path)
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    spec = _cold_spec()
+    model_ref = wire_ref(spec.models["pipeline"])
+    sent = []
+
+    async def _send(msg):
+        sent.append(msg)
+
+    ex = Executor([spec], _send)
+    ex.store._cache_dir = tmp_path / "cas"
+    pipe = _LoadablePipe()
+
+    async def _download(ref, **kwargs):
+        return artifact.parent if ref == CACHE_REF else model_dir
+
+    monkeypatch.setattr(executor_mod, "ensure_local", _download)
+    monkeypatch.setattr(
+        provision,
+        "load_slot",
+        lambda *args, **kwargs: provision.SlotLoad(obj=pipe, is_pipeline=True),
+    )
+    monkeypatch.setattr(ex, "_enable_compiled", _guarded_enable)
+    counter = {"hits": 0}
+
+    def _counters():
+        counter["hits"] += 1
+        return {"fxgraph_cache_hit": counter["hits"], "fxgraph_cache_miss": 0}
+
+    monkeypatch.setattr(cc, "inductor_counters", _counters)
+    # No real torch.compile runs in this fake-guard rig, so
+    # compile_wall_seconds() is naturally ~0 delta across the warmup window —
+    # the quiet path is exercised honestly, not forced.
+    _ColdEndpoint.setups = _ColdEndpoint.warmups = 0
+    snapshots = {
+        model_ref: pb.Snapshot(digest=MODEL_DIGEST),
+        CACHE_REF: pb.Snapshot(digest=DIGEST_A),
+    }
+
+    instance = asyncio.run(ex.ensure_setup(spec, snapshots))
+    assert isinstance(instance, _ColdEndpoint)
+    adopted = [
+        m for m in sent
+        if m.HasField("model_event")
+        and m.model_event.state == pb.MODEL_STATE_ADOPTED
+    ]
+    assert adopted == [], "a clean store-served boot must not emit any alarm event"
+
+
+def test_store_served_boot_with_hidden_compile_fires_alarm(
+    tmp_path, monkeypatch, caplog,
+):
+    """gw#587 runtime assertion, the poisoned/mismatched-cache half: a
+    store-served boot proves cache hits (the artifact round-tripped) but the
+    process ALSO burns real inductor compile wall time getting there — the
+    gw#586 defect class generalized (a cell that claims to serve while the
+    boot silently recompiles). Must alarm loudly AND report it hub-side via
+    the existing ADOPTED ModelEvent shape."""
+    import gen_worker.executor as executor_mod
+
+    artifact = _artifact(tmp_path)
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    spec = _cold_spec()
+    model_ref = wire_ref(spec.models["pipeline"])
+    sent = []
+
+    async def _send(msg):
+        sent.append(msg)
+
+    ex = Executor([spec], _send)
+    ex.store._cache_dir = tmp_path / "cas"
+    pipe = _LoadablePipe()
+
+    async def _download(ref, **kwargs):
+        return artifact.parent if ref == CACHE_REF else model_dir
+
+    monkeypatch.setattr(executor_mod, "ensure_local", _download)
+    monkeypatch.setattr(
+        provision,
+        "load_slot",
+        lambda *args, **kwargs: provision.SlotLoad(obj=pipe, is_pipeline=True),
+    )
+    monkeypatch.setattr(ex, "_enable_compiled", _guarded_enable)
+    # before, after — 45s of real inductor compile wall time hidden behind a
+    # store-served (delivered, not self-minted) boot.
+    wall = iter([0.0, 45.0])
+    monkeypatch.setattr(cc, "compile_wall_seconds", lambda: next(wall))
+    _ColdEndpoint.setups = _ColdEndpoint.warmups = 0
+    snapshots = {
+        model_ref: pb.Snapshot(digest=MODEL_DIGEST),
+        CACHE_REF: pb.Snapshot(digest=DIGEST_A),
+    }
+
+    with caplog.at_level("ERROR", logger="gen_worker.executor"):
+        instance = asyncio.run(ex.ensure_setup(spec, snapshots))
+    assert isinstance(instance, _ColdEndpoint)
+    assert any(
+        "STORE_SERVED_BOOT_COMPILED" in r.message for r in caplog.records
+    ), "a store-served boot that hid a real compile must alarm loudly"
+    adopted = [
+        m for m in sent
+        if m.HasField("model_event")
+        and m.model_event.state == pb.MODEL_STATE_ADOPTED
+    ]
+    (msg,) = adopted
+    assert msg.model_event.ref == CACHE_REF
+    assert msg.model_event.snapshot_digest == DIGEST_A
+    assert msg.model_event.cache_hits >= 1
+    assert msg.model_event.duration_ms == 45000
+
+
 def test_boot_warmup_proves_each_compile_object_independently(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Closes the one remaining gw#587 code checklist item: "runtime assertion: store-served boot => compile seconds ~= 0 (alarm on miss)". The sibling assertion ("cell miss => publish attempt recorded") already shipped in PR #335; this is its counterpart on the delivered-cell (HIT) side.
- Samples torch's cumulative inductor compile wall (`compile_cache.compile_wall_seconds`, mirrors the existing `inductor_counters()` before/after pattern) across the same exclusive-GPU boot warmup window that already proves cache hits/misses at boot.
- When a store-served boot (a cell was ATTACHED, `compile_selection` set — never a self-mint) proves at least one cache hit but the process also burned >=30s of real compile wall time, log a loud `STORE_SERVED_BOOT_COMPILED` alarm and ship it hub-side via the *existing* ADOPTED `ModelEvent` shape (`cache_hits`/`cache_misses`/`duration_ms`, all pre-existing fields). Boot-attached cells never sent this event before, even though the proto's own comments ("empty on boot-attached cells") anticipate it.
- No proto changes: the wire protocol is canonically owned by tensorhub and mirrored byte-for-byte into this repo; this reuses 100% pre-existing `ModelEvent` fields, so it needs no cross-repo coordination.
- This is the gw#586 defect class generalized to boot: a cell that claims to serve while the boot silently recompiles.

## Test plan
- [x] New outcome-level tests over the real Executor rig (`tests/test_executor_adopt.py`): a clean store-served boot emits no alarm; a store-served boot that proves hits but also burns real compile wall time (simulated poisoned/mismatched cache) fires the alarm and ships the ADOPTED event.
- [x] `ruff check` / `mypy` clean on changed files.
- [x] Full suite: 1530 passed, 9 pre-existing box-env failures reproduced identically on untouched master (verified via `git stash`), 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)