### PR TITLE
release 0.60.1: pgw#654 — first job on a converged v5 worker no longer kills the pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.60.1 (2026-07-25) — pgw#654: the false fleet-wide "model load failure"
+
+**Fixes the 0.56.0–0.60.0 defect that broke every real model release on the
+new floor (ie#544: qwen-image, z-image, ernie — 3/3 `release_broken` /
+`model_load_failure_streak`).** The worker loaded its models fine and went
+READY; the first real jobs then killed it: the post-RunJob residency re-pass
+asked `ensure_intent` for already-converged (terminal SUCCEEDED) command
+work, got `""` back by design, and `reported_await("")` armed `guard_await`'s
+2.0s unreported-wait fail-closed while `wait_idle()` blocked on the in-flight
+job — `UnreportedIntentWait` → `WORKER_PHASE_ERROR` exactly 2s after first
+dispatch → the hub counted a startup failure on a healthy worker and tripped
+the release breaker. Toy/CPU gates never caught it because their jobs finish
+inside the grace period.
+
+- `IntentRegistry.ensure_intent` now mints a worker-local compat carrier for
+  re-verified command work instead of returning `""` — every long await
+  stays reportable; the fail-closed guard remains for waits that genuinely
+  carry no intent id.
+- `apply_command` supersedes COMMAND-BORN intents only. Worker-local
+  job/setup/materialize obligations survive a generation bump — previously a
+  bump terminalized a live job's intent mid-flight.
+- Observability (the reason this took a fleet outage to see): every
+  `WORKER_PHASE_ERROR` entry now dials its cause through the gw#640
+  worker-fatal carrier (`Lifecycle._enter_error_phase` →
+  `report_worker_error_async`), so the hub persists a durable, queryable
+  `pod_events` row (class `hardware_unsuitable`, reason `worker_fatal`) with
+  the exception + traceback. The hub previously stored only
+  `detail="worker phase reported error"`, and the worker's lifecycle
+  snapshot carrying the failed intent was itself dropped by hub shadow
+  validation — double blindness.
+
 ## 0.60.0 (2026-07-25) — SDK v2: THE breaking cut (pgw#647)
 
 **HARD CUT, no compatibility window.** Design of record:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.60.0"
+version = "0.60.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/intent_registry.py
+++ b/src/gen_worker/intent_registry.py
@@ -390,6 +390,14 @@ class IntentRegistry:
         now = _now_ms()
         incoming_ids = {str(intent.intent_id) for intent in command.intents}
         for intent_id, state in self._intents.items():
+            # pgw#654: a command is a full replacement of COMMAND-OWNED work
+            # only. Worker-local compat obligations (job/setup/materialize
+            # carriers, never present in any hub command) must survive a
+            # generation bump — superseding them terminalized a LIVE job's
+            # intent mid-flight, so its next legal transition raised.
+            # Command-born intents are exactly the ids in _intent_digests.
+            if intent_id not in self._intent_digests:
+                continue
             if intent_id not in incoming_ids and int(state.status) in _ACTIVE_INTENT_STATES:
                 state.status = pb.LIFECYCLE_INTENT_STATUS_SUPERSEDED
                 state.updated_at_unix_ms = now
@@ -506,12 +514,22 @@ class IntentRegistry:
     ) -> str:
         """Find command-owned work or create a compatibility intent.
 
-        A current v5 command is a full replacement. Missing work under that
-        command is not fabricated: ``guard_await`` will fail it closed if the
-        corresponding await exceeds the reporting grace period.
+        pgw#654: this used to return "" whenever a v5 command was registered
+        but the matching intent was terminal (or absent) — "missing work is
+        not fabricated; guard_await fails it closed". That armed the 2.0s
+        unreported-wait bomb on every RECONCILE RE-PASS after convergence:
+        the pass's first await (``wait_idle``) blocks for the whole duration
+        of any in-flight tenant job, so the first real request on a freshly
+        converged pod drove the worker to WORKER_PHASE_ERROR two seconds in
+        (the hub then counted a "model load failure" on a healthy worker and
+        broke the release — the 0.58.0/0.60.0 fleet-wide false
+        ``model_load_failure_streak``). Re-verifying converged command work
+        is legitimate; it just needs a REPORTABLE carrier — so mint the same
+        worker-local compat intent the no-command path uses. guard_await's
+        fail-closed remains for waits that genuinely carry no intent id.
         """
         intent_id = self.intent_id(kind, function_name=function_name, ref=ref)
-        if intent_id or self._last_command_seq:
+        if intent_id:
             return intent_id
         identity = f"{int(kind)}\0{function_name}\0{ref}".encode()
         base_intent_id = f"compat-{hashlib.sha256(identity).hexdigest()[:24]}"

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -349,7 +349,10 @@ class Lifecycle:
                 # colocated legacy DesiredResidency. Mandatory rejection also
                 # withdraws aggregate readiness until the pod is replaced.
                 if self.intent_registry.protocol_rejected:
-                    self.phase = pb.WORKER_PHASE_ERROR
+                    self._enter_error_phase(
+                        "mandatory desired-state command rejected: "
+                        + str(receipt.detail or "")[:512]
+                    )
                 await self._send_lifecycle_snapshot(hello_ack=True, force=True)
                 self._last_delta = None
                 await self.maybe_send_state_delta(hello_ack=True)
@@ -394,7 +397,7 @@ class Lifecycle:
                     )
             except ConfigSnapshotWriteError as exc:
                 self.intent_registry.config_snapshot_failed(str(exc))
-                self.phase = pb.WORKER_PHASE_ERROR
+                self._enter_error_phase("config snapshot write failed", exc)
                 await self._send_lifecycle_snapshot(hello_ack=True, force=True)
                 self._last_delta = None
                 await self.maybe_send_state_delta(hello_ack=True)
@@ -561,8 +564,8 @@ class Lifecycle:
                     return
         except asyncio.CancelledError:
             return
-        except UnreportedIntentWait:
-            self.phase = pb.WORKER_PHASE_ERROR
+        except UnreportedIntentWait as exc:
+            self._enter_error_phase("residency reconcile", exc)
             self._last_delta = None
             await self.maybe_send_state_delta(force=True)
         finally:
@@ -785,8 +788,42 @@ class Lifecycle:
 
     def _config_snapshot_failed(self, detail: str) -> None:
         self.intent_registry.config_snapshot_failed(detail)
-        self.phase = pb.WORKER_PHASE_ERROR
+        self._enter_error_phase(f"config snapshot failed: {detail}")
         self.state_changed()
+
+    def _enter_error_phase(
+        self, reason: str, exc: Optional[BaseException] = None,
+    ) -> None:
+        """pgw#654 observability: every WORKER_PHASE_ERROR names its cause on
+        a durable channel. The hub persists only the bare phase flip
+        ("worker phase reported error" -> release breaker), and a worker's
+        lifecycle snapshot can be dropped by hub shadow validation — the
+        combination made the 0.58.0 fleet-wide breakage undiagnosable
+        (ie#544: signature="" detail="worker phase reported error"). Dial
+        the gw#640 worker-fatal carrier once per process, best-effort; the
+        hub stores it as a queryable pod_events row."""
+        from .worker_fatal import build_fatal_detail, report_worker_error_async
+
+        if exc is not None:
+            detail = build_fatal_detail(f"phase_error: {reason}", exc, exit_code=0)
+        else:
+            detail = f"phase=phase_error: {reason}"
+        logger.error("entering WORKER_PHASE_ERROR: %s", detail)
+        self.phase = pb.WORKER_PHASE_ERROR
+        # getattr: stubbed Lifecycles skip __init__ (same convention as
+        # _cancel_residency_reconcile, pgw#610).
+        if getattr(self, "_error_phase_reported", False):
+            return
+        self._error_phase_reported = True
+        settings = getattr(self, "_settings", None)
+
+        async def _dial() -> None:
+            await report_worker_error_async(settings, detail)
+
+        try:
+            asyncio.get_running_loop().create_task(_dial(), name="phase-error-report")
+        except RuntimeError:
+            pass
 
     async def _send_state_message(
         self,
@@ -1145,7 +1182,7 @@ class Lifecycle:
                 detail=str(exc)[:512],
                 error_code=pb.LIFECYCLE_ERROR_CODE_DRAIN_FAILED,
             )
-            self.phase = pb.WORKER_PHASE_ERROR
+            self._enter_error_phase("drain failed", exc)
             try:
                 await self.maybe_send_state_delta()
             except Exception:

--- a/src/gen_worker/worker_fatal.py
+++ b/src/gen_worker/worker_fatal.py
@@ -110,6 +110,23 @@ def report_worker_fatal(
         return False
 
 
+async def report_worker_error_async(settings: Optional[Settings], detail: str) -> bool:
+    """pgw#654: dial the hub from a STILL-LIVE worker that just entered
+    WORKER_PHASE_ERROR — same carrier and durable ``pod_events`` row as the
+    process-death fatal. The hub persists only the bare phase flip ("worker
+    phase reported error"), so without this the cause of a phase error was
+    unreachable (RunPod exposes no logs API, and a malformed lifecycle
+    snapshot is dropped by hub shadow validation). Best-effort on the
+    caller's running loop; opens its own short Connect like every report."""
+    if settings is None or not (settings.orchestrator_public_addr or "").strip():
+        return False
+    try:
+        return await _report_async(settings, _build_report(settings, _clip(detail)))
+    except Exception:
+        logger.warning("worker-error report failed entirely", exc_info=True)
+        return False
+
+
 def report_worker_detail(settings: Optional[Settings], detail: str) -> bool:
     """Dial the hub with an already-formatted fatal detail (gw#640 post-mortem).
 

--- a/tests/harness/slow_endpoints_pgw654.py
+++ b/tests/harness/slow_endpoints_pgw654.py
@@ -1,0 +1,45 @@
+"""pgw#654 fixture: a Slot endpoint whose setup outlasts the intent
+registry's 2.0s unreported-wait grace — the shape of every real model
+endpoint (multi-minute pipeline load), which no toy fixture had."""
+
+from __future__ import annotations
+
+import time
+
+import msgspec
+
+from gen_worker import Hub, RequestContext, Slot, endpoint
+from gen_worker.families.base import GenerationDefaults, family
+
+
+@family("harness-slowfam")
+class _SlowDefaults(GenerationDefaults, frozen=True):
+    steps: int = 7
+
+
+class SlowIn(msgspec.Struct):
+    text: str = ""
+    model: str = ""
+
+
+class SlowOut(msgspec.Struct):
+    response: str
+
+
+SLOW_DECLARED = Hub("harness/slow-pipeline", tag="prod")
+
+# Longer than _UNREPORTED_WAIT_TIMEOUT_S=2.0 with margin, short enough for a
+# unit test. Real endpoints take minutes here.
+SETUP_SLEEP_S = 4.0
+
+
+@endpoint(models={
+    "pipeline": Slot(str, default_checkpoint=SLOW_DECLARED),
+})
+class SlowSlotEndpoint:
+    def setup(self, pipeline: str) -> None:
+        time.sleep(SETUP_SLEEP_S)
+        self.pipeline_path = pipeline
+
+    def slow_slot_echo(self, ctx: RequestContext, data: SlowIn) -> SlowOut:
+        return SlowOut(response="ok")

--- a/tests/test_reconcile_busy_pgw654.py
+++ b/tests/test_reconcile_busy_pgw654.py
@@ -1,0 +1,282 @@
+"""pgw#654: the 0.58.0/0.60.0 fleet-wide false "model load failure".
+
+Live shape (ie#544, hub a838b34a): a pod converges its v5 shadow command
+(materialize SUCCEEDED, model on_disk), the first real jobs arrive, the
+post-RunJob residency re-pass asks ensure_intent for the now-TERMINAL
+command work, gets "" back, and reported_await("") arms guard_await's 2.0s
+unreported-wait bomb while wait_idle() blocks on the in-flight job ->
+UnreportedIntentWait -> WORKER_PHASE_ERROR -> the hub counts a startup
+failure on a HEALTHY worker -> model_load_failure_streak -> release_broken.
+3/3 releases (qwen-image, z-image, ernie) died exactly 2s after their first
+dispatch. Toy gates never saw it because their jobs finish inside the grace.
+
+The fix: ensure_intent mints a worker-local compat carrier for re-verified
+command work instead of returning "" (every long await stays reportable),
+and apply_command supersedes only COMMAND-BORN intents, never worker-local
+job/setup/materialize obligations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+
+import msgspec
+
+from gen_worker.intent_registry import IntentRegistry
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.blob_host import BlobHost
+from harness.hub_double import hub_double, is_ready
+from harness.toy_endpoints import EchoIn
+
+_REF_A = "harness/slow-pipeline"
+_REF_B = "harness/second-ref"
+_FN = "slow-slot-echo"
+_RELEASE = "rel-pgw654"
+
+
+def _shadow_command(
+    session_id: str, desired: pb.DesiredResidency,
+) -> pb.DesiredStateCommand:
+    """Mirror of tensorhub buildShadowDesiredStateCommand (a838b34a):
+    MATERIALIZE per disk ref + FUNCTION_READY per hot instance, all
+    mandatory, command_seq = desired generation, deterministic intent ids."""
+    now_ms = int(time.time() * 1000)
+    cmd = pb.DesiredStateCommand(
+        worker_session_id=session_id,
+        command_seq=desired.generation,
+        goal_id=f"goal-gen-{desired.generation}",
+        release_id=_RELEASE,
+        config_generation=desired.config_generation,
+        issued_at_unix_ms=now_ms,
+        accept_by_unix_ms=now_ms + 2_000,
+        first_action_by_unix_ms=now_ms + 60_000,
+        mandatory=True,
+    )
+    for i, ref in enumerate(desired.disk_refs):
+        digest = desired.snapshots[ref].digest if ref in desired.snapshots else ""
+        ident = hashlib.sha256(f"materialize|{ref}|{digest}".encode()).hexdigest()[:16]
+        cmd.intents.append(pb.DesiredIntent(
+            intent_id=f"intent-mat-{ident}",
+            kind=pb.DESIRED_INTENT_KIND_MATERIALIZE,
+            cause=pb.DESIRED_INTENT_CAUSE_PREPOSITION,
+            ref=ref,
+            snapshot_digest=digest.encode(),
+            desired_tier=pb.RESIDENCY_TIER_DISK,
+            priority=len(desired.disk_refs) - i,
+            mandatory=True,
+        ))
+    for i, instance in enumerate(desired.hot):
+        raw = instance.SerializeToString(deterministic=True)
+        bd = hashlib.sha256(raw)
+        cmd.intents.append(pb.DesiredIntent(
+            intent_id=f"intent-fn-{bd.hexdigest()[:16]}",
+            kind=pb.DESIRED_INTENT_KIND_FUNCTION_READY,
+            cause=pb.DESIRED_INTENT_CAUSE_COLD_BOOT,
+            function_name=instance.function_name,
+            desired_tier=pb.RESIDENCY_TIER_VRAM,
+            binding_digest=bd.digest(),
+            priority=len(desired.hot) - i,
+            mandatory=True,
+        ))
+    return cmd
+
+
+def test_first_job_on_converged_v5_worker_does_not_error(tmp_path) -> None:
+    """The live killer: converged command + in-flight >2s job + re-pass."""
+    blobs = BlobHost(tmp_path)
+    try:
+        snap_a = blobs.one_file_snapshot(
+            "snap-a", "blob-a", b"weights-a",
+            path_in_snapshot="transformer/weights.txt",
+        )
+        snap_b = blobs.one_file_snapshot(
+            "snap-b", "blob-b", b"weights-b",
+            path_in_snapshot="transformer/weights.txt",
+        )
+        with hub_double(
+            modules=("harness.toy_endpoints", "harness.slow_endpoints_pgw654"),
+        ) as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            session_id = conn.hello.worker_session_id
+
+            hot = [pb.DesiredInstance(
+                function_name=_FN,
+                models=[pb.ModelBinding(slot="pipeline", ref=_REF_A)],
+            )]
+            desired1 = pb.DesiredResidency(
+                generation=1, release_id=_RELEASE,
+                disk_refs=[_REF_A], hot=hot,
+                snapshots={_REF_A: snap_a},
+            )
+            conn.send(hello_ack=pb.HelloAck(
+                protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+                desired_residency=desired1,
+                desired_state_command=_shadow_command(session_id, desired1),
+            ))
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "state_delta"
+                and _FN in m.state_delta.available_functions,
+                timeout=30.0,
+            )
+
+            # FULL v5 convergence: the command's materialize intent must be
+            # terminal SUCCEEDED — the live pods' state at first dispatch.
+            def _mat_succeeded(m: pb.WorkerMessage) -> bool:
+                if m.WhichOneof("msg") != "lifecycle_snapshot":
+                    return False
+                return any(
+                    i.intent_id.startswith("intent-mat-") and i.status == 4
+                    for i in m.lifecycle_snapshot.intents
+                )
+
+            conn.wait_for(_mat_succeeded, timeout=30.0)
+
+            # First tenant job, runs well past the 2.0s grace.
+            conn.send(run_job=pb.RunJob(
+                request_id="r-long", attempt=1, function_name="slow-stream",
+                input_payload=msgspec.msgpack.encode(EchoIn(text="x")),
+            ))
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "job_accepted"
+                and m.job_accepted.request_id == "r-long"
+            )
+
+            # Generation bump mid-job (live: planner adds the sibling ref).
+            desired2 = pb.DesiredResidency(
+                generation=2, release_id=_RELEASE,
+                disk_refs=[_REF_A, _REF_B], hot=hot,
+                snapshots={_REF_A: snap_a, _REF_B: snap_b},
+            )
+            conn.send(hello_ack=pb.HelloAck(
+                protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+                desired_residency=desired2,
+                desired_state_command=_shadow_command(session_id, desired2),
+            ))
+
+            # The job must complete and the worker must NEVER report ERROR.
+            result = conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "job_result"
+                and m.job_result.request_id == "r-long",
+                timeout=30.0,
+            ).job_result
+            assert result.status == pb.JOB_STATUS_OK
+
+            errors = conn.count(
+                lambda m: m.WhichOneof("msg") == "state_delta"
+                and m.state_delta.phase == pb.WORKER_PHASE_ERROR
+            )
+            assert errors == 0, (
+                "worker reported WORKER_PHASE_ERROR — the pgw#654 false "
+                "model_load_failure regression is back"
+            )
+
+            # And the bumped desired state still converges after the job.
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "model_event"
+                and m.model_event.ref == _REF_B
+                and m.model_event.state == pb.MODEL_STATE_ON_DISK,
+                timeout=30.0,
+            )
+    finally:
+        blobs.shutdown()
+
+
+def test_ensure_intent_mints_carrier_for_terminal_command_work() -> None:
+    """ensure_intent never returns "" for re-verified command work."""
+    reg = IntentRegistry("rel-x", ["fn-a"])
+    cmd = pb.DesiredStateCommand(
+        worker_session_id=reg.worker_session_id, command_seq=1,
+        goal_id="goal-1", release_id="rel-x", mandatory=True,
+        issued_at_unix_ms=1, accept_by_unix_ms=2, first_action_by_unix_ms=3,
+        intents=[pb.DesiredIntent(
+            intent_id="mat-a", kind=pb.DESIRED_INTENT_KIND_MATERIALIZE,
+            cause=pb.DESIRED_INTENT_CAUSE_PREPOSITION, ref="refA",
+            snapshot_digest=b"d", desired_tier=pb.RESIDENCY_TIER_DISK,
+            mandatory=True,
+        )],
+    )
+    receipt = reg.apply_command(cmd)
+    assert receipt.status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+
+    # Command-owned while active.
+    assert reg.ensure_intent(
+        pb.DESIRED_INTENT_KIND_MATERIALIZE, ref="refA") == "mat-a"
+
+    reg.transition("mat-a", pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                   pb.LIFECYCLE_INTENT_STAGE_FETCHING)
+    reg.transition("mat-a", pb.LIFECYCLE_INTENT_STATUS_SUCCEEDED,
+                   pb.LIFECYCLE_INTENT_STAGE_ON_DISK)
+
+    # Terminal command work: a re-pass gets a live compat carrier, not "".
+    carrier = reg.ensure_intent(pb.DESIRED_INTENT_KIND_MATERIALIZE, ref="refA")
+    assert carrier and carrier != "mat-a"
+    assert reg.is_active(carrier)
+    # The carrier is transitionable (reported_await can report on it).
+    reg.transition(carrier, pb.LIFECYCLE_INTENT_STATUS_WAITING,
+                   pb.LIFECYCLE_INTENT_STAGE_WAIT_TENANT_IDLE,
+                   reason=pb.LIFECYCLE_WAIT_REASON_TENANT_WORK)
+
+
+def test_generation_bump_does_not_supersede_worker_local_intents() -> None:
+    """A command replaces command-owned work only; a live job/setup carrier
+    must survive the bump."""
+    reg = IntentRegistry("rel-x", ["fn-a"])
+
+    def cmd(seq: int, refs: list) -> pb.DesiredStateCommand:
+        c = pb.DesiredStateCommand(
+            worker_session_id=reg.worker_session_id, command_seq=seq,
+            goal_id=f"goal-{seq}", release_id="rel-x", mandatory=True,
+            issued_at_unix_ms=1, accept_by_unix_ms=2, first_action_by_unix_ms=3,
+        )
+        for ref in refs:
+            c.intents.append(pb.DesiredIntent(
+                intent_id=f"mat-{ref}", kind=pb.DESIRED_INTENT_KIND_MATERIALIZE,
+                cause=pb.DESIRED_INTENT_CAUSE_PREPOSITION, ref=ref,
+                snapshot_digest=b"d", desired_tier=pb.RESIDENCY_TIER_DISK,
+                mandatory=True,
+            ))
+        return c
+
+    assert reg.apply_command(cmd(1, ["refA"])).status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+    job_intent = reg.ensure_local_intent("job", "r1\x001", function_name="fn-a")
+    reg.transition(job_intent, pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                   pb.LIFECYCLE_INTENT_STAGE_READY, detail="executing")
+
+    assert reg.apply_command(cmd(2, ["refB"])).status == pb.GOAL_RECEIPT_STATUS_ACCEPTED
+
+    # Worker-local job carrier survived; the dropped command intent did not.
+    assert reg.is_active(job_intent), "generation bump killed a live job intent"
+    assert not reg.is_active("mat-refA"), "stale command intent not superseded"
+
+
+def test_enter_error_phase_dials_cause(monkeypatch) -> None:
+    """Every WORKER_PHASE_ERROR ships its cause on the gw#640 carrier."""
+    from gen_worker import worker_fatal
+    from gen_worker.lifecycle import Lifecycle
+
+    dialed: list = []
+
+    async def _fake_report(settings, detail):
+        dialed.append(detail)
+        return True
+
+    monkeypatch.setattr(worker_fatal, "report_worker_error_async", _fake_report)
+
+    lc = object.__new__(Lifecycle)  # stubbed Lifecycle (repo convention)
+    lc.phase = pb.WORKER_PHASE_READY
+    lc._settings = object()
+
+    async def _run() -> None:
+        lc._enter_error_phase("residency reconcile",
+                              RuntimeError("unreported protocol await: x"))
+        await asyncio.sleep(0)  # let the dial task run
+
+    asyncio.run(_run())
+    assert lc.phase == pb.WORKER_PHASE_ERROR
+    assert len(dialed) == 1
+    assert "unreported protocol await: x" in dialed[0]
+    assert "residency reconcile" in dialed[0]

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.60.0"
+version = "0.60.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Root cause and fix for the fleet-blocking 0.56.0–0.60.0 regression (ie#544: qwen-image / z-image / ernie, 3/3 `release_broken` / `model_load_failure_streak` on the 0.58.0 floor).

**What actually happened (locally reproduced against the real worker via the hub-double, and matching the live hub log second-for-second):** the pods loaded their models fine and went READY. The hub's shadow `DesiredStateCommand` converged (materialize intents SUCCEEDED). The first real jobs were then assigned, the post-RunJob residency re-pass asked `ensure_intent` for the now-terminal command work, got `""` back by design, and `reported_await("")` armed `guard_await`'s 2.0s unreported-wait fail-closed while `wait_idle()` blocked on the in-flight job → `UnreportedIntentWait` → `WORKER_PHASE_ERROR` exactly 2s after first dispatch → the hub counted a startup failure on a healthy worker and tripped the release breaker. Toy/CPU gates (th#1085 cold-boot) never caught it because their jobs finish inside the grace period.

- `ensure_intent` now mints a worker-local compat carrier for re-verified command work instead of returning `""`.
- `apply_command` supersedes command-born intents only; worker-local job/setup/materialize obligations survive a generation bump.
- Observability: every `WORKER_PHASE_ERROR` dials its cause through the gw#640 worker-fatal carrier → durable `pod_events` row (`reason=worker_fatal`) with the exception + traceback, queryable in one query.

Regression tests: `tests/test_reconcile_busy_pgw654.py` (hub-double e2e of the exact live sequence + registry unit tests + error-dial test). Full suite: 797 passed / 1 pre-existing load-flake (passes standalone). mypy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)