### PR TITLE
release: gen-worker 0.76.2 — pgw#739 export-input declaration + pgw#740 B5/B6 vocabulary sweep + pgw#746 OQ-7, plus two commits recovered from 0.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## 0.76.2 (2026-07-27) — the export-input contract becomes a DECLARATION; the component vocabulary stops being copy-pasted
+
+Version note: **0.76.1 was claimed by pgw#738 and is not published** — that lane's work
+is still uncommitted, so the line goes 0.76.0 -> 0.76.2 and the claim stays reserved.
+
+This train also carries two commits that were STRANDED — complete on chaos, recorded in
+the tracker as shipped, but absent from the published 0.76.0 wheel because the 0.76.0
+release branch was cut without them (pgw#744 and the ie#566 G3 correction, below).
+
+### pgw#744: `kind="eval"` — a measure-only function kind (th#1255)
+
+**Stranded from 0.76.0.** pgw#744 claimed 0.76.0 and stamped it on chaos, but the
+published wheel has only four legal kinds. `KINDS` now carries the fifth. An eval
+function MEASURES a candidate against a reference: it reads inputs and emits metrics but
+publishes no catalog repo — the hub refuses repo writes for eval tokens and never asks
+an eval where its output repo goes.
+
+### ie#566 G3 correction: pin detection is guard evidence, not integer arithmetic
+
+**Also stranded from 0.76.0.** The published wheel refuses a pinned relational axis by
+testing whether the static dim is an integer multiple of the product of the declared
+dynamic extents — which false-passes. The correction reads the exported program's actual
+guards instead. Without it pgw#739's `test_pinned_relational_axis_is_still_refused` fails
+against its own gate, which is how the gap surfaced.
+
+### pgw#739: the export-input contract is a DECLARATION
+
+The SDK shipped sdxl's export inputs as worker code (`aot_inputs.sdxl_unet_inputs`,
+`_sdxl_cfg_batched`, `SDXL_POOLED_DIM`, `SDXL_TIME_IDS`). All of it is deleted. `Compile`
+gains the pgw#739 vocabulary — named `dims` with `(input, axis)` bindings, graph-class
+`forks` bound to a `(source, field)`, resolved coordinate `classes`, `inputs`/`args`,
+`shape_strategy`, `warm_changes_key`, `eager` — and `aot_declaration` derives export
+inputs generically from it. No formula DSL: rows are resolved by the endpoint's own
+legality oracle and declared. sdxl and wan-2.2 are the first two real declarations.
+
+### pgw#723 residuals: three mint obligations banked as gates, not lore
+
+- An AOTI package takes **positional** inputs only. A kwarg-traced package refuses a
+  positional call and the lane silently revokes to eager, so all-positional example
+  feeds are now a MINT obligation rather than a convention.
+- `load_constants` is **FQN-keyed**; the constant-set drift gate is asymmetric.
+- The lifted-LoRA path takes a torch 2.13 floor.
+- Serve docs close the folding caveat: strict holds vs folding artifacts, folds
+  recompute from fresh binds, and the default config never folds.
+
+### pgw#740 B5/B6: ONE component vocabulary, actually used
+
+The vocabulary module landed in 0.76.0; the 20+ copies of `("transformer","unet",…)`
+did not go away. All 18 files are repointed — and the repoint is not a rename. Every
+copy was a **module-level tuple**, evaluated at import, while an endpoint's
+`declare_components()` runs at endpoint-module import, which is later. A module-level
+snapshot therefore froze the pre-declaration vocabulary and dropped exactly the
+components the declaration exists to add. Consumers now read through a call, and
+`apply_block_window_offload` plus two `convert/writer.py` entrypoints lose their default
+**arguments** for the same reason (a default is evaluated at def time).
+
+Three distinct sets were being copied, so the vocabulary grows the selectors that tell
+them apart: `weight_components` (walk/size/offload — includes VAEs),
+`quant_candidate_components` (excludes VAEs; QUANTIZATION-POLICY.md keeps them at
+compute precision), and `pipeline_component_dirs`. A fifth `auxiliaries` group holds the
+weight-bearing non-roles the convert copies carried (`controlnet`, `prior`, `decoder`,
+`image_encoder`) and retires `weight_components`' `or name == "image_encoder"` special
+case.
+
+The live correctness gap this closes: Wan MoE's `transformer_2` and a declared LTX
+`connectors` now reach every consumer, including the size walk the orchestrator gates
+VRAM placement on — an undeclared component previously contributed zero bytes.
+
+`convert/writer.py:FP8_TE_COMPONENTS` is **deleted**: its comment promised a drift guard
+in `tests/test_fp8_te_writer.py`, a file that does not exist. The drift is removed by
+removing the copy.
+
+### pgw#746 (OQ-7): `Compile(regional=True, dynamic=(...))` is refused by name
+
+`_with_declared_marks` runs only on the whole-graph branch; the regional branch calls
+`compile_repeated_blocks(dynamic=None)` and returns before the marks are reached — while
+`declared_contract_facts` folds the same `dynamic=` row into the contract digest. The key
+asserted a contract the artifact did not honor, the failure class pgw#716 exists to
+prevent. Refused at declaration time rather than marked: regional is retiring in favor of
+whole-graph export (LTX-AOT-DESIGN.md §3.2), so teaching a departing lane to mark would
+build on sand. No endpoint declares the combination today.
+
+
 ## 0.76.0 (2026-07-27) — P0: every self-mint fleet-wide was refused at pack; plus the ck5->ck6 identity arc, the AOT lanes (dark), and the fp8 restructure
 
 ### P0 (pgw#733): guard sources resolve their EMBEDDED root — no cell could be published, on any family

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.76.0"
+version = "0.76.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -26,6 +26,14 @@ from .api.decorators import (
     variant_of,
     worker_function,
 )
+from .api.export_contract import (
+    Arg,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+    register_export_declaration,
+)
 from .api.formula import RuntimeFormula
 from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
@@ -85,6 +93,13 @@ __all__ = [
     "CompileAxis",
     "AxisClass",
     "DynamicDim",
+    # pgw#739 export-declaration vocabulary.
+    "Dim",
+    "Fork",
+    "GraphClass",
+    "Input",
+    "Arg",
+    "register_export_declaration",
     "ConfigParam",
     "NoWarmup",
     "arm_compile",

--- a/src/gen_worker/aot_declaration.py
+++ b/src/gen_worker/aot_declaration.py
@@ -361,10 +361,19 @@ def declared_inputs(
     Widths come from the module's own config where the declaration says so;
     sizes come from the SELECTED CLASS ROW (which row seeds the trace
     decides nothing for a collapsed artifact — the derived range does).
+
+    The returned kwargs dict is ALWAYS empty: all-positional example feeds
+    are a mint obligation (pod 9, pgw#723 residuals — the AOTI package call
+    convention mirrors the traced args/kwargs split and the serve marshal
+    is positional), so every declared row — including nested containers and
+    the lifted-LoRA pair — is bound to its slot in the traced signature and
+    fed positionally, with signature defaults filling undeclared slots in
+    between. A declared name the target only takes keyword-only is refused
+    by name: such a target cannot meet the fleet call convention.
     """
     import torch
 
-    from .aot_inputs import lifted_lora_kwargs, module_dtype_device
+    from .aot_inputs import lifted_lora_values, module_dtype_device
 
     rows = target_inputs(decl, spec.target)
     if not rows:
@@ -380,8 +389,7 @@ def declared_inputs(
     config = getattr(module, "config", None)
     mod_dtype, device = module_dtype_device(module)
 
-    args: List[Any] = []
-    kwargs: Dict[str, Any] = {}
+    values: Dict[str, Any] = {}
     for row in rows:
         if row.dtype:
             name = _DTYPES.get(row.dtype)
@@ -406,14 +414,76 @@ def declared_inputs(
             tensor = torch.randn(shape, dtype=dtype, device=device)
         else:
             tensor = torch.ones(shape, dtype=dtype, device=device)
-        if row.positional:
-            args.append(tensor)
-        else:
-            _nest(kwargs, row.name, tensor)
+        _nest(values, row.name, tensor)
     for arg in target_args(decl, spec.target):
-        _nest(kwargs, arg.name, arg.value)
-    kwargs.update(lifted_lora_kwargs(module, spec))
-    return tuple(args), kwargs
+        _nest(values, arg.name, arg.value)
+    values.update(lifted_lora_values(module, spec))
+    return _positionalize(module, spec.target, decl.family, values), {}
+
+
+def _positionalize(
+    module: Any, target: str, family: str, values: Dict[str, Any],
+) -> Tuple[Any, ...]:
+    """Bind named values to their slots in the traced signature, all-positional.
+
+    Undeclared slots BETWEEN declared ones are filled with their signature
+    defaults; trailing undeclared slots are omitted. Refusals by name: a
+    declared name that is not a parameter (declaration/module drift), a
+    keyword-only declared name (cannot meet the positional serve marshal),
+    and a required in-between parameter with no default and no declaration.
+    """
+    import inspect
+
+    attr = target.rsplit(".", 1)[1] if "." in target else "forward"
+    fn = getattr(module, attr, None)
+    if fn is None:
+        raise MintRefused(
+            f"family {family!r}: resolved module {type(module).__name__} has "
+            f"no callable {attr!r} to read a signature from")
+    try:
+        params = list(inspect.signature(fn).parameters.values())
+    except (TypeError, ValueError) as exc:
+        raise MintRefused(
+            f"family {family!r}: cannot read the signature of {attr!r} on "
+            f"{type(module).__name__} ({exc}); without it the declared "
+            f"inputs cannot be bound to positional slots") from exc
+    positional = [
+        p for p in params
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        and p.name != "self"
+    ]
+    keyword_only = {p.name for p in params if p.kind == p.KEYWORD_ONLY}
+
+    hit = sorted(keyword_only & set(values))
+    if hit:
+        raise MintRefused(
+            f"family {family!r}: declared input(s) {hit!r} are KEYWORD-ONLY "
+            f"parameters of {attr!r} — all-positional example feeds are a "
+            f"mint obligation (the AOTI package call convention mirrors the "
+            f"traced args/kwargs split and the serve marshal is positional; "
+            f"pod 9, pgw#723 residuals), so this target cannot be exported "
+            f"as declared")
+    names = [p.name for p in positional]
+    unknown = sorted(set(values) - set(names))
+    if unknown:
+        raise MintRefused(
+            f"family {family!r}: declared input(s) {unknown!r} are not "
+            f"parameters of {attr!r} on {type(module).__name__} "
+            f"(parameters: {names!r}) — the declaration does not fit this "
+            f"module")
+    last = max(names.index(n) for n in values)
+    args: List[Any] = []
+    for p in positional[: last + 1]:
+        if p.name in values:
+            args.append(values[p.name])
+        elif p.default is not inspect.Parameter.empty:
+            args.append(p.default)
+        else:
+            raise MintRefused(
+                f"family {family!r}: parameter {p.name!r} of {attr!r} sits "
+                f"before declared inputs, is not declared, and has no "
+                f"default — the positional feed cannot skip it")
+    return tuple(args)
 
 
 def _nest(kwargs: Dict[str, Any], dotted: str, value: Any) -> None:

--- a/src/gen_worker/aot_declaration.py
+++ b/src/gen_worker/aot_declaration.py
@@ -1,0 +1,521 @@
+"""Derivation over the pgw#739 export-declaration vocabulary.
+
+:mod:`gen_worker.api.export_contract` defines the vocabulary and holds the
+registry; the endpoint writes the declaration; THIS module derives everything
+the mint needs from it — mint plans, dynamic-shape rows, fork assertions, and
+generic example inputs. No family name appears here (the #740 pattern:
+vocabulary / registration / engine, family-free all three).
+
+The one derivation rule
+-----------------------
+**Bounds derive from the declared class rows.** A dim's admissible range is
+the hull of its resolved values over the rows an artifact serves, rounded OUT
+to its ``multiple_of`` (rounding in would exclude a declared coordinate from
+the artifact's own contract, and pgw#704 B2 measured that nothing at runtime
+would refuse the difference). This is uniform across plain and RELATIONAL
+dims: a relational dim (``relates_to``) gets a free ranged
+``torch.export.Dim`` from the same hull and the solver unifies the relation
+into the shape env (ie#566 §5, measured on wan ti2v: ``31*s25*s56`` carried
+with 458 asserts, no free symbol surviving). The endpoint never hand-computes
+a bound — that hand-math is exactly what this module exists to prevent.
+
+Shape strategy (#730 ratified, per-family declared):
+
+- ``static-rows`` — one mint plan per class row, no dynamic dims (symbolic
+  latent H/W costs conv families the channels-last layout opt, +7.2%);
+- ``dynamic-collapse`` — one mint plan per FORK coordinate; dims that vary
+  across the coordinate's rows become declared-dynamic over their hull.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .aot_mint import DynamicDim, ExportSpec, MintRefused
+from .api.decorators import Compile
+from .api.export_contract import (
+    DYNAMIC_COLLAPSE,
+    STATIC_ROWS,
+    Arg,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+    export_declaration,
+)
+
+logger = logging.getLogger(__name__)
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class MintPlan:
+    """One artifact the declaration says to mint: a fork coordinate, the
+    class rows the artifact serves, the row that seeds the trace, and the
+    derived declared-dynamic rows for one target."""
+
+    family: str
+    target: str
+    fork: Tuple[Tuple[str, Any], ...]
+    rows: Tuple[GraphClass, ...]
+    seed: GraphClass
+    dynamic: Tuple[DynamicDim, ...]
+
+
+def target_inputs(decl: Compile, target: str) -> Tuple[Input, ...]:
+    return tuple(i for i in decl.inputs if not i.targets or target in i.targets)
+
+
+def target_args(decl: Compile, target: str) -> Tuple[Arg, ...]:
+    return tuple(a for a in decl.args if not a.targets or target in a.targets)
+
+
+def target_forks(decl: Compile, target: str) -> Tuple[Fork, ...]:
+    return tuple(f for f in decl.forks if not f.targets or target in f.targets)
+
+
+def _target_input_names(decl: Compile, target: str) -> Optional[frozenset]:
+    """Top-level input names declared for a target; None when the declaration
+    carries no input templates (bindings then pass through unfiltered and
+    ``aot_mint.dynamic_shapes_spec`` re-validates against the real forward)."""
+    rows = target_inputs(decl, target)
+    if not rows:
+        return None
+    return frozenset(i.top_name for i in rows)
+
+
+def _round_out(lo: int, hi: int, multiple_of: int) -> Tuple[int, int]:
+    m = max(1, int(multiple_of))
+    lo_r = (lo // m) * m
+    hi_r = -(-hi // m) * m
+    return (max(lo_r, m), hi_r)
+
+
+def dim_hull(rows: Sequence[GraphClass], dim: Dim) -> Tuple[int, int]:
+    """The (min, max) of one dim's resolved values over class rows, rounded
+    OUT to the dim's declared multiple."""
+    values = [row.dim_map[dim.name] for row in rows]
+    return _round_out(min(values), max(values), dim.multiple_of)
+
+
+def derived_dynamic(
+    decl: Compile, target: str, rows: Sequence[GraphClass],
+) -> Tuple[DynamicDim, ...]:
+    """The declared-dynamic rows one collapsed artifact needs, derived from
+    the class rows — the ``Compile`` -> :class:`aot_mint.DynamicDim` bridge
+    for the class vocabulary."""
+    names = _target_input_names(decl, target)
+    out: List[DynamicDim] = []
+    for dim in decl.dims:
+        values = {row.dim_map[dim.name] for row in rows}
+        if len(values) <= 1:
+            continue  # static across this artifact's rows
+        lo, hi = dim_hull(rows, dim)
+        if lo < 2:
+            raise MintRefused(
+                f"dim {dim.name!r} spans [{lo}, {hi}] across the collapsed "
+                f"rows; torch's 0/1 specialization is not overridable "
+                f"(ie#543), so an axis that reaches 1 must FORK the class "
+                f"instead of collapsing")
+        for bound, axis in dim.carried_by:
+            if names is not None and bound.split(".", 1)[0] not in names \
+                    and bound not in names:
+                continue
+            out.append(DynamicDim(
+                input_name=bound, axis=int(axis), min=lo, max=hi,
+                multiple_of=dim.multiple_of))
+    return tuple(out)
+
+
+def named_dynamic_rows(decl: Compile, target: str) -> Tuple[DynamicDim, ...]:
+    """Bridge ``Compile.dynamic`` rows that NAME a declared Dim (legal only
+    for class-less declarations — with classes the range is derived, never
+    hand-written) into per-binding :class:`aot_mint.DynamicDim` rows."""
+    by_name = {d.name: d for d in decl.dims}
+    names = _target_input_names(decl, target)
+    out: List[DynamicDim] = []
+    for dd in decl.dynamic:
+        dim = by_name.get(dd.dim)
+        if dim is None:
+            continue  # "batch"/"sequence" are the dynamo lane's business
+        for bound, axis in dim.carried_by:
+            if names is not None and bound.split(".", 1)[0] not in names \
+                    and bound not in names:
+                continue
+            out.append(DynamicDim(
+                input_name=bound, axis=int(axis), min=int(dd.min),
+                max=int(dd.max), multiple_of=dim.multiple_of))
+    return tuple(out)
+
+
+def mint_plans(decl: Compile, target: str) -> Tuple[MintPlan, ...]:
+    """Every artifact the declaration says to mint for one target."""
+    if not decl.classes:
+        raise MintRefused(
+            f"family {decl.family!r} declares no graph classes — there is "
+            f"no coordinate to mint")
+    strategy = str(decl.shape_strategy or "")
+    if not strategy:
+        raise MintRefused(
+            f"family {decl.family!r} declares classes but no shape_strategy "
+            f"— #730 made this a DECLARED per-family choice "
+            f"({STATIC_ROWS!r} for conv-bearing families, "
+            f"{DYNAMIC_COLLAPSE!r} for DiTs); declare it")
+    groups: Dict[Tuple[Tuple[str, Any], ...], List[GraphClass]] = {}
+    for cls in decl.classes:
+        groups.setdefault(cls.fork, []).append(cls)
+
+    plans: List[MintPlan] = []
+    if strategy == STATIC_ROWS:
+        for cls in decl.classes:
+            plans.append(MintPlan(
+                family=decl.family, target=target, fork=cls.fork,
+                rows=(cls,), seed=cls, dynamic=()))
+        return tuple(plans)
+    for fork, rows in groups.items():
+        # Seed with the max-volume row (deterministic; ties break on the
+        # coordinate itself). Which row seeds the trace decides nothing about
+        # what the artifact admits — the derived range does — but the biggest
+        # row reaches the allocator peak, mirroring the warmup doctrine.
+        def _volume(row: GraphClass) -> int:
+            product = 1
+            for _name, value in row.dims:
+                product *= int(value)
+            return product
+
+        seed = max(rows, key=lambda r: (_volume(r), r.dims))
+        plans.append(MintPlan(
+            family=decl.family, target=target, fork=fork,
+            rows=tuple(rows), seed=seed,
+            dynamic=derived_dynamic(decl, target, rows)))
+    return tuple(plans)
+
+
+def select_plan(
+    decl: Compile,
+    target: str,
+    *,
+    fork: Mapping[str, Any],
+    class_dims: Optional[Mapping[str, int]] = None,
+) -> MintPlan:
+    """The mint plan for one requested coordinate, refused by name when the
+    coordinate is not declared — reading only declared facts, never family
+    knowledge."""
+    want_fork = tuple(sorted((str(k), v) for k, v in dict(fork).items()))
+    plans = [p for p in mint_plans(decl, target) if p.fork == want_fork]
+    if not plans:
+        have = sorted({str(dict(p.fork)) for p in mint_plans(decl, target)})
+        raise MintRefused(
+            f"family {decl.family!r} declares no graph class at fork "
+            f"coordinate {dict(fork)!r} (declared coordinates: {have!r})")
+    if class_dims is None:
+        if len(plans) > 1:
+            raise MintRefused(
+                f"family {decl.family!r} has {len(plans)} static rows at fork "
+                f"{dict(fork)!r}; the request must name the row via "
+                f"'class_dims'")
+        return plans[0]
+    want_dims = tuple(sorted((str(k), int(v)) for k, v in dict(class_dims).items()))
+    for plan in plans:
+        for row in plan.rows:
+            if row.dims == want_dims:
+                if plan.seed.dims == want_dims:
+                    return plan
+                return replace(plan, seed=row)
+    have_rows = sorted(str(dict(r.dims)) for p in plans for r in p.rows)
+    raise MintRefused(
+        f"family {decl.family!r} declares no class row {dict(class_dims)!r} "
+        f"at fork {dict(fork)!r} (declared rows: {have_rows!r})")
+
+
+# ---------------------------------------------------------------------------
+# The fork gate — assert declared arms against the COMPOSED pipeline/module
+# ---------------------------------------------------------------------------
+
+
+def _read_source(obj: Any, field: str) -> Any:
+    """A declared fork field off a composed object: the diffusers config
+    first (``model_index.json`` / component config — where wan's
+    ``expand_timesteps`` actually lives), then a plain attribute (where the
+    Wan VAE's ``use_tiling`` actually lives)."""
+    config = getattr(obj, "config", None)
+    if config is not None:
+        value = getattr(config, field, _MISSING)
+        if value is _MISSING and hasattr(config, "get"):
+            value = config.get(field, _MISSING)
+        if value is not _MISSING:
+            return value
+    return getattr(obj, field, _MISSING)
+
+
+def fork_gaps(
+    decl: Compile,
+    fork: Mapping[str, Any],
+    *,
+    target: str,
+    pipeline: Any = None,
+    module: Any = None,
+) -> List[str]:
+    """Named reasons the requested fork coordinate is dishonest.
+
+    Two layers: the coordinate must state every declared fork on a SERVED
+    arm, and every fork with a ``source`` binding is read off the composed
+    pipeline/module and must agree — a graph exported under the wrong arm
+    is the wrong class wearing the declared class's key (ie#566 G6:
+    ``expand_timesteps`` is a PIPELINE field, invisible to module-config
+    readers, which is why the binding names its source).
+    """
+    gaps: List[str] = []
+    coordinate = {str(k): v for k, v in dict(fork).items()}
+    declared_names = {f.name for f in target_forks(decl, target)}
+    unknown = sorted(set(coordinate) - {f.name for f in decl.forks})
+    if unknown:
+        gaps.append(
+            f"fork coordinate names undeclared fork(s) {unknown!r} "
+            f"(declared: {sorted(f.name for f in decl.forks)!r})")
+    for f in target_forks(decl, target):
+        if f.name not in coordinate:
+            gaps.append(
+                f"fork coordinate omits declared fork {f.name!r} — an "
+                f"unstated arm silently exports one class as another")
+            continue
+        declared = coordinate[f.name]
+        if declared not in f.served:
+            gaps.append(
+                f"fork {f.name}={declared!r} is not a served arm "
+                f"(served: {list(f.served)!r})")
+            continue
+        if f.source is None:
+            continue
+        scope, field = f.source
+        obj = pipeline if scope == "pipeline" else module
+        if obj is None:
+            continue  # no composed object to assert against (planning-time)
+        actual = _read_source(obj, field)
+        if actual is _MISSING:
+            gaps.append(
+                f"fork {f.name!r} binds ({scope!r}, {field!r}) but the "
+                f"composed {scope} carries neither a config field nor an "
+                f"attribute of that name")
+            continue
+        actual_cmp = bool(actual) if isinstance(declared, bool) else actual
+        if actual_cmp != declared:
+            gaps.append(
+                f"{scope} field {field!r} is {actual!r} but the minted class "
+                f"declares {f.name}={declared!r} — the exported graph would "
+                f"be the wrong class wearing this class's key")
+    del declared_names
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# Generic example inputs — the one code path for every declared family
+# ---------------------------------------------------------------------------
+
+_DTYPES: Dict[str, str] = {
+    "fp16": "float16", "float16": "float16",
+    "bf16": "bfloat16", "bfloat16": "bfloat16",
+    "fp32": "float32", "float32": "float32",
+    "int32": "int32", "int64": "int64", "bool": "bool",
+}
+
+
+def _resolve_axis(
+    entry: Any, seed: GraphClass, config: Any, *, input_name: str, family: str,
+) -> int:
+    if isinstance(entry, int):
+        return entry
+    if isinstance(entry, str):
+        value = seed.dim_map.get(entry)
+        if value is None:
+            raise MintRefused(
+                f"input {input_name!r} names dim {entry!r}, which the "
+                f"selected class row does not carry (row dims: "
+                f"{sorted(seed.dim_map)!r})")
+        return int(value)
+    _kind, field = entry
+    raw: Any = _MISSING if config is None else getattr(config, field, _MISSING)
+    if raw is _MISSING and config is not None and hasattr(config, "get"):
+        raw = config.get(field, _MISSING)
+    if raw is _MISSING or raw is None:
+        raise MintRefused(
+            f"input {input_name!r} reads config field {field!r}, which the "
+            f"resolved module's config does not carry — family "
+            f"{family!r}'s declaration does not fit this module")
+    return int(raw)
+
+
+def declared_inputs(
+    module: Any, spec: ExportSpec, decl: Compile,
+) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+    """Example export inputs for ANY declared family — the single generic
+    code path that replaces per-family builder modules (#739: the worker
+    knows how to compile anything; only endpoints know what they are).
+
+    Widths come from the module's own config where the declaration says so;
+    sizes come from the SELECTED CLASS ROW (which row seeds the trace
+    decides nothing for a collapsed artifact — the derived range does).
+    """
+    import torch
+
+    from .aot_inputs import lifted_lora_kwargs, module_dtype_device
+
+    rows = target_inputs(decl, spec.target)
+    if not rows:
+        raise MintRefused(
+            f"family {decl.family!r} declares no Input rows for target "
+            f"{spec.target!r} — the export call contract is a declaration, "
+            f"and this target has none")
+    plan = select_plan(
+        decl, spec.target,
+        fork=dict(spec.fork),
+        class_dims=dict(spec.class_dims) if spec.class_dims else None)
+    seed = plan.seed
+    config = getattr(module, "config", None)
+    mod_dtype, device = module_dtype_device(module)
+
+    args: List[Any] = []
+    kwargs: Dict[str, Any] = {}
+    for row in rows:
+        if row.dtype:
+            name = _DTYPES.get(row.dtype)
+            if name is None:
+                raise MintRefused(
+                    f"input {row.name!r} declares unknown dtype {row.dtype!r} "
+                    f"(known: {sorted(set(_DTYPES))!r})")
+            dtype = getattr(torch, name)
+        else:
+            dtype = mod_dtype
+        shape = tuple(
+            _resolve_axis(e, seed, config, input_name=row.name,
+                          family=decl.family)
+            for e in row.shape)
+        if not shape:
+            tensor = torch.tensor(
+                row.value if row.value is not None else 1.0,
+                dtype=dtype, device=device)
+        elif row.value is not None:
+            tensor = torch.full(shape, row.value, dtype=dtype, device=device)
+        elif dtype.is_floating_point:
+            tensor = torch.randn(shape, dtype=dtype, device=device)
+        else:
+            tensor = torch.ones(shape, dtype=dtype, device=device)
+        if row.positional:
+            args.append(tensor)
+        else:
+            _nest(kwargs, row.name, tensor)
+    for arg in target_args(decl, spec.target):
+        _nest(kwargs, arg.name, arg.value)
+    kwargs.update(lifted_lora_kwargs(module, spec))
+    return tuple(args), kwargs
+
+
+def _nest(kwargs: Dict[str, Any], dotted: str, value: Any) -> None:
+    parts = dotted.split(".")
+    node = kwargs
+    for part in parts[:-1]:
+        node = node.setdefault(part, {})
+        if not isinstance(node, dict):
+            raise MintRefused(
+                f"input {dotted!r} nests under {part!r}, which another row "
+                f"already declared as a non-container")
+    node[parts[-1]] = value
+
+
+# ---------------------------------------------------------------------------
+# Request-side resolution — python -m gen_worker.aot_mint consumes this
+# ---------------------------------------------------------------------------
+
+
+def load_declaration(request: Mapping[str, Any], request_path: Optional[Path] = None) -> None:
+    """Import the endpoint's declaration module named by a mint request.
+
+    ``declaration_module`` is a dotted import; ``declaration_file`` is a
+    path (relative paths resolve against the request file, so a request in
+    ``aot/`` can say ``"declaration.py"``). Importing runs the endpoint's
+    ``register_export_declaration`` call — the same load-to-register shape
+    as ``convert.registry.load_declaration_module``.
+    """
+    dotted = str(request.get("declaration_module") or "").strip()
+    file_ref = str(request.get("declaration_file") or "").strip()
+    if dotted:
+        try:
+            importlib.import_module(dotted)
+        except ImportError as exc:
+            raise MintRefused(
+                f"cannot import declaration module {dotted!r}: {exc}") from exc
+    if file_ref:
+        path = Path(file_ref)
+        if not path.is_absolute() and request_path is not None:
+            path = Path(request_path).parent / path
+        if not path.exists():
+            raise MintRefused(f"declaration file {path} does not exist")
+        module_spec = importlib.util.spec_from_file_location(
+            f"_gen_worker_declaration_{path.stem}", path)
+        if module_spec is None or module_spec.loader is None:
+            raise MintRefused(f"cannot load declaration file {path}")
+        mod = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(mod)
+
+
+def apply_declaration(spec: ExportSpec) -> ExportSpec:
+    """Resolve a mint request against the family's registered declaration.
+
+    No registration -> the spec passes through untouched (the pre-#739
+    request shape stays valid for families that have not adopted the
+    vocabulary). With a registration: hand-written dynamic rows are REFUSED
+    (bounds derive from the rows), the mint-warm canon must be declared, and
+    the derived plan supplies the dynamic contract plus the identity facts.
+    """
+    decl = export_declaration(spec.family)
+    if decl is None:
+        return spec
+    if spec.dynamic:
+        raise MintRefused(
+            f"family {spec.family!r} has a registered export declaration; "
+            f"the request's hand-written 'dynamic' rows are refused — bounds "
+            f"derive from the declared class rows (#739)")
+    if decl.warm_changes_key is None:
+        raise MintRefused(
+            f"family {spec.family!r} declares no mint-warm canon "
+            f"(warm_changes_key) — whether pre-warm changes the graph is a "
+            f"measured per-family FACT (sdxl False, z-image True), not a "
+            f"default")
+    plan = select_plan(
+        decl, spec.target,
+        fork=dict(spec.fork),
+        class_dims=dict(spec.class_dims) if spec.class_dims else None)
+    specialization = dict(spec.specialization)
+    specialization.setdefault("shape_strategy", decl.shape_strategy)
+    specialization.setdefault("warm_changes_key", bool(decl.warm_changes_key))
+    for name, value in plan.fork:
+        specialization.setdefault(f"fork.{name}", value)
+    spec.dynamic = plan.dynamic
+    spec.fork = plan.fork
+    if not spec.class_dims and len(plan.rows) == 1:
+        spec.class_dims = plan.rows[0].dims
+    spec.specialization = specialization
+    return spec
+
+
+__all__ = [
+    "MintPlan",
+    "apply_declaration",
+    "declared_inputs",
+    "derived_dynamic",
+    "dim_hull",
+    "fork_gaps",
+    "load_declaration",
+    "mint_plans",
+    "named_dynamic_rows",
+    "select_plan",
+    "target_args",
+    "target_forks",
+    "target_inputs",
+]

--- a/src/gen_worker/aot_inputs.py
+++ b/src/gen_worker/aot_inputs.py
@@ -1,10 +1,16 @@
-"""Per-family export-input contracts for the AOT mint (#723).
+"""Generic export-input machinery for the AOT mint (#723, #739).
 
 ``torch.export`` needs example inputs with the exact structure the target's
-forward takes. That structure is FAMILY knowledge — SDXL's UNet wants
-``added_cond_kwargs={"text_embeds", "time_ids"}``, LTX2 drives per-token
-timesteps, z-image takes ragged lists of tensors (#729) — so it lives here,
-registered per family, rather than as an ``if`` ladder inside the mint driver.
+forward takes. That structure is FAMILY knowledge — and per Paul's SDK-generic
+rule (pgw#739) it is a DECLARATION in the endpoint spec, never worker code:
+the endpoint declares ``Compile(dims=..., forks=..., classes=..., inputs=...)``
+and :func:`gen_worker.aot_declaration.declared_inputs` derives the example
+inputs generically. This module carried the sdxl contract as per-family SDK
+code during bootstrap; that family knowledge is deleted (it lives in the sdxl
+endpoint's declaration now) and what remains is generic: composition, the
+lifted-LoRA kwargs, dtype/device introspection, and a registration hook for
+callers that need a hand-written builder while a family's declaration is
+still being written.
 
 Composition itself is NOT family-specific and mirrors the dynamo mint
 (``compile_cache.build``): ``load_from_pretrained`` -> ``place_pipeline``. That
@@ -35,31 +41,28 @@ if TYPE_CHECKING:  # pragma: no cover — typing only, no runtime import cycle
 
 logger = logging.getLogger(__name__)
 
-#: SDXL pooled-text-embedding width and micro-conditioning vector length. Both
-#: are architectural constants of the SDXL conditioning contract, not config
-#: fields — ``trt_engine._export_unet_onnx`` pins the same two.
-SDXL_POOLED_DIM = 1280
-SDXL_TIME_IDS = 6
-
 InputBuilder = Callable[[Any, "ExportSpec"], Tuple[Tuple[Any, ...], Dict[str, Any]]]
 
 #: Keyed by ``(family, target)`` — NOT by family (ie#566 G1). A family's compile
 #: targets are unrelated modules with unrelated call contracts: wan's span the
 #: denoiser AND the VAE, and a family-only key made ``vae.decode`` unmintable for
 #: EVERY family, not just wan. ``target=""`` registers a family-wide fallback.
+#: This registry is the ESCAPE HATCH while a family's declaration is being
+#: written; a registered export DECLARATION (pgw#739) always wins over it.
 _BUILDERS: Dict[Tuple[str, str], InputBuilder] = {}
 
 
 class InputContractError(RuntimeError):
-    """No export-input contract is registered for a family, or it cannot be
-    satisfied from the composed pipeline."""
+    """No export-input contract is declared or registered for a family, or it
+    cannot be satisfied from the composed pipeline."""
 
 
 def inputs_for(family: str, target: str = "") -> Callable[[InputBuilder], InputBuilder]:
-    """Register the example-input builder for one ``(family, target)``.
+    """Register a hand-written example-input builder for one ``(family,
+    target)``. ``target=""`` registers a family-wide fallback.
 
-    ``target=""`` registers a family-wide fallback for families whose every
-    compile target happens to share a call contract.
+    Prefer the declaration (``Compile(inputs=...)``): a registered export
+    declaration supersedes anything registered here.
     """
 
     def register(fn: InputBuilder) -> InputBuilder:
@@ -70,76 +73,36 @@ def inputs_for(family: str, target: str = "") -> Callable[[InputBuilder], InputB
 
 
 def builder_for(family: str, target: str = "") -> InputBuilder:
-    """The builder for ``(family, target)``, falling back to the family default.
+    """The builder for ``(family, target)``: the family's registered export
+    DECLARATION when it carries ``inputs=`` rows, else the hand-registered
+    builder, else a named refusal.
 
-    Exact ``(family, target)`` wins; a family-wide registration answers the rest.
-    A family with a registered denoiser but no VAE builder must FAIL for the VAE
-    rather than silently feed it denoiser inputs.
+    Exact ``(family, target)`` wins over a family-wide registration. A family
+    with a declared denoiser but no VAE contract must FAIL for the VAE rather
+    than silently feed it denoiser inputs.
     """
+    from .api.export_contract import export_declaration
+
     fam, tgt = str(family), str(target)
+    decl = export_declaration(fam)
+    if decl is not None and decl.inputs:
+        from . import aot_declaration
+
+        def declared(module: Any, spec: "ExportSpec") -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+            return aot_declaration.declared_inputs(module, spec, decl)
+
+        return declared
     for key in ((fam, tgt), (fam, "")):
         fn = _BUILDERS.get(key)
         if fn is not None:
             return fn
     known = sorted(f"{f}/{t or '*'}" for f, t in _BUILDERS)
     raise InputContractError(
-        f"no AOT export-input contract registered for {fam!r} target {tgt!r} "
-        f"(have: {known!r}) — a target's call contract is family knowledge and "
-        f"must be declared before it can be exported")
-
-
-# ---------------------------------------------------------------------------
-# SDXL
-# ---------------------------------------------------------------------------
-
-
-@inputs_for("sdxl", "unet")
-def sdxl_unet_inputs(
-    module: Any, spec: "ExportSpec",
-) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
-    """Example inputs for the SDXL ``UNet2DConditionModel`` forward.
-
-    Widths come from the module's own config (``in_channels``,
-    ``cross_attention_dim``) rather than from constants, so a family member
-    with a different conditioning width exports correctly instead of failing
-    deep inside the trace. Shapes come from the FIRST declared shape row: the
-    latent H/W axes are symbolic, so which row seeds the trace decides nothing
-    about what the artifact admits — the declared range does.
-
-    ``return_dict=False`` is passed because a dataclass output is not a valid
-    export output; the consumer re-wraps.
-    """
-    import torch
-
-    if not spec.shapes:
-        raise InputContractError(
-            "sdxl export needs at least one declared shape row (w, h) to seed "
-            "the trace")
-    width, height = int(spec.shapes[0][0]), int(spec.shapes[0][1])
-    scale = 8
-    latent_h, latent_w = height // scale, width // scale
-    batch = spec.batch or (2 if _sdxl_cfg_batched(spec) else 1)
-    text_len = int(spec.text_lens[0]) if spec.text_lens else 77
-    config = getattr(module, "config", None)
-    latent_channels = int(getattr(config, "in_channels", 4) or 4)
-    cross_dim = int(getattr(config, "cross_attention_dim", 2048) or 2048)
-    dtype, device = _module_dtype_device(module)
-    kw = {"dtype": dtype, "device": device}
-
-    args = (
-        torch.randn(batch, latent_channels, latent_h, latent_w, **kw),
-        torch.tensor(1.0, device=device),
-        torch.randn(batch, text_len, cross_dim, **kw),
-    )
-    kwargs: Dict[str, Any] = {
-        "added_cond_kwargs": {
-            "text_embeds": torch.randn(batch, SDXL_POOLED_DIM, **kw),
-            "time_ids": torch.randn(batch, SDXL_TIME_IDS, **kw),
-        },
-        "return_dict": False,
-    }
-    kwargs.update(lifted_lora_kwargs(module, spec))
-    return args, kwargs
+        f"no export-input contract for {fam!r} target {tgt!r}: no registered "
+        f"export declaration (Compile(inputs=...), pgw#739) and no "
+        f"hand-registered builder (have: {known!r}) — a target's call "
+        f"contract is family knowledge and must be DECLARED by the endpoint "
+        f"before it can be exported")
 
 
 def lifted_lora_kwargs(module: Any, spec: "ExportSpec") -> Dict[str, Any]:
@@ -162,30 +125,15 @@ def lifted_lora_kwargs(module: Any, spec: "ExportSpec") -> Dict[str, Any]:
     from .models import lora_lifted
 
     plan = lora_lifted.build_plan(module, int(spec.lora_bucket))
-    lora_a, lora_b = plan.alloc(_module_dtype_device(module)[1])
+    lora_a, lora_b = plan.alloc(module_dtype_device(module)[1])
     return {
         "lora_a": torch.randn_like(lora_a),
         "lora_b": torch.randn_like(lora_b),
     }
 
 
-def _sdxl_cfg_batched(spec: "ExportSpec") -> bool:
-    """Whether THIS SDXL cell's graph class is CFG-batched (ie#345).
-
-    **Deliberately SDXL-specific, and not a general rule (ie#566 G2.)** SDXL runs
-    CFG as one batch-2 forward, so guidance changes the traced SHAPE. wan does
-    not: its CFG is two SEQUENTIAL batch-1 forwards (`pipeline_wan.py:596-615`),
-    so guidance changes the call COUNT and the traced shape is batch-1 either
-    way. Inferring batch from ``guidance_scales`` family-agnostically doubled
-    wan's batch and traced a graph the serving path never calls.
-
-    Any family whose batching differs sets ``ExportSpec.batch`` explicitly.
-    """
-    return any(float(g) > 1.0 for g in spec.guidance_scales) \
-        or not spec.guidance_scales
-
-
-def _module_dtype_device(module: Any) -> Tuple[Any, Any]:
+def module_dtype_device(module: Any) -> Tuple[Any, Any]:
+    """The resident dtype/device of a module, read off its own tensors."""
     import torch
 
     for source in (module.parameters, module.buffers):
@@ -206,16 +154,20 @@ def latent_dims(
 ) -> Tuple["DynamicDim", ...]:
     """Declared symbolic latent H/W dims spanning ``spec.shapes``.
 
-    Derived from the declared aspect set rather than hand-written bounds, so
-    "these are the aspect ratios we serve" is stated once and the admissible
-    range cannot drift from it. ``downsamples`` is the divisibility the UNet
-    itself requires (SDXL downsamples 3x => multiples of 8 latent units); a
-    range not expressible as that multiple is refused at
+    Generic derivation for REQUEST-level dynamic rows (a family without a
+    class declaration): bounds derive from the declared aspect set rather
+    than hand-written numbers, so "these are the aspect ratios we serve" is
+    stated once and the admissible range cannot drift from it.
+    ``downsamples`` is the divisibility the network itself requires; a range
+    not expressible as that multiple is refused at
     ``aot_mint.dynamic_shapes_spec`` rather than silently 0/1-specialized.
 
     Bounds are ROUNDED OUT to the multiple, never in: rounding in would
     exclude a declared aspect ratio from the artifact's own contract, and B2
     measured that nothing at runtime would tell us.
+
+    Families with a class declaration never call this — their bounds derive
+    from the class rows (``aot_declaration.derived_dynamic``).
     """
     from .aot_mint import DynamicDim
 
@@ -278,11 +230,10 @@ def compose(
 
 __all__ = [
     "InputContractError",
-    "SDXL_POOLED_DIM",
-    "SDXL_TIME_IDS",
     "builder_for",
     "compose",
     "inputs_for",
     "latent_dims",
-    "sdxl_unet_inputs",
+    "lifted_lora_kwargs",
+    "module_dtype_device",
 ]

--- a/src/gen_worker/aot_inputs.py
+++ b/src/gen_worker/aot_inputs.py
@@ -105,8 +105,12 @@ def builder_for(family: str, target: str = "") -> InputBuilder:
         f"before it can be exported")
 
 
-def lifted_lora_kwargs(module: Any, spec: "ExportSpec") -> Dict[str, Any]:
-    """The mandatory ``lora_a``/``lora_b`` call kwargs for a LoRA-bucket mint.
+def lifted_lora_values(module: Any, spec: "ExportSpec") -> Dict[str, Any]:
+    """The mandatory ``lora_a``/``lora_b`` call values for a LoRA-bucket mint,
+    keyed by parameter NAME — the builder binds them to their POSITIONAL
+    slots (all-positional example feeds are a mint obligation: pod 9's
+    kwarg-traced package armed and silently revoked to eager on first call,
+    pgw#723 residuals).
 
     #725 option 2: the adapter rides as a flat 1-D pair with static per-layer
     offsets, passed as CALL ARGUMENTS. The pair must be present at trace time —
@@ -234,6 +238,6 @@ __all__ = [
     "compose",
     "inputs_for",
     "latent_dims",
-    "lifted_lora_kwargs",
+    "lifted_lora_values",
     "module_dtype_device",
 ]

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -180,6 +180,41 @@ class ExportSpec:
         return token
 
 
+#: The lifted-LoRA mint's torch floor (pgw#723 residuals, pod 8): torch 2.9
+#: strict export refuses ``bind_views``' in-trace ``mod.lora_a = ...`` setattr
+#: ("AssertionError: Mutating module attribute lora_a during export") that
+#: 2.13 traces fine. 2.9 is NOT a valid fallback for this lane.
+LIFTED_LORA_TORCH_FLOOR = (2, 13)
+
+
+def lifted_torch_gap(spec: ExportSpec) -> str:
+    """'' when torch meets the lifted-LoRA floor (or the spec has no lifted
+    fork declared), else the named refusal reason."""
+    if not (spec.lora_bucket or spec.lifted_inputs or spec.lora_fqns):
+        return ""
+    import torch
+
+    version = str(getattr(torch, "__version__", "") or "")
+    parts = version.split("+")[0].split(".")
+    try:
+        found = (int(parts[0]), int(parts[1]))
+    except (IndexError, ValueError):
+        return (
+            f"cannot parse torch version {version!r} to check the "
+            f"lifted-LoRA mint floor (torch >= "
+            f"{'.'.join(map(str, LIFTED_LORA_TORCH_FLOOR))})")
+    if found < LIFTED_LORA_TORCH_FLOOR:
+        floor = ".".join(map(str, LIFTED_LORA_TORCH_FLOOR))
+        return (
+            f"lifted-LoRA mint requires torch >= {floor}, got {version}: "
+            f"torch 2.9 strict export refuses bind_views' in-trace setattr "
+            f"('Mutating module attribute lora_a during export') that 2.13 "
+            f"traces fine — measured on pod 8 (pgw#723 residuals), so the "
+            f"2.13 prod floor is a mint PRECONDITION for this lane, not a "
+            f"preference")
+    return ""
+
+
 def lane_admitted(spec: ExportSpec, *, allow_regressed_lanes: bool) -> str:
     """'' when this lane may be minted, else the named refusal reason."""
     base, _bucket = lane_bucket(spec.weight_lane)
@@ -572,6 +607,9 @@ def mint(
     refusal = lane_admitted(spec, allow_regressed_lanes=allow_regressed_lanes)
     if refusal:
         raise MintRefused(refusal)
+    refusal = lifted_torch_gap(spec)
+    if refusal:
+        raise MintRefused(refusal)
 
     out_dir = Path(out_dir)
     work = out_dir / "work"
@@ -579,6 +617,22 @@ def mint(
     timings: Dict[str, float] = {}
 
     args, kwargs = example_inputs()
+    if kwargs:
+        # All-positional example feeds are a MINT OBLIGATION (pgw#723
+        # residuals, pod 9): the AOTI package's call convention mirrors the
+        # traced args/kwargs split, and the serve marshal is POSITIONAL
+        # (aot_serve.marshal_positional) — a kwarg-traced package arms, then
+        # silently revokes to eager on its first call ("Ran into a kwarg
+        # keyword mismatch: Got [] but expected ['lora_a','lora_b']",
+        # measured). Refused HERE so the failure is a named mint refusal
+        # instead of a vacuous eager-serving artifact.
+        raise MintRefused(
+            f"example feed carries keyword argument(s) {sorted(kwargs)!r} — "
+            f"all-positional feeds are a mint obligation (pod 9, pgw#723 "
+            f"residuals): a kwarg-traced package is uncallable by the "
+            f"positional serve marshal and fails only at first serve, "
+            f"silently revoking to eager. Feed every input positionally "
+            f"(signature defaults fill the gaps)")
     input_names = _input_names(module, args, kwargs)
     dynamic = dynamic_shapes_spec(spec.dynamic, input_names) \
         if spec.dynamic else None
@@ -1267,8 +1321,10 @@ __all__ = [
     "dynamic_shapes_spec",
     "export_program",
     "identity_blocks",
+    "LIFTED_LORA_TORCH_FLOOR",
     "lane_admitted",
     "lifted_input_gaps",
+    "lifted_torch_gap",
     "main",
     "mint",
     "mint_target",

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -157,6 +157,12 @@ class ExportSpec:
     text_lens: Tuple[int, ...] = ()
     guidance_scales: Tuple[float, ...] = ()
     dynamic: Tuple[DynamicDim, ...] = ()
+    #: pgw#739 declaration coordinate: the fork arm values and (for a
+    #: static-rows family) the class row this artifact is minted at. Both
+    #: KEY (a fork is a distinct graph class in #716's hash) — see
+    #: :func:`cell_identity`. Sorted (name, value) pairs.
+    fork: Tuple[Tuple[str, Any], ...] = ()
+    class_dims: Tuple[Tuple[str, int], ...] = ()
     specialization: Dict[str, Any] = field(default_factory=dict)
     lora_fqns: Tuple[str, ...] = ()
     lifted_inputs: Tuple[str, ...] = ()
@@ -348,6 +354,35 @@ def declared_range_gaps(
         syms = _free_symbols(dim)
         declared_symbols.extend(syms)
         covered = False
+        # The SOLVED range of the axis's full expression, when the program
+        # records one. This is what makes a UNIFIED relational axis (#739 /
+        # ie#566 §5) gate-able: wan ti2v's per-token dim solves to
+        # ``31*s25*s56`` with its own composite range entry, while the
+        # per-symbol path below would compare a governing symbol's [20, 40]
+        # against the declared [12400, 49600] and refuse a sound artifact.
+        # Composite entries are in the axis's OWN units, so the declared
+        # bounds compare directly, with no multiple-of scaling.
+        expr = getattr(getattr(dim, "node", None), "expr", None)
+        interval = ranges.get(expr) if expr is not None else None
+        if interval is not None:
+            try:
+                lo, hi = int(interval.lower), int(interval.upper)
+            except (TypeError, ValueError, OverflowError):
+                lo = hi = -1
+            if lo >= 0:
+                if lo == hi:
+                    gaps.append(
+                        f"{d.input_name}[{d.axis}] ({expr}) solved to the "
+                        f"single value {lo} — the declared range "
+                        f"[{d.min}, {d.max}] is advertised but the artifact "
+                        f"admits ONE shape")
+                elif lo > d.min or hi < d.max:
+                    gaps.append(
+                        f"{d.input_name}[{d.axis}] ({expr}) solved to "
+                        f"[{lo}, {hi}] which does not cover the declared "
+                        f"[{d.min}, {d.max}] — the artifact admits less "
+                        f"traffic than it advertises")
+                continue
         for sym in syms:
             interval = ranges.get(sym)
             if interval is None:
@@ -758,7 +793,7 @@ def cell_identity(meta: Mapping[str, Any], spec: ExportSpec) -> cell_key.CellKey
         raise MintRefused(
             "the envelope recorded no range_digest; an exported cell must not "
             "be keyed without its admissible-shape range (#723 S3)")
-    contract = cell_key.contract_digest({
+    contract_facts: Dict[str, Any] = {
         "v": 1,
         "shapes": sorted([int(v) for v in row] for row in spec.shapes),
         "targets": [spec.target],
@@ -768,7 +803,17 @@ def cell_identity(meta: Mapping[str, Any], spec: ExportSpec) -> cell_key.CellKey
         "range_digest": range_digest,
         "graph": dict(meta.get("graph") or {}),
         "strict": bool(spec.strict),
-    })
+    }
+    # pgw#739: a fork is a DISTINCT graph class in #716's hash, and a
+    # static-rows artifact's identity is its class row. Present only when the
+    # spec carries a declaration coordinate, so pre-declaration cells keep
+    # their digests.
+    if spec.fork:
+        contract_facts["fork"] = [[str(n), v] for n, v in sorted(spec.fork)]
+    if spec.class_dims:
+        contract_facts["class_dims"] = [
+            [str(n), int(v)] for n, v in sorted(spec.class_dims)]
+    contract = cell_key.contract_digest(contract_facts)
     return cell_key.from_axes({
         "format": str(meta.get("format") or ""),
         "kind": aot_serve.ARTIFACT_KIND,
@@ -912,6 +957,22 @@ def mint_target(
             f"pipeline {type(pipeline).__name__} has no compile target "
             f"{spec.target!r}")
     owner, attr, _fn = resolved
+    # pgw#739 fork gate: every declared fork with a (pipeline|module, field)
+    # source is read off the COMPOSED objects and must agree with the minted
+    # arm — a graph exported under the wrong arm is the wrong class wearing
+    # the declared class's key (wan's expand_timesteps is a PIPELINE field a
+    # module-config reader never sees; ie#566 G6).
+    from .api.export_contract import export_declaration
+
+    decl = export_declaration(spec.family)
+    if decl is not None and decl.forks:
+        from . import aot_declaration
+
+        gaps = aot_declaration.fork_gaps(
+            decl, dict(spec.fork), target=spec.target,
+            pipeline=pipeline, module=owner)
+        if gaps:
+            raise MintRefused("fork gate (pgw#739): " + "; ".join(gaps))
     module = owner if attr == "forward" else _CallableTarget(owner, attr)
     return mint(
         module, spec, out_dir,
@@ -1044,6 +1105,11 @@ def _load_spec(path: Path) -> Tuple[ExportSpec, Dict[str, Any]]:
         source_ref=str(body.get("source_ref") or ""),
         source_digest=str(body.get("source_digest") or ""),
         closure_roots=tuple(str(v) for v in body.get("closure_roots") or ()),
+        fork=tuple(sorted(
+            (str(k), v) for k, v in dict(body.get("fork") or {}).items())),
+        class_dims=tuple(sorted(
+            (str(k), int(v))
+            for k, v in dict(body.get("class_dims") or {}).items())),
     )
     if not spec.family or not spec.target:
         raise MintRefused(
@@ -1084,6 +1150,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     except Exception as exc:
         print(f"BAD REQUEST {args.request}: {exc}", file=sys.stderr)
         return 3
+    try:
+        # pgw#739: load the endpoint's declaration module (registers the
+        # family's export contract), then resolve the request against it —
+        # deriving the dynamic contract from the declared class rows. A
+        # family with no registration passes through untouched.
+        from . import aot_declaration
+
+        aot_declaration.load_declaration(body, request_path=args.request)
+        spec = aot_declaration.apply_declaration(spec)
+    except MintRefused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 2
     if args.require_toolchain and not toolchain_present():
         print(
             "REFUSED: no C toolchain (cc/gcc) — an AOTI mint needs the "

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -311,18 +311,16 @@ def declared_range_gaps(
        must COVER the declared ``[min, max]``. A collapsed (``lower == upper``)
        or narrowed range is a pin, and the artifact admits less traffic than it
        advertises;
-    3. **cross-input collapse** — a STATIC dim on ANOTHER input whose value is a
-       multiple of the product of the declared dims' trace-time values. Such a
-       dim is an algebraic function of the "dynamic" extents, so it silently
-       fixes them even though each symbol still reports a healthy range. This is
-       the check the presence-only gate lacked.
+    3. **pinning guards** — an equality guard in the shape env mentioning a
+       declared symbol. A dim that is genuinely a function of the declared
+       extents forces the tracer to record ``Eq(h*w, N)``; a dim that merely
+       shares a factor records nothing. This is the check the presence-only gate
+       lacked, and it is evidence-based rather than arithmetic — see
+       :func:`_pinning_guards` for why the arithmetic version was wrong.
     """
     gaps: List[str] = []
     shapes = _placeholder_shapes(program)
     ranges = getattr(program, "range_constraints", {}) or {}
-    env = _shape_env(program)
-    hints = dict(getattr(env, "var_to_val", {}) or {}) if env is not None else {}
-
     declared_symbols: List[Any] = []
     for d in dims:
         if d.min == d.max:
@@ -383,60 +381,84 @@ def declared_range_gaps(
                 f"{d.input_name}[{d.axis}] is symbolic ({text}) but carries no "
                 f"resolvable symbol; its admissible range is unprovable")
 
-    gaps.extend(_cross_input_collapse(shapes, dims, declared_symbols, hints))
+    gaps.extend(_pinning_guards(program, declared_symbols))
     return gaps
 
 
-def _cross_input_collapse(
-    shapes: Mapping[str, Tuple[Any, ...]],
-    dims: Sequence[DynamicDim],
-    declared_symbols: Sequence[Any],
-    hints: Mapping[Any, Any],
-) -> List[str]:
-    """Static dims on OTHER inputs that pin the declared dynamic extents.
+def _pinning_guards(program: Any, declared_symbols: Sequence[Any]) -> List[str]:
+    """Equality guards that pin a declared-dynamic symbol (ie#566 G3).
 
-    ie#566 G3, measured on wan ti2v-5b: H and W were declared symbolic and each
-    kept a healthy solved range, but a per-token input of static length 27,280
-    is an algebraic function of H*W — so the graph serves exactly the traced
-    shape regardless. Every per-symbol check passes; only comparing the static
-    dims against the PRODUCT of the trace-time extents finds it.
+    A dim that is GENUINELY a function of the declared extents forces the tracer
+    to record an equality guard; a dim that merely happens to share a factor
+    records nothing. Measured on this toolchain::
 
-    Fail-closed by design: the remedy is to declare that input's dim dynamic too
-    (or make it independent of H*W), and B2 doctrine forbids shipping the silent
-    version while we decide.
+        genuine  x.reshape(b, c, h*w) + tokens   ->  guards ['Eq(s37*s46, 384)']
+        coincidence  x.flatten(2).sum(-1) + tokens.sum()  ->  guards []
+
+    In BOTH cases ``range_constraints`` still reports the full declared range,
+    which is exactly why a presence check — and even a solved-range check —
+    passes the pinned artifact. The guard is the only place the truth appears.
+
+    This replaces an earlier divisibility heuristic that asked whether a static
+    dim was a multiple of the product of the declared extents. That test could
+    not distinguish the two cases above, and it FALSE-POSITIVED on sdxl, whose
+    cross-attention width 2048 and pooled width 1280 are multiples of the
+    declared extents' product by pure architectural coincidence — refusing every
+    symbolic sdxl mint, including the one reproducing pgw#704's headline. The
+    lesson is recorded here because the coincidence is easy to re-introduce:
+    integer arithmetic on shapes is NOT evidence of dependence; a solved
+    relation is.
+
+    A truly free symbol carries no equality guard, so any ``Eq`` mentioning a
+    declared symbol means that symbol is not free.
     """
-    values: List[int] = []
-    for sym in declared_symbols:
-        try:
-            values.append(int(hints[sym]))
-        except (KeyError, TypeError, ValueError):
-            continue
-    if len(values) < 2:
+    declared = {str(sym) for sym in declared_symbols}
+    if not declared:
         return []
-    product = 1
-    for v in values:
-        product *= v
-    if product <= 1:
+    env = _shape_env(program)
+    if env is None:
         return []
-    declared_inputs = {d.input_name for d in dims}
     out: List[str] = []
-    for name, shape in sorted(shapes.items()):
-        if name in declared_inputs:
-            continue
-        for axis, dim in enumerate(shape):
-            text = str(dim)
-            if not text.lstrip("-").isdigit():
+    seen: set = set()
+    for source in ("guards", "axioms"):
+        entries = getattr(env, source, None) or ()
+        if isinstance(entries, dict):
+            entries = list(entries)
+        for entry in entries:
+            expr = getattr(entry, "expr", entry)
+            if expr is None:
                 continue
-            n = int(text)
-            if n >= product and n % product == 0:
-                out.append(
-                    f"{name}[{axis}] is STATIC {n}, a multiple of {product} — "
-                    f"the product of the declared dynamic extents "
-                    f"{values!r}. That dim is an algebraic function of the "
-                    f"'dynamic' axes, so the graph is pinned to the traced "
-                    f"shape even though each symbol reports a range "
-                    f"(ie#566 G3). Declare {name}[{axis}] dynamic too, or make "
-                    f"it independent of the latent extent")
+            if getattr(expr, "func", None) is None or \
+                    type(expr).__name__ not in ("Eq", "Equality"):
+                continue
+            names = {str(sym) for sym in
+                     (getattr(expr, "free_symbols", ()) or ())}
+            hit = sorted(names & declared)
+            if not hit:
+                continue
+            # A pin has a CONSTANT on one side (``Eq(s37*s46, 384)``). An
+            # equality between two symbolic sides (``Eq(s37, 8*s95)``) is the
+            # DEFINITIONAL relation our own multiple-of factor introduces —
+            # ``8 * Dim(...)`` — and refusing it would block every mint that
+            # declares a divisibility, which is all of the image families.
+            sides = list(getattr(expr, "args", ()) or ())
+            if len(sides) != 2 or not any(
+                not (getattr(side, "free_symbols", None) or set())
+                for side in sides
+            ):
+                continue
+            text = str(expr)
+            if text in seen:
+                continue
+            seen.add(text)
+            out.append(
+                f"the exported program carries the equality guard {text}, "
+                f"which PINS the declared dynamic symbol(s) {hit!r} — some "
+                f"other input's static shape is an algebraic function of the "
+                f"declared extents, so the artifact serves exactly the traced "
+                f"shape even though its declared range says otherwise "
+                f"(ie#566 G3). Declare that input dynamic too, or make it "
+                f"independent of the latent extent")
     return out
 
 

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -618,6 +618,17 @@ def marshal_positional(
     the exact order export recorded, or it feeds the right tensor to the
     wrong graph input.
 
+    THE COMPLEMENT, measured on the pgw#723 residuals pod (2.13.0+cu130):
+    the package's call convention mirrors the traced EXAMPLE's args/kwargs
+    split. An input fed as a KWARG at export bakes a kwarg-demanding
+    ``in_spec`` — the package then refuses a positional call with the same
+    error in reverse (``Got [] but expected ['lora_a', 'lora_b']``), the
+    wrap treats it as an artifact failure, and the lane silently revokes to
+    eager on the FIRST call. So "positional inputs only" is a MINT
+    obligation, not a torch invariant: example inputs must be fed
+    all-positionally (lifted adapter pair included) so this positional
+    marshal matches the package.
+
     ``position`` in the declared contract is that order. Every declared
     input must be present — a package has a FIXED flat arity, so a missing
     one cannot be skipped without silently shifting every later argument

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -739,6 +739,16 @@ def resolve_constants(
     direct name lookup — no value-identity matching (``trt_engine`` needs
     that only because ONNX renames). An unresolvable FQN is a named refusal:
     binding a partial set is exactly the state that segfaults.
+
+    **MEASURED CONTRACT FACT (pgw#723 final pod, torch 2.13.0+cu130):**
+    ``load_constants`` keys by the ORIGINAL FQN (``lin.bias``), NOT the
+    mangled C++ identifier (``lin_bias``) that the package's own table
+    answers with. Keying a hand-rolled binder by ``DeclaredConstant.name``
+    fails with ``RuntimeError: Constant not found: lin_bias`` — and only at
+    bind time, on a pod. This function keys by ``spec.fqn`` (the
+    ``original_fqn`` the package records), which is the correct side of that
+    split; do not "simplify" it to the C++ name, and do not hand-roll a
+    binder that does.
     """
     out: Dict[str, Any] = {}
     missing: List[str] = []
@@ -826,12 +836,22 @@ class ArtifactRunner:
         # MEASURED (pgw#721 S8 first light, L4/torch 2.9.1+cu128): this HOLDS
         # on a real sdxl w8a8 cell — 2,422 constants, all state_dict-sourced,
         # declared and package sets identical, strict update accepted.
-        # CAVEAT, still open: that artifact folded NOTHING (zero literals,
-        # zero from_folded), so strictness is UNTESTED against a folding
-        # artifact. If a folding cell ever refuses here, the choice is to
-        # relax to check_full_update=False (keeping our own set-equality
-        # proof above as the real gate) or to have the mint ship the folded
-        # bytes — decide on evidence, not by loosening the gate first.
+        #
+        # FOLDING CAVEAT CLOSED (pgw#723 residuals, torch 2.13.0+cu130 — the
+        # prod floor): strictness also HOLDS against a genuinely FOLDING
+        # artifact. AOTInductor folds ONLY under
+        # ``aot_inductor.use_runtime_constant_folding=True`` (default never
+        # folds — measured on 3 constant-expression module shapes AND the
+        # real sdxl cell), and when it does, the ``_FOLDED_CONST_*`` entries
+        # (``from_folded=True``) are EXEMPT from the full-update check and
+        # RECOMPUTED from the freshly bound originals (mutate-arm proven:
+        # binding values 3x off compile time tracks eager bit-exactly). So
+        # strict is safe for both artifact classes. NOTE our own mint cannot
+        # ship a folding artifact today: folded entries classify as literals
+        # with no ``ep.constants`` value, so ``_write_literals`` refuses the
+        # mint by name — and if runtime folding is ever deliberately enabled,
+        # the change is to EXCLUDE from_folded constants from the manifest
+        # and binding (they are derived), not to loosen this gate.
         self.package.load_constants(values, check_full_update=True)
         self.bound_fqns = tuple(sorted(values))
         self.bound = True

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -44,6 +44,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Type
 import msgspec
 
 from .binding import BINDING_TYPES, Binding
+from .export_contract import Arg, Dim, Fork, GraphClass, Input, validate_contract
 from .formula import RuntimeFormula
 from .slot import OBJECTIVES, Slot
 from ..models import lanes as lanespec
@@ -615,10 +616,20 @@ class DynamicDim(msgspec.Struct, frozen=True):
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
-        d = str(self.dim or "").strip().lower()
-        if d not in ("batch", "sequence"):
+        d = str(self.dim or "").strip()
+        # pgw#739: the old hard-validation to "batch"|"sequence" was the
+        # vocabulary wall wan's latent-spatial axis hit (ie#550/ie#566). Any
+        # declared Dim name is now admissible; Compile.__post_init__
+        # cross-validates the name against Compile.dims, so an unknown axis
+        # is still refused — by cross-reference, not by a two-literal list.
+        # The two logical dynamo axes stay case-normalized; declared Dim
+        # names match exactly.
+        if d.lower() in ("batch", "sequence"):
+            d = d.lower()
+        if not d.isidentifier():
             raise ValueError(
-                f'DynamicDim.dim must be "batch" or "sequence", got {self.dim!r}'
+                f"DynamicDim.dim must name a logical axis (\"batch\", "
+                f"\"sequence\", or a declared Compile.dims name), got {self.dim!r}"
             )
         force(self, "dim", d)
         lo, hi = int(self.min), int(self.max)
@@ -676,7 +687,7 @@ class Compile(msgspec.Struct, frozen=True):
     ``gen_worker.compile_cache``.
     """
 
-    shapes: tuple[tuple[int, ...], ...]
+    shapes: tuple[tuple[int, ...], ...] = ()
     targets: tuple[str, ...] = ("transformer", "vae.decode")
     family: str = ""
     # SDK v2 text-sequence axis (ie#544): None = undeclared (walk-time lint
@@ -694,18 +705,44 @@ class Compile(msgspec.Struct, frozen=True):
     # graph per shape, reused across blocks). Cells record the mode — a
     # mode drift consumer stays eager (cache would miss anyway).
     regional: bool = False
+    # ------------------------------------------------------------------
+    # pgw#739 export-declaration vocabulary. Per-family content is a
+    # DECLARATION here, never worker code: named dims with (input, axis)
+    # bindings, graph-class forks, and RESOLVED coordinate rows generated
+    # by the endpoint's own legality oracle. See api/export_contract.py.
+    # ------------------------------------------------------------------
+    dims: tuple[Dim, ...] = ()
+    forks: tuple[Fork, ...] = ()
+    classes: tuple[GraphClass, ...] = ()
+    inputs: tuple[Input, ...] = ()
+    args: tuple[Arg, ...] = ()
+    # #730 ratified: shape strategy is a per-family DECLARED choice —
+    # conv-bearing families "static-rows" (symbolic latent H/W turns off
+    # inductor's channels-last layout opt, +7.2% measured on sdxl), DiTs
+    # "dynamic-collapse". "" = undeclared; refused at mint-plan time, not
+    # defaulted.
+    shape_strategy: str = ""
+    # Mint-warm canon (#723/#728): whether pre-warming the module changes
+    # the exported graph. A declared per-family FACT, not a ritual — sdxl
+    # measured False, z-image measured True (rope tables: 4327 cold vs
+    # 4285 warmed). None = unmeasured; refused at mint time for declared
+    # families.
+    warm_changes_key: Optional[bool] = None
+    # Declared-eager lanes (LTX §2.3): recorded decision, not an omission.
+    eager: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
         shapes = tuple(tuple(int(v) for v in s) for s in self.shapes)
         if (
-            not shapes
+            (not shapes and not self.classes)
             or any(len(s) not in (2, 3) for s in shapes)
             or any(v <= 0 for s in shapes for v in s)
         ):
             raise ValueError(
                 "Compile.shapes must be positive (w, h) or (w, h, frames) "
-                f"rows, got {self.shapes!r}"
+                f"rows (omittable only when classes= carries the coordinate "
+                f"rows), got {self.shapes!r}"
             )
         force(self, "shapes", shapes)
         targets = tuple(str(t).strip() for t in self.targets if str(t).strip())
@@ -727,6 +764,19 @@ class Compile(msgspec.Struct, frozen=True):
         if len({d.dim for d in dyn}) != len(dyn):
             raise ValueError("Compile.dynamic repeats a dim")
         force(self, "dynamic", dyn)
+        for name, typ in (("dims", Dim), ("forks", Fork),
+                          ("classes", GraphClass), ("inputs", Input),
+                          ("args", Arg)):
+            rows = tuple(getattr(self, name))
+            if any(not isinstance(r, typ) for r in rows):
+                raise TypeError(
+                    f"Compile.{name} must be a tuple of {typ.__name__} rows")
+            force(self, name, rows)
+        force(self, "shape_strategy", str(self.shape_strategy or "").strip())
+        if self.warm_changes_key is not None:
+            force(self, "warm_changes_key", bool(self.warm_changes_key))
+        force(self, "eager", tuple(str(e).strip() for e in self.eager))
+        validate_contract(self)
 
     @property
     def sequence_dynamic(self) -> Optional[DynamicDim]:
@@ -746,7 +796,7 @@ class Compile(msgspec.Struct, frozen=True):
         """The canonical shape-contract facts (feeds the cell key's
         contract digest — pgw#647: a worker on a newer contract must never
         consume an older cell)."""
-        return {
+        axes: Dict[str, Any] = {
             "shapes": [list(s) for s in self.shapes],
             "targets": list(self.targets),
             "text_len": self.text_len,
@@ -755,6 +805,25 @@ class Compile(msgspec.Struct, frozen=True):
             ],
             "regional": bool(self.regional),
         }
+        # pgw#739 declaration facts, present only when declared so a family
+        # that has not adopted the vocabulary keeps its existing digest.
+        if self.dims:
+            axes["dims"] = [d.as_row() for d in self.dims]
+        if self.forks:
+            axes["forks"] = [f.as_row() for f in self.forks]
+        if self.classes:
+            axes["classes"] = [c.as_row() for c in self.classes]
+        if self.inputs:
+            axes["inputs"] = [i.as_row() for i in self.inputs]
+        if self.args:
+            axes["args"] = [a.as_row() for a in self.args]
+        if self.shape_strategy:
+            axes["shape_strategy"] = self.shape_strategy
+        if self.warm_changes_key is not None:
+            axes["warm_changes_key"] = self.warm_changes_key
+        if self.eager:
+            axes["eager"] = list(self.eager)
+        return axes
 
 
 class EndpointDecl(msgspec.Struct, frozen=True, kw_only=True):
@@ -1408,6 +1477,13 @@ def endpoint(
             "unconditioned model, or a dynamic range via "
             "Compile(dynamic=(DynamicDim('sequence', min=.., max=..),))."
         )
+    if compile is not None and compile.classes and compile.family:
+        # pgw#739: a class-bearing declaration is the family's export
+        # contract; registering at decoration is what lets the mint derive
+        # export inputs with zero per-family SDK code.
+        from .export_contract import register_export_declaration
+
+        register_export_declaration(compile)
     bucket = int(lora_bucket or 0)
     if bucket:
         from ..models.w8a8_lora import RANK_BUCKETS

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -764,6 +764,29 @@ class Compile(msgspec.Struct, frozen=True):
         if len({d.dim for d in dyn}) != len(dyn):
             raise ValueError("Compile.dynamic repeats a dim")
         force(self, "dynamic", dyn)
+        if dyn and self.regional:
+            # OQ-7 (LTX-AOT-DESIGN.md): `_with_declared_marks` is applied only
+            # on the whole-graph branch. The regional branch calls
+            # compile_repeated_blocks(dynamic=None) and never marks, so this
+            # combination declares dynamism the trace never implements while
+            # the contract digest claims it — a key that asserts a contract the
+            # artifact does not honor, which is the exact failure class pgw#716
+            # exists to prevent.
+            #
+            # Refused by name rather than silently marked: regional is retiring
+            # (LTX §3.2 chose whole-transformer export), so teaching the
+            # regional branch to mark would be building on a lane that is going
+            # away. Refusal is the honest reading until it does.
+            raise ValueError(
+                "Compile(regional=True) cannot carry dynamic=(...): the "
+                "regional branch compiles repeated blocks and never applies "
+                "the declared marks, so the declaration would be silently "
+                "inert while the contract digest claimed the dynamism "
+                f"({', '.join(d.dim for d in dyn)}). Declare dynamic=() to "
+                "keep regional block compilation, or regional=False to get "
+                "the marks. Regional is retiring in favor of whole-graph "
+                "export (LTX-AOT-DESIGN.md §3.2)."
+            )
         for name, typ in (("dims", Dim), ("forks", Fork),
                           ("classes", GraphClass), ("inputs", Input),
                           ("args", Arg)):

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -19,6 +19,11 @@
   ``gen_worker.convert.publish_flavors(ctx, flavors)`` (one Tensorhub commit per
   ``ProducedFlavor``), and return a result struct. Generator handlers are
   rejected for producer kinds: nothing is ever published by yielding.
+* ``kind="eval"`` MEASURES a candidate against a reference (th#1255). It reads
+  reserved refs like every non-inference kind and writes request output assets,
+  but publishes no catalog repo — the hub refuses repo writes for eval tokens
+  and never asks an eval where its output repo goes. Its input struct declares
+  no destination, and that is the point.
 * An async-generator handler streams (inference only); there is no separate
   streaming decorator.
 * ``runtime="vllm"`` boots an engine-hosting server subprocess before setup.
@@ -48,7 +53,7 @@ from .tree import is_introspectable
 T = TypeVar("T")
 SlotLike = Union[Binding, Slot]
 
-KINDS = ("inference", "training", "dataset", "conversion")
+KINDS = ("inference", "training", "dataset", "conversion", "eval")
 RESERVED_METHODS = frozenset({"setup", "warmup", "shutdown"})
 
 

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -265,22 +265,28 @@ class GraphClass(msgspec.Struct, frozen=True):
 class Input(msgspec.Struct, frozen=True):
     """One example-input template of the export call contract.
 
-    ``name`` may be dotted for nested container kwargs (sdxl's
-    ``added_cond_kwargs.text_embeds``). ``shape`` entries are
-    :data:`AxisSpec`; a rank-0 tensor is ``shape=()`` with ``value``
-    (sdxl's scalar timestep). ``dtype`` "" means the resolved module's own
-    dtype (the resident-precision truth); anything else names an explicit
-    torch dtype (wan's int64 scalar timestep, ti2v's float32 per-token one).
-    ``positional`` inputs are emitted as args in declaration order — call
-    convention is part of the contract, because the serve side replays the
-    recorded pytree spec. ``targets`` scopes the row; empty = every target.
+    ``name`` may be dotted for nested container arguments (sdxl's
+    ``added_cond_kwargs.text_embeds`` — the container dict is built and fed
+    as ONE argument). ``shape`` entries are :data:`AxisSpec`; a rank-0
+    tensor is ``shape=()`` with ``value`` (sdxl's scalar timestep).
+    ``dtype`` "" means the resolved module's own dtype (the
+    resident-precision truth); anything else names an explicit torch dtype
+    (wan's int64 scalar timestep, ti2v's float32 per-token one).
+
+    There is NO args/kwargs choice to declare: all-positional example feeds
+    are a MINT OBLIGATION (pod 9, pgw#723 residuals — an AOTI package's call
+    convention mirrors the traced args/kwargs split, and the serve marshal
+    is positional, so a kwarg-traced package silently revokes to eager on
+    first call). The SDK binds each named row to its slot in the traced
+    signature and feeds everything positionally; declaring a name the
+    target takes only keyword-only is refused at mint time by name.
+    ``targets`` scopes the row; empty = every target.
     """
 
     name: str
     shape: Tuple[AxisSpec, ...]
     dtype: str = ""
     value: Optional[float] = None
-    positional: bool = False
     targets: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -307,9 +313,6 @@ class Input(msgspec.Struct, frozen=True):
                 shape.append(("config", str(ref[1]).strip()))
         force(self, "shape", tuple(shape))
         force(self, "dtype", str(self.dtype or "").strip())
-        if self.positional and "." in self.name:
-            raise DeclarationError(
-                f"Input {self.name!r} is dotted (nested) and cannot be positional")
         force(self, "targets", tuple(str(t).strip() for t in self.targets))
 
     @property
@@ -322,7 +325,6 @@ class Input(msgspec.Struct, frozen=True):
             "shape": [list(e) if isinstance(e, tuple) else e for e in self.shape],
             "dtype": self.dtype,
             "value": self.value,
-            "positional": self.positional,
             "targets": list(self.targets),
         }
 

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -1,0 +1,548 @@
+"""The declaration vocabulary for the AOT export contract (pgw#739).
+
+Paul's SDK-generic rule, applied to the export-input contract: per-family
+content is a DECLARATION in the endpoint spec, never worker code. This module
+defines the *vocabulary*; the endpoint writes the declaration;
+:mod:`gen_worker.aot_declaration` derives export inputs, dynamic-shape marks
+and mint plans from it. No family name appears in the SDK.
+
+The vocabulary, per the #739 ratification:
+
+- **NO formula DSL.** Endpoints emit RESOLVED ROWS (:class:`GraphClass`);
+  the vocabulary is named dims with ``(input, axis)`` bindings
+  (:class:`Dim`). Rows are coordinates, not expressions — the endpoint's own
+  legality oracle resolves them (LTX-AOT-DESIGN.md §2.3), and the SDK derives
+  every bound FROM the rows. A relational axis (wan ti2v's per-token
+  timestep) is a :class:`Dim` with ``relates_to``: the SDK derives its free
+  range from the rows and ``torch.export``'s solver unifies the relation into
+  the shape env (measured: ``31*s25*s56`` carried with 458 asserts, ie#566
+  §5) — endpoint hand-math is exactly what this prevents.
+- **Graph-class forks** (:class:`Fork`) bind to ``(source: pipeline|module,
+  field)``, not to ``module.config``: wan's ``expand_timesteps`` is a
+  ``WanPipeline`` field in ``model_index.json`` and is ABSENT from all four
+  transformer configs, so a builder that only reads module configs never
+  sees it (ie#566 G6).
+- **Shape strategy is a per-family DECLARED choice** (#730 ratification):
+  conv-bearing families declare ``static-rows`` (symbolic latent H/W turns
+  off inductor's channels-last layout opt — +7.2% measured on sdxl), DiTs
+  declare ``dynamic-collapse``.
+- **Mint-warm canon is a per-family DECLARED fact** (``warm_changes_key``):
+  sdxl measured False, z-image measured True (the rope pre-warm changes the
+  graph, 4327 cold vs 4285 warmed). A family with classes but no declared
+  canon is refused at mint time, not defaulted.
+"""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import (
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
+
+import msgspec
+
+#: A graph-class fork arm value. Bools are the common case (LTX's
+#: ``isolate_modalities``); ints/strs cover arity-style forks (z-image's CFG
+#: arity ``N``).
+ForkValue = Union[bool, int, str]
+
+#: One entry of an :class:`Input` shape template: a literal size, the NAME of
+#: a declared :class:`Dim` (resolved from the class row), or ``("config",
+#: field)`` — read off the resolved module's own config so a family member
+#: with a different width exports correctly instead of failing in the trace.
+AxisSpec = Union[int, str, Tuple[str, str]]
+
+STATIC_ROWS = "static-rows"
+DYNAMIC_COLLAPSE = "dynamic-collapse"
+SHAPE_STRATEGIES = (STATIC_ROWS, DYNAMIC_COLLAPSE)
+
+_FORK_SOURCES = ("pipeline", "module")
+
+
+class DeclarationError(ValueError):
+    """An export declaration is malformed. Raised at declaration time (module
+    import / ``Compile`` construction), never at mint time."""
+
+
+def _identifier(kind: str, name: Any) -> str:
+    text = str(name or "").strip()
+    if not text or not text.replace(".", "_").isidentifier():
+        raise DeclarationError(f"{kind} name {name!r} is not a valid identifier")
+    return text
+
+
+class Dim(msgspec.Struct, frozen=True):
+    """A named axis of the export contract with its ingress bindings.
+
+    ``carried_by`` is the ``(input, axis)`` binding set: every place this one
+    logical extent enters the traced call. This is what replaces the
+    two-literal ``DynamicDim.dim`` validation — wan's latent-spatial axis and
+    LTX's ``T_v`` are nameable — and it doubles as the ``Compile`` ->
+    ``aot_mint.DynamicDim`` bridge: the mint derives one
+    ``aot_mint.DynamicDim(input, axis, min, max, multiple_of)`` row per
+    binding.
+
+    A :class:`Dim` deliberately carries NO ``min``/``max``: bounds derive
+    from the declared :class:`GraphClass` rows (rows are coordinates), so
+    "these are the shapes we serve" is stated once and the admissible range
+    cannot drift from it. ``relates_to`` names the dims this axis is a
+    function of (wan ti2v: ``N_tok`` relates to ``F_lat``/``H_lat``/
+    ``W_lat``); the relation itself is NOT expressed — torch's solver
+    unifies it from the free derived range (ie#566 §5 remedy (a) part 2).
+    """
+
+    name: str
+    carried_by: Tuple[Tuple[str, int], ...]
+    multiple_of: int = 1
+    relates_to: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        force(self, "name", _identifier("Dim", self.name))
+        raw = tuple(self.carried_by)
+        if not raw:
+            raise DeclarationError(
+                f"Dim {self.name!r} declares no (input, axis) bindings — an "
+                f"unbound dim can never reach the traced call")
+        bindings: list[Tuple[str, int]] = []
+        for entry in raw:
+            if len(tuple(entry)) != 2:
+                raise DeclarationError(
+                    f"Dim {self.name!r}: binding {entry!r} is not (input, axis)")
+            inp, axis = entry
+            inp = str(inp or "").strip()
+            if not inp:
+                raise DeclarationError(
+                    f"Dim {self.name!r}: binding names an empty input")
+            axis = int(axis)
+            if axis < 0:
+                raise DeclarationError(
+                    f"Dim {self.name!r}: binding {inp!r} has negative axis {axis}")
+            if (inp, axis) in bindings:
+                raise DeclarationError(
+                    f"Dim {self.name!r} repeats binding ({inp!r}, {axis})")
+            bindings.append((inp, axis))
+        force(self, "carried_by", tuple(bindings))
+        mult = int(self.multiple_of)
+        if mult < 1:
+            raise DeclarationError(
+                f"Dim {self.name!r}: multiple_of must be >= 1, got {mult}")
+        force(self, "multiple_of", mult)
+        rel = tuple(_identifier("Dim.relates_to", n) for n in self.relates_to)
+        if self.name in rel:
+            raise DeclarationError(f"Dim {self.name!r} relates_to itself")
+        if len(set(rel)) != len(rel):
+            raise DeclarationError(f"Dim {self.name!r} repeats a relates_to name")
+        force(self, "relates_to", rel)
+
+    def as_row(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "carried_by": [list(b) for b in self.carried_by],
+            "multiple_of": self.multiple_of,
+            "relates_to": list(self.relates_to),
+        }
+
+
+class Fork(msgspec.Struct, frozen=True):
+    """A declared flag that FORKS the graph class rather than varying within
+    it (LTX's ``isolate_modalities``: 20,509 vs 30,877 nodes behind one
+    declaration).
+
+    ``served``/``unserved`` partition the arms: every declared
+    :class:`GraphClass` must sit on a served arm, and declaring a class on an
+    unserved arm is refused by name. ``source`` is the ``(pipeline|module,
+    field)`` binding the mint asserts against the composed pipeline — a fork
+    without a source (LTX's ``cfg``/``stg`` are call-argument facts) is
+    keyed but cannot be asserted from composition. ``targets`` scopes the
+    fork to a subset of ``Compile.targets`` (wan's ``use_tiling`` lives on
+    the VAE, not the denoiser); empty means every target.
+    """
+
+    name: str
+    served: Tuple[ForkValue, ...]
+    unserved: Tuple[ForkValue, ...] = ()
+    source: Optional[Tuple[str, str]] = None
+    targets: Tuple[str, ...] = ()
+    why: str = ""
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        force(self, "name", _identifier("Fork", self.name))
+        served = tuple(self.served)
+        if not served:
+            raise DeclarationError(
+                f"Fork {self.name!r} declares no served arm — a fork nothing "
+                f"serves is not a graph class, it is dead vocabulary")
+        unserved = tuple(self.unserved)
+        overlap = [v for v in served if v in unserved]
+        if overlap:
+            raise DeclarationError(
+                f"Fork {self.name!r}: arm(s) {overlap!r} declared BOTH served "
+                f"and unserved")
+        force(self, "served", served)
+        force(self, "unserved", unserved)
+        if self.source is not None:
+            src = tuple(self.source)
+            if len(src) != 2 or src[0] not in _FORK_SOURCES or not str(src[1]).strip():
+                raise DeclarationError(
+                    f"Fork {self.name!r}: source must be "
+                    f"(\"pipeline\"|\"module\", field), got {self.source!r}")
+            force(self, "source", (str(src[0]), str(src[1]).strip()))
+        force(self, "targets", tuple(str(t).strip() for t in self.targets))
+        force(self, "why", str(self.why or ""))
+
+    def as_row(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "served": list(self.served),
+            "unserved": list(self.unserved),
+            "source": list(self.source) if self.source else None,
+            "targets": list(self.targets),
+        }
+
+
+def _sorted_pairs(kind: str, owner: str, value: Any) -> Tuple[Tuple[str, Any], ...]:
+    if isinstance(value, Mapping):
+        items = list(value.items())
+    else:
+        items = [tuple(entry) for entry in value]
+    out: list[Tuple[str, Any]] = []
+    for entry in items:
+        if len(entry) != 2:
+            raise DeclarationError(f"{owner}: {kind} entry {entry!r} is not (name, value)")
+        out.append((str(entry[0]).strip(), entry[1]))
+    names = [n for n, _ in out]
+    if len(set(names)) != len(names):
+        raise DeclarationError(f"{owner}: {kind} repeats a name")
+    return tuple(sorted(out))
+
+
+class GraphClass(msgspec.Struct, frozen=True):
+    """One RESOLVED coordinate a legal request can trace: dim values plus
+    fork arm values. Generated by the endpoint's own legality oracle —
+    pgw#669: the payload is the legality oracle for the sparse legal set —
+    so the relation behind a relational axis stays in the one place that can
+    be right about it, and the declaration carries only its resolved values.
+
+    Accepts mappings at construction (``GraphClass(fork={...}, dims={...})``,
+    the LTX §2.3 draft form) and normalizes to sorted pairs, so instances
+    are hashable and endpoint generators can dedupe with ``dict.fromkeys``.
+    """
+
+    dims: Any
+    fork: Any = ()
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        dims = _sorted_pairs("dims", "GraphClass", self.dims)
+        if not dims:
+            raise DeclarationError("GraphClass declares no dim values")
+        for name, value in dims:
+            if int(value) <= 0:
+                raise DeclarationError(
+                    f"GraphClass dim {name!r} has non-positive value {value!r}")
+        force(self, "dims", tuple((n, int(v)) for n, v in dims))
+        force(self, "fork", _sorted_pairs("fork", "GraphClass", self.fork))
+
+    @property
+    def dim_map(self) -> Dict[str, int]:
+        return dict(self.dims)
+
+    @property
+    def fork_map(self) -> Dict[str, ForkValue]:
+        return dict(self.fork)
+
+    def as_row(self) -> Dict[str, Any]:
+        return {"dims": dict(self.dims), "fork": dict(self.fork)}
+
+
+class Input(msgspec.Struct, frozen=True):
+    """One example-input template of the export call contract.
+
+    ``name`` may be dotted for nested container kwargs (sdxl's
+    ``added_cond_kwargs.text_embeds``). ``shape`` entries are
+    :data:`AxisSpec`; a rank-0 tensor is ``shape=()`` with ``value``
+    (sdxl's scalar timestep). ``dtype`` "" means the resolved module's own
+    dtype (the resident-precision truth); anything else names an explicit
+    torch dtype (wan's int64 scalar timestep, ti2v's float32 per-token one).
+    ``positional`` inputs are emitted as args in declaration order — call
+    convention is part of the contract, because the serve side replays the
+    recorded pytree spec. ``targets`` scopes the row; empty = every target.
+    """
+
+    name: str
+    shape: Tuple[AxisSpec, ...]
+    dtype: str = ""
+    value: Optional[float] = None
+    positional: bool = False
+    targets: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        force(self, "name", _identifier("Input", self.name))
+        shape: list[AxisSpec] = []
+        for entry in tuple(self.shape):
+            if isinstance(entry, bool):
+                raise DeclarationError(
+                    f"Input {self.name!r}: bool is not an axis spec")
+            if isinstance(entry, int):
+                if entry <= 0:
+                    raise DeclarationError(
+                        f"Input {self.name!r}: literal axis {entry} must be positive")
+                shape.append(entry)
+            elif isinstance(entry, str):
+                shape.append(_identifier(f"Input {self.name!r} axis", entry))
+            else:
+                ref = tuple(entry)
+                if len(ref) != 2 or ref[0] != "config" or not str(ref[1]).strip():
+                    raise DeclarationError(
+                        f"Input {self.name!r}: axis spec {entry!r} is not an "
+                        f"int, a dim name, or (\"config\", field)")
+                shape.append(("config", str(ref[1]).strip()))
+        force(self, "shape", tuple(shape))
+        force(self, "dtype", str(self.dtype or "").strip())
+        if self.positional and "." in self.name:
+            raise DeclarationError(
+                f"Input {self.name!r} is dotted (nested) and cannot be positional")
+        force(self, "targets", tuple(str(t).strip() for t in self.targets))
+
+    @property
+    def top_name(self) -> str:
+        return self.name.split(".", 1)[0]
+
+    def as_row(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "shape": [list(e) if isinstance(e, tuple) else e for e in self.shape],
+            "dtype": self.dtype,
+            "value": self.value,
+            "positional": self.positional,
+            "targets": list(self.targets),
+        }
+
+
+class Arg(msgspec.Struct, frozen=True):
+    """A non-tensor literal argument of the export call (``return_dict=False``
+    — a dataclass output is not a valid export output; the consumer
+    re-wraps)."""
+
+    name: str
+    value: Union[bool, int, float, str, None]
+    targets: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        force = msgspec.structs.force_setattr
+        force(self, "name", _identifier("Arg", self.name))
+        force(self, "targets", tuple(str(t).strip() for t in self.targets))
+
+    def as_row(self) -> Dict[str, Any]:
+        return {"name": self.name, "value": self.value, "targets": list(self.targets)}
+
+
+def validate_contract(compile_decl: Any) -> None:
+    """Cross-validate the #739 declaration fields on a ``Compile``.
+
+    Called from ``Compile.__post_init__`` — a malformed declaration fails at
+    endpoint import, never on a mint pod. Every refusal names the offending
+    thing.
+    """
+    dims: Tuple[Dim, ...] = compile_decl.dims
+    forks: Tuple[Fork, ...] = compile_decl.forks
+    classes: Tuple[GraphClass, ...] = compile_decl.classes
+    inputs: Tuple[Input, ...] = compile_decl.inputs
+    args: Tuple[Arg, ...] = compile_decl.args
+    targets = tuple(compile_decl.targets)
+
+    dim_names = [d.name for d in dims]
+    if len(set(dim_names)) != len(dim_names):
+        raise DeclarationError("Compile.dims repeats a dim name")
+    fork_names = [f.name for f in forks]
+    if len(set(fork_names)) != len(fork_names):
+        raise DeclarationError("Compile.forks repeats a fork name")
+    shared = set(dim_names) & set(fork_names)
+    if shared:
+        raise DeclarationError(
+            f"name(s) {sorted(shared)!r} declared as BOTH a dim and a fork")
+
+    for d in dims:
+        unknown = sorted(set(d.relates_to) - set(dim_names))
+        if unknown:
+            raise DeclarationError(
+                f"Dim {d.name!r} relates_to undeclared dim(s) {unknown!r}")
+
+    for f in forks:
+        bad = sorted(set(f.targets) - set(targets))
+        if bad:
+            raise DeclarationError(
+                f"Fork {f.name!r} names target(s) {bad!r} not in "
+                f"Compile.targets {list(targets)!r}")
+    scoped: Tuple[Union[Input, Arg], ...] = (*inputs, *args)
+    for row in scoped:
+        bad = sorted(set(row.targets) - set(targets))
+        if bad:
+            raise DeclarationError(
+                f"{type(row).__name__} {row.name!r} names target(s) {bad!r} "
+                f"not in Compile.targets {list(targets)!r}")
+
+    if classes and not dims:
+        raise DeclarationError(
+            "Compile.classes declared without Compile.dims — rows are "
+            "coordinates over named dims")
+
+    served_by_fork = {f.name: set(f.served) for f in forks}
+    unserved_by_fork = {f.name: set(f.unserved) for f in forks}
+    seen: set = set()
+    for i, cls in enumerate(classes):
+        if cls in seen:
+            raise DeclarationError(f"Compile.classes repeats row #{i}: {cls.as_row()!r}")
+        seen.add(cls)
+        missing = sorted(set(dim_names) - set(cls.dim_map))
+        if missing:
+            raise DeclarationError(
+                f"graph class #{i} omits declared dim(s) {missing!r}")
+        unknown = sorted(set(cls.dim_map) - set(dim_names))
+        if unknown:
+            raise DeclarationError(
+                f"graph class #{i} carries undeclared dim(s) {unknown!r}")
+        # The omitted-fork refusal (#739 red test): a coordinate that varies
+        # on a flag the vocabulary does not declare would be silently
+        # exported into one class; a declared flag a coordinate does not
+        # state is the same defect read the other way.
+        missing_f = sorted(set(fork_names) - set(cls.fork_map))
+        if missing_f:
+            raise DeclarationError(
+                f"graph class #{i} omits declared fork(s) {missing_f!r} — "
+                f"every class states every fork arm, or two graph classes "
+                f"hide behind one declaration")
+        unknown_f = sorted(set(cls.fork_map) - set(fork_names))
+        if unknown_f:
+            raise DeclarationError(
+                f"graph class #{i} carries fork(s) {unknown_f!r} that "
+                f"Compile.forks does not declare — declare the forking flag "
+                f"by name rather than silently exporting into one class")
+        for name, value in cls.fork:
+            if value in unserved_by_fork.get(name, set()):
+                raise DeclarationError(
+                    f"graph class #{i} sits on UNSERVED arm {name}={value!r}")
+            if value not in served_by_fork.get(name, set()):
+                raise DeclarationError(
+                    f"graph class #{i}: fork {name}={value!r} is not a "
+                    f"declared arm (served: {sorted(map(repr, served_by_fork.get(name, set())))})")
+
+    strategy = str(compile_decl.shape_strategy or "")
+    if strategy and strategy not in SHAPE_STRATEGIES:
+        raise DeclarationError(
+            f"Compile.shape_strategy must be one of {SHAPE_STRATEGIES!r} "
+            f"(#730: conv-bearing families declare {STATIC_ROWS!r}, DiTs "
+            f"{DYNAMIC_COLLAPSE!r}), got {strategy!r}")
+
+    # Rows are coordinates: with classes declared, a hand-written range on a
+    # named dim is exactly the endpoint hand-math #739 exists to prevent.
+    for dd in compile_decl.dynamic:
+        if dd.dim in ("batch", "sequence"):
+            continue
+        if dd.dim not in dim_names:
+            raise DeclarationError(
+                f"Compile.dynamic names {dd.dim!r}, which is neither "
+                f"\"batch\"/\"sequence\" nor a declared Dim "
+                f"(declared: {dim_names!r})")
+        if classes:
+            raise DeclarationError(
+                f"Compile.dynamic hand-ranges dim {dd.dim!r} while classes "
+                f"are declared — bounds derive from the class rows "
+                f"(rows are coordinates, #739); delete the hand range")
+
+    # Input rows must be unambiguous per target.
+    for target in targets or ("",):
+        names: set[str] = set()
+        for inp in inputs:
+            if inp.targets and target not in inp.targets:
+                continue
+            if inp.name in names:
+                raise DeclarationError(
+                    f"Input {inp.name!r} is declared twice for target {target!r}")
+            names.add(inp.name)
+
+    # A binding may belong to any target's inputs; refuse only when NO
+    # declared Input row knows the name at all.
+    if inputs:
+        known = {i.name for i in inputs} | {i.top_name for i in inputs}
+        for d in dims:
+            for bound, _axis in d.carried_by:
+                if bound not in known and bound.split(".", 1)[0] not in known:
+                    raise DeclarationError(
+                        f"Dim {d.name!r} binds input {bound!r}, which no "
+                        f"declared Input row names")
+
+
+# ---------------------------------------------------------------------------
+# The export-declaration registry (the #740 pattern: vocabulary here,
+# registrations in the endpoint, derivation in gen_worker.aot_declaration).
+# ---------------------------------------------------------------------------
+
+_lock = RLock()
+_declared: Dict[str, Any] = {}
+
+
+def register_export_declaration(compile_decl: Any, *, replace: bool = False) -> Any:
+    """Register one family's export declaration (a ``Compile`` carrying
+    classes). Idempotent for an identical declaration; refuses a conflicting
+    one by name."""
+    family = str(getattr(compile_decl, "family", "") or "").strip()
+    if not family:
+        raise DeclarationError(
+            "cannot register an export declaration with no Compile.family")
+    if not getattr(compile_decl, "classes", ()):
+        raise DeclarationError(
+            f"export declaration for {family!r} carries no graph classes — "
+            f"there is nothing to derive from")
+    with _lock:
+        existing = _declared.get(family)
+        if existing is not None and existing != compile_decl and not replace:
+            raise DeclarationError(
+                f"family {family!r} already has a DIFFERENT export "
+                f"declaration registered; pass replace=True only if you own both")
+        _declared[family] = compile_decl
+    return compile_decl
+
+
+def export_declaration(family: str) -> Optional[Any]:
+    with _lock:
+        return _declared.get(str(family or "").strip())
+
+
+def registered_export_families() -> Tuple[str, ...]:
+    with _lock:
+        return tuple(sorted(_declared))
+
+
+def reset_export_declarations() -> None:
+    """Drop every registration. Tests only."""
+    with _lock:
+        _declared.clear()
+
+
+__all__ = [
+    "Arg",
+    "AxisSpec",
+    "DYNAMIC_COLLAPSE",
+    "DeclarationError",
+    "Dim",
+    "Fork",
+    "ForkValue",
+    "GraphClass",
+    "Input",
+    "SHAPE_STRATEGIES",
+    "STATIC_ROWS",
+    "export_declaration",
+    "register_export_declaration",
+    "registered_export_families",
+    "reset_export_declarations",
+    "validate_contract",
+]

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -202,9 +202,9 @@ def build_local_context(
     """Factory: build the right context subclass for ``kind``.
 
     ``kind`` is the endpoint's declared kind string from discover_manifest
-    (``inference`` / ``conversion`` / ``dataset`` / ``training``). Unknown
-    kinds fall back to ``RequestContext`` because the SDK guarantees the
-    base methods on every variant.
+    (``inference`` / ``conversion`` / ``dataset`` / ``training`` / ``eval``).
+    Unknown kinds fall back to ``RequestContext`` because the SDK guarantees
+    the base methods on every variant.
     """
     rid = request_id or _local_request_id()
     em = emitter if emitter is not None else _stderr_emitter
@@ -219,7 +219,7 @@ def build_local_context(
     }
 
     k = (kind or "").strip().lower()
-    if k == "conversion":
+    if k in ("conversion", "eval"):
         return LocalConversionContext(allow_publish=allow_publish, **common)
     if k == "dataset":
         return LocalDatasetContext(allow_publish=allow_publish, **common)

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -34,6 +34,7 @@ The full design lives in ``progress.json`` issue #340.
 
 from __future__ import annotations
 
+from ..component_vocab import weight_components
 import argparse
 import json
 import os
@@ -623,11 +624,6 @@ def _build_residency(vram_budget_gb: float = 0.0) -> Optional[Residency]:
 
 # diffusers/transformers pipeline-ish duck type: has .to() AND at least one of
 # the common module slots / a components mapping.
-_PIPELINE_SLOTS = (
-    "unet", "transformer", "vae", "text_encoder", "text_encoder_2", "text_encoder_3",
-)
-
-
 def _looks_like_pipeline(obj: Any) -> bool:
     if obj is None:
         return False
@@ -636,7 +632,7 @@ def _looks_like_pipeline(obj: Any) -> bool:
     comps = getattr(obj, "components", None)
     if isinstance(comps, dict) and comps:
         return True
-    return any(getattr(obj, slot, None) is not None for slot in _PIPELINE_SLOTS)
+    return any(getattr(obj, slot, None) is not None for slot in weight_components())
 
 
 def _find_pipeline_object(instance: Any) -> Optional[Any]:

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2374,8 +2374,17 @@ def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callabl
         if not isinstance(t, torch.Tensor) or not t.is_floating_point():
             return
         for d in dynamic_dims:
-            dim = 0 if d.dim == "batch" else (1 if t.dim() >= 3 else -1)
-            if dim < 0 or t.dim() <= dim:
+            # Only the two logical dynamo axes are markable here. A named
+            # declared Dim (pgw#739) carries (input, axis) bindings and is
+            # the EXPORT lane's business — marking it at axis 1 by the old
+            # sequence heuristic would mark the wrong axis silently.
+            if d.dim == "batch":
+                dim = 0
+            elif d.dim == "sequence" and t.dim() >= 3:
+                dim = 1
+            else:
+                continue
+            if t.dim() <= dim:
                 continue
             if int(t.shape[dim]) < int(d.min):
                 continue  # 0/1 (and sub-min) sizes keep their free static graph

--- a/src/gen_worker/component_vocab.py
+++ b/src/gen_worker/component_vocab.py
@@ -32,11 +32,17 @@ class ComponentVocabulary:
     text_encoders: tuple[str, ...]
     vaes: tuple[str, ...]
     extras: tuple[str, ...]
+    #: Weight-bearing components that are not one of the three primary roles
+    #: (``controlnet``, ``prior``, ``decoder``, ``image_encoder``). They carry
+    #: tensors — so they are walked, sized and quantized — but no consumer ever
+    #: picks "the denoiser" or "the VAE" and means one of these.
+    auxiliaries: tuple[str, ...] = ()
 
     @property
     def all(self) -> tuple[str, ...]:
         seen: dict[str, None] = {}
-        for group in (self.denoisers, self.text_encoders, self.vaes, self.extras):
+        for group in (self.denoisers, self.text_encoders, self.vaes,
+                      self.auxiliaries, self.extras):
             for name in group:
                 seen.setdefault(name, None)
         return tuple(seen)
@@ -58,6 +64,8 @@ class ComponentVocabulary:
             return "text_encoder"
         if head in self.vaes:
             return "vae"
+        if head in self.auxiliaries:
+            return "auxiliary"
         if head in self.extras:
             return "extra"
         return "unknown"
@@ -79,7 +87,9 @@ _GENERIC = ComponentVocabulary(
     denoisers=("transformer", "unet", "transformer_2", "dit"),
     text_encoders=("text_encoder", "text_encoder_2", "text_encoder_3", "text_encoder_4"),
     vaes=("vae", "vae_encoder", "vae_decoder"),
-    extras=("image_encoder", "scheduler", "tokenizer", "tokenizer_2", "tokenizer_3"),
+    extras=("scheduler", "tokenizer", "tokenizer_2", "tokenizer_3",
+            "feature_extractor", "safety_checker"),
+    auxiliaries=("image_encoder", "controlnet", "prior", "decoder"),
 )
 
 _lock = RLock()
@@ -98,6 +108,7 @@ def declare_components(
     text_encoders: tuple[str, ...] = (),
     vaes: tuple[str, ...] = (),
     extras: tuple[str, ...] = (),
+    auxiliaries: tuple[str, ...] = (),
 ) -> ComponentVocabulary:
     """Extend the vocabulary from an endpoint declaration. Additive and idempotent.
 
@@ -112,6 +123,7 @@ def declare_components(
             text_encoders=_merge(_current.text_encoders, text_encoders),
             vaes=_merge(_current.vaes, vaes),
             extras=_merge(_current.extras, extras),
+            auxiliaries=_merge(_current.auxiliaries, auxiliaries),
         )
         return _current
 
@@ -136,14 +148,43 @@ def denoiser_components() -> tuple[str, ...]:
     return component_vocabulary().denoisers
 
 
+def text_encoder_components() -> tuple[str, ...]:
+    return component_vocabulary().text_encoders
+
+
 def weight_components() -> tuple[str, ...]:
-    """Components that carry weights worth quantizing/offloading/walking."""
+    """Components that carry weights worth quantizing/offloading/walking.
+
+    Everything except the config-only extras (scheduler, tokenizers,
+    feature_extractor, safety_checker).
+    """
     vocab = component_vocabulary()
-    return tuple(
-        name
-        for name in vocab.all
-        if name not in vocab.extras or name == "image_encoder"
-    )
+    return _concat(vocab.denoisers, vocab.text_encoders, vocab.vaes, vocab.auxiliaries)
+
+
+def quant_candidate_components() -> tuple[str, ...]:
+    """Weight-bearing components a quantization pass may target.
+
+    :func:`weight_components` minus the VAEs. A quantized VAE is the first
+    thing to show as visible artifacting, so QUANTIZATION-POLICY.md keeps it
+    at compute precision and no default pass proposes it. Callers that want a
+    VAE quantized must name it explicitly.
+    """
+    vocab = component_vocabulary()
+    return _concat(vocab.denoisers, vocab.text_encoders, vocab.auxiliaries)
+
+
+def pipeline_component_dirs() -> tuple[str, ...]:
+    """Every known component subdirectory name in a diffusers snapshot."""
+    return component_vocabulary().all
+
+
+def _concat(*groups: tuple[str, ...]) -> tuple[str, ...]:
+    seen: dict[str, None] = {}
+    for group in groups:
+        for name in group:
+            seen.setdefault(name, None)
+    return tuple(seen)
 
 
 __all__ = [
@@ -151,6 +192,9 @@ __all__ = [
     "component_vocabulary",
     "declare_components",
     "denoiser_components",
+    "pipeline_component_dirs",
+    "quant_candidate_components",
     "reset_component_vocabulary",
+    "text_encoder_components",
     "weight_components",
 ]

--- a/src/gen_worker/convert/__init__.py
+++ b/src/gen_worker/convert/__init__.py
@@ -69,7 +69,7 @@ from .publish import publish_flavors
 from .source import FileLayout, Source
 from .svdq import build_svdq_flavor_tree, fetch_svdq_checkpoint, svdq_flavor_label
 from .writer import (
-    FP8_TE_COMPONENTS,
+    fp8_te_components,
     streaming_cast_snapshot,
     streaming_dtype_cast,
     streaming_fp8_snapshot,
@@ -105,7 +105,7 @@ __all__ = [
     "streaming_w8a8_cast",
     "streaming_w8a8_snapshot",
     "verify_w8a8_snapshot",
-    "FP8_TE_COMPONENTS",
+    "fp8_te_components",
     "CalibrationAction",
     "CalibrationPolicy",
     "resolve_calibration_action",

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -38,7 +38,7 @@ from .ingest import (
 )
 from .writer import (
     CAST_NORMALIZE_DTYPES as _CAST_NORMALIZE_DTYPES,
-    FP8_DEFAULT_COMPONENTS,
+    fp8_default_components,
     MAX_SAFETENSORS_SHARD_BYTES,
     VARIANT_WEIGHT_NAME_RE as _VARIANT_WEIGHT_NAME_RE,
     apply_objective_scheduler_config,
@@ -68,11 +68,11 @@ _KNOWN_DTYPES = {
     "f16", "f32", "q8_0", "q6_k", "q5_k_m", "q5_k_s", "q4_k_m", "q4_k_s",
     "q4_0", "q4_1", "q3_k_m", "q3_k_s", "q2_k",
 }
+from ..component_vocab import quant_candidate_components
 _KNOWN_FILE_LAYOUTS = {"diffusers", "singlefile"}
 _KNOWN_FILE_TYPES = {"safetensors", "gguf"}
 
-_DEFAULT_QUANT_COMPONENTS = ("transformer", "unet", "text_encoder", "text_encoder_2",
-                             "text_encoder_3", "image_encoder", "prior", "controlnet")
+_default_quant_components = quant_candidate_components
 _MIN_CONVERT_BYTES = 100 * 1024 * 1024  # leave tiny weights (embeddings) untouched
 
 
@@ -424,9 +424,9 @@ def build_flavor_tree(
     elif is_fp8:
         # Denoiser-only by default: matches apply_fp8_storage's consumption
         # scope; TEs join explicitly via the component-wise ladder (gw#392).
-        target_names = set(FP8_DEFAULT_COMPONENTS)
+        target_names = set(fp8_default_components())
     else:
-        target_names = set(_DEFAULT_QUANT_COMPONENTS)
+        target_names = set(_default_quant_components())
     is_quant = spec.dtype not in {"bf16", "fp16", "fp32", "f16", "f32"}
     converted: set[str] = set()
     for comp, entry in groups:

--- a/src/gen_worker/convert/convert.py
+++ b/src/gen_worker/convert/convert.py
@@ -507,13 +507,11 @@ def _run_bnb_inline(
     )
 
 
+from ..component_vocab import quant_candidate_components
 # Components that hold quantizable weights (DiT, UNet, text encoders, etc.).
 # Everything not in this set passes through unchanged.
-_DIFFUSERS_QUANT_COMPONENTS: frozenset[str] = frozenset({
-    "transformer", "unet",
-    "text_encoder", "text_encoder_2", "text_encoder_3",
-    "image_encoder", "prior", "controlnet",
-})
+def _diffusers_quant_components() -> frozenset[str]:
+    return frozenset(quant_candidate_components())
 
 # Top-level files copied verbatim into the destination snapshot.
 _DIFFUSERS_ROOT_FILES: tuple[str, ...] = (
@@ -557,7 +555,7 @@ def _run_bnb_diffusers_inline(
         comp_name = entry.name
         comp_out = out_dir / comp_name
 
-        if comp_name in _DIFFUSERS_QUANT_COMPONENTS:
+        if comp_name in _diffusers_quant_components():
             cfg_path = entry / "config.json"
             if not cfg_path.is_file():
                 _shutil.copytree(entry, comp_out, dirs_exist_ok=True)
@@ -607,7 +605,7 @@ def _run_bnb_diffusers_inline(
             reason=(
                 f"diffusers source at {repo_dir} has no quantizable "
                 f"components for {dtype} (looked for: "
-                f"{sorted(_DIFFUSERS_QUANT_COMPONENTS)})"
+                f"{sorted(_diffusers_quant_components())})"
             ),
             target_dtype=dtype,
         )

--- a/src/gen_worker/convert/layout_spec.py
+++ b/src/gen_worker/convert/layout_spec.py
@@ -14,6 +14,7 @@ one :class:`LayoutDeclaration` in its endpoint repo.
 from __future__ import annotations
 
 import re
+from ..component_vocab import pipeline_component_dirs
 from dataclasses import dataclass, field
 
 from .repack_spec import DeclarationError
@@ -131,19 +132,10 @@ class LayoutDeclaration:
 class LayoutSignals:
     """Generic, family-free evidence that a directory is a diffusers tree at all."""
 
+    # default_factory (not a literal default) so the vocabulary is read when a
+    # LayoutSignals is constructed, after endpoint declarations (pgw#740 B5).
     component_dirs: frozenset[str] = field(
-        default_factory=lambda: frozenset(
-            {
-                "unet",
-                "vae",
-                "text_encoder",
-                "text_encoder_2",
-                "tokenizer",
-                "tokenizer_2",
-                "scheduler",
-                "transformer",
-            }
-        )
+        default_factory=lambda: frozenset(pipeline_component_dirs())
     )
     index_file: str = "model_index.json"
     weight_suffixes: tuple[str, ...] = (".safetensors", ".gguf")

--- a/src/gen_worker/convert/size_walk.py
+++ b/src/gen_worker/convert/size_walk.py
@@ -31,25 +31,18 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ..component_vocab import weight_components
+
 # Weight file extensions counted toward a component's size. Restricted to
 # real weight containers — config.json, tokenizer.json, README, etc. are
 # excluded since they don't load into VRAM.
 _WEIGHT_EXTS: tuple[str, ...] = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".gguf")
 
-# Component subdirs that are weight-bearing. Matches gen-worker's
-# conversion._DIFFUSERS_COMPONENT_DIRS roughly; kept local so we don't
-# import a heavy module.
-_DIFFUSERS_WEIGHT_COMPONENT_DIRS: frozenset[str] = frozenset({
-    "transformer",
-    "unet",
-    "vae",
-    "text_encoder",
-    "text_encoder_2",
-    "text_encoder_3",
-    "image_encoder",
-    "prior",
-    "controlnet",
-})
+# Component subdirs that are weight-bearing — read from the ONE vocabulary at
+# call time (pgw#740 B5), so a component an endpoint declares is sized too
+# rather than silently contributing zero bytes.
+def _diffusers_weight_component_dirs() -> frozenset[str]:
+    return frozenset(weight_components())
 
 
 def compute_size_facts(snapshot_path: Path | str) -> dict[str, Any]:
@@ -73,7 +66,7 @@ def compute_size_facts(snapshot_path: Path | str) -> dict[str, Any]:
     # Diffusers layout: per-component subdirs.
     diffusers_entries = [
         entry for entry in path.iterdir()
-        if entry.is_dir() and entry.name in _DIFFUSERS_WEIGHT_COMPONENT_DIRS
+        if entry.is_dir() and entry.name in _diffusers_weight_component_dirs()
     ]
     if diffusers_entries:
         for entry in sorted(diffusers_entries):

--- a/src/gen_worker/convert/source.py
+++ b/src/gen_worker/convert/source.py
@@ -32,21 +32,24 @@ FileLayout = Literal["singlefile", "diffusers"]
 # config / tokenizer / scheduler / non-quantizable bits that should travel
 # verbatim into the output snapshot. vae is here because most quant tenants
 # (bnb) leave the vae bf16; modelopt may override per spec.
-_DEFAULT_PASSTHROUGH_COMPONENTS: frozenset[str] = frozenset({
-    "vae", "scheduler",
-    "tokenizer", "tokenizer_2", "tokenizer_3",
-    "feature_extractor", "safety_checker",
-})
+def _default_passthrough_components() -> frozenset[str]:
+    """Everything a default quant pass leaves alone: the config-only extras
+    plus the VAEs (weight_components minus quant_candidate_components)."""
+    vocab = component_vocabulary()
+    return frozenset(vocab.vaes + vocab.extras)
 
+from ..component_vocab import (
+    component_vocabulary,
+    pipeline_component_dirs,
+    quant_candidate_components,
+    weight_components,
+)
 # Components that are candidates for quantization. text_encoder_3 is in here
 # because flux.2-klein-9b / SD3 use three text encoders; older tenants that
 # hardcoded ('transformer', 'unet', 'text_encoder', 'text_encoder_2', 'vae')
 # silently skipped text_encoder_3.
-_DEFAULT_QUANT_CANDIDATE_COMPONENTS: frozenset[str] = frozenset({
-    "transformer", "unet",
-    "text_encoder", "text_encoder_2", "text_encoder_3",
-    "image_encoder", "prior", "controlnet",
-})
+def _default_quant_candidate_components() -> frozenset[str]:
+    return frozenset(quant_candidate_components())
 
 # Top-level file basenames yielded by the synthetic '_root' LoadedComponent.
 # model_index.json is the diffusers pipeline manifest; everything else is
@@ -60,18 +63,12 @@ _ROOT_PASSTHROUGH_FILES: tuple[str, ...] = (
 )
 
 
-_DIFFUSERS_COMPONENT_DIRS: frozenset[str] = frozenset({
-    "unet", "transformer", "vae", "text_encoder", "text_encoder_2",
-    "text_encoder_3", "image_encoder", "prior", "controlnet", "scheduler",
-    "tokenizer", "tokenizer_2", "tokenizer_3", "feature_extractor",
-    "safety_checker",
-})
+def _diffusers_component_dirs() -> frozenset[str]:
+    return frozenset(pipeline_component_dirs())
 # Component dirs that carry model weights (as opposed to scheduler/tokenizer
 # configuration). iter_tensors skips the rest unless explicitly named.
-_WEIGHT_COMPONENT_DIRS: frozenset[str] = frozenset({
-    "unet", "transformer", "vae", "text_encoder", "text_encoder_2",
-    "text_encoder_3", "image_encoder", "prior", "controlnet",
-})
+def _weight_component_dirs() -> frozenset[str]:
+    return frozenset(weight_components())
 
 
 def _detect_file_layout(path: Path) -> FileLayout:
@@ -89,7 +86,7 @@ def _enumerate_components(path: Path) -> dict[str, Component]:
     for entry in sorted(path.iterdir()):
         if not entry.is_dir():
             continue
-        if entry.name in _DIFFUSERS_COMPONENT_DIRS:
+        if entry.name in _diffusers_component_dirs():
             result[entry.name] = Component(entry.name, entry)
     return result
 
@@ -291,7 +288,7 @@ class Source:
         weight_exts = (".safetensors", ".bin", ".pt", ".pth", ".ckpt")
         total = 0
         if self._file_layout == "diffusers":
-            for comp_name in _WEIGHT_COMPONENT_DIRS:
+            for comp_name in _weight_component_dirs():
                 comp_path = self._path / comp_name
                 if not comp_path.is_dir():
                     continue
@@ -383,12 +380,12 @@ class Source:
         quant_set = (
             frozenset(quant_only)
             if quant_only is not None
-            else _DEFAULT_QUANT_CANDIDATE_COMPONENTS
+            else _default_quant_candidate_components()
         )
         passthrough_set = (
             frozenset(passthrough_only)
             if passthrough_only is not None
-            else _DEFAULT_PASSTHROUGH_COMPONENTS
+            else _default_passthrough_components()
         )
         offload_path = Path(offload_folder) if offload_folder is not None else None
         if offload_path is not None:
@@ -433,7 +430,7 @@ def _iter_diffusers_components(
 
     seen: set[str] = set()
     for entry in sorted(snapshot_path.iterdir()):
-        if not entry.is_dir() or entry.name not in _DIFFUSERS_COMPONENT_DIRS:
+        if not entry.is_dir() or entry.name not in _diffusers_component_dirs():
             continue
         seen.add(entry.name)
         if entry.name in quant_set and quantization_config is not None:

--- a/src/gen_worker/convert/svdq.py
+++ b/src/gen_worker/convert/svdq.py
@@ -16,6 +16,8 @@ Two producers emit this shape:
 
 from __future__ import annotations
 
+from ..component_vocab import denoiser_components
+
 import logging
 import os
 from pathlib import Path
@@ -75,7 +77,7 @@ def build_svdq_flavor_tree(
         )
     if component is None:
         component = next(
-            (c for c in ("transformer", "unet") if (base_dir / c).is_dir()), "",
+            (c for c in denoiser_components() if (base_dir / c).is_dir()), "",
         )
     if not component:
         raise ValueError(

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -263,13 +263,16 @@ def _tensor_to_bytes(t: "torch.Tensor") -> Any:
 
 
 # ---------------------------------------------------------------------------
+from ..component_vocab import (
+    denoiser_components,
+    text_encoder_components,
+    weight_components,
+)
 # Tensor iteration (single / sharded / pickle inputs)
 # ---------------------------------------------------------------------------
 
-_WEIGHT_COMPONENT_DIRS: frozenset[str] = frozenset({
-    "unet", "transformer", "vae", "text_encoder", "text_encoder_2",
-    "text_encoder_3", "image_encoder", "prior", "controlnet",
-})
+def _weight_component_dirs() -> frozenset[str]:
+    return frozenset(weight_components())
 
 
 def materialize_pickle_to_safetensors(pickle_path: Path, work_dir: Path) -> Path:
@@ -346,7 +349,7 @@ def iter_source_tensors(
             yield "", name, tensor
         return
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or entry.name not in _WEIGHT_COMPONENT_DIRS:
+        if not entry.is_dir() or entry.name not in _weight_component_dirs():
             continue
         if components_filter is not None and entry.name not in components_filter:
             continue
@@ -775,7 +778,9 @@ def streaming_w8a8_cast(
 # Components fp8 storage targets by default: the denoiser dominates VRAM and
 # is what apply_fp8_storage consumes (QUANTIZATION-POLICY.md order of
 # sacrifice; TEs join via gw#392's component-wise ladder, explicitly).
-FP8_DEFAULT_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
+def fp8_default_components() -> tuple[str, ...]:
+    """Components fp8 storage targets by default: the denoisers."""
+    return denoiser_components()
 
 
 def snapshot_weight_groups(source_dir: Path, layout: str) -> list[tuple[str, Path]]:
@@ -915,13 +920,12 @@ def streaming_cast_snapshot(
             "components": sorted(done), "output_dir": out_dir}
 
 
-# Text-encoder components the ``fp8+te`` rung casts (must mirror
-# gen_worker.models.loading._FP8_TEXT_ENCODER_COMPONENTS — drift guard in
-# tests/test_fp8_te_writer.py; not imported here to keep this module's
-# import cheap).
-FP8_TE_COMPONENTS: tuple[str, ...] = (
-    "text_encoder", "text_encoder_2", "text_encoder_3",
-)
+# Text-encoder components the ``fp8+te`` rung casts. This USED to be a
+# hand-maintained mirror of loading's copy with a drift guard in
+# tests/test_fp8_te_writer.py; pgw#740 B5 removed the drift by removing the
+# copy (component_vocab is stdlib-only, so importing it stays cheap).
+def fp8_te_components() -> tuple[str, ...]:
+    return text_encoder_components()
 
 
 def _component_stored_tensor_names(component_dir: Path) -> frozenset[str]:
@@ -1071,7 +1075,7 @@ def streaming_fp8_snapshot(
     out_dir: Path,
     *,
     file_layout: str,
-    components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
+    components: tuple[str, ...] | None = None,
     te_components: tuple[str, ...] = (),
     shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
 ) -> dict[str, Any]:
@@ -1079,7 +1083,7 @@ def streaming_fp8_snapshot(
 
     ``components`` (default: the denoiser) get the name-pattern fp8 cast;
     ``te_components`` (the ``fp8+te`` rung, gw#460 — pass
-    :data:`FP8_TE_COMPONENTS`) get the transformers block-window cast whose
+    :func:`fp8_te_components`) get the transformers block-window cast whose
     eligible set is derived from the loader itself. Every other component
     passes through untouched.
 
@@ -1088,6 +1092,10 @@ def streaming_fp8_snapshot(
     IS the denoiser, e.g. a UiT like HiDream-O1). That set gets the
     block-scoped fp8 cast; multi-set singlefile bundles still refuse
     (component identity is ambiguous there)."""
+    # Resolved at call time, never as a default argument: a default is
+    # evaluated at def time and would freeze the pre-declaration vocabulary.
+    if components is None:
+        components = fp8_default_components()
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     if file_layout != "diffusers":
         root_groups = snapshot_weight_groups(source_dir, file_layout)
@@ -1177,7 +1185,7 @@ def streaming_w8a8_snapshot(
     out_dir: Path,
     *,
     file_layout: str,
-    components: tuple[str, ...] = FP8_DEFAULT_COMPONENTS,
+    components: tuple[str, ...] | None = None,
     te_components: tuple[str, ...] = (),
     weight_set_patterns: tuple[str, ...] = (),
     shard_threshold: int = MAX_SAFETENSORS_SHARD_BYTES,
@@ -1201,6 +1209,10 @@ def streaming_w8a8_snapshot(
     (their quantized keys could never resolve in the denoiser at swap
     time). No component config exists; the headers alone carry
     detection."""
+    # Resolved at call time, never as a default argument: a default is
+    # evaluated at def time and would freeze the pre-declaration vocabulary.
+    if components is None:
+        components = fp8_default_components()
 
     source_dir, out_dir = Path(source_dir), Path(out_dir)
     if file_layout != "diffusers":
@@ -1676,8 +1688,8 @@ __all__ = [
     "copy_non_weight_files",
     "fp8_cast_eligible",
     "FP8_SKIP_TENSOR_PATTERNS",
-    "FP8_DEFAULT_COMPONENTS",
-    "FP8_TE_COMPONENTS",
+    "fp8_default_components",
+    "fp8_te_components",
     "te_fp8_castable_keys",
     "streaming_fp8_te_cast",
     "shard_safetensors_by_offset",

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -34,7 +34,7 @@ class EndpointLockValidationResult:
     warnings: tuple[str, ...] = ()
 
 
-_KNOWN_KINDS = frozenset(("inference", "training", "dataset", "conversion"))
+_KNOWN_KINDS = frozenset(("inference", "training", "dataset", "conversion", "eval"))
 
 
 def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationResult:
@@ -47,7 +47,7 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
          from a ``@inference`` / ``@training`` / ``@dataset`` / ``@conversion``
          decorated class, not a bare ``@inference``.
       2. ``archetype`` is ``"SerialWorker"`` or ``"BatchedWorker"``.
-      3. ``kind`` is one of the four supported kinds.
+      3. ``kind`` is one of the supported kinds.
       4. No two ``@inference.function`` methods on the SAME class slugify
          to the same wire route — that would silently shadow one of them
          at dispatch time.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -108,6 +108,13 @@ _CONTEXT_BY_KIND: Dict[str, type] = {
     "conversion": ConversionContext,
     "dataset": DatasetContext,
     "training": TrainingContext,
+    # th#1255: an eval materializes the same reserved refs a conversion does
+    # (its `source` IS the reference arm) and writes request output assets.
+    # It just publishes nothing, and there is no separate surface for that —
+    # publish authority is the hub's call, and the hub refuses repo writes
+    # for kind=eval. A distinct EvalContext would only restate that refusal
+    # somewhere it cannot be enforced.
+    "eval": ConversionContext,
 }
 
 logger = logging.getLogger(__name__)

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -299,14 +299,10 @@ async def ensure_local(
 # Hugging Face: snapshot_download + small variant selector
 # ---------------------------------------------------------------------------
 
+from ..component_vocab import denoiser_components, pipeline_component_dirs
 _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".gguf", ".onnx", ".msgpack", ".h5")
 _VARIANT_TAGS = ("bf16", "fp16", "fp8", "int8", "int4")
-_COMPONENT_DIRS = (
-    "transformer", "transformer_2", "unet", "vae", "text_encoder",
-    "text_encoder_2", "text_encoder_3", "tokenizer", "tokenizer_2",
-    "tokenizer_3", "scheduler", "feature_extractor", "image_encoder",
-    "safety_checker", "prior", "decoder",
-)
+_component_dirs = pipeline_component_dirs
 
 
 def _variant_of(filename: str) -> str:
@@ -335,7 +331,7 @@ def select_hf_files(
     if not files:
         return None
     dirs = {f.split("/", 1)[0] for f in files if "/" in f}
-    diffusers_like = "model_index.json" in files or any(d in dirs for d in ("transformer", "unet"))
+    diffusers_like = "model_index.json" in files or any(d in dirs for d in denoiser_components())
 
     weights_by_dir: Dict[str, list[str]] = {}
     non_weights: set[str] = set()

--- a/src/gen_worker/models/gguf_local.py
+++ b/src/gen_worker/models/gguf_local.py
@@ -22,6 +22,7 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
+from ..component_vocab import denoiser_components, text_encoder_components
 from .hub_client import WorkerResolvedRepo
 from .refs import TensorhubRef
 from .loading import FP8_STORAGE_FIT_FACTOR
@@ -76,12 +77,12 @@ def gguf_qtype(flavor: str) -> str:
 def is_denoiser_weight_path(path: str) -> bool:
     p = str(path or "").strip().lstrip("/")
     head, _, rest = p.partition("/")
-    return head in ("transformer", "unet") and bool(rest) and rest != "config.json"
+    return head in denoiser_components() and bool(rest) and rest != "config.json"
 
 
 def _is_text_encoder_weight(path: str) -> bool:
     head, _, rest = str(path or "").strip().lstrip("/").partition("/")
-    return head.startswith("text_encoder") and bool(rest)
+    return head in text_encoder_components() and bool(rest)
 
 
 def select_gguf(

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -10,6 +10,11 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..component_vocab import (
+    denoiser_components,
+    text_encoder_components,
+    weight_components,
+)
 from ..families.facts import component_dtype_for_class
 from .ladder import EMERGENCY_NF4_VRAM_FACTOR, NF4_WEIGHT_BYTES_FACTOR
 import importlib
@@ -161,7 +166,7 @@ def read_on_disk_quant_config(model_path: Path) -> bool:
             p = model_path / rel
             if p.exists():
                 candidates.append(p)
-        for sub in ("transformer", "unet", "text_encoder", "text_encoder_2", "vae"):
+        for sub in weight_components():
             cfg = model_path / sub / "config.json"
             if cfg.exists():
                 candidates.append(cfg)
@@ -205,17 +210,17 @@ def synthesize_quantization_config(attrs: Optional[Dict[str, str]]) -> Optional[
     )
 
 
-#: Denoiser component directory names — the only components a quantized
-#: artifact lane (w8a8 / w4a4 / svdq / gguf) ever covers.
-DENOISER_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
 # Pipeline components fp8 storage applies to: the denoiser dominates VRAM and
 # tolerates fp8-E4M3 weight rounding; text encoders / VAE stay at compute
 # precision (quality-safe default, QUANTIZATION-POLICY.md component policy).
-_FP8_STORAGE_COMPONENTS: tuple[str, ...] = DENOISER_COMPONENTS
+#
+# These read the vocabulary at CALL time, never at import: an endpoint's
+# declare_components() runs at endpoint-module import, which may be after this
+# module is imported. A module-level tuple would freeze the pre-declaration
+# vocabulary and silently skip the declared components (pgw#740 B5).
+_fp8_storage_components = denoiser_components
 # The "+te" rung (component fit-ladder rung 2): the pipeline's text encoders.
-_FP8_TEXT_ENCODER_COMPONENTS: tuple[str, ...] = (
-    "text_encoder", "text_encoder_2", "text_encoder_3",
-)
+_fp8_text_encoder_components = text_encoder_components
 
 class _Fp8WeightWindow:
     """Weight-only fp8 storage for one transformer block: the block's
@@ -397,9 +402,9 @@ def apply_fp8_storage(obj: Any, *, compute_dtype: Any = None,
         compute_dtype = torch.bfloat16
 
     if components is None:
-        components = _FP8_STORAGE_COMPONENTS
+        components = _fp8_storage_components()
         if text_encoders:
-            components += _FP8_TEXT_ENCODER_COMPONENTS
+            components += _fp8_text_encoder_components()
     targets: List[tuple[str, Any]] = []
     for name in components:
         mod = getattr(obj, name, None)
@@ -467,16 +472,10 @@ class _BlockOffloadWindow:
             p.data = h
 
 
-# Components block-window offload targets on a pipeline object (the VRAM
-# dominators); callers pass their own set for model-specific choices (e.g.
-# ltx adds "connectors" and "text_encoder").
-_BLOCK_OFFLOAD_COMPONENTS: tuple[str, ...] = ("transformer", "unet")
-
-
 def apply_block_window_offload(
     obj: Any,
     *,
-    components: tuple[str, ...] = _BLOCK_OFFLOAD_COMPONENTS,
+    components: tuple[str, ...] | None = None,
     device: Any = None,
 ) -> bool:
     """Park a module's per-block weights in pinned host RAM and stream each
@@ -493,6 +492,11 @@ def apply_block_window_offload(
     stream over PCIe (half the traffic), upcast happens on-device.
 
     Returns True when any module was armed. Idempotent per module."""
+    # Default resolved at call time, not in the signature: a default argument
+    # is evaluated at def time, which would freeze the vocabulary before an
+    # endpoint's declare_components() ever runs (pgw#740 B5).
+    if components is None:
+        components = denoiser_components()
     try:
         import torch
     except ImportError:
@@ -575,7 +579,7 @@ def block_offload_active(obj: Any) -> bool:
         return True
     return any(
         getattr(getattr(obj, name, None), "_cozy_block_offload_applied", False)
-        for name in _BLOCK_OFFLOAD_COMPONENTS
+        for name in denoiser_components()
     )
 
 
@@ -618,7 +622,7 @@ def load_gguf_pipeline(
     component = next(
         (
             name
-            for name in _FP8_STORAGE_COMPONENTS
+            for name in _fp8_storage_components()
             if isinstance(index.get(name), list) and len(index[name]) == 2
         ),
         None,
@@ -639,7 +643,7 @@ def load_gguf_pipeline(
     kwargs = dict(components or {})
     kwargs[component] = denoiser
     pipe = cls.from_pretrained(str(path), torch_dtype=compute, **kwargs)
-    for name in _FP8_TEXT_ENCODER_COMPONENTS:
+    for name in _fp8_text_encoder_components():
         text_encoder = getattr(pipe, name, None)
         if text_encoder is not None and hasattr(text_encoder, "parameters"):
             apply_fp8_storage(text_encoder, compute_dtype=compute)
@@ -792,7 +796,7 @@ def pipeline_weight_lane(pipeline: Any) -> str:
         return ""  # traces identically to plain bf16
     if lane:
         return lane
-    for name in _FP8_STORAGE_COMPONENTS:
+    for name in _fp8_storage_components():
         if getattr(getattr(pipeline, name, None), "_cozy_fp8_storage_applied", False):
             return "fp8-hooks"
     if getattr(pipeline, "_cozy_fp8_storage_applied", False):
@@ -830,9 +834,9 @@ def bf16_resident_fits(
     total = sum(comp.values())
     if total <= 0:
         return False
-    targets = set(_FP8_STORAGE_COMPONENTS)
+    targets = set(_fp8_storage_components())
     if text_encoders:
-        targets |= set(_FP8_TEXT_ENCODER_COMPONENTS)
+        targets |= set(_fp8_text_encoder_components())
     # Per-TENSOR fp8 byte accounting (ie#381 fix 2): the majority-dtype
     # component gate returned "bf16" for produced fp8 flavors whose scale/
     # norm tensors outnumber the (much larger) fp8 weight tensors, counting
@@ -1303,7 +1307,7 @@ def load_component(
             f"svdq engine during the PIPELINE load, so there is no "
             f"component-level production loader to borrow"
         )
-    if component in DENOISER_COMPONENTS and detect_gguf_snapshot(root):
+    if component in denoiser_components() and detect_gguf_snapshot(root):
         raise ComponentLaneUnsupported(
             f"component {component!r} of {root} is a GGUF denoiser: it is "
             f"dequantized by the pipeline's own gguf loader, so there is no "
@@ -1451,7 +1455,7 @@ def emergency_quantization_config(
         "bnb_4bit_use_double_quant": True,
     }
     if isinstance(cls, type) and issubclass(cls, diffusers.DiffusionPipeline):
-        targets = list(_FP8_STORAGE_COMPONENTS) if components is None else list(components)
+        targets = list(_fp8_storage_components()) if components is None else list(components)
         if not targets:
             logger.warning(
                 "emergency nf4 skipped: no quantizable component in the "
@@ -1525,9 +1529,9 @@ def _adaptive_fit_rung(
     budget = max(0.0, free_gb - _EMERGENCY_MARGIN_GB) * float(1 << 30)
 
     named = model_index_components(path) or set(comp_bytes)
-    denoisers = [c for c in _FP8_STORAGE_COMPONENTS
+    denoisers = [c for c in _fp8_storage_components()
                  if c in named and comp_bytes.get(c, 0) > 0]
-    encoders = [c for c in _FP8_TEXT_ENCODER_COMPONENTS
+    encoders = [c for c in _fp8_text_encoder_components()
                 if c in named and comp_bytes.get(c, 0) > 0]
     denoiser_bytes = sum(comp_bytes[c] for c in denoisers)
 

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, Iterable, List, Optional, TypeVar
 
 import msgspec
 
+from ..component_vocab import component_vocabulary
+
 _LOG = logging.getLogger(__name__)
 
 _GIB = 1024 ** 3
@@ -392,10 +394,19 @@ def cuda_allocated_bytes(device_index: Optional[int] = None) -> int:
 # Wan's `transformer_2` (the second MoE expert) and LTX's `connectors` came to
 # be silently skipped by the offload loops — a live memory bug for those
 # families. Enumeration is generic; this only decides who goes first.
-_COMPONENT_ORDER_HINT = (
-    "transformer", "transformer_2", "unet", "vae", "text_encoder",
-    "text_encoder_2", "text_encoder_3", "connectors",
-)
+#
+# B5: read from the ONE vocabulary at call time. Offload priority is
+# largest-first — denoisers, then VAEs, then text encoders — which is not
+# vocabulary declaration order, so the groups are concatenated explicitly.
+# `connectors` is no longer named here: an endpoint that carries it declares
+# it (declare_components) and lands in this hint; one that does not is still
+# enumerated generically and simply sorts alphabetically after the hint.
+def _component_order_hint() -> tuple[str, ...]:
+    vocab = component_vocabulary()
+    return tuple(dict.fromkeys(
+        vocab.denoisers + vocab.vaes + vocab.text_encoders
+        + vocab.auxiliaries + vocab.extras
+    ))
 
 
 def _module_attributes(pipeline: Any) -> List[tuple[str, Any]]:
@@ -414,7 +425,7 @@ def _module_attributes(pipeline: Any) -> List[tuple[str, Any]]:
             continue
         found[name] = value
     ordered: List[tuple[str, Any]] = [
-        (name, found.pop(name)) for name in _COMPONENT_ORDER_HINT
+        (name, found.pop(name)) for name in _component_order_hint()
         if name in found
     ]
     ordered.extend(sorted(found.items()))

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
+from ..component_vocab import denoiser_components
 from ..api.binding import ModelRef, wire_ref
 from ..config import get_settings
 from .cache_paths import tensorhub_cas_dir
@@ -135,7 +136,7 @@ def load_slot(
     # backstop).
     if storage_dtype in ("fp8", "fp8+te"):
         comps = model_index_components(path)
-        if comps and not ({"transformer", "unet"} & comps):
+        if comps and not (set(denoiser_components()) & comps):
             out.pre_drop_wanted = storage_dtype
             out.pre_drop_detail = (
                 f"cast {storage_dtype!r} dropped for slot {slot!r}: pipeline "

--- a/src/gen_worker/models/svdq.py
+++ b/src/gen_worker/models/svdq.py
@@ -24,6 +24,7 @@ import re
 import struct
 from dataclasses import dataclass
 from pathlib import Path
+from ..component_vocab import denoiser_components
 from typing import Any, Optional
 import importlib.metadata as md
 
@@ -327,9 +328,6 @@ def _svdq_from_file(component: str, path: Path) -> Optional[SvdqArtifact]:
     )
 
 
-_SVDQ_COMPONENT_DIRS = ("transformer", "unet")
-
-
 def detect_svdq_artifact(model_path: Path) -> Optional[SvdqArtifact]:
     """Find the nunchaku single-file checkpoint inside a snapshot: the
     denoiser dir's (or, for a bare artifact, the root's) sole svdq-tagged
@@ -339,7 +337,7 @@ def detect_svdq_artifact(model_path: Path) -> Optional[SvdqArtifact]:
         return _svdq_from_file("", root) if root.suffix == ".safetensors" else None
     if not root.is_dir():
         return None
-    for comp in _SVDQ_COMPONENT_DIRS:
+    for comp in denoiser_components():
         comp_dir = root / comp
         if not comp_dir.is_dir():
             continue

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -45,6 +45,7 @@ import logging
 import struct
 from dataclasses import dataclass
 from pathlib import Path
+from ..component_vocab import denoiser_components
 from typing import Any, Dict, Optional
 import shutil
 
@@ -71,7 +72,6 @@ W4A4_MIN_SM = 100
 _K_ALIGN = 32
 _N_ALIGN = 16
 _MAX_HEADER_BYTES = 100 << 20
-_COMPONENT_DIRS = ("transformer", "unet")
 _AUX_SUFFIXES = (".weight_scale", ".weight_scale_2", ".input_scale",
                  ".pre_quant_scale")
 
@@ -149,7 +149,7 @@ def detect_w4a4_artifact(model_path: Path) -> Optional[W4a4Artifact]:
     if not root.is_dir():
         return None
     if (root / "model_index.json").exists():
-        for comp in _COMPONENT_DIRS:
+        for comp in denoiser_components():
             comp_dir = root / comp
             if not comp_dir.is_dir():
                 continue
@@ -732,7 +732,7 @@ def swap_w4a4_linears(
 def _root_denoiser(pipe: Any) -> Any:
     import torch.nn as nn
 
-    for name in ("transformer", "unet", "dit"):
+    for name in denoiser_components():
         mod = getattr(pipe, name, None)
         if isinstance(mod, nn.Module):
             return mod
@@ -793,7 +793,7 @@ def quantize_tree_w4a4(
     from safetensors.torch import load_file, save_file
 
     src_tree, out_tree = Path(src_tree), Path(out_tree)
-    comp = next((c for c in _COMPONENT_DIRS if (src_tree / c).is_dir()), None)
+    comp = next((c for c in denoiser_components() if (src_tree / c).is_dir()), None)
     if comp is None or not (src_tree / "model_index.json").exists():
         raise W4a4SnapshotError(f"{src_tree} is not a diffusers tree with a denoiser")
     if out_tree.exists():

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -37,6 +37,7 @@ import logging
 import struct
 from dataclasses import dataclass
 from pathlib import Path
+from ..component_vocab import denoiser_components
 from typing import Any, Dict, Optional
 import shutil
 
@@ -51,7 +52,6 @@ W8A8_ROWWISE_MIN_SM = 90
 _FP8_MAX = 448.0
 _DIM_ALIGN = 16
 _MAX_HEADER_BYTES = 100 << 20
-_COMPONENT_DIRS = ("transformer", "unet")
 
 
 class W8a8Error(RuntimeError):
@@ -139,7 +139,7 @@ def detect_w8a8_artifact(model_path: Path) -> Optional[W8a8Artifact]:
     if not root.is_dir():
         return None
     if (root / "model_index.json").exists():
-        for comp in _COMPONENT_DIRS:
+        for comp in denoiser_components():
             comp_dir = root / comp
             if not comp_dir.is_dir():
                 continue
@@ -593,10 +593,11 @@ def load_w8a8_pipeline(cls: Any, path: Path, art: W8a8Artifact, *,
     except Exception:
         pass
     if fp8_text_encoders:
-        from .loading import _FP8_TEXT_ENCODER_COMPONENTS, apply_fp8_storage
+        from ..component_vocab import text_encoder_components
+        from .loading import apply_fp8_storage
 
         targets = tuple(
-            n for n in _FP8_TEXT_ENCODER_COMPONENTS
+            n for n in text_encoder_components()
             if hasattr(getattr(pipe, n, None), "parameters"))
         if targets:
             apply_fp8_storage(pipe, compute_dtype=compute, components=targets)
@@ -738,7 +739,7 @@ def swap_w8a8_linears(
 def _root_denoiser(pipe: Any) -> Any:
     import torch.nn as nn
 
-    for name in ("transformer", "unet", "dit"):
+    for name in denoiser_components():
         mod = getattr(pipe, name, None)
         if isinstance(mod, nn.Module):
             return mod
@@ -808,7 +809,7 @@ def quantize_tree_w8a8(
     from safetensors.torch import load_file, save_file
 
     src_tree, out_tree = Path(src_tree), Path(out_tree)
-    comp = next((c for c in _COMPONENT_DIRS if (src_tree / c).is_dir()), None)
+    comp = next((c for c in denoiser_components() if (src_tree / c).is_dir()), None)
     if comp is None or not (src_tree / "model_index.json").exists():
         raise W8a8SnapshotError(f"{src_tree} is not a diffusers tree with a denoiser")
     if out_tree.exists():

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -53,6 +53,7 @@ import math
 import time
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
+from ..component_vocab import denoiser_components
 from ..api.errors import RefCompatibilitySurprise, ValidationError
 from .fp8_storage import structural_base
 from .w8a8 import fp8_scaled_linear_class
@@ -69,22 +70,29 @@ _ACTIVE_ATTR = "_cozy_lora_active"
 _SPARSE_ATTR = "_cozy_lora_sparse"
 _MAPCACHE_ATTR = "_cozy_lora_mapcache"
 _MAPCACHE_MAX = 8
-_DENOISER_PREFIXES = ("unet.", "transformer.", "transformer_2.",
-                      "lora_unet_", "lora_transformer_")
+# The kohya-flat prefixes are NOT component namespaces (see below) and are not
+# vocabulary — sd-scripts emits them verbatim, so they stay literal here.
+_KOHYA_FLAT_PREFIXES = ("lora_unet_", "lora_transformer_")
 # gw#679: the denoiser components a pipeline can carry, in stamp order. A
 # dual-expert MoE carries transformer (high noise) AND transformer_2 (low).
-_DENOISER_COMPONENTS = ("transformer", "transformer_2", "unet")
-# Key prefix -> the component it NAMES, longest first (``transformer_2.``
-# must win over ``transformer.``). DOTTED forms only: that prefix IS the
-# diffusers component namespace. The kohya-flat ``lora_unet_`` prefix is
-# NOT a declaration — sd-scripts emits it for transformer denoisers too
-# (flux/qwen adapters serve fine on the branch today) — so those keys name
-# no component and follow the unprefixed rules below.
-_COMPONENT_PREFIXES = (
-    ("transformer_2.", "transformer_2"),
-    ("transformer.", "transformer"),
-    ("unet.", "unet"),
-)
+_denoiser_components = denoiser_components
+
+
+def _denoiser_prefixes() -> tuple[str, ...]:
+    return tuple(f"{c}." for c in _denoiser_components()) + _KOHYA_FLAT_PREFIXES
+
+
+def _component_prefixes() -> tuple[tuple[str, str], ...]:
+    """Key prefix -> the component it NAMES, longest first (``transformer_2.``
+    must win over ``transformer.``). DOTTED forms only: that prefix IS the
+    diffusers component namespace. The kohya-flat ``lora_unet_`` prefix is
+    NOT a declaration — sd-scripts emits it for transformer denoisers too
+    (flux/qwen adapters serve fine on the branch today) — so those keys name
+    no component and follow the unprefixed rules below."""
+    return tuple(
+        (f"{c}.", c)
+        for c in sorted(_denoiser_components(), key=len, reverse=True)
+    )
 # (normalized suffix marker, is_down) — dotted forms after key normalization.
 _DOWN_SUFFIXES = (".lora_down.weight", ".lora.down.weight", ".lora_A.weight")
 _UP_SUFFIXES = (".lora_up.weight", ".lora.up.weight", ".lora_B.weight")
@@ -117,7 +125,7 @@ def branch_targets(pipe: Any) -> Dict[str, Any]:
     adapters that map onto no Linear fail typed in :func:`map_adapter` (with
     the plain-lane peft fallback in AdapterResidency.activate)."""
     out: Dict[str, Any] = {}
-    for name in _DENOISER_COMPONENTS:
+    for name in _denoiser_components():
         denoiser = getattr(pipe, name, None)
         if denoiser is not None and hasattr(denoiser, "named_modules"):
             out[name] = denoiser
@@ -127,7 +135,7 @@ def branch_targets(pipe: Any) -> Dict[str, Any]:
 def declared_component(key: str) -> str:
     """The pipeline component one adapter key NAMES, or ``""`` when the key
     carries no component prefix (bare/kohya-flat module paths)."""
-    for prefix, comp in _COMPONENT_PREFIXES:
+    for prefix, comp in _component_prefixes():
         if key.startswith(prefix):
             return comp
     return ""
@@ -265,7 +273,7 @@ def split_state_dict(sd: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]
     den: Dict[str, Any] = {}
     rest: Dict[str, Any] = {}
     for k, v in sd.items():
-        (den if k.startswith(_DENOISER_PREFIXES) else rest)[k] = v
+        (den if k.startswith(_denoiser_prefixes()) else rest)[k] = v
     return den, rest
 
 

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, runtime_checkable
 
+from ..component_vocab import denoiser_components, text_encoder_components
 from ..api.errors import RefCompatibilitySurprise, ValidationError
 from dataclasses import replace
 from ..models import w8a8_lora
@@ -105,15 +106,23 @@ _SPLIT_CACHE_MAX = 8
 _SPLIT_CACHE_LOCK = threading.Lock()
 # Component prefix -> pipe attribute, for both normalized and kohya-flat key
 # grammars. Kohya te1/te2 numbering follows diffusers' convention.
-_TE_PREFIX_TO_COMPONENT = (
-    ("text_encoder_3", "text_encoder_3"),
-    ("text_encoder_2", "text_encoder_2"),
-    ("text_encoder", "text_encoder"),
+# The kohya-flat te aliases are sd-scripts' own grammar, not our vocabulary,
+# so they stay literal; they map ONTO vocabulary names.
+_KOHYA_TE_ALIASES = (
     ("lora_te3_", "text_encoder_3"),
     ("lora_te2_", "text_encoder_2"),
     ("lora_te1_", "text_encoder"),
     ("lora_te_", "text_encoder"),
 )
+
+
+def _te_prefix_to_component() -> tuple[tuple[str, str], ...]:
+    """Component prefix -> pipe attribute, longest first so ``text_encoder_2``
+    wins over ``text_encoder``. Read at call time (pgw#740 B5)."""
+    dotted = tuple(
+        (c, c) for c in sorted(text_encoder_components(), key=len, reverse=True)
+    )
+    return dotted + _KOHYA_TE_ALIASES
 
 
 # Config fields that DISCRIMINATE denoiser structure. The UNet set alone
@@ -143,7 +152,7 @@ def _denoiser_fingerprint(pipe: Any) -> str:
     whose config declares none of these fields falls back to its class name
     plus its parameter shape signature rather than to an empty string.
     """
-    for name in ("unet", "transformer", "transformer_2"):
+    for name in denoiser_components():
         module = getattr(pipe, name, None)
         cfg = getattr(module, "config", None)
         if cfg is None:
@@ -240,7 +249,7 @@ def _reject_te_keys_on_cast_te(
     the hooks. Keys targeting an UNCAST encoder in a mixed setup stay on
     the peft path."""
     def component_of(key: str) -> str:
-        for prefix, comp in _TE_PREFIX_TO_COMPONENT:
+        for prefix, comp in _te_prefix_to_component():
             if key.startswith(prefix):
                 return comp
         return ""

--- a/tests/test_aot_declaration_pgw739.py
+++ b/tests/test_aot_declaration_pgw739.py
@@ -95,7 +95,7 @@ def _wan_a14b_decl() -> Compile:
                   shape=("B", "T_txt", ("config", "text_dim")),
                   targets=("transformer", "transformer_2")),
             Input("z", shape=("B", ("config", "z_dim"), "F_lat", "H_lat", "W_lat"),
-                  positional=True, targets=("vae.decode",)),
+                  targets=("vae.decode",)),
         ),
         args=(Arg("return_dict", False),),
         shape_strategy="dynamic-collapse",
@@ -190,8 +190,8 @@ def _relational_decl() -> Compile:
             GraphClass(dims={"B": 2, "H": 8, "W": 8, "N": 64}, fork=fork),
         ),
         inputs=(
-            Input("x", shape=("B", 3, "H", "W"), positional=True),
-            Input("t", shape=("B", "N"), positional=True),
+            Input("x", shape=("B", 3, "H", "W")),
+            Input("t", shape=("B", "N")),
         ),
         shape_strategy="dynamic-collapse",
         warm_changes_key=False,
@@ -260,21 +260,33 @@ def test_pinned_relational_axis_is_still_refused() -> None:
 
 
 class FakeUnet(torch.nn.Module):
-    """sdxl-shaped: nested added_cond_kwargs, positional trio, config widths."""
+    """sdxl-shaped: nested added_cond_kwargs container, config widths. The
+    signature mirrors UNet2DConditionModel's positional order — the builder
+    binds declared names to these slots and feeds ALL-POSITIONAL."""
 
     def __init__(self) -> None:
         super().__init__()
         self.proj = torch.nn.Linear(4, 4)
         self.config = SimpleNamespace(in_channels=4, cross_attention_dim=2048)
 
+    def forward(self, sample, timestep, encoder_hidden_states,
+                added_cond_kwargs=None, return_dict=True):  # type: ignore[no-untyped-def]
+        return sample
+
 
 class FakeWanDit(torch.nn.Module):
-    """wan-ti2v-shaped: kwargs call, per-token float32 timestep, config widths."""
+    """wan-ti2v-shaped: per-token float32 timestep, config widths, and an
+    undeclared in-between parameter (encoder_hidden_states_image) whose
+    signature default must fill its positional slot."""
 
     def __init__(self) -> None:
         super().__init__()
         self.proj = torch.nn.Linear(8, 8)
         self.config = SimpleNamespace(in_channels=48, text_dim=4096)
+
+    def forward(self, hidden_states, timestep, encoder_hidden_states,
+                encoder_hidden_states_image=None, return_dict=True):  # type: ignore[no-untyped-def]
+        return hidden_states
 
 
 def _sdxl_shaped_decl() -> Compile:
@@ -298,11 +310,10 @@ def _sdxl_shaped_decl() -> Compile:
         ),
         inputs=(
             Input("sample", shape=("B", ("config", "in_channels"),
-                                   "H_lat", "W_lat"), positional=True),
-            Input("timestep", shape=(), value=1.0, positional=True),
+                                   "H_lat", "W_lat")),
+            Input("timestep", shape=(), value=1.0),
             Input("encoder_hidden_states",
-                  shape=("B", "T_txt", ("config", "cross_attention_dim")),
-                  positional=True),
+                  shape=("B", "T_txt", ("config", "cross_attention_dim"))),
             Input("added_cond_kwargs.text_embeds", shape=("B", 1280)),
             Input("added_cond_kwargs.time_ids", shape=("B", 6)),
         ),
@@ -347,31 +358,36 @@ def _ti2v_shaped_decl() -> Compile:
 
 def test_two_families_one_code_path() -> None:
     """The #739 red test: different declarations, correct example inputs,
-    ONE generic function — zero per-family SDK code."""
+    ONE generic function — zero per-family SDK code. Both feeds come out
+    ALL-POSITIONAL (the pod-9 mint obligation): named rows bind to their
+    signature slots, containers ride as one argument, and undeclared
+    in-between parameters get their signature defaults."""
     sdxl_spec = ExportSpec(
         family="sdxl-shaped", target="unet",
         fork=(("cfg", True),),
         class_dims=(("B", 2), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
     args, kwargs = aot_declaration.declared_inputs(
         FakeUnet(), sdxl_spec, _sdxl_shaped_decl())
+    assert kwargs == {}
     assert args[0].shape == (2, 4, 128, 128)
     assert args[1].ndim == 0 and float(args[1]) == 1.0
     assert args[2].shape == (2, 77, 2048)
-    assert kwargs["added_cond_kwargs"]["text_embeds"].shape == (2, 1280)
-    assert kwargs["added_cond_kwargs"]["time_ids"].shape == (2, 6)
-    assert kwargs["return_dict"] is False
+    assert args[3]["text_embeds"].shape == (2, 1280)
+    assert args[3]["time_ids"].shape == (2, 6)
+    assert args[4] is False  # return_dict, positionally
 
     wan_spec = ExportSpec(
         family="wan-ti2v-shaped", target="transformer",
         fork=(("expand_timesteps", True),))
     args2, kwargs2 = aot_declaration.declared_inputs(
         FakeWanDit(), wan_spec, _ti2v_shaped_decl())
-    assert args2 == ()
-    assert kwargs2["hidden_states"].shape == (1, 48, 31, 44, 80)
-    assert kwargs2["timestep"].shape == (1, 27280)
-    assert kwargs2["timestep"].dtype == torch.float32
-    assert kwargs2["encoder_hidden_states"].shape == (1, 512, 4096)
-    assert kwargs2["return_dict"] is False
+    assert kwargs2 == {}
+    assert args2[0].shape == (1, 48, 31, 44, 80)
+    assert args2[1].shape == (1, 27280)
+    assert args2[1].dtype == torch.float32
+    assert args2[2].shape == (1, 512, 4096)
+    assert args2[3] is None   # encoder_hidden_states_image: default fills the slot
+    assert args2[4] is False  # return_dict, positionally
 
 
 def test_declared_inputs_refuse_missing_config_fields_by_name() -> None:
@@ -396,8 +412,9 @@ def test_builder_for_prefers_the_registered_declaration() -> None:
         family="sdxl-shaped", target="unet", fork=(("cfg", False),),
         class_dims=(("B", 1), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
     args, kwargs = builder(FakeUnet(), spec)
+    assert kwargs == {}
     assert args[0].shape == (1, 4, 128, 128)
-    assert kwargs["return_dict"] is False
+    assert args[-1] is False  # return_dict rides positionally
 
 
 def test_declared_inputs_actually_export() -> None:
@@ -424,9 +441,77 @@ def test_declared_inputs_actually_export() -> None:
         class_dims=(("B", 2), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
     args, kwargs = aot_declaration.declared_inputs(
         TinyUnet(), spec, _sdxl_shaped_decl())
+    assert kwargs == {}  # the pod-9 obligation: the trace is all-positional
     program = aot_mint.export_program(TinyUnet().eval(), args, kwargs,
                                       strict=True)
     assert program.graph_module is not None
+
+
+# ---------------------------------------------------------------------------
+# The two pgw#723-residuals mint gates (pods 8/9)
+# ---------------------------------------------------------------------------
+
+
+def test_mint_refuses_kwarg_example_feeds_by_name(tmp_path) -> None:
+    """The pod-9 shape, refused at the mint instead of discovered at first
+    serve: the flat forward traced the lifted pair as kwargs, the package
+    demanded kwargs, the positional serve marshal fed none — 'Ran into a
+    kwarg keyword mismatch' swallowed on first call, every "armed" call
+    silently eager (splat_served=false, B_vs_eagerB_maxdiff=0.0)."""
+
+    class Tiny(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = torch.nn.Linear(4, 4)
+
+        def forward(self, x, lora_a=None, lora_b=None):  # type: ignore[no-untyped-def]
+            return self.proj(x)
+
+    spec = ExportSpec(family="f", target="t", weight_lane="w8a8")
+    with pytest.raises(MintRefused, match="kwarg"):
+        aot_mint.mint(
+            Tiny().eval(), spec, tmp_path,
+            example_inputs=lambda: (
+                (torch.randn(2, 4),),
+                {"lora_a": torch.randn(2, 4), "lora_b": torch.randn(4, 2)}))
+
+
+def test_positionalize_refuses_keyword_only_declared_inputs() -> None:
+    class KwOnly(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.p = torch.nn.Linear(2, 2)
+            self.config = SimpleNamespace(in_channels=48, text_dim=4096)
+
+        def forward(self, hidden_states, timestep, *,
+                    encoder_hidden_states=None):  # type: ignore[no-untyped-def]
+            return hidden_states
+
+    spec = ExportSpec(family="wan-ti2v-shaped", target="transformer",
+                      fork=(("expand_timesteps", True),))
+    with pytest.raises(MintRefused, match="KEYWORD-ONLY"):
+        aot_declaration.declared_inputs(KwOnly(), spec, _ti2v_shaped_decl())
+
+
+def test_lifted_lora_mint_requires_the_torch_213_floor(monkeypatch) -> None:
+    """Pod 8 (pgw#723 residuals): torch 2.9 strict export refuses
+    bind_views' in-trace setattr ('Mutating module attribute lora_a during
+    export') that 2.13 traces fine — a mint PRECONDITION when the lifted
+    fork is declared, recorded as a named refusal instead of a deep-trace
+    AssertionError."""
+    lifted = ExportSpec(family="f", target="t", lora_bucket=64)
+    plain = ExportSpec(family="f", target="t")
+
+    assert aot_mint.lifted_torch_gap(plain) == ""
+    # This box runs the 2.13 prod floor, so the lifted spec passes here...
+    assert aot_mint.lifted_torch_gap(lifted) == ""
+    # ...and refuses by name on the measured pod-8 version.
+    monkeypatch.setattr(torch, "__version__", "2.9.1+cu126")
+    gap = aot_mint.lifted_torch_gap(lifted)
+    assert "2.13" in gap and "bind_views" in gap
+    assert aot_mint.lifted_torch_gap(plain) == ""
+    monkeypatch.setattr(torch, "__version__", "nonsense")
+    assert "cannot parse" in aot_mint.lifted_torch_gap(lifted)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aot_declaration_pgw739.py
+++ b/tests/test_aot_declaration_pgw739.py
@@ -1,0 +1,560 @@
+"""pgw#739 — derivation over real declarations (the engine half).
+
+Red-verified against the accumulated worked examples:
+
+- a wan-a14b-shaped declaration derives EXACTLY the measured ie#566 §4
+  dynamic contract (latent H/W [90, 160] multiple-of-2, on the denoiser AND
+  the decoder's ``z``) from class rows alone — no endpoint hand-math;
+- the RELATIONAL axis (wan ti2v's per-token timestep) rides the measured
+  solver-unification path: a free ranged dim with SDK-derived bounds, a real
+  ``torch.export`` run, and torch unifying the relation into the shape env.
+  The composite-range check in ``declared_range_gaps`` is proven
+  load-bearing: every per-symbol range fails to cover the declared bounds,
+  so the pre-#739 per-symbol comparison would have refused a sound artifact;
+- two families with DIFFERENT declarations derive correct export inputs
+  through ONE code path (``declared_inputs``);
+- the fork gate reads ``(pipeline|module, field)`` sources off composed
+  objects and refuses a wrong or unstated arm by name;
+- fork coordinates and class rows reach the cell identity.
+
+Real torch throughout; the only fabricated things are tiny modules, per the
+pgw#723 test doctrine.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import aot_declaration, aot_mint  # noqa: E402
+from gen_worker.aot_mint import ExportSpec, MintRefused  # noqa: E402
+from gen_worker.api.decorators import Compile, DynamicDim  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    Arg,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+    register_export_declaration,
+    reset_export_declarations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+# ---------------------------------------------------------------------------
+# wan a14b — dynamic-collapse derivation from rows (ie#566 §4, measured)
+# ---------------------------------------------------------------------------
+
+
+def _wan_a14b_decl() -> Compile:
+    """The wan t2v-a14b declaration shape: two transposed rows, latent H/W
+    each spanning [90, 160], patch_size (1,2,2) => multiple_of=2."""
+    dims = (
+        Dim("B", carried_by=(("hidden_states", 0), ("z", 0))),
+        Dim("F_lat", carried_by=(("hidden_states", 2), ("z", 2))),
+        Dim("H_lat", carried_by=(("hidden_states", 3), ("z", 3)), multiple_of=2),
+        Dim("W_lat", carried_by=(("hidden_states", 4), ("z", 4)), multiple_of=2),
+        Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+    )
+    fork = {"expand_timesteps": False, "use_tiling": False}
+    return Compile(
+        family="wan-2.2-t2v-a14b", targets=("transformer", "transformer_2", "vae.decode"),
+        text_len=512,
+        dims=dims,
+        forks=(
+            Fork("expand_timesteps", served=(False,), unserved=(True,),
+                 source=("pipeline", "expand_timesteps"),
+                 why="ti2v-5b's per-token timestep is a DIFFERENT graph class"),
+            Fork("use_tiling", served=(False,), unserved=(True,),
+                 source=("module", "use_tiling"), targets=("vae.decode",),
+                 why="tiled decode forks AutoencoderKLWan._decode"),
+        ),
+        classes=(
+            GraphClass(dims={"B": 1, "F_lat": 21, "H_lat": 90, "W_lat": 160,
+                             "T_txt": 512}, fork=fork),
+            GraphClass(dims={"B": 1, "F_lat": 21, "H_lat": 160, "W_lat": 90,
+                             "T_txt": 512}, fork=fork),
+        ),
+        inputs=(
+            Input("hidden_states",
+                  shape=("B", ("config", "in_channels"), "F_lat", "H_lat", "W_lat"),
+                  targets=("transformer", "transformer_2")),
+            Input("timestep", shape=("B",), dtype="int64",
+                  targets=("transformer", "transformer_2")),
+            Input("encoder_hidden_states",
+                  shape=("B", "T_txt", ("config", "text_dim")),
+                  targets=("transformer", "transformer_2")),
+            Input("z", shape=("B", ("config", "z_dim"), "F_lat", "H_lat", "W_lat"),
+                  positional=True, targets=("vae.decode",)),
+        ),
+        args=(Arg("return_dict", False),),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+
+
+def test_wan_a14b_bounds_derive_from_rows_exactly() -> None:
+    decl = _wan_a14b_decl()
+    plans = aot_declaration.mint_plans(decl, "transformer")
+    assert len(plans) == 1  # one fork coordinate -> ONE collapsed artifact
+    rows = {(d.input_name, d.axis): d for d in plans[0].dynamic}
+    # The measured §4 contract, derived — never hand-written:
+    for axis in (3, 4):
+        d = rows[("hidden_states", axis)]
+        assert (d.min, d.max, d.multiple_of) == (90, 160, 2)
+    # B / F_lat / T_txt are constant across rows -> static, no row emitted.
+    assert set(rows) == {("hidden_states", 3), ("hidden_states", 4)}
+
+
+def test_wan_a14b_decoder_gets_the_same_axes_on_z() -> None:
+    decl = _wan_a14b_decl()
+    plan = aot_declaration.mint_plans(decl, "vae.decode")[0]
+    rows = {(d.input_name, d.axis) for d in plan.dynamic}
+    assert rows == {("z", 3), ("z", 4)}  # target-filtered via Input.targets
+
+
+def test_static_rows_strategy_mints_one_plan_per_row() -> None:
+    decl = _wan_a14b_decl()
+    static = Compile(**{**_fields(decl), "shape_strategy": "static-rows"})
+    plans = aot_declaration.mint_plans(static, "transformer")
+    assert len(plans) == 2 and all(p.dynamic == () for p in plans)
+
+
+def _fields(c: Compile) -> dict:
+    import msgspec
+
+    return {f.name: getattr(c, f.name) for f in msgspec.structs.fields(c)}
+
+
+def test_collapse_refuses_a_dim_reaching_one() -> None:
+    decl = Compile(
+        family="zero-one", targets=("t",), text_len=0,
+        dims=(Dim("B", carried_by=(("x", 0),)),),
+        classes=(GraphClass(dims={"B": 1}), GraphClass(dims={"B": 2})),
+        shape_strategy="dynamic-collapse", warm_changes_key=False)
+    with pytest.raises(MintRefused, match="FORK the class"):
+        aot_declaration.mint_plans(decl, "t")
+
+
+def test_select_plan_refuses_unknown_coordinates_by_name() -> None:
+    decl = _wan_a14b_decl()
+    with pytest.raises(MintRefused, match="expand_timesteps.*True"):
+        aot_declaration.select_plan(
+            decl, "transformer",
+            fork={"expand_timesteps": True, "use_tiling": False})
+
+
+# ---------------------------------------------------------------------------
+# The relational axis — SDK-derived bounds + solver unification (real export)
+# ---------------------------------------------------------------------------
+
+
+class RelatedTokens(torch.nn.Module):
+    """The wan ti2v shape of fact: input ``t``'s axis 1 IS ``H*W`` — a
+    product of two roots, inexpressible in the Dim API (measured verbatim:
+    "Only increasing linear operations with integer coefficients are
+    supported"), carried instead by solver unification."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(3, 3)
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        b, c, h, w = x.shape
+        flat = x.reshape(b, c, h * w) + t.unsqueeze(1)
+        return self.proj(flat.transpose(1, 2))
+
+
+def _relational_decl() -> Compile:
+    fork: dict = {}
+    return Compile(
+        family="rel", targets=("t",), text_len=0,
+        dims=(
+            Dim("B", carried_by=(("x", 0),)),
+            Dim("H", carried_by=(("x", 2),)),
+            Dim("W", carried_by=(("x", 3),)),
+            Dim("N", carried_by=(("t", 1),), relates_to=("H", "W")),
+        ),
+        classes=(
+            GraphClass(dims={"B": 2, "H": 4, "W": 4, "N": 16}, fork=fork),
+            GraphClass(dims={"B": 2, "H": 8, "W": 8, "N": 64}, fork=fork),
+        ),
+        inputs=(
+            Input("x", shape=("B", 3, "H", "W"), positional=True),
+            Input("t", shape=("B", "N"), positional=True),
+        ),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+
+
+def test_relational_bounds_are_derived_not_hand_written() -> None:
+    plan = aot_declaration.mint_plans(_relational_decl(), "t")[0]
+    rows = {(d.input_name, d.axis): (d.min, d.max) for d in plan.dynamic}
+    assert rows[("t", 1)] == (16, 64)      # hull over the rows: 4*4 .. 8*8
+    assert rows[("x", 2)] == (4, 8) and rows[("x", 3)] == (4, 8)
+    assert plan.seed.dim_map == {"B": 2, "H": 8, "W": 8, "N": 64}
+
+
+def test_relational_axis_unifies_and_gates_on_solved_ranges() -> None:
+    """The measured ie#566 §5 mechanism on a real export: the free derived
+    range unifies into the shape env, and ``declared_range_gaps`` reads the
+    SOLVED composite range — while every per-symbol range fails to cover the
+    declared bounds, which is exactly why the pre-#739 per-symbol comparison
+    refused a sound artifact."""
+    decl = _relational_decl()
+    plan = aot_declaration.mint_plans(decl, "t")[0]
+    module = RelatedTokens().eval()
+    args = (torch.randn(2, 3, 8, 8), torch.randn(2, 64))
+    shapes = aot_mint.dynamic_shapes_spec(plan.dynamic, ("x", "t"))
+    program = aot_mint.export_program(module, args, {}, dynamic_shapes=shapes,
+                                      strict=True)
+
+    gaps = aot_mint.declared_range_gaps(program, plan.dynamic)
+    assert gaps == [], gaps
+
+    # The red half: the relational axis's placeholder carries ONLY the
+    # governing symbols (no free N symbol survives unification), and no
+    # single symbol's range covers [16, 64].
+    t_dim = aot_mint._placeholder_shapes(program)["t"][1]
+    syms = aot_mint._free_symbols(t_dim)
+    assert len(syms) >= 2, "N must be unified away into the governing symbols"
+    ranges = getattr(program, "range_constraints", {})
+    for sym in syms:
+        interval = ranges.get(sym)
+        assert interval is not None
+        assert int(interval.upper) < 64, (
+            "per-symbol ranges must NOT cover the declared bounds — the "
+            "composite solved range is the load-bearing check")
+
+
+def test_pinned_relational_axis_is_still_refused() -> None:
+    """Leaving the related input STATIC while declaring H/W dynamic is the
+    ie#566 G3 false pass; the guard-evidence gate refuses it by name."""
+    module = RelatedTokens().eval()
+    dims = (
+        aot_mint.DynamicDim("x", 2, 4, 8),
+        aot_mint.DynamicDim("x", 3, 4, 8),
+    )
+    args = (torch.randn(2, 3, 8, 8), torch.randn(2, 64))
+    shapes = aot_mint.dynamic_shapes_spec(dims, ("x", "t"))
+    program = aot_mint.export_program(module, args, {}, dynamic_shapes=shapes,
+                                      strict=True)
+    gaps = aot_mint.declared_range_gaps(program, dims)
+    assert gaps and any("PINS" in g or "solved to" in g for g in gaps), gaps
+
+
+# ---------------------------------------------------------------------------
+# One code path, two families — generic declared inputs
+# ---------------------------------------------------------------------------
+
+
+class FakeUnet(torch.nn.Module):
+    """sdxl-shaped: nested added_cond_kwargs, positional trio, config widths."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(4, 4)
+        self.config = SimpleNamespace(in_channels=4, cross_attention_dim=2048)
+
+
+class FakeWanDit(torch.nn.Module):
+    """wan-ti2v-shaped: kwargs call, per-token float32 timestep, config widths."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(8, 8)
+        self.config = SimpleNamespace(in_channels=48, text_dim=4096)
+
+
+def _sdxl_shaped_decl() -> Compile:
+    """The real sdxl contract, as a declaration: aspect rows x CFG arms,
+    pooled width 1280 and 6 micro-conditioning ids as literal axes."""
+    return Compile(
+        family="sdxl-shaped", targets=("unet",), text_len=77,
+        dims=(
+            Dim("B", carried_by=(("sample", 0), ("encoder_hidden_states", 0))),
+            Dim("H_lat", carried_by=(("sample", 2),), multiple_of=8),
+            Dim("W_lat", carried_by=(("sample", 3),), multiple_of=8),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+        ),
+        forks=(Fork("cfg", served=(True, False),
+                    why="CFG is ONE batch-2 forward (ie#345); turbo is batch-1"),),
+        classes=tuple(
+            GraphClass(dims={"B": b, "H_lat": h // 8, "W_lat": w // 8,
+                             "T_txt": 77}, fork={"cfg": cfg})
+            for (w, h) in ((1024, 1024), (1152, 896))
+            for (cfg, b) in ((True, 2), (False, 1))
+        ),
+        inputs=(
+            Input("sample", shape=("B", ("config", "in_channels"),
+                                   "H_lat", "W_lat"), positional=True),
+            Input("timestep", shape=(), value=1.0, positional=True),
+            Input("encoder_hidden_states",
+                  shape=("B", "T_txt", ("config", "cross_attention_dim")),
+                  positional=True),
+            Input("added_cond_kwargs.text_embeds", shape=("B", 1280)),
+            Input("added_cond_kwargs.time_ids", shape=("B", 6)),
+        ),
+        args=(Arg("return_dict", False),),
+        shape_strategy="static-rows",   # #730 ratified: conv-bearing -> static
+        warm_changes_key=False,          # measured mint-order canon
+    )
+
+
+def _ti2v_shaped_decl() -> Compile:
+    fork = {"expand_timesteps": True}
+    return Compile(
+        family="wan-ti2v-shaped", targets=("transformer",), text_len=512,
+        dims=(
+            Dim("B", carried_by=(("hidden_states", 0), ("timestep", 0))),
+            Dim("F_lat", carried_by=(("hidden_states", 2),)),
+            Dim("H_lat", carried_by=(("hidden_states", 3),), multiple_of=2),
+            Dim("W_lat", carried_by=(("hidden_states", 4),), multiple_of=2),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+            Dim("N_tok", carried_by=(("timestep", 1),),
+                relates_to=("F_lat", "H_lat", "W_lat")),
+        ),
+        forks=(Fork("expand_timesteps", served=(True,), unserved=(False,),
+                    source=("pipeline", "expand_timesteps"),
+                    why="per-token timestep IS the ti2v graph class"),),
+        classes=(GraphClass(
+            dims={"B": 1, "F_lat": 31, "H_lat": 44, "W_lat": 80,
+                  "T_txt": 512, "N_tok": 27280}, fork=fork),),
+        inputs=(
+            Input("hidden_states",
+                  shape=("B", ("config", "in_channels"), "F_lat", "H_lat",
+                         "W_lat")),
+            Input("timestep", shape=("B", "N_tok"), dtype="float32"),
+            Input("encoder_hidden_states",
+                  shape=("B", "T_txt", ("config", "text_dim"))),
+        ),
+        args=(Arg("return_dict", False),),
+        shape_strategy="static-rows",   # decision (c): ONE row, ONE artifact
+        warm_changes_key=False,          # §7: wan needs no pre-warm
+    )
+
+
+def test_two_families_one_code_path() -> None:
+    """The #739 red test: different declarations, correct example inputs,
+    ONE generic function — zero per-family SDK code."""
+    sdxl_spec = ExportSpec(
+        family="sdxl-shaped", target="unet",
+        fork=(("cfg", True),),
+        class_dims=(("B", 2), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
+    args, kwargs = aot_declaration.declared_inputs(
+        FakeUnet(), sdxl_spec, _sdxl_shaped_decl())
+    assert args[0].shape == (2, 4, 128, 128)
+    assert args[1].ndim == 0 and float(args[1]) == 1.0
+    assert args[2].shape == (2, 77, 2048)
+    assert kwargs["added_cond_kwargs"]["text_embeds"].shape == (2, 1280)
+    assert kwargs["added_cond_kwargs"]["time_ids"].shape == (2, 6)
+    assert kwargs["return_dict"] is False
+
+    wan_spec = ExportSpec(
+        family="wan-ti2v-shaped", target="transformer",
+        fork=(("expand_timesteps", True),))
+    args2, kwargs2 = aot_declaration.declared_inputs(
+        FakeWanDit(), wan_spec, _ti2v_shaped_decl())
+    assert args2 == ()
+    assert kwargs2["hidden_states"].shape == (1, 48, 31, 44, 80)
+    assert kwargs2["timestep"].shape == (1, 27280)
+    assert kwargs2["timestep"].dtype == torch.float32
+    assert kwargs2["encoder_hidden_states"].shape == (1, 512, 4096)
+    assert kwargs2["return_dict"] is False
+
+
+def test_declared_inputs_refuse_missing_config_fields_by_name() -> None:
+    class NoConfig(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.p = torch.nn.Linear(2, 2)
+            self.config = SimpleNamespace()
+
+    spec = ExportSpec(family="wan-ti2v-shaped", target="transformer",
+                      fork=(("expand_timesteps", True),))
+    with pytest.raises(MintRefused, match="in_channels"):
+        aot_declaration.declared_inputs(NoConfig(), spec, _ti2v_shaped_decl())
+
+
+def test_builder_for_prefers_the_registered_declaration() -> None:
+    from gen_worker import aot_inputs
+
+    register_export_declaration(_sdxl_shaped_decl())
+    builder = aot_inputs.builder_for("sdxl-shaped", "unet")
+    spec = ExportSpec(
+        family="sdxl-shaped", target="unet", fork=(("cfg", False),),
+        class_dims=(("B", 1), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
+    args, kwargs = builder(FakeUnet(), spec)
+    assert args[0].shape == (1, 4, 128, 128)
+    assert kwargs["return_dict"] is False
+
+
+def test_declared_inputs_actually_export() -> None:
+    """The one code path produces inputs a REAL strict export accepts."""
+
+    class TinyUnet(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = torch.nn.Linear(2048, 4)
+            self.config = SimpleNamespace(in_channels=4, cross_attention_dim=2048)
+
+        def forward(self, sample: torch.Tensor, timestep: torch.Tensor,
+                    encoder_hidden_states: torch.Tensor,
+                    added_cond_kwargs: dict | None = None,
+                    return_dict: bool = True) -> Any:
+            cond = self.proj(encoder_hidden_states).mean(dim=(1, 2))
+            out = sample * timestep + cond.reshape(-1, 1, 1, 1)
+            if added_cond_kwargs:
+                out = out + added_cond_kwargs["text_embeds"].mean()
+            return (out,) if not return_dict else out
+
+    spec = ExportSpec(
+        family="sdxl-shaped", target="unet", fork=(("cfg", True),),
+        class_dims=(("B", 2), ("H_lat", 128), ("W_lat", 128), ("T_txt", 77)))
+    args, kwargs = aot_declaration.declared_inputs(
+        TinyUnet(), spec, _sdxl_shaped_decl())
+    program = aot_mint.export_program(TinyUnet().eval(), args, kwargs,
+                                      strict=True)
+    assert program.graph_module is not None
+
+
+# ---------------------------------------------------------------------------
+# The fork gate — sources read off composed objects
+# ---------------------------------------------------------------------------
+
+
+def test_fork_gate_refuses_wrong_pipeline_arm_by_name() -> None:
+    decl = _ti2v_shaped_decl()
+    pipeline = SimpleNamespace(config=SimpleNamespace(expand_timesteps=None))
+    gaps = aot_declaration.fork_gaps(
+        decl, {"expand_timesteps": True}, target="transformer",
+        pipeline=pipeline, module=None)
+    assert len(gaps) == 1 and "expand_timesteps" in gaps[0]
+    assert "wrong class" in gaps[0]
+
+    honest = SimpleNamespace(config=SimpleNamespace(expand_timesteps=True))
+    assert aot_declaration.fork_gaps(
+        decl, {"expand_timesteps": True}, target="transformer",
+        pipeline=honest, module=None) == []
+
+
+def test_fork_gate_reads_module_attributes_for_module_sources() -> None:
+    decl = _wan_a14b_decl()
+    vae = SimpleNamespace(use_tiling=True, config=SimpleNamespace())
+    gaps = aot_declaration.fork_gaps(
+        decl, {"expand_timesteps": False, "use_tiling": False},
+        target="vae.decode",
+        pipeline=SimpleNamespace(config=SimpleNamespace(expand_timesteps=None)),
+        module=vae)
+    assert any("use_tiling" in g and "module" in g for g in gaps), gaps
+
+
+def test_fork_gate_refuses_omitted_and_undeclared_forks() -> None:
+    decl = _wan_a14b_decl()
+    gaps = aot_declaration.fork_gaps(decl, {}, target="transformer")
+    assert any("omits declared fork 'expand_timesteps'" in g for g in gaps)
+    gaps2 = aot_declaration.fork_gaps(
+        decl, {"expand_timesteps": False, "made_up": 1}, target="transformer")
+    assert any("undeclared fork" in g and "made_up" in g for g in gaps2)
+
+
+def test_fork_gate_refuses_missing_source_field_by_name() -> None:
+    decl = _ti2v_shaped_decl()
+    bare = SimpleNamespace()
+    gaps = aot_declaration.fork_gaps(
+        decl, {"expand_timesteps": True}, target="transformer",
+        pipeline=bare, module=None)
+    assert any("neither a config field nor an attribute" in g for g in gaps)
+
+
+# ---------------------------------------------------------------------------
+# Request resolution + identity
+# ---------------------------------------------------------------------------
+
+
+def test_apply_declaration_refuses_hand_dynamic_rows() -> None:
+    register_export_declaration(_wan_a14b_decl())
+    spec = ExportSpec(
+        family="wan-2.2-t2v-a14b", target="transformer",
+        fork=(("expand_timesteps", False), ("use_tiling", False)),
+        dynamic=(aot_mint.DynamicDim("hidden_states", 3, 90, 160),))
+    with pytest.raises(MintRefused, match="hand-written"):
+        aot_declaration.apply_declaration(spec)
+
+
+def test_apply_declaration_requires_the_warm_canon() -> None:
+    decl = _wan_a14b_decl()
+    unmeasured = Compile(**{**_fields(decl), "warm_changes_key": None})
+    register_export_declaration(unmeasured)
+    spec = ExportSpec(
+        family="wan-2.2-t2v-a14b", target="transformer",
+        fork=(("expand_timesteps", False), ("use_tiling", False)))
+    with pytest.raises(MintRefused, match="warm_changes_key"):
+        aot_declaration.apply_declaration(spec)
+
+
+def test_apply_declaration_derives_the_contract() -> None:
+    register_export_declaration(_wan_a14b_decl())
+    spec = ExportSpec(
+        family="wan-2.2-t2v-a14b", target="transformer",
+        shapes=((1280, 720, 81), (720, 1280, 81)),
+        fork=(("expand_timesteps", False), ("use_tiling", False)))
+    out = aot_declaration.apply_declaration(spec)
+    assert {(d.input_name, d.axis, d.min, d.max) for d in out.dynamic} == {
+        ("hidden_states", 3, 90, 160), ("hidden_states", 4, 90, 160)}
+    assert out.specialization["shape_strategy"] == "dynamic-collapse"
+    assert out.specialization["warm_changes_key"] is False
+    assert out.specialization["fork.expand_timesteps"] is False
+
+
+def test_unregistered_family_passes_through_untouched() -> None:
+    spec = ExportSpec(family="plain", target="unet")
+    assert aot_declaration.apply_declaration(spec) is spec
+
+
+def test_fork_and_row_reach_the_cell_identity() -> None:
+    """A fork is a DISTINCT graph class in #716's hash; a static row is the
+    artifact's identity."""
+    meta = {"sm": "sm_89", "range_digest": "r1", "format": "pt2",
+            "family": "sdxl-shaped", "graph": {"v": 1}}
+    base = dict(family="sdxl-shaped", target="unet")
+    a = aot_mint.cell_identity(meta, ExportSpec(**base, fork=(("cfg", True),)))
+    b = aot_mint.cell_identity(meta, ExportSpec(**base, fork=(("cfg", False),)))
+    c = aot_mint.cell_identity(meta, ExportSpec(**base))
+    assert len({a.digest, b.digest, c.digest}) == 3
+    d1 = aot_mint.cell_identity(
+        meta, ExportSpec(**base, class_dims=(("H_lat", 128), ("W_lat", 128))))
+    d2 = aot_mint.cell_identity(
+        meta, ExportSpec(**base, class_dims=(("H_lat", 112), ("W_lat", 144))))
+    assert d1.digest != d2.digest
+
+
+def test_load_spec_parses_the_coordinate() -> None:
+    import json
+
+    body = {
+        "family": "sdxl-shaped", "target": "unet",
+        "fork": {"cfg": True},
+        "class_dims": {"H_lat": 128, "W_lat": 128, "B": 2, "T_txt": 77},
+    }
+    path = None
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "req.json"
+        path.write_text(json.dumps(body))
+        spec, _raw = aot_mint._load_spec(path)
+    assert spec.fork == (("cfg", True),)
+    assert dict(spec.class_dims)["H_lat"] == 128

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -1054,7 +1054,7 @@ def test_sdxl_lora_bucket_zero_takes_no_adapter_arguments() -> None:
     from gen_worker import aot_inputs
 
     spec = aot_mint.ExportSpec(family="sdxl", target="unet", lora_bucket=0)
-    assert aot_inputs.lifted_lora_kwargs(LiftedModule(), spec) == {}
+    assert aot_inputs.lifted_lora_values(LiftedModule(), spec) == {}
 
 
 def test_unknown_family_has_no_input_contract() -> None:

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -1015,7 +1015,8 @@ def test_cli_loads_a_full_request(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# The SDXL input contract
+# The generic input machinery (the sdxl contract itself is a DECLARATION in
+# the sdxl endpoint since pgw#739 — see test_aot_declaration_pgw739.py)
 # ---------------------------------------------------------------------------
 
 
@@ -1059,7 +1060,7 @@ def test_sdxl_lora_bucket_zero_takes_no_adapter_arguments() -> None:
 def test_unknown_family_has_no_input_contract() -> None:
     from gen_worker import aot_inputs
 
-    with pytest.raises(aot_inputs.InputContractError, match="no AOT export"):
+    with pytest.raises(aot_inputs.InputContractError, match="DECLARED"):
         aot_inputs.builder_for("madeup")
 
 
@@ -1071,12 +1072,20 @@ def test_unknown_family_has_no_input_contract() -> None:
 def test_G1_builders_are_keyed_by_family_AND_target() -> None:
     """A family's compile targets are unrelated modules with unrelated call
     contracts. Keying by family alone made ``vae.decode`` unmintable for EVERY
-    family, not just wan."""
+    family, not just wan. (sdxl's own contract is an endpoint DECLARATION now
+    — pgw#739 — so the keying property is proven on a hand registration.)"""
     from gen_worker import aot_inputs
 
-    assert aot_inputs.builder_for("sdxl", "unet") is aot_inputs.sdxl_unet_inputs
-    with pytest.raises(aot_inputs.InputContractError, match="vae.decode"):
-        aot_inputs.builder_for("sdxl", "vae.decode")
+    def _denoiser(module: Any, spec: Any) -> Any:  # pragma: no cover - key only
+        return (), {}
+
+    aot_inputs._BUILDERS[("keyfam", "unet")] = _denoiser
+    try:
+        assert aot_inputs.builder_for("keyfam", "unet") is _denoiser
+        with pytest.raises(aot_inputs.InputContractError, match="vae.decode"):
+            aot_inputs.builder_for("keyfam", "vae.decode")
+    finally:
+        aot_inputs._BUILDERS.pop(("keyfam", "unet"), None)
 
 
 def test_G1_family_wide_fallback_answers_any_target() -> None:
@@ -1134,25 +1143,30 @@ def test_G1b_signature_stamp_does_not_leak_between_targets() -> None:
 
 
 def test_G2_batch_is_declared_not_inferred_from_guidance() -> None:
-    """wan's CFG is two SEQUENTIAL batch-1 forwards, so guidance changes the call
-    COUNT, not the traced shape. Inferring batch from guidance family-agnostically
-    traced a graph the serving path never calls."""
-    from gen_worker import aot_inputs
+    """wan's CFG is two SEQUENTIAL batch-1 forwards, so guidance changes the
+    call COUNT, not the traced shape. The guidance heuristic that guessed
+    batch died with the sdxl SDK builder (pgw#739): batch is now a declared
+    coordinate — ``B`` is a Dim, the CFG regime is a Fork, and the class ROW
+    states the traced batch outright."""
+    from gen_worker.api.decorators import Compile
+    from gen_worker.api.export_contract import Dim, Fork, GraphClass
 
-    unet = LiftedModule()
-    cfg_spec = aot_mint.ExportSpec(
-        family="sdxl", target="unet", shapes=((1024, 1024),),
-        guidance_scales=(6.0,))
-    assert aot_inputs._sdxl_cfg_batched(cfg_spec) is True
+    decl = Compile(
+        family="g2fam", targets=("unet",), text_len=77,
+        dims=(Dim("B", carried_by=(("x", 0),)),),
+        forks=(Fork("cfg", served=(True, False)),),
+        classes=(
+            GraphClass(dims={"B": 2}, fork={"cfg": True}),
+            GraphClass(dims={"B": 1}, fork={"cfg": False}),
+        ),
+        shape_strategy="static-rows", warm_changes_key=False,
+    )
+    from gen_worker import aot_declaration
 
-    # An explicit declaration overrides the SDXL heuristic entirely.
-    pinned = aot_mint.ExportSpec(
-        family="sdxl", target="unet", shapes=((1024, 1024),),
-        guidance_scales=(6.0,), batch=1)
-    args, _ = aot_inputs.sdxl_unet_inputs(unet, pinned)
-    assert args[0].shape[0] == 1, "declared batch must win over the heuristic"
-    args2, _ = aot_inputs.sdxl_unet_inputs(unet, cfg_spec)
-    assert args2[0].shape[0] == 2
+    batched = aot_declaration.select_plan(decl, "unet", fork={"cfg": True})
+    pinned = aot_declaration.select_plan(decl, "unet", fork={"cfg": False})
+    assert batched.seed.dim_map["B"] == 2
+    assert pinned.seed.dim_map["B"] == 1
 
 
 def test_G3_genuine_dependence_is_REFUSED() -> None:

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -1155,31 +1155,94 @@ def test_G2_batch_is_declared_not_inferred_from_guidance() -> None:
     assert args2[0].shape[0] == 2
 
 
-def test_G3_cross_input_collapse_is_DETECTED() -> None:
-    """The measured FALSE PASS: each symbol keeps a healthy range, yet a static
-    per-token dim that is a function of H*W pins the graph to one shape."""
-    class Tokened(torch.nn.Module):
+def test_G3_genuine_dependence_is_REFUSED() -> None:
+    """The ti2v-5b true positive: a static dim that GENUINELY constrains H*W.
+
+    ``reshape(b, c, h*w)`` against a static-length input forces the tracer to
+    record ``Eq(h*w, N)``. That guard is the evidence — see the coincidence test
+    below for why arithmetic on the numbers is not.
+    """
+    class GenuineDep(torch.nn.Module):
+        def forward(self, x: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
+            b, c, h, w = x.shape
+            return x.reshape(b, c, h * w) + tokens.reshape(1, 1, -1)
+
+    h, w = 16, 24
+    program = torch.export.export(
+        GenuineDep().eval(), (torch.randn(2, 4, h, w), torch.randn(h * w)), {},
+        dynamic_shapes={
+            "x": {2: torch.export.Dim("h", min=8, max=32),
+                  3: torch.export.Dim("w", min=8, max=32)},
+            "tokens": None},
+        strict=True)
+    dims = (aot_mint.DynamicDim("x", 2, 8, 32),
+            aot_mint.DynamicDim("x", 3, 8, 32))
+    gaps = aot_mint.declared_range_gaps(program, dims)
+    assert gaps, "an Eq guard pinning h*w must not pass the gate"
+    joined = " ".join(gaps)
+    assert "PINS" in joined and "ie#566 G3" in joined
+    # range_constraints still reports the FULL declared range here — which is
+    # exactly why a presence check (and a solved-range check) miss this.
+    assert all(int(v.lower) == 8 and int(v.upper) == 32
+               for v in program.range_constraints.values())
+
+
+def test_G3_numeric_coincidence_is_NOT_refused() -> None:
+    """The counterpart that killed the arithmetic version of this gate.
+
+    ``tokens`` is numerically h*w but nothing REQUIRES it to be, so no guard is
+    recorded and the dims stay genuinely free. A divisibility test cannot tell
+    this apart from the case above.
+    """
+    class Coincidence(torch.nn.Module):
         def forward(self, x: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
             return x.flatten(2).sum(-1) + tokens.sum()
 
     h, w = 16, 24
     program = torch.export.export(
-        Tokened().eval(),
-        (torch.randn(2, 4, h, w), torch.randn(h * w)),
+        Coincidence().eval(), (torch.randn(2, 4, h, w), torch.randn(h * w)), {},
         dynamic_shapes={
             "x": {2: torch.export.Dim("h", min=8, max=32),
                   3: torch.export.Dim("w", min=8, max=32)},
-            "tokens": None,
-        },
-        strict=True,
-    )
+            "tokens": None},
+        strict=True)
     dims = (aot_mint.DynamicDim("x", 2, 8, 32),
             aot_mint.DynamicDim("x", 3, 8, 32))
-    gaps = aot_mint.declared_range_gaps(program, dims)
-    assert gaps, "a static dim equal to H*W must not pass the gate"
-    joined = " ".join(gaps)
-    assert "tokens[0]" in joined and "STATIC 384" in joined
-    assert "ie#566 G3" in joined
+    assert aot_mint.declared_range_gaps(program, dims) == []
+
+
+def test_G3_does_not_refuse_the_real_sdxl_shape_contract() -> None:
+    """REGRESSION: the arithmetic gate refused EVERY symbolic sdxl mint.
+
+    SDXL's cross-attention width 2048 and pooled width 1280 are multiples of the
+    declared extents' product by architectural coincidence. The old gate read
+    that as dependence and blocked the artifact reproducing pgw#704's headline
+    (one export serving a second in-range shape). This test exists so that
+    cannot come back.
+    """
+    class Sdxlish(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(2048, 4)
+
+        def forward(self, sample: torch.Tensor, ehs: torch.Tensor,
+                    pooled: torch.Tensor) -> torch.Tensor:
+            return (sample.flatten(2).sum(-1)
+                    + self.lin(ehs).sum() + pooled.sum())
+
+    program = torch.export.export(
+        Sdxlish().eval(),
+        (torch.randn(2, 4, 16, 16), torch.randn(2, 77, 2048),
+         torch.randn(2, 1280)), {},
+        dynamic_shapes={
+            "sample": {2: torch.export.Dim("h", min=8, max=32),
+                       3: torch.export.Dim("w", min=8, max=32)},
+            "ehs": None, "pooled": None},
+        strict=True)
+    dims = (aot_mint.DynamicDim("sample", 2, 8, 32),
+            aot_mint.DynamicDim("sample", 3, 8, 32))
+    assert aot_mint.declared_range_gaps(program, dims) == [], (
+        "2048 and 1280 are architectural constants, not evidence of dependence")
 
 
 def test_G3_does_not_fire_on_an_honest_dynamic_export() -> None:

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -916,8 +916,16 @@ def test_compile_struct_validation():
 def test_dynamic_dim_validation():
     d = DynamicDim(dim=" Batch ", min=2, max=8)
     assert (d.dim, d.min, d.max) == ("batch", 2, 8)
+    # pgw#739: the two-literal "batch"|"sequence" wall is REPLACED — wan's
+    # latent-spatial axis is the red case (ie#550/ie#566 hit it from both
+    # sides). A named axis constructs; validation moved to Compile, which
+    # cross-references the name against declared Compile.dims.
+    lat = DynamicDim(dim="latent_h", min=90, max=160)
+    assert lat.dim == "latent_h"
+    with pytest.raises(ValueError, match="latent_h"):
+        Compile(shapes=((768, 768),), dynamic=(lat,))  # no Dim declares it
     with pytest.raises(ValueError):
-        DynamicDim(dim="channels", min=2, max=8)
+        DynamicDim(dim="not an identifier", min=2, max=8)
     with pytest.raises(ValueError, match=">= 2"):
         DynamicDim(dim="batch", min=1, max=8)  # torch 0/1 specialization
     with pytest.raises(ValueError, match="exceed"):

--- a/tests/test_component_vocab_sweep_pgw740.py
+++ b/tests/test_component_vocab_sweep_pgw740.py
@@ -1,0 +1,250 @@
+"""pgw#740 B5/B6: the call-site sweep onto the ONE component vocabulary.
+
+B5 landed the vocabulary module; the 20+ copies of ``("transformer","unet",…)``
+across ``models/`` and ``convert/`` are repointed here. Two things are tested:
+
+1. **The sweep holds** — an extension of #740's tokenizer-based acceptance grep
+   to the swept files. A component-name string literal in LIVE code (comments
+   and docstrings are provenance and stay) is a new copy, and a new copy is how
+   Wan's ``transformer_2`` and LTX's ``connectors`` got silently dropped.
+
+2. **B6, the correctness gap the copies caused** — one ``declare_components``
+   call reaches every consumer, and it reaches them even though the consumer
+   modules were imported BEFORE the declaration ran. That ordering is the whole
+   hazard: a module-level tuple snapshots the vocabulary at import time, and
+   endpoint declarations run at endpoint-module import, which is later.
+"""
+
+from __future__ import annotations
+
+import re
+import tokenize
+from pathlib import Path
+
+import pytest
+
+from gen_worker.component_vocab import (
+    component_vocabulary,
+    declare_components,
+    denoiser_components,
+    quant_candidate_components,
+    reset_component_vocabulary,
+    weight_components,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+
+@pytest.fixture(autouse=True)
+def _clean_vocabulary():
+    reset_component_vocabulary()
+    yield
+    reset_component_vocabulary()
+
+
+# ---------------------------------------------------------------------------
+# 1. the sweep, as a permanent test
+# ---------------------------------------------------------------------------
+
+#: Files the B5 sweep repointed. A component literal in any of these is a
+#: regression unless it is allow-listed below with a reason.
+_SWEPT_FILES = (
+    "models/loading.py",
+    "models/memory.py",
+    "models/download.py",
+    "models/w8a8.py",
+    "models/w4a4.py",
+    "models/w8a8_lora.py",
+    "models/svdq.py",
+    "models/gguf_local.py",
+    "models/provision.py",
+    "utils/lora.py",
+    "convert/convert.py",
+    "convert/source.py",
+    "convert/writer.py",
+    "convert/clone.py",
+    "convert/size_walk.py",
+    "convert/svdq.py",
+    "convert/layout_spec.py",
+    "cli/serve.py",
+)
+
+#: (file, literal) -> why this one is NOT a vocabulary copy. Each names a
+#: single specific thing, never an enumeration of "the components".
+_ALLOWED = {
+    ("models/memory.py", "vae"):
+        "diffusers' VAE slicing/tiling APIs hang off the .vae attribute by "
+        "name; this addresses that one attribute, it does not enumerate.",
+    ("models/w8a8_lora.py", "unet"):
+        "diffusers' lora_state_dict(unet_config=...) keyword — upstream's "
+        "parameter name, not our component vocabulary.",
+    ("convert/writer.py", "decoder"):
+        "a layer-name pattern matched INSIDE a model; collides with the "
+        "component name by coincidence.",
+    ("convert/writer.py", "scheduler"):
+        "one specific path, out_dir/scheduler/config.json, for the distilled "
+        "scheduler overrides.",
+    ("utils/lora.py", "text_encoder"):
+        "right-hand side of the kohya alias table: sd-scripts' fixed grammar "
+        "(lora_te1_/lora_te_) mapped ONTO a vocabulary name. Upstream decides "
+        "which aliases exist, so the table is correctly literal.",
+    ("utils/lora.py", "text_encoder_2"): "kohya alias target — see above.",
+    ("utils/lora.py", "text_encoder_3"): "kohya alias target — see above.",
+}
+
+
+def _code_literals(path: Path) -> list[tuple[int, str]]:
+    """(lineno, value) for every string literal in LIVE code.
+
+    Comments and docstrings are stripped: a component name surviving in prose
+    is provenance and is allowed — exactly the rule #740's acceptance grep uses.
+    """
+    out: list[tuple[int, str]] = []
+    with open(path, "rb") as handle:
+        for tok in tokenize.tokenize(handle.readline):
+            if tok.type != tokenize.STRING:
+                continue
+            raw = tok.string.lstrip("rbufRBUF")
+            if raw.startswith(('"""', "'''")):
+                continue  # docstring
+            out.append((tok.start[0], raw[1:-1]))
+    return out
+
+
+def test_no_swept_file_repeats_the_component_vocabulary() -> None:
+    names = set(component_vocabulary().all)
+    offenders: list[str] = []
+    for rel in _SWEPT_FILES:
+        for lineno, value in _code_literals(_SRC / rel):
+            if value in names and (rel, value) not in _ALLOWED:
+                offenders.append(f"{rel}:{lineno}: {value!r}")
+    assert offenders == [], (
+        "component-name literals in live code — these are new copies of the "
+        "vocabulary. Read it from gen_worker.component_vocab instead, or "
+        "allow-list with a reason if it names one specific thing:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_the_sweep_left_no_module_level_snapshot() -> None:
+    """The copies were module-level tuples; a replacement that is still a
+    module-level tuple has fixed nothing. Every swept module must read the
+    vocabulary through a call."""
+    # Anchored at column 0: an indented `components = denoiser_components()`
+    # inside a function IS the correct call-time pattern. Binding the RESULT
+    # at module scope is the bug; binding the FUNCTION (no parens) is fine.
+    snapshot = re.compile(
+        r"^[A-Za-z_]\w*(?:\s*:[^=\n]+)?\s*=\s*"
+        r"(?:denoiser|weight|quant_candidate|pipeline_component|text_encoder)"
+        r"[a-z_]*\(\)",
+        re.MULTILINE,
+    )
+    offenders: list[str] = []
+    for rel in _SWEPT_FILES:
+        for hit in snapshot.finditer((_SRC / rel).read_text()):
+            offenders.append(f"{rel}: module-level snapshot {hit.group(0)!r}")
+    assert offenders == [], (
+        "these bind the vocabulary at import time, before an endpoint's "
+        "declare_components() runs:\n" + "\n".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. B6 — the correctness gap: transformer_2 and connectors
+# ---------------------------------------------------------------------------
+
+def test_wan_moe_second_expert_is_a_denoiser_everywhere() -> None:
+    """``transformer_2`` (Wan 2.2 A14B's low-noise expert) was absent from
+    several copies, so it was skipped by the offload and quant loops."""
+    assert "transformer_2" in denoiser_components()
+    assert "transformer_2" in weight_components()
+    assert "transformer_2" in quant_candidate_components()
+
+
+def test_a_declared_component_reaches_every_swept_consumer() -> None:
+    """One declaration, every consumer — the point of the sweep.
+
+    LTX's ``connectors`` is the real case: it carries weights, so it must be
+    walked, sized, offloaded and quantized, and it is not a diffusers name.
+    """
+    from gen_worker.convert import size_walk, source
+    from gen_worker.convert.layout_spec import LayoutSignals
+    from gen_worker.models import memory
+
+    assert "connectors" not in weight_components()
+
+    declare_components(auxiliaries=("connectors",))
+
+    assert component_vocabulary().role_of("connectors") == "auxiliary"
+    assert "connectors" in weight_components()
+    assert "connectors" in quant_candidate_components()
+    # ...and in each swept consumer's own derived view
+    assert "connectors" in size_walk._diffusers_weight_component_dirs()
+    assert "connectors" in source._weight_component_dirs()
+    assert "connectors" in source._diffusers_component_dirs()
+    assert "connectors" in source._default_quant_candidate_components()
+    assert "connectors" in LayoutSignals().component_dirs
+    assert "connectors" in memory._component_order_hint()
+
+
+def test_a_declaration_after_import_is_still_seen() -> None:
+    """The freeze hazard, directly. These modules are imported at the top of
+    this test session; the declaration happens now. A module-level tuple would
+    have snapshotted the vocabulary before this line and missed it."""
+    from gen_worker.convert import size_walk
+
+    before = size_walk._diffusers_weight_component_dirs()
+    declare_components(auxiliaries=("motion_adapter",))
+    after = size_walk._diffusers_weight_component_dirs()
+
+    assert "motion_adapter" not in before
+    assert "motion_adapter" in after
+
+
+def test_a_declared_component_is_sized_rather_than_counted_as_zero(tmp_path) -> None:
+    """End of the line for the bug: an undeclared component contributes zero
+    bytes to the size facts the orchestrator gates VRAM placement on."""
+    from gen_worker.convert.size_walk import compute_size_facts
+
+    (tmp_path / "transformer").mkdir()
+    (tmp_path / "transformer" / "m.safetensors").write_bytes(b"x" * 2048)
+    (tmp_path / "connectors").mkdir()
+    (tmp_path / "connectors" / "m.safetensors").write_bytes(b"y" * 1024)
+
+    undeclared = compute_size_facts(tmp_path)
+    assert "connectors" not in undeclared["components"]
+    assert undeclared["full_model_bytes"] == 2048
+
+    declare_components(auxiliaries=("connectors",))
+    declared = compute_size_facts(tmp_path)
+    assert declared["components"]["connectors"]["total_bytes"] == 1024
+    assert declared["full_model_bytes"] == 3072
+
+
+def test_both_moe_experts_are_lora_branch_targets() -> None:
+    """gw#679's defect restated as a vocabulary test: a dual-expert pipeline
+    must offer BOTH experts as branch targets, or the low expert serves
+    undistilled weights on a distilled ladder."""
+    from gen_worker.models.w8a8_lora import branch_targets
+
+    class _Mod:
+        def named_modules(self):
+            return iter(())
+
+    class _WanMoE:
+        transformer = _Mod()
+        transformer_2 = _Mod()
+
+    assert set(branch_targets(_WanMoE())) == {"transformer", "transformer_2"}
+
+
+def test_block_window_offload_defaults_to_every_denoiser() -> None:
+    """``apply_block_window_offload``'s default was a literal
+    ``("transformer","unet")`` in the signature — a default argument, so even
+    repointing it would have frozen the vocabulary at def time."""
+    import inspect
+
+    from gen_worker.models.loading import apply_block_window_offload
+
+    default = inspect.signature(apply_block_window_offload).parameters["components"].default
+    assert default is None, "a non-None default re-freezes the vocabulary at def time"

--- a/tests/test_eval_kind_th1255.py
+++ b/tests/test_eval_kind_th1255.py
@@ -1,0 +1,46 @@
+"""th#1255: kind="eval" is declarable, survives discovery/lock validation, and
+maps to a context that materializes reserved refs without a publish surface."""
+import msgspec
+import pytest
+
+from gen_worker.api.decorators import KINDS, endpoint
+from gen_worker.discovery.validation import _KNOWN_KINDS
+from gen_worker.executor import _CONTEXT_BY_KIND
+from gen_worker.request_context import ConversionContext, RequestContext
+
+
+class In(msgspec.Struct, forbid_unknown_fields=True):
+    source: dict
+
+
+class Out(msgspec.Struct):
+    lpips_mean: float
+
+
+def test_eval_kind_is_declarable():
+    assert "eval" in KINDS and "eval" in _KNOWN_KINDS
+
+    @endpoint(kind="eval")
+    class ExternalQualityEval:
+        def external_quality_eval(self, ctx, payload: In) -> Out:
+            return Out(lpips_mean=0.0)
+
+    assert ExternalQualityEval is not None
+
+
+def test_unknown_kind_still_rejected():
+    with pytest.raises(ValueError, match="kind must be one of"):
+        @endpoint(kind="evaluation")
+        class Nope:
+            def go(self, ctx, payload: In) -> Out:
+                return Out(lpips_mean=0.0)
+
+
+def test_eval_context_materializes_reserved_refs_and_is_not_the_base():
+    # The executor sets producer=True for every non-inference kind and passes
+    # source_info/destination_info kwargs; a base RequestContext would raise
+    # TypeError on them. Registering the kind is mandatory, not cosmetic.
+    cls = _CONTEXT_BY_KIND["eval"]
+    assert cls is ConversionContext
+    assert cls is not RequestContext
+    assert hasattr(cls, "source") and hasattr(cls, "source_path")

--- a/tests/test_export_contract_pgw739.py
+++ b/tests/test_export_contract_pgw739.py
@@ -1,0 +1,371 @@
+"""pgw#739 — the export-declaration vocabulary (schema half, no torch).
+
+The vocabulary must accept the accumulated rulings' worked examples and
+refuse the accumulated failure modes BY NAME:
+
+- named dims with ``(input, axis)`` bindings (wan's latent-spatial axis is
+  the red case the old ``DynamicDim`` two-literal wall refused);
+- ``Fork(served=, unserved=)`` with ``(pipeline|module, field)`` source
+  bindings (wan's ``expand_timesteps`` is a PIPELINE field);
+- rows-as-coordinates with NO formula DSL;
+- per-family shape strategy (#730) and mint-warm canon (``warm_changes_key``)
+  as declared facts;
+- the LTX-AOT-DESIGN.md §2.3 draft is the spec this vocabulary must accept —
+  it parses here as the third test case; its family stays unminted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker.api.decorators import Compile, DynamicDim
+from gen_worker.api.export_contract import (
+    DeclarationError,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+    Arg,
+    export_declaration,
+    register_export_declaration,
+    reset_export_declarations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dim — named axes with (input, axis) bindings
+# ---------------------------------------------------------------------------
+
+
+def test_dim_carries_input_axis_bindings() -> None:
+    d = Dim("T_v", carried_by=(("hidden_states", 1), ("timestep", 1),
+                               ("video_coords", 2)))
+    assert d.carried_by == (("hidden_states", 1), ("timestep", 1),
+                            ("video_coords", 2))
+    assert d.multiple_of == 1 and d.relates_to == ()
+
+
+def test_dim_refusals_are_named() -> None:
+    with pytest.raises(DeclarationError, match="no .*bindings"):
+        Dim("H_lat", carried_by=())
+    with pytest.raises(DeclarationError, match="negative axis"):
+        Dim("H_lat", carried_by=(("sample", -1),))
+    with pytest.raises(DeclarationError, match="repeats binding"):
+        Dim("H_lat", carried_by=(("sample", 2), ("sample", 2)))
+    with pytest.raises(DeclarationError, match="relates_to itself"):
+        Dim("N", carried_by=(("t", 1),), relates_to=("N",))
+    with pytest.raises(DeclarationError, match="multiple_of"):
+        Dim("H_lat", carried_by=(("sample", 2),), multiple_of=0)
+
+
+def test_dim_has_no_min_max_fields() -> None:
+    """Bounds derive from the class rows — a Dim carrying hand-written bounds
+    is the endpoint hand-math #739 forbids, so the field does not exist."""
+    with pytest.raises(TypeError):
+        Dim("N_tok", carried_by=(("timestep", 1),), min=12400)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Fork — graph-class forks with source bindings
+# ---------------------------------------------------------------------------
+
+
+def test_fork_served_unserved_partition() -> None:
+    f = Fork("isolate_modalities", served=(False,), unserved=(True,),
+             why="20,509 vs 30,877 nodes")
+    assert f.served == (False,) and f.unserved == (True,)
+    with pytest.raises(DeclarationError, match="no served arm"):
+        Fork("dead", served=())
+    with pytest.raises(DeclarationError, match="BOTH served and unserved"):
+        Fork("both", served=(True,), unserved=(True,))
+
+
+def test_fork_source_binds_pipeline_or_module() -> None:
+    f = Fork("expand_timesteps", served=(True,), unserved=(False,),
+             source=("pipeline", "expand_timesteps"))
+    assert f.source == ("pipeline", "expand_timesteps")
+    Fork("use_tiling", served=(False,), unserved=(True,),
+         source=("module", "use_tiling"))
+    with pytest.raises(DeclarationError, match="pipeline"):
+        Fork("bad", served=(True,), source=("config", "x"))
+
+
+# ---------------------------------------------------------------------------
+# GraphClass — resolved rows, hashable for endpoint-side dedupe
+# ---------------------------------------------------------------------------
+
+
+def test_graph_class_accepts_mappings_and_hashes() -> None:
+    a = GraphClass(fork={"cfg": False}, dims={"T_v": 130560, "B": 1})
+    b = GraphClass(dims={"B": 1, "T_v": 130560}, fork={"cfg": False})
+    assert a == b and len(dict.fromkeys([a, b])) == 1  # the LTX generator idiom
+    assert a.dim_map == {"T_v": 130560, "B": 1}
+    with pytest.raises(DeclarationError, match="non-positive"):
+        GraphClass(dims={"T_v": 0})
+    with pytest.raises(DeclarationError, match="no dim values"):
+        GraphClass(dims={})
+
+
+# ---------------------------------------------------------------------------
+# Compile cross-validation — refusals by name
+# ---------------------------------------------------------------------------
+
+
+def _decl(**overrides) -> Compile:
+    base = dict(
+        family="fam", targets=("transformer",), text_len=512,
+        dims=(Dim("H", carried_by=(("hidden_states", 2),), multiple_of=2),
+              Dim("B", carried_by=(("hidden_states", 0),))),
+        forks=(Fork("cfg", served=(False,), unserved=(True,)),),
+        classes=(GraphClass(dims={"H": 90, "B": 1}, fork={"cfg": False}),
+                 GraphClass(dims={"H": 160, "B": 1}, fork={"cfg": False})),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+    base.update(overrides)
+    return Compile(**base)  # type: ignore[arg-type]
+
+
+def test_valid_declaration_constructs_and_reaches_contract_axes() -> None:
+    c = _decl()
+    axes = c.contract_axes()
+    assert axes["shape_strategy"] == "dynamic-collapse"
+    assert axes["warm_changes_key"] is False
+    assert [row["name"] for row in axes["dims"]] == ["H", "B"]
+    assert len(axes["classes"]) == 2
+
+
+def test_undeclared_facts_do_not_change_existing_digests() -> None:
+    """A family that has not adopted the vocabulary must keep its digest."""
+    c = Compile(family="old", shapes=((768, 768),), text_len=77)
+    axes = c.contract_axes()
+    for key in ("dims", "forks", "classes", "inputs", "args",
+                "shape_strategy", "warm_changes_key", "eager"):
+        assert key not in axes
+
+
+def test_class_omitting_declared_fork_is_refused_by_name() -> None:
+    with pytest.raises(DeclarationError, match="omits declared fork.*cfg"):
+        _decl(classes=(GraphClass(dims={"H": 90, "B": 1}),))
+
+
+def test_class_carrying_undeclared_fork_is_refused_by_name() -> None:
+    """The #739 red case: a coordinate forking on a flag the vocabulary does
+    not declare would silently export two classes as one."""
+    with pytest.raises(DeclarationError, match="expand_timesteps.*does not declare"):
+        _decl(classes=(GraphClass(
+            dims={"H": 90, "B": 1},
+            fork={"cfg": False, "expand_timesteps": True}),))
+
+
+def test_class_on_unserved_arm_is_refused() -> None:
+    with pytest.raises(DeclarationError, match="UNSERVED arm cfg=True"):
+        _decl(classes=(GraphClass(dims={"H": 90, "B": 1}, fork={"cfg": True}),))
+
+
+def test_class_dims_must_match_declared_dims_exactly() -> None:
+    with pytest.raises(DeclarationError, match="omits declared dim.*B"):
+        _decl(classes=(GraphClass(dims={"H": 90}, fork={"cfg": False}),))
+    with pytest.raises(DeclarationError, match="undeclared dim.*W"):
+        _decl(classes=(GraphClass(
+            dims={"H": 90, "B": 1, "W": 3}, fork={"cfg": False}),))
+
+
+def test_duplicate_class_rows_are_refused() -> None:
+    row = GraphClass(dims={"H": 90, "B": 1}, fork={"cfg": False})
+    with pytest.raises(DeclarationError, match="repeats row"):
+        _decl(classes=(row, row))
+
+
+def test_relates_to_must_name_declared_dims() -> None:
+    with pytest.raises(DeclarationError, match="relates_to undeclared"):
+        _decl(dims=(Dim("H", carried_by=(("hidden_states", 2),)),
+                    Dim("B", carried_by=(("hidden_states", 0),)),
+                    Dim("N", carried_by=(("t", 1),), relates_to=("W_lat",))),
+              classes=(GraphClass(dims={"H": 90, "B": 1, "N": 10},
+                                  fork={"cfg": False}),))
+
+
+def test_shape_strategy_is_a_declared_choice() -> None:
+    with pytest.raises(DeclarationError, match="shape_strategy"):
+        _decl(shape_strategy="adaptive")
+    # "" parses (the LTX draft predates #730's ratification); the mint-plan
+    # derivation refuses it — see test_aot_declaration_pgw739.
+    assert _decl(shape_strategy="").shape_strategy == ""
+
+
+def test_hand_range_on_named_dim_is_refused_when_classes_exist() -> None:
+    """Rows are coordinates: a hand-written range beside class rows is the
+    endpoint hand-math the vocabulary exists to prevent."""
+    with pytest.raises(ValueError, match="delete the hand range"):
+        _decl(dynamic=(DynamicDim("H", min=90, max=160),))
+
+
+def test_dynamic_naming_nothing_declared_is_refused() -> None:
+    with pytest.raises(ValueError, match="neither"):
+        Compile(family="f", shapes=((768, 768),), text_len=77,
+                dynamic=(DynamicDim("latent_h", min=90, max=160),))
+
+
+def test_wan_latent_spatial_axis_is_nameable() -> None:
+    """The red case the old two-literal DynamicDim validation refused
+    (ie#550 hit it from the endpoint side, ie#566 from the mint side)."""
+    c = Compile(
+        family="wan-shaped", shapes=((1280, 720, 81),), text_len=512,
+        dims=(Dim("H_lat", carried_by=(("hidden_states", 3),), multiple_of=2),),
+        dynamic=(DynamicDim("H_lat", min=90, max=160),),
+    )
+    assert c.dynamic[0].dim == "H_lat"
+
+
+def test_fork_and_input_targets_must_exist() -> None:
+    with pytest.raises(DeclarationError, match="vae.decode"):
+        _decl(forks=(Fork("cfg", served=(False,), targets=("vae.decode",)),))
+    with pytest.raises(DeclarationError, match="not in Compile.targets"):
+        _decl(inputs=(Input("hidden_states", shape=("B",), targets=("vae",)),))
+
+
+def test_dim_bindings_must_name_declared_inputs_when_inputs_exist() -> None:
+    with pytest.raises(DeclarationError, match="binds input 'hidden_states'"):
+        _decl(inputs=(Input("other", shape=("B", "H")),))
+
+
+def test_shapes_omittable_only_with_classes() -> None:
+    with pytest.raises(ValueError, match="shapes"):
+        Compile(family="f", targets=("transformer",))
+    assert _decl().shapes == ()  # classes carry the coordinates
+
+
+# ---------------------------------------------------------------------------
+# Input / Arg templates
+# ---------------------------------------------------------------------------
+
+
+def test_input_axis_specs() -> None:
+    i = Input("hidden_states",
+              shape=("B", ("config", "in_channels"), "H", "W"),
+              positional=True)
+    assert i.shape[1] == ("config", "in_channels")
+    with pytest.raises(DeclarationError, match="axis spec"):
+        Input("x", shape=(("cfg", "in_channels"),))
+    with pytest.raises(DeclarationError, match="positive"):
+        Input("x", shape=(0,))
+    with pytest.raises(DeclarationError, match="cannot be positional"):
+        Input("added_cond_kwargs.time_ids", shape=("B", 6), positional=True)
+    assert Arg("return_dict", False).value is False
+
+
+# ---------------------------------------------------------------------------
+# The registry (the #740 load-to-register shape)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_round_trip_and_conflict() -> None:
+    reset_export_declarations()
+    try:
+        decl = _decl(family="regfam")
+        register_export_declaration(decl)
+        register_export_declaration(decl)  # idempotent for an identical one
+        assert export_declaration("regfam") is decl
+        different = _decl(family="regfam", shape_strategy="static-rows")
+        with pytest.raises(DeclarationError, match="DIFFERENT"):
+            register_export_declaration(different)
+        register_export_declaration(different, replace=True)
+        assert export_declaration("regfam") is different
+    finally:
+        reset_export_declarations()
+
+
+def test_registry_refuses_classless_declarations() -> None:
+    with pytest.raises(DeclarationError, match="no graph classes"):
+        register_export_declaration(
+            Compile(family="x", shapes=((768, 768),), text_len=77))
+
+
+# ---------------------------------------------------------------------------
+# The LTX-AOT-DESIGN.md §2.3 draft — the third test case. It must PARSE;
+# the family stays unminted (no shape_strategy declared yet, and the plan
+# derivation refuses that by name — the honest unminted state).
+# ---------------------------------------------------------------------------
+
+# The doc's tables, abbreviated to three size buckets x two duration buckets;
+# the generator mirrors _ltx_graph_classes' structure (including the
+# (10s,24) vs (5s,48) collision on frame count 241 that iterating
+# _LTX_FRAMES.items() — not set(values()) — keeps visible via T_a).
+_LTX_SIZES = {
+    ("1216p", "16:9"): (1216, 704, True),
+    ("704p", "1:1"): (704, 704, False),
+    ("1080p", "9:16"): (608, 1088, False),
+}
+_LTX_FRAMES = {(10, 24): 241, (5, 48): 241, (5, 24): 121}
+_AUDIO_TOKENS_PER_SECOND = 25.0
+
+
+def _ltx_graph_classes() -> tuple[GraphClass, ...]:
+    out: list[GraphClass] = []
+    for (_res, _aspect), (width, height, two_stage) in _LTX_SIZES.items():
+        for (duration_s, fps), frames in _LTX_FRAMES.items():
+            t_a = round(frames / fps * _AUDIO_TOKENS_PER_SECOND)
+            sizes = ((width // 2, height // 2), (width, height)) if two_stage \
+                else ((width, height),)
+            for w, h in sizes:
+                f_lat, h_lat, w_lat = (frames - 1) // 8 + 1, h // 32, w // 32
+                base = f_lat * h_lat * w_lat
+                fork = {"isolate_modalities": False, "cfg": False, "stg": False}
+                for t_kf in (0, h_lat * w_lat):
+                    out.append(GraphClass(
+                        fork=fork,
+                        dims={"T_v": base + t_kf, "T_a": t_a, "T_at": 1,
+                              "T_txt": 1024, "B": 1}))
+                out.append(GraphClass(
+                    fork=fork,
+                    dims={"T_v": base, "T_a": t_a, "T_at": t_a,
+                          "T_txt": 1024, "B": 1}))
+    return tuple(dict.fromkeys(out))
+
+
+def test_ltx_section_2_3_draft_parses() -> None:
+    classes = _ltx_graph_classes()
+    assert len(classes) > len({c.dim_map["T_v"] for c in classes})
+    draft = Compile(
+        family="ltx-2.3",
+        targets=("transformer",),
+        text_len=1024,
+        regional=False,
+        dims=(
+            Dim("T_v", carried_by=(("hidden_states", 1), ("timestep", 1),
+                                   ("video_coords", 2))),
+            Dim("T_a", carried_by=(("audio_hidden_states", 1),
+                                   ("audio_coords", 1))),
+            Dim("T_at", carried_by=(("audio_timestep", 1),)),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),
+                                     ("audio_encoder_hidden_states", 1),
+                                     ("encoder_attention_mask", 1),
+                                     ("audio_encoder_attention_mask", 1))),
+            Dim("B", carried_by=(("hidden_states", 0),)),
+        ),
+        forks=(
+            Fork("isolate_modalities", served=(False,), unserved=(True,),
+                 why="text_to_audio drops both AV cross-attentions: 20,509 vs "
+                     "30,877 nodes. UNSERVED today (ie#383 phase 2)."),
+            Fork("cfg", served=(False,), unserved=(True,),
+                 why="distilled recipe pins guidance 1.0"),
+            Fork("stg", served=(False,), unserved=(True,),
+                 why="the only path arming perturbation_mask"),
+        ),
+        classes=classes,
+        dynamic=(),
+        eager=("video_to_video", "audio_reactive"),
+    )
+    assert draft.eager == ("video_to_video", "audio_reactive")
+    # T_a differs across duration buckets sharing frame count 241 — the axis
+    # the (w, h, frames) row could not carry is now a declared coordinate
+    # (241f @ 24fps -> 251 tokens; 241f @ 48fps -> 126).
+    t_a_values = {c.dim_map["T_a"] for c in classes}
+    assert {251, 126} <= t_a_values
+    # Unminted is a recorded state, not an accident: no strategy declared.
+    from gen_worker import aot_declaration
+    from gen_worker.aot_mint import MintRefused
+
+    with pytest.raises(MintRefused, match="shape_strategy"):
+        aot_declaration.mint_plans(draft, "transformer")

--- a/tests/test_export_contract_pgw739.py
+++ b/tests/test_export_contract_pgw739.py
@@ -243,15 +243,17 @@ def test_shapes_omittable_only_with_classes() -> None:
 
 def test_input_axis_specs() -> None:
     i = Input("hidden_states",
-              shape=("B", ("config", "in_channels"), "H", "W"),
-              positional=True)
+              shape=("B", ("config", "in_channels"), "H", "W"))
     assert i.shape[1] == ("config", "in_channels")
     with pytest.raises(DeclarationError, match="axis spec"):
         Input("x", shape=(("cfg", "in_channels"),))
     with pytest.raises(DeclarationError, match="positive"):
         Input("x", shape=(0,))
-    with pytest.raises(DeclarationError, match="cannot be positional"):
-        Input("added_cond_kwargs.time_ids", shape=("B", 6), positional=True)
+    # No args/kwargs choice exists to declare: all-positional example feeds
+    # are a mint obligation (pod 9, pgw#723 residuals), so the vocabulary
+    # carries no `positional` knob at all.
+    with pytest.raises(TypeError):
+        Input("x", shape=("B",), positional=True)  # type: ignore[call-arg]
     assert Arg("return_dict", False).value is False
 
 

--- a/tests/test_regional_dynamic_refusal_pgw746.py
+++ b/tests/test_regional_dynamic_refusal_pgw746.py
@@ -1,0 +1,110 @@
+"""pgw#746 (OQ-7): ``regional=True`` + ``dynamic=(...)`` is refused by name.
+
+``_with_declared_marks`` is applied only on the whole-graph branch of
+``compile_cache._arm``. The regional branch calls
+``compile_repeated_blocks(dynamic=None)`` and returns before the marks are
+ever reached — so the combination declares dynamism the trace never
+implements, while ``declared_contract_facts`` folds that same declaration into
+the contract digest. The key then asserts a contract the artifact does not
+honor, which is the exact failure class pgw#716 exists to prevent.
+
+The fix is refusal, not marking: regional is retiring (LTX-AOT-DESIGN.md §3.2
+chose whole-transformer export), so teaching a departing lane to mark would be
+building on sand. Refusal is honest until it goes.
+
+Tested both directions — the combination is refused, and each half alone is
+still accepted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import compile_cache as cc
+from gen_worker.api.decorators import Compile, DynamicDim
+
+
+class _ContractCfg:
+    """Duck-typed contract source — bypasses Compile's validation so the test
+    can show what the digest WOULD have claimed."""
+
+    def __init__(self, *, dynamic=(), regional=False):
+        self.shapes = ((768, 768),)
+        self.targets = ("transformer",)
+        self.text_len = 0
+        self.dynamic = dynamic
+        self.regional = regional
+        self.lora_bucket = 0
+        self.guidance_scales = ()
+
+
+_SEQ = DynamicDim(dim="sequence", min=2, max=64)
+
+
+# ---------------------------------------------------------------------------
+# the harm is real: the digest does fold in a declaration the trace ignores
+# ---------------------------------------------------------------------------
+
+def test_the_digest_would_have_claimed_dynamism_the_regional_trace_ignores() -> None:
+    """Why this is refused rather than tolerated. Both configs compile the
+    same way regionally — blocks, no marks — yet they carry DIFFERENT contract
+    digests, so the key distinguishes artifacts that are byte-identical in
+    behavior and claims a dynamism neither of them has."""
+    without = cc.declared_contract_facts(_ContractCfg(regional=True))
+    with_dyn = cc.declared_contract_facts(
+        _ContractCfg(regional=True, dynamic=(_SEQ,)))
+
+    assert without["regional"] is True and with_dyn["regional"] is True
+    assert without["dynamic"] == []
+    assert with_dyn["dynamic"] == [{"dim": "sequence", "min": 2, "max": 64}]
+    assert without != with_dyn, (
+        "the declaration reaches the digest even on the regional branch — "
+        "which is precisely why it must not be declarable there"
+    )
+
+
+# ---------------------------------------------------------------------------
+# direction 1: the combination is refused, by name
+# ---------------------------------------------------------------------------
+
+def test_regional_with_declared_dynamic_is_refused() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        Compile(shapes=((768, 768),), regional=True, dynamic=(_SEQ,))
+
+    message = str(excinfo.value)
+    assert "regional" in message
+    assert "dynamic" in message
+    # names the offending dim, so the author knows what to drop
+    assert "sequence" in message
+
+
+def test_the_refusal_names_every_offending_dim() -> None:
+    dims = (DynamicDim(dim="batch", min=2, max=8), _SEQ)
+    with pytest.raises(ValueError) as excinfo:
+        Compile(shapes=((768, 768),), regional=True, dynamic=dims)
+
+    message = str(excinfo.value)
+    assert "batch" in message and "sequence" in message
+
+
+# ---------------------------------------------------------------------------
+# direction 2: each half alone is untouched
+# ---------------------------------------------------------------------------
+
+def test_regional_without_declared_dynamic_is_accepted() -> None:
+    cfg = Compile(shapes=((768, 768),), regional=True)
+    assert cfg.regional is True
+    assert cfg.dynamic == ()
+
+
+def test_declared_dynamic_without_regional_is_accepted_and_kept() -> None:
+    """The whole-graph branch is the one that DOES mark, so this stays legal
+    and the declaration must survive validation intact."""
+    cfg = Compile(shapes=((768, 768),), regional=False, dynamic=(_SEQ,))
+    assert cfg.regional is False
+    assert cfg.dynamic == (_SEQ,)
+
+
+def test_neither_is_accepted() -> None:
+    cfg = Compile(shapes=((768, 768),))
+    assert cfg.regional is False and cfg.dynamic == ()

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.76.0"
+version = "0.76.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Promotion train from chaos. Nine commits: seven planned, two **recovered**.

## Aboard

| commit | what |
|---|---|
| `a867c33` | **ie#566 G3 CORRECTION** — pin detection is guard evidence, not integer arithmetic. **Stranded from 0.76.0.** |
| `b8d198d` | **pgw#744** `kind="eval"` — a measure-only function kind (th#1255). **Stranded from 0.76.0.** |
| `60f8ca1` `cb1d1a6` `60bf39f` | pgw#723 residuals — load_constants FQN-keying, marshal_positional/positional-only package call convention, the two mint gates, serve-docs folding caveat |
| `1d87428` | **pgw#739** — the export-input contract is a DECLARATION; sdxl's export inputs leave the SDK |
| `d3e2104` | **pgw#740 B5/B6** — the component-vocabulary call-site sweep, 18 files |
| `058a7a1` | **pgw#746 (OQ-7)** — refuse `regional=True` + `dynamic=(...)` by name |
| `3aaf264` | version stamp + CHANGELOG + uv.lock |

## Two commits were stranded, and one of them was load-bearing

`pgw#744` and the `ie#566` G3 correction are complete on chaos and recorded in the
tracker as having shipped in 0.76.0 — but the 0.76.0 release branch was cut without
them, so the published wheel has neither. Consequences:

- the published 0.76.0 has only **four** legal `@endpoint(kind=)` values, not five;
- the published G3 gate refuses a pinned relational axis by integer arithmetic
  (a false pass) rather than by reading the exported program's guards.

The second one is not cosmetic: **pgw#739's own
`test_pinned_relational_axis_is_still_refused` fails against the un-corrected gate.**
That is how the gap surfaced — the first build of this branch was green on chaos and
red here, on exactly that test. Both are carried.

## Version

`0.76.1` is claimed by pgw#738 and is **not published** — that lane's work is still
uncommitted in the shared worktree — so the line goes 0.76.0 -> 0.76.2 and the claim
stays reserved. Stamp per pgw#739's ledger entry ("whoever cuts the next release stamps
0.76.2 with this entry's changelog").

## Gates (all local, on this exact head)

- full suite **1565 passed, 0 failed**, 12 skipped, 1 xfailed
- `mypy src/gen_worker` clean (171 files)
- `ruff check src/gen_worker` clean (CI scope)
- `scripts/lint_http_timeouts.py` clean
- `uv sync --locked` passes; `uv.lock` synced to 0.76.2

Baseline note: the "14 documented pre-existing failures" is **stale**. Six of them were
the order-dependent flux/trt cluster, root-caused and fixed in `6c5c4d2`; that fix
reached master via the 0.76.0 squash but never reached chaos, so chaos kept failing them.
Chaos now has it (`bca3c3c`) and a clean archive of chaos HEAD is **1565 passed, 0
failed** — identical to this branch. The remaining 8 were only ever the #738 lane's
uncommitted `request_context` WIP in the shared worktree, not a property of any commit.

## Not carried, deliberately

Chaos deletes `src/gen_worker/equivalence.py` (`7a5a428`, per Paul's ck5 ruling); master
still has it. That deletion is left for an explicit decision — the file has a history of
being removed by accident through the shared index (`43fc809` restored it once), so a
release train is the wrong place to do it silently.