### PR TITLE
release: gen-worker 0.70.2 — pgw#691 guard-closure classifier fixes + ck3 sku key collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.70.2 (2026-07-26) — pgw#691: guard-closure classifier fixes + sku key collapse (ck2 -> ck3)
+
+The offline audit (546 real torch-2.13 guard rows) proved the pgw#681 mint
+gate would refuse 100% of sdxl mints. Four fixes, all red-verified against
+real dynamo guard trees (CPU, `backend="eager"`):
+
+- **P0**: the RelationalGuard family (`NO_TENSOR_ALIASING`,
+  `OBJECT_ALIASING`, `STORAGE_OVERLAPPING`) is judged by TYPE before root
+  dispatch — torch attaches it to the INPUT managers, so the old root-first
+  dispatch leaked on every graph with >=2 tensor inputs.
+- Vocabulary rebuilt on the C++ leaf-class names the guard walk yields:
+  `SYMBOLIC_SHAPE_GUARD` (2.13's shape-env facts, incl. its synthetic tuple
+  sources) rides declared dynamic dims; input-rooted
+  `ID_MATCH`/`DICT_VERSION` classify as the object identity of a call-path
+  constant; `DUAL_LEVEL_MATCH`/`FAKE_SCRIPT_TYPE_MATCH` named; phantoms
+  (`AUTOCAST_STATE`, `KEYS_MATCH`) dropped.
+- `EQUALS_MATCH` against torch singletons (`L['dt'] == torch.float32`,
+  memory formats, device literals) is covered by weight_lane + the ingress
+  dtype memo instead of leaking "unparseable".
+- **ck2 → ck3**: `sku` left the cell-key identity axes (two byte-identical
+  cell pairs split only by sku in the audited corpus; no guard observes a
+  SKU — sm/cuda/torch/triton pin the hardware facts). `sku` stays in cell
+  metadata (publish-intent attestation unchanged); same-sku preference among
+  same-key candidates is a hub-side selection follow-up. Old ck2 keys fail
+  `is_key` outright — clean MISS, never a half-match. Hub-side confirmed
+  scheme-agnostic (`IsCellKey` shape check only, th#1183).
+
 ## 0.70.1 (2026-07-26) — pgw#677 REOPEN: the fix that did not hold live — one serveability brain, compile-steal sizing, and every mint refusal on the wire; plus pgw#689
 
 The ie#546 final verification cycle reproduced the 0.70.0 starvation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.1"
+version = "0.70.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -19,7 +19,6 @@ facts that actually change compiled-kernel identity:
     family        graph identity: fine-tunes of one family share cells
     lane          canonical traced weight lane token ("", w8a16, w8a8,
                   [-loraN]) — lane graphs differ (gw#534/gw#561)
-    sku           GPU SKU slug
     sm            compute capability (sm_100, ...)
     cuda          CUDA runtime the torch wheel was built for
     torch/triton  exact wheel versions (triton's disk cache keys on the
@@ -37,6 +36,16 @@ facts that actually change compiled-kernel identity:
     diffusers/transformers  exact lib versions when installed
     image_digest  the SERVING image OCI digest (absent for local runtimes)
 
+The GPU SKU is deliberately NOT a key axis (pgw#691, ck3): no dynamo guard
+observes a SKU — the only hardware facts the guard set carries are already
+pinned by sm + cuda + torch + triton (the same argument that keeps the host
+driver out of the key, gw#577). Keying on it was proven to mint byte-
+identical cells twice (a40 vs rtx-3090 on sm_86; l4 vs rtx-4090 on sm_89 —
+19% redundant mints in the audited corpus). ``sku`` stays in cell METADATA;
+preferring a same-sku cell among same-key candidates (autotune quality) is
+a hub-side SELECTION concern, not identity — the worker lookup is
+pull-by-exact-key and has no multi-candidate point.
+
 A wrong key can only produce a MISS (eager + demand + forge), never a
 refusal: verify-on-receipt of a self-requested cell degenerates to a digest
 check, and any failure to arm one is by construction a selection-logic bug
@@ -52,7 +61,9 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional
 
-KEY_SCHEME = "ck2"
+# ck2 -> ck3 (pgw#691): sku left the identity axes; the scheme bump makes
+# every pre-collapse key a clean MISS instead of a half-match.
+KEY_SCHEME = "ck3"
 _PREFIX = KEY_SCHEME + "-"
 # The key digest doubles as the store flavor token, whose shared grammar
 # (th#597 C5: [a-z0-9][a-z0-9._-]{0,63}, Go+Py identical) caps tokens at 64
@@ -61,7 +72,7 @@ _DIGEST_HEX = 56
 
 # Axes that must be non-empty for a computable key: a runtime that cannot
 # state them has no cell identity (CPU-only build, failed CUDA probe).
-_REQUIRED = ("format", "kind", "family", "sku", "sm", "cuda", "torch",
+_REQUIRED = ("format", "kind", "family", "sm", "cuda", "torch",
              "triton", "gen_worker", "contract")
 # Axes that may be legitimately absent ("" => omitted from canonical form):
 # image_digest is absent on local runtimes; libs may not be installed; lane
@@ -182,7 +193,6 @@ def compute(
         "family": str(family or ""),
         "lane": _canonical_lane(weight_lane, lora_bucket),
         "mode": "regional" if regional else "",
-        "sku": rt["sku"],
         "sm": rt["sm"],
         "cuda": rt["cuda"],
         "torch": rt["torch"],
@@ -211,8 +221,8 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     contract_facts = meta.get("shape_contract")
     if not isinstance(contract_facts, dict) or not contract_facts:
         raise CellKeyError(
-            "artifact records no shape_contract block (pre-ck2 cell); no "
-            "ck2 identity — a newer-contract worker must not consume it"
+            "artifact records no shape_contract block (pre-cell-key cell); "
+            "no key identity — a newer-contract worker must not consume it"
         )
     return from_axes({
         "format": str(meta.get("format") or ""),
@@ -223,7 +233,6 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
             int(meta.get("lora_bucket") or 0),
         ),
         "mode": "" if mode == "whole" else mode,
-        "sku": str(meta.get("sku") or ""),
         "sm": str(meta.get("sm") or ""),
         "cuda": str(meta.get("cuda") or ""),
         "torch": str(meta.get("torch") or ""),

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -15,10 +15,12 @@ declared ``CompileCell`` contract — never per-endpoint or per-family code):
    unavailable. Extraction failure is NEVER silent: a mint whose closure
    cannot be proven fails red (pgw#657 fail-loud doctrine).
 
-2. **Closure classifier** (:func:`classify`): every guard is classified by
-   its SOURCE ROOT first — module-rooted (``L['self']…``) guards are the
-   weights/structure identity (covered by family + graph_signature +
-   weight_contract ck2 axes) and global-rooted (``G[…]``) guards are the
+2. **Closure classifier** (:func:`classify`): the RelationalGuard family
+   (aliasing, symbolic shapes) is judged by TYPE first — torch attaches it
+   to input managers, never predictably to one root (pgw#691). Every other
+   guard is classified by its SOURCE ROOT — module-rooted (``L['self']…``)
+   guards are the weights/structure identity (covered by family +
+   graph_signature + weight_contract key axes) and global-rooted (``G[…]``) guards are the
    code identity (covered by gen_worker/diffusers/transformers/image_digest
    axes); neither can vary per request. Cross-request variance enters ONLY
    through call inputs and ambient process state, so those two roots form a
@@ -75,7 +77,7 @@ MANIFEST_KEY = "guard_manifest"
 
 # Verdicts. LEAK is the only failing one.
 LEAK = "LEAK"
-RUNTIME_STATE = "runtime-state"          # ambient process state (ck2 runtime axes)
+RUNTIME_STATE = "runtime-state"          # ambient process state (cell-key runtime axes)
 CODE_IDENTITY = "code-identity"          # G[...] roots (version/image axes)
 MODULE_STRUCTURE = "module-structure"    # L['self'] roots (family/graph/weight axes)
 CONTRACT_SHAPE = "contract-shape"        # input tensor shape/stride/dtype/device
@@ -89,23 +91,51 @@ _COVERED = (
     CONTRACT_SCALAR, STRUCTURAL, CODE_CONSTANT, CANONICALIZED,
 )
 
+# The vocabulary below is built on the C++ leaf CLASS names the structured
+# walk yields (`type(leaf).__name__` over the 31 concrete LeafGuard
+# subclasses in torch._C._dynamo.guards on 2.13.0 — the repr-parse fallback
+# prints the same names). Python GuardBuilder create_fn names survive only
+# where they harmlessly alias a covered fact; they never reach the walk
+# (pgw#691 audit).
+
+# RelationalGuard family (C++): torch attaches these to the INPUT guard
+# managers — one row per participating value, never the root — so they are
+# judged by TYPE before any root dispatch. Root-first dispatch made
+# NO_TENSOR_ALIASING an unconditional LEAK on every graph with >=2 tensor
+# inputs (pgw#691 P0). Cross-input (non-)aliasing/overlap is fixed by the
+# endpoint call topology: the compiled target receives freshly materialized,
+# distinct tensors each request, so the relation cannot vary per call.
+_RELATIONAL_ALIASING = frozenset({
+    "NO_TENSOR_ALIASING", "OBJECT_ALIASING", "STORAGE_OVERLAPPING",
+    "DUPLICATE_INPUT",  # python GuardBuilder alias of OBJECT_ALIASING
+})
 # Ambient (root-attached) guard types covered by process/runtime identity.
+# DETERMINISTIC_ALGORITHMS/GRAD_MODE/TORCH_FUNCTION_STATE/FUNCTORCH_STACK_
+# MATCH/DUAL_LEVEL are python-side aliases whose facts GLOBAL_STATE and
+# DUAL_LEVEL_MATCH (the C++ names) carry on 2.13.
 _AMBIENT_COVERED = frozenset({
     "GLOBAL_STATE", "TORCH_FUNCTION_MODE_STACK", "DEFAULT_DEVICE",
-    "DETERMINISTIC_ALGORITHMS", "GRAD_MODE", "AUTOCAST_STATE",
-    "TORCH_FUNCTION_STATE", "NO_TENSOR_ALIASING", "DUPLICATE_INPUT",
-    "FUNCTORCH_STACK_MATCH", "DUAL_LEVEL",
+    "DUAL_LEVEL_MATCH", "DETERMINISTIC_ALGORITHMS", "GRAD_MODE",
+    "TORCH_FUNCTION_STATE", "FUNCTORCH_STACK_MATCH", "DUAL_LEVEL",
 })
 # Input-rooted guard types that assert call TOPOLOGY (types, lengths,
 # presence), which the endpoint call path fixes deterministically.
+# FAKE_SCRIPT_TYPE_MATCH asserts a torchscript-facing input type — same
+# topology fact as TYPE_MATCH.
 _STRUCTURAL_TYPES = frozenset({
     "TYPE_MATCH", "DIMENSION_DYNAMIC_MARKING_GUARD", "HASATTR", "NO_HASATTR",
     "LENGTH_CHECK", "DICT_LENGTH", "DICT_CONTAINS", "SET_CONTAINS",
-    "MAPPING_KEYS_MATCH", "KEYS_MATCH", "TUPLE_ITERATOR_LEN",
+    "MAPPING_KEYS_MATCH", "TUPLE_ITERATOR_LEN", "FAKE_SCRIPT_TYPE_MATCH",
     "RANGE_ITERATOR_MATCH", "NONE_MATCH", "NOT_NONE", "NOT_NONE_MATCH",
     "TRUE_MATCH", "FALSE_MATCH", "DISPATCH_KEY_SET_MATCH", "FLOAT_IS_NAN",
     "COMPLEX_IS_NAN", "SEQUENCE_LENGTH",
 })
+# Input-rooted object-identity guard types: an object-valued argument whose
+# identity dynamo guards (enum member, callable, config dict) can only be
+# bound by the endpoint's fixed call path, so it cannot vary per request;
+# across processes an identity mismatch is a MISS (the pgw#680 guard-miss
+# path recompiles), never wrongness — CODE_CONSTANT, not a leak.
+_IDENTITY_CONSTANT_TYPES = frozenset({"ID_MATCH", "DICT_VERSION"})
 
 _CANONICAL_DEPTH = 4
 
@@ -463,14 +493,51 @@ def _scalar_verdict(value: Any, pins: ContractPins) -> Tuple[str, str]:
     return LEAK, f"unclassifiable literal {type(value).__name__}"
 
 
+# `L['dt'] == torch.float32` / `L['mf'] == torch.contiguous_format` — the
+# RHS a torch singleton renders in verbose parts. `device(type='cuda',
+# index=0)` is how a torch.device literal renders.
+_TORCH_ATTR_RE = re.compile(r"^torch\.([A-Za-z_][A-Za-z0-9_]*)$")
+_TORCH_DEVICE_RE = re.compile(r"^(?:torch\.)?device\(type=")
+
+
+def _torch_object_verdict(rhs: str) -> Optional[Tuple[str, str]]:
+    """Verdict for an EQUALS_MATCH RHS that is a torch singleton rather than
+    a python literal (pgw#691 P1: diffusers compares dtypes constantly, and
+    ``ast.literal_eval`` reported them as false-positive LEAKs). Dtype at the
+    compiled boundary is already pinned twice over — the ``weight_lane`` key
+    axis and :func:`canonical_ingress`'s per-path dtype memo (which raises a
+    NAMED :class:`GuardBoundaryError` on drift); layout/memory_format ride
+    the same canonical-form pin, device rides the runtime key axes."""
+    if _TORCH_DEVICE_RE.match(rhs):
+        return CONTRACT_SHAPE, "runtime device axes (sm/cuda/torch)"
+    m = _TORCH_ATTR_RE.match(rhs)
+    if m is None:
+        return None
+    try:
+        import torch
+    except ImportError:  # classification without torch: stay conservative
+        return None
+    obj = getattr(torch, m.group(1), None)
+    if isinstance(obj, (torch.dtype, torch.layout, torch.memory_format)):
+        return CONTRACT_SHAPE, "weight_lane + ingress dtype memo"
+    return None
+
+
 def _classify_equals(expr: str, pins: ContractPins) -> Tuple[str, str]:
     _lhs, sep, rhs = expr.partition(" == ")
     if not sep:
         return LEAK, "unparseable EQUALS_MATCH expression"
+    # classify() receives the RAW verbose part; python literals survive the
+    # trailing "  # file:line" comment (the tokenizer eats it) but the
+    # torch-object regex must see a clean RHS.
+    rhs = _COMMENT_RE.sub("", rhs).strip()
     try:
-        value = ast.literal_eval(rhs.strip())
+        value = ast.literal_eval(rhs)
     except Exception:
-        return LEAK, f"unparseable EQUALS_MATCH literal {rhs.strip()[:60]!r}"
+        torch_verdict = _torch_object_verdict(rhs)
+        if torch_verdict is not None:
+            return torch_verdict
+        return LEAK, f"unparseable EQUALS_MATCH literal {rhs[:60]!r}"
     return _scalar_verdict(value, pins)
 
 
@@ -479,10 +546,23 @@ def classify(
 ) -> Tuple[str, str]:
     """(verdict, covering axis / leak reason) for one guard.
 
-    Module- and global-rooted guards are covered by construction (weights +
-    code identity, pinned by the ck2 key axes). Input-rooted and ambient
-    guards are the closed world: unknown types are LEAKS, never waved on.
+    The RelationalGuard family is judged by TYPE first — torch attaches it
+    to the input managers (and SYMBOLIC_SHAPE_GUARD to synthetic tuple
+    sources), never predictably to one root. Everything else dispatches on
+    the source root: module- and global-rooted guards are covered by
+    construction (weights + code identity, pinned by the cell-key axes);
+    input-rooted and ambient guards are the closed world — unknown types are
+    LEAKS, never waved on.
     """
+    if guard_type in _RELATIONAL_ALIASING:
+        return STRUCTURAL, "cross-input aliasing fixed by call topology"
+    if guard_type == "SYMBOLIC_SHAPE_GUARD":
+        # torch 2.13's shape-env relations (install_symbolic_shape_guard,
+        # enable_cpp_symbolic_shape_guards) — also a RelationalGuard,
+        # observed with synthetic sources like "(0, L['x'].size()[0])".
+        if pins.has_dynamic:
+            return CONTRACT_SHAPE, "declared dynamic-dim range"
+        return LEAK, "shape-env relation without declared dynamic dims"
     root = _source_root(source)
     if root == "self":
         return MODULE_STRUCTURE, "family + graph_signature + weight_contract"
@@ -490,7 +570,7 @@ def classify(
         return CODE_IDENTITY, "gen_worker/diffusers/transformers/image versions"
     if root == "ambient":
         if guard_type in _AMBIENT_COVERED:
-            return RUNTIME_STATE, "process runtime state (ck2 runtime axes)"
+            return RUNTIME_STATE, "process runtime state (cell-key runtime axes)"
         if guard_type == "LAMBDA_GUARD":
             if ("init_ambient_guards" in expr
                     or "top_saved_tensors_hooks" in expr):
@@ -507,6 +587,8 @@ def classify(
         return _classify_tensor_match(expr)
     if guard_type in _STRUCTURAL_TYPES:
         return STRUCTURAL, "call topology (deterministic per endpoint code)"
+    if guard_type in _IDENTITY_CONSTANT_TYPES:
+        return CODE_CONSTANT, "object identity of a call-path constant"
     if guard_type == "EQUALS_MATCH":
         return _classify_equals(expr, pins)
     if guard_type == "LAMBDA_GUARD" and (".size()" in expr or ".stride()" in expr):

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -68,11 +68,15 @@ _BURST_META: Dict[str, Any] = {
     "shape_contract": _SHAPE_CONTRACT,
 }
 
-# What the hub saw, verbatim.
-PUBLISHED = "ck2-30b872ea452a3447ac368d0108de302c087b0a3b4b244ebeac10f15f"
-REQUESTED_PLAIN = (
+# What the hub saw, verbatim — ck2-era historical evidence. The pgw#691 sku
+# collapse bumped the scheme to ck3 (every digest changed), so these bytes
+# are RECORDS, no longer reproducible: the invariants below are asserted as
+# key RELATIONS from one axes dict, and the old keys must be dead (a clean
+# MISS, never a half-match).
+CK2_PUBLISHED = "ck2-30b872ea452a3447ac368d0108de302c087b0a3b4b244ebeac10f15f"
+CK2_REQUESTED_PLAIN = (
     "ck2-1688dc35245507a65d1a0fd2087adaae35f5885d5a71f05144a80710")
-REQUESTED_FP8_HOOKS = (
+CK2_REQUESTED_FP8_HOOKS = (
     "ck2-3156506b08a75f15202355242f7509abd409cfaabdd9467391ffe815")
 
 _RT = {
@@ -124,15 +128,20 @@ class _Pipe:
 # --- the defect, reproduced from the live evidence -------------------------
 
 
-def test_burst_divergence_reproduced_byte_exact(burst_runtime: None) -> None:
+def test_burst_divergence_reproduced_lane_only(burst_runtime: None) -> None:
     """All three observed keys are ONE identity varying only the lane axis:
     the advertised lanes name keys nobody publishes; the published lane
     names a key nobody advertises. Adoption was structurally impossible."""
-    assert ck.from_artifact_metadata(_BURST_META).digest == PUBLISHED
-    assert _requested("") == REQUESTED_PLAIN
-    assert _requested("fp8-hooks") == REQUESTED_FP8_HOOKS
-    assert _requested("w8a8") == PUBLISHED
-    assert _requested("w8a8-lora64") == PUBLISHED  # canonical-lane fold
+    published = ck.from_artifact_metadata(_BURST_META).digest
+    assert _requested("w8a8") == published
+    assert _requested("w8a8-lora64") == published  # canonical-lane fold
+    assert _requested("") != published
+    assert _requested("fp8-hooks") != published
+    assert _requested("") != _requested("fp8-hooks")
+    # pgw#691: the recorded ck2 burst keys are dead post-bump — is_key
+    # refuses them outright, so an old cell can only MISS, never half-match.
+    for old in (CK2_PUBLISHED, CK2_REQUESTED_PLAIN, CK2_REQUESTED_FP8_HOOKS):
+        assert not ck.is_key(old)
 
 
 def test_raw_pipeline_probe_is_blind_to_w8a8_mode(burst_runtime: None) -> None:
@@ -144,8 +153,10 @@ def test_raw_pipeline_probe_is_blind_to_w8a8_mode(burst_runtime: None) -> None:
     pipe = _Pipe()
     assert pipeline_weight_lane(pipe) == ""
     assert w8a8_lora.branch_lane(pipe.unet) == "w8a8"
-    # The pre-fix advertised key IS the burst's never-published key.
-    assert _requested(pipeline_weight_lane(pipe)) == REQUESTED_PLAIN
+    # The pre-fix advertised key IS the burst's never-published identity.
+    assert _requested(pipeline_weight_lane(pipe)) == _requested("")
+    assert _requested(pipeline_weight_lane(pipe)) \
+        != ck.from_artifact_metadata(_BURST_META).digest
 
 
 # --- the fix: one base-lane resolution for every cell-identity surface -----
@@ -156,7 +167,8 @@ def test_cell_base_lane_sees_w8a8_mode(burst_runtime: None) -> None:
     assert w8a8_lora.effective_base_lane(pipe) == "w8a8"
     assert cc.cell_base_lane(pipe) == "w8a8"
     # An identical worker now requests exactly the key the mint published.
-    assert _requested(cc.cell_base_lane(pipe)) == PUBLISHED
+    assert _requested(cc.cell_base_lane(pipe)) \
+        == ck.from_artifact_metadata(_BURST_META).digest
 
 
 def test_cell_base_lane_precedence() -> None:

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -36,7 +36,7 @@ _CONTRACT = ck.contract_digest(_FACTS)
 
 _AXES = {
     "format": "2", "kind": "inductor", "family": "ltx-2.3", "lane": "w8a8",
-    "sku": "b200", "sm": "sm_100", "cuda": "13.0", "torch": "2.13.0+cu130",
+    "sm": "sm_100", "cuda": "13.0", "torch": "2.13.0+cu130",
     "triton": "3.7.1", "gen_worker": "0.36.10", "contract": _CONTRACT,
     "diffusers": "0.39.0", "transformers": "5.13.1",
     "image_digest": "sha256:abc",
@@ -64,7 +64,7 @@ def test_key_deterministic_and_axis_sensitive():
     a = ck.from_axes(_AXES)
     assert a.digest == ck.from_axes(dict(_AXES)).digest
     assert ck.is_key(a.digest)
-    for axis in ("family", "lane", "sku", "torch", "gen_worker",
+    for axis in ("family", "lane", "sm", "torch", "gen_worker",
                  "contract", "image_digest"):
         bumped = dict(_AXES, **{axis: _AXES[axis] + "x"})
         assert ck.from_axes(bumped).digest != a.digest, axis
@@ -81,7 +81,42 @@ def test_unknown_and_missing_axes_refuse():
     with pytest.raises(ck.CellKeyError):
         ck.from_axes(dict(_AXES, cuda_driver="13020"))  # host lottery axis
     with pytest.raises(ck.CellKeyError):
+        ck.from_axes(dict(_AXES, sku="b200"))  # demoted to metadata (pgw#691)
+    with pytest.raises(ck.CellKeyError):
         ck.from_axes({k: v for k, v in _AXES.items() if k != "torch"})
+
+
+def test_sku_is_not_identity(fixed_runtime):
+    """pgw#691: the audited corpus held two byte-identical cell PAIRS split
+    only by sku (a40 vs rtx-3090 on sm_86; l4 vs rtx-4090 on sm_89) — 19%
+    redundant mints. No dynamo guard observes a SKU; sm + cuda + torch +
+    triton pin every hardware fact the guard set carries. Two artifacts
+    identical on every axis but sku share ONE identity; sm remains one."""
+
+    def _meta(sku, sm="sm_86"):
+        meta = cc.artifact_metadata(
+            family="sdxl", shapes=((768, 768),), targets=("transformer",),
+            shape_contract=_FACTS,
+        )
+        meta.update({"sku": sku, "sm": sm})
+        return ck.stamp(meta)
+
+    a40, rtx3090 = _meta("a40"), _meta("rtx-3090")
+    assert a40["cell_key"] == rtx3090["cell_key"]
+    # sku SURVIVES in metadata — the hub-side selection preference and the
+    # publish-intent anti-forgery attestation both read it from there.
+    assert a40["sku"] == "a40" and rtx3090["sku"] == "rtx-3090"
+    # sm stays identity: a different arch is a different cell.
+    assert _meta("a40", sm="sm_89")["cell_key"] != a40["cell_key"]
+
+
+def test_key_scheme_ck3_old_keys_never_half_match():
+    """The sku collapse changes every key, so the scheme is bumped: a ck2
+    digest is no longer a key at all — a clean MISS, never a half-match."""
+    key = ck.from_axes(_AXES).digest
+    assert key.startswith("ck3-")
+    assert not ck.is_key("ck2-" + "a" * 56)
+    assert "not a cell key" in ck.mismatch({}, "ck2-" + "a" * 56)
 
 
 def test_compute_matches_artifact_metadata_stamp(fixed_runtime):

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -183,8 +183,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck2-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck2-{'a' * 56}",
+            family=FAMILY, cell_key="ck3-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1178,7 +1178,7 @@ def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck2-" + "d" * 56
+    mint_key = "ck3-" + "d" * 56
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
@@ -1256,7 +1256,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck2-" + "a1" * 28
+    mint_key = "ck3-" + "a1" * 28
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     store_digest = "blake3:" + "f" * 64  # the store's snapshot-manifest form
@@ -1323,7 +1323,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
         "advertised digest must align to the store's form")
 
     # A genuinely DIFFERENT key still vacates (identity actually moved).
-    other_key = "ck2-" + "b2" * 28
+    other_key = "ck3-" + "b2" * 28
     other_ref = f"root/family-{FAMILY}#{other_key}"
 
     class _OtherKey:
@@ -1368,7 +1368,7 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
         compile=Compile(shapes=((768, 768),), family=FAMILY, text_len=0),
     )
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck2-" + "f" * 56
+    mint_key = "ck3-" + "f" * 56
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
     mint_artifact.parent.mkdir()
     mint_artifact.write_bytes(b"cell-bytes")
@@ -1439,7 +1439,7 @@ def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
     monkeypatch.setattr(cc, "toolchain_present", lambda: True)
 
     class _Key:
-        digest = "ck2-" + "9" * 56
+        digest = "ck3-" + "9" * 56
 
     monkeypatch.setattr(cell_key_mod, "compute", lambda *a, **k: _Key())
     captured: dict = {}
@@ -3796,7 +3796,7 @@ def test_fresh_boot_advertises_candidate_cell_lookups(monkeypatch):
     computed: list = []
 
     class _Key:
-        digest = "ck2-" + "5" * 56
+        digest = "ck3-" + "5" * 56
 
     def _compute(family, lane="", bucket=0, **kw):
         computed.append((family, lane))

--- a/tests/test_guard_closure_pgw681.py
+++ b/tests/test_guard_closure_pgw681.py
@@ -147,8 +147,11 @@ def test_classifier_closed_world() -> None:
         == gc.CONTRACT_SCALAR
     assert gc.classify("EQUALS_MATCH", "L['n']", "L['n'] == 999", pins) \
         == (gc.LEAK, "int 999 is not a declared contract pin")
+    # pgw#691: input-rooted ID_MATCH is the object identity of a call-path
+    # constant (enum member / callable bound by the endpoint call path) —
+    # covered, not a leak.
     assert gc.classify("ID_MATCH", "L['mask']", "___check_obj_id(...)", pins)[0] \
-        == gc.LEAK
+        == gc.CODE_CONSTANT
     assert gc.classify("WEIRD_NEW_GUARD", "L['x']", "whatever", pins)[0] == gc.LEAK
     # Ambient: known types covered, unknown leak.
     assert gc.classify("GLOBAL_STATE", "", "___check_global_state()", pins)[0] \

--- a/tests/test_guard_closure_pgw691.py
+++ b/tests/test_guard_closure_pgw691.py
@@ -1,0 +1,326 @@
+"""pgw#691: guard-closure classifier fixes, red-verified on real dynamo trees.
+
+The offline audit (tracker 4b37ee8) drove the shipped classifier against 546
+real torch-2.13.0 guard rows and proved the closed world was not closed:
+
+* P0 — the RelationalGuard family (NO_TENSOR_ALIASING, OBJECT_ALIASING,
+  STORAGE_OVERLAPPING) is attached to INPUT guard managers, but the
+  classifier dispatched on source root first, so every graph with >=2
+  tensor inputs leaked — i.e. every sdxl mint refused.
+* P1 — the enumerated vocabulary mixed python GuardBuilder names into the
+  C++ leaf-class universe the walk yields: 7 real classes unnameable,
+  2 phantoms, SYMBOLIC_SHAPE_GUARD (torch 2.13's shape-env facts) always a
+  LEAK so declared dynamic dims were unmintable.
+* P1 — EQUALS_MATCH against torch singletons (``L['dt'] == torch.float32``)
+  failed ``ast.literal_eval`` and false-positive leaked.
+
+All probes here are CPU ``backend="eager"`` (dynamo's guard machinery is
+production-identical; only inductor codegen is skipped) — no GPU, no
+inference.
+"""
+
+from __future__ import annotations
+
+import enum
+import threading
+from typing import Any, Callable, Dict, Iterator, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import compile_cache as cc
+from gen_worker import guard_closure as gc
+from gen_worker.registry import CompileCell
+
+
+@pytest.fixture(autouse=True)
+def _fresh_dynamo() -> Iterator[None]:
+    torch._dynamo.reset()
+    yield
+    torch._dynamo.reset()
+
+
+def _cfg(**overrides: Any) -> CompileCell:
+    base: Dict[str, Any] = dict(
+        shapes=((64, 64),), targets=("unet",), family="sdxl",
+        regional=False, text_len=77, dynamic=(), lora_bucket=0,
+        guidance_scales=(5.0,), text_lens=(),
+    )
+    base.update(overrides)
+    return CompileCell(**base)
+
+
+def _arm_marker(pipe: Any, module: Any, fn: Any) -> None:
+    setattr(pipe, cc._MARKER_ATTR, {
+        "targets": ["unet"],
+        "shapes": [(64, 64)],
+        "cache": True,
+        "originals": [(module, "forward", fn)],
+        "regional_mods": [],
+        "failure_signal": {
+            "callback": None, "lock": threading.Lock(),
+            "successful_calls": 0, "cache_hits": 0, "cache_misses": 0,
+            "router": None,
+        },
+    })
+
+
+def _sdxl_shaped_pipe(forward: Callable[..., Any]) -> Tuple[Any, Any]:
+    """An armed pipe whose target has the sdxl unet ingress ARGUMENT
+    TOPOLOGY: several tensor inputs + a tensor dict + None/bool/str kwargs +
+    a float guidance scalar (the audit's probe shape)."""
+
+    class _Unet(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(8, 8)
+
+    _Unet.forward = forward  # type: ignore[method-assign]
+
+    class _Pipe:
+        pass
+
+    pipe = _Pipe()
+    mod = _Unet()
+    pipe.unet = mod  # type: ignore[attr-defined]
+    _arm_marker(pipe, mod, mod.forward)
+    return pipe, mod.forward
+
+
+def _sdxl_forward(
+    self: Any, sample: Any, timestep: Any, encoder_hidden_states: Any,
+    added_cond_kwargs: Any, cross_attention_kwargs: Any = None,
+    guidance_scale: float = 5.0, return_dict: bool = False,
+    mode: str = "default",
+) -> Any:
+    out = self.lin(sample) + timestep + encoder_hidden_states
+    out = out + added_cond_kwargs["time_ids"]
+    if guidance_scale != 1.0:
+        out = out * guidance_scale
+    return out
+
+
+def _sdxl_inputs() -> Dict[str, Any]:
+    return dict(
+        sample=torch.randn(2, 4, 8),
+        timestep=torch.randn(2, 1, 8),
+        encoder_hidden_states=torch.randn(2, 4, 8),
+        added_cond_kwargs={"time_ids": torch.randn(2, 1, 8)},
+        cross_attention_kwargs=None,
+        return_dict=False,
+        mode="default",
+    )
+
+
+# ---------------------------------------------------------------------------
+# P0: the RelationalGuard family is input-attached, judged by TYPE
+# ---------------------------------------------------------------------------
+
+
+def test_multi_tensor_input_aliasing_guards_are_structural() -> None:
+    """>=2 tensor inputs => dynamo emits NO_TENSOR_ALIASING on the INPUT
+    managers (one row per participating tensor). Pre-fix these hit the
+    terminal input-root LEAK; they are call-topology facts — STRUCTURAL."""
+
+    def two_tensor(a: Any, b: Any) -> Any:
+        return a + b
+
+    compiled = torch.compile(two_tensor, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 8), torch.randn(2, 8))
+
+    graphs = gc.extract_target_guards(two_tensor, "t", _cfg())
+    assert len(graphs) == 1
+    rows = graphs[0].guards
+    alias = [r for r in rows if r.guard_type == "NO_TENSOR_ALIASING"]
+    assert alias, "the >=2-tensor trigger must emit the relational family"
+    assert {r.verdict for r in alias} == {gc.STRUCTURAL}
+    assert all(r.source.startswith("L[") for r in alias)  # input-attached
+    assert gc.LEAK not in {r.verdict for r in rows}
+
+
+def test_relational_family_judged_by_type_regardless_of_root() -> None:
+    pins = gc.contract_pins(_cfg())
+    for guard_type in ("NO_TENSOR_ALIASING", "OBJECT_ALIASING",
+                       "STORAGE_OVERLAPPING", "DUPLICATE_INPUT"):
+        for source in ("", "L['sample']", "L['added']['time_ids']"):
+            verdict, _axis = gc.classify(guard_type, source, "x", pins)
+            assert verdict == gc.STRUCTURAL, (guard_type, source)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: the sdxl-shaped mint gate passes closed, refuses named
+# ---------------------------------------------------------------------------
+
+
+def test_sdxl_shaped_mint_gate_passes_closed() -> None:
+    """The definitive acceptance: assert_closure returns an exit-0 closed
+    manifest on a real multi-tensor-input compiled module with the
+    sdxl-shaped contract. Pre-fix: refused 100% (NO_TENSOR_ALIASING)."""
+    pipe, fn = _sdxl_shaped_pipe(_sdxl_forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(guidance_scale=5.0, **_sdxl_inputs())
+
+    manifest = gc.assert_closure(pipe, _cfg(), label="sdxl")
+    assert manifest["leaks"] == []
+    assert manifest["graphs"]
+    types = {
+        r["type"] for g in manifest["graphs"] for r in g["guards"]}
+    assert "NO_TENSOR_ALIASING" in types  # the P0 family really was present
+
+
+def test_sdxl_shaped_mint_gate_refuses_naming_the_variable() -> None:
+    """A genuinely undeclared scalar still fails the mint red, naming the
+    exact variable — the fix widens nothing."""
+    pipe, fn = _sdxl_shaped_pipe(_sdxl_forward)
+    compiled = torch.compile(fn, backend="eager", dynamic=None)
+    compiled(guidance_scale=7.5, **_sdxl_inputs())  # 7.5 is NOT declared
+
+    with pytest.raises(gc.GuardClosureError) as excinfo:
+        gc.assert_closure(pipe, _cfg(), label="sdxl")
+    message = str(excinfo.value)
+    assert "L['guidance_scale']" in message
+    assert "7.5" in message
+
+
+# ---------------------------------------------------------------------------
+# P1: SYMBOLIC_SHAPE_GUARD is torch 2.13's shape-env fact
+# ---------------------------------------------------------------------------
+
+
+def test_symbolic_shape_guard_rides_declared_dynamic_dims() -> None:
+    """Real SYMBOLIC_SHAPE_GUARD rows (enable_cpp_symbolic_shape_guards)
+    arrive with synthetic tuple sources like ``(0, L['x'].size()[0])`` —
+    pre-fix both the ambient and the "other"-root paths leaked them, making
+    every declared-dynamic contract unmintable."""
+    flag = "enable_cpp_symbolic_shape_guards"
+    old = getattr(torch._dynamo.config, flag)
+    setattr(torch._dynamo.config, flag, True)
+    try:
+        def d(x: Any) -> Any:
+            if x.shape[0] > 2:
+                return x * 2
+            return x
+
+        xd = torch.randn(5, 3)
+        torch._dynamo.mark_dynamic(xd, 0)
+        torch.compile(d, backend="eager")(xd)
+
+        dyn_cfg = _cfg(dynamic=(
+            type("D", (), {"dim": "batch", "min": 2, "max": 64})(),))
+        rows = gc.extract_target_guards(d, "t", dyn_cfg)[0].guards
+        ssg = [r for r in rows if r.guard_type == "SYMBOLIC_SHAPE_GUARD"]
+        assert ssg, "cpp symbolic shape guards must be emitted on 2.13"
+        assert {r.verdict for r in ssg} == {gc.CONTRACT_SHAPE}
+
+        # The SAME graph without declared dynamism is a named LEAK.
+        undeclared = gc.extract_target_guards(d, "t", _cfg())[0].guards
+        ssg_leaks = [
+            r for r in undeclared if r.guard_type == "SYMBOLIC_SHAPE_GUARD"]
+        assert {r.verdict for r in ssg_leaks} == {gc.LEAK}
+        assert all("dynamic" in r.axis for r in ssg_leaks)
+    finally:
+        setattr(torch._dynamo.config, flag, old)
+
+
+# ---------------------------------------------------------------------------
+# P1: EQUALS_MATCH against torch singletons
+# ---------------------------------------------------------------------------
+
+
+def test_equals_match_torch_objects_are_covered() -> None:
+    """``L['dt'] == torch.float32`` is not a python literal; pre-fix it
+    leaked "unparseable". Dtype at the boundary is pinned by weight_lane +
+    the ingress dtype memo; memory_format rides the same canonical pin."""
+
+    def g(t: Any, dt: Any, mf: Any) -> Any:
+        if dt == torch.float16:
+            return t.half()
+        if mf == torch.channels_last:
+            return t
+        return t + 1
+
+    compiled = torch.compile(g, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 3), torch.float32, torch.contiguous_format)
+
+    rows = gc.extract_target_guards(g, "t", _cfg())[0].guards
+    eq = [r for r in rows
+          if r.guard_type == "EQUALS_MATCH" and r.source.startswith("L[")]
+    assert {r.source for r in eq} == {"L['dt']", "L['mf']"}
+    assert {r.verdict for r in eq} == {gc.CONTRACT_SHAPE}
+    assert all(r.axis == "weight_lane + ingress dtype memo" for r in eq)
+    assert gc.LEAK not in {r.verdict for r in rows}
+
+
+def test_equals_match_device_literal_and_garbage() -> None:
+    pins = gc.contract_pins(_cfg())
+    verdict, axis = gc.classify(
+        "EQUALS_MATCH", "L['dev']",
+        "L['dev'] == device(type='cuda', index=0)", pins)
+    assert verdict == gc.CONTRACT_SHAPE
+    assert "device" in axis
+    # Non-torch unparseables still leak — the fix widens only torch objects.
+    verdict, axis = gc.classify(
+        "EQUALS_MATCH", "L['obj']", "L['obj'] == SomeClass(1)", pins)
+    assert verdict == gc.LEAK
+    assert "unparseable" in axis
+    # torch attrs that are NOT dtype/layout/memory_format stay leaks.
+    verdict, _axis = gc.classify(
+        "EQUALS_MATCH", "L['fn']", "L['fn'] == torch.relu", pins)
+    assert verdict == gc.LEAK
+
+
+# ---------------------------------------------------------------------------
+# P1: input-rooted object identity of call-path constants
+# ---------------------------------------------------------------------------
+
+
+class _Mode(enum.Enum):
+    A = 1
+    B = 2
+
+
+def test_id_match_call_path_constants_are_code_constants() -> None:
+    """Enum members / callables bound by the fixed endpoint call path emit
+    input-rooted ID_MATCH; pre-fix any object-valued argument was
+    unmintable. Identity of a call-path constant cannot vary per request;
+    a cross-process identity miss recompiles via the guard-miss path —
+    never wrongness."""
+
+    def h(t: Any, mode: Any, hook: Any) -> Any:
+        if mode is _Mode.A:
+            return hook(t)
+        return t
+
+    compiled = torch.compile(h, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 3), _Mode.A, torch.relu)
+
+    rows = gc.extract_target_guards(h, "t", _cfg())[0].guards
+    idm = [r for r in rows
+           if r.guard_type == "ID_MATCH" and r.source.startswith("L[")]
+    assert {r.source for r in idm} >= {"L['mode']", "L['hook']"}
+    assert {r.verdict for r in idm} == {gc.CODE_CONSTANT}
+    assert gc.LEAK not in {r.verdict for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary hygiene: C++ names in, phantoms out
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_leaf_names_are_classified() -> None:
+    pins = gc.contract_pins(_cfg())
+    assert gc.classify("DUAL_LEVEL_MATCH", "", "x", pins)[0] == gc.RUNTIME_STATE
+    assert gc.classify("FAKE_SCRIPT_TYPE_MATCH", "L['x']", "x", pins)[0] \
+        == gc.STRUCTURAL
+    assert gc.classify("DICT_VERSION", "L['cfg']", "x", pins)[0] \
+        == gc.CODE_CONSTANT
+
+
+def test_phantom_names_are_leaks() -> None:
+    """AUTOCAST_STATE and KEYS_MATCH exist in NEITHER torch 2.13 universe
+    (C++ leaf classes or GuardBuilder names) — if one ever arrives it is by
+    definition unknown, and the closed world leaks it."""
+    pins = gc.contract_pins(_cfg())
+    assert gc.classify("AUTOCAST_STATE", "", "x", pins)[0] == gc.LEAK
+    assert gc.classify("KEYS_MATCH", "L['d']", "x", pins)[0] == gc.LEAK

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -449,7 +449,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck2-" + digest, axes={})
+    return SimpleNamespace(digest="ck3-" + digest, axes={})
 
 
 SHAPE = (768, 768)

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -205,8 +205,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck2-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck2-{'a' * 56}",
+            family=FAMILY, cell_key="ck3-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -212,8 +212,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck2-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck2-{'a' * 56}",
+            family=FAMILY, cell_key="ck3-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
@@ -547,8 +547,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root = tmp_path / "m"
         (mint_root / "capture").mkdir(parents=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck2-" + "b" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck2-{'b' * 56}",
+            family=FAMILY, cell_key="ck3-" + "b" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck3-{'b' * 56}",
             cfg=None, target=mint_root / "cell.tar.gz",
             capture_dir=mint_root / "capture", mint_root=mint_root,
             publisher=None, cache_dir=None,
@@ -568,8 +568,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root2 = tmp_path / "m2"
         (mint_root2 / "capture").mkdir(parents=True)
         pending2 = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck2-" + "c" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck2-{'c' * 56}",
+            family=FAMILY, cell_key="ck3-" + "c" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck3-{'c' * 56}",
             cfg=None, target=mint_root2 / "cell.tar.gz",
             capture_dir=mint_root2 / "capture", mint_root=mint_root2,
             publisher=None, cache_dir=None,

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -185,7 +185,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck2-" + digest, axes={})
+    return SimpleNamespace(digest="ck3-" + digest, axes={})
 
 
 def _endpoint_cls(shapes: tuple) -> type:
@@ -324,7 +324,7 @@ def test_second_same_family_arm_mints_its_own_graphs_and_finalizes(
     }
     assert len(refs) == 2, "two distinct cells, each proven by its own boot"
     for ref in refs:
-        assert ref.startswith(f"root/family-{FAMILY}#ck2-")
+        assert ref.startswith(f"root/family-{FAMILY}#ck3-")
         assert cc.cell_proven_in_process(ref)
     with fleet_cells._PENDING_LOCK:
         assert fleet_cells._PENDING == {}

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.1"
+version = "0.70.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Train carrying the pgw#681-fix lane's pgw#691 (chaos 285a817, byte-identical): RelationalGuard family judged by type (the fail-every-mint NO_TENSOR_ALIASING leak), C++ leaf-class vocabulary rebuild (SYMBOLIC_SHAPE_GUARD rides declared dynamic dims), torch-singleton EQUALS_MATCH covered, and ck2 -> ck3 (sku leaves cell-key identity; stays in metadata/attestation; old ck2 keys are a clean MISS). Expected on first fleet contact: one cell_exchange_key_split alarm per (endpoint, family) + a one-time re-mint wave — planned, not a regression.

Gates on this head: full suite 1097 passed / 0 failed / 9 skipped / 1 xfailed; mypy clean (152 files); ruff clean. One CI run on this final head only.

Unblocks: the two-pod adoption proof on sdxl 0.2.11 (the cell-reusability finale) — the closure gate can now PASS a real sdxl mint and publish the first closed guard_manifest.

Tracker: python-gen-worker/progress.md pgw#691 + pgw#677 reopen section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)