### PR TITLE
gw#627 train: Conv2d runtime-LoRA branch (0.51.0) + th#1063 fill-source boot guard (0.50.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.51.0 (2026-07-24)
+
+- **gw#627: Conv2d additive-branch support in the runtime LoRA overlay.**
+  The curated sdxl distill adapters (Lightning/DMD2) carry 49 conv LoRA
+  pairs each; the gw#547/558 branch was Linear-only, so on the w8a8 lane
+  (`_Fp8ScaledLinear`, no peft fallback) the only route for them was raw
+  peft injection — which rejects the quantized module class fatally (8/8
+  live sdxl generate-turbo failures on L4, th#1037 addendum). Plain
+  ``nn.Conv2d`` modules in the denoiser are now branch-capable: canonical
+  zeroed conv branches ride the same rank bucket (A [bucket, in, kh, kw]
+  at the base conv's stride/padding, B [out, bucket, 1, 1]), swap is the
+  same staged buffer copy, and the eager instance-forward wrap adds
+  ``conv1x1(conv(x, A), B)``. Convs are never quantized, so every lane
+  takes the wrap path; graph stability and cell lane naming
+  (``w8a8-lora<bucket>``) are unchanged.
+
+## 0.50.3 (2026-07-24)
+
+- **th#1063: loud boot log when a datacenter pod has no CAS fill source.**
+
 ## 0.50.2 (2026-07-23)
 
 - **th#1055: desired-hot warm works on slot-only endpoints; failures are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.50.2"
+version = "0.50.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.50.3"
+version = "0.51.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -639,6 +639,28 @@ class ModelStore:
         # otherwise resolve from env (production/tensorhub; unset -> None,
         # the cozy-local/no-volume degenerate case).
         self._fill_source_dir = fill_source_dir or tensorhub_fill_source_dir()
+        # th#1063 visibility guard: a datacenter pod without a warm fill
+        # source silently pulls everything from R2 with write-through off —
+        # that state must be visible in the boot log, never inferred.
+        if self._fill_source_dir is None and os.environ.get("RUNPOD_POD_ID") and (
+            os.environ.get("RUNPOD_PROVIDER", "") != "local"
+        ):
+            configured = os.environ.get("TENSORHUB_FILL_SOURCE_DIR", "").strip()
+            if configured:
+                logger.warning(
+                    "fill_source_disabled reason=not_a_mount configured=%s: "
+                    "TENSORHUB_FILL_SOURCE_DIR is set but not a mounted volume; "
+                    "all fills go to R2, write-through disabled (th#1063)",
+                    configured,
+                )
+            else:
+                logger.warning(
+                    "fill_source_disabled reason=unset: datacenter pod booted with no "
+                    "TENSORHUB_FILL_SOURCE_DIR (no endpoint volume attached); "
+                    "all fills go to R2, write-through disabled (th#1063)"
+                )
+        elif self._fill_source_dir is not None:
+            logger.info("fill_source_enabled dir=%s (volume-warm CAS fill tier)", self._fill_source_dir)
         self.residency = Residency(
             on_event=self._on_residency_event, vram_budget_bytes=vram_budget_bytes,
         )

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -1,4 +1,5 @@
-"""Runtime LoRA additive branches (gw#547 w8a8; gw#558 lane-general).
+"""Runtime LoRA additive branches (gw#547 w8a8; gw#558 lane-general;
+gw#627 Conv2d).
 
 Denoiser adapter halves ride a compute-dtype SIDE-BRANCH — ``y += B(A @ x)``
 reading the original activation and adding onto the output — never peft
@@ -32,6 +33,7 @@ both directions.
 from __future__ import annotations
 
 import logging
+import math
 import time
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -101,9 +103,12 @@ def quantized_modules(model: Any) -> Dict[str, Any]:
 
 
 def branch_modules(model: Any) -> Dict[str, Any]:
-    """name -> branch-capable Linear (Fp8ScaledLinear or plain nn.Linear)
-    for the denoiser. Convs and other module kinds are not branch targets —
-    adapters that name them fail loud in :func:`map_adapter`."""
+    """name -> branch-capable module for the denoiser: Fp8ScaledLinear,
+    plain nn.Linear, or plain nn.Conv2d (gw#627 — the curated sdxl distill
+    adapters carry conv pairs; convs are never quantized, so their branch
+    is always the eager instance-forward wrap). Other module kinds are not
+    branch targets — adapters that name them fail loud in
+    :func:`map_adapter`."""
     import torch.nn as nn
 
     from .w8a8 import fp8_scaled_linear_class
@@ -111,7 +116,7 @@ def branch_modules(model: Any) -> Dict[str, Any]:
     fp8_cls = fp8_scaled_linear_class()
     return {
         n: m for n, m in model.named_modules()
-        if isinstance(m, fp8_cls) or type(m) is nn.Linear
+        if isinstance(m, fp8_cls) or type(m) in (nn.Linear, nn.Conv2d)
     }
 
 
@@ -255,17 +260,43 @@ def map_adapter(
             )
         rank = int(a.shape[0])
         mod = mods[path]
-        if int(a.shape[1]) != mod.in_features or int(b.shape[0]) != mod.out_features:
-            raise RefCompatibilitySurprise(
-                f"adapter shapes for {path!r} do not match the base "
-                f"({tuple(a.shape)}/{tuple(b.shape)} vs "
-                f"in={mod.in_features} out={mod.out_features})",
-                ref=ref, axis="state_dict",
-            )
+        a, b = _validated_pair(path, mod, a, b, ref=ref)
         alpha = g.get("alpha")
         alpha_scale = (float(alpha) / rank) if alpha is not None else 1.0
         out[path] = (a, b, alpha_scale)
     return out
+
+
+def _validated_pair(path: str, mod: Any, a: Any, b: Any, *, ref: str) -> Tuple[Any, Any]:
+    """Shape-check one down/up pair against its branch module; conv pairs
+    (gw#627) normalize the up half to [out, r, 1, 1]."""
+    import torch.nn as nn
+
+    def bad(detail: str) -> RefCompatibilitySurprise:
+        return RefCompatibilitySurprise(
+            f"adapter shapes for {path!r} do not match the base "
+            f"({tuple(a.shape)}/{tuple(b.shape)}): {detail}",
+            ref=ref, axis="state_dict",
+        )
+
+    rank = int(a.shape[0])
+    if isinstance(mod, nn.Conv2d):
+        if mod.groups != 1:
+            raise bad(f"grouped conv (groups={mod.groups}) is not a branch target")
+        if a.dim() != 4 or int(a.shape[1]) != mod.in_channels or (
+                tuple(int(v) for v in a.shape[2:]) != tuple(mod.kernel_size)):
+            raise bad(
+                f"want down [r, {mod.in_channels}, "
+                f"{mod.kernel_size[0]}, {mod.kernel_size[1]}]")
+        if int(b.shape[0]) != mod.out_channels or int(b.shape[1]) != rank or (
+                b.dim() not in (2, 4)) or (
+                b.dim() == 4 and tuple(int(v) for v in b.shape[2:]) != (1, 1)):
+            raise bad(f"want up [{mod.out_channels}, {rank}(, 1, 1)]")
+        return a, b.reshape(mod.out_channels, rank, 1, 1)
+    if a.dim() != 2 or b.dim() != 2 or int(a.shape[1]) != mod.in_features or (
+            int(b.shape[0]) != mod.out_features or int(b.shape[1]) != rank):
+        raise bad(f"want down [r, {mod.in_features}] / up [{mod.out_features}, r]")
+    return a, b
 
 
 # Flat staging buffers above this size stay pageable — pinned host memory is
@@ -317,11 +348,12 @@ def _is_scaled_linear(mod: Any) -> bool:
 
 
 def _install_branch_forward(mod: Any) -> None:
-    """Idempotent instance-forward wrap for a plain ``nn.Linear``:
-    ``y = orig(x) + (x @ A.T) @ B.T``. Branch tensors are read from the
-    module ``__dict__`` so layerwise-cast hooks (``.to(dtype)``) never see
-    them (gw#558 / ie#374). With no branch installed the wrap is a pure
-    pass-through — removal is bit-exact."""
+    """Idempotent instance-forward wrap for a plain ``nn.Linear``
+    (``y = orig(x) + (x @ A.T) @ B.T``) or plain ``nn.Conv2d``
+    (``y = orig(x) + conv1x1(conv(x, A), B)`` — gw#627). Branch tensors are
+    read from the module ``__dict__`` so layerwise-cast hooks
+    (``.to(dtype)``) never see them (gw#558 / ie#374). With no branch
+    installed the wrap is a pure pass-through — removal is bit-exact."""
     if getattr(mod, _WRAP_ATTR, False):
         return
     orig = mod.forward
@@ -343,6 +375,13 @@ def _install_branch_forward(mod: Any) -> None:
                     and mod.__dict__.get("lora_b") is b):
                 mod.lora_a, mod.lora_b = a2, b2
             a, b = a2, b2
+        if a.dim() == 4:
+            import torch.nn.functional as F
+
+            x2 = x if x.dtype == a.dtype else x.to(a.dtype)
+            h = F.conv2d(x2, a, stride=mod.stride, padding=mod.padding,
+                         dilation=mod.dilation)
+            return y + F.conv2d(h, b).to(y.dtype)
         x2 = x.reshape(-1, x.shape[-1])
         if x2.dtype != a.dtype:
             x2 = x2.to(a.dtype)
@@ -355,14 +394,17 @@ def _install_branch_forward(mod: Any) -> None:
 
 
 def alloc_branch_buffers(mod: Any, bucket: int) -> None:
-    """Zeroed A/B branch tensors on one branch-capable Linear.
+    """Zeroed A/B branch tensors on one branch-capable module.
 
     Fp8ScaledLinear registers non-persistent buffers (they move with the
     module and its forward reads them natively; the w8a8 denoiser carries
-    no cast hooks). Plain ``nn.Linear`` gets a forward wrap + plain
-    ``__dict__`` attrs instead — registered buffers would be round-tripped
-    bf16->fp8->bf16 by the layerwise-cast hooks on the fp8-storage lane."""
+    no cast hooks). Plain ``nn.Linear``/``nn.Conv2d`` get a forward wrap +
+    plain ``__dict__`` attrs instead — registered buffers would be
+    round-tripped bf16->fp8->bf16 by the layerwise-cast hooks on the
+    fp8-storage lane. Conv branches (gw#627): A [bucket, in, kh, kw] runs
+    the base conv's stride/padding, B [out, bucket, 1, 1] projects up."""
     import torch
+    import torch.nn as nn
 
     dev = mod.weight.device
     # Branch tensors compute in the module's COMPUTE dtype — never its
@@ -377,6 +419,15 @@ def alloc_branch_buffers(mod: Any, bucket: int) -> None:
     for name in ("lora_a", "lora_b"):
         mod._buffers.pop(name, None)
         mod.__dict__.pop(name, None)
+    if isinstance(mod, nn.Conv2d):
+        a = torch.zeros(bucket, mod.in_channels, *mod.kernel_size,
+                        dtype=dtype, device=dev)
+        b = torch.zeros(mod.out_channels, bucket, 1, 1,
+                        dtype=dtype, device=dev)
+        _install_branch_forward(mod)
+        mod.lora_a = a
+        mod.lora_b = b
+        return
     a = torch.zeros(bucket, mod.in_features, dtype=dtype, device=dev)
     b = torch.zeros(mod.out_features, bucket, dtype=dtype, device=dev)
     if _is_scaled_linear(mod):
@@ -554,8 +605,8 @@ def apply_branch_adapters(
                     hit_any = True
                 (dt_a, off_a, shp_a), (dt_b, off_b, shp_b), alpha_scale = idx
                 r = shp_a[0]
-                n_a = shp_a[0] * shp_a[1]
-                n_b = shp_b[0] * shp_b[1]
+                n_a = math.prod(shp_a)
+                n_b = math.prod(shp_b)
                 mod.lora_a[r0:r0 + r].copy_(
                     df[dt_a][off_a:off_a + n_a].view(shp_a))
                 mod.lora_b[:, r0:r0 + r].copy_(

--- a/tests/test_managed_tier_fill_source.py
+++ b/tests/test_managed_tier_fill_source.py
@@ -383,3 +383,50 @@ def test_downloading_progress_reports_populated_bytes_done_and_total(
         "expected at least one mid-flight DOWNLOADING event with a "
         f"PARTIAL bytes_done; got {[e.bytes_done for e in later]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# th#1063 visibility guard: no fill source on a datacenter pod must be LOUD
+# ---------------------------------------------------------------------------
+
+def test_datacenter_pod_without_fill_source_logs(tmp_path: Path, monkeypatch, caplog) -> None:
+    async def _emit(msg: pb.WorkerMessage) -> None:
+        del msg
+
+    monkeypatch.setenv("RUNPOD_POD_ID", "pod-guard-test")
+    monkeypatch.delenv("RUNPOD_PROVIDER", raising=False)
+    monkeypatch.delenv("TENSORHUB_FILL_SOURCE_DIR", raising=False)
+    with caplog.at_level("WARNING", logger="gen_worker.executor"):
+        ModelStore(_emit, cache_dir=tmp_path / "local")
+    assert any("fill_source_disabled reason=unset" in r.message for r in caplog.records)
+
+
+def test_datacenter_pod_with_unmounted_fill_source_logs(tmp_path: Path, monkeypatch, caplog) -> None:
+    from gen_worker.config.loader import get_settings
+
+    async def _emit(msg: pb.WorkerMessage) -> None:
+        del msg
+
+    plain_dir = tmp_path / "not-a-mount"
+    plain_dir.mkdir()
+    monkeypatch.setenv("RUNPOD_POD_ID", "pod-guard-test")
+    monkeypatch.delenv("RUNPOD_PROVIDER", raising=False)
+    monkeypatch.setenv("TENSORHUB_FILL_SOURCE_DIR", str(plain_dir))
+    get_settings.cache_clear()
+    try:
+        with caplog.at_level("WARNING", logger="gen_worker.executor"):
+            ModelStore(_emit, cache_dir=tmp_path / "local")
+    finally:
+        get_settings.cache_clear()
+    assert any("fill_source_disabled reason=not_a_mount" in r.message for r in caplog.records)
+
+
+def test_local_pod_without_fill_source_stays_quiet(tmp_path: Path, monkeypatch, caplog) -> None:
+    async def _emit(msg: pb.WorkerMessage) -> None:
+        del msg
+
+    monkeypatch.delenv("RUNPOD_POD_ID", raising=False)
+    monkeypatch.delenv("TENSORHUB_FILL_SOURCE_DIR", raising=False)
+    with caplog.at_level("WARNING", logger="gen_worker.executor"):
+        ModelStore(_emit, cache_dir=tmp_path / "local")
+    assert not [r for r in caplog.records if "fill_source_disabled" in r.message]

--- a/tests/test_turbo_overlay_gw627.py
+++ b/tests/test_turbo_overlay_gw627.py
@@ -1,0 +1,241 @@
+"""gw#627: curated turbo LoRA onto the fp8 w8a8 lane — the live sdxl fatal.
+
+The live failure (th#1037 addendum, request 16205a14, L4, lane
+fp8-w8a8-dynamic+compiled): sdxl generate-turbo pushed its Lightning
+adapter through raw diffusers/peft ``load_lora_weights`` onto a UNet whose
+Linears are ``_Fp8ScaledLinear`` (pertensor) — peft rejects the module
+class fatally. The sanctioned route is the gw#547/558 additive branch via
+``AdapterResidency`` — which until gw#627 could not carry the 49 CONV LoRA
+pairs every curated sdxl distill adapter ships.
+
+These tests run the REAL codepath end-to-end on CPU: a real (tiny)
+diffusers ``UNet2DConditionModel`` with real ``_Fp8ScaledLinear`` pertensor
+swaps, an adapter in the exact live key grammar (kohya-flat diffusers
+naming: ``lora_unet_*.lora_down.weight`` / ``.lora_up.weight`` /
+``.alpha``, conv pairs 4-d), driven through
+``AdapterResidency.activate/deactivate`` with the compiled marker set —
+asserting the branch carries the adapter and peft is never consulted for
+the denoiser half. Forward numerics for the conv branch run on the plain
+lane (CPU has no ``torch._scaled_mm``; the Fp8ScaledLinear branch addend is
+the pre-existing gw#547 forward, unchanged here).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker.api.errors import RefCompatibilitySurprise  # noqa: E402
+from gen_worker.models import w8a8_lora  # noqa: E402
+from gen_worker.models.w8a8 import fp8_scaled_linear_class  # noqa: E402
+from gen_worker.utils.lora import AdapterResidency, PreparedAdapter  # noqa: E402
+
+
+def _tiny_unet() -> Any:
+    from diffusers import UNet2DConditionModel
+
+    torch.manual_seed(0)
+    return UNet2DConditionModel(
+        sample_size=16,
+        in_channels=4,
+        out_channels=4,
+        block_out_channels=(32, 64),
+        layers_per_block=1,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+        cross_attention_dim=32,
+        attention_head_dim=8,
+        norm_num_groups=8,
+    )
+
+
+def _swap_scaled(unet: Any, path: str) -> Any:
+    """Replace one plain Linear with a REAL _Fp8ScaledLinear (pertensor —
+    the live L4 mode) carrying the quantized form of its weights."""
+    cls = fp8_scaled_linear_class()
+    parent_path, _, leaf = path.rpartition(".")
+    parent = unet.get_submodule(parent_path) if parent_path else unet
+    old = getattr(parent, leaf)
+    new = cls(
+        old.in_features, old.out_features, bias=old.bias is not None,
+        compute_dtype=torch.float32, static_input_scale=False,
+        gemm_mode="pertensor",
+    )
+    new.weight = old.weight.detach().to(torch.float8_e4m3fn)
+    new.weight_scale = torch.ones(old.out_features, 1, dtype=torch.float32)
+    if old.bias is not None:
+        new.bias = torch.nn.Parameter(
+            old.bias.detach().clone(), requires_grad=False)
+    setattr(parent, leaf, new)
+    return new
+
+
+class _PeftRecorder:
+    """Stub diffusers-pipeline LoRA surface: every call is recorded; the
+    denoiser half must never arrive here."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+
+
+class _Pipe:
+    """Minimal pipeline holding the real unet (the branch machinery and the
+    normalize/split path key off ``pipe.unet`` and the class, nothing
+    else)."""
+
+    def __init__(self, unet: Any) -> None:
+        self.unet = unet
+        self.load_lora_weights = _PeftRecorder()
+        self.set_adapters = _PeftRecorder()
+        self.unload_lora_weights = _PeftRecorder()
+        self.disable_lora = _PeftRecorder()
+
+
+# Live key grammar: kohya-flat diffusers naming, exactly what
+# sdxl_lightning_4step_lora.safetensors ships (rank 64 there; small here).
+_RANK = 8
+
+
+def _turbo_style_adapter(unet: Any) -> Dict[str, Any]:
+    torch.manual_seed(1)
+    sd: Dict[str, Any] = {}
+
+    def pair(flat: str, a: Any, b: Any) -> None:
+        sd[f"lora_unet_{flat}.lora_down.weight"] = a
+        sd[f"lora_unet_{flat}.lora_up.weight"] = b
+        sd[f"lora_unet_{flat}.alpha"] = torch.tensor(float(_RANK))
+
+    # Linear pair onto the (quantized) attention projection.
+    q = unet.get_submodule(
+        "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_q")
+    pair(
+        "down_blocks_1_attentions_0_transformer_blocks_0_attn1_to_q",
+        torch.randn(_RANK, q.in_features) * 0.05,
+        torch.randn(q.out_features, _RANK) * 0.05,
+    )
+    # Conv pairs — the gw#627 gap: downsampler conv + resnet conv, 4-d
+    # halves at the base conv's kernel size (the 49-pair class every
+    # curated sdxl distill adapter carries).
+    ds = unet.get_submodule("down_blocks.0.downsamplers.0.conv")
+    pair(
+        "down_blocks_0_downsamplers_0_conv",
+        torch.randn(_RANK, ds.in_channels, *ds.kernel_size) * 0.05,
+        torch.randn(ds.out_channels, _RANK, 1, 1) * 0.05,
+    )
+    r1 = unet.get_submodule("down_blocks.0.resnets.0.conv1")
+    pair(
+        "down_blocks_0_resnets_0_conv1",
+        torch.randn(_RANK, r1.in_channels, *r1.kernel_size) * 0.05,
+        torch.randn(r1.out_channels, _RANK, 1, 1) * 0.05,
+    )
+    return sd
+
+
+def _prepared(unet: Any, name: str = "turbo-lightning-4step") -> PreparedAdapter:
+    return PreparedAdapter(
+        slot="pipeline",
+        ref="turbo/lightning-4step",
+        cache_key="turbo/lightning-4step",
+        name=name,
+        weight=1.0,
+        state_dict=_turbo_style_adapter(unet),
+    )
+
+
+def test_turbo_adapter_rides_the_branch_on_a_w8a8_pertensor_unet() -> None:
+    """The exact live shape: compiled w8a8 pipeline, quantized attention
+    Linears, conv-bearing curated adapter — activate must land the whole
+    adapter on the additive branch, never on peft."""
+    unet = _tiny_unet()
+    scaled = _swap_scaled(
+        unet, "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_q")
+    unet._cozy_w8a8_mode = "pertensor"
+    pipe = _Pipe(unet)
+    # The arming path (Compile.lora_bucket / apply_lora_lane) pre-enables
+    # canonical zeroed branches; the compiled marker forbids resizes.
+    w8a8_lora.enable_lora_branches(unet, 16)
+    pipe._cozy_compile = object()
+
+    residency = AdapterResidency()
+    residency.activate("pipeline", pipe, [_prepared(unet)], request_id="t1")
+
+    assert not pipe.load_lora_weights.calls, "denoiser half must never hit peft"
+    assert not pipe.set_adapters.calls
+    assert w8a8_lora.branches_active(unet)
+    assert w8a8_lora.branch_bucket(unet) == 16  # no resize under compile
+    # Quantized Linear carries the pair in its registered buffers.
+    assert float(scaled.lora_b.abs().sum()) > 0
+    # Conv branches carry theirs as __dict__ attrs (4-d).
+    ds = unet.get_submodule("down_blocks.0.downsamplers.0.conv")
+    assert ds.lora_a.dim() == 4 and float(ds.lora_b.abs().sum()) > 0
+    # Uncovered modules keep canonical zeroed slots.
+    r2 = unet.get_submodule("down_blocks.0.resnets.0.conv2")
+    assert getattr(r2, "lora_a", None) is not None
+    assert float(r2.lora_b.abs().sum()) == 0
+
+    # Deactivate zeroes B (graph stays); re-activate repopulates — the
+    # th#1036 "second request contributes nothing" class must stay dead.
+    residency.deactivate("pipeline", pipe, request_id="t1")
+    assert float(scaled.lora_b.abs().sum()) == 0
+    assert float(ds.lora_b.abs().sum()) == 0
+    residency.activate("pipeline", pipe, [_prepared(unet)], request_id="t2")
+    assert float(scaled.lora_b.abs().sum()) > 0
+    assert float(ds.lora_b.abs().sum()) > 0
+
+
+def test_conv_branch_changes_output_and_clears_bit_exact() -> None:
+    """Plain-lane numerics on CPU: the conv branch addend is real, and a
+    cleared branch restores the exact baseline output."""
+    unet = _tiny_unet().eval()
+    pipe = _Pipe(unet)
+    sample = torch.randn(1, 4, 16, 16)
+    t = torch.tensor([3])
+    ehs = torch.randn(1, 4, 32)
+
+    def run() -> Any:
+        with torch.no_grad():
+            return unet(sample, t, encoder_hidden_states=ehs).sample
+
+    baseline = run()
+    residency = AdapterResidency()
+    residency.activate("pipeline", pipe, [_prepared(unet)], request_id="n1")
+    overlaid = run()
+    assert not torch.equal(baseline, overlaid), "adapter must be visible"
+    residency.deactivate("pipeline", pipe, request_id="n1")
+    assert torch.equal(baseline, run()), "cleared branch must be bit-exact"
+
+
+def test_conv_pair_shape_mismatch_is_a_typed_refusal() -> None:
+    unet = _tiny_unet()
+    sd = {
+        "lora_unet_down_blocks_0_downsamplers_0_conv.lora_down.weight":
+            torch.randn(_RANK, 999, 3, 3),
+        "lora_unet_down_blocks_0_downsamplers_0_conv.lora_up.weight":
+            torch.randn(32, _RANK, 1, 1),
+    }
+    with pytest.raises(RefCompatibilitySurprise):
+        w8a8_lora.map_adapter(sd, unet, ref="turbo/bad")
+
+
+def test_grouped_conv_is_refused_not_silently_wrong() -> None:
+    import torch.nn as nn
+
+    class _M(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(8, 8, 3, padding=1, groups=2)
+
+    m = _M()
+    sd = {
+        "conv.lora_down.weight": torch.randn(4, 8, 3, 3),
+        "conv.lora_up.weight": torch.randn(8, 4, 1, 1),
+    }
+    with pytest.raises(RefCompatibilitySurprise, match="grouped conv"):
+        w8a8_lora.map_adapter(sd, m, ref="turbo/grouped")

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.50.2"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Release train (chaos -> master): two lanes.

## gw#627 (0.51.0): Conv2d additive-branch support in the runtime LoRA overlay
Live P1: sdxl generate-turbo was 100% fatal on the fp8 lane (8/8 on L4, th#1037
addendum, request 16205a14) — the endpoint's curated Lightning/DMD2 adapters
went through raw diffusers/peft `load_lora_weights`, and peft rejects
`_Fp8ScaledLinear` (pertensor). The sanctioned route (gw#547/558 branch via
AdapterResidency) could not carry them either: each adapter ships 49 CONV LoRA
pairs and the branch was Linear-only. This adds plain `nn.Conv2d` denoiser
modules as branch targets: canonical zeroed conv branches in the same rank
bucket (A [bucket,in,kh,kw] at base stride/padding, B [out,bucket,1,1]),
same staged-copy swap, eager instance-forward wrap `conv1x1(conv(x,A),B)`.
Convs are never quantized, so every lane takes the wrap path; cell lane naming
(`w8a8-lora<bucket>`) unchanged. e2e-style CPU test over the real codepath:
real tiny UNet2DConditionModel + real `_Fp8ScaledLinear` pertensor swaps +
live key grammar (kohya-flat, conv 4-d pairs) through
AdapterResidency.activate/deactivate under the compiled marker.

Endpoint half (sdxl overlay rewire, lora_bucket, warmup) follows in
inference-endpoints pinned to 0.51.0.

## th#1063 (0.50.3): loud boot log when a datacenter pod has no CAS fill source
Chaos 77c2e11 (Paul) — rides this train per the th#1063 tracker note.

Local: 670 passed / 5 skipped / 1 xfailed; mypy clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)