### PR TITLE
pgw#947: a lane verdict is EVIDENCE, not an instruction — serving re-applies the fit rule on its own card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+- **pgw#947: a kernel-lane verdict is evidence, not an instruction — serving
+  re-applies the fit rule on its own card.** Cell keys are keyed on SM and the
+  lane is deliberately not a key axis, so one key spans a 96 GB RTX PRO 6000
+  and a 32 GB RTX 5090. Adoption used to `pin()` the recorded winner with no
+  local re-validation, so the small card could pin a lane whose measured peak
+  does not fit it — the kernels' numerics self-checks are correctness checks
+  and know nothing about memory, so the symptom is an OOM or a silent slide
+  into CPU-offload degraded mode. `kernel_lane.adopt()` now re-applies the fit
+  constraint (`peak x1.20 + 1 GiB` against the honestly detected total)
+  before pinning: the recorded winner fits, it stands; it does not, the
+  fastest recorded candidate that fits here is pinned
+  (`kernel_lane_refit_local`); nothing fits, the smallest recorded peak is
+  (`kernel_lane_refit_no_fit`) — never the declared default, which carries
+  the larger DENSE modulation and would be the biggest ask of all. With the
+  published `kernel_lane_evidence` in hand the re-fit is `select()` itself
+  re-run against the local total. A cell with no recorded peaks is adopted
+  and marked `kernel_lane_fit_unverified`.
+- **Peak bytes now ride the packed cell (pgw#947).** The envelope gained a
+  `fit` block — each measured candidate's peak QUANTIZED up to 256 MiB, plus
+  the fallback order — so a worker that will never see the timings can still
+  re-apply the fit half of the rule. Bytes are admissible under the #699
+  double-mint byte-compare where wall clocks are not, because quantizing them
+  makes them reproducible across two mints the same way `MARGIN_FRACTION`
+  makes the winner reproducible; rounding UP can only make the constraint
+  stricter. Cell keys do not move (`cell_identity` keys named facts, not the
+  envelope). The SPEED axis is a recorded, unfixed limitation: a ranking
+  minted on one card of an SM class can still be wrong on another, and
+  detecting it would need re-benchmarking at serve time.
+
 - **th#1566: distillation `false` no longer means “unknown.”** The vendored
   worker protocol now carries `ModelBinding.distilled_status`; the SDK exposes
   it on resolved slots and refuses an explicitly unclassified or inconclusive

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -131,18 +131,39 @@ minted for and recorded in the cell (`gen_worker/kernel_lane.py`):
   verdict is recorded as its evidence.
 - **Where it lands.** `metadata.json` inside the packed cell carries the
   DISCRETE verdict (`kernel_lane`: winner, rule, binding term, margin,
-  candidates) — no wall clocks, because the #699 double-mint byte-compare
-  requires a reproducible artifact. The measurements ride the published
-  checkpoint metadata as `kernel_lane_evidence`, beside `mint_phases`.
-- **Serving.** The executor reads the verdict off the delivered cell and
-  pins it BEFORE `setup()` runs; each axis then projects its own value out of
-  the pin (`native_kernels.svdq_linear_lane` / `svdq_modulation_lane`). No
-  cell, a pre-pgw#947 cell, or an unreadable envelope is the declared
-  conservative default (`baseline+dense`) with a typed reason
+  candidates) plus a `fit` block — each measured candidate's peak, QUANTIZED
+  up to 256 MiB, and the fallback order. No wall clocks, because the #699
+  double-mint byte-compare requires a reproducible artifact; peak BYTES are
+  admissible precisely because quantizing them makes them reproducible the
+  way the 5% margin makes the winner reproducible. The timings ride the
+  published checkpoint metadata as `kernel_lane_evidence`, beside
+  `mint_phases`.
+- **Serving re-applies the fit rule locally.** Cell keys are keyed on SM and
+  the lane is deliberately NOT a key axis, so one key spans very different
+  cards — a 96 GB RTX PRO 6000 and a 32 GB RTX 5090 are both sm_120. A
+  recorded verdict is therefore EVIDENCE, not an instruction. The executor
+  reads it off the delivered cell and pins it BEFORE `setup()` runs, but only
+  after re-checking the recorded winner's peak against THIS device's honestly
+  detected total: it fits, the verdict stands (`kernel_lane_verdict_adopted`);
+  it does not, the fastest recorded candidate that DOES fit here is pinned
+  (`kernel_lane_refit_local`); nothing fits, the smallest recorded peak is
+  pinned (`kernel_lane_refit_no_fit`) — never the declared default, which
+  carries the larger DENSE modulation and would be the bigger ask. A cell with
+  no recorded peaks is adopted and marked `kernel_lane_fit_unverified`. Each
+  axis then projects its own value out of the pin
+  (`native_kernels.svdq_linear_lane` / `svdq_modulation_lane`). No cell, a
+  pre-pgw#947 cell, or an unreadable envelope is the declared conservative
+  default (`baseline+dense`) with a typed reason
   (`kernel_lane_verdict_absent` / `_unreadable` / `_unknown_lane` /
   `kernel_lane_no_cell`) — never a silent fall-through. An armed axis still
   has to pass its OWN numerics self-check on the box; a gap degrades that
-  axis alone, same artifact, with the reason logged.
+  axis alone, same artifact, with the reason logged. The numerics checks are
+  CORRECTNESS checks and say nothing about memory, which is why the fit has
+  to be re-applied rather than left to them.
+- **Known limitation (speed axis).** The re-fit covers MEMORY only. The
+  ranking itself can also differ inside an SM class (1189 ms/step on a 5090
+  vs 1063 on a PRO 6000 for the same work), and detecting that would need
+  re-benchmarking, which serving must not do. Tracked on pgw#947.
 
 `GEN_WORKER_NATIVE_KERNELS` survives only as the pgw#859 G0 rollout gate and
 kill switch (unset = off, `=0` = forced off). It gates the ROLLOUT and never

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -6591,6 +6591,10 @@ class Executor:
         # No cell (eager boot, self-minting boot, pre-pgw#947 cell) is the
         # declared conservative default WITH a typed reason; there is no SM
         # allowlist and no per-boot probe to fall back on any more.
+        # The verdict is EVIDENCE, not an instruction: cells are keyed on SM
+        # and the lane is not a key axis, so a 96 GB card's winner can reach a
+        # 32 GB card of the same SM. adopt() re-applies the fit constraint
+        # against THIS device before pinning.
         kernel_lane.adopt_from_artifact(
             compile_artifact, source=f"{spec.name} boot")
         # Loads serialize: concurrent setups would cross-contaminate each

--- a/src/gen_worker/kernel_lane.py
+++ b/src/gen_worker/kernel_lane.py
@@ -24,12 +24,26 @@ cell is being minted for, recorded INTO the cell, and adopted by serving:
     mint      probe(candidates, ...) -> Verdict     (every buildable
               combination built, compiled, and timed on the target card, in
               the pgw#784 mint process)
-    envelope  metadata.json["kernel_lane"] — the DISCRETE verdict only
+    envelope  metadata.json["kernel_lane"] — the DISCRETE verdict, plus each
+              candidate's QUANTIZED peak and the fallback order
     result    metadata["kernel_lane_evidence"] — the numbers, published with
               the checkpoint, never packed (the #699 double-mint byte-compare
               forbids wall clocks inside the artifact)
-    serve     adopt(meta) -> pin(); the load-time swap reads the pin, each
-              axis projecting its own value out of it
+    serve     adopt(meta) -> re-apply the fit rule on THIS card -> pin(); the
+              load-time swap reads the pin, each axis projecting its own
+              value out of it
+
+CELL KEYS ARE KEYED ON SM, AND THE LANE IS DELIBERATELY NOT A KEY AXIS (that
+would fork the namespace and halve reuse). One SM class is therefore many
+cards: a cell minted on a 96 GB RTX PRO 6000 and a 32 GB RTX 5090 share a
+key. Two GPUs of one compute capability cannot be assumed to want the same
+kernels, so a recorded verdict is EVIDENCE, not an instruction — serving
+RE-APPLIES the fit constraint against its own detected total before it
+adopts, and falls to the fastest candidate that does fit here with a typed
+reason when the minting card's winner does not. That is why each candidate's
+peak rides the packed envelope beside the winner: bytes are discrete, wall
+clocks are not, so the fit half of the rule can be re-applied by a worker
+that will never see the timings.
 
 A lane is therefore a COMBINATION, written ``"<linear>+<modulation>"``
 (``"baseline+packed"``, ``"fused+dense"``, ...). Measuring the combinations
@@ -58,7 +72,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple)
 
 import msgspec
 
@@ -141,6 +156,16 @@ MARGIN_FRACTION = 0.05
 ACTIVATION_SPIKE_FRACTION = 0.20
 FRAGMENTATION_HEADROOM_BYTES = 1 << 30  # 1 GiB
 
+# Peaks recorded in the PACKED envelope are quantized (rounded UP). A raw
+# `max_memory_allocated()` is a MEASUREMENT, and an unrounded measurement in
+# metadata.json is precisely what the #699 double-mint byte-compare forbids —
+# an autotuned kernel picking a different workspace on the second mint would
+# move the number and strand the cell. Rounding to a coarse grain makes the
+# recorded byte count reproducible for the same reason `MARGIN_FRACTION`
+# makes the winner reproducible, and rounding UP can only make the fit test
+# stricter, never optimistic (the strict_vram rule).
+PEAK_QUANTUM_BYTES = 1 << 28  # 256 MiB
+
 # Fixed measurement protocol — part of the verdict's determinism, recorded
 # with it so a re-measurement is comparable.
 BENCH_WARMUP = 3
@@ -159,6 +184,15 @@ REASON_UNREADABLE = "kernel_lane_verdict_unreadable"
 REASON_UNKNOWN_LANE = "kernel_lane_verdict_unknown_lane"
 REASON_NO_CELL = "kernel_lane_no_cell"
 REASON_ADOPTED = "kernel_lane_verdict_adopted"
+# The recorded winner does not fit THIS card (same SM class, smaller card):
+# the rule was re-applied locally and a different lane was pinned.
+REASON_REFIT_LOCAL = "kernel_lane_refit_local"
+# Nothing the cell measured fits this card. The smallest peak is pinned and
+# says so — obeying a verdict into an OOM is not conservatism.
+REASON_REFIT_NO_FIT = "kernel_lane_refit_no_fit"
+# The fit could not be re-applied here (no per-candidate peaks recorded, or
+# no detectable device total). Adopted, and marked as unverified across cards.
+REASON_FIT_UNVERIFIED = "kernel_lane_fit_unverified"
 
 # Which term bound a verdict.
 BIND_SPEED = "speed"
@@ -174,6 +208,31 @@ class LaneProbeError(RuntimeError):
 
 
 # --- value types ------------------------------------------------------------
+
+
+def required_for(peak_bytes: int) -> int:
+    """A measured peak's ASK: the peak plus the stated allowance. One
+    formula, used by the mint and re-used verbatim by every serving worker
+    that re-applies the constraint on its own card."""
+    return int(int(peak_bytes or 0) * (1.0 + ACTIVATION_SPIKE_FRACTION)) \
+        + FRAGMENTATION_HEADROOM_BYTES
+
+
+def fits_bytes(peak_bytes: int, device_total_bytes: int) -> bool:
+    """Does a peak fit a card with the stated allowance? A total of 0 is
+    "unknown" and constrains nothing."""
+    if not device_total_bytes:
+        return True
+    return required_for(peak_bytes) <= int(device_total_bytes)
+
+
+def quantize_peak(peak_bytes: int) -> int:
+    """A peak rounded UP to ``PEAK_QUANTUM_BYTES`` — the form that may ride
+    the packed envelope without moving between two mints."""
+    n = int(peak_bytes or 0)
+    if n <= 0:
+        return 0
+    return -(-n // PEAK_QUANTUM_BYTES) * PEAK_QUANTUM_BYTES
 
 
 class Measurement(msgspec.Struct, frozen=True, kw_only=True):
@@ -192,8 +251,7 @@ class Measurement(msgspec.Struct, frozen=True, kw_only=True):
     def required_bytes(self) -> int:
         """The peak plus the stated allowance for the shapes the mint did not
         measure (activation spikes, resolution variance, fragmentation)."""
-        return int(self.peak_bytes * (1.0 + ACTIVATION_SPIKE_FRACTION)) \
-            + FRAGMENTATION_HEADROOM_BYTES
+        return required_for(self.peak_bytes)
 
 
 class Verdict(msgspec.Struct, frozen=True, kw_only=True):
@@ -229,9 +287,7 @@ def fits(row: Measurement, device_total_bytes: int) -> bool:
     """Does this lane fit the card with the stated allowance? A card whose
     total is unknown (0) constrains nothing — the mint measured it there, so
     it ran there."""
-    if not device_total_bytes:
-        return True
-    return row.required_bytes() <= int(device_total_bytes)
+    return fits_bytes(row.peak_bytes, device_total_bytes)
 
 
 def select(
@@ -528,16 +584,80 @@ def candidates_here() -> Tuple[str, ...]:
 # --- recording and reading --------------------------------------------------
 
 
+def refit_order(
+    measurements: Sequence[Measurement], *, winner: str = "",
+) -> Tuple[str, ...]:
+    """The lanes best-first, as a DISCRETE fact a second mint reproduces.
+
+    A serving worker that has to drop the recorded winner needs to know what
+    to fall to, and it has no timings — so the ORDER travels instead. It is
+    discretized exactly the way the winner is: lanes within
+    ``MARGIN_FRACTION`` of the fastest remaining lane are one tie class,
+    ordered inside the class by quantized peak then name. Jitter therefore
+    has to cross the margin to move the order, which is the same bar that
+    already has to be cleared to move the winner.
+
+    The recorded ``winner`` is forced to the front so the order and the
+    verdict can never disagree about what won on the minting card.
+    """
+    usable = [r for r in measurements if r.usable]
+    ranked: List[str] = []
+    remaining = sorted(usable, key=lambda r: (r.ms_per_step, r.lane))
+    while remaining:
+        head = remaining[0]
+        tie = [
+            r for r in remaining
+            if (r.ms_per_step - head.ms_per_step)
+            / max(head.ms_per_step, 1e-9) < MARGIN_FRACTION
+        ]
+        ranked.extend(
+            r.lane for r in sorted(
+                tie, key=lambda r: (quantize_peak(r.peak_bytes), r.lane)))
+        remaining = [r for r in remaining if r not in tie]
+    if winner in ranked:
+        ranked = [winner] + [lane for lane in ranked if lane != winner]
+    return tuple(ranked)
+
+
+def fit_block(verdict: Verdict) -> Dict[str, Any]:
+    """Everything a DIFFERENT card of the same SM class needs to re-apply the
+    fit half of the rule: each measured candidate's quantized peak, and the
+    order to fall through when the recorded winner does not fit locally.
+
+    All discrete, all reproducible, no wall clocks — so it can ride the
+    packed envelope. ``{}`` when nothing was measured (a ``sole_candidate``
+    verdict), which is the honest signal that the fit cannot be re-applied.
+    """
+    peaks = {
+        r.lane: quantize_peak(r.peak_bytes)
+        for r in sorted(verdict.measurements, key=lambda r: r.lane)
+        if r.usable
+    }
+    if not peaks:
+        return {}
+    return {
+        "quantum_bytes": PEAK_QUANTUM_BYTES,
+        "activation_spike_fraction": float(verdict.activation_spike_fraction),
+        "fragmentation_headroom_bytes":
+            int(verdict.fragmentation_headroom_bytes),
+        "peaks": peaks,
+        "order": list(refit_order(verdict.measurements,
+                                  winner=verdict.winner)),
+    }
+
+
 def envelope_block(verdict: Verdict) -> Dict[str, Any]:
     """The DISCRETE verdict, for ``metadata.json`` inside the packed cell.
 
-    Deliberately carries no wall clocks and no measured numbers: the #699
-    double-mint byte-compare requires the artifact to be reproducible, and
-    milliseconds are not. What a serving worker needs is the winner; what an
-    auditor needs is :func:`evidence_block`, which rides the published
-    checkpoint metadata beside ``mint_phases``.
+    Deliberately carries no wall clocks: the #699 double-mint byte-compare
+    requires the artifact to be reproducible, and milliseconds are not. Peak
+    BYTES are a different kind of number — discrete, quantized here, and
+    load-bearing for a card that shares this cell's SM but not its memory —
+    so they ride the envelope while the timings stay in
+    :func:`evidence_block`, which rides the published checkpoint metadata
+    beside ``mint_phases``.
     """
-    return {
+    block = {
         "schema": int(verdict.schema),
         "winner": str(verdict.winner),
         "rule": str(verdict.rule),
@@ -545,6 +665,10 @@ def envelope_block(verdict: Verdict) -> Dict[str, Any]:
         "margin_fraction": float(verdict.margin_fraction),
         "candidates": sorted(r.lane for r in verdict.measurements),
     }
+    fit = fit_block(verdict)
+    if fit:
+        block["fit"] = fit
+    return block
 
 
 def evidence_block(verdict: Verdict) -> Dict[str, Any]:
@@ -646,6 +770,121 @@ def lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
         f"rule={block.get('rule') or '?'})")
 
 
+# --- re-applying the rule on THIS card --------------------------------------
+
+
+def recorded_fit(
+    meta: Mapping[str, Any],
+) -> Tuple[Dict[str, int], Tuple[str, ...], Tuple[Measurement, ...], str]:
+    """``(peaks, order, measurements, provenance)`` for the local re-fit.
+
+    Two channels, ranked by how much they carry:
+
+    * ``kernel_lane_evidence`` — the full record (ms/step AND peak bytes).
+      Present when the caller has the PUBLISHED checkpoint metadata, and
+      enough to re-run :func:`select` outright.
+    * the packed envelope's ``fit`` block — quantized peaks and the fallback
+      order, and nothing else. This is what a serving worker actually holds,
+      because it reads ``metadata.json`` out of the delivered cell.
+
+    Empty when neither is there (a cell minted before this block existed, or
+    a ``sole_candidate`` verdict that measured nothing) — the caller must
+    then say so rather than pretend the fit was checked.
+    """
+    evidence = meta.get(EVIDENCE_KEY)
+    if isinstance(evidence, Mapping):
+        rows = tuple(
+            r for r in verdict_from_evidence(evidence).measurements
+            if r.usable and r.lane in LANES)
+        if rows:
+            return (
+                {r.lane: r.peak_bytes for r in rows},
+                refit_order(rows, winner=str(evidence.get("winner") or "")),
+                rows, EVIDENCE_KEY)
+    block = meta.get(META_KEY)
+    fit = block.get("fit") if isinstance(block, Mapping) else None
+    if isinstance(fit, Mapping):
+        peaks = {
+            str(lane): int(peak)
+            for lane, peak in (fit.get("peaks") or {}).items()
+            if str(lane) in LANES and int(peak or 0) > 0
+        }
+        if peaks:
+            order = tuple(
+                str(lane) for lane in (fit.get("order") or ())
+                if str(lane) in peaks)
+            return peaks, order or tuple(sorted(peaks)), (), META_KEY
+    return {}, (), (), ""
+
+
+def refit(
+    lane: str, reason: str, meta: Mapping[str, Any],
+) -> Tuple[str, str]:
+    """Re-apply the fit constraint against THIS card and return the lane to
+    pin with the reason it is pinned.
+
+    Cells are keyed on SM and the lane is not a key axis, so the card that
+    minted this verdict may be much larger than the card serving it — a
+    96 GB RTX PRO 6000 and a 32 GB RTX 5090 are one cell key. The recorded
+    winner is therefore checked against this device's honestly detected
+    total before it is obeyed:
+
+    * it fits -> the recorded verdict, unchanged (the fast path);
+    * it does not -> the fastest RECORDED candidate that does fit here,
+      pinned with ``kernel_lane_refit_local``;
+    * nothing fits -> the smallest recorded peak, pinned with
+      ``kernel_lane_refit_no_fit``. Never the declared default: the default
+      carries the DENSE modulation, which is the LARGER residency, so
+      "fall back to the default" on a card that ran out of memory would
+      choose the biggest lane of all;
+    * the fit is not re-applicable here (no recorded peaks, or no detectable
+      device total) -> the recorded verdict, marked
+      ``kernel_lane_fit_unverified``.
+    """
+    total, name, sm = device_facts()
+    peaks, order, rows, provenance = recorded_fit(meta)
+    device = f"{name or 'this device'} ({sm or 'sm unknown'})"
+    if not total:
+        return lane, (
+            f"{reason}; {REASON_FIT_UNVERIFIED}: this process cannot detect a "
+            f"device total, so the cell's fit constraint could not be "
+            f"re-applied here")
+    if lane not in peaks:
+        return lane, (
+            f"{reason}; {REASON_FIT_UNVERIFIED}: the cell records no measured "
+            f"peak for {lane!r}, so its fit could not be re-applied on "
+            f"{device}, {total} B — adopting it unverified across cards "
+            f"(cells are keyed on SM, not on card memory)")
+    if fits_bytes(peaks[lane], total):
+        return lane, (
+            f"{reason}; re-checked here: {required_for(peaks[lane])} B "
+            f"required of {total} B on {device} [{provenance}]")
+    if rows:
+        # The full record is present: re-run THE rule, not a reduction of it.
+        local = select(rows, device_total_bytes=total, device_name=name, sm=sm)
+        winner, binding, detail = local.winner, local.binding, local.detail
+    else:
+        fitting = tuple(
+            cand for cand in order if fits_bytes(peaks[cand], total))
+        if fitting:
+            winner, binding = fitting[0], BIND_FIT
+            detail = (
+                f"{winner!r} is the fastest recorded candidate that fits "
+                f"({required_for(peaks[winner])} B required); order "
+                f"{list(order)!r}")
+        else:
+            winner = min(peaks, key=lambda cand: (peaks[cand], cand))
+            binding, detail = BIND_NO_FIT, (
+                f"no recorded candidate fits {total} B; the smallest peak "
+                f"wins ({winner!r}, {required_for(peaks[winner])} B required)")
+    tag = REASON_REFIT_LOCAL if binding != BIND_NO_FIT else REASON_REFIT_NO_FIT
+    return winner, (
+        f"{tag}: the cell's verdict {lane!r} asks "
+        f"{required_for(peaks[lane])} B and {device} has {total} B, so it "
+        f"does not fit here; re-applied the rule locally -> {winner!r} "
+        f"(binding={binding}) — {detail} [{provenance}]")
+
+
 # --- the process pin --------------------------------------------------------
 
 _PIN: Optional[str] = None
@@ -680,11 +919,17 @@ def clear() -> None:
 
 
 def adopt(meta: Optional[Mapping[str, Any]], *, source: str = "") -> str:
-    """Adopt the lane a delivered cell's metadata states, and return it.
+    """Adopt the lane a delivered cell's metadata states, RE-CHECKED against
+    this card, and return it.
 
     ``None`` (no cell for this boot) is the declared default with its own
     typed reason — an eager or self-minting boot has no verdict yet and must
     say so rather than guessing that a hand-written tuple was right.
+
+    A verdict that IS present is not obeyed on sight. The cell key is keyed
+    on SM and the lane is not one of its axes, so the minting card and this
+    one can differ by 64 GB of memory; :func:`refit` re-applies the fit
+    constraint here before the lane is pinned.
     """
     if meta is None:
         lane, reason = DEFAULT_LANE, (
@@ -692,6 +937,8 @@ def adopt(meta: Optional[Mapping[str, Any]], *, source: str = "") -> str:
             f"serving the declared default {DEFAULT_LANE!r}")
     else:
         lane, reason = lane_from_metadata(meta)
+        if reason.startswith(REASON_ADOPTED):
+            lane, reason = refit(lane, reason, meta)
     if source:
         reason = f"{reason} [{source}]"
     pin(lane, reason)
@@ -755,9 +1002,13 @@ __all__ = [
     "MOD_DENSE",
     "MOD_LANES",
     "MOD_PACKED",
+    "PEAK_QUANTUM_BYTES",
     "REASON_ABSENT",
     "REASON_ADOPTED",
+    "REASON_FIT_UNVERIFIED",
     "REASON_NO_CELL",
+    "REASON_REFIT_LOCAL",
+    "REASON_REFIT_NO_FIT",
     "REASON_UNKNOWN_LANE",
     "REASON_UNREADABLE",
     "SCHEMA",
@@ -773,7 +1024,9 @@ __all__ = [
     "device_facts",
     "envelope_block",
     "evidence_block",
+    "fit_block",
     "fits",
+    "fits_bytes",
     "fused_candidate_gap",
     "lane_from_metadata",
     "lane_of",
@@ -784,6 +1037,11 @@ __all__ = [
     "pin",
     "pinned",
     "probe",
+    "quantize_peak",
+    "recorded_fit",
+    "refit",
+    "refit_order",
+    "required_for",
     "select",
     "sole",
     "split_lane",

--- a/tests/test_kernel_lane_pgw947.py
+++ b/tests/test_kernel_lane_pgw947.py
@@ -33,6 +33,15 @@ def _m(lane: str, ms: float, peak_gb: float) -> kl.Measurement:
         samples_ms=(ms,))
 
 
+def _on_card(
+    monkeypatch: pytest.MonkeyPatch, total: int, name: str, sm: str,
+) -> None:
+    """Serve as if this process were on that card. Adoption re-applies the
+    fit rule against the LOCAL device, so a test of adoption has to say which
+    device it is adopting on — that is the whole point of the mechanism."""
+    monkeypatch.setattr(kl, "device_facts", lambda: (total, name, sm))
+
+
 @pytest.fixture(autouse=True)
 def _clear_pin():
     kl.clear()
@@ -183,8 +192,21 @@ def test_envelope_is_discrete_and_evidence_round_trips() -> None:
         "rule": "fit_constrained_speed", "binding": kl.BIND_SPEED,
         "margin_fraction": kl.MARGIN_FRACTION,
         "candidates": ["baseline+dense", "fused+packed"],
+        # The FIT half of the rule travels with the artifact, because a card
+        # of the same SM but a different size has to re-apply it. Quantized
+        # BYTES only — discrete, reproducible, and not a wall clock.
+        "fit": {
+            "quantum_bytes": kl.PEAK_QUANTUM_BYTES,
+            "activation_spike_fraction": kl.ACTIVATION_SPIKE_FRACTION,
+            "fragmentation_headroom_bytes": kl.FRAGMENTATION_HEADROOM_BYTES,
+            "peaks": {
+                "baseline+dense": kl.quantize_peak(int(44.1 * GB)),
+                "fused+packed": kl.quantize_peak(int(35.1 * GB)),
+            },
+            "order": ["baseline+dense", "fused+packed"],
+        },
     }
-    # No wall clocks, no measurements, JSON-clean.
+    # No wall clocks, no timings, JSON-clean.
     flat = json.dumps(envelope)
     assert "ms" not in flat and "measured_at" not in flat
 
@@ -214,7 +236,10 @@ def _packed(tmp_path: Path, meta: dict) -> Path:
     return artifact
 
 
-def test_serving_adopts_the_lane_the_cell_names(tmp_path: Path) -> None:
+def test_serving_adopts_the_lane_the_cell_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
     verdict = kl.select(
         [_m("baseline+dense", 1189.0, 22.4), _m("fused+packed", 975.0, 15.6)],
         device_total_bytes=32 * GB, sm="sm_120")
@@ -285,6 +310,247 @@ def test_verdict_survives_the_real_pack_unpack_round_trip(
     meta = aot_serve.unpack_metadata(artifact)
     assert meta[kl.META_KEY]["winner"] == "baseline+dense"
     assert kl.adopt_from_artifact(artifact) == "baseline+dense"
+
+
+# --- the same SM, a different card -----------------------------------------
+#
+# Cell keys are keyed on SM and the lane is deliberately NOT a key axis, so a
+# 96 GB RTX PRO 6000 and a 32 GB RTX 5090 are ONE cell key. Paul: "we cannot
+# guarantee that two separate GPUs with the same sm_x capability will both
+# want to use the same set of kernels." Serving therefore re-applies the FIT
+# half of the rule against its own detected total instead of obeying the
+# minting card.
+
+# The workload the PRO 6000 minted: the fast lane is 48 GB resident and the
+# small lane is 20 GB. Both fit 96 GB; only one fits 32 GB.
+_BIG = _m("baseline+dense", 1063.0, 48.0)
+_SMALL = _m("fused+packed", 1240.0, 20.0)
+
+
+def _minted_on_the_big_card(**extra) -> dict:
+    """A cell as the 96 GB card would have packed it."""
+    verdict = kl.select(
+        [_BIG, _SMALL], device_total_bytes=96 * GB,
+        device_name="NVIDIA RTX PRO 6000", sm="sm_120")
+    assert verdict.winner == "baseline+dense"  # correct ON THAT CARD
+    meta = {"kind": "aot-inductor", kl.META_KEY: kl.envelope_block(verdict)}
+    meta.update(extra)
+    return meta
+
+
+def test_a_verdict_from_a_bigger_card_of_the_same_sm_is_refit_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE gap this closes. The 96 GB card measured `baseline+dense` fastest
+    and recorded it. The 32 GB 5090 shares the cell key and would have pinned
+    a lane whose measured peak cannot fit its card — an OOM, or a silent
+    slide into CPU-offload degraded mode, because the kernels' self-checks
+    are CORRECTNESS checks and know nothing about memory.
+
+    Serving re-applies the rule here and falls to the fastest recorded
+    candidate that does fit, loudly."""
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    assert kl.adopt(_minted_on_the_big_card()) == "fused+packed"
+
+    lane, reason = kl.pinned()
+    assert lane == "fused+packed"
+    assert kl.REASON_REFIT_LOCAL in reason
+    # It names the recorded winner, this card, and the binding term.
+    assert "baseline+dense" in reason
+    assert str(32 * GB) in reason and "NVIDIA RTX 5090" in reason
+    assert f"binding={kl.BIND_FIT}" in reason
+
+
+def test_the_fast_path_is_unchanged_when_the_recorded_winner_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same cell, adopted on a card that CAN hold the recorded winner: the
+    verdict is obeyed exactly as before, and nothing calls itself a re-fit."""
+    _on_card(monkeypatch, 96 * GB, "NVIDIA RTX PRO 6000", "sm_120")
+    assert kl.adopt(_minted_on_the_big_card()) == "baseline+dense"
+
+    reason = kl.pinned()[1]
+    assert kl.REASON_ADOPTED in reason
+    assert kl.REASON_REFIT_LOCAL not in reason
+    assert kl.REASON_REFIT_NO_FIT not in reason
+    assert kl.REASON_FIT_UNVERIFIED not in reason
+
+
+def test_nothing_fitting_locally_takes_the_smallest_not_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 16 GB card holds neither lane. Obeying the verdict would OOM; so
+    would "fall back to the declared default", because the default carries
+    the DENSE modulation and is the LARGER of the two. The smallest recorded
+    peak is pinned instead, with its own typed reason, and the degrade path
+    owns what happens next."""
+    _on_card(monkeypatch, 16 * GB, "NVIDIA RTX 5080", "sm_120")
+    assert kl.adopt(_minted_on_the_big_card()) == "fused+packed"
+
+    lane, reason = kl.pinned()
+    assert kl.REASON_REFIT_NO_FIT in reason
+    assert lane != kl.DEFAULT_LANE  # the default is the 48 GB lane here
+    assert f"binding={kl.BIND_NO_FIT}" in reason
+
+
+def test_the_recorded_winner_survives_when_it_is_the_one_that_fits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-regression case: a verdict minted ON a small card names the
+    small lane, and adoption on that same class of card must not invent a
+    re-fit or drift to anything else."""
+    verdict = kl.select(
+        [_BIG, _SMALL], device_total_bytes=32 * GB,
+        device_name="NVIDIA RTX 5090", sm="sm_120")
+    assert verdict.winner == "fused+packed"
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    meta = {kl.META_KEY: kl.envelope_block(verdict)}
+    assert kl.adopt(meta) == "fused+packed"
+    assert kl.REASON_ADOPTED in kl.pinned()[1]
+    assert kl.REASON_REFIT_LOCAL not in kl.pinned()[1]
+
+
+def test_full_evidence_reruns_the_whole_rule_against_this_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the caller holds the PUBLISHED metadata, the evidence block has
+    both lanes' ms/step AND peaks — so the local re-fit is not a reduced
+    rule, it is `select()` itself re-run against this card's total. The
+    detail therefore carries the recorded timings, which the envelope-only
+    path cannot know."""
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    # Three lanes, so the local answer is a genuine SPEED decision among the
+    # survivors rather than "the one thing left".
+    mid = _m("baseline+packed", 1150.0, 22.0)
+    verdict = kl.select(
+        [_BIG, mid, _SMALL], device_total_bytes=96 * GB, sm="sm_120")
+    assert verdict.winner == "baseline+dense"
+    meta = json.loads(json.dumps({
+        kl.META_KEY: kl.envelope_block(verdict),
+        kl.EVIDENCE_KEY: kl.evidence_block(verdict),
+    }))
+    assert kl.adopt(meta) == "baseline+packed"
+    reason = kl.pinned()[1]
+    assert kl.REASON_REFIT_LOCAL in reason
+    assert kl.EVIDENCE_KEY in reason  # the provenance of the numbers used
+    # `select()`'s own speed detail — the envelope-only path has no timings
+    # and could not produce this sentence.
+    assert f"binding={kl.BIND_SPEED}" in reason
+    assert "1150.0" in reason and "1240.0" in reason
+
+
+def test_a_cell_with_no_recorded_peaks_is_adopted_but_marked_unverified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DECIDED: a cell that records no per-candidate peaks (a verdict minted
+    before the fit block existed, or a `sole_candidate` verdict that measured
+    nothing) is ADOPTED, not dropped — and it says the fit is unverified
+    across cards.
+
+    Falling to the declared default here would not be the conservative
+    choice: the default is `baseline+dense`, and DENSE is the larger
+    residency of the two modulation values, so "be safe, take the default"
+    would trade a possibly-too-big lane for a certainly-bigger one. The
+    numerics self-checks still gate arming on the box, and every verdict
+    minted from here on carries its peaks."""
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    meta = _minted_on_the_big_card()
+    meta[kl.META_KEY].pop("fit")  # a pre-fit-block pgw#947 cell
+
+    assert kl.adopt(meta) == "baseline+dense"
+    reason = kl.pinned()[1]
+    assert kl.REASON_ADOPTED in reason
+    assert kl.REASON_FIT_UNVERIFIED in reason
+    assert "baseline+dense" in reason
+
+
+def test_a_sole_candidate_verdict_records_no_peaks_and_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A card with one buildable lane pays for no benchmark, so there is
+    nothing to re-fit — and the envelope carries no fit block rather than an
+    empty one that would look like a checked constraint."""
+    _on_card(monkeypatch, 24 * GB, "NVIDIA L4", "sm_89")
+    verdict = kl.sole("baseline+dense", "sm_89 is not Blackwell")
+    envelope = kl.envelope_block(verdict)
+    assert "fit" not in envelope
+    assert kl.adopt({kl.META_KEY: envelope}) == "baseline+dense"
+    assert kl.REASON_FIT_UNVERIFIED in kl.pinned()[1]
+
+
+def test_a_worker_that_cannot_detect_its_card_adopts_and_says_unverified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _on_card(monkeypatch, 0, "", "")
+    assert kl.adopt(_minted_on_the_big_card()) == "baseline+dense"
+    assert kl.REASON_FIT_UNVERIFIED in kl.pinned()[1]
+
+
+def test_the_refit_runs_through_the_packed_artifact_the_executor_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end on the path the executor actually calls: a tar on disk,
+    read by `adopt_from_artifact`, re-fit against this card."""
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    artifact = _packed(tmp_path, _minted_on_the_big_card())
+    assert kl.adopt_from_artifact(artifact, source="unit") == "fused+packed"
+    assert kl.REASON_REFIT_LOCAL in kl.pinned()[1]
+
+
+def test_recorded_peaks_survive_the_double_mint_byte_compare() -> None:
+    """(c) Peak BYTES may ride the packed envelope; raw ones may not.
+
+    The #699 gate compares two mints' `metadata.json` byte for byte. A raw
+    `max_memory_allocated()` is a measurement — an autotuned kernel picking a
+    different workspace moves it — so the envelope carries the peak QUANTIZED
+    up to a coarse grain, which is the same trick `MARGIN_FRACTION` already
+    plays on the winner. Here two mints disagree by 40 MB of peak and 3 ms of
+    step time and produce byte-identical envelopes."""
+    def _mint(peak_jitter: float, ms_jitter: float) -> str:
+        verdict = kl.select(
+            [_m("baseline+dense", 1063.0 + ms_jitter, 48.0 + peak_jitter),
+             _m("fused+packed", 1240.0 - ms_jitter, 20.0 - peak_jitter)],
+            device_total_bytes=96 * GB, sm="sm_120")
+        return json.dumps(kl.envelope_block(verdict), sort_keys=True)
+
+    assert _mint(0.0, 0.0) == _mint(0.04, 3.0) == _mint(-0.04, -3.0)
+    # And the quantization only ever rounds UP, so the re-applied constraint
+    # is never more permissive than the measurement it came from.
+    assert kl.quantize_peak(int(48.0 * GB)) >= int(48.0 * GB)
+    assert kl.quantize_peak(1) == kl.PEAK_QUANTUM_BYTES
+    assert kl.quantize_peak(0) == 0
+
+
+def test_the_fallback_order_is_the_ranking_and_the_winner_leads_it() -> None:
+    """The order is what a serving worker falls THROUGH when the winner does
+    not fit, so it has to be the rule's own ranking — and it has to be
+    discrete, or it could not ride the envelope. Speed ranks it; ties inside
+    the margin are ordered by the smaller peak; the recorded winner leads."""
+    rows = [
+        _m("baseline+dense", 228.0, 44.1),
+        _m("baseline+packed", 231.0, 34.6),   # within the 5% margin
+        _m("fused+dense", 350.0, 44.6),
+        _m("fused+packed", 350.0, 35.1),
+    ]
+    verdict = kl.select(rows, device_total_bytes=180 * GB, sm="sm_100")
+    order = kl.refit_order(rows, winner=verdict.winner)
+    assert order[0] == verdict.winner == "baseline+packed"
+    assert order == ("baseline+packed", "baseline+dense",
+                     "fused+packed", "fused+dense")
+
+
+def test_the_refit_never_pins_a_lane_this_worker_cannot_implement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cell from a newer worker may record candidates this one has no
+    vocabulary for. They are dropped from the re-fit rather than pinned, and
+    `pin()` would refuse them anyway."""
+    _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
+    meta = _minted_on_the_big_card()
+    meta[kl.META_KEY]["fit"]["peaks"]["tcgen05-v2"] = 1
+    meta[kl.META_KEY]["fit"]["order"].insert(0, "tcgen05-v2")
+    assert kl.adopt(meta) == "fused+packed"
+    assert kl.pinned()[0] in kl.LANES
 
 
 # --- the mint-side A/B -----------------------------------------------------


### PR DESCRIPTION
## The gap (Paul, verified at source on `ea23db6c`)

`adopt()` / `adopt_from_artifact()` read the recorded lane out of the cell's `metadata.json` and `pin()`ed it with **no local re-validation**. The fit constraint (`measured_peak x 1.20 + 1 GiB <= detected total`) was applied **only at mint, against the MINTING card's memory**.

Cell keys are keyed on SM and the lane is deliberately **not** a key axis (correctly — it would fork the namespace and halve reuse). So one key spans a 96 GB RTX PRO 6000 and a 32 GB RTX 5090. The small card adopted the big card's verdict and could pin a lane whose measured peak does not fit it. The kernels' numerics self-checks are **correctness** checks, not memory checks, so the symptom is an OOM or a silent slide into CPU-offload degraded mode.

> "we cannot guarantee that two separate GPUs with the same sm_x capability will both want to use the same set of kernels."

## The fix (memory axis)

`kernel_lane.adopt()` re-applies the rule against **this** device's honestly detected total (`device_facts()`, the strict_vram rule) before pinning:

| local outcome | pinned | typed reason |
|---|---|---|
| recorded winner fits here | the recorded winner (fast path, unchanged) | `kernel_lane_verdict_adopted` + the re-check |
| it does not fit | the fastest RECORDED candidate that does | `kernel_lane_refit_local` |
| nothing fits | the SMALLEST recorded peak | `kernel_lane_refit_no_fit` |
| no recorded peaks / no detectable total | the recorded winner | `kernel_lane_fit_unverified` |

The refit reason names the recorded winner, its ask, this device and its total, the binding term, and the provenance of the numbers — visible, never silent.

With the published `kernel_lane_evidence` in hand (both lanes' ms/step **and** peaks) the re-fit is `select()` **itself** re-run against the local total, not a reduction of it.

### One deliberate refinement of the brief

"Nothing fits" pins the **smallest recorded peak**, not `DEFAULT_LANE`. `DEFAULT_LANE` is `baseline+dense`, and DENSE is the *larger* residency of the two modulation values (22.8 vs 13.3 GB on B200) — "be safe, take the default" on a card that just ran out of memory would trade a too-big lane for the biggest lane of all. `select()` already answers no-fit this way (`BIND_NO_FIT` takes the smallest peak); adoption now matches it.

## Peak bytes in the packed cell — yes, quantized

A serving worker only ever reads the packed cell, so the peaks have to travel in it. The #699 double-mint gate byte-compares two mints' `metadata.json`; a raw `max_memory_allocated()` is a **measurement** (an autotuned kernel picking a different workspace moves it), so the envelope carries `kernel_lane.fit` with each peak **rounded UP to 256 MiB**, plus the fallback `order`. Quantization is the same trick `MARGIN_FRACTION` already plays on the winner — noise must cross a coarse grain to move a recorded fact — and rounding up can only make the constraint stricter. Cell keys do not move: `cell_identity()` keys named facts, not the envelope.

`test_recorded_peaks_survive_the_double_mint_byte_compare` drives 40 MB of peak jitter and 3 ms of step jitter through two mints and gets byte-identical envelopes.

## Evidence-absent decision: ADOPT + `kernel_lane_fit_unverified`

Option (a), not (b), for the same asymmetry: falling to `DEFAULT_LANE` means moving to the DENSE modulation — the larger residency — on the exact axis the concern is about. The recorded winner did pass a fit test on a card of the same SM class, the per-axis numerics self-checks still gate arming, and the case is shrinking to nothing because every verdict minted from here on carries its peaks.

## Speed axis — recorded, NOT solved

The ranking can also differ inside an SM class (1189 ms/step on a 5090 vs 1063 on a PRO 6000 for the same work). Detecting that needs re-benchmarking, which serving must not do. Options are written up on pgw#947 for Paul's ruling; pgw#951 (the sibling design lane — SM-keyed graph, per-GPU-class verdict records accumulating beside it) is the durable answer, and this lane is the memory-axis safety net underneath it, not a competitor.

## Tests

12 new cases in `tests/test_kernel_lane_pgw947.py` (21 -> 33), same integration shape as the existing suite: the cross-card re-fit, the unchanged fast path, no-candidate-fits, the evidence-absent decision asserted, the full-evidence `select()` re-run, the packed-tar path the executor actually calls, the double-mint byte-compare, the fallback order, and an unknown-lane guard. `test_no_sm_allowlist_survives` stays green.

- lane suites: **33 passed** (`test_kernel_lane_pgw947.py` + `test_native_kernels_pgw860.py` = 33 + skips)
- full `tests/`: **3099 passed, 2 failed** — both `test_magic_timeouts_gw666`, the pre-existing pgw#949 failures on `dev`, not this lane's
- `tests_v2/`: **21 passed**
- mypy clean (226 files), ruff clean (0.15.21), `lint_http_timeouts.py` + `lint_unreached_surface.py` clean

No version bump.