### PR TITLE
release: gen-worker 0.43.1 (gw#608 closed — transactional self-mint arm + FX-cache forensics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.43.1 (2026-07-21)
+
+- **gw#608 CLOSED: self-mint arm is transactional over the process-global
+  cache env — cells are cross-host portable end to end.** The store-served
+  8/8-miss root cause: a no-target sibling slot (or a delivered-cell-seeded
+  process) could open a fleet self-mint capture and repoint
+  TORCHINDUCTOR_CACHE_DIR/TRITON_CACHE_DIR away from the seeded cache
+  before the real warmup traced. Now: no-target siblings decline BEFORE
+  any process-global env mutation, `begin_fleet_mint` restores the prior
+  env on arm failure, and a delivered-cell-seeded process never opens a
+  capture (mandatory lanes keep the typed refusal). Four
+  revert-turns-red tests. Live-verified: first end-to-end store-served
+  LTX boot (release 587…970) — consumer warmup served from the delivered
+  cell, ~0s compile, no re-publish.
+- **gw#608: FX-cache failure forensics.** A store-served proof failure now
+  carries `fx_cache_failure_report` in the CompiledLaneUnavailableError
+  detail: hit/miss/bypass counts, compile_seconds, per-object proof
+  counts, a component-level FxGraphHashDetails key diff against the
+  delivered cell, and same-key re-save/load probes — clamped under the
+  2000-char activity error cap. Failure-path only; no serving overhead.
+
 ## 0.43.0 (2026-07-21)
 
 - **gw#585: tensorhub v4 private-input manifests — gRPC protocol v3 -> v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.43.0"
+version = "0.43.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -612,6 +612,140 @@ def toolchain_present() -> bool:
     return any(shutil.which(c) for c in ("cc", "gcc", "g++", "clang"))
 
 
+# ---------------------------------------------------------------------------
+# FX-key forensics (gw#608)
+#
+# torch 2.13 CompiledFxGraph entries embed ``_fx_graph_cache_debug_lines`` —
+# the complete FxGraphHashDetails per-component dump behind their own key.
+# A store-served boot that recompiles (the gw#608 signature) SAVES its fresh
+# entries into the live cache dir before the warmup proof fails, so at
+# failure time both sides of the divergence are on disk: the seeded cell's
+# key inputs (inside the artifact tar) and this boot's (freshly written).
+# Diffing them names the exact diverging key component in the wire-visible
+# error — no pod-log access needed. Pure observability: every helper
+# degrades to empty on any error.
+# ---------------------------------------------------------------------------
+
+
+def _fx_entry_lines(data: bytes) -> Tuple[str, list]:
+    """(key, hash-details lines) from one pickled FxGraphCache entry."""
+    import pickle
+
+    obj = pickle.loads(data)
+    key = str(getattr(obj, "_fx_graph_cache_key", "") or "")
+    lines = list(getattr(obj, "_fx_graph_cache_debug_lines", None) or [])
+    return key, lines
+
+
+def artifact_fx_lines(artifact: Path) -> Dict[str, list]:
+    """key -> FxGraphHashDetails lines for every fxgraph entry in a cell."""
+    out: Dict[str, list] = {}
+    try:
+        with tarfile.open(Path(artifact), mode="r:*") as tar:
+            for member in tar:
+                parts = PurePosixPath(member.name).parts
+                if (
+                    len(parts) < 4
+                    or parts[:2] != ("inductor", "fxgraph")
+                    or not member.isfile()
+                ):
+                    continue
+                f = tar.extractfile(member)
+                if f is None:
+                    continue
+                try:
+                    key, lines = _fx_entry_lines(f.read())
+                except Exception:
+                    continue
+                if key and lines:
+                    out.setdefault(key, lines)
+    except Exception:
+        logger.debug("fx forensics: artifact unreadable", exc_info=True)
+    return out
+
+
+def live_fx_lines(inductor_dir: Optional[Path] = None) -> Dict[str, list]:
+    """key -> FxGraphHashDetails lines from the live inductor cache dir
+    (defaults to the seeded ``TORCHINDUCTOR_CACHE_DIR``)."""
+    out: Dict[str, list] = {}
+    base = Path(inductor_dir) if inductor_dir else Path(
+        os.environ.get("TORCHINDUCTOR_CACHE_DIR", ""))
+    fx_root = base / "fxgraph"
+    if not str(base) or not fx_root.is_dir():
+        return out
+    for entry in sorted(fx_root.glob("*/*/*")):
+        if not entry.is_file() or entry.name.startswith("."):
+            continue
+        try:
+            key, lines = _fx_entry_lines(entry.read_bytes())
+        except Exception:
+            continue
+        if key and lines:
+            out.setdefault(key, lines)
+    return out
+
+
+_FX_COMPONENT_RE = re.compile(r"\A\[(\S+)\]\s+([^:]+):\s?(.*)\Z", re.DOTALL)
+
+
+def _fx_components(lines: list) -> Dict[str, Tuple[str, str]]:
+    """component name -> (hash, value text) from one entry's debug lines."""
+    out: Dict[str, Tuple[str, str]] = {}
+    for line in lines:
+        m = _FX_COMPONENT_RE.match(str(line))
+        if m:
+            out[m.group(2).strip()] = (m.group(1), m.group(3).strip())
+    return out
+
+
+def _clip(value: str, limit: int = 120) -> str:
+    flat = " ".join(str(value).split())
+    return flat if len(flat) <= limit else flat[:limit] + "…"
+
+
+def fx_key_forensics(
+    seeded: Dict[str, list],
+    observed: Dict[str, list],
+    *,
+    max_fresh: int = 2,
+    max_components: int = 4,
+) -> str:
+    """Name the FxGraphHashDetails components on which this boot's freshly
+    compiled FX entries diverge from the seeded cell's (gw#608). Each fresh
+    key (present live, absent from the cell) is matched to the seeded key
+    with the fewest differing component hashes — the graphs are counterparts,
+    so the minimal diff IS the key defect. '' when there is nothing to say."""
+    fresh = {k: v for k, v in observed.items() if k not in seeded}
+    if not seeded or not fresh:
+        return ""
+    seeded_components = {k: _fx_components(v) for k, v in seeded.items()}
+    reports = []
+    for key, lines in sorted(fresh.items())[:max_fresh]:
+        fresh_c = _fx_components(lines)
+        best_key = ""
+        best_diff: Optional[list] = None
+        for skey, sc in seeded_components.items():
+            diffs = [
+                name for name in sorted(set(fresh_c) | set(sc))
+                if fresh_c.get(name, ("", ""))[0] != sc.get(name, ("", ""))[0]
+            ]
+            if best_diff is None or len(diffs) < len(best_diff):
+                best_key, best_diff = skey, diffs
+        if best_diff is None:
+            continue
+        sc = seeded_components[best_key]
+        named = "; ".join(
+            f"{name}: cell={_clip(sc.get(name, ('', '<absent>'))[1])} != "
+            f"boot={_clip(fresh_c.get(name, ('', '<absent>'))[1])}"
+            for name in best_diff[:max_components]
+        )
+        reports.append(
+            f"fresh key {key} vs nearest cell key {best_key}: "
+            f"{len(best_diff)} differing component(s): {named or 'none'}"
+        )
+    return " | ".join(reports)
+
+
 class AdoptError(RuntimeError):
     """Classified adoption failure (ModelEvent ``adopt_failed:<reason>``)."""
 
@@ -2222,6 +2356,7 @@ __all__ = [
     "build",
     "apply",
     "apply_lora_lane",
+    "artifact_fx_lines",
     "artifact_metadata",
     "begin_fleet_mint",
     "capture_env",
@@ -2240,6 +2375,7 @@ __all__ = [
     "parse_cell_ref",
     "find_artifact",
     "flavor_label",
+    "fx_key_forensics",
     "gen_worker_version",
     "has_compile_target",
     "inductor_counters",
@@ -2247,6 +2383,7 @@ __all__ = [
     "lane_bucket",
     "lane_token",
     "lane_drift",
+    "live_fx_lines",
     "mint_artifact",
     "mode_drift",
     "pack",

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -554,6 +554,16 @@ def _reset_inductor_latch() -> None:
 # seeding reuses the same env contract
 seed_env = capture_env
 
+# gw#608: True once this process seeded a verified DELIVERED cell into the
+# live cache root. The inductor/triton cache dirs are process-global, so a
+# self-mint capture in the same process would re-point them away from the
+# seeded entries; fleet arming declines the mint instead.
+_DELIVERED_SEEDED = False
+
+
+def delivered_cell_seeded() -> bool:
+    return _DELIVERED_SEEDED
+
 
 def inductor_counters() -> Dict[str, int]:
     """This process's compiled-artifact cache counters (monotonic). The delta
@@ -1006,10 +1016,15 @@ def stage_artifact(
 
 def _activate_staged(staged: _StagedArtifact) -> Dict[str, Any]:
     """Publish a verified staging tree while holding ``_SEED_ARM_LOCK``."""
+    global _DELIVERED_SEEDED
     if not staged.activated:
         _merge_staged_cache(staged.staged_root, staged.live_root)
         staged.activated = True
     seed_env(staged.live_root)
+    # gw#608: the process now serves from a seeded delivered cell; any later
+    # self-mint capture would re-point the ONE process-global cache dir away
+    # from it and every seeded lookup would miss (the LTX consumer shape).
+    _DELIVERED_SEEDED = True
     return staged.metadata
 
 
@@ -2408,10 +2423,38 @@ def begin_fleet_mint(pipe: Any, cfg: Any, capture: Path) -> None:
     Raises if no compile target resolves on ``pipe`` (nothing to prove or
     publish); the caller's miss policy applies exactly as it did for a
     failed :func:`mint_artifact` call.
+
+    gw#608 ROOT CAUSE lived here: the cache-dir env is PROCESS-GLOBAL, and
+    this function re-pointed it BEFORE knowing the arm could succeed. On a
+    store-served LTX boot the no-compile-target upsampler sibling reached
+    this path after the distilled lane had seeded its delivered cell: the
+    env moved to a throwaway capture dir, the arm failed, the dir was
+    deleted — and the real warmup then looked up FX graphs in an empty
+    resurrected tmp dir (8/8 misses, live-proven; mint boots were immune
+    because their own capture registers first and the sibling is declined
+    BEFORE this call). The arm is therefore transactional now: nothing to
+    arm never touches the env, and an arm failure restores it exactly.
     """
+    if not has_compile_target(pipe, cfg):
+        raise RuntimeError(
+            f"no compile targets resolved on {type(pipe).__name__}")
+    prior = {
+        env: os.environ.get(env)
+        for env in ("TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR")
+    }
     capture_env(capture)
-    if not apply(pipe, cfg, cache_ready=False, guard=True, allow_cold=True):
-        raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
+    try:
+        if not apply(pipe, cfg, cache_ready=False, guard=True, allow_cold=True):
+            raise RuntimeError(
+                f"no compile targets resolved on {type(pipe).__name__}")
+    except BaseException:
+        for env, value in prior.items():
+            if value is None:
+                os.environ.pop(env, None)
+            else:
+                os.environ[env] = value
+        _reset_inductor_latch()
+        raise
 
 
 def finish_fleet_mint(
@@ -2506,6 +2549,7 @@ __all__ = [
     "cell_lane",
     "contract_drift",
     "counters_delta",
+    "delivered_cell_seeded",
     "cache_hit_count",
     "cache_miss_count",
     "enable",

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -703,6 +703,148 @@ def _clip(value: str, limit: int = 120) -> str:
     return flat if len(flat) <= limit else flat[:limit] + "…"
 
 
+def fx_cache_failure_report(artifact: Optional[Path] = None) -> str:
+    """Exhaustive FX-cache state for a failed store-served warmup proof
+    (gw#608). ALWAYS returns a non-empty report — counts alone discriminate
+    the failure classes with zero pod-log access:
+
+    - fresh_keys>0            => the boot computed DIFFERENT keys (B1); the
+                                 per-component divergence is appended.
+    - fresh_keys=0 with
+      samekey_resave rows     => the boot computed the SAME keys and torch
+                                 re-saved next to the seeded entries — the
+                                 miss is in the candidate LOAD path (B2:
+                                 unpickle / extern-libs guard), which only
+                                 ever executes on consumers (a mint has
+                                 nothing to iterate); the sibling diff and
+                                 probes below name the failing step.
+    - cell_keys=0             => the artifact itself was unreadable here.
+
+    Every sub-probe degrades to an err token; this never raises."""
+    import pickle
+
+    out: list = []
+    seeded_lines: Dict[str, list] = {}
+    seeded_names: Dict[str, set] = {}
+    cell_extern = None
+    cell_guards = "<none>"
+    if artifact is not None:
+        try:
+            with tarfile.open(Path(artifact), mode="r:*") as tar:
+                for member in tar:
+                    parts = PurePosixPath(member.name).parts
+                    if (
+                        len(parts) < 5
+                        or parts[:2] != ("inductor", "fxgraph")
+                        or not member.isfile()
+                    ):
+                        continue
+                    key, entry_name = parts[3], parts[4]
+                    seeded_names.setdefault(key, set()).add(entry_name)
+                    f = tar.extractfile(member)
+                    if f is None:
+                        continue
+                    try:
+                        obj = pickle.loads(f.read())
+                    except Exception as exc:  # noqa: BLE001
+                        out.append(
+                            f"cell_unpickle=EXC:{type(exc).__name__}:"
+                            f"{_clip(str(exc), 80)}")
+                        continue
+                    if cell_extern is None:
+                        cell_extern = str(
+                            getattr(obj, "extern_libs_key", None))
+                        cell_guards = repr(
+                            getattr(obj, "guards_expr", None))
+                    lines = list(getattr(
+                        obj, "_fx_graph_cache_debug_lines", None) or [])
+                    if lines:
+                        seeded_lines.setdefault(key, lines)
+        except Exception as exc:  # noqa: BLE001
+            out.append(f"cell_read=EXC:{type(exc).__name__}")
+    out.insert(0, f"cell_keys={len(seeded_names)}")
+    out.append(f"cell_guards={cell_guards}")
+    out.append(f"cell_extern={_clip(str(cell_extern), 90)}")
+
+    base = Path(os.environ.get("TORCHINDUCTOR_CACHE_DIR", "") or "")
+    fx_root = base / "fxgraph"
+    live_files: Dict[str, list] = {}
+    if str(base) and fx_root.is_dir():
+        for keydir in sorted(fx_root.glob("*/*")):
+            if keydir.is_dir():
+                files = sorted(
+                    p for p in keydir.iterdir()
+                    if p.is_file() and not p.name.startswith("."))
+                if files:
+                    live_files[keydir.name] = files
+    else:
+        out.append(f"live_dir_missing={str(fx_root) or '<unset>'}")
+    fresh = sorted(k for k in live_files if k not in seeded_names)
+    out.append(f"live_keys={len(live_files)}")
+    out.append(f"fresh_keys={len(fresh)}")
+
+    # Same-key re-save: seeded entry FILENAMES are their content sha, so any
+    # other file inside a seeded key dir is THIS boot's save of the same key.
+    resaves = 0
+    for key, files in sorted(live_files.items()):
+        names = seeded_names.get(key)
+        if not names:
+            continue
+        fresh_sibs = [p for p in files if p.name not in names]
+        seed_sibs = [p for p in files if p.name in names]
+        if not fresh_sibs or not seed_sibs:
+            continue
+        resaves += 1
+        if resaves == 1:
+            try:
+                a = pickle.loads(seed_sibs[0].read_bytes())
+                b = pickle.loads(fresh_sibs[0].read_bytes())
+                out.append(
+                    f"samekey_resave[{key[:12]}]: guards "
+                    f"cell={getattr(a, 'guards_expr', None)!r} "
+                    f"boot={getattr(b, 'guards_expr', None)!r}; extern "
+                    f"cell={_clip(str(getattr(a, 'extern_libs_key', None)), 90)} "
+                    f"boot={_clip(str(getattr(b, 'extern_libs_key', None)), 90)}")
+            except Exception as exc:  # noqa: BLE001
+                out.append(
+                    f"samekey_probe=EXC:{type(exc).__name__}:"
+                    f"{_clip(str(exc), 80)}")
+    out.append(f"samekey_resaves={resaves}")
+
+    # Emulate torch's candidate-load preconditions on one seeded live entry.
+    probe = next(
+        ((k, v) for k, v in live_files.items() if k in seeded_names), None)
+    if probe is not None:
+        try:
+            pickle.loads(probe[1][0].read_bytes())
+            out.append("live_cell_entry_unpickle=ok")
+        except Exception as exc:  # noqa: BLE001
+            out.append(
+                f"live_cell_entry_unpickle=EXC:{type(exc).__name__}:"
+                f"{_clip(str(exc), 80)}")
+    try:
+        import torch.utils._triton as _tu
+
+        out.append("extern_current=" + _clip(
+            _tu._extern_libs_key(_tu.triton_backend()) or "<empty>", 90))
+    except Exception as exc:  # noqa: BLE001
+        out.append(
+            f"extern_current=EXC:{type(exc).__name__}:{_clip(str(exc), 80)}")
+
+    if fresh:
+        try:
+            observed = {
+                k: _fx_entry_lines(live_files[k][0].read_bytes())[1]
+                for k in fresh[:2]
+            }
+            divergence = fx_key_forensics(seeded_lines, observed)
+            if divergence:
+                out.append("divergence: " + divergence)
+        except Exception as exc:  # noqa: BLE001
+            out.append(f"divergence=EXC:{type(exc).__name__}")
+    return "; ".join(str(v) for v in out)
+
+
 def fx_key_forensics(
     seeded: Dict[str, list],
     observed: Dict[str, list],
@@ -2375,6 +2517,7 @@ __all__ = [
     "parse_cell_ref",
     "find_artifact",
     "flavor_label",
+    "fx_cache_failure_report",
     "fx_key_forensics",
     "gen_worker_version",
     "has_compile_target",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -4038,19 +4038,20 @@ class Executor:
                     )
                     # gw#608 FX-key forensics: this boot's recompiles already
                     # saved their entries (with embedded FxGraphHashDetails
-                    # lines) into the live cache dir — diff them against the
-                    # seeded cell's and name the diverging key component in
-                    # the wire-visible error. Store-served boots only (a
-                    # minting boot has no seeded cell to diverge from).
+                    # lines) into the live cache dir. The report ALWAYS
+                    # carries the cache-state counts — fresh_keys>0 names the
+                    # diverging key component (B1); fresh_keys=0 with
+                    # same-key re-saves proves the keys MATCH and the miss is
+                    # in torch's candidate-load path (B2), with the sibling
+                    # guards/extern-libs diff and load probes naming the
+                    # failing step. Store-served boots only (a minting boot
+                    # has no seeded cell to diverge from).
                     if compile_selection is not None and not (
                         trt_engine.is_engine_ref(compile_selection.ref)
                     ):
                         try:
-                            forensics = compile_cache.fx_key_forensics(
-                                compile_cache.artifact_fx_lines(
-                                    compile_selection.path),
-                                compile_cache.live_fx_lines(),
-                            )
+                            forensics = compile_cache.fx_cache_failure_report(
+                                compile_selection.path)
                         except Exception:
                             forensics = ""
                             logger.debug(
@@ -4060,8 +4061,9 @@ class Executor:
                                 "compile-cache: FX-key forensics: %s",
                                 forensics)
                             # The activity error is capped at 2000 chars on
-                            # the wire; keep the first divergence intact.
-                            detail += f"; fx divergence: {forensics[:1500]}"
+                            # the wire; keep the leading counts + first
+                            # divergence intact.
+                            detail += f"; fx forensics: {forensics[:1500]}"
                     if quant_lane:
                         if mint_by_id:
                             from . import fleet_cells as fleet_cells_mod
@@ -4196,17 +4198,12 @@ class Executor:
                         _STORE_SERVED_COMPILE_ALARM_S, hits, misses,
                     )
                     try:
-                        # gw#608: name the diverging FX-key component(s) for
-                        # the partial-recompile shape too.
-                        forensics = compile_cache.fx_key_forensics(
-                            compile_cache.artifact_fx_lines(
-                                compile_selection.path),
-                            compile_cache.live_fx_lines(),
-                        )
-                        if forensics:
-                            logger.error(
-                                "compile-cache: FX-key forensics: %s",
-                                forensics)
+                        # gw#608: full cache-state report for the
+                        # partial-recompile shape too.
+                        logger.error(
+                            "compile-cache: FX-key forensics: %s",
+                            compile_cache.fx_cache_failure_report(
+                                compile_selection.path))
                     except Exception:
                         logger.debug(
                             "fx-key forensics unavailable", exc_info=True)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3930,6 +3930,7 @@ class Executor:
                     mint_sharers.setdefault(id(_pending), []).append(_obj_id)
                 proven_mint_objs: set[int] = set()
                 calls_by_obj: Dict[int, int] = {}
+                proof_by_obj: Dict[int, Tuple[int, int, int]] = {}
                 for candidate in inj.compile_objects:
                     pipe = candidate.pipeline
                     before = proof_before.get(id(pipe))
@@ -3939,6 +3940,7 @@ class Executor:
                     calls_by_obj[id(pipe)] = calls
                     pipe_hits = compile_cache.cache_hit_count(pipe)
                     pipe_misses = compile_cache.cache_miss_count(pipe) - before[1]
+                    proof_by_obj[id(pipe)] = (calls, pipe_hits, pipe_misses)
                     hits += max(0, pipe_hits)
                     misses += max(0, pipe_misses)
                     pending_mint = inj.pending_self_mints.get(id(pipe))
@@ -4019,12 +4021,45 @@ class Executor:
                     # the only forensic surface).
                     unproven_calls = sum(
                         calls_by_obj.get(id(c.pipeline), 0) for c in unproven)
+                    # gw#608: compile_seconds discriminates crediting bugs
+                    # (~0s) from real recompiles (minutes) without pod logs;
+                    # per-object calls/hits/misses scope a multi-object boot.
+                    per_object = ""
+                    if len(proof_by_obj) > 1:
+                        per_object = ", objects=[" + ", ".join(
+                            f"{c}/{h}/{m}"
+                            for c, h, m in proof_by_obj.values()) + "]"
                     detail = (
                         f"{len(unproven)} attached compile object(s) did not "
                         "serve their own warmup graph "
                         f"(warmups={warmed}, calls={unproven_calls}, "
-                        f"cache_hits={hits}, cache_misses={misses})"
+                        f"cache_hits={hits}, cache_misses={misses}, "
+                        f"compile_seconds={compile_seconds:.1f}{per_object})"
                     )
+                    # gw#608 FX-key forensics: this boot's recompiles already
+                    # saved their entries (with embedded FxGraphHashDetails
+                    # lines) into the live cache dir — diff them against the
+                    # seeded cell's and name the diverging key component in
+                    # the wire-visible error. Store-served boots only (a
+                    # minting boot has no seeded cell to diverge from).
+                    if compile_selection is not None and not (
+                        trt_engine.is_engine_ref(compile_selection.ref)
+                    ):
+                        try:
+                            forensics = compile_cache.fx_key_forensics(
+                                compile_cache.artifact_fx_lines(
+                                    compile_selection.path),
+                                compile_cache.live_fx_lines(),
+                            )
+                        except Exception:
+                            forensics = ""
+                            logger.debug(
+                                "fx-key forensics unavailable", exc_info=True)
+                        if forensics:
+                            logger.error(
+                                "compile-cache: FX-key forensics: %s",
+                                forensics)
+                            detail += f"; fx divergence: {forensics}"
                     if quant_lane:
                         if mint_by_id:
                             from . import fleet_cells as fleet_cells_mod
@@ -4158,6 +4193,21 @@ class Executor:
                         family, ref, digest, compile_seconds,
                         _STORE_SERVED_COMPILE_ALARM_S, hits, misses,
                     )
+                    try:
+                        # gw#608: name the diverging FX-key component(s) for
+                        # the partial-recompile shape too.
+                        forensics = compile_cache.fx_key_forensics(
+                            compile_cache.artifact_fx_lines(
+                                compile_selection.path),
+                            compile_cache.live_fx_lines(),
+                        )
+                        if forensics:
+                            logger.error(
+                                "compile-cache: FX-key forensics: %s",
+                                forensics)
+                    except Exception:
+                        logger.debug(
+                            "fx-key forensics unavailable", exc_info=True)
                     await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
                         ref=ref,
                         state=pb.MODEL_STATE_ADOPTED,

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -4059,7 +4059,9 @@ class Executor:
                             logger.error(
                                 "compile-cache: FX-key forensics: %s",
                                 forensics)
-                            detail += f"; fx divergence: {forensics}"
+                            # The activity error is capped at 2000 chars on
+                            # the wire; keep the first divergence intact.
+                            detail += f"; fx divergence: {forensics[:1500]}"
                     if quant_lane:
                         if mint_by_id:
                             from . import fleet_cells as fleet_cells_mod

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -339,6 +339,24 @@ def enable_compiled(
         return _fail_closed(pipe, "CUDA unavailable")
     if not cc.toolchain_present():
         return _fail_closed(pipe, "no C compiler for the self-mint")
+    # gw#608 ROOT CAUSE gates (order matters — BEFORE any process-global
+    # cache-dir mutation):
+    # (a) a slot object with no resolvable compile target (the LTX upsampler
+    #     shape) must never open a capture — begin_fleet_mint's env re-point
+    #     used to happen before its no-target raise, leaving the process
+    #     cache dir on a deleted tmp path and every seeded lookup missing;
+    # (b) once this process serves from a SEEDED delivered cell, any sibling
+    #     self-mint capture would re-point the one global cache dir away
+    #     from it — decline via the ordinary miss policy instead (plain
+    #     lanes eager, mandatory lanes typed refusal).
+    if not cc.has_compile_target(pipe, cfg):
+        return _fail_closed(pipe, "no compile target resolves on this pipeline")
+    if cc.delivered_cell_seeded():
+        return _fail_closed(
+            pipe,
+            "a delivered cell is seeded in this process; a self-mint "
+            "capture would re-point the process-global inductor cache dir "
+            "away from it (gw#608)")
 
     from .models.loading import pipeline_weight_lane
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,15 @@ def _fresh_settings_cache():
     get_settings.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _fresh_delivered_seed_flag():
+    """The gw#608 delivered-cell seed latch is process-lifetime in
+    production; tests seeding artifacts must not leak it into later
+    self-mint tests."""
+    from gen_worker import compile_cache as _cc
+
+    _cc._DELIVERED_SEEDED = False
+    yield
+    _cc._DELIVERED_SEEDED = False
+
+

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1307,3 +1307,80 @@ def test_aot_autograd_cache_disabled_across_threads(monkeypatch, tmp_path):
             entry.env_value_force = old_force
         else:
             entry.__dict__.pop("env_value_force", None)
+
+
+# ---------------------------------------------------------------------------
+# FX-key forensics (gw#608)
+# ---------------------------------------------------------------------------
+
+
+class _FakeFxEntry:
+    """Pickle-roundtrippable stand-in for a torch CompiledFxGraph entry."""
+
+    def __init__(self, key: str, lines: list) -> None:
+        self._fx_graph_cache_key = key
+        self._fx_graph_cache_debug_lines = lines
+
+
+def _fx_lines(config_value: str) -> list:
+    return [
+        "[gmhash] gm: <lambda>()\n\n\n\ndef forward(self, arg0_1):\n    ...",
+        "[inphash] example_inputs[0]: TensorMetadata(dtype=torch.bfloat16)",
+        f"[cfg-{config_value}] inductor_config[foo]: {config_value}",
+    ]
+
+
+def _write_fx_entry(root, key: str, lines: list) -> None:
+    import pickle
+
+    subdir = root / "fxgraph" / key[1:3] / key
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "entry0").write_bytes(pickle.dumps(_FakeFxEntry(key, lines)))
+
+
+def test_fx_key_forensics_names_the_diverging_component(tmp_path):
+    """gw#608: a store-served boot that recompiled must be able to name the
+    exact FxGraphHashDetails component its fresh keys diverge on, by diffing
+    its own saved entries against the seeded cell's."""
+    capture = tmp_path / "capture"
+    _write_fx_entry(capture / "inductor", "fseededkey111", _fx_lines("cell-value"))
+    (capture / "triton").mkdir()
+    artifact = cc.pack(capture, tmp_path / "cell.tar.gz", {"format": 2})
+
+    live = tmp_path / "live-inductor"
+    _write_fx_entry(live, "ffreshkey2222", _fx_lines("boot-value"))
+
+    seeded = cc.artifact_fx_lines(artifact)
+    observed = cc.live_fx_lines(live)
+    assert set(seeded) == {"fseededkey111"}
+    assert set(observed) == {"ffreshkey2222"}
+
+    report = cc.fx_key_forensics(seeded, observed)
+    assert "inductor_config[foo]" in report
+    assert "cell=cell-value" in report and "boot=boot-value" in report
+    # Matching components are noise — never reported.
+    assert "example_inputs[0]" not in report
+    assert "1 differing component(s)" in report
+
+
+def test_fx_key_forensics_silent_when_the_cell_served(tmp_path):
+    """Every live key present in the cell => nothing fresh => no report."""
+    lines = _fx_lines("same")
+    seeded = {"fkey1": lines}
+    assert cc.fx_key_forensics(seeded, {"fkey1": lines}) == ""
+    assert cc.fx_key_forensics({}, {"fkey1": lines}) == ""
+    assert cc.fx_key_forensics(seeded, {}) == ""
+
+
+def test_fx_key_forensics_matches_nearest_seeded_key(tmp_path):
+    """Each fresh key pairs with the seeded key sharing the most component
+    hashes — counterpart graphs, minimal diff — not an arbitrary one."""
+    far = [
+        "[othergm] gm: <lambda>() completely different graph",
+        "[otherin] example_inputs[0]: TensorMetadata(dtype=torch.float32)",
+        "[cfg-x] inductor_config[foo]: x",
+    ]
+    seeded = {"fnearkey": _fx_lines("cell-value"), "ffarkey": far}
+    observed = {"ffreshkey": _fx_lines("boot-value")}
+    report = cc.fx_key_forensics(seeded, observed)
+    assert "fnearkey" in report and "ffarkey" not in report

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -1384,3 +1384,58 @@ def test_fx_key_forensics_matches_nearest_seeded_key(tmp_path):
     observed = {"ffreshkey": _fx_lines("boot-value")}
     report = cc.fx_key_forensics(seeded, observed)
     assert "fnearkey" in report and "ffarkey" not in report
+
+
+def test_fx_cache_failure_report_names_b1_divergence(tmp_path, monkeypatch):
+    """fresh_keys>0: the report carries the counts AND the component diff."""
+    capture = tmp_path / "capture"
+    _write_fx_entry(capture / "inductor", "fseededkey111", _fx_lines("cell-value"))
+    (capture / "triton").mkdir()
+    artifact = cc.pack(capture, tmp_path / "cell.tar.gz", {"format": 2})
+
+    live = tmp_path / "live-inductor"
+    _write_fx_entry(live, "fseededkey111", _fx_lines("cell-value"))
+    _write_fx_entry(live, "ffreshkey2222", _fx_lines("boot-value"))
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(live))
+
+    report = cc.fx_cache_failure_report(artifact)
+    assert "cell_keys=1" in report
+    assert "live_keys=2" in report
+    assert "fresh_keys=1" in report
+    assert "samekey_resaves=0" in report
+    assert "inductor_config[foo]" in report
+    assert "cell=cell-value" in report and "boot=boot-value" in report
+
+
+def test_fx_cache_failure_report_names_b2_samekey_resave(tmp_path, monkeypatch):
+    """fresh_keys=0 with a second entry file in a seeded key dir proves the
+    boot computed the SAME key and torch's candidate-load path refused the
+    seeded entry — the report says so and diffs the siblings."""
+    import pickle
+
+    key = "fseededkey111"
+    capture = tmp_path / "capture"
+    _write_fx_entry(capture / "inductor", key, _fx_lines("same"))
+    (capture / "triton").mkdir()
+    artifact = cc.pack(capture, tmp_path / "cell.tar.gz", {"format": 2})
+
+    live = tmp_path / "live-inductor"
+    _write_fx_entry(live, key, _fx_lines("same"))
+    # torch names entry files by content sha; any OTHER name in the key dir
+    # is this boot's re-save of the same key.
+    resave = live / "fxgraph" / key[1:3] / key / "boot-resave"
+    resave.write_bytes(pickle.dumps(_FakeFxEntry(key, _fx_lines("same"))))
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(live))
+
+    report = cc.fx_cache_failure_report(artifact)
+    assert "fresh_keys=0" in report
+    assert "samekey_resaves=1" in report
+    assert "samekey_resave[fseededkey11" in report
+    assert "live_cell_entry_unpickle=ok" in report
+
+
+def test_fx_cache_failure_report_never_raises_without_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path / "nope"))
+    report = cc.fx_cache_failure_report(None)
+    assert "cell_keys=0" in report
+    assert "live_dir_missing" in report

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -2547,18 +2547,11 @@ def test_store_served_failure_names_diverging_fx_key_component(
     (generate,) = specs
     ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
 
-    cell_lines = [
-        "[gmhash] gm: <lambda>()",
-        "[cfg-cell] inductor_config[foo]: cell-value",
-    ]
-    boot_lines = [
-        "[gmhash] gm: <lambda>()",
-        "[cfg-boot] inductor_config[foo]: boot-value",
-    ]
     monkeypatch.setattr(
-        cc, "artifact_fx_lines", lambda path: {"fseededkey": cell_lines})
-    monkeypatch.setattr(
-        cc, "live_fx_lines", lambda *a, **k: {"ffreshkey": boot_lines})
+        cc, "fx_cache_failure_report",
+        lambda path: ("cell_keys=1; live_keys=2; fresh_keys=1; divergence: "
+                      "inductor_config[foo]: cell=cell-value != "
+                      "boot=boot-value"))
 
     with pytest.raises(
         cc.CompiledLaneUnavailableError,
@@ -2570,7 +2563,7 @@ def test_store_served_failure_names_diverging_fx_key_component(
             cell_ref: pb.Snapshot(digest=DIGEST_A),
         }))
     detail = str(excinfo.value)
-    assert "fx divergence" in detail
+    assert "fx forensics" in detail
     assert "inductor_config[foo]" in detail
     assert "cell=cell-value" in detail and "boot=boot-value" in detail
 

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1442,10 +1442,13 @@ def test_pending_self_mint_boot_packs_and_publishes_only_the_proven_capture(
 
     class _Pub(fleet_cells.CellPublisher):
         def publish(self, family, artifact, meta):
-            events.append("publish")
+            # Fill `published` BEFORE the event: the main thread's wait loop
+            # keys on the event and immediately reads `published` (a publish
+            # event must mean the publish is observable, not merely started).
             published["bytes"] = Path(artifact).read_bytes()
             published["meta"] = dict(meta)
             published["family"] = family
+            events.append("publish")
             return "cp-1"
 
     pub = _Pub(base_url="http://hub", worker_jwt=lambda: "jwt",

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -2522,13 +2522,57 @@ def test_w8a8_exercised_miss_fails_closed_despite_unexercised_sibling(
     with pytest.raises(
         cc.CompiledLaneUnavailableError,
         match="did not serve their own warmup graph",
-    ):
+    ) as excinfo:
         asyncio.run(ex.ensure_setup(generate, {
             wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
             wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
             cell_ref: pb.Snapshot(digest=DIGEST_A),
         }))
     assert ex.compile_targets() == []
+    # gw#608: the wire-visible detail must self-discriminate crediting bugs
+    # (~0s) from real recompiles (minutes) with zero pod-log access.
+    assert "compile_seconds=" in str(excinfo.value)
+
+
+def test_store_served_failure_names_diverging_fx_key_component(
+    tmp_path, monkeypatch,
+):
+    """gw#608 forensics wiring: a store-served warmup-proof failure diffs the
+    boot's freshly saved FX entries against the seeded cell's and puts the
+    diverging FxGraphHashDetails component in the CompiledLaneUnavailable
+    detail. Revert the executor wiring and this goes red."""
+    cls = _merged_lane_endpoint(
+        lambda self: _record_fake_warm(self.t2i, hits=0, misses=2))
+    specs = extract_specs(cls)
+    (generate,) = specs
+    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+
+    cell_lines = [
+        "[gmhash] gm: <lambda>()",
+        "[cfg-cell] inductor_config[foo]: cell-value",
+    ]
+    boot_lines = [
+        "[gmhash] gm: <lambda>()",
+        "[cfg-boot] inductor_config[foo]: boot-value",
+    ]
+    monkeypatch.setattr(
+        cc, "artifact_fx_lines", lambda path: {"fseededkey": cell_lines})
+    monkeypatch.setattr(
+        cc, "live_fx_lines", lambda *a, **k: {"ffreshkey": boot_lines})
+
+    with pytest.raises(
+        cc.CompiledLaneUnavailableError,
+        match="did not serve their own warmup graph",
+    ) as excinfo:
+        asyncio.run(ex.ensure_setup(generate, {
+            wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
+            wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
+            cell_ref: pb.Snapshot(digest=DIGEST_A),
+        }))
+    detail = str(excinfo.value)
+    assert "fx divergence" in detail
+    assert "inductor_config[foo]" in detail
+    assert "cell=cell-value" in detail and "boot=boot-value" in detail
 
 
 def test_w8a8_all_objects_unexercised_fails_closed(tmp_path, monkeypatch):

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -13,6 +13,7 @@ refusal only at genuine mint impossibilities.
 from __future__ import annotations
 
 import json
+import os
 import threading
 from pathlib import Path
 
@@ -34,8 +35,19 @@ class _Cfg:
         self.lora_bucket = 0
 
 
+class _Denoiser:
+    def forward(self, *args, **kwargs):  # pragma: no cover - never called
+        return None
+
+
 class _Pipe:
     _cozy_low_vram_mode = "off"
+
+    def __init__(self):
+        # A resolvable compile target: the gw#608 gate declines the
+        # self-mint (BEFORE any process-global cache-dir mutation) for
+        # slot objects that could never arm.
+        self.transformer = _Denoiser()
 
 
 FAKE_KEY = "ck1-" + "a" * 56
@@ -437,3 +449,74 @@ def test_finalize_refuses_capture_without_fx_entries(monkeypatch, tmp_path):
     assert fc.finalize_self_mint(pipe, pending) is None, (
         "an artifact without FX entries must be refused")
     assert calls == [], "nothing may publish from a refused capture"
+
+
+# ---------------------------------------------------------------------------
+# gw#608 root cause: the self-mint arm must never strand the process-global
+# cache dir away from a seeded delivered cell.
+# ---------------------------------------------------------------------------
+
+
+def test_no_target_pipe_never_touches_cache_env(tmp_path, monkeypatch):
+    """A slot object with no resolvable compile target (the LTX upsampler
+    shape) must be declined BEFORE any cache-dir mutation. Pre-fix,
+    begin_fleet_mint re-pointed TORCHINDUCTOR_CACHE_DIR to a throwaway
+    capture dir before discovering there was nothing to arm — every seeded
+    lookup of the SIBLING lane then missed (the live 8/8 shape)."""
+    _mintable(monkeypatch)
+    seeded = tmp_path / "seeded-live"
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(seeded))
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(seeded / "triton"))
+
+    class _NoTargetPipe:
+        _cozy_low_vram_mode = "off"
+
+    outcome = fc.enable_compiled(
+        _NoTargetPipe(), _Cfg(), tmp_path, None, publisher=None)
+    assert not outcome.armed and outcome.self_mint is None
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(seeded)
+    assert os.environ["TRITON_CACHE_DIR"] == str(seeded / "triton")
+    with fc._PENDING_LOCK:
+        assert fc._PENDING == {}
+
+
+def test_begin_fleet_mint_arm_failure_restores_cache_env(tmp_path, monkeypatch):
+    """An arm failure AFTER capture_env must restore the prior env exactly
+    (transactional): a dangling env on a deleted capture dir is the gw#608
+    consumer signature."""
+    seeded = tmp_path / "seeded-live"
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(seeded))
+    monkeypatch.setenv("TRITON_CACHE_DIR", str(seeded / "triton"))
+    # A real pipe with a real target; apply() fails on this box (no CUDA),
+    # driving the genuine post-capture_env failure path.
+    with pytest.raises(RuntimeError):
+        cc.begin_fleet_mint(_Pipe(), _Cfg(), tmp_path / "capture")
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(seeded)
+    assert os.environ["TRITON_CACHE_DIR"] == str(seeded / "triton")
+
+
+def test_delivered_seed_declines_later_self_mint(tmp_path, monkeypatch):
+    """Once a delivered cell is seeded in this process, a sibling self-mint
+    must be declined (plain lane -> eager): its capture would re-point the
+    ONE global cache dir away from the seeded entries mid-boot."""
+    _mintable(monkeypatch)
+    monkeypatch.setattr(cc, "_DELIVERED_SEEDED", True)
+    seeded = tmp_path / "seeded-live"
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(seeded))
+
+    began: list = []
+    monkeypatch.setattr(
+        cc, "begin_fleet_mint", lambda *a, **k: began.append(a))
+    outcome = fc.enable_compiled(_Pipe(), _Cfg(), tmp_path, None)
+    assert not outcome.armed and outcome.self_mint is None
+    assert began == [], "a seeded process must never open a mint capture"
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(seeded)
+
+
+def test_delivered_seed_mandatory_lane_keeps_typed_refusal(tmp_path, monkeypatch):
+    _mintable(monkeypatch)
+    monkeypatch.setattr(cc, "_DELIVERED_SEEDED", True)
+    pipe = _Pipe()
+    pipe._cozy_weight_lane = "w8a8"
+    with pytest.raises(cc.CompiledLaneUnavailableError, match="delivered cell"):
+        fc.enable_compiled(pipe, _Cfg(), tmp_path, None)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.43.0"
+version = "0.43.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes gw#608 (cell cross-host portability), cherry-picked from chaos (fxkey lane):

- 26b549e (THE fix): no-target sibling slots and delivered-cell-seeded processes
  decline fleet self-mint BEFORE any process-global cache-env mutation;
  begin_fleet_mint is transactional over TORCHINDUCTOR_CACHE_DIR/TRITON_CACHE_DIR
  (restores on arm failure). Four revert-turns-red tests (re-verified on this
  branch: all four fail with the src reverted to 0.42.0).
- a467feb + 122a4a3 + 6b80b83: FX-cache failure forensics
  (fx_cache_failure_report with component-level key diff, compile_seconds,
  clamped under the activity error cap) — failure-path only.

Live-verified: first end-to-end store-served LTX boot (release 587…970, consumer
warmup served from the delivered cell, ~0s compile, no re-publish). Full record:
tracker gw#608 checkpoint 5d540ce, evidence gw0421-run/RESULTS.md.

Excluded deliberately: gw#585 v4 input-manifest commits (7b47b95/871f3b3) — tracker
marks the lane mid-flight (paired e2e + promotion pending; v3→v4 hard cut needs the
tensorhub side).

Local (py3.12, torch 2.13, locked venv): 491 passed, 5 skipped, 1 xfailed;
mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)