### PR TITLE
release: gen-worker 0.70.4 — pgw#696 P0 hotfix: the env gate killed every fleet pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.70.4 (2026-07-26) — pgw#696 P0 hotfix: the env gate killed every fleet pod
+
+0.70.3's `PYTORCH*` prefix widening + the boot-wired seal composed into a
+fleet-killer: the official `pytorch/pytorch` serving base stamps
+`PYTORCH_VERSION=2.13.0`, the gate refused it, and every pod exited
+pre-hello as a silent provider `pod_exited` (sdxl 0.2.12 was rolled back
+on prod). Build-info constants (`PYTORCH_VERSION`, `PYTORCH_BUILD_VERSION`,
+`PYTORCH_BUILD_NUMBER`) are allowlisted, and the seal now runs AFTER
+settings so a genuine refusal dials the hub as the typed `worker_fatal
+phase=env_seal` instead of dying dark. (Allowlist additions do not touch
+the seal digest — only present gated vars enter identity.)
+
 ## 0.70.3 (2026-07-26) — pgw#694 determinism hardening + cache-review fixes (ck4 keys, env-seal boot wiring, inner-FX sm shim)
 
 One train: the pgw#694 hardening set (chaos a73e6c8), its executor-side boot wiring (`entrypoint._establish_env_seal`), and the ML-cache-review fixes (chaos 23a34bd — the P0 inner-inductor-cache portability shim, B200-verified). ck3 -> ck4 is the second and final planned key-scheme bump; expect one `cell_exchange_key_split` alarm per (endpoint, family) and a one-time re-mint wave.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.3"
+version = "0.70.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -272,20 +272,22 @@ def _establish_env_seal() -> Dict[str, Any]:
 def _run_main() -> int:
     _log_startup_phase("boot", status="starting")
     _install_stack_dump_handler()
-    # pgw#696: seal the execution environment first — before settings can
-    # pull torch-adjacent config and before the CUDA probe touches the
-    # device. An unsealable process refuses to start, naming the variable.
-    try:
-        _establish_env_seal()
-    except Exception as e:
-        _log_worker_fatal("env_seal", e, exit_code=1)
-        logger.error(str(e))
-        return 1
     try:
         settings = get_settings()
     except Exception as e:
         logger.exception("Failed to load worker settings: %s", e)
         _log_worker_fatal("settings_load", e, exit_code=1)
+        return 1
+    # pgw#696: seal the execution environment before the CUDA probe touches
+    # the device and before any model/compile work. Ordered AFTER settings
+    # (which reads no torch config) so a refusal can DIAL THE HUB typed —
+    # the 0.70.3 pre-settings ordering made a seal refusal a silent
+    # pod_exited the fleet could not attribute.
+    try:
+        _establish_env_seal()
+    except Exception as e:
+        _log_worker_fatal("env_seal", e, exit_code=1, settings=settings)
+        logger.error(str(e))
         return 1
     manifest_path = Path(settings.endpoint_lock_path or MANIFEST_PATH)
     manifest = load_manifest(manifest_path)

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -92,6 +92,14 @@ ENV_ALLOWLIST = frozenset({
     "PYTORCH_CUDA_ALLOC_CONF",     # allocator sizing (live spelling)
     "PYTORCH_ALLOC_CONF",          # allocator sizing (2.13 preferred)
     "PYTORCH_NVML_BASED_CUDA_CHECK",  # probe-only: how availability is checked
+    # Build-info constants stamped by the official pytorch/pytorch base
+    # images (the fleet's serving base sets PYTORCH_VERSION=2.13.0). They
+    # are informational, not toggles — but the R7 prefix widening made the
+    # gate refuse them, which killed EVERY fleet pod at boot (silent
+    # pod_exited before hello; sdxl 0.2.12 rollback, 2026-07-26).
+    "PYTORCH_VERSION",
+    "PYTORCH_BUILD_VERSION",
+    "PYTORCH_BUILD_NUMBER",
     "TORCHINDUCTOR_CACHE_DIR",     # the SDK's own mint-capture redirect
     "TORCHINDUCTOR_AUTOGRAD_CACHE",  # set by the SDK's capture machinery
     "TRITON_CACHE_DIR",            # the SDK's own mint-capture redirect

--- a/tests/test_env_seal_boot_pgw694.py
+++ b/tests/test_env_seal_boot_pgw694.py
@@ -50,3 +50,23 @@ def test_run_main_seals_before_cuda_probe_and_worker() -> None:
         "the seal must be established before the CUDA probe")
     assert seal_at < src.index("Worker("), (
         "the seal must be established before the worker starts")
+    # 0.70.3 regression: sealed BEFORE settings, so a refusal could not
+    # dial the hub — every fleet pod died as a silent pod_exited.
+    assert src.index("get_settings") < seal_at, (
+        "the seal must run after settings so a refusal dials the hub typed")
+    assert "settings=settings" in src[src.index("_establish_env_seal"):
+                                      src.index("should_probe_cuda")]
+
+
+def test_base_image_build_constants_are_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fleet's pytorch/pytorch base image stamps PYTORCH_VERSION (and
+    siblings). RED on 0.70.3: the R7 prefix widening refused them and every
+    pod on the fleet base image died at boot before hello (the sdxl 0.2.12
+    rollback)."""
+    monkeypatch.setenv("PYTORCH_VERSION", "2.13.0")
+    monkeypatch.setenv("PYTORCH_BUILD_VERSION", "2.13.0")
+    monkeypatch.setenv("PYTORCH_BUILD_NUMBER", "1")
+    env_seal.check_torch_env()  # must not raise
+    entrypoint._establish_env_seal()

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.3"
+version = "0.70.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
0.70.3 fleet-killer hotfix, solo train (P0). The official pytorch/pytorch serving base stamps PYTORCH_VERSION=2.13.0; 0.70.3's PYTORCH* prefix gate refused it and EVERY pod exited pre-hello as a silent provider pod_exited (sdxl 0.2.12 rolled back on prod within minutes). Fix: build-info constants allowlisted (PYTORCH_VERSION/BUILD_VERSION/BUILD_NUMBER — informational, not toggles; digest unaffected), and the seal ordered AFTER settings so a genuine refusal dials the hub as typed worker_fatal phase=env_seal instead of dying dark. Red tape: test_base_image_build_constants_are_allowlisted + the ordering assert. Full suite 1124 passed / 0 failed; mypy + ruff clean. One CI run on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)