### PR TITLE
th#1582 Phase A (pgw): the EXECUTION LANE concept is spelled `execution_lane`, and `kernel_lane` is a kernel PATH — names only, with the five things that are NOT names proven untouched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **th#1582 Phase A: the EXECUTION LANE concept is spelled `execution_lane`.**
+  A names-only pass — 1,655 Python identifier tokens across 113 files (`Lane` ->
+  `ExecutionLane`, `lane` -> `execution_lane`, `parse_lane_spec` ->
+  `parse_execution_lane_spec`, ...) plus 18 identifier references inside `#`
+  comments, rewritten through `tokenize` over NAME tokens ONLY, so string
+  VALUES could not be touched by construction. Three modules move with their
+  concept: `gen_worker.kernel_lane` -> **`gen_worker.kernel_path`** (pgw#947:
+  which GEMM realizes a lane on this card is a kernel PATH, not a lane),
+  `gen_worker.models.lanes` -> `gen_worker.models.execution_lanes`, and
+  `gen_worker.models.lane_gate` -> `gen_worker.models.execution_lane_gate`.
+  **No value moved**: the lane grammar (`"fp8-w8a8-dynamic+compiled"`), every
+  proto field, `JobMetrics.lane`, the cell-key axis `lane`, the CLI flag
+  `--lane`, `kernel_lane.META_KEY == "kernel_lane"` in minted cell metadata,
+  and the `weight_lane` family (th#1580 Phase B) are byte-identical.
+
 - **pgw#943: a child-call wait now YIELDS the GPU permit — the worker
   pipelines while parked on a child request.** #455 measured the defect: at
   `gpu_slots=1` a parent in `ctx.call_endpoint` held its group permit for the

--- a/agents/gw551_pod_validate.py
+++ b/agents/gw551_pod_validate.py
@@ -28,7 +28,7 @@ log = logging.getLogger("gw551")
 
 ARM = os.environ.get("ARM", "after")
 GiB = 1024 ** 3
-LANE_GB = float(os.environ.get("LANE_GB", "38"))
+EXECUTION_LANE_GB = float(os.environ.get("LANE_GB", "38"))
 SHARED_GB = float(os.environ.get("SHARED_GB", "15"))
 DTYPE = torch.bfloat16
 WIDTH = 8192
@@ -45,7 +45,7 @@ def big_module(gb: float) -> nn.Module:
     return m.to_empty(device="cpu")
 
 
-class LanePipe:
+class ExecutionLanePipe:
     """diffusers-shaped pipeline: latents are created on the device it
     BELIEVES it is on (first transformer param); the shared encoder's cuda
     output feeds the transformer — the two te#79 crash shapes when demoted."""
@@ -73,13 +73,13 @@ class LanePipe:
         return str(out.device)
 
 
-def build(res) -> tuple["LanePipe", "LanePipe"]:
+def build(res) -> tuple["ExecutionLanePipe", "ExecutionLanePipe"]:
     from gen_worker.models.memory import estimate_cuda_resident_gb
     from gen_worker.models.residency import LoadedComponentKey
 
     t0 = time.monotonic()
     shared = big_module(SHARED_GB)
-    lanes = {"t2i": big_module(LANE_GB), "edit": big_module(LANE_GB)}
+    execution_lanes = {"t2i": big_module(EXECUTION_LANE_GB), "edit": big_module(EXECUTION_LANE_GB)}
     log.info("built modules in %.1fs", time.monotonic() - t0)
 
     shared.cuda()  # shared encoder: resident + refcount-held (gw#479 shape)
@@ -89,10 +89,10 @@ def build(res) -> tuple["LanePipe", "LanePipe"]:
                        vram_bytes=int(estimate_cuda_resident_gb(shared) * GiB))
 
     pipes = []
-    for name, tr in lanes.items():
+    for name, tr in execution_lanes.items():
         ref = f"tensorhub/gw551-{name}"
         excl = nn.ModuleDict({"transformer": tr})
-        need = int(LANE_GB * GiB)
+        need = int(EXECUTION_LANE_GB * GiB)
         res.make_room(need)
         if res.free_vram_bytes() >= need + 2 * GiB:
             t0 = time.monotonic()
@@ -104,7 +104,7 @@ def build(res) -> tuple["LanePipe", "LanePipe"]:
         else:
             log.info("lane %s stays host-resident (RAM tier)", name)
             res.track_ram(ref, excl)
-        pipes.append(LanePipe(tr, shared, name))
+        pipes.append(ExecutionLanePipe(tr, shared, name))
     return pipes[0], pipes[1]
 
 
@@ -116,20 +116,20 @@ def main() -> None:
     log.info("ARM=%s card=%s total=%.1fGiB free=%.1fGiB gen_worker=%s",
              ARM, torch.cuda.get_device_name(0), total / GiB, free / GiB,
              __import__("gen_worker").__file__)
-    assert 2 * LANE_GB + SHARED_GB > total / GiB, "not overcommitted; resize"
+    assert 2 * EXECUTION_LANE_GB + SHARED_GB > total / GiB, "not overcommitted; resize"
 
     res = Residency()
     t2i, edit = build(res)
     report: dict = {"arm": ARM, "card": torch.cuda.get_device_name(0),
-                    "lane_gb": LANE_GB, "shared_gb": SHARED_GB}
+                    "lane_gb": EXECUTION_LANE_GB, "shared_gb": SHARED_GB}
 
     refs = {"t2i": "tensorhub/gw551-t2i", "edit": "tensorhub/gw551-edit"}
     if ARM == "after":
         from gen_worker.api.errors import RetryableError
-        from gen_worker.models.lane_gate import LaneGate, arm_lane_gate
+        from gen_worker.models.execution_lane_gate import ExecutionLaneGate, arm_execution_lane_gate
 
         for p in (t2i, edit):
-            assert arm_lane_gate(p, LaneGate(
+            assert arm_execution_lane_gate(p, ExecutionLaneGate(
                 ref=refs[p.name], residency=res, label=refs[p.name],
                 retry_exc=RetryableError))
 
@@ -169,7 +169,7 @@ def main() -> None:
         report["alternating"] = timings
         report["transition_stats"] = res.transition_stats()
 
-    # ---- Part 3: raw swap timing on one ~LANE_GB transformer. --------------
+    # ---- Part 3: raw swap timing on one ~EXECUTION_LANE_GB transformer. --------------
     tr = t2i.transformer
     if ARM == "after":
         from gen_worker.models.pinned_swap import swap_module
@@ -187,12 +187,12 @@ def main() -> None:
             "demote_first_s": round(d1, 3), "promote_pinned_s": round(p1, 3),
             "demote_pointer_swap_s": round(d2, 3),
             "promote_pinned_2_s": round(p2, 3),
-            "promote_gib_per_s": round(LANE_GB / min(p1, p2), 1)}
+            "promote_gib_per_s": round(EXECUTION_LANE_GB / min(p1, p2), 1)}
         swap_module(tr, "cpu")
         swap_module(edit.transformer, "cpu")
     else:
         if next(tr.parameters()).device.type != "cuda":
-            res.make_room(int(LANE_GB * GiB))
+            res.make_room(int(EXECUTION_LANE_GB * GiB))
             tr.cuda(); torch.cuda.synchronize()
         t0 = time.perf_counter(); tr.cpu(); d1 = time.perf_counter() - t0
         torch.cuda.empty_cache()
@@ -200,7 +200,7 @@ def main() -> None:
         report["swap_timing"] = {
             "demote_pageable_s": round(d1, 3),
             "promote_pageable_s": round(p1, 3),
-            "promote_gib_per_s": round(LANE_GB / p1, 1)}
+            "promote_gib_per_s": round(EXECUTION_LANE_GB / p1, 1)}
         tr.cpu()
         edit.transformer.cpu()
     torch.cuda.empty_cache()
@@ -220,7 +220,7 @@ def main() -> None:
         d_cold = time.perf_counter() - t0
         report["disk_to_vram"] = {"save_s": round(d_save, 1),
                                   "load_to_cuda_s": round(d_cold, 1),
-                                  "gib_per_s": round(LANE_GB / d_cold, 1)}
+                                  "gib_per_s": round(EXECUTION_LANE_GB / d_cold, 1)}
         del sd
         os.remove(path)
 

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -102,7 +102,7 @@ because a single switch cannot say "baseline linears, packed modulation".
 
 A lane is therefore the **combination**, written `<linear>+<modulation>`
 (`baseline+packed`, `fused+dense`, …). It is measured on the card the cell is
-minted for and recorded in the cell (`gen_worker/kernel_lane.py`):
+minted for and recorded in the cell (`gen_worker/kernel_path.py`):
 
 - **Mint.** `mint_child.lane_verdict_for` loads the endpoint once per
   candidate combination (the swap happens at model load, so comparing lanes
@@ -110,7 +110,7 @@ minted for and recorded in the cell (`gen_worker/kernel_lane.py`):
   family's dominant declared graph class, on its own declared example feed,
   under `torch.compile` — and times it with a fixed warmup/median protocol.
   The winner's pipeline is the one that gets exported. Candidates come from
-  `kernel_lane.candidate_axes`, which asks only capability questions
+  `kernel_path.candidate_axes`, which asks only capability questions
   (Blackwell block-scaled MMA for the fused linear; triton plus a numerics
   self-check for the packed modulation, which has no SM term at all). An axis
   with one buildable value contributes no candidates, so a non-Blackwell card

--- a/scripts/svdq_bench/bench_arm.py
+++ b/scripts/svdq_bench/bench_arm.py
@@ -46,10 +46,10 @@ def load_ours(ckpt: Path, log):
     art = detect_svdq_artifact(ckpt)
     assert art is not None, f"no svdq artifact detected at {ckpt}"
     from gen_worker.models import native_kernels as nk
-    lane = nk.svdq_linear_lane()
-    mod_lane = nk.svdq_modulation_lane()
-    log(f"linear lane={lane} ({nk.svdq_linear_lane_reason()}); "
-        f"modulation lane={mod_lane} ({nk.svdq_modulation_lane_reason()})")
+    execution_lane = nk.svdq_linear_execution_lane()
+    mod_execution_lane = nk.svdq_modulation_execution_lane()
+    log(f"linear lane={execution_lane} ({nk.svdq_linear_execution_lane_reason()}); "
+        f"modulation lane={mod_execution_lane} ({nk.svdq_modulation_execution_lane_reason()})")
     avail = svdq_native_available()
     log(f"svdq_native_available={avail} reason={svdq_native_reason()!r} "
         f"model_class={art.model_class} rank={art.rank} precision={art.precision}")
@@ -68,11 +68,11 @@ def load_ours(ckpt: Path, log):
         elif getattr(mod, "_cozy_svdq_linear", False):
             census["blockwise"] += 1
     log(f"swap census={census}")
-    if lane == "fused":
+    if execution_lane == "fused":
         assert census["fused"] > 0, "fused lane armed but zero fused modules"
-    return den, {"runtime": "gen_worker svdq_native", "lane": lane,
-                 "modulation_lane": mod_lane,
-                 "lane_reason": nk.svdq_linear_lane_reason(),
+    return den, {"runtime": "gen_worker svdq_native", "lane": execution_lane,
+                 "modulation_lane": mod_execution_lane,
+                 "lane_reason": nk.svdq_linear_execution_lane_reason(),
                  "swap_census": census,
                  "gen_worker": getattr(gen_worker, "__version__", "?"),
                  "svdq_mode": got, "rank": art.rank, "precision": str(art.precision)}

--- a/scripts/svdq_bench/bench_b0.py
+++ b/scripts/svdq_bench/bench_b0.py
@@ -234,14 +234,14 @@ def run_bench(args) -> int:
     from gen_worker.models.svdq import detect_svdq_artifact
 
     out_dir = Path(args.out); out_dir.mkdir(parents=True, exist_ok=True)
-    lane = nk.svdq_linear_lane()
+    execution_lane = nk.svdq_linear_execution_lane()
     report: dict = {"device": torch.cuda.get_device_name(0),
                     "torch": torch.__version__,
                     "gen_worker": getattr(gen_worker, "__version__", "?"),
-                    "lane": lane,
-                    "modulation_lane": nk.svdq_modulation_lane(),
-                    "lane_reason": nk.svdq_linear_lane_reason()}
-    print(f"[bench] lane={lane} ({report['lane_reason']})", flush=True)
+                    "lane": execution_lane,
+                    "modulation_lane": nk.svdq_modulation_execution_lane(),
+                    "lane_reason": nk.svdq_linear_execution_lane_reason()}
+    print(f"[bench] lane={execution_lane} ({report['lane_reason']})", flush=True)
 
     art = detect_svdq_artifact(Path(args.ckpt))
     assert art is not None
@@ -264,7 +264,7 @@ def run_bench(args) -> int:
     report["resident_after_load_gb"] = torch.cuda.memory_allocated() / 2**30
     print(f"[bench] load {report['load_s']:.1f}s census={census} "
           f"resident={report['resident_after_load_gb']:.1f}GB", flush=True)
-    if lane == "fused":
+    if execution_lane == "fused":
         assert census["fused"] > 0, "fused lane armed but zero fused modules"
 
     kw = synth_inputs(model, "cuda", torch.bfloat16)
@@ -285,7 +285,7 @@ def run_bench(args) -> int:
     report["top_kernels_per_forward_ms"] = [
         {"key": r.key[:120], "cuda_ms": r.device_time_total / 1e3 / 10,
          "count": r.count} for r in top]
-    (out_dir / f"profile_{lane}.txt").write_text(
+    (out_dir / f"profile_{execution_lane}.txt").write_text(
         prof.key_averages().table(sort_by="cuda_time_total", row_limit=50))
 
     t0 = time.perf_counter()
@@ -302,9 +302,9 @@ def run_bench(args) -> int:
           f"{comp['mean_ms']:.1f}ms -> step {comp['mean_ms'] * 2:.0f}ms "
           f"peak {report['peak_vram_gb']:.1f}GB", flush=True)
 
-    (out_dir / f"bench_{lane}.json").write_text(json.dumps(report, indent=1))
+    (out_dir / f"bench_{execution_lane}.json").write_text(json.dumps(report, indent=1))
     print("[bench] DONE " + json.dumps({
-        "lane": lane, "eager_step_ms": report["eager_step_ms"],
+        "lane": execution_lane, "eager_step_ms": report["eager_step_ms"],
         "compiled_step_ms": report["compiled_step_ms"]}), flush=True)
     return 0
 

--- a/scripts/svdq_bench/pod_run.py
+++ b/scripts/svdq_bench/pod_run.py
@@ -304,7 +304,7 @@ def main() -> int:
                 armed["dockerEntrypoint"] = sc
             return rest(api, "POST", "/pods", armed)
 
-        lease = podguard.rent(api, body, lane=f"svdq-bench-{args.gpu}",
+        lease = podguard.rent(api, body, execution_lane=f"svdq-bench-{args.gpu}",
                               lease_seconds=args.wall_min * 60,
                               orig_cmd=["/bin/bash", "-lc", SSHD],
                               post=entrypoint_post)
@@ -312,7 +312,7 @@ def main() -> int:
         print(f"[pod] created {pod_id} rate=${lease.rate_per_hr}/hr",
               flush=True)
     else:
-        podguard.attend(api, pod_id, lane=f"svdq-bench-{args.gpu}")
+        podguard.attend(api, pod_id, execution_lane=f"svdq-bench-{args.gpu}")
         print(f"[pod] attached {pod_id}", flush=True)
     (res / "pod.txt").write_text(f"{pod_id} {int(started)} {args.gpu}\n")
 

--- a/scripts/svdq_bench/summarize.py
+++ b/scripts/svdq_bench/summarize.py
@@ -86,9 +86,9 @@ def main() -> int:
                 continue
             s = a["summary"]
             rt = a.get("runtime", {})
-            lane = rt.get("lane") or rt.get("runtime", "?")
+            execution_lane = rt.get("lane") or rt.get("runtime", "?")
             e2e, src = steady_e2e(a)
-            print(f"| {ARM_LABEL.get(name, name)} | {lane} "
+            print(f"| {ARM_LABEL.get(name, name)} | {execution_lane} "
                   f"| {fmt(s['step_mean_s'], '.0f', 1000)} "
                   f"| {fmt(e2e, '.2f')} ({src}) "
                   f"| {fmt(3600.0 / e2e, '.1f')} "

--- a/scripts/w4a4_parity.py
+++ b/scripts/w4a4_parity.py
@@ -148,46 +148,46 @@ def main() -> None:
     print(f"snapshot: {src}")
     print(f"w8a8_gemm_mode: {w8a8_gemm_mode()!r}  w4a4_gemm_mode: {w4a4_gemm_mode()!r}")
 
-    lanes = [x.strip() for x in args.lanes.split(",") if x.strip()]
+    execution_lanes = [x.strip() for x in args.execution_lanes.split(",") if x.strip()]
     images: dict = {}
     walls: dict = {}
     compiled_walls: dict = {}
     denoiser_gb: dict = {}
 
-    for lane in lanes:
-        print(f"--- lane {lane}")
-        if lane == "bf16":
+    for execution_lane in execution_lanes:
+        print(f"--- lane {execution_lane}")
+        if execution_lane == "bf16":
             pipe = DiffusionPipeline.from_pretrained(
                 str(src), torch_dtype=torch.bfloat16)
-        elif lane in ("w8a8", "w4a4"):
-            tree = out / f"{lane}-tree"
+        elif execution_lane in ("w8a8", "w4a4"):
+            tree = out / f"{execution_lane}-tree"
             if not tree.exists():
-                (quantize_tree_w8a8 if lane == "w8a8"
+                (quantize_tree_w8a8 if execution_lane == "w8a8"
                  else quantize_tree_w4a4)(src, tree)
             pipe = load_from_pretrained(DiffusionPipeline, tree)
-            lane_attr = getattr(pipe, "_cozy_weight_lane", "")
-            print(f"{lane} weight lane: {lane_attr!r}")
-            assert lane_attr == lane, f"{lane} scaled_mm lane did not engage"
+            execution_lane_attr = getattr(pipe, "_cozy_weight_lane", "")
+            print(f"{execution_lane} weight lane: {execution_lane_attr!r}")
+            assert execution_lane_attr == execution_lane, f"{execution_lane} scaled_mm lane did not engage"
         else:
-            raise SystemExit(f"unknown lane {lane}")
+            raise SystemExit(f"unknown lane {execution_lane}")
         pipe.to("cuda")
-        denoiser_gb[lane] = round(_module_bytes(_denoiser(pipe)) / 2**30, 3)
-        print(f"{lane} denoiser resident: {denoiser_gb[lane]} GiB")
+        denoiser_gb[execution_lane] = round(_module_bytes(_denoiser(pipe)) / 2**30, 3)
+        print(f"{execution_lane} denoiser resident: {denoiser_gb[execution_lane]} GiB")
         img, wall = _render(pipe, prompt=args.prompt, seed=args.seed,
                             steps=args.steps, size=args.size)
-        images[lane] = img
-        walls[lane] = wall
+        images[execution_lane] = img
+        walls[execution_lane] = wall
         from PIL import Image
 
-        Image.fromarray(img).save(out / f"{lane}.png")
-        print(f"{lane} eager: {wall:.2f}s for {args.steps} steps "
+        Image.fromarray(img).save(out / f"{execution_lane}.png")
+        print(f"{execution_lane} eager: {wall:.2f}s for {args.steps} steps "
               f"({wall / args.steps * 1000:.0f} ms/step)")
         if args.compiled:
             cw = _compiled_wall(pipe, prompt=args.prompt, seed=args.seed,
                                 steps=args.steps, size=args.size)
             if cw is not None:
-                compiled_walls[lane] = cw
-                print(f"{lane} compiled: {cw:.2f}s "
+                compiled_walls[execution_lane] = cw
+                print(f"{execution_lane} compiled: {cw:.2f}s "
                       f"({cw / args.steps * 1000:.0f} ms/step)")
         _free(pipe)
 
@@ -196,16 +196,16 @@ def main() -> None:
                     "compiled_walls_s": compiled_walls,
                     "denoiser_resident_gib": denoiser_gb, "deltas": {}}
     ref = images.get("bf16")
-    for lane, img in images.items():
-        if ref is None or lane == "bf16":
+    for execution_lane, img in images.items():
+        if ref is None or execution_lane == "bf16":
             continue
         mae, psnr = _mae_psnr(ref, img)
         d = {"mae": round(mae, 5), "psnr_db": round(psnr, 2)}
         lp = _lpips(ref, img)
         if lp is not None:
             d["lpips"] = round(lp, 4)
-        report["deltas"][lane] = d
-        print(f"{lane} vs bf16: {d}")
+        report["deltas"][execution_lane] = d
+        print(f"{execution_lane} vs bf16: {d}")
     for a, b in (("w8a8", "w4a4"), ("bf16", "w4a4")):
         if a in walls and b in walls:
             key = f"speedup_{b}_vs_{a}_eager"

--- a/scripts/w8a8_lora_bench.py
+++ b/scripts/w8a8_lora_bench.py
@@ -207,9 +207,9 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
             continue
         lora_sds[ref] = load_file(f)
 
-    def render_lane(w8a8_lane: bool) -> dict:
+    def render_execution_lane(w8a8_execution_lane: bool) -> dict:
         imgs: dict = {}
-        if w8a8_lane:
+        if w8a8_execution_lane:
             art = detect_w8a8_artifact(tree)
             assert art is not None
             pipe = load_w8a8_pipeline(
@@ -229,7 +229,7 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
             imgs[("base", i)] = _render(pipe, p, 1234 + i, steps)
         swap_stats = []
         for ref, sd in lora_sds.items():
-            if w8a8_lane:
+            if w8a8_execution_lane:
                 targets = w8a8_lora.branch_targets(pipe)
                 dsd, rest = w8a8_lora.split_state_dict(sd)
                 routed = w8a8_lora.route_denoiser_keys(dsd, targets, ref=ref)
@@ -249,8 +249,8 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
                 pipe.enable_lora()
             for i, p in enumerate(PROMPTS):
                 imgs[(ref, i)] = _render(pipe, p, 4321 + i, steps)
-            if w8a8_lane:
-                w8a8_lora.clear_branch_lanes(pipe)
+            if w8a8_execution_lane:
+                w8a8_lora.clear_branch_execution_lanes(pipe)
                 if hasattr(pipe, "disable_lora"):
                     try:
                         pipe.disable_lora()
@@ -263,8 +263,8 @@ def run_quality(base: str, loras: list, steps: int, out: Path) -> dict:
         torch.cuda.empty_cache()
         return imgs
 
-    ref_imgs = render_lane(False)
-    cand_imgs = render_lane(True)
+    ref_imgs = render_execution_lane(False)
+    cand_imgs = render_execution_lane(True)
 
     report: dict = {"base": base, "steps": steps, "loras": list(lora_sds),
                     "swap_stats": cand_imgs.pop("swap_stats"),

--- a/scripts/w8a8_parity.py
+++ b/scripts/w8a8_parity.py
@@ -103,55 +103,55 @@ def main() -> None:
     print(f"snapshot: {src}")
     print(f"scaled_mm_supported: {scaled_mm_supported()}")
 
-    lanes = [x.strip() for x in args.lanes.split(",") if x.strip()]
+    execution_lanes = [x.strip() for x in args.execution_lanes.split(",") if x.strip()]
     images: dict = {}
     walls: dict = {}
 
-    for lane in lanes:
-        print(f"--- lane {lane}")
-        if lane == "bf16":
+    for execution_lane in execution_lanes:
+        print(f"--- lane {execution_lane}")
+        if execution_lane == "bf16":
             pipe = DiffusionPipeline.from_pretrained(
                 str(src), torch_dtype=torch.bfloat16).to("cuda")
-        elif lane == "w8a16":
+        elif execution_lane == "w8a16":
             pipe = DiffusionPipeline.from_pretrained(
                 str(src), torch_dtype=torch.bfloat16)
             assert apply_fp8_storage(pipe, compute_dtype=torch.bfloat16)
             pipe.to("cuda")
-        elif lane == "w8a8":
+        elif execution_lane == "w8a8":
             tree = out / "w8a8-tree"
             if not tree.exists():
                 quantize_tree_w8a8(src, tree)
             pipe = load_from_pretrained(DiffusionPipeline, tree)
-            lane_attr = getattr(pipe, "_cozy_weight_lane", "")
-            print(f"w8a8 weight lane: {lane_attr!r}")
-            assert lane_attr == "w8a8", "scaled_mm lane did not engage"
+            execution_lane_attr = getattr(pipe, "_cozy_weight_lane", "")
+            print(f"w8a8 weight lane: {execution_lane_attr!r}")
+            assert execution_lane_attr == "w8a8", "scaled_mm lane did not engage"
             pipe.to("cuda")
         else:
-            raise SystemExit(f"unknown lane {lane}")
+            raise SystemExit(f"unknown lane {execution_lane}")
         img, wall = _render(pipe, prompt=args.prompt, seed=args.seed,
                             steps=args.steps, size=args.size)
-        images[lane] = img
-        walls[lane] = wall
+        images[execution_lane] = img
+        walls[execution_lane] = wall
         from PIL import Image
 
-        Image.fromarray(img).save(out / f"{lane}.png")
-        print(f"{lane}: {wall:.2f}s for {args.steps} steps "
+        Image.fromarray(img).save(out / f"{execution_lane}.png")
+        print(f"{execution_lane}: {wall:.2f}s for {args.steps} steps "
               f"({wall / args.steps * 1000:.0f} ms/step)")
         _free(pipe)
 
     report: dict = {"model": args.model, "steps": args.steps, "size": args.size,
                     "seed": args.seed, "walls_s": walls, "deltas": {}}
     ref = images.get("bf16")
-    for lane, img in images.items():
-        if ref is None or lane == "bf16":
+    for execution_lane, img in images.items():
+        if ref is None or execution_lane == "bf16":
             continue
         mae, psnr = _mae_psnr(ref, img)
         d = {"mae": round(mae, 5), "psnr_db": round(psnr, 2)}
         lp = _lpips(ref, img)
         if lp is not None:
             d["lpips"] = round(lp, 4)
-        report["deltas"][lane] = d
-        print(f"{lane} vs bf16: {d}")
+        report["deltas"][execution_lane] = d
+        print(f"{execution_lane} vs bf16: {d}")
     if "w8a16" in walls and "w8a8" in walls:
         report["speedup_w8a8_vs_w8a16"] = round(walls["w8a16"] / walls["w8a8"], 3)
         print(f"speedup w8a8 vs w8a16: {report['speedup_w8a8_vs_w8a16']}x")

--- a/src/gen_worker/aot_cells.py
+++ b/src/gen_worker/aot_cells.py
@@ -139,13 +139,13 @@ def _get(
         "GET", path, base_url=base_url, bearer=bearer, params=params, timeout=timeout)
 
 
-def _lane_of_meta(meta: Dict[str, Any]) -> str:
-    return cell_key._canonical_lane(
+def _execution_lane_of_meta(meta: Dict[str, Any]) -> str:
+    return cell_key._canonical_execution_lane(
         str(meta.get("weight_lane") or ""), int(meta.get("lora_bucket") or 0))
 
 
 def _candidates(
-    items: List[Dict[str, Any]], family: str, want_lane: str,
+    items: List[Dict[str, Any]], family: str, want_execution_lane: str,
     rejected: Optional[Dict[str, int]] = None,
 ) -> List[Tuple[str, str, Dict[str, Any]]]:
     """(updated_at, checkpoint_id, metadata) rows that pass the filter, best
@@ -199,7 +199,7 @@ def _candidates(
             # rather than as a generic "verify failed".
             _reject(f"verify:{reason}")
             continue
-        if _lane_of_meta(meta) != want_lane:
+        if _execution_lane_of_meta(meta) != want_execution_lane:
             _reject("lane_mismatch")
             continue
         out.append((
@@ -405,7 +405,7 @@ def _discover_inner(
         return None
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     try:
-        want_lane = cell_key._canonical_lane(cc.cell_base_lane(pipe), bucket)
+        want_execution_lane = cell_key._canonical_execution_lane(cc.cell_base_execution_lane(pipe), bucket)
         repo = cc.system_repo(family)
         bearer = str(worker_jwt() or "").strip()
         resp = _get(
@@ -427,7 +427,7 @@ def _discover_inner(
             return None
         items = (resp.json() or {}).get("items") or []
         rejected: Dict[str, int] = {}
-        rows = _candidates(items, family, want_lane, rejected)
+        rows = _candidates(items, family, want_execution_lane, rejected)
         if not rows:
             # pgw#824: WHY every candidate lost, as counts. "No matching cell
             # among 12 checkpoints" was true and useless — it could not tell an
@@ -437,7 +437,7 @@ def _discover_inner(
                 f"{cls}={n}" for cls, n in sorted(
                     rejected.items(), key=lambda kv: (-kv[1], kv[0])))
             _emit("miss",
-                  f"family={family} lane={want_lane or 'plain'}: no matching "
+                  f"family={family} lane={want_execution_lane or 'plain'}: no matching "
                   f"aot-inductor cell among {len(items)} checkpoint(s)"
                   + (f" — rejected by class: {histogram}" if histogram
                      else " (the family has no published cells at all)"))
@@ -464,7 +464,7 @@ def _discover_inner(
         )
         _emit("hit",
               f"family={family} key={key} checkpoint={checkpoint_id[:16]} "
-              f"lane={want_lane or 'plain'}")
+              f"lane={want_execution_lane or 'plain'}")
         logger.info(
             "aot-cells: discovered %s (checkpoint %s, %.1f MB)",
             adopted.ref, checkpoint_id[:16],

--- a/src/gen_worker/aot_contract.py
+++ b/src/gen_worker/aot_contract.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional, Tuple
 
-from .compile_cache import lane_bucket, lane_token
+from .compile_cache import execution_lane_bucket, execution_lane_token
 
 
 class MintRefused(RuntimeError):
@@ -144,10 +144,10 @@ class ExportSpec:
     source_digest: str = ""
     closure_roots: Tuple[str, ...] = ()
 
-    def lane_label(self) -> str:
-        base, observed = lane_bucket(self.weight_lane)
+    def execution_lane_label(self) -> str:
+        base, observed = execution_lane_bucket(self.weight_lane)
         bucket = observed or self.lora_bucket
-        token = lane_token(base)
+        token = execution_lane_token(base)
         if bucket:
             return f"{token}-lora{bucket}" if token else f"lora{bucket}"
         return token

--- a/src/gen_worker/aot_inputs.py
+++ b/src/gen_worker/aot_inputs.py
@@ -226,9 +226,9 @@ def compose(
         # #725 option 2 through pgw#822's ONE arm: containers then lifted
         # signature. The dynamo lane stops after the containers (module state
         # export would bake); the exported lane lifts the adapter to call
-        # arguments ON TOP of them — `install_lifted_lora_lanes` alone has no
+        # arguments ON TOP of them — `install_lifted_lora_execution_lanes` alone has no
         # container to lay its flat pair out over.
-        lora_lifted.arm_lifted_lora_lanes(pipe, int(spec.lora_bucket))
+        lora_lifted.arm_lifted_lora_execution_lanes(pipe, int(spec.lora_bucket))
     if callable(getattr(pipe, "set_progress_bar_config", None)):
         pipe.set_progress_bar_config(disable=True)
     return pipe, lambda module: builder(module, spec)

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -100,7 +100,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 from . import activity as activity_mod
 from . import (
     aot_compile_pool, aot_export_parallel, aot_export_reuse, aot_package,
-    aot_serve, aot_wrapper_split, cell_key, graph_hash, kernel_lane)
+    aot_serve, aot_wrapper_split, cell_key, graph_hash, kernel_path)
 from .aot_contract import (  # re-exported: the declaration layer's vocabulary
     ADAPTER_FORK,
     DynamicDim,
@@ -1358,8 +1358,8 @@ def _disarm_branches(pipeline: Any) -> None:
     """
     from .models import lora_lifted, w8a8_lora
 
-    lora_lifted.remove_lifted_lora_lanes(pipeline)
-    w8a8_lora.disable_branch_lanes(pipeline)
+    lora_lifted.remove_lifted_lora_execution_lanes(pipeline)
+    w8a8_lora.disable_branch_execution_lanes(pipeline)
     logger.info(
         "aot-mint: branch containers dropped — exporting the adapter=false "
         "graph class(es)")
@@ -1388,7 +1388,7 @@ def _arm_branches(pipeline: Any, bucket: int) -> None:
     """
     from .models import lora_lifted
 
-    lora_lifted.arm_lifted_lora_lanes(pipeline, int(bucket or 0))
+    lora_lifted.arm_lifted_lora_execution_lanes(pipeline, int(bucket or 0))
 
 
 # pgw#824: the phase tokens the in-mint progress callback reports under.
@@ -1465,7 +1465,7 @@ def mint(
     entry_device_peak_bytes: int = 0,
     on_progress: Optional[Callable[[str, int, int, str], None]] = None,
     phase_snapshot: Optional[Path] = None,
-    lane_verdict: Optional[kernel_lane.Verdict] = None,
+    execution_lane_verdict: Optional[kernel_path.Verdict] = None,
 ) -> MintResult:
     """:func:`_mint_cell`, with the phase table attached to EVERY terminus.
 
@@ -1519,7 +1519,7 @@ def mint(
             entry_workers=entry_workers,
             entry_peak_rss_bytes=entry_peak_rss_bytes,
             entry_device_peak_bytes=entry_device_peak_bytes,
-            lane_verdict=lane_verdict,
+            execution_lane_verdict=execution_lane_verdict,
             progress=progress)
     except BaseException as exc:
         _attach_partial_phases(exc, progress)
@@ -1707,7 +1707,7 @@ def _mint_cell(
     entry_workers: int = 0,
     entry_peak_rss_bytes: int = 0,
     entry_device_peak_bytes: int = 0,
-    lane_verdict: Optional[kernel_lane.Verdict] = None,
+    execution_lane_verdict: Optional[kernel_path.Verdict] = None,
     progress: Optional[MintProgress] = None,
 ) -> MintResult:
     """Export + compile EVERY declared graph class and pack them as ONE
@@ -1995,12 +1995,12 @@ def _mint_cell(
         raise MintRefused(
             f"envelope refused the declared contract: {exc}") from exc
     meta.update(shared_identity_blocks(spec))
-    if lane_verdict is not None:
+    if execution_lane_verdict is not None:
         # pgw#947: the DISCRETE verdict only. Milliseconds in metadata.json
         # would break the #699 double-mint byte-compare — the artifact
         # deliberately carries no wall clocks — and the margin threshold is
         # what makes the discrete answer reproducible across two mints.
-        meta[kernel_lane.META_KEY] = kernel_lane.envelope_block(lane_verdict)
+        meta[kernel_path.META_KEY] = kernel_path.envelope_block(execution_lane_verdict)
     mode_drift = aot_package.strict_mode_drift(meta, spec.strict)
     if mode_drift:
         raise MintRefused("trace-mode drift: " + "; ".join(mode_drift))
@@ -2020,18 +2020,18 @@ def _mint_cell(
     # metadata.json would break the #699 double-mint byte-compare — the
     # artifact deliberately carries no timestamps and no wall clocks.
     meta["mint_phases"] = phase_table
-    if lane_verdict is not None:
+    if execution_lane_verdict is not None:
         # The EVIDENCE: both lanes' ms/step and peak bytes, the margin, the
         # headroom terms, and the device it was all measured on. Same channel
         # as the phase table (published checkpoint metadata + the typed
         # event), so a verdict is auditable long after the pod is gone.
-        meta[kernel_lane.EVIDENCE_KEY] = kernel_lane.evidence_block(
-            lane_verdict)
+        meta[kernel_path.EVIDENCE_KEY] = kernel_path.evidence_block(
+            execution_lane_verdict)
 
     logger.info(
         "aot-mint: %s lane=%s -> %s (%d entr%s across %d target(s), %.1f MB "
         "package, combined=%s, %s)",
-        spec.family, spec.lane_label() or "(plain)", key,
+        spec.family, spec.execution_lane_label() or "(plain)", key,
         len(minted), "y" if len(minted) == 1 else "ies",
         len({row.spec.target for row in minted}),
         package.stat().st_size / 1e6, meta.get("combined_graph_hash"),
@@ -2074,7 +2074,7 @@ def _entry_device_bytes(
 
         budget = mint_budget.co_residency(
             family=str(spec.family or ""),
-            weight_lane=str(spec.lane_label() or ""))
+            weight_lane=str(spec.execution_lane_label() or ""))
     except Exception:  # noqa: BLE001
         return 0, "unmeasured"
     if not budget.probed:
@@ -2612,11 +2612,11 @@ def _emit_phase_event(spec: ExportSpec, table: Mapping[str, Any]) -> None:
     telemetry.
     """
     try:
-        family, lane = spec.family, spec.lane_label() or "plain"
+        family, execution_lane = spec.family, spec.execution_lane_label() or "plain"
     except Exception:  # pragma: no cover — telemetry never fails a mint
         logger.debug("aot-mint: phase event emission failed", exc_info=True)
         return
-    emit_phase_events(family=family, lane=lane, table=table)
+    emit_phase_events(family=family, execution_lane=execution_lane, table=table)
 
 
 #: pgw#842: the mint's WIDTH decision, as its own hub row.
@@ -2624,7 +2624,7 @@ POOL_PHASE = "pool"
 
 
 def _emit_pool_event(
-    *, family: str, lane: str, table: Mapping[str, Any],
+    *, family: str, execution_lane: str, table: Mapping[str, Any],
 ) -> None:
     """pgw#842: one event that says what K was, what chose it, and what it
     bought — the standing "no silent decisions" rule applied to the mint's
@@ -2650,7 +2650,7 @@ def _emit_pool_event(
     under = int(pool.get("underwidth") or 0)
     wall_s = float(pool.get("pool_wall_s") or 0.0)
     head = (
-        f"family={family} lane={lane} entry_workers={workers} "
+        f"family={family} lane={execution_lane} entry_workers={workers} "
         f"binding={binding} underwidth={under}")
     if under > 0:
         # Named in the FIRST line, so a narrow pool is legible without
@@ -2666,7 +2666,7 @@ def _emit_pool_event(
 
 
 def emit_phase_events(
-    *, family: str, lane: str, table: Mapping[str, Any],
+    *, family: str, execution_lane: str, table: Mapping[str, Any],
     terminus: str = "",
 ) -> None:
     """Typed telemetry event — the phase table must reach observability,
@@ -2687,7 +2687,7 @@ def emit_phase_events(
         from . import activity as activity_mod
 
         totals = dict(table.get("totals") or {})
-        lane = lane or "plain"
+        execution_lane = execution_lane or "plain"
         total_s = float(totals.get("total_s") or 0.0)
         # pgw#825: the roll-up's PHASE is the mint's terminus. An aborted mint
         # measured real entries and must report them — under `aborted`, never
@@ -2697,7 +2697,7 @@ def emit_phase_events(
             or activity_mod.PHASE_MINTED
         activity_mod.emit_event(
             MINT_PHASES_KIND,
-            f"family={family} lane={lane} status={roll_up} "
+            f"family={family} lane={execution_lane} status={roll_up} "
             f"n_entries={table.get('n_entries')} totals={totals} "
             f"phases={dict(table.get('phases') or {})} "
             f"overlays={dict(table.get('overlays') or {})} "
@@ -2705,7 +2705,7 @@ def emit_phase_events(
             phase=roll_up,
             duration_ms=int(round(total_s * 1000)),
         )
-        _emit_pool_event(family=family, lane=lane, table=table)
+        _emit_pool_event(family=family, execution_lane=execution_lane, table=table)
         for name, timings in sorted((table.get("entries") or {}).items()):
             if not isinstance(timings, Mapping):
                 continue
@@ -2714,7 +2714,7 @@ def emit_phase_events(
                 continue
             activity_mod.emit_event(
                 MINT_PHASES_KIND,
-                f"family={family} lane={lane} entry={name} "
+                f"family={family} lane={execution_lane} entry={name} "
                 f"timings={dict(timings)}",
                 phase=f"entry:{name}",
                 duration_ms=int(round(entry_s * 1000)),
@@ -2895,7 +2895,7 @@ def cell_identity(meta: Mapping[str, Any], spec: ExportSpec) -> cell_key.CellKey
         "format": str(meta.get("format") or ""),
         "kind": aot_serve.ARTIFACT_KIND,
         "family": str(meta.get("family") or ""),
-        "lane": spec.lane_label(),
+        "lane": spec.execution_lane_label(),
         # pgw#846: an exported cell is always whole-graph again; "" is the
         # optional-axis value `from_axes` omits, matching every pre-regional
         # whole-graph key.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -89,7 +89,7 @@ from .cell_adopt import AdoptOutcome
 from . import shape_growth
 from .compile_cache import (
     AdoptError,
-    CompiledLaneUnavailableError,
+    CompiledExecutionLaneUnavailableError,
     _clean_tarinfo,
     parse_cell_ref,
     sku_slug,
@@ -1820,7 +1820,7 @@ def wrap_module(
 
     def aot_forward(*args: Any, **kwargs: Any) -> Any:
         if state["revocation_error"]:
-            raise CompiledLaneUnavailableError(state["revocation_error"])
+            raise CompiledExecutionLaneUnavailableError(state["revocation_error"])
         # The lifted pair is resolved PER CALL, not captured at wrap time:
         # the LoRA lane may install/remove lifting independently of arming,
         # and a stale capture would either starve the graph of a mandatory
@@ -1926,7 +1926,7 @@ def _revoke(state: Dict[str, Any], detail: str) -> None:
             f"compiled-state revocation failed: "
             f"{type(callback_exc).__name__}: {callback_exc}")
         logger.exception("aot-serve: %s", state["revocation_error"])
-        raise CompiledLaneUnavailableError(state["revocation_error"]) from callback_exc
+        raise CompiledExecutionLaneUnavailableError(state["revocation_error"]) from callback_exc
 
 
 def report_ingress_refusal(state: Dict[str, Any], reason: str, detail: str) -> None:

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -47,7 +47,7 @@ from .binding import BINDING_TYPES, Binding
 from .export_contract import Arg, Dim, Fork, GraphClass, Input, validate_contract
 from .formula import RuntimeFormula
 from .slot import OBJECTIVES, TASKS, Slot
-from ..models import lanes as lanespec
+from ..models import execution_lanes as lanespec
 from ..runtimes.server import ServerHandle
 from .tree import is_introspectable
 
@@ -528,7 +528,7 @@ def _validate_handles(owner: str, handles: Any) -> Tuple[str, ...]:
             f"@endpoint {owner}: handles= must be a list/tuple of lane body "
             f"strings, got {type(handles).__name__}"
         )
-    known = lanespec.known_lane_bodies()
+    known = lanespec.known_execution_lane_bodies()
     out: list[str] = []
     for token in handles:
         t = str(token or "").strip().lower()

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -144,12 +144,12 @@ def from_axes(axes: Mapping[str, str]) -> CellKey:
     return CellKey(axes=tuple(sorted(clean.items())))
 
 
-def _canonical_lane(weight_lane: str, lora_bucket: int = 0) -> str:
+def _canonical_execution_lane(weight_lane: str, lora_bucket: int = 0) -> str:
     from . import compile_cache as cc  # cycle: compile_cache imports cell_key
 
-    base, observed = cc.lane_bucket(str(weight_lane or ""))
+    base, observed = cc.execution_lane_bucket(str(weight_lane or ""))
     bucket = observed or int(lora_bucket or 0)
-    token = cc.lane_token(base)
+    token = cc.execution_lane_token(base)
     if bucket:
         return f"{token}-lora{bucket}" if token else f"lora{bucket}"
     return token
@@ -203,7 +203,7 @@ def compute(
         "format": str(cc.ARTIFACT_FORMAT),
         "kind": "inductor",
         "family": str(family or ""),
-        "lane": _canonical_lane(weight_lane, lora_bucket),
+        "lane": _canonical_execution_lane(weight_lane, lora_bucket),
         "mode": "regional" if regional else "",
         "sm": rt["sm"],
         "contract": str(contract or ""),
@@ -266,7 +266,7 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
         "format": str(meta.get("format") or ""),
         "kind": "inductor",
         "family": str(meta.get("family") or ""),
-        "lane": _canonical_lane(
+        "lane": _canonical_execution_lane(
             str(meta.get("weight_lane") or ""),
             int(meta.get("lora_bucket") or 0),
         ),

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -33,7 +33,7 @@ from ..discovery.project import load_project_config
 from gen_worker.registry import collect_from_namespace
 from .args import ArgError, build_payload
 from ..api.slot import resolve_slot
-from ..models import lanes as lanespec
+from ..models import execution_lanes as lanespec
 from ..api.binding import rebind_pick
 from .serve import DEFAULT_SOCKET_PATH
 from . import invoke as invoke_mod
@@ -117,7 +117,7 @@ def add_subparser(sub: argparse._SubParsersAction[Any]) -> None:
         ),
     )
     p.add_argument(
-        "--lane", dest="lane", default="",
+        "--lane", dest="execution_lane", default="",
         help=(
             "Execution lane (th#913 dual-form): a family 'bf16'|'fp8', or a "
             "full descriptor like 'fp8-w8a8-dynamic+compiled'. Default: auto "
@@ -758,34 +758,34 @@ def _resolve_ctx_slots(ctx: Any, selected: "_SelectedFunction") -> None:
         set_slots(resolved, errors, root_slot=root)
 
 
-def _local_executing_lane(
-    bindings: Dict[str, Any], lane_str: str, handles: Tuple[str, ...]
+def _local_executing_execution_lane(
+    bindings: Dict[str, Any], execution_lane_str: str, handles: Tuple[str, ...]
 ) -> str:
     """th#1050 ctx.lane for local runs: a --lane the endpoint DECLARES wins
     (author kernels execute it); otherwise the most-quantized binding's lane
     (the local twin of Executor._served_lane, eager execution)."""
 
-    if lane_str and handles:
+    if execution_lane_str and handles:
         try:
-            req = lanespec.parse_lane_spec(lane_str)
-            if req.lane is not None and lanespec.lane_body_id(req.lane) in handles:
-                return lanespec.lane_id(req.lane)
+            req = lanespec.parse_execution_lane_spec(execution_lane_str)
+            if req.execution_lane is not None and lanespec.execution_lane_body_id(req.execution_lane) in handles:
+                return lanespec.execution_lane_id(req.execution_lane)
         except ValueError:
             pass
-    ranked = {b: i for i, b in enumerate(lanespec.known_lanes())}
+    ranked = {b: i for i, b in enumerate(lanespec.known_execution_lanes())}
     best, best_key = None, (2, len(ranked) + 1)
     for b in (bindings or {}).values():
-        lane = lanespec.lane_of_binding(
+        execution_lane = lanespec.execution_lane_of_binding(
             getattr(b, "flavor", "") or "",
             getattr(b, "storage_dtype", "") or "", False)
-        quant = 1 if lanespec.family_of(lane) == lanespec.FAMILY_BF16 else 0
-        key = (quant, ranked.get(lanespec.lane_id(lane), len(ranked)))
+        quant = 1 if lanespec.family_of(execution_lane) == lanespec.FAMILY_BF16 else 0
+        key = (quant, ranked.get(lanespec.execution_lane_id(execution_lane), len(ranked)))
         if best is None or key < best_key:
-            best, best_key = lane, key
-    return lanespec.lane_id(best) if best is not None else "bf16-w16a16+eager"
+            best, best_key = execution_lane, key
+    return lanespec.execution_lane_id(best) if best is not None else "bf16-w16a16+eager"
 
 
-def _apply_lane_to_bindings(bindings: Dict[str, Any], lane_str: str) -> Dict[str, Any]:
+def _apply_execution_lane_to_bindings(bindings: Dict[str, Any], execution_lane_str: str) -> Dict[str, Any]:
     """th#913/gw#596: fold a --lane choice into the declared bindings.
 
     bf16 = the declared base (no transform); fp8 family = the local cast
@@ -794,7 +794,7 @@ def _apply_lane_to_bindings(bindings: Dict[str, Any], lane_str: str) -> Dict[str
     lanes need an exact ref#flavor and are refused here."""
 
     try:
-        req = lanespec.parse_lane_spec(lane_str)
+        req = lanespec.parse_execution_lane_spec(execution_lane_str)
     except ValueError as e:
         raise _UsageError(f"--lane: {e}") from None
     if req.is_zero or req.family == lanespec.FAMILY_BF16:
@@ -803,7 +803,7 @@ def _apply_lane_to_bindings(bindings: Dict[str, Any], lane_str: str) -> Dict[str
         raise _UsageError(
             "--lane: 4bit lanes carry rank/engine-specific flavor tokens; "
             "bind the exact ref#flavor (e.g. '#svdq-int4-r128') instead.")
-    want_w8a8 = req.lane is not None and req.lane.activation == lanespec.ACT_W8A8
+    want_w8a8 = req.execution_lane is not None and req.execution_lane.activation == lanespec.ACT_W8A8
     out: Dict[str, Any] = {}
     for name, binding in bindings.items():
         try:
@@ -1038,8 +1038,8 @@ def _run_inner(args: argparse.Namespace) -> int:
 
     # th#913/gw#596: optional human lane choice, mapped onto the bindings
     # before resolution (the ladder twin's local expansion).
-    if getattr(args, "lane", ""):
-        selected.bindings = _apply_lane_to_bindings(selected.bindings, args.lane)
+    if getattr(args, "execution_lane", ""):
+        selected.bindings = _apply_execution_lane_to_bindings(selected.bindings, args.execution_lane)
 
     # Ergonomic `field=value` tokens -> payload bytes (coerced via the function's
     # msgspec type), merged over any --payload base.
@@ -1065,8 +1065,8 @@ def _run_inner(args: argparse.Namespace) -> int:
         kind=selected.kind,
         allow_publish=bool(args.allow_publish),
     )
-    ctx._set_lane(_local_executing_lane(
-        selected.bindings, getattr(args, "lane", ""), selected.handles))
+    ctx._set_execution_lane(_local_executing_execution_lane(
+        selected.bindings, getattr(args, "execution_lane", ""), selected.handles))
     if source_path is not None:
         set_source = getattr(ctx, "_set_source_path", None)
         if not callable(set_source):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -76,7 +76,7 @@ from . import cell_key, env_seal, guard_closure, hot_swap
 from .api.errors import RetryableError
 from .models import w8a8_lora
 from .models.loading import load_from_pretrained, pipeline_weight_lane
-from .models.loading import pipeline_weight_lane as _traced_lane
+from .models.loading import pipeline_weight_lane as _traced_execution_lane
 from .models.memory import low_vram_mode, place_pipeline, reconcile_resident_mode
 from .models.refs import parse_model_ref
 from .models.w8a8_lora import RANK_BUCKETS
@@ -601,19 +601,19 @@ def gen_worker_version() -> str:
         return ""
 
 
-def lane_bucket(lane: str) -> Tuple[str, int]:
+def execution_lane_bucket(execution_lane: str) -> Tuple[str, int]:
     """(base lane, rank bucket) for a weight lane in stamp OR label-token
     form: ``"w8a8-lora128"`` -> ``("w8a8", 128)``, ``"lora32"`` -> ``("", 32)``,
     ``"w8a8"`` -> ``("w8a8", 0)``. Sparse stamps (eager-only, never cells)
     do not parse as bucketed — they pass through as their whole string."""
-    m = re.search(r"(?:^|-)lora(\d+)$", str(lane or ""))
+    m = re.search(r"(?:^|-)lora(\d+)$", str(execution_lane or ""))
     if m is None:
-        return str(lane or ""), 0
-    base = lane[: m.start()]
+        return str(execution_lane or ""), 0
+    base = execution_lane[: m.start()]
     return base, int(m.group(1))
 
 
-def lane_token(weight_lane: str) -> str:
+def execution_lane_token(weight_lane: str) -> str:
     """Label token for a traced weight lane (gw#534): cells of different
     lanes are DIFFERENT graphs and must not collide on one flavor label.
     "" (plain resident, incl. bf16-resident) stays unsuffixed. LoRA-branch
@@ -621,7 +621,7 @@ def lane_token(weight_lane: str) -> str:
     ``w8a8-lora128`` -> ``w8a8-lora128``, ``fp8-hooks-lora32`` ->
     ``w8a16-lora32``, ``lora32`` -> ``lora32`` — one graph family per
     (base lane, rank bucket)."""
-    base, bucket = lane_bucket(str(weight_lane or ""))
+    base, bucket = execution_lane_bucket(str(weight_lane or ""))
     tok = {"": "", "fp8-hooks": "w8a16", "w8a8": "w8a8",
            "w4a4": "w4a4"}.get(base, base)
     if bucket:
@@ -629,17 +629,17 @@ def lane_token(weight_lane: str) -> str:
     return tok
 
 
-def cell_base_lane(pipeline: Any) -> str:
+def cell_base_execution_lane(pipeline: Any) -> str:
     """Base weight lane for CELL-IDENTITY computation (advertised requested
     keys, pull-by-key lookups, local-store lookups): the pipeline probe
     first, then the denoiser's own lane markers — the identical resolution
     the mint's ``stamp_lane`` memoizes, so requested == published by
     construction (pgw#686). Dispatch/policy surfaces keep the raw
     :func:`loading.pipeline_weight_lane` probe; this is cell identity only."""
-    return w8a8_lora.effective_base_lane(pipeline)
+    return w8a8_lora.effective_base_execution_lane(pipeline)
 
 
-def compile_target_lane_error(weight_lane: str, lora_bucket: int) -> str:
+def compile_target_execution_lane_error(weight_lane: str, lora_bucket: int) -> str:
     """Return why a worker compile-target lane is not wire-canonical.
 
     This is the Python half of Tensorhub's compile-target descriptor contract:
@@ -648,19 +648,19 @@ def compile_target_lane_error(weight_lane: str, lora_bucket: int) -> str:
     Keeping this vocabulary explicit prevents a test or future loader from
     advertising a target the scheduler must reject.
     """
-    lane = str(weight_lane or "")
+    execution_lane = str(weight_lane or "")
     declared = int(lora_bucket or 0)
-    base, observed = lane_bucket(lane)
+    base, observed = execution_lane_bucket(execution_lane)
     if base not in ("", "fp8-hooks", "w8a16", "w8a8", "w4a4"):
-        return f"unsupported pipeline_weight_lane {lane!r}"
+        return f"unsupported pipeline_weight_lane {execution_lane!r}"
 
     if observed not in (0, *RANK_BUCKETS):
-        return f"unsupported LoRA bucket {observed} in lane {lane!r}"
+        return f"unsupported LoRA bucket {observed} in lane {execution_lane!r}"
     canonical = f"{base}-lora{observed}" if base and observed else (
         f"lora{observed}" if observed else base
     )
-    if lane != canonical:
-        return f"non-canonical pipeline_weight_lane {lane!r}; expected {canonical!r}"
+    if execution_lane != canonical:
+        return f"non-canonical pipeline_weight_lane {execution_lane!r}; expected {canonical!r}"
     if observed != declared:
         return (
             f"pipeline lane LoRA bucket {observed} != declared "
@@ -676,7 +676,7 @@ def flavor_label(sku: str, torch_version: str, weight_lane: str = "") -> str:
     byte-compatible with tensorhub's compilecache.FlavorLabel."""
     short = ".".join(str(torch_version).split("+")[0].split(".")[:2])
     label = f"inductor-{sku}-torch{short}"
-    tok = lane_token(weight_lane)
+    tok = execution_lane_token(weight_lane)
     return f"{label}-{tok}" if tok else label
 
 
@@ -703,7 +703,7 @@ def parse_cell_ref(ref: str) -> Tuple[str, str]:
     return th.repo[len("family-"):], th.flavor or ""
 
 
-def cell_lane(ref: str) -> str:
+def cell_execution_lane(ref: str) -> str:
     """The compiled weight-lane token encoded in a system-cell ref.
 
     The flavor is human/routing metadata; artifact metadata remains the
@@ -715,8 +715,8 @@ def cell_lane(ref: str) -> str:
     _prefix, sep, suffix = flavor.partition("-torch")
     if not sep:
         return ""
-    _version, sep, lane = suffix.partition("-")
-    return lane if sep else ""
+    _version, sep, execution_lane = suffix.partition("-")
+    return execution_lane if sep else ""
 
 
 def family_from_ref(ref: str) -> str:
@@ -1412,12 +1412,12 @@ def _semantic_cache_tag(pipeline: Any, cfg: Any) -> str:
     already hashes them natively (system info, config, dtypes) and the ck5
     outer key pins them via env_seal/toolchain/code_closure — the tag's job
     is semantics only."""
-    lane = cell_key._canonical_lane(
+    execution_lane = cell_key._canonical_execution_lane(
         pipeline_weight_lane(pipeline),
         int(getattr(cfg, "lora_bucket", 0) or 0))
     payload = "|".join((
         str(ARTIFACT_FORMAT), "inductor",
-        str(getattr(cfg, "family", "") or ""), lane,
+        str(getattr(cfg, "family", "") or ""), execution_lane,
         "regional" if bool(getattr(cfg, "regional", False)) else "whole",
         cell_key.contract_digest(declared_contract_facts(cfg)),
     ))
@@ -1936,7 +1936,7 @@ class CellSelectionBugError(RuntimeError):
         self.detail = detail
 
 
-class CompiledLaneUnavailableError(RetryableError):
+class CompiledExecutionLaneUnavailableError(RetryableError):
     """A precision lane whose production contract requires a cell is unsafe."""
 
 
@@ -2100,7 +2100,7 @@ def mode_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     return ""
 
 
-def apply_lora_lane(pipeline: Any, bucket: int) -> bool:
+def apply_lora_execution_lane(pipeline: Any, bucket: int) -> bool:
     """Put the pipeline on the branch-bearing graph family for ``bucket``
     (gw#561): canonical zeroed rank-``bucket`` branches on every
     branch-capable denoiser Linear (the gw#547 compiled-lane contract) + the
@@ -2115,17 +2115,17 @@ def apply_lora_lane(pipeline: Any, bucket: int) -> bool:
     if not bucket:
         return False
 
-    targets = w8a8_lora.enable_branch_lanes(pipeline, int(bucket))
+    targets = w8a8_lora.enable_branch_execution_lanes(pipeline, int(bucket))
     if not targets:
         raise RuntimeError(
             "Compile.lora_bucket declared but the pipeline has no "
             "branch-capable denoiser (transformer/transformer_2/unet)"
         )
-    w8a8_lora.stamp_lane(pipeline, targets)
+    w8a8_lora.stamp_execution_lane(pipeline, targets)
     return True
 
 
-def drop_lora_lane(pipeline: Any) -> None:
+def drop_lora_execution_lane(pipeline: Any) -> None:
     """Undo :func:`apply_lora_lane`: drop the branch buffers on every
     denoiser and restore the branchless lane stamp (the eager rollback —
     canonical zeroed branches cost +21-32% eager, gw#547)."""
@@ -2133,11 +2133,11 @@ def drop_lora_lane(pipeline: Any) -> None:
     targets = w8a8_lora.branch_targets(pipeline)
     if not targets:
         return
-    w8a8_lora.disable_branch_lanes(pipeline)
-    w8a8_lora.stamp_lane(pipeline, targets)
+    w8a8_lora.disable_branch_execution_lanes(pipeline)
+    w8a8_lora.stamp_execution_lane(pipeline, targets)
 
 
-def lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:
+def execution_lane_drift(meta: Dict[str, Any], pipeline: Any) -> str:
     """'' when the cell's traced weight lane matches this pipeline's, else the
     mismatch (gw#534). Enforced SYMMETRICALLY (unlike ``mode_drift``): a
     bf16-resident pipeline must never adopt hook-cast-traced graphs and vice
@@ -2407,16 +2407,16 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
     }
     encoded = json.dumps(graph, sort_keys=True, separators=(",", ":")).encode()
 
-    lane = pipeline_weight_lane(pipeline)
-    weight_contract: Dict[str, Any] = {"lane": lane}
-    if lane.startswith(("w8a8", "w4a4")):
+    execution_lane = pipeline_weight_lane(pipeline)
+    weight_contract: Dict[str, Any] = {"lane": execution_lane}
+    if execution_lane.startswith(("w8a8", "w4a4")):
         activations = sorted({str(r["activation"]) for r in quantized})
         weight_contract.update({
             "artifact_schema": (
-                "nvfp4-w4a4-v1" if lane.startswith("w4a4") else "fp8-w8a8-v1"),
+                "nvfp4-w4a4-v1" if execution_lane.startswith("w4a4") else "fp8-w8a8-v1"),
             "operator": "torch._scaled_mm",
             "weight_scaling": (
-                "per-16-block+per-tensor" if lane.startswith("w4a4")
+                "per-16-block+per-tensor" if execution_lane.startswith("w4a4")
                 else "per-output-channel"),
             "activation_scaling": activations,
             "quantized": sorted(quantized, key=lambda r: str(r["path"])),
@@ -2640,10 +2640,10 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
             "weight-lane artifact schema/exclusion manifest mismatch: "
             + _first_contract_difference(meta_weights, weight_contract)
         )
-    cell_lane_base = str(weight_contract.get("lane") or "")
-    if cell_lane_base.startswith(("w8a8", "w4a4")):
+    cell_execution_lane_base = str(weight_contract.get("lane") or "")
+    if cell_execution_lane_base.startswith(("w8a8", "w4a4")):
         activations = weight_contract.get("activation_scaling") or []
-        if cell_lane_base.startswith("w8a8"):
+        if cell_execution_lane_base.startswith("w8a8"):
             # DYNAMIC only, one homogeneous granularity per graph (gw#564:
             # per-row = rowwise sm_90+, per-tensor = the sm_89 epilogue lane).
             if activations not in (["dynamic-per-row"], ["dynamic-per-tensor"]):
@@ -2656,7 +2656,7 @@ def contract_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
                 return (f"W4A4 activation scaling must be homogeneous "
                         f"static or dynamic-per-tensor, got {activations!r}")
         if not weight_contract.get("quantized"):
-            return (f"{cell_lane_base[:4].upper()} graph contains no "
+            return (f"{cell_execution_lane_base[:4].upper()} graph contains no "
                     "torch._scaled_mm modules")
         here_digest = runtime_key()["image_digest"]
         # cuda_driver excluded (gw#577): host-lottery axis, see verify().
@@ -2700,7 +2700,7 @@ def _guarded(
                     f"{type(exc).__name__}: {exc}"
                 )
                 logger.exception("compile-cache: %s", state["revocation_error"])
-                raise CompiledLaneUnavailableError(
+                raise CompiledExecutionLaneUnavailableError(
                     state["revocation_error"]
                 ) from exc
 
@@ -2739,7 +2739,7 @@ def _guarded(
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if state["revocation_error"]:
-            raise CompiledLaneUnavailableError(state["revocation_error"])
+            raise CompiledExecutionLaneUnavailableError(state["revocation_error"])
         if state["failed"]:
             return original(*args, **kwargs)
         # pgw#622: a novel input signature serves EAGER immediately while a
@@ -2869,7 +2869,7 @@ def _guarded_regional(
     @functools.wraps(original)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if state["revocation_error"]:
-            raise CompiledLaneUnavailableError(state["revocation_error"])
+            raise CompiledExecutionLaneUnavailableError(state["revocation_error"])
         if not state["failed"]:
             before = proof_before()
             try:
@@ -2905,7 +2905,7 @@ def _guarded_regional(
                         )
                         logger.exception(
                             "compile-cache: %s", state["revocation_error"])
-                        raise CompiledLaneUnavailableError(
+                        raise CompiledExecutionLaneUnavailableError(
                             state["revocation_error"]
                         ) from callback_exc
                 # pgw#672/pgw#673 posture: mandatory lanes degrade to explicit
@@ -2944,7 +2944,7 @@ EXECUTION_LANE_ATTR = "_cozy_execution_lane"
 #: around one record's whole setup, so pipelines armed through ANY path —
 #: slot injection or a self-loaded ``arm_compile`` inside ``setup()``
 #: (ArmingScope) — get the same lane stamped by :func:`apply`.
-_SETUP_EXEC_LANE: contextvars.ContextVar[str] = contextvars.ContextVar(
+_SETUP_EXEC_EXECUTION_LANE: contextvars.ContextVar[str] = contextvars.ContextVar(
     "gw_setup_execution_lane", default="")
 
 #: pgw#714: pin provenance of the stamped execution lane. True only when the
@@ -2953,7 +2953,7 @@ _SETUP_EXEC_LANE: contextvars.ContextVar[str] = contextvars.ContextVar(
 #: refuses to arm at all (no router, no background mint, no foreground
 #: compile) instead of treating the pin as merely "serve eager while minting".
 EXECUTION_LANE_PINNED_ATTR = "_cozy_execution_lane_pinned"
-_SETUP_EXEC_LANE_PINNED: contextvars.ContextVar[bool] = contextvars.ContextVar(
+_SETUP_EXEC_EXECUTION_LANE_PINNED: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "gw_setup_execution_lane_pinned", default=False)
 
 #: pgw#714: process-wide compile kill switch. Set once (with a reason) when
@@ -2981,25 +2981,25 @@ def operator_eager_pin(pipeline: Any) -> bool:
     """True when the hub-resolved execution lane stamped on ``pipeline`` was
     OPERATOR-PINNED to the eager execution axis (pgw#714 kill switch)."""
     pinned = bool(getattr(pipeline, EXECUTION_LANE_PINNED_ATTR, False))
-    lane_str = str(getattr(pipeline, EXECUTION_LANE_ATTR, "") or "").strip()
-    if not lane_str:
-        lane_str = _SETUP_EXEC_LANE.get().strip()
-        pinned = _SETUP_EXEC_LANE_PINNED.get()
-        if lane_str:
+    execution_lane_str = str(getattr(pipeline, EXECUTION_LANE_ATTR, "") or "").strip()
+    if not execution_lane_str:
+        execution_lane_str = _SETUP_EXEC_EXECUTION_LANE.get().strip()
+        pinned = _SETUP_EXEC_EXECUTION_LANE_PINNED.get()
+        if execution_lane_str:
             try:
-                setattr(pipeline, EXECUTION_LANE_ATTR, lane_str)
+                setattr(pipeline, EXECUTION_LANE_ATTR, execution_lane_str)
                 setattr(pipeline, EXECUTION_LANE_PINNED_ATTR, pinned)
             except Exception:
                 pass
-    if not (lane_str and pinned):
+    if not (execution_lane_str and pinned):
         return False
-    from .models import lanes as lanespec
+    from .models import execution_lanes as lanespec
 
     try:
-        lane = lanespec.parse_lane(lane_str)
+        execution_lane = lanespec.parse_execution_lane(execution_lane_str)
     except ValueError:
         return False
-    return lane.execution == lanespec.EXEC_EAGER
+    return execution_lane.execution == lanespec.EXEC_EAGER
 
 
 def eager_tier_available(pipeline: Any) -> bool:
@@ -3055,23 +3055,23 @@ def mandatory_serving(pipeline: Any) -> bool:
     routed the whole boot into the FOREGROUND compile-then-serve mint (the
     reopen's measured 26-minute tenant starvation). Without lane evidence
     the stamp remains the fail-closed fallback."""
-    lane_str = str(getattr(pipeline, EXECUTION_LANE_ATTR, "") or "").strip()
-    if not lane_str:
-        lane_str = _SETUP_EXEC_LANE.get().strip()
-        if lane_str:
+    execution_lane_str = str(getattr(pipeline, EXECUTION_LANE_ATTR, "") or "").strip()
+    if not execution_lane_str:
+        execution_lane_str = _SETUP_EXEC_EXECUTION_LANE.get().strip()
+        if execution_lane_str:
             try:
-                setattr(pipeline, EXECUTION_LANE_ATTR, lane_str)
+                setattr(pipeline, EXECUTION_LANE_ATTR, execution_lane_str)
             except Exception:
                 pass
-    if lane_str:
-        from .models import lanes as lanespec
+    if execution_lane_str:
+        from .models import execution_lanes as lanespec
 
         try:
-            lane = lanespec.parse_lane(lane_str)
+            execution_lane = lanespec.parse_execution_lane(execution_lane_str)
         except ValueError:
             pass
         else:
-            return lane.activation in (lanespec.ACT_W8A8, lanespec.ACT_W4A4)
+            return execution_lane.activation in (lanespec.ACT_W8A8, lanespec.ACT_W4A4)
     # Module-attr call (not the top-level import): tests monkeypatch
     # models.loading.pipeline_weight_lane; stay late-bound.
     from .models import loading as _loading
@@ -3391,7 +3391,7 @@ def artifact_drift(meta: Dict[str, Any], pipeline: Any, cfg: Any) -> str:
     """The complete pipeline/config compatibility verdict for one cell."""
     drift = (
         mode_drift(meta, pipeline)
-        or lane_drift(meta, pipeline)
+        or execution_lane_drift(meta, pipeline)
         or contract_drift(meta, pipeline, cfg)
     )
     if drift:
@@ -3518,7 +3518,7 @@ def enable(
 
                     # gw#632: the EFFECTIVE bucket — a slot object with no
                     # resolvable compile target (sdxl's bare vae) never rides
-                    # the branch lane (provision downgrades apply_lora_lane
+                    # the branch lane (provision downgrades apply_lora_execution_lane
                     # the same way, 0.52.1), so its self-key must not claim
                     # the family's lora<bucket> cell and then explode on
                     # lane drift (live: `weight_lane 'lora64' != pipeline ''`
@@ -3571,15 +3571,15 @@ def enable(
                 )
             from .models.loading import pipeline_weight_lane
 
-            quant_lane = pipeline_weight_lane(pipeline)
-            if quant_lane.startswith(("w8a8", "w4a4")) and not armed:
+            quant_execution_lane = pipeline_weight_lane(pipeline)
+            if quant_execution_lane.startswith(("w8a8", "w4a4")) and not armed:
                 if meta is not None:
                     refusal = "verified cell armed no compile target"
-                lane_name = quant_lane[:4].upper()
-                raise CompiledLaneUnavailableError(
-                    f"{lane_name} requires an exact compatible Forge cell "
+                execution_lane_name = quant_execution_lane[:4].upper()
+                raise CompiledExecutionLaneUnavailableError(
+                    f"{execution_lane_name} requires an exact compatible Forge cell "
                     f"({refusal}); eager/dequantized execution is not a "
-                    f"{lane_name} production lane"
+                    f"{execution_lane_name} production lane"
                 )
             return armed
     finally:
@@ -3820,7 +3820,7 @@ def build(
     # on a pod with the same free-VRAM class as the target workers.
     placed = place_pipeline(pipe)
 
-    if _traced_lane(pipe).startswith(("w8a8", "w4a4")) and not str(
+    if _traced_execution_lane(pipe).startswith(("w8a8", "w4a4")) and not str(
         serving_image_digest
     ).strip():
         # The lane can materialize as w8a8/w4a4 from the SOURCE flavor alone
@@ -3831,7 +3831,7 @@ def build(
     # branches installed — zeroed slots are bit-exact with branchless output
     # (gw#547), so the warm calls render normally while the traced graphs
     # carry the branch GEMMs.
-    apply_lora_lane(pipe, int(lora_bucket))
+    apply_lora_execution_lane(pipe, int(lora_bucket))
     if callable(getattr(pipe, "set_progress_bar_config", None)):
         pipe.set_progress_bar_config(disable=True)
     # Cold compilation is an explicit producer-library operation; serving
@@ -3859,7 +3859,7 @@ def build(
     # is watching the producer run; the event is for whoever asks the hub next
     # week how long a JIT mint takes.
     emit_jit_compile_event(
-        timings, family=family, lane=pipeline_weight_lane(pipe), route="build")
+        timings, family=family, execution_lane=pipeline_weight_lane(pipe), route="build")
 
     captured = [p for p in (capture_root / "inductor").rglob("*") if p.is_file()]
     if not captured:
@@ -3935,7 +3935,7 @@ def emit_jit_compile_event(
     timings: Mapping[str, float],
     *,
     family: str,
-    lane: str = "",
+    execution_lane: str = "",
     route: str = "",
     n_graphs: int = 0,
 ) -> None:
@@ -3956,8 +3956,8 @@ def emit_jit_compile_event(
 
         total_s = sum(float(v or 0.0) for v in timings.values())
         head = f"family={family or '(unset)'}"
-        if lane:
-            head += f" lane={lane}"
+        if execution_lane:
+            head += f" lane={execution_lane}"
         if route:
             head += f" route={route}"
         for key, seconds in timings.items():
@@ -4016,7 +4016,7 @@ def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2, say: Any = None) -
     # a column too.
     emit_jit_compile_event(
         timings, family=getattr(cfg, "family", "") or "",
-        lane=pipeline_weight_lane(pipe), route="compile_and_warm")
+        execution_lane=pipeline_weight_lane(pipe), route="compile_and_warm")
 
 
 def mint_artifact(
@@ -4241,17 +4241,17 @@ __all__ = [
     "ARTIFACT_FORMAT",
     "AdoptError",
     "CellSelectionBugError",
-    "CompiledLaneUnavailableError",
+    "CompiledExecutionLaneUnavailableError",
     "build",
     "apply",
-    "apply_lora_lane",
+    "apply_lora_execution_lane",
     "artifact_fx_lines",
     "artifact_metadata",
     "begin_fleet_mint",
     "capture_env",
-    "cell_base_lane",
-    "drop_lora_lane",
-    "cell_lane",
+    "cell_base_execution_lane",
+    "drop_lora_execution_lane",
+    "cell_execution_lane",
     "contract_drift",
     "counters_delta",
     "delivered_cell_seeded",
@@ -4279,9 +4279,9 @@ __all__ = [
     "tenant_serve_window",
     "inductor_counters",
     "is_cache_ref",
-    "lane_bucket",
-    "lane_token",
-    "lane_drift",
+    "execution_lane_bucket",
+    "execution_lane_token",
+    "execution_lane_drift",
     "live_fx_lines",
     "mint_artifact",
     "mode_drift",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -34,7 +34,7 @@ import msgspec
 from . import activity as activity_mod
 from . import boot_phases as boot_mod
 from . import cpu_budget
-from . import kernel_lane
+from . import kernel_path
 from . import mint_budget
 from . import progress as progress_mod
 from . import serving_mode as serving_mode_mod
@@ -94,7 +94,7 @@ from .models.memory import (
 from .models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from .models.download import ensure_local, lookup_provider_for_ref
 from .models.errors import MissingSnapshotError, UrlExpiredError
-from .models.lanes import LaneUnavailableError
+from .models.execution_lanes import ExecutionLaneUnavailableError
 from .models.residency import Residency
 from .topology import (
     ExecutionTopology,
@@ -575,7 +575,7 @@ def _snapshot_to_resolved(snap: pb.Snapshot) -> "WorkerResolvedRepo":
 
 #: Traced weight lanes a stored flavor MANDATES (fail-closed serving):
 #: `#fp8-w8a8` -> "w8a8" (gw#534), `#nvfp4-w4a4` -> "w4a4" (gw#540).
-_MANDATORY_LANES = ("w8a8", "w4a4")
+_MANDATORY_EXECUTION_LANES = ("w8a8", "w4a4")
 
 # pgw#671 eager-first boot: background-mint driver pacing. The abandon grace
 # bounds "finish the current unit" (one eager forward) before a hard cancel.
@@ -621,11 +621,11 @@ def _bg_yield_enabled() -> bool:
     return os.environ.get("GEN_WORKER_BG_YIELD", "1").strip() != "0"
 
 
-def _cell_lane_matches(
+def _cell_execution_lane_matches(
     ref: str,
     family: str,
     *,
-    want_lane: str,
+    want_execution_lane: str,
     want_bucket: int,
     candidate_keys: typing.AbstractSet[str] = frozenset(),
 ) -> bool:
@@ -643,15 +643,15 @@ def _cell_lane_matches(
     _fam, flavor = compile_cache.parse_cell_ref(ref)
     if cell_key.is_key(flavor):
         return flavor in candidate_keys
-    base, bucket = compile_cache.lane_bucket(compile_cache.cell_lane(ref))
+    base, bucket = compile_cache.execution_lane_bucket(compile_cache.cell_execution_lane(ref))
     if bucket != int(want_bucket or 0):
         return False
-    if want_lane:
-        return base == want_lane
-    return base not in _MANDATORY_LANES
+    if want_execution_lane:
+        return base == want_execution_lane
+    return base not in _MANDATORY_EXECUTION_LANES
 
 
-def _ref_mandatory_lane(ref: str) -> str:
+def _ref_mandatory_execution_lane(ref: str) -> str:
     """The traced weight lane one canonical Tensorhub model ref MANDATES:
     "w8a8" for `#fp8-w8a8` flavors, "w4a4" for `#nvfp4-w4a4`, "" otherwise."""
     from .models.refs import parse_model_ref
@@ -670,12 +670,12 @@ def _ref_mandatory_lane(ref: str) -> str:
     return ""
 
 
-def _mandatory_lane_of(refs: typing.Iterable[str]) -> str:
+def _mandatory_execution_lane_of(refs: typing.Iterable[str]) -> str:
     """The single mandatory lane a binding set selects ("" when none)."""
     for ref in refs:
-        lane = _ref_mandatory_lane(ref)
-        if lane:
-            return lane
+        execution_lane = _ref_mandatory_execution_lane(ref)
+        if execution_lane:
+            return execution_lane
     return ""
 
 
@@ -691,7 +691,7 @@ def _model_failure_vocab(exc: BaseException) -> str:
     return "load_failed"
 
 
-def _shared_lanes_need_fp8(
+def _shared_execution_lanes_need_fp8(
     slot_sizes: Dict[str, Dict[str, int]],
     shared_components: typing.Iterable[str],
     free_vram_bytes: int,
@@ -2488,7 +2488,7 @@ class ModelStore:
 # for two more lanes, in the constant whose own comment describes the
 # incident. It is now the loader's own list, so a new lane cannot be stamped
 # without appearing here.
-_SPECULATIVE_CELL_BASE_LANES: Tuple[str, ...] = loading.STAMPABLE_BASE_LANES
+_SPECULATIVE_CELL_BASE_EXECUTION_LANES: Tuple[str, ...] = loading.STAMPABLE_BASE_EXECUTION_LANES
 
 
 # ---------------------------------------------------------------------------
@@ -2658,9 +2658,9 @@ def _setup_error_will_retry(exc: BaseException) -> bool:
     """
     if not isinstance(exc, _TRANSIENT_SETUP_ERRORS):
         return False
-    from .compile_cache import CompiledLaneUnavailableError
+    from .compile_cache import CompiledExecutionLaneUnavailableError
 
-    return not isinstance(exc, CompiledLaneUnavailableError)
+    return not isinstance(exc, CompiledExecutionLaneUnavailableError)
 
 
 @dataclass
@@ -2720,10 +2720,10 @@ class _ClassRecord:
     # held_refs; the instance serves the OLD pick and must be vacated.
     stale: bool = False
     # gw#551: wire refs of lane-registered slots (gw#479). Lane residency is
-    # call-time-owned (LaneGate promotes + pins around each pipeline call);
+    # call-time-owned (ExecutionLaneGate promotes + pins around each pipeline call);
     # the executor must neither whole-job-pin nor eagerly promote them, or
     # the idle sibling can never be LRU-swapped out.
-    lane_refs: set = dc_field(default_factory=set)
+    execution_lane_refs: set = dc_field(default_factory=set)
     # pgw#572: exact compile-capable objects owned by this READY record. The
     # IDs are minted after successful setup and cleared before vacate; they do
     # not derive from mutable refs, authored specs, or object memory addresses.
@@ -2887,10 +2887,10 @@ class _InjectionResult:
     # residency/movement handle, so ``loaded``/``residency.obj`` is not the
     # object adapters, offload rungs or the LoRA registry may act on.
     slot_pipelines: Dict[str, Any] = dc_field(default_factory=dict)
-    lane_slots: set = dc_field(default_factory=set)
+    execution_lane_slots: set = dc_field(default_factory=set)
     shared_keys: List[Any] = dc_field(default_factory=list)
     shared_bytes: int = 0
-    # gw#551: slots whose pipeline __call__ the LaneGate wrapped. Only these
+    # gw#551: slots whose pipeline __call__ the ExecutionLaneGate wrapped. Only these
     # may become call-time-owned; an un-gateable pipeline (no instance
     # __call__) keeps the eager whole-job pin + promote path.
     gated_slots: set = dc_field(default_factory=set)
@@ -2959,7 +2959,7 @@ class _Job:
     finalizing: bool = False
     # th#913/gw#596: the CONCRETE lane serving this job (stamped post-setup,
     # reported on JobMetrics.lane). "" = not yet determined.
-    lane: str = ""
+    execution_lane: str = ""
     # pgw#789 (th#1293 dimensions): this request was served EAGER by a compiled
     # lane — a pgw#680 guard miss, a router heal/volatile verdict, or an
     # aot_serve ingress refusal. Set from the guard-miss callback, which fires
@@ -3477,7 +3477,7 @@ class Executor:
                 pick = resolutions.get(base_ref)
                 new_binding = base_binding
                 if pick is not None:
-                    resolved_ref, cast, _lane = pick
+                    resolved_ref, cast, _execution_lane = pick
                     try:
                         new_binding = rebind_pick(
                             base_binding,
@@ -3880,7 +3880,7 @@ class Executor:
         assert cfg is not None
         contract_digest = compile_cache.execution_contract_digest(
             target.pipeline, cfg)
-        lane = pipeline_weight_lane(target.pipeline)
+        execution_lane = pipeline_weight_lane(target.pipeline)
         bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
         requested_key = ""
         requested_axes: Tuple[Tuple[str, str], ...] = ()
@@ -3888,21 +3888,21 @@ class Executor:
             from . import cell_key
 
             # pgw#686: the KEY lane resolves through the one shared brain
-            # (compile_cache.cell_base_lane — probe, then denoiser markers),
+            # (compile_cache.cell_base_execution_lane — probe, then denoiser markers),
             # never the raw probe alone: the raw probe is blind to the w8a8
             # GEMM mode, so its key names a cell no mint ever publishes and
             # the fleet's armed cells are never adopted. The raw probe stays
             # authoritative for the wire lane descriptor below.
             key = cell_key.compute(
                 str(getattr(cfg, "family", "") or ""),
-                compile_cache.cell_base_lane(target.pipeline), bucket,
+                compile_cache.cell_base_execution_lane(target.pipeline), bucket,
                 contract=cfg.contract_digest(),
                 regional=bool(getattr(cfg, "regional", False)))
             requested_key, requested_axes = key.digest, key.axes
         except Exception:
             pass  # no computable identity on this runtime => no key
         with target.state_lock:
-            target.pipeline_weight_lane = lane
+            target.pipeline_weight_lane = execution_lane
             target.lora_bucket = bucket
             target.contract_digest = contract_digest
             target.requested_cell_key = requested_key
@@ -4293,7 +4293,7 @@ class Executor:
             else _CompileObjectCandidate(item, set(all_slots))
             for item in objects
         ]
-        requested_lane = self._mandatory_lane_of_bound(
+        requested_execution_lane = self._mandatory_execution_lane_of_bound(
             wire_ref(spec.models[slot]) for slot in self._setup_slots(spec)
         )
         active_artifacts = active_artifacts or {}
@@ -4392,14 +4392,14 @@ class Executor:
                 permitted_names = set(compatible_names)
             target.function_names = tuple(sorted(
                 compatible_names & permitted_names))
-            target_quant_lane = next(
-                (lane for lane in _MANDATORY_LANES
-                 if target.pipeline_weight_lane.startswith(lane)), "")
-            candidate_requested_lane = self._mandatory_lane_of_bound(
+            target_quant_execution_lane = next(
+                (execution_lane for execution_lane in _MANDATORY_EXECUTION_LANES
+                 if target.pipeline_weight_lane.startswith(execution_lane)), "")
+            candidate_requested_execution_lane = self._mandatory_execution_lane_of_bound(
                 ref for _slot, ref, _digest in bindings)
-            mandatory_quant = bool(target_quant_lane)
+            mandatory_quant = bool(target_quant_execution_lane)
             if (
-                (mandatory_quant or candidate_requested_lane)
+                (mandatory_quant or candidate_requested_execution_lane)
                 and not expected_names <= set(target.function_names)
             ):
                 # Every REQUIRED alias should be proven; a proven superset
@@ -4429,18 +4429,18 @@ class Executor:
                 self._note_eager_posture(
                     rec, "target_applicability_incomplete", detail)
                 continue
-            lane_error = compile_cache.compile_target_lane_error(
+            execution_lane_error = compile_cache.compile_target_execution_lane_error(
                 target.pipeline_weight_lane, target.lora_bucket)
-            if lane_error:
+            if execution_lane_error:
                 logger.warning(
-                    "compile target omitted for %s: %s", spec.name, lane_error)
+                    "compile target omitted for %s: %s", spec.name, execution_lane_error)
                 self._note_eager_posture(
-                    rec, "target_lane_unsupported", lane_error)
+                    rec, "target_lane_unsupported", execution_lane_error)
                 continue
-            if (candidate_requested_lane
-                    and target_quant_lane != candidate_requested_lane):
-                raise compile_cache.CompiledLaneUnavailableError(
-                    f"{candidate_requested_lane.upper()} binding for "
+            if (candidate_requested_execution_lane
+                    and target_quant_execution_lane != candidate_requested_execution_lane):
+                raise compile_cache.CompiledExecutionLaneUnavailableError(
+                    f"{candidate_requested_execution_lane.upper()} binding for "
                     f"{spec.name!r} materialized pipeline lane "
                     f"{target.pipeline_weight_lane!r}"
                 )
@@ -4468,11 +4468,11 @@ class Executor:
                     "%s compile target for %r has no proven active Forge "
                     "artifact; registering active-less — its aliases serve "
                     "explicit eager (pgw#672)",
-                    target_quant_lane.upper(), spec.name,
+                    target_quant_execution_lane.upper(), spec.name,
                 )
                 self._note_eager_posture(
                     rec, "mandatory_lane_active_less",
-                    f"{target_quant_lane.upper()} target registered with no "
+                    f"{target_quant_execution_lane.upper()} target registered with no "
                     f"proven active artifact")
             with target.state_lock:
                 target.active_compile_ref = active_ref
@@ -4508,17 +4508,17 @@ class Executor:
                         spec.name)
                 else:
                     self._report_no_growth_path(spec, target, pipeline)
-        if requested_lane and not rec.compile_targets:
+        if requested_execution_lane and not rec.compile_targets:
             # pgw#672: degrade, never die — the loaded pipeline serves its
             # functions eagerly; the missing compile target is loud on the
             # wire (serving_tier=eager) and in the activity stream.
             logger.error(
                 "%s setup for %r produced no addressable compile-capable "
                 "pipeline target; serving explicit eager (pgw#672)",
-                requested_lane.upper(), spec.name,
+                requested_execution_lane.upper(), spec.name,
             )
             activity_mod.current_note(
-                f"{requested_lane} lane serving eager: no addressable "
+                f"{requested_execution_lane} lane serving eager: no addressable "
                 "compile target survived the proof")
 
     def compile_targets(self) -> List[pb.CompileTarget]:
@@ -4580,16 +4580,16 @@ class Executor:
                 if cfg is None or not family:
                     continue
                 bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
-                want_lane = self._mandatory_lane_of_bound(
+                want_execution_lane = self._mandatory_execution_lane_of_bound(
                     wire_ref(binding) for binding in spec.models.values()
                 )
-                lanes = (
-                    (want_lane,) if want_lane
-                    else _SPECULATIVE_CELL_BASE_LANES)
-                for lane in lanes:
+                execution_lanes = (
+                    (want_execution_lane,) if want_execution_lane
+                    else _SPECULATIVE_CELL_BASE_EXECUTION_LANES)
+                for execution_lane in execution_lanes:
                     try:
                         digest = cell_key.compute(
-                            family, lane, bucket,
+                            family, execution_lane, bucket,
                             contract=cfg.contract_digest(),
                             regional=bool(getattr(cfg, "regional", False)),
                         ).digest
@@ -4613,7 +4613,7 @@ class Executor:
                 return rec, target
         return None
 
-    def _resolved_mandatory_lane(self, ref: str) -> str:
+    def _resolved_mandatory_execution_lane(self, ref: str) -> str:
         """th#1059 twin (hub: ``mandatoryTracedLane``): the flavor token names
         the STORAGE format, not the execution. Mandatory-ness follows the
         hub-resolved EXECUTION lane whenever one is known for this ref —
@@ -4623,35 +4623,35 @@ class Executor:
         token remains the fallback; conflicting evidence fails closed to the
         mandatory reading.
         """
-        from .models import lanes as lanespec
+        from .models import execution_lanes as lanespec
 
         ref = (ref or "").strip()
         known = False
         mandatory = ""
         for declared, pick in (self._model_resolutions or {}).items():
             resolved_ref = (pick[0] or declared).strip()
-            lane_str = (pick[2] or "").strip()
-            if not lane_str or ref not in (declared.strip(), resolved_ref):
+            execution_lane_str = (pick[2] or "").strip()
+            if not execution_lane_str or ref not in (declared.strip(), resolved_ref):
                 continue
             try:
-                lane = lanespec.parse_lane(lane_str)
+                execution_lane = lanespec.parse_execution_lane(execution_lane_str)
             except ValueError:
                 continue
             known = True
-            if lane.activation == lanespec.ACT_W8A8:
+            if execution_lane.activation == lanespec.ACT_W8A8:
                 mandatory = "w8a8"
-            elif lane.activation == lanespec.ACT_W4A4:
+            elif execution_lane.activation == lanespec.ACT_W4A4:
                 mandatory = "w4a4"
         if known:
             return mandatory
-        return _ref_mandatory_lane(ref)
+        return _ref_mandatory_execution_lane(ref)
 
-    def _mandatory_lane_of_bound(self, refs: typing.Iterable[str]) -> str:
+    def _mandatory_execution_lane_of_bound(self, refs: typing.Iterable[str]) -> str:
         """Resolution-aware :func:`_mandatory_lane_of` (th#1059)."""
         for ref in refs:
-            lane = self._resolved_mandatory_lane(ref)
-            if lane:
-                return lane
+            execution_lane = self._resolved_mandatory_execution_lane(ref)
+            if execution_lane:
+                return execution_lane
         return ""
 
     def _execution_lane_for_ref(self, ref: str) -> str:
@@ -4665,10 +4665,10 @@ class Executor:
         ref = (ref or "").strip()
         for declared, pick in (self._model_resolutions or {}).items():
             resolved_ref = (pick[0] or declared).strip()
-            lane_str = (pick[2] or "").strip()
-            if lane_str and ref in (declared.strip(), resolved_ref):
+            execution_lane_str = (pick[2] or "").strip()
+            if execution_lane_str and ref in (declared.strip(), resolved_ref):
                 pinned = bool(pick[3]) if len(pick) > 3 else False
-                return lane_str, pinned
+                return execution_lane_str, pinned
         return "", False
 
     def _validate_required_compile(
@@ -4682,13 +4682,13 @@ class Executor:
         than execute on a merely same-family pipeline.
         """
         setup_slots = self._setup_slots(spec)
-        want_lane = self._mandatory_lane_of_bound(
+        want_execution_lane = self._mandatory_execution_lane_of_bound(
             wire_ref(spec.models[slot]) for slot in setup_slots
         )
         if not run.HasField("required_compile"):
-            if want_lane:
+            if want_execution_lane:
                 raise RetryableError(
-                    f"required_compile_missing: {want_lane.upper()} dispatch "
+                    f"required_compile_missing: {want_execution_lane.upper()} dispatch "
                     "requires an exact active compile incarnation"
                 )
             return
@@ -4712,7 +4712,7 @@ class Executor:
             )
         _rec, target = found
         with target.state_lock:
-            target_lane = target.pipeline_weight_lane
+            target_execution_lane = target.pipeline_weight_lane
             target_functions = target.function_names
             target_active = (
                 target.active_compile_ref,
@@ -4720,11 +4720,11 @@ class Executor:
                 target.contract_digest,
             )
             target_bindings = target.model_bindings
-        if want_lane and not target_lane.startswith(want_lane):
+        if want_execution_lane and not target_execution_lane.startswith(want_execution_lane):
             raise RetryableError(
-                f"required_compile_lane_mismatch: {want_lane.upper()} "
+                f"required_compile_lane_mismatch: {want_execution_lane.upper()} "
                 "dispatch selected a live pipeline on lane "
-                f"{target_lane!r}"
+                f"{target_execution_lane!r}"
             )
         if spec.name not in target_functions:
             raise RetryableError(
@@ -5062,7 +5062,7 @@ class Executor:
             return spec
         return dc_replace(spec, models=effective)
 
-    def _lane_effective_spec(self, spec: EndpointSpec, lane_str: str) -> EndpointSpec:
+    def _execution_lane_effective_spec(self, spec: EndpointSpec, execution_lane_str: str) -> EndpointSpec:
         """th#913/gw#596: rebind the spec's declared tensorhub models to the
         instructed lane. A family instruction expands through the hub's
         per-card resolution picks (or the local cast lane for fp8-w8a16); a
@@ -5072,13 +5072,13 @@ class Executor:
         a new instance key, so warm workers keep both variants resident and
         cycle them via the gw#551 lane machinery."""
         from .api.binding import rebind_pick
-        from .models import lanes as lanespec
+        from .models import execution_lanes as lanespec
 
-        raw = str(lane_str or "").strip()
+        raw = str(execution_lane_str or "").strip()
         if not raw:
             return spec
         try:
-            req = lanespec.parse_lane_spec(raw)
+            req = lanespec.parse_execution_lane_spec(raw)
         except ValueError as exc:
             raise ValidationError(str(exc)) from None
         if req.is_zero:
@@ -5086,15 +5086,15 @@ class Executor:
         # th#1050: a lane the endpoint DECLARES (handles=) is served by the
         # author's own code branching on ctx.lane — satisfiable with no
         # laddered rebind (custom loaders/kernels have nothing to rebind).
-        declared_lane = (
-            req.lane is not None
-            and lanespec.lane_body_id(req.lane) in getattr(spec, "handles", ())
+        declared_execution_lane = (
+            req.execution_lane is not None
+            and lanespec.execution_lane_body_id(req.execution_lane) in getattr(spec, "handles", ())
         )
-        def pick_lane_of(pick: "Optional[Tuple[Any, ...]]") -> "Optional[Any]":
+        def pick_execution_lane_of(pick: "Optional[Tuple[Any, ...]]") -> "Optional[Any]":
             if pick is None or not pick[2]:
                 return None
             try:
-                return lanespec.parse_lane(pick[2])
+                return lanespec.parse_execution_lane(pick[2])
             except ValueError:
                 return None
 
@@ -5107,8 +5107,8 @@ class Executor:
         # bf16 is trivially serveable (the declared base IS bf16); quantized
         # lanes must find at least one laddered ref that can serve them —
         # unless the endpoint declares the lane (author code serves it).
-        satisfied = req.family == lanespec.FAMILY_BF16 or declared_lane
-        want_w8a8 = req.lane is not None and req.lane.activation == lanespec.ACT_W8A8
+        satisfied = req.family == lanespec.FAMILY_BF16 or declared_execution_lane
+        want_w8a8 = req.execution_lane is not None and req.execution_lane.activation == lanespec.ACT_W8A8
         for slot, base_binding in declared.items():
             if slot not in effective:
                 continue
@@ -5118,13 +5118,13 @@ class Executor:
             pick = self._model_resolutions.get(base_ref)
             if pick is None:
                 continue
-            plane = pick_lane_of(pick)
+            plane = pick_execution_lane_of(pick)
             new_binding = base_binding  # bf16 family: revert to the declared base
             if req.family == lanespec.FAMILY_BF16:
                 satisfied = True
             elif req.family == lanespec.FAMILY_FP8:
                 if plane is not None and lanespec.family_of(plane) == lanespec.FAMILY_FP8 and (
-                    req.lane is None or plane.activation == req.lane.activation
+                    req.execution_lane is None or plane.activation == req.execution_lane.activation
                 ):
                     resolved_ref, cast, _ = pick
                     new_binding = rebind_pick(
@@ -5141,7 +5141,7 @@ class Executor:
                     satisfied = True
             elif req.family == lanespec.FAMILY_4BIT:
                 if plane is None or lanespec.family_of(plane) != lanespec.FAMILY_4BIT or (
-                    req.lane is not None and plane.weights != req.lane.weights
+                    req.execution_lane is not None and plane.weights != req.execution_lane.weights
                 ):
                     continue
                 resolved_ref, cast, _ = pick
@@ -5158,7 +5158,7 @@ class Executor:
                 self.store.register_binding(wire_ref(new_binding), new_binding)
                 changed = True
         if not satisfied:
-            raise lanespec.LaneUnavailableError(
+            raise lanespec.ExecutionLaneUnavailableError(
                 raw, f"no laddered binding of {spec.name!r} can serve this lane "
                      "on this worker (flavor never resolved for its card)")
         if not changed:
@@ -5263,29 +5263,29 @@ class Executor:
             return serving_mode_mod.POSTURE_ARM_PENDING
         return serving_mode_mod.POSTURE_UNCOMPILED
 
-    def _handled_lane_body(self, spec: EndpointSpec, instructed: str) -> str:
+    def _handled_execution_lane_body(self, spec: EndpointSpec, instructed: str) -> str:
         """th#1050: the instructed lane's body when the endpoint DECLARES it
         (handles=) — the author's code, not binding surgery, serves it."""
-        from .models import lanes as lanespec
+        from .models import execution_lanes as lanespec
 
         if not instructed or not getattr(spec, "handles", ()):
             return ""
         try:
-            req = lanespec.parse_lane_spec(instructed)
+            req = lanespec.parse_execution_lane_spec(instructed)
         except ValueError:
             return ""
-        if req.lane is None:
+        if req.execution_lane is None:
             return ""
-        body = lanespec.lane_body_id(req.lane)
+        body = lanespec.execution_lane_body_id(req.execution_lane)
         return body if body in spec.handles else ""
 
-    def _served_lane(self, spec: EndpointSpec, instructed: str = "") -> str:
+    def _served_execution_lane(self, spec: EndpointSpec, instructed: str = "") -> str:
         """The CONCRETE lane this spec's instance executes as, for
         JobMetrics.lane and ctx.lane reporting: the most-quantized pipeline
         binding's lane (table rank), with live compile state as a preference.
         Fixed-mode bodies override it; a declared (handles=) instruction owns
         the full lane outright."""
-        from .models import lanes as lanespec
+        from .models import execution_lanes as lanespec
 
         compiled = False
         if spec.cls is not None:
@@ -5294,29 +5294,29 @@ class Executor:
                 compiled = any(
                     getattr(t, "active_compile_ref", "")
                     for t in rec.compile_targets.values())
-        handled = self._handled_lane_body(spec, instructed)
+        handled = self._handled_execution_lane_body(spec, instructed)
         if handled:
-            return lanespec.lane_id(lanespec.parse_lane(instructed))
+            return lanespec.execution_lane_id(lanespec.parse_execution_lane(instructed))
         # Report the most-quantized binding's lane: quantized lanes always
         # outrank bf16 (a bf16 VAE riding a w8a16 pipeline is still the
         # w8a16 lane), ties by table rank.
-        ranked = {body: i for i, body in enumerate(lanespec.known_lanes())}
+        ranked = {body: i for i, body in enumerate(lanespec.known_execution_lanes())}
         best = None
         best_key: Tuple[int, int] = (2, len(ranked) + 1)
         for binding in spec.models.values():
-            lane = lanespec.lane_of_binding(
+            execution_lane = lanespec.execution_lane_of_binding(
                 getattr(binding, "flavor", "") or "",
                 getattr(binding, "storage_dtype", "") or "",
                 compiled)
-            quant = 1 if lanespec.family_of(lane) == lanespec.FAMILY_BF16 else 0
-            key = (quant, ranked.get(lanespec.lane_id(lane), len(ranked)))
+            quant = 1 if lanespec.family_of(execution_lane) == lanespec.FAMILY_BF16 else 0
+            key = (quant, ranked.get(lanespec.execution_lane_id(execution_lane), len(ranked)))
             if best is None or key < best_key:
-                best, best_key = lane, key
+                best, best_key = execution_lane, key
         if best is None:
-            best = lanespec.Lane(
+            best = lanespec.ExecutionLane(
                 weights=lanespec.WEIGHTS_BF16, activation=lanespec.ACT_W16A16,
                 execution=lanespec.EXEC_COMPILED if compiled else lanespec.EXEC_EAGER)
-        return lanespec.lane_id(best)
+        return lanespec.execution_lane_id(best)
 
     async def ensure_desired_instance(
         self,
@@ -5426,7 +5426,7 @@ class Executor:
         block demotion, so an executing job must pin the TE/VAE entries its
         pipeline aliases)."""
         rec = self._classes.get(spec.instance_key) if spec.cls is not None else None
-        lane_refs = rec.lane_refs if rec is not None else set()
+        execution_lane_refs = rec.execution_lane_refs if rec is not None else set()
         shared_ids = (
             [k.cache_id() for k in rec.shared_keys] if rec is not None else []
         )
@@ -5434,7 +5434,7 @@ class Executor:
             [
                 r for s in slots
                 for r in _binding_wire_refs(spec.models[s])
-                if r not in lane_refs
+                if r not in execution_lane_refs
             ]
             + shared_ids
         ))
@@ -5575,7 +5575,7 @@ class Executor:
                         rec.stale = True
                         break
             if rec.ready and not rec.stale and spec.compile is not None:
-                mandatory_lane = self._mandatory_lane_of_bound(
+                mandatory_execution_lane = self._mandatory_execution_lane_of_bound(
                     wire_ref(spec.models[slot])
                     for slot in self._setup_slots(spec)
                 )
@@ -5584,8 +5584,8 @@ class Executor:
                 try:
                     desired_cell = await self._fetch_compile_snapshot(
                         spec, snapshots)
-                except compile_cache.CompiledLaneUnavailableError as exc:
-                    if mandatory_lane:
+                except compile_cache.CompiledExecutionLaneUnavailableError as exc:
+                    if mandatory_execution_lane:
                         # Desired state no longer supplies a mandatory exact
                         # cell. Remove the old READY incarnation before
                         # reporting the state-driven failure; it must not keep
@@ -5775,9 +5775,9 @@ class Executor:
                 # pipeline setup fails must surface a terminal per-function
                 # error to the hub, not sit in loading_functions forever
                 # while the worker reports READY.
-                from .compile_cache import CompiledLaneUnavailableError
+                from .compile_cache import CompiledExecutionLaneUnavailableError
 
-                if isinstance(exc, CompiledLaneUnavailableError):
+                if isinstance(exc, CompiledExecutionLaneUnavailableError):
                     self._mark_compile_setup_unavailable(rec, spec, str(exc))
                     self._on_state_change()
                 self._mark_setup_failed(rec, exc, exhausted=exhausted)
@@ -6155,7 +6155,7 @@ class Executor:
                 ctx: RequestContext[Any] = warmup.warm_context(
                     wj.spec, request_id=f"boot-warmup-{wj.spec.name}",
                     local_output_dir=tmp,
-                    lane=self._served_lane(wj.spec),
+                    execution_lane=self._served_execution_lane(wj.spec),
                     config=self._effective_config(wj.spec))
                 try:
                     await self._invoke_warmup(wj.spec, instance, ctx, payload, handler_kwargs)
@@ -6510,24 +6510,24 @@ class Executor:
         # lane — the ONE serveability brain compile_cache.mandatory_serving
         # reads. ContextVars ride to_thread, so the tenant setup thread and
         # its arms inherit the window.
-        from . import compile_cache as _cc_lane
+        from . import compile_cache as _cc_execution_lane
 
-        _setup_exec_lane, _setup_lane_pinned = "", False
+        _setup_exec_execution_lane, _setup_execution_lane_pinned = "", False
         for _slot in setup_slots:
-            _setup_exec_lane, _setup_lane_pinned = (
+            _setup_exec_execution_lane, _setup_execution_lane_pinned = (
                 self._execution_lane_pick_for_ref(
                     wire_ref(spec.models[_slot])))
-            if _setup_exec_lane:
+            if _setup_exec_execution_lane:
                 break
-        _lane_token = _cc_lane._SETUP_EXEC_LANE.set(_setup_exec_lane)
-        _pin_token = _cc_lane._SETUP_EXEC_LANE_PINNED.set(_setup_lane_pinned)
+        _execution_lane_token = _cc_execution_lane._SETUP_EXEC_EXECUTION_LANE.set(_setup_exec_execution_lane)
+        _pin_token = _cc_execution_lane._SETUP_EXEC_EXECUTION_LANE_PINNED.set(_setup_execution_lane_pinned)
         try:
             return await self._setup_locked_inner(
                 spec, rec, snapshots, intent_id=intent_id,
                 setup_slots=setup_slots)
         finally:
-            _cc_lane._SETUP_EXEC_LANE_PINNED.reset(_pin_token)
-            _cc_lane._SETUP_EXEC_LANE.reset(_lane_token)
+            _cc_execution_lane._SETUP_EXEC_EXECUTION_LANE_PINNED.reset(_pin_token)
+            _cc_execution_lane._SETUP_EXEC_EXECUTION_LANE.reset(_execution_lane_token)
 
     async def _setup_locked_inner(
         self, spec: EndpointSpec, rec: _ClassRecord,
@@ -6595,7 +6595,7 @@ class Executor:
         # and the lane is not a key axis, so a 96 GB card's winner can reach a
         # 32 GB card of the same SM. adopt() re-applies the fit constraint
         # against THIS device before pinning.
-        kernel_lane.adopt_from_artifact(
+        kernel_path.adopt_from_artifact(
             compile_artifact, source=f"{spec.name} boot")
         # Loads serialize: concurrent setups would cross-contaminate each
         # other's allocator deltas and place_pipeline's free-VRAM reads.
@@ -7150,9 +7150,9 @@ class Executor:
                 if unproven:
                     from .models.loading import pipeline_weight_lane
 
-                    quant_lane = any(
+                    quant_execution_lane = any(
                         pipeline_weight_lane(
-                            candidate.pipeline).startswith(_MANDATORY_LANES)
+                            candidate.pipeline).startswith(_MANDATORY_EXECUTION_LANES)
                         for candidate in unproven
                     )
                     for candidate in unproven:
@@ -7167,10 +7167,10 @@ class Executor:
                         if aot_serve.unwrap(pipe):
                             from .models import lora_lifted
 
-                            lora_lifted.remove_lifted_lora_lanes(pipe)
+                            lora_lifted.remove_lifted_lora_execution_lanes(pipe)
                         compile_cache.unwrap(pipe)
                         if spec.lora_bucket:
-                            compile_cache.drop_lora_lane(pipe)
+                            compile_cache.drop_lora_execution_lane(pipe)
                         # pgw#672: quarantine the disproven identity in this
                         # process so neither selection nor a fresh self-mint
                         # arm loops on it this boot.
@@ -7238,7 +7238,7 @@ class Executor:
                             # the wire; keep the leading counts + first
                             # divergence intact.
                             detail += f"; fx forensics: {forensics[:1500]}"
-                    if quant_lane:
+                    if quant_execution_lane:
                         # pgw#672 posture change: a failed serve/finalize
                         # proof on a mandatory (w8a8/w4a4) lane used to raise
                         # here -> cell_quarantined -> every declared function
@@ -7278,7 +7278,7 @@ class Executor:
                 for candidate in unexercised:
                     pipe = candidate.pipeline
                     mandatory = pipeline_weight_lane(pipe).startswith(
-                        _MANDATORY_LANES)
+                        _MANDATORY_EXECUTION_LANES)
                     if mandatory:
                         pending_mint = inj.pending_self_mints.pop(
                             id(pipe), None)
@@ -7337,10 +7337,10 @@ class Executor:
                     if aot_serve.unwrap(pipe):
                         from .models import lora_lifted
 
-                        lora_lifted.remove_lifted_lora_lanes(pipe)
+                        lora_lifted.remove_lifted_lora_execution_lanes(pipe)
                     compile_cache.unwrap(pipe)
                     if spec.lora_bucket:
-                        compile_cache.drop_lora_lane(pipe)
+                        compile_cache.drop_lora_execution_lane(pipe)
                     inj.active_compile_artifacts.pop(id(pipe), None)
                     self._abandon_pending_mint(inj, pipe)
                 if mint_by_id:
@@ -7492,16 +7492,16 @@ class Executor:
                     process_vram_bytes, rec.server.process.pid)
             self._register_residency(
                 spec, setup_slots, inj.loaded, vram_delta,
-                lane_slots=inj.lane_slots, shared_bytes=inj.shared_bytes,
+                execution_lane_slots=inj.execution_lane_slots, shared_bytes=inj.shared_bytes,
                 slot_refs=slot_refs, slot_identities=slot_identities)
             # gw#551: call-time-owned refs. Any record holding 2+ worker-
             # constructed pipelines can overcommit VRAM (content-keyed lanes
             # AND monolithic siblings alike) — those swap per use via the
-            # LaneGate instead of being job-pinned + eagerly promoted.
+            # ExecutionLaneGate instead of being job-pinned + eagerly promoted.
             pipe_slots = {s for s, (obj, _) in inj.loaded.items() if obj is not None}
-            swap_owned = pipe_slots if len(pipe_slots) >= 2 else set(inj.lane_slots)
+            swap_owned = pipe_slots if len(pipe_slots) >= 2 else set(inj.execution_lane_slots)
             swap_owned &= inj.gated_slots  # un-gateable pipes stay eager
-            rec.lane_refs = {slot_refs[s] for s in swap_owned if s in slot_refs}
+            rec.execution_lane_refs = {slot_refs[s] for s in swap_owned if s in slot_refs}
             rec.held_objects = {}
             for slot, ref in slot_refs.items():
                 obj = inj.loaded.get(slot, (None, 0))[0]
@@ -7598,7 +7598,7 @@ class Executor:
         # Rank 0 DECIDES; every rank obeys. Nothing below rank 0 ever measures
         # its own card and adapts (pgw#748 §5.4).
         plan = GroupPlan(
-            precision_lane=compile_cache.cell_base_lane(pipe),
+            precision_execution_lane=compile_cache.cell_base_execution_lane(pipe),
             gemm_mode=w8a8_gemm_mode(pipe),
             sp_degree=topo.degree,
         )
@@ -7650,7 +7650,7 @@ class Executor:
         loaded: Dict[str, Tuple[Any, int]],
         total_delta: int,
         *,
-        lane_slots: Optional[set] = None,
+        execution_lane_slots: Optional[set] = None,
         shared_bytes: int = 0,
         slot_refs: Optional[Dict[str, str]] = None,
         slot_identities: Optional[Dict[str, _ResidencyIdentity]] = None,
@@ -7664,13 +7664,13 @@ class Executor:
         the shared-entry bytes still reduce the residual, but re-tracking
         them here would clobber a mid-setup demotion."""
         res = self.store.residency
-        lanes = lane_slots or set()
+        execution_lanes = execution_lane_slots or set()
         refs = slot_refs or {}
         identities = slot_identities or {}
         per_ref: Dict[str, Tuple[Any, int]] = {}
         per_ref_identity: Dict[str, _ResidencyIdentity] = {}
         for slot in setup_slots:
-            if slot in lanes:
+            if slot in execution_lanes:
                 continue
             # gw#494: book under the SAME key the setup derived (never a
             # fresh wire_ref over possibly-rebound spec.models).
@@ -7687,9 +7687,9 @@ class Executor:
                 )
             if identity[0] or prior_identity is None:
                 per_ref_identity[ref] = identity
-        lane_bytes = sum(loaded[s][1] for s in lanes if s in loaded)
+        execution_lane_bytes = sum(loaded[s][1] for s in execution_lanes if s in loaded)
         residual = max(0, total_delta - sum(b for _, b in per_ref.values())
-                       - lane_bytes - max(0, int(shared_bytes)))
+                       - execution_lane_bytes - max(0, int(shared_bytes)))
         opaque = [r for r, (obj, _) in per_ref.items() if obj is None]
         share = residual // len(opaque) if opaque else 0
         for ref, (obj, measured) in per_ref.items():
@@ -7719,10 +7719,10 @@ class Executor:
         setup_slots = self._setup_slots(spec)
         if slots is not None:
             setup_slots = [s for s in setup_slots if s in slots]
-        lane_refs = rec.lane_refs if rec is not None else set()
+        execution_lane_refs = rec.execution_lane_refs if rec is not None else set()
         refs = [
             r for s in setup_slots
-            if (r := wire_ref(spec.models[s])) not in lane_refs
+            if (r := wire_ref(spec.models[s])) not in execution_lane_refs
         ]
         # pgw#636: shared-component entries (TE/VAE) the record's pipelines
         # alias are independently demotable now — swap any that went warm
@@ -8281,7 +8281,7 @@ class Executor:
         # checkpoints. Snapshot maps also contain attached cells and may carry
         # unrelated/prepositioned models, so they must not choose the lane.
         model_refs = [wire_ref(binding) for binding in spec.models.values()]
-        want_lane = self._mandatory_lane_of_bound(model_refs)
+        want_execution_lane = self._mandatory_execution_lane_of_bound(model_refs)
         want_bucket = int(ccell.lora_bucket or 0)
         # th#883 pull-by-key: a key-flavored cell is selected only when its
         # key is one this runtime computed for itself (the same candidates
@@ -8289,24 +8289,24 @@ class Executor:
         from . import cell_key
 
         candidate_keys: set[str] = set()
-        for lane in (
-                (want_lane,) if want_lane else _SPECULATIVE_CELL_BASE_LANES):
+        for execution_lane in (
+                (want_execution_lane,) if want_execution_lane else _SPECULATIVE_CELL_BASE_EXECUTION_LANES):
             try:
                 candidate_keys.add(cell_key.compute(
-                    family, lane, want_bucket,
+                    family, execution_lane, want_bucket,
                     contract=ccell.contract_digest(),
                     regional=bool(ccell.regional),
                 ).digest)
             except Exception:
                 continue
-        if want_lane:
+        if want_execution_lane:
             # TensorRT cells currently expose only their plain fp16 contract.
             # A Forge Inductor cell of the mandated lane is the sole artifact
             # proven to preserve the scaled_mm semantics (gw#534/gw#540).
             candidates = [
                 (ref, snap) for ref, snap in snapshots.items()
-                if _cell_lane_matches(
-                    ref, family, want_lane=want_lane, want_bucket=want_bucket,
+                if _cell_execution_lane_matches(
+                    ref, family, want_execution_lane=want_execution_lane, want_bucket=want_bucket,
                     candidate_keys=candidate_keys)
             ]
         else:
@@ -8316,8 +8316,8 @@ class Executor:
             ] if not want_bucket else []
             inductor_candidates = [
                 (ref, snap) for ref, snap in snapshots.items()
-                if _cell_lane_matches(
-                    ref, family, want_lane="", want_bucket=want_bucket,
+                if _cell_execution_lane_matches(
+                    ref, family, want_execution_lane="", want_bucket=want_bucket,
                     candidate_keys=candidate_keys)
             ]
             # Explicit kind policy, then uniqueness within that kind. A map's
@@ -8341,7 +8341,7 @@ class Executor:
                 if ref not in set(quarantined)
             ]
         candidates = sorted(candidates, key=lambda item: item[0])
-        if want_lane and not candidates:
+        if want_execution_lane and not candidates:
             # gw#587: the fail-closed cell WAIT is retired. A mandatory-lane
             # key with no delivered cell proceeds to load and SELF-MINTS in
             # _enable_compiled (the boot warmup is the mint); the quantized
@@ -8350,19 +8350,19 @@ class Executor:
             logger.info(
                 "no %s cell attached for family=%r lora_bucket=%d — "
                 "proceeding to self-mint (gw#587)",
-                want_lane.upper(), family, want_bucket)
+                want_execution_lane.upper(), family, want_bucket)
             return None
         if len(candidates) > 1:
             refs = ", ".join(ref for ref, _snap in candidates)
             detail = (
                 "multiple compatible compiled artifacts were attached for "
-                f"family={family!r} lane={want_lane or 'plain'}: "
+                f"family={family!r} lane={want_execution_lane or 'plain'}: "
                 f"{refs}; refusing map-order selection"
             )
-            if want_lane:
+            if want_execution_lane:
                 # Mandated lanes have no eager-compatible fallback: setup's
                 # lane gate must surface this as retryable before GPU load.
-                raise compile_cache.CompiledLaneUnavailableError(detail)
+                raise compile_cache.CompiledExecutionLaneUnavailableError(detail)
             logger.warning("%s; serving eager", detail)
             return None
         if candidates:
@@ -8370,17 +8370,17 @@ class Executor:
             digest = str(snap.digest or "").strip()
             if not digest:
                 detail = f"compiled-artifact snapshot {ref!r} has no immutable digest"
-                if want_lane:
-                    raise compile_cache.CompiledLaneUnavailableError(detail)
+                if want_execution_lane:
+                    raise compile_cache.CompiledExecutionLaneUnavailableError(detail)
                 logger.warning("%s; serving eager", detail)
                 return None
             try:
                 local = await self.store.ensure_local(ref, snap)
                 artifact = compile_cache.find_artifact(local)
                 if artifact is None:
-                    if want_lane:
-                        raise compile_cache.CompiledLaneUnavailableError(
-                            f"{want_lane.upper()} Forge snapshot {ref!r} "
+                    if want_execution_lane:
+                        raise compile_cache.CompiledExecutionLaneUnavailableError(
+                            f"{want_execution_lane.upper()} Forge snapshot {ref!r} "
                             "contains no artifact")
                     logger.warning(
                         "compiled-artifact snapshot %s contains no artifact; "
@@ -8389,13 +8389,13 @@ class Executor:
                 return _CompileArtifactSelection(
                     path=artifact, ref=ref, snapshot_digest=digest)
             except Exception as exc:
-                if want_lane and isinstance(
-                    exc, compile_cache.CompiledLaneUnavailableError
+                if want_execution_lane and isinstance(
+                    exc, compile_cache.CompiledExecutionLaneUnavailableError
                 ):
                     raise
-                if want_lane:
-                    raise compile_cache.CompiledLaneUnavailableError(
-                        f"{want_lane.upper()} Forge snapshot {ref!r} is "
+                if want_execution_lane:
+                    raise compile_cache.CompiledExecutionLaneUnavailableError(
+                        f"{want_execution_lane.upper()} Forge snapshot {ref!r} is "
                         f"unusable: {exc}") from exc
                 logger.warning(
                     "compiled-artifact snapshot %s unusable (%s); serving eager", ref, exc
@@ -8506,7 +8506,7 @@ class Executor:
                 return set()
             slot_sizes[slot] = self.store.component_sizes(wire_ref(binding))
         free = self.store.residency.free_vram_bytes()
-        if not _shared_lanes_need_fp8(slot_sizes, shared_components, free):
+        if not _shared_execution_lanes_need_fp8(slot_sizes, shared_components, free):
             return set()
         logger.info(
             "th#1043: shared-lane group %s for %s doesn't fit resident at "
@@ -8749,16 +8749,16 @@ class Executor:
                         # read the ONE serveability brain
                         # (compile_cache.mandatory_serving) instead of the
                         # weight-lane prefix. Never overwritten once set.
-                        exec_lane, lane_pinned = (
+                        exec_execution_lane, lane_pinned = (
                             self._execution_lane_pick_for_ref(ref))
-                        if exec_lane and not getattr(
+                        if exec_execution_lane and not getattr(
                                 pipe, compile_cache.EXECUTION_LANE_ATTR,
                                 None):
                             try:
                                 setattr(
                                     pipe,
                                     compile_cache.EXECUTION_LANE_ATTR,
-                                    exec_lane)
+                                    exec_execution_lane)
                                 setattr(
                                     pipe,
                                     compile_cache.EXECUTION_LANE_PINNED_ATTR,
@@ -8772,7 +8772,7 @@ class Executor:
                                 pipe, spec.compile_cell(), compile_artifact,
                                 compile_selection,
                             )
-                        except compile_cache.CompiledLaneUnavailableError as exc:
+                        except compile_cache.CompiledExecutionLaneUnavailableError as exc:
                             # Mandatory (w8a8/w4a4) lane: self-mint also hit a
                             # genuine impossibility (no CUDA/toolchain/target).
                             # When this refusal was chained from a caught
@@ -8828,7 +8828,7 @@ class Executor:
                                     result.pending_self_mints[id(pipe)] = pipe_mint
                     delta = max(0, self._vram_allocated() - before)
                     if slot_share:
-                        lane_obj, lane_bytes = self._register_lane(
+                        execution_lane_obj, execution_lane_bytes = self._register_execution_lane(
                             slot,
                             ref,
                             pipe,
@@ -8838,11 +8838,11 @@ class Executor:
                             result,
                             (slot_identities or {}).get(slot, ("", 0)),
                         )
-                        loaded[slot] = (lane_obj, lane_bytes)
-                        result.lane_slots.add(slot)
+                        loaded[slot] = (execution_lane_obj, execution_lane_bytes)
+                        result.execution_lane_slots.add(slot)
                     else:
                         loaded[slot] = (pipe, delta)
-                        if self._arm_lane_gate(pipe, ref, spec=spec):
+                        if self._arm_execution_lane_gate(pipe, ref, spec=spec):
                             result.gated_slots.add(slot)
                     kwargs[slot] = pipe
                 else:
@@ -8863,7 +8863,7 @@ class Executor:
             raise
         return result
 
-    def _register_lane(
+    def _register_execution_lane(
         self,
         slot: str,
         ref: str,
@@ -8903,27 +8903,27 @@ class Executor:
             name: m for name, m in comps.items()
             if isinstance(m, nn.Module) and name not in slot_share
         }
-        lane_obj: Any = nn.ModuleDict(exclusive) if exclusive else pipe
-        lane_bytes = max(0, delta - fresh_bytes)
+        execution_lane_obj: Any = nn.ModuleDict(exclusive) if exclusive else pipe
+        execution_lane_bytes = max(0, delta - fresh_bytes)
         result.shared_bytes += fresh_bytes
         logger.info(
             "lane %s (%s): exclusive %s (%.2f GiB), shared %s (%.2f GiB %s)",
-            slot, ref, sorted(exclusive) or ["<none>"], lane_bytes / _GiB,
+            slot, ref, sorted(exclusive) or ["<none>"], execution_lane_bytes / _GiB,
             sorted(slot_share), fresh_bytes / _GiB,
             "fresh" if fresh_bytes else "reused",
         )
         self.store.activate_load_identity(ref, load_identity)
-        if lane_bytes > 0:
-            res.track_vram(ref, lane_obj, vram_bytes=lane_bytes)
-        elif int(estimate_cuda_resident_gb(lane_obj) * _GiB) > 0:
-            res.track_vram(ref, lane_obj)
+        if execution_lane_bytes > 0:
+            res.track_vram(ref, execution_lane_obj, vram_bytes=execution_lane_bytes)
+        elif int(estimate_cuda_resident_gb(execution_lane_obj) * _GiB) > 0:
+            res.track_vram(ref, execution_lane_obj)
         else:
-            res.track_ram(ref, lane_obj)
-        if self._arm_lane_gate(pipe, ref):
+            res.track_ram(ref, execution_lane_obj)
+        if self._arm_execution_lane_gate(pipe, ref):
             result.gated_slots.add(slot)
-        return lane_obj, lane_bytes
+        return execution_lane_obj, execution_lane_bytes
 
-    def _arm_lane_gate(
+    def _arm_execution_lane_gate(
         self, pipe: Any, ref: str, spec: Optional[EndpointSpec] = None,
     ) -> bool:
         """gw#551: wrap a worker-constructed pipeline's ``__call__`` so a
@@ -8933,7 +8933,7 @@ class Executor:
         Monolithic pipelines (``spec`` given) additionally get the last-resort
         offload fallback; shared-component lanes never do (hooks on a shared
         module would poison sibling lanes)."""
-        from .models.lane_gate import LaneGate, arm_lane_gate
+        from .models.execution_lane_gate import ExecutionLaneGate, arm_execution_lane_gate
 
         fallback = None
         if spec is not None:
@@ -8941,7 +8941,7 @@ class Executor:
 
             def fallback() -> bool:
                 return self._serve_offload_fallback(bound_spec, pipe, ref)
-        return arm_lane_gate(pipe, LaneGate(
+        return arm_execution_lane_gate(pipe, ExecutionLaneGate(
             ref=ref, residency=self.store.residency, label=ref,
             retry_exc=RetryableError, offload_fallback=fallback,
         ))
@@ -9202,7 +9202,7 @@ class Executor:
             try:
                 compile_cache.unwrap(pipe)
                 if spec.lora_bucket:
-                    compile_cache.drop_lora_lane(pipe)
+                    compile_cache.drop_lora_execution_lane(pipe)
             except Exception:
                 logger.exception("declined mint target unwrap failed")
         flush_memory()
@@ -9314,7 +9314,7 @@ class Executor:
                     router.close()
                 compile_cache.unwrap(pipe)
                 if bg.spec.lora_bucket:
-                    compile_cache.drop_lora_lane(pipe)
+                    compile_cache.drop_lora_execution_lane(pipe)
             except Exception:
                 logger.exception("mint target unwrap failed")
         flush_memory()
@@ -9528,7 +9528,7 @@ class Executor:
                 ctx: RequestContext[Any] = warmup.warm_context(
                     wj.spec, request_id=f"bg-mint-{wj.spec.name}",
                     local_output_dir=tmp,
-                    lane=self._served_lane(wj.spec),
+                    execution_lane=self._served_execution_lane(wj.spec),
                     config=self._effective_config(wj.spec))
                 if preemptible:
                     bg.seed_ctx = ctx
@@ -9747,7 +9747,7 @@ class Executor:
                 fleet_cells_mod.abandon_self_mint(pending_mint)
             compile_cache.unwrap(pipe)
             if spec.lora_bucket:
-                compile_cache.drop_lora_lane(pipe)
+                compile_cache.drop_lora_execution_lane(pipe)
         sharers: Dict[int, List[int]] = {}
         mints: Dict[int, Any] = {}
         for pid, pending_mint in bg.pendings.items():
@@ -9880,8 +9880,8 @@ class Executor:
                         slot: dict(comps)
                         for slot, comps in bg.component_paths.items()
                     },
-                    weight_lane=compile_cache.cell_base_lane(pipe),
-                    lane=self._served_lane(spec),
+                    weight_lane=compile_cache.cell_base_execution_lane(pipe),
+                    execution_lane=self._served_execution_lane(spec),
                     configs={spec.name: self._effective_config(spec)},
                     device=mint_budget.device_of(pipe),
                 ),
@@ -10546,7 +10546,7 @@ class Executor:
                 assert cfg is not None
                 obj = target.pipeline
                 wrapped = False
-                lane_applied = False
+                execution_lane_applied = False
                 trt_before = trt_engine.execution_count(obj) if is_trt else 0
                 aot_before = aot_serve.execution_count(obj) if is_aot else 0
                 inductor_before = (0, 0, 0)
@@ -10560,8 +10560,8 @@ class Executor:
                     if wrapped:
                         if not is_trt and not is_aot:
                             compile_cache.unwrap(obj)
-                    if lane_applied:
-                        compile_cache.drop_lora_lane(obj)
+                    if execution_lane_applied:
+                        compile_cache.drop_lora_execution_lane(obj)
                     live = self._compile_target(target_incarnation_id)
                     if live is not None and live[0] is rec and live[1] is target:
                         self._refresh_compile_target(target)
@@ -10570,8 +10570,8 @@ class Executor:
                 bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
                 if bucket and not is_trt and not is_aot:
                     try:
-                        compile_cache.apply_lora_lane(obj, bucket)
-                        lane_applied = True
+                        compile_cache.apply_lora_execution_lane(obj, bucket)
+                        execution_lane_applied = True
                     except Exception as exc:
                         await rollback()
                         return await fail("lane_apply", str(exc))
@@ -10900,7 +10900,7 @@ class Executor:
         rec.held_refs = []
         rec.held_snapshot_digests = {}
         rec.held_bindings = []
-        rec.lane_refs = set()
+        rec.execution_lane_refs = set()
         rec.held_objects = {}
         rec.slot_pipelines = {}  # pgw#678: pipelines die with the instance
         # pgw#748: the rank siblings are an implementation detail of THIS
@@ -11488,8 +11488,8 @@ class Executor:
             # unserveable lane is a TYPED refusal naming it (INVALID) —
             # never a silent fallback.
             if run.lane:
-                spec = job.spec = self._lane_effective_spec(spec, run.lane)
-        except LaneUnavailableError as exc:
+                spec = job.spec = self._execution_lane_effective_spec(spec, run.lane)
+        except ExecutionLaneUnavailableError as exc:
             await self._finish(job, pb.JOB_STATUS_INVALID, safe_message=_sanitize(str(exc)))
             return
         except Exception as exc:
@@ -11523,7 +11523,7 @@ class Executor:
         # book the same free VRAM and OOM each other mid-load. Lane refs are
         # NOT leased (gw#551): lane dispatch is handler-side, so leasing every
         # declared lane would make the idle sibling un-demotable and the used
-        # lane un-promotable on an overcommitted card; the LaneGate pins
+        # lane un-promotable on an overcommitted card; the ExecutionLaneGate pins
         # exactly the lane it executes, at call time.
         try:
             with self.store.residency.admit(
@@ -11698,7 +11698,7 @@ class Executor:
             # th#913/gw#596: the concrete lane actually serving this job.
             # th#1050: ctx.lane exposes the same post-degrade truth to the
             # handler (declared-lane endpoints branch on it).
-            job.lane = self._served_lane(spec, instructed=run.lane)
+            job.execution_lane = self._served_execution_lane(spec, instructed=run.lane)
             # pgw#789: the shape coordinate, taken from the EXECUTED payload
             # with endpoint defaults applied. runtime_terms carries these only
             # when the endpoint declares a runtime formula (and the hub drops
@@ -11706,7 +11706,7 @@ class Executor:
             # shape axis at all for most endpoints.
             job.shape = serving_mode_mod.shape_of(
                 payload, self._effective_config(spec))
-            ctx._set_lane(job.lane)
+            ctx._set_execution_lane(job.execution_lane)
             # th#1087: effective declared-config values for this dispatch.
             effective_config = self._effective_config(spec, run)
             invocation_snapshot = None
@@ -11822,7 +11822,7 @@ class Executor:
             started = time.monotonic()
             # Pin-while-executing: the models (and adapter snapshots) this job
             # uses are not eviction candidates for its duration. Lane refs
-            # excluded (gw#551): the LaneGate pins the one lane the handler
+            # excluded (gw#551): the ExecutionLaneGate pins the one lane the handler
             # actually calls; pinning all of them here would deadlock the
             # gate's promote against its own job's pins.
             exec_refs = self._job_pin_refs(spec, routed)
@@ -11985,7 +11985,7 @@ class Executor:
             # total.tail and the map still closes against runtime_ms.
             ctx._stages.handler_close()
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
-                                    output=output, lane=job.lane,
+                                    output=output, execution_lane=job.execution_lane,
                                     runtime_terms=_runtime_term_values(spec, payload, ctx),
                                     peak_vram_bytes=peak_vram)
             # pgw#652: the request just told us what a concurrent one costs.
@@ -12036,13 +12036,13 @@ class Executor:
                                    metrics=metrics)
         except _DeadlineExceeded:
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
-                                    lane=job.lane)
+                                    execution_lane=job.execution_lane)
             await self._finish(job, pb.JOB_STATUS_FATAL, safe_message="deadline exceeded",
                                metrics=metrics)
         except BaseException as exc:
-            from .compile_cache import CompiledLaneUnavailableError
+            from .compile_cache import CompiledExecutionLaneUnavailableError
 
-            if isinstance(exc, CompiledLaneUnavailableError):
+            if isinstance(exc, CompiledExecutionLaneUnavailableError):
                 # pgw#672: a compiled lane failing at call time fails THIS
                 # request, never the function — the guard wrapper has already
                 # degraded the object to explicit eager and revoked the
@@ -12060,7 +12060,7 @@ class Executor:
             if status == pb.JOB_STATUS_FATAL:
                 logger.exception("handler %s failed", spec.name)
             metrics = self._metrics(queue_ms, started, concurrency_at_start, gpu_index,
-                                    lane=job.lane)
+                                    execution_lane=job.execution_lane)
             await self._finish(job, status, safe_message=msg, metrics=metrics)
         finally:
             if lease is not None:
@@ -12604,7 +12604,7 @@ class Executor:
 
     def _metrics(
         self, queue_ms: int, started: float, concurrency_at_start: int, gpu_index: int,
-        output: Any = None, lane: str = "",
+        output: Any = None, execution_lane: str = "",
         runtime_terms: "Optional[Dict[str, float]]" = None,
         peak_vram_bytes: "Optional[int]" = None,
     ) -> pb.JobMetrics:
@@ -12634,7 +12634,7 @@ class Executor:
             input_tokens=usage.prompt_tokens if usage is not None else 0,
             input_cached_tokens=usage.cached_tokens if usage is not None else 0,
             output_tokens=usage.completion_tokens if usage is not None else 0,
-            lane=lane,
+            lane=execution_lane,
             # th#1051: declared-formula term features from the EXECUTED
             # payload (defaults applied); empty = no declared formula.
             runtime_terms=runtime_terms or {},

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -491,13 +491,13 @@ def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
         if text:
             fallback[name] = text
     try:
-        base, observed = cc.lane_bucket(str(meta.get("weight_lane") or ""))
+        base, observed = cc.execution_lane_bucket(str(meta.get("weight_lane") or ""))
         bucket = observed or int(meta.get("lora_bucket") or 0)
-        token = cc.lane_token(base)
-        lane = f"{token}-lora{bucket}" if bucket and token else (
+        token = cc.execution_lane_token(base)
+        execution_lane = f"{token}-lora{bucket}" if bucket and token else (
             f"lora{bucket}" if bucket else token)
-        if lane:
-            fallback["lane"] = lane
+        if execution_lane:
+            fallback["lane"] = execution_lane
     except Exception:  # noqa: BLE001
         pass
     return fallback
@@ -863,7 +863,7 @@ def _arming_policy(
                     snapshot_digest=adopted.snapshot_digest,
                     artifact_kind=aot_serve.ARTIFACT_KIND,
                 )
-            except cc.CompiledLaneUnavailableError:
+            except cc.CompiledExecutionLaneUnavailableError:
                 # The AOT arm refused and the mandatory-lane no-artifact
                 # fallthrough raised — the ordinary policy below (with the
                 # delivered artifact) is still to run, so this is not
@@ -933,7 +933,7 @@ def _arming_policy(
             "fleet-cells: cell_selection_bug (%s); self-minting instead of "
             "retrying the same unusable cell", exc)
         selection_bug = exc
-    except cc.CompiledLaneUnavailableError:
+    except cc.CompiledExecutionLaneUnavailableError:
         # Mandatory (w8a8/w4a4) miss: production used to fail closed here.
         # The whole point of self-mint is that this worker can produce the
         # cell itself.
@@ -981,7 +981,7 @@ def _arming_policy(
     # the branch lane; the mint must key + trace the DECLARED graph family.
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     if bucket:
-        cc.apply_lora_lane(pipe, bucket)
+        cc.apply_lora_execution_lane(pipe, bucket)
 
     # ``cell_key`` is computable from STATIC axes (sku/torch/image/weight
     # lane/declared shapes+targets/module structure) — never the traced FX
@@ -998,7 +998,7 @@ def _arming_policy(
     except Exception as exc:  # noqa: BLE001 — key axes must be computable
         logger.warning("fleet-cells: self-mint key computation failed (%s)", exc)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(
             pipe, f"self-mint key computation failed: {exc}", selection_bug,
             phase=EagerPhase.KEY_COMPUTATION_FAILED)
@@ -1015,7 +1015,7 @@ def _arming_policy(
             "was quarantined by a failed proof in this process; serving "
             "eager (pgw#672)", family, key)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         # pgw#824: the ONE eager exit in this function that never rode a typed
         # event — it returns before `_fail_closed` and only logged. A pod that
         # quarantined its own cell serves eager for the rest of its life, which
@@ -1080,7 +1080,7 @@ def _arming_policy(
             "pending for key=%s (one inductor capture dir per process)",
             family, key, conflict)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(
             pipe, f"another self-mint capture is pending (key {conflict})",
             selection_bug, phase=EagerPhase.CAPTURE_CONFLICT)
@@ -1164,7 +1164,7 @@ def _arming_policy(
             "worker runs %d execution groups in one process and the inductor "
             "capture env is process-global (pgw#777)", family, key, topo.execution_groups)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(
             pipe,
             f"in-process mint refused at groups={topo.execution_groups}: the inductor "
@@ -1178,7 +1178,7 @@ def _arming_policy(
         if existing is None:
             shutil.rmtree(mint_root, ignore_errors=True)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(
             pipe, f"self-mint arm failed: {exc}", selection_bug,
             phase=EagerPhase.CAPTURE_ARM_FAILED)
@@ -1817,13 +1817,13 @@ def aot_export_spec(pipe: Any, cfg: Any) -> "Any":
     from . import aot_mint
     from .models import lora_lifted
 
-    lane = loading.pipeline_weight_lane(pipe)
+    execution_lane = loading.pipeline_weight_lane(pipe)
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     return aot_mint.ExportSpec(
         family=str(getattr(cfg, "family", "") or ""),
         target="",
-        weight_lane=lane,
-        precision=lane or "bf16",
+        weight_lane=execution_lane,
+        precision=execution_lane or "bf16",
         lora_bucket=bucket,
         shapes=tuple(
             tuple(int(v) for v in row) for row in (getattr(cfg, "shapes", ()) or ())),
@@ -1850,14 +1850,14 @@ def _fail_closed(
     ALSO followed a caught cell_selection_bug (th#1031) — chained onto the
     raised refusal so the caller's report is never dropped."""
 
-    lane = loading.pipeline_weight_lane(pipe)
+    execution_lane = loading.pipeline_weight_lane(pipe)
     # pgw#677 reopen: ONE serveability brain (cc.mandatory_serving) — the
     # hub-resolved execution lane outranks the weight-lane prefix, so an
     # eager-serveable mixed lane (sdxl #fp8-w8a8 storage on fp8-w8a16
     # execution) degrades to eager here instead of a typed refusal.
     if cc.mandatory_serving(pipe):
-        refusal = cc.CompiledLaneUnavailableError(
-            f"{lane[:4].upper()} requires a compile cell and the self-mint "
+        refusal = cc.CompiledExecutionLaneUnavailableError(
+            f"{execution_lane[:4].upper()} requires a compile cell and the self-mint "
             f"is unavailable ({reason})")
         if selection_bug is not None:
             raise refusal from selection_bug
@@ -1877,7 +1877,7 @@ def _fail_closed(
     logger.info("fleet-cells: serving eager (%s)", reason)
     activity_mod.emit_event(
         "self_mint_skipped",
-        f"lane={lane or 'plain'}: no cell and no mint — {reason}; this "
+        f"lane={execution_lane or 'plain'}: no cell and no mint — {reason}; this "
         f"worker serves eager and publishes nothing",
         phase=phase,
     )

--- a/src/gen_worker/intent_registry.py
+++ b/src/gen_worker/intent_registry.py
@@ -1136,7 +1136,7 @@ class IntentRegistry:
                 model_refs = sorted(
                     {model.ref for model in (instance.models if instance else ()) if model.ref}
                 )
-                lanes = sorted(
+                execution_lanes = sorted(
                     {
                         resolutions.get(ref, ("", "", ""))[2]
                         for ref in model_refs
@@ -1163,7 +1163,7 @@ class IntentRegistry:
                         release_id=self.release_id,
                         config_generation=target_generation,
                         binding_digest=_binding_digest(name, instance),
-                        lane=",".join(lanes),
+                        lane=",".join(execution_lanes),
                         models=[
                             pb.ModelIdentity(
                                 ref=ref,

--- a/src/gen_worker/kernel_path.py
+++ b/src/gen_worker/kernel_path.py
@@ -91,45 +91,45 @@ AXES = (AXIS_LINEAR, AXIS_MODULATION)
 
 LINEAR_BASELINE = "baseline"
 LINEAR_FUSED = "fused"
-LINEAR_LANES = (LINEAR_BASELINE, LINEAR_FUSED)
+LINEAR_EXECUTION_LANES = (LINEAR_BASELINE, LINEAR_FUSED)
 
 MOD_DENSE = "dense"
 MOD_PACKED = "packed"
-MOD_LANES = (MOD_DENSE, MOD_PACKED)
+MOD_EXECUTION_LANES = (MOD_DENSE, MOD_PACKED)
 
 # A lane NAME is the combination, so one string pins both axes, one verdict
 # ranks them together, and one grep finds a decision in a log.
 SEP = "+"
 
 
-def lane_of(linear: str, modulation: str) -> str:
+def execution_lane_of(linear: str, modulation: str) -> str:
     """The combination's canonical name."""
     return f"{linear}{SEP}{modulation}"
 
 
-def split_lane(lane: str) -> Tuple[str, str]:
+def split_execution_lane(execution_lane: str) -> Tuple[str, str]:
     """``(linear, modulation)`` for a combination name."""
-    linear, _, modulation = str(lane).partition(SEP)
+    linear, _, modulation = str(execution_lane).partition(SEP)
     return linear, modulation
 
 
-def linear_of(lane: str) -> str:
+def linear_of(execution_lane: str) -> str:
     """The linear-axis value a combination names."""
-    return split_lane(lane)[0]
+    return split_execution_lane(execution_lane)[0]
 
 
-def modulation_of(lane: str) -> str:
+def modulation_of(execution_lane: str) -> str:
     """The modulation-axis value a combination names."""
-    return split_lane(lane)[1]
+    return split_execution_lane(execution_lane)[1]
 
 
-LANES = tuple(
-    lane_of(linear, modulation)
-    for linear in LINEAR_LANES for modulation in MOD_LANES)
+EXECUTION_LANES = tuple(
+    execution_lane_of(linear, modulation)
+    for linear in LINEAR_EXECUTION_LANES for modulation in MOD_EXECUTION_LANES)
 
 # What a worker runs when no cell says otherwise: the pair that exists on
 # every card and is a pessimisation on none of them.
-DEFAULT_LANE = lane_of(LINEAR_BASELINE, MOD_DENSE)
+DEFAULT_EXECUTION_LANE = execution_lane_of(LINEAR_BASELINE, MOD_DENSE)
 
 # Envelope key (discrete facts, packed into metadata.json) and result key
 # (measurements, published with the checkpoint, NEVER packed).
@@ -181,7 +181,7 @@ FUSED_MIN_SM = 100
 # worker's degrade is greppable and never a silent fall-through.
 REASON_ABSENT = "kernel_lane_verdict_absent"
 REASON_UNREADABLE = "kernel_lane_verdict_unreadable"
-REASON_UNKNOWN_LANE = "kernel_lane_verdict_unknown_lane"
+REASON_UNKNOWN_EXECUTION_LANE = "kernel_lane_verdict_unknown_lane"
 REASON_NO_CELL = "kernel_lane_no_cell"
 REASON_ADOPTED = "kernel_lane_verdict_adopted"
 # The recorded winner does not fit THIS card (same SM class, smaller card):
@@ -202,7 +202,7 @@ BIND_SOLE_CANDIDATE = "sole_candidate"
 BIND_NO_FIT = "no_fit"
 
 
-class LaneProbeError(RuntimeError):
+class ExecutionLaneProbeError(RuntimeError):
     """A candidate could not be built or measured. Never fatal: the candidate
     drops out of the ranking with its reason recorded."""
 
@@ -238,7 +238,7 @@ def quantize_peak(peak_bytes: int) -> int:
 class Measurement(msgspec.Struct, frozen=True, kw_only=True):
     """One candidate lane, measured on the target card."""
 
-    lane: str
+    execution_lane: str
     ms_per_step: float = 0.0
     peak_bytes: int = 0
     samples_ms: Tuple[float, ...] = ()
@@ -273,9 +273,9 @@ class Verdict(msgspec.Struct, frozen=True, kw_only=True):
     measurements: Tuple[Measurement, ...] = ()
     detail: str = ""
 
-    def measurement(self, lane: str) -> Optional[Measurement]:
+    def measurement(self, execution_lane: str) -> Optional[Measurement]:
         for row in self.measurements:
-            if row.lane == lane:
+            if row.execution_lane == execution_lane:
                 return row
         return None
 
@@ -319,44 +319,44 @@ def select(
     }
     if not usable:
         gaps = "; ".join(
-            f"{r.lane}: {r.unavailable or 'no timing'}" for r in rows)
+            f"{r.execution_lane}: {r.unavailable or 'no timing'}" for r in rows)
         return Verdict(
-            winner=DEFAULT_LANE, binding=BIND_NO_FIT,
+            winner=DEFAULT_EXECUTION_LANE, binding=BIND_NO_FIT,
             detail=f"no candidate measured ({gaps or 'no candidates'})",
             **common)
 
     fitting = tuple(r for r in usable if fits(r, device_total_bytes))
     if not fitting:
-        smallest = min(usable, key=lambda r: (r.peak_bytes, r.lane))
+        smallest = min(usable, key=lambda r: (r.peak_bytes, r.execution_lane))
         return Verdict(
-            winner=smallest.lane, binding=BIND_NO_FIT,
+            winner=smallest.execution_lane, binding=BIND_NO_FIT,
             detail=(
                 f"no candidate fits {device_total_bytes} B with the stated "
-                f"allowance; smallest peak wins ({smallest.lane}, "
+                f"allowance; smallest peak wins ({smallest.execution_lane}, "
                 f"{smallest.peak_bytes} B peak, "
                 f"{smallest.required_bytes()} B required)"),
             **common)
 
-    excluded = tuple(r.lane for r in usable if r not in fitting)
+    excluded = tuple(r.execution_lane for r in usable if r not in fitting)
     if len(fitting) == 1:
         only = fitting[0]
         binding = BIND_FIT if excluded else BIND_SOLE_CANDIDATE
         detail = (
-            f"{only.lane} is the only lane that fits; excluded "
+            f"{only.execution_lane} is the only lane that fits; excluded "
             f"{sorted(excluded)!r}" if excluded
-            else f"{only.lane} is the only candidate")
-        return Verdict(winner=only.lane, binding=binding, detail=detail,
+            else f"{only.execution_lane} is the only candidate")
+        return Verdict(winner=only.execution_lane, binding=binding, detail=detail,
                        **common)
 
-    ranked = sorted(fitting, key=lambda r: (r.ms_per_step, r.lane))
+    ranked = sorted(fitting, key=lambda r: (r.ms_per_step, r.execution_lane))
     best, rival = ranked[0], ranked[1]
     gap = (rival.ms_per_step - best.ms_per_step) / max(best.ms_per_step, 1e-9)
     if gap >= MARGIN_FRACTION:
         return Verdict(
-            winner=best.lane, binding=BIND_SPEED,
+            winner=best.execution_lane, binding=BIND_SPEED,
             detail=(
-                f"{best.lane} {best.ms_per_step:.1f} ms/step beats "
-                f"{rival.lane} {rival.ms_per_step:.1f} by {gap * 100:.1f}% "
+                f"{best.execution_lane} {best.ms_per_step:.1f} ms/step beats "
+                f"{rival.execution_lane} {rival.ms_per_step:.1f} by {gap * 100:.1f}% "
                 f"(margin {MARGIN_FRACTION * 100:.0f}%)"
                 + (f"; excluded on fit {sorted(excluded)!r}" if excluded
                    else "")),
@@ -366,24 +366,24 @@ def select(
         r for r in fitting
         if (r.ms_per_step - best.ms_per_step)
         / max(best.ms_per_step, 1e-9) < MARGIN_FRACTION)
-    winner = min(tied, key=lambda r: (r.peak_bytes, r.lane))
+    winner = min(tied, key=lambda r: (r.peak_bytes, r.execution_lane))
     return Verdict(
-        winner=winner.lane, binding=BIND_VRAM_TIEBREAK,
+        winner=winner.execution_lane, binding=BIND_VRAM_TIEBREAK,
         detail=(
-            f"{[r.lane for r in tied]!r} within {MARGIN_FRACTION * 100:.0f}% "
+            f"{[r.execution_lane for r in tied]!r} within {MARGIN_FRACTION * 100:.0f}% "
             f"({best.ms_per_step:.1f}-{rival.ms_per_step:.1f} ms/step); "
-            f"smaller peak wins ({winner.lane}, {winner.peak_bytes} B)"),
+            f"smaller peak wins ({winner.execution_lane}, {winner.peak_bytes} B)"),
         **common)
 
 
-def sole(lane: str, detail: str) -> Verdict:
+def sole(execution_lane: str, detail: str) -> Verdict:
     """The verdict for a card that can only build ONE lane. No benchmark is
     run: with nothing to compare against, a measurement would buy a compile
     and decide nothing. The cell still records a real, typed verdict rather
     than the absence a serving worker has to guess about."""
     total, name, sm = device_facts()
     return Verdict(
-        winner=lane, binding=BIND_SOLE_CANDIDATE, detail=detail,
+        winner=execution_lane, binding=BIND_SOLE_CANDIDATE, detail=detail,
         device_total_bytes=total, device_name=name, sm=sm,
         measured_at=time.time())
 
@@ -407,7 +407,7 @@ def device_facts() -> Tuple[int, str, str]:
         return 0, "", ""
 
 
-def measure(lane: str, step: Callable[[], Any]) -> Measurement:
+def measure(execution_lane: str, step: Callable[[], Any]) -> Measurement:
     """Time one candidate's representative step and record its device peak.
 
     ``step`` must run ONE forward of the graph in its production posture
@@ -435,10 +435,10 @@ def measure(lane: str, step: Callable[[], Any]) -> Measurement:
     except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
         # measured drops out of the ranking; it never fails the mint.
         return Measurement(
-            lane=lane, unavailable=f"{type(exc).__name__}: {exc}")
+            execution_lane=execution_lane, unavailable=f"{type(exc).__name__}: {exc}")
     ordered = sorted(samples)
     return Measurement(
-        lane=lane, ms_per_step=ordered[len(ordered) // 2], peak_bytes=peak,
+        execution_lane=execution_lane, ms_per_step=ordered[len(ordered) // 2], peak_bytes=peak,
         samples_ms=tuple(samples))
 
 
@@ -460,21 +460,21 @@ def probe(
     if not device_total_bytes and not device_name and not sm:
         device_total_bytes, device_name, sm = device_facts()
     rows = []
-    for lane in candidates:
+    for execution_lane in candidates:
         t0 = time.monotonic()
         try:
-            step = build(lane)
+            step = build(execution_lane)
         except Exception as exc:  # noqa: BLE001
             logger.warning("kernel-lane probe: %s could not be built — %s",
-                           lane, exc)
+                           execution_lane, exc)
             rows.append(Measurement(
-                lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}"))
+                execution_lane=execution_lane, unavailable=f"build: {type(exc).__name__}: {exc}"))
             continue
-        row = measure(lane, step)
+        row = measure(execution_lane, step)
         rows.append(row)
         logger.info(
             "kernel-lane probe: %s -> %s (%.1f s to build+measure)",
-            lane,
+            execution_lane,
             (f"{row.ms_per_step:.1f} ms/step, {row.peak_bytes / 1e9:.1f} GB "
              f"peak" if row.usable else f"UNAVAILABLE {row.unavailable}"),
             time.monotonic() - t0)
@@ -576,7 +576,7 @@ def candidates_here() -> Tuple[str, ...]:
     """
     axes, _gaps = candidate_axes()
     return tuple(
-        lane_of(linear, modulation)
+        execution_lane_of(linear, modulation)
         for linear in axes[AXIS_LINEAR]
         for modulation in axes[AXIS_MODULATION])
 
@@ -602,7 +602,7 @@ def refit_order(
     """
     usable = [r for r in measurements if r.usable]
     ranked: List[str] = []
-    remaining = sorted(usable, key=lambda r: (r.ms_per_step, r.lane))
+    remaining = sorted(usable, key=lambda r: (r.ms_per_step, r.execution_lane))
     while remaining:
         head = remaining[0]
         tie = [
@@ -611,11 +611,11 @@ def refit_order(
             / max(head.ms_per_step, 1e-9) < MARGIN_FRACTION
         ]
         ranked.extend(
-            r.lane for r in sorted(
-                tie, key=lambda r: (quantize_peak(r.peak_bytes), r.lane)))
+            r.execution_lane for r in sorted(
+                tie, key=lambda r: (quantize_peak(r.peak_bytes), r.execution_lane)))
         remaining = [r for r in remaining if r not in tie]
     if winner in ranked:
-        ranked = [winner] + [lane for lane in ranked if lane != winner]
+        ranked = [winner] + [execution_lane for execution_lane in ranked if execution_lane != winner]
     return tuple(ranked)
 
 
@@ -629,8 +629,8 @@ def fit_block(verdict: Verdict) -> Dict[str, Any]:
     verdict), which is the honest signal that the fit cannot be re-applied.
     """
     peaks = {
-        r.lane: quantize_peak(r.peak_bytes)
-        for r in sorted(verdict.measurements, key=lambda r: r.lane)
+        r.execution_lane: quantize_peak(r.peak_bytes)
+        for r in sorted(verdict.measurements, key=lambda r: r.execution_lane)
         if r.usable
     }
     if not peaks:
@@ -663,7 +663,7 @@ def envelope_block(verdict: Verdict) -> Dict[str, Any]:
         "rule": str(verdict.rule),
         "binding": str(verdict.binding),
         "margin_fraction": float(verdict.margin_fraction),
-        "candidates": sorted(r.lane for r in verdict.measurements),
+        "candidates": sorted(r.execution_lane for r in verdict.measurements),
     }
     fit = fit_block(verdict)
     if fit:
@@ -692,7 +692,7 @@ def evidence_block(verdict: Verdict) -> Dict[str, Any]:
         "measured_at": float(verdict.measured_at),
         "candidates": [
             {
-                "lane": r.lane,
+                "lane": r.execution_lane,
                 "ms_per_step": float(r.ms_per_step),
                 "peak_bytes": int(r.peak_bytes),
                 "required_bytes": int(r.required_bytes()),
@@ -710,7 +710,7 @@ def verdict_from_evidence(block: Mapping[str, Any]) -> Verdict:
     round-trip, and how a recorded campaign is replayed against the rule."""
     rows = tuple(
         Measurement(
-            lane=str(c.get("lane") or ""),
+            execution_lane=str(c.get("lane") or ""),
             ms_per_step=float(c.get("ms_per_step") or 0.0),
             peak_bytes=int(c.get("peak_bytes") or 0),
             samples_ms=tuple(float(s) for s in (c.get("samples_ms") or ())),
@@ -719,7 +719,7 @@ def verdict_from_evidence(block: Mapping[str, Any]) -> Verdict:
         for c in (block.get("candidates") or ())
     )
     return Verdict(
-        winner=str(block.get("winner") or DEFAULT_LANE),
+        winner=str(block.get("winner") or DEFAULT_EXECUTION_LANE),
         binding=str(block.get("binding") or ""),
         rule=str(block.get("rule") or "fit_constrained_speed"),
         schema=int(block.get("schema") or SCHEMA),
@@ -741,7 +741,7 @@ def verdict_from_evidence(block: Mapping[str, Any]) -> Verdict:
     )
 
 
-def lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
+def execution_lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
     """``(lane, reason)`` a cell's envelope states.
 
     A cell minted before this mechanism records nothing — that is the
@@ -750,20 +750,20 @@ def lane_from_metadata(meta: Mapping[str, Any]) -> Tuple[str, str]:
     """
     block = meta.get(META_KEY) if isinstance(meta, Mapping) else None
     if block is None:
-        return DEFAULT_LANE, (
+        return DEFAULT_EXECUTION_LANE, (
             f"{REASON_ABSENT}: cell records no kernel-lane verdict "
             f"(pre-pgw#947 cell); serving the declared default "
-            f"{DEFAULT_LANE!r}")
+            f"{DEFAULT_EXECUTION_LANE!r}")
     if not isinstance(block, Mapping):
-        return DEFAULT_LANE, (
+        return DEFAULT_EXECUTION_LANE, (
             f"{REASON_UNREADABLE}: cell's {META_KEY!r} is "
-            f"{type(block).__name__}, not a block; serving {DEFAULT_LANE!r}")
+            f"{type(block).__name__}, not a block; serving {DEFAULT_EXECUTION_LANE!r}")
     winner = str(block.get("winner") or "")
-    if winner not in LANES:
-        return DEFAULT_LANE, (
-            f"{REASON_UNKNOWN_LANE}: cell names lane {winner!r}, which this "
-            f"worker does not implement ({list(LANES)!r}); serving "
-            f"{DEFAULT_LANE!r}")
+    if winner not in EXECUTION_LANES:
+        return DEFAULT_EXECUTION_LANE, (
+            f"{REASON_UNKNOWN_EXECUTION_LANE}: cell names lane {winner!r}, which this "
+            f"worker does not implement ({list(EXECUTION_LANES)!r}); serving "
+            f"{DEFAULT_EXECUTION_LANE!r}")
     return winner, (
         f"{REASON_ADOPTED}: cell verdict {winner!r} "
         f"(binding={block.get('binding') or '?'}, "
@@ -795,30 +795,30 @@ def recorded_fit(
     if isinstance(evidence, Mapping):
         rows = tuple(
             r for r in verdict_from_evidence(evidence).measurements
-            if r.usable and r.lane in LANES)
+            if r.usable and r.execution_lane in EXECUTION_LANES)
         if rows:
             return (
-                {r.lane: r.peak_bytes for r in rows},
+                {r.execution_lane: r.peak_bytes for r in rows},
                 refit_order(rows, winner=str(evidence.get("winner") or "")),
                 rows, EVIDENCE_KEY)
     block = meta.get(META_KEY)
     fit = block.get("fit") if isinstance(block, Mapping) else None
     if isinstance(fit, Mapping):
         peaks = {
-            str(lane): int(peak)
-            for lane, peak in (fit.get("peaks") or {}).items()
-            if str(lane) in LANES and int(peak or 0) > 0
+            str(execution_lane): int(peak)
+            for execution_lane, peak in (fit.get("peaks") or {}).items()
+            if str(execution_lane) in EXECUTION_LANES and int(peak or 0) > 0
         }
         if peaks:
             order = tuple(
-                str(lane) for lane in (fit.get("order") or ())
-                if str(lane) in peaks)
+                str(execution_lane) for execution_lane in (fit.get("order") or ())
+                if str(execution_lane) in peaks)
             return peaks, order or tuple(sorted(peaks)), (), META_KEY
     return {}, (), (), ""
 
 
 def refit(
-    lane: str, reason: str, meta: Mapping[str, Any],
+    execution_lane: str, reason: str, meta: Mapping[str, Any],
 ) -> Tuple[str, str]:
     """Re-apply the fit constraint against THIS card and return the lane to
     pin with the reason it is pinned.
@@ -845,19 +845,19 @@ def refit(
     peaks, order, rows, provenance = recorded_fit(meta)
     device = f"{name or 'this device'} ({sm or 'sm unknown'})"
     if not total:
-        return lane, (
+        return execution_lane, (
             f"{reason}; {REASON_FIT_UNVERIFIED}: this process cannot detect a "
             f"device total, so the cell's fit constraint could not be "
             f"re-applied here")
-    if lane not in peaks:
-        return lane, (
+    if execution_lane not in peaks:
+        return execution_lane, (
             f"{reason}; {REASON_FIT_UNVERIFIED}: the cell records no measured "
-            f"peak for {lane!r}, so its fit could not be re-applied on "
+            f"peak for {execution_lane!r}, so its fit could not be re-applied on "
             f"{device}, {total} B — adopting it unverified across cards "
             f"(cells are keyed on SM, not on card memory)")
-    if fits_bytes(peaks[lane], total):
-        return lane, (
-            f"{reason}; re-checked here: {required_for(peaks[lane])} B "
+    if fits_bytes(peaks[execution_lane], total):
+        return execution_lane, (
+            f"{reason}; re-checked here: {required_for(peaks[execution_lane])} B "
             f"required of {total} B on {device} [{provenance}]")
     if rows:
         # The full record is present: re-run THE rule, not a reduction of it.
@@ -879,8 +879,8 @@ def refit(
                 f"wins ({winner!r}, {required_for(peaks[winner])} B required)")
     tag = REASON_REFIT_LOCAL if binding != BIND_NO_FIT else REASON_REFIT_NO_FIT
     return winner, (
-        f"{tag}: the cell's verdict {lane!r} asks "
-        f"{required_for(peaks[lane])} B and {device} has {total} B, so it "
+        f"{tag}: the cell's verdict {execution_lane!r} asks "
+        f"{required_for(peaks[execution_lane])} B and {device} has {total} B, so it "
         f"does not fit here; re-applied the rule locally -> {winner!r} "
         f"(binding={binding}) — {detail} [{provenance}]")
 
@@ -891,7 +891,7 @@ _PIN: Optional[str] = None
 _PIN_REASON: str = ""
 
 
-def pin(lane: str, reason: str) -> None:
+def pin(execution_lane: str, reason: str) -> None:
     """Pin the lane THIS process loads on, with the reason it is pinned.
 
     Set by the mint (once per candidate while probing, then to the winner)
@@ -900,10 +900,10 @@ def pin(lane: str, reason: str) -> None:
     """
     global _PIN, _PIN_REASON
 
-    if lane not in LANES:
-        raise LaneProbeError(f"unknown kernel lane {lane!r} (have {LANES!r})")
-    _PIN, _PIN_REASON = lane, str(reason or "")
-    logger.info("kernel-lane: pinned %s — %s", lane, _PIN_REASON)
+    if execution_lane not in EXECUTION_LANES:
+        raise ExecutionLaneProbeError(f"unknown kernel lane {execution_lane!r} (have {EXECUTION_LANES!r})")
+    _PIN, _PIN_REASON = execution_lane, str(reason or "")
+    logger.info("kernel-lane: pinned %s — %s", execution_lane, _PIN_REASON)
 
 
 def pinned() -> Tuple[Optional[str], str]:
@@ -932,17 +932,17 @@ def adopt(meta: Optional[Mapping[str, Any]], *, source: str = "") -> str:
     constraint here before the lane is pinned.
     """
     if meta is None:
-        lane, reason = DEFAULT_LANE, (
+        execution_lane, reason = DEFAULT_EXECUTION_LANE, (
             f"{REASON_NO_CELL}: no compiled cell delivered for this load; "
-            f"serving the declared default {DEFAULT_LANE!r}")
+            f"serving the declared default {DEFAULT_EXECUTION_LANE!r}")
     else:
-        lane, reason = lane_from_metadata(meta)
+        execution_lane, reason = execution_lane_from_metadata(meta)
         if reason.startswith(REASON_ADOPTED):
-            lane, reason = refit(lane, reason, meta)
+            execution_lane, reason = refit(execution_lane, reason, meta)
     if source:
         reason = f"{reason} [{source}]"
-    pin(lane, reason)
-    return lane
+    pin(execution_lane, reason)
+    return execution_lane
 
 
 def adopt_from_artifact(artifact: Any, *, source: str = "") -> str:
@@ -967,14 +967,14 @@ def adopt_from_artifact(artifact: Any, *, source: str = "") -> str:
                         break
                     meta = json.loads(fh.read().decode())
                     return adopt(meta, source=source or str(artifact))
-        raise LaneProbeError("artifact has no metadata.json")
+        raise ExecutionLaneProbeError("artifact has no metadata.json")
     except Exception as exc:  # noqa: BLE001 — never fails a load
-        pin(DEFAULT_LANE, (
+        pin(DEFAULT_EXECUTION_LANE, (
             f"{REASON_UNREADABLE}: cannot read the verdict from "
             f"{artifact} ({type(exc).__name__}: {exc}); serving "
-            f"{DEFAULT_LANE!r}"
+            f"{DEFAULT_EXECUTION_LANE!r}"
             + (f" [{source}]" if source else "")))
-        return DEFAULT_LANE
+        return DEFAULT_EXECUTION_LANE
 
 
 __all__ = [
@@ -989,18 +989,18 @@ __all__ = [
     "BIND_SOLE_CANDIDATE",
     "BIND_SPEED",
     "BIND_VRAM_TIEBREAK",
-    "DEFAULT_LANE",
+    "DEFAULT_EXECUTION_LANE",
     "EVIDENCE_KEY",
     "FRAGMENTATION_HEADROOM_BYTES",
     "FUSED_MIN_SM",
-    "LANES",
+    "EXECUTION_LANES",
     "LINEAR_BASELINE",
     "LINEAR_FUSED",
-    "LINEAR_LANES",
+    "LINEAR_EXECUTION_LANES",
     "MARGIN_FRACTION",
     "META_KEY",
     "MOD_DENSE",
-    "MOD_LANES",
+    "MOD_EXECUTION_LANES",
     "MOD_PACKED",
     "PEAK_QUANTUM_BYTES",
     "REASON_ABSENT",
@@ -1009,11 +1009,11 @@ __all__ = [
     "REASON_NO_CELL",
     "REASON_REFIT_LOCAL",
     "REASON_REFIT_NO_FIT",
-    "REASON_UNKNOWN_LANE",
+    "REASON_UNKNOWN_EXECUTION_LANE",
     "REASON_UNREADABLE",
     "SCHEMA",
     "SEP",
-    "LaneProbeError",
+    "ExecutionLaneProbeError",
     "Measurement",
     "Verdict",
     "adopt",
@@ -1028,8 +1028,8 @@ __all__ = [
     "fits",
     "fits_bytes",
     "fused_candidate_gap",
-    "lane_from_metadata",
-    "lane_of",
+    "execution_lane_from_metadata",
+    "execution_lane_of",
     "linear_of",
     "measure",
     "modulation_of",
@@ -1044,6 +1044,6 @@ __all__ = [
     "required_for",
     "select",
     "sole",
-    "split_lane",
+    "split_execution_lane",
     "verdict_from_evidence",
 ]

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -113,10 +113,10 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
     try:
         # pgw#686: the ONE base-lane resolution the mint's stamp uses —
         # the raw pipeline probe is blind to the w8a8 GEMM mode, so a
-        # store save/lookup pair straddling apply_lora_lane would never
+        # store save/lookup pair straddling apply_lora_execution_lane would never
         # match and every boot would re-mint.
         want = cell_key.compute(
-            family, cc.cell_base_lane(pipe),
+            family, cc.cell_base_execution_lane(pipe),
             int(getattr(cfg, "lora_bucket", 0) or 0),
             contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
             regional=bool(getattr(cfg, "regional", False)),
@@ -127,7 +127,7 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
         reason = cell_key.mismatch(meta, want)
     if reason:
         return reason
-    reason = cc.mode_drift(meta, pipe) or cc.lane_drift(meta, pipe)
+    reason = cc.mode_drift(meta, pipe) or cc.execution_lane_drift(meta, pipe)
     if reason:
         return reason
     want_mode = "regional" if getattr(cfg, "regional", False) else "whole"
@@ -207,10 +207,10 @@ def _fail_closed(pipe: Any, reason: str) -> bool:
     TYPED (the same CompiledLaneUnavailableError the executor maps). Plain
     lanes keep the gw#555 never-raise miss policy (eager)."""
 
-    lane = pipeline_weight_lane(pipe)
-    if lane.startswith(("w8a8", "w4a4")):
-        raise cc.CompiledLaneUnavailableError(
-            f"{lane[:4].upper()} requires a compile cell and the local mint "
+    execution_lane = pipeline_weight_lane(pipe)
+    if execution_lane.startswith(("w8a8", "w4a4")):
+        raise cc.CompiledExecutionLaneUnavailableError(
+            f"{execution_lane[:4].upper()} requires a compile cell and the local mint "
             f"is unavailable ({reason})")
     return False
 
@@ -234,7 +234,7 @@ def enable_compiled(
     try:
         if provision.enable_compiled(pipe, cfg, cache_dir, artifact):
             return True
-    except cc.CompiledLaneUnavailableError:
+    except cc.CompiledExecutionLaneUnavailableError:
         # No delivered w8a8 cell => production would refuse here. The LOCAL
         # runtime's whole purpose is minting that cell (gw#555): fall
         # through to the store/mint path — the typed refusal re-asserts at
@@ -253,7 +253,7 @@ def enable_compiled(
     # family, so re-apply it for the rest of this arming attempt.
     bucket = int(getattr(cfg, "lora_bucket", 0) or 0)
     if bucket:
-        cc.apply_lora_lane(pipe, bucket)
+        cc.apply_lora_execution_lane(pipe, bucket)
 
     target = cell_path(family, pipeline_weight_lane(pipe))
     if target.exists():
@@ -272,7 +272,7 @@ def enable_compiled(
                 # store can always replace its cell).
                 _say(f"local-cells: cell_selection_bug: {exc}")
                 reason = f"cell_selection_bug: {exc}"
-            except cc.CompiledLaneUnavailableError:
+            except cc.CompiledExecutionLaneUnavailableError:
                 reason = "seed/arm failed (quantized-lane fail-closed)"
         _say(f"local-cells: stored cell no longer matches ({reason}); re-minting")
 
@@ -283,7 +283,7 @@ def enable_compiled(
             "Install one to let cozy compile once and cache the result."
         )
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(pipe, "no C compiler for the one-time local mint")
     _say(
         f"local-cells: no compile cell for this GPU/torch yet — compiling "
@@ -297,7 +297,7 @@ def enable_compiled(
         logger.warning("local-cells: mint failed (%s); serving eager", exc)
         cc.unwrap(pipe)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(pipe, f"local mint failed: {exc}")
     # Adopt the just-saved cell through the delivered-cell path (drops the
     # unguarded mint wrappers; re-traces hit the captured FX cache). This
@@ -309,16 +309,16 @@ def enable_compiled(
     except cc.CellSelectionBugError as exc:
         _say(f"local-cells: cell_selection_bug on freshly minted cell: {exc}")
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         return _fail_closed(pipe, f"cell_selection_bug: {exc}")
-    except cc.CompiledLaneUnavailableError as exc:
+    except cc.CompiledExecutionLaneUnavailableError as exc:
         logger.warning("local-cells: minted cell failed re-adoption (%s)", exc)
         if bucket:
-            cc.drop_lora_lane(pipe)
+            cc.drop_lora_execution_lane(pipe)
         raise
     logger.warning("local-cells: minted cell failed re-adoption; serving eager")
     if bucket:
-        cc.drop_lora_lane(pipe)
+        cc.drop_lora_execution_lane(pipe)
     return _fail_closed(pipe, "minted cell failed re-adoption")
 
 

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -307,7 +307,7 @@ def _warm_jobs(specs: Sequence[Any]) -> List[Any]:
     return jobs
 
 
-def _run_warm_job(instance: Any, job: Any, config: Dict[str, Any], lane: str) -> None:
+def _run_warm_job(instance: Any, job: Any, config: Dict[str, Any], execution_lane: str) -> None:
     """One warm forward through the endpoint's OWN handler.
 
     Mirrors the executor's ``_invoke_warmup`` (bound handler, ctx+payload
@@ -330,7 +330,7 @@ def _run_warm_job(instance: Any, job: Any, config: Dict[str, Any], lane: str) ->
         # nothing.
         ctx = warmup.warm_context(
             spec, request_id=f"mint-child-{spec.name}",
-            local_output_dir=tmp, lane=lane, config=config)
+            local_output_dir=tmp, execution_lane=execution_lane, config=config)
         bound = getattr(instance, spec.attr_name)
         kwargs = {spec.ctx_param: ctx, spec.payload_param: payload}
         if spec.is_async_gen:
@@ -389,29 +389,29 @@ def _release() -> None:
         logger.debug("mint-child: empty_cache failed", exc_info=True)
 
 
-def _measure_lane(lane: str, load: Any) -> Any:
+def _measure_execution_lane(execution_lane: str, load: Any) -> Any:
     """Load, build and time ONE candidate lane.
 
     Its own frame on purpose: the probe pipeline and its compiled step must
     be unreachable the moment this returns, or the next candidate loads onto
     a card the previous one is still resident on.
     """
-    from . import aot_mint, kernel_lane
+    from . import aot_mint, kernel_path
 
-    kernel_lane.pin(lane, "mint-time A/B probe (pgw#947)")
+    kernel_path.pin(execution_lane, "mint-time A/B probe (pgw#947)")
     try:
-        pipe, spec = load(lane)
-        return kernel_lane.measure(lane, aot_mint.bench_step(pipe, spec))
+        pipe, spec = load(execution_lane)
+        return kernel_path.measure(execution_lane, aot_mint.bench_step(pipe, spec))
     except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
         # built or measured drops out of the ranking; it never fails the
         # mint, and the reason is recorded with the verdict.
         logger.warning("mint-child: kernel-lane %s not buildable — %s",
-                       lane, exc)
-        return kernel_lane.Measurement(
-            lane=lane, unavailable=f"build: {type(exc).__name__}: {exc}")
+                       execution_lane, exc)
+        return kernel_path.Measurement(
+            execution_lane=execution_lane, unavailable=f"build: {type(exc).__name__}: {exc}")
 
 
-def lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
+def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
     """MEASURE which serving-kernel lane wins on THIS card (pgw#947).
 
     Returns ``(verdict, pipeline, spec)`` — the winning lane's loaded
@@ -441,40 +441,40 @@ def lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
     verdict, and says why — a cell with no verdict is the documented
     conservative-default case on the serving side.
     """
-    from . import kernel_lane
+    from . import kernel_path
 
-    candidates = kernel_lane.candidates_here()
+    candidates = kernel_path.candidates_here()
     if len(candidates) < 2:
-        _axes, gaps = kernel_lane.candidate_axes()
+        _axes, gaps = kernel_path.candidate_axes()
         detail = "; ".join(
             f"{axis}: {gap}" for axis, gap in sorted(gaps.items()))
-        verdict = kernel_lane.sole(
-            candidates[0] if candidates else kernel_lane.DEFAULT_LANE,
+        verdict = kernel_path.sole(
+            candidates[0] if candidates else kernel_path.DEFAULT_EXECUTION_LANE,
             f"only one lane combination is buildable on this card — "
             f"{detail or 'no rival'}")
-        kernel_lane.pin(verdict.winner, f"sole candidate: {verdict.detail}")
+        kernel_path.pin(verdict.winner, f"sole candidate: {verdict.detail}")
         frame(phase="load", note=f"kernel lane {verdict.winner} (sole)")
         pipe, spec = load(verdict.winner)
         return verdict, pipe, spec
 
     measurements = []
-    for index, lane in enumerate(candidates, start=1):
+    for index, execution_lane in enumerate(candidates, start=1):
         frame(phase="load", step=index, total=len(candidates),
-              note=f"kernel-lane probe: {lane}")
-        measurements.append(_measure_lane(lane, load))
+              note=f"kernel-lane probe: {execution_lane}")
+        measurements.append(_measure_execution_lane(execution_lane, load))
         # Each candidate is loaded onto an EMPTY card and torn down before the
         # next one: two resident pipelines would make the probe itself the
         # thing that OOMs a mint pod sized for one, and the peak this measures
         # has to be one lane's peak, not two lanes' sum. The probe pipeline
-        # dies with `_measure_lane`'s frame; this reclaims it.
+        # dies with `_measure_execution_lane`'s frame; this reclaims it.
         _release()
 
-    total, name, sm = kernel_lane.device_facts()
-    verdict = kernel_lane.select(
+    total, name, sm = kernel_path.device_facts()
+    verdict = kernel_path.select(
         measurements, device_total_bytes=total, device_name=name, sm=sm)
     frame(phase="load",
           note=f"kernel lane {verdict.winner} ({verdict.binding})")
-    kernel_lane.pin(verdict.winner, f"mint verdict: {verdict.detail}")
+    kernel_path.pin(verdict.winner, f"mint verdict: {verdict.detail}")
     # The winner is loaded FRESH rather than kept from its probe pass: the
     # probe ran `torch.compile` over the denoiser, and the graph that gets
     # exported must come from a pipeline nothing has warmed or specialized.
@@ -485,7 +485,7 @@ def lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
 def _mint_aot(
     request: MintRequest, pipe: Any, cfg: Any, target: Path, *,
     started: float, sha256_file: Any,
-    lane_verdict: Any = None,
+    execution_lane_verdict: Any = None,
     spec: Any = None,
 ) -> MintReport:
     """pgw#805: the AOT recipe — torch.export + AOTInductor over the family's
@@ -549,7 +549,7 @@ def _mint_aot(
             # pgw#947: the MEASURED serving-kernel lane for this card. The
             # discrete verdict lands in the packed envelope (serving reads it
             # instead of an SM tuple); the numbers ride the result metadata.
-            lane_verdict=lane_verdict)
+            execution_lane_verdict=execution_lane_verdict)
     except aot_mint.MintRefused as exc:
         # A named export refusal is a REFUSAL, not a crash: the parent must
         # not retry it, and the sentence is the whole diagnostic on a pod
@@ -636,7 +636,7 @@ def mint(request: MintRequest) -> MintReport:
         + (f" (+{sum(len(c) for c in overrides.values())} component "
            f"override(s))" if overrides else "")))
 
-    def _load(_lane: str) -> Tuple[Any, Any]:
+    def _load(_execution_lane: str) -> Tuple[Any, Any]:
         """One full endpoint load on the currently pinned kernel lane, plus
         the export spec of the pipeline it produced."""
         from . import fleet_cells
@@ -648,7 +648,7 @@ def mint(request: MintRequest) -> MintReport:
         _slot, loaded_pipe = _pick_compile_target(got, cfg)
         frame(phase="load", note=f"compile target on slot {_slot!r}")
         if cfg.lora_bucket:
-            cc.apply_lora_lane(loaded_pipe, cfg.lora_bucket)
+            cc.apply_lora_execution_lane(loaded_pipe, cfg.lora_bucket)
         return loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
 
     if request.recipe == RECIPE_AOT:
@@ -656,7 +656,7 @@ def mint(request: MintRequest) -> MintReport:
         # cell is exported, so the cell can carry the verdict instead of the
         # fleet re-deriving it from a hand-maintained SM tuple. The probe
         # loads once per candidate; the winner's pipeline is what gets minted.
-        verdict, pipe, aot_spec = lane_verdict_for(_load)
+        verdict, pipe, aot_spec = execution_lane_verdict_for(_load)
         # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
         # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
         # model ref for an operator's mint pod): the graphs this cell must
@@ -665,7 +665,7 @@ def mint(request: MintRequest) -> MintReport:
         # pod cannot adopt.
         return _mint_aot(
             request, pipe, cfg, target, started=started,
-            sha256_file=sha256_file, lane_verdict=verdict, spec=aot_spec)
+            sha256_file=sha256_file, execution_lane_verdict=verdict, spec=aot_spec)
 
     instance = spec.cls()
     loaded = run_setup(
@@ -675,7 +675,7 @@ def mint(request: MintRequest) -> MintReport:
     frame(phase="load", note=f"compile target on slot {slot!r}")
 
     if cfg.lora_bucket:
-        cc.apply_lora_lane(pipe, cfg.lora_bucket)
+        cc.apply_lora_execution_lane(pipe, cfg.lora_bucket)
 
     jobs = _warm_jobs(siblings)
     # Arm COLD, pointed at our own capture dir: the warm forwards below are
@@ -690,7 +690,7 @@ def mint(request: MintRequest) -> MintReport:
             note=job.spec.name)
         _run_warm_job(
             instance, job, dict(request.configs.get(job.spec.name) or {}),
-            request.lane)
+            request.execution_lane)
     frame(phase="inductor_compile", note="draining any queued compiles")
     _drain_router(pipe)
 

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -102,7 +102,7 @@ class MintTask:
     # only `snapshots` is handed a tree that cannot load.
     component_paths: Dict[str, Dict[str, str]] = field(default_factory=dict)
     weight_lane: str = ""
-    lane: str = ""
+    execution_lane: str = ""
     configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     device: Optional[int] = None
 
@@ -203,7 +203,7 @@ def build_request(
         },
         device=-1 if task.device is None else int(task.device),
         vram_cap_bytes=int(cap_bytes),
-        lane=task.lane,
+        execution_lane=task.execution_lane,
         configs={k: dict(v) for k, v in task.configs.items()},
         # pgw#805: the recipe rides the pending the arming brain built. The
         # child never decides it — the recipe determines the artifact KIND,
@@ -374,10 +374,10 @@ async def build_cell(
             family, task.weight_lane,
             _pool_stat(outcome.partial_phases, "peak_child_device_bytes"))
         if str(getattr(pending, "recipe", "")) == fleet_cells.RECIPE_AOT:
-            _emit_aot_phases(outcome, family=family, lane=task.weight_lane)
+            _emit_aot_phases(outcome, family=family, execution_lane=task.weight_lane)
         else:
             _emit_jit_compile(
-                outcome, family=family, lane=task.weight_lane,
+                outcome, family=family, execution_lane=task.weight_lane,
                 key=str(pending.cell_key), attempt=attempts)
 
         if outcome.status == mint_process.ABANDONED:
@@ -421,7 +421,7 @@ async def build_cell(
 
 
 def _emit_aot_phases(
-    outcome: MintOutcome, *, family: str, lane: str,
+    outcome: MintOutcome, *, family: str, execution_lane: str,
 ) -> None:
     """pgw#805: one delegated AOT mint's phase table, re-emitted PARENT-side.
 
@@ -474,14 +474,14 @@ def _emit_aot_phases(
         if table:
             table["terminus"] = terminus or table.get("terminus") or ""
             aot_mint.emit_phase_events(
-                family=family, lane=lane, table=table, terminus=terminus)
+                family=family, execution_lane=execution_lane, table=table, terminus=terminus)
         if outcome.minted or table:
             return
         if total_s <= 0:
             return
         activity_mod.emit_event(
             activity_mod.KIND_AOT_MINT,
-            f"family={family} lane={lane or 'plain'} status={outcome.status} "
+            f"family={family} lane={execution_lane or 'plain'} status={outcome.status} "
             f"total_s={round(total_s, 2)} — no cell produced",
             phase="aborted",
             duration_ms=int(round(total_s * 1000)),
@@ -492,7 +492,7 @@ def _emit_aot_phases(
 
 
 def _emit_jit_compile(
-    outcome: MintOutcome, *, family: str, lane: str, key: str, attempt: int,
+    outcome: MintOutcome, *, family: str, execution_lane: str, key: str, attempt: int,
 ) -> None:
     """th#1322: one delegated JIT mint's duration, as typed NUMERIC events.
 
@@ -512,7 +512,7 @@ def _emit_jit_compile(
     """
     report = outcome.report
     try:
-        head = f"family={family} lane={lane or 'plain'} key={key} attempt={attempt}"
+        head = f"family={family} lane={execution_lane or 'plain'} key={key} attempt={attempt}"
         phases: Dict[str, float] = dict(
             report.phases) if report is not None else {}
         for name, seconds in sorted(phases.items()):

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -217,7 +217,7 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     #: declared-parameter values per function (th#1087). Both STEER the warm
     #: forwards, so both must be the parent's values — a child warming at
     #: different config traces different graphs and the parent's proof misses.
-    lane: str = ""
+    execution_lane: str = ""
     configs: Dict[str, Dict[str, Any]] = {}
     #: pgw#805: ``"dynamo"`` (inductor FX capture, the original recipe) or
     #: ``"aot"`` (torch.export + AOTInductor). The parent decides; the child

--- a/src/gen_worker/models/execution_lane_gate.py
+++ b/src/gen_worker/models/execution_lane_gate.py
@@ -64,7 +64,7 @@ def _inference_mode_off() -> Any:
         return nullcontext()
 
 
-class LaneGate:
+class ExecutionLaneGate:
     """Ensures one lane ref is execution-ready around each pipeline call."""
 
     def __init__(
@@ -172,7 +172,7 @@ class LaneGate:
             )
 
 
-def arm_lane_gate(pipe: Any, gate: LaneGate) -> bool:
+def arm_execution_lane_gate(pipe: Any, gate: ExecutionLaneGate) -> bool:
     """Wrap ``pipe.__call__`` with the gate. Idempotent: an already-gated
     pipeline just gets the fresh gate. Object identity and isinstance are
     preserved (dynamic subclass with the same class name)."""
@@ -223,4 +223,4 @@ def arm_lane_gate(pipe: Any, gate: LaneGate) -> bool:
     return True
 
 
-__all__ = ["LaneGate", "arm_lane_gate"]
+__all__ = ["ExecutionLaneGate", "arm_execution_lane_gate"]

--- a/src/gen_worker/models/execution_lanes.py
+++ b/src/gen_worker/models/execution_lanes.py
@@ -37,26 +37,26 @@ EXEC_EAGER = "eager"
 EXEC_COMPILED = "compiled"
 
 
-class Lane(msgspec.Struct, frozen=True, kw_only=True):
+class ExecutionLane(msgspec.Struct, frozen=True, kw_only=True):
     weights: str
     activation: str
     scale: str = ""  # "" when the lane has no scale axis
     execution: str
 
 
-def lane_id(lane: Lane) -> str:
-    body = f"{lane.weights}-{lane.activation}"
-    if lane.scale:
-        body += f"-{lane.scale}"
-    return f"{body}+{lane.execution}"
+def execution_lane_id(execution_lane: ExecutionLane) -> str:
+    body = f"{execution_lane.weights}-{execution_lane.activation}"
+    if execution_lane.scale:
+        body += f"-{execution_lane.scale}"
+    return f"{body}+{execution_lane.execution}"
 
 
-def family_of(lane: Lane) -> str:
-    if lane.weights == WEIGHTS_BF16:
+def family_of(execution_lane: ExecutionLane) -> str:
+    if execution_lane.weights == WEIGHTS_BF16:
         return FAMILY_BF16
-    if lane.weights == WEIGHTS_FP8:
+    if execution_lane.weights == WEIGHTS_FP8:
         return FAMILY_FP8
-    if lane.weights in (WEIGHTS_SVDQ_FP4, WEIGHTS_SVDQ_INT4, WEIGHTS_NVFP4):
+    if execution_lane.weights in (WEIGHTS_SVDQ_FP4, WEIGHTS_SVDQ_INT4, WEIGHTS_NVFP4):
         return FAMILY_4BIT
     return ""
 
@@ -64,7 +64,7 @@ def family_of(lane: Lane) -> str:
 _EXECUTION_EITHER = "either"
 
 
-class _LaneBody(msgspec.Struct, frozen=True, kw_only=True):
+class _ExecutionLaneBody(msgspec.Struct, frozen=True, kw_only=True):
     weights: str
     activation: str
     execution_support: str
@@ -73,41 +73,41 @@ class _LaneBody(msgspec.Struct, frozen=True, kw_only=True):
 
 # THE lane table's rows, ranked best-first. Execution support is authoritative:
 # lane enumeration, validation, and binding resolution all read this one field.
-_KNOWN_BODIES: tuple[_LaneBody, ...] = (
+_KNOWN_BODIES: tuple[_ExecutionLaneBody, ...] = (
     # Eager w8a8 has not been measured; keep Tensorhub's compiled-only answer.
-    _LaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A8,
+    _ExecutionLaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A8,
               scale=SCALE_DYNAMIC, execution_support=EXEC_COMPILED),
     # Eager nvfp4 has not been measured; keep Tensorhub's compiled-only answer.
-    _LaneBody(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
+    _ExecutionLaneBody(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
               scale=SCALE_STATIC, execution_support=EXEC_COMPILED),
-    _LaneBody(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4,
+    _ExecutionLaneBody(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4,
               execution_support=EXEC_EAGER),
-    _LaneBody(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4,
+    _ExecutionLaneBody(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4,
               execution_support=EXEC_EAGER),
-    _LaneBody(weights=WEIGHTS_BF16, activation=ACT_W16A16,
+    _ExecutionLaneBody(weights=WEIGHTS_BF16, activation=ACT_W16A16,
               execution_support=_EXECUTION_EITHER),
-    _LaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A16,
+    _ExecutionLaneBody(weights=WEIGHTS_FP8, activation=ACT_W8A16,
               execution_support=_EXECUTION_EITHER),
 )
 
 
-def _supports(body: _LaneBody, execution: str) -> bool:
+def _supports(body: _ExecutionLaneBody, execution: str) -> bool:
     return body.execution_support == _EXECUTION_EITHER or body.execution_support == execution
 
 
-def _body_for_lane(lane: Lane) -> Optional[_LaneBody]:
+def _body_for_execution_lane(execution_lane: ExecutionLane) -> Optional[_ExecutionLaneBody]:
     for body in _KNOWN_BODIES:
         if (
-            body.weights == lane.weights
-            and body.activation == lane.activation
-            and body.scale == lane.scale
+            body.weights == execution_lane.weights
+            and body.activation == execution_lane.activation
+            and body.scale == execution_lane.scale
         ):
             return body
     return None
 
 
-def _lane_for_body(body: _LaneBody, execution: str) -> Lane:
-    return Lane(
+def _execution_lane_for_body(body: _ExecutionLaneBody, execution: str) -> ExecutionLane:
+    return ExecutionLane(
         weights=body.weights,
         activation=body.activation,
         scale=body.scale,
@@ -115,43 +115,43 @@ def _lane_for_body(body: _LaneBody, execution: str) -> Lane:
     )
 
 
-def known_lanes() -> list[str]:
+def known_execution_lanes() -> list[str]:
     """Every concrete lane id, ranked (table order, compiled before eager)."""
     out: list[str] = []
     for body in _KNOWN_BODIES:
         if _supports(body, EXEC_COMPILED):
-            out.append(lane_id(_lane_for_body(body, EXEC_COMPILED)))
+            out.append(execution_lane_id(_execution_lane_for_body(body, EXEC_COMPILED)))
         if _supports(body, EXEC_EAGER):
-            out.append(lane_id(_lane_for_body(body, EXEC_EAGER)))
+            out.append(execution_lane_id(_execution_lane_for_body(body, EXEC_EAGER)))
     return out
 
 
-def lane_body_id(lane: Lane) -> str:
+def execution_lane_body_id(execution_lane: ExecutionLane) -> str:
     """The lane id without the execution axis (verdict/declaration token)."""
-    body = f"{lane.weights}-{lane.activation}"
-    if lane.scale:
-        body += f"-{lane.scale}"
+    body = f"{execution_lane.weights}-{execution_lane.activation}"
+    if execution_lane.scale:
+        body += f"-{execution_lane.scale}"
     return body
 
 
-def known_lane_bodies() -> list[str]:
+def known_execution_lane_bodies() -> list[str]:
     """Every concrete lane BODY token, ranked (table order). These are the
     valid `handles=` declaration tokens (th#1050) — execution axis excluded:
     author kernels declare the quant scheme, the platform owns eager/compiled."""
     return [
-        lane_body_id(_lane_for_body(body, EXEC_EAGER))
+        execution_lane_body_id(_execution_lane_for_body(body, EXEC_EAGER))
         for body in _KNOWN_BODIES
     ]
 
 
-def valid_lane(lane: Lane) -> bool:
-    if lane.execution not in (EXEC_EAGER, EXEC_COMPILED):
+def valid_execution_lane(execution_lane: ExecutionLane) -> bool:
+    if execution_lane.execution not in (EXEC_EAGER, EXEC_COMPILED):
         return False
-    body = _body_for_lane(lane)
-    return body is not None and _supports(body, lane.execution)
+    body = _body_for_execution_lane(execution_lane)
+    return body is not None and _supports(body, execution_lane.execution)
 
 
-def parse_lane(s: str) -> Lane:
+def parse_execution_lane(s: str) -> ExecutionLane:
     """Parse a FULL descriptor id. Raises ValueError on anything else."""
     raw = str(s or "").strip().lower()
     parts = raw.split("+")
@@ -171,38 +171,38 @@ def parse_lane(s: str) -> Lane:
     rest = body[len(weights):].lstrip("-")
     segs = rest.split("-") if rest else []
     if len(segs) == 1:
-        lane = Lane(weights=weights, activation=segs[0], execution=execution)
+        execution_lane = ExecutionLane(weights=weights, activation=segs[0], execution=execution)
     elif len(segs) == 2:
-        lane = Lane(weights=weights, activation=segs[0], scale=segs[1], execution=execution)
+        execution_lane = ExecutionLane(weights=weights, activation=segs[0], scale=segs[1], execution=execution)
     else:
         raise ValueError(
             f"lane {s!r}: want `<weights>-<activation>[-<scale>]+<execution>`")
-    if not valid_lane(lane):
+    if not valid_execution_lane(execution_lane):
         raise ValueError(
-            f"lane {s!r} is not a known lane (known: {', '.join(known_lanes())})")
-    return lane
+            f"lane {s!r} is not a known lane (known: {', '.join(known_execution_lanes())})")
+    return execution_lane
 
 
-class LaneSpec(msgspec.Struct, frozen=True, kw_only=True):
+class ExecutionLaneSpec(msgspec.Struct, frozen=True, kw_only=True):
     """Dual-form parse result: a family (lane is None) or a full descriptor."""
 
     family: str = ""
-    lane: Optional[Lane] = None
+    execution_lane: Optional[ExecutionLane] = None
 
     @property
     def is_zero(self) -> bool:
-        return not self.family and self.lane is None
+        return not self.family and self.execution_lane is None
 
 
-def parse_lane_spec(s: str) -> LaneSpec:
+def parse_execution_lane_spec(s: str) -> ExecutionLaneSpec:
     """Dual-form: "" = auto, a family, or a full descriptor id."""
     raw = str(s or "").strip().lower()
     if not raw:
-        return LaneSpec()
+        return ExecutionLaneSpec()
     if raw in FAMILIES:
-        return LaneSpec(family=raw)
-    lane = parse_lane(raw)
-    return LaneSpec(family=family_of(lane), lane=lane)
+        return ExecutionLaneSpec(family=raw)
+    execution_lane = parse_execution_lane(raw)
+    return ExecutionLaneSpec(family=family_of(execution_lane), execution_lane=execution_lane)
 
 
 def is_w8a8_flavor(token: str) -> bool:
@@ -210,20 +210,20 @@ def is_w8a8_flavor(token: str) -> bool:
     return t == "fp8-w8a8" or t.startswith("fp8-w8a8-")
 
 
-def _with_supported_execution(lane: Lane, compiled: bool) -> Lane:
+def _with_supported_execution(execution_lane: ExecutionLane, compiled: bool) -> ExecutionLane:
     execution = EXEC_COMPILED if compiled else EXEC_EAGER
-    body = _body_for_lane(lane)
+    body = _body_for_execution_lane(execution_lane)
     if body is not None and not _supports(body, execution):
         execution = EXEC_COMPILED if _supports(body, EXEC_COMPILED) else EXEC_EAGER
-    return Lane(
-        weights=lane.weights,
-        activation=lane.activation,
-        scale=lane.scale,
+    return ExecutionLane(
+        weights=execution_lane.weights,
+        activation=execution_lane.activation,
+        scale=execution_lane.scale,
         execution=execution,
     )
 
 
-def lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> Lane:
+def execution_lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> ExecutionLane:
     """The concrete lane a (flavor, cast/storage_dtype) binding executes as —
     the twin of tensorhub's ``LaneOfResolution``."""
     # cycle: ladder imports lanes at module top
@@ -236,33 +236,33 @@ def lane_of_binding(flavor: str, storage_dtype: str, compiled: bool) -> Lane:
     )
 
     if str(storage_dtype or "").strip().lower() in ("fp8", "fp8+te"):
-        lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
+        execution_lane = ExecutionLane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
     elif (cls := classify_flavor_token(flavor)) == CLASS_FP8:
         if is_w8a8_flavor(flavor):
-            lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A8,
+            execution_lane = ExecutionLane(weights=WEIGHTS_FP8, activation=ACT_W8A8,
                         scale=SCALE_DYNAMIC, execution="")
         else:
-            lane = Lane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
+            execution_lane = ExecutionLane(weights=WEIGHTS_FP8, activation=ACT_W8A16, execution="")
     elif cls == CLASS_SVDQ_FP4:
-        lane = Lane(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4, execution="")
+        execution_lane = ExecutionLane(weights=WEIGHTS_SVDQ_FP4, activation=ACT_W4A4, execution="")
     elif cls == CLASS_SVDQ_INT4:
-        lane = Lane(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4, execution="")
+        execution_lane = ExecutionLane(weights=WEIGHTS_SVDQ_INT4, activation=ACT_W4A4, execution="")
     elif cls == CLASS_NVFP4_W4A4:
-        lane = Lane(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
+        execution_lane = ExecutionLane(weights=WEIGHTS_NVFP4, activation=ACT_W4A4,
                     scale=SCALE_STATIC, execution="")
     else:
-        lane = Lane(weights=WEIGHTS_BF16, activation=ACT_W16A16, execution="")
-    return _with_supported_execution(lane, compiled)
+        execution_lane = ExecutionLane(weights=WEIGHTS_BF16, activation=ACT_W16A16, execution="")
+    return _with_supported_execution(execution_lane, compiled)
 
 
-class LaneUnavailableError(ValueError):
+class ExecutionLaneUnavailableError(ValueError):
     """Typed refusal: the instructed lane cannot be served on this worker.
     Always names the lane — never a silent fallback."""
 
-    def __init__(self, lane: str, detail: str) -> None:
-        self.lane = lane
+    def __init__(self, execution_lane: str, detail: str) -> None:
+        self.execution_lane = execution_lane
         self.detail = detail
-        super().__init__(f"lane_unavailable: {lane} — {detail}")
+        super().__init__(f"lane_unavailable: {execution_lane} — {detail}")
 
 
 __all__ = [
@@ -276,9 +276,9 @@ __all__ = [
     "FAMILY_4BIT",
     "FAMILY_BF16",
     "FAMILY_FP8",
-    "Lane",
-    "LaneSpec",
-    "LaneUnavailableError",
+    "ExecutionLane",
+    "ExecutionLaneSpec",
+    "ExecutionLaneUnavailableError",
     "SCALE_DYNAMIC",
     "SCALE_STATIC",
     "WEIGHTS_BF16",
@@ -288,12 +288,12 @@ __all__ = [
     "WEIGHTS_SVDQ_INT4",
     "family_of",
     "is_w8a8_flavor",
-    "known_lane_bodies",
-    "known_lanes",
-    "lane_body_id",
-    "lane_id",
-    "lane_of_binding",
-    "parse_lane",
-    "parse_lane_spec",
-    "valid_lane",
+    "known_execution_lane_bodies",
+    "known_execution_lanes",
+    "execution_lane_body_id",
+    "execution_lane_id",
+    "execution_lane_of_binding",
+    "parse_execution_lane",
+    "parse_execution_lane_spec",
+    "valid_execution_lane",
 ]

--- a/src/gen_worker/models/gguf_local.py
+++ b/src/gen_worker/models/gguf_local.py
@@ -27,7 +27,7 @@ from .hub_client import WorkerResolvedRepo
 from .refs import TensorhubRef
 from .loading import FP8_STORAGE_FIT_FACTOR
 from .ladder import (placement_for_flavor, placement_from_metadata, w8a8_excluded_for_family)
-from .lanes import is_w8a8_flavor
+from .execution_lanes import is_w8a8_flavor
 import asyncio
 import time
 from .cozy_snapshot import ensure_snapshot_async

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
-from .lanes import is_w8a8_flavor
+from .execution_lanes import is_w8a8_flavor
 from .svdq import SVDQ_FP4_SMS, SVDQ_INT4_SMS
 
 CLASS_BASE = "base"  # bare bf16/fp16/fp32 row — runs anywhere a card fits it

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -824,7 +824,7 @@ _WEIGHT_LANE_ATTR = "_cozy_weight_lane"
 #:
 #: THE single source of this vocabulary. It is authored here, next to the
 #: attribute itself, because this is where the assignments live — and
-#: ``tests/test_speculative_lane_completeness_pgw918.py`` parses every
+#: ``tests/test_speculative_execution_lane_completeness_pgw918.py`` parses every
 #: assignment site under ``gen_worker/models`` and fails if a loader stamps a
 #: lane this tuple does not name. An authored list nothing checks is what
 #: ie#546 cost 9 pods, and what pgw#918 found still open for two more lanes.
@@ -832,9 +832,9 @@ _WEIGHT_LANE_ATTR = "_cozy_weight_lane"
 #: ``"bf16-resident"`` is deliberately absent: :func:`pipeline_weight_lane`
 #: folds it to ``""`` (it traces identically to plain bf16), so it is never a
 #: distinct cell-identity lane. Bucketed LoRA lanes
-#: (``w8a8_lora.lora_lane``) are these bases with a rank suffix and are
-#: decomposed by ``compile_cache.lane_bucket``, so the BASE set is complete.
-STAMPABLE_BASE_LANES: Tuple[str, ...] = (
+#: (``w8a8_lora.lora_execution_lane``) are these bases with a rank suffix and are
+#: decomposed by ``compile_cache.execution_lane_bucket``, so the BASE set is complete.
+STAMPABLE_BASE_EXECUTION_LANES: Tuple[str, ...] = (
     "",              # loading.py (plain/bf16-resident, folded)
     "fp8-hooks",     # loading.py fp8 storage cast
     "w8a8",          # models/w8a8.py
@@ -844,11 +844,11 @@ STAMPABLE_BASE_LANES: Tuple[str, ...] = (
 
 
 def pipeline_weight_lane(pipeline: Any) -> str:
-    lane = str(getattr(pipeline, _WEIGHT_LANE_ATTR, "") or "")
-    if lane == "bf16-resident":
+    execution_lane = str(getattr(pipeline, _WEIGHT_LANE_ATTR, "") or "")
+    if execution_lane == "bf16-resident":
         return ""  # traces identically to plain bf16
-    if lane:
-        return lane
+    if execution_lane:
+        return execution_lane
     for name in _fp8_storage_components():
         if getattr(getattr(pipeline, name, None), "_cozy_fp8_storage_applied", False):
             return "fp8-hooks"
@@ -971,7 +971,7 @@ def model_index_entry(path: str | Path, component: str) -> Optional[tuple]:
 #: Compute dtype of the quantized-artifact lanes when the binding declares
 #: none — MUST equal the ``compute_dtype or torch.bfloat16`` default in
 #: load_w8a8_pipeline / load_w4a4_pipeline / the svdq lane (test-guarded).
-QUANT_LANE_COMPUTE_DEFAULT = "bf16"
+QUANT_EXECUTION_LANE_COMPUTE_DEFAULT = "bf16"
 
 
 def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
@@ -998,7 +998,7 @@ def composition_compute_dtype(base_path: str | Path, dtype: str = "") -> str:
         or detect_w8a8_artifact(base) is not None
         or detect_w4a4_artifact(base) is not None
     ):
-        return QUANT_LANE_COMPUTE_DEFAULT
+        return QUANT_EXECUTION_LANE_COMPUTE_DEFAULT
     sniffed = detect_on_disk_dtype(base)
     if sniffed == "fp8":
         # Scale-free fp8 storage flavors compute at the bf16 default;
@@ -1177,7 +1177,7 @@ def _component_dtype_map(
     return out
 
 
-class ComponentLaneUnsupported(RuntimeError):
+class ComponentExecutionLaneUnsupported(RuntimeError):
     """This flavor has no component-level loader, so no honest one exists.
 
     svdq and gguf materialize their denoiser INSIDE the pipeline build (a
@@ -1302,14 +1302,14 @@ def load_component(
             root, w4a4_art, compute_dtype=torch_dtype, cls=cls)
     svdq_art = detect_svdq_artifact(root)
     if svdq_art is not None and _covers(svdq_art.component):
-        raise ComponentLaneUnsupported(
+        raise ComponentExecutionLaneUnsupported(
             f"component {component!r} of {root} is an svdq-{svdq_art.precision} "
             f"artifact ({svdq_art.file.name}): its denoiser is built by the "
             f"svdq engine during the PIPELINE load, so there is no "
             f"component-level production loader to borrow"
         )
     if component in denoiser_components() and detect_gguf_snapshot(root):
-        raise ComponentLaneUnsupported(
+        raise ComponentExecutionLaneUnsupported(
             f"component {component!r} of {root} is a GGUF denoiser: it is "
             f"dequantized by the pipeline's own gguf loader, so there is no "
             f"component-level production loader to borrow"
@@ -1828,7 +1828,7 @@ __all__ = [
     "assert_uniform_compute_dtype",
     "MixedComputeDtypeError",
     "composition_compute_dtype",
-    "QUANT_LANE_COMPUTE_DEFAULT",
+    "QUANT_EXECUTION_LANE_COMPUTE_DEFAULT",
     "apply_block_window_offload",
     "block_offload_active",
     "pipeline_weight_lane",

--- a/src/gen_worker/models/lora_lifted.py
+++ b/src/gen_worker/models/lora_lifted.py
@@ -464,7 +464,7 @@ def adapter_active(model: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def install_lifted_lora_lanes(pipe: Any, bucket: int = 0) -> Dict[str, LiftedLoraBinding]:
+def install_lifted_lora_execution_lanes(pipe: Any, bucket: int = 0) -> Dict[str, LiftedLoraBinding]:
     """Install the lifted signature on every branch-capable denoiser.
 
     Requires the canonical branch CONTAINERS to be allocated already — the
@@ -475,7 +475,7 @@ def install_lifted_lora_lanes(pipe: Any, bucket: int = 0) -> Dict[str, LiftedLor
             for comp, model in branch_targets(pipe).items()}
 
 
-def arm_lifted_lora_lanes(
+def arm_lifted_lora_execution_lanes(
     pipe: Any, bucket: int,
 ) -> Dict[str, LiftedLoraBinding]:
     """Put a pipeline on the LIFTED branch-bearing graph family: canonical
@@ -495,16 +495,16 @@ def arm_lifted_lora_lanes(
     """
     if not int(bucket or 0):
         return {}
-    w8a8_lora.enable_branch_lanes(pipe, int(bucket))
-    return install_lifted_lora_lanes(pipe, int(bucket))
+    w8a8_lora.enable_branch_execution_lanes(pipe, int(bucket))
+    return install_lifted_lora_execution_lanes(pipe, int(bucket))
 
 
-def remove_lifted_lora_lanes(pipe: Any) -> None:
+def remove_lifted_lora_execution_lanes(pipe: Any) -> None:
     for model in branch_targets(pipe).values():
         remove_lifted_lora_forward(model)
 
 
-def lifted_lane_kwargs(pipe: Any) -> Dict[str, Dict[str, Any]]:
+def lifted_execution_lane_kwargs(pipe: Any) -> Dict[str, Dict[str, Any]]:
     """component -> the two call kwargs for that component's compiled unit."""
     out: Dict[str, Dict[str, Any]] = {}
     for comp, model in branch_targets(pipe).items():
@@ -514,7 +514,7 @@ def lifted_lane_kwargs(pipe: Any) -> Dict[str, Dict[str, Any]]:
     return out
 
 
-def swap_lifted_lane_set(
+def swap_lifted_execution_lane_set(
     pipe: Any,
     routed: Mapping[str, Sequence[Tuple[Dict[str, Any], float, str]]],
     *,
@@ -668,7 +668,7 @@ def assert_no_baked_adapter(compiled: Any, *, label: str = "") -> None:
 __all__ = [
     "LIFTED_INPUT_NAMES",
     "adapter_active",
-    "arm_lifted_lora_lanes",
+    "arm_lifted_lora_execution_lanes",
     "LiftedLoraBinding",
     "LiftedLoraPlan",
     "ResolvedSlots",
@@ -677,15 +677,15 @@ __all__ = [
     "bind_views",
     "build_plan",
     "install_lifted_lora_forward",
-    "install_lifted_lora_lanes",
+    "install_lifted_lora_execution_lanes",
     "lifted_binding",
     "lifted_input_names",
-    "lifted_lane_kwargs",
+    "lifted_execution_lane_kwargs",
     "is_exported_program",
     "lora_constant_fqns",
     "package_constant_audit",
     "remove_lifted_lora_forward",
-    "remove_lifted_lora_lanes",
-    "swap_lifted_lane_set",
+    "remove_lifted_lora_execution_lanes",
+    "swap_lifted_execution_lane_set",
     "unbind_views",
 ]

--- a/src/gen_worker/models/native_kernels.py
+++ b/src/gen_worker/models/native_kernels.py
@@ -52,7 +52,7 @@ import logging
 import os
 from typing import Any, Callable, Dict, Optional
 
-from .. import kernel_lane
+from .. import kernel_path
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ _EXT_DEFAULT = "/opt/cozy/native/libcozy_kernels.so"
 _EXT_NAMESPACE = "cozy_kernels"
 
 # Two independent decisions, each cached with the reason that produced it.
-_LANES: Dict[str, str] = {}
+_EXECUTION_LANES: Dict[str, str] = {}
 _REASONS: Dict[str, str] = {}
 
 
@@ -113,7 +113,7 @@ def _packed_modulation_self_check() -> Optional[str]:
 
 
 def _record(axis: str, value: str, reason: str) -> str:
-    _LANES[axis], _REASONS[axis] = value, reason
+    _EXECUTION_LANES[axis], _REASONS[axis] = value, reason
     return value
 
 
@@ -126,8 +126,8 @@ def _decide(
 ) -> str:
     """One axis's arming decision: env, then the recorded verdict, then this
     axis's numerics. Cached per process with the reason that produced it."""
-    if axis in _LANES:
-        return _LANES[axis]
+    if axis in _EXECUTION_LANES:
+        return _EXECUTION_LANES[axis]
 
     requested = native_kernels_requested()
     if requested is False:
@@ -139,21 +139,21 @@ def _decide(
         logger.info("native kernels [%s]: %s (%s)", axis, off, reason)
         return _record(axis, off, reason)
 
-    lane, lane_reason = kernel_lane.pinned()
-    if lane is None:
+    execution_lane, execution_lane_reason = kernel_path.pinned()
+    if execution_lane is None:
         # Nothing pinned a lane for this load: no cell was delivered, or the
         # executor never reached the adoption hook. The DECLARED default, and
         # it names itself — there is no SM allowlist left to fall back on.
-        reason = (f"{kernel_lane.REASON_ABSENT}: nothing recorded a measured "
+        reason = (f"{kernel_path.REASON_ABSENT}: nothing recorded a measured "
                   f"kernel-lane verdict for this load; serving the declared "
-                  f"default {kernel_lane.DEFAULT_LANE!r}")
+                  f"default {kernel_path.DEFAULT_EXECUTION_LANE!r}")
         logger.warning("native kernels [%s]: %s", axis, reason)
-        return _record(axis, project(kernel_lane.DEFAULT_LANE), reason)
+        return _record(axis, project(kernel_path.DEFAULT_EXECUTION_LANE), reason)
 
-    want = project(lane)
+    want = project(execution_lane)
     if want != armed:
-        logger.info("native kernels [%s]: %s (%s)", axis, want, lane_reason)
-        return _record(axis, want, lane_reason)
+        logger.info("native kernels [%s]: %s (%s)", axis, want, execution_lane_reason)
+        return _record(axis, want, execution_lane_reason)
     try:
         gap = self_check()
     except Exception as exc:  # noqa: BLE001 — any self-check gap => degrade
@@ -164,45 +164,45 @@ def _decide(
         logger.warning("native kernels [%s]: NOT armed — %s; %s serves the "
                        "same artifact", axis, reason, off)
         return _record(axis, off, reason)
-    reason = f"{lane_reason}; {axis} numerics self-check passed"
+    reason = f"{execution_lane_reason}; {axis} numerics self-check passed"
     logger.info("native kernels [%s]: %s armed (%s)", axis, armed, reason)
     return _record(axis, armed, reason)
 
 
-def svdq_linear_lane() -> str:
+def svdq_linear_execution_lane() -> str:
     """``"fused"`` | ``"baseline"`` for the W4A4 linears in this process.
     Call at LOAD time — the first call compiles kernels and self-checks."""
     return _decide(
-        kernel_lane.AXIS_LINEAR,
-        kernel_lane.LINEAR_FUSED, kernel_lane.LINEAR_BASELINE,
-        kernel_lane.linear_of, _fused_linear_self_check)
+        kernel_path.AXIS_LINEAR,
+        kernel_path.LINEAR_FUSED, kernel_path.LINEAR_BASELINE,
+        kernel_path.linear_of, _fused_linear_self_check)
 
 
-def svdq_modulation_lane() -> str:
+def svdq_modulation_execution_lane() -> str:
     """``"packed"`` | ``"dense"`` for the W4A16 AdaLN modulation. Independent
     of the linear lane: a card that wants the baseline linears can still want
     packed modulation, and sm_100 does."""
     return _decide(
-        kernel_lane.AXIS_MODULATION,
-        kernel_lane.MOD_PACKED, kernel_lane.MOD_DENSE,
-        kernel_lane.modulation_of, _packed_modulation_self_check)
+        kernel_path.AXIS_MODULATION,
+        kernel_path.MOD_PACKED, kernel_path.MOD_DENSE,
+        kernel_path.modulation_of, _packed_modulation_self_check)
 
 
-def svdq_linear_lane_reason() -> str:
+def svdq_linear_execution_lane_reason() -> str:
     """The recorded reason for the linear-lane decision."""
-    svdq_linear_lane()
-    return _REASONS[kernel_lane.AXIS_LINEAR]
+    svdq_linear_execution_lane()
+    return _REASONS[kernel_path.AXIS_LINEAR]
 
 
-def svdq_modulation_lane_reason() -> str:
+def svdq_modulation_execution_lane_reason() -> str:
     """The recorded reason for the modulation-lane decision."""
-    svdq_modulation_lane()
-    return _REASONS[kernel_lane.AXIS_MODULATION]
+    svdq_modulation_execution_lane()
+    return _REASONS[kernel_path.AXIS_MODULATION]
 
 
 def reset_native_kernels_arming() -> None:
     """Forget both lane decisions (tests only)."""
-    _LANES.clear()
+    _EXECUTION_LANES.clear()
     _REASONS.clear()
 
 
@@ -284,8 +284,8 @@ __all__ = [
     "load_extension",
     "native_kernels_requested",
     "reset_native_kernels_arming",
-    "svdq_linear_lane",
-    "svdq_linear_lane_reason",
-    "svdq_modulation_lane",
-    "svdq_modulation_lane_reason",
+    "svdq_linear_execution_lane",
+    "svdq_linear_execution_lane_reason",
+    "svdq_modulation_execution_lane",
+    "svdq_modulation_execution_lane_reason",
 ]

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -474,7 +474,7 @@ def enable_compiled(
         # The loud no-denoiser error remains for real compile targets.
         bucket = 0
     if bucket:
-        compile_cache.apply_lora_lane(pipe, bucket)
+        compile_cache.apply_lora_execution_lane(pipe, bucket)
     if artifact is not None:
         # ONE kind sniff for every non-inductor backend. `metadata.json` is
         # the shared envelope member across all artifact kinds (the pgw#709
@@ -505,10 +505,10 @@ def enable_compiled(
         # th#883: the loud invariant propagates, but the caller continuing
         # eager must not inherit the branch-bearing lane.
         if bucket:
-            compile_cache.drop_lora_lane(pipe)
+            compile_cache.drop_lora_execution_lane(pipe)
         raise
     if bucket and not armed:
-        compile_cache.drop_lora_lane(pipe)
+        compile_cache.drop_lora_execution_lane(pipe)
     if armed:
         return AdoptOutcome.hit()
     # The inductor lane declines without a classified token of its own — "no

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -347,13 +347,13 @@ def swap_svdq_linears(
     alignment fold to dense individually rather than refusing."""
     import torch
 
-    from .native_kernels import svdq_linear_lane
+    from .native_kernels import svdq_linear_execution_lane
     from .svdq_fused import build_svdq_fused_linear, fused_shape_supported
 
     compute = compute_dtype or torch.bfloat16
     if mode not in ("blockwise", "dense"):
         mode = "blockwise" if svdq_native_available() else "dense"
-    lane = svdq_linear_lane() if mode == "blockwise" else "baseline"
+    execution_lane = svdq_linear_execution_lane() if mode == "blockwise" else "baseline"
     counts = {"blockwise": 0, "dense": 0, "fused": 0, "prefixes": 0,
               "linears": 0}
     for prefix in sorted(decoded):
@@ -374,7 +374,7 @@ def swap_svdq_linears(
             fp4_ok = (mode == "blockwise"
                       and part.in_features % _K_ALIGN == 0
                       and part.out_features % _N_ALIGN == 0)
-            fused_ok = (fp4_ok and lane == "fused" and fused_shape_supported(
+            fused_ok = (fp4_ok and execution_lane == "fused" and fused_shape_supported(
                 part.out_features, part.in_features, part.rank))
             if fused_ok:
                 new = build_svdq_fused_linear(part, compute_dtype=compute,
@@ -511,12 +511,12 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
                   else "cpu")
     dev = torch.device(device)
 
-    from .native_kernels import svdq_modulation_lane
+    from .native_kernels import svdq_modulation_execution_lane
     from .svdq_awq_packed import awq_packed_supported, build_awq_packed_linear
 
     # Only the modulation axis is read here; `swap_svdq_linears` below owns
     # the linear one and asks for it itself.
-    mod_lane = svdq_modulation_lane() if mode == "blockwise" else "dense"
+    mod_execution_lane = svdq_modulation_execution_lane() if mode == "blockwise" else "dense"
     t0 = time.perf_counter()
     plain: Dict[str, Any] = {}
     swapped = awq = awq_packed = 0
@@ -537,7 +537,7 @@ def load_svdq_native_denoiser(art: Any, *, compute_dtype: Any = None,
                 # delta was this dequant). pgw#863 split it off the linear
                 # lane — a card can want packed modulation and baseline
                 # linears at once, and sm_100 does. Degrade per-layer.
-                if mod_lane == "packed" and awq_packed_supported(out_f, in_f):
+                if mod_execution_lane == "packed" and awq_packed_supported(out_f, in_f):
                     _set_module(model, prefix, build_awq_packed_linear(
                         tensors, out_f, in_f, adanorm_splits=splits,
                         compute_dtype=compute, device=dev))

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -223,7 +223,7 @@ def route_denoiser_keys(
     return routed
 
 
-def branch_lane(model: Any) -> str:
+def branch_execution_lane(model: Any) -> str:
     """The denoiser's base weight lane for branch policy/stamping:
     ``"w8a8"`` | ``"fp8-hooks"`` | ``""`` (plain resident). Both fp8 GEMM
     dispatch branches (rowwise sm_90+, pertensor sm_89 — gw#564) are the
@@ -260,7 +260,7 @@ def branch_bucket(model: Any) -> int:
     return int(getattr(model, _BUCKET_ATTR, 0) or 0)
 
 
-def lora_lane(bucket: int, sparse: bool = False, base: str = "w8a8") -> str:
+def lora_execution_lane(bucket: int, sparse: bool = False, base: str = "w8a8") -> str:
     # Sparse (eager-only) placement is a different graph per coverage
     # pattern — the "-sparse" suffix can never match a produced cell label.
     # ``base`` is the branchless lane the branch rides on ("w8a8",
@@ -641,7 +641,7 @@ def branches_active(model: Any) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def enable_branch_lanes(pipe: Any, bucket: int) -> Dict[str, Any]:
+def enable_branch_execution_lanes(pipe: Any, bucket: int) -> Dict[str, Any]:
     """Allocate the rank-``bucket`` branch container on EVERY branch-capable
     denoiser (both experts of an MoE — the ``Compile(lora_bucket=)`` arming
     contract). Returns the targets it armed."""
@@ -651,19 +651,19 @@ def enable_branch_lanes(pipe: Any, bucket: int) -> Dict[str, Any]:
     return targets
 
 
-def disable_branch_lanes(pipe: Any) -> None:
+def disable_branch_execution_lanes(pipe: Any) -> None:
     """Drop the branch containers from every denoiser (demote/teardown)."""
     for model in branch_targets(pipe).values():
         disable_lora_branches(model)
 
 
-def clear_branch_lanes(pipe: Any) -> None:
+def clear_branch_execution_lanes(pipe: Any) -> None:
     """Deactivate every denoiser's branch (canonical: zero B; sparse: drop)."""
     for model in branch_targets(pipe).values():
         clear_branch_adapters(model)
 
 
-def branch_lanes_active(pipe: Any) -> bool:
+def branch_execution_lanes_active(pipe: Any) -> bool:
     return any(branches_active(m) for m in branch_targets(pipe).values())
 
 
@@ -1012,7 +1012,7 @@ def apply_branch_adapter_set(
     return stats
 
 
-def effective_base_lane(pipe: Any) -> str:
+def effective_base_execution_lane(pipe: Any) -> str:
     """The branchless base weight lane CELL IDENTITY rides on — the ONE
     resolution :func:`stamp_lane` memoizes: the memoized base, else the
     pipeline's stamped/probed lane, else the denoiser's own lane markers
@@ -1030,15 +1030,15 @@ def effective_base_lane(pipe: Any) -> str:
         return str(base)
     from .loading import pipeline_weight_lane
 
-    lane = pipeline_weight_lane(pipe)
-    if lane:
-        return lane
+    execution_lane = pipeline_weight_lane(pipe)
+    if execution_lane:
+        return execution_lane
     for model in branch_targets(pipe).values():
-        return branch_lane(model)
+        return branch_execution_lane(model)
     return ""
 
 
-def stamp_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
+def stamp_execution_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
     """Keep the compile-cache graph key honest: branch-bearing pipelines are
     a different graph family per (base lane, bucket) — lane_drift guards
     both directions. The branchless base lane is remembered on first stamp
@@ -1057,13 +1057,13 @@ def stamp_lane(pipe: Any, targets: Optional[Mapping[str, Any]] = None) -> None:
     if base is None:
         # One brain (pgw#686): the same resolution the advertised requested
         # key uses, so the stamped/published key can never diverge from it.
-        base = effective_base_lane(pipe)
+        base = effective_base_execution_lane(pipe)
         try:
             pipe._cozy_lora_base_lane = base
         except Exception:
             return
     try:
-        pipe._cozy_weight_lane = lora_lane(bucket, sparse, base=base) if bucket else base
+        pipe._cozy_weight_lane = lora_execution_lane(bucket, sparse, base=base) if bucket else base
     except Exception:
         pass
 
@@ -1132,19 +1132,19 @@ __all__ = [
     "apply_branch_adapter_set",
     "apply_branch_adapters",
     "branch_bucket",
-    "branch_lane",
-    "branch_lanes_active",
+    "branch_execution_lane",
+    "branch_execution_lanes_active",
     "branch_modules",
     "branch_targets",
     "branches_active",
     "clear_branch_adapters",
-    "clear_branch_lanes",
+    "clear_branch_execution_lanes",
     "declared_component",
-    "disable_branch_lanes",
+    "disable_branch_execution_lanes",
     "disable_lora_branches",
-    "enable_branch_lanes",
+    "enable_branch_execution_lanes",
     "enable_lora_branches",
-    "lora_lane",
+    "lora_execution_lane",
     "map_adapter",
     "normalize_adapter_state_dict",
     "pipeline_branch_bucket",
@@ -1152,5 +1152,5 @@ __all__ = [
     "require_component_declaration",
     "route_denoiser_keys",
     "split_state_dict",
-    "stamp_lane",
+    "stamp_execution_lane",
 ]

--- a/src/gen_worker/numerics_probe.py
+++ b/src/gen_worker/numerics_probe.py
@@ -105,7 +105,7 @@ class ProbeAxis:
     target: str
     fork: Tuple[Tuple[str, Any], ...] = ()
     class_dims: Tuple[Tuple[str, int], ...] = ()
-    lane: str = ""
+    execution_lane: str = ""
     lora_bucket: int = 0
 
     @property
@@ -122,7 +122,7 @@ class ProbeAxis:
         re-litigates from a screenshot.
         """
         digest = hashlib.sha256(
-            f"{self.entry}|{self.lane}|{self.lora_bucket}".encode()).hexdigest()
+            f"{self.entry}|{self.execution_lane}|{self.lora_bucket}".encode()).hexdigest()
         return int(digest[:8], 16)
 
     @property
@@ -133,7 +133,7 @@ class ProbeAxis:
 
     def __str__(self) -> str:
         return (f"entry={self.entry} target={self.target} "
-                f"row={self.shape_row} lane={self.lane or '(plain)'} "
+                f"row={self.shape_row} lane={self.execution_lane or '(plain)'} "
                 f"bucket={self.lora_bucket} seed={self.seed}")
 
 
@@ -147,7 +147,7 @@ def axes_from_meta(meta: Mapping[str, Any]) -> Tuple[ProbeAxis, ...]:
     from . import aot_serve
 
     entries = aot_serve.entries_from_meta(dict(meta))
-    lane = str(meta.get("precision") or "")
+    execution_lane = str(meta.get("precision") or "")
     cell_bucket = int(meta.get("lora_bucket") or 0)
     axes: List[ProbeAxis] = []
     for name in sorted(entries):
@@ -166,7 +166,7 @@ def axes_from_meta(meta: Mapping[str, Any]) -> Tuple[ProbeAxis, ...]:
             fork=tuple((str(n), v) for n, v in (block.get("fork") or ())),
             class_dims=tuple(
                 (str(n), int(v)) for n, v in (block.get("class_dims") or ())),
-            lane=lane,
+            execution_lane=execution_lane,
             lora_bucket=bucket,
         ))
     if not axes:

--- a/src/gen_worker/parallel/plan.py
+++ b/src/gen_worker/parallel/plan.py
@@ -55,7 +55,7 @@ class GroupPlan:
     """
 
     # Which precision lane the group serves (bf16 / w8a8 / fp8-storage / ...).
-    precision_lane: str = ""
+    precision_execution_lane: str = ""
     # The w8a8 GEMM mode. Under context parallelism this MUST be rowwise:
     # a per-tensor ACTIVATION scale is computed from the local shard, so two
     # ranks holding different sequence shards derive different scales and

--- a/src/gen_worker/parallel/runtime.py
+++ b/src/gen_worker/parallel/runtime.py
@@ -211,7 +211,7 @@ def sequence_rank_main(spec: RankSpec, channel: FollowerChannel) -> None:  # pra
     from .cp import w8a8_gemm_mode
 
     mine = GroupPlan(
-        precision_lane=plan.precision_lane,
+        precision_execution_lane=plan.precision_execution_lane,
         gemm_mode=w8a8_gemm_mode(pipe) or plan.gemm_mode,
         degraded_plan=plan.degraded_plan,
         compile_armed=plan.compile_armed,

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -226,7 +226,7 @@ class RequestContext(Generic[D]):
             self._deadline = self._started_at + (timeout_ms / 1000.0)
         self._canceled = False
         self._boot_warmup = bool(boot_warmup)
-        self._lane = ""  # th#1050: executing lane, set by the executor
+        self._execution_lane = ""  # th#1050: executing lane, set by the executor
         self._config: Dict[str, Any] = {}  # th#1087: effective config params
         self._config_snapshot: Optional[bytes] = None
         self._cancel_event = threading.Event()
@@ -297,16 +297,16 @@ class RequestContext(Generic[D]):
         return self._deadline
 
     @property
-    def lane(self) -> str:
+    def execution_lane(self) -> str:
         """The EXECUTING precision lane of this call (th#1050), a full
         descriptor id like ``"fp8-w8a8-dynamic+compiled"`` — post-degrade
         truth, the same value JobMetrics.lane reports (th#1043 consistent).
         Read-only; always available. Handlers that declared
         ``handles=[...]`` branch on it; everyone else may ignore it."""
-        return self._lane or "bf16-w16a16+eager"
+        return self._execution_lane or "bf16-w16a16+eager"
 
-    def _set_lane(self, lane: str) -> None:
-        self._lane = str(lane or "").strip()
+    def _set_execution_lane(self, execution_lane: str) -> None:
+        self._execution_lane = str(execution_lane or "").strip()
 
     @property
     def config(self) -> Dict[str, Any]:

--- a/src/gen_worker/trt_engine.py
+++ b/src/gen_worker/trt_engine.py
@@ -48,7 +48,7 @@ from . import activity as activity_mod
 from .cell_adopt import AdoptOutcome
 from .compile_cache import (
     AdoptError,
-    CompiledLaneUnavailableError,
+    CompiledExecutionLaneUnavailableError,
     _clean_tarinfo,
     parse_cell_ref,
     sku_slug,
@@ -515,7 +515,7 @@ def wrap_module(
 
     def trt_forward(*args: Any, **kwargs: Any) -> Any:
         if state["revocation_error"]:
-            raise CompiledLaneUnavailableError(state["revocation_error"])
+            raise CompiledExecutionLaneUnavailableError(state["revocation_error"])
         if state["failed"]:
             return original(*args, **kwargs)
         try:
@@ -539,7 +539,7 @@ def wrap_module(
                     )
                     logger.exception(
                         "trt-engine: %s", state["revocation_error"])
-                    raise CompiledLaneUnavailableError(
+                    raise CompiledExecutionLaneUnavailableError(
                         state["revocation_error"]
                     ) from callback_exc
             logger.warning(

--- a/src/gen_worker/utils/lora.py
+++ b/src/gen_worker/utils/lora.py
@@ -560,9 +560,9 @@ class AdapterResidency:
                     # (it IS that path, through views), canonical placement,
                     # no resize — the traced bucket is the floor, and a set
                     # that needs more refuses instead of recompiling.
-                    lora_lifted.swap_lifted_lane_set(
+                    lora_lifted.swap_lifted_execution_lane_set(
                         pipe, branch_set, request_id=request_id)
-                    w8a8_lora.stamp_lane(pipe, targets)
+                    w8a8_lora.stamp_execution_lane(pipe, targets)
                 elif targets and branch_set:
                     # Compiled pipelines keep canonical placement and ONE
                     # traced bucket (a resize would mean a recompile at swap
@@ -578,7 +578,7 @@ class AdapterResidency:
                         )
                     except RefCompatibilitySurprise:
                         if (sole is not None
-                                and w8a8_lora.branch_lane(sole) == ""
+                                and w8a8_lora.branch_execution_lane(sole) == ""
                                 and not compiled
                                 and isinstance(pipe, LoraCapablePipeline)):
                             logger.info(
@@ -586,13 +586,13 @@ class AdapterResidency:
                                 "branch Linears; falling back to the peft path "
                                 "(plain lane)", request_id,
                             )
-                            w8a8_lora.clear_branch_lanes(pipe)
-                            w8a8_lora.stamp_lane(pipe, targets)
+                            w8a8_lora.clear_branch_execution_lanes(pipe)
+                            w8a8_lora.stamp_execution_lane(pipe, targets)
                             adapters = all_adapters
                         else:
                             raise
                     else:
-                        w8a8_lora.stamp_lane(pipe, targets)
+                        w8a8_lora.stamp_execution_lane(pipe, targets)
                 elif targets:
                     # Adapter set has no denoiser half: make sure a previous
                     # request's branches are off. Lifted denoisers clear
@@ -606,8 +606,8 @@ class AdapterResidency:
                             else:
                                 w8a8_lora.clear_branch_adapters(model)
                     else:
-                        w8a8_lora.clear_branch_lanes(pipe)
-                    w8a8_lora.stamp_lane(pipe, targets)
+                        w8a8_lora.clear_branch_execution_lanes(pipe)
+                    w8a8_lora.stamp_execution_lane(pipe, targets)
                 if targets and not adapters:
                     # No peft half — make sure a previous request's peft
                     # adapters are off, then we're done. Only touch the peft
@@ -691,7 +691,7 @@ class AdapterResidency:
                             binding.clear()
                         else:
                             w8a8_lora.clear_branch_adapters(model)
-                    w8a8_lora.stamp_lane(pipe, targets)
+                    w8a8_lora.stamp_execution_lane(pipe, targets)
             except Exception as exc:
                 logger.warning(
                     "[request_id=%s] lora branch clear failed", request_id,
@@ -756,8 +756,8 @@ class AdapterResidency:
                 # bucket guard: never-lora pipelines skip the module walk
                 # entirely — this runs on EVERY demote (gw#551 swaps).
                 if targets and w8a8_lora.pipeline_branch_bucket(pipe):
-                    w8a8_lora.disable_branch_lanes(pipe)
-                    w8a8_lora.stamp_lane(pipe, targets)
+                    w8a8_lora.disable_branch_execution_lanes(pipe)
+                    w8a8_lora.stamp_execution_lane(pipe, targets)
             except Exception as exc:
                 logger.warning("lora branch drop on demote failed for %s",
                                ref, exc_info=True)

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -861,7 +861,7 @@ def warm_context(
     spec: "EndpointSpec", *,
     request_id: str,
     local_output_dir: str,
-    lane: str = "",
+    execution_lane: str = "",
     config: Optional[Mapping[str, Any]] = None,
 ) -> Any:
     """The ``RequestContext`` a WARM forward runs under — one construction.
@@ -894,8 +894,8 @@ def warm_context(
         **resolved_slots_kwargs(spec, None),
         boot_warmup=True,
     )
-    if lane:
-        ctx._set_lane(str(lane))
+    if execution_lane:
+        ctx._set_execution_lane(str(execution_lane))
     if config:
         ctx._set_config(dict(config))
     return ctx

--- a/tests/harness/toy_endpoints.py
+++ b/tests/harness/toy_endpoints.py
@@ -344,9 +344,9 @@ class ConfigKnobsEndpoint:
 class LaneAwareEndpoint:
     def lane_echo(self, ctx: RequestContext, data: EchoIn) -> EchoOut:
         # The divergence the declaration marks: an author kernel branch.
-        if ctx.lane.startswith("fp8-w8a8-dynamic"):
-            return EchoOut(response=f"author-kernel:{ctx.lane}")
-        return EchoOut(response=f"reference:{ctx.lane}")
+        if ctx.execution_lane.startswith("fp8-w8a8-dynamic"):
+            return EchoOut(response=f"author-kernel:{ctx.execution_lane}")
+        return EchoOut(response=f"reference:{ctx.execution_lane}")
 
 
 @endpoint
@@ -380,7 +380,7 @@ OPTIONAL_EDIT = Hub("harness/optional-lane-edit", tag="prod")
     "t2i": Slot(str, default_checkpoint=OPTIONAL_T2I, root=True),
     "edit": Slot(str, default_checkpoint=OPTIONAL_EDIT),
 })
-class OptionalLaneEndpoint:
+class OptionalExecutionLaneEndpoint:
     def setup(self, t2i: str, edit: str | None = None) -> None:
         self.t2i_path = t2i
         self.edit_path = edit

--- a/tests/test_abandoned_mint_telemetry_pgw848.py
+++ b/tests/test_abandoned_mint_telemetry_pgw848.py
@@ -125,7 +125,7 @@ def test_an_abandoned_outcome_emits_the_rows_it_measured(
     original = aot_mint.emit_phase_events
     aot_mint.emit_phase_events = _capture  # type: ignore[assignment]
     try:
-        mint_delegate._emit_aot_phases(outcome, family="sdxl", lane="w8a8")
+        mint_delegate._emit_aot_phases(outcome, family="sdxl", execution_lane="w8a8")
     finally:
         aot_mint.emit_phase_events = original  # type: ignore[assignment]
 
@@ -161,7 +161,7 @@ def test_a_report_beats_a_snapshot_when_both_exist(tmp_path: Path) -> None:
     aot_mint.emit_phase_events = (
         lambda **kw: emitted.append(kw))  # type: ignore[assignment]
     try:
-        mint_delegate._emit_aot_phases(outcome, family="sdxl", lane="w8a8")
+        mint_delegate._emit_aot_phases(outcome, family="sdxl", execution_lane="w8a8")
     finally:
         aot_mint.emit_phase_events = original  # type: ignore[assignment]
 

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -151,7 +151,7 @@ class _Pipe:
 # --- the defect, reproduced from the live evidence -------------------------
 
 
-def test_burst_divergence_reproduced_lane_only(burst_runtime: None) -> None:
+def test_burst_divergence_reproduced_execution_lane_only(burst_runtime: None) -> None:
     """All three observed keys are ONE identity varying only the lane axis:
     the advertised lanes name keys nobody publishes; the published lane
     names a key nobody advertises. Adoption was structurally impossible."""
@@ -170,24 +170,24 @@ def test_burst_divergence_reproduced_lane_only(burst_runtime: None) -> None:
 # --- the fix: one base-lane resolution for every cell-identity surface -----
 
 
-def test_cell_base_lane_sees_w8a8_mode(burst_runtime: None) -> None:
+def test_cell_base_execution_lane_sees_w8a8_mode(burst_runtime: None) -> None:
     pipe = _Pipe()
-    assert w8a8_lora.effective_base_lane(pipe) == "w8a8"
-    assert cc.cell_base_lane(pipe) == "w8a8"
+    assert w8a8_lora.effective_base_execution_lane(pipe) == "w8a8"
+    assert cc.cell_base_execution_lane(pipe) == "w8a8"
     # An identical worker now requests exactly the key the mint published.
-    assert _requested(cc.cell_base_lane(pipe)) \
+    assert _requested(cc.cell_base_execution_lane(pipe)) \
         == ck.from_artifact_metadata(_BURST_META).digest
 
 
-def test_cell_base_lane_precedence() -> None:
+def test_cell_base_execution_lane_precedence() -> None:
     # Explicit pipeline stamp wins.
     pipe = _Pipe()
     pipe._cozy_weight_lane = "w8a8-lora64"
-    assert cc.cell_base_lane(pipe) == "w8a8-lora64"
+    assert cc.cell_base_execution_lane(pipe) == "w8a8-lora64"
     # fp8-hooks marker (w8a16 storage lane) wins over the denoiser fallback.
     pipe2 = _Pipe()
     pipe2.unet._cozy_fp8_storage_applied = True
-    assert cc.cell_base_lane(pipe2) == "fp8-hooks"
+    assert cc.cell_base_execution_lane(pipe2) == "fp8-hooks"
     # Plain pipeline stays plain.
     class _PlainDenoiser:
         def named_modules(self) -> Iterator[Any]:
@@ -197,16 +197,16 @@ def test_cell_base_lane_precedence() -> None:
         def __init__(self) -> None:
             self.unet = _PlainDenoiser()
 
-    assert cc.cell_base_lane(_PlainPipe()) == ""
+    assert cc.cell_base_execution_lane(_PlainPipe()) == ""
 
 
-def test_stamp_lane_memoizes_the_same_base() -> None:
+def test_stamp_execution_lane_memoizes_the_same_base() -> None:
     """Parity by construction: the base stamp_lane memoizes at mint time is
     exactly what effective_base_lane resolved before the mint — so the
     requested key (advertise) and the stamped key (publish) share one lane."""
     pipe = _Pipe()
-    expected = w8a8_lora.effective_base_lane(pipe)
-    w8a8_lora.stamp_lane(pipe, {"unet": pipe.unet})
+    expected = w8a8_lora.effective_base_execution_lane(pipe)
+    w8a8_lora.stamp_execution_lane(pipe, {"unet": pipe.unet})
     assert pipe._cozy_lora_base_lane == expected == "w8a8"
     # bucket 0 on the stub: the stamp restores the branchless base lane.
     assert pipe._cozy_weight_lane == "w8a8"

--- a/tests/test_aot_adapter_fork_pgw790.py
+++ b/tests/test_aot_adapter_fork_pgw790.py
@@ -84,8 +84,8 @@ def _declare() -> Any:
 
 def _armed_pipe() -> Any:
     pipe = types.SimpleNamespace(unet=TinyUNet().eval())
-    w8a8_lora.enable_branch_lanes(pipe, BUCKET)
-    lora_lifted.install_lifted_lora_lanes(pipe, BUCKET)
+    w8a8_lora.enable_branch_execution_lanes(pipe, BUCKET)
+    lora_lifted.install_lifted_lora_execution_lanes(pipe, BUCKET)
     return pipe
 
 

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -368,7 +368,7 @@ def test_fleet_armed_other_path_never_advertises_aot(
     assert row.ref == _f1.ref and KEY in row.detail
 
 
-def test_fleet_lane_unavailable_is_recorded_against_the_candidate(
+def test_fleet_execution_lane_unavailable_is_recorded_against_the_candidate(
     monkeypatch: pytest.MonkeyPatch, _f1: Any, tmp_path: Path,
 ) -> None:
     from gen_worker import compile_cache as cc
@@ -380,7 +380,7 @@ def test_fleet_lane_unavailable_is_recorded_against_the_candidate(
     def _enable(pipe: Any, cfg: Any, cache_dir: Any, artifact: Any) -> Any:
         calls.append(artifact)
         if len(calls) == 1:
-            raise cc.CompiledLaneUnavailableError("no cell for w8a8")
+            raise cc.CompiledExecutionLaneUnavailableError("no cell for w8a8")
         return AdoptOutcome.hit()
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _enable)

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -77,9 +77,9 @@ RIG: Dict[str, Any] = {}
 class AotFamily:
     def setup(self, pipeline: str) -> None:
         self.pipe = _Pipe()
-        lane = RIG.get("weight_lane")
-        if lane:
-            setattr(self.pipe, "_cozy_weight_lane", lane)
+        execution_lane = RIG.get("weight_lane")
+        if execution_lane:
+            setattr(self.pipe, "_cozy_weight_lane", execution_lane)
         RIG["pipe"] = self.pipe
         gen_worker.arm_compile(self.pipe)
 
@@ -194,7 +194,7 @@ def test_unexercised_pure_aot_arm_disarms_to_true_eager(
     assert not compile_cache.cell_proven_in_process(ref)
 
 
-def test_mandatory_lane_disarm_degrades_without_killing_the_boot(
+def test_mandatory_execution_lane_disarm_degrades_without_killing_the_boot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _key, ref = _rig(monkeypatch, seed="c", exercise=False,

--- a/tests/test_aot_flip_pgw722.py
+++ b/tests/test_aot_flip_pgw722.py
@@ -64,7 +64,7 @@ def _runtime_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME))
 
 
-def _pilot_meta(key: str, *, lane: str = "w8a8", bucket: int = 64,
+def _pilot_meta(key: str, *, execution_lane: str = "w8a8", bucket: int = 64,
                 **over: Any) -> Dict[str, Any]:
     """A published-cell metadata dict shaped like the real (format-2,
     multi-graph) cells — one entry is simply the N=1 case."""
@@ -76,7 +76,7 @@ def _pilot_meta(key: str, *, lane: str = "w8a8", bucket: int = 64,
             "constants": [dict(r) for r in CONSTANTS], "graph": {},
         }},
         lora_bucket=bucket)
-    meta["weight_lane"] = lane
+    meta["weight_lane"] = execution_lane
     meta.update(over)
     return meta
 
@@ -123,7 +123,7 @@ def test_candidates_filter_and_newest_wins(_runtime_key: None) -> None:
     good_old = _pilot_meta(_key("a"))
     good_new = _pilot_meta(_key("b"))
     wrong_kind = _pilot_meta(_key("c"), kind="torch-inductor-cache")
-    wrong_lane = _pilot_meta(_key("d"), lane="w8a16")
+    wrong_execution_lane = _pilot_meta(_key("d"), execution_lane="w8a16")
     wrong_bucket = _pilot_meta(_key("e"), bucket=0)
     wrong_sm = _pilot_meta(_key("f"), sm="sm_80")
     unkeyed = _pilot_meta(_key("1"), cell_key="not-a-key")
@@ -135,7 +135,7 @@ def test_candidates_filter_and_newest_wins(_runtime_key: None) -> None:
         {"checkpoint_id": "x1", "updated_at": "2026-07-29T00:00:00Z",
          "metadata": wrong_kind},
         {"checkpoint_id": "x2", "updated_at": "2026-07-29T00:00:00Z",
-         "metadata": wrong_lane},
+         "metadata": wrong_execution_lane},
         {"checkpoint_id": "x3", "updated_at": "2026-07-29T00:00:00Z",
          "metadata": wrong_bucket},
         {"checkpoint_id": "x4", "updated_at": "2026-07-29T00:00:00Z",
@@ -278,14 +278,14 @@ class _Cfg:
 
 
 @pytest.fixture()
-def _plain_lane(monkeypatch: pytest.MonkeyPatch) -> None:
+def _plain_execution_lane(monkeypatch: pytest.MonkeyPatch) -> None:
     from gen_worker import compile_cache as cc
 
-    monkeypatch.setattr(cc, "cell_base_lane", lambda pipe: "w8a8")
+    monkeypatch.setattr(cc, "cell_base_execution_lane", lambda pipe: "w8a8")
 
 
 def test_discover_downloads_newest_and_registers_key(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
 ) -> None:
     key = _key("9")
     meta = _pilot_meta(key)
@@ -324,7 +324,7 @@ def test_discover_downloads_newest_and_registers_key(
 
 
 def test_discover_names_a_refusal_and_never_retries_anonymously(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
     monkeypatch: Any,
 ) -> None:
     """th#1335 (was: test_discover_retries_anonymously_on_401).
@@ -366,7 +366,7 @@ def test_discover_names_a_refusal_and_never_retries_anonymously(
 
 
 def test_discover_never_raises(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
 ) -> None:
     hub = _StubHub([], {}, fail_all=True)
     try:
@@ -412,7 +412,7 @@ def _discover_against(
 
 
 def test_discover_refuses_a_v1_blake3_only_cell_th1303(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """th#1303 S1 replaces `test_discover_digest_mismatch_is_a_miss`.
@@ -432,7 +432,7 @@ def test_discover_refuses_a_v1_blake3_only_cell_th1303(
 
 
 def test_discover_refuses_a_v2_cell_whose_bytes_do_not_match_th1303(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """th#1303 landmine 2 — the empty-guard class, on EXECUTABLE bytes.
@@ -458,7 +458,7 @@ def test_discover_refuses_a_v2_cell_whose_bytes_do_not_match_th1303(
 
 
 def test_discover_verifies_a_v2_cell_with_sha256_th1303(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
 ) -> None:
     """The green half: a correct v2 entry is verified UNDER SHA-256 and armed.
 
@@ -471,7 +471,7 @@ def test_discover_verifies_a_v2_cell_with_sha256_th1303(
 
 
 def test_discover_refuses_an_entry_with_no_digest_at_all_th1303(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No digest is a REFUSAL, never a skip. A cell artifact is compiled code
@@ -490,7 +490,7 @@ def test_discover_refuses_an_entry_with_no_digest_at_all_th1303(
 
 
 def test_discover_refetches_a_cached_artifact_that_stopped_matching_th1303(
-    tmp_path: Path, _runtime_key: None, _plain_lane: None,
+    tmp_path: Path, _runtime_key: None, _plain_execution_lane: None,
 ) -> None:
     """The cache-hit guard is the SECOND site the empty digest disarmed.
 
@@ -723,7 +723,7 @@ def test_f2_flag_on_installs_before_enable_in_proven_order(
     assert observed == [True]
     binding = lora_lifted.lifted_binding(pipe.unet)
     assert binding is not None and binding.plan.bucket == BUCKET
-    # ... and ON the canonical branch containers apply_lora_lane allocated.
+    # ... and ON the canonical branch containers apply_lora_execution_lane allocated.
     assert w8a8_lora.branch_bucket(pipe.unet) == BUCKET
 
 
@@ -778,7 +778,7 @@ def test_f3_flag_off_attach_is_the_buffer_copy(
     pipe = _Pipe()
     from gen_worker import compile_cache as cc
 
-    cc.apply_lora_lane(pipe, BUCKET)
+    cc.apply_lora_execution_lane(pipe, BUCKET)
     sd = _adapter(pipe.unet, seed=3)
     AdapterResidency().activate(
         "ref", pipe, [_prepared(sd, "hub/adapter@1")], request_id="off")
@@ -794,7 +794,7 @@ def test_f3_lifted_attach_writes_through_the_binding_views(
     pipe = _Pipe()
     from gen_worker import compile_cache as cc
 
-    cc.apply_lora_lane(pipe, BUCKET)
+    cc.apply_lora_execution_lane(pipe, BUCKET)
     binding = lora_lifted.install_lifted_lora_forward(pipe.unet, BUCKET)
     sd = _adapter(pipe.unet, seed=4)
     residency = AdapterResidency()

--- a/tests/test_aot_lifted_arm_pgw822.py
+++ b/tests/test_aot_lifted_arm_pgw822.py
@@ -93,7 +93,7 @@ def _container_only_pipe() -> Any:
     state the mint child handed to ``aot_mint.mint`` in the measured run.
     Branch containers allocated, denoiser forward untouched."""
     pipe = types.SimpleNamespace(unet=TinyUNet().eval())
-    w8a8_lora.enable_branch_lanes(pipe, BUCKET)
+    w8a8_lora.enable_branch_execution_lanes(pipe, BUCKET)
     assert lora_lifted.lifted_binding(pipe.unet) is None
     return pipe
 
@@ -124,7 +124,7 @@ def _fresh_registry():
 
 def test_the_arm_installs_both_halves_over_a_container_only_pipeline() -> None:
     pipe = _container_only_pipe()
-    lora_lifted.arm_lifted_lora_lanes(pipe, BUCKET)
+    lora_lifted.arm_lifted_lora_execution_lanes(pipe, BUCKET)
     binding = lora_lifted.lifted_binding(pipe.unet)
     assert binding is not None
     import inspect
@@ -135,15 +135,15 @@ def test_the_arm_installs_both_halves_over_a_container_only_pipeline() -> None:
 
 def test_the_arm_is_idempotent_and_a_noop_at_bucket_zero() -> None:
     pipe = _container_only_pipe()
-    first = lora_lifted.arm_lifted_lora_lanes(pipe, BUCKET)["unet"]
-    again = lora_lifted.arm_lifted_lora_lanes(pipe, BUCKET)["unet"]
+    first = lora_lifted.arm_lifted_lora_execution_lanes(pipe, BUCKET)["unet"]
+    again = lora_lifted.arm_lifted_lora_execution_lanes(pipe, BUCKET)["unet"]
     assert again is first
     plain = types.SimpleNamespace(unet=TinyUNet().eval())
-    assert lora_lifted.arm_lifted_lora_lanes(plain, 0) == {}
+    assert lora_lifted.arm_lifted_lora_execution_lanes(plain, 0) == {}
     assert lora_lifted.lifted_binding(plain.unet) is None
 
 
-def test_the_declared_feed_binds_once_the_lane_is_armed() -> None:
+def test_the_declared_feed_binds_once_the_execution_lane_is_armed() -> None:
     """The measured refusal, at its exact site: ``declared_inputs`` binding
     the declaration to the module's own signature."""
     decl = _declare()
@@ -153,7 +153,7 @@ def test_the_declared_feed_binds_once_the_lane_is_armed() -> None:
     with pytest.raises(aot_mint.MintRefused, match="are not parameters of"):
         aot_declaration.declared_inputs(pipe.unet, spec, decl)
 
-    lora_lifted.arm_lifted_lora_lanes(pipe, BUCKET)
+    lora_lifted.arm_lifted_lora_execution_lanes(pipe, BUCKET)
     args, kwargs = aot_declaration.declared_inputs(pipe.unet, spec, decl)
     assert kwargs == {}
     assert len(args) == 3          # sample + the lifted pair, all positional

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -918,7 +918,7 @@ def test_cell_key_differs_when_ONLY_the_declared_range_differs(
         "8..32")
 
 
-def test_cell_key_differs_by_lane(
+def test_cell_key_differs_by_execution_lane(
     _gpu_runtime: None, packages: Dict[str, Path],
 ) -> None:
     program = _export_lifted()
@@ -1055,7 +1055,7 @@ def test_cli_loads_a_full_request(tmp_path: Path) -> None:
     spec, body = aot_mint._load_spec(request)
     assert spec.family == "sdxl"
     assert spec.target == ""
-    assert spec.lane_label() == "w8a8-lora64"
+    assert spec.execution_lane_label() == "w8a8-lora64"
     assert spec.shapes == ((1024, 1024), (1152, 896))
     assert spec.strict is True
     assert body["specialization"] == {"gemm_mode": "pertensor"}

--- a/tests/test_aot_mint_unblock_pgw813_pgw815.py
+++ b/tests/test_aot_mint_unblock_pgw813_pgw815.py
@@ -163,8 +163,8 @@ def _w8a8_miss(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)
-    monkeypatch.setattr(fleet_cells.cc, "apply_lora_lane", lambda p, b: None)
-    monkeypatch.setattr(fleet_cells.cc, "drop_lora_lane", lambda p: None)
+    monkeypatch.setattr(fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
+    monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
     monkeypatch.setattr(
@@ -216,7 +216,7 @@ def test_a_w8a8_pipeline_has_an_eager_tier(
     assert compile_cache.eager_tier_available(pipe) is True
 
 
-def test_the_w8a8_lane_is_delegatable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_w8a8_execution_lane_is_delegatable(monkeypatch: pytest.MonkeyPatch) -> None:
     """RED at HEAD: `delegatable` refused `mandatory_serving(pipe)`, so the
     lane Paul ruled AOT-first was the one lane that could never get a
     delegated minter."""

--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -129,8 +129,8 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)
-    monkeypatch.setattr(fleet_cells.cc, "apply_lora_lane", lambda p, b: None)
-    monkeypatch.setattr(fleet_cells.cc, "drop_lora_lane", lambda p: None)
+    monkeypatch.setattr(fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
+    monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
     # No GPU on a dev box: the ck5 `sm` axis is a real-runtime fact, and this
@@ -250,9 +250,9 @@ def test_a_compile_block_without_graph_classes_is_not_a_declaration() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("base_lane", loading.STAMPABLE_BASE_LANES)
-def test_every_lane_a_pod_can_serve_reaches_the_aot_recipe(
-    base_lane: str,
+@pytest.mark.parametrize("base_execution_lane", loading.STAMPABLE_BASE_EXECUTION_LANES)
+def test_every_execution_lane_a_pod_can_serve_reaches_the_aot_recipe(
+    base_execution_lane: str,
     _miss: None, _events: List[Tuple[str, str, str]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -276,19 +276,19 @@ def test_every_lane_a_pod_can_serve_reaches_the_aot_recipe(
     """
     register_export_declaration(_declaration())
     monkeypatch.setattr(
-        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: base_lane)
+        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: base_execution_lane)
 
     pending = _arm(delegate=True).self_mint
 
     assert pending is not None and pending.recipe == fleet_cells.RECIPE_AOT, (
-        f"lane {base_lane!r} did not reach the AOT recipe — a mint-side lane "
+        f"lane {base_execution_lane!r} did not reach the AOT recipe — a mint-side lane "
         f"judgement has grown back")
     assert not _phases(_events, "self_mint_skipped"), (
-        f"lane {base_lane!r} was declined: "
+        f"lane {base_execution_lane!r} was declined: "
         f"{[d for k, _p, d in _events if k == 'self_mint_skipped']}")
 
 
-def test_the_bucketed_lora_form_of_a_lane_mints_too(
+def test_the_bucketed_lora_form_of_a_execution_lane_mints_too(
     _miss: None, _events: List[Tuple[str, str, str]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -306,7 +306,7 @@ def test_the_bucketed_lora_form_of_a_lane_mints_too(
     assert not _phases(_events, "self_mint_skipped")
 
 
-def test_the_mint_holds_no_lane_predicate() -> None:
+def test_the_mint_holds_no_execution_lane_predicate() -> None:
     """The deletion itself. `lane_admitted`/`PARITY_LANES` were a SECOND
     opinion about a lane the hub's resolution tree had already chosen; two
     opinions in two repos is what composed into the total block. Every
@@ -399,7 +399,7 @@ def test_the_parent_reemits_the_childs_aot_phase_table(
             "unet/nocfg": {"export_s": 30.0, "compile_s": 400.0},
         },
     }
-    aot_mint.emit_phase_events(family=FAMILY, lane="w8a8-lora64", table=table)
+    aot_mint.emit_phase_events(family=FAMILY, execution_lane="w8a8-lora64", table=table)
 
     kinds = {(k, p) for k, p, _ in rows}
     assert ("aot_mint_phases", "minted") in kinds
@@ -420,7 +420,7 @@ def test_a_mint_that_produced_no_cell_still_reports_its_seconds(
         status=mint_process.CRASHED, detail="boom", elapsed_s=120.0,
         report=MintReport(status="failed", elapsed_s=120.0, recipe="aot"))
     assert not outcome.minted
-    mint_delegate._emit_aot_phases(outcome, family=FAMILY, lane="w8a8")
+    mint_delegate._emit_aot_phases(outcome, family=FAMILY, execution_lane="w8a8")
 
     assert ("aot_mint_phases", "aborted") in [(k, p) for k, p, _ in _events]
 

--- a/tests/test_boot_compile_deferral_gw584.py
+++ b/tests/test_boot_compile_deferral_gw584.py
@@ -446,7 +446,7 @@ def _plain_compile_spec(setup_calls: List[str]) -> EndpointSpec:
     )
 
 
-def test_plain_lane_runjob_cold_setup_after_deferral(tmp_path, monkeypatch) -> None:
+def test_plain_execution_lane_runjob_cold_setup_after_deferral(tmp_path, monkeypatch) -> None:
     setup_calls: List[str] = []
     ex, sent, _enables = _harness(tmp_path, monkeypatch,
                                   [_plain_compile_spec(setup_calls)])

--- a/tests/test_cell_adoption_measurement_pgw923.py
+++ b/tests/test_cell_adoption_measurement_pgw923.py
@@ -90,7 +90,7 @@ def test_an_armed_adoption_reports_its_arm_time_AND_its_warm_time() -> None:
     assert ev.operation_id == "" and ev.target_incarnation_id == ""
 
 
-def test_a_refused_adoption_reports_the_classified_reason_on_the_same_lane() -> None:
+def test_a_refused_adoption_reports_the_classified_reason_on_the_same_execution_lane() -> None:
     """th#1352's half. `adopt_failed:<reason>` is the same grammar the
     hub-commanded path uses, so ONE `kind=compile_cache_adopt` query returns
     the whole outcome distribution instead of two half-populations."""

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -137,7 +137,7 @@ def test_compute_matches_artifact_metadata_stamp(fixed_runtime):
     assert ck.from_artifact_metadata(meta).digest == want
 
 
-def test_lane_canonicalization(fixed_runtime):
+def test_execution_lane_canonicalization(fixed_runtime):
     """fp8-hooks and w8a16 are one graph family; buckets fold into the lane."""
     assert (ck.compute("f", "fp8-hooks", contract=_CONTRACT).digest
             == ck.compute("f", "w8a16", contract=_CONTRACT).digest)
@@ -208,21 +208,21 @@ def test_is_cache_ref_accepts_key_flavor():
     assert not cc.is_cache_ref(f"owner/repo#{key}")
 
 
-def test_cell_lane_matcher_uses_candidate_keys():
-    from gen_worker.executor import _cell_lane_matches
+def test_cell_execution_lane_matcher_uses_candidate_keys():
+    from gen_worker.executor import _cell_execution_lane_matches
 
     key = ck.from_axes(_AXES).digest
     ref = f"root/family-ltx-2.3#{key}"
-    assert _cell_lane_matches(
-        ref, "ltx-2.3", want_lane="w8a8", want_bucket=0,
+    assert _cell_execution_lane_matches(
+        ref, "ltx-2.3", want_execution_lane="w8a8", want_bucket=0,
         candidate_keys={key})
-    assert not _cell_lane_matches(
-        ref, "ltx-2.3", want_lane="w8a8", want_bucket=0,
+    assert not _cell_execution_lane_matches(
+        ref, "ltx-2.3", want_execution_lane="w8a8", want_bucket=0,
         candidate_keys={"ck1-" + "0" * 56})
     # legacy labels keep the lane-parse policy
-    assert _cell_lane_matches(
+    assert _cell_execution_lane_matches(
         "root/family-ltx-2.3#inductor-b200-torch2.13-w8a8",
-        "ltx-2.3", want_lane="w8a8", want_bucket=0)
+        "ltx-2.3", want_execution_lane="w8a8", want_bucket=0)
 
 
 class _Target:

--- a/tests/test_cell_portability_gw611.py
+++ b/tests/test_cell_portability_gw611.py
@@ -154,7 +154,7 @@ def test_fresh_process_adopt_serves_from_the_packed_cell(tmp_path):
     )
 
 
-def test_union_cell_serves_both_lanes_in_a_fresh_process(tmp_path):
+def test_union_cell_serves_both_execution_lanes_in_a_fresh_process(tmp_path):
     """gw#614: a family cell minted with BOTH lanes' graphs (the synthesized
     media-variant warmup exercises the sibling lane, so the union publishes)
     must serve BOTH lanes as FX hits in a fresh adopting process — zero

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -35,18 +35,18 @@ def test_flavor_label():
     assert cc.flavor_label("h100-80gb-hbm3", "2.11.0") == "inductor-h100-80gb-hbm3-torch2.11"
 
 
-def test_cell_lane_is_exact_and_checkpoint_free():
-    assert cc.cell_lane(
+def test_cell_execution_lane_is_exact_and_checkpoint_free():
+    assert cc.cell_execution_lane(
         "root/family-sdxl#inductor-rtx-4090-torch2.13-w8a8"
     ) == "w8a8"
-    assert cc.cell_lane(
+    assert cc.cell_execution_lane(
         "root/family-sdxl#inductor-rtx-4090-torch2.13"
     ) == ""
-    assert cc.cell_lane("owner/checkpoint#fp8-w8a8") == ""
+    assert cc.cell_execution_lane("owner/checkpoint#fp8-w8a8") == ""
 
 
 @pytest.mark.parametrize(
-    ("lane", "bucket"),
+    ("execution_lane", "bucket"),
     [
         ("", 0),
         ("fp8-hooks", 0),
@@ -58,12 +58,12 @@ def test_cell_lane_is_exact_and_checkpoint_free():
         ("w8a8-lora128", 128),
     ],
 )
-def test_compile_target_lane_vocabulary_matches_tensorhub(lane, bucket):
-    assert cc.compile_target_lane_error(lane, bucket) == ""
+def test_compile_target_execution_lane_vocabulary_matches_tensorhub(execution_lane, bucket):
+    assert cc.compile_target_execution_lane_error(execution_lane, bucket) == ""
 
 
 @pytest.mark.parametrize(
-    ("lane", "bucket"),
+    ("execution_lane", "bucket"),
     [
         ("w8a8-row", 0),
         ("fp8", 0),
@@ -73,8 +73,8 @@ def test_compile_target_lane_vocabulary_matches_tensorhub(lane, bucket):
         ("w8a8", 32),
     ],
 )
-def test_compile_target_lane_vocabulary_rejects_impossible_states(lane, bucket):
-    assert cc.compile_target_lane_error(lane, bucket)
+def test_compile_target_execution_lane_vocabulary_rejects_impossible_states(execution_lane, bucket):
+    assert cc.compile_target_execution_lane_error(execution_lane, bucket)
 
 
 def test_verify_mismatches():
@@ -264,7 +264,7 @@ def test_w8a8_guard_degrades_to_eager_and_revokes(caplog):
     assert any("DEGRADED" in r.message for r in caplog.records)
 
 
-def test_guard_revocation_failure_latches_fail_closed_for_optional_lane():
+def test_guard_revocation_failure_latches_fail_closed_for_optional_execution_lane():
     calls = {"compiled": 0, "eager": 0, "callback": 0}
 
     def eager(value):
@@ -282,11 +282,11 @@ def test_guard_revocation_failure_latches_fail_closed_for_optional_lane():
     signal = {"callback": revoke}
     guarded = cc._guarded(eager, broken, "transformer", failure_signal=signal)
     with pytest.raises(
-        cc.CompiledLaneUnavailableError, match="revocation failed",
+        cc.CompiledExecutionLaneUnavailableError, match="revocation failed",
     ):
         guarded(1)
     with pytest.raises(
-        cc.CompiledLaneUnavailableError, match="revocation failed",
+        cc.CompiledExecutionLaneUnavailableError, match="revocation failed",
     ):
         guarded(2)
     assert calls == {"compiled": 1, "eager": 0, "callback": 1}
@@ -692,7 +692,7 @@ def test_w8a8_enable_refusal_carries_exact_reason(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
 
     # no artifact delivered
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="no cell artifact delivered"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="no cell artifact delivered"):
         cc.enable(pipe, cfg, cache_dir, artifact=None)
 
     # key mismatch: the axis and both values appear in the raise
@@ -703,7 +703,7 @@ def test_w8a8_enable_refusal_carries_exact_reason(tmp_path, monkeypatch):
     meta["torch"] = "0.0.0+fake"
     source = _capture_tree(tmp_path / "cand")
     artifact = cc.pack(source, tmp_path / "cell.tar.gz", meta)
-    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError) as exc:
         cc.enable(pipe, cfg, cache_dir, artifact=artifact)
     assert "torch" in str(exc.value) and "0.0.0+fake" in str(exc.value)
 
@@ -717,7 +717,7 @@ def test_w8a8_enable_refusal_carries_exact_reason(tmp_path, monkeypatch):
     meta.pop("cell_key", None)
     source2 = _capture_tree(tmp_path / "cand2")
     artifact2 = cc.pack(source2, tmp_path / "cell2.tar.gz", meta)
-    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError) as exc:
         cc.enable(pipe, cfg, cache_dir, artifact=artifact2)
     assert "module graph signature" in str(exc.value)
     assert "1" * 12 in str(exc.value)
@@ -1127,14 +1127,14 @@ def test_endpoint_compile_reaches_spec():
 
 
 def test_flavor_label_carries_weight_lane_gw534() -> None:
-    from gen_worker.compile_cache import flavor_label, is_cache_ref, lane_token
+    from gen_worker.compile_cache import flavor_label, is_cache_ref, execution_lane_token
 
     assert flavor_label("rtx-4090", "2.9.1+cu128") == "inductor-rtx-4090-torch2.9"
     assert flavor_label("h100-80gb-hbm3", "2.13.0+cu130", "w8a8") == (
         "inductor-h100-80gb-hbm3-torch2.13-w8a8")
     assert flavor_label("rtx-4090", "2.9.1", "fp8-hooks") == (
         "inductor-rtx-4090-torch2.9-w8a16")
-    assert lane_token("") == "" and lane_token("w8a8") == "w8a8"
+    assert execution_lane_token("") == "" and execution_lane_token("w8a8") == "w8a8"
     assert is_cache_ref("root/family-qwen-image#inductor-h100-80gb-hbm3-torch2.13-w8a8")
 
 
@@ -1283,7 +1283,7 @@ def test_offload_mode_drift_still_refuses(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cc, "apply", lambda pipeline, cfg, **kw: kw.get("cache_ready", False))
 
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="low_vram_mode"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="low_vram_mode"):
         cc.enable(pipe, cfg, tmp_path / "cache", artifact)
     assert pipe._cozy_low_vram_mode == "model_offload"
 

--- a/tests/test_compile_duration_th1322.py
+++ b/tests/test_compile_duration_th1322.py
@@ -217,7 +217,7 @@ def test_both_mint_routes_report_duration_over_real_grpc() -> None:
             family = "sdxl"
 
             @staticmethod
-            def lane_label() -> str:
+            def execution_lane_label() -> str:
                 return "w8a8"
 
         aot_mint._emit_phase_event(_Spec(), table)
@@ -233,7 +233,7 @@ def test_both_mint_routes_report_duration_over_real_grpc() -> None:
                         "seal_publish": 39.2}),
             elapsed_s=615.0)
         mint_delegate._emit_jit_compile(
-            outcome, family="sdxl", lane="w8a8", key="ck1-" + "a" * 64,
+            outcome, family="sdxl", execution_lane="w8a8", key="ck1-" + "a" * 64,
             attempt=1)
 
         aot = _wait_for_phases(
@@ -279,7 +279,7 @@ def test_the_producer_warm_loop_reports_its_per_shape_compile_time() -> None:
         conn = sched.wait_connection(0)
         cc.emit_jit_compile_event(
             {"1024x1024": 41.5, "768x768": 12.25},
-            family="sdxl", lane="w8a8", route="compile_and_warm", n_graphs=6)
+            family="sdxl", execution_lane="w8a8", route="compile_and_warm", n_graphs=6)
         jit = _wait_for_phases(
             conn, activity_mod.KIND_JIT_COMPILE,
             {"minted", "shape:1024x1024", "shape:768x768"})
@@ -308,7 +308,7 @@ def test_a_failed_jit_mint_reports_its_cost_but_not_as_minted() -> None:
                 elapsed_s=602.0, phases={"load": 30.0, "warmup_forward": 572.0}),
             exit_code=1, elapsed_s=605.0)
         mint_delegate._emit_jit_compile(
-            outcome, family="sdxl", lane="w8a8", key="ck1-" + "b" * 64,
+            outcome, family="sdxl", execution_lane="w8a8", key="ck1-" + "b" * 64,
             attempt=2)
         jit = _wait_for_phases(
             conn, activity_mod.KIND_JIT_COMPILE,
@@ -328,7 +328,7 @@ def test_a_child_that_died_before_reporting_still_costs_measured_time() -> None:
         mint_delegate._emit_jit_compile(
             mint_process.MintOutcome(
                 status=mint_process.CRASHED, report=None, elapsed_s=7.5),
-            family="sdxl", lane="", key="ck1-" + "c" * 64, attempt=1)
+            family="sdxl", execution_lane="", key="ck1-" + "c" * 64, attempt=1)
         jit = _wait_for_phases(conn, activity_mod.KIND_JIT_COMPILE, {"aborted"})
 
     assert jit["aborted"].duration_ms == 7_500
@@ -344,11 +344,11 @@ def test_telemetry_never_fails_the_compile_it_measures() -> None:
         family = "sdxl"
 
         @staticmethod
-        def lane_label() -> str:
+        def execution_lane_label() -> str:
             raise RuntimeError("boom")
 
     aot_mint._emit_phase_event(_Exploding(), {"totals": {"total_s": 1.0}})
     cc.emit_jit_compile_event({"a": "not-a-number"}, family="sdxl")  # type: ignore[dict-item]
     mint_delegate._emit_jit_compile(
         mint_process.MintOutcome(status=mint_process.MINTED, report=None),
-        family="sdxl", lane="", key="k", attempt=1)
+        family="sdxl", execution_lane="", key="k", attempt=1)

--- a/tests/test_compute_dtype_uniformity_pgw683.py
+++ b/tests/test_compute_dtype_uniformity_pgw683.py
@@ -145,7 +145,7 @@ def test_the_two_flavors_really_do_compute_at_different_dtypes(
     assert composition_compute_dtype(w8a8, "") == "bf16"
 
 
-def test_effective_dtype_identity_separates_the_lanes(tmp_path: Path) -> None:
+def test_effective_dtype_identity_separates_the_execution_lanes(tmp_path: Path) -> None:
     """GREEN: keyed on the EFFECTIVE compute dtype — what the executor passes
     now — the same bytes under two lanes are two entries, so a bf16
     composition can never be handed the fp16 lane's module."""
@@ -291,11 +291,11 @@ def test_invariant_admits_every_legal_composition() -> None:
     assert_uniform_compute_dtype(
         _Pipe(unet=_linear_stack(torch.bfloat16),
               vae=_linear_stack(torch.float32)), "bf16")
-    fp8_lane = _linear_stack(torch.bfloat16)
-    for leaf in fp8_lane:
+    fp8_execution_lane = _linear_stack(torch.bfloat16)
+    for leaf in fp8_execution_lane:
         if isinstance(leaf, torch.nn.Linear):
             leaf.weight.data = leaf.weight.data.to(torch.float8_e4m3fn)
-    assert_uniform_compute_dtype(_Pipe(unet=fp8_lane), "bf16")
+    assert_uniform_compute_dtype(_Pipe(unet=fp8_execution_lane), "bf16")
     assert_uniform_compute_dtype(_linear_stack(torch.bfloat16), "bf16")
     # No compute-dtype opinion (an fp32-defaulting composition) never refuses
     # on the second verdict.

--- a/tests/test_cxx_toolchain_pgw823.py
+++ b/tests/test_cxx_toolchain_pgw823.py
@@ -147,7 +147,7 @@ def test_the_child_refuses_the_AOT_recipe_before_reading_weights(
     req = types.SimpleNamespace(
         snapshots={}, component_paths={}, recipe=mint_child.RECIPE_AOT,
         target="/tmp/x", capture="/tmp/y", device=0, vram_cap_bytes=0,
-        modules=[], function="generate", cfg=None, configs={}, lane="",
+        modules=[], function="generate", cfg=None, configs={}, execution_lane="",
         report="/tmp/r", cell_key="")
     with pytest.raises(mint_child.MintChildRefused, match="no C\\+\\+ compiler"):
         mint_child.mint(req)
@@ -176,7 +176,7 @@ def test_the_dynamo_recipe_is_NOT_refused_by_the_cxx_gate(
     req = types.SimpleNamespace(
         snapshots={}, component_paths={}, recipe=mint_child.RECIPE_DYNAMO,
         target="/tmp/x", capture="/tmp/y", device=0, vram_cap_bytes=0,
-        modules=[], function="generate", cfg=None, configs={}, lane="",
+        modules=[], function="generate", cfg=None, configs={}, execution_lane="",
         report="/tmp/r", cell_key="")
     with pytest.raises(RuntimeError, match="reached discovery"):
         mint_child.mint(req)

--- a/tests/test_declaration_cannot_break_serving_pgw853.py
+++ b/tests/test_declaration_cannot_break_serving_pgw853.py
@@ -251,8 +251,8 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
     monkeypatch.setattr(fleet_cells.cc, "delivered_cell_seeded", lambda: False)
-    monkeypatch.setattr(fleet_cells.cc, "apply_lora_lane", lambda p, b: None)
-    monkeypatch.setattr(fleet_cells.cc, "drop_lora_lane", lambda p: None)
+    monkeypatch.setattr(fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
+    monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
     monkeypatch.setattr(

--- a/tests/test_declared_lane_th1050.py
+++ b/tests/test_declared_lane_th1050.py
@@ -43,7 +43,7 @@ def test_manifest_emits_handles_block() -> None:
     assert all("handles" not in f for f in plain)
 
 
-def test_declared_lane_executes_and_ctx_lane_reports_it() -> None:
+def test_declared_execution_lane_executes_and_ctx_execution_lane_reports_it() -> None:
     with hub_double() as (scheduler, _harness):
         conn = scheduler.wait_connection(0)
         conn.wait_for(is_ready)
@@ -72,7 +72,7 @@ def test_undeclared_dispatch_is_todays_behavior() -> None:
         assert res.metrics.lane == "bf16-w16a16+eager"
 
 
-def test_unhandled_lane_still_refuses_typed() -> None:
+def test_unhandled_execution_lane_still_refuses_typed() -> None:
     with hub_double() as (scheduler, _harness):
         conn = scheduler.wait_connection(0)
         conn.wait_for(is_ready)

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -407,7 +407,7 @@ def test_failed_background_compile_stays_eager_and_reports_typed_failure(
     asyncio.run(_run())
 
 
-def test_mandatory_quantized_lane_keeps_the_sequential_gate(
+def test_mandatory_quantized_execution_lane_keeps_the_sequential_gate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """gw#586: eager is not a production lane for w8a8 — the boot must keep

--- a/tests/test_entry_device_bank_pgw877.py
+++ b/tests/test_entry_device_bank_pgw877.py
@@ -88,17 +88,17 @@ def test_a_measured_child_peak_BELOW_the_estimate_narrows_the_ask(
     child provably holds.
     """
     monkeypatch.setattr(mint_budget, "_CHILD_PEAKS", {})
-    fam, lane = "pgw877-narrow", "w8a8"
+    fam, execution_lane = "pgw877-narrow", "w8a8"
     # 8 GiB resident, a 9 GiB high-water -> activation floor is the 0.25 guess
     # (2 GiB) since measured (1 GiB) is smaller. Estimate = 8 + 2 + 4 + 1 = 15.
     _fake_card(monkeypatch, total_gib=80, resident_gib=8, peak_gib=9)
-    estimated = mint_budget.co_residency(0, family=fam, weight_lane=lane)
+    estimated = mint_budget.co_residency(0, family=fam, weight_lane=execution_lane)
     assert estimated.need_bytes == pytest.approx(15 * _GIB, rel=0.01), (
         f"{estimated.need_bytes / _GIB:.2f} GiB")
 
     # The child then actually ran and peaked at 10 GiB — BELOW the estimate.
-    mint_budget.record_child_peak(fam, lane, 10 * _GIB)
-    measured = mint_budget.co_residency(0, family=fam, weight_lane=lane)
+    mint_budget.record_child_peak(fam, execution_lane, 10 * _GIB)
+    measured = mint_budget.co_residency(0, family=fam, weight_lane=execution_lane)
     assert measured.need_bytes == pytest.approx(11 * _GIB, rel=0.01), (
         f"the measurement must replace the guesses it measured, not be maxed "
         f"against them: {measured.need_bytes / _GIB:.2f} GiB")
@@ -119,10 +119,10 @@ def test_a_measurement_may_never_narrow_below_a_weight_copy_and_a_context(
     fraction and the workspace are the guesses. Only the guesses may go.
     """
     monkeypatch.setattr(mint_budget, "_CHILD_PEAKS", {})
-    fam, lane = "pgw877-floor", "w8a8"
+    fam, execution_lane = "pgw877-floor", "w8a8"
     _fake_card(monkeypatch, total_gib=80, resident_gib=8, peak_gib=9)
-    mint_budget.record_child_peak(fam, lane, 1 * _GIB)   # died at load
-    budget = mint_budget.co_residency(0, family=fam, weight_lane=lane)
+    mint_budget.record_child_peak(fam, execution_lane, 1 * _GIB)   # died at load
+    budget = mint_budget.co_residency(0, family=fam, weight_lane=execution_lane)
     assert budget.need_bytes == pytest.approx(9 * _GIB, rel=0.01), (
         f"floor is resident + context, not the dead child's peak: "
         f"{budget.need_bytes / _GIB:.2f} GiB")
@@ -134,10 +134,10 @@ def test_the_write_side_ratchet_is_the_one_that_keeps_the_ask_honest(
     """Narrowing at the READ must not weaken monotonicity at the WRITE: a
     lucky run still cannot talk the ask down."""
     monkeypatch.setattr(mint_budget, "_CHILD_PEAKS", {})
-    fam, lane = "pgw877-monotone", "w8a8"
-    mint_budget.record_child_peak(fam, lane, 30 * _GIB)
-    mint_budget.record_child_peak(fam, lane, 2 * _GIB)
-    assert mint_budget.child_peak(fam, lane) == 30 * _GIB
+    fam, execution_lane = "pgw877-monotone", "w8a8"
+    mint_budget.record_child_peak(fam, execution_lane, 30 * _GIB)
+    mint_budget.record_child_peak(fam, execution_lane, 2 * _GIB)
+    assert mint_budget.child_peak(fam, execution_lane) == 30 * _GIB
 
 
 # --------------------------------------------------------------- part 2 (#2)
@@ -193,12 +193,12 @@ def test_the_entry_device_bank_is_keyed_monotone_and_narrows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(mint_budget, "_ENTRY_DEVICE_PEAKS", {})
-    fam, lane = "pgw877-entry", "w8a8"
-    assert mint_budget.entry_device_peak(fam, lane) == 0
-    mint_budget.record_entry_device_peak(fam, lane, 5 * _GIB)
-    assert mint_budget.entry_device_peak(fam, lane) == 5 * _GIB
-    mint_budget.record_entry_device_peak(fam, lane, 2 * _GIB)
-    assert mint_budget.entry_device_peak(fam, lane) == 5 * _GIB
+    fam, execution_lane = "pgw877-entry", "w8a8"
+    assert mint_budget.entry_device_peak(fam, execution_lane) == 0
+    mint_budget.record_entry_device_peak(fam, execution_lane, 5 * _GIB)
+    assert mint_budget.entry_device_peak(fam, execution_lane) == 5 * _GIB
+    mint_budget.record_entry_device_peak(fam, execution_lane, 2 * _GIB)
+    assert mint_budget.entry_device_peak(fam, execution_lane) == 5 * _GIB
     assert mint_budget.entry_device_peak(fam, "plain") == 0
     # The ask adds a CUDA context: the peak is the ALLOCATOR's high-water and
     # a context lives outside the allocator.

--- a/tests/test_error_visibility_pgw760.py
+++ b/tests/test_error_visibility_pgw760.py
@@ -23,7 +23,7 @@ import pytest
 
 from gen_worker import activity, capability_renewal, hot_swap, preload, trt_engine
 from gen_worker.compile_cache import AdoptError
-from gen_worker.models import lane_gate, residency
+from gen_worker.models import execution_lane_gate, residency
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.utils import lora
 
@@ -274,13 +274,13 @@ class _SlotsPipe:
         pass
 
 
-def test_lane_gate_wrap_failure_rides_typed_event(events: List[Any]) -> None:
-    gate = lane_gate.LaneGate(
+def test_execution_lane_gate_wrap_failure_rides_typed_event(events: List[Any]) -> None:
+    gate = execution_lane_gate.ExecutionLaneGate(
         ref="ref-c", residency=object(), label="lane-c")  # type: ignore[arg-type]
     pipe = _SlotsPipe()
     # __class__ assignment onto a __dict__-bearing subclass of a __slots__
     # class fails with a layout TypeError — the wrap's failure mode.
-    assert lane_gate.arm_lane_gate(pipe, gate) is False
+    assert execution_lane_gate.arm_execution_lane_gate(pipe, gate) is False
 
     got = _by_kind(events, activity.KIND_SERVE_DEGRADE)
     assert [e.phase for e in got] == ["lane_gate_unarmed"]

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -838,13 +838,13 @@ def test_same_family_base_and_lora_targets_remain_distinct(tmp_path):
         return None
 
     ex = Executor([base, turbo], _send)
-    for spec, lane, digest in (
+    for spec, execution_lane, digest in (
         (base, "w8a8", MODEL_DIGEST),
         (turbo, "w8a8-lora128", DIGEST_B),
     ):
         rec = ex._classes[spec.instance_key]
         pipe = _Pipe()
-        setattr(pipe, "_cozy_weight_lane", lane)
+        setattr(pipe, "_cozy_weight_lane", execution_lane)
         rec.instance = spec.cls()
         rec.ready = True
         ref = wire_ref(spec.models["pipeline"])
@@ -1445,7 +1445,7 @@ def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
         fleet_cells._PENDING.clear()
 
     def _mandatory_miss(*a, **k):
-        raise cc.CompiledLaneUnavailableError("no delivered cell")
+        raise cc.CompiledExecutionLaneUnavailableError("no delivered cell")
 
     monkeypatch.setattr(provision, "enable_compiled", _mandatory_miss)
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
@@ -2396,7 +2396,7 @@ def test_w8a8_without_exact_cell_self_mints_and_fails_typed_without_cuda(
     )
     _ColdEndpoint.setups = _ColdEndpoint.warmups = _ColdEndpoint.runs = 0
 
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="self-mint is unavailable"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="self-mint is unavailable"):
         asyncio.run(ex.ensure_setup(
             spec, {model_ref: pb.Snapshot(digest=MODEL_DIGEST)}))
     # The load is the mint's precondition now (the boot warmup IS the mint).
@@ -2560,7 +2560,7 @@ def test_w8a8_custom_warmup_multi_alias_boot_serves_all_siblings(
     assert not ex.unavailable
 
 
-def _merged_lane_endpoint(record_warm):
+def _merged_execution_lane_endpoint(record_warm):
     """Two w8a8 lane pipes behind ONE handler (the qwen merged shape): the
     declared warmup can only exercise the t2i lane — edit needs an input
     image, so its object has no warmup modality by design (gw#595)."""
@@ -2585,7 +2585,7 @@ def _merged_lane_endpoint(record_warm):
     return _MergedEndpoint
 
 
-def _wire_merged_lane(ex_cls_specs, tmp_path, monkeypatch):
+def _wire_merged_execution_lane(ex_cls_specs, tmp_path, monkeypatch):
     import gen_worker.executor as executor_mod
 
     family = "qwen-image"
@@ -2623,10 +2623,10 @@ def test_w8a8_unexercised_sibling_stays_armed_unproven(
     """gw#595(b): an armed MANDATORY-lane object the warmup has no modality
     to exercise must not block adoption by the sibling that proves; it stays
     armed unproven and is logged explicitly."""
-    cls = _merged_lane_endpoint(lambda self: _record_fake_warm(self.t2i))
+    cls = _merged_execution_lane_endpoint(lambda self: _record_fake_warm(self.t2i))
     specs = extract_specs(cls)
     (generate,) = specs
-    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+    ex, pipes, cell_ref = _wire_merged_execution_lane(specs, tmp_path, monkeypatch)
 
     with caplog.at_level("WARNING"):
         asyncio.run(ex.ensure_setup(generate, {
@@ -2652,11 +2652,11 @@ def test_w8a8_exercised_miss_degrades_despite_unexercised_sibling(
     warmup graph disproves the cell — the unexercised sibling exemption
     never launders a genuine parity defect. pgw#672: the disproof now
     degrades to explicit eager instead of killing the boot."""
-    cls = _merged_lane_endpoint(
+    cls = _merged_execution_lane_endpoint(
         lambda self: _record_fake_warm(self.t2i, hits=0, misses=2))
     specs = extract_specs(cls)
     (generate,) = specs
-    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+    ex, pipes, cell_ref = _wire_merged_execution_lane(specs, tmp_path, monkeypatch)
 
     # pgw#672: the disproven proof DEGRADES to explicit eager — setup
     # completes, nothing is advertised, and the gw#608 self-discriminating
@@ -2685,11 +2685,11 @@ def test_store_served_failure_names_diverging_fx_key_component(
     boot's freshly saved FX entries against the seeded cell's and puts the
     diverging FxGraphHashDetails component in the CompiledLaneUnavailable
     detail. Revert the executor wiring and this goes red."""
-    cls = _merged_lane_endpoint(
+    cls = _merged_execution_lane_endpoint(
         lambda self: _record_fake_warm(self.t2i, hits=0, misses=2))
     specs = extract_specs(cls)
     (generate,) = specs
-    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+    ex, pipes, cell_ref = _wire_merged_execution_lane(specs, tmp_path, monkeypatch)
 
     monkeypatch.setattr(
         cc, "fx_cache_failure_report",
@@ -2718,10 +2718,10 @@ def test_w8a8_all_objects_unexercised_degrades_to_eager(tmp_path, monkeypatch):
     """gw#595(b): with ZERO proven objects the cell is entirely unverified —
     a warmup that exercises nothing cannot arm anything. pgw#672: the boot
     completes at explicit eager instead of failing closed."""
-    cls = _merged_lane_endpoint(lambda self: None)
+    cls = _merged_execution_lane_endpoint(lambda self: None)
     specs = extract_specs(cls)
     (generate,) = specs
-    ex, pipes, cell_ref = _wire_merged_lane(specs, tmp_path, monkeypatch)
+    ex, pipes, cell_ref = _wire_merged_execution_lane(specs, tmp_path, monkeypatch)
 
     asyncio.run(ex.ensure_setup(generate, {
         wire_ref(generate.models["t2i"]): pb.Snapshot(digest=MODEL_DIGEST),
@@ -2773,7 +2773,7 @@ def test_production_w8a8_ignores_legacy_compile_environment_fallbacks(
     # local/producer env cells (if the env were honored this would arm and
     # succeed); in a CUDA-less env the typed quantized refusal fires from
     # the self-mint exit.
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="self-mint is unavailable"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="self-mint is unavailable"):
         asyncio.run(ex.ensure_desired_instance(
             desired, {model_ref: snapshot},
         ))
@@ -2812,7 +2812,7 @@ def test_w8a8_binding_cannot_advertise_plain_materialized_pipeline(tmp_path):
         "snapshot_digest": DIGEST_A,
         "path": tmp_path / "cell.tar.gz",
     })()
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="materialized pipeline lane"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="materialized pipeline lane"):
         ex._install_compile_targets(
             rec, spec, [pipe], {id(pipe): selection}, {id(pipe): {spec.name}},
         )
@@ -3675,11 +3675,11 @@ def test_fetch_compile_snapshot_finds_family_cache_and_ignores_others(tmp_path):
     assert asyncio.run(ex._fetch_compile_snapshot(spec, None)) is None
 
 
-@pytest.mark.parametrize("lane", ["w8a8", "plain"])
-def test_fetch_compile_snapshot_selects_exact_lane(tmp_path, lane):
+@pytest.mark.parametrize("execution_lane", ["w8a8", "plain"])
+def test_fetch_compile_snapshot_selects_exact_execution_lane(tmp_path, execution_lane):
     """The spec's weight lane picks exactly its own cell — w8a8 specs take
     the -w8a8 cell, plain specs ignore it — and only that cell is fetched."""
-    if lane == "w8a8":
+    if execution_lane == "w8a8":
         spec = replace(
             _spec(), models={"pipeline": Hub(
                 "acme/klein-finetune", flavor="fp8-w8a8")},
@@ -3711,7 +3711,7 @@ def test_fetch_compile_snapshot_selects_exact_lane(tmp_path, lane):
     }
     got = asyncio.run(ex._fetch_compile_snapshot(spec, snapshots))
     assert got is not None
-    if lane == "w8a8":
+    if execution_lane == "w8a8":
         assert got.path == w8a8 / "w8a8.tar.gz"
         assert got.ref == w8a8_ref and got.snapshot_digest == DIGEST_B
         assert seen == [w8a8_ref]
@@ -3828,8 +3828,8 @@ def test_fresh_boot_advertises_candidate_cell_lookups(monkeypatch):
     class _Key:
         digest = "ck5-" + "5" * 56
 
-    def _compute(family, lane="", bucket=0, **kw):
-        computed.append((family, lane))
+    def _compute(family, execution_lane="", bucket=0, **kw):
+        computed.append((family, execution_lane))
         return _Key()
 
     monkeypatch.setattr(cell_key_mod, "compute", _compute)
@@ -3925,7 +3925,7 @@ def _dual_mint_boot(tmp_path, monkeypatch, *, publisher, warm_second: bool):
     return ex, spec, pipes, mint_key, snapshots
 
 
-def test_two_lane_mint_with_unexercised_sibling_completes_and_withholds_publish(
+def test_two_execution_lane_mint_with_unexercised_sibling_completes_and_withholds_publish(
     tmp_path, monkeypatch, caplog,
 ):
     """gw#612 regression, the ie#501 run-26 qwen shape: a two-lane
@@ -3986,7 +3986,7 @@ def test_two_lane_mint_with_unexercised_sibling_completes_and_withholds_publish(
         assert fleet_cells._PENDING == {}
 
 
-def test_two_lane_mint_fully_exercised_publishes_the_union_cell(
+def test_two_execution_lane_mint_fully_exercised_publishes_the_union_cell(
     tmp_path, monkeypatch,
 ):
     """Coverage-complete counterpart: when the warmup exercises BOTH lanes,
@@ -4134,7 +4134,7 @@ def _routed_mint_boot(tmp_path, monkeypatch, *, publisher):
     return ex, spec, pipes, _RoutedMerged, snapshots
 
 
-def test_routed_two_lane_mint_synthesized_media_coverage_publishes_union(
+def test_routed_two_execution_lane_mint_synthesized_media_coverage_publishes_union(
     tmp_path, monkeypatch, caplog,
 ):
     """gw#614 red-first: the declared warmup carries no media, so pre-fix the

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -182,7 +182,7 @@ def test_cell_selection_bug_still_fail_closed_when_mint_impossible(
 
     monkeypatch.setattr(
         "gen_worker.models.loading.pipeline_weight_lane", lambda pipe: "w8a8")
-    with pytest.raises(cc.CompiledLaneUnavailableError) as exc:
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError) as exc:
         fc.enable_compiled(
             _W8A8Pipe(), _Cfg(), tmp_path, None, publisher=_publisher([]))
     assert isinstance(exc.value.__cause__, cc.CellSelectionBugError)
@@ -374,7 +374,7 @@ def test_mint_impossible_keeps_quantized_typed_refusal(monkeypatch, tmp_path):
     setattr(w8a8, "_cozy_weight_lane", "w8a8")
     monkeypatch.setattr(
         "gen_worker.models.loading.pipeline_weight_lane", lambda p: "w8a8")
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="self-mint is unavailable"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="self-mint is unavailable"):
         fc.enable_compiled(w8a8, _Cfg(), tmp_path, None, publisher=None)
 
 
@@ -620,10 +620,10 @@ def test_delivered_seed_declines_later_self_mint(tmp_path, monkeypatch):
     assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(seeded)
 
 
-def test_delivered_seed_mandatory_lane_keeps_typed_refusal(tmp_path, monkeypatch):
+def test_delivered_seed_mandatory_execution_lane_keeps_typed_refusal(tmp_path, monkeypatch):
     _mintable(monkeypatch)
     monkeypatch.setattr(cc, "_DELIVERED_SEEDED", True)
     pipe = _Pipe()
     pipe._cozy_weight_lane = "w8a8"
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="delivered cell"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="delivered cell"):
         fc.enable_compiled(pipe, _Cfg(), tmp_path, None)

--- a/tests/test_fp8_storage_pgw727.py
+++ b/tests/test_fp8_storage_pgw727.py
@@ -70,7 +70,7 @@ class _Pipe:
         self.unet = unet
 
 
-def _hook_lane(unet: Any) -> List[str]:
+def _hook_execution_lane(unet: Any) -> List[str]:
     """Arm diffusers' layerwise casting (the lane as it shipped) and return
     the leaf paths it hooked."""
     unet.enable_layerwise_casting(storage_dtype=STORAGE, compute_dtype=COMPUTE)
@@ -102,11 +102,11 @@ def _nn_hook_count(module: Any) -> int:
 
 
 @pytest.fixture(scope="module")
-def lanes() -> Dict[str, Any]:
+def execution_lanes() -> Dict[str, Any]:
     """One hook-lane UNet and one restructured UNet from identical weights."""
     hooked = _tiny_unet()
     restructured = copy.deepcopy(hooked)
-    hooked_paths = _hook_lane(hooked)
+    hooked_paths = _hook_execution_lane(hooked)
     pipe = _Pipe(restructured)
     applied = apply_fp8_storage(pipe, compute_dtype=COMPUTE)
     assert applied is True
@@ -118,31 +118,31 @@ def lanes() -> Dict[str, Any]:
     }
 
 
-def test_hook_lane_has_hooks_restructured_lane_has_none(lanes: Dict[str, Any]) -> None:
-    assert len(lanes["hooked_paths"]) > 50, "the hook lane must actually hook"
-    assert _nn_hook_count(lanes["hooked"]) >= len(lanes["hooked_paths"])
-    assert _nn_hook_count(lanes["restructured"]) == 0
+def test_hook_execution_lane_has_hooks_restructured_execution_lane_has_none(execution_lanes: Dict[str, Any]) -> None:
+    assert len(execution_lanes["hooked_paths"]) > 50, "the hook lane must actually hook"
+    assert _nn_hook_count(execution_lanes["hooked"]) >= len(execution_lanes["hooked_paths"])
+    assert _nn_hook_count(execution_lanes["restructured"]) == 0
     assert not any(
-        "forward" in m.__dict__ for m in lanes["restructured"].modules()
+        "forward" in m.__dict__ for m in execution_lanes["restructured"].modules()
     ), "no instance-forward shadowing: the punned class owns forward"
 
 
-def test_coverage_matches_diffusers_own_rule(lanes: Dict[str, Any]) -> None:
+def test_coverage_matches_diffusers_own_rule(execution_lanes: Dict[str, Any]) -> None:
     """Anti-drift: our mirrored selection rule and the installed diffusers'
     rule must name the SAME leaves. If upstream changes its supported-layer
     set or default skip patterns, this fails here instead of on a pod."""
-    restructured = lanes["restructured"]
+    restructured = execution_lanes["restructured"]
     covered = sorted(fp8_storage.fp8_storage_leaves(restructured))
-    assert covered == sorted(lanes["hooked_paths"])
-    assert covered == sorted(fp8_storage.castable_leaves(lanes["hooked"]))
+    assert covered == sorted(execution_lanes["hooked_paths"])
+    assert covered == sorted(fp8_storage.castable_leaves(execution_lanes["hooked"]))
 
 
-def test_weights_reside_in_fp8_and_round_trip(lanes: Dict[str, Any]) -> None:
+def test_weights_reside_in_fp8_and_round_trip(execution_lanes: Dict[str, Any]) -> None:
     """Storage really is fp8, upcast really is the compute dtype, and the
     quantized values are the same bytes the hook lane holds."""
-    hooked, restructured = lanes["hooked"], lanes["restructured"]
+    hooked, restructured = execution_lanes["hooked"], execution_lanes["restructured"]
     checked = 0
-    for path in lanes["hooked_paths"]:
+    for path in execution_lanes["hooked_paths"]:
         a = hooked.get_submodule(path)
         b = restructured.get_submodule(path)
         assert b.weight.dtype is STORAGE
@@ -153,14 +153,14 @@ def test_weights_reside_in_fp8_and_round_trip(lanes: Dict[str, Any]) -> None:
             assert b.bias.dtype is STORAGE
             assert torch.equal(a.bias.to(COMPUTE), b.bias.to(COMPUTE))
         checked += 1
-    assert checked == len(lanes["hooked_paths"])
+    assert checked == len(execution_lanes["hooked_paths"])
 
 
-def test_outputs_are_bitwise_equal_to_the_hook_lane(lanes: Dict[str, Any]) -> None:
+def test_outputs_are_bitwise_equal_to_the_hook_execution_lane(execution_lanes: Dict[str, Any]) -> None:
     x, t, enc = _inputs()
     with torch.no_grad():
-        want = lanes["hooked"](x, t, enc).sample
-        have = lanes["restructured"](x, t, enc).sample
+        want = execution_lanes["hooked"](x, t, enc).sample
+        have = execution_lanes["restructured"](x, t, enc).sample
     assert torch.equal(want, have)
 
 
@@ -234,11 +234,11 @@ def test_no_bf16_original_survives_an_external_holder() -> None:
     assert after.get(str(COMPUTE), 0) <= skipped_bytes
 
 
-def test_restructured_lane_exports_and_the_hook_lane_is_refused(
-    lanes: Dict[str, Any],
+def test_restructured_execution_lane_exports_and_the_hook_execution_lane_is_refused(
+    execution_lanes: Dict[str, Any],
 ) -> None:
     args = _inputs()
-    exported = torch.export.export(lanes["restructured"], args, strict=False)
+    exported = torch.export.export(execution_lanes["restructured"], args, strict=False)
     nodes = list(exported.graph_module.graph.nodes)
     fp8_valued = sum(
         1 for n in nodes
@@ -246,19 +246,19 @@ def test_restructured_lane_exports_and_the_hook_lane_is_refused(
     )
     assert fp8_valued > 0, "the resident fp8 buffers must be visible in the graph"
     with pytest.raises(RuntimeError, match="Couldn't swap"):
-        torch.export.export(lanes["hooked"], args, strict=False)
+        torch.export.export(execution_lanes["hooked"], args, strict=False)
 
 
-def test_lane_value_kept_and_graph_contract_changed(lanes: Dict[str, Any]) -> None:
+def test_execution_lane_value_kept_and_graph_contract_changed(execution_lanes: Dict[str, Any]) -> None:
     """The wire lane value is unchanged ("fp8-hooks" — tensorhub maps it to
     w8a16); the traced graph is NOT, and the execution contract says so."""
     from gen_worker.compile_cache import execution_contract
 
-    pipe = lanes["pipe"]
+    pipe = execution_lanes["pipe"]
     assert pipe.unet._cozy_fp8_storage_applied is True
     assert pipeline_weight_lane(pipe) == "fp8-hooks"
 
-    hooked_pipe = _Pipe(lanes["hooked"])
+    hooked_pipe = _Pipe(execution_lanes["hooked"])
     hooked_pipe.unet._cozy_fp8_storage_applied = True
 
     class _Cfg:
@@ -280,7 +280,7 @@ def test_idempotent_and_refuses_to_compose_with_hooks() -> None:
     assert apply_fp8_storage(_Pipe(unet), compute_dtype=COMPUTE) is True
 
     hooked = _tiny_unet()
-    _hook_lane(hooked)
+    _hook_execution_lane(hooked)
     with pytest.raises(ValueError, match="already armed"):
         fp8_storage.restructure_fp8_storage(
             hooked, storage_dtype=STORAGE, compute_dtype=COMPUTE)
@@ -337,30 +337,30 @@ def test_fp8_storage_leaf_is_a_lora_branch_target() -> None:
     assert getattr(target, "lora_a", None) is None
 
 
-def test_model_dtype_still_reports_the_compute_dtype(lanes: Dict[str, Any]) -> None:
+def test_model_dtype_still_reports_the_compute_dtype(execution_lanes: Dict[str, Any]) -> None:
     """The defect this lane found (measured, CPU): diffusers resolves
     ``ModelMixin.dtype`` from the first floating-point PARAMETER, special-casing
     an armed layerwise-cast hook to return its ``compute_dtype``. Drop the hook
     and leave fp8 PARAMETERS and ``model.dtype`` starts answering fp8 — which
     silently breaks every denoiser that casts to ``self.dtype`` inside forward.
     fp8 storage therefore lives in BUFFERS."""
-    assert lanes["hooked"].dtype is COMPUTE  # upstream's answer
-    assert lanes["restructured"].dtype is COMPUTE  # ours must match it
-    for leaf in fp8_storage.fp8_storage_leaves(lanes["restructured"]).values():
+    assert execution_lanes["hooked"].dtype is COMPUTE  # upstream's answer
+    assert execution_lanes["restructured"].dtype is COMPUTE  # ours must match it
+    for leaf in fp8_storage.fp8_storage_leaves(execution_lanes["restructured"]).values():
         assert "weight" in leaf._buffers and "weight" not in leaf._parameters
         assert all(p.dtype is COMPUTE for p in leaf.parameters())
 
 
 def test_state_dict_keys_and_module_identity_are_preserved(
-    lanes: Dict[str, Any],
+    execution_lanes: Dict[str, Any],
 ) -> None:
     """A class pun, not a module replacement: same FQNs, same state_dict keys,
     same objects — so the offload rung, LoRA branch and every held reference
     keep working."""
     plain = _tiny_unet()
-    assert sorted(plain.state_dict()) == sorted(lanes["restructured"].state_dict())
-    for path in lanes["hooked_paths"]:
-        leaf = lanes["restructured"].get_submodule(path)
+    assert sorted(plain.state_dict()) == sorted(execution_lanes["restructured"].state_dict())
+    for path in execution_lanes["hooked_paths"]:
+        leaf = execution_lanes["restructured"].get_submodule(path)
         assert isinstance(leaf, type(plain.get_submodule(path)))
 
 
@@ -377,7 +377,7 @@ def test_a_denoiser_that_casts_to_self_dtype_runs_and_matches() -> None:
         up_block_types=("AttnUpBlock2D", "UpBlock2D"), norm_num_groups=8,
     ).to(COMPUTE).eval()
     restructured = copy.deepcopy(hooked)
-    hooked_paths = _hook_lane(hooked)
+    hooked_paths = _hook_execution_lane(hooked)
     covered = fp8_storage.restructure_fp8_storage(
         restructured, storage_dtype=STORAGE, compute_dtype=COMPUTE)
     assert sorted(covered) == sorted(hooked_paths)

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -512,7 +512,7 @@ class _Rig:
             return provision.SlotLoad(obj=pipe, is_pipeline=True)
 
         def _mandatory_miss(*a: Any, **k: Any) -> bool:
-            raise cc.CompiledLaneUnavailableError("no delivered cell")
+            raise cc.CompiledExecutionLaneUnavailableError("no delivered cell")
 
         monkeypatch.setattr(executor_mod, "ensure_local", _download)
         monkeypatch.setattr(provision, "load_slot", _load_slot)

--- a/tests/test_hot_swap_pgw622.py
+++ b/tests/test_hot_swap_pgw622.py
@@ -167,7 +167,7 @@ def test_prewarmed_signature_short_circuits():
     assert not router.pending
 
 
-def test_fail_closed_lane_never_enables():
+def test_fail_closed_execution_lane_never_enables():
     router = hot_swap.Router(fail_closed=True)
     assert not router.enable()
     wrapper = _wrapper(lambda x: "eager", lambda x: "compiled", router)

--- a/tests/test_kernel_lane_pgw947.py
+++ b/tests/test_kernel_lane_pgw947.py
@@ -21,15 +21,15 @@ from pathlib import Path
 
 import pytest
 
-from gen_worker import kernel_lane as kl
+from gen_worker import kernel_path as kl
 
 GB = 1000 ** 3  # the benchmark tables are in decimal GB
 GiB = 1 << 30
 
 
-def _m(lane: str, ms: float, peak_gb: float) -> kl.Measurement:
+def _m(execution_lane: str, ms: float, peak_gb: float) -> kl.Measurement:
     return kl.Measurement(
-        lane=lane, ms_per_step=ms, peak_bytes=int(peak_gb * GB),
+        execution_lane=execution_lane, ms_per_step=ms, peak_bytes=int(peak_gb * GB),
         samples_ms=(ms,))
 
 
@@ -52,7 +52,7 @@ def _clear_pin():
 # --- the rule --------------------------------------------------------------
 
 
-def test_fastest_that_fits_wins_even_when_it_is_the_larger_lane() -> None:
+def test_fastest_that_fits_wins_even_when_it_is_the_larger_execution_lane() -> None:
     """(a) Speed is the objective. B200 shape: the baseline lane is 9.5 GB
     BIGGER and 35% faster, and the card has the room — so it wins."""
     verdict = kl.select(
@@ -63,7 +63,7 @@ def test_fastest_that_fits_wins_even_when_it_is_the_larger_lane() -> None:
     assert "228.0" in verdict.detail and "350.0" in verdict.detail
 
 
-def test_a_lane_that_does_not_fit_is_excluded_even_when_faster() -> None:
+def test_a_execution_lane_that_does_not_fit_is_excluded_even_when_faster() -> None:
     """(b) Fit is a CONSTRAINT applied before ranking. Same two lanes, on a
     48 GB card: the baseline's 44.1 GB peak plus its allowance cannot fit, so
     the 35%-slower fused lane wins outright."""
@@ -75,7 +75,7 @@ def test_a_lane_that_does_not_fit_is_excluded_even_when_faster() -> None:
     assert "baseline+dense" in verdict.detail
 
 
-def test_headroom_allowance_excludes_a_lane_that_bare_peak_would_admit() -> None:
+def test_headroom_allowance_excludes_a_execution_lane_that_bare_peak_would_admit() -> None:
     """The allowance does real work: a 40 GB peak fits a 44 GB card by bare
     measurement and does NOT fit once the activation-spike + fragmentation
     allowance is applied — which is the point of stating one."""
@@ -85,7 +85,7 @@ def test_headroom_allowance_excludes_a_lane_that_bare_peak_would_admit() -> None
     assert row.required_bytes() == int(40 * GB * 1.20) + GiB
 
 
-def test_within_margin_ties_fall_to_the_smaller_lane() -> None:
+def test_within_margin_ties_fall_to_the_smaller_execution_lane() -> None:
     """(c) VRAM breaks a tie and ONLY a tie. 2% apart is noise, so the
     smaller peak wins; 6% apart is a real win, so speed does."""
     tie = kl.select(
@@ -116,7 +116,7 @@ def test_margin_makes_the_verdict_deterministic_across_mints() -> None:
 def test_unmeasurable_candidate_drops_out_with_its_reason() -> None:
     verdict = kl.select(
         [_m("baseline+dense", 400.0, 20.0),
-         kl.Measurement(lane="fused+packed", unavailable="triton compile failed")],
+         kl.Measurement(execution_lane="fused+packed", unavailable="triton compile failed")],
         device_total_bytes=180 * GB)
     assert verdict.winner == "baseline+dense"
     assert verdict.binding == kl.BIND_SOLE_CANDIDATE
@@ -133,7 +133,7 @@ def test_nothing_fits_names_itself_and_takes_the_smallest() -> None:
 
 def test_nothing_measured_is_the_declared_default() -> None:
     verdict = kl.select([], device_total_bytes=180 * GB)
-    assert verdict.winner == kl.DEFAULT_LANE
+    assert verdict.winner == kl.DEFAULT_EXECUTION_LANE
     assert verdict.binding == kl.BIND_NO_FIT
 
 
@@ -148,19 +148,19 @@ def test_probe_measures_every_candidate_and_a_build_failure_is_not_fatal(
     timings = {"baseline+dense": (250.0, 40 * GB),
                "fused+packed": (300.0, 30 * GB)}
 
-    def _measure(lane: str, step):
+    def _measure(execution_lane: str, step):
         step()
-        ms, peak = timings[lane]
-        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+        ms, peak = timings[execution_lane]
+        return kl.Measurement(execution_lane=execution_lane, ms_per_step=ms, peak_bytes=peak,
                               samples_ms=(ms,))
 
     monkeypatch.setattr(kl, "measure", _measure)
     built = []
 
-    def _build(lane: str):
-        if lane == "fused+dense":
+    def _build(execution_lane: str):
+        if execution_lane == "fused+dense":
             raise RuntimeError("no kernels here")
-        built.append(lane)
+        built.append(execution_lane)
         return lambda: None
 
     verdict = kl.probe(
@@ -236,7 +236,7 @@ def _packed(tmp_path: Path, meta: dict) -> Path:
     return artifact
 
 
-def test_serving_adopts_the_lane_the_cell_names(
+def test_serving_adopts_the_execution_lane_the_cell_names(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
@@ -248,8 +248,8 @@ def test_serving_adopts_the_lane_the_cell_names(
         kl.META_KEY: kl.envelope_block(verdict),
     })
     assert kl.adopt_from_artifact(artifact) == "fused+packed"
-    lane, reason = kl.pinned()
-    assert lane == "fused+packed"
+    execution_lane, reason = kl.pinned()
+    assert execution_lane == "fused+packed"
     assert kl.REASON_ADOPTED in reason
 
 
@@ -259,12 +259,12 @@ def test_cell_without_a_verdict_is_the_default_with_a_typed_reason(
     """(d) A pre-pgw#947 cell records nothing. That is the declared default
     and it SAYS which case it was — never a silent fall-through."""
     artifact = _packed(tmp_path, {"kind": "aot-inductor"})
-    assert kl.adopt_from_artifact(artifact) == kl.DEFAULT_LANE
+    assert kl.adopt_from_artifact(artifact) == kl.DEFAULT_EXECUTION_LANE
     assert kl.REASON_ABSENT in kl.pinned()[1]
 
 
 def test_no_cell_at_all_is_the_default_with_its_own_reason() -> None:
-    assert kl.adopt(None) == kl.DEFAULT_LANE
+    assert kl.adopt(None) == kl.DEFAULT_EXECUTION_LANE
     assert kl.REASON_NO_CELL in kl.pinned()[1]
 
 
@@ -273,19 +273,19 @@ def test_unreadable_artifact_degrades_and_names_the_failure(
 ) -> None:
     junk = tmp_path / "not-a-tar.tar.gz"
     junk.write_bytes(b"definitely not a tarball")
-    assert kl.adopt_from_artifact(junk) == kl.DEFAULT_LANE
+    assert kl.adopt_from_artifact(junk) == kl.DEFAULT_EXECUTION_LANE
     assert kl.REASON_UNREADABLE in kl.pinned()[1]
 
 
-def test_a_lane_this_worker_does_not_implement_is_refused_by_name() -> None:
-    lane, reason = kl.lane_from_metadata(
+def test_a_execution_lane_this_worker_does_not_implement_is_refused_by_name() -> None:
+    execution_lane, reason = kl.execution_lane_from_metadata(
         {kl.META_KEY: {"winner": "tcgen05-v2", "binding": "speed"}})
-    assert lane == kl.DEFAULT_LANE
-    assert kl.REASON_UNKNOWN_LANE in reason
+    assert execution_lane == kl.DEFAULT_EXECUTION_LANE
+    assert kl.REASON_UNKNOWN_EXECUTION_LANE in reason
 
 
-def test_pin_refuses_a_lane_outside_the_vocabulary() -> None:
-    with pytest.raises(kl.LaneProbeError):
+def test_pin_refuses_a_execution_lane_outside_the_vocabulary() -> None:
+    with pytest.raises(kl.ExecutionLaneProbeError):
         kl.pin("made-up", "test")
 
 
@@ -352,8 +352,8 @@ def test_a_verdict_from_a_bigger_card_of_the_same_sm_is_refit_locally(
     _on_card(monkeypatch, 32 * GB, "NVIDIA RTX 5090", "sm_120")
     assert kl.adopt(_minted_on_the_big_card()) == "fused+packed"
 
-    lane, reason = kl.pinned()
-    assert lane == "fused+packed"
+    execution_lane, reason = kl.pinned()
+    assert execution_lane == "fused+packed"
     assert kl.REASON_REFIT_LOCAL in reason
     # It names the recorded winner, this card, and the binding term.
     assert "baseline+dense" in reason
@@ -387,9 +387,9 @@ def test_nothing_fitting_locally_takes_the_smallest_not_the_default(
     _on_card(monkeypatch, 16 * GB, "NVIDIA RTX 5080", "sm_120")
     assert kl.adopt(_minted_on_the_big_card()) == "fused+packed"
 
-    lane, reason = kl.pinned()
+    execution_lane, reason = kl.pinned()
     assert kl.REASON_REFIT_NO_FIT in reason
-    assert lane != kl.DEFAULT_LANE  # the default is the 48 GB lane here
+    assert execution_lane != kl.DEFAULT_EXECUTION_LANE  # the default is the 48 GB lane here
     assert f"binding={kl.BIND_NO_FIT}" in reason
 
 
@@ -539,7 +539,7 @@ def test_the_fallback_order_is_the_ranking_and_the_winner_leads_it() -> None:
                      "fused+packed", "fused+dense")
 
 
-def test_the_refit_never_pins_a_lane_this_worker_cannot_implement(
+def test_the_refit_never_pins_a_execution_lane_this_worker_cannot_implement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A cell from a newer worker may record candidates this one has no
@@ -550,7 +550,7 @@ def test_the_refit_never_pins_a_lane_this_worker_cannot_implement(
     meta[kl.META_KEY]["fit"]["peaks"]["tcgen05-v2"] = 1
     meta[kl.META_KEY]["fit"]["order"].insert(0, "tcgen05-v2")
     assert kl.adopt(meta) == "fused+packed"
-    assert kl.pinned()[0] in kl.LANES
+    assert kl.pinned()[0] in kl.EXECUTION_LANES
 
 
 # --- the mint-side A/B -----------------------------------------------------
@@ -571,10 +571,10 @@ def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
     }
     loads: list[str] = []
 
-    def _load(lane: str):
-        loads.append(lane)
-        assert kl.pinned()[0] == lane, "the lane must be pinned BEFORE loading"
-        return f"pipe:{lane}", f"spec:{lane}"
+    def _load(execution_lane: str):
+        loads.append(execution_lane)
+        assert kl.pinned()[0] == execution_lane, "the lane must be pinned BEFORE loading"
+        return f"pipe:{execution_lane}", f"spec:{execution_lane}"
 
     monkeypatch.setattr(
         kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
@@ -584,15 +584,15 @@ def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
     monkeypatch.setattr(mint_child, "frame", lambda **kw: None)
     monkeypatch.setattr(mint_child, "_release", lambda: None)
 
-    def _measure(lane: str, step):
-        assert step == (f"pipe:{lane}", f"spec:{lane}")
-        ms, peak = timings[lane]
-        return kl.Measurement(lane=lane, ms_per_step=ms, peak_bytes=peak,
+    def _measure(execution_lane: str, step):
+        assert step == (f"pipe:{execution_lane}", f"spec:{execution_lane}")
+        ms, peak = timings[execution_lane]
+        return kl.Measurement(execution_lane=execution_lane, ms_per_step=ms, peak_bytes=peak,
                               samples_ms=(ms,))
 
     monkeypatch.setattr(kl, "measure", _measure)
 
-    verdict, pipe, spec = mint_child.lane_verdict_for(_load)
+    verdict, pipe, spec = mint_child.execution_lane_verdict_for(_load)
     assert verdict.winner == "baseline+dense"
     assert verdict.binding == kl.BIND_SPEED
     assert loads == ["baseline+dense", "fused+packed", "baseline+dense"]
@@ -603,7 +603,7 @@ def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
     assert verdict.measurement("baseline+dense").peak_bytes == int(44.1 * GB)
 
 
-def test_mint_records_a_typed_verdict_when_only_one_lane_can_be_built(
+def test_mint_records_a_typed_verdict_when_only_one_execution_lane_can_be_built(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A card with no rival lane gets a real verdict, not an absence — and
@@ -621,8 +621,8 @@ def test_mint_records_a_typed_verdict_when_only_one_lane_can_be_built(
         kl, "measure",
         lambda *a: pytest.fail("no benchmark for a sole candidate"))
 
-    verdict, pipe, _spec = mint_child.lane_verdict_for(
-        lambda lane: (f"pipe:{lane}", f"spec:{lane}"))
+    verdict, pipe, _spec = mint_child.execution_lane_verdict_for(
+        lambda execution_lane: (f"pipe:{execution_lane}", f"spec:{execution_lane}"))
     assert verdict.winner == "baseline+dense"
     assert verdict.binding == kl.BIND_SOLE_CANDIDATE
     assert "sm_89 is not Blackwell" in verdict.detail
@@ -630,15 +630,15 @@ def test_mint_records_a_typed_verdict_when_only_one_lane_can_be_built(
     assert pipe == "pipe:baseline+dense"
 
 
-def test_a_lane_that_cannot_be_built_never_fails_the_mint(
+def test_a_execution_lane_that_cannot_be_built_never_fails_the_mint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from gen_worker import aot_mint, mint_child
 
-    def _load(lane: str):
-        if lane == "fused+packed":
+    def _load(execution_lane: str):
+        if execution_lane == "fused+packed":
             raise RuntimeError("triton kernels will not compile here")
-        return f"pipe:{lane}", f"spec:{lane}"
+        return f"pipe:{execution_lane}", f"spec:{execution_lane}"
 
     monkeypatch.setattr(
         kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
@@ -648,10 +648,10 @@ def test_a_lane_that_cannot_be_built_never_fails_the_mint(
     monkeypatch.setattr(mint_child, "_release", lambda: None)
     monkeypatch.setattr(
         kl, "measure",
-        lambda lane, step: kl.Measurement(
-            lane=lane, ms_per_step=228.0, peak_bytes=int(44.1 * GB)))
+        lambda execution_lane, step: kl.Measurement(
+            execution_lane=execution_lane, ms_per_step=228.0, peak_bytes=int(44.1 * GB)))
 
-    verdict, pipe, _spec = mint_child.lane_verdict_for(_load)
+    verdict, pipe, _spec = mint_child.execution_lane_verdict_for(_load)
     assert verdict.winner == "baseline+dense"
     assert ("will not compile here"
             in verdict.measurement("fused+packed").unavailable)
@@ -733,7 +733,7 @@ def test_the_rule_derives_the_pgw863_split_without_a_hand_tuple() -> None:
     # residency win is simply not paid: the winner is the FAST linear lane.
     assert kl.linear_of(b200.winner) == kl.LINEAR_BASELINE
     assert kl.modulation_of(b200.winner) == kl.MOD_PACKED
-    assert b200.winner in kl.LANES
+    assert b200.winner in kl.EXECUTION_LANES
 
     # And the residency win is load-bearing, not decorative: shrink the card
     # until neither DENSE lane fits and the packed ones are the only
@@ -742,5 +742,5 @@ def test_the_rule_derives_the_pgw863_split_without_a_hand_tuple() -> None:
     tight = kl.select(four, device_total_bytes=45 * GB, sm="sm_100")
     assert tight.winner == "baseline+packed"
     assert sorted(
-        r.lane for r in four if not kl.fits(r, 45 * GB)
+        r.execution_lane for r in four if not kl.fits(r, 45 * GB)
     ) == ["baseline+dense", "fused+dense"]

--- a/tests/test_lane_determinism_pgw772.py
+++ b/tests/test_lane_determinism_pgw772.py
@@ -91,13 +91,13 @@ def _load_and_key(
         DDPMPipeline, str(root), slot="pipeline", device="cpu",
         binding=type("B", (), {"dtype": "", "storage_dtype": "fp8"})(),
     )
-    lane = cc.cell_base_lane(sl.obj)
+    execution_lane = cc.cell_base_execution_lane(sl.obj)
     cfg = _ContractCfg()
     key = ck.compute(
-        "sdxl", lane, cfg.lora_bucket,
+        "sdxl", execution_lane, cfg.lora_bucket,
         contract=ck.contract_digest(cc.declared_contract_facts(cfg)),
     )
-    return sl.obj, lane, key
+    return sl.obj, execution_lane, key
 
 
 def test_same_declared_config_same_key_across_free_vram(
@@ -112,11 +112,11 @@ def test_same_declared_config_same_key_across_free_vram(
     with tempfile.TemporaryDirectory() as td:
         root = _snapshot(Path(td))
         # The L4-shaped host: headroom below the old 4 GiB margin.
-        _, lane_tight, key_tight = _load_and_key(root, monkeypatch, free_gb=4.0)
+        _, execution_lane_tight, key_tight = _load_and_key(root, monkeypatch, free_gb=4.0)
         # The 4090-shaped host: headroom to spare.
-        _, lane_rich, key_rich = _load_and_key(root, monkeypatch, free_gb=999.0)
+        _, execution_lane_rich, key_rich = _load_and_key(root, monkeypatch, free_gb=999.0)
 
-    assert lane_tight == lane_rich == "fp8-hooks"
+    assert execution_lane_tight == execution_lane_rich == "fp8-hooks"
     # The issue's acceptance surface: the two requested_cell_axes dicts.
     assert key_tight.axes_dict() == key_rich.axes_dict()
     assert key_tight.digest == key_rich.digest

--- a/tests/test_lane_instruction_gw596.py
+++ b/tests/test_lane_instruction_gw596.py
@@ -23,7 +23,7 @@ import pytest
 from gen_worker.api.binding import Hub, wire_ref
 from gen_worker.api.errors import ValidationError
 from gen_worker.executor import Executor
-from gen_worker.models.lanes import LaneUnavailableError
+from gen_worker.models.execution_lanes import ExecutionLaneUnavailableError
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.registry import EndpointSpec
 
@@ -75,7 +75,7 @@ def test_bf16_override_rebinds_to_declared_base() -> None:
     assert wire_ref(spec.models["pipeline"]) == W8A8
     warm_key = spec.instance_key
 
-    derived = ex._lane_effective_spec(spec, "bf16")
+    derived = ex._execution_lane_effective_spec(spec, "bf16")
     assert wire_ref(derived.models["pipeline"]) == BASE
     assert derived.models["pipeline"].storage_dtype == ""
     assert wire_ref(derived.models["vae"]) == VAE
@@ -88,7 +88,7 @@ def test_w8a8_descriptor_keeps_the_pick() -> None:
     ex = _executor()
     _with_w8a8_pick(ex)
     spec = ex.specs["generate"]
-    derived = ex._lane_effective_spec(spec, "fp8-w8a8-dynamic+compiled")
+    derived = ex._execution_lane_effective_spec(spec, "fp8-w8a8-dynamic+compiled")
     assert wire_ref(derived.models["pipeline"]) == W8A8
     # Same bindings -> same spec object (no needless instance split).
     assert derived is spec
@@ -97,8 +97,8 @@ def test_w8a8_descriptor_keeps_the_pick() -> None:
 def test_w8a8_without_pick_refuses_typed() -> None:
     ex = _executor()  # no resolutions applied
     spec = ex.specs["generate"]
-    with pytest.raises(LaneUnavailableError) as e:
-        ex._lane_effective_spec(spec, "fp8-w8a8-dynamic+compiled")
+    with pytest.raises(ExecutionLaneUnavailableError) as e:
+        ex._execution_lane_effective_spec(spec, "fp8-w8a8-dynamic+compiled")
     assert "lane_unavailable: fp8-w8a8-dynamic+compiled" in str(e.value)
     assert "generate" in str(e.value)
 
@@ -107,16 +107,16 @@ def test_w8a8_eager_refuses() -> None:
     ex = _executor()
     _with_w8a8_pick(ex)
     with pytest.raises(ValidationError, match="not a known lane"):
-        ex._lane_effective_spec(ex.specs["generate"], "fp8-w8a8-dynamic+eager")
+        ex._execution_lane_effective_spec(ex.specs["generate"], "fp8-w8a8-dynamic+eager")
 
 
-def test_fp8_family_without_stored_pick_expands_to_cast_lane() -> None:
+def test_fp8_family_without_stored_pick_expands_to_cast_execution_lane() -> None:
     ex = _executor()
     # The hub laddered the pipeline but picked base (e.g. no fp8 flavor
     # published): family fp8 expands to the local cast lane on that ref.
     ex.apply_model_resolutions({BASE: (BASE, "", "bf16-w16a16+eager")})
     spec = ex.specs["generate"]
-    derived = ex._lane_effective_spec(spec, "fp8")
+    derived = ex._execution_lane_effective_spec(spec, "fp8")
     assert wire_ref(derived.models["pipeline"]) == BASE
     assert derived.models["pipeline"].storage_dtype == "fp8"
     # The never-laddered vae keeps its binding untouched.
@@ -125,44 +125,44 @@ def test_fp8_family_without_stored_pick_expands_to_cast_lane() -> None:
 
 def test_fp8_family_with_no_laddered_refs_refuses_typed() -> None:
     ex = _executor()  # hub delivered no resolutions at all
-    with pytest.raises(LaneUnavailableError):
-        ex._lane_effective_spec(ex.specs["generate"], "fp8")
+    with pytest.raises(ExecutionLaneUnavailableError):
+        ex._execution_lane_effective_spec(ex.specs["generate"], "fp8")
 
 
 def test_fp8_family_with_pick_uses_it() -> None:
     ex = _executor()
     _with_w8a8_pick(ex)
     spec = ex.specs["generate"]
-    derived = ex._lane_effective_spec(spec, "fp8")
+    derived = ex._execution_lane_effective_spec(spec, "fp8")
     assert wire_ref(derived.models["pipeline"]) == W8A8
 
 
-def test_unknown_lane_is_invalid() -> None:
+def test_unknown_execution_lane_is_invalid() -> None:
     ex = _executor()
     with pytest.raises(ValidationError):
-        ex._lane_effective_spec(ex.specs["generate"], "int8-w8a8+eager")
+        ex._execution_lane_effective_spec(ex.specs["generate"], "int8-w8a8+eager")
 
 
 def test_4bit_without_pick_refuses_typed() -> None:
     ex = _executor()
-    with pytest.raises(LaneUnavailableError):
-        ex._lane_effective_spec(ex.specs["generate"], "4bit")
+    with pytest.raises(ExecutionLaneUnavailableError):
+        ex._execution_lane_effective_spec(ex.specs["generate"], "4bit")
 
 
-def test_served_lane_reports_concrete_lane() -> None:
+def test_served_execution_lane_reports_concrete_execution_lane() -> None:
     ex = _executor()
     spec = ex.specs["generate"]
     # Declared base, no compile targets: bf16 eager.
-    assert ex._served_lane(spec) == "bf16-w16a16+eager"
+    assert ex._served_execution_lane(spec) == "bf16-w16a16+eager"
     # w8a8 pick applied: the pipeline's lane wins over the bf16 vae.
     _with_w8a8_pick(ex)
-    assert ex._served_lane(ex.specs["generate"]) == "fp8-w8a8-dynamic+compiled"
+    assert ex._served_execution_lane(ex.specs["generate"]) == "fp8-w8a8-dynamic+compiled"
     # cast pick: w8a16.
     ex.apply_model_resolutions({BASE: (BASE, "fp8", "fp8-w8a16+eager")})
-    assert ex._served_lane(ex.specs["generate"]) == "fp8-w8a16+eager"
+    assert ex._served_execution_lane(ex.specs["generate"]) == "fp8-w8a16+eager"
 
 
-def test_hello_ack_lane_field_flows_into_resolutions() -> None:
+def test_hello_ack_execution_lane_field_flows_into_resolutions() -> None:
     ex = _executor()
     ack = pb.HelloAck(resolutions=[pb.ModelResolution(
         ref=BASE, resolved_ref=W8A8, cast="", lane="fp8-w8a8-dynamic+compiled",

--- a/tests/test_lane_pipeline_identity_pgw678.py
+++ b/tests/test_lane_pipeline_identity_pgw678.py
@@ -126,13 +126,13 @@ class _ExecStub:
 
     _slot_pipeline = Executor._slot_pipeline
     _adapter_target = Executor._adapter_target
-    _register_lane = Executor._register_lane
+    _register_execution_lane = Executor._register_execution_lane
 
     def __init__(self) -> None:
         self.store = _StoreStub()
         self._classes: Dict[Any, _ClassRecord] = {}
 
-    def _arm_lane_gate(self, pipe: Any, ref: str, spec: Any = None) -> bool:
+    def _arm_execution_lane_gate(self, pipe: Any, ref: str, spec: Any = None) -> bool:
         return False
 
 
@@ -166,9 +166,9 @@ def _register(pipe: Any, *, override: bool) -> _ExecStub:
     injected: Dict[str, Any] = {"vae": pipe.vae} if override else {}
     result = _InjectionResult(kwargs={}, loaded={})
     result.slot_pipelines[_SLOT] = pipe          # the pgw#678 fix
-    lane_obj, _bytes = ex._register_lane(
+    execution_lane_obj, _bytes = ex._register_execution_lane(
         _SLOT, _REF, pipe, shared, injected, 0, result, ("", 0))
-    ex.store.residency.track_ram(_REF, lane_obj)
+    ex.store.residency.track_ram(_REF, execution_lane_obj)
     rec = _ClassRecord(cls=type(pipe), specs=[])  # type: ignore[call-arg]
     rec.slot_pipelines = dict(result.slot_pipelines)
     ex._classes["sdxl:SDXLFamily"] = rec
@@ -195,7 +195,7 @@ def test_component_override_makes_the_residency_handle_a_moduledict() -> None:
         no_override.store.residency.obj(_REF), torch.nn.ModuleDict)
 
 
-def test_the_lane_handle_reproduces_the_live_refusal_verbatim() -> None:
+def test_the_execution_lane_handle_reproduces_the_live_refusal_verbatim() -> None:
     """RED, byte-for-byte: handing the residency handle to the real
     `AdapterResidency.activate` — which is what `_adapter_target` did — raises
     the exact live message, for a UNet-only adapter on a branch-capable
@@ -216,7 +216,7 @@ def test_the_lane_handle_reproduces_the_live_refusal_verbatim() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_slot_pipeline_returns_the_pipeline_not_the_lane_handle() -> None:
+def test_slot_pipeline_returns_the_pipeline_not_the_execution_lane_handle() -> None:
     """`_slot_pipeline` (what `_adapter_target`, the explicit-deactivation
     sweep and the OOM offload rung all read now) returns the pipeline even
     when residency books a ModuleDict."""
@@ -234,7 +234,7 @@ def test_override_and_deploy_bound_lora_compose() -> None:
     pipe = _tiny_pipe()
     ex = _register(pipe, override=True)
     spec = _SpecStub()
-    compile_cache.apply_lora_lane(pipe, _RANK)
+    compile_cache.apply_lora_execution_lane(pipe, _RANK)
     overridden_vae = pipe.vae
 
     target = ex._adapter_target(spec, _SLOT)

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 import pytest
 
-from gen_worker.models import lanes
+from gen_worker.models import execution_lanes
 
 
-def test_known_lanes_stable() -> None:
-    assert lanes.known_lanes() == [
+def test_known_execution_lanes_stable() -> None:
+    assert execution_lanes.known_execution_lanes() == [
         "fp8-w8a8-dynamic+compiled",
         "nvfp4-w4a4-static+compiled",
         "svdq-fp4-w4a4+eager",
@@ -22,10 +22,10 @@ def test_known_lanes_stable() -> None:
     ]
 
 
-def test_parse_lane_round_trip() -> None:
-    parsed = [lanes.parse_lane(lane_id) for lane_id in lanes.known_lanes()]
-    assert [lanes.lane_id(lane) for lane in parsed] == lanes.known_lanes()
-    assert {lanes.lane_body_id(lane) for lane in parsed} == set(lanes.known_lane_bodies())
+def test_parse_execution_lane_round_trip() -> None:
+    parsed = [execution_lanes.parse_execution_lane(execution_lane_id) for execution_lane_id in execution_lanes.known_execution_lanes()]
+    assert [execution_lanes.execution_lane_id(execution_lane) for execution_lane in parsed] == execution_lanes.known_execution_lanes()
+    assert {execution_lanes.execution_lane_body_id(execution_lane) for execution_lane in parsed} == set(execution_lanes.known_execution_lane_bodies())
 
 
 @pytest.mark.parametrize("bad", [
@@ -38,23 +38,23 @@ def test_parse_lane_round_trip() -> None:
     "nvfp4-w4a4-static+eager",
     "int8-w8a8+eager",
 ])
-def test_parse_lane_rejects(bad: str) -> None:
+def test_parse_execution_lane_rejects(bad: str) -> None:
     with pytest.raises(ValueError):
-        lanes.parse_lane(bad)
+        execution_lanes.parse_execution_lane(bad)
 
 
-def test_parse_lane_spec_dual_form() -> None:
-    spec = lanes.parse_lane_spec("bf16")
-    assert spec.family == lanes.FAMILY_BF16 and spec.lane is None
+def test_parse_execution_lane_spec_dual_form() -> None:
+    spec = execution_lanes.parse_execution_lane_spec("bf16")
+    assert spec.family == execution_lanes.FAMILY_BF16 and spec.execution_lane is None
 
-    spec = lanes.parse_lane_spec("FP8-W8A8-Dynamic+Compiled")
-    assert spec.family == lanes.FAMILY_FP8
-    assert spec.lane is not None
-    assert lanes.lane_id(spec.lane) == "fp8-w8a8-dynamic+compiled"
+    spec = execution_lanes.parse_execution_lane_spec("FP8-W8A8-Dynamic+Compiled")
+    assert spec.family == execution_lanes.FAMILY_FP8
+    assert spec.execution_lane is not None
+    assert execution_lanes.execution_lane_id(spec.execution_lane) == "fp8-w8a8-dynamic+compiled"
 
-    assert lanes.parse_lane_spec("").is_zero
+    assert execution_lanes.parse_execution_lane_spec("").is_zero
     with pytest.raises(ValueError):
-        lanes.parse_lane_spec("int8")
+        execution_lanes.parse_execution_lane_spec("int8")
 
 
 @pytest.mark.parametrize("flavor,storage,compiled,want", [
@@ -69,11 +69,11 @@ def test_parse_lane_spec_dual_form() -> None:
     ("nvfp4-w4a4", "", True, "nvfp4-w4a4-static+compiled"),
     ("nvfp4-w4a4", "", False, "nvfp4-w4a4-static+compiled"),
 ])
-def test_lane_of_binding(flavor: str, storage: str, compiled: bool, want: str) -> None:
-    assert lanes.lane_id(lanes.lane_of_binding(flavor, storage, compiled)) == want
+def test_execution_lane_of_binding(flavor: str, storage: str, compiled: bool, want: str) -> None:
+    assert execution_lanes.execution_lane_id(execution_lanes.execution_lane_of_binding(flavor, storage, compiled)) == want
 
 
-def test_lane_of_binding_covers_every_body_with_valid_execution() -> None:
+def test_execution_lane_of_binding_covers_every_body_with_valid_execution() -> None:
     inputs = [
         ("", ""),
         ("", "fp8"),
@@ -85,7 +85,7 @@ def test_lane_of_binding_covers_every_body_with_valid_execution() -> None:
     bodies = set()
     for flavor, storage in inputs:
         for compiled in (False, True):
-            lane = lanes.lane_of_binding(flavor, storage, compiled)
-            assert lanes.valid_lane(lane)
-            bodies.add(lanes.lane_body_id(lane))
-    assert bodies == set(lanes.known_lane_bodies())
+            execution_lane = execution_lanes.execution_lane_of_binding(flavor, storage, compiled)
+            assert execution_lanes.valid_execution_lane(execution_lane)
+            bodies.add(execution_lanes.execution_lane_body_id(execution_lane))
+    assert bodies == set(execution_lanes.known_execution_lane_bodies())

--- a/tests/test_local_cells.py
+++ b/tests/test_local_cells.py
@@ -277,7 +277,7 @@ def test_no_family_no_mint(_local_env):
 
 # ---------------------------------------------------------------------------
 # gw#564: w8a8 fail-closed x local mint. Production's no-delivered-cell
-# refusal (CompiledLaneUnavailableError) must fall through to the LOCAL
+# refusal (CompiledExecutionLaneUnavailableError) must fall through to the LOCAL
 # store/mint path — found live on a 4090 where the raise aborted the mint —
 # and every exit that cannot produce a cell keeps the refusal TYPED.
 # ---------------------------------------------------------------------------
@@ -294,7 +294,7 @@ def _w8a8_env(_local_env, monkeypatch):
     from gen_worker.models import provision
 
     def refuse(*a, **k):
-        raise cc.CompiledLaneUnavailableError("no delivered w8a8 cell")
+        raise cc.CompiledExecutionLaneUnavailableError("no delivered w8a8 cell")
 
     monkeypatch.setattr(provision, "enable_compiled", refuse)
     return _local_env
@@ -314,7 +314,7 @@ def test_w8a8_delivered_refusal_falls_through_to_mint(_w8a8_env, monkeypatch):
 
 def test_w8a8_no_toolchain_refusal_stays_typed(_w8a8_env, monkeypatch):
     monkeypatch.setattr(cc, "toolchain_present", lambda: False)
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="C compiler"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="C compiler"):
         lc.enable_compiled(_W8a8Pipe(), _Cfg())
 
 
@@ -325,7 +325,7 @@ def test_w8a8_mint_failure_refusal_stays_typed(_w8a8_env, monkeypatch):
         raise RuntimeError("compile exploded")
 
     monkeypatch.setattr(cc, "_compile_and_warm", boom)
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="mint failed"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="mint failed"):
         lc.enable_compiled(_W8a8Pipe(), _Cfg())
     assert not lc.cell_path("fam", "w8a8").exists()
 

--- a/tests/test_lora_cells.py
+++ b/tests/test_lora_cells.py
@@ -18,7 +18,7 @@ pytest.importorskip("diffusers")
 pytest.importorskip("accelerate")
 
 from gen_worker import Compile, endpoint, compile_cache
-from gen_worker.executor import _cell_lane_matches
+from gen_worker.executor import _cell_execution_lane_matches
 from gen_worker.models import provision
 from gen_worker.models.w8a8 import detect_w8a8_artifact, load_w8a8_denoiser, quantize_tree_w8a8
 from gen_worker.models.w8a8_lora import RANK_BUCKETS, branch_bucket
@@ -122,31 +122,31 @@ def test_endpoint_lora_bucket_validation() -> None:
         Compile(shapes=((64, 64),), family="f", lora_bucket=32)  # type: ignore[call-arg]
 
 
-def test_lane_bucket_parses_stamp_and_token_forms() -> None:
-    assert compile_cache.lane_bucket("") == ("", 0)
-    assert compile_cache.lane_bucket("w8a8") == ("w8a8", 0)
-    assert compile_cache.lane_bucket("w8a8-lora128") == ("w8a8", 128)
-    assert compile_cache.lane_bucket("w8a16-lora32") == ("w8a16", 32)
-    assert compile_cache.lane_bucket("fp8-hooks-lora64") == ("fp8-hooks", 64)
-    assert compile_cache.lane_bucket("lora32") == ("", 32)
+def test_execution_lane_bucket_parses_stamp_and_token_forms() -> None:
+    assert compile_cache.execution_lane_bucket("") == ("", 0)
+    assert compile_cache.execution_lane_bucket("w8a8") == ("w8a8", 0)
+    assert compile_cache.execution_lane_bucket("w8a8-lora128") == ("w8a8", 128)
+    assert compile_cache.execution_lane_bucket("w8a16-lora32") == ("w8a16", 32)
+    assert compile_cache.execution_lane_bucket("fp8-hooks-lora64") == ("fp8-hooks", 64)
+    assert compile_cache.execution_lane_bucket("lora32") == ("", 32)
     # sparse stamps are eager-only and never parse as a cell bucket
-    assert compile_cache.lane_bucket("w8a8-lora32-sparse") == ("w8a8-lora32-sparse", 0)
+    assert compile_cache.execution_lane_bucket("w8a8-lora32-sparse") == ("w8a8-lora32-sparse", 0)
 
 
-def test_lane_token_and_label_carry_bucket() -> None:
-    assert compile_cache.lane_token("w8a8-lora128") == "w8a8-lora128"
-    assert compile_cache.lane_token("fp8-hooks-lora32") == "w8a16-lora32"
-    assert compile_cache.lane_token("lora32") == "lora32"
+def test_execution_lane_token_and_label_carry_bucket() -> None:
+    assert compile_cache.execution_lane_token("w8a8-lora128") == "w8a8-lora128"
+    assert compile_cache.execution_lane_token("fp8-hooks-lora32") == "w8a16-lora32"
+    assert compile_cache.execution_lane_token("lora32") == "lora32"
     assert compile_cache.flavor_label("h100-sxm", "2.13.0+cu130", "w8a8-lora128") == (
         "inductor-h100-sxm-torch2.13-w8a8-lora128")
     assert compile_cache.flavor_label("rtx-4090", "2.13.0", "lora32") == (
         "inductor-rtx-4090-torch2.13-lora32")
 
 
-def test_cell_lane_roundtrip_through_ref() -> None:
+def test_cell_execution_lane_roundtrip_through_ref() -> None:
     ref = "root/family-qwen-image#inductor-h100-sxm-torch2.13-w8a8-lora128"
-    assert compile_cache.cell_lane(ref) == "w8a8-lora128"
-    assert compile_cache.lane_bucket(compile_cache.cell_lane(ref)) == ("w8a8", 128)
+    assert compile_cache.cell_execution_lane(ref) == "w8a8-lora128"
+    assert compile_cache.execution_lane_bucket(compile_cache.cell_execution_lane(ref)) == ("w8a8", 128)
 
 
 # ---------------------------------------------------------------------------
@@ -154,33 +154,33 @@ def test_cell_lane_roundtrip_through_ref() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_apply_lora_lane_stamps_and_allocates(w8a8_pipe: Any) -> None:
-    assert compile_cache.apply_lora_lane(w8a8_pipe, 128)
+def test_apply_lora_execution_lane_stamps_and_allocates(w8a8_pipe: Any) -> None:
+    assert compile_cache.apply_lora_execution_lane(w8a8_pipe, 128)
     assert branch_bucket(w8a8_pipe.unet) == 128
     assert w8a8_pipe._cozy_weight_lane == "w8a8-lora128"
     meta = compile_cache.artifact_metadata(
         family="f", weight_lane="w8a8-lora128", lora_bucket=128)
-    assert compile_cache.lane_drift(meta, w8a8_pipe) == ""
+    assert compile_cache.execution_lane_drift(meta, w8a8_pipe) == ""
     assert meta["lora_bucket"] == 128
     # branchless cells refuse the branch-bearing pipeline (symmetric guard)
-    assert "weight_lane" in compile_cache.lane_drift(
+    assert "weight_lane" in compile_cache.execution_lane_drift(
         compile_cache.artifact_metadata(family="f", weight_lane="w8a8"), w8a8_pipe)
-    compile_cache.drop_lora_lane(w8a8_pipe)
+    compile_cache.drop_lora_execution_lane(w8a8_pipe)
     assert branch_bucket(w8a8_pipe.unet) == 0
     assert w8a8_pipe._cozy_weight_lane == "w8a8"
 
 
-def test_apply_lora_lane_zero_bucket_is_noop(w8a8_pipe: Any) -> None:
-    assert compile_cache.apply_lora_lane(w8a8_pipe, 0) is False
+def test_apply_lora_execution_lane_zero_bucket_is_noop(w8a8_pipe: Any) -> None:
+    assert compile_cache.apply_lora_execution_lane(w8a8_pipe, 0) is False
     assert branch_bucket(w8a8_pipe.unet) == 0
 
 
-def test_apply_lora_lane_requires_denoiser() -> None:
+def test_apply_lora_execution_lane_requires_denoiser() -> None:
     class _NoDenoiser:
         pass
 
     with pytest.raises(RuntimeError, match="branch-capable"):
-        compile_cache.apply_lora_lane(_NoDenoiser(), 32)
+        compile_cache.apply_lora_execution_lane(_NoDenoiser(), 32)
 
 
 def test_enable_compiled_rolls_back_branches_when_eager(plain_pipe: Any) -> None:
@@ -197,7 +197,7 @@ def test_enable_compiled_rolls_back_branches_when_eager(plain_pipe: Any) -> None
 
 def test_enable_compiled_w8a8_fail_closed_keeps_contract(w8a8_pipe: Any) -> None:
     cfg = _cfg("loracells-test", lora_bucket=128)
-    with pytest.raises(compile_cache.CompiledLaneUnavailableError):
+    with pytest.raises(compile_cache.CompiledExecutionLaneUnavailableError):
         provision.enable_compiled(w8a8_pipe, cfg, cache_dir=None, artifact=None)
 
 
@@ -206,7 +206,7 @@ def test_enable_compiled_w8a8_fail_closed_keeps_contract(w8a8_pipe: Any) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_cell_pick_is_lane_and_bucket_exact() -> None:
+def test_cell_pick_is_execution_lane_and_bucket_exact() -> None:
     fam = "qwen-image"
     plain = f"root/family-{fam}#inductor-h100-sxm-torch2.13"
     w8a8 = f"root/family-{fam}#inductor-h100-sxm-torch2.13-w8a8"
@@ -214,32 +214,32 @@ def test_cell_pick_is_lane_and_bucket_exact() -> None:
     w8a8_l32 = f"root/family-{fam}#inductor-h100-sxm-torch2.13-w8a8-lora32"
     plain_l32 = f"root/family-{fam}#inductor-h100-sxm-torch2.13-lora32"
 
-    def pick(ref: str, *, w8a8_lane: bool, bucket: int) -> bool:
-        return _cell_lane_matches(ref, fam, want_lane="w8a8" if w8a8_lane else "", want_bucket=bucket)
+    def pick(ref: str, *, w8a8_execution_lane: bool, bucket: int) -> bool:
+        return _cell_execution_lane_matches(ref, fam, want_execution_lane="w8a8" if w8a8_execution_lane else "", want_bucket=bucket)
 
     # branchless w8a8 endpoint: exactly the branchless w8a8 cell
-    assert pick(w8a8, w8a8_lane=True, bucket=0)
-    assert not pick(w8a8_l128, w8a8_lane=True, bucket=0)
-    assert not pick(plain, w8a8_lane=True, bucket=0)
+    assert pick(w8a8, w8a8_execution_lane=True, bucket=0)
+    assert not pick(w8a8_l128, w8a8_execution_lane=True, bucket=0)
+    assert not pick(plain, w8a8_execution_lane=True, bucket=0)
     # lora128 w8a8 endpoint: exactly the lora128 w8a8 cell
-    assert pick(w8a8_l128, w8a8_lane=True, bucket=128)
-    assert not pick(w8a8, w8a8_lane=True, bucket=128)
-    assert not pick(w8a8_l32, w8a8_lane=True, bucket=128)
-    assert not pick(plain_l32, w8a8_lane=True, bucket=128)
+    assert pick(w8a8_l128, w8a8_execution_lane=True, bucket=128)
+    assert not pick(w8a8, w8a8_execution_lane=True, bucket=128)
+    assert not pick(w8a8_l32, w8a8_execution_lane=True, bucket=128)
+    assert not pick(plain_l32, w8a8_execution_lane=True, bucket=128)
     # plain lora32 endpoint: never a w8a8 cell, never branchless
-    assert pick(plain_l32, w8a8_lane=False, bucket=32)
-    assert not pick(w8a8_l32, w8a8_lane=False, bucket=32)
-    assert not pick(plain, w8a8_lane=False, bucket=32)
+    assert pick(plain_l32, w8a8_execution_lane=False, bucket=32)
+    assert not pick(w8a8_l32, w8a8_execution_lane=False, bucket=32)
+    assert not pick(plain, w8a8_execution_lane=False, bucket=32)
     # wrong family never matches
-    assert not _cell_lane_matches(
-        w8a8_l128, "sdxl", want_lane="w8a8", want_bucket=128)
+    assert not _cell_execution_lane_matches(
+        w8a8_l128, "sdxl", want_execution_lane="w8a8", want_bucket=128)
     # w4a4 (gw#540): mandated-lane exactness, and plain endpoints never
     # fetch a quantized-lane cell
     w4a4 = f"root/family-{fam}#inductor-rtx-5090-torch2.13-w4a4"
-    assert _cell_lane_matches(w4a4, fam, want_lane="w4a4", want_bucket=0)
-    assert not _cell_lane_matches(w4a4, fam, want_lane="w8a8", want_bucket=0)
-    assert not _cell_lane_matches(w4a4, fam, want_lane="", want_bucket=0)
-    assert not _cell_lane_matches(w8a8, fam, want_lane="w4a4", want_bucket=0)
+    assert _cell_execution_lane_matches(w4a4, fam, want_execution_lane="w4a4", want_bucket=0)
+    assert not _cell_execution_lane_matches(w4a4, fam, want_execution_lane="w8a8", want_bucket=0)
+    assert not _cell_execution_lane_matches(w4a4, fam, want_execution_lane="", want_bucket=0)
+    assert not _cell_execution_lane_matches(w8a8, fam, want_execution_lane="w4a4", want_bucket=0)
 
 
 def test_rank_buckets_cover_declared_cells() -> None:
@@ -270,7 +270,7 @@ def test_discovery_carries_lora_bucket() -> None:
     assert meta["lora_bucket"] == 64
 
 
-def test_enable_compiled_skips_lane_on_component_slot_without_target() -> None:
+def test_enable_compiled_skips_execution_lane_on_component_slot_without_target() -> None:
     """gw#627 live find: enable_compiled runs for EVERY worker-loaded setup
     slot — a bare component slot (sdxl's standalone AutoencoderKL vae)
     resolves none of cfg.targets and must stay branchless-eager instead of

--- a/tests/test_mandatory_lane_th1059.py
+++ b/tests/test_mandatory_lane_th1059.py
@@ -31,8 +31,8 @@ class _Resolutions:
     def __init__(self, resolutions):
         self._model_resolutions = resolutions
 
-    _resolved_mandatory_lane = Executor._resolved_mandatory_lane
-    _mandatory_lane_of_bound = Executor._mandatory_lane_of_bound
+    _resolved_mandatory_execution_lane = Executor._resolved_mandatory_execution_lane
+    _mandatory_execution_lane_of_bound = Executor._mandatory_execution_lane_of_bound
     _validate_required_compile = Executor._validate_required_compile
     _setup_slots = staticmethod(Executor._setup_slots)
 
@@ -60,37 +60,37 @@ def _spec() -> EndpointSpec:
     )
 
 
-def test_w8a16_resolution_lane_is_not_mandatory() -> None:
+def test_w8a16_resolution_execution_lane_is_not_mandatory() -> None:
     ex = _Resolutions({BARE: (MIXED, "", "fp8-w8a16+compiled")})
-    assert ex._resolved_mandatory_lane(MIXED) == ""
-    assert ex._resolved_mandatory_lane(BARE) == ""
-    assert ex._mandatory_lane_of_bound([MIXED]) == ""
+    assert ex._resolved_mandatory_execution_lane(MIXED) == ""
+    assert ex._resolved_mandatory_execution_lane(BARE) == ""
+    assert ex._mandatory_execution_lane_of_bound([MIXED]) == ""
 
 
-def test_w8a8_resolution_lane_stays_mandatory() -> None:
+def test_w8a8_resolution_execution_lane_stays_mandatory() -> None:
     ex = _Resolutions({BARE: (MIXED, "", "fp8-w8a8-dynamic+compiled")})
-    assert ex._resolved_mandatory_lane(MIXED) == "w8a8"
-    assert ex._mandatory_lane_of_bound([MIXED]) == "w8a8"
+    assert ex._resolved_mandatory_execution_lane(MIXED) == "w8a8"
+    assert ex._mandatory_execution_lane_of_bound([MIXED]) == "w8a8"
 
 
-def test_flavor_token_fallback_without_lane_evidence() -> None:
+def test_flavor_token_fallback_without_execution_lane_evidence() -> None:
     ex = _Resolutions({})
-    assert ex._resolved_mandatory_lane(MIXED) == "w8a8"
-    assert ex._resolved_mandatory_lane("acme/other#nvfp4-w4a4") == "w4a4"
-    assert ex._resolved_mandatory_lane(BARE) == ""
-    empty_lane = _Resolutions({BARE: (MIXED, "", "")})
-    assert empty_lane._resolved_mandatory_lane(MIXED) == "w8a8"
+    assert ex._resolved_mandatory_execution_lane(MIXED) == "w8a8"
+    assert ex._resolved_mandatory_execution_lane("acme/other#nvfp4-w4a4") == "w4a4"
+    assert ex._resolved_mandatory_execution_lane(BARE) == ""
+    empty_execution_lane = _Resolutions({BARE: (MIXED, "", "")})
+    assert empty_execution_lane._resolved_mandatory_execution_lane(MIXED) == "w8a8"
 
 
-def test_conflicting_lane_evidence_fails_closed() -> None:
+def test_conflicting_execution_lane_evidence_fails_closed() -> None:
     ex = _Resolutions({
         BARE: (MIXED, "", "fp8-w8a16+compiled"),
         "acme/alias": (MIXED, "", "fp8-w8a8-dynamic+compiled"),
     })
-    assert ex._resolved_mandatory_lane(MIXED) == "w8a8"
+    assert ex._resolved_mandatory_execution_lane(MIXED) == "w8a8"
 
 
-def test_mixed_lane_dispatch_admits_without_required_compile() -> None:
+def test_mixed_execution_lane_dispatch_admits_without_required_compile() -> None:
     """The live failure shape: RunJob without required_compile for the mixed
     checkpoint must ADMIT (JIT setup), not raise required_compile_missing."""
     ex = _Resolutions({BARE: (MIXED, "", "fp8-w8a16+compiled")})

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -261,7 +261,7 @@ def test_the_parent_hands_its_resolved_overrides_across_the_wire(
         pending=pending, pipe=object(), function="gen",
         modules=bg.modules, snapshots=dict(bg.snapshot_paths),
         component_paths={k: dict(v) for k, v in bg.component_paths.items()},
-        lane="fp8-w8a16", device=0)
+        execution_lane="fp8-w8a16", device=0)
     request = mint_delegate.build_request(
         task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
 

--- a/tests/test_mint_child_warm_context_pgw828.py
+++ b/tests/test_mint_child_warm_context_pgw828.py
@@ -91,10 +91,10 @@ def test_the_child_and_the_executor_build_the_SAME_context(spec) -> None:
     with tempfile.TemporaryDirectory() as tmp:
         child = warmup.warm_context(
             spec, request_id="mint-child-x", local_output_dir=tmp,
-            lane="w8a8", config={})
+            execution_lane="w8a8", config={})
         served = warmup.warm_context(
             spec, request_id="boot-warmup-x", local_output_dir=tmp,
-            lane="w8a8", config={})
+            execution_lane="w8a8", config={})
     assert sorted(child.slots) == sorted(served.slots)
     assert sorted(child.slots) == sorted(spec.slots)
     for name in spec.slots:

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -93,8 +93,8 @@ def test_the_delegated_arm_never_touches_the_live_pipeline(
         lambda *a, **k: AdoptOutcome.miss("no_cell"))
     monkeypatch.setattr(cc, "has_compile_target", lambda *a, **k: True)
     monkeypatch.setattr(cc, "mandatory_serving", lambda pipe: False)
-    monkeypatch.setattr(cc, "apply_lora_lane", lambda pipe, bucket: True)
-    monkeypatch.setattr(cc, "drop_lora_lane", lambda pipe: True)
+    monkeypatch.setattr(cc, "apply_lora_execution_lane", lambda pipe, bucket: True)
+    monkeypatch.setattr(cc, "drop_lora_execution_lane", lambda pipe: True)
     monkeypatch.setattr(
         fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "fp8")
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
@@ -144,7 +144,7 @@ def test_the_wire_form_preserves_the_contract_facts_exactly(
     assert rebuilt.lora_bucket == parent.lora_bucket == 64
 
 
-def test_the_request_carries_the_lane_and_the_effective_config(
+def test_the_request_carries_the_execution_lane_and_the_effective_config(
     tmp_path: Path,
 ) -> None:
     """Both steer the warm forwards, so both must be the PARENT's values —
@@ -157,10 +157,10 @@ def test_the_request_carries_the_lane_and_the_effective_config(
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function="gen",
         modules=("app",), snapshots={"pipeline": "/cas/sdxl"},
-        lane="fp8-w8a16", configs={"gen": {"steps": 28}}, device=3)
+        execution_lane="fp8-w8a16", configs={"gen": {"steps": 28}}, device=3)
     req = mint_delegate.build_request(
         task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
-    assert req.lane == "fp8-w8a16"
+    assert req.execution_lane == "fp8-w8a16"
     assert req.configs == {"gen": {"steps": 28}}
     assert req.snapshots == {"pipeline": "/cas/sdxl"}
     assert req.device == 3 and req.vram_cap_bytes == 7 * GIB

--- a/tests/test_mint_memory_fit_pgw848.py
+++ b/tests/test_mint_memory_fit_pgw848.py
@@ -224,15 +224,15 @@ def test_a_measured_per_entry_ask_actually_narrows_the_pool() -> None:
 
 def test_the_measured_ask_is_banked_and_survives_to_the_next_mint() -> None:
     """The bank is monotone and keyed like its device twin."""
-    fam, lane = "pgw848-fam", "w8a8-lora64"
-    assert mint_budget.entry_peak_rss(fam, lane) == 0
-    mint_budget.record_entry_peak_rss(fam, lane, 5 * _GIB)
-    assert mint_budget.entry_peak_rss(fam, lane) == 5 * _GIB
+    fam, execution_lane = "pgw848-fam", "w8a8-lora64"
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 0
+    mint_budget.record_entry_peak_rss(fam, execution_lane, 5 * _GIB)
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 5 * _GIB
     # A luckier run must not talk the ask down.
-    mint_budget.record_entry_peak_rss(fam, lane, 2 * _GIB)
-    assert mint_budget.entry_peak_rss(fam, lane) == 5 * _GIB
-    mint_budget.record_entry_peak_rss(fam, lane, 9 * _GIB)
-    assert mint_budget.entry_peak_rss(fam, lane) == 9 * _GIB
+    mint_budget.record_entry_peak_rss(fam, execution_lane, 2 * _GIB)
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 5 * _GIB
+    mint_budget.record_entry_peak_rss(fam, execution_lane, 9 * _GIB)
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 9 * _GIB
     # Keyed, not global.
     assert mint_budget.entry_peak_rss(fam, "plain") == 0
 
@@ -250,7 +250,7 @@ def test_the_pools_own_measurement_reaches_the_bank_over_the_real_relay(
     from gen_worker import mint_delegate, mint_process
     from gen_worker import aot_mint
 
-    fam, lane = "pgw848-relay", "w8a8-lora64"
+    fam, execution_lane = "pgw848-relay", "w8a8-lora64"
     width = pool.entry_workers(
         2, vcpus=16, available_bytes=64 * _GIB, free_vram_bytes=0,
         device_lock=True, limit=2)
@@ -265,15 +265,15 @@ def test_the_pools_own_measurement_reaches_the_bank_over_the_real_relay(
         report=mint_process.MintReport(
             status=mint_process.MINTED, elapsed_s=1.0, mint_phases=table))
 
-    assert mint_budget.entry_peak_rss(fam, lane) == 0
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 0
     # The exact statement `build_cell` runs, against the real structures.
     pool_block = (outcome.report.mint_phases or {}).get("pool")
     mint_budget.record_entry_peak_rss(
-        fam, lane, int((pool_block or {}).get("peak_child_rss_bytes") or 0))
-    assert mint_budget.entry_peak_rss(fam, lane) == 6 * _GIB
+        fam, execution_lane, int((pool_block or {}).get("peak_child_rss_bytes") or 0))
+    assert mint_budget.entry_peak_rss(fam, execution_lane) == 6 * _GIB
 
     # ...and the request the NEXT attempt builds carries it to the child.
-    banked = mint_budget.entry_peak_rss(fam, lane)
+    banked = mint_budget.entry_peak_rss(fam, execution_lane)
     assert banked == 6 * _GIB
     request = mint_process.MintRequest(
         function="f", modules=(), family=fam, cell_key="k", target="t",

--- a/tests/test_mint_oom_classification_pgw848.py
+++ b/tests/test_mint_oom_classification_pgw848.py
@@ -198,10 +198,10 @@ def test_a_real_oom_killed_entry_child_is_a_retryable_shortfall_that_teaches_the
         assert table["pool"]["oom_entry"] == "probe/entry"
 
         # 5. ...and the parent banks it, so the RETRY is narrower
-        fam, lane = "pgw848-oom", "w8a8-lora64"
+        fam, execution_lane = "pgw848-oom", "w8a8-lora64"
         mint_budget.record_entry_peak_rss(
-            fam, lane, int(table["pool"]["peak_child_rss_bytes"]))
-        banked = mint_budget.entry_peak_rss(fam, lane)
+            fam, execution_lane, int(table["pool"]["peak_child_rss_bytes"]))
+        banked = mint_budget.entry_peak_rss(fam, execution_lane)
         assert banked > 0
         common = dict(
             vcpus=16, available_bytes=8 * _GIB, free_vram_bytes=0,

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -126,7 +126,7 @@ class _Harness:
         seed_forward_s: float = 0.0,
         tenant_forward_s: float = 0.02,
         weight_lane: str = "",
-        hub_lane: str = "",
+        hub_execution_lane: str = "",
         seed_oom_after: int = 0,
     ) -> None:
         self.tmp_path = tmp_path
@@ -200,9 +200,9 @@ class _Harness:
                                     "entry": 0, "guards": []}],
                 "verdicts": {}, "leaks": []})
         self.ex = Executor(self.specs, _send, store=store)
-        if hub_lane:
+        if hub_execution_lane:
             ref = wire_ref(self.spec.models["model"])
-            self.ex._model_resolutions = {ref: (ref, "", hub_lane)}
+            self.ex._model_resolutions = {ref: (ref, "", hub_execution_lane)}
 
     def _fake_enable_compiled(
         self, pipe: Any, cfg: Any, cache_dir: Any = None,
@@ -337,7 +337,7 @@ def test_w8a8_stamp_with_hub_execution_lane_boots_eager_first(
     h = _Harness(
         tmp_path, monkeypatch,
         compile_delay_s=0.4, seed_forward_s=0.05, tenant_forward_s=0.02,
-        weight_lane="w8a8", hub_lane="fp8-w8a16+eager")
+        weight_lane="w8a8", hub_execution_lane="fp8-w8a16+eager")
 
     async def _run() -> None:
         boot_t0 = time.monotonic()
@@ -359,7 +359,7 @@ def test_w8a8_stamp_with_hub_execution_lane_boots_eager_first(
     asyncio.run(_run())
 
 
-def test_true_mandatory_lane_still_refuses_eager_first(
+def test_true_mandatory_execution_lane_still_refuses_eager_first(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The qwen shape: hub lane says real w8a8 activations — eager is not
@@ -369,7 +369,7 @@ def test_true_mandatory_lane_still_refuses_eager_first(
     h = _Harness(
         tmp_path, monkeypatch,
         compile_delay_s=0.0, seed_forward_s=0.0, tenant_forward_s=0.01,
-        weight_lane="w8a8", hub_lane="fp8-w8a8-dynamic+compiled")
+        weight_lane="w8a8", hub_execution_lane="fp8-w8a8-dynamic+compiled")
 
     async def _run() -> None:
         await h.boot()
@@ -379,7 +379,7 @@ def test_true_mandatory_lane_still_refuses_eager_first(
     asyncio.run(_run())
 
 
-def test_w8a8_stamp_without_lane_evidence_stays_foreground(
+def test_w8a8_stamp_without_execution_lane_evidence_stays_foreground(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """No hub lane evidence: the weight-lane stamp remains the fail-closed
@@ -387,7 +387,7 @@ def test_w8a8_stamp_without_lane_evidence_stays_foreground(
     monkeypatch.setenv("GEN_WORKER_BG_YIELD", "1")
     h = _Harness(
         tmp_path, monkeypatch,
-        weight_lane="w8a8", hub_lane="")
+        weight_lane="w8a8", hub_execution_lane="")
 
     async def _run() -> None:
         await h.boot()

--- a/tests/test_mint_vram_cap_pgw848.py
+++ b/tests/test_mint_vram_cap_pgw848.py
@@ -149,13 +149,13 @@ def test_a_failed_attempt_banks_its_device_peak_so_the_next_ask_widens() -> None
     and refusal report paths carried none — so the attempt that hit the cap
     taught the retry nothing and attempt N+1 re-asked identically, forever.
     """
-    fam, lane = "pgw848-cap", "w8a8"
-    assert mint_budget.child_peak(fam, lane) == 0
+    fam, execution_lane = "pgw848-cap", "w8a8"
+    assert mint_budget.child_peak(fam, execution_lane) == 0
     # A child that died AT its cap reports that cap as its peak.
-    mint_budget.record_child_peak(fam, lane, 11 * _GIB)
-    assert mint_budget.child_peak(fam, lane) == 11 * _GIB
+    mint_budget.record_child_peak(fam, execution_lane, 11 * _GIB)
+    assert mint_budget.child_peak(fam, execution_lane) == 11 * _GIB
     # The next ask is built from the fact, not the fraction, and is BIGGER.
-    banked = mint_budget.child_peak(fam, lane)
+    banked = mint_budget.child_peak(fam, execution_lane)
     widened = banked + mint_budget._CUDA_CONTEXT_FLOOR_BYTES
     estimate = (_SDXL_RESIDENT
                 + int(_SDXL_RESIDENT * mint_budget._UNMEASURED_ACTIVATION_FRACTION)

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -215,7 +215,7 @@ def _wired(
         pipes={id(p): p for p in objs}, selections={},
         modules=("harness.toy_endpoints",),
         snapshot_paths={"pipeline": str(tmp_path / "snap")})
-    monkeypatch.setattr(ex, "_served_lane", lambda s, instructed="": "fp8-w8a16")
+    monkeypatch.setattr(ex, "_served_execution_lane", lambda s, instructed="": "fp8-w8a16")
     monkeypatch.setattr(ex, "_effective_config", lambda s, run=None: {"steps": 28})
     monkeypatch.setattr(
         executor_mod.mint_budget, "device_of", lambda pipe: 0)

--- a/tests/test_moe_branch_gw679.py
+++ b/tests/test_moe_branch_gw679.py
@@ -257,7 +257,7 @@ def test_a_broken_second_half_attaches_nothing_at_all() -> None:
 
 def test_lora_bucket_container_is_armed_on_both_experts() -> None:
     pipe = _wan_pipe()
-    assert compile_cache.apply_lora_lane(pipe, 32)
+    assert compile_cache.apply_lora_execution_lane(pipe, 32)
     assert w8a8_lora.branch_bucket(pipe.transformer) == 32
     assert w8a8_lora.branch_bucket(pipe.transformer_2) == 32
     assert w8a8_lora.pipeline_branch_bucket(pipe) == 32
@@ -323,7 +323,7 @@ def test_compiled_pipeline_refuses_a_set_that_needs_a_wider_bucket() -> None:
     """The no-recompile-at-swap-time rule is enforced over the SET (the sum
     of concatenated ranks on either expert)."""
     pipe = _wan_pipe()
-    compile_cache.apply_lora_lane(pipe, 16)
+    compile_cache.apply_lora_execution_lane(pipe, 16)
     pipe._cozy_compile = object()
     wide: Dict[str, Any] = {}
     for path, mod in w8a8_lora.branch_modules(pipe.transformer_2).items():

--- a/tests/test_native_kernels_pgw860.py
+++ b/tests/test_native_kernels_pgw860.py
@@ -8,7 +8,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from gen_worker import kernel_lane  # noqa: E402
+from gen_worker import kernel_path  # noqa: E402
 from gen_worker.models import native_kernels as nk  # noqa: E402
 from gen_worker.models import svdq_fused  # noqa: E402
 from gen_worker.models import svdq_native as native  # noqa: E402
@@ -19,10 +19,10 @@ from gen_worker.models.svdq_layout import DecodedLinear  # noqa: E402
 @pytest.fixture(autouse=True)
 def _reset_arming(monkeypatch: pytest.MonkeyPatch):
     nk.reset_native_kernels_arming()
-    kernel_lane.clear()
+    kernel_path.clear()
     yield
     nk.reset_native_kernels_arming()
-    kernel_lane.clear()
+    kernel_path.clear()
 
 
 # --- env gating ------------------------------------------------------------
@@ -30,36 +30,36 @@ def _reset_arming(monkeypatch: pytest.MonkeyPatch):
 
 def test_unset_env_stays_baseline_dormant(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(nk.NATIVE_ENV, raising=False)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert "env-gated" in nk.svdq_linear_lane_reason()
-    assert nk.svdq_modulation_lane() == "dense"
-    assert "env-gated" in nk.svdq_modulation_lane_reason()
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert "env-gated" in nk.svdq_linear_execution_lane_reason()
+    assert nk.svdq_modulation_execution_lane() == "dense"
+    assert "env-gated" in nk.svdq_modulation_execution_lane_reason()
 
 
 def test_kill_switch_forces_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "0")
     # Even an armed verdict + passing self-checks must not arm past the
     # kill-switch, on either axis.
-    kernel_lane.pin("fused+packed", "test")
+    kernel_path.pin("fused+packed", "test")
     monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: None)
     monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert "kill-switch" in nk.svdq_linear_lane_reason()
-    assert nk.svdq_modulation_lane() == "dense"
-    assert "kill-switch" in nk.svdq_modulation_lane_reason()
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert "kill-switch" in nk.svdq_linear_execution_lane_reason()
+    assert nk.svdq_modulation_execution_lane() == "dense"
+    assert "kill-switch" in nk.svdq_modulation_execution_lane_reason()
 
 
 def test_armed_verdict_with_passing_self_checks_arms_both_axes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("fused+packed", "cell verdict")
+    kernel_path.pin("fused+packed", "cell verdict")
     monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: None)
     monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
-    assert nk.svdq_linear_lane() == "fused"
-    assert nk.svdq_modulation_lane() == "packed"
-    assert "cell verdict" in nk.svdq_linear_lane_reason()
-    assert "cell verdict" in nk.svdq_modulation_lane_reason()
+    assert nk.svdq_linear_execution_lane() == "fused"
+    assert nk.svdq_modulation_execution_lane() == "packed"
+    assert "cell verdict" in nk.svdq_linear_execution_lane_reason()
+    assert "cell verdict" in nk.svdq_modulation_execution_lane_reason()
 
 
 def test_the_axes_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,10 +68,10 @@ def test_the_axes_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
     win or 19% of its step time, with no way to take both — so the verdict
     vocabulary has to be able to say `baseline+packed`, and B200's does."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("baseline+packed", "cell verdict: B200 228 vs 350 ms")
+    kernel_path.pin("baseline+packed", "cell verdict: B200 228 vs 350 ms")
     monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert nk.svdq_modulation_lane() == "packed"
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert nk.svdq_modulation_execution_lane() == "packed"
 
 
 def test_a_baseline_axis_never_runs_its_self_check(
@@ -83,24 +83,24 @@ def test_a_baseline_axis_never_runs_its_self_check(
         raise AssertionError("the self-check must not run for a degraded axis")
 
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("baseline+dense", "cell verdict: B200 measured 228 vs 350")
+    kernel_path.pin("baseline+dense", "cell verdict: B200 measured 228 vs 350")
     monkeypatch.setattr(nk, "_fused_linear_self_check", boom)
     monkeypatch.setattr(nk, "_packed_modulation_self_check", boom)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert nk.svdq_modulation_lane() == "dense"
-    assert "228 vs 350" in nk.svdq_linear_lane_reason()
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert nk.svdq_modulation_execution_lane() == "dense"
+    assert "228 vs 350" in nk.svdq_linear_execution_lane_reason()
 
 
 def test_a_failing_self_check_degrades_only_its_own_axis(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("fused+packed", "cell verdict")
+    kernel_path.pin("fused+packed", "cell verdict")
     monkeypatch.setattr(nk, "_fused_linear_self_check", lambda: "no fp4 here")
     monkeypatch.setattr(nk, "_packed_modulation_self_check", lambda: None)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert "no fp4 here" in nk.svdq_linear_lane_reason()
-    assert nk.svdq_modulation_lane() == "packed"
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert "no fp4 here" in nk.svdq_linear_execution_lane_reason()
+    assert nk.svdq_modulation_execution_lane() == "packed"
 
 
 def test_self_check_raise_degrades_not_raises(
@@ -110,10 +110,10 @@ def test_self_check_raise_degrades_not_raises(
         raise RuntimeError("driver exploded")
 
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("fused+packed", "cell verdict")
+    kernel_path.pin("fused+packed", "cell verdict")
     monkeypatch.setattr(nk, "_fused_linear_self_check", boom)
-    assert nk.svdq_linear_lane() == "baseline"
-    assert "driver exploded" in nk.svdq_linear_lane_reason()
+    assert nk.svdq_linear_execution_lane() == "baseline"
+    assert "driver exploded" in nk.svdq_linear_execution_lane_reason()
 
 
 def test_no_verdict_is_the_declared_default_and_says_so(
@@ -122,13 +122,13 @@ def test_no_verdict_is_the_declared_default_and_says_so(
     """pgw#947 (d): nothing pinned a lane => the conservative default on BOTH
     axes, with a TYPED reason. Never a silent fall-through to a hand tuple."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.clear()
-    assert nk.svdq_linear_lane() == kernel_lane.linear_of(
-        kernel_lane.DEFAULT_LANE)
-    assert nk.svdq_modulation_lane() == kernel_lane.modulation_of(
-        kernel_lane.DEFAULT_LANE)
-    assert kernel_lane.REASON_ABSENT in nk.svdq_linear_lane_reason()
-    assert kernel_lane.REASON_ABSENT in nk.svdq_modulation_lane_reason()
+    kernel_path.clear()
+    assert nk.svdq_linear_execution_lane() == kernel_path.linear_of(
+        kernel_path.DEFAULT_EXECUTION_LANE)
+    assert nk.svdq_modulation_execution_lane() == kernel_path.modulation_of(
+        kernel_path.DEFAULT_EXECUTION_LANE)
+    assert kernel_path.REASON_ABSENT in nk.svdq_linear_execution_lane_reason()
+    assert kernel_path.REASON_ABSENT in nk.svdq_modulation_execution_lane_reason()
 
 
 def test_no_sm_allowlist_survives() -> None:
@@ -141,7 +141,7 @@ def test_no_sm_allowlist_survives() -> None:
     assert not hasattr(nk, "FUSED_LINEAR_SMS")
     assert not hasattr(nk, "PACKED_MODULATION_SMS")
     assert not hasattr(nk, "BLACKWELL_SMS")
-    assert kernel_lane.FUSED_MIN_SM == 100
+    assert kernel_path.FUSED_MIN_SM == 100
 
 
 def test_real_self_checks_on_this_host_degrade_cleanly(
@@ -151,11 +151,11 @@ def test_real_self_checks_on_this_host_degrade_cleanly(
     reason, never raise (on a Blackwell runner they instead arm — also
     fine)."""
     monkeypatch.setenv(nk.NATIVE_ENV, "1")
-    kernel_lane.pin("fused+packed", "cell verdict")
-    assert nk.svdq_linear_lane() in ("baseline", "fused")
-    assert nk.svdq_linear_lane_reason()
-    assert nk.svdq_modulation_lane() in ("dense", "packed")
-    assert nk.svdq_modulation_lane_reason()
+    kernel_path.pin("fused+packed", "cell verdict")
+    assert nk.svdq_linear_execution_lane() in ("baseline", "fused")
+    assert nk.svdq_linear_execution_lane_reason()
+    assert nk.svdq_modulation_execution_lane() in ("dense", "packed")
+    assert nk.svdq_modulation_execution_lane_reason()
 
 
 # --- extension probe -------------------------------------------------------
@@ -255,26 +255,26 @@ class _Model(torch.nn.Module):
         self.proj = torch.nn.Linear(in_f, out_f, bias=True)
 
 
-def test_swap_picks_fused_lane_when_armed(
+def test_swap_picks_fused_execution_lane_when_armed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     if svdq_fused.fused_ops() is None:
         pytest.skip("triton unavailable")
     dec = _tiny_decoded()
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "fused")
-    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "packed")
+    monkeypatch.setattr(nk, "svdq_linear_execution_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_modulation_execution_lane", lambda: "packed")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts == {"blockwise": 0, "dense": 0, "fused": 1, "prefixes": 1,
                       "linears": 1}
     assert getattr(model.proj, "_cozy_svdq_fused", False)
 
 
-def test_swap_baseline_when_lane_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_swap_baseline_when_execution_lane_off(monkeypatch: pytest.MonkeyPatch) -> None:
     dec = _tiny_decoded()
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "baseline")
-    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "dense")
+    monkeypatch.setattr(nk, "svdq_linear_execution_lane", lambda: "baseline")
+    monkeypatch.setattr(nk, "svdq_modulation_execution_lane", lambda: "dense")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts["fused"] == 0
     assert counts["blockwise"] == 1
@@ -293,8 +293,8 @@ def test_swap_unsupported_shape_degrades_to_blockwise(
         second_kind=dec.second_kind, rank=0, proj_down=None, proj_up=None,
         smooth_factor=dec.smooth_factor, bias=dec.bias)
     model = _Model(dec.out_features, dec.in_features)
-    monkeypatch.setattr(nk, "svdq_linear_lane", lambda: "fused")
-    monkeypatch.setattr(nk, "svdq_modulation_lane", lambda: "packed")
+    monkeypatch.setattr(nk, "svdq_linear_execution_lane", lambda: "fused")
+    monkeypatch.setattr(nk, "svdq_modulation_execution_lane", lambda: "packed")
     counts = native.swap_svdq_linears(model, {"proj": dec}, mode="blockwise")
     assert counts["fused"] == 0
     assert counts["blockwise"] == 1

--- a/tests/test_numerics_gate_pgw868.py
+++ b/tests/test_numerics_gate_pgw868.py
@@ -444,7 +444,7 @@ def test_the_verdict_is_bisectable_to_ONE_named_axis(
     del provision  # imported for the arm path above; nothing else needs it
 
 
-def test_an_axis_names_its_entry_row_lane_and_seed_and_reproduces():
+def test_an_axis_names_its_entry_row_execution_lane_and_seed_and_reproduces():
     """Every verdict carries its inputs. The seed is DERIVED from the axis, so
     two rows of one cell are never fed the same latent and any reader can
     rebuild the exact feed."""
@@ -453,12 +453,12 @@ def test_an_axis_names_its_entry_row_lane_and_seed_and_reproduces():
     axes = axes_from_meta(metadata())
     assert [a.name for a in axes] == sorted(entry_name(h, w) for h, w in ROWS)
     a, b = axes
-    assert a.lane == "w8a8" and a.target == TARGET
+    assert a.execution_lane == "w8a8" and a.target == TARGET
     assert {a.shape_row, b.shape_row} == {"h=8,w=8", "h=16,w=16"}
     assert a.seed != b.seed, "two axes share a seed; a shape-independent bug " \
                              "would read as agreement"
     # Reproducible across processes: the seed is a pure function of the axis.
-    assert ProbeAxis(entry=a.entry, target=a.target, lane=a.lane).seed == a.seed
+    assert ProbeAxis(entry=a.entry, target=a.target, execution_lane=a.execution_lane).seed == a.seed
     assert str(a).startswith(f"entry={a.entry} target={TARGET}")
 
 

--- a/tests/test_optional_slots_th1226.py
+++ b/tests/test_optional_slots_th1226.py
@@ -38,9 +38,9 @@ def _decode(data: bytes) -> EchoOut:
 def test_optional_slot_is_derived_from_the_setup_default() -> None:
     """The signature is the single declaration — no second `optional=` flag
     to drift out of sync with it."""
-    from harness.toy_endpoints import OptionalLaneEndpoint
+    from harness.toy_endpoints import OptionalExecutionLaneEndpoint
 
-    slots = getattr(OptionalLaneEndpoint, "__gen_worker_endpoint__").slots
+    slots = getattr(OptionalExecutionLaneEndpoint, "__gen_worker_endpoint__").slots
     assert slots["t2i"].optional is False
     assert slots["edit"].optional is True
 
@@ -62,7 +62,7 @@ def test_defaulted_param_whose_annotation_rejects_none_is_a_decoration_error() -
                 return EchoOut(response="x")
 
 
-def test_single_lane_deploy_binds_only_the_required_slot(tmp_path) -> None:
+def test_single_execution_lane_deploy_binds_only_the_required_slot(tmp_path) -> None:
     """A Hot DesiredInstance naming ONLY `t2i` is accepted, setup runs with
     the unbound slot's own default, and the bound lane serves."""
     blobs = BlobHost(tmp_path)
@@ -109,7 +109,7 @@ def test_single_lane_deploy_binds_only_the_required_slot(tmp_path) -> None:
         blobs.shutdown()
 
 
-def test_unbound_lane_refuses_typed_and_never_crashes_setup(tmp_path) -> None:
+def test_unbound_execution_lane_refuses_typed_and_never_crashes_setup(tmp_path) -> None:
     """Calling the lane this deploy did not bind is a client-visible INVALID
     refusal that names the slot — not a retry storm, not a worker crash."""
     blobs = BlobHost(tmp_path)
@@ -141,7 +141,7 @@ def test_unbound_lane_refuses_typed_and_never_crashes_setup(tmp_path) -> None:
         blobs.shutdown()
 
 
-def test_both_lanes_still_bind_unchanged(tmp_path) -> None:
+def test_both_execution_lanes_still_bind_unchanged(tmp_path) -> None:
     """Optionality must not change the dual-lane deploy — the shape every
     existing release uses."""
     blobs = BlobHost(tmp_path)
@@ -192,10 +192,10 @@ def test_both_lanes_still_bind_unchanged(tmp_path) -> None:
 def test_manifest_marks_the_optional_slot() -> None:
     """The hub must be able to tell a partial bind is legal — absent field
     still means required, so existing manifests are unchanged."""
-    from harness.toy_endpoints import OptionalLaneEndpoint
+    from harness.toy_endpoints import OptionalExecutionLaneEndpoint
 
     from gen_worker.discovery.discover import _slot_to_manifest
 
-    slots = getattr(OptionalLaneEndpoint, "__gen_worker_endpoint__").slots
+    slots = getattr(OptionalExecutionLaneEndpoint, "__gen_worker_endpoint__").slots
     assert "optional" not in _slot_to_manifest("t2i", slots["t2i"], family="")
     assert _slot_to_manifest("edit", slots["edit"], family="")["optional"] is True

--- a/tests/test_override_dtype_pgw675.py
+++ b/tests/test_override_dtype_pgw675.py
@@ -33,7 +33,7 @@ from safetensors.torch import save_file
 
 from gen_worker.convert.writer import streaming_w8a8_cast
 from gen_worker.models.loading import (
-    QUANT_LANE_COMPUTE_DEFAULT,
+    QUANT_EXECUTION_LANE_COMPUTE_DEFAULT,
     composition_compute_dtype,
     load_component_override,
 )
@@ -99,18 +99,18 @@ def _fp32_vae_override(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_composition_compute_dtype_is_lane_aware_on_w8a8(
+def test_composition_compute_dtype_is_execution_lane_aware_on_w8a8(
     tmp_path: Path,
 ) -> None:
     """RED pre-fix: the majority sniff returned "fp16" for a w8a8 tree whose
     lane computes bf16."""
     root = _w8a8_base_tree(tmp_path)
-    assert composition_compute_dtype(root) == QUANT_LANE_COMPUTE_DEFAULT
+    assert composition_compute_dtype(root) == QUANT_EXECUTION_LANE_COMPUTE_DEFAULT
     # A declared binding dtype still wins outright.
     assert composition_compute_dtype(root, "fp16") == "fp16"
 
 
-def test_override_decodes_bf16_latents_on_the_w8a8_lane(
+def test_override_decodes_bf16_latents_on_the_w8a8_execution_lane(
     tmp_path: Path,
 ) -> None:
     """The exact production crash path, for real on CPU: load the override

--- a/tests/test_partial_shape_coverage_pgw844.py
+++ b/tests/test_partial_shape_coverage_pgw844.py
@@ -360,7 +360,7 @@ def _boot(
     return ex, generate, pipe, events
 
 
-def test_one_undispatchable_bucket_does_not_cost_the_boot_its_compiled_lane(
+def test_one_undispatchable_bucket_does_not_cost_the_boot_its_compiled_execution_lane(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ):
     """THE pgw#844 assertion, on the real derived warm plan.
@@ -443,7 +443,7 @@ def test_an_ambiguous_request_is_charged_ingress_refused_not_counted_compiled(
     assert refused.fallback_reason == serving_mode.FALLBACK_INGRESS_REFUSED
 
 
-def test_the_partial_coverage_claim_is_scoped_to_the_exported_lane(
+def test_the_partial_coverage_claim_is_scoped_to_the_exported_execution_lane(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ):
     """The relaxation is a statement about the EXPORTED lane only.

--- a/tests/test_pgw714_compile_crash.py
+++ b/tests/test_pgw714_compile_crash.py
@@ -141,13 +141,13 @@ def test_setup_window_carries_pin_provenance(reset_compile_disable):
     class Pipe:
         pass
 
-    lane_tok = cc._SETUP_EXEC_LANE.set("bf16-w16a16+eager")
-    pin_tok = cc._SETUP_EXEC_LANE_PINNED.set(True)
+    execution_lane_tok = cc._SETUP_EXEC_EXECUTION_LANE.set("bf16-w16a16+eager")
+    pin_tok = cc._SETUP_EXEC_EXECUTION_LANE_PINNED.set(True)
     try:
         pipe = Pipe()
         assert cc.operator_eager_pin(pipe) is True
         # Stamped through, like the lane itself.
         assert getattr(pipe, cc.EXECUTION_LANE_PINNED_ATTR) is True
     finally:
-        cc._SETUP_EXEC_LANE_PINNED.reset(pin_tok)
-        cc._SETUP_EXEC_LANE.reset(lane_tok)
+        cc._SETUP_EXEC_EXECUTION_LANE_PINNED.reset(pin_tok)
+        cc._SETUP_EXEC_EXECUTION_LANE.reset(execution_lane_tok)

--- a/tests/test_pool_sizing_pgw842.py
+++ b/tests/test_pool_sizing_pgw842.py
@@ -276,7 +276,7 @@ def _relayed(table: Dict[str, Any]) -> List[pb.ActivityUpdate]:
     try:
         activity_mod.bind_sink(_send, loop)
         mint_delegate._emit_aot_phases(
-            outcome, family="sdxl", lane="w8a8-lora64")
+            outcome, family="sdxl", execution_lane="w8a8-lora64")
         loop.run_until_complete(asyncio.sleep(0.05))
     finally:
         activity_mod.bind_sink(None, None)

--- a/tests/test_rotation_preload_pgw674.py
+++ b/tests/test_rotation_preload_pgw674.py
@@ -386,7 +386,7 @@ def test_preload_component_staging_feeds_injection(
     asyncio.run(_run())
 
 
-def test_preload_component_staging_skips_quantized_lanes(
+def test_preload_component_staging_skips_quantized_execution_lanes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Quantized/flavored bindings load through special lanes a vanilla

--- a/tests/test_sequence_parallel_pgw748.py
+++ b/tests/test_sequence_parallel_pgw748.py
@@ -59,7 +59,7 @@ def _follower_echo(spec: RankSpec, chan: FollowerChannel) -> None:  # pragma: no
     pg = init_rank(spec)
     cmd = chan.next_command(timeout=120)
     plan = cmd["plan"]
-    assert plan.precision_lane == "w8a8"
+    assert plan.precision_execution_lane == "w8a8"
     assert plan.gemm_mode == "rowwise"
     chan.report_ready(spec.rank)
     dist.barrier(group=pg)
@@ -72,7 +72,7 @@ def _follower_disagrees(spec: RankSpec, chan: FollowerChannel) -> None:  # pragm
     against the delivered plan)."""
     init_rank(spec)
     cmd = chan.next_command(timeout=120)
-    mine = GroupPlan(precision_lane="bf16", sp_degree=2)
+    mine = GroupPlan(precision_execution_lane="bf16", sp_degree=2)
     mine.assert_agrees(cmd["plan"], rank=spec.rank)
 
 
@@ -97,7 +97,7 @@ def test_rank_zero_decides_and_every_rank_obeys() -> None:
     try:
         assert spec.rank == 0 and spec.world_size == 2
         plan = GroupPlan(
-            precision_lane="w8a8", gemm_mode="rowwise", sp_degree=2,
+            precision_execution_lane="w8a8", gemm_mode="rowwise", sp_degree=2,
             loras=(("style", 0.8),),
         )
         group.send({"op": "arm", "plan": plan})
@@ -115,7 +115,7 @@ def test_a_follower_that_disagrees_fails_the_group() -> None:
     group.form()
     try:
         group.send({"op": "arm",
-                    "plan": GroupPlan(precision_lane="w8a8", sp_degree=2)})
+                    "plan": GroupPlan(precision_execution_lane="w8a8", sp_degree=2)})
         with pytest.raises(RankGroupError):
             for _ in range(200):
                 group.check_alive()
@@ -177,8 +177,8 @@ def test_degree_one_group_forms_nothing() -> None:
 
 
 def test_plan_agreement_names_the_exact_field() -> None:
-    a = GroupPlan(precision_lane="w8a8", compile_armed=True, sp_degree=2)
-    b = GroupPlan(precision_lane="w8a8", compile_armed=False, sp_degree=2)
+    a = GroupPlan(precision_execution_lane="w8a8", compile_armed=True, sp_degree=2)
+    b = GroupPlan(precision_execution_lane="w8a8", compile_armed=False, sp_degree=2)
     with pytest.raises(RankDivergence) as exc:
         a.assert_agrees(b, rank=1)
     assert exc.value.field_name == "compile_armed"
@@ -300,7 +300,7 @@ def test_degree_four_group_forms_and_every_rank_obeys_rank_zero() -> None:
         assert (spec.rank, spec.world_size) == (0, 4)
         assert group.degree == 4
         plan = GroupPlan(
-            precision_lane="w8a8", gemm_mode="rowwise", sp_degree=4,
+            precision_execution_lane="w8a8", gemm_mode="rowwise", sp_degree=4,
             compile_armed=False, loras=(("style", 0.8),),
         )
         group.send({"op": "arm", "plan": plan})

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -249,7 +249,7 @@ class _Rig:
             return provision.SlotLoad(obj=pipe, is_pipeline=True)
 
         def _mandatory_miss(*a: Any, **k: Any) -> bool:
-            raise cc.CompiledLaneUnavailableError("no delivered cell")
+            raise cc.CompiledExecutionLaneUnavailableError("no delivered cell")
 
         monkeypatch.setattr(executor_mod, "ensure_local", _download)
         monkeypatch.setattr(provision, "load_slot", _load_slot)
@@ -375,7 +375,7 @@ def test_same_key_rearm_reuses_finalized_cell_with_a_real_fx_hit(
         assert fleet_cells._PENDING == {}
 
 
-def test_genuinely_unservable_lane_degrades_to_eager_not_death(
+def test_genuinely_unservable_execution_lane_degrades_to_eager_not_death(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -398,7 +398,7 @@ def test_genuinely_unservable_lane_degrades_to_eager_not_death(
     with caplog.at_level(logging.ERROR):
         rig.boot(gen)
 
-    # The 0.64.0 outcome was CompiledLaneUnavailableError -> generate
+    # The 0.64.0 outcome was CompiledExecutionLaneUnavailableError -> generate
     # disabled -> pod retired. Now: alive, eager, loud.
     assert "generate" not in rig.ex.unavailable
     assert rig.ex.serving_tiers()["generate"] == "eager"
@@ -422,7 +422,7 @@ def test_genuinely_unservable_lane_degrades_to_eager_not_death(
         assert fleet_cells._PENDING == {}
 
 
-def test_compile_failure_on_mandatory_lane_degrades_per_sku(
+def test_compile_failure_on_mandatory_execution_lane_degrades_per_sku(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_shared_lane_precision_th1043.py
+++ b/tests/test_shared_lane_precision_th1043.py
@@ -12,7 +12,7 @@ precision for the WHOLE group up front, against its COMBINED footprint.
 
 from __future__ import annotations
 
-from gen_worker.executor import _shared_lanes_need_fp8
+from gen_worker.executor import _shared_execution_lanes_need_fp8
 
 _GiB = 1024 ** 3
 
@@ -29,29 +29,29 @@ def test_starved_group_forces_fp8_when_it_fits():
     # A100-80GB: ~79GiB usable. Native (15.5 + 40 + 40 = 95.5GiB) doesn't
     # fit; fp8'd transformers (15.5 + 20 + 20 = 55.5GiB) do.
     free = 79 * _GiB
-    assert _shared_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is True
+    assert _shared_execution_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is True
 
 
 def test_group_that_fits_natively_is_left_alone():
     # A card with enough headroom for both lanes at native precision needs
     # no forcing.
     free = 200 * _GiB
-    assert _shared_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is False
+    assert _shared_execution_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is False
 
 
 def test_group_that_cannot_fit_even_at_fp8_is_left_to_the_ladder():
     # Too small even halved: forcing fp8 here would just relocate the
     # failure, not fix it — leave it to the existing per-lane ladder.
     free = 30 * _GiB
-    assert _shared_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is False
+    assert _shared_execution_lanes_need_fp8(_QWEN_SIZES, _SHARED, free) is False
 
 
-def test_single_lane_group_never_forces():
-    assert _shared_lanes_need_fp8({"t2i": _QWEN_SIZES["t2i"]}, _SHARED, 1 * _GiB) is False
+def test_single_execution_lane_group_never_forces():
+    assert _shared_execution_lanes_need_fp8({"t2i": _QWEN_SIZES["t2i"]}, _SHARED, 1 * _GiB) is False
 
 
 def test_no_shared_components_never_forces():
-    assert _shared_lanes_need_fp8(_QWEN_SIZES, [], 1 * _GiB) is False
+    assert _shared_execution_lanes_need_fp8(_QWEN_SIZES, [], 1 * _GiB) is False
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ def test_no_shared_components_never_forces():
 # ---------------------------------------------------------------------------
 
 
-def test_fp8_lane_holds_with_and_without_group_forcing(tmp_path):
+def test_fp8_execution_lane_holds_with_and_without_group_forcing(tmp_path):
     import pytest
 
     pytest.importorskip("torch")

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -651,7 +651,7 @@ def test_an_eager_request_on_a_compile_declaring_release_names_its_reason() -> N
     ("w8a8", "w8a8_partial_swap"),
     ("w4a4", "w4a4_partial_swap"),
 ])
-def test_a_partially_swapped_quant_lane_confesses_with_counts(
+def test_a_partially_swapped_quant_execution_lane_confesses_with_counts(
     mod_name: str, phase: str,
 ) -> None:
     """RED before pgw#824.
@@ -684,7 +684,7 @@ def test_a_partially_swapped_quant_lane_confesses_with_counts(
         "per model — not once per skipped layer")
 
 
-def test_an_unqualified_fp8_gemm_is_a_lane_decision_that_reports_itself() -> None:
+def test_an_unqualified_fp8_gemm_is_a_execution_lane_decision_that_reports_itself() -> None:
     """The whole point of the w8a8 artifact is the fused fp8 GEMM. Falling to
     the dequant lane keeps the memory saving and gives up the speed, so every
     request is slower than the lane the pod advertises — and a fleet-wide

--- a/tests/test_speculative_lane_completeness_pgw918.py
+++ b/tests/test_speculative_lane_completeness_pgw918.py
@@ -24,12 +24,12 @@ from pathlib import Path
 from typing import Dict, Set, Tuple
 
 from gen_worker import aot_mint, executor
-from gen_worker.compile_cache import lane_bucket
+from gen_worker.compile_cache import execution_lane_bucket
 from gen_worker.models import loading
-from gen_worker.models.w8a8_lora import lora_lane
+from gen_worker.models.w8a8_lora import lora_execution_lane
 
 #: Assignment targets that mean "this pipeline's base weight lane".
-_LANE_TARGETS = frozenset({"_cozy_weight_lane", "_WEIGHT_LANE_ATTR"})
+_EXECUTION_LANE_TARGETS = frozenset({"_cozy_weight_lane", "_WEIGHT_LANE_ATTR"})
 
 #: Folded by :func:`loading.pipeline_weight_lane` to ``""`` — it traces
 #: identically to plain bf16 and is therefore not a distinct cell lane.
@@ -56,15 +56,15 @@ def _string_literals(node: ast.AST) -> Set[str]:
     return set()
 
 
-def _is_lane_target(target: ast.AST) -> bool:
+def _is_execution_lane_target(target: ast.AST) -> bool:
     if isinstance(target, ast.Attribute):
-        return target.attr in _LANE_TARGETS
+        return target.attr in _EXECUTION_LANE_TARGETS
     if isinstance(target, ast.Name):
-        return target.id in _LANE_TARGETS
+        return target.id in _EXECUTION_LANE_TARGETS
     return False
 
 
-def stamped_lanes() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
+def stamped_execution_lanes() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
     """``(literal lanes, derived lanes)`` keyed by ``file:line``.
 
     ``setattr(pipe, _WEIGHT_LANE_ATTR, "fp8-hooks")`` is a Call, not an
@@ -78,7 +78,7 @@ def stamped_lanes() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
         for node in ast.walk(tree):
             value: ast.AST | None = None
             if isinstance(node, ast.Assign) and any(
-                _is_lane_target(t) for t in node.targets
+                _is_execution_lane_target(t) for t in node.targets
             ):
                 value = node.value
             elif (
@@ -86,7 +86,7 @@ def stamped_lanes() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
                 and isinstance(node.func, ast.Name)
                 and node.func.id == "setattr"
                 and len(node.args) == 3
-                and _is_lane_target(node.args[1])
+                and _is_execution_lane_target(node.args[1])
             ):
                 value = node.args[2]
             if value is None:
@@ -106,13 +106,13 @@ def stamped_lanes() -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
     return literal, derived
 
 
-def test_every_stampable_lane_is_in_the_single_source_of_truth():
-    literal, _derived = stamped_lanes()
+def test_every_stampable_execution_lane_is_in_the_single_source_of_truth():
+    literal, _derived = stamped_execution_lanes()
     assert literal, "found no _cozy_weight_lane assignment sites to check"
-    known = set(loading.STAMPABLE_BASE_LANES) | _FOLDED
+    known = set(loading.STAMPABLE_BASE_EXECUTION_LANES) | _FOLDED
     unknown = {
-        where: sorted(lanes - known)
-        for where, lanes in literal.items() if lanes - known
+        where: sorted(execution_lanes - known)
+        for where, execution_lanes in literal.items() if execution_lanes - known
     }
     assert not unknown, (
         f"loaders stamp base lanes that loading.STAMPABLE_BASE_LANES does not "
@@ -122,20 +122,20 @@ def test_every_stampable_lane_is_in_the_single_source_of_truth():
     )
 
 
-def test_the_ie546_lanes_and_the_two_pgw918_found_are_all_covered():
+def test_the_ie546_execution_lanes_and_the_two_pgw918_found_are_all_covered():
     """The regression this issue IS: w4a4 and svdq-native were missing."""
-    for lane in ("", "fp8-hooks", "w8a8", "w4a4", "svdq-native"):
-        assert lane in loading.STAMPABLE_BASE_LANES
+    for execution_lane in ("", "fp8-hooks", "w8a8", "w4a4", "svdq-native"):
+        assert execution_lane in loading.STAMPABLE_BASE_EXECUTION_LANES
 
 
 def test_the_executor_speculates_exactly_the_loader_vocabulary():
     """One list, not two. The pre-load pull-by-key lookup speculates every
     lane a loader can leave, because there is no second copy to drift."""
-    assert (tuple(executor._SPECULATIVE_CELL_BASE_LANES)
-            == tuple(loading.STAMPABLE_BASE_LANES))
+    assert (tuple(executor._SPECULATIVE_CELL_BASE_EXECUTION_LANES)
+            == tuple(loading.STAMPABLE_BASE_EXECUTION_LANES))
 
 
-def test_the_mint_holds_no_lane_allowlist_at_all():
+def test_the_mint_holds_no_execution_lane_allowlist_at_all():
     """pgw#850 superseded pgw#918's second half by DELETION.
 
     ``PARITY_LANES`` was the surviving half of that allowlist — one member,
@@ -156,23 +156,23 @@ def test_the_one_derived_stamp_site_decomposes_to_a_named_base():
     as a literal.  It is the BUCKETED form of a base lane, so the base set
     stays complete iff every base it can be handed decomposes back out of
     ``lane_bucket`` into the same list."""
-    _literal, derived = stamped_lanes()
+    _literal, derived = stamped_execution_lanes()
     assert derived, "expected the bucketed lora_lane stamp site"
-    for base in loading.STAMPABLE_BASE_LANES:
+    for base in loading.STAMPABLE_BASE_EXECUTION_LANES:
         for sparse in (False, True):
-            stamp = lora_lane(64, sparse, base=base)
-            decomposed, bucket = lane_bucket(stamp)
+            stamp = lora_execution_lane(64, sparse, base=base)
+            decomposed, bucket = execution_lane_bucket(stamp)
             if sparse:
                 # Sparse placement is eager-only and never produces a cell —
                 # it deliberately does not parse as bucketed.
                 assert bucket == 0
                 continue
             assert bucket == 64
-            assert decomposed in loading.STAMPABLE_BASE_LANES, (
+            assert decomposed in loading.STAMPABLE_BASE_EXECUTION_LANES, (
                 f"lora_lane(base={base!r}) decomposes to {decomposed!r}, "
                 f"which is not a named base lane")
 
 
-def test_the_dead_regressed_lanes_constant_is_gone():
+def test_the_dead_regressed_execution_lanes_constant_is_gone():
     """It had no reader in src/ and named an unstampable lane."""
     assert not hasattr(aot_mint, "REGRESSED_LANES")

--- a/tests/test_svdq_lowrank_quant_te148.py
+++ b/tests/test_svdq_lowrank_quant_te148.py
@@ -264,7 +264,7 @@ def test_declaration_and_bytes_must_agree() -> None:
                          lowrank_quant="bf16").lowrank_quant == "bf16"
 
 
-def test_bf16_lane_is_byte_identical_to_before() -> None:
+def test_bf16_execution_lane_is_byte_identical_to_before() -> None:
     """Backward compatibility: a bf16-branch checkpoint decodes exactly as it
     did before te#148, with or without the declaration."""
     out_f, in_f = 3072, 3072

--- a/tests/test_svdq_official_layout_pgw770.py
+++ b/tests/test_svdq_official_layout_pgw770.py
@@ -51,9 +51,9 @@ E2M1_MAX, FP8_MAX = 6.0, 448.0
 # ---------------------------------------------------------------------------
 
 MEM_N, MEM_K = 128, 64
-NUM_N_PACKS, N_PACK_SIZE, NUM_N_LANES, REG_N = 8, 2, 8, 1
-NUM_K_PACKS, K_PACK_SIZE, NUM_K_LANES, REG_K = 1, 2, 4, 8
-WARP_N, NUM_LANES, INSN_K = 128, 32, 64
+NUM_N_PACKS, N_PACK_SIZE, NUM_N_EXECUTION_LANES, REG_N = 8, 2, 8, 1
+NUM_K_PACKS, K_PACK_SIZE, NUM_K_EXECUTION_LANES, REG_K = 1, 2, 4, 8
+WARP_N, NUM_EXECUTION_LANES, INSN_K = 128, 32, 64
 
 
 def dc_pack_weight(weight: torch.Tensor) -> torch.Tensor:
@@ -61,8 +61,8 @@ def dc_pack_weight(weight: torch.Tensor) -> torch.Tensor:
     n, k = weight.shape
     n_tiles, k_tiles = n // MEM_N, k // MEM_K
     weight = weight.to(torch.int32).reshape(
-        n_tiles, NUM_N_PACKS, N_PACK_SIZE, NUM_N_LANES, REG_N,
-        k_tiles, NUM_K_PACKS, K_PACK_SIZE, NUM_K_LANES, REG_K)
+        n_tiles, NUM_N_PACKS, N_PACK_SIZE, NUM_N_EXECUTION_LANES, REG_N,
+        k_tiles, NUM_K_PACKS, K_PACK_SIZE, NUM_K_EXECUTION_LANES, REG_K)
     weight = weight.permute(0, 5, 6, 1, 3, 8, 2, 7, 4, 9).contiguous()
     assert weight.shape[4:-2] == (8, 4, 2, 2)
     weight = weight.bitwise_and_(0xF)
@@ -81,7 +81,7 @@ def dc_pack_micro_scale(scale: torch.Tensor, group_size: int = 16,
     if cast:
         scale = scale.to(dtype=torch.float8_e4m3fn)
     n = scale.shape[0]
-    s_pack_size = min(max(WARP_N // NUM_LANES, 1), 4)
+    s_pack_size = min(max(WARP_N // NUM_EXECUTION_LANES, 1), 4)
     num_s_lanes = 4 * 8
     num_s_packs = -(-WARP_N // (s_pack_size * num_s_lanes))
     warp_s = num_s_packs * num_s_lanes * s_pack_size
@@ -95,8 +95,8 @@ def dc_pack_micro_scale(scale: torch.Tensor, group_size: int = 16,
 def dc_pack_scale(scale: torch.Tensor) -> torch.Tensor:
     """deepcompressor NunchakuWeightPacker.pack_scale, group_size=-1."""
     n = scale.shape[0]
-    s_pack_size = min(max(WARP_N // NUM_LANES, 2), 8)
-    num_s_lanes = min(NUM_LANES, WARP_N // s_pack_size)
+    s_pack_size = min(max(WARP_N // NUM_EXECUTION_LANES, 2), 8)
+    num_s_lanes = min(NUM_EXECUTION_LANES, WARP_N // s_pack_size)
     num_s_packs = WARP_N // (s_pack_size * num_s_lanes)
     warp_s = num_s_packs * num_s_lanes * s_pack_size
     assert warp_s == WARP_N
@@ -109,8 +109,8 @@ def dc_pack_scale(scale: torch.Tensor) -> torch.Tensor:
 def dc_pack_lowrank_weight(weight: torch.Tensor, down: bool) -> torch.Tensor:
     """deepcompressor NunchakuWeightPacker.pack_lowrank_weight."""
     reg_n, reg_k = 1, 2
-    pack_n = N_PACK_SIZE * NUM_N_LANES * reg_n
-    pack_k = K_PACK_SIZE * NUM_K_LANES * reg_k
+    pack_n = N_PACK_SIZE * NUM_N_EXECUTION_LANES * reg_n
+    pack_k = K_PACK_SIZE * NUM_K_EXECUTION_LANES * reg_k
     if down:
         r, c = weight.shape
         r_packs, c_packs = r // pack_n, c // pack_k
@@ -121,8 +121,8 @@ def dc_pack_lowrank_weight(weight: torch.Tensor, down: bool) -> torch.Tensor:
         c_packs, r_packs = c // pack_n, r // pack_k
         weight = weight.view(c_packs, pack_n, r_packs,
                              pack_k).permute(0, 2, 1, 3)
-    weight = weight.reshape(c_packs, r_packs, N_PACK_SIZE, NUM_N_LANES, reg_n,
-                            K_PACK_SIZE, NUM_K_LANES, reg_k)
+    weight = weight.reshape(c_packs, r_packs, N_PACK_SIZE, NUM_N_EXECUTION_LANES, reg_n,
+                            K_PACK_SIZE, NUM_K_EXECUTION_LANES, reg_k)
     weight = weight.permute(0, 1, 3, 6, 2, 5, 4, 7).contiguous()
     return weight.reshape(c, r)
 

--- a/tests/test_swap_bench_pgw689.py
+++ b/tests/test_swap_bench_pgw689.py
@@ -123,7 +123,7 @@ def test_benchmark_loads_a_quantized_component_via_the_serve_path(
     assert rel < 0.13
 
 
-def test_unquantized_siblings_still_load_and_honor_the_lane_dtype(
+def test_unquantized_siblings_still_load_and_honor_the_execution_lane_dtype(
     w8a8_tree: Path,
 ) -> None:
     """A w8a8 tree's NON-denoiser components take the ordinary path — and
@@ -160,7 +160,7 @@ def test_bench_load_walks_a_quantized_tree_end_to_end(
     assert any(r.bytes > 0 for r in rows)
 
 
-def test_lanes_without_a_component_loader_refuse_by_name(
+def test_execution_lanes_without_a_component_loader_refuse_by_name(
     tmp_path: Path,
 ) -> None:
     """svdq builds its denoiser inside the pipeline load. Handing back a
@@ -169,7 +169,7 @@ def test_lanes_without_a_component_loader_refuse_by_name(
     import json
 
     from gen_worker.models.loading import (
-        ComponentLaneUnsupported, load_component,
+        ComponentExecutionLaneUnsupported, load_component,
     )
 
     tree = tmp_path / "svdq"
@@ -191,7 +191,7 @@ def test_lanes_without_a_component_loader_refuse_by_name(
                       "weight": {"dtype": "int4"}})},
     )
     assert detect_svdq_artifact(tree) is not None
-    with pytest.raises(ComponentLaneUnsupported, match="svdq"):
+    with pytest.raises(ComponentExecutionLaneUnsupported, match="svdq"):
         load_component(tree, "transformer")
 
 

--- a/tests/test_trt_engine.py
+++ b/tests/test_trt_engine.py
@@ -309,9 +309,9 @@ def test_trt_guard_revocation_failure_never_falls_back(monkeypatch):
         raise RuntimeError("state path unavailable")
 
     state["failure_callback"] = revoke
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="revocation failed"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="revocation failed"):
         module.forward(object())
-    with pytest.raises(cc.CompiledLaneUnavailableError, match="revocation failed"):
+    with pytest.raises(cc.CompiledExecutionLaneUnavailableError, match="revocation failed"):
         module.forward(object())
     assert calls == {"eager": 0, "runner": 1, "callback": 1}
 

--- a/tests/test_turbo_overlay_gw627.py
+++ b/tests/test_turbo_overlay_gw627.py
@@ -168,7 +168,7 @@ def test_turbo_adapter_rides_the_branch_on_a_w8a8_pertensor_unet() -> None:
         unet, "down_blocks.1.attentions.0.transformer_blocks.0.attn1.to_q")
     unet._cozy_w8a8_mode = "pertensor"
     pipe = _Pipe(unet)
-    # The arming path (Compile.lora_bucket / apply_lora_lane) pre-enables
+    # The arming path (Compile.lora_bucket / apply_lora_execution_lane) pre-enables
     # canonical zeroed branches; the compiled marker forbids resizes.
     w8a8_lora.enable_lora_branches(unet, 16)
     pipe._cozy_compile = object()

--- a/tests/test_vocabulary_train_pgw654.py
+++ b/tests/test_vocabulary_train_pgw654.py
@@ -343,7 +343,7 @@ def test_warm_override_on_axis_field_is_a_walk_time_error() -> None:
         extract_specs(BadWarm)
 
 
-def test_dual_pin_lanes_never_dedupe_across_text_pins() -> None:
+def test_dual_pin_execution_lanes_never_dedupe_across_text_pins() -> None:
     from gen_worker import warmup as warmup_mod
 
     specs = extract_specs(DualPin)

--- a/tests/test_warm_tax_pgw654.py
+++ b/tests/test_warm_tax_pgw654.py
@@ -203,7 +203,7 @@ def test_eager_boot_reduces_and_instance_swaps_verify_once(
     asyncio.run(_run())
 
 
-def test_warm_contract_key_splits_on_lane_and_overrides_not_ref(
+def test_warm_contract_key_splits_on_execution_lane_and_overrides_not_ref(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     ex = _executor(tmp_path, monkeypatch)

--- a/tests/test_worker_outbox_pgw869.py
+++ b/tests/test_worker_outbox_pgw869.py
@@ -339,7 +339,7 @@ def test_beats_coalesce_in_place_and_facts_never_do() -> None:
     asyncio.run(_run())
 
 
-def test_a_result_never_enters_the_evidence_lane() -> None:
+def test_a_result_never_enters_the_evidence_execution_lane() -> None:
     """The precondition that makes `_evidence_bytes` total.
 
     `_message_key` returns None for a JobResult deliberately — a result is not


### PR DESCRIPTION
th#1582 Phase A (pgw): the EXECUTION LANE concept is spelled `execution_lane`, and `kernel_lane` is a kernel PATH — names only, with the five things that are NOT names proven untouched

The tensorhub half landed as th PR #788 (`e34657e0`). This is the twin cut, and it
carries the same contract: nothing but names moves.

## What moved

1,655 Python identifier tokens across 113 files (`Lane` -> `ExecutionLane`,
`lane` -> `execution_lane`, `LaneSpec`, `parse_lane_spec`, `LaneUnavailableError`,
`arm_lane_gate`, `known_lanes`, `stamp_lane`, ...), plus 18 identifier references
inside `#` comments. The rewrite ran through `tokenize` over NAME tokens ONLY, so
string literals and docstrings could not be touched by construction.

Three modules move with the concept, because a module name IS an identifier at
every import site:

  gen_worker.kernel_lane          -> gen_worker.kernel_path
  gen_worker.models.lanes         -> gen_worker.models.execution_lanes
  gen_worker.models.lane_gate     -> gen_worker.models.execution_lane_gate

`kernel_lane` -> `kernel_path` is th#1582's own instruction, not a liberty:
pgw#947 established that "which GEMM realizes this lane on this card" is a
kernel PATH, a different question from which lane is being served.

102 string literals also changed. Every one is a bare Python identifier in a
position that NAMES a symbol — an `__all__` entry, a `monkeypatch.setattr` /
`getattr` target, `add_argument(dest=...)`, a `pytest.mark.parametrize` argname,
or a forward-ref annotation. Proved, not asserted: every string literal in the
tree was dumped through `tokenize` on `origin/dev` and at HEAD and diffed; all
102 differences match `^[A-Za-z_][A-Za-z0-9_]*$` and every one is the old or new
spelling of a renamed symbol.

## The five things this does NOT change, and the proof for each

**1. The lane STRING grammar is data.** `"fp8-w8a8-dynamic+compiled"`,
`"bf16-w16a16+eager"`, the 25 ids in the shared-spec twin, refusal codes
(`lane_unavailable`, `unknown_lane`), report keys (`{"lane": ...}`) — all
byte-identical, from the literal diff above. th#1580 changes values on its own
schedule. The twin relationship with tensorhub's
`internal/orchestrator/precision/lane.go` is unaffected: the ids never moved.

**2. Nothing on the wire.** `proto/` and `src/gen_worker/pb/` have a zero-byte
diff; `scripts/proto-drift-check.sh` still matches `PROTO_DIGEST`
(`3e3313df…`). `RunJob.lane`, `JobMetrics.lane`, `ModelResolution.lane`,
`lane_pinned` and `FunctionCapability.lane` keep their spelling at every read
and every construction — an AST pass over the whole tree confirms no call
passes `execution_lane=` to a protobuf message that has no such field.

**3. `weight_lane` / `pipeline_weight_lane` / `_cozy_weight_lane` is Phase B.**
Excluded by the renamer itself. th#1580 REDEFINES the artifact side as a
versioned contract; giving it a new name now would cement the old meaning under
it. `_cozy_lora_base_lane` is kept for the same reason (it is the branchless
WEIGHT stamp, and it is read back by string).

**4. `kernel_lane.META_KEY` is a VALUE, so no cell re-mints.** The module is
now `kernel_path`, but `META_KEY == "kernel_lane"` — the key written into
minted cell metadata — is a string literal and is unchanged. The envelope's
`{"lane": ...}` keys are unchanged too. Not one published cell is stale, and
the self-mint-on-miss path (pgw#950) is never entered on account of this PR.

**5. `plane` is a substring trap, and so is a GPU warp lane.** The renamer
splits identifiers into words and matches whole words, so `plane` cannot match:
7 `plane`-bearing NAME tokens on `origin/dev`, the same 7 at HEAD, byte-identical
sorted dumps. `models/svdq_layout.py`'s `num_n_lanes` / `num_k_lanes` /
`num_s_lanes` are the SM's LANES IN AN MMA FRAGMENT — a fifth meaning of the
word, also read back as dict-key strings — and are excluded by name.

## Sites deliberately left, each with a reason

- `tests/harness/toy_endpoints.py`: `LaneAwareEndpoint.lane_echo` keeps its
  spelling. The class and method names are the endpoint id and the wire
  FUNCTION NAME, and tensorhub's committed cross-repo golden
  (`internal/builder/testdata/genworker_handles_manifest_th1050.json`) records
  `"LaneAwareEndpoint"`, `"lane-echo"` and `"lane_echo"` verbatim.
- `--lane` stays `--lane`. The FLAG is what a human types; only its `dest`
  became `execution_lane`.
- `cell_key`'s `lane` axis keeps its name: the axis vocabulary is hashed into
  every published cell key.
- `lanespec`, the local import alias for the vocabulary module, is a
  run-together spelling with no word boundary to match. Left as-is.
- Docstrings are NOT rewritten. Unlike a Go doc comment, a Python docstring is
  a string literal, and a blanket pass over string literals is exactly the pass
  that corrupts `{"lane": ...}` report keys — the same call tensorhub made for
  comment prose, for the same reason.
- `executor.py`'s local `plane = pick_execution_lane_of(pick)` is a
  pre-existing misspelling of `lane` on `dev`. Renaming it is a judgement about
  meaning, not a mechanical rename; left, and reported.

## Gates

`pytest tests/` 3102 passed / 37 skipped / 1 xfailed and `pytest tests_v2/`
21 passed — both IDENTICAL to the `origin/dev` baseline measured in the same
venv before the first edit. mypy clean (226 source files, same as baseline),
ruff clean, `scripts/lint_http_timeouts.py`, `scripts/lint_unreached_surface.py`,
`scripts/lint_config_reads.py`, `scripts/check_registry_contract.py` and
`scripts/proto-drift-check.sh` all exit 0.

Note on the pgw#949 baseline: the two guard tests filed red are GREEN on
`origin/dev` as of `f65b3cfa` — measured, not assumed — so this PR is gated
against a fully green baseline.
