### PR TITLE
release: gen-worker 0.70.0 — pgw#677 background-turn gate: tenant work always wins the GPU, the mint yields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.70.0 (2026-07-26) — pgw#677: tenant work always wins the GPU — the background mint yields
+
+th#1187's promise was "serve at eager speed while the compile mint runs in
+background". Measured reality (ie#546 retag cycle): the mint's 18 warm units
+monopolized the per-instance run gate — 0 renders in 19 min on a fresh L4
+release, every concurrent request degraded ~8.6x (completions landing exactly
+as mint units freed the gate), and on sm_86 the ungated warm-thread compile
+racing a tenant LoRA-branch forward SIGSEGV'd the worker process (pgw#676's
+confirmed frame: `w8a8_lora._forward_with_branch` concurrent with
+`hot_swap._run_warm`'s `compile_wrapper`). Two defects in one lock: the run
+gate was too WIDE for latency (a "seed" unit could inline-compile for minutes
+while holding it) and too NARROW for safety (the real compiles ran outside it,
+against live tenant forwards).
+
+- **Background-turn gate (executor)**: mint seed units AND shape-warm/heal
+  compiles now run only inside a granted background TURN — single-flight with
+  each other, holding the GPU permit + the instance's run gate + a new
+  per-instance `turn_mutex`, granted only when the worker is tenant-idle
+  (compile turns additionally wait a short quiescence window). A tenant
+  request can wait at most ONE bounded background unit, ever.
+- **Preemption**: a tenant admission cooperatively cancels the in-flight
+  idle-granted seed forward (the driver re-queues the unit), so the boundary
+  a tenant waits on is the handler's next cancel poll — not the unit.
+- **Seeds never compile inline**: inside the new `hot_swap.mint_seed_window`
+  a novel signature always routes EAGER + background enqueue, even on a
+  degraded router. The VRAM-headroom degrade-to-inline-compile is retired for
+  turn-gated routers (the warm thread ensures headroom inside its exclusive
+  turn); ungated legacy routers keep it.
+- **Race exclusion (the pgw#676 class)**: the shape-warm thread's compile
+  executes the shared modules only while holding the instance `turn_mutex`,
+  which the tenant path holds across adapter mutation + handler — concurrent
+  branch-forward/compile execution is structurally impossible. The gate is
+  loop-free (threading primitives) so the warm thread needs no event loop.
+- **Minimum progress under sustained load**: a background lane blocked by
+  continuous tenant demand STEALS one bounded turn per debt window
+  (`_BG_STEAL_FLOOR_S`, duty cycle capped by `_BG_STEAL_DEBT_FACTOR`); stolen
+  turns are not preemptible, so an 18-unit mint always finishes.
+- **Honest metrics**: time a tenant request spends queued behind the instance
+  gate is attributed to a new `instance_gate_wait` stage and excluded from
+  `runtime_ms` — mint contention no longer bills as tenant compute (measured:
+  16.9s reported for 1.95s of real work).
+- Kill switch `GEN_WORKER_BG_YIELD=0` restores the pre-fix shape
+  (red-verification and emergencies only).
+
+Tapes: `tests/test_mint_gate_pgw677.py` — starvation shape red-verified via
+the kill switch (tenant queued behind an inline-compiling mint unit), the
+pgw#676 overlap red-verified impossible post-fix with the bounded wait
+attributed, mint completion under a sustained tenant stream, and the
+seed-window routing contract.
+
 ## 0.69.0 (2026-07-26) — pgw#685: one fused triton kernel for the nvfp4 activation quantizer
 
 The `#nvfp4-w4a4` lane's per-call activation quantization was ~8 pure-torch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.69.0 (2026-07-26) — pgw#685: one fused triton kernel for the nvfp4 activation quantizer
+
+The `#nvfp4-w4a4` lane's per-call activation quantization was ~8 pure-torch
+passes (fp32 upcast, per-16-block amax, e4m3 scale, divide, `searchsorted`
+e2m1 cast, nibble pack, then a pad/permute swizzle of the scales into the
+cuBLAS blocked layout). gw#540 measured that chain — not the fp4 GEMM — as the
+whole reason the lane LOST to bf16. It is now ONE triton kernel.
+
+- **`gen_worker.models.nvfp4_quant`** owns the nvfp4 format primitives (moved
+  out of `w4a4.py`, which re-exports them unchanged) plus the fused kernel:
+  per-16 amax → e4m3 block scale → e2m1 RTN cast → nibble pack → block-scale
+  store **directly at its cuBLAS blocked-layout address**, in one pass.
+  Measured on RTX 5090 (sm_120) and B200 (sm_100): the quant step 6-36x
+  faster, taking the lane from 0.807x → 2.043x bf16 eager and 2.045x → 2.472x
+  compiled on sm_120, and 1.03x → 1.24x on sm_100 (pgw#682).
+- **Arch-portable by construction**: triton JITs per arch, so one source covers
+  sm_100/103 (B200/B300) and sm_120/121 (RTX 50xx / PRO 6000) — no nvcc
+  extension build, no per-family port. Launch config from the measured sweep:
+  128 blocks/program on both arches, 8 warps on sm_120/121 vs 4 on sm_100/103.
+- **`tl.math.div_rn`, deliberately.** Triton's `/` lowers to an approximate
+  divide; a 1-ulp drift lands values exactly on the 1.75 e2m1 tie boundary and
+  the ties-round-UP rule then flips a whole 4-bit code (0.16% of nibbles, 0.6%
+  output drift — small enough to read as noise).
+- **Arming is gated on BIT-IDENTITY against the pure-torch chain, not on a
+  tolerance**, on three probe shapes at load. The existing load-time numerics
+  self-check cannot see that class of bug (its threshold is 2e-2). A triton
+  release that changes rounding, or an arch we have not measured, falls back to
+  the reference chain rather than serving drifted numerics — never a refusal.
+- **Compile-safe**: registered as a `torch.library.custom_op` with an explicit
+  schema and a `register_fake`, so it is traced as an opaque call instead of
+  graph-breaking. Registration happens at load, never mid-trace.
+
 ## 0.68.1 (2026-07-26) — pgw#678 the lane handle is not the pipeline; pgw#683 shared-component identity carries the EFFECTIVE compute dtype
 
 Two P0s on the composition/residency path, both found live on the sdxl retag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ pgw#676 overlap red-verified impossible post-fix with the bounded wait
 attributed, mint completion under a sustained tenant stream, and the
 seed-window routing contract.
 
+Also in this train: **pgw#686** — cell adoption key parity (one base-lane
+brain for requested keys, mint stamps, lookups and the local store), the
+fix behind burst pods re-minting instead of adopting.
+
 ## 0.69.0 (2026-07-26) — pgw#685: one fused triton kernel for the nvfp4 activation quantizer
 
 The `#nvfp4-w4a4` lane's per-call activation quantization was ~8 pure-torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.68.1"
+version = "0.69.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.69.0"
+version = "0.70.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -618,6 +618,16 @@ def lane_token(weight_lane: str) -> str:
     return tok
 
 
+def cell_base_lane(pipeline: Any) -> str:
+    """Base weight lane for CELL-IDENTITY computation (advertised requested
+    keys, pull-by-key lookups, local-store lookups): the pipeline probe
+    first, then the denoiser's own lane markers — the identical resolution
+    the mint's ``stamp_lane`` memoizes, so requested == published by
+    construction (pgw#686). Dispatch/policy surfaces keep the raw
+    :func:`loading.pipeline_weight_lane` probe; this is cell identity only."""
+    return w8a8_lora.effective_base_lane(pipeline)
+
+
 def compile_target_lane_error(weight_lane: str, lora_bucket: int) -> str:
     """Return why a worker compile-target lane is not wire-canonical.
 
@@ -3236,6 +3246,7 @@ __all__ = [
     "artifact_metadata",
     "begin_fleet_mint",
     "capture_env",
+    "cell_base_lane",
     "drop_lora_lane",
     "cell_lane",
     "contract_drift",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -1951,6 +1951,16 @@ class ModelStore:
         return "download_failed"
 
 
+# pgw#686: base lanes speculated for pre-load pull-by-key cell lookups (no
+# pipeline exists yet to probe). Must cover every base lane a loader can
+# leave a pipeline on, or a cold worker can never pull the very cell its own
+# boot would mint — the ie#546 burst published on "w8a8" while lookups
+# speculated only ""/"fp8-hooks", so the armed cell was unreachable and all
+# 9 workers re-minted. Verify-on-receipt remains the arming gate; a wrong
+# speculation is only ever a benign extra lookup key.
+_SPECULATIVE_CELL_BASE_LANES = ("", "fp8-hooks", "w8a8")
+
+
 # ---------------------------------------------------------------------------
 # Endpoint instances (setup/warmup lifecycle)
 # ---------------------------------------------------------------------------
@@ -3074,8 +3084,15 @@ class Executor:
         try:
             from . import cell_key
 
+            # pgw#686: the KEY lane resolves through the one shared brain
+            # (compile_cache.cell_base_lane — probe, then denoiser markers),
+            # never the raw probe alone: the raw probe is blind to the w8a8
+            # GEMM mode, so its key names a cell no mint ever publishes and
+            # the fleet's armed cells are never adopted. The raw probe stays
+            # authoritative for the wire lane descriptor below.
             key = cell_key.compute(
-                str(getattr(cfg, "family", "") or ""), lane, bucket,
+                str(getattr(cfg, "family", "") or ""),
+                compile_cache.cell_base_lane(target.pipeline), bucket,
                 contract=cfg.contract_digest(),
                 regional=bool(getattr(cfg, "regional", False)))
             requested_key, requested_axes = key.digest, key.axes
@@ -3087,6 +3104,28 @@ class Executor:
             target.contract_digest = contract_digest
             target.requested_cell_key = requested_key
             target.requested_cell_axes = requested_axes
+
+    @staticmethod
+    def _warn_cell_key_divergence(spec_name: str, target: "_CompileTargetRecord") -> None:
+        """pgw#686 invariant: a SELF-MINTED active cell must carry exactly
+        the key an identical worker would REQUEST (requested_cell_key) —
+        anything else is fleet-wide silent zero-adoption: the published
+        cell sits armed in the store while every cold pod re-mints (the
+        ie#546 burst: 10 pods, 9 simultaneous mints, 0 adoptions). Loud
+        and greppable; never fatal to serving."""
+        with target.state_lock:
+            active = str(target.active_compile_ref or "")
+            self_mint = bool(target.active_self_mint)
+            requested = str(target.requested_cell_key or "")
+        if not (self_mint and active and requested):
+            return
+        if active.rpartition("#")[2] == requested:
+            return
+        logger.error(
+            "cell_key_divergence: self-minted active cell %s is not this "
+            "runtime's requested key %s for %s — the published cell can "
+            "never be adopted by an identical worker; the lane/axis probes "
+            "disagree (pgw#686)", active, requested, spec_name)
 
     def _compile_guard_failed(
         self,
@@ -3519,6 +3558,7 @@ class Executor:
                     "compile target %s has no runtime guard revocation signal; "
                     "advertising eager", incarnation_id,
                 )
+            self._warn_cell_key_divergence(spec.name, target)
             if target.active_compile_ref:
                 # pgw#622: post-proof, novel request shapes serve eager while
                 # the compiled path warms in the background; each completed
@@ -3608,7 +3648,9 @@ class Executor:
                 want_lane = self._mandatory_lane_of_bound(
                     wire_ref(binding) for binding in spec.models.values()
                 )
-                lanes = (want_lane,) if want_lane else ("", "fp8-hooks")
+                lanes = (
+                    (want_lane,) if want_lane
+                    else _SPECULATIVE_CELL_BASE_LANES)
                 for lane in lanes:
                     try:
                         digest = cell_key.compute(
@@ -6473,7 +6515,8 @@ class Executor:
         from . import cell_key
 
         candidate_keys: set[str] = set()
-        for lane in ((want_lane,) if want_lane else ("", "fp8-hooks")):
+        for lane in (
+                (want_lane,) if want_lane else _SPECULATIVE_CELL_BASE_LANES):
             try:
                 candidate_keys.add(cell_key.compute(
                     family, lane, want_bucket,
@@ -7518,6 +7561,12 @@ class Executor:
                     target.active_compile_snapshot_digest = str(
                         outcome.snapshot_digest)
                     target.active_self_mint = True
+                # pgw#686: the mint stamped the pipe's lane; re-advertise so
+                # the requested key names the key just published (the fleet
+                # adopts by requested key — a stale advertisement leaves the
+                # published cell unreachable), then assert the invariant.
+                self._refresh_compile_target(target)
+                self._warn_cell_key_divergence(spec.name, target)
                 if not self._bind_compile_guard(rec, target):
                     with target.state_lock:
                         target.active_compile_ref = ""

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -511,6 +511,32 @@ _MINT_ABANDON_GRACE_S = 60.0
 _MINT_SEED_MAX_PASSES = 8
 _MINT_POLL_INTERVAL_S = 1.0
 
+# pgw#677 background-turn gate: tenant requests always win the GPU; mint
+# seeds and shape-warm compiles run only in granted turns.
+#: Minimum continuous demand-blocked time before the background lane may
+#: STEAL one turn (the minimum-progress guarantee — background work still
+#: finishes under sustained tenant load).
+_BG_STEAL_FLOOR_S = 30.0
+#: A turn that ran against live demand "costs" this multiple of its own
+#: duration before the next steal — bounds the stolen duty cycle to
+#: 1/(1+factor) even when every turn is a multi-minute compile.
+_BG_STEAL_DEBT_FACTOR = 4.0
+#: Idle-granted COMPILE turns additionally wait for this much tenant quiet
+#: (arrivals cluster; this slashes the arrive-mid-compile collision).
+_BG_COMPILE_QUIESCENCE_S = 5.0
+#: How long one shape-warm thread admission attempt may wait before the job
+#: re-queues (TurnGateBusy) — bounds head-of-line blocking of the global
+#: warm queue; the persistent blocked-since clock keeps steals honest.
+_BG_THREAD_ADMIT_WAIT_S = 0.5
+
+
+def _bg_yield_enabled() -> bool:
+    """pgw#677: default ON; env kill switch for red-verification and
+    emergencies only. OFF restores the pre-fix shape: mint seeds idle-gate
+    + hold the bare run gate (inline compiles included) and shape-warm
+    compiles run ungated against tenant forwards."""
+    return os.environ.get("GEN_WORKER_BG_YIELD", "1").strip() != "0"
+
 
 def _cell_lane_matches(
     ref: str,
@@ -2112,6 +2138,13 @@ class _ClassRecord:
     # endpoint class declared ``reentrant=True``. One-job-per-GPU used to
     # mask this; multi-GPU permits and multi-residency do not.
     run_lock: asyncio.Lock = dc_field(default_factory=asyncio.Lock)
+    # pgw#677: module-exclusion mutex between loop-side executors (tenant
+    # handler + adapter mutation, mint seed forwards — all already
+    # serialized under run_lock) and the loop-LESS shape-warm thread, whose
+    # compile executes these same modules. threading.Lock on purpose: the
+    # warm thread must take it without an event loop; loop-side users take
+    # it via a joined to_thread so the loop never blocks.
+    turn_mutex: threading.Lock = dc_field(default_factory=threading.Lock)
     # Content-keyed shared components this record holds (gw#479): released
     # (refcount--) at vacate so the entries become LRU/drain candidates.
     shared_keys: List[Any] = dc_field(default_factory=list)
@@ -2163,6 +2196,11 @@ class _MintAbandoned(Exception):
     """The background mint was asked to stop (adoption/vacate/shutdown)."""
 
 
+class _SeedPreempted(Exception):
+    """pgw#677: a tenant arrival cooperatively cancelled the in-flight mint
+    seed forward; the driver re-queues the unit and yields the turn."""
+
+
 @dataclass
 class _BackgroundMint:
     """One deferred boot self-mint (pgw#671, worker half of th#1187).
@@ -2190,6 +2228,10 @@ class _BackgroundMint:
     abandon: asyncio.Event = dc_field(default_factory=asyncio.Event)
     task: Optional["asyncio.Task[None]"] = None
     act: Optional[Any] = None  # the handed-over self_mint_compile Activity
+    # pgw#677: the RequestContext of the in-flight PREEMPTIBLE seed forward
+    # (idle-granted turns only — stolen turns run to completion). A tenant
+    # admission cancels it; the driver re-queues the unit.
+    seed_ctx: Optional[Any] = None
 
 
 def _eager_first_boot_enabled() -> bool:
@@ -2444,6 +2486,21 @@ class Executor:
         self.jobs: Dict[Tuple[str, int], _Job] = {}
         self._idle = asyncio.Event()
         self._idle.set()
+        # pgw#677 background-turn gate state. Threading primitives on
+        # purpose: the shape-warm thread must block on them without a
+        # running event loop. _bg_unit_mutex = single-flight across ALL
+        # background GPU consumers (mint seed units + shape-warm compiles);
+        # _bg_quiet mirrors _idle for thread-side waits; the debt floats
+        # implement the minimum-progress steal accounting.
+        self._bg_unit_mutex = threading.Lock()
+        self._bg_state_lock = threading.Lock()
+        self._bg_quiet = threading.Event()
+        self._bg_quiet.set()
+        self._bg_steal_debt_until = 0.0
+        self._bg_last_tenant_activity = 0.0
+        # First refused thread-turn admission (spans TurnGateBusy requeue
+        # cycles); None once admitted. The steal clock reads it.
+        self._bg_blocked_since: Optional[float] = None
         # pgw#674 rotation preload: stages the hub's desired NEXT instances
         # (download -> pinned host -> VRAM double-buffer) WHILE jobs compute.
         # Lifecycle feeds it desired state; job admit/finish pokes it.
@@ -3291,6 +3348,11 @@ class Executor:
     ) -> bool:
         """Bind one live wrapper's first failure to exact target revocation."""
         from . import compile_cache, trt_engine
+
+        # pgw#677: every shape-warm/heal compile for this pipeline must run
+        # inside a background GPU turn (yield to tenant demand; mutual
+        # exclusion with tenant forwards on this instance).
+        self._wire_turn_gate(rec, target.pipeline)
 
         def callback(detail: str) -> None:
             self._compile_guard_failed(rec, target, detail)
@@ -5320,6 +5382,10 @@ class Executor:
                         mint_selections[pid] = sel
                     mint_pipes[pid] = candidate.pipeline
                     hot_swap.enable(candidate.pipeline)
+                    # pgw#677: the mint's own background compiles are the
+                    # first consumers of the turn gate — wire it before the
+                    # first seed can enqueue a warm job.
+                    self._wire_turn_gate(rec, candidate.pipeline)
                 rec.background_mint = _BackgroundMint(
                     spec=spec,
                     instance=instance,
@@ -7383,7 +7449,7 @@ class Executor:
             for pid, pipe in bg.pipes.items()
         }
 
-        async def _forward(wj: Any) -> None:
+        async def _forward(wj: Any, *, preemptible: bool = False) -> None:
             handler_kwargs = await self._handler_kwargs(
                 wj.spec, bg.snapshots or {})
             with tempfile.TemporaryDirectory(prefix="gw-bgmint-") as tmp:
@@ -7402,27 +7468,92 @@ class Executor:
                 )
                 ctx._set_lane(self._served_lane(wj.spec))
                 ctx._set_config(self._effective_config(wj.spec))
-                await self._invoke_warmup(
-                    wj.spec, bg.instance, ctx, payload, handler_kwargs)
+                if preemptible:
+                    bg.seed_ctx = ctx
+                    # Registration race: demand that arrived after the turn
+                    # was granted but before this ctx existed must still
+                    # preempt — check it here, not only at admission.
+                    if not self._bg_quiet.is_set():
+                        ctx._cancel()
+                try:
+                    # pgw#677: the seed window forces EAGER routing — a seed
+                    # must never pay an inline Dynamo+Inductor compile while
+                    # it holds the run gate (the measured 3.5-7 min units).
+                    with hot_swap.mint_seed_window():
+                        await self._invoke_warmup(
+                            wj.spec, bg.instance, ctx, payload,
+                            handler_kwargs)
+                except CanceledError:
+                    if preemptible and ctx.cancelled:
+                        raise _SeedPreempted()
+                    raise
+                finally:
+                    bg.seed_ctx = None
 
-        async def _unit(wj: Any) -> None:
-            """One warm forward, tenant work first, single-flight with real
-            requests (rec.run_lock) — the interference bound is one eager
-            forward, and the actual graph compiles run on the router's own
-            warm thread (nice +10, dedicated CUDA stream)."""
+        async def _unit(wj: Any) -> bool:
+            """One warm forward inside a background GPU turn (pgw#677):
+            tenant work always wins the gate — the turn is granted when the
+            worker is tenant-idle (or stolen under the minimum-progress
+            rule), the forward routes EAGER by construction (seed window),
+            and the actual graph compiles run on the router's warm thread
+            in their own turns. False = preempted by a tenant arrival; the
+            caller re-queues the unit."""
             _checkpoint()
-            idle = asyncio.ensure_future(self.wait_idle())
-            stop = asyncio.ensure_future(bg.abandon.wait())
-            try:
-                await asyncio.wait(
-                    {idle, stop}, return_when=asyncio.FIRST_COMPLETED)
-            finally:
-                for fut in (idle, stop):
-                    if not fut.done():
-                        fut.cancel()
-            _checkpoint()
-            async with rec.run_lock:
-                await _forward(wj)
+            if not _bg_yield_enabled():
+                # Legacy shape (kill switch / red-verification): idle-gate
+                # between units, bare run gate around the forward.
+                idle = asyncio.ensure_future(self.wait_idle())
+                stop = asyncio.ensure_future(bg.abandon.wait())
+                try:
+                    await asyncio.wait(
+                        {idle, stop}, return_when=asyncio.FIRST_COMPLETED)
+                finally:
+                    for fut in (idle, stop):
+                        if not fut.done():
+                            fut.cancel()
+                _checkpoint()
+                async with rec.run_lock:
+                    await _forward(wj)
+                return True
+            async with self._bg_turn(rec, "seed", abort=bg.abandon) as stole:
+                _checkpoint()
+                try:
+                    # A stolen turn runs to completion (the steal already
+                    # paid its debt); an idle-granted turn yields to any
+                    # tenant arrival at the handler's next cancel poll.
+                    await _forward(wj, preemptible=not stole)
+                except _SeedPreempted:
+                    return False
+            return True
+
+        async def _seed_pass(jobs_now: List[Any]) -> None:
+            """One full-plan seed pass; preempted units re-queue within the
+            pass (a preemption is not plan progress — the pass semantics
+            stay 'every unit ran to completion once')."""
+            pending_units = list(jobs_now)
+            completed = 0
+            while pending_units:
+                wj = pending_units.pop(0)
+                act.phase(
+                    activity_mod.PHASE_WARMUP_FORWARD,
+                    min(completed + 1, len(jobs_now)), len(jobs_now))
+                try:
+                    done = await _unit(wj)
+                except _MintAbandoned:
+                    raise
+                except Exception as exc:
+                    if not is_cuda_oom(exc):
+                        raise
+                    logger.warning(
+                        "background mint seed %s OOMed (%s); backing off "
+                        "this pass", wj.spec.name, exc)
+                    if torch is not None and torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    return
+                if done:
+                    completed += 1
+                else:
+                    pending_units.append(wj)
 
         # Phase 1 — SEED: run the full derived plan through the enabled
         # routers. Every novel signature serves EAGER here and enqueues its
@@ -7437,22 +7568,7 @@ class Executor:
                     f"mint seeding did not converge after "
                     f"{_MINT_SEED_MAX_PASSES} passes")
             before = _stats()
-            for idx, wj in enumerate(jobs, start=1):
-                act.phase(
-                    activity_mod.PHASE_WARMUP_FORWARD, idx, len(jobs))
-                try:
-                    await _unit(wj)
-                except _MintAbandoned:
-                    raise
-                except Exception as exc:
-                    if not is_cuda_oom(exc):
-                        raise
-                    logger.warning(
-                        "background mint seed %s OOMed (%s); backing off "
-                        "this pass", wj.spec.name, exc)
-                    if torch is not None and torch.cuda.is_available():
-                        torch.cuda.empty_cache()
-                    break
+            await _seed_pass(jobs)
             act.phase(activity_mod.PHASE_INDUCTOR_COMPILE)
             while True:
                 _checkpoint()
@@ -7483,7 +7599,8 @@ class Executor:
         for wj in jobs:
             if not _unproven_pids():
                 break
-            await _unit(wj)
+            while not await _unit(wj):
+                _checkpoint()
         proven_pids = [
             pid for pid in bg.pipes if pid not in set(_unproven_pids())
         ]
@@ -8473,6 +8590,12 @@ class Executor:
         )
         self.jobs[key] = job
         self._idle.clear()
+        # pgw#677: tenant demand exists NOW — no new background turn is
+        # granted (outside the minimum-progress rule) and any preemptible
+        # in-flight mint seed is cooperatively cancelled.
+        self._bg_quiet.clear()
+        self._bg_last_tenant_activity = time.monotonic()
+        self._preempt_background_seeds()
         logger.info("job admitted %s attempt=%d", run.request_id, run.attempt)
         await self._send(pb.WorkerMessage(job_accepted=pb.JobAccepted(
             request_id=run.request_id, attempt=run.attempt)))
@@ -8500,6 +8623,216 @@ class Executor:
             return True
         except asyncio.TimeoutError:
             return False
+
+    # ---- pgw#677 background-turn gate --------------------------------------
+    #
+    # Doctrine: tenant requests ALWAYS win the GPU; background work (mint
+    # seed units, shape-warm/heal compiles) yields. A background unit runs
+    # only inside a granted TURN: single-flight with every other background
+    # unit, holding the GPU permit + the owning instance's run gate, so it
+    # can never race a tenant forward on shared mutable state (the pgw#676
+    # SIGSEGV class) nor contend for the device (the measured 8.6x tenant
+    # degradation). Turns are granted when the worker is tenant-idle; under
+    # sustained load the minimum-progress rule STEALS one bounded turn per
+    # debt window so the mint still finishes (starvation both ways
+    # considered). A tenant arriving mid-turn waits at most ONE unit — and
+    # preempts idle-granted seed units cooperatively.
+
+    def _bg_admit(
+        self,
+        kind: str,
+        abort_check: Callable[[], None],
+        max_wait: Optional[float] = None,
+    ) -> bool:
+        """Thread-BLOCKING admission: wait until the worker is tenant-quiet
+        (plus compile quiescence) or the minimum-progress steal is due.
+        Returns ``stole``. ``abort_check`` raises to give up. With
+        ``max_wait`` set, raises ``hot_swap.TurnGateBusy`` instead of
+        waiting past it — the shape-warm thread re-queues rather than
+        head-of-line blocking every other router's jobs."""
+        attempt_start = time.monotonic()
+        blocked_since = attempt_start
+        # The steal clock spans requeue cycles (TurnGateBusy re-queues the
+        # job): continuous demand-block is measured from the FIRST refused
+        # admission, not per attempt.
+        if max_wait is not None:
+            with self._bg_state_lock:
+                if self._bg_blocked_since is not None:
+                    blocked_since = self._bg_blocked_since
+
+        def _admitted() -> None:
+            if max_wait is not None:
+                with self._bg_state_lock:
+                    self._bg_blocked_since = None
+
+        while True:
+            abort_check()
+            now = time.monotonic()
+            if self._bg_quiet.is_set():
+                quiet_for = now - self._bg_last_tenant_activity
+                if kind != "compile" or quiet_for >= _BG_COMPILE_QUIESCENCE_S:
+                    _admitted()
+                    return False
+                wait_s = max(_BG_COMPILE_QUIESCENCE_S - quiet_for, 0.0)
+            else:
+                with self._bg_state_lock:
+                    due = max(
+                        self._bg_steal_debt_until,
+                        blocked_since + _BG_STEAL_FLOOR_S,
+                    )
+                if now >= due:
+                    _admitted()
+                    return True
+                wait_s = due - now
+            if max_wait is not None and now - attempt_start >= max_wait:
+                with self._bg_state_lock:
+                    if self._bg_blocked_since is None:
+                        self._bg_blocked_since = blocked_since
+                from . import hot_swap
+
+                raise hot_swap.TurnGateBusy(kind)
+            if self._bg_quiet.is_set():
+                time.sleep(min(wait_s, 0.25))
+            else:
+                self._bg_quiet.wait(timeout=min(wait_s, 0.25))
+
+    def _bg_charge_debt(self, stole: bool, duration: float) -> None:
+        """A turn that ran against (or into) live tenant demand charges its
+        cost — the stolen background duty cycle stays bounded at
+        1/(1+debt_factor)."""
+        if stole or not self._bg_quiet.is_set():
+            with self._bg_state_lock:
+                self._bg_steal_debt_until = time.monotonic() + max(
+                    _BG_STEAL_FLOOR_S, _BG_STEAL_DEBT_FACTOR * duration)
+
+    @staticmethod
+    def _bg_mutex_acquire(
+        mutex: threading.Lock, abort_check: Callable[[], None],
+    ) -> None:
+        """Thread-blocking mutex acquire with an abort escape hatch."""
+        while not mutex.acquire(timeout=0.5):
+            abort_check()
+
+    async def _bg_locked(
+        self, mutex: threading.Lock, abort_check: Callable[[], None],
+    ) -> None:
+        """Loop-side acquire of a threading mutex, cancellation-safe: on
+        cancel the worker thread is JOINED and an acquire it completed is
+        released, so the mutex can never leak held."""
+        work = asyncio.create_task(
+            asyncio.to_thread(self._bg_mutex_acquire, mutex, abort_check))
+        try:
+            await asyncio.shield(work)
+        except asyncio.CancelledError:
+            try:
+                await work
+            except BaseException:
+                pass
+            else:
+                mutex.release()
+            raise
+
+    @asynccontextmanager
+    async def _bg_turn(
+        self,
+        rec: _ClassRecord,
+        kind: str,
+        abort: Optional[asyncio.Event] = None,
+    ) -> typing.AsyncIterator[bool]:
+        """Grant the mint driver one background GPU turn; yields ``stole``
+        (True when granted against live tenant demand under the
+        minimum-progress rule — stolen turns are not preemptible)."""
+
+        def abort_check() -> None:
+            if abort is not None and abort.is_set():
+                raise _MintAbandoned()
+            if self.draining:
+                if abort is not None:
+                    raise _MintAbandoned()
+                from . import hot_swap
+
+                raise hot_swap.TurnGateClosed("worker draining")
+
+        await self._bg_locked(self._bg_unit_mutex, abort_check)
+        try:
+            stole = await asyncio.to_thread(self._bg_admit, kind, abort_check)
+            turn_t0 = time.monotonic()
+            # Same order as the tenant path (permit -> run_lock ->
+            # turn_mutex): a tenant landing on ANOTHER instance mid-seed
+            # waits one bounded seed instead of contending for the device.
+            await self._gpu_semaphore.acquire()
+            try:
+                async with rec.run_lock:
+                    await self._bg_locked(rec.turn_mutex, abort_check)
+                    try:
+                        yield stole
+                    finally:
+                        rec.turn_mutex.release()
+                        self._bg_charge_debt(
+                            stole, time.monotonic() - turn_t0)
+            finally:
+                self._gpu_semaphore.release()
+        finally:
+            self._bg_unit_mutex.release()
+
+    def _bg_turn_threaded(
+        self, rec: _ClassRecord,
+    ) -> Callable[[str], typing.ContextManager[None]]:
+        """Thread-callable turn factory handed to hot-swap routers: the one
+        shape-warm thread blocks here — loop-free by construction — until
+        its turn is granted, then owns the instance's modules for exactly
+        one compile."""
+        from . import hot_swap
+
+        @contextmanager
+        def turn(kind: str) -> typing.Iterator[None]:
+            def abort_check() -> None:
+                if self.draining:
+                    raise hot_swap.TurnGateClosed("worker draining")
+
+            self._bg_mutex_acquire(self._bg_unit_mutex, abort_check)
+            try:
+                # Bounded admission: refused turns raise TurnGateBusy and
+                # the warm job RE-QUEUES — the one shape-warm thread never
+                # head-of-line blocks other routers' jobs behind one
+                # instance's demand-blocked compile.
+                stole = self._bg_admit(
+                    kind, abort_check, max_wait=_BG_THREAD_ADMIT_WAIT_S)
+                turn_t0 = time.monotonic()
+                self._bg_mutex_acquire(rec.turn_mutex, abort_check)
+                try:
+                    yield
+                finally:
+                    rec.turn_mutex.release()
+                    self._bg_charge_debt(stole, time.monotonic() - turn_t0)
+            finally:
+                self._bg_unit_mutex.release()
+
+        return turn
+
+    def _wire_turn_gate(self, rec: _ClassRecord, pipeline: Any) -> None:
+        """Hand this pipeline's hot-swap router the background-turn gate so
+        every shape-warm/heal compile serializes with — and yields to —
+        tenant work (pgw#677). Idempotent; no-op without a router."""
+        if not _bg_yield_enabled():
+            return
+        from . import hot_swap
+
+        router = hot_swap.router_of(pipeline)
+        if router is not None:
+            router.set_turn_gate(self._bg_turn_threaded(rec))
+
+    def _preempt_background_seeds(self) -> None:
+        """pgw#677: a tenant admission preempts the in-flight PREEMPTIBLE
+        mint seed at its next cooperative cancel point; the driver
+        re-queues the unit and the tenant takes the gate."""
+        for rec in self._classes.values():
+            bg = rec.background_mint
+            if bg is None:
+                continue
+            ctx = bg.seed_ctx
+            if ctx is not None and not ctx.cancelled:
+                ctx._cancel()
 
     async def abort_all(self, safe_message: str = "worker draining") -> None:
         for job in list(self.jobs.values()):
@@ -8844,10 +9177,31 @@ class Executor:
             # picks) still run concurrently; ``reentrant=True`` classes opt
             # out. Ordering: acquired AFTER the GPU permit and never held
             # while acquiring one — no cycle.
+            gate_t0 = time.monotonic()
             async with AsyncExitStack() as run_gate:
                 if spec.cls is not None and not spec.reentrant:
-                    await run_gate.enter_async_context(
-                        self._classes[spec.instance_key].run_lock)
+                    rec_gate = self._classes[spec.instance_key]
+                    await run_gate.enter_async_context(rec_gate.run_lock)
+                    # pgw#677: exclude the shape-warm thread's compile from
+                    # this request's whole mutation+forward window — the
+                    # ungated overlap was the pgw#676 SIGSEGV race and the
+                    # measured 8.6x mint-window degradation. Bounded: at
+                    # most one in-flight compile.
+                    await self._bg_locked(
+                        rec_gate.turn_mutex, lambda: None)
+                    run_gate.callback(rec_gate.turn_mutex.release)
+                    gate_wait = time.monotonic() - gate_t0
+                    if gate_wait >= 0.001:
+                        # pgw#677: time queued behind the instance gate
+                        # (typically a background mint/compile turn) is NOT
+                        # this request's compute — attribute it as its own
+                        # pre-handler stage and restart the compute clock,
+                        # so runtime_ms stops billing mint contention to
+                        # the tenant (measured: 16.9s reported for 1.95s of
+                        # real work).
+                        ctx._stages.record_pre(
+                            "instance_gate_wait", gate_wait)
+                        started = time.monotonic()
                 with self.store.residency.executing(*exec_refs, *adapter_refs):
                     active: List[Tuple[str, Any]] = []
                     try:
@@ -9615,8 +9969,12 @@ class Executor:
         self.preloader.poke()
 
     def _maybe_idle(self) -> None:
+        # pgw#677: compile-turn quiescence keys off the last tenant
+        # admission OR finish — arrivals cluster around completions.
+        self._bg_last_tenant_activity = time.monotonic()
         if not self.in_flight_keys():
             self._idle.set()
+            self._bg_quiet.set()
 
 
 class _DeadlineExceeded(Exception):

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -26,14 +26,52 @@ import os
 import queue
 import threading
 import time
+from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, ContextManager, Iterator, Optional, Tuple
 from . import compile_cache
 
 logger = logging.getLogger(__name__)
 
 EAGER = "eager"
 COMPILED = "compiled"
+
+
+class TurnGateClosed(Exception):
+    """The executor's background-turn gate is gone (shutdown/drain); the
+    warm job is dropped, its signature stays eager (pgw#677)."""
+
+
+class TurnGateBusy(Exception):
+    """No background turn within the bounded admission window (live tenant
+    demand). The warm job re-queues instead of blocking the ONE shape-warm
+    thread — a blocked compile for one instance must never head-of-line
+    delay every other router's jobs (pgw#677)."""
+
+
+# pgw#677: the background mint's seed forwards run inside this window. A
+# novel signature seen here must NEVER compile inline — the seed holds the
+# per-instance run gate, and an inline Dynamo+Inductor compile turns a
+# ~seconds eager forward into a minutes-long gate hold (the measured
+# 3.5-7 min warm units that starved every tenant request). Inside the
+# window, route() forces EAGER + background enqueue regardless of the
+# concurrent flag or VRAM headroom.
+_MINT_SEED: ContextVar[bool] = ContextVar("gw_mint_seed_window", default=False)
+
+
+@contextlib.contextmanager
+def mint_seed_window() -> Iterator[None]:
+    """Mark the current context (and its to_thread descendants) as a mint
+    seed forward (pgw#677)."""
+    token = _MINT_SEED.set(True)
+    try:
+        yield
+    finally:
+        _MINT_SEED.reset(token)
+
+
+def in_mint_seed_window() -> bool:
+    return _MINT_SEED.get()
 
 # Concurrent warm transient ~= one extra batch of activations. Conservative
 # free-VRAM floor; below it the request degrades to sequential (never OOM).
@@ -175,6 +213,10 @@ class _WarmJob:
     device: Optional[int]
     grad_mode: str  # "grad" | "no_grad" | "inference"
     autocast_dtype: Optional[Any]
+    # pgw#677: the executor's background GPU turn — the compile executes
+    # ONLY inside it (yields to tenant demand; mutually exclusive with
+    # tenant forwards on the owning instance). None = ungated legacy.
+    turn: Optional[Callable[[str], ContextManager[None]]] = None
 
 
 class Router:
@@ -205,6 +247,18 @@ class Router:
         self.healing: set = set()
         self.volatile: set = set()
         self.guard_miss_counts: dict = {}
+        # pgw#677: executor-provided background-turn factory. When set,
+        # every warm job for this router executes inside a turn, and
+        # route() stops degrading novel signatures to inline compiles on
+        # tight VRAM headroom (the warm thread ensures headroom inside its
+        # exclusive turn instead).
+        self.turn_gate: Optional[Callable[[str], ContextManager[None]]] = None
+
+    def set_turn_gate(
+        self, turn_gate: Optional[Callable[[str], ContextManager[None]]],
+    ) -> None:
+        with self.lock:
+            self.turn_gate = turn_gate
 
     def enable(self, on_warmed: Optional[Callable[[], None]] = None) -> bool:
         if self.fail_closed:
@@ -244,6 +298,7 @@ class Router:
         (sequential compile on a miss — today's behavior); EAGER serves the
         original while the background warm compiles this signature."""
         sig = (label, signature(args, kwargs))
+        seed = _MINT_SEED.get()
         with self.lock:
             # pgw#680: guard-miss verdicts outrank the concurrent gate — a
             # sig mid-heal (or proven per-request-volatile) serves eager on
@@ -253,7 +308,13 @@ class Router:
                 return EAGER, sig
             if sig in self.healing:
                 return EAGER, sig
-            if not self.concurrent or self.closed:
+            if self.closed:
+                return COMPILED, sig
+            # pgw#677: a mint seed forward holds the per-instance run gate —
+            # it must never pay an inline compile there. The seed's only job
+            # is vocabulary discovery: EAGER + background enqueue, even when
+            # concurrent routing is off for ordinary requests.
+            if not self.concurrent and not seed:
                 return COMPILED, sig
             if sig in self.warm:
                 return COMPILED, sig
@@ -269,18 +330,24 @@ class Router:
                 self.concurrent = False
                 return COMPILED, sig
             device = _first_cuda_device(args, kwargs)
-            if not _headroom_ok(device):
+            # pgw#677: with a turn gate the warm thread owns the device while
+            # it compiles (no concurrent transient to protect against) and
+            # ensures headroom itself; only ungated legacy routers keep the
+            # degrade-to-inline-compile fallback — and never for seeds.
+            if (self.turn_gate is None and not seed
+                    and not _headroom_ok(device)):
                 logger.warning(
                     "hot-swap: tight VRAM headroom for novel %s signature; "
                     "degrading to sequential compile-then-serve", label)
                 return COMPILED, sig
             self.pending.add(sig)
+            turn = self.turn_gate
         try:
             job = _WarmJob(
                 router=self, label=label, sig=sig, compiled=compiled,
                 args=_dummy_value(args), kwargs=_dummy_value(kwargs),
                 device=device, grad_mode=_grad_mode(),
-                autocast_dtype=_autocast_dtype(),
+                autocast_dtype=_autocast_dtype(), turn=turn,
             )
         except Exception:
             logger.warning(
@@ -348,12 +415,14 @@ class Router:
                 return "healing"
             self.healing.add(sig)
             self.pending.add(sig)
+            turn = self.turn_gate
         try:
             job = _WarmJob(
                 router=self, label=label, sig=sig, compiled=compiled,
                 args=_dummy_value(args), kwargs=_dummy_value(kwargs),
                 device=_first_cuda_device(args, kwargs),
                 grad_mode=_grad_mode(), autocast_dtype=_autocast_dtype(),
+                turn=turn,
             )
         except Exception:
             logger.warning(
@@ -440,12 +509,69 @@ def _worker_loop() -> None:
             _QUEUE.task_done()
 
 
+def _ensure_headroom(device: Optional[int]) -> None:
+    """Best-effort VRAM headroom for the warm forward: inside an exclusive
+    background turn the only reclaimable pressure is allocator cache
+    (pgw#677 — this replaces route()'s degrade-to-inline-compile). A real
+    OOM is still caught per-signature by the caller."""
+    if device is None:
+        return
+    try:
+        import torch
+
+        if not _headroom_ok(device):
+            torch.cuda.empty_cache()
+    except Exception:
+        pass
+
+
 def _run_warm(job: _WarmJob) -> None:
     router = job.router
     with router.lock:
         if router.closed:
             router.pending.discard(job.sig)
             return
+    if job.turn is not None:
+        # pgw#677: the compile + dummy forward execute the SAME modules the
+        # serving path runs (and inductor benchmarks on the same device) —
+        # ungated, that raced live tenant forwards: measured 8.6x tenant
+        # latency during mints and the pgw#676 sm_86 SIGSEGV
+        # (_forward_with_branch concurrent with compile_wrapper). The turn
+        # yields to tenant demand and excludes tenant forwards for the
+        # bounded duration of ONE compile.
+        try:
+            with job.turn("compile"):
+                with router.lock:
+                    if router.closed:
+                        router.pending.discard(job.sig)
+                        return
+                _ensure_headroom(job.device)
+                _run_warm_gated(job)
+        except TurnGateBusy:
+            # Live tenant demand: re-queue rather than block the one warm
+            # thread — other routers' jobs keep flowing; this one retries
+            # (and is eventually admitted by idle or the steal rule).
+            if not _submit(job):
+                with router.lock:
+                    router.pending.discard(job.sig)
+                    router.healing.discard(job.sig)
+                logger.warning(
+                    "hot-swap: warm queue full while yielding to tenant "
+                    "demand; %s stays eager (retried on a later request)",
+                    job.label)
+        except TurnGateClosed:
+            with router.lock:
+                router.pending.discard(job.sig)
+                router.healing.discard(job.sig)
+            logger.info(
+                "hot-swap: background turn gate closed; dropping warm job "
+                "for %s (stays eager)", job.label)
+        return
+    _run_warm_gated(job)
+
+
+def _run_warm_gated(job: _WarmJob) -> None:
+    router = job.router
     t0 = time.monotonic()
     try:
         with contextlib.ExitStack() as stack:

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -102,10 +102,13 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
     reason = ""
     try:
         from . import cell_key
-        from .models.loading import pipeline_weight_lane
 
+        # pgw#686: the ONE base-lane resolution the mint's stamp uses —
+        # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
+        # store save/lookup pair straddling apply_lora_lane would never
+        # match and every boot would re-mint.
         want = cell_key.compute(
-            family, pipeline_weight_lane(pipe),
+            family, cc.cell_base_lane(pipe),
             int(getattr(cfg, "lora_bucket", 0) or 0),
             contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
             regional=bool(getattr(cfg, "regional", False)),

--- a/src/gen_worker/models/nvfp4_quant.py
+++ b/src/gen_worker/models/nvfp4_quant.py
@@ -1,0 +1,371 @@
+"""nvfp4 format primitives + the fused triton activation quantizer (pgw#685).
+
+The pure-torch quantize chain (:func:`quantize_activation_torch`) is ~8 passes
+over the activation: fp32 upcast, per-16-block amax, e4m3 block scale, divide,
+``searchsorted`` e2m1 cast, nibble pack, then a pad/permute swizzle of the
+scales into the cuBLAS blocked layout. gw#540 measured that chain as the whole
+reason the w4a4 lane LOST to bf16 (0.807x eager on sm_120) — the fp4 GEMM was
+never the problem. :func:`quantize_activation` runs all of it in ONE triton
+kernel, writing each block scale directly at its blocked-layout address.
+
+Measured (pgw#682 G-B/G-B2, RTX 5090 sm_120 + B200 sm_100, torch 2.13/triton
+3.7.1): the quant step alone 6-36x faster; the stacked-block lane 0.807x ->
+2.043x bf16 eager and 2.045x -> 2.472x compiled on sm_120, 1.03x -> 1.24x on
+sm_100. Triton JITs per arch, so one source covers sm_100/103 and sm_120/121
+with no nvcc extension build and no per-family port.
+
+Two hazards carried deliberately:
+
+- ``tl.math.div_rn``. Triton's ``/`` lowers to an APPROXIMATE divide; a 1-ulp
+  drift lands a value exactly on the 1.75 e2m1 tie boundary, and because ties
+  round UP a whole 4-bit code flips (measured: 0.16% of nibbles, 0.6% output
+  drift). w4a4's load-time numerics self-check cannot see this — its threshold
+  is 2e-2.
+- Arming is gated on BIT-IDENTITY against the torch chain, never a tolerance.
+  A triton release that changes rounding, or an arch we have not measured,
+  falls back to the torch chain instead of serving drifted numerics.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+E2M1_MAX = 6.0
+FP8_MAX = 448.0
+SCALE_MIN = 2.0 ** -9  # e4m3 underflow guard (modelopt clamp)
+BLOCK = 16
+
+# Work-per-program for the fused kernel. Both arches want the SAME shape —
+# 128 blocks (2048 elements) per program; only the warp count differs
+# (pgw#682: sweeping this fixed a false "sm_100 is bad at 4-bit" reading. At
+# 8 blocks/program the B200 ran 21x off its own bandwidth floor). Halved
+# automatically when a shape has fewer k-blocks than this.
+_BLOCKS_PER_PROG = 128
+_WARPS_BY_SM = {100: 4, 103: 4, 120: 8, 121: 8}
+_WARPS_DEFAULT = 4
+
+# Probe shapes for the bit-identity gate: a small one, a row count that is not
+# a multiple of 128 (exercises blocked-layout row padding), and a real
+# qwen-image FFN width.
+_IDENTITY_PROBES = ((128, 512), (333, 3072), (1024, 12288))
+
+
+# ---------------------------------------------------------------------------
+# Format primitives (pure torch) — shared by the producer, the dequant lane,
+# and the reference activation-quant chain.
+# ---------------------------------------------------------------------------
+
+
+def _e2m1_lut(device: Any) -> Any:
+    import torch
+
+    return torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device=device, dtype=torch.float32)
+
+
+def _e2m1_bounds(device: Any) -> Any:
+    import torch
+
+    return torch.tensor(
+        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
+        device=device, dtype=torch.float32)
+
+
+def cast_e2m1(t: Any) -> Any:
+    """Float tensor -> e2m1 nibble codes (uint8, values 0-15). Round-to-
+    nearest with ties at the odd bounds (0.75/1.75/2.5) rounding UP —
+    byte-identical to modelopt's NVFP4QTensor._cast_fp4."""
+    import torch
+
+    v = t.float()
+    sign = (v < 0).to(torch.uint8)
+    a = v.abs()
+    ord_ = torch.searchsorted(
+        _e2m1_bounds(v.device), a.contiguous(), out_int32=True).to(torch.uint8)
+    tie = ((a == 0.75) | (a == 1.75) | (a == 2.5)).to(torch.uint8)
+    return (sign << 3) + ord_ + tie
+
+
+def pack_e2m1(codes: Any) -> Any:
+    """[..., K] nibble codes -> [..., K/2] packed uint8 (element 2j in the
+    LOW nibble — torch.float4_e2m1fn_x2 / modelopt convention). Explicitly
+    contiguous: cuBLASLt refuses strided fp4 operands
+    (CUBLAS_STATUS_NOT_SUPPORTED, found live on B200), and TensorIterator
+    may propagate the slice strides into the packed output."""
+    return ((codes[..., 1::2] << 4) | codes[..., 0::2]).contiguous()
+
+
+def unpack_e2m1(packed: Any) -> Any:
+    """[..., K/2] packed uint8 -> [..., K] float32 e2m1 values."""
+    import torch
+
+    lut = _e2m1_lut(packed.device)
+    shape = list(packed.shape)
+    shape[-1] = shape[-1] * 2
+    out = torch.empty(shape, dtype=torch.float32, device=packed.device)
+    out[..., 0::2] = lut[(packed & 0x0F).long()]
+    out[..., 1::2] = lut[(packed >> 4).long()]
+    return out
+
+
+def to_blocked_scales(scales: Any) -> Any:
+    """Flat per-block scales [rows, k_blocks] (e4m3) -> the cuBLAS 2-D tiled
+    ("blocked") layout torch's blockwise scaled_mm consumes: rows padded to
+    128, block columns padded to 4, 128x4 tiles rearranged (32, 4, 4) —
+    returned as a contiguous 1-D e4m3 tensor (the kernel checks numel +
+    contiguity only). Same rearrangement as modelopt's swizzle_nvfp4_scales /
+    torchao's to_blocked, and the layout the fused kernel writes directly."""
+    import torch
+
+    rows, cols = scales.shape
+    nrb = (rows + 127) // 128
+    ncb = (cols + 3) // 4
+    # fp8 has no pad/zeros kernels everywhere — swizzle a uint8 view.
+    raw = scales.view(torch.uint8)
+    padded = raw.new_zeros(nrb * 128, ncb * 4)
+    padded[:rows, :cols] = raw
+    blocks = padded.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
+    out = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1)
+    return out.contiguous().view(torch.float8_e4m3fn)
+
+
+def blocked_scale_numel(rows: int, k_blocks: int) -> int:
+    """Element count of :func:`to_blocked_scales`' output for a [rows,
+    k_blocks] scale grid — the fused kernel's output buffer size."""
+    return ((rows + 127) // 128) * 128 * ((k_blocks + 3) // 4) * 4
+
+
+def quantize_activation_torch(x2: Any, s2: Any) -> tuple[Any, Any]:
+    """Reference chain: 2-D activation [M, K] + per-tensor second-level scale
+    -> (packed uint8 [M, K/2], e4m3 block scales in the cuBLAS blocked
+    layout). The numerics the fused kernel must reproduce BIT-EXACTLY."""
+    import torch
+
+    in_f = int(x2.shape[1])
+    xb = x2.reshape(-1, in_f // BLOCK, BLOCK).float()
+    bmax = xb.abs().amax(dim=-1)
+    sa = (bmax / (E2M1_MAX * s2)).clamp(
+        min=SCALE_MIN, max=FP8_MAX).to(torch.float8_e4m3fn)
+    q = xb / (sa.float().unsqueeze(-1) * s2)
+    codes = cast_e2m1(q.reshape(-1, in_f))
+    return pack_e2m1(codes), to_blocked_scales(sa)
+
+
+# ---------------------------------------------------------------------------
+# The fused kernel, behind a torch.library custom op so it survives
+# torch.compile instead of graph-breaking.
+# ---------------------------------------------------------------------------
+
+_OP_NAME = "cozy_gen_worker::quant_nvfp4_act"
+
+
+@functools.lru_cache(maxsize=1)
+def _build_fused_op() -> Optional[Any]:
+    """Compile the triton kernel and register the custom op. ``None`` when
+    triton (or the fp8 cast it needs) is unavailable. Called at LOAD time so
+    registration never happens mid-trace."""
+    try:
+        import torch
+        import triton
+        import triton.language as tl
+    except Exception as exc:  # noqa: BLE001 — no triton => torch chain
+        logger.info("nvfp4: fused quantizer unavailable (%s); torch chain", exc)
+        return None
+
+    @triton.jit
+    def _e2m1_code(q):  # type: ignore[no-untyped-def]
+        """RTN to e2m1 nibble codes — the searchsorted+tie path expressed as
+        threshold counts (ties at 0.75/1.75/2.5 round UP, sign in bit 3)."""
+        a = tl.abs(q)
+        code = ((a > 0.25).to(tl.uint8) + (a > 0.75).to(tl.uint8)
+                + (a > 1.25).to(tl.uint8) + (a > 1.75).to(tl.uint8)
+                + (a > 2.5).to(tl.uint8) + (a > 3.5).to(tl.uint8)
+                + (a > 5.0).to(tl.uint8))
+        tie = ((a == 0.75) | (a == 1.75) | (a == 2.5)).to(tl.uint8)
+        return code + tie + ((q < 0).to(tl.uint8) * 8)
+
+    @triton.jit
+    def _quant_nvfp4_kernel(  # type: ignore[no-untyped-def]
+        x_ptr, q_ptr, s_ptr, s2_ptr,
+        K, KB, NCB,
+        stride_xm, stride_xk,
+        BLOCKS_PER_PROG: tl.constexpr,
+    ):
+        """One program = one row x BLOCKS_PER_PROG groups of 16 elements.
+
+        Writes packed nibbles (element 2j in the LOW nibble) and stores the
+        e4m3 block scale DIRECTLY in the cuBLAS blocked layout:
+          tile    = (row // 128) * NCB + (blk // 4)
+          in-tile = (row % 32) * 16 + ((row % 128) // 32) * 4 + (blk % 4)
+        """
+        row = tl.program_id(0)
+        blk0 = tl.program_id(1) * BLOCKS_PER_PROG
+
+        s2 = tl.load(s2_ptr)
+
+        offs_b = blk0 + tl.arange(0, BLOCKS_PER_PROG)
+        blk_ok = offs_b < KB
+        # Load each block's 16 elements as two [BPP, 8] tiles (even / odd
+        # positions) — the nibble pairing the packed layout needs, with no
+        # in-kernel reshape.
+        offs_lo = offs_b[:, None] * 16 + tl.arange(0, 8)[None, :] * 2
+        offs_hi = offs_lo + 1
+        base = x_ptr + row * stride_xm
+        m2 = blk_ok[:, None]
+        xe = tl.load(base + offs_lo * stride_xk, mask=m2, other=0.0).to(tl.float32)
+        xo = tl.load(base + offs_hi * stride_xk, mask=m2, other=0.0).to(tl.float32)
+
+        amax = tl.maximum(tl.max(tl.abs(xe), axis=1), tl.max(tl.abs(xo), axis=1))
+        scale = amax / (6.0 * s2)
+        scale = tl.minimum(tl.maximum(scale, 0.001953125), 448.0)
+        scale_f8 = scale.to(tl.float8e4nv)  # RTN to e4m3, as the torch chain does
+        denom = (scale_f8.to(tl.float32) * s2)[:, None]
+
+        # IEEE round-to-nearest divide. Triton's `/` is an approximate divide;
+        # a 1-ulp drift lands values exactly ON the 1.75 tie boundary and the
+        # ties-round-UP rule then flips a whole e2m1 code.
+        lo = _e2m1_code(tl.math.div_rn(xe, denom))
+        hi = _e2m1_code(tl.math.div_rn(xo, denom))
+        packed = lo | (hi << 4)
+
+        offs_p = offs_b[:, None] * 8 + tl.arange(0, 8)[None, :]
+        tl.store(q_ptr + row * (K // 2) + offs_p, packed, mask=m2)
+
+        rb = row // 128
+        rr = row % 128
+        tile = rb * NCB + (offs_b // 4)
+        in_tile = (rr % 32) * 16 + (rr // 32) * 4 + (offs_b % 4)
+        tl.store(s_ptr + tile * 512 + in_tile, scale_f8, mask=blk_ok)
+
+    def _launch(x2: Any, s2: Any) -> tuple[Any, Any]:
+        m, k = int(x2.shape[0]), int(x2.shape[1])
+        kb = k // BLOCK
+        ncb = (kb + 3) // 4
+        q = torch.empty(m, k // 2, dtype=torch.uint8, device=x2.device)
+        # Padding rows/columns are never written — the buffer must start zeroed.
+        s = torch.zeros(blocked_scale_numel(m, kb),
+                        dtype=torch.float8_e4m3fn, device=x2.device)
+        bpp = min(_BLOCKS_PER_PROG, kb)
+        while kb % bpp and bpp > 1:
+            bpp //= 2
+        _quant_nvfp4_kernel[(m, (kb + bpp - 1) // bpp)](
+            x2, q, s, s2, k, kb, ncb,
+            x2.stride(0), x2.stride(1), BLOCKS_PER_PROG=bpp,
+            num_warps=_quant_warps())
+        return q, s
+
+    # Explicit schema: the op must not depend on annotation inference (torch
+    # is imported lazily in this module, so string annotations would not
+    # resolve). mutates_args=() — both outputs are freshly allocated.
+    op = torch.library.custom_op(
+        _OP_NAME, _launch, mutates_args=(),
+        schema="(Tensor x2, Tensor s2) -> (Tensor, Tensor)")
+
+    @op.register_fake
+    def _(x2: Any, s2: Any) -> tuple[Any, Any]:
+        m, k = int(x2.shape[0]), int(x2.shape[1])
+        return (x2.new_empty(m, k // 2, dtype=torch.uint8),
+                x2.new_empty(blocked_scale_numel(m, k // BLOCK),
+                             dtype=torch.float8_e4m3fn))
+
+    return op
+
+
+def _quant_warps() -> int:
+    try:
+        import torch
+
+        major, minor = torch.cuda.get_device_capability()
+        return _WARPS_BY_SM.get(major * 10 + minor, _WARPS_DEFAULT)
+    except Exception:  # noqa: BLE001
+        return _WARPS_DEFAULT
+
+
+def _bit_identical(op: Any) -> bool:
+    """The arming gate: fused output must match the torch chain BYTE for byte
+    on every probe. A tolerance check cannot see the div_rn class of bug — one
+    flipped nibble in 600 is 0.6% output drift and reads as noise."""
+    import torch
+
+    for m, k in _IDENTITY_PROBES:
+        torch.manual_seed(0)
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        s2 = (x.abs().amax().float() / (E2M1_MAX * FP8_MAX)).clamp(min=1e-12)
+        want_q, want_s = quantize_activation_torch(x, s2)
+        got_q, got_s = op(x, s2)
+        if not torch.equal(got_q, want_q):
+            bad = int((got_q != want_q).sum())
+            logger.warning(
+                "nvfp4: fused quantizer differs from the torch chain at "
+                "%dx%d (%d/%d packed bytes); torch chain",
+                m, k, bad, want_q.numel())
+            return False
+        if not torch.equal(got_s.view(torch.uint8), want_s.view(torch.uint8)):
+            logger.warning(
+                "nvfp4: fused quantizer block scales differ from the torch "
+                "chain at %dx%d; torch chain", m, k)
+            return False
+    return True
+
+
+@functools.lru_cache(maxsize=1)
+def nvfp4_quantizer_mode() -> str:
+    """``"fused"`` | ``"torch"`` for THIS device, decided once per process.
+    Arms only when triton compiles the kernel AND it is bit-identical to the
+    reference chain on every probe shape."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return "torch"
+        op = _build_fused_op()
+        if op is None:
+            return "torch"
+        if not _bit_identical(op):
+            return "torch"
+    except Exception as exc:  # noqa: BLE001 — any gap => reference chain
+        logger.warning("nvfp4: fused quantizer probe failed (%s); torch chain",
+                       exc)
+        return "torch"
+    logger.info("nvfp4: fused triton activation quantizer armed "
+                "(%d blocks/program, %d warps)",
+                _BLOCKS_PER_PROG, _quant_warps())
+    return "fused"
+
+
+def quantize_activation(x2: Any, s2: Any) -> tuple[Any, Any]:
+    """2-D activation + per-tensor second-level scale -> (packed fp4 uint8
+    [M, K/2], e4m3 block scales in the cuBLAS blocked layout). Uses the fused
+    triton kernel when it armed for this device, else the reference chain.
+    Compile-safe: the fused path is a registered custom op.
+
+    ``s2`` is coerced to a 0-dim fp32 tensor — the kernel loads it as fp32, so
+    a bf16 scalar would be read as garbage bits rather than upcast."""
+    s2 = s2.reshape(()).float()
+    if nvfp4_quantizer_mode() == "fused":
+        op = _build_fused_op()
+        if op is not None:
+            return op(x2, s2)
+    return quantize_activation_torch(x2, s2)
+
+
+__all__ = [
+    "BLOCK",
+    "E2M1_MAX",
+    "FP8_MAX",
+    "SCALE_MIN",
+    "blocked_scale_numel",
+    "cast_e2m1",
+    "nvfp4_quantizer_mode",
+    "pack_e2m1",
+    "quantize_activation",
+    "quantize_activation_torch",
+    "to_blocked_scales",
+    "unpack_e2m1",
+]

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -24,10 +24,12 @@ Execution: quantized Linears become :class:`W4A4Linear` — blockwise
 cores, ~2x the fp8 rate: 4378 TFLOPS / 3.07x bf16 measured on B200, gw#540
 DP1). Activations are quantized per call: static per-tensor second-level
 scale from calibration (dynamic amax fallback), per-16-block e4m3 scales
-computed dynamically. torch's blockwise scaled_mm consumes scales in the
-cuBLAS 2-D tiled ("blocked") layout — weight scales are swizzled ONCE at
-load, activation scales per call (a reshape/permute that fuses under
-inductor). SM >= 100 only (sm_100/103 datacenter + sm_120/121 consumer
+computed dynamically. That per-call chain is ONE fused triton kernel
+(``nvfp4_quant``, pgw#685) which also writes the block scales straight into
+the cuBLAS 2-D tiled ("blocked") layout torch's blockwise scaled_mm consumes;
+weight scales are swizzled once at load. The fused kernel arms only when it
+is bit-identical to the pure-torch chain, which otherwise serves unchanged.
+SM >= 100 only (sm_100/103 datacenter + sm_120/121 consumer
 Blackwell); the hub never schedules the flavor below that. Hosts of a
 qualifying arch whose kernel probe, micro-benchmark, or numerics self-check
 fails DEQUANT once at load into plain bf16-resident weights — same
@@ -46,15 +48,24 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 import shutil
 
+from .nvfp4_quant import (
+    BLOCK as _BLOCK,
+    E2M1_MAX as _E2M1_MAX,
+    FP8_MAX as _FP8_MAX,
+    SCALE_MIN as _SCALE_MIN,
+    cast_e2m1,
+    nvfp4_quantizer_mode,
+    pack_e2m1,
+    quantize_activation,
+    to_blocked_scales,
+    unpack_e2m1,
+)
+
 logger = logging.getLogger(__name__)
 
 W4A4_FLAVOR = "nvfp4-w4a4"
 # Blackwell fp4 tensor cores: sm_100/103 (B200/B300) + sm_120/121 (RTX 50xx).
 W4A4_MIN_SM = 100
-_E2M1_MAX = 6.0
-_FP8_MAX = 448.0
-_SCALE_MIN = 2.0 ** -9  # e4m3 underflow guard (modelopt clamp)
-_BLOCK = 16
 # torch fp4 scaled_mm operand checks: packed K/2 % 16 == 0 and both mat2
 # dims % 16 == 0 => in_features % 32 == 0, out_features % 16 == 0.
 _K_ALIGN = 32
@@ -165,84 +176,10 @@ def detect_w4a4_artifact(model_path: Path) -> Optional[W4a4Artifact]:
 
 
 # ---------------------------------------------------------------------------
-# e2m1 quantize/dequantize + the cuBLAS blocked-scale swizzle (pure torch —
-# used by the producer, the dequant lane, and W4A4Linear's activation quant).
+# Weight quantize/dequantize. The e2m1 cast, nibble pack and blocked-scale
+# swizzle primitives live in nvfp4_quant (shared with the fused activation
+# quantizer) and are re-exported from here for the producer + dequant lane.
 # ---------------------------------------------------------------------------
-
-
-def _e2m1_lut(device: Any) -> Any:
-    import torch
-
-    return torch.tensor(
-        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-        device=device, dtype=torch.float32)
-
-
-def _e2m1_bounds(device: Any) -> Any:
-    import torch
-
-    return torch.tensor(
-        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
-        device=device, dtype=torch.float32)
-
-
-def cast_e2m1(t: Any) -> Any:
-    """Float tensor -> e2m1 nibble codes (uint8, values 0-15). Round-to-
-    nearest with ties at the odd bounds (0.75/1.75/2.5) rounding UP —
-    byte-identical to modelopt's NVFP4QTensor._cast_fp4."""
-    import torch
-
-    v = t.float()
-    sign = (v < 0).to(torch.uint8)
-    a = v.abs()
-    ord_ = torch.searchsorted(
-        _e2m1_bounds(v.device), a.contiguous(), out_int32=True).to(torch.uint8)
-    tie = ((a == 0.75) | (a == 1.75) | (a == 2.5)).to(torch.uint8)
-    return (sign << 3) + ord_ + tie
-
-
-def pack_e2m1(codes: Any) -> Any:
-    """[..., K] nibble codes -> [..., K/2] packed uint8 (element 2j in the
-    LOW nibble — torch.float4_e2m1fn_x2 / modelopt convention). Explicitly
-    contiguous: cuBLASLt refuses strided fp4 operands
-    (CUBLAS_STATUS_NOT_SUPPORTED, found live on B200), and TensorIterator
-    may propagate the slice strides into the packed output."""
-    return ((codes[..., 1::2] << 4) | codes[..., 0::2]).contiguous()
-
-
-def unpack_e2m1(packed: Any) -> Any:
-    """[..., K/2] packed uint8 -> [..., K] float32 e2m1 values."""
-    import torch
-
-    lut = _e2m1_lut(packed.device)
-    shape = list(packed.shape)
-    shape[-1] = shape[-1] * 2
-    out = torch.empty(shape, dtype=torch.float32, device=packed.device)
-    out[..., 0::2] = lut[(packed & 0x0F).long()]
-    out[..., 1::2] = lut[(packed >> 4).long()]
-    return out
-
-
-def to_blocked_scales(scales: Any) -> Any:
-    """Flat per-block scales [rows, k_blocks] (e4m3) -> the cuBLAS 2-D tiled
-    layout torch's blockwise scaled_mm consumes: rows padded to 128, block
-    columns padded to 4, 128x4 tiles rearranged (32, 4, 4) — returned as a
-    contiguous 1-D e4m3 tensor (the kernel checks numel + contiguity only).
-    Same rearrangement as modelopt's swizzle_nvfp4_scales / torchao's
-    to_blocked."""
-    import torch
-
-    rows, cols = scales.shape
-    nrb = (rows + 127) // 128
-    ncb = (cols + 3) // 4
-    # fp8 has no pad/zeros kernels everywhere — swizzle a uint8 view.
-    raw = scales.view(torch.uint8)
-    padded = raw.new_zeros(nrb * 128, ncb * 4)
-    padded[:rows, :cols] = raw
-    blocks = padded.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    out = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1)
-    return out.contiguous().view(torch.float8_e4m3fn)
 
 
 def quantize_nvfp4_tensor(w: Any) -> tuple[Any, Any, Any]:
@@ -407,6 +344,9 @@ def w4a4_gemm_mode() -> str:
     except Exception as exc:  # noqa: BLE001 — bench failure => dequant lane
         logger.warning("w4a4: qualification failed (%s); dequant lane", exc)
         return ""
+    # Decide the activation quantizer HERE, at load: registering the fused
+    # kernel's custom op must never happen mid-trace under torch.compile.
+    nvfp4_quantizer_mode()
     return "blockwise"
 
 
@@ -424,13 +364,12 @@ def _build_module_class() -> type:
 
         Per call: optional AWQ-lite smoothing (``x *= pre_quant_scale``),
         per-tensor activation second-level scale (static ``input_scale``
-        from calibration, else dynamic amax/(6*448)), dynamic per-16-block
-        e4m3 scales, e2m1 cast + nibble pack, blockwise ``torch._scaled_mm``
-        (weight scales pre-swizzled at load, activation scales swizzled per
-        call), then the fp32 second-level epilogue ``y *= s2_act * s2_w``
-        and bias. The quantize/pack ops fuse under inductor — the win lives
-        in the compiled lane (gw#534's lesson holds one tier down). NOTE:
-        never ``.to(dtype=...)`` this module (device moves are fine)."""
+        from calibration, else dynamic amax/(6*448)), then ONE fused pass
+        (:func:`~.nvfp4_quant.quantize_activation`) for the per-16-block e4m3
+        scales + e2m1 cast + nibble pack + blocked-layout scale store,
+        blockwise ``torch._scaled_mm`` (weight scales pre-swizzled at load),
+        then the fp32 second-level epilogue ``y *= s2_act * s2_w`` and bias.
+        NOTE: never ``.to(dtype=...)`` this module (device moves are fine)."""
 
         weight: Any        # uint8 [out, in/2] packed e2m1 pairs
         weight_scale: Any  # e4m3 1-D, cuBLAS blocked layout (swizzled at load)
@@ -484,16 +423,12 @@ def _build_module_class() -> type:
             else:
                 s2 = (x2.abs().amax().float()
                       / (_E2M1_MAX * _FP8_MAX)).clamp(min=1e-12)
-            xb = x2.reshape(-1, self.in_features // _BLOCK, _BLOCK).float()
-            bmax = xb.abs().amax(dim=-1)
-            sa = (bmax / (_E2M1_MAX * s2)).clamp(
-                min=_SCALE_MIN, max=_FP8_MAX).to(torch.float8_e4m3fn)
-            q = xb / (sa.float().unsqueeze(-1) * s2)
-            codes = cast_e2m1(q.reshape(-1, self.in_features))
-            xq = pack_e2m1(codes)
+            # One fused triton pass (amax -> e4m3 scale -> e2m1 cast -> nibble
+            # pack -> blocked-layout scale store) when it armed for this
+            # device, else the bit-identical pure-torch chain.
+            xq, sa_blocked = quantize_activation(x2, s2)
             y = _gemm_w4a4(
-                xq, self.weight, to_blocked_scales(sa), self.weight_scale,
-                x.dtype)
+                xq, self.weight, sa_blocked, self.weight_scale, x.dtype)
             y = y * (s2 * self.weight_scale_2.reshape(())).to(y.dtype)
             if self.bias is not None:
                 y = y + self.bias
@@ -919,7 +854,9 @@ __all__ = [
     "load_w4a4_denoiser",
     "load_w4a4_pipeline",
     "load_w4a4_root_pipeline",
+    "nvfp4_quantizer_mode",
     "pack_e2m1",
+    "quantize_activation",
     "quantize_nvfp4_tensor",
     "quantize_tree_w4a4",
     "sanitize_w4a4_state_dict",

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -950,6 +950,32 @@ def apply_branch_adapter_set(
     return stats
 
 
+def effective_base_lane(pipe: Any) -> str:
+    """The branchless base weight lane CELL IDENTITY rides on — the ONE
+    resolution :func:`stamp_lane` memoizes: the memoized base, else the
+    pipeline's stamped/probed lane, else the denoiser's own lane markers
+    (:func:`branch_lane`), which see the w8a8 GEMM mode
+    (``_cozy_w8a8_mode``) that ``loading.pipeline_weight_lane`` cannot.
+
+    pgw#686: the advertised requested cell key and the minted/published cell
+    key MUST resolve the base lane identically — when they don't, the
+    published cell is never requested by any worker, adoption is
+    structurally impossible, and every cold pod re-mints (the ie#546 burst
+    stampede: requested ``""``/``"fp8-hooks"`` vs published ``"w8a8"``,
+    every other axis digest-identical)."""
+    base = getattr(pipe, "_cozy_lora_base_lane", None)
+    if base is not None:
+        return str(base)
+    from .loading import pipeline_weight_lane
+
+    lane = pipeline_weight_lane(pipe)
+    if lane:
+        return lane
+    for model in branch_targets(pipe).values():
+        return branch_lane(model)
+    return ""
+
+
 def stamp_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
     """Keep the compile-cache graph key honest: branch-bearing pipelines are
     a different graph family per (base lane, bucket) — lane_drift guards
@@ -967,12 +993,9 @@ def stamp_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
     sparse = any(bool(getattr(m, _SPARSE_ATTR, False)) for m in models)
     base = getattr(pipe, "_cozy_lora_base_lane", None)
     if base is None:
-        from .loading import pipeline_weight_lane
-
-        # The loader stamps _cozy_weight_lane on real pipelines; the
-        # denoiser's own lane markers are the fallback authority.
-        base = pipeline_weight_lane(pipe) or (
-            branch_lane(models[0]) if models else "")
+        # One brain (pgw#686): the same resolution the advertised requested
+        # key uses, so the stamped/published key can never diverge from it.
+        base = effective_base_lane(pipe)
         try:
             pipe._cozy_lora_base_lane = base
         except Exception:

--- a/src/gen_worker/stage_timing.py
+++ b/src/gen_worker/stage_timing.py
@@ -302,8 +302,11 @@ def _clipped(
 
 
 #: Stages recorded OUTSIDE the handler window: reported, never part of the
-#: ``runtime_ms`` reconciliation.
-PRE_HANDLER_STAGES = frozenset({"gpu_permit_wait", "input_fetch", "setup_wait"})
+#: ``runtime_ms`` reconciliation. ``instance_gate_wait`` is pgw#677's
+#: attribution of time queued behind the per-instance gate (typically a
+#: background mint/compile turn) — deliberately outside ``runtime_ms``.
+PRE_HANDLER_STAGES = frozenset(
+    {"gpu_permit_wait", "input_fetch", "setup_wait", "instance_gate_wait"})
 
 
 def reconciliation(stage_ms: Mapping[str, int]) -> Tuple[int, int]:

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -1,0 +1,202 @@
+"""pgw#686: requested cell key and published cell key must resolve the base
+lane identically, or a published cell is never requested by ANY worker and
+every cold pod re-mints — the ie#546 16-checkpoint burst stampede (10 pods,
+9 simultaneous mints, 0 adoptions, 1,608 hub `cell not attached` resolves).
+
+The constants below are the LIVE burst evidence, byte-exact (hub
+`cozyhub-e2e112-34f3e64fe2`, sdxl release `b266454e92a9000c4c0c13f4`,
+gen-worker 0.67.1, L4/sm_89, 2026-07-26):
+
+* the two keys every worker ADVERTISED (and the hub tried to resolve 974x
+  each, `status=tag_not_found`) come from the speculative/probed base lanes
+  ``""`` and ``"fp8-hooks"``;
+* the ONE key both L4 workers PUBLISHED (`cell_store` row, obligation
+  discharged) is the same identity on the ``"w8a8"`` base lane — the lane
+  `w8a8_lora.branch_lane` sees on the denoiser (`_cozy_w8a8_mode`) but
+  `loading.pipeline_weight_lane` cannot.
+
+Every other axis is identical — proven by reproducing all three digests from
+one axes dict varying ONLY the lane.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator
+
+import pytest
+
+from gen_worker import cell_key as ck
+from gen_worker import compile_cache as cc
+from gen_worker.models import w8a8_lora
+
+# --- the burst's recorded artifact metadata (cell_store checkpoint
+# 9167d89b..., trimmed to the axes from_artifact_metadata consumes) ---------
+
+_SHAPE_CONTRACT: Dict[str, Any] = {
+    "v": 3,
+    "shapes": [
+        [640, 1536], [768, 1344], [832, 1216], [896, 1152], [1024, 1024],
+        [1152, 896], [1216, 832], [1344, 768], [1536, 640],
+    ],
+    "dynamic": [],
+    "targets": ["unet"],
+    "guidance": [0.0, 5.0],
+    "regional": False,
+    "lora_bucket": 64,
+    "text_lens": [77],
+}
+
+_IMAGE_DIGEST = (
+    "sha256:3f02f1051c572597fda3626b0ad85d284a5c1f945847b354b449d96bcb499071"
+)
+
+_BURST_META: Dict[str, Any] = {
+    "format": 2,
+    "kind": "torch-inductor-cache",
+    "family": "sdxl",
+    "weight_lane": "w8a8-lora64",
+    "lora_bucket": 64,
+    "compile_mode": "whole",
+    "sku": "l4",
+    "sm": "sm_89",
+    "cuda": "13.0",
+    "torch": "2.13.0+cu130",
+    "triton": "3.7.1",
+    "gen_worker": "0.67.1",
+    "image_digest": _IMAGE_DIGEST,
+    "libs": {"diffusers": "0.39.0", "transformers": "5.13.1"},
+    "shape_contract": _SHAPE_CONTRACT,
+}
+
+# What the hub saw, verbatim.
+PUBLISHED = "ck2-30b872ea452a3447ac368d0108de302c087b0a3b4b244ebeac10f15f"
+REQUESTED_PLAIN = (
+    "ck2-1688dc35245507a65d1a0fd2087adaae35f5885d5a71f05144a80710")
+REQUESTED_FP8_HOOKS = (
+    "ck2-3156506b08a75f15202355242f7509abd409cfaabdd9467391ffe815")
+
+_RT = {
+    "sku": "l4", "sm": "sm_89", "cuda": "13.0", "cuda_driver": "13000",
+    "torch": "2.13.0+cu130", "triton": "3.7.1",
+    "image_digest": _IMAGE_DIGEST,
+}
+
+
+@pytest.fixture()
+def burst_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin every probe to the burst pod's recorded axes."""
+    monkeypatch.setattr(cc, "runtime_key", lambda: dict(_RT))
+    monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.67.1")
+    monkeypatch.setattr(
+        cc, "_lib_versions",
+        lambda: {"diffusers": "0.39.0", "transformers": "5.13.1"})
+    monkeypatch.setenv("WORKER_IMAGE_DIGEST", _IMAGE_DIGEST)
+
+
+def _requested(weight_lane: str) -> str:
+    return ck.compute(
+        "sdxl", weight_lane, 64,
+        contract=ck.contract_digest(_SHAPE_CONTRACT),
+        regional=False,
+    ).digest
+
+
+class _Denoiser:
+    """A denoiser on the w8a8 GEMM lane, as the fp8-w8a8 flavor loader
+    leaves it (`_cozy_w8a8_mode`), with no pipeline-level lane stamp."""
+
+    _cozy_w8a8_mode = "pertensor"
+    _cozy_fp8_storage_applied: bool
+
+    def named_modules(self) -> Iterator[Any]:  # branch-capable duck
+        return iter(())
+
+
+class _Pipe:
+    # Dynamic lane markers real pipelines carry (declared for mypy).
+    _cozy_weight_lane: str
+    _cozy_lora_base_lane: str
+
+    def __init__(self) -> None:
+        self.unet = _Denoiser()
+
+
+# --- the defect, reproduced from the live evidence -------------------------
+
+
+def test_burst_divergence_reproduced_byte_exact(burst_runtime: None) -> None:
+    """All three observed keys are ONE identity varying only the lane axis:
+    the advertised lanes name keys nobody publishes; the published lane
+    names a key nobody advertises. Adoption was structurally impossible."""
+    assert ck.from_artifact_metadata(_BURST_META).digest == PUBLISHED
+    assert _requested("") == REQUESTED_PLAIN
+    assert _requested("fp8-hooks") == REQUESTED_FP8_HOOKS
+    assert _requested("w8a8") == PUBLISHED
+    assert _requested("w8a8-lora64") == PUBLISHED  # canonical-lane fold
+
+
+def test_raw_pipeline_probe_is_blind_to_w8a8_mode(burst_runtime: None) -> None:
+    """The mechanism: loading.pipeline_weight_lane cannot see the denoiser's
+    w8a8 GEMM mode, so a key computed from it can never equal the key the
+    mint stamps (stamp_lane's branch_lane fallback sees it)."""
+    from gen_worker.models.loading import pipeline_weight_lane
+
+    pipe = _Pipe()
+    assert pipeline_weight_lane(pipe) == ""
+    assert w8a8_lora.branch_lane(pipe.unet) == "w8a8"
+    # The pre-fix advertised key IS the burst's never-published key.
+    assert _requested(pipeline_weight_lane(pipe)) == REQUESTED_PLAIN
+
+
+# --- the fix: one base-lane resolution for every cell-identity surface -----
+
+
+def test_cell_base_lane_sees_w8a8_mode(burst_runtime: None) -> None:
+    pipe = _Pipe()
+    assert w8a8_lora.effective_base_lane(pipe) == "w8a8"
+    assert cc.cell_base_lane(pipe) == "w8a8"
+    # An identical worker now requests exactly the key the mint published.
+    assert _requested(cc.cell_base_lane(pipe)) == PUBLISHED
+
+
+def test_cell_base_lane_precedence() -> None:
+    # Explicit pipeline stamp wins.
+    pipe = _Pipe()
+    pipe._cozy_weight_lane = "w8a8-lora64"
+    assert cc.cell_base_lane(pipe) == "w8a8-lora64"
+    # fp8-hooks marker (w8a16 storage lane) wins over the denoiser fallback.
+    pipe2 = _Pipe()
+    pipe2.unet._cozy_fp8_storage_applied = True
+    assert cc.cell_base_lane(pipe2) == "fp8-hooks"
+    # Plain pipeline stays plain.
+    class _PlainDenoiser:
+        def named_modules(self) -> Iterator[Any]:
+            return iter(())
+
+    class _PlainPipe:
+        def __init__(self) -> None:
+            self.unet = _PlainDenoiser()
+
+    assert cc.cell_base_lane(_PlainPipe()) == ""
+
+
+def test_stamp_lane_memoizes_the_same_base() -> None:
+    """Parity by construction: the base stamp_lane memoizes at mint time is
+    exactly what effective_base_lane resolved before the mint — so the
+    requested key (advertise) and the stamped key (publish) share one lane."""
+    pipe = _Pipe()
+    expected = w8a8_lora.effective_base_lane(pipe)
+    w8a8_lora.stamp_lane(pipe, {"unet": pipe.unet})
+    assert pipe._cozy_lora_base_lane == expected == "w8a8"
+    # bucket 0 on the stub: the stamp restores the branchless base lane.
+    assert pipe._cozy_weight_lane == "w8a8"
+
+
+def test_lookup_speculation_covers_the_w8a8_lane() -> None:
+    """Pre-load pull-by-key speculation must include the w8a8 base lane, or
+    a cold worker can never pull the very cell its own boot will mint."""
+    from gen_worker import executor
+
+    assert "w8a8" in executor._SPECULATIVE_CELL_BASE_LANES
+    assert "" in executor._SPECULATIVE_CELL_BASE_LANES
+    assert "fp8-hooks" in executor._SPECULATIVE_CELL_BASE_LANES

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -1,0 +1,556 @@
+"""pgw#677: the background mint yields the GPU to tenant work.
+
+Doctrine under test — tenant requests ALWAYS win the GPU immediately;
+mint work yields:
+
+  1. STARVATION SHAPE (the live incident): during a background mint,
+     tenant requests complete at serving latency. RED-verified via the
+     GEN_WORKER_BG_YIELD=0 kill switch, which restores the pre-fix tree:
+     mint seed units inline-compile while holding the per-instance run
+     gate (the router's headroom degrade), so a tenant request queues for
+     the length of the unit — the measured "completions land exactly as
+     mint units free the gate / 0 renders in 19 min" shape.
+  2. RACE EXCLUSION (the pgw#676 SIGSEGV class): the shape-warm thread's
+     compile can never execute the shared modules concurrently with a
+     tenant forward. Post-fix the compile owns a background turn
+     (single-flight, instance turn_mutex, tenant-quiet admission); the
+     tenant that arrives mid-compile waits — bounded by ONE compile — and
+     its wait is attributed to `instance_gate_wait`, never to runtime_ms.
+     RED-verified: with the kill switch the overlap is observed.
+  3. MINIMUM PROGRESS: under a sustained tenant stream the mint still
+     finishes — the steal rule grants one bounded background unit per
+     debt window; stolen units are not preemptible.
+  4. SEED UNITS NEVER COMPILE INLINE: inside the mint seed window a novel
+     signature routes EAGER + background enqueue even on a degraded
+     router — every real compile lands on the shape-warm thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+from pathlib import Path
+from typing import Annotated, Any, Dict, List, Tuple
+
+import msgspec
+import pytest
+
+import gen_worker
+import gen_worker.executor as executor_mod
+from gen_worker import (
+    AxisClass,
+    Compile,
+    CompileAxis,
+    RequestContext,
+    Resources,
+    endpoint,
+    worker_function,
+)
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells, guard_closure, hot_swap
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+FAMILY = "sdxl"
+_ASPECT_AXIS = CompileAxis(classes=(
+    AxisClass("sq", match=lambda v: v == "1:1", warm="1:1"),
+    AxisClass("wide", match=lambda v: v == "16:9", warm="16:9"),
+))
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    aspect_ratio: Annotated[str, _ASPECT_AXIS] = "1:1"
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _Denoiser:
+    def forward(self, aspect: str) -> str:
+        return aspect
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.transformer = _Denoiser()
+
+
+@pytest.fixture(autouse=True)
+def _clean_process_registries() -> Any:
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+    yield
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+
+
+@pytest.fixture(autouse=True)
+def _fast_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Compress the gate's wall-clock constants for test speed; individual
+    tapes override where the specific rule is under test."""
+    monkeypatch.setattr(executor_mod, "_BG_COMPILE_QUIESCENCE_S", 0.05)
+    monkeypatch.setattr(executor_mod, "_MINT_POLL_INTERVAL_S", 0.05)
+
+
+class _Harness:
+    """Eager-first boot over the real executor codepath, plus a REAL
+    handle_run_job tenant lane and an instrumented compile leaf that
+    records execution intervals + the executing thread."""
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        compile_delay_s: float = 0.0,
+        seed_forward_s: float = 0.0,
+        tenant_forward_s: float = 0.02,
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.compile_delay_s = compile_delay_s
+        self.seed_forward_s = seed_forward_s
+        self.tenant_forward_s = tenant_forward_s
+        # (label, thread_name, start, end) per novel-signature compile.
+        self.compiles: List[Tuple[str, str, float, float]] = []
+        self.in_compile = threading.Event()
+        # True whenever a tenant forward observed a live compile (the
+        # pgw#676 race shape). Must stay empty post-fix.
+        self.overlaps: List[str] = []
+        self.tenant_windows: List[Tuple[float, float]] = []
+        self.seed_runs: List[str] = []
+        self.sent: List[pb.WorkerMessage] = []
+        self.pipes: List[_Pipe] = []
+        harness = self
+
+        @endpoint(
+            model=Hub("acme/sdxl-base"),
+            resources=Resources(gpu=True),
+            compile=Compile(family=FAMILY, shapes=((768, 768),), text_len=0),
+        )
+        class MintEndpoint:
+            def setup(self, model: str) -> None:
+                self.pipe = _Pipe()
+                harness.pipes.append(self.pipe)
+                gen_worker.arm_compile(self.pipe)
+
+            @worker_function()
+            def generate(self, ctx: RequestContext, payload: _In) -> _Out:
+                if ctx.boot_warmup:
+                    harness.seed_runs.append(payload.aspect_ratio)
+                    deadline = time.monotonic() + harness.seed_forward_s
+                    while time.monotonic() < deadline:
+                        time.sleep(0.005)
+                        ctx.raise_if_cancelled("seed preempted")
+                    self.pipe.transformer.forward(payload.aspect_ratio)
+                    return _Out()
+                t0 = time.monotonic()
+                if harness.in_compile.is_set():
+                    harness.overlaps.append("tenant-entered-during-compile")
+                self.pipe.transformer.forward(payload.aspect_ratio)
+                deadline = time.monotonic() + harness.tenant_forward_s
+                while time.monotonic() < deadline:
+                    if harness.in_compile.is_set():
+                        harness.overlaps.append("compile-during-tenant")
+                    time.sleep(0.002)
+                harness.tenant_windows.append((t0, time.monotonic()))
+                return _Out()
+
+        self.cls = MintEndpoint
+        self.specs = extract_specs(MintEndpoint)
+        (self.spec,) = [s for s in self.specs if s.name == "generate"]
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        store = ModelStore(
+            _send, cache_dir=tmp_path / "cas", vram_budget_bytes=4 << 30)
+
+        async def _fake_ensure_local(ref: str, **kwargs: Any) -> Path:
+            p = tmp_path / "snap"
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+
+        monkeypatch.setattr(executor_mod, "ensure_local", _fake_ensure_local)
+        monkeypatch.setattr(
+            fleet_cells, "enable_compiled", self._fake_enable_compiled)
+        monkeypatch.setattr(
+            guard_closure, "assert_closure",
+            lambda pipe, cfg, label="": {
+                "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                    "entry": 0, "guards": []}],
+                "verdicts": {}, "leaks": []})
+        self.ex = Executor(self.specs, _send, store=store)
+
+    # -- the compile-arm leaf ------------------------------------------------
+
+    def _fake_enable_compiled(
+        self, pipe: Any, cfg: Any, cache_dir: Any = None,
+        artifact: Any = None, publisher: Any = None,
+    ) -> fleet_cells.ArmOutcome:
+        mint_root = self.tmp_path / f"mint-{id(pipe)}"
+        capture = mint_root / "capture"
+        (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
+        pending = fleet_cells.PendingSelfMint(
+            family=FAMILY, cell_key="ck2-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck2-{'a' * 56}",
+            cfg=cfg, target=mint_root / "cell.tar.gz",
+            capture_dir=capture, mint_root=mint_root,
+            publisher=None, cache_dir=cache_dir,
+        )
+        original = pipe.transformer.forward
+        harness = self
+
+        seen_sigs: set = set()
+        seen_lock = threading.Lock()
+
+        def compiled(*args: Any, **kwargs: Any) -> Any:
+            sig = hot_swap.signature(args, kwargs)
+            with seen_lock:
+                novel = sig not in seen_sigs
+                seen_sigs.add(sig)
+            if novel:
+                start = time.monotonic()
+                harness.in_compile.set()
+                try:
+                    time.sleep(harness.compile_delay_s)
+                    (capture / "inductor" / "fxgraph"
+                     / f"g{len(harness.compiles)}.bin").write_bytes(b"graph")
+                finally:
+                    harness.in_compile.clear()
+                harness.compiles.append((
+                    str(sig[0]), threading.current_thread().name,
+                    start, time.monotonic()))
+            return original(*args, **kwargs)
+
+        signal: Dict[str, Any] = {
+            "callback": None,
+            "lock": threading.Lock(),
+            "successful_calls": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "router": hot_swap.Router(),
+        }
+        setattr(pipe, cc._MARKER_ATTR, {
+            "targets": ["transformer"],
+            "shapes": tuple(cfg.shapes),
+            "cache": True,
+            "originals": [(pipe.transformer, "forward", original)],
+            "regional_mods": [],
+            "failure_signal": signal,
+        })
+        pipe.transformer.forward = cc._guarded(
+            original, compiled, "transformer", failure_signal=signal)
+        cc._armed_pipelines().add(pipe)
+        return fleet_cells.ArmOutcome(armed=True, self_mint=pending)
+
+    # -- drive ---------------------------------------------------------------
+
+    async def boot(self) -> Any:
+        return await self.ex.ensure_setup(self.spec, {
+            wire_ref(self.spec.models["model"]): pb.Snapshot(
+                digest="blake3:" + "a" * 64),
+        })
+
+    @property
+    def rec(self) -> Any:
+        return self.ex._classes[self.spec.instance_key]
+
+    async def wait_mint(self, timeout: float = 60.0) -> None:
+        bg = self.rec.background_mint
+        if bg is None or bg.task is None:
+            return
+        await asyncio.wait_for(asyncio.shield(bg.task), timeout)
+
+    def _run_job(self, request_id: str, aspect: str = "1:1") -> pb.RunJob:
+        model_ref = wire_ref(self.spec.models["model"])
+        return pb.RunJob(
+            request_id=request_id, attempt=1,
+            function_name=self.spec.name,
+            input_payload=msgspec.msgpack.encode(
+                _In(prompt="a cat", aspect_ratio=aspect)),
+            models=[pb.ModelBinding(slot="model", ref=model_ref)],
+            snapshots={model_ref: pb.Snapshot(digest="blake3:" + "a" * 64)},
+        )
+
+    async def dispatch(
+        self, request_id: str, aspect: str = "1:1",
+    ) -> Tuple[pb.JobResult, float]:
+        """One REAL tenant request through handle_run_job; returns the
+        terminal result and the wall time from admission to completion."""
+        run = self._run_job(request_id, aspect)
+        t0 = time.monotonic()
+        await self.ex.handle_run_job(run)
+        job = self.ex.jobs[(run.request_id, run.attempt)]
+        assert job.task is not None
+        await job.task
+        wall = time.monotonic() - t0
+        results = [m.job_result for m in self.sent
+                   if m.WhichOneof("msg") == "job_result"
+                   and m.job_result.request_id == request_id]
+        assert results, f"no job_result for {request_id}"
+        return results[-1], wall
+
+
+def _stage_ms(res: pb.JobResult, name: str) -> int:
+    return int(res.metrics.stage_ms.get(name, 0))
+
+
+# ---------------------------------------------------------------------------
+# 1 + 4 — the starvation shape, red-verified via the kill switch
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_serves_at_serving_latency_during_mint_and_red_verifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-fix: tenant requests dispatched DURING the background mint
+    complete at serving latency (preempting the in-flight seed), no seed
+    ever inline-compiles, and every real compile lands on the shape-warm
+    thread. RED: the kill switch restores the pre-fix tree and the same
+    tenant request queues behind a minutes-scale (here: seconds-scale)
+    inline-compiling mint unit — the live 19s-for-2s collapse shape."""
+    # Degraded router everywhere: pre-fix this forces COMPILED (inline)
+    # verdicts; post-fix seeds force EAGER and the warm thread ensures
+    # headroom inside its exclusive turn instead.
+    monkeypatch.setattr(hot_swap, "_headroom_ok", lambda device: False)
+
+    # --- RED: pre-fix tree via the kill switch ---------------------------
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "0")
+    h_off = _Harness(
+        tmp_path / "off", monkeypatch,
+        compile_delay_s=0.15, seed_forward_s=0.6, tenant_forward_s=0.02)
+
+    async def _off() -> Tuple[float, pb.JobResult]:
+        await h_off.boot()
+        assert h_off.rec.background_mint is not None
+        # Wait until a BACKGROUND mint seed unit is in flight, holding the
+        # run gate (the boot's foreground eager pass contributed run #1).
+        deadline = time.monotonic() + 10.0
+        while len(h_off.seed_runs) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert len(h_off.seed_runs) >= 2, "mint never started seeding"
+        res, wall = await h_off.dispatch("r-red", aspect="16:9")
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+        return wall, res
+
+    wall_off, _res_off = asyncio.run(_off())
+    # The collapse shape: the request queued behind the seed unit's
+    # inline compile (and then paid its own inline compile on the
+    # degraded router) — an order of magnitude over serving latency.
+    assert wall_off >= 0.5, (
+        f"expected the pre-fix starvation shape, got {wall_off:.3f}s")
+    # Pre-fix, inline compiles ran on handler (to_thread) workers.
+    assert any(
+        "shape-warm" not in thread for _, thread, _, _ in h_off.compiles), (
+        "pre-fix tree should compile inline off the warm thread")
+
+    # --- POST-FIX ---------------------------------------------------------
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h_on = _Harness(
+        tmp_path / "on", monkeypatch,
+        compile_delay_s=0.15, seed_forward_s=0.6, tenant_forward_s=0.02)
+
+    async def _on() -> None:
+        await h_on.boot()
+        bg = h_on.rec.background_mint
+        assert bg is not None
+        # Wait until a PREEMPTIBLE background seed unit holds the gate.
+        deadline = time.monotonic() + 10.0
+        while bg.seed_ctx is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.005)
+        assert bg.seed_ctx is not None, "no preemptible seed in flight"
+        # A stream of tenant requests lands mid-mint; each must complete
+        # at serving latency — a fraction of one pre-fix unit — by
+        # preempting idle-granted seed units cooperatively (the only
+        # bounded residual is one short warm-thread compile).
+        walls: List[float] = []
+        for i in range(4):
+            res, wall = await h_on.dispatch(f"r-{i}", aspect="16:9")
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            walls.append(wall)
+        assert max(walls) < 0.45, (
+            f"tenant latencies not at serving levels during mint: {walls}")
+        # runtime_ms never absorbs gate contention: the handler runs
+        # ~tenant_forward_s, so reported runtime stays near it.
+        results = [m.job_result for m in h_on.sent
+                   if m.WhichOneof("msg") == "job_result"]
+        assert results
+        assert all(r.metrics.runtime_ms < 300 for r in results)
+        # The mint still finishes once the stream drains.
+        await h_on.wait_mint()
+        assert h_on.ex.serving_tiers() == {"generate": "compiled"}
+        # pgw#677 seed contract: every real compile ran on the shape-warm
+        # thread inside a granted turn — no seed unit compiled inline.
+        assert h_on.compiles
+        assert all(
+            "shape-warm" in thread for _, thread, _, _ in h_on.compiles), (
+            h_on.compiles)
+
+    asyncio.run(_on())
+
+
+# ---------------------------------------------------------------------------
+# 2 — the pgw#676 race shape cannot happen; the bounded wait is attributed
+# ---------------------------------------------------------------------------
+
+
+def test_compile_and_tenant_forward_never_overlap_and_red_verifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-fix: a tenant arriving while the shape-warm thread compiles
+    WAITS (bounded by that one compile) — the concurrent execution that
+    segfaulted sm_86 (pgw#676: _forward_with_branch racing compile_wrapper)
+    is structurally impossible — and the wait is attributed to the
+    instance_gate_wait stage, not billed as runtime. RED: with the kill
+    switch the overlap is observed."""
+
+    # --- RED: pre-fix tree — overlap happens -----------------------------
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "0")
+    h_off = _Harness(
+        tmp_path / "off", monkeypatch,
+        compile_delay_s=0.8, seed_forward_s=0.0, tenant_forward_s=0.05)
+
+    async def _off() -> None:
+        await h_off.boot()
+        deadline = time.monotonic() + 10.0
+        while not h_off.in_compile.is_set():
+            assert time.monotonic() < deadline, "no background compile ran"
+            await asyncio.sleep(0.005)
+        res, _wall = await h_off.dispatch("r-race", aspect="1:1")
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+
+    asyncio.run(_off())
+    assert h_off.overlaps, (
+        "pre-fix tree must exhibit the pgw#676 overlap (tenant forward "
+        "concurrent with the warm thread's compile)")
+
+    # --- POST-FIX: exclusion holds, wait is attributed -------------------
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h_on = _Harness(
+        tmp_path / "on", monkeypatch,
+        compile_delay_s=0.8, seed_forward_s=0.0, tenant_forward_s=0.05)
+
+    async def _on() -> None:
+        await h_on.boot()
+        deadline = time.monotonic() + 10.0
+        while not h_on.in_compile.is_set():
+            assert time.monotonic() < deadline, "no background compile ran"
+            await asyncio.sleep(0.005)
+        res, wall = await h_on.dispatch("r-safe", aspect="1:1")
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+        # It waited for the in-flight compile (bounded by ONE unit)...
+        assert wall >= 0.1
+        # ...the wait is attributed, and runtime_ms excludes it.
+        assert _stage_ms(res, "instance_gate_wait") >= 100
+        assert res.metrics.runtime_ms < 400
+        await h_on.wait_mint()
+
+    asyncio.run(_on())
+    assert not h_on.overlaps, h_on.overlaps
+
+
+# ---------------------------------------------------------------------------
+# 3 — minimum progress: the mint finishes under a sustained tenant stream
+# ---------------------------------------------------------------------------
+
+
+def test_mint_completes_under_sustained_tenant_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tenant stream that never drains would starve a purely idle-gated
+    mint forever. The steal rule grants one bounded background unit per
+    debt window: the mint completes while the stream keeps serving."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    monkeypatch.setattr(executor_mod, "_BG_STEAL_FLOOR_S", 0.1)
+    monkeypatch.setattr(executor_mod, "_BG_STEAL_DEBT_FACTOR", 1.0)
+    monkeypatch.setattr(executor_mod, "_BG_COMPILE_QUIESCENCE_S", 0.0)
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=0.05, seed_forward_s=0.05, tenant_forward_s=0.02)
+
+    async def _run() -> None:
+        await h.boot()
+        bg = h.rec.background_mint
+        assert bg is not None and bg.task is not None
+        stop = asyncio.Event()
+        served = 0
+
+        async def _stream() -> None:
+            nonlocal served
+            i = 0
+            while not stop.is_set():
+                res, _wall = await h.dispatch(f"r-load-{i}", aspect="16:9")
+                assert res.status == pb.JOB_STATUS_OK, res.safe_message
+                served += 1
+                i += 1
+
+        stream = asyncio.create_task(_stream())
+        try:
+            await asyncio.wait_for(asyncio.shield(bg.task), timeout=60.0)
+        finally:
+            stop.set()
+            await stream
+        assert h.ex.serving_tiers() == {"generate": "compiled"}
+        # The stream really was sustained while the mint progressed.
+        assert served >= 5
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 4 — the seed-window routing contract, pinned at the Router
+# ---------------------------------------------------------------------------
+
+
+def test_mint_seed_window_forces_eager_enqueue_on_degraded_routers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside the mint seed window a novel signature NEVER compiles inline:
+    EAGER + background enqueue even when the router is non-concurrent or
+    (turn-gated) short on headroom. Outside the window the legacy verdicts
+    stand."""
+    router = hot_swap.Router()
+
+    def compiled(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    # Non-concurrent router (never enabled): ordinary calls keep the
+    # sequential inline compile...
+    verdict, _sig = router.route("t", compiled, ("a",), {})
+    assert verdict == hot_swap.COMPILED
+    # ...a mint seed forces eager + enqueue.
+    with hot_swap.mint_seed_window():
+        verdict, sig = router.route("t", compiled, ("b",), {})
+    assert verdict == hot_swap.EAGER
+    with router.lock:
+        assert sig in router.pending
+
+    # Turn-gated router with tight headroom: the ordinary call no longer
+    # degrades to an inline compile either — the warm thread owns headroom
+    # inside its exclusive turn.
+    monkeypatch.setattr(hot_swap, "_headroom_ok", lambda device: False)
+    gated = hot_swap.Router()
+    gated.enable()
+    gated.set_turn_gate(lambda kind: contextlib.nullcontext())
+    verdict, sig = gated.route("t", compiled, ("c",), {})
+    assert verdict == hot_swap.EAGER
+    # Ungated legacy router with tight headroom keeps the pre-fix degrade
+    # (kill-switch parity).
+    legacy = hot_swap.Router()
+    legacy.enable()
+    verdict, _sig = legacy.route("t", compiled, ("d",), {})
+    assert verdict == hot_swap.COMPILED

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -457,6 +457,13 @@ def test_compile_and_tenant_forward_never_overlap_and_red_verifies(
         # ...the wait is attributed, and runtime_ms excludes it.
         assert _stage_ms(res, "instance_gate_wait") >= 100
         assert res.metrics.runtime_ms < 400
+        # th#1111 invariant survives the new pre-handler stage: the map
+        # still closes against runtime_ms with a large gate wait present.
+        from gen_worker.stage_timing import reconciliation
+
+        attributed, total = reconciliation(dict(res.metrics.stage_ms))
+        assert total == res.metrics.runtime_ms
+        assert abs(attributed - total) <= 5, dict(res.metrics.stage_ms)
         await h_on.wait_mint()
 
     asyncio.run(_on())

--- a/tests/test_nvfp4_fused_quant_pgw685.py
+++ b/tests/test_nvfp4_fused_quant_pgw685.py
@@ -1,0 +1,164 @@
+"""pgw#685 — the fused triton nvfp4 activation quantizer in the w4a4 lane.
+
+The CPU tests pin the reference chain, the blocked-layout geometry, and the
+fallback contract (no CUDA / no triton => the pure-torch chain still serves).
+The CUDA tests are the ones that matter for the kernel itself: BIT-IDENTITY
+against the reference chain (a tolerance check cannot see the ``div_rn`` class
+of bug — pgw#682 G-A measured a 1-ulp divide drift flipping 0.16% of nibbles
+outright) and survival under ``torch.compile``. They run in the GPU lane.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.models.nvfp4_quant import (  # noqa: E402
+    BLOCK,
+    E2M1_MAX,
+    FP8_MAX,
+    blocked_scale_numel,
+    nvfp4_quantizer_mode,
+    quantize_activation,
+    quantize_activation_torch,
+    to_blocked_scales,
+    unpack_e2m1,
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="needs a CUDA device")
+
+
+def _second_level(x: Any) -> Any:
+    return (x.abs().amax().float() / (E2M1_MAX * FP8_MAX)).clamp(min=1e-12)
+
+
+# --- geometry / reference chain (CPU) --------------------------------------
+
+
+@pytest.mark.parametrize("rows,k_blocks", [
+    (128, 4), (128, 32), (333, 192), (1, 1), (4096, 768), (129, 5)])
+def test_blocked_scale_numel_agrees_with_the_swizzle(rows: int,
+                                                     k_blocks: int) -> None:
+    """The fused kernel allocates its scale buffer from
+    :func:`blocked_scale_numel`; it must match what the pure-torch swizzle
+    produces for the same grid, padding included."""
+    flat = torch.zeros(rows, k_blocks).to(torch.float8_e4m3fn)
+    assert to_blocked_scales(flat).numel() == blocked_scale_numel(rows, k_blocks)
+
+
+def test_reference_chain_shapes_and_dequant_error() -> None:
+    """The reference chain's packed weights + blocked scales round-trip back
+    to the input within e2m1 block-quantization error."""
+    torch.manual_seed(0)
+    m, k = 333, 3072
+    x = torch.randn(m, k, dtype=torch.bfloat16)
+    s2 = _second_level(x)
+    packed, blocked = quantize_activation_torch(x, s2)
+
+    assert packed.shape == (m, k // 2)
+    assert packed.dtype == torch.uint8
+    assert blocked.numel() == blocked_scale_numel(m, k // BLOCK)
+    assert blocked.dtype == torch.float8_e4m3fn
+
+    # Recover per-block scales from the un-swizzled chain to dequantize.
+    xb = x.reshape(-1, k // BLOCK, BLOCK).float()
+    sa = (xb.abs().amax(dim=-1) / (E2M1_MAX * s2)).clamp(
+        min=2.0 ** -9, max=FP8_MAX).to(torch.float8_e4m3fn)
+    deq = (unpack_e2m1(packed).reshape(m, k // BLOCK, BLOCK)
+           * sa.float().unsqueeze(-1) * s2).reshape(m, k)
+    rel = ((deq - x.float()).norm() / x.float().norm()).item()
+    # e2m1 has 3 mantissa levels per binade — ~10% relative is the format's
+    # own floor, not slack in the implementation.
+    assert rel < 0.15, rel
+
+
+def test_low_nibble_holds_the_even_element() -> None:
+    """The packed convention (element 2j in the LOW nibble) is what
+    ``torch.float4_e2m1fn_x2`` and the artifact contract assume; getting it
+    backwards silently transposes every pair."""
+    x = torch.zeros(1, 32)
+    x[0, 0] = 6.0   # even position -> low nibble, code 7
+    x[0, 1] = 0.0   # odd position -> high nibble, code 0
+    packed, _ = quantize_activation_torch(x, torch.tensor(6.0 / (E2M1_MAX * 1.0)))
+    assert int(packed[0, 0]) & 0x0F == 7
+    assert int(packed[0, 0]) >> 4 == 0
+
+
+def test_quantizer_mode_is_torch_without_cuda(monkeypatch) -> None:
+    """No CUDA (CI, CPU boxes) => the reference chain, never a hard failure."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    nvfp4_quantizer_mode.cache_clear()
+    try:
+        assert nvfp4_quantizer_mode() == "torch"
+    finally:
+        nvfp4_quantizer_mode.cache_clear()
+
+
+def test_quantize_activation_dispatches_to_the_reference_chain_on_cpu(
+    monkeypatch,
+) -> None:
+    """The dispatcher's fallback is the reference chain BYTE for byte."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    nvfp4_quantizer_mode.cache_clear()
+    try:
+        torch.manual_seed(0)
+        x = torch.randn(64, 512, dtype=torch.bfloat16)
+        s2 = _second_level(x)
+        got_q, got_s = quantize_activation(x, s2)
+        want_q, want_s = quantize_activation_torch(x, s2)
+        assert torch.equal(got_q, want_q)
+        assert torch.equal(got_s.view(torch.uint8), want_s.view(torch.uint8))
+    finally:
+        nvfp4_quantizer_mode.cache_clear()
+
+
+# --- the fused kernel (CUDA) ----------------------------------------------
+
+
+@requires_cuda
+@pytest.mark.parametrize("m,k", [(128, 512), (333, 3072), (1024, 12288)])
+def test_fused_quantizer_is_bit_identical_to_the_reference_chain(
+    m: int, k: int,
+) -> None:
+    """pgw#682 G-A, as a standing test: packed nibbles AND scale bytes must
+    match exactly. Skipped (not failed) where triton cannot arm."""
+    from gen_worker.models.nvfp4_quant import _build_fused_op
+
+    op = _build_fused_op()
+    if op is None:
+        pytest.skip("triton unavailable — the reference chain serves")
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    s2 = _second_level(x)
+    got_q, got_s = op(x, s2)
+    want_q, want_s = quantize_activation_torch(x, s2)
+    mismatched = int((got_q != want_q).sum())
+    assert mismatched == 0, f"{mismatched}/{want_q.numel()} packed bytes differ"
+    assert torch.equal(got_s.view(torch.uint8), want_s.view(torch.uint8))
+
+
+@requires_cuda
+def test_fused_quantizer_survives_torch_compile() -> None:
+    """The custom op must be traced as an opaque call, not graph-break and not
+    get decomposed — that is the whole reason it is a ``custom_op`` with a
+    ``register_fake`` rather than a raw triton call."""
+    from gen_worker.models.nvfp4_quant import _build_fused_op
+
+    op = _build_fused_op()
+    if op is None:
+        pytest.skip("triton unavailable — the reference chain serves")
+
+    def f(x: Any, s2: Any) -> Any:
+        q, s = quantize_activation(x, s2)
+        return q.int().sum() + s.view(torch.uint8).int().sum()
+
+    torch.manual_seed(0)
+    x = torch.randn(256, 3072, device="cuda", dtype=torch.bfloat16)
+    s2 = _second_level(x)
+    eager = f(x, s2)
+    compiled = torch.compile(f, fullgraph=True)(x, s2)
+    assert torch.equal(eager, compiled)

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.68.1"
+version = "0.69.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.69.0"
+version = "0.70.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
release: gen-worker 0.70.0 — pgw#677 background-turn gate: tenant work always wins the GPU, the mint yields

## What

th#1187 promised "serve at eager speed while the compile mint runs in background". Measured
reality (ie#546 retag cycle): 0 renders in 19 min on a fresh L4 release while the mint's 18
warm units ran; every concurrent request degraded ~8.6x (completions landing exactly as mint
units freed the gate; `compute_ms` 16.9s for 1.95s of real work); and on sm_86 the ungated
warm-thread compile racing a tenant LoRA-branch forward SIGSEGV'd the worker (pgw#676's
confirmed frames).

Root cause — one lock wrong in both directions:
- **Too wide:** a mint seed unit could pay a full inline Dynamo+Inductor compile (3.5-7 min)
  while holding `rec.run_lock` (Router.route degrade paths: the 8GiB `_headroom_ok` floor,
  non-concurrent, dummy failure, `_MAX_SIGS`).
- **Too narrow:** the real graph compiles ran on the shape-warm thread against the same live
  nn.Modules under NO lock at all — the pgw#676 crash and the 8.6x contention.

## Fix

- **Background-turn gate:** mint seed units and shape-warm/heal compiles run only inside a
  granted turn — single-flight with each other, holding GPU permit + `rec.run_lock` + a new
  per-instance `turn_mutex` the tenant path holds across adapter mutation + handler. The
  pgw#676 overlap is structurally impossible; a tenant waits at most ONE bounded unit.
  Loop-free threading primitives, so the warm thread needs no event loop.
- **Tenant preemption:** an admission cooperatively cancels the in-flight idle-granted seed;
  the driver re-queues the unit.
- **Seeds never compile inline:** `hot_swap.mint_seed_window()` forces EAGER + background
  enqueue for novel signatures; the headroom degrade-to-inline-compile is retired for
  turn-gated routers (the warm thread ensures headroom inside its exclusive turn).
- **Minimum progress:** blocked >= `_BG_STEAL_FLOOR_S` of continuous demand steals one turn;
  debt (`4x duration`) caps the stolen duty cycle (~20%) — the mint always finishes under
  sustained tenant load; stolen turns are not preemptible.
- **Honest metrics:** instance-gate contention lands in a new `instance_gate_wait` stage and
  is excluded from `runtime_ms`.
- Kill switch `GEN_WORKER_BG_YIELD=0` restores the pre-fix shape (red-verification only).

## Tapes

`tests/test_mint_gate_pgw677.py` (4, real ensure_setup + handle_run_job codepaths), each
red-verified via the kill switch:
1. tenant stream during a mint stays at serving latency (pre-fix: >=0.5s queued behind an
   inline-compiling unit — the live collapse shape);
2. compile/tenant-forward overlap impossible; the bounded wait is attributed, runtime_ms
   stays honest (pre-fix: overlap observed);
3. mint completes under a sustained never-idle tenant stream (steals);
4. seed-window routing contract at the Router.

Full suite on this branch: 1034 passed / 5 skipped / 1 xfailed (zero failures). mypy clean (151 files), ruff clean. Follow-up folded in: `instance_gate_wait` added to PRE_HANDLER_STAGES so the th#1111 runtime_ms reconciliation still closes (tape asserts it with a ~600ms gate wait present).

## Release

0.70.0 (0.69.0 is pgw#685's chaos-only stamp; monotonic + unique wins). Worker half only —
th#1207 (hub counts a minting worker as spare capacity) stays the hub half.
