### PR TITLE
release: gen-worker 0.70.3 — pgw#694 determinism hardening + cache-review fixes (ck4, env-seal boot wiring, inner-FX sm shim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
-## Unreleased (cache-design review fixes) — inner FX key portability + strict verify
+## 0.70.3 (2026-07-26) — pgw#694 determinism hardening + cache-review fixes (ck4 keys, env-seal boot wiring, inner-FX sm shim)
+
+One train: the pgw#694 hardening set (chaos a73e6c8), its executor-side boot wiring (`entrypoint._establish_env_seal`), and the ML-cache-review fixes (chaos 23a34bd — the P0 inner-inductor-cache portability shim, B200-verified). ck3 -> ck4 is the second and final planned key-scheme bump; expect one `cell_exchange_key_split` alarm per (endpoint, family) and a one-time re-mint wave.
+
+### pgw#694 (#695-#698): execution-environment determinism hardening
+
+Four of the pgw#694 umbrella's five measures (the fifth, pgw#699, is a tracker-side
+harness). All red-verified against real torch state / real file trees; CPU only.
+
+- **#695 process-posture seal**: ONE canonical serving posture (grad, autocast,
+  torch-function stack, default device, deterministic-algos);
+  `guard_closure.establish_posture()` at boot, sealed into the guard manifest at mint
+  (manifest v2), re-asserted by `artifact_drift` before every arm — drift refuses the
+  arm NAMED, never a downstream guard miss. A mint in a non-canonical posture fails
+  red. `consolidate` flags cross-pod posture divergence.
+- **#696 config-surface freeze + ck4**: new `env_seal` module — canonical flag table
+  set explicitly at boot (`cudnn.allow_tf32` default-True pinned False,
+  float32_matmul_precision, TF32 matmul, cudnn.benchmark), unknown `TORCH*` env vars
+  refuse boot naming the var, portable inductor-config digest. Posture+config+inductor
+  fold into ONE versioned `env_seal` dict recorded verbatim in metadata; its digest is
+  a REQUIRED ck4 key axis recomputed from the recorded facts. KEY_SCHEME ck3 -> ck4
+  (final planned bump: seal_v versions the dict internally).
+- **#697 composition fingerprint**: module rows now carry hook presence; new
+  `composition_fingerprint()` stores per-module digests in metadata so a graph-
+  signature mismatch at adoption names the exact drifted module
+  (`transformer:lin2: cell ... != consumer ...`) — the pgw#683 bf16/Half class.
+  Fine-tunes still share cells (no tensor values in any row).
+- **#698 cubin-completeness gate**: `pack()` refuses (named kernels) when any kernel
+  ships PTX without an sm-exact cubin — closing the one path where the deliberately
+  unkeyed driver (gw#577) could re-enter behavior via PTX JIT.
+- **ck3-completion bug fix**: `verify()` still hard-pinned `sku` after the pgw#691
+  collapse — a same-sm cell minted on a different SKU refused to arm. sku is now
+  observability-only in verify; sm/cuda/torch/triton carry the hardware identity.
+
+### Cache-design review fixes — inner FX key portability + strict verify
 
 From the ML-systems + build-systems cache reviews (tracker, both in
 python-gen-worker/progress.md). All red-verified (7/8 new tests fail pre-fix).
@@ -33,252 +67,6 @@ python-gen-worker/progress.md). All red-verified (7/8 new tests fail pre-fix).
   NVIDIA_TF32_OVERRIDE, PYTHONHASHSEED). R2: operator `epoch` salt (`COZY_CELL_EPOCH`)
   sealed as a fact — disowning a poisoned mint generation is one config change, never
   a scheme bump (Bazel Action.salt / ccache HASH_PREFIX precedent).
-
-## Unreleased (pgw#694: #695-#698) — execution-environment determinism hardening
-
-Four of the pgw#694 umbrella's five measures (the fifth, pgw#699, is a tracker-side
-harness). All red-verified against real torch state / real file trees; CPU only.
-
-- **#695 process-posture seal**: ONE canonical serving posture (grad, autocast,
-  torch-function stack, default device, deterministic-algos);
-  `guard_closure.establish_posture()` at boot, sealed into the guard manifest at mint
-  (manifest v2), re-asserted by `artifact_drift` before every arm — drift refuses the
-  arm NAMED, never a downstream guard miss. A mint in a non-canonical posture fails
-  red. `consolidate` flags cross-pod posture divergence.
-- **#696 config-surface freeze + ck4**: new `env_seal` module — canonical flag table
-  set explicitly at boot (`cudnn.allow_tf32` default-True pinned False,
-  float32_matmul_precision, TF32 matmul, cudnn.benchmark), unknown `TORCH*` env vars
-  refuse boot naming the var, portable inductor-config digest. Posture+config+inductor
-  fold into ONE versioned `env_seal` dict recorded verbatim in metadata; its digest is
-  a REQUIRED ck4 key axis recomputed from the recorded facts. KEY_SCHEME ck3 -> ck4
-  (final planned bump: seal_v versions the dict internally).
-- **#697 composition fingerprint**: module rows now carry hook presence; new
-  `composition_fingerprint()` stores per-module digests in metadata so a graph-
-  signature mismatch at adoption names the exact drifted module
-  (`transformer:lin2: cell ... != consumer ...`) — the pgw#683 bf16/Half class.
-  Fine-tunes still share cells (no tensor values in any row).
-- **#698 cubin-completeness gate**: `pack()` refuses (named kernels) when any kernel
-  ships PTX without an sm-exact cubin — closing the one path where the deliberately
-  unkeyed driver (gw#577) could re-enter behavior via PTX JIT.
-- **ck3-completion bug fix**: `verify()` still hard-pinned `sku` after the pgw#691
-  collapse — a same-sm cell minted on a different SKU refused to arm. sku is now
-  observability-only in verify; sm/cuda/torch/triton carry the hardware identity.
-
-## 0.74.1 (2026-07-26) — pgw#692: `WanDefaults` carries the hub's recipe wire name
-
-**P0, every wan-2.2 request of every tier.** th#1174's migration
-`0046_recipe_steps_rename_hidream_wan22` renamed the recipe field `steps` ->
-`num_inference_steps` in the hub's `wan22.schema.json` and in every stored
-`repo_inference_defaults` / `release_slot_recipe` row (chaos, 2026-07-26
-00:12:20Z) — but the SDK half never shipped, so the hub-stamped recipe hit
-`GenerationDefaults`' `forbid_unknown_fields` and every request died at slot
-resolution, before handler code:
-
-```
-ValueError: slot 'pipeline': catalog inference-defaults metadata failed
-WanDefaults validation: Object contains unknown field `num_inference_steps`
-```
-
-- `WanDefaults.steps` -> `WanDefaults.num_inference_steps`. The hub is the
-  half that is right: `RuntimeFormula` resolves its terms by same-named
-  lookup across payload and `ctx.defaults`, and the
-  `PUT .../metadata/inference-defaults` route refuses a `steps` spelling
-  outright (`additionalProperties: false`).
-- Full audit of the registered vocabularies against the hub's family schemas:
-  `SdxlDefaults` and `SdxlLoraDefaults` keep `steps` (0040/0046 deliberately
-  left sdxl and qwen-image alone) and match field-for-field; wan22 was the
-  only skew in this repo. `HiDreamO1Defaults` has the identical exposure but
-  lives in `inference-endpoints/hidream-o1-image` — cross-repo, tracked on
-  pgw#692.
-- Guard (`tests/test_family_wire_names_pgw692.py`): every registered family's
-  `__struct_fields__` is asserted against a recorded snapshot of its hub
-  schema `properties`, so a one-sided rename can never be silent again.
-
-## 0.74.0 (2026-07-26) — pgw#685 S2c: the native svdq engine actually serves
-
-Wires the native engine into the load path. `load_svdq_pipeline` now chooses an
-ENGINE (`select_svdq_engine`) instead of assuming nunchaku, so `loading.py` needs
-no change at all — the dispatch lives behind the entry point the loading layer
-already called.
-
-- **`load_svdq_native_denoiser`** materializes a nunchaku-format checkpoint as a
-  STOCK diffusers module: skeleton on meta, W4A4 linears swapped for
-  `SvdqLinear` (fused `to_qkv` / `add_qkv_proj` split across the diffusers
-  projections), AWQ modulation layers decoded to bf16 Linears, everything else
-  assigned verbatim, then a STRICT check that nothing is left on the meta device —
-  a checkpoint that does not cover the module fails loud instead of serving a
-  half-initialized denoiser.
-- **`adanorm_splits_for`** is a table keyed on (diffusers class, module suffix),
-  not an inference from `out_features // in_features`. An unknown modulation layer
-  REFUSES; the exporter's adaLN transform is unrecoverable from the tensors and a
-  wrong split count corrupts output silently.
-- **Verified against the REAL 13 GB `svdq-fp4_r128-qwen-image` artifact**, pod-side
-  (weights never touch the dev box). Every one of its 4573 tensors is accounted
-  for: 480 svdq W4A4 prefixes (360 direct + 120 fused-qkv splits), 120 AWQ
-  modulation layers, 247 plain — **zero unmapped in any category** against the
-  stock `QwenImageTransformer2DModel`. Both decoders produce finite,
-  structurally-correct values (rank 128 throughout; `per_channel` second-level
-  scale exactly on the two fused qkv layers and `per_tensor` elsewhere, as the
-  layout predicted). The assembled loader then ran end to end: 2-block truncation
-  in 7.0s / 3.65 GB RSS and the **full 60 blocks in 163s / 55.7 GB RSS**, nothing
-  left on meta, `to_q`/`to_k`/`to_v` present as three working 3072-wide Linears,
-  modulation decoded to `Linear`, and a live forward finite.
-- mypy: fixed 7 `Optional`-narrowing errors this lane introduced (5 in
-  `svdq_native.py`, 2 in `svdq_layout.py`) by narrowing through locals rather than
-  silencing them; `mypy src/gen_worker` is green across 155 files.
-
-Admission is still NOT widened: `ladder.py`'s svdq placement keeps
-`sm_allowed=(120,121)`, `engines=("nunchaku",)`. Native now SERVES where it is
-selected, but the hub does not yet schedule svdq-fp4 onto sm_100 — that flip wants
-the fp4 (`blockwise`) full-artifact load and a numerical A/B, neither of which is
-measured yet (the verified load ran in the `dense` fold, and no nunchaku wheel was
-present to difference against).
-
-## 0.73.1 (2026-07-26)
-
-- **pgw#684: a fourth reserved repo field, `candidate`, for producer payloads
-  (te#121 two-ref quality eval).** The executor's reserved repo names were
-  `source`/`destination`/`text_encoder`; a producer payload can now also declare
-  `candidate: SourceRepo | None = None` and get it materialized the same way as
-  `source` — into `ctx.candidate_path` (`ctx.candidate` for the raw dict), fully
-  independent of `ctx.source_path`. This is the arm a two-ref eval COMPARES
-  against `source` rather than a component it builds from, which is what lets a
-  quality gate point at one of OUR OWN hub artifacts (a mirror, or a flavor the
-  quant ladder just produced) instead of only a public HF/Civitai coordinate.
-  Generic mechanism: gen-worker has no eval awareness. Absent field (every
-  existing endpoint) is byte-for-byte unchanged — no extra `ensure_local` call,
-  `ctx.candidate_path` stays `None`. The reserved-name set is still a hardcoded
-  literal list; pgw#690 tracks making it declarative.
-- Also re-covers reserved-repo materialization in `tests/`, which had NO coverage
-  after th#960/pgw#609 Phase 3b (`0b437aa`) swept pgw#594's two test files.
-- Corrects a `uv.lock` drift: 0.73.0 bumped `pyproject.toml` but left the lock's
-  `gen-worker` entry at 0.72.0, so `uv lock --check` failed on that commit.
-
-## 0.73.0 (2026-07-26) — pgw#687: a cancel that never unwinds no longer absorbs the next job
-
-Cancelling a job mid-compute could wedge a worker permanently while every
-hub-side signal read healthy: connected, heartbeating, still advertising its
-functions. Live (th#1165): job A cancelled mid-modelopt-calibration, job B
-assigned to the same pod 61 s later, then ZERO events of any kind for 46
-minutes. The only symptom was absence.
-
-Mechanism: cancelling a SYNC handler is cooperative. `handle_cancel` sets
-`ctx.cancelled` and (for async handlers only) cancels the task; a thread
-running `asyncio.to_thread` cannot be cancelled at all. A handler that never
-polls the flag — a modelopt calibration loop — keeps running, so `_run_job`
-never returns, the GPU permit and the per-instance run gate are never
-released, and the next job parks in `_gpu_semaphore.acquire()`, a wait that
-emits nothing. Nothing watched the cancel -> terminal edge.
-
-- **The cancel -> terminal edge is now watched.** Past
-  `_CANCEL_UNWIND_GRACE_S` (45 s) the executor is presumed unable to return
-  to idle and FAILS CLOSED: every function goes `unavailable` with reason
-  `cancel_unwind_stuck` (a real `FnUnavailable` on the wire, not merely an
-  empty function set), and any job still parked pre-execution is failed
-  RETRYABLE so the hub replans it NOW instead of letting it sit eventless.
-  Reversible: a late unwind re-advertises exactly the functions we took.
-- **A thread that never honours the cancel replaces the pod** — process
-  recycle after a further `_CANCEL_UNWIND_RECYCLE_S` (300 s), the only way to
-  reclaim a wedged thread. Routed through the same injectable exit seam as
-  the deadline reaper.
-- The bound is on cancel -> terminal latency, never on handler progress, so
-  it does not re-introduce the wall-clock bound gw#666/th#1157/th#1160
-  forbid: a 51-minute silent source download is not a cancelled job and is
-  untouched.
-- A PRODUCER (conversion/training) handler cancelled mid-run now marks its
-  instance stale, so the next dispatch reloads clean — modelopt installs
-  module-level quantizer hooks that the next `setup()` would otherwise
-  inherit. Inference cancels are excluded on purpose: a cancelled forward
-  mutates nothing, and discarding a warm serving pipeline on every user
-  cancel would be its own regression.
-- `tests/test_cancel_unwind_pgw687.py` drives the real executor over the
-  hub-double with a handler that ignores cancellation. The red row
-  (`test_wedge_shape_without_the_guard_is_silent_absorption`) is kept
-  permanently: with the grace pushed out of reach it reproduces the pre-fix
-  silence, and the four fix rows fail without the watchdog.
-
-## 0.72.0 (2026-07-26) — pgw#685 S2b: the AWQ W4A16 modulation decoder
-
-An svdq artifact does not quantize everything the same way. Its DiT Linears are
-W4A4 nvfp4 with a low-rank branch; its adaLN MODULATION layers (`img_mod` /
-`txt_mod`, which consume the timestep embedding rather than the token stream) are
-AWQ **W4A16** — a completely different layout. `models/svdq_awq.py` decodes them,
-which was the one thing blocking a real artifact from loading natively.
-
-- The layout is the inverse of deepcompressor's
-  `convert_to_nunchaku_w4x16_linear_weight` -> `convert_to_tinychat_w4x16y16_linear_weight`
-  -> `pack_w4` chain, and the tests invert that UPSTREAM code bit-exactly rather
-  than a paraphrase of it: within each run of 32 input elements output nibble `j`
-  packs elements `{j, 8+j, 16+j, 24+j}`, then the int16 grid is shuffled
-  `[oc/4, 4, ic/64, 16] -> permute(0, 2, 1, 3)` and stored as int32 pairs.
-  Confirmed against the real artifact's geometry (`qweight I32 [4608, 1536]`,
-  `wscales`/`wzeros BF16 [48, 18432]`, group 64).
-- Dequant is an **ADD**, not a subtract — `W = codes * wscales + wzeros` — because
-  the exporter stores the zero point already scaled AND negated.
-- `ceil_num_groups` padding is handled: trailing all-zero scale rows are the pad,
-  not groups. Reading 16 stored rows as 16 groups where only 2 are live would
-  rescale every weight in the layer.
-- **The trap this decoder exists to get right (`adanorm_splits`):** for modulation
-  layers the exporter ALSO interleaves output channels (stored row `j*splits + s`
-  is original row `s*(oc/splits) + j`) and ADDS 1 to the bias of splits `1` and
-  `splits-2` — adaLN's `1 + scale` folded into the artifact. Both are undone. The
-  split count is a REQUIRED argument defaulting to 1, never inferred: a wrong
-  count still yields a full-rank, plausible-looking weight and silently wrong
-  images, which `test_decoding_with_the_wrong_split_count_is_visibly_wrong` pins
-  at >0.5 relative error against <0.15 for the correct count.
-
-Also recorded from the S1 card verification, because it will otherwise look like a
-bug in the fused quantizer: compiled-vs-eager output for a `W4A4Linear` is NOT
-bit-identical, and that is inductor reassociating the bf16 second-level epilogue,
-not the kernel. Measured on a 5090 with the fused kernel disabled, the PURE-TORCH
-chain drifts **7.4x MORE** (5.9e-3) than the fused path (7.9e-4); the custom op
-itself is bit-exact under `fullgraph=True`.
-
-## 0.71.0 (2026-07-26) — pgw#685: a NATIVE svdq engine — SVDQuant checkpoints without nunchaku
-
-The layout converter, the serving module, and engine selection for serving
-svdq-fp4 on **every** Blackwell part through stock `torch._scaled_mm` instead of
-nunchaku's `sm_120a`-only kernels. Not yet wired into the default load path —
-see the named gap below.
-
-- **`models/svdq_layout.py`** inverts nunchaku's v1 single-file layout: the
-  `qweight` `mma.sync m16n8k64` FRAGMENT interleave and the `wscales` transpose
-  + 8-lane/stride-4/4-pack swizzle, both by replaying the packer's permutes
-  backwards (guaranteed bijective) rather than re-deriving index math. Decoding
-  lands in a LOGICAL domain first, which is what makes nunchaku's fused
-  `to_qkv` splittable into diffusers' separate `to_q`/`to_k`/`to_v` — exact
-  along the output dim, partitioning `proj_up` while SHARING `proj_down`.
-- **`models/svdq_native.py`** — `SvdqLinear`: `W4A4Linear` plus the three things
-  an SVDQuant checkpoint needs. A per-OUTPUT-CHANNEL second-level weight scale
-  (`wcscales`) as well as the scalar `wtscale`; the low-rank branch
-  `y += (x @ proj_down) @ proj_up.T`, which is what makes 4-bit survive
-  qwen-class outliers (plain nvfp4 PTQ measured lpips 0.63-0.69 vs the official
-  svdq artifact's 0.105); and `smooth_factor`, which DIVIDES the activation
-  feeding the 4-bit branch **only** — the low-rank branch consumes RAW x,
-  because deepcompressor pre-divides `proj_down` at export. Activation scaling
-  is always DYNAMIC: an svdq checkpoint carries no `input_scale` at all.
-- **Degrade, never refuse**: `fold_to_dense` collapses the 4-bit weight, the
-  smoothing vector and the low-rank branch into ONE plain bf16 Linear
-  (`W_eff = W_q / smooth + proj_up @ proj_down.T`, exact in the dequant limit),
-  so an svdq artifact stays servable on hardware with no fp4 tensor cores.
-- **Engine selection** (`svdq.svdq_engine_candidates` / `select_svdq_engine`):
-  `"native"` is preferred for fp4 — no nunchaku wheel, no diffusers signature
-  window, no pin-matrix row, no torch downgrade (the gw#405 / th#1211 coupling
-  class), and it covers sm_100/103 which nunchaku never will. int4 stays
-  nunchaku-only (a different single-level group-64 scale path). An explicit
-  override (`GEN_WORKER_SVDQ_ENGINE`, or the `override=` argument) is honored
-  STRICTLY — the other engine is never silently substituted.
-- **The native SM window is Blackwell only** (sm_100/103/120/121). torch's own
-  nvfp4 gate is `major >= 9 || (8,9)`, which admits sm_89/sm_90, but neither Ada
-  nor Hopper has fp4 tensor cores; below Blackwell the honest degrade is fp8
-  rowwise, which we already ship. Nothing emulates fp4.
-- **Named gap — deliberately NOT the default load path yet.** A real qwen svdq
-  artifact also carries its modulation layers as AWQ W4A16 (`wzeros`, group 64,
-  int32-packed, ~33% of the parameters but negligible FLOPs). That decoder is not
-  written, and shipping it unverified would be worse than declaring it, so
-  `loading.py` routing and the `ladder.py` svdq placement are UNCHANGED:
-  widening admission before a real artifact can fully load would strand
-  requests.
 
 ## 0.70.2 (2026-07-26) — pgw#691: guard-closure classifier fixes + sku key collapse (ck2 -> ck3)
 
@@ -441,6 +229,10 @@ pgw#676 overlap red-verified impossible post-fix with the bounded wait
 attributed, mint completion under a sustained tenant stream, and the
 seed-window routing contract.
 
+Also in this train: **pgw#686** — cell adoption key parity (one base-lane
+brain for requested keys, mint stamps, lookups and the local store), the
+fix behind burst pods re-minting instead of adopting.
+
 ## 0.69.0 (2026-07-26) — pgw#685: one fused triton kernel for the nvfp4 activation quantizer
 
 The `#nvfp4-w4a4` lane's per-call activation quantization was ~8 pure-torch
@@ -472,6 +264,49 @@ whole reason the lane LOST to bf16. It is now ONE triton kernel.
 - **Compile-safe**: registered as a `torch.library.custom_op` with an explicit
   schema and a `register_fake`, so it is traced as an opaque call instead of
   graph-breaking. Registration happens at load, never mid-trace.
+
+## 0.68.1 (2026-07-26) — pgw#678 the lane handle is not the pipeline; pgw#683 shared-component identity carries the EFFECTIVE compute dtype
+
+Two P0s on the composition/residency path, both found live on the sdxl retag
+cycle (ie#546), both about ONE object being asked to be two things.
+
+- **pgw#678 — a `components.*` deploy override no longer makes a deploy-bound
+  LoRA unattachable.** `generate-turbo` was **0/6** WITH the fp16-fix VAE
+  override and **4/4** WITHOUT it on the same release, wheel and card, failing
+  `model slot does not support LoRA adapters`. `utils/lora.py` was byte-identical
+  across the two versions that bracketed it, because the defect was object
+  identity, not adapter code: an overridden component is popped out of the
+  content-keyed share plan, so the lane owns a non-empty EXCLUSIVE module set
+  and its residency entry is `nn.ModuleDict(exclusive)` — correct as the
+  MOVEMENT handle (LRU must move only lane-owned weights), fatal when read as
+  the pipeline. `branch_targets` finds no denoiser on a ModuleDict, the whole
+  adapter stays on the peft side, and the pipeline-capability check refuses.
+  The record now owns the pipeline identity (`_ClassRecord.slot_pipelines`);
+  residency keeps the movement handle. The adapter target, the explicit
+  deactivation sweep and the OOM offload rung all read the pipeline — the last
+  of those had been silently skipping every lane slot, since a ModuleDict
+  carries no `enable_*_offload`. A lane whose placement falls to an offload
+  rung now LEARNS that the ref is un-shareable on this host instead of
+  re-deriving the refused plan until `retry_exhausted`.
+- **pgw#683 — a composition can no longer be handed a foreign-precision
+  component, and a mixed one is refused at LOAD.** `RuntimeError: mat1 and mat2
+  must have the same dtype, but got BFloat16 and Half` killed
+  `self_mint_compile phase=warmup_forward` and cost `generate` on a live prod
+  release with NO component override on the wire, so pgw#675's lane-aware
+  default could not explain it. `LoadedComponentKey` keyed on the binding's
+  DECLARED dtype; hub bindings declare none, and a quantizer rewrites only the
+  DENOISER, so the VAE and text encoders of `X` and `X#fp8-w8a8` are
+  byte-identical — one cache entry across compositions that compute at
+  DIFFERENT dtypes (bf16 on a quant lane, fp16 for a plain fp16-stored
+  mirror). Identity now carries the EFFECTIVE compute dtype
+  (`composition_compute_dtype`), so components still alias by content but never
+  across a precision boundary. `apply_fp8_storage` gets the SCALAR compute
+  dtype (it could previously be handed pgw#667's per-component dtype MAP), and
+  the new `assert_uniform_compute_dtype` invariant runs on every worker-loaded
+  slot: a composition presenting two compute dtypes to its GEMMs fails at load
+  naming the component and the offending tensor, instead of torch naming
+  neither at warm unit 4/18. fp32 widening (pgw#667) and the fp8/fp4 storage
+  lanes stay legal, and introspection failures never fail a load.
 
 ## 0.68.0 (2026-07-26) — pgw#681 guard-closure gate + boundary canonicalization; gw#679 per-expert MoE LoRA branch routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,251 @@
 # Changelog
 
+## Unreleased (pgw#694: #695-#698) — execution-environment determinism hardening
+
+Four of the pgw#694 umbrella's five measures (the fifth, pgw#699, is a tracker-side
+harness). All red-verified against real torch state / real file trees; CPU only.
+
+- **#695 process-posture seal**: ONE canonical serving posture (grad, autocast,
+  torch-function stack, default device, deterministic-algos);
+  `guard_closure.establish_posture()` at boot, sealed into the guard manifest at mint
+  (manifest v2), re-asserted by `artifact_drift` before every arm — drift refuses the
+  arm NAMED, never a downstream guard miss. A mint in a non-canonical posture fails
+  red. `consolidate` flags cross-pod posture divergence.
+- **#696 config-surface freeze + ck4**: new `env_seal` module — canonical flag table
+  set explicitly at boot (`cudnn.allow_tf32` default-True pinned False,
+  float32_matmul_precision, TF32 matmul, cudnn.benchmark), unknown `TORCH*` env vars
+  refuse boot naming the var, portable inductor-config digest. Posture+config+inductor
+  fold into ONE versioned `env_seal` dict recorded verbatim in metadata; its digest is
+  a REQUIRED ck4 key axis recomputed from the recorded facts. KEY_SCHEME ck3 -> ck4
+  (final planned bump: seal_v versions the dict internally).
+- **#697 composition fingerprint**: module rows now carry hook presence; new
+  `composition_fingerprint()` stores per-module digests in metadata so a graph-
+  signature mismatch at adoption names the exact drifted module
+  (`transformer:lin2: cell ... != consumer ...`) — the pgw#683 bf16/Half class.
+  Fine-tunes still share cells (no tensor values in any row).
+- **#698 cubin-completeness gate**: `pack()` refuses (named kernels) when any kernel
+  ships PTX without an sm-exact cubin — closing the one path where the deliberately
+  unkeyed driver (gw#577) could re-enter behavior via PTX JIT.
+- **ck3-completion bug fix**: `verify()` still hard-pinned `sku` after the pgw#691
+  collapse — a same-sm cell minted on a different SKU refused to arm. sku is now
+  observability-only in verify; sm/cuda/torch/triton carry the hardware identity.
+
+## 0.74.1 (2026-07-26) — pgw#692: `WanDefaults` carries the hub's recipe wire name
+
+**P0, every wan-2.2 request of every tier.** th#1174's migration
+`0046_recipe_steps_rename_hidream_wan22` renamed the recipe field `steps` ->
+`num_inference_steps` in the hub's `wan22.schema.json` and in every stored
+`repo_inference_defaults` / `release_slot_recipe` row (chaos, 2026-07-26
+00:12:20Z) — but the SDK half never shipped, so the hub-stamped recipe hit
+`GenerationDefaults`' `forbid_unknown_fields` and every request died at slot
+resolution, before handler code:
+
+```
+ValueError: slot 'pipeline': catalog inference-defaults metadata failed
+WanDefaults validation: Object contains unknown field `num_inference_steps`
+```
+
+- `WanDefaults.steps` -> `WanDefaults.num_inference_steps`. The hub is the
+  half that is right: `RuntimeFormula` resolves its terms by same-named
+  lookup across payload and `ctx.defaults`, and the
+  `PUT .../metadata/inference-defaults` route refuses a `steps` spelling
+  outright (`additionalProperties: false`).
+- Full audit of the registered vocabularies against the hub's family schemas:
+  `SdxlDefaults` and `SdxlLoraDefaults` keep `steps` (0040/0046 deliberately
+  left sdxl and qwen-image alone) and match field-for-field; wan22 was the
+  only skew in this repo. `HiDreamO1Defaults` has the identical exposure but
+  lives in `inference-endpoints/hidream-o1-image` — cross-repo, tracked on
+  pgw#692.
+- Guard (`tests/test_family_wire_names_pgw692.py`): every registered family's
+  `__struct_fields__` is asserted against a recorded snapshot of its hub
+  schema `properties`, so a one-sided rename can never be silent again.
+
+## 0.74.0 (2026-07-26) — pgw#685 S2c: the native svdq engine actually serves
+
+Wires the native engine into the load path. `load_svdq_pipeline` now chooses an
+ENGINE (`select_svdq_engine`) instead of assuming nunchaku, so `loading.py` needs
+no change at all — the dispatch lives behind the entry point the loading layer
+already called.
+
+- **`load_svdq_native_denoiser`** materializes a nunchaku-format checkpoint as a
+  STOCK diffusers module: skeleton on meta, W4A4 linears swapped for
+  `SvdqLinear` (fused `to_qkv` / `add_qkv_proj` split across the diffusers
+  projections), AWQ modulation layers decoded to bf16 Linears, everything else
+  assigned verbatim, then a STRICT check that nothing is left on the meta device —
+  a checkpoint that does not cover the module fails loud instead of serving a
+  half-initialized denoiser.
+- **`adanorm_splits_for`** is a table keyed on (diffusers class, module suffix),
+  not an inference from `out_features // in_features`. An unknown modulation layer
+  REFUSES; the exporter's adaLN transform is unrecoverable from the tensors and a
+  wrong split count corrupts output silently.
+- **Verified against the REAL 13 GB `svdq-fp4_r128-qwen-image` artifact**, pod-side
+  (weights never touch the dev box). Every one of its 4573 tensors is accounted
+  for: 480 svdq W4A4 prefixes (360 direct + 120 fused-qkv splits), 120 AWQ
+  modulation layers, 247 plain — **zero unmapped in any category** against the
+  stock `QwenImageTransformer2DModel`. Both decoders produce finite,
+  structurally-correct values (rank 128 throughout; `per_channel` second-level
+  scale exactly on the two fused qkv layers and `per_tensor` elsewhere, as the
+  layout predicted). The assembled loader then ran end to end: 2-block truncation
+  in 7.0s / 3.65 GB RSS and the **full 60 blocks in 163s / 55.7 GB RSS**, nothing
+  left on meta, `to_q`/`to_k`/`to_v` present as three working 3072-wide Linears,
+  modulation decoded to `Linear`, and a live forward finite.
+- mypy: fixed 7 `Optional`-narrowing errors this lane introduced (5 in
+  `svdq_native.py`, 2 in `svdq_layout.py`) by narrowing through locals rather than
+  silencing them; `mypy src/gen_worker` is green across 155 files.
+
+Admission is still NOT widened: `ladder.py`'s svdq placement keeps
+`sm_allowed=(120,121)`, `engines=("nunchaku",)`. Native now SERVES where it is
+selected, but the hub does not yet schedule svdq-fp4 onto sm_100 — that flip wants
+the fp4 (`blockwise`) full-artifact load and a numerical A/B, neither of which is
+measured yet (the verified load ran in the `dense` fold, and no nunchaku wheel was
+present to difference against).
+
+## 0.73.1 (2026-07-26)
+
+- **pgw#684: a fourth reserved repo field, `candidate`, for producer payloads
+  (te#121 two-ref quality eval).** The executor's reserved repo names were
+  `source`/`destination`/`text_encoder`; a producer payload can now also declare
+  `candidate: SourceRepo | None = None` and get it materialized the same way as
+  `source` — into `ctx.candidate_path` (`ctx.candidate` for the raw dict), fully
+  independent of `ctx.source_path`. This is the arm a two-ref eval COMPARES
+  against `source` rather than a component it builds from, which is what lets a
+  quality gate point at one of OUR OWN hub artifacts (a mirror, or a flavor the
+  quant ladder just produced) instead of only a public HF/Civitai coordinate.
+  Generic mechanism: gen-worker has no eval awareness. Absent field (every
+  existing endpoint) is byte-for-byte unchanged — no extra `ensure_local` call,
+  `ctx.candidate_path` stays `None`. The reserved-name set is still a hardcoded
+  literal list; pgw#690 tracks making it declarative.
+- Also re-covers reserved-repo materialization in `tests/`, which had NO coverage
+  after th#960/pgw#609 Phase 3b (`0b437aa`) swept pgw#594's two test files.
+- Corrects a `uv.lock` drift: 0.73.0 bumped `pyproject.toml` but left the lock's
+  `gen-worker` entry at 0.72.0, so `uv lock --check` failed on that commit.
+
+## 0.73.0 (2026-07-26) — pgw#687: a cancel that never unwinds no longer absorbs the next job
+
+Cancelling a job mid-compute could wedge a worker permanently while every
+hub-side signal read healthy: connected, heartbeating, still advertising its
+functions. Live (th#1165): job A cancelled mid-modelopt-calibration, job B
+assigned to the same pod 61 s later, then ZERO events of any kind for 46
+minutes. The only symptom was absence.
+
+Mechanism: cancelling a SYNC handler is cooperative. `handle_cancel` sets
+`ctx.cancelled` and (for async handlers only) cancels the task; a thread
+running `asyncio.to_thread` cannot be cancelled at all. A handler that never
+polls the flag — a modelopt calibration loop — keeps running, so `_run_job`
+never returns, the GPU permit and the per-instance run gate are never
+released, and the next job parks in `_gpu_semaphore.acquire()`, a wait that
+emits nothing. Nothing watched the cancel -> terminal edge.
+
+- **The cancel -> terminal edge is now watched.** Past
+  `_CANCEL_UNWIND_GRACE_S` (45 s) the executor is presumed unable to return
+  to idle and FAILS CLOSED: every function goes `unavailable` with reason
+  `cancel_unwind_stuck` (a real `FnUnavailable` on the wire, not merely an
+  empty function set), and any job still parked pre-execution is failed
+  RETRYABLE so the hub replans it NOW instead of letting it sit eventless.
+  Reversible: a late unwind re-advertises exactly the functions we took.
+- **A thread that never honours the cancel replaces the pod** — process
+  recycle after a further `_CANCEL_UNWIND_RECYCLE_S` (300 s), the only way to
+  reclaim a wedged thread. Routed through the same injectable exit seam as
+  the deadline reaper.
+- The bound is on cancel -> terminal latency, never on handler progress, so
+  it does not re-introduce the wall-clock bound gw#666/th#1157/th#1160
+  forbid: a 51-minute silent source download is not a cancelled job and is
+  untouched.
+- A PRODUCER (conversion/training) handler cancelled mid-run now marks its
+  instance stale, so the next dispatch reloads clean — modelopt installs
+  module-level quantizer hooks that the next `setup()` would otherwise
+  inherit. Inference cancels are excluded on purpose: a cancelled forward
+  mutates nothing, and discarding a warm serving pipeline on every user
+  cancel would be its own regression.
+- `tests/test_cancel_unwind_pgw687.py` drives the real executor over the
+  hub-double with a handler that ignores cancellation. The red row
+  (`test_wedge_shape_without_the_guard_is_silent_absorption`) is kept
+  permanently: with the grace pushed out of reach it reproduces the pre-fix
+  silence, and the four fix rows fail without the watchdog.
+
+## 0.72.0 (2026-07-26) — pgw#685 S2b: the AWQ W4A16 modulation decoder
+
+An svdq artifact does not quantize everything the same way. Its DiT Linears are
+W4A4 nvfp4 with a low-rank branch; its adaLN MODULATION layers (`img_mod` /
+`txt_mod`, which consume the timestep embedding rather than the token stream) are
+AWQ **W4A16** — a completely different layout. `models/svdq_awq.py` decodes them,
+which was the one thing blocking a real artifact from loading natively.
+
+- The layout is the inverse of deepcompressor's
+  `convert_to_nunchaku_w4x16_linear_weight` -> `convert_to_tinychat_w4x16y16_linear_weight`
+  -> `pack_w4` chain, and the tests invert that UPSTREAM code bit-exactly rather
+  than a paraphrase of it: within each run of 32 input elements output nibble `j`
+  packs elements `{j, 8+j, 16+j, 24+j}`, then the int16 grid is shuffled
+  `[oc/4, 4, ic/64, 16] -> permute(0, 2, 1, 3)` and stored as int32 pairs.
+  Confirmed against the real artifact's geometry (`qweight I32 [4608, 1536]`,
+  `wscales`/`wzeros BF16 [48, 18432]`, group 64).
+- Dequant is an **ADD**, not a subtract — `W = codes * wscales + wzeros` — because
+  the exporter stores the zero point already scaled AND negated.
+- `ceil_num_groups` padding is handled: trailing all-zero scale rows are the pad,
+  not groups. Reading 16 stored rows as 16 groups where only 2 are live would
+  rescale every weight in the layer.
+- **The trap this decoder exists to get right (`adanorm_splits`):** for modulation
+  layers the exporter ALSO interleaves output channels (stored row `j*splits + s`
+  is original row `s*(oc/splits) + j`) and ADDS 1 to the bias of splits `1` and
+  `splits-2` — adaLN's `1 + scale` folded into the artifact. Both are undone. The
+  split count is a REQUIRED argument defaulting to 1, never inferred: a wrong
+  count still yields a full-rank, plausible-looking weight and silently wrong
+  images, which `test_decoding_with_the_wrong_split_count_is_visibly_wrong` pins
+  at >0.5 relative error against <0.15 for the correct count.
+
+Also recorded from the S1 card verification, because it will otherwise look like a
+bug in the fused quantizer: compiled-vs-eager output for a `W4A4Linear` is NOT
+bit-identical, and that is inductor reassociating the bf16 second-level epilogue,
+not the kernel. Measured on a 5090 with the fused kernel disabled, the PURE-TORCH
+chain drifts **7.4x MORE** (5.9e-3) than the fused path (7.9e-4); the custom op
+itself is bit-exact under `fullgraph=True`.
+
+## 0.71.0 (2026-07-26) — pgw#685: a NATIVE svdq engine — SVDQuant checkpoints without nunchaku
+
+The layout converter, the serving module, and engine selection for serving
+svdq-fp4 on **every** Blackwell part through stock `torch._scaled_mm` instead of
+nunchaku's `sm_120a`-only kernels. Not yet wired into the default load path —
+see the named gap below.
+
+- **`models/svdq_layout.py`** inverts nunchaku's v1 single-file layout: the
+  `qweight` `mma.sync m16n8k64` FRAGMENT interleave and the `wscales` transpose
+  + 8-lane/stride-4/4-pack swizzle, both by replaying the packer's permutes
+  backwards (guaranteed bijective) rather than re-deriving index math. Decoding
+  lands in a LOGICAL domain first, which is what makes nunchaku's fused
+  `to_qkv` splittable into diffusers' separate `to_q`/`to_k`/`to_v` — exact
+  along the output dim, partitioning `proj_up` while SHARING `proj_down`.
+- **`models/svdq_native.py`** — `SvdqLinear`: `W4A4Linear` plus the three things
+  an SVDQuant checkpoint needs. A per-OUTPUT-CHANNEL second-level weight scale
+  (`wcscales`) as well as the scalar `wtscale`; the low-rank branch
+  `y += (x @ proj_down) @ proj_up.T`, which is what makes 4-bit survive
+  qwen-class outliers (plain nvfp4 PTQ measured lpips 0.63-0.69 vs the official
+  svdq artifact's 0.105); and `smooth_factor`, which DIVIDES the activation
+  feeding the 4-bit branch **only** — the low-rank branch consumes RAW x,
+  because deepcompressor pre-divides `proj_down` at export. Activation scaling
+  is always DYNAMIC: an svdq checkpoint carries no `input_scale` at all.
+- **Degrade, never refuse**: `fold_to_dense` collapses the 4-bit weight, the
+  smoothing vector and the low-rank branch into ONE plain bf16 Linear
+  (`W_eff = W_q / smooth + proj_up @ proj_down.T`, exact in the dequant limit),
+  so an svdq artifact stays servable on hardware with no fp4 tensor cores.
+- **Engine selection** (`svdq.svdq_engine_candidates` / `select_svdq_engine`):
+  `"native"` is preferred for fp4 — no nunchaku wheel, no diffusers signature
+  window, no pin-matrix row, no torch downgrade (the gw#405 / th#1211 coupling
+  class), and it covers sm_100/103 which nunchaku never will. int4 stays
+  nunchaku-only (a different single-level group-64 scale path). An explicit
+  override (`GEN_WORKER_SVDQ_ENGINE`, or the `override=` argument) is honored
+  STRICTLY — the other engine is never silently substituted.
+- **The native SM window is Blackwell only** (sm_100/103/120/121). torch's own
+  nvfp4 gate is `major >= 9 || (8,9)`, which admits sm_89/sm_90, but neither Ada
+  nor Hopper has fp4 tensor cores; below Blackwell the honest degrade is fp8
+  rowwise, which we already ship. Nothing emulates fp4.
+- **Named gap — deliberately NOT the default load path yet.** A real qwen svdq
+  artifact also carries its modulation layers as AWQ W4A16 (`wzeros`, group 64,
+  int32-packed, ~33% of the parameters but negligible FLOPs). That decoder is not
+  written, and shipping it unverified would be worse than declaring it, so
+  `loading.py` routing and the `ladder.py` svdq placement are UNCHANGED:
+  widening admission before a real artifact can fully load would strand
+  requests.
+
 ## 0.70.2 (2026-07-26) — pgw#691: guard-closure classifier fixes + sku key collapse (ck2 -> ck3)
 
 The offline audit (546 real torch-2.13 guard rows) proved the pgw#681 mint
@@ -161,10 +407,6 @@ pgw#676 overlap red-verified impossible post-fix with the bounded wait
 attributed, mint completion under a sustained tenant stream, and the
 seed-window routing contract.
 
-Also in this train: **pgw#686** — cell adoption key parity (one base-lane
-brain for requested keys, mint stamps, lookups and the local store), the
-fix behind burst pods re-minting instead of adopting.
-
 ## 0.69.0 (2026-07-26) — pgw#685: one fused triton kernel for the nvfp4 activation quantizer
 
 The `#nvfp4-w4a4` lane's per-call activation quantization was ~8 pure-torch
@@ -196,49 +438,6 @@ whole reason the lane LOST to bf16. It is now ONE triton kernel.
 - **Compile-safe**: registered as a `torch.library.custom_op` with an explicit
   schema and a `register_fake`, so it is traced as an opaque call instead of
   graph-breaking. Registration happens at load, never mid-trace.
-
-## 0.68.1 (2026-07-26) — pgw#678 the lane handle is not the pipeline; pgw#683 shared-component identity carries the EFFECTIVE compute dtype
-
-Two P0s on the composition/residency path, both found live on the sdxl retag
-cycle (ie#546), both about ONE object being asked to be two things.
-
-- **pgw#678 — a `components.*` deploy override no longer makes a deploy-bound
-  LoRA unattachable.** `generate-turbo` was **0/6** WITH the fp16-fix VAE
-  override and **4/4** WITHOUT it on the same release, wheel and card, failing
-  `model slot does not support LoRA adapters`. `utils/lora.py` was byte-identical
-  across the two versions that bracketed it, because the defect was object
-  identity, not adapter code: an overridden component is popped out of the
-  content-keyed share plan, so the lane owns a non-empty EXCLUSIVE module set
-  and its residency entry is `nn.ModuleDict(exclusive)` — correct as the
-  MOVEMENT handle (LRU must move only lane-owned weights), fatal when read as
-  the pipeline. `branch_targets` finds no denoiser on a ModuleDict, the whole
-  adapter stays on the peft side, and the pipeline-capability check refuses.
-  The record now owns the pipeline identity (`_ClassRecord.slot_pipelines`);
-  residency keeps the movement handle. The adapter target, the explicit
-  deactivation sweep and the OOM offload rung all read the pipeline — the last
-  of those had been silently skipping every lane slot, since a ModuleDict
-  carries no `enable_*_offload`. A lane whose placement falls to an offload
-  rung now LEARNS that the ref is un-shareable on this host instead of
-  re-deriving the refused plan until `retry_exhausted`.
-- **pgw#683 — a composition can no longer be handed a foreign-precision
-  component, and a mixed one is refused at LOAD.** `RuntimeError: mat1 and mat2
-  must have the same dtype, but got BFloat16 and Half` killed
-  `self_mint_compile phase=warmup_forward` and cost `generate` on a live prod
-  release with NO component override on the wire, so pgw#675's lane-aware
-  default could not explain it. `LoadedComponentKey` keyed on the binding's
-  DECLARED dtype; hub bindings declare none, and a quantizer rewrites only the
-  DENOISER, so the VAE and text encoders of `X` and `X#fp8-w8a8` are
-  byte-identical — one cache entry across compositions that compute at
-  DIFFERENT dtypes (bf16 on a quant lane, fp16 for a plain fp16-stored
-  mirror). Identity now carries the EFFECTIVE compute dtype
-  (`composition_compute_dtype`), so components still alias by content but never
-  across a precision boundary. `apply_fp8_storage` gets the SCALAR compute
-  dtype (it could previously be handed pgw#667's per-component dtype MAP), and
-  the new `assert_uniform_compute_dtype` invariant runs on every worker-loaded
-  slot: a composition presenting two compute dtypes to its GEMMs fails at load
-  naming the component and the offending tensor, instead of torch naming
-  neither at warm unit 4/18. fp32 widening (pgw#667) and the fp8/fp4 storage
-  lanes stay legal, and introspection failures never fail a load.
 
 ## 0.68.0 (2026-07-26) — pgw#681 guard-closure gate + boundary canonicalization; gw#679 per-expert MoE LoRA branch routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased (cache-design review fixes) — inner FX key portability + strict verify
+
+From the ML-systems + build-systems cache reviews (tracker, both in
+python-gen-worker/progress.md). All red-verified (7/8 new tests fail pre-fix).
+
+- **P0 — inner FX key hashed the GPU marketing name** (VERIFIED on a real B200 cell:
+  `system_info[device] = {'name': 'NVIDIA B200'}`): inductor's `CacheBase.get_system()`
+  files every fxgraph entry under the minting pod's SKU string, so the ck3/ck4 sku
+  collapse delivered ZERO cross-SKU hits — same-sm adoption passed every gate then
+  missed inside torch's own lookup. New version-pinned shim
+  (`compile_cache._install_fx_system_shim`, installed symmetrically via `apply()`)
+  normalizes the device name to the `sm_XX` token with the hash recomputed by torch's
+  own strategy (upstream precedent: `AOTI_COMPUTE_CAPABILITY`, codecache.py:260;
+  upstream ask tracked on pgw#708). A source-shape pin test fails loudly on a torch
+  bump (pgw#705 doctrine).
+- **P1 — `verify()` fail-open retired** (the JAX PR #27814 wrong-hit shape): silent
+  axes (`sm`/`cuda`/`image_digest`/libs/family) were accepted via `if want and ...`;
+  now absent axis = named refusal, no legacy path (pre-launch, per the no-legacy
+  doctrine).
+- `cache_key_tag` bound to the semantic cell identity (format|kind|family|lane|mode|
+  contract, environment axes deliberately excluded) — a foreign semantic identity can
+  never consume delivered inner entries; equivalence adoption (pgw#700) survives.
+- `content_keys` (torch_key/triton_key digests) recorded in metadata as the pgw#700
+  equivalence precondition (a patched wheel under an unchanged version string is now
+  visible; full toolchain closure is pgw#710).
+- **env_seal v2**: R7 defect fixed — the env gate matched `TORCH*` only, so every
+  `PYTORCH_*` var (incl. the live `PYTORCH_CUDA_ALLOC_CONF`) evaded it; gate now
+  covers `TORCH*`/`PYTORCH*`/`TRITON*` with both allocator spellings + the SDK's
+  `TRITON_CACHE_DIR` allowlisted, and `TRITON_PTXAS_PATH`-class toggles refused.
+  Recorded-env set extended (CUDA_LAUNCH_BLOCKING, CUDA_MODULE_LOADING,
+  NVIDIA_TF32_OVERRIDE, PYTHONHASHSEED). R2: operator `epoch` salt (`COZY_CELL_EPOCH`)
+  sealed as a fact — disowning a poisoned mint generation is one config change, never
+  a scheme bump (Bazel Action.salt / ccache HASH_PREFIX precedent).
+
 ## Unreleased (pgw#694: #695-#698) — execution-environment determinism hardening
 
 Four of the pgw#694 umbrella's five measures (the fifth, pgw#699, is a tracker-side

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.2"
+version = "0.70.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -25,6 +25,11 @@ facts that actually change compiled-kernel identity:
                   wheel's ptxas + SM arch — the host driver deliberately
                   never enters the key, gw#577)
     gen_worker    exact gen-worker version (graph-shaping code)
+    env_seal      digest of the execution-environment seal (pgw#696):
+                  process posture + frozen config flags + portable inductor
+                  config. The seal dict is internally versioned (seal_v),
+                  so future sealed facts change digest VALUES, never the
+                  axis set — ck4 is the final planned scheme bump.
     contract      digest of the DECLARED shape contract (SDK v2, pgw#647):
                   shapes, targets, text_len, dynamic dims, regional mode,
                   lora bucket, warm guidance classes. A contract change
@@ -61,9 +66,10 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional
 
-# ck2 -> ck3 (pgw#691): sku left the identity axes; the scheme bump makes
-# every pre-collapse key a clean MISS instead of a half-match.
-KEY_SCHEME = "ck3"
+# ck2 -> ck3 (pgw#691): sku left the identity axes. ck3 -> ck4 (pgw#696):
+# env_seal joined them. Each bump makes every older key a clean MISS
+# instead of a half-match.
+KEY_SCHEME = "ck4"
 _PREFIX = KEY_SCHEME + "-"
 # The key digest doubles as the store flavor token, whose shared grammar
 # (th#597 C5: [a-z0-9][a-z0-9._-]{0,63}, Go+Py identical) caps tokens at 64
@@ -73,7 +79,7 @@ _DIGEST_HEX = 56
 # Axes that must be non-empty for a computable key: a runtime that cannot
 # state them has no cell identity (CPU-only build, failed CUDA probe).
 _REQUIRED = ("format", "kind", "family", "sm", "cuda", "torch",
-             "triton", "gen_worker", "contract")
+             "triton", "gen_worker", "env_seal", "contract")
 # Axes that may be legitimately absent ("" => omitted from canonical form):
 # image_digest is absent on local runtimes; libs may not be installed; lane
 # "" is the plain-resident graph family; mode "" is whole-graph compilation
@@ -182,6 +188,7 @@ def compute(
     non-CUDA runtimes simply have no key.
     """
     from . import compile_cache as cc  # cycle: compile_cache imports cell_key
+    from . import env_seal
 
     rt = cc.runtime_key()
     if image_digest is None:
@@ -198,6 +205,7 @@ def compute(
         "torch": rt["torch"],
         "triton": rt["triton"],
         "gen_worker": cc.gen_worker_version(),
+        "env_seal": env_seal.seal_digest(env_seal.effective_seal()),
         "contract": str(contract or ""),
         "diffusers": libs.get("diffusers", ""),
         "transformers": libs.get("transformers", ""),
@@ -216,6 +224,8 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     kind = str(meta.get("kind") or "")
     if kind != "torch-inductor-cache":
         raise CellKeyError(f"artifact kind {kind!r} has no cell-key identity")
+    from . import env_seal
+
     libs = meta.get("libs") or {}
     mode = str(meta.get("compile_mode") or "whole")
     contract_facts = meta.get("shape_contract")
@@ -223,6 +233,12 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
         raise CellKeyError(
             "artifact records no shape_contract block (pre-cell-key cell); "
             "no key identity — a newer-contract worker must not consume it"
+        )
+    seal = meta.get(env_seal.SEAL_KEY)
+    if not isinstance(seal, dict) or not seal:
+        raise CellKeyError(
+            "artifact records no env_seal block (pre-ck4 cell); no key "
+            "identity — its execution environment is unproven"
         )
     return from_axes({
         "format": str(meta.get("format") or ""),
@@ -238,6 +254,7 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
         "torch": str(meta.get("torch") or ""),
         "triton": str(meta.get("triton") or ""),
         "gen_worker": str(meta.get("gen_worker") or ""),
+        "env_seal": env_seal.seal_digest(seal),
         "contract": contract_digest(contract_facts),
         "diffusers": str(libs.get("diffusers") or ""),
         "transformers": str(libs.get("transformers") or ""),

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -755,6 +755,33 @@ def declared_contract_facts(cfg: Any, *, lora_bucket_override: Optional[int] = N
     }
 
 
+@functools.lru_cache(None)
+def content_keys() -> Tuple[Tuple[str, str], ...]:
+    """torch/triton CONTENT identity (cache-design review §6.5): version
+    strings cannot detect a patched wheel — upstream hashes source bytes
+    (``torch_key``: the whole torch package; ``triton_key``: per-file shas +
+    the libtriton binary). Recorded in metadata, NOT the key: for the fleet
+    ``image_digest`` already pins userspace by content, but local self-mints
+    (gw#555) have no image identity, and pgw#700 equivalence adoption makes
+    byte-match of these a PRECONDITION before ``image_digest`` may be
+    relaxed (see also pgw#711/R3 toolchain_digest)."""
+    out: Dict[str, str] = {"torch": "", "triton": ""}
+    try:
+        from torch._inductor.codecache import torch_key
+
+        out["torch"] = hashlib.sha256(torch_key()).hexdigest()[:16]
+    except Exception:
+        logger.debug("content_keys: torch_key unavailable", exc_info=True)
+    try:
+        from triton.runtime.cache import triton_key
+
+        out["triton"] = hashlib.sha256(
+            str(triton_key()).encode()).hexdigest()[:16]
+    except Exception:
+        logger.debug("content_keys: triton_key unavailable", exc_info=True)
+    return tuple(sorted(out.items()))
+
+
 def artifact_metadata(
     *,
     family: str,
@@ -811,6 +838,9 @@ def artifact_metadata(
         # pgw#696: the execution-environment seal rides verbatim — the ck4
         # env_seal axis is recomputed FROM it, never trusted as a stamp.
         env_seal.SEAL_KEY: env_seal.effective_seal(),
+        # review §6.5: content identity of the compile stack (equivalence
+        # precondition, pgw#700) — metadata only, never a key axis.
+        "content_keys": dict(content_keys()),
         "libs": _lib_versions(),
     }
     # gw#581/th#883: stamp the worker-owned cell key the recorded axes
@@ -824,8 +854,15 @@ def artifact_metadata(
 def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     """'' when the artifact matches this runtime, else the mismatch reason.
 
-    Family is the graph-identity half of the key: checked when both sides
-    declare one (fine-tunes of the same family share caches by design)."""
+    STRICT on every axis (cache-design review §6.9): a cell that is SILENT
+    on an axis is refused, named — never accepted. The old
+    ``if want and want != have`` conditionals were the exact shape of JAX
+    PR #27814's one documented wrong-cache-hit (a version axis "only
+    sometimes incorporated"). Pre-launch, no external consumers, so the
+    legacy silent-axis compatibility path is retired outright.
+
+    Family is the graph-identity half of the key: fine-tunes of one family
+    share caches by design."""
     if int(meta.get("format") or 0) != ARTIFACT_FORMAT:
         return f"format {meta.get('format')!r} != {ARTIFACT_FORMAT}"
     here = runtime_key()
@@ -833,34 +870,26 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     # torch + triton pin every hardware fact the compiled artifacts carry,
     # and a same-sm cell minted on a different SKU must arm, not refuse.
     # It stays recorded in metadata for observability and selection only.
-    for field in ("torch", "triton"):
+    # cuda_driver is deliberately NOT here either (gw#577): triton's disk
+    # cache keys on the wheel's ptxas + SM arch; the host libcuda build
+    # never enters any compiled-artifact key. Recorded for observability.
+    for field in ("torch", "triton", "sm", "cuda", "image_digest"):
         want, have = str(meta.get(field) or ""), here[field]
         if want != have:
-            return f"{field} {want!r} != runtime {have!r}"
-    # Extended runtime axes are exact when a cell records them. Old proven
-    # non-W8A8 format-2 cells remain usable; W8A8 requires every field in
-    # contract_drift below and therefore never gets this compatibility path.
-    # cuda_driver is deliberately NOT here (gw#577): inductor/triton artifacts
-    # are keyed by torch/triton/cuda-runtime/SM-arch — triton's disk cache key
-    # is (source, ptxas_version-from-the-wheel, sm arch, options); the host
-    # libcuda build never enters any compiled-artifact key. Pinning it made
-    # cell delivery a host lottery across same-image same-SKU pods. The driver
-    # stays recorded in metadata for observability only.
-    for field in ("sm", "cuda", "image_digest"):
-        want, have = str(meta.get(field) or ""), here[field]
-        if want and want != have:
             return f"{field} {want!r} != runtime {have!r}"
     want_gw, have_gw = str(meta.get("gen_worker") or ""), gen_worker_version()
     if want_gw != have_gw:
         # gw#391: the producer's gen-worker shapes the traced graph; a version
         # drift means the FX-graph cache keys may no longer match.
         return f"gen_worker {want_gw!r} != runtime {have_gw!r}"
-    for lib, have in _lib_versions().items():
-        want = str((meta.get("libs") or {}).get(lib) or "")
-        if want and want != have:
+    libs = meta.get("libs") or {}
+    here_libs = _lib_versions()
+    for lib in sorted(set(libs) | set(here_libs)):
+        want, have = str(libs.get(lib) or ""), str(here_libs.get(lib) or "")
+        if want != have:
             return f"{lib} {want!r} != runtime {have!r}"
     want_fam = str(meta.get("family") or "")
-    if family and want_fam and want_fam != family:
+    if family and want_fam != family:
         return f"family {want_fam!r} != {family!r}"
     return ""
 
@@ -1021,6 +1050,92 @@ def unpack(artifact: Path, dest_root: Path) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Capture (producer) / seed (consumer)
 # ---------------------------------------------------------------------------
+
+
+def _normalize_system_info(info: Dict[str, Any], sm: str) -> Dict[str, Any]:
+    """The pure half of the fx system-key shim: replace the GPU marketing
+    name with the sm token and recompute the embedded hash exactly the way
+    ``CacheBase.get_system`` does."""
+    device = info.get("device")
+    if not sm or not isinstance(device, dict) or not device.get("name"):
+        return info
+    from torch._inductor.codecache import SYSTEM_CACHE_KEY_STRATEGY
+
+    normalized = json.loads(json.dumps(info))
+    normalized["device"]["name"] = sm
+    normalized["hash"] = SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+        {"device": normalized["device"], "version": normalized.get("version")})
+    return normalized
+
+
+def _install_fx_system_shim() -> None:
+    """P0 (cache-design review §6.1, VERIFIED on a real B200 cell): inductor
+    hashes ``torch.cuda.get_device_properties().name`` — the GPU MARKETING
+    string — into every FX graph key via ``CacheBase.get_system()``
+    (torch 2.13 codecache.py:287-311, consumed :1503). A cell minted on an
+    a40 therefore never HITS on an rtx-3090 despite the identical sm_86 ck
+    key: the pgw#691 sku collapse delivers zero cross-SKU hits until the
+    inner key is normalized. This shim rewrites the device name to our
+    ``sm_XX`` token (hash recomputed with torch's own strategy), installed
+    identically on mint and consumer (both arm through ``apply``).
+
+    Upstream precedent in the SAME file: AOTInductor already keys on
+    ``AOTI_COMPUTE_CAPABILITY`` (``get_compute_capability()``,
+    codecache.py:260) — capability, not name. Upstream ask (capability-based
+    ``get_system``) is tracked on the pgw#708 upstream-watch issue.
+
+    Version-pinned: test_determinism_pgw694 asserts the upstream source
+    shape and fails loudly on a torch bump that changes it (pgw#705 gate).
+    """
+    try:
+        from torch._inductor.codecache import CacheBase
+    except Exception:
+        logger.debug("fx system shim: inductor unavailable", exc_info=True)
+        return
+    if getattr(CacheBase.get_system, "_cozy_sm_normalized", False):
+        return
+    original = CacheBase.get_system
+
+    @functools.lru_cache(None)
+    def _normalized_get_system() -> Dict[str, Any]:
+        return _normalize_system_info(dict(original()), runtime_key()["sm"])
+
+    _normalized_get_system._cozy_sm_normalized = True  # type: ignore[attr-defined]
+    CacheBase.get_system = staticmethod(_normalized_get_system)  # type: ignore[assignment,method-assign]
+
+
+def _semantic_cache_tag(pipeline: Any, cfg: Any) -> str:
+    """Digest of the axes we will NEVER relax (format|kind|family|lane|mode|
+    contract) — bound into every inner torch.compile key via
+    ``cache_key_tag`` (review §6.3), so a delivered cell's entries are
+    mechanically unconsumable by a process whose declared semantic identity
+    differs. Environment axes (sm/cuda/torch/triton/gen_worker/image_digest/
+    env_seal) are deliberately EXCLUDED or pgw#700 equivalence adoption
+    across conservative axes becomes impossible."""
+    lane = cell_key._canonical_lane(
+        pipeline_weight_lane(pipeline),
+        int(getattr(cfg, "lora_bucket", 0) or 0))
+    payload = "|".join((
+        str(ARTIFACT_FORMAT), "inductor",
+        str(getattr(cfg, "family", "") or ""), lane,
+        "regional" if bool(getattr(cfg, "regional", False)) else "whole",
+        cell_key.contract_digest(declared_contract_facts(cfg)),
+    ))
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def _set_semantic_cache_tag(pipeline: Any, cfg: Any) -> None:
+    """Install the semantic tag for THIS arm's compiles. Process-global
+    (torch.compiler.config), set at every arm before its warm compiles; a
+    later cross-family arm in the same process retags before its own
+    compiles — a mid-serve heal recompile under the newer tag can only
+    MISS, never cross-consume."""
+    try:
+        import torch.compiler.config as compiler_config
+
+        compiler_config.cache_key_tag = _semantic_cache_tag(pipeline, cfg)
+    except Exception:
+        logger.debug("semantic cache tag: unavailable", exc_info=True)
 
 
 def capture_env(root: Path) -> Path:
@@ -2474,6 +2589,10 @@ def apply(
     # gw#608: cross-pod cell portability requires the (portable) FX graph
     # cache to be the lookup surface — see _disable_aot_autograd_cache.
     _disable_aot_autograd_cache()
+    # The two inner-key alignments (both symmetric mint/consumer by
+    # construction: every compile path arms through apply()):
+    _install_fx_system_shim()          # SKU name -> sm token (P0, review §6.1)
+    _set_semantic_cache_tag(pipeline, cfg)  # semantic identity tag (§6.3)
     if not torch.cuda.is_available():
         logger.info("compile-cache: no CUDA; staying eager")
         return False

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -68,7 +68,7 @@ import inspect
 import pickle
 import sys
 
-from . import cell_key, guard_closure, hot_swap
+from . import cell_key, env_seal, guard_closure, hot_swap
 from .api.errors import RetryableError
 from .models import w8a8_lora
 from .models.loading import load_from_pretrained, pipeline_weight_lane
@@ -771,6 +771,7 @@ def artifact_metadata(
     graph_signature: str = "",
     weight_contract: Optional[Dict[str, Any]] = None,
     shape_contract: Optional[Dict[str, Any]] = None,
+    composition: Iterable[Tuple[str, str]] = (),
 ) -> Dict[str, Any]:
     """Producer-side metadata for :func:`pack` (no timestamps: artifacts of
     identical content must be byte-identical). ``source_ref``/``source_digest``
@@ -804,6 +805,12 @@ def artifact_metadata(
         "graph_signature": str(graph_signature or ""),
         "weight_contract": dict(weight_contract or {}),
         "shape_contract": dict(shape_contract or {}),
+        # pgw#697: per-module fingerprint rows so an adoption refusal can
+        # name the exact drifted module, not just a digest mismatch.
+        "composition": [[str(p), str(d)] for p, d in composition],
+        # pgw#696: the execution-environment seal rides verbatim — the ck4
+        # env_seal axis is recomputed FROM it, never trusted as a stamp.
+        env_seal.SEAL_KEY: env_seal.effective_seal(),
         "libs": _lib_versions(),
     }
     # gw#581/th#883: stamp the worker-owned cell key the recorded axes
@@ -822,7 +829,11 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     if int(meta.get("format") or 0) != ARTIFACT_FORMAT:
         return f"format {meta.get('format')!r} != {ARTIFACT_FORMAT}"
     here = runtime_key()
-    for field in ("sku", "torch", "triton"):
+    # sku is NOT here (pgw#691/ck3): it left the identity axes — sm + cuda +
+    # torch + triton pin every hardware fact the compiled artifacts carry,
+    # and a same-sm cell minted on a different SKU must arm, not refuse.
+    # It stays recorded in metadata for observability and selection only.
+    for field in ("torch", "triton"):
         want, have = str(meta.get(field) or ""), here[field]
         if want != have:
             return f"{field} {want!r} != runtime {have!r}"
@@ -867,10 +878,68 @@ def _clean_tarinfo(ti: tarfile.TarInfo, executable: bool = False) -> tarfile.Tar
     return ti
 
 
+_ELF_MAGIC = b"\x7fELF"
+
+
+def _cubin_arch(path: Path) -> int:
+    """The SM arch a cubin was compiled for (nvidia ELF ``e_flags`` low
+    byte), 0 when the file is unreadable or not ELF."""
+    try:
+        with open(path, "rb") as f:
+            header = f.read(0x34)
+    except OSError:
+        return 0
+    if len(header) < 0x34 or not header.startswith(_ELF_MAGIC):
+        return 0
+    # EI_CLASS: 2 = ELF64 (e_flags at 0x30), 1 = ELF32 (e_flags at 0x24).
+    offset = 0x30 if header[4] == 2 else 0x24
+    flags = int.from_bytes(header[offset:offset + 4], "little")
+    return flags & 0xFF
+
+
+def _ptx_jit_gaps(
+    files: Iterable[Path], cache_root: Path, sm: str,
+) -> list[str]:
+    """PTX-JIT exposure per kernel (pgw#698). A kernel whose only compiled
+    form is PTX makes the HOST DRIVER's JIT compile it at load time — the
+    one path where the deliberately-unkeyed driver version (gw#577) can
+    re-enter compiled-kernel behavior. Every ``.ptx`` must ship a sibling
+    ``.cubin``, and when the artifact declares its sm the cubin arch must
+    match it exactly."""
+    want_arch = 0
+    if sm.startswith("sm_"):
+        try:
+            want_arch = int(sm[3:])
+        except ValueError:
+            want_arch = 0
+    kernels: Dict[Tuple[Path, str], Dict[str, Path]] = {}
+    for p in files:
+        if p.suffix in (".ptx", ".cubin"):
+            kernels.setdefault((p.parent, p.stem), {})[p.suffix] = p
+    gaps: list[str] = []
+    for (_parent, _stem), forms in sorted(
+        kernels.items(), key=lambda kv: str(kv[0][0] / kv[0][1]),
+    ):
+        ptx, cubin = forms.get(".ptx"), forms.get(".cubin")
+        if ptx is not None and cubin is None:
+            gaps.append(
+                f"{ptx.relative_to(cache_root)}: PTX only — no cubin, the "
+                "driver JIT would compile it")
+            continue
+        if cubin is not None and want_arch:
+            arch = _cubin_arch(cubin)
+            if arch and arch != want_arch:
+                gaps.append(
+                    f"{cubin.relative_to(cache_root)}: cubin arch sm_{arch} "
+                    f"!= artifact sm_{want_arch}")
+    return gaps
+
+
 def pack(cache_root: Path, out_path: Path, metadata: Dict[str, Any]) -> Path:
     """Deterministic artifact from a capture root holding ``inductor/`` and
     ``triton/``: sorted entries, zeroed times/owners, gzip mtime 0 — identical
-    content always packs to identical bytes."""
+    content always packs to identical bytes. Refuses (pgw#698) when any
+    kernel would rely on driver PTX JIT, naming the kernels."""
     cache_root = Path(cache_root)
     out_path = Path(out_path)
     files: list[Path] = []
@@ -882,6 +951,13 @@ def pack(cache_root: Path, out_path: Path, metadata: Dict[str, Any]) -> Path:
                 if p.is_file() and not p.name.endswith(_JUNK_SUFFIXES)
             )
     files.sort(key=lambda p: str(p.relative_to(cache_root)))
+    gaps = _ptx_jit_gaps(files, cache_root, str(metadata.get("sm") or ""))
+    if gaps:
+        shown = "; ".join(gaps[:10])
+        more = f" (+{len(gaps) - 10} more)" if len(gaps) > 10 else ""
+        raise RuntimeError(
+            f"cubin-completeness gate (pgw#698): {len(gaps)} kernel(s) "
+            f"would rely on driver PTX JIT — {shown}{more}")
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "wb") as raw:
@@ -1677,6 +1753,84 @@ def _direct_tensor_schema(module: Any) -> list[list[Any]]:
     return sorted(rows)
 
 
+def _module_hooks(module: Any) -> Dict[str, int]:
+    """Hook PRESENCE per module (pgw#697): installed hooks are traced into
+    the compiled graphs (fp8 layerwise-cast is hook-driven, ie#381), so a
+    hook-count drift is a composition drift. Counts only — never hook
+    identities or closures."""
+    out: Dict[str, int] = {}
+    for fact, attr in (
+        ("forward_pre", "_forward_pre_hooks"),
+        ("forward", "_forward_hooks"),
+        ("backward", "_backward_hooks"),
+        ("full_backward", "_full_backward_hooks"),
+    ):
+        hooks = getattr(module, attr, None)
+        count = len(hooks) if hooks is not None else 0
+        if count:
+            out[fact] = count
+    return out
+
+
+def _module_entry(path: str, module: Any) -> Dict[str, Any]:
+    """One module's composition facts: class, tensor schema, hook presence.
+    Exactly what the graph signature hashes and what the pgw#697 per-module
+    fingerprint digests — one builder so the two can never disagree."""
+    entry: Dict[str, Any] = {
+        "path": path,
+        "type": _type_name(module),
+        "tensors": _direct_tensor_schema(module),
+    }
+    hooks = _module_hooks(module)
+    if hooks:
+        entry["hooks"] = hooks
+    return entry
+
+
+def composition_fingerprint(pipeline: Any, cfg: Any) -> list[Tuple[str, str]]:
+    """``(path, digest)`` per resolved-target module — the pgw#697 adoption
+    fence. Digests the same per-module facts the graph signature hashes, so
+    a signature mismatch resolves to the exact drifted module (the pgw#683
+    class: one submodule left in Half inside a bf16 tree died as a raw
+    matmul RuntimeError — this names ``path: cell x != consumer y``
+    instead). Fine-tunes stay shared: no tensor VALUES enter any row."""
+    rows: list[Tuple[str, str]] = []
+    for target in tuple(getattr(cfg, "targets", ()) or ()):
+        resolved = _resolve_target(pipeline, str(target))
+        if resolved is None:
+            continue
+        owner, _attr, _fn = resolved
+        named = getattr(owner, "named_modules", None)
+        module_rows = list(named()) if callable(named) else [("", owner)]
+        for name, module in module_rows:
+            path = f"{target}:{name}" if name else str(target)
+            encoded = json.dumps(
+                _module_entry(path, module), sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+            rows.append((path, hashlib.sha256(encoded).hexdigest()[:16]))
+    return sorted(rows)
+
+
+def _first_composition_difference(
+    cell_rows: Iterable[Iterable[str]], here_rows: Iterable[Tuple[str, str]],
+) -> str:
+    """Name the first module whose composition digest differs (or that only
+    one side has)."""
+    cell = {str(p): str(d) for p, d in cell_rows}
+    here = {str(p): str(d) for p, d in here_rows}
+    for path in sorted(set(cell) | set(here)):
+        want, have = cell.get(path), here.get(path)
+        if want == have:
+            continue
+        if want is None:
+            return f"module {path!r} exists only in the consumer pipeline"
+        if have is None:
+            return f"module {path!r} exists only in the cell"
+        return f"{path}: cell composition {want} != consumer {have}"
+    return ""
+
+
 def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
     """Canonical family-graph and weight-lane contract for one loaded model.
 
@@ -1687,7 +1841,8 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
     and is rejected before adoption.
 
     The signature hashes ONLY the traced module structure — the resolved
-    targets' module types, paths and tensor schemas — never the wrapping
+    targets' module types, paths, tensor schemas (param shapes/dtypes,
+    buffer dtypes) and hook presence (pgw#697) — never the wrapping
     pipeline class (gw#577): torch.compile wraps target callables such as
     ``transformer.forward``; the pipeline class never enters any traced
     graph. Conversion producers load via generic ``DiffusionPipeline``
@@ -1711,11 +1866,7 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
         module_rows = list(named()) if callable(named) else [("", owner)]
         for name, module in module_rows:
             path = f"{target}:{name}" if name else str(target)
-            modules.append({
-                "path": path,
-                "type": _type_name(module),
-                "tensors": _direct_tensor_schema(module),
-            })
+            modules.append(_module_entry(path, module))
             # A target such as vae.decode can overlap another declaration;
             # record each module once in the W8A8 manifest.
             if id(module) in seen_modules:
@@ -1931,6 +2082,14 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     ).startswith(("w8a8", "w4a4")):
         return ""  # legacy format-2 non-quantized-lane cell
     if meta_signature != signature:
+        # pgw#697: when the cell carries per-module fingerprint rows, name
+        # the exact drifted module instead of two digest prefixes.
+        cell_rows = meta.get("composition") or []
+        if cell_rows:
+            named = _first_composition_difference(
+                cell_rows, composition_fingerprint(pipeline, cfg))
+            if named:
+                return f"module composition: {named}"
         return (
             f"module graph signature: cell {meta_signature[:12]!r} != "
             f"consumer {signature[:12]!r}"
@@ -2583,6 +2742,18 @@ def artifact_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     have = str(meta.get("compile_mode") or "whole")
     if have != want:
         return f"cell compile_mode {have!r} != declared {want!r}"
+    # pgw#695: the cell's sealed mint posture must be the posture THIS
+    # process presents at arm time — a drift here would otherwise surface
+    # later as an undiagnosable ambient guard miss.
+    manifest = meta.get(guard_closure.MANIFEST_KEY)
+    if isinstance(manifest, dict) and manifest:
+        sealed = manifest.get(guard_closure.POSTURE_KEY)
+        if not isinstance(sealed, dict) or not sealed:
+            return "cell guard manifest carries no posture seal (pre-pgw#695 mint)"
+        try:
+            guard_closure.assert_posture(sealed, label="arm")
+        except guard_closure.PostureError as exc:
+            return str(exc)
     return ""
 
 
@@ -3027,6 +3198,7 @@ def build(
         graph_signature=graph_signature,
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
+        composition=composition_fingerprint(pipe, cfg),
     )
     meta[guard_closure.MANIFEST_KEY] = guard_manifest
     if serving_image_digest:
@@ -3145,6 +3317,7 @@ def mint_artifact(
         graph_signature=graph_signature,
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
+        composition=composition_fingerprint(pipe, cfg),
     )
     meta[guard_closure.MANIFEST_KEY] = guard_manifest
     tmp = target.with_suffix(".part")
@@ -3282,6 +3455,7 @@ def finish_fleet_mint(
         graph_signature=graph_signature,
         weight_contract=weight_contract,
         shape_contract=declared_contract_facts(cfg),
+        composition=composition_fingerprint(pipe, cfg),
     )
     meta[guard_closure.MANIFEST_KEY] = guard_manifest
     tmp = target.with_suffix(".part")
@@ -3313,6 +3487,7 @@ __all__ = [
     "cache_miss_count",
     "enable",
     "execution_count",
+    "composition_fingerprint",
     "execution_contract",
     "execution_contract_digest",
     "family_from_ref",

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -250,9 +250,37 @@ def _install_stack_dump_handler() -> None:
     postmortem.enable_fault_dump()
 
 
+def _establish_env_seal() -> Dict[str, Any]:
+    """pgw#694/#696 boot wiring (the ONE executor-side hook): refuse unknown
+    ``TORCH*`` env vars, pin the canonical config surface, and record the
+    effective seal — BEFORE the CUDA probe or any model/compile work, so
+    every graph this process ever mints or serves runs under the sealed
+    posture and the ck4 ``env_seal`` axis describes reality. A process that
+    cannot be sealed must not advertise: the caller exits typed."""
+    from . import env_seal
+
+    seal = env_seal.establish()
+    _log_startup_phase(
+        "env_seal",
+        status="ok",
+        digest=env_seal.seal_digest(seal),
+        config=seal.get("config"),
+    )
+    return seal
+
+
 def _run_main() -> int:
     _log_startup_phase("boot", status="starting")
     _install_stack_dump_handler()
+    # pgw#696: seal the execution environment first — before settings can
+    # pull torch-adjacent config and before the CUDA probe touches the
+    # device. An unsealable process refuses to start, naming the variable.
+    try:
+        _establish_env_seal()
+    except Exception as e:
+        _log_worker_fatal("env_seal", e, exit_code=1)
+        logger.error(str(e))
+        return 1
     try:
         settings = get_settings()
     except Exception as e:

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -1,0 +1,182 @@
+"""Execution-environment seal (pgw#696).
+
+Compiled-cell identity depends on process environment facts no dynamo guard
+row names: TF32 toggles, matmul precision, cudnn autotune, the inductor
+config surface, and the pgw#695 process posture. This module freezes them:
+
+* :data:`CANONICAL_CONFIG` is the ONE table of behavior-affecting flags;
+  :func:`establish_config` sets every entry explicitly at boot and verifies
+  the effective read-back (``cudnn.allow_tf32`` defaults TRUE on torch 2.13
+  — a library default must never decide traced numerics).
+* :func:`check_torch_env` allowlist-rejects unknown ``TORCH*`` env vars at
+  boot, naming the variable: a stray ``TORCHINDUCTOR_*``/``TORCHDYNAMO_*``
+  toggle silently changes minted kernels.
+* :func:`effective_seal` snapshots posture + effective config + a digest of
+  the portable inductor config into ONE versioned dict; its
+  :func:`seal_digest` is the ``env_seal`` ck4 key axis. ``seal_v`` versions
+  the dict itself, so adding a sealed fact later changes digest VALUES only
+  — never the key-axis set: ck4 is the final planned scheme bump.
+
+The seal dict rides cell metadata verbatim (``artifact_metadata``), so
+``cell_key.from_artifact_metadata`` recomputes the axis from recorded facts
+and a stamp can never disagree with the environment it summarizes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any, Dict, List, Mapping, Optional
+
+from . import guard_closure
+
+SEAL_VERSION = 1
+SEAL_KEY = "env_seal"
+
+# Behavior-affecting global flags: ONE canonical value each, set explicitly
+# by establish_config() and read back effective. String-valued for JSON
+# determinism.
+CANONICAL_CONFIG: Dict[str, str] = {
+    "float32_matmul_precision": "highest",
+    "cuda_matmul_allow_tf32": "False",
+    "cudnn_allow_tf32": "False",
+    "cudnn_benchmark": "False",
+}
+
+# CUBLAS workspace config alters cublas kernel splits: recorded into the
+# seal (value participates in identity) but not canonicalized — bitwise
+# numerical determinism is an explicit pgw#694 non-goal.
+_RECORDED_ENV = ("CUBLAS_WORKSPACE_CONFIG",)
+
+# TORCH* env vars that may be present without compromising mint/serve
+# determinism: storage locations, observability, and the SDK's own capture
+# machinery. Everything else refuses boot, naming the variable.
+ENV_ALLOWLIST = frozenset({
+    "TORCH_HOME",
+    "TORCH_LOGS",
+    "TORCH_LOGS_FORMAT",
+    "TORCH_LOGS_OUT",
+    "TORCH_TRACE",
+    "TORCH_EXTENSIONS_DIR",
+    "TORCH_CUDA_ARCH_LIST",
+    "TORCH_CUDA_ALLOC_CONF",     # allocator sizing — never enters a graph
+    "TORCHINDUCTOR_CACHE_DIR",   # the SDK's own mint-capture redirect
+    "TORCHINDUCTOR_AUTOGRAD_CACHE",  # set by the SDK's capture machinery
+})
+
+
+class EnvSealError(RuntimeError):
+    """The process environment cannot be sealed: an unknown ``TORCH*``
+    variable is present, or a canonical flag did not take effect."""
+
+
+def check_torch_env(environ: Optional[Mapping[str, str]] = None) -> None:
+    """Refuse unknown ``TORCH*`` env vars, naming each one (pgw#696)."""
+    env = os.environ if environ is None else environ
+    unknown = sorted(
+        name for name in env
+        if name.startswith("TORCH") and name not in ENV_ALLOWLIST
+    )
+    if unknown:
+        raise EnvSealError(
+            f"unknown TORCH* environment variable(s) {unknown!r}: not in "
+            "the pgw#696 allowlist (env_seal.ENV_ALLOWLIST) — a stray "
+            "inductor/dynamo toggle silently changes minted kernels; unset "
+            "it or add it to the canonical table")
+
+
+def effective_config() -> Dict[str, str]:
+    """The live values of every sealed config flag (read back, never
+    assumed)."""
+    import torch
+
+    config = {
+        "float32_matmul_precision": str(torch.get_float32_matmul_precision()),
+        "cuda_matmul_allow_tf32": str(torch.backends.cuda.matmul.allow_tf32),
+        "cudnn_allow_tf32": str(torch.backends.cudnn.allow_tf32),
+        "cudnn_benchmark": str(torch.backends.cudnn.benchmark),
+    }
+    for name in _RECORDED_ENV:
+        config[name] = os.environ.get(name, "")
+    return config
+
+
+def establish_config() -> Dict[str, str]:
+    """Set every canonical flag explicitly, then verify the read-back."""
+    import torch
+
+    torch.set_float32_matmul_precision(
+        CANONICAL_CONFIG["float32_matmul_precision"])
+    torch.backends.cuda.matmul.allow_tf32 = (
+        CANONICAL_CONFIG["cuda_matmul_allow_tf32"] == "True")
+    torch.backends.cudnn.allow_tf32 = (
+        CANONICAL_CONFIG["cudnn_allow_tf32"] == "True")
+    torch.backends.cudnn.benchmark = (
+        CANONICAL_CONFIG["cudnn_benchmark"] == "True")
+    effective = effective_config()
+    diffs: List[str] = [
+        f"{name}: canonical {want!r} != effective {effective.get(name)!r}"
+        for name, want in CANONICAL_CONFIG.items()
+        if effective.get(name) != want
+    ]
+    if diffs:
+        raise EnvSealError("config freeze failed: " + "; ".join(diffs))
+    return effective
+
+
+def inductor_config_digest() -> str:
+    """Digest of torch's PORTABLE inductor config — the codegen surface a
+    cell's kernels were minted under (machine-specific entries excluded by
+    torch itself)."""
+    import torch._inductor.config as inductor_config
+
+    portable = inductor_config.save_config_portable()
+    encoded = json.dumps(
+        portable, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+        default=str,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def effective_seal() -> Dict[str, Any]:
+    """The live seal dict — recorded verbatim in cell metadata."""
+    return {
+        "seal_v": SEAL_VERSION,
+        "posture": guard_closure.posture_snapshot(),
+        "config": effective_config(),
+        "inductor": inductor_config_digest(),
+    }
+
+
+def seal_digest(seal: Mapping[str, Any]) -> str:
+    """The ``env_seal`` key-axis value for one seal dict."""
+    encoded = json.dumps(
+        dict(seal), sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def establish() -> Dict[str, Any]:
+    """The boot entry (executor wiring): refuse unknown TORCH* env, set the
+    canonical config and posture, return the effective seal."""
+    check_torch_env()
+    establish_config()
+    guard_closure.establish_posture()
+    return effective_seal()
+
+
+__all__ = [
+    "CANONICAL_CONFIG",
+    "ENV_ALLOWLIST",
+    "EnvSealError",
+    "SEAL_KEY",
+    "SEAL_VERSION",
+    "check_torch_env",
+    "effective_config",
+    "effective_seal",
+    "establish",
+    "establish_config",
+    "inductor_config_digest",
+    "seal_digest",
+]

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -31,8 +31,18 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from . import guard_closure
 
-SEAL_VERSION = 1
+# v2 (build-systems review R2/R7): + operator `epoch` salt (Bazel
+# Action.salt / ccache HASH_PREFIX precedent — disowning a poisoned
+# generation is one config change, never a scheme bump) and the widened
+# recorded-env set. Adding sealed facts bumps THIS version only.
+SEAL_VERSION = 2
 SEAL_KEY = "env_seal"
+
+# R2: the operator-settable generation salt. Bumping it disowns every cell
+# minted under the previous epoch (their env_seal digests stop matching) —
+# the recall lever for "a subtly broken image published cells" without a
+# KEY_SCHEME bump. Set in the fleet env; default generation is "0".
+EPOCH_ENV = "COZY_CELL_EPOCH"
 
 # Behavior-affecting global flags: ONE canonical value each, set explicitly
 # by establish_config() and read back effective. String-valued for JSON
@@ -44,12 +54,30 @@ CANONICAL_CONFIG: Dict[str, str] = {
     "cudnn_benchmark": "False",
 }
 
-# CUBLAS workspace config alters cublas kernel splits: recorded into the
-# seal (value participates in identity) but not canonicalized — bitwise
-# numerical determinism is an explicit pgw#694 non-goal.
-_RECORDED_ENV = ("CUBLAS_WORKSPACE_CONFIG",)
+# Value-semantic env recorded into the seal WITHOUT canonicalization (the
+# pattern the build-systems review endorses — extend it, don't allowlist
+# it): CUBLAS workspace alters cublas kernel splits; launch blocking and
+# module loading change CUDA behavior; NVIDIA_TF32_OVERRIDE flips numerics
+# under every torch flag; PYTHONHASHSEED can perturb codegen ordering.
+# Path-shaped and host-shaped vars (LD_LIBRARY_PATH, OMP_NUM_THREADS, cache
+# dirs) deliberately do NOT ride the seal — JAX's learned lesson: its own
+# auto-set cache path was poisoning its own keys (PR notes in the review).
+_RECORDED_ENV = (
+    "CUBLAS_WORKSPACE_CONFIG",
+    "CUDA_LAUNCH_BLOCKING",
+    "CUDA_MODULE_LOADING",
+    "NVIDIA_TF32_OVERRIDE",
+    "PYTHONHASHSEED",
+)
 
-# TORCH* env vars that may be present without compromising mint/serve
+# Gated prefixes (R7): the behavior-affecting namespaces. The original
+# gate matched only TORCH* — every PYTORCH_* var (including the LIVE
+# allocator spelling PYTORCH_CUDA_ALLOC_CONF) evaded it, while the
+# allowlist carried only the legacy TORCH_CUDA_ALLOC_CONF. TRITON_* is
+# gated too: TRITON_PTXAS_PATH silently changes emitted cubins.
+_GATED_PREFIXES = ("TORCH", "PYTORCH", "TRITON")
+
+# Gated-namespace vars that may be present without compromising mint/serve
 # determinism: storage locations, observability, and the SDK's own capture
 # machinery. Everything else refuses boot, naming the variable.
 ENV_ALLOWLIST = frozenset({
@@ -60,30 +88,35 @@ ENV_ALLOWLIST = frozenset({
     "TORCH_TRACE",
     "TORCH_EXTENSIONS_DIR",
     "TORCH_CUDA_ARCH_LIST",
-    "TORCH_CUDA_ALLOC_CONF",     # allocator sizing — never enters a graph
-    "TORCHINDUCTOR_CACHE_DIR",   # the SDK's own mint-capture redirect
+    "TORCH_CUDA_ALLOC_CONF",       # allocator sizing (legacy spelling)
+    "PYTORCH_CUDA_ALLOC_CONF",     # allocator sizing (live spelling)
+    "PYTORCH_ALLOC_CONF",          # allocator sizing (2.13 preferred)
+    "PYTORCH_NVML_BASED_CUDA_CHECK",  # probe-only: how availability is checked
+    "TORCHINDUCTOR_CACHE_DIR",     # the SDK's own mint-capture redirect
     "TORCHINDUCTOR_AUTOGRAD_CACHE",  # set by the SDK's capture machinery
+    "TRITON_CACHE_DIR",            # the SDK's own mint-capture redirect
 })
 
 
 class EnvSealError(RuntimeError):
-    """The process environment cannot be sealed: an unknown ``TORCH*``
+    """The process environment cannot be sealed: an unknown gated-namespace
     variable is present, or a canonical flag did not take effect."""
 
 
 def check_torch_env(environ: Optional[Mapping[str, str]] = None) -> None:
-    """Refuse unknown ``TORCH*`` env vars, naming each one (pgw#696)."""
+    """Refuse unknown ``TORCH*``/``PYTORCH*``/``TRITON*`` env vars, naming
+    each one (pgw#696, widened by the build-systems review R7)."""
     env = os.environ if environ is None else environ
     unknown = sorted(
         name for name in env
-        if name.startswith("TORCH") and name not in ENV_ALLOWLIST
+        if name.startswith(_GATED_PREFIXES) and name not in ENV_ALLOWLIST
     )
     if unknown:
         raise EnvSealError(
-            f"unknown TORCH* environment variable(s) {unknown!r}: not in "
+            f"unknown gated environment variable(s) {unknown!r}: not in "
             "the pgw#696 allowlist (env_seal.ENV_ALLOWLIST) — a stray "
-            "inductor/dynamo toggle silently changes minted kernels; unset "
-            "it or add it to the canonical table")
+            "inductor/dynamo/triton toggle silently changes minted "
+            "kernels; unset it or add it to the canonical table")
 
 
 def effective_config() -> Dict[str, str]:
@@ -143,6 +176,7 @@ def effective_seal() -> Dict[str, Any]:
     """The live seal dict — recorded verbatim in cell metadata."""
     return {
         "seal_v": SEAL_VERSION,
+        "epoch": os.environ.get(EPOCH_ENV, "0"),
         "posture": guard_closure.posture_snapshot(),
         "config": effective_config(),
         "inductor": inductor_config_digest(),
@@ -169,6 +203,7 @@ def establish() -> Dict[str, Any]:
 __all__ = [
     "CANONICAL_CONFIG",
     "ENV_ALLOWLIST",
+    "EPOCH_ENV",
     "EnvSealError",
     "SEAL_KEY",
     "SEAL_VERSION",

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -72,8 +72,9 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
-MANIFEST_VERSION = 1
+MANIFEST_VERSION = 2  # v2 (pgw#695): + "posture" process-seal block
 MANIFEST_KEY = "guard_manifest"
+POSTURE_KEY = "posture"
 
 # Verdicts. LEAK is the only failing one.
 LEAK = "LEAK"
@@ -157,6 +158,13 @@ class GuardBoundaryError(RuntimeError):
     boundary (dtype drift). Named — never a silent recompile. Consumer
     guards catch it into the pgw#672 explicit-eager degrade; mint arms
     (``guard=False``) let it fail the mint red."""
+
+
+class PostureError(GuardClosureError):
+    """The process posture differs from the canonical serving posture or
+    from a cell's sealed posture (pgw#695). Named per fact — a posture
+    drift refuses the mint/arm loudly instead of surfacing later as an
+    undiagnosable ambient guard miss."""
 
 
 @dataclass(frozen=True)
@@ -608,6 +616,83 @@ def _classify_row(
 
 
 # ---------------------------------------------------------------------------
+# Process-posture seal (pgw#695)
+# ---------------------------------------------------------------------------
+
+# The ONE canonical serving posture. Every fact is ambient process state a
+# dynamo guard observes (GLOBAL_STATE, TORCH_FUNCTION_MODE_STACK,
+# DEFAULT_DEVICE): mint and consumer must present the SAME posture or the
+# minted guards can never HIT — and a drift must refuse the arm with a
+# named reason, never surface as a downstream guard miss. String-valued
+# for JSON determinism.
+CANONICAL_POSTURE: Dict[str, str] = {
+    "grad_enabled": "True",
+    "inference_mode": "False",
+    "autocast_cpu": "False",
+    "autocast_cuda": "False",
+    "torch_function_stack": "0",
+    "default_device": "cpu",
+    "deterministic_algorithms": "False",
+    "deterministic_warn_only": "False",
+}
+
+
+def posture_snapshot() -> Dict[str, str]:
+    """The live process posture in canonical string form."""
+    import torch
+
+    return {
+        "grad_enabled": str(torch.is_grad_enabled()),
+        "inference_mode": str(torch.is_inference_mode_enabled()),
+        "autocast_cpu": str(torch.is_autocast_enabled("cpu")),
+        "autocast_cuda": str(torch.is_autocast_enabled("cuda")),
+        "torch_function_stack": str(torch._C._len_torch_function_stack()),
+        "default_device": str(torch.get_default_device()),
+        "deterministic_algorithms": str(
+            torch.are_deterministic_algorithms_enabled()),
+        "deterministic_warn_only": str(
+            torch.is_deterministic_algorithms_warn_only_enabled()),
+    }
+
+
+def _posture_diff(sealed: Mapping[str, Any], live: Mapping[str, str]) -> List[str]:
+    out: List[str] = []
+    for fact in sorted(set(sealed) | set(live)):
+        want = str(sealed.get(fact, "<absent>"))
+        have = str(live.get(fact, "<absent>"))
+        if want != have:
+            out.append(f"{fact}: sealed {want!r} != process {have!r}")
+    return out
+
+
+def establish_posture() -> Dict[str, str]:
+    """Set the canonical posture explicitly (boot entry). Settable facts are
+    SET (grad mode, deterministic algos); ambient contexts that library code
+    must not pop from under the embedding process (an active autocast, a
+    foreign torch-function mode, a moved default device) REFUSE with a named
+    :class:`PostureError` instead."""
+    import torch
+
+    torch.set_grad_enabled(True)
+    torch.use_deterministic_algorithms(False)
+    diffs = _posture_diff(CANONICAL_POSTURE, posture_snapshot())
+    if diffs:
+        raise PostureError(
+            "process posture is not canonical at establish: "
+            + "; ".join(diffs))
+    return dict(CANONICAL_POSTURE)
+
+
+def assert_posture(sealed: Mapping[str, Any], label: str = "") -> None:
+    """The live process must present exactly ``sealed`` (a cell's recorded
+    posture) — every differing fact is named in the raise."""
+    diffs = _posture_diff(sealed, posture_snapshot())
+    if diffs:
+        raise PostureError(
+            f"process posture drift ({label or 'arm'}): " + "; ".join(diffs))
+
+
+# ---------------------------------------------------------------------------
 # The mint gate + armed-cell audit
 # ---------------------------------------------------------------------------
 
@@ -636,10 +721,20 @@ def assert_closure(pipeline: Any, cfg: Any, label: str = "") -> Dict[str, Any]:
             f"guard-closure gate ({name}): {len(report.leaks)} out-of-"
             f"contract guard(s) — the mint depends on variables the "
             f"contract does not pin:\n  {leak_lines}")
+    # pgw#695: a mint in a non-canonical posture would arm nowhere (every
+    # canonical consumer refuses its seal) — fail THIS mint red instead.
+    posture = posture_snapshot()
+    canonical_diffs = _posture_diff(CANONICAL_POSTURE, posture)
+    if canonical_diffs:
+        raise PostureError(
+            f"guard-closure gate ({name}): minted in a non-canonical "
+            "process posture: " + "; ".join(canonical_diffs))
     logger.info(
         "guard-closure gate (%s): CLOSED — %d graph(s), verdicts=%s",
         name, len(report.graphs), report.verdict_counts())
-    return report.manifest()
+    manifest = report.manifest()
+    manifest[POSTURE_KEY] = posture
+    return manifest
 
 
 # ---------------------------------------------------------------------------
@@ -765,6 +860,7 @@ def consolidate(manifests: Mapping[str, Mapping[str, Any]]) -> FleetAudit:
     determinism (every guard row present in every manifest)."""
     leaks: List[str] = []
     per_name: Dict[str, set] = {}
+    postures: Dict[str, Dict[str, str]] = {}
     total = 0
     for name, manifest in sorted(manifests.items()):
         keys: set = set()
@@ -776,7 +872,24 @@ def consolidate(manifests: Mapping[str, Mapping[str, Any]]) -> FleetAudit:
                 total += 1
                 keys.add(_comparison_key(target, guard))
         per_name[name] = keys
+        sealed = manifest.get(POSTURE_KEY)
+        if isinstance(sealed, dict) and sealed:
+            postures[name] = {k: str(v) for k, v in sealed.items()}
     divergence: List[str] = []
+    # pgw#695: the sealed posture must be identical across every pod's
+    # mint of one release — a divergent posture is a divergent guard
+    # environment even when the guard rows happen to agree.
+    if postures and len(postures) < len(per_name):
+        missing_seal = sorted(set(per_name) - set(postures))
+        divergence.append(f"posture seal absent from {missing_seal}")
+    if len(postures) > 1:
+        facts: set = set()
+        for sealed in postures.values():
+            facts.update(sealed)
+        for fact in sorted(facts):
+            values = {n: p.get(fact, "<absent>") for n, p in postures.items()}
+            if len(set(values.values())) > 1:
+                divergence.append(f"posture/{fact} differs: {values}")
     if len(per_name) > 1:
         union: set = set().union(*per_name.values())
         for key in sorted(union):
@@ -845,6 +958,7 @@ if __name__ == "__main__":  # pragma: no cover
 
 __all__ = [
     "CANONICALIZED",
+    "CANONICAL_POSTURE",
     "CODE_CONSTANT",
     "CODE_IDENTITY",
     "CONTRACT_SCALAR",
@@ -860,17 +974,22 @@ __all__ = [
     "MANIFEST_KEY",
     "MANIFEST_VERSION",
     "MODULE_STRUCTURE",
+    "POSTURE_KEY",
+    "PostureError",
     "RUNTIME_STATE",
     "STRUCTURAL",
     "assert_closure",
+    "assert_posture",
     "audit_armed",
     "canonical_ingress",
     "canonical_strides",
     "classify",
     "consolidate",
     "contract_pins",
+    "establish_posture",
     "extract",
     "extract_target_guards",
     "load_manifest",
     "main",
+    "posture_snapshot",
 ]

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -27,6 +27,7 @@ import pytest
 
 from gen_worker import cell_key as ck
 from gen_worker import compile_cache as cc
+from gen_worker import env_seal
 from gen_worker.models import w8a8_lora
 
 # --- the burst's recorded artifact metadata (cell_store checkpoint
@@ -66,6 +67,16 @@ _BURST_META: Dict[str, Any] = {
     "image_digest": _IMAGE_DIGEST,
     "libs": {"diffusers": "0.39.0", "transformers": "5.13.1"},
     "shape_contract": _SHAPE_CONTRACT,
+    # pgw#696 reconstruction: the ck2-era burst pre-dates env sealing; a
+    # fixed representative seal keeps the lane-only-divergence relations
+    # provable under ck4 (burst_runtime pins effective_seal to THIS dict,
+    # exactly as it pins every other runtime probe).
+    "env_seal": {
+        "seal_v": 1,
+        "posture": {"grad_enabled": "True"},
+        "config": {"cudnn_benchmark": "False"},
+        "inductor": "0" * 16,
+    },
 }
 
 # What the hub saw, verbatim — ck2-era historical evidence. The pgw#691 sku
@@ -94,6 +105,9 @@ def burst_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         cc, "_lib_versions",
         lambda: {"diffusers": "0.39.0", "transformers": "5.13.1"})
+    monkeypatch.setattr(
+        env_seal, "effective_seal",
+        lambda: dict(_BURST_META["env_seal"]))
     monkeypatch.setenv("WORKER_IMAGE_DIGEST", _IMAGE_DIGEST)
 
 

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -37,7 +37,8 @@ _CONTRACT = ck.contract_digest(_FACTS)
 _AXES = {
     "format": "2", "kind": "inductor", "family": "ltx-2.3", "lane": "w8a8",
     "sm": "sm_100", "cuda": "13.0", "torch": "2.13.0+cu130",
-    "triton": "3.7.1", "gen_worker": "0.36.10", "contract": _CONTRACT,
+    "triton": "3.7.1", "gen_worker": "0.36.10",
+    "env_seal": "aa00bb11cc22dd33", "contract": _CONTRACT,
     "diffusers": "0.39.0", "transformers": "5.13.1",
     "image_digest": "sha256:abc",
 }
@@ -110,13 +111,15 @@ def test_sku_is_not_identity(fixed_runtime):
     assert _meta("a40", sm="sm_89")["cell_key"] != a40["cell_key"]
 
 
-def test_key_scheme_ck3_old_keys_never_half_match():
-    """The sku collapse changes every key, so the scheme is bumped: a ck2
-    digest is no longer a key at all — a clean MISS, never a half-match."""
+def test_key_scheme_ck4_old_keys_never_half_match():
+    """Each axis-set change bumps the scheme (sku collapse -> ck3, env_seal
+    -> ck4): an older digest is no longer a key at all — a clean MISS,
+    never a half-match."""
     key = ck.from_axes(_AXES).digest
-    assert key.startswith("ck3-")
-    assert not ck.is_key("ck2-" + "a" * 56)
-    assert "not a cell key" in ck.mismatch({}, "ck2-" + "a" * 56)
+    assert key.startswith("ck4-")
+    for dead in ("ck2-", "ck3-"):
+        assert not ck.is_key(dead + "a" * 56)
+        assert "not a cell key" in ck.mismatch({}, dead + "a" * 56)
 
 
 def test_compute_matches_artifact_metadata_stamp(fixed_runtime):

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -85,8 +85,13 @@ def test_verify_mismatches():
     other = dict(meta, torch="0.0.0")
     assert "torch" in cc.verify(other, family="sd15")
 
+    # pgw#691/ck3 completion: sku is metadata, not identity — a same-sm
+    # cell minted on a different SKU must arm (sm/cuda/torch/triton pin
+    # the hardware facts).
     other = dict(meta, sku="not-this-gpu")
-    assert "sku" in cc.verify(other, family="sd15")
+    assert cc.verify(other, family="sd15") == ""
+    other = dict(meta, sm="sm_00")
+    assert "sm" in cc.verify(other, family="sd15")
 
     assert "family" in cc.verify(meta, family="sdxl")
 

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -1,0 +1,387 @@
+"""pgw#694 determinism hardening: posture seal (#695), env seal + ck4
+(#696), composition fingerprint (#697), cubin gate (#698).
+
+Red-verified against real torch state and real file trees — no mocks of
+torch posture, no fabricated guard rows where a real API exists. CPU only.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any, Dict, Iterator
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import cell_key as ck
+from gen_worker import compile_cache as cc
+from gen_worker import guard_closure as gc
+from gen_worker.registry import CompileCell
+
+
+def _env_seal() -> Any:
+    """Function-scoped so the pre-fix red run COLLECTS: on a pre-pgw#696
+    tree the module is absent and each seal test fails red individually."""
+    from gen_worker import env_seal
+
+    return env_seal
+
+
+@pytest.fixture(autouse=True)
+def _fresh_dynamo() -> Iterator[None]:
+    torch._dynamo.reset()
+    yield
+    torch._dynamo.reset()
+
+
+def _cfg(**overrides: Any) -> CompileCell:
+    base: Dict[str, Any] = dict(
+        shapes=((64, 64),), targets=("transformer",), family="toyfam",
+        regional=False, text_len=None, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=(),
+    )
+    base.update(overrides)
+    return CompileCell(**base)
+
+
+# ---------------------------------------------------------------------------
+# #695: process-posture seal
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_process_posture_is_canonical() -> None:
+    """The canonical table IS this box's honest resting state — establish
+    must be a no-op assertion here, not a mutation."""
+    assert gc.posture_snapshot() == gc.CANONICAL_POSTURE
+    assert gc.establish_posture() == gc.CANONICAL_POSTURE
+
+
+def test_assert_posture_names_every_drifted_fact() -> None:
+    with torch.no_grad():
+        with pytest.raises(gc.PostureError) as excinfo:
+            gc.assert_posture(gc.CANONICAL_POSTURE, label="arm")
+    message = str(excinfo.value)
+    assert "grad_enabled" in message
+    assert "sealed 'True'" in message and "process 'False'" in message
+    assert "arm" in message
+    # Clean state passes.
+    gc.assert_posture(gc.CANONICAL_POSTURE, label="arm")
+
+
+def test_mint_manifest_carries_the_posture_seal() -> None:
+    """assert_closure seals the live posture into the manifest (v2)."""
+    import threading
+
+    def forward(self: Any, x: Any) -> Any:
+        return self.lin(x) + 1
+
+    class _Mod(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(8, 8)
+
+    _Mod.forward = forward  # type: ignore[method-assign]
+
+    class _Pipe:
+        pass
+
+    pipe = _Pipe()
+    mod = _Mod()
+    pipe.transformer = mod  # type: ignore[attr-defined]
+    setattr(pipe, cc._MARKER_ATTR, {
+        "targets": ["transformer"], "shapes": [(64, 64)], "cache": True,
+        "originals": [(mod, "forward", mod.forward)], "regional_mods": [],
+        "failure_signal": {
+            "callback": None, "lock": threading.Lock(),
+            "successful_calls": 0, "cache_hits": 0, "cache_misses": 0,
+            "router": None,
+        },
+    })
+    compiled = torch.compile(mod.forward, backend="eager", dynamic=None)
+    compiled(torch.randn(2, 4, 8))
+
+    manifest = gc.assert_closure(pipe, _cfg(), label="toyfam")
+    assert manifest[gc.POSTURE_KEY] == gc.CANONICAL_POSTURE
+    assert gc.MANIFEST_VERSION == 2 and manifest["v"] == 2
+
+    # A mint attempted in a non-canonical posture fails red, named.
+    with torch.no_grad():
+        with pytest.raises(gc.PostureError, match="grad_enabled"):
+            gc.assert_closure(pipe, _cfg(), label="toyfam")
+
+
+def test_arm_refuses_on_posture_drift_named() -> None:
+    """artifact_drift converts a sealed-vs-live posture mismatch into a
+    named refusal at arm time — never a downstream guard miss."""
+    base = {
+        "compile_mode": "whole", "shapes": [[64, 64]],
+        "targets": ["transformer"], "guidance_scales": [],
+    }
+    meta = dict(base)
+    meta[gc.MANIFEST_KEY] = {
+        "v": 2, "graphs": [], "leaks": [],
+        gc.POSTURE_KEY: dict(gc.CANONICAL_POSTURE),
+    }
+
+    class _Pipe:
+        pass
+
+    assert cc.artifact_drift(meta, _Pipe(), _cfg()) == ""
+    with torch.no_grad():
+        drift = cc.artifact_drift(meta, _Pipe(), _cfg())
+    assert "posture" in drift and "grad_enabled" in drift
+
+    # A manifest-bearing cell WITHOUT a posture seal is a pre-#695 mint.
+    legacy = dict(base)
+    legacy[gc.MANIFEST_KEY] = {"v": 1, "graphs": [], "leaks": []}
+    assert "no posture seal" in cc.artifact_drift(legacy, _Pipe(), _cfg())
+
+
+def test_consolidate_flags_posture_divergence() -> None:
+    base = {"v": 2, "graphs": [], "leaks": [],
+            gc.POSTURE_KEY: dict(gc.CANONICAL_POSTURE)}
+    drifted = json.loads(json.dumps(base))
+    drifted[gc.POSTURE_KEY]["grad_enabled"] = "False"
+    audit = gc.consolidate({"pod-a": base, "pod-b": drifted})
+    assert not audit.ok
+    assert any("posture/grad_enabled" in d for d in audit.divergence)
+    # Identical postures stay clean; a missing seal on ONE pod diverges.
+    assert gc.consolidate({"pod-a": base, "pod-b": base}).divergence == ()
+    unsealed = {"v": 1, "graphs": [], "leaks": []}
+    audit = gc.consolidate({"pod-a": base, "pod-b": unsealed})
+    assert any("posture seal absent" in d and "pod-b" in d
+               for d in audit.divergence)
+
+
+# ---------------------------------------------------------------------------
+# #696: env seal + ck4
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_torch_env_refuses_naming_the_var() -> None:
+    env = {"TORCHINDUCTOR_MAX_AUTOTUNE": "1", "TORCH_HOME": "/x",
+           "TORCHINDUCTOR_CACHE_DIR": "/y", "PATH": "/bin"}
+    with pytest.raises(_env_seal().EnvSealError) as excinfo:
+        _env_seal().check_torch_env(env)
+    message = str(excinfo.value)
+    assert "TORCHINDUCTOR_MAX_AUTOTUNE" in message
+    assert "TORCH_HOME" not in message  # allowlisted names are not named
+    # Allowlisted-only environments pass (incl. this process's real env,
+    # which carries the SDK's own TORCHINDUCTOR_CACHE_DIR redirect).
+    _env_seal().check_torch_env({k: v for k, v in env.items()
+                              if k != "TORCHINDUCTOR_MAX_AUTOTUNE"})
+    _env_seal().check_torch_env()
+
+
+def test_establish_config_pins_the_true_default() -> None:
+    """cudnn.allow_tf32 defaults TRUE on torch 2.13 — the freeze must pin
+    it False explicitly and verify the read-back."""
+    before = torch.backends.cudnn.allow_tf32
+    try:
+        torch.backends.cudnn.allow_tf32 = True
+        effective = _env_seal().establish_config()
+        assert effective["cudnn_allow_tf32"] == "False"
+        assert torch.backends.cudnn.allow_tf32 is False
+        assert _env_seal().effective_config() == effective
+    finally:
+        torch.backends.cudnn.allow_tf32 = before
+        _env_seal().establish_config()
+
+
+def test_seal_digest_tracks_config_flags() -> None:
+    """Flipping one sealed flag changes the seal digest — and therefore the
+    ck4 key (red pre-fix: no env_seal axis, keys blind to config)."""
+    baseline = _env_seal().seal_digest(_env_seal().effective_seal())
+    before = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = not before
+        assert _env_seal().seal_digest(_env_seal().effective_seal()) != baseline
+    finally:
+        torch.backends.cudnn.benchmark = before
+    assert _env_seal().seal_digest(_env_seal().effective_seal()) == baseline
+
+
+def test_ck4_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:
+    monkeypatch.setattr(cc, "runtime_key", lambda: {
+        "sku": "l4", "sm": "sm_89", "cuda": "13.0", "cuda_driver": "13000",
+        "torch": "2.13.0+cu130", "triton": "3.7.1", "image_digest": "",
+    })
+    monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.74.0")
+    monkeypatch.setattr(cc, "_lib_versions", lambda: {})
+    monkeypatch.delenv("WORKER_IMAGE_DIGEST", raising=False)
+
+    facts = cc.declared_contract_facts(_cfg())
+    want = ck.compute("toyfam", contract=ck.contract_digest(facts))
+    assert want.digest.startswith("ck4-")
+    assert not ck.is_key("ck3-" + "a" * 56)  # older schemes are dead
+
+    meta = cc.artifact_metadata(
+        family="toyfam", shapes=((64, 64),), targets=("transformer",),
+        shape_contract=facts,
+    )
+    # The metadata records the seal dict verbatim; the key axis is
+    # RECOMPUTED from it and matches the live compute.
+    assert meta[_env_seal().SEAL_KEY]["seal_v"] == _env_seal().SEAL_VERSION
+    assert meta["cell_key"] == want.digest
+    assert ck.mismatch(meta, want) == ""
+
+    # A cell sealed under a DIFFERENT environment gets a different key,
+    # and the mismatch names the env_seal axis.
+    drifted = json.loads(json.dumps(meta))
+    drifted[_env_seal().SEAL_KEY]["config"]["cudnn_benchmark"] = "True"
+    assert ck.from_artifact_metadata(drifted).digest != want.digest
+    assert ck.mismatch(drifted, want).startswith("env_seal:")
+
+    # No env_seal block = pre-ck4 cell = no identity.
+    unsealed = {k: v for k, v in meta.items() if k != _env_seal().SEAL_KEY}
+    with pytest.raises(ck.CellKeyError, match="env_seal"):
+        ck.from_artifact_metadata(unsealed)
+
+
+def test_verify_no_longer_pins_sku(monkeypatch: Any) -> None:
+    """ck3 completion (pgw#691): sku left the identity axes, but verify()
+    still hard-required it — a same-sm cell minted on a different SKU
+    refused to arm, structurally undoing the collapse."""
+    monkeypatch.setattr(cc, "runtime_key", lambda: {
+        "sku": "rtx-3090", "sm": "sm_86", "cuda": "13.0",
+        "cuda_driver": "13000", "torch": "2.13.0+cu130", "triton": "3.7.1",
+        "image_digest": "",
+    })
+    monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.74.0")
+    monkeypatch.setattr(cc, "_lib_versions", lambda: {})
+    meta = {
+        "format": cc.ARTIFACT_FORMAT, "sku": "a40", "sm": "sm_86",
+        "cuda": "13.0", "torch": "2.13.0+cu130", "triton": "3.7.1",
+        "gen_worker": "0.74.0", "libs": {},
+    }
+    assert cc.verify(dict(meta)) == ""  # sku differs, sm matches: arms
+    assert "sm" in cc.verify(dict(meta, sm="sm_89"))  # sm still refuses
+
+
+# ---------------------------------------------------------------------------
+# #697: composition fingerprint
+# ---------------------------------------------------------------------------
+
+
+class _Tree(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin1 = torch.nn.Linear(8, 8)
+        self.lin2 = torch.nn.Linear(8, 8)
+
+    def forward(self, x: Any) -> Any:
+        return self.lin2(self.lin1(x))
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.transformer = _Tree()
+
+
+def test_fingerprint_names_the_drifted_module_on_dtype_flip() -> None:
+    """The pgw#683 class: one submodule left in Half inside a bf16-tree.
+    Pre-fix the refusal was two digest prefixes; now it names the module."""
+    minted = _Pipe()
+    cfg = _cfg()
+    signature, contract = cc.execution_contract(minted, cfg)
+    meta = cc.artifact_metadata(
+        family="toyfam", shapes=cfg.shapes, targets=cfg.targets,
+        graph_signature=signature, weight_contract=contract,
+        shape_contract=cc.declared_contract_facts(cfg),
+        composition=cc.composition_fingerprint(minted, cfg),
+    )
+
+    consumer = _Pipe()
+    consumer.transformer.lin2.half()  # the drift
+    drift = cc.contract_drift(meta, consumer, cfg)
+    assert "module composition" in drift
+    assert "transformer:lin2" in drift
+    assert "transformer:lin1" not in drift
+
+    # Identical composition (different VALUES = a fine-tune) arms.
+    finetune = _Pipe()
+    with torch.no_grad():
+        finetune.transformer.lin1.weight.mul_(2.0)
+    assert cc.contract_drift(meta, finetune, cfg) == ""
+
+
+def test_hook_presence_is_a_composition_fact() -> None:
+    """fp8 layerwise-cast is hook-driven (ie#381): a hooked module tree is
+    a DIFFERENT composition than a bare one. Red pre-fix: identical
+    signatures with and without hooks."""
+    bare, hooked = _Pipe(), _Pipe()
+    handle = hooked.transformer.lin1.register_forward_hook(
+        lambda mod, args, out: out)
+    try:
+        cfg = _cfg()
+        sig_bare, _ = cc.execution_contract(bare, cfg)
+        sig_hooked, _ = cc.execution_contract(hooked, cfg)
+        assert sig_bare != sig_hooked
+        rows_bare = dict(cc.composition_fingerprint(bare, cfg))
+        rows_hooked = dict(cc.composition_fingerprint(hooked, cfg))
+        assert rows_bare["transformer:lin1"] != rows_hooked["transformer:lin1"]
+        assert rows_bare["transformer:lin2"] == rows_hooked["transformer:lin2"]
+    finally:
+        handle.remove()
+
+
+# ---------------------------------------------------------------------------
+# #698: cubin-completeness gate at pack
+# ---------------------------------------------------------------------------
+
+
+def _elf_cubin_bytes(arch: int) -> bytes:
+    """A minimal ELF64 header whose e_flags carry ``arch`` in the low byte
+    — the real layout nvidia cubins use (file-format check, no GPU)."""
+    header = bytearray(64)
+    header[0:4] = b"\x7fELF"
+    header[4] = 2  # ELF64
+    header[5] = 1  # little-endian
+    struct.pack_into("<I", header, 0x30, arch)
+    return bytes(header)
+
+
+def _capture(tmp_path: Path, *, ptx: bool, cubin_arch: int = 0) -> Path:
+    root = tmp_path / "capture"
+    fx = root / "inductor" / "fxgraph" / "aa" / "bb"
+    fx.mkdir(parents=True)
+    (fx / "entry").write_bytes(b"fx")
+    kdir = root / "triton" / "k1"
+    kdir.mkdir(parents=True)
+    if ptx:
+        (kdir / "kern.ptx").write_text(".version 8.0")
+    if cubin_arch:
+        (kdir / "kern.cubin").write_bytes(_elf_cubin_bytes(cubin_arch))
+    return root
+
+
+def test_ptx_only_kernel_fails_the_pack_naming_it(tmp_path: Path) -> None:
+    root = _capture(tmp_path, ptx=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        cc.pack(root, tmp_path / "cell.tar.gz", {"sm": "sm_89"})
+    message = str(excinfo.value)
+    assert "PTX" in message and "kern.ptx" in message and "pgw#698" in message
+    assert not (tmp_path / "cell.tar.gz").exists()
+
+
+def test_sm_exact_cubin_packs_and_wrong_arch_refuses(tmp_path: Path) -> None:
+    good = _capture(tmp_path, ptx=True, cubin_arch=89)
+    out = tmp_path / "cell.tar.gz"
+    cc.pack(good, out, {"sm": "sm_89"})
+    assert out.exists()
+
+    bad = _capture(tmp_path / "bad", ptx=True, cubin_arch=86)
+    with pytest.raises(RuntimeError) as excinfo:
+        cc.pack(bad, tmp_path / "bad.tar.gz", {"sm": "sm_89"})
+    assert "sm_86" in str(excinfo.value) and "sm_89" in str(excinfo.value)
+
+
+def test_inductor_only_capture_still_packs(tmp_path: Path) -> None:
+    """No triton kernels at all (the existing fixture shape) stays valid."""
+    root = _capture(tmp_path, ptx=False)
+    out = tmp_path / "cell.tar.gz"
+    cc.pack(root, out, {"sm": "sm_89"})
+    assert out.exists()

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -385,3 +385,167 @@ def test_inductor_only_capture_still_packs(tmp_path: Path) -> None:
     out = tmp_path / "cell.tar.gz"
     cc.pack(root, out, {"sm": "sm_89"})
     assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# cache-design review fixes (ML-systems + build-systems reviews)
+# ---------------------------------------------------------------------------
+
+
+def test_fx_system_shim_normalizes_device_name(monkeypatch: Any) -> None:
+    """P0 (review 6.1, VERIFIED on a real B200 cell: system_info[device] =
+    {'name': 'NVIDIA B200'}): the inner FX key hashes the GPU MARKETING
+    name, so cross-SKU same-sm adoption missed 100% inside torch's own
+    lookup. The shim rewrites the name to the sm token with the hash
+    recomputed via torch's own strategy — two SKUs of one arch become one
+    inner key."""
+    from torch._inductor.codecache import SYSTEM_CACHE_KEY_STRATEGY
+
+    a40 = {"device": {"name": "NVIDIA A40"},
+           "version": {"triton": "tk", "cuda": "13.0"}, "hash": "orig"}
+    rtx = {"device": {"name": "NVIDIA GeForce RTX 3090"},
+           "version": {"triton": "tk", "cuda": "13.0"}, "hash": "orig"}
+    na = cc._normalize_system_info(dict(a40), "sm_86")
+    nb = cc._normalize_system_info(dict(rtx), "sm_86")
+    assert na == nb  # THE portability claim: one arch, one inner key
+    assert na["device"]["name"] == "sm_86"
+    assert na["hash"] != "orig"
+    assert na["hash"] == SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+        {"device": na["device"], "version": na["version"]})
+    # CPU / cuda-less shape passes through untouched.
+    cpu = {"hash": "bare"}
+    assert cc._normalize_system_info(dict(cpu), "sm_86") == cpu
+    # No sm token (non-CUDA runtime): no rewrite.
+    assert cc._normalize_system_info(dict(a40), "") == a40
+
+
+def test_fx_system_shim_installs_idempotently(monkeypatch: Any) -> None:
+    from torch._inductor import codecache
+
+    fake = {"device": {"name": "NVIDIA A40"},
+            "version": {"triton": "tk", "cuda": "13.0"}, "hash": "orig"}
+    monkeypatch.setattr(
+        codecache.CacheBase, "get_system", staticmethod(lambda: dict(fake)))
+    monkeypatch.setattr(cc, "runtime_key", lambda: {
+        "sku": "a40", "sm": "sm_86", "cuda": "13.0", "cuda_driver": "",
+        "torch": "t", "triton": "3", "image_digest": "",
+    })
+    cc._install_fx_system_shim()
+    try:
+        got = codecache.CacheBase.get_system()
+        assert got["device"]["name"] == "sm_86"
+        marked = codecache.CacheBase.get_system
+        cc._install_fx_system_shim()  # second install is a no-op
+        assert codecache.CacheBase.get_system is marked
+    finally:
+        # monkeypatch restores the fake; the shim wrapped the fake only.
+        pass
+
+
+def test_upstream_get_system_shape_is_pinned() -> None:
+    """Version-pin (pgw#705 doctrine): the shim rewrites a structure torch
+    does not contract. If a torch bump changes get_system's shape, this
+    fails LOUDLY before the shim ships against it."""
+    from pathlib import Path as _P
+
+    from torch._inductor import codecache
+
+    source = _P(codecache.__file__).read_text()
+    assert "def get_system()" in source
+    assert "get_device_properties" in source
+    assert "device_properties.name" in source  # the SKU-name pin we rewrite
+    assert "SYSTEM_CACHE_KEY_STRATEGY" in source
+    # The upstream precedent the shim cites: AOTI keys on capability.
+    assert "AOTI_COMPUTE_CAPABILITY" in source
+
+
+def test_semantic_cache_tag_binds_semantic_axes_only() -> None:
+    """Review 6.3: the tag digests format|kind|family|lane|mode|contract —
+    a foreign semantic identity can never consume delivered entries; the
+    environment axes stay OUT so pgw#700 equivalence adoption survives."""
+    import torch.compiler.config as compiler_config
+
+    pipe_a, pipe_b = _Pipe(), _Pipe()
+    tag_same = cc._semantic_cache_tag(pipe_a, _cfg())
+    assert tag_same == cc._semantic_cache_tag(pipe_b, _cfg())
+    assert tag_same != cc._semantic_cache_tag(pipe_a, _cfg(family="other"))
+    assert tag_same != cc._semantic_cache_tag(
+        pipe_a, _cfg(shapes=((32, 32),)))  # contract rides the tag
+    before = compiler_config.cache_key_tag
+    try:
+        cc._set_semantic_cache_tag(pipe_a, _cfg())
+        assert compiler_config.cache_key_tag == tag_same
+    finally:
+        compiler_config.cache_key_tag = before
+
+
+def test_verify_refuses_silent_axes_named(monkeypatch: Any) -> None:
+    """P1 (review 6.9 — the JAX #27814 wrong-hit shape): a cell SILENT on
+    sm/cuda/image_digest/libs was accepted by `if want and ...`. Strict
+    now: absent axis = named refusal."""
+    monkeypatch.setattr(cc, "runtime_key", lambda: {
+        "sku": "l4", "sm": "sm_89", "cuda": "13.0", "cuda_driver": "",
+        "torch": "2.13.0+cu130", "triton": "3.7.1",
+        "image_digest": "sha256:live",
+    })
+    monkeypatch.setattr(cc, "gen_worker_version", lambda: "0.74.0")
+    monkeypatch.setattr(cc, "_lib_versions", lambda: {"diffusers": "0.39.0"})
+    complete = {
+        "format": cc.ARTIFACT_FORMAT, "torch": "2.13.0+cu130",
+        "triton": "3.7.1", "sm": "sm_89", "cuda": "13.0",
+        "image_digest": "sha256:live", "gen_worker": "0.74.0",
+        "libs": {"diffusers": "0.39.0"},
+    }
+    assert cc.verify(dict(complete)) == ""
+    for axis in ("sm", "cuda", "image_digest"):
+        silent = {k: v for k, v in complete.items() if k != axis}
+        assert axis in cc.verify(silent), axis
+    silent_libs = dict(complete, libs={})
+    assert "diffusers" in cc.verify(silent_libs)
+
+
+def test_pytorch_and_triton_env_are_gated(monkeypatch: Any) -> None:
+    """R7 (live defect): the gate matched startswith('TORCH') only, so
+    every PYTORCH_* var evaded it — including the LIVE allocator var
+    PYTORCH_CUDA_ALLOC_CONF — while the allowlist carried the legacy
+    TORCH_CUDA_ALLOC_CONF spelling. TRITON_PTXAS_PATH (silently different
+    cubins) is the TRITON* poster child."""
+    seal = _env_seal()
+    with pytest.raises(seal.EnvSealError, match="PYTORCH_FOO_TOGGLE"):
+        seal.check_torch_env({"PYTORCH_FOO_TOGGLE": "1"})
+    with pytest.raises(seal.EnvSealError, match="TRITON_PTXAS_PATH"):
+        seal.check_torch_env({"TRITON_PTXAS_PATH": "/opt/ptxas"})
+    # The live allocator spellings and the SDK's own redirects are allowed.
+    seal.check_torch_env({
+        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+        "TORCH_CUDA_ALLOC_CONF": "legacy",
+        "TRITON_CACHE_DIR": "/cap/triton",
+        "TORCHINDUCTOR_CACHE_DIR": "/cap/inductor",
+    })
+    seal.check_torch_env()  # the real process env stays clean
+
+
+def test_epoch_salt_disowns_a_generation(monkeypatch: Any) -> None:
+    """R2 (Bazel Action.salt / ccache HASH_PREFIX): bumping COZY_CELL_EPOCH
+    changes every env_seal digest — one config change disowns a poisoned
+    mint generation, no scheme bump."""
+    seal = _env_seal()
+    monkeypatch.delenv(seal.EPOCH_ENV, raising=False)
+    base = seal.effective_seal()
+    assert base["seal_v"] == 2 and base["epoch"] == "0"
+    baseline = seal.seal_digest(base)
+    monkeypatch.setenv(seal.EPOCH_ENV, "1")
+    assert seal.seal_digest(seal.effective_seal()) != baseline
+
+
+def test_content_keys_recorded_in_metadata() -> None:
+    """Review 6.5: torch/triton CONTENT digests ride metadata as the
+    pgw#700 equivalence precondition (a patched wheel under an unchanged
+    version string becomes visible)."""
+    keys = dict(cc.content_keys())
+    assert set(keys) == {"torch", "triton"}
+    assert all(len(v) == 16 for v in keys.values() if v)
+    assert keys["torch"], "torch_key must be computable on this wheel"
+    meta = cc.artifact_metadata(
+        family="toyfam", shapes=((64, 64),), targets=("transformer",))
+    assert meta["content_keys"] == keys

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -183,8 +183,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck3-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
+            family=FAMILY, cell_key="ck4-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck4-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_env_seal_boot_pgw694.py
+++ b/tests/test_env_seal_boot_pgw694.py
@@ -1,0 +1,52 @@
+"""pgw#694/#696 boot wiring: the worker entrypoint establishes the env seal.
+
+The hardening set (chaos a73e6c8) shipped `env_seal.establish()` with the
+executor-side boot wiring deliberately left to the executor owner. This
+pins it: the entrypoint seals the process BEFORE the CUDA probe and before
+any model/compile work, refuses to start on an unsealable environment
+(naming the variable), and the sealed config is effective in-process.
+RED on the unwired tree: `_establish_env_seal` does not exist and
+`_run_main` never seals.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from gen_worker import entrypoint, env_seal
+
+
+def test_entrypoint_refuses_unknown_torch_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TORCHDYNAMO_SUPPRESS_ERRORS", "1")
+    with pytest.raises(env_seal.EnvSealError) as exc:
+        entrypoint._establish_env_seal()
+    assert "TORCHDYNAMO_SUPPRESS_ERRORS" in str(exc.value)
+
+
+def test_entrypoint_establishes_effective_seal() -> None:
+    import torch
+
+    seal = entrypoint._establish_env_seal()
+    # The canonical surface is EFFECTIVE, not merely recorded.
+    assert torch.backends.cudnn.allow_tf32 is False
+    assert torch.backends.cuda.matmul.allow_tf32 is False
+    assert torch.get_float32_matmul_precision() == "highest"
+    # Every canonical entry is effective in the seal (the seal also records
+    # non-canonicalized facts like CUBLAS_WORKSPACE_CONFIG).
+    assert env_seal.CANONICAL_CONFIG.items() <= seal["config"].items()
+    # The digest is the ck4 env_seal axis and is deterministic.
+    assert env_seal.seal_digest(seal) == env_seal.seal_digest(
+        entrypoint._establish_env_seal())
+
+
+def test_run_main_seals_before_cuda_probe_and_worker() -> None:
+    src = inspect.getsource(entrypoint._run_main)
+    seal_at = src.index("_establish_env_seal")
+    assert seal_at < src.index("should_probe_cuda"), (
+        "the seal must be established before the CUDA probe")
+    assert seal_at < src.index("Worker("), (
+        "the seal must be established before the worker starts")

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -477,7 +477,9 @@ def test_adopt_failed_warmup_reports_reason(tmp_path, monkeypatch):
 
 
 def _case_key_mismatch(tmp_path, monkeypatch):
-    _artifact(tmp_path, sku="not-this-gpu")
+    # pgw#691/ck3: sku drift no longer mismatches (metadata-only axis);
+    # torch drift is the representative key mismatch.
+    _artifact(tmp_path, torch="0.0.0+nope")
     ex, sent = _wire_executor(_spec(), tmp_path)
     monkeypatch.setattr(cc, "apply", lambda *a, **k: pytest.fail("must not re-wrap"))
     return ex, sent, {}, None
@@ -1178,7 +1180,7 @@ def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck3-" + "d" * 56
+    mint_key = "ck4-" + "d" * 56
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
@@ -1256,7 +1258,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck3-" + "a1" * 28
+    mint_key = "ck4-" + "a1" * 28
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     store_digest = "blake3:" + "f" * 64  # the store's snapshot-manifest form
@@ -1323,7 +1325,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
         "advertised digest must align to the store's form")
 
     # A genuinely DIFFERENT key still vacates (identity actually moved).
-    other_key = "ck3-" + "b2" * 28
+    other_key = "ck4-" + "b2" * 28
     other_ref = f"root/family-{FAMILY}#{other_key}"
 
     class _OtherKey:
@@ -1368,7 +1370,7 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
         compile=Compile(shapes=((768, 768),), family=FAMILY, text_len=0),
     )
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck3-" + "f" * 56
+    mint_key = "ck4-" + "f" * 56
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
     mint_artifact.parent.mkdir()
     mint_artifact.write_bytes(b"cell-bytes")
@@ -1439,7 +1441,7 @@ def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
     monkeypatch.setattr(cc, "toolchain_present", lambda: True)
 
     class _Key:
-        digest = "ck3-" + "9" * 56
+        digest = "ck4-" + "9" * 56
 
     monkeypatch.setattr(cell_key_mod, "compute", lambda *a, **k: _Key())
     captured: dict = {}
@@ -3796,7 +3798,7 @@ def test_fresh_boot_advertises_candidate_cell_lookups(monkeypatch):
     computed: list = []
 
     class _Key:
-        digest = "ck3-" + "5" * 56
+        digest = "ck4-" + "5" * 56
 
     def _compute(family, lane="", bucket=0, **kw):
         computed.append((family, lane))

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -449,7 +449,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck3-" + digest, axes={})
+    return SimpleNamespace(digest="ck4-" + digest, axes={})
 
 
 SHAPE = (768, 768)

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -101,7 +101,8 @@ def test_store_verdict_hit(tmp_path):
     [
         ({"torch": "0.0.0+nope"}, "torch"),
         ({"gen_worker": "0.0.0-not-this"}, "gen_worker"),
-        ({"sku": "not-this-gpu"}, "sku"),
+        # pgw#691/ck3: sku is no longer identity — sm carries the arch pin.
+        ({"sm": "sm_00"}, "sm"),
         ({"format": 99}, "format"),
         ({"weight_lane": "fp8-hooks"}, "lane"),   # lane drift, symmetric
         ({"compile_mode": "regional"}, "mode"),

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -205,8 +205,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck3-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
+            family=FAMILY, cell_key="ck4-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck4-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -212,8 +212,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck3-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck3-{'a' * 56}",
+            family=FAMILY, cell_key="ck4-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck4-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
@@ -547,8 +547,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root = tmp_path / "m"
         (mint_root / "capture").mkdir(parents=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck3-" + "b" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck3-{'b' * 56}",
+            family=FAMILY, cell_key="ck4-" + "b" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck4-{'b' * 56}",
             cfg=None, target=mint_root / "cell.tar.gz",
             capture_dir=mint_root / "capture", mint_root=mint_root,
             publisher=None, cache_dir=None,
@@ -568,8 +568,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root2 = tmp_path / "m2"
         (mint_root2 / "capture").mkdir(parents=True)
         pending2 = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck3-" + "c" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck3-{'c' * 56}",
+            family=FAMILY, cell_key="ck4-" + "c" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck4-{'c' * 56}",
             cfg=None, target=mint_root2 / "cell.tar.gz",
             capture_dir=mint_root2 / "capture", mint_root=mint_root2,
             publisher=None, cache_dir=None,

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -185,7 +185,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck3-" + digest, axes={})
+    return SimpleNamespace(digest="ck4-" + digest, axes={})
 
 
 def _endpoint_cls(shapes: tuple) -> type:
@@ -324,7 +324,7 @@ def test_second_same_family_arm_mints_its_own_graphs_and_finalizes(
     }
     assert len(refs) == 2, "two distinct cells, each proven by its own boot"
     for ref in refs:
-        assert ref.startswith(f"root/family-{FAMILY}#ck3-")
+        assert ref.startswith(f"root/family-{FAMILY}#ck4-")
         assert cc.cell_proven_in_process(ref)
     with fleet_cells._PENDING_LOCK:
         assert fleet_cells._PENDING == {}

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.2"
+version = "0.70.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
One train (per coordinator GO): the pgw#694 hardening set (chaos a73e6c8: posture seal, env_seal config freeze, composition fingerprint v2, cubin gate, verify() sku demotion), the executor-side env_seal boot wiring (chaos 4456ed5: the entrypoint seals FIRST, refuses unsealable env typed), and the ML-cache-review fixes (chaos 23a34bd: the P0 inner-inductor-FX-key sm-normalization shim — B200-verified, unblocks cross-SKU same-sm adoption — plus strict verify(), cache_key_tag/content_keys, PYTORCH*/TRITON* env gating, seal-v2 epoch salt).

ck3 -> ck4: the second and FINAL planned key-scheme bump; one cell_exchange_key_split alarm per (endpoint, family) + a one-time re-mint wave is planned, not a regression. Publish-intent attestation unaffected.

Gates on this head: full suite 1123 passed / 0 failed / 9 skipped / 1 xfailed; mypy clean (153 files); ruff clean. One CI run on this final head only. (th#1232's pre-existing hub-side CI red is unrelated to this repo.)

Unblocks: prod sdxl 0.2.12 and the four-part cell-reusability evidence package (two-pod adoption incl. the cross-SKU leg, burst re-run, closure consolidate audit, double-mint identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)