### PR TITLE
release: gen-worker 0.67.3 — th#1211 svdq guard lift + nunchaku 1.3/diffusers 0.39 pin row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.67.3 (2026-07-26) — th#1211: the svdq 5 GB guard cited a cap that does not exist
+
+`MAX_SVDQ_FILE_BYTES` was `5 * 1000**3`, justified in-comment as an "R2
+single-PUT cap". There is no such cap in this stack: the hub's
+checkpoint-commit grant allows **64 GiB/file**
+(`checkpointGrantMaxBytesPerFile`), uploads leave as presigned **multipart**
+parts (the hub issues `part_urls`/`part_size`), and a 46 GB monolithic
+`ltx-2.3-22b-dev.safetensors` has already been published raw through this
+platform. The guard therefore refused **every** nunchaku-supported family
+except z-image-turbo — qwen-image at 11.5–13.1 GB and flux.1 at 6.8–7.0 GB
+were both blocked, even though the comment claimed flux fit.
+
+- `MAX_SVDQ_FILE_BYTES` is now `64 * 1024**3`, aligned with the hub's real
+  per-file ceiling, so it still refuses a genuinely absurd file. Comment
+  cites `checkpointGrantMaxBytesPerFile` so the next reader does not inherit
+  the myth.
+- The real constraint the guard was groping for is unchanged and still
+  honored: a nunchaku checkpoint must publish **whole**, because resharding
+  strips the `__metadata__` its loader reads. Verified the svdq lane never
+  reaches `clone.py`'s resharder — `build_svdq_flavor_tree` hardlinks the
+  single file itself, and `publish` → `publish_flavors` → `HubClient` goes
+  straight to the hub's part plan.
+- Same myth corrected in `models/loading.py`'s `_single_file_checkpoint`
+  docstring.
+
+Unblocks: mirroring the official nunchaku qwen-image fp4 artifact (th#1211's
+speed benchmark) and flux.1's 7 GB artifacts.
+
 ## 0.67.1 (2026-07-26) — pgw#675 override dtype + pgw#676 native-crash attribution (the sdxl retag blockers)
 
 ### pgw#675: a component override now loads at the dtype the base tree's LOAD LANE computes at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,30 @@ were both blocked, even though the comment claimed flux fit.
 Unblocks: mirroring the official nunchaku qwen-image fp4 artifact (th#1211's
 speed benchmark) and flux.1's 7 GB artifacts.
 
+### th#1211 G4: `_PIN_MATRIX` gains nunchaku 1.3 <-> diffusers 0.39 (UNVERIFIED)
+
+The matrix had ONE row (nunchaku 1.2 <-> diffusers 0.36), so
+`check_svdq_stack_versions` raised for every other nunchaku minor. That left no
+legal svdq stack for qwen-image, which serves diffusers 0.39: nunchaku 1.2.1 is
+in the matrix but demands 0.36 and caps at torch 2.11, while nunchaku 1.3.0dev
+has the torch-2.12/cu13.0 wheel but was refused outright.
+
+- New row `SvdqPin((1, 3), (0, 39), (0, 40))`, marked **UNVERIFIED** in-comment:
+  admitted on a STATIC signature check, with the live A/B still owed (closes
+  during th#1211's P2). Add-then-verify follows gw#405's own precedent, and the
+  row is inert until a nunchaku 1.3 wheel is actually installed — today only
+  th#1211's benchmark-only serve variant.
+- The static basis, recorded so the live check knows what to confirm: nunchaku's
+  `forward` and diffusers 0.39's have drifted positionally (nunchaku keeps
+  `txt_seq_lens`, 0.39 dropped it and added `additional_t_cond`, so position 6
+  onward misbinds on a positional call) — but diffusers 0.39's
+  `QwenImagePipeline` calls the transformer with **keyword arguments only** and
+  passes neither drifted param, so the gw#405 positional hazard is void and no
+  unexpected-kwarg error can fire on the t2i path. **Numerical equivalence is
+  NOT established by this.** t2i only; `QwenImageEditPlusPipeline` unchecked.
+- The 1.2 row is untouched and still rejects diffusers 0.39; the wheel-tag torch
+  guard still fires (a torch2.12 wheel on torch 2.13 raises, as before).
+
 ## 0.67.1 (2026-07-26) — pgw#675 override dtype + pgw#676 native-crash attribution (the sdxl retag blockers)
 
 ### pgw#675: a component override now loads at the dtype the base tree's LOAD LANE computes at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.67.1"
+version = "0.67.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/svdq.py
+++ b/src/gen_worker/convert/svdq.py
@@ -27,11 +27,17 @@ from ..net import hf
 
 logger = logging.getLogger(__name__)
 
-# R2 single-PUT cap (clone.py reshards bigger files) — but sharding a nunchaku
-# checkpoint strips the __metadata__ its loader needs, so oversize svdq
-# artifacts are refused until component-level reassembly lands (qwen-image
-# files are 11.5-13.1 GB; z-image/flux fit). Tracked in the qwen rollout issue.
-MAX_SVDQ_FILE_BYTES = 5 * 1000**3
+# Aligned with the hub's real per-file ceiling: the checkpoint-commit grant
+# allows 64 GiB/file (tensorhub checkpointGrantMaxBytesPerFile), and uploads go
+# out as presigned MULTIPART parts (hub issues part_urls/part_size), so a large
+# single file is just more parts. The old 5 GB value cited an "R2 single-PUT
+# cap" that does not exist in this stack — it wrongly blocked every nunchaku
+# family except z-image (qwen-image 11.5-13.1 GB, flux.1 6.8-7.0 GB).
+# Sharding a nunchaku checkpoint WOULD strip the __metadata__ its loader needs,
+# which is why it must publish whole — and publishing whole is allowed. The
+# svdq lane never reaches clone.py's resharder: build_svdq_flavor_tree hardlinks
+# the file itself, and publish_flavors goes straight to the hub client. th#1211.
+MAX_SVDQ_FILE_BYTES = 64 * 1024**3
 
 
 def svdq_flavor_label(art: SvdqArtifact) -> str:
@@ -62,9 +68,10 @@ def build_svdq_flavor_tree(
     size = svdq_file.stat().st_size
     if size > MAX_SVDQ_FILE_BYTES:
         raise ValueError(
-            f"svdq file {svdq_file.name} is {size / 1e9:.1f} GB > single-PUT "
-            f"cap; sharding would strip nunchaku metadata — component-level "
-            f"reassembly is not implemented yet (gw#415 follow-up)"
+            f"svdq file {svdq_file.name} is {size / 1e9:.1f} GB > "
+            f"{MAX_SVDQ_FILE_BYTES / 1024**3:.0f} GiB hub per-file ceiling; it "
+            f"must publish whole (sharding strips nunchaku metadata), so there "
+            f"is no fallback for a file this large"
         )
     if component is None:
         component = next(

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -620,9 +620,11 @@ def _single_file_checkpoint(path: Path) -> Optional[Path]:
     ``*.safetensors`` when no ``model_index.json``/``config.json`` exists
     (e.g. Illustrious-XL, civitai checkpoints).
 
-    Mirrors reshard any >5GB safetensors into byte-offset shards + an
-    ``*.safetensors.index.json`` (R2 single-PUT cap), so a big single-file
-    checkpoint arrives as N shards. Those are reassembled once into the
+    Mirrors reshard oversize safetensors into byte-offset shards + an
+    ``*.safetensors.index.json`` (the HF shard convention — NOT an "R2
+    single-PUT cap"; no such cap exists here, uploads are multipart and the
+    hub grants 64 GiB/file), so a big single-file checkpoint arrives as N
+    shards. Those are reassembled once into the
     original file (mmap-backed, ~disk-copy cost) and cached in the snapshot
     dir — ``from_single_file`` only takes one file."""
     if path.is_file():

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -76,6 +76,19 @@ class SvdqPin:
 _PIN_MATRIX: tuple[SvdqPin, ...] = (
     # 1.2.x: CI-pinned to diffusers 0.36 (verified live in gw#405).
     SvdqPin((1, 2), (0, 36), (0, 37)),
+    # 1.3.x <-> diffusers 0.39: UNVERIFIED — static signature check only, live
+    # A/B still owed (th#1211 G4/G4a). Admitted add-then-verify per gw#405's own
+    # precedent; inert until a nunchaku 1.3 wheel is actually installed, which
+    # today is only th#1211's benchmark-only serve variant.
+    # Static basis: nunchaku's forward and diffusers 0.39's HAVE drifted
+    # positionally (nunchaku keeps txt_seq_lens, 0.39 dropped it and added
+    # additional_t_cond, so position 6+ misbinds on a positional call), BUT
+    # diffusers 0.39's QwenImagePipeline calls the transformer with keyword
+    # arguments only and never passes either drifted param — so the gw#405
+    # positional hazard is void and no unexpected-kwarg error can fire on the
+    # t2i path. Numerical equivalence is NOT established by that check.
+    # t2i only: QwenImageEditPlusPipeline was not checked.
+    SvdqPin((1, 3), (0, 39), (0, 40)),
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.67.1"
+version = "0.67.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Promotes gen-worker **0.67.3** so it can be published to PyPI. th#1211's benchmark and
te#119's conversion lane are both blocked on a *published* 0.67.3 — neither can pin chaos
source.

## Cargo — verified by CONTENT, not by commit count

`git log origin/master..origin/chaos` lists ~200 commits, which is misleading: chaos merges
master back in while master takes squashed promotions, so the same work appears under
different SHAs. The honest signal is the content diff, and it is **exactly 5 files**:

```
CHANGELOG.md                     | 52 ++++++++++
pyproject.toml                   |  2 +-      (0.67.1 -> 0.67.3)
src/gen_worker/convert/svdq.py   | 23 +++---
src/gen_worker/models/loading.py |  8 +--
src/gen_worker/models/svdq.py    | 13 ++++
5 files changed, 86 insertions(+), 12 deletions(-)
```

`git diff HEAD origin/chaos` is **empty** — this branch is byte-identical to chaos.

**Nothing else rides along.** In particular **0.67.2's eager-first compile work is NOT in
this train** — it is still uncommitted in the chaos worktree, so it is not on `origin/chaos`
and cannot be carried. That lane's `0.67.2` claim is untouched and still theirs; this
release deliberately skipped to `0.67.3` to avoid taking a claimed version. Consequence
worth stating plainly: **PyPI will receive 0.67.3 before 0.67.2 exists.** That is legal and
harmless (no ordering requirement), but it will look odd in the release list, so it is
recorded here rather than discovered later.

## The two changes

**1. `MAX_SVDQ_FILE_BYTES` 5 GB -> 64 GiB** (`convert/svdq.py`)

The guard justified itself in-comment as an "R2 single-PUT cap". No such cap exists in this
stack:
- the hub's checkpoint-commit grant allows **64 GiB/file** (`checkpointGrantMaxBytesPerFile`)
- uploads leave as presigned **multipart** parts (the hub issues `part_urls`/`part_size`)
- a **46 GB** monolithic `ltx-2.3-22b-dev.safetensors` has already published raw here

It was therefore refusing **every** nunchaku-supported family except z-image-turbo:
qwen-image at 11.5-13.1 GB *and* flux.1 at 6.8-7.0 GB, the latter despite the comment
claiming flux fit. Now aligned to the hub's real ceiling, so it still refuses an absurd file.

The real constraint the guard was groping for is unchanged and still honored: a nunchaku
checkpoint must publish **whole**, because resharding strips the `__metadata__` its loader
reads. Verified the svdq lane never reaches `clone.py`'s resharder —
`build_svdq_flavor_tree` hardlinks the single file itself, and
`publish` -> `publish_flavors` -> `HubClient` goes straight to the hub's part plan
(`publish.py` has zero reshard/size-cap references). Same myth corrected in
`models/loading.py`'s `_single_file_checkpoint` docstring.

**2. `_PIN_MATRIX` gains nunchaku 1.3 <-> diffusers 0.39 — marked UNVERIFIED** (`models/svdq.py`)

The matrix had ONE row (1.2 <-> diffusers 0.36), so `check_svdq_stack_versions` raised for
every other nunchaku minor — leaving **no legal svdq stack for qwen-image**, which serves
diffusers 0.39. Neither option worked off the shelf: 1.2.1 is in the matrix but demands 0.36
and caps at torch 2.11; 1.3.0dev has the torch-2.12/cu13.0 wheel and was refused outright.

Admitted on a **static** signature check, add-then-verify per gw#405's own precedent. The
signatures HAVE drifted positionally — nunchaku keeps `txt_seq_lens`, 0.39 dropped it and
added `additional_t_cond`, so position 6+ misbinds on a positional call — **but** diffusers
0.39's `QwenImagePipeline` calls the transformer with keyword arguments only and passes
neither drifted param, so the gw#405 positional hazard is void and no unexpected-kwarg error
can fire on the t2i path.

**Numerical equivalence is NOT established by that check.** The row is commented UNVERIFIED
and the live A/B closes during th#1211's P2. It is inert until a nunchaku 1.3 wheel is
actually installed — today only th#1211's benchmark-only variant. t2i only;
`QwenImageEditPlusPipeline` unchecked. The 1.2 row is untouched and still rejects 0.39, and
the wheel-tag torch guard still fires.

## Tests

`pytest tests/ -k "svdq or quant or convert"` on this branch: **45 passed, 1 xfailed**.
Full suite is CI's gate.

## After merge

Tag `v0.67.3` from master -> `publish.yml` -> PyPI. Then te#119 bumps the conversion pin for
real, and th#1211's bench build proceeds.

Refs: th#1211 (F1-F4, G1-G5), th#1213, ie#559, gw#405, gw#415
