### PR TITLE
pgw#931 follow-up: the config gate stops keying on line numbers, and the control parent gets its credential at the right seam

### DIFF
--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -4,7 +4,16 @@
 # (`gen_worker.config`). Every OTHER `os.environ` / `os.getenv` access in
 # `src/gen_worker` needs a line here or CI fails.
 #
-# FORMAT:  <path>:<line>  <CLASSIFICATION>  <reason>
+# FORMAT:  <path>::<ENV_NAME>  <CLASSIFICATION>  <reason>
+#
+# Keyed on the VARIABLE, never on a line number. The first cut of this gate used
+# `path:line` and went red on `dev` within the hour: two sibling PRs merged
+# alongside it and shifted lines in four files nobody in that change had touched.
+# A line number is a fact OTHER PEOPLE change independently, so pinning an
+# allowlist to one makes it a second carrier that goes stale silently — §4.22,
+# and exactly the defect class this gate exists to police. `::<unresolved>` is
+# for a bare `os.environ` binding; `::$NAME` for a constant imported from a
+# sibling module, where the identifier is the stable key.
 #
 #   VIOLATION   a config value read behind the pipeline. A DEFECT, listed only
 #               so the gate can be green while it is burned down. Every line
@@ -27,144 +36,121 @@
 # sites so it is green on arrival, then burned down. A gate that fails on day
 # one gets switched off.
 #
-# SCOREBOARD at the pgw#929/930/931 landing: 100 sites (106 before; six raw
-# config reads were deleted outright, five of them `or os.environ.get(...)`
-# clauses sitting next to the Settings field for the SAME fact).
+# SCOREBOARD at the pgw#929/930/931 landing: 79 (file, variable) pairs.
+#   VIOLATION 14 | BOOTSTRAP 6 | IPC 18 | LIBRARY 17 | STANDALONE 18 | TRIPWIRE 6
 #
-# The count went UP against the issue's 103 because the gate catches a shape the
-# issue's grep could not: `os.environ` bound as a VALUE (`dict(os.environ)`,
-# `source = os.environ`). Eight such sites, and they are the widest reads in the
-# tree - three of them are the child-env denylist.
-#   VIOLATION 17 | BOOTSTRAP 6 | IPC 21 | LIBRARY 30 | STANDALONE 18 | TRIPWIRE 8
+# The unit is one FILE reading one VARIABLE, which is the unit a classification
+# actually belongs to. It is smaller than the raw access count (106 lines before
+# this work, 100 after) because two lines in one file reading the same variable
+# are one decision, not two.
 
 # ---------------------------------------------------------------------------
 # VIOLATION — the burn-down list. Each names its blocker.
 # ---------------------------------------------------------------------------
-src/gen_worker/compile_cache.py:553 VIOLATION WORKER_IMAGE_DIGEST is a Settings field AND a compile-cache KEY AXIS. runtime_key() has 21 callers and no settings; needs an install-once image identity. Latent not live: production pods receive this via env so the loader and the raw read agree - it diverges only on a deployment configuring it from yaml/.env/secrets, where the cell would silently key on "".
-src/gen_worker/executor.py:843 VIOLATION RUNPOD_POD_ID as a proxy for "managed runtime". Blocked on pgw#921/th#1488 RuntimeIdentity.managed - pgw#929 AMBIGUOUS #5 forbids adding a vendor Settings field instead.
-src/gen_worker/executor.py:844 VIOLATION RUNPOD_PROVIDER, same blocker. This is why a Vast pod has to be given a RunPod-named variable (vast/provider.go:414).
-src/gen_worker/executor.py:846 VIOLATION TENSORHUB_FILL_SOURCE_DIR has a Settings field; Executor.__init__ takes no Settings. Fix with the same pass that threads settings into the executor.
-src/gen_worker/postmortem.py:86 VIOLATION GEN_WORKER_BOOT_RECORD now HAS a field (boot_record_path). BOOT_RECORD_PATH is computed at IMPORT, before any process entry can have loaded config; needs an install-once path.
-src/gen_worker/postmortem.py:89 VIOLATION TENSORHUB_CACHE_DIR, same import-time constant, same fix.
-src/gen_worker/runtime_config.py:51 VIOLATION GEN_WORKER_CONFIG_SNAPSHOT_PATH has a field; this module is reached from paths with no Settings in hand.
-src/gen_worker/runtime_config.py:66 VIOLATION same.
-src/gen_worker/runtime_config.py:69 VIOLATION config->env WRITE-BACK. This is the mechanism keeping the raw readers working, so per pgw#931 sequencing it may only be deleted atomically with the LAST of them - never first.
-src/gen_worker/parallel/runtime.py:248 VIOLATION config->env write-back of boot.cache_dir, used as an intra-process bus. Same sequencing rule.
-src/gen_worker/url_fetch.py:84 VIOLATION GEN_WORKER_URL_FETCH_ALLOWED_HOSTS is an SSRF allow-list: security policy the hub owns and may need to change on a RUNNING worker. Ruled a Directive field (th#1488). As an env, a policy change needs a pod replacement.
-src/gen_worker/input_assets.py:451 VIOLATION GEN_WORKER_INTERNAL_OBJECT_HOSTS, same SSRF ruling, same blocker.
-src/gen_worker/env_seal.py:511 VIOLATION COZY_CELL_EPOCH is an axis of the cell key, so it looks like a value - but bumping it DISOWNS EVERY PREVIOUSLY MINTED CELL. That is a fleet-wide recall, and a recall must be a recorded operator intent with an actor and a reason. `cell_revocations` already exists on the hub and is the right home (th#1499).
-src/gen_worker/entrypoint.py:320 VIOLATION writes TORCHINDUCTOR_CACHE_DIR/TRITON_CACHE_DIR from a computed path. Legitimate library steering, but belongs in the one Settings-derived torch_env() builder rather than here.
+src/gen_worker/compile_cache.py::WORKER_IMAGE_DIGEST VIOLATION WORKER_IMAGE_DIGEST is a Settings field AND a compile-cache KEY AXIS. runtime_key() has 21 callers and no settings; needs an install-once image identity. Latent not live: production pods receive this via env so the loader and the raw read agree - it diverges only on a deployment configuring it from yaml/.env/secrets, where the cell would silently key on "".
+src/gen_worker/executor.py::RUNPOD_PROVIDER VIOLATION TENSORHUB_FILL_SOURCE_DIR has a Settings field; Executor.__init__ takes no Settings. Fix with the same pass that threads settings into the executor.
+src/gen_worker/postmortem.py::GEN_WORKER_BOOT_RECORD VIOLATION GEN_WORKER_BOOT_RECORD now HAS a field (boot_record_path). BOOT_RECORD_PATH is computed at IMPORT, before any process entry can have loaded config; needs an install-once path.
+src/gen_worker/postmortem.py::TENSORHUB_CACHE_DIR VIOLATION TENSORHUB_CACHE_DIR, same import-time constant, same fix.
+src/gen_worker/runtime_config.py::GEN_WORKER_CONFIG_SNAPSHOT_PATH VIOLATION GEN_WORKER_CONFIG_SNAPSHOT_PATH has a field; this module is reached from paths with no Settings in hand.
+src/gen_worker/parallel/runtime.py::TENSORHUB_CACHE_DIR VIOLATION config->env write-back of boot.cache_dir, used as an intra-process bus. Same sequencing rule.
+src/gen_worker/url_fetch.py::GEN_WORKER_URL_FETCH_ALLOWED_HOSTS VIOLATION GEN_WORKER_URL_FETCH_ALLOWED_HOSTS is an SSRF allow-list: security policy the hub owns and may need to change on a RUNNING worker. Ruled a Directive field (th#1488). As an env, a policy change needs a pod replacement.
+src/gen_worker/input_assets.py::GEN_WORKER_INTERNAL_OBJECT_HOSTS VIOLATION GEN_WORKER_INTERNAL_OBJECT_HOSTS, same SSRF ruling, same blocker.
+src/gen_worker/env_seal.py::COZY_CELL_EPOCH VIOLATION COZY_CELL_EPOCH is an axis of the cell key, so it looks like a value - but bumping it DISOWNS EVERY PREVIOUSLY MINTED CELL. That is a fleet-wide recall, and a recall must be a recorded operator intent with an actor and a reason. `cell_revocations` already exists on the hub and is the right home (th#1499).
+src/gen_worker/entrypoint.py::$var VIOLATION writes TORCHINDUCTOR_CACHE_DIR/TRITON_CACHE_DIR from a computed path. Legitimate library steering, but belongs in the one Settings-derived torch_env() builder rather than here.
 
-src/gen_worker/procsplit/parent.py:497 VIOLATION `dict(os.environ)` then `pop(_CHILD_FORBIDDEN_ENVS)` is a DENYLIST: the compute child inherits every variable not explicitly named. Correct shape is an allowlist built from Settings. Same shape th#1502 records at registry.go, and the reason tenant code can see anything nobody thought to strip.
-src/gen_worker/procsplit/parent.py:1359 VIOLATION same denylist shape for the silicon-measurement child.
-src/gen_worker/topology.py:573 VIOLATION binds the WHOLE environment as the default source and reads WORKER_EXECUTION_TOPOLOGY out of it. The hub-delivered topology has no Settings field; absent is legal and means one slot, so a misspelling silently serves one card on a multi-GPU pod.
-src/gen_worker/aot_compile_pool.py:975 IPC seeds the AOT entry child's env from this process's, then sets GEN_WORKER_AOT_ENTRY_CHILD. Parent-to-child handoff; the inherited base is the denylist shape above.
-src/gen_worker/mint_process.py:455 IPC seeds the mint child's env, then sets GEN_WORKER_MINT_CHILD. Same handoff shape.
-src/gen_worker/runtimes/server.py:119 IPC seeds an engine-server subprocess's env. The engine is a third-party binary configured by environment; there is no other API.
-src/gen_worker/subproc.py:140 IPC seeds a per-invoke subprocess's env in order to set GEN_WORKER_CONFIG_SNAPSHOT_PATH. §1.18 ownership test FAILS with its sibling at :144 - the snapshot path originates in Settings.
-src/gen_worker/env_seal.py:136 LIBRARY scrub_env() ITERATES the environment to find every name under SCRUB_PREFIXES and erase it before torch imports. Reading all of it is the mechanism; this is the one place §1.18 is already mechanically enforced in either repo.
+src/gen_worker/topology.py::<unresolved> VIOLATION binds the WHOLE environment as the default source and reads WORKER_EXECUTION_TOPOLOGY out of it. The hub-delivered topology has no Settings field; absent is legal and means one slot, so a misspelling silently serves one card on a multi-GPU pod.
+src/gen_worker/aot_compile_pool.py::<unresolved> IPC seeds the AOT entry child's env from this process's, then sets GEN_WORKER_AOT_ENTRY_CHILD. Parent-to-child handoff; the inherited base is the denylist shape above.
+src/gen_worker/mint_process.py::<unresolved> IPC seeds the mint child's env, then sets GEN_WORKER_MINT_CHILD. Same handoff shape.
+src/gen_worker/runtimes/server.py::<unresolved> IPC seeds an engine-server subprocess's env. The engine is a third-party binary configured by environment; there is no other API.
+src/gen_worker/subproc.py::<unresolved> IPC seeds a per-invoke subprocess's env in order to set GEN_WORKER_CONFIG_SNAPSHOT_PATH. §1.18 ownership test FAILS with its sibling at :144 - the snapshot path originates in Settings.
+src/gen_worker/env_seal.py::<unresolved> LIBRARY scrub_env() ITERATES the environment to find every name under SCRUB_PREFIXES and erase it before torch imports. Reading all of it is the mechanism; this is the one place §1.18 is already mechanically enforced in either repo.
 
+src/gen_worker/executor.py::RUNPOD_POD_ID VIOLATION RUNPOD_POD_ID as a proxy for "managed runtime". Blocked on pgw#921/th#1488 RuntimeIdentity.managed - pgw#929 AMBIGUOUS #5 forbids adding a vendor Settings field instead.
+src/gen_worker/executor.py::TENSORHUB_FILL_SOURCE_DIR VIOLATION has a Settings field; Executor.__init__ takes no Settings. Fix with the same pass that threads settings into the executor.
+src/gen_worker/procsplit/parent.py::<unresolved> VIOLATION `dict(os.environ)` then `pop(_CHILD_FORBIDDEN_ENVS)` is a DENYLIST: the compute child inherits every variable not explicitly named. Correct shape is an allowlist built from Settings. Same shape th#1502 records at registry.go, and the reason tenant code can see anything nobody thought to strip.
 # ---------------------------------------------------------------------------
 # BOOTSTRAP — six sites. The one thing this repo already gets right.
 # ---------------------------------------------------------------------------
-src/gen_worker/entrypoint.py:26 BOOTSTRAP PYTORCH_CUDA_ALLOC_CONF setdefault must precede any torch import; the reason is given at the site and is load-bearing.
-src/gen_worker/entrypoint.py:35 BOOTSTRAP TORCHINDUCTOR_AUTOGRAD_CACHE setdefault, same pre-import constraint.
-src/gen_worker/procsplit/__init__.py:72 BOOTSTRAP GEN_WORKER_COMPUTE_CHILD decides WHICH OF TWO PROGRAMS this process is, before _run_main and before any config exists.
-src/gen_worker/supervisor.py:66 BOOTSTRAP pre-fork supervisor predicate; runs before the worker process entry.
-src/gen_worker/supervisor.py:68 BOOTSTRAP pre-fork re-entry guard, same.
-src/gen_worker/aot_compile_child.py:292 BOOTSTRAP child log level, applied before the child has any config.
+src/gen_worker/entrypoint.py::PYTORCH_CUDA_ALLOC_CONF BOOTSTRAP PYTORCH_CUDA_ALLOC_CONF setdefault must precede any torch import; the reason is given at the site and is load-bearing.
+src/gen_worker/entrypoint.py::TORCHINDUCTOR_AUTOGRAD_CACHE BOOTSTRAP TORCHINDUCTOR_AUTOGRAD_CACHE setdefault, same pre-import constraint.
+src/gen_worker/procsplit/__init__.py::GEN_WORKER_COMPUTE_CHILD BOOTSTRAP GEN_WORKER_COMPUTE_CHILD decides WHICH OF TWO PROGRAMS this process is, before _run_main and before any config exists.
+src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISOR BOOTSTRAP pre-fork supervisor predicate; runs before the worker process entry.
+src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISED BOOTSTRAP pre-fork re-entry guard, same.
+src/gen_worker/aot_compile_child.py::GEN_WORKER_LOG_LEVEL BOOTSTRAP child log level, applied before the child has any config.
 
 # ---------------------------------------------------------------------------
 # IPC — parent to child across exec. §1.17 routes these to argv (pgw#929).
 # ---------------------------------------------------------------------------
-src/gen_worker/procsplit/__init__.py:59 IPC GEN_WORKER_HOST_SIBLINGS, parent-minted per child. Note pgw#929 AMBIGUOUS #4: it is ALSO a CPU/RAM budget divisor (a value) and <=1 skips inductor-cache isolation (a gate). The two want splitting.
-src/gen_worker/procsplit/__init__.py:66 IPC GEN_WORKER_GROUP_ORDINAL, parent-minted per child.
-src/gen_worker/procsplit/child.py:52 IPC GEN_WORKER_CHILD_SOCKET, parent-minted.
-src/gen_worker/procsplit/child.py:105 IPC GEN_WORKER_CHILD_WATCHDOG_PING_S, parent-minted.
-src/gen_worker/procsplit/child.py:126 IPC GEN_WORKER_CHILD_LIVENESS_FD, parent-minted.
-src/gen_worker/procsplit/child.py:246 IPC GEN_WORKER_CHILD_SOCKET, second reader in the same child.
-src/gen_worker/procsplit/parent.py:1109 IPC GEN_WORKER_CHILD_CMD is literally an argv override delivered by env - the sharpest case for the argv conversion.
-src/gen_worker/procsplit/parent.py:1171 IPC watchdog ping cadence handed down to the child.
-src/gen_worker/procsplit/privdrop.py:160 IPC GEN_WORKER_COMPUTE_UID, parent-minted per child.
-src/gen_worker/intent_registry.py:106 IPC GEN_WORKER_SESSION_ID must SURVIVE RESPAWN, so it is a genuine handoff value - keep it, on argv.
-src/gen_worker/env_seal.py:321 IPC GEN_WORKER_SEAL_LIB_MEMO, parent-minted memo path.
-src/gen_worker/subproc.py:144 IPC forwards GEN_WORKER_CONFIG_SNAPSHOT_PATH to a child. §1.18 ownership test FAILS: this value ORIGINATES in Settings, so the child must receive config rather than re-derive it from an env the parent re-exported.
-src/gen_worker/supervisor.py:226 IPC GEN_WORKER_SUPERVISED marks the forked child.
-src/gen_worker/supervisor.py:152 IPC GEN_WORKER_POSTMORTEM_FILE sink path for the pre-fork supervisor.
-src/gen_worker/lifecycle.py:185 IPC WORKER_EXECUTION_TOPOLOGY (topology.ENV_VAR), the hub-delivered multi-GPU topology JSON, re-read here only to decide whether the "GPUs are invisible" warning applies. Absent is legal and means one slot - which is why an unset value on a multi-GPU pod needs the warning at all.
-src/gen_worker/host_canary.py:566 IPC restores the child's saved env after the canary subprocess.
-src/gen_worker/host_canary.py:568 IPC restores the child's saved env after the canary subprocess.
+src/gen_worker/procsplit/__init__.py::GEN_WORKER_HOST_SIBLINGS IPC GEN_WORKER_HOST_SIBLINGS, parent-minted per child. Note pgw#929 AMBIGUOUS #4: it is ALSO a CPU/RAM budget divisor (a value) and <=1 skips inductor-cache isolation (a gate). The two want splitting.
+src/gen_worker/procsplit/__init__.py::GEN_WORKER_GROUP_ORDINAL IPC GEN_WORKER_GROUP_ORDINAL, parent-minted per child.
+src/gen_worker/procsplit/child.py::$ENV_SOCKET IPC GEN_WORKER_CHILD_SOCKET, parent-minted.
+src/gen_worker/procsplit/child.py::$ENV_WATCHDOG_PING_S IPC GEN_WORKER_CHILD_WATCHDOG_PING_S, parent-minted.
+src/gen_worker/procsplit/child.py::$ENV_LIVENESS_FD IPC GEN_WORKER_CHILD_LIVENESS_FD, parent-minted.
+src/gen_worker/procsplit/parent.py::$ENV_CHILD_CMD IPC watchdog ping cadence handed down to the child.
+src/gen_worker/procsplit/privdrop.py::GEN_WORKER_COMPUTE_UID IPC GEN_WORKER_COMPUTE_UID, parent-minted per child.
+src/gen_worker/intent_registry.py::GEN_WORKER_SESSION_ID IPC GEN_WORKER_SESSION_ID must SURVIVE RESPAWN, so it is a genuine handoff value - keep it, on argv.
+src/gen_worker/env_seal.py::GEN_WORKER_SEAL_LIB_MEMO IPC GEN_WORKER_SEAL_LIB_MEMO, parent-minted memo path.
+src/gen_worker/subproc.py::$SNAPSHOT_PATH_ENV IPC forwards GEN_WORKER_CONFIG_SNAPSHOT_PATH to a child. §1.18 ownership test FAILS: this value ORIGINATES in Settings, so the child must receive config rather than re-derive it from an env the parent re-exported.
+src/gen_worker/supervisor.py::GEN_WORKER_POSTMORTEM_FILE IPC GEN_WORKER_POSTMORTEM_FILE sink path for the pre-fork supervisor.
+src/gen_worker/host_canary.py::$k IPC restores the child's saved env after the canary subprocess.
 
+src/gen_worker/lifecycle.py::$ENV_VAR IPC WORKER_EXECUTION_TOPOLOGY (topology.ENV_VAR), the hub-delivered multi-GPU topology JSON, re-read only to decide whether the "GPUs are invisible" warning applies. Absent is legal and means one slot - which is why an unset value on a multi-GPU pod needs the warning at all.
+src/gen_worker/procsplit/parent.py::$ENV_WATCHDOG_PING_S IPC watchdog ping cadence handed down to the child.
 # ---------------------------------------------------------------------------
 # LIBRARY — torch / inductor / triton / NCCL read env at import. Accepted as a
 # MECHANISM. The VALUES are authored constants scattered across nine files,
 # which is C4 dressed as plumbing: pgw#931 deliverable 6 folds them into one
 # inspectable Settings-derived builder.
 # ---------------------------------------------------------------------------
-src/gen_worker/compile_cache.py:1219 LIBRARY reads the inductor/triton env block for the seal snapshot.
-src/gen_worker/compile_cache.py:1450 LIBRARY writes the inductor cache dir torch reads at import.
-src/gen_worker/compile_cache.py:1481 LIBRARY TORCHINDUCTOR_AUTOGRAD_CACHE=0; torch offers no other API.
-src/gen_worker/compile_cache.py:1621 LIBRARY CXX host-compiler discovery, the toolchain's own convention.
-src/gen_worker/compile_cache.py:1698 LIBRARY reads back the inductor cache dir torch was steered to.
-src/gen_worker/compile_cache.py:1794 LIBRARY reads back the inductor cache dir torch was steered to.
-src/gen_worker/compile_cache.py:4119 LIBRARY saves the inductor env block around a scoped override.
-src/gen_worker/compile_cache.py:4130 LIBRARY restores the saved inductor env block.
-src/gen_worker/compile_cache.py:4132 LIBRARY restores the saved inductor env block.
-src/gen_worker/aot_export_reuse.py:236 LIBRARY scopes TORCHINDUCTOR_CACHE_DIR around the reuse gate.
-src/gen_worker/aot_export_reuse.py:237 LIBRARY scopes TORCHINDUCTOR_CACHE_DIR around the reuse gate.
-src/gen_worker/aot_export_reuse.py:254 LIBRARY restores TORCHINDUCTOR_CACHE_DIR.
-src/gen_worker/aot_export_reuse.py:256 LIBRARY restores TORCHINDUCTOR_CACHE_DIR.
-src/gen_worker/host_canary.py:493 LIBRARY reads NCCL_P2P_DISABLE for the canary's recorded facts.
-src/gen_worker/host_canary.py:532 LIBRARY saves the NCCL/torch-distributed env before the canary.
-src/gen_worker/host_canary.py:534 LIBRARY MASTER_ADDR, torch.distributed reads it at init.
-src/gen_worker/host_canary.py:535 LIBRARY MASTER_PORT, torch.distributed reads it at init.
-src/gen_worker/host_canary.py:537 LIBRARY NCCL_P2P_DISABLE for the canary run.
-src/gen_worker/host_canary.py:539 LIBRARY restores NCCL_P2P_DISABLE.
-src/gen_worker/parallel/group.py:175 LIBRARY reads the prior NCCL_NVLS_ENABLE only to REPORT that it is being overwritten.
-src/gen_worker/parallel/group.py:176 LIBRARY NCCL_NVLS_ENABLE=0, written UNCONDITIONALLY immediately before communicator creation (pgw#929 AMBIGUOUS #3). NCCL reads env at init and offers no other API; the operator/image override was deleted.
-src/gen_worker/env_seal.py:138 LIBRARY scrub_env() ERASES the behaviour namespaces before torch imports. The one place §1.18 is already mechanically enforced in either repo - copy it, do not weaken it.
-src/gen_worker/env_seal.py:159 LIBRARY PYTHONHASHSEED is a CPython interpreter fact the seal must record.
-src/gen_worker/env_seal.py:169 LIBRARY PYTHONHASHSEED, second recording site.
-src/gen_worker/models/native_kernels.py:136 LIBRARY GEN_WORKER_NATIVE_KERNELS_LIB, explicit .so path override for the loader.
-src/gen_worker/aot_wrapper_split.py:327 LIBRARY GEN_WORKER_AOT_HOST_COMPILE_JOBS, per-entry host-compile fan-out; derived from the pod budget when unset.
-src/gen_worker/aot_export_parallel.py:55 LIBRARY DARK FEATURE, off by default. See the note at the end of this file - it must NOT be made unconditional.
-src/gen_worker/aot_export_reuse.py:82 LIBRARY DARK FEATURE, off by default. Same note.
-src/gen_worker/aot_wrapper_split.py:569 LIBRARY GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF. LIVE: five SDXL releases (0.2.111/112/113/116/117) declare it in `release_env_declarations` and one endpoint has a non-deleted `endpoint_env_entries` row. Verified on the standing hub 2026-08-03. NOT a deletion candidate.
+src/gen_worker/compile_cache.py::$env LIBRARY reads the inductor/triton env block for the seal snapshot.
+src/gen_worker/compile_cache.py::TORCHINDUCTOR_AUTOGRAD_CACHE LIBRARY TORCHINDUCTOR_AUTOGRAD_CACHE=0; torch offers no other API.
+src/gen_worker/compile_cache.py::CXX LIBRARY CXX host-compiler discovery, the toolchain's own convention.
+src/gen_worker/compile_cache.py::TORCHINDUCTOR_CACHE_DIR LIBRARY reads back the inductor cache dir torch was steered to.
+src/gen_worker/aot_export_reuse.py::TORCHINDUCTOR_CACHE_DIR LIBRARY scopes TORCHINDUCTOR_CACHE_DIR around the reuse gate.
+src/gen_worker/host_canary.py::NCCL_P2P_DISABLE LIBRARY reads NCCL_P2P_DISABLE for the canary's recorded facts.
+src/gen_worker/host_canary.py::MASTER_ADDR LIBRARY MASTER_ADDR, torch.distributed reads it at init.
+src/gen_worker/host_canary.py::MASTER_PORT LIBRARY MASTER_PORT, torch.distributed reads it at init.
+src/gen_worker/parallel/group.py::NCCL_NVLS_ENABLE LIBRARY reads the prior NCCL_NVLS_ENABLE only to REPORT that it is being overwritten.
+src/gen_worker/env_seal.py::$name LIBRARY scrub_env() ERASES the behaviour namespaces before torch imports. The one place §1.18 is already mechanically enforced in either repo - copy it, do not weaken it.
+src/gen_worker/env_seal.py::PYTHONHASHSEED LIBRARY PYTHONHASHSEED is a CPython interpreter fact the seal must record.
+src/gen_worker/models/native_kernels.py::GEN_WORKER_NATIVE_KERNELS_LIB LIBRARY GEN_WORKER_NATIVE_KERNELS_LIB, explicit .so path override for the loader.
+src/gen_worker/aot_wrapper_split.py::GEN_WORKER_AOT_HOST_COMPILE_JOBS LIBRARY GEN_WORKER_AOT_HOST_COMPILE_JOBS, per-entry host-compile fan-out; derived from the pod budget when unset.
+src/gen_worker/aot_export_parallel.py::GEN_WORKER_AOT_EXPORT_PARALLEL LIBRARY DARK FEATURE, off by default. See the note at the end of this file - it must NOT be made unconditional.
+src/gen_worker/aot_export_reuse.py::GEN_WORKER_AOT_EXPORT_REUSE LIBRARY DARK FEATURE, off by default. Same note.
+src/gen_worker/aot_wrapper_split.py::GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF LIBRARY GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF. LIVE: five SDXL releases (0.2.111/112/113/116/117) declare it in `release_env_declarations` and one endpoint has a non-deleted `endpoint_env_entries` row. Verified on the standing hub 2026-08-03. NOT a deletion candidate.
 
 # ---------------------------------------------------------------------------
 # STANDALONE — CLI / convert paths that load no app config.
 # ---------------------------------------------------------------------------
-src/gen_worker/cli/local_context.py:74 STANDALONE GEN_WORKER_LOCAL_OUTPUT_DIR, local-run output dir.
-src/gen_worker/cli/local_context.py:224 STANDALONE USER, for the local-dev owner label.
-src/gen_worker/convert/clone.py:634 STANDALONE COZY_CONVERT_SCRATCH_TTL_S, convert-tool scratch TTL.
-src/gen_worker/convert/clone.py:665 STANDALONE COZY_CONVERT_WORKDIR, convert-tool scratch base.
-src/gen_worker/convert/ingest.py:69 STANDALONE COZY_CLONE_DOWNLOAD_ATTEMPTS, convert-tool retry count.
-src/gen_worker/models/download.py:733 STANDALONE COZY_CIVITAI_DOWNLOAD_ATTEMPTS, provider retry count.
-src/gen_worker/net.py:44 STANDALONE COZY_HTTP_*_TIMEOUT_S. Documented as "read from env on every call (test-tunable)" - i.e. env used as a TEST SEAM, which is what loader `init_kwargs` exists for. Worth fixing; it is the last piece of prose from the old 5-file exception list that is still true.
-src/gen_worker/local_cells.py:74 STANDALONE GEN_WORKER_LOCAL_CELLS_DIR, local cell store for offline runs.
-src/gen_worker/video_encode.py:125 STANDALONE GEN_WORKER_VIDEO_ENCODER. pgw#929 rules this MEASURED-then-requested (th#1458-1460 store the evidence, pgw#891 carries the exact requested implementation). Env until then.
-src/gen_worker/video_encode.py:155 STANDALONE GEN_WORKER_VIDEO_ENCODE_CONCURRENCY, encode fan-out.
-src/gen_worker/models/native_kernels.py:48 STANDALONE GEN_WORKER_NATIVE_KERNELS, same measured-then-requested ruling as the video encoder.
-src/gen_worker/models/svdq.py:218 STANDALONE GEN_WORKER_SVDQ_ENGINE, same measured-then-requested ruling.
-src/gen_worker/aot_resume.py:150 STANDALONE GEN_WORKER_MINT_RESUME_MAX_BYTES, resume-area capacity bound.
-src/gen_worker/aot_resume.py:216 STANDALONE GEN_WORKER_MINT_RESUME_DIR. pgw#929: the ENABLE used to be hidden inside an empty string; `resume_enabled()` now states it.
-src/gen_worker/executor.py:618 STANDALONE GEN_WORKER_BG_YIELD=0 restores the pre-pgw#677 shape. See the kill-switch note below.
-src/gen_worker/executor.py:2840 STANDALONE GEN_WORKER_EAGER_FIRST_BOOT=0. See the kill-switch note below.
-src/gen_worker/mint_delegate.py:71 STANDALONE GEN_WORKER_MINT_IN_PROCESS forces the in-process mint shape, which VIOLATES the liveness contract and is kept reachable to prove that, not to run.
-src/gen_worker/mint_delegate.py:75 STANDALONE GEN_WORKER_EAGER_FIRST_BOOT, second reader; the two switches move together.
+src/gen_worker/cli/local_context.py::GEN_WORKER_LOCAL_OUTPUT_DIR STANDALONE GEN_WORKER_LOCAL_OUTPUT_DIR, local-run output dir.
+src/gen_worker/cli/local_context.py::USER STANDALONE USER, for the local-dev owner label.
+src/gen_worker/convert/clone.py::COZY_CONVERT_SCRATCH_TTL_S STANDALONE COZY_CONVERT_SCRATCH_TTL_S, convert-tool scratch TTL.
+src/gen_worker/convert/clone.py::COZY_CONVERT_WORKDIR STANDALONE COZY_CONVERT_WORKDIR, convert-tool scratch base.
+src/gen_worker/convert/ingest.py::COZY_CLONE_DOWNLOAD_ATTEMPTS STANDALONE COZY_CLONE_DOWNLOAD_ATTEMPTS, convert-tool retry count.
+src/gen_worker/models/download.py::COZY_CIVITAI_DOWNLOAD_ATTEMPTS STANDALONE COZY_CIVITAI_DOWNLOAD_ATTEMPTS, provider retry count.
+src/gen_worker/net.py::$name STANDALONE COZY_HTTP_*_TIMEOUT_S. Documented as "read from env on every call (test-tunable)" - i.e. env used as a TEST SEAM, which is what loader `init_kwargs` exists for. Worth fixing; it is the last piece of prose from the old 5-file exception list that is still true.
+src/gen_worker/local_cells.py::GEN_WORKER_LOCAL_CELLS_DIR STANDALONE GEN_WORKER_LOCAL_CELLS_DIR, local cell store for offline runs.
+src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODER STANDALONE GEN_WORKER_VIDEO_ENCODER. pgw#929 rules this MEASURED-then-requested (th#1458-1460 store the evidence, pgw#891 carries the exact requested implementation). Env until then.
+src/gen_worker/video_encode.py::GEN_WORKER_VIDEO_ENCODE_CONCURRENCY STANDALONE GEN_WORKER_VIDEO_ENCODE_CONCURRENCY, encode fan-out.
+src/gen_worker/models/native_kernels.py::GEN_WORKER_NATIVE_KERNELS STANDALONE GEN_WORKER_NATIVE_KERNELS, same measured-then-requested ruling as the video encoder.
+src/gen_worker/models/svdq.py::GEN_WORKER_SVDQ_ENGINE STANDALONE GEN_WORKER_SVDQ_ENGINE, same measured-then-requested ruling.
+src/gen_worker/aot_resume.py::GEN_WORKER_MINT_RESUME_MAX_BYTES STANDALONE GEN_WORKER_MINT_RESUME_MAX_BYTES, resume-area capacity bound.
+src/gen_worker/aot_resume.py::GEN_WORKER_MINT_RESUME_DIR STANDALONE GEN_WORKER_MINT_RESUME_DIR. pgw#929: the ENABLE used to be hidden inside an empty string; `resume_enabled()` now states it.
+src/gen_worker/mint_delegate.py::GEN_WORKER_MINT_IN_PROCESS STANDALONE GEN_WORKER_MINT_IN_PROCESS forces the in-process mint shape, which VIOLATES the liveness contract and is kept reachable to prove that, not to run.
+src/gen_worker/mint_delegate.py::GEN_WORKER_EAGER_FIRST_BOOT STANDALONE GEN_WORKER_EAGER_FIRST_BOOT, second reader; the two switches move together.
 
+src/gen_worker/executor.py::GEN_WORKER_BG_YIELD STANDALONE GEN_WORKER_BG_YIELD=0 restores the pre-pgw#677 shape. See the kill-switch note below.
+src/gen_worker/executor.py::GEN_WORKER_EAGER_FIRST_BOOT STANDALONE GEN_WORKER_EAGER_FIRST_BOOT=0. See the kill-switch note below.
 # ---------------------------------------------------------------------------
 # TRIPWIRE — guards whose entire purpose is to fire on a misconfiguration.
 # ---------------------------------------------------------------------------
-src/gen_worker/content_credentials.py:191 TRIPWIRE GEN_WORKER_C2PA_KEY_PEM / _KEY_PATH presence RAISES and refuses the boot (th#1307). A private key must never reach a pod. Correctly loud; carries no behaviour of its own.
-src/gen_worker/models/memory.py:1191 TRIPWIRE GEN_WORKER_FORBID_CPU_OFFLOAD, now enforced at the REAL placement boundary (pgw#929 AMBIGUOUS #1). Read as env rather than Settings because a control-plane box exports it box-wide with no worker config in sight.
-src/gen_worker/benchmarks/swap_latency.py:84 TRIPWIRE GEN_WORKER_FORBID_CPU_OFFLOAD, the original single reader. Retained: refusing the benchmark is still correct.
-src/gen_worker/host_move_guard.py:44 TRIPWIRE GEN_WORKER_HOST_MOVE_GUARD, the pgw#763 host-move guard's disable escape hatch. See the kill-switch note below.
-src/gen_worker/aot_wrapper_split.py:529 TRIPWIRE GEN_WORKER_AOT_WRAPPER_SPLIT_OFF, v1 ctor-split disable. See the kill-switch note below.
-src/gen_worker/aot_mint.py:1548 TRIPWIRE PODGUARD_STATE, gated on podguard_status()==armed.
-src/gen_worker/aot_mint.py:1581 TRIPWIRE PODGUARD_STATE validation. External watchdog adapter with a producer OUTSIDE this process (`podguard.arm()` on rented pods), so there is no argv to move it to and no Settings that could own it. pgw#929 owns its validation and observability permanently; deletion is explicitly out of scope.
-src/gen_worker/aot_mint.py:1604 TRIPWIRE PODGUARD_STATE, reported in the invalid-state diagnostic.
+src/gen_worker/content_credentials.py::$env_name TRIPWIRE GEN_WORKER_C2PA_KEY_PEM / _KEY_PATH presence RAISES and refuses the boot (th#1307). A private key must never reach a pod. Correctly loud; carries no behaviour of its own.
+src/gen_worker/models/memory.py::GEN_WORKER_FORBID_CPU_OFFLOAD TRIPWIRE GEN_WORKER_FORBID_CPU_OFFLOAD, now enforced at the REAL placement boundary (pgw#929 AMBIGUOUS #1). Read as env rather than Settings because a control-plane box exports it box-wide with no worker config in sight.
+src/gen_worker/benchmarks/swap_latency.py::GEN_WORKER_FORBID_CPU_OFFLOAD TRIPWIRE GEN_WORKER_FORBID_CPU_OFFLOAD, the original single reader. Retained: refusing the benchmark is still correct.
+src/gen_worker/host_move_guard.py::GEN_WORKER_HOST_MOVE_GUARD TRIPWIRE GEN_WORKER_HOST_MOVE_GUARD, the pgw#763 host-move guard's disable escape hatch. See the kill-switch note below.
+src/gen_worker/aot_wrapper_split.py::GEN_WORKER_AOT_WRAPPER_SPLIT_OFF TRIPWIRE GEN_WORKER_AOT_WRAPPER_SPLIT_OFF, v1 ctor-split disable. See the kill-switch note below.
 
+src/gen_worker/aot_mint.py::PODGUARD_STATE TRIPWIRE External watchdog adapter with a producer OUTSIDE this process (`podguard.arm()` on rented pods), so there is no argv to move it to and no Settings that could own it. Gated on podguard_status()==armed; pgw#929 owns its validation and observability permanently and deletion is explicitly out of scope.
 # ---------------------------------------------------------------------------
 # NOTE — the seven "kill switches" pgw#929 lists for deletion. FIVE can go once
 # their unconditional path has a named observable; TWO CANNOT, and saying so is

--- a/scripts/lint_config_reads.py
+++ b/scripts/lint_config_reads.py
@@ -63,6 +63,10 @@ CLASSIFICATIONS = {
 #: Namespaces this program owns; see config/loader.py `_OWNED_PREFIXES`.
 OWNED_PREFIXES = ("GEN_WORKER_", "TENSORHUB_", "WORKER_", "COZY_")
 
+#: Key for a site whose variable this walk cannot name statically — a bare
+#: `os.environ` binding (`dict(os.environ)`) or a computed key.
+UNRESOLVED = "<unresolved>"
+
 
 class EnvVisitor(ast.NodeVisitor):
     """Every `os.environ` / `os.getenv` access, with the name when it is static."""
@@ -70,6 +74,12 @@ class EnvVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.hits: List[Tuple[int, str]] = []
         self.consts: Dict[str, str] = {}
+        #: `os.environ` attribute nodes already accounted for as the base of a
+        #: `.get(...)` / `[...]`. Without this, `os.environ.get("X")` records
+        #: BOTH ("X", from the call) and an unnamed bare binding (from the
+        #: attribute), which double-counts the census and invents
+        #: `<unresolved>` entries for sites whose variable is right there.
+        self._consumed: Set[int] = set()
 
     def load_consts(self, tree: ast.AST) -> None:
         for node in ast.walk(tree):
@@ -86,9 +96,13 @@ class EnvVisitor(ast.NodeVisitor):
         if isinstance(node, ast.Constant) and isinstance(node.value, str):
             return node.value
         if isinstance(node, ast.Name):
-            return self.consts.get(node.id, "")
+            # A module constant imported from a sibling (`ENV_SOCKET`) cannot be
+            # resolved by a single-file walk, but the IDENTIFIER is itself a
+            # stable, specific key — and unlike a line number, nobody else's
+            # edit moves it.
+            return self.consts.get(node.id) or f"${node.id}"
         if isinstance(node, ast.Attribute):
-            return self.consts.get(node.attr, "")
+            return self.consts.get(node.attr) or f"${node.attr}"
         return ""
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -100,6 +114,7 @@ class EnvVisitor(ast.NodeVisitor):
             is_getenv = (isinstance(base, ast.Name) and base.id == "os"
                          and func.attr == "getenv")
             if is_environ or is_bare_environ or is_getenv:
+                self._consumed.add(id(base))
                 self.hits.append(
                     (node.lineno, self._name(node.args[0] if node.args else None)))
         self.generic_visit(node)
@@ -107,6 +122,7 @@ class EnvVisitor(ast.NodeVisitor):
     def visit_Subscript(self, node: ast.Subscript) -> None:
         value = node.value
         if isinstance(value, ast.Attribute) and value.attr == "environ":
+            self._consumed.add(id(value))
             self.hits.append((node.lineno, self._name(node.slice)))
         elif isinstance(value, ast.Name) and value.id == "environ":
             self.hits.append((node.lineno, self._name(node.slice)))
@@ -123,15 +139,32 @@ class EnvVisitor(ast.NodeVisitor):
         nobody thought to name. Same shape th#1502 records at `registry.go`.
         Hits dedupe by line, so an `os.environ.get(...)` is not double-counted.
         """
-        if isinstance(node.value, ast.Name) and node.value.id == "os" \
-                and node.attr == "environ":
+        if (isinstance(node.value, ast.Name) and node.value.id == "os"
+                and node.attr == "environ" and id(node) not in self._consumed):
             self.hits.append((node.lineno, ""))
         self.generic_visit(node)
 
 
-def scan() -> Tuple[Dict[str, Set[int]], Set[str]]:
-    """Returns {relative path: {line, ...}} outside config/, and every static name."""
-    sites: Dict[str, Set[int]] = {}
+def scan() -> Tuple[Dict[Tuple[str, str], int], Set[str]]:
+    """Every env access outside `config/`, keyed by (path, ENV NAME).
+
+    NOT by line number, and that is the whole point. pgw#931 shipped this gate
+    keyed on `path:line` and it went red on `dev` within the hour: two sibling
+    PRs (#432, #434) merged alongside it and shifted lines in four files nobody
+    in this change had touched. A line number is a fact OTHER PEOPLE change
+    independently, so pinning an allowlist to one makes the allowlist a second
+    carrier that goes stale silently — §4.22, and precisely the defect class
+    this gate exists to police. The gate committed the sin it polices.
+
+    (path, name) is stable under unrelated edits, and it is the meaningful unit
+    anyway: the classification belongs to "this file reading this variable",
+    not to a cursor position. Two sites in one file reading the same name share
+    one classification, which is correct — they are one decision.
+
+    The value per key is a representative line number, for DIAGNOSTICS only.
+    Never for matching.
+    """
+    sites: Dict[Tuple[str, str], int] = {}
     names: Set[str] = set()
     for path in sorted(SRC_ROOT.rglob("*.py")):
         if CONFIG_PKG in path.parents or path == CONFIG_PKG:
@@ -144,19 +177,17 @@ def scan() -> Tuple[Dict[str, Set[int]], Set[str]]:
         visitor = EnvVisitor()
         visitor.load_consts(tree)
         visitor.visit(tree)
-        if not visitor.hits:
-            continue
         rel = str(path.relative_to(REPO))
         for lineno, name in visitor.hits:
-            sites.setdefault(rel, set()).add(lineno)
+            sites.setdefault((rel, name or UNRESOLVED), lineno)
             if name:
                 names.add(name)
     return sites, names
 
 
-def load_allowlist() -> Tuple[Dict[str, Set[int]], List[str]]:
-    """Parse `path:line CLASSIFICATION reason` lines. Returns sites and errors."""
-    allowed: Dict[str, Set[int]] = {}
+def load_allowlist() -> Tuple[Dict[Tuple[str, str], str], List[str]]:
+    """Parse `path::ENV_NAME CLASSIFICATION reason` lines."""
+    allowed: Dict[Tuple[str, str], str] = {}
     errors: List[str] = []
     if not ALLOWLIST.is_file():
         return allowed, [f"{ALLOWLIST} is missing"]
@@ -168,7 +199,7 @@ def load_allowlist() -> Tuple[Dict[str, Set[int]], List[str]]:
         if len(parts) < 3:
             errors.append(
                 f"{ALLOWLIST.name}:{num}: expected "
-                f"'<path>:<line> <CLASSIFICATION> <reason>', got {raw!r}")
+                f"'<path>::<ENV_NAME> <CLASSIFICATION> <reason>', got {raw!r}")
             continue
         site, classification, reason = parts
         if classification not in CLASSIFICATIONS:
@@ -179,11 +210,14 @@ def load_allowlist() -> Tuple[Dict[str, Set[int]], List[str]]:
         if not reason.strip():
             errors.append(f"{ALLOWLIST.name}:{num}: a classification needs a reason")
             continue
-        path, _, lineno = site.rpartition(":")
-        if not path or not lineno.isdigit():
-            errors.append(f"{ALLOWLIST.name}:{num}: bad site {site!r}")
+        path, sep, name = site.partition("::")
+        if not path or not sep or not name:
+            errors.append(
+                f"{ALLOWLIST.name}:{num}: bad site {site!r} — expected "
+                f"'<path>::<ENV_NAME>' (use ::{UNRESOLVED} for a bare "
+                f"`os.environ` binding or a name this walk cannot resolve)")
             continue
-        allowed.setdefault(path, set()).add(int(lineno))
+        allowed[(path, name)] = classification
     return allowed, errors
 
 
@@ -213,22 +247,21 @@ def main() -> int:
     sites, names = scan()
     allowed, errors = load_allowlist()
 
-    for path in sorted(sites):
-        for lineno in sorted(sites[path] - allowed.get(path, set())):
-            errors.append(
-                f"{path}:{lineno}: reads the process environment outside "
-                f"gen_worker/config. Ruling §1.18: config is loaded once by the "
-                f"pipeline and PASSED. If this site is genuinely legitimate, add "
-                f"'{path}:{lineno} <CLASSIFICATION> <reason>' to "
-                f"{ALLOWLIST.name} — and say which classification it is.")
+    for key in sorted(set(sites) - set(allowed)):
+        path, name = key
+        errors.append(
+            f"{path}:{sites[key]} reads {name} from the process environment "
+            f"outside gen_worker/config. Ruling §1.18: config is loaded once by "
+            f"the pipeline and PASSED. If this site is genuinely legitimate, add "
+            f"'{path}::{name} <CLASSIFICATION> <reason>' to {ALLOWLIST.name} — "
+            f"and say which classification it is.")
 
-    for path in sorted(allowed):
-        stale = sorted(allowed[path] - sites.get(path, set()))
-        for lineno in stale:
-            errors.append(
-                f"{ALLOWLIST.name}: {path}:{lineno} is allowlisted but reads no "
-                f"environment any more. Delete the line — a stale allowlist is "
-                f"how an exception list stops describing the tree.")
+    for key in sorted(set(allowed) - set(sites)):
+        path, name = key
+        errors.append(
+            f"{ALLOWLIST.name}: {path}::{name} is allowlisted but no longer "
+            f"reads the environment. Delete the line — a stale allowlist is how "
+            f"an exception list stops describing the tree.")
 
     errors.extend(check_owned_names_known(names))
 
@@ -241,8 +274,8 @@ def main() -> int:
             file=sys.stderr)
         return 1
 
-    total = sum(len(v) for v in sites.values())
-    print(f"config-read guard: OK — {total} accepted site(s), all classified.")
+    print(f"config-read guard: OK — {len(sites)} accepted (file, variable) "
+          f"pair(s), all classified.")
     return 0
 
 

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -1168,6 +1168,19 @@ class ParentControl:
         transport_backoff_cap_s: float = 30.0,
     ) -> None:
         self._settings = settings
+        # pgw#931 follow-up: the CONTROL PARENT is the process that holds the
+        # worker credential — the compute child is deliberately stripped of it
+        # (`_CHILD_FORBIDDEN_ENVS`) and signs through this process. So the boot
+        # token is installed HERE, where the parent's `Settings` arrive, not
+        # only in `run_parent`.
+        #
+        # It was in `run_parent` alone, and that was wrong: every other way of
+        # building a control parent — the split harness, the group-process
+        # tests, any embedder — got a parent with no credential, and the
+        # mediated C2PA sign refused with "this pod holds no worker JWT".
+        # Deriving a fact at ONE of several entry points is the §4.22 defect:
+        # the fact and its carrier have to be established together.
+        worker_credential.install_bootstrap(settings)
         env_cmd = os.environ.get(ENV_CHILD_CMD, "").strip()
         self._child_cmd = list(
             child_cmd
@@ -2552,7 +2565,8 @@ def run_parent() -> int:
     # §1.18: the bootstrap-owned load for the CONTROL-PARENT process entry.
     settings = config.install(config.load_settings())
     worker_goals.install(worker_goals.from_settings(settings))
-    worker_credential.install_bootstrap(settings)
+    # The boot credential is installed by ParentControl.__init__, which is the
+    # seam every parent goes through — not just this entry point.
     code = ParentControl(settings).run()
     if code == 0:
         postmortem.clear_boot_record()

--- a/tests/test_config_boundary_pgw931.py
+++ b/tests/test_config_boundary_pgw931.py
@@ -165,3 +165,36 @@ def test_a_foreign_env_is_never_reported(monkeypatch) -> None:
     reported = config.unrecognised_owned_env()
     assert "HF_HUB_ENABLE_HF_TRANSFER" not in reported
     assert "CUDA_VISIBLE_DEVICES" not in reported
+
+
+# ---------------------------------------------------------------------------
+# 4. Derived process facts are established WHERE THE SETTINGS ARRIVE
+# ---------------------------------------------------------------------------
+
+
+def test_parent_control_installs_the_boot_credential(monkeypatch) -> None:
+    """The control parent holds the worker credential; the compute child is
+    stripped of it and signs through the parent.
+
+    pgw#931 first installed the boot token in `procsplit.parent.run_parent`
+    ONLY. That is one of several ways a control parent gets built — the split
+    harness and the group-process tests construct `ParentControl` directly — so
+    every other path produced a parent with no credential and the mediated C2PA
+    sign refused with *"this pod holds no worker JWT"*. Caught by
+    `test_procsplit_security_pgw763` after the merge.
+
+    The lesson is §4.22's: a fact and its carrier must be established together,
+    at the seam the fact's owner is constructed, not at one convenient entry
+    point. This asserts the seam rather than the entry point.
+    """
+    from gen_worker import worker_credential
+    from gen_worker.procsplit.parent import ParentControl
+
+    monkeypatch.setattr(worker_credential, "_TOKEN", "")
+    monkeypatch.setattr(worker_credential, "_BOOTSTRAP", "")
+    assert worker_credential.current() == ""
+
+    ParentControl(config.Settings(bootstrap_worker_jwt="boot-jwt-xyz"))
+    assert worker_credential.current() == "boot-jwt-xyz", (
+        "building a control parent must install its boot credential — the "
+        "child cannot sign through a parent that has none")


### PR DESCRIPTION
Follow-up to #436, found by verifying the **merged** result on `dev` rather than trusting the pre-merge run. Both defects are the same mistake the parent change set is about — *a fact established somewhere other than where it is owned* — which is why they are one commit.

## 1. The gate committed the sin it polices

`config_reads_allowlist.txt` keyed each entry on `path:line`. It went **red on `dev` within the hour**: #432 and #434 merged alongside #436 and shifted lines in four files nobody in that change had touched.

A line number is a fact **other people change independently**. Pinning an allowlist to one makes the allowlist a second carrier that goes stale silently — §4.22, precisely.

Re-keyed on **(path, ENV NAME)**: stable under unrelated edits, and the unit a classification actually belongs to. "This file reading this variable" is one decision, not one per cursor position.
- `path::GEN_WORKER_FOO` — a resolved name
- `path::$ENV_SOCKET` — a constant imported from a sibling module; the identifier is the stable key
- `path::<unresolved>` — a genuine bare `os.environ` binding

**Fixing the key exposed a second bug in the walk.** `visit_Attribute` also fired on the `os.environ` base of `os.environ.get("X")`, so every named read *also* recorded an unnamed one — inflating the census and inventing `<unresolved>` entries for sites whose variable is right there in the source. Consumed-node tracking fixes it.

100 line-keyed sites → **79 (file, variable) pairs**, only **7** genuinely unresolvable (the real bare bindings, three of them the child-env denylist).

| | VIOLATION | BOOTSTRAP | IPC | LIBRARY | STANDALONE | TRIPWIRE |
|---|---|---|---|---|---|---|
| pairs | 14 | 6 | 18 | 17 | 18 | 6 |

## 2. The control parent had no credential

`worker_credential.install_bootstrap` was called from `procsplit.parent.run_parent` **only**. That is one of several ways a control parent is built — the split harness, the group-process tests, and any embedder construct `ParentControl` directly. Every other path produced a parent holding no credential, and the mediated C2PA sign refused with *"this pod holds no worker JWT"*.

Three real failures in `test_procsplit_security_pgw763` (`delta1_tenant_code_finds_no_worker_jwt_in_its_process`, `delta1_the_legitimate_mediated_call_still_works`, `delta5_the_child_signs_through_the_parent_holding_no_credential`) — none of which the pre-merge run reached before the branch was cleaned up post-merge.

The install moves to `ParentControl.__init__`: the seam where the parent's `Settings` arrive and where the credential's owner is constructed. The new regression test asserts **the seam**, not the entry point — asserting the entry point is what missed it.

## Verification (all on merged `dev` + this fix)

- `mypy src/gen_worker` — clean, 223 files
- `ruff` — clean
- `scripts/lint_config_reads.py` — green, 79 pairs
- `tests/test_procsplit_security_pgw763.py` — **32 passed** (was 3 failed / 29 passed)
- `tests/test_config_boundary_pgw931.py` — 13 passed (+1 new)
- `tests/test_worker_goals_pgw930.py` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)