### PR TITLE
gw#627 live fix: enable_compiled skips the branch lane on slot objects with no compile target (0.52.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.52.1 (2026-07-24)
+
+- **gw#627 live fix: `enable_compiled` skips the branch lane on slot
+  objects with no compile target.** The arming path runs for every
+  worker-loaded setup slot; a bare component slot (sdxl's standalone
+  AutoencoderKL vae) resolves none of `cfg.targets`, and `apply_lora_lane`'s
+  no-denoiser error broke the whole model load (release-broken streak on
+  the first gw#627 sdxl deploy). The loud misconfig error remains for real
+  compile targets.
+
 ## 0.52.0 (2026-07-24)
 
 - **pgw#628: residency reporting v2 — content-addressed idempotent

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -199,6 +199,12 @@ def enable_compiled(
     from .. import compile_cache, trt_engine
 
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
+    if bucket and not compile_cache.has_compile_target(pipe, cfg):
+        # gw#627 live find: this arming runs for EVERY worker-loaded setup
+        # slot — a bare component slot (sdxl's AutoencoderKL vae) resolves
+        # none of cfg.targets and must stay branchless-eager, not raise.
+        # The loud no-denoiser error remains for real compile targets.
+        bucket = 0
     if bucket:
         compile_cache.apply_lora_lane(pipe, bucket)
     if artifact is not None and not bucket:

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -215,3 +215,22 @@ def test_discovery_carries_lora_bucket() -> None:
         family="f", weight_lane="w8a8-lora64", lora_bucket=64)
     assert meta["weight_lane"] == "w8a8-lora64"
     assert meta["lora_bucket"] == 64
+
+
+def test_enable_compiled_skips_lane_on_component_slot_without_target() -> None:
+    """gw#627 live find: enable_compiled runs for EVERY worker-loaded setup
+    slot — a bare component slot (sdxl's standalone AutoencoderKL vae)
+    resolves none of cfg.targets and must stay branchless-eager instead of
+    raising apply_lora_lane's no-denoiser error (which broke the whole
+    model load, release-broken streak)."""
+
+    class _Vae(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.decoder = torch.nn.Linear(8, 8)
+
+    vae = _Vae()
+    cfg = Compile(shapes=((64, 64),), family="loracells-test",
+                  targets=("unet",), lora_bucket=64)
+    armed = provision.enable_compiled(vae, cfg, cache_dir=None, artifact=None)
+    assert armed is False


### PR DESCRIPTION
Live find from the first gw#627 sdxl deploy (release ffd6e2d4, master stack):
`enable_compiled` runs for EVERY worker-loaded setup slot; sdxl's standalone
AutoencoderKL vae slot resolves none of `cfg.targets`, so with
`Compile.lora_bucket=64` declared, `apply_lora_lane`'s no-denoiser
RuntimeError broke the whole model load (model_load_failure_streak,
release-broken; prod was rolled back to dd82ebc7 within minutes). The lane
now applies only to objects that resolve a compile target; the loud misconfig
error stays for real targets. Regression test on a bare-VAE slot object.

Local: lora/overlay/quantization/compile-cache subsets green (92), mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)