### PR TITLE
gw#632: delivered lora-bucket cell at a bare component slot is an ordinary miss (0.52.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.52.2"
+version = "0.52.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1980,10 +1980,21 @@ def enable(
                         pipeline_weight_lane as _pwl,
                     )
 
+                    # gw#631: the EFFECTIVE bucket — a slot object with no
+                    # resolvable compile target (sdxl's bare vae) never rides
+                    # the branch lane (provision downgrades apply_lora_lane
+                    # the same way, 0.52.1), so its self-key must not claim
+                    # the family's lora<bucket> cell and then explode on
+                    # lane drift (live: `weight_lane 'lora64' != pipeline ''`
+                    # -> CellSelectionBugError -> gw#608 seeded-cell refusal
+                    # -> all_declared_functions_disabled pod retire).
+                    eff_bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
+                    if eff_bucket and not has_compile_target(pipeline, cfg):
+                        eff_bucket = 0
                     want = cell_key.compute(
                         str(getattr(cfg, "family", "") or ""),
                         _pwl(pipeline),
-                        int(getattr(cfg, "lora_bucket", 0) or 0),
+                        eff_bucket,
                         regional=bool(getattr(cfg, "regional", False)),
                     )
                     if not cell_key.mismatch(meta, want):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1980,7 +1980,7 @@ def enable(
                         pipeline_weight_lane as _pwl,
                     )
 
-                    # gw#631: the EFFECTIVE bucket — a slot object with no
+                    # gw#632: the EFFECTIVE bucket — a slot object with no
                     # resolvable compile target (sdxl's bare vae) never rides
                     # the branch lane (provision downgrades apply_lora_lane
                     # the same way, 0.52.1), so its self-key must not claim

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -239,7 +239,7 @@ def test_enable_compiled_skips_lane_on_component_slot_without_target() -> None:
 def test_delivered_lora_cell_on_component_slot_is_ordinary_miss(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """gw#631 (r3 live find, the all_declared_functions_disabled chain): a
+    """gw#632 (r3 live find, the all_declared_functions_disabled chain): a
     DELIVERED family lora<bucket> cell arriving at a bare component slot
     (sdxl's standalone vae — no cfg.target resolves) must be an ordinary
     lane miss that stays eager. Before the effective-bucket fix the self-key

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -234,3 +234,45 @@ def test_enable_compiled_skips_lane_on_component_slot_without_target() -> None:
                   targets=("unet",), lora_bucket=64)
     armed = provision.enable_compiled(vae, cfg, cache_dir=None, artifact=None)
     assert armed is False
+
+
+def test_delivered_lora_cell_on_component_slot_is_ordinary_miss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gw#631 (r3 live find, the all_declared_functions_disabled chain): a
+    DELIVERED family lora<bucket> cell arriving at a bare component slot
+    (sdxl's standalone vae — no cfg.target resolves) must be an ordinary
+    lane miss that stays eager. Before the effective-bucket fix the self-key
+    check claimed the cell as this runtime's own (cfg bucket, '' lane) and
+    raised CellSelectionBugError (`weight_lane 'lora64' != pipeline ''`),
+    which cascaded into the gw#608 seeded-cell refusal and retired the pod."""
+
+    # Pin the runtime axes so the self-key computes on a CPU host (the live
+    # failure needs cell_key.compute to succeed — sku/sm come from the GPU).
+    rt = {
+        "sku": "rtx-4090", "sm": "sm_89", "torch": "2.13.0+cu130",
+        "triton": "3.7.1", "cuda": "13.0", "cuda_driver": "13020",
+        "image_digest": "",
+    }
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: dict(rt))
+
+    class _Vae(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.decoder = torch.nn.Linear(8, 8)
+
+    src = tmp_path / "cellsrc"
+    (src / "inductor" / "ab").mkdir(parents=True)
+    (src / "inductor" / "ab" / "graph.py").write_text("code")
+    meta = compile_cache.artifact_metadata(
+        family="loracells-test", shapes=[(64, 64)], targets=["unet"],
+        weight_lane="lora64", lora_bucket=64,
+    )
+    artifact = compile_cache.pack(src, tmp_path / "cell.tar.gz", meta)
+
+    vae = _Vae()
+    cfg = Compile(shapes=((64, 64),), family="loracells-test",
+                  targets=("unet",), lora_bucket=64)
+    armed = provision.enable_compiled(
+        vae, cfg, cache_dir=tmp_path / "cache", artifact=artifact)
+    assert armed is False

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.52.2"
+version = "0.52.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
r3 live chain (pod xzhlioakq909wq, all_declared_functions_disabled): the self-key check in compile_cache.enable computed the family lora64 key from cfg.lora_bucket even when no cfg.target resolves on the slot object (sdxl's standalone vae), claimed the delivered cell as this runtime's own, and raised CellSelectionBugError (weight_lane 'lora64' != pipeline '') -> gw#608 seeded-cell self-mint refusal -> cell quarantine -> pod retired.

0.52.1 downgraded apply_lora_lane for targetless slots; this applies the same effective-bucket rule to the self-key so the delivered cell is an ordinary lane miss (stays eager) at component slots.

Test reproduces the live failure on the old code (CellSelectionBugError) and passes with the fix; runs the real provision.enable_compiled path with a packed cell artifact and pinned runtime axes.

Note: the flip that triggered the reload-then-adopt window is the hub half, fixed separately as th#1088 (tensorhub #629).

🤖 Generated with [Claude Code](https://claude.com/claude-code)