### PR TITLE
th#1534: mirror bounded formula evaluation in the worker

### DIFF
--- a/src/gen_worker/api/formula.py
+++ b/src/gen_worker/api/formula.py
@@ -11,15 +11,27 @@ The grammar and term-key canonicalization mirror tensorhub's
 ``internal/formula`` package exactly — the formula STRING is the wire
 contract and both sides must mint identical term keys.
 
-Grammar: ``+ - * /``, parentheses, numeric literals, identifiers. Top level
-must be a '+'-joined sum; each term starts with a bare constant identifier
-(the learned coefficient), optionally ``* <payload expression>``.
+Grammar (ASCII only; ``WS`` is space, tab, or newline)::
+
+    runtime := rterm ('+' rterm)*
+    rterm   := IDENT ('*' term)?
+    expr    := term (('+'|'-') term)*
+    term    := unary (('*'|'/') unary)*
+    unary   := '-'? primary
+    primary := NUMBER | IDENT | '(' expr ')'
+    IDENT   := [A-Za-z_] [A-Za-z0-9_]*
+    NUMBER  := ('0' | [1-9][0-9]*) ('.' [0-9]*)? ([eE] [+-]? [0-9]+)?
+             | '.' [0-9]+ ([eE] [+-]? [0-9]+)?
+
+There are no comments, calls, comparisons, Unicode identifiers, or numeric
+separators. Top-level ``+`` joins learned-coefficient terms.
 """
 
 from __future__ import annotations
 
 import ast
 import math
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
@@ -34,6 +46,14 @@ __all__ = [
 ]
 
 _NUMERIC_TYPES = (int, float, bool)
+_FORMULA_SPACE = " \t\n"
+_TOKEN = re.compile(
+    r"(?P<space>[ \t\n]+)|"
+    r"(?P<number>(?:(?:0|[1-9][0-9]*)(?:\.[0-9]*)?|\.[0-9]+)"
+    r"(?:[eE][+-]?[0-9]+)?)|"
+    r"(?P<ident>[A-Za-z_][A-Za-z0-9_]*)|"
+    r"(?P<operator>[+\-*/()])"
+)
 
 
 @dataclass(frozen=True)
@@ -85,12 +105,16 @@ class RuntimeFormula:
     def __init__(
         self, source: str, *, limits: FormulaLimits = COMPUTE_TIME_LIMITS,
     ) -> None:
-        if not isinstance(source, str) or not source.strip():
+        if not isinstance(source, str):
             raise FormulaParseError(
                 "RuntimeFormula: source must be a non-empty string"
             )
         _validate_source(source, limits)
-        self.source = source.strip()
+        self.source = source.strip(_FORMULA_SPACE)
+        if not self.source:
+            raise FormulaParseError(
+                "RuntimeFormula: source must be a non-empty string"
+            )
         self._limits = limits
         self.terms: List[_Term] = _parse_terms(self.source, limits)
         self.fields: Tuple[str, ...] = tuple(sorted({
@@ -255,9 +279,45 @@ def _validate_source(source: str, limits: FormulaLimits) -> None:
         raise FormulaParseError("runtime formula: unbalanced parentheses")
 
 
+def _validate_lexical_source(source: str) -> None:
+    pos = 0
+    previous = ""
+    while pos < len(source):
+        token = _TOKEN.match(source, pos)
+        if token is None:
+            raise FormulaParseError(
+                f"runtime formula: unexpected {source[pos]!r} at offset {pos}"
+            )
+        kind = token.lastgroup
+        text = token.group()
+        pos = token.end()
+        if kind == "space":
+            continue
+        if kind in ("number", "ident"):
+            if previous == "value":
+                raise FormulaParseError(
+                    f"runtime formula: adjacent values at offset {token.start()}"
+                )
+            previous = "value"
+            continue
+        if text == "-" and previous in ("", "(", "+", "-", "*", "/"):
+            following = pos
+            while following < len(source) and source[following] in _FORMULA_SPACE:
+                following += 1
+            if following < len(source) and source[following] == "-":
+                raise FormulaParseError(
+                    f"runtime formula: repeated unary '-' at offset {token.start()}"
+                )
+        previous = "value" if text == ")" else text
+
+
 def _parse_terms(source: str, limits: FormulaLimits) -> List[_Term]:
+    _validate_lexical_source(source)
     try:
-        tree = ast.parse(source, mode="eval")
+        tree = ast.parse(
+            "".join(" " if char in _FORMULA_SPACE else char for char in source),
+            mode="eval",
+        )
         _check_nodes(tree.body)
         term_exprs = _split_sum(tree.body)
     except (SyntaxError, RecursionError) as exc:

--- a/src/gen_worker/api/formula.py
+++ b/src/gen_worker/api/formula.py
@@ -19,7 +19,7 @@ Grammar (ASCII only; ``WS`` is space, tab, or newline)::
     term    := unary (('*'|'/') unary)*
     unary   := '-'? primary
     primary := NUMBER | IDENT | '(' expr ')'
-    IDENT   := [A-Za-z_] [A-Za-z0-9_]*
+    IDENT   := [A-Za-z_] [A-Za-z0-9_]*, excluding ``_RESERVED_IDENTIFIERS``
     NUMBER  := ('0' | [1-9][0-9]*) ('.' [0-9]*)? ([eE] [+-]? [0-9]+)?
              | '.' [0-9]+ ([eE] [+-]? [0-9]+)?
 
@@ -47,6 +47,13 @@ __all__ = [
 
 _NUMERIC_TYPES = (int, float, bool)
 _FORMULA_SPACE = " \t\n"
+_RESERVED_IDENTIFIERS = frozenset({
+    "False", "None", "True", "and", "as", "assert", "async", "await",
+    "break", "class", "continue", "def", "del", "elif", "else", "except",
+    "finally", "for", "from", "global", "if", "import", "in", "is",
+    "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
+    "while", "with", "yield",
+})
 _TOKEN = re.compile(
     r"(?P<space>[ \t\n]+)|"
     r"(?P<number>(?:(?:0|[1-9][0-9]*)(?:\.[0-9]*)?|\.[0-9]+)"
@@ -297,6 +304,10 @@ def _validate_lexical_source(source: str) -> None:
             if previous == "value":
                 raise FormulaParseError(
                     f"runtime formula: adjacent values at offset {token.start()}"
+                )
+            if kind == "ident" and text in _RESERVED_IDENTIFIERS:
+                raise FormulaParseError(
+                    f"runtime formula: reserved identifier {text!r}"
                 )
             previous = "value"
             continue

--- a/src/gen_worker/api/formula.py
+++ b/src/gen_worker/api/formula.py
@@ -20,13 +20,54 @@ from __future__ import annotations
 
 import ast
 import math
+from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
 import msgspec
 
-__all__ = ["RuntimeFormula"]
+__all__ = [
+    "COMPUTE_TIME_LIMITS",
+    "FormulaLimits",
+    "FormulaParseError",
+    "FormulaRefusal",
+    "RuntimeFormula",
+]
 
 _NUMERIC_TYPES = (int, float, bool)
+
+
+@dataclass(frozen=True)
+class FormulaLimits:
+    """The parser/evaluator budget shared with Tensorhub."""
+
+    max_depth: int
+    max_len: int
+    max_nodes: int
+    max_abs_result: float
+    fail_closed: bool = False
+
+
+# Safety ceilings, mirrored byte-for-byte in behavior rather than learned
+# scheduling constants: ordinary formulas are only a few terms, while these
+# make worst-case parser work fixed and exclude results such as 1e300.
+COMPUTE_TIME_LIMITS = FormulaLimits(
+    max_depth=32,
+    max_len=4096,
+    max_nodes=256,
+    max_abs_result=1e15,
+)
+
+
+class FormulaParseError(ValueError):
+    """The source is malformed or exceeds its parser budget."""
+
+
+class FormulaRefusal(ValueError):
+    """A fail-closed evaluation could not produce an allowed value."""
+
+
+class _EvaluationError(Exception):
+    pass
 
 
 class _Term:
@@ -41,11 +82,17 @@ class _Term:
 class RuntimeFormula:
     """Parsed, validated compute-time formula declaration."""
 
-    def __init__(self, source: str) -> None:
+    def __init__(
+        self, source: str, *, limits: FormulaLimits = COMPUTE_TIME_LIMITS,
+    ) -> None:
         if not isinstance(source, str) or not source.strip():
-            raise ValueError("RuntimeFormula: source must be a non-empty string")
+            raise FormulaParseError(
+                "RuntimeFormula: source must be a non-empty string"
+            )
+        _validate_source(source, limits)
         self.source = source.strip()
-        self.terms: List[_Term] = _parse_terms(self.source)
+        self._limits = limits
+        self.terms: List[_Term] = _parse_terms(self.source, limits)
         self.fields: Tuple[str, ...] = tuple(sorted({
             name for t in self.terms if t.factor is not None
             for name in _names(t.factor)
@@ -115,13 +162,31 @@ class RuntimeFormula:
         out: Dict[str, float] = {}
         for t in self.terms:
             if t.factor is None:
+                if 1.0 > self._limits.max_abs_result:
+                    self._evaluation_failure(
+                        "runtime formula: intercept exceeds the absolute result limit"
+                    )
+                    return None
                 out[t.key] = 1.0
                 continue
-            v = _eval(t.factor, values)
-            if v is None:
+            try:
+                v = _eval(t.factor, values)
+                if abs(v) > self._limits.max_abs_result:
+                    raise _EvaluationError(
+                        f"runtime formula: term {t.key!r} result {v:g} exceeds "
+                        f"absolute limit {self._limits.max_abs_result:g}"
+                    )
+            except _EvaluationError as exc:
+                self._evaluation_failure(str(exc), exc)
                 return None
             out[t.key] = v
         return out
+
+    def _evaluation_failure(
+        self, message: str, cause: Optional[BaseException] = None,
+    ) -> None:
+        if self._limits.fail_closed:
+            raise FormulaRefusal(message) from cause
 
     def term_values_from_struct(
         self, payload: Any, defaults: Any = None,
@@ -138,7 +203,7 @@ class RuntimeFormula:
             if isinstance(raw, bool):
                 values[name] = 1.0 if raw else 0.0
             elif isinstance(raw, (int, float)):
-                values[name] = float(raw)
+                values[name] = raw
         return self.term_values(values)
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -150,25 +215,78 @@ class RuntimeFormula:
 # ---------------------------------------------------------------------------
 
 
-def _parse_terms(source: str) -> List[_Term]:
+def _validate_source(source: str, limits: FormulaLimits) -> None:
+    if (
+        limits.max_depth <= 0
+        or limits.max_len <= 0
+        or limits.max_nodes <= 0
+        or limits.max_abs_result <= 0
+        or not math.isfinite(limits.max_abs_result)
+    ):
+        raise FormulaParseError("runtime formula: limits must be finite and positive")
+    if (
+        limits.max_depth > COMPUTE_TIME_LIMITS.max_depth
+        or limits.max_len > COMPUTE_TIME_LIMITS.max_len
+        or limits.max_nodes > COMPUTE_TIME_LIMITS.max_nodes
+        or limits.max_abs_result > COMPUTE_TIME_LIMITS.max_abs_result
+    ):
+        raise FormulaParseError("runtime formula: limits exceed the platform ceiling")
+    source_len = len(source.encode("utf-8"))
+    if source_len > limits.max_len:
+        raise FormulaParseError(
+            f"runtime formula: source is {source_len} bytes; limit is {limits.max_len}"
+        )
+    depth = 0
+    for offset, char in enumerate(source):
+        if char == "(":
+            depth += 1
+            if depth > limits.max_depth:
+                raise FormulaParseError(
+                    "runtime formula: nesting depth exceeds "
+                    f"{limits.max_depth} at offset {offset}"
+                )
+        elif char == ")":
+            depth -= 1
+            if depth < 0:
+                raise FormulaParseError(
+                    f"runtime formula: unexpected ')' at offset {offset}"
+                )
+    if depth:
+        raise FormulaParseError("runtime formula: unbalanced parentheses")
+
+
+def _parse_terms(source: str, limits: FormulaLimits) -> List[_Term]:
     try:
         tree = ast.parse(source, mode="eval")
-    except SyntaxError as exc:
-        raise ValueError(f"runtime formula: {exc}") from exc
-    _check_nodes(tree.body)
-    term_exprs = _split_sum(tree.body)
+        _check_nodes(tree.body)
+        term_exprs = _split_sum(tree.body)
+    except (SyntaxError, RecursionError) as exc:
+        raise FormulaParseError(f"runtime formula: {exc}") from exc
+    except ValueError as exc:
+        raise FormulaParseError(str(exc)) from exc
     terms: List[_Term] = []
     seen: Set[str] = set()
+    nodes = 0
     for expr in term_exprs:
-        constant, factor = _split_leading_constant(expr)
+        try:
+            constant, factor = _split_leading_constant(expr)
+        except ValueError as exc:
+            raise FormulaParseError(str(exc)) from exc
+        nodes += 1  # the learned coefficient is one logical node
+        if factor is not None:
+            nodes += _logical_nodes(factor)
+        if nodes > limits.max_nodes:
+            raise FormulaParseError(
+                f"runtime formula: node count exceeds {limits.max_nodes}"
+            )
         if constant in seen:
-            raise ValueError(
+            raise FormulaParseError(
                 f"runtime formula: constant {constant!r} used in more than one term"
             )
         seen.add(constant)
         key = "1" if factor is None else _canonical(factor)
         if factor is not None and not _names(factor):
-            raise ValueError(
+            raise FormulaParseError(
                 f"runtime formula term with constant {constant!r}: factor "
                 f"references no payload field"
             )
@@ -191,10 +309,16 @@ def _check_nodes(node: ast.expr) -> None:
             raise ValueError("runtime formula: only + - * / are allowed")
         if isinstance(n, ast.UnaryOp) and not isinstance(n.op, ast.USub):
             raise ValueError("runtime formula: only unary '-' is allowed")
-        if isinstance(n, ast.Constant) and (
-            isinstance(n.value, bool) or not isinstance(n.value, (int, float))
-        ):
-            raise ValueError("runtime formula: literals must be numeric")
+        if isinstance(n, ast.Constant):
+            value = n.value
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("runtime formula: literals must be numeric")
+            try:
+                literal = float(value)
+            except (OverflowError, ValueError) as exc:
+                raise ValueError("runtime formula: literal is not finite") from exc
+            if not math.isfinite(literal):
+                raise ValueError("runtime formula: literal is not finite")
 
 
 def _split_sum(node: ast.expr) -> List[ast.expr]:
@@ -253,6 +377,13 @@ def _names(node: ast.expr) -> Set[str]:
     return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
 
 
+def _logical_nodes(node: ast.expr) -> int:
+    return sum(
+        isinstance(n, (ast.BinOp, ast.UnaryOp, ast.Name, ast.Constant))
+        for n in ast.walk(node)
+    )
+
+
 def _prec(op: ast.operator) -> int:
     return 2 if isinstance(op, (ast.Mult, ast.Div)) else 1
 
@@ -263,10 +394,7 @@ def _canonical(node: ast.expr) -> str:
     if isinstance(node, ast.Name):
         return node.id
     if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
-        v = float(node.value)
-        if v == math.trunc(v) and abs(v) < 1e15:
-            return str(int(v))
-        return repr(v)
+        return _canonical_number(float(node.value))
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
         inner = _canonical(node.operand)
         if isinstance(node.operand, ast.BinOp) and _prec(node.operand.op) < 2:
@@ -287,27 +415,53 @@ def _canonical(node: ast.expr) -> str:
     raise ValueError(f"runtime formula: cannot canonicalize {type(node).__name__}")
 
 
-def _eval(node: ast.expr, values: Mapping[str, Any]) -> Optional[float]:
+def _canonical_number(value: float) -> str:
+    if value == math.trunc(value) and abs(value) < 1e15:
+        return str(int(value))
+    mantissa, exponent = format(value, ".16e").split("e")
+    mantissa = mantissa.rstrip("0").rstrip(".")
+    exp = int(exponent)
+    return mantissa if exp == 0 else f"{mantissa}e{exp}"
+
+
+def _eval(node: ast.expr, values: Mapping[str, Any]) -> float:
     if isinstance(node, ast.Name):
         v = values.get(node.id)
         if v is None or not isinstance(v, (int, float)) or isinstance(v, bool):
             if isinstance(v, bool):
                 return 1.0 if v else 0.0
-            return None
-        f = float(v)
-        return None if (math.isnan(f) or math.isinf(f)) else f
+            raise _EvaluationError(
+                f"runtime formula: missing numeric value for field {node.id!r}"
+            )
+        try:
+            f = float(v)
+        except (OverflowError, ValueError) as exc:
+            raise _EvaluationError(
+                f"runtime formula: field {node.id!r} is not finite"
+            ) from exc
+        if not math.isfinite(f):
+            raise _EvaluationError(
+                f"runtime formula: field {node.id!r} is not finite"
+            )
+        return f
     if isinstance(node, ast.Constant):
         if not isinstance(node.value, (int, float)):
-            return None
-        return float(node.value)
+            raise _EvaluationError("runtime formula: literal is not numeric")
+        value = float(node.value)
+        if not math.isfinite(value):
+            raise _EvaluationError("runtime formula: literal is not finite")
+        return value
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
         v = _eval(node.operand, values)
-        return None if v is None else -v
+        out = -v
+        if not math.isfinite(out):
+            raise _EvaluationError(
+                "runtime formula: non-finite result after negation"
+            )
+        return out
     if isinstance(node, ast.BinOp):
         left = _eval(node.left, values)
         right = _eval(node.right, values)
-        if left is None or right is None:
-            return None
         if isinstance(node.op, ast.Add):
             out = left + right
         elif isinstance(node.op, ast.Sub):
@@ -316,9 +470,11 @@ def _eval(node: ast.expr, values: Mapping[str, Any]) -> Optional[float]:
             out = left * right
         elif isinstance(node.op, ast.Div):
             if right == 0:
-                return None
+                raise _EvaluationError("runtime formula: division by zero")
             out = left / right
         else:  # pragma: no cover
-            return None
-        return None if (math.isnan(out) or math.isinf(out)) else out
-    return None  # pragma: no cover
+            raise _EvaluationError("runtime formula: operator is not supported")
+        if not math.isfinite(out):
+            raise _EvaluationError("runtime formula: non-finite result")
+        return out
+    raise _EvaluationError("runtime formula: expression node is not supported")

--- a/tests/test_formula_conformance_th1534.py
+++ b/tests/test_formula_conformance_th1534.py
@@ -1,0 +1,73 @@
+"""Cross-language formula limits and canonicalization contract (th#1534).
+
+The fixture is vendored byte-identically in Tensorhub under
+``internal/formula/testdata`` because each repository must validate in
+isolation. The JSON, rather than two hand-authored case lists, owns the cases.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker.api.formula import (
+    FormulaLimits,
+    FormulaParseError,
+    FormulaRefusal,
+    RuntimeFormula,
+)
+
+_DOCUMENT = json.loads(
+    (Path(__file__).parent / "testdata" / "formula_vectors.json").read_text()
+)
+_BASE_LIMITS = FormulaLimits(**_DOCUMENT["limits"])
+
+
+def _limits(overrides: dict[str, Any]) -> FormulaLimits:
+    return replace(_BASE_LIMITS, **overrides)
+
+
+def _values(values: dict[str, Any]) -> dict[str, float]:
+    sentinels = {"inf": math.inf, "-inf": -math.inf, "nan": math.nan}
+    return {
+        name: sentinels.get(value, value) if isinstance(value, str) else value
+        for name, value in values.items()
+    }
+
+
+@pytest.mark.parametrize(
+    "vector", _DOCUMENT["vectors"], ids=[v["name"] for v in _DOCUMENT["vectors"]]
+)
+def test_formula_conformance_vector(vector: dict[str, Any]) -> None:
+    limits = _limits(vector.get("limits", {}))
+    source = vector.get("source", "")
+    if repeat := vector.get("repeat_parentheses", 0):
+        source = f"a+b*{'(' * repeat}x{')' * repeat}"
+    if vector.get("parse_error"):
+        with pytest.raises(FormulaParseError):
+            RuntimeFormula(source, limits=limits)
+        return
+
+    formula = RuntimeFormula(source, limits=limits)
+    if "term_keys" in vector:
+        assert [term.key for term in formula.terms] == vector["term_keys"]
+    if "values" not in vector:
+        return
+
+    if vector.get("evaluation_error") and vector.get("refusal"):
+        with pytest.raises(FormulaRefusal) as raised:
+            formula.term_values(_values(vector["values"]))
+        if "error_contains" in vector:
+            assert vector["error_contains"] in str(raised.value)
+        return
+
+    got = formula.term_values(_values(vector["values"]))
+    if vector.get("evaluation_error"):
+        assert got is None
+    else:
+        assert got == vector["term_values"]

--- a/tests/testdata/formula_vectors.json
+++ b/tests/testdata/formula_vectors.json
@@ -1,0 +1,148 @@
+{
+  "version": 1,
+  "limits": {
+    "max_depth": 4,
+    "max_len": 64,
+    "max_nodes": 5,
+    "max_abs_result": 10,
+    "fail_closed": false
+  },
+  "vectors": [
+    {
+      "name": "ordinary evaluation",
+      "source": "a+b*x",
+      "term_keys": ["1", "x"],
+      "values": {"x": 3},
+      "term_values": {"1": 1, "x": 3}
+    },
+    {
+      "name": "range boundary is inclusive",
+      "source": "a+b*x",
+      "term_keys": ["1", "x"],
+      "values": {"x": 10},
+      "term_values": {"1": 1, "x": 10}
+    },
+    {
+      "name": "decimal canonicalization",
+      "source": "a+b*x/0.1",
+      "term_keys": ["1", "x/1.0000000000000001e-1"]
+    },
+    {
+      "name": "large integer canonicalization",
+      "source": "a+b*x/1000000000000000",
+      "term_keys": ["1", "x/1e15"]
+    },
+    {
+      "name": "small decimal canonicalization",
+      "source": "a+b*x/0.0000001",
+      "term_keys": ["1", "x/9.9999999999999995e-8"]
+    },
+    {
+      "name": "seventeen digit canonicalization",
+      "source": "a+b*x/1.2345678901234567",
+      "term_keys": ["1", "x/1.2345678901234567"]
+    },
+    {
+      "name": "depth boundary is inclusive",
+      "source": "a+b*((((x))))",
+      "term_keys": ["1", "x"]
+    },
+    {
+      "name": "depth over limit",
+      "source": "a+b*((((x))))",
+      "limits": {"max_depth": 3},
+      "parse_error": true
+    },
+    {
+      "name": "stack overflow payload is refused before parsing",
+      "repeat_parentheses": 100000,
+      "parse_error": true
+    },
+    {
+      "name": "length boundary is inclusive",
+      "source": "a+b*x",
+      "limits": {"max_len": 5},
+      "term_keys": ["1", "x"]
+    },
+    {
+      "name": "length over limit",
+      "source": "a+b*x",
+      "limits": {"max_len": 4},
+      "parse_error": true
+    },
+    {
+      "name": "node boundary is inclusive",
+      "source": "a+b*x+c*y",
+      "term_keys": ["1", "x", "y"]
+    },
+    {
+      "name": "node count over limit",
+      "source": "a+b*x+c*y+d*z",
+      "parse_error": true
+    },
+    {
+      "name": "non-finite literal is a parse error",
+      "source": "a+b*x/1e999",
+      "parse_error": true
+    },
+    {
+      "name": "range over limit stays fail soft for time",
+      "source": "a+b*x",
+      "values": {"x": 11},
+      "evaluation_error": true
+    },
+    {
+      "name": "range over limit refuses money",
+      "source": "a+b*x",
+      "limits": {"fail_closed": true},
+      "values": {"x": 11},
+      "evaluation_error": true,
+      "refusal": true
+    },
+    {
+      "name": "intercept obeys the range limit",
+      "source": "a",
+      "limits": {"max_abs_result": 0.5, "fail_closed": true},
+      "values": {},
+      "evaluation_error": true,
+      "refusal": true
+    },
+    {
+      "name": "missing value stays fail soft for time",
+      "source": "a+b*x",
+      "values": {},
+      "evaluation_error": true
+    },
+    {
+      "name": "missing value refuses money",
+      "source": "a+b*x",
+      "limits": {"fail_closed": true},
+      "values": {},
+      "evaluation_error": true,
+      "refusal": true
+    },
+    {
+      "name": "division by zero refuses money",
+      "source": "a+b*x/y",
+      "limits": {"fail_closed": true},
+      "values": {"x": 1, "y": 0},
+      "evaluation_error": true,
+      "refusal": true
+    },
+    {
+      "name": "finite negation",
+      "source": "a+b*(-x)",
+      "values": {"x": 3},
+      "term_values": {"1": 1, "-x": -3}
+    },
+    {
+      "name": "non-finite negation refuses money",
+      "source": "a+b*(-x)",
+      "limits": {"fail_closed": true},
+      "values": {"x": "inf"},
+      "evaluation_error": true,
+      "refusal": true,
+      "error_contains": "is not finite"
+    }
+  ]
+}

--- a/tests/testdata/formula_vectors.json
+++ b/tests/testdata/formula_vectors.json
@@ -38,6 +38,16 @@
       "term_keys": ["1", "x/9.9999999999999995e-8"]
     },
     {
+      "name": "negative signed exponent",
+      "source": "a+b*x/1e-7",
+      "term_keys": ["1", "x/9.9999999999999995e-8"]
+    },
+    {
+      "name": "positive signed exponent",
+      "source": "a+b*x/1e+7",
+      "term_keys": ["1", "x/10000000"]
+    },
+    {
       "name": "seventeen digit canonicalization",
       "source": "a+b*x/1.2345678901234567",
       "term_keys": ["1", "x/1.2345678901234567"]
@@ -86,6 +96,51 @@
       "parse_error": true
     },
     {
+      "name": "hex literal is refused",
+      "source": "a+b*x/0x10",
+      "parse_error": true
+    },
+    {
+      "name": "numeric separator is refused",
+      "source": "a+b*x/1_000",
+      "parse_error": true
+    },
+    {
+      "name": "repeated unary is refused",
+      "source": "a+b*--x",
+      "parse_error": true
+    },
+    {
+      "name": "unicode identifier is refused",
+      "source": "a+b*é",
+      "parse_error": true
+    },
+    {
+      "name": "trailing comment is refused",
+      "source": "a+b*x # comment",
+      "parse_error": true
+    },
+    {
+      "name": "leading-zero decimal is refused",
+      "source": "a+b*x/01",
+      "parse_error": true
+    },
+    {
+      "name": "unary plus is refused",
+      "source": "a+b*+x",
+      "parse_error": true
+    },
+    {
+      "name": "carriage return is not formula whitespace",
+      "source": "a+b*x\r",
+      "parse_error": true
+    },
+    {
+      "name": "ascii whitespace is accepted everywhere",
+      "source": " \t a \n + \t b * ( x / 1e-7 ) \n",
+      "term_keys": ["1", "x/9.9999999999999995e-8"]
+    },
+    {
       "name": "range over limit stays fail soft for time",
       "source": "a+b*x",
       "values": {"x": 11},
@@ -132,6 +187,12 @@
     {
       "name": "finite negation",
       "source": "a+b*(-x)",
+      "values": {"x": 3},
+      "term_values": {"1": 1, "-x": -3}
+    },
+    {
+      "name": "unparenthesized unary factor",
+      "source": "a+b*-x",
       "values": {"x": 3},
       "term_values": {"1": 1, "-x": -3}
     },

--- a/tests/testdata/formula_vectors.json
+++ b/tests/testdata/formula_vectors.json
@@ -116,6 +116,21 @@
       "parse_error": true
     },
     {
+      "name": "reserved literal identifier is refused",
+      "source": "a+b*True",
+      "parse_error": true
+    },
+    {
+      "name": "reserved constant identifier is refused",
+      "source": "lambda+b*x",
+      "parse_error": true
+    },
+    {
+      "name": "reserved async identifier is refused",
+      "source": "a+b*await",
+      "parse_error": true
+    },
+    {
       "name": "trailing comment is refused",
       "source": "a+b*x # comment",
       "parse_error": true


### PR DESCRIPTION
## What changed

- mirrors Tensorhub's hard ceilings for formula source bytes, nesting depth, logical nodes, and absolute results
- catches parser recursion as a typed parse error before endpoint declarations can escape the build path
- preserves worker time-formula fail-soft behavior while adding a typed fail-closed refusal posture
- fixes non-finite negation and numeric-literal handling
- replaces Python's divergent float rendering with the shared canonical algorithm
- adds an exact ASCII lexical boundary before `ast.parse`, including strict numeric literals and a fixed reserved-identifier set shared with Tensorhub
- loads byte-identical Go/Python conformance vectors covering signed exponents, numeric separators/hex/leading zeroes, whitespace, unary operators, comments, Unicode, and reserved identifiers such as `True`, `lambda`, and `await`

## Why

The worker and Tensorhub mint regression feature keys from the same formula string. They must reject the same bounded input classes and produce byte-identical numeric keys before the evaluator can safely be reused for money.

Companion Tensorhub PR: https://github.com/cozy-creator/tensorhub/pull/711

## Validation

- `uv run pytest -q tests/test_formula_conformance_th1534.py tests/test_runtime_formula_th1051.py tests/test_vocabulary_train_pgw654.py` — 64 passed
- `uvx --from 'ruff==0.15.21' ruff check src/gen_worker/api/formula.py tests/test_formula_conformance_th1534.py`
- `uv run --with 'mypy==2.2.0' mypy src/gen_worker/api/formula.py`
- shared fixture SHA-256: `3e9d1cbe2b1e319b0ec86994a3e2809d0073bdfcda508fee141423800d862291`

## Environment note

The aggregate `uv run --extra dev` sync is currently blocked before lint by the repository's locked `torch==2.13.0+cu130` wheel hash mismatch. Ruff, mypy, and the focused tests above were run independently with the locked tool versions.
