### PR TITLE
release: gen-worker 0.40.5 (gw#608 CI fix — adopt-test fake capture writes fxgraph entries)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.40.4"
+version = "0.40.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1461,10 +1461,16 @@ def test_pending_self_mint_boot_packs_and_publishes_only_the_proven_capture(
             events.append("warmup")
             # THE real serving execution: cold-compiles the serving graphs
             # into the live capture dir (successful compiled call, all
-            # misses — the honest cold-mint signature).
+            # misses — the honest cold-mint signature). A real cold compile
+            # writes one fxgraph store entry per miss — the gw#608 artifact
+            # assertion (finish_fleet_mint) requires them before publish.
             cap = captured["dir"]
             (cap / "inductor" / "g").mkdir(parents=True, exist_ok=True)
             (cap / "inductor" / "g" / "serving_graph.py").write_text("real")
+            fx = cap / "inductor" / "fxgraph"
+            for i in range(8):
+                (fx / f"g{i}").mkdir(parents=True, exist_ok=True)
+                (fx / f"g{i}" / "entry").write_text("fx")
             (cap / "triton").mkdir(exist_ok=True)
             _record_fake_warm(self.pipeline, hits=0, misses=8)
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.40.4"
+version = "0.40.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
The v0.40.4 tag's Publish-to-PyPI run (29794803988) failed its test gate on
tests/test_executor_adopt.py::test_pending_self_mint_boot_packs_and_publishes_only_the_proven_capture,
so PyPI is still at 0.40.3.

Root cause: the gw#608 hardening (finish_fleet_mint refuses a self-mint capture
with no inductor/fxgraph entries) updated the fake capture writers in
test_fleet_cells.py and test_compile_cache.py but missed the equivalent fake
warmup in test_executor_adopt.py, which still wrote only inductor/g/serving_graph.py.
The assertion correctly refused the pack; the capture path itself is fine.

Fix: the fake warmup now writes one fxgraph entry per recorded miss (8),
modeling the real cold-compile layout. The assertion is untouched.

Local: target file 82/82; full suite 1586 passed, 41 skipped (one pre-existing
env-flaky ram-admission test passes in isolation and in CI).

Ships forward as 0.40.5 (v0.40.4 tag stays put).

🤖 Generated with [Claude Code](https://claude.com/claude-code)