### PR TITLE
gw#627: version 0.52.1 (bump only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.52.0"
+version = "0.52.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.52.0"
+version = "0.52.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
PR #382 merged the 0.52.1 fix but the version bump sed silently no-op'd against the moved 0.52.0 base. Version + uv.lock only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)