### PR TITLE
pgw#850: the self-mint path was dead fleet-wide by COMPOSITION — re-measured, and fixed by deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,64 @@
   an explicit empty family keeps an auxiliary agnostic, and omission preserves
   pgw#747's compatibility behavior.
 
+## 0.91.4 (2026-08-03) — **pgw#850: the self-mint path was dead fleet-wide by COMPOSITION, and the fix is a deletion**
+
+PATCH: no wire-contract, `@endpoint` or `Resources` change. Removes `aot_mint.PARITY_LANES`,
+`aot_mint.lane_admitted`, the `allow_regressed_lanes` parameter/CLI flag, and the
+`self_mint_skipped phase=aot_lane_regressed` decline.
+
+### The composition, re-measured on `origin/dev` 2026-08-03 (the filing's numbers had moved)
+
+Each constraint is individually defensible; their intersection was empty, so nothing failed
+loudly — the path simply never ran.
+
+- **The mint admitted one lane token.** pgw#918 narrowed `PARITY_LANES` from two members to
+  `("w8a8",)` (the other named a lane no loader stamps). `lane_admitted` refused everything else
+  with a sentence quoting the 6.9-7.0% AOTI regression pgw#704 Q4 measured **on sdxl's lanes**,
+  at families and lanes it never measured.
+- **The hub cannot put an AUTO pod on that lane before a cell exists.** tensorhub PR #709 made
+  `fp8-w8a8-dynamic` **compiled-only** and `fp8-w8a8-dynamic+eager` refuse at parse. So
+  `RequiresCompiledCell` holds for every w8a8 row, `applyCompileCellAvailability` (th#1123) and
+  `applyPublishMintObligation` (th#1127) mark them `CompileCellUnavailable` while no cell exists,
+  and `autoEligibleModel` drops them. tensorhub's own comment: *"only a worker's own self-mint can
+  discharge it."*
+
+The one lane the mint admitted was the one lane no AUTO pod could be on; the four lanes a pod
+**can** be on — `""` (bf16-w16a16), `"fp8-hooks"` (fp8-w8a16), `"w4a4"` (nvfp4-w4a4-static) and
+`"svdq-native"` (svdq-fp4/int4-w4a4, newly servable after PR #709) — were each declined. Zero
+fleet families reached the mint gate on AUTO, on any card. The sub-sm_89 half filed originally
+(`FP8ComputeMinSM = 89`) still holds and is subsumed: below sm_89 the w8a8 lane is off the card
+outright.
+
+### The fix
+
+pgw#879's deletion, not a wider allowlist. The lane is an **input**: the hub's resolution tree
+chooses it, `loading.pipeline_weight_lane` observes it on the composed pipeline, and the mint
+compiles what it is handed — *"here is the code, here is the lane, please compile this for all
+graphs we have declared."* Every surviving mint check answers "can this compile physically run"
+(declaration existence, `declaration_module_gaps`, `cxx_toolchain_present`, delegation
+availability, torch floor, `MintResourceExhausted`); none reads lane policy, family history, or a
+measurement.
+
+The pgw#704 Q4 / #730 measurement is not discarded — it is a **ranking** input to the hub's
+`+compiled` vs `+eager` choice. A lane held on dynamo is never asked for a cell; a lane that IS
+asked for gets compiled.
+
+`tests/test_aot_selfmint_pgw805.py` now parametrises the real `mint_recipe` path over the whole
+`loading.STAMPABLE_BASE_LANES` vocabulary plus a bucketed LoRA stamp, asserting `RECIPE_AOT` and
+zero `self_mint_skipped`. Verified RED against the pre-fix source: exactly the four non-`w8a8`
+lanes failed.
+
+**Still open, and it needs a GPU.** Whether `fp8-w8a8` can execute **eager** is unmeasured
+(th#1556's open item); it is deliberately not liberalised here to make a composition work.
+Impossibility belongs in tensorhub's lane table, a performance judgement in its ranking. And the
+residue this deletion does **not** reach: a compiled-only lane still has no bootstrap path —
+tensorhub withholds it until a cell exists and only a pod already on it can mint one. That cycle
+is entirely hub-side (th#1408), and it is why `fp8-w8a8-dynamic` and `nvfp4-w4a4-static` stay
+unreachable on AUTO even now. What this release fixes is that `bf16-w16a16` and `fp8-w8a16` —
+both `either`-execution, both reachable without a pre-existing cell — can now mint the cells that
+make their compiled forms servable. The self-mint path is alive.
+
 ## 0.91.3 (2026-08-03) — **SECURITY: the th#1307 private-key refusal is reachable again**, and the NVLS override stays deleted
 
 PATCH: no wire-contract, `@endpoint` or `Resources` change. Both items are promotion blockers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.91.3"
+version = "0.91.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -21,14 +21,29 @@ module riding the compile-cache rails, and the dynamo mint stays live and
 fully-forced in parallel during rollout (#722: nothing retires before sdxl AOT
 is live in prod).
 
-Why the w8a8 lane first
------------------------
-pgw#704 measured w8a8 at 276.2 vs 274.6 ms — latency PARITY with dynamo, and
-numerics identical. The plain and fp8-storage lanes both carry an unexplained
-systematic ~7% AOTI regression (#730 owns it), so they mint only behind
-``allow_regressed_lanes``. That is not a preference: shipping a lane we
-measured 7% slower, while calling the migration a win, would be a regression
-sold as progress.
+The mint does not judge the lane (pgw#879, pgw#850)
+---------------------------------------------------
+Paul's ruling: *"here is the code, here is the lane, please compile this for
+all graphs we have declared. That's it."* The lane is an INPUT — chosen once,
+by the hub's resolution tree, and observed on the composed pipeline by
+``loading.pipeline_weight_lane``. This module compiles what it is handed.
+
+The refusal that used to live here (``lane_admitted`` / ``PARITY_LANES``, a
+one-member allowlist holding ``w8a8``) is deleted because it was a SECOND
+opinion about an already-resolved fact, and the two opinions composed into a
+total block: tensorhub's lane table makes ``fp8-w8a8-dynamic``
+compiled-only, so the hub withholds that lane from AUTO until a cell exists
+(th#1123/th#1127), and only a pod already serving the lane can mint one. The
+one lane the mint admitted was the one lane no pod could ever be on, and every
+lane a pod COULD be on (``bf16-w16a16``, ``fp8-w8a16``, ``svdq-*-w4a4``) was
+refused — quoting a 6.9-7.0% AOTI regression pgw#704 Q4 measured on sdxl's
+lanes at families and lanes it never measured. Measured result: zero fleet
+families reached the mint gate on AUTO, on any card (pgw#850).
+
+The pgw#704 Q4 / #730 measurement is not discarded — it is a RANKING input to
+the lane/execution choice (``+compiled`` vs ``+eager``), which lives in the
+hub. A lane held on dynamo is simply never asked for a cell; if one IS asked
+for, the mint compiles it.
 
 Where minting runs (#724 REJECTED — Paul, 2026-07-28)
 -----------------------------------------------------
@@ -94,30 +109,10 @@ from .aot_contract import (  # re-exported: the declaration layer's vocabulary
 )
 from .compile_cache import (
     _resolve_target,
-    lane_bucket,
-    lane_token,
     toolchain_present,
 )
 
 logger = logging.getLogger(__name__)
-
-#: Lane TOKENS measured at latency parity under AOTI (pgw#704 Q4). Everything
-#: else needs ``allow_regressed_lanes`` — see the module docstring.
-#:
-#: pgw#918: ``"w8a8-rowwise"`` was deleted. No loader ever stamped it and
-#: neither ``lane_token`` nor ``lane_bucket`` can synthesize it, so half of a
-#: two-member allowlist was a string ``lane_admitted`` could never be handed —
-#: which is why nobody noticed the sibling constant
-#: (``executor._SPECULATIVE_CELL_BASE_LANES``) was missing two lanes that CAN
-#: be stamped. Membership is proven against
-#: ``loading.STAMPABLE_BASE_LANES`` by
-#: ``tests/test_speculative_lane_completeness_pgw918.py``.
-#:
-#: The companion ``REGRESSED_LANES`` tuple was deleted with it: it had no
-#: reader anywhere in ``src/`` (``lane_admitted`` decides by absence from this
-#: tuple, never by presence in that one) and it too named an unstampable lane
-#: (``"fp8-storage"`` — loaders stamp ``"fp8-hooks"``).
-PARITY_LANES: Tuple[str, ...] = ("w8a8",)
 
 #: The inductor config that makes the package code-only. Not a knob: B1.
 CODE_ONLY_CONFIGS: Dict[str, Any] = {
@@ -226,22 +221,6 @@ def lifted_torch_gap(spec: ExportSpec) -> str:
             f"2.13 prod floor is a mint PRECONDITION for this lane, not a "
             f"preference")
     return ""
-
-
-def lane_admitted(spec: ExportSpec, *, allow_regressed_lanes: bool) -> str:
-    """'' when this lane may be minted, else the named refusal reason."""
-    base, _bucket = lane_bucket(spec.weight_lane)
-    token = lane_token(base)
-    if token in PARITY_LANES:
-        return ""
-    if allow_regressed_lanes:
-        return ""
-    return (
-        f"lane {token or '(plain)'!r} measured 6.9-7.0% SLOWER under AOTI than "
-        f"dynamo (pgw#704 Q4) and is HELD on dynamo by #730 until explained; "
-        f"mint the w8a8 lane first, or pass allow_regressed_lanes to override "
-        f"deliberately"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -1427,7 +1406,6 @@ def mint(
     spec: ExportSpec,
     out_dir: Path,
     *,
-    allow_regressed_lanes: bool = False,
     inductor_configs: Optional[Mapping[str, Any]] = None,
     entry_workers: int = 0,
     entry_peak_rss_bytes: int = 0,
@@ -1483,7 +1461,6 @@ def mint(
     try:
         return _mint_cell(
             pipeline, spec, out_dir,
-            allow_regressed_lanes=allow_regressed_lanes,
             inductor_configs=inductor_configs,
             entry_workers=entry_workers,
             entry_peak_rss_bytes=entry_peak_rss_bytes,
@@ -1671,7 +1648,6 @@ def _mint_cell(
     spec: ExportSpec,
     out_dir: Path,
     *,
-    allow_regressed_lanes: bool = False,
     inductor_configs: Optional[Mapping[str, Any]] = None,
     entry_workers: int = 0,
     entry_peak_rss_bytes: int = 0,
@@ -1704,9 +1680,6 @@ def _mint_cell(
     """
     from .api.export_contract import export_declaration
 
-    refusal = lane_admitted(spec, allow_regressed_lanes=allow_regressed_lanes)
-    if refusal:
-        raise MintRefused(refusal)
     refusal = lifted_torch_gap(spec)
     if refusal:
         raise MintRefused(refusal)
@@ -3187,9 +3160,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--model", type=str, default="",
                         help="model path/ref to compose (default: the "
                              "request's source_ref)")
-    parser.add_argument("--allow-regressed-lanes", action="store_true",
-                        help="mint a lane #730 holds on dynamo (plain / "
-                             "fp8) — deliberate override")
     parser.add_argument("--publish", action="store_true",
                         help="publish through the fleet CellPublisher")
     parser.add_argument("--require-toolchain", action="store_true",
@@ -3227,10 +3197,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 3
     try:
         pipeline, _build_inputs = compose_for_mint(model, spec, body)
-        result = mint(
-            pipeline, spec, Path(args.out),
-            allow_regressed_lanes=args.allow_regressed_lanes,
-        )
+        result = mint(pipeline, spec, Path(args.out))
     except MintRefused as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 2
@@ -3319,7 +3286,6 @@ __all__ = [
     "write_phase_snapshot",
     "MINT_COMPILE_THREADS",
     "MintResult",
-    "PARITY_LANES",
     "autotune_posture",
     "cell_identity",
     "compile_entry_files",
@@ -3332,7 +3298,6 @@ __all__ = [
     "export_program",
     "shared_identity_blocks",
     "LIFTED_LORA_TORCH_FLOOR",
-    "lane_admitted",
     "lifted_input_gaps",
     "lifted_torch_gap",
     "main",

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1757,13 +1757,13 @@ def mint_recipe(
     from . import aot_mint
 
     spec = aot_export_spec(pipe, cfg)
-    # #730's hold is a MEASURED policy (plain/fp8 are 6.9-7.0% slower under
-    # AOTI), so a pod on a held lane must decline BY NAME rather than mint a
-    # regression — and must never be silent about it, which is what the five
-    # measured L4 pods were.
-    refusal = aot_mint.lane_admitted(spec, allow_regressed_lanes=False)
-    if refusal:
-        return _decline("aot_lane_regressed", refusal)
+    # pgw#850/#879: there is NO lane admission here. The lane this pod serves
+    # was chosen by the hub's resolution tree and observed off the composed
+    # pipeline; re-ranking it at mint time was a second opinion that composed
+    # with tensorhub's compiled-only `fp8-w8a8-dynamic` into a total block —
+    # the one lane the mint admitted was the one lane no AUTO pod could be on.
+    # Every check below answers "can this compile physically run", never
+    # "should this lane exist".
     refusal = aot_mint.lifted_torch_gap(spec)
     if refusal:
         return _decline("aot_lifted_torch_gap", refusal)

--- a/tests/test_aot_adapter_fork_pgw790.py
+++ b/tests/test_aot_adapter_fork_pgw790.py
@@ -120,7 +120,7 @@ def cell(tmp_path_factory, request) -> Dict[str, Any]:
     tmp = tmp_path_factory.mktemp("cell790")
     pipe = _armed_pipe()
     result = aot_mint.mint(
-        pipe, _spec(), tmp / "out", allow_regressed_lanes=True)
+        pipe, _spec(), tmp / "out")
     reset_export_declarations()
     return {"pipe": pipe, "result": result, "tmp": tmp}
 
@@ -265,7 +265,7 @@ def test_identity_is_a_function_of_the_declaration_not_of_adapter_state(
             assert lora_lifted.adapter_active(pipe.unet)
         out = tmp_path / f"active{int(active)}"
         result = aot_mint.mint(
-            pipe, _spec(), out, allow_regressed_lanes=True)
+            pipe, _spec(), out)
         keys.append(result.metadata["cell_key"])
         names.append(sorted(result.metadata["entries"]))
         reset_export_declarations()

--- a/tests/test_aot_lifted_arm_pgw822.py
+++ b/tests/test_aot_lifted_arm_pgw822.py
@@ -180,7 +180,7 @@ def cell(tmp_path_factory, request) -> Dict[str, Any]:
     tmp = tmp_path_factory.mktemp("cell822")
     pipe = _container_only_pipe()
     result = aot_mint.mint(
-        pipe, _spec(), tmp / "out", allow_regressed_lanes=True)
+        pipe, _spec(), tmp / "out")
     reset_export_declarations()
     return {"pipe": pipe, "result": result}
 
@@ -289,9 +289,6 @@ def test_the_parent_declines_the_mint_by_name_instead_of_renting(monkeypatch) ->
         guidance_scales=(), targets=("unet",))
 
     monkeypatch.setattr(fleet_cells.aot_cells, "prefer_aot", lambda: True)
-    monkeypatch.setattr(
-        aot_mint, "lane_admitted",
-        lambda spec, allow_regressed_lanes=False: "")
     monkeypatch.setattr(aot_mint, "lifted_torch_gap", lambda spec: "")
     events: list = []
     monkeypatch.setattr(

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -666,20 +666,6 @@ def test_multiple_of_dim_actually_exports_with_the_declared_range() -> None:
         program, (aot_mint.DynamicDim("sample", 2, 64, 160, multiple_of=8),)) == []
 
 
-# ---------------------------------------------------------------------------
-# Lane order — w8a8 first
-# ---------------------------------------------------------------------------
-
-
-def test_mint_holds_a_regressed_lane_before_exporting(
-    tmp_path: Path, _gpu_runtime: None,
-) -> None:
-    spec = aot_mint.ExportSpec(family="tiny", target="", weight_lane="")
-    with pytest.raises(aot_mint.MintRefused, match="#730"):
-        aot_mint.mint(SimpleNamespace(unet=CellModule().eval()), spec, tmp_path)
-    assert list(tmp_path.iterdir()) == []
-
-
 def test_mint_requires_the_declared_warm_canon(
     tmp_path: Path, _gpu_runtime: None,
 ) -> None:

--- a/tests/test_aot_mint_unblock_pgw813_pgw815.py
+++ b/tests/test_aot_mint_unblock_pgw813_pgw815.py
@@ -179,8 +179,7 @@ def _w8a8_miss(monkeypatch: pytest.MonkeyPatch) -> Any:
         fleet_cells.loading, "pipeline_weight_lane",
         lambda pipe: "w8a8-lora64")
     # The torch-VERSION floor for the lifted-LoRA fork is not what these tests
-    # measure and torch is not importable on a CPU dev box; `lane_admitted`
-    # (the #730 hold — the OTHER half of "no lane can mint") stays REAL.
+    # measure and torch is not importable on a CPU dev box.
     from gen_worker import aot_mint
 
     monkeypatch.setattr(aot_mint, "lifted_torch_gap", lambda spec: "")

--- a/tests/test_aot_multigraph_pgw758.py
+++ b/tests/test_aot_multigraph_pgw758.py
@@ -88,7 +88,7 @@ def _mint(tmp_path: Path, pipe: Any = None) -> Tuple[Any, aot_mint.MintResult]:
     pipe = pipe or types.SimpleNamespace(unet=TinyUNet())
     spec = aot_mint.ExportSpec(family=FAMILY, target="")
     result = aot_mint.mint(
-        pipe, spec, tmp_path / "out", allow_regressed_lanes=True)
+        pipe, spec, tmp_path / "out")
     return pipe, result
 
 
@@ -224,7 +224,7 @@ def test_mint_refuses_a_family_with_no_declaration(tmp_path, fake_sm) -> None:
     pipe = types.SimpleNamespace(unet=TinyUNet())
     spec = aot_mint.ExportSpec(family="undeclared", target="")
     with pytest.raises(aot_mint.MintRefused, match="declaration"):
-        aot_mint.mint(pipe, spec, tmp_path, allow_regressed_lanes=True)
+        aot_mint.mint(pipe, spec, tmp_path)
 
 
 def test_mint_request_refuses_coordinate_subsets(tmp_path) -> None:
@@ -261,7 +261,7 @@ def test_export_failure_names_the_entry(tmp_path, fake_sm) -> None:
     pipe = types.SimpleNamespace(unet=Broken())
     spec = aot_mint.ExportSpec(family=FAMILY, target="")
     with pytest.raises(aot_mint.MintRefused) as err:
-        aot_mint.mint(pipe, spec, tmp_path, allow_regressed_lanes=True)
+        aot_mint.mint(pipe, spec, tmp_path)
     assert "unet/cfg=false/B=1" in str(err.value)
 
 
@@ -304,7 +304,7 @@ def test_declared_warm_family_mints_the_warmed_graph(tmp_path, fake_sm) -> None:
     module = WarmSensitive()
     pipe = types.SimpleNamespace(unet=module)
     spec = aot_mint.ExportSpec(family="warm758", target="")
-    result = aot_mint.mint(pipe, spec, tmp_path, allow_regressed_lanes=True)
+    result = aot_mint.mint(pipe, spec, tmp_path)
     # The pre-warm RAN before export (the cache branch is warm at trace time),
     # and the mint recorded its cost.
     assert module.warm_calls == 1
@@ -317,7 +317,7 @@ def test_undeclared_warm_family_is_not_warmed(tmp_path, fake_sm) -> None:
     module = WarmSensitive()
     pipe = types.SimpleNamespace(unet=module)
     spec = aot_mint.ExportSpec(family="cold758", target="")
-    result = aot_mint.mint(pipe, spec, tmp_path, allow_regressed_lanes=True)
+    result = aot_mint.mint(pipe, spec, tmp_path)
     # Export itself traces the cold branch; no separate warm forward ran and
     # none was recorded.
     entry = next(iter(result.metadata["mint_phases"]["entries"].values()))
@@ -342,7 +342,7 @@ def test_failed_declared_warm_is_a_named_refusal(tmp_path, fake_sm) -> None:
     pipe = types.SimpleNamespace(unet=Fails())
     spec = aot_mint.ExportSpec(family="warmfail758", target="")
     with pytest.raises(aot_mint.MintRefused, match="mint-warm"):
-        aot_mint.mint(pipe, spec, tmp_path, allow_regressed_lanes=True)
+        aot_mint.mint(pipe, spec, tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -30,6 +30,7 @@ kind. Three separate wires were missing, and each gets a test here:
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -43,6 +44,7 @@ from gen_worker.api.export_contract import (
 )
 from gen_worker import config as gw_config
 from gen_worker.cell_adopt import AdoptOutcome
+from gen_worker.models import loading
 
 FAMILY = "sdxl"
 
@@ -244,25 +246,75 @@ def test_a_compile_block_without_graph_classes_is_not_a_declaration() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. THE HELD LANES — #730's dynamo hold is a decision, and it must be audible
+# 3. THE LANE IS AN INPUT — pgw#850/#879: the mint compiles what it is handed
 # ---------------------------------------------------------------------------
 
 
-def test_a_lane_held_on_dynamo_declines_by_name(
+@pytest.mark.parametrize("base_lane", loading.STAMPABLE_BASE_LANES)
+def test_every_lane_a_pod_can_serve_reaches_the_aot_recipe(
+    base_lane: str,
     _miss: None, _events: List[Tuple[str, str, str]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """This is the five L4 pods' ACTUAL state: `pipeline_weight_lane` was the
-    plain lane, which #730 holds on dynamo (6.9-7.0% slower under AOTI). The
-    hold is right; being unable to say so is the defect."""
+    """pgw#850's fix, proven over the WHOLE lane vocabulary rather than the
+    one lane the allowlist named.
+
+    The composition this replaces, measured on `origin/dev` 2026-08-03:
+    `aot_mint.PARITY_LANES` admitted exactly `"w8a8"`, and tensorhub's lane
+    table makes `fp8-w8a8-dynamic` compiled-only — so the hub withholds it
+    from AUTO until a cell exists (th#1123 `applyCompileCellAvailability`,
+    th#1127 `applyPublishMintObligation`), and tensorhub's own comment says
+    "only a worker's own self-mint can discharge it". The single admitted
+    lane was the single lane no AUTO pod could ever be on, and the four lanes
+    a pod COULD be on were each declined `aot_lane_regressed`, quoting a
+    6.9-7.0% AOTI regression measured on sdxl's lanes alone. Zero fleet
+    families reached the mint gate, on any card.
+
+    The lane is an INPUT now. `loading.STAMPABLE_BASE_LANES` is every lane a
+    loader can leave a pipeline on (pgw#918, mechanically checked), so this
+    parametrisation IS the fleet: each one must mint.
+    """
     register_export_declaration(_declaration())
     monkeypatch.setattr(
-        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "")
+        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: base_lane)
 
     pending = _arm(delegate=True).self_mint
 
-    assert pending is not None and pending.recipe == fleet_cells.RECIPE_DYNAMO
-    assert "aot_lane_regressed" in _phases(_events, "self_mint_skipped")
+    assert pending is not None and pending.recipe == fleet_cells.RECIPE_AOT, (
+        f"lane {base_lane!r} did not reach the AOT recipe — a mint-side lane "
+        f"judgement has grown back")
+    assert not _phases(_events, "self_mint_skipped"), (
+        f"lane {base_lane!r} was declined: "
+        f"{[d for k, _p, d in _events if k == 'self_mint_skipped']}")
+
+
+def test_the_bucketed_lora_form_of_a_lane_mints_too(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stamp a pod carries in production is usually the BUCKETED form
+    (`w8a8-lora64`, `fp8-hooks-lora32`). It decomposes to a base lane and
+    must not be treated as an unknown string."""
+    register_export_declaration(_declaration())
+    monkeypatch.setattr(
+        fleet_cells.loading, "pipeline_weight_lane",
+        lambda pipe: "fp8-hooks-lora64")
+
+    pending = _arm(delegate=True).self_mint
+
+    assert pending is not None and pending.recipe == fleet_cells.RECIPE_AOT
+    assert not _phases(_events, "self_mint_skipped")
+
+
+def test_the_mint_holds_no_lane_predicate() -> None:
+    """The deletion itself. `lane_admitted`/`PARITY_LANES` were a SECOND
+    opinion about a lane the hub's resolution tree had already chosen; two
+    opinions in two repos is what composed into the total block. Every
+    surviving mint check answers "can this compile physically run"."""
+    assert not hasattr(aot_mint, "lane_admitted")
+    assert not hasattr(aot_mint, "PARITY_LANES")
+    assert "allow_regressed_lanes" not in inspect.signature(
+        aot_mint.mint).parameters
 
 
 def test_an_in_process_only_pod_declines_the_aot_recipe_by_name(

--- a/tests/test_cxx_toolchain_pgw823.py
+++ b/tests/test_cxx_toolchain_pgw823.py
@@ -103,8 +103,6 @@ def test_the_parent_declines_the_AOT_recipe_by_name(
     monkeypatch.setattr(fleet_cells.cc, "cxx_toolchain_present", lambda: False)
     from gen_worker import aot_mint
 
-    monkeypatch.setattr(
-        aot_mint, "lane_admitted", lambda *a, **k: "")
     monkeypatch.setattr(aot_mint, "lifted_torch_gap", lambda *a, **k: "")
     monkeypatch.setattr(
         fleet_cells, "aot_export_spec", lambda *a, **k: object())

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -265,7 +265,7 @@ def _mint(tmp_path: Any, monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> Any:
         return aot_mint.mint(
             types.SimpleNamespace(unet=_Tiny().eval()),
             aot_mint.ExportSpec(family=_FAMILY, target=""),
-            tmp_path / "out", allow_regressed_lanes=True, **kwargs)
+            tmp_path / "out", **kwargs)
     finally:
         reset_export_declarations()
 

--- a/tests/test_speculative_lane_completeness_pgw918.py
+++ b/tests/test_speculative_lane_completeness_pgw918.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Dict, Set, Tuple
 
 from gen_worker import aot_mint, executor
-from gen_worker.compile_cache import lane_bucket, lane_token
+from gen_worker.compile_cache import lane_bucket
 from gen_worker.models import loading
 from gen_worker.models.w8a8_lora import lora_lane
 
@@ -135,20 +135,20 @@ def test_the_executor_speculates_exactly_the_loader_vocabulary():
             == tuple(loading.STAMPABLE_BASE_LANES))
 
 
-def test_every_parity_lane_names_something_a_loader_can_stamp():
-    """pgw#918 second half: ``PARITY_LANES`` held ``"w8a8-rowwise"``, a token
-    ``lane_admitted`` could never be handed, so half the authored allowlist
-    was decorative."""
-    stampable_tokens = {
-        lane_token(lane_bucket(lane)[0])
-        for lane in loading.STAMPABLE_BASE_LANES
-    }
-    orphans = sorted(set(aot_mint.PARITY_LANES) - stampable_tokens)
-    assert not orphans, (
-        f"PARITY_LANES names lane token(s) nothing can stamp: {orphans}. "
-        f"lane_admitted is handed lane_token(lane_bucket(stamp)[0]), so a "
-        f"token outside {sorted(stampable_tokens)} is unreachable coverage."
-    )
+def test_the_mint_holds_no_lane_allowlist_at_all():
+    """pgw#850 superseded pgw#918's second half by DELETION.
+
+    ``PARITY_LANES`` was the surviving half of that allowlist — one member,
+    ``"w8a8"`` — and it composed with tensorhub's compiled-only
+    ``fp8-w8a8-dynamic`` lane into a total block: the hub withholds a
+    mandatory-compile lane until a cell exists, and only a pod already on the
+    lane can mint one, so the single admitted token named the single lane no
+    AUTO pod could ever be on. Checking an allowlist's members for
+    reachability is the wrong invariant when the right answer is that the mint
+    holds no allowlist. It is GIVEN a lane and compiles it.
+    """
+    assert not hasattr(aot_mint, "PARITY_LANES")
+    assert not hasattr(aot_mint, "lane_admitted")
 
 
 def test_the_one_derived_stamp_site_decomposes_to_a_named_base():


### PR DESCRIPTION
## The composition as it stands **today**, not as filed

The lane vocabulary moved under this issue, so it was re-derived from `origin/dev` before anything was changed. **It is still empty — and it is sharper than filed: a strict cycle, not a narrow allowlist.**

| | filed (2026-08-01) | measured on `origin/dev` (2026-08-03) |
|---|---|---|
| mint side | `PARITY_LANES = ("w8a8", "w8a8-rowwise")`, `REGRESSED_LANES` | pgw#918 deleted `REGRESSED_LANES` and the second member (unstampable). **`PARITY_LANES = ("w8a8",)` — one admitted token** |
| hub side | `FP8ComputeMinSM = 89` (sub-sm_89 cards can't) | still true, **and now subsumed**: PR #709 made `fp8-w8a8-dynamic` **compiled-only**, and `fp8-w8a8-dynamic+eager` refuses at parse |

`RequiresCompiledCell` therefore holds for every w8a8 row, so `applyCompileCellAvailability` (th#1123) and `applyPublishMintObligation` (th#1127) set `CompileCellUnavailable`, and `autoEligibleModel` (`ladder.go:289`) drops the row. tensorhub's own comment: *"only a worker's own self-mint can discharge it."*

**So the one lane the mint admitted was the one lane no AUTO pod could ever be on.** The four lanes a pod *can* be on were each declined `aot_lane_regressed`, citing a 6.9-7.0 % AOTI regression pgw#704 Q4 measured on sdxl's lanes alone:

| pod stamp (`STAMPABLE_BASE_LANES`) | `lane_token` | hub lane | admitted before? |
|---|---|---|---|
| `""` | `""` | `bf16-w16a16` (either) | no |
| `"fp8-hooks"` | `w8a16` | `fp8-w8a16` (either) | no |
| `"w8a8"` | `w8a8` | `fp8-w8a8-dynamic` (**compiled-only**) | yes — and unreachable |
| `"w4a4"` | `w4a4` | `nvfp4-w4a4-static` (**compiled-only**) | no |
| `"svdq-native"` | `svdq-native` | `svdq-fp4/int4-w4a4` (eager, newly servable via #709) | no |

Measured RED: parametrising the real `mint_recipe` path over `loading.STAMPABLE_BASE_LANES` against the pre-fix source fails on exactly the four non-`w8a8` rows. A forge pod does not rescue it — the `WORKER_MODE=forge` launch carries no lane, so it mints whatever its binding resolves to.

## What changed

pgw#879's **deletion**, per this issue's own adjudication ("delete both decision constants rather than widen an allowlist"), not a wider allowlist:

- `aot_mint.PARITY_LANES`, `aot_mint.lane_admitted`
- the `allow_regressed_lanes` thread — `mint`, `_mint_cell`, the `--allow-regressed-lanes` CLI flag, `__all__`
- `fleet_cells`' hardcoded `lane_admitted(..., allow_regressed_lanes=False)` call and the `self_mint_skipped phase=aot_lane_regressed` decline

The lane is an **input**: the hub's resolution tree chooses it, `loading.pipeline_weight_lane` observes it, the mint compiles what it is handed. Every surviving check answers "can this compile physically run" (declaration existence, `declaration_module_gaps`, `cxx_toolchain_present`, delegation availability, torch floor, `MintResourceExhausted`) — none reads lane policy, family history, or a measurement. The pgw#704 Q4 / #730 measurement is not discarded; it is a **ranking** input to the hub's `+compiled` vs `+eager` choice.

## Proof

`tests/test_aot_selfmint_pgw805.py` parametrises the real `mint_recipe` path over the whole `STAMPABLE_BASE_LANES` vocabulary plus a bucketed LoRA stamp, asserting `RECIPE_AOT` and zero `self_mint_skipped`; plus a guard that no lane predicate can grow back. `tests/test_speculative_lane_completeness_pgw918.py`'s reachability check on the allowlist is replaced by the assertion that there is no allowlist.

Ran: the 7 affected modules, **159 passed** (real CPU AOTI compiles, 27 m). `mypy` clean on both changed modules.

## What this does NOT reach — and what needs a GPU

- **Hub-side residue (th#1408).** A compiled-only lane still has no bootstrap path: withheld until a cell exists, and only a pod already on it can produce one. `fp8-w8a8-dynamic` and `nvfp4-w4a4-static` stay unreachable on AUTO. th#1556's `execution_support_th1556_test.go` proves every enumerated lane can *represent* its compile precondition; nothing proves one can *produce* it.
- **`fp8-w8a8` eager is UNMEASURED** (th#1556's open item) and was deliberately **not** liberalised to make this composition work. Impossibility belongs in the lane table, a performance judgement in ranking. Measuring it needs a GPU.
- **No real mint was run.** This box does no GPU work, so the end-to-end "pod on `fp8-w8a16` mints a cell that the hub then serves compiled" leg is unverified; it is proven only through the real `mint_recipe` decision path.

What this release *does* fix: `bf16-w16a16` and `fp8-w8a16` are `either`-execution and reachable with no pre-existing cell, so they can now mint the cells that make their compiled forms servable. **The self-mint path is alive.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)