### PR TITLE
pgw#950: hardcut the pre-stamp legacy arms — the cache they serve is disposable, and the miss policy is a re-mint

### DIFF
--- a/src/gen_worker/aot_cells.py
+++ b/src/gen_worker/aot_cells.py
@@ -181,6 +181,16 @@ def _candidates(
         if not cell_key.is_key(key):
             _reject("unreadable_cell_key")
             continue
+        # Pre-clamp retirement (arm-events lane, live-proven 2026-07-29):
+        # a cell carrying no host-ISA stamp states no requirement, so its true
+        # ISA need is undiscoverable from metadata and an AVX-512-built .pt2
+        # SIGILLs a non-AVX-512 host. ``aot_serve.verify`` refuses it too;
+        # ruling here first keeps the fact its OWN reject class rather than
+        # folding it into a ``verify:`` string.
+        if not isinstance(meta.get("host_isa"), dict):
+            logger.debug("aot-cells: %s filtered: no host_isa stamp", key)
+            _reject(aot_serve.NO_HOST_ISA_STAMP)
+            continue
         reason = aot_serve.verify(meta, family=family)
         if reason:
             logger.debug("aot-cells: %s filtered: %s", key, reason)
@@ -188,19 +198,6 @@ def _candidates(
             # fleet-wide sm/torch/ISA/contract mismatch surfaces as itself
             # rather than as a generic "verify failed".
             _reject(f"verify:{reason}")
-            continue
-        # Pre-clamp retirement (arm-events lane, live-proven 2026-07-29):
-        # a cell minted before the pgw#754 host-ISA stamp carries no
-        # metadata requirement, so its true ISA need is only discoverable
-        # AFTER download, at stage time — where an AVX-512-built .pt2
-        # refuses every non-AVX-512 host by name. Unstamped cells are
-        # structurally unadoptable across the fleet; retire them from
-        # discovery instead of downloading doomed candidates.
-        if not isinstance(meta.get("host_isa"), dict):
-            logger.debug(
-                "aot-cells: %s filtered: no host_isa stamp (pre-clamp cell)",
-                key)
-            _reject("no_host_isa_stamp")
             continue
         if _lane_of_meta(meta) != want_lane:
             _reject("lane_mismatch")
@@ -212,15 +209,14 @@ def _candidates(
         ))
     # Preference order (pgw#765), all descending:
     #   1. same SKU — the cell's inductor autotuning ran on this board;
-    #   2. a stamped ``sm`` axis — provably this architecture pre-download,
-    #      where an unstamped legacy cell only resolves at stage time;
-    #   3. newest (checkpoint ``updated_at``), key digest as the
+    #   2. newest (checkpoint ``updated_at``), key digest as the
     #      deterministic tie-break.
+    # (``sm`` is no longer a tie-break: ``verify`` refuses a cell silent on
+    # the axis, so every survivor here is stamped and matching.)
     here_sku = aot_serve.runtime_key()["sku"]
     out.sort(
         key=lambda row: (
             str(row[2].get("sku") or "") == here_sku and bool(here_sku),
-            bool(str(row[2].get("sm") or "")),
             row[0],
             str(row[2].get("cell_key")),
         ),

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -607,7 +607,8 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     not maj.min, or the load either fails obscurely or is undefined.
 
     Fail-closed on every REAL axis (:data:`IDENTITY_AXES` + host ISA +
-    contract hashes) and never on ``sku`` (pgw#765): a cell minted on an l4
+    contract hashes), each of them STRICTLY — an axis a cell is silent on is
+    refused by name, never skipped. Never on ``sku`` (pgw#765): a cell minted on an l4
     and a cell minted on an rtx-4090 are the same sm_89 compiled code, and
     refusing the cross-SKU adoption discards the whole point of the pgw#691
     collapse, the FX inner-key shim, and the pgw#754 ISA clamp. The JIT lane
@@ -630,14 +631,6 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
         return "torch not importable"
     for field_name in IDENTITY_AXES:
         want, have = str(meta.get(field_name) or ""), here[field_name]
-        if field_name == "sm" and not want:
-            # A pre-pgw#765 cell stamped no capability. Its REAL arch is
-            # readable from the .pt2's own AOTI_COMPUTE_CAPABILITY once the
-            # bytes are staged (:func:`verify_package_compute_capability`,
-            # the pgw#754 two-tier shape), so the axis is not silently
-            # dropped — it is ruled on where the answer exists, before any
-            # dlopen. Metadata-only callers (discovery) cannot know it.
-            continue
         if want != have:
             return f"{field_name} {want!r} != runtime {have!r}"
     isa_reason = host_isa_reason(meta)
@@ -670,45 +663,28 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     return ""
 
 
+#: :func:`host_isa_reason`'s refusal for a cell that stamped no requirement.
+#: Also the ``aot_cells`` discovery reject class, so the same fact has one name
+#: whether it is ruled on before download or after staging.
+NO_HOST_ISA_STAMP = "no_host_isa_stamp"
+
+
 def host_isa_reason(meta: Mapping[str, Any]) -> str:
     """'' when this host's CPU can execute the artifact's packaged host
     code, else the refusal reason (pgw#754).
 
     Reads the mint's ``host_isa`` requirement stamp — metadata-only, so
     discovery (``aot_cells._candidates``) filters unexecutable cells BEFORE
-    downloading them. Artifacts minted before the stamp existed return ''
-    here; :func:`verify_package_host_isa` covers them once bytes are staged.
+    downloading them. An artifact carrying NO stamp is refused here: its true
+    ISA need is undiscoverable from metadata, an AVX-512-built ``.pt2``
+    SIGILLs (exit 132 inside ``aoti_load_package``) on a host without it, and
+    the miss policy for a refused cell is a self-mint that stamps one.
     """
     block = meta.get("host_isa")
     if not isinstance(block, Mapping):
-        return ""
+        return f"artifact records no host_isa stamp ({NO_HOST_ISA_STAMP})"
     level, machine = host_isa.requirement_of_meta(block)
     return host_isa.unsupported_reason(level, machine)
-
-
-def verify_package_host_isa(meta: Mapping[str, Any], package: Path) -> str:
-    """The staged-bytes host-ISA gate: stamped requirement when present,
-    else torch's own ``AOTI_CPU_ISA``/``AOTI_MACHINE`` stamps inside the
-    ``.pt2`` (present since torch 2.x package format; the mint host's picked
-    vector ISA, which a ``-march=native`` build tracks). '' = executable.
-
-    This is what turns the live SIGILL class (exit 132 inside
-    ``aoti_load_package`` on a host lacking the mint host's AVX-512) into a
-    named ``adopt_failed:host_isa_unsupported`` refusal for every artifact,
-    including legacy cells minted before the metadata stamp existed.
-    """
-    reason = host_isa_reason(meta)
-    if reason:
-        return reason
-    if isinstance(meta.get("host_isa"), Mapping):
-        return ""  # stamped and satisfied; no legacy sniff needed
-    for row in _package_torch_stamps(package):
-        level = host_isa.vec_isa_level(str(row.get("AOTI_CPU_ISA") or ""))
-        machine = str(row.get("AOTI_MACHINE") or "")
-        reason = host_isa.unsupported_reason(level, machine)
-        if reason:
-            return reason + " (torch package stamp, pre-pgw#754 cell)"
-    return ""
 
 
 def _package_torch_stamps(package: Path) -> List[Dict[str, Any]]:
@@ -738,17 +714,15 @@ def _package_torch_stamps(package: Path) -> List[Dict[str, Any]]:
     return rows
 
 
-def verify_package_compute_capability(
-    meta: Mapping[str, Any], package: Path,
-) -> str:
+def verify_package_compute_capability(package: Path) -> str:
     """The staged-bytes GPU-architecture gate: torch's own
     ``AOTI_COMPUTE_CAPABILITY`` inside the ``.pt2`` against this device's
     capability. '' = same architecture (or unknowable).
 
     The second tier that lets :func:`verify` stop refusing on ``sku``
     without loosening the axis that actually matters (pgw#765). It rules on
-    the two cases metadata cannot: a pre-pgw#765 cell that stamped no ``sm``
-    axis at all, and a cell whose stamp disagrees with its own bytes. A
+    the one case metadata cannot: a cell whose ``sm`` stamp disagrees with
+    its own bytes. A
     cubin built for another arch has no PTX fallback (pgw#698 packs cubins
     only), so without this the refusal would be a raw CUDA load error
     instead of a named ``adopt_failed:sm_mismatch``.
@@ -764,7 +738,6 @@ def verify_package_compute_capability(
     # comparison also admits the dotted/tuple spellings other device
     # interfaces use, so a shape surprise is never read as a mismatch.
     here_digits = "".join(c for c in here if c.isdigit())
-    legacy = "" if meta.get("sm") else "pre-pgw#765 cell, "
     for row in _package_torch_stamps(package):
         raw = str(row.get("AOTI_COMPUTE_CAPABILITY") or "").strip()
         digits = "".join(c for c in raw if c.isdigit())
@@ -772,7 +745,7 @@ def verify_package_compute_capability(
             continue
         if digits != here_digits:
             return (f"sm 'sm_{digits}' != runtime {here!r} "
-                    f"({legacy}torch package stamp)")
+                    f"(torch package stamp)")
     return ""
 
 
@@ -895,9 +868,8 @@ def stage_artifact(
     try:
         meta = unpack(Path(artifact), root)
         # pgw#754: rule on host-CPU executability FIRST and by name — the
-        # one failure mode that must never reach dlopen. Covers stamped
-        # requirements and (via the .pt2's own torch stamps) legacy cells.
-        isa_reason = verify_package_host_isa(meta, root / PACKAGE_NAME)
+        # one failure mode that must never reach dlopen.
+        isa_reason = host_isa_reason(meta)
         if isa_reason:
             raise AdoptError("host_isa_unsupported", isa_reason)
         reason = verify(meta, family=family)

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -879,8 +879,7 @@ def stage_artifact(
         # on by name before dlopen — the tier that keeps cross-SKU adoption
         # honest now that ``sku`` no longer stands in for the arch. Runs
         # after `verify` so a stamped axis mismatch keeps its own name.
-        sm_reason = verify_package_compute_capability(
-            meta, root / PACKAGE_NAME)
+        sm_reason = verify_package_compute_capability(root / PACKAGE_NAME)
         if sm_reason:
             raise AdoptError("sm_mismatch", sm_reason)
         return _StagedAotArtifact(meta, root, temporary)
@@ -2357,6 +2356,7 @@ __all__ = [
     "find_artifact",
     "flavor_label",
     "host_isa_reason",
+    "NO_HOST_ISA_STAMP",
     "ingress_class_name",
     "ingress_refusals",
     "is_aot_artifact",
@@ -2382,6 +2382,5 @@ __all__ = [
     "unwrap",
     "verify",
     "verify_package_compute_capability",
-    "verify_package_host_isa",
     "wrap_module",
 ]

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -219,8 +219,10 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
 
     Derived from the metadata, never from the stamped ``cell_key`` field, so
     a stamp can never disagree with the axes it summarizes. Raises
-    :class:`CellKeyError` for artifacts that don't record every required axis
-    (pre-gw#581 cells have no key and stay on the legacy verify path).
+    :class:`CellKeyError` for artifacts that don't record every required axis.
+    That is the ONLY verdict — pgw#950 deleted the second, axis-by-axis verify
+    path keyless cells used to fall back to, on both the fleet and the local
+    store. A cell with no computable key is refused and re-minted.
 
     EXPORTED (``aot-inductor``) cells are refused here BY NAME (pgw#735): they
     ride the same ck5 key space — the axis names are what :func:`from_axes`

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2596,24 +2596,32 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
         )
     # SDK v2: the recorded shape contract must be the declared one — a
     # worker on a newer contract must never serve an older cell (pgw#647).
-    # SILENT IS A REFUSAL, on this axis as on every other: a cell recording no
-    # contract at all is a pre-contract mint, and adopting it is the exact
-    # "version axis only sometimes incorporated" wrong-cache-hit ``verify``
-    # was hardened against.
+    #
+    # NOT CUT by pgw#950, deliberately: a cell recording NO shape_contract is
+    # skipped here, which is the same silent-axis shape as the arm below, but
+    # ~9 test fixtures build metadata without one (every PRODUCTION mint passes
+    # ``shape_contract=declared_contract_facts(cfg)``, so the gap is fixtures,
+    # not producers). Tightening it is a fixture sweep, not a deletion, so it
+    # is its own change.
     cell_contract = meta.get("shape_contract") or {}
-    if not cell_contract:
-        return "cell records no shape_contract block (pre-contract mint)"
-    here_contract = declared_contract_facts(cfg)
-    if cell_contract != here_contract:
-        return (
-            "shape contract mismatch: "
-            + _first_contract_difference(cell_contract, here_contract)
-        )
+    if cell_contract:
+        here_contract = declared_contract_facts(cfg)
+        if cell_contract != here_contract:
+            return (
+                "shape contract mismatch: "
+                + _first_contract_difference(cell_contract, here_contract)
+            )
     signature, weight_contract = execution_contract(pipeline, cfg)
     meta_signature = str(meta.get("graph_signature") or "")
     meta_weights = meta.get("weight_contract") or {}
     if not meta_signature:
-        return "cell records no graph_signature (pre-contract mint)"
+        # pgw#950: this used to ``return ""`` — COMPATIBLE — for a cell silent
+        # on both graph_signature and weight_contract on a non-quantized lane
+        # ("legacy format-2"). Every production mint passes a signature (
+        # ``execution_contract`` always digests a structure, never ""), so the
+        # arm only ever admitted pre-format-3 cells, and admitting one is a
+        # wrong cache hit on the module graph itself.
+        return "cell records no graph_signature (pre-format-3 cell)"
     if meta_signature != signature:
         # pgw#697: when the cell carries per-module fingerprint rows, name
         # the exact drifted module instead of two digest prefixes.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2596,21 +2596,24 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
         )
     # SDK v2: the recorded shape contract must be the declared one — a
     # worker on a newer contract must never serve an older cell (pgw#647).
+    # SILENT IS A REFUSAL, on this axis as on every other: a cell recording no
+    # contract at all is a pre-contract mint, and adopting it is the exact
+    # "version axis only sometimes incorporated" wrong-cache-hit ``verify``
+    # was hardened against.
     cell_contract = meta.get("shape_contract") or {}
-    if cell_contract:
-        here_contract = declared_contract_facts(cfg)
-        if cell_contract != here_contract:
-            return (
-                "shape contract mismatch: "
-                + _first_contract_difference(cell_contract, here_contract)
-            )
+    if not cell_contract:
+        return "cell records no shape_contract block (pre-contract mint)"
+    here_contract = declared_contract_facts(cfg)
+    if cell_contract != here_contract:
+        return (
+            "shape contract mismatch: "
+            + _first_contract_difference(cell_contract, here_contract)
+        )
     signature, weight_contract = execution_contract(pipeline, cfg)
     meta_signature = str(meta.get("graph_signature") or "")
     meta_weights = meta.get("weight_contract") or {}
-    if not meta_signature and not meta_weights and not str(
-        weight_contract.get("lane") or ""
-    ).startswith(("w8a8", "w4a4")):
-        return ""  # legacy format-2 non-quantized-lane cell
+    if not meta_signature:
+        return "cell records no graph_signature (pre-contract mint)"
     if meta_signature != signature:
         # pgw#697: when the cell carries per-module fingerprint rows, name
         # the exact drifted module instead of two digest prefixes.

--- a/src/gen_worker/host_isa.py
+++ b/src/gen_worker/host_isa.py
@@ -317,19 +317,6 @@ def requirement_of_meta(block: Mapping[str, object]) -> Tuple[str, str]:
     return str(block.get("level") or ""), str(block.get("machine") or "")
 
 
-def vec_isa_level(aoti_cpu_isa: str) -> str:
-    """Map torch's own ``AOTI_CPU_ISA`` package stamp (the mint host's picked
-    vector ISA, e.g. ``"AVX512 AVX512_VNNI"``) to the psABI level it implies.
-    Best-effort legacy gate for artifacts minted before the stamp existed —
-    a native-built wrapper's needs track the mint host the pick describes."""
-    text = aoti_cpu_isa.upper()
-    if "AMX" in text or "AVX512" in text:
-        return "x86-64-v4"
-    if "AVX2" in text:
-        return "x86-64-v3"
-    return ""
-
-
 __all__ = [
     "BASELINE",
     "HostIsaError",
@@ -343,5 +330,4 @@ __all__ = [
     "requirement_of_meta",
     "stamp",
     "unsupported_reason",
-    "vec_isa_level",
 ]

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -95,29 +95,25 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
             meta = json.loads(member.read().decode())
     except Exception as exc:  # noqa: BLE001 — any unreadable cell re-mints
         return f"unreadable artifact ({exc})"
-    # th#883/gw#581: ONE compatibility brain — when both sides can state a
-    # cell key (local mints stamp one via artifact_metadata), the verdict is
-    # the exact key comparison fleet workers use; pre-key cells fall back to
-    # the legacy axis-by-axis verify.
-    reason = ""
-    try:
-        from . import cell_key
+    # th#883/gw#581: ONE compatibility brain, and only one. The verdict is the
+    # exact key comparison fleet workers use. A cell that cannot state a key —
+    # and a runtime that cannot compute one — is a refusal, not a fall-through
+    # to a second, weaker axis-by-axis verify: the local store is a cache whose
+    # miss policy is a re-mint, so the fallback bought a stale cell adoption
+    # and nothing else.
+    from . import cell_key
 
-        # pgw#686: the ONE base-lane resolution the mint's stamp uses —
-        # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
-        # store save/lookup pair straddling apply_lora_lane would never
-        # match and every boot would re-mint.
-        want = cell_key.compute(
-            family, cc.cell_base_lane(pipe),
-            int(getattr(cfg, "lora_bucket", 0) or 0),
-            contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
-            regional=bool(getattr(cfg, "regional", False)),
-        )
-        reason = cell_key.mismatch(meta, want)
-        if reason and "records no computable key" in reason:
-            reason = cc.verify(meta, family=family)
-    except Exception:
-        reason = cc.verify(meta, family=family)
+    # pgw#686: the ONE base-lane resolution the mint's stamp uses —
+    # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
+    # store save/lookup pair straddling apply_lora_lane would never
+    # match and every boot would re-mint.
+    want = cell_key.compute(
+        family, cc.cell_base_lane(pipe),
+        int(getattr(cfg, "lora_bucket", 0) or 0),
+        contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
+        regional=bool(getattr(cfg, "regional", False)),
+    )
+    reason = cell_key.mismatch(meta, want)
     if reason:
         return reason
     reason = cc.mode_drift(meta, pipe) or cc.lane_drift(meta, pipe)

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -95,25 +95,36 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
             meta = json.loads(member.read().decode())
     except Exception as exc:  # noqa: BLE001 — any unreadable cell re-mints
         return f"unreadable artifact ({exc})"
-    # th#883/gw#581: ONE compatibility brain, and only one. The verdict is the
-    # exact key comparison fleet workers use. A cell that cannot state a key —
-    # and a runtime that cannot compute one — is a refusal, not a fall-through
-    # to a second, weaker axis-by-axis verify: the local store is a cache whose
-    # miss policy is a re-mint, so the fallback bought a stale cell adoption
-    # and nothing else.
+    # th#883/gw#581: ONE compatibility brain when a key exists on both sides —
+    # the exact key comparison fleet workers use.
+    #
+    # pgw#950 deleted the arm below it: a cell that records no computable key
+    # used to fall through to ``cc.verify``'s axis-by-axis check, which is how
+    # a pre-gw#581 cell kept getting adopted. It does not any more. The local
+    # store is a cache; refusing a keyless cell costs one re-mint.
+    #
+    # The ``except`` that remains is NOT that arm. ``cell_key.compute`` needs a
+    # runtime ``sm``, so it raises on a host with no CUDA — the CLI, cozy-local
+    # and library use. There ``cc.verify`` is the only brain that can answer at
+    # all, so it is the no-GPU path, not a legacy one. Typed, so a real bug in
+    # the key brain surfaces instead of being read as "no GPU".
     from . import cell_key
 
-    # pgw#686: the ONE base-lane resolution the mint's stamp uses —
-    # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
-    # store save/lookup pair straddling apply_lora_lane would never
-    # match and every boot would re-mint.
-    want = cell_key.compute(
-        family, cc.cell_base_lane(pipe),
-        int(getattr(cfg, "lora_bucket", 0) or 0),
-        contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
-        regional=bool(getattr(cfg, "regional", False)),
-    )
-    reason = cell_key.mismatch(meta, want)
+    try:
+        # pgw#686: the ONE base-lane resolution the mint's stamp uses —
+        # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
+        # store save/lookup pair straddling apply_lora_lane would never
+        # match and every boot would re-mint.
+        want = cell_key.compute(
+            family, cc.cell_base_lane(pipe),
+            int(getattr(cfg, "lora_bucket", 0) or 0),
+            contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
+            regional=bool(getattr(cfg, "regional", False)),
+        )
+    except cell_key.CellKeyError:
+        reason = cc.verify(meta, family=family)
+    else:
+        reason = cell_key.mismatch(meta, want)
     if reason:
         return reason
     reason = cc.mode_drift(meta, pipe) or cc.lane_drift(meta, pipe)

--- a/src/gen_worker/topology.py
+++ b/src/gen_worker/topology.py
@@ -206,12 +206,22 @@ KEY_GPUS_PER_GROUP = "gpus_per_execution_group"
 KEY_EXECUTION_GROUPS = "execution_groups"
 KEY_PARALLEL = "parallel"
 
-# th#1375's pre-rename spelling. Accepted here, and emitted alongside the new
-# spelling by ``as_dict``, for exactly one release: the hub and the workers
-# deploy independently and prod pins gen-worker 0.79.0, so no flip day exists on
-# which every reader speaks the new names. Carrying both makes deploy ORDER
-# irrelevant rather than merely survivable. th#1376 deletes them, after which
-# they fall through to ``topology_unknown_field`` by construction.
+# th#1375's pre-rename spelling. NO LONGER EMITTED (pgw#950) — ``as_dict``
+# writes the canonical names only, which every hub already reads: tensorhub's
+# ``reconcileAlias`` treats an absent legacy key as "not written".
+#
+# Still ACCEPTED, and that is the entire remaining transition. It cannot be
+# deleted from this repo alone: the key set below is CLOSED, so an unrecognised
+# key is a hard ``topology_unknown_field`` refusal, and tensorhub's
+# ``internal/orchestrator/topology/topology.go`` STILL EMITS both spellings
+# (``wireValue.LegacyGroupDegree``/``LegacyGroups``). Dropping these two names
+# here before that changes fails EVERY topology decode on EVERY pod.
+#
+# th#1376 is the deletion, and TENSORHUB GOES FIRST: drop the legacy fields
+# from ``wireValue``, collapse it back into ``ExecutionTopology``, delete
+# ``reconcileAlias`` and the ``LegacyKey*`` constants. Once that ships, delete
+# these two names, ``_aliased``, and the two ``_KNOWN_KEYS`` entries — after
+# which they fall through to ``topology_unknown_field`` by construction.
 LEGACY_KEY_GPUS_PER_GROUP = "group_degree"
 LEGACY_KEY_EXECUTION_GROUPS = "groups"
 
@@ -404,12 +414,6 @@ class ExecutionTopology:
             KEY_GPU_COUNT: self.gpu_count,
             KEY_GPUS_PER_GROUP: self.gpus_per_execution_group,
             KEY_EXECUTION_GROUPS: self.execution_groups,
-            # th#1376 removes these two. They are here so this worker's own
-            # produced topology (the parent stamps one per split child, and
-            # ``procsplit`` children may run a different build during a rolling
-            # image swap) is readable by a pre-th#1375 reader.
-            LEGACY_KEY_GPUS_PER_GROUP: self.gpus_per_execution_group,
-            LEGACY_KEY_EXECUTION_GROUPS: self.execution_groups,
         }
         if self.parallel:
             d[KEY_PARALLEL] = self.parallel

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -21,6 +21,7 @@ still named, and now it is also timed and bound to the candidate's ref+digest.
 
 from __future__ import annotations
 
+import platform
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -128,6 +129,11 @@ def _meta(**over: Any) -> Dict[str, Any]:
         "strict_export": True, "lora_bucket": 0,
         "package_constants_in_so": False,
         "source_ref": "", "source_digest": "",
+        # pgw#950: every mint stamps a host-ISA requirement, and a cell that
+        # stamps none is refused rather than sniffed from the .pt2. Satisfiable
+        # anywhere: this host's machine, no ISA level.
+        "host_isa": {"machine": platform.machine(), "march": "", "simdlen": 0,
+                     "level": ""},
     }
     m["combined_graph_hash"] = aot_serve.combined_graph_hash(
         str((b or {}).get("class_hash") or "")
@@ -234,14 +240,16 @@ def test_candidates_retire_unstamped_preclamp_cells(
     stub_runtime: None,
 ) -> None:
     """Live-proven 2026-07-29 (pod 3cjmd3ohuk98a5): an unstamped pre-clamp
-    cell passes every metadata gate, gets downloaded, then refuses at stage
-    (`host_isa_unsupported`, torch package stamp). Discovery must retire the
-    whole class instead of shipping doomed candidates."""
+    cell passes every metadata gate, gets downloaded, then refuses at stage.
+    Discovery must retire the whole class instead of shipping doomed
+    candidates. pgw#950 deleted the stage-time torch-package sniff that used
+    to catch the survivors, so this filter is now the ONLY thing between an
+    unstamped cell and a wasted download."""
     from gen_worker import host_isa
 
     stamped = _meta(host_isa=host_isa.stamp())
     unstamped = _meta()
-    assert "host_isa" not in unstamped
+    unstamped.pop("host_isa")
     items = [
         {"checkpoint_id": "ck-old-preclamp",
          "updated_at": "2026-07-30T00:00:00Z", "metadata": unstamped},

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -17,6 +17,7 @@ The two tests that carry the issue:
 from __future__ import annotations
 
 import json
+import platform
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,13 @@ from gen_worker.cell_adopt import AdoptOutcome
 FAMILY = "sdxl-base"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
            "cuda": "13.0"}
+
+#: pgw#950: every mint stamps a host-ISA requirement (``artifact_metadata``
+#: calls ``host_isa.stamp()`` unconditionally), and a cell that stamps none is
+#: now refused rather than sniffed from the .pt2's own AOTI_CPU_ISA. This is
+#: the satisfiable-anywhere block: this host's machine, no ISA level.
+HOST_ISA = {"machine": platform.machine(), "march": "", "simdlen": 0,
+            "level": ""}
 
 # 1024x1024 exported with symbolic latent dims: the pgw#704 headline is that
 # the SAME artifact serves 1152x896 (144x112 latent units), so the declared
@@ -153,6 +161,7 @@ def _meta(**over):
         "strict_export": True, "lora_bucket": 0,
         "package_constants_in_so": False,
         "source_ref": "", "source_digest": "",
+        "host_isa": dict(HOST_ISA),
     }
     m["combined_graph_hash"] = aot.combined_graph_hash(
         str((b or {}).get("class_hash") or "")

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -981,6 +981,10 @@ def test_guidance_regimes_are_artifact_contract_axis():
     meta = cc.artifact_metadata(
         family="sdxl", shapes=cfg.shapes, targets=cfg.targets,
         guidance_scales=cfg.guidance_scales,
+        # pgw#950: as every production mint does — a cell silent on the
+        # module-graph signature is no longer adoptable.
+        graph_signature=cc.execution_contract(_Pipe(), cfg)[0],
+        weight_contract=cc.execution_contract(_Pipe(), cfg)[1],
     )
     assert meta["guidance_scales"] == [5.0, 0.0]
     assert cc.contract_drift(meta, _Pipe(), cfg) == ""

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -136,18 +136,22 @@ def test_mint_manifest_carries_the_posture_seal() -> None:
 def test_arm_refuses_on_posture_drift_named() -> None:
     """artifact_drift converts a sealed-vs-live posture mismatch into a
     named refusal at arm time — never a downstream guard miss."""
+    class _Pipe:
+        pass
+
+    _sig, _wc = cc.execution_contract(_Pipe(), _cfg())
     base = {
         "compile_mode": "whole", "shapes": [[64, 64]],
         "targets": ["transformer"], "guidance_scales": [],
+        # pgw#950: as every production mint does — a cell silent on the
+        # module-graph signature is no longer adoptable.
+        "graph_signature": _sig, "weight_contract": _wc,
     }
     meta = dict(base)
     meta[gc.MANIFEST_KEY] = {
         "v": 2, "graphs": [], "leaks": [],
         gc.POSTURE_KEY: dict(gc.CANONICAL_POSTURE),
     }
-
-    class _Pipe:
-        pass
 
     assert cc.artifact_drift(meta, _Pipe(), _cfg()) == ""
     with torch.no_grad():

--- a/tests/test_env_contract_pgw718.py
+++ b/tests/test_env_contract_pgw718.py
@@ -221,17 +221,21 @@ def test_arm_names_env_seal_drift(monkeypatch: pytest.MonkeyPatch) -> None:
     """artifact_drift's config half: a cell sealed under a different
     environment refuses with the fact named — a foreign cell is
     diagnosable, never a silent inner-key miss."""
+    class _Pipe:
+        pass
+
+    _sig, _wc = cc.execution_contract(_Pipe(), _cfg())
     base = {
         "compile_mode": "whole", "shapes": [[64, 64]],
         "targets": ["transformer"], "guidance_scales": [],
+        # pgw#950: as every production mint does — a cell silent on the
+        # module-graph signature is no longer adoptable.
+        "graph_signature": _sig, "weight_contract": _wc,
         gc.MANIFEST_KEY: {
             "v": 2, "graphs": [], "leaks": [],
             gc.POSTURE_KEY: dict(gc.CANONICAL_POSTURE),
         },
     }
-
-    class _Pipe:
-        pass
 
     live = dict(base, **{env_seal.SEAL_KEY: env_seal.effective_seal()})
     assert cc.artifact_drift(live, _Pipe(), _cfg()) == ""

--- a/tests/test_host_isa_pgw754.py
+++ b/tests/test_host_isa_pgw754.py
@@ -206,12 +206,16 @@ def test_discovery_filter_drops_stamped_requirement(tmp_path: Path) -> None:
     assert "avx512f" in reason
 
 
-def test_legacy_cell_refused_via_torch_package_stamp(tmp_path: Path) -> None:
-    """A pre-pgw#754 cell has no metadata stamp; the .pt2's own
-    ``AOTI_CPU_ISA`` (present in the live SIGILL artifact:
-    'AVX512 AVX512_VNNI') must still turn the crash into a named refusal."""
-    _requires_avx512()
-    pt2 = tmp_path / "legacy.pt2"
+def test_an_unstamped_cell_is_refused_from_metadata_alone(
+    tmp_path: Path,
+) -> None:
+    """pgw#950: a cell carrying no ``host_isa`` stamp used to be waved past
+    the metadata gate and sniffed at stage time from the ``.pt2``'s own
+    ``AOTI_CPU_ISA``. That sniff is gone. An unstamped cell states no
+    requirement, so it is refused where the metadata is read — BEFORE any
+    download — and the miss policy re-mints one that does stamp.
+    """
+    pt2 = tmp_path / "unstamped.pt2"
     with zipfile.ZipFile(pt2, "w") as zf:
         zf.writestr(
             "model/data/aotinductor/model/abc.wrapper_metadata.json",
@@ -221,15 +225,16 @@ def test_legacy_cell_refused_via_torch_package_stamp(tmp_path: Path) -> None:
             }))
     content, meta = _artifact(tmp_path, pt2.read_bytes())
     meta.pop("host_isa")
-    artifact = aot_serve.pack(content, tmp_path / "legacy.tar.gz", meta)
+    # Discovery rules on it without fetching a byte.
+    reason = aot_serve.host_isa_reason(meta)
+    assert aot_serve.NO_HOST_ISA_STAMP in reason
+    assert aot_serve.NO_HOST_ISA_STAMP in aot_serve.verify(meta)
+    # And staging names the same refusal, on the same class.
+    artifact = aot_serve.pack(content, tmp_path / "unstamped.tar.gz", meta)
     with pytest.raises(aot_serve.AdoptError) as exc_info:
         aot_serve.stage_artifact(artifact, "sdxl")
     assert exc_info.value.reason == "host_isa_unsupported"
-    assert "avx512f" in str(exc_info.value)
-    assert "pre-pgw#754" in str(exc_info.value)
-    # Discovery-side verify must NOT over-refuse a legacy cell from
-    # metadata alone (the requirement is only knowable from the bytes).
-    assert aot_serve.host_isa_reason(meta) == ""
+    assert aot_serve.NO_HOST_ISA_STAMP in str(exc_info.value)
 
 
 def test_satisfiable_stamp_stages(tmp_path: Path) -> None:

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -30,6 +30,7 @@ pod, and no test here may be cited as evidence about a real cell's numerics.
 from __future__ import annotations
 
 import math
+import platform
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -183,6 +184,11 @@ def metadata(rows: Tuple[Tuple[int, int], ...] = ROWS) -> Dict[str, Any]:
         "family": FAMILY, "precision": "w8a8", "cell_key": "cell868",
         "entries": entries, "strict_export": True, "lora_bucket": 0,
         "package_constants_in_so": False, "source_ref": "", "source_digest": "",
+        # pgw#950: every mint stamps a host-ISA requirement, and a cell that
+        # stamps none is refused rather than sniffed from the .pt2. Satisfiable
+        # anywhere: this host's machine, no ISA level.
+        "host_isa": {"machine": platform.machine(), "march": "", "simdlen": 0,
+                     "level": ""},
     }
     meta["combined_graph_hash"] = aot.combined_graph_hash(
         b["class_hash"] for b in entries.values())

--- a/tests/test_sku_relaxation_pgw765.py
+++ b/tests/test_sku_relaxation_pgw765.py
@@ -19,10 +19,16 @@ What is asserted here:
 2. **Both directions, red-verified** — an l4-minted cell verifies and is a
    candidate on an rtx-4090 runtime; an sm-mismatched cell still refuses by
    name, and so does every other real axis.
-3. **The second tier** — a legacy cell that stamped no ``sm`` axis is ruled
-   on from the ``.pt2``'s own ``AOTI_COMPUTE_CAPABILITY`` before dlopen
-   (``sm_mismatch``), because pgw#698 packs cubins with no PTX fallback and
-   a wrong-arch load must be a named refusal, not a CUDA error.
+3. **The second tier** — a cell whose ``sm`` stamp DISAGREES with its own
+   ``.pt2`` is ruled on from torch's ``AOTI_COMPUTE_CAPABILITY`` before
+   dlopen (``sm_mismatch``), because pgw#698 packs cubins with no PTX
+   fallback and a wrong-arch load must be a named refusal, not a CUDA error.
+
+pgw#950 removed the fourth thing this file used to assert: that a cell
+stamping NO ``sm`` axis was tolerated by ``verify`` and deferred to that
+second tier. It is not tolerated any more. A cell silent on an identity axis
+is refused like any other mismatch, and the miss policy re-mints it — so the
+second tier's remaining job is the lying stamp, which metadata cannot catch.
 """
 
 from __future__ import annotations
@@ -103,12 +109,15 @@ def test_torch_and_cuda_mismatches_still_refuse(on_4090: None) -> None:
         _meta(_key("d"), cuda="12.8"), family=FAMILY)
 
 
-def test_unstamped_sm_defers_to_the_staged_bytes(on_4090: None) -> None:
-    """A pre-pgw#765 cell stamped no capability. Metadata alone cannot rule,
-    so discovery must not over-refuse — the package gate rules instead."""
+def test_unstamped_sm_is_refused_like_every_other_silent_axis(
+    on_4090: None,
+) -> None:
+    """pgw#950: a cell silent on ``sm`` used to be waved through ``verify``
+    and deferred to the staged-bytes tier. Silence is now a refusal — the
+    cell is a cache entry, and refusing it costs one re-mint."""
     meta = _meta(_key("e"))
     meta.pop("sm")
-    assert aot_serve.verify(meta, family=FAMILY) == ""
+    assert aot_serve.verify(meta, family=FAMILY) == "sm '' != runtime 'sm_89'"
 
 
 # ---------------------------------------------------------------------------
@@ -151,18 +160,19 @@ def test_newest_wins_within_the_preferred_sku(on_4090: None) -> None:
     assert _picks(items) == ["ck-new", "ck-old", "ck-l4"]
 
 
-def test_a_stamped_sm_outranks_an_unstamped_cross_sku_cell(
+def test_an_unstamped_sm_cell_is_not_a_candidate_at_all(
     on_4090: None,
 ) -> None:
-    """Between two cross-SKU cells, the one provably this architecture
-    pre-download beats the one whose arch only resolves after the fetch."""
+    """pgw#950: an unstamped cell used to be a LOWER-RANKED candidate that
+    still got downloaded. It is not a candidate now — ``verify`` refuses it
+    from metadata, before any fetch."""
     unstamped = _meta(_key("a"))
     unstamped.pop("sm")
     items = [
         _item("ck-unstamped", "2026-07-30T00:00:00Z", unstamped),
         _item("ck-stamped", "2026-07-20T00:00:00Z", _meta(_key("b"))),
     ]
-    assert _picks(items) == ["ck-stamped", "ck-unstamped"]
+    assert _picks(items) == ["ck-stamped"]
 
 
 def test_sm_mismatched_cell_is_not_a_candidate(on_4090: None) -> None:
@@ -174,15 +184,19 @@ def test_sm_mismatched_cell_is_not_a_candidate(on_4090: None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 4. the staged-bytes tier — legacy cells, ruled on before dlopen
+# 4. the staged-bytes tier — a LYING stamp, ruled on before dlopen
+#
+# pgw#950: this tier no longer exists to rescue unstamped cells (they are
+# refused from metadata now). Its one remaining job is the case metadata
+# cannot reach — a cell whose stamp and whose bytes disagree.
 # ---------------------------------------------------------------------------
 
 
-def _legacy_artifact(tmp_path: Path, capability: Optional[str], name: str,
-                     **over: Any) -> Path:
-    """A packed cell with NO ``sm`` stamp whose ``.pt2`` carries torch's own
-    ``AOTI_COMPUTE_CAPABILITY`` (the shape ``get_device_information`` writes).
-    """
+def _bytes_artifact(tmp_path: Path, capability: Optional[str], name: str,
+                    **over: Any) -> Path:
+    """A packed, fully-stamped cell whose ``.pt2`` carries torch's own
+    ``AOTI_COMPUTE_CAPABILITY`` (the shape ``get_device_information`` writes),
+    so metadata and bytes can be made to agree or disagree independently."""
     pt2 = tmp_path / f"{name}.pt2"
     row: Dict[str, str] = {"AOTI_MACHINE": "x86_64"}
     if capability is not None:
@@ -195,20 +209,8 @@ def _legacy_artifact(tmp_path: Path, capability: Optional[str], name: str,
     content.mkdir()
     (content / aot_serve.PACKAGE_NAME).write_bytes(pt2.read_bytes())
     meta = _meta(_key("a"))
-    meta.pop("sm")
     meta.update(over)
     return aot_serve.pack(content, tmp_path / f"{name}.tar.gz", meta)
-
-
-def test_legacy_wrong_arch_cell_refused_by_name(
-    tmp_path: Path, on_4090: None,
-) -> None:
-    artifact = _legacy_artifact(tmp_path, "86", "wrong")
-    with pytest.raises(aot_serve.AdoptError) as exc_info:
-        aot_serve.stage_artifact(artifact, FAMILY)
-    assert exc_info.value.reason == "sm_mismatch"
-    assert "sm_86" in str(exc_info.value)
-    assert "pre-pgw#765" in str(exc_info.value)
 
 
 def test_a_lying_sm_stamp_is_caught_by_the_bytes(
@@ -217,18 +219,31 @@ def test_a_lying_sm_stamp_is_caught_by_the_bytes(
     """A cell stamped ``sm_89`` whose ``.pt2`` was built for sm_86 passes the
     metadata check and must still be refused — the stamp is a claim, the
     package's own capability is the fact."""
-    artifact = _legacy_artifact(tmp_path, "86", "liar", sm="sm_89")
+    artifact = _bytes_artifact(tmp_path, "86", "liar")
     with pytest.raises(aot_serve.AdoptError) as exc_info:
         aot_serve.stage_artifact(artifact, FAMILY)
     assert exc_info.value.reason == "sm_mismatch"
-    assert "pre-pgw#765" not in str(exc_info.value)
+    assert "sm_86" in str(exc_info.value)
 
 
-def test_legacy_same_arch_cell_stages(tmp_path: Path, on_4090: None) -> None:
-    """The l4-minted legacy cell on the 4090: torch stamped 89, this runtime
-    is sm_89, so the bytes stage and the arm proceeds."""
+def test_an_unstamped_cell_never_reaches_the_bytes_tier(
+    tmp_path: Path, on_4090: None,
+) -> None:
+    """pgw#950, the deletion proved: a cell with no ``sm`` stamp is refused
+    as a plain ``key_mismatch`` by ``verify``, NOT rescued (or condemned) by
+    the package's capability stamp."""
+    artifact = _bytes_artifact(tmp_path, "89", "unstamped", sm="")
+    with pytest.raises(aot_serve.AdoptError) as exc_info:
+        aot_serve.stage_artifact(artifact, FAMILY)
+    assert exc_info.value.reason == "key_mismatch"
+    assert "sm ''" in str(exc_info.value)
+
+
+def test_cross_sku_same_arch_cell_stages(tmp_path: Path, on_4090: None) -> None:
+    """The l4-minted cell on the 4090: stamped sm_89, torch stamped 89, this
+    runtime is sm_89, so the bytes stage and the arm proceeds."""
     staged = aot_serve.stage_artifact(
-        _legacy_artifact(tmp_path, "89", "right"), FAMILY)
+        _bytes_artifact(tmp_path, "89", "right"), FAMILY)
     try:
         assert staged.metadata["sku"] == "l4"
     finally:
@@ -241,5 +256,5 @@ def test_unreadable_capability_stamp_is_not_read_as_a_mismatch(
     """A package that stamps no capability at all must not be refused on a
     guess — the load path names its own failure."""
     staged = aot_serve.stage_artifact(
-        _legacy_artifact(tmp_path, None, "silent"), FAMILY)
+        _bytes_artifact(tmp_path, None, "silent"), FAMILY)
     staged.close()

--- a/tests/test_topology_fuzz_pgw867.py
+++ b/tests/test_topology_fuzz_pgw867.py
@@ -276,9 +276,9 @@ def test_decode_of_arbitrary_text_is_typed(raw: str) -> None:
 def test_round_trip(gpu_count: int, degree: int, parallel: str) -> None:
     """P2: ``decode(as_dict(t)) == t`` for every constructible topology.
 
-    ``as_dict`` still emits the th#1375 legacy spellings alongside the new ones,
-    so this is also the assertion that the transition's dual write is readable
-    by the decoder that has to survive it.
+    pgw#950: ``as_dict`` emits the canonical spellings ONLY, so this is also
+    the assertion that the dual write is gone and the round trip never
+    depended on it.
     """
     try:
         topo = ExecutionTopology(
@@ -287,9 +287,10 @@ def test_round_trip(gpu_count: int, degree: int, parallel: str) -> None:
     except TopologyError:
         return
     payload = topo.as_dict()
-    # Both spellings present and agreeing — deploy order must not matter.
-    assert payload[LEGACY_KEY_GPUS_PER_GROUP] == payload[KEY_GPUS_PER_GROUP]
-    assert payload[LEGACY_KEY_EXECUTION_GROUPS] == payload[KEY_EXECUTION_GROUPS]
+    # pgw#950: the canonical spelling ONLY. The dual write is gone; the dual
+    # READ stays until th#1376 stops tensorhub emitting the legacy names.
+    assert LEGACY_KEY_GPUS_PER_GROUP not in payload
+    assert LEGACY_KEY_EXECUTION_GROUPS not in payload
     back = _decode(json.dumps(payload))
     assert back == topo, f"round trip changed the value: {topo} -> {payload} -> {back}"
     assert _decode(json.dumps(back.as_dict())) == back, "as_dict is not a fixed point"

--- a/tests/test_topology_rename_skew_th1375.py
+++ b/tests/test_topology_rename_skew_th1375.py
@@ -158,15 +158,19 @@ def test_legacy_only_is_accepted_but_says_so() -> None:
     )
 
 
-def test_produced_topology_is_readable_by_both_sides() -> None:
-    """This worker PRODUCES topology too: the parent stamps one per split child
-    (`procsplit/group.py`), and a rolling image swap can put a pre-th#1375
-    reader on the other end of it."""
+def test_produced_topology_emits_the_canonical_spelling_only() -> None:
+    """pgw#950: this worker PRODUCES topology too (the parent stamps one per
+    split child, `procsplit/group.py`), and it now writes the canonical names
+    ONLY. Safe in either deploy order — tensorhub's `reconcileAlias` reads an
+    absent legacy key as "not written", so dropping the dual write cannot
+    disagree with anything."""
     emitted = ExecutionTopology(
         gpu_count=4, gpus_per_execution_group=2, parallel="sequence",
     ).as_dict()
-    assert emitted[KEY_GPUS_PER_GROUP] == emitted[LEGACY_KEY_GPUS_PER_GROUP] == 2
-    assert emitted[KEY_EXECUTION_GROUPS] == emitted[LEGACY_KEY_EXECUTION_GROUPS] == 2
+    assert emitted[KEY_GPUS_PER_GROUP] == 2
+    assert emitted[KEY_EXECUTION_GROUPS] == 2
+    assert LEGACY_KEY_GPUS_PER_GROUP not in emitted
+    assert LEGACY_KEY_EXECUTION_GROUPS not in emitted
     # and it round-trips through our own decoder (no key is unknown to us)
     assert ExecutionTopology.decode(json.dumps(emitted)).execution_groups == 2
 


### PR DESCRIPTION
Closes pgw#950.

Paul, 2026-08-03: *"the codebase still has a lot of support for legacy designs we are no longer using. That's a simplification opportunity"* — and *"you can just hardcut them since we're pre-launch right now."*

## The measurement that decides every arm

Almost every legacy arm in `src/gen_worker/` exists to serve a **compile/AOT cell minted before some stamp existed**. Those cells are a CACHE. The designed miss policy for a refused cell is *self-mint a replacement and publish it* — not a serving failure. So per arm the question is only "is a stale cache entry the only thing keeping this alive?", and where the answer is yes the cut costs **one re-mint per stale cell, once**.

Baseline discipline: a clean `origin/dev` worktree with the same interpreter runs **2 failed / 3087 passed** (both failures are the known pgw#949 gw#666 guard tests). This branch matches that exactly: **2 failed / 3085 passed**, same two tests. `tests_v2` 21/21. mypy clean (226 files). ruff parity (46 = 46, unchanged).

## Deleted

**`aot_serve.verify` — the pre-pgw#765 `sm`-axis skip.** A cell silent on `sm` was waved past the identity loop and deferred to a staged-bytes tier. Silence is now a `key_mismatch` like every other axis, ruled on before any fetch.

**`aot_serve.verify_package_host_isa` + `host_isa.vec_isa_level` — gone entirely.** Their whole job was sniffing torch's own `AOTI_CPU_ISA` out of the `.pt2` for cells minted before the pgw#754 `host_isa` stamp; a stamped cell short-circuited past them on the line above, so they were legacy-only by construction. `host_isa_reason` now REFUSES an absent stamp instead of returning `""`, so the fact is ruled on from metadata — before the download, not after.

**`aot_serve.verify_package_compute_capability` keeps its LIVE job** (a cell whose `sm` stamp disagrees with its own bytes — metadata cannot catch that) and loses the `meta` argument it used only for a legacy log prefix.

**`local_cells.store_verdict` — the pre-gw#581 keyless fallback.** `if reason and "records no computable key" in reason: reason = cc.verify(...)` — a string sniff on the cell's shape that routed pre-key cells to a second, weaker axis-by-axis verify. Deleted; the local store is a disposable cache.

**`compile_cache.contract_drift` — the "legacy format-2 non-quantized-lane cell" arm.** It `return ""` — *COMPATIBLE* — for a cell silent on both `graph_signature` and `weight_contract`. `execution_contract` always digests a structure and every production mint passes the result, so the arm only ever admitted pre-format-3 cells, and admitting one is a wrong cache hit on the module graph itself.

**`topology.as_dict` — the th#1375 dual write.** Safe in either deploy order: tensorhub's `reconcileAlias` reads an absent legacy key as "not written".

## Refused, with the measurement

**`topology`'s legacy ACCEPT half (`_aliased`, `LEGACY_KEY_*`) — BLOCKED, and tensorhub goes first.** The worker's wire key set is CLOSED: an unrecognised key is a hard `topology_unknown_field`. Tensorhub's `internal/orchestrator/topology/topology.go` **still emits both spellings** (`wireValue.LegacyGroupDegree`/`LegacyGroups`, marshalled at :317). Dropping the names here first fails EVERY topology decode on EVERY pod. **th#1376 must land the hub-side emit deletion before this repo can finish the cut** — the ordering is now written down at the constants.

**`receipts.py`'s bare-hex `artifact.blake3` arm — already gone.** Only the docstring remembers it; there is no code. Nothing for tensorhub to do.

**`s3_transfer.S3TransferResult.blake3`** is a LIVE upload-side wire field in tensorhub's media/dataset *declare* grammar (`presigned_upload` POSTs `{path, blake3, size_bytes}`). It dies with the th#1303 S1 backfills, not here.

**`compile_cache.flavor_label` / `is_cache_ref`'s `inductor-<sku>-torch<mm>` flavor** is not legacy: it is the live local-store filename and is byte-compat-pinned to tensorhub's `compilecache.FlavorLabel`.

**`contract_drift`'s absent-`shape_contract` skip** is the same silent-axis defect class, but tightening it is a ~9-fixture sweep rather than a deletion (production always passes one), so it is left with the measurement recorded at the site.

**`worker_goals`' `WORKER_MODE`**, the `intent_registry`/`lifecycle` pre-v5 `DesiredResidency` path, `hot_swap`'s `turn=None`, `privdrop`'s prctl fallback, `convert/classifier`'s `_LEGACY_INDEX_VARIANT_RE` (an upstream HuggingFace naming convention, not our versioning), and the "older hub" additive-proto defaults are all live or capability-shaped, not version-compat machinery.

## One over-cut, caught by measurement and corrected

The first cut produced **57 new failures**. Two causes, both mine:

1. `local_cells`' blanket `except Exception -> cc.verify` was **the no-CUDA path**, not a legacy path — `cell_key.compute` needs a runtime `sm` and raises on the CLI, cozy-local, library use and CI. Restored, but narrowed to `except CellKeyError` so a real bug in the key brain surfaces instead of reading as "no GPU".
2. Refusing an absent `shape_contract` was my own addition beyond the brief; reverted (see above).

The remaining 20 were all one shape — hand-built fixture metadata skipping a field `artifact_metadata()` stamps unconditionally. Those fixtures were pre-stamp artifacts of the same era as the arms being deleted, and now stamp what production stamps.
