### PR TITLE
pgw#937 a dead group's last frame no longer outvotes the live ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 - **pgw#938:** isolate transient post-mortem evidence per compute group and make
   concurrent grant downloads finalize through writer-unique temporary files.
+- **pgw#937: a dead execution group's last frame no longer outvotes the live ones.** The
+  parent's per-group fan-in state (`_group_activities`, `_group_fn_unavail`,
+  `_group_fn_degraded`, `slot.last_state_delta`) is now GENERATION-SCOPED and gated on a
+  liveness predicate. The ruling, written where `parent.py` already claimed it in prose: **a
+  group without a live child is not a participant, and its facts are UNKNOWN — neither "still
+  true" nor the live-group default — so its identity element is EXCLUSION from every merge.**
+  A bare `.pop()` would have been worse than the leak, because absence-of-a-value already means
+  "this group serves it". Fixes: an activity pinned RUNNING forever, a dead group vetoing a live
+  group's `self_stalled` confession, a natively-served function retired worker-wide, a down
+  group's functions and free VRAM still advertised, and the parent's dispatch-time observations
+  orphaned by the death path (which silently stopped billing attestation on a crash-looping
+  pod). The death path now EMITS the consequences — a terminal for every activity kind the dead
+  generation held open, plus the recomputed worker StateDelta — so the hub learns the capacity
+  dropped instead of inferring it from an update that stopped arriving. G == 1 is untouched by
+  construction.
 
 ## 0.91.0 (2026-08-02) — **the native kernel lane lands dormant** (pgw#862/pgw#864: env-gated opt-in, OFF by default — no serving path changes until the gate is set), the envelope gains the DEGREE axis (th#1426), an unprovable cell can no longer be declared (th#959), and v2 publish restates classification (th#1411)
 

--- a/src/gen_worker/procsplit/merge.py
+++ b/src/gen_worker/procsplit/merge.py
@@ -75,7 +75,13 @@ def merge_phase(phases: Sequence["pb.WorkerPhase"]) -> "pb.WorkerPhase":
 
 
 def merge_state_deltas(deltas: Sequence[pb.StateDelta]) -> pb.StateDelta:
-    """One worker-level StateDelta from G per-group ones."""
+    """One worker-level StateDelta from G per-group ones.
+
+    ``deltas`` carries only LIVE groups (pgw#937). A down group contributes no
+    function to the union, no free VRAM to the sum, and no vote to the phase
+    min — otherwise the worker keeps advertising a dead group's functions and
+    every dispatch onto it is answered "compute process restarting".
+    """
     if not deltas:
         return pb.StateDelta()
     if len(deltas) == 1:
@@ -213,7 +219,11 @@ def reconcile_activity_kind(
     mint would look like the whole worker's).
 
     ``per_group`` is the latest update of this kind, keyed by group ordinal, for
-    every group that currently has it open. The worker's activity of this kind:
+    every LIVE group that currently has it open. A group whose child is down is
+    not a member — see "down-group semantics" in ``parent.py``: its last frame
+    is a dead process's fact, and leaving it in would pin the kind RUNNING for
+    good and let it outvote every live group's ``self_stalled`` confession
+    below. The worker's activity of this kind:
 
     * is RUNNING while ANY group runs it (the worker IS minting if any group
       is); it is terminal only when EVERY group's latest is terminal, and FAILED
@@ -280,6 +290,15 @@ def worker_fn_unavailable(
     do NOT retire it worker-wide. Only when every group reports it unavailable
     does the worker report unavailable, carrying one representative reason (the
     admin availability view is per-worker, not per-group).
+
+    **THE CONTRACT THE CALLER MUST NOT GET BACKWARDS (pgw#937): a value of
+    ``None`` means "this group SERVES it", so a group whose child is DOWN is
+    EXCLUDED from the mapping — never entered as ``None``.** Popping a dead
+    group's entry without also dropping the group would make the dead group read
+    as serving every function there is, which is strictly worse than the stale
+    entry it replaced. Absence-of-a-value is the live-group default; absence of
+    the *group* is "unknown, because there is nobody there". See "down-group
+    semantics" in ``parent.py``.
     """
     if not per_group:
         return None
@@ -305,7 +324,10 @@ def worker_fn_degraded(
     FnDegraded is placement guidance — "this release runs degraded on this card,
     it wants a bigger one". Under ruling 1 the worker routes a dispatch to a
     group that can serve, so if ANY group serves the function NATIVE the worker
-    is not degraded: report nothing. The worker is degraded only when it serves
+    is not degraded: report nothing. ``served_native_somewhere`` and
+    ``per_group`` are both computed over LIVE groups only (pgw#937): absence
+    means "serves it native" here too, so a down group left in the scan would
+    veto a live group's degradation report. The worker is degraded only when it serves
     the function AND the best any group can do is degraded — then report the
     LEAST degraded of the group reports (the worker's true best), so the hub's
     placement hint reflects the best card the worker actually has for it.

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -151,9 +151,15 @@ _MEASURE_TIMEOUT_S = 180.0
 _MEASURE_BEFORE_SPAWN_S = 60.0
 _ATTESTATION_REPORT_MIN_INTERVAL_S = 300.0
 _CAPABILITY_REPORT_MIN_INTERVAL_S = 300.0
-# Bounded: an observation is dropped when its result passes back, so this only
-# has to survive jobs whose results never arrive (child deaths).
+# Bounded: an observation is dropped when its result passes back OR when the
+# death path attributes its job (pgw#937), so nothing but a live job holds one.
 _OBSERVATION_CAP = 512
+# The WorkerMessage kinds the fan-in reconciles across groups into one worker
+# view. Everything else is per-request or per-object and forwards verbatim.
+# Only a LIVE group may contribute one of these (see "down-group semantics").
+_WORKER_SCOPED_MSGS = frozenset(
+    {"state_delta", "activity_update", "fn_unavailable", "fn_degraded"}
+)
 # pgw#833: the child's stderr is captured by the parent (teed through to the
 # container log unchanged) so a pre-Hello death carries its OWN crash text in
 # the post-mortem dial. RunPod exposes no container-logs API (gw#640), so a
@@ -310,6 +316,19 @@ class _ChildSlot:
         # re-sends the merge of all groups'.
         self.last_state_delta: Optional[pb.WorkerMessage] = None
         self.last_state_delta_at = 0.0
+        # pgw#937 / DESIGN-RULINGS §4.15: a respawn is a NEW GENERATION of this
+        # same group. `generation` counts the incarnations that have spoken; it
+        # is stamped into the retirement dial so a fact attributed to the wrong
+        # incarnation is visible rather than inferred.
+        self.generation = 0
+        # PARTICIPATION is the fan-in's liveness predicate: do this group's
+        # facts count as the worker's? It goes False when an incarnation stops
+        # being able to speak and True again when the next one connects. A group
+        # that has not spoken YET starts True — it has no facts to be wrong
+        # about, and its absence from the dicts is the live-group default. The
+        # defect is only ever a group that HAS spoken and then died. See
+        # "down-group semantics" in the fan-in section.
+        self.participating = True
         self.last_crash_loop_report_at = _NEVER_REPORTED
         # Set once the link read loop has finished (EOF drained), so death
         # attribution never races the child's last frames.
@@ -326,6 +345,16 @@ class _ChildSlot:
     @property
     def label(self) -> str:
         return f"g{self.ordinal}"
+
+    def begin_generation(self) -> None:
+        """A NEW incarnation of this group starts speaking (pgw#937, §4.15).
+
+        It enters the merge with EMPTY fan-in state — the death path retired the
+        previous generation's — so "absent" once again means the live-group
+        default and never a dead incarnation's last frame.
+        """
+        self.generation += 1
+        self.participating = True
 
     # ---- unix socket server (one per group) ------------------------------
 
@@ -368,6 +397,7 @@ class _ChildSlot:
         self.last_frame_at = time.monotonic()
         self.link_closed.clear()
         self.link_ready.set()
+        self.begin_generation()
         logger.info("compute child %s connected on %s", self.label, self.socket_path)
         # pgw#783: at G>1 a RESPAWNED child (not the first boot) comes up empty
         # and needs the hub to re-drive its desired residency. The death path
@@ -395,6 +425,13 @@ class _ChildSlot:
             if self.link is link:
                 self.link = None
                 self.link_ready.clear()
+                # pgw#937: participation ends the moment this generation stops
+                # being able to speak, not when the OS finally reaps it. A group
+                # the parent already answers RETRYABLE for must not still be
+                # voting in the worker's merged view. (`self.link is link` keeps
+                # a superseded link's teardown from retiring the live one.)
+                self.participating = False
+                self.p._note_state_delta()
             waiter = self.hello_waiter
             if waiter is not None and not waiter.done():
                 waiter.set_exception(ConnectionError("compute child link lost"))
@@ -420,7 +457,10 @@ class _ChildSlot:
                 # delta 3: the billable numbers pass through the one component
                 # that watched this job from outside the process doing it.
                 await self.p._attest_result(r, self)
-            elif which == "state_delta":
+            elif which == "state_delta" and self.participating:
+                # pgw#937: a retired generation's late frame is a dead process's
+                # claim about a worker it has left. Recording it would put the
+                # group back into the merge without a live child behind it.
                 self.last_state_delta = msg
                 self.last_state_delta_at = time.monotonic()
                 self.p._note_state_delta()
@@ -752,6 +792,8 @@ class _ChildSlot:
             self.link = None
             self.link_ready.clear()
             self.link_closed.set()
+        # pgw#937: whatever route got us here, this generation is done speaking.
+        self.participating = False
 
     async def await_exit(self, timeout: float) -> bool:
         """TimeoutStopSec: wait for THIS child to exit, then SIGKILL it."""
@@ -788,6 +830,12 @@ class _ChildSlot:
         try:
             for (rid, att), fn in sorted(died_jobs.items()):
                 self.reported_dead[(rid, att)] = fn
+                # pgw#937: the death path is the OTHER exit from the parent's
+                # dispatch-time observation. `_attest_result` pops it on the
+                # child's JobResult; a job whose child died never produces one,
+                # and 512 orphans FIFO-evict LIVE jobs' observations — which
+                # silently stops billing attestation on a crash-looping pod.
+                self.p._observations.pop((rid, att), None)
                 while len(self.reported_dead) > _REPORTED_DEAD_CAP:
                     self.reported_dead.popitem(last=False)
                 await self.p.transport.send(pb.WorkerMessage(job_result=pb.JobResult(
@@ -873,8 +921,19 @@ class _ChildSlot:
             sorted(r for r, _ in died_jobs) or "none",
         )
 
+        # 1b) pgw#937: RETIRE this generation from the worker view before
+        # anything else ships. Until this runs, the dead child's last frame is
+        # still a vote — it can pin an activity RUNNING, retire a function a
+        # live group serves, and (merge.py's `all(...)`) veto a live group's
+        # `self_stalled` confession, which is the one that costs money.
+        for out in p._retire_group_generation(self):
+            try:
+                await p.transport.send(out)
+            except Exception:
+                logger.debug("retirement message send failed", exc_info=True)
+
         # 2) Post-mortem dial (gw#640 typed exit capture; pgw#676/714 parity).
-        extra: Dict[str, Any] = {"group": self.ordinal}
+        extra: Dict[str, Any] = {"group": self.ordinal, "generation": self.generation}
         if verdict.get("signaled"):
             try:
                 extra.update(postmortem.attribute_signal_death(
@@ -919,8 +978,11 @@ class _ChildSlot:
                 f"phase=compute_crash_loop group={self.ordinal} "
                 f"deaths={len(recent)} window_s={p._start_limit_interval:.0f} "
                 f"deaths_before_hello={self.deaths_before_hello} last_cause={cause} "
-                f"spawns={self.spawn_count} — respawn continues; this group "
-                "advertises no serving capacity while its child is down"
+                f"spawns={self.spawn_count} generation={self.generation} — "
+                "respawn continues; this group advertises no serving capacity "
+                "while its child is down, and contributes no fact to the "
+                "worker's merged view either (pgw#937 down-group semantics: "
+                "a down group is EXCLUDED from the fan-in, not defaulted)"
             )
 
         # 4) Give the live stream a moment to ship the FATALs.
@@ -1677,21 +1739,141 @@ class ParentControl:
         """
 
     # ---- fan-in: N children -> ONE worker view (pgw#783, Paul ruling 2) ----
+    #
+    # DOWN-GROUP SEMANTICS (pgw#937 ruling; the rule `_handle_child_death`'s
+    # crash-loop dial has always claimed in prose and nothing implemented).
+    #
+    # **A group without a live child is not a participant in the worker view,
+    # and its facts are UNKNOWN — which is neither "still true" nor the
+    # live-group default.** Every fan-in structure here is generation-scoped:
+    # it holds what the CURRENT incarnation of that group said, and it is
+    # dropped the moment that incarnation ends (§4.15 — a respawn is a new
+    # generation of the same group, under the same worker session).
+    #
+    # The vocabulary has three states per (group, function/kind), and the bug
+    # class this fixes is the §4.22 one — a *default* being made to carry a
+    # missing *fact*:
+    #
+    #   present entry -> a fact the live incarnation reported
+    #   absent entry  -> the live-group DEFAULT (serves it / no activity open)
+    #   not a member  -> UNKNOWN: this group has no live child
+    #
+    # so the identity element of a down group is **exclusion from the merge**,
+    # in every one of the four aggregations:
+    #
+    #   last_state_delta   -> dropped from `merge_state_deltas`: the group
+    #                         contributes no functions to the union, no free
+    #                         VRAM to the sum, and no vote to the phase min.
+    #   _group_fn_unavail  -> dropped from `worker_fn_unavailable`'s mapping.
+    #                         NOT set to None: None means "this group serves
+    #                         it", so popping alone would make a dead group
+    #                         read as serving EVERYTHING — strictly worse than
+    #                         the stale entry it replaced.
+    #   _group_fn_degraded -> dropped from both the mapping and the
+    #                         `served_native_somewhere` scan, for the same
+    #                         reason (absence there means "serves it native").
+    #   _group_activities  -> dropped from `reconcile_activity_kind`, so a dead
+    #                         group can no longer pin a kind RUNNING or veto a
+    #                         live group's `self_stalled` confession.
+    #
+    # Exclusion is chosen over inserting an explicit "unknown" sentinel because
+    # it carries the same information without teaching four merge functions a
+    # third case and without touching the wire vocabulary.
+    #
+    # A down group is not silently forgotten, though — that would replace one
+    # missing fact with another. `_retire_group_generation` EMITS the
+    # consequences: a terminal for every activity kind the dead generation held
+    # open that no live group still runs, and the recomputed worker StateDelta.
+    # The hub learns the capacity dropped; it never has to infer it from an
+    # update that stopped arriving.
+
+    def _live_slots(self) -> List["_ChildSlot"]:
+        """The groups whose facts are the worker's, i.e. the participating ones."""
+        return [s for s in self._slots if s.participating]
 
     def _note_state_delta(self) -> None:
         """Recompute the worker's freshest StateDelta after a group published.
         At G==1 it IS the child's message (byte-identical beat); at G>1 it is the
-        merge of every group's latest."""
+        merge of every LIVE group's latest."""
         self._last_state_delta_at = time.monotonic()
         if self.execution_groups == 1:
             self._last_state_delta = self._slots[0].last_state_delta
             return
-        deltas = [s.last_state_delta.state_delta for s in self._slots
+        deltas = [s.last_state_delta.state_delta for s in self._live_slots()
                   if s.last_state_delta is not None]
         if deltas:
             self._last_state_delta = pb.WorkerMessage(
                 state_delta=merge.merge_state_deltas(deltas)
             )
+            return
+        # Every group is down. Advertising the last live group's function set
+        # would keep the hub dispatching into `_dispatch_run_job`'s "compute
+        # process restarting" RETRYABLE — on a loop, with no end the hub can
+        # see. The honest worker-level fact is: nothing is served, and the pod
+        # is coming back.
+        self._last_state_delta = pb.WorkerMessage(
+            state_delta=pb.StateDelta(phase=pb.WORKER_PHASE_BOOTING)
+        )
+
+    def _retire_group_generation(self, slot: _ChildSlot) -> List[pb.WorkerMessage]:
+        """This group's child is gone: end its generation's participation.
+
+        Drops every fan-in fact the dead incarnation reported (see "down-group
+        semantics" above) and returns the worker-level messages the hub must
+        receive as a consequence — the terminals for activity kinds only that
+        group had open, then the recomputed worker StateDelta.
+
+        At G==1 the fan-in structures are never populated (`_fan_in` returns the
+        child's message verbatim), so this is a no-op there BY CONSTRUCTION, and
+        the single-child parent stays byte-identical.
+        """
+        if self.execution_groups == 1:
+            return []
+        slot.participating = False
+        slot.last_state_delta = None
+        open_kinds = self._group_activities.pop(slot.ordinal, {})
+        self._group_fn_unavail.pop(slot.ordinal, None)
+        self._group_fn_degraded.pop(slot.ordinal, None)
+
+        out: List[pb.WorkerMessage] = []
+        live_ordinals = {s.ordinal for s in self._live_slots()}
+        for kind in sorted(open_kinds):
+            per_group = {
+                ordinal: kinds[kind]
+                for ordinal, kinds in self._group_activities.items()
+                if kind in kinds and ordinal in live_ordinals
+            }
+            self._activity_seq += 1
+            if per_group:
+                # A live group still runs this kind: re-state the worker's
+                # activity WITHOUT the dead group's progress and without its
+                # vote on `self_stalled`.
+                merged = merge.reconcile_activity_kind(
+                    per_group, seq=self._activity_seq
+                )
+            else:
+                # Nobody runs it any more. It did not complete — the process
+                # doing it died — so the terminal is FAILED, not COMPLETED.
+                merged = pb.ActivityUpdate()
+                merged.CopyFrom(open_kinds[kind])
+                merged.state = pb.ACTIVITY_STATE_FAILED
+                merged.seq = self._activity_seq
+                merged.self_stalled = False
+                merged.stalled_for_ms = 0
+                if not merged.error:
+                    merged.error = "compute process died with this activity open"
+                merged.detail = (
+                    f"{merged.detail + '; ' if merged.detail else ''}"
+                    "the execution group running this activity died "
+                    "(worker alive; the group respawns)"
+                )[:512]
+            out.append(pb.WorkerMessage(activity_update=merged))
+
+        self._note_state_delta()
+        merged_delta = self._last_state_delta
+        if merged_delta is not None:
+            out.append(merged_delta)
+        return out
 
     def _fan_in(
         self, slot: _ChildSlot, msg: pb.WorkerMessage,
@@ -1707,6 +1889,13 @@ class ParentControl:
         if self.execution_groups == 1:
             return msg
         which = msg.WhichOneof("msg")
+        if which in _WORKER_SCOPED_MSGS and not slot.participating:
+            # pgw#937: a retired generation cannot speak for the worker. Its
+            # per-request frames still forward (they are about a job, and the
+            # death path has already attributed the ones it knows about); its
+            # WORKER-scoped claims are a dead process's view of a worker it has
+            # left, and re-recording them would resurrect it into the merge.
+            return None
         if which == "state_delta":
             merged = self._last_state_delta
             return merged if merged is not None else msg
@@ -1728,10 +1917,14 @@ class ParentControl:
             by_kind.pop(act.kind, None)
         else:
             by_kind[act.kind] = act
+        # Only LIVE groups vote. A dead group's last frame must not pin the kind
+        # RUNNING, and must not outvote a live group's `self_stalled` confession
+        # (merge.py's `all(...)`) — pgw#937.
+        live_ordinals = {s.ordinal for s in self._live_slots()}
         per_group = {
             ordinal: kinds[act.kind]
             for ordinal, kinds in self._group_activities.items()
-            if act.kind in kinds
+            if act.kind in kinds and ordinal in live_ordinals
         }
         if not per_group:
             # Every group's activity of this kind is terminal: emit the terminal
@@ -1751,8 +1944,13 @@ class ParentControl:
         fu = msg.fn_unavailable
         by_fn = self._group_fn_unavail.setdefault(slot.ordinal, {})
         by_fn[fu.function_name] = fu
+        # THE CONVENTION, stated at the call site because writing it backwards
+        # is the pgw#937 defect: `merge.worker_fn_unavailable` reads a `None`
+        # value as "this group SERVES the function". So a group is put in the
+        # mapping only while it is live — a down group is EXCLUDED, never
+        # entered as `None`, which would make it read as serving everything.
         per_group: Dict[int, Optional[pb.FnUnavailable]] = {}
-        for s in self._slots:
+        for s in self._live_slots():
             per_group[s.ordinal] = self._group_fn_unavail.get(
                 s.ordinal, {}
             ).get(fu.function_name)
@@ -1768,17 +1966,20 @@ class ParentControl:
         fd = msg.fn_degraded
         by_fn = self._group_fn_degraded.setdefault(slot.ordinal, {})
         by_fn[fd.function_name] = fd
+        live = self._live_slots()
         per_group: Dict[int, Optional[pb.FnDegraded]] = {}
-        for s in self._slots:
+        for s in live:
             per_group[s.ordinal] = self._group_fn_degraded.get(
                 s.ordinal, {}
             ).get(fd.function_name)
         # A group serves this function NATIVE when it reports neither degraded
-        # nor unavailable for it.
+        # nor unavailable for it. Absence means native here too, so a DOWN group
+        # is excluded rather than scanned — otherwise a dead group would veto a
+        # live group's degradation report (pgw#937).
         served_native = any(
             fd.function_name not in self._group_fn_degraded.get(s.ordinal, {})
             and fd.function_name not in self._group_fn_unavail.get(s.ordinal, {})
-            for s in self._slots
+            for s in live
         )
         worker_level = merge.worker_fn_degraded(
             per_group, served_native_somewhere=served_native

--- a/tests/harness/procsplit_endpoints.py
+++ b/tests/harness/procsplit_endpoints.py
@@ -142,6 +142,30 @@ class SplitProbe:
         ctypes.string_at(0)
         return ProbeOut(response="unreachable")
 
+    async def activity_die(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
+        """pgw#937: open a worker ACTIVITY, publish it RUNNING, then SIGKILL
+        this process while it is still open.
+
+        The shape the fan-in gets wrong: the group's last frame says RUNNING
+        forever, so nothing the parent later merges can retire it. The parent
+        must emit the terminal on the group's behalf when it reaps the child.
+        """
+        act = activity.begin(str(data.text or "g_hold"), phase="holding")
+        act.heartbeat()
+        await asyncio.sleep(0.2)
+        os.kill(os.getpid(), signal.SIGKILL)
+        return ProbeOut(response="unreachable")
+
+    async def activity_hold(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
+        """Open the same activity kind and keep it open, beating, until
+        cancelled — the LIVE group whose fact must survive a sibling's death."""
+        act = activity.begin(str(data.text or "g_hold"), phase="holding")
+        for _ in range(600):
+            ctx.raise_if_cancelled()
+            act.heartbeat()
+            await asyncio.sleep(0.1)
+        return ProbeOut(response="held")
+
     def sleepy(self, ctx: RequestContext, data: ProbeIn) -> ProbeOut:
         """Long cancellable job: measures cancel latency across the seam."""
         for _ in range(1200):

--- a/tests/test_fanin_generation_pgw937.py
+++ b/tests/test_fanin_generation_pgw937.py
@@ -1,0 +1,361 @@
+"""pgw#937: a DEAD group's last frame must not outvote the live ones.
+
+The parent's three per-group fan-in dicts (`_group_activities`,
+`_group_fn_unavail`, `_group_fn_degraded`) plus `slot.last_state_delta` are
+GENERATION-SCOPED facts: they say what the CURRENT incarnation of a group
+reported. Before this issue nothing ever cleaned them, and nothing ever asked
+whether the group behind an entry was still alive — so a group that died mid
+activity could pin that activity RUNNING forever, veto a live group's
+`self_stalled` confession, and retire a function a live group was serving.
+
+The ruling this file proves is "down-group semantics" in ``procsplit/parent.py``:
+**a group without a live child is not a participant, and its facts are UNKNOWN
+— which is neither "still true" nor the live-group default.** So the identity
+element of a down group is EXCLUSION from every merge; a bare `.pop()` is not
+the fix, because absence-of-a-value already means "this group serves it" and
+popping alone would make the dead group read as serving everything.
+
+Two layers, both driving production code:
+
+* the RUNTIME rows reuse the real G=2 harness — two real child processes, a
+  real ParentControl, real gRPC to the hub-double — and kill a child while it
+  holds an activity open;
+* the PARENT rows drive `_fan_in`, `_retire_group_generation` and
+  `begin_generation` (the exact functions `_on_child_frame` and
+  `_handle_child_death` call) on a real ParentControl, for the two observables
+  a real child cannot be made to produce on demand: a stall confession and a
+  setup-failure retirement.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import pytest
+
+from gen_worker.config import load_settings
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.procsplit.parent import DEATH_LABEL, ParentControl
+from gen_worker.topology import ExecutionTopology
+
+from harness.hub_double import is_ready, is_result_for
+from test_group_spawn_pgw783 import (  # the real two-process harness
+    BOOT_TIMEOUT_S,
+    G2Harness,
+    _dials,          # noqa: F401  (fixture)
+    _isolated_postmortem,  # noqa: F401  (fixture)
+    _payload,
+)
+
+HOLD_KIND = "g_hold"
+
+
+@pytest.fixture()
+def g2(tmp_path, _dials):  # noqa: F811
+    h = G2Harness(tmp_path)
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+def _activity(kind: str, state: Optional[int] = None) -> Callable[[pb.WorkerMessage], bool]:
+    def pred(m: pb.WorkerMessage) -> bool:
+        if m.WhichOneof("msg") != "activity_update":
+            return False
+        act = m.activity_update
+        return act.kind == kind and (state is None or act.state == state)
+
+    return pred
+
+
+# ---------------------------------------------------------------------------
+# RUNTIME: two real child processes, one of them dies holding an activity open
+# ---------------------------------------------------------------------------
+
+
+def test_a_dead_groups_open_activity_is_terminated_for_the_worker(g2):
+    """Observable A, on real processes.
+
+    g1 opens ``g_hold`` and SIGKILLs itself while it is still RUNNING. Nothing
+    else in the worker ever mentions that kind again, so unless the parent emits
+    the terminal ON THE DEAD GROUP'S BEHALF the hub folds a RUNNING update into
+    ``info.Activities["g_hold"]`` and never receives anything to close it.
+
+    Pre-fix this hangs on the FAILED wait: the only updates for the kind are the
+    dead child's RUNNING ones.
+    """
+    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+
+    conn.send(run_job=pb.RunJob(
+        request_id="r-die-g1", attempt=1, function_name="activity-die",
+        input_payload=_payload(HOLD_KIND), compute=pb.ResolvedCompute(gpu_index=1)))
+
+    # The group really did open it, and the hub really did see it RUNNING.
+    conn.wait_for(_activity(HOLD_KIND, pb.ACTIVITY_STATE_RUNNING))
+
+    died = conn.wait_for(is_result_for("r-die-g1"))
+    assert died.job_result.status == pb.JOB_STATUS_FATAL
+    assert DEATH_LABEL in died.job_result.safe_message
+
+    # THE ASSERTION: the worker's activity of that kind reaches a terminal.
+    term = conn.wait_for(_activity(HOLD_KIND, pb.ACTIVITY_STATE_FAILED))
+    # FAILED, not COMPLETED — the process doing it died, it did not finish.
+    assert term.activity_update.error, "a terminal with no reason is not evidence"
+    # The aggregation still never leaks a group ordinal to the wire.
+    assert "g1" not in term.activity_update.detail
+    assert "group=1" not in term.activity_update.detail
+
+    # The sibling was undisturbed and still serves.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-g0-after", attempt=1, function_name="whoami",
+        input_payload=_payload(), compute=pb.ResolvedCompute(gpu_index=0)))
+    ok = conn.wait_for(is_result_for("r-g0-after"))
+    assert ok.job_result.status == pb.JOB_STATUS_OK
+    assert b"g=0" in ok.job_result.inline
+
+
+def test_the_dead_generation_is_retired_and_the_respawn_starts_a_new_one(g2):
+    """The parent-side state behind the observable, measured on the live object.
+
+    The dead group's fan-in entry is gone, its participation is over, and the
+    respawned child comes back as a NEW generation with empty state — so
+    "absent" means the live-group default again (§4.15), not an inherited fact.
+    The surviving group's own entry is untouched throughout.
+    """
+    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    pc = g2.pc
+    assert pc._slots[1].generation == 1 and pc._slots[1].participating
+
+    # g0 holds the SAME kind open for the whole run; its fact must survive.
+    conn.send(run_job=pb.RunJob(
+        request_id="r-hold-g0", attempt=1, function_name="activity-hold",
+        input_payload=_payload(HOLD_KIND), compute=pb.ResolvedCompute(gpu_index=0)))
+    conn.wait_for(_activity(HOLD_KIND, pb.ACTIVITY_STATE_RUNNING))
+
+    conn.send(run_job=pb.RunJob(
+        request_id="r-die-g1", attempt=1, function_name="activity-die",
+        input_payload=_payload(HOLD_KIND), compute=pb.ResolvedCompute(gpu_index=1)))
+    died = conn.wait_for(is_result_for("r-die-g1"))
+    assert died.job_result.status == pb.JOB_STATUS_FATAL
+
+    # The dead group's fan-in entry is gone; the LIVE group still holds the kind.
+    assert 1 not in pc._group_activities or HOLD_KIND not in pc._group_activities[1]
+    assert HOLD_KIND in pc._group_activities.get(0, {})
+
+    # The dead group's parent-side observation went with it: the death path is
+    # the OTHER exit from `_observations`, and without it 512 orphans FIFO-evict
+    # live jobs' observations and billing attestation silently stops.
+    assert ("r-die-g1", 1) not in pc._observations
+    assert ("r-hold-g0", 1) in pc._observations
+
+    # The respawn is a NEW generation, participating again, with empty state.
+    # `_on_child_connect` calls `begin_generation()` and THEN cycles the stream
+    # to re-sync the worker, so the hub's second connection is the ordered proof
+    # that the new generation exists — no clock involved.
+    g2.scheduler.wait_connection(1, timeout=BOOT_TIMEOUT_S)
+    assert pc._slots[1].generation >= 2
+    assert pc._slots[1].participating
+    assert pc._group_activities.get(1, {}) == {}
+
+    # And a live group's activity is NOT terminated by a sibling's death.
+    assert conn.count(_activity(HOLD_KIND, pb.ACTIVITY_STATE_FAILED)) == 0
+    assert conn.count(_activity(HOLD_KIND, pb.ACTIVITY_STATE_COMPLETED)) == 0
+
+
+# ---------------------------------------------------------------------------
+# PARENT: the two observables a real child cannot be asked to produce, driven
+# through the same functions `_on_child_frame` / `_handle_child_death` call.
+# ---------------------------------------------------------------------------
+
+SOCK = "/tmp/pgw937.sock"
+
+
+def _parent(groups: int = 2) -> ParentControl:
+    settings = load_settings(
+        orchestrator_public_addr="127.0.0.1:1", worker_id="w-937", worker_jwt="",
+    )
+    topo = ExecutionTopology(gpu_count=groups, gpus_per_execution_group=1)
+    p = ParentControl(settings, socket_path=SOCK, topology=topo)
+    for slot in p._slots:
+        slot.begin_generation()
+    return p
+
+
+def _running(kind: str, *, stalled: bool, step: int = 1) -> pb.WorkerMessage:
+    return pb.WorkerMessage(activity_update=pb.ActivityUpdate(
+        kind=kind, state=pb.ACTIVITY_STATE_RUNNING, step=step,
+        counter="mint:graphs", counter_done=float(step), self_stalled=stalled,
+    ))
+
+
+def test_a_dead_groups_frame_cannot_veto_a_live_groups_stall_confession():
+    """Observable B — the one that costs money.
+
+    `merge.reconcile_activity_kind` computes `self_stalled` with `all(...)`, so
+    ONE non-stalled voter suppresses the confession the hub recycles the pod on.
+    A dead group is a permanent non-stalled voter.
+    """
+    p = _parent(2)
+    p._fan_in(p._slots[1], _running("mint", stalled=False))
+    p._fan_in(p._slots[0], _running("mint", stalled=False))
+
+    p._retire_group_generation(p._slots[1])   # g1's child dies
+
+    out = p._fan_in(p._slots[0], _running("mint", stalled=True, step=2))
+    assert out is not None
+    assert out.activity_update.self_stalled is True, (
+        "a dead group's last frame vetoed a live group's stall confession"
+    )
+
+
+def test_a_dead_group_cannot_pin_an_activity_running_forever():
+    """Observable A at the merge, complementing the runtime row: once the dead
+    group is retired, the LIVE group's terminal is the worker's terminal."""
+    p = _parent(2)
+    p._fan_in(p._slots[1], _running("mint", stalled=False))
+    p._fan_in(p._slots[0], _running("mint", stalled=False))
+
+    # Retiring g1 emits the consequence for a kind only IT still held...
+    p._retire_group_generation(p._slots[1])
+    # ...and g0's own completion now closes the kind for the worker.
+    out = p._fan_in(p._slots[0], pb.WorkerMessage(activity_update=pb.ActivityUpdate(
+        kind="mint", state=pb.ACTIVITY_STATE_COMPLETED)))
+    assert out is not None
+    assert out.activity_update.state == pb.ACTIVITY_STATE_COMPLETED
+
+
+def test_retiring_a_group_terminates_only_the_kinds_nobody_else_runs():
+    """The retirement is not a blanket terminal: a kind a LIVE group still runs
+    is re-stated RUNNING (without the dead group's progress), and only a kind
+    nobody runs any more is failed."""
+    p = _parent(2)
+    p._fan_in(p._slots[1], _running("shared", stalled=False, step=9))
+    p._fan_in(p._slots[1], _running("g1_only", stalled=False, step=3))
+    p._fan_in(p._slots[0], _running("shared", stalled=False, step=2))
+
+    out = p._retire_group_generation(p._slots[1])
+    acts = {m.activity_update.kind: m.activity_update
+            for m in out if m.WhichOneof("msg") == "activity_update"}
+    assert set(acts) == {"g1_only", "shared"}
+    assert acts["g1_only"].state == pb.ACTIVITY_STATE_FAILED
+    assert acts["shared"].state == pb.ACTIVITY_STATE_RUNNING
+    # The dead group's step-9 progress is gone: the worker's is the live one's.
+    assert acts["shared"].step == 2
+
+
+def test_a_respawned_group_does_not_inherit_the_dead_ones_unavailability():
+    """Observable C: there is no `fn_available` message, so a respawned group
+    that serves the function again says NOTHING. Its unavailability must
+    therefore have been dropped with the generation that reported it — or the
+    next transient failure anywhere retires the function worker-wide."""
+    p = _parent(2)
+    fu = pb.WorkerMessage(fn_unavailable=pb.FnUnavailable(
+        function_name="txt2img", reason="setup_failed"))
+    assert p._fan_in(p._slots[1], fu) is None      # g0 serves it: suppressed
+
+    p._retire_group_generation(p._slots[1])        # g1 dies...
+    p._slots[1].begin_generation()                 # ...and comes back serving
+
+    out = p._fan_in(p._slots[0], pb.WorkerMessage(fn_unavailable=pb.FnUnavailable(
+        function_name="txt2img", reason="insufficient_vram")))
+    assert out is None, (
+        "the respawned group inherited the dead one's FnUnavailable, so a "
+        "transient failure in g0 retired a function g1 was serving"
+    )
+
+
+def test_a_down_group_is_excluded_from_the_merge_not_defaulted_to_serving():
+    """The reason a bare `.pop()` is WORSE than the stale entry.
+
+    `worker_fn_unavailable` reads a `None` value as "this group serves it". With
+    g1 DOWN, g0's unavailability is the whole worker's truth and the hub must
+    hear it. A naive pop would leave `per_group[1] = None` and swallow it.
+    """
+    p = _parent(2)
+    p._retire_group_generation(p._slots[1])
+
+    out = p._fan_in(p._slots[0], pb.WorkerMessage(fn_unavailable=pb.FnUnavailable(
+        function_name="txt2img", reason="insufficient_vram")))
+    assert out is not None, (
+        "the down group was defaulted to 'serves everything', so the worker "
+        "never reported a function no live group can serve"
+    )
+    assert out.fn_unavailable.function_name == "txt2img"
+
+
+def test_a_down_group_does_not_veto_a_live_groups_degradation_report():
+    """Same inversion on FnDegraded: absence means "serves it native" there, so
+    a down group left in the `served_native_somewhere` scan silently suppresses
+    the placement hint the live group is asking for."""
+    p = _parent(2)
+    p._retire_group_generation(p._slots[1])
+
+    out = p._fan_in(p._slots[0], pb.WorkerMessage(fn_degraded=pb.FnDegraded(
+        function_name="txt2img", est_latency_multiplier=3.0)))
+    assert out is not None
+    assert out.fn_degraded.est_latency_multiplier == pytest.approx(3.0)
+
+
+def test_a_dead_group_stops_advertising_its_functions_and_its_free_vram():
+    """Observable D: `merge_state_deltas` UNIONS `available_functions` and SUMS
+    `free_vram_bytes`, with no liveness filter — so the hub kept dispatching
+    onto a down group and got "compute process restarting" on a loop, and the
+    pod's reported free VRAM counted a process that no longer exists."""
+    p = _parent(2)
+    p._slots[0].last_state_delta = pb.WorkerMessage(state_delta=pb.StateDelta(
+        available_functions=["a"], free_vram_bytes=10, phase=pb.WORKER_PHASE_READY))
+    p._slots[1].last_state_delta = pb.WorkerMessage(state_delta=pb.StateDelta(
+        available_functions=["b"], free_vram_bytes=30, phase=pb.WORKER_PHASE_READY))
+    p._note_state_delta()
+    assert list(p._last_state_delta.state_delta.available_functions) == ["a", "b"]
+
+    out = p._retire_group_generation(p._slots[1])
+    st = p._last_state_delta.state_delta
+    assert list(st.available_functions) == ["a"]
+    assert st.free_vram_bytes == 10
+    # The hub LEARNS it, rather than inferring it from an update that stopped.
+    assert any(m.WhichOneof("msg") == "state_delta" for m in out)
+
+
+def test_with_every_group_down_the_worker_advertises_nothing():
+    """The last group's function set is not the worker's while nothing is up."""
+    p = _parent(2)
+    for slot in p._slots:
+        slot.last_state_delta = pb.WorkerMessage(state_delta=pb.StateDelta(
+            available_functions=["a"], free_vram_bytes=10,
+            phase=pb.WORKER_PHASE_READY))
+    p._note_state_delta()
+    for slot in p._slots:
+        p._retire_group_generation(slot)
+    st = p._last_state_delta.state_delta
+    assert list(st.available_functions) == []
+    assert st.free_vram_bytes == 0
+    assert st.phase == pb.WORKER_PHASE_BOOTING
+
+
+def test_a_retired_generations_late_frame_cannot_resurrect_it():
+    """`_settle_link` is bounded, so a frame from a reaped child can still land
+    after the death path ran. A worker-SCOPED claim from a retired generation is
+    a dead process's view of a worker it has left."""
+    p = _parent(2)
+    p._retire_group_generation(p._slots[1])
+    assert p._fan_in(p._slots[1], _running("mint", stalled=False)) is None
+    assert p._group_activities.get(1, {}) == {}
+    # Per-request frames still forward: they are about a job, not the worker.
+    jr = pb.WorkerMessage(job_result=pb.JobResult(
+        request_id="r", attempt=1, status=pb.JOB_STATUS_OK))
+    assert p._fan_in(p._slots[1], jr) is jr
+
+
+def test_G1_is_untouched_by_all_of_this():
+    """The standing safety property: a one-child worker is byte-identical to the
+    pre-pgw#783 relay. The fan-in dicts are never populated there, so retirement
+    is a no-op BY CONSTRUCTION rather than by a flag."""
+    p = _parent(1)
+    msg = _running("mint", stalled=False)
+    assert p._fan_in(p._slots[0], msg) is msg
+    assert p._retire_group_generation(p._slots[0]) == []
+    assert p._fan_in(p._slots[0], msg) is msg   # still verbatim after a death


### PR DESCRIPTION
## The ruling (this issue needed one, not a patch)

**A group without a live child is not a participant in the worker view, and its facts are UNKNOWN — which is neither "still true" nor the live-group default. So the identity element of a down group is EXCLUSION from every merge.**

A bare `.pop()` on child death would have been *strictly worse* than the leak: `merge.worker_fn_unavailable` reads a `None` value as "this group serves it", so removing a dead group's entry makes the dead group read as serving **everything**. Same inversion on `FnDegraded` (absence means "serves it native") and on `_group_activities` (an empty group reads as terminal).

Membership in the merge input is the third state the vocabulary needed — the §4.22 fact-vs-default class:

| state | carrier | meaning |
|---|---|---|
| present entry | `_group_*[ordinal][key]` | a fact the LIVE incarnation reported |
| absent entry | key missing | the live-group DEFAULT (serves it / no activity open) |
| **not a member** | ordinal missing from the merge input | **UNKNOWN — no live child** |

An explicit "unknown" sentinel was considered and rejected: it would teach four merge functions a third case to say what membership already says, and would touch nothing on the wire either way.

## What changed

- The fan-in structures are **generation-scoped** (§4.15: a respawn is a new generation of the same group, under the same worker session). Two halves, not interchangeable:
  - a **liveness predicate** (`_ChildSlot.participating` / `ParentControl._live_slots`) gates `_fan_in`, `_note_state_delta` and all three reconcile paths, so no merge consumes a down ordinal's entry;
  - `_retire_group_generation` **drops** the dead incarnation's entries, so a respawned group does not inherit them. Ordinals are stable slot indices and there is no `fn_available` message for a recovered group to correct the record with, so the predicate alone is not enough.
- **A down group is not silently forgotten** — that would replace one missing fact with another. The death path EMITS the consequences: a FAILED terminal for every activity kind the dead generation held open that no live group still runs, plus the recomputed worker StateDelta. The hub *learns* the capacity dropped instead of inferring it from an update that stopped arriving.
- Participation ends at **link loss**, not at reap: a group the parent already answers RETRYABLE for must not still be voting, and `_settle_link` is bounded so a late frame from a reaped child is possible.
- `merge.worker_fn_unavailable`'s absent==serving convention is now documented at **both** ends, so the death-path fix cannot be written backwards.

## Observables fixed

A (activity pinned RUNNING forever) · B (a dead group vetoing a live group's `self_stalled` confession — `merge.py`'s `all()`) · C (a natively-served function retired worker-wide after a respawn) · D (a down group's functions and free VRAM still advertised) · E (the parent's dispatch-time `_observations` orphaned by the death path, FIFO-evicting live jobs' observations and silently stopping billing attestation on a crash-looping pod).

Beyond the issue: with **every** group down, `_note_state_delta` used to leave the last live group's function set standing (nothing recomputes it when there is no live delta). It now publishes an empty BOOTING delta, so the hub stops dispatching into "compute process restarting" on a loop.

**G == 1 is untouched BY CONSTRUCTION**, not by a flag: `_fan_in` returns the child's message verbatim there, the fan-in dicts are never populated, and `_retire_group_generation` returns `[]`. Asserted.

## How it was proved

`tests/test_fanin_generation_pgw937.py` — 2 rows on the real two-process G=2 harness (a child SIGKILLs itself while holding an activity open) and 10 on a real `ParentControl` driven through the production `_fan_in` / `_retire_group_generation` / `begin_generation` entry points.

- **Red by revert, not by argument.** With `src/gen_worker/procsplit/{parent,merge}.py` reverted to `origin/dev`, `test_a_dead_groups_open_activity_is_terminated_for_the_worker` fails with the observable verbatim: `activity_update` RUNNING, then `job_result` FATAL, **then no terminal ever arrives**. That row uses no API this change adds.
- **The "naive pop is worse" claim is measured too.** A variant keeping the new seam but neutering *only the rule* (`_live_slots` returns every slot; no participation flag) — the bare pop the issue warned about — turns three rows red, all of them the down-group-reads-as-serving-everything inversion.

## Corrections to the issue

1. "Zero `pop`" is true of the DEATH path, but `_reconcile_activity` (`parent.py:1709`) does pop a *kind* on a terminal. The leak is of the per-ordinal entry, not of every key.
2. "A per-slot `alive` predicate gates `_fan_in` and `_note_state_delta`" is necessary but not sufficient — a predicate alone leaves a respawned group inheriting the dead one's entries (observable C).
3. Observables A and D need the death path to **emit**, not merely to stop counting: a filter alone leaves the hub holding the last RUNNING update forever, because nothing recomputes a merge without an incoming frame.

## Validation

- **89/89 green on the final head** across `test_fanin_generation_pgw937.py`, `test_group_processes_pgw783.py`, `test_group_spawn_pgw783.py` and `test_gw640_postmortem.py`. Plus **74/74** on the broader death-path regression (`test_procsplit_pgw763`, `test_procsplit_security_pgw763`, `test_child_stderr_postmortem_pgw833`, `test_gw640_postmortem`, `test_report_throttle_boot_pgw763`, `test_worker_fatal_gw640`).
- Rebased twice — onto pgw#944 (vendored wire contract; `scripts/proto-drift-check.sh` passes layer 1) and onto pgw#938's merge. The #938 rebase conflicted in two files, both ADDITIVE and both resolved by keeping both sides: the `## Unreleased` CHANGELOG entry and `tests/harness/procsplit_endpoints.py` (their `segfault` probe beside this issue's `activity_die` / `activity_hold`). Both issues edit the same death path, so the 89/89 run is the proof they hold together.
- Ruff clean on every changed file; mypy clean on both changed source modules; `scripts/lint_http_timeouts.py` and `scripts/lint_unreached_surface.py` exit 0; `git diff --check` clean.
- No model inference, model weights, GPU smoke test, or stack lifecycle action was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)