### PR TITLE
release 0.45.0: pgw#622 eager-while-compiling with hot-swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.45.0 (2026-07-22)
+
+- **pgw#622: eager-while-compiling with hot-swap — a novel request shape
+  serves immediately.** A compiled target's first call at an unseen input
+  signature no longer stalls 30-60s behind Dynamo+Inductor: the consumer
+  guard serves the request (and followups at that signature) through the
+  EAGER original, one background thread warms the compiled callable with a
+  zero-filled dummy batch of the same signature (separate CUDA stream,
+  thread nice +10), and a successful warm atomically hot-swaps the
+  signature onto the compiled path. Each completed warm repacks the live
+  inductor/triton cache root and republishes the cell under the same key
+  (mode=replace) so no other worker ever compiles that (shape, GPU, lane)
+  again. Sequential compile-then-serve is preserved for: the boot
+  warmup-proof window, mandatory quantized lanes (w8a8/w4a4 — eager is not
+  a production lane there), tight VRAM headroom (degrade, never OOM),
+  regional mode, and signature-vocabulary explosions (per-request scalar
+  leaking into signatures disables concurrent routing loudly).
+
 ## 0.44.0 (2026-07-21)
 
 - **pgw#617: hierarchical slot bindings (th#980 companion).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.44.0"
+version = "0.45.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1508,10 +1508,20 @@ def _guarded(
             if fail_closed:
                 raise CompiledLaneUnavailableError(state["detail"])
             return original(*args, **kwargs)
+        # pgw#622: a novel input signature serves EAGER immediately while a
+        # background thread warms the compiled path, then hot-swaps.
+        router = (failure_signal or {}).get("router")
+        sig = None
+        if router is not None:
+            verdict, sig = router.route(label, compiled, args, kwargs)
+            if verdict == "eager":
+                return original(*args, **kwargs)
         before = proof_before()
         try:
             result = compiled(*args, **kwargs)
             record_success(before)
+            if router is not None:
+                router.mark_warm(sig)
             return result
         except Exception as exc:  # noqa: BLE001 — optional lanes may use eager
             state["failed"] = True
@@ -1708,12 +1718,17 @@ def apply(
     from .models.loading import pipeline_weight_lane
 
     fail_closed = pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
+    from . import hot_swap
+
     failure_signal: Dict[str, Any] = {
         "callback": None,
         "lock": threading.Lock(),
         "successful_calls": 0,
         "cache_hits": 0,
         "cache_misses": 0,
+        # pgw#622: whole-graph consumer guards route novel signatures
+        # through this; sequential until hot_swap.enable() post-proof.
+        "router": hot_swap.Router(fail_closed=fail_closed) if guard else None,
     }
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
@@ -1833,6 +1848,11 @@ def unwrap(pipeline: Any) -> bool:
     marker = getattr(pipeline, _MARKER_ATTR, None)
     if marker is None:
         return False
+    signal = marker.get("failure_signal")
+    if isinstance(signal, dict):
+        router = signal.get("router")
+        if router is not None:
+            router.close()  # pgw#622: in-flight background warms discard
     for owner, attr, fn in marker.get("originals") or ():
         try:
             setattr(owner, attr, fn)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2749,6 +2749,20 @@ class Executor:
                     "compile target %s has no runtime guard revocation signal; "
                     "advertising eager", incarnation_id,
                 )
+            if target.active_compile_ref:
+                # pgw#622: post-proof, novel request shapes serve eager while
+                # the compiled path warms in the background; each completed
+                # warm republishes the grown cell for the fleet.
+                from . import hot_swap
+
+                if hot_swap.enable(
+                    pipeline,
+                    on_warmed=hot_swap.Debounce(
+                        self._shape_warm_republisher(spec, pipeline)),
+                ):
+                    logger.info(
+                        "hot-swap: eager-while-compiling enabled for %s",
+                        spec.name)
         if requested_lane and not rec.compile_targets:
             raise compile_cache.CompiledLaneUnavailableError(
                 f"{requested_lane.upper()} setup for {spec.name!r} produced "
@@ -5568,6 +5582,27 @@ class Executor:
             image_digest=str(
                 getattr(self._settings, "worker_image_digest", "") or ""),
         )
+
+    def _shape_warm_republisher(
+        self, spec: EndpointSpec, pipeline: Any,
+    ) -> Callable[[], None]:
+        """Republish the grown cell after a background novel-shape warm
+        (pgw#622). Runs on the Debounce thread, never the serving path."""
+        cfg = spec.compile
+        family = str(getattr(cfg, "family", "") or "")
+
+        def republish() -> None:
+            from . import fleet_cells
+
+            cache_dir = self.store._cache_dir
+            live_root = (
+                Path(cache_dir) if cache_dir
+                else Path.home() / ".cache" / "gen-worker"
+            ) / "compile-cache"
+            fleet_cells.republish_after_shape_warm(
+                pipeline, cfg, family, self._cell_publisher(), live_root)
+
+        return republish
 
     def _enable_compiled(
         self, pipe: Any, cfg: Any, artifact: Optional[Path],

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -584,6 +584,66 @@ def withhold_self_mint_publish(pending: "PendingSelfMint", reason: str) -> None:
     shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
+def republish_after_shape_warm(
+    pipe: Any,
+    cfg: Any,
+    family: str,
+    publisher: Optional["CellPublisher"],
+    live_root: Path,
+) -> bool:
+    """Replace the fleet cell with the live cache root's grown contents
+    (pgw#622): after a background novel-shape warm, the root holds the
+    adopted/minted graphs PLUS the fresh signature's, so republishing under
+    the same key means no other worker ever compiles that (shape, GPU,
+    lane) again. Synchronous (callers run it off the serving path); every
+    failure is non-fatal to serving."""
+    if publisher is None or not publisher.enabled():
+        logger.warning(
+            "hot-swap: SHAPE_WARM_WITHOUT_PUBLISH_SINK family=%s — the "
+            "novel-shape graphs stay local to this pod", family)
+        return False
+    if not (Path(live_root) / "inductor").is_dir():
+        logger.warning(
+            "hot-swap: live cache root %s has no inductor tree; nothing to "
+            "republish", live_root)
+        return False
+    from .models.loading import pipeline_weight_lane
+    from .models.memory import low_vram_mode
+
+    tmp_root = Path(tempfile.mkdtemp(prefix="cellrepub-"))
+    try:
+        graph_signature, weight_contract = cc.execution_contract(pipe, cfg)
+        meta = cc.artifact_metadata(
+            family=family,
+            source_ref="shape-warm",
+            shapes=cfg.shapes,
+            targets=cfg.targets,
+            guidance_scales=getattr(cfg, "guidance_scales", ()),
+            low_vram_mode=low_vram_mode(pipe),
+            compile_mode=(
+                "regional" if getattr(cfg, "regional", False) else "whole"),
+            weight_lane=pipeline_weight_lane(pipe),
+            lora_bucket=int(getattr(cfg, "lora_bucket", 0) or 0),
+            graph_signature=graph_signature,
+            weight_contract=weight_contract,
+        )
+        label = cc.flavor_label(
+            meta["sku"], meta["torch"], meta.get("weight_lane", ""))
+        artifact = cc.pack(Path(live_root), tmp_root / f"{label}.tar.gz", meta)
+        publisher.publish(family, artifact, meta)
+        return True
+    except CellPublishRefused as exc:
+        logger.warning("hot-swap: cell republish refused (hub decision): %s", exc)
+        return False
+    except Exception:
+        logger.warning(
+            "hot-swap: cell republish failed; the fleet keeps the previous "
+            "cell", exc_info=True)
+        return False
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+
 def abandon_self_mint(pending: "PendingSelfMint") -> None:
     """Discard a self-mint capture the proof did not certify (disproven or
     genuinely unexercised with no proven sibling). Never packed, never
@@ -636,5 +696,6 @@ __all__ = [
     "enable_compiled",
     "finalize_self_mint",
     "publish_self_mint",
+    "republish_after_shape_warm",
     "withhold_self_mint_publish",
 ]

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -1,0 +1,463 @@
+"""Eager-while-compiling with hot-swap (pgw#622).
+
+``torch.compile(dynamic=False)`` recompiles at every novel input signature,
+which used to stall the first request at a new image shape behind a full
+Dynamo+Inductor compile (30-60s, CPU-dominant). Consumer guards now route a
+novel signature to the EAGER original immediately and warm the compiled
+callable concurrently in one background thread with a zero-filled dummy
+batch of the same signature (same weights in VRAM); a successful warm
+atomically marks the signature warm so later calls take the compiled path.
+The executor's ``on_warmed`` hook republishes the grown cell so the fleet
+never compiles that (shape, GPU, lane) again.
+
+Sequential (today's compile-then-serve) is kept when: concurrency is not
+enabled (boot warmup window), the lane is mandatory-quantized (w8a8/w4a4 —
+eager is not a production lane there), VRAM headroom is tight (degrade,
+never OOM), or the dummy batch cannot be built. Regional-compiled targets
+never consult the router (blocks are compiled in place; there is no
+separable eager callable).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+EAGER = "eager"
+COMPILED = "compiled"
+
+# Concurrent warm transient ~= one extra batch of activations. Conservative
+# free-VRAM floor; below it the request degrades to sequential (never OOM).
+_BG_FLOOR_BYTES = 8 << 30
+_QUEUE_MAX = 16
+_SIG_DEPTH = 4
+# A healthy shape-bucket vocabulary is dozens of signatures. An explosion
+# means some per-request scalar leaks into the signature — stop concurrent
+# routing for that router (back to today's behavior) instead of spamming
+# warm jobs forever.
+_MAX_SIGS = 256
+
+
+# ---------------------------------------------------------------------------
+# Input signatures
+# ---------------------------------------------------------------------------
+
+
+def _sig_value(value: Any, depth: int = 0) -> Any:
+    if depth > _SIG_DEPTH:
+        return type(value).__name__
+    try:
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            return ("T", tuple(value.shape), str(value.dtype), value.device.type)
+    except Exception:
+        pass
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return tuple(_sig_value(v, depth + 1) for v in value)
+    if isinstance(value, dict):
+        return tuple(
+            (str(k), _sig_value(v, depth + 1)) for k, v in sorted(
+                value.items(), key=lambda kv: str(kv[0]))
+        )
+    return type(value).__name__
+
+
+def signature(args: tuple, kwargs: dict) -> Tuple[Any, ...]:
+    """Hashable identity of one call's guard-relevant inputs: tensor
+    shapes/dtypes/devices plus scalar values (what dynamo specializes on)."""
+    return (
+        tuple(_sig_value(a) for a in args),
+        tuple((str(k), _sig_value(v)) for k, v in sorted(kwargs.items())),
+    )
+
+
+def _dummy_value(value: Any, depth: int = 0) -> Any:
+    if depth > _SIG_DEPTH:
+        return value
+    try:
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            # zeros: never retains request content; preserve_format keeps
+            # channels_last strides (a guard axis for VAE targets).
+            return torch.zeros_like(value)
+    except Exception:
+        pass
+    if isinstance(value, tuple):
+        return tuple(_dummy_value(v, depth + 1) for v in value)
+    if isinstance(value, list):
+        return [_dummy_value(v, depth + 1) for v in value]
+    if isinstance(value, dict):
+        return {k: _dummy_value(v, depth + 1) for k, v in value.items()}
+    return value
+
+
+def _first_cuda_device(args: tuple, kwargs: dict) -> Optional[int]:
+    try:
+        import torch
+    except Exception:
+        return None
+
+    def scan(value: Any, depth: int = 0) -> Optional[int]:
+        if isinstance(value, torch.Tensor) and value.is_cuda:
+            return int(value.device.index or 0)
+        if depth > _SIG_DEPTH:
+            return None
+        if isinstance(value, (list, tuple)):
+            for v in value:
+                found = scan(v, depth + 1)
+                if found is not None:
+                    return found
+        if isinstance(value, dict):
+            for v in value.values():
+                found = scan(v, depth + 1)
+                if found is not None:
+                    return found
+        return None
+
+    for value in (*args, *kwargs.values()):
+        found = scan(value)
+        if found is not None:
+            return found
+    return None
+
+
+def _headroom_ok(device: Optional[int]) -> bool:
+    """True when a concurrent dummy-batch forward has honest VRAM room.
+    Unknown/unprobeable state degrades to sequential (never OOM)."""
+    if device is None:
+        return True  # CPU-only call: no VRAM to protect
+    try:
+        import torch
+
+        free, total = torch.cuda.mem_get_info(device)
+        cached = max(
+            0,
+            torch.cuda.memory_reserved(device)
+            - torch.cuda.memory_allocated(device),
+        )
+        return (free + cached) >= max(_BG_FLOOR_BYTES, total // 8)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _WarmJob:
+    router: "Router"
+    label: str
+    sig: Tuple[Any, ...]
+    compiled: Callable[..., Any]
+    args: tuple
+    kwargs: dict
+    device: Optional[int]
+    grad_mode: str  # "grad" | "no_grad" | "inference"
+    autocast_dtype: Optional[Any]
+
+
+class Router:
+    """Per-pipeline signature routing shared by every whole-graph guard.
+
+    Sequential until :meth:`enable`; the executor enables concurrency only
+    AFTER the boot warmup proof, so the proof window keeps today's exact
+    semantics. ``fail_closed`` lanes never enable — eager is not a W8A8/W4A4
+    production lane, so their novel shapes keep the sequential inline
+    compile."""
+
+    def __init__(self, *, fail_closed: bool = False) -> None:
+        self.lock = threading.Lock()
+        self.fail_closed = bool(fail_closed)
+        self.concurrent = False
+        self.closed = False
+        self.on_warmed: Optional[Callable[[], None]] = None
+        self.warm: set = set()
+        self.pending: set = set()
+        self.bg_failed: set = set()
+
+    def enable(self, on_warmed: Optional[Callable[[], None]] = None) -> bool:
+        if self.fail_closed:
+            return False
+        with self.lock:
+            self.concurrent = True
+            self.on_warmed = on_warmed
+        return True
+
+    def close(self) -> None:
+        with self.lock:
+            self.closed = True
+            self.concurrent = False
+            self.on_warmed = None
+
+    def route(
+        self, label: str, compiled: Callable[..., Any],
+        args: tuple, kwargs: dict,
+    ) -> Tuple[str, Optional[Tuple[Any, ...]]]:
+        """(verdict, sig): COMPILED routes through the compiled callable
+        (sequential compile on a miss — today's behavior); EAGER serves the
+        original while the background warm compiles this signature."""
+        sig = (label, signature(args, kwargs))
+        with self.lock:
+            if not self.concurrent or self.closed:
+                return COMPILED, sig
+            if sig in self.warm:
+                return COMPILED, sig
+            if sig in self.pending or sig in self.bg_failed:
+                return EAGER, sig
+            if (len(self.warm) + len(self.pending)
+                    + len(self.bg_failed)) >= _MAX_SIGS:
+                logger.error(
+                    "hot-swap: signature vocabulary exceeded %d — a "
+                    "per-request scalar is leaking into signatures; "
+                    "disabling concurrent routing for this pipeline",
+                    _MAX_SIGS)
+                self.concurrent = False
+                return COMPILED, sig
+            device = _first_cuda_device(args, kwargs)
+            if not _headroom_ok(device):
+                logger.warning(
+                    "hot-swap: tight VRAM headroom for novel %s signature; "
+                    "degrading to sequential compile-then-serve", label)
+                return COMPILED, sig
+            self.pending.add(sig)
+        try:
+            job = _WarmJob(
+                router=self, label=label, sig=sig, compiled=compiled,
+                args=_dummy_value(args), kwargs=_dummy_value(kwargs),
+                device=device, grad_mode=_grad_mode(),
+                autocast_dtype=_autocast_dtype(),
+            )
+        except Exception:
+            logger.warning(
+                "hot-swap: dummy batch for %s failed; sequential compile",
+                label, exc_info=True)
+            with self.lock:
+                self.pending.discard(sig)
+            return COMPILED, sig
+        if not _submit(job):
+            with self.lock:
+                self.pending.discard(sig)
+            logger.warning(
+                "hot-swap: warm queue full; %s stays eager (retried on a "
+                "later request)", label)
+            return EAGER, sig
+        logger.info(
+            "hot-swap: novel input signature for %s — serving eager while "
+            "the compiled path warms in the background", label)
+        return EAGER, sig
+
+    def mark_warm(self, sig: Optional[Tuple[Any, ...]]) -> None:
+        """A successful compiled call at ``sig`` (inline or background)."""
+        if sig is None:
+            return
+        with self.lock:
+            self.pending.discard(sig)
+            self.bg_failed.discard(sig)
+            self.warm.add(sig)
+
+
+# ---------------------------------------------------------------------------
+# Background warm worker (one thread, one warm at a time)
+# ---------------------------------------------------------------------------
+
+_QUEUE: "queue.Queue[_WarmJob]" = queue.Queue(maxsize=_QUEUE_MAX)
+_WORKER_LOCK = threading.Lock()
+_WORKER: Optional[threading.Thread] = None
+
+
+def _grad_mode() -> str:
+    try:
+        import torch
+
+        if torch.is_inference_mode_enabled():
+            return "inference"
+        if not torch.is_grad_enabled():
+            return "no_grad"
+    except Exception:
+        pass
+    return "grad"
+
+
+def _autocast_dtype() -> Optional[Any]:
+    try:
+        import torch
+
+        if torch.is_autocast_enabled("cuda"):
+            return torch.get_autocast_dtype("cuda")
+    except Exception:
+        pass
+    return None
+
+
+def _submit(job: _WarmJob) -> bool:
+    global _WORKER
+    with _WORKER_LOCK:
+        if _WORKER is None or not _WORKER.is_alive():
+            _WORKER = threading.Thread(
+                target=_worker_loop, name="shape-warm", daemon=True)
+            _WORKER.start()
+    try:
+        _QUEUE.put_nowait(job)
+        return True
+    except queue.Full:
+        return False
+
+
+def _worker_loop() -> None:
+    try:  # background compile must never contend evenly with serving CPU
+        os.setpriority(os.PRIO_PROCESS, threading.get_native_id(), 10)
+    except Exception:
+        pass
+    while True:
+        job = _QUEUE.get()
+        try:
+            _run_warm(job)
+        except Exception:
+            logger.warning("hot-swap: warm worker item crashed", exc_info=True)
+        finally:
+            _QUEUE.task_done()
+
+
+def _run_warm(job: _WarmJob) -> None:
+    router = job.router
+    with router.lock:
+        if router.closed:
+            router.pending.discard(job.sig)
+            return
+    t0 = time.monotonic()
+    try:
+        with contextlib.ExitStack() as stack:
+            import torch
+
+            if job.grad_mode == "inference":
+                stack.enter_context(torch.inference_mode())
+            elif job.grad_mode == "no_grad":
+                stack.enter_context(torch.no_grad())
+            if job.device is not None:
+                torch.cuda.set_device(job.device)
+                if job.autocast_dtype is not None:
+                    stack.enter_context(
+                        torch.autocast("cuda", dtype=job.autocast_dtype))
+                # A separate stream so warm kernels/autotune benchmarks
+                # interleave with (never queue ahead of) a running
+                # generation on the default stream.
+                stream = torch.cuda.Stream(device=job.device)
+                stack.enter_context(torch.cuda.stream(stream))
+                job.compiled(*job.args, **job.kwargs)
+                stream.synchronize()
+            else:
+                job.compiled(*job.args, **job.kwargs)
+    except BaseException as exc:  # noqa: BLE001 — contained per-signature
+        with router.lock:
+            router.pending.discard(job.sig)
+            router.bg_failed.add(job.sig)
+        try:
+            import torch
+
+            if isinstance(exc, torch.cuda.OutOfMemoryError):
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+        logger.warning(
+            "hot-swap: background compile for %s failed (%s: %s); that "
+            "signature stays eager for this process",
+            job.label, type(exc).__name__, exc)
+        return
+    router.mark_warm(job.sig)
+    with router.lock:
+        callback = router.on_warmed
+    logger.info(
+        "hot-swap: compiled %s for novel signature in %.1fs; hot-swapped to "
+        "the compiled path", job.label, time.monotonic() - t0)
+    if callback is not None:
+        try:
+            callback()
+        except Exception:
+            logger.warning("hot-swap: on_warmed callback failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-level wiring
+# ---------------------------------------------------------------------------
+
+
+def router_of(pipeline: Any) -> Optional[Router]:
+    from . import compile_cache
+
+    marker = getattr(pipeline, compile_cache._MARKER_ATTR, None) or {}
+    signal = marker.get("failure_signal")
+    if not isinstance(signal, dict):
+        return None
+    router = signal.get("router")
+    return router if isinstance(router, Router) else None
+
+
+def enable(
+    pipeline: Any, on_warmed: Optional[Callable[[], None]] = None,
+) -> bool:
+    """Turn on eager-while-compiling for an armed pipeline's guards.
+
+    Call AFTER the boot warmup proof (the proof window must keep sequential
+    semantics). False when the pipeline has no router (eager-armed,
+    producer arms, regional-only) or its lane is mandatory-quantized."""
+    router = router_of(pipeline)
+    if router is None:
+        return False
+    return router.enable(on_warmed)
+
+
+@dataclass
+class Debounce:
+    """Coalesce ``on_warmed`` bursts into serialized runs of ``fn`` on a
+    background thread: at most one in flight, one queued."""
+
+    fn: Callable[[], None]
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _running: bool = False
+    _dirty: bool = False
+
+    def __call__(self) -> None:
+        with self._lock:
+            if self._running:
+                self._dirty = True
+                return
+            self._running = True
+        threading.Thread(
+            target=self._run, name="cell-republish", daemon=True).start()
+
+    def _run(self) -> None:
+        while True:
+            try:
+                self.fn()
+            except Exception:
+                logger.warning("hot-swap: debounced callback failed", exc_info=True)
+            with self._lock:
+                if not self._dirty:
+                    self._running = False
+                    return
+                self._dirty = False
+
+
+__all__ = [
+    "COMPILED",
+    "Debounce",
+    "EAGER",
+    "Router",
+    "enable",
+    "router_of",
+    "signature",
+]

--- a/tests/test_hot_swap_pgw622.py
+++ b/tests/test_hot_swap_pgw622.py
@@ -1,0 +1,420 @@
+"""pgw#622: eager-while-compiling with hot-swap.
+
+A novel input signature serves eager immediately, warms the compiled path
+in a background thread, and atomically hot-swaps; tight headroom degrades
+to the sequential compile-then-serve; a preexisting warm signature (cell/
+boot-warmed) short-circuits everything; the completed warm republishes the
+grown cell.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import threading
+import time
+
+import torch
+
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells, hot_swap
+
+
+def _wait(predicate, timeout=30.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _signal(router):
+    return {
+        "callback": None,
+        "lock": threading.Lock(),
+        "successful_calls": 0,
+        "cache_hits": 0,
+        "cache_misses": 0,
+        "router": router,
+    }
+
+
+def _wrapper(original, compiled, router, label="toy"):
+    return cc._guarded(
+        original, compiled, label, failure_signal=_signal(router))
+
+
+# ---------------------------------------------------------------------------
+# Signatures
+# ---------------------------------------------------------------------------
+
+
+def test_signature_keys_on_tensor_shape_dtype_and_scalars():
+    a = hot_swap.signature((torch.zeros(2, 8),), {"flag": True})
+    b = hot_swap.signature((torch.ones(2, 8),), {"flag": True})
+    c = hot_swap.signature((torch.zeros(3, 8),), {"flag": True})
+    d = hot_swap.signature((torch.zeros(2, 8),), {"flag": False})
+    e = hot_swap.signature((torch.zeros(2, 8, dtype=torch.float64),), {"flag": True})
+    assert a == b  # values never enter tensor identity
+    assert a != c and a != d and a != e
+
+
+def test_signature_recurses_containers():
+    a = hot_swap.signature((), {"cond": {"ids": torch.zeros(1, 6)}})
+    b = hot_swap.signature((), {"cond": {"ids": torch.zeros(1, 7)}})
+    assert a != b
+
+
+def test_dummy_batch_is_zero_filled_and_structure_preserving():
+    args = (torch.full((2, 3), 7.0), [torch.ones(4)], "keep")
+    dummy = hot_swap._dummy_value(args)
+    assert torch.equal(dummy[0], torch.zeros(2, 3))
+    assert torch.equal(dummy[1][0], torch.zeros(4))
+    assert dummy[2] == "keep"
+    assert hot_swap.signature(args, {}) == hot_swap.signature(dummy, {})
+
+
+# ---------------------------------------------------------------------------
+# Routing: miss -> eager + background compile + atomic swap
+# ---------------------------------------------------------------------------
+
+
+def test_miss_serves_eager_then_hot_swaps():
+    release = threading.Event()
+    bg_calls = []
+
+    def original(x):
+        return "eager"
+
+    def compiled(x):
+        bg_calls.append(x)
+        assert release.wait(30)
+        return "compiled"
+
+    router = hot_swap.Router()
+    assert router.enable()
+    wrapper = _wrapper(original, compiled, router)
+
+    x = torch.full((2, 8), 3.0)
+    assert wrapper(x) == "eager"          # never blocks on the compile
+    assert wrapper(x) == "eager"          # followups at the shape stay eager
+    assert _wait(lambda: bg_calls)
+    assert torch.equal(bg_calls[0], torch.zeros(2, 8))  # dummy, not the batch
+    release.set()
+    sig = ("toy", hot_swap.signature((x,), {}))
+    assert _wait(lambda: sig in router.warm)
+    assert wrapper(x) == "compiled"       # hot-swapped (real batch, inline)
+    zero_warms = [c for c in bg_calls if torch.equal(c, torch.zeros(2, 8))]
+    assert len(zero_warms) == 1           # exactly one dummy warm per signature
+
+
+def test_swap_is_race_free_vs_in_flight_eager_batch():
+    eager_gate = threading.Event()
+    in_eager = threading.Event()
+
+    def original(x):
+        in_eager.set()
+        assert eager_gate.wait(30)
+        return "eager"
+
+    def compiled(x):
+        return "compiled"
+
+    router = hot_swap.Router()
+    router.enable()
+    wrapper = _wrapper(original, compiled, router)
+    x = torch.zeros(2, 8)
+
+    results = []
+    t = threading.Thread(target=lambda: results.append(wrapper(x)))
+    t.start()
+    assert in_eager.wait(30)              # eager batch in flight
+    sig = ("toy", hot_swap.signature((x,), {}))
+    assert _wait(lambda: sig in router.warm)  # bg warm completes mid-flight
+    assert wrapper(x) == "compiled"       # new calls take the compiled path
+    eager_gate.set()
+    t.join(30)
+    assert results == ["eager"]           # in-flight batch finished eagerly
+
+
+def test_tight_headroom_degrades_to_sequential(monkeypatch):
+    monkeypatch.setattr(hot_swap, "_first_cuda_device", lambda a, k: 0)
+    monkeypatch.setattr(hot_swap, "_headroom_ok", lambda device: False)
+    calls = []
+
+    def compiled(x):
+        calls.append("inline")
+        return "compiled"
+
+    router = hot_swap.Router()
+    router.enable()
+    wrapper = _wrapper(lambda x: "eager", compiled, router)
+    x = torch.zeros(2, 8)
+    assert wrapper(x) == "compiled"       # today's compile-then-serve
+    assert calls == ["inline"]            # no background job
+    sig = ("toy", hot_swap.signature((x,), {}))
+    assert sig in router.warm             # inline success still marks warm
+
+
+def test_prewarmed_signature_short_circuits():
+    """Boot-warmed / cell-covered shapes never enter the eager+bg path."""
+    router = hot_swap.Router()
+    wrapper = _wrapper(lambda x: "eager", lambda x: "compiled", router)
+    x = torch.zeros(2, 8)
+    assert wrapper(x) == "compiled"       # sequential window (pre-enable)
+    router.enable()
+    assert wrapper(x) == "compiled"       # warm: straight to compiled
+    assert not router.pending
+
+
+def test_fail_closed_lane_never_enables():
+    router = hot_swap.Router(fail_closed=True)
+    assert not router.enable()
+    wrapper = _wrapper(lambda x: "eager", lambda x: "compiled", router)
+    assert wrapper(torch.zeros(2, 8)) == "compiled"
+
+
+def test_background_failure_is_contained_per_signature():
+    def compiled(x):
+        if x.shape[0] == 9:
+            raise RuntimeError("boom")
+        return "compiled"
+
+    router = hot_swap.Router()
+    router.enable()
+    wrapper = _wrapper(lambda x: "eager", compiled, router)
+    bad = torch.zeros(9, 8)
+    assert wrapper(bad) == "eager"
+    bad_sig = ("toy", hot_swap.signature((bad,), {}))
+    assert _wait(lambda: bad_sig in router.bg_failed)
+    assert wrapper(bad) == "eager"        # that signature stays eager
+    good = torch.zeros(2, 8)
+    assert wrapper(good) == "eager"       # other signatures still route
+    assert _wait(lambda: ("toy", hot_swap.signature((good,), {})) in router.warm)
+    assert wrapper(good) == "compiled"
+
+
+def test_signature_explosion_disables_concurrency():
+    router = hot_swap.Router()
+    router.enable()
+    with router.lock:
+        router.warm.update(("toy", ("pad", i)) for i in range(hot_swap._MAX_SIGS))
+    wrapper = _wrapper(lambda x: "eager", lambda x: "compiled", router)
+    assert wrapper(torch.zeros(2, 8)) == "compiled"
+    assert not router.concurrent
+
+
+def test_unwrap_closes_router():
+    class Pipe:
+        pass
+
+    pipe = Pipe()
+    router = hot_swap.Router()
+    setattr(pipe, cc._MARKER_ATTR, {
+        "targets": ["toy"], "shapes": [], "cache": True, "originals": [],
+        "regional_mods": [], "failure_signal": _signal(router),
+    })
+    assert hot_swap.router_of(pipe) is router
+    cc.unwrap(pipe)
+    assert router.closed
+    assert hot_swap.router_of(pipe) is None
+
+
+def test_enable_noop_without_router():
+    class Pipe:
+        pass
+
+    assert not hot_swap.enable(Pipe())
+
+
+def test_on_warmed_fires_and_debounce_coalesces():
+    warmed = threading.Event()
+    runs = []
+    gate = threading.Event()
+
+    def publish():
+        runs.append(1)
+        assert gate.wait(30)
+
+    debounced = hot_swap.Debounce(publish)
+
+    router = hot_swap.Router()
+    router.enable(on_warmed=lambda: (debounced(), warmed.set()))
+    wrapper = _wrapper(lambda x: "eager", lambda x: "compiled", router)
+    assert wrapper(torch.zeros(2, 8)) == "eager"
+    assert warmed.wait(30)
+    # a burst while the first publish is in flight coalesces to ONE rerun
+    debounced()
+    debounced()
+    debounced()
+    gate.set()
+    assert _wait(lambda: len(runs) == 2 and not debounced._running)
+    time.sleep(0.05)
+    assert len(runs) == 2
+
+
+# ---------------------------------------------------------------------------
+# Real torch.compile integration (CPU toy module)
+# ---------------------------------------------------------------------------
+
+
+def test_real_compile_eager_while_compiling_roundtrip():
+    torch._dynamo.reset()
+
+    class Toy(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = torch.nn.Parameter(torch.randn(8, 8))
+
+        def forward(self, x):
+            return torch.nn.functional.relu(x @ self.w) + 1.0
+
+    m = Toy()
+    original = m.forward
+    compiled = torch.compile(m.forward, dynamic=False)
+    router = hot_swap.Router()
+    wrapper = _wrapper(original, compiled, router, label="toy.forward")
+
+    # boot warmup window: sequential compile marks the declared shape warm
+    warm_x = torch.randn(2, 8)
+    assert torch.allclose(wrapper(warm_x), original(warm_x))
+    assert ("toy.forward", hot_swap.signature((warm_x,), {})) in router.warm
+
+    router.enable()
+    novel = torch.randn(5, 8)
+    t0 = time.monotonic()
+    out = wrapper(novel)                  # novel shape: served eagerly
+    first_latency = time.monotonic() - t0
+    assert torch.allclose(out, original(novel))
+    sig = ("toy.forward", hot_swap.signature((novel,), {}))
+    assert _wait(lambda: sig in router.warm, timeout=120)
+    assert torch.allclose(wrapper(novel), original(novel))  # compiled path
+    # the eager serve never waited on the background dynamo+inductor compile
+    assert first_latency < 5.0
+
+
+# ---------------------------------------------------------------------------
+# Cell republish after a background warm
+# ---------------------------------------------------------------------------
+
+
+class _Publisher:
+    def __init__(self, enabled=True):
+        self._enabled = enabled
+        self.published = []
+
+    def enabled(self):
+        return self._enabled
+
+    def publish(self, family, artifact, meta):
+        with tarfile.open(artifact) as tar:
+            names = sorted(tar.getnames())
+        self.published.append((family, names, dict(meta)))
+        return "ckpt-1"
+
+
+class _Cfg:
+    family = "toyfam"
+    shapes = ((512, 512),)
+    targets = ("transformer",)
+    guidance_scales = ()
+    regional = False
+    lora_bucket = 0
+
+
+def _pin_identity(monkeypatch):
+    key = {
+        "sku": "rtx-4090", "sm": "sm_89", "torch": str(torch.__version__),
+        "triton": "3.0.0", "cuda": "13.0", "cuda_driver": "13000",
+        "image_digest": "sha256:feed",
+    }
+    monkeypatch.setattr(cc, "runtime_key", lambda: dict(key))
+    monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.0.0-test")
+
+
+def test_republish_packs_live_root_under_same_key(monkeypatch, tmp_path):
+    _pin_identity(monkeypatch)
+    live_root = tmp_path / "compile-cache"
+    (live_root / "inductor" / "fxgraph" / "aa" / "bb").mkdir(parents=True)
+    (live_root / "inductor" / "fxgraph" / "aa" / "bb" / "entry").write_bytes(b"g1")
+    (live_root / "triton").mkdir()
+
+    class Pipe:
+        pass
+
+    publisher = _Publisher()
+    assert fleet_cells.republish_after_shape_warm(
+        Pipe(), _Cfg(), "toyfam", publisher, live_root)
+    family, names, meta = publisher.published[0]
+    assert family == "toyfam"
+    assert "inductor/fxgraph/aa/bb/entry" in names
+    assert meta["family"] == "toyfam"
+    from gen_worker import cell_key
+
+    assert meta["cell_key"] == cell_key.from_artifact_metadata(meta).digest
+
+
+def test_republish_without_sink_is_a_loud_noop(tmp_path, caplog):
+    live_root = tmp_path / "compile-cache"
+    (live_root / "inductor").mkdir(parents=True)
+
+    class Pipe:
+        pass
+
+    assert not fleet_cells.republish_after_shape_warm(
+        Pipe(), _Cfg(), "toyfam", _Publisher(enabled=False), live_root)
+    assert any(
+        "SHAPE_WARM_WITHOUT_PUBLISH_SINK" in r.message for r in caplog.records)
+
+
+def test_republish_failure_never_raises(monkeypatch, tmp_path):
+    _pin_identity(monkeypatch)
+    live_root = tmp_path / "compile-cache"
+    (live_root / "inductor").mkdir(parents=True)
+
+    class Boom(_Publisher):
+        def publish(self, family, artifact, meta):
+            raise RuntimeError("wire down")
+
+    class Pipe:
+        pass
+
+    assert not fleet_cells.republish_after_shape_warm(
+        Pipe(), _Cfg(), "toyfam", Boom(), live_root)
+
+
+# ---------------------------------------------------------------------------
+# apply() wires the router into consumer guards
+# ---------------------------------------------------------------------------
+
+
+def test_apply_installs_router_for_guarded_arms(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    class Pipe:
+        pass
+
+    class Cfg:
+        family = "toyfam"
+        shapes = ((64, 64),)
+        targets = ("transformer",)
+        guidance_scales = ()
+        regional = False
+        lora_bucket = 0
+
+    pipe = Pipe()
+    pipe.transformer = torch.nn.Linear(4, 4)
+    assert cc.apply(pipe, Cfg(), cache_ready=True)
+    router = hot_swap.router_of(pipe)
+    assert isinstance(router, hot_swap.Router)
+    assert not router.concurrent          # sequential until executor enables
+    assert hot_swap.enable(pipe)
+    assert router.concurrent
+    cc.unwrap(pipe)
+    assert router.closed
+
+    producer = Pipe()
+    producer.transformer = torch.nn.Linear(4, 4)
+    assert cc.apply(producer, Cfg(), cache_ready=True, guard=False)
+    assert hot_swap.router_of(producer) is None  # producer arms never route
+    cc.unwrap(producer)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.44.0"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Promotion chaos -> master: pgw#622 (release 0.45.0).

A compiled target's first call at a novel input signature no longer stalls
30-60s behind a Dynamo+Inductor compile. The consumer guard serves it (and
followups at that signature) through the eager original; one background
thread (nice +10, separate CUDA stream) warms the compiled callable with a
zero-filled dummy batch of the same signature; a successful warm atomically
hot-swaps the signature onto the compiled path. Each completed warm repacks
the live cache root and republishes the cell under the same ck1 key
(mode=replace) so the fleet never compiles that (shape, GPU, lane) again.

Sequential compile-then-serve is preserved for: the boot warmup-proof
window, mandatory quantized lanes (w8a8/w4a4), tight VRAM headroom
(degrade-don't-OOM), regional mode, and signature-vocabulary explosions.

Tests: tests/test_hot_swap_pgw622.py (18, incl. a real CPU torch.compile
round-trip and the race test vs an in-flight eager batch); adjacent
compile/cell suites green (248); mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)