### PR TITLE
Two promotion blockers: the th#1307 key refusal is reachable again (SECURITY), and the NVLS ruling is upheld (0.91.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.91.3 (2026-08-03) — **SECURITY: the th#1307 private-key refusal is reachable again**, and the NVLS override stays deleted
+
+PATCH: no wire-contract, `@endpoint` or `Resources` change. Both items are promotion blockers
+found on `release/20260803-night-pgw3`; both trace to the pgw#929/#931 env work.
+
+- **SECURITY — `content_credentials`: a C2PA private key delivered to a pod stopped being
+  refused unless something called `configure()`.** 0.91.x rewrote `_active_config` to stop
+  resolving lazily from the cached `Settings` loader. That part is right and stays — a signing
+  module must not go and find its own config in the environment — but the th#1307 ratchet
+  (`GEN_WORKER_C2PA_KEY_PEM` / `_KEY_PATH` present ⇒ raise) was riding *inside* the
+  `configure()` call the lazy path made, so deleting the path deleted the refusal with it.
+  `configure()` still refused; nothing else did. Any process that does not run the worker
+  bring-up — a library embed, a compute child, an endpoint importing the module directly —
+  got a quiet `enabled() == False` and shipped media **unsigned, beside a platform-wide
+  signing key sitting in `os.environ`**: both failure directions of th#1307 at once.
+  `_refuse_pod_private_key_material()` is now hoisted out of `configure()` and evaluated at
+  the top of `_active_config()`, *before* the `_configured` memo — so it fires for `enabled()`,
+  `sign_media_bytes()` and `sign_media_file()`, whether or not this process configured signing
+  and whether or not the key arrived after a clean configure. The refusal is a property of the
+  pod's environment; no entry point owns it.
+
+- **`NCCL_NVLS_ENABLE`: the unconditional write STANDS — the stale pgw#773 test did not.**
+  `tests/test_nccl_nvls_pgw773.py` still asserted that a pre-set `=1` survives. Checked against
+  pgw#773 before overriding it: pgw#773 never argued for the override — it was a live CUDA-401
+  bug hunt, and respect-if-set was the incidental shape of the one-line fix. pgw#929 §1.17
+  re-adjudicated the same variable as a library-adapter handoff, because the failure it guards
+  is TOTAL (every all-to-all of every arm dies) rather than gradual, so an env inherited from a
+  base image can silently take sequence parallelism to zero. The test encoded an assumption, not
+  a contract, and now encodes the ruling. The removed escape hatch is still covered: the
+  override is never silently discarded — the warning names the variable, the dropped value, the
+  measured reason, and the route forward (a measured capability and a new issue, never this
+  env), and that warning is now part of the pinned contract.
+
 ## 0.91.2 (2026-08-03) — **a produced flavor's passthrough components are one file too**: th#1362's producer invariant stops refusing the married trees it was meant to protect (the te#137 svdq publish blocker)
 
 PATCH: nothing here touches the worker<->hub wire contract, `@endpoint` or `Resources`, so no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.91.2"
+version = "0.91.3"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/content_credentials.py
+++ b/src/gen_worker/content_credentials.py
@@ -26,9 +26,16 @@ Config (Settings / env) — the PUBLIC half only:
 - ``GEN_WORKER_C2PA_TA_URL``   — optional RFC3161 timestamp authority URL.
 
 ``GEN_WORKER_C2PA_KEY_PEM`` / ``_KEY_PATH`` are REFUSED: if either is present
-this module raises at configure() instead of using it. That is the ratchet —
-a hub regression that re-injects the key kills the pod loudly rather than
-quietly re-creating the leak.
+this module raises instead of using it. That is the ratchet — a hub regression
+that re-injects the key kills the pod loudly rather than quietly re-creating
+the leak.
+
+The refusal is a property of the POD ENVIRONMENT, not of one call. It is
+therefore evaluated at every read of the signing state (:func:`_active_config`,
+and so :func:`enabled` and both ``sign_media_*``), not only inside
+:func:`configure`. A process that never called ``configure()`` — a library
+embed, a compute child, a test harness — must not be the process where a
+delivered private key goes unnoticed and media then ships unsigned.
 
 Signing is ON iff cert material is set. The hub transport is armed at HelloAck
 (``configure_remote_signer``, same wiring moment as the cell-receipt gate).
@@ -187,15 +194,7 @@ def configure(settings: Any) -> None:
     is configured (signing disabled).
     """
     global _configured, _config
-    for env_name in _REFUSED_KEY_ENVS:
-        if str(os.environ.get(env_name, "") or "").strip() or str(
-            getattr(settings, env_name.lower().removeprefix("gen_worker_"), "") or ""
-        ).strip():
-            raise C2paSigningError(
-                f"{env_name} is set: a C2PA PRIVATE KEY must never be delivered to a pod "
-                "(th#1307 — tenant code runs in this process and can read it). Signing is "
-                "hub-side: the hub holds the key and signs claims over POST " + SIGN_PATH
-            )
+    _refuse_pod_private_key_material(settings)
     inline_cert = str(getattr(settings, "c2pa_cert_pem", "") or "").strip()
     cert_path = str(getattr(settings, "c2pa_cert_path", "") or "").strip()
     with _lock:
@@ -338,8 +337,38 @@ def sign_media_file(
 # internals
 
 
+def _refuse_pod_private_key_material(settings: Any = None) -> None:
+    """Refuse, loudly, any C2PA PRIVATE KEY delivered to this pod (th#1307).
+
+    This is a ratchet on the pod's environment, so it is checked at every read
+    of the signing state rather than once at ``configure()``. pgw#931 removed
+    ``_active_config``'s lazy ``configure()`` fallback — correctly, since a
+    signing module must not go and find its own config — but the refusal rode
+    along inside that call, so it became reachable only from the one entry that
+    calls ``configure()``. Anything else (a library embed, a compute child, an
+    endpoint importing the module directly) got a quiet ``enabled() == False``
+    and shipped unsigned media beside a key that was sitting right there in the
+    environment. The presence of the key is the fact; no entry point owns it.
+
+    ``settings`` is checked too when supplied, so a field smuggled back into
+    Settings is refused on the same breath as the env.
+    """
+    for env_name in _REFUSED_KEY_ENVS:
+        if str(os.environ.get(env_name, "") or "").strip() or str(
+            getattr(settings, env_name.lower().removeprefix("gen_worker_"), "") or ""
+        ).strip():
+            raise C2paSigningError(
+                f"{env_name} is set: a C2PA PRIVATE KEY must never be delivered to a pod "
+                "(th#1307 — tenant code runs in this process and can read it). Signing is "
+                "hub-side: the hub holds the key and signs claims over POST " + SIGN_PATH
+            )
+
+
 def _active_config() -> Optional[_SignerConfig]:
     global _configured, _config
+    # Before the memoised answer, not after: a pod carrying key material is
+    # refused whether or not this process ever configured signing.
+    _refuse_pod_private_key_material()
     if _configured:
         return _config
     # pgw#931 (§1.18): this used to resolve lazily from the cached Settings

--- a/src/gen_worker/parallel/group.py
+++ b/src/gen_worker/parallel/group.py
@@ -171,6 +171,12 @@ def _refuse_nvls_multicast() -> None:
 
     A future collective that can benefit from NVLS needs a measured capability
     and its own issue. It may not revive this as a gate.
+
+    Removing an override removes an escape hatch, so the override is never
+    silently discarded: whoever set it is TOLD, at the moment it is dropped,
+    what was dropped and where the real route runs. A hard override that
+    reports itself is recoverable; one that does not is the thing worth
+    refusing.
     """
     previous = os.environ.get(_NVLS_ENV)
     os.environ[_NVLS_ENV] = "0"
@@ -179,7 +185,10 @@ def _refuse_nvls_multicast() -> None:
             "%s was %r; overwritten to 0. NVLS multicast cannot be bound in "
             "our containers (measured: ncclUnhandledCudaError / CUDA 401 on "
             "the first all-to-all of every group) and Ulysses does not use it "
-            "— this is not an operator choice (pgw#929)",
+            "— this is not an operator choice (pgw#929). If you have a "
+            "collective and a container that genuinely bind NVLS multicast, "
+            "that is a measured capability and a new issue, not this env: "
+            "re-enabling it here takes down every arm of every group.",
             _NVLS_ENV, previous,
         )
 

--- a/tests/test_c2pa_hub_side_signing_th1307.py
+++ b/tests/test_c2pa_hub_side_signing_th1307.py
@@ -152,6 +152,52 @@ def test_private_key_in_pod_env_is_refused(chain, monkeypatch, env_name):
     _reset(monkeypatch)
 
 
+@pytest.mark.parametrize("env_name", ["GEN_WORKER_C2PA_KEY_PEM", "GEN_WORKER_C2PA_KEY_PATH"])
+def test_key_bearing_pod_is_refused_even_if_configure_was_never_called(chain, monkeypatch, env_name):
+    """The refusal belongs to the POD, not to one entry point.
+
+    pgw#931 removed `_active_config`'s lazy `configure()` fallback. That is the
+    right call on its own terms — a signing module must not resolve its own
+    config from the environment — but the th#1307 refusal was riding inside
+    that `configure()` call, so it left with it. Every process that does not
+    run the worker bring-up (a library embed, a compute child, an endpoint that
+    imports the module itself) then got a quiet `enabled() == False` while a
+    platform-wide private key sat in `os.environ`, and shipped media unsigned.
+
+    So: no `configure()` here, deliberately. This is the shape that regressed.
+    """
+    _reset(monkeypatch)
+    monkeypatch.setenv(env_name, chain["key"].read_text())
+
+    for call in (
+        lambda: cc.enabled(),
+        lambda: cc.sign_media_bytes(_png(), ref="outputs/a.png"),
+        lambda: cc.sign_media_file("/nonexistent.png", ref="outputs/a.png"),
+    ):
+        with pytest.raises(cc.C2paSigningError) as e:
+            call()
+        assert env_name in str(e.value)
+    _reset(monkeypatch)
+
+
+def test_key_delivered_after_a_clean_configure_is_still_refused(chain, monkeypatch):
+    """Memoisation must not outrank the ratchet.
+
+    `_active_config` short-circuits on `_configured`. If the refusal sat behind
+    that fast path, a pod that configured cleanly and was handed key material
+    afterwards would sign happily for the rest of its life.
+    """
+    _configure_cert_only(chain, monkeypatch)
+    try:
+        assert cc.enabled()
+        monkeypatch.setenv("GEN_WORKER_C2PA_KEY_PEM", chain["key"].read_text())
+        with pytest.raises(cc.C2paSigningError) as e:
+            cc.enabled()
+        assert "GEN_WORKER_C2PA_KEY_PEM" in str(e.value)
+    finally:
+        _reset(monkeypatch)
+
+
 def test_settings_have_no_private_key_field_at_all():
     """The ratchet in the config layer: nothing can carry a key into Settings."""
     from gen_worker.config.loader import _ENV_TO_FIELD

--- a/tests/test_nccl_nvls_pgw773.py
+++ b/tests/test_nccl_nvls_pgw773.py
@@ -8,6 +8,11 @@ memory ... CUDA error 401"*. Sequence parallelism did not work at all on a stock
 
 Layer exercised: `parallel.group.init_rank` (the one function every rank of
 every group runs before any communicator exists).
+
+Contract UPDATED by pgw#929 §1.17 (AMBIGUOUS #3): the write is UNCONDITIONAL.
+pgw#773's respect-if-set behaviour was superseded, not regressed — see
+`test_nvls_is_off_whatever_the_image_says` for the argument and for the
+condition the override's removal has to keep meeting.
 """
 
 from __future__ import annotations
@@ -30,16 +35,52 @@ from gen_worker.parallel.group import (  # noqa: E402
 )
 
 
-def test_nvls_is_off_unless_the_image_says_otherwise(monkeypatch) -> None:
+def test_nvls_is_off_whatever_the_image_says(monkeypatch, caplog) -> None:
+    """pgw#929 §1.17 AMBIGUOUS #3 supersedes pgw#773's respect-if-set default.
+
+    pgw#773 wrote ``0`` only when the variable was UNSET and called that "a
+    default, not an override". It never argued for the override: the issue was
+    a live CUDA-401 bug hunt, and respect-if-set was the incidental shape of
+    the one-line fix, not a considered escape hatch with a named user. pgw#929
+    re-adjudicated the same variable and ruled it a LIBRARY-ADAPTER HANDOFF
+    rather than operator configuration, because the failure it guards is TOTAL
+    (every all-to-all of every arm dies) rather than gradual — so an env
+    inherited from an image can silently take sequence parallelism to zero.
+
+    This test therefore pins the ruling's own acceptance criterion: start at
+    ``1``, prove the adapter overwrites it to ``0`` before NCCL can observe it.
+    """
     monkeypatch.delenv(_NVLS_ENV, raising=False)
     _refuse_nvls_multicast()
     assert os.environ[_NVLS_ENV] == "0"
 
-    # An image that CAN bind multicast keeps its own answer: this decides a
-    # default, it is not an override.
     monkeypatch.setenv(_NVLS_ENV, "1")
+    with caplog.at_level("WARNING", logger="gen_worker.parallel.group"):
+        _refuse_nvls_multicast()
+    assert os.environ[_NVLS_ENV] == "0", "an image default may not re-enable NVLS"
+
+    # The losing half of the ruling still has to hold: removing an escape hatch
+    # is only acceptable while the removal REPORTS itself. Whoever set the
+    # variable learns that it was dropped, what it was, and where the real
+    # route runs — never a silent inversion of what they asked for.
+    assert caplog.records, "a dropped operator override must not be silent"
+    msg = caplog.records[-1].getMessage()
+    assert _NVLS_ENV in msg and "'1'" in msg
+    assert "new issue" in msg, "the warning must name the route, not just the refusal"
+
+
+@pytest.mark.parametrize("preset", ["1", "0", "", "true", "TRUE", "yes", "2", " 1 "])
+def test_no_image_value_can_revive_nvls(monkeypatch, preset: str) -> None:
+    """The ratchet, stated behaviourally rather than over source text.
+
+    The override is back the moment ANY incoming value survives, so the pin is
+    that every one of them lands on ``0`` — including the truthy spellings a
+    hand-written Dockerfile actually uses. A branch reintroduced anywhere on
+    the read side shows up here as a value that is not ``0``.
+    """
+    monkeypatch.setenv(_NVLS_ENV, preset)
     _refuse_nvls_multicast()
-    assert os.environ[_NVLS_ENV] == "1"
+    assert os.environ[_NVLS_ENV] == "0", f"{preset!r} survived the adapter"
 
 
 def test_forming_a_rank_sets_it_before_any_communicator_exists(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.91.2"
+version = "0.91.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Both red tests on `release/20260803-night-pgw3` (pinned at `dev@110f9a8`, run 30815024726). Both trace to tonight's pgw#929/#931 env work. One is a security regression; one needed a ruling.

## 1. SECURITY — the th#1307 private-key refusal became reachable only from `configure()`

`tests/test_c2pa_hub_side_signing_th1307.py::test_private_key_in_pod_env_is_refused` failed at **line 150**, not line 141 — `configure()` still raised. What stopped raising is the **lazy path**: "is signing on?"

**Where the refusal went.** PR #436 rewrote `content_credentials._active_config` to stop resolving lazily from the cached `Settings` loader. *That part is right and stays* — a signing module must not go and find its own config in the environment. But the th#1307 ratchet (`GEN_WORKER_C2PA_KEY_PEM` / `_KEY_PATH` present ⇒ raise) was riding **inside** the `configure()` call the lazy path made, so deleting the path deleted the refusal with it.

**Impact.** Any process that does not run the worker bring-up — a library embed, a compute child, an endpoint importing the module directly — got a quiet `enabled() == False` and shipped media **unsigned, beside a platform-wide C2PA leaf signing key sitting in `os.environ`**. Both failure directions of th#1307 at once: the key is present *and* provenance is missing.

This is the **same defect class as #438's boot-token finding, third instance tonight**: an invariant installed at one entry point rather than at the seam that owns it. Worth naming as a pattern — when a lane deletes a call, it must ask what *else* that call was carrying.

**Fix.** `_refuse_pod_private_key_material()` is hoisted out of `configure()` and evaluated at the top of `_active_config()`, **before** the `_configured` memo — so it fires for `enabled()`, `sign_media_bytes()` and `sign_media_file()`, whether or not this process configured signing, and whether or not the key arrived *after* a clean configure. The refusal is a property of the pod's environment; no entry point owns it.

**Proof — the test exercises the new site, not the one that stayed green.** The test was not relaxed; it was extended:
- `test_key_bearing_pod_is_refused_even_if_configure_was_never_called` — both env names, across all three public entries, with **no `configure()` call**: the shape that actually regressed.
- `test_key_delivered_after_a_clean_configure_is_still_refused` — the memo must not outrank the ratchet.

Verified against the **unpatched** module at `dev@110f9a8`: **5 refusal tests RED, 6 pass.** Patched: **11/11 green.**

## 2. RULING — `NCCL_NVLS_ENABLE`: the unconditional write STANDS

Read pgw#773 before overriding it, per policy. **pgw#773 never chose the override.** Its record (`progress.md` "NVLS multicast breaks SP outright", chaos `4e2af36`, cost \$1.66) is a live CUDA-401 bug hunt on a 4xH100 pod; respect-if-set was the incidental shape of the one-line fix. No user, no failure mode, no argument was ever recorded for honouring an image value — the "this decides a default, it is not an override" phrasing lived only in a test comment.

pgw#929 §1.17 AMBIGUOUS #3 re-adjudicated the same variable as a **library-adapter handoff**, and its deciding fact holds: the failure NVLS causes here is **total, not gradual** — every all-to-all of every arm dies with `ncclUnhandledCudaError` / CUDA 401, so sequence parallelism goes to zero. An env inherited from a base image is nobody's deliberate decision for this pod.

So this is a later ruling on a question pgw#773 did not consider, **not a regression against a decision it made**. The test encoded an assumption, not a contract. It now encodes the ruling — matching pgw#929's own acceptance criterion (start at `1`, prove the overwrite before NCCL observes it), which is ticked in the tracker.

**The losing side's concern is covered, not dismissed.** A hard override is only acceptable while it **reports itself**, so the warning now names the variable, the dropped value, the measured reason, **and the route forward** (a measured capability and a new issue, never this env) — and that warning is pinned by the test. `test_no_image_value_can_revive_nvls` parametrises the truthy spellings a hand-written Dockerfile actually uses (`1`/`true`/`TRUE`/`yes`/`2`/` 1 `), so a reintroduced read-side branch shows up as a surviving value rather than as a fragile source-text diff.

Both decisions recorded in `cozy-creator-tracker` (`538602fb`).

## Green locally (rebased on `origin/dev@a4effd8`)

`tests/` 3031 passed / 38 skipped / 1 xfailed · `tests_v2/` 21 passed · mypy clean (225 files) · ruff clean · `lint_config_reads.py` OK (79 classified pairs) · `lint_unreached_surface.py` OK · `lint_http_timeouts.py` OK · `uv lock --check` OK.

Version 0.91.3 (PATCH — no wire-contract, `@endpoint` or `Resources` change, so no `TENSORHUB_SUPPORTED_GEN_WORKER_VERSIONS` move).