### PR TITLE
pgw#664/ie#599: fit_to_native — one native bucket for the condition AND the output

### DIFF
--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -40,6 +40,17 @@ from .api.slot import OBJECTIVES, ObjectiveMismatchError, ResolvedSlot, Slot
 from .families import GenerationDefaults
 from .models.provision import arm_compile
 from .text_pin import TextLengthExceededError, pad_text_sequence
+from .geometry import (
+    FamilyGeometry,
+    FitMode,
+    FitPlan,
+    OutputSize,
+    RestoreResult,
+    fit_to_native,
+    nearest_bucket,
+    restore,
+    set_upscaler,
+)
 from .url_fetch import FetchedUrl, fetch_bytes, fetch_image
 from .view import for_request
 from .api.errors import (
@@ -110,6 +121,16 @@ __all__ = [
     "FetchedUrl",
     "fetch_bytes",
     "fetch_image",
+    # pgw#664/ie#599 fit-to-native geometry: mechanism here, table in the family.
+    "FamilyGeometry",
+    "FitMode",
+    "FitPlan",
+    "OutputSize",
+    "RestoreResult",
+    "fit_to_native",
+    "nearest_bucket",
+    "restore",
+    "set_upscaler",
     "pad_text_sequence",
     "TextLengthExceededError",
     "HF",

--- a/src/gen_worker/geometry.py
+++ b/src/gen_worker/geometry.py
@@ -15,7 +15,7 @@ Two rules that are not negotiable:
   returns the exact framing the user submitted.
 
 Geometry rules differ BY MODE (:class:`FitMode`). ``edit`` treats the user's
-framing as the contract; ``compose`` (multi-reference composition, ie#505)
+framing as the contract; ``compose`` (multi-reference composition, ie#600)
 treats output geometry as a free parameter and only fits the references.
 
 Super-resolution is a DECLARED, PLUGGABLE post-stage (:func:`set_upscaler`).
@@ -289,7 +289,7 @@ def fit_to_native(
 
     if mode is FitMode.COMPOSE:
         # References are fitted to native independently; output geometry is a
-        # free parameter the caller supplies (ie#505's reference-composition
+        # free parameter the caller supplies (ie#600's reference-composition
         # shape). Nothing is cropped back — there is no "user's framing".
         fitted_refs = []
         for image in images:
@@ -297,7 +297,15 @@ def fit_to_native(
             box = _contain_box(image.size, ref_bucket, geometry.multiple_of)
             fitted_refs.append(_edge_pad(image, ref_bucket, box))
         fitted = tuple(fitted_refs)
-        out_bucket = preset or nearest_bucket(source_size[0], source_size[1], geometry)
+        if preset is None:
+            # ie#600: compose output geometry is a FREE parameter the caller
+            # supplies. It must NOT silently inherit references[0]'s aspect —
+            # that inheritance is today's undocumented behaviour, not a design.
+            raise ValidationError(
+                "mode='compose' has no original framing to fit to: the caller "
+                "owns output geometry and must pass an explicit bucket"
+            )
+        out_bucket = preset
         return FitPlan(
             mode=mode,
             output_size=output_size,

--- a/src/gen_worker/geometry.py
+++ b/src/gen_worker/geometry.py
@@ -1,0 +1,470 @@
+"""Fit an image workload to a family's NATIVE geometry (pgw#664, grown by ie#599).
+
+The library owns the MECHANISM (snap / pad / crop / composite / restore); the
+family declares the DATA (:class:`FamilyGeometry`: native area + the declared
+grid rows). One bucket is chosen for the CONDITION and the OUTPUT together —
+picking them independently is the ie#599 defect (a t2i ~1.7 MP aspect table
+copied onto an edit lane whose native area is 1 MP).
+
+Two rules that are not negotiable:
+
+* The INPUT's own area never selects the tier — the MODEL's native area does.
+  A 12 MP phone photo and a 500x500 thumbnail both edit at the native bucket.
+* Aspect mismatch is resolved by PAD (reversible), never by stretch or
+  crop-to-fill. :func:`restore` crops the pad box back off, so an ``edit``
+  returns the exact framing the user submitted.
+
+Geometry rules differ BY MODE (:class:`FitMode`). ``edit`` treats the user's
+framing as the contract; ``compose`` (multi-reference composition, ie#505)
+treats output geometry as a free parameter and only fits the references.
+
+Super-resolution is a DECLARED, PLUGGABLE post-stage (:func:`set_upscaler`).
+No image upscaler exists in the fleet today (ie#599 catalog check: LTX-2.3's
+``upscale_2x`` is a video *latent* upsampler), so the stage is a no-op and
+:func:`restore` returns native-bucket-sized pixels at the user's framing.
+:class:`RestoreResult` reports that honestly rather than faking it.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
+
+import msgspec
+
+from .api.errors import ValidationError
+from .api.types import StringEnum
+
+if TYPE_CHECKING:  # Pillow is a real dependency but lazily imported (see io.py).
+    from PIL import Image as _PILImage
+
+    PILImage = _PILImage.Image
+else:
+    PILImage = Any
+
+
+__all__ = [
+    "FitMode",
+    "OutputSize",
+    "FamilyGeometry",
+    "FitPlan",
+    "RestoreResult",
+    "nearest_bucket",
+    "fit_to_native",
+    "restore",
+    "set_upscaler",
+    "current_upscaler",
+]
+
+
+class FitMode(StringEnum):
+    """What the output geometry is FOR."""
+
+    #: The user's framing is the contract: pad in, crop back out.
+    EDIT = "edit"
+    #: Multi-reference composition: references are fitted, output is free.
+    COMPOSE = "compose"
+
+
+class OutputSize(StringEnum):
+    """The caller-facing geometry policy on an edit lane."""
+
+    #: Fit to native for the edit, restore the caller's framing (default).
+    MATCH_INPUT = "match_input"
+    #: Return the model's bucket unrestored, for callers that post-process.
+    NATIVE = "native"
+    #: Honour an explicit ``aspect_ratio`` + ``megapixels`` reframe.
+    PRESET = "preset"
+
+
+# A declared row whose area strays outside this band of the family's native
+# area is the ie#599 defect in table form; refuse it at declaration time.
+_AREA_BAND = (0.75, 1.25)
+
+
+class FamilyGeometry(msgspec.Struct, frozen=True, kw_only=True):
+    """A family's native geometry. DATA, declared by the endpoint package.
+
+    ``buckets`` must be rows that already appear in the endpoint's
+    ``Compile(shapes=...)`` set — :func:`fit_to_native` never invents a size,
+    so the AOT compile shape set is unchanged by fitting. Assert the
+    containment in the endpoint's tests; :meth:`assert_declared` does it.
+    """
+
+    name: str
+    #: The pixel area the pipeline actually conditions and decodes at.
+    native_area: int
+    #: The declared grid rows at ``native_area``, as (width, height).
+    buckets: tuple[tuple[int, int], ...]
+    #: Latent/patch alignment every row must satisfy.
+    multiple_of: int = 16
+    #: Largest area an edit may be asked to produce. None -> ``native_area``.
+    max_edit_area: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not self.buckets:
+            raise ValueError(f"{self.name}: FamilyGeometry needs at least one bucket")
+        if self.native_area <= 0:
+            raise ValueError(f"{self.name}: native_area must be positive")
+        lo, hi = _AREA_BAND
+        for width, height in self.buckets:
+            if width <= 0 or height <= 0:
+                raise ValueError(f"{self.name}: bucket {width}x{height} is not positive")
+            if width % self.multiple_of or height % self.multiple_of:
+                raise ValueError(
+                    f"{self.name}: bucket {width}x{height} is not a multiple of "
+                    f"{self.multiple_of}"
+                )
+            ratio = (width * height) / self.native_area
+            if not lo <= ratio <= hi:
+                raise ValueError(
+                    f"{self.name}: bucket {width}x{height} is {ratio:.2f}x the declared "
+                    f"native area {self.native_area} — a native table cannot carry a row "
+                    f"outside {lo}..{hi}x (ie#599: this is exactly the t2i-table-on-an-"
+                    f"edit-lane defect)"
+                )
+
+    @property
+    def edit_area_ceiling(self) -> int:
+        return self.native_area if self.max_edit_area is None else self.max_edit_area
+
+    def assert_declared(self, shapes: Sequence[tuple[int, int]]) -> None:
+        """Every bucket must be a declared compile shape. Call from tests."""
+        declared = {(int(w), int(h)) for w, h in shapes}
+        missing = [b for b in self.buckets if b not in declared]
+        if missing:
+            raise ValueError(
+                f"{self.name}: buckets {missing} are not in the declared compile shape "
+                "set — fitting would mint an undeclared graph"
+            )
+
+
+class FitPlan(msgspec.Struct, frozen=True, kw_only=True):
+    """Everything the post-stage needs, DERIVED once rather than re-guessed."""
+
+    mode: FitMode
+    output_size: OutputSize
+    geometry: FamilyGeometry
+    #: The declared grid row the model runs at. Condition AND output.
+    bucket: tuple[int, int]
+    #: The fitted condition images, in the caller's order.
+    images: tuple[PILImage, ...]
+    #: The primary input's size exactly as submitted.
+    source_size: tuple[int, int]
+    #: The caller's framing inside ``bucket`` space (left, top, right, bottom).
+    crop_box: tuple[int, int, int, int]
+    #: What the caller should get back once super-resolution exists.
+    target_size: tuple[int, int]
+    #: Whether the restored edit should be composited onto the source pixels.
+    composite: bool
+    #: The primary input at source resolution, kept for the composite.
+    source_image: Optional[PILImage] = None
+    #: The primary condition cropped to ``crop_box``, for the composite mask.
+    condition_native: Optional[PILImage] = None
+
+    @property
+    def padded(self) -> bool:
+        left, top, right, bottom = self.crop_box
+        return (right - left, bottom - top) != self.bucket
+
+
+class RestoreResult(msgspec.Struct, frozen=True, kw_only=True):
+    """What the caller actually got, and what it is missing."""
+
+    image: PILImage
+    size: tuple[int, int]
+    #: True once a registered upscaler produced ``target_size`` pixels.
+    upscaled: bool
+    #: True once untouched regions were taken from the source at full detail.
+    composited: bool
+    note: str
+
+
+# -- the pluggable super-resolution stage ---------------------------------
+# A capability seam, not a toggle: nothing registers an upscaler today, so the
+# default is "no super-resolution exists" and restore says so.
+
+Upscaler = Callable[[PILImage, "tuple[int, int]"], "Optional[PILImage]"]
+
+_UPSCALER: Optional[Upscaler] = None
+
+
+def set_upscaler(upscaler: Optional[Upscaler]) -> Optional[Upscaler]:
+    """Register the fleet's image super-resolution stage. Returns the previous."""
+    global _UPSCALER
+    previous, _UPSCALER = _UPSCALER, upscaler
+    return previous
+
+
+def current_upscaler() -> Optional[Upscaler]:
+    return _UPSCALER
+
+
+# -- snapping --------------------------------------------------------------
+
+
+def nearest_bucket(
+    width: int, height: int, geometry: FamilyGeometry
+) -> tuple[int, int]:
+    """Snap to the declared row with the closest LOG aspect ratio.
+
+    Log distance, not ``abs(a - w/h)``: the linear form is scale-biased and
+    ranks 16:9 against 9:16 differently depending on which way up you ask.
+    The input's AREA is not read — the family's native area already fixed it.
+    """
+    ratio = math.log(max(int(width), 1) / max(int(height), 1))
+    return min(
+        geometry.buckets,
+        key=lambda wh: abs(math.log(wh[0] / wh[1]) - ratio),
+    )
+
+
+def _contain_box(
+    size: tuple[int, int], bucket: tuple[int, int], multiple_of: int
+) -> tuple[int, int, int, int]:
+    """Centre box inside ``bucket`` holding ``size``'s aspect at max scale."""
+    width, height = size
+    bucket_w, bucket_h = bucket
+    scale = min(bucket_w / max(width, 1), bucket_h / max(height, 1))
+    inner_w = min(bucket_w, max(multiple_of, int(round(width * scale))))
+    inner_h = min(bucket_h, max(multiple_of, int(round(height * scale))))
+    left = (bucket_w - inner_w) // 2
+    top = (bucket_h - inner_h) // 2
+    return (left, top, left + inner_w, top + inner_h)
+
+
+def _edge_pad(image: PILImage, bucket: tuple[int, int], box: tuple[int, int, int, int]) -> PILImage:
+    """Paste ``image`` at ``box`` and fill the margins by smearing the edges.
+
+    Edge replication, not black bars or reflection: bars read as content the
+    model will happily edit, reflection invents plausible objects.
+    """
+    from PIL import Image as PILImageModule
+
+    left, top, right, bottom = box
+    inner_w, inner_h = right - left, bottom - top
+    if image.size != (inner_w, inner_h):
+        image = image.resize((inner_w, inner_h), PILImageModule.Resampling.LANCZOS)
+    if (inner_w, inner_h) == bucket:
+        return image
+
+    canvas = PILImageModule.new(image.mode, bucket)
+    canvas.paste(image, (left, top))
+    bucket_w, bucket_h = bucket
+    if left > 0:
+        canvas.paste(image.crop((0, 0, 1, inner_h)).resize((left, inner_h)), (0, top))
+    if right < bucket_w:
+        strip = image.crop((inner_w - 1, 0, inner_w, inner_h))
+        canvas.paste(strip.resize((bucket_w - right, inner_h)), (right, top))
+    if top > 0:
+        band = canvas.crop((0, top, bucket_w, top + 1))
+        canvas.paste(band.resize((bucket_w, top)), (0, 0))
+    if bottom < bucket_h:
+        band = canvas.crop((0, bottom - 1, bucket_w, bottom))
+        canvas.paste(band.resize((bucket_w, bucket_h - bottom)), (0, bottom))
+    return canvas
+
+
+def fit_to_native(
+    images: Sequence[PILImage],
+    geometry: FamilyGeometry,
+    *,
+    mode: FitMode = FitMode.EDIT,
+    output_size: OutputSize = OutputSize.MATCH_INPUT,
+    preset: Optional[tuple[int, int]] = None,
+    primary: int = 0,
+) -> FitPlan:
+    """Fit condition images to ONE shared native bucket and plan the restore.
+
+    ``preset`` is required by (and only read under) ``OutputSize.PRESET``; it
+    must be a declared row unless ``mode`` is ``COMPOSE``, where the caller
+    owns output geometry outright.
+    """
+    if not images:
+        raise ValidationError("fit_to_native: at least one image is required")
+    mode = FitMode(mode)
+    output_size = OutputSize(output_size)
+    source = images[primary]
+    source_size = (int(source.size[0]), int(source.size[1]))
+
+    if mode is FitMode.COMPOSE:
+        # References are fitted to native independently; output geometry is a
+        # free parameter the caller supplies (ie#505's reference-composition
+        # shape). Nothing is cropped back — there is no "user's framing".
+        fitted_refs = []
+        for image in images:
+            ref_bucket = nearest_bucket(image.size[0], image.size[1], geometry)
+            box = _contain_box(image.size, ref_bucket, geometry.multiple_of)
+            fitted_refs.append(_edge_pad(image, ref_bucket, box))
+        fitted = tuple(fitted_refs)
+        out_bucket = preset or nearest_bucket(source_size[0], source_size[1], geometry)
+        return FitPlan(
+            mode=mode,
+            output_size=output_size,
+            geometry=geometry,
+            bucket=(int(out_bucket[0]), int(out_bucket[1])),
+            images=fitted,
+            source_size=source_size,
+            crop_box=(0, 0, int(out_bucket[0]), int(out_bucket[1])),
+            target_size=(int(out_bucket[0]), int(out_bucket[1])),
+            composite=False,
+        )
+
+    if output_size is OutputSize.PRESET:
+        if preset is None:
+            raise ValidationError("output_size='preset' requires an explicit bucket")
+        bucket = (int(preset[0]), int(preset[1]))
+        if bucket not in geometry.buckets:
+            raise ValidationError(
+                f"{geometry.name}: {bucket[0]}x{bucket[1]} is not a declared native row "
+                f"for this family's edit lane"
+            )
+    else:
+        bucket = nearest_bucket(source_size[0], source_size[1], geometry)
+
+    # The PRIMARY condition shares the output's bucket — that pairing is the
+    # ie#599 fix. Secondary references are content, not framing: each takes
+    # its OWN nearest native row, so a 16:9 style reference is not padded 44%
+    # into a square. Every row is ~native_area, so all conditions still sit on
+    # the same grid scale as the target latent.
+    boxes: list[tuple[int, int, int, int]] = []
+    fitted_list = []
+    for index, image in enumerate(images):
+        row = bucket if index == primary else nearest_bucket(
+            image.size[0], image.size[1], geometry)
+        box = _contain_box(image.size, row, geometry.multiple_of)
+        boxes.append(box)
+        fitted_list.append(_edge_pad(image, row, box))
+    fitted = tuple(fitted_list)
+
+    if output_size is OutputSize.NATIVE:
+        crop_box = (0, 0, bucket[0], bucket[1])
+        target = bucket
+        composite = False
+    elif output_size is OutputSize.PRESET:
+        # The caller explicitly asked to be reframed; do not crop back.
+        crop_box = (0, 0, bucket[0], bucket[1])
+        target = bucket
+        composite = False
+    else:
+        crop_box = boxes[primary]
+        # Inputs at or below the bucket default to the native bucket rather
+        # than true pixels-in == pixels-out; the below-native variant is
+        # UNPROVEN and is the A/B arm of the re-baseline run (ie#599 §6).
+        larger = source_size[0] * source_size[1] > bucket[0] * bucket[1]
+        target = source_size if larger else (crop_box[2] - crop_box[0], crop_box[3] - crop_box[1])
+        composite = larger
+
+    return FitPlan(
+        mode=mode,
+        output_size=output_size,
+        geometry=geometry,
+        bucket=bucket,
+        images=fitted,
+        source_size=source_size,
+        crop_box=crop_box,
+        target_size=(int(target[0]), int(target[1])),
+        composite=composite,
+        source_image=source if composite else None,
+        condition_native=fitted[primary].crop(crop_box) if composite else None,
+    )
+
+
+def _extrema(mask: PILImage) -> tuple[int, int]:
+    """(min, max) of an 8-bit mask, from its histogram (typed, unlike getextrema)."""
+    hist: list[int] = mask.histogram()
+    used = [level for level, count in enumerate(hist) if count]
+    return (used[0], used[-1]) if used else (0, 0)
+
+
+def _soft_mask(edited: PILImage, condition: PILImage) -> PILImage:
+    """Normalized |edit - condition| at native resolution, blurred to a soft mask."""
+    from PIL import Image as PILImageModule
+    from PIL import ImageChops, ImageFilter
+
+    diff = ImageChops.difference(edited.convert("RGB"), condition.convert("RGB"))
+    mask = diff.convert("L").filter(ImageFilter.GaussianBlur(radius=3))
+    peak = _extrema(mask)[1]
+    if peak <= 8:  # No usable localization: treat the edit as global.
+        return PILImageModule.new("L", mask.size, 255)
+    scale = 255.0 / peak
+    return mask.point(lambda v: min(255, int(v * scale)))
+
+
+def restore(
+    image: PILImage,
+    plan: FitPlan,
+    *,
+    upscaler: Optional[Upscaler] = None,
+) -> RestoreResult:
+    """Undo the fit: crop the pad box off, then run the super-resolution stage.
+
+    With no upscaler registered — the fleet's state today — the caller gets
+    native-bucket-sized pixels at exactly the framing they submitted, and
+    ``upscaled``/``composited`` are False. That is the honest result, not a
+    LANCZOS enlargement dressed up as detail.
+    """
+    from PIL import Image as PILImageModule
+
+    if plan.output_size is not OutputSize.MATCH_INPUT or plan.mode is FitMode.COMPOSE:
+        size = (int(image.size[0]), int(image.size[1]))
+        return RestoreResult(
+            image=image, size=size, upscaled=False, composited=False,
+            note=f"returned at the model's native bucket {size[0]}x{size[1]}",
+        )
+
+    if image.size != plan.bucket:
+        raise ValidationError(
+            f"restore: result is {image.size[0]}x{image.size[1]}, plan bucket is "
+            f"{plan.bucket[0]}x{plan.bucket[1]}"
+        )
+
+    framed = image.crop(plan.crop_box) if plan.padded else image
+    if framed.size == plan.target_size:
+        return RestoreResult(
+            image=framed, size=framed.size, upscaled=False, composited=False,
+            note=f"restored to the submitted framing at {framed.size[0]}x{framed.size[1]}",
+        )
+
+    stage = upscaler if upscaler is not None else _UPSCALER
+    enlarged = stage(framed, plan.target_size) if stage is not None else None
+    if enlarged is None or enlarged.size != plan.target_size:
+        # ie#599: no image super-resolution capability exists in the fleet.
+        return RestoreResult(
+            image=framed, size=framed.size, upscaled=False, composited=False,
+            note=(
+                f"edited at native {framed.size[0]}x{framed.size[1]} with the submitted "
+                f"framing; the {plan.target_size[0]}x{plan.target_size[1]} source "
+                "resolution needs an image upscaler, and none is deployed (ie#599)"
+            ),
+        )
+
+    if not plan.composite or plan.source_image is None or plan.condition_native is None:
+        return RestoreResult(
+            image=enlarged, size=enlarged.size, upscaled=True, composited=False,
+            note=f"upscaled to {enlarged.size[0]}x{enlarged.size[1]}",
+        )
+
+    # Untouched regions keep FULL source detail; edited regions carry the
+    # model's. A global edit has no usable mask and returns the upscale.
+    mask = _soft_mask(framed, plan.condition_native)
+    global_edit = _extrema(mask)[0] >= 250
+    source = plan.source_image.convert("RGB")
+    if source.size != plan.target_size:
+        source = source.resize(plan.target_size, PILImageModule.Resampling.LANCZOS)
+    if global_edit:
+        return RestoreResult(
+            image=enlarged, size=enlarged.size, upscaled=True, composited=False,
+            note="global edit: no localized mask, returned the upscaled edit whole",
+        )
+    blended = PILImageModule.composite(
+        enlarged.convert("RGB"), source,
+        mask.resize(plan.target_size, PILImageModule.Resampling.BILINEAR),
+    )
+    return RestoreResult(
+        image=blended, size=blended.size, upscaled=True, composited=True,
+        note=(
+            f"composited the edit back onto the {plan.target_size[0]}x"
+            f"{plan.target_size[1]} source; untouched regions keep source detail"
+        ),
+    )

--- a/tests/test_fit_to_native_pgw664.py
+++ b/tests/test_fit_to_native_pgw664.py
@@ -244,6 +244,12 @@ def test_compose_mode_fits_references_and_leaves_output_free():
     assert result.size == (1024, 1024) and not result.composited
 
 
+def test_compose_never_inherits_reference_geometry_silently():
+    """ie#600: compose output geometry is the caller's, not references[0]'s."""
+    with pytest.raises(ValidationError, match="owns output geometry"):
+        fit_to_native([_photo(1600, 900)], KLEIN_EDIT, mode=FitMode.COMPOSE)
+
+
 def test_edit_mode_and_compose_mode_disagree_on_purpose():
     refs = [_photo(1600, 900)]
     edit = fit_to_native(refs, KLEIN_EDIT, mode=FitMode.EDIT)

--- a/tests/test_fit_to_native_pgw664.py
+++ b/tests/test_fit_to_native_pgw664.py
@@ -1,0 +1,257 @@
+"""pgw#664 / ie#599: fit-to-native geometry — mechanism tests.
+
+Real PIL images through the real code path; no mocks. The properties under
+test are exactly the ie#599 defect statements inverted.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from PIL import Image
+
+from gen_worker import (
+    FamilyGeometry,
+    FitMode,
+    OutputSize,
+    fit_to_native,
+    nearest_bucket,
+    restore,
+    set_upscaler,
+)
+from gen_worker.api.errors import ValidationError
+
+
+# The qwen-image EDIT table: the pipeline's own VAE_IMAGE_SIZE, and rows that
+# already exist in the endpoint's declared Compile(shapes=...).
+QWEN_EDIT = FamilyGeometry(
+    name="qwen-image",
+    native_area=1024 * 1024,
+    buckets=(
+        (1024, 1024), (1152, 864), (864, 1152),
+        (1248, 832), (832, 1248), (1280, 720), (720, 1280),
+    ),
+)
+
+KLEIN_EDIT = FamilyGeometry(
+    name="flux2-klein",
+    native_area=1024 * 1024,
+    buckets=(
+        (1024, 1024), (1184, 880), (880, 1184), (1248, 832), (832, 1248),
+        (1392, 752), (752, 1392), (1568, 672), (672, 1568),
+    ),
+)
+
+
+_TILE = Image.new("RGB", (64, 64))
+_TILE.putdata([((x * 7) % 256, (y * 11) % 256, ((x ^ y) * 3) % 256)
+               for y in range(64) for x in range(64)])
+
+
+def _photo(width: int, height: int) -> Image.Image:
+    """A deterministic image with structure in every region."""
+    return _TILE.resize((width, height), Image.Resampling.NEAREST)
+
+
+# -- the table itself refuses the defect -----------------------------------
+
+
+def test_t2i_table_on_an_edit_lane_is_refused_at_declaration():
+    """The exact ie#599 root cause: Qwen's ~1.7 MP t2i rows on a 1 MP lane."""
+    with pytest.raises(ValueError, match="native area"):
+        FamilyGeometry(
+            name="qwen-image",
+            native_area=1024 * 1024,
+            buckets=((1328, 1328), (1472, 1104), (1664, 928)),
+        )
+
+
+def test_rows_must_be_latent_aligned():
+    with pytest.raises(ValueError, match="multiple of"):
+        FamilyGeometry(name="x", native_area=1024 * 1024, buckets=((1023, 1025),))
+
+
+def test_assert_declared_catches_an_undeclared_row():
+    QWEN_EDIT.assert_declared(QWEN_EDIT.buckets)
+    with pytest.raises(ValueError, match="compile shape set"):
+        QWEN_EDIT.assert_declared(((1024, 1024),))
+
+
+# -- the input's area must never select the tier ---------------------------
+
+
+@pytest.mark.parametrize("scale", [0.05, 0.25, 1.0, 4.0, 12.0])
+def test_bucket_is_area_invariant(scale: float):
+    """A 500x500 thumbnail and a 12 MP photo edit at the SAME bucket."""
+    base = (1024, 1024)
+    size = (int(base[0] * math.sqrt(scale)), int(base[1] * math.sqrt(scale)))
+    assert nearest_bucket(*size, QWEN_EDIT) == (1024, 1024)
+
+
+def test_bucket_follows_aspect_not_size():
+    assert nearest_bucket(4032, 3024, QWEN_EDIT) == (1152, 864)   # 4:3 phone photo
+    assert nearest_bucket(1920, 1080, QWEN_EDIT) == (1280, 720)   # 16:9
+    assert nearest_bucket(1080, 1920, QWEN_EDIT) == (720, 1280)   # 9:16
+    assert nearest_bucket(500, 500, QWEN_EDIT) == (1024, 1024)
+
+
+def test_primary_condition_and_output_share_one_bucket():
+    """The ie#599 pairing: the image being edited sits on the output's row."""
+    images = [_photo(768, 512), _photo(400, 400)]
+    plan = fit_to_native(images, QWEN_EDIT)
+    assert plan.bucket == (1248, 832)
+    assert plan.images[0].size == plan.bucket
+
+
+def test_secondary_references_keep_their_own_native_row():
+    """Content references are not framing: no 44% padding into a square."""
+    images = [_photo(1024, 1024), _photo(1920, 1080), _photo(1080, 1920)]
+    plan = fit_to_native(images, QWEN_EDIT)
+    assert [image.size for image in plan.images] == [
+        (1024, 1024), (1280, 720), (720, 1280)]
+    # Same grid SCALE for every condition — that is what the target latent needs.
+    areas = [w * h for w, h in (image.size for image in plan.images)]
+    assert max(areas) / min(areas) < 1.2
+
+
+# -- pad, never stretch; crop back to the user's framing -------------------
+
+
+@pytest.mark.parametrize("size", [(768, 512), (500, 500), (1080, 1920), (4032, 3024), (900, 700)])
+def test_pad_then_crop_returns_the_submitted_aspect(size):
+    plan = fit_to_native([_photo(*size)], QWEN_EDIT)
+    # The model's own output, faked at the plan's bucket.
+    result = restore(_photo(*plan.bucket), plan)
+    submitted = size[0] / size[1]
+    returned = result.size[0] / result.size[1]
+    assert abs(math.log(returned / submitted)) < 0.01, (size, result.size)
+
+
+def test_the_fit_never_stretches():
+    """Aspect through the fit is preserved to sub-percent, for every row."""
+    for size in [(768, 512), (1080, 1920), (4032, 3024), (300, 900), (1600, 900)]:
+        plan = fit_to_native([_photo(*size)], QWEN_EDIT)
+        left, top, right, bottom = plan.crop_box
+        inner = (right - left) / (bottom - top)
+        assert abs(math.log(inner / (size[0] / size[1]))) < 0.01, size
+
+
+def test_pad_is_reversible_pixel_for_pixel():
+    """Crop(pad(x)) == resize(x) exactly: the pad adds nothing recoverable."""
+    source = _photo(768, 512)
+    plan = fit_to_native([source], QWEN_EDIT)
+    inner = plan.images[0].crop(plan.crop_box)
+    left, top, right, bottom = plan.crop_box
+    direct = source.resize((right - left, bottom - top), Image.Resampling.LANCZOS)
+    assert list(inner.getdata()) == list(direct.getdata())
+
+
+def test_padding_is_only_ever_a_thin_margin():
+    """With the declared rows, no input loses more than 12% of the bucket."""
+    for size in [(768, 512), (500, 500), (1080, 1920), (4032, 3024), (1600, 900)]:
+        plan = fit_to_native([_photo(*size)], QWEN_EDIT)
+        left, top, right, bottom = plan.crop_box
+        used = ((right - left) * (bottom - top)) / (plan.bucket[0] * plan.bucket[1])
+        assert used > 0.88, (size, used)
+
+
+# -- output_size ------------------------------------------------------------
+
+
+def test_native_returns_the_bucket_unrestored():
+    plan = fit_to_native([_photo(768, 512)], QWEN_EDIT, output_size=OutputSize.NATIVE)
+    result = restore(_photo(*plan.bucket), plan)
+    assert result.size == plan.bucket
+    assert not result.upscaled and not result.composited
+
+
+def test_preset_requires_a_declared_row():
+    with pytest.raises(ValidationError, match="not a declared native row"):
+        fit_to_native(
+            [_photo(768, 512)], QWEN_EDIT,
+            output_size=OutputSize.PRESET, preset=(1328, 1328),
+        )
+    plan = fit_to_native(
+        [_photo(768, 512)], QWEN_EDIT,
+        output_size=OutputSize.PRESET, preset=(1024, 1024),
+    )
+    assert plan.bucket == (1024, 1024)
+    assert plan.images[0].size == (1024, 1024)
+
+
+def test_below_native_input_defaults_to_the_native_bucket():
+    """ie#599 §6: small inputs edit at native, not at their own size."""
+    plan = fit_to_native([_photo(500, 500)], QWEN_EDIT)
+    assert plan.bucket == (1024, 1024)
+    assert plan.target_size == (1024, 1024)
+    assert not plan.composite
+
+
+# -- the super-resolution stage is declared, pluggable, and absent ---------
+
+
+def test_no_upscaler_means_native_size_stated_honestly():
+    source = _photo(4032, 3024)
+    plan = fit_to_native([source], QWEN_EDIT)
+    assert plan.composite and plan.target_size == (4032, 3024)
+    result = restore(_photo(*plan.bucket), plan)
+    assert result.size == (1152, 864)
+    assert not result.upscaled and not result.composited
+    assert "none is deployed" in result.note
+
+
+def test_a_registered_upscaler_drives_the_composite():
+    source = _photo(2304, 1728)
+    plan = fit_to_native([source], QWEN_EDIT)
+    # Stand-in for the capability that does not exist yet.
+    def _stub(image, target):
+        return image.resize(target, Image.Resampling.LANCZOS)
+
+    edited = plan.images[0].copy()
+    edited.paste(Image.new("RGB", (200, 200), (255, 0, 0)), (400, 300))
+    result = restore(edited, plan, upscaler=_stub)
+    assert result.size == (2304, 1728)
+    assert result.upscaled and result.composited
+    # Untouched corner comes from the SOURCE, not from an upscale of the edit.
+    assert result.image.getpixel((5, 5)) == source.getpixel((5, 5))
+
+
+def test_set_upscaler_is_a_registration_seam_with_no_default():
+    from gen_worker.geometry import current_upscaler
+
+    assert current_upscaler() is None
+    previous = set_upscaler(lambda image, target: None)
+    try:
+        assert current_upscaler() is not None
+    finally:
+        set_upscaler(previous)
+    assert current_upscaler() is None
+
+
+# -- mode ------------------------------------------------------------------
+
+
+def test_compose_mode_fits_references_and_leaves_output_free():
+    refs = [_photo(768, 512), _photo(400, 900)]
+    plan = fit_to_native(
+        refs, KLEIN_EDIT, mode=FitMode.COMPOSE, preset=(1024, 1024),
+    )
+    assert plan.bucket == (1024, 1024)
+    assert plan.images[0].size == (1248, 832)   # each reference at its own row
+    assert plan.images[1].size == (672, 1568)
+    result = restore(_photo(1024, 1024), plan)
+    assert result.size == (1024, 1024) and not result.composited
+
+
+def test_edit_mode_and_compose_mode_disagree_on_purpose():
+    refs = [_photo(1600, 900)]
+    edit = fit_to_native(refs, KLEIN_EDIT, mode=FitMode.EDIT)
+    compose = fit_to_native(refs, KLEIN_EDIT, mode=FitMode.COMPOSE, preset=(1024, 1024))
+    assert edit.bucket == (1392, 752) and compose.bucket == (1024, 1024)
+    assert restore(_photo(*edit.bucket), edit).size != (1024, 1024)
+
+
+def test_empty_input_is_a_typed_refusal():
+    with pytest.raises(ValidationError):
+        fit_to_native([], QWEN_EDIT)


### PR DESCRIPTION
Mechanism half of the **ie#599** fix. The endpoint half is
cozy-creator/inference-endpoints (ie#599 lane), which is **blocked on this
merging and a gen-worker 0.92.0 publish**.

## The defect this exists to remove

ie#599 established a live production defect: every image-edit lane picks its
OUTPUT bucket and its CONDITION bucket independently. `qwen-image` `edit` at
the default `megapixels=2` asks for 1328² from `QwenImageEditPlusPipeline`,
whose native area is 1 MP and which resizes the condition to ~1024² *ignoring
height/width*. The model gets a 64×64 condition grid and is told to paint an
83×83 latent. The extra pixels are extrapolation, not detail.

Independently re-measured on the banked te#156 rows m10–m19 in this lane
(round-trip PSNR at the 1024/1328 cutoff, $0, no GPU) — ie#599's numbers
reproduce exactly:

| arm | round-trip PSNR |
|---|---|
| the user's input at its own size | **44.6 dB** |
| the 1328² bf16 output | **48.6 dB** |
| the 1328² 4-bit output | **48.7 dB** |
| a pure LANCZOS upscale of the input | **59.7 dB** |

The outputs carry *less* per-pixel structure than the user's own input does.

## What this PR adds — `gen_worker.geometry`

Library owns the MECHANISM, family declares the DATA (pgw#664's own
adjudication, verbatim).

- **`FamilyGeometry`** — native area + declared grid rows. Refuses at
  construction any row outside 0.75..1.25× the declared native area, so *the
  literal root cause — a ~1.7 MP t2i table on a 1 MP edit lane — cannot be
  declared again*.
- **`nearest_bucket`** — log-aspect snap. The input's own **area never selects
  the tier**; the model's native area does.
- **`fit_to_native(...) -> FitPlan`** — the primary condition and the output
  share **one** bucket; secondary references keep their own native row
  (content, not framing). Aspect mismatch → edge-replicating **pad**, never
  stretch or crop-to-fill.
- **`restore(image, plan) -> RestoreResult`** — crops the pad box back off, so
  an edit returns the caller's exact framing.
- **`FitMode`** — `edit` (caller's framing is the contract) vs `compose`
  (multi-reference composition, ie#505 — output geometry is a free parameter).
  Built so the sibling multi-image-reference lane has a mode to declare rather
  than a fork to write.

## The upscaler gap, stated plainly

ie#599's catalog check found **no image super-resolution anywhere in the
fleet** (LTX-2.3's `upscale_2x` is a video *latent* upsampler). So the
post-stage is a **declared, pluggable seam** (`set_upscaler`) that is
currently a **no-op**:

- **What a user gets today:** the edit at the model's native ~1 MP bucket,
  cropped back to exactly the framing they submitted. A 12 MP photo comes back
  at ~1 MP, and `RestoreResult.note` / `.upscaled` / `.composited` say so.
- **What the finished feature gives them:** register an upscaler and `restore`
  carries the edit to source resolution and composites it onto the source, so
  untouched regions keep **full source detail**. That path is written and
  tested (with a stand-in upscaler); it is deliberately not wired to a LANCZOS
  enlargement, because an enlargement is not resolution.

## AOT shape set — verified, not assumed

`FitPlan.bucket` is always a row the family declared.
`FamilyGeometry.assert_declared(Compile.shapes)` is the assertion each
endpoint runs in its own tests; both `qwen-image` and `flux.2-klein-4b/-9b`
reuse their **existing** 1 MP grids, so **zero new compile shapes**.

## Tests

28 integration tests over real PIL images (`tests/test_fit_to_native_pgw664.py`):
area-invariance of the tier, pixel-exact pad reversibility, sub-percent aspect
preservation across every row, the declaration-time refusal of a t2i table,
the honest no-upscaler result, and the composite path under a stand-in
upscaler. mypy + ruff clean.

Cross-refs: ie#599, ie#556 (six `_bucket` bodies, six answers to "16:9 at
1 MP" — this is their absorption target), ie#345, ie#505.