### PR TITLE
gw#627 live fix 2: reject legacy attn-processor converter output in adapter normalization (0.52.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.52.2 (2026-07-24)
+
+- **gw#627 live fix 2: normalization rejects legacy attn-processor
+  converter output.** diffusers' non-diffusers converter turns kohya-flat
+  sdxl attention keys into legacy `…attn1.processor.to_q_lora.down.weight`
+  names that match no real module, failing the whole curated adapter typed.
+  `normalize_adapter_state_dict` now falls back to the raw keys (which
+  resolve directly against module paths) whenever the converted dict
+  carries `.processor.` names.
+
 ## 0.52.1 (2026-07-24)
 
 - **gw#627 live fix: `enable_compiled` skips the branch lane on slot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.52.1"
+version = "0.52.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -703,6 +703,17 @@ def normalize_adapter_state_dict(
             return sd
         converted, raw_alphas = converted
         alphas = dict(raw_alphas or {})
+    if any(".processor." in k for k in converted):
+        # gw#627 live find: diffusers' non-diffusers converter emits LEGACY
+        # attn-processor names for kohya sdxl attention keys
+        # (…attn1.processor.to_q_lora.down.weight) — they match no real
+        # module, so the whole adapter would fail typed. The raw kohya-flat
+        # keys resolve directly against module paths in map_adapter.
+        logger.info(
+            "lora_state_dict normalization for %s emitted legacy "
+            "attn-processor names; using raw keys", ref,
+        )
+        return sd
     out = dict(converted)
     for k, v in alphas.items():
         key = k if k.endswith(".alpha") else f"{k}.alpha"

--- a/tests/test_turbo_overlay_gw627.py
+++ b/tests/test_turbo_overlay_gw627.py
@@ -86,9 +86,10 @@ class _PeftRecorder:
 
 
 class _Pipe:
-    """Minimal pipeline holding the real unet (the branch machinery and the
-    normalize/split path key off ``pipe.unet`` and the class, nothing
-    else)."""
+    """Minimal pipeline holding the real unet — plus the REAL diffusers SDXL
+    ``lora_state_dict`` converter, so normalization runs the exact live path
+    (which emits legacy attn-processor names for kohya-flat sdxl adapters —
+    the gw#627 second live find; normalize must fall back to raw keys)."""
 
     def __init__(self, unet: Any) -> None:
         self.unet = unet
@@ -96,6 +97,15 @@ class _Pipe:
         self.set_adapters = _PeftRecorder()
         self.unload_lora_weights = _PeftRecorder()
         self.disable_lora = _PeftRecorder()
+
+
+def _install_real_converter() -> None:
+    from diffusers import StableDiffusionXLPipeline
+
+    _Pipe.lora_state_dict = StableDiffusionXLPipeline.lora_state_dict
+
+
+_install_real_converter()
 
 
 # Live key grammar: kohya-flat diffusers naming, exactly what

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.52.1"
+version = "0.52.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Second live find from the gw#627 sdxl deploy (request 88604466, release
0adbc2d7): diffusers' non-diffusers converter turns the curated kohya-flat
sdxl adapters' attention keys into legacy
`…attn1.processor.to_q_lora.down.weight` names that match no real module —
map_adapter failed the whole adapter typed (1680 unresolved keys).
`normalize_adapter_state_dict` now falls back to the raw keys (which resolve
directly against module paths) whenever the converted dict carries
`.processor.` names. The gw627 overlay test now runs the REAL
StableDiffusionXLPipeline.lora_state_dict converter in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)