### PR TITLE
th#1031: cell_selection_bug recovers via self-mint instead of blocking every request

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3985,6 +3985,12 @@ class Executor:
                     if isinstance(inj.kwargs.get(slot), (str, Path))
                 )
                 scope_mints = arming_scope.self_mints
+                for bug in arming_scope.selection_bugs.values():
+                    # th#1031: the fleet policy already self-minted a working
+                    # cell instead of aborting — still report the th#883
+                    # invariant loudly.
+                    await self._report_cell_selection_bug(
+                        spec, compile_selection, bug)
                 for pipe, armed in arming_scope.objects:
                     if not compile_cache.has_compile_target(pipe, spec.compile):
                         continue
@@ -5396,44 +5402,27 @@ class Executor:
                             self._enable_compiled,
                             pipe, spec.compile, compile_artifact,
                         )
-                        armed = outcome.armed
-                        pipe_mint = outcome.self_mint
-                    except compile_cache.CellSelectionBugError as exc:
-                        # th#883 invariant: a SELF-REQUESTED, identity-
-                        # verified cell failed to arm — by construction a
-                        # bug in the one selection brain. Loud event class
-                        # on the wire; never a silent eager fallback.
-                        bug_ref = (
-                            compile_selection.ref
-                            if compile_selection is not None else ""
-                        )
-                        bug_digest = (
-                            compile_selection.snapshot_digest
-                            if compile_selection is not None else ""
-                        )
-                        logger.error(
-                            "cell_selection_bug on %s (%s): %s",
-                            spec.name, bug_ref, exc)
-                        await self._send(pb.WorkerMessage(
-                            model_event=self.store.model_event(
-                                bug_ref,
-                                pb.MODEL_STATE_FAILED,
-                                identity=(
-                                    (bug_digest, 0) if bug_digest else None),
-                                error=(
-                                    f"cell_selection_bug: {str(exc)[:300]}"),
-                            )
-                        ))
-                        from .models.loading import pipeline_weight_lane
-
-                        if pipeline_weight_lane(pipe).startswith(
-                                _MANDATORY_LANES):
-                            # Quantized lanes stay fail-closed: surface as
-                            # the retryable lane refusal, cause preserved.
-                            raise compile_cache.CompiledLaneUnavailableError(
-                                f"cell_selection_bug: {exc}") from exc
-                        armed = False
-                        pipe_mint = None
+                    except compile_cache.CompiledLaneUnavailableError as exc:
+                        # Mandatory (w8a8/w4a4) lane: self-mint also hit a
+                        # genuine impossibility (no CUDA/toolchain/target).
+                        # When this refusal was chained from a caught
+                        # cell_selection_bug (th#1031), report it — the
+                        # lane refusal must not silently swallow the
+                        # loud invariant event.
+                        bug = exc.__cause__
+                        if isinstance(bug, compile_cache.CellSelectionBugError):
+                            await self._report_cell_selection_bug(
+                                spec, compile_selection, bug)
+                        raise
+                    armed = outcome.armed
+                    pipe_mint = outcome.self_mint
+                    if outcome.selection_bug is not None:
+                        # th#1031: no longer fatal — this SAME call
+                        # already fell through to self-mint (or, for a
+                        # plain lane, eager); still reported loudly so
+                        # the th#883 invariant stays wire-visible.
+                        await self._report_cell_selection_bug(
+                            spec, compile_selection, outcome.selection_bug)
 
                     if compile_cache.has_compile_target(pipe, spec.compile):
                         result.add_compile_object(pipe, (slot,))
@@ -5610,18 +5599,45 @@ class Executor:
 
         return republish
 
+    async def _report_cell_selection_bug(
+        self,
+        spec: EndpointSpec,
+        compile_selection: Optional["_CompileArtifactSelection"],
+        exc: BaseException,
+    ) -> None:
+        """th#883 invariant: a SELF-REQUESTED, identity-verified cell failed
+        to arm — by construction a bug in the one selection brain. Loud
+        event class on the wire (th#1031: no longer fatal to serving — the
+        fleet policy already fell through to self-mint; this only makes
+        sure the invariant stays wire-visible)."""
+        bug_ref = compile_selection.ref if compile_selection is not None else ""
+        bug_digest = (
+            compile_selection.snapshot_digest
+            if compile_selection is not None else "")
+        logger.error("cell_selection_bug on %s (%s): %s", spec.name, bug_ref, exc)
+        await self._send(pb.WorkerMessage(
+            model_event=self.store.model_event(
+                bug_ref,
+                pb.MODEL_STATE_FAILED,
+                identity=((bug_digest, 0) if bug_digest else None),
+                error=f"cell_selection_bug: {str(exc)[:300]}",
+            )
+        ))
+
     def _enable_compiled(
         self, pipe: Any, cfg: Any, artifact: Optional[Path],
     ) -> "fleet_cells.ArmOutcome":
         """Arm the best available compiled path for a freshly loaded pipeline.
 
-        gw#587: delivered cell first (unchanged semantics incl. the
-        cell_selection_bug invariant), SELF-MINT on miss — the boot warmup
-        compiles the real serving graphs once, serves compiled immediately,
-        and publishes through the hub's attested gate so the next worker on
-        this key is store-served. Eager fallback and the fail-closed cell
-        wait are gone for reachable mints; genuine mint impossibilities
-        keep the old miss policy (plain=eager, quantized=typed refusal).
+        gw#587: delivered cell first — a th#1031 ``cell_selection_bug``
+        (self-requested cell fails contract_drift) is reported loudly but no
+        longer fatal: this falls through to SELF-MINT exactly like an
+        ordinary miss. The boot warmup compiles the real serving graphs
+        once, serves compiled immediately, and publishes through the hub's
+        attested gate so the next worker on this key is store-served. Eager
+        fallback and the fail-closed cell wait are gone for reachable mints;
+        genuine mint impossibilities keep the old miss policy (plain=eager,
+        quantized=typed refusal).
 
         Returns the fleet ``ArmOutcome``; a ``self_mint`` result is recorded
         into ``active_compile_artifacts`` exactly like a delivered cell so

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -132,10 +132,21 @@ class ArmOutcome:
     or, from callers that already hold a finalized identity, a
     :class:`SelfMint` — letting the executor synthesize the artifact
     selection it records/advertises.
+
+    ``selection_bug`` carries a caught :class:`CellSelectionBugError`
+    (th#1031): the th#883 invariant is a self-requested, identity-verified
+    cell that never OUGHT to fail, so it stays a loud, wire-visible event —
+    but a live cell key can legitimately collide across two structurally
+    different graphs (cell_key has no graph-shape axis), so a caught
+    instance no longer aborts arming. The caller reports it (ModelEvent /
+    pod_events, unchanged) while this same call proceeds to self-mint —
+    the ordinary MISS recovery — instead of leaving the pipeline stuck
+    retrying the identical unusable cell on every subsequent request.
     """
 
     armed: bool
     self_mint: Optional[Any] = None
+    selection_bug: Optional["cc.CellSelectionBugError"] = None
 
     def __bool__(self) -> bool:
         return self.armed
@@ -304,12 +315,19 @@ def enable_compiled(
     """Fleet arming policy (gw#587): delivered cell first, self-mint on miss.
 
     Replaces the executor's bare ``provision.enable_compiled`` call. HIT
-    keeps today's semantics exactly (incl. ``CellSelectionBugError``
-    propagation — the th#883 receipt invariant is untouched). MISS
-    self-mints and serves compiled; the ONLY remaining eager/fail-closed
-    exits are genuine mint impossibilities (no CUDA, no C toolchain, the
-    mint itself failing), where plain lanes serve eager and quantized lanes
-    keep their typed refusal — exactly the cozy-local store policy.
+    keeps today's semantics for a genuine match. A ``CellSelectionBugError``
+    (th#1031: a self-requested, identity-verified cell that STILL refuses to
+    arm — cell_key has no graph-shape axis, so two structurally different
+    graphs can legitimately collide on one key) no longer aborts arming: it
+    is captured onto the returned :class:`ArmOutcome` for the caller to
+    report loudly (unchanged wire event), and this call falls through to
+    self-mint exactly like an ordinary miss — a live worker must recover
+    into a working compiled state instead of retrying the identical
+    unusable cell forever. MISS self-mints and serves compiled; the ONLY
+    remaining eager/fail-closed exits are genuine mint impossibilities (no
+    CUDA, no C toolchain, the mint itself failing), where plain lanes serve
+    eager and quantized lanes keep their typed refusal — exactly the
+    cozy-local store policy.
 
     Returns :class:`ArmOutcome`; ``self_mint`` carries the minted cell's
     identity so the caller can record/advertise it (serving-bootstrap half
@@ -317,16 +335,20 @@ def enable_compiled(
     own key as the active compile ref).
     """
     family = str(getattr(cfg, "family", "") or "")
+    selection_bug: Optional[cc.CellSelectionBugError] = None
     try:
         if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
             return ArmOutcome(armed=True)
         # Plain-lane miss: no cell delivered / artifact unusable. Fall
         # through to the self-mint instead of the pre-gw#587 silent eager.
-    except cc.CellSelectionBugError:
-        # Self-requested, identity-verified cell refused to arm — the loud
-        # invariant propagates verbatim; a re-mint would mask a selection
-        # bug.
-        raise
+    except cc.CellSelectionBugError as exc:
+        # Self-requested, identity-verified cell refused to arm — always
+        # reported loudly (the caller sends the wire event), but no longer
+        # fatal: fall through and self-mint a cell this runtime can prove.
+        logger.warning(
+            "fleet-cells: cell_selection_bug (%s); self-minting instead of "
+            "retrying the same unusable cell", exc)
+        selection_bug = exc
     except cc.CompiledLaneUnavailableError:
         # Mandatory (w8a8/w4a4) miss: production used to fail closed here.
         # The whole point of self-mint is that this worker can produce the
@@ -334,11 +356,11 @@ def enable_compiled(
         logger.info("fleet-cells: no delivered cell for mandatory lane; self-minting")
 
     if not family:
-        return _fail_closed(pipe, "Compile decl has no family")
+        return _fail_closed(pipe, "Compile decl has no family", selection_bug)
     if not _cuda_ready():
-        return _fail_closed(pipe, "CUDA unavailable")
+        return _fail_closed(pipe, "CUDA unavailable", selection_bug)
     if not cc.toolchain_present():
-        return _fail_closed(pipe, "no C compiler for the self-mint")
+        return _fail_closed(pipe, "no C compiler for the self-mint", selection_bug)
     # gw#608 ROOT CAUSE gates (order matters — BEFORE any process-global
     # cache-dir mutation):
     # (a) a slot object with no resolvable compile target (the LTX upsampler
@@ -350,13 +372,14 @@ def enable_compiled(
     #     from it — decline via the ordinary miss policy instead (plain
     #     lanes eager, mandatory lanes typed refusal).
     if not cc.has_compile_target(pipe, cfg):
-        return _fail_closed(pipe, "no compile target resolves on this pipeline")
+        return _fail_closed(
+            pipe, "no compile target resolves on this pipeline", selection_bug)
     if cc.delivered_cell_seeded():
         return _fail_closed(
             pipe,
             "a delivered cell is seeded in this process; a self-mint "
             "capture would re-point the process-global inductor cache dir "
-            "away from it (gw#608)")
+            "away from it (gw#608)", selection_bug)
 
     from .models.loading import pipeline_weight_lane
 
@@ -381,7 +404,8 @@ def enable_compiled(
         logger.warning("fleet-cells: self-mint key computation failed (%s)", exc)
         if bucket:
             cc.drop_lora_lane(pipe)
-        return _fail_closed(pipe, f"self-mint key computation failed: {exc}")
+        return _fail_closed(
+            pipe, f"self-mint key computation failed: {exc}", selection_bug)
 
     # gw#587 CORRECT FIX (the defect this replaces: the old design minted
     # via a separate producer-style ``mint_artifact``/``_warm_call`` BEFORE
@@ -412,7 +436,8 @@ def enable_compiled(
         if bucket:
             cc.drop_lora_lane(pipe)
         return _fail_closed(
-            pipe, f"another self-mint capture is pending (key {conflict})")
+            pipe, f"another self-mint capture is pending (key {conflict})",
+            selection_bug)
 
     if existing is not None:
         mint_root, capture_dir = existing.mint_root, existing.capture_dir
@@ -433,13 +458,15 @@ def enable_compiled(
             shutil.rmtree(mint_root, ignore_errors=True)
         if bucket:
             cc.drop_lora_lane(pipe)
-        return _fail_closed(pipe, f"self-mint arm failed: {exc}")
+        return _fail_closed(
+            pipe, f"self-mint arm failed: {exc}", selection_bug)
 
     if existing is not None:
         logger.info(
             "fleet-cells: joined pending self-mint capture for %s (key=%s)",
             family, key)
-        return ArmOutcome(armed=True, self_mint=existing)
+        return ArmOutcome(
+            armed=True, self_mint=existing, selection_bug=selection_bug)
 
     pending = PendingSelfMint(
         family=family, cell_key=key, ref=f"{cc.system_repo(family)}#{key}",
@@ -452,7 +479,8 @@ def enable_compiled(
         "fleet-cells: armed self-mint capture for %s (key=%s) — the real "
         "warmup proof performs the only compile this mint will see",
         family, key)
-    return ArmOutcome(armed=True, self_mint=pending)
+    return ArmOutcome(
+        armed=True, self_mint=pending, selection_bug=selection_bug)
 
 
 def finalize_self_mint(
@@ -662,19 +690,28 @@ def _unregister(pending: "PendingSelfMint") -> None:
             del _PENDING[pending.cell_key]
 
 
-def _fail_closed(pipe: Any, reason: str) -> ArmOutcome:
+def _fail_closed(
+    pipe: Any, reason: str,
+    selection_bug: Optional["cc.CellSelectionBugError"] = None,
+) -> ArmOutcome:
     """The quantized-lane policy at every exit that cannot produce a cell:
     plain lanes serve eager (never-raise miss policy), w8a8/w4a4 keep the
-    typed refusal (same as the cozy-local store / pre-gw#587 production)."""
+    typed refusal (same as the cozy-local store / pre-gw#587 production).
+    ``selection_bug``, when set, is a genuine mint-impossibility exit that
+    ALSO followed a caught cell_selection_bug (th#1031) — chained onto the
+    raised refusal so the caller's report is never dropped."""
     from .models.loading import pipeline_weight_lane
 
     lane = pipeline_weight_lane(pipe)
     if lane.startswith(("w8a8", "w4a4")):
-        raise cc.CompiledLaneUnavailableError(
+        refusal = cc.CompiledLaneUnavailableError(
             f"{lane[:4].upper()} requires a compile cell and the self-mint "
             f"is unavailable ({reason})")
+        if selection_bug is not None:
+            raise refusal from selection_bug
+        raise refusal
     logger.info("fleet-cells: serving eager (%s)", reason)
-    return ArmOutcome(armed=False)
+    return ArmOutcome(armed=False, selection_bug=selection_bug)
 
 
 def _cuda_ready() -> bool:

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -246,6 +246,10 @@ class _ArmingContext:
     # id(pipe) -> self-mint identity (fleet_cells.SelfMint) for pipes the
     # scope's policy armed from their OWN mint rather than a delivered cell.
     self_mints: dict[int, Any]
+    # id(pipe) -> caught CellSelectionBugError (th#1031): the fleet policy
+    # no longer raises this (it self-mints instead), so the executor reads
+    # it here to still send the loud th#883 wire event after setup() returns.
+    selection_bugs: dict[int, Any]
 
 
 _ARMING_CTX: "contextvars.ContextVar[Optional[_ArmingContext]]" = contextvars.ContextVar(
@@ -269,6 +273,7 @@ class ArmingScope:
     ) -> None:
         self._objects: list[tuple[Any, bool]] = []
         self._self_mints: dict[int, Any] = {}
+        self._selection_bugs: dict[int, Any] = {}
         self._value = (
             _ArmingContext(
                 compile=compile,
@@ -277,6 +282,7 @@ class ArmingScope:
                 objects=self._objects,
                 enable=enable,
                 self_mints=self._self_mints,
+                selection_bugs=self._selection_bugs,
             )
             if compile is not None else None
         )
@@ -301,6 +307,12 @@ class ArmingScope:
     def self_mints(self) -> dict[int, Any]:
         """``id(pipe) -> SelfMint`` for scope pipes armed from their own mint."""
         return dict(self._self_mints)
+
+    @property
+    def selection_bugs(self) -> dict[int, Any]:
+        """``id(pipe) -> CellSelectionBugError`` caught (and recovered from
+        via self-mint) for scope pipes, th#1031."""
+        return dict(self._selection_bugs)
 
 
 def arm_compile(pipe: Any) -> bool:
@@ -337,6 +349,9 @@ def arm_compile(pipe: Any) -> bool:
     mint = getattr(outcome, "self_mint", None)
     if mint is not None:
         ctx.self_mints[id(pipe)] = mint
+    bug = getattr(outcome, "selection_bug", None)
+    if bug is not None:
+        ctx.selection_bugs[id(pipe)] = bug
     ctx.objects.append((pipe, armed))
     return armed
 

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -113,20 +113,51 @@ def test_delivered_cell_hit_never_mints_or_publishes(monkeypatch, tmp_path):
     assert calls == []
 
 
-def test_cell_selection_bug_propagates_untouched(monkeypatch, tmp_path):
-    """th#883 receipt invariant: a self-requested, identity-verified cell
-    that refuses to arm is a BUG — self-mint must never mask it by
-    re-minting over it. Revert-turns-red for the invariant."""
+def test_cell_selection_bug_reports_and_self_mints(monkeypatch, tmp_path):
+    """th#1031: a self-requested, identity-verified cell that refuses to
+    arm is still a BUG — reported to the caller via ``ArmOutcome.
+    selection_bug`` (unchanged wire visibility) — but no longer aborts
+    arming. cell_key has no graph-shape axis, so two structurally different
+    graphs can legitimately collide on one key; a worker stuck retrying the
+    identical unusable cell forever is worse than a loud report + recovery.
+    This call falls through to self-mint exactly like an ordinary miss."""
+    bug = cc.CellSelectionBugError("self-requested cell refused to arm")
+
+    def _raise(*a, **k):
+        raise bug
+
+    _mintable(monkeypatch)
+    monkeypatch.setattr(provision, "enable_compiled", _raise)
+
+    outcome = fc.enable_compiled(
+        _Pipe(), _Cfg(), tmp_path, None, publisher=_publisher([]))
+    assert outcome.armed
+    assert isinstance(outcome.self_mint, fc.PendingSelfMint)
+    assert outcome.selection_bug is bug
+
+
+def test_cell_selection_bug_still_fail_closed_when_mint_impossible(
+    monkeypatch, tmp_path,
+):
+    """A caught selection bug does not weaken the quantized-lane refusal at
+    a GENUINE mint impossibility (no CUDA here) — the typed refusal still
+    raises, chained from the selection bug so the report is never dropped."""
 
     def _raise(*a, **k):
         raise cc.CellSelectionBugError("self-requested cell refused to arm")
 
     monkeypatch.setattr(provision, "enable_compiled", _raise)
+    monkeypatch.setattr(fc, "_cuda_ready", lambda: False)
+
+    class _W8A8Pipe(_Pipe):
+        pass
+
     monkeypatch.setattr(
-        cc, "begin_fleet_mint",
-        lambda *a, **k: pytest.fail("selection bug must never open a capture"))
-    with pytest.raises(cc.CellSelectionBugError):
-        fc.enable_compiled(_Pipe(), _Cfg(), tmp_path, None, publisher=_publisher([]))
+        "gen_worker.models.loading.pipeline_weight_lane", lambda pipe: "w8a8")
+    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+        fc.enable_compiled(
+            _W8A8Pipe(), _Cfg(), tmp_path, None, publisher=_publisher([]))
+    assert isinstance(exc.value.__cause__, cc.CellSelectionBugError)
 
 
 def test_miss_arms_pending_capture_without_packing_or_publishing(


### PR DESCRIPTION
## Root cause (confirmed against live pod_events)

Two stacked compile-cache failures, both live on `pod_events.class='cell_selection_bug'`:

1. **Signature mismatch is real and persistent, not caused by pgw#622.** 54 rows across 2 releases (`7f57379eeab6464e96c9234c`, `ec4335c9700c445c09bb0c3c`) and 9 pods over 24h+. The earlier release's rows start 2026-07-22 08:16 UTC -- ~12h *before* pgw#622 was even committed (20:10 UTC same day) -- so pgw#622 is coincidental timing, not the cause. Every row rejects the same stale published signature `c3c4395265ad` against a consistently-different consumer signature (`826a1212a266`, mostly). `cell_key` (gw#581/th#883) has no graph-shape axis, so a stale/incompatible sdxl graph can sit published under a key that a structurally-different (or since-changed) consumer legitimately never matches.

2. **`cache_collision` on the hub-pushed re-adopt is a downstream symptom**, not a separate bug: because `CellSelectionBugError` aborted arming outright (`fleet_cells.enable_compiled` re-raised it verbatim, th#883's original "never mask it" invariant), the worker could never self-mint a corrected replacement. The hub kept re-pushing the same stale cell; each retry cycle left a fresh but non-matching local capture that later collided on adopt.

Net effect: every request on the affected worker paid a full `self_mint_compile phase=warmup_forward` cycle, because the only path back to a compiled state (self-mint) was structurally unreachable from the `cell_selection_bug` exit.

## Fix

`ArmOutcome` now carries the caught `CellSelectionBugError`. `fleet_cells.enable_compiled` still treats it as a bug (unchanged th#883 wire visibility -- callers still send the `cell_selection_bug` ModelEvent/pod_event) but no longer aborts arming: it falls through to self-mint exactly like an ordinary miss, so the worker recovers into a working, published-and-replacing compiled state instead of retrying the identical unusable cell forever. Self-mint's own fail-closed safety net (no CUDA/toolchain/target) is untouched -- a genuine mint impossibility on a mandatory lane still refuses, chained from the selection bug via `__cause__` so the report is never dropped.

Threaded through both compile-arming seams: the worker-loaded slot path (`_enable_compiled`) and the self-loaded pipeline path (`ArmingScope`/`arm_compile` -- what sdxl actually uses) via a new `selection_bugs` map on the scope.

## Tests

- `tests/test_fleet_cells.py`: rewrote the invariant test (`test_cell_selection_bug_propagates_untouched` -> `test_cell_selection_bug_reports_and_self_mints`) to lock in report-then-recover; added `test_cell_selection_bug_still_fail_closed_when_mint_impossible` for the genuine-impossibility fail-closed path.
- `cc.enable()`/`cell_key` tests (the lower-level primitive that still correctly raises) untouched -- this fix is purely in the fleet orchestration layer's *handling* of that exception.
- Full suite green locally: 636 passed, 5 skipped, 1 xfailed.

## Scope

SDXL-family only in the observed pod_events (no other family shows this class). Architecturally latent fleet-wide wherever `cell_key` doesn't fully capture graph-shape compatibility -- worth a follow-up to add a graph-signature axis to `cell_key` itself (bigger blast radius: invalidates every published cell fleet-wide, so deliberately out of scope for this hotfix). Filed as a follow-up note in th#1031.

Full writeup: `~/cozy/cozy-creator-tracker/tensorhub/progress.md` th#1031.