### PR TITLE
release: gen-worker 0.40.1 (gw#604 same-key no-op re-arm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.40.1 (2026-07-20)
+
+- **gw#604: a hub redelivery of the worker's OWN just-published self-mint
+  cell is a no-op re-arm.** Cell identity is the key (gw#581); the store's
+  snapshot digest and the self-attested tar blake3 are two transport forms
+  of the same bytes, so a same-key desired cell no longer vacates a proven
+  serving record (whose warm-process re-proof could never pass honestly —
+  the live fail-closed re-arm loop). The worker aligns its advertised
+  digest to the store's form instead. Delivered/label republish
+  (vacate/rebuild) and hot-adopt convergence are unchanged. Hub half:
+  tensorhub PR #512 (attach skip + th#930 prewarm demand conversion).
+
 ## 0.40.0 (2026-07-20)
 
 - **gw#596 instructed-lane contract (th#913 pair).** A lane is the FULL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.40.0"
+version = "0.40.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.40.0"
+version = "0.40.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Version bump + CHANGELOG + uv.lock regen for gw#604 (#350 / 3096279). Note: releases as 0.40.1 — the concurrent gw#596 lane shipped 0.40.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)