### PR TITLE
Release gen-worker 0.91.4: explicit Slot family intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.91.4 (2026-08-03) — **endpoint authors can explicitly keep a non-root model slot inside its architecture-family gates**
+
 - **pgw#766 / th#1566: `Slot(family=...)` makes non-root model governance
   explicit.** pgw#747 correctly stopped stamping family-agnostic auxiliaries
   with a function's model family, but inferred agnosticism from the proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.91.3"
+version = "0.91.4"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.91.3"
+version = "0.91.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Outcome

Publishes the already-merged pgw#766 Slot family bridge as the first installable SDK that Qwen Image Edit and Z-Image can consume.

## Scope

- bump project and editable lock entry from 0.91.3 to 0.91.4
- move the existing pgw#766 changelog entry under the 0.91.4 heading
- no source, dependency, or protocol changes

## Evidence

- PyPI current version checked before choosing the version: 0.91.3; 0.91.4 is unused and no v0.91.4 tag exists
- `uv lock --check`: clean
- `uv build`: produced 0.91.4 sdist and wheel with METADATA Version 0.91.4
- pgw#766 commit `3be60d1` is an ancestor through master merge `63c93bd`; source/tests/scripts trees are identical to that previously green head
- exact release-tree full CI passed: https://github.com/cozy-creator/python-gen-worker/actions/runs/30847566437
- the earlier exact-tree run had one isolated v2 boot timeout; the unchanged focused test passed locally and the unchanged full rerun passed v1, v2, typing, lint, guards, and package build
- current master is still `7429f849`; the potential merge tree is exactly the green head tree `d676ce623d64d8ea6fca35ffb57b54bb066b7a34`

## Release gate

Merge into master with the reviewed head, then re-check the actual merge tree equals the green CI tree before tagging `v0.91.4`. `publish.yml` must enforce exact-tree CI provenance and the built-wheel contract. After PyPI publication, bump/relock inference-endpoints PRs #256 and #257 and update their shared CI/mypy pin once.
