### PR TITLE
release 0.56.1: worker fatals reach the hub (gw#640 instrument)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.56.1 (2026-07-24)
+
+- **gw#640/th#1077: a worker fatal now reaches the HUB, not just pod stdout.**
+  `entrypoint._log_worker_fatal` wrote the exception class, message and
+  traceback to stdout only; RunPod exposes no container-logs API, so every
+  cloud-only worker death was unobservable by construction (six live th#1085
+  runs burned on a crash whose traceback existed and could not be read). The
+  fatal is now also dialed to the orchestrator over a fresh Connect stream,
+  reusing the `HardwareUnsuitable` carrier with `reason_class="worker_fatal"`
+  — the hub already persists that as a durable `pod_events` row, so this
+  needs NO proto change and NO hub redeploy and works against every hub pin
+  already deployed. Additionally, the run loop ending WITHOUT a hub Drain or
+  a shutdown signal is now itself a reported fatal (`UnexpectedWorkerExit`)
+  instead of a clean, silent `exit 0` — that silent exit was exactly the
+  gw#640 signature the hub could only see as a young-worker death.
+
 ## 0.56.0 (2026-07-24)
 
 - **th#1085 Slice 5: exact mutable-config convergence.** Protocol-v5 desired

--- a/examples/marco-polo/uv.lock
+++ b/examples/marco-polo/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.56.0"
+version = "0.56.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "blake3" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.56.0"
+version = "0.56.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -84,7 +84,19 @@ def _log_startup_phase(phase: str, *, status: str = "ok", level: int = logging.I
         logger.log(level, "worker.startup.phase phase=%s status=%s", phase, status)
 
 
-def _log_worker_fatal(phase: str, exc: BaseException, *, exit_code: int) -> None:
+def _log_worker_fatal(
+    phase: str,
+    exc: BaseException,
+    *,
+    exit_code: int,
+    settings: Optional[Any] = None,
+) -> None:
+    """Record this process's cause of death to stdout AND to the hub.
+
+    gw#640/th#1077: stdout alone is unreachable on RunPod (no container-logs
+    API), so every cloud-only crash was un-debuggable. The wire report reuses
+    the HardwareUnsuitable carrier and lands as a durable pod_events row.
+    """
     try:
         tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     except Exception:
@@ -102,6 +114,19 @@ def _log_worker_fatal(phase: str, exc: BaseException, *, exit_code: int) -> None
         logger.error("worker.fatal %s", json.dumps(payload, separators=(",", ":"), sort_keys=True))
     except Exception:
         logger.exception("worker.fatal: %s", exc)
+    try:
+        from .worker_fatal import report_worker_fatal
+
+        delivered = report_worker_fatal(settings, phase, exc, exit_code=exit_code)
+        _log_startup_phase(
+            "worker_fatal_report",
+            status="ok" if delivered else "error",
+            level=logging.INFO if delivered else logging.WARNING,
+            delivered=delivered,
+            phase_context=str(phase or ""),
+        )
+    except Exception:
+        logger.warning("worker-fatal wire report raised unexpectedly", exc_info=True)
 
 
 def load_manifest(path: Path = MANIFEST_PATH) -> Optional[dict]:
@@ -217,7 +242,7 @@ def _run_main() -> int:
     try:
         cache_cfg = _preflight_cache_dirs()
     except Exception as e:
-        _log_worker_fatal("cache_preflight", e, exit_code=1)
+        _log_worker_fatal("cache_preflight", e, exit_code=1, settings=settings)
         logger.error(str(e))
         return 1
 
@@ -243,6 +268,9 @@ def _run_main() -> int:
                 )
             except Exception:
                 logger.warning("hardware-unsuitable report raised unexpectedly", exc_info=True)
+            # settings=None: this path ALREADY dialed the hub with the typed
+            # HardwareUnsuitable report just above — a second wire dial would
+            # only duplicate it (and double the pre-exit budget).
             _log_worker_fatal("cuda_probe", RuntimeError(probe.reason), exit_code=1)
             return 1
         _log_startup_phase("cuda_probe_ok", status="ok")
@@ -259,7 +287,7 @@ def _run_main() -> int:
 
         _c2pa_configure(settings)
     except Exception as e:
-        _log_worker_fatal("c2pa_configure", e, exit_code=1)
+        _log_worker_fatal("c2pa_configure", e, exit_code=1, settings=settings)
         logger.error(str(e))
         return 1
 
@@ -297,11 +325,11 @@ def _run_main() -> int:
             e,
             user_modules,
         )
-        _log_worker_fatal("import", e, exit_code=1)
+        _log_worker_fatal("import", e, exit_code=1, settings=settings)
         return 1
     except Exception as e:
         logger.exception("Worker failed unexpectedly: %s", e)
-        _log_worker_fatal("runtime", e, exit_code=1)
+        _log_worker_fatal("runtime", e, exit_code=1, settings=settings)
         return 1
 
 

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 _SIGNAL_DRAIN_DEADLINE_MS = 30_000
 
 
+class UnexpectedWorkerExit(RuntimeError):
+    """The run loop ended without a hub Drain or a shutdown signal (gw#640)."""
+
+
 class _LoopStallWatchdog:
     """Forensics for gw#407: a host in RAM reclaim-thrash stalls the whole
     process — the event loop AND the gRPC C threads that answer h2 keepalive
@@ -138,12 +142,25 @@ class Worker:
         await self.transport.send(msg)
 
     def run(self) -> int:
-        return asyncio.run(self.arun())
+        """Always returns an exit code. gw#640: a fatal end to the run loop is
+        reported to the HUB here (sync context, own loop) before returning —
+        pod stdout is unreadable on RunPod, so this is the only channel that
+        survives the process."""
+        try:
+            return asyncio.run(self.arun())
+        except (FatalTransportError, UnexpectedWorkerExit) as exc:
+            from .worker_fatal import report_worker_fatal
+
+            logger.error("worker exiting on a fatal: %s", exc, exc_info=True)
+            report_worker_fatal(self.settings, "run_loop", exc, exit_code=1)
+            return 1
 
     _loop: Optional[asyncio.AbstractEventLoop] = None
+    _stop_requested: bool = False
 
     def stop(self) -> None:
         """Thread-safe stop (tests / embedding); production exits via Drain."""
+        self._stop_requested = True
         loop = self._loop
         if loop is not None and not loop.is_closed():
             loop.call_soon_threadsafe(self.transport.stop)
@@ -165,8 +182,10 @@ class Worker:
         try:
             await transport_task
         except FatalTransportError as exc:
+            # gw#640: surfaced to the entrypoint so the cause reaches the hub
+            # instead of only this pod's stdout.
             logger.error("worker exiting: %s", exc)
-            return 1
+            raise
         finally:
             watchdog.stop()
             startup.cancel()
@@ -174,4 +193,13 @@ class Worker:
         if self.lifecycle.drained.is_set():
             logger.info("worker drained; exiting 0")
             return 0
-        return 0
+        if self._stop_requested:
+            return 0
+        # gw#640: the reconnect loop is supposed to run until a hub Drain or a
+        # signal. Falling out of it any other way ended the process with a
+        # clean exit 0 and NOTHING on the wire — the hub saw only a stream
+        # close and a young-worker death. An unexplained exit is a fatal.
+        raise UnexpectedWorkerExit(
+            "transport loop ended without a Drain command or shutdown signal "
+            f"(connected={self.transport.connected} draining={self.lifecycle.draining})"
+        )

--- a/src/gen_worker/worker_fatal.py
+++ b/src/gen_worker/worker_fatal.py
@@ -1,0 +1,115 @@
+"""gw#640/th#1077: worker -> hub fatal report, dialed BEFORE the process dies.
+
+``entrypoint._log_worker_fatal`` wrote the exception + traceback to the pod's
+stdout ONLY. RunPod exposes no container-logs API, so every cloud-only worker
+death was unobservable by construction — the th#1085 cold-boot investigation
+burned six live runs on a crash whose traceback existed and was unreachable.
+
+This module reuses the ``HardwareUnsuitable`` carrier (gw#619/th#988) with
+``reason_class="worker_fatal"``: the hub already persists that message as a
+durable ``pod_events`` row (class ``hardware_unsuitable``, reason = the class,
+full JSON payload in ``provider_message``) and logs it, so a fatal becomes
+queryable per pod with NO proto change and NO hub redeploy — it works against
+every hub pin already deployed.
+
+Bounded best-effort, exactly like the hardware report: the process is already
+dying, so this is a diagnostic dial, never a reason to delay the exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+from typing import Optional
+
+from .config import Settings
+from .hardware_report import (
+    HardwareReport,
+    _identity_from_settings,
+    _report_async,
+)
+
+logger = logging.getLogger(__name__)
+
+REASON_CLASS = "worker_fatal"
+
+# The hub stores `detail` in a jsonb payload; a full traceback of a deep
+# framework stack can be very long. Keep the head (the raise site chain) and
+# the tail (the actual exception) — the middle is the least diagnostic part.
+_DETAIL_MAX = 8000
+_TAIL_KEEP = 3000
+
+
+def _clip(text: str) -> str:
+    if len(text) <= _DETAIL_MAX:
+        return text
+    head = _DETAIL_MAX - _TAIL_KEEP - len("\n...[clipped]...\n")
+    return text[:head] + "\n...[clipped]...\n" + text[-_TAIL_KEEP:]
+
+
+def build_fatal_detail(
+    phase: str, exc: Optional[BaseException], *, exit_code: int
+) -> str:
+    """phase + exception identity + traceback, as one human-readable blob."""
+    lines = [f"phase={phase or 'unknown'} exit_code={int(exit_code)}"]
+    if exc is not None:
+        lines.append(f"{type(exc).__name__}: {exc}")
+        try:
+            tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        except Exception:
+            tb = traceback.format_exc()
+        lines.append(tb.rstrip())
+    return _clip("\n".join(lines))
+
+
+def _build_report(settings: Settings, detail: str) -> HardwareReport:
+    gen_worker_version = ""
+    try:
+        from .compile_cache import gen_worker_version as _gwv
+
+        gen_worker_version = _gwv()
+    except Exception:
+        pass
+    torch_version = ""
+    try:
+        import torch
+
+        torch_version = str(getattr(torch, "__version__", "") or "")
+    except Exception:
+        pass
+    return HardwareReport(
+        reason_class=REASON_CLASS,
+        detail=detail,
+        torch_version=torch_version,
+        gen_worker_version=gen_worker_version,
+        image_digest=settings.worker_image_digest or "",
+        instance_id=settings.runpod_pod_id or "",
+    )
+
+
+def report_worker_fatal(
+    settings: Optional[Settings],
+    phase: str,
+    exc: Optional[BaseException],
+    *,
+    exit_code: int,
+) -> bool:
+    """Dial the hub with this process's cause of death. Never raises; returns
+    whether the hub is believed to have received it. Safe to call from a
+    non-async context only (it owns its own event loop) — the caller is on
+    its way out."""
+    if settings is None or not (settings.orchestrator_public_addr or "").strip():
+        return False
+    detail = build_fatal_detail(phase, exc, exit_code=exit_code)
+    try:
+        report = _build_report(settings, detail)
+        return asyncio.run(_report_async(settings, report))
+    except Exception:
+        logger.warning("worker-fatal report failed entirely", exc_info=True)
+        return False
+
+
+def fatal_identity(settings: Settings) -> str:
+    worker_id, release_id = _identity_from_settings(settings)
+    return f"worker={worker_id or '?'} release={release_id or '?'}"

--- a/tests/test_gw640_disk_only_residency.py
+++ b/tests/test_gw640_disk_only_residency.py
@@ -1,0 +1,60 @@
+"""gw#640: a Hub()-bound function whose desired residency is disk-only
+(disk=1 hot=0) must converge and keep the worker alive.
+
+Live shape (th#1085 cold-boot gate, RunPod CPU pod): the hub delivers the
+model on disk with NO hot instance, the gw#591 boot-setup watch completes
+setup — and the worker process exited 1-2s later, silently, ~18x per run.
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.blob_host import BlobHost
+from harness.hub_double import hub_double, is_model_event, is_ready, is_result_for
+from harness.toy_endpoints import EchoIn, EchoOut
+
+_MODEL_REF = "harness/residency-tiny"
+
+
+def test_disk_only_residency_sets_up_and_worker_survives(tmp_path) -> None:
+    blobs = BlobHost(tmp_path)
+    try:
+        payload = b"tiny-weights"
+        snapshot = blobs.one_file_snapshot("snap-640", "blob", payload)
+        with hub_double() as (scheduler, harness):
+            conn = scheduler.wait_connection(0)
+            ready = conn.wait_for(is_ready)
+            assert "model-echo" in ready.state_delta.loading_functions
+
+            # disk=1, hot=0 — the gw#640 shape.
+            conn.send(hello_ack=pb.HelloAck(
+                protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+                desired_residency=pb.DesiredResidency(
+                    generation=1,
+                    disk_refs=[_MODEL_REF],
+                    snapshots={_MODEL_REF: snapshot},
+                ),
+            ))
+            conn.wait_for(is_model_event(_MODEL_REF, pb.MODEL_STATE_ON_DISK))
+
+            # gw#591 boot-setup watch must advertise the function...
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "state_delta"
+                and "model-echo" in m.state_delta.available_functions
+            )
+            # ...and the worker must still be alive to serve it.
+            conn.send(run_job=pb.RunJob(
+                request_id="r640", attempt=1, function_name="model-echo",
+                input_payload=msgspec.msgpack.encode(EchoIn(text="x"))))
+            res = conn.wait_for(is_result_for("r640")).job_result
+            assert res.status == pb.JOB_STATUS_OK
+            assert msgspec.msgpack.decode(res.inline, type=EchoOut).response == payload.decode()
+            assert harness.exit_code is None, (
+                f"worker process exited (code={harness.exit_code}) on a disk-only "
+                "desired residency"
+            )
+    finally:
+        blobs.shutdown()

--- a/tests/test_worker_fatal_gw640.py
+++ b/tests/test_worker_fatal_gw640.py
@@ -1,0 +1,158 @@
+"""gw#640/th#1077: a worker fatal must reach the HUB, not just pod stdout.
+
+RunPod exposes no container-logs API, so a fatal written only to stdout is
+unreachable — six live th#1085 runs died on a crash whose traceback existed
+and could not be read. These tests pin the two halves of the fix:
+
+1. the fatal report is dialed over a real gRPC Connect stream and carries the
+   exception class, message and traceback;
+2. the run loop ending WITHOUT a Drain or a signal is itself a fatal (it used
+   to be a clean, silent exit 0 — the exact gw#640 signature).
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent import futures
+
+import grpc
+import pytest
+
+from gen_worker.config import load_settings
+from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
+from gen_worker.worker_fatal import REASON_CLASS, build_fatal_detail, report_worker_fatal
+
+
+class _FatalCatcher(pb_grpc.WorkerSchedulerServicer):
+    def __init__(self) -> None:
+        self.reports: list = []
+        self.got = threading.Event()
+
+    def Connect(self, request_iterator, context):
+        for msg in request_iterator:
+            if msg.WhichOneof("msg") == "hardware_unsuitable":
+                self.reports.append(msg.hardware_unsuitable)
+                self.got.set()
+        return
+        yield  # pragma: no cover - generator marker
+
+
+def _server():
+    catcher = _FatalCatcher()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    pb_grpc.add_WorkerSchedulerServicer_to_server(catcher, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    return catcher, server, port
+
+
+def test_fatal_detail_carries_class_message_and_traceback() -> None:
+    try:
+        raise ValueError("pipeline exploded")
+    except ValueError as exc:
+        detail = build_fatal_detail("runtime", exc, exit_code=1)
+    assert "phase=runtime" in detail
+    assert "exit_code=1" in detail
+    assert "ValueError: pipeline exploded" in detail
+    assert "Traceback (most recent call last)" in detail
+    assert "test_worker_fatal_gw640.py" in detail
+
+
+def test_fatal_detail_is_clipped_but_keeps_both_ends() -> None:
+    exc = RuntimeError("H" * 200 + "M" * 40_000 + "T" * 200)
+    detail = build_fatal_detail("runtime", exc, exit_code=1)
+    assert len(detail) < 12_000
+    assert "HHH" in detail and "TTT" in detail
+    assert "[clipped]" in detail
+
+
+def test_worker_fatal_reaches_the_hub_over_the_wire() -> None:
+    catcher, server, port = _server()
+    try:
+        settings = load_settings(
+            orchestrator_public_addr=f"127.0.0.1:{port}",
+            worker_id="worker-gw640",
+            worker_jwt="",
+        )
+        try:
+            raise RuntimeError("boom in reconcile")
+        except RuntimeError as exc:
+            delivered = report_worker_fatal(settings, "runtime", exc, exit_code=1)
+        assert catcher.got.wait(10), "hub never received a fatal report"
+        report = catcher.reports[0]
+        assert report.reason_class == REASON_CLASS
+        assert "RuntimeError: boom in reconcile" in report.detail
+        assert "Traceback" in report.detail
+        assert report.worker_id == "worker-gw640"
+        assert delivered is True
+    finally:
+        server.stop(grace=0)
+
+
+def test_report_is_a_noop_without_an_orchestrator_address() -> None:
+    settings = load_settings(orchestrator_public_addr="", worker_id="w")
+    assert report_worker_fatal(settings, "runtime", RuntimeError("x"), exit_code=1) is False
+
+
+def test_unexplained_loop_exit_is_a_fatal_not_a_silent_zero() -> None:
+    """gw#640's signature: transport.run() returning with no Drain and no
+    signal used to be `return 0` — a silent restart the hub could only see as
+    a young-worker death."""
+    import asyncio
+
+    from gen_worker.worker import UnexpectedWorkerExit, Worker
+
+    worker = Worker.__new__(Worker)  # no real wiring needed for this contract
+    worker._stop_requested = False
+
+    class _Lifecycle:
+        drained = threading.Event()
+        draining = False
+
+        def start_drain(self, deadline_ms):
+            pass
+
+        async def startup(self):
+            await asyncio.sleep(3600)
+
+    class _Transport:
+        connected = False
+
+        async def run(self):
+            return  # loop ends on its own — the gw#640 shape
+
+    worker.lifecycle = _Lifecycle()
+    worker.transport = _Transport()
+
+    with pytest.raises(UnexpectedWorkerExit) as caught:
+        asyncio.run(worker.arun())
+    assert "without a Drain command" in str(caught.value)
+
+
+def test_requested_stop_still_exits_zero() -> None:
+    import asyncio
+
+    from gen_worker.worker import Worker
+
+    worker = Worker.__new__(Worker)
+    worker._stop_requested = True
+
+    class _Lifecycle:
+        drained = threading.Event()
+        draining = False
+
+        def start_drain(self, deadline_ms):
+            pass
+
+        async def startup(self):
+            await asyncio.sleep(3600)
+
+    class _Transport:
+        connected = False
+
+        async def run(self):
+            return
+
+    worker.lifecycle = _Lifecycle()
+    worker.transport = _Transport()
+    assert asyncio.run(worker.arun()) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.56.0"
+version = "0.56.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Patch release cut solo (urgent P0 per WORKSPACE-GIT-POLICY promotion-train rule 1): this
release IS the diagnostic instrument for the gw#640 v5-cutover blocker.

## Why this is worth a release on its own

gw#640 only manifests on real RunPod pods, and the #238 cold-boot gate builds its endpoint
image by resolving `gen-worker==<version>` **from PyPI**. Without 0.56.1 published, the next
gate run reproduces the same blind death and we learn nothing again. With it, the pod
self-reports phase + exception class + message + traceback into `pod_events` and the
mystery ends on the next run.

Note RUN 7 (proof lane) has since shown the `Slot(str)` production shape fails identically,
so `Hub()` was never the discriminator — this instrument is needed regardless of shape.

## Contents

Exactly one cherry-pick from chaos (`553db0d`) + the version bump and relock. No other
chaos work (pgw#636/637/638/639, th#1107) is carried — this is a minimal patch.

- Worker fatals are now dialed to the orchestrator over a fresh Connect stream, reusing
  the `HardwareUnsuitable` carrier with `reason_class="worker_fatal"`. The hub already
  persists that as a durable `pod_events` row, so this needs **no proto change and no hub
  redeploy** and works against every hub pin already deployed.
- The run loop ending WITHOUT a hub Drain or a shutdown signal is now a reported
  `UnexpectedWorkerExit` fatal instead of a clean, silent `exit 0` — that silent exit was
  the gw#640 signature the hub could only see as a young-worker death.
- `Worker.run()` keeps its `int` contract; the `cuda_probe` path is untouched because it
  already sends its own typed report.

## Gates (local, pre-CI)

- `mypy src/gen_worker`: clean, 136 files
- `ruff check src/gen_worker`: clean
- `scripts/lint_http_timeouts.py`: clean
- `uv lock --check`: clean (root + marco-polo)
- full `pytest tests/`: running; will confirm before merge

Tests added: `tests/test_worker_fatal_gw640.py` (6, incl. a real gRPC server asserting the
traceback arrives on the wire), `tests/test_gw640_disk_only_residency.py`.