### PR TITLE
pgw#824/#923: reconcile the silent-failure audit with the typed adoption vocabulary — dev goes green

### DIFF
--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -25,8 +25,59 @@ spelling, and the spelling that carries numbers.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
-__all__ = ["AdoptOutcome", "CellAdoption"]
+__all__ = ["AdoptOutcome", "CellAdoption", "EagerPhase"]
+
+
+class EagerPhase(StrEnum):
+    """Why a compile-declaring pipeline is serving EAGER — one token, shared.
+
+    pgw#824 gave the arming policy's declines a classified token instead of the
+    single ``mint_unavailable`` constant they used to share; the token rides
+    ``self_mint_skipped``/``self_mint_started`` as ``phase`` and rides out of
+    the decision as ``ArmOutcome.eager_reason``, so the hub's activity rows and
+    the request row's ``fallback_reason`` join on one string.
+
+    The tokens lived as bare literals at each ``return``, and the pgw#824 audit
+    re-spelled the same nine strings in a second list to check they were all
+    still there. Two lists of literals is a drift channel, and it drifted:
+    pgw#923 moved every exit out of ``enable_compiled`` into ``_arming_policy``
+    and the audit — which read only ``enable_compiled``'s source — reported all
+    nine as lost when not one had changed. Naming the members here makes the
+    audit reference the vocabulary instead of re-typing it.
+
+    **The values are a wire contract.** The hub groups
+    ``worker_activity_events`` on them and joins them to request rows; renaming
+    one orphans that history, so ``test_silent_failure_audit_pgw824`` pins the
+    member-to-value mapping rather than reading it back out of this file.
+    """
+
+    #: The nine mint-impossibility exits, each a distinct `_fail_closed` cause.
+    NO_FAMILY = "no_family"
+    NO_CUDA = "no_cuda"
+    NO_TOOLCHAIN = "no_toolchain"
+    NO_COMPILE_TARGET = "no_compile_target"
+    DELIVERED_CELL_SEEDED = "delivered_cell_seeded"
+    KEY_COMPUTATION_FAILED = "key_computation_failed"
+    CAPTURE_CONFLICT = "capture_conflict"
+    MULTI_GROUP_IN_PROCESS = "multi_group_in_process"
+    CAPTURE_ARM_FAILED = "capture_arm_failed"
+
+    #: The tenth eager exit: it declines BEFORE `_fail_closed` (a quarantined
+    #: identity must not be re-minted) and was the one that only logged.
+    CELL_QUARANTINED = "cell_quarantined"
+
+    #: Eager with an END — a delegated mint child is building the cell. Equal
+    #: to ``serving_mode.POSTURE_MINT_IN_PROGRESS`` by contract; the audit
+    #: asserts the two, because a fleet that is warming up must never read as
+    #: a fleet that never will.
+    MINT_IN_PROGRESS = "mint_in_progress"
+
+    #: `_fail_closed`'s default, for a caller that has not classified its exit.
+    #: A new decline landing here rather than on its own member is the
+    #: regression pgw#824 exists to catch.
+    MINT_UNAVAILABLE = "mint_unavailable"
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -186,7 +186,8 @@ class ArmOutcome:
     retrying the identical unusable cell on every subsequent request.
 
     ``eager_reason`` (pgw#824) is the CLASSIFIED token for why this pipeline is
-    not serving from a cell — the same token the decline's
+    not serving from a cell — a :class:`~.cell_adopt.EagerPhase` member, which
+    is where that vocabulary is spelled ONCE — the same token the decline's
     ``self_mint_skipped``/``self_mint_started`` event carries in ``phase``, so a
     request row's ``fallback_reason`` and the worker's activity events join on
     one string. "" only when ``armed`` is true. Without it every eager request

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -70,7 +70,7 @@ from . import boot_phases as boot_mod
 from . import compile_cache as cc
 from . import guard_closure
 from . import topology as topology_mod
-from .cell_adopt import AdoptOutcome, CellAdoption
+from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
 from .models.chunk_cas import sha256_file
 from .procsplit import broker
 # module import (not `from .loading import pipeline_weight_lane`): tests
@@ -941,14 +941,14 @@ def _arming_policy(
     if not family:
         return _fail_closed(
             pipe, "Compile decl has no family", selection_bug,
-            phase="no_family")
+            phase=EagerPhase.NO_FAMILY)
     if not _cuda_ready():
         return _fail_closed(
-            pipe, "CUDA unavailable", selection_bug, phase="no_cuda")
+            pipe, "CUDA unavailable", selection_bug, phase=EagerPhase.NO_CUDA)
     if not cc.toolchain_present():
         return _fail_closed(
             pipe, "no C compiler for the self-mint", selection_bug,
-            phase="no_toolchain")
+            phase=EagerPhase.NO_TOOLCHAIN)
     # gw#608 ROOT CAUSE gates (order matters — BEFORE any process-global
     # cache-dir mutation):
     # (a) a slot object with no resolvable compile target (the LTX upsampler
@@ -962,7 +962,7 @@ def _arming_policy(
     if not cc.has_compile_target(pipe, cfg):
         return _fail_closed(
             pipe, "no compile target resolves on this pipeline", selection_bug,
-            phase="no_compile_target")
+            phase=EagerPhase.NO_COMPILE_TARGET)
     if cc.delivered_cell_seeded() and not delegate:
         # pgw#784: this gate exists ONLY because an in-process capture moves
         # the process-global inductor cache dir. A DELEGATED mint's capture
@@ -974,7 +974,7 @@ def _arming_policy(
             "a delivered cell is seeded in this process; a self-mint "
             "capture would re-point the process-global inductor cache dir "
             "away from it (gw#608)", selection_bug,
-            phase="delivered_cell_seeded")
+            phase=EagerPhase.DELIVERED_CELL_SEEDED)
 
     # gw#561: the eager-miss rollback in provision.enable_compiled dropped
     # the branch lane; the mint must key + trace the DECLARED graph family.
@@ -1000,7 +1000,7 @@ def _arming_policy(
             cc.drop_lora_lane(pipe)
         return _fail_closed(
             pipe, f"self-mint key computation failed: {exc}", selection_bug,
-            phase="key_computation_failed")
+            phase=EagerPhase.KEY_COMPUTATION_FAILED)
 
     # pgw#672: consult the process ledgers BEFORE opening a capture.
     key_ref = f"{cc.system_repo(family)}#{key}"
@@ -1026,11 +1026,11 @@ def _arming_policy(
             f"was quarantined by a failed serve/finalize proof earlier in this "
             f"process; re-minting it is the churn loop, so this worker serves "
             f"eager for the rest of its life and publishes nothing",
-            phase="cell_quarantined",
+            phase=EagerPhase.CELL_QUARANTINED,
         )
         return ArmOutcome(
             armed=False, selection_bug=selection_bug,
-            eager_reason="cell_quarantined")
+            eager_reason=EagerPhase.CELL_QUARANTINED)
     finalized_prior = finalized_in_process(key)
     if finalized_prior is not None:
         # This process already minted, proved, and FOLDED this exact cell
@@ -1082,7 +1082,7 @@ def _arming_policy(
             cc.drop_lora_lane(pipe)
         return _fail_closed(
             pipe, f"another self-mint capture is pending (key {conflict})",
-            selection_bug, phase="capture_conflict")
+            selection_bug, phase=EagerPhase.CAPTURE_CONFLICT)
 
     if existing is not None:
         mint_root, capture_dir = existing.mint_root, existing.capture_dir
@@ -1144,7 +1144,7 @@ def _arming_policy(
             # `mint_in_progress` is a fleet that is warming up; one carrying
             # `no_toolchain` is a fleet that never will. Reading them as the
             # same "" was the whole gap.
-            eager_reason="mint_in_progress")
+            eager_reason=EagerPhase.MINT_IN_PROGRESS)
 
     # pgw#777 / DPA-8: the IN-PROCESS capture moves the process-global
     # TORCHINDUCTOR_CACHE_DIR and clears inductor's latch for the whole
@@ -1168,7 +1168,7 @@ def _arming_policy(
             pipe,
             f"in-process mint refused at groups={topo.execution_groups}: the inductor "
             "capture env is process-global (pgw#777/DPA-8)",
-            selection_bug, phase="multi_group_in_process")
+            selection_bug, phase=EagerPhase.MULTI_GROUP_IN_PROCESS)
 
     try:
         cc.begin_fleet_mint(pipe, cfg, capture_dir)
@@ -1180,7 +1180,7 @@ def _arming_policy(
             cc.drop_lora_lane(pipe)
         return _fail_closed(
             pipe, f"self-mint arm failed: {exc}", selection_bug,
-            phase="capture_arm_failed")
+            phase=EagerPhase.CAPTURE_ARM_FAILED)
 
     if existing is not None:
         logger.info(
@@ -1840,7 +1840,7 @@ def aot_export_spec(pipe: Any, cfg: Any) -> "Any":
 def _fail_closed(
     pipe: Any, reason: str,
     selection_bug: Optional["cc.CellSelectionBugError"] = None,
-    *, phase: str = "mint_unavailable",
+    *, phase: EagerPhase = EagerPhase.MINT_UNAVAILABLE,
 ) -> ArmOutcome:
     """The quantized-lane policy at every exit that cannot produce a cell:
     plain lanes serve eager (never-raise miss policy), w8a8/w4a4 keep the

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -31,6 +31,13 @@ import pytest
 from gen_worker import activity, aot_cells, aot_serve, fleet_cells
 from gen_worker.cell_adopt import AdoptOutcome
 
+#: The arm is INDUCED to take this long, and the floor asserted against it is a
+#: share of that induced quantity rather than a bare constant (pgw#795). This is
+#: a LOWER bound on work the test itself produced: a slow runner only raises the
+#: measured value, so nothing here can fail because the machine was busy.
+_INDUCED_ARM_S = 0.02
+_MEASURED_ARM_FLOOR_MS = int(_INDUCED_ARM_S * 1000 * 0.75)
+
 FAMILY = "sdxl"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
            "cuda": "13.0"}
@@ -294,7 +301,7 @@ def test_fleet_success_is_one_measured_adoption_bound_to_the_candidate(
 ) -> None:
     def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         pipe._cozy_aot = {"state": {"failed": False}}
-        time.sleep(0.02)  # a real arm costs time; a measured one records it
+        time.sleep(_INDUCED_ARM_S)  # a real arm costs time; a measured one records it
         return AdoptOutcome.hit(f"family={FAMILY} key={KEY}")
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)
@@ -308,7 +315,8 @@ def test_fleet_success_is_one_measured_adoption_bound_to_the_candidate(
     # measurement lane exists for. `arm_ms == 0` is what shipped for a year.
     assert row.ref == _f1.ref and row.snapshot_digest == _f1.snapshot_digest
     assert row.artifact_kind == aot_serve.ARTIFACT_KIND
-    assert row.arm_ms >= 15, "the adoption recorded no time at all"
+    assert row.arm_ms >= _MEASURED_ARM_FLOOR_MS, (
+        "the adoption recorded no time at all")
 
 
 def test_fleet_did_not_arm_is_a_measured_refusal_naming_the_candidate(

--- a/tests/test_cell_adoption_measurement_pgw923.py
+++ b/tests/test_cell_adoption_measurement_pgw923.py
@@ -34,6 +34,13 @@ from gen_worker.pb import worker_scheduler_pb2 as pb
 REF = "root/family-sdxl#ck5-" + "b" * 56
 DIGEST = "blake3:" + "c" * 64
 
+#: The arm is INDUCED to take this long, and the floor asserted against it is a
+#: share of that induced quantity rather than a bare constant (pgw#795). This is
+#: a LOWER bound on work the test itself produced: a slow runner only raises the
+#: measured value, so nothing here can fail because the machine was busy.
+_INDUCED_ARM_S = 0.05
+_MEASURED_ARM_FLOOR_MS = int(_INDUCED_ARM_S * 1000 * 0.8)
+
 
 @pytest.fixture(autouse=True)
 def _reset() -> Any:
@@ -155,7 +162,7 @@ def test_the_arm_is_measured_and_recorded_as_the_cell_arm_boot_phase(
     artifact.write_bytes(b"cell")
 
     def _slow_arm(pipe: Any, cfg: Any, cache_dir: Any, art: Any) -> AdoptOutcome:
-        time.sleep(0.05)
+        time.sleep(_INDUCED_ARM_S)
         return AdoptOutcome.hit("family=sdxl key=ck5-abc")
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _slow_arm)
@@ -165,14 +172,14 @@ def test_the_arm_is_measured_and_recorded_as_the_cell_arm_boot_phase(
 
     assert outcome.armed
     assert len(outcome.adoptions) == 1
-    assert outcome.adoptions[0].arm_ms >= 40
+    assert outcome.adoptions[0].arm_ms >= _MEASURED_ARM_FLOOR_MS
 
     arm_rows = [r for r in boot_phases.recorded_rows()
                 if r.phase == boot_phases.PHASE_CELL_ARM and r.terminal]
     assert len(arm_rows) == 1, "the arm recorded no cell_arm boot phase"
     assert arm_rows[0].ref == REF
     assert arm_rows[0].artifact_key == DIGEST
-    assert arm_rows[0].duration_ms >= 40
+    assert arm_rows[0].duration_ms >= _MEASURED_ARM_FLOOR_MS
     assert arm_rows[0].outcome == boot_phases.OUTCOME_OK
 
 

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -18,11 +18,14 @@ premise of the audit.
 
 from __future__ import annotations
 
+import inspect
+import re
 from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from gen_worker import activity, fleet_cells, serving_mode
+from gen_worker.cell_adopt import EagerPhase
 
 
 @pytest.fixture()
@@ -110,42 +113,102 @@ def test_fail_closed_names_the_cause_instead_of_one_shared_constant(
         fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "")
 
     outcome = fleet_cells._fail_closed(
-        _Pipe(), "no C compiler for the self-mint", phase="no_toolchain")
+        _Pipe(), "no C compiler for the self-mint",
+        phase=EagerPhase.NO_TOOLCHAIN)
 
     assert outcome.armed is False
-    # the token rides the WIRE ...
+    # the token rides the WIRE, as the VALUE — a reader groups on the string,
+    # never on the member's repr.
     assert ("no_toolchain", ) == tuple(
         phase for phase, _ in _rows(events, "self_mint_skipped"))
     # ... and rides OUT of the decision, for the request path to report.
     assert outcome.eager_reason == "no_toolchain"
 
 
+#: The eager exits pgw#824 gave a classified cause, named as MEMBERS.
+#:
+#: This list is the audit's own specification of which causes must exist, and
+#: it stays here rather than being read back out of ``EagerPhase``: an audit
+#: that enumerates the enum agrees with the code by construction, which is the
+#: failure mode it exists to prevent. Deleting an exit must fail a test, not
+#: shrink a set on both sides at once.
+#:
+#: What is NOT re-typed here is the spelling. pgw#923 moved every one of these
+#: exits from ``enable_compiled`` into ``_arming_policy`` — no exit removed, no
+#: token changed — and this audit, which read only ``enable_compiled``'s source
+#: for nine string literals, reported all nine as lost. Two literal lists is a
+#: drift channel; naming members closes it while keeping the specification.
+_DECLINE_PHASES = (
+    EagerPhase.NO_FAMILY,
+    EagerPhase.NO_CUDA,
+    EagerPhase.NO_TOOLCHAIN,
+    EagerPhase.NO_COMPILE_TARGET,
+    EagerPhase.DELIVERED_CELL_SEEDED,
+    EagerPhase.KEY_COMPUTATION_FAILED,
+    EagerPhase.CAPTURE_CONFLICT,
+    EagerPhase.MULTI_GROUP_IN_PROCESS,
+    EagerPhase.CAPTURE_ARM_FAILED,
+)
+
+
+def _phase_uses(member: EagerPhase) -> int:
+    """How many exits in the arming module pass ``member`` as their phase.
+
+    Scans the whole ``fleet_cells`` module, not one function: WHICH function
+    holds the policy is an implementation detail that has already changed once,
+    and an audit that fails when a helper is extracted is an audit that gets
+    re-pointed rather than read.
+    """
+    src = inspect.getsource(fleet_cells)
+    return len(re.findall(rf"phase=EagerPhase\.{member.name}\b", src))
+
+
 def test_every_fail_closed_exit_carries_a_distinct_token() -> None:
     """The nine exits must not collapse back onto one token by accident: a
     reader groups on this string, so a duplicate silently merges two causes."""
-    import inspect
-
-    src = inspect.getsource(fleet_cells.enable_compiled)
-    tokens = {
-        "no_family", "no_cuda", "no_toolchain", "no_compile_target",
-        "delivered_cell_seeded", "key_computation_failed", "capture_conflict",
-        "multi_group_in_process", "capture_arm_failed",
-    }
-    missing = {t for t in tokens if f'phase="{t}"' not in src}
+    uses = {member: _phase_uses(member) for member in _DECLINE_PHASES}
+    missing = sorted(m.name for m, n in uses.items() if n == 0)
     assert not missing, f"these _fail_closed exits lost their token: {missing}"
+    shared = sorted(m.name for m, n in uses.items() if n > 1)
+    assert not shared, f"these tokens now cover more than one exit: {shared}"
+    # ... and none of them fell back onto the shared constant they replaced.
+    assert _phase_uses(EagerPhase.MINT_UNAVAILABLE) == 0
 
 
-def test_a_quarantined_cell_is_a_typed_event_not_a_log_line(
-    events: List[Any], monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """RED before pgw#824. This was the ONE eager exit in `enable_compiled`
+def test_the_eager_phase_values_are_a_wire_contract() -> None:
+    """The hub stores these as ``worker_activity_events.phase`` and joins them
+    to a request row's ``fallback_reason``. Renaming one does not break a
+    build — it orphans every row already grouped under the old spelling — so
+    the mapping is pinned here, in the one place a rename must be argued.
+    """
+    assert {m.name: m.value for m in EagerPhase} == {
+        "NO_FAMILY": "no_family",
+        "NO_CUDA": "no_cuda",
+        "NO_TOOLCHAIN": "no_toolchain",
+        "NO_COMPILE_TARGET": "no_compile_target",
+        "DELIVERED_CELL_SEEDED": "delivered_cell_seeded",
+        "KEY_COMPUTATION_FAILED": "key_computation_failed",
+        "CAPTURE_CONFLICT": "capture_conflict",
+        "MULTI_GROUP_IN_PROCESS": "multi_group_in_process",
+        "CAPTURE_ARM_FAILED": "capture_arm_failed",
+        "CELL_QUARANTINED": "cell_quarantined",
+        "MINT_IN_PROGRESS": "mint_in_progress",
+        "MINT_UNAVAILABLE": "mint_unavailable",
+    }
+    # The join the ArmOutcome docstring claims: a delegated mint's decline and
+    # the serving posture that describes it are ONE token, not two that happen
+    # to be spelled alike today.
+    assert EagerPhase.MINT_IN_PROGRESS == serving_mode.POSTURE_MINT_IN_PROGRESS
+
+
+def test_a_quarantined_cell_is_a_typed_event_not_a_log_line() -> None:
+    """RED before pgw#824. This was the ONE eager exit in the arming policy
     that returned before `_fail_closed` and only `logger.error`'d. A pod that
     quarantines its own cell serves eager for the rest of its life — the state
     the hub most needs named, and the one it could not see.
     """
-    src_ok = 'phase="cell_quarantined"' in __import__(
-        "inspect").getsource(fleet_cells.enable_compiled)
-    assert src_ok, "the quarantine exit must emit a typed event"
+    assert _phase_uses(EagerPhase.CELL_QUARANTINED) == 1, (
+        "the quarantine exit must emit a typed event")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`dev` was red at `a4effd8` with three tests, all from the pgw#923/#924 merge (#444, follow-up #445). Filed by the `promo-fixes` lane against pgw#923, which deliberately did not fix them — silently re-pointing another lane's silent-failure audit is the wrong move. This is that lane.

Reproduced first on a fresh worktree at pristine `origin/dev`: the same three, no others.

## 1 + 2. The nine `_fail_closed` tokens — a RELOCATION, not a behaviour change

pgw#923 split `fleet_cells.enable_compiled` into a thin adoption-ledger wrapper over a new `_arming_policy`, and every eager exit moved with the policy. The audit read `inspect.getsource(enable_compiled)` — 29 lines after the split — looking for nine string literals, and reported all nine as lost.

**Checked per phase.** `no_family`, `no_cuda`, `no_toolchain`, `no_compile_target`, `delivered_cell_seeded`, `key_computation_failed`, `capture_conflict`, `multi_group_in_process`, and the tenth exit `cell_quarantined` each still have exactly one live site, in `_arming_policy`, with the identical spelling. Not one exit was removed, not one token changed. So there is no behaviour change to surface, and the vocabulary is **re-expressed** rather than the audit re-pointed.

`cell_adopt.EagerPhase` is now the single spelling — a `StrEnum` the arming policy passes as `phase=` and the audit names as **members**. The audit keeps its own explicit list of which nine causes must exist; enumerating the enum would make it agree with the code by construction, which is the failure mode it exists to prevent. What it stops doing is re-typing the strings, which is the channel that actually drifted.

It also got stronger, each mutation-proved against the real module:

| mutation | result |
|---|---|
| an exit loses its token | `lost their token: ['NO_CUDA']` |
| two exits share one token | `now cover more than one exit: ['NO_CUDA']` |
| an exit falls back on `mint_unavailable` (the pre-pgw#824 state) | fails |
| a helper is extracted again | **passes** — the scan is module-wide now |

Plus `test_the_eager_phase_values_are_a_wire_contract`: the hub groups `worker_activity_events.phase` on these values, so a rename orphans history rather than breaking a build. It pins member→value, and asserts the join `ArmOutcome`'s docstring has always claimed — `EagerPhase.MINT_IN_PROGRESS == serving_mode.POSTURE_MINT_IN_PROGRESS` — which until now was two literals that merely happened to agree.

## 3. The pgw#795 burndown — a new suite, not a slowdown

Both entries are **new assertions**: `test_cell_adoption_measurement_pgw923.py` is #444's own suite, and `test_aot_adopt_events_pgw733.py` was rewritten in the same commit for the typed `AdoptOutcome`. No existing test changed its timing and no measured value moved. So the question was never whether to accept a worse baseline.

Each is a LOWER bound on an arm the test itself induces with `time.sleep`, so a slow runner only raises the measured value. What made them ratchet hits is that the floor was a bare constant (`>= 40` against a `0.05` sleep) with nothing tying it to the sleep it describes — exactly the shape pgw#795 asks to be a share of a measured baseline. Both now derive the floor from the induced duration. **The burn-down list is unchanged**: lines leave it, they never join it.

## Verification

- The three named tests, plus both suites they cover: 67 passed.
- All three ratchets exit 0; `lint_unreached_surface` output byte-identical to baseline.
- `mypy` and `ruff` clean on every changed file.
- `git diff --diff-filter=D --name-only origin/dev HEAD` empty.