### PR TITLE
th#1043: forced group-fit fp8 survives the bf16-resident upcast (0.48.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.48.1 (2026-07-23)
+
+- **th#1043 second layer: a forced group-fit fp8 survives the gw#534
+  bf16-resident upcast.** Found live on the first 0.48.0 pod: the joint
+  group decision forced fp8, but `load_from_pretrained`'s single-lane
+  resident-upcast check saw the FIRST lane fitting current free VRAM and
+  silently upgraded it back to bf16 residency — re-starving the sibling
+  lane into the refused offload placement. `force_storage_dtype` now
+  disables the local upgrade (`allow_bf16_resident_upgrade=False`): the
+  headroom belongs to the group, not the first lane to load.
+
 ## 0.48.0 (2026-07-23)
 
 - **th#1043: joint precision fit for shared-component multi-lane loads.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.48.0"
+version = "0.48.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1178,6 +1178,7 @@ def load_from_pretrained(
     storage_dtype: str = "",
     components: Optional[Dict[str, Any]] = None,
     declared_vram_gb: float = 0.0,
+    allow_bf16_resident_upgrade: bool = True,
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
@@ -1315,9 +1316,12 @@ def load_from_pretrained(
     fp8_storage = storage_dtype in ("fp8", "fp8+te") or sniffed == "fp8"
     fp8_text_encoders = storage_dtype == "fp8+te"
     bf16_resident = False
-    if fp8_storage and bf16_resident_fits(
+    # th#1043: a joint multi-lane fit decision (force_storage_dtype) budgets
+    # free VRAM for SIBLING lanes too — the single-lane resident-upcast
+    # check below would greedily un-force it and re-starve the group.
+    if (allow_bf16_resident_upgrade and fp8_storage and bf16_resident_fits(
             Path(path), text_encoders=fp8_text_encoders,
-            declared_vram_gb=declared_vram_gb):
+            declared_vram_gb=declared_vram_gb)):
         # gw#534 rung 2: fp8 download, bf16 resident — skip the cast hooks
         # (never voluntary W8A16); from_pretrained's torch_dtype upcasts once.
         fp8_storage = False

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -136,6 +136,9 @@ def load_slot(
     pipe = load_from_pretrained(
         annotation, path, dtype=dtype, storage_dtype=storage_dtype,
         components=components or None, declared_vram_gb=declared_vram_gb,
+        # A forced group-fit fp8 (th#1043) must never locally upgrade back
+        # to bf16 residency — the headroom belongs to sibling lanes.
+        allow_bf16_resident_upgrade=not force_storage_dtype,
     )
     out.obj = pipe
 

--- a/tests/test_shared_lane_precision_th1043.py
+++ b/tests/test_shared_lane_precision_th1043.py
@@ -52,3 +52,49 @@ def test_single_lane_group_never_forces():
 
 def test_no_shared_components_never_forces():
     assert _shared_lanes_need_fp8(_QWEN_SIZES, [], 1 * _GiB) is False
+
+
+# ---------------------------------------------------------------------------
+# th#1043 second layer (found live, pod 4xh4m999n26u5f): the gw#534
+# bf16-resident upcast made a SINGLE-lane fit call against current free VRAM
+# and silently un-forced the group's fp8 decision — the first lane loaded
+# full bf16 again and re-starved its sibling. A forced group fit must
+# disable the local upgrade.
+# ---------------------------------------------------------------------------
+
+
+def test_forced_group_fp8_survives_the_resident_upcast_check(tmp_path, monkeypatch):
+    import pytest
+
+    pytest.importorskip("torch")
+    pytest.importorskip("diffusers")
+    pytest.importorskip("accelerate")
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    from gen_worker.models import loading
+    from gen_worker.models.provision import load_slot
+
+    root = tmp_path / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"), norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+
+    # A card with plenty of free VRAM for ONE lane: the single-lane check
+    # says "upgrade to bf16-resident".
+    monkeypatch.setattr(loading, "bf16_resident_fits", lambda *a, **k: True)
+
+    # Unforced fp8: the upgrade applies (existing gw#534 behavior).
+    sl = load_slot(DDPMPipeline, str(root), slot="t2i", device="cpu",
+                   binding=type("B", (), {"dtype": "", "storage_dtype": "fp8"})())
+    assert getattr(sl.obj, "_cozy_weight_lane", "") == "bf16-resident"
+
+    # Forced group fp8 (th#1043): the upgrade must NOT fire — fp8 storage
+    # hooks stay armed so sibling lanes keep their budgeted headroom.
+    sl = load_slot(DDPMPipeline, str(root), slot="t2i", device="cpu",
+                   force_storage_dtype="fp8")
+    assert getattr(sl.obj, "_cozy_weight_lane", "") != "bf16-resident"
+    assert getattr(sl.obj, "_cozy_fp8_storage_requested", False) is True

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.48.0"
+version = "0.48.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Live 0.48.0 verification (pod 4xh4m999n26u5f, A100-80GB, bare-bf16 qwen-image bindings) showed the th#1043 joint fp8 forcing being silently defeated one layer deeper: `load_from_pretrained`'s gw#534 bf16-resident upcast check evaluates a SINGLE lane against current free VRAM, saw the first lane fit alone, and upgraded it back to full bf16 residency (in_vram 43.2GB) — re-starving the sibling lane into the offload placement the shared-component invariant refuses.
- Fix: `force_storage_dtype` (the joint group decision) now passes `allow_bf16_resident_upgrade=False` — a forced fp8 lane never locally upgrades; the headroom belongs to the group.
- Version 0.48.1 + changelog in the same train.

## Test plan
- [x] New regression test: with `bf16_resident_fits` returning True, an unforced fp8 load still upgrades (gw#534 preserved) while a forced one keeps fp8 hooks armed (real tiny diffusers pipeline, CPU)
- [x] mypy + ruff clean; quantization-lane suite green
- [ ] Live qwen-image bf16 generate on the rebuilt image (in progress, the actual th#1043 acceptance)