### PR TITLE
th#964: family lane policy twin — bare conv-UNet bindings AUTO-pick scale-free #fp8 locally

### DIFF
--- a/src/gen_worker/models/gguf_local.py
+++ b/src/gen_worker/models/gguf_local.py
@@ -100,11 +100,21 @@ def select_gguf(
     if base_gb <= free or base_gb * FP8_STORAGE_FIT_FACTOR <= free:
         return None
 
-    from .ladder import placement_for_flavor, placement_from_metadata
+    from .ladder import (
+        placement_for_flavor,
+        placement_from_metadata,
+        w8a8_excluded_for_family,
+    )
+    from .lanes import is_w8a8_flavor
 
+    # th#964: w8a8 rows of conv-UNet families are AUTO-ineligible — they
+    # must not count as a fitting native rung that suppresses the GGUF pick.
+    skip_w8a8 = w8a8_excluded_for_family(resolved.model_family)
     libs = frozenset(installed_libs)
     for row in resolved.sibling_flavors:
         if gguf_qtype(row.flavor) or row.size_bytes <= 0:
+            continue
+        if skip_w8a8 and is_w8a8_flavor(row.flavor):
             continue
         placement = placement_from_metadata(row.placement) or placement_for_flavor(row.flavor)
         if placement is None:

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -41,6 +41,9 @@ class WorkerResolvedRepo:
     # local precision ladder's candidate set. Empty on older hubs.
     size_bytes: int = 0
     sibling_flavors: List[WorkerResolvedFlavor] = field(default_factory=list)
+    # th#964: the resolved checkpoint's architecture family ("sdxl-pony",
+    # ...) — drives the local family lane policy. "" on hubs not sending it.
+    model_family: str = ""
 
 
 class HubResolveError(RuntimeError):
@@ -157,4 +160,5 @@ def resolve_repo(
         snapshot_digest=digest, files=files,
         size_bytes=int(body.get("size_bytes") or 0),
         sibling_flavors=siblings,
+        model_family=str(body.get("model_family") or "").strip(),
     )

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -11,16 +11,19 @@ Unstamped/mirrored rows fall back to the token-derived defaults here — the
 same defaults the stamping writes, so both paths agree. The ladder WALK
 (rung ordering per arch class) lives hub-side (tensorhub's
 internal/orchestrator/precision resolver) and delivers picks via HelloAck;
-this module is the classification + placement half. The former local walk
-(``resolve``/``resolve_local_bindings``) was deleted with pgw#515 — locally,
-fit is the loading layer's job (runtime fp8/nf4 rungs + the offload ladder).
+this module is the classification + placement half, plus the family lane
+policy (th#964) the local CLI fold shares with the hub. The former local
+walk (``resolve``/``resolve_local_bindings``) was deleted with pgw#515 —
+locally, fit is the loading layer's job (runtime fp8/nf4 rungs + the
+offload ladder).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
+from .lanes import is_w8a8_flavor
 from .svdq import SVDQ_FP4_SMS, SVDQ_INT4_SMS
 
 CLASS_BASE = "base"  # bare bf16/fp16/fp32 row — runs anywhere a card fits it
@@ -133,6 +136,123 @@ def placement_from_metadata(meta: Mapping[str, Any] | None) -> Optional[Placemen
 # path) — this floor gates only the fp8-over-bf16 PREFERENCE, never admission.
 FP8_COMPUTE_MIN_SM = 89
 
+
+# --- Family-root policy (th#964) — twin of tensorhub's modelfamily.Root ----
+
+# Families whose root is not derivable by normalization alone. Roots collapse
+# fine-tune/scheduler/distillation variants that keep the weight envelope.
+_FAMILY_ROOT_OVERRIDES = {
+    "sd14": "sd1", "sd15": "sd1",
+    "sdxl-turbo": "sdxl", "sdxl-pony": "sdxl", "sdxl-illustrious": "sdxl",
+    "sdxl-lightning": "sdxl", "sdxl-hyper": "sdxl", "sdxl-refiner": "sdxl",
+    "sd35-large-turbo": "sd35-large",
+    "flux1-dev": "flux1", "flux1-schnell": "flux1",
+    "flux1-kontext": "flux1", "flux1-krea": "flux1",
+    "flux2-dev": "flux2", "flux2-pro": "flux2",
+    "z-image-turbo": "z-image",
+    "svd-xt": "svd",
+}
+
+
+def family_root(family: str) -> str:
+    """Architecture root of a family name; "" for empty. Unrecognized
+    families root to their own normalized spelling."""
+    n = str(family or "").strip().lower().replace(".", "").replace(" ", "")
+    if not n:
+        return ""
+    return _FAMILY_ROOT_OVERRIDES.get(n, n)
+
+
+# Conv-UNet roots get no fp8-GEMM win (torch scaled_mm is Linear-only;
+# th#927 measured SDXL w8a8 1.9-2.7x slower than bf16): their fp8-w8a8 rows
+# are AUTO-ineligible and the scale-free #fp8 row is the family table-best
+# on sm_89+; bf16 stays the sub-floor default. Explicit pins still resolve
+# w8a8. Twin of tensorhub precision.convUNetW8A8ExcludedRoots.
+CONV_UNET_W8A8_EXCLUDED_ROOTS = frozenset({"sd1", "sd2", "sdxl"})
+
+
+def w8a8_excluded_for_family(family: str) -> bool:
+    """Whether AUTO selection policy-excludes fp8-w8a8 rows for this family
+    (any spelling — rooted internally)."""
+    return family_root(family) in CONV_UNET_W8A8_EXCLUDED_ROOTS
+
+
+def pick_family_fp8_flavor(
+    rows: Iterable[Any],
+    *,
+    model_family: str,
+    gpu_sm: int,
+    free_vram_gb: float,
+    installed_libs: Sequence[str] = (),
+) -> str:
+    """th#964 AUTO pick over a resolve's sibling flavor rows: for conv-UNet
+    families on sm_89+, the best scale-free #fp8 row (smallest token, hub
+    tiebreak) when it fits free VRAM. "" = keep the declared binding (bf16
+    sub-floor default, non-excluded family, or no admissible fitting row).
+    """
+    if not w8a8_excluded_for_family(model_family):
+        return ""
+    if gpu_sm < FP8_COMPUTE_MIN_SM:
+        return ""
+    libs = frozenset(installed_libs)
+    candidates: list[tuple[int, str, int]] = []
+    for row in rows:
+        token = str(getattr(row, "flavor", "") or "").strip().lower()
+        size = int(getattr(row, "size_bytes", 0) or 0)
+        if size <= 0 or classify_flavor_token(token) != CLASS_FP8:
+            continue
+        if is_w8a8_flavor(token):
+            continue
+        placement = (
+            placement_from_metadata(getattr(row, "placement", None))
+            or default_placement(CLASS_FP8)
+        )
+        if placement is None or not placement.admits_sm(gpu_sm):
+            continue
+        if any(lib not in libs for lib in placement.engines):
+            continue
+        candidates.append((len(token), token, size))
+    if not candidates:
+        return ""
+    # Hub walk gates only the single best fp8 rung on fit, then falls to bf16.
+    candidates.sort()
+    _, token, size = candidates[0]
+    return token if size / 1e9 <= float(free_vram_gb) else ""
+
+
+def maybe_rebind_family_fp8(
+    binding: Any,
+    *,
+    resolved: Any,
+    slot_family: str = "",
+    gpu_sm: int = 0,
+    free_vram_gb: float = 0.0,
+    installed_libs: Sequence[str] = (),
+) -> Any:
+    """Fail-open local CLI fold (th#964): rebind a bare conv-UNet-family
+    binding to its scale-free #fp8 sibling, matching the hub's AUTO pick.
+    Family comes from the resolve's model_family, slot-declared family as
+    fallback. Production resolution remains hub-owned."""
+    family = (
+        str(getattr(resolved, "model_family", "") or "").strip()
+        or str(slot_family or "").strip()
+    )
+    try:
+        flavor = pick_family_fp8_flavor(
+            getattr(resolved, "sibling_flavors", ()) or (),
+            model_family=family,
+            gpu_sm=int(gpu_sm or 0),
+            free_vram_gb=float(free_vram_gb or 0.0),
+            installed_libs=tuple(installed_libs or ()),
+        )
+        if not flavor:
+            return binding
+        from ..api.binding import rebind_pick
+
+        return rebind_pick(binding, flavor=flavor)
+    except Exception:
+        return binding
+
 EMERGENCY_NF4_VRAM_FACTOR = 0.45  # nf4 denoiser, encoders/VAE at compute dtype
 
 # Per-component resident-bytes factor for a bnb-nf4 quantized module vs its
@@ -150,12 +270,17 @@ __all__ = [
     "CLASS_NVFP4_W4A4",
     "CLASS_SVDQ_FP4",
     "CLASS_SVDQ_INT4",
+    "CONV_UNET_W8A8_EXCLUDED_ROOTS",
     "EMERGENCY_NF4_VRAM_FACTOR",
     "NF4_WEIGHT_BYTES_FACTOR",
     "Placement",
     "classify_flavor_token",
     "default_placement",
+    "family_root",
+    "maybe_rebind_family_fp8",
+    "pick_family_fp8_flavor",
     "placement_for_flavor",
     "placement_from_metadata",
     "placement_to_metadata",
+    "w8a8_excluded_for_family",
 ]

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -358,7 +358,6 @@ def resolve_bindings(
     runs a Slot's ``default_checkpoint`` ref locally.
     """
     from ..api.binding import ModelRef, wire_ref
-    from .gguf_local import maybe_rebind_gguf
 
     out: Dict[str, str] = {}
     for param_name, binding in bindings.items():
@@ -379,7 +378,7 @@ def resolve_bindings(
                 f"unknown binding type for param {param_name!r}: "
                 f"{type(binding).__name__}"
             )
-        selected = binding if offline else maybe_rebind_gguf(binding)
+        selected = binding if offline else _local_flavor_fold(binding, slot)
         out[param_name] = resolve_local_path(
             ref=wire_ref(selected), provider=selected.source,
             offline=offline, emit=emit,
@@ -388,6 +387,50 @@ def resolve_bindings(
             civitai_version_id=str(getattr(selected, "version", "") or ""),
         )
     return out
+
+
+def _local_flavor_fold(binding: Any, slot: Any) -> Any:
+    """Local AUTO flavor folds over ONE shared resolve: family fp8 (th#964)
+    first, then the GGUF small-VRAM pick (cl#27). Fail-open — any resolve or
+    probe error keeps the binding as declared. Production stays hub-owned."""
+    from ..api.binding import wire_ref
+    from .gguf_local import maybe_rebind_gguf
+    from .ladder import maybe_rebind_family_fp8
+    from .refs import parse_model_ref
+
+    if (
+        getattr(binding, "source", "") != "tensorhub"
+        or getattr(binding, "flavor", "")
+        or getattr(binding, "storage_dtype", "")
+        or getattr(binding, "components", ())
+    ):
+        return binding
+    try:
+        thref = parse_model_ref(wire_ref(binding)).tensorhub
+        if thref is None or thref.digest or thref.flavor:
+            return binding
+        from .hub_client import resolve_repo
+        from .hub_policy import detect_worker_capabilities
+        from .memory import get_available_vram_gb
+
+        resolved = resolve_repo(thref)
+        caps = detect_worker_capabilities()
+        free = get_available_vram_gb()
+    except Exception as exc:
+        logger.debug("local flavor fold failed open: %s", exc)
+        return binding
+    picked = maybe_rebind_family_fp8(
+        binding, resolved=resolved,
+        slot_family=str(getattr(slot, "family", "") or ""),
+        gpu_sm=caps.gpu_sm, free_vram_gb=free,
+        installed_libs=tuple(caps.installed_libs),
+    )
+    if picked is not binding:
+        return picked
+    return maybe_rebind_gguf(
+        binding, resolved=resolved, gpu_sm=caps.gpu_sm,
+        free_vram_gb=free, installed_libs=tuple(caps.installed_libs),
+    )
 
 
 def _hub_ref_map_path(cache_dir: Path, thref: Any) -> Path:

--- a/tests/test_ladder_family_fp8.py
+++ b/tests/test_ladder_family_fp8.py
@@ -1,0 +1,156 @@
+"""th#964 family lane policy — twin of tensorhub's precision family policy
+(internal/orchestrator/precision family_policy_th964_test.go): conv-UNet
+roots (sd1/sd2/sdxl) AUTO-pick the scale-free #fp8 sibling on sm_89+, w8a8
+rows are AUTO-ineligible, bf16 stays the sub-floor default."""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.api.binding import HF, Hub
+from gen_worker.models import gguf_local, ladder
+from gen_worker.models.hub_client import WorkerResolvedFlavor, WorkerResolvedRepo, WorkerResolvedRepoFile
+
+
+@pytest.mark.parametrize(("family", "root"), [
+    ("sdxl", "sdxl"),
+    ("sdxl-illustrious", "sdxl"),
+    ("sdxl-pony", "sdxl"),
+    ("sdxl-turbo", "sdxl"),
+    ("sd15", "sd1"),
+    ("sd14", "sd1"),
+    ("SD 1.5", "sd1"),
+    ("sd2", "sd2"),
+    ("sd35-large-turbo", "sd35-large"),
+    ("flux1-dev", "flux1"),
+    ("flux.2-klein-4b", "flux2-klein-4b"),
+    ("z-image-turbo", "z-image"),
+    ("qwen-image", "qwen-image"),
+    ("something-new", "something-new"),
+    ("", ""),
+])
+def test_family_root(family: str, root: str) -> None:
+    assert ladder.family_root(family) == root
+
+
+def test_w8a8_excluded_roots_match_hub_table() -> None:
+    assert ladder.CONV_UNET_W8A8_EXCLUDED_ROOTS == {"sd1", "sd2", "sdxl"}
+    for fam in ("sdxl", "sdxl-illustrious", "sd15", "sd2", "SDXL-Pony"):
+        assert ladder.w8a8_excluded_for_family(fam)
+    for fam in ("flux1-dev", "qwen-image", "ltx-2", "", "sdxl-distilled"):
+        assert not ladder.w8a8_excluded_for_family(fam)
+
+
+def _rows(*pairs: tuple[str, int]) -> list[WorkerResolvedFlavor]:
+    return [WorkerResolvedFlavor(flavor=f, size_bytes=s) for f, s in pairs]
+
+
+SDXL_ROWS = _rows(("", 6_941_377_969), ("fp8", 4_382_791_561), ("fp8-w8a8", 4_722_020_263))
+
+
+def test_pick_sdxl_sm89_prefers_scale_free_fp8() -> None:
+    for sm in (89, 90, 120):
+        assert ladder.pick_family_fp8_flavor(
+            SDXL_ROWS, model_family="sdxl-illustrious", gpu_sm=sm, free_vram_gb=24.0,
+        ) == "fp8"
+
+
+def test_pick_below_sm89_keeps_bf16_subfloor_default() -> None:
+    assert ladder.pick_family_fp8_flavor(
+        SDXL_ROWS, model_family="sdxl", gpu_sm=86, free_vram_gb=24.0,
+    ) == ""
+
+
+def test_pick_w8a8_only_never_auto_selected() -> None:
+    rows = _rows(("", 7_000_000_000), ("fp8-w8a8", 4_722_020_263))
+    assert ladder.pick_family_fp8_flavor(
+        rows, model_family="sdxl", gpu_sm=89, free_vram_gb=24.0,
+    ) == ""
+
+
+def test_pick_non_excluded_family_is_policy_off() -> None:
+    assert ladder.pick_family_fp8_flavor(
+        SDXL_ROWS, model_family="flux1-dev", gpu_sm=90, free_vram_gb=80.0,
+    ) == ""
+    assert ladder.pick_family_fp8_flavor(
+        SDXL_ROWS, model_family="", gpu_sm=90, free_vram_gb=80.0,
+    ) == ""
+
+
+def test_pick_gates_best_row_on_fit() -> None:
+    # 4.38 GB row vs 4.0 GB free: hub walk falls to bf16, local keeps declared.
+    assert ladder.pick_family_fp8_flavor(
+        SDXL_ROWS, model_family="sdxl", gpu_sm=89, free_vram_gb=4.0,
+    ) == ""
+
+
+def test_pick_tiebreak_smallest_token() -> None:
+    rows = _rows(("fp8-e4m3", 4_000_000_000), ("fp8", 4_400_000_000))
+    assert ladder.pick_family_fp8_flavor(
+        rows, model_family="sdxl", gpu_sm=89, free_vram_gb=24.0,
+    ) == "fp8"
+
+
+def _resolved(
+    rows: list[WorkerResolvedFlavor], family: str = "",
+    size_bytes: int = 6_941_377_969,
+) -> WorkerResolvedRepo:
+    files = [WorkerResolvedRepoFile(
+        path="model_index.json", size_bytes=1, blake3="ab", url="http://x/f",
+    )]
+    return WorkerResolvedRepo(
+        snapshot_digest="d" * 8, files=files, size_bytes=size_bytes,
+        sibling_flavors=rows, model_family=family,
+    )
+
+
+def test_rebind_bare_sdxl_binding_to_fp8() -> None:
+    binding = Hub("acme/wai-illustrious")
+    out = ladder.maybe_rebind_family_fp8(
+        binding, resolved=_resolved(SDXL_ROWS, "sdxl-illustrious"),
+        gpu_sm=89, free_vram_gb=24.0,
+    )
+    assert out.flavor == "fp8"
+    assert out.path == binding.path
+
+
+def test_rebind_slot_family_fallback_when_resolve_has_none() -> None:
+    binding = Hub("acme/wai-illustrious")
+    out = ladder.maybe_rebind_family_fp8(
+        binding, resolved=_resolved(SDXL_ROWS, ""), slot_family="sdxl",
+        gpu_sm=89, free_vram_gb=24.0,
+    )
+    assert out.flavor == "fp8"
+
+
+def test_rebind_resolve_family_wins_over_slot_family() -> None:
+    binding = Hub("acme/some-model")
+    out = ladder.maybe_rebind_family_fp8(
+        binding, resolved=_resolved(SDXL_ROWS, "flux1-dev"), slot_family="sdxl",
+        gpu_sm=89, free_vram_gb=24.0,
+    )
+    assert out is binding
+
+
+def test_rebind_fails_open_on_unfoldable_binding() -> None:
+    binding = HF("acme/model")
+    out = ladder.maybe_rebind_family_fp8(
+        binding, resolved=_resolved(SDXL_ROWS, "sdxl"), gpu_sm=89, free_vram_gb=24.0,
+    )
+    assert out is binding
+
+
+def test_select_gguf_ignores_w8a8_row_for_excluded_family() -> None:
+    # Base 12 GB on 6 GB free: neither resident nor 0.55-cast fits. The only
+    # non-gguf sibling is a FITTING w8a8 row — AUTO-ineligible for sdxl, so
+    # the GGUF pick must proceed.
+    rows = _rows(("fp8-w8a8", 4_722_020_263), ("gguf-q4_k_m", 3_000_000_000))
+    pick = gguf_local.select_gguf(
+        _resolved(rows, "sdxl", size_bytes=12_000_000_000), gpu_sm=86, free_vram_gb=6.0,
+    )
+    assert pick is not None and pick.flavor == "gguf-q4_k_m"
+    # Same rows without the family classification: w8a8 counts as a fitting
+    # native rung and suppresses the pick (pre-th#964 behavior preserved).
+    assert gguf_local.select_gguf(
+        _resolved(rows, "", size_bytes=12_000_000_000), gpu_sm=86, free_vram_gb=6.0,
+    ) is None


### PR DESCRIPTION
Local-parity half of th#964 (hub commits bb6b8808 / 47bb4bbf): cozy-local ladder picks must match hub picks for conv-UNet families.

- `gen_worker.models.ladder`: `family_root` (twin of tensorhub `modelfamily.Root`), `CONV_UNET_W8A8_EXCLUDED_ROOTS` = {sd1, sd2, sdxl}, `w8a8_excluded_for_family`, and `pick_family_fp8_flavor` / `maybe_rebind_family_fp8` — on sm_89+ a bare excluded-family binding AUTO-picks the best scale-free #fp8 sibling (hub tiebreak, fit-gated); below sm_89 bf16 stays the sub-floor default; explicit pins untouched.
- `WorkerResolvedRepo` carries the resolve's `model_family` ("" on hubs not sending it — policy off, matching Go's zero-value FamilyRoot); slot-declared family is the fallback, mirroring the hub's binding.Family fallback.
- Local CLI resolve (`resolve_bindings`) runs the family fold ahead of the GGUF fold over ONE shared resolve; `select_gguf` no longer lets an AUTO-ineligible w8a8 row suppress the GGUF pick.
- Shared precision-ladder vectors: this repo has carried none since pgw#515; no shared format touched.

Gates: ruff + mypy clean on touched files; full suite 453 passed, 5 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)