### PR TITLE
Align lane execution support with Tensorhub

### DIFF
--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -120,7 +120,7 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
         "--lane", dest="lane", default="",
         help=(
             "Execution lane (th#913 dual-form): a family 'bf16'|'fp8', or a "
-            "full descriptor like 'fp8-w8a8-dynamic+eager'. Default: auto "
+            "full descriptor like 'fp8-w8a8-dynamic+compiled'. Default: auto "
             "(the binding as declared). 'fp8' maps to the local cast lane; "
             "'fp8-w8a8*' folds the #fp8-w8a8 flavor (must be published); "
             "4bit lanes need an explicit ref#flavor instead."

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5262,9 +5262,9 @@ class Executor:
     def _served_lane(self, spec: EndpointSpec, instructed: str = "") -> str:
         """The CONCRETE lane this spec's instance executes as, for
         JobMetrics.lane and ctx.lane reporting: the most-quantized pipeline
-        binding's lane (table rank), execution axis from the record's live
-        compile state. A declared (handles=) instructed lane wins outright —
-        the author's kernels execute it regardless of binding surgery."""
+        binding's lane (table rank), with live compile state as a preference.
+        Fixed-mode bodies override it; a declared (handles=) instruction owns
+        the full lane outright."""
         from .models import lanes as lanespec
 
         compiled = False

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5065,21 +5065,11 @@ class Executor:
             return spec
         # th#1050: a lane the endpoint DECLARES (handles=) is served by the
         # author's own code branching on ctx.lane — satisfiable with no
-        # laddered rebind (custom loaders/kernels have nothing to rebind),
-        # and exempt from the platform-kernel compiled-only rule.
+        # laddered rebind (custom loaders/kernels have nothing to rebind).
         declared_lane = (
             req.lane is not None
             and lanespec.lane_body_id(req.lane) in getattr(spec, "handles", ())
         )
-        if not declared_lane and (
-                req.lane is not None and req.lane.weights == lanespec.WEIGHTS_FP8
-                and req.lane.activation == lanespec.ACT_W8A8
-                and req.lane.execution == lanespec.EXEC_EAGER):
-            # gw#586: w8a8 serves compiled-only; an eager w8a8 request would
-            # resurrect the silent-eager hole.
-            raise lanespec.LaneUnavailableError(
-                raw, "fp8-w8a8 serves compiled-only on this fleet")
-
         def pick_lane_of(pick: "Optional[Tuple[Any, ...]]") -> "Optional[Any]":
             if pick is None or not pick[2]:
                 return None
@@ -5286,8 +5276,7 @@ class Executor:
                     for t in rec.compile_targets.values())
         handled = self._handled_lane_body(spec, instructed)
         if handled:
-            exec_axis = lanespec.EXEC_COMPILED if compiled else lanespec.EXEC_EAGER
-            return f"{handled}+{exec_axis}"
+            return lanespec.lane_id(lanespec.parse_lane(instructed))
         # Report the most-quantized binding's lane: quantized lanes always
         # outrank bf16 (a bf16 VAE riding a w8a16 pipeline is still the
         # w8a16 lane), ties by table rank.

--- a/src/gen_worker/models/lanes.py
+++ b/src/gen_worker/models/lanes.py
@@ -61,27 +61,68 @@ def family_of(lane: Lane) -> str:
     return ""
 
 
-# THE lane table's (weights, activation, scale) rows, ranked best-first.
-_KNOWN_BODIES: tuple[tuple[str, str, str], ...] = (
-    (WEIGHTS_FP8, ACT_W8A8, SCALE_DYNAMIC),
-    (WEIGHTS_NVFP4, ACT_W4A4, SCALE_STATIC),
-    (WEIGHTS_SVDQ_FP4, ACT_W4A4, ""),
-    (WEIGHTS_SVDQ_INT4, ACT_W4A4, ""),
-    (WEIGHTS_BF16, ACT_W16A16, ""),
-    (WEIGHTS_FP8, ACT_W8A16, ""),
+_EXECUTION_EITHER = "either"
+
+
+class _LaneBody(msgspec.Struct, frozen=True, kw_only=True):
+    weights: str
+    activation: str
+    execution_support: str
+    scale: str = ""
+
+
+# THE lane table's rows, ranked best-first. Execution support is authoritative:
+# lane enumeration, validation, and binding resolution all read this one field.
+_KNOWN_BODIES: tuple[_LaneBody, ...] = (
+    # Eager w8a8 has not been measured; keep Tensorhub's compiled-only answer.
+    _LaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A8,
+              scale=SCALE_DYNAMIC, execution_support=EXEC_COMPILED),
+    # Eager nvfp4 has not been measured; keep Tensorhub's compiled-only answer.
+    _LaneBody(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
+              scale=SCALE_STATIC, execution_support=EXEC_COMPILED),
+    _LaneBody(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4,
+              execution_support=EXEC_EAGER),
+    _LaneBody(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4,
+              execution_support=EXEC_EAGER),
+    _LaneBody(weights=WEIGHTS_BF16, activation=ACT_W16A16,
+              execution_support=_EXECUTION_EITHER),
+    _LaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A16,
+              execution_support=_EXECUTION_EITHER),
 )
 
-# Engines that never run under torch.compile wrapping (nunchaku kernels).
-_EAGER_ONLY_WEIGHTS = frozenset({WEIGHTS_SVDQ_FP4, WEIGHTS_SVDQ_INT4})
+
+def _supports(body: _LaneBody, execution: str) -> bool:
+    return body.execution_support == _EXECUTION_EITHER or body.execution_support == execution
+
+
+def _body_for_lane(lane: Lane) -> Optional[_LaneBody]:
+    for body in _KNOWN_BODIES:
+        if (
+            body.weights == lane.weights
+            and body.activation == lane.activation
+            and body.scale == lane.scale
+        ):
+            return body
+    return None
+
+
+def _lane_for_body(body: _LaneBody, execution: str) -> Lane:
+    return Lane(
+        weights=body.weights,
+        activation=body.activation,
+        scale=body.scale,
+        execution=execution,
+    )
 
 
 def known_lanes() -> list[str]:
     """Every concrete lane id, ranked (table order, compiled before eager)."""
     out: list[str] = []
-    for weights, act, scale in _KNOWN_BODIES:
-        if weights not in _EAGER_ONLY_WEIGHTS:
-            out.append(lane_id(Lane(weights=weights, activation=act, scale=scale, execution=EXEC_COMPILED)))
-        out.append(lane_id(Lane(weights=weights, activation=act, scale=scale, execution=EXEC_EAGER)))
+    for body in _KNOWN_BODIES:
+        if _supports(body, EXEC_COMPILED):
+            out.append(lane_id(_lane_for_body(body, EXEC_COMPILED)))
+        if _supports(body, EXEC_EAGER):
+            out.append(lane_id(_lane_for_body(body, EXEC_EAGER)))
     return out
 
 
@@ -98,17 +139,16 @@ def known_lane_bodies() -> list[str]:
     valid `handles=` declaration tokens (th#1050) — execution axis excluded:
     author kernels declare the quant scheme, the platform owns eager/compiled."""
     return [
-        lane_body_id(Lane(weights=w, activation=a, scale=s, execution=EXEC_EAGER))
-        for w, a, s in _KNOWN_BODIES
+        lane_body_id(_lane_for_body(body, EXEC_EAGER))
+        for body in _KNOWN_BODIES
     ]
 
 
 def valid_lane(lane: Lane) -> bool:
     if lane.execution not in (EXEC_EAGER, EXEC_COMPILED):
         return False
-    if lane.execution == EXEC_COMPILED and lane.weights in _EAGER_ONLY_WEIGHTS:
-        return False
-    return (lane.weights, lane.activation, lane.scale) in _KNOWN_BODIES
+    body = _body_for_lane(lane)
+    return body is not None and _supports(body, lane.execution)
 
 
 def parse_lane(s: str) -> Lane:
@@ -170,6 +210,19 @@ def is_w8a8_flavor(token: str) -> bool:
     return t == "fp8-w8a8" or t.startswith("fp8-w8a8-")
 
 
+def _with_supported_execution(lane: Lane, compiled: bool) -> Lane:
+    execution = EXEC_COMPILED if compiled else EXEC_EAGER
+    body = _body_for_lane(lane)
+    if body is not None and not _supports(body, execution):
+        execution = EXEC_COMPILED if _supports(body, EXEC_COMPILED) else EXEC_EAGER
+    return Lane(
+        weights=lane.weights,
+        activation=lane.activation,
+        scale=lane.scale,
+        execution=execution,
+    )
+
+
 def lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> Lane:
     """The concrete lane a (flavor, cast/storage_dtype) binding executes as —
     the twin of tensorhub's ``LaneOfResolution``."""
@@ -182,23 +235,24 @@ def lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> Lane:
         classify_flavor_token,
     )
 
-    execution = EXEC_COMPILED if compiled else EXEC_EAGER
     if str(storage_dtype or "").strip().lower() in ("fp8", "fp8+te"):
-        return Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution=execution)
-    cls = classify_flavor_token(flavor)
-    if cls == CLASS_FP8:
+        lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
+    elif (cls := classify_flavor_token(flavor)) == CLASS_FP8:
         if is_w8a8_flavor(flavor):
-            return Lane(weights=WEIGHTS_FP8, activation=ACT_W8A8,
-                        scale=SCALE_DYNAMIC, execution=execution)
-        return Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution=execution)
-    if cls == CLASS_SVDQ_FP4:
-        return Lane(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4, execution=EXEC_EAGER)
-    if cls == CLASS_SVDQ_INT4:
-        return Lane(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4, execution=EXEC_EAGER)
-    if cls == CLASS_NVFP4_W4A4:
-        return Lane(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
-                    scale=SCALE_STATIC, execution=execution)
-    return Lane(weights=WEIGHTS_BF16, activation=ACT_W16A16, execution=execution)
+            lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A8,
+                        scale=SCALE_DYNAMIC, execution="")
+        else:
+            lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
+    elif cls == CLASS_SVDQ_FP4:
+        lane = Lane(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4, execution="")
+    elif cls == CLASS_SVDQ_INT4:
+        lane = Lane(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4, execution="")
+    elif cls == CLASS_NVFP4_W4A4:
+        lane = Lane(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
+                    scale=SCALE_STATIC, execution="")
+    else:
+        lane = Lane(weights=WEIGHTS_BF16, activation=ACT_W16A16, execution="")
+    return _with_supported_execution(lane, compiled)
 
 
 class LaneUnavailableError(ValueError):

--- a/tests/test_declared_lane_th1050.py
+++ b/tests/test_declared_lane_th1050.py
@@ -49,14 +49,14 @@ def test_declared_lane_executes_and_ctx_lane_reports_it() -> None:
         conn.wait_for(is_ready)
         conn.send(run_job=pb.RunJob(
             request_id="r-lane", attempt=1, function_name="lane-echo",
-            input_payload=_payload(), lane="fp8-w8a8-dynamic+eager"))
+            input_payload=_payload(), lane="fp8-w8a8-dynamic+compiled"))
         res = conn.wait_for(is_result_for("r-lane")).job_result
         assert res.status == pb.JOB_STATUS_OK, res.safe_message
         body = _decode(res)
         # ctx.lane carried the executing lane into the author branch...
-        assert body["response"] == "author-kernel:fp8-w8a8-dynamic+eager"
+        assert body["response"] == "author-kernel:fp8-w8a8-dynamic+compiled"
         # ...and JobMetrics.lane reports the SAME executing truth.
-        assert res.metrics.lane == "fp8-w8a8-dynamic+eager"
+        assert res.metrics.lane == "fp8-w8a8-dynamic+compiled"
 
 
 def test_undeclared_dispatch_is_todays_behavior() -> None:
@@ -78,7 +78,7 @@ def test_unhandled_lane_still_refuses_typed() -> None:
         conn.wait_for(is_ready)
         conn.send(run_job=pb.RunJob(
             request_id="r-nope", attempt=1, function_name="lane-echo",
-            input_payload=_payload(), lane="nvfp4-w4a4-static+eager"))
+            input_payload=_payload(), lane="nvfp4-w4a4-static+compiled"))
         res = conn.wait_for(is_result_for("r-nope")).job_result
         assert res.status == pb.JOB_STATUS_INVALID
         assert "lane_unavailable" in res.safe_message

--- a/tests/test_lane_instruction_gw596.py
+++ b/tests/test_lane_instruction_gw596.py
@@ -7,7 +7,7 @@ apply_model_resolutions), never mocks of them:
      instance stays resident (gw#551 cycling) while the bf16 variant loads.
   2. RunJob.lane="fp8-w8a8-dynamic+compiled" keeps the pick.
   3. A w8a8 request with no w8a8 pick refuses TYPED, naming the lane.
-  4. "fp8-w8a8-dynamic+eager" refuses (w8a8 is compiled-only).
+  4. "fp8-w8a8-dynamic+eager" is outside the shared lane vocabulary.
   5. Family "fp8" without a stored pick expands to the local cast lane.
   6. An unknown lane string is a ValidationError (INVALID), not a crash.
   7. JobMetrics.lane reports the CONCRETE serving lane.
@@ -106,9 +106,8 @@ def test_w8a8_without_pick_refuses_typed() -> None:
 def test_w8a8_eager_refuses() -> None:
     ex = _executor()
     _with_w8a8_pick(ex)
-    with pytest.raises(LaneUnavailableError) as e:
+    with pytest.raises(ValidationError, match="not a known lane"):
         ex._lane_effective_spec(ex.specs["generate"], "fp8-w8a8-dynamic+eager")
-    assert "compiled-only" in str(e.value)
 
 
 def test_fp8_family_without_stored_pick_expands_to_cast_lane() -> None:
@@ -157,7 +156,7 @@ def test_served_lane_reports_concrete_lane() -> None:
     assert ex._served_lane(spec) == "bf16-w16a16+eager"
     # w8a8 pick applied: the pipeline's lane wins over the bf16 vae.
     _with_w8a8_pick(ex)
-    assert ex._served_lane(ex.specs["generate"]) == "fp8-w8a8-dynamic+eager"
+    assert ex._served_lane(ex.specs["generate"]) == "fp8-w8a8-dynamic+compiled"
     # cast pick: w8a16.
     ex.apply_model_resolutions({BASE: (BASE, "fp8", "fp8-w8a16+eager")})
     assert ex._served_lane(ex.specs["generate"]) == "fp8-w8a16+eager"

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -71,3 +71,21 @@ def test_parse_lane_spec_dual_form() -> None:
 ])
 def test_lane_of_binding(flavor: str, storage: str, compiled: bool, want: str) -> None:
     assert lanes.lane_id(lanes.lane_of_binding(flavor, storage, compiled)) == want
+
+
+def test_lane_of_binding_covers_every_body_with_valid_execution() -> None:
+    inputs = [
+        ("", ""),
+        ("", "fp8"),
+        ("fp8-w8a8", ""),
+        ("svdq-fp4-r128", ""),
+        ("svdq-int4-r128", ""),
+        ("nvfp4-w4a4", ""),
+    ]
+    bodies = set()
+    for flavor, storage in inputs:
+        for compiled in (False, True):
+            lane = lanes.lane_of_binding(flavor, storage, compiled)
+            assert lanes.valid_lane(lane)
+            bodies.add(lanes.lane_body_id(lane))
+    assert bodies == set(lanes.known_lane_bodies())

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -12,9 +12,7 @@ from gen_worker.models import lanes
 def test_known_lanes_stable() -> None:
     assert lanes.known_lanes() == [
         "fp8-w8a8-dynamic+compiled",
-        "fp8-w8a8-dynamic+eager",
         "nvfp4-w4a4-static+compiled",
-        "nvfp4-w4a4-static+eager",
         "svdq-fp4-w4a4+eager",
         "svdq-int4-w4a4+eager",
         "bf16-w16a16+compiled",
@@ -25,16 +23,19 @@ def test_known_lanes_stable() -> None:
 
 
 def test_parse_lane_round_trip() -> None:
-    for lane_id in lanes.known_lanes():
-        assert lanes.lane_id(lanes.parse_lane(lane_id)) == lane_id
+    parsed = [lanes.parse_lane(lane_id) for lane_id in lanes.known_lanes()]
+    assert [lanes.lane_id(lane) for lane in parsed] == lanes.known_lanes()
+    assert {lanes.lane_body_id(lane) for lane in parsed} == set(lanes.known_lane_bodies())
 
 
 @pytest.mark.parametrize("bad", [
     "", "bf16", "fp8", "4bit",
     "fp8-w8a8-dynamic",
+    "fp8-w8a8-dynamic+eager",
     "fp8-w8a8+turbo",
     "fp8-w4a4-dynamic+compiled",
     "svdq-fp4-w4a4+compiled",
+    "nvfp4-w4a4-static+eager",
     "int8-w8a8+eager",
 ])
 def test_parse_lane_rejects(bad: str) -> None:
@@ -62,10 +63,11 @@ def test_parse_lane_spec_dual_form() -> None:
     ("", "fp8", False, "fp8-w8a16+eager"),
     ("fp8", "", True, "fp8-w8a16+compiled"),
     ("fp8-w8a8", "", True, "fp8-w8a8-dynamic+compiled"),
-    ("fp8-w8a8-cal1", "", False, "fp8-w8a8-dynamic+eager"),
+    ("fp8-w8a8-cal1", "", False, "fp8-w8a8-dynamic+compiled"),
     ("svdq-fp4-r128", "", True, "svdq-fp4-w4a4+eager"),
     ("svdq-int4-r128", "", False, "svdq-int4-w4a4+eager"),
     ("nvfp4-w4a4", "", True, "nvfp4-w4a4-static+compiled"),
+    ("nvfp4-w4a4", "", False, "nvfp4-w4a4-static+compiled"),
 ])
 def test_lane_of_binding(flavor: str, storage: str, compiled: bool, want: str) -> None:
     assert lanes.lane_id(lanes.lane_of_binding(flavor, storage, compiled)) == want


### PR DESCRIPTION
## What changed

- add one `execution_support` field (`eager`, `compiled`, or `either`) to the authoritative lane-body table
- make lane enumeration, validation, and binding resolution read that field
- delete `_EAGER_ONLY_WEIGHTS` and the executor's duplicate w8a8 compiled-only predicate
- keep declared-lane reporting on the canonical instructed descriptor instead of re-deriving its execution axis
- pin the worker vocabulary to Tensorhub's current table: w8a8/nvfp4 compiled-only, SVDQ eager-only, and bf16/w8a16 either

## Why

Tensorhub PR #709 made execution support a property of each lane body, but the Python twin still derived it from weight names and advertised eager w8a8/nvfp4 spellings Tensorhub rejects. That left the shared vocabulary divergent and allowed independent predicates to disagree again.

This is vocabulary parity only. It records no new GPU measurement and deliberately preserves Tensorhub's current unmeasured w8a8/nvfp4 answers.

## Validation

- 68 lane/precision tests passed across `test_lanes`, lane instruction/declaration, determinism, pipeline identity, mandatory-lane, resolution-apply, quantization, and shared-precision suites
- `ruff check` passed for all changed production modules
- `git diff --check` passed
