### PR TITLE
release: gen-worker 0.67.4 — pgw#680 guard-miss doctrine (fail-on-recompile at serve; catch -> eager + confession + background heal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.67.4 (2026-07-26) — pgw#680: guard-miss doctrine — fail-on-recompile at serve time
+
+The 187s incident class (ie#546 retag cycle): a tenant request whose inputs
+missed every cached guard set paid dynamo's INLINE recompile inside the
+request — and, single-flight, stalled every request queued behind it.
+Doctrine (Paul, verbatim intent): "instead of compiling [inline], it should
+throw an error, which we catch, then run in eager mode + compile [in
+background] and note the mismatch."
+
+- **Serve-window stance**: tenant request execution (the executor's
+  `tenant_serve_window`, entered around the handler call only) runs guarded
+  compiled targets under `torch._dynamo.config.error_on_recompile`, scoped
+  per call via `config.patch`. Chosen over
+  `torch.compiler.set_stance("fail_on_recompile")` deliberately: on torch
+  2.13 ConfigModule user overrides are thread-local ContextVars, so the
+  stance arms exactly the serving thread while the concurrent shape-warm
+  thread and background mint keep compiling; and `error_on_recompile` fires
+  only on a genuine recompile, composing with the multi-graph cache (warm
+  entries serve under it; a first compile never trips it). `set_stance` is
+  process-global and raises for any tensor frame. Warm/mint/adopt/boot
+  windows never enter the window — they exist to compile.
+- **The catch** (`compile_cache._guarded` / `_guarded_regional`): dynamo's
+  `RecompileError` serves THIS request eager immediately (regional: original
+  runs once under thread-scoped `config.patch(disable=True)` — block impls
+  untouched), never the permanent-degrade path: no revocation, no tier flip,
+  no quarantine — the lane is healthy for its known input classes.
+- **The confession is data**: every miss emits a typed `guard_miss`
+  activity event (`activity.emit_event` — one self-contained COMPLETED
+  update that never displaces an open activity's `_current` beat): phase =
+  the guard-reason class token (`compile_cache.guard_miss_reason_class`),
+  detail = torch's verbatim reason + signature identity + cell key + request
+  id (`postmortem.current_inflight_request`) + heal verdict — hub-countable
+  per (release, SKU, guard-reason); top-N reasons are one grep away.
+- **Background heal** (`hot_swap.Router.record_guard_miss`): the exact input
+  class recompiles through the existing shape-warm driver (nice +10, own
+  CUDA stream, zero-filled dummies of the failing request's args, dedup by
+  signature) so the SECOND request of the shape is compiled. Signatures
+  missing past `_GUARD_MISS_HEAL_LIMIT` (2) heals are per-request-volatile:
+  routed eager permanently on every router (including never-concurrent
+  mandatory lanes) instead of thrashing compile churn.
+
+Red-verified end to end (`tests/test_guard_miss_pgw680.py`): real-torch
+tapes (real dynamo guards, real RecompileError, real warm thread) + the
+full `handle_run_job` tenant path; with the window neutralized (the pre-fix
+tree) the same input pays a silent inline recompile with zero confession.
+
 ## 0.67.3 (2026-07-26) — th#1211: the svdq 5 GB guard cited a cap that does not exist
 
 `MAX_SVDQ_FILE_BYTES` was `5 * 1000**3`, justified in-comment as an "R2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.67.3"
+version = "0.67.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -48,6 +48,11 @@ logger = logging.getLogger(__name__)
 
 KIND_SELF_MINT_COMPILE = "self_mint_compile"
 KIND_WARMUP = "warmup"
+# pgw#680: one tenant request hit fail-on-recompile on a compiled lane and
+# was served eager; phase carries the guard-reason class token, detail the
+# full confession. The hub accepts any kind and logs completions verbatim,
+# so top-N reasons are countable per (worker -> release, SKU) hub-side.
+KIND_GUARD_MISS = "guard_miss"
 
 PHASE_LOAD = "load"
 PHASE_TRACE_GRAPH = "trace_graph"
@@ -223,6 +228,23 @@ class Activity:
             )[:2000],
         )
         _end(self)
+
+
+def emit_event(kind: str, detail: str, phase: str = "") -> None:
+    """One self-contained COMPLETED ActivityUpdate — a countable typed
+    EVENT (pgw#680 ``guard_miss``), not a running activity.
+
+    Deliberately bypasses :func:`begin`: begin() swaps the module-global
+    ``_current``, and ending an event would strand a concurrently open
+    long-running activity (background mint) without its progress beat.
+    Thread-safe; without a bound sink it lands on the logger like every
+    other report."""
+    _emit(pb.ActivityUpdate(
+        kind=kind, phase=phase[:300], seq=_next_seq(),
+        state=pb.ActivityState.ACTIVITY_STATE_COMPLETED,
+        detail=detail[:2000],
+        updated_at_unix_ms=int(time.time() * 1000),
+    ))
 
 
 def begin(kind: str, phase: str = "") -> Activity:

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -41,6 +41,8 @@ compiled from — informational, never part of the match.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import ctypes
 import filecmp
 import functools
@@ -60,7 +62,7 @@ import weakref
 from dataclasses import dataclass
 from pathlib import Path
 from pathlib import PurePosixPath
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple
 
 import inspect
 import pickle
@@ -311,6 +313,197 @@ def reset_target_code(pipeline: Any) -> int:
             "compile-cache: dropped in-memory compiled code for %d target "
             "code object(s) ahead of the proof window (pgw#672)", reset)
     return reset
+
+
+# ---------------------------------------------------------------------------
+# pgw#680: guard-miss doctrine — fail-on-recompile at serve time.
+#
+# The 187s incident class: a tenant request whose inputs miss every cached
+# guard set used to pay dynamo's INLINE recompile inside the request (and,
+# single-flight, stall every request queued behind it). Doctrine: tenant
+# requests on compiled lanes run under a fail-on-recompile stance; the raise
+# is caught in the guard wrappers, THIS request serves eager immediately, the
+# guard-failure reason is recorded verbatim (Activity event + hub-countable),
+# and the exact input class is healed by the existing background warm driver
+# so the SECOND request of that shape is compiled.
+#
+# Stance choice (deliberate, torch 2.13): ``torch._dynamo.config
+# .error_on_recompile`` scoped via ``config.patch`` around the guarded
+# compiled call — NOT ``torch.compiler.set_stance("fail_on_recompile")``.
+# Two reasons, both verified against torch 2.13.0:
+#   1. Scope. ConfigModule user overrides are ContextVars, i.e. THREAD-LOCAL
+#      (the same mechanics gw#608 measured for ``enable_autograd_cache``).
+#      The stance therefore arms exactly the serving thread's guarded call;
+#      the hot-swap shape-warm thread and the background mint driver — which
+#      run CONCURRENTLY with tenant requests by design (pgw#671) — keep
+#      compiling freely. ``set_stance`` mutates a module-global and swaps the
+#      process-wide eval-frame callback: it would fail every concurrent
+#      warm/mint compile for the duration of a tenant call.
+#   2. Semantics. ``error_on_recompile`` raises only on a genuine RECOMPILE
+#      (existing cache entries, none matching — the guard-miss), composing
+#      with the multi-graph cache: warm entries keep serving under it, and a
+#      first-ever compile of a new code object never trips it.
+#      ``fail_on_recompile``'s callback raises for ANY tensor frame reaching
+#      dynamo while set, first compiles included.
+#
+# Windows: only the tenant execute window (executor ``tenant_serve_window``)
+# arms the stance. Warm / mint / adopt / boot-proof windows never enter it —
+# they exist to compile — and the marking is positive (default off), so any
+# path not explicitly marked keeps today's semantics.
+# ---------------------------------------------------------------------------
+
+_SERVE_WINDOW: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "gw_tenant_serve_window", default=False)
+
+
+@contextlib.contextmanager
+def tenant_serve_window() -> Iterator[None]:
+    """Mark the current context as tenant-request execution (pgw#680).
+
+    Entered by the executor around the tenant handler call ONLY. ContextVars
+    propagate through ``asyncio.to_thread``/``create_task``, so the handler
+    thread that ultimately invokes the guarded compiled targets sees it."""
+    token = _SERVE_WINDOW.set(True)
+    try:
+        yield
+    finally:
+        _SERVE_WINDOW.reset(token)
+
+
+def in_tenant_serve_window() -> bool:
+    return _SERVE_WINDOW.get()
+
+
+@contextlib.contextmanager
+def _fail_on_recompile() -> Iterator[bool]:
+    """Arm the serve-window recompile stance for the calling thread.
+
+    Yields True when armed. No-op (False) outside the tenant serve window
+    or when torch/dynamo is unavailable — proof/warm/mint windows and
+    non-torch environments keep exact current semantics."""
+    if not _SERVE_WINDOW.get():
+        yield False
+        return
+    try:
+        import torch._dynamo
+
+        patch = torch._dynamo.config.patch(error_on_recompile=True)
+    except Exception:
+        logger.debug(
+            "compile-cache: recompile stance unavailable", exc_info=True)
+        yield False
+        return
+    with patch:
+        yield True
+
+
+def _is_recompile_error(exc: BaseException) -> bool:
+    """True for dynamo's fail-on-recompile raise (the guard-miss signal)."""
+    try:
+        from torch._dynamo import exc as dexc
+
+        return isinstance(exc, dexc.RecompileError)
+    except Exception:
+        return False
+
+
+@dataclass(frozen=True)
+class GuardMiss:
+    """One tenant request that hit fail-on-recompile on a compiled target.
+
+    ``reason`` is torch's verbatim message — per cached entry, the exact
+    guard that failed (size/stride/scalar specialization, …): the confession
+    is the data for the cell-reusability investigation (Paul's GPU-A/B
+    hypothesis). ``sig`` is the request's shape/axis identity as the hot-swap
+    router sees it; ``heal`` is the background-heal verdict."""
+
+    target: str
+    reason: str
+    sig: str
+    heal: str
+    misses: int
+
+
+_GUARD_REASON_LINE_RE = re.compile(r"^\s*-\s*(?:\d+/\d+:\s*)?(.+)$")
+
+
+def guard_miss_reason_class(reason: str) -> str:
+    """A short, stable class token for one verbatim guard-miss reason.
+
+    The first per-entry failure line, entry index stripped, whitespace
+    collapsed, clipped — so top-N reasons are one ``sort | uniq -c`` away on
+    the hub's activity log (per pgw#680 the reasons ARE the instrument)."""
+    for line in str(reason or "").splitlines():
+        m = _GUARD_REASON_LINE_RE.match(line)
+        if m:
+            return _clip(m.group(1), 120)
+    first = str(reason or "").strip().splitlines()
+    return _clip(first[0], 120) if first else "unclassified"
+
+
+def set_guard_miss_callback(
+    pipeline: Any, callback: Callable[[GuardMiss], None],
+) -> bool:
+    """Bind serve-time guard-miss telemetry to an armed consumer guard.
+
+    Observability only: a failing callback is logged and swallowed — it must
+    never break the eager serve of the request that confessed."""
+    marker = getattr(pipeline, _MARKER_ATTR, None) or {}
+    signal = marker.get("failure_signal")
+    if not isinstance(signal, dict):
+        return False
+    signal["on_guard_miss"] = callback
+    return True
+
+
+def guard_miss_count(pipeline: Any) -> int:
+    """Serve-time guard misses observed on this exact pipeline's guards."""
+    return _proof_count(pipeline, "guard_misses")
+
+
+def _record_guard_miss(
+    label: str,
+    exc: BaseException,
+    args: tuple,
+    kwargs: dict,
+    failure_signal: Optional[Dict[str, Any]],
+    heal_target: Callable[..., Any],
+) -> GuardMiss:
+    """The catch half of pgw#680: count, heal, confess. Never raises."""
+    signal = failure_signal or {}
+    router = signal.get("router")
+    sig: Tuple[Any, ...] = (label, hot_swap.signature(args, kwargs))
+    heal = "no_router"
+    if isinstance(router, hot_swap.Router):
+        heal = router.record_guard_miss(sig, label, heal_target, args, kwargs)
+    misses = 1
+    lock = signal.get("lock")
+    if isinstance(lock, _LOCK_TYPE):
+        with lock:
+            misses = int(signal.get("guard_misses", 0)) + 1
+            signal["guard_misses"] = misses
+    miss = GuardMiss(
+        target=label,
+        reason=str(exc),
+        sig=repr(sig[1]),
+        heal=heal,
+        misses=misses,
+    )
+    logger.warning(
+        "compile-cache: guard-miss on compiled %s — serving THIS request "
+        "eager, background heal=%s (pgw#680; miss #%d for this object). "
+        "Torch's verbatim reason:\n%s",
+        label, heal, misses, miss.reason,
+    )
+    callback = signal.get("on_guard_miss")
+    if callable(callback):
+        try:
+            callback(miss)
+        except Exception:
+            logger.exception(
+                "compile-cache: guard-miss telemetry callback failed "
+                "(request still served eager)")
+    return miss
 
 
 # ---------------------------------------------------------------------------
@@ -1846,12 +2039,25 @@ def _guarded(
                 return original(*args, **kwargs)
         before = proof_before()
         try:
-            result = compiled(*args, **kwargs)
+            # pgw#680: tenant serve windows run fail-on-recompile — a guard
+            # miss raises instead of paying dynamo's inline recompile in the
+            # request. Warm cache entries serve normally under the stance;
+            # proof/warm/mint windows never arm it (see _fail_on_recompile).
+            with _fail_on_recompile():
+                result = compiled(*args, **kwargs)
             record_success(before)
             if router is not None:
                 router.mark_warm(sig)
             return result
         except Exception as exc:  # noqa: BLE001 — every lane degrades to eager
+            if _is_recompile_error(exc):
+                # pgw#680 catch: the compiled lane is HEALTHY for its known
+                # input classes — this request's class missed. Serve it eager
+                # now, confess loudly, heal the exact class in background.
+                # Never the permanent-degrade path below.
+                _record_guard_miss(
+                    label, exc, args, kwargs, failure_signal, compiled)
+                return original(*args, **kwargs)
             state["failed"] = True
             state["detail"] = (
                 f"compiled {'W8A8 ' if fail_closed else ''}target {label} failed: "
@@ -1929,6 +2135,24 @@ def _guarded_regional(
             signal["cache_misses"] = int(signal.get("cache_misses", 0)) + max(
                 0, int(stats.get("fxgraph_cache_miss", 0)))
 
+    def _eager_once(args: tuple, kwargs: dict) -> Any:
+        """One fully-eager call of the in-place-compiled module (pgw#680).
+
+        Regional blocks have no separable eager callable — the compiled
+        impls live ON the blocks — so the guard-miss eager serve runs the
+        original with dynamo disabled for this thread/call: existing
+        compiled entries are bypassed, nothing recompiles, block state is
+        untouched (verified on torch 2.13: ``config.disable`` is the same
+        thread-local ContextVar surface as the stance)."""
+        try:
+            import torch._dynamo
+
+            patch = torch._dynamo.config.patch(disable=True)
+        except Exception:
+            return original(*args, **kwargs)
+        with patch:
+            return original(*args, **kwargs)
+
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if state["revocation_error"]:
@@ -1936,10 +2160,17 @@ def _guarded_regional(
         if not state["failed"]:
             before = proof_before()
             try:
-                result = original(*args, **kwargs)
+                # pgw#680: the compiled block impls execute inside this
+                # call — the serve-window stance covers them here.
+                with _fail_on_recompile():
+                    result = original(*args, **kwargs)
                 record_success(before)
                 return result
             except Exception as exc:  # noqa: BLE001 — every lane degrades to eager
+                if _is_recompile_error(exc):
+                    _record_guard_miss(
+                        label, exc, args, kwargs, failure_signal, original)
+                    return _eager_once(args, kwargs)
                 state["failed"] = True
                 state["detail"] = (
                     f"regional compiled {'W8A8 ' if fail_closed else ''}"
@@ -2059,6 +2290,9 @@ def apply(
         "successful_calls": 0,
         "cache_hits": 0,
         "cache_misses": 0,
+        # pgw#680: serve-window guard misses (count) + telemetry callback.
+        "guard_misses": 0,
+        "on_guard_miss": None,
         # pgw#622: whole-graph consumer guards route novel signatures
         # through this; sequential until hot_swap.enable() post-proof.
         "router": hot_swap.Router(fail_closed=fail_closed) if guard else None,
@@ -2993,7 +3227,13 @@ __all__ = [
     "fx_cache_failure_report",
     "fx_key_forensics",
     "gen_worker_version",
+    "GuardMiss",
+    "guard_miss_count",
+    "guard_miss_reason_class",
     "has_compile_target",
+    "in_tenant_serve_window",
+    "set_guard_miss_callback",
+    "tenant_serve_window",
     "inductor_counters",
     "is_cache_ref",
     "lane_bucket",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -89,6 +89,7 @@ from .runtime_config import ConfigStore, extract_job_config
 from .stage_timing import stage_ms_for_metrics
 
 if typing.TYPE_CHECKING:
+    from . import compile_cache
     from . import fleet_cells
     from .models.hub_client import WorkerResolvedRepo
     from .models.serve_fit import ServePlan
@@ -3239,7 +3240,55 @@ class Executor:
 
         if trt_engine.set_guard_failure_callback(target.pipeline, callback):
             return True
-        return compile_cache.set_guard_failure_callback(target.pipeline, callback)
+        if not compile_cache.set_guard_failure_callback(
+            target.pipeline, callback,
+        ):
+            return False
+        # pgw#680: serve-window guard misses confess through the same
+        # target (telemetry only — no state mutation, no revocation). TRT
+        # engines never dynamo-recompile, so only torch guards bind this.
+        def miss_callback(miss: compile_cache.GuardMiss) -> None:
+            self._compile_guard_missed(rec, target, miss)
+
+        compile_cache.set_guard_miss_callback(target.pipeline, miss_callback)
+        return True
+
+    def _compile_guard_missed(
+        self,
+        rec: _ClassRecord,
+        target: _CompileTargetRecord,
+        miss: "compile_cache.GuardMiss",
+    ) -> None:
+        """pgw#680 confession: one tenant request hit fail-on-recompile.
+
+        Pure observability — the compiled identity stays active, the tier
+        stays compiled (the lane is healthy for its known input classes;
+        THIS class is healing in background). The typed event rides the
+        activity stream so the hub can count misses per (release, SKU,
+        guard-reason): kind=guard_miss, phase=reason class, detail=the
+        verbatim torch reason + shape identity + cell key + request id."""
+        from . import compile_cache, postmortem
+
+        with target.state_lock:
+            cell = target.active_compile_ref
+            digest = target.active_compile_snapshot_digest
+        reason_class = compile_cache.guard_miss_reason_class(miss.reason)
+        request_id = postmortem.current_inflight_request()
+        detail = (
+            f"fn={sorted(target.function_names)} target={miss.target} "
+            f"cell={cell or '<none>'} digest={digest[:16] or '<none>'} "
+            f"request={request_id or '<unknown>'} heal={miss.heal} "
+            f"miss_n={miss.misses} sig={miss.sig[:400]} "
+            f"reason={miss.reason}"
+        )
+        logger.warning(
+            "guard_miss (pgw#680): compiled %s served eager for request %s "
+            "— reason class %r, heal=%s, cell=%s",
+            miss.target, request_id or "<unknown>", reason_class, miss.heal,
+            cell or "<none>",
+        )
+        activity_mod.emit_event(
+            activity_mod.KIND_GUARD_MISS, detail, phase=reason_class)
 
     def _install_compile_targets(
         self,
@@ -8727,9 +8776,17 @@ class Executor:
                             "request", spec.name,
                             request_id=str(run.request_id or ""))
                         try:
-                            output = await self._execute(
-                                job, spec, instance, ctx, payload, kwargs,
-                                timeout_ms=timeout_ms, gpu_index=gpu_index)
+                            from . import compile_cache as compile_cache_mod
+
+                            # pgw#680: tenant execution is THE serve window —
+                            # compiled lanes run fail-on-recompile inside it
+                            # (guard miss => eager + heal, never an inline
+                            # compile). Warm/mint/adopt paths go through
+                            # _invoke_warmup and never enter this window.
+                            with compile_cache_mod.tenant_serve_window():
+                                output = await self._execute(
+                                    job, spec, instance, ctx, payload, kwargs,
+                                    timeout_ms=timeout_ms, gpu_index=gpu_index)
                         except BaseException as exc:
                             # A mid-inference CUDA OOM learns a per-ref floor,
                             # but the live object is quarantined. The hub

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -45,6 +45,12 @@ _SIG_DEPTH = 4
 # routing for that router (back to today's behavior) instead of spamming
 # warm jobs forever.
 _MAX_SIGS = 256
+# pgw#680: how many background heals one signature gets after serve-window
+# guard misses. A signature that keeps missing AFTER its heals compiled is
+# diverging on something dynamo guards but our signature does not capture
+# per REQUEST (not per shape class) — healing cannot converge; route it
+# eager permanently instead of thrashing compile churn.
+_GUARD_MISS_HEAL_LIMIT = 2
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +195,16 @@ class Router:
         self.warm: set = set()
         self.pending: set = set()
         self.bg_failed: set = set()
+        # pgw#680 guard-miss heal state. ``healing``: sigs with an in-flight
+        # serve-window heal — routed EAGER (even on non-concurrent routers)
+        # until the warm thread marks them warm. ``volatile``: sigs past
+        # _GUARD_MISS_HEAL_LIMIT — permanently eager-routed (per-request
+        # guard variance; compiling cannot converge). Both are populated
+        # ONLY from serve-window misses, so proof/warm windows — which rely
+        # on sequential COMPILED verdicts — are never rerouted by them.
+        self.healing: set = set()
+        self.volatile: set = set()
+        self.guard_miss_counts: dict = {}
 
     def enable(self, on_warmed: Optional[Callable[[], None]] = None) -> bool:
         if self.fail_closed:
@@ -229,6 +245,14 @@ class Router:
         original while the background warm compiles this signature."""
         sig = (label, signature(args, kwargs))
         with self.lock:
+            # pgw#680: guard-miss verdicts outrank the concurrent gate — a
+            # sig mid-heal (or proven per-request-volatile) serves eager on
+            # EVERY router, including the never-concurrent mandatory lanes,
+            # instead of re-raising the stance each request.
+            if sig in self.volatile:
+                return EAGER, sig
+            if sig in self.healing:
+                return EAGER, sig
             if not self.concurrent or self.closed:
                 return COMPILED, sig
             if sig in self.warm:
@@ -284,7 +308,74 @@ class Router:
         with self.lock:
             self.pending.discard(sig)
             self.bg_failed.discard(sig)
+            self.healing.discard(sig)
             self.warm.add(sig)
+
+    def record_guard_miss(
+        self, sig: Tuple[Any, ...], label: str,
+        compiled: Callable[..., Any], args: tuple, kwargs: dict,
+    ) -> str:
+        """pgw#680 background heal: schedule the recompile for the exact
+        input class that just guard-missed at serve time.
+
+        Optimistic rules of the existing warm driver apply unchanged: the
+        one shape-warm thread compiles at nice +10 on its own CUDA stream,
+        no request ever waits, and the job carries a zero-filled dummy of
+        the failing request's own args (never tenant content) so the heal
+        targets the exact class. Dedup by signature; sigs past
+        ``_GUARD_MISS_HEAL_LIMIT`` become permanently eager (``volatile``).
+        Returns the verdict: healing | volatile | closed | queue_full |
+        no_dummy."""
+        with self.lock:
+            if self.closed:
+                return "closed"
+            self.warm.discard(sig)
+            count = self.guard_miss_counts.get(sig, 0) + 1
+            self.guard_miss_counts[sig] = count
+            if sig in self.volatile:
+                return "volatile"
+            if count > _GUARD_MISS_HEAL_LIMIT:
+                self.volatile.add(sig)
+                self.healing.discard(sig)
+                self.pending.discard(sig)
+                logger.error(
+                    "hot-swap: %s guard-missed %d times despite heals — "
+                    "per-request guard variance our signatures do not "
+                    "capture; routing this signature EAGER from now on "
+                    "(pgw#680)", label, count)
+                return "volatile"
+            if sig in self.healing:
+                return "healing"
+            self.healing.add(sig)
+            self.pending.add(sig)
+        try:
+            job = _WarmJob(
+                router=self, label=label, sig=sig, compiled=compiled,
+                args=_dummy_value(args), kwargs=_dummy_value(kwargs),
+                device=_first_cuda_device(args, kwargs),
+                grad_mode=_grad_mode(), autocast_dtype=_autocast_dtype(),
+            )
+        except Exception:
+            logger.warning(
+                "hot-swap: guard-miss heal dummy for %s failed; the "
+                "signature stays eager until its next miss", label,
+                exc_info=True)
+            with self.lock:
+                self.pending.discard(sig)
+                self.healing.discard(sig)
+            return "no_dummy"
+        if not _submit(job):
+            with self.lock:
+                self.pending.discard(sig)
+                self.healing.discard(sig)
+            logger.warning(
+                "hot-swap: warm queue full; guard-missed %s heal retried on "
+                "a later request", label)
+            return "queue_full"
+        logger.info(
+            "hot-swap: background heal scheduled for guard-missed %s "
+            "signature (pgw#680)", label)
+        return "healing"
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +472,10 @@ def _run_warm(job: _WarmJob) -> None:
     except BaseException as exc:  # noqa: BLE001 — contained per-signature
         with router.lock:
             router.pending.discard(job.sig)
+            # pgw#680: a failed guard-miss heal keeps the signature eager
+            # via bg_failed (concurrent routers) — the healing veto must
+            # not outlive its job on the non-concurrent ones.
+            router.healing.discard(job.sig)
             router.bg_failed.add(job.sig)
         try:
             import torch

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -574,6 +574,17 @@ def clear_inflight(
         _write_inflight(path)
 
 
+def current_inflight_request(kind: str = "request") -> str:
+    """The request id of the newest LIVE in-flight execution of ``kind``
+    (pgw#680: joins a serve-time guard-miss confession to the exact request
+    that hit it). '' when none is marked."""
+    with _inflight_lock:
+        for _token, record in sorted(_inflight_active.items(), reverse=True):
+            if record.get("kind") == kind and record.get("request_id"):
+                return str(record["request_id"])
+    return ""
+
+
 def take_inflight(path: Optional[Path] = None) -> list[Dict[str, Any]]:
     """Read and consume the active-execution list a dead process left."""
     path = path or INFLIGHT_PATH
@@ -676,6 +687,7 @@ __all__ = [
     "clear_inflight",
     "container_limits",
     "cpu_quota_cores",
+    "current_inflight_request",
     "describe_exit",
     "effective_cpu_count",
     "enable_fault_dump",

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -1,0 +1,646 @@
+"""pgw#680: guard-miss doctrine — fail-on-recompile at serve time.
+
+The 187s incident class (ie#546 retag cycle): a tenant request whose inputs
+missed every cached guard set paid dynamo's INLINE recompile inside the
+request, and single-flight stalled everything queued behind it. Paul's
+design, verbatim: "instead of compiling [inline], it should throw an error,
+which we catch, then run in eager mode + compile [in background] and note
+the mismatch."
+
+Doctrine under test:
+  1. STANCE — tenant requests on compiled lanes run under
+     ``torch._dynamo.config.error_on_recompile`` scoped to the executor's
+     ``tenant_serve_window`` (thread-local ConfigModule ContextVar, torch
+     2.13). Warm/mint/adopt/boot windows never enter the window, so they
+     keep compiling; the stance cannot leak into them by construction.
+  2. CATCH — the guard wrappers catch dynamo's ``RecompileError``, serve
+     THIS request eager immediately, and record the mismatch loudly: the
+     verbatim guard-failure reason, the shape/axis identity, the cell key,
+     the request id — as a typed ``guard_miss`` activity event the hub can
+     count per (release, SKU, guard-reason).
+  3. HEAL — the exact input class is recompiled through the existing
+     background shape-warm driver (nice +10, own stream, dedup by
+     signature), so the SECOND request of that shape hits compiled. A
+     signature that keeps missing after its heals is per-request-volatile
+     and gets routed eager permanently instead of thrashing.
+
+The real-torch tapes drive REAL ``torch.compile(backend="eager")`` guards —
+real dynamo guard evaluation, real RecompileError, the REAL wrappers and
+the REAL background warm thread. The executor tape drives the REAL
+``handle_run_job`` tenant path end-to-end with the torch.compile leaf
+simulated at the same boundary as tests/test_serve_finalize_pgw672.py.
+
+RED (verified before the fix landed): with the serve window neutralized —
+exactly the pre-pgw#680 tree's behavior — the same guard-missing input
+recompiles INLINE inside the request, silently
+(test_outside_serve_window_recompiles_inline is that behavior, kept as the
+permanent contrast tape for the warm/mint windows).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import msgspec
+import pytest
+import torch
+import torch.nn as nn
+from torch._dynamo import exc as dexc
+
+import gen_worker.executor as executor_mod
+from gen_worker import Compile, activity as activity_mod
+from gen_worker import cell_key as cell_key_mod
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells, hot_swap
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.executor import Executor
+from gen_worker.models import provision
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+FAMILY = "sdxl"
+MODEL_DIGEST = "blake3:" + "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# Real-torch tapes: REAL dynamo guards, REAL RecompileError, REAL wrappers,
+# REAL background warm thread. backend="eager" keeps full guard machinery
+# without needing an inductor toolchain or a GPU.
+# ---------------------------------------------------------------------------
+
+
+class _Mod(nn.Module):
+    """``k`` is an int attribute dynamo SPECIALIZES on: changing it after a
+    compile guard-misses with a byte-identical call signature — exactly the
+    "variable we're not understanding" class (scalar specialization)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.k = 2
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.k
+
+
+def _signal(router: Optional[hot_swap.Router]) -> Dict[str, Any]:
+    return {
+        "callback": None,
+        "lock": threading.Lock(),
+        "successful_calls": 0,
+        "cache_hits": 0,
+        "cache_misses": 0,
+        "guard_misses": 0,
+        "on_guard_miss": None,
+        "router": router,
+    }
+
+
+def _wait(predicate: Any, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("background heal never completed")
+
+
+def test_serve_window_guard_miss_serves_eager_records_and_heals() -> None:
+    """THE core tape: a warm-signature request whose guards miss under the
+    stance (a) never raises to the caller and never pays an inline compile,
+    (b) returns the correct EAGER result immediately, (c) confesses the
+    verbatim torch reason through the typed callback, (d) heals in
+    background so the SECOND request of the shape runs compiled."""
+    mod = _Mod()
+    original = mod.forward
+    compiled = torch.compile(mod.forward, backend="eager", dynamic=False)
+    router = hot_swap.Router()
+    signal = _signal(router)
+    misses: List[cc.GuardMiss] = []
+    signal["on_guard_miss"] = misses.append
+    wrapped = cc._guarded(
+        original, compiled, "transformer.forward", failure_signal=signal)
+
+    x = torch.ones(4)
+    # Boot-window semantics: sequential router, first compile outside the
+    # serve window (a first compile is not a recompile — it would not raise
+    # even inside it); concurrency enables post-proof, like the executor.
+    assert torch.equal(wrapped(x), x * 2)
+    warm_sig = ("transformer.forward", hot_swap.signature((x,), {}))
+    assert warm_sig in router.warm
+    router.enable()
+
+    mod.k = 3  # guard miss with an IDENTICAL call signature
+    with cc.tenant_serve_window():
+        out = wrapped(x)
+    # (a)+(b): served, eager, correct — and the object is NOT degraded.
+    assert torch.equal(out, x * 3)
+    assert not signal.get("failed", False)
+    assert cc.guard_miss_count is not None  # api exists
+    assert signal["guard_misses"] == 1
+    # (c): the confession carries torch's verbatim reason + identity.
+    assert len(misses) == 1
+    miss = misses[0]
+    assert miss.target == "transformer.forward"
+    assert "guard failure" in miss.reason
+    assert miss.heal == "healing"
+    assert miss.misses == 1
+    assert cc.guard_miss_reason_class(miss.reason) != "unclassified"
+    # The signature was demoted out of warm and routes EAGER while healing.
+    assert warm_sig not in router.warm
+    verdict, _sig = router.route(
+        "transformer.forward", compiled, (x,), {})
+    assert verdict == hot_swap.EAGER
+
+    # (d): the background warm thread compiles the exact class; the second
+    # request of the shape hits compiled under the stance, no new miss.
+    _wait(lambda: warm_sig in router.warm)
+    with cc.tenant_serve_window():
+        out2 = wrapped(x)
+    assert torch.equal(out2, x * 3)
+    assert signal["guard_misses"] == 1, "second request must not miss"
+    assert not misses[1:]
+
+
+def test_outside_serve_window_recompiles_inline() -> None:
+    """The warm/mint/boot-window contract (and the RED behavior): outside
+    the serve window the identical guard-missing input pays the inline
+    recompile silently — windows that exist to compile keep compiling."""
+    mod = _Mod()
+    compiled = torch.compile(mod.forward, backend="eager", dynamic=False)
+    router = hot_swap.Router()
+    signal = _signal(router)
+    misses: List[cc.GuardMiss] = []
+    signal["on_guard_miss"] = misses.append
+    wrapped = cc._guarded(
+        mod.forward, compiled, "transformer.forward", failure_signal=signal)
+
+    x = torch.ones(4)
+    wrapped(x)
+    router.enable()
+    mod.k = 5
+    out = wrapped(x)  # NO serve window: dynamo recompiles inline, no raise
+    assert torch.equal(out, x * 5)
+    assert signal["guard_misses"] == 0
+    assert misses == []
+
+
+def test_repeatedly_volatile_signature_routes_eager_permanently() -> None:
+    """A signature that guard-misses past the heal limit is per-request
+    volatile (guards diverge on something our signatures do not capture):
+    stop compile churn, route it eager permanently, keep serving."""
+    mod = _Mod()
+    compiled = torch.compile(mod.forward, backend="eager", dynamic=False)
+    router = hot_swap.Router()
+    signal = _signal(router)
+    misses: List[cc.GuardMiss] = []
+    signal["on_guard_miss"] = misses.append
+    wrapped = cc._guarded(
+        mod.forward, compiled, "transformer.forward", failure_signal=signal)
+
+    x = torch.ones(4)
+    wrapped(x)
+    router.enable()
+    sig = ("transformer.forward", hot_swap.signature((x,), {}))
+    for step, k in enumerate((3, 4, 5), start=1):
+        mod.k = k  # mutate per call: every heal compiles a stale guard set
+        with cc.tenant_serve_window():
+            out = wrapped(x)
+        assert torch.equal(out, x * k)
+        # miss recorded each time until the sig goes volatile
+        assert signal["guard_misses"] == step
+        if step <= hot_swap._GUARD_MISS_HEAL_LIMIT:
+            _wait(lambda: sig in router.warm or sig in router.bg_failed)
+    assert misses[-1].heal == "volatile"
+    assert sig in router.volatile
+    # Further requests: routed eager BEFORE the stance — served, no raise,
+    # no new miss, no heal enqueued.
+    mod.k = 9
+    with cc.tenant_serve_window():
+        out = wrapped(x)
+    assert torch.equal(out, x * 9)
+    assert signal["guard_misses"] == 3
+    assert sig not in router.healing and sig not in router.pending
+
+
+def test_regional_guard_miss_serves_eager_and_preserves_blocks() -> None:
+    """Regional lanes (in-place block compiles, ie#381): the stance covers
+    the block frames, the catch serves THIS request fully eager with dynamo
+    disabled for the call, and the compiled block impls survive intact."""
+
+    class _Stack(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.blk = _Mod()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.blk(x)
+
+    stack = _Stack()
+    original = stack.forward
+    stack.blk.compile(backend="eager", dynamic=False)  # in place, like
+    # compile_repeated_blocks
+    signal = _signal(hot_swap.Router())
+    misses: List[cc.GuardMiss] = []
+    signal["on_guard_miss"] = misses.append
+    wrapped = cc._guarded_regional(
+        stack, original, "transformer", failure_signal=signal)
+
+    x = torch.ones(4)
+    assert torch.equal(wrapped(x), x * 2)  # boot compile, outside window
+    stack.blk.k = 3
+    with cc.tenant_serve_window():
+        out = wrapped(x)
+    assert torch.equal(out, x * 3)
+    assert signal["guard_misses"] == 1 and len(misses) == 1
+    assert "guard failure" in misses[0].reason
+    assert not signal.get("failed", False)
+    # Blocks still compiled in place (not cleared like the permanent-degrade
+    # path would): a later out-of-window call recompiles/serves normally.
+    assert stack.blk._compiled_call_impl is not None
+    assert torch.equal(wrapped(x), x * 3)
+
+
+def test_reason_class_extraction() -> None:
+    reason = (
+        "Recompiling function forward in /x.py:5\n"
+        "    triggered by the following guard failure(s):\n"
+        "    - 0/1: tensor 'x' size mismatch at index 0. expected 3, actual 4\n"
+        "    - 0/0: tensor 'x' size mismatch at index 0. expected 2, actual 4"
+    )
+    got = cc.guard_miss_reason_class(reason)
+    assert got == "tensor 'x' size mismatch at index 0. expected 3, actual 4"
+    assert cc.guard_miss_reason_class("") == "unclassified"
+    assert cc.guard_miss_reason_class("plain text") == "plain text"
+
+
+def test_stance_is_thread_scoped_background_compiles_freely() -> None:
+    """The stance-choice invariant this lane's design stands on: the serve
+    window arms only the serving thread — a concurrent background thread
+    (the warm/mint driver) recompiles freely while the stance is up."""
+    mod = _Mod()
+    compiled = torch.compile(mod.forward, backend="eager", dynamic=False)
+    compiled(torch.ones(4))
+    mod.k = 7
+    result: Dict[str, Any] = {}
+
+    def bg() -> None:
+        try:
+            result["out"] = compiled(torch.ones(4))  # recompile, no stance
+        except BaseException as exc:  # noqa: BLE001
+            result["exc"] = exc
+
+    with cc.tenant_serve_window():
+        with cc._fail_on_recompile() as armed:
+            assert armed
+            t = threading.Thread(target=bg)
+            t.start()
+            t.join()
+    assert "exc" not in result, f"stance leaked into a background thread: {result.get('exc')}"
+    assert torch.equal(result["out"], torch.ones(4) * 7)
+
+
+# ---------------------------------------------------------------------------
+# Executor tape: the REAL handle_run_job tenant path end-to-end, torch leaf
+# simulated at the pgw#672 boundary. Boot mints through warm windows (no
+# stance, inline compiles), the tenant dispatch runs under the serve window,
+# and the guard_miss activity event reaches the (bound) wire sink.
+# ---------------------------------------------------------------------------
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _Denoiser:
+    def forward(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.transformer = _Denoiser()
+
+    @classmethod
+    def from_pretrained(cls, path: Any, **kwargs: Any) -> "_Pipe":
+        return cls()  # pragma: no cover - loader is patched
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries() -> Any:
+    # _Mod.forward.__code__ is class-shared: dynamo entries from one test's
+    # compiles would serve (or guard-miss) another's. Fresh guard state per
+    # test.
+    torch._dynamo.reset()
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+        cc._QUARANTINED_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+    sink_before = activity_mod._sink
+    yield
+    with activity_mod._lock:
+        activity_mod._sink = sink_before
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+        cc._QUARANTINED_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+
+
+class _Sim:
+    """Dynamo/inductor semantics at the torch boundary, with guard EPOCHS.
+
+    Entries are recorded at ``guard_epoch``; a call whose entry matches the
+    current epoch is a HIT. An entry from an older epoch is a guard miss —
+    dynamo must RECOMPILE: inside the tenant serve window the stance raises
+    torch's real RecompileError (what error_on_recompile does); outside it
+    the recompile happens inline (warm/mint windows, the warm thread's
+    heal). ``window_seen`` records the serve-window flag at every compile
+    so the mint-window tape can assert the stance never leaked in."""
+
+    def __init__(self) -> None:
+        self.guard_epoch = 0
+        self.counters: Dict[str, int] = {
+            "fxgraph_cache_hit": 0, "fxgraph_cache_miss": 0,
+            "aot_cache_hit": 0,
+        }
+        self.compiles: List[Tuple[str, int]] = []
+        self.window_seen: List[bool] = []
+        self.served_compiled: List[str] = []
+
+    def _entry(self, graph: str) -> Path:
+        import os
+
+        fx_dir = Path(os.environ["TORCHINDUCTOR_CACHE_DIR"]) / "fxgraph"
+        fx_dir.mkdir(parents=True, exist_ok=True)
+        return fx_dir / f"{graph}.bin"
+
+    def compiled_call(self, original: Any, label: str,
+                      args: tuple, kwargs: dict) -> Any:
+        graph = "g-" + hashlib.blake2s(
+            repr((label, args, sorted(kwargs))).encode()).hexdigest()[:16]
+        entry = self._entry(graph)
+        epoch: Optional[int] = None
+        if entry.exists():
+            epoch = int(entry.read_text() or 0)
+        if epoch == self.guard_epoch:
+            self.counters["fxgraph_cache_hit"] += 1
+            self.served_compiled.append(graph)
+            return original(*args, **kwargs)
+        if epoch is not None and cc.in_tenant_serve_window():
+            raise dexc.RecompileError(
+                f"Recompiling function forward in sim.py:1\n"
+                f"    triggered by the following guard failure(s):\n"
+                f"    - 0/0: tensor 'sample' stride mismatch at index 1. "
+                f"expected 4096, actual 1 (epoch {epoch} != "
+                f"{self.guard_epoch})")
+        self.window_seen.append(cc.in_tenant_serve_window())
+        entry.write_text(str(self.guard_epoch))
+        self.counters["fxgraph_cache_miss"] += 1
+        self.compiles.append((graph, self.guard_epoch))
+        return original(*args, **kwargs)
+
+
+def _sim_apply_factory(sim: _Sim):
+    def _sim_apply(pipeline: Any, cfg: Any, *, cache_ready: bool,
+                   guard: bool = True, allow_cold: bool = False) -> bool:
+        if getattr(pipeline, cc._MARKER_ATTR, None) is not None:
+            return True
+        original = pipeline.transformer.forward
+        signal = _signal(hot_swap.Router(fail_closed=True))
+
+        def compiled(*args: Any, **kwargs: Any) -> Any:
+            return sim.compiled_call(original, "transformer", args, kwargs)
+
+        setattr(pipeline, cc._MARKER_ATTR, {
+            "targets": ["transformer"],
+            "shapes": [tuple(s) for s in cfg.shapes],
+            "cache": bool(cache_ready),
+            "originals": [(pipeline.transformer, "forward", original)],
+            "regional_mods": [],
+            "failure_signal": signal,
+        })
+        pipeline.transformer.forward = cc._guarded(
+            original, compiled, "transformer",
+            fail_closed=True, failure_signal=signal)
+        cc._armed_pipelines().add(pipeline)
+        return True
+
+    return _sim_apply
+
+
+def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
+                      *, contract: str, regional: bool = False,
+                      image_digest: Optional[str] = None) -> Any:
+    digest = hashlib.blake2s(
+        f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
+    ).hexdigest()[:56]
+    return SimpleNamespace(digest="ck2-" + digest, axes={})
+
+
+SHAPE = (768, 768)
+
+
+def _endpoint_cls() -> type:
+    class _Ep:
+        def setup(self, pipeline: _Pipe) -> None:
+            self.pipeline = pipeline
+
+        def warmup(self) -> None:
+            self.pipeline.transformer.forward("warm", shape=SHAPE)
+
+        def run(self, ctx: Any, payload: _In) -> _Out:
+            # The tenant forward uses the SAME warm signature the boot
+            # proved — the guard miss is on an axis signatures don't carry
+            # (the sim's epoch: stride/autotune divergence in real life).
+            self.pipeline.transformer.forward("warm", shape=SHAPE)
+            return _Out()
+
+    return _Ep
+
+
+def _spec(name: str, cls: type) -> EndpointSpec:
+    return EndpointSpec(
+        name=name, method=cls.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=cls, attr_name="run",
+        models={"pipeline": Hub("acme/sdxl-base", flavor="fp8-w8a8")},
+        compile=Compile(shapes=(SHAPE,), family=FAMILY, text_len=0),
+    )
+
+
+class _Rig:
+    def __init__(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+                 specs: List[EndpointSpec]) -> None:
+        self.sim = _Sim()
+        self.sent: List[pb.WorkerMessage] = []
+        self.pipes: Dict[str, _Pipe] = {}
+        model_dir = tmp_path / "model"
+        model_dir.mkdir(exist_ok=True)
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        self.ex = Executor(specs, _send)
+        self.ex.store._cache_dir = tmp_path / "cas"
+
+        async def _download(ref: str, **kwargs: Any) -> Path:
+            return model_dir
+
+        def _load_slot(*args: Any, **kwargs: Any) -> Any:
+            pipe = _Pipe()
+            setattr(pipe, "_cozy_weight_lane", "w8a8")
+            self.pipes[f"pipe-{len(self.pipes)}"] = pipe
+            return provision.SlotLoad(obj=pipe, is_pipeline=True)
+
+        def _mandatory_miss(*a: Any, **k: Any) -> bool:
+            raise cc.CompiledLaneUnavailableError("no delivered cell")
+
+        monkeypatch.setattr(executor_mod, "ensure_local", _download)
+        monkeypatch.setattr(provision, "load_slot", _load_slot)
+        monkeypatch.setattr(provision, "enable_compiled", _mandatory_miss)
+        monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+        monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+        monkeypatch.setattr(cc, "apply", _sim_apply_factory(self.sim))
+        monkeypatch.setattr(
+            cc, "inductor_counters", lambda: dict(self.sim.counters))
+        monkeypatch.setattr(cell_key_mod, "compute", _fake_key_compute)
+        monkeypatch.setattr(cc, "reset_target_code", lambda pipeline: 0)
+        # pgw#681 coexistence: when the guard-closure mint gate is present,
+        # neutralize it — it audits REAL dynamo graphs, which this rig's
+        # simulated torch boundary never creates. Orthogonal to the
+        # guard-miss doctrine under test here.
+        try:
+            from gen_worker import guard_closure as gc_mod
+
+            monkeypatch.setattr(
+                gc_mod, "assert_closure", lambda *a, **k: dict())
+        except ImportError:
+            pass
+        monkeypatch.setattr(
+            self.ex, "_enable_compiled",
+            lambda p, cfg, artifact: fleet_cells.enable_compiled(
+                p, cfg, self.ex.store._cache_dir, artifact,
+                publisher=None))
+
+    def boot(self, spec: EndpointSpec) -> None:
+        model_ref = wire_ref(spec.models["pipeline"])
+        asyncio.run(self.ex.ensure_setup(
+            spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
+
+
+async def _dispatch(rig: _Rig, run: pb.RunJob) -> pb.JobResult:
+    loop = asyncio.get_running_loop()
+    activity_mod.bind_sink(rig.ex._send, loop)
+    await rig.ex.handle_run_job(run)
+    job = rig.ex.jobs[(run.request_id, run.attempt)]
+    assert job.task is not None
+    await job.task
+    results = [m.job_result for m in rig.sent
+               if m.WhichOneof("msg") == "job_result"
+               and m.job_result.request_id == run.request_id]
+    assert results, f"no job_result for {run.request_id}"
+    return results[-1]
+
+
+def _run_job(rig: _Rig, spec: EndpointSpec, request_id: str) -> pb.RunJob:
+    (target,) = rig.ex.compile_targets()
+    model_ref = wire_ref(spec.models["pipeline"])
+    return pb.RunJob(
+        request_id=request_id, attempt=1, function_name=spec.name,
+        input_payload=msgspec.msgpack.encode(_In(prompt="a cat")),
+        models=[pb.ModelBinding(slot="pipeline", ref=model_ref)],
+        snapshots={model_ref: pb.Snapshot(digest=MODEL_DIGEST)},
+        required_compile=pb.RequiredCompileExecution(
+            target_incarnation_id=target.incarnation_id,
+            cell_ref=target.active_compile_ref,
+            cell_snapshot_digest=target.active_compile_snapshot_digest,
+            contract_digest=target.contract_digest,
+        ),
+    )
+
+
+def test_tenant_guard_miss_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full doctrine through the REAL tenant path:
+
+    boot (mint window) compiles inline with the serve window OFF ->
+    request 1 guard-misses under the stance -> completes OK served eager,
+    guard_miss activity event on the wire (reason class in phase; cell,
+    request id, verbatim reason in detail), heal scheduled -> request 2 of
+    the same shape serves COMPILED. The compiled identity is never revoked
+    and nothing is disabled."""
+    cls = _endpoint_cls()
+    spec = _spec("generate", cls)
+    rig = _Rig(tmp_path, monkeypatch, [spec])
+
+    rig.boot(spec)
+    assert rig.ex.serving_tiers()["generate"] == "compiled"
+    # Mint-window contract: every boot compile ran with the window OFF.
+    assert rig.sim.compiles, "boot must have compiled"
+    assert rig.sim.window_seen and not any(rig.sim.window_seen), (
+        "the serve window leaked into a mint/warm window")
+    (target,) = rig.ex.compile_targets()
+    cell_ref = target.active_compile_ref
+    assert cell_ref
+
+    # The variable-we-don't-understand flips between mint and serve
+    # (stride/autotune divergence between minting and serving workers).
+    rig.sim.guard_epoch = 1
+    boot_compiles = len(rig.sim.compiles)
+
+    run1 = _run_job(rig, spec, "r-guard-miss")
+    res1 = asyncio.run(_dispatch(rig, run1))
+    assert res1.status == pb.JOB_STATUS_OK, res1.safe_message
+    # Served EAGER: no inline compile happened inside the request window.
+    (pipe,) = rig.pipes.values()
+    assert cc.guard_miss_count(pipe) == 1
+    # The heal ran on the background warm thread (window OFF there).
+    _wait(lambda: len(rig.sim.compiles) > boot_compiles)
+    assert not any(rig.sim.window_seen), (
+        "a compile executed inside the tenant serve window")
+
+    # The typed confession reached the wire, countable per reason class.
+    events = [m.activity_update for m in rig.sent
+              if m.WhichOneof("msg") == "activity_update"
+              and m.activity_update.kind == activity_mod.KIND_GUARD_MISS]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.state == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+    assert "stride mismatch" in ev.phase
+    assert cell_ref in ev.detail
+    assert "request=r-guard-miss" in ev.detail
+    assert "stride mismatch at index 1" in ev.detail
+    assert "heal=healing" in ev.detail
+
+    # Nothing was revoked, degraded, or disabled — the lane is healthy.
+    assert target.active_compile_ref == cell_ref
+    assert rig.ex.serving_tiers()["generate"] == "compiled"
+    assert rig.ex.unavailable == {}
+    assert not cc.cell_quarantined_in_process(cell_ref)
+
+    # SECOND request of the shape: compiled, no new miss, no new event.
+    served_before = len(rig.sim.served_compiled)
+    res2 = asyncio.run(_dispatch(rig, _run_job(rig, spec, "r-healed")))
+    assert res2.status == pb.JOB_STATUS_OK, res2.safe_message
+    assert cc.guard_miss_count(pipe) == 1
+    assert len(rig.sim.served_compiled) > served_before, (
+        "the healed entry must serve the second request compiled")
+    events_after = [m.activity_update for m in rig.sent
+                    if m.WhichOneof("msg") == "activity_update"
+                    and m.activity_update.kind == activity_mod.KIND_GUARD_MISS]
+    assert len(events_after) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.67.3"
+version = "0.67.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Paul-ordered P0 from the live 187s in-request-recompile incident (ie#546 retag cycle): a tenant request whose inputs miss every cached guard set must never pay dynamo's inline recompile inside the request.

**Stance** — tenant execution (`tenant_serve_window`, entered around the executor handler call only) runs guarded compiled targets under `torch._dynamo.config.error_on_recompile` scoped per call via `config.patch`. Chosen over `set_stance("fail_on_recompile")`: torch 2.13 ConfigModule overrides are thread-local ContextVars, so the stance arms exactly the serving thread while the concurrent shape-warm thread + background mint keep compiling; and it fires only on genuine recompiles (warm multi-graph entries serve under it, first compiles never trip). Warm/mint/adopt/boot windows never enter the window.

**Catch** — `_guarded`/`_guarded_regional` catch `RecompileError`, serve THIS request eager immediately (regional: one call under thread-scoped `config.patch(disable=True)`, block impls untouched). Never the pgw#672 permanent-degrade path: no revocation, no tier flip, no quarantine.

**Confession** — typed `guard_miss` activity event (`activity.emit_event`; zero proto change): phase = guard-reason class token, detail = verbatim torch reason + signature identity + cell key + request id + heal verdict. Hub-countable per (release, SKU, guard-reason); the top-N reason table is the instrument for the cell-reusability investigation (pgw#681 lane).

**Heal** — `hot_swap.Router.record_guard_miss` recompiles the exact input class through the existing shape-warm driver (nice +10, own stream, zero-filled dummies, dedup by signature) so the second request of the shape is compiled. Signatures past 2 failed heals are per-request-volatile: routed eager permanently.

Red-verified (`tests/test_guard_miss_pgw680.py`, 7 tapes): real dynamo guards + full `handle_run_job` path; with the window neutralized (the pre-fix tree) the same input pays a silent inline recompile with zero confession. Full suite 1002 passed / 5 skipped / 1 xfailed; mypy clean (150 files); ruff clean.

Ships as **0.67.4** (0.67.2/0.67.3 consumed by the th#1211 train that merged ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)