### PR TITLE
th#1362/te#137: a produced flavor's PASSTHROUGH components are one file too (0.91.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## Unreleased
+## 0.91.2 (2026-08-03) — **a produced flavor's passthrough components are one file too**: th#1362's producer invariant stops refusing the married trees it was meant to protect (the te#137 svdq publish blocker)
+
+PATCH: nothing here touches the worker<->hub wire contract, `@endpoint` or `Resources`, so no
+`TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` move is needed. Three de-shard helpers become
+public and move module (`clone` -> `writer`); the behaviour change is confined to how a
+producer materializes the half of its output tree it did not compute.
+
+- **th#1362 / te#137: a produced flavor's PASSTHROUGH components are one file too.**
+  `copy_non_weight_files` — the one door untouched weights enter a tree we produce — now
+  COLLAPSES an HF shard set it copies through. Item 4's producer invariant was right and
+  stays; what was missing is that item 2 wired de-shard into `clone.py`'s mirror arms only,
+  so the married-tree producers (`build_svdq_flavor_tree`, te's fuse) hardlinked a
+  legacy-sharded base component straight into their output and `publish_flavors` refused it
+  (`sharded_producer_output: ... text_encoder/model-00001-of-00009.safetensors`, found live
+  blocking every te#137 svdq flavor publish off `tensorhub/qwen-image`). `deshard_mirror_tree`
+  / `deshard_indexed_safetensors` / `tree_has_sharded_safetensors` moved from `clone.py` to
+  `writer.py` next to the `merge_safetensors_by_offset` primitive they drive, and are public.
+  The source snapshot is untouched (only this tree's hardlinks are unlinked), an unsharded
+  component is still passed through by inode, and a `-NNNNN-of-MMMMM` set with no index is
+  still REFUSED rather than published.
 
 - **pgw#938:** isolate transient post-mortem evidence per compute group and make
   concurrent grant downloads finalize through writer-unique temporary files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.91.1"
+version = "0.91.2"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/convert/clone.py
+++ b/src/gen_worker/convert/clone.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import fcntl
 import hashlib
-import json
 import logging
 import os
 import re
@@ -40,7 +39,8 @@ from .writer import (
     fp8_default_components,
     apply_objective_scheduler_config,
     copy_non_weight_files,
-    merge_safetensors_by_offset,
+    deshard_mirror_tree,
+    tree_has_sharded_safetensors,
     normalize_variant_filenames as _normalize_variant_filenames,
     snapshot_weight_groups,
 )
@@ -186,85 +186,6 @@ def normalize_outputs(values: Iterable[Any] | None, *, layout_hint: str = "diffu
 # ---------------------------------------------------------------------------
 # Flavor tree construction
 # ---------------------------------------------------------------------------
-
-def _deshard_indexed_safetensors(index_path: Path) -> Path:
-    """Collapse ONE HF shard set into a single ``<prefix>.safetensors``.
-
-    th#1362: repos WE pull are normalised to one file per component on the way
-    in, including pure pass-through mirrors, so the corpus we own has one shape.
-    Chunked CAS already gives resumable, parallel, partial-failure-tolerant
-    transfer BELOW the file, so the shard set buys nothing and costs an index
-    that can disagree with the bytes it names — the bug that made klein-4b
-    publish an unloadable text_encoder.
-
-    Provenance is unaffected: upstream per-file digests are recorded by the
-    provenance layer regardless of the layout we store.
-    """
-    payload = json.loads(index_path.read_text(encoding="utf-8"))
-    weight_map = payload.get("weight_map")
-    if not isinstance(weight_map, dict) or not weight_map:
-        raise ValueError(f"invalid safetensors index: {index_path}")
-    member_names: list[str] = []
-    for name in weight_map.values():
-        name = str(name)
-        if Path(name).name != name:
-            raise ValueError(
-                f"safetensors index member must be a basename: {index_path}")
-        if name not in member_names:
-            member_names.append(name)
-    members = [index_path.parent / name for name in member_names]
-    missing = [m for m in members if not m.is_file()]
-    if missing:
-        raise ValueError(f"safetensors index references a missing shard: {index_path}")
-
-    prefix = index_path.name.removesuffix(".safetensors.index.json")
-    merged = index_path.parent / f"{prefix}.safetensors"
-    if merged.exists() and merged not in members:
-        raise ValueError(f"deshard destination already exists: {merged}")
-    merge_safetensors_by_offset(members, merged)
-
-    # The merged header must name exactly the tensors the index claimed — the
-    # index-vs-bytes disagreement this whole change exists to kill is caught
-    # here, at ingest, instead of at load time on a GPU pod.
-    with open(merged, "rb") as f:
-        header_len = int.from_bytes(f.read(8), "little")
-        header = json.loads(f.read(header_len).decode("utf-8"))
-    got = {k for k in header if k != "__metadata__"}
-    want = {str(k) for k in weight_map}
-    if got != want:
-        merged.unlink(missing_ok=True)
-        raise ValueError(
-            f"deshard of {index_path} produced {len(got)} tensors, index names "
-            f"{len(want)} (missing={sorted(want - got)[:5]}, "
-            f"extra={sorted(got - want)[:5]})")
-
-    for member in members:
-        if member != merged:
-            member.unlink()
-    index_path.unlink()
-    logger.info("deshard_mirror index=%s shards=%d -> %s",
-                index_path.name, len(members), merged.name)
-    return merged
-
-
-def tree_has_sharded_safetensors(tree: Path) -> bool:
-    """Does this tree carry an HF shard set that mirror ingest must collapse?"""
-    return any(Path(tree).rglob("*.safetensors.index.json"))
-
-
-def deshard_mirror_tree(tree: Path) -> int:
-    """De-shard every HF shard set in an ingested mirror tree, in place.
-
-    One component at a time, unlinking each set's members as soon as its merged
-    file is verified, so the peak extra disk is the LARGEST component and not
-    the whole tree.
-    """
-    n = 0
-    for index_path in sorted(Path(tree).rglob("*.safetensors.index.json")):
-        _deshard_indexed_safetensors(index_path)
-        n += 1
-    return n
-
 
 def build_flavor_tree(
     source: IngestedSource,

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -22,6 +22,7 @@ torch/safetensors imports are deferred so importing gen_worker.convert stays che
 from __future__ import annotations
 
 import json
+import logging
 import math
 import re
 import shutil
@@ -37,6 +38,7 @@ from gen_worker.models.w8a8 import detect_w8a8_artifact
 if TYPE_CHECKING:
     import torch
 
+logger = logging.getLogger(__name__)
 
 
 class ConversionImplementationError(RuntimeError):
@@ -730,8 +732,21 @@ def _link_or_copy(src: Path, dst: Path) -> None:
 
 
 def copy_non_weight_files(source_dir: Path, out_dir: Path, *, skip_components: set[str]) -> None:
-    """Hardlink every non-weight file into the output tree; weight files and
-    their sharded indexes for converted components are skipped."""
+    """Materialize the PASSTHROUGH half of a produced tree: hardlink every file
+    the caller is not writing itself. Weight files and sharded indexes of the
+    components named in ``skip_components`` are skipped — the caller writes
+    those.
+
+    A passthrough component that arrives as an HF shard set is COLLAPSED here
+    (th#1362). This is the only door untouched weights enter a tree we produce,
+    and every caller is one of our producers, so the one-file-per-component
+    invariant is satisfied at the door rather than at each of the callers. The
+    source is untouched: what is unlinked is this tree's hardlink, and the
+    merge verifies the bytes against the index it consumed, so a klein-4b-class
+    index/shard disagreement fails the produce instead of publishing an
+    unloadable component.
+    """
+    copied_indexes: list[Path] = []
     for f in sorted(source_dir.rglob("*")):
         if not f.is_file():
             continue
@@ -746,6 +761,11 @@ def copy_non_weight_files(source_dir: Path, out_dir: Path, *, skip_components: s
         if name == ".civitai.json":
             continue
         _link_or_copy(f, out_dir / rel)
+        if name.endswith(".safetensors.index.json"):
+            copied_indexes.append(out_dir / rel)
+    for index_path in copied_indexes:
+        if index_path.is_file():
+            deshard_indexed_safetensors(index_path)
 
 
 # pgw#654: scheduler config overrides per checkpoint objective/distilled
@@ -1540,6 +1560,85 @@ def merge_safetensors_by_offset(
             os.close(fd)
 
 
+def deshard_indexed_safetensors(index_path: Path) -> Path:
+    """Collapse ONE HF shard set into a single ``<prefix>.safetensors``.
+
+    th#1362: bytes WE own are normalised to one file per component — mirrors we
+    ingest AND the passthrough components of the flavors we produce, which are
+    the same bytes one step later. Chunked CAS already gives resumable,
+    parallel, partial-failure-tolerant transfer BELOW the file, so the shard set
+    buys nothing and costs an index that can disagree with the bytes it names —
+    the bug that made klein-4b publish an unloadable text_encoder.
+
+    Provenance is unaffected: upstream per-file digests are recorded by the
+    provenance layer regardless of the layout we store.
+    """
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"invalid safetensors index: {index_path}")
+    member_names: list[str] = []
+    for name in weight_map.values():
+        name = str(name)
+        if Path(name).name != name:
+            raise ValueError(
+                f"safetensors index member must be a basename: {index_path}")
+        if name not in member_names:
+            member_names.append(name)
+    members = [index_path.parent / name for name in member_names]
+    missing = [m for m in members if not m.is_file()]
+    if missing:
+        raise ValueError(f"safetensors index references a missing shard: {index_path}")
+
+    prefix = index_path.name.removesuffix(".safetensors.index.json")
+    merged = index_path.parent / f"{prefix}.safetensors"
+    if merged.exists() and merged not in members:
+        raise ValueError(f"deshard destination already exists: {merged}")
+    merge_safetensors_by_offset(members, merged)
+
+    # The merged header must name exactly the tensors the index claimed — the
+    # index-vs-bytes disagreement this whole change exists to kill is caught
+    # here, at ingest, instead of at load time on a GPU pod.
+    with open(merged, "rb") as f:
+        header_len = int.from_bytes(f.read(8), "little")
+        header = json.loads(f.read(header_len).decode("utf-8"))
+    got = {k for k in header if k != "__metadata__"}
+    want = {str(k) for k in weight_map}
+    if got != want:
+        merged.unlink(missing_ok=True)
+        raise ValueError(
+            f"deshard of {index_path} produced {len(got)} tensors, index names "
+            f"{len(want)} (missing={sorted(want - got)[:5]}, "
+            f"extra={sorted(got - want)[:5]})")
+
+    for member in members:
+        if member != merged:
+            member.unlink()
+    index_path.unlink()
+    logger.info("deshard index=%s shards=%d -> %s",
+                index_path.name, len(members), merged.name)
+    return merged
+
+
+def tree_has_sharded_safetensors(tree: Path) -> bool:
+    """Does this tree carry an HF shard set that mirror ingest must collapse?"""
+    return any(Path(tree).rglob("*.safetensors.index.json"))
+
+
+def deshard_mirror_tree(tree: Path) -> int:
+    """De-shard every HF shard set in a tree, in place.
+
+    One component at a time, unlinking each set's members as soon as its merged
+    file is verified, so the peak extra disk is the LARGEST component and not
+    the whole tree.
+    """
+    n = 0
+    for index_path in sorted(Path(tree).rglob("*.safetensors.index.json")):
+        deshard_indexed_safetensors(index_path)
+        n += 1
+    return n
+
+
 # ---------------------------------------------------------------------------
 # Canonical published filenames (gw#466 / gw#522)
 # ---------------------------------------------------------------------------
@@ -1617,6 +1716,9 @@ __all__ = [
     "normalize_variant_filenames",
     "list_shard_files_from_index",
     "merge_safetensors_by_offset",
+    "deshard_indexed_safetensors",
+    "deshard_mirror_tree",
+    "tree_has_sharded_safetensors",
     "NEVER_SHARD_MAX_SIZE",
     "find_producer_shards",
     "assert_one_file_per_component",

--- a/tests/convert/test_passthrough_deshard_th1362.py
+++ b/tests/convert/test_passthrough_deshard_th1362.py
@@ -1,0 +1,229 @@
+"""th#1362: a produced flavor's PASSTHROUGH components are one file too.
+
+The gap this closes, found live on te#137: `build_svdq_flavor_tree` marries our
+4-bit denoiser to the base checkpoint's other components by hardlinking them
+through `copy_non_weight_files`. qwen-image's text_encoder was mirrored before
+th#1362 item 2 landed, so it is still a 9-member shard set — and it rode
+straight into the produced tree, where `publish_flavors`' producer invariant
+refused it:
+
+    ConversionImplementationError: sharded_producer_output:
+    publish_flavors[tensorhub/qwen-image] emitted a shard set (10 file(s), e.g.
+    text_encoder/model-00001-of-00009.safetensors ...)
+
+The guard was RIGHT — a flavor is our artifact whole, not just the component we
+computed. What was missing is the normalization: item 2 wired de-shard into
+clone.py's mirror arms only, so the married-tree producers passed legacy shards
+through untouched. It now happens at the door every passthrough weight enters a
+produced tree.
+
+Real trees, real safetensors, real `publish_flavors` over HTTP to the fake hub —
+the assertion is on the FILE LIST THAT GOES ON THE WIRE, not on an internal call.
+
+    pytest tests/convert/test_passthrough_deshard_th1362.py -q
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+safetensors_torch = pytest.importorskip("safetensors.torch")
+from safetensors import safe_open  # noqa: E402
+
+from gen_worker.convert.produced import ProducedFlavor  # noqa: E402
+from gen_worker.convert.publish import publish_flavors  # noqa: E402
+from gen_worker.convert.svdq import build_svdq_flavor_tree  # noqa: E402
+from gen_worker.convert.writer import ConversionImplementationError  # noqa: E402
+
+from fake_hub import _FakeHub  # noqa: E402
+
+
+class _Ctx:
+    def __init__(self, base_url: str) -> None:
+        self._file_api_base_url = base_url
+        self._worker_capability_token = "cap-token"
+        self.owner = "cozy"
+        self.lines: list[str] = []
+
+    def log(self, message: str, **fields: Any) -> None:
+        self.lines.append(message)
+
+
+def _tensors(seed: int, n: int) -> dict[str, "torch.Tensor"]:
+    g = torch.Generator().manual_seed(seed)
+    return {f"enc.{i}.weight": torch.randn(8, 8, generator=g) for i in range(n)}
+
+
+def _write_sharded(comp: Path, prefix: str, tensors, per_shard: int) -> None:
+    comp.mkdir(parents=True, exist_ok=True)
+    names = list(tensors)
+    groups = [names[i:i + per_shard] for i in range(0, len(names), per_shard)]
+    weight_map: dict[str, str] = {}
+    for i, group in enumerate(groups, start=1):
+        member = f"{prefix}-{i:05d}-of-{len(groups):05d}.safetensors"
+        safetensors_torch.save_file({k: tensors[k] for k in group},
+                                    str(comp / member))
+        for k in group:
+            weight_map[k] = member
+    (comp / f"{prefix}.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 0}, "weight_map": weight_map}))
+
+
+def _svdq_file(path: Path) -> Path:
+    """A real nunchaku single-file checkpoint — self-describing metadata is
+    what `detect_svdq_artifact` keys on, so this must be genuine."""
+    safetensors_torch.save_file(
+        _tensors(90, 2), str(path),
+        metadata={
+            "model_class": "NunchakuQwenImageTransformer2DModel",
+            "quantization_config": json.dumps(
+                {"method": "svdquant", "weight": {"dtype": "nvfp4"}, "rank": 128}),
+        })
+    return path
+
+
+def _base_tree(root: Path, *, sharded_text_encoder: bool) -> dict[str, "torch.Tensor"]:
+    """The qwen-image shape: a text_encoder (sharded or not), a vae, and the
+    transformer whose weights the svdq file replaces."""
+    te = _tensors(1, 18)
+    if sharded_text_encoder:
+        _write_sharded(root / "text_encoder", "model", te, per_shard=2)
+    else:
+        (root / "text_encoder").mkdir(parents=True)
+        safetensors_torch.save_file(te, str(root / "text_encoder" / "model.safetensors"))
+    (root / "vae").mkdir(parents=True)
+    safetensors_torch.save_file(
+        _tensors(2, 2), str(root / "vae" / "diffusion_pytorch_model.safetensors"))
+    (root / "transformer").mkdir(parents=True)
+    safetensors_torch.save_file(
+        _tensors(3, 2),
+        str(root / "transformer" / "diffusion_pytorch_model.safetensors"))
+    (root / "model_index.json").write_text('{"_class_name": "QwenImagePipeline"}')
+    (root / "scheduler").mkdir(parents=True)
+    (root / "scheduler" / "scheduler_config.json").write_text("{}")
+    return te
+
+
+def _publish_svdq_flavor(fake_hub: Any, tmp_path: Path, *, sharded: bool):
+    base = tmp_path / "base"
+    te = _base_tree(base, sharded_text_encoder=sharded)
+    tree, attrs = build_svdq_flavor_tree(
+        base, _svdq_file(tmp_path / "svdq-fp4_r128-cozy.safetensors"),
+        tmp_path / "flavor")
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    results = publish_flavors(
+        ctx, [ProducedFlavor(path=str(tree), flavor=attrs["flavor"],
+                             attributes=attrs)],
+        destination_repo="cozy/qwen-image", tags=["svdq-fp4-r128"])
+    paths = sorted(f["path"] for f in _FakeHub.state["publish_request"]["files"])
+    return base, tree, te, paths, results
+
+
+# --------------------------------------------------------------------------
+# The multi-shard producer output — the te#137 case
+# --------------------------------------------------------------------------
+
+def test_a_sharded_passthrough_component_publishes_as_ONE_file(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    base, tree, te, paths, results = _publish_svdq_flavor(
+        fake_hub, tmp_path, sharded=True)
+
+    assert paths == [
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "text_encoder/model.safetensors",
+        "transformer/svdq-fp4_r128-cozy.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+    ], paths
+    assert results and results[0].checkpoint_id
+
+    # Every tensor survived the merge, byte-exact.
+    got = {}
+    with safe_open(str(tree / "text_encoder" / "model.safetensors"),
+                   framework="pt", device="cpu") as f:
+        for k in f.keys():
+            got[k] = f.get_tensor(k)
+    assert set(got) == set(te)
+    for k, want in te.items():
+        assert torch.equal(got[k], want), k
+
+
+def test_the_source_snapshot_is_not_mutated(fake_hub: Any, tmp_path: Path) -> None:
+    """The passthrough files are HARDLINKS into the source snapshot. Collapsing
+    them must unlink OUR tree's names and nothing else — the ingested source
+    stays exactly as the mirror left it, so a second flavor off the same source
+    still has its input."""
+    base, _tree, _te, _paths, _ = _publish_svdq_flavor(
+        fake_hub, tmp_path, sharded=True)
+    members = sorted(p.name for p in (base / "text_encoder").iterdir())
+    assert members == [f"model-{i:05d}-of-00009.safetensors" for i in range(1, 10)] \
+        + ["model.safetensors.index.json"], members
+
+
+# --------------------------------------------------------------------------
+# The single-file producer output — the other half, so the fix cannot be a
+# rewrite-everything pass
+# --------------------------------------------------------------------------
+
+def test_an_unsharded_passthrough_component_publishes_unchanged(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    base, tree, te, paths, results = _publish_svdq_flavor(
+        fake_hub, tmp_path, sharded=False)
+
+    assert paths == [
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "text_encoder/model.safetensors",
+        "transformer/svdq-fp4_r128-cozy.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+    ], paths
+    assert results and results[0].checkpoint_id
+
+    # Untouched means UNTOUCHED: still the same inode the source holds, so a
+    # component that needed nothing done to it costs no bytes and no rewrite.
+    src = base / "text_encoder" / "model.safetensors"
+    dst = tree / "text_encoder" / "model.safetensors"
+    assert src.stat().st_ino == dst.stat().st_ino
+    assert src.read_bytes() == dst.read_bytes()
+
+
+# --------------------------------------------------------------------------
+# The guard is a BACKSTOP, not a formality — it must still fail closed
+# --------------------------------------------------------------------------
+
+def test_publish_still_refuses_a_shard_set_the_copy_cannot_collapse(
+    fake_hub: Any, tmp_path: Path,
+) -> None:
+    """A `-NNNNN-of-MMMMM` set with NO index is not collapsible (nothing names
+    the members' order), so it must still be REFUSED rather than published.
+    Normalizing the collapsible case must not soften the invariant."""
+    tree = tmp_path / "flavor"
+    (tree / "text_encoder").mkdir(parents=True)
+    safetensors_torch.save_file(
+        _tensors(7, 2),
+        str(tree / "text_encoder" / "model-00001-of-00002.safetensors"))
+    ctx = _Ctx(f"http://127.0.0.1:{fake_hub.server_port}")
+    with pytest.raises(ConversionImplementationError,
+                       match="sharded_producer_output"):
+        publish_flavors(ctx, [ProducedFlavor(path=str(tree), flavor="x")],
+                        destination_repo="cozy/qwen-image")
+
+
+def test_an_index_naming_a_missing_shard_fails_the_PRODUCE(tmp_path: Path) -> None:
+    """The klein-4b bug class: an index that disagrees with the bytes it names
+    used to publish and die on a GPU pod at load. The merge verifies against
+    the index, so it now dies here — in the producer, before any upload."""
+    base = tmp_path / "base"
+    _base_tree(base, sharded_text_encoder=True)
+    next((base / "text_encoder").glob("model-00003-of-00009.safetensors")).unlink()
+    with pytest.raises(ValueError, match="missing shard"):
+        build_svdq_flavor_tree(
+            base, _svdq_file(tmp_path / "svdq-fp4_r128-cozy.safetensors"),
+            tmp_path / "flavor")

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.91.0"
+version = "0.91.2"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The break

`publish_flavors` refused every te#137 svdq flavor publish off `tensorhub/qwen-image`, twice (the 0.8.15 leg and the 0.8.17 AWQ leg, the latter **after** its gate passed at LPIPS 0.2863):

```
ConversionImplementationError: sharded_producer_output:
publish_flavors[tensorhub/qwen-image] emitted a shard set (10 file(s),
e.g. text_encoder/model-00001-of-00009.safetensors ...)
```

Reproduced byte-for-byte before touching anything.

## Root cause, and which side was wrong

**The publish guard was right; the producer was wrong.** A flavor is our artifact *whole*, not just the component we computed.

`build_svdq_flavor_tree` (`convert/svdq.py:93`) marries our 4-bit denoiser to the base checkpoint's other components via `copy_non_weight_files` (`convert/writer.py:732`), which hardlinks every non-converted component's weights through **as-is**. qwen-image's text_encoder was mirrored before th#1362 item 2 landed, so it is still a 9-member shard set — and the ruling explicitly does *not* migrate the 59 legacy `multi-file` rows. th#1362 item 4 landed the invariant at `convert/publish.py:150`; item 2 wired the de-shard pass into `clone.py`'s mirror arms **only**. The married-tree producers were missed, so passthrough legacy shards rode into a tree the invariant then refused.

Narrowing the guard to "only the component we wrote" was the wrong fix: it would silently republish sharded artifacts and make `shard_count > 1` mean "legacy OR flavor passthrough", which is exactly the invariant th#1361 reads.

## The fix

De-shard at the door — `copy_non_weight_files` is the ONE place untouched weights enter a tree we produce, and every caller is one of our producers, so it normalizes there instead of at each of the eight callers. `deshard_indexed_safetensors` / `deshard_mirror_tree` / `tree_has_sharded_safetensors` move `clone.py` -> `writer.py` (beside the `merge_safetensors_by_offset` primitive they drive) and become public.

## Tests

`tests/convert/test_passthrough_deshard_th1362.py` — real trees, real safetensors, real `publish_flavors` over HTTP to the fake hub, asserting the **file list that goes on the wire**:

- multi-shard producer output: 9-shard passthrough text_encoder publishes as ONE `model.safetensors`, every tensor byte-exact;
- single-file producer output: passed through **by inode** — no rewrite, no bytes;
- the source snapshot is not mutated (only this tree's hardlinks are unlinked);
- a `-NNNNN-of-MMMMM` set with no index is still REFUSED — the guard stays a backstop;
- an index naming a missing shard now fails the PRODUCE (klein-4b class), not a GPU pod at load.

3 of the 5 fail without the fix; the 2 that pass are the two that should.

## Gates

Full suite **2990 passed / 37 skipped / 1 xfailed**; mypy clean on the three touched modules; ruff unchanged from baseline (46 pre-existing advisory).

## Release

Cut as **0.91.2** per `docs/releasing.md` rule 1 — a pod run needs it (the te#137 flavor publish). PATCH: no wire-contract / `@endpoint` / `Resources` change, so no `TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` move. Also relocks `uv.lock`, which had drifted from the 0.91.1 bump on `dev` (`uv sync --locked` was already failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)