### PR TITLE
pgw#602: drop dispatch-binding manifest parsing (th#928 companion)

### DIFF
--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -45,8 +45,7 @@ ProgressFn = Callable[[int, Optional[int]], None]
 #
 # ONE keying function (gw#492) normalizes both index keys and lookups —
 # replacing the old raw/stripped/tag-removed fallback chain and its
-# `_binding_canonical_ref` twin. Keys are flavor-granular (a dispatch table
-# may bind two providers to one repo name via different flavors) with a
+# `_binding_canonical_ref` twin. Keys are flavor-granular, with a
 # repo-identity fallback so hub-minted picks of NEW flavors (`#svdq-int4`)
 # still route to their repo's provider.
 # ---------------------------------------------------------------------------
@@ -116,11 +115,6 @@ def _collect_binding_entries(bindings: Any) -> list[dict[str, Any]]:
         return out
     for entry in bindings.values():
         if not isinstance(entry, dict):
-            continue
-        if str(entry.get("kind") or "").strip() == "dispatch":
-            table = entry.get("table")
-            if isinstance(table, dict):
-                out.extend(sub for sub in table.values() if isinstance(sub, dict))
             continue
         if entry.get("ref"):
             out.append(entry)

--- a/tests/test_provider_routing.py
+++ b/tests/test_provider_routing.py
@@ -74,12 +74,11 @@ def _manifest(*binding_blocks: dict) -> dict:
             {"acme/flux:canary#fp8": "tensorhub"},
         ),
         (
-            # Dispatch table: one repo name, two providers per flavor variant.
+            # th#928: retired dispatch-kind entries are ignored, not parsed.
             {"pipeline": {"kind": "dispatch", "field": "variant", "table": {
                 "bf16": {"provider": "hf", "ref": "owner/flux", "flavor": "bf16"},
-                "fp8": {"provider": "tensorhub", "ref": "owner/flux", "flavor": "fp8"},
             }}},
-            {"owner/flux#bf16": "hf", "owner/flux#fp8": "tensorhub"},
+            {"owner/flux#bf16": None},
         ),
     ],
 )


### PR DESCRIPTION
tensorhub th#928 retires the `dispatch` binding kind (closed model menus are curated slot policies). The SDK never emitted it; this removes the last consumer — `_collect_binding_entries`'s dispatch-table expansion in the provider index — and updates the fixture to assert retired entries are ignored.

Gates: `pytest tests/test_provider_routing.py` 14 passed; full suite 1543 passed / 16 failed — the 16 are identical or worktree-path-dependent failures on the UNMODIFIED base (verified by stash + rerun; compile-cache self-mint tests fail in any linked worktree regardless of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)