### PR TITLE
th#1580 A4: gen_worker.discover DERIVES the image's execution lanes (no capability list, no exclusion marker)

### DIFF
--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -26,6 +26,11 @@ from gen_worker.api.types import (
     Tensors,
     VideoAsset,
 )
+from gen_worker.discovery.execution_lanes import (
+    derive_execution_lanes,
+    execution_lanes_for_function,
+    manifest_block,
+)
 from gen_worker.discovery.heavy_deps import stub_missing_heavy_deps
 from gen_worker.discovery.names import slugify_name
 from gen_worker.discovery.project import load_project_config
@@ -903,8 +908,27 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
             )
         seen_fn[fn_name] = py_name
 
+    # th#1580 A4: the endpoint half of §1.30's intersection, DERIVED from the
+    # decoders this image actually carries — never a hand-maintained list.
+    # Runs inside the same heavy-dep stubbing the endpoint walk used, so a
+    # torch-less manifest build derives the same set an in-image build does.
+    with stub_missing_heavy_deps(cfg.discovery_heavy_deps):
+        derived = derive_execution_lanes()
+    for fn in functions:
+        bucket = int((fn.get("compile") or {}).get("lora_bucket") or 0)
+        lanes, exclusions = execution_lanes_for_function(
+            derived, lora_bucket=bucket
+        )
+        fn["execution_lanes"] = list(lanes)
+        if exclusions:
+            fn["execution_lane_exclusions"] = [
+                {"execution_lane": e.execution_lane, "reason": e.reason}
+                for e in exclusions
+            ]
+
     manifest: Dict[str, Any] = {
         "functions": functions,
+        "execution_lanes": manifest_block(derived),
     }
     return manifest
 

--- a/src/gen_worker/discovery/execution_lanes.py
+++ b/src/gen_worker/discovery/execution_lanes.py
@@ -1,0 +1,227 @@
+"""th#1580 A4: the endpoint-side execution-lane declaration, DERIVED at image
+build from the decoders actually present in the image.
+
+Three steps, none of them a list anybody maintains:
+
+1. import every module of the decoder packages and collect the
+   ``@implements_contract`` markers that survived the import;
+2. cross each declared lane BODY with the execution options the runtime table
+   says that body supports (``models.execution_lanes``) — the platform owns
+   eager/compiled, so a decoder never declares it;
+3. subtract nothing. Exclusions are derived per FUNCTION from declared traits
+   (A4 corollary: no exclusion marker in v1).
+
+A module that fails to import is EXCLUDED WITH ITS REASON, never silently
+dropped: an image whose svdq decoder cannot import must not claim the svdq
+lane, and it must be able to say why it does not.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import msgspec
+
+from gen_worker.models.artifact_contract import (
+    ContractDecoder,
+    contract_decoders_of,
+)
+from gen_worker.models.execution_lanes import (
+    execution_lane_body_id,
+    known_execution_lanes,
+    parse_execution_lane,
+)
+
+# Stamped into the manifest and into the hub's release row. It names the
+# MECHANISM, so an older image that predates it emits no block at all and is
+# UNPROVEN hub-side — distinct from an image that derived an empty set.
+DERIVATION = "gen_worker.discovery.execution_lanes@1"
+
+DEFAULT_DECODER_PACKAGES: tuple[str, ...] = ("gen_worker.models",)
+
+
+class ExcludedDecoderModule(msgspec.Struct, frozen=True, kw_only=True):
+    module: str
+    reason: str
+
+
+class DerivedContract(msgspec.Struct, frozen=True, kw_only=True):
+    contract: str
+    decoder: str
+    execution_lanes: tuple[str, ...]
+    composes_lora: bool
+
+
+class DerivedExecutionLanes(msgspec.Struct, frozen=True, kw_only=True):
+    derivation: str
+    execution_lanes: tuple[str, ...]
+    contracts: tuple[DerivedContract, ...]
+    excluded_modules: tuple[ExcludedDecoderModule, ...]
+
+
+class FunctionExclusion(msgspec.Struct, frozen=True, kw_only=True):
+    execution_lane: str
+    reason: str
+
+
+def _rank() -> dict[str, int]:
+    return {lane: i for i, lane in enumerate(known_execution_lanes())}
+
+
+def _lanes_for_body(body: str) -> tuple[str, ...]:
+    """Every concrete lane id the runtime supports for one lane body. This is
+    the cross with the execution options: the lane table is authoritative and
+    the decoder never names eager/compiled."""
+    out = []
+    for lane_id in known_execution_lanes():
+        if execution_lane_body_id(parse_execution_lane(lane_id)) == body:
+            out.append(lane_id)
+    return tuple(out)
+
+
+def _collect(
+    packages: tuple[str, ...],
+) -> tuple[tuple[ContractDecoder, ...], tuple[ExcludedDecoderModule, ...]]:
+    """Import every decoder module and harvest the markers that survived.
+
+    Import is the whole test: a module that raises contributes NO declaration
+    and one excluded-with-reason record. There is no third state where a
+    decoder is claimed but absent.
+    """
+    declared: dict[tuple[str, str], ContractDecoder] = {}
+    excluded: list[ExcludedDecoderModule] = []
+
+    def harvest(module: object) -> None:
+        for attr in sorted(dir(module)):
+            for dec in contract_decoders_of(getattr(module, attr, None)):
+                declared[(dec.contract, dec.decoder)] = dec
+
+    for package in packages:
+        try:
+            pkg = importlib.import_module(package)
+        except Exception as exc:
+            excluded.append(
+                ExcludedDecoderModule(
+                    module=package, reason=f"{type(exc).__name__}: {exc}"
+                )
+            )
+            continue
+        harvest(pkg)
+        paths = getattr(pkg, "__path__", None)
+        if not paths:
+            continue
+        for info in sorted(pkgutil.iter_modules(paths), key=lambda m: m.name):
+            name = f"{package}.{info.name}"
+            try:
+                harvest(importlib.import_module(name))
+            except Exception as exc:
+                excluded.append(
+                    ExcludedDecoderModule(
+                        module=name, reason=f"{type(exc).__name__}: {exc}"
+                    )
+                )
+    return tuple(declared[k] for k in sorted(declared)), tuple(excluded)
+
+
+def _derived_contract(dec: ContractDecoder) -> DerivedContract:
+    rank = _rank()
+    lanes: list[str] = []
+    for body in dec.serves:
+        for lane in _lanes_for_body(body):
+            if lane not in lanes:
+                lanes.append(lane)
+    lanes.sort(key=lambda lane: rank[lane])
+    return DerivedContract(
+        contract=dec.contract,
+        decoder=dec.decoder,
+        execution_lanes=tuple(lanes),
+        composes_lora=dec.composes_lora,
+    )
+
+
+def derive_execution_lanes(
+    packages: tuple[str, ...] = DEFAULT_DECODER_PACKAGES,
+) -> DerivedExecutionLanes:
+    """Enumerate the contracts this image's decoders implement, crossed with
+    the runtime's execution options."""
+    declared, excluded = _collect(packages)
+    contracts = tuple(_derived_contract(dec) for dec in declared)
+    rank = _rank()
+    union: list[str] = []
+    for contract in contracts:
+        for lane in contract.execution_lanes:
+            if lane not in union:
+                union.append(lane)
+    union.sort(key=lambda lane: rank[lane])
+    return DerivedExecutionLanes(
+        derivation=DERIVATION,
+        execution_lanes=tuple(union),
+        contracts=contracts,
+        excluded_modules=excluded,
+    )
+
+
+def execution_lanes_for_function(
+    derived: DerivedExecutionLanes,
+    *,
+    lora_bucket: int = 0,
+) -> tuple[tuple[str, ...], tuple[FunctionExclusion, ...]]:
+    """The image's derived set narrowed by one function's DECLARED traits.
+
+    The only trait that narrows anything today is ``lora_bucket``: a function
+    that takes runtime adapters cannot run on a lane whose decoder has no
+    adapter branch (``w8a8_lora`` is branch-capable on exactly three lanes),
+    and that is computable here — which is why A4's corollary refuses an
+    exclusion marker. Nothing about owner PREFERENCE lives here; §1.31 layer 2
+    owns ordering.
+    """
+    rank = _rank()
+    keep: list[str] = []
+    exclusions: dict[str, FunctionExclusion] = {}
+    for contract in derived.contracts:
+        for lane in contract.execution_lanes:
+            if lora_bucket > 0 and not contract.composes_lora:
+                exclusions.setdefault(
+                    lane,
+                    FunctionExclusion(
+                        execution_lane=lane,
+                        reason=(
+                            f"lora_bucket={lora_bucket} needs runtime adapter "
+                            f"composition; decoder {contract.decoder} for "
+                            f"{contract.contract} has no adapter branch"
+                        ),
+                    ),
+                )
+                continue
+            if lane not in keep:
+                keep.append(lane)
+    # A lane another contract serves WITH composition is not excluded.
+    for lane in keep:
+        exclusions.pop(lane, None)
+    keep.sort(key=lambda lane: rank[lane])
+    ordered = tuple(
+        exclusions[lane] for lane in sorted(exclusions, key=lambda x: rank[x])
+    )
+    return tuple(keep), ordered
+
+
+def manifest_block(derived: DerivedExecutionLanes) -> dict:
+    """The ``[execution_lanes]`` block as it lands in endpoint.lock."""
+    return {
+        "derivation": derived.derivation,
+        "lanes": list(derived.execution_lanes),
+        "contracts": [
+            {
+                "contract": c.contract,
+                "decoder": c.decoder,
+                "lanes": list(c.execution_lanes),
+                "composes_lora": c.composes_lora,
+            }
+            for c in derived.contracts
+        ],
+        "excluded_modules": [
+            {"module": m.module, "reason": m.reason}
+            for m in derived.excluded_modules
+        ],
+    }

--- a/src/gen_worker/models/artifact_contract.py
+++ b/src/gen_worker/models/artifact_contract.py
@@ -1,0 +1,137 @@
+"""th#1580 A4 (§1.30 declaration 2+3): a decoder declares WHICH ARTIFACT
+CONTRACT it implements, beside the code that implements it.
+
+The endpoint half of §1.30's compatibility intersection is DERIVED at image
+build (``gen_worker.discovery.execution_lanes``) from these markers. A
+hand-maintained capability list is a second trusted string — the defect class
+th#1580 exists to remove — so there is no list: the declaration is a property
+of the decoder function, and it ships or fails to ship with it.
+
+The vocabulary lives in tensorhub's ``internal/artifactcontract`` (A2:
+contracts are CODE). This module carries only the handles a decoder may name
+and refuses anything else; it does not re-specify the descriptors.
+
+**No exclusion marker exists, deliberately** (A4 corollary, Paul 2026-08-04).
+Exclusions are DERIVED from declared traits — ``composes_lora`` crossed with a
+function's ``lora_bucket`` is computable at build — or they do not exist.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Iterable, TypeVar
+
+import msgspec
+
+from .execution_lanes import known_execution_lane_bodies
+
+# The registered handles, transcribed from tensorhub's seeded registry. A
+# decoder naming anything else fails the BUILD: an unregistered contract is
+# OPAQUE (A2), and a decoder cannot unilaterally register one.
+CONTRACT_PLAIN_BF16 = "plain.bf16@1"
+CONTRACT_COZY_FP8_ROWWISE = "cozy.fp8-rowwise@1"
+CONTRACT_NUNCHAKU_V1 = "nunchaku.v1@1"
+CONTRACT_COZY_SVDQ_NVFP4_LR8 = "cozy.svdq-nvfp4-lr8@1"
+CONTRACT_BFL_NVFP4_PRESWIZZLED = "bfl.nvfp4-preswizzled@1"
+
+KNOWN_CONTRACTS: tuple[str, ...] = (
+    CONTRACT_PLAIN_BF16,
+    CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_NUNCHAKU_V1,
+    CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    CONTRACT_BFL_NVFP4_PRESWIZZLED,
+)
+
+_HANDLE_RE = re.compile(r"^([a-z0-9]+)\.([a-z0-9][a-z0-9._-]*)@([1-9][0-9]*)$")
+
+
+class ContractDecoder(msgspec.Struct, frozen=True, kw_only=True):
+    """One decoder's declaration: the contract it decodes, and the lane BODIES
+    the decoded units execute as. The execution axis (eager/compiled) is NOT
+    declared here — the platform owns it, and the derivation crosses these
+    bodies with the lane table's own execution support."""
+
+    contract: str
+    decoder: str  # "module:qualname" — the function carrying the marker
+    serves: tuple[str, ...]  # lane body tokens, e.g. "svdq-fp4-w4a4"
+    composes_lora: bool
+    why: str = ""
+
+
+# The declaration lives ON THE DECODER OBJECT, not in a module-level registry.
+# That is the point: it cannot be present without the decoder, cannot survive
+# the decoder being removed, and cannot be assembled anywhere else.
+MARKER = "__cozy_artifact_contracts__"
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _validate(dec: ContractDecoder) -> None:
+    if not _HANDLE_RE.match(dec.contract):
+        raise ValueError(
+            f"{dec.decoder}: {dec.contract!r} is not a contract handle "
+            "(want ns.name@N)"
+        )
+    if dec.contract not in KNOWN_CONTRACTS:
+        raise ValueError(
+            f"{dec.decoder}: contract {dec.contract!r} is not registered. "
+            "Contracts are CODE (th#1580 A2): register it in tensorhub's "
+            "internal/artifactcontract with a descriptor and a probe set "
+            "before a decoder may claim it."
+        )
+    if not dec.serves:
+        raise ValueError(
+            f"{dec.decoder}: serves= is empty; a decoder that executes no "
+            "lane body declares nothing"
+        )
+    bodies = set(known_execution_lane_bodies())
+    for token in dec.serves:
+        if token not in bodies:
+            raise ValueError(
+                f"{dec.decoder}: serves= token {token!r} is not a known lane "
+                f"body; valid: {sorted(bodies)}"
+            )
+    if len(set(dec.serves)) != len(dec.serves):
+        raise ValueError(f"{dec.decoder}: serves= repeats a lane body")
+
+
+def implements_contract(
+    *,
+    contract: str,
+    serves: Iterable[str],
+    composes_lora: bool,
+    why: str = "",
+) -> Callable[[F], F]:
+    """Mark a decode entrypoint as implementing ``contract``.
+
+    Stackable: one function may implement several contracts (``decode_linear``
+    implements both the nunchaku layout and te#148's quantized-branch major).
+    """
+
+    def deco(fn: F) -> F:
+        dec = ContractDecoder(
+            contract=contract,
+            decoder=f"{fn.__module__}:{fn.__qualname__}",
+            serves=tuple(serves),
+            composes_lora=bool(composes_lora),
+            why=why,
+        )
+        _validate(dec)
+        prior: tuple[ContractDecoder, ...] = getattr(fn, MARKER, ())
+        for existing in prior:
+            if existing.contract == dec.contract and existing != dec:
+                raise ValueError(
+                    f"{dec.decoder}: conflicting declarations for {dec.contract}"
+                )
+        setattr(fn, MARKER, prior + (dec,))
+        return fn
+
+    return deco
+
+
+def contract_decoders_of(obj: Any) -> tuple[ContractDecoder, ...]:
+    """The declarations carried by one object, or ``()``."""
+    marked = getattr(obj, MARKER, ())
+    if not isinstance(marked, tuple):
+        return ()
+    return tuple(d for d in marked if isinstance(d, ContractDecoder))

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -25,6 +25,7 @@ import os
 import struct
 import sys
 
+from .artifact_contract import CONTRACT_PLAIN_BF16, implements_contract
 from .fp8_storage import restructure_fp8_storage
 from .memory import get_available_vram_gb, meta_tensors
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
@@ -1549,6 +1550,15 @@ def _adaptive_fit_rung(
     return "nf4", qc
 
 
+@implements_contract(
+    contract=CONTRACT_PLAIN_BF16,
+    serves=("bf16-w16a16", "fp8-w8a16"),
+    composes_lora=True,
+    why="the dense-weights path: plain bf16 bytes are read as stored "
+        "(bf16-w16a16), and `storage_dtype=fp8` restructures the SAME bytes "
+        "into fp8 storage with per-layer upcast (fp8-w8a16). Both are "
+        "adapter-branch-capable (gw#558).",
+)
 def load_from_pretrained(
     cls: Any,
     path: str | Path,

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -63,6 +63,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
+from .artifact_contract import (
+    CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    CONTRACT_NUNCHAKU_V1,
+    implements_contract,
+)
 from .nvfp4_quant import BLOCK, pack_e2m1, to_blocked_scales
 
 # deepcompressor MmaWeightPackerBase geometry, bits=4 / warp_n=128
@@ -480,6 +485,22 @@ def _decode_quantized_lowrank(
 # ---------------------------------------------------------------------------
 
 
+@implements_contract(
+    contract=CONTRACT_NUNCHAKU_V1,
+    serves=("svdq-fp4-w4a4",),
+    composes_lora=False,
+    why="pgw#685: this is THE decoder of the nunchaku v1 single-file layout. "
+        "The decoded SvdqLinear has no additive adapter branch (w8a8_lora is "
+        "branch-capable on w8a8 / fp8-storage / plain bf16 only).",
+)
+@implements_contract(
+    contract=CONTRACT_COZY_SVDQ_NVFP4_LR8,
+    serves=("svdq-fp4-w4a4",),
+    composes_lora=False,
+    why="te#148's quantized low-rank branch is a distinct MAJOR and this "
+        "decoder branches on it (`lowrank_quant`), which is what makes the "
+        "claim true rather than inherited from nunchaku.v1@1.",
+)
 def decode_linear(tensors: dict[str, Any], out_features: int,
                   in_features: int, *,
                   lowrank_quant: Optional[str] = None) -> DecodedLinear:

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
+from .artifact_contract import CONTRACT_COZY_FP8_ROWWISE, implements_contract
 from typing import Any, Dict, List, Optional
 import shutil
 
@@ -514,6 +515,14 @@ def _denoiser_class(root: Path, component: str) -> Any:
     return cls
 
 
+@implements_contract(
+    contract=CONTRACT_COZY_FP8_ROWWISE,
+    serves=("fp8-w8a8-dynamic",),
+    composes_lora=True,
+    why="gw#547: Fp8ScaledLinear reads lora_a/lora_b non-persistent buffers "
+        "in its own forward, so the w8a8 lane composes runtime adapters "
+        "natively.",
+)
 def load_w8a8_denoiser(root: Path, art: W8a8Artifact, *,
                        compute_dtype: Any = None, mode: str = "",
                        cls: Any = None) -> Any:

--- a/tests/test_derived_execution_lanes_th1580.py
+++ b/tests/test_derived_execution_lanes_th1580.py
@@ -1,0 +1,199 @@
+"""th#1580 A4: the endpoint-side execution-lane set is DERIVED from the
+decoders in the image, not hand-listed.
+
+Proven here against a FAKE image package (two real decoders, one that cannot
+import) plus the real gen_worker.models tree:
+
+  1. two decoders declare exactly their two contracts and no others;
+  2. a decoder module that fails to import is EXCLUDED WITH ITS REASON;
+  3. the execution axis comes from the runtime lane table, never the decoder;
+  4. exclusions are DERIVED from a function's declared traits (A4 corollary:
+     no exclusion marker exists to test);
+  5. an unregistered contract handle fails the BUILD (A2).
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gen_worker.discovery.execution_lanes import (
+    DERIVATION,
+    derive_execution_lanes,
+    execution_lanes_for_function,
+    manifest_block,
+)
+from gen_worker.models.artifact_contract import (
+    CONTRACT_COZY_FP8_ROWWISE,
+    CONTRACT_NUNCHAKU_V1,
+    implements_contract,
+)
+
+_GOOD_A = '''
+from gen_worker.models.artifact_contract import implements_contract
+
+@implements_contract(
+    contract="nunchaku.v1@1", serves=("svdq-fp4-w4a4",), composes_lora=False,
+    why="fake svdq decoder",
+)
+def decode_svdq(tensors):
+    return tensors
+'''
+
+_GOOD_B = '''
+from gen_worker.models.artifact_contract import implements_contract
+
+@implements_contract(
+    contract="cozy.fp8-rowwise@1", serves=("fp8-w8a8-dynamic",),
+    composes_lora=True, why="fake fp8 decoder",
+)
+def decode_fp8(tensors):
+    return tensors
+'''
+
+# A decoder whose dependency is absent — the real failure this excludes is an
+# image built without the kernel extension its decoder imports at module top.
+_BROKEN = '''
+import a_dependency_this_image_does_not_have  # noqa: F401
+
+from gen_worker.models.artifact_contract import implements_contract
+
+@implements_contract(
+    contract="bfl.nvfp4-preswizzled@1", serves=("nvfp4-w4a4-static",),
+    composes_lora=False, why="never reached",
+)
+def decode_nvfp4(tensors):
+    return tensors
+'''
+
+
+@pytest.fixture
+def fake_image(tmp_path: pytest.TempPathFactory, monkeypatch):
+    """A package standing in for one image's decoder set."""
+    root = Path(str(tmp_path))
+    pkg = root / "fake_decoders"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", "utf-8")
+    (pkg / "svdq_decoder.py").write_text(textwrap.dedent(_GOOD_A), "utf-8")
+    (pkg / "fp8_decoder.py").write_text(textwrap.dedent(_GOOD_B), "utf-8")
+    (pkg / "broken_decoder.py").write_text(textwrap.dedent(_BROKEN), "utf-8")
+    monkeypatch.syspath_prepend(str(root))
+    for name in [n for n in sys.modules if n.startswith("fake_decoders")]:
+        del sys.modules[name]
+    try:
+        yield "fake_decoders"
+    finally:
+        for name in [n for n in sys.modules if n.startswith("fake_decoders")]:
+            del sys.modules[name]
+
+
+def test_two_decoders_declare_exactly_their_contracts(fake_image):
+    derived = derive_execution_lanes(packages=(fake_image,))
+
+    assert [c.contract for c in derived.contracts] == [
+        CONTRACT_COZY_FP8_ROWWISE,
+        CONTRACT_NUNCHAKU_V1,
+    ]
+    # And NOTHING else: the third registered contract the broken module would
+    # have claimed is absent, and the two contracts no decoder mentions are
+    # absent. "Supports everything" is not a reachable answer here.
+    assert "bfl.nvfp4-preswizzled@1" not in {c.contract for c in derived.contracts}
+    assert "plain.bf16@1" not in {c.contract for c in derived.contracts}
+    assert derived.derivation == DERIVATION
+
+
+def test_import_failure_is_excluded_with_a_reason(fake_image):
+    derived = derive_execution_lanes(packages=(fake_image,))
+
+    excluded = {m.module: m.reason for m in derived.excluded_modules}
+    assert "fake_decoders.broken_decoder" in excluded
+    reason = excluded["fake_decoders.broken_decoder"]
+    assert "ModuleNotFoundError" in reason
+    assert "a_dependency_this_image_does_not_have" in reason
+    # Excluded means excluded — not "declared but flagged".
+    lanes = set(derived.execution_lanes)
+    assert "nvfp4-w4a4-static+compiled" not in lanes
+    # ...and the exclusion is VISIBLE in what the hub receives.
+    block = manifest_block(derived)
+    assert block["excluded_modules"] == [
+        {"module": "fake_decoders.broken_decoder", "reason": reason}
+    ]
+
+
+def test_execution_axis_comes_from_the_runtime_table(fake_image):
+    """The decoder declares a lane BODY; eager/compiled is the platform's."""
+    derived = derive_execution_lanes(packages=(fake_image,))
+
+    lanes = set(derived.execution_lanes)
+    # svdq is eager-only and w8a8 compiled-only in the lane table, and neither
+    # decoder said so — the cross produced it.
+    assert lanes == {"fp8-w8a8-dynamic+compiled", "svdq-fp4-w4a4+eager"}
+
+
+def test_lora_bucket_derives_the_exclusion(fake_image):
+    """A4 corollary: no exclusion marker. `lora_bucket` x `composes_lora`."""
+    derived = derive_execution_lanes(packages=(fake_image,))
+
+    plain, no_exclusions = execution_lanes_for_function(derived, lora_bucket=0)
+    assert set(plain) == {"fp8-w8a8-dynamic+compiled", "svdq-fp4-w4a4+eager"}
+    assert no_exclusions == ()
+
+    lora, exclusions = execution_lanes_for_function(derived, lora_bucket=4)
+    assert set(lora) == {"fp8-w8a8-dynamic+compiled"}
+    assert [e.execution_lane for e in exclusions] == ["svdq-fp4-w4a4+eager"]
+    assert "lora_bucket=4" in exclusions[0].reason
+    assert "nunchaku.v1@1" in exclusions[0].reason
+
+
+def test_unregistered_contract_fails_the_build():
+    """A2: contracts are code. A decoder cannot mint one at the marker."""
+    with pytest.raises(ValueError, match="is not registered"):
+        @implements_contract(
+            contract="acme.secret-format@1",
+            serves=("bf16-w16a16",),
+            composes_lora=False,
+        )
+        def _decode(x):
+            return x
+
+    with pytest.raises(ValueError, match="not a contract handle"):
+        @implements_contract(
+            contract="nvfp4", serves=("bf16-w16a16",), composes_lora=False
+        )
+        def _decode2(x):
+            return x
+
+    with pytest.raises(ValueError, match="not a known lane body"):
+        @implements_contract(
+            contract=CONTRACT_NUNCHAKU_V1,
+            serves=("svdq-fp4-w4a4+eager",),  # execution axis is not a body
+            composes_lora=False,
+        )
+        def _decode3(x):
+            return x
+
+
+def test_real_image_tree_derives_its_own_set():
+    """The real gen_worker.models tree, imported the way the bake imports it."""
+    from gen_worker.discovery.heavy_deps import stub_missing_heavy_deps
+
+    with stub_missing_heavy_deps():
+        derived = derive_execution_lanes()
+
+    by_contract = {c.contract: c for c in derived.contracts}
+    assert CONTRACT_NUNCHAKU_V1 in by_contract
+    assert CONTRACT_COZY_FP8_ROWWISE in by_contract
+    assert "plain.bf16@1" in by_contract
+    # Our own flat-nvfp4 w4a4 decoder claims nothing: the registry has no
+    # entry for it yet (ours is LOW-nibble + unswizzled scales, which is NOT
+    # bfl.nvfp4-preswizzled@1 — te#151 measured what conflating them costs).
+    # An unclaimed decoder contributes no lane, which is the honest answer.
+    assert "bfl.nvfp4-preswizzled@1" not in by_contract
+    assert "nvfp4-w4a4-static+compiled" not in set(derived.execution_lanes)
+    # svdq has no adapter branch; the three branch-capable lanes do.
+    assert by_contract[CONTRACT_NUNCHAKU_V1].composes_lora is False
+    assert by_contract[CONTRACT_COZY_FP8_ROWWISE].composes_lora is True
+    assert by_contract["plain.bf16@1"].composes_lora is True


### PR DESCRIPTION
A4, adopted verbatim: *the endpoint-side declaration is derived by
`gen_worker.discover` at image build and stamped into the release. A
hand-maintained capability list is a second trusted string — the defect class
this issue exists to remove.*

Companion (hub half — storage, publish extraction, the tri-state):
**cozy-creator/tensorhub#805**.

## The declaration lives ON THE DECODER

A decode entrypoint carries `@implements_contract(contract=..., serves=(...),
composes_lora=...)`, and derivation harvests the marker off the function
**object**. That is the whole design: the declaration cannot be present
without the decoder, cannot survive its removal, and cannot be assembled
anywhere else. There is no list to forget to update.

Three steps, none of them authored:

1. import every module of the decoder packages and collect the markers that
   **survived** the import;
2. cross each declared lane **BODY** with the execution options the runtime
   table supports (`models.execution_lanes`) — the decoder never names
   eager/compiled, the platform owns that axis;
3. subtract nothing.

An import failure is **excluded with its reason**, never silently dropped: an
image whose svdq decoder cannot import must not claim the svdq lane, and it
must be able to say why. The reason rides into `endpoint.lock`.

## No exclusion marker (A4 corollary)

Exclusions derive from declared function traits. The one real case is live in
our tree and is now computed: `lora_bucket > 0` × `composes_lora`. gw#547 /
gw#558 make exactly three lanes adapter-branch-capable (w8a8 `scaled_mm`,
fp8-storage layerwise-cast, plain bf16 resident), so a `lora_bucket` function
drops `svdq-fp4-w4a4+eager` **automatically**, with a reason naming the
decoder and the contract. Owner *preference* is not here; §1.31 layer 2 owns
ordering.

## A2 enforced at the marker

A decoder naming an unregistered handle fails the **build**. A contract is a
code-trust surface and an image cannot mint one.

## What the real tree derives today

Verified end to end through `python -m gen_worker.discovery` on
`examples/marco-polo` — four contracts over three decoders:

| contract | decoder | lanes |
|---|---|---|
| `nunchaku.v1@1` | `svdq_layout:decode_linear` | `svdq-fp4-w4a4+eager` |
| `cozy.svdq-nvfp4-lr8@1` | `svdq_layout:decode_linear` | `svdq-fp4-w4a4+eager` |
| `cozy.fp8-rowwise@1` | `w8a8:load_w8a8_denoiser` | `fp8-w8a8-dynamic+compiled` |
| `plain.bf16@1` | `loading:load_from_pretrained` | `bf16-w16a16+{eager,compiled}`, `fp8-w8a16+{eager,compiled}` |

The second row is earned rather than inherited: `decode_linear` **branches**
on te#148's `lowrank_quant`, which is exactly what makes that a distinct major
in the registry.

## Finding, recorded rather than papered over

`models/w4a4.py` claims **nothing**. Our flat nvfp4 is LOW-nibble with
unswizzled `weight_scale`, which is **not** `bfl.nvfp4-preswizzled@1` — te#151
measured what conflating those costs (LPIPS 1.11). The registry has no entry
for our own variant yet, so the honest derived answer is that the lane is
unclaimed. Registering it is a code contribution under A2 and needs a
descriptor written from real header bytes; filed rather than guessed.

## Naming

Built on the names th#1582 Phase A landed — `models.execution_lanes`,
`models.execution_lane_gate`, `kernel_path`. th#1050's `handles=` is a
different thing and is deliberately untouched: it marks where the **author's**
code branches, not what the image's **decoders** can decode. Cross-validating
one against the other is out of scope.

## Tests

`tests/test_derived_execution_lanes_th1580.py` — a fake image package with two
working decoders and one that cannot import:

- two decoders declare exactly their two contracts **and no others**;
- the broken module is excluded with `ModuleNotFoundError` and its missing
  dependency named, and its lane is absent from the set and visible in the
  manifest block;
- the execution axis is proven to come from the lane table (svdq eager-only,
  w8a8 compiled-only — neither decoder said so);
- the `lora_bucket` exclusion is derived, with its reason;
- three build-time refusals: unregistered handle, non-handle shape,
  execution-suffixed lane body;
- the real `gen_worker.models` tree derives its own set, including the w4a4
  hole above.

Suite: **1961 passed / 95 failed / 25 errors** against a torch-less venv;
`origin/dev` measured **identically at 95 failed / 1955 passed / 25 errors**
in the same environment, so the delta is exactly the six new tests. Every
failure is `ModuleNotFoundError: torch`.

No version bump, no publish.

## Out of scope

tier-2 numeric probes; the owner ladder (§1.31 layers 2-3); `weight_lane` →
`artifact_contract` Phase B; repack edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)