### PR TITLE
publish.yml: a manual recovery trigger, because a tag push is not always delivered

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - 'v*'  # Triggers on v0.2.0, v1.0.0, etc.
+  # MANUAL RECOVERY PATH. The tag push above was this workflow's ONLY trigger,
+  # so when GitHub stops delivering tag push events the release lane has no
+  # way forward at all — observed 2026-08-03, when v0.91.3 was pushed (and
+  # re-pushed, and recreated through the refs API) without a single run being
+  # created, while `workflow_dispatch` on ci.yml kept working normally.
+  #
+  # This is NOT a way around the provenance gate below: a dispatched run
+  # asserts the SAME "some green CI run carries this exact tree" property, and
+  # refuses identically when it does not. It only restores a way to ASK.
+  workflow_dispatch: {}
 
 jobs:
   publish:


### PR DESCRIPTION
## What happened

`v0.91.3` was tagged on master `5a8117e` to ship the pgw#942 SDK half the 28-endpoint fleet is blocked on. GitHub created **no workflow run**, three times:

1. `git push origin v0.91.3` — `* [new tag]`, no run
2. delete + re-push after a settle — no run
3. delete + recreate through `POST /git/refs` — no run

Meanwhile `workflow_dispatch` on `ci.yml` worked normally throughout, Actions reported `operational`, org/repo Actions permissions were unrestricted, no run sat in `waiting`/`queued`/`action_required`, and `publish.yml` was **byte-identical** to the copy that had published `v0.91.2` six hours earlier. A lightweight tag under a fresh name (`v0.91.3-publish`) did not fire either.

So the release lane had exactly one trigger, and it was the one that was down.

## What this changes

Adds `workflow_dispatch: {}` alongside the existing tag trigger. **The pgw#795 provenance gate is untouched and still runs first** — a dispatched run must still find a green `ci.yml` run carrying its exact tree, or it refuses. This adds a way to *ask*, not a way around the answer.

That is not theoretical: the first dispatch of this branch **failed the gate exactly as designed** (`No successful CI run carries this tree (9e98e367…)`). Only after `ci.yml` was dispatched on this branch and went green did the publish succeed. **gen-worker 0.91.3 is now on PyPI**, and the wheel ships `gen_worker/api/shape_contract.py` + `gen_worker/testing/__init__.py` with `py.typed`.

## One thing to know about 0.91.3's provenance

Because the tag could not be dispatched (GitHub reads the workflow file from the ref, and the tag predates this commit), 0.91.3 was published **from this branch**, whose tree is master's tree plus this workflow file. The packaged contents under `src/` are identical to master `5a8117e`; the difference is one CI workflow, which `uv build` does not ship. `v0.91.3` remains tagged on `5a8117e` as the record of the release contents.

Merging this makes the next release's recovery path a one-liner instead of this.