### PR TITLE
pgw#954 / pgw#738 death-1: invert the worker lock order to instance gate -> GPU permit

### DIFF
--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -3032,7 +3032,12 @@ class _GpuSlotLease:
         return True
 
     def reacquire(self) -> None:
-        """Blocking re-acquire from a handler thread."""
+        """Blocking re-acquire from a handler thread.
+
+        Safe because of the pgw#954 order (instance gate -> permit): this
+        runs with the job's gates still held, and no permit acquirer anywhere
+        waits on a gate, so the permit is always reachable.
+        """
         asyncio.run_coroutine_threadsafe(self._sem.acquire(), self._loop).result()
         with self._lock:
             self._held = True
@@ -11336,25 +11341,26 @@ class Executor:
         try:
             stole = await asyncio.to_thread(self._bg_admit, kind, abort_check)
             turn_t0 = time.monotonic()
-            # Same order as the tenant path (permit -> run_lock ->
-            # turn_mutex): a tenant landing on ANOTHER instance mid-seed
-            # waits one bounded seed instead of contending for the device.
-            # pgw#779: the RECORD's group permit. A background turn on group 2
-            # must not consume group 0's slot - with a count it did, so a mint
-            # anywhere stalled a tenant everywhere.
-            permit = self._gpu_permit_for_record(rec)
-            await permit.acquire()
-            try:
-                async with rec.run_lock:
-                    await self._bg_locked(rec.turn_mutex, abort_check)
+            # pgw#954: same order as the tenant path — run_lock -> turn_mutex
+            # -> permit. A turn must never hold the permit while queued on an
+            # instance gate: that is the half of the cycle that wedges a
+            # tenant's mid-handler #382 reacquire.
+            async with rec.run_lock:
+                await self._bg_locked(rec.turn_mutex, abort_check)
+                try:
+                    # pgw#779: the RECORD's group permit. A background turn on
+                    # group 2 must not consume group 0's slot - with a count it
+                    # did, so a mint anywhere stalled a tenant everywhere.
+                    permit = self._gpu_permit_for_record(rec)
+                    await permit.acquire()
                     try:
                         yield stole
                     finally:
-                        rec.turn_mutex.release()
-                        self._bg_charge_debt(
-                            stole, time.monotonic() - turn_t0)
-            finally:
-                permit.release()
+                        permit.release()
+                finally:
+                    rec.turn_mutex.release()
+                    self._bg_charge_debt(
+                        stole, time.monotonic() - turn_t0)
         finally:
             self._bg_unit_mutex.release()
 
@@ -11751,75 +11757,6 @@ class Executor:
         started = time.monotonic()
         alloc_at_start = 0
         try:
-            if needs_gpu:
-                permit_t0 = time.monotonic()
-                # pgw#779: THIS job's group permit, not one of G interchangeable
-                # tickets. The group was stamped from the dispatch before
-                # anything ran, so a permit and a card are the same fact.
-                gpu_permit = self._gpu_permit_for_group(current_device_group())
-                await self._intent_await(
-                    job.intent_id,
-                    gpu_permit.acquire(),
-                    operation=f"GPU permit for request {run.request_id}",
-                    status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
-                    stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_GPU_SLOT,
-                    reason=pb.LIFECYCLE_WAIT_REASON_GPU_SLOT,
-                )
-                # th#1111: the permit wait was in NO metric — it precedes the
-                # handler window, so runtime_ms never saw it.
-                ctx._stages.record_pre("gpu_permit_wait", time.monotonic() - permit_t0)
-                self._loop = asyncio.get_running_loop()
-                lease = _GpuSlotLease(gpu_permit, self._loop)
-                ctx._gpu_slot_lease = lease
-                # pgw#943: a child-call wait may yield this permit ONLY when
-                # the job holds nothing another permit-holder could block on.
-                # Both permit acquirers (this path and _bg_turn) take the
-                # permit BEFORE the instance gate, so a parked parent still
-                # holding run_lock would wedge its own re-acquire: the
-                # follower/mint holds the permit waiting on run_lock, the
-                # parent waits on the permit — hold-and-wait cycle. And a
-                # follower on a shared pipeline would clobber this request's
-                # per-request adapter state mid-handler. Gate-holding or
-                # adapter-carrying parents therefore keep the permit across
-                # child calls (same-function pipelining is impossible for
-                # them anyway — single-flight per instance, pgw#647).
-                ctx._child_call_slot_yieldable = (
-                    (spec.cls is None or spec.reentrant) and not adapters
-                )
-                # gw#516: the handler thread reports the terminal
-                # decode->finalize slot release so the hub sees the job as
-                # "finalizing" while its encode/upload tail runs slotless.
-                ctx._on_finalize_release = lambda: self._enter_finalize(job)
-                if job.ctx.cancelled:
-                    raise CanceledError("canceled")
-                # pgw#513: reset the CUDA peak-allocator watermark now that
-                # this job exclusively owns gpu_index (jobs serialize under
-                # _gpu_semaphore) — peak_vram_bytes then measures THIS job's
-                # peak, not the process-lifetime high-water mark.
-                if torch is not None and torch.cuda.is_available():
-                    try:
-                        torch.cuda.reset_peak_memory_stats(gpu_index)
-                    except Exception:
-                        pass
-                    # pgw#652: the baseline the peak is measured AGAINST.
-                    # peak - baseline is this request's transient (activation)
-                    # footprint, as opposed to the resident weights that were
-                    # already allocated when it took the GPU.
-                    alloc_at_start = self._vram_allocated()
-            # Last execution fence: no adapter mutation or tenant handler has
-            # run yet. The repeated check catches a replacement between
-            # scheduler assignment/intake and this GPU turn.
-            self._validate_required_compile(spec, run)
-            # pgw#687: past here this job owns the permit/gate — it is no
-            # longer refusable-in-place by the cancel-unwind quarantine.
-            job.executing = True
-            self._intent_transition(
-                job.intent_id,
-                pb.LIFECYCLE_INTENT_STATUS_RUNNING,
-                pb.LIFECYCLE_INTENT_STAGE_READY,
-                detail="executing",
-            )
-            started = time.monotonic()
             # Pin-while-executing: the models (and adapter snapshots) this job
             # uses are not eviction candidates for its duration. Lane refs
             # excluded (gw#551): the ExecutionLaneGate pins the one lane the handler
@@ -11827,18 +11764,22 @@ class Executor:
             # gate's promote against its own job's pins.
             exec_refs = self._job_pin_refs(spec, routed)
             adapter_refs = [a.ref for group in adapters.values() for a in group]
-            # pgw#647: SINGLE-FLIGHT per live instance. Adapter attach and the
-            # handler itself mutate the instance's materialized graph (LoRA
-            # buffers, adapter enable state); two concurrent requests on one
-            # instance corrupt each other — one-job-per-GPU used to mask
-            # this; multi-GPU permits and multi-residency do not. The lock is
-            # per-_ClassRecord, so jobs on DIFFERENT instances (different
-            # picks) still run concurrently; ``reentrant=True`` classes opt
-            # out. Ordering: acquired AFTER the GPU permit and never held
-            # while acquiring one — no cycle.
-            gate_t0 = time.monotonic()
             async with AsyncExitStack() as run_gate:
+                # pgw#954 LOCK ORDER, worker-wide: instance gate -> GPU permit,
+                # so no permit holder ever waits on a gate and the #382 lease's
+                # mid-handler reacquire always finds the permit reachable. The
+                # inverse order killed real jobs (pgw#738: 62922680 + d0cbf910,
+                # one H100, 3h51m silent). Conforming acquirers: `_bg_turn`,
+                # `_bg_turn_threaded` (gate only), `_exclusive_gpu` (permits
+                # under the load-lock family, never an instance gate).
+                #
+                # pgw#647: SINGLE-FLIGHT per live instance — adapter attach and
+                # the handler mutate the instance's materialized graph, so two
+                # concurrent requests on one instance corrupt each other. Jobs
+                # on DIFFERENT instances still run concurrently;
+                # ``reentrant=True`` opts out.
                 if spec.cls is not None and not spec.reentrant:
+                    gate_t0 = time.monotonic()
                     rec_gate = self._classes[spec.instance_key]
                     await run_gate.enter_async_context(rec_gate.run_lock)
                     # pgw#677: exclude the shape-warm thread's compile from
@@ -11853,14 +11794,77 @@ class Executor:
                     if gate_wait >= 0.001:
                         # pgw#677: time queued behind the instance gate
                         # (typically a background mint/compile turn) is NOT
-                        # this request's compute — attribute it as its own
-                        # pre-handler stage and restart the compute clock,
-                        # so runtime_ms stops billing mint contention to
-                        # the tenant (measured: 16.9s reported for 1.95s of
-                        # real work).
+                        # this request's compute — its own pre-handler stage,
+                        # so runtime_ms stops billing mint contention to the
+                        # tenant (measured: 16.9s reported for 1.95s of real
+                        # work). Now measured while holding no permit, so the
+                        # card stays exploitable by other instances for it.
                         ctx._stages.record_pre(
                             "instance_gate_wait", gate_wait)
-                        started = time.monotonic()
+                if needs_gpu:
+                    permit_t0 = time.monotonic()
+                    # pgw#779: THIS job's group permit, not one of G
+                    # interchangeable tickets. The group was stamped from the
+                    # dispatch before anything ran, so a permit and a card are
+                    # the same fact.
+                    gpu_permit = self._gpu_permit_for_group(current_device_group())
+                    await self._intent_await(
+                        job.intent_id,
+                        gpu_permit.acquire(),
+                        operation=f"GPU permit for request {run.request_id}",
+                        status=pb.LIFECYCLE_INTENT_STATUS_WAITING,
+                        stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_GPU_SLOT,
+                        reason=pb.LIFECYCLE_WAIT_REASON_GPU_SLOT,
+                    )
+                    # th#1111: the permit wait was in NO metric — it precedes
+                    # the handler window, so runtime_ms never saw it.
+                    ctx._stages.record_pre(
+                        "gpu_permit_wait", time.monotonic() - permit_t0)
+                    self._loop = asyncio.get_running_loop()
+                    lease = _GpuSlotLease(gpu_permit, self._loop)
+                    ctx._gpu_slot_lease = lease
+                    # pgw#954: gate-holding parents may now yield. What still
+                    # cannot is a job carrying per-request adapters — a
+                    # follower on the shared pipeline would deactivate or
+                    # replace this request's adapter state mid-handler, and no
+                    # lock orders that away.
+                    ctx._child_call_slot_yieldable = not adapters
+                    # gw#516: the handler thread reports the terminal
+                    # decode->finalize slot release so the hub sees the job as
+                    # "finalizing" while its encode/upload tail runs slotless.
+                    ctx._on_finalize_release = lambda: self._enter_finalize(job)
+                    if job.ctx.cancelled:
+                        raise CanceledError("canceled")
+                    # pgw#513: reset the CUDA peak-allocator watermark now that
+                    # this job exclusively owns gpu_index (jobs serialize under
+                    # _gpu_semaphore) — peak_vram_bytes then measures THIS
+                    # job's peak, not the process-lifetime high-water mark.
+                    if torch is not None and torch.cuda.is_available():
+                        try:
+                            torch.cuda.reset_peak_memory_stats(gpu_index)
+                        except Exception:
+                            pass
+                        # pgw#652: the baseline the peak is measured AGAINST.
+                        # peak - baseline is this request's transient
+                        # (activation) footprint, as opposed to the resident
+                        # weights already allocated when it took the GPU.
+                        alloc_at_start = self._vram_allocated()
+                # Last execution fence: no adapter mutation or tenant handler
+                # has run yet. The repeated check catches a replacement between
+                # scheduler assignment/intake and this GPU turn.
+                self._validate_required_compile(spec, run)
+                # pgw#687: past here this job owns the permit/gate — it is no
+                # longer refusable-in-place by the cancel-unwind quarantine.
+                job.executing = True
+                self._intent_transition(
+                    job.intent_id,
+                    pb.LIFECYCLE_INTENT_STATUS_RUNNING,
+                    pb.LIFECYCLE_INTENT_STAGE_READY,
+                    detail="executing",
+                )
+                # The compute clock starts once BOTH admissions are paid; each
+                # wait is its own `record_pre` stage above.
+                started = time.monotonic()
                 with self.store.residency.executing(*exec_refs, *adapter_refs):
                     active: List[Tuple[str, Any]] = []
                     try:

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -819,23 +819,16 @@ class RequestContext(Generic[D]):
         (#382); the wait itself stays on the handler thread, so heartbeats
         and StateDeltas ride the free event loop exactly as before.
 
-        SCOPED to jobs the executor stamped yieldable, because both permit
-        acquirers (`_run_job` and `_bg_turn`) take the permit BEFORE the
-        instance gate:
-
-        * a job holding its instance gate (non-reentrant class endpoint)
-          must NOT yield — a same-instance follower or background turn
-          would hold the permit while waiting on this job's ``run_lock``,
-          and the re-acquire would wedge (hold-and-wait cycle);
-        * a job with per-request adapters active must NOT yield — a
-          follower on the shared pipeline would deactivate/replace this
-          request's adapter state mid-handler.
-
-        For those jobs the child call keeps the permit (the pre-pgw#943
-        behaviour); same-function pipelining was impossible for them anyway
-        (single-flight per instance, pgw#647). The wait is bracketed as its
-        own stage so the child park shows up as GPU-idle time in the stage
-        map instead of masquerading as compute.
+        Gate-holding class endpoints yield too (pgw#954): every permit
+        acquirer now takes the instance gate FIRST, so a same-instance
+        follower queues on ``run_lock`` holding no permit and the re-acquire
+        cannot wedge. What remains SCOPED out is a job with per-request
+        adapters active — a follower on the shared pipeline would
+        deactivate/replace this request's adapter state mid-handler, which
+        is a data race no lock order fixes. Those jobs keep the permit
+        across the wait. The wait is bracketed as its own stage so the child
+        park shows up as GPU-idle time in the stage map instead of
+        masquerading as compute.
         """
         with self._stages.stage("child_call_wait"):
             if not self._child_call_slot_yieldable:

--- a/tests/test_child_call_pipelining_pgw943.py
+++ b/tests/test_child_call_pipelining_pgw943.py
@@ -16,13 +16,13 @@ trip. The fix routes every child-call wait (``wait=True`` and the
 which yields the #382 GPU-slot lease for the park and re-acquires before
 returning to tenant code.
 
-The yield is SCOPED to jobs that hold no instance gate and no per-request
-adapters, because both permit acquirers (``_run_job`` and ``_bg_turn``) take
-the permit BEFORE the instance gate: a parked parent still holding
-``run_lock`` would wedge its own re-acquire (the follower holds the permit
-waiting on ``run_lock``; the parent waits on the permit — hold-and-wait
-cycle), and a follower on a shared pipeline would clobber per-request
-adapter state mid-handler. That scope is pinned below too.
+pgw#954 then inverted the worker's lock order to instance gate -> permit at
+every acquirer, which deleted the hold-and-wait cycle that had scoped the
+yield away from class endpoints; §4 below pins the widened scope and the
+inversion at its own seam. What stays scoped out is a job carrying
+per-request adapters — a follower on the shared pipeline would clobber this
+request's adapter state mid-handler, which is a data race no lock order
+fixes.
 
 Everything runs on the real executor, over the real ``@endpoint`` ->
 ``RequestContext`` -> ``callout.CalloutClient`` path, with a real HTTP server
@@ -39,7 +39,6 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-import time
 from contextlib import asynccontextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
@@ -58,12 +57,6 @@ from harness.progress_wait import Cadence, await_count, await_progress
 #: `completed` only after `release()`), so this bounds the observation by work
 #: the system under test performed rather than by elapsed time.
 _OBSERVED_CHILD_POLLS = 100
-
-#: The second handler's entry, once the permit comes free, must be a small
-#: SHARE of how long the same permit had it blocked in this run. #455 measured
-#: 10.7 ms against a multi-second block. A ratio keeps it a claim about WHAT
-#: GATED the handler: a slow runner lengthens both sides.
-_PROMPT_ENTRY_SHARE = 0.25
 
 
 class _In(msgspec.Struct):
@@ -276,8 +269,9 @@ def _endpoints(probe: _Probe, *, gpu: bool) -> List[Any]:
 
 
 def _gated_endpoints(probe: _Probe) -> List[Any]:
-    """A class-based (non-reentrant) parent: holds its instance gate for the
-    whole handler, so its child calls must NOT yield the permit."""
+    """A class-based (non-reentrant) parent holding its instance gate for the
+    whole handler, plus a sibling function on the SAME instance and a plain
+    function on another — the two follower shapes pgw#954 distinguishes."""
     res = Resources(gpu=True)
 
     @endpoint(kind="inference", child_calls=True, resources=res)
@@ -296,12 +290,28 @@ def _gated_endpoints(probe: _Probe) -> List[Any]:
             probe.parent_result.append(out)
             return _Out(tag="parent-done")
 
+        def gated_sibling(self, ctx: Any, payload: _In) -> _Out:
+            if not payload.tag:
+                return _Out(tag="warmup")
+            probe.second_ran.set()
+            return _Out(tag="sibling-done")
+
     @endpoint(kind="inference", resources=res, name="second")
     def second(ctx: Any, payload: _In) -> _Out:
         probe.second_ran.set()
         return _Out(tag="second-done")
 
     return [GatedParent, second]
+
+
+def _gated_name(which: str) -> str:
+    """The wire name of a ``GatedParent`` method, read off the real specs."""
+    wanted = which.replace("_", "-")
+    for fn in _gated_endpoints(_Probe()):
+        for spec in extract_specs(fn):
+            if spec.cls is not None and spec.name == wanted:
+                return str(spec.name)
+    raise AssertionError(f"no gated spec named {wanted!r}")
 
 
 def _run_job(request_id: str, function_name: str) -> pb.RunJob:
@@ -677,39 +687,68 @@ def test_cancel_mid_yield_leaves_the_permit_free() -> None:
 
 
 # --------------------------------------------------------------------------
-# 4. the scope: a gate-holding parent must KEEP its permit
+# 4. the scope, widened by pgw#954: a gate-holding parent yields too
 # --------------------------------------------------------------------------
 
 
-def test_gate_holding_parent_keeps_the_permit_across_child_calls() -> None:
-    """A non-reentrant CLASS endpoint holds its instance gate (``run_lock``)
-    for the whole handler. Yielding its permit would wedge: both `_run_job`
-    and `_bg_turn` take the permit BEFORE the gate, so a same-instance
-    follower (or mint turn) would hold the permit while waiting on the
-    parked parent's `run_lock`, and the parent's re-acquire would wait on
-    that permit forever — hold-and-wait cycle. So for this shape the child
-    call KEEPS the permit (pre-#943 behaviour), pinned here so widening the
-    yield is a deliberate act (it requires inverting the permit/gate lock
-    order first — see the pgw#943 tracker entry)."""
+def test_gate_holding_parent_yields_its_permit_across_child_calls() -> None:
+    """The pgw#954 widening. A non-reentrant CLASS endpoint holds its
+    instance gate (``run_lock``) for the whole handler, and now yields the
+    permit anyway: with every acquirer taking the gate BEFORE the permit, a
+    job on another instance takes the freed permit and runs to completion
+    while the gated parent is parked. (#943 pinned the opposite and said
+    widening required inverting the order first; the order is inverted.)"""
 
     async def _measure() -> None:
         async with _running(_gated_endpoints) as run:
-            gated_name = next(
-                s.name for fn in _gated_endpoints(_Probe())
-                for s in extract_specs(fn) if s.cls is not None
-            )
-            await run.park_parent(gated_name)
-            polls_at_dispatch = run.platform.polls()
-            blocked_from = time.monotonic()
+            await run.park_parent(_gated_name("gated_parent"))
             await run.ex.handle_run_job(_run_job("req-second", "second"))
-            # The observation window: _OBSERVED_CHILD_POLLS of the child
-            # call's own progress, ending early if the second handler enters
-            # (which would be the fix's scope leaking). Group 0's permit is
-            # sampled on every observation.
-            permit_samples: List[bool] = []
+            await _progress(
+                run.probe.second_ran.is_set, lambda entered: entered,
+                what="the cross-instance follower entering on the freed permit",
+                gone=run.parent_done_early,
+            )
+            await _progress(
+                lambda: "req-second" in _results(run.sent), lambda done: done,
+                what="the cross-instance follower completing while parked",
+                gone=run.parent_done_early,
+            )
+            # The parent really was still suspended on its child throughout.
+            assert not run.probe.parent_resumed.is_set()
+            assert "req-parent" not in _results(run.sent)
+            run.platform.release()
+            statuses = await run.finish()
+            assert statuses.get("req-parent") == pb.JOB_STATUS_OK, statuses
+            assert statuses.get("req-second") == pb.JOB_STATUS_OK, statuses
+
+    asyncio.run(_measure())
+
+
+def test_same_instance_follower_queues_on_the_gate_holding_no_permit() -> None:
+    """THE pgw#954 inversion, at its own seam — the deliberately-held
+    contender is the instance gate itself.
+
+    A second request on the SAME class instance, dispatched while the parent
+    is parked mid-handler with its permit yielded: it must NOT enter (pgw#647
+    single-flight), and while it waits the permit must be FREE. Under the old
+    permit-first order this follower held the permit while queued on
+    ``run_lock``, so the parent's re-acquire never returned and BOTH jobs died
+    silently (pgw#738: 62922680 + d0cbf910). Here the parent resumes and both
+    complete, in order."""
+
+    async def _measure() -> None:
+        async with _running(_gated_endpoints) as run:
+            await run.park_parent(_gated_name("gated_parent"))
+            polls_at_dispatch = run.platform.polls()
+            await run.ex.handle_run_job(
+                _run_job("req-sibling", _gated_name("gated_sibling")))
+            # Observation window denominated in the child call's OWN progress
+            # (status polls the platform answered), ending early if the
+            # follower enters — which would mean the gate leaked.
+            permit_free: List[bool] = []
 
             def _observe() -> Tuple[int, bool]:
-                permit_samples.append(run.ex._gpu_permits[0].locked())
+                permit_free.append(not run.ex._gpu_permits[0].locked())
                 return run.platform.polls(), run.probe.second_ran.is_set()
 
             await _progress(
@@ -719,35 +758,25 @@ def test_gate_holding_parent_keeps_the_permit_across_child_calls() -> None:
                     or seen[0] - polls_at_dispatch >= _OBSERVED_CHILD_POLLS
                 ),
                 what=(
-                    f"{_OBSERVED_CHILD_POLLS} child-status polls with the "
-                    f"gate-holding parent suspended"
+                    f"{_OBSERVED_CHILD_POLLS} child-status polls with a "
+                    f"same-instance follower queued on the gate"
                 ),
                 gone=run.parent_done_early,
             )
             assert not run.probe.second_ran.is_set(), (
-                "a gate-holding parent yielded its permit — that shape wedges "
-                "on re-acquire (see docstring); the scope stamp regressed"
+                "a same-instance follower entered while the parent held "
+                "run_lock — pgw#647 single-flight regressed"
             )
-            assert all(permit_samples)
+            assert all(permit_free), (
+                "the gate-queued follower is holding the GPU permit — the "
+                "pgw#954 order regressed and the parent's re-acquire wedges"
+            )
             assert run.platform.polls() - polls_at_dispatch >= _OBSERVED_CHILD_POLLS
-            blocked_s = time.monotonic() - blocked_from
-            released_at = time.monotonic()
             run.platform.release()
-            await _progress(
-                run.probe.second_ran.is_set, lambda entered: entered,
-                what="the second handler entering once the permit is free",
-                poll_s=0.005,
-            )
-            second_latency = time.monotonic() - released_at
-            # The ordering, as a share of a baseline measured in this same
-            # run: the handler entered on the permit coming free, in a small
-            # fraction of the time that same permit had it blocked. A slow
-            # runner lengthens both sides.
-            assert second_latency < blocked_s * _PROMPT_ENTRY_SHARE, (
-                second_latency, blocked_s,
-            )
             statuses = await run.finish()
+            assert run.probe.parent_resumed.is_set(), (
+                "the parent never re-acquired its permit")
             assert statuses.get("req-parent") == pb.JOB_STATUS_OK, statuses
-            assert statuses.get("req-second") == pb.JOB_STATUS_OK, statuses
+            assert statuses.get("req-sibling") == pb.JOB_STATUS_OK, statuses
 
     asyncio.run(_measure())

--- a/tests/test_upload_deadlock_pgw738.py
+++ b/tests/test_upload_deadlock_pgw738.py
@@ -33,28 +33,25 @@ from typing import Any, ClassVar, Optional, Tuple
 import msgspec
 import pytest
 
-# pgw#797 adjudication (test-health audit): SKIP, do not FAIL. Unlike its two
-# pgw#738 siblings, this file's src half exists NOWHERE — all three cases fail
-# against HEAD *and* against the worktree carrying every sibling's WIP, so it is
-# a test written ahead of a fix that was never made. It still describes a real,
-# expensive incident (62922680 + d0cbf910, one H100, ~$24.6, 3h51m of
-# heartbeating silence), and the contract it states — run_lock-first admission,
-# a typed GpuSlotReacquireTimeout, a reaped terminal JobResult — is the design
-# pgw#738 asked for. So it is preserved as the executable specification of that
-# fix rather than deleted, and named as unimplemented rather than left red.
-# REMOVE THIS GUARD as the first step of implementing pgw#738: it should go red,
-# then green.
-_ADMISSION_FIX_LANDED = hasattr(
+# pgw#954 landed the FIRST of this file's three contract clauses —
+# gate-first admission — so `test_two_packed_jobs_survive_a_mid_handler_save`
+# (the incident shape itself: 62922680 + d0cbf910) now RUNS. The other two
+# clauses are still unimplemented and skip individually:
+#
+#   * a typed `GpuSlotReacquireTimeout` bound on the re-acquire. Note this
+#     clause predates the no-magic-timeouts rule (gw#666/pgw#795) — a fixed
+#     `REACQUIRE_TIMEOUT_S` is exactly the shape that rule forbids, so pgw#738
+#     should re-derive it as a progress/liveness bound before implementing.
+#   * a dead-job-task reaper turning an escaped `_run_job` into a terminal
+#     JobResult (the never-silent guarantee).
+_REACQUIRE_BOUND_LANDED = hasattr(
     __import__("gen_worker.api.errors", fromlist=["errors"]),
     "GpuSlotReacquireTimeout",
 )
-if not _ADMISSION_FIX_LANDED:
-    pytest.skip(
-        "pgw#738 UNIMPLEMENTED: the upload/publish admission fix (run_lock-first "
-        "admission + typed GpuSlotReacquireTimeout + dead-task reaper) has not "
-        "landed on any branch. This file is its executable specification.",
-        allow_module_level=True,
-    )
+_needs_reacquire_bound = pytest.mark.skipif(
+    not _REACQUIRE_BOUND_LANDED,
+    reason="pgw#738 UNIMPLEMENTED: typed GpuSlotReacquireTimeout bound",
+)
 
 from gen_worker import executor as executor_mod
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -153,6 +150,7 @@ def test_two_packed_jobs_survive_a_mid_handler_save() -> None:
         httpd.shutdown()
 
 
+@_needs_reacquire_bound
 def test_reacquire_bound_fails_typed_never_silent() -> None:
     """If the yielded permit genuinely cannot come back (simulated thief on
     the semaphore), the job fails TYPED + RETRYABLE within the bound instead
@@ -190,6 +188,8 @@ async def _release(ex: Any) -> None:
     ex._gpu_semaphore.release()
 
 
+@pytest.mark.skip(
+    reason="pgw#738 UNIMPLEMENTED: dead-job-task reaper (never-silent terminal)")
 def test_dead_job_task_reports_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     """Never-silent guarantee: a job task that dies without reporting (any
     escape from _run_job's own handlers) is reaped into a terminal


### PR DESCRIPTION
## The defect

The #382 lease lets a handler yield its GPU permit mid-handler (`save_bytes`, and since pgw#943 child-call waits) and re-acquire it afterwards. **Both permit acquirers took the permit BEFORE the instance gate**, so a same-instance follower grabbed the freed permit and then blocked on the parked parent's `run_lock` — and the parent's `reacquire()` waited on the permit that follower held. Hold-and-wait; both jobs dead, worker still heartbeating.

**pgw#954 filed this as latent. It is not.** It is **pgw#738's death 1**, root-caused from `62922680` + `d0cbf910` (one H100, ~$24.6, 3h51m of silence) plus four more instances. `tests/test_upload_deadlock_pgw738.py` has been in the tree since the pgw#797 audit as the *executable specification* of exactly this fix, skipped because its src half was never written. pgw#943's lane re-derived the same cycle from the code independently.

## Acquisition-site census (every site, both orders)

| site | before | after |
|---|---|---|
| `_run_job_pinned` | permit → `run_lock` → `turn_mutex` | `run_lock` → `turn_mutex` → permit |
| `_bg_turn` | `_bg_unit_mutex` → permit → `run_lock` → `turn_mutex` | `_bg_unit_mutex` → `run_lock` → `turn_mutex` → permit |
| `_GpuSlotLease.reacquire()` | gates HELD → permit (**the violator**) | unchanged — now **conforms** |
| `_bg_turn_threaded` | `_bg_unit_mutex` → `turn_mutex`, no permit | unchanged, conforms |
| `_exclusive_gpu` (`_setup_locked_inner`, `_adopt_compile_cache`) | load-lock family → ALL permits, never an instance gate | unchanged, conforms |
| `_unit` legacy `_bg_yield_enabled()==False` | `run_lock` only, no permit | unchanged, conforms |

**No third path takes permit → gate.** The one remaining permits-first holder is `_exclusive_gpu`, and the `_invoke_warmup` body it wraps acquires neither `run_lock` nor `turn_mutex`. The invariant is stated once, at `_run_job_pinned`'s gate: *no permit holder ever waits on an instance gate.*

## pgw#943's scope, widened

`ctx._child_call_slot_yieldable` drops the `(spec.cls is None or spec.reentrant)` clause — that clause existed **only** to route around this cycle. Class endpoints now pipeline across child calls. Jobs carrying per-request adapters still keep the permit: a follower on the shared pipeline would deactivate/replace their adapter state mid-handler, which no lock order fixes.

## Proofs — real code paths, progress-gated, no clocks

- **`test_two_packed_jobs_survive_a_mid_handler_save`** (pgw#738's, un-skipped): the incident shape over the real hub-double + a real local media-upload sink. Green here; with the permit-first order restored it fails on its own message *"uploader vanished: the pgw#738 reacquire deadlock"*. The file's other two cases (typed `GpuSlotReacquireTimeout`, dead-task reaper) stay pgw#738's and now skip individually rather than at module level.
- **`test_same_instance_follower_queues_on_the_gate_holding_no_permit`** (new): a same-instance follower dispatched while the parent is parked must queue on `run_lock` holding **no** permit. Red under the old order with the wedge signature — the permit observed taken by the queued job.
- **`test_gate_holding_parent_yields_its_permit_across_child_calls`**: pgw#943's scope pin, inverted per its own instruction. Red if the scope stamp is reverted.

## Deliberate consequences

- `instance_gate_wait` is now measured holding **no** permit — the card stays exploitable by other instances for the whole gate queue, which is the throughput half of the fix. `gpu_permit_wait` is now measured holding the gate. Both stay `record_pre` GPU-idle stages and the compute clock starts once both admissions are paid, so `runtime_ms` reconciliation is unchanged.
- `_bg_turn`'s admission/steal semantics are untouched — `_bg_admit` still runs before any gate; only the permit moved inside.
- The shape-warm thread's `turn_mutex` window now also spans a tenant's permit wait — strictly the tenant-wins doctrine pgw#677 already states.
- pgw#513's peak-watermark reset still happens immediately after the permit.

## Not fixed here

pgw#738 keeps its other two clauses. Note the typed re-acquire bound as specified (`_GpuSlotLease.REACQUIRE_TIMEOUT_S`) is a fixed duration, which gw#666/pgw#795 forbids — it should be re-derived as a progress/liveness bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)