### PR TITLE
pgw#946: the mint MEASURES the serving-kernel lane; the SM allowlist is deleted

### DIFF
--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -83,3 +83,50 @@ Fix one of:
    unconditionally (ie#522). An endpoint
    with several self-loaded pipelines sharing weights (e.g. one class
    assembling `self.t2i`/`self.i2v`/`self.v2v`) calls it once per object.
+
+## The serving-kernel lane is MEASURED at mint, not gated by SM (pgw#946)
+
+The svdq path can run its linears through hand-fused native kernels or the
+baseline unfused chain. Which one is faster is a per-card fact — a custom op
+is opaque to inductor, so on sm_120 our fusion beats what inductor does with
+the open chain and on sm_100 it loses to it — and it used to be a
+hand-maintained SM tuple, one $12 benchmark campaign and one human edit per
+new card class.
+
+It is now measured on the card the cell is minted for and recorded in the
+cell (`gen_worker/kernel_lane.py`):
+
+- **Mint.** `mint_child.lane_verdict_for` loads the endpoint once per
+  candidate lane (the swap happens at model load, so comparing two lanes
+  means loading twice), runs `aot_mint.bench_step` — one forward of the
+  family's dominant declared graph class, on its own declared example feed,
+  under `torch.compile` — and times it with a fixed warmup/median protocol.
+  The winner's pipeline is the one that gets exported.
+- **The rule: fit-constrained speed maximization.** Among lanes whose
+  measured peak plus a stated allowance (`+20%` for activation spikes and
+  resolution variance, `+1 GiB` for fragmentation) fits the card, the
+  FASTEST wins. VRAM is a constraint, not an objective; it breaks a tie only
+  inside the 5% margin. A B200 therefore takes the baseline lane
+  (228 ms/step, 44.1 GB) over the fused lane (350 ms/step, 35.1 GB) — the
+  card has the room — while on a 24 GB card the same fit constraint excludes
+  a lane outright.
+- **Determinism.** The 5% margin means measurement noise cannot flip a
+  recorded verdict between two mints on one card, and every number behind a
+  verdict is recorded as its evidence.
+- **Where it lands.** `metadata.json` inside the packed cell carries the
+  DISCRETE verdict (`kernel_lane`: winner, rule, binding term, margin,
+  candidates) — no wall clocks, because the #699 double-mint byte-compare
+  requires a reproducible artifact. The measurements ride the published
+  checkpoint metadata as `kernel_lane_evidence`, beside `mint_phases`.
+- **Serving.** The executor reads the verdict off the delivered cell and
+  pins it BEFORE `setup()` runs. No cell, a pre-pgw#946 cell, or an
+  unreadable envelope is the declared conservative default (`baseline`) with
+  a typed reason (`kernel_lane_verdict_absent` / `_unreadable` /
+  `_unknown_lane` / `kernel_lane_no_cell`) — never a silent fall-through.
+  A `fused` verdict still has to pass the numerics self-check on the box; a
+  gap degrades to baseline, same artifact, with the reason logged.
+
+`GEN_WORKER_NATIVE_KERNELS` survives only as the pgw#859 G0 rollout gate and
+kill switch (unset = off, `=0` = forced off). It gates the ROLLOUT and never
+picks a lane; flipping it is pgw#865's call. It is on th#1445's elimination
+list and must not grow new meanings.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -85,7 +85,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 from . import activity as activity_mod
 from . import (
     aot_compile_pool, aot_export_parallel, aot_export_reuse, aot_package,
-    aot_serve, aot_wrapper_split, cell_key, graph_hash)
+    aot_serve, aot_wrapper_split, cell_key, graph_hash, kernel_lane)
 from .aot_contract import (  # re-exported: the declaration layer's vocabulary
     ADAPTER_FORK,
     DynamicDim,
@@ -1164,6 +1164,59 @@ def _export_entry(
         timings=timings)
 
 
+def bench_step(pipeline: Any, spec: ExportSpec) -> Callable[[], Any]:
+    """A zero-argument callable running ONE forward of this family's DOMINANT
+    declared graph class, in the PRODUCTION (compiled) posture (pgw#946).
+
+    The dominant class is the declaration's FIRST target — the denoiser,
+    which runs once per step while the VAE runs once per image — so "ms/step"
+    means what the pgw#862/#863 benchmark tables mean by it. A cell-level spec
+    that names a target (the operator CLI path) overrides that. Its inputs are
+    the family's OWN declared example feed (``aot_inputs.builder_for``), i.e.
+    the same representative shape the mint is about to export against, not a
+    shape invented here.
+
+    COMPILED, deliberately: pgw#863's whole finding is that the eager ranking
+    and the compiled ranking disagree — inductor fuses the baseline lane's
+    open elementwise chain and cannot fuse across our custom ops — and the
+    compiled posture is the only one production serves from.
+    """
+    import torch
+
+    from . import aot_declaration as _decl
+    from . import aot_inputs
+    from .api.export_contract import export_declaration
+
+    decl = export_declaration(spec.family)
+    if decl is None:
+        raise MintRefused(
+            f"family {spec.family!r} has no export declaration — nothing to "
+            f"benchmark a kernel lane against")
+    plans = list(_decl.cell_plans(decl))
+    if not plans:
+        raise MintRefused(f"family {spec.family!r} declares no graph classes")
+    want = str(spec.target or "") or str(decl.targets[0])
+    dominant = next(
+        (p for p in plans if str(p.target) == want), plans[0])
+    espec = _entry_spec(spec, dominant, decl)
+    resolved = _resolve_target(pipeline, espec.target)
+    if resolved is None:
+        raise MintRefused(
+            f"pipeline {type(pipeline).__name__} has no compile target "
+            f"{espec.target!r} to benchmark")
+    owner, attr, _fn = resolved
+    module = owner if attr == "forward" else _CallableTarget(owner, attr)
+    builder = aot_inputs.builder_for(espec.family, espec.target)
+    args, kwargs = builder(owner, espec)
+    compiled = torch.compile(module)
+
+    def step() -> Any:
+        with torch.no_grad():
+            return compiled(*args, **kwargs)
+
+    return step
+
+
 def replace_spec(spec: ExportSpec, **changes: Any) -> ExportSpec:
     """``dataclasses.replace`` on an :class:`ExportSpec`, named so the
     deferred-import dance does not have to repeat at every call site."""
@@ -1434,6 +1487,7 @@ def mint(
     entry_device_peak_bytes: int = 0,
     on_progress: Optional[Callable[[str, int, int, str], None]] = None,
     phase_snapshot: Optional[Path] = None,
+    lane_verdict: Optional[kernel_lane.Verdict] = None,
 ) -> MintResult:
     """:func:`_mint_cell`, with the phase table attached to EVERY terminus.
 
@@ -1488,6 +1542,7 @@ def mint(
             entry_workers=entry_workers,
             entry_peak_rss_bytes=entry_peak_rss_bytes,
             entry_device_peak_bytes=entry_device_peak_bytes,
+            lane_verdict=lane_verdict,
             progress=progress)
     except BaseException as exc:
         _attach_partial_phases(exc, progress)
@@ -1676,10 +1731,18 @@ def _mint_cell(
     entry_workers: int = 0,
     entry_peak_rss_bytes: int = 0,
     entry_device_peak_bytes: int = 0,
+    lane_verdict: Optional[kernel_lane.Verdict] = None,
     progress: Optional[MintProgress] = None,
 ) -> MintResult:
     """Export + compile EVERY declared graph class and pack them as ONE
     multi-graph cell (pgw#758).
+
+    ``lane_verdict`` (pgw#946) is the MEASURED serving-kernel lane for this
+    card, produced by the mint driver before the pipeline was loaded — only
+    the loader can swap the linears, so the A/B happens one level up
+    (``mint_child.lane_verdict_for``). The discrete verdict is packed into
+    the envelope so serving reads it instead of an SM tuple; the numbers ride
+    the result metadata beside ``mint_phases``, never the artifact.
 
     ``entry_workers`` CAPS pgw#809's compile pool; it never widens it. The
     width is derived from the pod (see :func:`aot_compile_pool.entry_workers`),
@@ -1959,6 +2022,12 @@ def _mint_cell(
         raise MintRefused(
             f"envelope refused the declared contract: {exc}") from exc
     meta.update(shared_identity_blocks(spec))
+    if lane_verdict is not None:
+        # pgw#946: the DISCRETE verdict only. Milliseconds in metadata.json
+        # would break the #699 double-mint byte-compare — the artifact
+        # deliberately carries no wall clocks — and the margin threshold is
+        # what makes the discrete answer reproducible across two mints.
+        meta[kernel_lane.META_KEY] = kernel_lane.envelope_block(lane_verdict)
     mode_drift = aot_package.strict_mode_drift(meta, spec.strict)
     if mode_drift:
         raise MintRefused("trace-mode drift: " + "; ".join(mode_drift))
@@ -1978,6 +2047,13 @@ def _mint_cell(
     # metadata.json would break the #699 double-mint byte-compare — the
     # artifact deliberately carries no timestamps and no wall clocks.
     meta["mint_phases"] = phase_table
+    if lane_verdict is not None:
+        # The EVIDENCE: both lanes' ms/step and peak bytes, the margin, the
+        # headroom terms, and the device it was all measured on. Same channel
+        # as the phase table (published checkpoint metadata + the typed
+        # event), so a verdict is auditable long after the pod is gone.
+        meta[kernel_lane.EVIDENCE_KEY] = kernel_lane.evidence_block(
+            lane_verdict)
 
     logger.info(
         "aot-mint: %s lane=%s -> %s (%d entr%s across %d target(s), %.1f MB "
@@ -3321,6 +3397,7 @@ __all__ = [
     "MintResult",
     "PARITY_LANES",
     "autotune_posture",
+    "bench_step",
     "cell_identity",
     "compile_entry_files",
     "compose_for_mint",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -34,6 +34,7 @@ import msgspec
 from . import activity as activity_mod
 from . import boot_phases as boot_mod
 from . import cpu_budget
+from . import kernel_lane
 from . import mint_budget
 from . import progress as progress_mod
 from . import serving_mode as serving_mode_mod
@@ -6584,6 +6585,14 @@ class Executor:
             else await self._fetch_compile_snapshot(spec, snapshots)
         )
         compile_artifact = compile_selection.path if compile_selection else None
+        # pgw#946: the serving-kernel lane comes from the CELL, and it has to
+        # be pinned BEFORE setup() — the linears are swapped at model load, so
+        # a verdict read afterwards would arrive one whole pipeline too late.
+        # No cell (eager boot, self-minting boot, pre-pgw#946 cell) is the
+        # declared conservative default WITH a typed reason; there is no SM
+        # allowlist and no per-boot probe to fall back on any more.
+        kernel_lane.adopt_from_artifact(
+            compile_artifact, source=f"{spec.name} boot")
         # Loads serialize: concurrent setups would cross-contaminate each
         # other's allocator deltas and place_pipeline's free-VRAM reads.
         async with self._intent_lock(

--- a/src/gen_worker/kernel_lane.py
+++ b/src/gen_worker/kernel_lane.py
@@ -1,0 +1,659 @@
+"""Measured serving-kernel lane selection (pgw#946).
+
+The svdq serving path can run its linears through hand-fused native kernels
+or through the baseline unfused chain. Which one is FASTER is a per-card
+FACT, not a derivable one: a custom op is opaque to inductor, so on sm_120
+our fusion beats what inductor can do with the open chain and on sm_100 it
+loses to it. That was a hand-maintained SM tuple, informed by ~$12 benchmark
+campaigns per card and one human edit per new card class.
+
+This module replaces the tuple with a measurement taken on the card the cell
+is being minted for, recorded INTO the cell, and adopted by serving:
+
+    mint      probe(candidates, ...) -> Verdict     (both lanes built,
+              compiled, and timed on the target card, in the pgw#784 mint
+              process)
+    envelope  metadata.json["kernel_lane"] — the DISCRETE verdict only
+    result    metadata["kernel_lane_evidence"] — the numbers, published with
+              the checkpoint, never packed (the #699 double-mint byte-compare
+              forbids wall clocks inside the artifact)
+    serve     adopt(meta) -> pin(); the load-time swap reads the pin
+
+THE SELECTION RULE (Paul, 2026-08-03): **fit-constrained speed
+maximization.** Among lanes whose measured peak VRAM fits the target card
+with headroom, pick the FASTEST. VRAM is a CONSTRAINT, not an objective — it
+breaks a tie only when two lanes are within the speed noise margin. On a
+B200 that means the baseline lane (228 ms/step, 44.1 GB) over the fused lane
+(350 ms/step, 35.1 GB): the card has the room. On a 32 GB 5090 the fit
+constraint does real work and can exclude a faster lane outright.
+
+`models/w4a4.py::_gemm_profitable` is the in-tree precedent — it
+micro-benchmarks fp4 against bf16 at boot and refuses to arm unless it wins
+by a real margin. This is that mechanism one level up: whole compiled graphs
+instead of one GEMM, paid once at mint instead of on every boot, and
+RECORDED instead of re-derived.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+import msgspec
+
+logger = logging.getLogger(__name__)
+
+# --- vocabulary -------------------------------------------------------------
+
+LANE_BASELINE = "baseline"
+LANE_FUSED = "fused"
+LANES = (LANE_BASELINE, LANE_FUSED)
+
+# What a worker runs when no cell says otherwise. The unfused chain is the
+# one that exists on every card and is never a pessimisation on any of them.
+DEFAULT_LANE = LANE_BASELINE
+
+# Envelope key (discrete facts, packed into metadata.json) and result key
+# (measurements, published with the checkpoint, NEVER packed).
+META_KEY = "kernel_lane"
+EVIDENCE_KEY = "kernel_lane_evidence"
+SCHEMA = 1
+
+# --- the policy constants ---------------------------------------------------
+
+# A candidate must beat the incumbent by this much to be declared the SPEED
+# winner. Below it the two are a tie and the smaller peak wins, so ordinary
+# measurement noise can never flip a recorded verdict between two mints on
+# one card. `_gemm_profitable` uses 1.10x on a 4096^3 microbenchmark; a
+# whole-graph step timed over `BENCH_ITERS` medians is far quieter, and every
+# decision this mechanism exists to make is 7-34% wide.
+MARGIN_FRACTION = 0.05
+
+# "Fits" = the measured peak, plus an allowance for the shapes the mint did
+# NOT measure. The mint times ONE representative shape; a tenant may ask for a
+# larger resolution or a longer prompt, and the allocator fragments. The
+# strict_vram rule stands (declare the honest peak ask — a marketing-GB
+# declaration is release-broken by one GiB), so the allowance is explicit and
+# the term that bound a verdict is recorded with it.
+ACTIVATION_SPIKE_FRACTION = 0.20
+FRAGMENTATION_HEADROOM_BYTES = 1 << 30  # 1 GiB
+
+# Fixed measurement protocol — part of the verdict's determinism, recorded
+# with it so a re-measurement is comparable.
+BENCH_WARMUP = 3
+BENCH_ITERS = 9  # odd: a true median, no interpolation
+
+# Capability floor for the fused lane: block-scaled MMA (`dot_scaled` lowering
+# to kind::mxf4nvf4 / tcgen05) is Blackwell silicon. This is a CAPABILITY
+# precondition — can the candidate be built at all — not a performance
+# allowlist. Whether it WINS on a qualifying card is what gets measured.
+FUSED_MIN_SM = 100
+
+# Why a lane is what it is, when no verdict decided it. Typed so a serving
+# worker's degrade is greppable and never a silent fall-through.
+REASON_ABSENT = "kernel_lane_verdict_absent"
+REASON_UNREADABLE = "kernel_lane_verdict_unreadable"
+REASON_UNKNOWN_LANE = "kernel_lane_verdict_unknown_lane"
+REASON_NO_CELL = "kernel_lane_no_cell"
+REASON_ADOPTED = "kernel_lane_verdict_adopted"
+
+# Which term bound a verdict.
+BIND_SPEED = "speed"
+BIND_FIT = "fit"
+BIND_VRAM_TIEBREAK = "vram_tiebreak"
+BIND_SOLE_CANDIDATE = "sole_candidate"
+BIND_NO_FIT = "no_fit"
+
+
+class LaneProbeError(RuntimeError):
+    """A candidate could not be built or measured. Never fatal: the candidate
+    drops out of the ranking with its reason recorded."""
+
+
+# --- value types ------------------------------------------------------------
+
+
+class Measurement(msgspec.Struct, frozen=True, kw_only=True):
+    """One candidate lane, measured on the target card."""
+
+    lane: str
+    ms_per_step: float = 0.0
+    peak_bytes: int = 0
+    samples_ms: Tuple[float, ...] = ()
+    unavailable: str = ""  # typed reason it could not be measured
+
+    @property
+    def usable(self) -> bool:
+        return not self.unavailable and self.ms_per_step > 0.0
+
+    def required_bytes(self) -> int:
+        """The peak plus the stated allowance for the shapes the mint did not
+        measure (activation spikes, resolution variance, fragmentation)."""
+        return int(self.peak_bytes * (1.0 + ACTIVATION_SPIKE_FRACTION)) \
+            + FRAGMENTATION_HEADROOM_BYTES
+
+
+class Verdict(msgspec.Struct, frozen=True, kw_only=True):
+    """Which lane won on this card, why, and on what evidence."""
+
+    winner: str
+    binding: str
+    rule: str = "fit_constrained_speed"
+    schema: int = SCHEMA
+    margin_fraction: float = MARGIN_FRACTION
+    activation_spike_fraction: float = ACTIVATION_SPIKE_FRACTION
+    fragmentation_headroom_bytes: int = FRAGMENTATION_HEADROOM_BYTES
+    device_total_bytes: int = 0
+    device_name: str = ""
+    sm: str = ""
+    warmup: int = BENCH_WARMUP
+    iters: int = BENCH_ITERS
+    measured_at: float = 0.0
+    measurements: Tuple[Measurement, ...] = ()
+    detail: str = ""
+
+    def measurement(self, lane: str) -> Optional[Measurement]:
+        for row in self.measurements:
+            if row.lane == lane:
+                return row
+        return None
+
+
+# --- the rule ---------------------------------------------------------------
+
+
+def fits(row: Measurement, device_total_bytes: int) -> bool:
+    """Does this lane fit the card with the stated allowance? A card whose
+    total is unknown (0) constrains nothing — the mint measured it there, so
+    it ran there."""
+    if not device_total_bytes:
+        return True
+    return row.required_bytes() <= int(device_total_bytes)
+
+
+def select(
+    measurements: Sequence[Measurement],
+    *,
+    device_total_bytes: int = 0,
+    device_name: str = "",
+    sm: str = "",
+) -> Verdict:
+    """FIT-CONSTRAINED SPEED MAXIMIZATION.
+
+    1. Drop candidates that could not be measured.
+    2. Drop candidates whose measured peak + allowance does not fit the card.
+    3. Among the rest take the FASTEST; a rival within ``MARGIN_FRACTION`` of
+       it is a TIE and the smaller peak wins.
+
+    Nothing fits, or nothing measured -> the smallest-peak usable candidate
+    with ``binding="no_fit"`` (loud, and the serving degrade path owns what
+    happens next), or the declared default with no measurements at all.
+    """
+    rows = tuple(measurements)
+    usable = tuple(r for r in rows if r.usable)
+    common: Dict[str, Any] = {
+        "device_total_bytes": int(device_total_bytes or 0),
+        "device_name": str(device_name or ""),
+        "sm": str(sm or ""),
+        "measurements": rows,
+        "measured_at": time.time(),
+    }
+    if not usable:
+        gaps = "; ".join(
+            f"{r.lane}: {r.unavailable or 'no timing'}" for r in rows)
+        return Verdict(
+            winner=DEFAULT_LANE, binding=BIND_NO_FIT,
+            detail=f"no candidate measured ({gaps or 'no candidates'})",
+            **common)
+
+    fitting = tuple(r for r in usable if fits(r, device_total_bytes))
+    if not fitting:
+        smallest = min(usable, key=lambda r: (r.peak_bytes, r.lane))
+        return Verdict(
+            winner=smallest.lane, binding=BIND_NO_FIT,
+            detail=(
+                f"no candidate fits {device_total_bytes} B with the stated "
+                f"allowance; smallest peak wins ({smallest.lane}, "
+                f"{smallest.peak_bytes} B peak, "
+                f"{smallest.required_bytes()} B required)"),
+            **common)
+
+    excluded = tuple(r.lane for r in usable if r not in fitting)
+    if len(fitting) == 1:
+        only = fitting[0]
+        binding = BIND_FIT if excluded else BIND_SOLE_CANDIDATE
+        detail = (
+            f"{only.lane} is the only lane that fits; excluded "
+            f"{sorted(excluded)!r}" if excluded
+            else f"{only.lane} is the only candidate")
+        return Verdict(winner=only.lane, binding=binding, detail=detail,
+                       **common)
+
+    ranked = sorted(fitting, key=lambda r: (r.ms_per_step, r.lane))
+    best, rival = ranked[0], ranked[1]
+    gap = (rival.ms_per_step - best.ms_per_step) / max(best.ms_per_step, 1e-9)
+    if gap >= MARGIN_FRACTION:
+        return Verdict(
+            winner=best.lane, binding=BIND_SPEED,
+            detail=(
+                f"{best.lane} {best.ms_per_step:.1f} ms/step beats "
+                f"{rival.lane} {rival.ms_per_step:.1f} by {gap * 100:.1f}% "
+                f"(margin {MARGIN_FRACTION * 100:.0f}%)"
+                + (f"; excluded on fit {sorted(excluded)!r}" if excluded
+                   else "")),
+            **common)
+    # Within the noise margin: VRAM breaks the tie, and only here.
+    tied = tuple(
+        r for r in fitting
+        if (r.ms_per_step - best.ms_per_step)
+        / max(best.ms_per_step, 1e-9) < MARGIN_FRACTION)
+    winner = min(tied, key=lambda r: (r.peak_bytes, r.lane))
+    return Verdict(
+        winner=winner.lane, binding=BIND_VRAM_TIEBREAK,
+        detail=(
+            f"{[r.lane for r in tied]!r} within {MARGIN_FRACTION * 100:.0f}% "
+            f"({best.ms_per_step:.1f}-{rival.ms_per_step:.1f} ms/step); "
+            f"smaller peak wins ({winner.lane}, {winner.peak_bytes} B)"),
+        **common)
+
+
+def sole(lane: str, detail: str) -> Verdict:
+    """The verdict for a card that can only build ONE lane. No benchmark is
+    run: with nothing to compare against, a measurement would buy a compile
+    and decide nothing. The cell still records a real, typed verdict rather
+    than the absence a serving worker has to guess about."""
+    total, name, sm = device_facts()
+    return Verdict(
+        winner=lane, binding=BIND_SOLE_CANDIDATE, detail=detail,
+        device_total_bytes=total, device_name=name, sm=sm,
+        measured_at=time.time())
+
+
+# --- measurement ------------------------------------------------------------
+
+
+def device_facts() -> Tuple[int, str, str]:
+    """``(total_bytes, name, sm)`` for the card this process is on, honestly
+    detected (an H100-80GB reports 79.19 GiB — declare that, not the
+    marketing number). ``(0, "", "")`` off-GPU."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return 0, "", ""
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        major, minor = torch.cuda.get_device_capability()
+        return int(props.total_memory), str(props.name), f"sm_{major}{minor}"
+    except Exception:  # noqa: BLE001 — a probe never changes an outcome
+        return 0, "", ""
+
+
+def measure(lane: str, step: Callable[[], Any]) -> Measurement:
+    """Time one candidate's representative step and record its device peak.
+
+    ``step`` must run ONE forward of the graph in its production posture
+    (compiled), already built. Fixed warmup + median over ``BENCH_ITERS``
+    CUDA-event timings — the same protocol `_gemm_profitable` uses, so two
+    mints on one card measure the same thing.
+    """
+    import torch
+
+    try:
+        for _ in range(BENCH_WARMUP):
+            step()
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        samples = []
+        for _ in range(BENCH_ITERS):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            step()
+            end.record()
+            torch.cuda.synchronize()
+            samples.append(round(float(start.elapsed_time(end)), 3))
+        peak = int(torch.cuda.max_memory_allocated())
+    except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
+        # measured drops out of the ranking; it never fails the mint.
+        return Measurement(
+            lane=lane, unavailable=f"{type(exc).__name__}: {exc}")
+    ordered = sorted(samples)
+    return Measurement(
+        lane=lane, ms_per_step=ordered[len(ordered) // 2], peak_bytes=peak,
+        samples_ms=tuple(samples))
+
+
+def probe(
+    candidates: Sequence[str],
+    build: Callable[[str], Callable[[], Any]],
+    *,
+    device_total_bytes: int = 0,
+    device_name: str = "",
+    sm: str = "",
+) -> Verdict:
+    """Build, measure and rank every candidate lane on THIS card.
+
+    ``build(lane)`` returns a zero-argument callable that runs one
+    representative step with that lane armed — the mint's job, because only
+    the loader can swap the linears. A builder that raises drops its
+    candidate with the reason recorded; it never fails the mint.
+    """
+    if not device_total_bytes and not device_name and not sm:
+        device_total_bytes, device_name, sm = device_facts()
+    rows = []
+    for lane in candidates:
+        t0 = time.monotonic()
+        try:
+            step = build(lane)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kernel-lane probe: %s could not be built — %s",
+                           lane, exc)
+            rows.append(Measurement(
+                lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}"))
+            continue
+        row = measure(lane, step)
+        rows.append(row)
+        logger.info(
+            "kernel-lane probe: %s -> %s (%.1f s to build+measure)",
+            lane,
+            (f"{row.ms_per_step:.1f} ms/step, {row.peak_bytes / 1e9:.1f} GB "
+             f"peak" if row.usable else f"UNAVAILABLE {row.unavailable}"),
+            time.monotonic() - t0)
+    verdict = select(
+        rows, device_total_bytes=device_total_bytes,
+        device_name=device_name, sm=sm)
+    logger.info("kernel-lane verdict: %s (%s) — %s",
+                verdict.winner, verdict.binding, verdict.detail)
+    return verdict
+
+
+def fused_candidate_gap(sm: int) -> str:
+    """Why the fused lane is not even a CANDIDATE here, or ''.
+
+    Capability only — silicon plus the numerics self-check. Whether it is
+    the faster lane on a qualifying card is what :func:`probe` measures, and
+    is deliberately NOT asked here.
+    """
+    if sm < FUSED_MIN_SM:
+        return (f"fused svdq kernels need Blackwell block-scaled MMA "
+                f"(sm_{FUSED_MIN_SM}+); this GPU is sm_{sm}")
+    try:
+        from .models.svdq_fused import fused_self_check
+    except Exception as exc:  # noqa: BLE001
+        return f"fused kernels are not importable: {exc}"
+    try:
+        return str(fused_self_check() or "")
+    except Exception as exc:  # noqa: BLE001
+        return f"fused self-check raised: {type(exc).__name__}: {exc}"
+
+
+def candidates_here() -> Tuple[str, ...]:
+    """The lanes that can be BUILT on this card, cheapest-first. Always
+    includes the baseline: it exists everywhere."""
+    lanes = [LANE_BASELINE]
+    total, _name, sm_text = device_facts()
+    if not total:
+        return tuple(lanes)
+    try:
+        sm = int(str(sm_text or "sm_0").removeprefix("sm_"))
+    except ValueError:
+        return tuple(lanes)
+    gap = fused_candidate_gap(sm)
+    if gap:
+        logger.info("kernel-lane: fused is not a candidate here — %s", gap)
+    else:
+        lanes.append(LANE_FUSED)
+    return tuple(lanes)
+
+
+# --- recording and reading --------------------------------------------------
+
+
+def envelope_block(verdict: Verdict) -> Dict[str, Any]:
+    """The DISCRETE verdict, for ``metadata.json`` inside the packed cell.
+
+    Deliberately carries no wall clocks and no measured numbers: the #699
+    double-mint byte-compare requires the artifact to be reproducible, and
+    milliseconds are not. What a serving worker needs is the winner; what an
+    auditor needs is :func:`evidence_block`, which rides the published
+    checkpoint metadata beside ``mint_phases``.
+    """
+    return {
+        "schema": int(verdict.schema),
+        "winner": str(verdict.winner),
+        "rule": str(verdict.rule),
+        "binding": str(verdict.binding),
+        "margin_fraction": float(verdict.margin_fraction),
+        "candidates": sorted(r.lane for r in verdict.measurements),
+    }
+
+
+def evidence_block(verdict: Verdict) -> Dict[str, Any]:
+    """Every number behind the verdict — published with the checkpoint, never
+    packed. This is what makes a verdict auditable and a flip explicable."""
+    return {
+        "schema": int(verdict.schema),
+        "winner": str(verdict.winner),
+        "rule": str(verdict.rule),
+        "binding": str(verdict.binding),
+        "detail": str(verdict.detail),
+        "margin_fraction": float(verdict.margin_fraction),
+        "activation_spike_fraction": float(verdict.activation_spike_fraction),
+        "fragmentation_headroom_bytes":
+            int(verdict.fragmentation_headroom_bytes),
+        "device_total_bytes": int(verdict.device_total_bytes),
+        "device_name": str(verdict.device_name),
+        "sm": str(verdict.sm),
+        "warmup": int(verdict.warmup),
+        "iters": int(verdict.iters),
+        "measured_at": float(verdict.measured_at),
+        "candidates": [
+            {
+                "lane": r.lane,
+                "ms_per_step": float(r.ms_per_step),
+                "peak_bytes": int(r.peak_bytes),
+                "required_bytes": int(r.required_bytes()),
+                "fits": fits(r, verdict.device_total_bytes),
+                "samples_ms": list(r.samples_ms),
+                "unavailable": r.unavailable,
+            }
+            for r in verdict.measurements
+        ],
+    }
+
+
+def verdict_from_evidence(block: Mapping[str, Any]) -> Verdict:
+    """Rebuild a :class:`Verdict` from :func:`evidence_block` — the audit
+    round-trip, and how a recorded campaign is replayed against the rule."""
+    rows = tuple(
+        Measurement(
+            lane=str(c.get("lane") or ""),
+            ms_per_step=float(c.get("ms_per_step") or 0.0),
+            peak_bytes=int(c.get("peak_bytes") or 0),
+            samples_ms=tuple(float(s) for s in (c.get("samples_ms") or ())),
+            unavailable=str(c.get("unavailable") or ""),
+        )
+        for c in (block.get("candidates") or ())
+    )
+    return Verdict(
+        winner=str(block.get("winner") or DEFAULT_LANE),
+        binding=str(block.get("binding") or ""),
+        rule=str(block.get("rule") or "fit_constrained_speed"),
+        schema=int(block.get("schema") or SCHEMA),
+        margin_fraction=float(block.get("margin_fraction") or MARGIN_FRACTION),
+        activation_spike_fraction=float(
+            block.get("activation_spike_fraction")
+            or ACTIVATION_SPIKE_FRACTION),
+        fragmentation_headroom_bytes=int(
+            block.get("fragmentation_headroom_bytes")
+            or FRAGMENTATION_HEADROOM_BYTES),
+        device_total_bytes=int(block.get("device_total_bytes") or 0),
+        device_name=str(block.get("device_name") or ""),
+        sm=str(block.get("sm") or ""),
+        warmup=int(block.get("warmup") or BENCH_WARMUP),
+        iters=int(block.get("iters") or BENCH_ITERS),
+        measured_at=float(block.get("measured_at") or 0.0),
+        measurements=rows,
+        detail=str(block.get("detail") or ""),
+    )
+
+
+def lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
+    """``(lane, reason)`` a cell's envelope states.
+
+    A cell minted before this mechanism records nothing — that is the
+    DECLARED default with a typed reason, never a silent fall-through. An
+    unreadable or unknown verdict is the same: conservative, and it says so.
+    """
+    block = meta.get(META_KEY) if isinstance(meta, Mapping) else None
+    if block is None:
+        return DEFAULT_LANE, (
+            f"{REASON_ABSENT}: cell records no kernel-lane verdict "
+            f"(pre-pgw#946 cell); serving the declared default "
+            f"{DEFAULT_LANE!r}")
+    if not isinstance(block, Mapping):
+        return DEFAULT_LANE, (
+            f"{REASON_UNREADABLE}: cell's {META_KEY!r} is "
+            f"{type(block).__name__}, not a block; serving {DEFAULT_LANE!r}")
+    winner = str(block.get("winner") or "")
+    if winner not in LANES:
+        return DEFAULT_LANE, (
+            f"{REASON_UNKNOWN_LANE}: cell names lane {winner!r}, which this "
+            f"worker does not implement ({list(LANES)!r}); serving "
+            f"{DEFAULT_LANE!r}")
+    return winner, (
+        f"{REASON_ADOPTED}: cell verdict {winner!r} "
+        f"(binding={block.get('binding') or '?'}, "
+        f"rule={block.get('rule') or '?'})")
+
+
+# --- the process pin --------------------------------------------------------
+
+_PIN: Optional[str] = None
+_PIN_REASON: str = ""
+
+
+def pin(lane: str, reason: str) -> None:
+    """Pin the lane THIS process loads on, with the reason it is pinned.
+
+    Set by the mint (once per candidate while probing, then to the winner)
+    and by the executor from the delivered cell before ``setup()`` runs —
+    the swap happens at model load, so the pin must precede it.
+    """
+    global _PIN, _PIN_REASON
+
+    if lane not in LANES:
+        raise LaneProbeError(f"unknown kernel lane {lane!r} (have {LANES!r})")
+    _PIN, _PIN_REASON = lane, str(reason or "")
+    logger.info("kernel-lane: pinned %s — %s", lane, _PIN_REASON)
+
+
+def pinned() -> Tuple[Optional[str], str]:
+    """``(lane, reason)`` or ``(None, "")`` when nothing has pinned one."""
+    return _PIN, _PIN_REASON
+
+
+def clear() -> None:
+    """Forget the pin (mint between candidates; tests)."""
+    global _PIN, _PIN_REASON
+
+    _PIN, _PIN_REASON = None, ""
+
+
+def adopt(meta: Optional[Mapping[str, Any]], *, source: str = "") -> str:
+    """Adopt the lane a delivered cell's metadata states, and return it.
+
+    ``None`` (no cell for this boot) is the declared default with its own
+    typed reason — an eager or self-minting boot has no verdict yet and must
+    say so rather than guessing that a hand-written tuple was right.
+    """
+    if meta is None:
+        lane, reason = DEFAULT_LANE, (
+            f"{REASON_NO_CELL}: no compiled cell delivered for this load; "
+            f"serving the declared default {DEFAULT_LANE!r}")
+    else:
+        lane, reason = lane_from_metadata(meta)
+    if source:
+        reason = f"{reason} [{source}]"
+    pin(lane, reason)
+    return lane
+
+
+def adopt_from_artifact(artifact: Any, *, source: str = "") -> str:
+    """Adopt the verdict recorded in a packed cell on disk.
+
+    Reads ``metadata.json`` out of the tar without unpacking it (both the
+    exported and the inductor-cache artifact kinds put it at the root). Any
+    read failure is the conservative default WITH the failure named — a
+    serving worker must never guess a lane.
+    """
+    if artifact is None:
+        return adopt(None, source=source)
+    try:
+        import json
+        import tarfile
+
+        with tarfile.open(str(artifact), "r:*") as tar:
+            for member in tar:
+                if member.name == "metadata.json" and member.isfile():
+                    fh = tar.extractfile(member)
+                    if fh is None:
+                        break
+                    meta = json.loads(fh.read().decode())
+                    return adopt(meta, source=source or str(artifact))
+        raise LaneProbeError("artifact has no metadata.json")
+    except Exception as exc:  # noqa: BLE001 — never fails a load
+        pin(DEFAULT_LANE, (
+            f"{REASON_UNREADABLE}: cannot read the verdict from "
+            f"{artifact} ({type(exc).__name__}: {exc}); serving "
+            f"{DEFAULT_LANE!r}"
+            + (f" [{source}]" if source else "")))
+        return DEFAULT_LANE
+
+
+__all__ = [
+    "ACTIVATION_SPIKE_FRACTION",
+    "BENCH_ITERS",
+    "BENCH_WARMUP",
+    "BIND_FIT",
+    "BIND_NO_FIT",
+    "BIND_SOLE_CANDIDATE",
+    "BIND_SPEED",
+    "BIND_VRAM_TIEBREAK",
+    "DEFAULT_LANE",
+    "EVIDENCE_KEY",
+    "FRAGMENTATION_HEADROOM_BYTES",
+    "FUSED_MIN_SM",
+    "LANES",
+    "LANE_BASELINE",
+    "LANE_FUSED",
+    "MARGIN_FRACTION",
+    "META_KEY",
+    "REASON_ABSENT",
+    "REASON_ADOPTED",
+    "REASON_NO_CELL",
+    "REASON_UNKNOWN_LANE",
+    "REASON_UNREADABLE",
+    "SCHEMA",
+    "LaneProbeError",
+    "Measurement",
+    "Verdict",
+    "adopt",
+    "adopt_from_artifact",
+    "candidates_here",
+    "clear",
+    "device_facts",
+    "envelope_block",
+    "evidence_block",
+    "fits",
+    "fused_candidate_gap",
+    "lane_from_metadata",
+    "measure",
+    "pin",
+    "pinned",
+    "probe",
+    "select",
+    "sole",
+    "verdict_from_evidence",
+]

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -372,9 +372,122 @@ def _drain_router(pipe: Any, *, poll_s: float = 0.5) -> None:
         time.sleep(poll_s)
 
 
+def _release() -> None:
+    """Reclaim a probe pipeline's device memory. The caller has already
+    dropped its references; this collects the cycles and returns the cached
+    blocks so the next candidate loads onto an empty card."""
+    import gc
+
+    gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+    except Exception:  # noqa: BLE001 — best effort
+        logger.debug("mint-child: empty_cache failed", exc_info=True)
+
+
+def _measure_lane(lane: str, load: Any) -> Any:
+    """Load, build and time ONE candidate lane.
+
+    Its own frame on purpose: the probe pipeline and its compiled step must
+    be unreachable the moment this returns, or the next candidate loads onto
+    a card the previous one is still resident on.
+    """
+    from . import aot_mint, kernel_lane
+
+    kernel_lane.pin(lane, "mint-time A/B probe (pgw#946)")
+    try:
+        pipe, spec = load(lane)
+        return kernel_lane.measure(lane, aot_mint.bench_step(pipe, spec))
+    except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
+        # built or measured drops out of the ranking; it never fails the
+        # mint, and the reason is recorded with the verdict.
+        logger.warning("mint-child: kernel-lane %s not buildable — %s",
+                       lane, exc)
+        return kernel_lane.Measurement(
+            lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}")
+
+
+def lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
+    """MEASURE which serving-kernel lane wins on THIS card (pgw#946).
+
+    Returns ``(verdict, pipeline, spec)`` — the winning lane's loaded
+    pipeline and its export spec, ready to mint, so the artifact and the
+    verdict inside it can never describe different code.
+
+    The A/B has to happen HERE and not inside ``aot_mint``: the lane is
+    chosen when the checkpoint's linears are swapped, which is model LOAD, so
+    comparing two lanes means loading twice. ``load(lane)`` does one full
+    endpoint load with that lane pinned and hands back
+    ``(pipeline, export_spec)``.
+
+    Replaces the hand-maintained SM tuple this used to be. Whether the fused
+    kernels EXIST on a card is still a capability question
+    (``kernel_lane.candidates_here``); whether they are FASTER there is now
+    measured on the card instead of edited into a tuple after a $12 campaign.
+
+    Never fails a mint: any gap leaves the default lane pinned, records no
+    verdict, and says why — a cell with no verdict is the documented
+    conservative-default case on the serving side.
+    """
+    from . import kernel_lane
+
+    candidates = kernel_lane.candidates_here()
+    if len(candidates) < 2:
+        gap = kernel_lane.fused_candidate_gap(_current_sm())
+        verdict = kernel_lane.sole(
+            candidates[0] if candidates else kernel_lane.DEFAULT_LANE,
+            f"only one lane is buildable on this card — {gap or 'no rival'}")
+        kernel_lane.pin(verdict.winner, f"sole candidate: {verdict.detail}")
+        frame(phase="load", note=f"kernel lane {verdict.winner} (sole)")
+        pipe, spec = load(verdict.winner)
+        return verdict, pipe, spec
+
+    measurements = []
+    for index, lane in enumerate(candidates, start=1):
+        frame(phase="load", step=index, total=len(candidates),
+              note=f"kernel-lane probe: {lane}")
+        measurements.append(_measure_lane(lane, load))
+        # Each candidate is loaded onto an EMPTY card and torn down before the
+        # next one: two resident pipelines would make the probe itself the
+        # thing that OOMs a mint pod sized for one, and the peak this measures
+        # has to be one lane's peak, not two lanes' sum. The probe pipeline
+        # dies with `_measure_lane`'s frame; this reclaims it.
+        _release()
+
+    total, name, sm = kernel_lane.device_facts()
+    verdict = kernel_lane.select(
+        measurements, device_total_bytes=total, device_name=name, sm=sm)
+    frame(phase="load",
+          note=f"kernel lane {verdict.winner} ({verdict.binding})")
+    kernel_lane.pin(verdict.winner, f"mint verdict: {verdict.detail}")
+    # The winner is loaded FRESH rather than kept from its probe pass: the
+    # probe ran `torch.compile` over the denoiser, and the graph that gets
+    # exported must come from a pipeline nothing has warmed or specialized.
+    pipe, spec = load(verdict.winner)
+    return verdict, pipe, spec
+
+
+def _current_sm() -> int:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return 0
+        major, minor = torch.cuda.get_device_capability()
+        return major * 10 + minor
+    except Exception:  # noqa: BLE001
+        return 0
+
+
 def _mint_aot(
     request: MintRequest, pipe: Any, cfg: Any, target: Path, *,
     started: float, sha256_file: Any,
+    lane_verdict: Any = None,
+    spec: Any = None,
 ) -> MintReport:
     """pgw#805: the AOT recipe — torch.export + AOTInductor over the family's
     whole declared graph-class set, packed as ONE multi-graph cell (pgw#758).
@@ -401,7 +514,8 @@ def _mint_aot(
     aot_resume.set_root(request.resume)
 
     frame(phase="trace_graph", note=f"export declaration for {cfg.family!r}")
-    spec = fleet_cells.aot_export_spec(pipe, cfg)
+    if spec is None:
+        spec = fleet_cells.aot_export_spec(pipe, cfg)
     out_dir = target.parent / "aot"
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -432,7 +546,11 @@ def _mint_aot(
             # KILLED in still leaves its measurements on disk for the parent.
             phase_snapshot=(
                 Path(request.phases_snapshot)
-                if request.phases_snapshot else None))
+                if request.phases_snapshot else None),
+            # pgw#946: the MEASURED serving-kernel lane for this card. The
+            # discrete verdict lands in the packed envelope (serving reads it
+            # instead of an SM tuple); the numbers ride the result metadata.
+            lane_verdict=lane_verdict)
     except aot_mint.MintRefused as exc:
         # A named export refusal is a REFUSAL, not a crash: the parent must
         # not retry it, and the sentence is the whole diagnostic on a pod
@@ -518,6 +636,38 @@ def mint(request: MintRequest) -> MintReport:
         f"setup {spec.cls.__name__}"
         + (f" (+{sum(len(c) for c in overrides.values())} component "
            f"override(s))" if overrides else "")))
+
+    def _load(_lane: str) -> Tuple[Any, Any]:
+        """One full endpoint load on the currently pinned kernel lane, plus
+        the export spec of the pipeline it produced."""
+        from . import fleet_cells
+
+        obj = spec.cls()
+        got = run_setup(
+            obj, dict(request.snapshots), arm_compile=False,
+            return_loaded=True, component_paths=overrides) or {}
+        _slot, loaded_pipe = _pick_compile_target(got, cfg)
+        frame(phase="load", note=f"compile target on slot {_slot!r}")
+        if cfg.lora_bucket:
+            cc.apply_lora_lane(loaded_pipe, cfg.lora_bucket)
+        return loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
+
+    if request.recipe == RECIPE_AOT:
+        # pgw#946: MEASURE the serving-kernel lane on this card before the
+        # cell is exported, so the cell can carry the verdict instead of the
+        # fleet re-deriving it from a hand-maintained SM tuple. The probe
+        # loads once per candidate; the winner's pipeline is what gets minted.
+        verdict, pipe, aot_spec = lane_verdict_for(_load)
+        # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
+        # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
+        # model ref for an operator's mint pod): the graphs this cell must
+        # serve are the graphs the ENDPOINT's own composed pipeline runs, and
+        # composing a second time is how a mint exports something the serving
+        # pod cannot adopt.
+        return _mint_aot(
+            request, pipe, cfg, target, started=started,
+            sha256_file=sha256_file, lane_verdict=verdict, spec=aot_spec)
+
     instance = spec.cls()
     loaded = run_setup(
         instance, dict(request.snapshots), arm_compile=False,
@@ -527,17 +677,6 @@ def mint(request: MintRequest) -> MintReport:
 
     if cfg.lora_bucket:
         cc.apply_lora_lane(pipe, cfg.lora_bucket)
-
-    if request.recipe == RECIPE_AOT:
-        # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
-        # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
-        # model ref for an operator's mint pod): the graphs this cell must
-        # serve are the graphs the ENDPOINT's own composed pipeline runs, and
-        # composing a second time is how a mint exports something the serving
-        # pod cannot adopt.
-        return _mint_aot(
-            request, pipe, cfg, target, started=started,
-            sha256_file=sha256_file)
 
     jobs = _warm_jobs(siblings)
     # Arm COLD, pointed at our own capture dir: the warm forwards below are

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -1,16 +1,33 @@
-"""Native-kernel dispatch + capability probe (pgw#860).
+"""Native-kernel dispatch (pgw#860, pgw#946).
 
 One decision, made once per process at LOAD time: does the svdq serving path
 run the FUSED native lane (pgw#862 triton kernels today; `_cozy_kernels` C++
-ops if/when a lane needs them) or the baseline unfused lane. The decision is
-typed, logged, and never silent-wrong:
+ops if/when a lane needs them) or the baseline unfused lane.
+
+**The decision is not made here and is not derived from the SM (pgw#946).**
+Which lane is faster is a per-card FACT — a custom op is opaque to inductor,
+so our fusion beats inductor's own on sm_120 and loses to it on sm_100 — and
+it used to live in a hand-maintained SM tuple informed by ~$12 benchmark
+campaigns per card. It is now MEASURED at mint on the card the cell is being
+minted for, recorded into the cell, and read back here: see
+``gen_worker.kernel_lane``. This module's whole job is to apply the pin,
+prove the kernels still self-check, and say loudly what it did.
+
+Order of decision, each step typed and never silent-wrong:
 
 - env kill-switch first: ``GEN_WORKER_NATIVE_KERNELS=0`` forces baseline.
-  Rollout is env-GATED (Paul, pgw#859 G0): unset means OFF; ``=1`` opts in.
-- capability probe: CUDA device + a supported SM + the fused kernels compile
-  AND pass the numerics self-check (activation-quant BIT-IDENTITY vs the
-  pgw#685 reference chain + GEMM tolerance) — any gap degrades to baseline
-  with the reason logged, same artifact, no refusal.
+  Rollout is still env-GATED (pgw#859 G0: unset means OFF, ``=1`` opts in)
+  because flipping that gate belongs to pgw#865, not to this mechanism. The
+  env is on th#1445's elimination list and MUST NOT grow new meanings — it
+  gates the ROLLOUT, it never picks a lane.
+- the recorded verdict: ``kernel_lane.pinned()``, set by the executor from
+  the delivered cell before ``setup()`` runs. No pin (eager boot, pre-pgw#946
+  cell, unreadable envelope) => the declared conservative default with the
+  typed reason that says which of those it was.
+- numerics self-check: a verdict of ``fused`` still has to pass the
+  activation-quant BIT-IDENTITY check (vs the pgw#685 reference chain) and
+  the awq-packed check on THIS box. A gap degrades to baseline with the
+  reason logged — same artifact, no refusal.
 - contract mismatches inside an armed lane raise typed errors; they are bugs,
   not degrade paths.
 
@@ -25,15 +42,12 @@ import logging
 import os
 from typing import Any, Optional
 
+from .. import kernel_lane
+
 logger = logging.getLogger(__name__)
 
 NATIVE_ENV = "GEN_WORKER_NATIVE_KERNELS"
 NATIVE_LIB_ENV = "GEN_WORKER_NATIVE_KERNELS_LIB"
-
-# dot_scaled lowers to native block-scaled MMA on Blackwell (PTX census banked
-# in pgw#862: sm_120a => kind::mxf4nvf4, sm_100a => tcgen05). 103/121 are
-# family variants triton targets per-device; the self-check still gates them.
-FUSED_SMS = (100, 103, 120, 121)
 
 _EXT_DEFAULT = "/opt/cozy/native/libcozy_kernels.so"
 _EXT_NAMESPACE = "cozy_kernels"
@@ -53,20 +67,20 @@ def native_kernels_requested() -> Optional[bool]:
     return None
 
 
-def _probe_fused_lane() -> Optional[str]:
-    """Why the fused lane cannot arm HERE, or None when it can."""
+def _self_check_gap() -> Optional[str]:
+    """Why an ARMED fused verdict cannot execute on this box, or None.
+
+    Numerics only. The SM is not consulted: a cell that says ``fused`` was
+    minted on this compute capability (``sm`` is a cell-key axis), so a
+    capability question here would only ever re-derive what the verdict
+    already proved by running.
+    """
     try:
         import torch
     except ImportError:
         return "torch is not installed"
     if not torch.cuda.is_available():
         return "fused svdq lane requires a CUDA GPU"
-    major, minor = torch.cuda.get_device_capability()
-    sm = major * 10 + minor
-    if sm not in FUSED_SMS:
-        return (f"fused svdq lane needs Blackwell block-scaled MMA "
-                f"(sm_{'/'.join(str(s) for s in FUSED_SMS)}); this GPU is "
-                f"sm_{sm}")
     from .svdq_awq_packed import awq_packed_self_check
     from .svdq_fused import fused_self_check
 
@@ -81,31 +95,53 @@ def _probe_fused_lane() -> Optional[str]:
 
 def svdq_execution_lane() -> str:
     """``"fused"`` | ``"baseline"`` for this process. Call at LOAD time — the
-    first call compiles kernels and runs the self-check."""
+    first call runs the numerics self-check."""
     global _LANE, _LANE_REASON
 
     if _LANE is not None:
         return _LANE
+    baseline = kernel_lane.LANE_BASELINE
     requested = native_kernels_requested()
     if requested is False:
-        _LANE, _LANE_REASON = "baseline", f"{NATIVE_ENV}=0 (kill-switch)"
+        _LANE, _LANE_REASON = baseline, f"{NATIVE_ENV}=0 (kill-switch)"
         logger.info("native kernels: baseline lane (%s)", _LANE_REASON)
         return _LANE
     if requested is None:
-        _LANE, _LANE_REASON = "baseline", (
-            f"dormant — rollout is env-gated, set {NATIVE_ENV}=1 to opt in")
+        _LANE, _LANE_REASON = baseline, (
+            f"dormant — rollout is env-gated (pgw#859 G0 / pgw#865), set "
+            f"{NATIVE_ENV}=1 to opt in")
         logger.info("native kernels: baseline lane (%s)", _LANE_REASON)
         return _LANE
+
+    verdict_lane, verdict_reason = kernel_lane.pinned()
+    if verdict_lane is None:
+        # Nothing pinned a lane for this load: no cell was delivered, or the
+        # executor never reached the adoption hook. The DECLARED default, and
+        # it names itself.
+        _LANE, _LANE_REASON = kernel_lane.DEFAULT_LANE, (
+            f"{kernel_lane.REASON_ABSENT}: nothing recorded a measured "
+            f"kernel-lane verdict for this load; serving the declared "
+            f"default {kernel_lane.DEFAULT_LANE!r}")
+        logger.warning("native kernels: %s", _LANE_REASON)
+        return _LANE
+    if verdict_lane == baseline:
+        _LANE, _LANE_REASON = baseline, verdict_reason
+        logger.info("native kernels: baseline lane (%s)", _LANE_REASON)
+        return _LANE
+
     try:
-        reason = _probe_fused_lane()
+        gap = _self_check_gap()
     except Exception as exc:  # noqa: BLE001 — any probe gap => baseline
-        reason = f"probe raised: {exc}"
-    if reason is not None:
-        _LANE, _LANE_REASON = "baseline", reason
-        logger.warning("native kernels: requested but NOT armed — %s; "
-                       "baseline lane serves the same artifact", reason)
+        gap = f"self-check raised: {exc}"
+    if gap is not None:
+        _LANE, _LANE_REASON = baseline, (
+            f"verdict said {verdict_lane!r} but the kernels do not "
+            f"self-check here — {gap}")
+        logger.warning("native kernels: NOT armed — %s; baseline lane serves "
+                       "the same artifact", _LANE_REASON)
     else:
-        _LANE, _LANE_REASON = "fused", "probe + numerics self-check passed"
+        _LANE, _LANE_REASON = kernel_lane.LANE_FUSED, (
+            f"{verdict_reason}; numerics self-check passed")
         logger.info("native kernels: FUSED lane armed (%s)", _LANE_REASON)
     return _LANE
 
@@ -194,7 +230,6 @@ def extension_available() -> bool:
 
 
 __all__ = [
-    "FUSED_SMS",
     "NATIVE_ENV",
     "NATIVE_LIB_ENV",
     "extension_available",

--- a/tests/test_kernel_lane_pgw946.py
+++ b/tests/test_kernel_lane_pgw946.py
@@ -1,0 +1,420 @@
+"""pgw#946 — the mint MEASURES which serving-kernel lane wins on the target
+card, records the verdict into the cell, and serving adopts it.
+
+Integration-style over mocks: the tests drive the REAL selection rule, the
+REAL envelope/evidence round-trip, and the REAL adoption path (a packed tar
+on disk, read by the code the executor calls). The only thing stubbed is the
+pair of lanes themselves — a benchmark needs a GPU and two compiled graphs,
+and what has to be proven here is the DECISION, not that torch can time a
+kernel.
+
+The decisive check is the last one: the mechanism, handed the recorded
+pgw#862/#863 numbers, independently reproduces the two answers we already
+know are right — fused on the 5090, baseline on the B200.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from gen_worker import kernel_lane as kl
+
+GB = 1000 ** 3  # the benchmark tables are in decimal GB
+GiB = 1 << 30
+
+
+def _m(lane: str, ms: float, peak_gb: float) -> kl.Measurement:
+    return kl.Measurement(
+        lane=lane, ms_per_step=ms, peak_bytes=int(peak_gb * GB),
+        samples_ms=(ms,))
+
+
+@pytest.fixture(autouse=True)
+def _clear_pin():
+    kl.clear()
+    yield
+    kl.clear()
+
+
+# --- the rule --------------------------------------------------------------
+
+
+def test_fastest_that_fits_wins_even_when_it_is_the_larger_lane() -> None:
+    """(a) Speed is the objective. B200 shape: the baseline lane is 9.5 GB
+    BIGGER and 35% faster, and the card has the room — so it wins."""
+    verdict = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=180 * GB, sm="sm_100")
+    assert verdict.winner == "baseline"
+    assert verdict.binding == kl.BIND_SPEED
+    assert "228.0" in verdict.detail and "350.0" in verdict.detail
+
+
+def test_a_lane_that_does_not_fit_is_excluded_even_when_faster() -> None:
+    """(b) Fit is a CONSTRAINT applied before ranking. Same two lanes, on a
+    48 GB card: the baseline's 44.1 GB peak plus its allowance cannot fit, so
+    the 35%-slower fused lane wins outright."""
+    verdict = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=48 * GB, sm="sm_100")
+    assert verdict.winner == "fused"
+    assert verdict.binding == kl.BIND_FIT
+    assert "baseline" in verdict.detail
+
+
+def test_headroom_allowance_excludes_a_lane_that_bare_peak_would_admit() -> None:
+    """The allowance does real work: a 40 GB peak fits a 44 GB card by bare
+    measurement and does NOT fit once the activation-spike + fragmentation
+    allowance is applied — which is the point of stating one."""
+    row = _m("baseline", 100.0, 40.0)
+    assert row.peak_bytes < 44 * GB
+    assert not kl.fits(row, 44 * GB)
+    assert row.required_bytes() == int(40 * GB * 1.20) + GiB
+
+
+def test_within_margin_ties_fall_to_the_smaller_lane() -> None:
+    """(c) VRAM breaks a tie and ONLY a tie. 2% apart is noise, so the
+    smaller peak wins; 6% apart is a real win, so speed does."""
+    tie = kl.select(
+        [_m("baseline", 300.0, 44.0), _m("fused", 306.0, 35.0)],
+        device_total_bytes=180 * GB)
+    assert tie.winner == "fused"
+    assert tie.binding == kl.BIND_VRAM_TIEBREAK
+
+    win = kl.select(
+        [_m("baseline", 300.0, 44.0), _m("fused", 319.0, 35.0)],
+        device_total_bytes=180 * GB)
+    assert win.winner == "baseline"
+    assert win.binding == kl.BIND_SPEED
+
+
+def test_margin_makes_the_verdict_deterministic_across_mints() -> None:
+    """Two mints on one card must not disagree. The measurement jitters; the
+    verdict may not, because a win under the margin is not a win."""
+    verdicts = {
+        kl.select([_m("baseline", 300.0 + jitter, 44.0),
+                   _m("fused", 297.0 - jitter, 35.0)],
+                  device_total_bytes=180 * GB).winner
+        for jitter in (-3.0, -1.0, 0.0, 1.0, 3.0)
+    }
+    assert verdicts == {"fused"}  # within margin every time => smaller peak
+
+
+def test_unmeasurable_candidate_drops_out_with_its_reason() -> None:
+    verdict = kl.select(
+        [_m("baseline", 400.0, 20.0),
+         kl.Measurement(lane="fused", unavailable="triton compile failed")],
+        device_total_bytes=180 * GB)
+    assert verdict.winner == "baseline"
+    assert verdict.binding == kl.BIND_SOLE_CANDIDATE
+    assert verdict.measurement("fused").unavailable == "triton compile failed"
+
+
+def test_nothing_fits_names_itself_and_takes_the_smallest() -> None:
+    verdict = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=24 * GB)
+    assert verdict.binding == kl.BIND_NO_FIT
+    assert verdict.winner == "fused"
+
+
+def test_nothing_measured_is_the_declared_default() -> None:
+    verdict = kl.select([], device_total_bytes=180 * GB)
+    assert verdict.winner == kl.DEFAULT_LANE
+    assert verdict.binding == kl.BIND_NO_FIT
+
+
+# --- the probe loop --------------------------------------------------------
+
+
+def test_probe_measures_every_candidate_and_a_build_failure_is_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The A/B harness end to end with a stubbed timer: both candidates are
+    built, one blows up, the survivor wins and the failure is recorded."""
+    timings = {"baseline": (250.0, 40 * GB), "fused": (300.0, 30 * GB)}
+
+    def _measure(lane: str, step):
+        step()
+        ms, peak = timings[lane]
+        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+                              samples_ms=(ms,))
+
+    monkeypatch.setattr(kl, "measure", _measure)
+    built = []
+
+    def _build(lane: str):
+        if lane == "broken":
+            raise RuntimeError("no kernels here")
+        built.append(lane)
+        return lambda: None
+
+    verdict = kl.probe(
+        ("baseline", "broken", "fused"), _build,
+        device_total_bytes=180 * GB, device_name="stub", sm="sm_100")
+    assert built == ["baseline", "fused"]
+    assert verdict.winner == "baseline"
+    assert "no kernels here" in verdict.measurement("broken").unavailable
+
+
+# --- recording -------------------------------------------------------------
+
+
+def test_envelope_is_discrete_and_evidence_round_trips() -> None:
+    """(e) The verdict rides the packed envelope; the NUMBERS ride the
+    published evidence block and come back out unchanged.
+
+    The split is not cosmetic: the #699 double-mint byte-compare forbids wall
+    clocks inside the artifact, so metadata.json carries only facts a second
+    mint would reproduce."""
+    verdict = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=180 * GB, device_name="NVIDIA B200", sm="sm_100")
+
+    envelope = kl.envelope_block(verdict)
+    assert envelope == {
+        "schema": kl.SCHEMA, "winner": "baseline",
+        "rule": "fit_constrained_speed", "binding": kl.BIND_SPEED,
+        "margin_fraction": kl.MARGIN_FRACTION,
+        "candidates": ["baseline", "fused"],
+    }
+    # No wall clocks, no measurements, JSON-clean.
+    flat = json.dumps(envelope)
+    assert "ms" not in flat and "measured_at" not in flat
+
+    evidence = json.loads(json.dumps(kl.evidence_block(verdict)))
+    back = kl.verdict_from_evidence(evidence)
+    assert back.winner == verdict.winner
+    assert back.binding == verdict.binding
+    assert back.device_name == "NVIDIA B200"
+    assert back.measurement("fused").ms_per_step == 350.0
+    assert back.measurement("baseline").peak_bytes == int(44.1 * GB)
+    # Re-running the RULE over the recorded evidence reproduces the verdict —
+    # which is what makes a recorded decision auditable rather than asserted.
+    assert kl.select(
+        back.measurements,
+        device_total_bytes=back.device_total_bytes).winner == verdict.winner
+
+
+# --- adoption --------------------------------------------------------------
+
+
+def _packed(tmp_path: Path, meta: dict) -> Path:
+    body = tmp_path / "metadata.json"
+    body.write_text(json.dumps(meta))
+    artifact = tmp_path / "cell.tar.gz"
+    with tarfile.open(artifact, "w:gz") as tar:
+        tar.add(body, arcname="metadata.json")
+    return artifact
+
+
+def test_serving_adopts_the_lane_the_cell_names(tmp_path: Path) -> None:
+    verdict = kl.select(
+        [_m("baseline", 1189.0, 22.4), _m("fused", 975.0, 15.6)],
+        device_total_bytes=32 * GB, sm="sm_120")
+    artifact = _packed(tmp_path, {
+        "kind": "aot-inductor",
+        kl.META_KEY: kl.envelope_block(verdict),
+    })
+    assert kl.adopt_from_artifact(artifact) == "fused"
+    lane, reason = kl.pinned()
+    assert lane == "fused"
+    assert kl.REASON_ADOPTED in reason
+
+
+def test_cell_without_a_verdict_is_the_default_with_a_typed_reason(
+    tmp_path: Path,
+) -> None:
+    """(d) A pre-pgw#946 cell records nothing. That is the declared default
+    and it SAYS which case it was — never a silent fall-through."""
+    artifact = _packed(tmp_path, {"kind": "aot-inductor"})
+    assert kl.adopt_from_artifact(artifact) == kl.DEFAULT_LANE
+    assert kl.REASON_ABSENT in kl.pinned()[1]
+
+
+def test_no_cell_at_all_is_the_default_with_its_own_reason() -> None:
+    assert kl.adopt(None) == kl.DEFAULT_LANE
+    assert kl.REASON_NO_CELL in kl.pinned()[1]
+
+
+def test_unreadable_artifact_degrades_and_names_the_failure(
+    tmp_path: Path,
+) -> None:
+    junk = tmp_path / "not-a-tar.tar.gz"
+    junk.write_bytes(b"definitely not a tarball")
+    assert kl.adopt_from_artifact(junk) == kl.DEFAULT_LANE
+    assert kl.REASON_UNREADABLE in kl.pinned()[1]
+
+
+def test_a_lane_this_worker_does_not_implement_is_refused_by_name() -> None:
+    lane, reason = kl.lane_from_metadata(
+        {kl.META_KEY: {"winner": "tcgen05-v2", "binding": "speed"}})
+    assert lane == kl.DEFAULT_LANE
+    assert kl.REASON_UNKNOWN_LANE in reason
+
+
+def test_pin_refuses_a_lane_outside_the_vocabulary() -> None:
+    with pytest.raises(kl.LaneProbeError):
+        kl.pin("made-up", "test")
+
+
+def test_verdict_survives_the_real_pack_unpack_round_trip(
+    tmp_path: Path,
+) -> None:
+    """(e) Through the ACTUAL artifact writer and reader the mint and the
+    worker use — not a hand-rolled tar."""
+    pytest.importorskip("torch")
+    from gen_worker import aot_serve
+
+    verdict = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=180 * GB, sm="sm_100")
+    content = tmp_path / "work"
+    content.mkdir()
+    (content / aot_serve.PACKAGE_NAME).write_bytes(b"stub")
+    artifact = aot_serve.pack(
+        content, tmp_path / "cell.tar.gz",
+        {"kind": "aot-inductor", kl.META_KEY: kl.envelope_block(verdict)})
+
+    meta = aot_serve.unpack_metadata(artifact)
+    assert meta[kl.META_KEY]["winner"] == "baseline"
+    assert kl.adopt_from_artifact(artifact) == "baseline"
+
+
+# --- the mint-side A/B -----------------------------------------------------
+
+
+def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mint driver end to end with two stubbed lanes of known timing:
+    each candidate is loaded onto an empty card and measured, the winner is
+    pinned, and the pipeline handed to the exporter is a FRESH load of the
+    winner — never a probe pipeline the benchmark already compiled."""
+    from gen_worker import aot_mint, mint_child
+
+    timings = {  # the recorded B200 pair
+        "baseline": (228.0, int(44.1 * GB)),
+        "fused": (350.0, int(35.1 * GB)),
+    }
+    loads: list[str] = []
+
+    def _load(lane: str):
+        loads.append(lane)
+        assert kl.pinned()[0] == lane, "the lane must be pinned BEFORE loading"
+        return f"pipe:{lane}", f"spec:{lane}"
+
+    monkeypatch.setattr(kl, "candidates_here", lambda: ("baseline", "fused"))
+    monkeypatch.setattr(
+        kl, "device_facts", lambda: (180 * GB, "NVIDIA B200", "sm_100"))
+    monkeypatch.setattr(aot_mint, "bench_step", lambda pipe, spec: (pipe, spec))
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(mint_child, "_release", lambda: None)
+
+    def _measure(lane: str, step):
+        assert step == (f"pipe:{lane}", f"spec:{lane}")
+        ms, peak = timings[lane]
+        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+                              samples_ms=(ms,))
+
+    monkeypatch.setattr(kl, "measure", _measure)
+
+    verdict, pipe, spec = mint_child.lane_verdict_for(_load)
+    assert verdict.winner == "baseline"
+    assert verdict.binding == kl.BIND_SPEED
+    assert loads == ["baseline", "fused", "baseline"]
+    assert (pipe, spec) == ("pipe:baseline", "spec:baseline")
+    assert kl.pinned()[0] == "baseline"
+    # Both lanes' numbers are in the record, not just the winner's.
+    assert verdict.measurement("fused").ms_per_step == 350.0
+    assert verdict.measurement("baseline").peak_bytes == int(44.1 * GB)
+
+
+def test_mint_records_a_typed_verdict_when_only_one_lane_can_be_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A card with no rival lane gets a real verdict, not an absence — and
+    pays for no benchmark, because there is nothing to compare."""
+    from gen_worker import mint_child
+
+    monkeypatch.setattr(kl, "candidates_here", lambda: ("baseline",))
+    monkeypatch.setattr(kl, "device_facts", lambda: (24 * GB, "L4", "sm_89"))
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(
+        kl, "measure",
+        lambda *a: pytest.fail("no benchmark for a sole candidate"))
+
+    verdict, pipe, _spec = mint_child.lane_verdict_for(
+        lambda lane: (f"pipe:{lane}", f"spec:{lane}"))
+    assert verdict.winner == "baseline"
+    assert verdict.binding == kl.BIND_SOLE_CANDIDATE
+    assert verdict.detail
+    assert pipe == "pipe:baseline"
+
+
+def test_a_lane_that_cannot_be_built_never_fails_the_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker import aot_mint, mint_child
+
+    def _load(lane: str):
+        if lane == "fused":
+            raise RuntimeError("triton kernels will not compile here")
+        return f"pipe:{lane}", f"spec:{lane}"
+
+    monkeypatch.setattr(kl, "candidates_here", lambda: ("baseline", "fused"))
+    monkeypatch.setattr(kl, "device_facts", lambda: (180 * GB, "B200", "sm_100"))
+    monkeypatch.setattr(aot_mint, "bench_step", lambda pipe, spec: lambda: None)
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(mint_child, "_release", lambda: None)
+    monkeypatch.setattr(
+        kl, "measure",
+        lambda lane, step: kl.Measurement(
+            lane=lane, ms_per_step=228.0, peak_bytes=int(44.1 * GB)))
+
+    verdict, pipe, _spec = mint_child.lane_verdict_for(_load)
+    assert verdict.winner == "baseline"
+    assert "will not compile here" in verdict.measurement("fused").unavailable
+    assert pipe == "pipe:baseline"
+
+
+# --- the replay ------------------------------------------------------------
+
+
+def test_replays_the_recorded_campaigns() -> None:
+    """THE acceptance: handed the numbers the two hand-run campaigns produced,
+    the rule independently reaches the two answers the tuple was hand-edited
+    to encode.
+
+    B200 (pgw#863 run b200-r3, normalized 1024^2/30, COMPILED posture):
+    baseline 228 ms @ 44.1 GB vs fused 350 ms @ 35.1 GB on a 180 GB card.
+    Speed wins; the 9.5 GB the fused lane saves buys nothing on that card.
+
+    5090 (pgw#862 final table, pod mus8neq4kk7b6k, EAGER posture — the only
+    posture where BOTH 5090 lanes were measured; the compiled baseline was
+    never run there, which is exactly the hole this mechanism closes):
+    baseline 1189 ms @ 22.4 GB vs fused 975 ms @ 15.6 GB on a 32 GB card.
+    Fused wins on speed, and it would still win if the baseline's 22.4 GB
+    peak were excluded on fit.
+    """
+    b200 = kl.select(
+        [_m("baseline", 228.0, 44.1), _m("fused", 350.0, 35.1)],
+        device_total_bytes=180 * GB, device_name="NVIDIA B200", sm="sm_100")
+    assert (b200.winner, b200.binding) == ("baseline", kl.BIND_SPEED)
+
+    rtx5090 = kl.select(
+        [_m("baseline", 1189.0, 22.4), _m("fused", 975.0, 15.6)],
+        device_total_bytes=32 * GB, device_name="NVIDIA RTX 5090", sm="sm_120")
+    assert (rtx5090.winner, rtx5090.binding) == ("fused", kl.BIND_SPEED)
+
+    # And the fit constraint is not decorative on a consumer card: put the
+    # same 5090 pair on a 24 GB card and the baseline lane is excluded before
+    # speed is ever consulted.
+    tight = kl.select(
+        [_m("baseline", 1189.0, 22.4), _m("fused", 975.0, 15.6)],
+        device_total_bytes=24 * GB, sm="sm_120")
+    assert (tight.winner, tight.binding) == ("fused", kl.BIND_FIT)

--- a/tests/test_native_kernels_pgw860.py
+++ b/tests/test_native_kernels_pgw860.py
@@ -8,6 +8,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+from gen_worker import kernel_lane  # noqa: E402
 from gen_worker.models import native_kernels as nk  # noqa: E402
 from gen_worker.models import svdq_fused  # noqa: E402
 from gen_worker.models import svdq_native as native  # noqa: E402
@@ -18,8 +19,10 @@ from gen_worker.models.svdq_layout import DecodedLinear  # noqa: E402
 @pytest.fixture(autouse=True)
 def _reset_arming(monkeypatch: pytest.MonkeyPatch):
     nk.reset_native_kernels_arming()
+    kernel_lane.clear()
     yield
     nk.reset_native_kernels_arming()
+    kernel_lane.clear()
 
 
 # --- env gating ------------------------------------------------------------
@@ -33,47 +36,81 @@ def test_unset_env_stays_baseline_dormant(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_kill_switch_forces_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "0")
-    # Even a passing probe must not arm past the kill-switch.
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: None)
+    # Even a fused verdict + a passing self-check must not arm past the
+    # kill-switch.
+    kernel_lane.pin("fused", "test")
+    monkeypatch.setattr(nk, "_self_check_gap", lambda: None)
     assert nk.svdq_execution_lane() == "baseline"
     assert "kill-switch" in nk.svdq_lane_reason()
 
 
-def test_opt_in_with_passing_probe_arms(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: None)
-    assert nk.svdq_execution_lane() == "fused"
-
-
-def test_opt_in_with_failing_probe_degrades_with_reason(
+def test_fused_verdict_with_passing_self_check_arms(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", lambda: "no fp4 here")
+    kernel_lane.pin("fused", "cell verdict")
+    monkeypatch.setattr(nk, "_self_check_gap", lambda: None)
+    assert nk.svdq_execution_lane() == "fused"
+    assert "cell verdict" in nk.svdq_lane_reason()
+
+
+def test_fused_verdict_with_failing_self_check_degrades_with_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    kernel_lane.pin("fused", "cell verdict")
+    monkeypatch.setattr(nk, "_self_check_gap", lambda: "no fp4 here")
     assert nk.svdq_execution_lane() == "baseline"
-    assert nk.svdq_lane_reason() == "no fp4 here"
+    assert "no fp4 here" in nk.svdq_lane_reason()
 
 
-def test_opt_in_probe_raise_degrades_not_raises(
+def test_self_check_raise_degrades_not_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def boom() -> str:
         raise RuntimeError("driver exploded")
 
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_lane", boom)
+    kernel_lane.pin("fused", "cell verdict")
+    monkeypatch.setattr(nk, "_self_check_gap", boom)
     assert nk.svdq_execution_lane() == "baseline"
     assert "driver exploded" in nk.svdq_lane_reason()
 
 
-def test_real_probe_on_this_host_degrades_cleanly(
+def test_baseline_verdict_never_runs_the_self_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """On a box without Blackwell the REAL probe must return a reason, never
-    raise (on sm_100/120 CI runners this instead arms — also fine)."""
+    """A cell that says baseline is obeyed verbatim: no probe, no SM read."""
+    def boom() -> str:
+        raise AssertionError("the self-check must not run for a baseline "
+                             "verdict")
+
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    assert nk.svdq_execution_lane() in ("baseline", "fused")
-    assert nk.svdq_lane_reason()
+    kernel_lane.pin("baseline", "cell verdict: B200 measured 228 vs 350")
+    monkeypatch.setattr(nk, "_self_check_gap", boom)
+    assert nk.svdq_execution_lane() == "baseline"
+    assert "228 vs 350" in nk.svdq_lane_reason()
+
+
+def test_no_verdict_is_the_declared_default_and_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#946 (d): nothing pinned a lane => the conservative default, with a
+    TYPED reason. Never a silent fall-through to a hand-written tuple."""
+    monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    kernel_lane.clear()
+    assert nk.svdq_execution_lane() == kernel_lane.DEFAULT_LANE
+    assert kernel_lane.REASON_ABSENT in nk.svdq_lane_reason()
+
+
+def test_no_sm_allowlist_survives() -> None:
+    """pgw#946: the hand-maintained tuple is DELETED, not renamed. The only
+    SM fact left in the mechanism is the fused lane's capability floor, and it
+    lives in kernel_lane where the candidate enumeration is."""
+    assert not hasattr(nk, "FUSED_SMS")
+    assert not hasattr(nk, "FUSED_LINEAR_SMS")
+    assert not hasattr(nk, "PACKED_MODULATION_SMS")
+    assert kernel_lane.FUSED_MIN_SM == 100
 
 
 # --- extension probe -------------------------------------------------------


### PR DESCRIPTION
Closes the pgw#946 design of record. Which svdq lane is faster is a per-card fact — a custom op is opaque to inductor, so our fusion beats inductor's own chain on sm_120 and loses to it on sm_100 — and it lived in a hand-maintained SM tuple, one ~\$12 benchmark campaign and one human edit per new card class.

## The mechanism — `src/gen_worker/kernel_lane.py`

- `probe(candidates, build)` builds and times every candidate lane on the target card with a fixed warmup/median protocol. `w4a4._gemm_profitable`'s shape, one level up: whole compiled graphs instead of one GEMM, paid once at mint instead of every boot.
- `select()` implements **fit-constrained speed maximization** (Paul's ruling, 2026-08-03): among lanes whose measured peak plus a stated allowance (+20% for activation spikes / resolution variance, +1 GiB for fragmentation) fits the card, the **fastest** wins. VRAM is a constraint, not an objective; it breaks a tie only inside the 5% margin.
  - B200 takes the **baseline** lane (228 ms/step, 44.1 GB) over the fused lane (350 ms/step, 35.1 GB) — the card has the room.
  - A 24 GB card has the fit constraint exclude a lane outright, before speed is consulted.
- The 5% margin is the determinism gate: noise cannot flip a recorded winner between two mints on one card. Every number behind a verdict is kept as its evidence.

## Where the decision is recorded

| | carries | why |
|---|---|---|
| packed `metadata.json` → `kernel_lane` | winner, rule, binding term, margin, candidates | discrete only — the #699 double-mint byte-compare forbids wall clocks in the artifact |
| published checkpoint metadata → `kernel_lane_evidence` | both lanes' ms/step + peak bytes, samples, headroom terms, device | same channel as `mint_phases`; auditable long after the pod is gone |

The lane is deliberately **not** a cell-key axis — that would fork the namespace and halve reuse.

## Mint

`mint_child.lane_verdict_for` loads the endpoint once per candidate (the swap happens at model **load**, so comparing two lanes means loading twice), benchmarks the family's dominant declared graph class on its own declared example feed under `torch.compile` (`aot_mint.bench_step`), then loads the winner **fresh** so the exported graph comes from a pipeline nothing warmed or specialized. Each candidate gets an empty card. A candidate that cannot be built drops out with its reason recorded and never fails the mint.

## Serving

The executor reads the verdict off the delivered cell and pins it **before** `setup()` — the linears are swapped at model load, so a verdict read afterwards arrives one whole pipeline too late. No cell / pre-pgw#946 cell / unreadable envelope / unknown lane are four separate **typed** reasons on the declared conservative default (`baseline`), never a silent fall-through. A `fused` verdict still has to pass the numerics self-check on the box; a gap degrades with the reason logged, same artifact, no refusal.

## Deleted

`native_kernels.FUSED_SMS` and the per-boot capability probe that consumed it. The only SM fact left is `kernel_lane.FUSED_MIN_SM`, a **capability** floor used when enumerating candidates at mint — can the lane be built at all, not is it faster here. A test asserts the tuple names do not come back.

`GEN_WORKER_NATIVE_KERNELS` survives **only** as the pgw#859 G0 rollout gate and kill switch. Flipping it is pgw#865's call, not this mechanism's, so this PR does not touch its semantics. It is on th#1445's elimination list and must not grow new meanings — it gates the rollout, it never picks a lane.

> **Coordination note:** the `FUSED_LINEAR_SMS` / `PACKED_MODULATION_SMS` split lives on the unmerged `pgw863-sm100-b200` lane branch, not on `dev`. This PR deletes the allowlist as it exists on `dev` (`FUSED_SMS`). Whichever of the two lands second must resolve `native_kernels.py` toward the measured mechanism — the split's two independent decisions are exactly two candidate axes for `probe()`, not two more tuples.

## Tests

Integration-style over the real rule, the real envelope round-trip through `aot_serve.pack`/`unpack_metadata`, and the real mint driver (`tests/test_kernel_lane_pgw946.py`, 21 cases; `tests/test_native_kernels_pgw860.py` updated). Proven: fastest-that-fits wins; a lane that does not fit is excluded even when faster; within-margin ties fall to the smaller peak; a missing cell is the documented default with a typed signal; the evidence round-trips and re-running the rule over it reproduces the verdict; the mint probes every candidate and mints the winner fresh.

The decisive case, `test_replays_the_recorded_campaigns`: handed the recorded pgw#862/#863 numbers, the rule independently reaches both answers the tuple was hand-edited to encode — **fused on the 5090, baseline on the B200**.

## On-card validation: DEFERRED, and why

Not run. It needs a wheel built from this branch, a rebuilt endpoint image, and a mint pod on each of a B200 and a 5090 — the pgw#863 campaign's own shape (110 min / \$10.82 for the B200 leg). The rule itself is already validated against those campaigns' recorded numbers; what remains unproven on-card is narrower and specific: that `bench_step`'s single dominant-class forward under `torch.compile` ranks the two lanes the same way the full pgw#865 harness did. That is a question for the pgw#865 instrument on its next paid run, not a reason to hold this. Recorded as an open acceptance item on pgw#946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)