### PR TITLE
pgw#766: make Slot family intent explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **pgw#766 / th#1566: `Slot(family=...)` makes non-root model governance
+  explicit.** pgw#747 correctly stopped stamping family-agnostic auxiliaries
+  with a function's model family, but inferred agnosticism from the proxy
+  "non-root + no hardcoded checkpoint". That also emptied deploy-bound model
+  lanes such as qwen-image's `edit`, disabling the hub's binding and serving-
+  contract gates. A non-empty explicit family now overrides that inference;
+  an explicit empty family keeps an auxiliary agnostic, and omission preserves
+  pgw#747's compatibility behavior.
+
 ## 0.91.3 (2026-08-03) — **SECURITY: the th#1307 private-key refusal is reachable again**, and the NVLS override stays deleted
 
 PATCH: no wire-contract, `@endpoint` or `Resources` change. Both items are promotion blockers

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ SomeModelChoice | ModelRef` opens BYOM. Streaming = an async-generator handler.
 Engine-hosted endpoints declare `runtime="vllm"` and get a booted,
 health-checked server subprocess injected into `setup()`.
 
-`Slot(pipeline_cls, selected_by=, default_checkpoint=)` is the hub-resolved
+`Slot(pipeline_cls, selected_by=, family=, default_checkpoint=)` is the hub-resolved
 alternative to `ModelChoice`: the model SET lives in platform config, not
 code, and the COMPONENT TREE (`pipeline.unet`, `pipeline.vae`, ...) is
 derived from the pipeline class and published to the hub — parts are never
@@ -106,6 +106,10 @@ declared as sibling slots. The per-model config SCHEMA derives from the
 handler's context annotation (`ctx: RequestContext[SdxlDefaults]`, a
 `gen_worker.families.GenerationDefaults` vocabulary); the catalog owns the
 VALUES and `ctx.defaults` hands the resolved recipe to the handler typed.
+`family="sdxl"` explicitly keeps a non-root/defaultless model lane inside
+that architecture's binding gate; `family=""` explicitly marks a shared
+auxiliary as family-agnostic. Omitting it preserves the compatibility
+inference.
 
 Full reference: [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
 

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -210,7 +210,7 @@ standalone distilled checkpoint is a separate class/endpoint.
 
 ## `Slot`: hub-resolved model slots (SDK v2, pgw#647)
 
-`Slot(pipeline_cls, selected_by=, default_checkpoint=)` resolves the model set
+`Slot(pipeline_cls, selected_by=, family=, default_checkpoint=)` resolves the model set
 from the hub catalog (th#767) rather than from code, so adding a checkpoint is
 not a software release. Under SDK v2 the declaration shrinks to the ROOT of the
 component tree:
@@ -260,6 +260,12 @@ class Generate:
   field; the SDK never bakes a curated list.
 - `default_checkpoint` seeds the hub mapping at first publish and is the
   ONLY resolution source in hub-less mode; a live hub mapping always wins.
+- `family=None` keeps the compatibility inference: root/ref-bearing slots
+  inherit the handler's family, while a non-root/defaultless slot is treated
+  as family-agnostic. Set `family="qwen-image"` when such a non-root slot is a
+  real deploy-bound model lane; set `family=""` when a ref-bearing auxiliary
+  explicitly remains architecture-agnostic. Explicit intent wins over the
+  inference and is published into the slot manifest.
 - **Component sharing is AUTOMATIC by content address** — byte-identical
   components (the qwen text encoder, a shared VAE) load once and are
   refcounted across checkpoint picks; there is nothing to declare

--- a/src/gen_worker/api/slot.py
+++ b/src/gen_worker/api/slot.py
@@ -105,6 +105,14 @@ class Slot(Generic[D]):
     ``str`` (the schema enum of legal values is overlaid live by the hub,
     never baked into the SDK).
 
+    ``family`` is the slot's architecture-family intent. ``None`` keeps the
+    compatibility inference: a non-root, defaultless slot is treated as
+    family-agnostic, while a root/ref-bearing slot inherits the handler's
+    family. A non-empty value explicitly declares this slot's family and wins
+    over that inference; ``""`` explicitly declares a family-agnostic
+    auxiliary slot. This distinction matters for non-root model lanes that are
+    deploy-bound rather than hardcoding a checkpoint ref.
+
     ``default_checkpoint`` seeds the hub mapping at first publish and is the
     ONLY resolution source in hub-less mode (``cozy run``, hermetic tests) —
     a live hub mapping always wins when present. ``None`` means this slot
@@ -126,7 +134,8 @@ class Slot(Generic[D]):
     """
 
     __slots__ = (
-        "pipeline_cls", "selected_by", "default_checkpoint", "root", "optional",
+        "pipeline_cls", "selected_by", "family", "default_checkpoint", "root",
+        "optional",
     )
 
     def __init__(
@@ -134,6 +143,7 @@ class Slot(Generic[D]):
         pipeline_cls: type,
         *,
         selected_by: str = "",
+        family: Optional[str] = None,
         default_checkpoint: Optional[ModelRef] = None,
         root: bool = False,
     ) -> None:
@@ -149,6 +159,7 @@ class Slot(Generic[D]):
             )
         self.pipeline_cls = pipeline_cls
         self.selected_by = str(selected_by or "").strip()
+        self.family = None if family is None else str(family or "").strip()
         self.default_checkpoint = default_checkpoint
         self.root = bool(root)
         self.optional = False  # derived at decoration from setup()'s default
@@ -156,8 +167,8 @@ class Slot(Generic[D]):
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return (
             f"Slot({self.pipeline_cls.__name__}, selected_by={self.selected_by!r}, "
-            f"default_checkpoint={self.default_checkpoint!r}, root={self.root!r}, "
-            f"optional={self.optional!r})"
+            f"family={self.family!r}, default_checkpoint={self.default_checkpoint!r}, "
+            f"root={self.root!r}, optional={self.optional!r})"
         )
 
 

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -688,14 +688,18 @@ def _extract_entries(obj: Any, module_name: str) -> List[Dict[str, Any]]:
         # Every binding carries the endpoint's architecture family, when
         # known, so the hub's th#586 gate can family-police any LoRA
         # overlay attached at that slot (pgw#523: unconditional-when-known,
-        # not allow_lora-triggered). pgw#520:
-        # a Slot-declared binding with no Compile(family=...) may still carry
-        # a family via its own default_config preset's registration — that's what
-        # es.slot_family reconciles (Compile(family=) wins when both exist).
+        # not allow_lora-triggered). For Slot-declared bindings the slot map is
+        # AUTHORITATIVE: it already reconciles the function family with the
+        # slot's explicit intent. Bare bindings have no slot declaration and
+        # retain the function-level compile family fallback.
         compile_family = es.compile.family if es.compile is not None else ""
         for key, block in bindings_block.items():
-            slot_family = es.slot_family.get(key, "") if es.slot_family else ""
-            _stamp_family(block, compile_family or slot_family)
+            family = (
+                es.slot_family.get(key, "")
+                if key in es.slots
+                else compile_family
+            )
+            _stamp_family(block, family)
 
         # pgw#747: `es.slot_family` is AUTHORITATIVE per slot — it already
         # folds in Compile(family=...), and it deliberately holds "" for an

--- a/src/gen_worker/registry.py
+++ b/src/gen_worker/registry.py
@@ -499,8 +499,12 @@ def _spec_for_handler(
     # schema's own @family registration when both are present.
     function_family = compile_family or defaults_family
     slot_family = {
-        name: ("" if _slot_is_family_agnostic(name, slot, slots)
-               else function_family)
+        name: (
+            slot.family
+            if slot.family is not None
+            else ("" if _slot_is_family_agnostic(name, slot, slots)
+                  else function_family)
+        )
         for name, slot in slots.items()
     }
     # SDK v2: derive each introspectable pipeline slot's component tree.

--- a/tests/test_auxiliary_slot_family_pgw747.py
+++ b/tests/test_auxiliary_slot_family_pgw747.py
@@ -63,11 +63,16 @@ _TWO_SLOT = """
 """
 
 
-def _slots(tmp_pkg: Path, name: str, src: str) -> dict[str, dict]:
+def _function(tmp_pkg: Path, name: str, src: str) -> dict:
     from gen_worker.discovery.discover import discover_functions
 
     _write(tmp_pkg / name, src)
     (fn,) = discover_functions(tmp_pkg, main_module=f"{name}.main")
+    return fn
+
+
+def _slots(tmp_pkg: Path, name: str, src: str) -> dict[str, dict]:
+    fn = _function(tmp_pkg, name, src)
     return {s["name"]: s for s in fn["slots"]}
 
 
@@ -94,6 +99,40 @@ def test_auxiliary_slot_that_names_a_ref_still_inherits(tmp_pkg: Path) -> None:
 
     assert slots["pipeline"]["family"] == "example"
     assert slots["interpolator"]["family"] == "example"
+
+
+def test_explicit_family_keeps_non_root_defaultless_model_governed(
+    tmp_pkg: Path,
+) -> None:
+    """pgw#766/th#1566: a deploy-bound non-root model slot has no ref by
+    design, so its explicit family must win over pgw#747's auxiliary-slot
+    inference."""
+    slots = _slots(
+        tmp_pkg, "ep_pgw766_explicit_model",
+        _TWO_SLOT.replace(
+            '"interpolator": Slot(Interpolator),',
+            '"interpolator": Slot(Interpolator, family="example"),'),
+    )
+
+    assert slots["interpolator"]["family"] == "example"
+
+
+def test_explicit_empty_family_keeps_ref_bearing_auxiliary_agnostic(
+    tmp_pkg: Path,
+) -> None:
+    """Explicit agnosticism also wins: a shared auxiliary may name its
+    bootstrap mirror without claiming the handler's architecture family."""
+    fn = _function(
+        tmp_pkg, "ep_pgw766_explicit_aux",
+        _TWO_SLOT.replace(
+            '"interpolator": Slot(Interpolator),',
+            '"interpolator": Slot(Interpolator, family="", '
+            'default_checkpoint=HF("example/aux")),'),
+    )
+    slots = {s["name"]: s for s in fn["slots"]}
+
+    assert "family" not in slots["interpolator"], slots["interpolator"]
+    assert "family" not in fn["bindings"]["interpolator"]
 
 
 def test_single_defaultless_slot_keeps_its_family(tmp_pkg: Path) -> None:


### PR DESCRIPTION
## What changed

- adds tri-state `Slot(family=...)` intent
- gives explicit family intent precedence over the pgw#747 compatibility inference
- makes the resolved slot family authoritative for Slot-backed default bindings
- documents the contract and records the change under Unreleased

## Why

pgw#747 correctly inferred many non-root/defaultless slots as auxiliary, but the same shape is also used by genuine deploy-bound model slots such as Qwen Image Edit. Emptying those families disables Tensorhub binding and serving-contract governance. Restoring a hardcoded checkpoint reference would conceal the ownership issue instead of fixing it.

## Compatibility

- omitted `family` preserves the existing inference
- `family=""` explicitly marks an auxiliary slot as family-agnostic
- a non-empty family explicitly keeps a deploy-bound slot under that family

## Validation

- 74 relevant registry/discovery/serving-contract tests passed
- Ruff and mypy passed for all touched Python sources
- full-source Ruff passed
- a broader core-only run reached 1,898 passed and 140 skipped, but the optional-dependency lane could not be installed because uv rejected the PyTorch 2.13.0+cu130 artifact with a hash mismatch; the remaining collection/runtime failures were missing optional packages such as torch, diffusers, Pillow, and hypothesis

No CI was manually triggered.