### PR TITLE
pgw#678 + pgw#683 (both P0): the lane's residency handle is not the pipeline; shared-component identity carries the EFFECTIVE compute dtype (0.68.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.68.1 (2026-07-26) — pgw#678 the lane handle is not the pipeline; pgw#683 shared-component identity carries the EFFECTIVE compute dtype
+
+Two P0s on the composition/residency path, both found live on the sdxl retag
+cycle (ie#546), both about ONE object being asked to be two things.
+
+- **pgw#678 — a `components.*` deploy override no longer makes a deploy-bound
+  LoRA unattachable.** `generate-turbo` was **0/6** WITH the fp16-fix VAE
+  override and **4/4** WITHOUT it on the same release, wheel and card, failing
+  `model slot does not support LoRA adapters`. `utils/lora.py` was byte-identical
+  across the two versions that bracketed it, because the defect was object
+  identity, not adapter code: an overridden component is popped out of the
+  content-keyed share plan, so the lane owns a non-empty EXCLUSIVE module set
+  and its residency entry is `nn.ModuleDict(exclusive)` — correct as the
+  MOVEMENT handle (LRU must move only lane-owned weights), fatal when read as
+  the pipeline. `branch_targets` finds no denoiser on a ModuleDict, the whole
+  adapter stays on the peft side, and the pipeline-capability check refuses.
+  The record now owns the pipeline identity (`_ClassRecord.slot_pipelines`);
+  residency keeps the movement handle. The adapter target, the explicit
+  deactivation sweep and the OOM offload rung all read the pipeline — the last
+  of those had been silently skipping every lane slot, since a ModuleDict
+  carries no `enable_*_offload`. A lane whose placement falls to an offload
+  rung now LEARNS that the ref is un-shareable on this host instead of
+  re-deriving the refused plan until `retry_exhausted`.
+- **pgw#683 — a composition can no longer be handed a foreign-precision
+  component, and a mixed one is refused at LOAD.** `RuntimeError: mat1 and mat2
+  must have the same dtype, but got BFloat16 and Half` killed
+  `self_mint_compile phase=warmup_forward` and cost `generate` on a live prod
+  release with NO component override on the wire, so pgw#675's lane-aware
+  default could not explain it. `LoadedComponentKey` keyed on the binding's
+  DECLARED dtype; hub bindings declare none, and a quantizer rewrites only the
+  DENOISER, so the VAE and text encoders of `X` and `X#fp8-w8a8` are
+  byte-identical — one cache entry across compositions that compute at
+  DIFFERENT dtypes (bf16 on a quant lane, fp16 for a plain fp16-stored
+  mirror). Identity now carries the EFFECTIVE compute dtype
+  (`composition_compute_dtype`), so components still alias by content but never
+  across a precision boundary. `apply_fp8_storage` gets the SCALAR compute
+  dtype (it could previously be handed pgw#667's per-component dtype MAP), and
+  the new `assert_uniform_compute_dtype` invariant runs on every worker-loaded
+  slot: a composition presenting two compute dtypes to its GEMMs fails at load
+  naming the component and the offending tensor, instead of torch naming
+  neither at warm unit 4/18. fp32 widening (pgw#667) and the fp8/fp4 storage
+  lanes stay legal, and introspection failures never fail a load.
+
 ## 0.68.0 (2026-07-26) — pgw#681 guard-closure gate + boundary canonicalization; gw#679 per-expert MoE LoRA branch routing
 
 Dynamo's guard set IS the exhaustive dependency list of a compiled graph, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.68.0"
+version = "0.68.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2122,6 +2122,12 @@ class _ClassRecord:
     # wire ref, so a multiply-held ref needs this map to transfer its strong
     # representative when the latest owner leaves.
     held_objects: Dict[str, Any] = dc_field(default_factory=dict)
+    # pgw#678: slot -> the worker-constructed pipeline injected into setup.
+    # ``held_objects``/residency hold the LANE handle (an nn.ModuleDict of the
+    # lane's exclusive modules whenever any component is unshared), which is
+    # not a diffusers pipeline: adapters and the OOM offload rung must act on
+    # THIS map instead.
+    slot_pipelines: Dict[str, Any] = dc_field(default_factory=dict)
     # gw#494: a resolution re-pick moved the specs' bindings away from
     # held_refs; the instance serves the OLD pick and must be vacated.
     stale: bool = False
@@ -2213,6 +2219,12 @@ class _InjectionResult:
 
     kwargs: Dict[str, Any]
     loaded: Dict[str, Tuple[Any, int]]
+    # pgw#678: the worker-constructed PIPELINE per slot, kept apart from
+    # ``loaded`` for the same reason ``compile_objects`` is: a shared-component
+    # lane books an ``nn.ModuleDict`` of the lane's EXCLUSIVE modules as its
+    # residency/movement handle, so ``loaded``/``residency.obj`` is not the
+    # object adapters, offload rungs or the LoRA registry may act on.
+    slot_pipelines: Dict[str, Any] = dc_field(default_factory=dict)
     lane_slots: set = dc_field(default_factory=set)
     shared_keys: List[Any] = dc_field(default_factory=list)
     shared_bytes: int = 0
@@ -2374,6 +2386,12 @@ class Executor:
         # let an older rollback mutate a newer adoption.
         self._compile_cache_adoption_lock = asyncio.Lock()
         self._compile_cache_adoption_active = ""
+        # pgw#678: wire refs whose content-keyed share plan proved impossible
+        # on THIS host — the lane's placement fell to an offload rung, which
+        # the shared-component invariant refuses (hooks on a shared module
+        # poison sibling lanes). Learned once so the retry loads monolithically
+        # instead of re-deriving the same refused plan until retry_exhausted.
+        self._no_share_refs: typing.Set[str] = set()
         # pgw#548: worker-local capacity blocks retain the exact numeric
         # requirement that failed. They are cleared only by a later measured
         # observation after owner/pin release; no timer or prose retry path.
@@ -5803,6 +5821,9 @@ class Executor:
                 obj = inj.loaded.get(slot, (None, 0))[0]
                 if obj is not None or ref not in rec.held_objects:
                     rec.held_objects[ref] = obj
+            # pgw#678: the pipeline identities, kept out of held_objects (which
+            # is the residency/movement handle space).
+            rec.slot_pipelines = dict(inj.slot_pipelines)
             self._install_compile_targets(
                 rec,
                 spec,
@@ -6595,14 +6616,38 @@ class Executor:
             if binding is None:
                 return None
             ref = wire_ref(binding)
+            if ref in self._no_share_refs:
+                # pgw#678: this ref proved un-shareable on this host (its lane
+                # landed offloaded, which the shared-component invariant
+                # refuses). Retrying the same shared plan is a dead end —
+                # load it monolithically instead.
+                continue
+            # pgw#683: identity must carry the EFFECTIVE compute dtype, not the
+            # binding's DECLARED one. Hub bindings declare no dtype, so every
+            # flavor of a ref answered "" and byte-identical non-denoiser
+            # components (a quantizer only rewrites the denoiser, so the VAE and
+            # text encoders of `X` and `X#fp8-w8a8` are the SAME bytes) shared
+            # ONE cache entry across compositions that compute at DIFFERENT
+            # dtypes: a quant-artifact tree computes bf16, a plain fp16-stored
+            # mirror computes fp16. Whichever pick loaded first won, and the
+            # loser aliased a foreign-precision module into its own
+            # composition — a Half nn.Linear meeting a bf16 activation is
+            # `mat1 and mat2 must have the same dtype, but got BFloat16 and
+            # Half`, with no component override anywhere on the wire.
+            from .models.loading import composition_compute_dtype
+
+            effective_dtype = composition_compute_dtype(
+                paths[slot], str(getattr(binding, "dtype", "") or ""))
             digests = self.store.component_digests(ref, local_path=Path(paths[slot]))
             keys[slot] = {
                 comp: residency_mod.LoadedComponentKey.for_component(
                     content_digest=digest, component=comp, binding=binding,
-                    label=f"{ref}/{comp}",
+                    dtype=effective_dtype, label=f"{ref}/{comp}",
                 )
                 for comp, digest in digests.items() if comp
             }
+        if not keys:
+            return None
         counts: Dict[Any, int] = {}
         for slot_keys in keys.values():
             for k in slot_keys.values():
@@ -6822,6 +6867,9 @@ class Executor:
                             strict_vram=bool(spec.resources.strict_vram),
                         )
                     pipe = sl.obj
+                    # pgw#678: record the PIPELINE identity for this slot
+                    # before any lane bookkeeping can shadow it.
+                    result.slot_pipelines[slot] = pipe
                     # pgw#654: generic materialization tuning — per-request
                     # progress bars are worker noise on every diffusers
                     # pipeline; endpoints never write this line.
@@ -6856,10 +6904,18 @@ class Executor:
                     if slot_share and str(placed.get("mode") or "") not in (
                         "", "off", "vae_only", "cpu",
                     ):
+                        # pgw#678: LEARN it. Re-deriving the same share plan on
+                        # every retry made this a silent dead end
+                        # (retry_exhausted -> worker_function_unavailable, live
+                        # on the sdxl turbo lane). The ref is marked
+                        # un-shareable so the retry composes monolithically,
+                        # where an offload rung is legal.
+                        self._no_share_refs.add(ref)
                         raise RetryableError(
                             f"lane {slot!r} of {spec.name} placed "
                             f"{placed.get('mode')!r}: shared-component lanes "
-                            "require resident placement; retrying")
+                            "require resident placement; retrying without "
+                            "content-keyed sharing for this ref")
                     if spec.compile is not None:
                         # Opt-in acceleration against a pre-built per-SKU artifact:
                         # a TRT engine (#390, refit with this pipeline's weights)
@@ -8269,6 +8325,7 @@ class Executor:
         rec.held_bindings = []
         rec.lane_refs = set()
         rec.held_objects = {}
+        rec.slot_pipelines = {}  # pgw#678: pipelines die with the instance
         # Do not let this teardown frame itself retain a departing pipeline
         # while the cgroup probe decides whether capacity really progressed.
         old_obj = None
@@ -8761,7 +8818,8 @@ class Executor:
                                 continue
                             ref = wire_ref(spec.models[slot])
                             if self._adapters.needs_deactivation(ref):
-                                pipe = self.store.residency.obj(ref)
+                                # pgw#678: the PIPELINE, not the lane handle.
+                                pipe = self._slot_pipeline(spec, slot)
                                 if pipe is not None:
                                     await asyncio.to_thread(
                                         self._adapters.deactivate, ref, pipe, run.request_id
@@ -9050,9 +9108,35 @@ class Executor:
             out[slot] = prepared
         return out
 
+    def _slot_pipeline(self, spec: EndpointSpec, slot: str) -> Any:
+        """The worker-CONSTRUCTED pipeline object for ``slot``, or None.
+
+        pgw#678: this is NOT ``residency.obj(ref)``. A shared-component lane
+        books its EXCLUSIVE module set (an ``nn.ModuleDict``) as the residency
+        entry so LRU demote/promote moves only lane-owned weights — and
+        ``exclusive`` is non-empty exactly when some component does NOT ride
+        the shared cache, which a th#980 ``components.*`` deploy override
+        guarantees (the overridden component's bytes differ from the base's,
+        so it is popped out of the share plan). The registry handle was then
+        handed to ``LoraRegistry.activate`` as if it were the pipeline:
+        ``branch_targets`` finds no denoiser on a ModuleDict, ``_split_adapters``
+        never runs, and the residue meets ``isinstance(pipe,
+        LoraCapablePipeline) is False`` -> "model slot does not support LoRA
+        adapters" for every request (0/6 live on the sdxl turbo picks). The
+        record keeps the pipeline identity separately; residency keeps the
+        movement handle. Both facts are true — they are just not one object.
+        """
+        rec = self._classes.get(spec.instance_key)
+        pipe = (rec.slot_pipelines.get(slot) if rec is not None else None)
+        if pipe is not None:
+            return pipe
+        # Tenant-loaded slots have no worker-constructed pipeline; a
+        # monolithic worker-loaded slot's residency entry IS the pipeline.
+        return self.store.residency.obj(wire_ref(spec.models[slot]))
+
     def _adapter_target(self, spec: EndpointSpec, slot: str) -> Any:
         """The worker-managed pipeline object adapters for ``slot`` apply to."""
-        pipe = self.store.residency.obj(wire_ref(spec.models[slot]))
+        pipe = self._slot_pipeline(spec, slot)
         if pipe is None:
             raise ValidationError(
                 f"model slot {slot!r} has no worker-managed pipeline; "
@@ -9096,7 +9180,10 @@ class Executor:
         transitions: List[Tuple[str, str, str, float]] = []
         for slot in spec.models:
             ref = wire_ref(spec.models[slot])
-            obj = self.store.residency.obj(ref)
+            # pgw#678: a shared-component lane's residency entry is an
+            # nn.ModuleDict, which carries none of the offload methods below —
+            # the OOM rung would silently skip every lane slot.
+            obj = self._slot_pipeline(spec, slot)
             if obj is None:
                 continue
             if diffusers_component_type and isinstance(obj, diffusers_component_type):

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -952,6 +952,134 @@ def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
     return ""
 
 
+class MixedComputeDtypeError(RuntimeError):
+    """A composed pipeline presents more than one COMPUTE dtype to its GEMMs.
+
+    pgw#683's invariant. torch's matmul/conv kernels take no dtype opinion
+    from the module — they raise mid-forward, with a message that names
+    neither the tensor nor the component::
+
+        RuntimeError: mat1 and mat2 must have the same dtype, but got
+        BFloat16 and Half      (an nn.Linear WITH bias: addmm)
+        RuntimeError: Input type (c10::BFloat16) and bias type (c10::Half)
+        should be the same     (a conv)
+
+    Live, that message arrived at ``self_mint_compile phase=warmup_forward``
+    warm unit 4/18 on an L4 and cost `generate` on a prod release, with
+    nothing in it to attribute the fault to a component, a ref or a load path.
+    This error is raised at LOAD instead, naming the component, the parameter
+    path and both dtypes.
+    """
+
+
+#: Dtypes a GEMM can actually compute in. Storage-only dtypes (fp8/fp4/int)
+#: are excluded on purpose: the w8a8/svdq/nvfp4 lanes and diffusers' layerwise
+#: casting hold weights at those precisions BY DESIGN and upcast per forward.
+_COMPUTE_DTYPE_NAMES = ("float16", "bfloat16", "float32", "float64")
+#: The pair that cannot interoperate and never legitimately coexists in one
+#: composition. fp32 is the DECLARED widening axis (pgw#667) and is reported
+#: but never fatal — widening is a precision decision, not a dtype collision.
+_INCOMPATIBLE_COMPUTE = ("float16", "bfloat16")
+
+
+def _gemm_param_dtypes(module: Any) -> Dict[str, str]:
+    """``{parameter path: dtype name}`` for every GEMM input under ``module``
+    — Linear/conv weights and biases, the tensors torch actually refuses to
+    mix. Norms/embeddings are excluded: they carry their own (legitimately
+    wider) precision and never meet a weight in one kernel."""
+    import torch.nn as nn
+
+    gemm_types = (
+        nn.Linear, nn.Conv1d, nn.Conv2d, nn.Conv3d,
+        nn.ConvTranspose1d, nn.ConvTranspose2d, nn.ConvTranspose3d,
+    )
+    out: Dict[str, str] = {}
+    for name, leaf in module.named_modules():
+        if not isinstance(leaf, gemm_types):
+            continue
+        for attr in ("weight", "bias"):
+            t = getattr(leaf, attr, None)
+            dt = getattr(t, "dtype", None)
+            if dt is None:
+                continue
+            dt_name = str(dt).rsplit(".", 1)[-1]
+            if dt_name in _COMPUTE_DTYPE_NAMES:
+                out[f"{name}.{attr}" if name else attr] = dt_name
+    return out
+
+
+def assert_uniform_compute_dtype(
+    obj: Any, expected: str = "", *, label: str = "",
+) -> None:
+    """Refuse a MIXED-precision composition at LOAD (pgw#683).
+
+    Checks every GEMM input of every component: an fp16 weight and a bf16
+    weight in one composition means some forward will die on a dtype the
+    kernel cannot reconcile, and torch's message names nothing. Two verdicts
+    are fatal:
+
+    1. a single component that is internally fp16 AND bf16;
+    2. any component whose compute dtype is fp16/bf16 but is not ``expected``
+       (the composition's own compute dtype) — the cross-composition aliasing
+       shape: a content-keyed shared component loaded by another pick's record
+       at ITS dtype and injected here unconverted.
+
+    fp32 parts are legal (pgw#667 declares wider components deliberately) and
+    storage dtypes are legal (fp8/fp4 lanes upcast per forward), so neither
+    is counted. Introspection failures never fail a load — only a proven
+    collision does.
+    """
+    try:
+        comps = getattr(obj, "components", None)
+        if isinstance(comps, dict) and comps:
+            parts = [(str(n), m) for n, m in comps.items()
+                     if hasattr(m, "named_modules")]
+        elif hasattr(obj, "named_modules"):
+            parts = [(type(obj).__name__, obj)]
+        else:
+            return
+        seen: Dict[str, Dict[str, str]] = {}
+        for name, module in parts:
+            dtypes = _gemm_param_dtypes(module)
+            if dtypes:
+                seen[name] = dtypes
+    except Exception:  # introspection is best-effort; never fail a load on it
+        logger.debug("compute-dtype invariant could not inspect %r", label,
+                     exc_info=True)
+        return
+
+    what = label or type(obj).__name__
+    for name, dtypes in seen.items():
+        present = {d for d in dtypes.values() if d in _INCOMPATIBLE_COMPUTE}
+        if len(present) > 1:
+            offenders = sorted(
+                f"{p}={d}" for p, d in dtypes.items()
+                if d in _INCOMPATIBLE_COMPUTE
+            )
+            raise MixedComputeDtypeError(
+                f"{what}: component {name!r} is internally mixed-precision "
+                f"({'/'.join(sorted(present))}) — some forward will die on "
+                f"`mat1 and mat2 must have the same dtype`. Offending GEMM "
+                f"inputs: {offenders[:6]}"
+            )
+    if expected not in ("fp16", "bf16", "float16", "bfloat16"):
+        return
+    want = "float16" if expected in ("fp16", "float16") else "bfloat16"
+    for name, dtypes in seen.items():
+        wrong = sorted(
+            f"{p}={d}" for p, d in dtypes.items()
+            if d in _INCOMPATIBLE_COMPUTE and d != want
+        )
+        if wrong:
+            raise MixedComputeDtypeError(
+                f"{what}: component {name!r} loaded at "
+                f"{wrong[0].rsplit('=', 1)[-1]} inside a {want} composition — "
+                f"a foreign-precision component in a composed pipeline is the "
+                f"pgw#683 warmup/serve fatal. Offending GEMM inputs: "
+                f"{wrong[:6]}"
+            )
+
+
 def _component_dtype_map(
     cls: Any, path: str | Path, scalar_dtype: Any,
 ) -> Optional[Dict[str, Any]]:
@@ -1473,6 +1601,9 @@ def load_from_pretrained(
                 adaptive_rung = "nf4"
         if qc is not None:
             kwargs["quantization_config"] = qc
+    # The composition's ONE compute dtype, captured before pgw#667's
+    # per-component map can replace the kwarg with a dict (pgw#683).
+    scalar_dtype = kwargs.get("torch_dtype")
     single = _single_file_checkpoint(Path(path))
     if single is not None and callable(getattr(cls, "from_single_file", None)):
         kwargs.pop("variant", None)
@@ -1484,7 +1615,6 @@ def load_from_pretrained(
         # truncation. diffusers takes a per-component dtype MAP (a "default"
         # key plus per-part overrides), so the widening happens inside the one
         # from_pretrained instead of a hand-assembled sibling load.
-        scalar_dtype = kwargs.get("torch_dtype")
         per_component = _component_dtype_map(cls, path, scalar_dtype)
         if per_component:
             kwargs["torch_dtype"] = per_component
@@ -1518,7 +1648,13 @@ def load_from_pretrained(
             f"unmaterialized meta tensors (e.g. {unmaterialized[:3]})"
         )
     if fp8_storage and "quantization_config" not in kwargs:
-        applied = apply_fp8_storage(pipe, compute_dtype=kwargs.get("torch_dtype"),
+        # pgw#683: the SCALAR compute dtype — `kwargs["torch_dtype"]` may be
+        # pgw#667's per-component MAP by now, and a dict reaching
+        # `enable_layerwise_casting(compute_dtype=...)` either explodes into
+        # "serving at full precision" or arms windows that upcast to a
+        # non-dtype. The cast window's compute dtype is a composition-level
+        # fact, so it is the composition default that belongs here.
+        applied = apply_fp8_storage(pipe, compute_dtype=scalar_dtype,
                                     text_encoders=fp8_text_encoders)
         # th#737: make the outcome observable — a cast that silently no-ops
         # (denoiser-less pipeline) must surface as a structural degradation
@@ -1567,6 +1703,10 @@ __all__ = [
     "read_on_disk_quant_config",
     "synthesize_quantization_config",
     "apply_fp8_storage",
+    "assert_uniform_compute_dtype",
+    "MixedComputeDtypeError",
+    "composition_compute_dtype",
+    "QUANT_LANE_COMPUTE_DEFAULT",
     "apply_block_window_offload",
     "bf16_resident_fits",
     "block_offload_active",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -31,7 +31,12 @@ from ..config import get_settings
 from .cache_paths import tensorhub_cas_dir
 from .errors import UrlExpiredError
 from .ladder import maybe_rebind_family_fp8
-from .loading import load_from_pretrained, model_index_components
+from .loading import (
+    assert_uniform_compute_dtype,
+    composition_compute_dtype,
+    load_from_pretrained,
+    model_index_components,
+)
 from .memory import place_pipeline
 from .refs import parse_model_ref
 
@@ -146,6 +151,13 @@ def load_slot(
         allow_bf16_resident_upgrade=not force_storage_dtype,
     )
     out.obj = pipe
+
+    # pgw#683: the composition must present ONE compute dtype to its GEMMs.
+    # Fail HERE, naming the component and the tensor, instead of at warm unit
+    # 4/18 with torch's `mat1 and mat2 must have the same dtype` — which names
+    # neither, and which cost `generate` on a live prod release.
+    assert_uniform_compute_dtype(
+        pipe, composition_compute_dtype(path, dtype), label=f"slot {slot!r} ({ref})")
 
     rung = str(getattr(pipe, "_cozy_adaptive_rung", "") or "")
     cast_failed = getattr(

--- a/tests/test_compute_dtype_uniformity_pgw683.py
+++ b/tests/test_compute_dtype_uniformity_pgw683.py
@@ -1,0 +1,348 @@
+"""pgw#683: pgw#675's lane-aware default is necessary but NOT sufficient — a
+composition can still be handed a foreign-precision component with NO
+component override anywhere on the wire.
+
+Live, on the release that is currently `prod` (`b266454e92a9000c4c0c13f4`,
+sdxl 0.2.7, gen-worker 0.67.1, NVIDIA L4)::
+
+    activity failed kind=self_mint_compile phase=warmup_forward
+      error=RuntimeError: mat1 and mat2 must have the same dtype,
+                          but got BFloat16 and Half
+    worker_function_unavailable function=generate reason=setup_failed
+
+`comps=None` on both functions, so pgw#675's story ("a component OVERRIDE
+loaded Half into a bf16 composition") cannot apply. Two facts close the gap.
+
+**1. The signature names the operator.** MEASURED on torch 2.13.0 (the fleet's
+version) — the three dtype-mismatch messages are distinct, and only one is
+ours::
+
+    nn.Linear WITH bias  (addmm) -> mat1 and mat2 must have the same dtype,
+                                    but got BFloat16 and Half      <-- pgw#683
+    bare matmul / no bias        -> expected m1 and m2 to have the same dtype
+    conv                         -> Input type (c10::BFloat16) and bias type
+                                    (c10::Half) should be the same  <-- pgw#675
+
+So pgw#683 is a `nn.Linear` WITH a bias whose weight is Half inside a bf16
+activation flow — not the LoRA side-branch (a bare matmul), not the VAE decode
+conv that pgw#675 was.
+
+**2. Identity, not dtype decision, is what let a Half module in.** The
+content-keyed shared-component cache (gw#479) keys on
+`LoadedComponentKey`, whose `dtype` field is the binding's DECLARED dtype.
+Hub bindings declare none, and prod's binding is flavor-unpinned
+(`ref=tensorhub/wai-illustrious`, `tag=prod`), so the flavor is resolved per
+pod/per pick. A quantizer only rewrites the DENOISER, so the VAE and text
+encoders of `X` and `X#fp8-w8a8` are byte-identical — same content digest,
+same empty declared dtype, therefore ONE cache entry — while the two
+compositions compute at DIFFERENT dtypes (`#fp8-w8a8` -> bf16 by pgw#675's own
+lane rule; a plain fp16-stored mirror -> fp16). Whichever pick loaded first
+won the entry; the other aliased a foreign-precision module into its
+composition. That is per-pod non-deterministic by ARRIVAL ORDER, needs no
+override, and — because injection only happens once an entry already EXISTS —
+lands in a LATER window, which is exactly what the live pod showed: `generate`
+served 3/3 at 11.1s and reached `compiled` BEFORE the mint that died.
+
+The fix is in two parts, both taped here: identity carries the EFFECTIVE
+compute dtype, and a hard post-load invariant refuses a mixed composition at
+LOAD, naming the component and the tensor — instead of torch naming neither at
+warm unit 4/18.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from safetensors.torch import save_file  # noqa: E402
+
+from gen_worker.convert.writer import streaming_w8a8_cast  # noqa: E402
+from gen_worker.models.loading import (  # noqa: E402
+    MixedComputeDtypeError,
+    assert_uniform_compute_dtype,
+    composition_compute_dtype,
+    detect_on_disk_dtype,
+)
+from gen_worker.models.residency import LoadedComponentKey  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: the two real trees that share byte-identical components.
+# ---------------------------------------------------------------------------
+
+
+def _quantizable(dtype: Any) -> dict:
+    tensors = {
+        # Eligible for the producer: 2-D .weight, 16-aligned, inside a `.N.`
+        # block container.
+        "down_blocks.0.attentions.0.transformer_blocks.0.attn1.to_q.weight":
+            torch.randn(16, 16, dtype=dtype),
+    }
+    for i in range(6):
+        tensors[f"passthrough.norm_{i}.weight"] = torch.randn(8, dtype=dtype)
+    return tensors
+
+
+def _plain_fp16_tree(tmp_path: Path) -> Path:
+    """A plain fp16-stored mirror — what an unquantized SDXL fine-tune is."""
+    root = tmp_path / "plain-fp16"
+    (root / "unet").mkdir(parents=True)
+    save_file(_quantizable(torch.float16), str(root / "unet" / "model.safetensors"))
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "StableDiffusionXLPipeline",
+        "unet": ["diffusers", "UNet2DConditionModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+    }))
+    return root
+
+
+def _w8a8_tree(tmp_path: Path) -> Path:
+    """The `#fp8-w8a8` flavor of the SAME model, built by the REAL producer."""
+    src = tmp_path / "src-unet"
+    src.mkdir()
+    save_file(_quantizable(torch.float16), str(src / "model.safetensors"))
+    root = tmp_path / "flavor-w8a8"
+    out = streaming_w8a8_cast(src / "model.safetensors", root / "unet")
+    assert int(out["converted_count"]) == 1
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "StableDiffusionXLPipeline",
+        "unet": ["diffusers", "UNet2DConditionModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+    }))
+    return root
+
+
+#: A hub-resolved binding: NO declared dtype (the production shape), and
+#: flavor-unpinned or flavor-pinned depending on how the pick resolved.
+def _binding(path: str, flavor: str = "") -> Any:
+    from gen_worker.api.binding import ModelRef
+
+    return ModelRef(source="tensorhub", path=path, tag="prod", flavor=flavor)
+
+
+# ---------------------------------------------------------------------------
+# 1. The identity hole: two lanes, one shared entry.
+# ---------------------------------------------------------------------------
+
+
+def test_the_two_flavors_really_do_compute_at_different_dtypes(
+    tmp_path: Path,
+) -> None:
+    """Pin the premise: the same upstream bytes, mirrored two ways, answer two
+    DIFFERENT compute dtypes — and neither binding declares one."""
+    plain, w8a8 = _plain_fp16_tree(tmp_path), _w8a8_tree(tmp_path)
+    assert detect_on_disk_dtype(plain) == "fp16"
+    assert composition_compute_dtype(plain, "") == "fp16"
+    # pgw#675's lane rule: a quantized-artifact tree computes bf16 whatever its
+    # majority on-disk dtype says.
+    assert detect_on_disk_dtype(w8a8) == "fp16"
+    assert composition_compute_dtype(w8a8, "") == "bf16"
+
+
+def test_declared_dtype_identity_collides_across_lanes(tmp_path: Path) -> None:
+    """RED, at the identity layer: keyed on the BINDING's declared dtype — the
+    pre-fix call — the two lanes' byte-identical `text_encoder` maps to ONE
+    cache entry. That single entry is how a Half module reaches a bf16
+    composition with no override on the wire."""
+    shared_digest = "same-text-encoder-bytes"
+    pre_fix = [
+        LoadedComponentKey.for_component(
+            content_digest=shared_digest, component="text_encoder",
+            binding=_binding("tensorhub/wai-illustrious"),
+        )
+        for _ in range(2)
+    ]
+    assert pre_fix[0].cache_id() == pre_fix[1].cache_id()
+    assert pre_fix[0].dtype == "", "hub bindings declare no dtype"
+
+
+def test_effective_dtype_identity_separates_the_lanes(tmp_path: Path) -> None:
+    """GREEN: keyed on the EFFECTIVE compute dtype — what the executor passes
+    now — the same bytes under two lanes are two entries, so a bf16
+    composition can never be handed the fp16 lane's module."""
+    plain, w8a8 = _plain_fp16_tree(tmp_path), _w8a8_tree(tmp_path)
+    shared_digest = "same-text-encoder-bytes"
+    keys = [
+        LoadedComponentKey.for_component(
+            content_digest=shared_digest, component="text_encoder",
+            binding=_binding("tensorhub/wai-illustrious"),
+            dtype=composition_compute_dtype(tree, ""),
+        )
+        for tree in (plain, w8a8)
+    ]
+    assert keys[0].dtype == "fp16" and keys[1].dtype == "bf16"
+    assert keys[0].cache_id() != keys[1].cache_id()
+    # Same lane, same bytes still aliases — sharing is not disabled, only made
+    # precision-honest.
+    again = LoadedComponentKey.for_component(
+        content_digest=shared_digest, component="text_encoder",
+        binding=_binding("tensorhub/wai-illustrious"), dtype=composition_compute_dtype(w8a8, ""),
+    )
+    assert again.cache_id() == keys[1].cache_id()
+
+
+def test_the_share_plan_itself_keys_on_the_effective_dtype(
+    tmp_path: Path,
+) -> None:
+    """The FIX SITE, through the real `Executor._component_share_plan`: two
+    pipeline slots on the two flavors, byte-identical `text_encoder`, and the
+    plan must mint two different cache ids. RED pre-fix — one id, and the
+    second lane injects the first lane's foreign-precision module."""
+    from gen_worker.executor import Executor
+    from gen_worker.models import residency as residency_mod
+
+    plain, w8a8 = _plain_fp16_tree(tmp_path), _w8a8_tree(tmp_path)
+
+    class _Pipeline:
+        @classmethod
+        def from_pretrained(cls, path: str) -> "_Pipeline":  # pragma: no cover
+            return cls()
+
+    class _Store:
+        def __init__(self) -> None:
+            self.residency = residency_mod.Residency()
+
+        def component_digests(self, ref: str, local_path: Path) -> dict:
+            # Byte-identical non-denoiser components across flavors; the
+            # denoiser's bytes differ (the quantizer rewrote it).
+            return {"text_encoder": "same-te-bytes",
+                    "unet": f"unet-{Path(local_path).name}"}
+
+    class _Exec:
+        _component_share_plan = Executor._component_share_plan
+
+        def __init__(self) -> None:
+            self.store = _Store()
+            self._no_share_refs: set = set()
+
+    class _Spec:
+        name = "sdxl"
+        slots = {"plain": object(), "quant": object()}
+        models = {"plain": _binding("tensorhub/cyberrealistic-xl"),
+                  "quant": _binding("tensorhub/wai-illustrious", "fp8-w8a8")}
+
+    ex = _Exec()
+    paths = {"plain": str(plain), "quant": str(w8a8)}
+    hints = {"plain": _Pipeline, "quant": _Pipeline}
+    plan = ex._component_share_plan(_Spec(), paths, hints)  # type: ignore[arg-type]
+    assert plan is not None
+    te_ids = {
+        slot: plan[slot]["text_encoder"].cache_id()
+        for slot in ("plain", "quant") if "text_encoder" in plan[slot]
+    }
+    assert set(te_ids) == {"plain", "quant"}
+    assert te_ids["plain"] != te_ids["quant"], (
+        "byte-identical components of an fp16 tree and a bf16 quant lane must "
+        "NOT share one entry — that alias is the pgw#683 fatal"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The invariant: refuse at LOAD, naming the tensor.
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    """A composition in the diffusers shape (`.components` -> modules)."""
+
+    def __init__(self, **parts: Any) -> None:
+        self._parts = parts
+
+    @property
+    def components(self) -> dict:
+        return dict(self._parts)
+
+
+def _linear_stack(dtype: Any, *, bias: bool = True) -> Any:
+    torch.manual_seed(0)
+    return torch.nn.Sequential(
+        torch.nn.Linear(16, 16, bias=bias),
+        torch.nn.LayerNorm(16),
+        torch.nn.Linear(16, 16, bias=bias),
+    ).to(dtype)
+
+
+def test_the_live_torch_signature_is_an_nn_linear_with_bias() -> None:
+    """The measurement this issue turns on: a bf16 activation meeting a Half
+    `nn.Linear` WITH bias raises the pgw#683 message VERBATIM, and the
+    bias-less/bare-matmul form raises a DIFFERENT one. This is what excludes
+    the LoRA side-branch (`(x @ a.t()) @ b.t()`) as the site."""
+    x = torch.randn(2, 16, dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError) as with_bias:
+        _linear_stack(torch.float16)(x)
+    assert "mat1 and mat2 must have the same dtype" in str(with_bias.value)
+    assert "BFloat16 and Half" in str(with_bias.value)
+
+    with pytest.raises(RuntimeError) as no_bias:
+        _linear_stack(torch.float16, bias=False)(x)
+    assert "mat1 and mat2 must have the same dtype" not in str(no_bias.value)
+
+
+def test_invariant_refuses_a_foreign_precision_component() -> None:
+    """The aliasing shape: a Half `text_encoder` inside a bf16 composition is
+    refused AT LOAD, naming the component and the offending GEMM input —
+    instead of torch's message, which names neither, arriving at warm unit
+    4/18 and costing the function."""
+    pipe = _Pipe(
+        unet=_linear_stack(torch.bfloat16),
+        text_encoder=_linear_stack(torch.float16),
+    )
+    with pytest.raises(MixedComputeDtypeError) as excinfo:
+        assert_uniform_compute_dtype(pipe, "bf16", label="slot 'pipeline'")
+    msg = str(excinfo.value)
+    assert "text_encoder" in msg
+    assert "float16" in msg and "bfloat16" in msg
+    assert "0.weight=float16" in msg, f"the tensor must be named: {msg}"
+    assert "slot 'pipeline'" in msg
+
+
+def test_invariant_refuses_an_internally_mixed_component() -> None:
+    """The other fatal verdict, and it needs no `expected`: one component
+    carrying both fp16 and bf16 GEMM inputs cannot survive its own forward."""
+    mixed = torch.nn.Sequential(
+        torch.nn.Linear(16, 16).to(torch.bfloat16),
+        torch.nn.Linear(16, 16).to(torch.float16),
+    )
+    with pytest.raises(MixedComputeDtypeError, match="internally mixed"):
+        assert_uniform_compute_dtype(_Pipe(unet=mixed), "")
+
+
+def test_invariant_admits_every_legal_composition() -> None:
+    """It must not refuse what the platform does on purpose. A uniform
+    composition, a pgw#667 fp32-WIDENED component, an fp8-storage lane (weights
+    at rest in fp8, upcast per forward), and a bare module all pass."""
+    assert_uniform_compute_dtype(
+        _Pipe(unet=_linear_stack(torch.bfloat16),
+              text_encoder=_linear_stack(torch.bfloat16)), "bf16")
+    # pgw#667: the wider part is a DECLARED decision, never a collision.
+    assert_uniform_compute_dtype(
+        _Pipe(unet=_linear_stack(torch.bfloat16),
+              vae=_linear_stack(torch.float32)), "bf16")
+    fp8_lane = _linear_stack(torch.bfloat16)
+    for leaf in fp8_lane:
+        if isinstance(leaf, torch.nn.Linear):
+            leaf.weight.data = leaf.weight.data.to(torch.float8_e4m3fn)
+    assert_uniform_compute_dtype(_Pipe(unet=fp8_lane), "bf16")
+    assert_uniform_compute_dtype(_linear_stack(torch.bfloat16), "bf16")
+    # No compute-dtype opinion (an fp32-defaulting composition) never refuses
+    # on the second verdict.
+    assert_uniform_compute_dtype(
+        _Pipe(unet=_linear_stack(torch.float16)), "")
+
+
+def test_invariant_never_fails_a_load_on_introspection() -> None:
+    """Fail-loud on a proven collision, never on a shape it cannot read."""
+
+    class _Hostile:
+        @property
+        def components(self) -> dict:
+            raise RuntimeError("no")
+
+    assert_uniform_compute_dtype(_Hostile(), "bf16")
+    assert_uniform_compute_dtype(object(), "bf16")

--- a/tests/test_lane_pipeline_identity_pgw678.py
+++ b/tests/test_lane_pipeline_identity_pgw678.py
@@ -1,0 +1,262 @@
+"""pgw#678: a `components.*` deploy override must not make the deploy-bound
+LoRA unattachable — the lane's RESIDENCY handle is not the PIPELINE.
+
+The live A/B was exact: same release `b266454e92a9000c4c0c13f4`, same
+gen-worker 0.67.1 image, same `wai-illustrious#fp8-w8a8` base, same
+`sdxl-lightning-4step-lora` deploy adapter, same L4 —
+
+  | deploy binding                          | generate-turbo picks |
+  |-----------------------------------------|----------------------|
+  | `pipeline.components.vae = fp16-fix vae` | **0/6**, `compute_ms=7`, "model slot does not support LoRA adapters" |
+  | no components at all                     | 4/4, 1.9 s |
+
+`utils/lora.py` is byte-identical across 0.66.0 and 0.67.1, so the defect was
+never in the adapter code. It is an OBJECT IDENTITY defect in the executor:
+
+  * sharing is automatic by content address (pgw#647), so every component of a
+    Slot-declared pipeline slot enters the share plan;
+  * an OVERRIDDEN component is popped OUT of that plan (its bytes differ from
+    the base's), so the lane acquires a non-empty EXCLUSIVE module set;
+  * `_register_lane` books `nn.ModuleDict(exclusive)` as the residency entry —
+    correct, and deliberate: LRU demote/promote must move only lane-owned
+    weights, never the shared encoder;
+  * but `_adapter_target` read `residency.obj(ref)` as if it were the
+    pipeline. `branch_targets` finds no denoiser on a ModuleDict, so
+    `_split_adapters` never runs, the whole adapter stays on the peft side,
+    and `isinstance(pipe, LoraCapablePipeline)` is False -> the refusal above,
+    on EVERY request, on the eager lane AND after `compiled_armed=true`.
+
+With no override, `exclusive` is empty and `_register_lane` returns the pipe
+itself — which is exactly why the same release was 4/4 without the override
+and 0/6 with it. The fix keeps BOTH facts and stops conflating them: the
+record owns the pipeline identity (`slot_pipelines`), residency owns the
+movement handle.
+
+Real path throughout: a real diffusers pipeline carrying a real (tiny)
+transformer, the real `Residency`, the real `_register_lane` /
+`_slot_pipeline` executor functions, and the real `AdapterResidency.activate`
+with a real denoiser-key adapter grammar.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+
+from gen_worker import compile_cache  # noqa: E402
+from gen_worker.api.binding import ModelRef, wire_ref  # noqa: E402
+from gen_worker.api.errors import ValidationError  # noqa: E402
+from gen_worker.executor import Executor, _ClassRecord, _InjectionResult  # noqa: E402
+from gen_worker.models import residency as residency_mod  # noqa: E402
+from gen_worker.utils.lora import AdapterResidency, PreparedAdapter  # noqa: E402
+
+#: A real RANK_BUCKETS value — the branch lane refuses anything else, and the
+#: curated distillation adapters are rank 64 (sdxl declares lora_bucket=64).
+_RANK = 16
+_SLOT = "pipeline"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a real pipeline whose vae is the OVERRIDDEN (exclusive) component.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_pipe() -> Any:
+    """A real diffusers pipeline: branch-capable denoiser + a real VAE (the
+    component a th#980 `components.vae` override substitutes)."""
+    from diffusers import (
+        AutoencoderKLWan,
+        UniPCMultistepScheduler,
+        WanPipeline,
+        WanTransformer3DModel,
+    )
+
+    torch.manual_seed(0)
+    transformer = WanTransformer3DModel(
+        patch_size=(1, 2, 2), num_attention_heads=2, attention_head_dim=8,
+        in_channels=4, out_channels=4, text_dim=16, freq_dim=16, ffn_dim=32,
+        num_layers=1, cross_attn_norm=True,
+        qk_norm="rms_norm_across_heads", rope_max_seq_len=32,
+    )
+    vae = AutoencoderKLWan(
+        base_dim=4, z_dim=4, dim_mult=[1], num_res_blocks=1,
+        temperal_downsample=[False],
+    )
+    scheduler = UniPCMultistepScheduler(
+        prediction_type="flow_prediction", use_flow_sigmas=True, flow_shift=3.0)
+    return WanPipeline(
+        tokenizer=None, text_encoder=None, vae=vae, scheduler=scheduler,
+        transformer=transformer,
+    )
+
+
+def _denoiser_adapter() -> PreparedAdapter:
+    """A UNet/transformer-only distillation overlay in diffusers key grammar —
+    the shape of `sdxl-lightning-4step-lora`: no text-encoder half at all."""
+    sd: Dict[str, Any] = {}
+    for kind, shape in (("lora_A", (_RANK, 16)), ("lora_B", (16, _RANK))):
+        sd[f"transformer.blocks.0.attn1.to_q.{kind}.weight"] = (
+            torch.randn(*shape) * 0.02)
+    return PreparedAdapter(
+        slot=_SLOT, ref="tensorhub/sdxl-lightning-4step-lora:prod",
+        cache_key="lightning@deadbeef", name="lightning",
+        weight=1.0, state_dict=sd,
+    )
+
+
+class _StoreStub:
+    """Only what `_register_lane` touches on the store: the REAL residency
+    registry plus the load-identity sink."""
+
+    def __init__(self) -> None:
+        self.residency = residency_mod.Residency()
+        self.identities: List[Any] = []
+
+    def activate_load_identity(self, ref: str, identity: Any) -> None:
+        self.identities.append((ref, identity))
+
+
+class _ExecStub:
+    """A minimal `self` carrying the REAL executor functions under test — the
+    surrounding store is stubbed, the logic never is."""
+
+    _slot_pipeline = Executor._slot_pipeline
+    _adapter_target = Executor._adapter_target
+    _register_lane = Executor._register_lane
+
+    def __init__(self) -> None:
+        self.store = _StoreStub()
+        self._classes: Dict[Any, _ClassRecord] = {}
+
+    def _arm_lane_gate(self, pipe: Any, ref: str, spec: Any = None) -> bool:
+        return False
+
+
+_BINDING = ModelRef(
+    source="tensorhub", path="tensorhub/wai-illustrious",
+    tag="prod", flavor="fp8-w8a8")
+#: The one ref spelling the executor books under — derived, never hand-typed.
+_REF = wire_ref(_BINDING)
+
+
+class _SpecStub:
+    def __init__(self) -> None:
+        self.instance_key = "sdxl:SDXLFamily"
+        self.models = {_SLOT: _BINDING}
+
+
+def _key(component: str, digest: str) -> Any:
+    return residency_mod.LoadedComponentKey.for_component(
+        content_digest=digest, component=component, dtype="bf16",
+        label=f"{_REF}/{component}")
+
+
+def _register(pipe: Any, *, override: bool) -> _ExecStub:
+    """Book the lane exactly as setup injection does. `override=True` is the
+    th#980 shape: the overridden component is popped out of the share plan, so
+    it becomes the lane's EXCLUSIVE module."""
+    ex = _ExecStub()
+    shared = {"transformer": _key("transformer", "d-transformer")}
+    if not override:
+        shared["vae"] = _key("vae", "d-vae")
+    injected: Dict[str, Any] = {"vae": pipe.vae} if override else {}
+    result = _InjectionResult(kwargs={}, loaded={})
+    result.slot_pipelines[_SLOT] = pipe          # the pgw#678 fix
+    lane_obj, _bytes = ex._register_lane(
+        _SLOT, _REF, pipe, shared, injected, 0, result, ("", 0))
+    ex.store.residency.track_ram(_REF, lane_obj)
+    rec = _ClassRecord(cls=type(pipe), specs=[])  # type: ignore[call-arg]
+    rec.slot_pipelines = dict(result.slot_pipelines)
+    ex._classes["sdxl:SDXLFamily"] = rec
+    return ex
+
+
+# ---------------------------------------------------------------------------
+# 1. The defect, reproduced through the real objects.
+# ---------------------------------------------------------------------------
+
+
+def test_component_override_makes_the_residency_handle_a_moduledict() -> None:
+    """The mechanism, pinned: WITH an override the lane's residency entry is an
+    `nn.ModuleDict` of exclusive modules; WITHOUT one it is the pipeline. Both
+    are correct as MOVEMENT handles — only reading one as the pipeline is not."""
+    pipe = _tiny_pipe()
+    with_override = _register(pipe, override=True)
+    assert isinstance(
+        with_override.store.residency.obj(_REF), torch.nn.ModuleDict)
+
+    no_override = _register(_tiny_pipe(), override=False)
+    assert no_override.store.residency.obj(_REF) is not None
+    assert not isinstance(
+        no_override.store.residency.obj(_REF), torch.nn.ModuleDict)
+
+
+def test_the_lane_handle_reproduces_the_live_refusal_verbatim() -> None:
+    """RED, byte-for-byte: handing the residency handle to the real
+    `AdapterResidency.activate` — which is what `_adapter_target` did — raises
+    the exact live message, for a UNet-only adapter on a branch-capable
+    pipeline that supports LoRA perfectly well."""
+    pipe = _tiny_pipe()
+    ex = _register(pipe, override=True)
+    handle = ex.store.residency.obj(_REF)
+    adapters = AdapterResidency()
+    with pytest.raises(ValidationError) as excinfo:
+        adapters.activate(_REF, handle, [_denoiser_adapter()], "r-red")
+    assert "model slot does not support LoRA adapters" in str(excinfo.value)
+    assert "load_lora_weights/set_adapters/unload_lora_weights" in str(
+        excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. The fix: the record owns the pipeline identity.
+# ---------------------------------------------------------------------------
+
+
+def test_slot_pipeline_returns_the_pipeline_not_the_lane_handle() -> None:
+    """`_slot_pipeline` (what `_adapter_target`, the explicit-deactivation
+    sweep and the OOM offload rung all read now) returns the pipeline even
+    when residency books a ModuleDict."""
+    pipe = _tiny_pipe()
+    ex = _register(pipe, override=True)
+    spec = _SpecStub()
+    assert ex._slot_pipeline(spec, _SLOT) is pipe
+    assert ex._adapter_target(spec, _SLOT) is pipe
+
+
+def test_override_and_deploy_bound_lora_compose() -> None:
+    """The contradiction the issue names is gone: the th#1174 vae binding and
+    the th#1135 deploy adapter coexist. The adapter lands on the BRANCH (the
+    denoiser half never touches peft) and the override survives it."""
+    pipe = _tiny_pipe()
+    ex = _register(pipe, override=True)
+    spec = _SpecStub()
+    compile_cache.apply_lora_lane(pipe, _RANK)
+    overridden_vae = pipe.vae
+
+    target = ex._adapter_target(spec, _SLOT)
+    adapters = AdapterResidency()
+    adapters.activate(_REF, target, [_denoiser_adapter()], "r-green")
+
+    probe = pipe.transformer.get_submodule("blocks.0.attn1.to_q")
+    lora_a = getattr(probe, "lora_a", None)
+    assert lora_a is not None, "the denoiser half did not reach the branch"
+    assert float(lora_a.abs().sum()) > 0.0, "branch buffers still zeroed"
+    # The overridden component is untouched by the attach.
+    assert pipe.vae is overridden_vae
+
+    adapters.deactivate(_REF, target, "r-green")
+
+
+def test_tenant_loaded_slot_still_refuses_typed() -> None:
+    """A slot with no worker-constructed pipeline keeps the honest refusal —
+    the fix widens object identity, not the contract."""
+    ex = _ExecStub()
+    ex._classes["sdxl:SDXLFamily"] = _ClassRecord(
+        cls=object, specs=[])  # type: ignore[call-arg]
+    spec = _SpecStub()
+    with pytest.raises(ValidationError, match="no worker-managed pipeline"):
+        ex._adapter_target(spec, _SLOT)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.68.0"
+version = "0.68.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Two P0s from the ie#546 sdxl retag cycle, both on the composition/residency path, both the same mistake in different clothes: **one object asked to be two things.** Solo P0 promotion (policy allows it for urgent P0s) — pgw#685 and pgw#686 are on chaos unpromoted but their lanes are still live, so they ride the next train.

## pgw#678 — a `components.*` override made the deploy-bound LoRA unattachable

The live A/B was exact, one variable: same release `b266454e92a9000c4c0c13f4`, same 0.67.1 wheel, same `wai-illustrious#fp8-w8a8` base, same `sdxl-lightning-4step-lora`, same L4.

| deploy binding | `generate-turbo` picks |
|---|---|
| `pipeline.components.vae = sdxl-vae-fp16-fix` | **0/6**, `compute_ms=7`, `model slot does not support LoRA adapters` |
| no components at all | **4/4**, 1.9 s |

`utils/lora.py` is byte-identical across 0.66.0 and 0.67.1, so it was never the adapter code. Root cause: sharing is automatic by content address (pgw#647), an OVERRIDDEN component is popped out of the share plan (its bytes differ from the base's), so the lane holds a non-empty EXCLUSIVE set and `_register_lane` books `nn.ModuleDict(exclusive)` as the residency entry. That is **right** as the movement handle — LRU demote/promote must move only lane-owned weights, never the shared encoder — and **fatal** when read as the pipeline, which `_adapter_target` did: `branch_targets` finds no denoiser on a ModuleDict, `_split_adapters` never runs, and the residue meets `isinstance(pipe, LoraCapablePipeline) is False`. With no override `exclusive` is empty and the pipe itself is booked, which is exactly why the same release was 4/4 that way.

Fix: the record owns the pipeline identity (`_ClassRecord.slot_pipelines`), residency keeps the movement handle. `_adapter_target`, the explicit-deactivation sweep and `_quarantine_for_oom` all read the pipeline — that last one had been silently skipping every lane slot, since a ModuleDict carries no `enable_*_offload`. Plus the issue's second live refusal: a lane whose placement falls to offload now **learns** `_no_share_refs` instead of re-deriving the refused plan until `retry_exhausted`.

## pgw#683 — a foreign-precision component with NO override on the wire

`RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Half` killed `self_mint_compile phase=warmup_forward` -> `worker_function_unavailable function=generate reason=setup_failed` on the release now tagged `prod`, with `comps=None` on both functions.

Two facts closed it:

1. **Measured on torch 2.13.0** (taped): that exact string comes from an `nn.Linear` **with bias** (addmm). A bare matmul says `expected m1 and m2 to have the same dtype`; a conv says `Input type ... and bias type ...` (pgw#675's signature). So it is a Half Linear meeting a bf16 activation — not the LoRA side-branch, not the VAE decode conv.
2. **`LoadedComponentKey` keyed on the binding's DECLARED dtype**, and hub bindings declare none. prod's binding is flavor-unpinned, and a quantizer rewrites only the DENOISER — so the VAE/text encoders of `X` and `X#fp8-w8a8` are byte-identical: one cache entry across compositions computing at DIFFERENT dtypes (bf16 on the quant lane by pgw#675's own rule, fp16 for a plain fp16-stored mirror). First loader wins; the other aliases a foreign-precision module. Per-pod non-deterministic by arrival order, and injection only happens once an entry already EXISTS — which is why the live pod served `generate` 3/3 and reached `compiled` **before** the mint that died.

Fix: identity carries the EFFECTIVE compute dtype (`composition_compute_dtype`) — components still alias by content, never across a precision boundary. Two more holes on the same path: `apply_fp8_storage` was handed pgw#667's per-component dtype MAP instead of the scalar compute dtype, and nothing asserted composition uniformity. `assert_uniform_compute_dtype` now runs on every worker-loaded slot in `provision.load_slot` and refuses at LOAD, naming the component and the offending GEMM input, instead of torch naming neither at warm unit 4/18. fp32 widening (pgw#667) and the fp8/fp4 storage lanes stay legal; introspection failure never fails a load.

**Honest scope note:** the identity fix + the invariant close the CLASS. The exact live tensor is not yet pinned to one line — pod-side logs are unreachable on this image (the standing ie#546 gap). The invariant is what will name it on the next occurrence, as a typed `setup_failed`.

## Tapes — real code, both red-verified

- `tests/test_lane_pipeline_identity_pgw678.py` (5) — real diffusers pipeline, real `Residency`, real `_register_lane` / `_slot_pipeline` / `_adapter_target`, real `AdapterResidency.activate`, real `compile_cache.apply_lora_lane`. RED pre-fix with the live message verbatim: `model slot does not support LoRA adapters (pipeline lacks load_lora_weights/set_adapters/unload_lora_weights)`. GREEN: the override and the deploy-bound adapter compose — the denoiser half lands on the branch and the overridden component survives.
- `tests/test_compute_dtype_uniformity_pgw683.py` (9) — the REAL `streaming_w8a8_cast` producer output vs a plain fp16 mirror, through the REAL `_component_share_plan`. RED pre-fix: the two lanes collide on one cache id. Also tapes the torch signature measurement and every legal composition the invariant must NOT refuse.

Local suite: **1086 passed**, 10 skipped, 1 xfailed. mypy + ruff clean on every file touched.

Prod posture for #683 is recorded on the issue: the failure IS probabilistic across pods, but a blanket rollback to `1b05382865d7e536622466bb` would trade a partial `generate` outage for turbo picks broken on ALL pods (that release is pre-th#1199, 0/20). The recorded trigger stands (roll back only if `generate` availability drops below one healthy pod), and `gpu_tier` is now pinned to L4 on the sdxl release, which removes the sm_86 SIGSEGV mode.