### PR TITLE
th#1590: record why models/w4a4.py claims no artifact contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **th#1590: `models/w4a4.py` stays contract-UNCLAIMED, on purpose.** Measured
+  against both standing catalogs and the R2 CAS: no artifact of our flat nvfp4
+  layout has ever been published, so no descriptor can be derived from real
+  bytes and the decoder declares no execution lane. The guard comment names the
+  wrong answer explicitly — `bfl.nvfp4-preswizzled@1` is HIGH-nibble with
+  pre-swizzled scales, and te#151 measured that conflation at LPIPS 1.11.
+
 - **th#1582 Phase A: the EXECUTION LANE concept is spelled `execution_lane`.**
   A names-only pass — 1,655 Python identifier tokens across 113 files (`Lane` ->
   `ExecutionLane`, `lane` -> `execution_lane`, `parse_lane_spec` ->

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -488,6 +488,11 @@ def _dequant_into(sd: Dict[str, Any], name: str, compute: Any) -> None:
         sd.pop(f"{name}{suffix}", None)
 
 
+# NO `@implements_contract` HERE, deliberately (th#1590): this flat nvfp4 layout
+# has no registry entry yet, and it is NOT `bfl.nvfp4-preswizzled@1` — that one is
+# HIGH-nibble with pre-swizzled scales, and conflating them measured LPIPS 1.11
+# (te#151). Registering ours needs a real artifact to read; none has ever passed
+# the publish gate (gw#540), so this decoder contributes no execution lane.
 def load_w4a4_denoiser(root: Path, art: W4a4Artifact, *,
                        compute_dtype: Any = None, mode: str = "",
                        cls: Any = None) -> Any:


### PR DESCRIPTION
`models/w4a4.py` — our flat nvfp4 decoder — declares no `@implements_contract`. th#1580's A4 landing flagged that as an open A2 code contribution. It is not registerable today, and the blocker is artifact supply, not registry design.

**No artifact of this format has ever been published.** Measured, not inferred:

- Both standing catalogs, every checkpoint ever created including soft-deleted: the complete `flavor` x `placement.precision_class` set is `{(none,-), (none,fp8), (svdq-fp4-r128, svdq-fp4), (svdq-int4-r128,-)}` on `master` and `{(none,-), (none,fp8), (svdq-fp4-r128, svdq-fp4)}` on `dev`. The complete `quant_recipe` set is `{fp8-w8a8 (modelopt), w8a8-pcs-dynamic (gen-worker)}`. Zero `nvfp4-w4a4` rows.
- The two artifacts usually named as candidates are **not** this format, proven from real header bytes: `tensorhub/qwen-image:svdq-te137` and `tensorhub/qwen-image-edit-2511:svdq-te156` both decode to the `nunchaku.v1@1` leaf census (qweight 600 / wscales 600 / wcscales 120 / wtscale 360 / proj_down 480 / proj_up 480 / smooth_factor(+orig) 480 / wzeros 120 / weight 247 / bias 606, 4,573 tensors) with **`weight_scale_2` count 0** — and `weight_scale_2` is precisely the triple member `detect_w4a4_artifact` keys on.
- R2 sweep of `repo-cas`, `repo-cas-chaos`, `tensorhub-public{,-chaos}`: no staged flat-nvfp4 tree.
- Why none exists: gw#540's close-out. The one production attempt through `produce_quant_flavor` (flux.2-klein-4b, B200) was **refused by the quality gate** (0.4742 / 0.4734 / 0.4637 LPIPS against a <=0.38 budget), and every other family measured the same (qwen .6325, klein-4b .4637, z-image .7374, sdxl .4909).

**Why the code cannot substitute for the bytes.** The two fields that separate our variant from `bfl.nvfp4-preswizzled@1` are `packing.nibble_order` and `scale_layout` — both DECLARED-CONVENTION in schema v0, invisible to any name/shape/dtype check (te#151's `weight_scale F8_E4M3 [3072,192]` is byte-shaped identically to a flat `[out,in/16]`). Transcribing them out of the writer source would put an UNPROVEN convention into a machine-checkable identity, which is the failure TRI-STATE PROOF exists to forbid.

So this PR ships the durable half only: a guard comment naming the wrong answer, so the next lane does not reach for `bfl.nvfp4-preswizzled@1` because "it is also nvfp4". Full evidence and the unblock condition: tracker th#1590.

Tests: `tests/test_derived_execution_lanes_th1580.py` 6 passed.