### PR TITLE
release 0.48.0: th#1043 shared-lane joint precision fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.48.0 (2026-07-23)
+
+- **th#1043: joint precision fit for shared-component multi-lane loads.**
+  A `gw#479` shared-component multi-lane record (e.g. qwen-image's t2i/edit
+  lanes: a shared text encoder + VAE, an exclusive transformer per lane)
+  decided each lane's resident precision reactively, one lane at a time,
+  against whatever free VRAM happened to be measured at that moment. The
+  first lane to load could consume all headroom at native precision,
+  starving a sibling shared lane into an offload placement the shared-
+  component invariant then refused outright (`RetryableError:
+  shared-component lanes require resident placement`). Precision for the
+  whole shared-component group is now decided jointly, against its
+  combined footprint (shared components counted once), before any lane
+  loads — every lane in a starved group forces fp8 storage together
+  instead of one lane greedily grabbing headroom another lane needs.
+
 ## 0.47.0 (2026-07-23)
 
 - **th#1031: `cell_selection_bug` recovers via self-mint instead of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.47.0"
+version = "0.48.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Version bump + changelog for th#1043 (#373, already merged to master).

## Test plan
- [x] pytest passes on the bumped version