### PR TITLE
th#1043: forced group-fit fp8 reports as a structural degradation (0.48.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.48.2 (2026-07-23)
+
+- **th#1043: the forced group-fit fp8 downgrade reports structurally.**
+  A joint shared-lane fit that forces fp8 storage now stamps the same
+  rung outcome as the adaptive ladder (`FnDegraded` wanted=bf16
+  ran=fp8_storage) instead of serving a silent precision downgrade the
+  hub believes is native bf16.
+
 ## 0.48.1 (2026-07-23)
 
 - **th#1043 second layer: a forced group-fit fp8 survives the gw#534

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.48.1"
+version = "0.48.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -163,6 +163,16 @@ def load_slot(
         out.cast_fail_detail = (
             f"fp8 storage failed on every component of slot {slot!r} "
             f"({type(pipe).__name__}); serving at base precision")
+    elif (force_storage_dtype and not rung
+          and getattr(pipe, "_cozy_fp8_storage_requested", False)
+          and getattr(pipe, "_cozy_fp8_storage_ok", True)):
+        # th#1043: a joint shared-lane fit forced fp8 storage the binding
+        # never asked for — report it structurally (FnDegraded) exactly like
+        # an adaptive rung; a silent precision downgrade lies to placement.
+        out.rung = "fp8"
+        out.rung_detail = (
+            f"joint shared-lane fit forced fp8 storage for slot {slot!r} "
+            f"({type(pipe).__name__}); sibling lanes share the VRAM budget")
 
     # Worker-owned placement/offload policy: one decider for the whole
     # worker; endpoints never write device/offload code. A CUDA OOM inside

--- a/tests/test_shared_lane_precision_th1043.py
+++ b/tests/test_shared_lane_precision_th1043.py
@@ -98,3 +98,7 @@ def test_forced_group_fp8_survives_the_resident_upcast_check(tmp_path, monkeypat
                    force_storage_dtype="fp8")
     assert getattr(sl.obj, "_cozy_weight_lane", "") != "bf16-resident"
     assert getattr(sl.obj, "_cozy_fp8_storage_requested", False) is True
+    # th#1043 (0.48.2): the forced downgrade is reported structurally, not
+    # served silently as a native bf16 plan.
+    assert sl.rung == "fp8"
+    assert "shared-lane" in sl.rung_detail

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.48.1"
+version = "0.48.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary
- Live 0.48.1 verification completed a real bare-bf16 qwen-image generate (request ceb69832, A100-80GB) — but the forced fp8 serve emitted NO FnDegraded: the hub believes the function serves native bf16. Placement can never learn the card is too small for the group at native precision.
- The forced downgrade now stamps the same rung outcome (`SlotLoad.rung="fp8"` + detail) as the adaptive ladder, riding the existing `_record_adaptive_rung` -> FnDegraded path.

## Test plan
- [x] Extended regression test asserts the forced path stamps rung="fp8" with the shared-lane detail
- [x] mypy + ruff clean