### PR TITLE
pgw#938 isolate compute-group postmortem evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **pgw#938:** isolate transient post-mortem evidence per compute group and make
+  concurrent grant downloads finalize through writer-unique temporary files.
+
 ## 0.91.0 (2026-08-02) — **the native kernel lane lands dormant** (pgw#862/pgw#864: env-gated opt-in, OFF by default — no serving path changes until the gate is set), the envelope gains the DEGREE axis (th#1426), an unprovable cell can no longer be declared (th#959), and v2 publish restates classification (th#1411)
 
 MINOR, not patch: `Resources` gains a field (`max_gpus_per_execution_group`), `@endpoint`

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -426,7 +426,9 @@ def previous_boot_detail(path: Path = BOOT_RECORD_PATH) -> Optional[str]:
     # pgw#676: the previous process's in-flight marker + fault dump are the
     # death's attribution; consuming them here also feeds the crash registry
     # so this boot's gate can refuse a crash-streak function.
-    extra.update(attribute_signal_death(signal_name="container_death"))
+    extra.update(attribute_all_signal_deaths(
+        signal_name="container_death", marker_dir=path.parent,
+    ))
     return format_detail(
         phase="previous_container_death",
         verdict={"exit_code": None, "signaled": None},
@@ -471,9 +473,43 @@ def _sibling(name: str) -> Path:
     return BOOT_RECORD_PATH.parent / name
 
 
-INFLIGHT_PATH = _sibling(_INFLIGHT_NAME)
+# pgw#938: a compute group is a separate OS process.  Its transient markers
+# therefore need one writer just as its inductor cache does; otherwise one
+# child replaces or truncates a sibling's evidence.  The crash registry stays
+# pod-wide on purpose: it is the worker-level refusal fact consumed by every
+# group on its next boot.
+def _group_marker_path(
+    name: str, ordinal: int, marker_dir: Optional[Path] = None,
+) -> Path:
+    root = marker_dir or BOOT_RECORD_PATH.parent
+    return root / f"g{max(0, int(ordinal))}" / name
+
+
+def group_inflight_path(
+    ordinal: int, marker_dir: Optional[Path] = None,
+) -> Path:
+    return _group_marker_path(_INFLIGHT_NAME, ordinal, marker_dir)
+
+
+def group_fault_dump_path(
+    ordinal: int, marker_dir: Optional[Path] = None,
+) -> Path:
+    return _group_marker_path(_FAULT_DUMP_NAME, ordinal, marker_dir)
+
+
+def _local_marker_path(name: str) -> Path:
+    # Importing procsplit's tiny environment helpers here keeps the reserved
+    # names canonical without pulling in the parent or any compute dependency.
+    from .procsplit import group_ordinal, host_siblings
+
+    if host_siblings() > 1:
+        return _group_marker_path(name, group_ordinal())
+    return _sibling(name)
+
+
+INFLIGHT_PATH = _local_marker_path(_INFLIGHT_NAME)
 CRASH_REGISTRY_PATH = _sibling(_CRASH_REGISTRY_NAME)
-FAULT_DUMP_PATH = _sibling(_FAULT_DUMP_NAME)
+FAULT_DUMP_PATH = _local_marker_path(_FAULT_DUMP_NAME)
 
 _fault_dump_file: Optional[Any] = None
 
@@ -748,6 +784,98 @@ def attribute_signal_death(
     return extra
 
 
+def _group_marker_dirs(marker_dir: Optional[Path] = None) -> list[Path]:
+    """Existing ``gN`` marker dirs, sorted by ordinal.
+
+    The whole-worker supervisor and next-container reporter do not own the
+    delivered topology, so the durable filesystem is their census.  Only the
+    exact directory form this module creates is admitted.
+    """
+    marker_dir = marker_dir or BOOT_RECORD_PATH.parent
+    try:
+        dirs = [
+            p for p in marker_dir.iterdir()
+            if p.is_dir() and p.name.startswith("g") and p.name[1:].isdigit()
+        ]
+    except OSError:
+        return []
+    return sorted(dirs, key=lambda p: int(p.name[1:]))
+
+
+def clear_all_inflight(marker_dir: Optional[Path] = None) -> None:
+    """Remove transient markers for the whole worker, including every group."""
+    paths = {
+        marker_dir / _INFLIGHT_NAME if marker_dir is not None else INFLIGHT_PATH
+    }
+    paths.update(p / _INFLIGHT_NAME for p in _group_marker_dirs(marker_dir))
+    for path in paths:
+        clear_inflight(path=path)
+
+
+def clear_all_fault_dumps(marker_dir: Optional[Path] = None) -> None:
+    """Remove fault dumps for the whole worker, including every group."""
+    paths = {
+        marker_dir / _FAULT_DUMP_NAME if marker_dir is not None else FAULT_DUMP_PATH
+    }
+    paths.update(p / _FAULT_DUMP_NAME for p in _group_marker_dirs(marker_dir))
+    for path in paths:
+        clear_fault_dump(path=path)
+
+
+def attribute_all_signal_deaths(
+    *, signal_name: str, marker_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Consume signal evidence after the whole control process/container dies.
+
+    A per-slot death calls :func:`attribute_signal_death` with its ordinal.
+    The outer supervisor and next boot instead lost the owner of every slot,
+    so they aggregate all one-writer group files without letting one group's
+    record overwrite another's.
+    """
+    pairs = [(
+        "worker",
+        marker_dir / _INFLIGHT_NAME if marker_dir is not None else INFLIGHT_PATH,
+        marker_dir / _FAULT_DUMP_NAME if marker_dir is not None else FAULT_DUMP_PATH,
+    )]
+    pairs.extend(
+        (p.name, p / _INFLIGHT_NAME, p / _FAULT_DUMP_NAME)
+        for p in _group_marker_dirs(marker_dir)
+    )
+    seen: set[tuple[Path, Path]] = set()
+    inflight: list[Dict[str, Any]] = []
+    streaks: Dict[str, int] = {}
+    tails: list[str] = []
+    for label, inflight_path, dump_path in pairs:
+        key = (inflight_path, dump_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not inflight_path.exists() and not dump_path.exists():
+            continue
+        detail = attribute_signal_death(
+            signal_name=signal_name,
+            inflight_path=inflight_path,
+            dump_path=dump_path,
+        )
+        rows = detail.get("inflight")
+        if isinstance(rows, list):
+            inflight.extend(r for r in rows if isinstance(r, dict))
+        counts = detail.get("native_crash_streaks")
+        if isinstance(counts, dict):
+            streaks.update({str(k): int(v) for k, v in counts.items()})
+        tail = str(detail.get("fault_dump_tail") or "")
+        if tail:
+            tails.append(f"[{label}]\n{tail}")
+    extra: Dict[str, Any] = {}
+    if inflight:
+        extra["inflight"] = inflight
+    if streaks:
+        extra["native_crash_streaks"] = streaks
+    if tails:
+        extra["fault_dump_tail"] = "\n\n".join(tails)[-_FAULT_DUMP_TAIL_BYTES:]
+    return extra
+
+
 __all__ = [
     "BOOT_RECORD_PATH",
     "CRASH_REGISTRY_PATH",
@@ -755,11 +883,14 @@ __all__ = [
     "INFLIGHT_PATH",
     "COMPILE_KIND",
     "NATIVE_CRASH_REFUSE_STREAK",
+    "attribute_all_signal_deaths",
     "attribute_signal_death",
     "compile_crash_rows",
     "compile_marker",
     "boot_record_is_volatile",
     "clear_boot_record",
+    "clear_all_fault_dumps",
+    "clear_all_inflight",
     "clear_fault_dump",
     "clear_inflight",
     "container_limits",
@@ -770,6 +901,8 @@ __all__ = [
     "enable_fault_dump",
     "fault_dump_tail",
     "format_detail",
+    "group_fault_dump_path",
+    "group_inflight_path",
     "native_crash_streaks",
     "note_inflight",
     "oom_kill_count",

--- a/src/gen_worker/procsplit/__init__.py
+++ b/src/gen_worker/procsplit/__init__.py
@@ -41,9 +41,10 @@ ENV_SESSION_ID = "GEN_WORKER_SESSION_ID"
 # pgw#783: one child per EXECUTION GROUP. The hub's delivered packing is the
 # only source of G — there is no new knob to mis-set.
 ENV_TOPOLOGY = "WORKER_EXECUTION_TOPOLOGY"
-# Which group this child owns. Labelling only (logs, dials, per-group dirs);
-# no behaviour reads it, because the child is rewritten into a SINGLE-group
-# worker over its own cards (see procsplit.group).
+# Which group this child owns. It labels logs/dials and selects one-writer
+# per-group filesystem carriers (inductor cache and post-mortem markers); it
+# never changes serving policy, because the child is rewritten into a
+# SINGLE-group worker over its own cards (see procsplit.group).
 ENV_GROUP_ORDINAL = "GEN_WORKER_GROUP_ORDINAL"
 # How many compute children share this pod's cgroup. The one fact a child
 # needs about its siblings: the CPU (pgw#782) and host-RAM (pgw#752) budgets

--- a/src/gen_worker/procsplit/group.py
+++ b/src/gen_worker/procsplit/group.py
@@ -172,7 +172,8 @@ def _child_env(
         "CUDA_VISIBLE_DEVICES": ",".join(str(d) for d in devices),
         # Locally G == 1: the child is the most-tested shape in the worker.
         ENV_TOPOLOGY: json.dumps(local.as_dict(), separators=(",", ":")),
-        # Labelling only (logs, dials, per-group dirs). No behaviour reads it.
+        # Filesystem/process identity only (logs, dials, per-group dirs). It
+        # never selects serving behaviour.
         ENV_GROUP_ORDINAL: str(ordinal),
         # The ONE thing a child must know about its siblings: how many
         # processes share this pod's cgroup. Without it pgw#782's cpu_budget

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -55,6 +55,7 @@ import signal
 import sys
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import msgspec
@@ -266,6 +267,14 @@ class _ChildSlot:
         # DxD-rewritten topology, the sibling count. Applied over the parent's
         # shared child env at spawn.
         self.group_env: Dict[str, str] = dict(group.env)
+        self.inflight_marker_path = (
+            postmortem.group_inflight_path(group.ordinal, parent._postmortem_dir)
+            if parent._topology.execution_groups > 1 else None
+        )
+        self.fault_dump_path = (
+            postmortem.group_fault_dump_path(group.ordinal, parent._postmortem_dir)
+            if parent._topology.execution_groups > 1 else None
+        )
 
         self.server: Optional[asyncio.AbstractServer] = None
         self.link: Optional[_ChildLink] = None
@@ -818,7 +827,9 @@ class _ChildSlot:
             logger.info(
                 "compute child %s exited cleanly (rc=%s)", self.label, rc,
             )
-        postmortem.clear_inflight()   # nothing of this child may attribute the next
+        # Nothing of this child may attribute the next generation. At G>1 the
+        # explicit path cannot unlink a live sibling's marker (pgw#938).
+        postmortem.clear_inflight(path=self.inflight_marker_path)
         await p._finish_shutdown_flush(
             reason="terminating" if p._terminating else "drain"
         )
@@ -867,12 +878,14 @@ class _ChildSlot:
         if verdict.get("signaled"):
             try:
                 extra.update(postmortem.attribute_signal_death(
-                    signal_name=str(verdict.get("signal_name") or "")
+                    signal_name=str(verdict.get("signal_name") or ""),
+                    inflight_path=self.inflight_marker_path,
+                    dump_path=self.fault_dump_path,
                 ))
             except Exception:
                 logger.warning("signal-death attribution failed", exc_info=True)
         else:
-            postmortem.clear_inflight()
+            postmortem.clear_inflight(path=self.inflight_marker_path)
         # pgw#833: the dying child's own stderr tail rides the dial — the only
         # forensic channel that survives a pre-Hello death on a provider with
         # no container-logs API.
@@ -1100,6 +1113,12 @@ class ParentControl:
             else (shlex.split(env_cmd) if env_cmd else [sys.executable, "-m", "gen_worker.entrypoint"])
         )
         self._child_env = dict(child_env or {})
+        record_path = (
+            self._child_env.get("GEN_WORKER_BOOT_RECORD")
+            or os.environ.get("GEN_WORKER_BOOT_RECORD")
+            or str(postmortem.BOOT_RECORD_PATH)
+        )
+        self._postmortem_dir = Path(record_path).parent
         self._socket_path = socket_path or f"/tmp/gen-worker-compute-{os.getpid()}.sock"
         self._backoff_base = respawn_backoff_base_s
         self._backoff_cap = respawn_backoff_cap_s
@@ -2320,7 +2339,7 @@ def run_parent() -> int:
     from ..supervisor import report_previous_container_death
 
     report_previous_container_death()
-    postmortem.clear_inflight()
+    postmortem.clear_all_inflight()
     postmortem.write_boot_record()
     from ..config import get_settings
 
@@ -2328,5 +2347,5 @@ def run_parent() -> int:
     code = ParentControl(settings).run()
     if code == 0:
         postmortem.clear_boot_record()
-        postmortem.clear_inflight()
+        postmortem.clear_all_inflight()
     return code

--- a/src/gen_worker/s3_transfer.py
+++ b/src/gen_worker/s3_transfer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -162,46 +163,63 @@ def download_file_with_grant(
         )
     dest = Path(dest_path)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_name(dest.name + ".tmp")
-    client = _s3_client(grant)
+    # pgw#938: G compute children share this destination directory.  A fixed
+    # ``dest.tmp`` lets one process rename/unlink another process's verified
+    # download.  Each writer gets its own same-directory temp, preserving the
+    # atomic-finalize contract while making concurrent finalizers independent.
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{dest.name}.", suffix=".tmp", dir=str(dest.parent)
+    )
+    os.close(fd)
+    tmp = Path(tmp_name)
     try:
-        client.download_file(grant.bucket, grant.key, str(tmp), Config=_transfer_config())
-    except Exception as exc:
-        raise ArtifactTransferError(
-            f"tensorhub SDK download failed: {exc}",
-            provider="tensorhub",
-            phase="sdk_download",
-            retryable=True,
-            cause_type=type(exc).__name__,
-        ) from exc
+        client = _s3_client(grant)
+        try:
+            client.download_file(
+                grant.bucket, grant.key, str(tmp), Config=_transfer_config()
+            )
+        except Exception as exc:
+            raise ArtifactTransferError(
+                f"tensorhub SDK download failed: {exc}",
+                provider="tensorhub",
+                phase="sdk_download",
+                retryable=True,
+                cause_type=type(exc).__name__,
+            ) from exc
 
-    size = int(tmp.stat().st_size)
-    if expected_size_bytes is not None and size != int(expected_size_bytes):
-        tmp.unlink(missing_ok=True)
-        raise ArtifactTransferError(
-            f"downloaded object size mismatch: expected {expected_size_bytes}, got {size}",
-            provider="tensorhub",
-            phase="sdk_download",
-            retryable=False,
+        size = int(tmp.stat().st_size)
+        if expected_size_bytes is not None and size != int(expected_size_bytes):
+            raise ArtifactTransferError(
+                f"downloaded object size mismatch: expected {expected_size_bytes}, got {size}",
+                provider="tensorhub",
+                phase="sdk_download",
+                retryable=False,
+            )
+        try:
+            verify_file_digest(tmp, expected_digest)
+        except (DigestMismatch, ValueError) as exc:
+            raise ArtifactTransferError(
+                f"downloaded object digest mismatch: {exc}",
+                provider="tensorhub",
+                phase="sdk_download",
+                retryable=False,
+            ) from exc
+        # Durable atomic finalize (gw#408): see cozy_cas — data must hit stable
+        # storage before the rename, or a pod hard-kill persists a truncated blob.
+        fsync_file(tmp)
+        os.replace(tmp, dest)
+        fsync_dir(dest.parent)
+        return S3TransferResult(
+            bucket=grant.bucket,
+            key=grant.key,
+            size_bytes=size,
+            digest=expected_digest,
         )
-    try:
-        verify_file_digest(tmp, expected_digest)
-    except (DigestMismatch, ValueError) as exc:
-        tmp.unlink(missing_ok=True)
-        raise ArtifactTransferError(
-            f"downloaded object digest mismatch: {exc}",
-            provider="tensorhub",
-            phase="sdk_download",
-            retryable=False,
-        ) from exc
-    # Durable atomic finalize (gw#408): see cozy_cas — data must hit stable
-    # storage before the rename, or a pod hard-kill persists a truncated blob.
-
-    fsync_file(tmp)
-    os.replace(tmp, dest)
-    fsync_dir(dest.parent)
-    return S3TransferResult(
-        bucket=grant.bucket, key=grant.key, size_bytes=size, digest=expected_digest)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 class _sdk_upload_slot:

--- a/src/gen_worker/supervisor.py
+++ b/src/gen_worker/supervisor.py
@@ -197,7 +197,7 @@ def supervise(
     report_previous_container_death(record_path)
     # Anything the previous-death report did not consume is stale by now —
     # a lingering marker would misattribute the NEXT death (pgw#676).
-    postmortem.clear_inflight()
+    postmortem.clear_all_inflight(record_path.parent)
     postmortem.write_boot_record(record_path)
 
     started = time.time()
@@ -234,8 +234,8 @@ def supervise(
     clean = not verdict.get("signaled") and verdict.get("exit_code") == 0
     if clean:
         postmortem.clear_boot_record(record_path)
-        postmortem.clear_inflight()
-        postmortem.clear_fault_dump()
+        postmortem.clear_all_inflight(record_path.parent)
+        postmortem.clear_all_fault_dumps(record_path.parent)
     else:
         oom_after = postmortem.oom_kill_count()
         extra: dict = {"child_pid": child_pid}
@@ -244,8 +244,10 @@ def supervise(
             # executing), the faulthandler dump (every thread's Python
             # stack, written below Python by the dying child), and the
             # per-pod crash streak the next boot's gate refuses on.
-            extra.update(postmortem.attribute_signal_death(
-                signal_name=str(verdict.get("signal_name") or "")))
+            extra.update(postmortem.attribute_all_signal_deaths(
+                signal_name=str(verdict.get("signal_name") or ""),
+                marker_dir=record_path.parent,
+            ))
         _emit(
             postmortem.format_detail(
                 phase="worker_process_exit",

--- a/tests/harness/procsplit_child_main.py
+++ b/tests/harness/procsplit_child_main.py
@@ -12,8 +12,14 @@ import sys
 
 
 def main() -> int:
+    from gen_worker import postmortem
     from gen_worker.config import load_settings
     from gen_worker.worker import Worker
+
+    # The container entrypoint installs this before constructing Worker.  The
+    # harness enters one layer lower, so reproduce that production hook here
+    # rather than testing a child that cannot emit native-fault evidence.
+    postmortem.enable_fault_dump()
 
     # worker_jwt is deliberately NOT overridden: the loader reads WORKER_JWT
     # from the environment exactly as production does, so the pgw#763 delta-1

--- a/tests/harness/procsplit_endpoints.py
+++ b/tests/harness/procsplit_endpoints.py
@@ -135,6 +135,13 @@ class SplitProbe:
         os.kill(os.getpid(), signal.SIGKILL)
         return ProbeOut(response="unreachable")
 
+    def segfault(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
+        """Real native fault: exercises per-group faulthandler attribution."""
+        import ctypes
+
+        ctypes.string_at(0)
+        return ProbeOut(response="unreachable")
+
     def sleepy(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
         """Long cancellable job: measures cancel latency across the seam."""
         for _ in range(1200):

--- a/tests/test_grant_download_digest_th1303.py
+++ b/tests/test_grant_download_digest_th1303.py
@@ -17,9 +17,15 @@ constructed, so this test touches no network.
 
 from __future__ import annotations
 
+import hashlib
+import multiprocessing
+import os
+from pathlib import Path
+
 import pytest
 
 from gen_worker.api.errors import ArtifactTransferError
+from gen_worker import s3_transfer
 from gen_worker.s3_transfer import S3TransferGrant, download_file_with_grant
 
 
@@ -29,6 +35,32 @@ def _grant() -> S3TransferGrant:
         "endpoint_url": "https://example.invalid", "region": "auto",
         "access_key_id": "k", "secret_access_key": "s", "session_token": "t",
     })
+
+
+class _BarrierClient:
+    def __init__(self, barrier, paths, data: bytes) -> None:
+        self.barrier = barrier
+        self.paths = paths
+        self.data = data
+
+    def download_file(self, _bucket, _key, filename, Config=None) -> None:
+        Path(filename).write_bytes(self.data)
+        self.paths.put(filename)
+        self.barrier.wait(timeout=10.0)
+
+
+def _concurrent_download(grant, dest, digest, size, results) -> None:
+    try:
+        download_file_with_grant(
+            grant=grant,
+            dest_path=dest,
+            expected_digest=digest,
+            expected_size_bytes=size,
+        )
+    except BaseException as exc:  # pragma: no cover - reported to parent
+        results.put(f"{type(exc).__name__}: {exc}")
+    else:
+        results.put("")
 
 
 def test_grant_download_refuses_an_absent_digest(tmp_path):
@@ -64,3 +96,45 @@ def test_grant_download_signature_requires_the_digest(tmp_path):
         "expected_digest must have no default — a defaulted digest is how a "
         "call site silently opts out of verification"
     )
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="cross-process race is POSIX-only")
+def test_two_processes_finalize_one_grant_download_without_sharing_a_temp(
+    tmp_path, monkeypatch,
+):
+    """pgw#938: two G children may receive the same residency broadcast.
+
+    Both processes enter the real download/verify/fsync/replace path together.
+    Their transfer client records the target it was handed; a fixed
+    ``dest.tmp`` deterministically fails the distinct-path assertion even when
+    scheduling happens to hide the FileNotFoundError race.
+    """
+    ctx = multiprocessing.get_context("fork")
+    barrier = ctx.Barrier(2)
+    paths = ctx.Queue()
+    results = ctx.Queue()
+    data = b"pgw938-concurrent-grant-download" * 1024
+    digest = "sha256:" + hashlib.sha256(data).hexdigest()
+    monkeypatch.setattr(
+        s3_transfer, "_s3_client", lambda _grant: _BarrierClient(barrier, paths, data)
+    )
+    dest = tmp_path / "blob.bin"
+    procs = [
+        ctx.Process(
+            target=_concurrent_download,
+            args=(_grant(), dest, digest, len(data), results),
+        )
+        for _ in range(2)
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(30.0)
+        assert proc.exitcode == 0
+
+    errors = [results.get(timeout=2.0) for _ in procs]
+    assert errors == ["", ""]
+    writer_paths = [paths.get(timeout=2.0) for _ in procs]
+    assert len(set(writer_paths)) == 2, writer_paths
+    assert dest.read_bytes() == data
+    assert not list(tmp_path.glob(".blob.bin.*.tmp"))

--- a/tests/test_group_spawn_pgw783.py
+++ b/tests/test_group_spawn_pgw783.py
@@ -16,7 +16,6 @@ CPU-only, so it boots identically with or without CUDA visibility.
 from __future__ import annotations
 
 import os
-import signal
 import sys
 import threading
 import time
@@ -35,7 +34,7 @@ from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
 from gen_worker.procsplit.parent import DEATH_LABEL, ParentControl
 from gen_worker.topology import ExecutionTopology
 
-from harness.hub_double import FakeScheduler, is_ready, is_result_for
+from harness.hub_double import FakeScheduler, is_accept_for, is_ready, is_result_for
 
 TESTS_DIR = Path(__file__).resolve().parent
 SRC_DIR = TESTS_DIR.parent / "src"
@@ -115,9 +114,15 @@ def _isolated_postmortem(tmp_path, monkeypatch):
     from gen_worker import postmortem
 
     d = _postmortem_dir(tmp_path)
-    monkeypatch.setattr(postmortem, "INFLIGHT_PATH", d / "inflight.json")
-    monkeypatch.setattr(postmortem, "CRASH_REGISTRY_PATH", d / "crash.json")
-    monkeypatch.setattr(postmortem, "FAULT_DUMP_PATH", d / "fault.txt")
+    monkeypatch.setattr(
+        postmortem, "INFLIGHT_PATH", d / "gen-worker-inflight.json"
+    )
+    monkeypatch.setattr(
+        postmortem, "CRASH_REGISTRY_PATH", d / "gen-worker-crash-streaks.json"
+    )
+    monkeypatch.setattr(
+        postmortem, "FAULT_DUMP_PATH", d / "gen-worker-fault-dump.txt"
+    )
     return d
 
 
@@ -175,7 +180,9 @@ def test_two_children_boot_and_each_group_serves_its_own_dispatch(g2):
     assert g2.alive and g2.exit_code is None
 
 
-def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(g2):
+def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(
+    g2, _dials, tmp_path,
+):
     """A group where one of the children dies is not a dead group: only the dead
     child's in-flight job is attributed, only its group respawns, and the sibling
     group serves throughout — the pgw#783 failure model on real processes."""
@@ -184,18 +191,53 @@ def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(g2)
 
     slot1_pid_before = g2.pc._slots[1].proc.pid
 
-    # Kill group 0's child with a job that SIGKILLs its own process.
+    # Keep a real request open in g1 while g0 dies.  Its marker is the exact
+    # cross-process evidence pgw#938 found the shared path could unlink.
     conn.send(run_job=pb.RunJob(
-        request_id="r-die-g0", attempt=1, function_name="die-hard",
+        request_id="r-sleep-g1", attempt=1, function_name="sleepy",
+        input_payload=_payload(), compute=pb.ResolvedCompute(gpu_index=1)))
+    conn.wait_for(is_accept_for("r-sleep-g1"), timeout=30.0)
+    g1_marker = _postmortem_dir(tmp_path) / "g1" / "gen-worker-inflight.json"
+    deadline = time.monotonic() + 10.0
+    while not g1_marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert g1_marker.exists(), "g1 never published its per-group in-flight marker"
+
+    # Kill group 0 below Python while group 1's request and fault-dump file are
+    # live.  The parent must consume only g0's one-writer evidence.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-die-g0", attempt=1, function_name="segfault",
         input_payload=_payload(), compute=pb.ResolvedCompute(gpu_index=0)))
     died = conn.wait_for(is_result_for("r-die-g0"), timeout=60.0)
     assert died.job_result.status == pb.JOB_STATUS_FATAL
     assert DEATH_LABEL in died.job_result.safe_message
-    assert "function=die-hard" in died.job_result.safe_message
+    assert "function=segfault" in died.job_result.safe_message
+
+    deadline = time.monotonic() + 10.0
+    while not any('"group": 0' in d for d in _dials) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    g0_dials = [d for d in _dials if '"group": 0' in d]
+    assert g0_dials, "group-0 death produced no typed post-mortem dial"
+    assert any(
+        '"function": "segfault"' in d
+        and "r-die-g0" in d
+        and "fault_dump_tail" in d
+        and "procsplit_endpoints.py" in d
+        for d in g0_dials
+    )
+    assert all("r-sleep-g1" not in d for d in g0_dials), (
+        "group 0 was attributed to group 1's live request"
+    )
+    assert g1_marker.exists() and "r-sleep-g1" in g1_marker.read_text(), (
+        "reaping group 0 destroyed group 1's live marker"
+    )
 
     # The sibling group (g1) never died — same process — and still serves.
     assert g2.pc._slots[1].proc is not None
     assert g2.pc._slots[1].proc.pid == slot1_pid_before, "sibling group was disturbed"
+    conn.send(cancel_job=pb.CancelJob(request_id="r-sleep-g1", attempt=1))
+    slept = conn.wait_for(is_result_for("r-sleep-g1"), timeout=30.0)
+    assert slept.job_result.status == pb.JOB_STATUS_CANCELED
     conn.send(run_job=pb.RunJob(
         request_id="r-g1-after", attempt=1, function_name="whoami",
         input_payload=_payload(), compute=pb.ResolvedCompute(gpu_index=1)))

--- a/tests/test_group_spawn_pgw783.py
+++ b/tests/test_group_spawn_pgw783.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import os
 import sys
 import threading
-import time
 from concurrent import futures
 from pathlib import Path
 from typing import Optional
@@ -35,6 +34,7 @@ from gen_worker.procsplit.parent import DEATH_LABEL, ParentControl
 from gen_worker.topology import ExecutionTopology
 
 from harness.hub_double import FakeScheduler, is_accept_for, is_ready, is_result_for
+from harness.progress_wait import Cadence, await_count, await_progress
 
 TESTS_DIR = Path(__file__).resolve().parent
 SRC_DIR = TESTS_DIR.parent / "src"
@@ -198,9 +198,13 @@ def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(
         input_payload=_payload(), compute=pb.ResolvedCompute(gpu_index=1)))
     conn.wait_for(is_accept_for("r-sleep-g1"), timeout=30.0)
     g1_marker = _postmortem_dir(tmp_path) / "g1" / "gen-worker-inflight.json"
-    deadline = time.monotonic() + 10.0
-    while not g1_marker.exists() and time.monotonic() < deadline:
-        time.sleep(0.02)
+    await_progress(
+        g1_marker.exists,
+        lambda exists: exists,
+        what="g1 per-group in-flight marker",
+        cadence=Cadence(),
+        gone=lambda: None if g2.alive else f"parent exited {g2.exit_code}",
+    )
     assert g1_marker.exists(), "g1 never published its per-group in-flight marker"
 
     # Kill group 0 below Python while group 1's request and fault-dump file are
@@ -213,9 +217,13 @@ def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(
     assert DEATH_LABEL in died.job_result.safe_message
     assert "function=segfault" in died.job_result.safe_message
 
-    deadline = time.monotonic() + 10.0
-    while not any('"group": 0' in d for d in _dials) and time.monotonic() < deadline:
-        time.sleep(0.02)
+    await_count(
+        lambda: sum('"group": 0' in d for d in _dials),
+        1,
+        what="group-0 post-mortem dials",
+        cadence=Cadence(),
+        gone=lambda: None if g2.alive else f"parent exited {g2.exit_code}",
+    )
     g0_dials = [d for d in _dials if '"group": 0' in d]
     assert g0_dials, "group-0 death produced no typed post-mortem dial"
     assert any(

--- a/tests/test_gw640_postmortem.py
+++ b/tests/test_gw640_postmortem.py
@@ -113,6 +113,43 @@ def test_previous_container_death_is_reported_on_next_boot(tmp_path):
     assert not record.exists()
 
 
+def test_previous_container_death_aggregates_every_group_marker(
+    tmp_path, monkeypatch,
+):
+    """Per-group files must not erase whole-container post-mortem coverage."""
+    from gen_worker import postmortem
+
+    record = tmp_path / "boot.json"
+    record.write_text(json.dumps({
+        "pid": 4242, "boot_unix": 1.0, "oom_kill_at_boot": 0,
+    }))
+    monkeypatch.setattr(
+        postmortem, "CRASH_REGISTRY_PATH", tmp_path / "crash-streaks.json"
+    )
+    for ordinal, function in enumerate(("image", "video")):
+        group_dir = tmp_path / f"g{ordinal}"
+        group_dir.mkdir()
+        (group_dir / "gen-worker-inflight.json").write_text(json.dumps({
+            "active": [{
+                "kind": "request", "function": function,
+                "request_id": f"r-{ordinal}", "pid": 100 + ordinal,
+            }],
+        }))
+        (group_dir / "gen-worker-fault-dump.txt").write_text(
+            f"fault-tail-g{ordinal}"
+        )
+
+    detail = postmortem.previous_boot_detail(record)
+    assert detail is not None
+    assert all(value in detail for value in (
+        '"function": "image"', '"function": "video"',
+        "fault-tail-g0", "fault-tail-g1",
+    ))
+    assert not list(tmp_path.glob("g*/gen-worker-inflight.json"))
+    streaks = postmortem.native_crash_streaks()
+    assert streaks["image"]["count"] == streaks["video"]["count"] == 1
+
+
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX only")
 def test_sigterm_is_forwarded_to_the_worker(tmp_path):
     """Drain must still work: PID 1 is the supervisor, the worker is the child."""


### PR DESCRIPTION
## What changed

- give each G>1 compute child one-writer `g<ordinal>/` in-flight and fault-dump files
- make per-slot death attribution consume only that slot's files, while whole-worker/container death aggregates every group
- keep the crash-streak registry pod-wide, preserving worker-level refusal semantics
- finalize concurrent grant downloads through writer-unique same-directory temporary files
- add real two-child/process regression coverage and an Unreleased changelog entry

## Why

All compute children previously replaced or truncated the same transient files. A child death could therefore be attributed to a sibling's function, and per-slot cleanup could delete a live sibling's marker. Concurrent grant downloads had the same fixed-temp finalization race.

## Observable behavior

The G=2 integration test holds `r-sleep-g1` open in group 1 while group 0 segfaults. The emitted group-0 dial contains only `segfault` / `r-die-g0` plus its native stack; group 1's marker and PID survive and complete after cancellation. A whole-container regression proves both group records are aggregated. A two-process transfer regression proves the writers receive distinct temp paths and both finalize the same verified destination.

## Audit corrections

- The issue grouped `parent.py:2323` and `supervisor.py:200/237` with per-slot cleanup, but those sites run before children start or after the whole worker exits. They must aggregate/clear every group; only `_ChildSlot` death is slot-scoped.
- The crash-streak registry must remain worker-wide. Splitting it per group would weaken the existing native-crash refusal gate, so only transient evidence is partitioned.

## Validation

- rebased onto `dev` merge `b223825b`
- `46 passed in 35.13s`: timeout guard, grant finalization, native-crash streaks, whole-worker aggregation, and real G=2 spawn/death coverage
- broader G=1 procsplit/supervisor/security regression: `53 passed in 244.17s`
- Ruff clean on all changed Python files
- mypy clean on the four changed source modules
- `git diff --check` clean
- final-head CI: https://github.com/cozy-creator/python-gen-worker/actions/runs/30805843458

No model inference, model weights, GPU smoke test, or stack lifecycle action was used.