### PR TITLE
pgw#863: the sm_120 fused lane does NOT transfer to sm_100 — measured, and the lane split that fixes it

### DIFF
--- a/scripts/svdq_bench/bench_arm.py
+++ b/scripts/svdq_bench/bench_arm.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""svdq runtime bench: ONE arm per process (pgw#865 instrument).
+
+Arms: ``ours`` (gen-worker svdq lane — baseline or fused, chosen by the
+per-process lane decision), ``bf16`` (the unquantized reference transformer on
+the same card), ``nunchaku`` (their wheel, sm_120a only).
+
+Renders cozy-hard-eval-v1 (20 prompts, 28 steps, true_cfg 4.5, 1328x1328,
+fixed seeds, negative " ") from the SAME nunchaku fp4_r128 checkpoint bytes,
+with per-step timing (cuda-sync at each step end), e2e wall per image, and
+peak VRAM. Repeats one row 3x for variance. Saves product-grade webps
+(q95 method4) + a JSON report. Run on-pod only.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import time
+from pathlib import Path
+
+
+class StepTimer:
+    def __init__(self) -> None:
+        self.ts: list[float] = []
+
+    def __call__(self, pipe, i, t, kw):
+        import torch
+        torch.cuda.synchronize()
+        self.ts.append(time.perf_counter())
+        return {}
+
+
+def save_webp(img, dest: Path) -> None:
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, format="WEBP", quality=95, lossless=False, method=4)
+    dest.write_bytes(buf.getvalue())
+
+
+def load_ours(ckpt: Path, log):
+    import torch
+    from gen_worker.models.svdq import detect_svdq_artifact
+    from gen_worker.models.svdq_native import (
+        load_svdq_native_denoiser, svdq_native_available, svdq_native_reason)
+
+    art = detect_svdq_artifact(ckpt)
+    assert art is not None, f"no svdq artifact detected at {ckpt}"
+    from gen_worker.models import native_kernels as nk
+    lane = nk.svdq_execution_lane()
+    log(f"execution lane={lane} ({nk.svdq_lane_reason()})")
+    avail = svdq_native_available()
+    log(f"svdq_native_available={avail} reason={svdq_native_reason()!r} "
+        f"model_class={art.model_class} rank={art.rank} precision={art.precision}")
+    assert avail, "REFUSING: blockwise kernels not armed on this card"
+    den = load_svdq_native_denoiser(art, compute_dtype=torch.bfloat16, mode="blockwise")
+    got = getattr(den, "_cozy_svdq_mode", "?")
+    assert got == "blockwise", f"decoded mode {got}, not blockwise — no silent dense fallback"
+    log(f"OURS decoded blockwise; class={type(den).__name__}")
+    import gen_worker
+    census = {"fused": 0, "blockwise": 0, "awq_packed": 0}
+    for _n, mod in den.named_modules():
+        if getattr(mod, "_cozy_awq_packed", False):
+            census["awq_packed"] += 1
+        elif getattr(mod, "_cozy_svdq_fused", False):
+            census["fused"] += 1
+        elif getattr(mod, "_cozy_svdq_linear", False):
+            census["blockwise"] += 1
+    log(f"swap census={census}")
+    if lane == "fused":
+        assert census["fused"] > 0, "fused lane armed but zero fused modules"
+    return den, {"runtime": "gen_worker svdq_native", "lane": lane,
+                 "lane_reason": nk.svdq_lane_reason(), "swap_census": census,
+                 "gen_worker": getattr(gen_worker, "__version__", "?"),
+                 "svdq_mode": got, "rank": art.rank, "precision": str(art.precision)}
+
+
+def load_bf16(tree: Path, log):
+    """The unquantized reference transformer from the same component tree —
+    the same-card bf16 row every quantized number is judged against."""
+    import torch
+    from diffusers import QwenImageTransformer2DModel
+
+    den = QwenImageTransformer2DModel.from_pretrained(
+        str(tree), subfolder="transformer", torch_dtype=torch.bfloat16)
+    log(f"BF16 reference transformer loaded; class={type(den).__name__}")
+    import gen_worker
+    return den, {"runtime": "diffusers bf16 reference",
+                 "gen_worker": getattr(gen_worker, "__version__", "?"),
+                 "precision": "bfloat16"}
+
+
+def load_fp8(tree: Path, log):
+    """The PUBLISHED #fp8-w8a8 flavor through the production w8a8 loader —
+    fp8 weights RESIDENT on torch._scaled_mm, the same dispatch prod runs."""
+    import torch
+    from gen_worker.models.w8a8 import (detect_w8a8_artifacts,
+                                        load_w8a8_denoiser, w8a8_gemm_mode)
+
+    arts = detect_w8a8_artifacts(tree)
+    assert arts, f"no #fp8-w8a8 artifact detected at {tree}"
+    assert len(arts) == 1, f"expected one denoiser, got {len(arts)}"
+    art = arts[0]
+    mode = w8a8_gemm_mode()
+    log(f"w8a8 gemm mode={mode!r} component={art.component!r} "
+        f"quantized={len(art.quantized)} static_scales={art.static_input_scales}")
+    assert mode in ("rowwise", "pertensor"), (
+        f"REFUSING: w8a8 fell back to {mode!r} — that arm is not fp8 compute")
+    den = load_w8a8_denoiser(tree, art, compute_dtype=torch.bfloat16,
+                             mode=mode)
+    swapped = sum(1 for _n, m in den.named_modules()
+                  if getattr(m, "_cozy_w8a8_linear", False))
+    log(f"FP8 loaded; class={type(den).__name__} fp8_linears={swapped}")
+    assert swapped > 0, "fp8 arm swapped zero Linears — it is not serving fp8"
+    import gen_worker
+    return den, {"runtime": "gen_worker w8a8", "lane": f"w8a8:{mode}",
+                 "gen_worker": getattr(gen_worker, "__version__", "?"),
+                 "fp8_linears": swapped, "precision": "fp8-w8a8"}
+
+
+def load_theirs(ckpt: Path, log):
+    import torch
+    import nunchaku
+    from nunchaku import NunchakuQwenImageTransformer2DModel
+    try:
+        from nunchaku.utils import get_precision
+        prec = get_precision()
+    except Exception:  # noqa: BLE001
+        prec = "?"
+    log(f"nunchaku {getattr(nunchaku, '__version__', '?')} get_precision={prec}")
+    assert prec == "fp4", f"expected fp4 on sm_120, got {prec}"
+    try:
+        den = NunchakuQwenImageTransformer2DModel.from_pretrained(
+            str(ckpt), torch_dtype=torch.bfloat16)
+    except TypeError:
+        den = NunchakuQwenImageTransformer2DModel.from_pretrained(str(ckpt))
+    log(f"THEIRS loaded; class={type(den).__name__}")
+    return den, {"runtime": "nunchaku official",
+                 "nunchaku": getattr(nunchaku, "__version__", "?"),
+                 "precision": prec}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True,
+                    choices=["ours", "bf16", "fp8", "nunchaku"])
+    ap.add_argument("--fp8-tree", default="",
+                    help="materialized #fp8-w8a8 tree (arm fp8)")
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--reference-tree", required=True)
+    ap.add_argument("--prompts", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--compile", action="store_true",
+                    help="production posture: torch.compile(den.forward, dynamic=None)")
+    ap.add_argument("--attn-drop", action="store_true",
+                    help="sdpa lever: drop the attn_mask (exact for batch-1 "
+                         "unpadded prompts; frees flash/cuDNN backends)")
+    ap.add_argument("--repeat-id", default="t02")
+    ap.add_argument("--rows", default="",
+                    help="comma-separated row ids; default = the whole set")
+    ap.add_argument("--norm-rows", type=int, default=3,
+                    help="rows for the normalized shape block (0 disables)")
+    ap.add_argument("--norm-shape", default="1024x1024x30x4.0",
+                    help="WxHxSTEPSxTRUE_CFG — the market-comparable row "
+                         "(1024^2/30/cfg4.0 = the diffusers default fal "
+                         "serves); true_cfg 1.0 means ONE forward/step")
+    args = ap.parse_args()
+
+    def log(m):
+        print(f"[{args.arm}] {m}", flush=True)
+
+    import torch
+    assert torch.cuda.is_available()
+    dev = torch.cuda.get_device_name(0)
+    sm = "".join(str(x) for x in torch.cuda.get_device_capability())
+    _free, total = torch.cuda.mem_get_info()
+    log(f"device={dev} sm_{sm} torch={torch.__version__} vram={total/1e9:.1f}GB")
+
+    spec = json.loads(Path(args.prompts).read_text())
+    if args.rows:
+        keep = [r.strip() for r in args.rows.split(",") if r.strip()]
+        spec["t2i"] = [r for r in spec["t2i"] if r["id"] in keep]
+        assert spec["t2i"], f"no rows matched {keep}"
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t_load0 = time.perf_counter()
+    if args.arm == "ours":
+        den, rtinfo = load_ours(Path(args.ckpt), log)
+    elif args.arm == "bf16":
+        den, rtinfo = load_bf16(Path(args.reference_tree), log)
+    elif args.arm == "fp8":
+        den, rtinfo = load_fp8(Path(args.fp8_tree), log)
+    else:
+        den, rtinfo = load_theirs(Path(args.ckpt), log)
+    if args.attn_drop:
+        import torch.nn.functional as F
+        _orig_sdpa = F.scaled_dot_product_attention
+
+        def _maskfree(*a, **kw):
+            if "attn_mask" in kw:
+                kw["attn_mask"] = None
+                return _orig_sdpa(*a, **kw)
+            if len(a) >= 4:
+                return _orig_sdpa(*(a[:3] + (None,) + a[4:]), **kw)
+            return _orig_sdpa(*a, attn_mask=None, **kw)
+
+        F.scaled_dot_product_attention = _maskfree
+        rtinfo["attn_drop"] = True
+        log("sdpa attn_mask DROPPED (exact for batch-1 unpadded prompts)")
+    if args.compile:
+        # two shape blocks per process; each specializes once under
+        # dynamic=None, and the default limit is what polluted the banked
+        # 5090 20-row summary.
+        import torch._dynamo
+        torch._dynamo.config.cache_size_limit = 32
+        den.forward = torch.compile(den.forward, dynamic=None)
+        rtinfo["compiled"] = "torch.compile(dynamic=None)"
+        log("denoiser forward compiled (production posture)")
+
+    import diffusers
+    import transformers
+    from diffusers import DiffusionPipeline
+    pipe = DiffusionPipeline.from_pretrained(
+        args.reference_tree, torch_dtype=torch.bfloat16, transformer=den)
+    offload = total < 40e9
+    if offload:
+        pipe.enable_model_cpu_offload()
+        log("model_cpu_offload enabled (<40GB card); denoise stays on cuda")
+    else:
+        pipe = pipe.to("cuda")
+    load_s = time.perf_counter() - t_load0
+    log(f"pipeline {type(pipe).__name__} ready in {load_s:.1f}s "
+        f"diffusers={diffusers.__version__} transformers={transformers.__version__}")
+
+    steps, cfg = int(spec["steps"]), float(spec["true_cfg_scale"])
+    neg, (w, h) = spec["negative_prompt"], spec["resolution"]
+
+    def render_at(prompt: str, seed: int, n_steps: int, rw: int, rh: int,
+                  rcfg: float):
+        timer = StepTimer()
+        g = torch.Generator(device="cuda").manual_seed(seed)
+        t0 = time.perf_counter()
+        img = pipe(prompt=prompt, num_inference_steps=n_steps, width=rw,
+                   height=rh, generator=g, true_cfg_scale=rcfg,
+                   negative_prompt=neg,
+                   callback_on_step_end=timer).images[0]
+        wall = time.perf_counter() - t0
+        deltas = [timer.ts[i] - timer.ts[i - 1]
+                  for i in range(1, len(timer.ts))]
+        return img, wall, deltas
+
+    def render(prompt: str, seed: int, n_steps: int):
+        return render_at(prompt, seed, n_steps, w, h, cfg)
+
+    # warmup (full res/shape so kernel autotune is covered; not counted)
+    log("warmup render (4 steps, not counted)")
+    wimg, wwall, _ = render(spec["t2i"][0]["prompt"], spec["t2i"][0]["seed"], 4)
+    save_webp(wimg, out_dir / "warmup.webp")
+    torch.cuda.reset_peak_memory_stats()
+
+    rows = []
+    for r in spec["t2i"]:
+        img, wall, deltas = render(r["prompt"], r["seed"], steps)
+        save_webp(img, out_dir / f"{r['id']}.webp")
+        steady = deltas[1:] if len(deltas) > 2 else deltas
+        rows.append({"id": r["id"], "seed": r["seed"], "e2e_s": wall,
+                     "steps": steps, "step_deltas": deltas,
+                     "step_mean_s": sum(steady) / len(steady)})
+        log(f"{r['id']} e2e={wall:.2f}s step_mean={rows[-1]['step_mean_s']*1000:.0f}ms")
+
+    rep_row = next((r for r in spec["t2i"] if r["id"] == args.repeat_id),
+                   spec["t2i"][0])
+    repeats = []
+    for i in range(args.repeats):
+        _img, wall, deltas = render(rep_row["prompt"], rep_row["seed"], steps)
+        steady = deltas[1:] if len(deltas) > 2 else deltas
+        repeats.append({"e2e_s": wall, "step_mean_s": sum(steady) / len(steady)})
+        log(f"repeat{i} {args.repeat_id} e2e={wall:.2f}s")
+
+    # Normalized block: same process, same weights, market-comparable shape.
+    # Reported separately — never mixed into the main summary.
+    norm = None
+    if args.norm_rows > 0 and args.norm_shape:
+        nw, nh, nsteps, ncfg = args.norm_shape.split("x")
+        nw, nh, nsteps, ncfg = int(nw), int(nh), int(nsteps), float(ncfg)
+        log(f"normalized block {nw}x{nh} steps={nsteps} true_cfg={ncfg} "
+            f"({'2 fwd' if ncfg > 1.0 else '1 fwd'}/step)")
+        nrows = []
+        wimg2, _w2, _d2 = render_at(spec["t2i"][0]["prompt"],
+                                    spec["t2i"][0]["seed"], 4, nw, nh, ncfg)
+        save_webp(wimg2, out_dir / "norm_warmup.webp")
+        for r in spec["t2i"][:args.norm_rows]:
+            img, wall, deltas = render_at(r["prompt"], r["seed"], nsteps,
+                                          nw, nh, ncfg)
+            save_webp(img, out_dir / f"norm_{r['id']}.webp")
+            steady = deltas[1:] if len(deltas) > 2 else deltas
+            nrows.append({"id": r["id"], "e2e_s": wall,
+                          "step_mean_s": sum(steady) / len(steady)})
+            log(f"norm {r['id']} e2e={wall:.2f}s "
+                f"step_mean={nrows[-1]['step_mean_s'] * 1000:.0f}ms")
+        ne = [r["e2e_s"] for r in nrows]
+        ns = [r["step_mean_s"] for r in nrows]
+        norm = {"shape": [nw, nh], "steps": nsteps, "true_cfg_scale": ncfg,
+                "forwards_per_step": 2 if ncfg > 1.0 else 1,
+                "rows": nrows,
+                "e2e_mean_s": sum(ne) / len(ne), "e2e_min_s": min(ne),
+                "step_mean_s": sum(ns) / len(ns),
+                "images_per_hour": 3600.0 / (sum(ne) / len(ne))}
+        log(f"NORM e2e_mean={norm['e2e_mean_s']:.2f}s "
+            f"step={norm['step_mean_s'] * 1000:.0f}ms")
+
+    peak_alloc = torch.cuda.max_memory_allocated()
+    peak_res = torch.cuda.max_memory_reserved()
+    e2e = [r["e2e_s"] for r in rows[1:]]  # drop first counted image from means too
+    stepms = [r["step_mean_s"] for r in rows[1:]]
+    report = {
+        "arm": args.arm, "runtime": rtinfo, "device": dev, "sm": sm,
+        "torch": torch.__version__, "diffusers": diffusers.__version__,
+        "transformers": transformers.__version__,
+        "offload": "model_cpu_offload" if offload else "none",
+        "ckpt": str(args.ckpt), "load_s": load_s,
+        "recipe": {"steps": steps, "true_cfg_scale": cfg, "resolution": [w, h],
+                   "negative_prompt": neg, "set": spec["set"],
+                   "note": "per step = 2 transformer forwards (true CFG)"},
+        "images": rows, "repeats": repeats, "normalized": norm,
+        "summary": {
+            "e2e_mean_s": sum(e2e) / len(e2e),
+            "e2e_min_s": min(e2e), "e2e_max_s": max(e2e),
+            "step_mean_s": sum(stepms) / len(stepms),
+            "images_per_hour": 3600.0 / (sum(e2e) / len(e2e)),
+            "peak_vram_alloc_gb": peak_alloc / 2**30,
+            "peak_vram_reserved_gb": peak_res / 2**30,
+        },
+    }
+    (out_dir / f"bench_{args.arm}.json").write_text(json.dumps(report, indent=1))
+    s = report["summary"]
+    nz = (f" | norm {norm['shape'][0]}^2/{norm['steps']}: "
+          f"e2e={norm['e2e_mean_s']:.2f}s "
+          f"step={norm['step_mean_s'] * 1000:.0f}ms" if norm else "")
+    log(f"DONE e2e_mean={s['e2e_mean_s']:.2f}s "
+        f"step_mean={s['step_mean_s']*1000:.0f}ms "
+        f"imgs/hr={s['images_per_hour']:.1f} "
+        f"peak_vram={s['peak_vram_alloc_gb']:.1f}GB load={load_s:.1f}s{nz}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/bench_arm.py
+++ b/scripts/svdq_bench/bench_arm.py
@@ -46,8 +46,10 @@ def load_ours(ckpt: Path, log):
     art = detect_svdq_artifact(ckpt)
     assert art is not None, f"no svdq artifact detected at {ckpt}"
     from gen_worker.models import native_kernels as nk
-    lane = nk.svdq_execution_lane()
-    log(f"execution lane={lane} ({nk.svdq_lane_reason()})")
+    lane = nk.svdq_linear_lane()
+    mod_lane = nk.svdq_modulation_lane()
+    log(f"linear lane={lane} ({nk.svdq_linear_lane_reason()}); "
+        f"modulation lane={mod_lane} ({nk.svdq_modulation_lane_reason()})")
     avail = svdq_native_available()
     log(f"svdq_native_available={avail} reason={svdq_native_reason()!r} "
         f"model_class={art.model_class} rank={art.rank} precision={art.precision}")
@@ -69,7 +71,9 @@ def load_ours(ckpt: Path, log):
     if lane == "fused":
         assert census["fused"] > 0, "fused lane armed but zero fused modules"
     return den, {"runtime": "gen_worker svdq_native", "lane": lane,
-                 "lane_reason": nk.svdq_lane_reason(), "swap_census": census,
+                 "modulation_lane": mod_lane,
+                 "lane_reason": nk.svdq_linear_lane_reason(),
+                 "swap_census": census,
                  "gen_worker": getattr(gen_worker, "__version__", "?"),
                  "svdq_mode": got, "rank": art.rank, "precision": str(art.precision)}
 

--- a/scripts/svdq_bench/bench_b0.py
+++ b/scripts/svdq_bench/bench_b0.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""pgw#862 B0 pod cell — fused svdq lane vs baseline on one sm_120 card.
+
+Modes (each its own process; the lane decision is per-process):
+  correctness: baseline model + fused twins on REAL captured activations —
+               quant bit-identity, per-unit tolerances vs the fp32
+               quant-sim reference, fused-vs-baseline divergence.
+  bench:       one lane (GEN_WORKER_NATIVE_KERNELS picks it): load, swap
+               census, eager + compiled step time, top kernels, peak VRAM.
+
+Usage: bench_b0.py --ckpt F --out D --mode {correctness,bench}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+
+def synth_inputs(model, dev, dtype):
+    """1328^2-shaped synthetic inputs, filtered to the model's actual forward
+    signature (diffusers 0.39 dropped txt_seq_lens)."""
+    import inspect
+
+    import torch
+    g = torch.Generator(device="cpu").manual_seed(7)
+    hs = torch.randn(1, 6889, 64, generator=g).to(dev, dtype)      # (1328/16)^2
+    txt = torch.randn(1, 512, 3584, generator=g).to(dev, dtype)
+    mask = torch.ones(1, 512, dtype=torch.long, device=dev)
+    t = torch.full((1,), 0.5, dtype=dtype, device=dev)
+    kw = dict(hidden_states=hs, encoder_hidden_states=txt,
+              encoder_hidden_states_mask=mask, timestep=t,
+              img_shapes=[(1, 83, 83)], txt_seq_lens=[512],
+              return_dict=False)
+    accepted = set(inspect.signature(
+        type(model).forward).parameters) - {"self"}
+    return {k: v for k, v in kw.items() if k in accepted}
+
+
+def time_forwards(model, kw, n, warmup=5):
+    import torch
+    for _ in range(warmup):
+        with torch.no_grad():
+            model(**kw)
+    torch.cuda.synchronize()
+    ts = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        with torch.no_grad():
+            model(**kw)
+        torch.cuda.synchronize()
+        ts.append(time.perf_counter() - t0)
+    ts.sort()
+    return {"mean_ms": sum(ts) / len(ts) * 1e3,
+            "p50_ms": ts[len(ts) // 2] * 1e3,
+            "min_ms": ts[0] * 1e3, "max_ms": ts[-1] * 1e3, "n": n}
+
+
+# Sampled units: every shape class, early/mid/late blocks.
+SAMPLE_BLOCKS = (0, 29, 59)
+SAMPLE_SUFFIXES = (
+    "attn.to_q", "attn.to_out.0", "attn.add_q_proj", "attn.to_add_out",
+    "img_mlp.net.0.proj", "img_mlp.net.2", "txt_mlp.net.0.proj",
+    "txt_mlp.net.2",
+)
+
+
+def _decode_for_paths(art, model, wanted: set):
+    """path -> DecodedLinear for the wanted module paths. Cannot use
+    plan_targets here: the model is already swapped, so the targets are
+    _SvdqLinear (not nn.Linear) — resolve by out_features attribute."""
+    from safetensors import safe_open
+
+    from gen_worker.models.svdq_layout import decode_linear, split_decoded
+    from gen_worker.models.svdq_native import (_FUSED_SPLITS, _group_by_prefix,
+                                               _module_at)
+
+    def targets_for(prefix):
+        direct = _module_at(model, prefix)
+        if direct is not None and hasattr(direct, "out_features"):
+            return ((prefix, int(direct.out_features)),)
+        parent, _, leaf = prefix.rpartition(".")
+        parts = _FUSED_SPLITS.get(leaf)
+        if parts is None:
+            return None
+        out = []
+        for p in parts:
+            path = f"{parent}.{p}" if parent else p
+            mod = _module_at(model, path)
+            if mod is None or not hasattr(mod, "out_features"):
+                return None
+            out.append((path, int(mod.out_features)))
+        return tuple(out)
+
+    out = {}
+    with safe_open(str(art.file), framework="pt", device="cuda") as fh:
+        groups = _group_by_prefix(fh.keys())
+        for prefix, leaves in sorted(groups.items()):
+            targets = targets_for(prefix)
+            if not targets:
+                continue
+            paths = [p for p, _ in targets]
+            if not any(p in wanted for p in paths):
+                continue
+            tensors = {leaf: fh.get_tensor(f"{prefix}.{leaf}")
+                       for leaf in leaves}
+            if "qweight" not in tensors:
+                continue
+            out_f = sum(o for _, o in targets)
+            in_f = int(_module_at(model, paths[0]).in_features)
+            dec = decode_linear(tensors, out_f, in_f)
+            parts = (dec,) if len(targets) == 1 else split_decoded(
+                dec, tuple(o for _, o in targets))
+            for (p, _o), part in zip(targets, parts):
+                if p in wanted:
+                    out[p] = part
+    return out
+
+
+def run_correctness(args) -> int:
+    import torch
+    from gen_worker.models import svdq_fused
+    from gen_worker.models import svdq_native as native
+    from gen_worker.models.svdq import detect_svdq_artifact
+    from gen_worker.models.svdq_fused import _dyn_s2, _reference_quant_flat
+
+    out_dir = Path(args.out); out_dir.mkdir(parents=True, exist_ok=True)
+    art = detect_svdq_artifact(Path(args.ckpt))
+    assert art is not None
+    assert native.svdq_native_available(), "blockwise must arm"
+
+    model = native.load_svdq_native_denoiser(
+        art, compute_dtype=torch.bfloat16, mode="blockwise", device="cuda")
+
+    wanted = {f"transformer_blocks.{b}.{s}" for b in SAMPLE_BLOCKS
+              for s in SAMPLE_SUFFIXES}
+    captured: dict = {}
+    hooks = []
+    for name, mod in model.named_modules():
+        if name in wanted and getattr(mod, "_cozy_svdq_linear", False):
+            def mk(nm):
+                def hook(m, inp, outp):
+                    if nm not in captured:
+                        captured[nm] = inp[0].detach().reshape(
+                            -1, m.in_features).contiguous()
+                return hook
+            hooks.append(mod.register_forward_hook(mk(name)))
+    kw = synth_inputs(model, "cuda", torch.bfloat16)
+    with torch.no_grad():
+        model(**kw)
+    for h in hooks:
+        h.remove()
+    print(f"[corr] captured {len(captured)}/{len(wanted)} real activations",
+          flush=True)
+
+    decs = _decode_for_paths(art, model, set(captured))
+    rows = []
+    quant_bitident = True
+    ops = svdq_fused.fused_ops()
+    assert ops is not None
+    quant_op = ops[0]
+    for name in sorted(captured):
+        x = captured[name]
+        base_mod = model.get_submodule(name)
+        dec = decs[name]
+        fused_mod = svdq_fused.build_svdq_fused_linear(dec, device="cuda")
+        with torch.no_grad():
+            y_base = base_mod(x)
+            y_fused = fused_mod(x)
+
+            smooth = fused_mod.smooth_factor
+            s2 = _dyn_s2(x, smooth)
+            xs = (x / smooth) if smooth is not None else x
+            qa, sa = _reference_quant_flat(xs, s2)
+            got_qa, got_sa = quant_op(x, smooth, s2, False)
+            bit_q = torch.equal(got_qa, qa)
+            bit_s = torch.equal(got_sa.view(torch.uint8),
+                                sa.view(torch.uint8))
+            quant_bitident &= (bit_q and bit_s)
+
+            from gen_worker.models.nvfp4_quant import BLOCK, unpack_e2m1
+            m, k = x.shape
+            n = dec.out_features
+            a_deq = (unpack_e2m1(qa).reshape(m, k // BLOCK, BLOCK)
+                     * sa.float().unsqueeze(-1)).reshape(m, k) * s2
+            from gen_worker.models.svdq_layout import dequantize_decoded
+            w_deq = dequantize_decoded(dec)  # includes second level
+            ref = a_deq @ w_deq.t()
+            ref = ref + (x @ dec.proj_down.to(x.dtype)).float() \
+                @ dec.proj_up.float().t()
+            if dec.bias is not None:
+                ref = ref + dec.bias.float()
+
+            def rel(a, b):
+                return ((a.float() - b.float()).norm()
+                        / b.float().norm().clamp(min=1e-9)).item()
+
+            rows.append({
+                "unit": name, "m": int(m), "k": int(k), "n": int(n),
+                "second_kind": dec.second_kind,
+                "quant_bit_identical": bool(bit_q and bit_s),
+                "rel_base_vs_ref": rel(y_base, ref),
+                "rel_fused_vs_ref": rel(y_fused, ref),
+                "rel_fused_vs_base": rel(y_fused, y_base),
+                "max_abs_fused_vs_base": float(
+                    (y_fused.float() - y_base.float()).abs().max()),
+            })
+            print(f"[corr] {name}: bit={bit_q and bit_s} "
+                  f"base_vs_ref={rows[-1]['rel_base_vs_ref']:.2e} "
+                  f"fused_vs_ref={rows[-1]['rel_fused_vs_ref']:.2e} "
+                  f"fused_vs_base={rows[-1]['rel_fused_vs_base']:.2e}",
+                  flush=True)
+        del fused_mod
+        torch.cuda.empty_cache()
+
+    worse = [r for r in rows if r["rel_fused_vs_ref"]
+             > r["rel_base_vs_ref"] * 1.05 + 1e-6]
+    report = {"device": torch.cuda.get_device_name(0),
+              "units": rows, "quant_bit_identical_all": quant_bitident,
+              "fused_worse_than_base_vs_ref": [r["unit"] for r in worse],
+              "self_check": svdq_fused.fused_self_check()}
+    (out_dir / "correctness.json").write_text(json.dumps(report, indent=1))
+    print(f"[corr] DONE bitident={quant_bitident} worse_units={len(worse)} "
+          f"self_check={report['self_check']}", flush=True)
+    return 0
+
+
+def run_bench(args) -> int:
+    import torch
+    import gen_worker
+    from gen_worker.models import native_kernels as nk
+    from gen_worker.models import svdq_native as native
+    from gen_worker.models.svdq import detect_svdq_artifact
+
+    out_dir = Path(args.out); out_dir.mkdir(parents=True, exist_ok=True)
+    lane = nk.svdq_execution_lane()
+    report: dict = {"device": torch.cuda.get_device_name(0),
+                    "torch": torch.__version__,
+                    "gen_worker": getattr(gen_worker, "__version__", "?"),
+                    "lane": lane, "lane_reason": nk.svdq_lane_reason()}
+    print(f"[bench] lane={lane} ({report['lane_reason']})", flush=True)
+
+    art = detect_svdq_artifact(Path(args.ckpt))
+    assert art is not None
+    assert native.svdq_native_available(), "blockwise must arm"
+
+    t0 = time.perf_counter()
+    model = native.load_svdq_native_denoiser(
+        art, compute_dtype=torch.bfloat16, mode="blockwise", device="cuda")
+    torch.cuda.synchronize()
+    report["load_s"] = time.perf_counter() - t0
+    census = {"fused": 0, "blockwise": 0, "awq_packed": 0}
+    for _n, mod in model.named_modules():
+        if getattr(mod, "_cozy_awq_packed", False):
+            census["awq_packed"] += 1
+        elif getattr(mod, "_cozy_svdq_fused", False):
+            census["fused"] += 1
+        elif getattr(mod, "_cozy_svdq_linear", False):
+            census["blockwise"] += 1
+    report["swap_census"] = census
+    report["resident_after_load_gb"] = torch.cuda.memory_allocated() / 2**30
+    print(f"[bench] load {report['load_s']:.1f}s census={census} "
+          f"resident={report['resident_after_load_gb']:.1f}GB", flush=True)
+    if lane == "fused":
+        assert census["fused"] > 0, "fused lane armed but zero fused modules"
+
+    kw = synth_inputs(model, "cuda", torch.bfloat16)
+    eager = time_forwards(model, kw, 20, warmup=8)
+    report["eager_forward"] = eager
+    report["eager_step_ms"] = eager["mean_ms"] * 2
+    print(f"[bench] eager fwd {eager['mean_ms']:.1f}ms "
+          f"-> step {eager['mean_ms'] * 2:.0f}ms", flush=True)
+
+    from torch.profiler import ProfilerActivity, profile
+    with torch.no_grad():
+        with profile(activities=[ProfilerActivity.CPU,
+                                 ProfilerActivity.CUDA]) as prof:
+            for _ in range(10):
+                model(**kw)
+            torch.cuda.synchronize()
+    top = sorted(prof.key_averages(), key=lambda r: -r.device_time_total)[:25]
+    report["top_kernels_per_forward_ms"] = [
+        {"key": r.key[:120], "cuda_ms": r.device_time_total / 1e3 / 10,
+         "count": r.count} for r in top]
+    (out_dir / f"profile_{lane}.txt").write_text(
+        prof.key_averages().table(sort_by="cuda_time_total", row_limit=50))
+
+    t0 = time.perf_counter()
+    model.forward = torch.compile(model.forward, dynamic=None)
+    with torch.no_grad():
+        model(**kw)
+    torch.cuda.synchronize()
+    report["compile_wall_s"] = time.perf_counter() - t0
+    comp = time_forwards(model, kw, 20)
+    report["compiled_forward"] = comp
+    report["compiled_step_ms"] = comp["mean_ms"] * 2
+    report["peak_vram_gb"] = torch.cuda.max_memory_allocated() / 2**30
+    print(f"[bench] compiled wall {report['compile_wall_s']:.0f}s fwd "
+          f"{comp['mean_ms']:.1f}ms -> step {comp['mean_ms'] * 2:.0f}ms "
+          f"peak {report['peak_vram_gb']:.1f}GB", flush=True)
+
+    (out_dir / f"bench_{lane}.json").write_text(json.dumps(report, indent=1))
+    print("[bench] DONE " + json.dumps({
+        "lane": lane, "eager_step_ms": report["eager_step_ms"],
+        "compiled_step_ms": report["compiled_step_ms"]}), flush=True)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--mode", choices=("correctness", "bench"),
+                    required=True)
+    args = ap.parse_args()
+    if args.mode == "correctness":
+        return run_correctness(args)
+    return run_bench(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/bench_b0.py
+++ b/scripts/svdq_bench/bench_b0.py
@@ -234,11 +234,13 @@ def run_bench(args) -> int:
     from gen_worker.models.svdq import detect_svdq_artifact
 
     out_dir = Path(args.out); out_dir.mkdir(parents=True, exist_ok=True)
-    lane = nk.svdq_execution_lane()
+    lane = nk.svdq_linear_lane()
     report: dict = {"device": torch.cuda.get_device_name(0),
                     "torch": torch.__version__,
                     "gen_worker": getattr(gen_worker, "__version__", "?"),
-                    "lane": lane, "lane_reason": nk.svdq_lane_reason()}
+                    "lane": lane,
+                    "modulation_lane": nk.svdq_modulation_lane(),
+                    "lane_reason": nk.svdq_linear_lane_reason()}
     print(f"[bench] lane={lane} ({report['lane_reason']})", flush=True)
 
     art = detect_svdq_artifact(Path(args.ckpt))

--- a/scripts/svdq_bench/bench_gemm.py
+++ b/scripts/svdq_bench/bench_gemm.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Which W4A4 GEMM wins on THIS card, at qwen-image's real shapes (pgw#863).
+
+The sm_120 verdict was: cuBLAS block-scaled fp4 (``torch._scaled_mm``) beats
+the pure-triton ``tl.dot_scaled`` kernel by ~2.5x, so the serving path is the
+HYBRID (triton quant -> cuBLAS GEMM -> triton epilogue). That verdict is not
+transferable by assumption: sm_100a issues block-scaled MMA through tcgen05
+rather than sm_120a's mxf4nvf4, and cuBLAS's fp4 path was separately measured
+(pgw#682) at only 1.03x bf16 on sm_100 against 2.04x on sm_120. If the
+ordering inverts here, the fused pure-triton kernel — which also absorbs the
+low-rank branch and the epilogue — becomes the sm_100 serving path, and the
+"instantiate CUTLASS templates" plan is unnecessary.
+
+Measures, per shape, with no checkpoint and no model:
+  bf16          plain bf16 mm (the roofline everything is judged against)
+  cublas        the shipped hybrid: quant + _scaled_mm + fused epilogue
+  triton        the fused alternative: quant + dot_scaled GEMM w/ lora epilogue
+plus the quant kernel alone at several warp counts, because _WARPS_BY_SM's
+sm_100 entry (4) was never swept on real sm_100 silicon.
+
+  bench_gemm.py --out DIR
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+# (M, K, N) at 1328^2 (6889 image tokens + 512 text) and 1024^2 (4096+512),
+# covering every distinct qwen-image svdq unit shape.
+SHAPES = [
+    (7401, 3072, 3072),    # attn qkv-split / to_out at 1328^2
+    (7401, 3072, 12288),   # img_mlp.net.0.proj
+    (7401, 12288, 3072),   # img_mlp.net.2
+    (4608, 3072, 3072),    # the same three at 1024^2
+    (4608, 3072, 12288),
+    (4608, 12288, 3072),
+    (512, 3072, 3072),     # txt-only stream
+]
+RANK = 128
+
+
+def median_ms(fn, iters=30, warmup=10):
+    import torch
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    ts = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        ts.append((time.perf_counter() - t0) * 1e3)
+    ts.sort()
+    return ts[len(ts) // 2]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    import torch
+    from gen_worker.models.nvfp4_quant import (BLOCK, pack_e2m1,
+                                               to_blocked_scales)
+    from gen_worker.models.svdq_fused import _dyn_s2, fused_ops
+    from gen_worker.models.w4a4 import _gemm_w4a4
+
+    dev = torch.cuda.get_device_name(0)
+    cap = torch.cuda.get_device_capability()
+    sm = cap[0] * 10 + cap[1]
+    print(f"[gemm] {dev} sm_{sm} torch={torch.__version__}", flush=True)
+    ops = fused_ops()
+    assert ops is not None, "triton fused ops unavailable"
+    quant_op, gemm_op, epi_op = ops
+
+    rows = []
+    for m, k, n in SHAPES:
+        torch.manual_seed(0)
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        wq_codes = torch.randint(0, 16, (n, k), device="cuda",
+                                 dtype=torch.uint8)
+        wq = pack_e2m1(wq_codes)                       # [n, k/2]
+        ws_flat = (torch.rand(n, k // BLOCK, device="cuda") + 0.5).to(
+            torch.float8_e4m3fn)
+        ws_blocked = to_blocked_scales(ws_flat)
+        # the triton kernel consumes [k/2, n] nibbles + flat [n, k/16] scales
+        wq_kn = pack_e2m1(wq_codes.t().contiguous())
+        second = (torch.rand(n, device="cuda") + 0.1)
+        up = torch.randn(n, RANK, device="cuda", dtype=torch.bfloat16) * 0.02
+        down = torch.randn(k, RANK, device="cuda",
+                           dtype=torch.bfloat16) * 0.02
+        bias = torch.randn(n, device="cuda", dtype=torch.bfloat16)
+        wb = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+        s2 = _dyn_s2(x, None)
+
+        def bf16_arm():
+            y = x @ wb.t()
+            return y + (x @ down) @ up.t() + bias
+
+        def cublas_arm():
+            qa, sa = quant_op(x, None, s2, True)
+            y0 = _gemm_w4a4(qa, wq, sa, ws_blocked, torch.bfloat16)
+            la = x @ down
+            return epi_op(y0, la, up, s2, second, bias)
+
+        def triton_arm():
+            qa, sa = quant_op(x, None, s2, False)
+            la = x @ down
+            return gemm_op(qa, sa, wq_kn, ws_flat, s2, second, la, up, bias)
+
+        def quant_only():
+            return quant_op(x, None, s2, True)
+
+        row = {"m": m, "k": k, "n": n}
+        for name, fn in (("bf16", bf16_arm), ("cublas", cublas_arm),
+                         ("triton", triton_arm), ("quant", quant_only)):
+            try:
+                row[f"{name}_ms"] = median_ms(fn)
+            except Exception as exc:  # noqa: BLE001
+                row[f"{name}_ms"] = None
+                row[f"{name}_err"] = f"{type(exc).__name__}: {exc}"[:200]
+        # agreement between the two fp4 paths (they must compute the same op)
+        try:
+            a, b = cublas_arm().float(), triton_arm().float()
+            row["rel_cublas_vs_triton"] = float(
+                (a - b).norm() / b.norm().clamp(min=1e-9))
+        except Exception as exc:  # noqa: BLE001
+            row["rel_cublas_vs_triton"] = None
+            row["agree_err"] = f"{type(exc).__name__}: {exc}"[:200]
+        rows.append(row)
+        c, t, b16 = (row.get("cublas_ms"), row.get("triton_ms"),
+                     row.get("bf16_ms"))
+        print(f"[gemm] {m}x{k}x{n}: bf16={b16} cublas={c} triton={t} "
+              f"quant={row.get('quant_ms')} "
+              f"rel={row.get('rel_cublas_vs_triton')}", flush=True)
+
+    # quant-kernel warp sweep: the sm_100 entry in _WARPS_BY_SM was a guess.
+    warp_rows = []
+    from gen_worker.models import svdq_fused as sf
+    m, k = 7401, 3072
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    s2 = _dyn_s2(x, None)
+    saved = dict(sf._QUANT_WARPS_BY_SM)
+    for w in (1, 2, 4, 8, 16):
+        try:
+            sf._QUANT_WARPS_BY_SM[sm] = w
+            # the op is registered once; only the launch config is re-read,
+            # so drop the build cache to pick the new warp count up.
+            sf._build_fused_ops.cache_clear()
+            qop = sf.fused_ops()[0]
+            ms = median_ms(lambda: qop(x, None, s2, True))
+            warp_rows.append({"num_warps": w, "quant_ms": ms})
+            print(f"[gemm] quant warps={w}: {ms:.4f} ms", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            warp_rows.append({"num_warps": w, "err": str(exc)[:200]})
+    sf._QUANT_WARPS_BY_SM.clear()
+    sf._QUANT_WARPS_BY_SM.update(saved)
+    sf._build_fused_ops.cache_clear()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    report = {"device": dev, "sm": sm, "torch": torch.__version__,
+              "rank": RANK, "shapes": rows, "quant_warp_sweep": warp_rows}
+    (out / "gemm_choice.json").write_text(json.dumps(report, indent=1))
+    wins = sum(1 for r in rows
+               if r.get("triton_ms") and r.get("cublas_ms")
+               and r["triton_ms"] < r["cublas_ms"])
+    print(f"[gemm] DONE triton beats cublas on {wins}/{len(rows)} shapes",
+          flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/bench_prompts.json
+++ b/scripts/svdq_bench/bench_prompts.json
@@ -1,0 +1,112 @@
+{
+ "set": "cozy-hard-eval-v1",
+ "steps": 28,
+ "true_cfg_scale": 4.5,
+ "negative_prompt": " ",
+ "resolution": [
+  1328,
+  1328
+ ],
+ "t2i": [
+  {
+   "id": "t01",
+   "seed": 101,
+   "prompt": "A photograph of a small neighbourhood bakery's chalkboard A-frame sign standing on wet pavement at eight in the morning. The board is hand-lettered in white and pale-yellow chalk and reads, on five clearly separated lines: \"MORNING BAKE\" as a heading, then \"SOURDOUGH  4.50\", then \"ALMOND CROISSANT  3.75\", then \"CARDAMOM BUN  4.20\", and at the bottom, underlined, \"SOLD OUT BY NOON\". A small chalk drawing of a wheat sheaf sits in the lower right corner of the board. Shallow depth of field, the bakery's warm interior glowing out of focus behind it, overcast daylight, 50mm lens, fine grain."
+  },
+  {
+   "id": "t02",
+   "seed": 102,
+   "prompt": "A close-up documentary photograph of a man's weathered hands holding an open broadsheet newspaper at a cafe table. The visible headline reads \"HARBOUR BRIDGE REOPENS\" in heavy black serif capitals, with a smaller subheading beneath reading \"After nineteen months of repairs\", and two columns of small grey body text below that. His fingers are clearly articulated, five on each hand, thumb creasing the paper's edge, a plain steel wedding band on the left ring finger. A half-finished espresso and a folded pair of reading glasses sit beside the paper. Hard morning window light raking across the page, visible paper texture, 35mm."
+  },
+  {
+   "id": "t03",
+   "seed": 103,
+   "prompt": "An intimate studio portrait of an eighty-year-old Portuguese fisherwoman against a deep charcoal seamless backdrop. Her face fills most of the frame: deeply sun-creased skin, a constellation of small sunspots across her cheekbones, pale grey-green eyes with clearly defined catchlights, sparse silver eyebrows, a small healed scar through her left eyebrow, and dry lips slightly parted as if mid-sentence. Individual white hairs escape from a navy headscarf. Single large softbox at forty-five degrees camera left with a subtle silver reflector filling the shadow side, 85mm at f/4, sharp on the iris, medium-format tonality."
+  },
+  {
+   "id": "t04",
+   "seed": 104,
+   "prompt": "A photograph inside a specialty coffee bar: a young barista with short bleached hair and a nose ring, seen from the chest up, looking down in concentration as she pours a rosetta pattern of steamed milk into a white ceramic cup she is holding. Both hands are clearly visible and correctly formed \u2014 the left gripping the cup's handle, the right tilting a steel pitcher, fingers wrapped naturally around it. Behind her shoulder a small black chalkboard reads \"SINGLE ORIGIN\" on the first line and \"ETHIOPIA \u2014 GUJI\" on the second. Warm tungsten light mixed with cool daylight from a window on the right, 35mm, natural skin texture with visible pores."
+  },
+  {
+   "id": "t05",
+   "seed": 105,
+   "prompt": "A photograph of a hand-painted gold-leaf and black window sign on the glass front of an old-fashioned ironmonger's shop. The lettering is ornate Victorian signwriting with drop shadows and reads, in three stacked lines of decreasing size: \"H. WHITLOCK & SON\", then \"IRONMONGERS\", then \"ESTABLISHED 1897\". Through the glass behind the lettering, out of focus, are shelves of brass hinges and coils of rope. Reflections of a narrow cobbled street and a red pillar box are visible in the glass. Late afternoon sun catching the gold leaf, 50mm, high micro-contrast."
+  },
+  {
+   "id": "t06",
+   "seed": 106,
+   "prompt": "A documentary photograph of a luthier in her fifties in a sawdust-filled workshop, bent over a half-finished violin body clamped to a bench. Her face is in three-quarter profile, brow furrowed in concentration, reading glasses pushed up into greying curly hair. Both hands are prominent and anatomically correct: the left steadying the instrument's scroll, the right drawing a small finger plane along the spruce top, curls of shavings coming off the blade. Afternoon light from a high dusty window, motes visible in the air, warm wood tones, 35mm, f/2.8."
+  },
+  {
+   "id": "t07",
+   "seed": 107,
+   "prompt": "A night photograph of a narrow alley crowded with layered neon signage in two scripts. A large vertical red-and-white neon sign reads \"KOBAYASHI\" from top to bottom; beside it a horizontal cyan sign reads \"OPEN LATE\"; a smaller magenta sign below reads \"\u5c45\u9152\u5c4b\"; and a yellow arrow sign points down a stairwell with the word \"BASEMENT\" beside it. Rain has just stopped, so every sign is doubled in the puddles underfoot. Steam drifts from a vent. Anamorphic flares, deep blacks, slight chromatic aberration, 40mm, handheld at 1/60."
+  },
+  {
+   "id": "t08",
+   "seed": 108,
+   "prompt": "An overhead photograph of a wooden desk where a woman's hands are writing a letter with a black fountain pen. The visible portion of the cream writing paper carries a printed letterhead reading \"THE ORCHARD PRESS\" in small copperplate capitals, and below it four lines of neat cursive handwriting beginning \"Dear Margaret, I hope this finds you well \u2014\". The writing hand is correctly formed with the pen held in a natural tripod grip; the other hand rests flat, steadying the page, all five fingers distinct. A brass letter opener, a cup of tea, and a scattering of dried pressed leaves surround the paper. Soft north-facing window light, 50mm, top-down."
+  },
+  {
+   "id": "t09",
+   "seed": 109,
+   "prompt": "A candid photograph of two men shaking hands across a market stall of fresh fish on crushed ice. The vendor on the left, mid-forties, ruddy complexion, laughing with his eyes creased shut and teeth showing, wears a rubber apron. The customer on the right, older, silver-bearded, smiles more reservedly in three-quarter view. Their clasped hands are the compositional centre and are clearly and correctly rendered \u2014 the interlocking grip readable, knuckles and tendons visible, no extra fingers. Cold overcast light under a striped awning, wet reflective surfaces, 35mm, f/4, decisive-moment framing."
+  },
+  {
+   "id": "t10",
+   "seed": 110,
+   "prompt": "A photograph of a weathered enamel railway platform sign bolted to a brick wall, photographed straight on. The sign is deep blue with white capitals reading \"KIRKWOOD JUNCTION\" across the centre, with smaller text beneath reading \"CHANGE HERE FOR THE COAST LINE\" and, in the bottom right corner in yellow, \"PLATFORM 3\". The enamel is chipped in several places exposing rust; a small bird has left a mark on the upper edge. Diffuse morning light, a sliver of the empty platform and a wooden bench visible at the frame's edge, 50mm, documentary flatness."
+  },
+  {
+   "id": "t11",
+   "seed": 111,
+   "prompt": "A detailed ink-and-watercolour illustration, in the manner of an antique cartographer's plate, of a mapmaker's hands spreading open a hand-drawn map across a cluttered oak table. The map's calligraphic labels are legible: \"THE SUNDERED COAST\" arcs across the top in decorative capitals, \"Gallowmere\" and \"Thistle Bay\" mark two inlets, a compass rose in the lower left is lettered \"N\" \"E\" \"S\" \"W\", and a banner in the corner reads \"HERE BE FOG\". Both hands are carefully drawn with correct anatomy, one weighting the curling parchment with a brass divider. Sepia washes, crosshatched shadows, visible paper tooth, muted indigo and ochre palette."
+  },
+  {
+   "id": "t12",
+   "seed": 112,
+   "prompt": "A richly painted fantasy illustration of a sorceress standing in a ruined library, mid-incantation. Her face is the focal point, three-quarter view, high cheekbones, a scar across the bridge of her nose, amber eyes lit from beneath by the spell, expression of fierce concentration rather than serenity. Both hands are raised and clearly articulated with five correct fingers each, palms turned inward, fingertips trailing thin ribbons of pale-gold light that spiral into a floating glyph between them. Torn spellbooks hover around her; dust and vellum fragments catch the light. Oil-painting texture, dramatic chiaroscuro, deep viridian and old-gold palette, painterly brushwork visible in the robes."
+  },
+  {
+   "id": "t13",
+   "seed": 113,
+   "prompt": "An art-nouveau travel poster illustration of a mountain funicular railway, in the flat-colour lithographic style of the 1910s with heavy organic outlines. Stylised lettering is integral to the design: \"MONT SAVAREL\" arches across the top in tall decorative art-nouveau capitals, a ribbon banner across the lower third reads \"BY FUNICULAR \u2014 ALL SEASONS\", and a small block in the bottom right corner reads \"CHEMIN DE FER DU SUD\". A woman in a long teal coat with a parasol stands on the platform in the mid-ground. Limited palette of teal, mustard, cream and rust; visible lithographic registration texture; whiplash floral border."
+  },
+  {
+   "id": "t14",
+   "seed": 114,
+   "prompt": "A dwarven forge rendered as a highly detailed fantasy painting. A broad-shouldered dwarven smith with a plaited copper beard, soot-streaked face and a leather eyepatch is caught mid-strike, his expression set in effort, teeth clenched. His hands are the technical centrepiece and must be correct: the left gripping long iron tongs that hold a glowing orange billet against the anvil, the right swinging a heavy cross-peen hammer, every finger distinct and wrapped believably around each handle. Runes glow faintly along the anvil's base. Sparks arc through the smoke; the forge mouth throws hard orange rim light while cold blue daylight leaks from a shaft above. Painterly realism, heavy texture, warm-cool split lighting."
+  },
+  {
+   "id": "t15",
+   "seed": 115,
+   "prompt": "A whimsical hand-painted illustration of a hillside village bakery in a soft anime-adjacent storybook style, with rounded architecture and warm gouache textures. A carved and painted wooden shop sign hangs on an iron bracket above the door, clearly lettered \"THE FLOURING MOON\" in friendly rounded capitals with a small crescent-moon-and-wheat emblem beneath, and a smaller propped slate by the step reads \"FRESH LOAVES 7am\". Ivy climbs the plaster, window boxes spill with geraniums, and a striped cat sleeps on the sill. Late golden-hour light, visible brush and pencil under-drawing, pastel-warm palette, gentle rim light on the rooftops."
+  },
+  {
+   "id": "t16",
+   "seed": 116,
+   "prompt": "An ornate tarot card illustration in a symmetrical art-deco-occult style, printed look with visible ink texture. The card's title banner along the bottom reads \"THE CARTOGRAPHER\" in engraved serif capitals, and the top of the card carries the roman numeral \"XIII\". The central figure is a hooded woman seen frontally, her face half-lit and calm, holding a sextant in both hands \u2014 hands drawn with deliberate correctness, fingers wrapped around the instrument's frame and index finger extended along the sighting arm. Stylised stars, a crescent, and a coiled sea-serpent border fill the negative space. Gold-ink accents on a midnight-blue ground, cream card stock edges, fine linework."
+  },
+  {
+   "id": "t17",
+   "seed": 117,
+   "prompt": "A photograph of a cyberpunk street-food stall at night, shot slightly from the side. The vendor, an older woman with deep laugh lines and a headset earpiece, leans over a steaming griddle and looks directly at the camera with a wry half-smile; her face is lit from below by the griddle and from the side by signage. The stall's illuminated header board is legible: \"RAMEN 8 CREDITS\" in white LED capitals on the top line, with \"NO REFUNDS\" in smaller red text beneath, and a vertical strip sign to the left reading \"24H\". Volumetric steam, magenta and cyan practicals, rain-slicked asphalt, 35mm, f/2, shallow focus falling off behind her."
+  },
+  {
+   "id": "t18",
+   "seed": 118,
+   "prompt": "A moody oil-painting still life on a dark walnut table, in the Dutch golden-age manner with thick impasto highlights. At the centre a leather-bound book lies open face-down, its spine turned to the viewer with gilt-stamped lettering clearly readable as \"ON THE MOTION OF TIDES\" above a smaller stamped line reading \"VOL. II\". Beside it sit a guttering beeswax candle, a pewter inkwell with a grey goose quill, three walnuts, and a half-peeled lemon with its rind spiralling off the table edge. Single warm light source from the upper left, deep umber shadows, glazed reflections in the pewter, visible canvas weave and cracked varnish."
+  },
+  {
+   "id": "t19",
+   "seed": 119,
+   "prompt": "A warmly lit fantasy tavern interior painted in a detailed illustrative style. In the foreground a halfling bard sits cross-legged on a table, mid-song, her face turned up and mouth open in a laughing note, freckled cheeks flushed. Her hands are the anatomical showpiece: the left fingers pressing a chord high on a lute's neck with each fingertip placed distinctly on the strings, the right caught mid-strum with fingers gently curled. Behind her, three patrons' faces react in the smoky middle distance \u2014 one laughing, one clapping, one asleep on folded arms. Firelight from a hearth camera right, hanging lanterns above, warm amber palette with cool blue window light behind, rich painterly texture."
+  },
+  {
+   "id": "t20",
+   "seed": 120,
+   "prompt": "A tightly framed photograph of a scientist's spiral-bound lab notebook lying open on a stainless steel bench under bright even light. The left page carries a hand-drawn graph with labelled axes reading \"TIME (h)\" horizontally and \"YIELD (%)\" vertically, with a plotted curve and three circled data points. The right page has a boxed heading reading \"RUN 14 \u2014 NOTES\" followed by five lines of small neat handwriting, the first of which reads \"Repeated with fresh catalyst; see fig. 2.\" A retracted mechanical pencil, a pair of nitrile gloves, and a glass vial with a handwritten label reading \"B-14\" lie alongside. Clinical daylight-balanced light, 50mm macro, crisp paper fibre detail, top-down."
+  }
+ ]
+}

--- a/scripts/svdq_bench/materialize_bench.py
+++ b/scripts/svdq_bench/materialize_bench.py
@@ -5,6 +5,7 @@ Reads refs_map.json next to this file. Weights never touch the control box."""
 from __future__ import annotations
 
 import concurrent.futures as cf
+import hashlib
 import json
 import os
 import sys
@@ -97,22 +98,43 @@ def fp8_from_manifest(manifest: Path) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists() and dest.stat().st_size == f["size_bytes"]:
             return dest, f["size_bytes"], "cached"
+        # Big objects are chunk-CAS (th#1310): one presigned URL per chunk,
+        # in order. Small ones carry a single "url".
+        urls = f.get("chunk_urls") or ([f["url"]] if f.get("url") else [])
+        if not urls:
+            raise KeyError(f"{f['path']}: manifest entry has no url/chunk_urls")
+        tmp = dest.with_suffix(dest.suffix + ".part")
         for attempt in range(3):
             try:
-                with urllib.request.urlopen(f["url"], timeout=120) as r, \
-                        open(dest, "wb") as fh:
-                    while True:
-                        chunk = r.read(1 << 24)
-                        if not chunk:
-                            break
-                        fh.write(chunk)
+                with open(tmp, "wb") as fh:
+                    for u in urls:
+                        with urllib.request.urlopen(u, timeout=300) as r:
+                            while True:
+                                chunk = r.read(1 << 24)
+                                if not chunk:
+                                    break
+                                fh.write(chunk)
+                got = tmp.stat().st_size
+                if got != f["size_bytes"]:
+                    raise OSError(f"{f['path']}: got {got} of "
+                                  f"{f['size_bytes']} bytes")
+                want = str(f.get("digest") or "")
+                if want.startswith("sha256:"):
+                    h = hashlib.sha256()
+                    with open(tmp, "rb") as fh:
+                        for blk in iter(lambda: fh.read(1 << 24), b""):
+                            h.update(blk)
+                    if h.hexdigest() != want.split(":", 1)[1]:
+                        raise OSError(f"{f['path']}: sha256 mismatch — "
+                                      f"chunk order or content is wrong")
+                tmp.rename(dest)
                 break
             except Exception as exc:  # noqa: BLE001
                 print(f"[mat] fp8 attempt{attempt} {f['path']}: "
                       f"{type(exc).__name__}: {exc}", flush=True)
                 if attempt == 2:
                     raise
-        return dest, dest.stat().st_size, "get"
+        return dest, dest.stat().st_size, f"get({len(urls)} chunks)"
 
     with cf.ThreadPoolExecutor(max_workers=6) as ex:
         for fu in cf.as_completed([ex.submit(fetch, f) for f in want]):
@@ -125,6 +147,10 @@ def main() -> int:
     # chaos-R2 qwen refs blobs GC'd 2026-08-01 -> HF mirror is primary now.
     # --bf16 also pulls the transformer shards: the same-card bf16 arm.
     refs_from_hf("--bf16" in sys.argv)
+    # Markers as soon as each artifact is real: the reference tree and the
+    # svdq checkpoint are what every arm needs, and an optional extra
+    # artifact must never be able to invalidate them.
+    print("REFS_TREE=" + str(REFS), flush=True)
 
     NUN.mkdir(parents=True, exist_ok=True)
     from huggingface_hub import hf_hub_download
@@ -134,12 +160,17 @@ def main() -> int:
         revision="4d9f4f667ea571ab172e0ee29ac2c27b82a41a6b",
         local_dir=str(NUN), token=os.environ.get("HF_TOKEN") or None)
     print(f"[mat] nunchaku -> {fn} {Path(fn).stat().st_size/1e9:.2f} GB", flush=True)
+    print("NUN_FILE=" + str(fn), flush=True)
+
     man = Path("/root/fp8_manifest.json")
     if "--fp8" in sys.argv and man.exists():
-        fp8_from_manifest(man)
-
-    print("REFS_TREE=" + str(REFS), flush=True)
-    print("NUN_FILE=" + str(fn), flush=True)
+        try:
+            fp8_from_manifest(man)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mat] fp8 flavor FAILED ({type(exc).__name__}: {exc}) — "
+                  f"the fp8 arms will be skipped, every other arm stands",
+                  flush=True)
+    print("MAT_DONE", flush=True)
     return 0
 
 

--- a/scripts/svdq_bench/materialize_bench.py
+++ b/scripts/svdq_bench/materialize_bench.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""te#137 bench: materialize ON THE POD — bf16 reference tree (R2 blobs) +
+nunchaku svdq-fp4_r128 qwen-image checkpoint (public HF, pinned revision).
+Reads refs_map.json next to this file. Weights never touch the control box."""
+from __future__ import annotations
+
+import concurrent.futures as cf
+import json
+import os
+import sys
+from pathlib import Path
+
+ART = Path("/root/art")
+REFS = ART / "refs"
+NUN = ART / "nun"
+FP8 = ART / "fp8"
+
+
+def s3():
+    import boto3
+    from botocore.config import Config
+    return boto3.client(
+        "s3", endpoint_url=os.environ["TENSORHUB_S3_ENDPOINT_URL"],
+        aws_access_key_id=os.environ["TENSORHUB_S3_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["TENSORHUB_S3_SECRET_ACCESS_KEY"],
+        region_name=os.environ.get("TENSORHUB_S3_REGION", "auto"),
+        config=Config(max_pool_connections=16, retries={"max_attempts": 5}))
+
+
+def get_blob(cli, bucket, blake3, dest: Path):
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest, dest.stat().st_size, "cached"
+    key = f"blobs/blake3/{blake3[:2]}/{blake3[2:4]}/{blake3}"
+    for attempt in range(3):
+        try:
+            cli.download_file(bucket, key, str(dest))
+            break
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mat] attempt{attempt} FAILED key={key} dest={dest}: "
+                  f"{type(exc).__name__}: {exc}", flush=True)
+            if attempt == 2:
+                raise
+    return dest, dest.stat().st_size, "get"
+
+
+def refs_from_r2() -> None:
+    m = json.loads((Path(__file__).parent / "refs_map.json").read_text())
+    cli = s3()
+    tasks = [(r["blake3"], REFS / r["path"]) for r in m["refs"]]
+    print(f"[mat] {len(tasks)} R2 objects from {m['bucket']}", flush=True)
+    total = 0
+    with cf.ThreadPoolExecutor(max_workers=8) as ex:
+        futs = {ex.submit(get_blob, cli, m["bucket"], b, d): d for b, d in tasks}
+        for fu in cf.as_completed(futs):
+            dest, sz, how = fu.result()
+            total += sz
+            print(f"[mat] {how:6} {sz/1e6:9.1f}MB {dest}", flush=True)
+    print(f"[mat] R2 total {total/1e9:.2f} GB", flush=True)
+
+
+def refs_from_hf(with_transformer: bool) -> None:
+    """The chaos-R2 qwen-image blobs were GC'd 2026-08-01; our mirror IS
+    Qwen/Qwen-Image HEAD 75e0b4be (eval_sets.py, verified 2026-07-26), so the
+    public tree at that pinned revision is byte-identical for every component
+    we load (VAE/TEs/tokenizer/scheduler/model_index; transformer is injected)."""
+    import os as _os
+    from huggingface_hub import snapshot_download
+    ignore = ["*.png", "*.md"]
+    if not with_transformer:
+        ignore.append("transformer/*.safetensors")
+    p = snapshot_download(
+        repo_id="Qwen/Qwen-Image",
+        revision="75e0b4be04f60ec59a75f475837eced720f823b6",
+        local_dir=str(REFS), ignore_patterns=ignore,
+        token=_os.environ.get("HF_TOKEN") or None)
+    print(f"[mat] HF refs tree -> {p}", flush=True)
+
+
+def fp8_from_manifest(manifest: Path) -> None:
+    """The PUBLISHED prod #fp8-w8a8 flavor, straight from R2 through the
+    presigned URLs the hub's /resolve handed us. Only the denoiser component
+    and model_index.json: the pipeline's other components come from the same
+    bf16 reference tree every other arm uses, so the arms differ in exactly
+    one thing."""
+    import urllib.request
+
+    m = json.loads(manifest.read_text())
+    want = [f for f in m["files"]
+            if f["path"].startswith("transformer/")
+            or f["path"] == "model_index.json"]
+    print(f"[mat] fp8 flavor {m.get('checkpoint_id')} — {len(want)} files, "
+          f"{sum(f['size_bytes'] for f in want) / 1e9:.2f} GB", flush=True)
+
+    def fetch(f):
+        dest = FP8 / f["path"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists() and dest.stat().st_size == f["size_bytes"]:
+            return dest, f["size_bytes"], "cached"
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(f["url"], timeout=120) as r, \
+                        open(dest, "wb") as fh:
+                    while True:
+                        chunk = r.read(1 << 24)
+                        if not chunk:
+                            break
+                        fh.write(chunk)
+                break
+            except Exception as exc:  # noqa: BLE001
+                print(f"[mat] fp8 attempt{attempt} {f['path']}: "
+                      f"{type(exc).__name__}: {exc}", flush=True)
+                if attempt == 2:
+                    raise
+        return dest, dest.stat().st_size, "get"
+
+    with cf.ThreadPoolExecutor(max_workers=6) as ex:
+        for fu in cf.as_completed([ex.submit(fetch, f) for f in want]):
+            dest, sz, how = fu.result()
+            print(f"[mat] {how:6} {sz / 1e6:9.1f}MB {dest}", flush=True)
+    print("FP8_TREE=" + str(FP8), flush=True)
+
+
+def main() -> int:
+    # chaos-R2 qwen refs blobs GC'd 2026-08-01 -> HF mirror is primary now.
+    # --bf16 also pulls the transformer shards: the same-card bf16 arm.
+    refs_from_hf("--bf16" in sys.argv)
+
+    NUN.mkdir(parents=True, exist_ok=True)
+    from huggingface_hub import hf_hub_download
+    fn = hf_hub_download(
+        repo_id="nunchaku-ai/nunchaku-qwen-image",
+        filename="svdq-fp4_r128-qwen-image.safetensors",
+        revision="4d9f4f667ea571ab172e0ee29ac2c27b82a41a6b",
+        local_dir=str(NUN), token=os.environ.get("HF_TOKEN") or None)
+    print(f"[mat] nunchaku -> {fn} {Path(fn).stat().st_size/1e9:.2f} GB", flush=True)
+    man = Path("/root/fp8_manifest.json")
+    if "--fp8" in sys.argv and man.exists():
+        fp8_from_manifest(man)
+
+    print("REFS_TREE=" + str(REFS), flush=True)
+    print("NUN_FILE=" + str(fn), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/svdq_bench/metrics_pod.py
+++ b/scripts/svdq_bench/metrics_pod.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""LPIPS/PSNR between rendered arms (pgw#865 quality gate).
+
+Same metric stack as the banked 0.246/0.460 anchors: torchmetrics LPIPS
+net_type=alex normalize=True on /255 tensors; PSNR data_range=255 capped 99.
+Every input is a product webp (q95) — the encoding the anchors compared.
+
+  metrics_pod.py --ref REFDIR --cand NAME=DIR [--cand NAME=DIR ...]
+                 --out report.json [--rows t01,t02,...]
+
+Row ids are the webp basenames each arm writes, so any arm pair works; the
+reference arm is compared against every candidate, and candidates against
+each other.
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+from pathlib import Path
+
+PSNR_CAP = 99.0
+
+
+def tensor(img):
+    import numpy as np
+    import torch
+    arr = np.asarray(img.convert("RGB"))
+    return (torch.from_numpy(np.array(arr, copy=True)).float()
+            .permute(2, 0, 1).unsqueeze(0))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ref", required=True)
+    ap.add_argument("--cand", action="append", required=True,
+                    help="NAME=DIR")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--rows", default="")
+    args = ap.parse_args()
+
+    ref_dir = Path(args.ref)
+    cands = {}
+    for spec in args.cand:
+        name, _, d = spec.partition("=")
+        cands[name] = Path(d)
+
+    if args.rows:
+        ids = [r.strip() for r in args.rows.split(",") if r.strip()]
+    else:
+        ids = sorted(p.stem for p in ref_dir.glob("t*.webp"))
+
+    import torch
+    from PIL import Image
+    from torchmetrics.functional.image import peak_signal_noise_ratio
+    from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
+
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    lp = LearnedPerceptualImagePatchSimilarity(
+        net_type="alex", normalize=True).to(dev).eval()
+
+    def lpips(a, b):
+        with torch.no_grad():
+            return float(lp((tensor(a) / 255.0).to(dev),
+                            (tensor(b) / 255.0).to(dev)))
+
+    def psnr(a, b):
+        v = peak_signal_noise_ratio(tensor(a), tensor(b), data_range=255.0)
+        return min(PSNR_CAP, float(v))
+
+    pairs = [(name, "ref") for name in cands]
+    pairs += list(itertools.combinations(sorted(cands), 2))
+
+    rows = []
+    for tid in ids:
+        imgs = {"ref": Image.open(ref_dir / f"{tid}.webp").convert("RGB")}
+        for name, d in cands.items():
+            f = d / f"{tid}.webp"
+            if f.exists():
+                imgs[name] = Image.open(f).convert("RGB")
+        row = {"id": tid}
+        for a, b in pairs:
+            if a not in imgs or b not in imgs:
+                continue
+            row[f"lpips_{a}_vs_{b}"] = lpips(imgs[a], imgs[b])
+            row[f"psnr_{a}_vs_{b}"] = psnr(imgs[a], imgs[b])
+        rows.append(row)
+        print(f"[met] {tid} " + " ".join(
+            f"{k[6:]}={v:.4f}" for k, v in row.items()
+            if k.startswith("lpips_")), flush=True)
+
+    keys = sorted({k for r in rows for k in r if k != "id"})
+
+    def agg(key):
+        vs = [r[key] for r in rows if key in r]
+        return {"mean": sum(vs) / len(vs),
+                "worst": (max(vs) if key.startswith("lpips") else min(vs)),
+                "n": len(vs)}
+
+    out = {"metric_models": {"lpips": "torchmetrics:lpips-alex",
+                             "psnr": "torchmetrics-255"},
+           "ref_dir": str(ref_dir),
+           "cand_dirs": {k: str(v) for k, v in cands.items()},
+           "rows": rows, "summary": {k: agg(k) for k in keys}}
+    Path(args.out).write_text(json.dumps(out, indent=1))
+    print(json.dumps(out["summary"], indent=1), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -394,14 +394,15 @@ def main() -> int:
                         f"setsid nohup python3 /root/materialize_bench.py {flag} "
                         f"> /root/mat.log 2>&1 & echo started", 60,
                         env={"HF_TOKEN": hf})
-                    last, stalls = -1, 0
+                    last, stalls, mat_done = -1, 0, False
                     deadline = time.time() + 90 * 60
                     while time.time() < deadline:
                         time.sleep(60)
                         _rc, out = ssh(
                             ip, port,
-                            "grep -hE 'NUN_FILE=|REFS_TREE=' /root/mat.log "
-                            "2>/dev/null; du -sb /root/art 2>/dev/null | cut -f1",
+                            "grep -hE 'NUN_FILE=|REFS_TREE=|MAT_DONE' "
+                            "/root/mat.log 2>/dev/null; "
+                            "du -sb /root/art 2>/dev/null | cut -f1",
                             60)
                         size = 0
                         for line in out.splitlines():
@@ -409,9 +410,16 @@ def main() -> int:
                                 ck = line.split("=", 1)[1].strip()
                             elif line.startswith("REFS_TREE="):
                                 refs_tree = line.split("=", 1)[1].strip()
+                            elif line.strip() == "MAT_DONE":
+                                mat_done = True
                             elif line.strip().isdigit():
                                 size = int(line.strip())
-                        if ck and refs_tree:
+                        # An fp8 arm that starts while its shards are still
+                        # landing loads a PARTIAL state dict and dies on
+                        # missing keys — so when fp8 is wanted, wait for the
+                        # whole materialization, not just the two markers
+                        # every other arm needs.
+                        if ck and refs_tree and (mat_done or not want_fp8):
                             break
                         stalls = stalls + 1 if size == last else 0
                         last = size

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -37,7 +37,10 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-os.environ.pop("SSH_AUTH_SOCK", None)
+# NOTE: do NOT drop SSH_AUTH_SOCK. The runpod key on this box is
+# passphrase-protected, so `-i` alone cannot authenticate — the agent holds
+# the only usable copy. Dropping it produced 90 silent "Permission denied"
+# retries that read exactly like a slow boot.
 
 HERE = Path(__file__).resolve().parent
 REPO = HERE.parent.parent
@@ -55,7 +58,7 @@ ENVF = Path(os.environ.get("COZY_BENCH_ENV",
 KEY = Path.home() / ".ssh" / "runpod"
 SSH_OPTS = ["-i", str(KEY), "-o", "StrictHostKeyChecking=no",
             "-o", "UserKnownHostsFile=/dev/null", "-o", "ConnectTimeout=15",
-            "-o", "BatchMode=yes", "-o", "LogLevel=ERROR"]
+            "-o", "LogLevel=ERROR"]
 
 # cuda-13 profile tag of the deployed conversion image: the bare -linux-x86
 # tag of the same build is CPU torch.
@@ -306,14 +309,21 @@ def main() -> int:
         ip, port, rate = ep
         manifest["rate_per_hr"] = rate
         print(f"[pod] ssh root@{ip}:{port} rate=${rate}/hr", flush=True)
-        for _ in range(90):
-            rc, _o = sh(["ssh", *SSH_OPTS, "-p", str(port), f"root@{ip}",
-                         "true"], 30)
+        last = ""
+        for attempt in range(60):
+            rc, last = sh(["ssh", *SSH_OPTS, "-p", str(port), f"root@{ip}",
+                           "true"], 30)
             if rc == 0:
                 break
+            # Print the reason, every time. A retry loop that hides ssh's
+            # stderr cannot distinguish "still booting" from "wrong key".
+            if attempt % 5 == 0:
+                print(f"[pod] ssh not ready ({attempt}): "
+                      f"{last.strip()[-160:]}", flush=True)
             time.sleep(10)
         else:
-            print("[pod] ssh never came up", flush=True)
+            print(f"[pod] ssh never came up: {last.strip()[-300:]}",
+                  flush=True)
             return 3
 
         files = [str(HERE / f) for f in
@@ -331,17 +341,21 @@ def main() -> int:
             'M=$(python3 -c "import gen_worker.models, pathlib; '
             'print(pathlib.Path(gen_worker.models.__file__).parent)"); '
             + "cp " + " ".join(f"/root/{f}" for f in OVERLAY)
-            + ' "$M/"; echo overlay-ok; '
-            'python3 -c "import torch, gen_worker; '
-            'print(\'ENV\', torch.__version__, '
-            'torch.cuda.get_device_name(0), '
-            'torch.cuda.get_device_capability(), gen_worker.__version__)"',
-            180)
+            + ' "$M/" && echo overlay-ok', 180)
         print(f"[overlay] rc={rc} {out.strip()[-300:]}", flush=True)
         if rc != 0 or "overlay-ok" not in out:
             return 4
-        manifest["env_line"] = [ln for ln in out.splitlines()
-                                if ln.startswith("ENV")][:1]
+        # Environment census is EVIDENCE, never a gate: a probe that cannot
+        # read a version must not be able to delete a rented pod.
+        _rc, env_out = ssh(
+            ip, port,
+            'python3 -c "import torch, importlib.metadata as im; '
+            'print(\'ENV\', torch.__version__, '
+            'torch.cuda.get_device_name(0), '
+            'torch.cuda.get_device_capability(), '
+            'im.version(\'gen-worker\'))" 2>&1 | tail -3', 180)
+        print(f"[env] {env_out.strip()[-300:]}", flush=True)
+        manifest["env_line"] = env_out.strip().splitlines()[-3:]
         bank()
 
         ck = refs_tree = ""

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -360,146 +360,166 @@ def main() -> int:
 
         ck = refs_tree = ""
 
+        dropped: set = set()
+
         for cell in cells:
+            if cell in dropped:
+                print(f"[skip] {cell} — dropped upstream", flush=True)
+                continue
             print(f"\n===== CELL {cell} "
                   f"(t+{(time.time() - started) / 60:.0f}min) =====",
                   flush=True)
+            try:
 
-            if cell == "mat":
-                flag = "--bf16" if want_bf16 else ""
-                if want_fp8:
-                    org, name, tag, flavor = FP8_REF
-                    url = (f"{HUB_BASE}/api/v1/repos/{org}/{name}/resolve"
-                           f"?tag={tag}&flavor={flavor}")
-                    with urllib.request.urlopen(url, timeout=120) as fh:
-                        man = json.loads(fh.read())
-                    manifest["fp8_checkpoint_id"] = man["checkpoint_id"]
-                    manifest["fp8_size_bytes"] = man["size_bytes"]
-                    mf = res / "fp8_manifest.json"
-                    mf.write_text(json.dumps(man))
-                    print(f"[mat] fp8 flavor {man['checkpoint_id']} "
-                          f"{man['size_bytes'] / 1e9:.1f} GB resolved",
-                          flush=True)
-                    rc, _o = sh(["scp", *SSH_OPTS, "-P", str(port), str(mf),
-                                 f"root@{ip}:/root/fp8_manifest.json"], 120)
-                    assert rc == 0, "fp8 manifest scp failed"
-                    flag += " --fp8"
-                ssh(ip, port,
-                    f"setsid nohup python3 /root/materialize_bench.py {flag} "
-                    f"> /root/mat.log 2>&1 & echo started", 60,
-                    env={"HF_TOKEN": hf})
-                last, stalls = -1, 0
-                deadline = time.time() + 90 * 60
-                while time.time() < deadline:
-                    time.sleep(60)
-                    _rc, out = ssh(
-                        ip, port,
-                        "grep -hE 'NUN_FILE=|REFS_TREE=' /root/mat.log "
-                        "2>/dev/null; du -sb /root/art 2>/dev/null | cut -f1",
-                        60)
-                    size = 0
-                    for line in out.splitlines():
-                        if line.startswith("NUN_FILE="):
-                            ck = line.split("=", 1)[1].strip()
-                        elif line.startswith("REFS_TREE="):
-                            refs_tree = line.split("=", 1)[1].strip()
-                        elif line.strip().isdigit():
-                            size = int(line.strip())
-                    if ck and refs_tree:
-                        break
-                    stalls = stalls + 1 if size == last else 0
-                    last = size
-                    print(f"[mat] {size / 2**30:.1f} GiB (stalls={stalls})",
-                          flush=True)
-                    if stalls >= 10:
-                        print("[mat] stalled 10min — abort", flush=True)
-                        break
-                print(f"[mat] ck={ck!r} refs={refs_tree!r}", flush=True)
-                if not (ck and refs_tree):
-                    return 5
-                if want_fp8:
-                    _rc, out = ssh(ip, port,
-                                   "ls /root/art/fp8/transformer/*.safetensors "
-                                   "| wc -l; du -sh /root/art/fp8", 60)
-                    print(f"[mat] fp8 tree: {out.strip()}", flush=True)
-                    assert out.strip().split()[0] != "0", "fp8 tree empty"
-                manifest["ckpt"], manifest["refs_tree"] = ck, refs_tree
-                bank()
-                continue
-
-            assert ck and refs_tree, "mat must run (or be resumed) first"
-
-            if cell in ("corr", "bb", "bf"):
-                mode = "correctness" if cell == "corr" else "bench"
-                env_val = "1" if cell in ("corr", "bf") else "0"
-                ssh(ip, port,
-                    f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
-                    f"python3 /root/bench_b0.py --ckpt {ck} "
-                    f"--out /root/b0_{cell} --mode {mode} "
-                    f"> /root/{cell}.log 2>&1 & echo started", 60)
-                ok, tail = wait_for(ip, port, f"/root/{cell}.log",
-                                    "DONE", 45 * 60, 45, cell)
-                (res / f"{cell}_log.txt").write_text(tail)
-                sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
-                    f"root@{ip}:/root/b0_{cell}", str(res) + "/"], 600)
-                print(f"[{cell}] ok={ok}\n{tail[-1200:]}", flush=True)
-                manifest["results"][cell] = "ok" if ok else "FAILED"
-                bank()
-                if not ok:
-                    return 6
-                continue
-
-            if cell.startswith("e:"):
-                name = cell[2:]
-                env_val, extra = ARMS[name]
-                rows = f"--rows {args.rows}" if args.rows else ""
-                rows += (f" --norm-rows {args.norm_rows} "
-                         f"--norm-shape {args.norm_shape}")
-                ssh(ip, port,
-                    f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
-                    f"python3 /root/bench_arm.py {extra} --ckpt {ck} "
-                    f"--reference-tree {refs_tree} "
-                    f"--prompts /root/bench_prompts.json {rows} "
-                    f"--out /root/e2e/{name} > /root/arm_{name}.log 2>&1 & "
-                    f"echo started", 60)
-                ok, tail = wait_for(ip, port, f"/root/arm_{name}.log",
-                                    "DONE", 100 * 60, 90, f"arm {name}")
-                (res / f"arm_{name}_log.txt").write_text(tail)
-                sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
-                    f"root@{ip}:/root/e2e/{name}", str(res) + "/"], 900)
-                print(f"[arm {name}] ok={ok}\n{tail[-1200:]}", flush=True)
-                manifest["results"][cell] = "ok" if ok else "FAILED"
-                bank()
-                if not ok:
-                    return 6
-                continue
-
-            if cell == "met":
-                done = [a for a in e2e_arms
-                        if manifest["results"].get(f"e:{a}") == "ok"]
-                if "bf16" not in done or len(done) < 2:
-                    print("[met] need bf16 + >=1 candidate arm — skipped",
-                          flush=True)
+                if cell == "mat":
+                    flag = "--bf16" if want_bf16 else ""
+                    if want_fp8:
+                        org, name, tag, flavor = FP8_REF
+                        url = (f"{HUB_BASE}/api/v1/repos/{org}/{name}/resolve"
+                               f"?tag={tag}&flavor={flavor}")
+                        with urllib.request.urlopen(url, timeout=120) as fh:
+                            man = json.loads(fh.read())
+                        manifest["fp8_checkpoint_id"] = man["checkpoint_id"]
+                        manifest["fp8_size_bytes"] = man["size_bytes"]
+                        mf = res / "fp8_manifest.json"
+                        mf.write_text(json.dumps(man))
+                        print(f"[mat] fp8 flavor {man['checkpoint_id']} "
+                              f"{man['size_bytes'] / 1e9:.1f} GB resolved",
+                              flush=True)
+                        rc, _o = sh(["scp", *SSH_OPTS, "-P", str(port), str(mf),
+                                     f"root@{ip}:/root/fp8_manifest.json"], 120)
+                        assert rc == 0, "fp8 manifest scp failed"
+                        flag += " --fp8"
+                    ssh(ip, port,
+                        f"setsid nohup python3 /root/materialize_bench.py {flag} "
+                        f"> /root/mat.log 2>&1 & echo started", 60,
+                        env={"HF_TOKEN": hf})
+                    last, stalls = -1, 0
+                    deadline = time.time() + 90 * 60
+                    while time.time() < deadline:
+                        time.sleep(60)
+                        _rc, out = ssh(
+                            ip, port,
+                            "grep -hE 'NUN_FILE=|REFS_TREE=' /root/mat.log "
+                            "2>/dev/null; du -sb /root/art 2>/dev/null | cut -f1",
+                            60)
+                        size = 0
+                        for line in out.splitlines():
+                            if line.startswith("NUN_FILE="):
+                                ck = line.split("=", 1)[1].strip()
+                            elif line.startswith("REFS_TREE="):
+                                refs_tree = line.split("=", 1)[1].strip()
+                            elif line.strip().isdigit():
+                                size = int(line.strip())
+                        if ck and refs_tree:
+                            break
+                        stalls = stalls + 1 if size == last else 0
+                        last = size
+                        print(f"[mat] {size / 2**30:.1f} GiB (stalls={stalls})",
+                              flush=True)
+                        if stalls >= 10:
+                            print("[mat] stalled 10min — abort", flush=True)
+                            break
+                    print(f"[mat] ck={ck!r} refs={refs_tree!r}", flush=True)
+                    if not (ck and refs_tree):
+                        return 5
+                    if want_fp8:
+                        _rc, out = ssh(ip, port,
+                                       "ls /root/art/fp8/transformer/"
+                                       "*.safetensors 2>/dev/null | wc -l; "
+                                       "du -sh /root/art/fp8 2>/dev/null", 60)
+                        print(f"[mat] fp8 tree: {out.strip()}", flush=True)
+                        # An OPTIONAL artifact that did not land drops its OWN
+                        # arms. It does not fail the run, and it must never tear
+                        # down a pod already carrying 70 GB of other artifacts.
+                        if out.strip().split()[:1] == ["0"]:
+                            dropped.update(f"e:{a}" for a in NEEDS_FP8_TREE)
+                            print("[mat] fp8 tree absent — fp8 arms dropped; "
+                                  "every other arm stands", flush=True)
+                    manifest["ckpt"], manifest["refs_tree"] = ck, refs_tree
+                    bank()
                     continue
-                cand = " ".join(f"--cand {a}=/root/e2e/{a}"
-                                for a in done if a != "bf16")
-                ssh(ip, port,
-                    "python3 -c 'import torchmetrics' 2>/dev/null || "
-                    "pip install -q torchmetrics lpips 2>&1 | tail -2", 900)
-                rc, out = ssh(
-                    ip, port,
-                    f"python3 /root/metrics_pod.py --ref /root/e2e/bf16 "
-                    f"{cand} --out /root/metrics.json 2>&1 | tail -60", 1800)
-                (res / "metrics_log.txt").write_text(out)
-                sh(["scp", *SSH_OPTS, "-P", str(port),
-                    f"root@{ip}:/root/metrics.json", str(res) + "/"], 300)
-                print(f"[met] rc={rc}\n{out[-2000:]}", flush=True)
-                manifest["results"]["met"] = "ok" if rc == 0 else "FAILED"
+
+                if not (ck and refs_tree):
+                    raise RuntimeError("mat must run before any other cell")
+
+                if cell in ("corr", "bb", "bf"):
+                    mode = "correctness" if cell == "corr" else "bench"
+                    env_val = "1" if cell in ("corr", "bf") else "0"
+                    ssh(ip, port,
+                        f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
+                        f"python3 /root/bench_b0.py --ckpt {ck} "
+                        f"--out /root/b0_{cell} --mode {mode} "
+                        f"> /root/{cell}.log 2>&1 & echo started", 60)
+                    ok, tail = wait_for(ip, port, f"/root/{cell}.log",
+                                        "DONE", 45 * 60, 45, cell)
+                    (res / f"{cell}_log.txt").write_text(tail)
+                    sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
+                        f"root@{ip}:/root/b0_{cell}", str(res) + "/"], 600)
+                    print(f"[{cell}] ok={ok}\n{tail[-1200:]}", flush=True)
+                    manifest["results"][cell] = "ok" if ok else "FAILED"
+                    bank()
+                    continue
+
+                if cell.startswith("e:"):
+                    name = cell[2:]
+                    env_val, extra = ARMS[name]
+                    rows = f"--rows {args.rows}" if args.rows else ""
+                    rows += (f" --norm-rows {args.norm_rows} "
+                             f"--norm-shape {args.norm_shape}")
+                    ssh(ip, port,
+                        f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
+                        f"python3 /root/bench_arm.py {extra} --ckpt {ck} "
+                        f"--reference-tree {refs_tree} "
+                        f"--prompts /root/bench_prompts.json {rows} "
+                        f"--out /root/e2e/{name} > /root/arm_{name}.log 2>&1 & "
+                        f"echo started", 60)
+                    ok, tail = wait_for(ip, port, f"/root/arm_{name}.log",
+                                        "DONE", 100 * 60, 90, f"arm {name}")
+                    (res / f"arm_{name}_log.txt").write_text(tail)
+                    sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
+                        f"root@{ip}:/root/e2e/{name}", str(res) + "/"], 900)
+                    print(f"[arm {name}] ok={ok}\n{tail[-1200:]}", flush=True)
+                    manifest["results"][cell] = "ok" if ok else "FAILED"
+                    bank()
+                    continue
+
+                if cell == "met":
+                    done = [a for a in e2e_arms
+                            if manifest["results"].get(f"e:{a}") == "ok"]
+                    if "bf16" not in done or len(done) < 2:
+                        print("[met] need bf16 + >=1 candidate arm — skipped",
+                              flush=True)
+                        continue
+                    cand = " ".join(f"--cand {a}=/root/e2e/{a}"
+                                    for a in done if a != "bf16")
+                    ssh(ip, port,
+                        "python3 -c 'import torchmetrics' 2>/dev/null || "
+                        "pip install -q torchmetrics lpips 2>&1 | tail -2", 900)
+                    rc, out = ssh(
+                        ip, port,
+                        f"python3 /root/metrics_pod.py --ref /root/e2e/bf16 "
+                        f"{cand} --out /root/metrics.json 2>&1 | tail -60", 1800)
+                    (res / "metrics_log.txt").write_text(out)
+                    sh(["scp", *SSH_OPTS, "-P", str(port),
+                        f"root@{ip}:/root/metrics.json", str(res) + "/"], 300)
+                    print(f"[met] rc={rc}\n{out[-2000:]}", flush=True)
+                    manifest["results"]["met"] = "ok" if rc == 0 else "FAILED"
+                    bank()
+                    continue
+
+                raise RuntimeError(f"unknown cell {cell}")
+
+            except Exception as exc:  # noqa: BLE001
+                # One cell's failure is one row missing from the table, not a
+                # lost pod. Only `mat` is load-bearing for everything after.
+                print(f"[{cell}] RAISED {type(exc).__name__}: {exc}",
+                      flush=True)
+                manifest["results"][cell] = f"RAISED {type(exc).__name__}"
                 bank()
+                if cell == "mat":
+                    return 5
                 continue
-
-            raise SystemExit(f"unknown cell {cell}")
-
         return 0
     finally:
         manifest["elapsed_min"] = (time.time() - started) / 60

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""svdq lane bench driver — ONE watched pod, cells run in sequence (pgw#865).
+
+Promoted from the one-shot te#137/pgw#862 drivers into the repeatable
+instrument pgw#865 owns, and generalised over the card so pgw#863's sm_100
+row is the same instrument as the banked sm_120 one.
+
+Cells (``--cells``, run in the order given):
+
+  mat    materialize pod-side: Qwen-Image component tree (+ bf16 transformer
+         when the bf16 arm is asked for) and the official nunchaku fp4_r128
+         checkpoint. Weights never touch the control box.
+  corr   bench_b0 correctness — activation-quant bit-identity vs the pgw#685
+         chain on REAL captured activations, fused-vs-fp32-ref error per unit.
+  bb     bench_b0 bucket bench, BASELINE lane (synthetic frame, eager +
+         compiled forward, top kernels, peak VRAM).
+  bf     bench_b0 bucket bench, FUSED lane.
+  e:NAME e2e arm in the pipeline frame. NAME is one of
+         base | native | nativec | bf16 (compiled variants suffixed c).
+  met    LPIPS/PSNR over whatever e2e arms have been banked this run.
+
+Everything is banked off-pod after each cell, so a teardown at any point
+keeps the evidence. Teardown is REST DELETE + GET-404 + podguard record.
+
+  pod_run.py --gpu b200 --cells mat,corr,bb,bf,e:bf16,e:base,e:native,e:nativec,met
+  pod_run.py --list / --terminate <id> / --pod <id> (attach to a live pod)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+os.environ.pop("SSH_AUTH_SOCK", None)
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+MODELS = REPO / "src" / "gen_worker" / "models"
+
+PODGUARD_DIR = Path(os.environ.get(
+    "COZY_PODGUARD_DIR",
+    Path.home() / "cozy" / "cozy-creator-tracker" / "scripts" / "podguard"))
+sys.path.insert(0, str(PODGUARD_DIR))
+import podguard  # noqa: E402
+
+REST = "https://rest.runpod.io/v1"
+ENVF = Path(os.environ.get("COZY_BENCH_ENV",
+                           Path.home() / "cozy" / "e2e" / ".env"))
+KEY = Path.home() / ".ssh" / "runpod"
+SSH_OPTS = ["-i", str(KEY), "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null", "-o", "ConnectTimeout=15",
+            "-o", "BatchMode=yes", "-o", "LogLevel=ERROR"]
+
+# cuda-13 profile tag of the deployed conversion image: the bare -linux-x86
+# tag of the same build is CPU torch.
+IMAGE = ("tensorhub/endpoints-chaos:"
+         "tensorhub-conversion-697fdaa0d2f40e2f75dcec10-linux-cuda-13-x86")
+CARDS = {
+    "b200": (["NVIDIA B200"], 220),
+    "h100": (["NVIDIA H100 80GB HBM3", "NVIDIA H100 PCIe",
+              "NVIDIA H100 NVL"], 220),
+    "5090": (["NVIDIA GeForce RTX 5090",
+              "NVIDIA RTX PRO 6000 Blackwell Server Edition"], 220),
+}
+# gen-worker source overlaid onto the image's installed package: the image
+# pins a published wheel, the lane under test is this worktree.
+OVERLAY = ("svdq_fused.py", "svdq_awq_packed.py", "native_kernels.py",
+           "svdq_native.py", "svdq_layout.py", "svdq_awq.py", "svdq.py",
+           "nvfp4_quant.py", "w4a4.py")
+
+SSHD = (
+    'set -e; mkdir -p /root/.ssh && chmod 700 /root/.ssh; '
+    'printf "%s\\n" "$PUBLIC_KEY" >> /root/.ssh/authorized_keys && '
+    'chmod 600 /root/.ssh/authorized_keys; '
+    'if [ ! -x /usr/sbin/sshd ] && ! command -v sshd >/dev/null 2>&1; then '
+    'apt-get update -qq && DEBIAN_FRONTEND=noninteractive '
+    'apt-get install -y -qq openssh-server; fi; '
+    'ssh-keygen -A 2>/dev/null || true; '
+    'mkdir -p /run/sshd; exec /usr/sbin/sshd -D -e')
+
+# e2e arms: label -> (native lane env, extra bench_arm flags)
+ARMS = {
+    "bf16": ("0", "--arm bf16"),
+    "bf16c": ("0", "--arm bf16 --compile"),
+    "fp8": ("0", "--arm fp8 --fp8-tree /root/art/fp8"),
+    "fp8c": ("0", "--arm fp8 --fp8-tree /root/art/fp8 --compile"),
+    "base": ("0", "--arm ours"),
+    "basec": ("0", "--arm ours --compile"),
+    "native": ("1", "--arm ours"),
+    "nativec": ("1", "--arm ours --compile"),
+}
+# Which arms need which materialized artifact.
+NEEDS_BF16_TREE = ("bf16", "bf16c")
+NEEDS_FP8_TREE = ("fp8", "fp8c")
+NEEDS_SVDQ_CK = ("base", "basec", "native", "nativec")
+
+HUB_BASE = os.environ.get("COZY_HUB_BASE", "http://localhost:30070")
+FP8_REF = ("tensorhub", "qwen-image", "latest", "fp8-w8a8")
+
+
+def dotenv(names):
+    out = {}
+    for line in ENVF.read_text().splitlines():
+        if "=" in line and not line.strip().startswith("#"):
+            k, v = line.split("=", 1)
+            if k.strip() in names:
+                out[k.strip()] = v.strip().strip('"').strip("'")
+    for n in names:
+        if not out.get(n) and os.environ.get(n):
+            out[n] = os.environ[n]
+    return out
+
+
+def rest(api, method, path, body=None):
+    if method == "POST" and path.rstrip("/") == "/pods":
+        podguard.assert_armed(body)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{REST}{path}", data=data, method=method,
+        headers={"Authorization": f"Bearer {api}",
+                 "Content-Type": "application/json",
+                 "User-Agent": "curl/8.5.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as fh:
+            raw = fh.read()
+        return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        sys.stderr.write(
+            f"HTTP {exc.code} {method} {path}: {exc.read()[:600]!r}\n")
+        raise
+
+
+def sh(cmd, timeout=3600):
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True,
+                           timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        parts = (exc.stdout or b"", exc.stderr or b"")
+        txt = "".join(o.decode(errors="replace") if isinstance(o, bytes) else o
+                      for o in parts)
+        return 124, txt + f"\n[sh] timeout after {timeout}s"
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+def ssh(ip, port, script, timeout=3600, env=None):
+    pre = "".join(f"export {k}={json.dumps(v)}; "
+                  for k, v in (env or {}).items())
+    return sh(["ssh", *SSH_OPTS, "-p", str(port), f"root@{ip}", pre + script],
+              timeout)
+
+
+def ssh_endpoint(api, pod_id):
+    d = rest(api, "GET", f"/pods/{pod_id}")
+    ip = d.get("publicIp")
+    port = (d.get("portMappings") or {}).get("22")
+    if ip and port:
+        return ip, int(port), float(d.get("costPerHr") or 0.0)
+    return None
+
+
+def confirm_404(api, pod_id):
+    try:
+        rest(api, "GET", f"/pods/{pod_id}")
+        return False
+    except urllib.error.HTTPError as exc:
+        return exc.code == 404
+
+
+def registry_auth_id(api):
+    import base64
+    creds = dotenv(("DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"))
+    user = creds.get("DOCKERHUB_USERNAME", "")
+    pw = creds.get("DOCKERHUB_TOKEN", "")
+    if not (user and pw):
+        d = json.load(open(Path.home() / ".docker" / "config.json"))
+        a = d["auths"]["https://index.docker.io/v1/"]["auth"]
+        user, pw = base64.b64decode(a).decode().split(":", 1)
+    r = rest(api, "POST", "/containerregistryauth",
+             {"name": f"svdqbench-{int(time.time())}",
+              "username": user, "password": pw})
+    print(f"[auth] registry auth id={r.get('id')}", flush=True)
+    return r["id"]
+
+
+def wait_for(ip, port, log, marker, deadline_s, tick=45, label=""):
+    """Poll a pod-side log for DONE/Traceback. Returns (ok, tail)."""
+    end = time.time() + deadline_s
+    while time.time() < end:
+        time.sleep(tick)
+        _rc, out = ssh(ip, port,
+                       f"grep -hE '{marker}|Traceback' {log} | tail -1", 60)
+        if "Traceback" in out:
+            _rc, tail = ssh(ip, port, f"tail -30 {log}", 60)
+            return False, tail
+        if marker.split("|")[0] in out:
+            _rc, tail = ssh(ip, port, f"tail -30 {log}", 60)
+            return True, tail
+        _rc, prog = ssh(ip, port, f"tail -1 {log}", 60)
+        print(f"[{label}] {prog.strip()[:160]}", flush=True)
+    _rc, tail = ssh(ip, port, f"tail -30 {log}", 60)
+    return False, tail + "\n[driver] TIMEOUT"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gpu", default="b200", choices=sorted(CARDS))
+    ap.add_argument("--cells", default="mat,corr,bb,bf,e:bf16,e:base,"
+                                       "e:native,e:nativec,met")
+    ap.add_argument("--rows", default="",
+                    help="row-id subset for the e2e cells")
+    ap.add_argument("--norm-rows", type=int, default=3)
+    ap.add_argument("--norm-shape", default="1024x1024x30x4.0")
+    ap.add_argument("--wall-min", type=float, default=300.0)
+    ap.add_argument("--pod", default="")
+    ap.add_argument("--out", default="")
+    ap.add_argument("--list", action="store_true")
+    ap.add_argument("--terminate", default="")
+    ap.add_argument("--keep", action="store_true",
+                    help="skip teardown (a follow-on cell run will attach)")
+    args = ap.parse_args()
+
+    api = dotenv(("RUNPOD_API_KEY",))["RUNPOD_API_KEY"]
+    if args.list:
+        pods = rest(api, "GET", "/pods")
+        for p in (pods if isinstance(pods, list)
+                  else pods.get("data", [])) or []:
+            print(p.get("id"), p.get("name"), p.get("desiredStatus"),
+                  (p.get("machine") or {}).get("gpuTypeId"), p.get("costPerHr"))
+        return 0
+    if args.terminate:
+        rest(api, "DELETE", f"/pods/{args.terminate}")
+        print("terminated", args.terminate,
+              "404=", confirm_404(api, args.terminate))
+        return 0
+
+    cells = [c.strip() for c in args.cells.split(",") if c.strip()]
+    e2e_arms = [c[2:] for c in cells if c.startswith("e:")]
+    for a in e2e_arms:
+        assert a in ARMS, f"unknown arm {a}; known: {sorted(ARMS)}"
+    want_bf16 = any(a in NEEDS_BF16_TREE for a in e2e_arms)
+    want_fp8 = any(a in NEEDS_FP8_TREE for a in e2e_arms)
+
+    hf = dotenv(("HF_TOKEN",)).get("HF_TOKEN", "")
+    started = time.time()
+    res = Path(args.out) if args.out else (
+        HERE / f"results-{args.gpu}-{int(started)}")
+    res.mkdir(parents=True, exist_ok=True)
+    print(f"[run] banking to {res}", flush=True)
+
+    gpu_ids, disk = CARDS[args.gpu]
+    pod_id = args.pod
+    if not pod_id:
+        body = {"name": f"svdq-bench-{args.gpu}-{int(started)}",
+                "imageName": IMAGE, "gpuTypeIds": gpu_ids, "gpuCount": 1,
+                "containerDiskInGb": disk, "cloudType": "SECURE",
+                "supportPublicIp": True, "ports": ["22/tcp"],
+                # cu130 image: a 12.8-driver host raises "driver too old"
+                "allowedCudaVersions": ["13.0"],
+                "containerRegistryAuthId": registry_auth_id(api),
+                "env": {"PUBLIC_KEY": KEY.with_suffix(".pub")
+                        .read_text().strip()}}
+
+        def entrypoint_post(armed):
+            # RunPod treats dockerEntrypoint=[] as unset; ship the armed
+            # command AS the entrypoint so sshd (not the worker) runs.
+            armed = dict(armed)
+            sc = armed.pop("dockerStartCmd", None)
+            if sc:
+                armed["dockerEntrypoint"] = sc
+            return rest(api, "POST", "/pods", armed)
+
+        lease = podguard.rent(api, body, lane=f"svdq-bench-{args.gpu}",
+                              lease_seconds=args.wall_min * 60,
+                              orig_cmd=["/bin/bash", "-lc", SSHD],
+                              post=entrypoint_post)
+        pod_id = lease.pod_id
+        print(f"[pod] created {pod_id} rate=${lease.rate_per_hr}/hr",
+              flush=True)
+    else:
+        podguard.attend(api, pod_id, lane=f"svdq-bench-{args.gpu}")
+        print(f"[pod] attached {pod_id}", flush=True)
+    (res / "pod.txt").write_text(f"{pod_id} {int(started)} {args.gpu}\n")
+
+    manifest = {"pod": pod_id, "gpu": args.gpu, "image": IMAGE,
+                "cells": cells, "started": started, "results": {}}
+
+    def bank():
+        (res / "manifest.json").write_text(json.dumps(manifest, indent=1))
+
+    try:
+        ep = None
+        while time.time() - started < 1800:
+            ep = ssh_endpoint(api, pod_id)
+            if ep:
+                break
+            time.sleep(10)
+        if not ep:
+            print("[pod] no ssh endpoint in 30min", flush=True)
+            return 3
+        ip, port, rate = ep
+        manifest["rate_per_hr"] = rate
+        print(f"[pod] ssh root@{ip}:{port} rate=${rate}/hr", flush=True)
+        for _ in range(90):
+            rc, _o = sh(["ssh", *SSH_OPTS, "-p", str(port), f"root@{ip}",
+                         "true"], 30)
+            if rc == 0:
+                break
+            time.sleep(10)
+        else:
+            print("[pod] ssh never came up", flush=True)
+            return 3
+
+        files = [str(HERE / f) for f in
+                 ("bench_b0.py", "bench_arm.py", "materialize_bench.py",
+                  "metrics_pod.py", "bench_prompts.json")]
+        files += [str(MODELS / f) for f in OVERLAY]
+        rc, out = sh(["scp", *SSH_OPTS, "-P", str(port), *files,
+                      f"root@{ip}:/root/"], 300)
+        print(f"[scp] rc={rc}", flush=True)
+        if rc != 0:
+            print(out[-1500:], flush=True)
+            return 4
+        rc, out = ssh(
+            ip, port,
+            'M=$(python3 -c "import gen_worker.models, pathlib; '
+            'print(pathlib.Path(gen_worker.models.__file__).parent)"); '
+            + "cp " + " ".join(f"/root/{f}" for f in OVERLAY)
+            + ' "$M/"; echo overlay-ok; '
+            'python3 -c "import torch, gen_worker; '
+            'print(\'ENV\', torch.__version__, '
+            'torch.cuda.get_device_name(0), '
+            'torch.cuda.get_device_capability(), gen_worker.__version__)"',
+            180)
+        print(f"[overlay] rc={rc} {out.strip()[-300:]}", flush=True)
+        if rc != 0 or "overlay-ok" not in out:
+            return 4
+        manifest["env_line"] = [ln for ln in out.splitlines()
+                                if ln.startswith("ENV")][:1]
+        bank()
+
+        ck = refs_tree = ""
+
+        for cell in cells:
+            print(f"\n===== CELL {cell} "
+                  f"(t+{(time.time() - started) / 60:.0f}min) =====",
+                  flush=True)
+
+            if cell == "mat":
+                flag = "--bf16" if want_bf16 else ""
+                if want_fp8:
+                    org, name, tag, flavor = FP8_REF
+                    url = (f"{HUB_BASE}/api/v1/repos/{org}/{name}/resolve"
+                           f"?tag={tag}&flavor={flavor}")
+                    with urllib.request.urlopen(url, timeout=120) as fh:
+                        man = json.loads(fh.read())
+                    manifest["fp8_checkpoint_id"] = man["checkpoint_id"]
+                    manifest["fp8_size_bytes"] = man["size_bytes"]
+                    mf = res / "fp8_manifest.json"
+                    mf.write_text(json.dumps(man))
+                    print(f"[mat] fp8 flavor {man['checkpoint_id']} "
+                          f"{man['size_bytes'] / 1e9:.1f} GB resolved",
+                          flush=True)
+                    rc, _o = sh(["scp", *SSH_OPTS, "-P", str(port), str(mf),
+                                 f"root@{ip}:/root/fp8_manifest.json"], 120)
+                    assert rc == 0, "fp8 manifest scp failed"
+                    flag += " --fp8"
+                ssh(ip, port,
+                    f"setsid nohup python3 /root/materialize_bench.py {flag} "
+                    f"> /root/mat.log 2>&1 & echo started", 60,
+                    env={"HF_TOKEN": hf})
+                last, stalls = -1, 0
+                deadline = time.time() + 90 * 60
+                while time.time() < deadline:
+                    time.sleep(60)
+                    _rc, out = ssh(
+                        ip, port,
+                        "grep -hE 'NUN_FILE=|REFS_TREE=' /root/mat.log "
+                        "2>/dev/null; du -sb /root/art 2>/dev/null | cut -f1",
+                        60)
+                    size = 0
+                    for line in out.splitlines():
+                        if line.startswith("NUN_FILE="):
+                            ck = line.split("=", 1)[1].strip()
+                        elif line.startswith("REFS_TREE="):
+                            refs_tree = line.split("=", 1)[1].strip()
+                        elif line.strip().isdigit():
+                            size = int(line.strip())
+                    if ck and refs_tree:
+                        break
+                    stalls = stalls + 1 if size == last else 0
+                    last = size
+                    print(f"[mat] {size / 2**30:.1f} GiB (stalls={stalls})",
+                          flush=True)
+                    if stalls >= 10:
+                        print("[mat] stalled 10min — abort", flush=True)
+                        break
+                print(f"[mat] ck={ck!r} refs={refs_tree!r}", flush=True)
+                if not (ck and refs_tree):
+                    return 5
+                if want_fp8:
+                    _rc, out = ssh(ip, port,
+                                   "ls /root/art/fp8/transformer/*.safetensors "
+                                   "| wc -l; du -sh /root/art/fp8", 60)
+                    print(f"[mat] fp8 tree: {out.strip()}", flush=True)
+                    assert out.strip().split()[0] != "0", "fp8 tree empty"
+                manifest["ckpt"], manifest["refs_tree"] = ck, refs_tree
+                bank()
+                continue
+
+            assert ck and refs_tree, "mat must run (or be resumed) first"
+
+            if cell in ("corr", "bb", "bf"):
+                mode = "correctness" if cell == "corr" else "bench"
+                env_val = "1" if cell in ("corr", "bf") else "0"
+                ssh(ip, port,
+                    f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
+                    f"python3 /root/bench_b0.py --ckpt {ck} "
+                    f"--out /root/b0_{cell} --mode {mode} "
+                    f"> /root/{cell}.log 2>&1 & echo started", 60)
+                ok, tail = wait_for(ip, port, f"/root/{cell}.log",
+                                    "DONE", 45 * 60, 45, cell)
+                (res / f"{cell}_log.txt").write_text(tail)
+                sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
+                    f"root@{ip}:/root/b0_{cell}", str(res) + "/"], 600)
+                print(f"[{cell}] ok={ok}\n{tail[-1200:]}", flush=True)
+                manifest["results"][cell] = "ok" if ok else "FAILED"
+                bank()
+                if not ok:
+                    return 6
+                continue
+
+            if cell.startswith("e:"):
+                name = cell[2:]
+                env_val, extra = ARMS[name]
+                rows = f"--rows {args.rows}" if args.rows else ""
+                rows += (f" --norm-rows {args.norm_rows} "
+                         f"--norm-shape {args.norm_shape}")
+                ssh(ip, port,
+                    f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
+                    f"python3 /root/bench_arm.py {extra} --ckpt {ck} "
+                    f"--reference-tree {refs_tree} "
+                    f"--prompts /root/bench_prompts.json {rows} "
+                    f"--out /root/e2e/{name} > /root/arm_{name}.log 2>&1 & "
+                    f"echo started", 60)
+                ok, tail = wait_for(ip, port, f"/root/arm_{name}.log",
+                                    "DONE", 100 * 60, 90, f"arm {name}")
+                (res / f"arm_{name}_log.txt").write_text(tail)
+                sh(["scp", *SSH_OPTS, "-P", str(port), "-r",
+                    f"root@{ip}:/root/e2e/{name}", str(res) + "/"], 900)
+                print(f"[arm {name}] ok={ok}\n{tail[-1200:]}", flush=True)
+                manifest["results"][cell] = "ok" if ok else "FAILED"
+                bank()
+                if not ok:
+                    return 6
+                continue
+
+            if cell == "met":
+                done = [a for a in e2e_arms
+                        if manifest["results"].get(f"e:{a}") == "ok"]
+                if "bf16" not in done or len(done) < 2:
+                    print("[met] need bf16 + >=1 candidate arm — skipped",
+                          flush=True)
+                    continue
+                cand = " ".join(f"--cand {a}=/root/e2e/{a}"
+                                for a in done if a != "bf16")
+                ssh(ip, port,
+                    "python3 -c 'import torchmetrics' 2>/dev/null || "
+                    "pip install -q torchmetrics lpips 2>&1 | tail -2", 900)
+                rc, out = ssh(
+                    ip, port,
+                    f"python3 /root/metrics_pod.py --ref /root/e2e/bf16 "
+                    f"{cand} --out /root/metrics.json 2>&1 | tail -60", 1800)
+                (res / "metrics_log.txt").write_text(out)
+                sh(["scp", *SSH_OPTS, "-P", str(port),
+                    f"root@{ip}:/root/metrics.json", str(res) + "/"], 300)
+                print(f"[met] rc={rc}\n{out[-2000:]}", flush=True)
+                manifest["results"]["met"] = "ok" if rc == 0 else "FAILED"
+                bank()
+                continue
+
+            raise SystemExit(f"unknown cell {cell}")
+
+        return 0
+    finally:
+        manifest["elapsed_min"] = (time.time() - started) / 60
+        manifest["est_cost_usd"] = (manifest.get("rate_per_hr", 0.0)
+                                    * manifest["elapsed_min"] / 60)
+        bank()
+        if args.keep:
+            print(f"[pod] KEPT {pod_id} — attach with --pod {pod_id}",
+                  flush=True)
+            return 0
+        try:
+            rest(api, "DELETE", f"/pods/{pod_id}")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[pod] DELETE failed ({exc}) — VERIFY {pod_id}", flush=True)
+        gone = False
+        for _ in range(30):
+            gone = confirm_404(api, pod_id)
+            if gone:
+                break
+            time.sleep(10)
+        podguard.record_release(pod_id, gone, "svdq-bench teardown")
+        manifest["teardown_404"] = gone
+        bank()
+        print(f"[pod] terminated {pod_id}; 404={gone}; "
+              f"elapsed={manifest['elapsed_min']:.1f}min "
+              f"est=${manifest['est_cost_usd']:.2f}", flush=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/svdq_bench/summarize.py
+++ b/scripts/svdq_bench/summarize.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Turn a banked run directory into the reportable tables (pgw#865).
+
+Every row carries its shape/steps/CFG, because the whole reason the
+"how do we compare to fal / to the 5090" question was unanswerable is that
+our banked numbers were at incomparable settings.
+
+  summarize.py RUNDIR [RUNDIR ...]
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ARM_LABEL = {
+    "bf16": "bf16 (reference)",
+    "bf16c": "bf16 + compile",
+    "fp8": "fp8-w8a8 (published flavor)",
+    "fp8c": "fp8-w8a8 + compile",
+    "base": "nvfp4 svdq, baseline triton lane",
+    "basec": "nvfp4 svdq, baseline + compile",
+    "native": "nvfp4 svdq, NATIVE fused lane",
+    "nativec": "nvfp4 svdq, NATIVE fused + compile",
+}
+ORDER = ["bf16", "bf16c", "fp8", "fp8c", "base", "basec", "native", "nativec"]
+
+
+def load(run: Path):
+    man = json.loads((run / "manifest.json").read_text())
+    arms = {}
+    for d in sorted(run.iterdir()):
+        if not d.is_dir():
+            continue
+        for f in d.glob("bench_*.json"):
+            arms[d.name] = json.loads(f.read_text())
+    return man, arms
+
+
+def fmt(v, spec=".1f", scale=1.0):
+    return "—" if v is None else format(v * scale, spec)
+
+
+def steady_e2e(arm):
+    """Warm, recompile-free e2e for this arm.
+
+    A compiled arm's per-row mean is NOT a serving number: dynamo
+    re-specializes on each distinct prompt shape, so most rows carry a
+    ~175 s compile. The repeat rows re-render ONE prompt against an
+    already-warm graph, which is what a served request sees (production
+    pins shapes through the cell store). Eager arms have no such split, so
+    both paths agree there."""
+    reps = [r["e2e_s"] for r in arm.get("repeats") or []]
+    compiled = bool((arm.get("runtime") or {}).get("compiled"))
+    if compiled and reps:
+        return sum(reps) / len(reps), "repeats"
+    return arm["summary"]["e2e_mean_s"], "rows"
+
+
+def main() -> int:
+    for run in [Path(a) for a in sys.argv[1:]]:
+        man, arms = load(run)
+        gpu = man.get("gpu", "?")
+        env = " ".join(man.get("env_line") or [])
+        print(f"\n## {run.name} — {gpu} ({env})")
+        print(f"pod {man.get('pod')} rate ${man.get('rate_per_hr')}/hr "
+              f"elapsed {man.get('elapsed_min', 0):.0f} min "
+              f"est ${man.get('est_cost_usd', 0):.2f} "
+              f"teardown_404={man.get('teardown_404')}")
+
+        spec = None
+        for a in arms.values():
+            spec = a.get("recipe")
+            break
+        if spec:
+            print(f"\n### A · {spec['resolution'][0]}^2, {spec['steps']} steps,"
+                  f" true_cfg {spec['true_cfg_scale']} "
+                  f"(2 transformer forwards/step), {spec['set']}\n")
+        print("| arm | executed lane | ms/step | e2e s/img | imgs/hr "
+              "| peak VRAM GB | load s |")
+        print("|---|---|---|---|---|---|---|")
+        for name in ORDER:
+            a = arms.get(name)
+            if not a:
+                continue
+            s = a["summary"]
+            rt = a.get("runtime", {})
+            lane = rt.get("lane") or rt.get("runtime", "?")
+            e2e, src = steady_e2e(a)
+            print(f"| {ARM_LABEL.get(name, name)} | {lane} "
+                  f"| {fmt(s['step_mean_s'], '.0f', 1000)} "
+                  f"| {fmt(e2e, '.2f')} ({src}) "
+                  f"| {fmt(3600.0 / e2e, '.1f')} "
+                  f"| {fmt(s['peak_vram_alloc_gb'], '.1f')} "
+                  f"| {fmt(a.get('load_s'), '.0f')} |")
+
+        norm = None
+        for name in ORDER:
+            a = arms.get(name)
+            if a and a.get("normalized"):
+                norm = a["normalized"]
+                break
+        if norm:
+            print(f"\n### B · NORMALIZED {norm['shape'][0]}^2, "
+                  f"{norm['steps']} steps, true_cfg "
+                  f"{norm['true_cfg_scale']} "
+                  f"({norm['forwards_per_step']} forward(s)/step) — the "
+                  f"market-comparable shape\n")
+            print("| arm | ms/step | e2e s/img | imgs/hr |")
+            print("|---|---|---|---|")
+            for name in ORDER:
+                a = arms.get(name)
+                if not a or not a.get("normalized"):
+                    continue
+                n = a["normalized"]
+                # same recompile caveat: the FIRST normalized row runs on the
+                # graph the block just compiled, later rows re-specialize.
+                compiled = bool((a.get("runtime") or {}).get("compiled"))
+                e2e = n["e2e_min_s"] if compiled else n["e2e_mean_s"]
+                print(f"| {ARM_LABEL.get(name, name)} "
+                      f"| {fmt(n['step_mean_s'], '.0f', 1000)} "
+                      f"| {fmt(e2e, '.2f')} "
+                      f"| {fmt(3600.0 / e2e, '.1f')} |")
+
+        met = run / "metrics.json"
+        if met.exists():
+            m = json.loads(met.read_text())
+            print("\n### Quality vs the SAME-CARD bf16 arm (LPIPS-alex, "
+                  "lower is closer)\n")
+            print("| pair | mean | worst | n |")
+            print("|---|---|---|---|")
+            for k, v in sorted(m["summary"].items()):
+                if k.startswith("lpips") and k.endswith("_vs_ref"):
+                    print(f"| {k[6:]} | {v['mean']:.4f} | {v['worst']:.4f} "
+                          f"| {v['n']} |")
+
+        for extra, title in (("b0_corr/correctness.json", "correctness"),
+                             ("b0_bb/bench_baseline.json", "bucket baseline"),
+                             ("b0_bf/bench_fused.json", "bucket fused")):
+            f = run / extra
+            if not f.exists():
+                continue
+            d = json.loads(f.read_text())
+            if title == "correctness":
+                bad = d.get("fused_worse_than_base_vs_ref") or []
+                print(f"\n### correctness — quant bit-identical: "
+                      f"{d.get('quant_bit_identical_all')}; units worse than "
+                      f"baseline vs the fp32 reference: {len(bad)}/"
+                      f"{len(d.get('units', []))}; self_check="
+                      f"{d.get('self_check')}")
+            else:
+                print(f"\n### {title}: eager step "
+                      f"{d.get('eager_step_ms', 0):.0f} ms, compiled step "
+                      f"{d.get('compiled_step_ms', 0):.0f} ms, load "
+                      f"{d.get('load_s', 0):.0f} s, census "
+                      f"{d.get('swap_census')}, peak "
+                      f"{d.get('peak_vram_gb', 0):.1f} GB")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/tune_quant.py
+++ b/scripts/svdq_bench/tune_quant.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Roofline + shape sweep for the fused activation quantizer (pgw#863).
+
+The quantizer is pure memory traffic: read [M, K] bf16, write [M, K/2] nibbles
+plus [M, K/16] e4m3 scales. So it has an honest ceiling — bytes / HBM
+bandwidth — and "is it tuned for this card" is answerable rather than a
+matter of taste.
+
+The shipped kernel was tuned on sm_120 (one row x BPP 16-element groups per
+program, strided even/odd loads). This sweeps the two launch knobs that were
+never swept on sm_100 (blocks-per-program and warps) and reports achieved
+GB/s against the device's own measured copy bandwidth, so the verdict is
+"n% of THIS card's roofline", not a number that means nothing on its own.
+
+  tune_quant.py --out DIR
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+# (M, K) the real qwen-image units present at 1328^2 and 1024^2.
+SHAPES = [(7401, 3072), (7401, 12288), (4608, 3072), (4608, 12288),
+          (512, 3072)]
+BPPS = (16, 32, 64, 128, 256)
+WARPS = (1, 2, 4, 8)
+
+
+def median_ms(fn, iters=50, warmup=15):
+    import torch
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    ts = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        ts.append((time.perf_counter() - t0) * 1e3)
+    ts.sort()
+    return ts[len(ts) // 2]
+
+
+def device_copy_gbs() -> float:
+    """The card's own achievable bandwidth, measured — not a spec sheet."""
+    import torch
+    n = 1 << 28  # 256 Mi elements = 512 MB bf16
+    a = torch.empty(n, dtype=torch.bfloat16, device="cuda")
+    b = torch.empty_like(a)
+    ms = median_ms(lambda: b.copy_(a), iters=20, warmup=5)
+    return (2 * a.numel() * 2) / (ms * 1e-3) / 1e9
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    import torch
+    from gen_worker.models import svdq_fused as sf
+    from gen_worker.models.svdq_fused import _dyn_s2
+
+    cap = torch.cuda.get_device_capability()
+    sm = cap[0] * 10 + cap[1]
+    dev = torch.cuda.get_device_name(0)
+    peak = device_copy_gbs()
+    print(f"[tune] {dev} sm_{sm} measured copy bandwidth "
+          f"{peak:.0f} GB/s", flush=True)
+
+    saved_bpp, saved_warps = sf._QBPP, dict(sf._QUANT_WARPS_BY_SM)
+    rows = []
+    for m, k in SHAPES:
+        torch.manual_seed(0)
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        s2 = _dyn_s2(x, None)
+        # bytes moved: read bf16 + write nibbles + write e4m3 scales
+        moved = m * k * 2 + m * k // 2 + m * (k // 16)
+        best = None
+        for bpp in BPPS:
+            for w in WARPS:
+                sf._QBPP = bpp
+                sf._QUANT_WARPS_BY_SM[sm] = w
+                sf._build_fused_ops.cache_clear()
+                try:
+                    op = sf.fused_ops()[0]
+                    ms = median_ms(lambda: op(x, None, s2, True))
+                except Exception as exc:  # noqa: BLE001
+                    rows.append({"m": m, "k": k, "bpp": bpp, "warps": w,
+                                 "err": f"{type(exc).__name__}: {exc}"[:160]})
+                    continue
+                gbs = moved / (ms * 1e-3) / 1e9
+                rows.append({"m": m, "k": k, "bpp": bpp, "warps": w,
+                             "ms": ms, "gb_s": gbs,
+                             "pct_roofline": 100.0 * gbs / peak})
+                if best is None or ms < best["ms"]:
+                    best = rows[-1]
+        print(f"[tune] {m}x{k}: best bpp={best['bpp']} warps={best['warps']} "
+              f"{best['ms'] * 1000:.1f}us {best['gb_s']:.0f} GB/s "
+              f"({best['pct_roofline']:.0f}% roofline)", flush=True)
+
+    sf._QBPP = saved_bpp
+    sf._QUANT_WARPS_BY_SM.clear()
+    sf._QUANT_WARPS_BY_SM.update(saved_warps)
+    sf._build_fused_ops.cache_clear()
+
+    # shipped config, for the delta the tuning is worth
+    shipped = []
+    for m, k in SHAPES:
+        torch.manual_seed(0)
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        s2 = _dyn_s2(x, None)
+        op = sf.fused_ops()[0]
+        shipped.append({"m": m, "k": k,
+                        "ms": median_ms(lambda: op(x, None, s2, True))})
+        print(f"[tune] shipped {m}x{k}: "
+              f"{shipped[-1]['ms'] * 1000:.1f}us", flush=True)
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "quant_tuning.json").write_text(json.dumps(
+        {"device": dev, "sm": sm, "copy_gb_s": peak,
+         "shipped_qbpp": saved_bpp, "shipped_warps": saved_warps.get(sm),
+         "sweep": rows, "shipped": shipped}, indent=1))
+    print("[tune] DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/tune_quant_v2.py
+++ b/scripts/svdq_bench/tune_quant_v2.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Candidate: CONTIGUOUS-load activation quantizer for sm_100 (pgw#863).
+
+The shipped kernel reads each 16-element block as two stride-2 gathers (even
+lanes, odd lanes) because the packer needs the low/high nibble pair. That
+costs nothing measurable on sm_120 but leaves B200 at 9-21% of its own copy
+roofline (measured: tune_quant.py), and the launch-config sweep cannot fix it
+— every (blocks-per-program, warps) pair lands in the same band.
+
+This variant loads the block as ONE contiguous [BPP, 16] tile and does the
+even/odd separation in registers via reshape + tl.split. Same arithmetic,
+same rounding, so the output must be BIT-IDENTICAL to the shipped kernel —
+which is the first thing this script checks, before any timing is reported.
+
+  tune_quant_v2.py --out DIR
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+SHAPES = [(7401, 3072), (7401, 12288), (4608, 3072), (4608, 12288),
+          (512, 3072)]
+
+
+def median_ms(fn, iters=50, warmup=15):
+    import torch
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    ts = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        ts.append((time.perf_counter() - t0) * 1e3)
+    ts.sort()
+    return ts[len(ts) // 2]
+
+
+def build(bpp_default):
+    import torch
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _e2m1_code(q):
+        a = tl.abs(q)
+        code = ((a > 0.25).to(tl.uint8) + (a > 0.75).to(tl.uint8)
+                + (a > 1.25).to(tl.uint8) + (a > 1.75).to(tl.uint8)
+                + (a > 2.5).to(tl.uint8) + (a > 3.5).to(tl.uint8)
+                + (a > 5.0).to(tl.uint8))
+        tie = ((a == 0.75) | (a == 1.75) | (a == 2.5)).to(tl.uint8)
+        return code + tie + ((q < 0).to(tl.uint8) * 8)
+
+    @triton.jit
+    def _quant_contig(x_ptr, s2_ptr, q_ptr, s_ptr, K, KB, NCB,
+                      BLOCKED: tl.constexpr, BPP: tl.constexpr):
+        row = tl.program_id(0)
+        blk0 = tl.program_id(1) * BPP
+        s2 = tl.load(s2_ptr)
+        offs_b = blk0 + tl.arange(0, BPP)
+        blk_ok = offs_b < KB
+        # ONE contiguous [BPP, 16] tile — every lane reads its neighbour.
+        offs = offs_b[:, None] * 16 + tl.arange(0, 16)[None, :]
+        tile = tl.load(x_ptr + row * K + offs, mask=blk_ok[:, None],
+                       other=0.0).to(tl.float32)
+        amax = tl.max(tl.abs(tile), axis=1)
+        scale = tl.math.div_rn(amax, 6.0 * s2)
+        scale = tl.minimum(tl.maximum(scale, 0.001953125), 448.0)
+        scale_f8 = scale.to(tl.float8e4nv)
+        denom = (scale_f8.to(tl.float32) * s2)[:, None]
+        codes = _e2m1_code(tl.math.div_rn(tile, denom))
+        # de-interleave in registers: [BPP,16] -> [BPP,8,2] -> lo, hi
+        lo, hi = tl.split(tl.reshape(codes, (BPP, 8, 2)))
+        packed = lo | (hi << 4)
+        offs_p = offs_b[:, None] * 8 + tl.arange(0, 8)[None, :]
+        tl.store(q_ptr + row * (K // 2) + offs_p, packed,
+                 mask=blk_ok[:, None])
+        if BLOCKED:
+            rb = row // 128
+            rr = row % 128
+            tile_i = rb * NCB + (offs_b // 4)
+            in_tile = (rr % 32) * 16 + (rr // 32) * 4 + (offs_b % 4)
+            tl.store(s_ptr + tile_i * 512 + in_tile, scale_f8, mask=blk_ok)
+        else:
+            tl.store(s_ptr + row * KB + offs_b, scale_f8, mask=blk_ok)
+
+    def launch(x2, s2, blocked, bpp=None, warps=4):
+        from gen_worker.models.nvfp4_quant import BLOCK, blocked_scale_numel
+        m, k = int(x2.shape[0]), int(x2.shape[1])
+        kb = k // BLOCK
+        ncb = (kb + 3) // 4
+        q = torch.empty(m, k // 2, dtype=torch.uint8, device=x2.device)
+        if blocked:
+            s = torch.zeros(blocked_scale_numel(m, kb),
+                            dtype=torch.float8_e4m3fn, device=x2.device)
+        else:
+            s = torch.empty(m, kb, dtype=torch.float8_e4m3fn,
+                            device=x2.device)
+        b = min(bpp or bpp_default, kb)
+        while kb % b and b > 1:
+            b //= 2
+        _quant_contig[(m, (kb + b - 1) // b)](
+            x2, s2, q, s, k, kb, ncb, BLOCKED=blocked, BPP=b,
+            num_warps=warps)
+        return q, s
+
+    return launch
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    import torch
+    from gen_worker.models import svdq_fused as sf
+    from gen_worker.models.svdq_fused import _dyn_s2
+
+    cap = torch.cuda.get_device_capability()
+    sm = cap[0] * 10 + cap[1]
+    shipped_op = sf.fused_ops()[0]
+    launch = build(sf._QBPP)
+    print(f"[v2] {torch.cuda.get_device_name(0)} sm_{sm}", flush=True)
+
+    rows = []
+    for m, k in SHAPES:
+        torch.manual_seed(0)
+        x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        s2 = _dyn_s2(x, None)
+        moved = m * k * 2 + m * k // 2 + m * (k // 16)
+        row = {"m": m, "k": k}
+        for blocked in (True, False):
+            want_q, want_s = shipped_op(x, None, s2, blocked)
+            got_q, got_s = launch(x, s2, blocked)
+            ident = (torch.equal(got_q, want_q)
+                     and torch.equal(got_s.view(torch.uint8),
+                                     want_s.view(torch.uint8)))
+            row[f"bit_identical_blocked_{blocked}"] = bool(ident)
+        if not row["bit_identical_blocked_True"]:
+            print(f"[v2] {m}x{k}: NOT bit-identical — candidate rejected",
+                  flush=True)
+            rows.append(row)
+            continue
+        base = median_ms(lambda: shipped_op(x, None, s2, True))
+        best = None
+        for bpp in (32, 64, 128, 256):
+            for w in (1, 2, 4, 8):
+                try:
+                    ms = median_ms(lambda: launch(x, s2, True, bpp, w))
+                except Exception as exc:  # noqa: BLE001
+                    continue
+                if best is None or ms < best[0]:
+                    best = (ms, bpp, w)
+        row.update({"shipped_ms": base, "v2_ms": best[0], "v2_bpp": best[1],
+                    "v2_warps": best[2],
+                    "speedup": base / best[0],
+                    "v2_gb_s": moved / (best[0] * 1e-3) / 1e9})
+        rows.append(row)
+        print(f"[v2] {m}x{k}: shipped {base * 1000:.1f}us -> v2 "
+              f"{best[0] * 1000:.1f}us (bpp={best[1]} warps={best[2]}) "
+              f"= {row['speedup']:.2f}x, {row['v2_gb_s']:.0f} GB/s",
+              flush=True)
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "quant_v2.json").write_text(json.dumps(
+        {"sm": sm, "device": torch.cuda.get_device_name(0),
+         "rows": rows}, indent=1))
+    print("[v2] DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,8 @@ def _probe_packed_modulation(sm: int) -> Optional[str]:
     return awq_packed_self_check()
 
 
-def _decide(kind: str, on: str, off: str, probe) -> str:
+def _decide(kind: str, on: str, off: str,
+            probe: Callable[[int], Optional[str]]) -> str:
     """One arming decision: env, then silicon, then numerics. Cached per
     process with the reason that produced it."""
     if kind in _LANES:

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -1,9 +1,18 @@
 """Native-kernel dispatch + capability probe (pgw#860).
 
-One decision, made once per process at LOAD time: does the svdq serving path
-run the FUSED native lane (pgw#862 triton kernels today; `_cozy_kernels` C++
-ops if/when a lane needs them) or the baseline unfused lane. The decision is
-typed, logged, and never silent-wrong:
+TWO decisions, each made once per process at LOAD time and each INDEPENDENT of
+the other (pgw#863 — binding them to one switch cost sm_100 either 9.5 GB of
+residency or 19% of its step time, with no way to take both):
+
+- ``svdq_linear_lane()`` — FUSED W4A4 linears (pgw#862 triton kernels;
+  `_cozy_kernels` C++ ops if/when a lane needs them) or the baseline unfused
+  chain. Armed only where the fused path is measurably faster in the
+  PRODUCTION (compiled) posture.
+- ``svdq_modulation_lane()`` — PACKED W4A16 AdaLN modulation (pgw#864) or
+  dense bf16. A residency win rather than a throughput one, so it arms on
+  every Blackwell card.
+
+Both decisions are typed, logged, and never silent-wrong:
 
 - env kill-switch first: ``GEN_WORKER_NATIVE_KERNELS=0`` forces baseline.
   Rollout is env-GATED (Paul, pgw#859 G0): unset means OFF; ``=1`` opts in.
@@ -30,16 +39,39 @@ logger = logging.getLogger(__name__)
 NATIVE_ENV = "GEN_WORKER_NATIVE_KERNELS"
 NATIVE_LIB_ENV = "GEN_WORKER_NATIVE_KERNELS_LIB"
 
-# dot_scaled lowers to native block-scaled MMA on Blackwell (PTX census banked
-# in pgw#862: sm_120a => kind::mxf4nvf4, sm_100a => tcgen05). 103/121 are
-# family variants triton targets per-device; the self-check still gates them.
-FUSED_SMS = (100, 103, 120, 121)
+# Blackwell block-scaled MMA silicon (PTX census banked in pgw#862: sm_120a =>
+# kind::mxf4nvf4, sm_100a => tcgen05). 103/121 are family variants triton
+# targets per-device; the self-checks still gate them.
+BLACKWELL_SMS = (100, 103, 120, 121)
+
+# Where the FUSED W4A4 LINEAR is the faster serving path — measured, per card,
+# in the PRODUCTION (torch.compile) posture, which is the only posture that
+# decides anything:
+#   sm_120 (RTX 5090): fused+compiled 785 ms/step beats the baseline lane and
+#     nunchaku's 843 (pgw#862 final table).
+#   sm_100 (B200): fused+compiled 385 ms/step LOSES to the SAME artifact on the
+#     baseline lane compiled, 312 ms/step (-19% at 1328^2, -34% at 1024^2;
+#     pgw#863 run b200-r3, pod aokw0wficrhwkb). Inductor fuses the baseline's
+#     open elementwise chain better than our custom ops can, and our ops are
+#     opaque to it — so on this card the fusion is a pessimisation.
+# sm_100/103 are therefore deliberately ABSENT. This is a measurement, not a
+# capability gap: the kernels arm, they are bit-identical, they are simply
+# slower there.
+FUSED_LINEAR_SMS = (120, 121)
+
+# Where the PACKED W4A16 modulation is worth arming. It is a pure residency
+# win — 22.8 -> 13.3 GB transformer-resident on B200, speed-neutral — so it
+# arms on every Blackwell card, INCLUDING the ones whose linear lane stays on
+# the baseline. Binding these two to one switch was the pgw#862 shape and it
+# cost sm_100 either 9.5 GB or 19% of its step time with no way to take both.
+PACKED_MODULATION_SMS = (100, 103, 120, 121)
 
 _EXT_DEFAULT = "/opt/cozy/native/libcozy_kernels.so"
 _EXT_NAMESPACE = "cozy_kernels"
 
-_LANE: Optional[str] = None
-_LANE_REASON: str = ""
+# Two independent decisions, each cached with its own recorded reason.
+_LANES: dict[str, str] = {}
+_REASONS: dict[str, str] = {}
 
 
 def native_kernels_requested() -> Optional[bool]:
@@ -53,75 +85,104 @@ def native_kernels_requested() -> Optional[bool]:
     return None
 
 
-def _probe_fused_lane() -> Optional[str]:
-    """Why the fused lane cannot arm HERE, or None when it can."""
+def _gpu_sm() -> tuple[int, Optional[str]]:
+    """``(sm, None)`` or ``(0, why-not)``."""
     try:
         import torch
     except ImportError:
-        return "torch is not installed"
+        return 0, "torch is not installed"
     if not torch.cuda.is_available():
-        return "fused svdq lane requires a CUDA GPU"
+        return 0, "native svdq kernels require a CUDA GPU"
     major, minor = torch.cuda.get_device_capability()
-    sm = major * 10 + minor
-    if sm not in FUSED_SMS:
-        return (f"fused svdq lane needs Blackwell block-scaled MMA "
-                f"(sm_{'/'.join(str(s) for s in FUSED_SMS)}); this GPU is "
-                f"sm_{sm}")
-    from .svdq_awq_packed import awq_packed_self_check
+    return major * 10 + minor, None
+
+
+def _probe_fused_linear(sm: int) -> Optional[str]:
+    """Why the fused W4A4 linear cannot arm HERE, or None when it can."""
+    if sm not in FUSED_LINEAR_SMS:
+        if sm in BLACKWELL_SMS:
+            return (f"sm_{sm} has the silicon but the fused linear is SLOWER "
+                    f"than the baseline lane under torch.compile there "
+                    f"(pgw#863); armed on "
+                    f"sm_{'/'.join(str(s) for s in FUSED_LINEAR_SMS)}")
+        return (f"fused svdq linear needs Blackwell block-scaled MMA "
+                f"(sm_{'/'.join(str(s) for s in FUSED_LINEAR_SMS)}); this GPU "
+                f"is sm_{sm}")
     from .svdq_fused import fused_self_check
 
-    reason = fused_self_check()
-    if reason is not None:
-        return reason
-    reason = awq_packed_self_check()
-    if reason is not None:
-        return f"awq packed lane: {reason}"
-    return None
+    return fused_self_check()
 
 
-def svdq_execution_lane() -> str:
-    """``"fused"`` | ``"baseline"`` for this process. Call at LOAD time — the
-    first call compiles kernels and runs the self-check."""
-    global _LANE, _LANE_REASON
+def _probe_packed_modulation(sm: int) -> Optional[str]:
+    """Why the packed W4A16 modulation cannot arm HERE, or None."""
+    if sm not in PACKED_MODULATION_SMS:
+        return (f"packed modulation needs Blackwell "
+                f"(sm_{'/'.join(str(s) for s in PACKED_MODULATION_SMS)}); "
+                f"this GPU is sm_{sm}")
+    from .svdq_awq_packed import awq_packed_self_check
 
-    if _LANE is not None:
-        return _LANE
+    return awq_packed_self_check()
+
+
+def _decide(kind: str, on: str, off: str, probe) -> str:
+    """One arming decision: env, then silicon, then numerics. Cached per
+    process with the reason that produced it."""
+    if kind in _LANES:
+        return _LANES[kind]
     requested = native_kernels_requested()
     if requested is False:
-        _LANE, _LANE_REASON = "baseline", f"{NATIVE_ENV}=0 (kill-switch)"
-        logger.info("native kernels: baseline lane (%s)", _LANE_REASON)
-        return _LANE
-    if requested is None:
-        _LANE, _LANE_REASON = "baseline", (
+        _LANES[kind], _REASONS[kind] = off, f"{NATIVE_ENV}=0 (kill-switch)"
+    elif requested is None:
+        _LANES[kind], _REASONS[kind] = off, (
             f"dormant — rollout is env-gated, set {NATIVE_ENV}=1 to opt in")
-        logger.info("native kernels: baseline lane (%s)", _LANE_REASON)
-        return _LANE
-    try:
-        reason = _probe_fused_lane()
-    except Exception as exc:  # noqa: BLE001 — any probe gap => baseline
-        reason = f"probe raised: {exc}"
-    if reason is not None:
-        _LANE, _LANE_REASON = "baseline", reason
-        logger.warning("native kernels: requested but NOT armed — %s; "
-                       "baseline lane serves the same artifact", reason)
     else:
-        _LANE, _LANE_REASON = "fused", "probe + numerics self-check passed"
-        logger.info("native kernels: FUSED lane armed (%s)", _LANE_REASON)
-    return _LANE
+        sm, why = _gpu_sm()
+        try:
+            reason = why or probe(sm)
+        except Exception as exc:  # noqa: BLE001 — any probe gap => degrade
+            reason = f"probe raised: {exc}"
+        if reason is not None:
+            _LANES[kind], _REASONS[kind] = off, reason
+            logger.warning("native kernels [%s]: requested but NOT armed — "
+                           "%s; %s serves the same artifact",
+                           kind, reason, off)
+            return _LANES[kind]
+        _LANES[kind], _REASONS[kind] = on, "probe + numerics self-check passed"
+        logger.info("native kernels [%s]: %s armed", kind, on)
+        return _LANES[kind]
+    logger.info("native kernels [%s]: %s (%s)", kind, off, _REASONS[kind])
+    return _LANES[kind]
 
 
-def svdq_lane_reason() -> str:
-    """The recorded reason for the current lane decision."""
-    if _LANE is None:
-        svdq_execution_lane()
-    return _LANE_REASON
+def svdq_linear_lane() -> str:
+    """``"fused"`` | ``"baseline"`` for the W4A4 linears in this process.
+    Call at LOAD time — the first call compiles kernels and self-checks."""
+    return _decide("linear", "fused", "baseline", _probe_fused_linear)
+
+
+def svdq_modulation_lane() -> str:
+    """``"packed"`` | ``"dense"`` for the W4A16 AdaLN modulation. Independent
+    of the linear lane: it is a residency win, not a throughput one, so a card
+    that wants the baseline linears still wants this."""
+    return _decide("modulation", "packed", "dense", _probe_packed_modulation)
+
+
+def svdq_linear_lane_reason() -> str:
+    """The recorded reason for the linear-lane decision."""
+    svdq_linear_lane()
+    return _REASONS["linear"]
+
+
+def svdq_modulation_lane_reason() -> str:
+    """The recorded reason for the modulation-lane decision."""
+    svdq_modulation_lane()
+    return _REASONS["modulation"]
 
 
 def reset_native_kernels_arming() -> None:
-    """Forget the lane decision (tests only)."""
-    global _LANE, _LANE_REASON
-
-    _LANE, _LANE_REASON = None, ""
+    """Forget both lane decisions (tests only)."""
+    _LANES.clear()
+    _REASONS.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +255,9 @@ def extension_available() -> bool:
 
 
 __all__ = [
-    "FUSED_SMS",
+    "BLACKWELL_SMS",
+    "FUSED_LINEAR_SMS",
+    "PACKED_MODULATION_SMS",
     "NATIVE_ENV",
     "NATIVE_LIB_ENV",
     "extension_available",
@@ -203,6 +266,8 @@ __all__ = [
     "load_extension",
     "native_kernels_requested",
     "reset_native_kernels_arming",
-    "svdq_execution_lane",
-    "svdq_lane_reason",
+    "svdq_linear_lane",
+    "svdq_linear_lane_reason",
+    "svdq_modulation_lane",
+    "svdq_modulation_lane_reason",
 ]

--- a/src/gen_worker/models/svdq_fused.py
+++ b/src/gen_worker/models/svdq_fused.py
@@ -51,8 +51,19 @@ _SELF_CHECK_PROBES = ((128, 512, 256), (77, 3072, 384))
 
 # Warps for the fused quant kernel, per SM — module level so a sweep can
 # rebind it (scripts/svdq_bench/bench_gemm.py) instead of editing source.
-_QUANT_WARPS_BY_SM = {100: 4, 103: 4, 120: 8, 121: 8}
+# Quantizer launch config per SM. Module level so scripts/svdq_bench/
+# tune_quant.py can sweep it per card instead of anyone editing source.
+# sm_120: 8 warps (pgw#862, strided kernel). sm_100: 1 warp on the contiguous
+# kernel — a whole-sweep optimum on B200, where more warps only add
+# contention on an already memory-bound kernel (pgw#863).
+_QUANT_WARPS_BY_SM = {100: 1, 103: 1, 120: 8, 121: 8}
 _QUANT_WARPS_DEFAULT = 4
+# 16-element blocks handled per program, per SM.
+_QBPP = 128
+_QBPP_BY_SM = {100: 128, 103: 128, 120: 128, 121: 128}
+# SMs served by the contiguous-load quantizer (pgw#863). sm_120 keeps the
+# strided kernel: register re-layout measured SLOWER there (pgw#862).
+_CONTIG_QUANT_SMS = (100, 103)
 
 
 class SvdqFusedError(RuntimeError):
@@ -108,8 +119,18 @@ def _build_fused_ops() -> Optional[tuple[Any, Any, Any]]:
     # smooth divide (bf16-rounded to match the aten reference) and FLAT
     # [M, K/16] scale stores (dot_scaled's native layout) instead of the
     # cuBLAS blocked swizzle.
-    _QBPP = 128
-
+    #
+    # The stride-2 pair of loads is why there are TWO kernels below. It costs
+    # nothing on sm_120, but on sm_100 it leaves the quantizer at 9-21% of
+    # B200's own measured 6.0 TB/s copy roofline, and no (blocks-per-program,
+    # warps) combination moves it — the whole sweep lands in one band
+    # (pgw#863, scripts/svdq_bench/tune_quant.py). `_quant_contig_kernel`
+    # loads the block as ONE contiguous [BPP, 16] tile and de-interleaves in
+    # registers instead; measured 1.10-1.73x on B200 across the real qwen
+    # shapes, bit-identical output in both scale layouts. It is NOT made the
+    # sm_120 path: the 5090 lesson above is that re-layout in registers loses
+    # there, and a shared "improvement" that regresses the card we actually
+    # ship on is not an improvement.
     @triton.jit
     def _quant_smooth_kernel(  # type: ignore[no-untyped-def]
         x_ptr, sm_ptr, s2_ptr, q_ptr, s_ptr,
@@ -156,6 +177,53 @@ def _build_fused_ops() -> Optional[tuple[Any, Any, Any]]:
             tile = rb * NCB + (offs_b // 4)
             in_tile = (rr % 32) * 16 + (rr // 32) * 4 + (offs_b % 4)
             tl.store(s_ptr + tile * 512 + in_tile, scale_f8, mask=blk_ok)
+        else:
+            tl.store(s_ptr + row * KB + offs_b, scale_f8, mask=blk_ok)
+
+    @triton.jit
+    def _quant_contig_kernel(  # type: ignore[no-untyped-def]
+        x_ptr, sm_ptr, s2_ptr, q_ptr, s_ptr,
+        K, KB, NCB,
+        HAS_SMOOTH: tl.constexpr, BLOCKED: tl.constexpr, BPP: tl.constexpr,
+    ):
+        """Same arithmetic as ``_quant_smooth_kernel``, contiguous loads.
+
+        Every value is read exactly once by an adjacent lane; the even/odd
+        split the packer needs happens after the codes exist, as a register
+        reshape + split. Bit-identity with the strided kernel is enforced by
+        ``fused_self_check`` before the lane can arm."""
+        row = tl.program_id(0)
+        blk0 = tl.program_id(1) * BPP
+        s2 = tl.load(s2_ptr)
+
+        offs_b = blk0 + tl.arange(0, BPP)
+        blk_ok = offs_b < KB
+        offs = offs_b[:, None] * 16 + tl.arange(0, 16)[None, :]
+        m2 = blk_ok[:, None]
+        tile = tl.load(x_ptr + row * K + offs, mask=m2,
+                       other=0.0).to(tl.float32)
+        if HAS_SMOOTH:
+            smv = tl.load(sm_ptr + offs, mask=m2, other=1.0).to(tl.float32)
+            tile = tl.math.div_rn(tile, smv).to(tl.bfloat16).to(tl.float32)
+
+        amax = tl.max(tl.abs(tile), axis=1)
+        scale = tl.math.div_rn(amax, 6.0 * s2)
+        scale = tl.minimum(tl.maximum(scale, 0.001953125), 448.0)
+        scale_f8 = scale.to(tl.float8e4nv)
+        denom = (scale_f8.to(tl.float32) * s2)[:, None]
+
+        codes = _e2m1_code(tl.math.div_rn(tile, denom))
+        lo, hi = tl.split(tl.reshape(codes, (BPP, 8, 2)))
+        packed = lo | (hi << 4)
+
+        offs_p = offs_b[:, None] * 8 + tl.arange(0, 8)[None, :]
+        tl.store(q_ptr + row * (K // 2) + offs_p, packed, mask=m2)
+        if BLOCKED:
+            rb = row // 128
+            rr = row % 128
+            tile_i = rb * NCB + (offs_b // 4)
+            in_tile = (rr % 32) * 16 + (rr // 32) * 4 + (offs_b % 4)
+            tl.store(s_ptr + tile_i * 512 + in_tile, scale_f8, mask=blk_ok)
         else:
             tl.store(s_ptr + row * KB + offs_b, scale_f8, mask=blk_ok)
 
@@ -242,13 +310,19 @@ def _build_fused_ops() -> Optional[tuple[Any, Any, Any]]:
         tl.store(out_ptr + offs_m[:, None] * N + offs_n[None, :],
                  y.to(tl.bfloat16), mask=m_ok[:, None] & n_ok[None, :])
 
-    def _quant_warps() -> int:
+    def _sm() -> int:
         try:
             major, minor = torch.cuda.get_device_capability()
-            return _QUANT_WARPS_BY_SM.get(major * 10 + minor,
-                                          _QUANT_WARPS_DEFAULT)
+            return major * 10 + minor
         except Exception:  # noqa: BLE001
-            return _QUANT_WARPS_DEFAULT
+            return 0
+
+    def _quant_warps() -> int:
+        return _QUANT_WARPS_BY_SM.get(_sm(), _QUANT_WARPS_DEFAULT)
+
+    def _quant_kernel():  # type: ignore[no-untyped-def]
+        return (_quant_contig_kernel if _sm() in _CONTIG_QUANT_SMS
+                else _quant_smooth_kernel)
 
     def _quant_launch(x2: Any, smooth: Optional[Any], s2: Any,
                       blocked: bool) -> tuple[Any, Any]:
@@ -265,10 +339,10 @@ def _build_fused_ops() -> Optional[tuple[Any, Any, Any]]:
         else:
             s = torch.empty(m, kb, dtype=torch.float8_e4m3fn,
                             device=x2.device)
-        bpp = min(_QBPP, kb)
+        bpp = min(_QBPP_BY_SM.get(_sm(), _QBPP), kb)
         while kb % bpp and bpp > 1:
             bpp //= 2
-        _quant_smooth_kernel[(m, (kb + bpp - 1) // bpp)](
+        _quant_kernel()[(m, (kb + bpp - 1) // bpp)](
             x2, smooth if smooth is not None else x2, s2, q, s, k, kb, ncb,
             HAS_SMOOTH=smooth is not None, BLOCKED=blocked, BPP=bpp,
             num_warps=_quant_warps())

--- a/src/gen_worker/models/svdq_fused.py
+++ b/src/gen_worker/models/svdq_fused.py
@@ -49,6 +49,11 @@ _RANK_ALIGN = 16
 
 _SELF_CHECK_PROBES = ((128, 512, 256), (77, 3072, 384))
 
+# Warps for the fused quant kernel, per SM — module level so a sweep can
+# rebind it (scripts/svdq_bench/bench_gemm.py) instead of editing source.
+_QUANT_WARPS_BY_SM = {100: 4, 103: 4, 120: 8, 121: 8}
+_QUANT_WARPS_DEFAULT = 4
+
 
 class SvdqFusedError(RuntimeError):
     """Typed fused-lane failure (contract mismatch — never silent-wrong)."""
@@ -240,10 +245,10 @@ def _build_fused_ops() -> Optional[tuple[Any, Any, Any]]:
     def _quant_warps() -> int:
         try:
             major, minor = torch.cuda.get_device_capability()
-            return {100: 4, 103: 4, 120: 8, 121: 8}.get(
-                major * 10 + minor, 4)
+            return _QUANT_WARPS_BY_SM.get(major * 10 + minor,
+                                          _QUANT_WARPS_DEFAULT)
         except Exception:  # noqa: BLE001
-            return 4
+            return _QUANT_WARPS_DEFAULT
 
     def _quant_launch(x2: Any, smooth: Optional[Any], s2: Any,
                       blocked: bool) -> tuple[Any, Any]:

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -347,13 +347,13 @@ def swap_svdq_linears(
     alignment fold to dense individually rather than refusing."""
     import torch
 
-    from .native_kernels import svdq_execution_lane
+    from .native_kernels import svdq_linear_lane
     from .svdq_fused import build_svdq_fused_linear, fused_shape_supported
 
     compute = compute_dtype or torch.bfloat16
     if mode not in ("blockwise", "dense"):
         mode = "blockwise" if svdq_native_available() else "dense"
-    lane = svdq_execution_lane() if mode == "blockwise" else "baseline"
+    lane = svdq_linear_lane() if mode == "blockwise" else "baseline"
     counts = {"blockwise": 0, "dense": 0, "fused": 0, "prefixes": 0,
               "linears": 0}
     for prefix in sorted(decoded):
@@ -511,10 +511,11 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
                   else "cpu")
     dev = torch.device(device)
 
-    from .native_kernels import svdq_execution_lane
+    from .native_kernels import svdq_linear_lane, svdq_modulation_lane
     from .svdq_awq_packed import awq_packed_supported, build_awq_packed_linear
 
-    lane = svdq_execution_lane() if mode == "blockwise" else "baseline"
+    lane = svdq_linear_lane() if mode == "blockwise" else "baseline"
+    mod_lane = svdq_modulation_lane() if mode == "blockwise" else "dense"
     t0 = time.perf_counter()
     plain: Dict[str, Any] = {}
     swapped = awq = awq_packed = 0
@@ -531,9 +532,11 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
                 splits = adanorm_splits_for(type(model).__name__, prefix)
                 out_f = int(target.out_features)
                 in_f = int(target.in_features)
-                # pgw#864: modulation stays packed-resident on the fused lane
-                # (the +6.8 GB delta was this dequant); degrade per-layer.
-                if lane == "fused" and awq_packed_supported(out_f, in_f):
+                # pgw#864: modulation stays packed-resident (the +6.8 GB
+                # delta was this dequant). pgw#863 split it off the linear
+                # lane — a card can want packed modulation and baseline
+                # linears at once, and sm_100 does. Degrade per-layer.
+                if mod_lane == "packed" and awq_packed_supported(out_f, in_f):
                     _set_module(model, prefix, build_awq_packed_linear(
                         tensors, out_f, in_f, adanorm_splits=splits,
                         compute_dtype=compute, device=dev))

--- a/tests/test_native_kernels_pgw860.py
+++ b/tests/test_native_kernels_pgw860.py
@@ -27,53 +27,83 @@ def _reset_arming(monkeypatch: pytest.MonkeyPatch):
 
 def test_unset_env_stays_baseline_dormant(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(nk.NATIVE_ENV, raising=False)
-    assert nk.svdq_execution_lane() == "baseline"
-    assert "env-gated" in nk.svdq_lane_reason()
+    assert nk.svdq_linear_lane() == "baseline"
+    assert "env-gated" in nk.svdq_linear_lane_reason()
+    assert nk.svdq_modulation_lane() == "dense"
+    assert "env-gated" in nk.svdq_modulation_lane_reason()
 
 
 def test_kill_switch_forces_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "0")
     # Even a passing probe must not arm past the kill-switch.
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: None)
-    assert nk.svdq_execution_lane() == "baseline"
-    assert "kill-switch" in nk.svdq_lane_reason()
+    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: None)
+    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    assert nk.svdq_linear_lane() == "baseline"
+    assert "kill-switch" in nk.svdq_linear_lane_reason()
+    assert nk.svdq_modulation_lane() == "dense"
 
 
 def test_opt_in_with_passing_probe_arms(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: None)
-    assert nk.svdq_execution_lane() == "fused"
+    monkeypatch.setattr(nk, "_gpu_sm", lambda: (120, None))
+    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: None)
+    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    assert nk.svdq_linear_lane() == "fused"
+    assert nk.svdq_modulation_lane() == "packed"
+
+
+def test_lanes_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pgw#863: a card whose fused LINEAR loses must still get the packed
+    modulation. Binding them cost sm_100 either the residency win or the
+    step time, and there was no way to take both."""
+    monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: "slower here")
+    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    assert nk.svdq_linear_lane() == "baseline"
+    assert nk.svdq_modulation_lane() == "packed"
+
+
+def test_sm100_is_excluded_from_the_fused_linear_by_measurement() -> None:
+    """The exclusion is a measured verdict, not a capability gap — sm_100 has
+    the silicon (BLACKWELL_SMS) and still must not take the fused linear."""
+    assert 100 in nk.BLACKWELL_SMS
+    assert 100 in nk.PACKED_MODULATION_SMS
+    assert 100 not in nk.FUSED_LINEAR_SMS
+    reason = nk._probe_fused_linear(100)
+    assert reason and "SLOWER" in reason
 
 
 def test_opt_in_with_failing_probe_degrades_with_reason(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: "no fp4 here")
-    assert nk.svdq_execution_lane() == "baseline"
-    assert nk.svdq_lane_reason() == "no fp4 here"
+    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: "no fp4 here")
+    assert nk.svdq_linear_lane() == "baseline"
+    assert nk.svdq_linear_lane_reason() == "no fp4 here"
 
 
 def test_opt_in_probe_raise_degrades_not_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def boom() -> str:
+    def boom(sm: int) -> str:
         raise RuntimeError("driver exploded")
 
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", boom)
-    assert nk.svdq_execution_lane() == "baseline"
-    assert "driver exploded" in nk.svdq_lane_reason()
+    monkeypatch.setattr(nk, "_probe_fused_linear", boom)
+    assert nk.svdq_linear_lane() == "baseline"
+    assert "driver exploded" in nk.svdq_linear_lane_reason()
 
 
 def test_real_probe_on_this_host_degrades_cleanly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """On a box without Blackwell the REAL probe must return a reason, never
-    raise (on sm_100/120 CI runners this instead arms — also fine)."""
+    raise (on an sm_120 runner this instead arms — also fine)."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    assert nk.svdq_execution_lane() in ("baseline", "fused")
-    assert nk.svdq_lane_reason()
+    assert nk.svdq_linear_lane() in ("baseline", "fused")
+    assert nk.svdq_linear_lane_reason()
+    assert nk.svdq_modulation_lane() in ("dense", "packed")
+    assert nk.svdq_modulation_lane_reason()
 
 
 # --- extension probe -------------------------------------------------------
@@ -180,7 +210,8 @@ def test_swap_picks_fused_lane_when_armed(
         pytest.skip("triton unavailable")
     dec = _tiny_decoded()
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_execution_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "packed")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts == {"blockwise": 0, "dense": 0, "fused": 1, "prefixes": 1,
                       "linears": 1}
@@ -190,7 +221,8 @@ def test_swap_picks_fused_lane_when_armed(
 def test_swap_baseline_when_lane_off(monkeypatch: pytest.MonkeyPatch) -> None:
     dec = _tiny_decoded()
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_execution_lane", lambda: "baseline")
+    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "baseline")
+    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "dense")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts["fused"] == 0
     assert counts["blockwise"] == 1
@@ -209,7 +241,8 @@ def test_swap_unsupported_shape_degrades_to_blockwise(
         second_kind=dec.second_kind, rank=0, proj_down=None, proj_up=None,
         smooth_factor=dec.smooth_factor, bias=dec.bias)
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_execution_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "packed")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts["fused"] == 0
     assert counts["blockwise"] == 1


### PR DESCRIPTION
## What this measured

pgw#863 asked for the B200 half of the native-kernel programme: verify what
transfers from the sm_120 fused lane, then close the gap with CUTLASS
templates. The measurement came first, and it inverted the plan.

One B200 (pod `aokw0wficrhwkb`, run `b200-r3`), same official nunchaku
fp4_r128 artifact and same instrument as the banked 5090 table:

| nvfp4 svdq posture, 1328²/28/cfg4.5 | ms/step | e2e s/img | transformer-resident |
|---|---|---|---|
| baseline triton lane, eager | 633 | 18.07 | 22.8 GB |
| **baseline triton lane, compiled** | **312** | **8.92** | 22.8 GB |
| native fused lane, eager | 665 | 18.94 | 13.3 GB |
| native fused lane, compiled | 385 | 10.92 | **13.3 GB** |

Everything armed and everything was correct — activation quant **bit-identical**
to the pgw#685 chain on every sampled real activation, **0/24** units worse than
baseline against an fp32 reference. The fused lane is simply **19% slower than
the same artifact on our own baseline lane under torch.compile** (34% at 1024²),
while being **9.5 GB smaller**. The profile shows why: the baseline's open
elementwise chain (`mul` ×26460 / `add` ×24040 / `div` ×14410 per forward) is
fused better by inductor than by our hand-fused custom ops, and a custom op is
opaque to inductor. On a 5090 the fusion wins. Both are true.

## What changed

**1. The lane is now two lanes.** `svdq_execution_lane()` gated BOTH the W4A4
linear fusion and pgw#864's packed W4A16 modulation, so on sm_100 it offered a
choice between 9.5 GB and 19% of step time and no way to take both — which is
not a choice the artifact or the card forces. Split into
`svdq_linear_lane()` (armed on `FUSED_LINEAR_SMS = (120, 121)`) and
`svdq_modulation_lane()` (all Blackwell), each with its own probe, self-check
and recorded degrade reason. sm_100 now takes both wins.

The sm_100 exclusion is a **measurement, not a capability gap**, and the refusal
reason says so.

**2. Contiguous-load activation quantizer for sm_100.** The quantizer ran at
9-21% of B200's own measured 6003 GB/s copy roofline (~93% on a 5090). The full
(blocks-per-program × warps) sweep moved nothing — the shipped config is within
0-6% of the best cell in the entire sweep, which is worth recording so nobody
re-buys that pod. The gap is the stride-2 even/odd load pair the nibble packer
wants. A contiguous `[BPP,16]` tile + register de-interleave measures
**1.10-1.73×** faster, bit-identical in both scale layouts. Selected by SM;
sm_120 keeps the strided kernel (pgw#862 measured re-layout as slower there).

**3. The bench is now a repeatable instrument** (`scripts/svdq_bench/`), promoted
out of the one-shot tracker scripts and generalised over the card, so the sm_100
row is the *same* instrument that produced the sm_120 one. Every arm records its
executed lane rather than trusting the env it was launched with; evidence is
banked off-pod after every cell; teardown is REST DELETE + GET-404 + podguard.

## What this retires

- The **pure-triton `tl.dot_scaled` GEMM — this issue's registered "seed" —
  does not COMPILE on sm_100** with torch 2.13.0+cu130
  (`TritonGPUAccelerateMatmul` MLIR pass failure). Absent, not slow. Arming is
  unaffected (the op is registered lazily; the serving path never launches it).
- **CUTLASS template instantiation is not justified.** cuBLAS block-scaled fp4
  already beats bf16 1.9× on the wide MLP units and 1.0× on the square attention
  projections; it loses (0.36×) only on the short text-stream unit, where the
  quantize pass is most of the cost. The step time is dominated elsewhere.

## Harness defects found the expensive way, and fixed

Three rentals died before the measuring one, each on something that reads as
something else — all fixed here: the driver dropped `SSH_AUTH_SOCK` (this box's
runpod key is passphrase-protected, so `-i` alone can never authenticate, and
the retry loop swallowed ssh's stderr for 90 attempts); the post-overlay version
census was wired into the overlay's exit status, so a missing `__version__`
returned non-zero → `finally` → DELETE on a healthy pod; and the fetcher read
`f["url"]` when the hub returns `chunk_urls` for every large object, then
asserted on the result, destroying a pod carrying 70 GB of correct artifacts.
Cells are now isolated — an arm that fails is a missing row, not a lost pod — and
optional artifacts drop only their own arms.

## Evidence + cost

`~/cozy/samples/pgw863-b200-20260803/` (+ `pgw863-h100-20260803/`): per-arm JSON,
renders, kernel profiles, LPIPS, correctness, driver logs, and the tuning
console transcript. Tracker: pgw#863 (verdict), pgw#865 (format matrix),
pgw#770 (its sm_100 re-gate PASSED as a by-product — the same official artifact
that scored LPIPS 0.8215 through the broken decoder now scores 0.1443).

~$14 of GPU across B200 + H100; every pod REST-DELETE + 404 verified, account at
zero.

## Not in this PR, and it is the actual shipping blocker

`svdq.py:SVDQ_FP4_SMS = (120, 121)` drives the published placement stamp
(`sm_allowed=[120,121]`, `engines=["nunchaku"]`) and `hub_policy.fit_for_binding`,
so a worker on a B200 refuses an svdq-fp4 binding outright before any of this can
run. Opening that window is a decision for Paul against the format matrix, where
nvfp4 is the slowest compiled arm on B200 and its only win is residency.
