### PR TITLE
release 0.56.2: gw#640 post-mortem supervisor — name the death that happens below Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.56.2 (2026-07-24)
+
+- **gw#640: a post-mortem supervisor names the death that happens BELOW
+  Python.** 0.56.1 instruments every death Python can observe; th#1085 run 9
+  produced six process restarts and ZERO `worker_fatal` rows, which leaves
+  exactly one class — a signal (cgroup OOM `SIGKILL`, `SIGSEGV` in a C
+  extension, an external kill). No `except` catches that and no in-process
+  reporter can dial out after it, so the reporter is now the NEXT process.
+  `python -m gen_worker.entrypoint` forks a supervisor before its heavy
+  imports: the parent stays a bare interpreter (the OOM killer picks the fat
+  child, not the reporter), forwards signals, and on an abnormal exit reports
+  `WIFSIGNALED`/`WTERMSIG`/`WCOREDUMP` plus `memory.max` vs `memory.current`
+  vs `memory.peak`, `cpu.max`, and the `memory.events` `oom_kill` counter
+  delta through the same `worker_fatal` carrier — a durable `pod_events` row
+  on any already-deployed hub, queryable with `class='hardware_unsuitable'
+  AND reason='worker_fatal'`. A boot record on the container filesystem covers
+  the case where the whole cgroup goes (`memory.oom.group`) or the container
+  is restarted: the next boot finds the unfinished record and reports it.
+  Exit status is propagated unchanged, so container-restart semantics are
+  identical; `GEN_WORKER_SUPERVISOR=0` opts out.
+- **gw#640: the host canary reports the cores this container actually owns.**
+  It shipped `os.cpu_count()` — the HOST's count, 32 on a pod that owns 4 —
+  next to a cgroup-derived `ram_total_gb` of 14.9 GB, a "32 vCPUs / 14.9 GB"
+  report that misdirected the th#1085 investigation. `vcpus` is now
+  `min(host cores, sched_getaffinity, cpu.max quota)`, and the multi-core
+  throughput probe runs that many threads instead of oversubscribing a quota.
+
 ## 0.56.1 (2026-07-24)
 
 - **gw#640/th#1077: a worker fatal now reaches the HUB, not just pod stdout.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.56.1"
+version = "0.56.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -32,6 +32,15 @@ os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 # compile-worker subprocess. See compile_cache._disable_aot_autograd_cache.
 os.environ.setdefault("TORCHINDUCTOR_AUTOGRAD_CACHE", "0")
 
+# gw#640: fork the supervisor BEFORE the heavy imports below. The parent stays
+# a bare interpreter (so the OOM killer picks the fat child, not the reporter)
+# and outlives the worker to report WTERMSIG / cgroup oom_kill over the wire.
+# In the child this returns immediately; the parent never returns from it.
+if __name__ == "__main__":
+    from .supervisor import supervise  # noqa: E402
+
+    supervise()
+
 import json
 import logging
 import sys

--- a/src/gen_worker/host_canary.py
+++ b/src/gen_worker/host_canary.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -144,7 +143,13 @@ def measure_host_canary() -> HostCanaryReport:
     """Run every axis once; failures zero their axis instead of raising."""
     t0 = time.perf_counter()
     memcpy = single = multi = 0.0
-    vcpus = os.cpu_count() or 0
+    # gw#640: os.cpu_count() reports the HOST's cores — 32 on a pod that owns
+    # 4 — and shipping that next to a cgroup-derived ram_total_gb produced a
+    # "32 vCPUs / 14.9 GB" report nobody could interpret. Report what this
+    # container may actually use, and benchmark with that many threads.
+    from .postmortem import effective_cpu_count
+
+    vcpus = effective_cpu_count()
     try:
         memcpy = _measure_memcpy_gbps()
     except Exception:

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -1,0 +1,378 @@
+"""gw#640: name a death the dying process cannot report.
+
+`worker_fatal` (0.56.1) covers every death Python can observe: an exception
+anywhere in boot/run, and the clean `return 0` from the run loop. RUN 9 of the
+th#1085 cold-boot gate produced SIX process restarts and ZERO `worker_fatal`
+rows, which proves the remaining class: the process dies BELOW Python — a
+signal (cgroup OOM SIGKILL, SIGSEGV in a C extension, an external kill). No
+`except` catches that and no in-process reporter can dial out after it.
+
+So the reporter is the NEXT process, not the dying one. Two carriers:
+
+  * the supervisor parent (``supervisor.py``) survives the child and reads its
+    ``waitpid`` status directly — WIFSIGNALED / WTERMSIG / WCOREDUMP;
+  * a boot record on the container filesystem covers the case where the whole
+    cgroup goes (``memory.oom.group``) or the container is restarted: the next
+    boot finds an unfinished record and reports it.
+
+Both carry the container's memory facts — ``memory.max`` vs ``memory.current``
+vs ``memory.peak``, and the ``memory.events`` ``oom_kill`` counter delta — so
+"the kernel OOM-killed us" is a fact in the report, not an inference.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+_GIB = 1024 ** 3
+
+# Default location of the boot record. Container-local and restart-persistent:
+# RunPod restarts the container in place, so this file outlives the death.
+BOOT_RECORD_PATH = Path(
+    os.environ.get("GEN_WORKER_BOOT_RECORD", "/tmp/gen-worker-boot-record.json")
+)
+
+
+def _cgroup_nodes(
+    root: Path = _CGROUP_ROOT, proc_self_cgroup: Path = _PROC_SELF_CGROUP
+) -> list[Path]:
+    """cgroup-v2 dirs from root down to this process's own cgroup."""
+    rel = ""
+    try:
+        for line in proc_self_cgroup.read_text().splitlines():
+            if line.startswith("0::"):
+                rel = line[3:].strip().strip("/")
+                break
+    except OSError:
+        pass
+    nodes = [root]
+    node = root
+    for part in Path(rel).parts:
+        node = node / part
+        nodes.append(node)
+    return nodes
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _read_int(path: Path) -> Optional[int]:
+    raw = _read_text(path)
+    if raw is None or raw == "max":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _read_keyed(path: Path) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    raw = _read_text(path)
+    if not raw:
+        return out
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            out[parts[0]] = int(parts[1])
+        except ValueError:
+            continue
+    return out
+
+
+def _deepest(name: str) -> Optional[Path]:
+    for node in reversed(_cgroup_nodes()):
+        p = node / name
+        if p.exists():
+            return p
+    return None
+
+
+def oom_kill_count() -> int:
+    """``memory.events`` oom_kill for this cgroup (0 when unreadable).
+
+    Counts kernel OOM kills in this cgroup since it was created. A delta
+    across a worker death is direct proof the kernel did it.
+    """
+    p = _deepest("memory.events")
+    if p is None:
+        return 0
+    events = _read_keyed(p)
+    return int(events.get("oom_kill", 0) or 0)
+
+
+def container_limits() -> Dict[str, Any]:
+    """Memory/CPU facts for the container we are actually running inside.
+
+    Everything the "we sized for a bigger box than we got" family of bugs
+    needs: the cgroup ceiling, what we are using against it, the high-water
+    mark, the OOM counters, and the CPU quota vs the host's core count (the
+    number ``os.cpu_count()`` reports, which is the HOST's, not ours).
+    """
+    facts: Dict[str, Any] = {}
+    mem_max = _deepest("memory.max")
+    mem_cur = _deepest("memory.current")
+    mem_peak = _deepest("memory.peak")
+    swap_max = _deepest("memory.swap.max")
+    facts["memory_max_bytes"] = _read_int(mem_max) if mem_max else None
+    facts["memory_current_bytes"] = _read_int(mem_cur) if mem_cur else None
+    facts["memory_peak_bytes"] = _read_int(mem_peak) if mem_peak else None
+    facts["memory_swap_max_bytes"] = _read_int(swap_max) if swap_max else None
+    ev = _deepest("memory.events")
+    facts["memory_events"] = _read_keyed(ev) if ev else {}
+    cpu_max = _deepest("cpu.max")
+    raw_cpu = _read_text(cpu_max) if cpu_max else None
+    facts["cpu_max"] = raw_cpu
+    facts["cpu_quota_cores"] = cpu_quota_cores()
+    facts["host_cpu_count"] = os.cpu_count() or 0
+    try:
+        facts["affinity_cpus"] = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        facts["affinity_cpus"] = None
+    meminfo = _read_meminfo()
+    facts["meminfo_total_kb"] = meminfo.get("MemTotal")
+    facts["meminfo_available_kb"] = meminfo.get("MemAvailable")
+    return facts
+
+
+def _read_meminfo(path: Path = Path("/proc/meminfo")) -> Dict[str, int]:
+    """``/proc/meminfo`` as {key: kB} ("MemTotal:  65...  kB" -> 3 fields)."""
+    out: Dict[str, int] = {}
+    raw = _read_text(path)
+    if not raw:
+        return out
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) < 2 or not parts[0].endswith(":"):
+            continue
+        try:
+            out[parts[0][:-1]] = int(parts[1])
+        except ValueError:
+            continue
+    return out
+
+
+def cpu_quota_cores() -> Optional[float]:
+    """Cores this cgroup may actually use, from ``cpu.max`` (None = uncapped).
+
+    ``os.cpu_count()`` reports the HOST's cores — 32 on a pod that owns 4.
+    Anything that sizes work by core count must use THIS number.
+    """
+    p = _deepest("cpu.max")
+    raw = _read_text(p) if p else None
+    if not raw:
+        return None
+    parts = raw.split()
+    if len(parts) != 2 or parts[0] == "max":
+        return None
+    try:
+        quota, period = int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+    if period <= 0 or quota <= 0:
+        return None
+    return quota / period
+
+
+def effective_cpu_count() -> int:
+    """Honest usable-core count: host cores min'd with affinity and quota."""
+    candidates = [os.cpu_count() or 1]
+    try:
+        candidates.append(len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        pass
+    quota = cpu_quota_cores()
+    if quota is not None:
+        candidates.append(max(1, int(quota + 0.5)))
+    return max(1, min(candidates))
+
+
+def describe_exit(status: int) -> Dict[str, Any]:
+    """Decode a ``waitpid`` status into a reportable verdict."""
+    out: Dict[str, Any] = {"raw_status": int(status)}
+    if os.WIFSIGNALED(status):
+        sig = os.WTERMSIG(status)
+        try:
+            name = signal.Signals(sig).name
+        except ValueError:
+            name = f"SIG{sig}"
+        out.update(
+            signaled=True,
+            signal=sig,
+            signal_name=name,
+            core_dumped=bool(os.WCOREDUMP(status)),
+            exit_code=128 + sig,
+        )
+    elif os.WIFEXITED(status):
+        out.update(signaled=False, exit_code=int(os.WEXITSTATUS(status)))
+    else:
+        out.update(signaled=False, exit_code=-1)
+    return out
+
+
+def _gb(value: Optional[int]) -> str:
+    if value is None:
+        return "unlimited"
+    return f"{value / _GIB:.2f}GiB"
+
+
+def format_detail(
+    *,
+    phase: str,
+    verdict: Dict[str, Any],
+    limits: Dict[str, Any],
+    oom_kill_delta: Optional[int] = None,
+    lifetime_s: Optional[float] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> str:
+    """One human-readable blob for the ``worker_fatal`` carrier's ``detail``."""
+    head = [f"phase={phase} exit_code={verdict.get('exit_code')}"]
+    if verdict.get("signaled"):
+        head.append(
+            f"KILLED BY SIGNAL {verdict.get('signal_name')}"
+            f"({verdict.get('signal')}) core_dumped={verdict.get('core_dumped')}"
+        )
+    else:
+        head.append(f"exited normally code={verdict.get('exit_code')}")
+    if lifetime_s is not None:
+        head.append(f"lifetime_s={lifetime_s:.1f}")
+    if oom_kill_delta is not None:
+        head.append(
+            f"cgroup_oom_kill_delta={oom_kill_delta}"
+            + ("  <-- THE KERNEL OOM-KILLED US" if oom_kill_delta > 0 else "")
+        )
+    head.append(
+        "memory.max=%s memory.current=%s memory.peak=%s swap.max=%s"
+        % (
+            _gb(limits.get("memory_max_bytes")),
+            _gb(limits.get("memory_current_bytes")),
+            _gb(limits.get("memory_peak_bytes")),
+            _gb(limits.get("memory_swap_max_bytes")),
+        )
+    )
+    head.append(
+        "cpu.max=%s quota_cores=%s host_cpu_count=%s affinity=%s"
+        % (
+            limits.get("cpu_max"),
+            limits.get("cpu_quota_cores"),
+            limits.get("host_cpu_count"),
+            limits.get("affinity_cpus"),
+        )
+    )
+    head.append(f"memory.events={json.dumps(limits.get('memory_events') or {}, sort_keys=True)}")
+    if limits.get("meminfo_total_kb"):
+        head.append(
+            "meminfo_total=%.2fGiB meminfo_available=%.2fGiB"
+            % (
+                (limits.get("meminfo_total_kb") or 0) / (1024 * 1024),
+                (limits.get("meminfo_available_kb") or 0) / (1024 * 1024),
+            )
+        )
+    if extra:
+        head.append(json.dumps(extra, sort_keys=True, default=str))
+    return "\n".join(head)
+
+
+# ---- boot record ----------------------------------------------------------
+#
+# Covers the death the supervisor parent cannot survive (memory.oom.group, an
+# external `docker kill`, the whole container going): the record is written at
+# boot and cleared on a clean exit, so an unfinished record found at the NEXT
+# boot IS the previous process's unreported death.
+
+
+def write_boot_record(path: Path = BOOT_RECORD_PATH, **extra: Any) -> None:
+    """Stamp this boot: pid, time, and the OOM counter to diff against."""
+    record = {
+        "pid": os.getpid(),
+        "boot_unix": time.time(),
+        "oom_kill_at_boot": oom_kill_count(),
+        "limits": container_limits(),
+    }
+    record.update(extra)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record, default=str))
+    except OSError:
+        pass
+
+
+def clear_boot_record(path: Path = BOOT_RECORD_PATH) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def take_boot_record(path: Path = BOOT_RECORD_PATH) -> Optional[Dict[str, Any]]:
+    """Read and consume a previous boot's record (None when absent/garbage)."""
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    clear_boot_record(path)
+    try:
+        record = json.loads(raw)
+    except ValueError:
+        return None
+    return record if isinstance(record, dict) else None
+
+
+def previous_boot_detail(path: Path = BOOT_RECORD_PATH) -> Optional[str]:
+    """A report for a previous process that vanished without clearing its
+    record — i.e. one killed so hard even the supervisor did not survive."""
+    record = take_boot_record(path)
+    if record is None:
+        return None
+    limits = container_limits()
+    before = int(record.get("oom_kill_at_boot") or 0)
+    now = oom_kill_count()
+    lifetime = None
+    try:
+        lifetime = max(0.0, time.time() - float(record.get("boot_unix") or 0.0))
+    except (TypeError, ValueError):
+        pass
+    return format_detail(
+        phase="previous_container_death",
+        verdict={"exit_code": None, "signaled": None},
+        limits=limits,
+        oom_kill_delta=max(0, now - before) if now >= before else None,
+        lifetime_s=lifetime,
+        extra={
+            "previous_pid": record.get("pid"),
+            "limits_at_previous_boot": record.get("limits"),
+            "note": (
+                "the previous process left an unfinished boot record: it died "
+                "without its supervisor surviving to report (whole-cgroup OOM "
+                "kill, container restart, or external kill)"
+            ),
+        },
+    )
+
+
+__all__ = [
+    "BOOT_RECORD_PATH",
+    "clear_boot_record",
+    "container_limits",
+    "cpu_quota_cores",
+    "describe_exit",
+    "effective_cpu_count",
+    "format_detail",
+    "oom_kill_count",
+    "previous_boot_detail",
+    "take_boot_record",
+    "write_boot_record",
+]

--- a/src/gen_worker/supervisor.py
+++ b/src/gen_worker/supervisor.py
@@ -1,0 +1,164 @@
+"""gw#640: a supervisor parent that outlives the worker and names its death.
+
+The worker process is the container's PID 1. When it is killed by a signal —
+cgroup OOM SIGKILL, SIGSEGV in a C extension, an external kill — there is no
+Python left to report anything, which is why six live runs of the th#1085
+cold-boot gate produced restarts and zero diagnostics.
+
+So we fork FIRST, before the heavy imports: the parent stays a few MiB of
+interpreter, the child is the worker. The parent forwards signals, waits, and
+on an abnormal exit reports ``WTERMSIG``/``WCOREDUMP`` plus the container's
+memory facts through the existing ``worker_fatal`` carrier — a durable
+``pod_events`` row on any already-deployed hub. It then exits with the child's
+status, so container-restart semantics are unchanged.
+
+Set ``GEN_WORKER_SUPERVISOR=0`` to run the worker in-process (local dev, or an
+escape hatch if a fork-hostile environment ever turns up).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from . import postmortem
+
+logger = logging.getLogger("WorkerSupervisor")
+
+_CHILD_ENV = "GEN_WORKER_SUPERVISED"
+_DISABLE_ENV = "GEN_WORKER_SUPERVISOR"
+# Where the parent mirrors its report when asked (tests, and a pod-side
+# forensic file that survives the report failing to reach the hub).
+_SINK_ENV = "GEN_WORKER_POSTMORTEM_FILE"
+
+_FORWARDED = (
+    signal.SIGTERM,
+    signal.SIGINT,
+    signal.SIGHUP,
+    signal.SIGQUIT,
+    signal.SIGUSR1,
+    signal.SIGUSR2,
+)
+
+
+def supervision_enabled() -> bool:
+    if os.environ.get(_DISABLE_ENV, "").strip() in ("0", "false", "no"):
+        return False
+    if os.environ.get(_CHILD_ENV):
+        return False
+    return hasattr(os, "fork")
+
+
+def _forward(child_pid: int) -> None:
+    def handler(signum: int, _frame: object) -> None:
+        try:
+            os.kill(child_pid, signum)
+        except ProcessLookupError:
+            pass
+
+    for sig in _FORWARDED:
+        try:
+            signal.signal(sig, handler)
+        except (OSError, ValueError):
+            pass
+
+
+def _wait_for(child_pid: int) -> int:
+    """Reap until OUR child exits; PID 1 also reaps reparented orphans."""
+    while True:
+        try:
+            pid, status = os.waitpid(-1, 0)
+        except InterruptedError:
+            continue
+        except ChildProcessError:
+            return 0
+        if pid == child_pid:
+            return status
+
+
+def _emit(detail: str) -> None:
+    logger.error("worker.postmortem\n%s", detail)
+    sink = os.environ.get(_SINK_ENV, "").strip()
+    if sink:
+        try:
+            Path(sink).write_text(detail)
+        except OSError:
+            logger.warning("post-mortem sink write failed", exc_info=True)
+    try:
+        from .config import get_settings
+        from .worker_fatal import report_worker_detail
+
+        delivered = report_worker_detail(get_settings(), detail)
+        logger.info("worker.postmortem wire report delivered=%s", delivered)
+    except Exception:
+        logger.warning("post-mortem wire report failed", exc_info=True)
+
+
+def report_previous_container_death(
+    record_path: Path = postmortem.BOOT_RECORD_PATH,
+) -> Optional[str]:
+    """Report a previous process whose supervisor did not survive either."""
+    detail = postmortem.previous_boot_detail(record_path)
+    if detail:
+        _emit(detail)
+    return detail
+
+
+def supervise(record_path: Path = postmortem.BOOT_RECORD_PATH) -> None:
+    """Parent: fork, wait, report, exit. Child: return and be the worker.
+
+    Called before the worker's heavy imports so the parent stays tiny — the
+    kernel's OOM killer picks the fat child, leaving the reporter alive.
+    """
+    if not supervision_enabled():
+        return
+
+    report_previous_container_death(record_path)
+    postmortem.write_boot_record(record_path)
+
+    started = time.time()
+    oom_before = postmortem.oom_kill_count()
+    try:
+        child_pid = os.fork()
+    except OSError:
+        logger.warning("fork failed; running the worker in-process", exc_info=True)
+        return
+    if child_pid == 0:
+        os.environ[_CHILD_ENV] = "1"
+        return  # the child continues into the worker
+
+    # The parent forked before the worker configured logging.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    _forward(child_pid)
+    status = _wait_for(child_pid)
+    verdict = postmortem.describe_exit(status)
+    clean = not verdict.get("signaled") and verdict.get("exit_code") == 0
+    if clean:
+        postmortem.clear_boot_record(record_path)
+    else:
+        oom_after = postmortem.oom_kill_count()
+        _emit(
+            postmortem.format_detail(
+                phase="worker_process_exit",
+                verdict=verdict,
+                limits=postmortem.container_limits(),
+                oom_kill_delta=max(0, oom_after - oom_before),
+                lifetime_s=time.time() - started,
+                extra={"child_pid": child_pid},
+            )
+        )
+        postmortem.clear_boot_record(record_path)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(int(verdict.get("exit_code") or 0))
+
+
+__all__ = ["report_previous_container_death", "supervise", "supervision_enabled"]

--- a/src/gen_worker/supervisor.py
+++ b/src/gen_worker/supervisor.py
@@ -81,7 +81,14 @@ def _wait_for(child_pid: int) -> int:
             return status
 
 
-def _emit(detail: str) -> None:
+def _emit(detail: str, *, dial: bool = True) -> None:
+    """Record a post-mortem. ``dial`` reaches the hub (bounded ~7s).
+
+    Only the deaths Python could not report itself are worth the dial: a
+    signal, or a previous container that vanished whole. An ordinary non-zero
+    exit already had 0.56.1's in-process `worker_fatal`, so re-dialing it would
+    only duplicate the row and add its budget to every failing boot's exit.
+    """
     logger.error("worker.postmortem\n%s", detail)
     sink = os.environ.get(_SINK_ENV, "").strip()
     if sink:
@@ -89,6 +96,8 @@ def _emit(detail: str) -> None:
             Path(sink).write_text(detail)
         except OSError:
             logger.warning("post-mortem sink write failed", exc_info=True)
+    if not dial:
+        return
     try:
         from .config import get_settings
         from .worker_fatal import report_worker_detail
@@ -153,7 +162,8 @@ def supervise(record_path: Path = postmortem.BOOT_RECORD_PATH) -> None:
                 oom_kill_delta=max(0, oom_after - oom_before),
                 lifetime_s=time.time() - started,
                 extra={"child_pid": child_pid},
-            )
+            ),
+            dial=bool(verdict.get("signaled")),
         )
         postmortem.clear_boot_record(record_path)
     sys.stdout.flush()

--- a/src/gen_worker/worker_fatal.py
+++ b/src/gen_worker/worker_fatal.py
@@ -110,6 +110,22 @@ def report_worker_fatal(
         return False
 
 
+def report_worker_detail(settings: Optional[Settings], detail: str) -> bool:
+    """Dial the hub with an already-formatted fatal detail (gw#640 post-mortem).
+
+    Same carrier and same durable `pod_events` row as `report_worker_fatal`;
+    used by the supervisor parent, which has a `waitpid` verdict rather than a
+    Python exception to report.
+    """
+    if settings is None or not (settings.orchestrator_public_addr or "").strip():
+        return False
+    try:
+        return asyncio.run(_report_async(settings, _build_report(settings, _clip(detail))))
+    except Exception:
+        logger.warning("worker-postmortem report failed entirely", exc_info=True)
+        return False
+
+
 def fatal_identity(settings: Settings) -> str:
     worker_id, release_id = _identity_from_settings(settings)
     return f"worker={worker_id or '?'} release={release_id or '?'}"

--- a/tests/harness/subprocess_runner.py
+++ b/tests/harness/subprocess_runner.py
@@ -53,6 +53,10 @@ def run_entrypoint(
         "ORCHESTRATOR_PUBLIC_ADDR": "192.0.2.1:1",
         "TENSORHUB_CACHE_DIR": str(tmp_path / "cache"),
         "ENDPOINT_LOCK_PATH": str(manifest_path),
+        # gw#640: the supervisor's boot record must not be shared between runs
+        # (its default is a fixed container-local path), or one boot reports
+        # the previous one's death and pays the report budget for it.
+        "GEN_WORKER_BOOT_RECORD": str(tmp_path / "boot-record.json"),
     }
     env.update(env_overrides or {})
 

--- a/tests/test_gw640_postmortem.py
+++ b/tests/test_gw640_postmortem.py
@@ -1,0 +1,122 @@
+"""gw#640: the supervisor must name a death that happens below Python.
+
+Real forks, real signals, real `waitpid` — the class of death that produced
+six silent restarts on the th#1085 cold-boot gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = textwrap.dedent(
+    """
+    import os, signal, sys
+    from pathlib import Path
+    from gen_worker.supervisor import supervise
+
+    supervise(Path(sys.argv[2]))
+    # only the child gets here
+    mode = sys.argv[1]
+    if mode == "segv":
+        os.kill(os.getpid(), signal.SIGSEGV)
+    elif mode == "kill":
+        os.kill(os.getpid(), signal.SIGKILL)
+    elif mode == "code":
+        os._exit(7)
+    os._exit(0)
+    """
+)
+
+
+def _run(mode: str, tmp_path: Path, *, record: Path | None = None):
+    script = tmp_path / "boot.py"
+    script.write_text(_SCRIPT)
+    sink = tmp_path / f"postmortem-{mode}.txt"
+    record = record or (tmp_path / f"record-{mode}.json")
+    env = dict(os.environ)
+    env["GEN_WORKER_POSTMORTEM_FILE"] = str(sink)
+    env.pop("GEN_WORKER_SUPERVISED", None)
+    env.pop("ORCHESTRATOR_PUBLIC_ADDR", None)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    proc = subprocess.run(
+        [sys.executable, str(script), mode, str(record)],
+        env=env, capture_output=True, text=True, timeout=120,
+    )
+    return proc, sink, record
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+@pytest.mark.parametrize(
+    "mode,signal_name,exit_code",
+    [("segv", "SIGSEGV", 139), ("kill", "SIGKILL", 137)],
+)
+def test_signal_death_is_named(tmp_path, mode, signal_name, exit_code):
+    proc, sink, record = _run(mode, tmp_path)
+    assert proc.returncode == exit_code
+    assert sink.exists(), proc.stderr
+    detail = sink.read_text()
+    assert f"KILLED BY SIGNAL {signal_name}" in detail
+    assert "cgroup_oom_kill_delta=" in detail
+    assert "memory.max=" in detail and "memory.current=" in detail
+    assert "cpu.max=" in detail and "host_cpu_count=" in detail
+    # the record is consumed so the next boot does not re-report this death
+    assert not record.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+def test_nonzero_exit_is_reported(tmp_path):
+    proc, sink, _ = _run("code", tmp_path)
+    assert proc.returncode == 7
+    assert sink.exists()
+    assert "exited normally code=7" in sink.read_text()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+def test_clean_exit_reports_nothing(tmp_path):
+    proc, sink, record = _run("ok", tmp_path)
+    assert proc.returncode == 0
+    assert not sink.exists()
+    assert not record.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+def test_previous_container_death_is_reported_on_next_boot(tmp_path):
+    """The whole cgroup can go (memory.oom.group) — then the NEXT boot reports."""
+    record = tmp_path / "leftover.json"
+    record.write_text(json.dumps({"pid": 4242, "boot_unix": 1.0, "oom_kill_at_boot": 0}))
+    proc, sink, _ = _run("ok", tmp_path, record=record)
+    assert proc.returncode == 0
+    assert sink.exists(), proc.stderr
+    detail = sink.read_text()
+    assert "previous_container_death" in detail
+    assert "4242" in detail
+    assert not record.exists()
+
+
+def test_container_limits_are_readable():
+    from gen_worker import postmortem
+
+    limits = postmortem.container_limits()
+    assert "memory_max_bytes" in limits
+    assert limits["host_cpu_count"] >= 1
+    assert postmortem.effective_cpu_count() >= 1
+    assert postmortem.effective_cpu_count() <= (os.cpu_count() or 1)
+
+
+def test_describe_exit_decodes_signals():
+    from gen_worker import postmortem
+
+    signaled = postmortem.describe_exit(os.WTERMSIG(9) if False else 9)
+    assert signaled["signaled"] is True
+    assert signaled["signal_name"] == "SIGKILL"
+    assert signaled["exit_code"] == 137
+    exited = postmortem.describe_exit(3 << 8)
+    assert exited["signaled"] is False
+    assert exited["exit_code"] == 3

--- a/tests/test_gw640_postmortem.py
+++ b/tests/test_gw640_postmortem.py
@@ -24,6 +24,13 @@ _SCRIPT = textwrap.dedent(
     supervise(Path(sys.argv[2]))
     # only the child gets here
     mode = sys.argv[1]
+    if mode == "term":
+        # drain semantics: the parent must forward SIGTERM to the child
+        got = []
+        signal.signal(signal.SIGTERM, lambda *_: got.append(1))
+        print("READY", flush=True)
+        signal.pause()
+        os._exit(0 if got else 3)
     if mode == "segv":
         os.kill(os.getpid(), signal.SIGSEGV)
     elif mode == "kill":
@@ -98,6 +105,29 @@ def test_previous_container_death_is_reported_on_next_boot(tmp_path):
     assert "previous_container_death" in detail
     assert "4242" in detail
     assert not record.exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+def test_sigterm_is_forwarded_to_the_worker(tmp_path):
+    """Drain must still work: PID 1 is the supervisor, the worker is the child."""
+    import signal as _signal
+
+    script = tmp_path / "boot.py"
+    script.write_text(_SCRIPT)
+    sink = tmp_path / "postmortem-term.txt"
+    env = dict(os.environ)
+    env["GEN_WORKER_POSTMORTEM_FILE"] = str(sink)
+    env.pop("GEN_WORKER_SUPERVISED", None)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    proc = subprocess.Popen(
+        [sys.executable, str(script), "term", str(tmp_path / "rec.json")],
+        env=env, stdout=subprocess.PIPE, text=True,
+    )
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "READY"
+    proc.send_signal(_signal.SIGTERM)
+    assert proc.wait(timeout=60) == 0
+    assert not sink.exists()
 
 
 def test_container_limits_are_readable():

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.56.1"
+version = "0.56.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cherry-pick of chaos `ebf0b9d` + version bump + CHANGELOG + relock. Nothing else from chaos is carried, so this is safe to pin without inheriting in-flight work (same discipline as 0.56.1).

## Why

0.56.1 instruments both death classes Python can observe (any exception -> `worker_fatal`; the clean `return 0` -> `UnexpectedWorkerExit`). th#1085 run 9 produced **six process restarts and ZERO `worker_fatal` rows**, which leaves exactly one class: the process is killed by a signal — cgroup OOM `SIGKILL`, `SIGSEGV` in a C extension, or an external kill. No `except` catches that and no in-process reporter can dial out after it.

So the reporter is the NEXT process.

## What

- `gen_worker/supervisor.py` — `python -m gen_worker.entrypoint` forks a supervisor **before** the heavy imports. The parent stays a bare interpreter (so the OOM killer picks the fat child, not the reporter), forwards `SIGTERM/INT/HUP/QUIT/USR1/USR2` to the child, reaps reparented orphans as PID 1, and exits with the child's status — container-restart semantics are unchanged. `GEN_WORKER_SUPERVISOR=0` opts out.
- On an abnormal child exit the parent reports through the existing `worker_fatal` carrier (`class='hardware_unsuitable' AND reason='worker_fatal'`, no proto change, no hub redeploy, works on hub pin `024c9125`): `WIFSIGNALED`/`WTERMSIG`/`WCOREDUMP`, plus `memory.max` vs `memory.current` vs `memory.peak`, `memory.swap.max`, `cpu.max`/quota vs host core count, `/proc/meminfo`, and the **`memory.events` `oom_kill` counter delta** — so "the kernel OOM-killed us" is a fact in the row, not an inference.
- `gen_worker/postmortem.py` — the cgroup/exit facts, plus a boot record on the container filesystem that covers the death the supervisor cannot survive (`memory.oom.group`, container restart, external kill): the next boot finds the unfinished record and reports it.
- Host canary: `vcpus` was `os.cpu_count()` — the HOST's count, 32 on a pod that owns 4 — shipped next to a cgroup-derived `ram_total_gb` of 14.9 GB. That "32 vCPUs / 14.9 GB" report is what sent the investigation looking for vCPU-derived RAM sizing (there is none: `probe_host_ram` mins meminfo with the cgroup cap, and the RAM floor is already adaptive). It now reports `min(host cores, sched_getaffinity, cpu.max quota)` and benchmarks with that many threads instead of oversubscribing the quota.

## Tests

`tests/test_gw640_postmortem.py` — real forks, real signals, real `waitpid`: SIGSEGV and SIGKILL children are named with the right signal and exit code (139/137), a non-zero exit is reported, a clean exit reports nothing and clears the record, and a leftover boot record is reported on the next boot. Plus a live smoke of the real `python -m gen_worker.entrypoint` supervising an actual failing boot.