### PR TITLE
pgw#865: the EDIT family on the svdq_bench instrument — qwen-image-edit-2511 measured on B200 + H100

### DIFF
--- a/scripts/svdq_bench/bench_edit_arm.py
+++ b/scripts/svdq_bench/bench_edit_arm.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""svdq runtime bench, EDIT family: ONE arm per process (pgw#865 instrument).
+
+The image+text-conditioned twin of ``bench_arm.py``. Same shapes, same
+timing/reporting contract, same executed-lane recording — so the qwen-image
+table and the qwen-image-edit table are read side by side.
+
+Arms: ``bf16`` (unquantized reference transformer) and ``fp8`` (the PUBLISHED
+``#fp8-w8a8`` flavor through the production w8a8 loader). There is no nvfp4
+arm: no 4-bit qwen-image-edit artifact exists (te#137's edit produce is
+planned, not run), and this instrument never fabricates one.
+
+Inputs are the REAL gate inputs (see edit_prompts.json provenance), verified
+by sha256 at load: a benchmark whose conditioning image is synthetic noise is
+not measuring the edit workload.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import time
+from pathlib import Path
+
+from bench_arm import StepTimer, load_bf16, load_fp8, save_webp  # noqa: F401
+
+
+def load_befores(spec: dict, before_dir: Path, log) -> dict:
+    """BEFORE image bytes, sha256-verified against the recorded gate inputs."""
+    out = {}
+    from PIL import Image
+    for r in spec["edit"]:
+        p = before_dir / r["before"]
+        raw = p.read_bytes()
+        got = hashlib.sha256(raw).hexdigest()
+        assert got == r["before_sha256"], (
+            f"{r['id']}: BEFORE {p} sha256 {got} != recorded "
+            f"{r['before_sha256']} — the conditioning input is not the one "
+            f"the gate ran on")
+        img = Image.open(io.BytesIO(raw)).convert("RGB")
+        assert list(img.size) == r["before_size"], (
+            f"{r['id']}: BEFORE size {img.size} != {r['before_size']}")
+        out[r["id"]] = img
+        log(f"BEFORE {r['id']} {p.name} {img.size} sha256={got[:16]} ok")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True, choices=["bf16", "fp8"])
+    ap.add_argument("--fp8-tree", default="")
+    ap.add_argument("--reference-tree", required=True)
+    ap.add_argument("--before-dir", default="/root/before")
+    ap.add_argument("--prompts", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--compile", action="store_true")
+    ap.add_argument("--repeat-id", default="m01")
+    ap.add_argument("--rows", default="")
+    ap.add_argument("--norm-rows", type=int, default=3)
+    ap.add_argument("--norm-shape", default="1024x1024x30x4.0")
+    args = ap.parse_args()
+
+    def log(m):
+        print(f"[edit:{args.arm}] {m}", flush=True)
+
+    import torch
+    assert torch.cuda.is_available()
+    dev = torch.cuda.get_device_name(0)
+    sm = "".join(str(x) for x in torch.cuda.get_device_capability())
+    _free, total = torch.cuda.mem_get_info()
+    log(f"device={dev} sm_{sm} torch={torch.__version__} "
+        f"vram={total / 1e9:.1f}GB")
+
+    spec = json.loads(Path(args.prompts).read_text())
+    if args.rows:
+        keep = [r.strip() for r in args.rows.split(",") if r.strip()]
+        spec["edit"] = [r for r in spec["edit"] if r["id"] in keep]
+        assert spec["edit"], f"no rows matched {keep}"
+    befores = load_befores(spec, Path(args.before_dir), log)
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t_load0 = time.perf_counter()
+    if args.arm == "bf16":
+        den, rtinfo = load_bf16(Path(args.reference_tree), log)
+    else:
+        den, rtinfo = load_fp8(Path(args.fp8_tree), log)
+    if args.compile:
+        import torch._dynamo
+        torch._dynamo.config.cache_size_limit = 32
+        den.forward = torch.compile(den.forward, dynamic=None)
+        rtinfo["compiled"] = "torch.compile(dynamic=None)"
+        log("denoiser forward compiled (production posture)")
+
+    import diffusers
+    import transformers
+    from diffusers import DiffusionPipeline
+    pipe = DiffusionPipeline.from_pretrained(
+        args.reference_tree, torch_dtype=torch.bfloat16, transformer=den)
+    assert type(pipe).__name__ == "QwenImageEditPlusPipeline", (
+        f"expected the edit pipeline, got {type(pipe).__name__}")
+    offload = total < 60e9
+    if offload:
+        pipe.enable_model_cpu_offload()
+        log("model_cpu_offload enabled (<60GB card); denoise stays on cuda")
+    else:
+        pipe = pipe.to("cuda")
+    load_s = time.perf_counter() - t_load0
+    log(f"pipeline {type(pipe).__name__} ready in {load_s:.1f}s "
+        f"diffusers={diffusers.__version__} "
+        f"transformers={transformers.__version__}")
+
+    steps, cfg = int(spec["steps"]), float(spec["true_cfg_scale"])
+    neg, (w, h) = spec["negative_prompt"], spec["resolution"]
+
+    def render_at(row, n_steps, rw, rh, rcfg):
+        timer = StepTimer()
+        g = torch.Generator(device="cuda").manual_seed(row["seed"])
+        t0 = time.perf_counter()
+        img = pipe(image=[befores[row["id"]]], prompt=row["instruction"],
+                   num_inference_steps=n_steps, width=rw, height=rh,
+                   generator=g, true_cfg_scale=rcfg, negative_prompt=neg,
+                   callback_on_step_end=timer).images[0]
+        wall = time.perf_counter() - t0
+        deltas = [timer.ts[i] - timer.ts[i - 1]
+                  for i in range(1, len(timer.ts))]
+        return img, wall, deltas
+
+    log("warmup render (4 steps, not counted)")
+    wimg, _ww, _wd = render_at(spec["edit"][0], 4, w, h, cfg)
+    save_webp(wimg, out_dir / "warmup.webp")
+    torch.cuda.reset_peak_memory_stats()
+
+    rows = []
+    for r in spec["edit"]:
+        img, wall, deltas = render_at(r, steps, w, h, cfg)
+        save_webp(img, out_dir / f"{r['id']}.webp")
+        steady = deltas[1:] if len(deltas) > 2 else deltas
+        rows.append({"id": r["id"], "seed": r["seed"], "e2e_s": wall,
+                     "steps": steps, "step_deltas": deltas,
+                     "step_mean_s": sum(steady) / len(steady)})
+        log(f"{r['id']} e2e={wall:.2f}s "
+            f"step_mean={rows[-1]['step_mean_s'] * 1000:.0f}ms")
+
+    rep_row = next((r for r in spec["edit"] if r["id"] == args.repeat_id),
+                   spec["edit"][0])
+    repeats = []
+    for i in range(args.repeats):
+        _img, wall, deltas = render_at(rep_row, steps, w, h, cfg)
+        steady = deltas[1:] if len(deltas) > 2 else deltas
+        repeats.append({"e2e_s": wall,
+                        "step_mean_s": sum(steady) / len(steady)})
+        log(f"repeat{i} {rep_row['id']} e2e={wall:.2f}s")
+
+    norm = None
+    if args.norm_rows > 0 and args.norm_shape:
+        nw, nh, nsteps, ncfg = args.norm_shape.split("x")
+        nw, nh, nsteps, ncfg = int(nw), int(nh), int(nsteps), float(ncfg)
+        log(f"normalized block {nw}x{nh} steps={nsteps} true_cfg={ncfg} "
+            f"({'2 fwd' if ncfg > 1.0 else '1 fwd'}/step)")
+        nrows = []
+        wimg2, _w2, _d2 = render_at(spec["edit"][0], 4, nw, nh, ncfg)
+        save_webp(wimg2, out_dir / "norm_warmup.webp")
+        for r in spec["edit"][:args.norm_rows]:
+            img, wall, deltas = render_at(r, nsteps, nw, nh, ncfg)
+            save_webp(img, out_dir / f"norm_{r['id']}.webp")
+            steady = deltas[1:] if len(deltas) > 2 else deltas
+            nrows.append({"id": r["id"], "e2e_s": wall,
+                          "step_mean_s": sum(steady) / len(steady)})
+            log(f"norm {r['id']} e2e={wall:.2f}s "
+                f"step_mean={nrows[-1]['step_mean_s'] * 1000:.0f}ms")
+        ne = [r["e2e_s"] for r in nrows]
+        ns = [r["step_mean_s"] for r in nrows]
+        norm = {"shape": [nw, nh], "steps": nsteps, "true_cfg_scale": ncfg,
+                "forwards_per_step": 2 if ncfg > 1.0 else 1, "rows": nrows,
+                "e2e_mean_s": sum(ne) / len(ne), "e2e_min_s": min(ne),
+                "step_mean_s": sum(ns) / len(ns),
+                "images_per_hour": 3600.0 / (sum(ne) / len(ne))}
+        log(f"NORM e2e_mean={norm['e2e_mean_s']:.2f}s "
+            f"step={norm['step_mean_s'] * 1000:.0f}ms")
+
+    peak_alloc = torch.cuda.max_memory_allocated()
+    peak_res = torch.cuda.max_memory_reserved()
+    e2e = [r["e2e_s"] for r in rows[1:]]
+    stepms = [r["step_mean_s"] for r in rows[1:]]
+    report = {
+        "arm": args.arm, "family": "edit", "runtime": rtinfo, "device": dev,
+        "sm": sm, "torch": torch.__version__,
+        "diffusers": diffusers.__version__,
+        "transformers": transformers.__version__,
+        "offload": "model_cpu_offload" if offload else "none",
+        "load_s": load_s,
+        "recipe": {"steps": steps, "true_cfg_scale": cfg,
+                   "resolution": [w, h], "negative_prompt": neg,
+                   "set": spec["set"],
+                   "inputs": [{"id": r["id"], "before": r["before"],
+                               "before_sha256": r["before_sha256"],
+                               "instruction": r["instruction"]}
+                              for r in spec["edit"]],
+                   "note": "per step = 2 transformer forwards (true CFG); "
+                           "condition image is resized to a 1024^2 area by "
+                           "the pipeline, so the sequence carries the edit "
+                           "tokens on top of the output latents"},
+        "images": rows, "repeats": repeats, "normalized": norm,
+        "summary": {
+            "e2e_mean_s": sum(e2e) / len(e2e),
+            "e2e_min_s": min(e2e), "e2e_max_s": max(e2e),
+            "step_mean_s": sum(stepms) / len(stepms),
+            "images_per_hour": 3600.0 / (sum(e2e) / len(e2e)),
+            "peak_vram_alloc_gb": peak_alloc / 2**30,
+            "peak_vram_reserved_gb": peak_res / 2**30,
+        },
+    }
+    (out_dir / f"bench_{args.arm}.json").write_text(json.dumps(report, indent=1))
+    s = report["summary"]
+    nz = (f" | norm {norm['shape'][0]}^2/{norm['steps']}: "
+          f"e2e={norm['e2e_mean_s']:.2f}s "
+          f"step={norm['step_mean_s'] * 1000:.0f}ms" if norm else "")
+    log(f"DONE e2e_mean={s['e2e_mean_s']:.2f}s "
+        f"step_mean={s['step_mean_s'] * 1000:.0f}ms "
+        f"imgs/hr={s['images_per_hour']:.1f} "
+        f"peak_vram={s['peak_vram_alloc_gb']:.1f}GB load={load_s:.1f}s{nz}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/svdq_bench/edit_prompts.json
+++ b/scripts/svdq_bench/edit_prompts.json
@@ -1,0 +1,46 @@
+{
+ "set": "magicbrush-gate-edit-v1",
+ "provenance": "The BEFORE images and instructions are the REAL inputs the published tensorhub/qwen-image-edit-2511#fp8-w8a8 degradation gate ran on: osunlp/MagicBrush train split, seed 1000, count 512, max_side 768, recovered byte-identically against the gate's recorded input_sha256 (~/cozy/samples/qwen-edit-fp8-20260727/BEFORES.json). Not synthetic.",
+ "before_dir": "~/cozy/samples/qwen-edit-fp8-20260727",
+ "steps": 28,
+ "true_cfg_scale": 4.5,
+ "negative_prompt": " ",
+ "resolution": [
+  1328,
+  1328
+ ],
+ "edit": [
+  {
+   "id": "m00",
+   "seed": 1492,
+   "before": "00-before.png",
+   "before_sha256": "0480f817b0ad9a44dd8f50eadf5bee82522dfa448137967ec24c895152491a67",
+   "before_size": [500, 500],
+   "instruction": "let the skateboard read JESUS"
+  },
+  {
+   "id": "m01",
+   "seed": 1493,
+   "before": "01-before.png",
+   "before_sha256": "a575a16b34caa4f36fcae17c0eeb4921e5a3b05d70adc13156d9f3c8da6f07d7",
+   "before_size": [768, 768],
+   "instruction": "Put a plate under the pancakes."
+  },
+  {
+   "id": "m02",
+   "seed": 1494,
+   "before": "02-before.png",
+   "before_sha256": "8b5d57f37238e5c51e77b7947fb8550b832e0489160e2cff760601e6ca0b1a29",
+   "before_size": [768, 768],
+   "instruction": "Add a doll next to the teddy bear"
+  },
+  {
+   "id": "m03",
+   "seed": 1495,
+   "before": "03-before.png",
+   "before_sha256": "7891bd33266d8f7d2df866f084fe42d83c21ee0e31039b59d69eb5bf4c578000",
+   "before_size": [500, 500],
+   "instruction": "change the green train into a smoke train"
+  }
+ ]
+}

--- a/scripts/svdq_bench/materialize_bench.py
+++ b/scripts/svdq_bench/materialize_bench.py
@@ -60,22 +60,32 @@ def refs_from_r2() -> None:
     print(f"[mat] R2 total {total/1e9:.2f} GB", flush=True)
 
 
-def refs_from_hf(with_transformer: bool) -> None:
-    """The chaos-R2 qwen-image blobs were GC'd 2026-08-01; our mirror IS
-    Qwen/Qwen-Image HEAD 75e0b4be (eval_sets.py, verified 2026-07-26), so the
-    public tree at that pinned revision is byte-identical for every component
-    we load (VAE/TEs/tokenizer/scheduler/model_index; transformer is injected)."""
+# family -> (HF repo, pinned revision). Our published bf16 flavor is the
+# mirror of these pins, so the public tree is byte-identical for every
+# component we load (VAE/TEs/tokenizer/processor/scheduler/model_index; the
+# transformer is injected by the arm).
+FAMILY_REFS = {
+    "t2i": ("Qwen/Qwen-Image",
+            "75e0b4be04f60ec59a75f475837eced720f823b6"),
+    "edit": ("Qwen/Qwen-Image-Edit-2511",
+             "6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9"),
+}
+
+
+def refs_from_hf(with_transformer: bool, family: str = "t2i") -> None:
+    """The chaos-R2 qwen blobs were GC'd 2026-08-01, so the pinned public
+    tree is the reference source."""
     import os as _os
     from huggingface_hub import snapshot_download
+    repo_id, revision = FAMILY_REFS[family]
     ignore = ["*.png", "*.md"]
     if not with_transformer:
         ignore.append("transformer/*.safetensors")
     p = snapshot_download(
-        repo_id="Qwen/Qwen-Image",
-        revision="75e0b4be04f60ec59a75f475837eced720f823b6",
+        repo_id=repo_id, revision=revision,
         local_dir=str(REFS), ignore_patterns=ignore,
         token=_os.environ.get("HF_TOKEN") or None)
-    print(f"[mat] HF refs tree -> {p}", flush=True)
+    print(f"[mat] HF refs tree {repo_id}@{revision[:8]} -> {p}", flush=True)
 
 
 def fp8_from_manifest(manifest: Path) -> None:
@@ -146,21 +156,28 @@ def fp8_from_manifest(manifest: Path) -> None:
 def main() -> int:
     # chaos-R2 qwen refs blobs GC'd 2026-08-01 -> HF mirror is primary now.
     # --bf16 also pulls the transformer shards: the same-card bf16 arm.
-    refs_from_hf("--bf16" in sys.argv)
+    family = "edit" if "--edit" in sys.argv else "t2i"
+    refs_from_hf("--bf16" in sys.argv, family)
     # Markers as soon as each artifact is real: the reference tree and the
     # svdq checkpoint are what every arm needs, and an optional extra
     # artifact must never be able to invalidate them.
     print("REFS_TREE=" + str(REFS), flush=True)
 
-    NUN.mkdir(parents=True, exist_ok=True)
-    from huggingface_hub import hf_hub_download
-    fn = hf_hub_download(
-        repo_id="nunchaku-ai/nunchaku-qwen-image",
-        filename="svdq-fp4_r128-qwen-image.safetensors",
-        revision="4d9f4f667ea571ab172e0ee29ac2c27b82a41a6b",
-        local_dir=str(NUN), token=os.environ.get("HF_TOKEN") or None)
-    print(f"[mat] nunchaku -> {fn} {Path(fn).stat().st_size/1e9:.2f} GB", flush=True)
-    print("NUN_FILE=" + str(fn), flush=True)
+    if family == "t2i":
+        NUN.mkdir(parents=True, exist_ok=True)
+        from huggingface_hub import hf_hub_download
+        fn = hf_hub_download(
+            repo_id="nunchaku-ai/nunchaku-qwen-image",
+            filename="svdq-fp4_r128-qwen-image.safetensors",
+            revision="4d9f4f667ea571ab172e0ee29ac2c27b82a41a6b",
+            local_dir=str(NUN), token=os.environ.get("HF_TOKEN") or None)
+        print(f"[mat] nunchaku -> {fn} "
+              f"{Path(fn).stat().st_size / 1e9:.2f} GB", flush=True)
+        print("NUN_FILE=" + str(fn), flush=True)
+    else:
+        # No 4-bit qwen-image-edit artifact exists (te#137's edit produce is
+        # planned, not run). Absence is recorded, never fabricated.
+        print("NUN_FILE=none", flush=True)
 
     man = Path("/root/fp8_manifest.json")
     if "--fp8" in sys.argv and man.exists():

--- a/scripts/svdq_bench/metrics_pod.py
+++ b/scripts/svdq_bench/metrics_pod.py
@@ -48,7 +48,11 @@ def main() -> int:
     if args.rows:
         ids = [r.strip() for r in args.rows.split(",") if r.strip()]
     else:
-        ids = sorted(p.stem for p in ref_dir.glob("t*.webp"))
+        # Every counted row, whatever the family names them (t2i writes
+        # t01…, edit writes m00…). Warmups and the normalized-shape block are
+        # not comparison rows.
+        ids = sorted(p.stem for p in ref_dir.glob("*.webp")
+                     if not p.stem.startswith(("norm_", "warmup")))
 
     import torch
     from PIL import Image

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -103,8 +103,30 @@ NEEDS_BF16_TREE = ("bf16", "bf16c")
 NEEDS_FP8_TREE = ("fp8", "fp8c")
 NEEDS_SVDQ_CK = ("base", "basec", "native", "nativec")
 
-HUB_BASE = os.environ.get("COZY_HUB_BASE", "http://localhost:30070")
-FP8_REF = ("tensorhub", "qwen-image", "latest", "fp8-w8a8")
+HUB_BASE = os.environ.get("COZY_HUB_BASE", "http://localhost:31550")
+
+# Model family under test. `edit` is image+text conditioned: same shapes, same
+# reporting contract, no svdq arm (no 4-bit edit artifact exists), and the
+# BEFORE images ship from the banked gate inputs.
+FAMILIES = {
+    "t2i": {
+        "fp8_ref": ("tensorhub", "qwen-image", "prod", "fp8-w8a8"),
+        "bench": "bench_arm.py",
+        "prompts": "bench_prompts.json",
+        "mat_flag": "",
+        "arms": set(ARMS),
+        "before_dir": "",
+    },
+    "edit": {
+        "fp8_ref": ("tensorhub", "qwen-image-edit-2511", "prod", "fp8-w8a8"),
+        "bench": "bench_edit_arm.py",
+        "prompts": "edit_prompts.json",
+        "mat_flag": "--edit",
+        "arms": {"bf16", "bf16c", "fp8", "fp8c"},
+        "before_dir": str(Path.home() / "cozy" / "samples"
+                          / "qwen-edit-fp8-20260727"),
+    },
+}
 
 
 def dotenv(names):
@@ -213,6 +235,7 @@ def wait_for(ip, port, log, marker, deadline_s, tick=45, label=""):
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--gpu", default="b200", choices=sorted(CARDS))
+    ap.add_argument("--family", default="t2i", choices=sorted(FAMILIES))
     ap.add_argument("--cells", default="mat,corr,bb,bf,e:bf16,e:base,"
                                        "e:native,e:nativec,met")
     ap.add_argument("--rows", default="",
@@ -242,10 +265,13 @@ def main() -> int:
               "404=", confirm_404(api, args.terminate))
         return 0
 
+    fam = FAMILIES[args.family]
     cells = [c.strip() for c in args.cells.split(",") if c.strip()]
     e2e_arms = [c[2:] for c in cells if c.startswith("e:")]
     for a in e2e_arms:
-        assert a in ARMS, f"unknown arm {a}; known: {sorted(ARMS)}"
+        assert a in fam["arms"], (
+            f"unknown arm {a} for family {args.family}; "
+            f"known: {sorted(fam['arms'])}")
     want_bf16 = any(a in NEEDS_BF16_TREE for a in e2e_arms)
     want_fp8 = any(a in NEEDS_FP8_TREE for a in e2e_arms)
 
@@ -290,8 +316,9 @@ def main() -> int:
         print(f"[pod] attached {pod_id}", flush=True)
     (res / "pod.txt").write_text(f"{pod_id} {int(started)} {args.gpu}\n")
 
-    manifest = {"pod": pod_id, "gpu": args.gpu, "image": IMAGE,
-                "cells": cells, "started": started, "results": {}}
+    manifest = {"pod": pod_id, "gpu": args.gpu, "family": args.family,
+                "image": IMAGE, "cells": cells, "started": started,
+                "results": {}}
 
     def bank():
         (res / "manifest.json").write_text(json.dumps(manifest, indent=1))
@@ -327,8 +354,9 @@ def main() -> int:
             return 3
 
         files = [str(HERE / f) for f in
-                 ("bench_b0.py", "bench_arm.py", "materialize_bench.py",
-                  "metrics_pod.py", "bench_prompts.json")]
+                 ("bench_b0.py", "bench_arm.py", "bench_edit_arm.py",
+                  "materialize_bench.py", "metrics_pod.py",
+                  "bench_prompts.json", "edit_prompts.json")]
         files += [str(MODELS / f) for f in OVERLAY]
         rc, out = sh(["scp", *SSH_OPTS, "-P", str(port), *files,
                       f"root@{ip}:/root/"], 300)
@@ -336,6 +364,20 @@ def main() -> int:
         if rc != 0:
             print(out[-1500:], flush=True)
             return 4
+        if fam["before_dir"]:
+            # The conditioning inputs. bench_edit_arm.py sha256-verifies them
+            # against the recipe, so a wrong/missing BEFORE fails loudly
+            # rather than benchmarking a different workload.
+            spec = json.loads((HERE / fam["prompts"]).read_text())
+            befores = [str(Path(fam["before_dir"]) / r["before"])
+                       for r in spec["edit"]]
+            ssh(ip, port, "mkdir -p /root/before", 60)
+            rc, out = sh(["scp", *SSH_OPTS, "-P", str(port), *befores,
+                          f"root@{ip}:/root/before/"], 300)
+            print(f"[scp before] rc={rc} n={len(befores)}", flush=True)
+            if rc != 0:
+                print(out[-1500:], flush=True)
+                return 4
         rc, out = ssh(
             ip, port,
             'M=$(python3 -c "import gen_worker.models, pathlib; '
@@ -373,8 +415,10 @@ def main() -> int:
 
                 if cell == "mat":
                     flag = "--bf16" if want_bf16 else ""
+                    if fam["mat_flag"]:
+                        flag += " " + fam["mat_flag"]
                     if want_fp8:
-                        org, name, tag, flavor = FP8_REF
+                        org, name, tag, flavor = fam["fp8_ref"]
                         url = (f"{HUB_BASE}/api/v1/repos/{org}/{name}/resolve"
                                f"?tag={tag}&flavor={flavor}")
                         with urllib.request.urlopen(url, timeout=120) as fh:
@@ -475,11 +519,12 @@ def main() -> int:
                     rows = f"--rows {args.rows}" if args.rows else ""
                     rows += (f" --norm-rows {args.norm_rows} "
                              f"--norm-shape {args.norm_shape}")
+                    ckarg = "" if args.family == "edit" else f"--ckpt {ck}"
                     ssh(ip, port,
                         f"setsid nohup env GEN_WORKER_NATIVE_KERNELS={env_val} "
-                        f"python3 /root/bench_arm.py {extra} --ckpt {ck} "
+                        f"python3 /root/{fam['bench']} {extra} {ckarg} "
                         f"--reference-tree {refs_tree} "
-                        f"--prompts /root/bench_prompts.json {rows} "
+                        f"--prompts /root/{fam['prompts']} {rows} "
                         f"--out /root/e2e/{name} > /root/arm_{name}.log 2>&1 & "
                         f"echo started", 60)
                     ok, tail = wait_for(ip, port, f"/root/arm_{name}.log",

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -371,12 +371,19 @@ def main() -> int:
             spec = json.loads((HERE / fam["prompts"]).read_text())
             befores = [str(Path(fam["before_dir"]) / r["before"])
                        for r in spec["edit"]]
-            ssh(ip, port, "mkdir -p /root/before", 60)
-            rc, out = sh(["scp", *SSH_OPTS, "-P", str(port), *befores,
-                          f"root@{ip}:/root/before/"], 300)
-            print(f"[scp before] rc={rc} n={len(befores)}", flush=True)
-            if rc != 0:
-                print(out[-1500:], flush=True)
+            # A freshly booted sshd drops connections for a while; one broken
+            # pipe here must not cost a rented pod.
+            for attempt in range(5):
+                ssh(ip, port, "mkdir -p /root/before", 60)
+                rc, out = sh(["scp", *SSH_OPTS, "-P", str(port), *befores,
+                              f"root@{ip}:/root/before/"], 300)
+                print(f"[scp before] attempt{attempt} rc={rc} "
+                      f"n={len(befores)}", flush=True)
+                if rc == 0:
+                    break
+                print(out[-600:], flush=True)
+                time.sleep(20)
+            else:
                 return 4
         rc, out = ssh(
             ip, port,

--- a/scripts/svdq_bench/summarize.py
+++ b/scripts/svdq_bench/summarize.py
@@ -62,7 +62,8 @@ def main() -> int:
         man, arms = load(run)
         gpu = man.get("gpu", "?")
         env = " ".join(man.get("env_line") or [])
-        print(f"\n## {run.name} — {gpu} ({env})")
+        print(f"\n## {run.name} — {gpu} · "
+              f"{man.get('family', 't2i')} ({env})")
         print(f"pod {man.get('pod')} rate ${man.get('rate_per_hr')}/hr "
               f"elapsed {man.get('elapsed_min', 0):.0f} min "
               f"est ${man.get('est_cost_usd', 0):.2f} "


### PR DESCRIPTION
qwen-image had a full format matrix; `qwen-image-edit-2511` had **no inference number on any card**. This adds the edit family to the same instrument and fills the table.

Stacked on `pgw863-sm100-b200` (#440) because the harness this extends lives there; retarget to `dev` once that lands.

## What this adds

- **`bench_edit_arm.py`** — the image+text-conditioned twin of `bench_arm.py`. Identical timing/reporting contract (warm per-step ms with cuda-sync, e2e wall, imgs/hr, peak VRAM, cold load, executed-lane recording), the same two shape blocks, and the two arms the published catalog actually has: bf16 and the published `#fp8-w8a8` flavor through the production w8a8 loader. **No nvfp4 arm** — no 4-bit edit artifact exists; the instrument records the absence rather than fabricating one.
- **`edit_prompts.json`** — the REAL conditioning inputs, not `synthetic_image_png`: the MagicBrush before/instruction rows the published fp8-w8a8 edit flavor's own degradation gate ran on, recovered byte-identically against the gate's recorded `input_sha256`. Each arm re-verifies every BEFORE's sha256 at load, so a swapped input fails loudly instead of quietly benchmarking a different workload. The image bytes stay in `~/cozy/samples/`; the repo carries only the recipe + digests.
- **`pod_run.py --family {t2i,edit}`** — one `FAMILIES` table carries the fp8 ref, bench script, prompt file, legal arms and the BEFORE upload. Default `HUB_BASE` moves to the authoritative master stack (`:31550`), still env-overridable.

## Two harness bugs the run found

- the BEFORE upload had no retry — one broken pipe on a freshly booted sshd tore down an H100 ($0.15). Now 5 attempts.
- `metrics_pod.py` row discovery was `glob("t*.webp")`, hardcoded to t2i row names, so the edit rows scored **zero pairs**. Now family-agnostic (everything but warmups and the normalized block).

## Measured (evidence `~/cozy/samples/qwen-edit-bench-20260803/TABLE.md`, tracker pgw#865)

1328²/28/cfg4.5 ms/step — B200 bf16 626 / bf16+compile 442 / fp8 797 / **fp8+compile 402**; H100 1146 / 892 / 1316 / **790**. 1024²/30/cfg4.0 — B200 457 / 313 / 604 / **275**; H100 816 / 618 / 953 / **532**. Peak VRAM 60.8 GB bf16, 41.8 GB fp8 on both.

**The edit cost delta is exactly the extra conditioning**: the condition image adds latent tokens (6889→10985 at 1328², 4096→8192 at 1024²), and measured per-step cost lands at 1.64-1.87× / 1.86-2.24× — on the token ratio. Peak VRAM is identical to the digit across families. Same transformer, longer sequence, nothing else.

Ops: 2 pods + 1 aborted boot, **$6.67** total, all REST-DELETE'd with GET-404 proof.