### PR TITLE
pgw#864 make kernel compile proof weak-proxy safe

### DIFF
--- a/tests/test_svdq_awq_packed_pgw864.py
+++ b/tests/test_svdq_awq_packed_pgw864.py
@@ -89,9 +89,17 @@ def test_awq_kernel_compiles_for_blackwell() -> None:
     assert pk.awq_op() is not None
     fn = None
     for obj in gc.get_objects():
-        if isinstance(obj, Autotuner) and getattr(
-                obj.fn, "__name__", "") == "_awq_mm_kernel":
-            fn = obj.fn
+        try:
+            if not isinstance(obj, Autotuner):
+                continue
+            candidate = obj.fn
+            if getattr(candidate, "__name__", "") == "_awq_mm_kernel":
+                fn = candidate
+                break
+        except ReferenceError:
+            # gc.get_objects() can contain an expired weak proxy. It is not a
+            # kernel candidate, and dereferencing it must not flake this proof.
+            continue
     assert fn is not None
     src = ASTSource(
         fn=fn,


### PR DESCRIPTION
## What changed

The box-side pgw#864 kernel compile proof now skips expired weak proxies returned by `gc.get_objects()`. It still requires finding `_awq_mm_kernel` and compiling it for both Blackwell targets.

## Why

PR #428's final-head CI run reached 2,937 passing tests and failed only because the unchanged pgw#864 test dereferenced `obj.fn` after a GC weak proxy expired:

https://github.com/cozy-creator/python-gen-worker/actions/runs/30801609485

The lookup now reads `obj.fn` once inside a `ReferenceError` boundary and stops once the named kernel is found.

## Validation

- `test_awq_kernel_compiles_for_blackwell`: 1 passed in 9.84s on the real CPU/Triton compile path
- Ruff clean
- `git diff --check` clean

No model inference, model weights, GPU smoke test, or stack lifecycle action was used.