### PR TITLE
release 0.56.4: gw#640 — well-formed WAITING intents (the secondary half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.56.4 (2026-07-25)
+
+- **gw#640 (secondary half): a WAITING lifecycle intent always carries a
+  blocker, a retry time, or a deadline.** The hub's shadow validator requires
+  one of the three. Compat-synthesized intents (`ensure_local_intent` ->
+  `compat-materialize-*` / `compat-setup-*`) are minted OUTSIDE a
+  `DesiredStateCommand`, so they never received the command's `first_action`
+  deadline and carried none of the three — and that malformed state is what the
+  hub rejected on every reconnect for twelve consecutive th#1085 cold-boot runs
+  (it used to reject it by ENDING THE RPC, which is fixed hub-side). Guaranteed
+  now at `IntentRegistry.transition`, the single choke point, rather than at
+  each call site; an explicitly supplied blocker/retry/deadline is never
+  overwritten. Without this the hub correctly DROPS the snapshot, so the shadow
+  projection never converges even though the worker and its jobs are healthy.
+
 ## 0.56.3 (2026-07-24)
 
 - **gw#640: a message-handler exception is no longer indistinguishable from a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.56.3"
+version = "0.56.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/intent_registry.py
+++ b/src/gen_worker/intent_registry.py
@@ -14,6 +14,9 @@ from .pb import worker_scheduler_pb2 as pb
 _MAX_INTENTS = 128
 _MAX_RECEIPTS = 32
 _UNREPORTED_WAIT_TIMEOUT_S = 2.0
+# gw#640: fallback deadline for a WAITING state with no blocker and no retry
+# time. Mirrors the hub's shadow first-action budget (60s).
+_WAITING_DEADLINE_FALLBACK_MS = 60_000
 _ACTIVE_INTENT_STATES = {
     pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,
     pb.LIFECYCLE_INTENT_STATUS_WAITING,
@@ -641,6 +644,23 @@ class IntentRegistry:
             state.ClearField("blocker_request")
         else:
             state.blocker_request.CopyFrom(blocker_request)
+        # gw#640: a WAITING state MUST carry a blocker, a retry time, or a
+        # deadline — the hub's shadow validator requires one of the three, and
+        # compat-synthesized intents (compat-materialize-*, minted outside a
+        # DesiredStateCommand) had none, so they were rejected. Guarantee it at
+        # the single choke point instead of at each call site. (The hub no
+        # longer kills the stream over this as of the gw#640 hub fix; emitting
+        # well-formed state is still ours to get right.)
+        if int(status) == pb.LIFECYCLE_INTENT_STATUS_WAITING:
+            blocked = bool(state.blocker_intent_id) or bool(
+                state.blocker_request.request_id
+            )
+            if (
+                not blocked
+                and state.next_retry_at_unix_ms <= 0
+                and state.deadline_at_unix_ms <= 0
+            ):
+                state.deadline_at_unix_ms = now + _WAITING_DEADLINE_FALLBACK_MS
         if progress is None:
             state.ClearField("progress")
         else:

--- a/tests/test_gw640_handler_launder.py
+++ b/tests/test_gw640_handler_launder.py
@@ -119,3 +119,54 @@ def test_transport_failures_are_still_plain_transport_failures():
 
     with pytest.raises(ConnectionError):
         asyncio.run(t._recv_loop(_EofStream()))
+
+
+# --- gw#640 secondary half: stop EMITTING malformed shadow state ------------
+
+
+def test_waiting_intent_always_carries_blocker_retry_or_deadline():
+    """The hub's shadow validator requires one of the three on a WAITING state.
+
+    compat-synthesized intents (`compat-materialize-*`, minted by
+    ensure_local_intent OUTSIDE a DesiredStateCommand, so they never get the
+    command's first_action deadline) carried none of the three. That is the
+    exact snapshot the hub rejected for twelve straight th#1085 runs.
+    """
+    from gen_worker.intent_registry import IntentRegistry
+    from gen_worker.pb import worker_scheduler_pb2 as p
+
+    reg = IntentRegistry("release-1", ["artifact-stat"])
+    intent_id = reg.ensure_local_intent("materialize", "tensorhub/tiny:prod")
+    assert intent_id.startswith("compat-materialize-"), intent_id
+
+    reg.transition(
+        intent_id,
+        p.LIFECYCLE_INTENT_STATUS_WAITING,
+        p.LIFECYCLE_INTENT_STAGE_FETCHING,
+        reason=p.LIFECYCLE_WAIT_REASON_NETWORK_RETRY,
+    )
+    state = next(s for s in reg.snapshot().intents if s.intent_id == intent_id)
+    blocked = bool(state.blocker_intent_id) or bool(state.blocker_request.request_id)
+    assert blocked or state.next_retry_at_unix_ms > 0 or state.deadline_at_unix_ms > 0, (
+        "a WAITING intent with no blocker and no retry must get a fallback "
+        "deadline, or the hub rejects the whole snapshot"
+    )
+
+
+def test_explicit_waiting_fields_are_not_overwritten():
+    """The fallback must only fill a genuine gap."""
+    from gen_worker.intent_registry import IntentRegistry
+    from gen_worker.pb import worker_scheduler_pb2 as p
+
+    reg = IntentRegistry("release-1", ["artifact-stat"])
+    intent_id = reg.ensure_local_intent("materialize", "tensorhub/tiny:prod")
+    reg.transition(
+        intent_id,
+        p.LIFECYCLE_INTENT_STATUS_WAITING,
+        p.LIFECYCLE_INTENT_STAGE_FETCHING,
+        reason=p.LIFECYCLE_WAIT_REASON_NETWORK_RETRY,
+        next_retry_at_unix_ms=1234,
+    )
+    state = next(s for s in reg.snapshot().intents if s.intent_id == intent_id)
+    assert state.next_retry_at_unix_ms == 1234
+    assert state.deadline_at_unix_ms == 0, "an explicit retry time needs no deadline"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.56.3"
+version = "0.56.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cherry-pick of chaos `30cd866` onto v0.56.3 + version bump + CHANGELOG + relock. Deliberately branched from `v0.56.3` (not master head) so the proto stays identical to the th#1085 gate's hub pin `024c9125` — this is the worker pin the acceptance run needs.

## Why

gw#640's root cause is hub-side and is fixed on tensorhub chaos (`257743b4`): shadow-protocol validation must never terminate a live worker's RPC. **Run 13 proved that fix works** — one connection instead of six kills, stream alive 61s, and the first request `completed (status=JOB_STATUS_OK)` on attempt 1.

This is the other half: stop *emitting* the malformed shadow state in the first place. `ensure_local_intent` mints `compat-materialize-*` / `compat-setup-*` intents outside a `DesiredStateCommand`, so they never receive the command's `first_action_by` deadline. When such an intent goes WAITING with no blocker and no retry time it has none of the three fields the hub's validator requires, and the hub (correctly, now) DROPS the snapshot — so the shadow projection never converges even though the worker and its jobs are perfectly healthy.

Fixed at `IntentRegistry.transition`, the single choke point, rather than per call site. An explicitly supplied blocker / retry / deadline is never overwritten.

## Tests

`tests/test_gw640_handler_launder.py`:
- a real `compat-materialize-*` intent from `ensure_local_intent` transitioned to WAITING with only a reason now ends up with a deadline (was: nothing, hub-rejected);
- an explicit `next_retry_at_unix_ms` is preserved and no deadline is invented.

Intent/lifecycle/shadow suite: 46 passed, 1 skipped.