### PR TITLE
pgw#955: the republish flake is a product race — a plan re-send landing mid-reconcile was swallowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@
   `--lane`, `kernel_lane.META_KEY == "kernel_lane"` in minted cell metadata,
   and the `weight_lane` family (th#1580 Phase B) are byte-identical.
 
+- **pgw#955: a hub plan re-send that landed WHILE a residency reconcile was
+  running was dropped on the floor — the redrive's re-report never happened.**
+  It presented as a load-only test flake (`test_reissued_plan_republishes_held_
+  identity` stalling at "1 of 2 ON_DISK re-reports" on both attempts of PR
+  #470's `tests` job) and it is a product bug. gw#614 taught
+  `_replace_residency_reconcile` not to CANCEL an in-flight reconcile when the
+  re-sent plan's semantic model set is unchanged — a running `self_mint_compile`
+  needs its window — but it then returned having told the running loop nothing.
+  Meanwhile `replace_desired_snapshots` had already opened a republish epoch,
+  and only a reconcile pass ever reads one: no cancel, no restart, no
+  re-announce, and no later event to heal it. Under pgw#628/th#1070 v2 that
+  epoch IS the hub asking for a resync of the lost success observation, so the
+  swallow silently defeated the resync precisely when the worker was busiest —
+  the state in which observations get lost. The branch now signals the
+  level-triggered restart (gw#623's mechanism) instead of returning silently:
+  the loop finishes the item it is on, then re-converges and re-announces under
+  the new epoch. gw#614's no-cancel guarantee is untouched, the re-pass
+  short-circuits everything already satisfied, and the epoch guard still caps
+  emission at one re-report per ref per applied ack. The window was ~one
+  event-loop step wide when the plan materialized instantly, which is the whole
+  reason it read as a flake; the new test holds it open on purpose (a second
+  ref in the same plan parked on a blob the test does not answer until it has
+  proven the re-sent plan was applied) and reproduces the exact CI failure
+  message deterministically.
+
 - **pgw#943: a child-call wait now YIELDS the GPU permit — the worker
   pipelines while parked on a child request.** #455 measured the defect: at
   `gpu_slots=1` a parent in `ctx.call_endpoint` held its group permit for the

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -648,6 +648,17 @@ class Lifecycle:
             and getattr(self, "_residency_model_key", None) == model_key
         ):
             self._desired_residency = desired
+            # pgw#955: not cancelling is not the same as doing nothing. The
+            # ack already opened a republish epoch (replace_desired_snapshots),
+            # and only a reconcile pass reads it — so returning silently here
+            # dropped the hub's redrive on the floor, with no cancel, no
+            # restart, and no later event to heal it. Signal the level-
+            # triggered loop instead: it finishes the item it is on (gw#614
+            # intact) and then re-converges, which re-announces the held
+            # identities under the new epoch. The re-pass is cheap and cannot
+            # spam — satisfied refs short-circuit, and the epoch guard emits
+            # at most one re-report per ref per applied ack.
+            self._signal_residency_restart()
             wanted = {instance.function_name for instance in desired.hot if instance.function_name}
             if wanted.issubset(set(self.executor.available_functions())):
                 self.intent_registry.bindings_applied(int(desired.config_generation))

--- a/tests/harness/blob_host.py
+++ b/tests/harness/blob_host.py
@@ -16,8 +16,15 @@ from gen_worker.pb import worker_scheduler_pb2 as pb
 
 
 class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args: Any, directory: str, **kwargs: Any) -> None:
+    def __init__(
+        self, *args: Any, directory: str, host: "BlobHost", **kwargs: Any,
+    ) -> None:
+        self._host = host
         super().__init__(*args, directory=directory, **kwargs)
+
+    def send_head(self) -> Any:
+        self._host.before_serve(self.path.lstrip("/"))
+        return super().send_head()
 
     def log_message(self, *_args: Any) -> None:  # silence
         pass
@@ -31,7 +38,8 @@ class BlobHost:
         self._dir.mkdir(parents=True, exist_ok=True)
 
         def _handler(*args: Any, **kwargs: Any) -> _QuietHandler:
-            return _QuietHandler(*args, directory=str(self._dir), **kwargs)
+            return _QuietHandler(
+                *args, directory=str(self._dir), host=self, **kwargs)
 
         self._httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _handler)
         self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
@@ -40,6 +48,9 @@ class BlobHost:
     @property
     def base_url(self) -> str:
         return f"http://127.0.0.1:{self._httpd.server_address[1]}"
+
+    def before_serve(self, name: str) -> None:
+        """Hook run on the handler thread just before ``name`` is served."""
 
     def put(self, name: str, payload: bytes) -> str:
         (self._dir / name).write_bytes(payload)
@@ -81,3 +92,33 @@ class CorruptingBlobHost(BlobHost):
         if name == self._corrupt:
             payload = b"\x00" * len(payload) if payload else b"\x00"
         return super().put(name, payload)
+
+
+class GatedBlobHost(BlobHost):
+    """Holds the GET for ONE named blob until :meth:`release`.
+
+    pgw#955: a deterministic way to keep a residency reconcile pass genuinely
+    in flight while the test does something else — the download the pass is
+    awaiting simply does not answer yet. ``requested`` fires when the gated GET
+    arrives, so the test waits on the EVENT rather than on a sleep. ``shutdown``
+    releases, so a failing test cannot leave the handler thread parked.
+    """
+
+    def __init__(self, root: Path, *, gated: str) -> None:
+        super().__init__(root)
+        self._gated = gated
+        self.requested = threading.Event()
+        self._release = threading.Event()
+
+    def before_serve(self, name: str) -> None:
+        if name != self._gated:
+            return
+        self.requested.set()
+        self._release.wait()
+
+    def release(self) -> None:
+        self._release.set()
+
+    def shutdown(self) -> None:
+        self.release()
+        super().shutdown()

--- a/tests/test_residency_republish_pgw628.py
+++ b/tests/test_residency_republish_pgw628.py
@@ -14,9 +14,9 @@ import time
 
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
-from harness.blob_host import BlobHost
+from harness.blob_host import BlobHost, GatedBlobHost
 from harness.hub_double import Conn, WorkerHarness, hub_double, is_model_event, is_ready
-from harness.progress_wait import Cadence, await_count
+from harness.progress_wait import Cadence, await_count, await_progress
 
 # pgw#795 (the v0.78.0 release blocker): this ref must NOT be one a toy
 # endpoint declares. It used to be `harness/residency-tiny`, which
@@ -30,6 +30,11 @@ from harness.progress_wait import Cadence, await_count
 # property holds at any spacing (verified at 0.5 s and 5 s gaps).
 _MODEL_REF = "harness/republish-tiny"
 
+# pgw#955: a SECOND undeclared ref, materialized after _MODEL_REF in the same
+# plan, whose blob the test can hold open — that is what keeps a reconcile pass
+# genuinely in flight while the hub re-sends the plan.
+_GATE_REF = "harness/republish-gate"
+
 
 def _disk_only_ack(snapshot: pb.Snapshot, generation: int) -> pb.HelloAck:
     return pb.HelloAck(
@@ -38,6 +43,20 @@ def _disk_only_ack(snapshot: pb.Snapshot, generation: int) -> pb.HelloAck:
             generation=generation,
             disk_refs=[_MODEL_REF],
             snapshots={_MODEL_REF: snapshot},
+        ),
+    )
+
+
+def _gated_ack(
+    held: pb.Snapshot, gated: pb.Snapshot, generation: int,
+) -> pb.HelloAck:
+    """The same plan every time: two disk refs, _MODEL_REF declared first."""
+    return pb.HelloAck(
+        protocol_version=pb.PROTOCOL_VERSION_CURRENT,
+        desired_residency=pb.DesiredResidency(
+            generation=generation,
+            disk_refs=[_MODEL_REF, _GATE_REF],
+            snapshots={_MODEL_REF: held, _GATE_REF: gated},
         ),
     )
 
@@ -141,5 +160,95 @@ def test_reissued_plan_republishes_held_identity(tmp_path) -> None:
             _wait_on_disk_count(conn, harness, baseline + 2)
             _settle()
             assert _count_on_disk(conn) == baseline + 2
+    finally:
+        blobs.shutdown()
+
+
+def _await_gate_request(blobs: GatedBlobHost, harness: WorkerHarness) -> None:
+    """Wait until the reconcile pass is parked on the gated blob's GET."""
+    await_progress(
+        blobs.requested.is_set,
+        bool,
+        what=f"the reconcile pass to reach {_GATE_REF}'s download",
+        cadence=Cadence(),
+        gone=lambda: None if harness.alive else "the worker thread exited",
+    )
+
+
+def _await_applied_ack(harness: WorkerHarness, after: int) -> None:
+    """Wait until an ack past ``after`` has been APPLIED to desired state.
+
+    The republish epoch is bumped by ``replace_desired_snapshots``, which
+    ``on_hello_ack`` runs immediately before it decides what to do with the
+    running reconcile — so an advanced epoch is proof the decision under test
+    has already been taken, with no clock and no guessing.
+    """
+    store = harness.worker.executor.store
+    await_progress(
+        lambda: int(store._residency_republish_epoch),
+        lambda seen: seen > after,
+        what="the re-sent plan to be applied",
+        cadence=Cadence(),
+        gone=lambda: None if harness.alive else "the worker thread exited",
+    )
+
+
+def test_reissued_plan_republishes_across_an_in_flight_reconcile(tmp_path) -> None:
+    """pgw#955: a plan re-send that lands WHILE the reconcile is still running
+    must still produce its re-report.
+
+    This is the same property as the test above, at the moment it was being
+    lost. gw#614 taught ``_replace_residency_reconcile`` not to cancel an
+    in-flight reconcile when the re-sent plan's model set is unchanged — a
+    running self_mint_compile needs its window — but it returned there without
+    telling the running loop anything. So the ack bumped the republish epoch
+    and nothing ever read it: no cancel, no restart, no re-announce, and no
+    later event to heal it. The hub's redrive vanished, permanently.
+
+    That window is ~one event-loop step wide when the plan materializes
+    instantly, which is why it presented as a load-only flake ("1 of 2 ON_DISK
+    re-reports", both attempts of PR #470's `tests` job) rather than as the
+    product bug it is. Here the window is held open on purpose: the second ref
+    of the same plan parks on a blob the test does not answer until it has
+    proven the re-sent plan was applied.
+    """
+    blobs = GatedBlobHost(tmp_path, gated="gate-blob")
+    try:
+        held = blobs.one_file_snapshot("snap-1", "blob", b"tiny-weights")
+        gated = blobs.one_file_snapshot("snap-gate", "gate-blob", b"gated-weights")
+        ack = _gated_ack(held, gated, generation=1)
+        with hub_double() as (scheduler, harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+
+            conn.send(hello_ack=ack)
+            conn.wait_for(is_model_event(_MODEL_REF, pb.MODEL_STATE_ON_DISK))
+            baseline = _count_on_disk(conn)
+
+            # _MODEL_REF is on disk and reported; the pass has moved on to
+            # _GATE_REF and is now parked inside its download.
+            _await_gate_request(blobs, harness)
+            epoch = int(harness.worker.executor.store._residency_republish_epoch)
+            conn.send(hello_ack=ack)
+            _await_applied_ack(harness, epoch)
+
+            # Only now does the held download answer, so the reconcile the ack
+            # met was unambiguously still in flight.
+            blobs.release()
+            _wait_on_disk_count(conn, harness, baseline + 1)
+            events = [
+                m.model_event
+                for m in conn.received
+                if m.WhichOneof("msg") == "model_event"
+                and m.model_event.ref == _MODEL_REF
+                and m.model_event.state == pb.MODEL_STATE_ON_DISK
+            ]
+            assert events[-1].snapshot_digest == "snap-1"
+            assert events[-1].residency_generation == 1
+
+            # Still exactly one per applied plan — the re-converge pass does
+            # not re-announce inside its own epoch.
+            _settle()
+            assert _count_on_disk(conn) == baseline + 1
     finally:
         blobs.shutdown()


### PR DESCRIPTION
Closes the pgw#955 flake that went twice-red on PR #470's `tests` job and forced a coordinator override.

## Verdict: product bug, not a fixture bug

`test_reissued_plan_republishes_held_identity` waits for 2 ON_DISK re-reports and receives 1. The second re-report is **never emitted**, and the reason is in `src/`.

`Lifecycle._replace_residency_reconcile` has a gw#614 branch: an ack whose semantic model set is unchanged must not CANCEL an in-flight reconcile (a running `self_mint_compile` needs its full window). Correct — but it returned having told the running loop nothing. Meanwhile `ModelStore.replace_desired_snapshots`, called on that same ack a few lines earlier, had already bumped `_residency_republish_epoch`, and **only a reconcile pass ever reads an epoch** (`_confirm_cached_identity`, reached from `ensure_local`'s cached path).

So an ack that arrived while the previous reconcile was still running produced: no cancel, no restart, no re-announce, and no later event to heal it. The hub's redrive vanished — permanently, which is why the wait stalls for the full silence floor instead of arriving late.

Under pgw#628 / th#1070 v2 that epoch *is* the hub asking for a resync of a lost success observation. The swallow therefore defeated the resync precisely when the worker was busy — the state in which observations get lost in the first place. A flake on CI; on the fleet, a worker whose residency truth silently stops matching the hub's until something else happens to move it.

The window is ~one event-loop step wide when the plan materializes instantly (emit ON_DISK → finish the pass → task done), which is exactly why it presented as load-only.

## The fix

Signal the level-triggered restart (gw#623's own mechanism) in that branch instead of returning silently. The loop finishes the item it is on — gw#614's no-cancel guarantee untouched — then re-converges and re-announces under the new epoch. Satisfied refs short-circuit, and the epoch guard still caps emission at one re-report per ref per applied ack, so "exactly one per applied plan" still holds.

No wait was tuned. No floor was raised. `tests/test_residency_republish_pgw628.py`'s existing wait is unchanged.

## Reproduction — deterministic, not load-dependent

`test_reissued_plan_republishes_across_an_in_flight_reconcile` holds the window open on purpose: a second ref in the same plan parks on a blob the test does not answer until it has observed the re-sent plan's republish epoch land, so the reconcile the ack met was unambiguously still in flight. On the unfixed tree it fails with the **byte-identical CI message**:

```
harness.progress_wait.StalledError: waiting for 2 ON_DISK re-reports of
harness/republish-tiny: nothing advanced for 30.0s (staleness window 30.0s
silence floor (slowest advance in THIS wait 0.00s)); last saw '1 of 2'
```

`GatedBlobHost` is the harness half: a `before_serve` hook on `BlobHost` plus a release gate. gw#666 clean — no clock anywhere; `shutdown()` releases, so a failing test cannot park the handler thread.

## Proof

- `pytest tests/ -n 4 --dist loadfile` — **3108 passed, 1 failed, 37 skipped, 1 xfailed** in 10m28s, run concurrently with another agent's 4-worker suite (heavier contention than CI's 4-core runner). The target test passed; so did the new one.
- The one failure is **unrelated**: `test_pod_privilege_isolation_pgw858.py::test_privilege_isolation_rows_under_a_real_root_parent`, inner row `test_the_parent_can_still_signal_and_reap_the_dropped_child` — "the dropped child was never reaped". A docker-in-docker reap under double load; zero surface overlap with this diff (that file never touches residency or `BlobHost`). Re-run **alone at load 5.4: 1 passed, 13 skipped**. Recorded rather than re-run-until-green, per pgw#943's precedent, and filed as its own tracker item.
- `pytest tests_v2/ -n 4 --dist loadfile` — 21 passed.
- Contention loop: the target file 20/20 green while 3 neighbour pytest workers churned the rest of the suite, load ~16.
- `mypy src/gen_worker` clean (226 files); `ruff check src/gen_worker` clean.