### PR TITLE
pgw#689 (P0): the swap benchmark loads what SERVING loads; a broken diagnostic is not a broken release (0.70.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.70.1 (2026-07-26) — pgw#689: the swap benchmark loads what SERVING loads; a broken diagnostic is not a broken release
+
+The SDK's own swap-latency benchmark could not load a QUANTIZED component
+tree — i.e. every flavor the fleet actually serves — so every `load` /
+`demote` / `stage` / `swap` row was unreachable on a real serving pod. It
+owned a second loader (`cls.from_pretrained` per component), and a
+modelopt-produced tree carries a `quantization_config` block diffusers
+rebuilds into `NVIDIAModelOptConfig`, whose constructor requires a
+`quant_type` the block does not supply.
+
+- **One component-load path (`models.loading.load_component`)**: everything
+  that loads a single component now goes through it — the executor's pgw#617
+  substitution, the pgw#674 rotation preloader (`load_component_override` is
+  a wrapper), and the benchmark. Quantized artifacts take their own lane
+  exactly as `load_from_pretrained` routes a whole pipeline; svdq/gguf, which
+  have no component-level loader, refuse by name
+  (`ComponentLaneUnsupported`) rather than measuring something serving never
+  runs.
+- **No more identical-retry `except TypeError`**: it caught any
+  construction-time TypeError (including one from deep inside quant-config
+  reconstruction) and retried a path that failed identically, destroying the
+  evidence. Whether a loader takes `torch_dtype` is now answered by
+  signature inspection.
+- **A diagnostic failure is its own outcome**: `SwapLatencyDiagnostics`
+  returns `status="refused"|"failed"` with the cause on a SUCCEEDING job
+  instead of raising. Raising fed the hub's fast-failure breaker — two
+  invokes tripped `model_load_failure_streak` and recycled a warm pod that
+  had just spent 26 minutes minting. A function that never serves tenant
+  traffic cannot cost a serving pod.
+- **`SwapLatencyInput.checkpoint`/`to` default to `""`**: a family-less
+  `Slot(str)` cannot carry a curated policy, a fixed slot rejects every
+  supplied value, and a required msgspec field cannot be omitted — without
+  the defaults no payload exists that the hub accepts.
+- **Discovery's out-of-package skip is LOUD**: `discovery/walk.py` dropped
+  decorated classes defined outside the walked package at INFO, which is how
+  an SDK diagnostics endpoint, re-exported exactly as its own docstring
+  instructed, vanished from a release silently. Now a WARNING naming the
+  class and the fix — subclass it locally, which is what the docstring says.
+
+
 ## 0.70.0 (2026-07-26) — pgw#677: tenant work always wins the GPU — the background mint yields
 
 th#1187's promise was "serve at eager speed while the compile mint runs in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.0"
+version = "0.70.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/benchmarks/swap_latency.py
+++ b/src/gen_worker/benchmarks/swap_latency.py
@@ -13,7 +13,10 @@ an NFS mount) to compare source tiers; R2 cold-fetch is the store's job and
 is measured by the worker's own transfer telemetry, not here.
 
 Cases:
-  load        disk -> VRAM, per component (from_pretrained + .to(cuda))
+  load        disk -> VRAM, per component. Components load through the
+              PRODUCTION path (``models.loading.load_component``), so a
+              quantized flavor is materialized by its artifact loader and
+              the row measures what serving actually pays (pgw#689).
   demote      VRAM -> host RAM (pinned swap cache built on first demote)
   promote     host RAM -> VRAM — the resident re-pick
   swap        component-first A -> B: only components whose content digest
@@ -55,7 +58,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import importlib
 import json
 import os
 import sys
@@ -134,17 +136,17 @@ def _cuda_bytes() -> int:
     return int(torch.cuda.memory_allocated())
 
 
-def _component_entries(tree: Path) -> Dict[str, Tuple[str, str]]:
-    """component name -> (library, class) from model_index.json."""
+def _component_names(tree: Path) -> List[str]:
+    """Loadable component names from model_index.json (sorted). The module
+    CLASS is not read here — :func:`_load_component` resolves it through the
+    production loader, which is the one place that mapping may live."""
     idx = json.loads((tree / "model_index.json").read_text())
-    out: Dict[str, Tuple[str, str]] = {}
-    for name, entry in idx.items():
-        if name.startswith("_") or not isinstance(entry, list) or len(entry) != 2:
-            continue
-        if entry[0] is None or entry[1] is None:
-            continue
-        out[name] = (str(entry[0]), str(entry[1]))
-    return out
+    return sorted(
+        name for name, entry in idx.items()
+        if not name.startswith("_")
+        and isinstance(entry, list) and len(entry) == 2
+        and entry[0] is not None and entry[1] is not None
+    )
 
 
 def component_digest(tree: Path, component: str) -> str:
@@ -172,10 +174,10 @@ def component_digest(tree: Path, component: str) -> str:
 def swap_plan(tree_a: Path, tree_b: Path) -> Tuple[List[str], List[str]]:
     """(differing, shared_by_content_address) component names for A -> B.
     Pure planning — runs anywhere, no CUDA needed."""
-    comps_b = _component_entries(tree_b)
+    comps_b = _component_names(tree_b)
     differing: List[str] = []
     shared: List[str] = []
-    for name in sorted(comps_b):
+    for name in comps_b:
         if not (tree_b / name).is_dir():
             continue
         if component_digest(tree_a, name) == component_digest(tree_b, name):
@@ -185,18 +187,20 @@ def swap_plan(tree_a: Path, tree_b: Path) -> Tuple[List[str], List[str]]:
     return differing, shared
 
 
-def _load_component(tree: Path, name: str, lib: str, cls_name: str) -> Any:
-    module = importlib.import_module(lib)
-    cls = getattr(module, cls_name)
-    src = tree / name
-    if callable(getattr(cls, "from_pretrained", None)):
-        try:
-            import torch
+def _load_component(tree: Path, name: str) -> Any:
+    """One component, through the PRODUCTION component-load path.
 
-            return cls.from_pretrained(str(src), torch_dtype=torch.bfloat16)
-        except TypeError:
-            return cls.from_pretrained(str(src))
-    raise OffPodError(f"component {name}: {lib}.{cls_name} has no from_pretrained")
+    The benchmark's whole purpose is measuring what serving pays, so it must
+    not own a second loader. ``models.loading.load_component`` is the same
+    function the executor's component substitution and the pgw#674 rotation
+    preloader call, and it routes quantized artifacts (w8a8 / w4a4) to their
+    lane loaders. The reimplementation this replaced called
+    ``cls.from_pretrained`` directly, which on any modelopt-produced flavor
+    — i.e. every tree the fleet actually serves — died reconstructing
+    ``NVIDIAModelOptConfig`` (pgw#689)."""
+    from ..models.loading import load_component
+
+    return load_component(tree, name)
 
 
 def _module_bytes(obj: Any) -> int:
@@ -214,11 +218,11 @@ def bench_load(tree: Path, emit: EmitFn) -> Dict[str, Any]:
     loaded: Dict[str, Any] = {}
     total_t0 = time.monotonic()
     total_bytes = 0
-    for name, (lib, cls_name) in sorted(_component_entries(tree).items()):
+    for name in _component_names(tree):
         if not (tree / name).is_dir():
             continue
         t0 = time.monotonic()
-        obj = _load_component(tree, name, lib, cls_name)
+        obj = _load_component(tree, name)
         host_s = time.monotonic() - t0
         t1 = time.monotonic()
         import torch
@@ -264,7 +268,6 @@ def bench_swap(
     """Component-first swap A -> B: only differing components move."""
     import torch
 
-    comps_b = _component_entries(tree_b)
     differing, shared = swap_plan(tree_a, tree_b)
     emit(Row("swap", f"{tree_a.name}->{tree_b.name}/plan", 0.0, 0,
              {"differing": differing, "shared_by_content_address": shared}))
@@ -274,8 +277,7 @@ def bench_swap(
     replaced_bytes = 0
     fresh: Dict[str, Any] = {}
     for name in differing:
-        lib, cls_name = comps_b[name]
-        obj = _load_component(tree_b, name, lib, cls_name)
+        obj = _load_component(tree_b, name)
         if isinstance(obj, torch.nn.Module):
             obj = obj.to("cuda")
         fresh[name] = obj
@@ -318,11 +320,11 @@ def bench_stage(tree: Path, emit: EmitFn) -> None:
 
     total_pin = 0
     total_h2d_s = 0.0
-    for name, (lib, cls_name) in sorted(_component_entries(tree).items()):
+    for name in _component_names(tree):
         if not (tree / name).is_dir():
             continue
         t0 = time.monotonic()
-        obj = _load_component(tree, name, lib, cls_name)
+        obj = _load_component(tree, name)
         load_s = time.monotonic() - t0
         if not isinstance(obj, torch.nn.Module):
             continue

--- a/src/gen_worker/diagnostics.py
+++ b/src/gen_worker/diagnostics.py
@@ -3,26 +3,44 @@
 The swap-latency harness (:mod:`gen_worker.benchmarks.swap_latency`) needs
 a first-class delivery path onto serving-class pods — ie#546 recorded that
 no such path existed (no sshd on pods). This module gives it one: an
-ordinary ``@endpoint`` class an endpoint project re-exports, so the harness
-is dispatched through the NORMAL request path — the same payload path
+ordinary ``@endpoint`` class an endpoint project adopts, so the harness is
+dispatched through the NORMAL request path — the same payload path
 th#1198's admin benchmark runs use — and its rows come back as the job
 result.
 
 Usage (in an endpoint project, e.g. inference-endpoints)::
 
-    from gen_worker.diagnostics import SwapLatencyDiagnostics  # noqa: F401
+    from gen_worker.diagnostics import SwapLatencyDiagnostics
 
-Discovery picks the class up like any other endpoint; publish it as its
-own diagnostics release. Bind ``checkpoint``/``to`` at deploy time or per
-request via ``selected_by`` — the trees come out of the hub CAS through
-the worker's ordinary snapshot materialization, so the benchmark measures
-the exact tiers production serving uses. Invoker policy (who may call it)
-is hub catalog data, not SDK code.
+    class SwapLatency(SwapLatencyDiagnostics):
+        '''This project's swap-latency diagnostics endpoint.'''
+
+SUBCLASS it — do not merely re-export it. Discovery walks a package and
+skips decorated objects whose ``__module__`` lies outside it (a bare
+``from ... import X`` re-export is a third-party object by that rule and is
+dropped — loudly, since pgw#689). A subclass is declared IN the endpoint
+package, inherits the decorator's declaration, and is picked up like any
+other endpoint. Publish it as its own diagnostics release.
+
+Bind ``checkpoint``/``to`` at deploy time — the trees come out of the hub
+CAS through the worker's ordinary snapshot materialization, so the
+benchmark measures the exact tiers production serving uses. Invoker policy
+(who may call it) is hub catalog data, not SDK code.
+
+Failure contract (pgw#689 defect 3): this handler NEVER raises for a
+benchmark-domain failure. A diagnostic that cannot measure has produced a
+measurement RESULT — ``status="failed"`` naming the cause — not evidence
+that the release is broken. Raising here fed the hub's fast-failure breaker
+and tripped ``model_load_failure_streak`` on a live release, which recycled
+a warm pod that had just spent 26 minutes minting. Sibling functions serve
+tenant traffic on that same pod; this one never does.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import traceback
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -33,11 +51,14 @@ from .api.slot import Slot
 from .benchmarks import swap_latency as bench
 from .request_context import RequestContext
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "SwapLatencyDiagnostics",
     "SwapLatencyInput",
     "SwapLatencyOutput",
     "SwapLatencyRow",
+    "failure_outcome",
 ]
 
 
@@ -45,12 +66,23 @@ class SwapLatencyInput(msgspec.Struct, frozen=True):
     """One benchmark request.
 
     ``checkpoint``/``to`` drive the slot picks (``selected_by``); the hub
-    overlays the allowed-value enum. ``cases`` defaults to everything that
-    needs only tree A — pass ``("swap",)`` with a distinct ``to`` pick for
-    the component-diff swap case.
+    overlays the allowed-value enum. Both default to ``""`` — the hub reads
+    an empty pick as "no value supplied" and uses the DEPLOY binding, which
+    is what this handler reads anyway (``setup()`` owns both trees). The
+    defaults are load-bearing, not cosmetic: a family-less ``Slot(str)``
+    cannot carry a ``curated`` policy (the hub cannot derive an architecture
+    family for it), a ``fixed`` slot rejects every supplied value, and a
+    REQUIRED msgspec field cannot be omitted — so without the defaults no
+    payload exists that the hub accepts (pgw#689). Dropping them re-breaks
+    dispatch; making a family-less string slot curatable hub-side is the
+    alternative fix.
+
+    ``cases`` defaults to everything that needs only tree A — pass
+    ``("swap",)`` with a distinct ``to`` binding for the component-diff swap
+    case.
     """
 
-    checkpoint: str
+    checkpoint: str = ""
     to: str = ""
     cases: Tuple[str, ...] = ("load", "demote", "stage", "overlap")
     overlap_gb: float = 4.0
@@ -80,6 +112,13 @@ class SwapLatencyOutput(msgspec.Struct, frozen=True):
     # when both trees are bound, even without the measured swap case.
     differing_components: Tuple[str, ...] = ()
     shared_components: Tuple[str, ...] = ()
+    # The measurement's own outcome (pgw#689 defect 3): "ok" | "refused"
+    # (this host must not run weight benchmarks — off-pod / no CUDA) |
+    # "failed" (it ran and could not measure). Never a raised fatal: a
+    # broken diagnostic is not a broken release.
+    status: str = "ok"
+    error: str = ""
+    traceback_text: str = ""
 
 
 def _to_row(row: bench.Row) -> SwapLatencyRow:
@@ -95,6 +134,24 @@ def _to_row(row: bench.Row) -> SwapLatencyRow:
     )
 
 
+def failure_outcome(exc: BaseException) -> SwapLatencyOutput:
+    """A failed measurement, as data. Loud in the pod log, benign on the
+    wire — the job SUCCEEDS, so no release-health signal is emitted."""
+    status = "refused" if isinstance(exc, bench.OffPodError) else "failed"
+    logger.error(
+        "swap-latency diagnostics %s — %s: %s (diagnostic outcome only; the "
+        "release's serving functions are unaffected)",
+        status, type(exc).__name__, exc, exc_info=exc,
+    )
+    return SwapLatencyOutput(
+        rows=[],
+        status=status,
+        error=f"{type(exc).__name__}: {exc}",
+        traceback_text="".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    )
+
+
 @endpoint(
     models={
         "checkpoint": Slot(str, selected_by="checkpoint", root=True),
@@ -107,7 +164,10 @@ def _to_row(row: bench.Row) -> SwapLatencyRow:
     ),
 )
 class SwapLatencyDiagnostics:
-    """Pod-side physical swap benchmark as an ordinary worker function."""
+    """Pod-side physical swap benchmark as an ordinary worker function.
+
+    Subclass this inside an endpoint package to publish it — a bare
+    re-export is skipped by discovery (see the module docstring)."""
 
     def setup(self, checkpoint: str, to: str) -> None:
         self._checkpoint = Path(checkpoint)
@@ -117,6 +177,12 @@ class SwapLatencyDiagnostics:
     def swap_latency(
         self, ctx: RequestContext, payload: SwapLatencyInput,
     ) -> SwapLatencyOutput:
+        try:
+            return self._measure(payload)
+        except Exception as exc:  # noqa: BLE001 — the failure contract above
+            return failure_outcome(exc)
+
+    def _measure(self, payload: SwapLatencyInput) -> SwapLatencyOutput:
         to: Optional[Path] = self._to
         if to is not None and to == self._checkpoint:
             to_effective: Optional[Path] = None

--- a/src/gen_worker/discovery/walk.py
+++ b/src/gen_worker/discovery/walk.py
@@ -8,7 +8,11 @@ registry use this single walker so they can never drift apart.
 Invariants:
 
 * Objects whose ``__module__`` is outside the walked package tree are
-  skipped (third-party re-exports stay out).
+  skipped (third-party re-exports stay out) — LOUDLY, at WARNING, naming the
+  class and the fix (subclass it locally). The skip was silent until
+  pgw#689, which is how an SDK-provided diagnostics endpoint, re-exported
+  exactly as its own docstring instructed, vanished from a release with no
+  trace in any log.
 * Each object is yielded exactly once even when re-exported into multiple
   namespaces (dedup by ``id``).
 * A module that fails to IMPORT is a HARD failure
@@ -115,9 +119,18 @@ def _scan_module(
             obj_module != walked_package_name
             and not obj_module.startswith(walked_package_prefix)
         ):
-            logger.info(
-                "Skipping endpoint '%s.%s' — defined outside the walked "
-                "package '%s'.",
+            logger.warning(
+                "SKIPPING @endpoint '%s.%s' re-exported into '%s' — it is "
+                "DEFINED in '%s', outside the walked package '%s', so it "
+                "will NOT appear in endpoint.lock or the worker's route "
+                "table. A bare `from %s import %s` never publishes: SUBCLASS "
+                "it inside '%s' instead (the subclass inherits the "
+                "declaration and is declared here). pgw#689: this skip used "
+                "to be silent, and an SDK diagnostics endpoint went missing "
+                "for a whole release because of it.",
+                obj_module, getattr(obj, "__name__", "<unknown>"),
+                getattr(module, "__name__", "<unknown>"),
+                obj_module, walked_package_name,
                 obj_module, getattr(obj, "__name__", "<unknown>"),
                 walked_package_name,
             )

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -14,14 +14,25 @@ from ..families.facts import component_dtype_for_class
 from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
 import importlib
 import importlib.util
+import inspect
 import os
 import struct
 import sys
 
 from .memory import get_available_vram_gb, meta_tensors
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
-from .w4a4 import detect_w4a4_artifact, load_w4a4_pipeline, load_w4a4_root_pipeline
-from .w8a8 import detect_w8a8_artifact, load_w8a8_pipeline, load_w8a8_root_pipeline
+from .w4a4 import (
+    detect_w4a4_artifact,
+    load_w4a4_denoiser,
+    load_w4a4_pipeline,
+    load_w4a4_root_pipeline,
+)
+from .w8a8 import (
+    detect_w8a8_artifact,
+    load_w8a8_denoiser,
+    load_w8a8_pipeline,
+    load_w8a8_root_pipeline,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -193,10 +204,13 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
     )
 
 
+#: Denoiser component directory names — the only components a quantized
+#: artifact lane (w8a8 / w4a4 / svdq / gguf) ever covers.
+DENOISER_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
 # Pipeline components fp8 storage applies to: the denoiser dominates VRAM and
 # tolerates fp8-E4M3 weight rounding; text encoders / VAE stay at compute
 # precision (quality-safe default, QUANTIZATION-POLICY.md component policy).
-_FP8_STORAGE_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+_FP8_STORAGE_COMPONENTS: tuple[str, ...] = DENOISER_COMPONENTS
 # The "+te" rung (component fit-ladder rung 2): the pipeline's text encoders.
 _FP8_TEXT_ENCODER_COMPONENTS: tuple[str, ...] = (
     "text_encoder", "text_encoder_2", "text_encoder_3",
@@ -1119,30 +1133,84 @@ def _component_dtype_map(
     return out
 
 
-def load_component_override(
-    base_path: str | Path, component: str, override_path: str | Path,
-    *, dtype: str = "",
+class ComponentLaneUnsupported(RuntimeError):
+    """This flavor has no component-level loader, so no honest one exists.
+
+    svdq and gguf materialize their denoiser INSIDE the pipeline build (a
+    nunchaku file / a single gguf checkpoint the pipeline class assembles).
+    Handing back a plain ``from_pretrained`` module for those would not be
+    what serving runs, so the component path refuses by name instead
+    (pgw#689: a benchmark that measures something other than the serve path
+    is worse than one that refuses)."""
+
+
+def _accepts_kwarg(fn: Any, name: str) -> bool:
+    """True when ``fn`` can take ``name=`` (declared or via ``**kwargs``).
+
+    Replaces the ``except TypeError: retry without it`` idiom, which caught
+    ANY construction-time TypeError — including one raised deep inside
+    diffusers' quantization-config reconstruction — and retried a path that
+    failed identically, so the real cause never surfaced (pgw#689 defect 2).
+    Introspection failure means "pass it": the call then fails naming
+    itself."""
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return True
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == name and param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return True
+    return False
+
+
+def load_component(
+    tree: str | Path, component: str, *,
+    dtype: str = "", weights_tree: str | Path | None = None,
 ) -> Any:
-    """Load one named pipeline component from an OVERRIDE snapshot tree
-    (pgw#617 hierarchical bindings). The module class comes from the BASE
-    tree's model_index.json; weights come from the override tree's
-    ``<component>/`` subtree when present, else its root.
+    """THE production loader for ONE named pipeline component.
+
+    Every caller that needs a single component — the executor's pgw#617
+    substitution, the pgw#674 rotation preloader, the swap benchmark — goes
+    through here, so what they load is by construction what serving loads.
+
+    ``tree`` is the BASE composition: it names the module class
+    (model_index.json) and decides the compute dtype. ``weights_tree`` is
+    where the bytes live (default: ``tree``); an override binding points it
+    at its own snapshot, whose ``<component>/`` subtree is used when present,
+    else its root.
+
+    Quantized artifacts take their OWN lane, exactly as
+    :func:`load_from_pretrained` routes a whole pipeline: a w8a8/w4a4
+    denoiser is materialized by its artifact loader. A modelopt-produced
+    tree carries a ``quantization_config`` block diffusers reconstructs into
+    ``NVIDIAModelOptConfig``, whose constructor requires a ``quant_type``
+    the block does not supply — so a bare ``from_pretrained`` on the
+    denoiser dies at config reconstruction on every flavor the fleet
+    actually serves (pgw#689 defect 1). Lanes with no component-level
+    loader raise :class:`ComponentLaneUnsupported`.
 
     dtype resolution (pgw#647 gap #2): the base binding's declared dtype
-    wins; otherwise the override inherits the BASE COMPOSITION's compute
-    dtype (:func:`composition_compute_dtype`); the override's own on-disk
+    wins; otherwise the component inherits the BASE COMPOSITION's compute
+    dtype (:func:`composition_compute_dtype`); the weights' own on-disk
     dtype is only the last resort. Hub-resolved bindings carry no dtype, so
     the old override-on-disk fallback loaded e.g. the fp32-stored fp16-fix
-    VAE into a bf16 pipeline and setup died on the first latent
-    (ie#546 canary, 2/2 pods). Blocking; callers on an event loop run it
+    VAE into a bf16 pipeline and setup died on the first latent (ie#546
+    canary, 2/2 pods). Blocking; callers on an event loop run it
     off-thread."""
 
-    entry = model_index_entry(base_path, component)
+    base = Path(tree)
+    root = Path(weights_tree) if weights_tree is not None else base
+    entry = model_index_entry(base, component)
     if entry is None:
         raise ValueError(
             f"component {component!r} is not in the base composition "
             f"(model_index components: "
-            f"{sorted(model_index_components(base_path))})"
+            f"{sorted(model_index_components(base))})"
         )
     library, class_name = entry
     module = importlib.import_module(library)
@@ -1151,10 +1219,10 @@ def load_component_override(
         raise ValueError(
             f"{library}.{class_name} declares no from_pretrained loader"
         )
-    src = Path(override_path) / component
+    src = root / component
     if not src.is_dir():
-        src = Path(override_path)
-    kwargs: Dict[str, Any] = {}
+        src = root
+
     # pgw#667: a component with a declared load-dtype fact keeps it when it is
     # SUBSTITUTED too — the fact is a property of the component class, and the
     # substituted tree's part must be resident at the same precision the base
@@ -1162,18 +1230,63 @@ def load_component_override(
     fact = component_dtype_for_class(class_name)
     wanted = (
         (fact.dtype if fact is not None else "")
-        or composition_compute_dtype(base_path, dtype)
+        or composition_compute_dtype(base, dtype)
         or detect_on_disk_dtype(src)
     )
+    torch_dtype: Any = None
     if wanted in ("bf16", "fp16", "bfloat16", "float16", "fp32", "float32"):
         try:
-            kwargs["torch_dtype"] = get_torch_dtype(wanted)
+            torch_dtype = get_torch_dtype(wanted)
         except ImportError:
             pass  # torch-less environment: loader fails on its own terms
-    try:
-        return cls.from_pretrained(str(src), **kwargs)
-    except TypeError:
-        return cls.from_pretrained(str(src))
+
+    def _covers(artifact_component: str) -> bool:
+        """The artifact's weight set IS this component: a diffusers tree
+        names it, a bare override tree (root layout) has nothing else in
+        it."""
+        return artifact_component == component or (
+            not artifact_component and src == root
+        )
+
+    w8a8_art = detect_w8a8_artifact(root)
+    if w8a8_art is not None and _covers(w8a8_art.component):
+        return load_w8a8_denoiser(
+            root, w8a8_art, compute_dtype=torch_dtype, cls=cls)
+    w4a4_art = detect_w4a4_artifact(root)
+    if w4a4_art is not None and _covers(w4a4_art.component):
+        return load_w4a4_denoiser(
+            root, w4a4_art, compute_dtype=torch_dtype, cls=cls)
+    svdq_art = detect_svdq_artifact(root)
+    if svdq_art is not None and _covers(svdq_art.component):
+        raise ComponentLaneUnsupported(
+            f"component {component!r} of {root} is an svdq-{svdq_art.precision} "
+            f"artifact ({svdq_art.file.name}): its denoiser is built by the "
+            f"svdq engine during the PIPELINE load, so there is no "
+            f"component-level production loader to borrow"
+        )
+    if component in DENOISER_COMPONENTS and detect_gguf_snapshot(root):
+        raise ComponentLaneUnsupported(
+            f"component {component!r} of {root} is a GGUF denoiser: it is "
+            f"dequantized by the pipeline's own gguf loader, so there is no "
+            f"component-level production loader to borrow"
+        )
+
+    kwargs: Dict[str, Any] = {}
+    if torch_dtype is not None and _accepts_kwarg(
+            cls.from_pretrained, "torch_dtype"):
+        kwargs["torch_dtype"] = torch_dtype
+    return cls.from_pretrained(str(src), **kwargs)
+
+
+def load_component_override(
+    base_path: str | Path, component: str, override_path: str | Path,
+    *, dtype: str = "",
+) -> Any:
+    """Load one named pipeline component from an OVERRIDE snapshot tree
+    (pgw#617 hierarchical bindings) — :func:`load_component` with the
+    weights pointed at the override."""
+    return load_component(
+        base_path, component, dtype=dtype, weights_tree=override_path)
 
 
 def _safetensors_data_bytes(p: Path) -> int:

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -488,12 +488,15 @@ def _dequant_into(sd: Dict[str, Any], name: str, compute: Any) -> None:
 
 
 def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
-                       compute_dtype: Any = None, mode: str = "") -> Any:
+                       compute_dtype: Any = None, mode: str = "",
+                       cls: Any = None) -> Any:
     """Materialize the quantized denoiser: skeleton on meta, quantized
     Linears swapped for W4A4Linear, tensors assigned from the shards.
     ``mode`` "blockwise" | "dequant" (default: probe). Layers whose dims
     break fp4 scaled_mm alignment are dequantized individually (AWQ-lite
-    ``pre_quant_scale`` folds back into the dequantized weight)."""
+    ``pre_quant_scale`` folds back into the dequantized weight).
+    ``cls`` pins the module class (the component path already resolved it
+    from the BASE composition's model_index); default: this tree's own."""
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
@@ -503,7 +506,8 @@ def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
     if mode not in ("blockwise", "dequant"):
         mode = w4a4_gemm_mode() or "dequant"
 
-    cls = _denoiser_class(root, art.component)
+    if cls is None:
+        cls = _denoiser_class(root, art.component)
     cfg = dict(cls.load_config(str(root / art.component)))
     cfg.pop("quantization_config", None)
     with init_empty_weights():

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -474,11 +474,14 @@ def _denoiser_class(root: Path, component: str) -> Any:
 
 
 def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
-                       compute_dtype: Any = None, mode: str = "") -> Any:
+                       compute_dtype: Any = None, mode: str = "",
+                       cls: Any = None) -> Any:
     """Materialize the quantized denoiser: skeleton on meta, quantized
     Linears swapped for Fp8ScaledLinear, tensors assigned from the shards.
     ``mode`` "rowwise" | "pertensor" | "dequant" (default: probe). Layers
-    whose dims break scaled_mm's 16-alignment are dequantized individually."""
+    whose dims break scaled_mm's 16-alignment are dequantized individually.
+    ``cls`` pins the module class (the component path already resolved it
+    from the BASE composition's model_index); default: this tree's own."""
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
@@ -488,7 +491,8 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
     if mode not in ("rowwise", "pertensor", "dequant"):
         mode = w8a8_gemm_mode() or "dequant"
 
-    cls = _denoiser_class(root, art.component)
+    if cls is None:
+        cls = _denoiser_class(root, art.component)
     cfg = dict(cls.load_config(str(root / art.component)))
     cfg.pop("quantization_config", None)
     with init_empty_weights():

--- a/tests/test_swap_bench_pgw689.py
+++ b/tests/test_swap_bench_pgw689.py
@@ -1,0 +1,349 @@
+"""pgw#689: the swap benchmark must load what SERVING loads, a broken
+diagnostic must not look like a broken release, and a re-exported endpoint
+must never be dropped silently.
+
+Four tapes, all red before the fix:
+
+1. ``benchmarks.swap_latency._load_component`` on a REAL modelopt-shaped
+   w8a8 tree — the flavor the fleet actually serves. Pre-fix it called
+   ``cls.from_pretrained`` itself and died reconstructing
+   ``NVIDIAModelOptConfig`` (evidence tape below pins that exact mechanism
+   on the pinned diffusers); post-fix it goes through
+   ``models.loading.load_component``, so the module comes back off the w8a8
+   artifact lane.
+2. ``bench_load`` end to end over that tree with a fake-CUDA seam (the
+   real-GPU numbers are a pod's job; the LOADABILITY is CI's).
+3. The diagnostics handler converts every benchmark-domain failure into a
+   typed outcome and returns normally — the job succeeds, so no
+   ``model_load_failure_streak`` signal is ever emitted for it.
+4. Discovery's out-of-package skip is a WARNING naming the class.
+"""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+
+@pytest.fixture(scope="module")
+def tiny_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A minimal REAL diffusers tree (unet + scheduler)."""
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("pgw689") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"), norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tiny_tree: Path) -> Path:
+    """The same tree quantized to the gw#534 w8a8 contract — carrying the
+    modelopt ``quantization_config`` block that broke the benchmark."""
+    import json
+
+    from gen_worker.models.w8a8 import quantize_tree_w8a8
+
+    tree = quantize_tree_w8a8(tiny_tree, tiny_tree.parent / "w8a8")
+    cfg = json.loads((tree / "unet" / "config.json").read_text())
+    assert cfg["quantization_config"] == {
+        "quant_method": "modelopt", "quant_algo": "FP8"}
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# 1: the evidence — a bare from_pretrained on a modelopt tree is the fatal
+# ---------------------------------------------------------------------------
+
+
+def test_bare_from_pretrained_on_a_modelopt_tree_is_the_recorded_fatal(
+    w8a8_tree: Path,
+) -> None:
+    """The mechanism, reproduced on the pinned stack (diffusers 0.39.0 —
+    the release's own version): diffusers rebuilds ``NVIDIAModelOptConfig``
+    from the stored block, whose constructor demands a ``quant_type`` the
+    block does not carry. This call IS what the benchmark used to make per
+    component, and the message below is verbatim the ie#546 fatal. If a
+    diffusers bump ever makes this call succeed, this tape is the thing to
+    update — the fix does not depend on it."""
+    from diffusers import UNet2DModel
+
+    with pytest.raises(TypeError) as excinfo:
+        UNet2DModel.from_pretrained(
+            str(w8a8_tree / "unet"), torch_dtype=torch.bfloat16)
+    assert "NVIDIAModelOptConfig.__init__()" in str(excinfo.value)
+    assert "quant_type" in str(excinfo.value)
+    # ...and dropping the torch_dtype kwarg (the retry the benchmark did)
+    # fails IDENTICALLY — the fallback never could have helped.
+    with pytest.raises(TypeError, match="quant_type"):
+        UNet2DModel.from_pretrained(str(w8a8_tree / "unet"))
+
+
+# ---------------------------------------------------------------------------
+# 2: the fix — the benchmark loads through the production component path
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_loads_a_quantized_component_via_the_serve_path(
+    tiny_tree: Path, w8a8_tree: Path,
+) -> None:
+    from diffusers import UNet2DModel
+
+    from gen_worker.benchmarks import swap_latency as bench
+    from gen_worker.models import w8a8
+
+    if hasattr(w8a8.w8a8_gemm_mode, "cache_clear"):
+        w8a8.w8a8_gemm_mode.cache_clear()
+
+    unet = bench._load_component(w8a8_tree, "unet")
+
+    # The w8a8 artifact lane ran — the same loader load_from_pretrained
+    # routes a served pipeline through — not a bare from_pretrained.
+    assert getattr(unet, "_cozy_w8a8_mode", None) in (
+        "rowwise", "pertensor", "dequant")
+    # ...and it materialized the real weights, to fp8 rounding.
+    ref = UNet2DModel.from_pretrained(str(tiny_tree / "unet"))
+    name = w8a8.detect_w8a8_artifact(w8a8_tree).quantized[0] + ".weight"
+    a = ref.state_dict()[name].float()
+    b = unet.state_dict()[name].float()
+    rel = ((a - b).abs() / a.abs().clamp(min=1e-3)).max().item()
+    assert rel < 0.13
+
+
+def test_unquantized_siblings_still_load_and_honor_the_lane_dtype(
+    w8a8_tree: Path,
+) -> None:
+    """A w8a8 tree's NON-denoiser components take the ordinary path — and
+    inherit the quant lane's bf16 compute default, not the tree's majority
+    on-disk sniff (pgw#675/pgw#683's rule, now shared by construction)."""
+    from gen_worker.models.loading import load_component
+
+    sched = load_component(w8a8_tree, "scheduler")
+    assert type(sched).__name__ == "DDPMScheduler"
+
+
+def test_bench_load_walks_a_quantized_tree_end_to_end(
+    w8a8_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `load` case over a quantized tree. CUDA is faked (this box has
+    none, and the real numbers are the pod's run) — what CI proves is that
+    every component of a served flavor is loadable at all, which is exactly
+    what was broken."""
+    from gen_worker.benchmarks import swap_latency as bench
+
+    monkeypatch.setattr(
+        torch.nn.Module, "to", lambda self, *a, **k: self, raising=True)
+    monkeypatch.setattr(bench, "_sync", lambda: None)
+    monkeypatch.setattr(bench, "_cuda_bytes", lambda: 0)
+
+    rows: List[bench.Row] = []
+    loaded = bench.bench_load(w8a8_tree, rows.append)
+
+    assert "unet" in loaded
+    assert getattr(loaded["unet"], "_cozy_w8a8_mode", None) is not None
+    labels = {r.label for r in rows}
+    assert f"{w8a8_tree.name}/unet" in labels
+    assert f"{w8a8_tree.name}/TOTAL" in labels
+    assert any(r.bytes > 0 for r in rows)
+
+
+def test_lanes_without_a_component_loader_refuse_by_name(
+    tmp_path: Path,
+) -> None:
+    """svdq builds its denoiser inside the pipeline load. Handing back a
+    plain from_pretrained module would be measuring something serving never
+    runs — refuse, named."""
+    import json
+
+    from gen_worker.models.loading import (
+        ComponentLaneUnsupported, load_component,
+    )
+
+    tree = tmp_path / "svdq"
+    (tree / "transformer").mkdir(parents=True)
+    (tree / "model_index.json").write_text(json.dumps({
+        "_class_name": "FluxPipeline",
+        "transformer": ["diffusers", "FluxTransformer2DModel"],
+    }))
+    from safetensors.torch import save_file
+
+    from gen_worker.models.svdq import SVDQ_METHOD, detect_svdq_artifact
+
+    save_file(
+        {"x": torch.zeros(2)},
+        str(tree / "transformer" / "svdq-int4_r32-model.safetensors"),
+        metadata={"model_class": "NunchakuFluxTransformer2dModel",
+                  "quantization_config": json.dumps({
+                      "method": SVDQ_METHOD, "rank": 32,
+                      "weight": {"dtype": "int4"}})},
+    )
+    assert detect_svdq_artifact(tree) is not None
+    with pytest.raises(ComponentLaneUnsupported, match="svdq"):
+        load_component(tree, "transformer")
+
+
+def test_the_identical_typeerror_retry_is_gone() -> None:
+    """Defect 2: the retry could not help (it re-ran the failing path) and
+    it destroyed the evidence. A loader TypeError now propagates, and the
+    torch_dtype question is answered by INSPECTION instead."""
+    import inspect as _inspect
+
+    from gen_worker.models import loading
+
+    src = _inspect.getsource(loading.load_component)
+    assert "except TypeError" not in src
+
+    class _NoDtype:
+        @staticmethod
+        def from_pretrained(path: str) -> str:
+            return path
+
+    class _AnyKwargs:
+        @staticmethod
+        def from_pretrained(path: str, **kwargs: Any) -> str:
+            return path
+
+    assert loading._accepts_kwarg(_NoDtype.from_pretrained, "torch_dtype") is False
+    assert loading._accepts_kwarg(_AnyKwargs.from_pretrained, "torch_dtype") is True
+
+
+# ---------------------------------------------------------------------------
+# 3: a broken DIAGNOSTIC is not a broken release (defect 3)
+# ---------------------------------------------------------------------------
+
+
+def _handler() -> Any:
+    from gen_worker.diagnostics import SwapLatencyDiagnostics
+
+    obj = SwapLatencyDiagnostics()
+    obj.setup(checkpoint="/nonexistent/tree", to="")
+    return obj
+
+
+def test_a_load_fatal_inside_the_benchmark_never_escapes_the_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact ie#546 fatal. Pre-fix it left the handler as a fast fatal,
+    the hub counted it, and two of them marked the release's function broken
+    — recycling a warm pod. It must come back as data."""
+    from gen_worker.benchmarks import swap_latency as bench
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise TypeError(
+            "NVIDIAModelOptConfig.__init__() missing 1 required positional "
+            "argument: 'quant_type'")
+
+    monkeypatch.setattr(bench, "run_cases", _boom)
+    out = _handler().swap_latency(None, SwapLatencyInput())
+
+    assert out.status == "failed"
+    assert "quant_type" in out.error
+    assert "NVIDIAModelOptConfig" in out.traceback_text
+    assert out.rows == []
+
+
+def test_off_pod_refusal_is_an_outcome_not_a_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    out = _handler().swap_latency(None, SwapLatencyInput())
+
+    assert out.status == "refused"
+    assert "weights-locality" in out.error
+
+
+def test_a_bad_case_request_is_an_outcome_not_a_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    # 'swap' with no distinct `to` binding: a caller error, still a
+    # measurement outcome — never a release-health signal.
+    out = _handler().swap_latency(None, SwapLatencyInput(cases=("swap",)))
+    assert out.status == "failed"
+    assert "swap case" in out.error
+
+
+def test_the_family_less_slot_convention_is_dispatchable() -> None:
+    """The hub cannot put a curated policy on a family-less string slot, a
+    fixed slot rejects supplied values, and msgspec cannot omit a required
+    field — so an all-defaults payload MUST be valid or the diagnostics
+    function is uninvokable (the pgw#689 ``checkpoint: ""`` workaround, now
+    the declared contract)."""
+    import msgspec
+
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    payload = msgspec.json.decode(b"{}", type=SwapLatencyInput)
+    assert payload.checkpoint == "" and payload.to == ""
+    assert "stage" in payload.cases
+
+
+# ---------------------------------------------------------------------------
+# 4: the other final-cycle trap — a silent discovery skip
+# ---------------------------------------------------------------------------
+
+
+def _pkg(root: Path, name: str, body: str) -> None:
+    pkg = root / name
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(textwrap.dedent(body))
+
+
+def test_reexported_endpoint_skip_is_loud_and_names_the_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gen_worker.discovery.walk import find_endpoints
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _pkg(tmp_path, "ep_pgw689_reexport", """
+        from gen_worker.diagnostics import SwapLatencyDiagnostics  # noqa: F401
+    """)
+
+    with caplog.at_level(logging.WARNING, logger="gen_worker.discovery.walk"):
+        found = find_endpoints(["ep_pgw689_reexport"])
+
+    assert found == []
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "an endpoint dropped from the route table must be LOUD"
+    text = warnings[0].getMessage()
+    assert "SwapLatencyDiagnostics" in text
+    assert "ep_pgw689_reexport" in text
+    assert "SUBCLASS" in text
+
+
+def test_subclassing_in_the_endpoint_package_actually_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix the warning names has to work."""
+    from gen_worker.discovery.walk import find_endpoints
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _pkg(tmp_path, "ep_pgw689_subclass", """
+        from gen_worker.diagnostics import SwapLatencyDiagnostics
+
+        class SwapLatency(SwapLatencyDiagnostics):
+            pass
+    """)
+
+    found = find_endpoints(["ep_pgw689_subclass"])
+    assert [f.qualname for f in found] == ["SwapLatency"]
+    assert found[0].module == "ep_pgw689_subclass"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.0"
+version = "0.70.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Closes the pgw#689 P0. The SDK's own swap-latency benchmark could not load a
QUANTIZED component tree — i.e. every flavor the fleet actually serves — so
every `load`/`demote`/`stage`/`swap` row was unreachable on a real serving
pod, and Paul's RAM→VRAM + interference table was blocked on it.

## Root cause

The benchmark owned a SECOND loader (`cls.from_pretrained` per component). A
modelopt-produced tree carries a `quantization_config` block diffusers
rebuilds into `NVIDIAModelOptConfig`, whose constructor requires a
`quant_type` the stored block does not supply:

```
TypeError: NVIDIAModelOptConfig.__init__() missing 1 required positional argument: 'quant_type'
```

Reproduced byte-exact in CI on the release's own pinned diffusers 0.39.0.

## Fixes

1. **`models.loading.load_component` is THE production per-component load
   path.** Every caller that needs one component goes through it — the
   executor's pgw#617 substitution, the pgw#674 rotation preloader
   (`load_component_override` is now a thin wrapper), and the benchmark's
   `_load_component`. Quantized artifacts take their own lane exactly as
   `load_from_pretrained` routes a whole pipeline (`cls=` added to
   `load_w8a8_denoiser`/`load_w4a4_denoiser` so the component path can pin the
   class from the BASE composition's model_index). svdq/gguf have no
   component-level loader, so the path refuses by name
   (`ComponentLaneUnsupported`) instead of measuring something serving never
   runs.
2. **The identical-retry `except TypeError` is gone.** It caught ANY
   construction-time TypeError — including one raised deep inside quant-config
   reconstruction — and retried a path that failed IDENTICALLY, so the real
   cause never surfaced. Whether a loader accepts `torch_dtype` is answered by
   signature inspection (`_accepts_kwarg`).
3. **A broken DIAGNOSTIC no longer poisons a release.** The handler's failures
   are a typed outcome (`status="refused"|"failed"` + error + traceback) on a
   SUCCEEDING job, loud in the pod log. Raising fed the hub's fast-failure
   breaker: two invokes tripped `model_load_failure_streak` and recycled a
   warm pod that had just spent 26 minutes minting.
4. **`SwapLatencyInput.checkpoint`/`to` default to `""`.** A family-less
   `Slot(str)` cannot carry a curated policy, a `fixed` slot rejects every
   supplied value, and a required msgspec field cannot be omitted — so without
   the defaults NO payload exists that the hub accepts. The workaround is now
   the declared contract, reason in the docstring. (The alternative — making a
   family-less string slot curatable hub-side — stays open as a hub-side
   option.)

Also the final cycle's OTHER discovery trap: `discovery/walk.py` skipped
decorated classes defined outside the walked package at INFO. That is how an
SDK diagnostics endpoint, re-exported exactly as its own docstring instructed,
vanished from a release with no trace. Now a WARNING naming the class, the
module it was re-exported into, and the fix (subclass it locally) — and the
docstring says subclass, because re-export never worked.

## Tapes

`tests/test_swap_bench_pgw689.py` — 10 of 12 red pre-fix (verified against the
pre-fix sources in a sandbox; the 2 green are the "this is the mechanism"
evidence tape and the subclass-publishes control):

- the recorded fatal reproduced byte-exact on pinned diffusers 0.39.0, plus
  its identical retry
- `_load_component` on a REAL `quantize_tree_w8a8` tree returns a module off
  the artifact lane (`_cozy_w8a8_mode` stamped) whose weights reproduce the
  source to fp8 rounding
- `bench_load` walks that quantized tree end to end on a fake-CUDA seam (the
  real-GPU numbers are the retag session's; loadability is CI's)
- every diagnostics failure mode (load fatal / off-pod refusal / bad case
  request) returns a typed outcome instead of raising
- the all-defaults payload decodes
- the discovery skip is a WARNING naming the class, and the subclass it
  recommends actually publishes

Suite: 1125 passed / 10 skipped / 1 xfailed locally (one unrelated
load-sensitive watchdog timing test flaked at box load 40 and passes in
isolation). mypy clean on every touched file.

## Train

Cut solo as 0.70.1 (P0, and the pgw#677-reopen lane has no branch up yet) —
its 0.70.1 work rebases over this or rides the next train.