### PR TITLE
pgw#929: wire report_podguard_status into mint boot — it shipped with no caller

### DIFF
--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1450,6 +1450,13 @@ def mint(
     positions are pushed out live, and the last one pushed is what an aborted
     table reports as ``at``.
     """
+    # pgw#929: say the podguard state ONCE, before any compile. `invalid` means
+    # this pod's progress signal goes nowhere, and a mint that looks
+    # unprogressing to the watchdog gets reaped mid-compile — the failure the
+    # `_touch_pod_progress` beats below exist to prevent. Reporting it only when
+    # a beat fires would announce the problem after the expensive part has
+    # started; reporting it here makes a broken handoff visible at boot.
+    report_podguard_status()
     progress = MintProgress(
         inductor_configs=inductor_configs, on_progress=on_progress)
     if phase_snapshot is not None:


### PR DESCRIPTION
`dev` is red. The pgw#849 unreached-public-surface guard reports exactly **one NEW entry**:

```
NEW unreached public surface: gen_worker.aot_mint.report_podguard_status()
  Nothing on the pod's production path calls this. This is the program's dominant
  defect class (pgw#849) — wire it, delete it, or add an exemption WITH A REASON.
```

It was added by the pgw#929 env work (`PODGUARD_STATE` retained, reporting `armed|not_present|invalid`) and nothing calls it. The other 20 entries are baselined and unchanged.

**Wired rather than deleted or exempted**, because its docstring already states the purpose — *"log the podguard state once, so a broken handoff is visible at boot"* — and the purpose is real: `PODGUARD_STATE=invalid` means this pod's progress signal goes nowhere, and **a mint that looks unprogressing to the watchdog gets reaped mid-compile**. That is precisely the failure the `_touch_pod_progress` beats further down exist to prevent, so the state they depend on deserves to be said out loud once.

Called at the top of `mint()`, before any compile, rather than from a beat — a beat would announce the problem only after the expensive part had already started.

## Verification

`scripts/lint_unreached_surface.py`: **21 unreached → 20, no NEW entries, exit 0.** Syntax checked.

**Heavy suites deliberately not run:** box 1-minute load was **62** against a ceiling of 24 (several sibling lanes finishing at once). This is a two-line call-site addition, and the static guard that flagged it is the gate that matters for it. If you would rather it wait for a full suite, hold the merge — but `dev` stays red until this or an exemption lands.