### PR TITLE
pgw#923 + pgw#924: one adoption vocabulary, and a boot ladder whose every phase has a producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,46 @@ producer materializes the half of its output tree it did not compute.
   component is still passed through by inode, and a `-NNNNN-of-MMMMM` set with no index is
   still REFUSED rather than published.
 
+- **pgw#923 + pgw#924: two telemetry lanes that reported zeros.** A lane that reports zeros is
+  worse than an absent one — it looks like a measurement.
+  - **The adoption fact had three spellings and the measured one was empty.** th#1329/th#1352's
+    `compile_cache_adopt` — durable, two partial indexes, a p50/p95/max admin surface — held
+    **0 rows on both live stacks**, while every real adoption rode free-text `aot_adopt` at
+    `duration_ms=0` (5 rows chaos, 27 master) and `trt_adopt` held 0. Z-gated, not unused: the
+    only sender of the measured `ModelEvent{ADOPTED}` was the hub-commanded
+    `ADOPT_COMPILE_CACHE` handler, which no stack has ever dispatched. Real adoptions are boot
+    attaches through `fleet_cells`, and that path sent no `ModelEvent` at all. The mechanism was
+    a return type: `aot_serve.enable` / `provision.arm_aot` / `provision.enable_compiled` /
+    `trt_engine.enable` narrated the outcome into an event and returned a bool, so the frame
+    that knew the outcome was not the frame that owns the wire. **They now return a typed
+    `AdoptOutcome`** (`gen_worker.cell_adopt`; still truthy/falsy, so every
+    `if enable_compiled(...)` reads unchanged), `fleet_cells.enable_compiled` measures each arm
+    onto `ArmOutcome.adoptions`, and `Executor._report_adoptions` sends one `ModelEvent` per
+    attempt after the boot warmup so `duration_ms` (arm) and `warmup_s` (what the armed cell
+    still costs) are both real. `operation_id` stays empty — already the wire contract's own
+    name for a boot-attached cell, so no proto or hub change is needed. `aot_adopt` and
+    `trt_adopt` are DELETED; their tokens survive as `adopt_failed:<reason>`, the grammar the
+    commanded path already uses, so one `kind=compile_cache_adopt` query returns the whole
+    outcome distribution. The STORE_SERVED_BOOT_COMPILED alarm stops hijacking
+    `ModelEvent{ADOPTED}` with `duration_ms` redefined as inductor compile wall — a second
+    meaning for the one field that lane percentiles over — and gets its own typed event.
+  - **The boot ladder declared 17 phases and had 8 producers.** `process_start`, `env_seal`,
+    `manifest_load`, `cache_preflight`, `cuda_probe`, `cell_load` and `first_request` had no
+    producer anywhere in `src/` — only unit tests constructed them — and are deleted.
+    `cell_arm` was in the same state but is RETAINED and its producer BUILT: it brackets the
+    real arm in `fleet_cells`, over the same interval the adoption reports, so the ladder and
+    the hub's measurement cannot disagree about what an arm cost. `warm_complete` is deleted
+    for a stronger reason — live rows reach **4,863,664 ms**, eighty minutes past the boot it
+    claimed to be a phase of (the deferred background mint) — while the mint-goal latch and the
+    pgw#805 eager-forever backstop it also performed are kept. `warmup` is the §4.22 defect:
+    the bracket opened unconditionally around a plan that is empty on most setup slots, so
+    240/240 boot rows and 336/336 activity events read `duration_ms=0`. It is now recorded only
+    when a forward actually ran, with the count in `detail` — "nobody warmed" and "warming was
+    free" stop being the same row. `warmup_iteration` is deleted on the vocabulary ruling, not
+    on absence: it is NOT unwired, the pgw#797 real-boot harness fires it, and its zero on both
+    stacks is traffic. `graph_class` (0/517 live) is no longer produced; the proto field is a
+    vendored artifact under a digest gate, so its removal is tensorhub's.
+
 - **pgw#942: three SDK holes the 28 endpoints were each paying for, closed once.**
   The framing, and the reason a P2 was worth doing: *if 28 endpoints all write the same
   fifteen lines to do something ordinary, that is an SDK gap.* Measured across the

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -74,7 +74,6 @@ KIND_SHAPE_GAP = "shape_gap"
 # ``detail`` naming the identifiers (ref/function/label/request) + the
 # exception. Fail-soft BEHAVIOR is unchanged — these are confessions.
 KIND_SERVE_DEGRADE = "serve_degrade"
-KIND_TRT_ADOPT = "trt_adopt"
 KIND_LORA_HYGIENE = "lora_hygiene"
 # pgw#794: the serve-side adapter-fidelity gate. `phase=refused` is a
 # fail-CLOSED decision (the request also gets a typed error); `phase=degraded`

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -85,6 +85,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Seque
 
 from . import activity as activity_mod
 from . import host_isa
+from .cell_adopt import AdoptOutcome
 from . import shape_growth
 from .compile_cache import (
     AdoptError,
@@ -101,12 +102,6 @@ METADATA_NAME = "metadata.json"
 PACKAGE_NAME = "model.pt2"
 LITERALS_NAME = "constants.safetensors"
 ARTIFACT_KIND = "aot-inductor"
-#: pgw#733 (arm half): every adopt/arm outcome of an AOT artifact — success
-#: AND every classified refusal — rides this ONE typed wire event. ``phase``
-#: carries the outcome class (``armed`` / the AdoptError reason), countable
-#: hub-side; ``detail`` names the candidate cell. Hub-spawned workers expose
-#: no stdout, so a reason that only reaches the logger does not exist.
-ADOPT_EVENT = "aot_adopt"
 #: pgw#791: an input the artifact was compiled for as 16-byte aligned arrived
 #: unaligned (or non-contiguous) and this ingress realigned it. Typed and
 #: hub-visible because the ALTERNATIVE is what shipped: AOTInductor's own
@@ -2153,44 +2148,42 @@ def enable(
     cfg: Any,
     cache_dir: Optional[Path] = None,
     artifact: Optional[Path] = None,
-) -> bool:
+) -> AdoptOutcome:
     """Consumer entry point: verify + load + bind + swap an AOTI artifact.
 
-    Returns False (staying eager) on ANY miss — the caller's ordinary miss
-    policy (fleet self-mint / eager / typed refusal) takes over, exactly as
-    for a TRT engine. Returning True IS the HIT: ``fleet_cells`` treats it
-    as a genuine match and skips the self-mint.
+    Falsy (staying eager) on ANY miss — the caller's ordinary miss policy
+    (fleet self-mint / eager / typed refusal) takes over, exactly as for a TRT
+    engine. Truthy IS the HIT: ``fleet_cells`` treats it as a genuine match and
+    skips the self-mint.
+
+    pgw#923: the outcome is RETURNED rather than narrated. The classified
+    refusal reason used to leave this function only as the ``phase`` of a
+    free-text ``aot_adopt`` event, which is why the adoption that actually
+    happens on every boot had no measured row anywhere — the caller could not
+    see what it had just been told.
     """
     if artifact is None:
-        return False
+        return AdoptOutcome.miss("no_artifact")
     try:
         meta = load_and_wrap(pipeline, cfg, Path(artifact), cache_dir=cache_dir)
     except Exception as exc:
         reason = str(getattr(exc, "reason", "") or "") or type(exc).__name__
+        identity = _adopt_identity(Path(artifact))
         logger.warning(
             "aot-serve: artifact unusable (%s: %s); staying eager",
             reason, exc)
-        activity_mod.emit_event(
-            ADOPT_EVENT,
-            f"{_adopt_identity(Path(artifact))}: "
-            f"{type(exc).__name__}: {exc}",
-            phase=reason,
-        )
-        return False
+        return AdoptOutcome.miss(
+            reason, f"{identity}: {type(exc).__name__}: {exc}", identity)
     logger.info(
         "aot-serve: armed %s [%d entr%s] (sku=%s torch=%s precision=%s, "
         "constants bound from resident weights)",
         meta.get("family"), len(meta.get("entries") or {}),
         "y" if len(meta.get("entries") or {}) == 1 else "ies",
         meta.get("sku"), meta.get("torch"), meta.get("precision"))
-    activity_mod.emit_event(
-        ADOPT_EVENT,
+    return AdoptOutcome.hit(
         f"family={meta.get('family')} key={meta.get('cell_key')} "
         f"entries={len(meta.get('entries') or {})} sku={meta.get('sku')} "
-        f"torch={meta.get('torch')} precision={meta.get('precision')}",
-        phase="armed",
-    )
-    return True
+        f"torch={meta.get('torch')} precision={meta.get('precision')}")
 
 
 def _marker_states(pipeline: Any) -> List[Dict[str, Any]]:
@@ -2357,7 +2350,7 @@ def unwrap(pipeline: Any) -> bool:
 
 
 __all__ = [
-    "ADOPT_EVENT",
+    "AdoptOutcome",
     "ARTIFACT_FORMAT",
     "ARTIFACT_KIND",
     "ArtifactContract",

--- a/src/gen_worker/boot_phases.py
+++ b/src/gen_worker/boot_phases.py
@@ -49,31 +49,39 @@ from .pb import worker_scheduler_pb2 as pb
 logger = logging.getLogger(__name__)
 
 # --- phase vocabulary (wire-shared with tensorhub's bootphase.go) -----------
-# Reuses the entrypoint's existing de-facto boot phase names (_log_startup_phase)
-# rather than inventing a second vocabulary for the same milestones.
-PHASE_PROCESS_START = "process_start"
-PHASE_ENV_SEAL = "env_seal"
-PHASE_MANIFEST_LOAD = "manifest_load"
-PHASE_CACHE_PREFLIGHT = "cache_preflight"
-PHASE_CUDA_PROBE = "cuda_probe"
+# pgw#924: EXACTLY eight values, and every one of them has a production
+# producer on the shipping path. The previous vocabulary declared seventeen;
+# eight of those (`process_start`, `env_seal`, `manifest_load`,
+# `cache_preflight`, `cuda_probe`, `cell_load`, `first_request`, and — as a
+# phase — `cell_arm`) were constructed only by unit tests, and
+# `warmup_iteration` was wired to a body that never ran. A declared phase with
+# no producer is not "coverage we have not gotten to": every reader of the
+# ladder saw a name that could only ever report nothing, which is a default
+# read as a fact. `warm_complete` is deleted for a different and stronger
+# reason — live rows reach 4,863,664 ms, i.e. eighty minutes after the boot it
+# was supposedly a phase of. It is a serving-tier disposition, not a boot
+# phase, and it now lives only where it belongs (the mint-goal latch and the
+# `self_mint_skipped` backstop).
 PHASE_HELLO = "hello"
 PHASE_WEIGHTS_FETCH = "weights_fetch"
 PHASE_PIPELINE_LOAD = "pipeline_load"
 #: pgw#797: the warmup forwards, split OUT of `pipeline_load` and nested under
 #: it, so `pipeline_load` becomes weights->VRAM by subtraction and "what does a
 #: cell save on warmup" is a column instead of an estimate.
+#:
+#: pgw#924: emitted ONLY when warm work actually runs. It used to bracket the
+#: warm call unconditionally, and on the shipping path — where most setup slots
+#: plan no warm units at all — that produced 240 live rows of `duration_ms=0`.
+#: A skipped warmup now emits no row, because "nobody warmed" and "warming was
+#: free" are different answers and only one of them was ever true.
 PHASE_WARMUP = "warmup"
-#: One warm forward. The first iteration dominates (allocator growth, CUDA
-#: module load, cuDNN/cuBLAS algorithm selection), so a warmup total without the
-#: shape of the sequence cannot answer what a cell removes.
-PHASE_WARMUP_ITERATION = "warmup_iteration"
 PHASE_CELL_DISCOVER = "cell_discover"
 PHASE_CELL_FETCH = "cell_fetch"
-PHASE_CELL_LOAD = "cell_load"
+#: pgw#923/#924: the arm of ONE delivered or discovered cell. Its duration is
+#: the same quantity the hub stores as the adoption's `duration_ms`, measured
+#: once, in the one place that does the arming.
 PHASE_CELL_ARM = "cell_arm"
 PHASE_FIRST_REQUEST_SERVABLE = "first_request_servable"
-PHASE_FIRST_REQUEST = "first_request"
-PHASE_WARM_COMPLETE = "warm_complete"
 
 #: The boot's closing milestone: the phase whose completion means this worker
 #: can serve. Everything after it is optimization, not boot.
@@ -87,27 +95,23 @@ CLASS_LOAD = "load"        # weights -> VRAM, cell load+arm
 CLASS_SETUP = "setup"      # probes, seals, manifests, handshake
 
 _CLASS_BY_PHASE: Dict[str, str] = {
-    PHASE_PROCESS_START: CLASS_SETUP,
-    PHASE_ENV_SEAL: CLASS_SETUP,
-    PHASE_MANIFEST_LOAD: CLASS_SETUP,
-    PHASE_CACHE_PREFLIGHT: CLASS_SETUP,
-    PHASE_CUDA_PROBE: CLASS_SETUP,
     PHASE_HELLO: CLASS_SETUP,
     PHASE_WEIGHTS_FETCH: CLASS_FETCH,
     PHASE_CELL_DISCOVER: CLASS_SETUP,
     PHASE_CELL_FETCH: CLASS_FETCH,
-    PHASE_CELL_LOAD: CLASS_LOAD,
     PHASE_CELL_ARM: CLASS_LOAD,
     PHASE_PIPELINE_LOAD: CLASS_LOAD,
     # pgw#797: an UNARMED warm pays the compile; an ARMED one pays only the
     # call. The default is the expensive reading; `span(..., klass=)` overrides
     # per row, which is why classification is a lookup and not a constant.
     PHASE_WARMUP: CLASS_COMPILE,
-    PHASE_WARMUP_ITERATION: CLASS_COMPILE,
-    PHASE_WARM_COMPLETE: CLASS_COMPILE,
     PHASE_FIRST_REQUEST_SERVABLE: CLASS_SETUP,
-    PHASE_FIRST_REQUEST: CLASS_COMPILE,
 }
+
+#: The complete vocabulary (pgw#924). Exported so a test can assert the
+#: declaration and the production producers are the SAME set — the property
+#: that failed here, silently, for seventeen names.
+PHASES: frozenset = frozenset(_CLASS_BY_PHASE)
 
 
 def phase_class(phase: str, ordinal: int = 0) -> str:
@@ -365,7 +369,6 @@ class BootSpan:
             artifact_kind=self._row.artifact_kind,
             artifact_key=self._row.artifact_key,
             function=self._row.function,
-            graph_class=self._row.graph_class,
             outcome=outcome,
             reason=reason[:300],
             detail=detail[:2000],
@@ -379,7 +382,6 @@ def open_span(
     function: str = "",
     artifact_kind: str = "",
     artifact_key: str = "",
-    graph_class: str = "",
     parent: Optional[int] = None,
     klass: str = "",
 ) -> BootSpan:
@@ -412,7 +414,6 @@ def open_span(
         function=function,
         artifact_kind=artifact_kind,
         artifact_key=artifact_key,
-        graph_class=graph_class,
     )
     _emit(row)
     return BootSpan(phase, ordinal, parent, row)
@@ -426,7 +427,6 @@ def span(
     function: str = "",
     artifact_kind: str = "",
     artifact_key: str = "",
-    graph_class: str = "",
     parent: Optional[int] = None,
     klass: str = "",
 ) -> Iterator[BootSpan]:
@@ -439,8 +439,7 @@ def span(
     """
     handle = open_span(
         phase, ref=ref, function=function, artifact_kind=artifact_kind,
-        artifact_key=artifact_key, graph_class=graph_class,
-        parent=parent, klass=klass,
+        artifact_key=artifact_key, parent=parent, klass=klass,
     )
     token = _stack_var.set(_stack_var.get() + (handle.ordinal,))
     try:
@@ -463,19 +462,25 @@ def mark(
     function: str = "",
     artifact_kind: str = "",
     artifact_key: str = "",
-    graph_class: str = "",
     bytes_moved: int = 0,
     source: str = "",
     outcome: str = OUTCOME_OK,
     reason: str = "",
     detail: str = "",
     klass: str = "",
+    parent: Optional[int] = None,
 ) -> None:
     """Record an instantaneous boot MILESTONE as a single closed row.
 
     ``since_process_start=True`` measures the milestone from OS process start —
     which is what "time to first-request-servable" means and what the
     autoscaler's cold-boot horizon needs.
+
+    ``parent`` names the enclosing span's ordinal EXPLICITLY, for the same
+    reason :func:`open_span` takes one: a phase measured across an ``await``
+    boundary cannot read its parent off the implicit stack. pgw#924's `warmup`
+    is exactly that shape — it is decided and measured around the warm call but
+    only recorded once its cost is known to be real.
 
     A boot-CLOSING milestone (:data:`SERVABLE_PHASES`) recorded before ``hello``
     is HELD, not emitted: see the ``_hello_seen`` note. It is released, with its
@@ -491,7 +496,7 @@ def mark(
                         since_process_start=since_process_start,
                         ref=ref, function=function,
                         artifact_kind=artifact_kind, artifact_key=artifact_key,
-                        graph_class=graph_class, bytes_moved=bytes_moved,
+                        bytes_moved=bytes_moved,
                         source=source, outcome=outcome, reason=reason,
                         detail=detail,
                     )
@@ -508,7 +513,10 @@ def mark(
     # the servable mark rides a StateDelta task created inside the setup span,
     # so it INHERITED that span's context. Cumulative rows are top-level, by
     # construction rather than by the caller remembering.
-    parent = 0 if since_process_start else (_stack()[-1] if _stack() else 0)
+    if since_process_start:
+        parent = 0
+    elif parent is None:
+        parent = _stack()[-1] if _stack() else 0
     if klass:
         with _lock:
             _class_override[ordinal] = klass
@@ -540,7 +548,6 @@ def mark(
         function=function,
         artifact_kind=artifact_kind,
         artifact_key=artifact_key,
-        graph_class=graph_class,
         outcome=outcome,
         reason=reason[:300],
         detail=detail[:2000],
@@ -701,23 +708,15 @@ __all__ = [
     "recorded_rows",
     "reset_for_tests",
     "servable_ms",
-    "PHASE_PROCESS_START",
-    "PHASE_ENV_SEAL",
-    "PHASE_MANIFEST_LOAD",
-    "PHASE_CACHE_PREFLIGHT",
-    "PHASE_CUDA_PROBE",
+    "PHASES",
     "PHASE_HELLO",
     "PHASE_WEIGHTS_FETCH",
     "PHASE_PIPELINE_LOAD",
     "PHASE_WARMUP",
-    "PHASE_WARMUP_ITERATION",
     "PHASE_CELL_DISCOVER",
     "PHASE_CELL_FETCH",
-    "PHASE_CELL_LOAD",
     "PHASE_CELL_ARM",
     "PHASE_FIRST_REQUEST_SERVABLE",
-    "PHASE_FIRST_REQUEST",
-    "PHASE_WARM_COMPLETE",
     "OUTCOME_OK",
     "OUTCOME_REFUSED",
     "OUTCOME_FAILED",

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -1,0 +1,87 @@
+"""The ONE adoption vocabulary (pgw#923).
+
+Adopting a pre-built compiled cell — hub-delivered or catalog-discovered — used
+to be described twice. The typed description rode ``ModelEvent{ADOPTED}``
+(``duration_ms``, ``cache_hits``, ``cache_misses``, ``warmup_s``), which the hub
+persists as ``worker_activity_events.kind='compile_cache_adopt'`` with two
+partial indexes and a p50/p95/max admin surface. The other description was a
+free-text ``aot_adopt`` activity event that put ``family=… key=… sku=…`` in
+prose and no numbers anywhere.
+
+Only the free-text one was ever reachable from the path adoptions actually take
+(boot attach through ``fleet_cells``); the typed one was reachable only from the
+hub-commanded ``ADOPT_COMPILE_CACHE`` operation, which no stack has ever
+dispatched. So the measured lane had zero rows on both live stacks while every
+real adoption landed at ``duration_ms=0``, and the percentile endpoint
+aggregated a population with no members.
+
+The free-text lane is DELETED. This module is what replaced it: the arm returns
+a typed outcome instead of a bare bool, the arming policy times it and names the
+candidate, and the executor — the one component that owns the wire — turns it
+into the ``ModelEvent`` the hub already knows how to store. One fact, one
+spelling, and the spelling that carries numbers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["AdoptOutcome", "CellAdoption"]
+
+
+@dataclass(frozen=True)
+class AdoptOutcome:
+    """The result of arming ONE candidate artifact on ONE pipeline.
+
+    Truthy exactly when the cell armed, so the many ``if enable_compiled(...)``
+    call sites read unchanged while the classified refusal — previously
+    reachable only as the ``phase`` of a free-text event — becomes a value the
+    caller can act on and put on the wire.
+
+    ``reason`` is the short, stable, countable token (an ``AdoptError.reason``,
+    a lane-gate refusal, ``no_cell``); ``detail`` is the human sentence.
+    ``identity`` carries ``family=… key=…`` when the candidate's own metadata
+    could be read — a refusal must still name the cell it refused, including
+    when the refusal IS a metadata problem.
+    """
+
+    armed: bool
+    reason: str = ""
+    detail: str = ""
+    identity: str = ""
+
+    def __bool__(self) -> bool:
+        return self.armed
+
+    @classmethod
+    def hit(cls, identity: str = "") -> "AdoptOutcome":
+        return cls(armed=True, identity=identity)
+
+    @classmethod
+    def miss(cls, reason: str, detail: str = "", identity: str = "") -> "AdoptOutcome":
+        return cls(armed=False, reason=reason, detail=detail[:2000], identity=identity)
+
+
+@dataclass(frozen=True)
+class CellAdoption:
+    """One adoption ATTEMPT, measured, with the identity the hub fences on.
+
+    ``arm_ms`` is the wall time of the arm itself — load, bind, wrap, gate —
+    and is the same quantity the hub stores as the adoption's ``duration_ms``.
+    The warmup half is deliberately absent: a boot-attached cell is armed during
+    injection and warmed later, by the setup warmup, so the two numbers are
+    known at two different instants and the executor joins them. A hot
+    (hub-commanded) adoption arms and warms in one frame and fills both there.
+    """
+
+    ref: str
+    snapshot_digest: str
+    artifact_kind: str
+    arm_ms: int
+    armed: bool
+    reason: str = ""
+    detail: str = ""
+    #: ``id()`` of the pipeline this attempt armed, so the executor can join the
+    #: adoption to that object's own warmup proof (its cache hit/miss deltas)
+    #: instead of attributing another slot's evidence to it.
+    pipeline_id: int = 0

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2911,6 +2911,12 @@ class _InjectionResult:
     # that ended this setup WITHOUT an armed cell. Carried into the record, so
     # the reason outlives the function that computed it.
     eager_postures: List[str] = dc_field(default_factory=list)
+    # pgw#923: every measured adoption ATTEMPT this injection made, in order.
+    # The arm happens here; the warmup that prices it happens after setup
+    # returns, so the terminal wire event is sent once BOTH halves are known —
+    # which is exactly why the boot-attached adoption never had a measured row
+    # while the hub-commanded one (arm and warm in a single frame) did.
+    adoptions: List["fleet_cells.CellAdoption"] = dc_field(default_factory=list)
 
     def add_compile_object(
         self, pipeline: Any, slots: typing.Iterable[str],
@@ -3220,6 +3226,9 @@ class Executor:
         self._warm_contract_runs: Dict[Any, set] = {}
         # pgw#797: warm forwards counted by the in-flight `warmup` span.
         self._warm_iterations: int = 0
+        # pgw#923: the boot warmup's measured cost, joined onto the
+        # adoption event for every cell this boot attached.
+        self._boot_warm_ms: int = 0
         # Hardware-gate failures: fn name -> (reason, detail, axes).
         self.unavailable: Dict[str, Tuple[str, str, Dict[str, str]]] = {}
         # Runtime compile failures are owned by the exact record/target that
@@ -5816,23 +5825,20 @@ class Executor:
             return instance
 
     def _mark_warm_complete(self, rec: "_ClassRecord", function: str) -> None:
-        """Close the compiled-serving milestone once per process (pgw#797).
+        """Latch this process's compiled-serving disposition as FINAL.
 
-        `outcome` says whether compiled serving was reached at all; `ref` names
-        the cell that got there. `mark_once` keeps the several owners — inline
-        setup here, the deferred background mint — from double-claiming it.
+        pgw#924 removed the `warm_complete` BOOT PHASE this used to record. It
+        was never a phase of the boot: live rows reached 4,863,664 ms — the
+        deferred background mint finishes eighty minutes after the worker
+        became servable — so summing it against the boot window was arithmetic
+        on two different clocks, and the `first_request_servable` milestone
+        already answers "when could this worker serve". What survives is the
+        part that was always real: the mint-goal latch and the pgw#805 backstop
+        below.
         """
         armed = next(
             (t.active_compile_ref for t in rec.compile_targets.values()
              if t.active_compile_ref), "")
-        boot_mod.mark_once(
-            boot_mod.PHASE_WARM_COMPLETE,
-            since_process_start=True,
-            function=function,
-            ref=armed,
-            outcome=(boot_mod.OUTCOME_OK if armed else boot_mod.OUTCOME_REFUSED),
-            reason="" if armed else "serving_eager",
-        )
         # th#1359: reaching here means this boot's mint disposition is FINAL
         # on every path (inline setup, adopted cell, eager-without-mint, and
         # the background mint's own `finally`). The mint-goal driver waits on
@@ -5866,7 +5872,7 @@ class Executor:
     @contextmanager
     def _warmup_span(
         self, spec: EndpointSpec, rec: "_ClassRecord", inj: Any
-    ) -> typing.Iterator[Optional[boot_mod.BootSpan]]:
+    ) -> typing.Iterator[None]:
         """`warmup`, nested under the open `pipeline_load` (pgw#797).
 
         The armed/unarmed tag is the point of the row, not decoration: an
@@ -5874,43 +5880,67 @@ class Executor:
         difference between the two IS what a cell saves on warmup. They are
         separate ROWS here rather than two code paths that happen to share a
         name, so the question is a `GROUP BY`.
+
+        pgw#924: the row is emitted only when a warm forward actually ran. This
+        bracket used to open unconditionally, and most setup slots plan no warm
+        units at all (a non-inference spec, a class with no declared warmup, a
+        bare component slot), so 240 of 240 live `warmup` rows and 245 of 245
+        `warmup` activity events reported `duration_ms=0` — a bracket around
+        nothing, read by everyone downstream as "boot warmup is free". Whether
+        work ran is known only at the END of the body, so the row is recorded
+        then, against the `pipeline_load` ordinal it belongs to, rather than
+        opened on a guess.
         """
         if not boot_mod.in_boot():
-            yield None
+            yield
             return
         armed_refs = sorted(
             {sel.ref for sel in inj.active_compile_artifacts.values() if sel.ref}
         )
         armed = bool(armed_refs)
         minting = bool(inj.pending_self_mints)
-        with boot_mod.span(
-            boot_mod.PHASE_WARMUP,
-            function=spec.name,
-            # An armed warm is a LOAD-class cost; unarmed it is COMPILE.
-            klass=boot_mod.CLASS_LOAD if armed else boot_mod.CLASS_COMPILE,
-            ref=armed_refs[0] if armed_refs else "",
-            parent=rec.boot_load_ordinal or None,
-        ) as sp:
-            t0 = time.monotonic()
-            try:
-                yield sp
-            finally:
-                warm_ms = int(round((time.monotonic() - t0) * 1000))
-                sp.note(
-                    f"armed={int(armed)} minting={int(minting)} "
-                    f"iterations={self._warm_iterations} "
-                    f"refs={','.join(armed_refs[:4])}"
+        started = time.monotonic()
+        failure: Optional[BaseException] = None
+        try:
+            yield
+        except BaseException as exc:
+            failure = exc
+            raise
+        finally:
+            warm_ms = int(round((time.monotonic() - started) * 1000))
+            ran = self._warm_iterations
+            self._warm_iterations = 0
+            self._boot_warm_ms = warm_ms if ran else 0
+            if ran or failure is not None:
+                boot_mod.mark(
+                    boot_mod.PHASE_WARMUP,
+                    duration_ms=warm_ms,
+                    function=spec.name,
+                    # An armed warm is a LOAD-class cost; unarmed it is COMPILE.
+                    klass=(boot_mod.CLASS_LOAD if armed
+                           else boot_mod.CLASS_COMPILE),
+                    ref=armed_refs[0] if armed_refs else "",
+                    parent=rec.boot_load_ordinal or 0,
+                    outcome=(boot_mod.OUTCOME_FAILED if failure is not None
+                             else boot_mod.OUTCOME_OK),
+                    reason=("" if failure is None
+                            else (str(getattr(failure, "reason", "") or "")
+                                  or type(failure).__name__)),
+                    detail=(
+                        f"armed={int(armed)} minting={int(minting)} "
+                        f"forwards={ran} refs={','.join(armed_refs[:4])}"
+                    ),
                 )
                 # th#1322's numeric home, so the boot span and the activity
                 # stream agree on one number rather than two derivations.
                 activity_mod.emit_event(
                     "warmup",
                     f"boot warmup for {spec.name} "
-                    f"({'armed' if armed else 'unarmed'})",
+                    f"({'armed' if armed else 'unarmed'}, {ran} forward"
+                    f"{'' if ran == 1 else 's'})",
                     phase=activity_mod.PHASE_WARMUP_FORWARD,
                     duration_ms=warm_ms,
                 )
-                self._warm_iterations = 0
 
     def _warmup_plan(
         self, spec: EndpointSpec, rec: _ClassRecord,
@@ -6156,29 +6186,21 @@ class Executor:
                         torch.cuda.empty_cache()
                     return False
             evidence.count += 1
-            # pgw#797: per-ITERATION warm cost. The first forward is typically
-            # far slower than the rest (allocator growth, CUDA module load,
-            # cuDNN/cuBLAS algorithm selection), so a warmup total without the
-            # shape of the sequence cannot say what a cell removes — a cell
-            # removes the compile inside the FIRST forward, not the whole pass.
-            # One nested span per forward: counts are small and bounded by the
-            # declared handler set, and `iteration=` orders them.
-            iter_ms = int(round((time.monotonic() - t0) * 1000))
             if boot_mod.in_boot():
-                # Counted INSIDE the gate: a steady-state warm hours later has
-                # no `warmup` span to belong to, and letting it bump the counter
-                # would misreport the next boot span's iteration total.
+                # pgw#924: this counter is what makes the `warmup` boot row
+                # honest — it is the difference between "the warm pass cost
+                # nothing" and "there was no warm pass". Counted INSIDE the
+                # gate: a steady-state warm hours later has no boot row to
+                # belong to, and letting it bump the counter would misreport
+                # the next boot's warmup.
+                #
+                # The per-forward `warmup_iteration` row that used to be
+                # recorded here is DELETED. It was wired and never fired once
+                # on either live stack (0 rows against 240 `warmup` rows),
+                # because the plan that reaches this line is empty on the
+                # shipping path; a per-iteration decomposition of a pass that
+                # does not run is not a measurement anyone can read.
                 self._warm_iterations += 1
-                boot_mod.mark(
-                    boot_mod.PHASE_WARMUP_ITERATION,
-                    duration_ms=iter_ms,
-                    function=wj.spec.name,
-                    graph_class=str(getattr(wj, "graph_key", "") or "")[:200],
-                    detail=(
-                        f"iteration={self._warm_iterations} mode={mode} "
-                        f"armed={int(bool(objects))}"
-                    ),
-                )
             for obj in objects:
                 calls_before, trt_before, aot_before = before[id(obj)]
                 inductor_proven = (
@@ -6960,6 +6982,12 @@ class Executor:
             compile_seconds = (
                 compile_cache.compile_wall_seconds() - compile_seconds_before
                 if proves_inductor else 0.0)
+            # id(pipeline) -> (calls, cache_hits, cache_misses) observed across
+            # this setup's warmup. Declared out here because pgw#923's adoption
+            # report reads it whether or not this boot proved anything: a cell
+            # that armed and then warmed to zero hits is exactly the adoption
+            # the measurement lane exists to price.
+            proof_by_obj: Dict[int, Tuple[int, int, int]] = {}
             if proves_inductor or proves_exported:
                 # gw#595 per-object provability: the proof scopes to objects
                 # the warmup actually EXERCISED (calls>0). An exercised object
@@ -6983,7 +7011,6 @@ class Executor:
                     mint_sharers.setdefault(id(_pending), []).append(_obj_id)
                 proven_mint_objs: set[int] = set()
                 calls_by_obj: Dict[int, int] = {}
-                proof_by_obj: Dict[int, Tuple[int, int, int]] = {}
                 for candidate in inj.compile_objects:
                     pipe = candidate.pipeline
                     aot_before = aot_proof_before.get(id(pipe))
@@ -7383,14 +7410,24 @@ class Executor:
                     except Exception:
                         logger.debug(
                             "fx-key forensics unavailable", exc_info=True)
-                    await self._send(pb.WorkerMessage(model_event=pb.ModelEvent(
-                        ref=ref,
-                        state=pb.MODEL_STATE_ADOPTED,
-                        snapshot_digest=digest,
-                        cache_hits=hits,
-                        cache_misses=misses,
+                    # pgw#923: this alarm used to ride the ADOPTED ModelEvent
+                    # with `duration_ms` redefined to mean "inductor compile
+                    # wall" — a second meaning for the one field the adoption
+                    # measurement lane percentiles over. It has its own typed
+                    # event now, so `compile_cache_adopt.duration_ms` means the
+                    # arm, always, and this alarm keeps its own number.
+                    activity_mod.emit_event(
+                        "store_served_boot_compiled",
+                        f"family={family} cell={ref} digest={digest}: a "
+                        f"store-served boot burned {compile_seconds:.1f}s of "
+                        f"inductor compile wall (alarm threshold "
+                        f"{_STORE_SERVED_COMPILE_ALARM_S:.0f}s, cache_hits="
+                        f"{hits} cache_misses={misses}) — the delivered cell "
+                        f"is not serving the graphs this boot compiled",
+                        phase="alarm",
                         duration_ms=int(compile_seconds * 1000),
-                    )))
+                    )
+            await self._report_adoptions(inj, proof_by_obj)
             # pgw#815: THE assertion. `finalize completed` must be
             # unreachable while a mint obligation is unresolved — running it
             # OUTSIDE the `proves_inductor or proves_exported` block is the
@@ -8720,6 +8757,7 @@ class Executor:
                             outcome = await _to_thread_complete(
                                 self._enable_compiled,
                                 pipe, spec.compile_cell(), compile_artifact,
+                                compile_selection,
                             )
                         except compile_cache.CompiledLaneUnavailableError as exc:
                             # Mandatory (w8a8/w4a4) lane: self-mint also hit a
@@ -8735,6 +8773,7 @@ class Executor:
                             raise
                         armed = outcome.armed
                         pipe_mint = outcome.self_mint
+                        result.adoptions.extend(outcome.adoptions)
                         # pgw#824: the arming brain already classified WHY it
                         # is not arming; without carrying it here the reason
                         # died at the end of this function and every eager
@@ -9921,6 +9960,7 @@ class Executor:
 
     def _enable_compiled(
         self, pipe: Any, cfg: Any, artifact: Optional[Path],
+        delivered: Optional["_CompileArtifactSelection"] = None,
     ) -> "fleet_cells.ArmOutcome":
         """Arm the best available compiled path for a freshly loaded pipeline.
 
@@ -9943,6 +9983,8 @@ class Executor:
         return fleet_cells.enable_compiled(
             pipe, cfg, self.store._cache_dir, artifact,
             publisher=self._cell_publisher(),
+            delivered_ref=delivered.ref if delivered else "",
+            delivered_digest=delivered.snapshot_digest if delivered else "",
         )
 
     def _arming_enable(
@@ -10056,6 +10098,79 @@ class Executor:
         finally:
             if self._compile_cache_adoption_active == intent_id:
                 self._compile_cache_adoption_active = ""
+
+    async def _report_adoptions(
+        self,
+        inj: "_InjectionResult",
+        proof_by_obj: Dict[int, Tuple[int, int, int]],
+    ) -> None:
+        """Send ONE terminal `ModelEvent` per boot-attached adoption (pgw#923).
+
+        This is the producer the `compile_cache_adopt` measurement lane never
+        had. th#1329/th#1352 gave the hub a durable, indexed, percentile-backed
+        home for "what did arming this cell cost, and what does it still cost
+        at warm time" — and both live stacks held ZERO rows in it, because the
+        only worker-side sender was the hub-commanded `ADOPT_COMPILE_CACHE`
+        handler and no stack has ever issued that operation. Every adoption
+        that actually happens is a boot attach, and a boot attach reported
+        itself in prose (`aot_adopt`, `duration_ms=0`) on a lane with no
+        numbers in it. Two builders, one fact, and only the unmeasured builder
+        reached the consumer.
+
+        `operation_id` is empty by construction here: the wire contract already
+        specifies empty as "boot-attached cell", so the hub stores these
+        without being taught a second spelling.
+
+        Telemetry only. A send failure never changes what this worker serves —
+        the cell is already armed or already refused by the time this runs.
+        """
+        if not inj.adoptions:
+            return
+        warmup_s = round(max(0, self._boot_warm_ms) / 1000.0, 3)
+        for adoption in inj.adoptions:
+            if not adoption.ref:
+                # An arm with no candidate identity is not an adoption anyone
+                # can attribute; recording it would add a row that answers
+                # nothing. (The hub applies the same rule from its side.)
+                continue
+            calls, hits, misses = proof_by_obj.get(adoption.pipeline_id, (0, 0, 0))
+            if adoption.armed:
+                event = pb.ModelEvent(
+                    ref=adoption.ref,
+                    snapshot_digest=adoption.snapshot_digest,
+                    # Empty: the wire contract's own name for a boot-attached
+                    # cell, so the hub stores these without a second spelling.
+                    operation_id="",
+                    target_incarnation_id="",
+                    state=pb.MODEL_STATE_ADOPTED,
+                    duration_ms=adoption.arm_ms,
+                    cache_hits=max(0, hits),
+                    cache_misses=max(0, misses),
+                    warmup_s=warmup_s,
+                )
+            else:
+                event = pb.ModelEvent(
+                    ref=adoption.ref,
+                    snapshot_digest=adoption.snapshot_digest,
+                    operation_id="",
+                    target_incarnation_id="",
+                    state=pb.MODEL_STATE_FAILED,
+                    # The same `adopt_failed:<reason>` grammar the commanded
+                    # path uses, so one `kind=compile_cache_adopt` query
+                    # returns the whole outcome distribution rather than two
+                    # half-populations that have to be unioned by hand.
+                    error=f"adopt_failed:{adoption.reason or 'no_cell'}",
+                    duration_ms=adoption.arm_ms,
+                )
+            logger.info(
+                "cell adoption %s ref=%s digest=%s arm_ms=%d warmup_s=%.3f "
+                "calls=%d hits=%d misses=%d%s",
+                "ADOPTED" if adoption.armed else "FAILED",
+                adoption.ref, adoption.snapshot_digest, adoption.arm_ms,
+                warmup_s, calls, hits, misses,
+                "" if adoption.armed else f" reason={adoption.reason}")
+            await self._send(pb.WorkerMessage(model_event=event))
+        inj.adoptions.clear()
 
     def _adoption_event(
         self,
@@ -10540,14 +10655,18 @@ class Executor:
                 # and the adopt event answer "what does an armed cell still pay
                 # on warmup" identically instead of by two derivations. Always
                 # armed=1 by construction — this runs after the wrap.
-                if boot_mod.in_boot():
+                if boot_mod.in_boot() and warmed:
+                    # pgw#924: `and warmed`. A warmup that ran no forward has
+                    # no cost to report, and a zero-duration row here reads
+                    # identically to "an armed cell warms instantly" — the
+                    # exact reading 240 live rows of `duration_ms=0` invited.
                     boot_mod.mark(
                         boot_mod.PHASE_WARMUP,
                         duration_ms=int(round(warmup_s * 1000)),
                         function=spec.name,
                         ref=ref,
                         klass=boot_mod.CLASS_LOAD,
-                        detail=f"armed=1 minting=0 iterations={warmed} adopt=1",
+                        detail=f"armed=1 minting=0 forwards={warmed} adopt=1",
                     )
                 hits = 0
                 misses = 0

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -61,14 +61,16 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
 from . import activity as activity_mod
 from . import aot_cells, cell_key
+from . import boot_phases as boot_mod
 from . import compile_cache as cc
 from . import guard_closure
 from . import topology as topology_mod
+from .cell_adopt import AdoptOutcome, CellAdoption
 from .models.chunk_cas import sha256_file
 from .procsplit import broker
 # module import (not `from .loading import pipeline_weight_lane`): tests
@@ -197,6 +199,11 @@ class ArmOutcome:
     self_mint: Optional[Any] = None
     selection_bug: Optional["cc.CellSelectionBugError"] = None
     eager_reason: str = ""
+    #: pgw#923: every ADOPTION attempt this policy made, in order, measured.
+    #: A self-mint is not an adoption and never appears here. The caller turns
+    #: these into the `ModelEvent{ADOPTED}` / `{FAILED}` the hub already stores
+    #: as `kind=compile_cache_adopt` — the one place the wire is owned.
+    adoptions: Tuple[CellAdoption, ...] = ()
 
     def __bool__(self) -> bool:
         return self.armed
@@ -679,6 +686,66 @@ def delegatable(pipe: Any, cfg: Any) -> bool:
     return not delegation_refusal(pipe, cfg)
 
 
+def _arm_candidate(
+    pipe: Any,
+    cfg: Any,
+    cache_dir: Optional[Path],
+    artifact: Optional[Path],
+    *,
+    ref: str,
+    snapshot_digest: str,
+    artifact_kind: str,
+) -> Tuple[AdoptOutcome, CellAdoption]:
+    """Arm ONE candidate cell, measured, and record the boot phase for it.
+
+    pgw#923/#924. The `cell_arm` boot span and the adoption's `duration_ms`
+    bracket the same interval, taken in the one place that does the arming, so
+    the boot ladder and the hub's adoption measurement cannot disagree about
+    what an arm cost. `cell_arm` was a DECLARED boot phase with no producer at
+    all until this call site existed.
+    """
+    # A CANDIDATE must exist for this to be a cell arm. `provision.
+    # enable_compiled` with no artifact also covers the seeded and ALLOW_COLD
+    # inductor lanes, and bracketing those would put a near-zero `cell_arm` row
+    # on every compile-declaring boot — the same "a default that reads as a
+    # fact" defect pgw#924 is closing for `warmup`.
+    span = (
+        boot_mod.open_span(
+            boot_mod.PHASE_CELL_ARM,
+            ref=ref,
+            artifact_kind=artifact_kind,
+            artifact_key=snapshot_digest,
+        )
+        if artifact is not None and boot_mod.in_boot()
+        else None
+    )
+    started = time.monotonic()
+    try:
+        outcome = provision.enable_compiled(pipe, cfg, cache_dir, artifact)
+    except BaseException as exc:
+        if span is not None:
+            span.close(exc)
+        raise
+    arm_ms = int(round(max(0.0, time.monotonic() - started) * 1000.0))
+    if span is not None:
+        if outcome.armed:
+            if outcome.identity:
+                span.note(outcome.identity)
+        else:
+            span.refused(outcome.reason or "no_cell", outcome.detail)
+        span.close()
+    return outcome, CellAdoption(
+        ref=ref,
+        snapshot_digest=snapshot_digest,
+        artifact_kind=artifact_kind,
+        arm_ms=arm_ms,
+        armed=outcome.armed,
+        reason=outcome.reason,
+        detail=outcome.detail or outcome.identity,
+        pipeline_id=id(pipe),
+    )
+
+
 def enable_compiled(
     pipe: Any,
     cfg: Any,
@@ -686,8 +753,49 @@ def enable_compiled(
     artifact: Optional[Path] = None,
     publisher: Optional[CellPublisher] = None,
     delegate: Optional[bool] = None,
+    delivered_ref: str = "",
+    delivered_digest: str = "",
+) -> ArmOutcome:
+    """Fleet arming policy, plus the adoption ledger every exit shares.
+
+    pgw#923: the policy has a dozen exits and an adoption attempt can precede
+    any of them, so the measured attempts are collected in ONE place rather
+    than threaded through each ``return``. That is the shape that lets a
+    refusal be reported: the old code could only announce an adoption from the
+    frame that made it, which is why the successful ones were narrated and the
+    measured ones never sent.
+    """
+    adoptions: List[CellAdoption] = []
+    outcome = _arming_policy(
+        pipe, cfg, cache_dir, artifact,
+        publisher=publisher, delegate=delegate,
+        delivered_ref=delivered_ref, delivered_digest=delivered_digest,
+        adoptions=adoptions,
+    )
+    if not adoptions:
+        return outcome
+    return dataclasses.replace(outcome, adoptions=tuple(adoptions))
+
+
+def _arming_policy(
+    pipe: Any,
+    cfg: Any,
+    cache_dir: Optional[Path],
+    artifact: Optional[Path],
+    *,
+    publisher: Optional[CellPublisher],
+    delegate: Optional[bool],
+    delivered_ref: str,
+    delivered_digest: str,
+    adoptions: List[CellAdoption],
 ) -> ArmOutcome:
     """Fleet arming policy (gw#587): delivered cell first, self-mint on miss.
+
+    ``delivered_ref``/``delivered_digest`` name the HUB-attached candidate.
+    They are the identity the hub fences an adoption on, they are known only to
+    the caller that resolved the delivery, and without them a boot-attached
+    adoption has nothing to report itself as (pgw#923). Every arm attempt is
+    appended to ``adoptions``, measured.
 
     Replaces the executor's bare ``provision.enable_compiled`` call. HIT
     keeps today's semantics for a genuine match. A ``CellSelectionBugError``
@@ -747,61 +855,72 @@ def enable_compiled(
         if adopted is not None:
             from . import aot_serve
 
-            aot_armed = False
-            lane_refused = False
             try:
-                aot_armed = provision.enable_compiled(
-                    pipe, cfg, cache_dir, adopted.artifact)
+                aot_out, aot_row = _arm_candidate(
+                    pipe, cfg, cache_dir, adopted.artifact,
+                    ref=adopted.ref,
+                    snapshot_digest=adopted.snapshot_digest,
+                    artifact_kind=aot_serve.ARTIFACT_KIND,
+                )
             except cc.CompiledLaneUnavailableError:
                 # The AOT arm refused and the mandatory-lane no-artifact
                 # fallthrough raised — the ordinary policy below (with the
                 # delivered artifact) is still to run, so this is not
                 # terminal here.
-                lane_refused = True
                 logger.warning(
                     "fleet-cells: discovered AOT cell %s did not arm; "
                     "falling through to the ordinary arming policy",
                     adopted.ref)
-                activity_mod.emit_event(
-                    aot_serve.ADOPT_EVENT,
-                    f"family={family} key={adopted.cell_key} "
-                    f"ref={adopted.ref}: arm refused and the mandatory-lane "
-                    "fallthrough raised; ordinary policy resumes with the "
-                    "delivered artifact",
-                    phase="lane_unavailable",
-                )
-            if aot_armed and aot_serve.is_armed(pipe):
-                logger.info(
-                    "fleet-cells: armed discovered AOT cell %s (pgw#722)",
-                    adopted.ref)
-                return ArmOutcome(armed=True, self_mint=adopted)
-            if aot_armed:
-                # Armed, but not through the exported artifact (e.g. a
-                # seeded dynamo cell picked up on the fallthrough): honest
-                # plain HIT — never advertise the AOT identity for bytes
-                # this pipe does not serve.
-                activity_mod.emit_event(
-                    aot_serve.ADOPT_EVENT,
-                    f"family={family} key={adopted.cell_key} "
-                    f"ref={adopted.ref}: armed via the fallthrough, NOT the "
-                    "discovered artifact; AOT identity not advertised",
-                    phase="armed_other_path",
-                )
-                return ArmOutcome(armed=True)
-            if not lane_refused:
-                # The classified inner refusal already rode its own
-                # ADOPT_EVENT (aot_serve.enable / cell_receipt_refused);
-                # this row binds it to the DISCOVERED candidate's identity.
-                activity_mod.emit_event(
-                    aot_serve.ADOPT_EVENT,
-                    f"family={family} key={adopted.cell_key} "
-                    f"ref={adopted.ref}: discovered cell did not arm; "
-                    "falling through to the ordinary arming policy",
-                    phase="did_not_arm",
-                )
+                adoptions.append(CellAdoption(
+                    ref=adopted.ref,
+                    snapshot_digest=adopted.snapshot_digest,
+                    artifact_kind=aot_serve.ARTIFACT_KIND,
+                    arm_ms=0,
+                    armed=False,
+                    reason="lane_unavailable",
+                    detail=(
+                        f"family={family} key={adopted.cell_key}: arm refused "
+                        "and the mandatory-lane fallthrough raised; ordinary "
+                        "policy resumes with the delivered artifact"),
+                    pipeline_id=id(pipe),
+                ))
+            else:
+                if aot_out.armed and not aot_serve.is_armed(pipe):
+                    # Armed, but not through the exported artifact (e.g. a
+                    # seeded dynamo cell picked up on the fallthrough): honest
+                    # plain HIT — never advertise the AOT identity for bytes
+                    # this pipe does not serve, so the DISCOVERED cell's own
+                    # adoption is a miss with its own token.
+                    aot_row = dataclasses.replace(
+                        aot_row, armed=False, reason="armed_other_path",
+                        detail=(
+                            f"family={family} key={adopted.cell_key}: armed "
+                            "via the fallthrough, NOT the discovered "
+                            "artifact; AOT identity not advertised"))
+                    adoptions.append(aot_row)
+                    return ArmOutcome(armed=True)
+                adoptions.append(aot_row)
+                if aot_out.armed:
+                    logger.info(
+                        "fleet-cells: armed discovered AOT cell %s (pgw#722)",
+                        adopted.ref)
+                    return ArmOutcome(armed=True, self_mint=adopted)
 
     try:
-        if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
+        delivered_out, delivered_row = _arm_candidate(
+            pipe, cfg, cache_dir, artifact,
+            ref=delivered_ref,
+            snapshot_digest=delivered_digest,
+            artifact_kind="",
+        )
+        if artifact is not None:
+            # ONE rule, the same one `_arm_candidate` opens its boot span on: a
+            # call with no delivered artifact is not an adoption ATTEMPT —
+            # `compile_cache.enable` also covers the seeded and ALLOW_COLD
+            # lanes — so it must not manufacture a row for a cell that was
+            # never offered, in either direction.
+            adoptions.append(delivered_row)
+        if delivered_out.armed:
             return ArmOutcome(armed=True)
         # Plain-lane miss: no cell delivered / artifact unusable. Fall
         # through to the self-mint instead of the pre-gw#587 silent eager.
@@ -1248,12 +1367,12 @@ def adopt_delegated_mint(
             # passes; `provision.enable_compiled` itself is not reusable here
             # because its pgw#709 receipts gate would drop a cell this pod
             # minted seconds ago and the hub has not countersigned yet.
-            armed = provision.arm_aot(
+            armed = bool(provision.arm_aot(
                 pipe, pending.cfg, pending.cache_dir, pending.target,
-                int(getattr(pending.cfg, "lora_bucket", 0) or 0))
+                int(getattr(pending.cfg, "lora_bucket", 0) or 0)))
         else:
-            armed = cc.enable(pipe, pending.cfg, pending.cache_dir,
-                              artifact=pending.target)
+            armed = bool(cc.enable(pipe, pending.cfg, pending.cache_dir,
+                                   artifact=pending.target))
     except cc.CellSelectionBugError as exc:
         # th#883, delegated edition: the child's own cell, whose axes describe
         # exactly this runtime, refused to arm. Loud — it is a bug in the one

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Tuple
 
+from ..cell_adopt import AdoptOutcome
 from ..component_vocab import denoiser_components
 from ..api.binding import ModelRef, wire_ref
 from ..config import Settings, current_or
@@ -238,7 +239,7 @@ def arm_route(mode: str) -> Optional[str]:
 def arm_aot(
     pipe: Any, cfg: Any, cache_dir: Optional[Path], artifact: Path,
     bucket: int, meta: Optional[Dict[str, Any]] = None,
-) -> bool:
+) -> AdoptOutcome:
     """Arm ONE exported ``.pt2`` cell on ``pipe``. The whole AOT arm, in one
     place, for every source of such an artifact.
 
@@ -279,7 +280,9 @@ def arm_aot(
         logger.warning(
             "aot arm: artifact declares mode=%r, which this runtime has no "
             "arm for; staying eager", mode)
-        return False
+        return AdoptOutcome.miss(
+            "no_arm_for_mode",
+            f"artifact declares mode={mode!r}, which this runtime has no arm for")
     if bucket and current_or(_STANDALONE).compile_prefer_aot:
         from . import lora_lifted
 
@@ -303,36 +306,33 @@ def arm_aot(
                     "aot arm: lifted-binding install failed on %r (%s); a "
                     "lifted artifact will refuse at assert_lifted_contract",
                     module_name, exc)
-    if aot_serve.enable(pipe, cfg, cache_dir, artifact):
+    outcome = aot_serve.enable(pipe, cfg, cache_dir, artifact)
+    if outcome.armed:
         if gate_cell_numerics(pipe, cfg):
-            return True
+            return outcome
         # A refused cell is UNARMED, not merely reported: the whole point is
         # that it must not serve. Staying eager is the ordinary miss policy
         # every other adopt gate uses, so the tenant keeps being served.
         #
-        # And the ADOPT ledger has to agree with it. `enable` already emitted
-        # `aot_adopt phase=armed` before the gate ran, so a reader counting
-        # armed adoptions would over-count every numerics refusal. One closing
-        # row keeps that count honest — the numbers themselves ride the
-        # `cell_numerics` row.
+        # pgw#923: and the ADOPT ledger agrees with it by CONSTRUCTION now.
+        # `enable` used to announce `aot_adopt phase=armed` before the gate
+        # ran, so a reader counting armed adoptions over-counted every numerics
+        # refusal and a second closing row existed only to correct the first.
+        # Nothing is announced until the arm is final, so the refusal is simply
+        # what this function returns; the numbers still ride `cell_numerics`.
         meta = aot_serve.armed_metadata(pipe)
         aot_serve.unwrap(pipe)
-        try:
-            from .. import activity as activity_mod
-
-            activity_mod.emit_event(
-                aot_serve.ADOPT_EVENT,
-                f"family={meta.get('family')} key={meta.get('cell_key')}: "
-                f"armed, then UNARMED by the numerics gate — this pod serves "
-                f"eager (pgw#868)",
-                phase="numerics_refused")
-        except Exception:  # noqa: BLE001 — the refusal already stands
-            logger.debug("could not close the adopt ledger", exc_info=True)
+        outcome = AdoptOutcome.miss(
+            "numerics_refused",
+            f"family={meta.get('family')} key={meta.get('cell_key')}: armed, "
+            f"then UNARMED by the numerics gate — this pod serves eager "
+            f"(pgw#868)",
+            outcome.identity)
     if lifted_installed:
         from . import lora_lifted
 
         lora_lifted.remove_lifted_lora_forward(lifted_target)
-    return False
+    return outcome
 
 
 def gate_cell_numerics(pipe: Any, cfg: Any) -> bool:
@@ -441,7 +441,7 @@ def _refuse_unmeasurable(family: str, reason: str, detail: str) -> bool:
 def enable_compiled(
     pipe: Any, cfg: Any, cache_dir: Optional[Path] = None,
     artifact: Optional[Path] = None,
-) -> bool:
+) -> AdoptOutcome:
     """Arm the best available compiled path for a freshly loaded pipeline:
     a TRT engine artifact swaps the module (fail-soft), anything else goes
     through the torch.compile cache policy (which also covers the no-
@@ -465,6 +465,7 @@ def enable_compiled(
     ):
         artifact = None
 
+    refused: Optional[AdoptOutcome] = None
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     if bucket and not compile_cache.has_compile_target(pipe, cfg):
         # gw#627 live find: this arming runs for EVERY worker-loaded setup
@@ -485,14 +486,18 @@ def enable_compiled(
             meta = None
         kind = str((meta or {}).get("kind") or "")
         if kind == aot_serve.ARTIFACT_KIND:
-            if arm_aot(pipe, cfg, cache_dir, Path(artifact), bucket, meta):
-                return True
+            aot = arm_aot(pipe, cfg, cache_dir, Path(artifact), bucket, meta)
+            if aot.armed:
+                return aot
+            refused = aot
             artifact = None  # unusable artifact: fall through to eager policy
         elif kind == "trt-engine" and not bucket:
             # TRT engines expose only their plain contract — a lora_bucket
             # declaration always rides the inductor lane.
-            if trt_engine.enable(pipe, cfg, cache_dir, artifact):
-                return True
+            trt = trt_engine.enable(pipe, cfg, cache_dir, artifact)
+            if trt.armed:
+                return trt
+            refused = trt
             artifact = None  # unusable engine: fall through to eager policy
     try:
         armed = compile_cache.enable(pipe, cfg, cache_dir, artifact)
@@ -504,7 +509,12 @@ def enable_compiled(
         raise
     if bucket and not armed:
         compile_cache.drop_lora_lane(pipe)
-    return armed
+    if armed:
+        return AdoptOutcome.hit()
+    # The inductor lane declines without a classified token of its own — "no
+    # delivered cell for this identity" is the whole answer. A prior typed
+    # refusal from the exported/TRT arm is the more specific one and survives.
+    return refused if refused is not None else AdoptOutcome.miss("no_cell")
 
 
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/trt_engine.py
+++ b/src/gen_worker/trt_engine.py
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from . import activity as activity_mod
+from .cell_adopt import AdoptOutcome
 from .compile_cache import (
     AdoptError,
     CompiledLaneUnavailableError,
@@ -575,44 +576,46 @@ def enable(
     cfg: Any,
     cache_dir: Optional[Path] = None,
     artifact: Optional[Path] = None,
-) -> bool:
+) -> AdoptOutcome:
     """Consumer entry point: verify + unpack a TRT engine artifact, refit it
-    with the resident module's weights, and swap the module forward. Returns
-    False (staying eager) on ANY miss; raises :class:`AdoptError` only via
-    the adopt path (executor catches + classifies)."""
+    with the resident module's weights, and swap the module forward. Falsy
+    (staying eager) on ANY miss; raises :class:`AdoptError` only via the adopt
+    path (executor catches + classifies).
+
+    pgw#923: the outcome is RETURNED, for the same reason the exported arm's
+    is. The classified reason used to leave here only as the ``phase`` of a
+    free-text ``trt_adopt`` event — a THIRD spelling of "a cell adopted, and
+    what it cost", alongside ``aot_adopt`` and the measured
+    ``compile_cache_adopt``. The arming policy now measures this arm and the
+    executor reports it on the one lane that carries numbers.
+    """
     if artifact is None:
-        return False
+        return AdoptOutcome.miss("no_artifact")
     try:
         meta = load_and_wrap(pipeline, cfg, Path(artifact), cache_dir=cache_dir)
-        logger.info(
-            "trt-engine: armed %s (sku=%s trt=%s precision=%s, refit from resident weights)",
-            meta.get("module"), meta.get("sku"), meta.get("trt"), meta.get("precision"),
-        )
-        activity_mod.emit_event(
-            activity_mod.KIND_TRT_ADOPT,
-            f"family={getattr(cfg, 'family', '')} "
-            f"module={meta.get('module')} sku={meta.get('sku')} "
-            f"trt={meta.get('trt')} precision={meta.get('precision')}: "
-            f"armed {Path(artifact).name}",
-            phase="armed",
-        )
-        return True
     except Exception as exc:
         # pgw#760 (the pgw#733 pattern, TRT half): the classified AdoptError
-        # reason was reduced to logger.warning — structurally invisible on
-        # hub-spawned workers. phase carries the reason class, countable
-        # hub-side; detail names the candidate artifact.
+        # reason must not be reduced to logger.warning — that is structurally
+        # invisible on hub-spawned workers. The reason token is the countable
+        # fact and it now rides the adoption's own wire event.
         reason = str(getattr(exc, "reason", "") or "") or type(exc).__name__
         logger.warning(
             "trt-engine: artifact unusable (%s: %s); staying eager",
             reason, exc)
-        activity_mod.emit_event(
-            activity_mod.KIND_TRT_ADOPT,
+        return AdoptOutcome.miss(
+            reason,
             f"family={getattr(cfg, 'family', '')} "
             f"artifact={Path(artifact).name}: {type(exc).__name__}: {exc}",
-            phase=reason,
-        )
-        return False
+            f"artifact={Path(artifact).name}")
+    logger.info(
+        "trt-engine: armed %s (sku=%s trt=%s precision=%s, refit from resident weights)",
+        meta.get("module"), meta.get("sku"), meta.get("trt"), meta.get("precision"),
+    )
+    return AdoptOutcome.hit(
+        f"family={getattr(cfg, 'family', '')} "
+        f"module={meta.get('module')} sku={meta.get('sku')} "
+        f"trt={meta.get('trt')} precision={meta.get('precision')}: "
+        f"armed {Path(artifact).name}")
 
 
 def load_and_wrap(

--- a/tests/test_abandoned_mint_telemetry_pgw848.py
+++ b/tests/test_abandoned_mint_telemetry_pgw848.py
@@ -34,6 +34,7 @@ import pytest
 
 from gen_worker import aot_compile_pool as pool
 from gen_worker import aot_mint, mint_delegate, mint_process
+from gen_worker.cell_adopt import AdoptOutcome
 
 _GIB = 1 << 30
 
@@ -501,7 +502,8 @@ def test_the_unchecked_announcement_is_gone_because_the_gate_landed(
 
     assert not hasattr(provision, "_announce_unchecked_numerics")
 
-    monkeypatch.setattr(aot_serve, "enable", lambda *a, **k: True)
+    monkeypatch.setattr(
+        aot_serve, "enable", lambda *a, **k: AdoptOutcome.hit())
     said: list[tuple[str, str, str]] = []
     monkeypatch.setattr(
         activity_mod, "emit_event",
@@ -511,7 +513,8 @@ def test_the_unchecked_announcement_is_gone_because_the_gate_landed(
     cfg = type("Cfg", (), {"family": "sdxl", "numerics_floor": 0.995,
                            "numerics_warn": 0.999, "lora_bucket": 0,
                            "targets": ()})()
-    assert provision.arm_aot(object(), cfg, None, Path("cell.pt2"), 0) is False
+    assert provision.arm_aot(
+        object(), cfg, None, Path("cell.pt2"), 0).armed is False
     rows = [(d, p) for k, d, p in said if k == activity_mod.KIND_CELL_NUMERICS]
     assert rows, "an arm that could not be measured said nothing"
     detail, phase = rows[-1]

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -1,22 +1,27 @@
-"""pgw#733 (arm half): every AOT adopt/arm outcome is a TYPED wire event.
+"""pgw#733 (arm half) + pgw#923: every AOT adopt/arm outcome is TYPED and MEASURED.
 
-The verdict lane's blocker (tracker CP5, 2026-07-29): a cross-pod adopt
-fails inside stage/bind/arm with a classified ``AdoptError`` reason, and
-v0.76.5 reduces ALL of them to ``logger.warning`` — hub-spawned workers
-expose no stdout, so the reason is structurally invisible. These tests are
-the red half: each classified refusal must ride ``aot_serve.ADOPT_EVENT``
-(one event class, ``phase`` = the reason), a successful arm must too, and
-the fleet-level F1 consumer must bind the outcome to the DISCOVERED
-candidate's identity (key + ref) on the same event class.
+The verdict lane's blocker (tracker CP5, 2026-07-29): a cross-pod adopt fails
+inside stage/bind/arm with a classified ``AdoptError`` reason, and v0.76.5
+reduced ALL of them to ``logger.warning`` — hub-spawned workers expose no
+stdout, so the reason was structurally invisible. pgw#733 fixed that with a
+free-text ``aot_adopt`` activity event.
 
-The wire transport itself (ActivityUpdate -> hub row, th#1250) is captured
-at ``activity._emit`` — the exact envelope the stream sink sends — so the
-assertion covers kind/phase/detail truncation as wired, not a test double
-of the event API.
+pgw#923 replaced that spelling. The event carried a reason and no numbers,
+while the MEASURED lane it duplicated (``compile_cache_adopt``, fed by
+``ModelEvent{ADOPTED}``) had zero rows on both live stacks because its only
+sender was a hub operation nothing dispatches. So the arm now RETURNS its
+outcome, the arming policy MEASURES it, and one ledger — ``ArmOutcome.
+adoptions`` — carries every attempt with its identity, its classified reason
+and its wall time to the executor, which puts it on the wire the hub already
+stores.
+
+The acceptance is unchanged and strictly stronger: every classified refusal is
+still named, and now it is also timed and bound to the candidate's ref+digest.
 """
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -24,7 +29,7 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from gen_worker import activity, aot_cells, aot_serve, fleet_cells
-from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "sdxl"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
@@ -144,8 +149,9 @@ def stub_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME))
 
 
-def _adopt_rows(events: List[Any]) -> List[Any]:
-    return [e for e in events if e.kind == aot_serve.ADOPT_EVENT]
+def _reasons(outcome: Any) -> List[str]:
+    """The classified reason of every adoption ATTEMPT, in order."""
+    return [row.reason for row in outcome.adoptions]
 
 
 # ---------------------------------------------------------------------------
@@ -153,17 +159,14 @@ def _adopt_rows(events: List[Any]) -> List[Any]:
 # ---------------------------------------------------------------------------
 
 
-def test_successful_arm_emits_armed(
-    tmp_path: Path, events: List[Any], stub_runtime: None,
-    monkeypatch: pytest.MonkeyPatch,
+def test_successful_arm_returns_an_armed_outcome_naming_the_cell(
+    tmp_path: Path, stub_runtime: None, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         aot_serve, "_load_package", lambda path, entry: FakePackage())
-    assert aot_serve.enable(FakePipeline(), Cfg(), artifact=_tar(tmp_path))
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["armed"]
-    assert KEY in rows[0].detail and FAMILY in rows[0].detail
-    assert rows[0].state == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=_tar(tmp_path))
+    assert out.armed and out.reason == ""
+    assert KEY in out.identity and FAMILY in out.identity
 
 
 def test_key_mismatch_named_on_the_wire(
@@ -172,18 +175,17 @@ def test_key_mismatch_named_on_the_wire(
     # pgw#765: an sm mismatch is the key mismatch; a SKU difference alone is
     # adopted (same-sm cross-SKU cells are the point of the pgw#691 collapse).
     art = _tar(tmp_path, _meta(sm="sm_80"))
-    assert not aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["key_mismatch"]
-    assert KEY in rows[0].detail  # the refusal names the candidate cell
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
+    assert not out.armed and out.reason == "key_mismatch"
+    assert KEY in out.detail  # the refusal names the candidate cell
 
 
 def test_host_isa_unsupported_named_on_the_wire(
     tmp_path: Path, events: List[Any], stub_runtime: None,
 ) -> None:
     art = _tar(tmp_path, _meta(host_isa={"machine": "sparc64", "level": ""}))
-    assert not aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
-    assert [e.phase for e in _adopt_rows(events)] == ["host_isa_unsupported"]
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
+    assert not out.armed and out.reason == "host_isa_unsupported"
 
 
 def test_artifact_invalid_named_on_the_wire(
@@ -191,19 +193,16 @@ def test_artifact_invalid_named_on_the_wire(
 ) -> None:
     art = tmp_path / "corrupt.tar.gz"
     art.write_bytes(b"\x00definitely not a tarball")
-    assert not aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["artifact_invalid"]
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=art)
+    assert not out.armed and out.reason == "artifact_invalid"
     # Identity is best-effort: an unreadable artifact still names its file.
-    assert "corrupt.tar.gz" in rows[0].detail
+    assert "corrupt.tar.gz" in out.detail
 
     # Malformed entries classify the same, with the reason in the detail.
-    events.clear()
     malformed = _tar(tmp_path, _meta(entries={ENTRY: {"target": "unet"}}))
-    assert not aot_serve.enable(FakePipeline(), Cfg(), artifact=malformed)
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["artifact_invalid"]
-    assert "declares no inputs" in rows[0].detail
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=malformed)
+    assert not out.armed and out.reason == "artifact_invalid"
+    assert "declares no inputs" in out.detail
 
 
 def test_constants_refusal_named_on_the_wire(
@@ -214,10 +213,9 @@ def test_constants_refusal_named_on_the_wire(
         aot_serve, "_load_package",
         lambda path, entry: FakePackage(fqns=("conv_in.weight",
                                               "not.in.state_dict")))
-    assert not aot_serve.enable(FakePipeline(), Cfg(), artifact=_tar(tmp_path))
-    rows = _adopt_rows(events)
-    assert len(rows) == 1
-    assert rows[0].phase.startswith("constants_")
+    out = aot_serve.enable(FakePipeline(), Cfg(), artifact=_tar(tmp_path))
+    assert not out.armed
+    assert out.reason.startswith("constants_")
 
 
 # ---------------------------------------------------------------------------
@@ -291,57 +289,71 @@ def _f1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     gw_config.reload_for_test()
 
 
-def test_fleet_success_is_one_armed_row(
-    monkeypatch: pytest.MonkeyPatch, events: List[Any], _f1: Any,
+def test_fleet_success_is_one_measured_adoption_bound_to_the_candidate(
+    monkeypatch: pytest.MonkeyPatch, _f1: Any,
 ) -> None:
-    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> bool:
+    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         pipe._cozy_aot = {"state": {"failed": False}}
-        activity.emit_event(aot_serve.ADOPT_EVENT, "k", phase="armed")
-        return True
+        time.sleep(0.02)  # a real arm costs time; a measured one records it
+        return AdoptOutcome.hit(f"family={FAMILY} key={KEY}")
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)
     outcome = fleet_cells.enable_compiled(
         _FleetPipe(), _FleetCfg(), publisher=_StubPublisher())  # type: ignore[arg-type]
     assert outcome.armed and outcome.self_mint is _f1
-    # exactly the inner "armed" row — the fleet layer adds no duplicate
-    assert [e.phase for e in _adopt_rows(events)] == ["armed"]
+    assert len(outcome.adoptions) == 1
+    row = outcome.adoptions[0]
+    assert row.armed and row.reason == ""
+    # The identity the hub fences an adoption on, and the number the whole
+    # measurement lane exists for. `arm_ms == 0` is what shipped for a year.
+    assert row.ref == _f1.ref and row.snapshot_digest == _f1.snapshot_digest
+    assert row.artifact_kind == aot_serve.ARTIFACT_KIND
+    assert row.arm_ms >= 15, "the adoption recorded no time at all"
 
 
-def test_fleet_did_not_arm_row_names_the_candidate(
-    monkeypatch: pytest.MonkeyPatch, events: List[Any], _f1: Any,
-    tmp_path: Path,
+def test_fleet_did_not_arm_is_a_measured_refusal_naming_the_candidate(
+    monkeypatch: pytest.MonkeyPatch, _f1: Any, tmp_path: Path,
 ) -> None:
     delivered = tmp_path / "delivered.tar.gz"
     delivered.write_bytes(b"dynamo")
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: artifact == delivered)
+        lambda pipe, cfg, cache_dir, artifact: (
+            AdoptOutcome.hit() if artifact == delivered
+            else AdoptOutcome.miss("key_mismatch", f"key={KEY}")))
     outcome = fleet_cells.enable_compiled(
         _FleetPipe(), _FleetCfg(), artifact=delivered,
-        publisher=_StubPublisher())  # type: ignore[arg-type]
+        publisher=_StubPublisher(),  # type: ignore[arg-type]
+        delivered_ref="root/family-sdxl#ck5-delivered",
+        delivered_digest="blake3:" + "7" * 64)
     assert outcome.armed and outcome.self_mint is None
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["did_not_arm"]
-    assert KEY in rows[0].detail and _f1.ref in rows[0].detail
+    # BOTH attempts are on the ledger, in order: the discovered cell that
+    # refused, then the delivered cell that armed. The old vocabulary recorded
+    # the refusal and nothing at all for the adoption that actually happened.
+    assert _reasons(outcome) == ["key_mismatch", ""]
+    assert outcome.adoptions[0].ref == _f1.ref
+    assert not outcome.adoptions[0].armed
+    assert outcome.adoptions[1].armed
+    assert outcome.adoptions[1].ref == "root/family-sdxl#ck5-delivered"
 
 
 def test_fleet_armed_other_path_never_advertises_aot(
-    monkeypatch: pytest.MonkeyPatch, events: List[Any], _f1: Any,
+    monkeypatch: pytest.MonkeyPatch, _f1: Any,
 ) -> None:
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: True)  # armed, marker absent
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.hit())  # marker absent
     outcome = fleet_cells.enable_compiled(
         _FleetPipe(), _FleetCfg(), publisher=_StubPublisher())  # type: ignore[arg-type]
     assert outcome.armed and outcome.self_mint is None
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["armed_other_path"]
-    assert KEY in rows[0].detail
+    assert _reasons(outcome) == ["armed_other_path"]
+    row = outcome.adoptions[0]
+    assert not row.armed, "the DISCOVERED cell is not what armed this pipe"
+    assert row.ref == _f1.ref and KEY in row.detail
 
 
-def test_fleet_lane_unavailable_row_names_the_candidate(
-    monkeypatch: pytest.MonkeyPatch, events: List[Any], _f1: Any,
-    tmp_path: Path,
+def test_fleet_lane_unavailable_is_recorded_against_the_candidate(
+    monkeypatch: pytest.MonkeyPatch, _f1: Any, tmp_path: Path,
 ) -> None:
     from gen_worker import compile_cache as cc
 
@@ -349,20 +361,20 @@ def test_fleet_lane_unavailable_row_names_the_candidate(
     delivered.write_bytes(b"dynamo")
     calls: List[Any] = []
 
-    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> bool:
+    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         calls.append(artifact)
         if len(calls) == 1:
             raise cc.CompiledLaneUnavailableError("no cell for w8a8")
-        return True
+        return AdoptOutcome.hit()
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)
     outcome = fleet_cells.enable_compiled(
         _FleetPipe(), _FleetCfg(), artifact=delivered,
         publisher=_StubPublisher())  # type: ignore[arg-type]
     assert outcome.armed
-    rows = _adopt_rows(events)
-    assert [e.phase for e in rows] == ["lane_unavailable"]
-    assert KEY in rows[0].detail
+    assert _reasons(outcome) == ["lane_unavailable", ""]
+    assert outcome.adoptions[0].ref == _f1.ref
+    assert KEY in outcome.adoptions[0].detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aot_flip_pgw722.py
+++ b/tests/test_aot_flip_pgw722.py
@@ -553,7 +553,7 @@ def test_flag_off_never_discovers(
     monkeypatch.setattr(aot_cells, "discover", _forbidden)
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: True)
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.hit())
     outcome = fleet_cells.enable_compiled(
         _FakePipe(), _Cfg(), publisher=_StubPublisher())  # type: ignore[arg-type]
     assert outcome.armed and outcome.self_mint is None
@@ -573,11 +573,11 @@ def test_flag_on_arms_discovered_cell_and_advertises_it(
         aot_cells, "discover", lambda *a, **k: adopted)
     armed_with: List[Optional[Path]] = []
 
-    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> bool:
+    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         armed_with.append(artifact)
         # The real path wraps the module; is_armed then reads the marker.
         pipe._cozy_aot = {"state": {"failed": False}}
-        return True
+        return AdoptOutcome.hit()
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)
     outcome = fleet_cells.enable_compiled(
@@ -604,9 +604,10 @@ def test_flag_on_failed_aot_arm_falls_through(
     monkeypatch.setattr(aot_cells, "discover", lambda *a, **k: adopted)
     calls: List[Optional[Path]] = []
 
-    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> bool:
+    def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         calls.append(artifact)
-        return artifact == delivered
+        return (AdoptOutcome.hit() if artifact == delivered
+                else AdoptOutcome.miss("key_mismatch"))
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)
     outcome = fleet_cells.enable_compiled(
@@ -627,7 +628,7 @@ def test_flag_on_without_publisher_skips_discovery(
     monkeypatch.setattr(aot_cells, "discover", _forbidden)
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: True)
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.hit())
     outcome = fleet_cells.enable_compiled(_FakePipe(), _Cfg(), publisher=None)
     assert outcome.armed and outcome.self_mint is None
 
@@ -683,10 +684,12 @@ def _arm_aot(
         lambda p: {"kind": aot_serve.ARTIFACT_KIND, "module": "unet"})
     observed: List[bool] = []
 
-    def _enable(p: Any, c: Any, cache_dir: Any, artifact: Any) -> bool:
+    def _enable(p: Any, c: Any, cache_dir: Any, artifact: Any) -> Any:
         observed.append(
             lora_lifted.lifted_binding(p.unet) is not None)
-        return enable_result
+        # pgw#923: the arm returns a typed outcome, not a bool.
+        return (AdoptOutcome.hit() if enable_result
+                else AdoptOutcome.miss("artifact_invalid"))
 
     monkeypatch.setattr(aot_serve, "enable", _enable)
     provision.enable_compiled(
@@ -740,6 +743,7 @@ def test_f2_failed_arm_rolls_the_install_back(
 # ---------------------------------------------------------------------------
 
 from gen_worker.utils.lora import AdapterResidency, PreparedAdapter  # noqa: E402
+from gen_worker.cell_adopt import AdoptOutcome
 
 
 def _adapter(model: nn.Module, seed: int) -> Dict[str, Any]:

--- a/tests/test_aot_mint_unblock_pgw813_pgw815.py
+++ b/tests/test_aot_mint_unblock_pgw813_pgw815.py
@@ -49,6 +49,7 @@ from gen_worker.api.export_contract import (
     reset_export_declarations,
 )
 from gen_worker import config as gw_config
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "sdxl"
 
@@ -158,7 +159,7 @@ def _w8a8_miss(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(aot_cells, "discover", lambda *a, **k: None)
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: False)
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 from gen_worker import aot_serve as aot
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "sdxl-base"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
@@ -684,7 +685,7 @@ def test_enable_arms_and_binds_from_resident_weights(tmp_path, monkeypatch, stub
     pipeline = FakePipeline(module)
     original = module.forward
 
-    assert aot.enable(pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)) is True
+    assert aot.enable(pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)).armed is True
     assert aot.is_armed(pipeline) is True
     assert module.forward is not original
     # constants came from the RESIDENT weights, not from the artifact
@@ -699,28 +700,28 @@ def test_enable_stays_eager_on_any_miss(tmp_path, monkeypatch, stub_runtime):
     original = module.forward
 
     # no artifact
-    assert aot.enable(pipeline, Cfg(), tmp_path / "c") is False
+    assert aot.enable(pipeline, Cfg(), tmp_path / "c").armed is False
     # wrong runtime key
     monkeypatch.setattr(aot, "_load_package", lambda p, e="model": FakePackage())
     assert aot.enable(
         pipeline, Cfg(), tmp_path / "c",
-        _tar(tmp_path, _meta(torch="2.12.0"), name="old.tar.gz")) is False
+        _tar(tmp_path, _meta(torch="2.12.0"), name="old.tar.gz")).armed is False
     # package will not load
     def _boom(path, entry="model"):
         raise RuntimeError("dlopen failed: undefined symbol")
     monkeypatch.setattr(aot, "_load_package", _boom)
-    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)) is False
+    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)).armed is False
     # constants cannot bind
     monkeypatch.setattr(
         aot, "_load_package",
         lambda p, e="model": FakePackage(fqns=("nope.weight",)))
-    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)) is False
+    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)).armed is False
 
     # pipeline without the target module
     class Bare:
         pass
 
-    assert aot.enable(Bare(), Cfg(), tmp_path / "c", _tar(tmp_path)) is False
+    assert aot.enable(Bare(), Cfg(), tmp_path / "c", _tar(tmp_path)).armed is False
 
     # every miss leaves the pipeline exactly eager
     assert module.forward == original
@@ -751,7 +752,7 @@ def test_provision_dispatches_aot_kind_and_reports_a_hit(tmp_path, monkeypatch, 
     module = FakeModule()
     pipeline = FakePipeline(module)
     assert provision.enable_compiled(
-        pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)) is True
+        pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)).armed is True
     assert aot.is_armed(pipeline) is True
 
 
@@ -772,7 +773,7 @@ def test_provision_falls_through_to_inductor_when_the_pt2_is_unusable(
 
     pipeline = FakePipeline()
     assert provision.enable_compiled(
-        pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)) is False
+        pipeline, Cfg(), tmp_path / "cache", _tar(tmp_path)).armed is False
     # the unusable .pt2 was DROPPED, not handed to the inductor lane
     assert seen == [None]
 
@@ -783,11 +784,11 @@ def test_provision_still_routes_trt_and_inductor_kinds(tmp_path, monkeypatch, st
     from gen_worker.models import provision
 
     monkeypatch.setattr(aot, "_load_package", lambda p, e="model": FakePackage())
-    monkeypatch.setattr(te, "enable", lambda *a, **k: True)
+    monkeypatch.setattr(te, "enable", lambda *a, **k: AdoptOutcome.hit())
     pipeline = FakePipeline()
     trt = _tar(tmp_path, _meta(kind="trt-engine"), name="trt.tar.gz")
     assert provision.enable_compiled(
-        pipeline, Cfg(), tmp_path / "cache", trt) is True
+        pipeline, Cfg(), tmp_path / "cache", trt).armed is True
     assert aot.is_armed(pipeline) is False
 
     calls: list = []
@@ -798,7 +799,7 @@ def test_provision_still_routes_trt_and_inductor_kinds(tmp_path, monkeypatch, st
     monkeypatch.setattr(cc, "enable", _inductor)
     inductor = _tar(tmp_path, _meta(kind="compile-cache"), name="cc.tar.gz")
     assert provision.enable_compiled(
-        FakePipeline(), Cfg(), tmp_path / "cache", inductor) is True
+        FakePipeline(), Cfg(), tmp_path / "cache", inductor).armed is True
     assert calls == [inductor]
 
 
@@ -822,7 +823,7 @@ def test_provision_drops_the_artifact_when_the_receipts_gate_refuses(
     monkeypatch.setattr(cc, "enable", _inductor)
 
     assert provision.enable_compiled(
-        FakePipeline(), Cfg(), tmp_path / "cache", _tar(tmp_path)) is False
+        FakePipeline(), Cfg(), tmp_path / "cache", _tar(tmp_path)).armed is False
     assert seen == [None]
 
 
@@ -981,7 +982,7 @@ def test_enable_refuses_a_lifted_module_against_a_branchless_cell(
     pipeline = FakePipeline(module)
     original = module.forward
 
-    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)) is False
+    assert aot.enable(pipeline, Cfg(), tmp_path / "c", _tar(tmp_path)).armed is False
     assert aot.is_armed(pipeline) is False
     assert module.forward == original
 
@@ -995,7 +996,7 @@ def test_enable_arms_a_lifted_module_against_a_lifted_cell(
     pipeline = FakePipeline(module)
     art = _tar(tmp_path, _meta(inputs=LIFTED_INPUTS), name="lifted.tar.gz")
 
-    assert aot.enable(pipeline, Cfg(), tmp_path / "c", art) is True
+    assert aot.enable(pipeline, Cfg(), tmp_path / "c", art).armed is True
     assert module.forward(*_in_range_call()[0]) == "ARTIFACT_OUTPUT"
     assert package.invocations[0][0][3] is binding.tensors[0]
     assert aot.execution_count(pipeline) == 1

--- a/tests/test_arm_compile_pgw517.py
+++ b/tests/test_arm_compile_pgw517.py
@@ -29,6 +29,7 @@ from gen_worker.executor import Executor, ModelStore
 from gen_worker.models import provision
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec, extract_specs
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "wan-2.2-t2v-a14b"
 
@@ -170,7 +171,9 @@ def test_arm_compile_inside_scope_reaches_enable_compiled(monkeypatch, tmp_path)
     seen: list = []
     monkeypatch.setattr(
         provision, "enable_compiled",
-        lambda pipe, c, cache_dir, artifact: seen.append((pipe, c, cache_dir, artifact)) or True,
+        lambda pipe, c, cache_dir, artifact: (
+            seen.append((pipe, c, cache_dir, artifact))
+            or AdoptOutcome.hit()),
     )
     pipe = _StubPipe()
     scope = provision.ArmingScope(cfg, tmp_path, None)
@@ -359,7 +362,7 @@ def test_self_loaded_w8a8_pipeline_emits_exact_target_and_requires_cell_fence(
             "originals": [],
             "regional_mods": [],
         })
-        return True
+        return AdoptOutcome.hit()
 
     class Endpoint:
         def setup(self, model: str) -> None:

--- a/tests/test_boot_compile_deferral_gw584.py
+++ b/tests/test_boot_compile_deferral_gw584.py
@@ -55,6 +55,7 @@ from gen_worker.lifecycle import Lifecycle
 from gen_worker.models import provision
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
+from gen_worker.cell_adopt import AdoptOutcome
 
 
 @family("gw584-testfam")
@@ -209,7 +210,7 @@ def _harness(tmp_path: Path, monkeypatch, specs: List[EndpointSpec]):
             "originals": [],
             "regional_mods": [],
         })
-        return True
+        return AdoptOutcome.hit()
 
     monkeypatch.setattr(provision, "enable_compiled", _fake_enable)
     return ex, sent, enables

--- a/tests/test_boot_phases_arm_pgw764.py
+++ b/tests/test_boot_phases_arm_pgw764.py
@@ -62,7 +62,7 @@ def test_a_refused_arm_rides_a_boot_row_with_its_reason(
     artifact.write_bytes(b"not-a-real-artifact")
 
     # Behaviour is unchanged: a refused arm stays eager and returns False.
-    assert aot_serve.enable(object(), object(), artifact=artifact) is False
+    assert aot_serve.enable(object(), object(), artifact=artifact).armed is False
 
     arms = [r for r in boot_phases.recorded_rows()
             if r.terminal and r.phase == boot_phases.PHASE_CELL_ARM]
@@ -85,7 +85,7 @@ def test_an_armed_cell_rides_an_ok_boot_row(
     artifact = tmp_path / "ck5_feed.tar.gz"
     artifact.write_bytes(b"x")
 
-    assert aot_serve.enable(object(), object(), artifact=artifact) is True
+    assert aot_serve.enable(object(), object(), artifact=artifact).armed is True
     arms = [r for r in boot_phases.recorded_rows()
             if r.terminal and r.phase == boot_phases.PHASE_CELL_ARM]
     assert len(arms) == 1

--- a/tests/test_boot_phases_pgw764.py
+++ b/tests/test_boot_phases_pgw764.py
@@ -52,7 +52,7 @@ def _phases(rows: List[pb.BootPhase]) -> List[str]:
 
 
 def test_boot_rows_are_ordered_and_carry_one_boot_id() -> None:
-    with boot_phases.span(boot_phases.PHASE_ENV_SEAL):
+    with boot_phases.span(boot_phases.PHASE_CELL_DISCOVER):
         pass
     boot_phases.mark(boot_phases.PHASE_HELLO, since_process_start=True)
     with boot_phases.span(boot_phases.PHASE_WEIGHTS_FETCH, ref="repo/sdxl") as fetch:
@@ -60,7 +60,7 @@ def test_boot_rows_are_ordered_and_carry_one_boot_id() -> None:
 
     rows = boot_phases.recorded_rows()
     assert _phases(rows) == [
-        boot_phases.PHASE_ENV_SEAL,
+        boot_phases.PHASE_CELL_DISCOVER,
         boot_phases.PHASE_HELLO,
         boot_phases.PHASE_WEIGHTS_FETCH,
     ]
@@ -80,7 +80,7 @@ def test_boot_rows_are_ordered_and_carry_one_boot_id() -> None:
 def test_a_span_opens_a_row_and_closes_the_same_ordinal() -> None:
     """th#1269's shape: a pod that dies mid-phase leaves the OPEN row behind,
     which is how the hub can still say which phase it died in."""
-    handle = boot_phases.open_span(boot_phases.PHASE_CELL_LOAD)
+    handle = boot_phases.open_span(boot_phases.PHASE_PIPELINE_LOAD)
     rows = boot_phases.recorded_rows()
     assert len(rows) == 1 and rows[0].terminal is False
     opened_ordinal = rows[0].ordinal
@@ -94,7 +94,7 @@ def test_a_span_opens_a_row_and_closes_the_same_ordinal() -> None:
 def test_rows_recorded_before_the_sink_exists_are_flushed_on_bind() -> None:
     """The boot window IS the no-sink window. Everything before bind must
     arrive, in order, once the stream comes up."""
-    boot_phases.mark(boot_phases.PHASE_CUDA_PROBE)
+    boot_phases.mark(boot_phases.PHASE_CELL_DISCOVER)
     with boot_phases.span(boot_phases.PHASE_WEIGHTS_FETCH, ref="repo/a"):
         pass
 
@@ -121,7 +121,7 @@ def test_rows_recorded_before_the_sink_exists_are_flushed_on_bind() -> None:
     assert all(m.WhichOneof("msg") == "boot_phase" for m in sent)
     shipped = [m.boot_phase for m in sent]
     # The pre-bind rows were flushed, and the post-bind row followed them.
-    assert boot_phases.PHASE_CUDA_PROBE in _phases(shipped)
+    assert boot_phases.PHASE_CELL_DISCOVER in _phases(shipped)
     assert boot_phases.PHASE_WEIGHTS_FETCH in _phases(shipped)
     assert _phases(shipped)[-1] == boot_phases.PHASE_FIRST_REQUEST_SERVABLE
 
@@ -132,8 +132,8 @@ def test_rows_recorded_before_the_sink_exists_are_flushed_on_bind() -> None:
 
 
 def test_nested_phases_charge_the_child_so_the_boot_reconciles() -> None:
-    with boot_phases.span(boot_phases.PHASE_CELL_ARM):
-        with boot_phases.span(boot_phases.PHASE_CELL_LOAD):
+    with boot_phases.span(boot_phases.PHASE_PIPELINE_LOAD):
+        with boot_phases.span(boot_phases.PHASE_WARMUP):
             pass
     # pgw#797: `hello` gates the boot close (see the flush test above).
     boot_phases.mark(boot_phases.PHASE_HELLO, since_process_start=True)
@@ -141,9 +141,9 @@ def test_nested_phases_charge_the_child_so_the_boot_reconciles() -> None:
                      since_process_start=True)
 
     rows = {r.phase: r for r in boot_phases.recorded_rows() if r.terminal}
-    arm = rows[boot_phases.PHASE_CELL_ARM]
-    load = rows[boot_phases.PHASE_CELL_LOAD]
-    assert load.parent_ordinal == arm.ordinal
+    load = rows[boot_phases.PHASE_PIPELINE_LOAD]
+    warm = rows[boot_phases.PHASE_WARMUP]
+    assert warm.parent_ordinal == load.ordinal
 
     recon = boot_phases.reconciliation()
     # The nested load is charged once, to the child — the parent keeps only its
@@ -185,7 +185,7 @@ def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
     already account for. Summing both double-counts the entire boot — and any
     hub-side SUM(duration_ms) would inherit the error, which is why
     `cumulative` is a wire field and not an SDK-local detail."""
-    with boot_phases.span(boot_phases.PHASE_ENV_SEAL):
+    with boot_phases.span(boot_phases.PHASE_CELL_DISCOVER):
         pass
     boot_phases.mark(boot_phases.PHASE_HELLO, since_process_start=True)
     boot_phases.mark(boot_phases.PHASE_FIRST_REQUEST_SERVABLE,
@@ -194,7 +194,7 @@ def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
     rows = {r.phase: r for r in boot_phases.recorded_rows() if r.terminal}
     assert rows[boot_phases.PHASE_HELLO].cumulative is True
     assert rows[boot_phases.PHASE_FIRST_REQUEST_SERVABLE].cumulative is True
-    assert rows[boot_phases.PHASE_ENV_SEAL].cumulative is False
+    assert rows[boot_phases.PHASE_CELL_DISCOVER].cumulative is False
 
     recon = boot_phases.reconciliation()
     # measured_ms counts the env_seal span only; the two milestones are the
@@ -204,11 +204,8 @@ def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
 
 
 def test_phase_classes_cover_the_vocabulary() -> None:
-    for phase in (
-        boot_phases.PHASE_WEIGHTS_FETCH, boot_phases.PHASE_CELL_FETCH,
-        boot_phases.PHASE_CELL_LOAD, boot_phases.PHASE_CELL_ARM,
-        boot_phases.PHASE_HELLO, boot_phases.PHASE_WARM_COMPLETE,
-    ):
+    assert boot_phases.PHASES, "the vocabulary cannot be empty"
+    for phase in boot_phases.PHASES:
         assert boot_phases.phase_class(phase) != "", phase
     # An unknown phase is reported unattributed rather than guessed.
     assert boot_phases.phase_class("something_new") == ""
@@ -218,11 +215,11 @@ def test_telemetry_never_breaks_the_boot_it_measures() -> None:
     """A span that raises still closes (as failed, with the classified reason)
     and re-raises: this is a measurement, never a behaviour change."""
     with pytest.raises(AdoptError):
-        with boot_phases.span(boot_phases.PHASE_CELL_LOAD):
+        with boot_phases.span(boot_phases.PHASE_PIPELINE_LOAD):
             raise AdoptError("artifact_invalid", "truncated tar")
 
     row = [r for r in boot_phases.recorded_rows()
-           if r.terminal and r.phase == boot_phases.PHASE_CELL_LOAD][0]
+           if r.terminal and r.phase == boot_phases.PHASE_PIPELINE_LOAD][0]
     assert row.outcome == boot_phases.OUTCOME_FAILED
     assert row.reason == "artifact_invalid"
     assert "truncated tar" in row.detail

--- a/tests/test_boot_span_ladder_pgw797.py
+++ b/tests/test_boot_span_ladder_pgw797.py
@@ -179,11 +179,7 @@ def test_the_boot_close_is_last_so_no_span_is_suppressed(ladder) -> None:
     silently deletes the rest of the ladder. Assert the close is last."""
     rows = ladder
     servable = _one(rows, boot_phases.PHASE_FIRST_REQUEST_SERVABLE)
-    later = [
-        r for r in rows
-        if r.ordinal > servable.ordinal
-        and r.phase not in (boot_phases.PHASE_WARM_COMPLETE,)
-    ]
+    later = [r for r in rows if r.ordinal > servable.ordinal]
     assert not later, (
         "phases recorded after the boot closed (they would have been "
         f"suppressed by in_boot()): {[r.phase for r in later]}"
@@ -260,38 +256,43 @@ def test_a_warmup_row_says_whether_a_cell_was_armed(ladder) -> None:
         assert tags["armed"] in ("0", "1")
 
 
-def test_per_iteration_warm_cost_is_recorded(ladder) -> None:
-    """The first forward dominates (allocator growth, CUDA module load, algo
-    selection). A total without the sequence cannot say what a cell removes."""
-    rows = ladder
-    warms = _terminal(rows, boot_phases.PHASE_WARMUP)
-    iters = _terminal(rows, boot_phases.PHASE_WARMUP_ITERATION)
-    assert iters, (
-        "no warmup_iteration rows — the harness endpoint declares "
-        "Resources(gpu=True) precisely so `warmup.plan` schedules a real warm "
-        "job; without them this issue's per-iteration question is unanswerable"
+def test_a_warmup_row_exists_ONLY_when_a_forward_actually_ran(ladder) -> None:
+    """pgw#924, the headline. This bracket used to open unconditionally, so a
+    setup slot with no planned warm units — most of them: a non-inference spec,
+    a class with no declared warmup, a bare component slot — still emitted a
+    `warmup` row at `duration_ms=0`. Live, that was 240 of 240 rows and 245 of
+    245 `warmup` activity events, and every consumer of "what does warmup cost
+    at boot" read zero. "Nobody warmed" and "warming was free" are different
+    answers; only one of them was ever true.
+
+    This harness endpoint declares `Resources(gpu=True)` precisely so
+    `warmup.plan` schedules a REAL warm job, so the rows here must carry a real
+    forward count — and any row that exists must have run at least one.
+    """
+    warms = _terminal(ladder, boot_phases.PHASE_WARMUP)
+    assert warms, (
+        "no warmup row on a boot whose endpoint declares a warm plan — the "
+        "gate is now suppressing real work, which is the opposite defect"
     )
-    warm_ordinals = {w.ordinal for w in warms}
-    assert all(i.parent_ordinal in warm_ordinals for i in iters), (
-        "warmup_iteration rows are not children of their warmup span"
-    )
-    seq = [int(_detail(i).get("iteration", "0")) for i in iters]
-    assert seq == sorted(seq) and seq[0] == 1, (
-        f"iteration indices are not a 1-based ordered sequence: {seq}"
-    )
+    for w in warms:
+        forwards = int(_detail(w).get("forwards", "0"))
+        assert forwards >= 1, (
+            f"a warmup row was emitted for a pass that ran no forward: "
+            f"{w.detail!r}"
+        )
 
 
-def test_warm_complete_is_emitted_on_a_boot_with_no_background_mint(ladder) -> None:
-    """pgw#789 put `warm_complete` in `_background_mint`'s finally only, and
-    `rec.background_mint` is set ONLY under eager-first — so an inline-mint,
-    cell-adopt or plain eager boot emitted nothing and was read as "compiled
-    serving never reached" when the truth was "never measured"."""
-    row = _one(ladder, boot_phases.PHASE_WARM_COMPLETE)
-    assert row.cumulative, "warm_complete is a milestone off process start"
-    assert row.outcome in (
-        boot_phases.OUTCOME_OK, boot_phases.OUTCOME_REFUSED)
-    if row.outcome == boot_phases.OUTCOME_REFUSED:
-        assert row.reason == "serving_eager"
+def test_no_row_carries_a_phase_outside_the_declared_vocabulary(ladder) -> None:
+    """pgw#924: the declaration and the producers must be the SAME set. Seventeen
+    phase names were declared; nine of them could only ever report nothing, and
+    a reader of the ladder could not tell a name that means "zero" from a name
+    that means "never measured"."""
+    seen = {r.phase for r in ladder}
+    assert seen <= boot_phases.PHASES, (
+        f"a real boot emitted phases outside the vocabulary: "
+        f"{sorted(seen - boot_phases.PHASES)}"
+    )
+    assert boot_phases.PHASE_HELLO in seen
 
 
 def test_the_ladder_reconciles_against_the_boot_total(ladder) -> None:

--- a/tests/test_cell_adoption_measurement_pgw923.py
+++ b/tests/test_cell_adoption_measurement_pgw923.py
@@ -1,0 +1,219 @@
+"""pgw#923: a boot-attached adoption produces a MEASURED wire event.
+
+The defect, from both live stacks: `worker_activity_events` held **zero**
+`compile_cache_adopt` rows — the kind th#1329/th#1352 built two partial indexes
+and a p50/p95/max admin surface on — while every adoption that actually
+happened rode a free-text `aot_adopt` row at `duration_ms=0`. The cause was
+reachability, not correctness: the only worker-side sender of the measured
+`ModelEvent{ADOPTED}` was the hub-commanded `ADOPT_COMPILE_CACHE` handler, and
+no stack has ever dispatched that operation. Adoptions happen at BOOT, through
+`fleet_cells`, and that path sent no `ModelEvent` at all.
+
+So a reader of the th#1329 surface concluded adoption never happens, a reader of
+`aot_adopt` got no numbers, and the percentile endpoint aggregated a population
+with no members. Nothing went red.
+
+These tests hold an adoption open for a KNOWN interval and a warmup for a
+second known interval, and assert the stored numbers. The emitter that shipped
+for a year cannot pass them: it reported zero.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import boot_phases, fleet_cells
+from gen_worker.cell_adopt import AdoptOutcome, CellAdoption
+from gen_worker.executor import Executor, _InjectionResult
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+REF = "root/family-sdxl#ck5-" + "b" * 56
+DIGEST = "blake3:" + "c" * 64
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Any:
+    boot_phases.reset_for_tests()
+    yield
+    boot_phases.reset_for_tests()
+
+
+def _report(adoptions: List[CellAdoption], proof: Dict[int, Tuple[int, int, int]],
+            warm_ms: int) -> List[pb.ModelEvent]:
+    """Drive the REAL executor method and read the REAL protobuf it sends."""
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    ex = Executor.__new__(Executor)
+    ex._boot_warm_ms = warm_ms          # type: ignore[attr-defined]
+    ex._send = _send                    # type: ignore[assignment]
+    inj = _InjectionResult(kwargs={}, loaded={})
+    inj.adoptions.extend(adoptions)
+    asyncio.run(ex._report_adoptions(inj, proof))
+    return [m.model_event for m in sent if m.WhichOneof("msg") == "model_event"]
+
+
+def test_an_armed_adoption_reports_its_arm_time_AND_its_warm_time() -> None:
+    """The acceptance: both halves are non-zero and both are the real numbers.
+
+    `duration_ms` is what arming cost; `warmup_s` is what the cell STILL costs
+    once armed — the "with-cell side of the trade" th#1329 exists to price and
+    has never had a single sample of.
+    """
+    row = CellAdoption(
+        ref=REF, snapshot_digest=DIGEST, artifact_kind="aot-inductor",
+        arm_ms=412, armed=True, pipeline_id=7)
+    events = _report([row], {7: (5, 4, 1)}, warm_ms=1_750)
+
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.state == pb.MODEL_STATE_ADOPTED
+    assert ev.ref == REF and ev.snapshot_digest == DIGEST
+    assert ev.duration_ms == 412, "the arm reported no time"
+    assert ev.warmup_s == pytest.approx(1.75), "the warmup reported no time"
+    assert (ev.cache_hits, ev.cache_misses) == (4, 1)
+    # The wire contract's own name for a boot-attached cell. The hub stores
+    # these without being taught a second spelling.
+    assert ev.operation_id == "" and ev.target_incarnation_id == ""
+
+
+def test_a_refused_adoption_reports_the_classified_reason_on_the_same_lane() -> None:
+    """th#1352's half. `adopt_failed:<reason>` is the same grammar the
+    hub-commanded path uses, so ONE `kind=compile_cache_adopt` query returns
+    the whole outcome distribution instead of two half-populations."""
+    row = CellAdoption(
+        ref=REF, snapshot_digest=DIGEST, artifact_kind="aot-inductor",
+        arm_ms=88, armed=False, reason="key_mismatch",
+        detail="cell was minted for sm_90", pipeline_id=9)
+    events = _report([row], {}, warm_ms=0)
+
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.state == pb.MODEL_STATE_FAILED
+    assert ev.error == "adopt_failed:key_mismatch"
+    assert ev.ref == REF and ev.snapshot_digest == DIGEST
+    assert ev.duration_ms == 88
+
+
+def test_an_adoption_with_no_candidate_identity_is_not_reported() -> None:
+    """A measurement the hub cannot attribute to a cell answers nothing, and
+    the hub drops it from its side too. Not reporting it is cheaper than
+    storing a row that has to be filtered out of every query."""
+    row = CellAdoption(
+        ref="", snapshot_digest="", artifact_kind="", arm_ms=5, armed=True)
+    assert _report([row], {}, warm_ms=10) == []
+
+
+def test_each_adoption_is_its_own_sample() -> None:
+    """Two attempts are two measurements — a discovered cell that refused and
+    a delivered cell that armed are different facts about the same boot."""
+    events = _report(
+        [
+            CellAdoption(ref=REF, snapshot_digest=DIGEST,
+                         artifact_kind="aot-inductor", arm_ms=30,
+                         armed=False, reason="no_arm_for_mode", pipeline_id=1),
+            CellAdoption(ref=REF + "-b", snapshot_digest=DIGEST,
+                         artifact_kind="", arm_ms=90, armed=True,
+                         pipeline_id=1),
+        ],
+        {1: (2, 2, 0)}, warm_ms=500)
+    assert [e.state for e in events] == [
+        pb.MODEL_STATE_FAILED, pb.MODEL_STATE_ADOPTED]
+    assert events[0].error == "adopt_failed:no_arm_for_mode"
+    assert events[1].warmup_s == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# the arm itself: measured once, in the one place that arms (pgw#923/#924)
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    pass
+
+
+class _Cfg:
+    family = "sdxl"
+    lora_bucket = 0
+
+
+def test_the_arm_is_measured_and_recorded_as_the_cell_arm_boot_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any,
+) -> None:
+    """`cell_arm` was a DECLARED boot phase with no producer anywhere in the
+    SDK — only unit tests constructed it. It now brackets the real arm, and its
+    duration is the same interval the adoption reports, so the boot ladder and
+    the hub's adoption measurement cannot disagree about what an arm cost.
+    """
+    artifact = tmp_path / "cell.tar.gz"
+    artifact.write_bytes(b"cell")
+
+    def _slow_arm(pipe: Any, cfg: Any, cache_dir: Any, art: Any) -> AdoptOutcome:
+        time.sleep(0.05)
+        return AdoptOutcome.hit("family=sdxl key=ck5-abc")
+
+    monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _slow_arm)
+    outcome = fleet_cells.enable_compiled(
+        _Pipe(), _Cfg(), artifact=artifact,
+        delivered_ref=REF, delivered_digest=DIGEST)
+
+    assert outcome.armed
+    assert len(outcome.adoptions) == 1
+    assert outcome.adoptions[0].arm_ms >= 40
+
+    arm_rows = [r for r in boot_phases.recorded_rows()
+                if r.phase == boot_phases.PHASE_CELL_ARM and r.terminal]
+    assert len(arm_rows) == 1, "the arm recorded no cell_arm boot phase"
+    assert arm_rows[0].ref == REF
+    assert arm_rows[0].artifact_key == DIGEST
+    assert arm_rows[0].duration_ms >= 40
+    assert arm_rows[0].outcome == boot_phases.OUTCOME_OK
+
+
+def test_a_refused_arm_records_the_reason_on_its_boot_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any,
+) -> None:
+    artifact = tmp_path / "cell.tar.gz"
+    artifact.write_bytes(b"cell")
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("host_isa_unsupported", "sparc64"))
+    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: False)
+
+    outcome = fleet_cells.enable_compiled(
+        _Pipe(), _Cfg(), artifact=artifact,
+        delivered_ref=REF, delivered_digest=DIGEST)
+
+    assert not outcome.armed
+    assert [r.reason for r in outcome.adoptions] == ["host_isa_unsupported"]
+    arm_rows = [r for r in boot_phases.recorded_rows()
+                if r.phase == boot_phases.PHASE_CELL_ARM and r.terminal]
+    assert len(arm_rows) == 1
+    # A typed refusal, never a failure: the worker declined this cell and goes
+    # on serving eager.
+    assert arm_rows[0].outcome == boot_phases.OUTCOME_REFUSED
+    assert arm_rows[0].reason == "host_isa_unsupported"
+
+
+def test_an_arm_with_no_candidate_records_no_cell_arm_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`provision.enable_compiled` with no artifact also covers the seeded and
+    ALLOW_COLD inductor lanes. Bracketing those would put a near-zero
+    `cell_arm` row on every compile-declaring boot — the same default-read-as-a-
+    fact defect pgw#924 closes for `warmup`."""
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.hit())
+    outcome = fleet_cells.enable_compiled(_Pipe(), _Cfg())
+
+    assert outcome.armed
+    assert outcome.adoptions == ()
+    assert not [r for r in boot_phases.recorded_rows()
+                if r.phase == boot_phases.PHASE_CELL_ARM]

--- a/tests/test_desired_hot_th1055.py
+++ b/tests/test_desired_hot_th1055.py
@@ -43,6 +43,7 @@ from gen_worker.executor import Executor
 from gen_worker.models import provision
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "th1055-fam"
 AUTHORED = Hub("acme/qwen-image", tag="prod")
@@ -184,7 +185,7 @@ def _harness(tmp_path: Path, monkeypatch, specs: List[EndpointSpec]):
             "originals": [],
             "regional_mods": [],
         })
-        return True
+        return AdoptOutcome.hit()
 
     monkeypatch.setattr(provision, "enable_compiled", _fake_enable)
     return ex, sent, enables

--- a/tests/test_error_visibility_pgw760.py
+++ b/tests/test_error_visibility_pgw760.py
@@ -48,37 +48,43 @@ class _Cfg:
     family = "sdxl"
 
 
-def test_trt_enable_refusal_rides_typed_event(
+def test_trt_enable_refusal_names_the_classified_reason(
     events: List[Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
+    """pgw#923: the reason is RETURNED, not narrated.
+
+    It used to ride a free-text `trt_adopt` event — a third spelling of "a cell
+    adopted and what it cost", next to `aot_adopt` and the measured
+    `compile_cache_adopt`. `trt_adopt` is deleted; the classified reason now
+    reaches the hub as this adoption's own `adopt_failed:<reason>`, which is
+    countable in the same query as every other adoption outcome.
+    """
     def refuse(*a: Any, **k: Any) -> Dict[str, Any]:
         raise AdoptError("no_target", "pipeline has no module 'unet'")
 
     monkeypatch.setattr(trt_engine, "load_and_wrap", refuse)
     artifact = tmp_path / "engine.tar"
     artifact.write_bytes(b"not-a-real-artifact")
-    assert trt_engine.enable(object(), _Cfg(), artifact=artifact) is False
+    out = trt_engine.enable(object(), _Cfg(), artifact=artifact)
+    assert out.armed is False
+    assert out.reason == "no_target"  # the CLASSIFIED reason, not a kind
+    assert "engine.tar" in out.detail
+    assert "no module 'unet'" in out.detail
+    # And no second vocabulary was written on the way past.
+    assert not [e for e in events if e.kind == "trt_adopt"]
 
-    got = _by_kind(events, activity.KIND_TRT_ADOPT)
-    assert len(got) == 1
-    assert got[0].phase == "no_target"  # the CLASSIFIED reason, not a kind
-    assert "engine.tar" in got[0].detail
-    assert "no module 'unet'" in got[0].detail
 
-
-def test_trt_enable_success_rides_typed_event(
+def test_trt_enable_success_names_the_engine(
     events: List[Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     meta = {"module": "unet", "sku": "l4", "trt": "10.8", "precision": "fp8"}
     monkeypatch.setattr(trt_engine, "load_and_wrap", lambda *a, **k: meta)
     artifact = tmp_path / "engine.tar"
     artifact.write_bytes(b"x")
-    assert trt_engine.enable(object(), _Cfg(), artifact=artifact) is True
-
-    got = _by_kind(events, activity.KIND_TRT_ADOPT)
-    assert len(got) == 1
-    assert got[0].phase == "armed"
-    assert "module=unet" in got[0].detail
+    out = trt_engine.enable(object(), _Cfg(), artifact=artifact)
+    assert out.armed is True
+    assert "module=unet" in out.identity
+    assert not [e for e in events if e.kind == "trt_adopt"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1150,16 +1150,27 @@ def test_store_served_boot_with_hidden_compile_fires_alarm(
     assert any(
         "STORE_SERVED_BOOT_COMPILED" in r.message for r in caplog.records
     ), "a store-served boot that hid a real compile must alarm loudly"
-    adopted = [
+    # pgw#923: the alarm has its OWN typed event. It used to ride
+    # `ModelEvent{ADOPTED}` with `duration_ms` redefined to mean "inductor
+    # compile wall" — a second meaning for the one field the adoption
+    # measurement lane (`compile_cache_adopt`) percentiles over, on the only
+    # other boot-path sender of that message. Two meanings for one field is
+    # how the lane could never be read.
+    alarms = [
+        m for m in sent
+        if m.HasField("activity_update")
+        and m.activity_update.kind == "store_served_boot_compiled"
+    ]
+    (alarm,) = alarms
+    assert CACHE_REF in alarm.activity_update.detail
+    assert DIGEST_A in alarm.activity_update.detail
+    assert alarm.activity_update.duration_ms == 45000
+    assert not [
         m for m in sent
         if m.HasField("model_event")
         and m.model_event.state == pb.MODEL_STATE_ADOPTED
-    ]
-    (msg,) = adopted
-    assert msg.model_event.ref == CACHE_REF
-    assert msg.model_event.snapshot_digest == DIGEST_A
-    assert msg.model_event.cache_hits >= 1
-    assert msg.model_event.duration_ms == 45000
+        and m.model_event.duration_ms == 45000
+    ], "the alarm still hijacks the adoption measurement's duration field"
 
 
 def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
@@ -1545,7 +1556,7 @@ def test_pending_self_mint_boot_packs_and_publishes_only_the_proven_capture(
     )
     monkeypatch.setattr(
         ex, "_enable_compiled",
-        lambda p, cfg, artifact: fleet_cells.enable_compiled(
+        lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
             p, cfg, ex.store._cache_dir, artifact, publisher=pub))
     _MintingEndpoint.setups = _MintingEndpoint.warmups = 0
 
@@ -1654,7 +1665,7 @@ def test_pending_self_mint_unproven_fails_closed_and_never_publishes(
     )
     monkeypatch.setattr(
         ex, "_enable_compiled",
-        lambda p, cfg, artifact: fleet_cells.enable_compiled(
+        lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
             p, cfg, ex.store._cache_dir, artifact, publisher=pub))
     _UnprovenEndpoint.setups = _UnprovenEndpoint.warmups = 0
 
@@ -3905,7 +3916,7 @@ def _dual_mint_boot(tmp_path, monkeypatch, *, publisher, warm_second: bool):
     )
     monkeypatch.setattr(
         ex, "_enable_compiled",
-        lambda p, cfg, artifact: fleet_cells.enable_compiled(
+        lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
             p, cfg, ex.store._cache_dir, artifact, publisher=publisher))
     snapshots = {
         wire_ref(spec.models["first"]): pb.Snapshot(digest=MODEL_DIGEST),
@@ -4114,7 +4125,7 @@ def _routed_mint_boot(tmp_path, monkeypatch, *, publisher):
     )
     monkeypatch.setattr(
         ex, "_enable_compiled",
-        lambda p, cfg, artifact: fleet_cells.enable_compiled(
+        lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
             p, cfg, ex.store._cache_dir, artifact, publisher=publisher))
     snapshots = {
         wire_ref(spec.models["first"]): pb.Snapshot(digest=MODEL_DIGEST),

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -24,6 +24,7 @@ from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure
 from gen_worker.models import provision
+from gen_worker.cell_adopt import AdoptOutcome
 
 
 class _Cfg:
@@ -65,7 +66,9 @@ def _clear_pending():
 
 def _mintable(monkeypatch, *, key=FAKE_KEY):
     """Route a MISS into the cold-capture arm with no CUDA/toolchain."""
-    monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: False)
+    monkeypatch.setattr(
+        provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fc, "_cuda_ready", lambda: True)
     monkeypatch.setattr(cc, "toolchain_present", lambda: True)
     # pgw#681 gate at its torch boundary, simmed: these rigs never compile
@@ -127,7 +130,8 @@ def _in_process_mint_shape(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_delivered_cell_hit_never_mints_or_publishes(monkeypatch, tmp_path):
     calls: list = []
-    monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: True)
+    monkeypatch.setattr(
+        provision, "enable_compiled", lambda *a, **k: AdoptOutcome.hit())
     monkeypatch.setattr(
         cc, "begin_fleet_mint",
         lambda *a, **k: pytest.fail("HIT must never open a mint capture"))
@@ -357,7 +361,9 @@ def test_withheld_publish_never_ships_and_is_final(monkeypatch, tmp_path):
 def test_mint_impossible_keeps_quantized_typed_refusal(monkeypatch, tmp_path):
     """No CUDA => plain lanes serve eager (False), quantized lanes keep the
     typed fail-closed refusal — never a silent slow eager serve."""
-    monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: False)
+    monkeypatch.setattr(
+        provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fc, "_cuda_ready", lambda: False)
 
     plain = _Pipe()

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -537,7 +537,7 @@ class _Rig:
             pass
         monkeypatch.setattr(
             self.ex, "_enable_compiled",
-            lambda p, cfg, artifact: fleet_cells.enable_compiled(
+            lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
                 p, cfg, self.ex.store._cache_dir, artifact,
                 publisher=None))
 

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -16,6 +16,7 @@ import pytest
 from gen_worker import compile_cache as cc
 from gen_worker import guard_closure
 from gen_worker import local_cells as lc
+from gen_worker.cell_adopt import AdoptOutcome
 
 
 @pytest.fixture(autouse=True)
@@ -190,7 +191,9 @@ def _local_env(monkeypatch, tmp_path):
     # keep the delivered-artifact leg deterministic on GPU-less CI
     from gen_worker.models import provision
 
-    monkeypatch.setattr(provision, "enable_compiled", lambda *a, **k: False)
+    monkeypatch.setattr(
+        provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell"))
     return tmp_path / "store"
 
 

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -187,7 +187,7 @@ def test_enable_compiled_rolls_back_branches_when_eager(plain_pipe: Any) -> None
     """No cell + no CUDA => stays eager; the declared branch lane must not
     leak into eager serving (canonical zeroed slots cost +21-32% eager)."""
     cfg = _cfg("loracells-test", lora_bucket=32)
-    armed = provision.enable_compiled(plain_pipe, cfg, cache_dir=None, artifact=None)
+    armed = provision.enable_compiled(plain_pipe, cfg, cache_dir=None, artifact=None).armed
     assert armed is False
     assert branch_bucket(plain_pipe.unet) == 0
     from gen_worker.models.loading import pipeline_weight_lane
@@ -284,7 +284,7 @@ def test_enable_compiled_skips_lane_on_component_slot_without_target() -> None:
 
     vae = _Vae()
     cfg = _cfg("loracells-test", lora_bucket=64)
-    armed = provision.enable_compiled(vae, cfg, cache_dir=None, artifact=None)
+    armed = provision.enable_compiled(vae, cfg, cache_dir=None, artifact=None).armed
     assert armed is False
 
 
@@ -326,5 +326,5 @@ def test_delivered_lora_cell_on_component_slot_is_ordinary_miss(
 
     vae = _Vae()
     armed = provision.enable_compiled(
-        vae, cfg, cache_dir=tmp_path / "cache", artifact=artifact)
+        vae, cfg, cache_dir=tmp_path / "cache", artifact=artifact).armed
     assert armed is False

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -47,6 +47,7 @@ from gen_worker.executor import (
     _mint_modules,
 )
 from gen_worker.registry import CompileCell, extract_specs
+from gen_worker.cell_adopt import AdoptOutcome
 
 GIB = 1 << 30
 STUB_MODULE = "harness.mint_child_stub"
@@ -106,7 +107,8 @@ def test_the_arm_returns_armed_false_with_a_delegated_pending(
     """Restating it from the other side, so the two halves cannot drift: the
     arming brain really does hand back armed=False plus an obligation."""
     monkeypatch.setattr(
-        fleet_cells.provision, "enable_compiled", lambda *a, **k: False)
+        fleet_cells.provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda *a, **k: True)
     monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda pipe: False)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)

--- a/tests/test_mode_decline_pgw846.py
+++ b/tests/test_mode_decline_pgw846.py
@@ -35,7 +35,9 @@ def test_a_cell_whose_mode_has_no_arm_is_declined_by_name_and_stays_eager(
     class _Pipe:
         pass
 
-    armed = provision.arm_aot(
+    outcome = provision.arm_aot(
         _Pipe(), object(), None, Path("/nonexistent/cell.tar.gz"),
         0, {"mode": mode})
-    assert armed is False
+    assert outcome.armed is False
+    # The decline is BY NAME (pgw#827/pgw#923), not a bare False.
+    assert outcome.reason == "no_arm_for_mode"

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -219,8 +219,14 @@ def events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
 
 def arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
         packages: Dict[str, ProbePackage],
-        meta: Dict[str, Any] | None = None) -> Tuple[Any, Any, bool]:
-    """Drive the REAL arm path and return ``(pipeline, module, armed)``."""
+        meta: Dict[str, Any] | None = None) -> Tuple[Any, Any, Any]:
+    """Drive the REAL arm path and return ``(pipeline, module, outcome)``.
+
+    pgw#923: the arm returns a typed :class:`AdoptOutcome` rather than a bool,
+    so its verdict — armed, or refused with the classified reason — is a value
+    the caller can assert on and the executor can put on the wire. It stays
+    truthy/falsy, so `assert outcome` reads exactly as `assert armed` did.
+    """
     from gen_worker.models import provision
 
     monkeypatch.setattr(aot, "runtime_key", lambda: dict(RUNTIME))
@@ -228,9 +234,9 @@ def arm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, decl: Any,
         aot, "_load_package", lambda path, entry="model": packages[entry])
     module = ProbeDenoiser()
     pipeline = ProbePipeline(module)
-    armed = provision.arm_aot(
+    outcome = provision.arm_aot(
         pipeline, decl, tmp_path / "cache", artifact(tmp_path, meta), 0)
-    return pipeline, module, armed
+    return pipeline, module, outcome
 
 
 def numerics_rows(said: List[Tuple[str, str, str]]) -> List[Tuple[str, str]]:
@@ -255,20 +261,22 @@ def test_a_cell_below_its_declared_floor_REFUSES_TO_ARM(
     returns True and the 0.99-cosine cell serves every subsequent request.
     """
     packages = {entry_name(h, w): ProbePackage(cosine=0.99) for h, w in ROWS}
-    pipeline, module, armed = arm(tmp_path, monkeypatch, declared, packages)
+    pipeline, module, outcome = arm(tmp_path, monkeypatch, declared, packages)
 
-    assert armed is False, "a cell that lost 1% of the output's direction armed"
+    assert outcome.armed is False, "a cell that lost 1% of the output's direction armed"
     # Refused means UNARMED, not merely reported: the module must be eager.
     assert aot.is_armed(pipeline) is False
     assert aot.armed_targets(pipeline) == {}
     assert isinstance(module.forward(torch.zeros(8, 8), torch.tensor(1.0)),
                       torch.Tensor)
 
-    # The ADOPT ledger closes too: `enable` said `armed` before the gate ran,
-    # so a reader counting armed adoptions must see the retraction.
-    adopt = [(d, ph) for k, d, ph in events if k == aot.ADOPT_EVENT]
-    assert [ph for _d, ph in adopt] == ["armed", "numerics_refused"], adopt
-    assert "UNARMED by the numerics gate" in adopt[-1][0]
+    # pgw#923: the adopt ledger cannot need closing, because nothing is
+    # announced until the arm is FINAL. `enable` used to say `armed` before
+    # this gate ran, so a reader counting armed adoptions over-counted every
+    # numerics refusal and a second "retraction" row existed only to correct
+    # the first. The arm returns ONE outcome, with the gate's verdict in it.
+    assert outcome.reason == "numerics_refused"
+    assert "UNARMED by the numerics gate" in outcome.detail
 
     rows = numerics_rows(events)
     assert rows, "a refused cell said nothing on the wire"
@@ -286,9 +294,9 @@ def test_between_floor_and_warn_it_ARMS_and_records_the_warning(
     """The gray band is not a refusal and not a silence. It serves, and it
     confesses — a fleet-wide rate is only countable from activity records."""
     packages = {entry_name(h, w): ProbePackage(cosine=0.997) for h, w in ROWS}
-    pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
+    pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
 
-    assert armed is True, "a cell inside the declared gray band failed to arm"
+    assert outcome.armed is True, "a cell inside the declared gray band failed to arm"
     assert aot.is_armed(pipeline) is True
     rows = numerics_rows(events)
     assert [p for _d, p in rows] == ["degraded"], rows
@@ -303,9 +311,9 @@ def test_a_faithful_cell_arms_AND_THE_PASS_IS_ANNOUNCED(
     this program's signature failure. So the pass is a hub row too, carrying
     every axis it was taken on."""
     packages = {entry_name(h, w): ProbePackage() for h, w in ROWS}
-    pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
+    pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
 
-    assert armed is True
+    assert outcome.armed is True
     assert aot.is_armed(pipeline) is True
     rows = numerics_rows(events)
     assert [p for _d, p in rows] == ["checked"], rows
@@ -333,9 +341,9 @@ def test_a_cell_that_cannot_be_MEASURED_does_not_arm(
     is the ordinary miss policy of every other adopt gate, so the cost of a
     probe defect is an un-armed cell — never a silently degraded one."""
     packages = {entry_name(h, w): package for h, w in ROWS}
-    pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
+    pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
 
-    assert armed is False
+    assert outcome.armed is False
     assert aot.is_armed(pipeline) is False
     detail, phase = numerics_rows(events)[-1]
     assert phase == "unmeasurable"
@@ -349,10 +357,10 @@ def test_an_undeclared_family_cannot_be_probed_AND_THEREFORE_CANNOT_ARM(
     state the whole fleet was in, and it must read as a refusal."""
     reset_export_declarations()
     packages = {entry_name(h, w): ProbePackage() for h, w in ROWS}
-    _pipeline, _module, armed = arm(
+    _pipeline, _module, outcome = arm(
         tmp_path, monkeypatch, declaration(), packages)
 
-    assert armed is False
+    assert outcome.armed is False
     detail, phase = numerics_rows(events)[-1]
     assert phase == "unmeasurable"
     assert "no_input_contract" in detail
@@ -398,9 +406,9 @@ def test_the_verdict_is_bisectable_to_ONE_named_axis(
 
     good, bad = entry_name(*ROWS[0]), entry_name(*ROWS[1])
     packages = {good: ProbePackage(), bad: ProbePackage(cosine=0.90)}
-    pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
+    pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
 
-    assert armed is False
+    assert outcome.armed is False
     detail, phase = numerics_rows(events)[-1]
     assert phase == "refused"
     # The whole-cell verdict names the class that parted from eager, and the
@@ -416,7 +424,7 @@ def test_the_verdict_is_bisectable_to_ONE_named_axis(
     module = ProbeDenoiser()
     pipeline = ProbePipeline(module)
     assert aot.enable(pipeline, declared, tmp_path / "c2",
-                      artifact(tmp_path)) is True
+                      artifact(tmp_path)).armed is True
     one = numerics_probe.probe_cell(
         pipeline, declared, aot.armed_metadata(pipeline), only=bad)
     assert [v.axis.name for v in one.verdicts] == [bad]
@@ -456,8 +464,8 @@ def test_the_probe_does_not_disturb_the_serving_RNG(
     torch.manual_seed(4242)
     before = torch.get_rng_state().clone()
     packages = {entry_name(h, w): ProbePackage() for h, w in ROWS}
-    _pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
-    assert armed is True
+    _pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
+    assert outcome.armed is True
     assert torch.equal(torch.get_rng_state(), before)
 
 
@@ -476,8 +484,8 @@ def test_a_REAL_arm_reaches_the_gate(tmp_path, monkeypatch, declared, events):
     `invocations` stays 0 and `armed` is True.
     """
     packages = {entry_name(h, w): ProbePackage() for h, w in ROWS}
-    _pipeline, _module, armed = arm(tmp_path, monkeypatch, declared, packages)
-    assert armed is True
+    _pipeline, _module, outcome = arm(tmp_path, monkeypatch, declared, packages)
+    assert outcome.armed is True
     assert all(p.invocations == 1 for p in packages.values()), (
         "a REAL arm did not run the cell against its eager reference: "
         f"{ {k: p.invocations for k, p in packages.items()} }")

--- a/tests/test_receipts_pgw709.py
+++ b/tests/test_receipts_pgw709.py
@@ -379,7 +379,7 @@ class TestProvisionHook:
             family = FAMILY
             lora_bucket = 0
 
-        armed = provision.enable_compiled(object(), Cfg(), tmp_path, artifact)
+        armed = provision.enable_compiled(object(), Cfg(), tmp_path, artifact).armed
         assert armed is False
         assert seen["artifact"] is None, (
             "refused delivered artifact leaked through to compile_cache.enable"
@@ -408,7 +408,7 @@ class TestProvisionHook:
             family = FAMILY
             lora_bucket = 0
 
-        armed = provision.enable_compiled(object(), Cfg(), tmp_path, artifact)
+        armed = provision.enable_compiled(object(), Cfg(), tmp_path, artifact).armed
         assert armed is True
         assert seen["artifact"] == artifact
 

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -279,7 +279,7 @@ class _Rig:
         for spec in specs:
             monkeypatch.setattr(
                 self.ex, "_enable_compiled",
-                lambda p, cfg, artifact: fleet_cells.enable_compiled(
+                lambda p, cfg, artifact, delivered=None: fleet_cells.enable_compiled(
                     p, cfg, self.ex.store._cache_dir, artifact,
                     publisher=None))
             break

--- a/tests/test_trt_engine.py
+++ b/tests/test_trt_engine.py
@@ -15,6 +15,7 @@ import pytest
 from gen_worker import compile_cache as cc
 from gen_worker import trt_engine as te
 from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.cell_adopt import AdoptOutcome
 
 from test_executor_adopt import (  # noqa: F401 — shared harness
     CACHE_REF,
@@ -485,7 +486,7 @@ def test_enable_compiled_dispatches_on_artifact_kind(tmp_path, monkeypatch):
 
     def _trt_enable(p, c, d, a):
         seen["trt"] = Path(a)
-        return True
+        return AdoptOutcome.hit()
 
     def _cc_enable(p, c, d, a):
         seen["cc"] = a


### PR DESCRIPTION
Two telemetry lanes that reported zeros. A lane that reports zeros is worse than an absent one: it looks like a measurement.

## pgw#923 — the adoption fact had two spellings, and the typed one was empty

**Classification: Z-gated.** th#1329/th#1352 gave the hub a durable, indexed, percentile-backed home for "what did arming this cell cost, and what does it still cost at warm time" — `worker_activity_events` kind `compile_cache_adopt`, fed by `ModelEvent{ADOPTED}`/`{FAILED}`. Confirmed live before building:

```
kind='compile_cache_adopt' -> 0 rows
kind='aot_adopt'           -> 5 rows, all duration_ms=0
kind='trt_adopt'           -> 0 rows
```

Not a receiver bug. The only worker-side sender of the measured event was the hub-commanded `ADOPT_COMPILE_CACHE` handler, and no stack has ever dispatched that operation. Adoptions happen at **boot**, through `fleet_cells`, and that path sent no `ModelEvent` at all — it emitted free-text `aot_adopt`, which lands at `duration_ms=0` and smuggles identity into prose.

**Verdict: the typed vocabulary survives; both free-text ones are deleted.** The free-text lane carried nothing the typed one cannot — identity is `ref` (`root/family-<f>#ck5-…`, already family + cell key) plus `snapshot_digest`, and the classified reason survives as `adopt_failed:<reason>`, the same grammar the commanded path uses. The typed lane additionally carries the four numbers the free-text one never had.

- `aot_serve.enable`, `provision.arm_aot`/`enable_compiled`, `trt_engine.enable` **return** a typed `AdoptOutcome` (`src/gen_worker/cell_adopt.py`) instead of narrating into an event and returning a bool. This was the mechanism of the defect: the frame that knew the outcome was not the frame that owns the wire. Still truthy/falsy, so every `if enable_compiled(...)` reads unchanged.
- `fleet_cells.enable_compiled` measures each arm and collects every attempt onto `ArmOutcome.adoptions`.
- `Executor._report_adoptions` sends one `ModelEvent` per attempt after the boot warmup, so `duration_ms` (arm) and `warmup_s` (what the armed cell still costs) are both real. `operation_id` is empty — already the wire contract's own name for a boot-attached cell (`worker_scheduler.proto:1149-1152`), so **no proto or hub change is needed** for the rows to land.
- **`trt_adopt` deleted too** (beyond the issue as filed): a third spelling of the same fact.
- **The STORE_SERVED_BOOT_COMPILED alarm stops hijacking `ModelEvent{ADOPTED}`** with `duration_ms` redefined as "inductor compile wall" — a second meaning for the one field the measurement lane percentiles over. It gets its own typed event.
- The numerics gate's `numerics_refused` retraction row is deleted *with its cause*: `enable` announced `armed` before the gate ran, so a second row existed only to correct the first.

## pgw#924 — 17 declared phases, 8 producers, and every warmup span a zero

| phase | classification | action |
|---|---|---|
| `process_start` `env_seal` `manifest_load` `cache_preflight` `cuda_probe` `cell_load` `first_request` | **Z-none** — no producer in `src/`, only unit tests constructed them | deleted |
| `cell_arm` | declared, no producer, **retained by ruling** | **producer built** — brackets the real arm in `fleet_cells._arm_candidate`, over the same interval the adoption reports |
| `warm_complete` | live and real, but **not a boot phase** — rows reach 4,863,664 ms, 80 minutes past the boot | boot row deleted; the mint-goal latch and pgw#805 backstop it also performed are kept |
| `warmup_iteration` | **Z-traffic**, not Z-structural (see correction) | deleted on the design ruling |
| `warmup` | producer fires 240× and every row is `duration_ms=0` — the §4.22 defect | emitted only when a forward actually ran |
| `hello` `weights_fetch` `pipeline_load` `cell_discover` `cell_fetch` `first_request_servable` | live, real | kept |

### Two corrections to the issue's evidence

1. **`warmup_iteration` is NOT unwired.** "wired — `executor.py:6176` — never fired" is wrong about the code: `tests/test_boot_span_ladder_pgw797.py` boots a real `Worker` against a real gRPC hub double and the row *does* fire there. Its zero on both stacks is Z-traffic — the live endpoints plan no boot warm units. Deleted anyway, on the ruling (an admin-forensics table carries no per-forward decomposition), not on "no producer".
2. **`warmup`'s zero has the same cause.** The producer is reachable; the bracket opened unconditionally around a plan that is empty on most setup slots. So the fix is to stop emitting a row when nothing warmed, not to build a missing producer.

`graph_class` (0/517 live) is dropped from the recorder API. The proto field is **vendored** from tensorhub under a digest gate (pgw#944), so its removal is th#1457/th#1488's.

## Hub-side remainder (th#1458/th#1459)

A boot-attached adoption has no issued operation, so `recordCompileCacheAdoptResult` returns `operation_id_missing` and the row lands in phase `adopted_unmatched` — documented as "a delayed, replayed or superseded answer". Wrong label for a shape the proto explicitly anticipates. The hub should give boot attachment its own phase and decide whether the percentile surface includes it. Rows are stored and queryable meanwhile.

## Proof

- `tests/test_boot_span_ladder_pgw797.py` — real `Worker`, real gRPC hub double, rows read off the wire. Now asserts no phase outside the eight-name vocabulary appears and every `warmup` row carries `forwards>=1`.
- `tests/test_cell_adoption_measurement_pgw923.py` — holds an arm open for a known interval and a warmup for a second known interval, asserts the stored numbers. The emitter that shipped for a year reported zero and cannot pass it.
- mypy clean (224 files); ruff clean on `src/`.

**Not verified end to end:** a real cell adoption needs a real `.pt2`/dynamo artifact on a GPU pod. The arm, ledger and wire event are proven on real code paths; the row actually appearing in `worker_activity_events` needs one GPU-lane boot with a delivered cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)