### PR TITLE
release: gen-worker 0.76.5 — pgw#754 host-ISA portability (the AOT SIGILL fix) + pgw#752 + th#1259 SDK half

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,30 @@ and `torch.export` accepts it. This lands independent of the AOT migration.
   to get its tensors in, the FQNs are structural from construction, and a
   branch-disable cycle keeps the slots declared.
 
+## 0.76.4 (2026-07-27) — pgw#752: clean page cache is RAM the next load can have
+
+ie#535's last wan-2.2 blocker. `text_to_video_turbo` was refused on an H100 pod with
+**251 GB of host RAM** for "~64.3GiB incoming + 8.0GiB safety floor = 72.3GiB required;
+71.5GiB available" — then bounced 5 attempts across 2 identically-sized pods (th#1228).
+
+- **Root cause: the model was charged twice.** `probe_host_ram` credited only the
+  *inactive* file LRU back out of `memory.current`. Pages read or written seconds ago sit
+  on the ACTIVE file LRU, so the pipeline's own freshly-downloaded 64.3 GiB snapshot cache
+  counted as consumed memory in the very decision about whether there was room to load
+  that snapshot. ~180 GiB of a 251 GB cgroup read as unavailable. The turbo tier tipped
+  over first only because its two LoRA halves added ~1.8 GiB of fresh cache that the base
+  tier did not read — base cleared the same bar by luck, and bounced once itself.
+- **Fix**: the working set is `memory.current` minus every reclaimable clean page (both
+  file LRUs), excluding what the kernel genuinely cannot drop on demand — shmem/tmpfs,
+  dirty and writeback pages. Anonymous memory is still fully charged, so an over-admit
+  cannot trade a false refusal for an OOM kill. `HostRam.reclaimable_file_gb` reports it.
+- **A structural shortfall stops re-selling the same pod**: when the requirement exceeds
+  the host's TOTAL RAM, no eviction and no identically-sized pod can ever satisfy it. That
+  verdict is now `HostRamCapacityError` (`reason=host_ram_capacity`, a HardwareUnmetError
+  carrying required-vs-total axes) — the function self-disables on this worker and the
+  orchestrator gets a placement fact instead of another dispatch. Genuine local pressure
+  stays `InsufficientHostRamError`/RETRYABLE.
+
 ## 0.76.3 (2026-07-27) — pgw#747: an auxiliary slot stops claiming the function's family
 
 Discovery stamped **every** slot of a function with that function's architecture family —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,34 @@ and `torch.export` accepts it. This lands independent of the AOT migration.
   to get its tensors in, the FQNs are structural from construction, and a
   branch-disable cycle keeps the slots declared.
 
+## 0.76.5 (2026-07-27) — th#1259: a bad address in the payload fails the REQUEST, not the release
+
+A `score_benchmark` invoke passed the ref-STEM of a two-address image where the content
+digest belonged. `ctx.materialize_blob` raised a bare `RuntimeError: blob fetch 404`, the
+executor mapped that to `JOB_STATUS_FATAL`, and the hub counted a fatal as evidence the
+RELEASE was unhealthy — `503 release_broken / model_load_failure_streak` for every caller
+of release `866eaaefa7b868289aa65855`. One wrong field, no special privilege, shared release
+down until a new one was cut.
+
+**PROVENANCE decides the class** — not the status code, not the message text. A resolve
+boundary now says where the address came from, and only that answers "whose fault":
+
+- `REF_ORIGIN_PAYLOAD` (default) — the caller named it. A terminal miss raises the typed
+  `PayloadRefError` family (`BlobNotFoundError` / `BlobForbiddenError` /
+  `DatasetNotFoundError`, all `ValidationError`), so `_map_exception` returns
+  `JOB_STATUS_INVALID`: the REQUEST fails 4xx with a machine-readable code and the hub
+  books no health signal at all.
+- `REF_ORIGIN_PLATFORM` — the hub produced the address (dataset manifest blobs, via the
+  new `_fetch_platform_blob`). Unchanged: still fatal, still real breaker evidence.
+
+`str(exc)` is `"<code>: <detail>"` so the code survives the `safe_message` hop into the
+request's `error.code`. `resolve_dataset` classifies at the same boundary — the `_datasets`
+helpers see an opaque id and raise the internal `DatasetRefNotFound` marker; the caller,
+which knows the ref came from the payload, converts. Downstream-of-resolution faults
+(empty manifest, silent hub, exhausted download) stay platform faults.
+
+Hub half in tensorhub th#1259 (breaker input allowlist). **Version claim: 0.76.5** is the
+first worker that classifies payload-ref misses; older workers still report these FATAL.
 ## 0.76.4 (2026-07-27) — pgw#752: clean page cache is RAM the next load can have
 
 ie#535's last wan-2.2 blocker. `text_to_video_turbo` was refused on an H100 pod with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.76.5 — pgw#754 host-ISA portability (the AOT SIGILL fix) + pgw#752 + th#1259 SDK half
+
+One patch train, AOT-flip-critical. Ships as 0.76.5: th#1259's stamp was the
+highest aboard; pgw#752's 0.76.4 claim is ABSORBED into this release (its
+section below) — no version hole.
+
+- **pgw#754 (the headline)**: AOT cells no longer SIGILL foreign hosts. Root
+  cause: the mint host compiled its .pt2 wrapper code with -march=native
+  (AVX-512 on the mint host) while torch hashes cpp.march=None identically
+  everywhere — the seal was blind to real machine-code ISA. Host compiles now
+  CLAMP to x86-64-v3 (measured perf-neutral: the wrapper has zero vector
+  instructions), the clamp is SEAL-VISIBLE (SEAL_VERSION 5 -> 6), discovery
+  filters unexecutable cells BEFORE download, and serve refuses by name before
+  dlopen. CONSEQUENCE: seal_v6 retires ALL pre-clamp cells (JIT and AOT,
+  including the prod-recipe AOT cells and canary cells) — remint required, by
+  design (the recipe changed).
+- **pgw#752**: clean page cache is RAM the next load can have (capability
+  probe + residency accounting; see its absorbed section below).
+- **th#1259 SDK half**: a ref the PAYLOAD named fails the REQUEST
+  (typed payload-ref provenance), never the release — the worker-side half of
+  the breaker-poisoning fix (the hub half rides a hub train).
+
 ## 0.76.3 — the reuse wave: adopt-without-mint unblocked + AOT flip seams
 
 The four structural bugs that held cell adoption at zero in the sdxl 0.2.14
@@ -179,7 +201,7 @@ which knows the ref came from the payload, converts. Downstream-of-resolution fa
 
 Hub half in tensorhub th#1259 (breaker input allowlist). **Version claim: 0.76.5** is the
 first worker that classifies payload-ref misses; older workers still report these FATAL.
-## 0.76.4 (2026-07-27) — pgw#752: clean page cache is RAM the next load can have
+## 0.76.4 stamp — ABSORBED INTO 0.76.5 (never separately published) — pgw#752: clean page cache is RAM the next load can have
 
 ie#535's last wan-2.2 blocker. `text_to_video_turbo` was refused on an H100 pod with
 **251 GB of host RAM** for "~64.3GiB incoming + 8.0GiB safety floor = 72.3GiB required;

--- a/proto/worker_scheduler.proto
+++ b/proto/worker_scheduler.proto
@@ -1137,7 +1137,8 @@ enum ActivityState {
 message FnUnavailable {
   string function_name = 1;
   // reason vocabulary: compute_capability_unmet, insufficient_vram,
-  // missing_cuda_library, insufficient_disk, cuda_unavailable, setup_failed.
+  // missing_cuda_library, insufficient_disk, host_ram_capacity,
+  // cuda_unavailable, setup_failed.
   string reason = 2;
   string detail = 3; // human-readable elaboration for the admin availability view
   map<string, string> axes = 4; // e.g. {detected_sm: "8.9", required_sm: "10.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.76.4"
+version = "0.76.5"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.76.3"
+version = "0.76.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -66,6 +66,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
+from . import host_isa
 from .compile_cache import (
     AdoptError,
     CompiledLaneUnavailableError,
@@ -413,6 +414,11 @@ def artifact_metadata(
         "package_constants_in_so": False,
         "source_ref": str(source_ref or ""),
         "source_digest": str(source_digest or ""),
+        # pgw#754: the host-CPU execution requirement of the packaged host
+        # code (wrapper .so + cpu kernels). Consumers refuse by name when
+        # this host cannot execute it — the .so must never be dlopen'd
+        # first and SIGILL second.
+        "host_isa": host_isa.stamp(),
     }
     contract_from_meta(meta)
     constants_from_meta(meta)
@@ -445,6 +451,9 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
         want, have = str(meta.get(field_name) or ""), here[field_name]
         if want != have:
             return f"{field_name} {want!r} != runtime {have!r}"
+    isa_reason = host_isa_reason(meta)
+    if isa_reason:
+        return isa_reason
     want_fam = str(meta.get("family") or "")
     if family and want_fam and want_fam != family:
         return f"family {want_fam!r} != {family!r}"
@@ -456,6 +465,64 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     stamped = str(meta.get("range_digest") or "")
     if stamped and stamped != range_digest(meta):
         return "range_digest does not match the declared contract"
+    return ""
+
+
+def host_isa_reason(meta: Mapping[str, Any]) -> str:
+    """'' when this host's CPU can execute the artifact's packaged host
+    code, else the refusal reason (pgw#754).
+
+    Reads the mint's ``host_isa`` requirement stamp — metadata-only, so
+    discovery (``aot_cells._candidates``) filters unexecutable cells BEFORE
+    downloading them. Artifacts minted before the stamp existed return ''
+    here; :func:`verify_package_host_isa` covers them once bytes are staged.
+    """
+    block = meta.get("host_isa")
+    if not isinstance(block, Mapping):
+        return ""
+    level, machine = host_isa.requirement_of_meta(block)
+    return host_isa.unsupported_reason(level, machine)
+
+
+def verify_package_host_isa(meta: Mapping[str, Any], package: Path) -> str:
+    """The staged-bytes host-ISA gate: stamped requirement when present,
+    else torch's own ``AOTI_CPU_ISA``/``AOTI_MACHINE`` stamps inside the
+    ``.pt2`` (present since torch 2.x package format; the mint host's picked
+    vector ISA, which a ``-march=native`` build tracks). '' = executable.
+
+    This is what turns the live SIGILL class (exit 132 inside
+    ``aoti_load_package`` on a host lacking the mint host's AVX-512) into a
+    named ``adopt_failed:host_isa_unsupported`` refusal for every artifact,
+    including legacy cells minted before the metadata stamp existed.
+    """
+    reason = host_isa_reason(meta)
+    if reason:
+        return reason
+    if isinstance(meta.get("host_isa"), Mapping):
+        return ""  # stamped and satisfied; no legacy sniff needed
+    try:
+        import zipfile
+
+        with zipfile.ZipFile(package) as zf:
+            names = [
+                n for n in zf.namelist() if n.endswith("_metadata.json")]
+            for name in names:
+                try:
+                    row = json.loads(zf.read(name).decode("utf-8"))
+                except (ValueError, UnicodeDecodeError):
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                level = host_isa.vec_isa_level(
+                    str(row.get("AOTI_CPU_ISA") or ""))
+                machine = str(row.get("AOTI_MACHINE") or "")
+                reason = host_isa.unsupported_reason(level, machine)
+                if reason:
+                    return reason + " (torch package stamp, pre-pgw#754 cell)"
+    except (OSError, zipfile.BadZipFile) as exc:
+        # An unreadable package fails later, loudly, in the load path with
+        # its own named error; the ISA gate only rules on what it can read.
+        logger.debug("aot-serve: host-isa package sniff failed: %s", exc)
     return ""
 
 
@@ -575,6 +642,12 @@ def stage_artifact(
     root = Path(temporary.name)
     try:
         meta = unpack(Path(artifact), root)
+        # pgw#754: rule on host-CPU executability FIRST and by name — the
+        # one failure mode that must never reach dlopen. Covers stamped
+        # requirements and (via the .pt2's own torch stamps) legacy cells.
+        isa_reason = verify_package_host_isa(meta, root / PACKAGE_NAME)
+        if isa_reason:
+            raise AdoptError("host_isa_unsupported", isa_reason)
         reason = verify(meta, family=family)
         if reason:
             raise AdoptError("key_mismatch", reason)
@@ -1281,6 +1354,7 @@ __all__ = [
     "proven_since",
     "find_artifact",
     "flavor_label",
+    "host_isa_reason",
     "ingress_refusals",
     "is_aot_artifact",
     "is_aot_ref",
@@ -1300,5 +1374,6 @@ __all__ = [
     "unpack_metadata",
     "unwrap",
     "verify",
+    "verify_package_host_isa",
     "wrap_module",
 ]

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -105,6 +105,60 @@ class OutputTooLargeError(ValidationError):
         super().__init__(f"output file too large (size_bytes={self.size_bytes}, max_bytes={self.max_bytes})")
 
 
+class PayloadRefError(ValidationError):
+    """A ref the REQUEST PAYLOAD named could not be resolved (th#1259).
+
+    PROVENANCE decides the class, not the status code or the message: an
+    address the caller supplied is the caller's to get right, so this is a
+    request error (JOB_STATUS_INVALID, 4xx) and never model-health evidence.
+    The identical 404 on a ref the RELEASE declares stays fatal — that one
+    IS a statement about the release.
+
+    Raise it only at a resolve boundary that KNOWS the ref came from the
+    payload. ``code`` is the machine-readable class the hub surfaces to the
+    caller; ``str(exc)`` is ``"<code>: <detail>"`` so the code survives the
+    ``safe_message`` wire hop into the request's ``error.code``.
+    """
+
+    def __init__(self, detail: str, *, code: str, ref: str = "") -> None:
+        self.code = code
+        self.ref = ref
+        super().__init__(f"{code}: {detail}")
+
+
+class BlobNotFoundError(PayloadRefError):
+    """No CAS blob exists at a caller-supplied content digest."""
+
+    def __init__(self, digest: str) -> None:
+        super().__init__(
+            f"no blob exists at digest {digest} supplied by the request payload — "
+            "the address must be a CONTENT DIGEST, not an object-key stem",
+            code="blob_not_found", ref=digest,
+        )
+
+
+class BlobForbiddenError(PayloadRefError):
+    """A caller-supplied digest is not readable under this request's grant."""
+
+    def __init__(self, digest: str, status: int) -> None:
+        super().__init__(
+            f"digest {digest} supplied by the request payload is not readable "
+            f"by this request ({status})",
+            code="blob_forbidden", ref=digest,
+        )
+
+
+class DatasetNotFoundError(PayloadRefError):
+    """A caller-supplied dataset ref does not resolve to a dataset."""
+
+    def __init__(self, ref: str, detail: str = "") -> None:
+        super().__init__(
+            f"no dataset exists at ref {ref!r} supplied by the request payload"
+            + (f" ({detail})" if detail else ""),
+            code="dataset_not_found", ref=ref,
+        )
+
+
 class ModelSlotIdentityError(WorkerError):
     """Dispatched model slot's repo differs from the function's declared ref
     (gw#583, the ie#518 silence).

--- a/src/gen_worker/capability.py
+++ b/src/gen_worker/capability.py
@@ -60,7 +60,67 @@ class InsufficientDiskError(HardwareUnmetError):
         return out
 
 
-class InsufficientHostRamError(RetryableError):
+class _HostRamFacts:
+    """The measured facts behind one host-RAM admission refusal.
+
+    Shared by the transient and the structural verdict so both speak one
+    vocabulary on the wire; each carries its own error base because the two
+    demand opposite dispatch behaviour.
+    """
+
+    #: Message stem; the terminal form names the structural verdict.
+    _headline = "insufficient host RAM"
+
+    def _describe(
+        self,
+        function_name: str,
+        *,
+        incoming_bytes: int,
+        floor_bytes: int,
+        required_bytes: int,
+        available_before_bytes: int,
+        available_after_bytes: int,
+        evicted_refs: tuple[str, ...],
+        total_bytes: int,
+    ) -> str:
+        self.function_name = str(function_name)
+        self.incoming_bytes = int(incoming_bytes)
+        self.floor_bytes = int(floor_bytes)
+        self.required_bytes = int(required_bytes)
+        self.available_before_bytes = int(available_before_bytes)
+        self.available_after_bytes = int(available_after_bytes)
+        self.evicted_refs = tuple(evicted_refs)
+        self.total_bytes = int(total_bytes)
+
+        gib = float(1024**3)
+        evicted = ",".join(self.evicted_refs) or "none"
+        total = (
+            f"; host total {self.total_bytes / gib:.1f}GiB"
+            if self.total_bytes else ""
+        )
+        return (
+            f"{self._headline} to load {self.function_name}: "
+            f"~{self.incoming_bytes / gib:.1f}GiB incoming + "
+            f"{self.floor_bytes / gib:.1f}GiB safety floor = "
+            f"{self.required_bytes / gib:.1f}GiB required; "
+            f"{self.available_before_bytes / gib:.1f}GiB available before eviction, "
+            f"{self.available_after_bytes / gib:.1f}GiB after; "
+            f"evicted_refs={evicted}{total}"
+        )
+
+    def axes(self) -> dict[str, str]:
+        return {
+            "incoming_bytes": str(self.incoming_bytes),
+            "floor_bytes": str(self.floor_bytes),
+            "required_bytes": str(self.required_bytes),
+            "available_before_bytes": str(self.available_before_bytes),
+            "available_after_bytes": str(self.available_after_bytes),
+            "evicted_refs": ",".join(self.evicted_refs),
+            "total_bytes": str(self.total_bytes),
+        }
+
+
+class InsufficientHostRamError(_HostRamFacts, RetryableError):
     """A worker cannot stage a model without crossing its host-RAM floor.
 
     Unlike a static hardware gate, this is transient: another worker may have
@@ -81,40 +141,67 @@ class InsufficientHostRamError(RetryableError):
         available_before_bytes: int,
         available_after_bytes: int,
         evicted_refs: tuple[str, ...] = (),
+        total_bytes: int = 0,
     ) -> None:
-        self.function_name = str(function_name)
-        self.incoming_bytes = int(incoming_bytes)
-        self.floor_bytes = int(floor_bytes)
-        self.required_bytes = int(required_bytes)
-        self.available_before_bytes = int(available_before_bytes)
-        self.available_after_bytes = int(available_after_bytes)
-        self.evicted_refs = tuple(evicted_refs)
+        super().__init__(self._describe(
+            function_name,
+            incoming_bytes=incoming_bytes,
+            floor_bytes=floor_bytes,
+            required_bytes=required_bytes,
+            available_before_bytes=available_before_bytes,
+            available_after_bytes=available_after_bytes,
+            evicted_refs=tuple(evicted_refs),
+            total_bytes=total_bytes,
+        ))
 
-        gib = float(1024**3)
-        evicted = ",".join(self.evicted_refs) or "none"
-        super().__init__(
-            f"insufficient host RAM to load {self.function_name}: "
-            f"~{self.incoming_bytes / gib:.1f}GiB incoming + "
-            f"{self.floor_bytes / gib:.1f}GiB safety floor = "
-            f"{self.required_bytes / gib:.1f}GiB required; "
-            f"{self.available_before_bytes / gib:.1f}GiB available before eviction, "
-            f"{self.available_after_bytes / gib:.1f}GiB after; "
-            f"evicted_refs={evicted}"
-        )
 
-    def axes(self) -> dict[str, str]:
-        return {
-            "incoming_bytes": str(self.incoming_bytes),
-            "floor_bytes": str(self.floor_bytes),
-            "required_bytes": str(self.required_bytes),
-            "available_before_bytes": str(self.available_before_bytes),
-            "available_after_bytes": str(self.available_after_bytes),
-            "evicted_refs": ",".join(self.evicted_refs),
-        }
+class HostRamCapacityError(_HostRamFacts, HardwareUnmetError):
+    """This pod SIZE can never stage the model — an empty host is too small.
+
+    pgw#752: the retryable form says "another worker may have room", which is
+    true only while the shortfall is pressure. When the requirement exceeds the
+    host's TOTAL RAM, every retry re-buys an identically-sized pod and refuses
+    identically (observed: 5 attempts across 2 pods, th#1228). Reporting a
+    hardware axis instead disables the function on this worker and hands the
+    orchestrator the exact placement fact (required vs total) it needs to pick
+    a bigger host.
+    """
+
+    reason = "host_ram_capacity"
+    _headline = "host RAM capacity too small"
+
+    def __init__(
+        self,
+        function_name: str,
+        *,
+        incoming_bytes: int,
+        floor_bytes: int,
+        required_bytes: int,
+        available_before_bytes: int,
+        available_after_bytes: int,
+        evicted_refs: tuple[str, ...] = (),
+        total_bytes: int = 0,
+    ) -> None:
+        super().__init__(self._describe(
+            function_name,
+            incoming_bytes=incoming_bytes,
+            floor_bytes=floor_bytes,
+            required_bytes=required_bytes,
+            available_before_bytes=available_before_bytes,
+            available_after_bytes=available_after_bytes,
+            evicted_refs=tuple(evicted_refs),
+            total_bytes=total_bytes,
+        ))
+
+
+#: Both host-RAM admission verdicts — one transient, one structural.
+HOST_RAM_REFUSALS = (InsufficientHostRamError, HostRamCapacityError)
 
 
 __all__ = [
+    "HOST_RAM_REFUSALS",
     "HardwareUnmetError",
+    "HostRamCapacityError",
     "InsufficientDiskError",
     "InsufficientHostRamError",
 ]

--- a/src/gen_worker/cli/local_context.py
+++ b/src/gen_worker/cli/local_context.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Dict, Optional
 
 from ..api.types import Asset
 from ..request_context import (
+    REF_ORIGIN_PAYLOAD,
     ConversionContext,
     DatasetContext,
     RequestContext,
@@ -143,9 +144,12 @@ class LocalConversionContext(LocalRequestContextMixin, ConversionContext):
     implementation — useful for round-tripping against a dev tensorhub).
     """
 
-    def materialize_blob(self, digest: str, dest: "str | os.PathLike[str]") -> Path:
+    def materialize_blob(
+        self, digest: str, dest: "str | os.PathLike[str]",
+        *, origin: str = REF_ORIGIN_PAYLOAD,
+    ) -> Path:
         if self._local_allow_publish:
-            return super().materialize_blob(digest, dest)
+            return super().materialize_blob(digest, dest, origin=origin)
         # Local stub: look in the tensorhub CAS for a matching snapshot. If
         # nothing's there we can't materialize — surface a typed error so
         # the tenant adjusts (run without --offline first, or seed the CAS).
@@ -169,8 +173,13 @@ class LocalConversionContext(LocalRequestContextMixin, ConversionContext):
 class LocalDatasetContext(LocalRequestContextMixin, DatasetContext):
     """Dataset-kind local context."""
 
-    def materialize_blob(self, digest: str, dest: "str | os.PathLike[str]") -> Path:
-        # Same fallback as ConversionContext.
+    def materialize_blob(
+        self, digest: str, dest: "str | os.PathLike[str]",
+        *, origin: str = REF_ORIGIN_PAYLOAD,
+    ) -> Path:
+        # Same fallback as ConversionContext (origin is a provenance tag for
+        # the th#1259 breaker classification; the local CAS stub has no
+        # breaker, so it is accepted and unused here).
         d = (digest or "").strip()
         if not d:
             raise ValueError("materialize_blob: empty digest")

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -53,7 +53,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-from . import guard_closure
+from . import guard_closure, host_isa
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +64,10 @@ logger = logging.getLogger(__name__)
 # identity). v5 (pgw#749): the identity manifest is the python env's
 # toolchain libs ON DISK — phase-independent — never the mapped set.
 # Adding/changing sealed facts bumps THIS version only — never the
-# key-axis set.
-SEAL_VERSION = 5
+# key-axis set. v6 (pgw#754): host-ISA codegen clamp facts (cpp_march /
+# cpp_simdlen) — deliberately retires every pre-clamp cell: they were
+# compiled -march=native for their mint host's CPU and are not portable.
+SEAL_VERSION = 6
 SEAL_KEY = "env_seal"
 
 # R2: the operator-settable generation salt. Bumping it disowns every cell
@@ -155,6 +157,10 @@ def effective_config() -> Dict[str, str]:
         "cudnn_benchmark": str(torch.backends.cudnn.benchmark),
         "python_hash_seed": os.environ.get("PYTHONHASHSEED", ""),
         "hash_randomization": str(sys.flags.hash_randomization),
+        # pgw#754: the host codegen target. Named here (beyond the opaque
+        # inductor digest, which also covers cpp.march/cpp.simdlen) so a
+        # cohort split is legible in the seal itself.
+        **host_isa.effective(),
     }
 
 
@@ -446,6 +452,10 @@ def establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     global _BOOT_SEAL
     scrub_env()
     establish_config(overrides)
+    try:
+        host_isa.impose()
+    except host_isa.HostIsaError as exc:
+        raise EnvSealError(str(exc)) from exc
     guard_closure.establish_posture()
     _BOOT_SEAL = effective_seal()
     return dict(_BOOT_SEAL)

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -55,7 +55,9 @@ from .api.streaming import (
 )
 from .api.types import Asset
 from .capability import (
+    HOST_RAM_REFUSALS,
     HardwareUnmetError,
+    HostRamCapacityError,
     InsufficientDiskError,
     InsufficientHostRamError,
 )
@@ -4405,7 +4407,7 @@ class Executor:
             # Host-RAM admission already emitted the precise largest staged
             # ref(s) that caused the capacity failure. Do not overwrite that
             # signal by failing smaller shared refs such as an SDXL VAE.
-            if not isinstance(exc, InsufficientHostRamError):
+            if not isinstance(exc, HOST_RAM_REFUSALS):
                 error = _model_failure_vocab(exc)
                 for ref in instance_refs:
                     await self._send(pb.WorkerMessage(
@@ -6371,7 +6373,8 @@ class Executor:
         }
 
     async def _record_host_ram_failure(
-        self, refs: List[str], error: InsufficientHostRamError,
+        self, refs: List[str],
+        error: typing.Union[InsufficientHostRamError, HostRamCapacityError],
     ) -> None:
         """Publish and retain one typed capacity block per causal ref."""
         causal_refs = sorted(_canonical_host_ram_refs(refs))
@@ -6738,7 +6741,13 @@ class Executor:
                 advised, spec.name,
             )
 
-        error = InsufficientHostRamError(
+        # pgw#752: a shortfall the whole host cannot cover is not pressure —
+        # it is this pod SIZE's verdict, and re-dispatching buys an identical
+        # pod that refuses identically (th#1228). Report it as a hardware axis
+        # so the function self-disables here and the orchestrator learns the
+        # required-vs-total placement fact.
+        cls = HostRamCapacityError if after.structural else InsufficientHostRamError
+        error = cls(
             spec.name,
             incoming_bytes=incoming,
             floor_bytes=after.floor_bytes,
@@ -6746,6 +6755,7 @@ class Executor:
             available_before_bytes=before.available_bytes,
             available_after_bytes=after.available_bytes,
             evicted_refs=tuple(_canonical_host_ram_refs(evicted)),
+            total_bytes=after.total_bytes,
         )
         # th#807: model-failure state is the scheduler's typed capacity seam.
         # Only the largest sequentially staged ref(s) caused this admission

--- a/src/gen_worker/host_isa.py
+++ b/src/gen_worker/host_isa.py
@@ -1,0 +1,245 @@
+"""Host CPU ISA portability for compiled artifacts (pgw#754).
+
+An AOTI ``.pt2`` ships host-side machine code (the wrapper ``.so`` plus any
+CPU kernels). torch compiles that code ``-march=native`` when
+``inductor.config.cpp.march`` is None and vectorizes CPU kernels with
+``cpu_vec_isa.pick_vec_isa()`` — both resolve to the MINT host's CPU. A cell
+minted on an AVX-512 host therefore carries EVEX-encoded instructions that
+SIGILL any serving host without AVX-512 (observed live 2026-07-28: machine
+``hv220gc4f7vu``, exit 132 inside ``aoti_load_package``, five crash loops).
+GPU compatibility is keyed (``sm``); host CPU compatibility was not — and
+``cpp.march=None`` hashes identically into the env seal on every host while
+the emitted code differs per host, so the key could not see the difference.
+
+Fix: at boot (``env_seal.establish``) the effective codegen target is clamped
+to ``min(host level, BASELINE)`` — psABI micro-architecture levels, baseline
+``x86-64-v3`` (AVX2/FMA/BMI2; every GPU host SKU family we rent is >= v3).
+Measured on the live artifact this costs nothing: the ``-march=native``
+wrapper contains ZERO ymm/zmm vector instructions (inductor passes
+``-fno-tree-loop-vectorize``); the only above-baseline code is a handful of
+incidental EVEX scalar encodings with exact SSE2 equivalents. Because
+``cpp.march``/``cpp.simdlen`` are part of ``save_config_portable`` the clamp
+is env_seal- and therefore cell-key-visible: hosts below baseline mint and
+serve their own honestly-keyed cohort instead of sharing a lying key.
+
+Defense in depth: mints stamp :func:`stamp` into artifact metadata, and
+``aot_serve`` refuses an artifact whose requirement this host cannot execute
+(``adopt_failed:host_isa_unsupported``) BEFORE ``aoti_load_package`` — a
+named refusal that composes with the ordinary miss policy, never a SIGILL.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+from functools import lru_cache
+from typing import Dict, FrozenSet, Mapping, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+#: The fleet-wide mint target on x86-64 hosts at or above it (psABI level).
+BASELINE = "x86-64-v3"
+
+#: ``cpp.simdlen`` companion per effective march level: AVX2-wide CPU-kernel
+#: vectorization at >= v3 (within the v3 envelope), 128-bit below (resolves
+#: to scalar on x86 torch builds — nothing above the host's own level).
+_SIMDLEN_V3 = 256
+_SIMDLEN_BELOW_V3 = 128
+
+#: psABI micro-architecture levels as CUMULATIVE /proc/cpuinfo flag sets.
+_LEVELS: Tuple[Tuple[str, FrozenSet[str]], ...] = (
+    ("x86-64", frozenset()),
+    ("x86-64-v2", frozenset(
+        {"cx16", "lahf_lm", "popcnt", "sse4_1", "sse4_2", "ssse3"})),
+    ("x86-64-v3", frozenset(
+        {"abm", "avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "movbe",
+         "xsave"})),
+    ("x86-64-v4", frozenset(
+        {"avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl"})),
+)
+
+_RANK: Dict[str, int] = {name: i for i, (name, _) in enumerate(_LEVELS)}
+
+
+class HostIsaError(RuntimeError):
+    """The ISA clamp could not be imposed or read back."""
+
+
+def machine() -> str:
+    return platform.machine()
+
+
+@lru_cache(maxsize=1)
+def host_flags() -> FrozenSet[str]:
+    """The host CPU feature flags (``/proc/cpuinfo``), lowercased."""
+    try:
+        with open("/proc/cpuinfo", encoding="ascii", errors="replace") as f:
+            for line in f:
+                if line.lower().startswith("flags"):
+                    _, _, rest = line.partition(":")
+                    return frozenset(rest.lower().split())
+    except OSError as exc:
+        logger.warning("host-isa: /proc/cpuinfo unreadable: %s", exc)
+    return frozenset()
+
+
+def _required_flags(level: str) -> FrozenSet[str]:
+    """Cumulative flag set a host must have to EXECUTE code built for
+    ``level``. Unknown level names are conservatively treated as the
+    host-native worst case (require the highest defined level)."""
+    rank = _RANK.get(level)
+    if rank is None:
+        rank = len(_LEVELS) - 1
+    out: set[str] = set()
+    for _, flags in _LEVELS[: rank + 1]:
+        out |= flags
+    return frozenset(out)
+
+
+def host_level() -> str:
+    """The highest psABI level this host fully supports."""
+    flags = host_flags()
+    level = _LEVELS[0][0]
+    for name, _ in _LEVELS[1:]:
+        if _required_flags(name) <= flags:
+            level = name
+        else:
+            break
+    return level
+
+
+def mint_march() -> Optional[str]:
+    """The march value mints must build with: ``min(host, BASELINE)``.
+
+    None on non-x86 machines (no clamp; torch's own default applies and the
+    stamp records the machine so a cross-machine arm still refuses by name).
+    """
+    if machine() != "x86_64":
+        return None
+    host = host_level()
+    if _RANK[host] >= _RANK[BASELINE]:
+        return BASELINE
+    return host
+
+
+def mint_simdlen(march: Optional[str]) -> Optional[int]:
+    if march is None:
+        return None
+    if _RANK.get(march, 0) >= _RANK[BASELINE]:
+        return _SIMDLEN_V3
+    return _SIMDLEN_BELOW_V3
+
+
+def impose() -> Dict[str, str]:
+    """Clamp torch's inductor codegen target to the portable mint target and
+    verify the read-back. Called from ``env_seal.establish`` at boot, before
+    any compile. No-op (empty dict) on non-x86 machines."""
+    march = mint_march()
+    if march is None:
+        return {}
+    simdlen = mint_simdlen(march)
+    import torch._inductor.config as inductor_config
+
+    inductor_config.cpp.march = march
+    inductor_config.cpp.simdlen = simdlen
+    got_march = inductor_config.cpp.march
+    got_simdlen = inductor_config.cpp.simdlen
+    if got_march != march or got_simdlen != simdlen:
+        raise HostIsaError(
+            f"isa clamp did not take effect: imposed march={march!r} "
+            f"simdlen={simdlen!r}, effective march={got_march!r} "
+            f"simdlen={got_simdlen!r}")
+    logger.info(
+        "host-isa: codegen clamped to march=%s simdlen=%s (host level %s)",
+        march, simdlen, host_level())
+    return {"cpp_march": march, "cpp_simdlen": str(simdlen)}
+
+
+def effective() -> Dict[str, str]:
+    """Read-back of the live codegen target (seal fact; never assumed)."""
+    import torch._inductor.config as inductor_config
+
+    return {
+        "cpp_march": str(inductor_config.cpp.march or ""),
+        "cpp_simdlen": str(inductor_config.cpp.simdlen or ""),
+    }
+
+
+def stamp() -> Dict[str, Union[str, int]]:
+    """The host-ISA requirement block a mint records in artifact metadata.
+
+    ``level`` is the EXECUTION requirement: the imposed march when clamped,
+    else this host's own level — an unclamped (native) build may use any
+    instruction the mint host has, so its requirement is the whole host.
+    """
+    import torch._inductor.config as inductor_config
+
+    march = str(inductor_config.cpp.march or "")
+    if march in _RANK:
+        level = march
+    elif machine() == "x86_64":
+        level = host_level()
+    else:
+        level = ""
+    return {
+        "machine": machine(),
+        "march": march,
+        "simdlen": int(inductor_config.cpp.simdlen or 0),
+        "level": level,
+    }
+
+
+def unsupported_reason(level: str, artifact_machine: str) -> str:
+    """'' when THIS host can execute code built for (machine, level), else
+    the refusal reason naming the missing capability."""
+    here = machine()
+    if artifact_machine and artifact_machine != here:
+        return (
+            f"artifact host code is {artifact_machine}, this host is {here}")
+    if not level:
+        return ""
+    if here != "x86_64":
+        # x86 level stamped but we are not x86 (and machine field was
+        # empty/matching): unexecutable by construction.
+        return f"artifact requires x86-64 level {level!r} on {here}"
+    missing = sorted(_required_flags(level) - host_flags())
+    if missing:
+        return (
+            f"artifact requires {level} but this host cpu lacks "
+            f"{','.join(missing)}")
+    return ""
+
+
+def requirement_of_meta(block: Mapping[str, object]) -> Tuple[str, str]:
+    """(level, machine) requirement recorded by a mint's ``host_isa`` block."""
+    return str(block.get("level") or ""), str(block.get("machine") or "")
+
+
+def vec_isa_level(aoti_cpu_isa: str) -> str:
+    """Map torch's own ``AOTI_CPU_ISA`` package stamp (the mint host's picked
+    vector ISA, e.g. ``"AVX512 AVX512_VNNI"``) to the psABI level it implies.
+    Best-effort legacy gate for artifacts minted before the stamp existed —
+    a native-built wrapper's needs track the mint host the pick describes."""
+    text = aoti_cpu_isa.upper()
+    if "AMX" in text or "AVX512" in text:
+        return "x86-64-v4"
+    if "AVX2" in text:
+        return "x86-64-v3"
+    return ""
+
+
+__all__ = [
+    "BASELINE",
+    "HostIsaError",
+    "effective",
+    "host_flags",
+    "host_level",
+    "impose",
+    "machine",
+    "mint_march",
+    "mint_simdlen",
+    "requirement_of_meta",
+    "stamp",
+    "unsupported_reason",
+    "vec_isa_level",
+]

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -85,10 +85,17 @@ class HostRamHeadroom:
     available_bytes: int
     floor_bytes: int
     required_bytes: int
+    total_bytes: int = 0
 
     @property
     def sufficient(self) -> bool:
         return self.available_bytes >= self.required_bytes
+
+    @property
+    def structural(self) -> bool:
+        """The requirement exceeds the whole host — no eviction can help, and
+        no identically-sized pod ever will either (pgw#752)."""
+        return self.total_bytes > 0 and self.required_bytes > self.total_bytes
 
 
 @dataclass(frozen=True)
@@ -330,6 +337,7 @@ class Residency:
             available_bytes=int(get_available_ram_gb() * _GiB),
             floor_bytes=floor,
             required_bytes=max(0, int(needed_bytes)) + floor,
+            total_bytes=int(get_total_ram_gb() * _GiB),
         )
 
     # ---- queries ---------------------------------------------------------------

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -48,8 +48,23 @@ class LoraOverlay(TypedDict):
 LogLevel = Literal["debug", "info", "warning", "error"]
 """Severity for :meth:`RequestContext.log` (pgw#508's operator stream)."""
 
-from ..api.errors import AuthError
+from ..api.errors import (
+    AuthError,
+    BlobForbiddenError,
+    BlobNotFoundError,
+    DatasetNotFoundError,
+)
 from ..api.slot import ResolvedSlot
+
+# th#1259 ref provenance. A resolve boundary must say WHERE the address came
+# from; that — not the HTTP status, not the message text — is what decides
+# whether a terminal miss is the CALLER's error (typed 4xx request failure,
+# no health signal) or the RELEASE's (fatal, model-health evidence).
+REF_ORIGIN_PAYLOAD = "payload"
+"""The address came from this request's payload. The caller owns it."""
+REF_ORIGIN_PLATFORM = "platform"
+"""The address was produced by the platform (hub manifest, release
+declaration). A miss is the platform's fault and stays fatal."""
 from ..families.base import GenerationDefaults
 from ..deferred_outputs import (
     DeferredImageAsset,
@@ -1491,7 +1506,9 @@ class _PublisherMixin:
             epoch_number=epoch_number,
         )
 
-    def _download_blob_by_digest(self, digest: str, dest: Path) -> None:
+    def _download_blob_by_digest(
+        self, digest: str, dest: Path, *, origin: str = REF_ORIGIN_PAYLOAD,
+    ) -> None:
         """Fetch a blob by ``<algo>:<hex>`` digest to ``dest``.
 
         Uses the repo-CAS by-digest read endpoint — works for any blob
@@ -1499,6 +1516,10 @@ class _PublisherMixin:
         checkpoint file or a dataset file. The server indexes all CAS
         content by blake3 digest; callers that know the digest can fetch
         without needing to know which subsystem the blob belongs to.
+
+        ``origin`` is the th#1259 provenance of the ADDRESS, and it is the
+        only thing that decides how a terminal miss classifies. See
+        :data:`REF_ORIGIN_PAYLOAD`.
         """
         import requests
         base = (self._file_api_base_url or "").strip().rstrip("/")
@@ -1507,10 +1528,15 @@ class _PublisherMixin:
         digest_norm = digest if ":" in digest else f"blake3:{digest}"
         url = f"{base}/api/v1/blobs/{urllib.parse.quote(digest_norm, safe=':')}/content"
         headers = {"Authorization": f"Bearer {token}"}
+        caller_supplied = origin == REF_ORIGIN_PAYLOAD
         with requests.get(url, headers=headers, stream=True, timeout=300) as resp:
             if resp.status_code in (401, 403):
+                if caller_supplied:
+                    raise BlobForbiddenError(digest, resp.status_code)
                 raise AuthError(f"blob fetch unauthorized ({resp.status_code}) digest={digest}")
             if resp.status_code == 404:
+                if caller_supplied:
+                    raise BlobNotFoundError(digest)
                 raise RuntimeError(f"blob fetch 404 for digest={digest}")
             if resp.status_code < 200 or resp.status_code >= 300:
                 raise RuntimeError(f"blob fetch failed ({resp.status_code}) digest={digest}: {resp.text[:256]}")
@@ -1519,18 +1545,31 @@ class _PublisherMixin:
                     if chunk:
                         f.write(chunk)
 
+    def _fetch_platform_blob(self, digest: str, dest: Path) -> None:
+        """`_download_blob_by_digest` bound to PLATFORM provenance — for
+        addresses the hub itself produced (dataset manifests). A miss there
+        is a platform fault, not the caller's."""
+        self._download_blob_by_digest(digest, dest, origin=REF_ORIGIN_PLATFORM)
 
-    def materialize_blob(self, digest: str, dest: "str | os.PathLike[str]") -> Path:
+    def materialize_blob(
+        self, digest: str, dest: "str | os.PathLike[str]",
+        *, origin: str = REF_ORIGIN_PAYLOAD,
+    ) -> Path:
         """Fetch a blob by ``<algo>:<hex>`` content-addressed digest.
 
         Returns the ``Path`` the blob was written to. Replacement for the
         private ``_download_blob_by_digest`` — exposed publicly so tenants
         that handle a digest directly (e.g. consuming a snapshot manifest
         emitted by an earlier conversion) can pull the bytes themselves.
+
+        ``origin`` defaults to :data:`REF_ORIGIN_PAYLOAD` because that is
+        the untrusted case and the safe default (th#1259): a bad address
+        fails the REQUEST typed rather than indicting the release. Pass
+        :data:`REF_ORIGIN_PLATFORM` for a digest the platform produced.
         """
         dest_path = Path(os.fspath(dest))
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        self._download_blob_by_digest(digest, dest_path)
+        self._download_blob_by_digest(digest, dest_path, origin=origin)
         return dest_path
 
     def checkpoint_dir(self, *, key: str) -> Path:
@@ -1594,10 +1633,14 @@ class _PublisherMixin:
            bounded retries. Entries lacking a presigned URL fall back to the
            repo-CAS by-digest reader.
 
-        Raises ``RuntimeError`` when the dataset isn't found, the manifest is
-        empty, the hub goes silent, or any download exhausts its retries.
+        The REF is caller-supplied, so a ref that resolves to nothing raises
+        ``DatasetNotFoundError`` — a typed request error (th#1259), never
+        release-health evidence. Everything downstream of a resolved ref (an
+        empty manifest, a silent hub, an exhausted download) is the
+        platform's and still raises ``RuntimeError``.
         """
         from ._datasets import (
+            DatasetRefNotFound,
             download_entries,
             fetch_materialize_manifest,
             lookup_dataset_id,
@@ -1611,28 +1654,37 @@ class _PublisherMixin:
             raise RuntimeError(f"resolve_dataset({ref!r}): no file_api_base_url")
         token = self._get_worker_capability_token()
 
-        if "/" in ref:
-            owner, name = _parse_owner_repo(ref)
-            dataset_id = lookup_dataset_id(base, token, owner, name)
-            cache_key = (owner, name)
-        else:
-            dataset_id = ref.strip()
-            if not dataset_id:
-                raise RuntimeError("resolve_dataset: empty ref")
-            cache_key = ("by-id", dataset_id)
         fetch_kwargs: Dict[str, Any] = {"cancelled": lambda: self.cancelled}
         if hub_silence_window_s is not None:
             fetch_kwargs["hub_silence_window_s"] = hub_silence_window_s
-        snapshot_id, entries = fetch_materialize_manifest(
-            base, token, dataset_id, **fetch_kwargs,
-        )
+        # th#1259: `ref` came from the caller, so THIS is the boundary that
+        # knows the provenance — the lookup helpers only see an opaque id.
+        # A ref that resolves to nothing is a payload verdict; everything
+        # after resolution keeps its platform-fault classification.
+        try:
+            if "/" in ref:
+                owner, name = _parse_owner_repo(ref)
+                dataset_id = lookup_dataset_id(base, token, owner, name)
+                cache_key = (owner, name)
+            else:
+                dataset_id = ref.strip()
+                if not dataset_id:
+                    raise DatasetRefNotFound("empty ref")
+                cache_key = ("by-id", dataset_id)
+            snapshot_id, entries = fetch_materialize_manifest(
+                base, token, dataset_id, **fetch_kwargs,
+            )
+        except DatasetRefNotFound as exc:
+            raise DatasetNotFoundError(ref, str(exc)) from exc
 
         cache_root = Path(tempfile.gettempdir()) / "gen_worker_datasets"
         target_root = cache_root.joinpath(*cache_key) / (snapshot_id or dataset_id)
         target_root.mkdir(parents=True, exist_ok=True)
         download_entries(
             entries, target_root,
-            fetch_blob=self._download_blob_by_digest,
+            # th#1259: these digests come from the HUB's own manifest, not
+            # from the payload — a miss is a platform fault, not the caller's.
+            fetch_blob=self._fetch_platform_blob,
             cancelled=lambda: self.cancelled,
         )
         self.dataset_paths[ref] = str(target_root)

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -22,6 +22,16 @@ import blake3
 
 logger = logging.getLogger(__name__)
 
+
+class DatasetRefNotFound(RuntimeError):
+    """No dataset exists at the requested address (th#1259).
+
+    Internal marker only: these helpers see an opaque id and cannot know
+    whether the caller or the platform chose it. ``resolve_dataset`` — the
+    boundary that DOES know — converts this into the typed request error.
+    """
+
+
 _DOWNLOAD_RETRIES = 3
 _DOWNLOAD_BACKOFF_S = 1.0
 _CHUNK_BYTES = 1024 * 1024
@@ -59,6 +69,8 @@ def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
     resp = requests.get(url, headers=headers, timeout=30)
     if resp.status_code in (401, 403):
         raise AuthError(f"dataset lookup unauthorized ({resp.status_code})")
+    if resp.status_code == 404:
+        raise DatasetRefNotFound(f"no such tenant dataset list: tenant={tenant}")
     if resp.status_code < 200 or resp.status_code >= 300:
         raise RuntimeError(f"dataset lookup failed ({resp.status_code}): {resp.text[:256]}")
     items = resp.json().get("items") or []
@@ -67,7 +79,7 @@ def lookup_dataset_id(base: str, token: str, tenant: str, name: str) -> str:
             dataset_id = str(it.get("dataset_id") or "")
             if dataset_id:
                 return dataset_id
-    raise RuntimeError(f"dataset not found for tenant={tenant} name={name}")
+    raise DatasetRefNotFound(f"dataset not found for tenant={tenant} name={name}")
 
 
 def _check_cancelled(cancelled: Optional[Callable[[], bool]]) -> None:
@@ -217,6 +229,10 @@ def fetch_materialize_manifest(
                 _wait_or_hub_silent(backoff, f"http {resp.status_code}")
                 backoff = min(backoff * 2.0, _POLL_BACKOFF_CAP_S)
                 continue
+            if resp.status_code == 404:
+                raise DatasetRefNotFound(
+                    f"dataset_id={dataset_id} does not exist"
+                )
             raise RuntimeError(
                 f"dataset materialize failed ({resp.status_code}): {resp.text[:256]}"
             )

--- a/tests/test_host_isa_pgw754.py
+++ b/tests/test_host_isa_pgw754.py
@@ -1,0 +1,240 @@
+"""pgw#754: host-CPU ISA portability of AOTI cells.
+
+Live incident (2026-07-28, machine hv220gc4f7vu): a worker arming a
+DISCOVERED aot-inductor cell died SIGILL (exit 132) inside
+``aoti_load_package`` — the cell's host wrapper ``.so`` was compiled
+``-march=native`` on an AVX-512 mint host (the shipped kernel.cpp embeds the
+compile command: ``-march=native ... -mavx512f -mavx512vnni``) and carries
+EVEX-encoded AVX-512F scalar instructions the serving host cannot decode.
+
+Red-verified here through the REAL paths:
+
+* the boot clamp (``env_seal.establish`` -> ``host_isa.impose``) pins
+  ``cpp.march``/``cpp.simdlen`` to the portable target, seal-visibly;
+* ``aot_mint.compile_package`` under the clamp emits NO instruction above
+  the target (objdump assertion on the produced ``.so``) and the package
+  still loads via ``aoti_load_package`` — portable by construction;
+* an artifact whose requirement this host genuinely lacks (this box has no
+  AVX-512) is refused BY NAME (``adopt_failed:host_isa_unsupported``)
+  before any dlopen — including legacy cells via the ``.pt2``'s own
+  ``AOTI_CPU_ISA`` stamp — and never SIGILLs the worker.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import aot_mint, aot_serve, env_seal, host_isa
+
+pytestmark = pytest.mark.skipif(
+    host_isa.machine() != "x86_64", reason="x86-64 ISA-level semantics")
+
+
+# ---------------------------------------------------------------------------
+# Detection + clamp
+# ---------------------------------------------------------------------------
+
+
+def test_host_level_is_a_defined_level() -> None:
+    level = host_isa.host_level()
+    assert level in {name for name, _ in host_isa._LEVELS}
+    # Any box this suite runs on is at least v2 (2009+ silicon).
+    assert host_isa._RANK[level] >= host_isa._RANK["x86-64-v2"]
+
+
+def test_mint_target_never_exceeds_baseline_or_host() -> None:
+    march = host_isa.mint_march()
+    assert march is not None
+    assert host_isa._RANK[march] <= host_isa._RANK[host_isa.BASELINE]
+    assert host_isa._RANK[march] <= host_isa._RANK[host_isa.host_level()]
+    # The mint host must be able to execute its own artifact.
+    assert host_isa.unsupported_reason(march, "x86_64") == ""
+
+
+def test_impose_is_seal_visible(monkeypatch: pytest.MonkeyPatch) -> None:
+    import torch._inductor.config as inductor_config
+
+    monkeypatch.setattr(inductor_config.cpp, "march", None)
+    monkeypatch.setattr(inductor_config.cpp, "simdlen", None)
+    facts = host_isa.impose()
+    march = host_isa.mint_march()
+    assert facts["cpp_march"] == march == inductor_config.cpp.march
+    assert int(facts["cpp_simdlen"]) == inductor_config.cpp.simdlen
+    # The clamp reaches the sealed inductor-config digest surface...
+    portable = inductor_config.save_config_portable()
+    assert portable["cpp.march"] == march
+    # ...and the named seal facts.
+    assert env_seal.effective_config()["cpp_march"] == march
+
+
+def test_establish_wires_the_clamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    import torch._inductor.config as inductor_config
+
+    monkeypatch.setattr(inductor_config.cpp, "march", None)
+    monkeypatch.setattr(inductor_config.cpp, "simdlen", None)
+    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None)
+    seal = env_seal.establish()
+    assert seal["config"]["cpp_march"] == host_isa.mint_march()
+
+
+# ---------------------------------------------------------------------------
+# Red-verify 1: the clamped mint path emits nothing above the target
+# ---------------------------------------------------------------------------
+
+
+class _Glue(torch.nn.Module):
+    """Parameter-free module: the packaged host code is pure glue, like the
+    real wrapper (all fleet compute lives in device kernels)."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * 2.0 + 1.0
+
+
+#: Instructions/operands that require anything above x86-64-v2: AVX+ vector
+#: registers, opmasks, and the EVEX scalar forms observed in the live
+#: artifact (vcvtusi2sd / vcvttsd2usi / vrndscalesd are AVX-512F-only even
+#: on xmm operands — the exact SIGILL class).
+_ABOVE_V2 = re.compile(
+    r"%[yz]mm|%k[0-7]\b|vcvtusi2|vcvttsd2usi|vcvttss2usi|vrndscale|"
+    r"vpternlog|vgather|vscatter")
+
+
+@pytest.mark.skipif(
+    shutil.which("objdump") is None, reason="objdump required")
+def test_clamped_compile_package_is_portable_and_loads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch._inductor.config as inductor_config
+
+    # Clamp BELOW this host's level (any host running this suite is >= v2):
+    # every instruction the compile emits above the clamp would be exactly
+    # the live SIGILL class, just one level down.
+    monkeypatch.setattr(inductor_config.cpp, "march", "x86-64-v2")
+    monkeypatch.setattr(inductor_config.cpp, "simdlen", 128)
+
+    program = torch.export.export(_Glue(), (torch.randn(4, 8),))
+    package = aot_mint.compile_package(program, tmp_path / "model.pt2")
+
+    with zipfile.ZipFile(package) as zf:
+        so_names = [n for n in zf.namelist() if n.endswith(".so")]
+        assert so_names, "package ships no host .so"
+        for name in so_names:
+            zf.extract(name, tmp_path / "x")
+
+    for name in so_names:
+        dis = subprocess.run(
+            ["objdump", "-d", str(tmp_path / "x" / name)],
+            check=True, capture_output=True, text=True).stdout
+        hits = sorted({
+            m.group(0) for m in _ABOVE_V2.finditer(dis)})
+        assert not hits, (
+            f"{name} contains above-baseline instructions {hits} — "
+            "unloadable on a host without the mint host's CPU features")
+
+    # The live crash site: loading must succeed for a portable package.
+    loaded = torch._inductor.aoti_load_package(str(package))
+    assert loaded is not None
+
+
+# ---------------------------------------------------------------------------
+# Red-verify 2: refusal by name, never a SIGILL
+# ---------------------------------------------------------------------------
+
+
+def _artifact(tmp_path: Path, pt2_bytes: bytes) -> tuple[Path, dict]:
+    meta = aot_serve.artifact_metadata(
+        family="sdxl", module="unet", precision="bf16", cell_key="",
+        inputs=[{
+            "name": "x", "position": 0, "dtype": "float32",
+            "shape": [1, 4], "optional": False,
+        }],
+        symbols={}, constants=[],
+    )
+    content = tmp_path / "content"
+    content.mkdir(exist_ok=True)
+    (content / aot_serve.PACKAGE_NAME).write_bytes(pt2_bytes)
+    return content, meta
+
+
+def _requires_avx512() -> None:
+    if "avx512f" in host_isa.host_flags():
+        pytest.skip("host has AVX-512; the genuine-lack refusal needs a "
+                    "host without it")
+
+
+def test_stamped_requirement_refused_by_name(tmp_path: Path) -> None:
+    _requires_avx512()
+    content, meta = _artifact(tmp_path, b"not-a-real-pt2")
+    meta["host_isa"] = {
+        "machine": "x86_64", "march": "", "simdlen": 0,
+        "level": "x86-64-v4",
+    }
+    artifact = aot_serve.pack(content, tmp_path / "cell.tar.gz", meta)
+    with pytest.raises(aot_serve.AdoptError) as exc_info:
+        aot_serve.stage_artifact(artifact, "sdxl")
+    assert exc_info.value.reason == "host_isa_unsupported"
+    assert "avx512f" in str(exc_info.value)
+
+
+def test_discovery_filter_drops_stamped_requirement(tmp_path: Path) -> None:
+    """The metadata-only check reaches ``aot_serve.verify`` — discovery
+    (aot_cells._candidates) skips unexecutable cells BEFORE downloading."""
+    _requires_avx512()
+    _, meta = _artifact(tmp_path, b"")
+    meta["host_isa"] = {
+        "machine": "x86_64", "march": "", "simdlen": 0,
+        "level": "x86-64-v4",
+    }
+    reason = aot_serve.verify(meta)
+    assert "avx512f" in reason
+
+
+def test_legacy_cell_refused_via_torch_package_stamp(tmp_path: Path) -> None:
+    """A pre-pgw#754 cell has no metadata stamp; the .pt2's own
+    ``AOTI_CPU_ISA`` (present in the live SIGILL artifact:
+    'AVX512 AVX512_VNNI') must still turn the crash into a named refusal."""
+    _requires_avx512()
+    pt2 = tmp_path / "legacy.pt2"
+    with zipfile.ZipFile(pt2, "w") as zf:
+        zf.writestr(
+            "model/data/aotinductor/model/abc.wrapper_metadata.json",
+            json.dumps({
+                "AOTI_CPU_ISA": "AVX512 AVX512_VNNI",
+                "AOTI_MACHINE": "x86_64",
+            }))
+    content, meta = _artifact(tmp_path, pt2.read_bytes())
+    meta.pop("host_isa")
+    artifact = aot_serve.pack(content, tmp_path / "legacy.tar.gz", meta)
+    with pytest.raises(aot_serve.AdoptError) as exc_info:
+        aot_serve.stage_artifact(artifact, "sdxl")
+    assert exc_info.value.reason == "host_isa_unsupported"
+    assert "avx512f" in str(exc_info.value)
+    assert "pre-pgw#754" in str(exc_info.value)
+    # Discovery-side verify must NOT over-refuse a legacy cell from
+    # metadata alone (the requirement is only knowable from the bytes).
+    assert aot_serve.host_isa_reason(meta) == ""
+
+
+def test_satisfiable_stamp_stages(tmp_path: Path) -> None:
+    content, meta = _artifact(tmp_path, b"pt2-bytes-never-read")
+    # artifact_metadata stamped this host's own mint target — executable
+    # here by construction.
+    staged = aot_serve.stage_artifact(
+        aot_serve.pack(content, tmp_path / "ok.tar.gz", meta), "sdxl")
+    try:
+        assert staged.metadata["host_isa"]["machine"] == "x86_64"
+    finally:
+        staged.close()
+
+
+def test_cross_machine_artifact_refused() -> None:
+    assert "aarch64" in host_isa.unsupported_reason("", "aarch64")

--- a/tests/test_host_ram_probe_pgw752.py
+++ b/tests/test_host_ram_probe_pgw752.py
@@ -1,0 +1,98 @@
+"""pgw#752: clean page cache is host RAM the next load can have.
+
+The wan-2.2 turbo blocker: a 251GB H100 pod refused a 64.3GiB pipeline for
+"71.5GiB available" while ~180GiB of the cgroup was the freshly-downloaded
+snapshot's own clean page cache. Charging that cache against the room needed
+to load the same snapshot counts the model twice.
+
+Real cgroup files on disk, the real probe — no mocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gen_worker.models.memory import probe_host_ram
+
+_GIB = 1024 ** 3
+
+
+def _cgroup(tmp_path: Path, *, limit: int, current: int, **stat: int) -> tuple[Path, Path]:
+    root = tmp_path / "cgroup"
+    root.mkdir()
+    (root / "memory.max").write_text(str(limit))
+    (root / "memory.current").write_text(str(current))
+    (root / "memory.stat").write_text(
+        "".join(f"{k} {v}\n" for k, v in stat.items()))
+    proc = tmp_path / "self_cgroup"
+    proc.write_text("0::/\n")
+    return root, proc
+
+
+def test_active_snapshot_cache_is_available_to_the_next_load(tmp_path) -> None:
+    """The wan-2.2 pod's shape: 251GiB cap, ~10GiB anonymous, the rest clean
+    snapshot cache on the ACTIVE file LRU because it was just written."""
+    root, proc = _cgroup(
+        tmp_path,
+        limit=251 * _GIB,
+        current=190 * _GIB,
+        anon=10 * _GIB,
+        file=180 * _GIB,
+        active_file=178 * _GIB,
+        inactive_file=2 * _GIB,
+        shmem=0,
+        file_dirty=0,
+        file_writeback=0,
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+
+    # 190 used - 180 reclaimable = 10GiB truly held; a 64.3GiB pipeline plus
+    # an 8GiB floor has to fit, and it does with room to spare.
+    assert ram.reclaimable_file_gb == 180.0
+    assert ram.cgroup_limit_gb == 251.0
+    cgroup_available = ram.cgroup_limit_gb - 10.0
+    assert cgroup_available >= 64.3 + 8.0
+    # available_gb mins in /proc/meminfo, which is the real host on this box;
+    # the cgroup term is the one under test.
+    assert ram.available_gb <= cgroup_available
+
+
+def test_unreclaimable_pages_stay_charged(tmp_path) -> None:
+    """Anonymous memory, tmpfs and not-yet-written-back pages are NOT room —
+    crediting them would trade a false refusal for an OOM kill."""
+    root, proc = _cgroup(
+        tmp_path,
+        limit=100 * _GIB,
+        current=90 * _GIB,
+        anon=40 * _GIB,
+        file=50 * _GIB,
+        active_file=30 * _GIB,
+        inactive_file=20 * _GIB,
+        shmem=10 * _GIB,
+        file_dirty=5 * _GIB,
+        file_writeback=1 * _GIB,
+    )
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+
+    # 50GiB on the file LRUs, of which 16GiB cannot be dropped on demand.
+    assert ram.reclaimable_file_gb == 34.0
+    assert ram.cgroup_limit_gb == 100.0
+    assert ram.cgroup_limit_gb - (90.0 - ram.reclaimable_file_gb) == 44.0
+
+
+def test_cgroup_v1_totals_are_read(tmp_path) -> None:
+    """v1 hosts report the same facts under total_* keys."""
+    root = tmp_path / "cgroup"
+    (root / "memory").mkdir(parents=True)
+    (root / "memory" / "memory.limit_in_bytes").write_text(str(64 * _GIB))
+    (root / "memory" / "memory.usage_in_bytes").write_text(str(40 * _GIB))
+    (root / "memory" / "memory.stat").write_text(
+        f"total_active_file {20 * _GIB}\n"
+        f"total_inactive_file {5 * _GIB}\n"
+        f"total_shmem {1 * _GIB}\n"
+    )
+    proc = tmp_path / "self_cgroup"
+    proc.write_text("")
+
+    ram = probe_host_ram(root=root, proc_self_cgroup=proc)
+    assert ram.reclaimable_file_gb == 24.0

--- a/tests/test_p2_residency_reconcile.py
+++ b/tests/test_p2_residency_reconcile.py
@@ -353,6 +353,65 @@ def test_host_ram_failure_precedes_retryable_result_on_wire(tmp_path, monkeypatc
         blobs.shutdown()
 
 
+def test_structural_host_ram_shortfall_stops_reselling_the_same_pod(
+    tmp_path, monkeypatch,
+) -> None:
+    """pgw#752: a requirement larger than the WHOLE host is this pod SIZE's
+    verdict, not local pressure — an empty host of this size still refuses.
+
+    The wan-2.2 turbo failure bounced 5 attempts across 2 identically-sized
+    pods (th#1228) because every refusal claimed to be transient. A structural
+    shortfall crosses the wire as a hardware axis carrying required-vs-total,
+    and the worker stops advertising the function instead of inviting the
+    same dispatch again.
+    """
+    from gen_worker.models import disk_gc
+    from gen_worker.models import residency as residency_mod
+
+    monkeypatch.setattr(residency_mod, "get_total_ram_gb", lambda: 31.0)
+    monkeypatch.setattr(residency_mod, "get_available_ram_gb", lambda: 8.0)
+
+    blobs = BlobHost(tmp_path)
+    try:
+        pipeline_payload = b"host-is-too-small"
+        pipeline_snap = blobs.one_file_snapshot(
+            "ram-pipeline", "pipeline", pipeline_payload)
+        vae_snap = blobs.one_file_snapshot("ram-vae", "vae", b"small-shared-vae")
+
+        def _tree_bytes(path) -> int:
+            data = (path / "model.safetensors").read_bytes()
+            # 40GiB of weights on a 31GiB host: no eviction can ever cover it.
+            return (40 if data == pipeline_payload else 1) * 1024**3
+
+        monkeypatch.setattr(disk_gc, "tree_bytes", _tree_bytes)
+
+        def is_host_ram_capacity(m) -> bool:
+            return (
+                m.WhichOneof("msg") == "fn_unavailable"
+                and m.fn_unavailable.function_name == "ram-pressure"
+            )
+
+        with hub_double() as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(run_job=pb.RunJob(
+                request_id="r-host-ram-structural", attempt=1,
+                function_name="ram-pressure",
+                input_payload=msgspec.msgpack.encode(EchoIn(text="x")),
+                snapshots={_RAM_PIPELINE_REF: pipeline_snap, _RAM_VAE_REF: vae_snap},
+            ))
+            sig = conn.wait_for(is_host_ram_capacity).fn_unavailable
+            assert sig.reason == "host_ram_capacity"
+            assert int(sig.axes["required_bytes"]) > int(sig.axes["total_bytes"]) > 0
+            conn.wait_for(
+                lambda m: m.WhichOneof("msg") == "state_delta"
+                and "ram-pressure" not in m.state_delta.available_functions
+            )
+            conn.wait_for(is_result_for("r-host-ram-structural"))
+    finally:
+        blobs.shutdown()
+
+
 def test_corrupt_load_failure_refetches_and_retries_once(tmp_path, monkeypatch) -> None:
     """Absorbed from test_snapshot_corruption.py (gw#408, J17 flood: a pod-
     churn-interrupted write left truncated safetensors trusted forever). A

--- a/tests/test_payload_ref_provenance_th1259.py
+++ b/tests/test_payload_ref_provenance_th1259.py
@@ -1,0 +1,171 @@
+"""th#1259: a bad address in the REQUEST PAYLOAD must fail the request, not
+the release.
+
+The filed chain: `score_benchmark` passed the ref-stem of a two-address image
+instead of its content digest, `ctx.materialize_blob` raised a bare
+`RuntimeError: blob fetch 404`, the executor mapped that to JOB_STATUS_FATAL,
+and the hub counted a fatal as model-health evidence — 503 release_broken /
+model_load_failure_streak for every caller of the release.
+
+These run the REAL fetch path (a real HTTP server, the real
+`_download_blob_by_digest`, the real `_map_exception`), because the defect
+lived in exactly the seam between them.
+"""
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.api.errors import (
+    AuthError,
+    BlobForbiddenError,
+    BlobNotFoundError,
+    DatasetNotFoundError,
+    PayloadRefError,
+    ValidationError,
+)
+from gen_worker.executor import _map_exception
+from gen_worker.request_context import (
+    REF_ORIGIN_PAYLOAD,
+    REF_ORIGIN_PLATFORM,
+    ConversionContext,
+)
+
+GOOD_DIGEST = "blake3:" + "aa" * 32
+MISSING_DIGEST = "sha256:6f3306ab3b849905dd21c6e3073a2f88a4ae34ac4ee5f3af4bda597f559e9d17"
+FORBIDDEN_DIGEST = "blake3:" + "bb" * 32
+BLOB_BYTES = b"real blob bytes"
+
+
+class _Hub(BaseHTTPRequestHandler):
+    """The blob-read and dataset surfaces, answering exactly like the hub."""
+
+    def log_message(self, *_a: object) -> None:  # keep pytest output clean
+        pass
+
+    def _send(self, code: int, body: bytes = b"") -> None:
+        self.send_response(code)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path
+        if "/blobs/" in path:
+            if MISSING_DIGEST.replace(":", "%3A") in path or MISSING_DIGEST in path:
+                return self._send(404, b"no such blob")
+            if FORBIDDEN_DIGEST.replace(":", "%3A") in path or FORBIDDEN_DIGEST in path:
+                return self._send(403, b"forbidden")
+            return self._send(200, BLOB_BYTES)
+        if "/materialize" in path:
+            return self._send(404, b"no such dataset")
+        if "/datasets" in path:
+            return self._send(200, b'{"items": []}')
+        return self._send(404, b"")
+
+
+@pytest.fixture()
+def hub() -> Iterator[str]:
+    srv = HTTPServer(("127.0.0.1", 0), _Hub)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_port}"
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _ctx(hub_url: str) -> ConversionContext:
+    ctx = ConversionContext(request_id="r-th1259")
+    ctx._file_api_base_url = hub_url
+    ctx._worker_capability_token = "test-token"
+    return ctx
+
+
+def test_payload_digest_404_is_a_typed_request_error(hub: str, tmp_path: Path) -> None:
+    """The filed repro. A well-formed but non-existent CALLER-SUPPLIED digest
+    fails the request with a typed 4xx class — and the executor maps it to
+    JOB_STATUS_INVALID, which is what keeps it out of every health signal."""
+    ctx = _ctx(hub)
+
+    with pytest.raises(BlobNotFoundError) as ei:
+        ctx.materialize_blob(MISSING_DIGEST, tmp_path / "out.webp")
+
+    exc = ei.value
+    assert exc.code == "blob_not_found"
+    assert exc.ref == MISSING_DIGEST
+    assert isinstance(exc, PayloadRefError)
+    assert isinstance(exc, ValidationError)  # -> the INVALID branch
+
+    status, message = _map_exception(exc)
+    assert status == pb.JOB_STATUS_INVALID, (
+        "a payload-origin miss must never reach the hub as FATAL — FATAL is "
+        "what fed model_load_failure_streak in th#1259"
+    )
+    # The machine-readable class survives the safe_message hop.
+    assert message.startswith("blob_not_found: ")
+    assert MISSING_DIGEST in message
+
+
+def test_payload_digest_403_is_a_typed_request_error(hub: str, tmp_path: Path) -> None:
+    ctx = _ctx(hub)
+    with pytest.raises(BlobForbiddenError) as ei:
+        ctx.materialize_blob(FORBIDDEN_DIGEST, tmp_path / "out.bin")
+    assert ei.value.code == "blob_forbidden"
+    assert _map_exception(ei.value)[0] == pb.JOB_STATUS_INVALID
+
+
+def test_platform_origin_404_stays_fatal(hub: str, tmp_path: Path) -> None:
+    """The other half of the provenance rule: an address the PLATFORM
+    produced (a hub dataset manifest) that 404s is a platform fault and keeps
+    its fatal classification, so genuine breakage still reaches the breaker."""
+    ctx = _ctx(hub)
+
+    with pytest.raises(RuntimeError) as ei:
+        ctx.materialize_blob(
+            MISSING_DIGEST, tmp_path / "out.bin", origin=REF_ORIGIN_PLATFORM,
+        )
+    assert not isinstance(ei.value, PayloadRefError)
+    assert _map_exception(ei.value)[0] == pb.JOB_STATUS_FATAL
+
+    # And the same address forbidden platform-side is still an AuthError.
+    with pytest.raises(AuthError):
+        ctx.materialize_blob(
+            FORBIDDEN_DIGEST, tmp_path / "out2.bin", origin=REF_ORIGIN_PLATFORM,
+        )
+
+
+def test_platform_blob_helper_is_bound_to_platform_origin(hub: str, tmp_path: Path) -> None:
+    """The dataset downloader is wired to `_fetch_platform_blob`; prove that
+    helper really carries platform provenance rather than the default."""
+    ctx = _ctx(hub)
+    with pytest.raises(RuntimeError) as ei:
+        ctx._fetch_platform_blob(MISSING_DIGEST, tmp_path / "out.bin")
+    assert not isinstance(ei.value, PayloadRefError)
+
+
+def test_payload_dataset_ref_404_is_a_typed_request_error(hub: str) -> None:
+    """Same rule on the second caller-supplied resolution path."""
+    ctx = _ctx(hub)
+    with pytest.raises(DatasetNotFoundError) as ei:
+        ctx.resolve_dataset("00000000-0000-0000-0000-000000000000")
+    assert ei.value.code == "dataset_not_found"
+    assert _map_exception(ei.value)[0] == pb.JOB_STATUS_INVALID
+
+    # owner/name refs take the list-lookup leg and classify identically.
+    with pytest.raises(DatasetNotFoundError):
+        ctx.resolve_dataset("acme/nope")
+
+
+def test_good_digest_still_downloads(hub: str, tmp_path: Path) -> None:
+    ctx = _ctx(hub)
+    out = ctx.materialize_blob(GOOD_DIGEST, tmp_path / "ok.bin")
+    assert out.read_bytes() == BLOB_BYTES
+    assert REF_ORIGIN_PAYLOAD == "payload"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.76.3"
+version = "0.76.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
AOT-flip-critical patch train. Ships as 0.76.5 (th#1259's stamp was the highest aboard; pgw#752's 0.76.4 claim is ABSORBED — noted in CHANGELOG; the 0.77.0/0.78.0 chaos claims ride their own trains).

**Aboard, verified by content:**
- **pgw#754** (chaos 5fc7fd8): host compiles clamp to x86-64-v3 (the mint host's -march=native AVX-512 wrapper code SIGILLed non-AVX-512 serving hosts while torch hashed cpp.march=None identically everywhere); clamp is seal-visible (**SEAL_VERSION 5 -> 6**); discovery filters unexecutable cells before download; serve refuses by name before dlopen. `src/gen_worker/host_isa.py` + aot_serve + env_seal + 240-line test.
- **pgw#752** (99c8373): clean page cache is RAM the next load can have (capability + residency accounting).
- **th#1259 SDK half** (4eadabf): payload-named refs fail the REQUEST typed, never the release — the worker half of today's live breaker-poisoning class.
- train's own find: th#1259 left `cli/local_context.py` overrides on the old `materialize_blob` signature — mypy red on chaos since 4eadabf; fixed on chaos 4266251 + aboard.

**Consequence to plan around: seal_v6 retires ALL pre-clamp cells** (JIT + AOT, incl. the four prod-recipe AOT cells and canaries) — remint required before the flip and proof runs; expected and correct (recipe changed).

**Gates on the head:** full suite **1629 passed / 0 failed** (18m44s); mypy clean (173 files); ruff clean; lint_http_timeouts clean; `uv lock --check` consistent; stamped 0.76.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)