### PR TITLE
pgw#942: the SDK stops making 28 endpoints write its own facts — a recording test context, the deleted-field contract, and the bare-mypy ruling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+- **pgw#942: three SDK holes the 28 endpoints were each paying for, closed once.**
+  The framing, and the reason a P2 was worth doing: *if 28 endpoints all write the same
+  fifteen lines to do something ordinary, that is an SDK gap.* Measured across the
+  endpoint tree at 56,750 Python lines.
+  - **`gen_worker.testing` gains the `save_*` half — a `Recorder`.** `fake_context`
+    shipped for exactly this and reached 4/27 adoption; the other 23 hand-roll 26
+    `class _Ctx(RequestContext)` subclasses (473 lines) whose only real content is a
+    CAPTURING `save_image`/`save_audio` and a `log` override. Passing
+    `fake_context(recorder=Recorder())` records every save — kind, ref, the typed asset
+    with its real `sha256`/`size_bytes`, and the keyword arguments the handler passed —
+    **after** the production `save_*` ran, with outputs written to the recorder's own
+    directory instead of uploaded. `ctx.log`/`ctx.progress` are captured at the emitter
+    seam, so they need no override either. This closes a real hole rather than a
+    cosmetic one: **23 suites are green over an encode path they never call**, which is
+    the reason hidream's own test comment gives for migrating.
+  - **The SDK asserts its own deleted-field set, once** —
+    `gen_worker.api.shape_contract.DELETED_FIELDS`, with `assert_sdk_shape()` (the SDK's
+    self-check) and `assert_declaration_shape(decl)` (walks one endpoint's decl,
+    resources, compile and slots). 25 of 28 packages carried 91 `assert not hasattr(...)`
+    lines plus 46 `for deleted in (...)` loops asserting fields the pinned SDK *cannot*
+    ship, which is the mechanism by which one field rename breaks 25 downstream suites at
+    once. The table is the only place that can be right: `compute_capability` was deleted
+    at 0.60 and RESTORED at 0.75 (pgw#660), and every fleet-side copy of the list had to
+    be corrected by hand.
+  - **The bare-mypy `StringEnum` question is answered: a mypy run without the SDK
+    installed is UNSUPPORTED, and the SDK cannot fix it.** With the package absent,
+    `--ignore-missing-imports` types every SDK name `Any`, and mypy then resolves the
+    members of `class AspectRatio(StringEnum)` as bare `str` — false `dict-item` errors
+    on every ratio-keyed table (reproduced: 11 errors on sdxl). A `.pyi` inside the wheel
+    cannot help, because the wheel is what is missing. Endpoints type-check against the
+    installed SDK with `--follow-imports=silent` (measured: 0-1 error delta per package)
+    and delete the 20 `if TYPE_CHECKING: from enum import StrEnum as StringEnum` shims in
+    15 packages — production import blocks were being shaped by a report script.
+
+  **Endpoint-side ordering (ie#594):** the fleet pins `gen-worker==0.89.0`, so the
+  `Recorder` and `assert_declaration_shape` migrations cannot land until this ships and
+  a fleet repin train moves the 28 endpoints onto it. The `StringEnum` half depends on
+  no new SDK and can land immediately.
+
 - **pgw#930 (§1.17): `WORKER_MODE` is deleted; serve and mint are COMPOSABLE goals.**
   Paul: *"you can spawn a GPU and tell it to mint some AOT-cells, while also using it to
   serve jobs (inference) as needed."* `worker_mode.py` was a closed two-tuple

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -125,6 +125,30 @@ for any OTHER reason (missing non-heavy dep, SyntaxError): a broken
 submodule fails the build with the real traceback instead of silently
 dropping its functions from the manifest.
 
+### Type-check against the INSTALLED SDK (pgw#942)
+
+A mypy run with `gen_worker` not installed is **not supported**, and the SDK
+cannot make it work: with the package absent, `--ignore-missing-imports`
+resolves every SDK name to `Any`, and mypy then types the members of
+`class AspectRatio(StringEnum)` as bare `str` — so every `AspectRatio`-keyed
+table lights up with false `dict-item` errors. A `.pyi` inside the wheel
+cannot fix that, because the wheel is exactly what is missing.
+
+So: install `gen-worker` in the environment your type-check runs in, and add
+`--follow-imports=silent` so the SDK's own diagnostics are not attributed to
+your package. Do NOT reshape production imports to satisfy a bare checker —
+a `if TYPE_CHECKING: from enum import StrEnum as StringEnum / else: from
+gen_worker import StringEnum` shim is a report script editing your source.
+Import the name once, normally:
+
+```python
+from gen_worker import StringEnum
+```
+
+(`StringEnum` is a direct alias for `enum.StrEnum`, not a subclass — an
+empty enum base makes a tenant's members resolve as `str`. It exists as the
+named, documented vocabulary for endpoint payload enums.)
+
 ## Bindings
 
 The slot name is the `models={}` key (or, with the single-binding `model=`
@@ -312,6 +336,49 @@ ctx = fake_context(slots={
 })
 out = Generate().generate(ctx, TextToImage(prompt="a cat"))
 ```
+
+Add a `Recorder` to assert what the handler SAVED and LOGGED (pgw#942).
+Outputs run the SDK's real encode / C2PA stamp / size-limit path and are
+written into the recorder's own directory instead of uploaded, so there is
+no hub and no network — and, unlike a `save_image` override, the encode
+under test is the one production runs:
+
+```python
+from gen_worker.testing import Recorder, fake_context
+
+rec = Recorder()
+ctx = fake_context(slots={...}, recorder=rec)
+Generate().generate(ctx, TextToImage(prompt="a cat"))
+
+assert rec.refs == ["outputs/test-request/image.webp"]
+assert rec.images[0].call["quality"] == 95        # what the handler asked for
+assert rec.images[0].read_bytes()[:4] == b"RIFF"  # what it actually produced
+assert rec.messages == ["scheduler: dpmpp_2m_karras"]   # ctx.log
+assert rec.progress[-1].payload["step"] == 28           # ctx.progress
+```
+
+`rec.saved` holds every `save_*` in order (`images` / `audio` / `videos` /
+`files` filter it); each entry carries the typed asset the handler received,
+with its real `sha256` and `size_bytes`. `ctx.log` and `ctx.progress` are
+captured at the emitter seam, so neither needs an override either.
+
+**Do not assert the SDK's own shape.** A field the SDK deleted is the SDK's
+fact: it is listed once in `gen_worker.api.shape_contract.DELETED_FIELDS`
+and asserted by the SDK's suite. An endpoint asserts what IT declares, and
+gets the deleted-field walk for free:
+
+```python
+from gen_worker.testing import assert_declaration_shape
+
+decl = Generate.__gen_worker_endpoint__
+assert_declaration_shape(decl)          # decl + resources + compile + slots
+assert decl.resources.gpu is True       # your declaration — keep asserting this
+```
+
+A hand-written `assert not hasattr(decl.resources, "vram_gb")` is a copy of
+that list which no SDK change can update: `compute_capability` was deleted
+at 0.60 and RESTORED at 0.75 (pgw#660), and every stale copy of the list
+had to be found by hand.
 
 ## Lanes: multi-model classes with shared components (gw#479)
 

--- a/src/gen_worker/api/shape_contract.py
+++ b/src/gen_worker/api/shape_contract.py
@@ -1,0 +1,219 @@
+"""The SDK's own declaration-shape contract (pgw#942).
+
+A field that the SDK DELETED is a fact only the SDK knows. Before this
+module, 25 of 28 endpoint packages asserted that knowledge for it — 91
+``assert not hasattr(...)`` lines plus 46 ``for deleted in (...)`` loops,
+each naming fields the pinned SDK cannot ship. That is a shape contract
+written 25 times by the parties least able to maintain it: one rename here
+broke 25 downstream suites at once.
+
+The table below is the single copy. :func:`assert_sdk_shape` checks the SDK
+against itself; :func:`assert_declaration_shape` checks one endpoint's
+concrete declaration, so an endpoint asserts only what *it* declares.
+
+Adding a row is the deletion's completion, not paperwork: it is what makes
+the deletion enforced everywhere at once, and it is the only place a reader
+can find out when and why a field went away.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+
+import msgspec
+
+from .decorators import Compile, EndpointDecl, Resources, WorkerFunctionDecl
+from .slot import Slot
+
+
+class DeletedField(msgspec.Struct, frozen=True, kw_only=True):
+    """One field the SDK removed, and the version that removed it."""
+
+    owner: type
+    name: str
+    deleted_at: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.owner.__name__}.{self.name}"
+
+
+#: Every field deleted from the declaration surface, newest cut last. A row
+#: is removed ONLY if the field comes back (``compute_capability`` did, at
+#: 0.75.0 / pgw#660 — which is exactly why it is absent here and why an
+#: endpoint must never keep its own copy of this list).
+DELETED_FIELDS: Tuple[DeletedField, ...] = (
+    DeletedField(
+        owner=Resources,
+        name="vram_gb",
+        deleted_at="0.60.0",
+        reason=(
+            "th#683 prove-and-profile MEASURES the real VRAM requirement per lane "
+            "and shape; an authored floor is a placement gate over a guess. The "
+            "survivor is the optional first-build hint `vram_gb_hint`."
+        ),
+    ),
+    DeletedField(
+        owner=Resources,
+        name="ram_gb",
+        deleted_at="0.60.0",
+        reason=(
+            "same cut as `vram_gb`. Restored as the OPTIONAL allocation-time hint "
+            "`ram_gb_hint` (pgw#670) after ie#492 sized a real host-RAM floor; the "
+            "gate-shaped spelling did not come back."
+        ),
+    ),
+    DeletedField(
+        owner=EndpointDecl,
+        name="regimes",
+        deleted_at="0.60.0",
+        reason=(
+            "SDK v2 (pgw#647): the endpoint declares one shape contract, not a set "
+            "of named operating regimes the hub had to re-derive."
+        ),
+    ),
+    DeletedField(
+        owner=EndpointDecl,
+        name="route",
+        deleted_at="0.60.0",
+        reason=(
+            "SDK v2: routing is the hub's decision from bindings and declared "
+            "compile axes; endpoint code never names a route."
+        ),
+    ),
+    DeletedField(
+        owner=Compile,
+        name="guidance_scales",
+        deleted_at="0.60.0",
+        reason=(
+            "SDK v2: guidance is a payload axis (`Compile(args=)` / the derived "
+            "warm plan), not a compile-time enumeration on the spec."
+        ),
+    ),
+    DeletedField(
+        owner=Compile,
+        name="lora_bucket",
+        deleted_at="0.60.0",
+        reason=(
+            "gw#561: the resident traced rank bucket shapes the graph family whether "
+            "or not `compile=` is present, so it moved to `@endpoint(lora_bucket=)` "
+            "— i.e. `EndpointDecl.lora_bucket`. Two carriers for one fact was the bug."
+        ),
+    ),
+    DeletedField(
+        owner=Slot,
+        name="default_config",
+        deleted_at="0.60.0",
+        reason=(
+            "th#1116: the CATALOG owns per-model config; a code-side default was a "
+            "second answer that could disagree with the live one."
+        ),
+    ),
+    DeletedField(
+        owner=Slot,
+        name="share_components",
+        deleted_at="0.60.0",
+        reason=(
+            "SDK v2: the component tree is DERIVED from `pipeline_cls`, and sharing "
+            "is a deploy-binding decision (th#980), never an endpoint declaration."
+        ),
+    ),
+)
+
+
+class DeclarationShapeError(AssertionError):
+    """A declaration carries a field the SDK deleted."""
+
+
+def _rows_for(owner: type) -> Tuple[DeletedField, ...]:
+    return tuple(row for row in DELETED_FIELDS if row.owner is owner)
+
+
+def _check_instance(obj: Any, owner: type, where: str, failures: list[str]) -> None:
+    for row in _rows_for(owner):
+        if hasattr(obj, row.name):
+            failures.append(
+                f"{where}.{row.name} exists — deleted at gen-worker {row.deleted_at}: {row.reason}"
+            )
+
+
+def assert_sdk_shape() -> None:
+    """Assert the SDK itself ships none of :data:`DELETED_FIELDS`.
+
+    The SDK's own suite calls this; an endpoint never needs to. It is the
+    assertion the 91 endpoint-side fossils were each approximating.
+    """
+    failures: list[str] = []
+    for row in DELETED_FIELDS:
+        owner = row.owner
+        fields = getattr(owner, "__struct_fields__", None)
+        names: Iterable[str]
+        if fields is not None:
+            names = fields
+        else:
+            names = getattr(owner, "__slots__", ()) or ()
+        if row.name in tuple(names) or hasattr(owner, row.name):
+            failures.append(
+                f"{row} is back on the class but still listed as deleted "
+                f"(at {row.deleted_at}) — remove the DELETED_FIELDS row or the field"
+            )
+    if failures:
+        raise DeclarationShapeError("; ".join(failures))
+
+
+def assert_declaration_shape(
+    decl: Any,
+    *,
+    slots: Optional[Sequence[str]] = None,
+) -> None:
+    """Assert one endpoint's declaration carries no deleted field.
+
+    ``decl`` is the object ``@endpoint`` attaches
+    (``MyClass.__gen_worker_endpoint__``) — an :class:`EndpointDecl` or a
+    :class:`WorkerFunctionDecl`. Its ``resources``, ``compile`` and every
+    ``slots`` entry are checked with it, so::
+
+        from gen_worker.testing import assert_declaration_shape
+
+        assert_declaration_shape(m.SDXLFamily.__gen_worker_endpoint__)
+
+    replaces every ``assert not hasattr(decl.resources, "vram_gb")`` in the
+    suite. ``slots=`` narrows the walk to named slots; by default every
+    declared slot is checked.
+
+    The endpoint keeps asserting what it POSITIVELY declares (``decl.resources.gpu
+    is True``, ``set(decl.slots) == {"pipeline"}``) — that is its own contract
+    and belongs in its own suite. What it stops re-deriving is the SDK's.
+    """
+    failures: list[str] = []
+    _check_instance(decl, EndpointDecl, "decl", failures)
+    _check_instance(decl, WorkerFunctionDecl, "decl", failures)
+
+    resources = getattr(decl, "resources", None)
+    if resources is not None:
+        _check_instance(resources, Resources, "decl.resources", failures)
+
+    compile_spec = getattr(decl, "compile", None)
+    if compile_spec is not None:
+        _check_instance(compile_spec, Compile, "decl.compile", failures)
+
+    declared: Mapping[str, Any] = getattr(decl, "slots", {}) or {}
+    names = tuple(slots) if slots is not None else tuple(declared)
+    for name in names:
+        slot = declared.get(name)
+        if slot is None:
+            failures.append(f"decl.slots[{name!r}] is not declared")
+            continue
+        _check_instance(slot, Slot, f"decl.slots[{name!r}]", failures)
+
+    if failures:
+        raise DeclarationShapeError("; ".join(failures))
+
+
+__all__ = [
+    "DELETED_FIELDS",
+    "DeclarationShapeError",
+    "DeletedField",
+    "assert_declaration_shape",
+    "assert_sdk_shape",
+]

--- a/src/gen_worker/testing/__init__.py
+++ b/src/gen_worker/testing/__init__.py
@@ -16,6 +16,23 @@ pairs::
     })
     out = Generate().generate(ctx, TextToImage(prompt="a cat"))
 
+Pass a :class:`Recorder` to assert what the handler SAVED and LOGGED
+(pgw#942) — the outputs go through the SDK's real encode/stamp/write path
+and land in an inspectable list::
+
+    rec = Recorder()
+    ctx = fake_context(slots={...}, recorder=rec)
+    Generate().generate(ctx, TextToImage(prompt="a cat"))
+
+    assert rec.refs == ["outputs/test-request/image.webp"]
+    assert rec.images[0].read_bytes()[:4] == b"RIFF"     # a real webp encode
+    assert "loaded 2 loras" in rec.messages
+
+That is the half 23 endpoint suites were hand-rolling: a ``_Ctx`` subclass
+overriding ``save_image``/``save_audio`` to capture the call. Overriding it
+is what made those suites green over an encode path they never ran; the
+recorder captures the same facts on the way THROUGH it.
+
 Not imported by ``gen_worker`` itself — production code has no reason to
 import test helpers; import ``gen_worker.testing`` explicitly from test
 modules.
@@ -23,12 +40,45 @@ modules.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Tuple, Type, TypeVar
+import os
+import shutil
+import tempfile
+import weakref
+from contextlib import contextmanager
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+import msgspec
 
 from ..api.binding import ModelRef
+from ..api.shape_contract import (
+    DELETED_FIELDS,
+    DeclarationShapeError,
+    DeletedField,
+    assert_declaration_shape,
+    assert_sdk_shape,
+)
 from ..api.slot import ResolvedSlot
+from ..api.types import Asset, AudioAsset, ImageAsset, VideoAsset
 from ..families.base import GenerationDefaults
 from ..request_context import RequestContext
+
+if TYPE_CHECKING:  # heavy optional deps — imported only for signature fidelity
+    import numpy as np
+    import torch
+    from PIL import Image
 
 C = TypeVar("C", bound=RequestContext)
 
@@ -42,11 +92,228 @@ def stub_slots(
     return {name: ResolvedSlot(ref=ref, defaults=defaults) for name, (ref, defaults) in slots.items()}
 
 
+class SavedArtifact(msgspec.Struct, frozen=True, kw_only=True):
+    """One output the handler saved, as the real ``save_*`` path produced it.
+
+    ``kind`` is which ``ctx.save_*`` the handler called (``image`` / ``audio``
+    / ``video`` / ``file`` / ``bytes``); ``ref`` is the normalized output ref
+    the SDK assigned (handlers often pass none); ``asset`` is the typed value
+    the handler got back, carrying the REAL ``sha256`` and ``size_bytes``;
+    ``call`` is the keyword arguments the handler passed (``format``,
+    ``quality``, ``sample_rate``, ...) so a suite can assert the encode
+    REQUEST as well as its result.
+    """
+
+    kind: str
+    ref: str
+    asset: Asset
+    call: Mapping[str, Any] = {}
+
+    @property
+    def path(self) -> Optional[Path]:
+        """Where the recorder's output directory holds the encoded bytes."""
+        return Path(self.asset.local_path) if self.asset.local_path else None
+
+    def read_bytes(self) -> bytes:
+        """The encoded payload — a real webp/wav/mp4, not a stub."""
+        p = self.path
+        if p is None:
+            raise FileNotFoundError(f"{self.ref} has no local payload")
+        return p.read_bytes()
+
+
+class RecordedEvent(msgspec.Struct, frozen=True, kw_only=True):
+    """One event the context emitted (``request.log``, ``request.progress``,
+    ``request.checkpoint``), captured at the REAL emitter seam — which is why
+    ``ctx.log`` and ``ctx.progress`` need no override to be observed."""
+
+    type: str
+    payload: Mapping[str, Any] = {}
+
+
+class Recorder:
+    """Collects what a handler saved and emitted through a
+    :func:`fake_context`.
+
+    Hold one per test and read it after the handler returns::
+
+        rec = Recorder()
+        ctx = fake_context(slots={...}, recorder=rec)
+        out = Generate().generate(ctx, payload)
+        assert rec.images[0].call["format"] == "png"
+
+    The recorder owns a temporary output directory (removed when it is
+    garbage-collected), which is what lets every ``save_*`` run its real
+    encode, C2PA stamp and size-limit checks with no hub and no network.
+    """
+
+    def __init__(self, *, output_dir: Optional[str | os.PathLike[str]] = None) -> None:
+        self.saved: List[SavedArtifact] = []
+        self.events: List[RecordedEvent] = []
+        if output_dir is None:
+            created = tempfile.mkdtemp(prefix="gw-recorder-")
+            weakref.finalize(self, shutil.rmtree, created, True)
+            self.output_dir = Path(created)
+        else:
+            self.output_dir = Path(output_dir)
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- reads ------------------------------------------------------------
+
+    def of_kind(self, kind: str) -> List[SavedArtifact]:
+        return [a for a in self.saved if a.kind == kind]
+
+    @property
+    def images(self) -> List[SavedArtifact]:
+        return self.of_kind("image")
+
+    @property
+    def audio(self) -> List[SavedArtifact]:
+        return self.of_kind("audio")
+
+    @property
+    def videos(self) -> List[SavedArtifact]:
+        return self.of_kind("video")
+
+    @property
+    def files(self) -> List[SavedArtifact]:
+        return self.of_kind("file")
+
+    @property
+    def refs(self) -> List[str]:
+        return [a.ref for a in self.saved]
+
+    @property
+    def logs(self) -> List[RecordedEvent]:
+        return [e for e in self.events if e.type == "request.log"]
+
+    @property
+    def messages(self) -> List[str]:
+        """``ctx.log`` message strings, in order — the list 23 suites were
+        hand-rolling a ``log`` override to build."""
+        return [str(e.payload.get("message", "")) for e in self.logs]
+
+    @property
+    def progress(self) -> List[RecordedEvent]:
+        return [e for e in self.events if e.type == "request.progress"]
+
+    # -- writes (called by the recording context) -------------------------
+
+    def emit(self, event: Mapping[str, Any]) -> None:
+        """Emitter callback — the same seam the worker installs in production."""
+        self.events.append(
+            RecordedEvent(
+                type=str(event.get("type", "")),
+                payload=dict(event.get("payload") or {}),
+            )
+        )
+
+    def record(self, kind: str, asset: Asset, call: Mapping[str, Any]) -> None:
+        self.saved.append(
+            SavedArtifact(kind=kind, ref=asset.ref, asset=asset, call=dict(call))
+        )
+
+
+class _RecordingMixin:
+    """Records each ``save_*`` AFTER the real implementation ran.
+
+    Mixed in front of the requested context class by :func:`fake_context`, so
+    every ``super()`` call below is the production method — the encode, the
+    C2PA stamp, the output-size limit and the ref normalization all happen
+    exactly as they do on a pod. Nested calls (``save_image`` -> ``save_bytes``)
+    record once, at the outermost frame, under the kind the handler asked for.
+    """
+
+    _gw_recorder: Recorder
+    _gw_depth: int
+
+    @contextmanager
+    def _gw_outermost(self) -> Iterator[bool]:
+        depth = self._gw_depth
+        self._gw_depth = depth + 1
+        try:
+            yield depth == 0
+        finally:
+            self._gw_depth = depth
+
+    def _gw_capture(
+        self, kind: str, call: Mapping[str, Any], run: Callable[[], Any]
+    ) -> Any:
+        with self._gw_outermost() as outermost:
+            asset = run()
+        if outermost:
+            self._gw_recorder.record(kind, asset, call)
+        return asset
+
+    def save_bytes(self, ref: str, data: bytes) -> Asset:
+        return self._gw_capture(
+            "bytes",
+            {},
+            lambda: super(_RecordingMixin, self).save_bytes(ref, data),  # type: ignore[misc]
+        )
+
+    def save_image(
+        self, image: "Image.Image", ref: Optional[str] = None, **kwargs: Any
+    ) -> ImageAsset:
+        return self._gw_capture(
+            "image",
+            kwargs,
+            lambda: super(_RecordingMixin, self).save_image(image, ref, **kwargs),  # type: ignore[misc]
+        )
+
+    def save_audio(
+        self,
+        audio: "np.ndarray[Any, Any] | torch.Tensor | bytes",
+        ref: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AudioAsset:
+        return self._gw_capture(
+            "audio",
+            kwargs,
+            lambda: super(_RecordingMixin, self).save_audio(audio, ref, **kwargs),  # type: ignore[misc]
+        )
+
+    def save_video(
+        self,
+        video: "bytes | str | os.PathLike[str]",
+        ref: Optional[str] = None,
+        **kwargs: Any,
+    ) -> VideoAsset:
+        return self._gw_capture(
+            "video",
+            kwargs,
+            lambda: super(_RecordingMixin, self).save_video(video, ref, **kwargs),  # type: ignore[misc]
+        )
+
+    def save_file(
+        self, ref: str, local_path: str | os.PathLike[str], **kwargs: Any
+    ) -> Asset:
+        return self._gw_capture(
+            "file",
+            kwargs,
+            lambda: super(_RecordingMixin, self).save_file(ref, local_path, **kwargs),  # type: ignore[misc]
+        )
+
+
+_RECORDING_CLASSES: Dict[type, type] = {}
+
+
+def _recording_class(cls: type) -> type:
+    """``RecordingRequestContext`` / ``RecordingConversionContext`` / ... —
+    built once per context class so ``isinstance(ctx, cls)`` still holds."""
+    built = _RECORDING_CLASSES.get(cls)
+    if built is None:
+        built = type(f"Recording{cls.__name__}", (_RecordingMixin, cls), {})
+        _RECORDING_CLASSES[cls] = built
+    return built
+
+
 def fake_context(
     *,
     request_id: str = "test-request",
     slots: Mapping[str, Tuple[ModelRef, GenerationDefaults]] = {},
     cls: Type[C] = RequestContext,  # type: ignore[assignment]
+    recorder: Optional[Recorder] = None,
     **kwargs: Any,
 ) -> C:
     """Build a :class:`RequestContext` (or ``cls=``, a producer-kind
@@ -58,12 +325,49 @@ def fake_context(
     ``ctx.slots["<name>"].ref`` / ``.defaults``. Every other
     :class:`RequestContext` constructor kwarg (``owner``, ``timeout_ms``,
     ``compute``, ...) passes through via ``**kwargs``.
+
+    ``recorder`` (pgw#942) turns on RECORDING MODE: saves land in
+    ``recorder.saved`` and events in ``recorder.events``, and outputs are
+    written into the recorder's own directory instead of being uploaded — so
+    the handler runs the SDK's real encode path with no hub and no network.
+    An explicit ``local_output_dir=`` still wins, and a caller's ``emitter=``
+    is chained rather than replaced.
     """
-    return cls(
+    if recorder is None:
+        return cls(
+            request_id=request_id,
+            resolved_slots=stub_slots(slots),
+            **kwargs,
+        )
+
+    caller_emitter: Optional[Callable[[Dict[str, Any]], None]] = kwargs.pop("emitter", None)
+
+    def _emit(event: Dict[str, Any]) -> None:
+        recorder.emit(event)
+        if caller_emitter is not None:
+            caller_emitter(event)
+
+    kwargs.setdefault("local_output_dir", str(recorder.output_dir))
+    ctx = _recording_class(cls)(
         request_id=request_id,
         resolved_slots=stub_slots(slots),
+        emitter=_emit,
         **kwargs,
     )
+    ctx._gw_recorder = recorder
+    ctx._gw_depth = 0
+    return ctx
 
 
-__all__ = ["fake_context", "stub_slots"]
+__all__ = [
+    "DELETED_FIELDS",
+    "DeclarationShapeError",
+    "DeletedField",
+    "RecordedEvent",
+    "Recorder",
+    "SavedArtifact",
+    "assert_declaration_shape",
+    "assert_sdk_shape",
+    "fake_context",
+    "stub_slots",
+]

--- a/tests/test_testing_recorder_pgw942.py
+++ b/tests/test_testing_recorder_pgw942.py
@@ -1,0 +1,251 @@
+"""pgw#942: the recording test context and the SDK's declaration-shape contract.
+
+These are integration tests in the sense that matters here: nothing below is
+mocked. A real ``@endpoint`` class is declared, a real handler runs, and the
+assertions read what the SDK's own ``save_*`` implementations produced —
+encode, ref normalization, sha256 and size included. That is precisely the
+path the 23 endpoint suites with a hand-rolled ``_Ctx.save_image`` override
+never execute.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Optional
+
+import msgspec
+import pytest
+from PIL import Image
+
+from gen_worker import HF, Slot, endpoint
+from gen_worker.api.decorators import Compile, Resources
+from gen_worker.api.types import AudioAsset, ImageAsset, VideoAsset
+from gen_worker.request_context import ConversionContext, RequestContext
+from gen_worker.testing import (
+    DELETED_FIELDS,
+    DeclarationShapeError,
+    Recorder,
+    assert_declaration_shape,
+    assert_sdk_shape,
+    fake_context,
+)
+
+from _example_family import ExampleDefaults
+
+
+class Render(msgspec.Struct, frozen=True):
+    size: int = 64
+    image_format: str = "webp"
+    ref: Optional[str] = None
+
+
+class Rendered(msgspec.Struct, frozen=True):
+    image: ImageAsset
+
+
+@endpoint(
+    resources=Resources(gpu=True, vram_gb_hint=12.0),
+    compile=Compile(family="example", shapes=((512, 512),), text_len=77),
+    models={"pipeline": Slot(str, default_checkpoint=HF("example/pipeline"))},
+)
+class ExampleEndpoint:
+    """A minimally real endpoint: one root slot, one handler that saves."""
+
+    def setup(self, pipeline: str) -> None:
+        self.pipeline = pipeline
+
+    def generate(self, ctx: RequestContext[ExampleDefaults], payload: Render) -> Rendered:
+        ctx.progress(0.5, "denoise", step=1, total=2)
+        ctx.log("rendering", level="info", steps=ctx.defaults.steps)
+        image = Image.new("RGB", (payload.size, payload.size), (10, 120, 200))
+        return Rendered(
+            image=ctx.save_image(
+                image, payload.ref, format=payload.image_format, quality=80
+            )
+        )
+
+
+def _slots() -> dict:
+    return {"pipeline": (HF("example/pipeline"), ExampleDefaults(steps=7))}
+
+
+# --------------------------------------------------------------------------- #
+# 1. recording mode: real encode, inspectable result                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_recorder_captures_a_real_webp_encode() -> None:
+    rec = Recorder()
+    ctx = fake_context(request_id="req", slots=_slots(), recorder=rec)
+
+    out = ExampleEndpoint().generate(ctx, Render())
+
+    assert isinstance(out.image, ImageAsset)
+    assert rec.refs == ["outputs/req/image.webp"]
+    saved = rec.images[0]
+    assert saved.call == {"format": "webp", "quality": 80}
+
+    # The bytes exist and are a real webp — the encode the handler's own
+    # save_image override would have skipped.
+    payload = saved.read_bytes()
+    assert payload[:4] == b"RIFF" and payload[8:12] == b"WEBP"
+    decoded = Image.open(io.BytesIO(payload))
+    assert decoded.size == (64, 64)
+
+    # ...and the asset the HANDLER received carries the real attestation.
+    assert saved.asset.sha256 and len(saved.asset.sha256) == 64
+    assert saved.asset.size_bytes == len(payload)
+    assert out.image.sha256 == saved.asset.sha256
+
+
+def test_recorder_captures_the_format_the_handler_asked_for() -> None:
+    rec = Recorder()
+    ctx = fake_context(request_id="req", slots=_slots(), recorder=rec)
+
+    ExampleEndpoint().generate(ctx, Render(image_format="png"))
+
+    assert rec.refs == ["outputs/req/image.png"]
+    assert rec.images[0].read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_recorder_captures_log_and_progress_off_the_real_emitter() -> None:
+    rec = Recorder()
+    ctx = fake_context(request_id="req", slots=_slots(), recorder=rec)
+
+    ExampleEndpoint().generate(ctx, Render())
+
+    assert rec.messages == ["rendering"]
+    assert rec.logs[0].payload["fields"] == {"steps": 7}
+    assert [e.payload["step"] for e in rec.progress] == [1]
+
+
+def test_nested_saves_record_once_under_the_handler_kind() -> None:
+    """``save_image`` calls ``save_bytes`` internally; one handler call is one
+    recorded artifact, and its kind is the one the handler asked for."""
+    rec = Recorder()
+    ctx = fake_context(request_id="req", slots=_slots(), recorder=rec)
+
+    ExampleEndpoint().generate(ctx, Render())
+
+    assert len(rec.saved) == 1
+    assert rec.saved[0].kind == "image"
+
+
+def test_recorder_covers_every_save_kind() -> None:
+    rec = Recorder()
+    ctx = fake_context(request_id="req", slots=_slots(), recorder=rec)
+
+    ctx.save_bytes("outputs/req/blob.bin", b"raw")
+    audio = ctx.save_audio(b"RIFFfake", "outputs/req/a.wav")
+    video = ctx.save_video(b"\x00\x00\x00 ftypisom", "outputs/req/v.mp4")
+
+    src = rec.output_dir / "src.txt"
+    src.write_text("from disk")
+    ctx.save_file("outputs/req/copy.txt", src)
+
+    assert [a.kind for a in rec.saved] == ["bytes", "audio", "video", "file"]
+    assert isinstance(audio, AudioAsset) and isinstance(video, VideoAsset)
+    assert rec.files[0].read_bytes() == b"from disk"
+    assert rec.audio[0].asset.size_bytes == len(b"RIFFfake")
+
+
+def test_recorder_works_for_producer_context_subclasses() -> None:
+    rec = Recorder()
+    ctx = fake_context(request_id="req", cls=ConversionContext, recorder=rec)
+
+    assert isinstance(ctx, ConversionContext)
+    ctx.save_bytes("outputs/req/blob.bin", b"raw")
+    assert rec.refs == ["outputs/req/blob.bin"]
+
+
+def test_recorder_chains_a_caller_supplied_emitter() -> None:
+    seen: list[dict] = []
+    rec = Recorder()
+    ctx = fake_context(
+        request_id="req", slots=_slots(), recorder=rec, emitter=seen.append
+    )
+
+    ctx.log("both")
+
+    assert rec.messages == ["both"]
+    assert [e["payload"]["message"] for e in seen] == ["both"]
+
+
+def test_fake_context_without_a_recorder_is_unchanged() -> None:
+    ctx = fake_context(request_id="req", slots=_slots())
+
+    assert type(ctx) is RequestContext
+    assert ctx.slots["pipeline"].defaults.steps == 7
+
+
+def test_recorder_output_dir_is_removed_with_the_recorder() -> None:
+    rec = Recorder()
+    path = rec.output_dir
+    assert path.is_dir()
+    del rec
+    assert not path.exists()
+
+
+# --------------------------------------------------------------------------- #
+# 2. the SDK asserts its own deleted-field set, once                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_sdk_ships_no_deleted_field() -> None:
+    assert_sdk_shape()
+
+
+def test_the_deleted_table_covers_what_the_fleet_was_asserting() -> None:
+    """The endpoint-side fossils this replaces named exactly these."""
+    named = {(row.owner.__name__, row.name) for row in DELETED_FIELDS}
+    assert {
+        ("Resources", "vram_gb"),
+        ("Resources", "ram_gb"),
+        ("EndpointDecl", "regimes"),
+        ("EndpointDecl", "route"),
+        ("Compile", "guidance_scales"),
+        ("Compile", "lora_bucket"),
+        ("Slot", "default_config"),
+        ("Slot", "share_components"),
+    } <= named
+    # compute_capability came BACK at 0.75.0 (pgw#660) — a fleet-side copy of
+    # this list is exactly how that restoration would have gone unnoticed.
+    assert not any(row.name == "compute_capability" for row in DELETED_FIELDS)
+
+
+def test_assert_declaration_shape_passes_a_real_declaration() -> None:
+    assert_declaration_shape(ExampleEndpoint.__gen_worker_endpoint__)
+
+
+def test_assert_declaration_shape_walks_resources_compile_and_slots() -> None:
+    decl = ExampleEndpoint.__gen_worker_endpoint__
+
+    for owner, name in (
+        (decl.resources, "vram_gb"),
+        (decl.compile, "lora_bucket"),
+        (decl.slots["pipeline"], "share_components"),
+        (decl, "regimes"),
+    ):
+        # msgspec Structs and __slots__ classes both refuse a stray attribute,
+        # so the regression is staged on a stand-in that CAN carry one.
+        assert not hasattr(owner, name)
+
+    class _Revived:
+        vram_gb = 24.0
+
+    class _Decl:
+        resources = _Revived()
+        compile = None
+        slots: dict = {}
+
+    with pytest.raises(DeclarationShapeError) as exc:
+        assert_declaration_shape(_Decl())
+    assert "decl.resources.vram_gb" in str(exc.value)
+    assert "0.60.0" in str(exc.value)
+
+
+def test_assert_declaration_shape_reports_an_undeclared_slot() -> None:
+    with pytest.raises(DeclarationShapeError, match="'missing'"):
+        assert_declaration_shape(
+            ExampleEndpoint.__gen_worker_endpoint__, slots=["missing"]
+        )


### PR DESCRIPTION
Closes the SDK half of pgw#942. Endpoint half is ie#594.

**The framing:** *if 28 endpoints all write the same fifteen lines to do something ordinary, that is an SDK gap.* Measured across 28 packages / 56,750 Python lines.

| gap | cost today | this PR |
|---|---|---|
| `fake_context` has no recording mode | 26 hand-rolled `_Ctx(RequestContext)` doubles, 473 lines, in 23 endpoints | `fake_context(recorder=Recorder())` |
| the SDK never asserts its own deleted-field set | 91 `assert not hasattr` + 46 `for deleted in (...)` loops across 25 packages | `DELETED_FIELDS` + `assert_declaration_shape(decl)` |
| `StringEnum` does not resolve under a dep-less mypy | a `TYPE_CHECKING` shim in 20 files / 15 endpoints | a ruling in `docs/endpoint-authoring.md`, reproduced and measured |

### 1. `Recorder` — the `save_*` half of `gen_worker.testing`

`fake_context` builds a REAL context but gives a test nowhere to read what was saved, so 23 suites answered that by overriding `save_image`/`save_audio`. That is also why **23 suites are green over an encode path they never call** — hidream's own test comment records migrating for exactly that reason.

```python
rec = Recorder()
ctx = fake_context(slots={...}, recorder=rec)
Generate().generate(ctx, TextToImage(prompt="a cat"))

assert rec.refs == ["outputs/test-request/image.webp"]
assert rec.images[0].call["quality"] == 95         # what the handler asked for
assert rec.images[0].read_bytes()[:4] == b"RIFF"   # what it actually produced
assert rec.messages == ["scheduler: dpmpp_2m_karras"]   # ctx.log, no override
```

Recording happens **after** the production `save_*` returns — the encode, C2PA stamp, ref normalization, size limit and sha256 are the real ones. Outputs land in the recorder's own temp directory instead of being uploaded, so there is no hub and no network. `ctx.log`/`ctx.progress` are captured at the emitter seam.

### 2. `api/shape_contract.py` — the deleted-field set, in one place

A field the SDK deleted is a fact only the SDK knows; 25 packages were asserting it for us. `DELETED_FIELDS` records each removal with its version and its reason; `assert_sdk_shape()` is the SDK's self-check; `assert_declaration_shape(decl)` walks one endpoint's decl + resources + compile + slots so the endpoint keeps asserting only what it declares.

Only the SDK can keep this list right: `compute_capability` was deleted at 0.60 and **restored** at 0.75 (pgw#660), and every fleet-side copy had to be found and corrected by hand.

**The declaration surface is untouched** — no field added, removed or renamed in `api/decorators.py` (th#1361's territory).

### 3. The bare-mypy `StringEnum` ruling

Reproduced rather than assumed. With `gen_worker` absent, `--ignore-missing-imports` types every SDK name `Any`, and mypy resolves the members of `class AspectRatio(StringEnum)` as bare `str` — 11 false errors on sdxl with the shim removed. **A `.pyi` in the wheel cannot fix this, because the wheel is what is missing.** So the ruling is the other one: type-check against the installed SDK, with `--follow-imports=silent`. Measured across 8 endpoints, that costs a **0-1 error delta per package** — it does not move the ie#466 baselines.

### Tests

`tests/test_testing_recorder_pgw942.py` — 14 tests, no mocks: a real `@endpoint` class, a real handler, real webp/png encodes decoded back off disk, every save kind, producer-kind contexts, emitter chaining, temp-dir lifetime, and the shape contract. `mypy src` clean (224 files); declaration-surface regression suites green.

### Endpoint-side ordering (please read before merging ie#594)

The fleet hard-pins `gen-worker==0.89.0` in all 26 endpoint `pyproject.toml`s. The `Recorder` and `assert_declaration_shape` migrations therefore **cannot land until this ships and a fleet repin train moves the 28 endpoints onto it**. The `StringEnum` half needs no new SDK and can land in `inference-endpoints` today.