### PR TITLE
Mixed slot defaults never boot-setup (th#927 civitai_not_found crash-loop); release 0.40.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.40.1"
+version = "0.40.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -489,6 +489,17 @@ class Lifecycle:
                     # (raw upstream) default is never eagerly fetched here —
                     # mirror-first (gw#465) still applies; that case is left
                     # to per-dispatch resolution as before.
+                    # A MIXED spec (any raw-upstream slot default alongside
+                    # tensorhub ones, e.g. sdxl's Civitai pipeline seed +
+                    # Hub vae) must not be watched at all: the watcher's
+                    # `ensure_setup` on the unmodified spec would self-fetch
+                    # the raw default the moment the tensorhub refs land
+                    # (th#927 live crash-loop: civitai_not_found at boot).
+                    raw_default = any(
+                        (b := spec.models.get(slot)) is not None
+                        and b.source != "tensorhub"
+                        for slot in spec.slots
+                    )
                     missing = sorted({
                         wire_ref(slot_binding) for slot in spec.slots
                         if (slot_binding := spec.models.get(slot)) is not None
@@ -496,7 +507,7 @@ class Lifecycle:
                         and self.executor.store.local_path(
                             wire_ref(slot_binding)) is None
                     })
-                    if missing:
+                    if missing and not raw_default:
                         awaiting_hub[spec.name] = missing
                 continue
             missing = sorted({

--- a/tests/test_slot_boot_setup_th912.py
+++ b/tests/test_slot_boot_setup_th912.py
@@ -151,3 +151,42 @@ def test_raw_upstream_slot_default_never_queued_on_watcher() -> None:
 
     assert lc._boot_setup_watch is None, "a raw-upstream Slot default must not spawn a boot-setup watcher"
     assert setup_calls == []
+
+
+def test_mixed_slot_defaults_never_queued_on_watcher() -> None:
+    """th#927: a spec with BOTH a raw-upstream slot default (sdxl's Civitai
+    pipeline seed) and a tensorhub one (Hub vae) must not be watched — the
+    watcher would run `ensure_setup` on the unmodified spec once the
+    tensorhub refs land and self-fetch the raw default (mirror-first
+    violation; live civitai_not_found boot crash-loop)."""
+    setup_calls: List[Tuple[str, str]] = []
+
+    class Endpoint:
+        def setup(self, pipeline: str, vae: str) -> None:  # pragma: no cover
+            setup_calls.append(("generate", pipeline))
+
+        def generate(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out(pipeline_path="")
+
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="generate",
+        models={
+            "pipeline": HF("th927-fixture/raw-model"),
+            "vae": Hub("th927-fixture/vae", tag="prod"),
+        },
+        slots={
+            "pipeline": Slot(str, selected_by="model",
+                             default_checkpoint=HF("th927-fixture/raw-model")),
+            "vae": Slot(str, default_checkpoint=Hub("th927-fixture/vae", tag="prod")),
+        },
+    )
+    ex = Executor([spec], _noop_send)
+    lc = Lifecycle(Settings(orchestrator_public_addr="localhost:1"), ex)
+    lc.hardware = _hardware()
+
+    asyncio.run(lc.startup())
+
+    assert lc._boot_setup_watch is None, "a mixed-default Slot spec must not spawn a boot-setup watcher"
+    assert setup_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.40.1"
+version = "0.40.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
th#927 live finding: a spec with BOTH a raw-upstream slot default (sdxl's Civitai pipeline seed) and a tensorhub one (Hub vae) got queued on the th#912/gw#591 boot-setup watcher keyed only on its tensorhub refs. The moment the vae landed, the watcher ran `ensure_setup` on the unmodified spec and self-fetched the Civitai default — mirror-first violation (pgw#532/gw#465), observed as a `civitai_not_found` setup crash-loop on 3 consecutive SECURE 4090 pods before release-broken tripped.

Fix: a mixed-default Slot spec is never watched; its setup is per-dispatch (hub-supplied models), same as a pure raw-upstream default. New `test_mixed_slot_defaults_never_queued_on_watcher` fails pre-fix, passes post-fix; full th912 suite green.

Version 0.40.2 (the th#927 SDXL serve validation pins it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)