### PR TITLE
th#1055: desired-hot warm works on slot-only endpoints; refusals emit model events (0.50.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.50.2 (2026-07-23)
+
+- **th#1055: desired-hot warm works on slot-only endpoints; failures are
+  loud.** `ensure_desired_instance` demanded the instance's binding set
+  equal `spec.models`, but deploy-bound Slots (ie#524/th#980) carry no code
+  default so `spec.models` is empty on every fleet endpoint — every hub hot
+  intent (gw#587 self-mint prewarm, th#912 slot-default seeding, #567
+  compile-cell reload) was refused with a ValidationError swallowed as one
+  pod-local warning: no warmup, no self-mint, w8a8 fence never opened
+  (qwen/sdxl/ltx serving deadlocks), precompiled cells never armed.
+  Validation now accepts exactly the declared slots (code defaults may fill
+  their own), declared-space bindings remap through the HelloAck precision
+  picks (th#697 contract), and every desired-instance failure — including
+  pre-setup refusals — emits MODEL_STATE_FAILED for the instance refs so a
+  stalled warm is fleet-visible.
+
 ## 0.50.1 (2026-07-23)
 
 - **pgw#626 / th#1059 twin: mandatory-lane admission follows the hub-resolved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.50.1"
+version = "0.50.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3396,51 +3396,96 @@ class Executor:
         desired: "pb.DesiredInstance",
         snapshots: Dict[str, "pb.Snapshot"],
     ) -> None:
-        """Best-effort warm of one declarative, fully bound instance."""
-        spec = self.specs.get(desired.function_name)
-        if spec is None:
-            raise ValidationError(f"unknown function {desired.function_name!r}")
-        if spec.cls is None:
-            raise ValidationError(
-                f"function {desired.function_name!r} has no persistent instance to warm"
-            )
+        """Best-effort warm of one declarative, fully bound instance.
 
-        pairs = [(m.slot.strip(), m.ref.strip()) for m in desired.models]
-        bindings = dict(pairs)
-        expected = set(spec.models)
-        if any(not slot or not ref for slot, ref in pairs):
-            raise ValidationError(
-                f"desired instance {desired.function_name!r} has an empty slot or ref"
-            )
-        if len(bindings) != len(pairs) or set(bindings) != expected:
-            raise ValidationError(
-                f"desired instance {desired.function_name!r} must bind exactly "
-                f"{sorted(expected)!r}; got {sorted(bindings)!r}"
-            )
-
-        run = pb.RunJob(function_name=desired.function_name, models=desired.models)
-        effective = self._effective_spec(spec, run)
-        resolved = {slot: wire_ref(binding) for slot, binding in effective.models.items()}
-        if resolved != bindings:
-            raise ValidationError(
-                f"desired instance {desired.function_name!r} does not match the "
-                "worker's resolved bindings"
-            )
+        Every failure — including a binding-shape refusal before setup —
+        emits MODEL_STATE_FAILED for the instance's refs (th#1055: the old
+        pre-setup ValidationErrors were pod-local only, so a refused hot
+        intent stalled the worker fleet-invisibly forever)."""
+        instance_refs = [
+            r for r in dict.fromkeys(m.ref.strip() for m in desired.models) if r
+        ]
         try:
-            await self.ensure_setup(effective, snapshots)
+            spec = self.specs.get(desired.function_name)
+            if spec is None:
+                raise ValidationError(
+                    f"unknown function {desired.function_name!r}")
+            await self._ensure_desired_instance_validated(spec, desired, snapshots)
         except Exception as exc:
             # Host-RAM admission already emitted the precise largest staged
             # ref(s) that caused the capacity failure. Do not overwrite that
             # signal by failing smaller shared refs such as an SDXL VAE.
             if not isinstance(exc, InsufficientHostRamError):
                 error = _model_failure_vocab(exc)
-                for ref in dict.fromkeys(bindings.values()):
+                for ref in instance_refs:
                     await self._send(pb.WorkerMessage(
                         model_event=self.store.model_event(
                             ref, pb.MODEL_STATE_FAILED, error=error,
                         )
                     ))
             raise
+
+    async def _ensure_desired_instance_validated(
+        self,
+        spec: EndpointSpec,
+        desired: "pb.DesiredInstance",
+        snapshots: Dict[str, "pb.Snapshot"],
+    ) -> None:
+        if spec.cls is None:
+            raise ValidationError(
+                f"function {desired.function_name!r} has no persistent instance to warm"
+            )
+        # th#697/hello_ack contract: hot bindings may arrive in DECLARED ref
+        # space; remap through the hub's precision picks so the warm instance
+        # derives the SAME per-pick key a laddered dispatch derives.
+        remapped: List[pb.ModelBinding] = []
+        for m in desired.models:
+            binding = pb.ModelBinding()
+            binding.CopyFrom(m)
+            binding.slot = m.slot.strip()
+            ref = m.ref.strip()
+            pick = self._model_resolutions.get(ref)
+            if pick is not None and pick[0]:
+                ref = pick[0]
+            binding.ref = ref
+            remapped.append(binding)
+        pairs = [(m.slot, m.ref) for m in remapped]
+        bindings = dict(pairs)
+        if any(not slot or not ref for slot, ref in pairs):
+            raise ValidationError(
+                f"desired instance {desired.function_name!r} has an empty slot or ref"
+            )
+        # th#1055: deploy-bound Slots (ie#524/th#980) carry NO code default,
+        # so spec.models does not name them — demanding set-equality against
+        # spec.models refused EVERY hot intent on slot-only endpoints. The
+        # instance must cover exactly the declared slots, where a missing
+        # slot is acceptable only when a code default can fill it (the same
+        # fallback dispatch uses).
+        declared = set(spec.models) | set(spec.slots)
+        undeclared = sorted(set(bindings) - declared)
+        unbound = sorted(
+            s for s in declared if s not in bindings and s not in spec.models
+        )
+        if len(bindings) != len(pairs) or undeclared or unbound:
+            raise ValidationError(
+                f"desired instance {desired.function_name!r} must bind the "
+                f"declared slots {sorted(declared)!r} (code defaults exist for "
+                f"{sorted(spec.models)!r}); got {sorted(bindings)!r}"
+            )
+
+        run = pb.RunJob(function_name=desired.function_name, models=remapped)
+        effective = self._effective_spec(spec, run)
+        mismatched = {
+            slot: wire_ref(effective.models[slot])
+            for slot, ref in bindings.items()
+            if slot in effective.models and wire_ref(effective.models[slot]) != ref
+        }
+        if mismatched:
+            raise ValidationError(
+                f"desired instance {desired.function_name!r} does not match the "
+                f"worker's resolved bindings: {mismatched!r}"
+            )
+        await self.ensure_setup(effective, snapshots)
 
     def _job_pin_refs(self, spec: EndpointSpec, slots: List[str]) -> List[str]:
         """Wire refs a job pins for its whole lifetime: every routed slot

--- a/tests/test_desired_hot_th1055.py
+++ b/tests/test_desired_hot_th1055.py
@@ -1,0 +1,302 @@
+"""th#1055: desired-hot warm on slot-only endpoints + loud failures.
+
+Live root cause (master fleet, 2026-07-23): ``ensure_desired_instance``
+demanded ``set(bindings) == set(spec.models)``, but every fleet endpoint now
+declares deploy-bound Slots with NO code default (ie#524/th#980), so
+``spec.models`` is EMPTY and every hub hot intent — gw#587 self-mint
+prewarm, th#912 slot-default seeding, #567 compile-cell reload — was refused
+with ``ValidationError("must bind exactly []")``, swallowed by
+``_reconcile_pass`` as one pod-local warning. Zero events, zero VRAM, no
+retry signal: the th#868 w8a8 fence never opened (qwen H100 rigs, sdxl
+ie529.r2, ltx B200 all deadlocked) and precompiled cells never armed
+fleet-wide.
+
+Pinned here:
+  1. a slot-only (default-less) compile endpoint warms + arms from a
+     resolved-space DesiredInstance;
+  2. declared-space hot bindings remap through the HelloAck precision picks
+     (the hello_ack.go "hot bindings stay declared" contract) instead of
+     silently undoing the pick;
+  3. every desired-instance failure — including the pre-setup validation
+     refusals — emits MODEL_STATE_FAILED for the instance refs so the stall
+     is fleet-visible (the never-logs stall must be impossible).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import threading
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+import msgspec
+import pytest
+
+import gen_worker
+from gen_worker import Compile
+from gen_worker import compile_cache as cc
+from gen_worker.api.binding import Hub
+from gen_worker.api.slot import Slot
+from gen_worker.api.errors import ValidationError
+from gen_worker.executor import Executor
+from gen_worker.models import provision
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+FAMILY = "th1055-fam"
+AUTHORED = Hub("acme/qwen-image", tag="prod")
+AUTHORED_REF = "acme/qwen-image:prod"
+RESOLVED_REF = "acme/qwen-image:prod#fp8-w8a8"
+ADAPTER_REF = "acme/qwen-lightning:prod"
+CELL_REF = f"root/family-{FAMILY}#inductor-rtx-4090-torch2.9-w8a8"
+
+
+class _Denoiser:
+    def forward(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        return None
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.transformer = _Denoiser()
+
+
+class _CompilePipe(_Pipe):
+    def __init__(self) -> None:
+        super().__init__()
+        self._cozy_weight_lane = "w8a8"
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+def _slot_only_spec(setup_calls: List[Tuple[str, str]]) -> EndpointSpec:
+    """The fleet's real shape: deploy-bound Slots, EMPTY spec.models."""
+
+    class Endpoint:
+        def setup(self, pipeline: str, adapter: str) -> None:
+            self.pipe = _CompilePipe()
+            self.armed = gen_worker.arm_compile(self.pipe)
+            setup_calls.append((pipeline, adapter))
+
+        def warmup(self) -> None:
+            signal = getattr(self.pipe, cc._MARKER_ATTR)["failure_signal"]
+            with signal["lock"]:
+                signal["successful_calls"] += 1
+                signal["cache_hits"] += 1
+
+        def generate(self, ctx: Any, payload: _In) -> _Out:
+            return _Out()
+
+    return EndpointSpec(
+        name="generate", method=Endpoint.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="generate", models={},
+        slots={"pipeline": Slot(str), "adapter": Slot(str)},
+        slot_family={"pipeline": FAMILY, "adapter": FAMILY},
+        compile=Compile(shapes=((768, 768),), family=FAMILY),
+    )
+
+
+def _default_binding_spec(setup_calls: List[str]) -> EndpointSpec:
+    class Endpoint:
+        def setup(self, pipeline: str) -> None:
+            self.pipe = _CompilePipe()
+            self.armed = gen_worker.arm_compile(self.pipe)
+            setup_calls.append(pipeline)
+
+        def warmup(self) -> None:
+            signal = getattr(self.pipe, cc._MARKER_ATTR)["failure_signal"]
+            with signal["lock"]:
+                signal["successful_calls"] += 1
+                signal["cache_hits"] += 1
+
+        def generate(self, ctx: Any, payload: _In) -> _Out:
+            return _Out()
+
+    return EndpointSpec(
+        name="generate", method=Endpoint.generate, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint,
+        attr_name="generate", models={"pipeline": AUTHORED},
+        compile=Compile(shapes=((768, 768),), family=FAMILY),
+    )
+
+
+def _snapshot(digest: str) -> pb.Snapshot:
+    return pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
+        path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+        url="http://r2.invalid/presigned")])
+
+
+def _cell_artifact(tmp_path: Path) -> Path:
+    cap = tmp_path / "cap"
+    (cap / "inductor" / "g").mkdir(parents=True)
+    (cap / "inductor" / "g" / "code.py").write_text("x")
+    (cap / "triton").mkdir()
+    cfg = Compile(shapes=((768, 768),), family=FAMILY)
+    signature, weight_contract = cc.execution_contract(_Pipe(), cfg)
+    meta = cc.artifact_metadata(
+        family=FAMILY, shapes=cfg.shapes, targets=cfg.targets,
+        graph_signature=signature, weight_contract=weight_contract,
+    )
+    out = tmp_path / "minted"
+    out.mkdir(exist_ok=True)
+    return cc.pack(cap, out / "inductor-rtx-4090-torch2.9-w8a8.tar.gz", meta)
+
+
+def _harness(tmp_path: Path, monkeypatch, specs: List[EndpointSpec]):
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor(specs, _send)
+    artifact = _cell_artifact(tmp_path)
+
+    async def _fake_download(ref: str, **kwargs: Any) -> Path:
+        p = tmp_path / ref.replace("/", "_").replace(":", "_").replace("#", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        if ref.startswith("root/"):
+            shutil.copy(artifact, p / artifact.name)
+        return p
+
+    import gen_worker.executor as ex_mod
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+
+    enables: List[Tuple[Any, Optional[Path]]] = []
+
+    def _fake_enable(pipe: Any, _cfg: Any, _cache_dir: Any, artifact_path: Any) -> bool:
+        enables.append((pipe, artifact_path))
+        setattr(pipe, cc._MARKER_ATTR, {
+            "failure_signal": {
+                "callback": None,
+                "lock": threading.Lock(),
+                "successful_calls": 0,
+                "cache_hits": 0,
+                "cache_misses": 0,
+            },
+            "originals": [],
+            "regional_mods": [],
+        })
+        return True
+
+    monkeypatch.setattr(provision, "enable_compiled", _fake_enable)
+    return ex, sent, enables
+
+
+def _failed_model_events(sent: List[pb.WorkerMessage]) -> List[pb.ModelEvent]:
+    return [
+        m.model_event for m in sent
+        if m.WhichOneof("msg") == "model_event"
+        and m.model_event.state == pb.MODEL_STATE_FAILED
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. slot-only endpoint: the resolved-space hot intent warms and arms
+# ---------------------------------------------------------------------------
+
+
+def test_slot_only_desired_instance_warms_and_arms(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, enables = _harness(tmp_path, monkeypatch,
+                                 [_slot_only_spec(setup_calls)])
+    ex.apply_model_resolutions(
+        {AUTHORED_REF: (RESOLVED_REF, "", "fp8-w8a8-dynamic+compiled")})
+
+    desired = pb.DesiredInstance(
+        function_name="generate",
+        models=[pb.ModelBinding(slot="pipeline", ref=RESOLVED_REF),
+                pb.ModelBinding(slot="adapter", ref=ADAPTER_REF)],
+    )
+    snapshots = {RESOLVED_REF: _snapshot("aa" * 32),
+                 ADAPTER_REF: _snapshot("ab" * 32),
+                 CELL_REF: _snapshot("bb" * 32)}
+    asyncio.run(ex.ensure_desired_instance(desired, snapshots))
+
+    assert len(setup_calls) == 1
+    pipeline_path, adapter_path = setup_calls[0]
+    assert "fp8-w8a8" in pipeline_path
+    assert len(enables) == 1
+    (target,) = ex.compile_targets()
+    assert target.active_compile_ref == CELL_REF
+    assert "generate" in ex.available_functions()
+    assert not _failed_model_events(sent)
+
+
+# ---------------------------------------------------------------------------
+# 2. declared-space hot bindings remap through the precision picks
+# ---------------------------------------------------------------------------
+
+
+def test_declared_space_hot_bindings_remap_through_picks(tmp_path, monkeypatch) -> None:
+    """seedDynamicSlotDefaults sends DECLARED refs ("the worker rebinds
+    specs through the resolutions map", hello_ack.go th#697) — the warm
+    instance must derive the RESOLVED binding, never silently undo the
+    pick (and never download the declared artifact the disk plan skipped)."""
+    setup_calls: List[str] = []
+    ex, _sent, _enables = _harness(tmp_path, monkeypatch,
+                                   [_default_binding_spec(setup_calls)])
+    ex.apply_model_resolutions(
+        {AUTHORED_REF: (RESOLVED_REF, "", "fp8-w8a8-dynamic+compiled")})
+
+    desired = pb.DesiredInstance(
+        function_name="generate",
+        models=[pb.ModelBinding(slot="pipeline", ref=AUTHORED_REF)],
+    )
+    snapshots = {RESOLVED_REF: _snapshot("aa" * 32),
+                 CELL_REF: _snapshot("bb" * 32)}
+    asyncio.run(ex.ensure_desired_instance(desired, snapshots))
+
+    assert len(setup_calls) == 1
+    assert "fp8-w8a8" in setup_calls[0], (
+        "declared-space hot binding undid the precision pick")
+    rec = ex._classes[ex.specs["generate"].instance_key]
+    assert rec.held_refs == [RESOLVED_REF]
+
+
+# ---------------------------------------------------------------------------
+# 3. failures are LOUD: validation refusals emit MODEL_STATE_FAILED
+# ---------------------------------------------------------------------------
+
+
+def test_validation_refusal_emits_model_events(tmp_path, monkeypatch) -> None:
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, _enables = _harness(tmp_path, monkeypatch,
+                                  [_slot_only_spec(setup_calls)])
+
+    desired = pb.DesiredInstance(
+        function_name="generate",
+        models=[pb.ModelBinding(slot="pipeline", ref=RESOLVED_REF),
+                pb.ModelBinding(slot="bogus", ref=ADAPTER_REF)],
+    )
+    with pytest.raises(ValidationError, match="declared slots"):
+        asyncio.run(ex.ensure_desired_instance(desired, {}))
+
+    failed = _failed_model_events(sent)
+    assert {e.ref for e in failed} == {RESOLVED_REF, ADAPTER_REF}, (
+        "a refused hot intent must be fleet-visible, not a pod-local warning")
+    assert setup_calls == []
+
+
+def test_unbound_default_less_slot_refuses_loud(tmp_path, monkeypatch) -> None:
+    """A hot intent missing a default-less slot cannot fall back to code —
+    refuse (loud), matching dispatch's mirror-first contract."""
+    setup_calls: List[Tuple[str, str]] = []
+    ex, sent, _enables = _harness(tmp_path, monkeypatch,
+                                  [_slot_only_spec(setup_calls)])
+
+    desired = pb.DesiredInstance(
+        function_name="generate",
+        models=[pb.ModelBinding(slot="pipeline", ref=RESOLVED_REF)],
+    )
+    with pytest.raises(ValidationError, match="declared slots"):
+        asyncio.run(ex.ensure_desired_instance(desired, {}))
+    assert _failed_model_events(sent)
+    assert setup_calls == []

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.50.1"
+version = "0.50.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Root cause of the fleet-wide silent warmup stall (th#1055 / th#1044 item 4 / th#1049 ltx deadlock / th#1059 worker silence):

`ensure_desired_instance` required the hot instance's binding set to EQUAL `spec.models`. Deploy-bound Slots (ie#524/th#980) carry no code default, so `spec.models` is EMPTY on every fleet endpoint (qwen, sdxl, ltx, z-image, ernie, klein, anima, hidream) — every hub hot intent (gw#587 self-mint prewarm, th#912 slot-default seeding, #567 compile-cell reload) raised `ValidationError("must bind exactly []")`, swallowed by `_reconcile_pass` as one pod-local warning. No warmup, no self-mint, zero events, 0% VRAM; the th#868 mandatory-w8a8 fence never opened and precompiled cells never armed.

Live evidence (master hub log, worker d7bfd1ea / pod rjvp3srr8s7zsh): hot intent `HelloAck (desired_generation=3 disk=2 hot=1)` sent 20:09:02Z one second after the last fp8 download hit disk, then 95 minutes of total worker silence until `cold_idle_never_dispatched`.

Fix:
- validate against the declared slot set (`spec.models` | `spec.slots`); missing slots acceptable only when a code default fills them (dispatch's own fallback semantics)
- declared-space hot bindings remap through the HelloAck precision picks (hello_ack.go th#697 "hot bindings stay declared" contract) so the warm derives the SAME per-pick instance key a dispatch derives
- EVERY desired-instance failure — including pre-setup validation refusals — emits MODEL_STATE_FAILED for the instance refs: the never-logs stall is impossible

Tests: tests/test_desired_hot_th1055.py (4 tests, revert-turns-red verified against the pre-fix executor). Full suite green locally (663 passed; one known-flaky zero-cpu watchdog test failed once under box load, passes on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)