### PR TITLE
pgw#952: a lane -> dev PR ran NO CI AT ALL — ci.yml now runs on [dev, master], as two parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,34 +36,44 @@ name: CI
 #
 # ─── MEASURED, ON THE RUNNER ───────────────────────────────────────────────────
 #
-# Not extrapolated from a laptop. These are the per-step durations of run
-# 30847566437 (the last green run of the old single-job shape, ubuntu-latest, no
-# cache, cold) re-attributed to the two jobs below:
+# Not extrapolated from this 32-core box — a 4-core `ubuntu-latest` behaves
+# nothing like it, which is the trap th#1572's lane fell into by a factor of 40.
+# Left column: run 30847566437, the last green run of the old single-job shape,
+# re-attributed to the two jobs below. Right column: this workflow's OWN PR
+# (#467, head 91c73388) — the shape as it actually ships. Both cold; there is no
+# cache in either.
 #
-#                                          cold
-#   Set up job + checkout                    4s   both jobs
-#   Install uv + Set up Python 3.12          3s   both jobs
-#   uv sync --locked --extra dev            21s   both jobs
-#   ------------------------------------------------ gates
-#   Type check (mypy)                       60s
-#   Lint (ruff)                              0s
-#   HTTP timeout guard                       1s
-#   unreached public surface guard           2s
-#   config reads guard                       2s
-#   Build package                            2s
-#                                        -------
-#   gates TOTAL                          1m 35s
-#   ------------------------------------------------ tests
-#   Install llama-server (pinned, CPU)       1s
-#   Run tests (v1)                      10m 59s
-#   Run tests (v2)                       3m 47s
-#                                        -------
-#   tests TOTAL                         15m 15s
+#                                    old shape   THIS workflow (PR #467)
+#   Set up job + checkout                   4s      3s   both jobs
+#   Install uv + Set up Python 3.12         3s      2s   both jobs
+#   uv sync --locked --extra dev           21s     18s   both jobs
+#   ------------------------------------------------------- gates
+#   Type check (mypy)                      60s     59s
+#   Lint (ruff)                             0s      1s
+#   HTTP timeout guard                      1s      1s
+#   unreached public surface guard          2s      2s
+#   config reads guard                      2s      2s
+#   Build package                           2s      1s
+#                                       -------  ------
+#   gates TOTAL                         1m 35s  1m 29s   observed, green
+#   ------------------------------------------------------- tests
+#   Install llama-server (pinned, CPU)      1s      0s
+#   Run tests (v1)                     10m 59s 10m 17s   3092 passed, 2 failed
+#   Run tests (v2)                      3m 47s      —    (see note)
+#                                       -------  ------
+#   tests TOTAL                        15m 15s ~14m 28s
 #
-# The two jobs run concurrently, so the WALL time of a full run is 15m 15s —
-# slightly FASTER than the 16m 22s the single serial job cost, while also
-# returning the cheap half nine times sooner. The split costs one extra 28s
-# install and buys that.
+# The two jobs run concurrently, so the WALL time of a full run is ~14m 30s —
+# FASTER than the 16m 22s the single serial job cost, while also returning the
+# cheap half TEN times sooner (1m 29s). The split costs one extra 18s install
+# and buys that.
+#
+# The `—` is not a missing measurement, it is a DEFECT this run exposed: with
+# `tests/` red, `tests_v2/` reported `skipped`, because a failing step skips
+# every later step by default. The step's own comment had claimed since pgw#808
+# that the two-step split existed so one suite's failure "must not erase the
+# other's answer" — it never did that. Fixed at the step with `if: !cancelled()`.
+# 3m 47s is that step's last unobstructed measurement, from the left column.
 #
 # NO CACHE STEP, deliberately, and this is the one place the tensorhub precedent
 # (th#1572) does NOT transfer. There, `setup-go`'s cache key was shared across
@@ -251,5 +261,16 @@ jobs:
       # "is the replacement ready"), and a collection error in either must not
       # erase the other's answer. The flip (pgw#808: point CI at `tests_v2/`,
       # `git rm -r tests/`) deletes the step above and this comment with it.
+      #
+      # pgw#952: `if: !cancelled()` is what makes the paragraph above TRUE. It
+      # never was — a failing step skips every later step by default, so a red
+      # `tests/` silently erased the `tests_v2/` answer, which is exactly the
+      # outcome the two-step split was written to prevent. Observed on this
+      # workflow's own PR: `tests/` failed on pgw#949's two guards and
+      # `tests_v2/` reported `skipped`, telling a reader nothing about the
+      # zero-based suite. `!cancelled()` rather than `always()` so a cancelled
+      # run (the concurrency group above cancels superseded pushes) does not
+      # spend four more minutes on a result nobody will read.
       - name: Run tests (v2, zero-based — pgw#808)
+        if: ${{ !cancelled() }}
         run: uv run pytest tests_v2/ -n 4 --dist loadfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,142 @@
 name: CI
 
-# th#960/pgw#609 Phase 4: one suite, one lane. Manual dispatch + PR-into-master
-# only — CI spend is metered (WORKSPACE-GIT-POLICY.md); no on-push trigger.
+# pgw#952 — this workflow now runs on PRs into `dev` AS WELL AS `master`, and is
+# split into two PARALLEL jobs. Both changes are corrections; the reasoning is
+# below because the premise that produced the old shape was measurably false.
+#
+# ─── THE GAP THIS CLOSES ───────────────────────────────────────────────────────
+#
+# Until pgw#952, a lane -> `dev` PR in this repository ran NO CI AT ALL. Verified
+# on PR #466 (`950-legacy-hardcut`, 215+/178-, merged into `dev`):
+# `statusCheckRollup` was `[]`. Not a check that passed — no check ran.
+#
+#   ci.yml             `branches: [master]`  -> silent on every dev PR
+#   proto-contract.yml `[dev, master]` BUT with a `paths:` filter #466 missed
+#   native-kernels.yml master only
+#   publish.yml        tag push only
+#
+# So every lane merged into `dev` having run whatever it happened to run locally,
+# and whatever it did not run was discovered by the NEXT lane rebasing onto it —
+# or by a promotion train, minutes before production. pgw#949 is that failure mode
+# already written down: `dev` has been RED on two gw#666 guard tests since PR #455
+# and nothing said so.
+#
+# ─── WHY THE OLD `branches: [master]` WAS WRONG HERE ───────────────────────────
+#
+# The retired header said "CI spend is metered (WORKSPACE-GIT-POLICY.md)". That is
+# true of tensorhub, which is PRIVATE. **This repository is PUBLIC**
+# (`gh repo view --json visibility` -> PUBLIC), and GitHub Actions on standard
+# runners is free and unmetered for public repositories. `ubuntu-latest` is a
+# standard runner. The constraint the split was designed around does not exist on
+# this repo — it was inherited from a sibling with different economics.
+#
+# What remains real is LATENCY, not spend. That is what the two jobs below are
+# for: a lane gets the cheap verdict in ~1m35s and does not wait 15m to learn
+# that mypy is unhappy.
+#
+# ─── MEASURED, ON THE RUNNER ───────────────────────────────────────────────────
+#
+# Not extrapolated from a laptop. These are the per-step durations of run
+# 30847566437 (the last green run of the old single-job shape, ubuntu-latest, no
+# cache, cold) re-attributed to the two jobs below:
+#
+#                                          cold
+#   Set up job + checkout                    4s   both jobs
+#   Install uv + Set up Python 3.12          3s   both jobs
+#   uv sync --locked --extra dev            21s   both jobs
+#   ------------------------------------------------ gates
+#   Type check (mypy)                       60s
+#   Lint (ruff)                              0s
+#   HTTP timeout guard                       1s
+#   unreached public surface guard           2s
+#   config reads guard                       2s
+#   Build package                            2s
+#                                        -------
+#   gates TOTAL                          1m 35s
+#   ------------------------------------------------ tests
+#   Install llama-server (pinned, CPU)       1s
+#   Run tests (v1)                      10m 59s
+#   Run tests (v2)                       3m 47s
+#                                        -------
+#   tests TOTAL                         15m 15s
+#
+# The two jobs run concurrently, so the WALL time of a full run is 15m 15s —
+# slightly FASTER than the 16m 22s the single serial job cost, while also
+# returning the cheap half nine times sooner. The split costs one extra 28s
+# install and buys that.
+#
+# NO CACHE STEP, deliberately, and this is the one place the tensorhub precedent
+# (th#1572) does NOT transfer. There, `setup-go`'s cache key was shared across
+# workflows, a cheap sibling won the save, and that job paid a 224s compile every
+# run — so two explicit `actions/cache` steps were load-bearing. The Python
+# equivalent does not bite: `uv sync --locked --extra dev` is 21 SECONDS cold, on
+# a runner with no warm cache at all. An `actions/cache` restore of a uv cache
+# large enough to matter would cost more than it saves, and would add a key that
+# can go stale against `uv.lock`. If this line ever stops being true, measure the
+# install step first — it is step 5 in every run.
+#
+# ─── NO `paths:` / `paths-ignore:` FILTER ──────────────────────────────────────
+#
+# The old `paths-ignore: ["**.md"]` is gone, and no `paths:` filter replaces it.
+# A path filter is precisely what made proto-contract.yml silently absent from
+# #466, and three of the gates below scan the WHOLE TREE:
+# `lint_unreached_surface.py` walks the public surface for unreached symbols,
+# `lint_config_reads.py` censuses every `os.environ` access against
+# `scripts/config_reads_allowlist.txt`, and the gw#666 guards inside the suite
+# scan all of `tests/` for fixed-deadline waits. Each is invalidated COLLATERALLY
+# — by a change touching none of the files it reads. pgw#949 is exactly that:
+# pgw#943 added ONE new test file and broke two guards in a file it never opened.
+# Any path filter narrow enough to be useful is the filter that misses these.
+#
+# A docs-only PR therefore runs the full suite. On an unmetered public repo that
+# is the cheaper mistake: "zero checks on this PR" is the state this issue exists
+# to make impossible, and a reader cannot tell it apart from "CI is broken".
+#
+# ─── WHAT THIS GATE DOES NOT CATCH — read this before trusting a green ─────────
+#
+#   * ANYTHING REQUIRING A GPU. There is no CUDA device on `ubuntu-latest`. Every
+#     device path here runs through fakes, skips, or CPU fallbacks. A regression
+#     that only manifests on a real card is NOT caught, and green here is not
+#     evidence about the fleet. That is the nightly GPU lane's job.
+#     native-kernels.yml proves the kernels COMPILE; it never runs one.
+#   * LINT. `Lint` is `continue-on-error` (pre-existing debt) — findings are
+#     visible in the log and block nothing.
+#   * DEPENDENCY-RESOLUTION DRIFT beyond `--locked`. `uv sync --locked` proves the
+#     lock is internally consistent, not that its pins are current.
+#   * CROSS-REPO CONTRACT DRIFT against tensorhub's canonical proto. That is
+#     proto-contract.yml layer 1 here and layer 2 in tensorhub, by design.
+#
+# What it DOES catch is the class that has actually been costing lanes time:
+# a behavioural regression in the ~3,000-test suite, and the three tree-scanning
+# guards. pgw#950's own lane found a 57-failure regression only by running a
+# baseline differential BY HAND against clean `origin/dev`; mypy, ruff and the
+# three script guards would every one of them have passed it. That is why the
+# suite is on the dev trigger and not just the cheap half.
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
-    paths-ignore:
-      - "**.md"
+    branches: [dev, master]
+    # `ready_for_review` is NOT a default `pull_request` type, and the jobs below
+    # skip drafts. Without it listed here a lane that opens a draft, pushes, then
+    # clicks "Ready for review" gets NO run for the head it actually merges —
+    # the same invisible-green this issue exists to remove. (tensorhub's
+    # fast-gates.yaml has this bug; its comment claims the gate re-fires on ready.
+    # It does not. Not inherited here.)
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  # ~1m35s. Everything decidable without running the suite, so a lane learns
+  # about a type error or a guard violation in under two minutes instead of
+  # behind an 11-minute pytest run.
+  gates:
+    name: fast gates
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -35,7 +154,7 @@ jobs:
       # same resolution publish.yml uses on tag push, so PR-CI green
       # actually implies publish green (fails loudly instead if uv.lock
       # drifts from pyproject.toml, the 0.18.0 silent-publish-failure root
-      # cause).
+      # cause). Both jobs use this exact line; keep them identical.
       - name: Install dependencies
         run: uv sync --locked --extra dev
 
@@ -65,8 +184,40 @@ jobs:
       - name: pgw#931 guard - config reads outside the pipeline
         run: uv run python scripts/lint_config_reads.py
 
+      # Cheap (2s) and it belongs with the gates, not behind the suite: a
+      # broken sdist/wheel build is a publish-time failure, and publish.yml
+      # gates on a green run of THIS workflow.
+      - name: Build package
+        run: uv build
+
+  # ~15m15s. The only job that can catch a behavioural regression — see the
+  # header on why that is worth a dev trigger rather than master-only.
+  tests:
+    name: tests
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked --extra dev
+
       # Pinned CPU build so the gw#402 llama.cpp runtime tests exercise the
       # real llama-server codepath (tests skip when the binary is absent).
+      # Measured 1s on the runner — a ~20 MB tarball fetch, NOT part of what
+      # makes this suite expensive, so there is no version of this job worth
+      # running without it. Dropping it silently skips five tests.
       - name: Install llama-server (pinned, CPU)
         run: |
           curl -sSL --retry 3 -o /tmp/llama.tgz \
@@ -102,6 +253,3 @@ jobs:
       # `git rm -r tests/`) deletes the step above and this comment with it.
       - name: Run tests (v2, zero-based — pgw#808)
         run: uv run pytest tests_v2/ -n 4 --dist loadfile
-
-      - name: Build package
-        run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,36 +44,40 @@ name: CI
 # cache in either.
 #
 #                                    old shape   THIS workflow (PR #467)
-#   Set up job + checkout                   4s      3s   both jobs
+#   Set up job + checkout                   4s      4s   both jobs
 #   Install uv + Set up Python 3.12         3s      2s   both jobs
-#   uv sync --locked --extra dev           21s     18s   both jobs
+#   uv sync --locked --extra dev           21s  21-28s   both jobs
 #   ------------------------------------------------------- gates
-#   Type check (mypy)                      60s     59s
+#   Type check (mypy)                      60s     58s
 #   Lint (ruff)                             0s      1s
 #   HTTP timeout guard                      1s      1s
 #   unreached public surface guard          2s      2s
 #   config reads guard                      2s      2s
 #   Build package                           2s      1s
 #                                       -------  ------
-#   gates TOTAL                         1m 35s  1m 29s   observed, green
+#   gates JOB WALL                      1m 35s  1m 42s   observed GREEN, twice
 #   ------------------------------------------------------- tests
-#   Install llama-server (pinned, CPU)      1s      0s
-#   Run tests (v1)                     10m 59s 10m 17s   3092 passed, 2 failed
-#   Run tests (v2)                      3m 47s      —    (see note)
+#   Install llama-server (pinned, CPU)      1s      1s
+#   Run tests (v1)                     10m 59s 11m 13s   3092 passed, 2 failed
+#   Run tests (v2)                      3m 47s   3m 54s   21 passed
 #                                       -------  ------
-#   tests TOTAL                        15m 15s ~14m 28s
+#   tests JOB WALL                     15m 15s 15m 37s
 #
-# The two jobs run concurrently, so the WALL time of a full run is ~14m 30s —
-# FASTER than the 16m 22s the single serial job cost, while also returning the
-# cheap half TEN times sooner (1m 29s). The split costs one extra 18s install
-# and buys that.
+# `tests/` runtime is the only noisy line — 10m 17s and 11m 13s on two runs of
+# the same tree. That is runner variance on a 4-core box, not a signal; size the
+# 40-minute timeout against the upper figure, not the lower.
 #
-# The `—` is not a missing measurement, it is a DEFECT this run exposed: with
-# `tests/` red, `tests_v2/` reported `skipped`, because a failing step skips
-# every later step by default. The step's own comment had claimed since pgw#808
-# that the two-step split existed so one suite's failure "must not erase the
-# other's answer" — it never did that. Fixed at the step with `if: !cancelled()`.
-# 3m 47s is that step's last unobstructed measurement, from the left column.
+# The two jobs run concurrently, so a full run is ~15m 40s of WALL time against
+# the old serial 16m 22s, while returning the cheap half TEN times sooner
+# (1m 42s). The split costs one extra ~25s install and buys that.
+#
+# NOTE ON THE `Run tests (v2)` LINE. Its first run on this PR reported `skipped`,
+# not a duration, because `tests/` was red and a failing step skips every later
+# step by default — so the two-step split had never once delivered the property
+# its own comment claimed for it since pgw#808 ("a collection error in either
+# must not erase the other's answer"). `if: !cancelled()` at the step is the fix,
+# and the 3m 54s / 21 passed above is the proof: same red `tests/`, v2 reported
+# anyway.
 #
 # NO CACHE STEP, deliberately, and this is the one place the tensorhub precedent
 # (th#1572) does NOT transfer. There, `setup-go`'s cache key was shared across

--- a/.github/workflows/native-kernels.yml
+++ b/.github/workflows/native-kernels.yml
@@ -6,7 +6,12 @@ name: native-kernels compile
 on:
   workflow_dispatch: {}
   pull_request:
-    branches: [master]
+    # pgw#952: `dev` added. A csrc change otherwise reached `dev` unproven and
+    # was only compiled at the promotion PR, where the next lane pays for it.
+    # The `paths:` filter STAYS, unlike ci.yml's: this job compiles one
+    # directory and its verdict is a property of that directory alone — it is
+    # not tree-scanning, so nothing can invalidate it collaterally.
+    branches: [dev, master]
     paths:
       - "csrc/**"
       - "scripts/native/**"

--- a/.github/workflows/proto-contract.yml
+++ b/.github/workflows/proto-contract.yml
@@ -4,13 +4,16 @@ name: proto contract
 # copy of tensorhub's canonical copy. Until th#1457/#1488 makes the schema
 # generated, the two are maintained by hand and this gate keeps them identical.
 #
-# SEPARATE FROM ci.yml on purpose. ci.yml runs on PRs into master only, because
-# CI spend is metered (WORKSPACE-GIT-POLICY.md) — it installs llama-server and
-# runs two pytest suites. But the contract is edited at the lane -> dev PR, so a
-# master-only gate catches the mistake after it has already shipped into dev and
-# into every worker image built from it. This job is sha256sum plus one codegen,
-# so it can afford to run on dev too, and keeping it out of ci.yml is what
-# guarantees it stays that cheap.
+# SEPARATE FROM ci.yml on purpose — but NOT for the reason first written here.
+# The original text said ci.yml was master-only "because CI spend is metered
+# (WORKSPACE-GIT-POLICY.md)". pgw#952 measured that premise and it is false for
+# THIS repo: python-gen-worker is PUBLIC, so standard-runner minutes are free and
+# unmetered. ci.yml now runs on `[dev, master]` like this workflow does.
+#
+# What still justifies a separate file is COST SHAPE, not spend: this job is a
+# sha256sum plus one codegen (~40s, no llama-server, no pytest), so it returns a
+# contract verdict in well under a minute instead of behind ci.yml's 15m suite,
+# and keeping it out of ci.yml is what guarantees it stays that cheap.
 #
 # This side runs LAYER 1 ONLY (local copy vs the shared PROTO_DIGEST). Layer 2 —
 # comparing against tensorhub's copy — cannot run here: tensorhub is a PRIVATE
@@ -28,6 +31,13 @@ on:
       - "scripts/vendor-proto.sh"
       - "src/gen_worker/pb/**"
       - ".github/workflows/proto-contract.yml"
+      # pgw#952: the second step REGENERATES the bindings with grpc_tools.protoc
+      # and diffs them, so the generator's own version is an input to this
+      # gate's verdict. A `grpcio-tools` bump moves the generated header and the
+      # descriptor bytes while touching none of the paths above — the committed
+      # bindings then silently drift from what the pinned toolchain produces.
+      - "pyproject.toml"
+      - "uv.lock"
 
 concurrency:
   group: proto-contract-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
   file it never opened. `ready_for_review` is now in the trigger types, because
   the jobs skip drafts and it is not a default type — without it a draft marked
   ready gets no run for the head it actually merges.
+- **A red `tests/` silently erased the `tests_v2/` answer (pgw#952).** Since
+  pgw#808 the two suites have run as two steps, with a comment stating the split
+  existed so "a collection error in either must not erase the other's answer".
+  It never did that: a failing step skips every later step by default. Observed
+  on pgw#952's own PR — `tests/` failed on pgw#949's two guards and `tests_v2/`
+  reported `skipped`. The step now carries `if: ${{ !cancelled() }}`, so both
+  suites always report; `!cancelled()` rather than `always()` so a run superseded
+  by the concurrency group does not spend four more minutes on a dead result.
 - **`native-kernels.yml` gained the `dev` trigger; `proto-contract.yml` gained
   `pyproject.toml`/`uv.lock` to its paths (pgw#952).** The latter regenerates
   bindings with `grpc_tools.protoc` and diffs them, so the generator's pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+- **pgw#952: a lane -> `dev` PR used to run NO CI AT ALL; `ci.yml` now runs on
+  `[dev, master]` as two parallel jobs.** Verified on PR #466 (215+/178-, merged
+  into `dev`): `statusCheckRollup` was `[]` — not a check that passed, no check
+  ran. `ci.yml` was `branches: [master]`, `proto-contract.yml` fires on `dev` but
+  its `paths:` filter matched nothing in that diff, and the other two workflows
+  are master/tag only. The stated reason — "CI spend is metered" — was inherited
+  from tensorhub, which is PRIVATE; **this repo is PUBLIC**, so standard-runner
+  minutes are free. The real constraint is latency, so the suite is split into
+  `fast gates` (mypy, ruff, the three script guards, `uv build` — 1m35s) and
+  `tests` (llama-server + both pytest suites — 15m15s), running concurrently.
+  Full-run wall time drops from 16m22s to 15m15s and the cheap verdict arrives
+  nine times sooner. Per-step times are measured on the runner, not locally, and
+  recorded in the workflow header along with what the gate does NOT catch —
+  above all that there is no GPU on `ubuntu-latest`, so a green says nothing
+  about the fleet.
+- **No `paths:` filter on `ci.yml`, and `paths-ignore: ["**.md"]` deleted
+  (pgw#952).** Three gates scan the whole tree — `lint_unreached_surface.py`,
+  `lint_config_reads.py`, and the gw#666 guards inside the suite — so they are
+  invalidated COLLATERALLY, by a change touching none of the files they read.
+  pgw#949 is exactly that: pgw#943 added one test file and broke two guards in a
+  file it never opened. `ready_for_review` is now in the trigger types, because
+  the jobs skip drafts and it is not a default type — without it a draft marked
+  ready gets no run for the head it actually merges.
+- **`native-kernels.yml` gained the `dev` trigger; `proto-contract.yml` gained
+  `pyproject.toml`/`uv.lock` to its paths (pgw#952).** The latter regenerates
+  bindings with `grpc_tools.protoc` and diffs them, so the generator's pinned
+  version is an input to its verdict — a `grpcio-tools` bump could drift the
+  committed bindings while touching none of the filtered paths.
+
 - **pgw#947: a kernel-lane verdict is evidence, not an instruction — serving
   re-applies the fit rule on its own card.** Cell keys are keyed on SM and the
   lane is deliberately not a key axis, so one key spans a 96 GB RTX PRO 6000

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,16 +83,27 @@ one version deliberately; do not reach for a global exact pin to get it.
 
 ## The gate — what actually has to be green
 
-`ci.yml`, in order. **A local `pytest` run is not the gate** and will let you push a red:
+`ci.yml`. **A local `pytest` run is not the gate** and will let you push a red.
+
+Since pgw#952 it is TWO PARALLEL JOBS, and both must be green — `publish.yml` keys on
+the run's conclusion, which is success only when both are. It also runs on PRs into
+`dev`, not just `master`, so a cut no longer inherits a pile of unproven lane merges.
+
+**`fast gates`** (~1m35s):
 
 1. `uv sync --locked --extra dev` — a version bump without `uv lock` fails here. It has.
 2. `mypy src/gen_worker` — GATING (gw#497; the tree is mypy-clean, no baseline)
 3. `scripts/lint_http_timeouts.py` (gw#467)
 4. `scripts/lint_unreached_surface.py` (pgw#849 guard 2)
-5. install pinned CPU `llama-server` (so the gw#402 runtime tests run for real)
-6. `pytest tests/ -n 4 --dist loadfile`
-7. `pytest tests_v2/ -n 4 --dist loadfile` — **`testpaths = ["tests"]`, so a bare `pytest` skips this.**
-8. `uv build` — a cut can still fail here, after every test is green.
+5. `scripts/lint_config_reads.py` (pgw#931 guard)
+6. `uv build` — a cut can still fail here, after every test is green.
+
+**`tests`** (~15m15s):
+
+1. `uv sync --locked --extra dev`
+2. install pinned CPU `llama-server` (so the gw#402 runtime tests run for real)
+3. `pytest tests/ -n 4 --dist loadfile`
+4. `pytest tests_v2/ -n 4 --dist loadfile` — **`testpaths = ["tests"]`, so a bare `pytest` skips this.**
 
 **`ruff check src/gen_worker` is NOT a gate.** `ci.yml` runs it with
 `continue-on-error: true` (lint debt, mostly `worker.py`) — it is visible in

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -113,17 +113,26 @@ the logs and blocks nothing. Do not spend cut time on red ruff output.
 tree SHAs, not commit SHAs). Tag a commit CI has already proven, or dispatch CI on the tag and re-run
 publish.
 
-### Why a cut costs hours: chaos accrues CI debt and the cut pays all of it
+### Why a cut used to cost hours — and what pgw#952 changed
 
-`chaos` is a shared branch everyone commits to directly (by design), and **nothing gates a chaos
-commit on being green.** The publish gate is the first thing that ever demands a green run on an
-exact tree — so every red accumulated since the last cut lands on whoever cuts next, who usually
+**Historically:** `chaos` was a shared branch everyone committed to directly, and nothing gated a
+chaos commit on being green. The publish gate was the first thing that ever demanded a green run on
+an exact tree — so every red accumulated since the last cut landed on whoever cut next, who usually
 authored none of it.
 
 Measured on the 0.90.6 cut: three reds, none authored by the cutter — another lane's `mypy` error, a
 stale pgw#849 baseline entry, and **two tests that had never passed CI in their lives** (established
-by `git merge-base --is-ancestor` against the last green run). Budget hours, not minutes, and expect
-to choose between fixing another lane's code and branching around it.
+by `git merge-base --is-ancestor` against the last green run).
+
+**Since pgw#952** the same debt could still accrue on `dev` — `chaos` is retired, but until then
+`ci.yml` was `branches: [master]` and a lane -> `dev` PR ran NO CI AT ALL (PR #466's
+`statusCheckRollup` was literally `[]`). `ci.yml` now runs on `[dev, master]`, so a red is refused
+at the lane PR that introduces it rather than at the cut. Expect this section to shrink; do not
+assume it already has. `dev` was RED on pgw#949's two gw#666 guard tests when the gate was turned
+on, and anything that merged before pgw#952 was never gated.
+
+The rule for whoever cuts is unchanged while any pre-pgw#952 history is in range: budget hours, not
+minutes, and establish by ancestry — never from cut notes — whether a red is yours.
 
 **If the red is a semantics decision inside another lane's work, do not fix it to unblock your tag.**
 Branch the release from a commit that predates it and say so in the CHANGELOG. A cut that launders


### PR DESCRIPTION
## The gap

Verified on PR #466 (`950-legacy-hardcut`, 215+/178-, merged into `dev`): `statusCheckRollup` was `[]`. **Not a check that passed — no check ran.**

| workflow | trigger | fired on #466? |
|---|---|---|
| `ci.yml` | `branches: [master]` | no |
| `proto-contract.yml` | `[dev, master]` **+ `paths:`** | no — filter matched nothing |
| `native-kernels.yml` | master only | no |
| `publish.yml` | tag push | no |

Every lane merges into `dev` having run whatever it happened to run locally; the rest is discovered by the next lane rebasing onto it, or by a promotion train. pgw#949 is that failure mode already written down.

## The premise was false for this repo

`ci.yml`'s header justified master-only with *"CI spend is metered (WORKSPACE-GIT-POLICY.md)"*. That is **tensorhub's** economics — tensorhub is PRIVATE. **This repo is PUBLIC** (`gh repo view --json visibility` → `PUBLIC`), so standard-runner minutes are free and unmetered. The constraint the split was designed around does not exist here.

What *is* real is latency. Hence two concurrent jobs rather than a cheap-gates-only compromise.

## Measured, on the runner

Per-step durations of run `30847566437` (last green run of the old single-job shape, `ubuntu-latest`, no cache, cold), re-attributed:

| | cold |
|---|---|
| setup + checkout + uv + python | 7s (both jobs) |
| `uv sync --locked --extra dev` | **21s** (both jobs) |
| mypy | 60s |
| ruff / 3 script guards / `uv build` | 0s / 5s / 2s |
| **`fast gates` total** | **1m 35s** |
| llama-server install | 1s |
| `pytest tests/` | 10m 59s |
| `pytest tests_v2/` | 3m 47s |
| **`tests` total** | **15m 15s** |

Jobs run concurrently → full-run wall time **16m 22s → 15m 15s**, and the cheap verdict returns nine times sooner.

**No cache step, deliberately.** This is where th#1572's precedent does *not* transfer: there `setup-go`'s shared cache key cost a 224s compile every run. `uv sync --locked` is **21s cold** — an `actions/cache` restore would cost more than it saves and adds a key that can stale against `uv.lock`.

## Why the whole suite, not just the cheap gates

pgw#950's lane caught a **57-failure regression** only by running a baseline differential by hand against clean `origin/dev`. Its cause was semantic (a blanket `except Exception` that was the no-CUDA path, not a legacy path). **mypy, ruff and all three script guards pass it.** Only the suite catches that class — and on a repo with free minutes there is no reason to buy the cheap half only.

## No `paths:` / `paths-ignore:` filter

`paths-ignore: ["**.md"]` deleted, nothing replaces it. Three gates scan the **whole tree** — `lint_unreached_surface.py`, `lint_config_reads.py`, and the gw#666 guards inside the suite — so they are invalidated **collaterally**, by a change touching none of the files they read. pgw#949 is exactly that: pgw#943 added one test file and broke two guards in a file it never opened.

`ready_for_review` is in the trigger types. The jobs skip drafts and it is **not** a default `pull_request` type, so without it a draft marked ready gets no run for the head it actually merges. (tensorhub's `fast-gates.yaml` has this bug and its comment claims otherwise — not inherited.)

## Collateral holes found while measuring

- `proto-contract.yml` regenerates bindings with `grpc_tools.protoc` and diffs them, so the generator's pinned version is an input to its verdict → added `pyproject.toml` + `uv.lock` to its paths.
- `native-kernels.yml` gained `dev`. Its `paths:` filter **stays**, correctly: it compiles one directory and nothing invalidates it collaterally.

## What this gate does NOT catch

Stated in full in the workflow header. Above all: **there is no GPU on `ubuntu-latest`.** Green here is not evidence about the fleet. Also not caught: lint (`continue-on-error`, pre-existing debt), dependency drift beyond `--locked`, and cross-repo proto drift against tensorhub's canonical copy.

## Expected result on this PR

The `tests` job is expected **RED**, on exactly two tests:

```
tests/test_magic_timeouts_gw666.py::test_no_new_fixed_deadline_wait_appears_in_a_test
tests/test_magic_timeouts_gw666.py::test_no_new_wall_clock_assertion_appears_in_a_test
```

Both name `tests/test_child_call_pipelining_pgw943.py`. This is **pgw#949**, pre-existing on `origin/dev` since PR #455 and reproduced here on a clean `origin/dev` checkout before any change in this branch. Its tracker entry assigns the resolution to **pgw#943's lane** and says explicitly *"do not let another lane pick the resolution"*, so this lane does not touch it and does not quarantine it.

pgw#949's own headline is *"and no CI will say so before the train"*. **This PR is the thing that says so.**