### PR TITLE
release 0.66.0 — pgw#672: minted cell serves itself; compiled-lane failures degrade to eager, never kill the worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.66.0 (2026-07-25) — pgw#672: the minted cell serves itself; broken compiled lanes degrade, never die
+
+Live defect closed (ie#546 burst rerun #2, 0.64.0, L4): a worker minted and
+armed its ck2 cell, then failed its own finalize with
+`CompiledLaneUnavailableError: ... did not serve their own warmup graph
+(warmups=18, calls=18, cache_hits=0, cache_misses=0, compile_seconds=0.0)`
+-> cell quarantined -> both functions disabled -> pod retired -> the
+replacement re-minted the SAME key. 5 cycles, 4 dead workers, 6/36 requests
+served. Root cause: dynamo's in-memory code cache (keyed on the
+class-shared `__code__`; torch 2.13 inlined-module guards match any
+same-class instance) serves the proof warmup of a LATER same-family arm in
+a warm process — the pending capture stays empty (`finish_fleet_mint:
+captured nothing`), and warm re-proofs of a published cell read 0 hits / 0
+misses past the pgw#637 escape.
+
+- **Honest proof windows** (`compile_cache.reset_target_code`): a scoped
+  per-code dynamo reset runs immediately before every proof window — the
+  foreground exclusive-GPU warmup, the pgw#671 background-mint seed, and
+  hot adoption (`arm_staged_artifact`) — so the warmup MUST go through the
+  real lookup path: a mint truly compiles into its capture, an adoption
+  truly HITS its seeded FX entries. Sibling-safe: the live cache root is
+  an additive union, so a sibling whose shared code is dropped re-traces
+  into an FX hit (seconds), never a recompile.
+- **In-process finalized-mint reuse** (`fleet_cells._FINALIZED`): a cell
+  key this process already minted + folded re-arms `cache_ready` from the
+  live root (proven by a real FX hit) instead of opening a doomed second
+  capture.
+- **Degrade, never die (Paul's doctrine; also pgw#673):** a failed
+  serve/finalize proof, a failed compiled call (sm120 `InductorError:
+  CantSplit` class), or a tripped runtime guard now DEGRADES the object to
+  explicit eager serving — mandatory (w8a8/w4a4) lanes included. The
+  compiled identity is revoked (serving_tier flips to `"eager"` on the
+  wire, th#1187 field), the confession rides the activity stream
+  (`Activity.note`), the functions STAY dispatchable, and the pod stays
+  up. `compile_cell_failed` self-disables and the
+  `all_declared_functions_disabled` retire no longer exist on these paths.
+- **In-process cell quarantine** (`record_cell_quarantined`, key-normalized
+  refs — also fixes the th#1166 exact-string false-negative class in the
+  proven-cell registry): a proof-failed identity is never re-selected or
+  re-minted by the same process, breaking the fail/re-mint churn loop.
+  Cross-worker (hub-side) quarantine visibility remains a tensorhub
+  follow-up.
+- Red-verified over the REAL `ensure_setup` + fleet_cells miss policy in
+  `tests/test_serve_finalize_pgw672.py`: the pre-fix tree reproduces the
+  exact live signature (`cache_hits=0, cache_misses=0,
+  compile_seconds=0.0` + empty capture); the fixed tree mints, hits, and
+  finalizes.
+
 ## 0.65.0 (2026-07-25) — eager-first boot: READY in ~2 min, the mint compiles in the background
 
 pgw#671 (worker half of th#1187, Paul's ruling): the startup ladder no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.65.0"
+version = "0.66.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -175,6 +175,16 @@ class Activity:
             updated_at_unix_ms=int(time.time() * 1000),
         ))
 
+    def note(self, detail: str) -> None:
+        """One RUNNING report carrying a typed detail (pgw#672: the
+        degrade-to-eager confession rides the activity stream so the hub
+        sees WHY a compiled lane is now serving eager — loud, never a
+        terminal state)."""
+        if self._done:
+            return
+        self._report(
+            pb.ActivityState.ACTIVITY_STATE_RUNNING, detail=detail[:2000])
+
     def completed(self) -> None:
         if not self._done:
             self._done = True
@@ -231,6 +241,15 @@ def current_phase(phase: str, step: int = 0, total: int = 0) -> None:
         act = _current
     if act is not None and not act._done:
         act.phase(phase, step, total)
+
+
+def current_note(detail: str) -> None:
+    """Attach a typed detail to the current activity (pgw#672 degrade
+    visibility); no-op when none is running."""
+    with _lock:
+        act = _current
+    if act is not None and not act._done:
+        act.note(detail)
 
 
 def _end(act: Activity) -> None:

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -112,6 +112,10 @@ _LOCK_TYPE = type(threading.Lock())
 # object's hit certify another's silence, which gw#603/gw#611 forbid.
 _PROVEN_CELLS_LOCK = threading.Lock()
 _PROVEN_CELLS: set[str] = set()
+# pgw#672: cells whose serve/finalize proof FAILED in this process. Consulted
+# at selection and self-mint arm time so one boot never loops adopt-fail /
+# mint-fail on the identical identity (the L4 churn loop's worker half).
+_QUARANTINED_CELLS: set[str] = set()
 # Live armed pipelines (weakly held): the disproof path must never
 # ``torch._dynamo.reset()`` globally while a HEALTHY sibling's compiled
 # code is live — the global reset killed the first checkpoint's proven
@@ -119,18 +123,55 @@ _PROVEN_CELLS: set[str] = set()
 _ARMED_PIPELINES: Optional["weakref.WeakSet[Any]"] = None
 
 
-def record_cell_proven(ref: str) -> None:
-    """Mark one cell identity as served-and-proven in this process."""
+def _cell_ref_identity(ref: str) -> str:
+    """Process-registry identity for one cell ref (pgw#672 / th#1166).
+
+    The SAME cell can be named in two forms — the mint path's
+    ``system_repo(family)#<key>`` vs the store's delivered ref (tag/digest
+    decorated). Exact-string matching between those forms manufactured
+    false negatives in the pgw#637 escape. A key-flavored ref collapses to
+    its (family, key); anything else keeps its literal string."""
     ref = str(ref or "").strip()
     if not ref:
+        return ""
+    family, flavor = parse_cell_ref(ref)
+    if family and flavor:
+        from . import cell_key
+
+        if cell_key.is_key(flavor):
+            return f"{family}#{flavor}"
+    return ref
+
+
+def record_cell_proven(ref: str) -> None:
+    """Mark one cell identity as served-and-proven in this process."""
+    identity = _cell_ref_identity(ref)
+    if not identity:
         return
     with _PROVEN_CELLS_LOCK:
-        _PROVEN_CELLS.add(ref)
+        _PROVEN_CELLS.add(identity)
 
 
 def cell_proven_in_process(ref: str) -> bool:
+    identity = _cell_ref_identity(ref)
     with _PROVEN_CELLS_LOCK:
-        return str(ref or "").strip() in _PROVEN_CELLS
+        return bool(identity) and identity in _PROVEN_CELLS
+
+
+def record_cell_quarantined(ref: str) -> None:
+    """Mark one cell identity as proof-failed in this process (pgw#672)."""
+    identity = _cell_ref_identity(ref)
+    if not identity:
+        return
+    with _PROVEN_CELLS_LOCK:
+        _QUARANTINED_CELLS.add(identity)
+        _PROVEN_CELLS.discard(identity)
+
+
+def cell_quarantined_in_process(ref: str) -> bool:
+    identity = _cell_ref_identity(ref)
+    with _PROVEN_CELLS_LOCK:
+        return bool(identity) and identity in _QUARANTINED_CELLS
 
 
 def _armed_pipelines() -> "weakref.WeakSet[Any]":
@@ -200,6 +241,76 @@ def has_inmemory_compiled_code(pipeline: Any) -> bool:
             if _has_entries(getattr(type(child), "forward", None)):
                 return True
     return False
+
+
+def reset_target_code(pipeline: Any) -> int:
+    """Drop dynamo's in-memory compiled code for ``pipeline``'s armed compile
+    targets (pgw#672 root-cause fix, honesty half).
+
+    Dynamo keys its code cache on the target's class-shared ``__code__``, so
+    in a WARM process a later arm's proof warmup is served straight from a
+    sibling's resident compiled code with ZERO FX/AOT counter movement —
+    a pending self-mint then captures nothing (``finish_fleet_mint:
+    captured nothing``) and a seeded adoption proves nothing (hits=0,
+    misses=0), the exact ``warmups=N, calls=N, cache_hits=0,
+    cache_misses=0`` live loop. Calling this immediately before a proof
+    window forces the warmup through the real lookup path: a mint truly
+    compiles into its capture dir, an adoption truly hits its seeded FX
+    entries.
+
+    Sibling safety: the live cache root is an ADDITIVE union
+    (:func:`_merge_staged_cache`), so a healthy sibling whose in-memory
+    code this reset also drops (shared ``__code__``) re-traces into an FX
+    cache HIT on its next call — seconds, never a recompile. Callers run
+    inside the exclusive-GPU proof window or an idle adopt, so no compiled
+    frame is mid-flight during the reset.
+
+    Returns the number of code objects reset (0 when dynamo/torch is
+    unavailable or nothing is armed — a fresh process is a no-op).
+    """
+    marker = getattr(pipeline, _MARKER_ATTR, None)
+    if not marker:
+        return 0
+    try:
+        import torch._dynamo
+    except Exception:
+        return 0
+    codes: list[Any] = []
+    for _owner, _attr, fn in marker.get("originals") or ():
+        code = getattr(getattr(fn, "__func__", fn), "__code__", None)
+        if code is not None:
+            codes.append(code)
+    for mod in marker.get("regional_mods") or ():
+        try:
+            children = list(mod.modules())
+        except Exception:
+            logger.warning(
+                "compile-cache: could not enumerate regional submodules of %s "
+                "for the proof-window code reset", type(mod).__name__,
+                exc_info=True)
+            continue
+        for child in children:
+            fwd = getattr(type(child), "forward", None)
+            code = getattr(getattr(fwd, "__func__", fwd), "__code__", None)
+            if code is not None:
+                codes.append(code)
+    reset = 0
+    for code in dict.fromkeys(codes):
+        try:
+            torch._dynamo.reset_code(code)
+            reset += 1
+        except Exception:
+            # pgw#657: a silent skip here is indistinguishable from "no stale
+            # in-memory code existed" — say it, the proof may be dishonest.
+            logger.warning(
+                "compile-cache: dynamo reset_code failed for %r — the proof "
+                "warmup may be served from stale in-memory compiled code",
+                code, exc_info=True)
+    if reset:
+        logger.info(
+            "compile-cache: dropped in-memory compiled code for %d target "
+            "code object(s) ahead of the proof window (pgw#672)", reset)
+    return reset
 
 
 # ---------------------------------------------------------------------------
@@ -1724,8 +1835,6 @@ def _guarded(
         if state["revocation_error"]:
             raise CompiledLaneUnavailableError(state["revocation_error"])
         if state["failed"]:
-            if fail_closed:
-                raise CompiledLaneUnavailableError(state["detail"])
             return original(*args, **kwargs)
         # pgw#622: a novel input signature serves EAGER immediately while a
         # background thread warms the compiled path, then hot-swaps.
@@ -1742,21 +1851,26 @@ def _guarded(
             if router is not None:
                 router.mark_warm(sig)
             return result
-        except Exception as exc:  # noqa: BLE001 — optional lanes may use eager
+        except Exception as exc:  # noqa: BLE001 — every lane degrades to eager
             state["failed"] = True
             state["detail"] = (
                 f"compiled {'W8A8 ' if fail_closed else ''}target {label} failed: "
                 f"{type(exc).__name__}: {exc}"
             )
-            # Revoke scheduler-visible compiled proof synchronously before
-            # either the optional eager fallback or mandatory W8A8 error.
+            # Revoke scheduler-visible compiled proof synchronously before the
+            # eager fallback: the tier flips to explicit eager on the wire.
             revoke(state["detail"])
-            if fail_closed:
-                logger.error("compile-cache: %s", state["detail"])
-                raise CompiledLaneUnavailableError(state["detail"]) from exc
-            logger.warning(
-                "compile-cache: compiled %s failed (%s: %s); eager for the rest "
-                "of this process", label, type(exc).__name__, exc,
+            # pgw#672/pgw#673 posture: a broken optimization must never kill a
+            # serving worker. Mandatory lanes used to raise here (and the
+            # setup/dispatch paths then disabled every declared function —
+            # sm120 CantSplit retired the pod for $0.25 of nothing). They now
+            # degrade like every other lane, LOUDLY: the revocation above is
+            # the wire-visible tier flip, never silent eager (gw#586).
+            log = logger.error if fail_closed else logger.warning
+            log(
+                "compile-cache: compiled %s failed (%s: %s); serving eager for "
+                "the rest of this process%s", label, type(exc).__name__, exc,
+                " (mandatory lane DEGRADED, pgw#672)" if fail_closed else "",
             )
             return original(*args, **kwargs)
 
@@ -1825,7 +1939,7 @@ def _guarded_regional(
                 result = original(*args, **kwargs)
                 record_success(before)
                 return result
-            except Exception as exc:  # noqa: BLE001 — optional lanes may use eager
+            except Exception as exc:  # noqa: BLE001 — every lane degrades to eager
                 state["failed"] = True
                 state["detail"] = (
                     f"regional compiled {'W8A8 ' if fail_closed else ''}"
@@ -1850,15 +1964,17 @@ def _guarded_regional(
                         raise CompiledLaneUnavailableError(
                             state["revocation_error"]
                         ) from callback_exc
-                if fail_closed:
-                    logger.error("compile-cache: %s", state["detail"])
-                    raise CompiledLaneUnavailableError(state["detail"]) from exc
-                logger.warning(
-                    "compile-cache: regional-compiled %s failed (%s: %s); eager "
-                    "for the rest of this process", label, type(exc).__name__, exc,
+                # pgw#672/pgw#673 posture: mandatory lanes degrade to explicit
+                # eager (revocation above flips the wire tier) instead of
+                # raising — a broken optimization never kills serving.
+                log = logger.error if fail_closed else logger.warning
+                log(
+                    "compile-cache: regional-compiled %s failed (%s: %s); "
+                    "eager for the rest of this process%s",
+                    label, type(exc).__name__, exc,
+                    " (mandatory lane DEGRADED, pgw#672)" if fail_closed
+                    else "",
                 )
-        if fail_closed:
-            raise CompiledLaneUnavailableError(state["detail"])
         return original(*args, **kwargs)
 
     return wrapper
@@ -2185,6 +2301,11 @@ def arm_staged_artifact(
             except Exception:
                 unwrap(pipeline)
                 raise
+            # pgw#672: hot adoption runs idle-only; drop stale in-memory
+            # compiled code so the adoption's proof warmup consults the
+            # just-seeded FX entries (a real hit) instead of being served
+            # counter-silently by a prior arm's resident code.
+            reset_target_code(pipeline)
             return meta
     finally:
         staged.close()
@@ -2885,6 +3006,11 @@ __all__ = [
     "prepare",
     "resolve_pipeline_class",
     "runtime_key",
+    "record_cell_proven",
+    "record_cell_quarantined",
+    "cell_proven_in_process",
+    "cell_quarantined_in_process",
+    "reset_target_code",
     "seed_artifact",
     "seed_env",
     "set_guard_failure_callback",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3043,7 +3043,11 @@ class Executor:
 
         The target remains addressable with an empty active identity so the
         causal failure can be correlated regardless of event/StateDelta order.
-        A mandatory W8A8 object cannot serve eager; its next setup reloads it.
+        pgw#672: mandatory (w8a8/w4a4) lanes no longer disable their aliases
+        or force a reload here — the guard wrapper degrades the object to
+        explicit eager serving and this revocation flips the wire tier; the
+        failed identity is quarantined (per-target AND process-wide) so it is
+        never re-adopted or re-minted this boot.
         """
         if rec.compile_targets.get(target.incarnation_id) is not target:
             raise RuntimeError("compiled target is no longer live")
@@ -3060,18 +3064,12 @@ class Executor:
             target.active_compile_ref = ""
             target.active_compile_snapshot_digest = ""
             target.active_adoption_operation_id = ""
-            mandatory_quant = target.pipeline_weight_lane.startswith(
-                _MANDATORY_LANES)
-            if mandatory_quant:
-                # Keep the same incarnation visible with an empty active
-                # identity until declarative reconciliation replaces it.
-                # RequiredCompileExecution then fails closed locally while
-                # Tensorhub can correlate the causal FAILED to this row.
-                rec.stale = True
-        if mandatory_quant:
-            self._mark_compile_target_unavailable(rec, target, detail)
+        from . import compile_cache
+
+        compile_cache.record_cell_quarantined(failed_ref)
         logger.warning(
-            "compile target %s runtime guard tripped; compiled proof revoked: %s",
+            "compile target %s runtime guard tripped; compiled proof revoked, "
+            "serving degrades to explicit eager: %s",
             target.incarnation_id,
             detail,
         )
@@ -3342,13 +3340,16 @@ class Executor:
                 (mandatory_quant or candidate_requested_lane)
                 and not expected_names <= set(target.function_names)
             ):
-                # Every REQUIRED alias must be proven; a proven superset
+                # Every REQUIRED alias should be proven; a proven superset
                 # (custom-warmup attribution covering a non-required
-                # sibling) is not a defect.
-                raise compile_cache.CompiledLaneUnavailableError(
+                # sibling) is not a defect. pgw#672: an unproven required
+                # alias now serves explicit eager (no compile attribution)
+                # instead of killing the whole setup.
+                logger.error(
                     "mandatory quantized-lane function proof incomplete "
-                    f"(expected={sorted(expected_names)!r} "
-                    f"proven={list(target.function_names)!r})"
+                    "(expected=%r proven=%r); unproven aliases serve "
+                    "explicit eager (pgw#672)",
+                    sorted(expected_names), list(target.function_names),
                 )
             if not target.function_names or not bindings_valid:
                 detail = (
@@ -3359,14 +3360,12 @@ class Executor:
                 logger.warning(
                     "compile target omitted for %s: %s", spec.name, detail,
                 )
-                if mandatory_quant or candidate_requested_lane:
-                    raise compile_cache.CompiledLaneUnavailableError(detail)
+                # pgw#672: mandatory lanes no longer raise here — the
+                # functions serve explicit eager instead of dying.
                 continue
             lane_error = compile_cache.compile_target_lane_error(
                 target.pipeline_weight_lane, target.lora_bucket)
             if lane_error:
-                if mandatory_quant or candidate_requested_lane:
-                    raise compile_cache.CompiledLaneUnavailableError(lane_error)
                 logger.warning(
                     "compile target omitted for %s: %s", spec.name, lane_error)
                 continue
@@ -3388,12 +3387,17 @@ class Executor:
                 )
                 continue
             if mandatory_quant and not active_ref:
-                # A quantized-lane object without a proven exact cell is not
-                # a READY serving target. The loader normally raises earlier;
-                # keep this final wire-state invariant fail closed too.
-                raise compile_cache.CompiledLaneUnavailableError(
-                    f"{target_quant_lane.upper()} compile target for "
-                    f"{spec.name!r} has no proven active Forge artifact"
+                # pgw#672: a quantized-lane object without a proven exact
+                # cell used to fail closed here. It now registers as an
+                # ADDRESSABLE, active-less target — serving_tier projects
+                # "eager" for its aliases and the hub sees the degrade; the
+                # incarnation stays adoptable so a later armed cell can
+                # restore the compiled tier without a reload.
+                logger.error(
+                    "%s compile target for %r has no proven active Forge "
+                    "artifact; registering active-less — its aliases serve "
+                    "explicit eager (pgw#672)",
+                    target_quant_lane.upper(), spec.name,
                 )
             with target.state_lock:
                 target.active_compile_ref = active_ref
@@ -3404,15 +3408,10 @@ class Executor:
             if active_ref and not self._bind_compile_guard(rec, target):
                 # Production wrappers always expose one of the two guard
                 # signals. A hand-built/custom wrapper without revocation
-                # cannot be advertised as compiled. W8A8 remains fail-closed.
+                # cannot be advertised as compiled (pgw#672: eager, loudly).
                 with target.state_lock:
                     target.active_compile_ref = ""
                     target.active_compile_snapshot_digest = ""
-                if mandatory_quant:
-                    raise compile_cache.CompiledLaneUnavailableError(
-                        f"{target_quant_lane.upper()} compile target for "
-                        f"{spec.name!r} has no runtime guard revocation signal"
-                    )
                 logger.warning(
                     "compile target %s has no runtime guard revocation signal; "
                     "advertising eager", incarnation_id,
@@ -3432,10 +3431,17 @@ class Executor:
                         "hot-swap: eager-while-compiling enabled for %s",
                         spec.name)
         if requested_lane and not rec.compile_targets:
-            raise compile_cache.CompiledLaneUnavailableError(
-                f"{requested_lane.upper()} setup for {spec.name!r} produced "
-                "no addressable compile-capable pipeline target"
+            # pgw#672: degrade, never die — the loaded pipeline serves its
+            # functions eagerly; the missing compile target is loud on the
+            # wire (serving_tier=eager) and in the activity stream.
+            logger.error(
+                "%s setup for %r produced no addressable compile-capable "
+                "pipeline target; serving explicit eager (pgw#672)",
+                requested_lane.upper(), spec.name,
             )
+            activity_mod.current_note(
+                f"{requested_lane} lane serving eager: no addressable "
+                "compile target survived the proof")
 
     def compile_targets(self) -> List[pb.CompileTarget]:
         """Full-replace READY compile-target snapshot for StateDelta."""
@@ -5241,6 +5247,22 @@ class Executor:
                     intent_id,
                     resume_stage=warmup_stage,
                 ):
+                    # pgw#672 honesty: drop stale in-memory compiled code for
+                    # every object under proof so the warmup MUST go through
+                    # the real lookup path — a mint truly compiles into its
+                    # capture, an adoption truly hits its seeded FX entries.
+                    # In a warm process, dynamo's class-keyed code cache
+                    # otherwise serves these calls counter-silently (calls>0,
+                    # hits=0, misses=0) and the proof disproves a healthy
+                    # lane. No sibling GPU work runs inside this window, so
+                    # the per-code reset is race-free; siblings re-trace to
+                    # FX hits afterwards (additive live root).
+                    for _cand in inj.compile_objects:
+                        _sel = inj.active_compile_artifacts.get(
+                            id(_cand.pipeline))
+                        if _sel is not None and not trt_engine.is_engine_ref(
+                                _sel.ref):
+                            compile_cache.reset_target_code(_cand.pipeline)
                     warmed, function_proofs = await run_warmup()
             else:
                 warmed, function_proofs = await run_warmup()
@@ -5386,7 +5408,18 @@ class Executor:
                         compile_cache.unwrap(pipe)
                         if spec.lora_bucket:
                             compile_cache.drop_lora_lane(pipe)
-                        inj.active_compile_artifacts.pop(id(pipe), None)
+                        # pgw#672: quarantine the disproven identity in this
+                        # process so neither selection nor a fresh self-mint
+                        # arm loops on it this boot.
+                        failed_sel = inj.active_compile_artifacts.pop(
+                            id(pipe), None)
+                        if failed_sel is not None:
+                            compile_cache.record_cell_quarantined(
+                                failed_sel.ref)
+                        failed_pending = inj.pending_self_mints.get(id(pipe))
+                        if failed_pending is not None:
+                            compile_cache.record_cell_quarantined(
+                                str(failed_pending.ref))
                         self._abandon_pending_mint(inj, pipe)
                     # gw#611: `calls` discriminates the failure classes on the
                     # wire — calls=0 is an orphaned/never-invoked wrapper (or
@@ -5440,14 +5473,32 @@ class Executor:
                             # divergence intact.
                             detail += f"; fx forensics: {forensics[:1500]}"
                     if quant_lane:
+                        # pgw#672 posture change: a failed serve/finalize
+                        # proof on a mandatory (w8a8/w4a4) lane used to raise
+                        # here -> cell_quarantined -> every declared function
+                        # disabled -> pod retired -> the replacement re-mints
+                        # the same key (5 cycles / 4 dead workers on the L4
+                        # burst). A broken optimization must never kill a
+                        # serving worker: withhold the unproven publish,
+                        # quarantine the identity (above), and DEGRADE to
+                        # explicit eager — serving_tier flips on the wire and
+                        # the activity carries the confession; never silent
+                        # (gw#586).
                         if mint_by_id:
                             from . import fleet_cells as fleet_cells_mod
 
                             for pending in mint_by_id.values():
                                 fleet_cells_mod.withhold_self_mint_publish(
-                                    pending, f"boot failed closed ({detail})")
-                        raise compile_cache.CompiledLaneUnavailableError(detail)
-                    logger.warning("%s; serving eager", detail)
+                                    pending,
+                                    f"proof failed; degraded to eager "
+                                    f"({detail})")
+                        logger.error(
+                            "%s; mandatory lane DEGRADED to explicit eager "
+                            "serving (pgw#672)", detail)
+                        activity_mod.current_note(
+                            f"compiled lane degraded to eager: {detail}")
+                    else:
+                        logger.warning("%s; serving eager", detail)
                 if unexercised:
                     from .models.loading import pipeline_weight_lane
                 for candidate in unexercised:
@@ -6323,6 +6374,22 @@ class Executor:
             # iteration order never chooses the artifact, while the existing
             # measured plain-lane TRT preference remains intact.
             candidates = trt_candidates or inductor_candidates
+        # pgw#672: never re-select an identity whose serve/finalize proof
+        # already failed in this process — one boot must not loop
+        # adopt-fail on the same cell.
+        quarantined = [
+            ref for ref, _snap in candidates
+            if compile_cache.cell_quarantined_in_process(ref)
+        ]
+        if quarantined:
+            logger.warning(
+                "skipping %d compiled-cell candidate(s) quarantined by a "
+                "failed proof in this process: %s (pgw#672)",
+                len(quarantined), ", ".join(sorted(quarantined)))
+            candidates = [
+                (ref, snap) for ref, snap in candidates
+                if ref not in set(quarantined)
+            ]
         candidates = sorted(candidates, key=lambda item: item[0])
         if want_lane and not candidates:
             # gw#587: the fail-closed cell WAIT is retired. A mandatory-lane
@@ -7089,6 +7156,13 @@ class Executor:
             if bg.abandon.is_set():
                 raise _MintAbandoned()
 
+        # pgw#672 honesty: a warm process may hold resident compiled code
+        # for these class-shared targets from an earlier same-family arm —
+        # the router's warm compiles would then capture NOTHING and the
+        # finalize below would pack an empty cell. Reset so the background
+        # compiles really trace into the pending capture.
+        for pipe in bg.pipes.values():
+            compile_cache.reset_target_code(pipe)
         exec_before = {
             pid: compile_cache.execution_count(pipe)
             for pid, pipe in bg.pipes.items()
@@ -8694,24 +8768,16 @@ class Executor:
             from .compile_cache import CompiledLaneUnavailableError
 
             if isinstance(exc, CompiledLaneUnavailableError):
-                # A seeded W8A8 graph failing at call time is a genuine lane
-                # failure, not an invitation to retry eager under the same
-                # advertised function. Remove this worker/function pair from
-                # dispatch until a fresh setup with a compatible cell.
-                found = None
-                if run.HasField("required_compile"):
-                    found = self._compile_target(
-                        run.required_compile.target_incarnation_id)
-                if found is not None and spec.name in found[1].function_names:
-                    self._mark_compile_target_unavailable(
-                        found[0], found[1], str(exc))
-                elif spec.name not in self.unavailable:
-                    # Defensive path for a custom compiled lane that raised
-                    # without a live protocol target. It is intentionally not
-                    # recovery-owned: no exact fresh target can prove it safe.
-                    self.unavailable[spec.name] = (
-                        "compile_cell_failed", _sanitize(str(exc)), {},
-                    )
+                # pgw#672: a compiled lane failing at call time fails THIS
+                # request, never the function — the guard wrapper has already
+                # degraded the object to explicit eager and revoked the
+                # compiled identity (tier flips on the wire). Disabling the
+                # function here was half of the quarantine->disable->die loop.
+                logger.error(
+                    "compiled lane unavailable during %s; request failed, "
+                    "function continues at eager tier: %s",
+                    spec.name, exc,
+                )
                 self._on_state_change()
             status, msg = _map_exception(exc)
             if status == pb.JOB_STATUS_FATAL:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -166,6 +166,17 @@ _COMPLETE_TIMEOUT_S = 30
 # live at a time; same-key sibling pipes join the existing capture.
 _PENDING_LOCK = threading.Lock()
 _PENDING: Dict[str, "PendingSelfMint"] = {}
+# pgw#672: cells this process already finalized (packed + folded into the
+# live cache root). A later same-key arm re-arms cache_ready from the folded
+# entries instead of opening a SECOND capture — which, with the first mint's
+# compiled code resident in dynamo's in-memory cache, would capture nothing
+# and disprove itself at finalize (the L4 churn loop).
+_FINALIZED: Dict[str, "SelfMint"] = {}
+
+
+def finalized_in_process(key: str) -> Optional["SelfMint"]:
+    with _PENDING_LOCK:
+        return _FINALIZED.get(str(key or "").strip())
 
 
 class CellPublishRefused(Exception):
@@ -411,6 +422,41 @@ def enable_compiled(
         return _fail_closed(
             pipe, f"self-mint key computation failed: {exc}", selection_bug)
 
+    # pgw#672: consult the process ledgers BEFORE opening a capture.
+    key_ref = f"{cc.system_repo(family)}#{key}"
+    if cc.cell_quarantined_in_process(key_ref):
+        # This exact identity already failed its serve/finalize proof in
+        # this process — re-minting it is the churn loop, not recovery.
+        # DEGRADE (explicit eager, mandatory lanes included): a broken
+        # optimization must never kill a serving worker.
+        logger.error(
+            "fleet-cells: declining self-mint for %s key=%s — this identity "
+            "was quarantined by a failed proof in this process; serving "
+            "eager (pgw#672)", family, key)
+        if bucket:
+            cc.drop_lora_lane(pipe)
+        return ArmOutcome(armed=False, selection_bug=selection_bug)
+    finalized_prior = finalized_in_process(key)
+    if finalized_prior is not None:
+        # This process already minted, proved, and FOLDED this exact cell
+        # into the live cache root — re-arm cache_ready from those entries
+        # (the proof warmup then serves a real FX hit) instead of opening a
+        # doomed second capture the resident compiled code would starve.
+        try:
+            armed_ready = cc.apply(pipe, cfg, cache_ready=True)
+        except Exception as exc:  # noqa: BLE001 — fall back to a fresh mint
+            logger.warning(
+                "fleet-cells: re-arm from the in-process finalized cell "
+                "failed (%s); falling through to a fresh mint", exc)
+            armed_ready = False
+        if armed_ready:
+            logger.info(
+                "fleet-cells: re-armed %s from this process's finalized "
+                "cell (key=%s) — no second capture (pgw#672)", family, key)
+            return ArmOutcome(
+                armed=True, self_mint=finalized_prior,
+                selection_bug=selection_bug)
+
     # gw#587 CORRECT FIX (the defect this replaces: the old design minted
     # via a separate producer-style ``mint_artifact``/``_warm_call`` BEFORE
     # the real serving warmup ran — a synthetic single-stage call that can
@@ -537,6 +583,10 @@ def finalize_self_mint(
     state["minted"] = minted
     state["meta"] = dict(meta)
     _unregister(pending)
+    with _PENDING_LOCK:
+        # pgw#672: remember the finalized identity so a later same-key arm
+        # in this process reuses the folded cell instead of re-minting.
+        _FINALIZED[key] = minted
     logger.info(
         "fleet-cells: self-mint proof passed for %s (key=%s, %.1f MB) — "
         "serving compiled; publish decided after sibling coverage is known",
@@ -732,6 +782,7 @@ __all__ = [
     "abandon_self_mint",
     "enable_compiled",
     "finalize_self_mint",
+    "finalized_in_process",
     "publish_self_mint",
     "republish_after_shape_warm",
     "withhold_self_mint_publish",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,22 @@ def _fresh_delivered_seed_flag():
     _cc._DELIVERED_SEEDED = False
 
 
+@pytest.fixture(autouse=True)
+def _fresh_cell_ledgers():
+    """pgw#672 process ledgers (quarantined identities, in-process finalized
+    mints) are process-lifetime in production; clear them between tests so a
+    proof failure in one test cannot poison another's arm/selection."""
+    from gen_worker import compile_cache as _cc
+    from gen_worker import fleet_cells as _fc
+
+    def _clear() -> None:
+        with _cc._PROVEN_CELLS_LOCK:
+            getattr(_cc, "_QUARANTINED_CELLS", set()).clear()
+        with _fc._PENDING_LOCK:
+            getattr(_fc, "_FINALIZED", {}).clear()
+
+    _clear()
+    yield
+    _clear()
+
+

--- a/tests/test_boot_compile_deferral_gw584.py
+++ b/tests/test_boot_compile_deferral_gw584.py
@@ -329,12 +329,14 @@ def test_hub_delivery_selects_delivered_cell(tmp_path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_w8a8_setup_without_cell_fails_loud(tmp_path, monkeypatch) -> None:
-    """gw#587 moved the refusal, not the invariant: a mandatory-lane miss no
-    longer fail-closes BEFORE load (the worker proceeds to self-mint, which
-    requires the loaded pipeline — tenant setup necessarily runs), but an
-    armed compile object that cannot PROVE itself on the warmup still
-    refuses typed and loud — never a silent eager serve."""
+def test_w8a8_setup_without_cell_degrades_to_explicit_eager(
+    tmp_path, monkeypatch,
+) -> None:
+    """gw#587 moved the refusal to the proof gate; pgw#672 changed its
+    POSTURE: an armed compile object that cannot PROVE itself on the warmup
+    no longer kills the boot — it degrades to EXPLICIT eager (the tier is
+    on the wire, never silent), the function stays dispatchable, and no
+    compiled identity is ever advertised."""
     setup_calls: List[str] = []
     ex, _sent, _enables = _harness(tmp_path, monkeypatch,
                                    [_compile_spec(setup_calls)])
@@ -345,13 +347,17 @@ def test_w8a8_setup_without_cell_fails_loud(tmp_path, monkeypatch) -> None:
         function_name="generate",
         models=[pb.ModelBinding(slot="pipeline", ref=RESOLVED_REF)],
     )
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="W8A8"):
-        asyncio.run(ex.ensure_desired_instance(
-            desired, {RESOLVED_REF: _snapshot("aa" * 32)}))
-    # The load/setup ran (the self-mint's precondition); the typed refusal
-    # fired at the proof gate, so nothing was ever advertised.
+    asyncio.run(ex.ensure_desired_instance(
+        desired, {RESOLVED_REF: _snapshot("aa" * 32)}))
+    # The load/setup ran (the self-mint's precondition); the unprovable
+    # lane degraded at the proof gate: dispatchable at eager tier, nothing
+    # advertised as compiled.
     assert len(setup_calls) == 1
-    assert "generate" not in ex.available_functions()
+    assert "generate" in ex.available_functions()
+    assert ex.serving_tiers()["generate"] == "eager"
+    assert all(
+        not t.active_compile_ref for t in ex.compile_targets()
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import tarfile
 import threading
@@ -230,8 +231,13 @@ def test_execution_contract_digest_covers_every_runtime_graph_axis():
     assert cc.execution_contract_digest(_Pipe(low_vram="model_offload"), base_cfg) != base
 
 
-def test_w8a8_guard_never_retries_eager():
-    calls = {"eager": 0}
+def test_w8a8_guard_degrades_to_eager_and_revokes(caplog):
+    """pgw#672/pgw#673: a failing mandatory-lane compiled call DEGRADES to
+    explicit eager (revocation flips the wire tier) instead of raising —
+    a broken optimization must never kill a serving worker. The old
+    behavior (raise, function disabled, pod retired) produced the sm120
+    CantSplit $0.25-for-nothing pods and the L4 finalize churn loop."""
+    calls = {"eager": 0, "revoked": []}
 
     def eager(value):
         calls["eager"] += 1
@@ -240,12 +246,17 @@ def test_w8a8_guard_never_retries_eager():
     def broken(_value):
         raise RuntimeError("graph miss")
 
-    guarded = cc._guarded(eager, broken, "transformer", fail_closed=True)
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="graph miss"):
-        guarded(1)
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="graph miss"):
-        guarded(2)
-    assert calls["eager"] == 0
+    signal = {"callback": calls["revoked"].append}
+    guarded = cc._guarded(
+        eager, broken, "transformer", fail_closed=True, failure_signal=signal)
+    with caplog.at_level(logging.ERROR, logger="gen_worker.compile_cache"):
+        assert guarded(1) == 1
+    assert guarded(2) == 2
+    assert calls["eager"] == 2
+    # Revoked exactly once, loudly, before the first eager fallback.
+    assert len(calls["revoked"]) == 1
+    assert "graph miss" in calls["revoked"][0]
+    assert any("DEGRADED" in r.message for r in caplog.records)
 
 
 def test_guard_revocation_failure_latches_fail_closed_for_optional_lane():

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -6,6 +6,7 @@ a compile-cache snapshot on RunJob.snapshots reaches compile_cache.enable."""
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 from dataclasses import replace
 from pathlib import Path
@@ -1399,15 +1400,16 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
     monkeypatch.setattr(ex, "_enable_compiled", _minting_enable)
     _NoProofEndpoint.setups = _NoProofEndpoint.warmups = _NoProofEndpoint.runs = 0
 
-    with pytest.raises(
-        cc.CompiledLaneUnavailableError,
-        match="did not serve their own warmup graph",
-    ):
-        asyncio.run(ex.ensure_setup(
-            spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
+    # pgw#672: the disproven mandatory-lane mint DEGRADES to explicit eager
+    # instead of failing the boot closed — the function stays dispatchable,
+    # nothing is advertised, and the identity is quarantined in-process.
+    asyncio.run(ex.ensure_setup(
+        spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
     assert _NoProofEndpoint.warmups == 1, "the proof must have actually run"
     assert ex.compile_targets() == [], "an unproven self-mint must not advertise"
-    assert ex.unavailable[spec.name][0] == "compile_cell_failed"
+    assert spec.name not in ex.unavailable
+    assert ex.serving_tiers() == {spec.name: "eager"}
+    assert cc.cell_quarantined_in_process(f"root/family-{FAMILY}#{mint_key}")
 
 
 def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
@@ -1632,15 +1634,15 @@ def test_pending_self_mint_unproven_fails_closed_and_never_publishes(
             p, cfg, ex.store._cache_dir, artifact, publisher=pub))
     _UnprovenEndpoint.setups = _UnprovenEndpoint.warmups = 0
 
-    with pytest.raises(
-        cc.CompiledLaneUnavailableError,
-        match="did not serve their own warmup graph",
-    ):
-        asyncio.run(ex.ensure_setup(
-            spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
+    # pgw#672: an unproven mandatory-lane self-mint DEGRADES to explicit
+    # eager — the boot completes, nothing is advertised, nothing publishes,
+    # and the function stays dispatchable.
+    asyncio.run(ex.ensure_setup(
+        spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
     assert _UnprovenEndpoint.warmups == 1, "the proof must have actually run"
     assert ex.compile_targets() == [], "an unproven self-mint must not advertise"
-    assert ex.unavailable[spec.name][0] == "compile_cell_failed"
+    assert spec.name not in ex.unavailable
+    assert ex.serving_tiers() == {spec.name: "eager"}
     # The capture was abandoned, never packed.
     mint_root = captured["dir"].parent
     assert not mint_root.exists(), "an uncertified capture must be discarded"
@@ -1856,7 +1858,10 @@ def test_flux_base_w8a8_boot_proves_generate_and_edit_aliases(
     assert target.active_compile_ref == cell_ref
 
     # Replay binds a real operation identity to the boot-attached active cell,
-    # then a runtime guard failure disables every alias on the exact target.
+    # then a runtime guard failure revokes the compiled identity — pgw#672:
+    # the aliases STAY dispatchable at explicit eager tier (a broken
+    # optimization never kills a serving worker); the identity is
+    # quarantined in-process so it is never re-adopted this boot.
     _adopt(
         ex,
         ref=cell_ref,
@@ -1881,12 +1886,14 @@ def test_flux_base_w8a8_boot_proves_generate_and_edit_aliases(
         await asyncio.sleep(0)
 
     asyncio.run(_trip())
-    assert rec.stale is True
-    assert set(ex.unavailable) >= {"edit", "generate"}
-    assert all(
-        ex.unavailable[name][0] == "compile_cell_failed"
-        for name in ("edit", "generate")
-    )
+    # pgw#672: no reload churn, no function disable — serving continues.
+    assert rec.stale is False
+    assert "edit" not in ex.unavailable
+    assert "generate" not in ex.unavailable
+    (tripped,) = ex.compile_targets()
+    assert tripped.active_compile_ref == ""
+    assert ex.serving_tiers() == {"edit": "eager", "generate": "eager"}
+    assert cc.cell_quarantined_in_process(cell_ref)
     failed = _events(sent, pb.MODEL_STATE_FAILED)
     assert len(failed) == 1
     assert failed[0].error == "adopt_failed:runtime_guard"
@@ -1895,28 +1902,9 @@ def test_flux_base_w8a8_boot_proves_generate_and_edit_aliases(
     lifecycle = Lifecycle(
         SimpleNamespace(worker_jwt="", worker_id="worker"), ex)
     failed_delta = lifecycle._state_delta()
-    assert "edit" not in failed_delta.available_functions
-    assert "generate" not in failed_delta.available_functions
-
-    # Declarative reconciliation replaces the stale incarnation. Only after
-    # the new exact active target proves both aliases are its owned marks
-    # cleared; unrelated unavailable reasons would remain untouched.
-    asyncio.run(ex.ensure_setup(generate, snapshots))
-    (recovered,) = ex.compile_targets()
-    assert recovered.incarnation_id != target.incarnation_id
-    assert recovered.active_compile_ref == cell_ref
-    assert list(recovered.function_names) == ["edit", "generate"]
-    # pgw#654 warm-tax fix: the recovery re-setup shares the boot's warm
-    # contract and re-arms a cell already proven in-process, so it runs ONE
-    # verification job (here: edit, the plan's first row) whose proof
-    # inherits full-plan attribution — function_names above show both
-    # aliases recovered. A broken re-arm still fails closed on that call.
-    assert calls == {"generate": 1, "edit": 2}
-    assert "edit" not in ex.unavailable
-    assert "generate" not in ex.unavailable
+    assert "edit" in failed_delta.available_functions
+    assert "generate" in failed_delta.available_functions
     assert ex.unavailable["unrelated-hardware-gate"][0] == "hardware_unmet"
-    recovered_delta = lifecycle._state_delta()
-    assert {"edit", "generate"}.issubset(recovered_delta.available_functions)
 
 
 @pytest.mark.parametrize(
@@ -2615,35 +2603,41 @@ def test_w8a8_unexercised_sibling_stays_armed_unproven(
     assert generate.name not in ex.unavailable
 
 
-def test_w8a8_exercised_miss_fails_closed_despite_unexercised_sibling(
-    tmp_path, monkeypatch,
+def test_w8a8_exercised_miss_degrades_despite_unexercised_sibling(
+    tmp_path, monkeypatch, caplog,
 ):
     """gw#595(b) keeps gw#586 shut: an EXERCISED object that misses its own
-    warmup graph disproves the cell and fails closed — the unexercised
-    sibling exemption never launders a genuine parity defect."""
+    warmup graph disproves the cell — the unexercised sibling exemption
+    never launders a genuine parity defect. pgw#672: the disproof now
+    degrades to explicit eager instead of killing the boot."""
     cls = _merged_lane_endpoint(
         lambda self: _record_fake_warm(self.t2i, hits=0, misses=2))
     specs = extract_specs(cls)
     (generate,) = specs
     ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
 
-    with pytest.raises(
-        cc.CompiledLaneUnavailableError,
-        match="did not serve their own warmup graph",
-    ) as excinfo:
+    # pgw#672: the disproven proof DEGRADES to explicit eager — setup
+    # completes, nothing is advertised, and the gw#608 self-discriminating
+    # counts (compile_seconds ~0 = crediting bug vs minutes = recompile)
+    # land in the loud degrade record instead of a fatal raise.
+    with caplog.at_level(logging.ERROR, logger="gen_worker.executor"):
         asyncio.run(ex.ensure_setup(generate, {
             wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
             wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
             cell_ref: pb.Snapshot(digest=DIGEST_A),
         }))
     assert ex.compile_targets() == []
-    # gw#608: the wire-visible detail must self-discriminate crediting bugs
-    # (~0s) from real recompiles (minutes) with zero pod-log access.
-    assert "compile_seconds=" in str(excinfo.value)
+    assert generate.name not in ex.unavailable
+    degrade = [
+        r for r in caplog.records
+        if "did not serve their own warmup graph" in r.getMessage()
+    ]
+    assert degrade and "compile_seconds=" in degrade[0].getMessage()
+    assert "DEGRADED" in degrade[0].getMessage()
 
 
 def test_store_served_failure_names_diverging_fx_key_component(
-    tmp_path, monkeypatch,
+    tmp_path, monkeypatch, caplog,
 ):
     """gw#608 forensics wiring: a store-served warmup-proof failure diffs the
     boot's freshly saved FX entries against the seeded cell's and puts the
@@ -2661,39 +2655,40 @@ def test_store_served_failure_names_diverging_fx_key_component(
                       "inductor_config[foo]: cell=cell-value != "
                       "boot=boot-value"))
 
-    with pytest.raises(
-        cc.CompiledLaneUnavailableError,
-        match="did not serve their own warmup graph",
-    ) as excinfo:
+    # pgw#672: the disproof degrades; the forensics ride the degrade record.
+    with caplog.at_level(logging.ERROR, logger="gen_worker.executor"):
         asyncio.run(ex.ensure_setup(generate, {
             wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
             wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
             cell_ref: pb.Snapshot(digest=DIGEST_A),
         }))
-    detail = str(excinfo.value)
+    assert generate.name not in ex.unavailable
+    (detail,) = [
+        r.getMessage() for r in caplog.records
+        if "did not serve their own warmup graph" in r.getMessage()
+    ]
     assert "fx forensics" in detail
     assert "inductor_config[foo]" in detail
     assert "cell=cell-value" in detail and "boot=boot-value" in detail
 
 
-def test_w8a8_all_objects_unexercised_fails_closed(tmp_path, monkeypatch):
+def test_w8a8_all_objects_unexercised_degrades_to_eager(tmp_path, monkeypatch):
     """gw#595(b): with ZERO proven objects the cell is entirely unverified —
-    a warmup that exercises nothing cannot arm anything."""
+    a warmup that exercises nothing cannot arm anything. pgw#672: the boot
+    completes at explicit eager instead of failing closed."""
     cls = _merged_lane_endpoint(lambda self: None)
     specs = extract_specs(cls)
     (generate,) = specs
     ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
 
-    with pytest.raises(
-        cc.CompiledLaneUnavailableError,
-        match="did not serve their own warmup graph",
-    ):
-        asyncio.run(ex.ensure_setup(generate, {
-            wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
-            wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
-            cell_ref: pb.Snapshot(digest=DIGEST_A),
-        }))
+    asyncio.run(ex.ensure_setup(generate, {
+        wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
+        wire_ref(generate.models["edit"]): pb.Snapshot(digest=DIGEST_B),
+        cell_ref: pb.Snapshot(digest=DIGEST_A),
+    }))
     assert ex.compile_targets() == []
+    assert generate.name not in ex.unavailable
+    assert ex.serving_tiers()[generate.name] == "eager"
 
 
 def test_production_w8a8_ignores_legacy_compile_environment_fallbacks(
@@ -2781,7 +2776,7 @@ def test_w8a8_binding_cannot_advertise_plain_materialized_pipeline(tmp_path):
         )
 
 
-def test_w8a8_setup_with_no_addressable_compile_object_fails(tmp_path, monkeypatch):
+def test_w8a8_setup_with_no_addressable_compile_object_serves_eager(tmp_path, monkeypatch):
     import gen_worker.executor as executor_mod
 
     artifact = _artifact(tmp_path)
@@ -2812,12 +2807,15 @@ def test_w8a8_setup_with_no_addressable_compile_object_fails(tmp_path, monkeypat
     )
     monkeypatch.setattr(ex, "_enable_compiled", _guarded_enable)
 
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="no addressable"):
-        asyncio.run(ex.ensure_setup(spec, {
-            model_ref: pb.Snapshot(digest=MODEL_DIGEST),
-            cell_ref: pb.Snapshot(digest=DIGEST_A),
-        }))
+    # pgw#672: no addressable compile target => the functions serve
+    # explicit eager; the boot never dies for a missing optimization.
+    asyncio.run(ex.ensure_setup(spec, {
+        model_ref: pb.Snapshot(digest=MODEL_DIGEST),
+        cell_ref: pb.Snapshot(digest=DIGEST_A),
+    }))
     assert ex.compile_targets() == []
+    assert spec.name not in ex.unavailable
+    assert ex.serving_tiers()[spec.name] == "eager"
 
 
 def test_desired_w8a8_cell_digest_and_ref_changes_vacate_then_rebuild(
@@ -3203,7 +3201,12 @@ def test_runtime_guard_revokes_state_emits_one_causal_failure_and_quarantines(
     assert revoked.incarnation_id == active_id
     assert revoked.active_compile_ref == ""
     assert revoked.active_compile_snapshot_digest == ""
-    assert rec.stale is True
+    # pgw#672: the record is NOT marked stale and the aliases stay
+    # dispatchable — the object serves explicit eager; the identity is
+    # quarantined per-target and process-wide.
+    assert rec.stale is False
+    assert spec.name not in ex.unavailable
+    assert cc.cell_quarantined_in_process(active_ref)
     failed = _events(sent, pb.MODEL_STATE_FAILED)
     assert len(failed) == 1
     assert failed[0].error == "adopt_failed:runtime_guard"

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -1,0 +1,433 @@
+"""pgw#672: the minted/attached ck2 compile object must serve its own warmup.
+
+Live signature this closes (ie#546 burst rerun #2, gen-worker 0.64.0, L4):
+a worker MINTS its cell (publish-intent 200, armed, obligation discharged),
+then fails its own finalize —
+
+    CompiledLaneUnavailableError: 1 attached compile object(s) did not serve
+    their own warmup graph (warmups=18, calls=18, cache_hits=0,
+    cache_misses=0, compile_seconds=0.0)
+
+Zero hits AND zero misses with calls>0 means the FX cache was never even
+consulted: dynamo's in-memory code cache (keyed on the class-shared
+``__code__``; torch 2.13 inlined-module guards match any same-class
+instance) served the warmup that a LATER same-family arm in the same warm
+process was supposed to compile/look up. The pending capture stays empty,
+finalize disproves it, the mandatory lane raised, both functions disabled,
+pod retired, replacement re-mints the same key — 5 cycles, 4 dead workers.
+
+These tests run the REAL executor ensure_setup codepath and the REAL
+fleet_cells miss policy (arm_self_mint -> begin_fleet_mint env transaction
+-> executor proof -> finalize_self_mint -> finish_fleet_mint pack), faking
+only the torch boundary: ``compile_cache.apply``'s torch.compile leaf is a
+simulator with dynamo-in-memory-code semantics, ``inductor_counters`` reads
+the simulator, and ``torch._dynamo.reset_code`` drops simulator entries.
+
+Fix under test (pgw#672):
+  (a) honesty — a scoped per-code dynamo reset before every proof window
+      forces the warmup through the real lookup path (mint: real capture;
+      re-arm of an in-process finalized cell: real FX HIT);
+  (b) finalize succeeds for the second same-family arm (its own graphs);
+  (c) posture — when a compiled lane genuinely cannot serve, the worker
+      DEGRADES to explicit eager (tier flips, loud) instead of
+      quarantine -> disable -> die (also pgw#673's sm120 CantSplit shape).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import msgspec
+import pytest
+
+import gen_worker.executor as executor_mod
+from gen_worker import Compile, cell_key as cell_key_mod
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells, hot_swap
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.executor import Executor
+from gen_worker.models import provision
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+FAMILY = "sdxl"
+MODEL_DIGEST = "blake3:" + "c" * 64
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _Denoiser:
+    def forward(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.transformer = _Denoiser()
+
+    @classmethod
+    def from_pretrained(cls, path: Any, **kwargs: Any) -> "_Pipe":
+        return cls()  # pragma: no cover - loader is patched
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries() -> Any:
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    armed = cc._armed_pipelines()
+    for pipe in list(armed):
+        armed.discard(pipe)
+    yield
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+
+
+class _Sim:
+    """Dynamo/inductor semantics at the torch boundary.
+
+    ``inmem`` is dynamo's in-memory code cache (keyed on the class-shared
+    ``__code__`` — every same-class pipeline instance shares it, exactly the
+    torch 2.13 mechanism). A call whose code is resident serves WITHOUT any
+    counter movement or capture write. Otherwise the FX cache dir named by
+    ``TORCHINDUCTOR_CACHE_DIR`` is consulted: an existing content-addressed
+    entry is a HIT, a missing one is a compile (entry written + MISS).
+    """
+
+    def __init__(self) -> None:
+        self.inmem: set[Any] = set()
+        self.counters: Dict[str, int] = {
+            "fxgraph_cache_hit": 0, "fxgraph_cache_miss": 0,
+            "aot_cache_hit": 0,
+        }
+        self.compiles: List[str] = []
+        self.raise_on_compile: Optional[Exception] = None
+
+    def compiled_call(self, code: Any, original: Any, label: str,
+                      args: tuple, kwargs: dict) -> Any:
+        if code in self.inmem:
+            return original(*args, **kwargs)  # in-memory serve: 0/0 counters
+        if self.raise_on_compile is not None:
+            raise self.raise_on_compile
+        graph = "g-" + hashlib.blake2s(
+            repr((label, args, sorted(kwargs))).encode()).hexdigest()[:16]
+        fx_dir = Path(os.environ["TORCHINDUCTOR_CACHE_DIR"]) / "fxgraph"
+        fx_dir.mkdir(parents=True, exist_ok=True)
+        entry = fx_dir / f"{graph}.bin"
+        if entry.exists():
+            self.counters["fxgraph_cache_hit"] += 1
+        else:
+            entry.write_bytes(b"graph")
+            self.counters["fxgraph_cache_miss"] += 1
+            self.compiles.append(graph)
+        self.inmem.add(code)
+        return original(*args, **kwargs)
+
+
+def _sim_apply_factory(sim: _Sim):
+    def _sim_apply(pipeline: Any, cfg: Any, *, cache_ready: bool,
+                   guard: bool = True, allow_cold: bool = False) -> bool:
+        if getattr(pipeline, cc._MARKER_ATTR, None) is not None:
+            return True
+        original = pipeline.transformer.forward
+        code = original.__func__.__code__
+        signal: Dict[str, Any] = {
+            "callback": None,
+            "lock": threading.Lock(),
+            "successful_calls": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "router": hot_swap.Router(fail_closed=True),
+        }
+
+        def compiled(*args: Any, **kwargs: Any) -> Any:
+            return sim.compiled_call(code, original, "transformer", args, kwargs)
+
+        setattr(pipeline, cc._MARKER_ATTR, {
+            "targets": ["transformer"],
+            "shapes": [tuple(s) for s in cfg.shapes],
+            "cache": bool(cache_ready),
+            "originals": [(pipeline.transformer, "forward", original)],
+            "regional_mods": [],
+            "failure_signal": signal,
+        })
+        pipeline.transformer.forward = cc._guarded(
+            original, compiled, "transformer",
+            fail_closed=True, failure_signal=signal)
+        cc._armed_pipelines().add(pipeline)
+        return True
+
+    return _sim_apply
+
+
+def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
+                      *, contract: str, regional: bool = False,
+                      image_digest: Optional[str] = None) -> Any:
+    digest = hashlib.blake2s(
+        f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
+    ).hexdigest()[:56]
+    return SimpleNamespace(digest="ck2-" + digest, axes={})
+
+
+def _endpoint_cls(shapes: tuple) -> type:
+    class _Ep:
+        pipes: List[_Pipe] = []
+        warmups = 0
+
+        def setup(self, pipeline: _Pipe) -> None:
+            self.pipeline = pipeline
+
+        def warmup(self) -> None:
+            type(self).warmups += 1
+            # The endpoint's own serving call — through the REAL guard
+            # wrapper installed by (sim) apply. One call per declared shape.
+            for shape in shapes:
+                self.pipeline.transformer.forward("warm", shape=tuple(shape))
+
+        def run(self, ctx: Any, payload: _In) -> _Out:
+            return _Out()
+
+    return _Ep
+
+
+def _spec(name: str, cls: type, shapes: tuple) -> EndpointSpec:
+    return EndpointSpec(
+        name=name, method=cls.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=cls, attr_name="run",
+        models={"pipeline": Hub("acme/sdxl-base", flavor="fp8-w8a8")},
+        compile=Compile(shapes=shapes, family=FAMILY, text_len=0),
+    )
+
+
+class _Rig:
+    """The REAL executor + REAL fleet_cells miss policy, torch leaves faked."""
+
+    def __init__(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+                 specs: List[EndpointSpec]) -> None:
+        self.sim = _Sim()
+        self.pipes: Dict[str, _Pipe] = {}
+        model_dir = tmp_path / "model"
+        model_dir.mkdir(exist_ok=True)
+
+        async def _send(_msg: pb.WorkerMessage) -> None:
+            return None
+
+        self.ex = Executor(specs, _send)
+        self.ex.store._cache_dir = tmp_path / "cas"
+
+        async def _download(ref: str, **kwargs: Any) -> Path:
+            return model_dir
+
+        def _load_slot(*args: Any, **kwargs: Any) -> Any:
+            pipe = _Pipe()
+            setattr(pipe, "_cozy_weight_lane", "w8a8")
+            self.pipes[f"pipe-{len(self.pipes)}"] = pipe
+            return provision.SlotLoad(obj=pipe, is_pipeline=True)
+
+        def _mandatory_miss(*a: Any, **k: Any) -> bool:
+            raise cc.CompiledLaneUnavailableError("no delivered cell")
+
+        monkeypatch.setattr(executor_mod, "ensure_local", _download)
+        monkeypatch.setattr(provision, "load_slot", _load_slot)
+        monkeypatch.setattr(provision, "enable_compiled", _mandatory_miss)
+        monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+        monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+        monkeypatch.setattr(cc, "apply", _sim_apply_factory(self.sim))
+        monkeypatch.setattr(
+            cc, "inductor_counters", lambda: dict(self.sim.counters))
+        monkeypatch.setattr(cell_key_mod, "compute", _fake_key_compute)
+        # torch boundary of the fix: the scoped reset drops the simulator's
+        # in-memory code entries, exactly like torch._dynamo.reset_code.
+        import torch._dynamo
+
+        monkeypatch.setattr(
+            torch._dynamo, "reset_code",
+            lambda code: self.sim.inmem.discard(code))
+        for spec in specs:
+            monkeypatch.setattr(
+                self.ex, "_enable_compiled",
+                lambda p, cfg, artifact: fleet_cells.enable_compiled(
+                    p, cfg, self.ex.store._cache_dir, artifact,
+                    publisher=None))
+            break
+
+    def boot(self, spec: EndpointSpec) -> None:
+        model_ref = wire_ref(spec.models["pipeline"])
+        asyncio.run(self.ex.ensure_setup(
+            spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
+
+
+def test_second_same_family_arm_mints_its_own_graphs_and_finalizes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE L4 LOOP (red-verified against the pre-fix tree): generate mints
+    fine; generate-turbo (same denoiser class, different cell key) then has
+    its warmup served by dynamo's in-memory code — pre-fix its capture
+    stays empty and finalize kills both functions with
+    ``cache_hits=0, cache_misses=0``. Post-fix the proof-window reset makes
+    the second mint REAL: its own graphs are captured, finalize succeeds,
+    both functions serve compiled."""
+    cls_a = _endpoint_cls(((768, 768),))
+    cls_b = _endpoint_cls(((1024, 1024),))
+    gen = _spec("generate", cls_a, ((768, 768),))
+    turbo = _spec("generate-turbo", cls_b, ((1024, 1024),))
+    rig = _Rig(tmp_path, monkeypatch, [gen, turbo])
+
+    rig.boot(gen)
+    assert rig.ex.serving_tiers()["generate"] == "compiled"
+    compiles_after_a = len(rig.sim.compiles)
+    assert compiles_after_a >= 1
+    # The first mint's compiled code is resident in (sim) dynamo — the
+    # exact precondition that starved the second capture live.
+    assert rig.sim.inmem
+
+    rig.boot(turbo)
+
+    # The trace's failure mode is gone: turbo compiled its OWN graphs into
+    # its OWN capture (real misses, not counter-silent in-memory service),
+    # finalized, and serves compiled. Nothing was disabled.
+    assert rig.ex.unavailable == {}
+    tiers = rig.ex.serving_tiers()
+    assert tiers["generate"] == "compiled"
+    assert tiers["generate-turbo"] == "compiled"
+    assert len(rig.sim.compiles) > compiles_after_a
+    refs = {
+        t.active_compile_ref for t in rig.ex.compile_targets()
+    }
+    assert len(refs) == 2, "two distinct cells, each proven by its own boot"
+    for ref in refs:
+        assert ref.startswith(f"root/family-{FAMILY}#ck2-")
+        assert cc.cell_proven_in_process(ref)
+    with fleet_cells._PENDING_LOCK:
+        assert fleet_cells._PENDING == {}
+
+
+def test_same_key_rearm_reuses_finalized_cell_with_a_real_fx_hit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Requirement (a): the minted object SERVES — a later same-key arm in
+    the same process re-arms from the folded live cache and its proof
+    warmup records a REAL FX cache hit on the exact warm graph (the cache
+    is consulted and hits; pre-fix it re-minted an empty capture and
+    died)."""
+    cls_a = _endpoint_cls(((768, 768),))
+    cls_c = _endpoint_cls(((768, 768),))  # same shapes => same cell key
+    gen = _spec("generate", cls_a, ((768, 768),))
+    twin = _spec("generate-twin", cls_c, ((768, 768),))
+    rig = _Rig(tmp_path, monkeypatch, [gen, twin])
+
+    rig.boot(gen)
+    (target_a,) = rig.ex.compile_targets()
+    ref_a = target_a.active_compile_ref
+    compiles_after_a = len(rig.sim.compiles)
+
+    rig.boot(twin)
+
+    assert rig.ex.unavailable == {}
+    assert rig.ex.serving_tiers()["generate-twin"] == "compiled"
+    # No second mint: the twin re-armed the in-process finalized cell and
+    # PROVED it with a genuine FX-cache hit (counters moved, hit>0).
+    assert len(rig.sim.compiles) == compiles_after_a
+    twin_pipe = [
+        p for p in rig.pipes.values()
+        if cc.cache_hit_count(p) > 0
+    ]
+    assert twin_pipe, "the re-armed object must record a real cache hit"
+    twin_target = [
+        t for t in rig.ex.compile_targets()
+        if "generate-twin" in t.function_names
+    ]
+    assert twin_target and twin_target[0].active_compile_ref == ref_a
+    with fleet_cells._PENDING_LOCK:
+        assert fleet_cells._PENDING == {}
+
+
+def test_genuinely_unservable_lane_degrades_to_eager_not_death(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Requirement (c): when the compiled lane truly cannot prove itself
+    (here: the reset is ineffective and stale in-memory code keeps serving
+    — the th#1166 false-negative class), the worker DEGRADES: setup
+    completes, the function stays dispatchable at explicit eager tier, the
+    identity is quarantined, and a follow-up setup does NOT re-mint the
+    same key (no churn loop)."""
+    cls_a = _endpoint_cls(((768, 768),))
+    gen = _spec("generate", cls_a, ((768, 768),))
+    rig = _Rig(tmp_path, monkeypatch, [gen])
+    # Break the fix's torch leaf: reset does nothing, and the denoiser code
+    # is already "resident" — every warmup call serves counter-silently.
+    import torch._dynamo
+
+    monkeypatch.setattr(torch._dynamo, "reset_code", lambda code: None)
+    rig.sim.inmem.add(_Denoiser.forward.__code__)
+
+    with caplog.at_level(logging.ERROR):
+        rig.boot(gen)
+
+    # The 0.64.0 outcome was CompiledLaneUnavailableError -> generate
+    # disabled -> pod retired. Now: alive, eager, loud.
+    assert "generate" not in rig.ex.unavailable
+    assert rig.ex.serving_tiers()["generate"] == "eager"
+    assert rig.ex.compile_targets() == []
+    degrade = [
+        r.getMessage() for r in caplog.records
+        if "did not serve their own warmup graph" in r.getMessage()
+    ]
+    assert degrade and "cache_hits=0, cache_misses=0" in degrade[0]
+    assert "DEGRADED" in degrade[0]
+    # The failed identity is quarantined: a fresh setup of the same spec
+    # declines to re-mint the key (loop broken), still serves eager.
+    rec = rig.ex._classes[gen.instance_key]
+    rec.stale = True
+    pending_before = len(rig.sim.compiles)
+    rig.boot(gen)
+    assert "generate" not in rig.ex.unavailable
+    assert rig.ex.serving_tiers()["generate"] == "eager"
+    assert len(rig.sim.compiles) == pending_before, "no re-mint of a quarantined key"
+    with fleet_cells._PENDING_LOCK:
+        assert fleet_cells._PENDING == {}
+
+
+def test_compile_failure_on_mandatory_lane_degrades_per_sku(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """pgw#673 posture half: an InductorError-class failure compiling the
+    W8A8 target (sm120 CantSplit) degrades THAT worker to eager serving —
+    warmup completes, function stays up — instead of disabling every
+    declared function and retiring the pod."""
+    cls_a = _endpoint_cls(((768, 768),))
+    gen = _spec("generate", cls_a, ((768, 768),))
+    rig = _Rig(tmp_path, monkeypatch, [gen])
+    rig.sim.raise_on_compile = RuntimeError(
+        "InductorError: CantSplit: 640*(((s69 - 1)//2)) ... not divisible")
+
+    with caplog.at_level(logging.ERROR):
+        rig.boot(gen)
+
+    assert "generate" not in rig.ex.unavailable
+    assert rig.ex.serving_tiers()["generate"] == "eager"
+    assert rig.ex.compile_targets() == []
+    assert any(
+        "CantSplit" in r.getMessage() and "eager" in r.getMessage()
+        for r in caplog.records
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.65.0"
+version = "0.66.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
P0 fix for pgw#672 (gates the sdxl prod retag and the th#1187 eager-first deploy), plus the pgw#673 degrade half.

**Live defect** (ie#546 burst rerun #2, 0.64.0 on L4): a worker mints + arms its ck2 cell, then fails its own finalize with `CompiledLaneUnavailableError: ... did not serve their own warmup graph (warmups=18, calls=18, cache_hits=0, cache_misses=0, compile_seconds=0.0)` -> cell_quarantined -> both functions disabled -> pod retired -> replacement re-mints the same key. 5 cycles, 4 dead workers, 6/36 requests.

**Root cause**: dynamo's in-memory code cache (keyed on the class-shared `__code__`; torch 2.13 inlined-module guards match any same-class instance) serves the proof warmup of a LATER same-family arm in a warm process — the pending capture stays empty (`finish_fleet_mint: captured nothing`) and warm re-proofs read 0 hits / 0 misses past the pgw#637 escape.

**Fix**
- `compile_cache.reset_target_code`: scoped per-code dynamo reset before every proof window (foreground exclusive-GPU warmup, pgw#671 background-mint seed, hot-adopt arm) — mints truly capture, adoptions truly HIT their seeded FX entries. Sibling-safe (additive live root => re-trace = FX hit).
- `fleet_cells._FINALIZED`: a key finalized in-process re-arms cache_ready from the folded live root; no doomed second capture.
- **Degrade, never die** (Paul's doctrine; covers pgw#673's sm120 `InductorError: CantSplit`): failed proof / failed compiled call / tripped runtime guard => explicit eager serving. Identity revoked (serving_tier flips to "eager" on the th#1187 wire field), `Activity.note` confession, functions stay dispatchable, pod stays up. Mandatory w8a8/w4a4 lanes included.
- In-process cell quarantine with key-normalized ref identity (also closes the th#1166 exact-string false-negative class): a proof-failed identity is never re-selected or re-minted by the same process.

**Evidence**: `tests/test_serve_finalize_pgw672.py` over the REAL `ensure_setup` + fleet_cells miss policy, red-verified against the pre-fix tree (reproduces the exact live signature incl. empty capture). Full suite 936 passed / 5 skipped / 1 xfailed (two runs; two known load-flakes passed on re-run), mypy clean (144 files), ruff clean on touched files.

Hub follow-ups (tensorhub, tracked in pgw#672): cross-worker quarantine visibility; accept eager-tier dispatch on mandated lanes when no armed cell exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)