### PR TITLE
release 0.64.0: warm-tax fix (pgw#654) — contract-keyed warm runs + gw#665/#666 liveness + pgw#647 gap #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## 0.64.0 (2026-07-25) — the warm tax dies: contract-keyed warm runs; wall clocks become liveness
+
+The P0 for the sdxl multi-checkpoint stress test (pgw#654 warm-tax fix,
+measured by the ie#546 canary on 0.61.0), plus gw#665/gw#666 (the last
+fixed wall clocks become liveness checks — ONE breaking deletion) and
+pgw#647 gap #2.
+
+### pgw#654 — warm RUNS are contract-keyed, never instance-keyed
+
+The 0.61.0 derived warm plan re-ran per CHECKPOINT INSTANCE: first boots
+took ~28–32 min (18 real eager denoises at 1MP+; was ~3.3 min on 0.60.x)
+and every juggle swap paid a ~9-min warm re-run on top of its genuine
+~74s transfer+load. Multi-checkpoint juggling — the v2 flagship — now
+works as designed:
+
+- **Warm-run memory is keyed by CONTRACT** (endpoint class + per-slot
+  precision-lane facts + component overrides — never the checkpoint ref).
+  The plan executes once per contract per process; a further checkpoint
+  instance of the same family runs ONE clamped verification job (proves
+  the fresh weights compose and forward pre-READY; supplies the calls>0
+  the compile proof needs). Swap cost is transfer + VRAM load, bounded by
+  the residency path, never a warm-plan re-run. Allocator pool,
+  cuBLAS/cuDNN heuristics and dynamo's in-memory compiled code are
+  process-global — that is what makes the inheritance sound. Inheritance
+  is refused while a self-mint capture is pending or an armed cell is not
+  yet proven in-process (those boots keep the full plan and full proof).
+- **Eager lanes stop paying the cross-product.** When nothing is armed or
+  minting, the boot warm runs ONE shape representative per (function,
+  guidance class) — allocator peak and kernel-heuristic warm are
+  shape-driven, not coverage-driven; nothing is being traced. Numeric
+  shape axes (megapixels-style) keep their max-area bucket; enum axes
+  keep the first declared class. The full class x bucket product still
+  runs whenever a compile artifact is armed or minting.
+- **Synthesized warm payloads clamp step fields** (`num_inference_steps`
+  / `steps`) to their declared floor (`msgspec.Meta` ge/gt honored) —
+  the traced graph and the allocator peak are step-count independent, so
+  a warm run never pays a full recipe's steps even on an endpoint that
+  forgot `ctx.boot_warmup`. A `@worker_function(warm=...)` override still
+  wins.
+- New pod-side benchmark: `benchmarks/swap_latency.py` — per-component
+  disk->VRAM load, VRAM->host-RAM demote, resident re-pick promote,
+  component-first swap by content address (in-place copy vs replace; a
+  DMD-distilled sibling is the same case), H2D copy-stream overlap with
+  compute-interference measurement. Refuses to run off-pod.
+
+### pgw#647 gap #2 — component overrides inherit the composition's dtype
+
+`load_component_override` resolves dtype as: base binding's declared
+dtype, else the base COMPOSITION's compute dtype
+(`composition_compute_dtype`: fp8-stored bases map to their bf16 compute
+default), else — last resort — the override's own on-disk dtype. The old
+override-on-disk fallback loaded the fp32-stored `sdxl-vae-fp16-fix` into
+a bf16 pipeline and setup died on the first latent (ie#546 canary, 2/2
+pods). The VAE-override deploy path is unblocked.
+
+### `ctx.adjustments` — the public read side of the adjustment ledger
+
+`RequestContext.adjustments` returns an immutable tuple of the
+`ctx.adjusted`/`ctx.clamp` rows. Endpoint test suites migrate off the
+private `ctx._adjustments` read at their next relock.
+
+### gw#666 — BREAKING: `boot_timeout_s` is DELETED (fixed durations -> liveness)
+
+The last five gen-worker wall clocks became liveness checks
+(`gen_worker.stall`: `SilenceWindow` over the engine's own output +
+`ProgressFloor`). `ServerProcess`/`vllm_server`/`llama_server` no longer
+accept `boot_timeout_s` — pass `stall_window_s` (silence window, not a
+boot budget) if you must tune it; an engine that keeps talking boots for
+as long as it needs. **Migration (ie#558): both qwen3.6 endpoints on ie
+master (`qwen3.6-35b-a3b`, `qwen3.6-27b-mtp-gguf`, currently pinned
+0.61.0) pass `boot_timeout_s=1800` — delete the argument in the same
+commit that bumps their pin, or the import dies at decoration time.**
+
+### gw#665 — the conversion toolchain is bounded by silence, not a 2-hour wall
+
+Conversion subprocesses (`subproc.LineTail`) are killed on output
+SILENCE, not on a fixed wall clock — a talking 3-hour GGUF conversion
+finishes; a silent hang dies fast.
+
 ## 0.63.0 (2026-07-25) — debt sweep: a worker never advertises a model it does not have
 
 Four fleet-debt issues from Paul's audit (pgw#655 / #656 / #657) plus the SDK half of

--- a/benchmarks/swap_latency.py
+++ b/benchmarks/swap_latency.py
@@ -1,0 +1,359 @@
+"""Checkpoint-swap latency benchmark (pgw#654 / WORKER-RESIDENCY-DESIGN).
+
+Measures the PHYSICAL costs behind multi-checkpoint juggling, one narrow
+case at a time, on a REAL GPU pod with already-materialized snapshot trees
+(weights-locality: this never runs on the control-plane box — it refuses
+without CUDA and under GEN_WORKER_FORBID_CPU_OFFLOAD).
+
+Cache/eviction ladder measured here (design of record): VRAM -> host RAM ->
+local-disk CAS (the pod NVMe IS content-addressed storage) -> NFS CAS
+(remote disk, when mounted) -> re-download from R2 (tensorhub's remote CAS
+origin). Point ``--checkpoint`` at trees on different tiers (local NVMe vs
+an NFS mount) to compare source tiers; R2 cold-fetch is the store's job and
+is measured by the worker's own transfer telemetry, not here.
+
+Cases:
+  load        disk -> VRAM, per component (from_pretrained + .to(cuda))
+  demote      VRAM -> host RAM (pipe.to("cpu"))
+  promote     host RAM -> VRAM (pipe.to("cuda")) — the resident re-pick
+  swap        component-first A -> B: only components whose content digest
+              differs are touched (Paul's ruling: swap components, never
+              whole pipelines — the pipeline object / compiled graphs are
+              the stable identity). Two mechanisms measured:
+                replace: load a fresh module and swap the attribute
+                         (breaks compiled-graph object binding — the
+                         anti-pattern, timed for comparison)
+                copy:    in-place load_state_dict into the RESIDENT module
+                         (preserves object identity; the design target).
+              A DMD-distilled full-checkpoint sibling is the same case —
+              pass it as B and serve the distilled recipe per request; same
+              contract, no re-trace.
+  overlap     H2D copy on a dedicated copy stream (pinned staging) while a
+              synthetic compute load runs — copy bandwidth and the
+              interference cost on compute throughput.
+
+Usage (pod-side):
+  python -m benchmarks.swap_latency load    --checkpoint /path/A
+  python -m benchmarks.swap_latency demote  --checkpoint /path/A
+  python -m benchmarks.swap_latency swap    --checkpoint /path/A --to /path/B
+  python -m benchmarks.swap_latency overlap --gb 4
+  python -m benchmarks.swap_latency all --checkpoint /path/A --to /path/B
+
+Each case prints one JSON object per measurement row (machine-parseable)
+plus a summary table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import os
+import sys
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+_GiB = float(1 << 30)
+
+
+def _refuse_off_pod() -> None:
+    if os.environ.get("GEN_WORKER_FORBID_CPU_OFFLOAD"):
+        raise SystemExit(
+            "refusing: GEN_WORKER_FORBID_CPU_OFFLOAD is set — this is the "
+            "control-plane box; run this benchmark on a GPU pod "
+            "(weights-locality rule)")
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SystemExit("refusing: no CUDA device — run on a GPU pod")
+
+
+@dataclass
+class Row:
+    case: str
+    label: str
+    seconds: float
+    bytes: int = 0
+    extra: Optional[Dict[str, Any]] = None
+
+    def emit(self) -> None:
+        d = asdict(self)
+        d["gib"] = round(self.bytes / _GiB, 3)
+        d["gib_per_s"] = (
+            round(self.bytes / _GiB / self.seconds, 2) if self.seconds > 0 else 0.0
+        )
+        print(json.dumps(d, sort_keys=True), flush=True)
+
+
+def _sync() -> None:
+    import torch
+
+    torch.cuda.synchronize()
+
+
+def _cuda_bytes() -> int:
+    import torch
+
+    return int(torch.cuda.memory_allocated())
+
+
+def _component_entries(tree: Path) -> Dict[str, Tuple[str, str]]:
+    """component name -> (library, class) from model_index.json."""
+    idx = json.loads((tree / "model_index.json").read_text())
+    out: Dict[str, Tuple[str, str]] = {}
+    for name, entry in idx.items():
+        if name.startswith("_") or not isinstance(entry, list) or len(entry) != 2:
+            continue
+        if entry[0] is None or entry[1] is None:
+            continue
+        out[name] = (str(entry[0]), str(entry[1]))
+    return out
+
+
+def component_digest(tree: Path, component: str) -> str:
+    """Content address of one component subtree (file names + sizes + head/
+    tail samples — fast, discriminates real weight differences without
+    hashing multi-GB files end to end)."""
+    root = tree / component
+    if not root.is_dir():
+        return ""
+    h = hashlib.sha256()
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        st = p.stat()
+        h.update(str(p.relative_to(root)).encode())
+        h.update(str(st.st_size).encode())
+        with open(p, "rb") as f:
+            h.update(f.read(1 << 16))
+            if st.st_size > (1 << 20):
+                f.seek(-(1 << 16), 2)
+                h.update(f.read(1 << 16))
+    return h.hexdigest()
+
+
+def _load_component(tree: Path, name: str, lib: str, cls_name: str) -> Any:
+    module = importlib.import_module(lib)
+    cls = getattr(module, cls_name)
+    src = tree / name
+    if callable(getattr(cls, "from_pretrained", None)):
+        try:
+            import torch
+
+            return cls.from_pretrained(str(src), torch_dtype=torch.bfloat16)
+        except TypeError:
+            return cls.from_pretrained(str(src))
+    raise SystemExit(f"component {name}: {lib}.{cls_name} has no from_pretrained")
+
+
+def _module_bytes(obj: Any) -> int:
+    import torch
+
+    if not isinstance(obj, torch.nn.Module):
+        return 0
+    return sum(
+        p.numel() * p.element_size() for p in obj.parameters()
+    ) + sum(b.numel() * b.element_size() for b in obj.buffers())
+
+
+def bench_load(tree: Path) -> Dict[str, Any]:
+    """disk -> VRAM per component; returns {name: module} for reuse."""
+    loaded: Dict[str, Any] = {}
+    total_t0 = time.monotonic()
+    total_bytes = 0
+    for name, (lib, cls_name) in sorted(_component_entries(tree).items()):
+        if not (tree / name).is_dir():
+            continue
+        t0 = time.monotonic()
+        obj = _load_component(tree, name, lib, cls_name)
+        host_s = time.monotonic() - t0
+        t1 = time.monotonic()
+        import torch
+
+        if isinstance(obj, torch.nn.Module):
+            obj = obj.to("cuda")
+        _sync()
+        h2d_s = time.monotonic() - t1
+        nbytes = _module_bytes(obj)
+        total_bytes += nbytes
+        loaded[name] = obj
+        Row("load", f"{tree.name}/{name}", host_s + h2d_s, nbytes,
+            {"disk_to_host_s": round(host_s, 3),
+             "host_to_vram_s": round(h2d_s, 3)}).emit()
+    Row("load", f"{tree.name}/TOTAL", time.monotonic() - total_t0,
+        total_bytes, {"vram_allocated": _cuda_bytes()}).emit()
+    return loaded
+
+
+def bench_demote_promote(loaded: Dict[str, Any]) -> None:
+    import torch
+
+    mods = {n: m for n, m in loaded.items() if isinstance(m, torch.nn.Module)}
+    nbytes = sum(_module_bytes(m) for m in mods.values())
+    _sync()
+    t0 = time.monotonic()
+    for m in mods.values():
+        m.to("cpu")
+    _sync()
+    torch.cuda.empty_cache()
+    Row("demote", "vram->host_ram", time.monotonic() - t0, nbytes).emit()
+    t1 = time.monotonic()
+    for m in mods.values():
+        m.to("cuda")
+    _sync()
+    Row("promote", "host_ram->vram (resident re-pick)",
+        time.monotonic() - t1, nbytes).emit()
+
+
+def bench_swap(tree_a: Path, tree_b: Path, loaded: Dict[str, Any]) -> None:
+    """Component-first swap A -> B: only differing components move."""
+    import torch
+
+    comps_b = _component_entries(tree_b)
+    differing: List[str] = []
+    shared: List[str] = []
+    for name in sorted(comps_b):
+        if not (tree_b / name).is_dir():
+            continue
+        if component_digest(tree_a, name) == component_digest(tree_b, name):
+            shared.append(name)
+        else:
+            differing.append(name)
+    Row("swap", f"{tree_a.name}->{tree_b.name}/plan", 0.0, 0,
+        {"differing": differing, "shared_by_content_address": shared}).emit()
+
+    # Mechanism 1 (anti-pattern, for comparison): fresh module + replace.
+    t0 = time.monotonic()
+    replaced_bytes = 0
+    fresh: Dict[str, Any] = {}
+    for name in differing:
+        lib, cls_name = comps_b[name]
+        obj = _load_component(tree_b, name, lib, cls_name)
+        if isinstance(obj, torch.nn.Module):
+            obj = obj.to("cuda")
+        fresh[name] = obj
+        replaced_bytes += _module_bytes(obj)
+    _sync()
+    Row("swap", "mechanism=replace (breaks compiled binding)",
+        time.monotonic() - t0, replaced_bytes).emit()
+
+    # Mechanism 2 (design target): in-place state_dict copy into the
+    # RESIDENT module — pipeline object + compiled graphs stay bound.
+    t1 = time.monotonic()
+    copied_bytes = 0
+    for name in differing:
+        resident = loaded.get(name)
+        source = fresh.get(name)
+        if (
+            resident is None or source is None
+            or not isinstance(resident, torch.nn.Module)
+            or type(resident) is not type(source)
+        ):
+            continue
+        resident.load_state_dict(source.state_dict(), strict=True)
+        copied_bytes += _module_bytes(resident)
+    _sync()
+    Row("swap", "mechanism=copy (in-place, object identity preserved)",
+        time.monotonic() - t1, copied_bytes,
+        {"note": "same contract => no re-trace; a DMD-distilled sibling "
+                 "swaps identically and serves the distilled recipe via "
+                 "per-request views"}).emit()
+
+
+def bench_overlap(gb: float) -> None:
+    """H2D on a copy stream with pinned staging, concurrent with compute."""
+    import torch
+
+    n = int(gb * _GiB / 2)  # fp16 elements
+    staging = torch.empty(n, dtype=torch.float16, pin_memory=True)
+    dst = torch.empty(n, dtype=torch.float16, device="cuda")
+    a = torch.randn(4096, 4096, device="cuda", dtype=torch.float16)
+    b = torch.randn(4096, 4096, device="cuda", dtype=torch.float16)
+
+    def _compute(stop: threading.Event, out: List[int]) -> None:
+        count = 0
+        while not stop.is_set():
+            _ = a @ b
+            count += 1
+        _sync()
+        out.append(count)
+
+    # Baseline compute throughput.
+    stop = threading.Event()
+    counts: List[int] = []
+    t = threading.Thread(target=_compute, args=(stop, counts))
+    _sync()
+    t0 = time.monotonic()
+    t.start()
+    time.sleep(3.0)
+    stop.set()
+    t.join()
+    base_rate = counts[0] / (time.monotonic() - t0)
+    Row("overlap", "compute baseline", 3.0, 0,
+        {"matmul_per_s": round(base_rate, 1)}).emit()
+
+    # Baseline copy bandwidth (idle GPU).
+    copy_stream = torch.cuda.Stream()
+    _sync()
+    t1 = time.monotonic()
+    with torch.cuda.stream(copy_stream):
+        dst.copy_(staging, non_blocking=True)
+    copy_stream.synchronize()
+    Row("overlap", "h2d idle (pinned, copy stream)",
+        time.monotonic() - t1, staging.numel() * 2).emit()
+
+    # Concurrent: compute on default stream + copy on the copy stream.
+    stop = threading.Event()
+    counts = []
+    t = threading.Thread(target=_compute, args=(stop, counts))
+    _sync()
+    t2 = time.monotonic()
+    t.start()
+    with torch.cuda.stream(copy_stream):
+        dst.copy_(staging, non_blocking=True)
+    copy_stream.synchronize()
+    copy_s = time.monotonic() - t2
+    stop.set()
+    t.join()
+    wall = time.monotonic() - t2
+    rate = counts[0] / wall if wall > 0 else 0.0
+    Row("overlap", "h2d during compute", copy_s, staging.numel() * 2,
+        {"matmul_per_s": round(rate, 1),
+         "compute_interference_pct": round(
+             100.0 * (1.0 - rate / base_rate), 1) if base_rate else 0.0,
+         }).emit()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("case", choices=("load", "demote", "swap", "overlap", "all"))
+    ap.add_argument("--checkpoint", type=Path, help="materialized snapshot tree A")
+    ap.add_argument("--to", type=Path, help="snapshot tree B (swap target; a "
+                    "fine-tune or a DMD-distilled sibling)")
+    ap.add_argument("--gb", type=float, default=4.0, help="overlap copy size")
+    args = ap.parse_args(argv)
+    _refuse_off_pod()
+
+    if args.case in ("load", "demote", "swap", "all") and not args.checkpoint:
+        ap.error("--checkpoint is required for this case")
+    if args.case in ("swap", "all") and not args.to:
+        ap.error("--to is required for the swap case")
+
+    loaded: Dict[str, Any] = {}
+    if args.case in ("load", "demote", "swap", "all"):
+        loaded = bench_load(args.checkpoint)
+    if args.case in ("demote", "all"):
+        bench_demote_promote(loaded)
+    if args.case in ("swap", "all"):
+        bench_swap(args.checkpoint, args.to, loaded)
+    if args.case in ("overlap", "all"):
+        bench_overlap(args.gb)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.63.0"
+version = "0.64.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -71,7 +71,7 @@ from .request_context import (
     TrainingContext,
     TrainingMetric,
 )
-from .subproc import run_process
+from .subproc import ProcessStalledError, run_process
 
 
 __all__ = [
@@ -116,6 +116,7 @@ __all__ = [
     # Per-step progress helper for diffusers pipelines.
     "diffusers_step_callback",
     # Delegated-trainer subprocess primitive.
+    "ProcessStalledError",
     "run_process",
     # Errors.
     "CanceledError",

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -39,8 +39,8 @@ from .writer import streaming_fp8_storage_cast
 import json as _json
 import shutil as _shutil
 from ._hf_load import load_component_module
-import subprocess
-from .gguf_tools import (prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
+from ..subproc import ProcessStalledError, run_process
+from .gguf_tools import (GGUF_TOOLCHAIN_STALL_WINDOW_S, prepare_hf_source_tree_for_gguf, resolve_gguf_convert_script, run_hf_to_gguf_conversion)
 
 logger = logging.getLogger(__name__)
 
@@ -699,17 +699,30 @@ def _run_gguf_inline(
             encoding="f16",
         )
         llama_quantize = "llama-quantize"
-        proc = subprocess.run(
-            [llama_quantize, str(intermediate), str(final_path), dtype.upper()],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=7200.0,
-        )
-        if proc.returncode != 0:
+        cmd = [llama_quantize, str(intermediate), str(final_path), dtype.upper()]
+        # No wall clock: llama-quantize prints a line per quantized tensor, so
+        # SILENCE is the wedge signal and elapsed time is not (a large source
+        # legitimately runs for hours). The tail is kept only for the error.
+        tail: list[str] = []
+
+        def _quantize_line(line: str) -> None:
+            logger.info("llama-quantize: %s", line)
+            tail.append(line)
+            if len(tail) > 200:
+                del tail[0]
+
+        try:
+            returncode = run_process(
+                cmd,
+                on_line=_quantize_line,
+                stall_window_s=GGUF_TOOLCHAIN_STALL_WINDOW_S,
+            )
+        except ProcessStalledError as exc:
+            raise RuntimeError(f"llama-quantize stalled: {exc}") from exc
+        if returncode != 0:
             raise RuntimeError(
-                f"llama-quantize failed (rc={proc.returncode}): "
-                f"{(proc.stderr or '').strip()[-2000:]}"
+                f"llama-quantize failed (rc={returncode}): "
+                f"{chr(10).join(tail).strip()[-2000:]}"
             )
         if not final_path.exists() or final_path.stat().st_size <= 0:
             raise RuntimeError(f"llama-quantize produced no output for {dtype}")

--- a/src/gen_worker/convert/gguf_tools.py
+++ b/src/gen_worker/convert/gguf_tools.py
@@ -4,11 +4,26 @@ package (replaces the hand-rolled binary parser in gguf_utils.py)."""
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
+
+from ..subproc import ProcessStalledError, run_process
+
+logger = logging.getLogger(__name__)
+
+# The llama.cpp toolchain is chatty per TENSOR (convert_hf_to_gguf.py prints a
+# line per tensor, llama-quantize prints one per quantized block), so silence
+# is the honest wedge signal and elapsed time is not: a 200GB source legitimately
+# runs for hours on a shared conversion pod. Fifteen minutes of total silence is
+# orders of magnitude past any real inter-tensor gap.
+#
+# This replaces a flat ``timeout=7200`` that killed conversions mid-write purely
+# for taking two hours (gw#655's principle: a wall clock cannot tell a healthy
+# long job from a wedge, so it is either useless or it kills real work).
+GGUF_TOOLCHAIN_STALL_WINDOW_S = 900.0
 
 _SUPPORTED_ARCH_ALIASES: dict[str, str] = {
     "llama": "llama", "mistral": "llama", "gemma": "gemma",
@@ -117,18 +132,23 @@ def run_hf_to_gguf_conversion(
     cmd = [sys.executable, str(script_path), str(hf_model_dir),
            "--outfile", str(output_path), "--outtype", normalize_gguf_encoding(encoding)]
     try:
-        proc = subprocess.run(cmd, check=False, text=True, capture_output=True, timeout=7200.0)
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError("gguf_conversion_timeout") from exc
+        returncode = run_process(
+            cmd,
+            on_line=lambda line: logger.info("hf-to-gguf: %s", line),
+            stall_window_s=GGUF_TOOLCHAIN_STALL_WINDOW_S,
+        )
+    except ProcessStalledError as exc:
+        raise RuntimeError(f"gguf_conversion_stalled:{exc}") from exc
     except Exception as exc:
         raise RuntimeError("gguf_conversion_exec_failed") from exc
-    if proc.returncode != 0:
-        raise RuntimeError(f"gguf_conversion_failed:rc={proc.returncode}")
+    if returncode != 0:
+        raise RuntimeError(f"gguf_conversion_failed:rc={returncode}")
     if not output_path.exists() or output_path.stat().st_size <= 0:
         raise RuntimeError("gguf_conversion_failed:missing_output")
 
 
 __all__ = [
+    "GGUF_TOOLCHAIN_STALL_WINDOW_S",
     "detect_supported_architecture",
     "normalize_gguf_encoding",
     "prepare_hf_source_tree_for_gguf",

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -30,6 +30,7 @@ import socket
 from blake3 import blake3
 from ..api.errors import AuthError
 from ..request_context._helpers import _parse_owner_repo
+from ..stall import SilenceWindow
 from gen_worker.models.refs import flavor_token as _token
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,21 @@ _COMPLETE_IN_PROGRESS_POLL_S = 5.0
 # each attempt can legitimately take a full verify. Found live twice on the
 # flux2-klein-4b clone (te#44 J9 runs 7+8: RemoteDisconnected at ~4m50s).
 _COMPLETE_NETWORK_RETRY_DELAY_S = 15.0
-_COMPLETE_NETWORK_MAX_WAIT_S = 1800.0
+
+# gw#666 (th#1166 finding D): the old `_COMPLETE_NETWORK_MAX_WAIT_S = 1800.0`
+# abandoned the publish at 30 minutes of wall time — throwing away a commit
+# whose bytes were already uploaded, because a stopwatch expired while the
+# hub was still verifying them.
+#
+# The hub tells us which case we are in. A `409 upload_complete_in_progress`
+# is a DEFINITE answer: the hub is up and something holds the completion lock
+# (which the hub sets NX with a TTL and never renews, so the 409 cannot
+# outlive a dead holder). While those keep arriving the verify is advancing
+# and there is nothing to give up on. What is NOT definite is silence — a
+# severed connection or an edge-masked 5xx tells us nothing — so only those
+# accumulate the window below. It is derived from the call cadence: two full
+# verify-length attempts' worth of hearing nothing definite.
+_COMPLETE_SILENCE_WINDOW_S = 2.0 * _COMPLETE_TIMEOUT_S
 
 _SESSION: Optional[requests.Session] = None
 
@@ -283,35 +298,44 @@ class HubClient:
         as fatal: /complete is idempotent once finalized (tensorhub's
         sess.Finalized fast path returns the same success payload), so
         re-POSTing catches up to whatever the in-flight attempt decides.
-        Network-severed attempts get the same treatment on a longer clock
-        (_COMPLETE_NETWORK_MAX_WAIT_S): each re-POST may re-run a full
-        multi-minute verify, so give it room instead of failing the commit."""
-        deadline = time.monotonic() + _COMPLETE_NETWORK_MAX_WAIT_S
+        Network-severed attempts get the same treatment, bounded by SILENCE
+        rather than a clock (gw#666): every 409 in-progress answer is proof
+        the hub is up and verifying, so the loop waits as long as the hub
+        keeps saying so, and gives up only after _COMPLETE_SILENCE_WINDOW_S
+        with no definite answer at all."""
+        contact = SilenceWindow(_COMPLETE_SILENCE_WINDOW_S)
         while True:
             try:
                 resp = self._post(complete_path, payload, timeout=_COMPLETE_TIMEOUT_S)
             except HubPublishError:
-                if time.monotonic() >= deadline:
+                if contact.stalled():
                     raise
-                logger.warning("POST %s network-severed; re-POSTing (idempotent complete)", complete_path)
+                logger.warning(
+                    "POST %s network-severed; re-POSTing (idempotent complete; "
+                    "no definite answer for %.0fs of %.0fs)",
+                    complete_path, contact.silent_for(), contact.window_s)
                 time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
                 continue
             if resp.status_code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
-                if time.monotonic() >= deadline:
-                    return resp
+                # The hub is alive AND a verify holds the lock: that is
+                # progress, not a reason to give up. Wait it out.
+                contact.touch()
                 time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
                 continue
             if resp.status_code >= 500:
                 # gw#565: an edge/tunnel in front of tensorhub (ngrok) times
                 # out DURING the synchronous verify and answers 5xx while the
                 # server is still working. A returned 5xx is the same case as
-                # a severed connection — re-POST on the patient clock; the
-                # sess.Finalized fast path answers the catch-up POST.
-                if time.monotonic() >= deadline:
+                # a severed connection — it says nothing definite, so it does
+                # NOT refresh the window; the sess.Finalized fast path answers
+                # the catch-up POST if the verify did land.
+                if contact.stalled():
                     return resp
                 logger.warning(
-                    "POST %s returned %d (edge-masked verify?); re-POSTing (idempotent complete)",
-                    complete_path, resp.status_code)
+                    "POST %s returned %d (edge-masked verify?); re-POSTing "
+                    "(idempotent complete; no definite answer for %.0fs of %.0fs)",
+                    complete_path, resp.status_code,
+                    contact.silent_for(), contact.window_s)
                 time.sleep(_COMPLETE_NETWORK_RETRY_DELAY_S)
                 continue
             return resp

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2380,6 +2380,14 @@ class Executor:
                 continue
             rec = self._classes.setdefault(s.instance_key, _ClassRecord(cls=s.cls))
             rec.specs.append(s)
+        # pgw#654 warm-tax fix: graph_keys already warm-RUN in this process,
+        # keyed by warm CONTRACT (class + per-slot lane facts + component
+        # overrides — everything that selects graphs/kernels, NEVER the
+        # checkpoint ref). A new checkpoint instance of an already-warmed
+        # contract is a cache hit: it runs one verification job, not the
+        # plan. Process-local by design — allocator pool, cuBLAS/cuDNN
+        # heuristics and dynamo's code cache die with the process.
+        self._warm_contract_runs: Dict[Any, set] = {}
         # Hardware-gate failures: fn name -> (reason, detail, axes).
         self.unavailable: Dict[str, Tuple[str, str, Dict[str, str]]] = {}
         # Runtime compile failures are owned by the exact record/target that
@@ -4467,6 +4475,26 @@ class Executor:
             has_warmup_method=False,
         )
 
+    def _warm_contract_key(self, spec: EndpointSpec) -> Any:
+        """The identity under which warm RUNS are shared across checkpoint
+        instances (pgw#654 warm-tax fix): the class plus every per-slot fact
+        that selects graphs or kernels — precision lane (flavor /
+        storage_dtype / dtype) and component overrides — and NEVER the
+        checkpoint ref itself. Two fine-tunes of one family land on the same
+        key by construction; a lane rebind or a component substitution
+        derives a different one."""
+        rows = tuple(
+            (
+                slot,
+                getattr(b, "flavor", "") or "",
+                getattr(b, "storage_dtype", "") or "",
+                getattr(b, "dtype", "") or "",
+                tuple(getattr(b, "component_overrides", ()) or ()),
+            )
+            for slot, b in sorted(spec.models.items())
+        )
+        return (spec.cls, rows)
+
     def _compile_contract_names(
         self, spec: EndpointSpec, rec: _ClassRecord,
     ) -> set[str]:
@@ -4501,6 +4529,8 @@ class Executor:
         *,
         proof_objects: typing.Iterable[Any] = (),
         cold_proof_ids: typing.Container[int] = (),
+        allow_contract_skip: bool = False,
+        armed_cell_refs: typing.Iterable[str] = (),
     ) -> _WarmupEvidence:
         """Run the declared per-handler warmup contract pre-READY.
 
@@ -4514,13 +4544,46 @@ class Executor:
         proof (there is nothing pre-existing on disk to HIT against; the
         capture this very call populates becomes the cell). Delivered cells
         keep requiring a real cache hit.
+
+        ``allow_contract_skip`` (pgw#654 warm-tax fix, setup path only):
+        permit the contract-keyed run memory to collapse this warmup to a
+        single verification job when every planned run already executed in
+        this process for the same warm contract. Inheritance is refused
+        when a self-mint capture is pending (its cell must trace every
+        graph) or when any armed cell is not yet proven in-process (a
+        1-job run must never disprove a cell the full plan would have
+        proven). The hot-adopt path never passes it: a NEW cell on a live
+        instance requires its own full proof.
         """
         from . import compile_cache, trt_engine
+        from . import warmup as warmup_mod
 
         jobs, skips = self._warmup_plan(spec, rec)
         for skip in skips:
             logger.info("boot warmup skipped for %s: %s", skip.spec.name, skip.reason)
         objects = tuple({id(obj): obj for obj in proof_objects}.values())
+        # Tracing == some artifact is armed or minting on this setup; only
+        # then does the full class x bucket cross-product buy anything (each
+        # graph must trace into the capture / prove against the cell).
+        tracing = bool(objects)
+        memory = self._warm_contract_runs.setdefault(
+            self._warm_contract_key(spec), set())
+        armed_refs = tuple(armed_cell_refs)
+        skip_ok = (
+            allow_contract_skip
+            and not cold_proof_ids
+            and all(compile_cache.cell_proven_in_process(r) for r in armed_refs)
+        )
+        run_jobs, warm_mode = warmup_mod.select_runs(
+            jobs,
+            tracing=tracing,
+            executed=(memory if skip_ok else frozenset()),
+        )
+        if warm_mode != "full":
+            logger.info(
+                "boot warm plan for %s: mode=%s runs=%d/%d planned "
+                "(contract-keyed warm memory holds %d graph keys)",
+                spec.name, warm_mode, len(run_jobs), len(jobs), len(memory))
         evidence = _WarmupEvidence()
         start_counts = {
             id(obj): (
@@ -4600,16 +4663,20 @@ class Executor:
                 wj.spec.name, mode, time.monotonic() - t0)
             return True
 
-        for wj_index, wj in enumerate(jobs, start=1):
+        for wj_index, wj in enumerate(run_jobs, start=1):
             activity_mod.current_phase(
-                activity_mod.PHASE_WARMUP_FORWARD, wj_index, len(jobs))
+                activity_mod.PHASE_WARMUP_FORWARD, wj_index, len(run_jobs))
             act = activity_mod.current()
             if act is not None:
                 act.counter("warmup:jobs", progress_mod.UNIT_STEPS,
-                            total=len(jobs)).set_done(wj_index)
-            mode = "declared" if wj.declared else "synthesized"
+                            total=len(run_jobs)).set_done(wj_index)
+            mode = (
+                "verify" if warm_mode == "verify"
+                else "declared" if wj.declared else "synthesized"
+            )
             if not await _one(wj, wj.build, mode, variant=False):
                 return evidence
+            memory.add(wj.graph_key)
 
         def _unexercised() -> list[Any]:
             return [
@@ -4624,18 +4691,16 @@ class Executor:
         # (gw#612) and an adopt arms it unproven. Synthesized media variants
         # of the same base payloads exercise those lanes with matching
         # compile-key derivation (only the media field differs).
-        if jobs and _unexercised():
-            from . import warmup as warmup_mod
-
+        if warm_mode == "full" and run_jobs and _unexercised():
             variant_jobs = [
                 (wj, label, build)
-                for wj in jobs
+                for wj in run_jobs
                 for label, build in warmup_mod.media_variants(
                     wj.spec.payload_type, wj.build)
             ]
-            total = len(jobs) + len(variant_jobs)
+            total = len(run_jobs) + len(variant_jobs)
             for v_index, (wj, label, build) in enumerate(
-                    variant_jobs, start=len(jobs) + 1):
+                    variant_jobs, start=len(run_jobs) + 1):
                 if not _unexercised():
                     break
                 activity_mod.current_phase(
@@ -4646,6 +4711,19 @@ class Executor:
                                 total=total).set_done(v_index)
                 if not await _one(wj, build, label, variant=True):
                     break
+        if warm_mode == "verify" and evidence.count:
+            # Contract inheritance (pgw#654 warm-tax fix): the verification
+            # run proving this object, together with every graph key already
+            # EXECUTED in this process for the same warm contract (the skip
+            # precondition), certifies the full plan on this object —
+            # handler code paths and graph classes are instance-invariant;
+            # only the weights changed. Without this, a 1-job verify would
+            # attribute a single alias and fail the mandatory-lane
+            # completeness gate that the full plan (whose runs would land on
+            # dynamo's in-memory code anyway) passes.
+            all_keys = {wj.graph_key for wj in jobs}
+            for obj_id in list(proven_keys):
+                proven_keys[obj_id] |= all_keys
         # Coverage attribution (pgw#654): name -> its full graph-class set,
         # from the plan; an alias attributes to an object only when EVERY
         # one of its classes proved there — a partially-traced alias is
@@ -5020,6 +5098,14 @@ class Executor:
                         if id(candidate.pipeline) in inj.active_compile_artifacts
                     ),
                     cold_proof_ids=frozenset(inj.pending_self_mints),
+                    # pgw#654 warm-tax fix: a checkpoint instance of an
+                    # already-warmed contract collapses to one verification
+                    # job (setup path only; hot-adopt keeps full proof).
+                    allow_contract_skip=True,
+                    armed_cell_refs=tuple(
+                        sel.ref
+                        for sel in inj.active_compile_artifacts.values()
+                    ),
                 )
                 return evidence.count, evidence.functions_by_object
 

--- a/src/gen_worker/models/cozy_cas.py
+++ b/src/gen_worker/models/cozy_cas.py
@@ -6,7 +6,6 @@ import logging
 import os
 import random
 import threading
-import time
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, Optional
@@ -15,17 +14,30 @@ import requests
 from blake3 import blake3
 
 from ..capability import InsufficientDiskError
+from ..stall import ProgressFloor
 from .errors import UrlExpiredError
 
 _log = logging.getLogger(__name__)
 
 _DOWNLOAD_CHUNK_BYTES = 4 * 1024 * 1024
 
-# Retry policy: transient network errors get a long budget; verification
-# failures (size/blake3 mismatch) mean the source blob is likely corrupt —
-# 2 re-downloads, then give up. UrlExpiredError / ENOSPC never retry.
+# Retry policy. Verification failures (size/blake3 mismatch) mean the source
+# blob is likely corrupt — 2 re-downloads, then give up. UrlExpiredError /
+# ENOSPC never retry.
+#
+# gw#666 (th#1166 finding C): the transient half used to give up after
+# `_MAX_RETRY_TIME_S = 3600.0` of WALL time, however many bytes had landed —
+# a clock cannot tell a 200GB blob crawling in over a bad pod uplink from a
+# wedge, and resume-on-retry means the slow case was genuinely converging.
+# The give-up is now a PROGRESS question: `_TRANSIENT_MAX_TRIES` counts
+# CONSECUTIVE transient failures that failed to move the byte floor, and any
+# attempt that delivers `_RETRY_PROGRESS_FLOOR_BYTES` resets the count. A
+# link that keeps landing bytes is never "30 strikes and out"; a link that
+# delivers nothing gives up in 30 attempts as before. The floor matches
+# models/download.py's gw#655 progress-rate floor, and the per-attempt
+# network timeouts (60s connect / 180s read) still bound each try.
 _TRANSIENT_MAX_TRIES = 30
-_MAX_RETRY_TIME_S = 3600.0
+_RETRY_PROGRESS_FLOOR_BYTES = 8 * 1024 * 1024
 _VERIFY_MAX_FAILURES = 3  # initial try + 2 retries
 _RETRY_BACKOFF_CAP_S = 30.0
 
@@ -56,9 +68,19 @@ async def _download_one_file(
     on_bytes: Optional[Callable[[int], None]] = None,
 ) -> None:
     loop = asyncio.get_running_loop()
-    started = time.monotonic()
     transient_failures = 0
     verify_failures = 0
+    # Bytes this call has actually pulled down, across attempts — the only
+    # honest evidence that the transfer is still alive.
+    delivered = 0
+    floor = ProgressFloor(_RETRY_PROGRESS_FLOOR_BYTES)
+
+    def _count_bytes(n: int) -> None:
+        nonlocal delivered
+        delivered += n
+        if on_bytes is not None:
+            on_bytes(n)
+
     # Writer-unique for the lifetime of this call (stable across its own
     # retries, so HTTP Range resume-on-retry still works) but distinct from
     # every OTHER writer of this digest — including a different PROCESS.
@@ -72,7 +94,7 @@ async def _download_one_file(
                 None,
                 lambda: _download_one_file_sync(
                     url, dst, expected_size, expected_blake3,
-                    on_bytes=on_bytes, writer_id=writer_id,
+                    on_bytes=_count_bytes, writer_id=writer_id,
                 ),
             )
             return
@@ -87,9 +109,14 @@ async def _download_one_file(
                 verify_failures += 1
                 failures, cap = verify_failures, _VERIFY_MAX_FAILURES
             else:
+                # Bytes that landed since the last give-up check are real
+                # progress; a flaky link that keeps delivering starts its
+                # strike count over rather than accumulating toward a cap.
+                if floor.cleared(delivered):
+                    transient_failures = 0
                 transient_failures += 1
                 failures, cap = transient_failures, _TRANSIENT_MAX_TRIES
-            if failures >= cap or time.monotonic() - started >= _MAX_RETRY_TIME_S:
+            if failures >= cap:
                 raise
             delay = random.uniform(0.5, 1.0) * min(_RETRY_BACKOFF_CAP_S, 2.0 ** failures)
             _log.warning("download of %s failed (%s, failure %d/%d): %s; retrying in %.1fs",

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -29,6 +30,7 @@ from urllib.parse import parse_qs, urlparse
 
 from ..api.errors import ValidationError
 from ..config import get_settings
+from ..stall import ProgressFloor, SilenceWindow
 from .cache_paths import tensorhub_cas_dir
 from .refs import HuggingFaceRef, TensorhubRef, fold_ref, parse_model_ref
 import hashlib
@@ -506,18 +508,16 @@ def _run_with_stall_watchdog(
     dl_thread = threading.Thread(target=_run, name="model-download", daemon=True)
     dl_thread.start()
 
-    started_at = time.monotonic()
     last_bytes = 0
-    # Progress window: bytes on disk when the current window opened, and when
-    # it opened. The window closes (and reopens from here) the moment the
-    # floor is cleared; it never resets on a byte, so a trickle expires it.
-    window_bytes = 0
-    window_opened_at = started_at
+    # The progress window as two shared values (gw#666): the floor decides
+    # what counts as an advance (a trickle never does), the window decides how
+    # long an unadvanced loop may run. Same pair now guards the CAS fetch.
+    floor = ProgressFloor(max(int(min_window_bytes), 1))
+    window = SilenceWindow(stall_timeout if stall_timeout > 0 else math.inf)
     while not holder.get("done"):
         dl_thread.join(timeout=poll_interval)
         if holder.get("done"):
             break
-        now = time.monotonic()
         if progress_root is not None:
             try:
                 seen = scan_bytes(progress_root)
@@ -530,15 +530,14 @@ def _run_with_stall_watchdog(
                         progress_callback(seen, total_hint)
                     except Exception:
                         pass
-            if seen - window_bytes >= max(int(min_window_bytes), 1):
-                window_bytes = seen
-                window_opened_at = now
-            elif stall_timeout > 0 and (now - window_opened_at) > stall_timeout:
-                moved = seen - window_bytes
+            if floor.cleared(seen):
+                window.touch()
+            elif window.stalled():
+                moved, silent_for = floor.moved(seen), window.silent_for()
                 logger.error(
                     "download STALLED %s: %d bytes in the last %.0fs (floor %d bytes; "
                     "downloaded=%d total); abandoning the wedged thread (#379, pgw#655)",
-                    label, moved, now - window_opened_at, int(min_window_bytes), last_bytes,
+                    label, moved, silent_for, int(min_window_bytes), last_bytes,
                 )
                 raise DownloadStalledError(
                     f"download({label}) stalled: only {moved} bytes in "

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -866,6 +866,25 @@ def model_index_entry(path: str | Path, component: str) -> Optional[tuple]:
     return None
 
 
+def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
+    """The compute dtype the COMPOSED pipeline will run at (pgw#647 gap #2):
+    the base binding's declared dtype when present, else the base tree's
+    on-disk dtype with fp8/quantized storage mapping to its bf16 compute
+    default (mirrors :func:`load_diffusers_pipeline`'s own selection).
+    ``""`` = unknown (an fp32-defaulting composition)."""
+    if dtype:
+        return dtype
+    sniffed = detect_on_disk_dtype(Path(base_path))
+    if sniffed == "fp8":
+        # fp8-stored flavors (w8a16/w8a8 alike) compute in bf16; per-layer
+        # storage precision is restored separately (apply_fp8_storage /
+        # the scaled-mm lane).
+        return "bf16"
+    if sniffed in ("bf16", "fp16"):
+        return sniffed
+    return ""
+
+
 def load_component_override(
     base_path: str | Path, component: str, override_path: str | Path,
     *, dtype: str = "",
@@ -873,9 +892,16 @@ def load_component_override(
     """Load one named pipeline component from an OVERRIDE snapshot tree
     (pgw#617 hierarchical bindings). The module class comes from the BASE
     tree's model_index.json; weights come from the override tree's
-    ``<component>/`` subtree when present, else its root. ``dtype`` (the
-    base binding's) wins; otherwise the override's on-disk dtype is
-    honored. Blocking; callers on an event loop run it off-thread."""
+    ``<component>/`` subtree when present, else its root.
+
+    dtype resolution (pgw#647 gap #2): the base binding's declared dtype
+    wins; otherwise the override inherits the BASE COMPOSITION's compute
+    dtype (:func:`composition_compute_dtype`); the override's own on-disk
+    dtype is only the last resort. Hub-resolved bindings carry no dtype, so
+    the old override-on-disk fallback loaded e.g. the fp32-stored fp16-fix
+    VAE into a bf16 pipeline and setup died on the first latent
+    (ie#546 canary, 2/2 pods). Blocking; callers on an event loop run it
+    off-thread."""
 
     entry = model_index_entry(base_path, component)
     if entry is None:
@@ -895,7 +921,10 @@ def load_component_override(
     if not src.is_dir():
         src = Path(override_path)
     kwargs: Dict[str, Any] = {}
-    wanted = dtype or detect_on_disk_dtype(src)
+    wanted = (
+        composition_compute_dtype(base_path, dtype)
+        or detect_on_disk_dtype(src)
+    )
     if wanted in ("bf16", "fp16", "bfloat16", "float16", "fp32", "float32"):
         try:
             kwargs["torch_dtype"] = get_torch_dtype(wanted)

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -66,6 +66,7 @@ from ._upload_transport import (
 from . import activity as _activity
 from . import progress as _progress
 from .api.errors import ArtifactTransferError, AuthError, CanceledError
+from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,20 @@ _FINALIZE_RETRY_BACKOFF_S = 0.5
 # the in-flight attempt finishes, /complete's `sess.Finalized` fast path
 # returns the same 200 success payload to the next poll, no data lost.
 _COMPLETE_IN_PROGRESS_POLL_S = 5.0
-_COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600.0
+
+# gw#666 (th#1166 finding E): the old `_COMPLETE_IN_PROGRESS_MAX_WAIT_S = 600`
+# FAILED THE JOB after 10 minutes of wall time — the worker had already
+# uploaded every byte and then discarded the result because the hub was still
+# stitching a large multipart object. A clock cannot distinguish "assembly is
+# taking a while" from "nothing is happening"; the hub's own answer can.
+#
+# Each `409 upload_complete_in_progress` is a DEFINITE answer: the hub is up
+# and holds the completion lock. The hub sets that lock NX with a TTL and
+# never renews it, so a dead holder's lock expires and the next poll takes
+# over the verify — a 409 therefore cannot persist without live work behind
+# it. Only silence (no HTTP answer at all) accumulates the window, which is
+# derived from the call cadence: two full finalize-length attempts.
+_COMPLETE_SILENCE_WINDOW_S = 2.0 * _FINALIZE_TIMEOUT_S
 
 # Default part size sent by server, but we read it from the response.
 _FALLBACK_PART_SIZE = 64 * 1024 * 1024  # 64 MiB
@@ -432,37 +446,42 @@ def _poll_until_finalized(
     synchronously and can outlast whatever timeout sits in front of it, so the
     CLIENT'S view (5xx/timeout) can lag the server's. /complete is idempotent
     once finalized (`sess.Finalized` fast path returns the same success
-    payload), so re-POST it instead of treating the race as fatal."""
-    deadline = time.monotonic() + _COMPLETE_IN_PROGRESS_MAX_WAIT_S
+    payload), so re-POST it instead of treating the race as fatal.
+
+    The wait is bounded by SILENCE, never by a clock (gw#666): a hub that
+    keeps answering 409 is a hub actively assembling the object we just
+    uploaded, and failing the job at that moment throws the whole upload
+    away for nothing."""
+    contact = SilenceWindow(_COMPLETE_SILENCE_WINDOW_S)
     while True:
         if cancel_check and cancel_check():
             raise CanceledError("canceled")
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if contact.stalled():
             raise ArtifactTransferError(
-                "tensorhub upload finalize: gave up waiting for a concurrent "
-                "completion to finish (upload_complete_in_progress persisted "
-                f"past {_COMPLETE_IN_PROGRESS_MAX_WAIT_S:.0f}s)",
+                "tensorhub upload finalize: the hub stopped answering while a "
+                "completion was in progress (no response for "
+                f"{contact.silent_for():.0f}s, window {contact.window_s:.0f}s)",
                 provider="tensorhub",
                 phase="complete",
                 retryable=True,
                 status_code=409,
             )
-        time.sleep(min(_COMPLETE_IN_PROGRESS_POLL_S, remaining))
+        time.sleep(_COMPLETE_IN_PROGRESS_POLL_S)
         try:
             resp = session.post(
                 complete_url, headers=complete_headers, data=json.dumps(payload),
                 timeout=_FINALIZE_TIMEOUT_S,
             )
         except requests.RequestException:
-            continue  # transient — keep polling within the deadline
+            continue  # no answer: the silence window is the only give-up
         code = resp.status_code
         if code in (401, 403):
             raise AuthError(f"file save unauthorized ({code})")
         if 200 <= code < 300:
             return _parse_json_response(resp, phase="complete")
         if code == 409 and _error_code_of(resp) == "upload_complete_in_progress":
-            continue  # still racing the first attempt
+            contact.touch()  # definite answer: assembly is live, keep waiting
+            continue
         # Any other terminal error: stop polling, surface it normally.
         raise ArtifactTransferError(
             f"tensorhub upload finalize failed: {_response_body_sample(resp)}",

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -403,6 +403,13 @@ class RequestContext(Generic[D]):
             "reason": str(reason or ""),
         })
 
+    @property
+    def adjustments(self) -> Tuple[Dict[str, str], ...]:
+        """Immutable view of the adjustment ledger (:meth:`adjusted` /
+        :meth:`clamp` rows, in emission order). The PUBLIC read side —
+        endpoint tests assert against this, never ``_adjustments``."""
+        return tuple(dict(row) for row in self._adjustments)
+
     def clamp(
         self,
         field: str,
@@ -1534,7 +1541,9 @@ class _PublisherMixin:
             self._dataset_paths = d
         return d
 
-    def resolve_dataset(self, ref: str, *, budget_s: Optional[float] = None) -> str:
+    def resolve_dataset(
+        self, ref: str, *, hub_silence_window_s: Optional[float] = None,
+    ) -> str:
         """Materialize a dataset by bare dataset-id or ``owner/name`` ref;
         return the local root.
 
@@ -1549,15 +1558,17 @@ class _PublisherMixin:
         2. ``GET /api/v1/datasets/:id/materialize?format=files&include_urls=true``
            → a rows.jsonl-style entry index (raw CAS blobs by digest) with
            presigned URLs, sizes and blake3 checksums. A 202 (async snapshot
-           build, th#691) is polled until ready within ``budget_s`` (default
-           30 min, ≥ the hub's 20-min build budget); a typed
-           ``snapshot_build_failed`` raises ``SnapshotBuildFailedError``.
+           build, th#691) is polled for as long as the hub keeps answering —
+           there is no wall-clock budget (gw#666); a typed
+           ``snapshot_build_failed`` raises ``SnapshotBuildFailedError``, and
+           ``hub_silence_window_s`` bounds only how long a hub that answers
+           NOTHING is tolerated.
         3. Stream each entry to disk (bounded memory), digest-verified, with
            bounded retries. Entries lacking a presigned URL fall back to the
            repo-CAS by-digest reader.
 
         Raises ``RuntimeError`` when the dataset isn't found, the manifest is
-        empty, the poll budget runs out, or any download exhausts its retries.
+        empty, the hub goes silent, or any download exhausts its retries.
         """
         from ._datasets import (
             download_entries,
@@ -1583,8 +1594,8 @@ class _PublisherMixin:
                 raise RuntimeError("resolve_dataset: empty ref")
             cache_key = ("by-id", dataset_id)
         fetch_kwargs: Dict[str, Any] = {"cancelled": lambda: self.cancelled}
-        if budget_s is not None:
-            fetch_kwargs["budget_s"] = budget_s
+        if hub_silence_window_s is not None:
+            fetch_kwargs["hub_silence_window_s"] = hub_silence_window_s
         snapshot_id, entries = fetch_materialize_manifest(
             base, token, dataset_id, **fetch_kwargs,
         )

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..api.errors import AuthError, SnapshotBuildFailedError
+from ..stall import SilenceWindow
 import requests
 import blake3
 
@@ -25,9 +26,19 @@ _DOWNLOAD_RETRIES = 3
 _DOWNLOAD_BACKOFF_S = 1.0
 _CHUNK_BYTES = 1024 * 1024
 
-# DATASET-V2 202 contract (th#691): the hub's snapshot build budget is 20 min;
-# the worker waits it out with headroom (training pods can afford minutes).
-_MATERIALIZE_BUDGET_S = 30.0 * 60.0
+# DATASET-V2 202 contract (th#691).
+#
+# gw#666 (th#1166 finding F): the old `_MATERIALIZE_BUDGET_S = 30 min` gave up
+# on a materialization purely because a stopwatch expired. What the hub
+# actually reports is a DEFINITE state per poll — `202 building`, `503
+# snapshot_build_failed` (typed, terminal), or the manifest — and every poll
+# also re-enqueues the (unique) build job, so a lost build self-heals rather
+# than hanging. A 202 is therefore evidence the build is live and the loop
+# waits; only silence — no answer at all, or a 5xx that says nothing —
+# accumulates the window below, derived from the poll's own request timeout
+# times headroom.
+_MATERIALIZE_REQUEST_TIMEOUT_S = 120.0
+_MATERIALIZE_SILENCE_WINDOW_S = 3.0 * _MATERIALIZE_REQUEST_TIMEOUT_S
 _MATERIALIZE_WAIT_HINT_S = 30  # ?wait long-poll hint (server caps ~30s)
 _POLL_BACKOFF_START_S = 1.0
 _POLL_BACKOFF_CAP_S = 30.0
@@ -115,7 +126,7 @@ def fetch_materialize_manifest(
     token: str,
     dataset_id: str,
     *,
-    budget_s: float = _MATERIALIZE_BUDGET_S,
+    hub_silence_window_s: float = _MATERIALIZE_SILENCE_WINDOW_S,
     cancelled: Optional[Callable[[], bool]] = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """GET /datasets/:id/materialize?format=files&include_urls=true.
@@ -127,10 +138,15 @@ def fetch_materialize_manifest(
     DATASET-V2 async contract (th#691 / gw#457): the hub may answer
     202 ``{status: building, state_version, retry_after}`` while the snapshot
     builds in the background. We long-poll (``?wait=``, ignored by pre-v2
-    hubs) and retry with backoff — honoring ``retry_after`` — until ready or
-    ``budget_s`` runs out. A typed ``snapshot_build_failed`` raises
-    ``SnapshotBuildFailedError``; transient transport/5xx errors retry within
-    the same budget (hub restart mid-build).
+    hubs) and retry with backoff, honoring ``retry_after``.
+
+    There is NO total budget (gw#666). A 202 is the hub definitively saying
+    the build is live, and each poll re-enqueues the unique build job, so the
+    loop waits as long as the hub keeps answering. A typed
+    ``snapshot_build_failed`` raises ``SnapshotBuildFailedError`` — that is
+    the terminal outcome. Only silence gives up: transport errors and 5xx
+    say nothing definite, and ``hub_silence_window_s`` bounds how long the
+    loop tolerates hearing nothing at all.
     """
 
     url = (
@@ -139,27 +155,32 @@ def fetch_materialize_manifest(
         f"&wait={_MATERIALIZE_WAIT_HINT_S}"
     )
     headers = {"Authorization": f"Bearer {token}"}
-    deadline = time.monotonic() + max(0.0, budget_s)
+    contact = SilenceWindow(hub_silence_window_s)
     backoff = _POLL_BACKOFF_START_S
 
-    def _wait_or_budget_exhausted(sleep_s: float, why: str) -> None:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
+    def _wait_or_hub_silent(sleep_s: float, why: str) -> None:
+        """Sleep before the next poll, unless the hub has told us nothing
+        definite for the whole silence window — the only give-up."""
+        if contact.stalled():
             raise RuntimeError(
-                f"dataset materialize budget exhausted after {budget_s:.0f}s "
-                f"for dataset_id={dataset_id} (last state: {why})"
+                f"dataset materialize: the hub said nothing definite for "
+                f"{contact.silent_for():.0f}s (window "
+                f"{contact.window_s:.0f}s) for dataset_id={dataset_id} "
+                f"(last state: {why})"
             )
-        _sleep_cancellable(min(sleep_s, _POLL_SLEEP_MAX_S, remaining), cancelled)
+        _sleep_cancellable(min(sleep_s, _POLL_SLEEP_MAX_S), cancelled)
 
     while True:
         _check_cancelled(cancelled)
         try:
-            resp = requests.get(url, headers=headers, timeout=120)
+            resp = requests.get(
+                url, headers=headers, timeout=_MATERIALIZE_REQUEST_TIMEOUT_S,
+            )
         except requests.RequestException as exc:
             logger.warning(
                 "dataset %s materialize request failed (%s); retrying", dataset_id, exc,
             )
-            _wait_or_budget_exhausted(backoff, f"transport error: {exc}")
+            _wait_or_hub_silent(backoff, f"transport error: {exc}")
             backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
             continue
 
@@ -167,6 +188,8 @@ def fetch_materialize_manifest(
             raise AuthError(f"dataset materialize unauthorized ({resp.status_code})")
 
         if resp.status_code == 202:
+            # A definite answer: the build is live hub-side.
+            contact.touch()
             try:
                 data = resp.json() if resp.text else {}
             except ValueError:
@@ -179,7 +202,7 @@ def fetch_materialize_manifest(
                 "dataset %s snapshot building (state_version=%s); polling again in %.1fs",
                 dataset_id, data.get("state_version"), min(sleep_s, _POLL_SLEEP_MAX_S),
             )
-            _wait_or_budget_exhausted(sleep_s, "202 building")
+            _wait_or_hub_silent(sleep_s, "202 building")
             backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
             continue
 
@@ -191,7 +214,7 @@ def fetch_materialize_manifest(
                 logger.warning(
                     "dataset %s materialize got %d; retrying", dataset_id, resp.status_code,
                 )
-                _wait_or_budget_exhausted(backoff, f"http {resp.status_code}")
+                _wait_or_hub_silent(backoff, f"http {resp.status_code}")
                 backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
                 continue
             raise RuntimeError(

--- a/src/gen_worker/runtimes/server.py
+++ b/src/gen_worker/runtimes/server.py
@@ -20,11 +20,25 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, Sequence
+from ..subproc import LineTail
 from .llama import plan_for, resolve_gguf
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_BOOT_TIMEOUT_S = 600.0
+# gw#666 (th#1166 finding B): a boot is bounded by SILENCE, never by a clock.
+# The old `_DEFAULT_BOOT_TIMEOUT_S = 600.0` killed the child on a flat deadline
+# whose only liveness check was `proc.poll()` — "has not exited yet", which
+# says nothing about progress — while the engine was printing weight-load
+# progress to a stdout nobody read. A 70B vLLM cold load routinely outlives
+# 600s, and endpoints had already started papering over it with
+# `boot_timeout_s=1800`, which is the same mistake with a bigger number.
+#
+# The window below is a SILENCE window over the engine's own output, not a
+# boot budget: an engine that keeps talking boots for as long as it needs, and
+# one that says nothing for 15 minutes is wedged. 900s is orders of magnitude
+# past any real silent phase (CUDA graph capture, torch.compile) and matches
+# the window gw#665 gave the llama.cpp toolchain.
+_BOOT_STALL_WINDOW_S = 900.0
 _TERM_GRACE_S = 10.0
 
 
@@ -62,7 +76,12 @@ class ServerHandle:
 
 
 class ServerBootError(RuntimeError):
-    """The engine server exited or failed health checks during boot."""
+    """The engine server exited, or went silent, during boot.
+
+    ``DegradingBoot`` degrades on this — so it must only be raised on real
+    evidence (the process died, or it produced no output for its stall
+    window), never because a stopwatch expired.
+    """
 
 
 class ServerProcess:
@@ -84,13 +103,13 @@ class ServerProcess:
         *,
         health_url: str,
         base_url: str = "",
-        boot_timeout_s: float = _DEFAULT_BOOT_TIMEOUT_S,
+        stall_window_s: float = _BOOT_STALL_WINDOW_S,
         env: Optional[dict[str, str]] = None,
     ) -> None:
         self.command = [str(c) for c in command]
         self.health_url = health_url
         self.base_url = base_url or health_url.rsplit("/", 1)[0]
-        self.boot_timeout_s = float(boot_timeout_s)
+        self.stall_window_s = float(stall_window_s)
         self.env = env
 
     def start(self) -> ServerHandle:
@@ -98,18 +117,42 @@ class ServerProcess:
         env = dict(os.environ)
         if self.env:
             env.update(self.env)
-        proc = subprocess.Popen(self.command, env=env, start_new_session=True)
+        # Capture the engine's merged output instead of inheriting stdio: it
+        # is both the boot-progress signal AND the log line an operator needs
+        # when a boot goes wrong. The tail thread keeps draining for the whole
+        # life of the server — a child whose pipe fills blocks mid-serving.
+        proc = subprocess.Popen(
+            self.command,
+            env=env,
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        tail = LineTail(
+            proc,
+            window_s=self.stall_window_s,
+            on_line=self._log_line,
+            name="engine-server-tail",
+        ).start()
         handle = ServerHandle(base_url=self.base_url, process=proc)
         try:
-            self._wait_healthy(proc)
+            self._wait_healthy(proc, tail)
         except BaseException:
             handle.stop()
             raise
         logger.info("engine server healthy at %s", self.base_url)
         return handle
 
-    def _wait_healthy(self, proc: subprocess.Popen) -> None:
-        deadline = time.monotonic() + self.boot_timeout_s
+    def _log_line(self, line: str) -> None:
+        logger.info("[engine] %s", line)
+
+    def _wait_healthy(self, proc: subprocess.Popen, tail: LineTail) -> None:
+        """Boot is over when the health URL answers. It has FAILED only when
+        the process died or stopped emitting output for its stall window —
+        every log line the engine prints is proof it is still loading, so a
+        slow cold load is never a failure (gw#666)."""
         delay = 0.25
         while True:
             code = proc.poll()
@@ -124,10 +167,12 @@ class ServerProcess:
                         return
             except (urllib.error.URLError, OSError, TimeoutError):
                 pass
-            if time.monotonic() >= deadline:
+            if tail.stalled():
                 raise ServerBootError(
-                    f"engine server failed health check within "
-                    f"{self.boot_timeout_s:.0f}s at {self.health_url}"
+                    f"engine server produced no output for "
+                    f"{tail.silent_for():.0f}s (stall window "
+                    f"{tail.window_s:.0f}s) and never became healthy at "
+                    f"{self.health_url}: {shlex.join(self.command)}"
                 )
             time.sleep(delay)
             delay = min(delay * 1.5, 2.0)
@@ -138,16 +183,19 @@ def vllm_server(
     *,
     port: Optional[int] = None,
     extra_args: Sequence[str] = (),
-    boot_timeout_s: float = _DEFAULT_BOOT_TIMEOUT_S,
 ) -> ServerProcess:
-    """``vllm serve <model_path>`` with an OpenAI-compatible API + /health."""
+    """``vllm serve <model_path>`` with an OpenAI-compatible API + /health.
+
+    There is no boot-duration knob: how long a cold load legitimately takes
+    is not something an endpoint can know in advance, and the boot is bounded
+    by engine silence instead (gw#666).
+    """
     p = port or free_port()
     return ServerProcess(
         ["vllm", "serve", model_path, "--host", "127.0.0.1", "--port", str(p),
          *extra_args],
         health_url=f"http://127.0.0.1:{p}/health",
         base_url=f"http://127.0.0.1:{p}",
-        boot_timeout_s=boot_timeout_s,
     )
 
 
@@ -184,7 +232,6 @@ def llama_server(
     *,
     port: Optional[int] = None,
     extra_args: Sequence[str] = (),
-    boot_timeout_s: float = _DEFAULT_BOOT_TIMEOUT_S,
     vram_budget_gb: Optional[float] = None,
     n_ctx: Optional[int] = None,
 ) -> "ServerProcess | DegradingBoot":
@@ -207,7 +254,6 @@ def llama_server(
              "--port", str(p), *fit_args, *args],
             health_url=f"http://127.0.0.1:{p}/health",
             base_url=f"http://127.0.0.1:{p}",
-            boot_timeout_s=boot_timeout_s,
         )
 
     if any(a in _NGL_FLAGS for a in args):

--- a/src/gen_worker/stall.py
+++ b/src/gen_worker/stall.py
@@ -1,0 +1,106 @@
+"""Progress-based give-up for retry and poll loops (gw#666).
+
+Paul's standing rule, and the whole point of the th#1166 audit: nothing that
+can END REAL WORK may key on a wall clock. A fixed budget cannot tell a
+healthy three-hour transfer from a wedge, so it is either useless or it
+kills work that was about to succeed. The honest question is always "has
+anything advanced lately?".
+
+Two tiny values answer it, and every long loop in the SDK is built from
+them:
+
+:class:`SilenceWindow`
+    Time since the last ADVANCE, where the caller decides what an advance
+    is — a peer that answered, a state token that changed, a floor that was
+    cleared. ``stalled()`` is the give-up test. There is deliberately no
+    total-runtime bound: a loop that keeps advancing runs as long as the
+    work does.
+
+:class:`ProgressFloor`
+    A monotonic total that must GROW BY A FLOOR to count as an advance
+    (gw#655's rule: a trickle is a stall). Without it, a byte a minute
+    keeps an any-progress watchdog alive forever.
+
+Both take their clock by injection so tests drive them deterministically
+rather than by sleeping.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+__all__ = ["ProgressFloor", "SilenceWindow"]
+
+_UNSET: Any = object()
+
+
+class SilenceWindow:
+    """How long since anything advanced — the only legitimate give-up test.
+
+    ``window_s`` is a SILENCE window, never a work budget: it bounds how
+    long the loop tolerates hearing nothing, not how long the work may take.
+    Derive it from the loop's own cadence (a per-call network timeout, a
+    protocol's reporting interval) times headroom, so it is a statement
+    about the channel rather than a guess about the job.
+    """
+
+    __slots__ = ("window_s", "_now", "_last", "_marker")
+
+    def __init__(
+        self, window_s: float, *, now: Callable[[], float] = time.monotonic
+    ) -> None:
+        if window_s <= 0:
+            raise ValueError("window_s must be positive")
+        self.window_s = float(window_s)
+        self._now = now
+        self._last = now()
+        self._marker: Any = _UNSET
+
+    def touch(self) -> None:
+        """Record an advance."""
+        self._last = self._now()
+
+    def touch_if_changed(self, marker: Any) -> bool:
+        """Advance only when a peer-reported ``marker`` differs from the last
+        one observed. Returns whether this counted as an advance (the first
+        observation always does)."""
+        if self._marker is not _UNSET and marker == self._marker:
+            return False
+        self._marker = marker
+        self.touch()
+        return True
+
+    def silent_for(self) -> float:
+        """Seconds since the last advance."""
+        return max(0.0, self._now() - self._last)
+
+    def stalled(self) -> bool:
+        return self.silent_for() >= self.window_s
+
+
+class ProgressFloor:
+    """A monotonic total that must move by ``floor`` to count as progress.
+
+    ``cleared(total)`` rebases and returns True only once ``total`` has grown
+    by at least ``floor`` since the last clearance — so a transfer that
+    trickles can never masquerade as a healthy one (gw#655).
+    """
+
+    __slots__ = ("floor", "_base")
+
+    def __init__(self, floor: int, *, base: int = 0) -> None:
+        if floor <= 0:
+            raise ValueError("floor must be positive")
+        self.floor = int(floor)
+        self._base = int(base)
+
+    def moved(self, total: int) -> int:
+        """How far ``total`` has come since the window opened."""
+        return int(total) - self._base
+
+    def cleared(self, total: int) -> bool:
+        if self.moved(total) < self.floor:
+            return False
+        self._base = int(total)
+        return True

--- a/src/gen_worker/subproc.py
+++ b/src/gen_worker/subproc.py
@@ -27,6 +27,23 @@ _DEFAULT_TERM_GRACE_S = 10.0
 _POLL_INTERVAL_S = 0.2
 
 
+class ProcessStalledError(RuntimeError):
+    """The child produced no output for its stall window — presumed wedged.
+
+    Raised only by ``run_process(stall_window_s=...)``. It is the
+    progress-based replacement for a wall-clock ``timeout=``: a long job that
+    keeps talking is never killed, a silent one is killed quickly.
+    """
+
+    def __init__(self, cmd: Sequence[str], silent_for_s: float, window_s: float) -> None:
+        super().__init__(
+            f"subprocess produced no output for {silent_for_s:.0f}s "
+            f"(stall window {window_s:.0f}s): {' '.join(cmd)}"
+        )
+        self.silent_for_s = silent_for_s
+        self.window_s = window_s
+
+
 def run_process(
     cmd: Sequence[str],
     *,
@@ -35,6 +52,7 @@ def run_process(
     cwd: "str | os.PathLike[str] | None" = None,
     env: Optional[Mapping[str, str]] = None,
     term_grace_s: float = _DEFAULT_TERM_GRACE_S,
+    stall_window_s: Optional[float] = None,
 ) -> int:
     """Run ``cmd``, streaming merged stdout+stderr lines to ``on_line``.
 
@@ -44,6 +62,12 @@ def run_process(
     - ``on_line``: called from a reader thread with each output line
       (trailing newline stripped). Exceptions in the callback are logged
       and swallowed — a bad parse must not kill the trainer.
+    - ``stall_window_s``: optional PROGRESS watchdog. Every output line is an
+      advance; the group is terminated and ``ProcessStalledError`` raised only
+      once the child has been silent this long. ``None`` (default) = no
+      watchdog. There is deliberately no total-runtime bound: a wall clock
+      cannot tell a healthy 3-hour quantize from a wedge, so it is either
+      useless or it kills real work (gw#655's residency-design principle).
     - Returns the process exit code on natural exit (callers decide whether
       nonzero is fatal).
     """
@@ -69,9 +93,15 @@ def run_process(
             start_new_session=True,  # own process group → group-wide signals
         )
 
+        # Last-advance stamp for the stall watchdog. Written by the reader
+        # thread on every line, read by the supervisor loop; a float store is
+        # atomic under the GIL, so no lock is needed.
+        last_advance = [time.monotonic()]
+
         def _tail() -> None:
             assert proc.stdout is not None
             for raw in proc.stdout:
+                last_advance[0] = time.monotonic()
                 line = raw.rstrip("\n")
                 if on_line is None:
                     continue
@@ -94,6 +124,12 @@ def run_process(
                     _terminate_group(proc, term_grace_s=term_grace_s)
                     reader.join(timeout=5.0)
                     raise CanceledError("subprocess cancelled")
+                if stall_window_s is not None and stall_window_s > 0:
+                    silent_for = time.monotonic() - last_advance[0]
+                    if silent_for >= stall_window_s:
+                        _terminate_group(proc, term_grace_s=term_grace_s)
+                        reader.join(timeout=5.0)
+                        raise ProcessStalledError(cmd, silent_for, stall_window_s)
                 time.sleep(_POLL_INTERVAL_S)
         finally:
             if proc.poll() is None:  # unexpected exit path (exception in caller)

--- a/src/gen_worker/subproc.py
+++ b/src/gen_worker/subproc.py
@@ -9,6 +9,7 @@ line parsing — e.g. mapping trainer output to ``ctx.progress(...)``.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import signal
 import subprocess
@@ -20,11 +21,72 @@ from typing import Any, Callable, Mapping, Optional, Sequence
 
 from .api.errors import CanceledError
 from .runtime_config import SNAPSHOT_PATH_ENV
+from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TERM_GRACE_S = 10.0
 _POLL_INTERVAL_S = 0.2
+
+
+class LineTail:
+    """Reader thread over a child's merged stdout+stderr.
+
+    Streams every line to ``on_line`` and stamps a :class:`SilenceWindow`, so
+    "the child has said nothing for N seconds" is answerable at any moment.
+    Draining is not optional: a child whose pipe fills BLOCKS, so whoever
+    captures output must keep reading for the process's whole life.
+
+    ``run_process`` uses it to bound a run-to-completion tool (gw#665);
+    ``runtimes.server`` uses it to bound an engine BOOT while keeping the
+    child alive afterwards (gw#666).
+    """
+
+    __slots__ = ("_proc", "_on_line", "_window", "_thread")
+
+    def __init__(
+        self,
+        proc: "subprocess.Popen[str]",
+        *,
+        window_s: float,
+        on_line: Optional[Callable[[str], None]] = None,
+        name: str = "subproc-tail",
+    ) -> None:
+        self._proc = proc
+        self._on_line = on_line
+        self._window = SilenceWindow(window_s)
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+
+    def start(self) -> "LineTail":
+        self._thread.start()
+        return self
+
+    def _run(self) -> None:
+        stdout = self._proc.stdout
+        assert stdout is not None
+        for raw in stdout:
+            self._window.touch()
+            line = raw.rstrip("\n")
+            if self._on_line is None:
+                continue
+            try:
+                self._on_line(line)
+            except Exception:
+                logger.exception("subprocess output callback failed")
+        stdout.close()
+
+    def silent_for(self) -> float:
+        return self._window.silent_for()
+
+    def stalled(self) -> bool:
+        return self._window.stalled()
+
+    @property
+    def window_s(self) -> float:
+        return self._window.window_s
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self._thread.join(timeout=timeout)
 
 
 class ProcessStalledError(RuntimeError):
@@ -93,26 +155,12 @@ def run_process(
             start_new_session=True,  # own process group → group-wide signals
         )
 
-        # Last-advance stamp for the stall watchdog. Written by the reader
-        # thread on every line, read by the supervisor loop; a float store is
-        # atomic under the GIL, so no lock is needed.
-        last_advance = [time.monotonic()]
-
-        def _tail() -> None:
-            assert proc.stdout is not None
-            for raw in proc.stdout:
-                last_advance[0] = time.monotonic()
-                line = raw.rstrip("\n")
-                if on_line is None:
-                    continue
-                try:
-                    on_line(line)
-                except Exception:
-                    logger.exception("run_process on_line callback failed")
-            proc.stdout.close()
-
-        reader = threading.Thread(target=_tail, name="subproc-tail", daemon=True)
-        reader.start()
+        window = (
+            float(stall_window_s)
+            if stall_window_s is not None and stall_window_s > 0
+            else math.inf
+        )
+        reader = LineTail(proc, window_s=window, on_line=on_line).start()
 
         try:
             while True:
@@ -124,12 +172,11 @@ def run_process(
                     _terminate_group(proc, term_grace_s=term_grace_s)
                     reader.join(timeout=5.0)
                     raise CanceledError("subprocess cancelled")
-                if stall_window_s is not None and stall_window_s > 0:
-                    silent_for = time.monotonic() - last_advance[0]
-                    if silent_for >= stall_window_s:
-                        _terminate_group(proc, term_grace_s=term_grace_s)
-                        reader.join(timeout=5.0)
-                        raise ProcessStalledError(cmd, silent_for, stall_window_s)
+                if reader.stalled():
+                    silent_for = reader.silent_for()
+                    _terminate_group(proc, term_grace_s=term_grace_s)
+                    reader.join(timeout=5.0)
+                    raise ProcessStalledError(cmd, silent_for, window)
                 time.sleep(_POLL_INTERVAL_S)
         finally:
             if proc.poll() is None:  # unexpected exit path (exception in caller)

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -36,7 +36,16 @@ hit, never a second trace.
 
 Handlers SHOULD cheapen non-graph work on ``ctx.boot_warmup`` (e.g.
 ``steps = 1 if ctx.boot_warmup else steps``): the allocator peak is
-shape-driven and the traced graph is step-count-independent.
+shape-driven and the traced graph is step-count-independent. The SDK no
+longer trusts that alone: synthesized payloads CLAMP step-count fields
+(:data:`_STEP_FIELDS`) to their declared floor, so a warm run never pays a
+full recipe's steps even on an endpoint that forgot the clamp.
+
+Warm RUNS are further bounded by :func:`select_runs` (the pgw#654 warm-tax
+fix): eager lanes run one shape representative per guidance class instead
+of the full cross-product, and a checkpoint INSTANCE whose warm contract
+already executed in this process runs a single verification job — juggle
+swaps cost weights transfer + load, never a warm-plan re-run.
 
 Remaining class-level surfaces: a class-defined ``warmup()`` method wins
 outright (fully custom — the LTX two-stage synthetic);
@@ -58,7 +67,16 @@ import typing
 import wave
 import zlib
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import msgspec
 
@@ -276,13 +294,21 @@ class WarmupJob:
     function whose graph set contains this run's class (proof attribution
     is by GRAPH COVERAGE: an alias is proven once ALL of its graph classes
     proved — pgw#654/pgw#647 gap #1); ``declared`` is True when a
-    ``@worker_function(warm=...)`` override applied."""
+    ``@worker_function(warm=...)`` override applied.
+
+    ``eager_group`` and ``shape_rank`` drive :func:`select_runs`'s
+    eager-lane reduction: jobs sharing an ``eager_group`` (function +
+    guidance classes + text pin) trace the SAME batch regime and differ
+    only in shape; ``shape_rank`` orders them so the reduction keeps the
+    largest (allocator-peak) representative."""
 
     spec: "EndpointSpec"
     build: _Factory
     declared: bool
     graph_key: Tuple = ()
     covers: Tuple[str, ...] = ()
+    eager_group: Tuple = ()
+    shape_rank: Tuple = ()
 
 
 @dataclass(frozen=True)
@@ -296,6 +322,57 @@ class WarmupSkip:
 # so its graph falls in the class containing 0 — that mapping is what lets
 # generate's cfg_off trace cover turbo's (pgw#647 gap #1).
 _GUIDANCE_FIELDS = ("guidance_scale", "guidance", "cfg", "true_cfg_scale")
+
+# Step-count payload fields (post-gap-#4 family vocabulary). The traced
+# graph and the allocator peak are step-count INDEPENDENT (the denoise loop
+# repeats one graph), so synthesized warm payloads clamp these to the
+# field's declared floor — a warm run must never pay a full recipe's steps
+# (the 0.61.0 ~30-min boot regression; ie#546 canary measurement).
+_STEP_FIELDS = ("num_inference_steps", "steps")
+
+
+def _numeric_floor(t: Any) -> Tuple[bool, int]:
+    """(is_numeric_field, declared floor) for a payload field type: unwraps
+    Annotated/Optional, honors ``msgspec.Meta`` ge/gt bounds, floor >= 1."""
+    lo = 1
+    while typing.get_origin(t) is typing.Annotated:
+        args = typing.get_args(t)
+        for extra in args[1:]:
+            if isinstance(extra, msgspec.Meta):
+                if extra.ge is not None:
+                    lo = max(lo, int(extra.ge))
+                if extra.gt is not None:
+                    lo = max(lo, int(extra.gt) + 1)
+        t = args[0]
+    origin = typing.get_origin(t)
+    if origin in (typing.Union, py_types.UnionType):
+        for arm in typing.get_args(t):
+            if arm is type(None):
+                continue
+            ok, arm_lo = _numeric_floor(arm)
+            if ok:
+                return True, max(lo, arm_lo)
+        return False, lo
+    if t is int or t is float:
+        return True, lo
+    return False, lo
+
+
+def _step_clamps(
+    payload_type: type, axis_fields: AbstractSet[str], overrides: Any,
+) -> dict:
+    """{field: floor} for step-count fields this plan clamps: known fields
+    from :data:`_STEP_FIELDS` that are neither axes nor warm-overridden."""
+    out: dict = {}
+    for f in msgspec.structs.fields(payload_type):
+        if f.name not in _STEP_FIELDS:
+            continue
+        if f.name in axis_fields or f.name in dict(overrides or {}):
+            continue
+        ok, lo = _numeric_floor(f.type)
+        if ok:
+            out[f.name] = lo
+    return out
 
 
 def _axis_combos(
@@ -347,8 +424,10 @@ def _job_factory(
     base: _Factory,
     combo: Tuple[Tuple[str, str, Any], ...],
     overrides: Any,
+    clamps: Optional[dict] = None,
 ) -> _Factory:
-    changes = {f: w for f, _, w in combo}
+    changes = dict(clamps or {})
+    changes.update({f: w for f, _, w in combo})
     changes.update(dict(overrides or {}))
 
     def build(dir_path: str) -> Any:
@@ -358,6 +437,90 @@ def _job_factory(
         return msgspec.structs.replace(payload, **changes)
 
     return build
+
+
+def _shape_rank(
+    spec: "EndpointSpec", combo: Tuple[Tuple[str, str, Any], ...],
+) -> Tuple:
+    """Sortable preference over one function's combos, HIGHER = preferred by
+    the eager reduction: per non-guidance axis, a numeric warm value ranks
+    by magnitude (megapixels-style axes keep their max-area bucket), a
+    non-numeric one by reverse declaration order (first declared class
+    wins). Structure is identical across one spec's combos, so tuples
+    compare cleanly."""
+    order: dict = {}
+    for a in getattr(spec, "payload_axes", ()) or ():
+        for i, n in enumerate(a.class_names):
+            order[(a.field, n)] = i
+    rank: List[Tuple[int, float]] = []
+    for field, cls_name, warm in combo:
+        if field in _GUIDANCE_FIELDS:
+            continue
+        if isinstance(warm, (int, float)) and not isinstance(warm, bool):
+            rank.append((1, float(warm)))
+        else:
+            rank.append((0, -float(order.get((field, cls_name), 0))))
+    return tuple(rank)
+
+
+def _eager_group(
+    spec: "EndpointSpec", combo: Tuple[Tuple[str, str, Any], ...],
+) -> Tuple:
+    """Jobs sharing this key trace the same batch regime (function +
+    guidance classes + text pin) and differ only in shape."""
+    guid = tuple(
+        (f, c) for f, c, _ in combo if f in _GUIDANCE_FIELDS
+    )
+    return (spec.name, guid, getattr(spec, "text_len", None))
+
+
+def select_runs(
+    jobs: Sequence[WarmupJob],
+    *,
+    tracing: bool,
+    executed: AbstractSet[Tuple] = frozenset(),
+) -> Tuple[List[WarmupJob], str]:
+    """The subset of the derived plan one setup actually EXECUTES, with the
+    mode: ``"full"`` | ``"eager"`` | ``"verify"`` (pgw#654 warm-tax fix; the
+    ie#546 canary measured the full plan re-running per checkpoint
+    INSTANCE: ~30-min first boots and a ~9-min tax on every juggle swap).
+
+    - ``tracing=True`` (a compile artifact is armed or minting): the FULL
+      plan — every graph class must trace into the capture / prove against
+      the cell.
+    - ``tracing=False`` (eager lane — nothing armed, nothing minting): one
+      run per (function, guidance class), collapsed to a single shape
+      representative (:func:`_shape_rank`). Eager warm cost is allocator-
+      pool growth plus kernel-heuristic selection — shape-driven, not
+      coverage-driven (gw#470) — and nothing is being traced, so the class
+      x bucket cross-product buys nothing.
+    - ``executed`` covering every selected run's ``graph_key``: ONE clamped
+      verification run. Allocator pool, cuBLAS/cuDNN heuristics and
+      dynamo's in-memory compiled code are PROCESS-global, and handler code
+      paths were exercised when this contract first warmed — a new
+      checkpoint INSTANCE of the same contract shares all of it. The single
+      run proves the fresh weights compose and forward end-to-end before
+      READY (and, on compiled lanes, provides the calls>0 the pgw#637
+      in-memory/cache-hit proof needs). The caller passes ``executed``
+      non-empty only when inheritance is sound (same contract, proven
+      cells, no pending mint).
+    """
+    runs = list(jobs)
+    if not runs:
+        return [], "full"
+    mode = "full"
+    if not tracing:
+        best: dict = {}
+        for wj in runs:
+            cur = best.get(wj.eager_group)
+            if cur is None or wj.shape_rank > cur.shape_rank:
+                best[wj.eager_group] = wj
+        chosen = {id(wj) for wj in best.values()}
+        runs = [wj for wj in runs if id(wj) in chosen]
+        mode = "eager"
+    if executed and all(wj.graph_key in executed for wj in runs):
+        return [runs[0]], "verify"
+    return runs, mode
 
 
 def plan(
@@ -391,6 +554,10 @@ def plan(
             skips.append(WarmupSkip(s, f"not auto-synthesizable: {reason}"))
             continue
         overrides = dict(getattr(s, "warm_overrides", {}) or {})
+        axis_fields = {
+            a.field for a in (getattr(s, "payload_axes", ()) or ())
+        }
+        clamps = _step_clamps(s.payload_type, axis_fields, overrides)
         seen: set = set()
         for combo in _axis_combos(tuple(getattr(s, "payload_axes", ()) or ())):
             sig = _combo_signature(s, combo, union_axes)
@@ -399,10 +566,12 @@ def plan(
             seen.add(sig)
             jobs.append(WarmupJob(
                 spec=s,
-                build=_job_factory(base, combo, overrides),
+                build=_job_factory(base, combo, overrides, clamps),
                 declared=bool(overrides),
                 graph_key=(s.name,) + sig,
                 covers=(s.name,),
+                eager_group=_eager_group(s, combo),
+                shape_rank=_shape_rank(s, combo),
             ))
     return jobs, skips
 

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1906,7 +1906,12 @@ def test_flux_base_w8a8_boot_proves_generate_and_edit_aliases(
     assert recovered.incarnation_id != target.incarnation_id
     assert recovered.active_compile_ref == cell_ref
     assert list(recovered.function_names) == ["edit", "generate"]
-    assert calls == {"generate": 2, "edit": 2}
+    # pgw#654 warm-tax fix: the recovery re-setup shares the boot's warm
+    # contract and re-arms a cell already proven in-process, so it runs ONE
+    # verification job (here: edit, the plan's first row) whose proof
+    # inherits full-plan attribution — function_names above show both
+    # aliases recovered. A broken re-arm still fails closed on that call.
+    assert calls == {"generate": 1, "edit": 2}
     assert "edit" not in ex.unavailable
     assert "generate" not in ex.unavailable
     assert ex.unavailable["unrelated-hardware-gate"][0] == "hardware_unmet"

--- a/tests/test_llama_runtime.py
+++ b/tests/test_llama_runtime.py
@@ -279,7 +279,7 @@ def llama_path(monkeypatch) -> None:
 @needs_llama
 @pytest.mark.integration
 def test_real_server_stream_and_usage(tiny_gguf_dir, llama_path) -> None:
-    handle = llama_server(str(tiny_gguf_dir), boot_timeout_s=120).start()
+    handle = llama_server(str(tiny_gguf_dir)).start()
     try:
         deltas = list(completion_deltas(
             handle, "Once upon a time", max_tokens=16, temperature=0.0))
@@ -311,7 +311,7 @@ def test_real_server_terminal_output_via_executor(tiny_gguf_dir, llama_path) -> 
     from gen_worker.pb import worker_scheduler_pb2 as pb
     from gen_worker.registry import EndpointSpec
 
-    handle = llama_server(str(tiny_gguf_dir), boot_timeout_s=120).start()
+    handle = llama_server(str(tiny_gguf_dir)).start()
 
     class _In(msgspec.Struct):
         prompt: str = "Once upon a time"
@@ -376,7 +376,7 @@ def test_real_gguf_header_info(tiny_gguf_dir) -> None:
 def test_gpu_smoke_offload_and_measured_vram(tiny_gguf_dir, llama_path) -> None:
     from gen_worker.runtimes.server import process_vram_bytes
 
-    boot = llama_server(str(tiny_gguf_dir), boot_timeout_s=300)
+    boot = llama_server(str(tiny_gguf_dir))
     handle = boot.start()
     try:
         deltas = list(completion_deltas(handle, "Once", max_tokens=4, temperature=0.0))

--- a/tests/test_magic_timeouts_gw666.py
+++ b/tests/test_magic_timeouts_gw666.py
@@ -1,0 +1,550 @@
+"""gw#666 (th#1166 findings B-F): the last five gen-worker wall clocks.
+
+Every tape here runs against REAL children and REAL loopback HTTP servers —
+the point is precisely that a mock cannot tell you whether a slow-but-alive
+peer survives, and that is the only property under test.
+
+Each pair is deliberately discriminating: the "alive" case runs FAR longer
+than the give-up window and must still succeed, which is exactly what the
+deleted wall clocks made impossible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.server
+import json
+import os
+import re
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import pytest
+import requests
+from blake3 import blake3
+
+from gen_worker.stall import ProgressFloor, SilenceWindow
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: a real loopback HTTP server driven by a per-request callback.
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _Server:
+    """One loopback HTTP server whose every request is answered by ``handler``
+    -> (status, body_bytes, extra_headers)."""
+
+    def __init__(self, handler: Callable[[Any], tuple]) -> None:
+        self.calls = 0
+        outer = self
+
+        class _H(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def _answer(self) -> None:
+                outer.calls += 1
+                # Drain the request body or the next keep-alive request on this
+                # connection reads it as a request line.
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                status, body, headers = handler(self)
+                self.send_response(status)
+                for k, v in (headers or {}).items():
+                    self.send_header(k, v)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            do_GET = _answer
+            do_POST = _answer
+
+            def log_message(self, *a: Any) -> None:
+                pass
+
+        self.port = _free_port()
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", self.port), _H)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def __enter__(self) -> "_Server":
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+def _json_body(payload: dict) -> bytes:
+    return json.dumps(payload).encode()
+
+
+_IN_PROGRESS = _json_body({"error": {"code": "upload_complete_in_progress"}})
+
+
+def _n_then_ok(n: int, hot: tuple, cold: tuple) -> Callable[[Any], tuple]:
+    """Answer ``hot`` for the first ``n`` requests, then ``cold`` forever."""
+    seen = {"n": 0}
+
+    def _h(_req: Any) -> tuple:
+        seen["n"] += 1
+        return hot if seen["n"] <= n else cold
+
+    return _h
+
+
+# ---------------------------------------------------------------------------
+# The primitive
+# ---------------------------------------------------------------------------
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def test_silence_window_measures_advances_not_runtime() -> None:
+    clock = _Clock()
+    w = SilenceWindow(10.0, now=clock)
+
+    for _ in range(100):  # runs 900s — ten times the window — while advancing
+        clock.t += 9.0
+        assert not w.stalled()
+        w.touch()
+
+    clock.t += 10.0
+    assert w.stalled()
+    assert w.silent_for() == pytest.approx(10.0)
+
+
+def test_silence_window_marker_advances_only_on_change() -> None:
+    clock = _Clock()
+    w = SilenceWindow(10.0, now=clock)
+
+    assert w.touch_if_changed("building@7") is True  # first sighting counts
+    clock.t += 6.0
+    assert w.touch_if_changed("building@7") is False  # same token: no advance
+    clock.t += 6.0
+    assert w.stalled()
+    assert w.touch_if_changed("building@8") is True
+    assert not w.stalled()
+
+
+def test_progress_floor_treats_a_trickle_as_no_progress() -> None:
+    floor = ProgressFloor(1000)
+    total = 0
+    for _ in range(500):  # 500 bytes of "progress" — half the floor
+        total += 1
+        assert floor.cleared(total) is False
+    assert floor.moved(total) == 500
+    total += 500
+    assert floor.cleared(total) is True
+    assert floor.moved(total) == 0  # rebased
+
+
+# ---------------------------------------------------------------------------
+# B — runtimes/server.py: an engine boot is bounded by SILENCE
+# ---------------------------------------------------------------------------
+
+# A slow-booting engine: prints load progress for a while, THEN serves /health.
+# Under the deleted `_DEFAULT_BOOT_TIMEOUT_S` this shape died for the sole
+# crime of taking longer than the constant.
+_CHATTY_ENGINE = """
+import sys, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+port, talk_s = int(sys.argv[1]), float(sys.argv[2])
+i = 0
+end = time.time() + talk_s
+while time.time() < end:
+    print("loading weights shard %d" % i, flush=True)
+    i += 1
+    time.sleep(0.05)
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+    def log_message(self, *a):
+        pass
+HTTPServer(("127.0.0.1", port), H).serve_forever()
+"""
+
+# An engine that says one thing and then wedges, never serving.
+_WEDGED_ENGINE = """
+import sys, time
+open(sys.argv[1], "w").write(str(__import__("os").getpid()))
+print("initializing engine", flush=True)
+time.sleep(600)
+"""
+
+
+def _proc_for(script: str, *args: str, port: int, window_s: float):
+    from gen_worker.runtimes.server import ServerProcess
+
+    return ServerProcess(
+        [sys.executable, "-u", "-c", script, *args],
+        health_url=f"http://127.0.0.1:{port}/health",
+        stall_window_s=window_s,
+    )
+
+
+def test_a_talking_engine_boots_however_long_it_takes(caplog) -> None:
+    """The stall window is a FIFTH of the boot; only silence may fail it."""
+    port = _free_port()
+    boot = _proc_for(_CHATTY_ENGINE, str(port), "1.5", port=port, window_s=0.3)
+
+    caplog.set_level("INFO", logger="gen_worker.runtimes.server")
+    start = time.monotonic()
+    handle = boot.start()
+    try:
+        elapsed = time.monotonic() - start
+        assert elapsed > 0.3 * 3  # outlived several windows while advancing
+        assert handle.alive
+        # The engine's own boot log now reaches the worker log, where an
+        # operator can see it — it used to go to an unread inherited stdout.
+        assert any("[engine] loading weights shard" in r.getMessage()
+                   for r in caplog.records)
+    finally:
+        handle.stop()
+    assert not handle.alive
+
+
+def test_a_silent_engine_fails_on_the_stall_window_and_is_killed(tmp_path) -> None:
+    from gen_worker.runtimes.server import ServerBootError
+
+    pidfile = tmp_path / "engine.pid"
+    port = _free_port()
+    boot = _proc_for(_WEDGED_ENGINE, str(pidfile), port=port, window_s=0.5)
+
+    start = time.monotonic()
+    with pytest.raises(ServerBootError) as excinfo:
+        boot.start()
+    elapsed = time.monotonic() - start
+
+    assert "produced no output" in str(excinfo.value)
+    assert elapsed < 30.0  # NOT the child's own 600s sleep
+    pid = int(pidfile.read_text())
+    for _ in range(100):  # SIGTERM -> exit is not instantaneous
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail(f"wedged engine pid {pid} survived the boot failure")
+
+
+def test_the_boot_gate_keys_on_the_GAP_not_on_total_runtime() -> None:
+    """Control for the two tapes above: the same chatty engine, with a window
+    narrower than its 0.05s inter-line gap, DOES fail — so the gate is live,
+    and what it measures is silence between lines rather than elapsed time."""
+    from gen_worker.runtimes.server import ServerBootError
+
+    port = _free_port()
+    boot = _proc_for(_CHATTY_ENGINE, str(port), "5.0", port=port, window_s=0.01)
+    with pytest.raises(ServerBootError) as excinfo:
+        boot.start()
+    assert "produced no output" in str(excinfo.value)
+
+
+def test_degrading_boot_degrades_on_silence_not_on_a_clock(tmp_path) -> None:
+    from gen_worker.runtimes.server import DegradingBoot
+
+    dead_port, live_port = _free_port(), _free_port()
+    boot = DegradingBoot([
+        _proc_for(_WEDGED_ENGINE, str(tmp_path / "p"), port=dead_port, window_s=0.4),
+        _proc_for(_CHATTY_ENGINE, str(live_port), "0.3", port=live_port, window_s=0.4),
+    ])
+    handle = boot.start()
+    try:
+        assert handle.base_url.endswith(str(live_port))
+        assert handle.alive
+    finally:
+        handle.stop()
+
+
+# ---------------------------------------------------------------------------
+# C — models/cozy_cas.py: the CAS retry give-up is byte progress
+# ---------------------------------------------------------------------------
+
+
+class _FlakyBlobServer:
+    """Serves ``blob`` with Range resume, severing the connection after
+    ``sever_after`` bytes of every response (or answering ``fail_status``)."""
+
+    def __init__(self, blob: bytes, *, sever_after: int = 0, fail_status: int = 0) -> None:
+        self.blob, self.calls = blob, 0
+        outer = self
+
+        class _H(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_GET(self) -> None:
+                outer.calls += 1
+                if fail_status:
+                    self.send_response(fail_status)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                start = 0
+                rng = str(self.headers.get("Range") or "")
+                if rng.startswith("bytes="):
+                    start = int(rng.split("=", 1)[1].split("-", 1)[0])
+                body = outer.blob[start:]
+                self.send_response(206 if start else 200)
+                if start:
+                    self.send_header(
+                        "Content-Range",
+                        f"bytes {start}-{len(outer.blob) - 1}/{len(outer.blob)}",
+                    )
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                if sever_after and len(body) > sever_after:
+                    # Truncate mid-body and drop the socket: exactly what a
+                    # flaky pod uplink does, and the client resumes by Range.
+                    self.wfile.write(body[:sever_after])
+                    self.wfile.flush()
+                    self.close_connection = True
+                    self.connection.close()
+                else:
+                    self.wfile.write(body)
+
+            def log_message(self, *a: Any) -> None:
+                pass
+
+        self.port = _free_port()
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", self.port), _H)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/blob"
+
+    def __enter__(self) -> "_FlakyBlobServer":
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+def _fetch(url: str, dst: Path, blob: bytes) -> None:
+    from gen_worker.models import cozy_cas
+
+    asyncio.run(cozy_cas._download_one_file(
+        url, dst, len(blob), blake3(blob).hexdigest(),
+    ))
+
+
+@pytest.fixture()
+def fast_cas_retries(monkeypatch) -> None:
+    from gen_worker.models import cozy_cas
+
+    monkeypatch.setattr(cozy_cas, "_RETRY_BACKOFF_CAP_S", 0.01)
+    monkeypatch.setattr(cozy_cas, "_RETRY_PROGRESS_FLOOR_BYTES", 4 * 1024 * 1024)
+    monkeypatch.setattr(cozy_cas, "_TRANSIENT_MAX_TRIES", 2)
+
+
+def test_a_flaky_but_advancing_cas_fetch_outlives_its_retry_cap(
+    tmp_path, fast_cas_retries,
+) -> None:
+    """Two severed connections against a cap of TWO — and it still lands,
+    because each attempt put 8 MiB on disk and cleared the byte floor. The
+    old code counted failures (and wall seconds) regardless of bytes."""
+    blob = os.urandom(24 * 1024 * 1024)
+    dst = tmp_path / "blob.bin"
+    with _FlakyBlobServer(blob, sever_after=8 * 1024 * 1024) as srv:
+        _fetch(srv.url, dst, blob)
+        assert srv.calls == 3  # 8 MiB + 8 MiB + the resumed tail
+    assert dst.read_bytes() == blob
+
+
+def test_a_cas_fetch_that_delivers_nothing_gives_up_on_the_count(
+    tmp_path, fast_cas_retries,
+) -> None:
+    blob = os.urandom(4096)
+    with _FlakyBlobServer(blob, fail_status=500) as srv:
+        with pytest.raises(requests.RequestException):
+            _fetch(srv.url, tmp_path / "blob.bin", blob)
+        assert srv.calls == 2  # exactly _TRANSIENT_MAX_TRIES, no byte progress
+
+
+# ---------------------------------------------------------------------------
+# E — presigned_upload.py: a live hub-side assembly is never a job failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fast_finalize_polls(monkeypatch) -> None:
+    from gen_worker import presigned_upload as pu
+
+    monkeypatch.setattr(pu, "_COMPLETE_IN_PROGRESS_POLL_S", 0.05)
+    monkeypatch.setattr(pu, "_COMPLETE_SILENCE_WINDOW_S", 0.4)
+
+
+def _poll_finalize(url: str) -> dict:
+    from gen_worker.presigned_upload import _poll_until_finalized
+
+    return _poll_until_finalized(
+        complete_url=url,
+        complete_headers={"Content-Type": "application/json"},
+        payload={"parts": []},
+        cancel_check=None,
+        session=requests.Session(),
+    )
+
+
+def test_a_long_hub_side_assembly_is_waited_out_not_failed(fast_finalize_polls) -> None:
+    """Twenty in-progress answers spanning ~2.5x the give-up window — the job
+    must survive, because the hub was working the whole time."""
+    ok = _json_body({"ref": "cas/abc", "blake3": "ab", "size_bytes": 1})
+    with _Server(_n_then_ok(
+        20, (409, _IN_PROGRESS, None), (200, ok, {"Content-Type": "application/json"}),
+    )) as srv:
+        start = time.monotonic()
+        out = _poll_finalize(f"{srv.base}/complete")
+        assert time.monotonic() - start > 0.4 * 2
+    assert out["ref"] == "cas/abc"
+
+
+def test_a_hub_that_stops_answering_fails_the_finalize(fast_finalize_polls) -> None:
+    from gen_worker.api.errors import ArtifactTransferError
+
+    dead = f"http://127.0.0.1:{_free_port()}/complete"  # nothing listening
+    with pytest.raises(ArtifactTransferError) as excinfo:
+        _poll_finalize(dead)
+    assert "stopped answering" in str(excinfo.value)
+    assert excinfo.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# D — convert/hub.py: publish-complete waits while the hub verifies
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fast_hub_retries(monkeypatch) -> None:
+    from gen_worker.convert import hub
+
+    monkeypatch.setattr(hub, "_COMPLETE_IN_PROGRESS_POLL_S", 0.05)
+    monkeypatch.setattr(hub, "_COMPLETE_NETWORK_RETRY_DELAY_S", 0.05)
+    monkeypatch.setattr(hub, "_COMPLETE_SILENCE_WINDOW_S", 0.4)
+    monkeypatch.setattr(hub, "_RETRY_BASE_DELAY_S", 0.01)
+    monkeypatch.setattr(hub, "_RETRY_MAX_DELAY_S", 0.02)
+
+
+def _hub_client(base: str):
+    from gen_worker.convert.hub import HubClient
+
+    return HubClient(base_url=base, token="t", owner="o")
+
+
+def test_publish_complete_waits_while_the_hub_keeps_verifying(fast_hub_retries) -> None:
+    ok = _json_body({"ok": True})
+    with _Server(_n_then_ok(
+        15, (409, _IN_PROGRESS, None), (200, ok, {"Content-Type": "application/json"}),
+    )) as srv:
+        start = time.monotonic()
+        resp = _hub_client(srv.base)._post_complete("/complete", {})
+        assert time.monotonic() - start > 0.4  # outlived the give-up window
+    assert resp.status_code == 200
+
+
+def test_publish_complete_gives_up_once_the_hub_goes_silent(fast_hub_retries) -> None:
+    from gen_worker.convert.hub import HubPublishError
+
+    client = _hub_client(f"http://127.0.0.1:{_free_port()}")  # nothing listening
+    with pytest.raises(HubPublishError):
+        client._post_complete("/complete", {})
+
+
+# ---------------------------------------------------------------------------
+# F — request_context/_datasets.py: materialize polls while the hub answers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fast_dataset_polls(monkeypatch) -> None:
+    from gen_worker.request_context import _datasets
+
+    monkeypatch.setattr(_datasets, "_POLL_BACKOFF_START_S", 0.02)
+    monkeypatch.setattr(_datasets, "_POLL_BACKOFF_CAP_S", 0.05)
+
+
+def _materialize(base: str, window_s: float):
+    from gen_worker.request_context._datasets import fetch_materialize_manifest
+
+    return fetch_materialize_manifest(
+        base, "tok", "11111111-1111-1111-1111-111111111111",
+        hub_silence_window_s=window_s,
+    )
+
+
+def test_a_building_snapshot_is_polled_for_as_long_as_the_hub_answers(
+    fast_dataset_polls,
+) -> None:
+    building = _json_body({"status": "building", "state_version": 7, "retry_after": 0})
+    ready = _json_body({
+        "snapshot_id": "dsnap-1",
+        "entries": [{"path": "rows.jsonl", "inline_text": "{}"}],
+    })
+    with _Server(_n_then_ok(
+        20, (202, building, None), (200, ready, {"Content-Type": "application/json"}),
+    )) as srv:
+        start = time.monotonic()
+        snapshot_id, entries = _materialize(srv.base, 0.3)
+        # The build outran the give-up window several times over: a 202 is the
+        # hub saying the build is LIVE, so it refreshes the window.
+        assert time.monotonic() - start > 0.3 * 2
+    assert snapshot_id == "dsnap-1" and len(entries) == 1
+
+
+def test_materialize_gives_up_only_when_the_hub_says_nothing_definite(
+    fast_dataset_polls,
+) -> None:
+    with _Server(lambda _r: (502, b"", None)) as srv:
+        with pytest.raises(RuntimeError) as excinfo:
+            _materialize(srv.base, 0.3)
+    assert "said nothing definite" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Source guard: none of the five may regrow a wall clock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "relpath, gone",
+    [
+        ("runtimes/server.py", "_DEFAULT_BOOT_TIMEOUT_S"),
+        ("models/cozy_cas.py", "_MAX_RETRY_TIME_S"),
+        ("convert/hub.py", "_COMPLETE_NETWORK_MAX_WAIT_S"),
+        ("presigned_upload.py", "_COMPLETE_IN_PROGRESS_MAX_WAIT_S"),
+        ("request_context/_datasets.py", "_MATERIALIZE_BUDGET_S"),
+    ],
+)
+def test_the_wall_clock_constants_are_gone(relpath: str, gone: str) -> None:
+    """No module-level ASSIGNMENT may reappear (the comments that explain why
+    each one died still name them, and should)."""
+    source = (SRC / relpath).read_text()
+    assert re.search(rf"^{gone}\s*=", source, re.MULTILINE) is None

--- a/tests/test_subprocess_stall_gw665.py
+++ b/tests/test_subprocess_stall_gw665.py
@@ -1,0 +1,87 @@
+"""gw#665: the conversion toolchain is bounded by SILENCE, not by wall clock.
+
+Real ``run_process`` over real child processes — no mocks. The children stand
+in for ``convert_hf_to_gguf.py`` / ``llama-quantize``: both print a line per
+tensor, so "has said nothing for N seconds" is the wedge signal and "has been
+running for N seconds" is not.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import pytest
+
+from gen_worker.subproc import ProcessStalledError, run_process
+
+
+def _python(script: str) -> list[str]:
+    return [sys.executable, "-u", "-c", script]
+
+
+# A chatty long-runner: 40 lines at 0.05s each. Under the old ``timeout=``
+# regime a job like this died purely for outliving the constant.
+_CHATTY = """
+import sys, time
+for i in range(40):
+    print("quantizing blk.%d" % i, flush=True)
+    time.sleep(0.05)
+"""
+
+# Speaks once, then wedges forever.
+_WEDGED = """
+import sys, time
+print("quantizing blk.0", flush=True)
+time.sleep(600)
+"""
+
+
+def test_a_talking_process_is_never_killed_however_long_it_runs() -> None:
+    """The window is far SHORTER than the runtime; only silence may kill."""
+    lines: list[str] = []
+    start = time.monotonic()
+    rc = run_process(_python(_CHATTY), on_line=lines.append, stall_window_s=0.6)
+    elapsed = time.monotonic() - start
+
+    assert rc == 0
+    assert len(lines) == 40
+    # It genuinely outlived several stall windows while advancing.
+    assert elapsed > 0.6 * 2
+
+
+def test_a_silent_process_is_killed_at_the_stall_window() -> None:
+    start = time.monotonic()
+    with pytest.raises(ProcessStalledError) as excinfo:
+        run_process(_python(_WEDGED), stall_window_s=0.5)
+    elapsed = time.monotonic() - start
+
+    assert excinfo.value.window_s == 0.5
+    assert excinfo.value.silent_for_s >= 0.5
+    # Killed on the window, not on the child's own 600s sleep.
+    assert elapsed < 30
+
+
+def test_no_stall_window_means_no_watchdog_at_all() -> None:
+    """Default is unbounded: there is no wall clock hiding in the primitive."""
+    lines: list[str] = []
+    rc = run_process(_python(_CHATTY), on_line=lines.append)
+    assert rc == 0
+    assert len(lines) == 40
+
+
+def test_the_gguf_toolchain_window_is_a_stall_window_not_a_runtime_cap() -> None:
+    """Guard against a wall-clock constant creeping back into the call sites."""
+    import inspect
+
+    from gen_worker.convert import convert as convert_mod
+    from gen_worker.convert import gguf_tools
+
+    assert gguf_tools.GGUF_TOOLCHAIN_STALL_WINDOW_S > 0
+    for mod in (gguf_tools, convert_mod):
+        code = "\n".join(
+            line for line in inspect.getsource(mod).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "timeout=7200" not in code
+        assert "subprocess.run(" not in code

--- a/tests/test_vocabulary_train_pgw654.py
+++ b/tests/test_vocabulary_train_pgw654.py
@@ -299,8 +299,9 @@ def test_derived_warm_plan_cross_products_axes_per_function() -> None:
     built = [j.build("/tmp") for j in by_fn["generate"]]
     combos = {(p.aspect_ratio, p.guidance_scale) for p in built}
     assert combos == {("1:1", 0.0), ("1:1", 5.0), ("16:9", 0.0), ("16:9", 5.0)}
-    # Defaulted non-axis fields keep their defaults; required strs synthesize.
-    assert all(p.steps == 2 and p.prompt == "warmup" for p in built)
+    # Required strs synthesize; step fields clamp to their declared floor
+    # (pgw#654 warm-tax fix — a warm run never pays a full recipe's steps).
+    assert all(p.steps == 1 and p.prompt == "warmup" for p in built)
 
 
 def test_warm_override_applies_to_non_axis_fields_only() -> None:

--- a/tests/test_warm_tax_pgw654.py
+++ b/tests/test_warm_tax_pgw654.py
@@ -394,3 +394,31 @@ def test_ctx_adjustments_is_public_and_immutable() -> None:
     assert row["requested"] == "15.0" and row["applied"] == "10.0"
     with pytest.raises(AttributeError):
         rows.append({})  # noqa: B038 — proves immutability
+
+
+# ---------------------------------------------------------------------------
+# benchmark harness: content-address plan (CPU-safe half)
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_component_digest_discriminates(tmp_path: Path) -> None:
+    """The swap benchmark's component plan: identical component subtrees
+    share a content address (no bytes move on swap); differing ones split."""
+    sys_path = __import__("sys").path
+    root = str(Path(__file__).resolve().parents[1])
+    if root not in sys_path:
+        sys_path.insert(0, root)
+    from benchmarks.swap_latency import component_digest
+
+    a = tmp_path / "a" / "vae"
+    b = tmp_path / "b" / "vae"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    (a / "w.safetensors").write_bytes(b"same-bytes")
+    (b / "w.safetensors").write_bytes(b"same-bytes")
+    assert component_digest(tmp_path / "a", "vae") == component_digest(
+        tmp_path / "b", "vae")
+    (b / "w.safetensors").write_bytes(b"other-bytes")
+    assert component_digest(tmp_path / "a", "vae") != component_digest(
+        tmp_path / "b", "vae")
+    assert component_digest(tmp_path / "a", "absent") == ""

--- a/tests/test_warm_tax_pgw654.py
+++ b/tests/test_warm_tax_pgw654.py
@@ -1,0 +1,396 @@
+"""pgw#654 warm-tax fix: warm RUNS are contract-keyed, never instance-keyed.
+
+The ie#546 sdxl canary measured the 0.61.0 derived warm plan re-running per
+CHECKPOINT INSTANCE: ~30-min first boots (full class x bucket cross-product
+of real eager denoises) and a ~9-min warm tax on every juggle swap whose
+genuine cost (download + VRAM load) was ~74s. Pinned here, through the REAL
+executor setup path (fakes only at the download boundary):
+
+  1. boot on an eager lane runs ONE shape representative per (function,
+     guidance class) — not the cross-product — with step fields clamped to
+     their declared floor;
+  2. a SECOND checkpoint instance of the same family/contract runs exactly
+     ONE verification job (swap cost = transfer + load, never a warm-plan
+     re-run), and a third does the same;
+  3. the warm contract key unifies across checkpoint refs but splits on
+     lane facts (flavor/storage_dtype) and component overrides;
+  4. select_runs keeps the full plan while tracing, keeps the max-area
+     bucket for numeric shape axes, and honors msgspec Meta floors in the
+     step clamp;
+  5. pgw#647 gap #2: a component override inherits the base COMPOSITION's
+     compute dtype (fp8-stored base => bf16 compute), never the override's
+     on-disk dtype;
+  6. ctx.adjustments is the public, immutable read side of the ledger.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from pathlib import Path
+from typing import Annotated, Any, List, Optional, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import (
+    AxisClass,
+    CompileAxis,
+    RequestContext,
+    Resources,
+    Slot,
+    endpoint,
+    worker_function,
+)
+from gen_worker import warmup as warmup_mod
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+_GUIDANCE_AXIS = CompileAxis(classes=(
+    AxisClass("cfg_off", match=lambda v: v == 0, warm=0.0),
+    AxisClass("cfg_on", match=lambda v: v != 0, warm=7.5),
+))
+_ASPECT_AXIS = CompileAxis(classes=(
+    AxisClass("sq", match=lambda v: v == "1:1", warm="1:1"),
+    AxisClass("wide", match=lambda v: v == "16:9", warm="16:9"),
+    AxisClass("tall", match=lambda v: v == "9:16", warm="9:16"),
+))
+
+
+class GenIn(msgspec.Struct):
+    prompt: str
+    aspect_ratio: Annotated[str, _ASPECT_AXIS] = "1:1"
+    guidance_scale: Annotated[Optional[float], _GUIDANCE_AXIS] = None
+    num_inference_steps: int = 8
+
+
+class TurboIn(msgspec.Struct):
+    # Distilled contract: no guidance field (classifies as the 0-class).
+    prompt: str
+    aspect_ratio: Annotated[str, _ASPECT_AXIS] = "1:1"
+    num_inference_steps: int = 4
+
+
+class Out(msgspec.Struct):
+    y: str = "ok"
+
+
+# (function, pipeline path, guidance, steps, aspect) per warm invocation.
+CALLS: List[Tuple[str, str, Optional[float], int, str]] = []
+
+
+@endpoint(
+    models={"pipeline": Slot(str)},
+    resources=Resources(gpu=True),
+)
+class Family:
+    def setup(self, pipeline: str) -> None:
+        self.pipeline = pipeline
+
+    @worker_function()
+    def generate(self, ctx: RequestContext, p: GenIn) -> Out:
+        CALLS.append((
+            "generate", self.pipeline, p.guidance_scale,
+            p.num_inference_steps, p.aspect_ratio,
+        ))
+        return Out()
+
+    @worker_function()
+    def generate_turbo(self, ctx: RequestContext, p: TurboIn) -> Out:
+        CALLS.append((
+            "generate_turbo", self.pipeline, None,
+            p.num_inference_steps, p.aspect_ratio,
+        ))
+        return Out()
+
+
+def _executor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Executor:
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    specs = extract_specs(Family)
+    ex = Executor(specs, _send)
+    ex.store._cache_dir = tmp_path / "cas"
+
+    async def _fake_download(ref: str, **kwargs: Any) -> Path:
+        p = tmp_path / ref.replace("/", "_").replace(":", "_").replace("#", "_")
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    import gen_worker.executor as ex_mod
+
+    monkeypatch.setattr(ex_mod, "ensure_local", _fake_download)
+    return ex
+
+
+def _pick(ex: Executor, name: str, ref: str) -> Any:
+    spec = ex.specs[name]
+    run = pb.RunJob(
+        function_name=name,
+        models=[pb.ModelBinding(slot="pipeline", ref=ref)],
+    )
+    return ex._effective_spec(spec, run)
+
+
+def _snapshots(ref: str, digest: str) -> dict:
+    return {ref: pb.Snapshot(digest=digest, files=[pb.SnapshotFile(
+        path="model.safetensors", size_bytes=5, blake3="cd" * 32,
+        url="http://r2.invalid/presigned")])}
+
+
+def test_eager_boot_reduces_and_instance_swaps_verify_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The regression test Paul asked for: N instances of one family — the
+    warm plan runs once; each additional instance costs ONE verification
+    run, never a re-run of the plan."""
+    CALLS.clear()
+    ex = _executor(tmp_path, monkeypatch)
+
+    async def _run() -> None:
+        # --- boot: first checkpoint instance -------------------------------
+        eff1 = _pick(ex, "generate", "acme/sdxl-base:prod")
+        await ex.ensure_setup(eff1, _snapshots("acme/sdxl-base:prod", "d1" * 16))
+        boot_calls = list(CALLS)
+        # generate's full eager cross-product would be 6 runs (2 cfg x 3
+        # aspects). The eager reduction runs one shape representative per
+        # guidance class: cfg_off + cfg_on.
+        assert len(boot_calls) == 2, boot_calls
+        assert {(fn, g) for fn, _p, g, _s, _a in boot_calls} == {
+            ("generate", 0.0), ("generate", 7.5),
+        }
+        # One shape representative only (first declared class for a
+        # non-numeric axis), steps clamped to the declared floor.
+        assert all(a == "1:1" for *_x, a in boot_calls)
+        assert all(s == 1 for _f, _p, _g, s, _a in boot_calls)
+
+        # A sibling-alias dispatch on the SAME pick joins the ready record
+        # without any further warm work.
+        CALLS.clear()
+        turbo1 = _pick(ex, "generate-turbo", "acme/sdxl-base:prod")
+        assert turbo1.instance_key == eff1.instance_key
+        await ex.ensure_setup(
+            turbo1, _snapshots("acme/sdxl-base:prod", "d1" * 16))
+        assert CALLS == []
+
+        # --- juggle swap: second checkpoint, same family/contract ----------
+        CALLS.clear()
+        eff2 = _pick(ex, "generate", "acme/cyberrealistic-xl:prod")
+        assert eff2.instance_key != eff1.instance_key
+        await ex.ensure_setup(eff2, _snapshots("acme/cyberrealistic-xl:prod", "d2" * 16))
+        assert len(CALLS) == 1, (
+            "an instance swap must be a warm-contract cache hit "
+            f"(one verification run), got {CALLS}"
+        )
+
+        # --- third instance: same again ------------------------------------
+        CALLS.clear()
+        eff3 = _pick(ex, "generate", "acme/nova-anime-xl:prod")
+        await ex.ensure_setup(eff3, _snapshots("acme/nova-anime-xl:prod", "d3" * 16))
+        assert len(CALLS) == 1, CALLS
+
+        # All three instances are READY and share ONE warm contract.
+        ready = [r for r in ex._classes.values() if r.ready]
+        assert len(ready) == 3
+        assert len(ex._warm_contract_runs) == 1
+        (memory,) = ex._warm_contract_runs.values()
+        assert len(memory) == 2  # cfg_off + cfg_on; verify re-runs a member
+
+    asyncio.run(_run())
+
+
+def test_warm_contract_key_splits_on_lane_and_overrides_not_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ex = _executor(tmp_path, monkeypatch)
+    base = _pick(ex, "generate", "acme/sdxl-base:prod")
+    fine_tune = _pick(ex, "generate", "acme/cyberrealistic-xl:prod")
+    assert ex._warm_contract_key(base) == ex._warm_contract_key(fine_tune)
+
+    quant = _pick(ex, "generate", "acme/sdxl-base:prod#fp8-w8a8")
+    assert ex._warm_contract_key(quant) != ex._warm_contract_key(base)
+
+    run = pb.RunJob(function_name="generate", models=[pb.ModelBinding(
+        slot="pipeline", ref="acme/sdxl-base:prod",
+        components={"vae": "tensorhub/sdxl-vae-fp16-fix:prod"},
+    )])
+    overridden = ex._effective_spec(ex.specs["generate"], run)
+    assert ex._warm_contract_key(overridden) != ex._warm_contract_key(base)
+
+
+# ---------------------------------------------------------------------------
+# select_runs unit rows
+# ---------------------------------------------------------------------------
+
+
+def _family_jobs() -> List[warmup_mod.WarmupJob]:
+    jobs, skips = warmup_mod.plan(extract_specs(Family), decl_warmup=None)
+    assert not skips
+    return jobs
+
+
+def test_select_runs_full_while_tracing() -> None:
+    jobs = _family_jobs()
+    runs, mode = warmup_mod.select_runs(jobs, tracing=True)
+    assert mode == "full" and runs == jobs
+
+
+def test_select_runs_verify_only_when_contract_covered() -> None:
+    jobs = _family_jobs()
+    executed = {wj.graph_key for wj in jobs}
+    runs, mode = warmup_mod.select_runs(jobs, tracing=True, executed=executed)
+    assert mode == "verify" and len(runs) == 1
+    # Partial coverage never collapses to verify.
+    partial = set(list(executed)[:-1])
+    _runs, mode = warmup_mod.select_runs(jobs, tracing=True, executed=partial)
+    assert mode == "full"
+
+
+class MpIn(msgspec.Struct):
+    prompt: str
+    megapixels: Annotated[float, CompileAxis(classes=(
+        AxisClass("mp1", match=lambda v: v <= 1.5, warm=1.0),
+        AxisClass("mp2", match=lambda v: v > 1.5, warm=2.0),
+    ))] = 1.0
+
+
+class FloorIn(msgspec.Struct):
+    prompt: str
+    num_inference_steps: Annotated[int, msgspec.Meta(ge=4)] = 20
+
+
+def test_eager_reduction_keeps_max_numeric_bucket() -> None:
+    @endpoint(models={"pipeline": Slot(str)}, resources=Resources(gpu=True))
+    class Z:
+        def setup(self, pipeline: str) -> None:
+            self.pipeline = pipeline
+
+        @worker_function()
+        def generate(self, ctx: RequestContext, p: MpIn) -> Out:
+            return Out()
+
+    jobs, _ = warmup_mod.plan(extract_specs(Z), decl_warmup=None)
+    assert len(jobs) == 2
+    runs, mode = warmup_mod.select_runs(jobs, tracing=False)
+    assert mode == "eager" and len(runs) == 1
+    # The allocator-peak (max-area) bucket is the one kept.
+    payload = runs[0].build(".")
+    assert payload.megapixels == 2.0
+
+
+def test_step_clamp_honors_meta_floor() -> None:
+    @endpoint(models={"pipeline": Slot(str)}, resources=Resources(gpu=True))
+    class F:
+        def setup(self, pipeline: str) -> None:
+            self.pipeline = pipeline
+
+        @worker_function()
+        def generate(self, ctx: RequestContext, p: FloorIn) -> Out:
+            return Out()
+
+    jobs, _ = warmup_mod.plan(extract_specs(F), decl_warmup=None)
+    (job,) = jobs
+    assert job.build(".").num_inference_steps == 4
+
+
+# ---------------------------------------------------------------------------
+# pgw#647 gap #2: component-override dtype inherits the composition's
+# ---------------------------------------------------------------------------
+
+
+def _write_safetensors(dir_path: Path, dtype: str) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    header = {"weight": {
+        "dtype": dtype, "shape": [1], "data_offsets": [0, 4],
+    }}
+    blob = json.dumps(header).encode()
+    (dir_path / "model.safetensors").write_bytes(
+        struct.pack("<Q", len(blob)) + blob + b"\x00\x00\x00\x00")
+
+
+def test_composition_compute_dtype_inherits_base_not_override(
+    tmp_path: Path,
+) -> None:
+    from gen_worker.models.loading import composition_compute_dtype
+
+    bf16_base = tmp_path / "base-bf16"
+    _write_safetensors(bf16_base, "BF16")
+    fp8_base = tmp_path / "base-fp8"
+    _write_safetensors(fp8_base, "F8_E4M3")
+    fp32_base = tmp_path / "base-fp32"
+    _write_safetensors(fp32_base, "F32")
+
+    # Declared binding dtype wins outright.
+    assert composition_compute_dtype(bf16_base, "fp16") == "fp16"
+    # No declared dtype: the base tree's compute dtype, with fp8 storage
+    # mapping to its bf16 compute default (the ie#546 canary case — the
+    # fp32-stored fp16-fix VAE must land bf16 in an fp8-w8a16 composition).
+    assert composition_compute_dtype(bf16_base) == "bf16"
+    assert composition_compute_dtype(fp8_base) == "bf16"
+    # An fp32/undetectable base stays "" (caller falls back).
+    assert composition_compute_dtype(fp32_base) == ""
+
+
+def test_load_component_override_prefers_composition_dtype(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.models import loading as loading_mod
+
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakePipe", "vae": ["fake_lib", "FakeVae"],
+    }))
+    _write_safetensors(base / "vae", "F8_E4M3")  # composition computes bf16
+    override = tmp_path / "override"
+    _write_safetensors(override, "F32")  # fp32-stored fp16-fix shape
+
+    seen: dict = {}
+
+    class FakeVae:
+        @classmethod
+        def from_pretrained(cls, path: str, **kwargs: Any) -> "FakeVae":
+            seen.update(kwargs)
+            return cls()
+
+    import types
+
+    fake_lib = types.ModuleType("fake_lib")
+    fake_lib.FakeVae = FakeVae  # type: ignore[attr-defined]
+    monkeypatch.setitem(__import__("sys").modules, "fake_lib", fake_lib)
+
+    captured: dict = {}
+
+    def _get_torch_dtype(name: str) -> str:
+        captured["wanted"] = name
+        raise ImportError("torch-less test rig")
+
+    monkeypatch.setattr(loading_mod, "get_torch_dtype", _get_torch_dtype)
+    loading_mod.load_component_override(base, "vae", override)
+    assert captured["wanted"] == "bf16", (
+        "override must inherit the base composition's compute dtype, "
+        "never its own on-disk fp32"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ctx.adjustments: the public read side
+# ---------------------------------------------------------------------------
+
+
+def test_ctx_adjustments_is_public_and_immutable() -> None:
+    ctx: RequestContext[Any] = RequestContext(
+        request_id="t", local_output_dir=".", models={})
+    assert len(ctx.adjustments) == 0
+    ctx.clamp("guidance_scale", 15.0, hi=10.0, reason="model maximum")
+    rows = ctx.adjustments
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["field"] == "guidance_scale"
+    assert row["requested"] == "15.0" and row["applied"] == "10.0"
+    with pytest.raises(AttributeError):
+        rows.append({})  # noqa: B038 — proves immutability

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.63.0"
+version = "0.64.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## 0.64.0 promotion train

P0 for the sdxl multi-checkpoint stress test (ie#546 canary measured the regression live on 0.61.0).

### pgw#654 warm-tax fix
- Warm RUNS are contract-keyed (class + per-slot lane facts + component overrides — never the checkpoint ref). Plan executes once per contract per process; each further checkpoint instance runs ONE clamped verification job. Swap cost = transfer + VRAM load (~74s measured), never a ~9-min warm re-run; the ~30-min eager first boot collapses too.
- Eager lanes (nothing armed/minting) run one shape representative per (function, guidance class) instead of the class x bucket cross-product; numeric shape axes keep their max-area bucket.
- Synthesized warm payloads clamp step fields to their declared floor (Meta ge/gt honored).
- Inheritance refused while a self-mint capture is pending or an armed cell is unproven in-process; verify-mode proof inherits full-plan attribution (mandatory-lane completeness preserved).
- New pod-side `benchmarks/swap_latency.py` (component-first swap by content address, demote/promote, H2D copy-stream overlap; refuses off-pod).

### Also riding
- pgw#647 gap #2: `load_component_override` inherits the base composition's compute dtype (fp8 base -> bf16); unblocks the VAE-override deploy path.
- `ctx.adjustments` public immutable ledger view.
- gw#665: conversion subprocesses bounded by output silence, not a 2h wall.
- gw#666 (BREAKING): `boot_timeout_s` deleted -> `stall_window_s` liveness; ie#558 migration note in CHANGELOG (both qwen3.6 endpoints).

### Verification
- Local: 926 passed / 5 skipped / 1 xfail; mypy clean (144 files); ruff clean.
- Regression rows: `tests/test_warm_tax_pgw654.py` — N instances of one family through the real `ensure_setup`: plan runs once (2 eager runs, steps clamped), 2nd/3rd instance cost exactly 1 verification run each.
- Release branch == chaos content (zero diff vs origin/chaos).

CI will be triggered manually on this head (one run, per spend policy).