### PR TITLE
release: gen-worker 0.70.1 — pgw#677 REOPEN (one serveability brain, compile-steal sizing, typed mint refusals) + pgw#689 (one train)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 # Changelog
 
-## 0.70.1 (2026-07-26) — pgw#689: the swap benchmark loads what SERVING loads; a broken diagnostic is not a broken release
+## 0.70.1 (2026-07-26) — pgw#677 REOPEN: the fix that did not hold live — one serveability brain, compile-steal sizing, and every mint refusal on the wire; plus pgw#689
+
+The ie#546 final verification cycle reproduced the 0.70.0 starvation
+verbatim on three cold L4 pods with the gate armed: one tenant `generate`
+held 26m25s behind 4-7-minute mint units, finalize at unit 8/18, and not
+one publish-intent from any of six workers. Root causes (each red-taped in
+`tests/test_mint_reopen_pgw677.py`):
+
+### pgw#677 reopen
+
+- **One serveability brain (`compile_cache.mandatory_serving`)** — THE live
+  break. sdxl's mixed `#fp8-w8a8`-storage checkpoint stamps
+  `_cozy_weight_lane` `w8a8*` (cell identity, pgw#686) while the hub serves
+  it `fp8-w8a16+eager`. `_eager_first_eligible` and the router's
+  `fail_closed` read the weight-lane PREFIX, classified the boot
+  mandatory-quantized, and silently fell back to the FOREGROUND
+  compile-then-serve mint — the tenant sat inside `ensure_setup` for the
+  whole inline-compile plan and none of the 0.70.0 gate/preemption
+  machinery ever ran. Serveability now follows the hub-resolved th#913
+  execution lane (only real w8a8/w4a4 ACTIVATIONS forbid eager), stamped on
+  every arm path via a setup-scoped window; without lane evidence the
+  weight-lane stamp remains the fail-closed fallback (the qwen real-w8a8
+  shape keeps its foreground proof).
+- **Stolen-compile sizing (the ~100x correction)**: a stolen turn is not
+  preemptible and a real inductor compile is 4-7 unabortable minutes, not
+  the advertised 30-90s. Compile turns now steal only after
+  `_BG_COMPILE_STEAL_FLOOR_S` (600s) of continuous tenant demand — real
+  traffic has idle gaps between completions, and that is where compiles
+  run — and a granted compile steal announces itself as a typed
+  `bg_turn_steal` event. Seed turns keep the 30s floor.
+- **The mint→publish break is typed on the wire, every door**: the cycle
+  lost its root cause to unreachable pod logs; never again. `self_mint_abort`
+  (pack/closure-gate refusal with the pgw#681 leak named verbatim, warmup
+  OOM, proof-failed degrade, abandon, driver error),
+  `self_mint_publish_withheld` (gw#612 sharer gap, missing publish sink),
+  `self_mint_publish_failed` (hub refusal / upload error).
+- **A truncated warm plan can never finalize a partial capture**: an
+  OOM-cut seed pass no longer satisfies the convergence check (bounded
+  retries, then a loud abort); the foreground path withholds publish on a
+  cut-short plan; `Router.route`'s seed-window holes (`_MAX_SIGS` overflow,
+  dummy-batch failure) route EAGER and count `seed_dropped` so the driver
+  refuses an incomplete capture instead of inline-compiling under the run
+  gate.
+
+### pgw#689: the swap benchmark loads what SERVING loads; a broken diagnostic is not a broken release
 
 The SDK's own swap-latency benchmark could not load a QUANTIZED component
 tree — i.e. every flavor the fleet actually serves — so every `load` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.70.1 (2026-07-26) — pgw#689: the swap benchmark loads what SERVING loads; a broken diagnostic is not a broken release
+
+The SDK's own swap-latency benchmark could not load a QUANTIZED component
+tree — i.e. every flavor the fleet actually serves — so every `load` /
+`demote` / `stage` / `swap` row was unreachable on a real serving pod. It
+owned a second loader (`cls.from_pretrained` per component), and a
+modelopt-produced tree carries a `quantization_config` block diffusers
+rebuilds into `NVIDIAModelOptConfig`, whose constructor requires a
+`quant_type` the block does not supply.
+
+- **One component-load path (`models.loading.load_component`)**: everything
+  that loads a single component now goes through it — the executor's pgw#617
+  substitution, the pgw#674 rotation preloader (`load_component_override` is
+  a wrapper), and the benchmark. Quantized artifacts take their own lane
+  exactly as `load_from_pretrained` routes a whole pipeline; svdq/gguf, which
+  have no component-level loader, refuse by name
+  (`ComponentLaneUnsupported`) rather than measuring something serving never
+  runs.
+- **No more identical-retry `except TypeError`**: it caught any
+  construction-time TypeError (including one from deep inside quant-config
+  reconstruction) and retried a path that failed identically, destroying the
+  evidence. Whether a loader takes `torch_dtype` is now answered by
+  signature inspection.
+- **A diagnostic failure is its own outcome**: `SwapLatencyDiagnostics`
+  returns `status="refused"|"failed"` with the cause on a SUCCEEDING job
+  instead of raising. Raising fed the hub's fast-failure breaker — two
+  invokes tripped `model_load_failure_streak` and recycled a warm pod that
+  had just spent 26 minutes minting. A function that never serves tenant
+  traffic cannot cost a serving pod.
+- **`SwapLatencyInput.checkpoint`/`to` default to `""`**: a family-less
+  `Slot(str)` cannot carry a curated policy, a fixed slot rejects every
+  supplied value, and a required msgspec field cannot be omitted — without
+  the defaults no payload exists that the hub accepts.
+- **Discovery's out-of-package skip is LOUD**: `discovery/walk.py` dropped
+  decorated classes defined outside the walked package at INFO, which is how
+  an SDK diagnostics endpoint, re-exported exactly as its own docstring
+  instructed, vanished from a release silently. Now a WARNING naming the
+  class and the fix — subclass it locally, which is what the docstring says.
+
+
 ## 0.70.0 (2026-07-26) — pgw#677: tenant work always wins the GPU — the background mint yields
 
 th#1187's promise was "serve at eager speed while the compile mint runs in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.0"
+version = "0.70.1"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/benchmarks/swap_latency.py
+++ b/src/gen_worker/benchmarks/swap_latency.py
@@ -13,7 +13,10 @@ an NFS mount) to compare source tiers; R2 cold-fetch is the store's job and
 is measured by the worker's own transfer telemetry, not here.
 
 Cases:
-  load        disk -> VRAM, per component (from_pretrained + .to(cuda))
+  load        disk -> VRAM, per component. Components load through the
+              PRODUCTION path (``models.loading.load_component``), so a
+              quantized flavor is materialized by its artifact loader and
+              the row measures what serving actually pays (pgw#689).
   demote      VRAM -> host RAM (pinned swap cache built on first demote)
   promote     host RAM -> VRAM — the resident re-pick
   swap        component-first A -> B: only components whose content digest
@@ -55,7 +58,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import importlib
 import json
 import os
 import sys
@@ -134,17 +136,17 @@ def _cuda_bytes() -> int:
     return int(torch.cuda.memory_allocated())
 
 
-def _component_entries(tree: Path) -> Dict[str, Tuple[str, str]]:
-    """component name -> (library, class) from model_index.json."""
+def _component_names(tree: Path) -> List[str]:
+    """Loadable component names from model_index.json (sorted). The module
+    CLASS is not read here — :func:`_load_component` resolves it through the
+    production loader, which is the one place that mapping may live."""
     idx = json.loads((tree / "model_index.json").read_text())
-    out: Dict[str, Tuple[str, str]] = {}
-    for name, entry in idx.items():
-        if name.startswith("_") or not isinstance(entry, list) or len(entry) != 2:
-            continue
-        if entry[0] is None or entry[1] is None:
-            continue
-        out[name] = (str(entry[0]), str(entry[1]))
-    return out
+    return sorted(
+        name for name, entry in idx.items()
+        if not name.startswith("_")
+        and isinstance(entry, list) and len(entry) == 2
+        and entry[0] is not None and entry[1] is not None
+    )
 
 
 def component_digest(tree: Path, component: str) -> str:
@@ -172,10 +174,10 @@ def component_digest(tree: Path, component: str) -> str:
 def swap_plan(tree_a: Path, tree_b: Path) -> Tuple[List[str], List[str]]:
     """(differing, shared_by_content_address) component names for A -> B.
     Pure planning — runs anywhere, no CUDA needed."""
-    comps_b = _component_entries(tree_b)
+    comps_b = _component_names(tree_b)
     differing: List[str] = []
     shared: List[str] = []
-    for name in sorted(comps_b):
+    for name in comps_b:
         if not (tree_b / name).is_dir():
             continue
         if component_digest(tree_a, name) == component_digest(tree_b, name):
@@ -185,18 +187,20 @@ def swap_plan(tree_a: Path, tree_b: Path) -> Tuple[List[str], List[str]]:
     return differing, shared
 
 
-def _load_component(tree: Path, name: str, lib: str, cls_name: str) -> Any:
-    module = importlib.import_module(lib)
-    cls = getattr(module, cls_name)
-    src = tree / name
-    if callable(getattr(cls, "from_pretrained", None)):
-        try:
-            import torch
+def _load_component(tree: Path, name: str) -> Any:
+    """One component, through the PRODUCTION component-load path.
 
-            return cls.from_pretrained(str(src), torch_dtype=torch.bfloat16)
-        except TypeError:
-            return cls.from_pretrained(str(src))
-    raise OffPodError(f"component {name}: {lib}.{cls_name} has no from_pretrained")
+    The benchmark's whole purpose is measuring what serving pays, so it must
+    not own a second loader. ``models.loading.load_component`` is the same
+    function the executor's component substitution and the pgw#674 rotation
+    preloader call, and it routes quantized artifacts (w8a8 / w4a4) to their
+    lane loaders. The reimplementation this replaced called
+    ``cls.from_pretrained`` directly, which on any modelopt-produced flavor
+    — i.e. every tree the fleet actually serves — died reconstructing
+    ``NVIDIAModelOptConfig`` (pgw#689)."""
+    from ..models.loading import load_component
+
+    return load_component(tree, name)
 
 
 def _module_bytes(obj: Any) -> int:
@@ -214,11 +218,11 @@ def bench_load(tree: Path, emit: EmitFn) -> Dict[str, Any]:
     loaded: Dict[str, Any] = {}
     total_t0 = time.monotonic()
     total_bytes = 0
-    for name, (lib, cls_name) in sorted(_component_entries(tree).items()):
+    for name in _component_names(tree):
         if not (tree / name).is_dir():
             continue
         t0 = time.monotonic()
-        obj = _load_component(tree, name, lib, cls_name)
+        obj = _load_component(tree, name)
         host_s = time.monotonic() - t0
         t1 = time.monotonic()
         import torch
@@ -264,7 +268,6 @@ def bench_swap(
     """Component-first swap A -> B: only differing components move."""
     import torch
 
-    comps_b = _component_entries(tree_b)
     differing, shared = swap_plan(tree_a, tree_b)
     emit(Row("swap", f"{tree_a.name}->{tree_b.name}/plan", 0.0, 0,
              {"differing": differing, "shared_by_content_address": shared}))
@@ -274,8 +277,7 @@ def bench_swap(
     replaced_bytes = 0
     fresh: Dict[str, Any] = {}
     for name in differing:
-        lib, cls_name = comps_b[name]
-        obj = _load_component(tree_b, name, lib, cls_name)
+        obj = _load_component(tree_b, name)
         if isinstance(obj, torch.nn.Module):
             obj = obj.to("cuda")
         fresh[name] = obj
@@ -318,11 +320,11 @@ def bench_stage(tree: Path, emit: EmitFn) -> None:
 
     total_pin = 0
     total_h2d_s = 0.0
-    for name, (lib, cls_name) in sorted(_component_entries(tree).items()):
+    for name in _component_names(tree):
         if not (tree / name).is_dir():
             continue
         t0 = time.monotonic()
-        obj = _load_component(tree, name, lib, cls_name)
+        obj = _load_component(tree, name)
         load_s = time.monotonic() - t0
         if not isinstance(obj, torch.nn.Module):
             continue

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2234,6 +2234,53 @@ def _vae_supports_channels_last(vae: Any) -> bool:
         return False
 
 
+#: The hub-resolved execution-lane descriptor for the checkpoint this
+#: pipeline serves (th#913 ``lane`` string), stamped by the executor at
+#: injection time. Consumed by :func:`mandatory_serving` only — cell keys
+#: keep the weight-lane brain (pgw#686).
+EXECUTION_LANE_ATTR = "_cozy_execution_lane"
+
+#: Setup-scoped fallback (pgw#677 reopen): the executor opens this window
+#: around one record's whole setup, so pipelines armed through ANY path —
+#: slot injection or a self-loaded ``arm_compile`` inside ``setup()``
+#: (ArmingScope) — get the same lane stamped by :func:`apply`.
+_SETUP_EXEC_LANE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "gw_setup_execution_lane", default="")
+
+
+def mandatory_serving(pipeline: Any) -> bool:
+    """ONE brain for "may this pipeline serve eager?" (pgw#677 reopen).
+
+    Mandatory-ness follows the hub-resolved EXECUTION lane whenever the
+    executor stamped one (``_cozy_execution_lane``, th#913/th#1059): only
+    real w8a8/w4a4 ACTIVATION execution forbids the eager tier. The weight
+    -lane stamp stays the CELL IDENTITY brain (pgw#686) — but it names the
+    storage/branch family, not serveability: sdxl's mixed ``#fp8-w8a8``
+    storage stamps ``w8a8-lora64`` while the hub serves it as
+    ``fp8-w8a16+eager``, and classifying that stamp as mandatory silently
+    routed the whole boot into the FOREGROUND compile-then-serve mint (the
+    reopen's measured 26-minute tenant starvation). Without lane evidence
+    the stamp remains the fail-closed fallback."""
+    lane_str = str(getattr(pipeline, EXECUTION_LANE_ATTR, "") or "").strip()
+    if not lane_str:
+        lane_str = _SETUP_EXEC_LANE.get().strip()
+        if lane_str:
+            try:
+                setattr(pipeline, EXECUTION_LANE_ATTR, lane_str)
+            except Exception:
+                pass
+    if lane_str:
+        from .models import lanes as lanespec
+
+        try:
+            lane = lanespec.parse_lane(lane_str)
+        except ValueError:
+            pass
+        else:
+            return lane.activation in (lanespec.ACT_W8A8, lanespec.ACT_W4A4)
+    return pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
+
+
 def apply(
     pipeline: Any,
     cfg: Any,
@@ -2295,7 +2342,12 @@ def apply(
 
     regional = bool(getattr(cfg, "regional", False))
 
-    fail_closed = pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
+    # pgw#677 reopen: fail-closed follows the ONE serveability brain — the
+    # hub-resolved execution lane when stamped, the weight-lane prefix
+    # otherwise. A fail-closed router can never enable eager-while-compiling
+    # routing, so misclassifying an eager-serveable lane here re-creates the
+    # sequential inline-compile boot for the whole record.
+    fail_closed = mandatory_serving(pipeline)
 
     failure_signal: Dict[str, Any] = {
         "callback": None,

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2278,7 +2278,12 @@ def mandatory_serving(pipeline: Any) -> bool:
             pass
         else:
             return lane.activation in (lanespec.ACT_W8A8, lanespec.ACT_W4A4)
-    return pipeline_weight_lane(pipeline).startswith(("w8a8", "w4a4"))
+    # Module-attr call (not the top-level import): tests monkeypatch
+    # models.loading.pipeline_weight_lane; stay late-bound.
+    from .models import loading as _loading
+
+    return _loading.pipeline_weight_lane(pipeline).startswith(
+        ("w8a8", "w4a4"))
 
 
 def apply(

--- a/src/gen_worker/diagnostics.py
+++ b/src/gen_worker/diagnostics.py
@@ -3,26 +3,44 @@
 The swap-latency harness (:mod:`gen_worker.benchmarks.swap_latency`) needs
 a first-class delivery path onto serving-class pods — ie#546 recorded that
 no such path existed (no sshd on pods). This module gives it one: an
-ordinary ``@endpoint`` class an endpoint project re-exports, so the harness
-is dispatched through the NORMAL request path — the same payload path
+ordinary ``@endpoint`` class an endpoint project adopts, so the harness is
+dispatched through the NORMAL request path — the same payload path
 th#1198's admin benchmark runs use — and its rows come back as the job
 result.
 
 Usage (in an endpoint project, e.g. inference-endpoints)::
 
-    from gen_worker.diagnostics import SwapLatencyDiagnostics  # noqa: F401
+    from gen_worker.diagnostics import SwapLatencyDiagnostics
 
-Discovery picks the class up like any other endpoint; publish it as its
-own diagnostics release. Bind ``checkpoint``/``to`` at deploy time or per
-request via ``selected_by`` — the trees come out of the hub CAS through
-the worker's ordinary snapshot materialization, so the benchmark measures
-the exact tiers production serving uses. Invoker policy (who may call it)
-is hub catalog data, not SDK code.
+    class SwapLatency(SwapLatencyDiagnostics):
+        '''This project's swap-latency diagnostics endpoint.'''
+
+SUBCLASS it — do not merely re-export it. Discovery walks a package and
+skips decorated objects whose ``__module__`` lies outside it (a bare
+``from ... import X`` re-export is a third-party object by that rule and is
+dropped — loudly, since pgw#689). A subclass is declared IN the endpoint
+package, inherits the decorator's declaration, and is picked up like any
+other endpoint. Publish it as its own diagnostics release.
+
+Bind ``checkpoint``/``to`` at deploy time — the trees come out of the hub
+CAS through the worker's ordinary snapshot materialization, so the
+benchmark measures the exact tiers production serving uses. Invoker policy
+(who may call it) is hub catalog data, not SDK code.
+
+Failure contract (pgw#689 defect 3): this handler NEVER raises for a
+benchmark-domain failure. A diagnostic that cannot measure has produced a
+measurement RESULT — ``status="failed"`` naming the cause — not evidence
+that the release is broken. Raising here fed the hub's fast-failure breaker
+and tripped ``model_load_failure_streak`` on a live release, which recycled
+a warm pod that had just spent 26 minutes minting. Sibling functions serve
+tenant traffic on that same pod; this one never does.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import traceback
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -33,11 +51,14 @@ from .api.slot import Slot
 from .benchmarks import swap_latency as bench
 from .request_context import RequestContext
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "SwapLatencyDiagnostics",
     "SwapLatencyInput",
     "SwapLatencyOutput",
     "SwapLatencyRow",
+    "failure_outcome",
 ]
 
 
@@ -45,12 +66,23 @@ class SwapLatencyInput(msgspec.Struct, frozen=True):
     """One benchmark request.
 
     ``checkpoint``/``to`` drive the slot picks (``selected_by``); the hub
-    overlays the allowed-value enum. ``cases`` defaults to everything that
-    needs only tree A — pass ``("swap",)`` with a distinct ``to`` pick for
-    the component-diff swap case.
+    overlays the allowed-value enum. Both default to ``""`` — the hub reads
+    an empty pick as "no value supplied" and uses the DEPLOY binding, which
+    is what this handler reads anyway (``setup()`` owns both trees). The
+    defaults are load-bearing, not cosmetic: a family-less ``Slot(str)``
+    cannot carry a ``curated`` policy (the hub cannot derive an architecture
+    family for it), a ``fixed`` slot rejects every supplied value, and a
+    REQUIRED msgspec field cannot be omitted — so without the defaults no
+    payload exists that the hub accepts (pgw#689). Dropping them re-breaks
+    dispatch; making a family-less string slot curatable hub-side is the
+    alternative fix.
+
+    ``cases`` defaults to everything that needs only tree A — pass
+    ``("swap",)`` with a distinct ``to`` binding for the component-diff swap
+    case.
     """
 
-    checkpoint: str
+    checkpoint: str = ""
     to: str = ""
     cases: Tuple[str, ...] = ("load", "demote", "stage", "overlap")
     overlap_gb: float = 4.0
@@ -80,6 +112,13 @@ class SwapLatencyOutput(msgspec.Struct, frozen=True):
     # when both trees are bound, even without the measured swap case.
     differing_components: Tuple[str, ...] = ()
     shared_components: Tuple[str, ...] = ()
+    # The measurement's own outcome (pgw#689 defect 3): "ok" | "refused"
+    # (this host must not run weight benchmarks — off-pod / no CUDA) |
+    # "failed" (it ran and could not measure). Never a raised fatal: a
+    # broken diagnostic is not a broken release.
+    status: str = "ok"
+    error: str = ""
+    traceback_text: str = ""
 
 
 def _to_row(row: bench.Row) -> SwapLatencyRow:
@@ -95,6 +134,24 @@ def _to_row(row: bench.Row) -> SwapLatencyRow:
     )
 
 
+def failure_outcome(exc: BaseException) -> SwapLatencyOutput:
+    """A failed measurement, as data. Loud in the pod log, benign on the
+    wire — the job SUCCEEDS, so no release-health signal is emitted."""
+    status = "refused" if isinstance(exc, bench.OffPodError) else "failed"
+    logger.error(
+        "swap-latency diagnostics %s — %s: %s (diagnostic outcome only; the "
+        "release's serving functions are unaffected)",
+        status, type(exc).__name__, exc, exc_info=exc,
+    )
+    return SwapLatencyOutput(
+        rows=[],
+        status=status,
+        error=f"{type(exc).__name__}: {exc}",
+        traceback_text="".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)),
+    )
+
+
 @endpoint(
     models={
         "checkpoint": Slot(str, selected_by="checkpoint", root=True),
@@ -107,7 +164,10 @@ def _to_row(row: bench.Row) -> SwapLatencyRow:
     ),
 )
 class SwapLatencyDiagnostics:
-    """Pod-side physical swap benchmark as an ordinary worker function."""
+    """Pod-side physical swap benchmark as an ordinary worker function.
+
+    Subclass this inside an endpoint package to publish it — a bare
+    re-export is skipped by discovery (see the module docstring)."""
 
     def setup(self, checkpoint: str, to: str) -> None:
         self._checkpoint = Path(checkpoint)
@@ -117,6 +177,12 @@ class SwapLatencyDiagnostics:
     def swap_latency(
         self, ctx: RequestContext, payload: SwapLatencyInput,
     ) -> SwapLatencyOutput:
+        try:
+            return self._measure(payload)
+        except Exception as exc:  # noqa: BLE001 — the failure contract above
+            return failure_outcome(exc)
+
+    def _measure(self, payload: SwapLatencyInput) -> SwapLatencyOutput:
         to: Optional[Path] = self._to
         if to is not None and to == self._checkpoint:
             to_effective: Optional[Path] = None

--- a/src/gen_worker/discovery/walk.py
+++ b/src/gen_worker/discovery/walk.py
@@ -8,7 +8,11 @@ registry use this single walker so they can never drift apart.
 Invariants:
 
 * Objects whose ``__module__`` is outside the walked package tree are
-  skipped (third-party re-exports stay out).
+  skipped (third-party re-exports stay out) — LOUDLY, at WARNING, naming the
+  class and the fix (subclass it locally). The skip was silent until
+  pgw#689, which is how an SDK-provided diagnostics endpoint, re-exported
+  exactly as its own docstring instructed, vanished from a release with no
+  trace in any log.
 * Each object is yielded exactly once even when re-exported into multiple
   namespaces (dedup by ``id``).
 * A module that fails to IMPORT is a HARD failure
@@ -115,9 +119,18 @@ def _scan_module(
             obj_module != walked_package_name
             and not obj_module.startswith(walked_package_prefix)
         ):
-            logger.info(
-                "Skipping endpoint '%s.%s' — defined outside the walked "
-                "package '%s'.",
+            logger.warning(
+                "SKIPPING @endpoint '%s.%s' re-exported into '%s' — it is "
+                "DEFINED in '%s', outside the walked package '%s', so it "
+                "will NOT appear in endpoint.lock or the worker's route "
+                "table. A bare `from %s import %s` never publishes: SUBCLASS "
+                "it inside '%s' instead (the subclass inherits the "
+                "declaration and is declared here). pgw#689: this skip used "
+                "to be silent, and an SDK diagnostics endpoint went missing "
+                "for a whole release because of it.",
+                obj_module, getattr(obj, "__name__", "<unknown>"),
+                getattr(module, "__name__", "<unknown>"),
+                obj_module, walked_package_name,
                 obj_module, getattr(obj, "__name__", "<unknown>"),
                 walked_package_name,
             )

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -509,6 +509,9 @@ _MANDATORY_LANES = ("w8a8", "w4a4")
 # bounds "finish the current unit" (one eager forward) before a hard cancel.
 _MINT_ABANDON_GRACE_S = 60.0
 _MINT_SEED_MAX_PASSES = 8
+#: Consecutive OOM-truncated seed passes before the mint aborts loudly
+#: (pgw#677 reopen: never finalize a partial capture off an OOM'd plan).
+_MINT_OOM_MAX_PASSES = 3
 _MINT_POLL_INTERVAL_S = 1.0
 
 # pgw#677 background-turn gate: tenant requests always win the GPU; mint
@@ -517,6 +520,14 @@ _MINT_POLL_INTERVAL_S = 1.0
 #: STEAL one turn (the minimum-progress guarantee — background work still
 #: finishes under sustained tenant load).
 _BG_STEAL_FLOOR_S = 30.0
+#: COMPILE turns get a far higher steal floor (pgw#677 reopen sizing
+#: correction): a stolen turn is not preemptible, and a real inductor
+#: compile is 4-7 unabortable minutes on an L4 — ~100x the advertised
+#: 30-90s residual. Compiles therefore run in tenant-idle gaps (arrivals
+#: cluster around completions, so gaps exist under real load) and may
+#: steal only against MINUTES of truly continuous demand — and when one
+#: does, it announces itself on the wire (``bg_turn_steal``).
+_BG_COMPILE_STEAL_FLOOR_S = 600.0
 #: A turn that ran against live demand "costs" this multiple of its own
 #: duration before the next steal — bounds the stolen duty cycle to
 #: 1/(1+factor) even when every turn is a multi-minute compile.
@@ -2094,6 +2105,10 @@ class _WarmupEvidence:
 
     count: int = 0
     functions_by_object: Dict[int, set[str]] = dc_field(default_factory=dict)
+    #: pgw#677 reopen: non-empty when the warm plan was CUT SHORT (OOM
+    #: backoff) — names the truncation. A truncated plan must never publish
+    #: its partial capture as the family cell.
+    aborted: str = ""
 
 
 # gw#661: setup failures whose contract is "will be re-attempted". These are
@@ -3781,6 +3796,17 @@ class Executor:
                 return lane
         return ""
 
+    def _execution_lane_for_ref(self, ref: str) -> str:
+        """The hub-resolved th#913 execution-lane descriptor for ``ref``
+        (declared or resolved form), "" when the hub sent no lane."""
+        ref = (ref or "").strip()
+        for declared, pick in (self._model_resolutions or {}).items():
+            resolved_ref = (pick[0] or declared).strip()
+            lane_str = (pick[2] or "").strip()
+            if lane_str and ref in (declared.strip(), resolved_ref):
+                return lane_str
+        return ""
+
     def _validate_required_compile(
         self, spec: EndpointSpec, run: pb.RunJob,
     ) -> None:
@@ -4936,6 +4962,20 @@ class Executor:
                         "boot warmup %s OOMed (%s) — skipping remaining "
                         "warmups; the first-request fit ladder owns this",
                         wj.spec.name, exc)
+                    # pgw#677 reopen: a truncated plan is recorded — the
+                    # caller withholds any pending mint's publish (the
+                    # partial cell would brick adopters) — and, when this
+                    # boot IS minting, the truncation reaches the hub as a
+                    # typed event instead of dying in pod logs.
+                    evidence.aborted = (
+                        f"cuda_oom at warm unit "
+                        f"{evidence.count + 1} ({wj.spec.name}): {exc}")
+                    if tracing:
+                        activity_mod.emit_event(
+                            "self_mint_abort",
+                            f"boot warm plan cut short: {evidence.aborted}",
+                            phase="warmup_oom",
+                        )
                     if torch is not None and torch.cuda.is_available():
                         torch.cuda.empty_cache()
                     return False
@@ -5189,6 +5229,36 @@ class Executor:
     ) -> Any:
         assert spec.cls is not None  # guarded by ensure_setup
         setup_slots = self._setup_slots(spec)
+        # pgw#677 reopen: open the setup-scoped execution-lane window so
+        # EVERY arm path (slot injection AND self-loaded arm_compile via
+        # ArmingScope) stamps its pipelines with the hub-resolved th#913
+        # lane — the ONE serveability brain compile_cache.mandatory_serving
+        # reads. ContextVars ride to_thread, so the tenant setup thread and
+        # its arms inherit the window.
+        from . import compile_cache as _cc_lane
+
+        _setup_exec_lane = ""
+        for _slot in setup_slots:
+            _setup_exec_lane = self._execution_lane_for_ref(
+                wire_ref(spec.models[_slot]))
+            if _setup_exec_lane:
+                break
+        _lane_token = _cc_lane._SETUP_EXEC_LANE.set(_setup_exec_lane)
+        try:
+            return await self._setup_locked_inner(
+                spec, rec, snapshots, intent_id=intent_id,
+                setup_slots=setup_slots)
+        finally:
+            _cc_lane._SETUP_EXEC_LANE.reset(_lane_token)
+
+    async def _setup_locked_inner(
+        self, spec: EndpointSpec, rec: _ClassRecord,
+        snapshots: Optional[Dict[str, pb.Snapshot]],
+        *,
+        intent_id: str = "",
+        setup_slots: List[str],
+    ) -> Any:
+        assert spec.cls is not None
         # gw#494: residency keys for this setup are derived ONCE, here, in
         # resolved space; downloads, booking and the record's held_refs all
         # use these exact strings (a HelloAck rebind during an await below
@@ -5422,7 +5492,7 @@ class Executor:
             }
             warmup = getattr(instance, "warmup", None)
 
-            async def run_warmup() -> Tuple[int, Dict[int, set[str]]]:
+            async def run_warmup() -> Tuple[int, Dict[int, set[str]], str]:
                 if callable(warmup):
                     warm_t0 = time.monotonic()
                     if asyncio.iscoroutinefunction(warmup):
@@ -5433,7 +5503,7 @@ class Executor:
                         logger.info(
                             "compile-cache warmup %s completed in %.1fs",
                             spec.name, time.monotonic() - warm_t0)
-                    return 1, {}
+                    return 1, {}, ""
 
                 # gw#470: no custom warmup() — run every declared handler of
                 # this instance group. A failure propagates as a load failure.
@@ -5456,7 +5526,8 @@ class Executor:
                         for sel in inj.active_compile_artifacts.values()
                     ),
                 )
-                return evidence.count, evidence.functions_by_object
+                return (evidence.count, evidence.functions_by_object,
+                        evidence.aborted)
 
             # pgw#671: an eager-first foreground pass is an eager warm, not
             # the inductor compile — that runs in the background driver.
@@ -5501,9 +5572,9 @@ class Executor:
                         if _sel is not None and not trt_engine.is_engine_ref(
                                 _sel.ref):
                             compile_cache.reset_target_code(_cand.pipeline)
-                    warmed, function_proofs = await run_warmup()
+                    warmed, function_proofs, warm_aborted = await run_warmup()
             else:
-                warmed, function_proofs = await run_warmup()
+                warmed, function_proofs, warm_aborted = await run_warmup()
             compile_seconds = (
                 compile_cache.compile_wall_seconds() - compile_seconds_before
                 if proves_inductor else 0.0)
@@ -5735,6 +5806,14 @@ class Executor:
                             "serving (pgw#672)", detail)
                         activity_mod.current_note(
                             f"compiled lane degraded to eager: {detail}")
+                        # pgw#677 reopen: countable typed event — the
+                        # degrade + withheld publish must be visible
+                        # without pod logs.
+                        activity_mod.emit_event(
+                            "self_mint_abort",
+                            f"proof failed; degraded to eager: {detail}",
+                            phase="proof_failed",
+                        )
                     else:
                         logger.warning("%s; serving eager", detail)
                 if unexercised:
@@ -5817,7 +5896,17 @@ class Executor:
                             oid for oid in sharers
                             if oid not in proven_mint_objs
                         ]
-                        if gap:
+                        if warm_aborted:
+                            # pgw#677 reopen: a plan cut short (OOM backoff)
+                            # can leave every OBJECT looking proven while
+                            # whole graph CLASSES are missing — publishing
+                            # that partial pack bricks every adopting boot.
+                            fleet_cells_mod.withhold_self_mint_publish(
+                                pending,
+                                f"warm plan cut short ({warm_aborted}); "
+                                "planned graphs are absent from the packed "
+                                "cell")
+                        elif gap:
                             fleet_cells_mod.withhold_self_mint_publish(
                                 pending,
                                 f"{len(gap)}/{len(sharers)} capture-sharing "
@@ -7032,6 +7121,24 @@ class Executor:
                         # stays eager. ``compile_artifact`` is hub-attached (#569).
                         from . import compile_cache
 
+                        # pgw#677 reopen: stamp the hub-resolved execution
+                        # lane on the pipe BEFORE arming, so the router's
+                        # fail_closed and the eager-first eligibility both
+                        # read the ONE serveability brain
+                        # (compile_cache.mandatory_serving) instead of the
+                        # weight-lane prefix. Never overwritten once set.
+                        exec_lane = self._execution_lane_for_ref(ref)
+                        if exec_lane and not getattr(
+                                pipe, compile_cache.EXECUTION_LANE_ATTR,
+                                None):
+                            try:
+                                setattr(
+                                    pipe,
+                                    compile_cache.EXECUTION_LANE_ATTR,
+                                    exec_lane)
+                            except Exception:
+                                pass
+
                         try:
                             outcome = await _to_thread_complete(
                                 self._enable_compiled,
@@ -7279,15 +7386,23 @@ class Executor:
             wire_ref(spec.models[slot]) for slot in self._setup_slots(spec)
         ):
             return False
-        from . import hot_swap
-        from .models.loading import pipeline_weight_lane
+        from . import compile_cache, hot_swap
 
         saw_router = False
         for candidate in inj.compile_objects:
             if id(candidate.pipeline) not in inj.pending_self_mints:
                 continue
-            if pipeline_weight_lane(candidate.pipeline).startswith(
-                    _MANDATORY_LANES):
+            # pgw#677 reopen: THE live break. The weight-lane stamp names
+            # cell identity (pgw#686), not serveability — sdxl's mixed
+            # ``#fp8-w8a8`` storage stamps ``w8a8-lora64`` while the hub
+            # serves it ``fp8-w8a16+eager``. Classifying that stamp as
+            # mandatory silently sent the whole boot down the FOREGROUND
+            # compile-then-serve mint: the first tenant request sat inside
+            # ensure_setup for the full 18-unit inline-compile plan (the
+            # measured 26-minute starvation on three cold L4 pods, zero
+            # renders, gate machinery never engaged). Serveability follows
+            # the ONE brain: hub execution lane first, stamp as fallback.
+            if compile_cache.mandatory_serving(candidate.pipeline):
                 return False
             router = hot_swap.router_of(candidate.pipeline)
             if router is None or router.fail_closed:
@@ -7386,12 +7501,27 @@ class Executor:
             logger.info(
                 "background mint for %s abandoned cleanly; serving continues "
                 "at its current tier", bg.spec.name)
+            activity_mod.emit_event(
+                "self_mint_abort",
+                f"background mint for {bg.spec.name} abandoned "
+                "(adopt-on-arm / vacate / shutdown); serving continues at "
+                "its current tier",
+                phase="abandoned",
+            )
             act.completed()
         except Exception as exc:
             self._abandon_mint_state(rec, bg)
             logger.warning(
                 "background mint for %s failed (%s: %s); serving stays eager "
                 "for this process", bg.spec.name, type(exc).__name__, exc)
+            # pgw#677 reopen: the abort cause rides the wire typed and
+            # countable, in addition to the FAILED activity terminal.
+            activity_mod.emit_event(
+                "self_mint_abort",
+                f"background mint for {bg.spec.name} failed: "
+                f"{type(exc).__name__}: {exc}",
+                phase="error",
+            )
             act.failed(exc)
         else:
             act.completed()
@@ -7526,10 +7656,14 @@ class Executor:
                     return False
             return True
 
-        async def _seed_pass(jobs_now: List[Any]) -> None:
+        async def _seed_pass(jobs_now: List[Any]) -> bool:
             """One full-plan seed pass; preempted units re-queue within the
             pass (a preemption is not plan progress — the pass semantics
-            stay 'every unit ran to completion once')."""
+            stay 'every unit ran to completion once'). False = the pass was
+            CUT SHORT by an OOM backoff — the caller must never treat such
+            a pass as converged (pgw#677 reopen: an OOM-truncated plan that
+            converged silently is how a partial capture reached finalize at
+            unit 8/18 with nothing publishable)."""
             pending_units = list(jobs_now)
             completed = 0
             while pending_units:
@@ -7547,13 +7681,22 @@ class Executor:
                     logger.warning(
                         "background mint seed %s OOMed (%s); backing off "
                         "this pass", wj.spec.name, exc)
+                    activity_mod.emit_event(
+                        "self_mint_abort",
+                        f"seed pass cut short by CUDA OOM at unit "
+                        f"{completed + 1}/{len(jobs_now)} "
+                        f"({wj.spec.name}): {exc}; backing off and "
+                        "retrying the pass",
+                        phase="warmup_oom",
+                    )
                     if torch is not None and torch.cuda.is_available():
                         torch.cuda.empty_cache()
-                    return
+                    return False
                 if done:
                     completed += 1
                 else:
                     pending_units.append(wj)
+            return True
 
         # Phase 1 — SEED: run the full derived plan through the enabled
         # routers. Every novel signature serves EAGER here and enqueues its
@@ -7561,6 +7704,7 @@ class Executor:
         # the signature vocabulary is stable (a full queue drops seeds — a
         # later pass re-enqueues them) and no compile is pending.
         seeding_pass = 0
+        oom_passes = 0
         while True:
             seeding_pass += 1
             if seeding_pass > _MINT_SEED_MAX_PASSES:
@@ -7568,7 +7712,7 @@ class Executor:
                     f"mint seeding did not converge after "
                     f"{_MINT_SEED_MAX_PASSES} passes")
             before = _stats()
-            await _seed_pass(jobs)
+            pass_ok = await _seed_pass(jobs)
             act.phase(activity_mod.PHASE_INDUCTOR_COMPILE)
             while True:
                 _checkpoint()
@@ -7576,6 +7720,20 @@ class Executor:
                 if pending == 0:
                     break
                 await asyncio.sleep(_MINT_POLL_INTERVAL_S)
+            if not pass_ok:
+                # pgw#677 reopen: an OOM-truncated pass is NEVER
+                # convergence — stats can be stable precisely because the
+                # remaining units never ran. Retry (bounded by the pass
+                # cap); a persistent OOM aborts the mint loudly instead of
+                # finalizing a partial capture.
+                oom_passes += 1
+                if oom_passes >= _MINT_OOM_MAX_PASSES:
+                    raise RuntimeError(
+                        f"mint aborted: the warm plan OOMed on "
+                        f"{oom_passes} consecutive passes; refusing to "
+                        "finalize a partial capture")
+                continue
+            oom_passes = 0
             after = _stats()
             if after == before:
                 break
@@ -7584,6 +7742,12 @@ class Executor:
             raise RuntimeError(
                 f"{failed_sigs} signature(s) failed their background "
                 "compile; the capture is incomplete")
+        dropped = sum(r.seed_dropped for r in routers.values())
+        if dropped:
+            raise RuntimeError(
+                f"{dropped} mint seed signature(s) could not enqueue their "
+                "background compile (vocabulary overflow or dummy-batch "
+                "failure); the capture would be incomplete")
 
         # Phase 2 — VERIFY: every signature is warm, so these forwards
         # route COMPILED through the guarded wrappers — the successful
@@ -8675,13 +8839,29 @@ class Executor:
                     return False
                 wait_s = max(_BG_COMPILE_QUIESCENCE_S - quiet_for, 0.0)
             else:
+                floor = (
+                    _BG_COMPILE_STEAL_FLOOR_S if kind == "compile"
+                    else _BG_STEAL_FLOOR_S)
                 with self._bg_state_lock:
                     due = max(
                         self._bg_steal_debt_until,
-                        blocked_since + _BG_STEAL_FLOOR_S,
+                        blocked_since + floor,
                     )
                 if now >= due:
                     _admitted()
+                    if kind == "compile":
+                        # pgw#677 reopen: a stolen compile turn stalls the
+                        # next tenant on this instance for one unabortable
+                        # multi-minute compile — never silently.
+                        activity_mod.emit_event(
+                            "bg_turn_steal",
+                            f"stole a background compile turn after "
+                            f"{now - blocked_since:.0f}s of continuous "
+                            "tenant demand; the next tenant on this "
+                            "instance waits out one unabortable compile "
+                            "(attributed to instance_gate_wait)",
+                            phase="compile",
+                        )
                     return True
                 wait_s = due - now
             if max_wait is not None and now - attempt_start >= max_wait:

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -61,6 +61,7 @@ from typing import Any, Callable, Dict, Optional
 
 import requests
 
+from . import activity as activity_mod
 from . import cell_key
 from . import compile_cache as cc
 from . import guard_closure
@@ -312,8 +313,19 @@ def _publish_async(publisher: CellPublisher, family: str, artifact: Path, meta: 
             publisher.publish(family, artifact, meta)
         except CellPublishRefused as exc:
             logger.warning("fleet-cells: publish refused (hub decision): %s", exc)
-        except Exception:
+            activity_mod.emit_event(
+                "self_mint_publish_failed",
+                f"family={family}: hub refused the publish: {exc}",
+                phase="refused",
+            )
+        except Exception as exc:  # noqa: BLE001 — reported, never fatal
             logger.warning("fleet-cells: publish failed; the next worker on this key re-mints", exc_info=True)
+            activity_mod.emit_event(
+                "self_mint_publish_failed",
+                f"family={family}: publish attempt failed: "
+                f"{type(exc).__name__}: {exc}",
+                phase="error",
+            )
         finally:
             shutil.rmtree(artifact.parent, ignore_errors=True)
 
@@ -569,6 +581,16 @@ def finalize_self_mint(
             "fleet-cells: self-mint pack failed after a passed proof (%s) — "
             "the compiled callables stay live for this process, but this "
             "boot cannot advertise or publish a cell", exc)
+        # pgw#677 reopen: this exit swallowed the pgw#681 closure-gate
+        # refusal (and every other pack failure) into unreachable pod logs
+        # — the ie#546 final cycle lost its root cause to exactly that.
+        # The reason now rides the wire as a typed, countable event.
+        activity_mod.emit_event(
+            "self_mint_abort",
+            f"pack/finalize failed for family={pending.family} "
+            f"key={pending.cell_key}: {type(exc).__name__}: {exc}",
+            phase="pack_failed",
+        )
         state["minted"] = None
         _unregister(pending)
         shutil.rmtree(pending.mint_root, ignore_errors=True)
@@ -640,6 +662,13 @@ def publish_self_mint(pending: "PendingSelfMint") -> None:
             "fleet-cells: SELF_MINT_WITHOUT_PUBLISH_SINK family=%s — cell "
             "stays local to this pod; the fleet store gains nothing",
             pending.family)
+        activity_mod.emit_event(
+            "self_mint_publish_withheld",
+            f"family={pending.family} key={pending.cell_key}: no publish "
+            "sink (file_base_url/worker JWT absent at arming time); cell "
+            "stays local to this pod",
+            phase="no_sink",
+        )
         shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
@@ -662,6 +691,14 @@ def withhold_self_mint_publish(pending: "PendingSelfMint", reason: str) -> None:
         "fleet-cells: SELF_MINT_PUBLISH_WITHHELD family=%s key=%s — %s; "
         "cell stays local to this pod",
         pending.family, pending.cell_key, reason)
+    # pgw#677 reopen: the withhold decision is hub-relevant truth (the mint
+    # obligation stays undischarged and every cold pod re-mints) — it must
+    # never live only in unreachable pod logs.
+    activity_mod.emit_event(
+        "self_mint_publish_withheld",
+        f"family={pending.family} key={pending.cell_key}: {reason}",
+        phase="incomplete",
+    )
     shutil.rmtree(pending.mint_root, ignore_errors=True)
 
 
@@ -760,7 +797,11 @@ def _fail_closed(
     raised refusal so the caller's report is never dropped."""
 
     lane = loading.pipeline_weight_lane(pipe)
-    if lane.startswith(("w8a8", "w4a4")):
+    # pgw#677 reopen: ONE serveability brain (cc.mandatory_serving) — the
+    # hub-resolved execution lane outranks the weight-lane prefix, so an
+    # eager-serveable mixed lane (sdxl #fp8-w8a8 storage on fp8-w8a16
+    # execution) degrades to eager here instead of a typed refusal.
+    if cc.mandatory_serving(pipe):
         refusal = cc.CompiledLaneUnavailableError(
             f"{lane[:4].upper()} requires a compile cell and the self-mint "
             f"is unavailable ({reason})")

--- a/src/gen_worker/hot_swap.py
+++ b/src/gen_worker/hot_swap.py
@@ -247,6 +247,11 @@ class Router:
         self.healing: set = set()
         self.volatile: set = set()
         self.guard_miss_counts: dict = {}
+        # pgw#677 reopen: seeds that could NOT enqueue their background
+        # compile (vocabulary overflow / dummy failure). A nonzero count
+        # means the mint's capture would be incomplete — the driver aborts
+        # loudly instead of finalizing/publishing a partial cell.
+        self.seed_dropped = 0
         # pgw#677: executor-provided background-turn factory. When set,
         # every warm job for this router executes inside a turn, and
         # route() stops degrading novel signatures to inline compiles on
@@ -328,6 +333,12 @@ class Router:
                     "disabling concurrent routing for this pipeline",
                     _MAX_SIGS)
                 self.concurrent = False
+                # pgw#677 reopen: NEVER inline-compile inside a seed — the
+                # seed holds the run gate. The sig stays eager (unwarmed);
+                # the mint driver's convergence loop fails LOUDLY instead.
+                if seed:
+                    self.seed_dropped += 1
+                    return EAGER, sig
                 return COMPILED, sig
             device = _first_cuda_device(args, kwargs)
             # pgw#677: with a turn gate the warm thread owns the device while
@@ -350,11 +361,21 @@ class Router:
                 autocast_dtype=_autocast_dtype(), turn=turn,
             )
         except Exception:
+            with self.lock:
+                self.pending.discard(sig)
+            if seed:
+                # pgw#677 reopen: a seed must never pay the inline compile,
+                # even when its dummy cannot be built — the signature stays
+                # eager and the mint's convergence loop reports it loudly.
+                with self.lock:
+                    self.seed_dropped += 1
+                logger.warning(
+                    "hot-swap: dummy batch for %s failed in a mint seed; "
+                    "the signature stays eager", label, exc_info=True)
+                return EAGER, sig
             logger.warning(
                 "hot-swap: dummy batch for %s failed; sequential compile",
                 label, exc_info=True)
-            with self.lock:
-                self.pending.discard(sig)
             return COMPILED, sig
         if not _submit(job):
             with self.lock:

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -14,14 +14,25 @@ from ..families.facts import component_dtype_for_class
 from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
 import importlib
 import importlib.util
+import inspect
 import os
 import struct
 import sys
 
 from .memory import get_available_vram_gb, meta_tensors
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
-from .w4a4 import detect_w4a4_artifact, load_w4a4_pipeline, load_w4a4_root_pipeline
-from .w8a8 import detect_w8a8_artifact, load_w8a8_pipeline, load_w8a8_root_pipeline
+from .w4a4 import (
+    detect_w4a4_artifact,
+    load_w4a4_denoiser,
+    load_w4a4_pipeline,
+    load_w4a4_root_pipeline,
+)
+from .w8a8 import (
+    detect_w8a8_artifact,
+    load_w8a8_denoiser,
+    load_w8a8_pipeline,
+    load_w8a8_root_pipeline,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -193,10 +204,13 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
     )
 
 
+#: Denoiser component directory names — the only components a quantized
+#: artifact lane (w8a8 / w4a4 / svdq / gguf) ever covers.
+DENOISER_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
 # Pipeline components fp8 storage applies to: the denoiser dominates VRAM and
 # tolerates fp8-E4M3 weight rounding; text encoders / VAE stay at compute
 # precision (quality-safe default, QUANTIZATION-POLICY.md component policy).
-_FP8_STORAGE_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+_FP8_STORAGE_COMPONENTS: tuple[str, ...] = DENOISER_COMPONENTS
 # The "+te" rung (component fit-ladder rung 2): the pipeline's text encoders.
 _FP8_TEXT_ENCODER_COMPONENTS: tuple[str, ...] = (
     "text_encoder", "text_encoder_2", "text_encoder_3",
@@ -1119,30 +1133,84 @@ def _component_dtype_map(
     return out
 
 
-def load_component_override(
-    base_path: str | Path, component: str, override_path: str | Path,
-    *, dtype: str = "",
+class ComponentLaneUnsupported(RuntimeError):
+    """This flavor has no component-level loader, so no honest one exists.
+
+    svdq and gguf materialize their denoiser INSIDE the pipeline build (a
+    nunchaku file / a single gguf checkpoint the pipeline class assembles).
+    Handing back a plain ``from_pretrained`` module for those would not be
+    what serving runs, so the component path refuses by name instead
+    (pgw#689: a benchmark that measures something other than the serve path
+    is worse than one that refuses)."""
+
+
+def _accepts_kwarg(fn: Any, name: str) -> bool:
+    """True when ``fn`` can take ``name=`` (declared or via ``**kwargs``).
+
+    Replaces the ``except TypeError: retry without it`` idiom, which caught
+    ANY construction-time TypeError — including one raised deep inside
+    diffusers' quantization-config reconstruction — and retried a path that
+    failed identically, so the real cause never surfaced (pgw#689 defect 2).
+    Introspection failure means "pass it": the call then fails naming
+    itself."""
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return True
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == name and param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return True
+    return False
+
+
+def load_component(
+    tree: str | Path, component: str, *,
+    dtype: str = "", weights_tree: str | Path | None = None,
 ) -> Any:
-    """Load one named pipeline component from an OVERRIDE snapshot tree
-    (pgw#617 hierarchical bindings). The module class comes from the BASE
-    tree's model_index.json; weights come from the override tree's
-    ``<component>/`` subtree when present, else its root.
+    """THE production loader for ONE named pipeline component.
+
+    Every caller that needs a single component — the executor's pgw#617
+    substitution, the pgw#674 rotation preloader, the swap benchmark — goes
+    through here, so what they load is by construction what serving loads.
+
+    ``tree`` is the BASE composition: it names the module class
+    (model_index.json) and decides the compute dtype. ``weights_tree`` is
+    where the bytes live (default: ``tree``); an override binding points it
+    at its own snapshot, whose ``<component>/`` subtree is used when present,
+    else its root.
+
+    Quantized artifacts take their OWN lane, exactly as
+    :func:`load_from_pretrained` routes a whole pipeline: a w8a8/w4a4
+    denoiser is materialized by its artifact loader. A modelopt-produced
+    tree carries a ``quantization_config`` block diffusers reconstructs into
+    ``NVIDIAModelOptConfig``, whose constructor requires a ``quant_type``
+    the block does not supply — so a bare ``from_pretrained`` on the
+    denoiser dies at config reconstruction on every flavor the fleet
+    actually serves (pgw#689 defect 1). Lanes with no component-level
+    loader raise :class:`ComponentLaneUnsupported`.
 
     dtype resolution (pgw#647 gap #2): the base binding's declared dtype
-    wins; otherwise the override inherits the BASE COMPOSITION's compute
-    dtype (:func:`composition_compute_dtype`); the override's own on-disk
+    wins; otherwise the component inherits the BASE COMPOSITION's compute
+    dtype (:func:`composition_compute_dtype`); the weights' own on-disk
     dtype is only the last resort. Hub-resolved bindings carry no dtype, so
     the old override-on-disk fallback loaded e.g. the fp32-stored fp16-fix
-    VAE into a bf16 pipeline and setup died on the first latent
-    (ie#546 canary, 2/2 pods). Blocking; callers on an event loop run it
+    VAE into a bf16 pipeline and setup died on the first latent (ie#546
+    canary, 2/2 pods). Blocking; callers on an event loop run it
     off-thread."""
 
-    entry = model_index_entry(base_path, component)
+    base = Path(tree)
+    root = Path(weights_tree) if weights_tree is not None else base
+    entry = model_index_entry(base, component)
     if entry is None:
         raise ValueError(
             f"component {component!r} is not in the base composition "
             f"(model_index components: "
-            f"{sorted(model_index_components(base_path))})"
+            f"{sorted(model_index_components(base))})"
         )
     library, class_name = entry
     module = importlib.import_module(library)
@@ -1151,10 +1219,10 @@ def load_component_override(
         raise ValueError(
             f"{library}.{class_name} declares no from_pretrained loader"
         )
-    src = Path(override_path) / component
+    src = root / component
     if not src.is_dir():
-        src = Path(override_path)
-    kwargs: Dict[str, Any] = {}
+        src = root
+
     # pgw#667: a component with a declared load-dtype fact keeps it when it is
     # SUBSTITUTED too — the fact is a property of the component class, and the
     # substituted tree's part must be resident at the same precision the base
@@ -1162,18 +1230,63 @@ def load_component_override(
     fact = component_dtype_for_class(class_name)
     wanted = (
         (fact.dtype if fact is not None else "")
-        or composition_compute_dtype(base_path, dtype)
+        or composition_compute_dtype(base, dtype)
         or detect_on_disk_dtype(src)
     )
+    torch_dtype: Any = None
     if wanted in ("bf16", "fp16", "bfloat16", "float16", "fp32", "float32"):
         try:
-            kwargs["torch_dtype"] = get_torch_dtype(wanted)
+            torch_dtype = get_torch_dtype(wanted)
         except ImportError:
             pass  # torch-less environment: loader fails on its own terms
-    try:
-        return cls.from_pretrained(str(src), **kwargs)
-    except TypeError:
-        return cls.from_pretrained(str(src))
+
+    def _covers(artifact_component: str) -> bool:
+        """The artifact's weight set IS this component: a diffusers tree
+        names it, a bare override tree (root layout) has nothing else in
+        it."""
+        return artifact_component == component or (
+            not artifact_component and src == root
+        )
+
+    w8a8_art = detect_w8a8_artifact(root)
+    if w8a8_art is not None and _covers(w8a8_art.component):
+        return load_w8a8_denoiser(
+            root, w8a8_art, compute_dtype=torch_dtype, cls=cls)
+    w4a4_art = detect_w4a4_artifact(root)
+    if w4a4_art is not None and _covers(w4a4_art.component):
+        return load_w4a4_denoiser(
+            root, w4a4_art, compute_dtype=torch_dtype, cls=cls)
+    svdq_art = detect_svdq_artifact(root)
+    if svdq_art is not None and _covers(svdq_art.component):
+        raise ComponentLaneUnsupported(
+            f"component {component!r} of {root} is an svdq-{svdq_art.precision} "
+            f"artifact ({svdq_art.file.name}): its denoiser is built by the "
+            f"svdq engine during the PIPELINE load, so there is no "
+            f"component-level production loader to borrow"
+        )
+    if component in DENOISER_COMPONENTS and detect_gguf_snapshot(root):
+        raise ComponentLaneUnsupported(
+            f"component {component!r} of {root} is a GGUF denoiser: it is "
+            f"dequantized by the pipeline's own gguf loader, so there is no "
+            f"component-level production loader to borrow"
+        )
+
+    kwargs: Dict[str, Any] = {}
+    if torch_dtype is not None and _accepts_kwarg(
+            cls.from_pretrained, "torch_dtype"):
+        kwargs["torch_dtype"] = torch_dtype
+    return cls.from_pretrained(str(src), **kwargs)
+
+
+def load_component_override(
+    base_path: str | Path, component: str, override_path: str | Path,
+    *, dtype: str = "",
+) -> Any:
+    """Load one named pipeline component from an OVERRIDE snapshot tree
+    (pgw#617 hierarchical bindings) — :func:`load_component` with the
+    weights pointed at the override."""
+    return load_component(
+        base_path, component, dtype=dtype, weights_tree=override_path)
 
 
 def _safetensors_data_bytes(p: Path) -> int:

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -488,12 +488,15 @@ def _dequant_into(sd: Dict[str, Any], name: str, compute: Any) -> None:
 
 
 def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
-                       compute_dtype: Any = None, mode: str = "") -> Any:
+                       compute_dtype: Any = None, mode: str = "",
+                       cls: Any = None) -> Any:
     """Materialize the quantized denoiser: skeleton on meta, quantized
     Linears swapped for W4A4Linear, tensors assigned from the shards.
     ``mode`` "blockwise" | "dequant" (default: probe). Layers whose dims
     break fp4 scaled_mm alignment are dequantized individually (AWQ-lite
-    ``pre_quant_scale`` folds back into the dequantized weight)."""
+    ``pre_quant_scale`` folds back into the dequantized weight).
+    ``cls`` pins the module class (the component path already resolved it
+    from the BASE composition's model_index); default: this tree's own."""
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
@@ -503,7 +506,8 @@ def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
     if mode not in ("blockwise", "dequant"):
         mode = w4a4_gemm_mode() or "dequant"
 
-    cls = _denoiser_class(root, art.component)
+    if cls is None:
+        cls = _denoiser_class(root, art.component)
     cfg = dict(cls.load_config(str(root / art.component)))
     cfg.pop("quantization_config", None)
     with init_empty_weights():

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -474,11 +474,14 @@ def _denoiser_class(root: Path, component: str) -> Any:
 
 
 def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
-                       compute_dtype: Any = None, mode: str = "") -> Any:
+                       compute_dtype: Any = None, mode: str = "",
+                       cls: Any = None) -> Any:
     """Materialize the quantized denoiser: skeleton on meta, quantized
     Linears swapped for Fp8ScaledLinear, tensors assigned from the shards.
     ``mode`` "rowwise" | "pertensor" | "dequant" (default: probe). Layers
-    whose dims break scaled_mm's 16-alignment are dequantized individually."""
+    whose dims break scaled_mm's 16-alignment are dequantized individually.
+    ``cls`` pins the module class (the component path already resolved it
+    from the BASE composition's model_index); default: this tree's own."""
     import torch
     import torch.nn as nn
     from accelerate import init_empty_weights
@@ -488,7 +491,8 @@ def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
     if mode not in ("rowwise", "pertensor", "dequant"):
         mode = w8a8_gemm_mode() or "dequant"
 
-    cls = _denoiser_class(root, art.component)
+    if cls is None:
+        cls = _denoiser_class(root, art.component)
     cfg = dict(cls.load_config(str(root / art.component)))
     cfg.pop("quantization_config", None)
     with init_empty_weights():

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -1,0 +1,665 @@
+"""pgw#677 REOPEN: the live break the 0.70.0 tapes could not see.
+
+The ie#546 final cycle measured, on gen-worker 0.70.0, a cold L4 pod
+holding one tenant `generate` for 26m25s while an 18-unit mint ran
+4-7-minute units back to back, finalizing at unit 8/18 and publishing
+nothing — with the turn gate armed. Root causes, each pinned here:
+
+  1. ELIGIBILITY MISCLASSIFICATION (the starvation): sdxl's mixed
+     ``#fp8-w8a8``-storage checkpoint stamps ``_cozy_weight_lane =
+     "w8a8-lora64"`` while the hub serves it ``fp8-w8a16+eager``. The
+     eager-first eligibility (and the router's ``fail_closed``) read the
+     weight-lane prefix, classified the boot mandatory-quantized, and
+     silently fell back to the FOREGROUND compile-then-serve mint: the
+     tenant sat inside ensure_setup for the whole inline-compile plan,
+     and the entire pgw#677 gate/preemption machinery never ran.
+     Fix: ONE serveability brain (``compile_cache.mandatory_serving``) —
+     the hub-resolved execution lane outranks the weight-lane stamp.
+  2. STOLEN-COMPILE SIZING: a stolen turn is not preemptible and a real
+     inductor compile is 4-7 unabortable minutes — ~100x the advertised
+     30-90s residual. Compile turns now steal only against MINUTES of
+     continuous demand (``_BG_COMPILE_STEAL_FLOOR_S``) and announce the
+     steal on the wire.
+  3. THE PUBLISH BREAK: every mint-abort / publish-withhold /
+     closure-refusal exit died in unreachable pod logs. All of them now
+     ride the wire as typed events (``self_mint_abort``,
+     ``self_mint_publish_withheld``, ``self_mint_publish_failed``), and
+     an OOM-truncated warm plan can no longer converge silently into a
+     partial finalize.
+
+Every tape here is RED on the 0.70.0 tree (this file is self-contained
+so it can be dropped onto that tree to prove it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from typing import Annotated, Any, Dict, List, Tuple
+
+import msgspec
+import pytest
+
+import gen_worker
+import gen_worker.executor as executor_mod
+from gen_worker import (
+    AxisClass,
+    Compile,
+    CompileAxis,
+    RequestContext,
+    Resources,
+    endpoint,
+    worker_function,
+)
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells, guard_closure, hot_swap
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+FAMILY = "sdxl"
+_ASPECT_AXIS = CompileAxis(classes=(
+    AxisClass("sq", match=lambda v: v == "1:1", warm="1:1"),
+    AxisClass("wide", match=lambda v: v == "16:9", warm="16:9"),
+))
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+    aspect_ratio: Annotated[str, _ASPECT_AXIS] = "1:1"
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _Denoiser:
+    def forward(self, aspect: str) -> str:
+        return aspect
+
+
+class _Pipe:
+    def __init__(self, weight_lane: str = "") -> None:
+        self.transformer = _Denoiser()
+        if weight_lane:
+            self._cozy_weight_lane = weight_lane
+
+
+@pytest.fixture(autouse=True)
+def _clean_process_registries() -> Any:
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+    yield
+    with cc._PROVEN_CELLS_LOCK:
+        cc._PROVEN_CELLS.clear()
+    with fleet_cells._PENDING_LOCK:
+        fleet_cells._PENDING.clear()
+    for pipe in list(cc._armed_pipelines()):
+        cc._armed_pipelines().discard(pipe)
+
+
+@pytest.fixture(autouse=True)
+def _fast_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(executor_mod, "_BG_COMPILE_QUIESCENCE_S", 0.02)
+    monkeypatch.setattr(executor_mod, "_MINT_POLL_INTERVAL_S", 0.05)
+
+
+class _Harness:
+    """Real-executor rig: ensure_setup boot, REAL handle_run_job tenant
+    lane, instrumented compile leaf. ``weight_lane`` stamps the sim pipe
+    (the live sdxl shape is ``"w8a8-lora64"``); ``hub_lane`` seeds the
+    executor's model-resolution table with a th#913 execution lane."""
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        compile_delay_s: float = 0.0,
+        seed_forward_s: float = 0.0,
+        tenant_forward_s: float = 0.02,
+        weight_lane: str = "",
+        hub_lane: str = "",
+        seed_oom_after: int = 0,
+    ) -> None:
+        self.tmp_path = tmp_path
+        self.compile_delay_s = compile_delay_s
+        self.seed_forward_s = seed_forward_s
+        self.tenant_forward_s = tenant_forward_s
+        self.seed_oom_after = seed_oom_after
+        self.compiles: List[Tuple[str, str, float, float]] = []
+        self.in_compile = threading.Event()
+        self.seed_runs: List[str] = []
+        self.sent: List[pb.WorkerMessage] = []
+        self.pipes: List[_Pipe] = []
+        harness = self
+
+        @endpoint(
+            model=Hub("acme/sdxl-base"),
+            resources=Resources(gpu=True),
+            compile=Compile(family=FAMILY, shapes=((768, 768),), text_len=0),
+        )
+        class MintEndpoint:
+            def setup(self, model: str) -> None:
+                self.pipe = _Pipe(weight_lane=weight_lane)
+                harness.pipes.append(self.pipe)
+                gen_worker.arm_compile(self.pipe)
+
+            @worker_function()
+            def generate(self, ctx: RequestContext, payload: _In) -> _Out:
+                if ctx.boot_warmup:
+                    harness.seed_runs.append(payload.aspect_ratio)
+                    if (harness.seed_oom_after
+                            and len(harness.seed_runs)
+                            > harness.seed_oom_after):
+                        import torch
+
+                        raise torch.cuda.OutOfMemoryError(
+                            "CUDA out of memory (sim)")
+                    deadline = time.monotonic() + harness.seed_forward_s
+                    while time.monotonic() < deadline:
+                        time.sleep(0.005)
+                        ctx.raise_if_cancelled("seed preempted")
+                    self.pipe.transformer.forward(payload.aspect_ratio)
+                    return _Out()
+                self.pipe.transformer.forward(payload.aspect_ratio)
+                deadline = time.monotonic() + harness.tenant_forward_s
+                while time.monotonic() < deadline:
+                    time.sleep(0.002)
+                return _Out()
+
+        self.cls = MintEndpoint
+        self.specs = extract_specs(MintEndpoint)
+        (self.spec,) = [s for s in self.specs if s.name == "generate"]
+
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        store = ModelStore(
+            _send, cache_dir=tmp_path / "cas", vram_budget_bytes=4 << 30)
+
+        async def _fake_ensure_local(ref: str, **kwargs: Any) -> Path:
+            p = tmp_path / "snap"
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+
+        monkeypatch.setattr(executor_mod, "ensure_local", _fake_ensure_local)
+        monkeypatch.setattr(
+            fleet_cells, "enable_compiled", self._fake_enable_compiled)
+        monkeypatch.setattr(
+            guard_closure, "assert_closure",
+            lambda pipe, cfg, label="": {
+                "v": 1, "graphs": [{"target": "transformer", "code": "sim",
+                                    "entry": 0, "guards": []}],
+                "verdicts": {}, "leaks": []})
+        self.ex = Executor(self.specs, _send, store=store)
+        if hub_lane:
+            ref = wire_ref(self.spec.models["model"])
+            self.ex._model_resolutions = {ref: (ref, "", hub_lane)}
+
+    def _fake_enable_compiled(
+        self, pipe: Any, cfg: Any, cache_dir: Any = None,
+        artifact: Any = None, publisher: Any = None,
+    ) -> fleet_cells.ArmOutcome:
+        mint_root = self.tmp_path / f"mint-{id(pipe)}"
+        capture = mint_root / "capture"
+        (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
+        pending = fleet_cells.PendingSelfMint(
+            family=FAMILY, cell_key="ck2-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck2-{'a' * 56}",
+            cfg=cfg, target=mint_root / "cell.tar.gz",
+            capture_dir=capture, mint_root=mint_root,
+            publisher=None, cache_dir=cache_dir,
+        )
+        original = pipe.transformer.forward
+        harness = self
+
+        seen_sigs: set = set()
+        seen_lock = threading.Lock()
+
+        def compiled(*args: Any, **kwargs: Any) -> Any:
+            sig = hot_swap.signature(args, kwargs)
+            with seen_lock:
+                novel = sig not in seen_sigs
+                seen_sigs.add(sig)
+            if novel:
+                start = time.monotonic()
+                harness.in_compile.set()
+                try:
+                    time.sleep(harness.compile_delay_s)
+                    (capture / "inductor" / "fxgraph"
+                     / f"g{len(harness.compiles)}.bin").write_bytes(b"graph")
+                finally:
+                    harness.in_compile.clear()
+                harness.compiles.append((
+                    str(sig[0]), threading.current_thread().name,
+                    start, time.monotonic()))
+            return original(*args, **kwargs)
+
+        # Honor the one serveability brain exactly like the real arm path.
+        fail_closed = cc.mandatory_serving(pipe) if hasattr(
+            cc, "mandatory_serving") else False
+        signal: Dict[str, Any] = {
+            "callback": None,
+            "lock": threading.Lock(),
+            "successful_calls": 0,
+            "cache_hits": 0,
+            "cache_misses": 0,
+            "router": hot_swap.Router(fail_closed=fail_closed),
+        }
+        setattr(pipe, cc._MARKER_ATTR, {
+            "targets": ["transformer"],
+            "shapes": tuple(cfg.shapes),
+            "cache": True,
+            "originals": [(pipe.transformer, "forward", original)],
+            "regional_mods": [],
+            "failure_signal": signal,
+        })
+        pipe.transformer.forward = cc._guarded(
+            original, compiled, "transformer", failure_signal=signal)
+        cc._armed_pipelines().add(pipe)
+        return fleet_cells.ArmOutcome(armed=True, self_mint=pending)
+
+    async def boot(self) -> Any:
+        return await self.ex.ensure_setup(self.spec, {
+            wire_ref(self.spec.models["model"]): pb.Snapshot(
+                digest="blake3:" + "a" * 64),
+        })
+
+    @property
+    def rec(self) -> Any:
+        return self.ex._classes[self.spec.instance_key]
+
+    async def wait_mint(self, timeout: float = 60.0) -> None:
+        bg = self.rec.background_mint
+        if bg is None or bg.task is None:
+            return
+        await asyncio.wait_for(asyncio.shield(bg.task), timeout)
+
+    def _run_job(self, request_id: str, aspect: str = "1:1") -> pb.RunJob:
+        model_ref = wire_ref(self.spec.models["model"])
+        return pb.RunJob(
+            request_id=request_id, attempt=1,
+            function_name=self.spec.name,
+            input_payload=msgspec.msgpack.encode(
+                _In(prompt="a cat", aspect_ratio=aspect)),
+            models=[pb.ModelBinding(slot="model", ref=model_ref)],
+            snapshots={model_ref: pb.Snapshot(digest="blake3:" + "a" * 64)},
+        )
+
+    async def dispatch(
+        self, request_id: str, aspect: str = "1:1",
+    ) -> Tuple[pb.JobResult, float]:
+        run = self._run_job(request_id, aspect)
+        t0 = time.monotonic()
+        await self.ex.handle_run_job(run)
+        job = self.ex.jobs[(run.request_id, run.attempt)]
+        assert job.task is not None
+        await job.task
+        wall = time.monotonic() - t0
+        results = [m.job_result for m in self.sent
+                   if m.WhichOneof("msg") == "job_result"
+                   and m.job_result.request_id == request_id]
+        assert results, f"no job_result for {request_id}"
+        return results[-1], wall
+
+    def events(self, kind: str) -> List[pb.ActivityUpdate]:
+        return [
+            m.activity_update for m in self.sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == kind
+        ]
+
+
+# ---------------------------------------------------------------------------
+# 1 — THE LIVE BREAK: a w8a8-stamped pipe on a hub-declared eager-serveable
+#     execution lane must boot eager-first (background mint), not foreground
+# ---------------------------------------------------------------------------
+
+
+def test_w8a8_stamp_with_hub_execution_lane_boots_eager_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact live shape: pipe stamped ``w8a8-lora64`` (cell identity),
+    hub resolution lane ``fp8-w8a16+eager`` (serveability). RED on 0.70.0:
+    the weight-lane prefix classified this boot mandatory-quantized, the
+    setup ran the FOREGROUND compile-then-serve mint (rec.background_mint
+    is None), and the first tenant request sat behind the whole inline
+    plan — the measured 26-minute cold-L4 starvation."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=0.4, seed_forward_s=0.05, tenant_forward_s=0.02,
+        weight_lane="w8a8", hub_lane="fp8-w8a16+eager")
+
+    async def _run() -> None:
+        boot_t0 = time.monotonic()
+        await h.boot()
+        boot_wall = time.monotonic() - boot_t0
+        # Eager-first: READY without paying the plan's compiles foreground.
+        assert h.rec.background_mint is not None, (
+            "w8a8-stamped pipe with hub lane fp8-w8a16+eager was refused "
+            "eager-first — the foreground compile-then-serve mint is the "
+            "reopen's measured 26-minute starvation")
+        assert boot_wall < 2.0, f"boot paid the plan foreground: {boot_wall:.1f}s"
+        # A tenant request mid-mint completes at serving latency.
+        res, wall = await h.dispatch("r-live", aspect="16:9")
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+        assert wall < 1.0, f"tenant starved during mint: {wall:.2f}s"
+        await h.wait_mint()
+        assert h.ex.serving_tiers() == {"generate": "compiled"}
+
+    asyncio.run(_run())
+
+
+def test_true_mandatory_lane_still_refuses_eager_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The qwen shape: hub lane says real w8a8 activations — eager is not
+    a production tier there; the boot keeps the sequential foreground
+    proof. Guards the fix from over-rotating."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=0.0, seed_forward_s=0.0, tenant_forward_s=0.01,
+        weight_lane="w8a8", hub_lane="fp8-w8a8-dynamic+compiled")
+
+    async def _run() -> None:
+        await h.boot()
+        assert h.rec.background_mint is None, (
+            "a REAL w8a8-activation lane must keep the foreground proof")
+
+    asyncio.run(_run())
+
+
+def test_w8a8_stamp_without_lane_evidence_stays_foreground(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No hub lane evidence: the weight-lane stamp remains the fail-closed
+    fallback — unchanged pre-reopen behavior."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h = _Harness(
+        tmp_path, monkeypatch,
+        weight_lane="w8a8", hub_lane="")
+
+    async def _run() -> None:
+        await h.boot()
+        assert h.rec.background_mint is None
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 2 — SIZING: a multi-minute unabortable compile + waiting tenant. The
+#     compile lane must not steal against short demand; the tenant completes.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_minute_compile_never_steals_against_live_demand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reopen's missing tape: background compile units are MINUTES of
+    unabortable wall (here scaled to 1.2s vs a 20ms tenant forward), and a
+    tenant stream is live the whole time. Post-fix, compile turns steal
+    only after `_BG_COMPILE_STEAL_FLOOR_S` of continuous demand, so every
+    tenant completes at serving latency. RED on 0.70.0: the single 30s
+    floor (patched to 0.1s, as tape 3 always did) lets the compile steal
+    almost immediately and a tenant waits out the whole unabortable unit."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    monkeypatch.setattr(executor_mod, "_BG_STEAL_FLOOR_S", 0.1)
+    # raising=False: on the pre-fix tree this attribute does not exist and
+    # the single floor governs — that IS the red run.
+    monkeypatch.setattr(
+        executor_mod, "_BG_COMPILE_STEAL_FLOOR_S", 30.0, raising=False)
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=1.2, seed_forward_s=0.02, tenant_forward_s=0.02)
+
+    async def _run() -> None:
+        # A sustained, never-idle stream FROM THE FIRST ADMISSION: the next
+        # dispatch is always admitted before the previous completes, so
+        # `_bg_quiet` never sets and no compile turn can be idle-granted —
+        # any multi-second tenant wall in this window is a STEAL. (The
+        # arrive-mid-idle-compile residual is a separate, documented bound
+        # and deliberately not provoked here.) The first request performs
+        # setup and starts the mint; its wall is excluded.
+        walls: List[float] = []
+        pending_task: Any = None
+        for i in range(12):
+            nxt = asyncio.create_task(h.dispatch(f"r-{i}", aspect="16:9"))
+            if pending_task is not None:
+                res, wall = await pending_task
+                assert res.status == pb.JOB_STATUS_OK, res.safe_message
+                walls.append(wall)
+            pending_task = nxt
+            await asyncio.sleep(0)
+        res, wall = await pending_task
+        walls.append(wall)
+        assert h.rec.background_mint is not None
+        # Post-fix: no tenant ever waits out the 1.2s unabortable compile.
+        steady = walls[1:]
+        assert max(steady) < 1.0, (
+            f"a tenant waited out a stolen multi-minute compile: {steady}")
+        # Drain: with the stream gone, idle grants finish the mint.
+        await h.wait_mint()
+
+    asyncio.run(_run())
+
+
+def test_compile_steal_is_announced_on_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the compile floor DOES elapse under truly continuous demand,
+    the steal happens (minimum progress) and announces itself as a typed
+    ``bg_turn_steal`` event."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    monkeypatch.setattr(executor_mod, "_BG_STEAL_FLOOR_S", 0.05)
+    monkeypatch.setattr(
+        executor_mod, "_BG_COMPILE_STEAL_FLOOR_S", 0.3, raising=False)
+    monkeypatch.setattr(executor_mod, "_BG_STEAL_DEBT_FACTOR", 0.5)
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=0.1, seed_forward_s=0.02, tenant_forward_s=0.02)
+
+    async def _run() -> None:
+        await h.boot()
+        assert h.rec.background_mint is not None
+        pending_task: Any = None
+        deadline = time.monotonic() + 30.0
+        i = 0
+        while time.monotonic() < deadline:
+            nxt = asyncio.create_task(h.dispatch(f"r-{i}", aspect="16:9"))
+            if pending_task is not None:
+                res, _wall = await pending_task
+                assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            pending_task = nxt
+            i += 1
+            if h.events("bg_turn_steal"):
+                break
+        if pending_task is not None:
+            await pending_task
+        assert h.events("bg_turn_steal"), (
+            "a compile steal under continuous demand must be announced")
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 3 — THE PUBLISH BREAK: every refusal reason reaches the hub typed
+# ---------------------------------------------------------------------------
+
+
+def test_pack_or_closure_refusal_reaches_the_wire(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ie#546 cycle lost its root cause because a finalize refusal
+    (closure gate / pack) died in pod logs. Post-fix the verbatim reason
+    rides the wire as a typed ``self_mint_abort`` event. RED on 0.70.0:
+    no such event exists anywhere."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+
+    def _refuse(*args: Any, **kwargs: Any) -> None:
+        raise ValueError("closure refused: guard leak L['scale']")
+
+    monkeypatch.setattr(cc, "finish_fleet_mint", _refuse)
+    h = _Harness(tmp_path, monkeypatch, compile_delay_s=0.02)
+
+    async def _run() -> None:
+        await h.boot()
+        bg = h.rec.background_mint
+        assert bg is not None and bg.task is not None
+        # The driver contains the failure (serving stays eager and alive);
+        # the typed abort must still name the refusal verbatim.
+        await asyncio.wait_for(bg.task, timeout=30.0)
+        assert h.ex.serving_tiers() == {"generate": "eager"}
+        aborts = h.events("self_mint_abort")
+        assert aborts, "finalize refusal never reached the wire"
+        assert any("L['scale']" in a.detail for a in aborts), (
+            [a.detail for a in aborts])
+        assert any(a.phase == "pack_failed" for a in aborts)
+
+    asyncio.run(_run())
+
+
+def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
+    """Unit tapes for the two publish-withhold doors (gw#612 gap and the
+    missing publish sink): both emit typed events naming the reason."""
+    from gen_worker import activity as activity_mod
+
+    sent: List[pb.WorkerMessage] = []
+    loop = asyncio.new_event_loop()
+
+    async def _pump() -> None:
+        pass
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    try:
+        activity_mod.bind_sink(_send, loop)
+        mint_root = tmp_path / "m"
+        (mint_root / "capture").mkdir(parents=True)
+        pending = fleet_cells.PendingSelfMint(
+            family=FAMILY, cell_key="ck2-" + "b" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck2-{'b' * 56}",
+            cfg=None, target=mint_root / "cell.tar.gz",
+            capture_dir=mint_root / "capture", mint_root=mint_root,
+            publisher=None, cache_dir=None,
+        )
+        pending._state["minted"] = object()
+        fleet_cells.withhold_self_mint_publish(
+            pending, "2/3 capture-sharing objects never proved")
+        loop.run_until_complete(asyncio.sleep(0.05))
+        events = [
+            m.activity_update for m in sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == "self_mint_publish_withheld"
+        ]
+        assert events and "2/3" in events[0].detail
+
+        # no-sink door
+        mint_root2 = tmp_path / "m2"
+        (mint_root2 / "capture").mkdir(parents=True)
+        pending2 = fleet_cells.PendingSelfMint(
+            family=FAMILY, cell_key="ck2-" + "c" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck2-{'c' * 56}",
+            cfg=None, target=mint_root2 / "cell.tar.gz",
+            capture_dir=mint_root2 / "capture", mint_root=mint_root2,
+            publisher=None, cache_dir=None,
+        )
+        pending2._state["minted"] = object()
+        pending2._state["meta"] = {}
+        fleet_cells.publish_self_mint(pending2)
+        loop.run_until_complete(asyncio.sleep(0.05))
+        no_sink = [
+            m.activity_update for m in sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == "self_mint_publish_withheld"
+            and m.activity_update.phase == "no_sink"
+        ]
+        assert no_sink, "missing publish sink must be a typed event"
+    finally:
+        activity_mod.bind_sink(None, None)
+        loop.close()
+
+
+def test_oom_truncated_plan_never_finalizes_partial_capture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The finalize@8/18 shape: seeds OOM persistently mid-plan. Post-fix
+    the driver retries bounded, then aborts LOUDLY with typed
+    ``self_mint_abort`` events — it never converges into a finalize of a
+    partial capture, and serving stays eager and alive. RED on 0.70.0:
+    the OOM'd pass satisfied the stats-stable convergence and the mint
+    finalized (phase=finalize) with nothing publishable and no event."""
+    monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
+    h = _Harness(
+        tmp_path, monkeypatch,
+        compile_delay_s=0.02, seed_forward_s=0.01, tenant_forward_s=0.01,
+        seed_oom_after=1)
+
+    async def _run() -> None:
+        await h.boot()
+        bg = h.rec.background_mint
+        assert bg is not None and bg.task is not None
+        await asyncio.wait(
+            {bg.task}, timeout=60.0, return_when=asyncio.ALL_COMPLETED)
+        assert bg.task.done(), "mint driver hung on the OOM'd plan"
+        # The mint must NOT have armed a partial capture.
+        assert h.ex.serving_tiers() == {"generate": "eager"}, (
+            "an OOM-truncated plan finalized a partial capture")
+        aborts = h.events("self_mint_abort")
+        assert aborts, "the OOM truncation never reached the wire"
+        assert any(a.phase == "warmup_oom" for a in aborts)
+        # Serving is alive: a tenant request still completes eager.
+        res, _wall = await h.dispatch("r-after-oom", aspect="1:1")
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 4 — Router seed-window holes (vocabulary overflow / dummy failure)
+# ---------------------------------------------------------------------------
+
+
+def test_seed_window_holes_never_compile_inline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED on 0.70.0: the _MAX_SIGS overflow and the dummy-build failure
+    branches returned COMPILED even inside the seed window — an inline
+    Dynamo+Inductor compile while holding the run gate. Post-fix both
+    return EAGER and count ``seed_dropped`` so the driver aborts loudly."""
+    router = hot_swap.Router()
+
+    def compiled(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    # Vocabulary overflow.
+    monkeypatch.setattr(hot_swap, "_MAX_SIGS", 1)
+    router.warm.add(("t", (("x",), ())))
+    with hot_swap.mint_seed_window():
+        verdict, _sig = router.route("t", compiled, ("overflow",), {})
+    assert verdict == hot_swap.EAGER
+    assert router.seed_dropped == 1
+
+    # Dummy-build failure.
+    monkeypatch.setattr(hot_swap, "_MAX_SIGS", 256)
+    monkeypatch.setattr(
+        hot_swap, "_dummy_value",
+        lambda value, depth=0: (_ for _ in ()).throw(RuntimeError("boom")))
+    fresh = hot_swap.Router()
+    with hot_swap.mint_seed_window():
+        verdict, _sig = fresh.route("t", compiled, ("nodummy",), {})
+    assert verdict == hot_swap.EAGER
+    assert fresh.seed_dropped == 1
+    # Outside the window the legacy verdict stands.
+    verdict, _sig = fresh.route("t", compiled, ("plain",), {})
+    assert verdict == hot_swap.COMPILED

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -348,7 +348,7 @@ def test_w8a8_stamp_with_hub_execution_lane_boots_eager_first(
             "w8a8-stamped pipe with hub lane fp8-w8a16+eager was refused "
             "eager-first — the foreground compile-then-serve mint is the "
             "reopen's measured 26-minute starvation")
-        assert boot_wall < 2.0, f"boot paid the plan foreground: {boot_wall:.1f}s"
+        assert boot_wall < 6.0, f"boot paid the plan foreground: {boot_wall:.1f}s"
         # A tenant request mid-mint completes at serving latency.
         res, wall = await h.dispatch("r-live", aspect="16:9")
         assert res.status == pb.JOB_STATUS_OK, res.safe_message

--- a/tests/test_swap_bench_pgw689.py
+++ b/tests/test_swap_bench_pgw689.py
@@ -1,0 +1,349 @@
+"""pgw#689: the swap benchmark must load what SERVING loads, a broken
+diagnostic must not look like a broken release, and a re-exported endpoint
+must never be dropped silently.
+
+Four tapes, all red before the fix:
+
+1. ``benchmarks.swap_latency._load_component`` on a REAL modelopt-shaped
+   w8a8 tree — the flavor the fleet actually serves. Pre-fix it called
+   ``cls.from_pretrained`` itself and died reconstructing
+   ``NVIDIAModelOptConfig`` (evidence tape below pins that exact mechanism
+   on the pinned diffusers); post-fix it goes through
+   ``models.loading.load_component``, so the module comes back off the w8a8
+   artifact lane.
+2. ``bench_load`` end to end over that tree with a fake-CUDA seam (the
+   real-GPU numbers are a pod's job; the LOADABILITY is CI's).
+3. The diagnostics handler converts every benchmark-domain failure into a
+   typed outcome and returns normally — the job succeeds, so no
+   ``model_load_failure_streak`` signal is ever emitted for it.
+4. Discovery's out-of-package skip is a WARNING naming the class.
+"""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("diffusers")
+pytest.importorskip("accelerate")
+
+
+@pytest.fixture(scope="module")
+def tiny_tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A minimal REAL diffusers tree (unet + scheduler)."""
+    from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
+
+    root = tmp_path_factory.mktemp("pgw689") / "src"
+    unet = UNet2DModel(
+        sample_size=8, in_channels=3, out_channels=3,
+        block_out_channels=(32, 32), layers_per_block=1,
+        down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+        up_block_types=("AttnUpBlock2D", "UpBlock2D"), norm_num_groups=8,
+    )
+    DDPMPipeline(unet=unet, scheduler=DDPMScheduler()).save_pretrained(str(root))
+    return root
+
+
+@pytest.fixture(scope="module")
+def w8a8_tree(tiny_tree: Path) -> Path:
+    """The same tree quantized to the gw#534 w8a8 contract — carrying the
+    modelopt ``quantization_config`` block that broke the benchmark."""
+    import json
+
+    from gen_worker.models.w8a8 import quantize_tree_w8a8
+
+    tree = quantize_tree_w8a8(tiny_tree, tiny_tree.parent / "w8a8")
+    cfg = json.loads((tree / "unet" / "config.json").read_text())
+    assert cfg["quantization_config"] == {
+        "quant_method": "modelopt", "quant_algo": "FP8"}
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# 1: the evidence — a bare from_pretrained on a modelopt tree is the fatal
+# ---------------------------------------------------------------------------
+
+
+def test_bare_from_pretrained_on_a_modelopt_tree_is_the_recorded_fatal(
+    w8a8_tree: Path,
+) -> None:
+    """The mechanism, reproduced on the pinned stack (diffusers 0.39.0 —
+    the release's own version): diffusers rebuilds ``NVIDIAModelOptConfig``
+    from the stored block, whose constructor demands a ``quant_type`` the
+    block does not carry. This call IS what the benchmark used to make per
+    component, and the message below is verbatim the ie#546 fatal. If a
+    diffusers bump ever makes this call succeed, this tape is the thing to
+    update — the fix does not depend on it."""
+    from diffusers import UNet2DModel
+
+    with pytest.raises(TypeError) as excinfo:
+        UNet2DModel.from_pretrained(
+            str(w8a8_tree / "unet"), torch_dtype=torch.bfloat16)
+    assert "NVIDIAModelOptConfig.__init__()" in str(excinfo.value)
+    assert "quant_type" in str(excinfo.value)
+    # ...and dropping the torch_dtype kwarg (the retry the benchmark did)
+    # fails IDENTICALLY — the fallback never could have helped.
+    with pytest.raises(TypeError, match="quant_type"):
+        UNet2DModel.from_pretrained(str(w8a8_tree / "unet"))
+
+
+# ---------------------------------------------------------------------------
+# 2: the fix — the benchmark loads through the production component path
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_loads_a_quantized_component_via_the_serve_path(
+    tiny_tree: Path, w8a8_tree: Path,
+) -> None:
+    from diffusers import UNet2DModel
+
+    from gen_worker.benchmarks import swap_latency as bench
+    from gen_worker.models import w8a8
+
+    if hasattr(w8a8.w8a8_gemm_mode, "cache_clear"):
+        w8a8.w8a8_gemm_mode.cache_clear()
+
+    unet = bench._load_component(w8a8_tree, "unet")
+
+    # The w8a8 artifact lane ran — the same loader load_from_pretrained
+    # routes a served pipeline through — not a bare from_pretrained.
+    assert getattr(unet, "_cozy_w8a8_mode", None) in (
+        "rowwise", "pertensor", "dequant")
+    # ...and it materialized the real weights, to fp8 rounding.
+    ref = UNet2DModel.from_pretrained(str(tiny_tree / "unet"))
+    name = w8a8.detect_w8a8_artifact(w8a8_tree).quantized[0] + ".weight"
+    a = ref.state_dict()[name].float()
+    b = unet.state_dict()[name].float()
+    rel = ((a - b).abs() / a.abs().clamp(min=1e-3)).max().item()
+    assert rel < 0.13
+
+
+def test_unquantized_siblings_still_load_and_honor_the_lane_dtype(
+    w8a8_tree: Path,
+) -> None:
+    """A w8a8 tree's NON-denoiser components take the ordinary path — and
+    inherit the quant lane's bf16 compute default, not the tree's majority
+    on-disk sniff (pgw#675/pgw#683's rule, now shared by construction)."""
+    from gen_worker.models.loading import load_component
+
+    sched = load_component(w8a8_tree, "scheduler")
+    assert type(sched).__name__ == "DDPMScheduler"
+
+
+def test_bench_load_walks_a_quantized_tree_end_to_end(
+    w8a8_tree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `load` case over a quantized tree. CUDA is faked (this box has
+    none, and the real numbers are the pod's run) — what CI proves is that
+    every component of a served flavor is loadable at all, which is exactly
+    what was broken."""
+    from gen_worker.benchmarks import swap_latency as bench
+
+    monkeypatch.setattr(
+        torch.nn.Module, "to", lambda self, *a, **k: self, raising=True)
+    monkeypatch.setattr(bench, "_sync", lambda: None)
+    monkeypatch.setattr(bench, "_cuda_bytes", lambda: 0)
+
+    rows: List[bench.Row] = []
+    loaded = bench.bench_load(w8a8_tree, rows.append)
+
+    assert "unet" in loaded
+    assert getattr(loaded["unet"], "_cozy_w8a8_mode", None) is not None
+    labels = {r.label for r in rows}
+    assert f"{w8a8_tree.name}/unet" in labels
+    assert f"{w8a8_tree.name}/TOTAL" in labels
+    assert any(r.bytes > 0 for r in rows)
+
+
+def test_lanes_without_a_component_loader_refuse_by_name(
+    tmp_path: Path,
+) -> None:
+    """svdq builds its denoiser inside the pipeline load. Handing back a
+    plain from_pretrained module would be measuring something serving never
+    runs — refuse, named."""
+    import json
+
+    from gen_worker.models.loading import (
+        ComponentLaneUnsupported, load_component,
+    )
+
+    tree = tmp_path / "svdq"
+    (tree / "transformer").mkdir(parents=True)
+    (tree / "model_index.json").write_text(json.dumps({
+        "_class_name": "FluxPipeline",
+        "transformer": ["diffusers", "FluxTransformer2DModel"],
+    }))
+    from safetensors.torch import save_file
+
+    from gen_worker.models.svdq import SVDQ_METHOD, detect_svdq_artifact
+
+    save_file(
+        {"x": torch.zeros(2)},
+        str(tree / "transformer" / "svdq-int4_r32-model.safetensors"),
+        metadata={"model_class": "NunchakuFluxTransformer2dModel",
+                  "quantization_config": json.dumps({
+                      "method": SVDQ_METHOD, "rank": 32,
+                      "weight": {"dtype": "int4"}})},
+    )
+    assert detect_svdq_artifact(tree) is not None
+    with pytest.raises(ComponentLaneUnsupported, match="svdq"):
+        load_component(tree, "transformer")
+
+
+def test_the_identical_typeerror_retry_is_gone() -> None:
+    """Defect 2: the retry could not help (it re-ran the failing path) and
+    it destroyed the evidence. A loader TypeError now propagates, and the
+    torch_dtype question is answered by INSPECTION instead."""
+    import inspect as _inspect
+
+    from gen_worker.models import loading
+
+    src = _inspect.getsource(loading.load_component)
+    assert "except TypeError" not in src
+
+    class _NoDtype:
+        @staticmethod
+        def from_pretrained(path: str) -> str:
+            return path
+
+    class _AnyKwargs:
+        @staticmethod
+        def from_pretrained(path: str, **kwargs: Any) -> str:
+            return path
+
+    assert loading._accepts_kwarg(_NoDtype.from_pretrained, "torch_dtype") is False
+    assert loading._accepts_kwarg(_AnyKwargs.from_pretrained, "torch_dtype") is True
+
+
+# ---------------------------------------------------------------------------
+# 3: a broken DIAGNOSTIC is not a broken release (defect 3)
+# ---------------------------------------------------------------------------
+
+
+def _handler() -> Any:
+    from gen_worker.diagnostics import SwapLatencyDiagnostics
+
+    obj = SwapLatencyDiagnostics()
+    obj.setup(checkpoint="/nonexistent/tree", to="")
+    return obj
+
+
+def test_a_load_fatal_inside_the_benchmark_never_escapes_the_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact ie#546 fatal. Pre-fix it left the handler as a fast fatal,
+    the hub counted it, and two of them marked the release's function broken
+    — recycling a warm pod. It must come back as data."""
+    from gen_worker.benchmarks import swap_latency as bench
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise TypeError(
+            "NVIDIAModelOptConfig.__init__() missing 1 required positional "
+            "argument: 'quant_type'")
+
+    monkeypatch.setattr(bench, "run_cases", _boom)
+    out = _handler().swap_latency(None, SwapLatencyInput())
+
+    assert out.status == "failed"
+    assert "quant_type" in out.error
+    assert "NVIDIAModelOptConfig" in out.traceback_text
+    assert out.rows == []
+
+
+def test_off_pod_refusal_is_an_outcome_not_a_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    monkeypatch.setenv("GEN_WORKER_FORBID_CPU_OFFLOAD", "1")
+    out = _handler().swap_latency(None, SwapLatencyInput())
+
+    assert out.status == "refused"
+    assert "weights-locality" in out.error
+
+
+def test_a_bad_case_request_is_an_outcome_not_a_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    monkeypatch.delenv("GEN_WORKER_FORBID_CPU_OFFLOAD", raising=False)
+    # 'swap' with no distinct `to` binding: a caller error, still a
+    # measurement outcome — never a release-health signal.
+    out = _handler().swap_latency(None, SwapLatencyInput(cases=("swap",)))
+    assert out.status == "failed"
+    assert "swap case" in out.error
+
+
+def test_the_family_less_slot_convention_is_dispatchable() -> None:
+    """The hub cannot put a curated policy on a family-less string slot, a
+    fixed slot rejects supplied values, and msgspec cannot omit a required
+    field — so an all-defaults payload MUST be valid or the diagnostics
+    function is uninvokable (the pgw#689 ``checkpoint: ""`` workaround, now
+    the declared contract)."""
+    import msgspec
+
+    from gen_worker.diagnostics import SwapLatencyInput
+
+    payload = msgspec.json.decode(b"{}", type=SwapLatencyInput)
+    assert payload.checkpoint == "" and payload.to == ""
+    assert "stage" in payload.cases
+
+
+# ---------------------------------------------------------------------------
+# 4: the other final-cycle trap — a silent discovery skip
+# ---------------------------------------------------------------------------
+
+
+def _pkg(root: Path, name: str, body: str) -> None:
+    pkg = root / name
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(textwrap.dedent(body))
+
+
+def test_reexported_endpoint_skip_is_loud_and_names_the_class(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gen_worker.discovery.walk import find_endpoints
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _pkg(tmp_path, "ep_pgw689_reexport", """
+        from gen_worker.diagnostics import SwapLatencyDiagnostics  # noqa: F401
+    """)
+
+    with caplog.at_level(logging.WARNING, logger="gen_worker.discovery.walk"):
+        found = find_endpoints(["ep_pgw689_reexport"])
+
+    assert found == []
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "an endpoint dropped from the route table must be LOUD"
+    text = warnings[0].getMessage()
+    assert "SwapLatencyDiagnostics" in text
+    assert "ep_pgw689_reexport" in text
+    assert "SUBCLASS" in text
+
+
+def test_subclassing_in_the_endpoint_package_actually_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix the warning names has to work."""
+    from gen_worker.discovery.walk import find_endpoints
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    _pkg(tmp_path, "ep_pgw689_subclass", """
+        from gen_worker.diagnostics import SwapLatencyDiagnostics
+
+        class SwapLatency(SwapLatencyDiagnostics):
+            pass
+    """)
+
+    found = find_endpoints(["ep_pgw689_subclass"])
+    assert [f.qualname for f in found] == ["SwapLatency"]
+    assert found[0].module == "ep_pgw689_subclass"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.0"
+version = "0.70.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
One 0.70.1 train (per coordinator): the pgw#677 REOPEN fix + pgw#689 (rides byte-identical from PR #408, which closes unmerged).

## pgw#677 REOPEN — the 0.70.0 fix did not hold live

The ie#546 final verification cycle reproduced the starvation verbatim on 0.70.0: a cold L4 held one tenant `generate` for 26m25s behind 4-7-minute mint units, finalized at unit 8/18, and published nothing — three pods, all six burst workers.

Root cause: **the 0.70.0 gate machinery never ran.** sdxl's mixed `#fp8-w8a8`-storage checkpoint stamps `_cozy_weight_lane` `w8a8*` (cell identity, pgw#686) while the hub serves it `fp8-w8a16+eager`; `_eager_first_eligible` and the router's `fail_closed` read the weight-lane **prefix**, classified the boot mandatory-quantized, and silently fell back to the FOREGROUND compile-then-serve mint — the tenant sat inside `ensure_setup` for the whole inline-compile plan.

- **One serveability brain** — `compile_cache.mandatory_serving`: the hub-resolved th#913 execution lane (stamped at slot injection + via a setup-scoped ContextVar window covering `arm_compile`/ArmingScope) outranks the weight-lane stamp; only real w8a8/w4a4 ACTIVATIONS forbid eager. No lane evidence → stamp stays the fail-closed fallback (real-w8a8 keeps its foreground proof; guarded by tape). Cell identity (pgw#686) untouched.
- **Stolen-compile sizing** (the reopen's ~100x correction): compile turns steal only after `_BG_COMPILE_STEAL_FLOOR_S` (600s) of continuous demand — they run in the idle gaps real traffic has — and a granted steal emits a typed `bg_turn_steal` event. Seed turns keep the 30s floor.
- **The mint→publish break is typed on the wire, every door** (the cycle lost its root cause to unreachable pod logs): `self_mint_abort` (pack/closure refusal verbatim incl. the pgw#681 leak name, warmup OOM with unit N/M, proof-failed degrade, abandon, driver error), `self_mint_publish_withheld` (gw#612 gap, no sink), `self_mint_publish_failed` (hub refusal / upload error).
- **No partial captures**: an OOM-truncated seed pass never satisfies convergence (bounded retries, then loud abort); the foreground path withholds publish on a cut-short plan; `Router.route` seed-window holes (`_MAX_SIGS`, dummy failure) route EAGER + `seed_dropped` so the driver refuses an incomplete capture.

Tapes: `tests/test_mint_reopen_pgw677.py` (9), red-verified against master `161a15c` (7 fail there; the 2 passing are deliberate behavior-preservation guards).

## pgw#689 — the swap benchmark loads what SERVING loads

Byte-identical to PR #408 (`eb19b24` + `3629ee4`): one component-load path, no identical-retry `except TypeError`, diagnostics failures are their own outcome (never `model_load_failure_streak`), loud out-of-package discovery skip.

## Gates

- Full suite on the train head: see checklist below (local run recorded in the tracker).
- mypy clean (152 files), ruff clean (CI scope).
- One CI run on this final head only (CI-spend policy).

Tracker: `cozy-creator-tracker/python-gen-worker/progress.md` pgw#677 (reopen section) + pgw#689.
