### PR TITLE
release 0.67.1: pgw#675 override dtype + pgw#676 native-crash attribution (sdxl retag blockers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 0.67.1 (2026-07-26) — pgw#675 override dtype + pgw#676 native-crash attribution (the sdxl retag blockers)
+
+### pgw#675: a component override now loads at the dtype the base tree's LOAD LANE computes at
+
+`composition_compute_dtype` (pgw#647 gap #2) picked the compute dtype by
+MAJORITY on-disk sniff. A produced `#fp8-w8a8` flavor quantizes only the
+repeated-block Linears; every other tensor passes through at SOURCE
+precision — so an fp16-mirrored fine-tune sniffs majority-fp16 (measured on
+the live sdxl snapshot: 1902 F16 / 739 F8_E4M3 / 739 F32) while
+`load_w8a8_pipeline` loads the composition at its bf16 compute default. The
+fp16-fix VAE override therefore loaded Half into a bf16-activation pipeline
+and EVERY forward through it — foreground eager warm, background-mint seed,
+serve — died with `RuntimeError: Input type (c10::BFloat16) and bias type
+(c10::Half) should be the same` (ie#546 sdxl finale: 3/3 workers, release
+unprovable; the defect was latent since 0.64.0 and surfaced when the hub's
+th#1134 fix + the finale's full-binding deploy first actually delivered a
+`components.vae` override to a worker).
+
+- `composition_compute_dtype` is now LANE-aware: a quantized-artifact tree
+  (svdq / w8a8 / w4a4) answers the lane's bf16 compute default
+  (`QUANT_LANE_COMPUTE_DEFAULT`, test-guarded against the loaders'
+  `compute_dtype or torch.bfloat16`); the majority sniff only decides for
+  plain trees. Binding-declared dtype still wins outright; pgw#667
+  per-component facts still take precedence for fragile parts.
+- Because every path (warm, eager, serve, background mint) forwards through
+  the ONE instance built at setup, fixing the load fixes them all — there
+  was no per-path cast to re-apply.
+- Tapes (`tests/test_override_dtype_pgw675.py`, red-verified on the pre-fix
+  tree): the REAL producer (`streaming_w8a8_cast`) builds a majority-fp16
+  w8a8 tree, the REAL `load_component_override` loads a REAL tiny diffusers
+  `AutoencoderKL`, and bf16 latents decode through it on CPU — pre-fix the
+  override lands `torch.float16` (the exact crash precondition), post-fix
+  `torch.bfloat16` end to end.
+
+### pgw#676: native crashes are named, attributed, and stop crash-looping the pod
+
+gen-worker 0.66.0 SIGSEGV'd (`exit_code=139`) on the 28-step CFG-on
+`generate` shape on RTX A4500 (sm_86) — 6x across two pods, every request
+burned 5 attempts deep, pod billed until th#878's wedge terminate — and the
+hub saw NOTHING but the exit code. Degrade-never-die now extends below
+Python:
+
+- **faulthandler dump file** (`postmortem.enable_fault_dump`, on from the
+  entrypoint): SIGSEGV/SIGABRT/SIGBUS/SIGFPE write every thread's Python
+  stack to a file the surviving supervisor attaches — exit 139 carries
+  frames.
+- **In-flight markers** (`postmortem.note_inflight`): real requests and
+  warm forwards (foreground AND background mint) stamp what is executing;
+  a signal death attributes to the exact function + request id. Token
+  stack, so overlapping executions all stay visible.
+- **Per-pod crash-streak refusal**: the supervisor (and the next-boot
+  container-death path) records the attributed crash; after
+  `NATIVE_CRASH_REFUSE_STREAK` (2) signal deaths mid-flight on one
+  function, `gate_functions` refuses THAT function on THIS pod —
+  `native_crash_streak`, loud and typed — while siblings (turbo completed
+  on the same A4500s) keep serving. The registry lives on the pod's fs:
+  per-SKU-instance by construction.
+- Hub half filed as th#1205 (placement rented the sm_86 card KNOWING it was
+  below the preferred arch): respect the arch floor or gate on th#1198
+  benchmark rows, and feed `native_crash_streak` into the fence.
+- Tapes (`tests/test_native_crash_streak_pgw676.py`, red-verified): a real
+  fork + real NULL-deref SIGSEGV produces an attributed post-mortem with
+  frames; the gate refuses `generate` after 2 recorded deaths and leaves
+  `generate-turbo` serving.
+
 ## 0.67.0 (2026-07-25) — rotation preload + the three recorded SDK gaps
 
 Two lanes ride this train: pgw#674 (rotation preload) and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.67.0"
+version = "0.67.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -242,6 +242,12 @@ def _install_stack_dump_handler() -> None:
         logger.info(
             "pgw#639: SIGUSR2 dumps all thread stacks to stderr (pid=%d)",
             os.getpid())
+    # pgw#676: fatal signals (SIGSEGV/SIGABRT/SIGBUS/SIGFPE) dump every
+    # thread's stack to a file the surviving supervisor attaches to its
+    # post-mortem — exit_code=139 carries frames instead of nothing.
+    from . import postmortem
+
+    postmortem.enable_fault_dump()
 
 
 def _run_main() -> int:

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2852,8 +2852,37 @@ class Executor:
             torch_version=str(gpu_info.get("torch_version") or ""),
             installed_libs=list(libs),
         )
+        # pgw#676: per-pod native-crash streaks (SIGSEGV & friends recorded
+        # by the supervisor/boot-record post-mortem). A function that keeps
+        # killing the PROCESS on this card is refused here — loudly, typed —
+        # so its siblings keep serving instead of the whole pod crash-looping
+        # into th#878's wedge terminate. Per-SKU-instance by construction:
+        # the registry lives on the pod's container fs.
+        from . import postmortem
+
+        crash_streaks = postmortem.native_crash_streaks()
         for name, spec in self.specs.items():
             r = spec.resources
+            streak_row = crash_streaks.get(name)
+            streak = int((streak_row or {}).get("count") or 0)
+            if streak >= postmortem.NATIVE_CRASH_REFUSE_STREAK:
+                detail = (
+                    f"{streak} worker-process signal death(s) mid-"
+                    f"{(streak_row or {}).get('last_kind') or 'execution'} on "
+                    f"this pod (last={((streak_row or {}).get('last_signal')) or 'unknown'}); "
+                    "refusing this function on this hardware — siblings keep "
+                    "serving (pgw#676 degrade-never-die across process death)"
+                )
+                logger.error(
+                    "NATIVE CRASH STREAK: function %r disabled on this pod — %s",
+                    name, detail)
+                self.unavailable[name] = (
+                    "native_crash_streak", detail,
+                    {"streak": str(streak),
+                     "last_signal": str(
+                         (streak_row or {}).get("last_signal") or "")})
+                self._gate_owned.add(name)
+                continue
             # SDK v2 (pgw#647): NO compute-capability gate — precision per
             # card class is the fit ladder's decision (sdxl runs fine in
             # fp16 on sm75); only stored-flavor SM windows (svdq/nvfp4,
@@ -4839,21 +4868,30 @@ class Executor:
         self, spec: EndpointSpec, instance: Any, ctx: "RequestContext",
         payload: Any, kwargs: Dict[str, Any],
     ) -> None:
+        from . import postmortem
+
         bound = getattr(instance, spec.attr_name)
         call_kwargs = {spec.ctx_param: ctx, spec.payload_param: payload, **kwargs}
-        if spec.is_async_gen:
-            async for _ in bound(**call_kwargs):
-                pass
-        elif spec.is_async:
-            await bound(**call_kwargs)
-        else:
-            def _consume() -> None:
-                out = bound(**call_kwargs)
-                if spec.output_mode == "stream":
-                    for _ in out:
-                        pass
+        # pgw#676: warm forwards (foreground eager warm AND background mint
+        # seeds) get the same signal-death attribution as real requests.
+        inflight_token = postmortem.note_inflight(
+            "warmup", spec.name, request_id=str(ctx.request_id or ""))
+        try:
+            if spec.is_async_gen:
+                async for _ in bound(**call_kwargs):
+                    pass
+            elif spec.is_async:
+                await bound(**call_kwargs)
+            else:
+                def _consume() -> None:
+                    out = bound(**call_kwargs)
+                    if spec.output_mode == "stream":
+                        for _ in out:
+                            pass
 
-            await _to_thread_complete(_consume)
+                await _to_thread_complete(_consume)
+        finally:
+            postmortem.clear_inflight(inflight_token)
 
     def _mark_setup_failed(
         self, rec: _ClassRecord, exc: BaseException, *, exhausted: bool = False,
@@ -8680,6 +8718,14 @@ class Executor:
                                         self._adapters.deactivate, ref, pipe, run.request_id
                                     )
                         ctx.raise_if_cancelled("canceled")
+                        # pgw#676: name the execution before the GPU touches
+                        # it — a signal death mid-handler leaves this marker
+                        # for the supervisor's post-mortem attribution.
+                        from . import postmortem as postmortem_mod
+
+                        inflight_token = postmortem_mod.note_inflight(
+                            "request", spec.name,
+                            request_id=str(run.request_id or ""))
                         try:
                             output = await self._execute(
                                 job, spec, instance, ctx, payload, kwargs,
@@ -8691,6 +8737,10 @@ class Executor:
                             # cleanly at that rung.
                             await self._quarantine_for_oom(spec, ctx, exc)
                             raise
+                        finally:
+                            # Python-visible exits are not native crashes —
+                            # only a signal death leaves the marker behind.
+                            postmortem_mod.clear_inflight(inflight_token)
                     finally:
                         # Guaranteed-inactive on every exit (OK / cancel /
                         # deadline / handler error); attachments stay resident.

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -908,19 +908,42 @@ def model_index_entry(path: str | Path, component: str) -> Optional[tuple]:
     return None
 
 
+#: Compute dtype of the quantized-artifact lanes when the binding declares
+#: none — MUST equal the ``compute_dtype or torch.bfloat16`` default in
+#: load_w8a8_pipeline / load_w4a4_pipeline / the svdq lane (test-guarded).
+QUANT_LANE_COMPUTE_DEFAULT = "bf16"
+
+
 def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
     """The compute dtype the COMPOSED pipeline will run at (pgw#647 gap #2):
-    the base binding's declared dtype when present, else the base tree's
-    on-disk dtype with fp8/quantized storage mapping to its bf16 compute
-    default (mirrors :func:`load_diffusers_pipeline`'s own selection).
-    ``""`` = unknown (an fp32-defaulting composition)."""
+    the base binding's declared dtype when present, else the dtype the base
+    tree's LOAD LANE actually computes at. ``""`` = unknown (an
+    fp32-defaulting composition).
+
+    Lane selection mirrors :func:`load_from_pretrained` (pgw#675): a
+    quantized-artifact tree (svdq / w8a8 / w4a4) computes at the lane's bf16
+    default regardless of the tree's MAJORITY on-disk dtype — a produced
+    ``#fp8-w8a8`` flavor quantizes only the repeated-block Linears and passes
+    every other tensor through at SOURCE precision, so a fine-tune mirrored
+    from an fp16 upstream sniffs majority-fp16 while its pipeline loads
+    ``torch_dtype=bf16``. The old majority sniff loaded a component override
+    fp16 into that bf16 composition and every warm/serve forward died with
+    ``Input type (c10::BFloat16) and bias type (c10::Half)`` (ie#546 sdxl
+    finale, 3/3 workers)."""
     if dtype:
         return dtype
-    sniffed = detect_on_disk_dtype(Path(base_path))
+    base = Path(base_path)
+    if (
+        detect_svdq_artifact(base) is not None
+        or detect_w8a8_artifact(base) is not None
+        or detect_w4a4_artifact(base) is not None
+    ):
+        return QUANT_LANE_COMPUTE_DEFAULT
+    sniffed = detect_on_disk_dtype(base)
     if sniffed == "fp8":
-        # fp8-stored flavors (w8a16/w8a8 alike) compute in bf16; per-layer
-        # storage precision is restored separately (apply_fp8_storage /
-        # the scaled-mm lane).
+        # Scale-free fp8 storage flavors compute at the bf16 default;
+        # per-layer storage precision is restored separately
+        # (apply_fp8_storage).
         return "bf16"
     if sniffed in ("bf16", "fp16"):
         return sniffed

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -26,6 +26,7 @@ import json
 import logging
 import os
 import signal
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -413,35 +414,279 @@ def previous_boot_detail(path: Path = BOOT_RECORD_PATH) -> Optional[str]:
         lifetime = max(0.0, time.time() - float(record.get("boot_unix") or 0.0))
     except (TypeError, ValueError):
         pass
+    extra: Dict[str, Any] = {
+        "previous_pid": record.get("pid"),
+        "limits_at_previous_boot": record.get("limits"),
+        "note": (
+            "the previous process left an unfinished boot record: it died "
+            "without its supervisor surviving to report (whole-cgroup OOM "
+            "kill, container restart, or external kill)"
+        ),
+    }
+    # pgw#676: the previous process's in-flight marker + fault dump are the
+    # death's attribution; consuming them here also feeds the crash registry
+    # so this boot's gate can refuse a crash-streak function.
+    extra.update(attribute_signal_death(signal_name="container_death"))
     return format_detail(
         phase="previous_container_death",
         verdict={"exit_code": None, "signaled": None},
         limits=limits,
         oom_kill_delta=max(0, now - before) if now >= before else None,
         lifetime_s=lifetime,
-        extra={
-            "previous_pid": record.get("pid"),
-            "limits_at_previous_boot": record.get("limits"),
-            "note": (
-                "the previous process left an unfinished boot record: it died "
-                "without its supervisor surviving to report (whole-cgroup OOM "
-                "kill, container restart, or external kill)"
-            ),
-        },
+        extra=extra,
     )
+
+
+# ---- in-flight marker + native-crash streaks (pgw#676) --------------------
+#
+# exit_code=139 used to reach the hub carrying NOTHING: no frame, no function,
+# and the restarted process would take the same request shape and die again —
+# six SIGSEGVs across two sm_86 pods, every `generate` burned 5 attempts deep,
+# and the pod billed until th#878's wedge terminate (~31 min). Three pieces
+# close that class:
+#
+#   * a faulthandler dump file the dying process writes below Python — the
+#     surviving supervisor attaches its tail, so a signal death carries the
+#     Python stacks of every thread;
+#   * an in-flight marker naming what was executing (function, kind,
+#     request id) — written at request/warmup start, cleared on finish;
+#   * a per-pod crash registry: a function whose in-flight execution died by
+#     signal ``NATIVE_CRASH_REFUSE_STREAK`` times is refused at the next
+#     boot's gate (degrade-never-die across process death: siblings keep
+#     serving, the refusal is loud and typed, the hub reroutes).
+
+_INFLIGHT_NAME = "gen-worker-inflight.json"
+_CRASH_REGISTRY_NAME = "gen-worker-crash-streaks.json"
+_FAULT_DUMP_NAME = "gen-worker-fault-dump.txt"
+
+#: Signal deaths mid-flight on one function, on one pod, before the gate
+#: refuses it. 2 = one free retry for a genuinely transient fault.
+NATIVE_CRASH_REFUSE_STREAK = 2
+
+_FAULT_DUMP_TAIL_BYTES = 8000
+
+
+def _sibling(name: str) -> Path:
+    """Same durable carrier the boot record chose."""
+    return BOOT_RECORD_PATH.parent / name
+
+
+INFLIGHT_PATH = _sibling(_INFLIGHT_NAME)
+CRASH_REGISTRY_PATH = _sibling(_CRASH_REGISTRY_NAME)
+FAULT_DUMP_PATH = _sibling(_FAULT_DUMP_NAME)
+
+_fault_dump_file: Optional[Any] = None
+
+
+def enable_fault_dump(path: Optional[Path] = None) -> None:
+    """Point ``faulthandler`` at a file the supervisor can read after we die.
+
+    ``faulthandler.enable`` writes every thread's Python stack from inside
+    the signal handler (SIGSEGV/SIGFPE/SIGABRT/SIGBUS) without allocating,
+    then the default action re-raises — so the file has content by the time
+    ``waitpid`` returns to the parent."""
+    import faulthandler
+
+    global _fault_dump_file
+    path = path or FAULT_DUMP_PATH
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _fault_dump_file = open(path, "w", buffering=1)
+        faulthandler.enable(file=_fault_dump_file, all_threads=True)
+    except (OSError, ValueError):
+        logger.warning("fault-dump file unavailable at %s; faulthandler "
+                       "falls back to stderr", path)
+        faulthandler.enable(all_threads=True)
+
+
+def fault_dump_tail(path: Optional[Path] = None,
+                    limit: int = _FAULT_DUMP_TAIL_BYTES) -> str:
+    path = path or FAULT_DUMP_PATH
+    try:
+        raw = path.read_text(errors="replace").strip()
+    except OSError:
+        return ""
+    return raw[-limit:]
+
+
+def clear_fault_dump(path: Optional[Path] = None) -> None:
+    path = path or FAULT_DUMP_PATH
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+_inflight_lock = threading.Lock()
+_inflight_active: Dict[int, Dict[str, Any]] = {}
+_inflight_next_token = 0
+
+
+def _write_inflight(path: Path) -> None:
+    try:
+        if not _inflight_active:
+            path.unlink(missing_ok=True)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(
+            {"active": list(_inflight_active.values())}))
+    except OSError:
+        pass
+
+
+def note_inflight(
+    kind: str, function: str, *, request_id: str = "",
+    path: Optional[Path] = None,
+) -> int:
+    """Stamp an execution about to touch the GPU; returns a token for
+    :func:`clear_inflight`. The file carries EVERY active execution (a
+    background-mint seed can overlap another instance's request), so a
+    signal death attributes to all of them — usually exactly one. Cheap:
+    one tiny json write off the compute path."""
+    global _inflight_next_token
+    path = path or INFLIGHT_PATH
+    record = {
+        "kind": kind,
+        "function": function,
+        "request_id": request_id,
+        "pid": os.getpid(),
+        "started_unix": time.time(),
+    }
+    with _inflight_lock:
+        _inflight_next_token += 1
+        token = _inflight_next_token
+        _inflight_active[token] = record
+        _write_inflight(path)
+    return token
+
+
+def clear_inflight(
+    token: Optional[int] = None, path: Optional[Path] = None,
+) -> None:
+    """Retire one execution (or, with no token, every marker — boot/exit
+    hygiene)."""
+    path = path or INFLIGHT_PATH
+    with _inflight_lock:
+        if token is None:
+            _inflight_active.clear()
+        else:
+            _inflight_active.pop(token, None)
+        _write_inflight(path)
+
+
+def take_inflight(path: Optional[Path] = None) -> list[Dict[str, Any]]:
+    """Read and consume the active-execution list a dead process left."""
+    path = path or INFLIGHT_PATH
+    try:
+        raw = path.read_text()
+    except OSError:
+        return []
+    try:
+        path.unlink()
+    except OSError:
+        pass
+    try:
+        record = json.loads(raw)
+    except ValueError:
+        return []
+    if not isinstance(record, dict):
+        return []
+    active = record.get("active")
+    return [r for r in active if isinstance(r, dict)] if isinstance(
+        active, list) else []
+
+
+def record_native_crash(
+    function: str, *, kind: str = "", signal_name: str = "",
+    path: Optional[Path] = None,
+) -> int:
+    """Count one signal death attributed to ``function``; returns the new
+    streak. The registry lives on the pod's container fs, so it survives
+    process restarts and dies with the pod — per-SKU-instance by
+    construction."""
+    path = path or CRASH_REGISTRY_PATH
+    streaks = native_crash_streaks(path)
+    row = streaks.get(function) or {"count": 0}
+    row["count"] = int(row.get("count") or 0) + 1
+    row["last_kind"] = kind
+    row["last_signal"] = signal_name
+    row["last_unix"] = time.time()
+    streaks[function] = row
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(streaks, default=str))
+    except OSError:
+        pass
+    return int(row["count"])
+
+
+def native_crash_streaks(
+    path: Optional[Path] = None,
+) -> Dict[str, Dict[str, Any]]:
+    path = path or CRASH_REGISTRY_PATH
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(fn): row for fn, row in raw.items() if isinstance(row, dict)
+    }
+
+
+def attribute_signal_death(
+    *, signal_name: str,
+    inflight_path: Optional[Path] = None,
+    registry_path: Optional[Path] = None,
+    dump_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Everything the post-mortem reporter can attach to a signal death:
+    the in-flight markers (consumed), the fault-dump tail, and — for each
+    marker naming a function — the recorded crash streak."""
+    extra: Dict[str, Any] = {}
+    inflight = take_inflight(inflight_path)
+    if inflight:
+        extra["inflight"] = inflight
+        streaks: Dict[str, int] = {}
+        for row in inflight:
+            fn = str(row.get("function") or "")
+            if fn:
+                streaks[fn] = record_native_crash(
+                    fn, kind=str(row.get("kind") or ""),
+                    signal_name=signal_name, path=registry_path)
+        if streaks:
+            extra["native_crash_streaks"] = streaks
+    tail = fault_dump_tail(dump_path)
+    if tail:
+        extra["fault_dump_tail"] = tail
+    return extra
 
 
 __all__ = [
     "BOOT_RECORD_PATH",
+    "CRASH_REGISTRY_PATH",
+    "FAULT_DUMP_PATH",
+    "INFLIGHT_PATH",
+    "NATIVE_CRASH_REFUSE_STREAK",
+    "attribute_signal_death",
     "boot_record_is_volatile",
     "clear_boot_record",
+    "clear_fault_dump",
+    "clear_inflight",
     "container_limits",
     "cpu_quota_cores",
     "describe_exit",
     "effective_cpu_count",
+    "enable_fault_dump",
+    "fault_dump_tail",
     "format_detail",
+    "native_crash_streaks",
+    "note_inflight",
     "oom_kill_count",
     "previous_boot_detail",
+    "record_native_crash",
     "take_boot_record",
+    "take_inflight",
     "write_boot_record",
 ]

--- a/src/gen_worker/supervisor.py
+++ b/src/gen_worker/supervisor.py
@@ -128,6 +128,9 @@ def supervise(record_path: Path = postmortem.BOOT_RECORD_PATH) -> None:
         return
 
     report_previous_container_death(record_path)
+    # Anything the previous-death report did not consume is stale by now —
+    # a lingering marker would misattribute the NEXT death (pgw#676).
+    postmortem.clear_inflight()
     postmortem.write_boot_record(record_path)
 
     started = time.time()
@@ -152,8 +155,18 @@ def supervise(record_path: Path = postmortem.BOOT_RECORD_PATH) -> None:
     clean = not verdict.get("signaled") and verdict.get("exit_code") == 0
     if clean:
         postmortem.clear_boot_record(record_path)
+        postmortem.clear_inflight()
+        postmortem.clear_fault_dump()
     else:
         oom_after = postmortem.oom_kill_count()
+        extra: dict = {"child_pid": child_pid}
+        if verdict.get("signaled"):
+            # pgw#676: name the death — the in-flight marker (what was
+            # executing), the faulthandler dump (every thread's Python
+            # stack, written below Python by the dying child), and the
+            # per-pod crash streak the next boot's gate refuses on.
+            extra.update(postmortem.attribute_signal_death(
+                signal_name=str(verdict.get("signal_name") or "")))
         _emit(
             postmortem.format_detail(
                 phase="worker_process_exit",
@@ -161,7 +174,7 @@ def supervise(record_path: Path = postmortem.BOOT_RECORD_PATH) -> None:
                 limits=postmortem.container_limits(),
                 oom_kill_delta=max(0, oom_after - oom_before),
                 lifetime_s=time.time() - started,
-                extra={"child_pid": child_pid},
+                extra=extra,
             ),
             dial=bool(verdict.get("signaled")),
         )

--- a/tests/test_native_crash_streak_pgw676.py
+++ b/tests/test_native_crash_streak_pgw676.py
@@ -1,0 +1,204 @@
+"""pgw#676: a native crash (SIGSEGV in a CUDA/C extension) must be NAMED and
+must not crash-loop the pod.
+
+The live shape: gen-worker 0.66.0 on RTX A4500 (sm_86) segfaulted
+(``exit_code=139``) on every 28-step CFG-on ``generate`` — six times across
+two pods — while 4-step ``generate-turbo`` completed on the same workers.
+The hub saw ``phase=worker_process_exit exit_code=139`` and NOTHING else; the
+process restarted in the pod, took the same shape, and died again until
+th#878's wedge terminate killed the pod (~31 min of billing), with every
+request burned 5 attempts deep first.
+
+Three closures, tested here with real forks and a real native fault:
+
+  * the dying process's faulthandler dump file gives exit 139 Python frames;
+  * the in-flight marker names WHAT was executing (function, kind, request);
+  * the per-pod crash registry makes the NEXT boot's gate refuse a function
+    with ``NATIVE_CRASH_REFUSE_STREAK`` signal deaths — siblings keep
+    serving, the refusal is loud and typed (degrade-never-die across
+    process death; the pgw#673/pgw#672 posture extended below Python).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import List
+
+import msgspec
+import pytest
+
+from gen_worker.api.binding import Hub
+from gen_worker.api.decorators import Resources
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+from gen_worker import postmortem
+
+# ---------------------------------------------------------------------------
+# Real fork + real native fault: the supervisor names the death.
+# ---------------------------------------------------------------------------
+
+_SEGV_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    from pathlib import Path
+    from gen_worker.supervisor import supervise
+
+    supervise(Path(sys.argv[1]))
+    # only the child gets here
+    from gen_worker import postmortem
+    postmortem.enable_fault_dump()
+    postmortem.note_inflight("request", "generate", request_id="req-676")
+    import ctypes
+    ctypes.string_at(0)  # real native fault: NULL deref -> SIGSEGV
+    """
+)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
+def test_segv_death_is_attributed_and_carries_frames(tmp_path: Path) -> None:
+    script = tmp_path / "boot.py"
+    script.write_text(_SEGV_SCRIPT)
+    record = tmp_path / "record.json"
+    sink = tmp_path / "postmortem.txt"
+    env = dict(os.environ)
+    env["GEN_WORKER_POSTMORTEM_FILE"] = str(sink)
+    env["GEN_WORKER_BOOT_RECORD"] = str(record)  # siblings land in tmp_path
+    env.pop("GEN_WORKER_SUPERVISED", None)
+    env.pop("ORCHESTRATOR_PUBLIC_ADDR", None)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    proc = subprocess.run(
+        [sys.executable, str(script), str(record)],
+        env=env, capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 139, proc.stderr
+    detail = sink.read_text()
+    assert "KILLED BY SIGNAL SIGSEGV" in detail
+    # the in-flight marker attributes the death to the executing function
+    assert '"function": "generate"' in detail
+    assert "req-676" in detail
+    # the faulthandler dump gives exit 139 actual Python frames
+    assert "fault_dump_tail" in detail
+    assert "boot.py" in detail  # the dying frame is visible
+    # the crash registry on the "pod" fs recorded the streak
+    streaks = json.loads((tmp_path / "gen-worker-crash-streaks.json").read_text())
+    assert streaks["generate"]["count"] == 1
+    assert streaks["generate"]["last_signal"] == "SIGSEGV"
+    # marker consumed: the next death cannot re-attribute this one
+    assert not (tmp_path / "gen-worker-inflight.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# The gate: streak >= NATIVE_CRASH_REFUSE_STREAK refuses the function,
+# siblings keep serving.
+# ---------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Fake:
+    def setup(self, pipeline) -> None:  # pragma: no cover
+        self.pipeline = pipeline
+
+    def generate(self, ctx, payload: _In) -> dict:  # pragma: no cover
+        return {}
+
+    def generate_turbo(self, ctx, payload: _In) -> dict:  # pragma: no cover
+        return {}
+
+
+def _specs() -> List[EndpointSpec]:
+    return [
+        EndpointSpec(
+            name="generate", method=_Fake.generate, kind="inference",
+            payload_type=_In, output_mode="single", cls=_Fake,
+            models={"pipeline": Hub("acme/sdxl")},
+            resources=Resources(gpu=True),
+        ),
+        EndpointSpec(
+            name="generate-turbo", method=_Fake.generate_turbo,
+            kind="inference", payload_type=_In, output_mode="single",
+            cls=_Fake, models={"pipeline": Hub("acme/sdxl")},
+            resources=Resources(gpu=True),
+        ),
+    ]
+
+
+def _executor() -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:  # pragma: no cover
+        pass
+
+    return Executor(_specs(), _send)
+
+
+_GPU = {"gpu_total_mem": 20 * 1024**3, "gpu_free_mem": 20 * 1024**3,
+        "gpu_sm": "86", "installed_libs": []}
+
+
+def test_crash_streak_gates_only_the_crashing_function(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = tmp_path / "streaks.json"
+    monkeypatch.setattr(postmortem, "CRASH_REGISTRY_PATH", registry)
+
+    ex = _executor()
+    # One crash = one free retry; nothing is gated yet.
+    postmortem.record_native_crash(
+        "generate", kind="request", signal_name="SIGSEGV")
+    ex.gate_functions(_GPU)
+    assert "generate" not in ex.unavailable
+
+    # The second signal death trips the refusal — for that function only.
+    postmortem.record_native_crash(
+        "generate", kind="request", signal_name="SIGSEGV")
+    ex.gate_functions(_GPU)
+    code, detail, axes = ex.unavailable["generate"]
+    assert code == "native_crash_streak"
+    assert "SIGSEGV" in detail and "siblings keep serving" in detail
+    assert axes["streak"] == "2"
+    assert "generate-turbo" not in ex.unavailable, (
+        "the turbo sibling completed on the same A4500 workers live — it "
+        "must keep serving"
+    )
+    # Idempotent re-gate: the mark is gate-owned, re-derived every pass.
+    ex.gate_functions(_GPU)
+    assert ex.unavailable["generate"][0] == "native_crash_streak"
+
+
+# ---------------------------------------------------------------------------
+# Marker mechanics: overlapping executions, boot/exit hygiene.
+# ---------------------------------------------------------------------------
+
+
+def test_inflight_markers_stack_and_clear_by_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "inflight.json"
+    monkeypatch.setattr(postmortem, "INFLIGHT_PATH", path)
+    postmortem.clear_inflight()  # process-global hygiene for the test rig
+
+    t_req = postmortem.note_inflight("request", "generate", request_id="r1")
+    t_warm = postmortem.note_inflight("warmup", "generate-turbo")
+    active = json.loads(path.read_text())["active"]
+    assert {r["function"] for r in active} == {"generate", "generate-turbo"}
+
+    postmortem.clear_inflight(t_warm)
+    active = json.loads(path.read_text())["active"]
+    assert [r["function"] for r in active] == ["generate"]
+
+    postmortem.clear_inflight(t_req)
+    assert not path.exists()
+
+    # take_inflight consumes whatever a dead process left
+    postmortem.note_inflight("request", "generate", request_id="r2")
+    left = postmortem.take_inflight(path)
+    assert [r["request_id"] for r in left] == ["r2"]
+    assert not path.exists()
+    postmortem.clear_inflight()

--- a/tests/test_override_dtype_pgw675.py
+++ b/tests/test_override_dtype_pgw675.py
@@ -1,0 +1,160 @@
+"""pgw#675: a component override must load at the dtype the base tree's LOAD
+LANE computes at — never at the tree's MAJORITY on-disk dtype.
+
+The ie#546 sdxl finale hit this live: `wai-illustrious#fp8-w8a8` quantizes
+only the repeated-block Linears (F8_E4M3 + F32 scale twins) and passes every
+other tensor through at SOURCE precision. The upstream fine-tune is
+fp16-stored, so the flavor tree header-counts majority-F16 (measured on the
+real snapshot: 1902 F16 / 739 F8 / 739 F32) while `load_w8a8_pipeline` loads
+the composition at its bf16 compute default. `composition_compute_dtype`'s
+majority sniff said "fp16", the fp16-fix VAE override loaded Half into a
+bf16-activation pipeline, and every warm/serve forward died with the exact
+signature::
+
+    RuntimeError: Input type (c10::BFloat16) and bias type (c10::Half)
+    should be the same
+
+(3/3 workers, ~4 min into `self_mint_compile phase=warmup_forward`; release
+`9037b1b3...` unprovable). These tapes rebuild that composition for real on
+CPU: the REAL producer (`streaming_w8a8_cast`) makes the w8a8 tree from an
+fp16 source, the REAL `load_component_override` loads a REAL tiny diffusers
+`AutoencoderKL` override, and the decode forward runs bf16 latents through
+it — the exact crash path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import torch
+from diffusers import AutoencoderKL
+from safetensors.torch import save_file
+
+from gen_worker.convert.writer import streaming_w8a8_cast
+from gen_worker.models.loading import (
+    QUANT_LANE_COMPUTE_DEFAULT,
+    composition_compute_dtype,
+    detect_on_disk_dtype,
+    get_torch_dtype,
+    load_component_override,
+)
+from gen_worker.models.w8a8 import detect_w8a8_artifact, load_w8a8_pipeline
+from gen_worker.models.w4a4 import load_w4a4_pipeline
+
+# ---------------------------------------------------------------------------
+# Fixture: a majority-fp16 #fp8-w8a8 base tree, built by the REAL producer.
+# ---------------------------------------------------------------------------
+
+_TINY_VAE_CONFIG = dict(
+    in_channels=3,
+    out_channels=3,
+    down_block_types=("DownEncoderBlock2D",),
+    up_block_types=("UpDecoderBlock2D",),
+    block_out_channels=(4,),
+    layers_per_block=1,
+    latent_channels=4,
+    norm_num_groups=4,
+    sample_size=8,
+)
+
+
+def _w8a8_base_tree(tmp_path: Path) -> Path:
+    """Diffusers root whose unet is a REAL streaming_w8a8_cast product of an
+    fp16 source: one eligible repeated-block Linear becomes F8+F32-scale;
+    enough passthrough tensors stay F16 that F16 is the tree majority —
+    the exact shape of the production `#fp8-w8a8` sdxl mirrors."""
+    src = tmp_path / "src-unet"
+    src.mkdir()
+    tensors = {
+        # Eligible: 2-D .weight, 16-aligned, inside a `.N.` block container.
+        "down_blocks.0.attentions.0.transformer_blocks.0.attn1.to_q.weight":
+            torch.randn(16, 16, dtype=torch.float16),
+    }
+    # Passthrough majority (norms/biases/convs keep source precision).
+    for i in range(6):
+        tensors[f"passthrough.norm_{i}.weight"] = torch.randn(
+            8, dtype=torch.float16)
+    save_file(tensors, str(src / "model.safetensors"))
+
+    root = tmp_path / "base-w8a8"
+    out = streaming_w8a8_cast(src / "model.safetensors", root / "unet")
+    assert int(out["converted_count"]) == 1
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "StableDiffusionXLPipeline",
+        "unet": ["diffusers", "UNet2DConditionModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+    }))
+    return root
+
+
+def _fp32_vae_override(tmp_path: Path) -> Path:
+    """A REAL tiny AutoencoderKL saved fp32 — the sdxl-vae-fp16-fix mirror is
+    fp32-stored (334MB on the wire), so the override's own on-disk dtype must
+    never win either."""
+    override = tmp_path / "override-vae"
+    vae = AutoencoderKL(**_TINY_VAE_CONFIG)
+    vae.save_pretrained(str(override))
+    return override
+
+
+# ---------------------------------------------------------------------------
+# The tapes
+# ---------------------------------------------------------------------------
+
+
+def test_w8a8_tree_majority_sniff_is_the_trap(tmp_path: Path) -> None:
+    """Pin the production shape: the tree IS w8a8 and its majority on-disk
+    dtype IS fp16 — the two facts whose combination broke the composition."""
+    root = _w8a8_base_tree(tmp_path)
+    assert detect_w8a8_artifact(root) is not None
+    assert detect_on_disk_dtype(root) == "fp16"
+
+
+def test_composition_compute_dtype_is_lane_aware_on_w8a8(
+    tmp_path: Path,
+) -> None:
+    """RED pre-fix: the majority sniff returned "fp16" for a w8a8 tree whose
+    lane computes bf16."""
+    root = _w8a8_base_tree(tmp_path)
+    assert composition_compute_dtype(root) == QUANT_LANE_COMPUTE_DEFAULT
+    # A declared binding dtype still wins outright.
+    assert composition_compute_dtype(root, "fp16") == "fp16"
+
+
+def test_override_decodes_bf16_latents_on_the_w8a8_lane(
+    tmp_path: Path,
+) -> None:
+    """The exact production crash path, for real on CPU: load the override
+    through `load_component_override` against the w8a8 base (hub bindings
+    carry no dtype), then run bf16 latents through its decode. RED pre-fix
+    with the exact live signature: `Input type (c10::BFloat16) and bias type
+    (c10::Half) should be the same`."""
+    root = _w8a8_base_tree(tmp_path)
+    override = _fp32_vae_override(tmp_path)
+
+    vae = load_component_override(root, "vae", override)
+    dtypes = {p.dtype for p in vae.parameters()}
+    assert dtypes == {torch.bfloat16}, (
+        f"override must land at the w8a8 lane's bf16 compute dtype, got "
+        f"{dtypes} — a Half override in a bf16 composition is the pgw#675 "
+        "warmup/serve fatal"
+    )
+    latents = torch.randn(1, 4, 8, 8, dtype=torch.bfloat16)
+    with torch.inference_mode():
+        decoded = vae.decode(latents).sample
+    assert decoded.dtype == torch.bfloat16
+
+
+def test_quant_lane_compute_default_matches_the_loaders() -> None:
+    """Drift guard: the constant `composition_compute_dtype` answers with for
+    quantized-artifact trees must be the same default the w8a8/w4a4 pipeline
+    loaders actually use (`compute_dtype or torch.bfloat16`)."""
+    assert get_torch_dtype(QUANT_LANE_COMPUTE_DEFAULT) is torch.bfloat16
+    for loader in (load_w8a8_pipeline, load_w4a4_pipeline):
+        src = inspect.getsource(loader)
+        assert "compute_dtype or torch.bfloat16" in src, (
+            f"{loader.__name__} no longer defaults to torch.bfloat16 — "
+            "update QUANT_LANE_COMPUTE_DEFAULT (pgw#675) in the same change"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.67.0"
+version = "0.67.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Two P0 fixes — the last worker-side blockers before the sdxl prod retag (ie#546 finale).

## pgw#675 — component override loaded at the tree's MAJORITY dtype, not the lane's compute dtype

Root cause (ground-truthed against the live snapshot): `wai-illustrious#fp8-w8a8` header-counts **1902 F16 / 739 F8_E4M3 / 739 F32** — the w8a8 producer quantizes only repeated-block Linears and passes everything else through at source (fp16) precision. `composition_compute_dtype`'s majority sniff therefore said `fp16` while `load_w8a8_pipeline` loads the composition at its **bf16** default. The fp16-fix VAE override loaded Half into a bf16-activation pipeline and every forward died with the exact live signature `Input type (c10::BFloat16) and bias type (c10::Half) should be the same` (3/3 workers, release unprovable). Latent since 0.64.0; surfaced when th#1134 + the finale's full-binding deploy first actually delivered a `components.vae` override to a worker.

Fix: `composition_compute_dtype` is lane-aware — quantized-artifact trees (svdq/w8a8/w4a4) answer `QUANT_LANE_COMPUTE_DEFAULT` (bf16, test-guarded against the loaders). Binding dtype still wins; pgw#667 facts still take precedence. Every path (warm, eager, serve, background mint) forwards through the one instance built at setup, so fixing the load fixes them all.

Tape (`tests/test_override_dtype_pgw675.py`, **red-verified**: pre-fix returns `fp16` and lands the override at `torch.float16`): real `streaming_w8a8_cast` tree + real tiny diffusers `AutoencoderKL` + bf16 decode on CPU.

## pgw#676 — exit 139 now carries frames + attribution, and stops crash-looping the pod

6x SIGSEGV on 28-step CFG-on `generate` across two sm_86 A4500s while turbo completed on the same workers; the hub saw only the exit code, requests burned 5 attempts deep, pod billed ~31 min until th#878's wedge. Degrade-never-die extended below Python:

- `postmortem.enable_fault_dump()` (entrypoint): fatal signals write all-thread Python stacks to a file the surviving supervisor attaches.
- In-flight markers (token stack) around real requests and every warm forward: the death names its function + request id.
- Per-pod crash registry: 2 signal deaths mid-flight on one function ⇒ `gate_functions` refuses it (`native_crash_streak`, loud, typed); siblings keep serving. Per-SKU-instance by construction (registry lives on the pod fs).

Tape (`tests/test_native_crash_streak_pgw676.py`, **red-verified**): real fork + real NULL-deref SIGSEGV ⇒ attributed post-mortem with frames; gate refuses `generate`, leaves `generate-turbo` serving.

Hub half filed as **th#1205** (placement rented the sm_86 card knowing it was below the preferred arch — arch floor / benchmark-row gating / crash-streak fence).

## Verification
- suite: **995 passed / 5 skipped / 1 xfailed**; mypy clean (150 files); ruff clean
- live sm_89 discriminator (finale's prescription) running on the master stack: `generate` 28-step CFG-on pinned to RTX 4090 on release `9037b1b3…` with no VAE override — separates #675 from #676