### PR TITLE
gw#604: same-key self-mint cell redelivery is a no-op re-arm (never re-prove a warm proven object)

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1437,6 +1437,10 @@ class _CompileTargetRecord:
     requested_cell_axes: Tuple[Tuple[str, str], ...] = ()
     active_compile_ref: str = ""
     active_compile_snapshot_digest: str = ""
+    # gw#604: True when the active artifact is this worker's OWN mint (the
+    # advertised digest is then the self-attested tar blake3, not the store's
+    # snapshot manifest digest — same bytes, different transport form).
+    active_self_mint: bool = False
     function_names: Tuple[str, ...] = ()
     model_bindings: Tuple[Tuple[str, str, str], ...] = ()
     # Runtime guard failure is signaled from a handler thread. Guard every
@@ -2565,6 +2569,8 @@ class Executor:
             with target.state_lock:
                 target.active_compile_ref = active_ref
                 target.active_compile_snapshot_digest = active_digest
+                target.active_self_mint = bool(getattr(
+                    active_selection, "self_mint", False))
             rec.compile_targets[incarnation_id] = target
             if active_ref and not self._bind_compile_guard(rec, target):
                 # Production wrappers always expose one of the two guard
@@ -3064,12 +3070,53 @@ class Executor:
                             target_identities.append((
                                 target.active_compile_ref,
                                 target.active_compile_snapshot_digest,
+                                target.active_self_mint,
                             ))
-                    if not target_identities or any(
-                        active_ref != desired_cell.ref
-                        or active_digest != desired_cell.snapshot_digest
-                        for active_ref, active_digest in target_identities
-                    ):
+                    identity_moved = not target_identities
+                    digest_aligned = False
+                    for active_ref, active_digest, is_self_mint in (
+                            target_identities):
+                        if active_ref != desired_cell.ref:
+                            identity_moved = True
+                            break
+                        if active_digest == desired_cell.snapshot_digest:
+                            continue
+                        if not is_self_mint:
+                            # Delivered target: a same-ref digest move is a
+                            # genuine republish (mutable label cells) — the
+                            # pre-gw#604 vacate/rebuild convergence stands
+                            # (the rebuild loads a FRESH pipe, whose re-trace
+                            # produces honest FX lookups).
+                            identity_moved = True
+                            break
+                        # gw#604: for the worker's OWN self-mint, cell
+                        # identity IS the key (gw#581), and the ref encodes
+                        # it — the desired cell is the SAME cell this live
+                        # object already proved, published, and serves; the
+                        # digests differ only in transport FORM
+                        # (self-attested tar blake3 vs the store's snapshot
+                        # manifest digest, th#910 ruling). A passed proof on
+                        # a live object stays valid for that object's
+                        # lifetime; a warm-process re-proof cannot produce
+                        # honest FX lookups (dynamo serves from in-memory
+                        # code, hits stay 0 — the live fail-closed re-arm
+                        # loop). NEVER vacate; align the advertised digest to
+                        # the store's so gw#577 receipts/fences line up
+                        # fleet-wide.
+                        for target in live_targets:
+                            with target.state_lock:
+                                if (target.active_compile_ref
+                                        == desired_cell.ref):
+                                    target.active_compile_snapshot_digest = (
+                                        desired_cell.snapshot_digest)
+                        digest_aligned = True
+                        logger.info(
+                            "self-mint cell %s confirmed by the store; "
+                            "advertised digest aligned %s -> %s (no re-arm)",
+                            desired_cell.ref, active_digest,
+                            desired_cell.snapshot_digest,
+                        )
+                    if identity_moved:
                         logger.info(
                             "desired compile identity moved for %s -> %s@%s; "
                             "vacating stale instance",
@@ -3078,6 +3125,8 @@ class Executor:
                             desired_cell.snapshot_digest,
                         )
                         rec.stale = True
+                    elif digest_aligned:
+                        self._on_state_change()
             if rec.ready and rec.stale:
                 # gw#494: the instance was loaded for a superseded pick —
                 # vacate (releasing its OLD-ref bookings) and set up fresh

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1214,6 +1214,107 @@ def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
     ] == []
 
 
+def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
+    tmp_path, monkeypatch,
+):
+    """gw#604 revert-turns-red: after a proven self-mint boot, the hub
+    (now holding the worker's published cell) attaches that SAME KEY back
+    with the store's snapshot digest — a different transport FORM of the
+    identical bytes (store snapshot-manifest digest vs self-attested tar
+    blake3). Cell identity IS the key (gw#581): the worker must NOT vacate
+    or re-prove the live proven object (a warm-process re-proof cannot
+    produce honest FX lookups — live-found death loop), and must align its
+    advertised digest to the store's so fleet-wide receipts line up."""
+    import gen_worker.executor as executor_mod
+    from gen_worker import cell_key as cell_key_mod
+    from gen_worker import fleet_cells
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
+    model_ref = wire_ref(spec.models["pipeline"])
+    mint_key = "ck1-" + "a1" * 28
+    mint_ref = f"_system/family-{FAMILY}#{mint_key}"
+    mint_digest = "blake3:" + "e" * 64
+    store_digest = "blake3:" + "f" * 64  # the store's snapshot-manifest form
+    mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
+    mint_artifact.parent.mkdir()
+    mint_artifact.write_bytes(b"cell-bytes")
+    # The redelivered snapshot dir must contain a cell artifact for
+    # _fetch_compile_snapshot's find_artifact.
+    store_snap_dir = tmp_path / "store-snap"
+    store_snap_dir.mkdir()
+    (store_snap_dir / "cell.tar.gz").write_bytes(b"cell-bytes")
+
+    async def _send(_msg):
+        return None
+
+    ex = Executor([spec], _send)
+    ex.store._cache_dir = tmp_path / "cas"
+    pipe = _LoadablePipe()
+    setattr(pipe, "_cozy_weight_lane", "w8a8")
+
+    async def _download(ref, **kwargs):
+        return model_dir if ref == model_ref else store_snap_dir
+
+    monkeypatch.setattr(executor_mod, "ensure_local", _download)
+    monkeypatch.setattr(
+        provision,
+        "load_slot",
+        lambda *args, **kwargs: provision.SlotLoad(obj=pipe, is_pipeline=True),
+    )
+
+    def _minting_enable(pipeline, *_args):
+        _mark_fake_guard(pipeline)
+        return fleet_cells.ArmOutcome(armed=True, self_mint=fleet_cells.SelfMint(
+            family=FAMILY, cell_key=mint_key, ref=mint_ref,
+            snapshot_digest=mint_digest, artifact=mint_artifact))
+
+    monkeypatch.setattr(ex, "_enable_compiled", _minting_enable)
+
+    class _Key:
+        digest = mint_key
+
+    monkeypatch.setattr(cell_key_mod, "compute", lambda *a, **k: _Key())
+    _ColdEndpoint.setups = _ColdEndpoint.warmups = 0
+
+    # Boot 1: fresh key, self-mint, proven, advertised under the own key.
+    asyncio.run(ex.ensure_setup(
+        spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
+    assert (_ColdEndpoint.setups, _ColdEndpoint.warmups) == (1, 1)
+    (target,) = ex.compile_targets()
+    assert target.active_compile_snapshot_digest == mint_digest
+
+    # Hub reconcile: the SAME key comes back attached, store digest form.
+    instance = asyncio.run(ex.ensure_setup(spec, {
+        model_ref: pb.Snapshot(digest=MODEL_DIGEST),
+        mint_ref: pb.Snapshot(digest=store_digest),
+    }))
+    assert isinstance(instance, _ColdEndpoint)
+    # No vacate, no reload, no re-proof — the live proof stays valid.
+    assert (_ColdEndpoint.setups, _ColdEndpoint.warmups) == (1, 1), (
+        "same-key redelivery must be a no-op re-arm, never a teardown")
+    (target,) = ex.compile_targets()
+    assert target.active_compile_ref == mint_ref
+    assert target.active_compile_snapshot_digest == store_digest, (
+        "advertised digest must align to the store's form")
+
+    # A genuinely DIFFERENT key still vacates (identity actually moved).
+    other_key = "ck1-" + "b2" * 28
+    other_ref = f"_system/family-{FAMILY}#{other_key}"
+
+    class _OtherKey:
+        digest = other_key
+
+    monkeypatch.setattr(cell_key_mod, "compute", lambda *a, **k: _OtherKey())
+    asyncio.run(ex.ensure_setup(spec, {
+        model_ref: pb.Snapshot(digest=MODEL_DIGEST),
+        other_ref: pb.Snapshot(digest="blake3:" + "9" * 64),
+    }))
+    assert _ColdEndpoint.setups == 2, (
+        "a real identity move must still vacate and re-arm")
+
+
 def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
     tmp_path, monkeypatch,
 ):
@@ -2640,8 +2741,12 @@ def test_desired_w8a8_cell_digest_and_ref_changes_vacate_then_rebuild(
 
     monkeypatch.setattr(ex, "_vacate_record", _observed_vacate)
 
-    # Same mutable cell ref, new immutable bytes: no hot unwrap; declarative
-    # reconcile vacates and creates a fresh incarnation against the new digest.
+    # Same mutable cell ref, new immutable bytes: a DELIVERED (label-cell)
+    # republish still vacates and rebuilds against the new digest — the
+    # rebuild loads a fresh pipe whose re-trace produces honest FX lookups.
+    # (The gw#604 no-op re-arm applies ONLY to the worker's own self-mint
+    # under its key ref — see
+    # test_hub_redelivery_of_own_minted_key_is_a_noop_rearm.)
     reconcile(cell_a, DIGEST_B)
     second = ex.compile_targets()[0]
     assert second.incarnation_id != first.incarnation_id


### PR DESCRIPTION
Live-found (gw#587 proof-01 rerun): ~4min after a proven self-mint boot served its first compiled request, the hub attached the worker's OWN just-published cell back; the store snapshot digest can never equal the self-attested tar blake3 (different transport forms of identical bytes), so the digest comparison vacated a healthy serving record — and the warm-process re-proof can never pass honestly (dynamo in-memory reuse, zero FX lookups, hits=0) => fail-closed re-arm loop until pod retirement. Full forensics: tracker gw#604.

Ruling (coordinator 2026-07-20): cell identity IS the key (gw#581); a passed proof on a live object stays valid for that object's lifetime — re-proof only on fresh arm/boot.

- Self-mint target + desired cell under the SAME key ref: no vacate, no re-proof; the advertised digest aligns to the store's form so gw#577 receipts/fences line up fleet-wide (digest-form ruling recorded in th#910).
- Delivered/label targets: unchanged — same-ref digest movement is a genuine republish and keeps the vacate/rebuild convergence (fresh pipe => honest re-trace); hot-adopt stays the in-place convergence vehicle.
- A genuinely different key still vacates and re-arms.

Hub half (skip-redeliver + th#930 prewarm demand conversion): tensorhub PR #512 — both ends fixed so neither can regress alone.

Revert-turns-red over the real Executor rig (same-key redelivery => no teardown/no re-warmup/digest aligned; different key => still vacates; label republish pins unchanged). Suite 1547 passed / 41 skipped (1 documented box flake, passes isolated); mypy/ruff clean. Ships as gen-worker 0.39.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)