### PR TITLE
release 0.63.0: promotion train — th#1130 tail overlap, gw#661 retry rung, pgw#655/#656/#657 debt sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,31 @@
 
 ## 0.63.0 (2026-07-25) — debt sweep: a worker never advertises a model it does not have
 
-Three fleet-debt issues from Paul's audit (pgw#655 / #656 / #657). No endpoint
-changes; three behaviour changes worth reading before upgrading.
+Four fleet-debt issues from Paul's audit (pgw#655 / #656 / #657) plus the SDK half of
+ie#554 (pgw#663). One new public API; three behaviour changes worth reading before
+upgrading.
+
+### pgw#663 — one guarded URL fetch for endpoint code (NEW PUBLIC API; ie#554)
+
+`gen_worker.fetch_bytes` / `fetch_image` (and `url_fetch.open_guarded_stream`
+for streaming callers) replace the hand-rolled `urlopen(url).read()` that
+endpoints accepting caller URLs were each writing for themselves:
+
+- scheme, destination (private/loopback/link-local/metadata addresses refused)
+  and an optional host allowlist — caller-level plus a deployment-wide outer
+  bound in `GEN_WORKER_URL_FETCH_ALLOWED_HOSTS`;
+- **redirects are followed manually, with the policy re-applied to every hop.**
+  `urlopen` follows them silently, so a pre-flight check on the caller's URL
+  said nothing about where the bytes came from — a public URL 302-ing to the
+  cloud metadata service was the one-line bypass. `input_assets` had the same
+  hole on its caller-transport path and now goes through the same opener
+  (resolver-minted units keep their internal-object-host exemption);
+- a streamed byte cap that does not depend on the server declaring a size;
+- MIME matched against the SNIFFED type.
+
+Refusals are `ValidationError` (caller-caused), transport failures
+`RetryableError`. Documented limit: per-hop validation does not close DNS
+rebinding — see the module docstring.
 
 ### pgw#655 — READY-without-the-model, and a download bound that was off (P0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,128 @@
 # Changelog
 
+## 0.63.0 (2026-07-25) — debt sweep: a worker never advertises a model it does not have
+
+Three fleet-debt issues from Paul's audit (pgw#655 / #656 / #657). No endpoint
+changes; three behaviour changes worth reading before upgrading.
+
+### pgw#655 — READY-without-the-model, and a download bound that was off (P0)
+
+- **Boot prefetch failure now GATES the function.** A failed startup prefetch of
+  an hf/civitai-source ref used to log "failed terminally" and walk on to READY.
+  Function-shaped (`cls=None`) and non-inference functions are advertised
+  unconditionally, so the hub then dispatched paid GPU jobs that each
+  re-discovered the missing model as a per-request load failure. Those functions
+  now go `FnUnavailable(reason="model_unavailable", axes={"ref": …})` instead.
+  Per function, never the process: a sibling whose model landed keeps serving.
+  Hub-resolved slot refs are unaffected — they arrive by delivery, not prefetch.
+- **The HF download bound is a progress-RATE floor, not a wall clock.**
+  `_HF_DOWNLOAD_MAX_SECONDS` was `0.0` (off) for its entire life, and the stall
+  watchdog reset its window on ANY byte — so a trickle pinned
+  `DOWNLOADING_MODELS` forever. A transfer must now put
+  `_HF_DOWNLOAD_MIN_WINDOW_BYTES` (8 MiB) on disk within the 180s window or it
+  raises `DownloadStalledError`. That is ~46 KiB/s: three orders of magnitude
+  under any real pod link, and still 60+ hours for a 10GB checkpoint. The dead
+  wall-clock knob is deleted, not defaulted.
+
+### pgw#656 — dataset ingest never creates a duplicate it could have found
+
+`publish_dataset_revision`'s existing-dataset lookup had three ways to come back
+empty, and empty means CREATE:
+
+- a swallowed JSON-parse error **and** a non-2xx response that simply fell
+  through — both now raise (`AuthError` on 401/403, `RuntimeError` otherwise);
+- one unpaginated page (tensorhub defaults `limit` to 50) — now walks
+  `next_cursor` at the API's 200 cap, with a no-movement/page-ceiling guard;
+- `?tenant=`, which the hub's `listDatasets` never reads — now `?org=`.
+
+The `__cozy_kind__` / `__cozy_dataset_info__` / `__cozy_snapshot_manifest__`
+features_json squat needs hub columns first: tracked as th#1162.
+
+### pgw#657 — fail-loud hardening
+
+- `install_hf_http_timeouts()` now **proves** the huggingface_hub timeout floor
+  on the client hf will actually build, and raises `HfHttpFloorError` at boot if
+  it cannot. The patch reaches into hf's private backend (already reshaped once,
+  requests -> httpx); a silent revert puts the fleet back on infinite HTTP
+  timeouts (gw#456) with nothing to say so.
+- The gw#640 boot record picks a **durable** carrier
+  (`GEN_WORKER_BOOT_RECORD` > the model-cache volume > `/tmp`), detects a
+  tmpfs/ramfs carrier, records `carrier_volatile` in the record itself, and warns
+  loudly — a record on RAM is freed by the very OOM it exists to report.
+- `Source.iter_hf_components()` on a diffusers-singlefile source is now a typed
+  `ValidationError` naming the supported layouts, replacing a
+  `NotImplementedError` that the docstring promised worked.
+- Compile-evidence probes say why they failed: a silent
+  `has_inmemory_compiled_code` false negative kills a healthy compiled lane, and
+  a silently-degraded `runtime_key()` computes a different cell key than every
+  healthy pod (a guaranteed miss + re-mint).
+- Three inline `gc.collect` + `empty_cache` copies in the executor fold into
+  `models.memory.aflush_memory` (`reset_peak=False` — pgw#652's activation
+  learning reads `max_memory_allocated`).
+
+## 0.62.1 (2026-07-25) — gw#661: a retrying worker no longer reports itself failed
+
+A setup/warmup loss whose contract is "will be re-attempted" now reports
+`ACTIVITY_STATE_RUNNING` with a `retrying (attempt N/5)` detail instead of the
+`ACTIVITY_STATE_FAILED` terminal. Exhausting the budget reports FAILED and
+disables the function (`reason=retry_exhausted`), so the hub still gets the
+terminal truth.
+
+- **Premise correction.** gw#661 was filed as "`RetryableError` is mapped onto
+  startup `phase=error`". It is not: `WORKER_PHASE_ERROR` has exactly five
+  sources (mandatory-command rejection, config-snapshot write failure,
+  `UnreportedIntentWait` out of residency reconcile, config-snapshot failure,
+  drain failure) and none of them is the self-mint compile path. The signal the
+  incident actually quoted (`activity failed kind=self_mint_compile
+  phase=warmup_forward error=RetryableError: ... retrying`) is the
+  **ActivityUpdate** carrier, and that is the one that was lying.
+- **Why it condemned pods anyway.** The hub's th#1160 progress-aware verdict
+  reads `lastWorkerProgressLocked`, which *excludes* activities in state
+  `failed`. Declaring a will-retry attempt FAILED therefore erased exactly the
+  progress evidence that keeps a working pod alive — the worker was deleting its
+  own defense. Measured 2026-07-25: 4 condemnations, 4 self-mint compiles that
+  then COMPLETED, one finishing 53s after its pod was condemned.
+- `CompiledLaneUnavailableError` subclasses `RetryableError` but the worker does
+  give up on it (it disables every handler needing the unproven lane), so it
+  stays on the FAILED rung. Job-path `RetryableError` -> `JOB_STATUS_RETRYABLE`
+  is unchanged; `ConfigSnapshotWriteError` -> `WORKER_PHASE_ERROR` is unchanged
+  (nothing re-attempts a failed snapshot write worker-side).
+- No proto change: `WorkerPhase` and `ActivityState` are untouched, so this
+  needs no hub lockstep. A distinct `retrying` wire rung remains available as
+  follow-up if the hub ever wants to distinguish it from ordinary running.
+- The hub-side defenses (th#1157 debounce, th#1160 progress-aware verdict) stay.
+  They are correct independent of this fix — defense in depth.
+
+## 0.62.0 (2026-07-25) — th#1130: the image encode+upload tail overlaps the next request
+
+**No endpoint changes required.** `ctx.save_image` now DEFERS its encode +
+C2PA stamp + upload to the finalize tail: the executor releases the GPU permit
+at handler return (as it always did), then drains the deferred outputs, so the
+webp encode (~250ms for a 1024^2 frame, ~1.1s for 1328^2 at q95) and the upload
+run while the next request is already denoising. Previously they ran inside the
+handler, holding the permit — `finalize_wall_ms` was 0 on every image endpoint.
+
+- Why deferral and not a terminal marker: th#1107's
+  `_release_gpu_slot_for_finalize` is terminal and once-only, so it could not be
+  copied onto `save_image` — endpoints save mid-pipeline and in N-image loops,
+  and the first of N saves would have freed the permit with GPU work still to
+  come. The terminality signal already existed: the handler's RETURN. `save_image`
+  releases nothing; the executor's existing post-handler release is the seam.
+- Safety, by construction: pixels are SNAPSHOTTED at save (`image.copy()`, ~2ms
+  against a ~250ms encode) so mutate-after-save cannot change the upload;
+  reading a bytes field (`size_bytes`, `sha256`, `inline_bytes`, ...) inside the
+  handler forces the encode inline (correct, just not overlapped, and logged);
+  the drain runs before the OK result is built, so a failing encode fails the
+  request instead of shipping a hollow asset. Format validation and the ref's
+  extension stay EAGER (a bad `format=` still raises at the call).
+- Not armed for streaming handlers (they serialize items mid-handler), CLI runs
+  or endpoint unit tests — those stay exactly as they were.
+- th#1111: the stage window now covers the tail, so `image_encode`/
+  `credential_stamp`/`upload` land in `total.tail` and the map still closes
+  exactly against `runtime_ms`. `FINALIZE_OVERLAP` gained `handoff=handler|
+  executor`; `runtime_ms` is unchanged in meaning (the same work, reordered).
+- New: `gen_worker.io.image_format(format) -> (PIL format, extension)`.
+
 ## 0.61.0 (2026-07-25) — pgw#654: the objective/distilled vocabulary train (v2.1)
 
 **HARD CUT on the v2 vocabulary — the wave-1 endpoints (sdxl, z-image,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.61.0"
+version = "0.63.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -31,6 +31,7 @@ from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
 from .models.provision import arm_compile
 from .text_pin import TextLengthExceededError, pad_text_sequence
+from .url_fetch import FetchedUrl, fetch_bytes, fetch_image
 from .view import for_request
 from .api.errors import (
     CanceledError,
@@ -88,6 +89,9 @@ __all__ = [
     "arm_compile",
     # SDK v2 per-request views + text pinning.
     "for_request",
+    "FetchedUrl",
+    "fetch_bytes",
+    "fetch_image",
     "pad_text_sequence",
     "TextLengthExceededError",
     "HF",

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -191,6 +191,29 @@ class Activity:
             )
         _end(self)
 
+    def retrying(self, exc: BaseException, attempt: int, max_attempts: int) -> None:
+        """gw#661: this attempt lost, but the work is contractually
+        re-attempted — so the activity is still RUNNING, not FAILED.
+
+        FAILED is the hub's terminal rung: ``lastWorkerProgressLocked``
+        (th#1160) excludes failed activities from progress evidence, so a
+        will-retry attempt that reports FAILED erases exactly the evidence
+        that keeps a working pod alive. Measured 2026-07-25: 4 condemnations,
+        4 self-mint compiles that then COMPLETED. Only exhaustion is failure.
+        """
+        if self._done:
+            _end(self)
+            return
+        self._done = True
+        self._report(
+            pb.ActivityState.ACTIVITY_STATE_RUNNING,
+            detail=(
+                f"retrying (attempt {attempt}/{max_attempts}): "
+                f"{type(exc).__name__}: {exc}"
+            )[:2000],
+        )
+        _end(self)
+
 
 def begin(kind: str, phase: str = "") -> Activity:
     global _current

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -22,6 +22,9 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import msgspec
+from msgspec import structs
+
+from ..models.refs import HuggingFaceRef, fold_ref, normalize_model_ref, parse_model_ref
 
 ModelSource = Literal["tensorhub", "huggingface", "civitai", "modelscope"]
 
@@ -245,7 +248,6 @@ def wire_ref(binding: Binding) -> str:
     ``#flavor`` suffixes; HF refs carry ``@revision``. Load-time metadata
     (dtype/subfolder/files/storage_dtype) never enters the ref.
     """
-    from ..models.refs import HuggingFaceRef, fold_ref
 
     if binding.source == "tensorhub":
         # The default tag never overrides one embedded in ``ref``.
@@ -277,9 +279,6 @@ def rebind_pick(
     struct always accepts the field (msgspec has no per-source shape), so the
     round-trip mismatch is the enforcement point.
     """
-    from msgspec import structs
-
-    from ..models.refs import fold_ref, normalize_model_ref, parse_model_ref
 
     if resolved_ref:
         parsed = parse_model_ref(resolved_ref)

--- a/src/gen_worker/api/compile_axis.py
+++ b/src/gen_worker/api/compile_axis.py
@@ -229,7 +229,7 @@ def extract_payload_axes(owner: str, payload_type: type) -> Tuple[PayloadAxis, .
 def warm_guidance_values(axes: Sequence[PayloadAxis]) -> Tuple[float, ...]:
     """The warm representatives of the guidance axis, when one is declared.
 
-    Compile warm calls key CFG regimes off the ``guidance_scale`` /
+    Compile warm calls key CFG graph classes off the ``guidance_scale`` /
     ``guidance`` / ``cfg`` payload field's declared classes — the v2
     replacement for the deleted ``Compile(guidance_scales=...)`` tuple.
     """

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -41,6 +41,9 @@ import msgspec
 from .binding import BINDING_TYPES, Binding
 from .formula import RuntimeFormula
 from .slot import OBJECTIVES, Slot
+from ..models import lanes as lanespec
+from ..runtimes.server import ServerHandle
+from .tree import is_introspectable
 
 T = TypeVar("T")
 SlotLike = Union[Binding, Slot]
@@ -276,7 +279,6 @@ def _validate_handles(owner: str, handles: Any) -> Tuple[str, ...]:
     behavioral divergence only, never inventory. Tokens are concrete lane
     BODIES (no `+eager|+compiled`: execution is platform-managed). Nothing
     declared = fully platform-managed lanes, exactly as before."""
-    from ..models import lanes as lanespec
 
     if handles is None:
         return ()
@@ -547,7 +549,7 @@ class Compile(msgspec.Struct, frozen=True):
     declare the axis dynamic via ``dynamic=(DynamicDim("sequence", min=...,
     max=...),)``.
 
-    CFG regimes are graph shapes too, but they are a PAYLOAD-FIELD fact:
+    CFG graph classes are graph shapes too, but they are a PAYLOAD-FIELD fact:
     annotate the guidance field with :class:`~gen_worker.CompileAxis`
     equivalence classes (``Compile(guidance_scales=...)`` is deleted in
     v2). The warm plan derives from the cross-product of axis classes x
@@ -863,7 +865,6 @@ def _is_server_handle_param(p: inspect.Parameter) -> bool:
     ann = p.annotation
     if ann is inspect.Parameter.empty:
         return False
-    from ..runtimes.server import ServerHandle
 
     if ann is ServerHandle:
         return True
@@ -973,7 +974,6 @@ def _validate_lora_state_dict(owner: str, slots: Dict[str, Slot], lora_bucket: i
     pipeline class is endpoint-internal) and are skipped."""
     if not lora_bucket or not slots:
         return
-    from .tree import is_introspectable
 
     roots = [s for s in slots.values() if s.root]
     root = roots[0] if roots else slots.get("pipeline") or (

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -122,7 +122,7 @@ class CalloutClient:
         tier: Optional[str] = None,
     ) -> str:
         """Submit one child request; returns its request id."""
-        import requests
+        import requests  # lazy (all sites): callout is on the `import gen_worker` path; stays requests-free
 
         endpoint = (endpoint or "").strip().strip("/")
         if "/" not in endpoint:

--- a/src/gen_worker/capability_renewal.py
+++ b/src/gen_worker/capability_renewal.py
@@ -14,6 +14,7 @@ import time
 from typing import Callable, Optional, Tuple
 
 from .request_context import _decode_unverified_jwt_claims
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,6 @@ def renew_once(
     Raises ``RenewDenied`` on terminal refusals (401/403/404/409) and
     ``RuntimeError`` on transient failures (5xx / malformed response).
     """
-    import requests
 
     url = f"{file_base_url.rstrip('/')}/v1/worker/capability/renew"
     resp = requests.post(

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -127,7 +127,7 @@ def from_axes(axes: Mapping[str, str]) -> CellKey:
 
 
 def _canonical_lane(weight_lane: str, lora_bucket: int = 0) -> str:
-    from . import compile_cache as cc
+    from . import compile_cache as cc  # cycle: compile_cache imports cell_key
 
     base, observed = cc.lane_bucket(str(weight_lane or ""))
     bucket = observed or int(lora_bucket or 0)
@@ -170,7 +170,7 @@ def compute(
     :class:`CellKeyError` when a required axis is unavailable — callers on
     non-CUDA runtimes simply have no key.
     """
-    from . import compile_cache as cc
+    from . import compile_cache as cc  # cycle: compile_cache imports cell_key
 
     rt = cc.runtime_key()
     if image_digest is None:

--- a/src/gen_worker/cli/families.py
+++ b/src/gen_worker/cli/families.py
@@ -22,6 +22,7 @@ import json
 import sys
 from pathlib import Path
 from typing import Any
+from ..families import export_all_schemas, schema_filename
 
 
 def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
@@ -60,8 +61,6 @@ def _handle_export_schemas(args: argparse.Namespace) -> int:
         except Exception as e:
             sys.stderr.write(f"gen-worker families export-schemas: failed to import {args.module!r}: {e}\n")
             return 2
-
-    from ..families import export_all_schemas, schema_filename
 
     schemas = export_all_schemas()
     if not schemas:

--- a/src/gen_worker/cli/invoke.py
+++ b/src/gen_worker/cli/invoke.py
@@ -36,6 +36,7 @@ from typing import Any, List, Optional
 from . import run as run_mod
 from . import transport
 from .serve import DEFAULT_SOCKET_PATH
+from .args import ArgError, build_payload, looks_like_field_token
 
 
 # --------------------------------------------------------------------------
@@ -218,7 +219,6 @@ def _resolve_payload(args: argparse.Namespace) -> Any:
     A single JSON/@file/- blob takes the thin path. Otherwise the tokens are
     ergonomic ``field=value`` args coerced against the function's schema (#350).
     """
-    from .args import ArgError, build_payload, looks_like_field_token
 
     tokens: List[str] = list(getattr(args, "args", []) or [])
     if not tokens:

--- a/src/gen_worker/cli/listing.py
+++ b/src/gen_worker/cli/listing.py
@@ -14,6 +14,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import msgspec
 
 from .protocol import CAPABILITIES, PROTOCOL_VERSION, gen_worker_version
+from ..api.binding import ModelRef
+from ..models.hub_policy import detect_worker_capabilities
+from ..models.memory import get_available_vram_gb
+from ..models.hub_policy import (FIT_EMERGENCY, FIT_EMERGENCY_FP8, FIT_GGUF, FIT_OFFLOAD, TensorhubWorkerCapabilities, variant_fit)
 
 if TYPE_CHECKING:
     from .run import _SelectedFunction
@@ -21,7 +25,6 @@ if TYPE_CHECKING:
 
 def describe_binding(binding: Any) -> Dict[str, Any]:
     """Introspect one model binding into a JSON-able dict (no model load)."""
-    from ..api.binding import ModelRef
 
     if isinstance(binding, ModelRef):
         out: Dict[str, Any] = {
@@ -78,8 +81,6 @@ def _describe_resources(resources: Any) -> Dict[str, Any]:
 def detected_capabilities() -> Dict[str, Any]:
     """This machine's capabilities block (#380): SM, torch/cuda, installed
     quant libs, free VRAM. Imports torch; loads no model."""
-    from ..models.hub_policy import detect_worker_capabilities
-    from ..models.memory import get_available_vram_gb
 
     caps = detect_worker_capabilities()
     out = caps.to_dict()
@@ -133,14 +134,6 @@ def function_entries(
     ``serve --list-functions --json``. With ``detected`` (the
     ``detected_capabilities()`` block), each entry carries a ``fit`` verdict
     (``fits | offload | incompatible``) computed from its ``Resources``."""
-    from ..models.hub_policy import (
-        FIT_EMERGENCY,
-        FIT_EMERGENCY_FP8,
-        FIT_GGUF,
-        FIT_OFFLOAD,
-        TensorhubWorkerCapabilities,
-        variant_fit,
-    )
 
     caps: Optional[TensorhubWorkerCapabilities] = None
     free_gb = 0.0

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -37,6 +37,7 @@ from ..request_context import (
     RequestContext,
     TrainingContext,
 )
+from ..models.cache_paths import tensorhub_cas_dir
 
 
 _LOCAL_OUTPUT_DIR_NAME = ".gen-worker-run"
@@ -148,7 +149,6 @@ class LocalConversionContext(LocalRequestContextMixin, ConversionContext):
         # Local stub: look in the tensorhub CAS for a matching snapshot. If
         # nothing's there we can't materialize — surface a typed error so
         # the tenant adjusts (run without --offline first, or seed the CAS).
-        from ..models.cache_paths import tensorhub_cas_dir
         d = (digest or "").strip()
         if not d:
             raise ValueError("materialize_blob: empty digest")
@@ -171,7 +171,6 @@ class LocalDatasetContext(LocalRequestContextMixin, DatasetContext):
 
     def materialize_blob(self, digest: str, dest: "str | os.PathLike[str]") -> Path:
         # Same fallback as ConversionContext.
-        from ..models.cache_paths import tensorhub_cas_dir
         d = (digest or "").strip()
         if not d:
             raise ValueError("materialize_blob: empty digest")

--- a/src/gen_worker/cli/prefetch.py
+++ b/src/gen_worker/cli/prefetch.py
@@ -24,6 +24,10 @@ import sys
 from typing import Any, Dict, Tuple
 
 from ..api.binding import ModelRef
+from ..api.binding import wire_ref
+from ..models.gguf_local import maybe_rebind_gguf
+from ..models.provision import resolve_local_path
+from .run import (_collect_class_methods, _ensure_sys_path, _load_project_main)
 
 
 def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
@@ -50,14 +54,6 @@ def add_subparser(sub: "argparse._SubParsersAction[Any]") -> None:
 
 def _handle_prefetch(args: argparse.Namespace) -> int:
     # Reuse run's discovery + the shared hub-less resolver (models/provision).
-    from ..api.binding import wire_ref
-    from ..models.gguf_local import maybe_rebind_gguf
-    from ..models.provision import resolve_local_path
-    from .run import (
-        _collect_class_methods,
-        _ensure_sys_path,
-        _load_project_main,
-    )
 
     if args.json:
         def emit(ev: Dict[str, Any]) -> None:

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -29,6 +29,15 @@ import msgspec
 from ..api.errors import CanceledError
 from ..models import provision
 from .local_context import build_local_context
+from ..discovery.project import load_project_config
+from gen_worker.registry import collect_from_namespace
+from .args import ArgError, build_payload
+from ..api.slot import resolve_slot
+from ..models import lanes as lanespec
+from ..api.binding import rebind_pick
+from .serve import DEFAULT_SOCKET_PATH
+from . import invoke as invoke_mod
+from .local_context import _stderr_emitter
 
 
 # Exit codes — tracked here for one-line reference. Mirrors progress.json #12.
@@ -151,7 +160,6 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
 
 def _load_project_main(config_path: Optional[str]) -> Tuple[Path, str]:
     """Return ``(project_root, main_module)`` from pyproject [tool.gen_worker]."""
-    from ..discovery.project import load_project_config
 
     try:
         cfg = load_project_config(config_path)
@@ -221,7 +229,6 @@ def _collect_class_methods(mod: Any) -> List[_SelectedFunction]:
     """Collect every routable function on every @endpoint object in a module
     namespace. Delegates signature inspection to ``gen_worker.registry`` — the
     one walker shared with the worker runtime and build-time discovery."""
-    from gen_worker.registry import collect_from_namespace
 
     return [
         _SelectedFunction(
@@ -341,7 +348,6 @@ def _apply_field_tokens(
     """
     if not fields:
         return raw_bytes
-    from .args import ArgError, build_payload
 
     try:
         base = json.loads(raw_bytes.decode("utf-8") or "{}")
@@ -683,7 +689,6 @@ def _resolve_ctx_slots(ctx: Any, selected: "_SelectedFunction") -> None:
     ever arrives, so every Slot resolves to the NEUTRAL schema defaults of
     the handler's derived config schema (``RequestContext[D]``) — exactly
     the hub's own neutral stamp, so hub-less and production agree."""
-    from ..api.slot import resolve_slot
 
     spec = getattr(selected, "spec", None)
     defaults_cls = getattr(spec, "defaults_type", None)
@@ -715,7 +720,6 @@ def _local_executing_lane(
     """th#1050 ctx.lane for local runs: a --lane the endpoint DECLARES wins
     (author kernels execute it); otherwise the most-quantized binding's lane
     (the local twin of Executor._served_lane, eager execution)."""
-    from ..models import lanes as lanespec
 
     if lane_str and handles:
         try:
@@ -744,8 +748,6 @@ def _apply_lane_to_bindings(bindings: Dict[str, Any], lane_str: str) -> Dict[str
     lane (per-layer fp8 storage); an explicit fp8-w8a8 descriptor folds the
     #fp8-w8a8 flavor (fails loudly if unpublished at resolve time); 4bit
     lanes need an exact ref#flavor and are refused here."""
-    from ..api.binding import rebind_pick
-    from ..models import lanes as lanespec
 
     try:
         req = lanespec.parse_lane_spec(lane_str)
@@ -866,7 +868,6 @@ def _handle_run(args: argparse.Namespace) -> int:
 def _warm_serve_socket() -> Optional[Path]:
     """Return the default serve socket path if a warm ``gen-worker serve``
     is listening, else None. Used by the explicit ``--attach`` flag."""
-    from .serve import DEFAULT_SOCKET_PATH
 
     sock = Path(DEFAULT_SOCKET_PATH).resolve()
     try:
@@ -885,7 +886,6 @@ def _run_via_warm_serve(
     class/method, but serve addresses by FUNCTION NAME — so we still import the
     module to resolve the selected function's wire name (cheap; no model load).
     """
-    from . import invoke as invoke_mod
 
     _root, mod = load_endpoint_module(
         config_path=args.config_path, module=args.module,
@@ -1009,8 +1009,6 @@ def _run_inner(args: argparse.Namespace) -> int:
         raw_bytes = _inject_default_source(
             raw_bytes, selected.payload_type, source_path,
         )
-
-    from .local_context import _stderr_emitter
 
     # 4. Build the local context for this kind.
     ctx = build_local_context(

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -56,6 +56,8 @@ from . import run as run_mod
 from . import transport
 from .local_context import _stderr_emitter, build_local_context
 from .protocol import PROTOCOL_VERSION, gen_worker_version
+from ..api.binding import BINDING_TYPES
+from ..models import provision
 
 
 DEFAULT_SOCKET_PATH = "./.gen-worker.sock"
@@ -586,7 +588,6 @@ def _resolve_static_models(
     All bindings are static picks now; resolved at boot so weights land in
     VRAM during ``setup()``.
     """
-    from ..api.binding import BINDING_TYPES
 
     static = {
         k: v for k, v in (bindings or {}).items()
@@ -594,7 +595,6 @@ def _resolve_static_models(
     }
     if not static:
         return {}
-    from ..models import provision
 
     return provision.resolve_bindings(
         static, offline=offline, emit=_stderr_emitter,

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -23,7 +23,7 @@ are CODE: only the platform's first-party compile job publishes shared ones.
 Artifact = deterministic ``.tar.gz``::
 
     metadata.json      key: family, sku/torch/triton/cuda, shapes, targets,
-                       image guidance regimes, diffusers/transformers
+                       image guidance classes, diffusers/transformers
                        versions (+ source_ref info)
     inductor/**        TORCHINDUCTOR_CACHE_DIR contents
     triton/**          TRITON_CACHE_DIR contents
@@ -62,7 +62,19 @@ from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
+import inspect
+import pickle
+import sys
+
+from . import cell_key, hot_swap
 from .api.errors import RetryableError
+from .models import w8a8_lora
+from .models.loading import load_from_pretrained, pipeline_weight_lane
+from .models.loading import pipeline_weight_lane as _traced_lane
+from .models.memory import low_vram_mode, place_pipeline, reconcile_resident_mode
+from .models.refs import parse_model_ref
+from .models.w8a8_lora import RANK_BUCKETS
+from .registry import CompileCell
 
 logger = logging.getLogger(__name__)
 
@@ -144,10 +156,19 @@ def has_inmemory_compiled_code(pipeline: Any) -> bool:
     marker = getattr(pipeline, _MARKER_ATTR, None)
     if not marker:
         return False
+    # pgw#657: every `return False` below is a NEGATIVE compile-proof verdict,
+    # and a false negative here kills a healthy compiled lane (the pgw#637 /
+    # gw#603 class). A probe that fails must therefore say WHY — silently it
+    # is indistinguishable from "nothing was ever compiled".
     try:
         from torch._dynamo import eval_frame
     except Exception:
+        logger.warning(
+            "compile-cache: torch._dynamo.eval_frame unavailable — in-memory "
+            "compile evidence reads as ABSENT (false-negative risk)",
+            exc_info=True)
         return False
+
     def _has_entries(fn: Any) -> bool:
         code = getattr(getattr(fn, "__func__", fn), "__code__", None)
         if code is None:
@@ -155,6 +176,10 @@ def has_inmemory_compiled_code(pipeline: Any) -> bool:
         try:
             return bool(eval_frame._debug_get_cache_entry_list(code))
         except Exception:
+            logger.warning(
+                "compile-cache: dynamo cache-entry probe failed for %s — "
+                "counted as NOT compiled", getattr(fn, "__qualname__", fn),
+                exc_info=True)
             return False
 
     for _owner, _attr, fn in marker.get("originals") or ():
@@ -166,6 +191,10 @@ def has_inmemory_compiled_code(pipeline: Any) -> bool:
         try:
             children = list(mod.modules())
         except Exception:
+            logger.warning(
+                "compile-cache: could not enumerate regional submodules of %s "
+                "— its compiled blocks read as ABSENT",
+                type(mod).__name__, exc_info=True)
             continue
         for child in children:
             if _has_entries(getattr(type(child), "forward", None)):
@@ -222,13 +251,19 @@ def runtime_key() -> Dict[str, str]:
             # rather than provider-specific nvidia-smi output.
             key["cuda_driver"] = _cuda_driver_version()
     except Exception:
-        pass
+        # pgw#657: silently leaving these EMPTY manufactures a different cell
+        # key than every healthy pod computes — i.e. a guaranteed cache miss
+        # (and a mint) whose cause is invisible. Say it.
+        logger.warning(
+            "compile-cache: torch/CUDA runtime-key probe failed — cell identity "
+            "falls back to empty sku/sm/torch fields; expect a cache MISS",
+            exc_info=True)
     try:
         import triton
 
         key["triton"] = str(triton.__version__)
     except Exception:
-        pass
+        logger.debug("compile-cache: triton version unavailable", exc_info=True)
     return key
 
 
@@ -293,7 +328,6 @@ def compile_target_lane_error(weight_lane: str, lora_bucket: int) -> str:
     base, observed = lane_bucket(lane)
     if base not in ("", "fp8-hooks", "w8a16", "w8a8", "w4a4"):
         return f"unsupported pipeline_weight_lane {lane!r}"
-    from .models.w8a8_lora import RANK_BUCKETS
 
     if observed not in (0, *RANK_BUCKETS):
         return f"unsupported LoRA bucket {observed} in lane {lane!r}"
@@ -333,7 +367,6 @@ def parse_cell_ref(ref: str) -> Tuple[str, str]:
     """(family, flavor) from a system cell ref
     (``root/family-<f>[:tag][@digest][#<flavor>]``) via the ONE ref
     grammar (gw#492); ('', '') when the ref is not a system-family ref."""
-    from .models.refs import parse_model_ref
 
     try:
         parsed = parse_model_ref(str(ref or ""))
@@ -372,7 +405,6 @@ def is_cache_ref(ref: str, family: str = "") -> bool:
     one specific family). Cells are flavored either with the legacy human
     label (``inductor-<sku>-torch<mm>[-lane]``) or, post-th#883, with the
     worker-computed cell key itself (``ck2-<sha256>`` — pull-by-key)."""
-    from . import cell_key
 
     fam, flavor = parse_cell_ref(ref)
     if not fam or (family and fam != family):
@@ -438,7 +470,7 @@ def artifact_metadata(
     layerwise-cast; the hooks are traced INTO the graphs, ie#381) and is
     parity-checked at :func:`enable` like ``low_vram_mode``. Shape rows are
     (w, h) or (w, h, frames); ``guidance_scales`` records the image CFG /
-    no-CFG graph regimes captured for every 2-D row — see ``Compile``."""
+    no-CFG graph classes captured for every 2-D row — see ``Compile``."""
     meta: Dict[str, Any] = {
         "format": ARTIFACT_FORMAT,
         "kind": "torch-inductor-cache",
@@ -464,7 +496,6 @@ def artifact_metadata(
     # describe. Derived FROM the metadata (never probed separately), so the
     # stamp can never disagree with the axes it summarizes. Callers that
     # later override a key axis (build()'s serving image digest) re-stamp.
-    from . import cell_key
 
     return cell_key.stamp(meta)
 
@@ -643,7 +674,6 @@ def _disable_aot_autograd_cache() -> None:
     the installed config entry's ``env_value_force`` mutated here (torch
     already imported — tools, tests, embedders)."""
     os.environ["TORCHINDUCTOR_AUTOGRAD_CACHE"] = "0"
-    import sys
 
     if "torch" not in sys.modules:
         return
@@ -662,7 +692,6 @@ def _disable_aot_autograd_cache() -> None:
 def _reset_inductor_latch() -> None:
     """Clear inductor's in-memory caches that may have latched the previous
     cache-dir paths (torch's own ``temporary_cache_dir`` does the same)."""
-    import sys
 
     if "torch" not in sys.modules:
         return
@@ -762,7 +791,6 @@ def toolchain_present() -> bool:
 
 def _fx_entry_lines(data: bytes) -> Tuple[str, list]:
     """(key, hash-details lines) from one pickled FxGraphCache entry."""
-    import pickle
 
     obj = pickle.loads(data)
     key = str(getattr(obj, "_fx_graph_cache_key", "") or "")
@@ -854,7 +882,6 @@ def fx_cache_failure_report(artifact: Optional[Path] = None) -> str:
     - cell_keys=0             => the artifact itself was unreadable here.
 
     Every sub-probe degrades to an err token; this never raises."""
-    import pickle
 
     out: list = []
     seeded_lines: Dict[str, list] = {}
@@ -1182,7 +1209,6 @@ def mode_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     want = str(meta.get("low_vram_mode") or "")
     if not want:
         return ""
-    from .models.memory import low_vram_mode
 
     have = low_vram_mode(pipeline)
     if want != have:
@@ -1200,7 +1226,6 @@ def apply_lora_lane(pipeline: Any, bucket: int) -> bool:
     publish/adopt the wrong graph."""
     if not bucket:
         return False
-    from .models import w8a8_lora
 
     denoiser = w8a8_lora.branch_target(pipeline)
     if denoiser is None:
@@ -1217,7 +1242,6 @@ def drop_lora_lane(pipeline: Any) -> None:
     """Undo :func:`apply_lora_lane`: drop the branch buffers and restore the
     branchless lane stamp (the eager rollback — canonical zeroed branches
     cost +21-32% eager, gw#547)."""
-    from .models import w8a8_lora
 
     denoiser = w8a8_lora.branch_target(pipeline)
     if denoiser is None:
@@ -1233,7 +1257,6 @@ def lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     versa — both directions are guaranteed FX-graph misses that would serve
     eager while reporting adopted (the gw#391 bug class)."""
     want = str(meta.get("weight_lane") or "")
-    from .models.loading import pipeline_weight_lane
 
     have = pipeline_weight_lane(pipeline)
     if want != have:
@@ -1420,7 +1443,6 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
         "targets": graph_targets,
     }
     encoded = json.dumps(graph, sort_keys=True, separators=(",", ":")).encode()
-    from .models.loading import pipeline_weight_lane
 
     lane = pipeline_weight_lane(pipeline)
     weight_contract: Dict[str, Any] = {"lane": lane}
@@ -1470,7 +1492,6 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
     mark torch cannot honor raises ``ConstraintViolationError`` at
     compile/warm time — a LOUD build failure, never a silent fallback to
     recompilation (the mint's warm calls do not guard)."""
-    import functools
 
     import torch
 
@@ -1501,13 +1522,12 @@ def execution_contract_digest(pipeline: Any, cfg: Any) -> str:
 
     ``execution_contract()[0]`` is intentionally only the module-graph
     signature. Scheduler fencing needs the complete contract: declared graph
-    shapes/targets/CFG regimes, whole-vs-regional mode, actual weight lane and
+    shapes/targets/CFG classes, whole-vs-regional mode, actual weight lane and
     activation-scaling schema, LoRA bucket, and observed low-VRAM preparation.
     Tensor values and checkpoint identities remain excluded so compatible
     fine-tunes share one family cell.
     """
     graph_signature, weight_contract = execution_contract(pipeline, cfg)
-    from .models.memory import low_vram_mode
 
     text_lens = tuple(getattr(cfg, "text_lens", ()) or ())
     if not text_lens and getattr(cfg, "text_len", None) is not None:
@@ -1914,10 +1934,8 @@ def apply(
         logger.debug("compile-cache: could not raise recompile limit", exc_info=True)
 
     regional = bool(getattr(cfg, "regional", False))
-    from .models.loading import pipeline_weight_lane
 
     fail_closed = pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
-    from . import hot_swap
 
     failure_signal: Dict[str, Any] = {
         "callback": None,
@@ -2116,7 +2134,6 @@ def _reconcile_resident_mode(meta: Optional[Dict[str, Any]], pipeline: Any) -> N
     if not meta:
         return
     want = str(meta.get("low_vram_mode") or "")
-    from .models.memory import low_vram_mode, reconcile_resident_mode
 
     resident = ("off", "vae_only")
     have = low_vram_mode(pipeline)
@@ -2339,7 +2356,7 @@ def _warm_call(
     count only, so a plain single-pipeline call traces the same graph the
     serving path (including a two-stage refine, whose latents arrive from an
     upsampler of identical shape) will look up. Video calls force the
-    batch-1 no-CFG serving regime (CFG is a graph shape — ``Compile``) and
+    batch-1 no-CFG serving class (CFG is a graph shape — ``Compile``) and
     skip decode unless a vae target is declared. Image calls run once per
     explicitly declared guidance scale, capturing CFG and no-CFG graphs in
     one family cell.
@@ -2350,7 +2367,6 @@ def _warm_call(
     ``true_cfg_scale`` + a non-None ``negative_prompt`` — warming through
     ``guidance_scale`` there traces the SAME unconditioned graph for every
     declared scale and the serving CFG lookup can never hit."""
-    import inspect
 
     import torch
 
@@ -2456,9 +2472,6 @@ def build(
     first call per shape is the compile cost. Raises on any compile failure
     or an empty capture; a silently-eager build must never publish.
     """
-    from .models.loading import load_from_pretrained
-    from .models.memory import place_pipeline
-    from .registry import CompileCell
 
     _W8A8_MINT_NEEDS_DIGEST = (
         "W8A8 cell mint requires serving_image_digest (the endpoint "
@@ -2518,7 +2531,6 @@ def build(
     # traced under travels in the metadata for adopt-time parity checks. Run
     # on a pod with the same free-VRAM class as the target workers.
     placed = place_pipeline(pipe)
-    from .models.loading import pipeline_weight_lane as _traced_lane
 
     if _traced_lane(pipe).startswith(("w8a8", "w4a4")) and not str(
         serving_image_digest
@@ -2562,7 +2574,6 @@ def build(
             "was inductor already latched to another dir in this process?"
         )
 
-    from .models.loading import pipeline_weight_lane
 
     graph_signature, weight_contract = execution_contract(pipe, cfg)
     meta = artifact_metadata(
@@ -2596,7 +2607,6 @@ def build(
     # forge's echo — a demand-driven mint names the exact worker-computed
     # key it must satisfy, and publishing a cell under a key its own axes
     # do not describe would be a permanently un-armable store entry.
-    from . import cell_key
 
     cell_key.stamp(meta)
     if str(requested_cell_key or "").strip():
@@ -2675,8 +2685,6 @@ def mint_artifact(
         raise RuntimeError(
             "compile warm-up captured nothing under TORCHINDUCTOR_CACHE_DIR"
         )
-    from .models.loading import pipeline_weight_lane
-    from .models.memory import low_vram_mode
 
     # gw#564: record the execution contract exactly like the production
     # build — w8a8 cells are contract_drift-gated on the graph signature and
@@ -2805,8 +2813,6 @@ def finish_fleet_mint(
             f"the warmup proof compiled {expected_graphs} graph(s) — "
             "partial capture, refusing to publish"
         )
-    from .models.loading import pipeline_weight_lane
-    from .models.memory import low_vram_mode
 
     # gw#564: record the execution contract exactly like the production
     # build — w8a8 cells are contract_drift-gated on the graph signature and

--- a/src/gen_worker/content_credentials.py
+++ b/src/gen_worker/content_credentials.py
@@ -38,6 +38,8 @@ import logging
 import threading
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
+import os
+import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -243,8 +245,6 @@ def sign_media_file(
     mime = sniff_media_mime(head, ref)
     if mime is None:
         return None
-    import os
-    import tempfile
 
     suffix = os.path.splitext(str(src_path))[1] or ".bin"
     fd, out_path = tempfile.mkstemp(suffix=suffix, prefix="c2pa-")

--- a/src/gen_worker/convert/calibration.py
+++ b/src/gen_worker/convert/calibration.py
@@ -29,6 +29,7 @@ unsupported for a requested scheme; callers own how datasets are selected.
 from __future__ import annotations
 
 from typing import Literal
+import logging
 
 CalibrationPolicy = Literal["required", "beneficial", "unsupported"]
 
@@ -84,7 +85,6 @@ def resolve_calibration_action(
     Tenants typically take the returned action + any ``WARN-``-tagged notes
     they want to surface. A raise means the caller must fix the request.
     """
-    import logging
 
     _log = logging.getLogger(__name__)
     label = f"[{scheme}]" if scheme else ""

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -47,6 +47,10 @@ from .writer import (
     shard_safetensors_by_offset,
     snapshot_weight_groups,
 )
+from .convert import run_inline_conversion
+from .layout import infer_model_family_variant_from_hint
+from ..api.slot import OBJECTIVES
+from gen_worker.models.refs import flavor_token
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +90,6 @@ class OutputSpec:
 
     @property
     def label(self) -> str:
-        from gen_worker.models.refs import flavor_token
 
         return flavor_token(f"{self.dtype}-{self.file_layout}-{self.file_type}")
 
@@ -317,7 +320,6 @@ def build_flavor_tree(
     Returns ``(tree_root, attrs)``. Raises ``InlineConversionNotPossible``
     for calibrated dtypes.
     """
-    from .convert import run_inline_conversion
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -647,7 +649,6 @@ def _hf_plan_looks_like_ltx2(plan: Any) -> bool:
     token themselves, so :func:`layout.infer_model_family_variant_from_hint`
     resolves it from paths alone — the same signal
     ``detect_huggingface_source_layout`` uses post-download."""
-    from .layout import infer_model_family_variant_from_hint
 
     for p in getattr(plan, "paths", None) or ():
         if infer_model_family_variant_from_hint(str(p)) == "ltx2":
@@ -864,7 +865,6 @@ def run_clone(
     objective: str | None = None,
     distilled: bool = False,
 ) -> CloneResult:
-    from ..api.slot import OBJECTIVES
 
     provider = str(provider or "").strip().lower()
     destination = normalize_destination_ref(destination_repo)

--- a/src/gen_worker/convert/component.py
+++ b/src/gen_worker/convert/component.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator
+from .writer import iter_component_tensors
 
 if TYPE_CHECKING:
     import torch
@@ -57,7 +58,6 @@ class Component:
         local to the component (e.g. ``conv_in.weight``), NOT prefixed with
         the component name.
         """
-        from .writer import iter_component_tensors
 
         yield from iter_component_tensors(self._path)
 

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -34,6 +34,13 @@ import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from .writer import streaming_dtype_cast
+from .writer import streaming_fp8_storage_cast
+import json as _json
+import shutil as _shutil
+from ._hf_load import load_component_module
+import subprocess
+from .gguf_tools import (prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
 
 logger = logging.getLogger(__name__)
 
@@ -282,8 +289,6 @@ def _run_cast_inline(
     """bf16/fp16/fp32 streaming dtype cast."""
     import torch
 
-    from .writer import streaming_dtype_cast
-
     dtype = _normalize(target_dtype)
     if dtype in {"bf16"}:
         torch_dtype = torch.bfloat16
@@ -339,7 +344,6 @@ def _run_fp8_storage_inline(
     exactly. Stamps dtype ``fp8`` — the detector keys on F8_E4M3 headers.
     ``block_scope=True`` = the transformers-backbone lane (repeated-block
     params only)."""
-    from .writer import streaming_fp8_storage_cast
 
     result = streaming_fp8_storage_cast(
         Path(source_path), Path(out_dir), shard_prefix=shard_prefix,
@@ -444,7 +448,6 @@ def _run_bnb_inline(
         bnb_4bit_compute_dtype=torch.bfloat16,
     )
 
-    import json as _json
     cfg_path = repo_dir / "config.json"
     try:
         cfg_blob = _json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.is_file() else {}
@@ -533,12 +536,8 @@ def _run_bnb_diffusers_inline(
     handles its own save/load via ``module.save_pretrained`` directly — no
     flatten helper needed.
     """
-    import json as _json
-    import shutil as _shutil
     import torch
     from transformers import BitsAndBytesConfig
-
-    from ._hf_load import load_component_module
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -657,13 +656,6 @@ def _run_gguf_inline(
     encoding: str,
 ) -> InlineConversionResult:
     """GGUF quantization — convert_hf_to_gguf.py (+ optional llama-quantize)."""
-    import subprocess
-
-    from .gguf_tools import (
-        prepare_hf_source_tree_for_gguf,
-        resolve_gguf_convert_script,
-        run_hf_to_gguf_conversion,
-    )
 
     dtype = _normalize(encoding)
     if dtype not in _INLINE_GGUF_ENCODINGS:

--- a/src/gen_worker/convert/dataset.py
+++ b/src/gen_worker/convert/dataset.py
@@ -60,6 +60,7 @@ import base64
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator
+import random
 
 if TYPE_CHECKING:
     from torch.utils.data import DataLoader
@@ -148,7 +149,6 @@ class Dataset:
         batches at ``batch_size``. Deterministic seeded shuffle. Suitable
         input for modelopt's ``forward_loop`` and GPTQ/AWQ calibration.
         """
-        import random
 
         import torch
         from torch.utils.data import DataLoader, TensorDataset

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -26,6 +26,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 
 import requests
+import socket
+from blake3 import blake3
+from ..api.errors import AuthError
+from ..request_context._helpers import _parse_owner_repo
+from gen_worker.models.refs import flavor_token as _token
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +78,6 @@ def _http_session() -> requests.Session:
     """Shared session with TCP keepalives so NAT/conntrack middleboxes don't
     evict the idle flow while the server verifies (no response bytes for
     minutes)."""
-    import socket
 
     global _SESSION
     if _SESSION is not None:
@@ -163,7 +167,6 @@ def _send_with_retries(what: str, send: Callable[[], requests.Response]) -> requ
 
 
 def blake3_file(path: Path, *, chunk: int = 8 * 1024 * 1024) -> str:
-    from blake3 import blake3
 
     h = blake3()
     with open(path, "rb") as f:
@@ -510,7 +513,6 @@ class HubClient:
         # token against [a-z0-9][a-z0-9._-]{0,63} — the internal dtype-axis
         # colon forms ("gguf:q4_k_m", "int8:awq") publish as "-" forms.
         # ONE implementation: gen_worker.models.refs.flavor_token (gw#492).
-        from gen_worker.models.refs import flavor_token as _token
 
         if tags:
             df = _token(default_flavor)
@@ -637,6 +639,61 @@ class HubClient:
         }
 
 
+_DATASET_PAGE_LIMIT = 200  # tensorhub's cap; a larger value is clamped there.
+_DATASET_PAGE_CEILING = 1000  # pages, i.e. 200k datasets — a runaway guard.
+
+
+def _find_dataset_id(
+    base: str, headers: dict[str, str], owner: str, name: str,
+) -> str:
+    """dataset_id of ``owner/name``, or "" when it genuinely does not exist.
+
+    Raises ``AuthError``/``RuntimeError`` rather than returning "" on any
+    response it cannot READ — the caller creates on "", so a swallowed error
+    is a duplicate dataset (pgw#656).
+    """
+    wanted = name.lower()
+    cursor = ""
+    seen_pages = 0
+    while True:
+        query = {"org": owner, "limit": str(_DATASET_PAGE_LIMIT)}
+        if cursor:
+            query["cursor"] = cursor
+        resp = requests.get(
+            f"{base}/api/v1/datasets?{urllib.parse.urlencode(query)}",
+            headers=headers,
+            timeout=30,
+        )
+        if resp.status_code in (401, 403):
+            raise AuthError(f"dataset list unauthorized ({resp.status_code})")
+        if resp.status_code < 200 or resp.status_code >= 300:
+            raise RuntimeError(
+                f"dataset list failed ({resp.status_code}): {resp.text[:256]}"
+            )
+        try:
+            body = resp.json() if resp.text else {}
+            items = list(body.get("items") or [])
+        except (ValueError, AttributeError) as exc:
+            raise RuntimeError(
+                f"dataset list returned unreadable JSON: {exc}"
+            ) from exc
+        for it in items:
+            if str(it.get("name") or "").lower() == wanted:
+                return str(it.get("dataset_id") or "")
+        next_cursor = str(body.get("next_cursor") or "").strip()
+        seen_pages += 1
+        # No cursor, no movement, or a server that ignores paging: stop. Never
+        # spin — but never silently truncate the search either.
+        if not next_cursor or next_cursor == cursor or not items:
+            return ""
+        if seen_pages >= _DATASET_PAGE_CEILING:
+            raise RuntimeError(
+                f"dataset list did not terminate after {seen_pages} pages "
+                f"(org={owner}); refusing to create a possible duplicate"
+            )
+        cursor = next_cursor
+
+
 def publish_dataset_revision(
     *,
     base_url: str,
@@ -654,7 +711,10 @@ def publish_dataset_revision(
     Hub-API plumbing for ``DatasetContext.publish_dataset_revision`` (which
     documents the tenant-facing contract). The flow:
 
-    1. Resolve ``destination_dataset`` (owner/name) against tensorhub.
+    1. Resolve ``destination_dataset`` (owner/name) against tensorhub — the
+       FULL cursor-paginated listing, and any unreadable response raises
+       rather than reading as "no such dataset" (pgw#656: every silent miss
+       here becomes a duplicate dataset in step 2).
     2. If the dataset row doesn't exist: ``POST /api/v1/datasets`` with
        ``{tenant, name, visibility, schema: features_json}``.
     3. Otherwise: ``PATCH /api/v1/datasets/:id`` to update the schema
@@ -662,11 +722,9 @@ def publish_dataset_revision(
 
     ``kind`` / ``dataset_info`` / ``snapshot_manifest`` ride inside
     ``features_json`` under reserved ``__cozy_*__`` keys until tensorhub
-    grows dedicated columns. Raises ``AuthError`` on 401/403 and
+    grows dedicated columns (th#1162). Raises ``AuthError`` on 401/403 and
     ``RuntimeError`` on any other HTTP failure.
     """
-    from ..api.errors import AuthError
-    from ..request_context._helpers import _parse_owner_repo
 
     owner, name = _parse_owner_repo(destination_dataset)
     base = (base_url or "").strip().rstrip("/")
@@ -694,21 +752,20 @@ def publish_dataset_revision(
     if snapshot_manifest:
         features_payload["__cozy_snapshot_manifest__"] = snapshot_manifest
 
-    # Step 1: look up any existing dataset by (tenant, name). tensorhub
-    # lists by ?tenant= and we filter client-side; this is O(N) but N is
-    # small (typically <100 datasets per org in practice).
-    list_url = f"{base}/api/v1/datasets?tenant={urllib.parse.quote(owner, safe='')}"
-    list_resp = requests.get(list_url, headers=headers, timeout=30)
-    existing_id = ""
-    if 200 <= list_resp.status_code < 300:
-        try:
-            items = list_resp.json().get("items") or []
-            for it in items:
-                if str(it.get("name") or "").lower() == name.lower():
-                    existing_id = str(it.get("dataset_id") or "")
-                    break
-        except Exception:
-            pass
+    # Step 1: look up any existing dataset by (owner, name).
+    #
+    # pgw#656: every way this lookup can fail to SEE an existing row ends in
+    # step 2a — CREATE — i.e. a duplicate dataset, silently. So it fails loud
+    # instead of falling through, and it walks the whole listing:
+    #   * a non-2xx / unparseable response now raises (it used to be
+    #     indistinguishable from "no such dataset");
+    #   * the listing is CURSOR-paginated (tensorhub caps `limit` at 200 and
+    #     returns `next_cursor`), where it used to read one default page of 50
+    #     and call that the org's whole dataset set;
+    #   * the filter is `?org=`, which is the parameter the handler actually
+    #     reads — `?tenant=` was silently ignored and the result only
+    #     happened to be right because the token's own org was the default.
+    existing_id = _find_dataset_id(base, headers, owner, name)
 
     if not existing_id:
         # Step 2a: create.

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -16,7 +16,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, NoReturn, Optional, Sequence
 
+import hashlib
+import re
+import struct
+
 from gen_worker.api.errors import ValidationError
+from gen_worker.models.download import (
+    _HF_DOWNLOAD_STALL_TIMEOUT_S,
+    _civitai_select_files,
+    _run_with_stall_watchdog,
+    download_civitai,
+    fetch_civitai_model_version,
+)
 
 from ..net import hf, install_hf_http_timeouts
 from .classifier import RepoClassification, apply_source_include, classify_repo
@@ -75,7 +86,6 @@ def _detect_snapshot_dtype(root: Path) -> str:
     ('bf16' / 'fp16' / 'fp32' / 'fp8', '' when undetectable). Civitai
     version metadata is unreliable (fp labels routinely contradict the
     file bytes), so read the headers."""
-    import struct
 
     counts: dict[str, int] = {}
     try:
@@ -274,7 +284,6 @@ def _civitai_manifest_revision(file_names: list[str]) -> str:
     """The clone-side civitai 'revision': a hash over the downloaded file
     listing (civitai has no commit sha). MUST stay identical between
     plan_civitai and ingest_civitai so bank hits match full-clone runs."""
-    import hashlib
 
     manifest = json.dumps(
         [{"name": n} for n in sorted(file_names)], sort_keys=True, separators=(",", ":"))
@@ -330,7 +339,6 @@ def plan_civitai(
     gguf_quant: str | None = None,
 ) -> CivitaiSourcePlan:
     """Fetch one civitai model version's metadata (no downloads)."""
-    from gen_worker.models.download import _civitai_select_files, fetch_civitai_model_version
 
     version_id = int(model_version_id or 0)
     if version_id <= 0:
@@ -368,12 +376,6 @@ def _snapshot_download_with_retries(
         RevisionNotFoundError,
     )
 
-    from gen_worker.models.download import (
-        _HF_DOWNLOAD_MAX_SECONDS,
-        _HF_DOWNLOAD_STALL_TIMEOUT_S,
-        _run_with_stall_watchdog,
-    )
-
     attempts = _download_attempts()
     last: Exception | None = None
     for attempt in range(1, attempts + 1):
@@ -391,7 +393,6 @@ def _snapshot_download_with_retries(
                 progress_callback=progress,
                 total_hint=total_hint,
                 stall_timeout=_HF_DOWNLOAD_STALL_TIMEOUT_S,
-                wall_clock_max=_HF_DOWNLOAD_MAX_SECONDS,
             )
             return
         except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError,
@@ -519,7 +520,6 @@ def _is_multi_weight_names(names: Iterable[str]) -> bool:
     TOP-LEVEL weight file names form more than one logical weight set
     (HF-convention shards collapse into one). Callers pass basenames only."""
     global _SHARD_NAME_RE
-    import re
 
     if _SHARD_NAME_RE is None:
         _SHARD_NAME_RE = re.compile(r"^(.+)-(\d+)-of-(\d+)\.(safetensors|gguf)$")
@@ -584,7 +584,6 @@ def ingest_civitai(
     gguf_quant: str | None = None,
 ) -> IngestedSource:
     """Fetch one civitai model version into ``dest_dir`` (bounded provider API)."""
-    from gen_worker.models.download import download_civitai, fetch_civitai_model_version
 
     version_id = int(model_version_id or 0)
     if version_id <= 0:

--- a/src/gen_worker/convert/repackage.py
+++ b/src/gen_worker/convert/repackage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from .writer import ConversionImplementationError
+import importlib
 
 if TYPE_CHECKING:
     import torch
@@ -251,7 +252,6 @@ def _load_component_from_config_repo(
     config repo. DiT-only fine-tunes (common on civitai for z-image) ship no
     text-encoder/VAE weights — sourcing them from the base repo is exactly the
     CAS dedup story: the fine-tune tree stores only its denoiser."""
-    import importlib
 
     comp_cls = None
     for lib in ("transformers", "diffusers"):
@@ -585,8 +585,6 @@ def _convert_sd_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]) 
         ("text_projection.weight", "text_projection"),
     ]
 
-    import re
-
     protected = {re.escape(src): dst for src, dst in textenc_conversion_lst}
     pattern = re.compile("|".join(protected.keys()))
 
@@ -808,8 +806,6 @@ def _convert_sdxl_text_enc_state_dict(text_enc_dict: dict[str, torch.Tensor]) ->
         ("positional_embedding", "positional_embedding"),
         ("text_projection", "text_projection"),
     ]
-
-    import re
 
     protected = {re.escape(src): dst for src, dst in textenc_conversion_lst}
     pattern = re.compile("|".join(protected.keys()))

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -14,8 +14,12 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal
 
+from gen_worker.api.errors import ValidationError
+
 from .component import Component
 from .loaded_component import LoadedComponent
+from ._hf_load import load_component_module
+from .writer import iter_source_tensors
 
 if TYPE_CHECKING:
     import torch
@@ -237,7 +241,6 @@ class Source:
         Handles pickle → safetensors conversion and sharded-safetensors via
         .index.json internally. Tenant sees a flat iteration.
         """
-        from .writer import iter_source_tensors
 
         yield from iter_source_tensors(
             self._path,
@@ -332,11 +335,13 @@ class Source:
              card without OOM-walks in tenant code.
 
           2. **Layout dispatch.** The same iteration shape works for
-             diffusers-layout (multiple component subdirs), diffusers
-             singlefile (one .safetensors reconstructed via
-             ``from_single_file``), and transformers singlefile (one
-             ``AutoModelForCausalLM.from_pretrained``). The tenant doesn't
-             care which it is.
+             diffusers-layout (multiple component subdirs) and transformers
+             singlefile (one ``AutoModelForCausalLM.from_pretrained``). A
+             DIFFUSERS-singlefile source (a lone ``.safetensors`` needing
+             ``from_single_file``) is refused here, typed: use
+             ``Source.as_hf_model()`` and quantize the resulting pipeline
+             yourself. Nothing in the fleet converts that layout through this
+             API, and a half-wired branch reads as support (pgw#657).
 
           3. **Passthrough vs quant decision.** Components matching
              ``quant_only`` are loaded + quantized; the rest are yielded
@@ -422,7 +427,6 @@ def _iter_diffusers_components(
     passthrough. A final ``_root`` LoadedComponent carries the top-level
     files (model_index.json, README, etc).
     """
-    from ._hf_load import load_component_module
 
     if not snapshot_path.is_dir():
         return
@@ -505,22 +509,15 @@ def _iter_singlefile_components(
     compute_dtype: Any,
     offload_folder: Path | None,
 ) -> Iterator[LoadedComponent]:
-    """Yield a single LoadedComponent for a singlefile-layout snapshot.
+    """Yield a single LoadedComponent for a **transformers** singlefile
+    snapshot: a directory with ``config.json`` + weights at the top level
+    (e.g. a llama / qwen dump), loaded via
+    ``AutoModelForCausalLM.from_pretrained(path, quantization_config=...,
+    torch_dtype=..., device_map='auto', offload_folder=...)``.
 
-    Two flavors handled here:
-      - **transformers singlefile** — directory with ``config.json`` +
-        weights at the top level (e.g. a llama / qwen model dump). Loaded
-        via ``AutoModelForCausalLM.from_pretrained(path, quantization_config=
-        ..., torch_dtype=..., device_map='auto', offload_folder=...)``.
-      - **diffusers singlefile** — one ``.safetensors`` file reconstructible
-        via ``from_single_file``. Less common; the library defers to the
-        diffusers-layout caller (``StableDiffusionPipeline.from_single_file``)
-        and yields the resulting pipeline as a single ``LoadedComponent
-        (name='model')``.
-
-    For now the diffusers singlefile path raises NotImplementedError if
-    invoked — the calling tenant can fall back to the legacy ``as_hf_model``
-    + manual quant path. Wiring it up is a small follow-up.
+    Anything else on this branch is a DIFFUSERS singlefile (a lone
+    ``.safetensors`` needing ``from_single_file``) and is refused typed — see
+    the refusal below.
     """
     if (snapshot_path / "config.json").is_file():
         # See _iter_diffusers_components for the device_map rationale —
@@ -553,10 +550,15 @@ def _iter_singlefile_components(
         )
         return
 
-    raise NotImplementedError(
-        "iter_hf_components: diffusers-singlefile sources are not yet "
-        "supported. Use the legacy Source.as_hf_model() path and quantize "
-        "the resulting DiffusionPipeline manually for now."
+    # pgw#657: this was a NotImplementedError plus docs promising the layout
+    # worked — a dispatchable branch nobody wired, with no tracker item. It is
+    # a REFUSAL, not a gap: no fleet conversion uses this layout through this
+    # API, and the documented alternative is one call away.
+    raise ValidationError(
+        f"iter_hf_components: {snapshot_path.name} is a diffusers-singlefile "
+        "source (no top-level config.json); this API serves diffusers-layout "
+        "and transformers-singlefile only. Use Source.as_hf_model() and "
+        "quantize the resulting DiffusionPipeline directly."
     )
 
 

--- a/src/gen_worker/convert/svdq.py
+++ b/src/gen_worker/convert/svdq.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 from ..models.svdq import SvdqArtifact, detect_svdq_artifact
 from .writer import copy_non_weight_files
+from ..net import hf
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,6 @@ def fetch_svdq_checkpoint(
     hf_token: Optional[str] = None,
 ) -> Path:
     """Download ONE nunchaku checkpoint file from an HF repo (mirror lane)."""
-    from ..net import hf
 
     dest_dir = Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -25,6 +25,11 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional
+import os
+from gen_worker.models.loading import (_fp8_block_windows, _fp8_block_windows_whole)
+from fnmatch import fnmatch
+import random
+from gen_worker.models.w8a8 import detect_w8a8_artifact
 
 if TYPE_CHECKING:
     import torch
@@ -515,7 +520,6 @@ def fp8_cast_eligible(
     *, skip_patterns: tuple[str, ...] = FP8_SKIP_TENSOR_PATTERNS,
 ) -> bool:
     """True when a tensor is safe to store as fp8-E4M3 for the ``#fp8`` flavor."""
-    import re
 
     if src_st_dtype not in {"F64", "F32", "F16", "BF16"}:
         return False
@@ -535,7 +539,6 @@ _FP8_BLOCK_SCOPE_RE = r"\.\d+\."
 
 
 def _in_repeated_block(name: str) -> bool:
-    import re
 
     return re.search(_FP8_BLOCK_SCOPE_RE, name) is not None
 
@@ -810,7 +813,6 @@ def snapshot_weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Pat
 
 
 def _link_or_copy(src: Path, dst: Path) -> None:
-    import os
 
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists():
@@ -1000,11 +1002,6 @@ def te_fp8_castable_keys(component_dir: Path) -> frozenset[str]:
     Embeddings, norms, biases, poolers stay at source precision."""
     import torch
     import transformers
-
-    from gen_worker.models.loading import (
-        _fp8_block_windows,
-        _fp8_block_windows_whole,
-    )
 
     component_dir = Path(component_dir)
     cfg = transformers.AutoConfig.from_pretrained(str(component_dir))
@@ -1204,7 +1201,6 @@ def streaming_w8a8_snapshot(
     (their quantized keys could never resolve in the denoiser at swap
     time). No component config exists; the headers alone carry
     detection."""
-    from fnmatch import fnmatch
 
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     if file_layout != "diffusers":
@@ -1336,12 +1332,9 @@ def verify_w8a8_snapshot(
     producer-side quantization input view. For example, an immutable FP16
     checkpoint loaded as production BF16 is cast to BF16 before exact
     recomputation; storage and compute dtypes are both reported."""
-    import random
 
     import torch
     from safetensors import safe_open
-
-    from gen_worker.models.w8a8 import detect_w8a8_artifact
 
     aliases = {
         "storage": ("storage", None),
@@ -1484,7 +1477,6 @@ _RAW_COPY_CHUNK = 8 * 1024 * 1024
 
 
 def _read_safetensors_header(fd: int) -> tuple[dict, int]:
-    import os
 
     os.lseek(fd, 0, os.SEEK_SET)
     prefix = os.read(fd, _HEADER_LEN_PREFIX)
@@ -1515,7 +1507,6 @@ def shard_safetensors_by_offset(
     Returns (shard_paths, index_path, shard_sizes). The index is always
     written; callers skip uploading it for single-shard plans.
     """
-    import os
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/gen_worker/deferred_outputs.py
+++ b/src/gen_worker/deferred_outputs.py
@@ -1,0 +1,147 @@
+"""Deferred output materialization — the image encode+upload tail runs AFTER
+the handler returns, with the GPU permit already released (th#1130, pgw#652
+Phase 0 for images).
+
+Why: 19 of 19 live image endpoints call ``ctx.save_image`` INSIDE the handler,
+so a webp q95 encode (~1.1s for a 1328^2 frame on a loaded host) plus the
+upload ran while the request still held the GPU permit. th#1107's terminal
+``_release_gpu_slot_for_finalize`` could not just be copied onto
+``save_image``: that release is terminal and once-only, while endpoints save
+mid-pipeline and in N-image loops, so the first of N saves would free the
+permit with GPU work still to come.
+
+The terminality signal this needs already exists: the HANDLER'S RETURN. The
+executor releases the permit right there anyway. So ``save_image`` snapshots
+the pixels, hands back the ``ImageAsset`` the handler drops into its output
+struct, and the executor drains the queue after the release — encode, C2PA
+stamp and upload all land in the slotless tail while the next request denoises.
+No endpoint changes, no new protocol, no early release.
+
+Failure modes handled here:
+
+* **Read-back.** Reading a not-yet-materialized field (``size_bytes``,
+  ``sha256``, ``inline_bytes``, ...) forces the encode inline. Correct, just
+  not overlapped, and it says so in the log.
+* **Mutate-after-save.** ``save_image`` snapshots via ``image.copy()`` (a few
+  ms of memcpy against a ~1.1s encode), so a handler that keeps painting on
+  the PIL object cannot change what gets uploaded.
+* **A failing tail.** The drain runs before the OK result is built, so an
+  exception in the deferred encode fails the request like any handler error
+  instead of reporting OK with a hollow asset.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, List, Optional
+
+from .api.types import Asset, ImageAsset
+
+logger = logging.getLogger(__name__)
+
+#: Asset fields only the completed upload knows. Reading one before the tail
+#: runs forces materialization.
+PENDING_FIELDS = frozenset({
+    "local_path", "mime_type", "size_bytes", "sha256", "blake3",
+    "media_id", "download_token", "stream_mode", "inline_bytes",
+})
+
+
+def fill_from(target: Asset, done: Asset) -> None:
+    """Copy the materialized upload's fields onto the handle the handler
+    already returned (same object identity, so the output struct sees them)."""
+    for field in done.__struct_fields__:
+        setattr(target, field, getattr(done, field))
+
+
+class PendingOutput:
+    """One deferred encode+upload. Runs at most once, from whichever thread
+    gets there first (the drain, or a read-back inside the handler)."""
+
+    __slots__ = ("_materialize", "_lock", "_done", "forced", "ref")
+
+    def __init__(self, ref: str, materialize: Callable[[], None]) -> None:
+        self.ref = ref
+        self._materialize = materialize
+        self._lock = threading.Lock()
+        self._done = False
+        self.forced = False
+
+    @property
+    def done(self) -> bool:
+        return self._done
+
+    def run(self, *, forced: bool = False) -> None:
+        with self._lock:
+            if self._done:
+                return
+            # Marked done BEFORE running: a read-back from inside the
+            # materialization must not recurse, and a raising tail is
+            # terminal for this output either way.
+            self._done = True
+            self.forced = forced
+            self._materialize()
+
+
+class DeferredImageAsset(ImageAsset, dict=True):
+    """``ImageAsset`` whose bytes-attestation fields materialize in the
+    finalize tail. ``ref``/``owner`` are known eagerly (every live endpoint
+    only ever puts the handle in its output struct); the rest come from the
+    upload. Reading one of those early forces the encode inline."""
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in PENDING_FIELDS:
+            pending: Optional[PendingOutput] = object.__getattribute__(
+                self, "__dict__").get("_gw_pending")
+            if pending is not None and not pending.done:
+                logger.warning(
+                    "deferred output %s: handler read %r before the finalize "
+                    "tail — encoding inline, so this request loses the "
+                    "encode/upload overlap", pending.ref, name)
+                pending.run(forced=True)
+        return object.__getattribute__(self, name)
+
+
+class DeferredTail:
+    """One request's queue of deferred output materializations."""
+
+    __slots__ = ("_lock", "_queue", "armed")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._queue: List[PendingOutput] = []
+        # Armed by the executor only where a post-handler tail exists: a
+        # streaming handler serializes items MID-handler, so its outputs can
+        # never be deferred. CLI runs and endpoint unit tests stay eager.
+        self.armed = False
+
+    def defer(self, pending: PendingOutput) -> None:
+        with self._lock:
+            self._queue.append(pending)
+
+    def pending(self) -> int:
+        with self._lock:
+            return sum(1 for p in self._queue if not p.done)
+
+    def drain(self) -> int:
+        """Materialize everything still pending, in save order. Returns how
+        many ran HERE (i.e. actually overlapped); raises the first failure."""
+        with self._lock:
+            queue = list(self._queue)
+        ran = 0
+        for pending in queue:
+            if pending.done:
+                continue
+            pending.run()
+            ran += 1
+        return ran
+
+
+__all__ = [
+    "DeferredImageAsset",
+    "DeferredTail",
+    "PendingOutput",
+    "PENDING_FIELDS",
+    "fill_from",
+]

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -30,6 +30,8 @@ from gen_worker.discovery.heavy_deps import stub_missing_heavy_deps
 from gen_worker.discovery.names import slugify_name
 from gen_worker.discovery.project import load_project_config
 from gen_worker.discovery.walk import EndpointImportError, find_endpoints
+from gen_worker.registry import extract_specs
+from .validation import validate_endpoint_lock
 
 
 def _type_id(t: type) -> Dict[str, str]:
@@ -575,7 +577,6 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
     shared with the worker runtime and the CLI. This adds only the
     manifest-specific enrichment (schemas, moderation, bindings blocks).
     """
-    from gen_worker.registry import extract_specs
 
     out: List[Dict[str, Any]] = []
     for es in extract_specs(obj, walked_module=module_name):
@@ -835,7 +836,6 @@ def main() -> None:
     # uniqueness check; non-class shapes (an entry without archetype/kind)
     # are caught by the required-field check. All errors flow out at once
     # so the build surfaces every problem rather than one-at-a-time.
-    from .validation import validate_endpoint_lock
 
     val = validate_endpoint_lock(manifest)
     for w in val.warnings:

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -9,6 +9,8 @@ Usage:
 """
 
 import os
+import faulthandler
+import signal
 
 # Reduce CUDA allocator fragmentation for tight-VRAM single-process workers.
 # Set BEFORE any module imports torch (PyTorch reads this env var only at
@@ -231,8 +233,6 @@ def _install_stack_dump_handler() -> None:
     by CPython and by torch; faulthandler writes without allocating, so it
     works even when the process is wedged on memory.
     """
-    import faulthandler
-    import signal
 
     try:
         faulthandler.register(signal.SIGUSR2, all_threads=True, chain=True)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -65,6 +65,7 @@ from .models import disk_telemetry
 from .models import provision
 from .models import residency as residency_mod
 from .models.memory import (
+    aflush_memory,
     deeper_offload_mode,
     degraded_log_line,
     estimate_cuda_resident_gb,
@@ -2051,6 +2052,32 @@ class _WarmupEvidence:
     functions_by_object: Dict[int, set[str]] = dc_field(default_factory=dict)
 
 
+# gw#661: setup failures whose contract is "will be re-attempted". These are
+# reported to the hub as a still-RUNNING activity, not the FAILED terminal —
+# the hub reads FAILED as "no progress here" (th#1160) and condemns the pod.
+_TRANSIENT_SETUP_ERRORS = (InsufficientDiskError, RetryableError, MissingSnapshotError)
+
+# Consecutive transient losses on ONE record before the condition is this
+# function's terminal truth. Each attempt already carries its own internal
+# wait (the lane gate polls VRAM headroom for 45s), so this is minutes of
+# real patience, not a tight spin.
+MAX_TRANSIENT_SETUP_ATTEMPTS = 5
+
+
+def _setup_error_will_retry(exc: BaseException) -> bool:
+    """Whether this setup loss is contractually re-attempted (gw#661).
+
+    CompiledLaneUnavailableError subclasses RetryableError but the worker
+    DOES give up on it — it disables every handler requiring the unproven
+    lane — so it is a failure, not a retry.
+    """
+    if not isinstance(exc, _TRANSIENT_SETUP_ERRORS):
+        return False
+    from .compile_cache import CompiledLaneUnavailableError
+
+    return not isinstance(exc, CompiledLaneUnavailableError)
+
+
 @dataclass
 class _ClassRecord:
     cls: type
@@ -2099,6 +2126,8 @@ class _ClassRecord:
     # IDs are minted after successful setup and cleared before vacate; they do
     # not derive from mutable refs, authored specs, or object memory addresses.
     compile_targets: Dict[str, _CompileTargetRecord] = dc_field(default_factory=dict)
+    # gw#661: consecutive will-retry setup losses; reset by any success.
+    transient_setup_failures: int = 0
 
 
 @dataclass
@@ -4335,7 +4364,23 @@ class Executor:
                         intent_id=intent_id,
                     )
             except BaseException as exc:
-                act.failed(exc)
+                # gw#661: a will-retry condition is not a failure. Only
+                # exhausting the budget is, and then the hub must see it.
+                will_retry = _setup_error_will_retry(exc)
+                exhausted = False
+                if will_retry:
+                    rec.transient_setup_failures += 1
+                    exhausted = (
+                        rec.transient_setup_failures >= MAX_TRANSIENT_SETUP_ATTEMPTS
+                    )
+                if will_retry and not exhausted:
+                    act.retrying(
+                        exc,
+                        rec.transient_setup_failures,
+                        MAX_TRANSIENT_SETUP_ATTEMPTS,
+                    )
+                else:
+                    act.failed(exc)
                 # Setup is a transaction: endpoint construction, tenant
                 # setup/warmup, residency registration, and compile-target
                 # publication either all reach READY or all ownership is
@@ -4371,7 +4416,7 @@ class Executor:
                 if isinstance(exc, CompiledLaneUnavailableError):
                     self._mark_compile_setup_unavailable(rec, spec, str(exc))
                     self._on_state_change()
-                self._mark_setup_failed(rec, exc)
+                self._mark_setup_failed(rec, exc, exhausted=exhausted)
                 raise
             if rec.failed is not None:
                 # Recovery (desired-state retry succeeded): lift the
@@ -4379,6 +4424,7 @@ class Executor:
                 rec.failed = None
                 for s in rec.specs:
                     self.unavailable.pop(s.name, None)
+            rec.transient_setup_failures = 0
             rec.instance = instance
             rec.ready = True
             act.completed()
@@ -4637,13 +4683,21 @@ class Executor:
 
             await _to_thread_complete(_consume)
 
-    def _mark_setup_failed(self, rec: _ClassRecord, exc: BaseException) -> None:
-        if isinstance(exc, (InsufficientDiskError, RetryableError, MissingSnapshotError)):
+    def _mark_setup_failed(
+        self, rec: _ClassRecord, exc: BaseException, *, exhausted: bool = False,
+    ) -> None:
+        if isinstance(exc, _TRANSIENT_SETUP_ERRORS) and not exhausted:
             # Transient pressure (disk GC frees space / warm-tier RAM drains /
             # the hub re-mints a snapshot): fail the op RETRYABLE, never
             # disable the function.
             return
-        if isinstance(exc, HardwareUnmetError):
+        if isinstance(exc, _TRANSIENT_SETUP_ERRORS):
+            # gw#661: the budget is spent. "Retryable" described the class of
+            # error, not an infinite entitlement — a condition that survives
+            # every attempt is this function's terminal truth (th#1159's
+            # genuinely-unfittable VRAM lane is the case this exists for).
+            reason, axes = "retry_exhausted", {}
+        elif isinstance(exc, HardwareUnmetError):
             reason = getattr(exc, "reason", "hardware_unmet")
             axes = {str(k): str(v) for k, v in (exc.axes() or {}).items()}
         else:
@@ -4653,6 +4707,39 @@ class Executor:
         for s in rec.specs:
             self.unavailable[s.name] = (reason, detail, axes)
         self._on_state_change()
+
+    def mark_ref_unmaterializable(self, ref: str, detail: str) -> List[str]:
+        """pgw#655: a model this worker fetches ITSELF never landed — gate
+        every function that statically binds it.
+
+        The alternative (log and continue) is what produced the live wedge:
+        the worker walked on to READY, advertised the function, and the hub
+        dispatched paid GPU jobs that each re-discovered the missing model as
+        a per-request load failure. A worker never advertises a function whose
+        model is absent. This is deliberately NOT a process kill — a sibling
+        function whose model DID land keeps serving, exactly as a hardware
+        gate leaves the rest of the endpoint alive.
+
+        Hub-resolved slots are excluded: their refs arrive by delivery
+        (pgw#532), so the worker never prefetches them and their absence at
+        boot is not a failure.
+        """
+        gated: List[str] = []
+        for name, spec in self.specs.items():
+            bound = any(
+                ref in _binding_wire_refs(binding)
+                for slot, binding in spec.models.items()
+                if slot not in spec.slots
+            )
+            if not bound:
+                continue
+            self.unavailable[name] = (
+                "model_unavailable", _sanitize(detail), {"ref": ref},
+            )
+            gated.append(name)
+        if gated:
+            self._on_state_change()
+        return sorted(gated)
 
     @staticmethod
     def _record_has_setup_ownership(rec: _ClassRecord) -> bool:
@@ -4689,12 +4776,7 @@ class Executor:
             return
         async with self._load_lock:
             released = await self._vacate_record(rec)
-        await asyncio.to_thread(gc.collect)
-        if torch is not None and torch.cuda.is_available():
-            try:
-                await asyncio.to_thread(torch.cuda.empty_cache)
-            except Exception:
-                pass
+        await aflush_memory()
         released_pinned = await asyncio.to_thread(
             release_unused_pinned_host_cache)
         logger.info(
@@ -4712,12 +4794,7 @@ class Executor:
             return
         self._pending_alloc_purge = False
         freed_before = time.monotonic()
-        await asyncio.to_thread(gc.collect)
-        if torch is not None and torch.cuda.is_available():
-            try:
-                await asyncio.to_thread(torch.cuda.empty_cache)
-            except Exception:
-                pass
+        await aflush_memory()
         logger.info(
             "purged prior cancelled-setup allocations in %.1fs",
             time.monotonic() - freed_before,
@@ -7365,11 +7442,10 @@ class Executor:
         if server is not None:
             await asyncio.to_thread(server.stop)
         server = None
-        if torch is not None and torch.cuda.is_available():
-            try:
-                await asyncio.to_thread(torch.cuda.empty_cache)
-            except Exception:
-                pass
+        # No gc pass here: the caller holds the load lock and the departing
+        # objects' owners were just dropped above, so only the allocator cache
+        # needs returning (pgw#657 fold).
+        await aflush_memory(collect=False)
         # gw#494: inspect exactly what the instance BOOKED (held_refs) —
         # re-deriving from spec.models would inspect the wrong keys after a
         # resolution rebind. A multiply-held ref stays resident until its last
@@ -7683,6 +7759,15 @@ class Executor:
             **producer_kwargs,
         )
         job.ctx = ctx
+        # th#1130 / pgw#652 Phase 0: let ctx.save_image defer its encode +
+        # C2PA stamp + upload to the finalize tail, which this method drains
+        # AFTER releasing the GPU permit. The handler's RETURN is the
+        # terminality signal — no endpoint change, and an N-image loop cannot
+        # release the permit early because save_image no longer releases
+        # anything. Streaming handlers are excluded: they serialize items
+        # MID-handler, so their outputs have no post-handler tail to ride.
+        if spec.output_mode != "stream" and not spec.is_async_gen:
+            ctx._arm_deferred_outputs()
         if job.cancel_requested:
             ctx._cancel()
         if run.capability_token and self.file_base_url:
@@ -7907,9 +7992,49 @@ class Executor:
                             await asyncio.to_thread(
                                 self._adapters.deactivate, ref, pipe, run.request_id
                             )
+            # The peak is read BEFORE the permit is released: the next job
+            # resets the CUDA peak-allocator watermark when it takes the GPU,
+            # and the finalize tail below runs concurrently with it.
+            peak_vram = self._peak_vram_bytes(gpu_index)
+            # Handler GPU work is done — free the slot before the deferred
+            # encode/upload tail, the result-blob upload and the result send,
+            # so the next job's compute starts now.
+            overlapped = False
+            released_at: Optional[float] = None
+            if lease is not None:
+                overlapped = not lease.yield_slot()
+                released_at = lease.released_at
+            self._intent_transition(
+                job.intent_id,
+                pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
+            )
+            # th#1130: THE tail. Slotless by construction (the permit is gone
+            # above), on a thread so the event loop keeps dispatching. Inside
+            # the try, so a failing encode fails the request cleanly instead
+            # of reporting OK with a hollow asset.
+            if ctx._deferred.pending():
+                from .video_encode import finalize_permit
+
+                def _drain() -> int:
+                    # gw#516 back-pressure: bound how many slotless CPU
+                    # finalizes stack up, same permit the video path takes.
+                    with finalize_permit():
+                        return ctx._drain_deferred_outputs()
+
+                drained = await asyncio.to_thread(_drain)
+                logger.info(
+                    "finalize tail: %d deferred output(s) encoded+uploaded "
+                    "slotless for request %s", drained, run.request_id)
+            handler_done = time.monotonic()
+            # th#1111: the stage map's window must cover the tail it now
+            # contains, so image_encode/credential_stamp/upload land in
+            # total.tail and the map still closes against runtime_ms.
+            ctx._stages.handler_close()
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
                                     output=output, lane=job.lane,
-                                    runtime_terms=_runtime_term_values(spec, payload, ctx))
+                                    runtime_terms=_runtime_term_values(spec, payload, ctx),
+                                    peak_vram_bytes=peak_vram)
             # pgw#652: the request just told us what a concurrent one costs.
             # Only a completed run is evidence — a cancelled or OOM-killed job
             # never reached its real peak.
@@ -7918,12 +8043,7 @@ class Executor:
                     self._activation_key(spec),
                     metrics.peak_vram_bytes - alloc_at_start,
                 )
-            handler_done = time.monotonic()
-            # Handler GPU work is done — free the slot before result-blob
-            # upload and result send so the next job's compute starts now.
             if lease is not None:
-                overlapped = not lease.yield_slot()
-                released_at = lease.released_at
                 if released_at is not None:
                     # gw#516 typed split of runtime_ms: how long the GPU slot
                     # was actually held vs the slotless finalize tail.
@@ -7931,23 +8051,21 @@ class Executor:
                         0, int((released_at - started) * 1000))
                     metrics.finalize_wall_ms = max(
                         0, int((handler_done - released_at) * 1000))
-                if overlapped and released_at is not None:
-                    # The handler released terminally at the decode->finalize
-                    # handoff (gw#476/gw#516): the whole encode/upload tail
-                    # overlapped the next request.
+                if released_at is not None and handler_done > released_at:
+                    # The encode/upload tail ran slotless, overlapping the next
+                    # request. `handoff` says who ended the GPU phase: the
+                    # HANDLER at the decode->finalize signal (gw#476/gw#516
+                    # write_video/write_image), or the EXECUTOR at handler
+                    # return with a deferred tail behind it (th#1130).
                     logger.info(
-                        "FINALIZE_OVERLAP fn=%s request=%s slot_held_ms=%d "
-                        "handler_wall_ms=%d overlap_ms=%d",
+                        "FINALIZE_OVERLAP fn=%s request=%s handoff=%s "
+                        "slot_held_ms=%d handler_wall_ms=%d overlap_ms=%d",
                         spec.name, run.request_id,
+                        "handler" if overlapped else "executor",
                         int((released_at - started) * 1000),
                         int((handler_done - started) * 1000),
                         int((handler_done - released_at) * 1000),
                     )
-            self._intent_transition(
-                job.intent_id,
-                pb.LIFECYCLE_INTENT_STATUS_RUNNING,
-                pb.LIFECYCLE_INTENT_STAGE_FINALIZING,
-            )
             if spec.output_mode == "stream":
                 # gw#475: live deltas are droppable by contract (in-memory
                 # ProgressHub only) — the terminal JobResult carries the
@@ -8388,6 +8506,15 @@ class Executor:
     async def _serialize_output(
         self, ctx: RequestContext, run: pb.RunJob, output: Any
     ) -> Tuple[Optional[bytes], Optional[str]]:
+        # th#1130 safety net: msgpack reads struct fields straight off the C
+        # layout, so an un-drained deferred asset would serialize as nulls.
+        # _run_job_pinned always drains first; this catches any future path
+        # that does not, loudly rather than by shipping a hollow asset.
+        if ctx._deferred.pending():
+            logger.error(
+                "deferred outputs reached serialization un-drained for %s — "
+                "materializing inline", run.request_id)
+            await asyncio.to_thread(ctx._drain_deferred_outputs)
         data = msgspec.msgpack.encode(output)
         if len(data) <= INLINE_RESULT_MAX_BYTES:
             return data, None
@@ -8403,10 +8530,22 @@ class Executor:
             logger.warning("result blob upload failed for %s: %s", run.request_id, exc)
             raise RetryableError("output upload failed") from exc
 
+    @staticmethod
+    def _peak_vram_bytes(gpu_index: int) -> int:
+        """This job's CUDA peak-allocator high-water mark (reset when it took
+        the GPU). 0 without torch/CUDA."""
+        if torch is not None and torch.cuda.is_available():
+            try:
+                return int(torch.cuda.max_memory_allocated(gpu_index))
+            except Exception:
+                return 0
+        return 0
+
     def _metrics(
         self, queue_ms: int, started: float, concurrency_at_start: int, gpu_index: int,
         output: Any = None, lane: str = "",
         runtime_terms: "Optional[Dict[str, float]]" = None,
+        peak_vram_bytes: "Optional[int]" = None,
     ) -> pb.JobMetrics:
         runtime_ms = int((time.monotonic() - started) * 1000)
         # rss_at_end_bytes (pgw#513): instantaneous RSS, honestly named — the
@@ -8419,12 +8558,12 @@ class Executor:
             rss_at_end = int(psutil.Process().memory_info().rss)
         except Exception:
             pass
-        peak_vram = 0
-        if torch is not None and torch.cuda.is_available():
-            try:
-                peak_vram = int(torch.cuda.max_memory_allocated(gpu_index))
-            except Exception:
-                pass
+        # th#1130: the caller reads the peak before releasing the GPU permit
+        # (the next job resets the watermark), and passes it in.
+        peak_vram = (
+            self._peak_vram_bytes(gpu_index) if peak_vram_bytes is None
+            else int(peak_vram_bytes)
+        )
         duration_s, output_count = _scan_output_assets(output)
         usage = _output_token_usage(output)
         return pb.JobMetrics(

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -59,8 +59,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+import requests
+
+from . import cell_key
 from . import compile_cache as cc
-from .models import provision
+from .convert.hub import blake3_file
+# module import (not `from .loading import pipeline_weight_lane`): tests
+# monkeypatch models.loading.pipeline_weight_lane; stay late-bound.
+from .models import loading, provision
+from .models.memory import low_vram_mode
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +199,6 @@ class CellPublisher:
     # -- wire ---------------------------------------------------------------
 
     def _post(self, path: str, payload: dict, *, timeout: float) -> dict:
-        import requests
 
         resp = requests.post(
             f"{self.base_url}{path}",
@@ -226,7 +232,6 @@ class CellPublisher:
         publish-complete bookkeeping. Raises on any failure; the caller
         treats every raise as non-fatal to serving.
         """
-        from . import cell_key
 
         key = str(meta.get("cell_key") or "").strip()
         if not key:
@@ -381,8 +386,6 @@ def enable_compiled(
             "capture would re-point the process-global inductor cache dir "
             "away from it (gw#608)", selection_bug)
 
-    from .models.loading import pipeline_weight_lane
-
     # gw#561: the eager-miss rollback in provision.enable_compiled dropped
     # the branch lane; the mint must key + trace the DECLARED graph family.
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
@@ -393,12 +396,11 @@ def enable_compiled(
     # lane/declared shapes+targets/module structure) — never the traced FX
     # graph bytes — so the ref the hub's self-attested dispatch fence needs
     # is known BEFORE any compile has happened.
-    from . import cell_key as cell_key_mod
 
     try:
-        key = cell_key_mod.compute(
-            family, pipeline_weight_lane(pipe), bucket,
-            contract=cell_key_mod.contract_digest(
+        key = cell_key.compute(
+            family, loading.pipeline_weight_lane(pipe), bucket,
+            contract=cell_key.contract_digest(
                 cc.declared_contract_facts(cfg)),
             regional=bool(getattr(cfg, "regional", False)),
         ).digest
@@ -449,7 +451,7 @@ def enable_compiled(
         capture_dir = mint_root / "capture"
         label = cc.flavor_label(
             cc.runtime_key()["sku"], cc.runtime_key()["torch"],
-            pipeline_weight_lane(pipe))
+            loading.pipeline_weight_lane(pipe))
         target = mint_root / f"{label}.tar.gz"
 
     try:
@@ -524,8 +526,6 @@ def finalize_self_mint(
         _unregister(pending)
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return None
-
-    from .convert.hub import blake3_file
 
     key = str(meta.get("cell_key") or "").strip() or pending.cell_key
     minted = SelfMint(
@@ -637,8 +637,6 @@ def republish_after_shape_warm(
             "hot-swap: live cache root %s has no inductor tree; nothing to "
             "republish", live_root)
         return False
-    from .models.loading import pipeline_weight_lane
-    from .models.memory import low_vram_mode
 
     tmp_root = Path(tempfile.mkdtemp(prefix="cellrepub-"))
     try:
@@ -652,7 +650,7 @@ def republish_after_shape_warm(
             low_vram_mode=low_vram_mode(pipe),
             compile_mode=(
                 "regional" if getattr(cfg, "regional", False) else "whole"),
-            weight_lane=pipeline_weight_lane(pipe),
+            weight_lane=loading.pipeline_weight_lane(pipe),
             lora_bucket=int(getattr(cfg, "lora_bucket", 0) or 0),
             graph_signature=graph_signature,
             weight_contract=weight_contract,
@@ -703,9 +701,8 @@ def _fail_closed(
     ``selection_bug``, when set, is a genuine mint-impossibility exit that
     ALSO followed a caught cell_selection_bug (th#1031) — chained onto the
     raised refusal so the caller's report is never dropped."""
-    from .models.loading import pipeline_weight_lane
 
-    lane = pipeline_weight_lane(pipe)
+    lane = loading.pipeline_weight_lane(pipe)
     if lane.startswith(("w8a8", "w4a4")):
         refusal = cc.CompiledLaneUnavailableError(
             f"{lane[:4].upper()} requires a compile cell and the self-mint "

--- a/src/gen_worker/host_canary.py
+++ b/src/gen_worker/host_canary.py
@@ -20,6 +20,8 @@ import logging
 import time
 from dataclasses import dataclass
 from typing import Optional
+from concurrent.futures import ThreadPoolExecutor
+from .postmortem import effective_cpu_count
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,6 @@ def _measure_cpu_mbps(workers: int) -> float:
     sha256 releases the GIL and stresses the ALU + memory system — a stable
     proxy for the x264/VAE-postprocess CPU work the encode tail is made of.
     """
-    from concurrent.futures import ThreadPoolExecutor
 
     block = b"\xa5" * _HASH_BLOCK
 
@@ -147,7 +148,6 @@ def measure_host_canary() -> HostCanaryReport:
     # 4 — and shipping that next to a cgroup-derived ram_total_gb produced a
     # "32 vCPUs / 14.9 GB" report nobody could interpret. Report what this
     # container may actually use, and benchmark with that many threads.
-    from .postmortem import effective_cpu_count
 
     vcpus = effective_cpu_count()
     try:

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -28,6 +28,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Tuple
+from . import compile_cache
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +397,6 @@ def _run_warm(job: _WarmJob) -> None:
 
 
 def router_of(pipeline: Any) -> Optional[Router]:
-    from . import compile_cache
 
     marker = getattr(pipeline, compile_cache._MARKER_ATTR, None) or {}
     signal = marker.get("failure_signal")

--- a/src/gen_worker/input_assets.py
+++ b/src/gen_worker/input_assets.py
@@ -33,6 +33,7 @@ import msgspec
 from .api.errors import CanceledError, RetryableError, ValidationError
 from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
 from .request_context._helpers import _infer_mime_type, _url_is_blocked
+from .url_fetch import open_guarded_stream
 
 logger = logging.getLogger(__name__)
 
@@ -488,7 +489,13 @@ def _download(
                 f"input_asset_too_large: {occurrences[0].path} exceeds its byte cap"
             )
         cap = entry.size_bytes
-    req = urllib.request.Request(unit.url, headers={"User-Agent": "gen-worker"})
+    # pgw#663: redirects go through the guarded opener, which re-applies the
+    # SSRF policy to EVERY hop. `urlopen` follows them silently, so the
+    # pre-flight `_validate_transport_url` only ever covered hop 0 — a caller
+    # transport that 302s at the metadata service was reachable. Private
+    # (resolver-minted, blake3-attested) units keep their internal-object-host
+    # exemption, which is the whole reason that env var exists.
+    resolver_minted = entry is not None
     try:
         fd, tmp_name = tempfile.mkstemp(prefix=f"input-{index}-", suffix=".part", dir=dest_dir)
     except OSError:
@@ -501,7 +508,17 @@ def _download(
     hasher = blake3_mod.blake3() if entry is not None else None
     try:
         try:
-            with urllib.request.urlopen(req, timeout=_DOWNLOAD_TIMEOUT_S) as response:
+            with open_guarded_stream(
+                unit.url,
+                timeout_s=_DOWNLOAD_TIMEOUT_S,
+                extra_allowed_hosts=(
+                    tuple(_internal_object_hosts()) if resolver_minted else ()
+                ),
+                # This module's own reference to the destination policy, so
+                # the pre-flight check and the per-hop check are provably the
+                # same function.
+                is_blocked=_url_is_blocked,
+            ) as response:
                 raw_length = str(response.headers.get("Content-Length") or "").strip()
                 expected_length = int(raw_length) if raw_length.isdigit() else 0
                 if expected_length > cap:

--- a/src/gen_worker/io.py
+++ b/src/gen_worker/io.py
@@ -136,6 +136,24 @@ IMAGE_FORMATS: dict[str, tuple[str, str]] = {
 }
 
 
+def image_format(format: str = DEFAULT_IMAGE_FORMAT) -> tuple[str, str]:
+    """``(PIL format, file extension)`` for a tenant-facing format name.
+
+    Split out of :func:`encode_image` so the deferred-tail path (th#1130) can
+    validate the format and derive the ref's extension EAGERLY, at the
+    ``save_image`` call — a bad format must raise in the handler, never in the
+    finalize tail.
+    """
+    fmt = str(format or DEFAULT_IMAGE_FORMAT).strip().lower()
+    try:
+        return IMAGE_FORMATS[fmt]
+    except KeyError:
+        raise ValidationError(
+            f"unsupported image format {format!r}; expected one of "
+            f"{', '.join(sorted(IMAGE_FORMATS))}"
+        ) from None
+
+
 def encode_image(
     image: Any,
     *,
@@ -156,14 +174,7 @@ def encode_image(
     :class:`~gen_worker.api.errors.ValidationError` rather than surfacing a
     PIL traceback.
     """
-    fmt = str(format or DEFAULT_IMAGE_FORMAT).strip().lower()
-    try:
-        pil_format, ext = IMAGE_FORMATS[fmt]
-    except KeyError:
-        raise ValidationError(
-            f"unsupported image format {format!r}; expected one of "
-            f"{', '.join(sorted(IMAGE_FORMATS))}"
-        ) from None
+    pil_format, ext = image_format(format)
 
     img = image
     # JPEG has no alpha channel and no palette; convert or PIL raises.
@@ -388,6 +399,7 @@ __all__ = [
     "read_image",
     "read_audio",
     "encode_image",
+    "image_format",
     "write_image",
     "DEFAULT_IMAGE_FORMAT",
     "DEFAULT_IMAGE_QUALITY",

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -19,6 +19,9 @@ from .intent_registry import IntentRegistry, UnreportedIntentWait
 from .pb import worker_scheduler_pb2 as pb
 from .runtime_config import ConfigSnapshotWriteError, extract_config_push
 from .transport import FatalTransportError, PROTOCOL_VERSION, Transport
+from .api.binding import wire_ref
+# module import: tests monkeypatch worker_fatal.report_worker_error_async; stay late-bound.
+from . import worker_fatal
 
 logger = logging.getLogger(__name__)
 
@@ -802,10 +805,9 @@ class Lifecycle:
         (ie#544: signature="" detail="worker phase reported error"). Dial
         the gw#640 worker-fatal carrier once per process, best-effort; the
         hub stores it as a queryable pod_events row."""
-        from .worker_fatal import build_fatal_detail, report_worker_error_async
 
         if exc is not None:
-            detail = build_fatal_detail(f"phase_error: {reason}", exc, exit_code=0)
+            detail = worker_fatal.build_fatal_detail(f"phase_error: {reason}", exc, exit_code=0)
         else:
             detail = f"phase=phase_error: {reason}"
         logger.error("entering WORKER_PHASE_ERROR: %s", detail)
@@ -818,7 +820,7 @@ class Lifecycle:
         settings = getattr(self, "_settings", None)
 
         async def _dial() -> None:
-            await report_worker_error_async(settings, detail)
+            await worker_fatal.report_worker_error_async(settings, detail)
 
         try:
             asyncio.get_running_loop().create_task(_dial(), name="phase-error-report")
@@ -963,8 +965,6 @@ class Lifecycle:
         self.executor.store.rescan_disk()
         self.executor.gate_functions(self.hardware)
 
-        from .api.binding import wire_ref
-
         prefetch_refs: List[str] = []
         for spec in self.executor.specs.values():
             if spec.name in self.executor.unavailable:
@@ -991,7 +991,21 @@ class Lifecycle:
                 try:
                     await self.executor.store.ensure_local(ref)
                 except Exception as exc:
-                    logger.error("startup prefetch of %s failed terminally: %s", ref, exc)
+                    # pgw#655: this used to log and walk on to READY with an
+                    # unmaterialized model, so the failure resurfaced as a
+                    # per-job load failure on paid GPU. `_materialize_local`
+                    # has already retried the transient classes with backoff;
+                    # reaching here means the model is not coming, so the
+                    # functions that need it go unavailable NOW and the hub
+                    # stops routing to them.
+                    gated = self.executor.mark_ref_unmaterializable(
+                        ref, f"{type(exc).__name__}: {exc}")
+                    logger.error(
+                        "startup prefetch of %s failed terminally: %s — gating %s "
+                        "(pgw#655: a worker never advertises a function whose "
+                        "model is absent)",
+                        ref, exc, ", ".join(gated) or "no function",
+                    )
 
         await self.set_phase(pb.WORKER_PHASE_LOADING_PIPELINES)
         awaiting_hub: Dict[str, List[str]] = {}

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -60,6 +60,8 @@ from typing import Any, Optional
 
 from . import activity as activity_mod
 from . import compile_cache as cc
+from .models.loading import pipeline_weight_lane
+from .models import provision
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +196,6 @@ def _fail_closed(pipe: Any, reason: str) -> bool:
     when the local mint cannot produce a cell either, the refusal stays
     TYPED (the same CompiledLaneUnavailableError the executor maps). Plain
     lanes keep the gw#555 never-raise miss policy (eager)."""
-    from .models.loading import pipeline_weight_lane
 
     lane = pipeline_weight_lane(pipe)
     if lane.startswith(("w8a8", "w4a4")):
@@ -218,7 +219,6 @@ def enable_compiled(
     mint attempt, never to silent slow eager (gw#564 found the raise
     aborting the mint path live on a 4090).
     """
-    from .models import provision
 
     family = str(getattr(cfg, "family", "") or "")
     try:
@@ -237,8 +237,6 @@ def enable_compiled(
     if not _cuda_ready():
         # apply() already logged; nothing to mint for
         return _fail_closed(pipe, "CUDA unavailable")
-
-    from .models.loading import pipeline_weight_lane
 
     # gw#561: the eager-miss rollback in provision.enable_compiled dropped
     # the branch lane; local store/mint must key + trace the DECLARED graph

--- a/src/gen_worker/models/cozy_cas.py
+++ b/src/gen_worker/models/cozy_cas.py
@@ -248,7 +248,6 @@ def _download_one_file_sync(
 
 def fsync_file(path: Path) -> None:
     """Force a file's data to stable storage (read-only fd works on Linux)."""
-    import os
 
     try:
         fd = os.open(path, os.O_RDONLY)
@@ -264,7 +263,6 @@ def fsync_file(path: Path) -> None:
 
 def fsync_dir(path: Path) -> None:
     """Persist a directory entry (the rename itself) to stable storage."""
-    import os
 
     try:
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -22,6 +22,7 @@ from .refs import TensorhubRef
 from .. import activity as _activity
 from ..capability import InsufficientDiskError
 from ..s3_transfer import S3TransferGrant, download_file_with_grant
+from .loading import safetensors_file_valid
 
 _log = logging.getLogger("gen_worker.download")
 
@@ -778,7 +779,6 @@ def _verify_materialized_tree(
     BLAKE3; reassembled chunked originals (which the manifest digests only
     part-wise) get the structural safetensors check. Returns
     ``(ok, bad)`` — hex digests in ``bad`` name blobs to quarantine."""
-    from .loading import safetensors_file_valid
 
     bad: List[str] = []
     covered: Set[Path] = set()

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -31,6 +31,8 @@ from ..api.errors import ValidationError
 from ..config import get_settings
 from .cache_paths import tensorhub_cas_dir
 from .refs import HuggingFaceRef, TensorhubRef, fold_ref, parse_model_ref
+import hashlib
+from fnmatch import fnmatch
 
 if TYPE_CHECKING:
     from .hub_client import WorkerResolvedRepo
@@ -424,26 +426,34 @@ def components_present(paths: Sequence[str], components: Sequence[str]) -> bool:
 def _match_allow_patterns(repo_files: Sequence[str], patterns: Sequence[str]) -> set[str]:
     """Repo files matched by ``patterns`` — huggingface_hub semantics
     (fnmatch; a trailing ``/`` means the whole directory)."""
-    from fnmatch import fnmatch
 
     pats = [p + "*" if p.endswith("/") else p for p in patterns]
     return {f for f in repo_files if any(fnmatch(f, p) for p in pats)}
 
 
-# HF snapshot-download guards (#379): stall window (no byte progress), wall-
-# clock cap (0 = off), and the accidental-huge-repo cap (0 = off). No
-# deployment has ever overridden these (pgw#514 dead-config sweep found zero
-# producers for the env vars that used to back them), so they're fixed
-# constants rather than Settings fields.
+# HF snapshot-download guards (#379): the progress window and the
+# accidental-huge-repo cap (0 = off). No deployment has ever overridden these
+# (pgw#514 dead-config sweep found zero producers for the env vars that used
+# to back them), so they're fixed constants rather than Settings fields.
+#
+# pgw#655: the bound is a PROGRESS-RATE FLOOR, never a wall clock. A wall-clock
+# cap cannot distinguish a healthy 200GB pull from a wedge, so it is either
+# useless (the 0.0 it sat at for its whole life) or it kills real downloads;
+# the honest question is "is this transfer still moving fast enough to ever
+# finish?". A transfer that cannot put _HF_DOWNLOAD_MIN_WINDOW_BYTES on disk
+# within _HF_DOWNLOAD_STALL_TIMEOUT_S is stalled — including the trickle that
+# used to reset the old any-progress watchdog forever with a byte a minute.
+# 8 MiB / 180s ~= 46 KiB/s: three orders of magnitude under any real pod link,
+# and still 60+ hours for a 10GB checkpoint, so nothing healthy is near it.
 _HF_DOWNLOAD_STALL_TIMEOUT_S = 180.0
-_HF_DOWNLOAD_MAX_SECONDS = 0.0
+_HF_DOWNLOAD_MIN_WINDOW_BYTES = 8 * 1024 * 1024
 _HF_MAX_REPO_BYTES = 60_000_000_000
 
 
 class DownloadStalledError(RuntimeError):
-    """Raised when a blocking snapshot download makes no byte progress for the
-    stall window (or exceeds the wall-clock cap) — a bounded, observable
-    failure instead of a silent hang (#379)."""
+    """Raised when a blocking snapshot download fails the progress-rate floor
+    (less than ``min_window_bytes`` of new bytes within the stall window) — a
+    bounded, observable failure instead of a silent hang (#379, pgw#655)."""
 
 
 def _scan_bytes(root: Path) -> int:
@@ -474,13 +484,15 @@ def _run_with_stall_watchdog(
     progress_callback: Optional[ProgressFn],
     total_hint: Optional[int],
     stall_timeout: float,
-    wall_clock_max: float,
+    min_window_bytes: int = _HF_DOWNLOAD_MIN_WINDOW_BYTES,
     scan_bytes: Callable[[Path], int] = _scan_bytes,
     poll_interval: float = 0.5,
 ) -> str:
     """Run a blocking download on a daemon thread; the watchdog doubles as the
     progress reporter (scans bytes-on-disk under ``progress_root``) and raises
-    :class:`DownloadStalledError` on no-progress / wall-clock breach."""
+    :class:`DownloadStalledError` when the transfer falls below the progress
+    floor: fewer than ``min_window_bytes`` new bytes within ``stall_timeout``
+    (pgw#655 — a trickle is a stall, and there is no wall-clock cap)."""
     holder: Dict[str, Any] = {}
 
     def _run() -> None:
@@ -496,7 +508,11 @@ def _run_with_stall_watchdog(
 
     started_at = time.monotonic()
     last_bytes = 0
-    last_progress_at = started_at
+    # Progress window: bytes on disk when the current window opened, and when
+    # it opened. The window closes (and reopens from here) the moment the
+    # floor is cleared; it never resets on a byte, so a trickle expires it.
+    window_bytes = 0
+    window_opened_at = started_at
     while not holder.get("done"):
         dl_thread.join(timeout=poll_interval)
         if holder.get("done"):
@@ -509,25 +525,26 @@ def _run_with_stall_watchdog(
                 seen = last_bytes
             if seen > last_bytes:
                 last_bytes = seen
-                last_progress_at = now
                 if progress_callback is not None:
                     try:
                         progress_callback(seen, total_hint)
                     except Exception:
                         pass
-            elif stall_timeout > 0 and (now - last_progress_at) > stall_timeout:
+            if seen - window_bytes >= max(int(min_window_bytes), 1):
+                window_bytes = seen
+                window_opened_at = now
+            elif stall_timeout > 0 and (now - window_opened_at) > stall_timeout:
+                moved = seen - window_bytes
                 logger.error(
-                    "download STALLED %s: no byte progress for %.0fs (downloaded=%d bytes); "
-                    "abandoning the wedged thread (#379)", label, now - last_progress_at, last_bytes,
+                    "download STALLED %s: %d bytes in the last %.0fs (floor %d bytes; "
+                    "downloaded=%d total); abandoning the wedged thread (#379, pgw#655)",
+                    label, moved, now - window_opened_at, int(min_window_bytes), last_bytes,
                 )
                 raise DownloadStalledError(
-                    f"download({label}) stalled: no progress for "
-                    f"{stall_timeout:.0f}s after {last_bytes} bytes"
+                    f"download({label}) stalled: only {moved} bytes in "
+                    f"{stall_timeout:.0f}s (floor {int(min_window_bytes)} bytes) "
+                    f"after {last_bytes} bytes"
                 )
-        if wall_clock_max > 0 and (now - started_at) > wall_clock_max:
-            raise DownloadStalledError(
-                f"download({label}) exceeded {wall_clock_max:.0f}s wall-clock cap"
-            )
 
     if "exc" in holder:
         raise holder["exc"]
@@ -563,7 +580,7 @@ def download_hf(
     per-component flavor picking (bf16 > fp16 > untagged), just over a
     smaller candidate set.
     """
-    from ..net import hf
+    from ..net import hf  # lazy: net imports requests; keeps `import gen_worker` light
 
     try:
         hub = hf()  # gw#456: no HF socket may wait forever
@@ -667,7 +684,6 @@ def download_hf(
         progress_callback=progress,
         total_hint=total_hint,
         stall_timeout=_HF_DOWNLOAD_STALL_TIMEOUT_S,
-        wall_clock_max=_HF_DOWNLOAD_MAX_SECONDS,
     )
     if progress is not None:
         try:
@@ -716,8 +732,7 @@ def parse_civitai_version_id(raw: str) -> int:
 
 
 def _civitai_get_json(url: str, api_key: str = "") -> dict[str, Any]:
-    import requests
-    from urllib.parse import urlparse
+    import requests  # lazy (all sites): download is on the `import gen_worker` path; stays requests-free
 
     headers: Dict[str, str] = {}
     if api_key and urlparse(url).hostname in _CIVITAI_AUTH_HOSTS:
@@ -843,10 +858,8 @@ def _civitai_stream_one(
     expected_sha256: str,
     on_bytes: Callable[[int], None],
 ) -> int:
-    import hashlib
 
     import requests
-    from urllib.parse import urlparse
 
     headers: Dict[str, str] = {}
     if api_key and urlparse(url).hostname in _CIVITAI_AUTH_HOSTS:

--- a/src/gen_worker/models/gguf_local.py
+++ b/src/gen_worker/models/gguf_local.py
@@ -24,6 +24,13 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from .hub_client import WorkerResolvedRepo
 from .refs import TensorhubRef
+from .loading import FP8_STORAGE_FIT_FACTOR
+from .ladder import (placement_for_flavor, placement_from_metadata, w8a8_excluded_for_family)
+from .lanes import is_w8a8_flavor
+import asyncio
+import time
+from .cozy_snapshot import ensure_snapshot_async
+from .errors import UrlExpiredError
 
 logger = logging.getLogger(__name__)
 
@@ -95,17 +102,9 @@ def select_gguf(
     base_gb = float(resolved.size_bytes or sum(f.size_bytes for f in files)) / 1e9
     # The regular loader can keep the base resident or cast its denoiser to
     # fp8 at load. GGUF is the rung after those, never a preference over them.
-    from .loading import FP8_STORAGE_FIT_FACTOR
 
     if base_gb <= free or base_gb * FP8_STORAGE_FIT_FACTOR <= free:
         return None
-
-    from .ladder import (
-        placement_for_flavor,
-        placement_from_metadata,
-        w8a8_excluded_for_family,
-    )
-    from .lanes import is_w8a8_flavor
 
     # th#964: w8a8 rows of conv-UNet families are AUTO-ineligible — they
     # must not count as a fitting native rung that suppresses the GGUF pick.
@@ -257,11 +256,6 @@ def fetch_gguf_snapshot(
     ref. Mirrors ``_fetch_tensorhub_snapshot``'s contract (progress events,
     one re-resolve retry on presigned-URL expiry); returns the snapshot dir.
     """
-    import asyncio
-    import time
-
-    from .cozy_snapshot import ensure_snapshot_async
-    from .errors import UrlExpiredError
 
     if resolve is not None:
         resolver = resolve

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 
 from ..config import get_settings
 from .refs import TensorhubRef
+import requests
 
 
 # In-memory shape of a resolved cozy: ref. PRODUCTION workers never resolve
@@ -81,7 +82,6 @@ def resolve_repo(
     for private. Returns the manifest + presigned GET URLs ready for
     ``cozy_snapshot.ensure_snapshot_async``.
     """
-    import requests
 
     base = hub_base_url(base_url)
     if not base:

--- a/src/gen_worker/models/hub_policy.py
+++ b/src/gen_worker/models/hub_policy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+from .memory import effective_vram_requirement_gb
+from .loading import EMERGENCY_FIT_FACTOR, FP8_STORAGE_FIT_FACTOR
 
 
 @dataclass(frozen=True)
@@ -218,7 +220,6 @@ def variant_fit(
     # vram_gb recommends a card SIZE (total VRAM), so an idle card of exactly
     # that size counts as fitting: subtract the fixed driver/framebuffer/CUDA
     # reserve before comparing against measured free VRAM.
-    from .memory import effective_vram_requirement_gb
 
     if vram is None or effective_vram_requirement_gb(vram) <= float(free_vram_gb):
         if svdq_kind == "fp4":
@@ -230,7 +231,6 @@ def variant_fit(
         if quant_kind == "nvfp4":
             return FIT_NVFP4, "nvfp4 stored flavor (Blackwell rung)"
         return FIT_FITS, ""
-    from .loading import EMERGENCY_FIT_FACTOR, FP8_STORAGE_FIT_FACTOR
 
     # Runtime rungs are automatic on CUDA hosts (gw#420) — pure functions of
     # the declared capabilities, so verdicts don't depend on the probing host.

--- a/src/gen_worker/models/lanes.py
+++ b/src/gen_worker/models/lanes.py
@@ -173,6 +173,7 @@ def is_w8a8_flavor(token: str) -> bool:
 def lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> Lane:
     """The concrete lane a (flavor, cast/storage_dtype) binding executes as —
     the twin of tensorhub's ``LaneOfResolution``."""
+    # cycle: ladder imports lanes at module top
     from .ladder import (
         CLASS_FP8,
         CLASS_NVFP4_W4A4,

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -11,6 +11,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
+import importlib
+import importlib.util
+import os
+import struct
+import sys
+
+from .memory import get_available_vram_gb, meta_tensors
+from .svdq import detect_svdq_artifact, load_svdq_pipeline
+from .w4a4 import detect_w4a4_artifact, load_w4a4_pipeline, load_w4a4_root_pipeline
+from .w8a8 import detect_w8a8_artifact, load_w8a8_pipeline, load_w8a8_root_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +82,6 @@ def safetensors_file_valid(path: Path) -> bool:
     header must parse and the file must contain every declared tensor byte.
     Catches truncation (pod-churn-interrupted writes, gw#408) without hashing;
     zero-page corruption inside tensor data needs the digest check instead."""
-    import struct
 
     try:
         p = Path(path)
@@ -106,7 +115,6 @@ def detect_on_disk_dtype(model_path: Path) -> str:
     this a bf16 snapshot silently loads via diffusers' fp32 default — 2x the
     VRAM. "fp8" marks an fp8-E4M3-stored flavor whose storage precision must
     be preserved (see :func:`apply_fp8_storage`)."""
-    import struct
 
     counts: Dict[str, int] = {}
     try:
@@ -543,6 +551,7 @@ def detect_gguf_snapshot(path: Path) -> Optional[tuple[Path, str]]:
     p = Path(path)
     if not p.is_dir() or not (p / "model_index.json").exists():
         return None
+    # cycle: gguf_local imports loading at module top
     from .gguf_local import gguf_qtype, read_marker
 
     marker = read_marker(p)
@@ -567,7 +576,6 @@ def load_gguf_pipeline(
     components: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Load a GGUF denoiser into the remaining components' base tree."""
-    import importlib
 
     import torch
     from diffusers import GGUFQuantizationConfig
@@ -641,7 +649,6 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
     combined header with rebased offsets, then stream-copy each tensor's byte
     range. No torch/safetensors dependency, no RAM spike. Idempotent: the
     merged file is cached next to the shards."""
-    import struct
 
     merged = snapshot_dir / index_path.name[: -len(".index.json")]
     if merged.exists():
@@ -699,7 +706,6 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
                     out.write(buf)
                     remaining -= len(buf)
         out.flush()
-        import os
 
         os.fsync(out.fileno())  # durable before rename (gw#408)
     tmp.rename(merged)
@@ -870,7 +876,6 @@ def load_component_override(
     ``<component>/`` subtree when present, else its root. ``dtype`` (the
     base binding's) wins; otherwise the override's on-disk dtype is
     honored. Blocking; callers on an event loop run it off-thread."""
-    import importlib
 
     entry = model_index_entry(base_path, component)
     if entry is None:
@@ -903,7 +908,6 @@ def load_component_override(
 
 
 def _safetensors_data_bytes(p: Path) -> int:
-    import struct
 
     with open(p, "rb") as f:
         raw = f.read(8)
@@ -923,7 +927,6 @@ def _safetensors_data_bytes(p: Path) -> int:
 
 def _safetensors_fp8_bytes(p: Path) -> int:
     """Bytes of F8_E4M3-stored tensors in one safetensors file (header-only)."""
-    import struct
 
     with open(p, "rb") as f:
         raw = f.read(8)
@@ -983,8 +986,6 @@ def bitsandbytes_available() -> bool:
     constructs fine without bitsandbytes and the load then dies deep in
     ``validate_environment`` (PackageNotFoundError -> setup_failed). An
     unavailable rung must be SKIPPED, never attempted."""
-    import importlib.util
-    import sys
 
     if "bitsandbytes" in sys.modules:
         return True
@@ -1092,7 +1093,6 @@ def _adaptive_fit_rung(
     emergency-quantize."""
     if not emergency_quant_enabled():
         return "", None
-    from .memory import get_available_vram_gb
 
     free_gb = get_available_vram_gb()
     if free_gb <= 0:
@@ -1194,7 +1194,6 @@ def load_from_pretrained(
     # pipeline. Detection precedes every other rung; failures are typed
     # (SvdqStackError / SvdqHardwareError / SvdqSnapshotError), never a
     # mid-denoise crash.
-    from .svdq import detect_svdq_artifact, load_svdq_pipeline
 
     svdq_art = detect_svdq_artifact(Path(path))
     if svdq_art is not None and callable(getattr(cls, "from_pretrained", None)):
@@ -1205,11 +1204,6 @@ def load_from_pretrained(
     # scaled-mm lane (fp8 resident, no per-layer cast); hosts without usable
     # scaled_mm dequant once to bf16-resident. Precedes the storage-cast
     # rungs — a scale-free fp8 tree never detects here.
-    from .w8a8 import (
-        detect_w8a8_artifact,
-        load_w8a8_pipeline,
-        load_w8a8_root_pipeline,
-    )
 
     w8a8_art = detect_w8a8_artifact(Path(path))
     if w8a8_art is not None and callable(getattr(cls, "from_pretrained", None)):
@@ -1240,11 +1234,6 @@ def load_from_pretrained(
     # take the blockwise fp4 scaled_mm lane on Blackwell (sm_100+); other
     # qualifying hosts dequant once to bf16-resident. Disjoint from w8a8
     # detection (uint8 vs e4m3 weights) and from scale-free trees.
-    from .w4a4 import (
-        detect_w4a4_artifact,
-        load_w4a4_pipeline,
-        load_w4a4_root_pipeline,
-    )
 
     w4a4_art = detect_w4a4_artifact(Path(path))
     if w4a4_art is not None and callable(getattr(cls, "from_pretrained", None)):
@@ -1356,7 +1345,6 @@ def load_from_pretrained(
             kwargs.pop("variant", None)
             kwargs.pop("quantization_config", None)
             pipe = cls.from_pretrained(path, **kwargs)
-    from .memory import meta_tensors
 
     unmaterialized = meta_tensors(pipe)
     if unmaterialized:

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -531,6 +531,37 @@ def flush_memory() -> None:
         pass
 
 
+async def aflush_memory(*, collect: bool = True, reset_peak: bool = False) -> None:
+    """Async twin of :func:`flush_memory` for the executor's teardown paths
+    (pgw#657 — three hand-rolled copies of this lived inline).
+
+    Both steps are blocking C calls (a full gc pass over a torn-down pipeline
+    is seconds), so each rides ``asyncio.to_thread`` — that, not the body, is
+    why this could not simply call ``flush_memory``.
+
+    ``reset_peak`` defaults FALSE and the executor never sets it: pgw#652's
+    activation learning reads ``max_memory_allocated`` per request, so a
+    teardown that quietly reset the peak would zero the measurement the
+    admission ladder is built on.
+    """
+    import asyncio
+
+    if collect:
+        await asyncio.to_thread(gc.collect)
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 — torch-free installs (cozy-local CLI)
+        return
+    if not torch.cuda.is_available():
+        return
+    try:
+        await asyncio.to_thread(torch.cuda.empty_cache)
+        if reset_peak:
+            await asyncio.to_thread(torch.cuda.reset_peak_memory_stats)
+    except Exception:
+        _LOG.debug("aflush_memory: CUDA cache flush failed", exc_info=True)
+
+
 def release_unused_pinned_host_cache() -> int:
     """Return unused PyTorch pinned-host blocks to the OS, best effort.
 
@@ -1227,6 +1258,7 @@ __all__ = [
     "effective_vram_requirement_gb",
     "get_available_ram_gb",
     "get_total_ram_gb",
+    "aflush_memory",
     "flush_memory",
     "release_unused_pinned_host_cache",
 ]

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -18,6 +18,7 @@ ModelScope downloads — through the same download layer.
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import logging
 import time
@@ -25,8 +26,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
+from ..api.binding import ModelRef, wire_ref
 from ..config import get_settings
-from .loading import model_index_components
+from .cache_paths import tensorhub_cas_dir
+from .errors import UrlExpiredError
+from .ladder import maybe_rebind_family_fp8
+from .loading import load_from_pretrained, model_index_components
+from .memory import place_pipeline
+from .refs import parse_model_ref
 
 __all__ = ["model_index_components"]  # re-export: single source in loading.py (gw#521)
 
@@ -112,9 +119,6 @@ def load_slot(
             and callable(getattr(annotation, "from_pretrained", None))):
         return SlotLoad(obj=path)
 
-    from .loading import load_from_pretrained
-    from .memory import place_pipeline
-
     dtype = str(getattr(binding, "dtype", "") or "")
     storage_dtype = force_storage_dtype or str(getattr(binding, "storage_dtype", "") or "")
     out = SlotLoad(obj=None, is_pipeline=True, ran=(dtype or "bf16"))
@@ -197,7 +201,7 @@ def enable_compiled(
     adopt. Staying eager rolls the branches back — canonical zeroed slots
     cost +21-32% eager (gw#547); the eager adapter path re-enables sparse
     placement per request."""
-    from .. import compile_cache, trt_engine
+    from .. import compile_cache, trt_engine  # lazy: keeps `import gen_worker` off the compile/pb stack
 
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     if bucket and not compile_cache.has_compile_target(pipe, cfg):
@@ -404,7 +408,6 @@ def resolve_bindings(
     instead of silently running the slot's default — ``cozy run`` only ever
     runs a Slot's ``default_checkpoint`` ref locally.
     """
-    from ..api.binding import ModelRef, wire_ref
 
     out: Dict[str, str] = {}
     for param_name, binding in bindings.items():
@@ -440,10 +443,7 @@ def _local_flavor_fold(binding: Any, slot: Any) -> Any:
     """Local AUTO flavor folds over ONE shared resolve: family fp8 (th#964)
     first, then the GGUF small-VRAM pick (cl#27). Fail-open — any resolve or
     probe error keeps the binding as declared. Production stays hub-owned."""
-    from ..api.binding import wire_ref
-    from .gguf_local import maybe_rebind_gguf
-    from .ladder import maybe_rebind_family_fp8
-    from .refs import parse_model_ref
+    from .gguf_local import maybe_rebind_gguf  # cycle: gguf_local imports loading
 
     if (
         getattr(binding, "source", "") != "tensorhub"
@@ -520,10 +520,8 @@ def _fetch_tensorhub_snapshot(
     covers the FULL-repo case — a components=-scoped ref must be fetched
     online at least once per component set.
     """
-    import asyncio
-
+    # lazy: cozy_snapshot/hub_client import requests; keeps `import gen_worker` light
     from .cozy_snapshot import ensure_snapshot_async, snapshot_dir_key
-    from .errors import UrlExpiredError
     from .hub_client import HubResolveError, resolve_repo
 
     canonical = thref.canonical()
@@ -605,8 +603,6 @@ def resolve_local_path(
     pipeline component subfolders (+ root config files) — see
     ``download.select_component_paths`` / ``cozy_snapshot.snapshot_dir_key``.
     """
-    from .cache_paths import tensorhub_cas_dir
-    from .refs import parse_model_ref
 
     env_cas = get_settings().tensorhub_cas_dir.strip()
     cache_dir = Path(env_cas) if env_cas else Path(tensorhub_cas_dir())

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -40,6 +40,8 @@ from .memory import (
     log_ram_budget_once,
     repair_device_placement,
 )
+from .pinned_swap import swap_object
+from .pinned_swap import cached_swap_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +205,6 @@ def _move_obj(obj: Any, device: str) -> None:
     CUDA OOM here used to book a half-moved pipeline as resident (gw#409)."""
     if obj is None or _obj_manages_own_device(obj):
         return
-    from .pinned_swap import swap_object
 
     if swap_object(obj, device):
         return
@@ -502,7 +503,6 @@ class Residency:
             # the host thrashes into the keepalive-stall livelock. Bytes
             # already staged in the pinned swap cache (gw#551) are resident
             # host RAM — only the uncached remainder is a fresh demand.
-            from .pinned_swap import cached_swap_bytes
 
             need_gb = float(e.vram_hint or e.vram_bytes) / _GiB
             if need_gb <= 0.0:

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -25,6 +25,7 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
+import importlib.metadata as md
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +149,6 @@ def svdq_stack_reason() -> Optional[str]:
     """Non-raising stack check against the INSTALLED environment (importlib
     metadata only — does not import nunchaku's CUDA extension). Returns the
     failure reason, or None when the svdq lane is servable here."""
-    import importlib.metadata as md
 
     try:
         nunchaku_version = md.version("nunchaku")

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -44,6 +44,7 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -848,7 +849,6 @@ def quantize_tree_w4a4(
     """Copy a diffusers tree, rewriting the denoiser's eligible 2D weights
     to the gw#540 contract triple. Eligible: ``*.weight``, 2D, float,
     in %% 32 == 0, out %% 16 == 0, name not matching ``exclude``."""
-    import shutil
 
     import torch
     from safetensors.torch import load_file, save_file

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -38,6 +38,7 @@ import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -790,7 +791,6 @@ def quantize_tree_w8a8(
     fp8 + per-out-channel ``weight_scale`` per the gw#534 contract. Eligible:
     ``*.weight``, 2D, bf16/fp16/fp32, both dims 16-aligned, name not matching
     ``exclude`` substrings."""
-    import shutil
 
     import torch
     from safetensors.torch import load_file, save_file

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -38,6 +38,8 @@ import time
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from ..api.errors import RefCompatibilitySurprise, ValidationError
+from .w8a8 import fp8_scaled_linear_class
+import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +104,6 @@ def branch_modules(model: Any) -> Dict[str, Any]:
     branch targets — adapters that name them fail loud in
     :func:`map_adapter`."""
     import torch.nn as nn
-
-    from .w8a8 import fp8_scaled_linear_class
 
     fp8_cls = fp8_scaled_linear_class()
     return {
@@ -334,7 +334,6 @@ _WRAP_ATTR = "_cozy_lora_wrapped"
 
 
 def _is_scaled_linear(mod: Any) -> bool:
-    from .w8a8 import fp8_scaled_linear_class
 
     return isinstance(mod, fp8_scaled_linear_class())
 
@@ -664,7 +663,6 @@ def normalize_adapter_state_dict(
     before. sdxl-class converters receive ``unet_config`` for SGM block
     remapping of kohya adapters. Returned ``network_alphas`` fold back in as
     ``<module>.alpha`` entries."""
-    import inspect
 
     fn = getattr(type(pipe), "lora_state_dict", None)
     if fn is None:

--- a/src/gen_worker/net.py
+++ b/src/gen_worker/net.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import threading
 from typing import Any
+import requests
 
 CONNECT_TIMEOUT_ENV = "COZY_HTTP_CONNECT_TIMEOUT_S"
 READ_TIMEOUT_ENV = "COZY_HTTP_READ_TIMEOUT_S"
@@ -25,6 +26,18 @@ DEFAULT_READ_TIMEOUT_S = 60.0
 
 _lock = threading.Lock()
 _installed = False
+
+
+class HfHttpFloorError(RuntimeError):
+    """The huggingface_hub timeout floor could not be installed or PROVEN.
+
+    pgw#657: this patch is load-bearing and reaches into ``huggingface_hub``'s
+    backend, which has already been reshaped once (requests -> httpx). A silent
+    revert puts the whole fleet back on infinite timeouts — the gw#456 hang —
+    and nothing would say so. So installation ends in a behavioural assertion
+    on the session huggingface_hub will actually use, and a failure is loud at
+    boot instead of a wedge weeks later.
+    """
 
 
 def _env_seconds(name: str, default: float) -> float:
@@ -57,8 +70,51 @@ def _floor_timeout_hook(request: Any) -> None:
     }
 
 
+def _hf_version() -> str:
+    try:
+        import huggingface_hub
+
+        return str(getattr(huggingface_hub, "__version__", "") or "unknown")
+    except Exception:  # noqa: BLE001 — only used to name a version in an error
+        return "unknown"
+
+
+def _verify_httpx_floor() -> None:
+    """Prove the floor on the session huggingface_hub will actually use."""
+    from huggingface_hub.utils import _http as hf_http
+
+    # Drop any client built before the factory was registered, so this checks
+    # the client huggingface_hub will BUILD, not one that happens to be cached
+    # (set_client_factory does this today; do not depend on it).
+    close = getattr(hf_http, "close_session", None)
+    if callable(close):
+        close()
+    client = hf_http.get_session()
+    hooks = list(getattr(client, "event_hooks", {}).get("request") or [])
+    if _floor_timeout_hook not in hooks:
+        raise HfHttpFloorError(
+            "huggingface_hub timeout floor did not take: get_session() returned "
+            f"a client without the floor hook (huggingface_hub {_hf_version()}). "
+            "The backend was reshaped — re-derive the patch in gen_worker/net.py; "
+            "running without it means infinite HTTP timeouts fleet-wide (gw#456)."
+        )
+
+
+def _verify_requests_floor() -> None:
+    from huggingface_hub.utils import get_session
+
+    session = get_session()
+    if not isinstance(session, _TimeoutSession):
+        raise HfHttpFloorError(
+            "huggingface_hub timeout floor did not take: get_session() returned "
+            f"{type(session).__name__} (huggingface_hub {_hf_version()}). "
+            "See gen_worker/net.py — infinite HTTP timeouts fleet-wide (gw#456)."
+        )
+
+
 def install_hf_http_timeouts() -> None:
-    """Idempotent; call before any huggingface_hub network use."""
+    """Idempotent; call before any huggingface_hub network use. Raises
+    :class:`HfHttpFloorError` if the floor cannot be proven (pgw#657)."""
     global _installed
     with _lock:
         if _installed:
@@ -70,6 +126,7 @@ def install_hf_http_timeouts() -> None:
             set_factory = hf_http.set_client_factory
         except (ImportError, AttributeError):
             _install_requests_backend()  # huggingface_hub 0.x
+            _verify_requests_floor()
             _installed = True
             return
 
@@ -81,20 +138,23 @@ def install_hf_http_timeouts() -> None:
             return client
 
         set_factory(_factory)
+        _verify_httpx_floor()
         _installed = True
+
+
+class _TimeoutSession(requests.Session):
+    """huggingface_hub 0.x backend: floor every otherwise-infinite timeout."""
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:  # type: ignore[override]
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = http_timeouts()
+        return super().request(method, url, **kwargs)
 
 
 def _install_requests_backend() -> None:
     """huggingface_hub 0.x (requests): default a (connect, read) timeout on
     every Session request that would otherwise wait forever."""
-    import requests
     from huggingface_hub import configure_http_backend
-
-    class _TimeoutSession(requests.Session):
-        def request(self, method: str, url: str, **kwargs: Any) -> Any:  # type: ignore[override]
-            if kwargs.get("timeout") is None:
-                kwargs["timeout"] = http_timeouts()
-            return super().request(method, url, **kwargs)
 
     configure_http_backend(backend_factory=_TimeoutSession)
 

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -23,21 +23,77 @@ vs ``memory.peak``, and the ``memory.events`` ``oom_kill`` counter delta — so
 from __future__ import annotations
 
 import json
+import logging
 import os
 import signal
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+logger = logging.getLogger(__name__)
+
 _CGROUP_ROOT = Path("/sys/fs/cgroup")
 _PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+_PROC_MOUNTS = Path("/proc/mounts")
 _GIB = 1024 ** 3
 
-# Default location of the boot record. Container-local and restart-persistent:
-# RunPod restarts the container in place, so this file outlives the death.
-BOOT_RECORD_PATH = Path(
-    os.environ.get("GEN_WORKER_BOOT_RECORD", "/tmp/gen-worker-boot-record.json")
-)
+# Filesystems whose contents die with the container's memory — i.e. exactly
+# the death this record exists to report (pgw#657).
+_VOLATILE_FSTYPES = {"tmpfs", "ramfs"}
+
+_BOOT_RECORD_NAME = "gen-worker-boot-record.json"
+
+
+def _fstype_for(path: Path, mounts: Path = _PROC_MOUNTS) -> str:
+    """fstype of the longest mount point that is a prefix of ``path``.
+    Empty string when /proc/mounts is unreadable (non-Linux, sandboxes)."""
+    try:
+        lines = mounts.read_text().splitlines()
+    except OSError:
+        return ""
+    target = os.path.abspath(str(path))
+    best, best_type = "", ""
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        point, fstype = parts[1].replace("\\040", " "), parts[2]
+        if (target == point or target.startswith(point.rstrip("/") + "/")) and (
+            len(point) > len(best)
+        ):
+            best, best_type = point, fstype
+    return best_type
+
+
+def boot_record_is_volatile(path: Path, mounts: Path = _PROC_MOUNTS) -> bool:
+    """Whether the record's carrier is wiped by the very death it instruments.
+
+    pgw#657: the record used to be unconditionally ``/tmp``, which on many
+    container images is tmpfs — RAM. A cgroup OOM kill (the headline case this
+    module reports) frees that RAM, so the evidence dies with the process and
+    the next boot finds nothing, indistinguishable from "no death happened".
+    """
+    probe = path if path.exists() else path.parent
+    return _fstype_for(probe, mounts) in _VOLATILE_FSTYPES
+
+
+def _default_boot_record_path() -> Path:
+    """Prefer a DURABLE carrier. ``GEN_WORKER_BOOT_RECORD`` wins; otherwise the
+    model-cache volume (a real RunPod disk) when it is not itself volatile;
+    ``/tmp`` only as the last resort, and then :func:`write_boot_record` says
+    so loudly rather than pretending the record is durable."""
+    explicit = os.environ.get("GEN_WORKER_BOOT_RECORD", "").strip()
+    if explicit:
+        return Path(explicit)
+    cache = os.environ.get("TENSORHUB_CACHE_DIR", "").strip()
+    if cache:
+        candidate = Path(cache) / _BOOT_RECORD_NAME
+        if not boot_record_is_volatile(candidate):
+            return candidate
+    return Path("/tmp") / _BOOT_RECORD_NAME
+
+
+BOOT_RECORD_PATH = _default_boot_record_path()
 
 
 def _cgroup_nodes(
@@ -296,11 +352,15 @@ def format_detail(
 
 def write_boot_record(path: Path = BOOT_RECORD_PATH, **extra: Any) -> None:
     """Stamp this boot: pid, time, and the OOM counter to diff against."""
+    volatile = boot_record_is_volatile(path)
     record = {
         "pid": os.getpid(),
         "boot_unix": time.time(),
         "oom_kill_at_boot": oom_kill_count(),
         "limits": container_limits(),
+        # Carried IN the record so a reader can tell "the pod did not die"
+        # from "the evidence was on RAM and died with it" (pgw#657).
+        "carrier_volatile": volatile,
     }
     record.update(extra)
     try:
@@ -308,6 +368,14 @@ def write_boot_record(path: Path = BOOT_RECORD_PATH, **extra: Any) -> None:
         path.write_text(json.dumps(record, default=str))
     except OSError:
         pass
+    if volatile:
+        logger.warning(
+            "POSTMORTEM CARRIER IS VOLATILE: boot record at %s lives on %s — a "
+            "cgroup OOM kill frees it, so the death this record exists to report "
+            "will look like no death at all. Point GEN_WORKER_BOOT_RECORD at a "
+            "real volume (pgw#657).",
+            path, _fstype_for(path if path.exists() else path.parent) or "an unknown fs",
+        )
 
 
 def clear_boot_record(path: Path = BOOT_RECORD_PATH) -> None:
@@ -365,6 +433,7 @@ def previous_boot_detail(path: Path = BOOT_RECORD_PATH) -> Optional[str]:
 
 __all__ = [
     "BOOT_RECORD_PATH",
+    "boot_record_is_volatile",
     "clear_boot_record",
     "container_limits",
     "cpu_quota_cores",

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -26,6 +26,11 @@ from .api.slot import Slot
 from .api.tree import derive_components, validate_no_sibling_parts
 from .discovery.names import slugify_name
 from .discovery.walk import find_endpoints
+from .families.base import GenerationDefaults
+from .warmup import validate_class_warmup
+import dataclasses
+from .api.compile_axis import warm_guidance_values
+from .cell_key import contract_digest
 
 _ITER_ORIGINS = (
     typing.Iterator, typing.Iterable, typing.AsyncIterator, typing.AsyncIterable,
@@ -91,7 +96,6 @@ class CompileCell:
         }
 
     def contract_digest(self) -> str:
-        from .cell_key import contract_digest
 
         return contract_digest(self.contract_facts())
 
@@ -193,7 +197,6 @@ class EndpointSpec:
         cfg = self.compile
         if cfg is None:
             return None
-        from .api.compile_axis import warm_guidance_values
 
         effective_text_len = self.text_len if self.text_len is not None else cfg.text_len
         return CompileCell(
@@ -243,7 +246,6 @@ def _derive_defaults_type(
     candidate = args[0]
     if isinstance(candidate, typing.TypeVar):
         return None
-    from .families.base import GenerationDefaults
 
     if not (isinstance(candidate, type) and issubclass(candidate, GenerationDefaults)):
         raise ValueError(
@@ -582,7 +584,6 @@ def extract_specs(obj: Any, *, walked_module: str = "") -> List[EndpointSpec]:
     out = _apply_class_unions(out)
     # gw#470: boot warmup is default-on for GPU inference classes — fail at
     # walk time (discovery/CI/boot), never at first request.
-    from .warmup import validate_class_warmup
 
     validate_class_warmup(cls, decl, out)
     return out
@@ -598,9 +599,6 @@ def _apply_class_unions(specs: List[EndpointSpec]) -> List[EndpointSpec]:
     CLASSES keep divergent contracts by design (ernie's base/turbo are two
     checkpoints, two instances, two cells). Compile-less classes pass
     through untouched."""
-    import dataclasses
-
-    from .api.compile_axis import warm_guidance_values
 
     compiled = [s for s in specs if s.compile is not None]
     if not compiled:

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -50,7 +50,18 @@ LogLevel = Literal["debug", "info", "warning", "error"]
 from ..api.errors import AuthError
 from ..api.slot import ResolvedSlot
 from ..families.base import GenerationDefaults
-from ..io import DEFAULT_IMAGE_FORMAT, DEFAULT_IMAGE_QUALITY, encode_image
+from ..deferred_outputs import (
+    DeferredImageAsset,
+    DeferredTail,
+    PendingOutput,
+    fill_from,
+)
+from ..io import (
+    DEFAULT_IMAGE_FORMAT,
+    DEFAULT_IMAGE_QUALITY,
+    encode_image,
+    image_format,
+)
 from ..stage_timing import StageTimer
 from ..api.types import (
     Asset,
@@ -233,6 +244,11 @@ class RequestContext(Generic[D]):
         # decode->finalize handoff, so the worker's finalizing-job count (and
         # the hub's StateDelta view of it) tracks the encode/upload tail.
         self._on_finalize_release: Optional[Callable[[], None]] = None
+
+        # th#1130: outputs whose encode+upload run in the finalize tail,
+        # after the executor releases the GPU permit. Disarmed by default —
+        # CLI runs, endpoint unit tests and streaming handlers stay eager.
+        self._deferred = DeferredTail()
 
         # th#1111: per-stage timing for this request. Framework hooks
         # (permit wait, input fetch, encode, stamp, upload, denoise steps)
@@ -961,19 +977,66 @@ class RequestContext(Generic[D]):
         ``format`` is ``webp`` (the platform default), ``png``, or ``jpg``.
         ``quality`` applies to webp/jpg; ``lossless`` is webp-only. The
         extension is derived from the format when ``ref`` has no suffix.
+
+        On the serve path the encode + C2PA stamp + upload are DEFERRED to the
+        finalize tail (th#1130): the returned handle carries its ``ref``
+        immediately and its bytes fields fill in after the handler returns and
+        the GPU permit is released, so the ~1.1s webp encode overlaps the next
+        request's denoise instead of holding the card. Nothing about the
+        contract changes — return the asset in your output struct as before.
+        Reading a bytes field (``size_bytes``, ``sha256``, ``inline_bytes``,
+        ...) inside the handler is still correct; it just encodes inline and
+        loses the overlap for that request.
         """
-        with self._stages.stage("image_encode"):
-            payload, ext = encode_image(
-                image, format=format, quality=quality, lossless=lossless,
-                **encode_kwargs,
-            )
+        _pil_format, ext = image_format(format)
         if ref is None or str(ref).strip() == "":
             ref = f"outputs/{self.request_id}/image{ext}"
         else:
             ref = _normalize_output_ref(str(ref))
             if Path(ref).suffix == "":
                 ref += ext
-        return _as_asset(self.save_bytes(ref, payload), ImageAsset)
+        if not self._deferred.armed:
+            with self._stages.stage("image_encode"):
+                payload, _ext = encode_image(
+                    image, format=format, quality=quality, lossless=lossless,
+                    **encode_kwargs,
+                )
+            return _as_asset(self.save_bytes(ref, payload), ImageAsset)
+
+        # Snapshot the pixels: a handler that keeps mutating its PIL object
+        # must not change what gets uploaded. A few ms of memcpy against a
+        # ~1.1s encode.
+        copier = getattr(image, "copy", None)
+        snapshot = copier() if callable(copier) else image
+        handle = DeferredImageAsset(ref=ref, owner=self._owner)
+        target = ref
+
+        def _materialize() -> None:
+            with self._stages.stage("image_encode"):
+                payload, _ext = encode_image(
+                    snapshot, format=format, quality=quality,
+                    lossless=lossless, **encode_kwargs,
+                )
+            fill_from(handle, self.save_bytes(target, payload))
+
+        pending = PendingOutput(ref, _materialize)
+        handle.__dict__["_gw_pending"] = pending
+        self._deferred.defer(pending)
+        return handle
+
+    # -- deferred finalize tail (th#1130) ---------------------------------
+
+    def _arm_deferred_outputs(self) -> None:
+        """Worker-internal: let ``save_image`` defer its encode+upload to the
+        finalize tail. Armed by the executor only where a post-handler tail
+        exists (never for streaming handlers, which serialize mid-handler)."""
+        self._deferred.armed = True
+
+    def _drain_deferred_outputs(self) -> int:
+        """Worker-internal: materialize the deferred outputs. Called by the
+        executor AFTER the GPU permit is released, so this is the work that
+        overlaps the next request's compute. Returns how many ran here."""
+        return self._deferred.drain()
 
     def save_audio(
         self,

--- a/src/gen_worker/request_context/_concurrent_upload.py
+++ b/src/gen_worker/request_context/_concurrent_upload.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import threading
 from typing import Any
+from gen_worker.request_context._helpers import _decode_unverified_jwt_claims
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +152,6 @@ def budget_gate_from_capability_jwt(token: str) -> BudgetGate:
     in dev/test paths without a server-issued JWT.
     """
     # Import locally to avoid a module-level circular dep on _helpers.
-    from gen_worker.request_context._helpers import _decode_unverified_jwt_claims
 
     claims = _decode_unverified_jwt_claims(token) if token else {}
 

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..api.errors import AuthError, SnapshotBuildFailedError
+import requests
+import blake3
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +42,6 @@ def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
     dataset UUIDs and skip the lookup — a grant-scoped read_dataset capability
     token cannot list datasets at all.
     """
-    import requests
 
     url = f"{base}/api/v1/datasets?tenant={urllib.parse.quote(tenant, safe='')}"
     headers = {"Authorization": f"Bearer {token}"}
@@ -131,7 +132,6 @@ def fetch_materialize_manifest(
     ``SnapshotBuildFailedError``; transient transport/5xx errors retry within
     the same budget (hub restart mid-build).
     """
-    import requests
 
     url = (
         f"{base}/api/v1/datasets/{urllib.parse.quote(dataset_id, safe='')}"
@@ -222,8 +222,6 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
     Writes to ``dest.tmp`` then renames, so a partial download can never be
     mistaken for a complete shard.
     """
-    import blake3
-    import requests
 
     tmp = dest.with_name(dest.name + ".tmp")
     hasher = blake3.blake3() if expected_digest.startswith("blake3:") else None

--- a/src/gen_worker/request_context/_helpers.py
+++ b/src/gen_worker/request_context/_helpers.py
@@ -18,6 +18,7 @@ import urllib.parse
 from typing import Any, Dict
 
 from ..api.errors import OutputTooLargeError
+import mimetypes
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,6 @@ def _infer_mime_type(ref: str, head: bytes) -> str:
         return "image/webp"
 
     # Fall back to extension.
-    import mimetypes
 
     guessed, _ = mimetypes.guess_type(ref)
     return guessed or "application/octet-stream"

--- a/src/gen_worker/request_context/_stream.py
+++ b/src/gen_worker/request_context/_stream.py
@@ -327,7 +327,7 @@ class _RequestOutputStream:
         One save_checkpoint == one commit == one finalized repo revision;
         the repo is auto-created server-side under the job's create_repo
         grant on first publish."""
-        from ..convert.hub import CommitFile, HubClient
+        from ..convert.hub import CommitFile, HubClient  # lazy: keeps `import gen_worker` off the convert/requests stack
 
         assert self._tmp_path is not None
         assert self._repo_job_scope is not None
@@ -392,7 +392,7 @@ class _RequestOutputStream:
         """Hash the buffered temp file, then upload to the MEDIA route via
         presigned S3 multipart. Checkpoint saves with a repo-job scope go
         through `_finalize_checkpoint_commit` instead (gw#453 routing)."""
-        from ..presigned_upload import presigned_upload_file
+        from ..presigned_upload import presigned_upload_file  # lazy: keeps `import gen_worker` requests-free
 
         assert self._tmp_path is not None
         file_size = os.path.getsize(self._tmp_path)

--- a/src/gen_worker/runtimes/llama.py
+++ b/src/gen_worker/runtimes/llama.py
@@ -22,6 +22,7 @@ import msgspec
 
 from ..api.errors import FatalError
 from ..api.streaming import IncrementalTokenDelta, TokenUsage
+from ..models.memory import get_available_vram_gb
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,6 @@ def plan_fit(
 def free_vram_gb() -> float:
     """Free VRAM on device 0. Torch-free fallback: nvidia-smi (llama-server
     serve images carry no torch)."""
-    from ..models.memory import get_available_vram_gb
 
     via_torch = get_available_vram_gb()
     if via_torch > 0:
@@ -271,7 +271,7 @@ def _stream(
     cancelled: Optional[Callable[[], bool]],
     idle_timeout_s: float,
 ) -> Iterator[Union[IncrementalTokenDelta, TokenUsage]]:
-    import requests
+    import requests  # lazy: llama runtime is reachable from `import gen_worker`; stay requests-free there
 
     prompt_tokens = completion_tokens = 0
     tokens_per_second = 0.0

--- a/src/gen_worker/runtimes/server.py
+++ b/src/gen_worker/runtimes/server.py
@@ -20,6 +20,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, Sequence
+from .llama import plan_for, resolve_gguf
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +196,6 @@ def llama_server(
     are sized to the free-VRAM budget (gw#402) and the boot degrades
     through fewer GPU layers rather than failing.
     """
-    from .llama import plan_for, resolve_gguf
 
     gguf_path = str(resolve_gguf(model_source))
     args = [str(a) for a in extra_args]

--- a/src/gen_worker/s3_transfer.py
+++ b/src/gen_worker/s3_transfer.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Optional
 
 from .api.errors import ArtifactTransferError
 from .presigned_upload import blake3_hash_file
+from .models.cozy_cas import fsync_dir, fsync_file
 
 _MULTIPART_CHUNK_BYTES = 64 * 1024 * 1024
 _MULTIPART_MAX_WORKERS = 10
@@ -174,7 +175,6 @@ def download_file_with_grant(
         )
     # Durable atomic finalize (gw#408): see cozy_cas — data must hit stable
     # storage before the rename, or a pod hard-kill persists a truncated blob.
-    from .models.cozy_cas import fsync_dir, fsync_file
 
     fsync_file(tmp)
     os.replace(tmp, dest)

--- a/src/gen_worker/subproc.py
+++ b/src/gen_worker/subproc.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 from .api.errors import CanceledError
+from .runtime_config import SNAPSHOT_PATH_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,6 @@ def run_process(
     - Returns the process exit code on natural exit (callers decide whether
       nonzero is fatal).
     """
-    from .runtime_config import SNAPSHOT_PATH_ENV
 
     invocation_snapshot_path = _write_invocation_snapshot(ctx)
     child_env = dict(env) if env is not None else None

--- a/src/gen_worker/trt_engine.py
+++ b/src/gen_worker/trt_engine.py
@@ -51,6 +51,8 @@ from .compile_cache import (
     parse_cell_ref,
     sku_slug,
 )
+import gzip
+from .models.loading import load_from_pretrained
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +175,6 @@ def pack(content_dir: Path, out_path: Path, metadata: Dict[str, Any]) -> Path:
     content_dir = Path(content_dir)
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    import gzip
 
     with open(out_path, "wb") as raw:
         with gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz:
@@ -768,8 +769,6 @@ def build(
     import tensorrt as trt
     import torch
     from diffusers import DiffusionPipeline
-
-    from .models.loading import load_from_pretrained
 
     if not torch.cuda.is_available():
         raise RuntimeError("trt-engine build requires CUDA")

--- a/src/gen_worker/url_fetch.py
+++ b/src/gen_worker/url_fetch.py
@@ -1,0 +1,313 @@
+"""The ONE guarded HTTP fetch for endpoint code (pgw#663, ie#554).
+
+Endpoints that accept a URL from a caller — a VLM caption input, an img2img
+source — were each hand-rolling `urlopen(url).read()`. That is an SSRF hole
+(the worker sits inside a datacenter network with a cloud metadata endpoint at
+169.254.169.254) plus an unbounded read into a pod's RAM, and it was already
+copied four times, so every copy has to be found and fixed independently
+forever.
+
+This module is that policy's single home:
+
+  * **scheme** — http/https only;
+  * **destination** — every hop's host is resolved and refused if it lands on a
+    private / loopback / link-local / multicast / reserved address;
+  * **redirects** — followed MANUALLY, with the policy re-applied to each hop.
+    A public URL 302-ing to the metadata service is the standard bypass, and
+    `urlopen` follows redirects silently, so anything that delegates redirect
+    handling to urllib has this hole open;
+  * **size** — streamed against a byte cap, checked against `Content-Length`
+    first and again per chunk, so a lying header cannot blow up the pod;
+  * **time** — an explicit timeout on every hop;
+  * **content** — optional MIME allowlist, sniffed from the bytes rather than
+    trusted from the header.
+
+Refusals are typed `ValidationError` (caller-caused -> INVALID); transport
+failures are `RetryableError`, matching the input-asset vocabulary.
+
+**Known limit, stated rather than papered over:** validation resolves the
+hostname, then the connection resolves it again — a DNS rebinding attacker can
+win that race. Closing it means pinning the connection to the validated address
+with an explicit Host header, which breaks TLS SNI/verification for the general
+case. Per-hop validation is the practical guard; do not describe it as proof
+against a rebinding adversary.
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator, Sequence
+
+from .api.errors import RetryableError, ValidationError
+from .request_context._helpers import _infer_mime_type, _url_is_blocked
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_TIMEOUT_S",
+    "FetchedUrl",
+    "MAX_REDIRECTS",
+    "fetch_bytes",
+    "fetch_image",
+    "open_guarded_stream",
+]
+
+DEFAULT_MAX_BYTES = 50 << 20  # 50 MiB — tensorhub's default media cap
+DEFAULT_TIMEOUT_S = 30.0
+MAX_REDIRECTS = 5
+_CHUNK = 1 << 20
+
+# Deployment-wide outer bound. When set, NO fetch may leave these hosts, whatever
+# an endpoint passes as `allowed_hosts`.
+ALLOWED_HOSTS_ENV = "GEN_WORKER_URL_FETCH_ALLOWED_HOSTS"
+
+
+@dataclass(frozen=True)
+class FetchedUrl:
+    """Bytes plus the provenance a caller needs to reason about them."""
+
+    url: str
+    final_url: str
+    data: bytes
+    mime: str
+
+    @property
+    def size_bytes(self) -> int:
+        return len(self.data)
+
+
+def _env_allowed_hosts() -> frozenset[str]:
+    raw = os.environ.get(ALLOWED_HOSTS_ENV, "")
+    return frozenset(h.strip().lower() for h in raw.split(",") if h.strip())
+
+
+def _check_hop(
+    url: str,
+    *,
+    allowed_hosts: frozenset[str],
+    what: str,
+    is_blocked: Callable[[str], bool] | None = None,
+) -> None:
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        raise ValidationError(f"url_fetch_refused: {what} is not a valid URL") from None
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.hostname:
+        raise ValidationError(
+            f"url_fetch_refused: {what} must be an http(s) URL with a host"
+        )
+    host = parsed.hostname.lower()
+    env_hosts = _env_allowed_hosts()
+    if env_hosts and host not in env_hosts:
+        raise ValidationError(
+            f"url_fetch_refused: {what} host {host!r} is outside this deployment's "
+            f"{ALLOWED_HOSTS_ENV} allowlist"
+        )
+    if allowed_hosts and host not in allowed_hosts:
+        raise ValidationError(
+            f"url_fetch_refused: {what} host {host!r} is not in the caller's allowlist"
+        )
+    # Resolved at CALL time: the module global is the one policy, and a
+    # caller that already owns a reference to it (input_assets) passes its
+    # own so the two cannot drift or be patched apart.
+    check = is_blocked or _url_is_blocked
+    try:
+        blocked = check(url)
+    except Exception:
+        raise RetryableError("url_fetch_failed: destination policy check failed") from None
+    if blocked:
+        raise ValidationError(
+            f"url_fetch_refused: {what} resolves to a non-public address"
+        )
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Hand redirects back to us instead of following them blind."""
+
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+_opener = urllib.request.build_opener(_NoRedirect)
+
+
+@contextmanager
+def open_guarded_stream(
+    url: str,
+    *,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    allowed_hosts: Sequence[str] = (),
+    extra_allowed_hosts: Sequence[str] = (),
+    max_redirects: int = MAX_REDIRECTS,
+    headers: dict[str, str] | None = None,
+    is_blocked: Callable[[str], bool] | None = None,
+) -> Iterator[Any]:
+    """Open ``url`` with the full policy applied to every hop.
+
+    Yields the live ``http.client.HTTPResponse`` — the caller owns the read
+    (and its byte cap). ``extra_allowed_hosts`` names hosts that are exempt
+    from the private-address refusal but not from the scheme/allowlist rules:
+    a deployment's internal object store, which is private BY DESIGN.
+    """
+    allow = frozenset(h.strip().lower() for h in allowed_hosts if h and h.strip())
+    exempt = frozenset(h.strip().lower() for h in extra_allowed_hosts if h and h.strip())
+    current = str(url or "")
+    for hop in range(max_redirects + 1):
+        host = (urllib.parse.urlsplit(current).hostname or "").lower()
+        what = "url" if hop == 0 else f"redirect hop {hop}"
+        if host and host in exempt:
+            if urllib.parse.urlsplit(current).scheme.lower() not in ("http", "https"):
+                raise ValidationError(f"url_fetch_refused: {what} must be an http(s) URL")
+        else:
+            _check_hop(
+                current, allowed_hosts=allow, what=what, is_blocked=is_blocked,
+            )
+        request = urllib.request.Request(
+            current, headers={"User-Agent": "gen-worker", **(headers or {})}
+        )
+        try:
+            response = _opener.open(request, timeout=timeout_s)
+        except urllib.error.HTTPError as exc:
+            location = str(exc.headers.get("Location") or "").strip() if exc.headers else ""
+            if 300 <= int(exc.code) < 400 and location:
+                exc.close()
+                current = urllib.parse.urljoin(current, location)
+                continue
+            # Not a redirect: the STATUS is the caller's business, not this
+            # opener's. Re-raise it untouched so input_assets keeps its own
+            # (retryable) reading of a 404 on an authorized transport, while
+            # fetch_bytes below maps it to a typed refusal.
+            exc.close()
+            raise
+        except (ValidationError, RetryableError):
+            raise
+        except Exception as exc:
+            raise RetryableError(f"url_fetch_failed: {type(exc).__name__}") from None
+        try:
+            yield response
+        finally:
+            response.close()
+        return
+    raise ValidationError(f"url_fetch_refused: {url} exceeded {max_redirects} redirects")
+
+
+def fetch_bytes(
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    allowed_hosts: Sequence[str] = (),
+    allowed_mime_types: Sequence[str] = (),
+    max_redirects: int = MAX_REDIRECTS,
+) -> FetchedUrl:
+    """Fetch ``url`` under the full policy and return its bytes.
+
+    ``max_bytes`` is enforced against ``Content-Length`` AND against the bytes
+    actually read, so a lying header buys nothing. ``allowed_mime_types`` is
+    matched against the SNIFFED type, never the server's claim.
+    """
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    try:
+        return _read_capped(
+            url, max_bytes, timeout_s, allowed_hosts, allowed_mime_types, max_redirects,
+        )
+    except urllib.error.HTTPError as exc:
+        raise ValidationError(
+            f"url_fetch_refused: {url} returned HTTP {exc.code}"
+        ) from None
+
+
+def _read_capped(
+    url: str,
+    max_bytes: int,
+    timeout_s: float,
+    allowed_hosts: Sequence[str],
+    allowed_mime_types: Sequence[str],
+    max_redirects: int,
+) -> FetchedUrl:
+    chunks: list[bytes] = []
+    total = 0
+    final_url = str(url)
+    with open_guarded_stream(
+        url,
+        timeout_s=timeout_s,
+        allowed_hosts=allowed_hosts,
+        max_redirects=max_redirects,
+    ) as response:
+        final_url = str(getattr(response, "url", url) or url)
+        raw_length = str(response.headers.get("Content-Length") or "").strip()
+        if raw_length.isdigit() and int(raw_length) > max_bytes:
+            raise ValidationError(
+                f"url_fetch_too_large: {url} declares {raw_length} bytes "
+                f"(cap {max_bytes})"
+            )
+        while True:
+            try:
+                chunk = response.read(_CHUNK)
+            except Exception as exc:
+                raise RetryableError(f"url_fetch_failed: {type(exc).__name__}") from None
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                raise ValidationError(
+                    f"url_fetch_too_large: {url} exceeds its {max_bytes}-byte cap"
+                )
+            chunks.append(chunk)
+    data = b"".join(chunks)
+    mime = _infer_mime_type(final_url, data[:64])
+    if allowed_mime_types:
+        allowed = {m.strip().lower() for m in allowed_mime_types if m and m.strip()}
+        if mime.lower() not in allowed:
+            raise ValidationError(
+                f"url_fetch_refused: {url} content type {mime!r} is not allowed"
+            )
+    return FetchedUrl(url=str(url), final_url=final_url, data=data, mime=mime)
+
+
+def fetch_image(
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    allowed_hosts: Sequence[str] = (),
+    mode: str = "RGB",
+    max_redirects: int = MAX_REDIRECTS,
+) -> Any:
+    """Fetch an image URL under the full policy; returns a PIL image.
+
+    The image-shaped case endpoints keep re-writing (joycaption's
+    `_load_rgb_image_from_url` is the live one). Decoding is what proves the
+    bytes are an image, so the MIME allowlist is the sniffed image family and
+    a non-image body is a typed refusal, not a decoder traceback.
+    """
+    from PIL import Image, UnidentifiedImageError  # heavy, optional at import time
+
+    fetched = fetch_bytes(
+        url,
+        max_bytes=max_bytes,
+        timeout_s=timeout_s,
+        allowed_hosts=allowed_hosts,
+        max_redirects=max_redirects,
+    )
+    if not fetched.mime.startswith("image/"):
+        raise ValidationError(
+            f"url_fetch_refused: {url} is {fetched.mime!r}, not an image"
+        )
+    from io import BytesIO
+
+    try:
+        image = Image.open(BytesIO(fetched.data))
+        image.load()
+    except UnidentifiedImageError:
+        raise ValidationError(f"url_fetch_refused: {url} is not a decodable image") from None
+    except Exception as exc:
+        raise ValidationError(
+            f"url_fetch_refused: {url} could not be decoded ({type(exc).__name__})"
+        ) from None
+    return image.convert(mode) if mode else image

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, runtime_checkable
 
 from ..api.errors import RefCompatibilitySurprise, ValidationError
+from dataclasses import replace
+from ..models import w8a8_lora
 
 logger = logging.getLogger(__name__)
 
@@ -138,9 +140,6 @@ def _split_adapters(
     additive branch, the rest (text-encoder halves) keep peft. Branch
     entries are (state_dict, weight, ref) — the
     models.w8a8_lora.apply_branch_adapters contract."""
-    from dataclasses import replace
-
-    from ..models import w8a8_lora
 
     fp = _denoiser_fingerprint(pipe)
     peft: List[PreparedAdapter] = []
@@ -443,7 +442,6 @@ class AdapterResidency:
         whose adapter cannot map onto branch-capable Linears (e.g. conv-
         targeting LoCon) fall back to the whole-adapter peft path when the
         pipeline supports it — capability preserved, branch primary."""
-        from ..models import w8a8_lora
 
         all_adapters = list(adapters)
         denoiser = w8a8_lora.branch_target(pipe)

--- a/src/gen_worker/video_encode.py
+++ b/src/gen_worker/video_encode.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, Optional
 
 from .api.errors import ValidationError
+import io as _io
+from fractions import Fraction
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +76,6 @@ def _probe_nvenc() -> bool:
     (H.264 min is 145x49) — a 64x64 probe fails "Frame Dimension less than
     the minimum supported value" on GENUINELY capable cards (measured live
     on an L4, gw#476)."""
-    import io as _io
 
     try:
         import av
@@ -378,7 +379,6 @@ class StreamingVideoEncoder:
 # ---- audio mux (moved verbatim from gen_worker.io, gw#387) ------------------
 
 def _prepare_audio_stream(container: Any, sample_rate: int, av: Any) -> Any:
-    from fractions import Fraction
 
     stream = container.add_stream("aac", rate=sample_rate)
     cc = stream.codec_context

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -65,6 +65,7 @@ import msgspec
 from .api.compile_axis import PayloadAxis
 from .api.decorators import EndpointDecl, NoWarmup
 from .api.types import Asset, AudioAsset, ImageAsset, VideoAsset
+import inspect
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from .registry import EndpointSpec
@@ -410,7 +411,6 @@ def validate_at_decoration(cls: type, decl: EndpointDecl) -> None:
     """Best-effort decoration-time enforcement (fails at import, the
     earliest possible moment). Unresolvable type hints defer silently to
     the authoritative walk-time check (``validate_class_warmup``)."""
-    import inspect
 
     if decl.kind != "inference" or not decl.resources.gpu:
         return

--- a/tests/convert/test_dataset_ingest_pgw656.py
+++ b/tests/convert/test_dataset_ingest_pgw656.py
@@ -1,0 +1,146 @@
+"""pgw#656: dataset ingest never creates a duplicate it could have found.
+
+Drives the real ``publish_dataset_revision`` over a real HTTP server that
+implements tensorhub's actual listing contract (``?org=``, ``?limit=`` capped
+at 200, ``?cursor=``, ``next_cursor``). Every row here is a way the lookup
+used to come back empty — a torn response, a 500, a second page — each of
+which fell straight through to CREATE.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from gen_worker.convert.hub import publish_dataset_revision
+from gen_worker.api.errors import AuthError
+
+
+class _DatasetHub(BaseHTTPRequestHandler):
+    server_version = "FakeTensorhubDatasets/1.0"
+    state: dict[str, Any] = {}
+
+    def log_message(self, *args: Any) -> None:  # silence
+        pass
+
+    def _send(self, code: int, payload: Any = None, raw: bytes | None = None) -> None:
+        body = raw if raw is not None else json.dumps(payload or {}).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        st = _DatasetHub.state
+        parsed = urlparse(self.path)
+        query = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+        st.setdefault("list_calls", []).append(query)
+
+        status = int(st.get("list_status", 200))
+        if status != 200:
+            self._send(status, {"error": "boom"})
+            return
+        if st.get("list_garbage"):
+            self._send(200, raw=b"<html>gateway</html>")
+            return
+
+        # tensorhub semantics: org filter, limit capped at 200, integer cursor.
+        rows = [r for r in st.get("rows", []) if r["org"] == query.get("org")]
+        limit = min(int(query.get("limit") or 50), 200)
+        offset = int(query.get("cursor") or 0)
+        page = rows[offset:offset + limit]
+        next_cursor = str(offset + len(page)) if len(page) == limit else ""
+        self._send(200, {
+            "items": [
+                {"dataset_id": r["dataset_id"], "name": r["name"]} for r in page
+            ],
+            "next_cursor": next_cursor,
+        })
+
+    def do_POST(self) -> None:  # noqa: N802
+        _DatasetHub.state.setdefault("creates", []).append(self.path)
+        self._send(200, {"dataset_id": "created-id"})
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        _DatasetHub.state.setdefault("patches", []).append(self.path)
+        self._send(200, {})
+
+
+@pytest.fixture
+def hub():
+    _DatasetHub.state = {"rows": [], "creates": [], "patches": [], "list_calls": []}
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _DatasetHub)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}", _DatasetHub.state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _publish(base: str, dataset: str = "acme/faces"):
+    return publish_dataset_revision(
+        base_url=base,
+        token="t",
+        destination_dataset=dataset,
+        features_json={"image": "bytes"},
+        kind="image",
+    )
+
+
+def test_absent_dataset_is_created_once(hub) -> None:
+    base, state = hub
+    out = _publish(base)
+    assert out["existed"] is False
+    assert len(state["creates"]) == 1
+
+
+def test_existing_dataset_beyond_the_first_page_is_found(hub) -> None:
+    """The unpaginated read saw one page and called it the org's whole set —
+    dataset 250 of 300 then got a duplicate row."""
+    base, state = hub
+    state["rows"] = [
+        {"org": "acme", "dataset_id": f"id-{i}", "name": f"ds-{i}"} for i in range(300)
+    ]
+    state["rows"][250] = {"org": "acme", "dataset_id": "the-one", "name": "faces"}
+
+    out = _publish(base)
+    assert out == {
+        "ok": True, "dataset_id": "the-one", "owner": "acme",
+        "name": "faces", "existed": True,
+    }
+    assert state["creates"] == []
+    assert len(state["list_calls"]) == 2  # 200 + the remainder
+    assert state["list_calls"][0]["org"] == "acme"  # not the ignored ?tenant=
+
+
+def test_a_500_on_the_listing_refuses_instead_of_creating(hub) -> None:
+    base, state = hub
+    state["list_status"] = 500
+    with pytest.raises(RuntimeError, match="dataset list failed"):
+        _publish(base)
+    assert state["creates"] == []
+
+
+def test_unreadable_json_refuses_instead_of_creating(hub) -> None:
+    """The exact `except Exception: pass` this issue names: a transient
+    proxy/HTML body read as 'no existing dataset'."""
+    base, state = hub
+    state["list_garbage"] = True
+    with pytest.raises(RuntimeError, match="unreadable JSON"):
+        _publish(base)
+    assert state["creates"] == []
+
+
+def test_unauthorized_listing_is_typed(hub) -> None:
+    base, state = hub
+    state["list_status"] = 403
+    with pytest.raises(AuthError):
+        _publish(base)
+    assert state["creates"] == []

--- a/tests/harness/deferred_endpoints.py
+++ b/tests/harness/deferred_endpoints.py
@@ -1,0 +1,166 @@
+"""th#1130 harness endpoints: image handlers whose encode+upload tail must run
+AFTER the GPU permit is released.
+
+Every handler here calls ``ctx.save_image`` — the surface the whole live image
+fleet uses (19 of 19 call sites) — and marks its own timeline into
+:data:`EVENTS` with ``time.monotonic()``. The hub-double runs the worker
+in-process, so those marks are directly comparable with the test's own clock:
+that is how "request B's GPU phase started while request A was still encoding"
+is proven without a GPU.
+
+No torch, no weights. Payload sizes are kept under the 64 KiB inline-result cap
+so the encoded bytes come back on the wire and can be decoded and asserted.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, List, Tuple
+
+import msgspec
+from PIL import Image
+
+from gen_worker import RequestContext, diffusers_step_callback, endpoint
+from gen_worker.api.types import ImageAsset
+
+#: Handler shape the tests assert against (seconds / pixels).
+STEP_S = 0.02
+STEPS = 4
+#: A smooth 1024^2 frame: ~250ms of webp q95/method=6 encode for ~29 KB of
+#: output — a tail long enough to observe, small enough to ride the inline
+#: result. (Noise of the same size is 370ms but 800 KB.)
+SLOW_PX = 1024
+#: GPU-shaped work the N-image loop does BETWEEN saves: if any save released
+#: the permit, a peer job would start during these.
+LOOP_GPU_WORK_S = 0.15
+LOOP_IMAGES = 3
+
+EVENTS: List[Tuple[str, str, float]] = []
+_lock = threading.Lock()
+
+
+def mark(label: str, ctx: RequestContext) -> float:
+    now = time.monotonic()
+    with _lock:
+        EVENTS.append((label, ctx.request_id, now))
+    return now
+
+
+def at(label: str, request_id: str) -> float:
+    """The monotonic time of one mark; raises if it never happened."""
+    with _lock:
+        for name, rid, when in EVENTS:
+            if name == label and rid == request_id:
+                return when
+    raise AssertionError(f"no {label!r} mark for {request_id!r} in {EVENTS}")
+
+
+def counts() -> Dict[str, int]:
+    with _lock:
+        out: Dict[str, int] = {}
+        for name, _rid, _when in EVENTS:
+            out[name] = out.get(name, 0) + 1
+        return out
+
+
+def reset() -> None:
+    with _lock:
+        EVENTS.clear()
+
+
+def gradient(px: int) -> Image.Image:
+    """A smooth RGB frame — cheap to build, slow to webp-encode, small once
+    encoded."""
+    base = Image.merge("RGB", (
+        Image.linear_gradient("L"),
+        Image.linear_gradient("L").rotate(90),
+        Image.radial_gradient("L"),
+    ))
+    return base.resize((px, px), Image.Resampling.BILINEAR)
+
+
+class _ExplodingImage:
+    """PIL-shaped enough for the encode core, and it fails IN THE TAIL."""
+
+    mode = "RGB"
+
+    def copy(self) -> "_ExplodingImage":
+        return self
+
+    def save(self, buf: object, **_kwargs: object) -> None:
+        raise ValueError("encoder exploded")
+
+
+class GenIn(msgspec.Struct):
+    prompt: str = ""
+
+
+class GenOut(msgspec.Struct):
+    image: ImageAsset
+
+
+class MultiOut(msgspec.Struct):
+    images: list[ImageAsset]
+
+
+class SizeOut(msgspec.Struct):
+    ref: str
+    size_bytes: int
+
+
+@endpoint
+class DeferredImages:
+    def slow_encode(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        """A diffusion-shaped handler: stepped denoise, then one save whose
+        encode is the whole tail."""
+        mark("handler_start", ctx)
+        on_step = diffusers_step_callback(ctx, STEPS)
+        for i in range(STEPS):
+            time.sleep(STEP_S)
+            on_step(None, i, None, {})
+        asset = ctx.save_image(
+            gradient(SLOW_PX), format="webp", quality=95, method=6)
+        mark("handler_end", ctx)
+        return GenOut(image=asset)
+
+    def fast_peer(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        """Request B. Its handler_start mark is the moment it holds the GPU
+        permit (the executor acquires before calling the handler)."""
+        mark("handler_start", ctx)
+        asset = ctx.save_image(gradient(64), format="webp")
+        mark("handler_end", ctx)
+        return GenOut(image=asset)
+
+    def n_images(self, ctx: RequestContext, data: GenIn) -> MultiOut:
+        """N saves with GPU-shaped work AFTER each one — the case a blanket
+        terminal release on save would break."""
+        mark("handler_start", ctx)
+        assets = []
+        for i in range(LOOP_IMAGES):
+            assets.append(ctx.save_image(
+                gradient(256), f"outputs/{ctx.request_id}/img{i}", format="webp"))
+            mark(f"saved_{i}", ctx)
+            time.sleep(LOOP_GPU_WORK_S)  # stands in for more GPU work
+        mark("handler_end", ctx)
+        return MultiOut(images=assets)
+
+    def fails_in_tail(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        asset = ctx.save_image(_ExplodingImage(), "outputs/boom.webp")
+        mark("handler_end", ctx)
+        return GenOut(image=asset)
+
+    def mutates_after_save(self, ctx: RequestContext, data: GenIn) -> GenOut:
+        """Saves a RED frame, then keeps painting on the same PIL object."""
+        img = Image.new("RGB", (32, 32), (255, 0, 0))
+        asset = ctx.save_image(img, "outputs/mutated", format="png")
+        img.paste((0, 0, 255), (0, 0, 32, 32))
+        mark("handler_end", ctx)
+        return GenOut(image=asset)
+
+    def reads_back(self, ctx: RequestContext, data: GenIn) -> SizeOut:
+        """Reads a bytes field inside the handler — must be REAL, which means
+        the deferred encode is forced inline rather than answered with None."""
+        asset = ctx.save_image(gradient(64), "outputs/readback", format="png")
+        mark("handler_end", ctx)
+        return SizeOut(ref=asset.ref, size_bytes=int(asset.size_bytes or 0))

--- a/tests/harness/hf_bound_endpoints_pgw655.py
+++ b/tests/harness/hf_bound_endpoints_pgw655.py
@@ -1,0 +1,29 @@
+"""pgw#655 fixture: one endpoint bound to a WORKER-FETCHED (hf) model that
+never materializes, plus one model-free endpoint that must keep serving.
+
+Its own module (not ``toy_endpoints``) because adding an endpoint there
+changes the world every hub-double test observes.
+"""
+
+from __future__ import annotations
+
+from gen_worker import HF, RequestContext, endpoint
+
+from harness.toy_endpoints import EchoIn, EchoOut
+
+UPSTREAM_REF = "harness/pgw655-upstream"
+
+
+@endpoint(model=HF("harness/pgw655-upstream"))
+class HfBoundEndpoint:
+    def setup(self, model: str) -> None:
+        self.model_path = model
+
+    def hf_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        return EchoOut(response=self.model_path)
+
+
+@endpoint
+class ModelFreeEndpoint:
+    def plain_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
+        return EchoOut(response=data.text)

--- a/tests/test_fail_loud_pgw657.py
+++ b/tests/test_fail_loud_pgw657.py
@@ -1,0 +1,146 @@
+"""pgw#657: the load-bearing patches say so when they stop being load-bearing.
+
+Each row here locks a guard whose SILENT failure mode was the debt: the
+huggingface_hub timeout floor reverting on a backend reshape (gw#456's
+infinite-timeout hang, fleet-wide), and the gw#640 boot record living on RAM
+that the very OOM it reports frees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker import net, postmortem
+
+
+# ---------------------------------------------------------------------------
+# net.py — the floor is PROVEN on the session huggingface_hub actually uses.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def uninstalled_floor(monkeypatch):
+    """Re-arm the install path without leaking state into other tests."""
+    from huggingface_hub.utils import _http as hf_http
+
+    factory_before = hf_http._GLOBAL_CLIENT_FACTORY
+    # Back to a virgin process shape: no floor installed anywhere.
+    hf_http.set_client_factory(hf_http.default_client_factory)
+    monkeypatch.setattr(net, "_installed", False)
+    yield hf_http
+    # undo() first: a test may have patched set_client_factory itself.
+    monkeypatch.undo()
+    hf_http.set_client_factory(factory_before)
+
+
+def test_floor_installs_and_is_verifiable(uninstalled_floor) -> None:
+    net.install_hf_http_timeouts()
+    client = uninstalled_floor.get_session()
+    assert net._floor_timeout_hook in client.event_hooks["request"]
+
+
+def test_a_backend_that_ignores_the_factory_fails_loudly(
+    uninstalled_floor, monkeypatch,
+) -> None:
+    """The exact silent revert this issue exists for: huggingface_hub keeps
+    the API but stops honouring it. Before, the worker booted happily with
+    infinite HTTP timeouts."""
+    monkeypatch.setattr(
+        uninstalled_floor, "set_client_factory", lambda _factory: None,
+    )
+    with pytest.raises(net.HfHttpFloorError) as exc:
+        net.install_hf_http_timeouts()
+    assert "gen_worker/net.py" in str(exc.value)
+    # ...and it stays un-installed, so the next call retries rather than
+    # caching a lie.
+    assert net._installed is False
+
+
+def test_floor_hook_keeps_explicit_timeouts_and_floors_infinite_ones() -> None:
+    class _Req:
+        extensions: dict = {"timeout": {"connect": 3.0, "read": None}}
+
+    req = _Req()
+    net._floor_timeout_hook(req)
+    assert req.extensions["timeout"]["connect"] == 3.0  # caller's number wins
+    assert req.extensions["timeout"]["read"] == net.http_timeouts()[1]
+
+
+# ---------------------------------------------------------------------------
+# postmortem.py — a boot record on tmpfs is evidence that dies with the death.
+# ---------------------------------------------------------------------------
+
+
+def _mounts(tmp_path, entries):
+    p = tmp_path / "mounts"
+    p.write_text("".join(f"dev {point} {fstype} rw 0 0\n" for point, fstype in entries))
+    return p
+
+
+def test_tmpfs_carrier_is_recognised_as_volatile(tmp_path) -> None:
+    mounts = _mounts(tmp_path, [("/", "ext4"), ("/tmp", "tmpfs")])
+    assert postmortem.boot_record_is_volatile(Path("/tmp/x.json"), mounts)
+    assert not postmortem.boot_record_is_volatile(
+        Path("/var/lib/x.json"), mounts
+    )
+
+
+def test_longest_mount_prefix_wins(tmp_path) -> None:
+    mounts = _mounts(tmp_path, [("/", "tmpfs"), ("/workspace", "ext4")])
+    assert postmortem._fstype_for(
+        Path("/workspace/cache/rec.json"), mounts,
+    ) == "ext4"
+
+
+def test_written_record_carries_its_own_durability(tmp_path, caplog) -> None:
+    """A reader must be able to tell 'the pod did not die' from 'the evidence
+    was on RAM'. /dev/shm is tmpfs on every Linux box, so this exercises the
+    real /proc/mounts path, not a fixture."""
+    import json
+
+    durable = tmp_path / "rec.json"
+    postmortem.write_boot_record(durable)
+    assert json.loads(durable.read_text())["carrier_volatile"] is False
+
+    volatile_root = Path("/dev/shm")
+    if not volatile_root.is_dir():
+        pytest.skip("no tmpfs mount available")
+    volatile = volatile_root / "pgw657-rec.json"
+    try:
+        postmortem.write_boot_record(volatile)
+        record = json.loads(volatile.read_text())
+        assert record["carrier_volatile"] is True
+        assert any("VOLATILE" in m for m in caplog.messages)
+    finally:
+        volatile.unlink(missing_ok=True)
+
+
+def test_explicit_env_path_still_wins(monkeypatch) -> None:
+    monkeypatch.setenv("GEN_WORKER_BOOT_RECORD", "/somewhere/explicit.json")
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", "/mnt/cache")
+    assert str(postmortem._default_boot_record_path()) == "/somewhere/explicit.json"
+
+
+def test_cache_volume_is_preferred_over_tmp(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("GEN_WORKER_BOOT_RECORD", raising=False)
+    monkeypatch.setenv("TENSORHUB_CACHE_DIR", str(tmp_path))
+    assert postmortem._default_boot_record_path() == tmp_path / "gen-worker-boot-record.json"
+
+
+# ---------------------------------------------------------------------------
+# convert/source.py — the documented-but-unwired branch is a typed refusal.
+# ---------------------------------------------------------------------------
+
+
+def test_diffusers_singlefile_is_a_typed_refusal(tmp_path) -> None:
+    from gen_worker.api.errors import ValidationError
+    from gen_worker.convert.source import Source
+
+    (tmp_path / "model.safetensors").write_bytes(b"\x00")
+    src = Source(tmp_path)
+    assert src.file_layout == "singlefile"
+    with pytest.raises(ValidationError) as exc:
+        list(src.iter_hf_components())
+    assert "as_hf_model" in str(exc.value)

--- a/tests/test_model_absence_pgw655.py
+++ b/tests/test_model_absence_pgw655.py
@@ -1,0 +1,153 @@
+"""pgw#655: a worker never reports READY-with-a-serveable-function while that
+function's model is absent, and a download that trickles is a stall.
+
+Two independent halves of the same live wedge (Paul's fleet audit, DEBT
+R3): boot prefetch logged "failed terminally" and walked on to READY, so the
+hub dispatched paid GPU jobs that each re-discovered the missing model; and
+the download watchdog reset its window on ANY byte, so a trickle could pin
+DOWNLOADING_MODELS forever (the wall-clock cap that was supposed to catch it
+had been 0.0 — off — for its whole life).
+"""
+
+from __future__ import annotations
+
+import threading
+
+from pathlib import Path
+
+import pytest
+
+from gen_worker.models.download import (
+    _HF_DOWNLOAD_MIN_WINDOW_BYTES,
+    DownloadStalledError,
+    _run_with_stall_watchdog,
+)
+
+from harness.hf_bound_endpoints_pgw655 import UPSTREAM_REF
+from harness.hub_double import hub_double, is_fn_unavailable, is_ready
+
+_MODULE = "harness.hf_bound_endpoints_pgw655"
+
+
+# ---------------------------------------------------------------------------
+# Half 1 — boot prefetch failure gates the function it belongs to.
+# ---------------------------------------------------------------------------
+
+
+class _Upstream404(Exception):
+    """What a missing/private HF repo looks like to the download classifier:
+    a 4xx-carrying exception, hence terminal, hence no retry storm."""
+
+    status_code = 404
+
+
+def test_absent_worker_fetched_model_gates_its_function(monkeypatch) -> None:
+    import gen_worker.models.download as download_mod
+
+    calls: list = []
+
+    def _refuse(ref, **kwargs):  # network boundary — the only fake here
+        calls.append(ref)
+        raise _Upstream404("404 Client Error: Repository Not Found")
+
+    monkeypatch.setattr(download_mod, "download_hf", _refuse)
+
+    with hub_double(modules=(_MODULE,)) as (scheduler, harness):
+        conn = scheduler.wait_connection(0)
+        unavailable = conn.wait_for(is_fn_unavailable("hf-echo")).fn_unavailable
+        assert unavailable.reason == "model_unavailable"
+        assert "404" in unavailable.detail
+        assert unavailable.axes["ref"] == UPSTREAM_REF
+
+        ready = conn.wait_for(is_ready).state_delta
+        # The wedge: READY while advertising a function with no model.
+        assert "hf-echo" not in ready.available_functions
+        # ...and it is not merely "still loading" either — it is refused.
+        assert "hf-echo" not in ready.loading_functions
+        # Gating is per function, never the process: the model-free sibling
+        # serves, and the worker is alive.
+        assert "plain-echo" in ready.available_functions
+        assert harness.exit_code is None
+        assert calls, "the prefetch never reached the download path"
+
+
+# ---------------------------------------------------------------------------
+# Half 2 — the progress floor. Real watchdog; fakes at the clock/disk boundary.
+# ---------------------------------------------------------------------------
+
+
+def _watchdog(byte_series, *, stall_timeout: float, min_window_bytes: int) -> str:
+    """Run the real watchdog over a scripted bytes-on-disk series. The
+    download thread finishes only when the series is exhausted, so a stall
+    verdict comes from the watchdog, never from the download returning."""
+    done = threading.Event()
+    seen = iter(byte_series)
+    last = [0]
+
+    def _download() -> str:
+        done.wait(timeout=30.0)
+        return "/tmp/pgw655-done"
+
+    def _scan(_root: Path) -> int:
+        try:
+            last[0] = next(seen)
+        except StopIteration:
+            done.set()
+        return last[0]
+
+    try:
+        return _run_with_stall_watchdog(
+            _download,
+            label="pgw655",
+            progress_root=Path("/nonexistent"),
+            progress_callback=None,
+            total_hint=None,
+            stall_timeout=stall_timeout,
+            min_window_bytes=min_window_bytes,
+            scan_bytes=_scan,
+            poll_interval=0.01,
+        )
+    finally:
+        done.set()
+
+
+def test_trickling_download_is_a_stall() -> None:
+    """One byte per poll forever used to reset the window on every tick —
+    the exact shape that pinned DOWNLOADING_MODELS with no wall-clock cap."""
+    trickle = (n for n in range(1, 10_000))
+    with pytest.raises(DownloadStalledError) as exc:
+        _watchdog(trickle, stall_timeout=0.2, min_window_bytes=1024)
+    assert "stalled" in str(exc.value)
+
+
+def test_download_clearing_the_floor_is_not_a_stall() -> None:
+    series = [4096 * i for i in range(1, 40)]
+    assert _watchdog(series, stall_timeout=0.2, min_window_bytes=1024)
+
+
+def test_zero_progress_is_still_a_stall() -> None:
+    with pytest.raises(DownloadStalledError):
+        _watchdog([0] * 10_000, stall_timeout=0.2, min_window_bytes=1024)
+
+
+def test_bursty_transfer_survives() -> None:
+    """A transfer that sits still for several polls and then jumps past the
+    floor must NOT be killed — the floor is a rate over the window, not a
+    per-tick demand."""
+    series: list[int] = []
+    total = 0
+    for _ in range(20):
+        series.extend([total] * 5)
+        total += 4096
+    assert _watchdog(iter(series), stall_timeout=0.3, min_window_bytes=1024)
+
+
+def test_the_shipped_floor_is_non_zero() -> None:
+    """The constant this issue exists to fix: the wall-clock cap was 0.0 —
+    'no bound at all' — for its entire life."""
+    import gen_worker.models.download as download_mod
+
+    assert _HF_DOWNLOAD_MIN_WINDOW_BYTES > 0
+    assert not hasattr(download_mod, "_HF_DOWNLOAD_MAX_SECONDS"), (
+        "the dead wall-clock knob must stay deleted (pgw#655)"
+    )

--- a/tests/test_retry_activity_gw661.py
+++ b/tests/test_retry_activity_gw661.py
@@ -1,0 +1,176 @@
+"""gw#661: a will-retry setup condition must not present to the hub as a
+failure.
+
+Measured live 2026-07-25: a self-mint compile hit ``RetryableError: lane
+tensorhub/qwen-image:prod cannot promote to VRAM (waited 45s for headroom);
+retrying``, reported ACTIVITY_STATE_FAILED, and the hub condemned the pod —
+4 condemnations against 4 compiles that then COMPLETED, one finishing 53s
+after its pod was already condemned. The hub's ``lastWorkerProgressLocked``
+(th#1160) *excludes* failed activities from progress evidence, so declaring a
+will-retry attempt FAILED erases exactly the evidence that keeps a working pod
+alive.
+
+So: retryable losses report RUNNING with a ``retrying`` detail, exhaustion
+reports FAILED and disables the function (the hub must still see the terminal
+truth — th#1159's genuinely-unfittable VRAM lane depends on it), and a
+non-retryable failure reports FAILED on the first attempt as it always did.
+
+These drive the real ``Executor.ensure_setup`` path with the real activity
+sink, not a stub reporter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import msgspec
+import pytest
+
+from gen_worker import activity
+from gen_worker.api import Resources, endpoint
+from gen_worker.api.errors import RetryableError
+from gen_worker.executor import MAX_TRANSIENT_SETUP_ATTEMPTS, Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+
+class _In(msgspec.Struct):
+    prompt: str = "x"
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+@pytest.fixture(autouse=True)
+def _reset_activity_sink():
+    yield
+    with activity._lock:
+        activity._sink = None
+        activity._current = None
+        activity._last_progress_heartbeat = 0.0
+
+
+def _updates(sent: List[pb.WorkerMessage]) -> List[pb.ActivityUpdate]:
+    return [m.activity_update for m in sent if m.WhichOneof("msg") == "activity_update"]
+
+
+def _executor(setup_fn):
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    @endpoint(resources=Resources(vram_gb_hint=8))
+    class Ep:
+        def setup(self) -> None:
+            setup_fn()
+
+        def generate(self, ctx, payload: _In) -> _Out:
+            return _Out(y="ok")
+
+    specs = extract_specs(Ep)
+    return Executor(specs, _send), specs, sent
+
+
+async def _attempt(ex, spec, expected_exc) -> None:
+    if expected_exc is None:
+        await ex.ensure_setup(spec)
+    else:
+        with pytest.raises(expected_exc):
+            await ex.ensure_setup(spec)
+    for _ in range(10):  # the sink schedules sends onto this loop
+        await asyncio.sleep(0)
+
+
+def test_retryable_setup_loss_reports_running_not_failed():
+    """The lane-gate case: the attempt lost, the work will be re-attempted,
+    so the hub must still see a RUNNING activity — its only progress
+    evidence — and the function must stay servable."""
+    outcomes = [RetryableError("cannot promote to VRAM (waited 45s); retrying"), None]
+
+    def _setup() -> None:
+        exc = outcomes.pop(0)
+        if exc is not None:
+            raise exc
+
+    ex, specs, sent = _executor(_setup)
+
+    async def _go() -> None:
+        await _attempt(ex, specs[0], RetryableError)
+
+        ups = _updates(sent)
+        assert ups, "no activity envelopes emitted"
+        last = ups[-1]
+        assert last.state == pb.ActivityState.ACTIVITY_STATE_RUNNING, (
+            "a will-retry condition reported the FAILED terminal — the hub "
+            "drops failed activities from its progress evidence and condemns "
+            "the pod (gw#661)"
+        )
+        assert "retrying (attempt 1/" in last.detail
+        assert "RetryableError" in last.detail
+        assert not last.error, "a RUNNING update must not carry the error rung"
+        # Not disabled: the hub may still dispatch, and the retry may win.
+        assert specs[0].name not in ex.unavailable
+
+        # The retry wins, and the record's patience is restored for next time.
+        await _attempt(ex, specs[0], None)
+        assert _updates(sent)[-1].state == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+        assert ex._class_record(specs[0]).transient_setup_failures == 0
+
+    asyncio.run(_go())
+
+
+def test_retry_exhaustion_reports_failed_and_disables_the_function():
+    """Exhaustion is the terminal truth and the hub must see it: FAILED on
+    the activity carrier plus a typed per-function unavailability. Without
+    this, 'retryable' would mean an infinite entitlement and th#1159's
+    genuinely-unfittable VRAM lane could never reach a verdict."""
+    def _setup() -> None:
+        raise RetryableError("cannot promote to VRAM (waited 45s); retrying")
+
+    ex, specs, sent = _executor(_setup)
+
+    async def _go() -> None:
+        for attempt in range(1, MAX_TRANSIENT_SETUP_ATTEMPTS + 1):
+            await _attempt(ex, specs[0], RetryableError)
+            last = _updates(sent)[-1]
+            if attempt < MAX_TRANSIENT_SETUP_ATTEMPTS:
+                assert last.state == pb.ActivityState.ACTIVITY_STATE_RUNNING, (
+                    f"attempt {attempt} of {MAX_TRANSIENT_SETUP_ATTEMPTS} "
+                    "reported terminal before the budget was spent"
+                )
+                assert specs[0].name not in ex.unavailable
+            else:
+                assert last.state == pb.ActivityState.ACTIVITY_STATE_FAILED, (
+                    "the budget was spent and the worker still told the hub "
+                    "it was working — the terminal truth never arrives"
+                )
+                assert "RetryableError" in last.error
+
+        reason, detail, _axes = ex.unavailable[specs[0].name]
+        assert reason == "retry_exhausted"
+        assert "RetryableError" in detail
+
+    asyncio.run(_go())
+
+
+def test_non_retryable_setup_failure_still_reports_failed_immediately():
+    """No budget for a failure that carries no retry contract: first
+    attempt, FAILED, function disabled."""
+    def _setup() -> None:
+        raise RuntimeError("induced setup crash")
+
+    ex, specs, sent = _executor(_setup)
+
+    async def _go() -> None:
+        await _attempt(ex, specs[0], RuntimeError)
+
+        last = _updates(sent)[-1]
+        assert last.state == pb.ActivityState.ACTIVITY_STATE_FAILED
+        assert "RuntimeError: induced setup crash" in last.error
+        assert not last.detail.startswith("retrying")
+        assert ex.unavailable[specs[0].name][0] == "setup_failed"
+
+    asyncio.run(_go())

--- a/tests/test_th1130_deferred_tail.py
+++ b/tests/test_th1130_deferred_tail.py
@@ -63,7 +63,14 @@ def test_the_permit_is_released_before_the_deferred_encode_runs() -> None:
     assert res.status == pb.JOB_STATUS_OK, res.safe_message
     stages = dict(res.metrics.stage_ms)
     encode_ms = stages["image_encode"]
-    assert encode_ms >= 100, f"the 1024^2 webp encode should be visible: {stages}"
+    # The encode must be big enough that "it ran slotless" means something —
+    # but NOT a wall-clock claim about the runner's CPU. `>= 100` failed on a
+    # GitHub runner at 83ms (pgw debt-sweep lane, PR #397), which said nothing
+    # about the property under test. Measurable, and dominating the tail, is
+    # the honest form of the same requirement.
+    assert encode_ms >= 10, f"the 1024^2 webp encode should be visible: {stages}"
+    assert encode_ms >= 0.5 * stages["total.tail"], (
+        f"the deferred encode should dominate the tail: {stages}")
 
     # The whole encode fits inside the post-release window: the GPU was free
     # for every millisecond of it.

--- a/tests/test_th1130_deferred_tail.py
+++ b/tests/test_th1130_deferred_tail.py
@@ -1,0 +1,181 @@
+"""th#1130: the image encode+upload tail runs AFTER the GPU permit is released.
+
+th#1107 put the slot-release + finalize-permit machinery on ``gw_io.write_image``
+— which no deployed endpoint calls. All 19 live image call sites use
+``ctx.save_image``, so the whole image fleet serialized a ~250ms-1.1s webp
+encode plus the upload behind the GPU permit. The fix cannot be a blanket
+terminal release inside ``save_image`` (endpoints save mid-pipeline and in
+N-image loops); the terminality signal is the HANDLER'S RETURN, where the
+executor already releases the permit. ``save_image`` therefore defers its
+encode+upload and the executor drains the queue after the release.
+
+Everything below drives the REAL executor over the hub-double: a real gRPC
+socket, real transport/lifecycle/executor, real PIL encodes, real GPU-permit
+semantics (``ResolvedCompute(accelerator="cuda")`` — no CUDA is touched).
+"""
+
+from __future__ import annotations
+
+import time
+from io import BytesIO
+
+import msgspec
+from PIL import Image
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.stage_timing import reconciliation
+
+from harness import deferred_endpoints as de
+from harness.hub_double import hub_double, is_ready, is_result_for
+
+MODULES = ("harness.deferred_endpoints",)
+CUDA = pb.ResolvedCompute(accelerator="cuda", gpu_index=0)
+
+
+def _payload() -> bytes:
+    return msgspec.msgpack.encode({"prompt": "a cat"})
+
+
+def _run(conn: object, rid: str, fn: str) -> None:
+    # Handler methods are advertised kebab-cased (``slow_encode`` ->
+    # ``slow-encode``).
+    conn.send(run_job=pb.RunJob(  # type: ignore[attr-defined]
+        request_id=rid, attempt=1, function_name=fn.replace("_", "-"),
+        input_payload=_payload(),
+        output_mode=pb.OUTPUT_MODE_INLINE, compute=CUDA))
+
+
+def _image_bytes(res: pb.JobResult, field: str = "image") -> bytes:
+    out = msgspec.msgpack.decode(res.inline)
+    return out[field]["inline_bytes"]
+
+
+def test_the_permit_is_released_before_the_deferred_encode_runs() -> None:
+    """(a) The encode lands entirely inside the SLOTLESS window, and the
+    th#1111 stage map still closes exactly."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-slow", "slow_encode")
+        res = conn.wait_for(is_result_for("r-slow"), timeout=30).job_result
+
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    stages = dict(res.metrics.stage_ms)
+    encode_ms = stages["image_encode"]
+    assert encode_ms >= 100, f"the 1024^2 webp encode should be visible: {stages}"
+
+    # The whole encode fits inside the post-release window: the GPU was free
+    # for every millisecond of it.
+    assert res.metrics.finalize_wall_ms >= encode_ms, (
+        res.metrics.finalize_wall_ms, encode_ms, stages)
+    # ...and the permit was NOT held for it.
+    assert res.metrics.slot_held_ms <= res.metrics.runtime_ms - encode_ms + 15, (
+        res.metrics.slot_held_ms, res.metrics.runtime_ms, encode_ms)
+
+    # th#1111: the tail work is attributed to the tail, and the map reconciles.
+    assert stages["total.tail"] >= encode_ms
+    attributed, total = reconciliation(stages)
+    assert total == res.metrics.runtime_ms
+    assert abs(attributed - total) <= 5, (attributed, total, stages)
+    assert stages["class.gpu_idle"] >= encode_ms
+
+
+def test_a_second_job_takes_the_gpu_while_the_first_is_still_encoding() -> None:
+    """(b) The point of the whole lane: in-flight-N overlap."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-a", "slow_encode")
+        _run(conn, "r-b", "fast_peer")
+        a = conn.wait_for(is_result_for("r-a"), timeout=30).job_result
+        a_done_at = time.monotonic()
+        b = conn.wait_for(is_result_for("r-b"), timeout=30).job_result
+
+    assert a.status == pb.JOB_STATUS_OK, a.safe_message
+    assert b.status == pb.JOB_STATUS_OK, b.safe_message
+
+    b_start = de.at("handler_start", "r-b")
+    a_handler_end = de.at("handler_end", "r-a")
+    # B waited for A's GPU phase (one slot)...
+    assert b_start > a_handler_end, "B must not run inside A's GPU phase"
+    # ...and started BEFORE A's tail finished: A's encode+upload and B's
+    # compute were in flight at the same time.
+    assert b_start < a_done_at, (
+        f"B started {b_start - a_done_at:.3f}s after A's result — no overlap")
+    overlap_ms = int((a_done_at - b_start) * 1000)
+    encode_ms = dict(a.metrics.stage_ms)["image_encode"]
+    assert overlap_ms >= encode_ms * 0.5, (
+        f"only {overlap_ms}ms of B ran inside A's {encode_ms}ms tail")
+
+
+def test_an_n_image_loop_never_releases_the_permit_early() -> None:
+    """(c) The failure mode that ruled out copying th#1107's terminal release
+    onto save_image: a handler that saves, then does more GPU work."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-loop", "n_images")
+        _run(conn, "r-peer", "fast_peer")
+        loop = conn.wait_for(is_result_for("r-loop"), timeout=30).job_result
+        peer = conn.wait_for(is_result_for("r-peer"), timeout=30).job_result
+
+    assert loop.status == pb.JOB_STATUS_OK, loop.safe_message
+    assert peer.status == pb.JOB_STATUS_OK, peer.safe_message
+    assert len(msgspec.msgpack.decode(loop.inline)["images"]) == de.LOOP_IMAGES
+
+    peer_start = de.at("handler_start", "r-peer")
+    # Not one of the N saves handed the permit away: the peer ran only after
+    # the whole handler returned.
+    assert peer_start > de.at("handler_end", "r-loop"), (
+        "a save released the GPU permit while the handler still had work")
+    assert peer_start > de.at(f"saved_{de.LOOP_IMAGES - 1}", "r-loop")
+
+
+def test_a_failing_deferred_encode_fails_the_request() -> None:
+    """(d) A tail that raises must fail the request, not report OK with a
+    hollow asset."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-boom", "fails_in_tail")
+        res = conn.wait_for(is_result_for("r-boom"), timeout=30).job_result
+
+    assert res.status != pb.JOB_STATUS_OK, "a broken encode reported success"
+    assert not res.inline, "no output may be shipped for a failed tail"
+    assert res.safe_message, "the failure must carry a message"
+
+
+def test_mutating_the_image_after_save_cannot_change_the_upload() -> None:
+    """(e) Copy-on-save: the handler paints blue over the same PIL object after
+    saving a red frame; the uploaded bytes must still be red."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-mut", "mutates_after_save")
+        res = conn.wait_for(is_result_for("r-mut"), timeout=30).job_result
+
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    img = Image.open(BytesIO(_image_bytes(res))).convert("RGB")
+    assert img.getpixel((5, 5)) == (255, 0, 0), (
+        "the deferred encode picked up the handler's later mutation")
+
+
+def test_reading_a_bytes_field_in_the_handler_forces_a_real_encode() -> None:
+    """Read-back is CORRECT, just not overlapped: the handle materializes
+    inline rather than answering None."""
+    de.reset()
+    with hub_double(modules=MODULES) as (scheduler, _h):
+        conn = scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
+        _run(conn, "r-read", "reads_back")
+        res = conn.wait_for(is_result_for("r-read"), timeout=30).job_result
+
+    assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    out = msgspec.msgpack.decode(res.inline)
+    assert out["size_bytes"] > 0, "the handler read a hollow size_bytes"
+    assert out["ref"].endswith(".png")

--- a/tests/test_url_fetch_pgw663.py
+++ b/tests/test_url_fetch_pgw663.py
@@ -1,0 +1,200 @@
+"""pgw#663 (ie#554): one guarded URL fetch, and it survives the redirect bypass.
+
+Real HTTP servers on loopback, real policy — the only thing stubbed is the
+address classifier, because a test cannot make a public IP appear on this box.
+That stub is exactly one function (`_url_is_blocked`), and the rows that matter
+(redirect re-validation, byte caps, MIME) run the real code end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from io import BytesIO
+from typing import Any
+
+import pytest
+
+from gen_worker import url_fetch
+from gen_worker.api.errors import ValidationError
+
+
+class _Origin(BaseHTTPRequestHandler):
+    """Serves payloads, redirects, and an oversize body."""
+
+    state: dict[str, Any] = {}
+
+    def log_message(self, *args: Any) -> None:
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        st = _Origin.state
+        st.setdefault("paths", []).append(self.path)
+        if self.path.startswith("/redirect-to-"):
+            target = st["targets"][self.path.rsplit("-", 1)[-1]]
+            self.send_response(302)
+            self.send_header("Location", target)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if self.path == "/no-length":
+            # No Content-Length at all: HTTP/1.0 read-until-close, i.e. a body
+            # whose size the client cannot know before reading it. This is the
+            # shape an unbounded `resp.read()` blows the pod up on.
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"x" * 5000)
+            return
+        if st.get("status"):
+            self.send_error(int(st["status"]))
+            return
+        payload = st.get("body", b"hello")
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+@pytest.fixture
+def origin():
+    _Origin.state = {"targets": {}}
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Origin)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield base, _Origin.state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def public(monkeypatch):
+    """Treat every 127.0.0.1 URL as public EXCEPT ones marked ``blocked``.
+
+    The classifier itself (`_is_private_ip_str`) is covered by its own callers;
+    what this suite is for is the policy AROUND it — above all whether it is
+    consulted on redirect hops at all.
+    """
+    def _blocked(url: str) -> bool:
+        return "blocked" in url
+
+    monkeypatch.setattr(url_fetch, "_url_is_blocked", _blocked)
+    return _blocked
+
+
+def test_plain_fetch(origin, public) -> None:
+    base, state = origin
+    state["body"] = b"a caption input"
+    got = url_fetch.fetch_bytes(f"{base}/ok")
+    assert got.data == b"a caption input"
+    assert got.size_bytes == 15
+
+
+def test_redirect_into_a_blocked_destination_is_refused(origin, public) -> None:
+    """THE bug this issue exists for. `urlopen` follows redirects silently, so
+    a pre-flight check on the caller's URL says nothing about where the bytes
+    actually come from — the metadata-service bypass in one line."""
+    base, state = origin
+    state["targets"]["meta"] = f"{base}/blocked-metadata"
+    with pytest.raises(ValidationError) as exc:
+        url_fetch.fetch_bytes(f"{base}/redirect-to-meta")
+    assert "redirect hop 1" in str(exc.value)
+    # It refused BEFORE fetching the destination.
+    assert not any("blocked-metadata" in p for p in state["paths"])
+
+
+def test_a_permitted_redirect_still_works(origin, public) -> None:
+    base, state = origin
+    state["body"] = b"redirected"
+    state["targets"]["ok"] = f"{base}/final"
+    assert url_fetch.fetch_bytes(f"{base}/redirect-to-ok").data == b"redirected"
+
+
+def test_redirect_loops_terminate(origin, public) -> None:
+    base, state = origin
+    state["targets"]["loop"] = f"{base}/redirect-to-loop"
+    with pytest.raises(ValidationError, match="redirects"):
+        url_fetch.fetch_bytes(f"{base}/redirect-to-loop", max_redirects=2)
+
+
+def test_non_http_scheme_is_refused(public) -> None:
+    with pytest.raises(ValidationError, match="http"):
+        url_fetch.fetch_bytes("file:///etc/passwd")
+
+
+def test_blocked_host_is_refused(origin, public) -> None:
+    base, _ = origin
+    with pytest.raises(ValidationError, match="non-public address"):
+        url_fetch.fetch_bytes(f"{base}/blocked")
+
+
+def test_caller_allowlist(origin, public) -> None:
+    base, state = origin
+    state["body"] = b"ok"
+    with pytest.raises(ValidationError, match="caller's allowlist"):
+        url_fetch.fetch_bytes(f"{base}/ok", allowed_hosts=("cdn.example.com",))
+    assert url_fetch.fetch_bytes(f"{base}/ok", allowed_hosts=("127.0.0.1",)).data == b"ok"
+
+
+def test_deployment_allowlist_is_an_outer_bound(origin, public, monkeypatch) -> None:
+    base, state = origin
+    state["body"] = b"ok"
+    monkeypatch.setenv(url_fetch.ALLOWED_HOSTS_ENV, "cdn.example.com")
+    with pytest.raises(ValidationError, match="allowlist"):
+        # even with the caller explicitly permitting the host
+        url_fetch.fetch_bytes(f"{base}/ok", allowed_hosts=("127.0.0.1",))
+
+
+def test_declared_oversize_is_refused_before_reading(origin, public) -> None:
+    base, state = origin
+    state["body"] = b"x" * 4096
+    with pytest.raises(ValidationError, match="declares"):
+        url_fetch.fetch_bytes(f"{base}/big", max_bytes=100)
+
+
+def test_a_body_with_no_declared_length_is_still_capped(origin, public) -> None:
+    """The cap cannot depend on the server declaring a size — the per-chunk
+    accounting is what actually bounds the read."""
+    base, _ = origin
+    with pytest.raises(ValidationError, match="exceeds its"):
+        url_fetch.fetch_bytes(f"{base}/no-length", max_bytes=1000)
+
+
+def test_an_error_status_is_a_typed_refusal_for_callers(origin, public) -> None:
+    """`fetch_bytes` maps a bad status to a caller refusal — but the OPENER
+    re-raises it untouched, so `input_assets` keeps its own (retryable)
+    reading of a 404 on an authorized transport."""
+    import urllib.error
+
+    base, state = origin
+    state["status"] = 404
+    with pytest.raises(ValidationError, match="HTTP 404"):
+        url_fetch.fetch_bytes(f"{base}/gone")
+    with pytest.raises(urllib.error.HTTPError):
+        with url_fetch.open_guarded_stream(f"{base}/gone"):
+            pass
+
+
+def test_mime_allowlist_uses_the_sniffed_type(origin, public) -> None:
+    base, state = origin
+    state["body"] = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    assert url_fetch.fetch_bytes(f"{base}/x.png", allowed_mime_types=("image/png",))
+    with pytest.raises(ValidationError, match="content type"):
+        url_fetch.fetch_bytes(f"{base}/x.png", allowed_mime_types=("image/jpeg",))
+
+
+def test_fetch_image_returns_rgb_and_refuses_non_images(origin, public) -> None:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGBA", (8, 8), (10, 20, 30, 255)).save(buf, format="PNG")
+    base, state = origin
+    state["body"] = buf.getvalue()
+    image = url_fetch.fetch_image(f"{base}/x.png")
+    assert image.mode == "RGB" and image.size == (8, 8)
+
+    state["body"] = json.dumps({"not": "an image"}).encode()
+    with pytest.raises(ValidationError, match="not an image"):
+        url_fetch.fetch_image(f"{base}/x.json")

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.61.0"
+version = "0.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Promotion train, chaos -> master. The tree is byte-identical to `origin/chaos` at `63df547`.

## What rides

| lane | chaos sha | what |
|---|---|---|
| th#1130 (0.62.0) | `2c28e1e` | `ctx.save_image` defers encode + C2PA + upload to the finalize tail — the image tail now overlaps the next request's compute (pgw#652 Phase 0, images). Zero endpoint changes. |
| gw#661 (0.62.1) | `a419677` (+ executor half in `a19bb0b`) | a will-be-re-attempted setup loss reports RUNNING, not the FAILED terminal the hub's progress-aware verdict reads as "no progress". |
| **pgw#655** (P0) | `a19bb0b` | a worker never advertises a function whose model is absent; the HF download bound is a progress-RATE floor (the wall-clock knob sat at `0.0` for its whole life and is deleted). |
| **pgw#656** | `4972cd9` | dataset ingest never creates a duplicate it could have found (raise instead of fall-through-to-CREATE, cursor pagination, `?org=`). |
| **pgw#657** | `74576c0` | fail-loud batch: the hf timeout floor is PROVEN at boot; the boot record picks a durable carrier; the diffusers-singlefile branch is a typed refusal; compile-evidence probes say why they failed. |
| pgw#654 tail | `eb378f9` `5c39f62` `cd143d8` `95d89e5` `68400b3` | import-convention sweep, `ModelRef.label`, last "regime" comments retired. |

Every lane recorded "rides the next train" on its own tracker issue before this was cut.

## Behaviour changes worth reading (CHANGELOG 0.63.0 is the full list)

- A boot prefetch failure now makes the bound functions `FnUnavailable(model_unavailable)` instead of letting the worker reach READY and fail per job on paid GPU.
- An HF transfer that cannot put 8 MiB on disk per 180s window raises `DownloadStalledError` (~46 KiB/s floor).
- `install_hf_http_timeouts()` raises `HfHttpFloorError` if the floor cannot be proven, rather than silently reverting the fleet to infinite timeouts.

## Local gates on this exact tree

- `mypy src/gen_worker` — clean, 142 files
- `ruff check src/gen_worker` — clean
- `pytest tests/` — 878 passed, 5 skipped, 1 xfailed. One failure, `test_cancelled_to_thread_join_releases_result`, is the documented load-flake (pgw#641 gotcha 4; 1-min load 44 at the time) and passes in isolation.

CI dispatched once on this head, per the CI-spend policy.