### PR TITLE
pgw#923 follow-up: three arm stubs that still hand back a bool

### DIFF
--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -42,6 +42,7 @@ from gen_worker.api.export_contract import (
     export_declaration, register_export_declaration, reset_export_declarations,
 )
 from gen_worker import config as gw_config
+from gen_worker.cell_adopt import AdoptOutcome
 
 FAMILY = "sdxl"
 
@@ -122,7 +123,7 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(aot_cells, "discover", lambda *a, **k: None)
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: False)
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)
@@ -468,7 +469,7 @@ def test_a_self_minted_aot_cell_arms_through_the_aot_gates(
     calls: List[str] = []
     monkeypatch.setattr(
         fleet_cells.provision, "arm_aot",
-        lambda *a, **k: (calls.append("aot"), True)[1])
+        lambda *a, **k: (calls.append("aot"), AdoptOutcome.hit())[1])
     monkeypatch.setattr(
         fleet_cells.cc, "enable",
         lambda *a, **k: (calls.append("dynamo"), True)[1])

--- a/tests/test_declaration_cannot_break_serving_pgw853.py
+++ b/tests/test_declaration_cannot_break_serving_pgw853.py
@@ -40,6 +40,7 @@ from gen_worker.api.export_contract import (
 )
 from gen_worker import config as gw_config
 from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.cell_adopt import AdoptOutcome
 
 from harness.hub_double import hub_double, is_ready, is_result_for
 
@@ -246,7 +247,7 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     monkeypatch.setattr(aot_cells, "discover", lambda *a, **k: None)
     monkeypatch.setattr(
         fleet_cells.provision, "enable_compiled",
-        lambda pipe, cfg, cache_dir, artifact: False)
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -36,6 +36,7 @@ from gen_worker import fleet_cells, mint_budget, mint_delegate
 from gen_worker import mint_process as mp
 from gen_worker.api.decorators import DynamicDim
 from gen_worker.registry import CompileCell
+from gen_worker.cell_adopt import AdoptOutcome
 
 GIB = 1 << 30
 STUB_MODULE = "harness.mint_child_stub"
@@ -88,7 +89,8 @@ def test_the_delegated_arm_never_touches_the_live_pipeline(
         cc, "begin_fleet_mint",
         lambda *a, **k: armed.append("begin_fleet_mint"))
     monkeypatch.setattr(
-        fleet_cells.provision, "enable_compiled", lambda *a, **k: False)
+        fleet_cells.provision, "enable_compiled",
+        lambda *a, **k: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(cc, "has_compile_target", lambda *a, **k: True)
     monkeypatch.setattr(cc, "mandatory_serving", lambda pipe: False)
     monkeypatch.setattr(cc, "apply_lora_lane", lambda pipe, bucket: True)


### PR DESCRIPTION
#444 changed the arm's return type from `bool` to the typed `AdoptOutcome` — that *was* the fix, since the frame that knew the adoption outcome could not put it on the wire, which is why `compile_cache_adopt` had zero rows on both stacks.

Three test stubs of `provision.enable_compiled` / `provision.arm_aot` were missed in the sweep and still return `True`/`False`, so `fleet_cells._arm_candidate` receives a bool and raises `AttributeError: 'bool' object has no attribute 'armed'`. **12 tests are currently red on `dev`:**

- `tests/test_aot_selfmint_pgw805.py` (6)
- `tests/test_declaration_cannot_break_serving_pgw853.py` (2)
- `tests/test_mint_delegate_pgw784.py` (1)
- plus 3 more that cascade through the same stubs

All 38 tests in those files pass with this change.

## How they were missed, and how they were found

The original sweep grepped for `setattr(..., "enable_compiled", ...)` and patched what it found. These three hid behind different shapes — a `lambda pipe, cfg, cache_dir, artifact: False` inside a fixture, and a `(calls.append("aot"), True)[1]` tuple-index idiom. A grep for the *name* found the call sites; it could not see the *type* flowing out of them.

What found them was re-running the complete pre-change failure list file by file instead of trusting the sweep. Worth keeping: after a return-type change, the honest check is the failing-test list, not a grep.

## The two that are NOT this work

`tests/test_c2pa_hub_side_signing_th1307.py` (2) and `tests/test_nccl_nvls_pgw773.py` (1) were on the same failure list and fail independently — neither touches adoption or boot phases. The NCCL one is a sibling lane's behaviour change speaking for itself in the log: `NCCL_NVLS_ENABLE was '1'; overwritten to 0 … this is not an operator choice (pgw#929)`. The test still asserts the operator's value survives. Both need their own owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)