### PR TITLE
release: gen-worker 0.68.0 — pgw#681 guard-closure gate + boundary canonicalization; gw#679 per-expert MoE LoRA branch routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## 0.68.0 (2026-07-26) — pgw#681 guard-closure gate + boundary canonicalization; gw#679 per-expert MoE LoRA branch routing
+
+Dynamo's guard set IS the exhaustive dependency list of a compiled graph, so
+cell portability is now proven by construction instead of discovered one
+guard-miss at a time. SDK-generic, parameterized only by the declared
+contract — zero per-endpoint/per-family code (Paul's mandate).
+
+- **Guard-closure gate** (`gen_worker.guard_closure`): every mint path
+  (`finish_fleet_mint`, `mint_artifact`, `build`, the pgw#622 shape-warm
+  republish) now extracts the complete live guard set per compiled graph
+  (torch 2.13 structured `GuardManager` walk via
+  `_debug_get_cache_entry_list` → `guard_manager.root` child/leaf traversal
+  + `verbose_code_parts()`, repr-parse fallback) and classifies each guard
+  by source root: module-rooted = weights/structure identity, global-rooted
+  = code identity (both ck2-pinned), input-rooted + ambient = the CLOSED
+  WORLD every guard type must be contract-covered in. An out-of-contract
+  guard (e.g. an undeclared scalar baked in as `EQUALS_MATCH`) fails the
+  mint RED naming the exact variable; an unprovable closure (no extractable
+  graphs) also refuses. Downstream posture unchanged: pgw#672 degrades to
+  explicit eager, never a pod death.
+- **Boundary canonicalization** (`guard_closure.canonical_ingress`,
+  installed by `compile_cache.apply` at the single compiled-graph ingress,
+  mint and consumer symmetrically): tensor strides are pinned to the
+  canonical contiguous layout — including the ie#544 trap where a size-1
+  dim keeps `is_contiguous()` true under an arbitrary stride and
+  `.contiguous()` is a no-op (residue rebuilt via `as_strided`); a
+  stride-perturbed serving input now HITS the minted graph instead of
+  paying a recompile (red-verified both directions). Per-path dtype drift
+  raises a NAMED `GuardBoundaryError` instead of a silent recompile.
+- **Full guard reporting**: the complete classified guard dump rides every
+  cell as `metadata.json`'s `guard_manifest` (deterministic: comments
+  stripped, ASLR ids scrubbed, rows sorted) — into CAS and the publish
+  metadata. Audit surfaces: `guard_closure.audit_armed(pipeline, cfg)` for
+  a live armed cell, and `python -m gen_worker.guard_closure <cells...>`
+  as the runnable N-cold-pod closure/zero-miss check (exit 0 closed +
+  consistent, 2 leaks, 3 divergence; per-host ambient state compared by
+  presence, content kept in the dump).
+
+**gw#679: a denoiser is a SET — per-expert LoRA branch routing for MoE pipelines.**
+
+Wan 2.2 A14B is a dual-expert MoE (`transformer` high-noise + `transformer_2`
+low-noise) and its Lightning distillation is two adapters. `branch_target()`
+returned ONE denoiser, and diffusers' Wan converters rewrite every
+non-diffusers key onto the `transformer.` prefix whatever expert the file was
+trained for — so both halves landed rank-concatenated on the HIGH expert,
+`map_adapter` succeeded, and the LOW expert ran undistilled weights on a
+4-step distilled ladder. A wrong picture with a clean log. (Same failure
+class as ie#522's `fuse_lora(components=["transformer"])`, at runtime attach.)
+
+- **`branch_targets(pipe) -> {component: module}`** replaces `branch_target`:
+  every branch operation runs over the whole denoiser set
+  (`transformer`/`transformer_2`/`unet`). `enable_branch_lanes` /
+  `clear_branch_lanes` / `disable_branch_lanes` / `apply_branch_adapter_set` /
+  `pipeline_branch_bucket` / `stamp_lane(pipe)` are the set-level surface;
+  the per-module primitives are unchanged.
+- **Routing is DATA, not a wire field.** An adapter half declares its expert
+  in its own keys (`transformer.` / `transformer_2.`), which is how diffusers
+  already namespaces multi-denoiser pipelines. Per-expert mirrors carry the
+  prefix; one repo carrying both prefixes works identically. A `component`
+  field on the overlay was deliberately rejected — the fact is in the weights.
+- **Fail-closed, three ways.** On a multi-expert pipeline an adapter that
+  names no component is refused as ambiguous (checked on the RAW keys, before
+  the converter can synthesize a `transformer.` prefix); a key naming a
+  component the pipeline does not carry is refused on any topology; and a
+  compiled pipeline whose experts are not all armed refuses instead of
+  copying a half into nothing. Every refusal happens BEFORE any buffer is
+  touched — a half-attached MoE (distilled expert beside an undistilled one)
+  is never an outcome. The peft fallback is refused on multi-expert
+  pipelines: diffusers reaches the second expert only through a
+  `load_into_transformer_2=True` kwarg the fallback cannot pass.
+- **The bucket container is per component.** `Compile(lora_bucket=N)` /
+  `apply_lora_lane` arm every denoiser, and the whole set always shares ONE
+  bucket, so the pipeline carries one coherent graph family. The lane STRING
+  is unchanged (`<base>-lora<bucket>`): how many experts a family has is a
+  property of the pipeline class, not of the lane, so published cell keys
+  keep their meaning.
+- **Single-denoiser lanes (LTX/sdxl/qwen) are untouched by construction**:
+  with one target every denoiser key routes to it, prefixed or not, kohya-flat
+  `lora_unet_` included (never read as a component declaration — sd-scripts
+  emits it for transformer denoisers too), and no declaration is required.
+- Endpoint note: a Wan MoE family should declare BOTH experts as compile
+  targets (`Compile(targets=("transformer", "transformer_2", "vae.decode"))`)
+  — the container is armed on both either way, and canonical branches on an
+  uncompiled expert pay the eager branch tax.
+
 ## 0.67.4 (2026-07-26) — pgw#680: guard-miss doctrine — fail-on-recompile at serve time
 
 The 187s incident class (ie#546 retag cycle): a tenant request whose inputs
@@ -46,43 +131,7 @@ tapes (real dynamo guards, real RecompileError, real warm thread) + the
 full `handle_run_job` tenant path; with the window neutralized (the pre-fix
 tree) the same input pays a silent inline recompile with zero confession.
 
-## Unreleased — pgw#681: graph determinism — guard-closure gate + boundary canonicalization
-
-Dynamo's guard set IS the exhaustive dependency list of a compiled graph, so
-cell portability is now proven by construction instead of discovered one
-guard-miss at a time. SDK-generic, parameterized only by the declared
-contract — zero per-endpoint/per-family code (Paul's mandate).
-
-- **Guard-closure gate** (`gen_worker.guard_closure`): every mint path
-  (`finish_fleet_mint`, `mint_artifact`, `build`, the pgw#622 shape-warm
-  republish) now extracts the complete live guard set per compiled graph
-  (torch 2.13 structured `GuardManager` walk via
-  `_debug_get_cache_entry_list` → `guard_manager.root` child/leaf traversal
-  + `verbose_code_parts()`, repr-parse fallback) and classifies each guard
-  by source root: module-rooted = weights/structure identity, global-rooted
-  = code identity (both ck2-pinned), input-rooted + ambient = the CLOSED
-  WORLD every guard type must be contract-covered in. An out-of-contract
-  guard (e.g. an undeclared scalar baked in as `EQUALS_MATCH`) fails the
-  mint RED naming the exact variable; an unprovable closure (no extractable
-  graphs) also refuses. Downstream posture unchanged: pgw#672 degrades to
-  explicit eager, never a pod death.
-- **Boundary canonicalization** (`guard_closure.canonical_ingress`,
-  installed by `compile_cache.apply` at the single compiled-graph ingress,
-  mint and consumer symmetrically): tensor strides are pinned to the
-  canonical contiguous layout — including the ie#544 trap where a size-1
-  dim keeps `is_contiguous()` true under an arbitrary stride and
-  `.contiguous()` is a no-op (residue rebuilt via `as_strided`); a
-  stride-perturbed serving input now HITS the minted graph instead of
-  paying a recompile (red-verified both directions). Per-path dtype drift
-  raises a NAMED `GuardBoundaryError` instead of a silent recompile.
-- **Full guard reporting**: the complete classified guard dump rides every
-  cell as `metadata.json`'s `guard_manifest` (deterministic: comments
-  stripped, ASLR ids scrubbed, rows sorted) — into CAS and the publish
-  metadata. Audit surfaces: `guard_closure.audit_armed(pipeline, cfg)` for
-  a live armed cell, and `python -m gen_worker.guard_closure <cells...>`
-  as the runnable N-cold-pod closure/zero-miss check (exit 0 closed +
-  consistent, 2 leaks, 3 divergence; per-host ambient state compared by
-  presence, content kept in the dump).
+## 0.67.3 (2026-07-26) — th#1211: the svdq 5 GB guard cited a cap that does not exist
 
 `MAX_SVDQ_FILE_BYTES` was `5 * 1000**3`, justified in-comment as an "R2
 single-PUT cap". There is no such cap in this stack: the hub's
@@ -133,53 +182,6 @@ has the torch-2.12/cu13.0 wheel but was refused outright.
   NOT established by this.** t2i only; `QwenImageEditPlusPipeline` unchecked.
 - The 1.2 row is untouched and still rejects diffusers 0.39; the wheel-tag torch
   guard still fires (a torch2.12 wheel on torch 2.13 raises, as before).
-
-## 0.68.0 (2026-07-26) — gw#679: a denoiser is a SET — per-expert LoRA branch routing for MoE pipelines
-
-Wan 2.2 A14B is a dual-expert MoE (`transformer` high-noise + `transformer_2`
-low-noise) and its Lightning distillation is two adapters. `branch_target()`
-returned ONE denoiser, and diffusers' Wan converters rewrite every
-non-diffusers key onto the `transformer.` prefix whatever expert the file was
-trained for — so both halves landed rank-concatenated on the HIGH expert,
-`map_adapter` succeeded, and the LOW expert ran undistilled weights on a
-4-step distilled ladder. A wrong picture with a clean log. (Same failure
-class as ie#522's `fuse_lora(components=["transformer"])`, at runtime attach.)
-
-- **`branch_targets(pipe) -> {component: module}`** replaces `branch_target`:
-  every branch operation runs over the whole denoiser set
-  (`transformer`/`transformer_2`/`unet`). `enable_branch_lanes` /
-  `clear_branch_lanes` / `disable_branch_lanes` / `apply_branch_adapter_set` /
-  `pipeline_branch_bucket` / `stamp_lane(pipe)` are the set-level surface;
-  the per-module primitives are unchanged.
-- **Routing is DATA, not a wire field.** An adapter half declares its expert
-  in its own keys (`transformer.` / `transformer_2.`), which is how diffusers
-  already namespaces multi-denoiser pipelines. Per-expert mirrors carry the
-  prefix; one repo carrying both prefixes works identically. A `component`
-  field on the overlay was deliberately rejected — the fact is in the weights.
-- **Fail-closed, three ways.** On a multi-expert pipeline an adapter that
-  names no component is refused as ambiguous (checked on the RAW keys, before
-  the converter can synthesize a `transformer.` prefix); a key naming a
-  component the pipeline does not carry is refused on any topology; and a
-  compiled pipeline whose experts are not all armed refuses instead of
-  copying a half into nothing. Every refusal happens BEFORE any buffer is
-  touched — a half-attached MoE (distilled expert beside an undistilled one)
-  is never an outcome. The peft fallback is refused on multi-expert
-  pipelines: diffusers reaches the second expert only through a
-  `load_into_transformer_2=True` kwarg the fallback cannot pass.
-- **The bucket container is per component.** `Compile(lora_bucket=N)` /
-  `apply_lora_lane` arm every denoiser, and the whole set always shares ONE
-  bucket, so the pipeline carries one coherent graph family. The lane STRING
-  is unchanged (`<base>-lora<bucket>`): how many experts a family has is a
-  property of the pipeline class, not of the lane, so published cell keys
-  keep their meaning.
-- **Single-denoiser lanes (LTX/sdxl/qwen) are untouched by construction**:
-  with one target every denoiser key routes to it, prefixed or not, kohya-flat
-  `lora_unet_` included (never read as a component declaration — sd-scripts
-  emits it for transformer denoisers too), and no declaration is required.
-- Endpoint note: a Wan MoE family should declare BOTH experts as compile
-  targets (`Compile(targets=("transformer", "transformer_2", "vae.decode"))`)
-  — the container is armed on both either way, and canonical branches on an
-  uncompiled expert pay the eager branch tax.
 
 ## 0.67.1 (2026-07-26) — pgw#675 override dtype + pgw#676 native-crash attribution (the sdxl retag blockers)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,53 @@ has the torch-2.12/cu13.0 wheel but was refused outright.
 - The 1.2 row is untouched and still rejects diffusers 0.39; the wheel-tag torch
   guard still fires (a torch2.12 wheel on torch 2.13 raises, as before).
 
+## 0.68.0 (2026-07-26) — gw#679: a denoiser is a SET — per-expert LoRA branch routing for MoE pipelines
+
+Wan 2.2 A14B is a dual-expert MoE (`transformer` high-noise + `transformer_2`
+low-noise) and its Lightning distillation is two adapters. `branch_target()`
+returned ONE denoiser, and diffusers' Wan converters rewrite every
+non-diffusers key onto the `transformer.` prefix whatever expert the file was
+trained for — so both halves landed rank-concatenated on the HIGH expert,
+`map_adapter` succeeded, and the LOW expert ran undistilled weights on a
+4-step distilled ladder. A wrong picture with a clean log. (Same failure
+class as ie#522's `fuse_lora(components=["transformer"])`, at runtime attach.)
+
+- **`branch_targets(pipe) -> {component: module}`** replaces `branch_target`:
+  every branch operation runs over the whole denoiser set
+  (`transformer`/`transformer_2`/`unet`). `enable_branch_lanes` /
+  `clear_branch_lanes` / `disable_branch_lanes` / `apply_branch_adapter_set` /
+  `pipeline_branch_bucket` / `stamp_lane(pipe)` are the set-level surface;
+  the per-module primitives are unchanged.
+- **Routing is DATA, not a wire field.** An adapter half declares its expert
+  in its own keys (`transformer.` / `transformer_2.`), which is how diffusers
+  already namespaces multi-denoiser pipelines. Per-expert mirrors carry the
+  prefix; one repo carrying both prefixes works identically. A `component`
+  field on the overlay was deliberately rejected — the fact is in the weights.
+- **Fail-closed, three ways.** On a multi-expert pipeline an adapter that
+  names no component is refused as ambiguous (checked on the RAW keys, before
+  the converter can synthesize a `transformer.` prefix); a key naming a
+  component the pipeline does not carry is refused on any topology; and a
+  compiled pipeline whose experts are not all armed refuses instead of
+  copying a half into nothing. Every refusal happens BEFORE any buffer is
+  touched — a half-attached MoE (distilled expert beside an undistilled one)
+  is never an outcome. The peft fallback is refused on multi-expert
+  pipelines: diffusers reaches the second expert only through a
+  `load_into_transformer_2=True` kwarg the fallback cannot pass.
+- **The bucket container is per component.** `Compile(lora_bucket=N)` /
+  `apply_lora_lane` arm every denoiser, and the whole set always shares ONE
+  bucket, so the pipeline carries one coherent graph family. The lane STRING
+  is unchanged (`<base>-lora<bucket>`): how many experts a family has is a
+  property of the pipeline class, not of the lane, so published cell keys
+  keep their meaning.
+- **Single-denoiser lanes (LTX/sdxl/qwen) are untouched by construction**:
+  with one target every denoiser key routes to it, prefixed or not, kohya-flat
+  `lora_unet_` included (never read as a component declaration — sd-scripts
+  emits it for transformer denoisers too), and no declaration is required.
+- Endpoint note: a Wan MoE family should declare BOTH experts as compile
+  targets (`Compile(targets=("transformer", "transformer_2", "vae.decode"))`)
+  — the container is armed on both either way, and canonical branches on an
+  uncompiled expert pay the eager branch tax.
+
 ## 0.67.1 (2026-07-26) — pgw#675 override dtype + pgw#676 native-crash attribution (the sdxl retag blockers)
 
 ### pgw#675: a component override now loads at the dtype the base tree's LOAD LANE computes at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,43 @@ tapes (real dynamo guards, real RecompileError, real warm thread) + the
 full `handle_run_job` tenant path; with the window neutralized (the pre-fix
 tree) the same input pays a silent inline recompile with zero confession.
 
-## 0.67.3 (2026-07-26) — th#1211: the svdq 5 GB guard cited a cap that does not exist
+## Unreleased — pgw#681: graph determinism — guard-closure gate + boundary canonicalization
+
+Dynamo's guard set IS the exhaustive dependency list of a compiled graph, so
+cell portability is now proven by construction instead of discovered one
+guard-miss at a time. SDK-generic, parameterized only by the declared
+contract — zero per-endpoint/per-family code (Paul's mandate).
+
+- **Guard-closure gate** (`gen_worker.guard_closure`): every mint path
+  (`finish_fleet_mint`, `mint_artifact`, `build`, the pgw#622 shape-warm
+  republish) now extracts the complete live guard set per compiled graph
+  (torch 2.13 structured `GuardManager` walk via
+  `_debug_get_cache_entry_list` → `guard_manager.root` child/leaf traversal
+  + `verbose_code_parts()`, repr-parse fallback) and classifies each guard
+  by source root: module-rooted = weights/structure identity, global-rooted
+  = code identity (both ck2-pinned), input-rooted + ambient = the CLOSED
+  WORLD every guard type must be contract-covered in. An out-of-contract
+  guard (e.g. an undeclared scalar baked in as `EQUALS_MATCH`) fails the
+  mint RED naming the exact variable; an unprovable closure (no extractable
+  graphs) also refuses. Downstream posture unchanged: pgw#672 degrades to
+  explicit eager, never a pod death.
+- **Boundary canonicalization** (`guard_closure.canonical_ingress`,
+  installed by `compile_cache.apply` at the single compiled-graph ingress,
+  mint and consumer symmetrically): tensor strides are pinned to the
+  canonical contiguous layout — including the ie#544 trap where a size-1
+  dim keeps `is_contiguous()` true under an arbitrary stride and
+  `.contiguous()` is a no-op (residue rebuilt via `as_strided`); a
+  stride-perturbed serving input now HITS the minted graph instead of
+  paying a recompile (red-verified both directions). Per-path dtype drift
+  raises a NAMED `GuardBoundaryError` instead of a silent recompile.
+- **Full guard reporting**: the complete classified guard dump rides every
+  cell as `metadata.json`'s `guard_manifest` (deterministic: comments
+  stripped, ASLR ids scrubbed, rows sorted) — into CAS and the publish
+  metadata. Audit surfaces: `guard_closure.audit_armed(pipeline, cfg)` for
+  a live armed cell, and `python -m gen_worker.guard_closure <cells...>`
+  as the runnable N-cold-pod closure/zero-miss check (exit 0 closed +
+  consistent, 2 leaks, 3 divergence; per-host ambient state compared by
+  presence, content kept in the dump).
 
 `MAX_SVDQ_FILE_BYTES` was `5 * 1000**3`, justified in-comment as an "R2
 single-PUT cap". There is no such cap in this stack: the hub's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.67.4"
+version = "0.68.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/scripts/w8a8_lora_bench.py
+++ b/scripts/w8a8_lora_bench.py
@@ -230,10 +230,12 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
         swap_stats = []
         for ref, sd in lora_sds.items():
             if w8a8_lane:
-                den = w8a8_lora.branch_target(pipe)
+                targets = w8a8_lora.branch_targets(pipe)
                 dsd, rest = w8a8_lora.split_state_dict(sd)
+                routed = w8a8_lora.route_denoiser_keys(dsd, targets, ref=ref)
                 t0 = time.monotonic()
-                st = w8a8_lora.apply_branch_adapters(den, [(dsd, 1.0, ref)])
+                st = w8a8_lora.apply_branch_adapter_set(
+                    pipe, {c: [(d, 1.0, ref)] for c, d in routed.items()})
                 swap_stats.append({"ref": ref, **st})
                 if rest:
                     pipe.load_lora_weights(dict(rest), adapter_name="te")
@@ -248,7 +250,7 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
             for i, p in enumerate(PROMPTS):
                 imgs[(ref, i)] = _render(pipe, p, 4321 + i, steps)
             if w8a8_lane:
-                w8a8_lora.clear_branch_adapters(w8a8_lora.branch_target(pipe))
+                w8a8_lora.clear_branch_lanes(pipe)
                 if hasattr(pipe, "disable_lora"):
                     try:
                         pipe.disable_lora()

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -68,7 +68,7 @@ import inspect
 import pickle
 import sys
 
-from . import cell_key, hot_swap
+from . import cell_key, guard_closure, hot_swap
 from .api.errors import RetryableError
 from .models import w8a8_lora
 from .models.loading import load_from_pretrained, pipeline_weight_lane
@@ -2319,15 +2319,20 @@ def apply(
             # place; the guard wrapper clears them on the first failure.
             _apply_declared_shape_config(cfg)
             owner.compile_repeated_blocks(dynamic=None)
+            # pgw#681: regional entry crosses the same canonical boundary as
+            # whole-graph entry — block guards mint over canonical inputs.
+            ingress = guard_closure.canonical_ingress(fn, target)
             if guard:
                 setattr(owner, attr, _guarded_regional(
                     owner,
-                    fn,
+                    ingress,
                     target,
                     fail_closed=fail_closed,
                     failure_signal=failure_signal,
                 ))
-                originals.append((owner, attr, fn))
+            else:
+                setattr(owner, attr, ingress)
+            originals.append((owner, attr, fn))
             regional_mods.append(owner)
             applied.append(target)
             continue
@@ -2356,6 +2361,10 @@ def apply(
         declared_dynamic = tuple(getattr(cfg, "dynamic", ()) or ())
         if declared_dynamic:
             compiled = _with_declared_marks(compiled, declared_dynamic)
+        # pgw#681: the single compiled-graph ingress — canonical strides +
+        # dtype asserts OUTSIDE the declared marks, so the marks (and the
+        # traced guards) always see the canonical form serving presents.
+        compiled = guard_closure.canonical_ingress(compiled, target)
         setattr(owner, attr, _guarded(
             fn,
             compiled,
@@ -2932,6 +2941,9 @@ def build(
             "was inductor already latched to another dir in this process?"
         )
 
+    # pgw#681: guard-closure gate — the platform build fails red on any
+    # guard the declared contract does not pin, naming the variable.
+    guard_manifest = guard_closure.assert_closure(pipe, cfg, label=family)
 
     graph_signature, weight_contract = execution_contract(pipe, cfg)
     meta = artifact_metadata(
@@ -2949,6 +2961,7 @@ def build(
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
     )
+    meta[guard_closure.MANIFEST_KEY] = guard_manifest
     if serving_image_digest:
         # The producer image contains a compiler; the graph is consumed by
         # the endpoint's serving image. Tensorhub supplies that immutable OCI
@@ -3044,6 +3057,10 @@ def mint_artifact(
             "compile warm-up captured nothing under TORCHINDUCTOR_CACHE_DIR"
         )
 
+    # pgw#681: guard-closure gate — a leak fails the mint red, naming the
+    # variable; the manifest rides the cell as its dependency dump.
+    guard_manifest = guard_closure.assert_closure(pipe, cfg, label=family)
+
     # gw#564: record the execution contract exactly like the production
     # build — w8a8 cells are contract_drift-gated on the graph signature and
     # weight-lane manifest, so a mint without them can never re-adopt.
@@ -3062,6 +3079,7 @@ def mint_artifact(
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
     )
+    meta[guard_closure.MANIFEST_KEY] = guard_manifest
     tmp = target.with_suffix(".part")
     target.parent.mkdir(parents=True, exist_ok=True)
     pack(capture, tmp, meta)
@@ -3172,6 +3190,12 @@ def finish_fleet_mint(
             "partial capture, refusing to publish"
         )
 
+    # pgw#681: the guard-closure gate. The proof confirmed the graphs SERVE;
+    # this confirms they depend on NOTHING the contract does not pin — an
+    # out-of-contract guard fails the mint red, naming the variable. The
+    # returned manifest rides the cell as its dependency dump.
+    guard_manifest = guard_closure.assert_closure(pipe, cfg, label=family)
+
     # gw#564: record the execution contract exactly like the production
     # build — w8a8 cells are contract_drift-gated on the graph signature and
     # weight-lane manifest, so a mint without them can never re-adopt. Both
@@ -3192,6 +3216,7 @@ def finish_fleet_mint(
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
     )
+    meta[guard_closure.MANIFEST_KEY] = guard_manifest
     tmp = target.with_suffix(".part")
     target.parent.mkdir(parents=True, exist_ok=True)
     pack(capture, tmp, meta)

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -1527,31 +1527,34 @@ def apply_lora_lane(pipeline: Any, bucket: int) -> bool:
     ``<base>-lora<bucket>`` lane stamp, so :func:`lane_drift` admits exactly
     the matching lora cells. Raises when the pipeline has no branch-capable
     denoiser — a declared bucket that cannot trace must fail loud, not
-    publish/adopt the wrong graph."""
+    publish/adopt the wrong graph.
+
+    gw#679: the container is allocated on EVERY denoiser the pipeline
+    carries, so a dual-expert MoE traces both experts branch-bearing and a
+    per-expert adapter set can land at request time without a recompile."""
     if not bucket:
         return False
 
-    denoiser = w8a8_lora.branch_target(pipeline)
-    if denoiser is None:
+    targets = w8a8_lora.enable_branch_lanes(pipeline, int(bucket))
+    if not targets:
         raise RuntimeError(
             "Compile.lora_bucket declared but the pipeline has no "
-            "branch-capable denoiser (transformer/unet)"
+            "branch-capable denoiser (transformer/transformer_2/unet)"
         )
-    w8a8_lora.enable_lora_branches(denoiser, int(bucket))
-    w8a8_lora.stamp_lane(pipeline, denoiser)
+    w8a8_lora.stamp_lane(pipeline, targets)
     return True
 
 
 def drop_lora_lane(pipeline: Any) -> None:
-    """Undo :func:`apply_lora_lane`: drop the branch buffers and restore the
-    branchless lane stamp (the eager rollback — canonical zeroed branches
-    cost +21-32% eager, gw#547)."""
+    """Undo :func:`apply_lora_lane`: drop the branch buffers on every
+    denoiser and restore the branchless lane stamp (the eager rollback —
+    canonical zeroed branches cost +21-32% eager, gw#547)."""
 
-    denoiser = w8a8_lora.branch_target(pipeline)
-    if denoiser is None:
+    targets = w8a8_lora.branch_targets(pipeline)
+    if not targets:
         return
-    w8a8_lora.disable_lora_branches(denoiser)
-    w8a8_lora.stamp_lane(pipeline, denoiser)
+    w8a8_lora.disable_branch_lanes(pipeline)
+    w8a8_lora.stamp_lane(pipeline, targets)
 
 
 def lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -63,6 +63,7 @@ import requests
 
 from . import cell_key
 from . import compile_cache as cc
+from . import guard_closure
 from .convert.hub import blake3_file
 # module import (not `from .loading import pipeline_weight_lane`): tests
 # monkeypatch models.loading.pipeline_weight_lane; stay late-bound.
@@ -690,6 +691,11 @@ def republish_after_shape_warm(
 
     tmp_root = Path(tempfile.mkdtemp(prefix="cellrepub-"))
     try:
+        # pgw#681: the grown cell must stay guard-closed — a background
+        # novel-signature warm that baked an out-of-contract guard refuses
+        # to republish (caught below, non-fatal to serving, loudly named).
+        guard_manifest = guard_closure.assert_closure(
+            pipe, cfg, label=family)
         graph_signature, weight_contract = cc.execution_contract(pipe, cfg)
         meta = cc.artifact_metadata(
             family=family,
@@ -706,6 +712,7 @@ def republish_after_shape_warm(
             weight_contract=weight_contract,
             shape_contract=cc.declared_contract_facts(cfg),
         )
+        meta[guard_closure.MANIFEST_KEY] = guard_manifest
         label = cc.flavor_label(
             meta["sku"], meta["torch"], meta.get("weight_lane", ""))
         artifact = cc.pack(Path(live_root), tmp_root / f"{label}.tar.gz", meta)

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -1,0 +1,794 @@
+"""Guard-closure gate + boundary canonicalization (pgw#681).
+
+Dynamo's guard set for a compiled graph IS the exhaustive list of everything
+that graph depends on — so closure against the declared compile contract is
+machine-checkable. Three pieces, all SDK-generic (parameterized ONLY by the
+declared ``CompileCell`` contract — never per-endpoint or per-family code):
+
+1. **Extraction** (:func:`extract`): post-mint, walk every compiled graph's
+   live guard tree. The robust torch 2.13 surface (probed on 2.13.0+cu130):
+   ``torch._dynamo.eval_frame._debug_get_cache_entry_list(code)`` →
+   ``entry.guard_manager.root`` → recursive ``get_child_managers()`` (each
+   carries ``get_source()``) + ``get_leaf_guards()`` (each carries its type
+   name and ``verbose_code_parts()``). A repr parse of the guard manager's
+   ``TREE_GUARD_MANAGER`` dump is the fallback when the structured walk is
+   unavailable. Extraction failure is NEVER silent: a mint whose closure
+   cannot be proven fails red (pgw#657 fail-loud doctrine).
+
+2. **Closure classifier** (:func:`classify`): every guard is classified by
+   its SOURCE ROOT first — module-rooted (``L['self']…``) guards are the
+   weights/structure identity (covered by family + graph_signature +
+   weight_contract ck2 axes) and global-rooted (``G[…]``) guards are the
+   code identity (covered by gen_worker/diffusers/transformers/image_digest
+   axes); neither can vary per request. Cross-request variance enters ONLY
+   through call inputs and ambient process state, so those two roots form a
+   CLOSED WORLD: every input/ambient guard type must be explicitly covered
+   by the contract (declared shapes/dynamic dims, pinned scalars, structural
+   constants) or canonicalized away at the ingress — anything else is a
+   LEAK, and a leak fails the mint naming the exact variable.
+
+3. **Boundary canonicalization** (:func:`canonical_ingress`): one wrapper at
+   the single compiled-graph ingress (installed by ``compile_cache.apply``
+   for every target, mint and consumer alike, so the traced guards and the
+   serving inputs see the SAME canonical form). Tensor strides are pinned to
+   the canonical contiguous layout — ``.contiguous()`` alone is NOT the pin:
+   a size-1 dim makes ``is_contiguous()`` true under an arbitrary stride and
+   ``.contiguous()`` a no-op while TENSOR_MATCH still guards the exact
+   stride tuple (ie#544, reproduced: entries 1→2 on ``stride=(8,999,1)`` for
+   size ``(4,1,8)``), so the residue case rebuilds via ``as_strided``.
+   Tensor dtypes are memo-asserted per argument path — a drift raises a
+   NAMED :class:`GuardBoundaryError` instead of a silent recompile. Scalar
+   policy is enforced at the mint gate (only contract-pinned scalars may be
+   baked into guards; declared dynamism rides ``mark_dynamic``) — the
+   ingress never rewrites scalar values.
+
+The full guard dump rides the cell as ``metadata.json``'s
+``guard_manifest`` block (deterministic: comments stripped, ASLR ids
+scrubbed, rows sorted) — every armed cell carries its complete dependency
+manifest into CAS and the publish-intent metadata. The audit surface
+(:func:`audit_armed` for a live armed pipeline, :func:`consolidate` +
+``python -m gen_worker.guard_closure`` over N pods' cells/manifests) is the
+N-cold-pod zero-miss closure check: exit 0 = closed and consistent, 2 =
+leaks, 3 = cross-pod divergence.
+
+Note: ``_debug_get_cache_entry_list`` keys on the class-shared ``__code__``
+(pgw#637), so a warm process's dump can include same-family sibling entries;
+classification is source-based, so siblings classify identically.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import json
+import logging
+import re
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_VERSION = 1
+MANIFEST_KEY = "guard_manifest"
+
+# Verdicts. LEAK is the only failing one.
+LEAK = "LEAK"
+RUNTIME_STATE = "runtime-state"          # ambient process state (ck2 runtime axes)
+CODE_IDENTITY = "code-identity"          # G[...] roots (version/image axes)
+MODULE_STRUCTURE = "module-structure"    # L['self'] roots (family/graph/weight axes)
+CONTRACT_SHAPE = "contract-shape"        # input tensor shape/stride/dtype/device
+CONTRACT_SCALAR = "contract-scalar"      # input scalar pinned by the contract
+STRUCTURAL = "structural"                # type/len/None/bool topology of the call
+CODE_CONSTANT = "code-constant"          # string constants from the call path
+CANONICALIZED = "canonicalized-stride"   # stride axes the ingress pins
+
+_COVERED = (
+    RUNTIME_STATE, CODE_IDENTITY, MODULE_STRUCTURE, CONTRACT_SHAPE,
+    CONTRACT_SCALAR, STRUCTURAL, CODE_CONSTANT, CANONICALIZED,
+)
+
+# Ambient (root-attached) guard types covered by process/runtime identity.
+_AMBIENT_COVERED = frozenset({
+    "GLOBAL_STATE", "TORCH_FUNCTION_MODE_STACK", "DEFAULT_DEVICE",
+    "DETERMINISTIC_ALGORITHMS", "GRAD_MODE", "AUTOCAST_STATE",
+    "TORCH_FUNCTION_STATE", "NO_TENSOR_ALIASING", "DUPLICATE_INPUT",
+    "FUNCTORCH_STACK_MATCH", "DUAL_LEVEL",
+})
+# Input-rooted guard types that assert call TOPOLOGY (types, lengths,
+# presence), which the endpoint call path fixes deterministically.
+_STRUCTURAL_TYPES = frozenset({
+    "TYPE_MATCH", "DIMENSION_DYNAMIC_MARKING_GUARD", "HASATTR", "NO_HASATTR",
+    "LENGTH_CHECK", "DICT_LENGTH", "DICT_CONTAINS", "SET_CONTAINS",
+    "MAPPING_KEYS_MATCH", "KEYS_MATCH", "TUPLE_ITERATOR_LEN",
+    "RANGE_ITERATOR_MATCH", "NONE_MATCH", "NOT_NONE", "NOT_NONE_MATCH",
+    "TRUE_MATCH", "FALSE_MATCH", "DISPATCH_KEY_SET_MATCH", "FLOAT_IS_NAN",
+    "COMPLEX_IS_NAN", "SEQUENCE_LENGTH",
+})
+
+_CANONICAL_DEPTH = 4
+
+# `___check_obj_id(x, 129760138209744)` / `___check_type_id(x, 21008688)`
+# embed process memory addresses (ASLR) — scrub for cross-pod determinism.
+_ID_SCRUB_RE = re.compile(r"(___check_(?:obj|type)_id\(.*?,\s*)\d+(\))")
+_COMMENT_RE = re.compile(r"\s{2,}#.*$", re.DOTALL)
+_TENSOR_MATCH_RE = re.compile(r"size=\[([^\]]*)\], stride=\[([^\]]*)\]")
+_SOURCE_LOCAL_RE = re.compile(r"^L\['([^']+)'\]")
+
+
+class GuardClosureError(RuntimeError):
+    """The mint's guard set is not closed over the declared contract (or
+    could not be extracted). The message names every leaking variable."""
+
+
+class GuardBoundaryError(RuntimeError):
+    """An input crossed the compiled-graph ingress outside the canonical
+    boundary (dtype drift). Named — never a silent recompile. Consumer
+    guards catch it into the pgw#672 explicit-eager degrade; mint arms
+    (``guard=False``) let it fail the mint red."""
+
+
+@dataclass(frozen=True)
+class GuardRecord:
+    """One classified dynamo guard."""
+
+    guard_type: str
+    source: str  # "" for root/ambient guards
+    expr: str    # comment-stripped, id-scrubbed
+    verdict: str
+    axis: str    # covering contract/runtime axis, or the leak reason
+
+    def row(self) -> Dict[str, str]:
+        return {
+            "type": self.guard_type, "source": self.source,
+            "expr": self.expr, "verdict": self.verdict, "axis": self.axis,
+        }
+
+
+@dataclass(frozen=True)
+class GraphGuards:
+    """The complete guard set of one compiled graph (one cache entry)."""
+
+    target: str
+    code: str
+    entry: int
+    guards: Tuple[GuardRecord, ...]
+
+
+@dataclass(frozen=True)
+class ClosureReport:
+    """The audit view for one armed pipeline / minted cell."""
+
+    graphs: Tuple[GraphGuards, ...]
+
+    @property
+    def leaks(self) -> Tuple[str, ...]:
+        out: List[str] = []
+        for g in self.graphs:
+            for r in g.guards:
+                if r.verdict == LEAK:
+                    out.append(
+                        f"target={g.target} {r.guard_type} "
+                        f"{r.source or '<ambient>'}: {r.expr} ({r.axis})")
+        return tuple(out)
+
+    @property
+    def closed(self) -> bool:
+        return bool(self.graphs) and not self.leaks
+
+    def verdict_counts(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for g in self.graphs:
+            for r in g.guards:
+                counts[r.verdict] = counts.get(r.verdict, 0) + 1
+        return dict(sorted(counts.items()))
+
+    def manifest(self) -> Dict[str, Any]:
+        """Deterministic JSON manifest — the durable per-cell guard dump."""
+        return {
+            "v": MANIFEST_VERSION,
+            "graphs": [
+                {
+                    "target": g.target, "code": g.code, "entry": g.entry,
+                    "guards": [r.row() for r in g.guards],
+                }
+                for g in self.graphs
+            ],
+            "verdicts": self.verdict_counts(),
+            "leaks": list(self.leaks),
+        }
+
+    def text(self) -> str:
+        lines = [
+            f"guard closure: {len(self.graphs)} graph(s), "
+            f"verdicts={self.verdict_counts()}",
+        ]
+        for leak in self.leaks:
+            lines.append(f"  LEAK {leak}")
+        if not self.graphs:
+            lines.append("  (no compiled graphs extractable)")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Contract pins
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContractPins:
+    """The scalar/dynamic vocabulary one declared contract admits into
+    guards. 0/1 are torch's own free specializations; everything else must
+    be a declared axis value."""
+
+    ints: frozenset
+    floats: frozenset
+    has_dynamic: bool
+
+
+def contract_pins(cfg: Any) -> ContractPins:
+    ints = {0, 1}
+    for row in tuple(getattr(cfg, "shapes", ()) or ()):
+        ints.update(int(v) for v in row)
+    ints.update(int(v) for v in tuple(getattr(cfg, "text_lens", ()) or ()))
+    text_len = getattr(cfg, "text_len", None)
+    if text_len is not None:
+        ints.add(int(text_len))
+    bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
+    if bucket:
+        ints.add(bucket)
+    dynamic = tuple(getattr(cfg, "dynamic", ()) or ())
+    for d in dynamic:
+        ints.add(int(getattr(d, "min", 0)))
+        ints.add(int(getattr(d, "max", 0)))
+    floats = {0.0, 1.0}
+    floats.update(float(v) for v in tuple(getattr(cfg, "guidance_scales", ()) or ()))
+    return ContractPins(
+        ints=frozenset(ints), floats=frozenset(floats),
+        has_dynamic=bool(dynamic))
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def _normalize(expr: str) -> str:
+    out = _COMMENT_RE.sub("", str(expr)).strip()
+    return _ID_SCRUB_RE.sub(r"\g<1><id>\g<2>", out)
+
+
+def _walk_manager(manager: Any, source: str, out: List[Tuple[str, str, str]]) -> None:
+    for leaf in manager.get_leaf_guards():
+        parts_attr = getattr(leaf, "verbose_code_parts", None)
+        parts = list(parts_attr() if callable(parts_attr) else (parts_attr or ()))
+        if not parts:
+            parts = [type(leaf).__name__]
+        for part in parts:
+            out.append((type(leaf).__name__, source, str(part)))
+    for child in manager.get_child_managers():
+        get_source = getattr(child, "get_source", None)
+        child_source = str(get_source()) if callable(get_source) else source
+        _walk_manager(child, child_source or source, out)
+
+
+_TREE_LEAF_RE = re.compile(r"^\|(?: \|)* \+- ([A-Z0-9_]+): (.*)$")
+_TREE_MGR_RE = re.compile(r"^\|(?: \|)* \+- \w*GuardManager: source=([^,]+),")
+
+
+def _parse_tree_repr(dump: str) -> List[Tuple[str, str, str]]:
+    """Fallback: parse the ``TREE_GUARD_MANAGER`` repr into (type, source,
+    raw expr) rows. Depth-tracked so leaves attach to the nearest manager."""
+    out: List[Tuple[str, str, str]] = []
+    source_by_depth: Dict[int, str] = {}
+    for line in dump.splitlines():
+        depth = line.count("| ")
+        mgr = _TREE_MGR_RE.match(line)
+        if mgr:
+            source_by_depth[depth] = mgr.group(1).strip()
+            continue
+        leaf = _TREE_LEAF_RE.match(line)
+        if leaf:
+            source = ""
+            for d in sorted(source_by_depth):
+                if d < depth:
+                    source = source_by_depth[d]
+            out.append((leaf.group(1), source, leaf.group(2)))
+    return out
+
+
+def _code_of(fn: Any) -> Optional[Any]:
+    return getattr(getattr(fn, "__func__", fn), "__code__", None)
+
+
+def _entry_guard_rows(entry: Any) -> List[Tuple[str, str, str]]:
+    manager = getattr(entry, "guard_manager", None)
+    if manager is None:
+        raise GuardClosureError(
+            "dynamo cache entry exposes no guard_manager — the guard debug "
+            "surface changed; closure is unprovable on this torch")
+    root = getattr(manager, "root", None)
+    if root is not None:
+        try:
+            rows: List[Tuple[str, str, str]] = []
+            _walk_manager(root, "", rows)
+            if rows:
+                return rows
+        except Exception:
+            logger.warning(
+                "guard-closure: structured guard walk failed; falling back "
+                "to the repr parse", exc_info=True)
+    rows = _parse_tree_repr(str(manager))
+    if not rows:
+        raise GuardClosureError(
+            "no guards extractable from a live cache entry (structured walk "
+            "and repr parse both empty) — closure is unprovable")
+    return rows
+
+
+def extract_target_guards(
+    fn: Any, target: str, cfg: Any,
+) -> List[GraphGuards]:
+    """Classified guard sets for every live compiled graph on ``fn``."""
+    code = _code_of(fn)
+    if code is None:
+        return []
+    from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+    pins = contract_pins(cfg)
+    graphs: List[GraphGuards] = []
+    for index, entry in enumerate(_debug_get_cache_entry_list(code)):
+        records = sorted(
+            {
+                _classify_row(guard_type, source, raw, pins)
+                for guard_type, source, raw in _entry_guard_rows(entry)
+            },
+            key=lambda r: (r.guard_type, r.source, r.expr),
+        )
+        graphs.append(GraphGuards(
+            target=str(target), code=str(getattr(code, "co_qualname", code.co_name)),
+            entry=index, guards=tuple(records),
+        ))
+    return graphs
+
+
+def extract(pipeline: Any, cfg: Any) -> ClosureReport:
+    """Classified guard sets for every compiled graph on an armed pipeline
+    (whole-graph targets via the marker's originals; regional targets via
+    the repeated-block forwards — same enumeration the in-memory compile
+    probe trusts)."""
+    from . import compile_cache as cc
+
+    marker = getattr(pipeline, cc._MARKER_ATTR, None) or {}
+    graphs: List[GraphGuards] = []
+    seen_codes: set = set()
+    for _owner, attr, fn in marker.get("originals") or ():
+        code = _code_of(fn)
+        if code is None or id(code) in seen_codes:
+            continue
+        seen_codes.add(id(code))
+        graphs.extend(extract_target_guards(fn, str(attr), cfg))
+    for mod in marker.get("regional_mods") or ():
+        try:
+            children = list(mod.modules())
+        except Exception:
+            logger.warning(
+                "guard-closure: could not enumerate regional submodules of "
+                "%s", type(mod).__name__, exc_info=True)
+            continue
+        for child in children:
+            fwd = getattr(type(child), "forward", None)
+            code = _code_of(fwd)
+            if code is None or id(code) in seen_codes:
+                continue
+            seen_codes.add(id(code))
+            graphs.extend(extract_target_guards(
+                fwd, f"{type(child).__name__}.forward", cfg))
+    graphs.sort(key=lambda g: (g.target, g.code, g.entry))
+    return ClosureReport(graphs=tuple(graphs))
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _source_root(source: str) -> str:
+    s = str(source or "").strip()
+    if not s:
+        return "ambient"
+    if s.startswith("G[") or s.startswith("G."):
+        return "global"
+    m = _SOURCE_LOCAL_RE.match(s)
+    if m is None:
+        return "other"
+    return "self" if m.group(1) == "self" else "input"
+
+
+def _contiguous_strides(shape: Sequence) -> Tuple[int, ...]:
+    out: List[int] = []
+    step = 1
+    for dim in reversed([int(v) for v in shape]):
+        out.append(step)
+        step *= max(dim, 1)
+    return tuple(reversed(out))
+
+
+def _classify_tensor_match(expr: str) -> Tuple[str, str]:
+    m = _TENSOR_MATCH_RE.search(expr)
+    if m is None:
+        return CONTRACT_SHAPE, "shapes/dtype/device (contract + lane)"
+    size_txt = [v.strip() for v in m.group(1).split(",") if v.strip()]
+    stride_txt = [v.strip() for v in m.group(2).split(",") if v.strip()]
+    if any(v == "None" for v in size_txt):
+        # Declared-dynamic dims record None; dependent strides follow suit.
+        return CONTRACT_SHAPE, "declared dynamic dims"
+    try:
+        size = [int(v) for v in size_txt]
+        stride = tuple(int(v) for v in stride_txt if v != "None")
+    except ValueError:
+        return CONTRACT_SHAPE, "shapes/dtype/device (contract + lane)"
+    want = _contiguous_strides(size)
+    have = tuple(
+        int(v) if v != "None" else want[i]
+        for i, v in enumerate(stride_txt)
+    ) if len(stride_txt) == len(size) else stride
+    if have != want:
+        return LEAK, (
+            f"non-canonical stride {list(have)} for size {size} survived "
+            "the ingress pin")
+    return CANONICALIZED, "ingress stride pin + contract shapes"
+
+
+def _scalar_verdict(value: Any, pins: ContractPins) -> Tuple[str, str]:
+    if value is None or isinstance(value, bool):
+        return STRUCTURAL, "call-path constant"
+    if isinstance(value, (str, bytes)):
+        return CODE_CONSTANT, "call-path string constant"
+    if isinstance(value, int):
+        if value in pins.ints:
+            return CONTRACT_SCALAR, "declared contract int"
+        return LEAK, f"int {value} is not a declared contract pin"
+    if isinstance(value, float):
+        if value in pins.floats or (value.is_integer() and int(value) in pins.ints):
+            return CONTRACT_SCALAR, "declared contract float"
+        return LEAK, f"float {value} is not a declared contract pin"
+    if isinstance(value, (tuple, list)):
+        for v in value:
+            verdict, axis = _scalar_verdict(v, pins)
+            if verdict == LEAK:
+                return LEAK, f"element {axis}"
+        return CONTRACT_SCALAR, "declared contract sequence"
+    return LEAK, f"unclassifiable literal {type(value).__name__}"
+
+
+def _classify_equals(expr: str, pins: ContractPins) -> Tuple[str, str]:
+    _lhs, sep, rhs = expr.partition(" == ")
+    if not sep:
+        return LEAK, "unparseable EQUALS_MATCH expression"
+    try:
+        value = ast.literal_eval(rhs.strip())
+    except Exception:
+        return LEAK, f"unparseable EQUALS_MATCH literal {rhs.strip()[:60]!r}"
+    return _scalar_verdict(value, pins)
+
+
+def classify(
+    guard_type: str, source: str, expr: str, pins: ContractPins,
+) -> Tuple[str, str]:
+    """(verdict, covering axis / leak reason) for one guard.
+
+    Module- and global-rooted guards are covered by construction (weights +
+    code identity, pinned by the ck2 key axes). Input-rooted and ambient
+    guards are the closed world: unknown types are LEAKS, never waved on.
+    """
+    root = _source_root(source)
+    if root == "self":
+        return MODULE_STRUCTURE, "family + graph_signature + weight_contract"
+    if root == "global":
+        return CODE_IDENTITY, "gen_worker/diffusers/transformers/image versions"
+    if root == "ambient":
+        if guard_type in _AMBIENT_COVERED:
+            return RUNTIME_STATE, "process runtime state (ck2 runtime axes)"
+        if guard_type == "LAMBDA_GUARD":
+            if ("init_ambient_guards" in expr
+                    or "top_saved_tensors_hooks" in expr):
+                return RUNTIME_STATE, "torch ambient state"
+            if ".size()" in expr or ".stride()" in expr:
+                if pins.has_dynamic:
+                    return CONTRACT_SHAPE, "declared dynamic-dim range"
+                return LEAK, "shape-env relation without declared dynamic dims"
+        return LEAK, f"unclassified ambient guard {guard_type}"
+    if root == "other":
+        return LEAK, f"unrecognized guard source {source!r}"
+    # input-rooted
+    if guard_type == "TENSOR_MATCH":
+        return _classify_tensor_match(expr)
+    if guard_type in _STRUCTURAL_TYPES:
+        return STRUCTURAL, "call topology (deterministic per endpoint code)"
+    if guard_type == "EQUALS_MATCH":
+        return _classify_equals(expr, pins)
+    if guard_type == "LAMBDA_GUARD" and (".size()" in expr or ".stride()" in expr):
+        if pins.has_dynamic:
+            return CONTRACT_SHAPE, "declared dynamic-dim range"
+        return LEAK, "shape-env relation without declared dynamic dims"
+    return LEAK, f"input-dependent guard {guard_type} outside the contract"
+
+
+def _classify_row(
+    guard_type: str, source: str, raw_expr: str, pins: ContractPins,
+) -> GuardRecord:
+    verdict, axis = classify(guard_type, source, raw_expr, pins)
+    return GuardRecord(
+        guard_type=str(guard_type), source=str(source or ""),
+        expr=_normalize(raw_expr), verdict=verdict, axis=axis)
+
+
+# ---------------------------------------------------------------------------
+# The mint gate + armed-cell audit
+# ---------------------------------------------------------------------------
+
+
+def audit_armed(pipeline: Any, cfg: Any) -> ClosureReport:
+    """The auditable diagnostics view of an armed pipeline's guard closure."""
+    return extract(pipeline, cfg)
+
+
+def assert_closure(pipeline: Any, cfg: Any, label: str = "") -> Dict[str, Any]:
+    """The guard-closure mint gate: every compiled graph's guard set must be
+    closed over the declared contract. Returns the deterministic guard
+    manifest to embed in the cell metadata; raises :class:`GuardClosureError`
+    naming every out-of-contract variable (mint red — downstream the pgw#672
+    posture degrades to explicit eager, never a pod death)."""
+    report = audit_armed(pipeline, cfg)
+    name = label or type(pipeline).__name__
+    if not report.graphs:
+        raise GuardClosureError(
+            f"guard-closure gate ({name}): no compiled graphs extractable "
+            "from the armed targets — closure is unprovable, refusing the "
+            "mint")
+    if report.leaks:
+        leak_lines = "\n  ".join(report.leaks)
+        raise GuardClosureError(
+            f"guard-closure gate ({name}): {len(report.leaks)} out-of-"
+            f"contract guard(s) — the mint depends on variables the "
+            f"contract does not pin:\n  {leak_lines}")
+    logger.info(
+        "guard-closure gate (%s): CLOSED — %d graph(s), verdicts=%s",
+        name, len(report.graphs), report.verdict_counts())
+    return report.manifest()
+
+
+# ---------------------------------------------------------------------------
+# Boundary canonicalization (the single compiled-graph ingress)
+# ---------------------------------------------------------------------------
+
+
+def canonical_strides(shape: Sequence) -> Tuple[int, ...]:
+    """The canonical contiguous stride tuple torch mints for fresh tensors."""
+    return _contiguous_strides(shape)
+
+
+def _canonical_tensor(t: Any, path: str, label: str, dtypes: Dict[str, str]) -> Any:
+    want = _contiguous_strides(t.shape)
+    if tuple(t.stride()) != want:
+        t = t.contiguous()
+        if tuple(t.stride()) != want:
+            # ie#544: a size-1 dim keeps is_contiguous() true under an
+            # arbitrary stride, making .contiguous() a no-op while
+            # TENSOR_MATCH guards the exact stride tuple. The layout is
+            # already contiguous, so restating the strides is safe.
+            t = t.as_strided(tuple(int(v) for v in t.shape), want)
+    seen = dtypes.setdefault(path, str(t.dtype))
+    if seen != str(t.dtype):
+        raise GuardBoundaryError(
+            f"compiled ingress {label}: {path} arrived as {t.dtype} but "
+            f"this boundary first observed {seen} — out-of-contract dtype "
+            "drift at the compiled graph boundary")
+    return t
+
+
+def _canonical_value(
+    value: Any, path: str, label: str, dtypes: Dict[str, str],
+    torch_mod: Any, depth: int = 0,
+) -> Any:
+    if isinstance(value, torch_mod.Tensor):
+        return _canonical_tensor(value, path, label, dtypes)
+    if depth >= _CANONICAL_DEPTH:
+        return value
+    if isinstance(value, tuple):
+        return tuple(
+            _canonical_value(v, f"{path}[{i}]", label, dtypes, torch_mod, depth + 1)
+            for i, v in enumerate(value))
+    if isinstance(value, list):
+        return [
+            _canonical_value(v, f"{path}[{i}]", label, dtypes, torch_mod, depth + 1)
+            for i, v in enumerate(value)]
+    if isinstance(value, dict):
+        return {
+            k: _canonical_value(v, f"{path}[{k!r}]", label, dtypes, torch_mod, depth + 1)
+            for k, v in value.items()}
+    return value
+
+
+def canonical_ingress(fn: Callable[..., Any], label: str) -> Callable[..., Any]:
+    """Wrap the compiled callable so every entry crosses one canonical
+    boundary: contiguous-canonical strides (stride-perturbed inputs HIT the
+    minted graph instead of recompiling) and per-path dtype asserts.
+    Installed symmetrically for mint capture and consumer serving, so the
+    traced guards describe exactly the form serving presents."""
+    dtypes: Dict[str, str] = {}
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        import torch
+
+        canon_args = tuple(
+            _canonical_value(a, f"args[{i}]", label, dtypes, torch)
+            for i, a in enumerate(args))
+        canon_kwargs = {
+            k: _canonical_value(v, f"kwargs[{k!r}]", label, dtypes, torch)
+            for k, v in kwargs.items()}
+        return fn(*canon_args, **canon_kwargs)
+
+    setattr(wrapper, "_cozy_canonical_ingress", label)
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Fleet consolidation: the N-cold-pod zero-miss closure check
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FleetAudit:
+    """Consolidated closure audit across N cells/pods of one release."""
+
+    names: Tuple[str, ...]
+    leaks: Tuple[str, ...]          # "name: leak line"
+    divergence: Tuple[str, ...]     # guards not present in every manifest
+    guard_total: int
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.names) and not self.leaks and not self.divergence
+
+    def text(self) -> str:
+        lines = [
+            f"fleet guard audit: {len(self.names)} manifest(s), "
+            f"{self.guard_total} guard row(s), {len(self.leaks)} leak(s), "
+            f"{len(self.divergence)} divergent row(s)",
+        ]
+        lines.extend(f"  LEAK {v}" for v in self.leaks)
+        lines.extend(f"  DIVERGENT {v}" for v in self.divergence)
+        if self.ok:
+            lines.append("  CLOSED: every guard is contract-covered and "
+                         "identical across all manifests")
+        return "\n".join(lines)
+
+
+def _comparison_key(target: str, guard: Mapping[str, Any]) -> Tuple[str, ...]:
+    guard_type = str(guard.get("type") or "")
+    source = str(guard.get("source") or "")
+    # Ambient state dumps embed per-host facts (num_threads); their
+    # PRESENCE is compared across pods, their content stays in the dump.
+    if guard_type in _AMBIENT_COVERED:
+        return (target, guard_type, source)
+    return (target, guard_type, source, str(guard.get("expr") or ""))
+
+
+def consolidate(manifests: Mapping[str, Mapping[str, Any]]) -> FleetAudit:
+    """Compare N cells' guard manifests: closure (no leaks anywhere) and
+    determinism (every guard row present in every manifest)."""
+    leaks: List[str] = []
+    per_name: Dict[str, set] = {}
+    total = 0
+    for name, manifest in sorted(manifests.items()):
+        keys: set = set()
+        for leak in manifest.get("leaks") or ():
+            leaks.append(f"{name}: {leak}")
+        for graph in manifest.get("graphs") or ():
+            target = str(graph.get("target") or "")
+            for guard in graph.get("guards") or ():
+                total += 1
+                keys.add(_comparison_key(target, guard))
+        per_name[name] = keys
+    divergence: List[str] = []
+    if len(per_name) > 1:
+        union: set = set().union(*per_name.values())
+        for key in sorted(union):
+            missing = sorted(n for n, keys in per_name.items() if key not in keys)
+            if missing:
+                divergence.append(f"{'/'.join(map(str, key))} absent from {missing}")
+    return FleetAudit(
+        names=tuple(sorted(per_name)), leaks=tuple(leaks),
+        divergence=tuple(divergence), guard_total=total)
+
+
+def load_manifest(path: Path) -> Dict[str, Any]:
+    """A guard manifest from a raw ``.json`` dump or a cell ``.tar.gz``
+    (the ``guard_manifest`` block of its metadata.json)."""
+    path = Path(path)
+    if path.suffix == ".json":
+        data = json.loads(path.read_text())
+        found = data.get(MANIFEST_KEY, data) if isinstance(data, dict) else None
+    else:
+        from . import compile_cache as cc
+
+        found = None
+        with tarfile.open(path, mode="r:*") as tar:
+            member = tar.getmember(cc.METADATA_NAME)
+            f = tar.extractfile(member)
+            meta = json.loads(f.read().decode()) if f else {}
+            found = meta.get(MANIFEST_KEY)
+    if not isinstance(found, dict) or not found.get("graphs"):
+        raise GuardClosureError(
+            f"{path} carries no guard manifest — pre-pgw#681 cell or bare "
+            "dump; the closure of this cell is unproven")
+    return found
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """``python -m gen_worker.guard_closure <cell.tar.gz|manifest.json>...``
+    — the runnable N-cold-pod closure check. Exit 0 closed+consistent,
+    2 leaks, 3 divergence (or unreadable manifests)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="gen_worker.guard_closure",
+        description="Audit guard-closure manifests across N cells/pods.")
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    manifests: Dict[str, Mapping[str, Any]] = {}
+    broken = False
+    for p in args.paths:
+        try:
+            manifests[str(p)] = load_manifest(p)
+        except Exception as exc:  # noqa: BLE001 — named per input, audit continues
+            broken = True
+            print(f"UNREADABLE {p}: {exc}")
+    audit = consolidate(manifests)
+    print(audit.text())
+    if audit.leaks:
+        return 2
+    if broken or audit.divergence or not manifests:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CANONICALIZED",
+    "CODE_CONSTANT",
+    "CODE_IDENTITY",
+    "CONTRACT_SCALAR",
+    "CONTRACT_SHAPE",
+    "ClosureReport",
+    "ContractPins",
+    "FleetAudit",
+    "GraphGuards",
+    "GuardBoundaryError",
+    "GuardClosureError",
+    "GuardRecord",
+    "LEAK",
+    "MANIFEST_KEY",
+    "MANIFEST_VERSION",
+    "MODULE_STRUCTURE",
+    "RUNTIME_STATE",
+    "STRUCTURAL",
+    "assert_closure",
+    "audit_armed",
+    "canonical_ingress",
+    "canonical_strides",
+    "classify",
+    "consolidate",
+    "contract_pins",
+    "extract",
+    "extract_target_guards",
+    "load_manifest",
+    "main",
+]

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -28,6 +28,22 @@ The branch-bearing pipeline stamps ``_cozy_weight_lane =
 ``lora32`` for plain bf16) so the SYMMETRIC ``compile_cache.lane_drift``
 guard keeps LoRA-bearing pipelines and branchless compile cells apart in
 both directions.
+
+**Branch targets are PER-COMPONENT (gw#679).** A pipeline's denoiser is a
+SET, not a module: Wan 2.2 A14B is a dual-expert MoE (``transformer``
+high-noise + ``transformer_2`` low-noise, handed off at ``boundary_ratio``)
+and its distillation is correspondingly two adapters. Every branch
+operation therefore runs over :func:`branch_targets` — the bucket container
+is allocated on each expert, and an adapter set is ROUTED to the component
+its own keys name (``transformer.`` / ``transformer_2.`` / ``unet.``).
+Routing is data, never a wire field: diffusers already namespaces
+multi-denoiser pipelines by component, so a per-expert adapter is mirrored
+with its component prefix. On a multi-denoiser pipeline an adapter that
+does NOT name its component is refused (``diffusers``' Wan converters
+rewrite every non-diffusers key to the ``transformer.`` prefix whatever
+expert the file was trained for — landing both halves on the high expert
+with a clean log was the gw#679 defect). Single-denoiser pipelines route
+every denoiser key to their one target exactly as before.
 """
 
 from __future__ import annotations
@@ -35,7 +51,7 @@ from __future__ import annotations
 import logging
 import math
 import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from ..api.errors import RefCompatibilitySurprise, ValidationError
 from .w8a8 import fp8_scaled_linear_class
@@ -52,7 +68,22 @@ _ACTIVE_ATTR = "_cozy_lora_active"
 _SPARSE_ATTR = "_cozy_lora_sparse"
 _MAPCACHE_ATTR = "_cozy_lora_mapcache"
 _MAPCACHE_MAX = 8
-_DENOISER_PREFIXES = ("unet.", "transformer.", "lora_unet_", "lora_transformer_")
+_DENOISER_PREFIXES = ("unet.", "transformer.", "transformer_2.",
+                      "lora_unet_", "lora_transformer_")
+# gw#679: the denoiser components a pipeline can carry, in stamp order. A
+# dual-expert MoE carries transformer (high noise) AND transformer_2 (low).
+_DENOISER_COMPONENTS = ("transformer", "transformer_2", "unet")
+# Key prefix -> the component it NAMES, longest first (``transformer_2.``
+# must win over ``transformer.``). DOTTED forms only: that prefix IS the
+# diffusers component namespace. The kohya-flat ``lora_unet_`` prefix is
+# NOT a declaration — sd-scripts emits it for transformer denoisers too
+# (flux/qwen adapters serve fine on the branch today) — so those keys name
+# no component and follow the unprefixed rules below.
+_COMPONENT_PREFIXES = (
+    ("transformer_2.", "transformer_2"),
+    ("transformer.", "transformer"),
+    ("unet.", "unet"),
+)
 # (normalized suffix marker, is_down) — dotted forms after key normalization.
 _DOWN_SUFFIXES = (".lora_down.weight", ".lora.down.weight", ".lora_A.weight")
 _UP_SUFFIXES = (".lora_up.weight", ".lora.up.weight", ".lora_B.weight")
@@ -69,19 +100,116 @@ def rank_bucket(total_rank: int) -> int:
     )
 
 
-def branch_target(pipe: Any) -> Optional[Any]:
-    """The pipeline's denoiser when it is branch-capable (gw#558: every
-    lane — w8a8 scaled_mm, fp8-storage layerwise-cast, plain resident), else
-    None (no discoverable denoiser module — such pipelines keep the whole
-    peft path). Deliberately NO module scan here: this runs on every demote
-    (residency.pre_demote -> detach) — adapters that map onto no Linear
-    fail typed in :func:`map_adapter` (with the plain-lane peft fallback in
-    AdapterResidency.activate)."""
-    for name in ("transformer", "unet"):
+def branch_targets(pipe: Any) -> Dict[str, Any]:
+    """component name -> denoiser module for EVERY branch-capable denoiser
+    the pipeline carries (gw#679), in stamp order.
+
+    One entry for an ordinary pipeline (LTX/sdxl/qwen: ``transformer`` or
+    ``unet``) — every operation below then degenerates to the pre-gw#679
+    single-target behavior. TWO for a dual-expert MoE (Wan 2.2 A14B), and
+    both are real branch targets: adapting only the high expert leaves the
+    low one running undistilled weights on a distilled ladder.
+
+    Branch-capability is per-lane-agnostic (gw#558: w8a8 scaled_mm,
+    fp8-storage layerwise-cast, plain resident). Deliberately NO module scan
+    here: this runs on every demote (residency.pre_demote -> detach) —
+    adapters that map onto no Linear fail typed in :func:`map_adapter` (with
+    the plain-lane peft fallback in AdapterResidency.activate)."""
+    out: Dict[str, Any] = {}
+    for name in _DENOISER_COMPONENTS:
         denoiser = getattr(pipe, name, None)
         if denoiser is not None and hasattr(denoiser, "named_modules"):
-            return denoiser
-    return None
+            out[name] = denoiser
+    return out
+
+
+def declared_component(key: str) -> str:
+    """The pipeline component one adapter key NAMES, or ``""`` when the key
+    carries no component prefix (bare/kohya-flat module paths)."""
+    for prefix, comp in _COMPONENT_PREFIXES:
+        if key.startswith(prefix):
+            return comp
+    return ""
+
+
+def require_component_declaration(
+    components: Iterable[str], raw_sd: Mapping[str, Any], *, ref: str = "",
+) -> None:
+    """gw#679 fail-closed, checked against the adapter's RAW keys.
+
+    On a MULTI-denoiser pipeline an adapter must name the expert it adapts.
+    This cannot be checked after normalization: diffusers' Wan converters
+    rewrite every non-diffusers key (``diffusion_model.…``, ``lora_unet_…``)
+    to the ``transformer.`` prefix regardless of which expert the file was
+    trained for, so an unmirrored per-expert half would arrive looking like
+    an explicit high-noise declaration and land there with a clean log —
+    exactly the silent defect this issue is about. Mirror per-expert
+    adapters with their component prefix instead."""
+    comps = tuple(components)
+    if len(comps) < 2:
+        return
+    if any(declared_component(k) for k in raw_sd):
+        return
+    raise RefCompatibilitySurprise(
+        f"this pipeline has {len(comps)} denoiser experts "
+        f"({', '.join(comps)}) and the adapter does not name the one it "
+        "adapts — its keys carry no component prefix, and the diffusers "
+        "converter would rewrite them all onto the high-noise expert. "
+        "Publish per-expert adapters with their component prefix "
+        "(e.g. 'transformer.blocks.0…' / 'transformer_2.blocks.0…')",
+        ref=ref, axis="state_dict",
+    )
+
+
+def route_denoiser_keys(
+    den_sd: Dict[str, Any], components: Iterable[str], *, ref: str = "",
+) -> Dict[str, Dict[str, Any]]:
+    """Partition one adapter's denoiser keys by the component they target
+    (gw#679). Keys keep their prefixes — :func:`map_adapter` strips them.
+
+    A key naming a component the pipeline does not carry is unroutable on
+    ANY topology and refuses. Beyond that, a single-denoiser pipeline takes
+    every remaining key, prefixed or not (unchanged pre-gw#679 behavior: an
+    unresolvable key still fails typed in :func:`map_adapter`, which is what
+    keeps the plain-lane peft fallback reachable). With two or more experts
+    routing is explicit and total: a key naming no component is ambiguous
+    and refuses too. Both refuse before anything is attached — never a
+    partial application."""
+    comps = tuple(components)
+    if not den_sd:
+        return {}
+    routed: Dict[str, Dict[str, Any]] = {}
+    bare: Dict[str, Any] = {}
+    foreign: Dict[str, str] = {}
+    for key, tensor in den_sd.items():
+        comp = declared_component(key)
+        if comp and comp not in comps:
+            foreign.setdefault(comp, key)
+        elif not comp:
+            bare[key] = tensor
+        else:
+            routed.setdefault(comp, {})[key] = tensor
+    if not foreign and bare and len(comps) == 1:
+        # One target: prefixed and unprefixed keys alike are its own.
+        routed.setdefault(comps[0], {}).update(bare)
+        bare = {}
+    if bare and not foreign:
+        raise RefCompatibilitySurprise(
+            f"{len(bare)} adapter key(s) name no denoiser component "
+            f"(e.g. {', '.join(sorted(bare)[:3])}) but this pipeline has "
+            f"{len(comps)} experts ({', '.join(comps)}) — which one they "
+            "adapt is ambiguous and guessing would silently leave an "
+            "expert unadapted",
+            ref=ref, axis="state_dict",
+        )
+    if foreign:
+        detail = ", ".join(f"{c} (e.g. {k})" for c, k in sorted(foreign.items()))
+        raise RefCompatibilitySurprise(
+            f"adapter targets component(s) this pipeline does not carry: "
+            f"{detail} — it has {', '.join(comps)}",
+            ref=ref, axis="component_missing",
+        )
+    return routed
 
 
 def branch_lane(model: Any) -> str:
@@ -191,7 +319,8 @@ def _group_keys(
     flat = {p.replace(".", "_"): p for p in mods}
 
     def resolve(base: str) -> str:
-        for pref in ("unet.", "transformer."):
+        # Longest first: "transformer_2." must not be read as "transformer.".
+        for pref in ("unet.", "transformer_2.", "transformer."):
             if base.startswith(pref) and base[len(pref):] in mods:
                 return base[len(pref):]
         for pref in ("lora_unet_", "lora_transformer_"):
@@ -481,39 +610,56 @@ def branches_active(model: Any) -> bool:
     return bool(getattr(model, _ACTIVE_ATTR, False))
 
 
-def apply_branch_adapters(
-    model: Any,
-    adapters: Sequence[Tuple[Dict[str, Any], float, str]],
-    *,
-    allow_resize: bool = True,
-    uniform: bool = False,
-    request_id: str = "",
-) -> Dict[str, Any]:
-    """Make exactly ``adapters`` (state_dict, user weight, ref) the denoiser's
-    active branch set. Rank-concat across adapters, pad to the bucket, fold
-    ``alpha/rank * weight`` into the B copy. Returns swap stats.
+# ---------------------------------------------------------------------------
+# Set-level operations (gw#679): every branch-capable denoiser the pipeline
+# carries moves TOGETHER — one bucket, one lane stamp, one active set.
+# ---------------------------------------------------------------------------
 
-    ``uniform=True`` (compiled pipelines) keeps canonical placement — every
-    quantized Linear carries a branch, zeroed slots for uncovered layers,
-    never shrinking the bucket; ``allow_resize=False`` additionally refuses
-    bucket changes (a resize is a new graph family, and prod never compiles
-    at runtime). ``uniform=False`` (eager) allocates branches ONLY on
-    covered layers and drops stale ones — eager pays a per-kernel launch
-    tax even for zeroed slots, so sparse placement keeps uncovered layers
-    at exactly branchless speed."""
-    import torch
 
-    t0 = time.monotonic()
-    if not adapters:
+def enable_branch_lanes(pipe: Any, bucket: int) -> Dict[str, Any]:
+    """Allocate the rank-``bucket`` branch container on EVERY branch-capable
+    denoiser (both experts of an MoE — the ``Compile(lora_bucket=)`` arming
+    contract). Returns the targets it armed."""
+    targets = branch_targets(pipe)
+    for model in targets.values():
+        enable_lora_branches(model, bucket)
+    return targets
+
+
+def disable_branch_lanes(pipe: Any) -> None:
+    """Drop the branch containers from every denoiser (demote/teardown)."""
+    for model in branch_targets(pipe).values():
+        disable_lora_branches(model)
+
+
+def clear_branch_lanes(pipe: Any) -> None:
+    """Deactivate every denoiser's branch (canonical: zero B; sparse: drop)."""
+    for model in branch_targets(pipe).values():
         clear_branch_adapters(model)
-        return {"bucket": branch_bucket(model), "resized": False, "covered": 0,
-                "modules": 0, "copied_bytes": 0, "swap_ms": 0}
-    # Mapping and flat staging are pure in the state dict; repeat swaps of a
-    # resident adapter (the AdapterCache serves the SAME dict object) skip
-    # the key-mapping pass AND the CPU flatten — the flatten measured ~700ms
-    # at SDXL scale, the actual H2D+device placement ~130ms.
+
+
+def branch_lanes_active(pipe: Any) -> bool:
+    return any(branches_active(m) for m in branch_targets(pipe).values())
+
+
+def pipeline_branch_bucket(pipe: Any) -> int:
+    """The pipeline's branch bucket — one value across the denoiser set (the
+    set is always enabled/resized together), 0 when no branch is enabled."""
+    return max(
+        (branch_bucket(m) for m in branch_targets(pipe).values()), default=0)
+
+
+def _stage_for(
+    model: Any, adapters: Sequence[Tuple[Dict[str, Any], float, str]],
+) -> List[Tuple[Dict[str, Any], float, str]]:
+    """Map + stage one component's adapters. PURE — no module is touched, so
+    an unmappable adapter fails before anything is attached (gw#679's
+    never-partially-attach rule). Repeat swaps of a resident adapter (the
+    AdapterCache serves the SAME dict object) skip the key-mapping pass AND
+    the CPU flatten — the flatten measured ~700ms at SDXL scale, the actual
+    H2D+device placement ~130ms."""
     cache: Dict[Any, Any] = getattr(model, _MAPCACHE_ATTR, None) or {}
-    mapped = []
+    staged: List[Tuple[Dict[str, Any], float, str]] = []
     for sd, w, ref in adapters:
         key = (ref, id(sd), len(sd))
         entry = cache.get(key)
@@ -522,28 +668,58 @@ def apply_branch_adapters(
             cache[key] = entry
             while len(cache) > _MAPCACHE_MAX:
                 cache.pop(next(iter(cache)))
-        mapped.append((entry, w, ref))
+        staged.append((entry, w, ref))
     setattr(model, _MAPCACHE_ATTR, cache)
+    return staged
+
+
+def _needed_rank(staged: Sequence[Tuple[Dict[str, Any], float, str]]) -> int:
+    """The widest per-layer concatenated rank this staged set needs."""
     per_layer: Dict[str, int] = {}
-    for entry, _w, _ref in mapped:
+    for entry, _w, _ref in staged:
         for path, r in entry["ranks"].items():
             per_layer[path] = per_layer.get(path, 0) + r
-    needed = max(per_layer.values(), default=0)
-    bucket = rank_bucket(max(needed, 1))
-    current = branch_bucket(model)
-    was_sparse = bool(getattr(model, _SPARSE_ATTR, False))
-    if uniform:
-        if current >= bucket and current and not was_sparse:
-            bucket = current  # never shrink — stay on the already-traced graph
-        if current != bucket or was_sparse:
-            if not allow_resize:
-                raise ValidationError(
-                    f"active LoRA set needs rank bucket {bucket} but the compiled "
-                    f"pipeline traced bucket {current or 'none'} — recompile at "
-                    "swap time is never allowed; publish a matching lora cell"
-                )
-            enable_lora_branches(model, bucket)
-    else:
+    return max(per_layer.values(), default=0)
+
+
+def _settle_bucket(
+    models: Sequence[Any], want: int, *, uniform: bool, allow_resize: bool,
+) -> int:
+    """The bucket the whole branch SET lands on, allocated under canonical
+    placement. One value for every component: two experts on different
+    buckets would be two graph families under one lane stamp."""
+    current = max((branch_bucket(m) for m in models), default=0)
+    was_sparse = any(bool(getattr(m, _SPARSE_ATTR, False)) for m in models)
+    if not uniform:
+        return want
+    if current >= want and current and not was_sparse:
+        want = current  # never shrink — stay on the already-traced graph
+    if current != want or was_sparse:
+        if not allow_resize:
+            raise ValidationError(
+                f"active LoRA set needs rank bucket {want} but the compiled "
+                f"pipeline traced bucket {current or 'none'} — recompile at "
+                "swap time is never allowed; publish a matching lora cell"
+            )
+        for model in models:
+            enable_lora_branches(model, want)
+    return want
+
+
+def _place_adapters(
+    model: Any,
+    staged: Sequence[Tuple[Dict[str, Any], float, str]],
+    bucket: int,
+    *,
+    uniform: bool,
+    current: int,
+    t0: float,
+) -> Dict[str, Any]:
+    """Copy one component's staged adapters into its branch buffers."""
+    import torch
+
+    mapped = list(staged)
+    if not uniform:
         covered_paths: set[str] = set()
         for entry, _w, _ref in mapped:
             covered_paths.update(entry["ranks"])
@@ -612,36 +788,191 @@ def apply_branch_adapters(
                 mod.lora_b.zero_()  # canonical zeroed slot (uniform)
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+    if mapped and not covered:
+        # Every mapped key resolved to a branch-capable module, so zero
+        # covered means this component carries no branch CONTAINER — the
+        # adapter would be a silent no-op (gw#679: half-armed MoE).
+        raise RefCompatibilitySurprise(
+            f"the adapter maps onto {len(mapped)} module set(s) of this "
+            "denoiser but none of them carries a branch container — the "
+            "adapter would apply to nothing; arm the lora bucket on every "
+            "denoiser (compile_cache.apply_lora_lane) before attaching",
+            axis="state_dict",
+        )
     setattr(model, _ACTIVE_ATTR, True)
-    stats = {
+    return {
         "bucket": bucket, "resized": current != bucket,
         "sparse": not uniform, "covered": covered,
+        "adapters": len(mapped),
         "modules": len(mods), "copied_bytes": copied,
         "swap_ms": int((time.monotonic() - t0) * 1000),
     }
+
+
+def _idle_stats(model: Any) -> Dict[str, Any]:
+    return {"bucket": branch_bucket(model), "resized": False, "covered": 0,
+            "adapters": 0, "modules": 0, "copied_bytes": 0, "swap_ms": 0}
+
+
+def apply_branch_adapters(
+    model: Any,
+    adapters: Sequence[Tuple[Dict[str, Any], float, str]],
+    *,
+    allow_resize: bool = True,
+    uniform: bool = False,
+    request_id: str = "",
+    rank_floor: int = 0,
+) -> Dict[str, Any]:
+    """Make exactly ``adapters`` (state_dict, user weight, ref) ONE denoiser's
+    active branch set. Rank-concat across adapters, pad to the bucket, fold
+    ``alpha/rank * weight`` into the B copy. Returns swap stats.
+
+    ``uniform=True`` (compiled pipelines) keeps canonical placement — every
+    quantized Linear carries a branch, zeroed slots for uncovered layers,
+    never shrinking the bucket; ``allow_resize=False`` additionally refuses
+    bucket changes (a resize is a new graph family, and prod never compiles
+    at runtime). ``uniform=False`` (eager) allocates branches ONLY on
+    covered layers and drops stale ones — eager pays a per-kernel launch
+    tax even for zeroed slots, so sparse placement keeps uncovered layers
+    at exactly branchless speed.
+
+    ``rank_floor`` (gw#679) is the widest rank a SIBLING expert needs: the
+    components of one pipeline always share a bucket. Prefer
+    :func:`apply_branch_adapter_set` — it routes an adapter set across the
+    whole denoiser set and computes the floor itself."""
+    t0 = time.monotonic()
+    if not adapters:
+        clear_branch_adapters(model)
+        return _idle_stats(model)
+    staged = _stage_for(model, adapters)
+    current = branch_bucket(model)
+    bucket = _settle_bucket(
+        [model], rank_bucket(max(_needed_rank(staged), int(rank_floor), 1)),
+        uniform=uniform, allow_resize=allow_resize)
+    stats = _place_adapters(
+        model, staged, bucket, uniform=uniform, current=current, t0=t0)
     logger.info(
         "[request_id=%s] w8a8 lora branch swap: adapters=%d bucket=%d "
         "covered=%d/%d copied_bytes=%d resized=%s swap_ms=%d",
-        request_id, len(adapters), bucket, covered, len(mods), copied,
-        stats["resized"], stats["swap_ms"],
+        request_id, len(adapters), bucket, stats["covered"], stats["modules"],
+        stats["copied_bytes"], stats["resized"], stats["swap_ms"],
     )
     return stats
 
 
-def stamp_lane(pipe: Any, model: Any) -> None:
+def apply_branch_adapter_set(
+    pipe: Any,
+    routed: Mapping[str, Sequence[Tuple[Dict[str, Any], float, str]]],
+    *,
+    allow_resize: bool = True,
+    uniform: bool = False,
+    request_id: str = "",
+) -> Dict[str, Any]:
+    """Make exactly ``routed`` (component -> adapters) the PIPELINE's active
+    branch set (gw#679).
+
+    Every branch-capable denoiser is settled in one pass: components named
+    in ``routed`` take their own adapters, components not named are cleared
+    (a stale expert branch is exactly the silent-wrong-picture class this
+    guards), and all of them share one bucket so the pipeline carries a
+    single coherent graph family and lane stamp.
+
+    Fail-closed: an unroutable component and any unmappable adapter key
+    raise BEFORE a single buffer is touched — a half-attached MoE serves a
+    distilled expert next to an undistilled one."""
+    t0 = time.monotonic()
+    targets = branch_targets(pipe)
+    unknown = sorted(c for c in routed if c not in targets)
+    if unknown:
+        raise RefCompatibilitySurprise(
+            f"adapter set targets component(s) {', '.join(unknown)} which "
+            f"this pipeline does not carry (it has "
+            f"{', '.join(targets) or 'no branch-capable denoiser'})",
+            axis="component_missing",
+        )
+    # Pure pass first: map + stage every component. Raises here leave the
+    # pipeline exactly as it was.
+    staged: Dict[str, List[Tuple[Dict[str, Any], float, str]]] = {}
+    for comp, model in targets.items():
+        entries = list(routed.get(comp) or ())
+        staged[comp] = _stage_for(model, entries) if entries else []
+    want = max((_needed_rank(s) for s in staged.values()), default=0)
+    pre = {comp: branch_bucket(model) for comp, model in targets.items()}
+    current = max(pre.values(), default=0)
+    bucket = current
+    if want:
+        bucket = _settle_bucket(
+            list(targets.values()), rank_bucket(max(want, 1)),
+            uniform=uniform, allow_resize=allow_resize)
+    if uniform:
+        # A half-armed set (one expert carrying the container, the other not
+        # — e.g. a family that declares only `transformer` as a compile
+        # target) would place the sibling's adapter into nothing. Refuse
+        # before touching either expert.
+        bare = [c for c, s in staged.items() if s and not branch_bucket(targets[c])]
+        if bare:
+            raise RefCompatibilitySurprise(
+                f"component(s) {', '.join(sorted(bare))} carry no branch "
+                f"container at bucket {bucket} while the pipeline is "
+                "compiled — every denoiser an adapter set targets must be "
+                "armed (Compile(lora_bucket=...) arms them all; declare each "
+                "expert as a compile target too)",
+                axis="state_dict",
+            )
+    per: Dict[str, Dict[str, Any]] = {}
+    for comp, model in targets.items():
+        if not staged[comp]:
+            clear_branch_adapters(model)
+            per[comp] = _idle_stats(model)
+            continue
+        per[comp] = _place_adapters(
+            model, staged[comp], bucket, uniform=uniform,
+            current=pre[comp], t0=t0)
+    stats: Dict[str, Any] = {
+        "bucket": bucket, "resized": current != bucket,
+        "sparse": not uniform,
+        "adapters": sum(p["adapters"] for p in per.values()),
+        "covered": sum(p["covered"] for p in per.values()),
+        "modules": sum(p["modules"] for p in per.values()),
+        "copied_bytes": sum(p["copied_bytes"] for p in per.values()),
+        "swap_ms": int((time.monotonic() - t0) * 1000),
+        "components": per,
+    }
+    logger.info(
+        "[request_id=%s] w8a8 lora branch swap: adapters=%d bucket=%d "
+        "covered=%d/%d copied_bytes=%d resized=%s swap_ms=%d components=%s",
+        request_id, stats["adapters"], bucket, stats["covered"],
+        stats["modules"], stats["copied_bytes"], stats["resized"],
+        stats["swap_ms"],
+        " ".join(f"{c}:{p['adapters']}a/{p['covered']}m"
+                 for c, p in per.items()),
+    )
+    return stats
+
+
+def stamp_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
     """Keep the compile-cache graph key honest: branch-bearing pipelines are
     a different graph family per (base lane, bucket) — lane_drift guards
     both directions. The branchless base lane is remembered on first stamp
-    so clearing the branch restores it exactly."""
-    bucket = branch_bucket(model)
-    sparse = bool(getattr(model, _SPARSE_ATTR, False))
+    so clearing the branch restores it exactly.
+
+    The stamp is per PIPELINE, over its whole denoiser set (gw#679): the
+    components always carry the same bucket, and how many experts a family
+    has is a property of the pipeline class, not of the lane — so the lane
+    STRING (and therefore every published cell key) is unchanged by MoE
+    support."""
+    tg = branch_targets(pipe) if targets is None else dict(targets)
+    models = list(tg.values())
+    bucket = max((branch_bucket(m) for m in models), default=0)
+    sparse = any(bool(getattr(m, _SPARSE_ATTR, False)) for m in models)
     base = getattr(pipe, "_cozy_lora_base_lane", None)
     if base is None:
         from .loading import pipeline_weight_lane
 
         # The loader stamps _cozy_weight_lane on real pipelines; the
         # denoiser's own lane markers are the fallback authority.
-        base = pipeline_weight_lane(pipe) or branch_lane(model)
+        base = pipeline_weight_lane(pipe) or (
+            branch_lane(models[0]) if models else "")
         try:
             pipe._cozy_lora_base_lane = base
         except Exception:
@@ -713,19 +1044,28 @@ def normalize_adapter_state_dict(
 
 __all__ = [
     "RANK_BUCKETS",
+    "apply_branch_adapter_set",
     "apply_branch_adapters",
     "branch_bucket",
     "branch_lane",
+    "branch_lanes_active",
     "branch_modules",
-    "branch_target",
+    "branch_targets",
     "branches_active",
     "clear_branch_adapters",
+    "clear_branch_lanes",
+    "declared_component",
+    "disable_branch_lanes",
     "disable_lora_branches",
+    "enable_branch_lanes",
     "enable_lora_branches",
     "lora_lane",
     "map_adapter",
     "normalize_adapter_state_dict",
+    "pipeline_branch_bucket",
     "rank_bucket",
+    "require_component_declaration",
+    "route_denoiser_keys",
     "split_state_dict",
     "stamp_lane",
 ]

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -131,19 +131,25 @@ def _denoiser_fingerprint(pipe: Any) -> str:
 
 
 def _split_adapters(
-    pipe: Any, adapters: Sequence["PreparedAdapter"],
-) -> tuple[List["PreparedAdapter"], List[tuple]]:
-    """(peft-path adapters with denoiser keys stripped, branch set) for a
-    branch-capable pipeline. Each adapter is first normalized through the
-    pipeline class's own ``lora_state_dict`` converter (zero drift with the
-    boot-time path, te#81 pattern), then split: denoiser keys ride the
-    additive branch, the rest (text-encoder halves) keep peft. Branch
-    entries are (state_dict, weight, ref) — the
-    models.w8a8_lora.apply_branch_adapters contract."""
+    pipe: Any, adapters: Sequence["PreparedAdapter"], components: Sequence[str],
+) -> tuple[List["PreparedAdapter"], Dict[str, List[tuple]]]:
+    """(peft-path adapters with denoiser keys stripped, branch set BY
+    COMPONENT) for a branch-capable pipeline. Each adapter is first
+    normalized through the pipeline class's own ``lora_state_dict`` converter
+    (zero drift with the boot-time path, te#81 pattern), then split: denoiser
+    keys ride the additive branch, the rest (text-encoder halves) keep peft.
+    Branch entries are (state_dict, weight, ref) — the
+    models.w8a8_lora.apply_branch_adapter_set contract.
+
+    gw#679: the denoiser half is ROUTED to the component its keys name, so a
+    dual-expert MoE lands each half of a distillation on ITS expert. The
+    routed slices are cached with the split (not rebuilt per request) —
+    the branch staging cache keys on ``id(sd)``, and a fresh dict every
+    request would re-pay the ~700ms CPU flatten."""
 
     fp = _denoiser_fingerprint(pipe)
     peft: List[PreparedAdapter] = []
-    branch: List[tuple] = []
+    branch: Dict[str, List[tuple]] = {}
     for a in adapters:
         key = (type(pipe).__qualname__, fp, a.cache_key)
         with _SPLIT_CACHE_LOCK:
@@ -154,7 +160,19 @@ def _split_adapters(
             sd = w8a8_lora.normalize_adapter_state_dict(
                 pipe, a.state_dict, ref=a.ref
             )
-            cached = w8a8_lora.split_state_dict(sd)
+            den, rest = w8a8_lora.split_state_dict(sd)
+            if den:
+                # RAW keys decide routability on a multi-expert pipeline —
+                # the converter above rewrites every non-diffusers key onto
+                # the high-noise prefix whatever expert it came from
+                # (gw#679). Only adapters that HAVE a denoiser half owe a
+                # declaration; a text-encoder-only overlay is unaffected.
+                w8a8_lora.require_component_declaration(
+                    components, a.state_dict, ref=a.ref)
+            cached = (
+                w8a8_lora.route_denoiser_keys(den, components, ref=a.ref),
+                rest,
+            )
             with _SPLIT_CACHE_LOCK:
                 # A racing thread may have inserted the same key — keep the
                 # FIRST entry so every caller shares one den_sd object (the
@@ -162,9 +180,10 @@ def _split_adapters(
                 cached = _SPLIT_CACHE.setdefault(key, cached)
                 while len(_SPLIT_CACHE) > _SPLIT_CACHE_MAX:
                     _SPLIT_CACHE.popitem(last=False)
-        den, rest = cached
-        if den:
-            branch.append((den, a.weight, a.ref))
+        routed, rest = cached
+        for comp, den_sd in routed.items():
+            if den_sd:
+                branch.setdefault(comp, []).append((den_sd, a.weight, a.ref))
         if rest:
             peft.append(replace(a, state_dict=rest))
     return peft, branch
@@ -441,36 +460,55 @@ class AdapterResidency:
         text-encoder keys keep the peft path below. Plain-bf16 pipelines
         whose adapter cannot map onto branch-capable Linears (e.g. conv-
         targeting LoCon) fall back to the whole-adapter peft path when the
-        pipeline supports it — capability preserved, branch primary."""
+        pipeline supports it — capability preserved, branch primary.
+
+        gw#679: a pipeline's denoiser is a SET. Each adapter half is routed
+        to the expert its keys name and the set is applied atomically; the
+        peft fallback is refused outright on a multi-expert pipeline
+        (diffusers expresses the second expert as a ``load_lora_weights(...,
+        load_into_transformer_2=True)`` kwarg the peft path cannot reach, so
+        falling back there would re-create the silent mis-landing)."""
 
         all_adapters = list(adapters)
-        denoiser = w8a8_lora.branch_target(pipe)
-        branch_set: List[tuple] = []
-        if denoiser is not None:
-            adapters, branch_set = _split_adapters(pipe, adapters)
-            _reject_te_keys_on_cast_te(pipe, adapters)
-        if adapters and not isinstance(pipe, LoraCapablePipeline):
-            raise ValidationError(
-                "model slot does not support LoRA adapters "
-                "(pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)"
-            )
+        targets = w8a8_lora.branch_targets(pipe)
+        branch_set: Dict[str, List[tuple]] = {}
+        # Normalization + routing run OFF the residency lock (they are pure
+        # CPU work under the split cache's own lock), but a refusal here
+        # still owes the caller a deactivated pipeline — a rejected request
+        # must never leave the previous request's branch live.
+        try:
+            if targets:
+                adapters, branch_set = _split_adapters(
+                    pipe, adapters, tuple(targets))
+                _reject_te_keys_on_cast_te(pipe, adapters)
+            if adapters and not isinstance(pipe, LoraCapablePipeline):
+                raise ValidationError(
+                    "model slot does not support LoRA adapters "
+                    "(pipeline lacks load_lora_weights/set_adapters/"
+                    "unload_lora_weights)"
+                )
+        except BaseException:
+            self.deactivate(ref, pipe, request_id=request_id)
+            raise
         with self._lock:
             st = self._state(ref, pipe)
             try:
-                if denoiser is not None and branch_set:
+                if targets and branch_set:
                     # Compiled pipelines keep canonical placement and ONE
                     # traced bucket (a resize would mean a recompile at swap
                     # time — never allowed in prod); eager pipelines use
                     # sparse placement (branch kernels only where covered).
                     compiled = getattr(pipe, "_cozy_compile", None) is not None
+                    sole = next(iter(targets.values())) if len(targets) == 1 else None
                     try:
-                        w8a8_lora.apply_branch_adapters(
-                            denoiser, branch_set,
+                        w8a8_lora.apply_branch_adapter_set(
+                            pipe, branch_set,
                             allow_resize=not compiled, uniform=compiled,
                             request_id=request_id,
                         )
                     except RefCompatibilitySurprise:
-                        if (w8a8_lora.branch_lane(denoiser) == ""
+                        if (sole is not None
+                                and w8a8_lora.branch_lane(sole) == ""
                                 and not compiled
                                 and isinstance(pipe, LoraCapablePipeline)):
                             logger.info(
@@ -478,19 +516,19 @@ class AdapterResidency:
                                 "branch Linears; falling back to the peft path "
                                 "(plain lane)", request_id,
                             )
-                            w8a8_lora.clear_branch_adapters(denoiser)
-                            w8a8_lora.stamp_lane(pipe, denoiser)
+                            w8a8_lora.clear_branch_lanes(pipe)
+                            w8a8_lora.stamp_lane(pipe, targets)
                             adapters = all_adapters
                         else:
                             raise
                     else:
-                        w8a8_lora.stamp_lane(pipe, denoiser)
-                elif denoiser is not None:
+                        w8a8_lora.stamp_lane(pipe, targets)
+                elif targets:
                     # Adapter set has no denoiser half: make sure a previous
                     # request's branches are off.
-                    w8a8_lora.clear_branch_adapters(denoiser)
-                    w8a8_lora.stamp_lane(pipe, denoiser)
-                if denoiser is not None and not adapters:
+                    w8a8_lora.clear_branch_lanes(pipe)
+                    w8a8_lora.stamp_lane(pipe, targets)
+                if targets and not adapters:
                     # No peft half — make sure a previous request's peft
                     # adapters are off, then we're done. Only touch the peft
                     # surface when THIS registry attached something there:
@@ -564,10 +602,10 @@ class AdapterResidency:
             try:
                 from ..models import w8a8_lora
 
-                denoiser = w8a8_lora.branch_target(pipe)
-                if denoiser is not None:
-                    w8a8_lora.clear_branch_adapters(denoiser)
-                    w8a8_lora.stamp_lane(pipe, denoiser)
+                targets = w8a8_lora.branch_targets(pipe)
+                if targets:
+                    w8a8_lora.clear_branch_lanes(pipe)
+                    w8a8_lora.stamp_lane(pipe, targets)
             except Exception:
                 logger.warning(
                     "[request_id=%s] lora branch clear failed", request_id,
@@ -610,12 +648,12 @@ class AdapterResidency:
             try:
                 from ..models import w8a8_lora
 
-                denoiser = w8a8_lora.branch_target(pipe)
-                # branch_bucket guard: never-lora pipelines skip the module
-                # walk entirely — this runs on EVERY demote (gw#551 swaps).
-                if denoiser is not None and w8a8_lora.branch_bucket(denoiser):
-                    w8a8_lora.disable_lora_branches(denoiser)
-                    w8a8_lora.stamp_lane(pipe, denoiser)
+                targets = w8a8_lora.branch_targets(pipe)
+                # bucket guard: never-lora pipelines skip the module walk
+                # entirely — this runs on EVERY demote (gw#551 swaps).
+                if targets and w8a8_lora.pipeline_branch_bucket(pipe):
+                    w8a8_lora.disable_branch_lanes(pipe)
+                    w8a8_lora.stamp_lane(pipe, targets)
             except Exception:
                 logger.warning("lora branch drop on demote failed for %s",
                                ref, exc_info=True)

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -52,7 +52,7 @@ from gen_worker import (
     worker_function,
 )
 from gen_worker import compile_cache as cc
-from gen_worker import fleet_cells, hot_swap
+from gen_worker import fleet_cells, guard_closure, hot_swap
 from gen_worker.api.binding import Hub, wire_ref
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.intent_registry import IntentRegistry
@@ -162,6 +162,15 @@ class _Harness:
         monkeypatch.setattr(executor_mod, "ensure_local", _fake_ensure_local)
         monkeypatch.setattr(
             fleet_cells, "enable_compiled", self._fake_enable_compiled)
+        # pgw#681 gate at its torch boundary, simmed: this rig's compiles
+        # never touch dynamo, so extraction would honestly report closure
+        # unprovable and refuse every finalize.
+        monkeypatch.setattr(
+            guard_closure, "assert_closure",
+            lambda pipe, cfg, label="": {
+                "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                    "entry": 0, "guards": []}],
+                "verdicts": {}, "leaks": []})
         self.ex = Executor(self.specs, _send, store=store)
 
     # -- the compile-arm leaf ------------------------------------------------

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -27,6 +27,7 @@ from gen_worker import (
     endpoint,
 )
 from gen_worker import compile_cache as cc
+from gen_worker import guard_closure
 from gen_worker.models import provision
 from gen_worker.api.binding import Hub
 from gen_worker.api.binding import wire_ref
@@ -1412,6 +1413,13 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
     assert cc.cell_quarantined_in_process(f"root/family-{FAMILY}#{mint_key}")
 
 
+def _sim_guard_closure(pipe, cfg, label=""):
+    """A closed pgw#681 manifest for rigs whose compiles never touch dynamo."""
+    return {"v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                "entry": 0, "guards": []}],
+            "verdicts": {}, "leaks": []}
+
+
 def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
     """Wire the REAL fleet_cells miss path (prove-produces-the-mint) into an
     Executor boot: delivered arm refuses (mandatory miss), the cold-capture
@@ -1442,6 +1450,10 @@ def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
         _mark_fake_guard(p)
 
     monkeypatch.setattr(cc, "begin_fleet_mint", _begin)
+    # pgw#681 gate at its torch boundary, simmed like cc.apply's compile
+    # leaf: this rig's "compiles" never touch dynamo, so extraction would
+    # honestly report closure unprovable and refuse every finalize.
+    monkeypatch.setattr(guard_closure, "assert_closure", _sim_guard_closure)
     return captured, _Key.digest
 
 

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -22,6 +22,7 @@ import pytest
 from gen_worker import cell_key
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells as fc
+from gen_worker import guard_closure
 from gen_worker.models import provision
 
 
@@ -67,6 +68,14 @@ def _mintable(monkeypatch, *, key=FAKE_KEY):
     monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: False)
     monkeypatch.setattr(fc, "_cuda_ready", lambda: True)
     monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+    # pgw#681 gate at its torch boundary, simmed: these rigs never compile
+    # through dynamo, so extraction would honestly refuse every finalize.
+    monkeypatch.setattr(
+        guard_closure, "assert_closure",
+        lambda pipe, cfg, label="": {
+            "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                "entry": 0, "guards": []}],
+            "verdicts": {}, "leaks": []})
 
     class _Key:
         digest = key

--- a/tests/test_guard_closure_pgw681.py
+++ b/tests/test_guard_closure_pgw681.py
@@ -1,0 +1,410 @@
+"""pgw#681: guard-closure gate + boundary canonicalization.
+
+Real-dynamo tapes (CPU, ``backend="eager"`` — dynamo's guard machinery is
+identical to production's; only inductor codegen is skipped): dynamo's guard
+set IS the exhaustive dependency list of a compiled graph, so the gate can
+machine-check closure over the declared contract, and the ingress can pin
+the input boundary so serving inputs HIT the minted guards.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import compile_cache as cc
+from gen_worker import guard_closure as gc
+from gen_worker.registry import CompileCell
+
+
+@pytest.fixture(autouse=True)
+def _fresh_dynamo() -> Iterator[None]:
+    torch._dynamo.reset()
+    yield
+    torch._dynamo.reset()
+
+
+def _cfg(**overrides: Any) -> CompileCell:
+    base: Dict[str, Any] = dict(
+        shapes=((64, 64),), targets=("transformer",), family="toyfam",
+        regional=False, text_len=None, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=(),
+    )
+    base.update(overrides)
+    return CompileCell(**base)
+
+
+def _entries(fn: Any) -> int:
+    from torch._dynamo.eval_frame import _debug_get_cache_entry_list
+
+    code = getattr(getattr(fn, "__func__", fn), "__code__", None)
+    return len(_debug_get_cache_entry_list(code))
+
+
+def _arm_marker(pipe: Any, module: Any, fn: Any) -> None:
+    """A real apply()-shaped marker (apply() itself refuses on CPU hosts)."""
+    setattr(pipe, cc._MARKER_ATTR, {
+        "targets": ["transformer"],
+        "shapes": [(64, 64)],
+        "cache": True,
+        "originals": [(module, "forward", fn)],
+        "regional_mods": [],
+        "failure_signal": {
+            "callback": None, "lock": threading.Lock(),
+            "successful_calls": 0, "cache_hits": 0, "cache_misses": 0,
+            "router": None,
+        },
+    })
+
+
+def _compiled_toy(
+    forward: Callable[..., Any],
+) -> Tuple[Any, Any, Callable[..., Any]]:
+    """(pipe, module, bound_forward) with a marker armed and the forward
+    really compiled through dynamo (guards live on the code object)."""
+
+    class _Mod(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(8, 8)
+
+    _Mod.forward = forward  # type: ignore[method-assign]
+
+    class _Pipe:
+        pass
+
+    pipe = _Pipe()
+    mod = _Mod()
+    pipe.transformer = mod  # type: ignore[attr-defined]
+    _arm_marker(pipe, mod, mod.forward)
+    return pipe, mod, mod.forward
+
+
+# ---------------------------------------------------------------------------
+# Extraction + classification
+# ---------------------------------------------------------------------------
+
+
+def test_extraction_walks_real_dynamo_guard_tree() -> None:
+    def forward(self: Any, x: Any, scale: float) -> Any:
+        return self.lin(x) * scale
+
+    pipe, _mod, fn = _compiled_toy(forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 4, 8), 7.5)
+
+    report = gc.extract(pipe, _cfg(guidance_scales=(7.5,)))
+    assert len(report.graphs) == 1
+    rows = report.graphs[0].guards
+    by_type = {(r.guard_type, r.source): r for r in rows}
+    tensor = by_type[("TENSOR_MATCH", "L['x']")]
+    assert tensor.verdict == gc.CANONICALIZED
+    scalar = by_type[("EQUALS_MATCH", "L['scale']")]
+    assert scalar.verdict == gc.CONTRACT_SCALAR
+    verdicts = {r.verdict for r in rows}
+    assert gc.MODULE_STRUCTURE in verdicts    # L['self'] weights/structure
+    assert gc.RUNTIME_STATE in verdicts       # ambient global state
+    assert gc.LEAK not in verdicts
+    assert report.closed
+
+
+def test_manifest_is_deterministic_and_scrubs_aslr_ids() -> None:
+    def forward(self: Any, x: Any) -> Any:
+        return self.lin(x) + 1
+
+    pipe, _mod, fn = _compiled_toy(forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 4, 8))
+
+    cfg = _cfg()
+    one = gc.extract(pipe, cfg).manifest()
+    two = gc.extract(pipe, cfg).manifest()
+    assert json.dumps(one, sort_keys=True) == json.dumps(two, sort_keys=True)
+    dump = json.dumps(one)
+    assert "<id>" in dump
+    # No raw process addresses survive in check_obj_id/check_type_id.
+    assert not any(
+        "_id(" in r["expr"] and r["expr"].split("_id(")[1].rstrip(")").split(", ")[-1].isdigit()
+        for g in one["graphs"] for r in g["guards"]
+    )
+
+
+def test_classifier_closed_world() -> None:
+    pins = gc.contract_pins(_cfg(guidance_scales=(7.5,), text_lens=(256,)))
+    # Module + global roots: covered by construction.
+    assert gc.classify("ID_MATCH", "L['self']._modules['lin']", "x", pins)[0] \
+        == gc.MODULE_STRUCTURE
+    assert gc.classify("ID_MATCH", "G['mod'].F.linear", "x", pins)[0] \
+        == gc.CODE_IDENTITY
+    # Inputs: closed world.
+    assert gc.classify("EQUALS_MATCH", "L['n']", "L['n'] == 256", pins)[0] \
+        == gc.CONTRACT_SCALAR
+    assert gc.classify("EQUALS_MATCH", "L['n']", "L['n'] == 999", pins) \
+        == (gc.LEAK, "int 999 is not a declared contract pin")
+    assert gc.classify("ID_MATCH", "L['mask']", "___check_obj_id(...)", pins)[0] \
+        == gc.LEAK
+    assert gc.classify("WEIRD_NEW_GUARD", "L['x']", "whatever", pins)[0] == gc.LEAK
+    # Ambient: known types covered, unknown leak.
+    assert gc.classify("GLOBAL_STATE", "", "___check_global_state()", pins)[0] \
+        == gc.RUNTIME_STATE
+    assert gc.classify("MYSTERY", "", "x", pins)[0] == gc.LEAK
+    # Shape-env relations only pass under declared dynamism.
+    rel = "2 <= L['x'].size()[0] <= 64"
+    assert gc.classify("LAMBDA_GUARD", "L['x']", rel, pins)[0] == gc.LEAK
+    dyn_pins = gc.contract_pins(_cfg(dynamic=(
+        type("D", (), {"dim": "batch", "min": 2, "max": 64})(),)))
+    assert gc.classify("LAMBDA_GUARD", "L['x']", rel, dyn_pins)[0] \
+        == gc.CONTRACT_SHAPE
+
+
+def test_noncanonical_minted_stride_is_a_leak() -> None:
+    """A TENSOR_MATCH whose stride is not the ingress-canonical layout can
+    never HIT once serving canonicalizes — the gate refuses the mint."""
+    verdict, axis = gc.classify(
+        "TENSOR_MATCH", "L['x']",
+        "check_tensor(L['x'], Tensor, ..., size=[4, 1, 8], stride=[8, 999, 1])",
+        gc.contract_pins(_cfg()))
+    assert verdict == gc.LEAK
+    assert "non-canonical stride" in axis
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: out-of-contract scalar leak fails the mint red
+# ---------------------------------------------------------------------------
+
+
+def test_out_of_contract_scalar_fails_the_gate_naming_the_variable() -> None:
+    def forward(self: Any, x: Any, scale: float) -> Any:
+        return self.lin(x) * scale
+
+    pipe, _mod, fn = _compiled_toy(forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 4, 8), 3.25)  # 3.25 is NOT declared
+
+    with pytest.raises(gc.GuardClosureError) as excinfo:
+        gc.assert_closure(pipe, _cfg(), label="toyfam")
+    message = str(excinfo.value)
+    assert "L['scale']" in message
+    assert "3.25" in message
+
+    # Red-verified other direction: the SAME graph passes once the contract
+    # declares the pin — the gate keys on the contract, not the code shape.
+    manifest = gc.assert_closure(
+        pipe, _cfg(guidance_scales=(3.25,)), label="toyfam")
+    assert manifest["leaks"] == []
+
+
+def test_gate_refuses_when_nothing_is_extractable() -> None:
+    """Closure must be PROVEN — an armed pipe with no live compiled graphs
+    (extraction empty) refuses the mint instead of waving it through."""
+
+    class _Mod:
+        def forward(self, x: Any) -> Any:  # pragma: no cover - never called
+            return x
+
+    class _Pipe:
+        pass
+
+    pipe = _Pipe()
+    mod = _Mod()
+    pipe.transformer = mod  # type: ignore[attr-defined]
+    _arm_marker(pipe, mod, mod.forward)
+    with pytest.raises(gc.GuardClosureError, match="unprovable"):
+        gc.assert_closure(pipe, _cfg())
+
+
+def test_finish_fleet_mint_runs_the_gate_red_and_green(tmp_path: Path) -> None:
+    """The gate rides the real mint finalize: a leaking capture refuses to
+    pack; a closed capture packs with the manifest riding metadata.json."""
+
+    def forward(self: Any, x: Any, scale: float) -> Any:
+        return self.lin(x) * scale
+
+    pipe, _mod, fn = _compiled_toy(forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 4, 8), 3.25)
+
+    capture = tmp_path / "capture"
+    fx_entry = capture / "inductor" / "fxgraph" / "aa" / "bb"
+    fx_entry.mkdir(parents=True)
+    (fx_entry / "entry").write_bytes(b"fx")
+    target = tmp_path / "cell.tar.gz"
+
+    with pytest.raises(gc.GuardClosureError, match=r"L\['scale'\]"):
+        cc.finish_fleet_mint(pipe, _cfg(), "toyfam", target, capture)
+    assert not target.exists()
+
+    meta = cc.finish_fleet_mint(
+        pipe, _cfg(guidance_scales=(3.25,)), "toyfam", target, capture)
+    assert meta[gc.MANIFEST_KEY]["leaks"] == []
+    assert target.exists()
+    loaded = gc.load_manifest(target)
+    assert loaded == meta[gc.MANIFEST_KEY]
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: stride-perturbed input canonicalizes and HITS
+# ---------------------------------------------------------------------------
+
+
+def _perturbed_inputs() -> List[Any]:
+    base = torch.randn(4, 1, 8)
+    return [
+        # ie#544 trap: size-1 dim keeps is_contiguous() true under a garbage
+        # stride, so .contiguous() alone is a no-op.
+        base.as_strided((4, 1, 8), (8, 999, 1)),
+        # Genuinely non-contiguous layout of the same shape.
+        torch.randn(8, 4, 1).permute(1, 2, 0),
+    ]
+
+
+def test_stride_perturbed_input_recompiles_without_the_ingress() -> None:
+    """RED half: the raw compiled callable pays one recompile per stride
+    perturbation (live-confirmed dynamo behavior the ingress exists for)."""
+
+    def f(x: Any) -> Any:
+        return x * 2 + 1
+
+    compiled = torch.compile(f, backend="eager", dynamic=None)
+    compiled(torch.randn(4, 1, 8))
+    assert _entries(f) == 1
+    for t in _perturbed_inputs():
+        compiled(t)
+    assert _entries(f) == 3
+
+
+def test_stride_perturbed_input_canonicalizes_and_hits() -> None:
+    def f(x: Any) -> Any:
+        return x * 2 + 1
+
+    compiled = gc.canonical_ingress(
+        torch.compile(f, backend="eager", dynamic=None), "transformer")
+    warm = torch.randn(4, 1, 8)
+    compiled(warm)
+    assert _entries(f) == 1
+    for t in _perturbed_inputs():
+        out = compiled(t)
+        assert torch.equal(out, t.contiguous() * 2 + 1)
+    assert _entries(f) == 1  # zero recompiles: both perturbations HIT
+
+
+def test_ingress_pins_size1_dim_strides_not_just_contiguous() -> None:
+    seen: List[Tuple[int, ...]] = []
+
+    def f(x: Any) -> Any:
+        seen.append(tuple(x.stride()))
+        return x
+
+    wrapped = gc.canonical_ingress(f, "t")
+    weird = torch.randn(4, 1, 8).as_strided((4, 1, 8), (8, 999, 1))
+    assert weird.is_contiguous() and weird.contiguous() is weird
+    wrapped(weird)
+    assert seen == [gc.canonical_strides((4, 1, 8))]
+
+
+def test_ingress_canonicalizes_nested_containers_and_kwargs() -> None:
+    seen: List[Tuple[int, ...]] = []
+
+    def f(xs: Any, *, cond: Any = None) -> Any:
+        seen.append(tuple(xs[0].stride()))
+        seen.append(tuple(cond["c"].stride()))
+        return xs[0]
+
+    wrapped = gc.canonical_ingress(f, "t")
+    nc = torch.randn(8, 4, 1).permute(1, 2, 0)
+    wrapped([nc], cond={"c": nc.clone()})
+    assert seen == [gc.canonical_strides((4, 1, 8))] * 2
+
+
+def test_ingress_dtype_drift_raises_named() -> None:
+    def f(x: Any) -> Any:
+        return x
+
+    wrapped = gc.canonical_ingress(f, "transformer")
+    wrapped(torch.randn(2, 8))
+    with pytest.raises(gc.GuardBoundaryError) as excinfo:
+        wrapped(torch.randn(2, 8, dtype=torch.float64))
+    message = str(excinfo.value)
+    assert "args[0]" in message
+    assert "float64" in message and "float32" in message
+    assert "transformer" in message
+
+
+# ---------------------------------------------------------------------------
+# Fleet consolidation: the N-cold-pod zero-miss closure check
+# ---------------------------------------------------------------------------
+
+
+def _toy_manifest(**mutate: Any) -> Dict[str, Any]:
+    guards = [
+        {"type": "TENSOR_MATCH", "source": "L['x']",
+         "expr": "check_tensor(size=[4, 1, 8], stride=[8, 8, 1])",
+         "verdict": gc.CANONICALIZED, "axis": "ingress"},
+        {"type": "GLOBAL_STATE", "source": "",
+         "expr": '___check_global_state() against {"num_threads":24}',
+         "verdict": gc.RUNTIME_STATE, "axis": "runtime"},
+    ]
+    manifest: Dict[str, Any] = {
+        "v": 1,
+        "graphs": [{"target": "transformer", "code": "forward", "entry": 0,
+                    "guards": guards}],
+        "verdicts": {}, "leaks": [],
+    }
+    manifest.update(mutate)
+    return manifest
+
+
+def test_consolidate_identical_manifests_is_closed() -> None:
+    audit = gc.consolidate({"pod-a": _toy_manifest(), "pod-b": _toy_manifest()})
+    assert audit.ok
+    assert audit.guard_total == 4
+
+
+def test_consolidate_tolerates_per_host_ambient_content() -> None:
+    """GLOBAL_STATE content is per-host (num_threads); its PRESENCE is
+    compared, its content stays in the dump."""
+    other = _toy_manifest()
+    other["graphs"][0]["guards"][1]["expr"] = (
+        '___check_global_state() against {"num_threads":8}')
+    audit = gc.consolidate({"pod-a": _toy_manifest(), "pod-b": other})
+    assert audit.ok
+
+
+def test_consolidate_names_divergence_and_leaks() -> None:
+    missing = _toy_manifest()
+    missing["graphs"][0]["guards"] = missing["graphs"][0]["guards"][:1]
+    audit = gc.consolidate({"pod-a": _toy_manifest(), "pod-b": missing})
+    assert not audit.ok
+    assert any("GLOBAL_STATE" in d and "pod-b" in d for d in audit.divergence)
+
+    leaky = _toy_manifest(leaks=["target=transformer EQUALS_MATCH L['s']: ..."])
+    audit = gc.consolidate({"pod-a": leaky})
+    assert audit.leaks and "pod-a" in audit.leaks[0]
+
+
+def test_cli_zero_miss_check_exit_codes(tmp_path: Path) -> None:
+    good_a = tmp_path / "a.json"
+    good_b = tmp_path / "b.json"
+    good_a.write_text(json.dumps(_toy_manifest()))
+    good_b.write_text(json.dumps(_toy_manifest()))
+    assert gc.main([str(good_a), str(good_b)]) == 0
+
+    leaky = tmp_path / "leak.json"
+    leaky.write_text(json.dumps(_toy_manifest(leaks=["leak row"])))
+    assert gc.main([str(good_a), str(leaky)]) == 2
+
+    divergent = _toy_manifest()
+    divergent["graphs"][0]["guards"] = divergent["graphs"][0]["guards"][:1]
+    div = tmp_path / "div.json"
+    div.write_text(json.dumps(divergent))
+    assert gc.main([str(good_a), str(div)]) == 3
+
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({"graphs": []}))
+    assert gc.main([str(good_a), str(empty)]) == 3  # unproven cell never passes

--- a/tests/test_hot_swap_pgw622.py
+++ b/tests/test_hot_swap_pgw622.py
@@ -16,7 +16,7 @@ import time
 import torch
 
 from gen_worker import compile_cache as cc
-from gen_worker import fleet_cells, hot_swap
+from gen_worker import fleet_cells, guard_closure, hot_swap
 
 
 def _wait(predicate, timeout=30.0):
@@ -330,6 +330,15 @@ def _pin_identity(monkeypatch):
     }
     monkeypatch.setattr(cc, "runtime_key", lambda: dict(key))
     monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.0.0-test")
+    # pgw#681 gate at its torch boundary, simmed: these republish rigs
+    # never compile through dynamo, so extraction would honestly report
+    # closure unprovable and refuse the republish.
+    monkeypatch.setattr(
+        guard_closure, "assert_closure",
+        lambda pipe, cfg, label="": {
+            "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                "entry": 0, "guards": []}],
+            "verdicts": {}, "leaks": []})
 
 
 def test_republish_packs_live_root_under_same_key(monkeypatch, tmp_path):

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker import compile_cache as cc
+from gen_worker import guard_closure
 from gen_worker import local_cells as lc
 
 
@@ -133,6 +134,19 @@ def _fake_compile_and_warm(pipe, cfg, **kw):
     TORCHINDUCTOR/TRITON cache env points (what inductor would do)."""
     Path(os.environ["TORCHINDUCTOR_CACHE_DIR"], "graph.so").write_bytes(b"\x7fELF-ish")
     Path(os.environ["TRITON_CACHE_DIR"], "kern.cubin").write_bytes(b"cubin")
+
+
+@pytest.fixture(autouse=True)
+def _sim_guard_closure(monkeypatch):
+    """pgw#681 gate at its torch boundary, simmed like _fake_compile_and_warm:
+    these rigs never compile through dynamo, so extraction would honestly
+    report closure unprovable and refuse every mint."""
+    monkeypatch.setattr(
+        guard_closure, "assert_closure",
+        lambda pipe, cfg, label="": {
+            "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                "entry": 0, "guards": []}],
+            "verdicts": {}, "leaks": []})
 
 
 def test_mint_saves_atomically_and_roundtrips(monkeypatch, tmp_path):

--- a/tests/test_moe_branch_gw679.py
+++ b/tests/test_moe_branch_gw679.py
@@ -1,0 +1,415 @@
+"""gw#679: a DUAL-EXPERT MoE denoiser is a SET of branch targets.
+
+Wan 2.2 A14B is two experts — ``transformer`` (high noise) and
+``transformer_2`` (low noise, handed off at ``boundary_ratio``) — and the
+lightx2v Lightning distillation is correspondingly TWO adapters. Before this
+fix the branch machinery resolved ONE denoiser (``pipe.transformer``), and
+diffusers' Wan converter rewrites every non-diffusers key onto the
+``transformer.`` prefix whatever expert the file was trained for, so both
+halves landed rank-concatenated on the HIGH expert, ``map_adapter``
+succeeded, and the LOW expert served undistilled weights on a 4-step
+distilled ladder: a wrong picture with a clean log.
+
+These run the REAL path — a real diffusers ``WanPipeline`` carrying two real
+(tiny) ``WanTransformer3DModel`` experts, real adapter key grammars, driven
+through ``AdapterResidency.activate/deactivate/detach`` and the real
+``compile_cache.apply_lora_lane`` arming — and check WHERE the weights
+landed by the branch lane's own scaling equivalent (``B @ A``, and the
+forward addend it produces), never by an adapter-name list.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker import compile_cache  # noqa: E402
+from gen_worker.api.errors import RefCompatibilitySurprise  # noqa: E402
+from gen_worker.models import w8a8_lora  # noqa: E402
+from gen_worker.utils.lora import AdapterResidency, PreparedAdapter  # noqa: E402
+
+_RANK = 8
+_PROBE = "blocks.0.attn1.to_q"
+
+
+def _tiny_expert(seed: int) -> Any:
+    from diffusers import WanTransformer3DModel
+
+    torch.manual_seed(seed)
+    return WanTransformer3DModel(
+        patch_size=(1, 2, 2), num_attention_heads=2, attention_head_dim=8,
+        in_channels=4, out_channels=4, text_dim=16, freq_dim=16, ffn_dim=32,
+        num_layers=1, cross_attn_norm=True,
+        qk_norm="rms_norm_across_heads", rope_max_seq_len=32,
+    )
+
+
+def _wan_pipe(*, moe: bool = True) -> Any:
+    """A REAL diffusers WanPipeline over stub weights (the A14B topology when
+    ``moe``, the dense TI2V-5B topology otherwise)."""
+    from diffusers import UniPCMultistepScheduler, WanPipeline
+
+    scheduler = UniPCMultistepScheduler(
+        prediction_type="flow_prediction", use_flow_sigmas=True, flow_shift=3.0)
+    return WanPipeline(
+        tokenizer=None, text_encoder=None, vae=None, scheduler=scheduler,
+        transformer=_tiny_expert(0),
+        transformer_2=_tiny_expert(1) if moe else None,
+        boundary_ratio=0.9 if moe else None,
+    )
+
+
+def _half(expert: Any, prefix: str, seed: int) -> Dict[str, Any]:
+    """One expert's adapter half in the MIRRORED grammar: peft keys under the
+    component prefix that names the expert it adapts."""
+    torch.manual_seed(seed)
+    sd: Dict[str, Any] = {}
+    for path, mod in w8a8_lora.branch_modules(expert).items():
+        sd[f"{prefix}{path}.lora_A.weight"] = (
+            torch.randn(_RANK, mod.in_features) * 0.05)
+        sd[f"{prefix}{path}.lora_B.weight"] = (
+            torch.randn(mod.out_features, _RANK) * 0.05)
+    return sd
+
+
+def _raw_lightx2v_half(seed: int) -> Dict[str, Any]:
+    """The UNMIRRORED shipping grammar of both 250928 halves — identical key
+    names in each file (`diffusion_model.blocks.N.self_attn.q...`), which
+    diffusers rewrites onto `transformer.` for high and low alike."""
+    torch.manual_seed(seed)
+    sd: Dict[str, Any] = {}
+    for o in ("q", "k", "v", "o"):
+        base = f"diffusion_model.blocks.0.self_attn.{o}"
+        sd[f"{base}.lora_A.weight"] = torch.randn(_RANK, 16) * 0.05
+        sd[f"{base}.lora_B.weight"] = torch.randn(16, _RANK) * 0.05
+    return sd
+
+
+def _prepared(sd: Dict[str, Any], ref: str, weight: float = 1.0) -> PreparedAdapter:
+    return PreparedAdapter(
+        slot="pipeline", ref=ref, cache_key=ref,
+        name=f"gw-{abs(hash(ref)) % 10**8}", weight=weight, state_dict=sd,
+    )
+
+
+def _delta(expert: Any, path: str = _PROBE) -> Any:
+    """The branch's effective weight delta on one module: ``B @ A`` with the
+    alpha/rank * user-weight scale already folded into B — the branch lane's
+    scaling equivalent, and what the forward actually adds."""
+    mod = expert.get_submodule(path)
+    return mod.lora_b.detach() @ mod.lora_a.detach()
+
+
+def _expected_delta(sd: Dict[str, Any], prefix: str, weight: float,
+                    path: str = _PROBE) -> Any:
+    a = sd[f"{prefix}{path}.lora_A.weight"]
+    b = sd[f"{prefix}{path}.lora_B.weight"]
+    return (b @ a) * weight
+
+
+def _branch_addend(expert: Any, x: Any, path: str = _PROBE) -> Any:
+    """What the branch adds in the REAL forward: y(x) - base(x)."""
+    import torch.nn.functional as F
+
+    mod = expert.get_submodule(path)
+    with torch.no_grad():
+        return mod(x) - F.linear(x, mod.weight, mod.bias)
+
+
+# ---------------------------------------------------------------------------
+# The fix: each half lands on ITS expert
+# ---------------------------------------------------------------------------
+
+
+def test_each_distillation_half_lands_on_its_own_expert() -> None:
+    pipe = _wan_pipe()
+    assert list(w8a8_lora.branch_targets(pipe)) == ["transformer", "transformer_2"]
+
+    high = _half(pipe.transformer, "transformer.", seed=11)
+    low = _half(pipe.transformer_2, "transformer_2.", seed=22)
+    residency = AdapterResidency()
+    residency.activate(
+        "wan22", pipe,
+        [_prepared(high, "hub/lightning-250928-high@1", weight=2.0),
+         _prepared(low, "hub/lightning-250928-low@1", weight=1.0)],
+        request_id="moe1",
+    )
+
+    assert w8a8_lora.branches_active(pipe.transformer)
+    assert w8a8_lora.branches_active(pipe.transformer_2), (
+        "the low-noise expert must be adapted — serving it undistilled on a "
+        "distilled ladder is the gw#679 silent defect")
+
+    want_high = _expected_delta(high, "transformer.", 2.0)
+    want_low = _expected_delta(low, "transformer_2.", 1.0)
+    got_high, got_low = _delta(pipe.transformer), _delta(pipe.transformer_2)
+
+    assert torch.allclose(got_high, want_high, atol=1e-5)
+    assert torch.allclose(got_low, want_low, atol=1e-5)
+    # Pre-fix, transformer carried BOTH halves rank-concatenated (high + low)
+    # and transformer_2 carried none. Both directions must now be false.
+    assert not torch.allclose(got_high, want_high + want_low, atol=1e-5)
+    assert not torch.allclose(got_high, got_low, atol=1e-5)
+
+    # And it is real in the forward, per expert, at its own scale.
+    x = torch.randn(2, 16)
+    assert torch.allclose(_branch_addend(pipe.transformer, x),
+                          x @ want_high.t(), atol=1e-4)
+    assert torch.allclose(_branch_addend(pipe.transformer_2, x),
+                          x @ want_low.t(), atol=1e-4)
+
+    # Bit-exact teardown on BOTH experts (the gw#547 invariant, per expert).
+    base_high = _branch_addend(pipe.transformer, x)
+    residency.deactivate("wan22", pipe, request_id="moe1")
+    assert not w8a8_lora.branches_active(pipe.transformer)
+    assert not w8a8_lora.branches_active(pipe.transformer_2)
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) == 0.0
+    assert float(_branch_addend(pipe.transformer_2, x).abs().sum()) == 0.0
+    assert float(base_high.abs().sum()) > 0  # the probe was meaningful
+
+
+def test_one_half_alone_leaves_the_other_expert_bare_not_double_adapted() -> None:
+    """A single-expert adapter is routed, not smeared: the named expert gets
+    it and the sibling keeps exactly branchless behavior."""
+    pipe = _wan_pipe()
+    low = _half(pipe.transformer_2, "transformer_2.", seed=33)
+    AdapterResidency().activate(
+        "wan22", pipe, [_prepared(low, "hub/lightning-250928-low@2")],
+        request_id="moe2")
+
+    assert w8a8_lora.branches_active(pipe.transformer_2)
+    assert not w8a8_lora.branches_active(pipe.transformer)
+    x = torch.randn(2, 16)
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) == 0.0
+    assert torch.allclose(
+        _delta(pipe.transformer_2), _expected_delta(low, "transformer_2.", 1.0),
+        atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: never a partial attach, never a silent landing
+# ---------------------------------------------------------------------------
+
+
+def test_unmirrored_per_expert_file_is_refused_not_silently_high_noise() -> None:
+    """The exact live shape of the defect: both 250928 halves ship the same
+    `diffusion_model.` key names, and diffusers' converter puts both on the
+    `transformer.` prefix. On a two-expert pipeline that is unroutable, and
+    must fail loud instead of landing everything on the high expert."""
+    pipe = _wan_pipe()
+    residency = AdapterResidency()
+    with pytest.raises(RefCompatibilitySurprise) as err:
+        residency.activate(
+            "wan22", pipe,
+            [_prepared(_raw_lightx2v_half(44), "hub/lightning-250928-high@3"),
+             _prepared(_raw_lightx2v_half(55), "hub/lightning-250928-low@3")],
+            request_id="moe3",
+        )
+    assert "component" in str(err.value)
+    assert not w8a8_lora.branches_active(pipe.transformer)
+    assert not w8a8_lora.branches_active(pipe.transformer_2)
+
+
+def test_declared_component_the_pipeline_lacks_is_refused() -> None:
+    """A `transformer_2.` half bound to a DENSE pipeline names a component
+    that does not exist — unroutable, and nothing may attach."""
+    pipe = _wan_pipe(moe=False)
+    assert list(w8a8_lora.branch_targets(pipe)) == ["transformer"]
+    sd = _half(pipe.transformer, "transformer_2.", seed=66)
+    with pytest.raises(RefCompatibilitySurprise, match="does not carry"):
+        AdapterResidency().activate(
+            "wan22-dense", pipe, [_prepared(sd, "hub/lightning-250928-low@4")],
+            request_id="moe4")
+    assert not w8a8_lora.branches_active(pipe.transformer)
+
+
+def test_a_broken_second_half_attaches_nothing_at_all() -> None:
+    """Fail-closed under a MAPPING error, not just a routing one: a good high
+    half next to a shape-broken low half must leave the pipeline bare. Half
+    an MoE distillation is the silently-wrong picture, so 'partially applied'
+    is never an acceptable outcome."""
+    pipe = _wan_pipe()
+    high = _half(pipe.transformer, "transformer.", seed=77)
+    low = _half(pipe.transformer_2, "transformer_2.", seed=88)
+    low[f"transformer_2.{_PROBE}.lora_A.weight"] = torch.randn(_RANK, 999)
+
+    with pytest.raises(RefCompatibilitySurprise):
+        AdapterResidency().activate(
+            "wan22", pipe,
+            [_prepared(high, "hub/lightning-250928-high@5"),
+             _prepared(low, "hub/lightning-250928-low@5")],
+            request_id="moe5",
+        )
+    assert not w8a8_lora.branches_active(pipe.transformer)
+    assert not w8a8_lora.branches_active(pipe.transformer_2)
+    x = torch.randn(2, 16)
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The bucket container is per component (Compile(lora_bucket=...) arming)
+# ---------------------------------------------------------------------------
+
+
+def test_lora_bucket_container_is_armed_on_both_experts() -> None:
+    pipe = _wan_pipe()
+    assert compile_cache.apply_lora_lane(pipe, 32)
+    assert w8a8_lora.branch_bucket(pipe.transformer) == 32
+    assert w8a8_lora.branch_bucket(pipe.transformer_2) == 32
+    assert w8a8_lora.pipeline_branch_bucket(pipe) == 32
+    # The lane STRING is unchanged by MoE support — how many experts a family
+    # has is a property of the pipeline class, not of the graph family, so
+    # published cell keys keep their meaning.
+    assert pipe._cozy_weight_lane == "lora32"
+
+    pipe._cozy_compile = object()
+    residency = AdapterResidency()
+    high = _half(pipe.transformer, "transformer.", seed=99)
+    low = _half(pipe.transformer_2, "transformer_2.", seed=100)
+    for attempt in ("attach", "swap", "reattach"):
+        residency.activate(
+            "wan22", pipe,
+            [_prepared(high, "hub/lightning-250928-high@6"),
+             _prepared(low, "hub/lightning-250928-low@6")],
+            request_id=attempt,
+        )
+        # Canonical placement holds on BOTH experts: same traced bucket, no
+        # resize, every branch-capable Linear still carries a slot.
+        assert w8a8_lora.branch_bucket(pipe.transformer) == 32
+        assert w8a8_lora.branch_bucket(pipe.transformer_2) == 32
+        assert pipe._cozy_weight_lane == "lora32"
+        for expert in (pipe.transformer, pipe.transformer_2):
+            slots = [m for m in w8a8_lora.branch_modules(expert).values()
+                     if getattr(m, "lora_a", None) is not None]
+            assert len(slots) == len(w8a8_lora.branch_modules(expert))
+        assert torch.allclose(
+            _delta(pipe.transformer_2),
+            _expected_delta(low, "transformer_2.", 1.0), atol=1e-5)
+        residency.deactivate("wan22", pipe, request_id=attempt)
+        # Canonical clear zeroes B and keeps the graph on both experts.
+        assert w8a8_lora.branch_bucket(pipe.transformer_2) == 32
+        assert float(_delta(pipe.transformer_2).abs().sum()) == 0.0
+
+    residency.detach("wan22", pipe)
+    assert w8a8_lora.pipeline_branch_bucket(pipe) == 0
+    assert getattr(pipe.transformer_2, "lora_a", None) is None
+    assert pipe._cozy_weight_lane == ""
+
+
+def test_a_half_armed_compiled_pipeline_refuses_instead_of_no_opping() -> None:
+    """If only one expert carries the container (a family that declared just
+    `transformer` as a compile target), the sibling's half would be copied
+    into nothing. That must refuse, and refuse before the armed expert is
+    touched."""
+    pipe = _wan_pipe()
+    w8a8_lora.enable_lora_branches(pipe.transformer, 32)  # high only
+    pipe._cozy_compile = object()
+    high = _half(pipe.transformer, "transformer.", seed=111)
+    low = _half(pipe.transformer_2, "transformer_2.", seed=222)
+    with pytest.raises(RefCompatibilitySurprise, match="branch container"):
+        AdapterResidency().activate(
+            "wan22", pipe,
+            [_prepared(high, "hub/high@7"), _prepared(low, "hub/low@7")],
+            request_id="moe7")
+    assert not w8a8_lora.branches_active(pipe.transformer)
+    assert float(_delta(pipe.transformer).abs().sum()) == 0.0
+
+
+def test_compiled_pipeline_refuses_a_set_that_needs_a_wider_bucket() -> None:
+    """The no-recompile-at-swap-time rule is enforced over the SET (the sum
+    of concatenated ranks on either expert)."""
+    pipe = _wan_pipe()
+    compile_cache.apply_lora_lane(pipe, 16)
+    pipe._cozy_compile = object()
+    wide: Dict[str, Any] = {}
+    for path, mod in w8a8_lora.branch_modules(pipe.transformer_2).items():
+        wide[f"transformer_2.{path}.lora_A.weight"] = torch.randn(24, mod.in_features)
+        wide[f"transformer_2.{path}.lora_B.weight"] = torch.randn(mod.out_features, 24)
+    from gen_worker.api.errors import ValidationError
+
+    with pytest.raises(ValidationError, match="rank bucket"):
+        AdapterResidency().activate(
+            "wan22", pipe, [_prepared(wide, "hub/wide")], request_id="moe6")
+
+
+# ---------------------------------------------------------------------------
+# Single-component regression: the LTX/sdxl/qwen lanes are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_single_denoiser_pipeline_takes_the_component_prefixed_grammar() -> None:
+    """One denoiser => its own component prefix routes to it, and the whole
+    request behaves exactly as the LTX/qwen lanes do today."""
+    pipe = _wan_pipe(moe=False)
+    sd = _half(pipe.transformer, "transformer.", seed=123)
+    residency = AdapterResidency()
+    residency.activate(
+        "dense", pipe, [_prepared(sd, "hub/style@dotted")], request_id="dense1")
+    assert w8a8_lora.branches_active(pipe.transformer)
+    assert torch.allclose(
+        _delta(pipe.transformer), _expected_delta(sd, "transformer.", 1.0),
+        atol=1e-5)
+
+    x = torch.randn(2, 16)
+    residency.deactivate("dense", pipe, request_id="dense1")
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) == 0.0
+
+
+def test_single_denoiser_pipeline_still_takes_an_UNDECLARED_adapter() -> None:
+    """The declaration requirement is a MULTI-expert rule only: the raw
+    lightx2v grammar (which the diffusers converter rewrites onto
+    `transformer.`) keeps working unchanged on a dense pipeline — no mirror
+    re-key is imposed on the single-denoiser families."""
+    pipe = _wan_pipe(moe=False)
+    raw = _raw_lightx2v_half(seed=321)
+    residency = AdapterResidency()
+    residency.activate(
+        "dense", pipe, [_prepared(raw, "hub/lightx2v@dense")],
+        request_id="dense2")
+    assert w8a8_lora.branches_active(pipe.transformer)
+    x = torch.randn(2, 16)
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) > 0
+    residency.deactivate("dense", pipe, request_id="dense2")
+    assert float(_branch_addend(pipe.transformer, x).abs().sum()) == 0.0
+
+
+def test_text_encoder_only_overlay_owes_no_component_declaration() -> None:
+    """The declaration is owed by adapters with a DENOISER half. A TE-only
+    overlay on a two-expert pipeline keeps the peft path untouched."""
+    from gen_worker.utils.lora import _split_adapters
+
+    pipe = _wan_pipe()
+    sd = {
+        "text_encoder.layers.0.self_attn.q_proj.lora_A.weight": torch.randn(4, 16),
+        "text_encoder.layers.0.self_attn.q_proj.lora_B.weight": torch.randn(16, 4),
+    }
+    peft, branch = _split_adapters(
+        pipe, [_prepared(sd, "hub/te-only@8")],
+        ("transformer", "transformer_2"))
+    assert branch == {}
+    assert [a.ref for a in peft] == ["hub/te-only@8"]
+
+
+def test_route_is_a_pure_partition_of_the_denoiser_half() -> None:
+    """The routing primitive itself, on both topologies."""
+    both = {"transformer.a.lora_A.weight": 1, "transformer_2.a.lora_A.weight": 2}
+    dense = {"transformer.a.lora_A.weight": 1, "lora_unet_a.lora_down.weight": 2}
+    # One target takes its own prefix AND the kohya-flat grammar (sd-scripts
+    # emits lora_unet_ for transformer denoisers too — never a declaration).
+    assert w8a8_lora.route_denoiser_keys(dense, ("transformer",)) == {
+        "transformer": dense}
+    assert w8a8_lora.route_denoiser_keys(
+        both, ("transformer", "transformer_2")) == {
+            "transformer": {"transformer.a.lora_A.weight": 1},
+            "transformer_2": {"transformer_2.a.lora_A.weight": 2},
+        }
+    assert w8a8_lora.route_denoiser_keys({}, ("transformer",)) == {}
+    with pytest.raises(RefCompatibilitySurprise, match="ambiguous"):
+        w8a8_lora.route_denoiser_keys(
+            {"a.lora_A.weight": 1}, ("transformer", "transformer_2"))
+    with pytest.raises(RefCompatibilitySurprise, match="does not carry"):
+        w8a8_lora.route_denoiser_keys(both, ("transformer",))

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -50,6 +50,7 @@ import pytest
 import gen_worker.executor as executor_mod
 from gen_worker import Compile, cell_key as cell_key_mod
 from gen_worker import compile_cache as cc
+from gen_worker import guard_closure
 from gen_worker import fleet_cells, hot_swap
 from gen_worker.api.binding import Hub, wire_ref
 from gen_worker.executor import Executor
@@ -251,6 +252,15 @@ class _Rig:
         monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
         monkeypatch.setattr(cc, "toolchain_present", lambda: True)
         monkeypatch.setattr(cc, "apply", _sim_apply_factory(self.sim))
+        # pgw#681 gate at its torch boundary, simmed like apply's compile
+        # leaf: _Sim never touches dynamo, so extraction would honestly
+        # report closure unprovable and refuse every finalize.
+        monkeypatch.setattr(
+            guard_closure, "assert_closure",
+            lambda pipe, cfg, label="": {
+                "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                    "entry": 0, "guards": []}],
+                "verdicts": {}, "leaks": []})
         monkeypatch.setattr(
             cc, "inductor_counters", lambda: dict(self.sim.counters))
         monkeypatch.setattr(cell_key_mod, "compute", _fake_key_compute)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.67.4"
+version = "0.68.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
0.68.0 train, two chaos commits cherry-picked onto master:

- **pgw#681** (`35196ee`): graph determinism — dynamo's guard set is machine-checked for closure over the declared contract at every mint (leak => mint red naming the variable; unprovable closure refuses); canonical stride/dtype ingress at the single compiled-graph boundary (stride-perturbed inputs HIT instead of recompiling, incl. the ie#544 size-1-dim trap); the full classified guard manifest rides every cell's metadata.json; `python -m gen_worker.guard_closure` is the runnable N-cold-pod zero-miss closure check. SDK-generic only — parameterized by the declared contract, zero per-endpoint code.
- **gw#679** (`b57f3b5`): a denoiser is a SET — per-expert LoRA branch routing for MoE pipelines (Wan 2.2 dual-expert; `transformer_2` now adapted).

Plus a release-assembly commit: version 0.68.0 (pyproject + uv.lock), CHANGELOG ordered 0.68.0 > 0.67.4 > 0.67.3 (also restores the 0.67.3 heading the pgw#681 chaos edit had dropped).

Verification: full suite on the exact staged tree = 1010 passed / 5 skipped / 1 xfailed (single failure is the documented box timing flake, passes standalone); combined 680+681 mint-surface suites 279 passed; mypy 151 files clean; ruff clean. pgw#680 (0.67.4, already on master) is the serve-time stopper this gate is the build-time prevention for — one doctrine, two halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)