### PR TITLE
release 0.56.3: gw#640 — a handler exception is no longer a dropped socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.56.3 (2026-07-24)
+
+- **gw#640: a message-handler exception is no longer indistinguishable from a
+  dropped socket — and this is the bug the last two instrument releases were
+  hunting.** `transport._recv_loop` awaits the handlers inline, so a raise while
+  handling (say) a `RunJob` propagated into `Transport.run()`'s catch-all and was
+  logged as `connection to <addr> failed`. The worker then reconnected with
+  backoff, forever; the hub, whose only death signal is a closed stream, reported
+  `young worker death lifetime=1s` and `requeue_exhausted: workers kept dying
+  mid-job`. The process was alive the entire time — which is why 0.56.1's
+  `worker_fatal`/`UnexpectedWorkerExit` and 0.56.2's post-mortem supervisor all
+  stayed silent across ten live th#1085 cold-boot runs: nothing ever escaped to
+  them and nothing ever exited. Proof from run 10: one unchanging
+  `worker_session_id`, `state_seq` climbing 14 -> 146, and six byte-identical
+  (process-cached) boot-canary payloads.
+  `HandlerError` now wraps handler raises with the offending message kind,
+  `run()` catches it as its own class, and `_report_handler_failure` dials the
+  existing `worker_fatal` carrier with `phase=message_handler:<kind>` plus the
+  traceback — a durable `pod_events` row on every hub pin already deployed, no
+  proto change and no hub redeploy. Deduped per (message kind, exception class)
+  so the reconnect loop cannot re-dial the same fault every cycle. Reconnect
+  behaviour is deliberately unchanged: this release unmasks the fault, it does
+  not change liveness policy.
+
 ## 0.56.2 (2026-07-24)
 
 - **gw#640: a post-mortem supervisor names the death that happens BELOW

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.56.2"
+version = "0.56.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -48,6 +48,28 @@ class FatalTransportError(Exception):
     """Unrecoverable protocol mismatch or persistent registration rejection."""
 
 
+class HandlerError(Exception):
+    """A MESSAGE HANDLER raised — this is not a transport failure (gw#640).
+
+    `_recv_loop` awaits the handlers inline, so a raise while handling (say) a
+    RunJob used to propagate into `run()`'s catch-all and be logged as
+    "connection to <addr> failed" — a handler bug wearing a dropped socket's
+    clothes. The worker then reconnected forever while the hub, whose only
+    death signal is a closed stream, reported `young worker death` and
+    `workers kept dying mid-job`. Ten live th#1085 runs and two prior
+    instrument releases (0.56.1 fatals, 0.56.2 post-mortem supervisor) found
+    nothing because the process never died and nothing ever escaped to them.
+
+    Carries which message was being handled so the report names it.
+    """
+
+    def __init__(self, kind: str, cause: BaseException) -> None:
+        super().__init__(f"handler for {kind or 'unknown'} raised: "
+                         f"{type(cause).__name__}: {cause}")
+        self.kind = kind or "unknown"
+        self.cause = cause
+
+
 def normalize_grpc_addr(addr: str, default_tls: Optional[bool] = None) -> Tuple[str, bool]:
     """Normalize a scheduler address into (host:port, use_tls).
 
@@ -445,6 +467,8 @@ class Transport:
         self._consecutive_auth_failures = 0
         self._first_auth_failure_at: Optional[float] = None
         self._connected_at: Optional[float] = None  # set on each HelloAck
+        # gw#640: (message kind, exception class) already dialed to the hub.
+        self._reported_handler_failures: set = set()
         # Latest hub-pushed worker JWT (TokenRefresh, contract §1 rotation).
         # Used by the live connection's successor dials: reconnects always
         # present the newest credential; the boot-time settings token is only
@@ -514,6 +538,38 @@ class Transport:
             return None
         return [("authorization", f"Bearer {token}")]
 
+    def _report_handler_failure(self, err: HandlerError) -> None:
+        """Log a handler failure as ITSELF and dial it to the hub (gw#640).
+
+        Reuses the `worker_fatal` carrier, so this lands as a durable
+        `pod_events` row on every hub pin already deployed — no proto change,
+        no hub redeploy. Deduped per (message kind, exception class): the
+        reconnect loop would otherwise re-dial the same fault every cycle.
+        The reconnect itself is unchanged — this release unmasks the fault, it
+        does not change liveness policy.
+        """
+        logger.error(
+            "HANDLER FAILURE while handling %s (this is NOT a connection "
+            "failure; the process is alive and will reconnect): %s: %s",
+            err.kind, type(err.cause).__name__, err.cause,
+            exc_info=err.cause,
+        )
+        key = (err.kind, type(err.cause).__name__)
+        if key in self._reported_handler_failures:
+            return
+        self._reported_handler_failures.add(key)
+        try:
+            from .worker_fatal import report_worker_fatal
+
+            delivered = report_worker_fatal(
+                self._settings, f"message_handler:{err.kind}", err.cause, exit_code=0,
+            )
+            logger.info(
+                "handler-failure report for %s delivered=%s", err.kind, delivered,
+            )
+        except Exception:
+            logger.warning("handler-failure report raised unexpectedly", exc_info=True)
+
     async def run(self) -> None:
         """Reconnect until stopped; fatal protocol/auth failures still exit."""
         attempt = 0
@@ -568,6 +624,9 @@ class Transport:
                     logger.warning("stream error %s: %s", code, details)
             except FatalTransportError:
                 raise
+            except HandlerError as e:
+                # gw#640: NEVER let this look like a dropped socket again.
+                self._report_handler_failure(e)
             except Exception as e:
                 logger.warning("connection to %s failed: %s: %s", target, type(e).__name__, e)
             finally:
@@ -695,7 +754,12 @@ class Transport:
             if which is None:
                 raise FatalTransportError("scheduler sent an unknown mandatory command")
             if which == "hello_ack":
-                await self._handlers.on_hello_ack(msg.hello_ack)
+                try:
+                    await self._handlers.on_hello_ack(msg.hello_ack)
+                except (FatalTransportError, asyncio.CancelledError):
+                    raise
+                except Exception as e:
+                    raise HandlerError(which, e) from e
                 continue
             if which == "token_refresh":
                 # Kubelet-style rotation (contract §1): swap the stored
@@ -711,4 +775,9 @@ class Transport:
                         msg.token_refresh.expires_at_unix,
                     )
                 continue
-            await self._handlers.on_message(msg)
+            try:
+                await self._handlers.on_message(msg)
+            except (FatalTransportError, asyncio.CancelledError):
+                raise
+            except Exception as e:
+                raise HandlerError(which, e) from e

--- a/tests/test_gw640_handler_launder.py
+++ b/tests/test_gw640_handler_launder.py
@@ -1,0 +1,121 @@
+"""gw#640: a message-handler exception must never wear a dropped socket's clothes.
+
+Ten live th#1085 runs read as "the worker keeps dying" because `_recv_loop`
+awaits the handlers inline and `run()`'s catch-all logged the raise as
+"connection to <addr> failed". The process was alive the whole time, so no
+in-process instrument could ever see it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.transport import HandlerError, Transport
+
+
+class _Handlers:
+    """Handlers whose on_message raises the way the live worker's did."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+        self.disconnects = 0
+
+    def build_hello(self):  # pragma: no cover - not reached in these tests
+        return pb.Hello()
+
+    async def on_hello_ack(self, ack):
+        return None
+
+    async def on_message(self, msg):
+        raise self.exc
+
+    async def on_disconnect(self):
+        self.disconnects += 1
+
+
+def _transport(handlers, settings) -> Transport:
+    return Transport(settings, handlers)
+
+
+def _settings():
+    from gen_worker.config import get_settings
+
+    return get_settings()
+
+
+def test_handler_exception_is_its_own_class_not_a_transport_error():
+    """The wrapper carries WHICH message and the original cause."""
+    err = HandlerError("run_job", ValueError("payload decode blew up"))
+    assert err.kind == "run_job"
+    assert isinstance(err.cause, ValueError)
+    assert "run_job" in str(err)
+    assert "ValueError" in str(err)
+    assert "payload decode blew up" in str(err)
+
+
+def test_recv_loop_wraps_handler_raise_and_names_the_message(monkeypatch):
+    """A RunJob handler raise surfaces as HandlerError(kind='run_job')."""
+    boom = RuntimeError("msgpack decode failed")
+    handlers = _Handlers(boom)
+    t = _transport(handlers, _settings())
+
+    run_job = pb.SchedulerMessage(run_job=pb.RunJob(request_id="r1", attempt=1))
+
+    class _Stream:
+        def __init__(self):
+            self.reads = [run_job]
+
+        async def read(self):
+            return self.reads.pop(0)
+
+    with pytest.raises(HandlerError) as caught:
+        asyncio.run(t._recv_loop(_Stream()))
+    assert caught.value.kind == "run_job"
+    assert caught.value.cause is boom
+
+
+def test_handler_failure_is_reported_through_the_worker_fatal_carrier(monkeypatch):
+    """It dials the hub (bounded), naming the phase after the message kind."""
+    t = _transport(_Handlers(RuntimeError("x")), _settings())
+    seen = {}
+
+    def _fake_report(settings, phase, exc, *, exit_code):
+        seen["phase"] = phase
+        seen["exc"] = exc
+        seen["exit_code"] = exit_code
+        return True
+
+    import gen_worker.worker_fatal as wf
+
+    monkeypatch.setattr(wf, "report_worker_fatal", _fake_report)
+
+    cause = RuntimeError("msgpack decode failed")
+    t._report_handler_failure(HandlerError("run_job", cause))
+    assert seen["phase"] == "message_handler:run_job"
+    assert seen["exc"] is cause
+
+    # deduped: the reconnect loop must not re-dial the same fault every cycle
+    seen.clear()
+    t._report_handler_failure(HandlerError("run_job", RuntimeError("msgpack decode failed")))
+    assert seen == {}
+
+    # a DIFFERENT fault still reports
+    t._report_handler_failure(HandlerError("run_job", ValueError("other")))
+    assert seen["phase"] == "message_handler:run_job"
+
+
+def test_transport_failures_are_still_plain_transport_failures():
+    """EOF from the scheduler stays a ConnectionError, not a HandlerError."""
+    import grpc
+
+    t = _transport(_Handlers(RuntimeError("unused")), _settings())
+
+    class _EofStream:
+        async def read(self):
+            return grpc.aio.EOF
+
+    with pytest.raises(ConnectionError):
+        asyncio.run(t._recv_loop(_EofStream()))

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.56.2"
+version = "0.56.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cherry-pick of chaos `0044cb7` + version bump + CHANGELOG + relock. Nothing else carried.

## This is the bug 0.56.1 and 0.56.2 were built to find

`transport._recv_loop` awaits the handlers **inline**, so a raise while handling a `RunJob` propagated into `Transport.run()`'s catch-all:

```python
except Exception as e:
    logger.warning("connection to %s failed: %s: %s", target, type(e).__name__, e)
```

A handler bug wearing a dropped socket's clothes. The worker reconnected forever; the hub — whose only death signal is a closed stream — reported `young worker death lifetime=1s` and `requeue_exhausted: workers kept dying mid-job`. **The process never died**, which is exactly why 0.56.1's `worker_fatal`/`UnexpectedWorkerExit` and 0.56.2's post-mortem supervisor were both silent across ten live th#1085 runs: nothing escaped to them and nothing exited.

Run 10 proof (all from one run's `/v1/admin/fleet-status`): a single unchanging `worker_session_id` across six connections, `state_seq` climbing 14 → 146 over 32s, and six **byte-identical** boot-canary payloads (the canary is process-cached, so a fresh process would re-measure).

## What changes

- `HandlerError(kind, cause)` wraps handler raises with the offending `msg.WhichOneof("msg")`.
- `run()` catches it as its own class — a handler failure can never again be logged as a connection failure.
- `_report_handler_failure` dials the existing `worker_fatal` carrier with `phase=message_handler:<kind>` + traceback: durable `pod_events` row on **every hub pin already deployed**, no proto change, no hub redeploy. Deduped per (kind, exception class) so the reconnect loop cannot re-dial the same fault each cycle.
- `FatalTransportError` and `CancelledError` pass through untouched; stream EOF stays a plain `ConnectionError`.
- **Reconnect behaviour is deliberately unchanged** — this unmasks the fault, it does not change liveness policy. (The reconnect-livelock on a permanently-failing handler is a real follow-up, sequenced separately.)

## Tests

`tests/test_gw640_handler_launder.py`: the wrapper names the message and keeps the cause; a real `_recv_loop` over a `RunJob` whose handler raises surfaces `HandlerError(kind='run_job')`; the report reaches the `worker_fatal` carrier with the right phase and dedupes correctly; and scheduler EOF is still a `ConnectionError`, not a handler failure. Existing `test_p1_stream_lifecycle` + `test_p6_cancel_stream_backpressure` (24 passed, 1 skipped) unaffected.