### PR TITLE
pgw#947: the mint MEASURES the serving-kernel lane; the SM allowlist is deleted

### DIFF
--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -83,3 +83,68 @@ Fix one of:
    unconditionally (ie#522). An endpoint
    with several self-loaded pipelines sharing weights (e.g. one class
    assembling `self.t2i`/`self.i2v`/`self.v2v`) calls it once per object.
+
+## The serving-kernel lane is MEASURED at mint, not gated by SM (pgw#863, pgw#947)
+
+The svdq path has two independent kernel choices:
+
+| axis | armed | degraded | what it buys |
+|---|---|---|---|
+| `linear` | `fused` | `baseline` | throughput (W4A4 matmuls) |
+| `modulation` | `packed` | `dense` | residency (W4A16 AdaLN, 22.8 → 13.3 GB on B200) |
+
+Which one is faster is a per-card fact — a custom op is opaque to inductor,
+so on sm_120 our fusion beats what inductor does with the open chain and on
+sm_100 it loses to it — and it used to be two hand-maintained SM tuples, one
+$12 benchmark campaign and one human edit per new card class. While they were
+*one* tuple, sm_100 had to give up either the 9.5 GB or 19% of its step time,
+because a single switch cannot say "baseline linears, packed modulation".
+
+A lane is therefore the **combination**, written `<linear>+<modulation>`
+(`baseline+packed`, `fused+dense`, …). It is measured on the card the cell is
+minted for and recorded in the cell (`gen_worker/kernel_lane.py`):
+
+- **Mint.** `mint_child.lane_verdict_for` loads the endpoint once per
+  candidate combination (the swap happens at model load, so comparing lanes
+  means loading once each), runs `aot_mint.bench_step` — one forward of the
+  family's dominant declared graph class, on its own declared example feed,
+  under `torch.compile` — and times it with a fixed warmup/median protocol.
+  The winner's pipeline is the one that gets exported. Candidates come from
+  `kernel_lane.candidate_axes`, which asks only capability questions
+  (Blackwell block-scaled MMA for the fused linear; triton plus a numerics
+  self-check for the packed modulation, which has no SM term at all). An axis
+  with one buildable value contributes no candidates, so a non-Blackwell card
+  has exactly one combination and pays for no benchmark.
+- **The rule: fit-constrained speed maximization.** Among lanes whose
+  measured peak plus a stated allowance (`+20%` for activation spikes and
+  resolution variance, `+1 GiB` for fragmentation) fits the card, the
+  FASTEST wins. VRAM is a constraint, not an objective; it breaks a tie only
+  inside the 5% margin. A B200 therefore takes the baseline linears
+  (228 ms/step) over the fused ones (350 ms/step) — the card has the room —
+  while on a 24 GB card the same fit constraint excludes a lane outright.
+  Ranking combinations is what makes this one rule enough for both axes: the
+  packed modulation is speed-neutral, so it can only win on the VRAM
+  tiebreak, and it does — which is how sm_100 arrives at `baseline+packed`
+  without anyone hand-editing a tuple to say so.
+- **Determinism.** The 5% margin means measurement noise cannot flip a
+  recorded verdict between two mints on one card, and every number behind a
+  verdict is recorded as its evidence.
+- **Where it lands.** `metadata.json` inside the packed cell carries the
+  DISCRETE verdict (`kernel_lane`: winner, rule, binding term, margin,
+  candidates) — no wall clocks, because the #699 double-mint byte-compare
+  requires a reproducible artifact. The measurements ride the published
+  checkpoint metadata as `kernel_lane_evidence`, beside `mint_phases`.
+- **Serving.** The executor reads the verdict off the delivered cell and
+  pins it BEFORE `setup()` runs; each axis then projects its own value out of
+  the pin (`native_kernels.svdq_linear_lane` / `svdq_modulation_lane`). No
+  cell, a pre-pgw#947 cell, or an unreadable envelope is the declared
+  conservative default (`baseline+dense`) with a typed reason
+  (`kernel_lane_verdict_absent` / `_unreadable` / `_unknown_lane` /
+  `kernel_lane_no_cell`) — never a silent fall-through. An armed axis still
+  has to pass its OWN numerics self-check on the box; a gap degrades that
+  axis alone, same artifact, with the reason logged.
+
+`GEN_WORKER_NATIVE_KERNELS` survives only as the pgw#859 G0 rollout gate and
+kill switch (unset = off, `=0` = forced off). It gates the ROLLOUT and never
+picks a lane; flipping it is pgw#865's call. It is on th#1445's elimination
+list and must not grow new meanings.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -100,7 +100,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 from . import activity as activity_mod
 from . import (
     aot_compile_pool, aot_export_parallel, aot_export_reuse, aot_package,
-    aot_serve, aot_wrapper_split, cell_key, graph_hash)
+    aot_serve, aot_wrapper_split, cell_key, graph_hash, kernel_lane)
 from .aot_contract import (  # re-exported: the declaration layer's vocabulary
     ADAPTER_FORK,
     DynamicDim,
@@ -1143,6 +1143,59 @@ def _export_entry(
         timings=timings)
 
 
+def bench_step(pipeline: Any, spec: ExportSpec) -> Callable[[], Any]:
+    """A zero-argument callable running ONE forward of this family's DOMINANT
+    declared graph class, in the PRODUCTION (compiled) posture (pgw#947).
+
+    The dominant class is the declaration's FIRST target — the denoiser,
+    which runs once per step while the VAE runs once per image — so "ms/step"
+    means what the pgw#862/#863 benchmark tables mean by it. A cell-level spec
+    that names a target (the operator CLI path) overrides that. Its inputs are
+    the family's OWN declared example feed (``aot_inputs.builder_for``), i.e.
+    the same representative shape the mint is about to export against, not a
+    shape invented here.
+
+    COMPILED, deliberately: pgw#863's whole finding is that the eager ranking
+    and the compiled ranking disagree — inductor fuses the baseline lane's
+    open elementwise chain and cannot fuse across our custom ops — and the
+    compiled posture is the only one production serves from.
+    """
+    import torch
+
+    from . import aot_declaration as _decl
+    from . import aot_inputs
+    from .api.export_contract import export_declaration
+
+    decl = export_declaration(spec.family)
+    if decl is None:
+        raise MintRefused(
+            f"family {spec.family!r} has no export declaration — nothing to "
+            f"benchmark a kernel lane against")
+    plans = list(_decl.cell_plans(decl))
+    if not plans:
+        raise MintRefused(f"family {spec.family!r} declares no graph classes")
+    want = str(spec.target or "") or str(decl.targets[0])
+    dominant = next(
+        (p for p in plans if str(p.target) == want), plans[0])
+    espec = _entry_spec(spec, dominant, decl)
+    resolved = _resolve_target(pipeline, espec.target)
+    if resolved is None:
+        raise MintRefused(
+            f"pipeline {type(pipeline).__name__} has no compile target "
+            f"{espec.target!r} to benchmark")
+    owner, attr, _fn = resolved
+    module = owner if attr == "forward" else _CallableTarget(owner, attr)
+    builder = aot_inputs.builder_for(espec.family, espec.target)
+    args, kwargs = builder(owner, espec)
+    compiled = torch.compile(module)
+
+    def step() -> Any:
+        with torch.no_grad():
+            return compiled(*args, **kwargs)
+
+    return step
+
+
 def replace_spec(spec: ExportSpec, **changes: Any) -> ExportSpec:
     """``dataclasses.replace`` on an :class:`ExportSpec`, named so the
     deferred-import dance does not have to repeat at every call site."""
@@ -1412,6 +1465,7 @@ def mint(
     entry_device_peak_bytes: int = 0,
     on_progress: Optional[Callable[[str, int, int, str], None]] = None,
     phase_snapshot: Optional[Path] = None,
+    lane_verdict: Optional[kernel_lane.Verdict] = None,
 ) -> MintResult:
     """:func:`_mint_cell`, with the phase table attached to EVERY terminus.
 
@@ -1465,6 +1519,7 @@ def mint(
             entry_workers=entry_workers,
             entry_peak_rss_bytes=entry_peak_rss_bytes,
             entry_device_peak_bytes=entry_device_peak_bytes,
+            lane_verdict=lane_verdict,
             progress=progress)
     except BaseException as exc:
         _attach_partial_phases(exc, progress)
@@ -1652,10 +1707,18 @@ def _mint_cell(
     entry_workers: int = 0,
     entry_peak_rss_bytes: int = 0,
     entry_device_peak_bytes: int = 0,
+    lane_verdict: Optional[kernel_lane.Verdict] = None,
     progress: Optional[MintProgress] = None,
 ) -> MintResult:
     """Export + compile EVERY declared graph class and pack them as ONE
     multi-graph cell (pgw#758).
+
+    ``lane_verdict`` (pgw#947) is the MEASURED serving-kernel lane for this
+    card, produced by the mint driver before the pipeline was loaded — only
+    the loader can swap the linears, so the A/B happens one level up
+    (``mint_child.lane_verdict_for``). The discrete verdict is packed into
+    the envelope so serving reads it instead of an SM tuple; the numbers ride
+    the result metadata beside ``mint_phases``, never the artifact.
 
     ``entry_workers`` CAPS pgw#809's compile pool; it never widens it. The
     width is derived from the pod (see :func:`aot_compile_pool.entry_workers`),
@@ -1932,6 +1995,12 @@ def _mint_cell(
         raise MintRefused(
             f"envelope refused the declared contract: {exc}") from exc
     meta.update(shared_identity_blocks(spec))
+    if lane_verdict is not None:
+        # pgw#947: the DISCRETE verdict only. Milliseconds in metadata.json
+        # would break the #699 double-mint byte-compare — the artifact
+        # deliberately carries no wall clocks — and the margin threshold is
+        # what makes the discrete answer reproducible across two mints.
+        meta[kernel_lane.META_KEY] = kernel_lane.envelope_block(lane_verdict)
     mode_drift = aot_package.strict_mode_drift(meta, spec.strict)
     if mode_drift:
         raise MintRefused("trace-mode drift: " + "; ".join(mode_drift))
@@ -1951,6 +2020,13 @@ def _mint_cell(
     # metadata.json would break the #699 double-mint byte-compare — the
     # artifact deliberately carries no timestamps and no wall clocks.
     meta["mint_phases"] = phase_table
+    if lane_verdict is not None:
+        # The EVIDENCE: both lanes' ms/step and peak bytes, the margin, the
+        # headroom terms, and the device it was all measured on. Same channel
+        # as the phase table (published checkpoint metadata + the typed
+        # event), so a verdict is auditable long after the pod is gone.
+        meta[kernel_lane.EVIDENCE_KEY] = kernel_lane.evidence_block(
+            lane_verdict)
 
     logger.info(
         "aot-mint: %s lane=%s -> %s (%d entr%s across %d target(s), %.1f MB "
@@ -3287,6 +3363,7 @@ __all__ = [
     "MINT_COMPILE_THREADS",
     "MintResult",
     "autotune_posture",
+    "bench_step",
     "cell_identity",
     "compile_entry_files",
     "compose_for_mint",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -34,6 +34,7 @@ import msgspec
 from . import activity as activity_mod
 from . import boot_phases as boot_mod
 from . import cpu_budget
+from . import kernel_lane
 from . import mint_budget
 from . import progress as progress_mod
 from . import serving_mode as serving_mode_mod
@@ -6584,6 +6585,14 @@ class Executor:
             else await self._fetch_compile_snapshot(spec, snapshots)
         )
         compile_artifact = compile_selection.path if compile_selection else None
+        # pgw#947: the serving-kernel lane comes from the CELL, and it has to
+        # be pinned BEFORE setup() — the linears are swapped at model load, so
+        # a verdict read afterwards would arrive one whole pipeline too late.
+        # No cell (eager boot, self-minting boot, pre-pgw#947 cell) is the
+        # declared conservative default WITH a typed reason; there is no SM
+        # allowlist and no per-boot probe to fall back on any more.
+        kernel_lane.adopt_from_artifact(
+            compile_artifact, source=f"{spec.name} boot")
         # Loads serialize: concurrent setups would cross-contaminate each
         # other's allocator deltas and place_pipeline's free-VRAM reads.
         async with self._intent_lock(

--- a/src/gen_worker/kernel_lane.py
+++ b/src/gen_worker/kernel_lane.py
@@ -1,0 +1,791 @@
+"""Measured serving-kernel lane selection (pgw#863, pgw#947).
+
+The svdq serving path has TWO independent kernel choices, and pgw#863 is the
+proof they cannot be one switch:
+
+    linear      W4A4 matmuls: ``fused`` (our triton kernels) or ``baseline``
+                (the open unfused chain). A THROUGHPUT question.
+    modulation  W4A16 AdaLN modulation: ``packed`` (4-bit resident,
+                dequantised in-kernel) or ``dense`` (decoded to bf16 at
+                load). A RESIDENCY question — 22.8 -> 13.3 GB on B200.
+
+Which COMBINATION wins on a card is a per-card FACT, not a derivable one: a
+custom op is opaque to inductor, so on sm_120 our fusion beats what inductor
+can do with the open chain and on sm_100 it loses to it by 19%, while the
+packed modulation is worth having on both. That used to be two
+hand-maintained SM tuples, informed by ~$12 benchmark campaigns per card and
+one human edit per new card class — and while they were ONE tuple, sm_100
+had to give up either 9.5 GB of residency or 19% of its step time, because a
+single switch cannot express "baseline linears, packed modulation".
+
+This module replaces both tuples with a measurement taken on the card the
+cell is being minted for, recorded INTO the cell, and adopted by serving:
+
+    mint      probe(candidates, ...) -> Verdict     (every buildable
+              combination built, compiled, and timed on the target card, in
+              the pgw#784 mint process)
+    envelope  metadata.json["kernel_lane"] — the DISCRETE verdict only
+    result    metadata["kernel_lane_evidence"] — the numbers, published with
+              the checkpoint, never packed (the #699 double-mint byte-compare
+              forbids wall clocks inside the artifact)
+    serve     adopt(meta) -> pin(); the load-time swap reads the pin, each
+              axis projecting its own value out of it
+
+A lane is therefore a COMBINATION, written ``"<linear>+<modulation>"``
+(``"baseline+packed"``, ``"fused+dense"``, ...). Measuring the combinations
+rather than each axis alone is deliberate: it assumes no independence between
+them, and it is what lets ONE rule price a residency win and a throughput win
+against each other instead of hard-coding which one matters.
+
+THE SELECTION RULE (Paul, 2026-08-03): **fit-constrained speed
+maximization.** Among lanes whose measured peak VRAM fits the target card
+with headroom, pick the FASTEST. VRAM is a CONSTRAINT, not an objective — it
+breaks a tie only when two lanes are within the speed noise margin. On a
+B200 that means baseline linears (228 ms/step) over fused (350 ms/step): the
+card has the room. The packed modulation is speed-NEUTRAL, so it wins its
+axis on exactly that tiebreak — the smaller peak — which is how sm_100 ends
+up on ``baseline+packed`` without anyone writing that down. On a 32 GB card
+the fit constraint does real work and can exclude a faster lane outright.
+
+`models/w4a4.py::_gemm_profitable` is the in-tree precedent — it
+micro-benchmarks fp4 against bf16 at boot and refuses to arm unless it wins
+by a real margin. This is that mechanism one level up: whole compiled graphs
+instead of one GEMM, paid once at mint instead of on every boot, and
+RECORDED instead of re-derived.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+import msgspec
+
+logger = logging.getLogger(__name__)
+
+# --- vocabulary -------------------------------------------------------------
+
+# The two axes. Each is decided independently at serving time (a card can want
+# baseline linears AND packed modulation — sm_100 does), but they are MEASURED
+# together, as combinations, so the rule never has to assume they do not
+# interact.
+AXIS_LINEAR = "linear"
+AXIS_MODULATION = "modulation"
+AXES = (AXIS_LINEAR, AXIS_MODULATION)
+
+LINEAR_BASELINE = "baseline"
+LINEAR_FUSED = "fused"
+LINEAR_LANES = (LINEAR_BASELINE, LINEAR_FUSED)
+
+MOD_DENSE = "dense"
+MOD_PACKED = "packed"
+MOD_LANES = (MOD_DENSE, MOD_PACKED)
+
+# A lane NAME is the combination, so one string pins both axes, one verdict
+# ranks them together, and one grep finds a decision in a log.
+SEP = "+"
+
+
+def lane_of(linear: str, modulation: str) -> str:
+    """The combination's canonical name."""
+    return f"{linear}{SEP}{modulation}"
+
+
+def split_lane(lane: str) -> Tuple[str, str]:
+    """``(linear, modulation)`` for a combination name."""
+    linear, _, modulation = str(lane).partition(SEP)
+    return linear, modulation
+
+
+def linear_of(lane: str) -> str:
+    """The linear-axis value a combination names."""
+    return split_lane(lane)[0]
+
+
+def modulation_of(lane: str) -> str:
+    """The modulation-axis value a combination names."""
+    return split_lane(lane)[1]
+
+
+LANES = tuple(
+    lane_of(linear, modulation)
+    for linear in LINEAR_LANES for modulation in MOD_LANES)
+
+# What a worker runs when no cell says otherwise: the pair that exists on
+# every card and is a pessimisation on none of them.
+DEFAULT_LANE = lane_of(LINEAR_BASELINE, MOD_DENSE)
+
+# Envelope key (discrete facts, packed into metadata.json) and result key
+# (measurements, published with the checkpoint, NEVER packed).
+META_KEY = "kernel_lane"
+EVIDENCE_KEY = "kernel_lane_evidence"
+SCHEMA = 1
+
+# --- the policy constants ---------------------------------------------------
+
+# A candidate must beat the incumbent by this much to be declared the SPEED
+# winner. Below it the two are a tie and the smaller peak wins, so ordinary
+# measurement noise can never flip a recorded verdict between two mints on
+# one card. `_gemm_profitable` uses 1.10x on a 4096^3 microbenchmark; a
+# whole-graph step timed over `BENCH_ITERS` medians is far quieter, and every
+# decision this mechanism exists to make is 7-34% wide.
+MARGIN_FRACTION = 0.05
+
+# "Fits" = the measured peak, plus an allowance for the shapes the mint did
+# NOT measure. The mint times ONE representative shape; a tenant may ask for a
+# larger resolution or a longer prompt, and the allocator fragments. The
+# strict_vram rule stands (declare the honest peak ask — a marketing-GB
+# declaration is release-broken by one GiB), so the allowance is explicit and
+# the term that bound a verdict is recorded with it.
+ACTIVATION_SPIKE_FRACTION = 0.20
+FRAGMENTATION_HEADROOM_BYTES = 1 << 30  # 1 GiB
+
+# Fixed measurement protocol — part of the verdict's determinism, recorded
+# with it so a re-measurement is comparable.
+BENCH_WARMUP = 3
+BENCH_ITERS = 9  # odd: a true median, no interpolation
+
+# Capability floor for the fused lane: block-scaled MMA (`dot_scaled` lowering
+# to kind::mxf4nvf4 / tcgen05) is Blackwell silicon. This is a CAPABILITY
+# precondition — can the candidate be built at all — not a performance
+# allowlist. Whether it WINS on a qualifying card is what gets measured.
+FUSED_MIN_SM = 100
+
+# Why a lane is what it is, when no verdict decided it. Typed so a serving
+# worker's degrade is greppable and never a silent fall-through.
+REASON_ABSENT = "kernel_lane_verdict_absent"
+REASON_UNREADABLE = "kernel_lane_verdict_unreadable"
+REASON_UNKNOWN_LANE = "kernel_lane_verdict_unknown_lane"
+REASON_NO_CELL = "kernel_lane_no_cell"
+REASON_ADOPTED = "kernel_lane_verdict_adopted"
+
+# Which term bound a verdict.
+BIND_SPEED = "speed"
+BIND_FIT = "fit"
+BIND_VRAM_TIEBREAK = "vram_tiebreak"
+BIND_SOLE_CANDIDATE = "sole_candidate"
+BIND_NO_FIT = "no_fit"
+
+
+class LaneProbeError(RuntimeError):
+    """A candidate could not be built or measured. Never fatal: the candidate
+    drops out of the ranking with its reason recorded."""
+
+
+# --- value types ------------------------------------------------------------
+
+
+class Measurement(msgspec.Struct, frozen=True, kw_only=True):
+    """One candidate lane, measured on the target card."""
+
+    lane: str
+    ms_per_step: float = 0.0
+    peak_bytes: int = 0
+    samples_ms: Tuple[float, ...] = ()
+    unavailable: str = ""  # typed reason it could not be measured
+
+    @property
+    def usable(self) -> bool:
+        return not self.unavailable and self.ms_per_step > 0.0
+
+    def required_bytes(self) -> int:
+        """The peak plus the stated allowance for the shapes the mint did not
+        measure (activation spikes, resolution variance, fragmentation)."""
+        return int(self.peak_bytes * (1.0 + ACTIVATION_SPIKE_FRACTION)) \
+            + FRAGMENTATION_HEADROOM_BYTES
+
+
+class Verdict(msgspec.Struct, frozen=True, kw_only=True):
+    """Which lane won on this card, why, and on what evidence."""
+
+    winner: str
+    binding: str
+    rule: str = "fit_constrained_speed"
+    schema: int = SCHEMA
+    margin_fraction: float = MARGIN_FRACTION
+    activation_spike_fraction: float = ACTIVATION_SPIKE_FRACTION
+    fragmentation_headroom_bytes: int = FRAGMENTATION_HEADROOM_BYTES
+    device_total_bytes: int = 0
+    device_name: str = ""
+    sm: str = ""
+    warmup: int = BENCH_WARMUP
+    iters: int = BENCH_ITERS
+    measured_at: float = 0.0
+    measurements: Tuple[Measurement, ...] = ()
+    detail: str = ""
+
+    def measurement(self, lane: str) -> Optional[Measurement]:
+        for row in self.measurements:
+            if row.lane == lane:
+                return row
+        return None
+
+
+# --- the rule ---------------------------------------------------------------
+
+
+def fits(row: Measurement, device_total_bytes: int) -> bool:
+    """Does this lane fit the card with the stated allowance? A card whose
+    total is unknown (0) constrains nothing — the mint measured it there, so
+    it ran there."""
+    if not device_total_bytes:
+        return True
+    return row.required_bytes() <= int(device_total_bytes)
+
+
+def select(
+    measurements: Sequence[Measurement],
+    *,
+    device_total_bytes: int = 0,
+    device_name: str = "",
+    sm: str = "",
+) -> Verdict:
+    """FIT-CONSTRAINED SPEED MAXIMIZATION.
+
+    1. Drop candidates that could not be measured.
+    2. Drop candidates whose measured peak + allowance does not fit the card.
+    3. Among the rest take the FASTEST; a rival within ``MARGIN_FRACTION`` of
+       it is a TIE and the smaller peak wins.
+
+    Nothing fits, or nothing measured -> the smallest-peak usable candidate
+    with ``binding="no_fit"`` (loud, and the serving degrade path owns what
+    happens next), or the declared default with no measurements at all.
+    """
+    rows = tuple(measurements)
+    usable = tuple(r for r in rows if r.usable)
+    common: Dict[str, Any] = {
+        "device_total_bytes": int(device_total_bytes or 0),
+        "device_name": str(device_name or ""),
+        "sm": str(sm or ""),
+        "measurements": rows,
+        "measured_at": time.time(),
+    }
+    if not usable:
+        gaps = "; ".join(
+            f"{r.lane}: {r.unavailable or 'no timing'}" for r in rows)
+        return Verdict(
+            winner=DEFAULT_LANE, binding=BIND_NO_FIT,
+            detail=f"no candidate measured ({gaps or 'no candidates'})",
+            **common)
+
+    fitting = tuple(r for r in usable if fits(r, device_total_bytes))
+    if not fitting:
+        smallest = min(usable, key=lambda r: (r.peak_bytes, r.lane))
+        return Verdict(
+            winner=smallest.lane, binding=BIND_NO_FIT,
+            detail=(
+                f"no candidate fits {device_total_bytes} B with the stated "
+                f"allowance; smallest peak wins ({smallest.lane}, "
+                f"{smallest.peak_bytes} B peak, "
+                f"{smallest.required_bytes()} B required)"),
+            **common)
+
+    excluded = tuple(r.lane for r in usable if r not in fitting)
+    if len(fitting) == 1:
+        only = fitting[0]
+        binding = BIND_FIT if excluded else BIND_SOLE_CANDIDATE
+        detail = (
+            f"{only.lane} is the only lane that fits; excluded "
+            f"{sorted(excluded)!r}" if excluded
+            else f"{only.lane} is the only candidate")
+        return Verdict(winner=only.lane, binding=binding, detail=detail,
+                       **common)
+
+    ranked = sorted(fitting, key=lambda r: (r.ms_per_step, r.lane))
+    best, rival = ranked[0], ranked[1]
+    gap = (rival.ms_per_step - best.ms_per_step) / max(best.ms_per_step, 1e-9)
+    if gap >= MARGIN_FRACTION:
+        return Verdict(
+            winner=best.lane, binding=BIND_SPEED,
+            detail=(
+                f"{best.lane} {best.ms_per_step:.1f} ms/step beats "
+                f"{rival.lane} {rival.ms_per_step:.1f} by {gap * 100:.1f}% "
+                f"(margin {MARGIN_FRACTION * 100:.0f}%)"
+                + (f"; excluded on fit {sorted(excluded)!r}" if excluded
+                   else "")),
+            **common)
+    # Within the noise margin: VRAM breaks the tie, and only here.
+    tied = tuple(
+        r for r in fitting
+        if (r.ms_per_step - best.ms_per_step)
+        / max(best.ms_per_step, 1e-9) < MARGIN_FRACTION)
+    winner = min(tied, key=lambda r: (r.peak_bytes, r.lane))
+    return Verdict(
+        winner=winner.lane, binding=BIND_VRAM_TIEBREAK,
+        detail=(
+            f"{[r.lane for r in tied]!r} within {MARGIN_FRACTION * 100:.0f}% "
+            f"({best.ms_per_step:.1f}-{rival.ms_per_step:.1f} ms/step); "
+            f"smaller peak wins ({winner.lane}, {winner.peak_bytes} B)"),
+        **common)
+
+
+def sole(lane: str, detail: str) -> Verdict:
+    """The verdict for a card that can only build ONE lane. No benchmark is
+    run: with nothing to compare against, a measurement would buy a compile
+    and decide nothing. The cell still records a real, typed verdict rather
+    than the absence a serving worker has to guess about."""
+    total, name, sm = device_facts()
+    return Verdict(
+        winner=lane, binding=BIND_SOLE_CANDIDATE, detail=detail,
+        device_total_bytes=total, device_name=name, sm=sm,
+        measured_at=time.time())
+
+
+# --- measurement ------------------------------------------------------------
+
+
+def device_facts() -> Tuple[int, str, str]:
+    """``(total_bytes, name, sm)`` for the card this process is on, honestly
+    detected (an H100-80GB reports 79.19 GiB — declare that, not the
+    marketing number). ``(0, "", "")`` off-GPU."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return 0, "", ""
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        major, minor = torch.cuda.get_device_capability()
+        return int(props.total_memory), str(props.name), f"sm_{major}{minor}"
+    except Exception:  # noqa: BLE001 — a probe never changes an outcome
+        return 0, "", ""
+
+
+def measure(lane: str, step: Callable[[], Any]) -> Measurement:
+    """Time one candidate's representative step and record its device peak.
+
+    ``step`` must run ONE forward of the graph in its production posture
+    (compiled), already built. Fixed warmup + median over ``BENCH_ITERS``
+    CUDA-event timings — the same protocol `_gemm_profitable` uses, so two
+    mints on one card measure the same thing.
+    """
+    import torch
+
+    try:
+        for _ in range(BENCH_WARMUP):
+            step()
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        samples = []
+        for _ in range(BENCH_ITERS):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            step()
+            end.record()
+            torch.cuda.synchronize()
+            samples.append(round(float(start.elapsed_time(end)), 3))
+        peak = int(torch.cuda.max_memory_allocated())
+    except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
+        # measured drops out of the ranking; it never fails the mint.
+        return Measurement(
+            lane=lane, unavailable=f"{type(exc).__name__}: {exc}")
+    ordered = sorted(samples)
+    return Measurement(
+        lane=lane, ms_per_step=ordered[len(ordered) // 2], peak_bytes=peak,
+        samples_ms=tuple(samples))
+
+
+def probe(
+    candidates: Sequence[str],
+    build: Callable[[str], Callable[[], Any]],
+    *,
+    device_total_bytes: int = 0,
+    device_name: str = "",
+    sm: str = "",
+) -> Verdict:
+    """Build, measure and rank every candidate lane on THIS card.
+
+    ``build(lane)`` returns a zero-argument callable that runs one
+    representative step with that lane armed — the mint's job, because only
+    the loader can swap the linears. A builder that raises drops its
+    candidate with the reason recorded; it never fails the mint.
+    """
+    if not device_total_bytes and not device_name and not sm:
+        device_total_bytes, device_name, sm = device_facts()
+    rows = []
+    for lane in candidates:
+        t0 = time.monotonic()
+        try:
+            step = build(lane)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kernel-lane probe: %s could not be built — %s",
+                           lane, exc)
+            rows.append(Measurement(
+                lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}"))
+            continue
+        row = measure(lane, step)
+        rows.append(row)
+        logger.info(
+            "kernel-lane probe: %s -> %s (%.1f s to build+measure)",
+            lane,
+            (f"{row.ms_per_step:.1f} ms/step, {row.peak_bytes / 1e9:.1f} GB "
+             f"peak" if row.usable else f"UNAVAILABLE {row.unavailable}"),
+            time.monotonic() - t0)
+    verdict = select(
+        rows, device_total_bytes=device_total_bytes,
+        device_name=device_name, sm=sm)
+    logger.info("kernel-lane verdict: %s (%s) — %s",
+                verdict.winner, verdict.binding, verdict.detail)
+    return verdict
+
+
+def fused_candidate_gap(sm: int) -> str:
+    """Why the fused LINEAR is not even a CANDIDATE here, or ''.
+
+    Capability only — silicon plus the numerics self-check. Whether it is
+    the faster lane on a qualifying card is what :func:`probe` measures, and
+    is deliberately NOT asked here.
+    """
+    if sm < FUSED_MIN_SM:
+        return (f"fused svdq kernels need Blackwell block-scaled MMA "
+                f"(sm_{FUSED_MIN_SM}+); this GPU is sm_{sm}")
+    try:
+        from .models.svdq_fused import fused_self_check
+    except Exception as exc:  # noqa: BLE001
+        return f"fused kernels are not importable: {exc}"
+    try:
+        return str(fused_self_check() or "")
+    except Exception as exc:  # noqa: BLE001
+        return f"fused self-check raised: {type(exc).__name__}: {exc}"
+
+
+def packed_candidate_gap() -> str:
+    """Why the PACKED modulation is not a candidate here, or ''.
+
+    No SM term at all, deliberately: the W4A16 dequant-GEMM is ordinary
+    triton with no block-scaled-MMA dependency, so it builds on any CUDA card
+    triton supports. pgw#863 carried a Blackwell tuple for it purely because
+    it shared a switch with the fused linear; separating the axes removes the
+    reason, and the measurement decides the rest.
+    """
+    try:
+        from .models.svdq_awq_packed import awq_packed_self_check
+    except Exception as exc:  # noqa: BLE001
+        return f"packed modulation kernels are not importable: {exc}"
+    try:
+        return str(awq_packed_self_check() or "")
+    except Exception as exc:  # noqa: BLE001
+        return (f"packed modulation self-check raised: "
+                f"{type(exc).__name__}: {exc}")
+
+
+def candidate_axes() -> Tuple[Dict[str, Tuple[str, ...]], Dict[str, str]]:
+    """``({axis: buildable values}, {axis: why the armed value is not one})``.
+
+    The gaps are CAPABILITY answers only. An axis with one value needs no
+    measurement on that axis; an axis with two is what :func:`probe` prices.
+    """
+    linear = [LINEAR_BASELINE]
+    modulation = [MOD_DENSE]
+    gaps: Dict[str, str] = {}
+    total, _name, sm_text = device_facts()
+    if not total:
+        gaps[AXIS_LINEAR] = gaps[AXIS_MODULATION] = (
+            "no CUDA device — native kernels cannot be built here")
+        return ({AXIS_LINEAR: tuple(linear),
+                 AXIS_MODULATION: tuple(modulation)}, gaps)
+    try:
+        sm = int(str(sm_text or "sm_0").removeprefix("sm_"))
+    except ValueError:
+        sm = 0
+    gap = fused_candidate_gap(sm)
+    if gap:
+        gaps[AXIS_LINEAR] = gap
+        logger.info("kernel-lane: the fused linear is not a candidate "
+                    "here — %s", gap)
+    else:
+        linear.append(LINEAR_FUSED)
+    gap = packed_candidate_gap()
+    if gap:
+        gaps[AXIS_MODULATION] = gap
+        logger.info("kernel-lane: the packed modulation is not a candidate "
+                    "here — %s", gap)
+    else:
+        modulation.append(MOD_PACKED)
+    return ({AXIS_LINEAR: tuple(linear),
+             AXIS_MODULATION: tuple(modulation)}, gaps)
+
+
+def candidates_here() -> Tuple[str, ...]:
+    """Every lane COMBINATION that can be BUILT on this card, cheapest-first.
+
+    The cross product, not one axis at a time: measuring the pairs assumes
+    nothing about whether the two kernels interact, and it is what lets the
+    one rule in :func:`select` weigh a residency win against a throughput
+    win. On a card where neither armed value can be built this is exactly one
+    combination and the mint skips the benchmark entirely
+    (``mint_child.lane_verdict_for``), so the cost lands only where there is
+    actually a choice to make.
+    """
+    axes, _gaps = candidate_axes()
+    return tuple(
+        lane_of(linear, modulation)
+        for linear in axes[AXIS_LINEAR]
+        for modulation in axes[AXIS_MODULATION])
+
+
+# --- recording and reading --------------------------------------------------
+
+
+def envelope_block(verdict: Verdict) -> Dict[str, Any]:
+    """The DISCRETE verdict, for ``metadata.json`` inside the packed cell.
+
+    Deliberately carries no wall clocks and no measured numbers: the #699
+    double-mint byte-compare requires the artifact to be reproducible, and
+    milliseconds are not. What a serving worker needs is the winner; what an
+    auditor needs is :func:`evidence_block`, which rides the published
+    checkpoint metadata beside ``mint_phases``.
+    """
+    return {
+        "schema": int(verdict.schema),
+        "winner": str(verdict.winner),
+        "rule": str(verdict.rule),
+        "binding": str(verdict.binding),
+        "margin_fraction": float(verdict.margin_fraction),
+        "candidates": sorted(r.lane for r in verdict.measurements),
+    }
+
+
+def evidence_block(verdict: Verdict) -> Dict[str, Any]:
+    """Every number behind the verdict — published with the checkpoint, never
+    packed. This is what makes a verdict auditable and a flip explicable."""
+    return {
+        "schema": int(verdict.schema),
+        "winner": str(verdict.winner),
+        "rule": str(verdict.rule),
+        "binding": str(verdict.binding),
+        "detail": str(verdict.detail),
+        "margin_fraction": float(verdict.margin_fraction),
+        "activation_spike_fraction": float(verdict.activation_spike_fraction),
+        "fragmentation_headroom_bytes":
+            int(verdict.fragmentation_headroom_bytes),
+        "device_total_bytes": int(verdict.device_total_bytes),
+        "device_name": str(verdict.device_name),
+        "sm": str(verdict.sm),
+        "warmup": int(verdict.warmup),
+        "iters": int(verdict.iters),
+        "measured_at": float(verdict.measured_at),
+        "candidates": [
+            {
+                "lane": r.lane,
+                "ms_per_step": float(r.ms_per_step),
+                "peak_bytes": int(r.peak_bytes),
+                "required_bytes": int(r.required_bytes()),
+                "fits": fits(r, verdict.device_total_bytes),
+                "samples_ms": list(r.samples_ms),
+                "unavailable": r.unavailable,
+            }
+            for r in verdict.measurements
+        ],
+    }
+
+
+def verdict_from_evidence(block: Mapping[str, Any]) -> Verdict:
+    """Rebuild a :class:`Verdict` from :func:`evidence_block` — the audit
+    round-trip, and how a recorded campaign is replayed against the rule."""
+    rows = tuple(
+        Measurement(
+            lane=str(c.get("lane") or ""),
+            ms_per_step=float(c.get("ms_per_step") or 0.0),
+            peak_bytes=int(c.get("peak_bytes") or 0),
+            samples_ms=tuple(float(s) for s in (c.get("samples_ms") or ())),
+            unavailable=str(c.get("unavailable") or ""),
+        )
+        for c in (block.get("candidates") or ())
+    )
+    return Verdict(
+        winner=str(block.get("winner") or DEFAULT_LANE),
+        binding=str(block.get("binding") or ""),
+        rule=str(block.get("rule") or "fit_constrained_speed"),
+        schema=int(block.get("schema") or SCHEMA),
+        margin_fraction=float(block.get("margin_fraction") or MARGIN_FRACTION),
+        activation_spike_fraction=float(
+            block.get("activation_spike_fraction")
+            or ACTIVATION_SPIKE_FRACTION),
+        fragmentation_headroom_bytes=int(
+            block.get("fragmentation_headroom_bytes")
+            or FRAGMENTATION_HEADROOM_BYTES),
+        device_total_bytes=int(block.get("device_total_bytes") or 0),
+        device_name=str(block.get("device_name") or ""),
+        sm=str(block.get("sm") or ""),
+        warmup=int(block.get("warmup") or BENCH_WARMUP),
+        iters=int(block.get("iters") or BENCH_ITERS),
+        measured_at=float(block.get("measured_at") or 0.0),
+        measurements=rows,
+        detail=str(block.get("detail") or ""),
+    )
+
+
+def lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
+    """``(lane, reason)`` a cell's envelope states.
+
+    A cell minted before this mechanism records nothing — that is the
+    DECLARED default with a typed reason, never a silent fall-through. An
+    unreadable or unknown verdict is the same: conservative, and it says so.
+    """
+    block = meta.get(META_KEY) if isinstance(meta, Mapping) else None
+    if block is None:
+        return DEFAULT_LANE, (
+            f"{REASON_ABSENT}: cell records no kernel-lane verdict "
+            f"(pre-pgw#947 cell); serving the declared default "
+            f"{DEFAULT_LANE!r}")
+    if not isinstance(block, Mapping):
+        return DEFAULT_LANE, (
+            f"{REASON_UNREADABLE}: cell's {META_KEY!r} is "
+            f"{type(block).__name__}, not a block; serving {DEFAULT_LANE!r}")
+    winner = str(block.get("winner") or "")
+    if winner not in LANES:
+        return DEFAULT_LANE, (
+            f"{REASON_UNKNOWN_LANE}: cell names lane {winner!r}, which this "
+            f"worker does not implement ({list(LANES)!r}); serving "
+            f"{DEFAULT_LANE!r}")
+    return winner, (
+        f"{REASON_ADOPTED}: cell verdict {winner!r} "
+        f"(binding={block.get('binding') or '?'}, "
+        f"rule={block.get('rule') or '?'})")
+
+
+# --- the process pin --------------------------------------------------------
+
+_PIN: Optional[str] = None
+_PIN_REASON: str = ""
+
+
+def pin(lane: str, reason: str) -> None:
+    """Pin the lane THIS process loads on, with the reason it is pinned.
+
+    Set by the mint (once per candidate while probing, then to the winner)
+    and by the executor from the delivered cell before ``setup()`` runs —
+    the swap happens at model load, so the pin must precede it.
+    """
+    global _PIN, _PIN_REASON
+
+    if lane not in LANES:
+        raise LaneProbeError(f"unknown kernel lane {lane!r} (have {LANES!r})")
+    _PIN, _PIN_REASON = lane, str(reason or "")
+    logger.info("kernel-lane: pinned %s — %s", lane, _PIN_REASON)
+
+
+def pinned() -> Tuple[Optional[str], str]:
+    """``(lane, reason)`` or ``(None, "")`` when nothing has pinned one."""
+    return _PIN, _PIN_REASON
+
+
+def clear() -> None:
+    """Forget the pin (mint between candidates; tests)."""
+    global _PIN, _PIN_REASON
+
+    _PIN, _PIN_REASON = None, ""
+
+
+def adopt(meta: Optional[Mapping[str, Any]], *, source: str = "") -> str:
+    """Adopt the lane a delivered cell's metadata states, and return it.
+
+    ``None`` (no cell for this boot) is the declared default with its own
+    typed reason — an eager or self-minting boot has no verdict yet and must
+    say so rather than guessing that a hand-written tuple was right.
+    """
+    if meta is None:
+        lane, reason = DEFAULT_LANE, (
+            f"{REASON_NO_CELL}: no compiled cell delivered for this load; "
+            f"serving the declared default {DEFAULT_LANE!r}")
+    else:
+        lane, reason = lane_from_metadata(meta)
+    if source:
+        reason = f"{reason} [{source}]"
+    pin(lane, reason)
+    return lane
+
+
+def adopt_from_artifact(artifact: Any, *, source: str = "") -> str:
+    """Adopt the verdict recorded in a packed cell on disk.
+
+    Reads ``metadata.json`` out of the tar without unpacking it (both the
+    exported and the inductor-cache artifact kinds put it at the root). Any
+    read failure is the conservative default WITH the failure named — a
+    serving worker must never guess a lane.
+    """
+    if artifact is None:
+        return adopt(None, source=source)
+    try:
+        import json
+        import tarfile
+
+        with tarfile.open(str(artifact), "r:*") as tar:
+            for member in tar:
+                if member.name == "metadata.json" and member.isfile():
+                    fh = tar.extractfile(member)
+                    if fh is None:
+                        break
+                    meta = json.loads(fh.read().decode())
+                    return adopt(meta, source=source or str(artifact))
+        raise LaneProbeError("artifact has no metadata.json")
+    except Exception as exc:  # noqa: BLE001 — never fails a load
+        pin(DEFAULT_LANE, (
+            f"{REASON_UNREADABLE}: cannot read the verdict from "
+            f"{artifact} ({type(exc).__name__}: {exc}); serving "
+            f"{DEFAULT_LANE!r}"
+            + (f" [{source}]" if source else "")))
+        return DEFAULT_LANE
+
+
+__all__ = [
+    "ACTIVATION_SPIKE_FRACTION",
+    "AXES",
+    "AXIS_LINEAR",
+    "AXIS_MODULATION",
+    "BENCH_ITERS",
+    "BENCH_WARMUP",
+    "BIND_FIT",
+    "BIND_NO_FIT",
+    "BIND_SOLE_CANDIDATE",
+    "BIND_SPEED",
+    "BIND_VRAM_TIEBREAK",
+    "DEFAULT_LANE",
+    "EVIDENCE_KEY",
+    "FRAGMENTATION_HEADROOM_BYTES",
+    "FUSED_MIN_SM",
+    "LANES",
+    "LINEAR_BASELINE",
+    "LINEAR_FUSED",
+    "LINEAR_LANES",
+    "MARGIN_FRACTION",
+    "META_KEY",
+    "MOD_DENSE",
+    "MOD_LANES",
+    "MOD_PACKED",
+    "REASON_ABSENT",
+    "REASON_ADOPTED",
+    "REASON_NO_CELL",
+    "REASON_UNKNOWN_LANE",
+    "REASON_UNREADABLE",
+    "SCHEMA",
+    "SEP",
+    "LaneProbeError",
+    "Measurement",
+    "Verdict",
+    "adopt",
+    "adopt_from_artifact",
+    "candidate_axes",
+    "candidates_here",
+    "clear",
+    "device_facts",
+    "envelope_block",
+    "evidence_block",
+    "fits",
+    "fused_candidate_gap",
+    "lane_from_metadata",
+    "lane_of",
+    "linear_of",
+    "measure",
+    "modulation_of",
+    "packed_candidate_gap",
+    "pin",
+    "pinned",
+    "probe",
+    "select",
+    "sole",
+    "split_lane",
+    "verdict_from_evidence",
+]

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -372,9 +372,121 @@ def _drain_router(pipe: Any, *, poll_s: float = 0.5) -> None:
         time.sleep(poll_s)
 
 
+def _release() -> None:
+    """Reclaim a probe pipeline's device memory. The caller has already
+    dropped its references; this collects the cycles and returns the cached
+    blocks so the next candidate loads onto an empty card."""
+    import gc
+
+    gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+    except Exception:  # noqa: BLE001 — best effort
+        logger.debug("mint-child: empty_cache failed", exc_info=True)
+
+
+def _measure_lane(lane: str, load: Any) -> Any:
+    """Load, build and time ONE candidate lane.
+
+    Its own frame on purpose: the probe pipeline and its compiled step must
+    be unreachable the moment this returns, or the next candidate loads onto
+    a card the previous one is still resident on.
+    """
+    from . import aot_mint, kernel_lane
+
+    kernel_lane.pin(lane, "mint-time A/B probe (pgw#947)")
+    try:
+        pipe, spec = load(lane)
+        return kernel_lane.measure(lane, aot_mint.bench_step(pipe, spec))
+    except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
+        # built or measured drops out of the ranking; it never fails the
+        # mint, and the reason is recorded with the verdict.
+        logger.warning("mint-child: kernel-lane %s not buildable — %s",
+                       lane, exc)
+        return kernel_lane.Measurement(
+            lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}")
+
+
+def lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
+    """MEASURE which serving-kernel lane wins on THIS card (pgw#947).
+
+    Returns ``(verdict, pipeline, spec)`` — the winning lane's loaded
+    pipeline and its export spec, ready to mint, so the artifact and the
+    verdict inside it can never describe different code.
+
+    A "lane" is the pgw#863 COMBINATION of both axes (``fused+packed``,
+    ``baseline+packed``, ...), so the ranking prices the modulation lane's
+    residency win and the linear lane's throughput win against each other
+    under one rule instead of a hand tuple per axis.
+
+    The A/B has to happen HERE and not inside ``aot_mint``: the lane is
+    chosen when the checkpoint's linears are swapped, which is model LOAD, so
+    comparing lanes means loading once per candidate. ``load(lane)`` does one
+    full endpoint load with that lane pinned and hands back
+    ``(pipeline, export_spec)``.
+
+    Replaces the hand-maintained SM tuples this used to be. Whether each
+    kernel EXISTS on a card is still a capability question
+    (``kernel_lane.candidate_axes``), and an axis with one buildable value
+    contributes no candidates — a non-Blackwell card therefore has ONE
+    combination and pays no benchmark at all. Whether an armed value is
+    FASTER on a qualifying card is now measured there instead of edited into
+    a tuple after a $12 campaign.
+
+    Never fails a mint: any gap leaves the default lane pinned, records no
+    verdict, and says why — a cell with no verdict is the documented
+    conservative-default case on the serving side.
+    """
+    from . import kernel_lane
+
+    candidates = kernel_lane.candidates_here()
+    if len(candidates) < 2:
+        _axes, gaps = kernel_lane.candidate_axes()
+        detail = "; ".join(
+            f"{axis}: {gap}" for axis, gap in sorted(gaps.items()))
+        verdict = kernel_lane.sole(
+            candidates[0] if candidates else kernel_lane.DEFAULT_LANE,
+            f"only one lane combination is buildable on this card — "
+            f"{detail or 'no rival'}")
+        kernel_lane.pin(verdict.winner, f"sole candidate: {verdict.detail}")
+        frame(phase="load", note=f"kernel lane {verdict.winner} (sole)")
+        pipe, spec = load(verdict.winner)
+        return verdict, pipe, spec
+
+    measurements = []
+    for index, lane in enumerate(candidates, start=1):
+        frame(phase="load", step=index, total=len(candidates),
+              note=f"kernel-lane probe: {lane}")
+        measurements.append(_measure_lane(lane, load))
+        # Each candidate is loaded onto an EMPTY card and torn down before the
+        # next one: two resident pipelines would make the probe itself the
+        # thing that OOMs a mint pod sized for one, and the peak this measures
+        # has to be one lane's peak, not two lanes' sum. The probe pipeline
+        # dies with `_measure_lane`'s frame; this reclaims it.
+        _release()
+
+    total, name, sm = kernel_lane.device_facts()
+    verdict = kernel_lane.select(
+        measurements, device_total_bytes=total, device_name=name, sm=sm)
+    frame(phase="load",
+          note=f"kernel lane {verdict.winner} ({verdict.binding})")
+    kernel_lane.pin(verdict.winner, f"mint verdict: {verdict.detail}")
+    # The winner is loaded FRESH rather than kept from its probe pass: the
+    # probe ran `torch.compile` over the denoiser, and the graph that gets
+    # exported must come from a pipeline nothing has warmed or specialized.
+    pipe, spec = load(verdict.winner)
+    return verdict, pipe, spec
+
+
 def _mint_aot(
     request: MintRequest, pipe: Any, cfg: Any, target: Path, *,
     started: float, sha256_file: Any,
+    lane_verdict: Any = None,
+    spec: Any = None,
 ) -> MintReport:
     """pgw#805: the AOT recipe — torch.export + AOTInductor over the family's
     whole declared graph-class set, packed as ONE multi-graph cell (pgw#758).
@@ -401,7 +513,8 @@ def _mint_aot(
     aot_resume.set_root(request.resume)
 
     frame(phase="trace_graph", note=f"export declaration for {cfg.family!r}")
-    spec = fleet_cells.aot_export_spec(pipe, cfg)
+    if spec is None:
+        spec = fleet_cells.aot_export_spec(pipe, cfg)
     out_dir = target.parent / "aot"
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -432,7 +545,11 @@ def _mint_aot(
             # KILLED in still leaves its measurements on disk for the parent.
             phase_snapshot=(
                 Path(request.phases_snapshot)
-                if request.phases_snapshot else None))
+                if request.phases_snapshot else None),
+            # pgw#947: the MEASURED serving-kernel lane for this card. The
+            # discrete verdict lands in the packed envelope (serving reads it
+            # instead of an SM tuple); the numbers ride the result metadata.
+            lane_verdict=lane_verdict)
     except aot_mint.MintRefused as exc:
         # A named export refusal is a REFUSAL, not a crash: the parent must
         # not retry it, and the sentence is the whole diagnostic on a pod
@@ -518,6 +635,38 @@ def mint(request: MintRequest) -> MintReport:
         f"setup {spec.cls.__name__}"
         + (f" (+{sum(len(c) for c in overrides.values())} component "
            f"override(s))" if overrides else "")))
+
+    def _load(_lane: str) -> Tuple[Any, Any]:
+        """One full endpoint load on the currently pinned kernel lane, plus
+        the export spec of the pipeline it produced."""
+        from . import fleet_cells
+
+        obj = spec.cls()
+        got = run_setup(
+            obj, dict(request.snapshots), arm_compile=False,
+            return_loaded=True, component_paths=overrides) or {}
+        _slot, loaded_pipe = _pick_compile_target(got, cfg)
+        frame(phase="load", note=f"compile target on slot {_slot!r}")
+        if cfg.lora_bucket:
+            cc.apply_lora_lane(loaded_pipe, cfg.lora_bucket)
+        return loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
+
+    if request.recipe == RECIPE_AOT:
+        # pgw#947: MEASURE the serving-kernel lane on this card before the
+        # cell is exported, so the cell can carry the verdict instead of the
+        # fleet re-deriving it from a hand-maintained SM tuple. The probe
+        # loads once per candidate; the winner's pipeline is what gets minted.
+        verdict, pipe, aot_spec = lane_verdict_for(_load)
+        # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
+        # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
+        # model ref for an operator's mint pod): the graphs this cell must
+        # serve are the graphs the ENDPOINT's own composed pipeline runs, and
+        # composing a second time is how a mint exports something the serving
+        # pod cannot adopt.
+        return _mint_aot(
+            request, pipe, cfg, target, started=started,
+            sha256_file=sha256_file, lane_verdict=verdict, spec=aot_spec)
+
     instance = spec.cls()
     loaded = run_setup(
         instance, dict(request.snapshots), arm_compile=False,
@@ -527,17 +676,6 @@ def mint(request: MintRequest) -> MintReport:
 
     if cfg.lora_bucket:
         cc.apply_lora_lane(pipe, cfg.lora_bucket)
-
-    if request.recipe == RECIPE_AOT:
-        # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
-        # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
-        # model ref for an operator's mint pod): the graphs this cell must
-        # serve are the graphs the ENDPOINT's own composed pipeline runs, and
-        # composing a second time is how a mint exports something the serving
-        # pod cannot adopt.
-        return _mint_aot(
-            request, pipe, cfg, target, started=started,
-            sha256_file=sha256_file)
 
     jobs = _warm_jobs(siblings)
     # Arm COLD, pointed at our own capture dir: the warm forwards below are

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -1,77 +1,70 @@
-"""Native-kernel dispatch + capability probe (pgw#860).
+"""Native-kernel dispatch (pgw#860, pgw#863, pgw#947).
 
-TWO decisions, each made once per process at LOAD time and each INDEPENDENT of
-the other (pgw#863 — binding them to one switch cost sm_100 either 9.5 GB of
-residency or 19% of its step time, with no way to take both):
+TWO decisions, each made once per process at LOAD time and each INDEPENDENT
+of the other (pgw#863 — binding them to one switch cost sm_100 either 9.5 GB
+of residency or 19% of its step time, with no way to take both):
 
 - ``svdq_linear_lane()`` — FUSED W4A4 linears (pgw#862 triton kernels;
   `_cozy_kernels` C++ ops if/when a lane needs them) or the baseline unfused
-  chain. Armed only where the fused path is measurably faster in the
-  PRODUCTION (compiled) posture.
+  chain. A throughput question.
 - ``svdq_modulation_lane()`` — PACKED W4A16 AdaLN modulation (pgw#864) or
-  dense bf16. A residency win rather than a throughput one, so it arms on
-  every Blackwell card.
+  dense bf16. A residency question.
 
-Both decisions are typed, logged, and never silent-wrong:
+**Neither decision is made here, and neither is derived from the SM
+(pgw#947).** Which combination of the two wins on a card is a per-card FACT,
+not a derivable one — a custom op is opaque to inductor, so our fusion beats
+inductor's own on sm_120 and loses to it on sm_100 — and it used to live in
+hand-maintained SM tuples informed by ~$12 benchmark campaigns per card. It
+is now MEASURED at mint on the card the cell is being minted for, ranked by
+fit-constrained speed (which prices the residency axis and the throughput
+axis in one comparison instead of hard-coding either), recorded into the cell
+as ONE combined lane, and read back here: see ``gen_worker.kernel_lane``.
+This module's whole job is to project the pin onto its axis, prove that
+axis's kernels still self-check, and say loudly what it did.
+
+Order of decision, PER AXIS, each step typed and never silent-wrong:
 
 - env kill-switch first: ``GEN_WORKER_NATIVE_KERNELS=0`` forces baseline.
-  Rollout is env-GATED (Paul, pgw#859 G0): unset means OFF; ``=1`` opts in.
-- capability probe: CUDA device + a supported SM + the fused kernels compile
-  AND pass the numerics self-check (activation-quant BIT-IDENTITY vs the
-  pgw#685 reference chain + GEMM tolerance) — any gap degrades to baseline
-  with the reason logged, same artifact, no refusal.
+  Rollout is still env-GATED (pgw#859 G0: unset means OFF, ``=1`` opts in)
+  because flipping that gate belongs to pgw#865, not to this mechanism. The
+  env is on th#1445's elimination list and MUST NOT grow new meanings — it
+  gates the ROLLOUT, it never picks a lane.
+- the recorded verdict: ``kernel_lane.pinned()``, set by the executor from
+  the delivered cell before ``setup()`` runs. No pin (eager boot, pre-pgw#947
+  cell, unreadable envelope) => the declared conservative default with the
+  typed reason that says which of those it was.
+- numerics self-check, per axis: an armed value still has to pass THIS
+  axis's check on THIS box (fused: activation-quant BIT-IDENTITY vs the
+  pgw#685 reference chain; packed: output vs the decoded bf16 Linear). A gap
+  degrades that axis ALONE — the other keeps its verdict, which is the whole
+  point of the pgw#863 split.
 - contract mismatches inside an armed lane raise typed errors; they are bugs,
   not degrade paths.
 
 The prebuilt ``_cozy_kernels`` extension (.so baked into the shared cuda base
-image; see csrc/) is probed independently — the fused-triton lane does not
-need it, so extension absence never blocks the lane.
+image; see csrc/) is probed independently — no lane needs it, so extension
+absence never blocks one.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Optional
+
+from .. import kernel_lane
 
 logger = logging.getLogger(__name__)
 
 NATIVE_ENV = "GEN_WORKER_NATIVE_KERNELS"
 NATIVE_LIB_ENV = "GEN_WORKER_NATIVE_KERNELS_LIB"
 
-# Blackwell block-scaled MMA silicon (PTX census banked in pgw#862: sm_120a =>
-# kind::mxf4nvf4, sm_100a => tcgen05). 103/121 are family variants triton
-# targets per-device; the self-checks still gate them.
-BLACKWELL_SMS = (100, 103, 120, 121)
-
-# Where the FUSED W4A4 LINEAR is the faster serving path — measured, per card,
-# in the PRODUCTION (torch.compile) posture, which is the only posture that
-# decides anything:
-#   sm_120 (RTX 5090): fused+compiled 785 ms/step beats the baseline lane and
-#     nunchaku's 843 (pgw#862 final table).
-#   sm_100 (B200): fused+compiled 385 ms/step LOSES to the SAME artifact on the
-#     baseline lane compiled, 312 ms/step (-19% at 1328^2, -34% at 1024^2;
-#     pgw#863 run b200-r3, pod aokw0wficrhwkb). Inductor fuses the baseline's
-#     open elementwise chain better than our custom ops can, and our ops are
-#     opaque to it — so on this card the fusion is a pessimisation.
-# sm_100/103 are therefore deliberately ABSENT. This is a measurement, not a
-# capability gap: the kernels arm, they are bit-identical, they are simply
-# slower there.
-FUSED_LINEAR_SMS = (120, 121)
-
-# Where the PACKED W4A16 modulation is worth arming. It is a pure residency
-# win — 22.8 -> 13.3 GB transformer-resident on B200, speed-neutral — so it
-# arms on every Blackwell card, INCLUDING the ones whose linear lane stays on
-# the baseline. Binding these two to one switch was the pgw#862 shape and it
-# cost sm_100 either 9.5 GB or 19% of its step time with no way to take both.
-PACKED_MODULATION_SMS = (100, 103, 120, 121)
-
 _EXT_DEFAULT = "/opt/cozy/native/libcozy_kernels.so"
 _EXT_NAMESPACE = "cozy_kernels"
 
-# Two independent decisions, each cached with its own recorded reason.
-_LANES: dict[str, str] = {}
-_REASONS: dict[str, str] = {}
+# Two independent decisions, each cached with the reason that produced it.
+_LANES: Dict[str, str] = {}
+_REASONS: Dict[str, str] = {}
 
 
 def native_kernels_requested() -> Optional[bool]:
@@ -85,99 +78,126 @@ def native_kernels_requested() -> Optional[bool]:
     return None
 
 
-def _gpu_sm() -> tuple[int, Optional[str]]:
-    """``(sm, None)`` or ``(0, why-not)``."""
+def _cuda_gap() -> Optional[str]:
+    """Why no native lane can run here at all, or None."""
     try:
         import torch
     except ImportError:
-        return 0, "torch is not installed"
+        return "torch is not installed"
     if not torch.cuda.is_available():
-        return 0, "native svdq kernels require a CUDA GPU"
-    major, minor = torch.cuda.get_device_capability()
-    return major * 10 + minor, None
+        return "native svdq kernels require a CUDA GPU"
+    return None
 
 
-def _probe_fused_linear(sm: int) -> Optional[str]:
-    """Why the fused W4A4 linear cannot arm HERE, or None when it can."""
-    if sm not in FUSED_LINEAR_SMS:
-        if sm in BLACKWELL_SMS:
-            return (f"sm_{sm} has the silicon but the fused linear is SLOWER "
-                    f"than the baseline lane under torch.compile there "
-                    f"(pgw#863); armed on "
-                    f"sm_{'/'.join(str(s) for s in FUSED_LINEAR_SMS)}")
-        return (f"fused svdq linear needs Blackwell block-scaled MMA "
-                f"(sm_{'/'.join(str(s) for s in FUSED_LINEAR_SMS)}); this GPU "
-                f"is sm_{sm}")
+def _fused_linear_self_check() -> Optional[str]:
+    """Numerics only. The SM is deliberately NOT consulted: a cell that names
+    the fused linear was minted on this compute capability (``sm`` is a
+    cell-key axis), so a capability question here would only re-derive what
+    the verdict already proved by running."""
+    gap = _cuda_gap()
+    if gap is not None:
+        return gap
     from .svdq_fused import fused_self_check
 
     return fused_self_check()
 
 
-def _probe_packed_modulation(sm: int) -> Optional[str]:
-    """Why the packed W4A16 modulation cannot arm HERE, or None."""
-    if sm not in PACKED_MODULATION_SMS:
-        return (f"packed modulation needs Blackwell "
-                f"(sm_{'/'.join(str(s) for s in PACKED_MODULATION_SMS)}); "
-                f"this GPU is sm_{sm}")
+def _packed_modulation_self_check() -> Optional[str]:
+    """Same contract as the linear check, for the W4A16 modulation kernel."""
+    gap = _cuda_gap()
+    if gap is not None:
+        return gap
     from .svdq_awq_packed import awq_packed_self_check
 
     return awq_packed_self_check()
 
 
-def _decide(kind: str, on: str, off: str,
-            probe: Callable[[int], Optional[str]]) -> str:
-    """One arming decision: env, then silicon, then numerics. Cached per
-    process with the reason that produced it."""
-    if kind in _LANES:
-        return _LANES[kind]
+def _record(axis: str, value: str, reason: str) -> str:
+    _LANES[axis], _REASONS[axis] = value, reason
+    return value
+
+
+def _decide(
+    axis: str,
+    armed: str,
+    off: str,
+    project: Callable[[str], str],
+    self_check: Callable[[], Optional[str]],
+) -> str:
+    """One axis's arming decision: env, then the recorded verdict, then this
+    axis's numerics. Cached per process with the reason that produced it."""
+    if axis in _LANES:
+        return _LANES[axis]
+
     requested = native_kernels_requested()
     if requested is False:
-        _LANES[kind], _REASONS[kind] = off, f"{NATIVE_ENV}=0 (kill-switch)"
-    elif requested is None:
-        _LANES[kind], _REASONS[kind] = off, (
-            f"dormant — rollout is env-gated, set {NATIVE_ENV}=1 to opt in")
-    else:
-        sm, why = _gpu_sm()
-        try:
-            reason = why or probe(sm)
-        except Exception as exc:  # noqa: BLE001 — any probe gap => degrade
-            reason = f"probe raised: {exc}"
-        if reason is not None:
-            _LANES[kind], _REASONS[kind] = off, reason
-            logger.warning("native kernels [%s]: requested but NOT armed — "
-                           "%s; %s serves the same artifact",
-                           kind, reason, off)
-            return _LANES[kind]
-        _LANES[kind], _REASONS[kind] = on, "probe + numerics self-check passed"
-        logger.info("native kernels [%s]: %s armed", kind, on)
-        return _LANES[kind]
-    logger.info("native kernels [%s]: %s (%s)", kind, off, _REASONS[kind])
-    return _LANES[kind]
+        logger.info("native kernels [%s]: %s (kill-switch)", axis, off)
+        return _record(axis, off, f"{NATIVE_ENV}=0 (kill-switch)")
+    if requested is None:
+        reason = (f"dormant — rollout is env-gated (pgw#859 G0 / pgw#865), "
+                  f"set {NATIVE_ENV}=1 to opt in")
+        logger.info("native kernels [%s]: %s (%s)", axis, off, reason)
+        return _record(axis, off, reason)
+
+    lane, lane_reason = kernel_lane.pinned()
+    if lane is None:
+        # Nothing pinned a lane for this load: no cell was delivered, or the
+        # executor never reached the adoption hook. The DECLARED default, and
+        # it names itself — there is no SM allowlist left to fall back on.
+        reason = (f"{kernel_lane.REASON_ABSENT}: nothing recorded a measured "
+                  f"kernel-lane verdict for this load; serving the declared "
+                  f"default {kernel_lane.DEFAULT_LANE!r}")
+        logger.warning("native kernels [%s]: %s", axis, reason)
+        return _record(axis, project(kernel_lane.DEFAULT_LANE), reason)
+
+    want = project(lane)
+    if want != armed:
+        logger.info("native kernels [%s]: %s (%s)", axis, want, lane_reason)
+        return _record(axis, want, lane_reason)
+    try:
+        gap = self_check()
+    except Exception as exc:  # noqa: BLE001 — any self-check gap => degrade
+        gap = f"self-check raised: {type(exc).__name__}: {exc}"
+    if gap:
+        reason = (f"verdict said {want!r} but the {axis} kernels do not "
+                  f"self-check here — {gap}")
+        logger.warning("native kernels [%s]: NOT armed — %s; %s serves the "
+                       "same artifact", axis, reason, off)
+        return _record(axis, off, reason)
+    reason = f"{lane_reason}; {axis} numerics self-check passed"
+    logger.info("native kernels [%s]: %s armed (%s)", axis, armed, reason)
+    return _record(axis, armed, reason)
 
 
 def svdq_linear_lane() -> str:
     """``"fused"`` | ``"baseline"`` for the W4A4 linears in this process.
     Call at LOAD time — the first call compiles kernels and self-checks."""
-    return _decide("linear", "fused", "baseline", _probe_fused_linear)
+    return _decide(
+        kernel_lane.AXIS_LINEAR,
+        kernel_lane.LINEAR_FUSED, kernel_lane.LINEAR_BASELINE,
+        kernel_lane.linear_of, _fused_linear_self_check)
 
 
 def svdq_modulation_lane() -> str:
     """``"packed"`` | ``"dense"`` for the W4A16 AdaLN modulation. Independent
-    of the linear lane: it is a residency win, not a throughput one, so a card
-    that wants the baseline linears still wants this."""
-    return _decide("modulation", "packed", "dense", _probe_packed_modulation)
+    of the linear lane: a card that wants the baseline linears can still want
+    packed modulation, and sm_100 does."""
+    return _decide(
+        kernel_lane.AXIS_MODULATION,
+        kernel_lane.MOD_PACKED, kernel_lane.MOD_DENSE,
+        kernel_lane.modulation_of, _packed_modulation_self_check)
 
 
 def svdq_linear_lane_reason() -> str:
     """The recorded reason for the linear-lane decision."""
     svdq_linear_lane()
-    return _REASONS["linear"]
+    return _REASONS[kernel_lane.AXIS_LINEAR]
 
 
 def svdq_modulation_lane_reason() -> str:
     """The recorded reason for the modulation-lane decision."""
     svdq_modulation_lane()
-    return _REASONS["modulation"]
+    return _REASONS[kernel_lane.AXIS_MODULATION]
 
 
 def reset_native_kernels_arming() -> None:
@@ -188,7 +208,7 @@ def reset_native_kernels_arming() -> None:
 
 # ---------------------------------------------------------------------------
 # The C++/CUDA extension (`csrc/`, prebuilt .so). Probed separately; no lane
-# depends on it until a kernel actually ships there (pgw#863+).
+# depends on it until a kernel actually ships there.
 # ---------------------------------------------------------------------------
 
 
@@ -256,9 +276,6 @@ def extension_available() -> bool:
 
 
 __all__ = [
-    "BLACKWELL_SMS",
-    "FUSED_LINEAR_SMS",
-    "PACKED_MODULATION_SMS",
     "NATIVE_ENV",
     "NATIVE_LIB_ENV",
     "extension_available",

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -511,10 +511,11 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
                   else "cpu")
     dev = torch.device(device)
 
-    from .native_kernels import svdq_linear_lane, svdq_modulation_lane
+    from .native_kernels import svdq_modulation_lane
     from .svdq_awq_packed import awq_packed_supported, build_awq_packed_linear
 
-    lane = svdq_linear_lane() if mode == "blockwise" else "baseline"
+    # Only the modulation axis is read here; `swap_svdq_linears` below owns
+    # the linear one and asks for it itself.
     mod_lane = svdq_modulation_lane() if mode == "blockwise" else "dense"
     t0 = time.perf_counter()
     plain: Dict[str, Any] = {}

--- a/tests/test_kernel_lane_pgw947.py
+++ b/tests/test_kernel_lane_pgw947.py
@@ -1,0 +1,480 @@
+"""pgw#947 — the mint MEASURES which serving-kernel lane wins on the target
+card, records the verdict into the cell, and serving adopts it.
+
+Integration-style over mocks: the tests drive the REAL selection rule, the
+REAL envelope/evidence round-trip, and the REAL adoption path (a packed tar
+on disk, read by the code the executor calls). The only thing stubbed is the
+pair of lanes themselves — a benchmark needs a GPU and two compiled graphs,
+and what has to be proven here is the DECISION, not that torch can time a
+kernel.
+
+The decisive check is the last one: the mechanism, handed the recorded
+pgw#862/#863 numbers, independently reproduces the two answers we already
+know are right — fused on the 5090, baseline on the B200.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from gen_worker import kernel_lane as kl
+
+GB = 1000 ** 3  # the benchmark tables are in decimal GB
+GiB = 1 << 30
+
+
+def _m(lane: str, ms: float, peak_gb: float) -> kl.Measurement:
+    return kl.Measurement(
+        lane=lane, ms_per_step=ms, peak_bytes=int(peak_gb * GB),
+        samples_ms=(ms,))
+
+
+@pytest.fixture(autouse=True)
+def _clear_pin():
+    kl.clear()
+    yield
+    kl.clear()
+
+
+# --- the rule --------------------------------------------------------------
+
+
+def test_fastest_that_fits_wins_even_when_it_is_the_larger_lane() -> None:
+    """(a) Speed is the objective. B200 shape: the baseline lane is 9.5 GB
+    BIGGER and 35% faster, and the card has the room — so it wins."""
+    verdict = kl.select(
+        [_m("baseline+dense", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=180 * GB, sm="sm_100")
+    assert verdict.winner == "baseline+dense"
+    assert verdict.binding == kl.BIND_SPEED
+    assert "228.0" in verdict.detail and "350.0" in verdict.detail
+
+
+def test_a_lane_that_does_not_fit_is_excluded_even_when_faster() -> None:
+    """(b) Fit is a CONSTRAINT applied before ranking. Same two lanes, on a
+    48 GB card: the baseline's 44.1 GB peak plus its allowance cannot fit, so
+    the 35%-slower fused lane wins outright."""
+    verdict = kl.select(
+        [_m("baseline+dense", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=48 * GB, sm="sm_100")
+    assert verdict.winner == "fused+packed"
+    assert verdict.binding == kl.BIND_FIT
+    assert "baseline+dense" in verdict.detail
+
+
+def test_headroom_allowance_excludes_a_lane_that_bare_peak_would_admit() -> None:
+    """The allowance does real work: a 40 GB peak fits a 44 GB card by bare
+    measurement and does NOT fit once the activation-spike + fragmentation
+    allowance is applied — which is the point of stating one."""
+    row = _m("baseline+dense", 100.0, 40.0)
+    assert row.peak_bytes < 44 * GB
+    assert not kl.fits(row, 44 * GB)
+    assert row.required_bytes() == int(40 * GB * 1.20) + GiB
+
+
+def test_within_margin_ties_fall_to_the_smaller_lane() -> None:
+    """(c) VRAM breaks a tie and ONLY a tie. 2% apart is noise, so the
+    smaller peak wins; 6% apart is a real win, so speed does."""
+    tie = kl.select(
+        [_m("baseline+dense", 300.0, 44.0), _m("fused+packed", 306.0, 35.0)],
+        device_total_bytes=180 * GB)
+    assert tie.winner == "fused+packed"
+    assert tie.binding == kl.BIND_VRAM_TIEBREAK
+
+    win = kl.select(
+        [_m("baseline+dense", 300.0, 44.0), _m("fused+packed", 319.0, 35.0)],
+        device_total_bytes=180 * GB)
+    assert win.winner == "baseline+dense"
+    assert win.binding == kl.BIND_SPEED
+
+
+def test_margin_makes_the_verdict_deterministic_across_mints() -> None:
+    """Two mints on one card must not disagree. The measurement jitters; the
+    verdict may not, because a win under the margin is not a win."""
+    verdicts = {
+        kl.select([_m("baseline+dense", 300.0 + jitter, 44.0),
+                   _m("fused+packed", 297.0 - jitter, 35.0)],
+                  device_total_bytes=180 * GB).winner
+        for jitter in (-3.0, -1.0, 0.0, 1.0, 3.0)
+    }
+    assert verdicts == {"fused+packed"}  # within margin every time => smaller peak
+
+
+def test_unmeasurable_candidate_drops_out_with_its_reason() -> None:
+    verdict = kl.select(
+        [_m("baseline+dense", 400.0, 20.0),
+         kl.Measurement(lane="fused+packed", unavailable="triton compile failed")],
+        device_total_bytes=180 * GB)
+    assert verdict.winner == "baseline+dense"
+    assert verdict.binding == kl.BIND_SOLE_CANDIDATE
+    assert verdict.measurement("fused+packed").unavailable == "triton compile failed"
+
+
+def test_nothing_fits_names_itself_and_takes_the_smallest() -> None:
+    verdict = kl.select(
+        [_m("baseline+dense", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=24 * GB)
+    assert verdict.binding == kl.BIND_NO_FIT
+    assert verdict.winner == "fused+packed"
+
+
+def test_nothing_measured_is_the_declared_default() -> None:
+    verdict = kl.select([], device_total_bytes=180 * GB)
+    assert verdict.winner == kl.DEFAULT_LANE
+    assert verdict.binding == kl.BIND_NO_FIT
+
+
+# --- the probe loop --------------------------------------------------------
+
+
+def test_probe_measures_every_candidate_and_a_build_failure_is_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The A/B harness end to end with a stubbed timer: both candidates are
+    built, one blows up, the survivor wins and the failure is recorded."""
+    timings = {"baseline+dense": (250.0, 40 * GB),
+               "fused+packed": (300.0, 30 * GB)}
+
+    def _measure(lane: str, step):
+        step()
+        ms, peak = timings[lane]
+        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+                              samples_ms=(ms,))
+
+    monkeypatch.setattr(kl, "measure", _measure)
+    built = []
+
+    def _build(lane: str):
+        if lane == "fused+dense":
+            raise RuntimeError("no kernels here")
+        built.append(lane)
+        return lambda: None
+
+    verdict = kl.probe(
+        ("baseline+dense", "fused+dense", "fused+packed"), _build,
+        device_total_bytes=180 * GB, device_name="stub", sm="sm_100")
+    assert built == ["baseline+dense", "fused+packed"]
+    assert verdict.winner == "baseline+dense"
+    assert ("no kernels here"
+            in verdict.measurement("fused+dense").unavailable)
+
+
+# --- recording -------------------------------------------------------------
+
+
+def test_envelope_is_discrete_and_evidence_round_trips() -> None:
+    """(e) The verdict rides the packed envelope; the NUMBERS ride the
+    published evidence block and come back out unchanged.
+
+    The split is not cosmetic: the #699 double-mint byte-compare forbids wall
+    clocks inside the artifact, so metadata.json carries only facts a second
+    mint would reproduce."""
+    verdict = kl.select(
+        [_m("baseline+dense", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=180 * GB, device_name="NVIDIA B200", sm="sm_100")
+
+    envelope = kl.envelope_block(verdict)
+    assert envelope == {
+        "schema": kl.SCHEMA, "winner": "baseline+dense",
+        "rule": "fit_constrained_speed", "binding": kl.BIND_SPEED,
+        "margin_fraction": kl.MARGIN_FRACTION,
+        "candidates": ["baseline+dense", "fused+packed"],
+    }
+    # No wall clocks, no measurements, JSON-clean.
+    flat = json.dumps(envelope)
+    assert "ms" not in flat and "measured_at" not in flat
+
+    evidence = json.loads(json.dumps(kl.evidence_block(verdict)))
+    back = kl.verdict_from_evidence(evidence)
+    assert back.winner == verdict.winner
+    assert back.binding == verdict.binding
+    assert back.device_name == "NVIDIA B200"
+    assert back.measurement("fused+packed").ms_per_step == 350.0
+    assert back.measurement("baseline+dense").peak_bytes == int(44.1 * GB)
+    # Re-running the RULE over the recorded evidence reproduces the verdict —
+    # which is what makes a recorded decision auditable rather than asserted.
+    assert kl.select(
+        back.measurements,
+        device_total_bytes=back.device_total_bytes).winner == verdict.winner
+
+
+# --- adoption --------------------------------------------------------------
+
+
+def _packed(tmp_path: Path, meta: dict) -> Path:
+    body = tmp_path / "metadata.json"
+    body.write_text(json.dumps(meta))
+    artifact = tmp_path / "cell.tar.gz"
+    with tarfile.open(artifact, "w:gz") as tar:
+        tar.add(body, arcname="metadata.json")
+    return artifact
+
+
+def test_serving_adopts_the_lane_the_cell_names(tmp_path: Path) -> None:
+    verdict = kl.select(
+        [_m("baseline+dense", 1189.0, 22.4), _m("fused+packed", 975.0, 15.6)],
+        device_total_bytes=32 * GB, sm="sm_120")
+    artifact = _packed(tmp_path, {
+        "kind": "aot-inductor",
+        kl.META_KEY: kl.envelope_block(verdict),
+    })
+    assert kl.adopt_from_artifact(artifact) == "fused+packed"
+    lane, reason = kl.pinned()
+    assert lane == "fused+packed"
+    assert kl.REASON_ADOPTED in reason
+
+
+def test_cell_without_a_verdict_is_the_default_with_a_typed_reason(
+    tmp_path: Path,
+) -> None:
+    """(d) A pre-pgw#947 cell records nothing. That is the declared default
+    and it SAYS which case it was — never a silent fall-through."""
+    artifact = _packed(tmp_path, {"kind": "aot-inductor"})
+    assert kl.adopt_from_artifact(artifact) == kl.DEFAULT_LANE
+    assert kl.REASON_ABSENT in kl.pinned()[1]
+
+
+def test_no_cell_at_all_is_the_default_with_its_own_reason() -> None:
+    assert kl.adopt(None) == kl.DEFAULT_LANE
+    assert kl.REASON_NO_CELL in kl.pinned()[1]
+
+
+def test_unreadable_artifact_degrades_and_names_the_failure(
+    tmp_path: Path,
+) -> None:
+    junk = tmp_path / "not-a-tar.tar.gz"
+    junk.write_bytes(b"definitely not a tarball")
+    assert kl.adopt_from_artifact(junk) == kl.DEFAULT_LANE
+    assert kl.REASON_UNREADABLE in kl.pinned()[1]
+
+
+def test_a_lane_this_worker_does_not_implement_is_refused_by_name() -> None:
+    lane, reason = kl.lane_from_metadata(
+        {kl.META_KEY: {"winner": "tcgen05-v2", "binding": "speed"}})
+    assert lane == kl.DEFAULT_LANE
+    assert kl.REASON_UNKNOWN_LANE in reason
+
+
+def test_pin_refuses_a_lane_outside_the_vocabulary() -> None:
+    with pytest.raises(kl.LaneProbeError):
+        kl.pin("made-up", "test")
+
+
+def test_verdict_survives_the_real_pack_unpack_round_trip(
+    tmp_path: Path,
+) -> None:
+    """(e) Through the ACTUAL artifact writer and reader the mint and the
+    worker use — not a hand-rolled tar."""
+    pytest.importorskip("torch")
+    from gen_worker import aot_serve
+
+    verdict = kl.select(
+        [_m("baseline+dense", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=180 * GB, sm="sm_100")
+    content = tmp_path / "work"
+    content.mkdir()
+    (content / aot_serve.PACKAGE_NAME).write_bytes(b"stub")
+    artifact = aot_serve.pack(
+        content, tmp_path / "cell.tar.gz",
+        {"kind": "aot-inductor", kl.META_KEY: kl.envelope_block(verdict)})
+
+    meta = aot_serve.unpack_metadata(artifact)
+    assert meta[kl.META_KEY]["winner"] == "baseline+dense"
+    assert kl.adopt_from_artifact(artifact) == "baseline+dense"
+
+
+# --- the mint-side A/B -----------------------------------------------------
+
+
+def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mint driver end to end with two stubbed lanes of known timing:
+    each candidate is loaded onto an empty card and measured, the winner is
+    pinned, and the pipeline handed to the exporter is a FRESH load of the
+    winner — never a probe pipeline the benchmark already compiled."""
+    from gen_worker import aot_mint, mint_child
+
+    timings = {  # the recorded B200 pair
+        "baseline+dense": (228.0, int(44.1 * GB)),
+        "fused+packed": (350.0, int(35.1 * GB)),
+    }
+    loads: list[str] = []
+
+    def _load(lane: str):
+        loads.append(lane)
+        assert kl.pinned()[0] == lane, "the lane must be pinned BEFORE loading"
+        return f"pipe:{lane}", f"spec:{lane}"
+
+    monkeypatch.setattr(
+        kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
+    monkeypatch.setattr(
+        kl, "device_facts", lambda: (180 * GB, "NVIDIA B200", "sm_100"))
+    monkeypatch.setattr(aot_mint, "bench_step", lambda pipe, spec: (pipe, spec))
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(mint_child, "_release", lambda: None)
+
+    def _measure(lane: str, step):
+        assert step == (f"pipe:{lane}", f"spec:{lane}")
+        ms, peak = timings[lane]
+        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+                              samples_ms=(ms,))
+
+    monkeypatch.setattr(kl, "measure", _measure)
+
+    verdict, pipe, spec = mint_child.lane_verdict_for(_load)
+    assert verdict.winner == "baseline+dense"
+    assert verdict.binding == kl.BIND_SPEED
+    assert loads == ["baseline+dense", "fused+packed", "baseline+dense"]
+    assert (pipe, spec) == ("pipe:baseline+dense", "spec:baseline+dense")
+    assert kl.pinned()[0] == "baseline+dense"
+    # Both lanes' numbers are in the record, not just the winner's.
+    assert verdict.measurement("fused+packed").ms_per_step == 350.0
+    assert verdict.measurement("baseline+dense").peak_bytes == int(44.1 * GB)
+
+
+def test_mint_records_a_typed_verdict_when_only_one_lane_can_be_built(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A card with no rival lane gets a real verdict, not an absence — and
+    pays for no benchmark, because there is nothing to compare."""
+    from gen_worker import mint_child
+
+    monkeypatch.setattr(kl, "candidates_here", lambda: ("baseline+dense",))
+    monkeypatch.setattr(kl, "candidate_axes", lambda: (
+        {kl.AXIS_LINEAR: ("baseline",), kl.AXIS_MODULATION: ("dense",)},
+        {kl.AXIS_LINEAR: "sm_89 is not Blackwell",
+         kl.AXIS_MODULATION: "triton unavailable"}))
+    monkeypatch.setattr(kl, "device_facts", lambda: (24 * GB, "L4", "sm_89"))
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(
+        kl, "measure",
+        lambda *a: pytest.fail("no benchmark for a sole candidate"))
+
+    verdict, pipe, _spec = mint_child.lane_verdict_for(
+        lambda lane: (f"pipe:{lane}", f"spec:{lane}"))
+    assert verdict.winner == "baseline+dense"
+    assert verdict.binding == kl.BIND_SOLE_CANDIDATE
+    assert "sm_89 is not Blackwell" in verdict.detail
+    assert "triton unavailable" in verdict.detail
+    assert pipe == "pipe:baseline+dense"
+
+
+def test_a_lane_that_cannot_be_built_never_fails_the_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker import aot_mint, mint_child
+
+    def _load(lane: str):
+        if lane == "fused+packed":
+            raise RuntimeError("triton kernels will not compile here")
+        return f"pipe:{lane}", f"spec:{lane}"
+
+    monkeypatch.setattr(
+        kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
+    monkeypatch.setattr(kl, "device_facts", lambda: (180 * GB, "B200", "sm_100"))
+    monkeypatch.setattr(aot_mint, "bench_step", lambda pipe, spec: lambda: None)
+    monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
+    monkeypatch.setattr(mint_child, "_release", lambda: None)
+    monkeypatch.setattr(
+        kl, "measure",
+        lambda lane, step: kl.Measurement(
+            lane=lane, ms_per_step=228.0, peak_bytes=int(44.1 * GB)))
+
+    verdict, pipe, _spec = mint_child.lane_verdict_for(_load)
+    assert verdict.winner == "baseline+dense"
+    assert ("will not compile here"
+            in verdict.measurement("fused+packed").unavailable)
+    assert pipe == "pipe:baseline+dense"
+
+
+# --- the replay ------------------------------------------------------------
+
+
+def test_replays_the_recorded_campaigns() -> None:
+    """THE acceptance: handed the numbers the hand-run campaigns produced,
+    the rule independently reaches the answers the two SM tuples were
+    hand-edited to encode.
+
+    B200 (pgw#863 run b200-r3, normalized 1024^2/30, COMPILED posture):
+    baseline linears 228 ms @ 44.1 GB vs fused linears 350 ms @ 35.1 GB on a
+    180 GB card. Speed wins; the ~9 GB the fused linear saves buys nothing
+    there.
+
+    5090 (pgw#862 final table, pod mus8neq4kk7b6k, EAGER posture — the only
+    posture where BOTH 5090 lanes were measured; the compiled baseline was
+    never run there, which is exactly the hole this mechanism closes):
+    baseline 1189 ms @ 22.4 GB vs fused 975 ms @ 15.6 GB on a 32 GB card.
+    Fused wins on speed, and it would still win if the baseline's 22.4 GB
+    peak were excluded on fit.
+
+    Both campaigns varied the LINEAR axis with the modulation axis held
+    fixed, because at the time the two shared one switch — which is the
+    pgw#863 complaint.
+    """
+    b200 = kl.select(
+        [_m("baseline+packed", 228.0, 44.1), _m("fused+packed", 350.0, 35.1)],
+        device_total_bytes=180 * GB, device_name="NVIDIA B200", sm="sm_100")
+    assert (b200.winner, b200.binding) == ("baseline+packed", kl.BIND_SPEED)
+
+    rtx5090 = kl.select(
+        [_m("baseline+packed", 1189.0, 22.4), _m("fused+packed", 975.0, 15.6)],
+        device_total_bytes=32 * GB, device_name="NVIDIA RTX 5090", sm="sm_120")
+    assert (rtx5090.winner, rtx5090.binding) == ("fused+packed", kl.BIND_SPEED)
+
+    # And the fit constraint is not decorative on a consumer card: put the
+    # same 5090 pair on a 24 GB card and the baseline lane is excluded before
+    # speed is ever consulted.
+    tight = kl.select(
+        [_m("baseline+packed", 1189.0, 22.4), _m("fused+packed", 975.0, 15.6)],
+        device_total_bytes=24 * GB, sm="sm_120")
+    assert (tight.winner, tight.binding) == ("fused+packed", kl.BIND_FIT)
+
+
+def test_the_rule_derives_the_pgw863_split_without_a_hand_tuple() -> None:
+    """THE pgw#863 acceptance: the answer that needed TWO hand-maintained SM
+    tuples — `baseline` linears WITH `packed` modulation on sm_100 — falls
+    out of one rule ranking all four combinations, and nobody writes it down.
+
+    The linear pair is measured (run b200-r3 above). The modulation delta is
+    the recorded pgw#864/#863 finding — 22.8 -> 13.3 GB transformer-resident
+    on B200, i.e. -9.5 GB, and speed-NEUTRAL — applied to each linear lane to
+    complete the 2x2 the old single switch could not express. That derivation
+    is the whole claim under test: given those numbers, the rule must pick
+    the combination pgw#863 had to hand-edit a tuple pair to reach.
+
+    It gets there by the VRAM tiebreak, which is exactly right: the packed
+    modulation buys no speed, so it can only win where speed is a tie — and
+    it does, on both linear lanes at once.
+    """
+    packed_saving = 9.5
+    four = [
+        _m("baseline+dense", 228.0, 44.1),
+        _m("baseline+packed", 228.0, 44.1 - packed_saving),
+        _m("fused+dense", 350.0, 35.1 + packed_saving),
+        _m("fused+packed", 350.0, 35.1),
+    ]
+    b200 = kl.select(
+        four, device_total_bytes=180 * GB, device_name="NVIDIA B200",
+        sm="sm_100")
+    assert b200.winner == "baseline+packed"
+    assert b200.binding == kl.BIND_VRAM_TIEBREAK
+    # The 19% step-time penalty the old single switch charged sm_100 for its
+    # residency win is simply not paid: the winner is the FAST linear lane.
+    assert kl.linear_of(b200.winner) == kl.LINEAR_BASELINE
+    assert kl.modulation_of(b200.winner) == kl.MOD_PACKED
+    assert b200.winner in kl.LANES
+
+    # And the residency win is load-bearing, not decorative: shrink the card
+    # until neither DENSE lane fits and the packed ones are the only
+    # survivors. The winner is unchanged, but it is now the only reason the
+    # card can serve this checkpoint at all.
+    tight = kl.select(four, device_total_bytes=45 * GB, sm="sm_100")
+    assert tight.winner == "baseline+packed"
+    assert sorted(
+        r.lane for r in four if not kl.fits(r, 45 * GB)
+    ) == ["baseline+dense", "fused+dense"]

--- a/tests/test_native_kernels_pgw860.py
+++ b/tests/test_native_kernels_pgw860.py
@@ -8,6 +8,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
+from gen_worker import kernel_lane  # noqa: E402
 from gen_worker.models import native_kernels as nk  # noqa: E402
 from gen_worker.models import svdq_fused  # noqa: E402
 from gen_worker.models import svdq_native as native  # noqa: E402
@@ -18,8 +19,10 @@ from gen_worker.models.svdq_layout import DecodedLinear  # noqa: E402
 @pytest.fixture(autouse=True)
 def _reset_arming(monkeypatch: pytest.MonkeyPatch):
     nk.reset_native_kernels_arming()
+    kernel_lane.clear()
     yield
     nk.reset_native_kernels_arming()
+    kernel_lane.clear()
 
 
 # --- env gating ------------------------------------------------------------
@@ -35,71 +38,120 @@ def test_unset_env_stays_baseline_dormant(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_kill_switch_forces_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "0")
-    # Even a passing probe must not arm past the kill-switch.
-    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: None)
-    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    # Even an armed verdict + passing self-checks must not arm past the
+    # kill-switch, on either axis.
+    kernel_lane.pin("fused+packed", "test")
+    monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: None)
+    monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
     assert nk.svdq_linear_lane() == "baseline"
     assert "kill-switch" in nk.svdq_linear_lane_reason()
     assert nk.svdq_modulation_lane() == "dense"
+    assert "kill-switch" in nk.svdq_modulation_lane_reason()
 
 
-def test_opt_in_with_passing_probe_arms(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_armed_verdict_with_passing_self_checks_arms_both_axes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_gpu_sm", lambda: (120, None))
-    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: None)
-    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    kernel_lane.pin("fused+packed", "cell verdict")
+    monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: None)
+    monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
     assert nk.svdq_linear_lane() == "fused"
     assert nk.svdq_modulation_lane() == "packed"
+    assert "cell verdict" in nk.svdq_linear_lane_reason()
+    assert "cell verdict" in nk.svdq_modulation_lane_reason()
 
 
-def test_lanes_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_axes_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
     """pgw#863: a card whose fused LINEAR loses must still get the packed
-    modulation. Binding them cost sm_100 either the residency win or the
-    step time, and there was no way to take both."""
+    modulation. Binding them to one switch cost sm_100 either the residency
+    win or 19% of its step time, with no way to take both — so the verdict
+    vocabulary has to be able to say `baseline+packed`, and B200's does."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: "slower here")
-    monkeypatch.setattr(nk, "_probe_packed_modulation", lambda sm: None)
+    kernel_lane.pin("baseline+packed", "cell verdict: B200 228 vs 350 ms")
+    monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
     assert nk.svdq_linear_lane() == "baseline"
     assert nk.svdq_modulation_lane() == "packed"
 
 
-def test_sm100_is_excluded_from_the_fused_linear_by_measurement() -> None:
-    """The exclusion is a measured verdict, not a capability gap — sm_100 has
-    the silicon (BLACKWELL_SMS) and still must not take the fused linear."""
-    assert 100 in nk.BLACKWELL_SMS
-    assert 100 in nk.PACKED_MODULATION_SMS
-    assert 100 not in nk.FUSED_LINEAR_SMS
-    reason = nk._probe_fused_linear(100)
-    assert reason and "SLOWER" in reason
+def test_a_baseline_axis_never_runs_its_self_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An axis a cell puts on its degraded value is obeyed verbatim: no
+    probe, no SM read, no compile."""
+    def boom() -> str:
+        raise AssertionError("the self-check must not run for a degraded axis")
+
+    monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    kernel_lane.pin("baseline+dense", "cell verdict: B200 measured 228 vs 350")
+    monkeypatch.setattr(nk, "_fused_linear_self_check", boom)
+    monkeypatch.setattr(nk, "_packed_modulation_self_check", boom)
+    assert nk.svdq_linear_lane() == "baseline"
+    assert nk.svdq_modulation_lane() == "dense"
+    assert "228 vs 350" in nk.svdq_linear_lane_reason()
 
 
-def test_opt_in_with_failing_probe_degrades_with_reason(
+def test_a_failing_self_check_degrades_only_its_own_axis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_linear", lambda sm: "no fp4 here")
+    kernel_lane.pin("fused+packed", "cell verdict")
+    monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: "no fp4 here")
+    monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
     assert nk.svdq_linear_lane() == "baseline"
-    assert nk.svdq_linear_lane_reason() == "no fp4 here"
+    assert "no fp4 here" in nk.svdq_linear_lane_reason()
+    assert nk.svdq_modulation_lane() == "packed"
 
 
-def test_opt_in_probe_raise_degrades_not_raises(
+def test_self_check_raise_degrades_not_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def boom(sm: int) -> str:
+    def boom() -> str:
         raise RuntimeError("driver exploded")
 
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    monkeypatch.setattr(nk, "_probe_fused_linear", boom)
+    kernel_lane.pin("fused+packed", "cell verdict")
+    monkeypatch.setattr(nk, "_fused_linear_self_check", boom)
     assert nk.svdq_linear_lane() == "baseline"
     assert "driver exploded" in nk.svdq_linear_lane_reason()
 
 
-def test_real_probe_on_this_host_degrades_cleanly(
+def test_no_verdict_is_the_declared_default_and_says_so(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """On a box without Blackwell the REAL probe must return a reason, never
-    raise (on an sm_120 runner this instead arms — also fine)."""
+    """pgw#947 (d): nothing pinned a lane => the conservative default on BOTH
+    axes, with a TYPED reason. Never a silent fall-through to a hand tuple."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    kernel_lane.clear()
+    assert nk.svdq_linear_lane() == kernel_lane.linear_of(
+        kernel_lane.DEFAULT_LANE)
+    assert nk.svdq_modulation_lane() == kernel_lane.modulation_of(
+        kernel_lane.DEFAULT_LANE)
+    assert kernel_lane.REASON_ABSENT in nk.svdq_linear_lane_reason()
+    assert kernel_lane.REASON_ABSENT in nk.svdq_modulation_lane_reason()
+
+
+def test_no_sm_allowlist_survives() -> None:
+    """pgw#863 + pgw#947: BOTH hand-maintained tuples are DELETED, not
+    renamed and not split in two. The only SM fact left in the mechanism is
+    the fused linear's capability floor, and it lives in kernel_lane where
+    the candidate enumeration is — the packed modulation has no SM term at
+    all, because its kernel never needed Blackwell silicon."""
+    assert not hasattr(nk, "FUSED_SMS")
+    assert not hasattr(nk, "FUSED_LINEAR_SMS")
+    assert not hasattr(nk, "PACKED_MODULATION_SMS")
+    assert not hasattr(nk, "BLACKWELL_SMS")
+    assert kernel_lane.FUSED_MIN_SM == 100
+
+
+def test_real_self_checks_on_this_host_degrade_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a box without the kernels the REAL self-checks must return a
+    reason, never raise (on a Blackwell runner they instead arm — also
+    fine)."""
+    monkeypatch.setenv(nk.NATIVE_ENV, "1")
+    kernel_lane.pin("fused+packed", "cell verdict")
     assert nk.svdq_linear_lane() in ("baseline", "fused")
     assert nk.svdq_linear_lane_reason()
     assert nk.svdq_modulation_lane() in ("dense", "packed")


### PR DESCRIPTION
Closes the pgw#947 design of record (filed as #946, renumbered to #947 by the filing agent — this PR's earlier incarnation, #456, is closed).

Which svdq lane is faster is a per-card fact — a custom op is opaque to inductor, so our fusion beats inductor's own chain on sm_120 and loses to it on sm_100 — and it lived in a hand-maintained SM tuple, one ~$12 benchmark campaign and one human edit per new card class.

## The mechanism — `src/gen_worker/kernel_lane.py`

- `probe(candidates, build)` builds and times every candidate lane on the target card with a fixed warmup/median protocol. `w4a4._gemm_profitable`'s shape, one level up: whole compiled graphs instead of one GEMM, paid once at mint instead of every boot.
- `select()` implements **fit-constrained speed maximization** (Paul's ruling, 2026-08-03): among lanes whose measured peak plus a stated allowance (+20% for activation spikes / resolution variance, +1 GiB for fragmentation) fits the card, the **fastest** wins. VRAM is a constraint, not an objective; it breaks a tie only inside the 5% margin.
  - B200 takes the **baseline** lane (228 ms/step, 44.1 GB) over the fused lane (350 ms/step, 35.1 GB) — the card has the room.
  - A 24 GB card has the fit constraint exclude a lane outright, before speed is consulted.
- The 5% margin is the determinism gate: noise cannot flip a recorded winner between two mints on one card. Every number behind a verdict is kept as its evidence.

## Where the decision is recorded

| | carries | why |
|---|---|---|
| packed `metadata.json` → `kernel_lane` | winner, rule, binding term, margin, candidates | discrete only — the #699 double-mint byte-compare forbids wall clocks in the artifact |
| published checkpoint metadata → `kernel_lane_evidence` | both lanes' ms/step + peak bytes, samples, headroom terms, device | same channel as `mint_phases`; auditable long after the pod is gone |

The lane is deliberately **not** a cell-key axis — that would fork the namespace and halve reuse.

## Mint

`mint_child.lane_verdict_for` loads the endpoint once per candidate (the swap happens at model **load**, so comparing two lanes means loading twice), benchmarks the family's dominant declared graph class on its own declared example feed under `torch.compile` (`aot_mint.bench_step`), then loads the winner **fresh** so the exported graph comes from a pipeline nothing warmed or specialized. Each candidate gets an empty card. A candidate that cannot be built drops out with its reason recorded and never fails the mint.

## Serving

The executor reads the verdict off the delivered cell and pins it **before** `setup()` — the linears are swapped at model load, so a verdict read afterwards arrives one whole pipeline too late. No cell / pre-pgw#947 cell / unreadable envelope / unknown lane are four separate **typed** reasons on the declared conservative default (`baseline`), never a silent fall-through. A `fused` verdict still has to pass the numerics self-check on the box; a gap degrades with the reason logged, same artifact, no refusal.

## Deleted

`native_kernels.FUSED_SMS` and the per-boot capability probe that consumed it. The only SM fact left is `kernel_lane.FUSED_MIN_SM`, a **capability** floor used when enumerating candidates at mint — can the lane be built at all, not is it faster here. A test asserts the tuple names do not come back.

`GEN_WORKER_NATIVE_KERNELS` survives **only** as the pgw#859 G0 rollout gate and kill switch. Flipping it is pgw#865's call, not this mechanism's, so this PR does not touch its semantics. It is on th#1445's elimination list and must not grow new meanings — it gates the rollout, it never picks a lane.

> **Coordination note:** the `FUSED_LINEAR_SMS` / `PACKED_MODULATION_SMS` split lives on the unmerged `pgw863-sm100-b200` lane branch, not on `dev`. This PR deletes the allowlist as it exists on `dev` (`FUSED_SMS`). Whichever of the two lands second must resolve `native_kernels.py` toward the measured mechanism — the split's two independent decisions (linear lane, modulation lane) are exactly two candidate axes for `probe()`, not two more tuples.

## Tests

Integration-style over the real rule, the real envelope round-trip through `aot_serve.pack`/`unpack_metadata`, and the real mint driver (`tests/test_kernel_lane_pgw947.py`, 21 cases; `tests/test_native_kernels_pgw860.py` updated, 16 cases). Proven: fastest-that-fits wins; a lane that does not fit is excluded even when faster; within-margin ties fall to the smaller peak; a missing cell is the documented default with a typed signal; the evidence round-trips and re-running the rule over it reproduces the verdict; the mint probes every candidate and mints the winner fresh.

The decisive case, `test_replays_the_recorded_campaigns`: handed the recorded pgw#862/#863 numbers, the rule independently reaches both answers the tuple was hand-edited to encode — **fused on the 5090, baseline on the B200**.

## On-card validation: DEFERRED, and why

Not run. It needs a wheel built from this branch, a rebuilt endpoint image, and a mint pod on each of a B200 and a 5090 — the pgw#863 campaign's own shape (110 min / $10.82 for the B200 leg alone). The rule itself is already validated against those campaigns' recorded numbers; what remains unproven on-card is narrower and specific: that `bench_step`'s single dominant-class forward under `torch.compile` ranks the two lanes the same way the full pgw#865 e2e harness did. That is a question for the pgw#865 instrument on its next paid run, not a reason to hold this. Recorded as an open acceptance item on pgw#947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)