### PR TITLE
release 0.46.0: th#1017 inference regimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.46.0 (2026-07-22)
+
+- **th#1017: inference regimes — checkpoints whose weights demand a specific
+  inference configuration.** New per-method `regimes=` on `@endpoint`
+  ("standard" | "v_prediction" | "distilled"; per-method dict on class
+  handlers mirroring `warmup=`, bare tuple on the function form; absent =
+  ("standard",)), exported per-function in the discovery manifest (key
+  omitted for the default). `ResolvedSlot` gains `.regime` (from the hub
+  resolve response's `inference_regime`; "standard" on older hubs) so
+  handlers can branch — e.g. a dual-mode turbo lane skips its distillation
+  LoRA for an already-distilled (fused DMD/Lightning/LCM) checkpoint. The
+  executor enforces a `RegimeMismatchError` backstop (hub gates enforce
+  upstream at deploy + request time; the wire carries no real regime yet,
+  so every dispatch resolves "standard" — never declare a tuple excluding
+  it). `SdxlScheduler` vocab gains "lcm" and "euler_trailing"; the
+  converter stamps regime-correct scheduler config into produced diffusers
+  snapshots (v_prediction -> prediction_type + rescale_betas_zero_snr,
+  distilled -> trailing timestep spacing) via an `inference_regime` hint on
+  clone/convert.
+
 ## 0.45.0 (2026-07-22)
 
 - **pgw#622: eager-while-compiling with hot-swap — a novel request shape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.45.0"
+version = "0.46.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -39,7 +39,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Tuple, TypeVar, Union
 import msgspec
 
 from .binding import BINDING_TYPES, Binding
-from .slot import Slot
+from .slot import DEFAULT_REGIMES, REGIMES, Slot
 
 T = TypeVar("T")
 SlotLike = Union[Binding, Slot]
@@ -154,6 +154,64 @@ def _validate_warmup_decl(owner: str, warmup: Optional[WarmupDecl]) -> Optional[
     )
 
 
+# th#1017 inference regimes: what checkpoint(s) a handler's CFG/scheduling
+# code path was written for. Class handlers declare a {method_name:
+# (regime, ...)} mapping (mirrors warmup=); the function form (one handler)
+# declares a bare tuple. A method/function absent from the declaration gets
+# DEFAULT_REGIMES ("standard",).
+RegimesDecl = Union[Tuple[str, ...], Mapping[str, Tuple[str, ...]]]
+
+
+def _validate_regime_tuple(owner: str, value: Any) -> Tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise TypeError(
+            f"@endpoint {owner}: regimes= entries must be a tuple of regime "
+            f"strings, got {type(value).__name__}"
+        )
+    regimes = tuple(str(v).strip() for v in value)
+    if not regimes:
+        raise ValueError(f"@endpoint {owner}: regimes= entry must not be empty")
+    bad = [r for r in regimes if r not in REGIMES]
+    if bad:
+        raise ValueError(
+            f"@endpoint {owner}: unknown regime(s) {bad!r} (valid: {REGIMES})"
+        )
+    return regimes
+
+
+def _validate_class_regimes(
+    owner: str, regimes: Optional[RegimesDecl], handler_names: "set[str]"
+) -> Dict[str, Tuple[str, ...]]:
+    if regimes is None:
+        return {}
+    if not isinstance(regimes, Mapping):
+        raise TypeError(
+            f"@endpoint {owner}: class regimes= must be a "
+            "{method_name: (regime, ...)} mapping, got "
+            f"{type(regimes).__name__}"
+        )
+    unknown = set(regimes) - handler_names
+    if unknown:
+        raise ValueError(
+            f"@endpoint {owner}: regimes= names unknown handler method(s) "
+            f"{sorted(unknown)} (known: {sorted(handler_names)})"
+        )
+    return {k: _validate_regime_tuple(f"{owner}.{k}", v) for k, v in regimes.items()}
+
+
+def _validate_function_regimes(
+    owner: str, regimes: Optional[RegimesDecl]
+) -> Tuple[str, ...]:
+    if regimes is None:
+        return DEFAULT_REGIMES
+    if isinstance(regimes, Mapping):
+        raise TypeError(
+            f"@endpoint function {owner!r}: regimes= must be a tuple of "
+            "regime strings (functions have one handler, no per-method mapping)"
+        )
+    return _validate_regime_tuple(owner, regimes)
+
+
 class Compile(msgspec.Struct, frozen=True):
     """Opt-in torch.compile over pre-built per-SKU cache artifacts (#384).
 
@@ -263,6 +321,9 @@ class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
     # schema; {method: payload-or-None} = declared warmup payloads (None
     # skips that method); NoWarmup(reason) = class-level opt-out.
     warmup: Optional[WarmupDecl] = None
+    # th#1017: per-handler declared regimes, attr_name -> (regime, ...).
+    # Function-shaped endpoints key their single handler under "".
+    regimes: Mapping[str, Tuple[str, ...]] = msgspec.field(default_factory=dict)
 
 
 ATTR = "__gen_worker_endpoint__"
@@ -515,6 +576,7 @@ def _decorate_class(
     compile: Optional[Compile] = None,
     child_calls: bool = False,
     warmup: Optional[WarmupDecl] = None,
+    regimes: Optional[RegimesDecl] = None,
 ) -> type:
     handlers = _find_handler_methods(cls)
     for attr, member in handlers:
@@ -532,6 +594,9 @@ def _decorate_class(
         kind=kind, resources=resources, models=models, slots=slots,
         runtime=runtime, compile=compile, child_calls=child_calls,
         warmup=_validate_warmup_decl(cls.__name__, warmup),
+        regimes=_validate_class_regimes(
+            cls.__name__, regimes, {attr for attr, _ in handlers}
+        ),
     )
     setattr(cls, ATTR, decl)
     setattr(cls, "__gen_worker_handlers__", handlers)
@@ -556,6 +621,7 @@ def _decorate_function(
     compile: Optional[Compile] = None,
     child_calls: bool = False,
     warmup: Optional[WarmupDecl] = None,
+    regimes: Optional[RegimesDecl] = None,
 ) -> Callable[..., Any]:
     _validate_handler_shape(fn.__name__, fn, is_method=False)
     _reject_producer_generator(fn.__name__, fn, kind)
@@ -586,6 +652,7 @@ def _decorate_function(
         kind=kind, resources=resources, models=models, slots=slots,
         runtime=None, name=(name or fn.__name__), is_function=True,
         compile=compile, child_calls=child_calls,
+        regimes={"": _validate_function_regimes(fn.__name__, regimes)},
     )
     setattr(fn, ATTR, decl)
     return fn
@@ -607,6 +674,7 @@ def endpoint(
     compile: Optional[Compile] = ...,
     child_calls: bool = ...,
     warmup: Optional[WarmupDecl] = ...,
+    regimes: Optional[RegimesDecl] = ...,
 ) -> Callable[[T], T]: ...  # configured @endpoint(...) form
 
 
@@ -622,6 +690,7 @@ def endpoint(
     compile: Optional[Compile] = None,
     child_calls: bool = False,
     warmup: Optional[WarmupDecl] = None,
+    regimes: Optional[RegimesDecl] = None,
 ) -> Any:
     """The one endpoint decorator. See the module docstring for shapes.
 
@@ -653,13 +722,13 @@ def endpoint(
             return _decorate_class(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, compile=compile,
-                child_calls=child_calls, warmup=warmup,
+                child_calls=child_calls, warmup=warmup, regimes=regimes,
             )
         if inspect.isfunction(obj):
             return _decorate_function(
                 obj, kind=kind, resources=resources_value, models=dict(model_map),
                 slots=dict(slot_map), runtime=runtime, name=name, compile=compile,
-                child_calls=child_calls, warmup=warmup,
+                child_calls=child_calls, warmup=warmup, regimes=regimes,
             )
         raise TypeError(
             f"@endpoint requires a function or class, got {type(obj).__name__}"
@@ -671,6 +740,6 @@ def endpoint(
 
 
 __all__ = [
-    "Compile", "EndpointDecl", "NoWarmup", "Resources", "SlotLike",
-    "VariantDecl", "WarmupDecl", "endpoint", "variant_of",
+    "Compile", "EndpointDecl", "NoWarmup", "RegimesDecl", "Resources",
+    "SlotLike", "VariantDecl", "WarmupDecl", "endpoint", "variant_of",
 ]

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -43,6 +43,19 @@ from ..families.base import KIND_LORA, FamilyDefaults, family_for
 
 D = TypeVar("D", bound=FamilyDefaults)
 
+# th#1017 inference regimes: a checkpoint-level fact about what inference
+# configuration the WEIGHTS demand. "distilled" routes (CFG-off contract
+# only); "v_prediction" configures (scheduler prediction_type) — both are
+# hub-classified at ingest; the SDK only consumes.
+REGIMES = ("standard", "v_prediction", "distilled")
+DEFAULT_REGIMES = ("standard",)
+
+
+class RegimeMismatchError(ValueError):
+    """A resolved checkpoint's inference_regime is outside the invoked
+    function's declared ``regimes=`` (th#1017). Hub routing enforces this
+    upstream; reaching here means version skew or a hub bug."""
+
 
 class Slot(Generic[D]):
     """One ``models={}`` slot as a hub-resolved value.
@@ -125,16 +138,26 @@ class ResolvedSlot(Generic[D]):
     Explicit PAYLOAD values still win over ``.defaults`` — that precedence
     is handler logic; this object only carries the merged HUB-vs-CODE
     result.
+
+    ``regime`` (th#1017) is the resolved checkpoint's inference regime —
+    ``"standard"`` unless the hub classified the weights otherwise
+    (``"v_prediction"`` | ``"distilled"``). Handlers branch on it (e.g. a
+    dual-mode turbo lane skips its distillation LoRA for an
+    already-distilled checkpoint).
     """
 
-    __slots__ = ("ref", "defaults")
+    __slots__ = ("ref", "defaults", "regime")
 
-    def __init__(self, ref: ModelRef, defaults: D) -> None:
+    def __init__(self, ref: ModelRef, defaults: D, regime: str = "standard") -> None:
         self.ref = ref
         self.defaults = defaults
+        self.regime = regime
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
-        return f"ResolvedSlot(ref={self.ref!r}, defaults={self.defaults!r})"
+        return (
+            f"ResolvedSlot(ref={self.ref!r}, defaults={self.defaults!r}, "
+            f"regime={self.regime!r})"
+        )
 
 
 def _apply_lora_overrides(
@@ -187,6 +210,28 @@ def _apply_lora_overrides(
     return result
 
 
+def _finish_resolved(
+    name: str,
+    ref: ModelRef,
+    defaults: D,
+    *,
+    inference_regime: str,
+    allowed_regimes: Optional[Sequence[str]],
+) -> "ResolvedSlot[D]":
+    """Build the ``ResolvedSlot`` and, when the caller knows the invoked
+    function's declared regimes, enforce the th#1017 backstop: the hub
+    enforces checkpoint-regime/function-regime compatibility at deploy and
+    request time upstream — reaching a mismatch here means version skew or
+    a hub bug, never a normal-path outcome."""
+    resolved = ResolvedSlot(ref=ref, defaults=defaults, regime=inference_regime)
+    if allowed_regimes is not None and resolved.regime not in allowed_regimes:
+        raise RegimeMismatchError(
+            f"slot {name!r}: resolved checkpoint regime {resolved.regime!r} is "
+            f"not in the invoked function's declared regimes {tuple(allowed_regimes)!r}"
+        )
+    return resolved
+
+
 def resolve_slot(
     name: str,
     slot: "Slot[D]",
@@ -195,6 +240,8 @@ def resolve_slot(
     family: str = "",
     raw_metadata_json: str = "",
     lora_metadata_json: Sequence[str] = (),
+    inference_regime: str = "standard",
+    allowed_regimes: Optional[Sequence[str]] = None,
 ) -> "ResolvedSlot[D]":
     """Merge repo-metadata inference defaults over ``slot.default_config``,
     then apply per-lora FIELD-LEVEL overrides — the pgw#520/pgw#516
@@ -213,6 +260,11 @@ def resolve_slot(
     ``ModelBinding.loras[i].inference_defaults`` on the wire) applies LAST,
     field by field, on top of whichever recipe precedence above picked — see
     :func:`_apply_lora_overrides`.
+
+    ``inference_regime`` (th#1017) is the resolved checkpoint's hub-
+    classified regime ("standard" on hubs/paths that don't send one).
+    ``allowed_regimes``, when given, is the invoked function's declared
+    ``regimes=`` — see :func:`_finish_resolved`.
     """
     if ref is None:
         raise ValueError(
@@ -240,10 +292,16 @@ def resolve_slot(
                 f"{defaults_cls.__name__} validation: {exc}"
             ) from exc
         defaults = _apply_lora_overrides(name, defaults, fam, lora_metadata_json)
-        return ResolvedSlot(ref=ref, defaults=defaults)
+        return _finish_resolved(
+            name, ref, defaults,
+            inference_regime=inference_regime, allowed_regimes=allowed_regimes,
+        )
     if slot.default_config is not None:
         merged = _apply_lora_overrides(name, slot.default_config, fam, lora_metadata_json)
-        return ResolvedSlot(ref=ref, defaults=merged)
+        return _finish_resolved(
+            name, ref, merged,
+            inference_regime=inference_regime, allowed_regimes=allowed_regimes,
+        )
     raise ValueError(
         f"slot {name!r}: no repo inference-defaults metadata for the "
         "resolved model and no Slot(default_config=...) on the endpoint — "
@@ -258,12 +316,15 @@ def resolve_slots(
     families: Mapping[str, str] = {},
     raw_metadata: Mapping[str, str] = {},
     lora_metadata: Mapping[str, Sequence[str]] = {},
+    regimes: Mapping[str, str] = {},
+    allowed_regimes: Optional[Sequence[str]] = None,
 ) -> Dict[str, "ResolvedSlot[Any]" | Exception]:
     """Resolve every declared slot, collecting per-slot failures instead of
     raising — callers (RequestContext) surface each failure lazily, only
     when the handler actually reads that slot ("clear error at request
     time", not a blanket dispatch-time failure for slots the handler never
-    touches)."""
+    touches). ``allowed_regimes`` (th#1017), when given, applies to every
+    slot: one invoked function has one declared ``regimes=`` set."""
     out: Dict[str, "ResolvedSlot[Any]" | Exception] = {}
     for name, slot in slots.items():
         try:
@@ -273,10 +334,15 @@ def resolve_slots(
                 family=families.get(name, ""),
                 raw_metadata_json=raw_metadata.get(name, ""),
                 lora_metadata_json=lora_metadata.get(name, ()),
+                inference_regime=regimes.get(name, "standard"),
+                allowed_regimes=allowed_regimes,
             )
         except ValueError as exc:
             out[name] = exc
     return out
 
 
-__all__ = ["ResolvedSlot", "Slot", "resolve_slot", "resolve_slots"]
+__all__ = [
+    "DEFAULT_REGIMES", "REGIMES", "RegimeMismatchError", "ResolvedSlot",
+    "Slot", "resolve_slot", "resolve_slots",
+]

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -39,6 +39,7 @@ from .writer import (
     FP8_DEFAULT_COMPONENTS,
     MAX_SAFETENSORS_SHARD_BYTES,
     VARIANT_WEIGHT_NAME_RE as _VARIANT_WEIGHT_NAME_RE,
+    apply_regime_scheduler_config,
     copy_non_weight_files,
     normalize_variant_filenames as _normalize_variant_filenames,
     shard_safetensors_by_offset,
@@ -297,12 +298,17 @@ def build_flavor_tree(
     out_dir: Path,
     *,
     quantize_components: list[str] | None = None,
+    inference_regime: str = "standard",
 ) -> tuple[Path, dict[str, str]]:
     """Materialize one output flavor as a local file tree.
 
     Passthrough (dtype/layout/container match the source) hardlinks the
     snapshot. Otherwise: optional layout repackage, then per-weight-set
     cast / quant / gguf via :mod:`gen_worker.convert.convert`.
+
+    ``inference_regime`` (th#1017) stamps regime-correct scheduler config
+    into the produced tree's ``scheduler/config.json`` (no-op for
+    "standard" or a layout with no scheduler component).
 
     Returns ``(tree_root, attrs)``. Raises ``InlineConversionNotPossible``
     for calibrated dtypes.
@@ -336,6 +342,7 @@ def build_flavor_tree(
         _stage_oversize_safetensors(out_dir)
         if source_dtype in _CAST_NORMALIZE_DTYPES:
             _normalize_variant_filenames(out_dir)
+        apply_regime_scheduler_config(out_dir, inference_regime)
         return out_dir, attrs
 
     # GGUF: single-artifact container.
@@ -384,6 +391,7 @@ def build_flavor_tree(
         _stage_oversize_safetensors(out_dir)
         if spec.dtype in _CAST_NORMALIZE_DTYPES:
             _normalize_variant_filenames(out_dir)
+        apply_regime_scheduler_config(out_dir, inference_regime)
         return out_dir, attrs
 
     # Dtype conversion per weight set.
@@ -439,6 +447,7 @@ def build_flavor_tree(
     _stage_oversize_safetensors(out_dir)
     if spec.dtype in _CAST_NORMALIZE_DTYPES:
         _normalize_variant_filenames(out_dir)
+    apply_regime_scheduler_config(out_dir, inference_regime)
     if work_root is not source_dir:
         shutil.rmtree(work_root, ignore_errors=True)
     return out_dir, attrs
@@ -848,13 +857,19 @@ def run_clone(
     hf_token: str | None = None,
     civitai_api_key: str | None = None,
     source_include: Any = None,
+    inference_regime: str | None = None,
 ) -> CloneResult:
+    from ..api.slot import REGIMES
+
     provider = str(provider or "").strip().lower()
     destination = normalize_destination_ref(destination_repo)
     tags = normalize_tags(destination_repo_tags)
     layout_hint = str(target_layout or "diffusers").strip().lower() or "diffusers"
     specs = normalize_outputs(outputs, layout_hint=layout_hint)
     include = normalize_source_include(source_include)
+    regime = str(inference_regime or "standard").strip().lower() or "standard"
+    if regime not in REGIMES:
+        raise ValueError(f"inference_regime must be one of {REGIMES}, got {inference_regime!r}")
     if include and provider != "huggingface":
         raise ValueError("source_include is only supported for provider='huggingface'")
     # th#901: normalize_outputs collapses "caller asked for nothing" onto a
@@ -1061,6 +1076,7 @@ def run_clone(
                         tree, attrs = build_flavor_tree(
                             source, cast_spec, flavor_dir,
                             quantize_components=quantize_components,
+                            inference_regime=regime,
                         )
                         flavor_label = str(attrs.get("dtype") or spec.dtype)
                     else:
@@ -1085,6 +1101,7 @@ def run_clone(
                     tree, attrs = build_flavor_tree(
                         source, spec, flavor_dir,
                         quantize_components=quantize_components,
+                        inference_regime=regime,
                     )
                     # dtype="source" resolves to the detected on-disk dtype.
                     flavor_label = str(attrs.get("dtype") or spec.dtype)
@@ -1248,6 +1265,7 @@ def from_huggingface(ctx: Any, payload: Any, *, hf_token: str | None = None) -> 
         gguf_quant=getattr(payload, "gguf_quant", None),
         hf_token=hf_token,
         source_include=getattr(payload, "source_include", None),
+        inference_regime=getattr(payload, "inference_regime", None),
     )
 
 
@@ -1268,6 +1286,7 @@ def from_civitai(ctx: Any, payload: Any, *, civitai_api_key: str | None = None) 
         overwrite_repo=bool(getattr(payload, "overwrite_repo", False)),
         gguf_quant=getattr(payload, "gguf_quant", None),
         civitai_api_key=civitai_api_key,
+        inference_regime=getattr(payload, "inference_regime", None),
     )
 
 

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -864,6 +864,30 @@ def copy_non_weight_files(source_dir: Path, out_dir: Path, *, skip_components: s
         _link_or_copy(f, out_dir / rel)
 
 
+# th#1017: scheduler config overrides per checkpoint-declared inference
+# regime. v_prediction needs zero-terminal-SNR v-prediction sampling;
+# distilled needs trailing timestep spacing (few-step, near-zero CFG).
+_REGIME_SCHEDULER_OVERRIDES: dict[str, dict[str, Any]] = {
+    "v_prediction": {"prediction_type": "v_prediction", "rescale_betas_zero_snr": True},
+    "distilled": {"timestep_spacing": "trailing"},
+}
+
+
+def apply_regime_scheduler_config(out_dir: Path, inference_regime: str) -> None:
+    """Stamp ``inference_regime``'s scheduler overrides into a produced
+    diffusers snapshot's ``scheduler/config.json``. No-op for "standard" or
+    a tree with no scheduler component (e.g. singlefile output)."""
+    overrides = _REGIME_SCHEDULER_OVERRIDES.get(inference_regime)
+    if not overrides:
+        return
+    cfg_path = Path(out_dir) / "scheduler" / "config.json"
+    if not cfg_path.is_file():
+        return
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    cfg.update(overrides)
+    cfg_path.write_text(json.dumps(cfg, indent=2, sort_keys=True), encoding="utf-8")
+
+
 def _group_shard_prefix(entry: Path) -> str:
     stem = entry.name
     for suffix in (".safetensors.index.json", ".safetensors"):

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import msgspec
 
 from gen_worker.api.binding import Binding
-from gen_worker.api.slot import Slot
+from gen_worker.api.slot import DEFAULT_REGIMES, Slot
 from gen_worker.api.types import (
     Asset,
     AudioAsset,
@@ -757,6 +757,10 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         if es.variant_of:
             fn["variant_of"] = es.variant_of
             fn["variant"] = es.variant_kind
+        # th#1017: declared inference regimes — omitted when it's just the
+        # default (absent = ["standard"]).
+        if tuple(es.regimes) != DEFAULT_REGIMES:
+            fn["regimes"] = list(es.regimes)
         if model_key is not None:
             fn["model"] = model_key
         if slots_block:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -260,12 +260,18 @@ def _resolve_slots_kwargs(spec: EndpointSpec, run: "Optional[pb.RunJob]") -> Dic
     errors: Dict[str, str] = {}
     for name, slot in spec.slots.items():
         try:
+            # th#1017: allowed_regimes is the backstop, not primary
+            # enforcement (the hub gates checkpoint<->function regime
+            # compatibility at deploy/dispatch time) — RunJob.ModelBinding
+            # has no wire field for the resolved checkpoint's regime yet, so
+            # inference_regime stays "standard" here until that lands.
             resolved[name] = resolve_slot(
                 name, slot,
                 ref=spec.models.get(name),
                 family=spec.slot_family.get(name, ""),
                 raw_metadata_json=raw_defaults.get(name, ""),
                 lora_metadata_json=lora_defaults.get(name, ()),
+                allowed_regimes=spec.regimes,
             )
         except ValueError as exc:
             errors[name] = str(exc)

--- a/src/gen_worker/families/sdxl.py
+++ b/src/gen_worker/families/sdxl.py
@@ -9,7 +9,11 @@ from typing import Literal, Optional, Tuple
 
 from .base import FamilyDefaults, family
 
-SdxlScheduler = Literal["euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras"]
+SdxlScheduler = Literal[
+    "euler_a", "dpmpp_2m_karras", "dpmpp_2m_sde_karras",
+    # th#1017: distilled-regime schedulers (few-step, near-zero CFG).
+    "lcm", "euler_trailing",
+]
 
 
 @family("sdxl")

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -44,6 +44,10 @@ class WorkerResolvedRepo:
     # th#964: the resolved checkpoint's architecture family ("sdxl-pony",
     # ...) — drives the local family lane policy. "" on hubs not sending it.
     model_family: str = ""
+    # th#1017: the resolved checkpoint's hub-classified inference regime
+    # ("standard" | "v_prediction" | "distilled"). "" on hubs not sending
+    # it — callers treat that the same as "standard".
+    inference_regime: str = ""
 
 
 class HubResolveError(RuntimeError):
@@ -161,4 +165,5 @@ def resolve_repo(
         size_bytes=int(body.get("size_bytes") or 0),
         sibling_flavors=siblings,
         model_family=str(body.get("model_family") or "").strip(),
+        inference_regime=str(body.get("inference_regime") or "").strip(),
     )

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -17,7 +17,7 @@ import msgspec
 
 from .api.binding import Binding, ModelRef
 from .api.decorators import ATTR, VARIANT_ATTR, Compile, EndpointDecl, Resources, VariantDecl
-from .api.slot import Slot
+from .api.slot import DEFAULT_REGIMES, Slot
 from .discovery.names import slugify_name
 from .discovery.walk import find_endpoints
 
@@ -75,6 +75,9 @@ class EndpointSpec:
     # sibling function variant_of (both slugs). Empty = not a variant.
     variant_of: str = ""
     variant_kind: str = ""
+    # th#1017: this handler's declared inference regimes (from @endpoint's
+    # regimes=); ("standard",) when undeclared.
+    regimes: tuple = DEFAULT_REGIMES
     module: str = ""              # declaring module
     walked_module: str = ""       # top-level package the object was found under
 
@@ -305,6 +308,7 @@ def _spec_for_handler(
         child_calls=decl.child_calls,
         variant_of=variant_of_slug,
         variant_kind=variant_kind,
+        regimes=decl.regimes.get(attr_name, DEFAULT_REGIMES),
         module=getattr(cls or method, "__module__", "") or "",
         walked_module=walked_module,
     )

--- a/tests/convert/test_p8_convert_publish_contract.py
+++ b/tests/convert/test_p8_convert_publish_contract.py
@@ -67,7 +67,8 @@ def _install_fake_ingest(monkeypatch: pytest.MonkeyPatch, source: IngestedSource
 
 
 def _stub_build_flavor_tree(monkeypatch: pytest.MonkeyPatch, calls: list) -> None:
-    def fake_build_flavor_tree(source, spec, out_dir, *, quantize_components=None):
+    def fake_build_flavor_tree(source, spec, out_dir, *, quantize_components=None,
+                                inference_regime="standard"):
         calls.append({"dtype": spec.dtype, "file_layout": spec.file_layout})
         out_dir.mkdir(parents=True, exist_ok=True)
         (out_dir / "model.safetensors").write_bytes(b"\x01" * 32)

--- a/tests/test_regimes_th1017.py
+++ b/tests/test_regimes_th1017.py
@@ -1,0 +1,326 @@
+"""th#1017: inference regimes — @endpoint's ``regimes=`` decorator surface,
+discovery manifest emission, Slot resolution's ``.regime``/backstop, and the
+converter's scheduler-config regime stamp. Real discovery/registry/convert
+code, no mocking (same idiom as test_variant_th1004.py).
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import msgspec
+import pytest
+
+
+@pytest.fixture()
+def tmp_pkg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return tmp_path
+
+
+def _write(pkg: Path, main_src: str) -> None:
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent(main_src))
+
+
+# ---------------------------------------------------------------------------
+# decorator surface + discovery manifest emission
+# ---------------------------------------------------------------------------
+
+
+def test_class_per_method_regimes_round_trip_into_manifest(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_r_method"
+    _write(pkg, """
+        import msgspec
+        from gen_worker import RequestContext, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(regimes={"generate_distilled": ("distilled",)})
+        class Gen:
+            def generate(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="base")
+
+            def generate_distilled(self, ctx: RequestContext, data: In_) -> Out_:
+                return Out_(y="distilled")
+    """)
+
+    fns = {f["name"]: f for f in discover_functions(tmp_pkg, main_module="ep_r_method.main")}
+    # Undeclared method defaults to ("standard",) -> omitted from the manifest.
+    assert "regimes" not in fns["generate"]
+    assert fns["generate-distilled"]["regimes"] == ["distilled"]
+
+
+def test_function_form_tuple_regimes_round_trips(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_r_fn"
+    _write(pkg, """
+        import msgspec
+        from gen_worker import RequestContext, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(regimes=("v_prediction", "standard"))
+        def render(ctx: RequestContext, data: In_) -> Out_:
+            return Out_(y="base")
+    """)
+
+    fns = {f["name"]: f for f in discover_functions(tmp_pkg, main_module="ep_r_fn.main")}
+    assert set(fns["render"]["regimes"]) == {"v_prediction", "standard"}
+
+
+def test_function_form_default_regimes_omitted_from_manifest(tmp_pkg: Path) -> None:
+    from gen_worker.discovery.discover import discover_functions
+
+    pkg = tmp_pkg / "ep_r_fn_default"
+    _write(pkg, """
+        import msgspec
+        from gen_worker import RequestContext, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint
+        def render(ctx: RequestContext, data: In_) -> Out_:
+            return Out_(y="base")
+    """)
+
+    fns = {f["name"]: f for f in discover_functions(tmp_pkg, main_module="ep_r_fn_default.main")}
+    assert "regimes" not in fns["render"]
+
+
+# Module scope: typing.get_type_hints resolves handler annotations from the
+# declaring module's globals, so spec-time structs cannot be test-local.
+from gen_worker import RequestContext, endpoint
+
+
+class RIn(msgspec.Struct):
+    prompt: str = ""
+
+
+class ROut(msgspec.Struct):
+    y: str
+
+
+def test_unknown_regime_string_rejected_at_decoration() -> None:
+    with pytest.raises(ValueError, match="unknown regime"):
+        @endpoint(regimes=("fried",))
+        def render(ctx: RequestContext, data: RIn) -> ROut:  # pragma: no cover
+            return ROut(y="x")
+
+
+def test_class_regimes_unknown_method_rejected_at_decoration() -> None:
+    with pytest.raises(ValueError, match="unknown handler method"):
+        @endpoint(regimes={"nonexistent": ("distilled",)})
+        class Gen:
+            def generate(self, ctx: RequestContext, data: RIn) -> ROut:
+                return ROut(y="x")
+
+
+def test_function_form_rejects_per_method_mapping() -> None:
+    with pytest.raises(TypeError, match="tuple of"):
+        @endpoint(regimes={"render": ("distilled",)})
+        def render(ctx: RequestContext, data: RIn) -> ROut:  # pragma: no cover
+            return ROut(y="x")
+
+
+def test_class_form_rejects_bare_tuple() -> None:
+    with pytest.raises(TypeError, match="mapping"):
+        @endpoint(regimes=("distilled",))
+        class Gen:
+            def generate(self, ctx: RequestContext, data: RIn) -> ROut:
+                return ROut(y="x")
+
+
+# ---------------------------------------------------------------------------
+# Slot resolution: .regime + the executor-level backstop
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_slot_carries_regime_from_resolve_slot() -> None:
+    from gen_worker.api.binding import HF
+    from gen_worker.api.slot import Slot, resolve_slot
+    from gen_worker.families import SdxlDefaults
+
+    slot = Slot(object, default_config=SdxlDefaults())
+    ref = HF("acme/gonzalomo-xl")
+    resolved = resolve_slot("pipeline", slot, ref=ref, inference_regime="distilled")
+    assert resolved.regime == "distilled"
+
+
+def test_resolve_slot_defaults_regime_to_standard() -> None:
+    from gen_worker.api.binding import HF
+    from gen_worker.api.slot import Slot, resolve_slot
+    from gen_worker.families import SdxlDefaults
+
+    slot = Slot(object, default_config=SdxlDefaults())
+    resolved = resolve_slot("pipeline", slot, ref=HF("acme/plain-xl"))
+    assert resolved.regime == "standard"
+
+
+def test_regime_mismatch_raises_typed_backstop_error() -> None:
+    from gen_worker.api.binding import HF
+    from gen_worker.api.slot import RegimeMismatchError, Slot, resolve_slot
+    from gen_worker.families import SdxlDefaults
+
+    slot = Slot(object, default_config=SdxlDefaults())
+    ref = HF("acme/gonzalomo-xl")
+    with pytest.raises(RegimeMismatchError, match="distilled"):
+        resolve_slot(
+            "pipeline", slot, ref=ref,
+            inference_regime="distilled", allowed_regimes=("standard",),
+        )
+
+
+def test_regime_within_allowed_set_resolves_cleanly() -> None:
+    from gen_worker.api.binding import HF
+    from gen_worker.api.slot import Slot, resolve_slot
+    from gen_worker.families import SdxlDefaults
+
+    slot = Slot(object, default_config=SdxlDefaults())
+    ref = HF("acme/gonzalomo-xl")
+    resolved = resolve_slot(
+        "pipeline", slot, ref=ref,
+        inference_regime="distilled", allowed_regimes=("standard", "distilled"),
+    )
+    assert resolved.regime == "distilled"
+
+
+# ---------------------------------------------------------------------------
+# hub_client: resolve_repo parses inference_regime (mirrors model_family)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_repo_parses_inference_regime(monkeypatch: pytest.MonkeyPatch) -> None:
+    import requests
+
+    from gen_worker.models.hub_client import resolve_repo
+    from gen_worker.models.refs import TensorhubRef
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self) -> dict:
+            return {
+                "snapshot_digest": "abc123",
+                "files": [{"path": "model.safetensors", "blake3": "b3", "url": "http://x/f",
+                           "size_bytes": 10}],
+                "model_family": "sdxl",
+                "inference_regime": "distilled",
+            }
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _FakeResp())
+    ref = TensorhubRef(owner="acme", repo="gonzalomo-xl", tag="prod", flavor="")
+    resolved = resolve_repo(ref, base_url="https://hub.example")
+    assert resolved.inference_regime == "distilled"
+
+
+def test_resolve_repo_defaults_inference_regime_empty_on_older_hubs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import requests
+
+    from gen_worker.models.hub_client import resolve_repo
+    from gen_worker.models.refs import TensorhubRef
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self) -> dict:
+            return {
+                "snapshot_digest": "abc123",
+                "files": [{"path": "model.safetensors", "blake3": "b3", "url": "http://x/f",
+                           "size_bytes": 10}],
+            }
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _FakeResp())
+    ref = TensorhubRef(owner="acme", repo="plain-xl", tag="prod", flavor="")
+    resolved = resolve_repo(ref, base_url="https://hub.example")
+    assert resolved.inference_regime == ""
+
+
+# ---------------------------------------------------------------------------
+# convert: regime-correct scheduler config written into produced snapshots
+# ---------------------------------------------------------------------------
+
+
+def _diffusers_source(tmp_path: Path) -> "IngestedSource":  # noqa: F821
+    from gen_worker.convert.ingest import IngestedSource
+
+    src = tmp_path / "source"
+    (src / "scheduler").mkdir(parents=True)
+    (src / "scheduler" / "config.json").write_text(json.dumps({
+        "_class_name": "EulerDiscreteScheduler", "prediction_type": "epsilon",
+    }))
+    (src / "unet").mkdir()
+    (src / "unet" / "model.safetensors").write_bytes(b"\x00" * 8)
+    (src / "model_index.json").write_text(json.dumps({"_class_name": "StableDiffusionXLPipeline"}))
+    return IngestedSource(
+        provider="huggingface", source_ref="acme/gonzalomo-xl", source_revision="sha1",
+        dir=src, layout="diffusers", model_family="sdxl", model_family_variant="",
+        attrs={"dtype": "fp16"},
+    )
+
+
+def test_distilled_regime_writes_trailing_timestep_spacing(tmp_path: Path) -> None:
+    from gen_worker.convert.clone import OutputSpec, build_flavor_tree
+
+    source = _diffusers_source(tmp_path)
+    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    out_dir = tmp_path / "flavor-distilled"
+    tree, _attrs = build_flavor_tree(source, spec, out_dir, inference_regime="distilled")
+
+    cfg = json.loads((tree / "scheduler" / "config.json").read_text())
+    assert cfg["timestep_spacing"] == "trailing"
+    assert cfg["prediction_type"] == "epsilon"  # untouched
+
+
+def test_v_prediction_regime_writes_zero_snr_v_pred(tmp_path: Path) -> None:
+    from gen_worker.convert.clone import OutputSpec, build_flavor_tree
+
+    source = _diffusers_source(tmp_path)
+    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    out_dir = tmp_path / "flavor-vpred"
+    tree, _attrs = build_flavor_tree(source, spec, out_dir, inference_regime="v_prediction")
+
+    cfg = json.loads((tree / "scheduler" / "config.json").read_text())
+    assert cfg["prediction_type"] == "v_prediction"
+    assert cfg["rescale_betas_zero_snr"] is True
+
+
+def test_standard_regime_leaves_scheduler_config_untouched(tmp_path: Path) -> None:
+    from gen_worker.convert.clone import OutputSpec, build_flavor_tree
+
+    source = _diffusers_source(tmp_path)
+    spec = OutputSpec(dtype="fp16", file_layout="diffusers", file_type="safetensors")
+    out_dir = tmp_path / "flavor-standard"
+    tree, _attrs = build_flavor_tree(source, spec, out_dir, inference_regime="standard")
+
+    cfg = json.loads((tree / "scheduler" / "config.json").read_text())
+    assert cfg == {"_class_name": "EulerDiscreteScheduler", "prediction_type": "epsilon"}
+
+
+def test_apply_regime_scheduler_config_noop_without_scheduler_dir(tmp_path: Path) -> None:
+    from gen_worker.convert.writer import apply_regime_scheduler_config
+
+    out_dir = tmp_path / "singlefile-out"
+    out_dir.mkdir()
+    apply_regime_scheduler_config(out_dir, "distilled")  # must not raise
+    assert not (out_dir / "scheduler").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Promotes the th#1017 inference-regime lane from chaos (5 commits, cherry-picked clean) plus the 0.46.0 release commit.

- `regimes=` per-method declaration on `@endpoint` + discovery-manifest export
- `ResolvedSlot.regime` from the hub resolve response + executor `RegimeMismatchError` backstop
- `SdxlScheduler` vocab += `lcm`, `euler_trailing`
- converter stamps regime-correct scheduler config (`inference_regime` hint on clone/convert)

Chaos suite at tip: 635 passed, 5 skipped, 1 xfailed. Unblocks inference-endpoints' sdxl image (gen-worker floor >=0.46.0, ie#527). Tag v0.46.0 after merge to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)