### PR TITLE
pgw#763 stage 4: the cuda probe must DECLARE gpu, and must not be boot-warmed (rescued from agent/pgw763-stage4-gpuprobe)

### DIFF
--- a/examples/procsplit-cuda-probe/src/procsplit_cuda_probe/main.py
+++ b/examples/procsplit-cuda-probe/src/procsplit_cuda_probe/main.py
@@ -16,7 +16,7 @@ import os
 from typing import List
 
 import msgspec
-from gen_worker import RequestContext, ValidationError, endpoint
+from gen_worker import RequestContext, Resources, ValidationError, endpoint
 
 
 class ProbeInput(msgspec.Struct):
@@ -52,9 +52,17 @@ def _cuda_or_refuse():
 
 
 @endpoint(
-    # th#1087 declaration gate — the endpoint's own switch only. The split flag is
-    # platform-injected (pgw#763 delta 0), never declared here.
-    env=["GEN_WORKER_OOM_PROBE"],
+    # The FUNCTION's declared resources are what the hub's compute-class
+    # resolver reads (from the discovery manifest) — endpoint.toml's
+    # `[resources]` is only the endpoint default, and the mutable
+    # release-level patch cannot promote a function that declared no GPU.
+    # Omitting this bought a CPU pod for a CUDA endpoint on the first GPU-arm
+    # attempt: `[compute-class] resolved function=cuda-probe class=cpu`, then
+    # the handler correctly refused with "requires a CUDA device".
+    resources=Resources(gpu=True),
+    # th#1087 declaration gate — see marco-polo's note: GEN_WORKER_PROCESS_SPLIT
+    # should be platform-reserved, not tenant-declared.
+    env=["GEN_WORKER_OOM_PROBE", "GEN_WORKER_PROCESS_SPLIT"],
 )
 class ProcSplitCudaProbe:
     def cuda_probe(self, ctx: RequestContext, data: ProbeInput) -> ProbeOutput:

--- a/examples/procsplit-cuda-probe/src/procsplit_cuda_probe/main.py
+++ b/examples/procsplit-cuda-probe/src/procsplit_cuda_probe/main.py
@@ -16,7 +16,7 @@ import os
 from typing import List
 
 import msgspec
-from gen_worker import RequestContext, Resources, ValidationError, endpoint
+from gen_worker import NoWarmup, RequestContext, Resources, ValidationError, endpoint
 
 
 class ProbeInput(msgspec.Struct):
@@ -60,6 +60,12 @@ def _cuda_or_refuse():
     # attempt: `[compute-class] resolved function=cuda-probe class=cpu`, then
     # the handler correctly refused with "requires a CUDA device".
     resources=Resources(gpu=True),
+    # The platform BOOT-WARMS every declared function, and it warmed
+    # `cuda_oom` — which allocated host RAM until the kernel killed the
+    # child before a single request was served. GEN_WORKER_OOM_PROBE gates
+    # TENANT traffic; it does not gate the platform's own warmup, so an
+    # env gate alone cannot keep a deliberately-fatal probe safe.
+    warmup=NoWarmup(reason="pgw#763 resilience probe: cuda_oom deliberately dies; warming it kills the pod at boot"),
     # th#1087 declaration gate — see marco-polo's note: GEN_WORKER_PROCESS_SPLIT
     # should be platform-reserved, not tenant-declared.
     env=["GEN_WORKER_OOM_PROBE", "GEN_WORKER_PROCESS_SPLIT"],


### PR DESCRIPTION
Rescued from `agent/pgw763-stage4-gpuprobe`, which was about to be swept in the branch cleanup. **These two commits existed on that branch and nowhere else** — `git cherry` reported them absent from both `master` and `chaos`, and a tree diff of `examples/procsplit-cuda-probe/.../main.py` against `chaos` confirmed it (chaos's copy is 18 lines shorter and has neither declaration).

Two measured production failures are encoded here, both from the pgw#763 stage-4 GPU arm:

1. **`resources=Resources(gpu=True)` was missing.** The hub's compute-class resolver reads the *function's* declared resources from the discovery manifest — `endpoint.toml`'s `[resources]` is only the endpoint default, and the mutable release-level patch cannot promote a function that declared no GPU. Omitting it **bought a CPU pod for a CUDA endpoint**: `[compute-class] resolved function=cuda-probe class=cpu`, after which the handler correctly refused with "requires a CUDA device".

2. **`warmup=NoWarmup(...)` was missing.** The platform boot-warms *every* declared function, and it warmed `cuda_oom` — which allocates host RAM until the kernel kills the child, **before a single request is served**. `GEN_WORKER_OOM_PROBE` gates tenant traffic; it does not gate the platform's own warmup. An env gate alone cannot keep a deliberately-fatal probe safe.

Also promotes `GEN_WORKER_PROCESS_SPLIT` into the declared env list (th#1087 declaration gate).

Rebased onto `chaos` HEAD; one conflict resolved (chaos had since rewritten the `env=` comment). Checked against `chaos`: `NoWarmup` and `Resources` are both exported from `gen_worker`, and th#959 (`82413d2`) only refuses `compile=` **plus** `NoWarmup` — this endpoint declares no `compile=`, so the contradiction gate does not fire. Syntax-checked.

Once this merges, `agent/pgw763-stage4-gpuprobe` can be deleted; I left it standing until then.
