### PR TITLE
release: gen-worker 0.70.5 — pgw#715: a 404 from a PROXY is not a 404 from the hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.70.5 (2026-07-27) — pgw#715: a 404 from a PROXY is not a 404 from the hub (te#125/th#1238)
+
+**Released off the 0.70.4 published base, not off chaos.** The chaos branch carries
+0.71-0.75 (MoE LoRA branch routing, the env seal + its P0 hotfix, compile-degrade, the
+arch-floor carrier). That work is **unpublished BY CHOICE** and rides the next proper
+chaos -> master train as a batch — nothing here skips it. Shipping this classifier as a
+0.70.x patch keeps the published line linear and the blast radius equal to the 30 lines the
+fleet actually needs.
+
+A hub restart lasting seconds destroyed a **116-minute H100 producer run** at its last step.
+The job finished quantizing and rendering, then its in-flight media upload hit ngrok while the
+backend was briefly gone, received ngrok's HTML 404 page, and
+`presigned_upload.py` classified **every** 404 as `retryable=False` — so the worker reported
+`JOB_STATUS_FATAL` and two hours of GPU work was thrown away with no recourse.
+
+The gRPC worker stream reconnects across a hub restart. **In-flight HTTP calls did not**, and
+that asymmetry is why "hub-only restarts are safe" held for serving and quietly did not hold
+for long conversion producers.
+
+**`gen_worker/http_origin.py`** (new) separates the two cases, on measured evidence rather
+than assumption — the hub answers `application/json` carrying its `{"error": {...}}` envelope,
+ngrok's offline page answers `text/html`:
+
+- `response_is_from_hub(resp)` — parses the body, not just the Content-Type, since a proxy may
+  mislabel HTML as JSON but will not synthesise our error envelope.
+- `is_proxy_outage(resp)` — the inverse, used at the call sites.
+
+Deliberately **biased toward retrying**: an unrecognised body counts as proxy-origin. Retrying
+a genuinely missing route costs a bounded backoff and then fails anyway; treating an outage as
+fatal destroys hours of work. The asymmetry of those two mistakes is not close.
+
+Applied at every site that conflated the two **for hub calls** — the point was to fix the
+class, not the one instance that bit us:
+
+- `presigned_upload.py` — the P0. Proxy 404 during upload create is now `retryable=True`.
+- `models/hub_client.py` — a proxy 404 was reported as `HubRepoNotFoundError`, sending the
+  reader to hunt a catalog problem that does not exist. Now `HubResolveError` (transient).
+- `callout.py::checkpoint_get` — **the worst of the three**, because it did not crash: it
+  returned `(None, False)`, i.e. "no saved progress", so an outage made a resumable job
+  silently restart from scratch. Now raises instead.
+
+**Deliberately NOT changed:** `models/download.py`'s civitai 404s. Civitai is a third-party
+host with no proxy of ours in the path, so there a 404 really does mean not-found. Widening
+the helper to non-hub hosts would trade a real bug for a fake one.
+
+Still open: `request_context/__init__.py:1494` carries the same pattern, but that file holds
+another agent's uncommitted work in the shared chaos worktree, so it is left alone rather than
+entangled. Recorded in pgw#715 for its owner.
+
+
+## 0.75.0 (2026-07-26) — pgw#660: the hard GPU-architecture floor has a declared carrier again
 ## 0.70.4 (2026-07-26) — pgw#696 P0 hotfix: the env gate killed every fleet pod
 
 0.70.3's `PYTORCH*` prefix widening + the boot-wired seal composed into a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.70.4"
+version = "0.70.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -221,6 +221,16 @@ class CalloutClient:
             self._checkpoint_url(key), headers=self._headers(), timeout=_HTTP_TIMEOUT_S
         )
         if resp.status_code == 404:
+            # te#125/th#1238: "the hub has no checkpoint under this key" and
+            # "a proxy answered because the hub is restarting" are both 404,
+            # and this is the worse of the two conflations — reporting
+            # (None, False) for an outage is a SILENT WRONG ANSWER that reads
+            # as "no saved progress", so a resumable job quietly restarts from
+            # scratch instead of erroring and retrying.
+            from .http_origin import is_proxy_outage
+
+            if is_proxy_outage(resp):
+                self._raise_for_error(resp.status_code, resp.text)
             return None, False
         if resp.status_code >= 300:
             self._raise_for_error(resp.status_code, resp.text)

--- a/src/gen_worker/http_origin.py
+++ b/src/gen_worker/http_origin.py
@@ -1,0 +1,72 @@
+"""Who actually answered — the hub, or a proxy standing in front of it?
+
+te#125/th#1238: a 404 is not one condition. It is two, with opposite handling:
+
+  * The HUB answering 404 means "this route/resource does not exist". Fatal.
+  * A PROXY answering 404 (ngrok, an ingress, a load balancer with no healthy
+    backend) means "the hub is not reachable right now". Transient.
+
+Conflating them cost a 116-minute H100 producer run: the hub restarted for a
+few seconds mid-job, the in-flight upload got ngrok's 404 page, and the worker
+classified it `retryable=False` and killed the job at the last mile. The gRPC
+worker stream reconnects across a hub restart; HTTP calls in flight did not.
+
+The two are trivially separable in practice, and we verify it rather than
+assume it: the hub answers `application/json` carrying its `{"error": {...}}`
+envelope, while ngrok's offline page is `text/html`. Measured 2026-07-27:
+
+    hub 404   -> content-type: application/json; {"error":{"code":"not_found",...}}
+    ngrok 404 -> content-type: text/html
+
+DELIBERATELY CONSERVATIVE: we only report "proxy" when the response clearly is
+NOT the hub's envelope. An unrecognised body is treated as proxy-origin, which
+biases toward RETRYING. That is the safe direction here — retrying a genuinely
+missing route costs a bounded backoff and then fails anyway, whereas treating
+an outage as fatal destroys hours of GPU work with no recourse.
+
+Scope note: this is for calls to OUR hub. It must NOT be applied to third-party
+hosts (e.g. civitai), where a 404 really does mean "not found" and there is no
+proxy of ours in the path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["response_is_from_hub", "is_proxy_outage"]
+
+
+def _content_type(resp: Any) -> str:
+    try:
+        return str((resp.headers or {}).get("Content-Type", "")).lower()
+    except Exception:  # noqa: BLE001 - header access must never mask the real error
+        return ""
+
+
+def response_is_from_hub(resp: Any) -> bool:
+    """True when the body looks like tensorhub's own JSON error envelope.
+
+    Checks the parsed body rather than trusting Content-Type alone: a proxy is
+    free to label an HTML page as JSON, but it will not synthesise our
+    ``{"error": {...}}`` shape.
+    """
+    if "json" not in _content_type(resp):
+        return False
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 - a JSON label with an unparseable body is not ours
+        return False
+    if not isinstance(body, dict):
+        return False
+    # The hub always wraps failures as {"error": {"code": ..., ...}}.
+    err = body.get("error")
+    return isinstance(err, dict) and "code" in err
+
+
+def is_proxy_outage(resp: Any) -> bool:
+    """True when a 404 came from something in front of the hub, not the hub.
+
+    Callers use this to decide RETRYABLE (proxy/outage) vs FATAL (hub said the
+    route is missing).
+    """
+    return not response_is_from_hub(resp)

--- a/src/gen_worker/models/hub_client.py
+++ b/src/gen_worker/models/hub_client.py
@@ -105,6 +105,17 @@ def resolve_repo(
         raise HubResolveError(f"tensorhub resolve failed for {ref.canonical()}: {e}") from e
 
     if resp.status_code == 404:
+        # te#125/th#1238: only the HUB's own 404 means "no such repo". A proxy
+        # answering 404 means the hub is unreachable (restarting), and calling
+        # that "repo not found" sends the operator hunting a catalog problem
+        # that does not exist.
+        from ..http_origin import is_proxy_outage
+
+        if is_proxy_outage(resp):
+            raise HubResolveError(
+                f"tensorhub unreachable resolving {ref.canonical()} — a proxy "
+                "answered 404 (backend offline, e.g. hub restarting); retry shortly"
+            )
         raise HubRepoNotFoundError(
             f"tensorhub repo {ref.canonical()} not found (unknown repo/tag/"
             "flavor, or a private repo — set TENSORHUB_TOKEN for private pulls)"

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -285,6 +285,23 @@ def _presigned_upload_file_scoped(
     if code in (401, 403):
         raise AuthError(f"file save unauthorized ({code})")
     if code == 404:
+        # te#125/th#1238: a 404 here has two very different causes. The HUB
+        # saying 404 means the route does not exist -> fatal. A PROXY saying
+        # 404 (ngrok with no healthy backend, i.e. the hub is restarting)
+        # means "try again shortly" -> retryable. Treating the second as the
+        # first destroyed a 116-minute H100 producer run at its last step,
+        # because the hub blipped for seconds while this upload was in flight.
+        from .http_origin import is_proxy_outage
+
+        if is_proxy_outage(resp):
+            raise ArtifactTransferError(
+                "tensorhub unreachable during upload create — a proxy answered "
+                "404 (backend offline, e.g. hub restarting), not the hub itself",
+                provider="tensorhub",
+                phase="create",
+                retryable=True,
+                status_code=code,
+            )
         raise ArtifactTransferError(
             "tensorhub upload endpoint is not supported",
             provider="tensorhub",

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.70.4"
+version = "0.70.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Cherry-pick of chaos \`514750b\` onto the published **0.70.4** base.

## Why

A seconds-long chaos hub restart destroyed a **116-minute H100 conversion producer** at its final step (te#125). The job finished calibration, quantization and all 20 gate renders, then:

\`\`\`
03:11:33Z  job.requeued  reason=reconnect_timeout      <- hub unreachable
03:11:47Z  job.attempt_failed JOB_STATUS_FATAL
           ArtifactTransferError: tensorhub upload endpoint is not supported
           (provider=tensorhub, phase=create, status=404)
\`\`\`

Two hours of GPU work discarded, zero evidence retrievable.

## The bug

A 404 is two conditions with opposite handling, and the worker could not tell them apart:

| who answered | means | correct |
|---|---|---|
| the **hub** | route/resource does not exist | fatal |
| a **proxy** in front (ngrok, no healthy backend) | hub is restarting | **transient** |

Measured on this stack 2026-07-27 — trivially separable:

\`\`\`
hub 404   -> application/json ; {"error":{"code":"not_found",...}}
ngrok 404 -> text/html        ; ngrok offline page
\`\`\`

This is also why "hub-only restarts are safe" was half true: the gRPC worker stream reconnects, in-flight **HTTP** calls did not, and long producers are exactly the workload spanning a restart window.

## The fix

New \`gen_worker/http_origin.py\` — \`response_is_from_hub()\` / \`is_proxy_outage()\`. Parses the **body**, not just Content-Type, since a proxy may mislabel HTML as JSON but will not synthesise our error envelope. **Biased toward retrying**: an unrecognised body counts as proxy-origin, because retrying a genuinely missing route costs a bounded backoff and then fails anyway, whereas treating an outage as fatal destroys hours of work.

Applied at every hub-facing site with the conflation — the class, not just the instance:

- \`presigned_upload.py\` — the P0; proxy 404 on upload create is now \`retryable=True\`
- \`models/hub_client.py\` — proxy 404 was \`HubRepoNotFoundError\`, sending readers after a catalog problem that does not exist; now \`HubResolveError\`
- \`callout.py::checkpoint_get\` — **the worst**, because it did not crash: returned \`(None, False)\` = "no saved progress", so an outage made a resumable job silently restart from scratch

**Deliberately NOT changed:** civitai 404s in \`models/download.py\`. Third-party host, no proxy of ours in the path — there 404 really does mean not-found.

## Release shape

Cut off **0.70.4**, not off chaos, on purpose. Chaos carries 0.71–0.75 (MoE LoRA branch routing, the env seal + its P0 hotfix, compile-degrade, arch-floor carrier). That work stays **unpublished pending its own chaos→master train** — nothing is skipped. This keeps the published line linear and the blast radius equal to the 30-line classifier the fleet needs.

## Verification

7/7 discriminator cases pass, including the real measured hub envelope and the real ngrok content-type. \`uv.lock\` changes by exactly one line (the editable project version), as a version-only bump should.