### PR TITLE
pgw#956: `returncode` can confirm a reap but never deny one — the pgw#858 reap row waits on the PROCESS TABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- **pgw#956: `proc.returncode` can confirm a reap but never deny one, so the
+  pgw#858 reap row now waits on the PROCESS TABLE.** The row asserted
+  `proc.returncode is not None` once after `close()`, and failed under heavy
+  runner load with "the dropped child was never reaped". The child had in fact
+  been reaped. `returncode` is asyncio bookkeeping that the child-watcher thread
+  delivers into the parent's event loop, and `ThreadedChildWatcher._do_waitpid`
+  **drops** that delivery when the loop is already closed (`if loop.is_closed():
+  logger.warning(...)`) — which is exactly what `SplitHarness.close()` races,
+  since `stop()` SIGKILLs the child and the loop then tears down without waiting
+  for the reap. So the field stays `None` permanently on a child the kernel did
+  reap: re-reading it, or polling it, recovers nothing. The row now polls
+  `os.waitid(P_PID, WEXITED|WNOHANG|WNOWAIT)` — `ChildProcessError` means it is
+  no longer our child, i.e. reaped, and `WNOWAIT` leaves the status for the
+  watcher — through `harness.progress_wait.await_progress`, settling on
+  "parent exited AND child reaped" with `returncode` still accepted as the
+  fast-path proof. Liveness plus progress-staleness, no wall clock (gw#666).
+  Measured: 1 natural failure in 12 iterations at load ~31, then reproduced
+  DETERMINISTICALLY by delaying the watcher's delivery past loop close — the old
+  form fails there with the byte-identical CI message and the new form passes
+  3/3, with `returncode` still `None` after 5s of polling.
+
 - **th#1590: `models/w4a4.py` stays contract-UNCLAIMED, on purpose.** Measured
   against both standing catalogs and the R2 CAS: no artifact of our flat nvfp4
   layout has ever been published, so no descriptor can be derived from real

--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -129,6 +129,7 @@ root_only = pytest.mark.skipif(
 )
 
 from harness.hub_double import is_ready, is_result_for  # noqa: E402
+from harness.progress_wait import Cadence, await_progress  # noqa: E402
 from test_procsplit_pgw763 import (  # noqa: E402,F401 — fixtures come with it
     BOOT_TIMEOUT_S,
     SplitHarness,
@@ -342,6 +343,26 @@ def test_the_dropped_child_can_still_write_the_config_snapshot(dropped):
     )
 
 
+def _reap_state(proc: Any, pid: int) -> str:
+    """``running`` -> ``exited`` -> ``reaped``, read from the process table.
+
+    pgw#956: ``proc.returncode`` is asyncio bookkeeping delivered to the parent's
+    loop by the child-watcher thread, and ``ThreadedChildWatcher._do_waitpid``
+    DROPS that delivery when the loop has already closed. So it can confirm a
+    reap and never deny one — under load it stays None permanently on a child
+    the kernel did reap, which no amount of re-reading recovers.
+    """
+    if proc.returncode is not None:
+        return "reaped"
+    try:
+        # WNOWAIT leaves the status for the watcher thread; ChildProcessError
+        # means it is no longer our child, i.e. somebody in this process reaped.
+        info = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+    except ChildProcessError:
+        return "reaped"
+    return "running" if info is None else "exited"
+
+
 @root_only
 def test_the_parent_can_still_signal_and_reap_the_dropped_child(dropped):
     """pgw#845's bounded shutdown across the new uid boundary: root can signal
@@ -350,16 +371,20 @@ def test_the_parent_can_still_signal_and_reap_the_dropped_child(dropped):
     _probe(dropped, "report-identity")           # a live, serving child
     proc = dropped.pc._proc
     assert proc is not None and proc.returncode is None
-    # gw#666/pgw#795: NO `assert time.monotonic() - started < 120.0` here. That
-    # asserted the RUNNER'S SPEED, and the two assertions below already state
-    # the property it was standing in for — the parent exited and the child was
-    # reaped. A slow runner made the old form fail for being slow; a hung
-    # `close()` makes the new form fail by never reaping, which is the actual
-    # defect. Hang containment belongs to the job timeout, not to a literal in
-    # a correctness assertion.
+    pid = proc.pid
+    # gw#666/pgw#795: NO `assert time.monotonic() - started < 120.0` here, and
+    # (pgw#956) no single read after `close()` either — returning from `close()`
+    # is not proof the reap completed. The property is that the parent exited
+    # and the child was reaped, so wait on THAT advancing; a hang fails by never
+    # reaping, which is the actual defect.
     dropped.close()
-    assert not dropped.alive, "the parent did not exit after SIGTERM"
-    assert proc.returncode is not None, "the dropped child was never reaped"
+    await_progress(
+        lambda: (dropped.alive, _reap_state(proc, pid)),
+        lambda seen: seen == (False, "reaped"),
+        what="the parent to exit after SIGTERM and the dropped child to be reaped",
+        cadence=Cadence(),
+        render=lambda seen: f"parent alive={seen[0]}, child {seen[1]}",
+    )
 
 
 # ---- the pieces, exercised directly --------------------------------------


### PR DESCRIPTION
Closes the pgw#956 load-flake: `test_pod_privilege_isolation_pgw858.py`'s inner row
`the dropped child was never reaped`, which reds under heavy runner load and passes alone.

## The filing was right that it was load-sensitive, and wrong about the mechanism

The filing guessed "the kernel can still be reaping when the assertion reads `returncode`",
and prescribed polling `returncode`. Measured, that is not what happens — and polling would
only have traded an `AssertionError` for a `StalledError`.

`proc.returncode` is asyncio bookkeeping. The child-watcher thread reaps with
`os.waitpid` and then delivers the code into the parent's event loop, and
`ThreadedChildWatcher._do_waitpid` **drops** that delivery outright when the loop has
already closed:

```python
if loop.is_closed():
    logger.warning("Loop %r that handles pid %r is closed", loop, pid)
else:
    loop.call_soon_threadsafe(callback, pid, returncode, *args)
```

That is exactly the window `SplitHarness.close()` races. `ParentControl.stop()` sets
`_stopping`, stops the transport, and SIGKILLs the child — it never waits for the reap.
`arun()` then returns as soon as the transport task finishes and `asyncio.run` closes the
loop. Under load the watcher thread loses that race, so **`returncode` stays `None`
permanently on a child the kernel did reap.** It can confirm a reap; it can never deny one.

## The wait

The row now waits on the process table — the durable truth — through
`harness.progress_wait.await_progress`:

```python
info = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
```

`ChildProcessError` means the pid is no longer our child, i.e. somebody in this process
reaped it (and it is immune to pid reuse, unlike `os.kill(pid, 0)`); `WNOWAIT` leaves the
status for the watcher thread so the probe cannot steal the reap. `returncode` is still
accepted as the fast-path proof when it does land. The wait settles on
`(parent exited, child reaped)` and gives up only on progress-staleness — liveness plus
progress, no wall clock (gw#666).

The sweep found one sibling of the same shape, in the same row, and it goes too:
`assert not dropped.alive` was also a single read after a call — `close()`'s own
`join(20.0)` — so a parent thread needing 21s under load failed it for being slow. It is
now the other half of the same progress wait. The file's remaining `returncode` reads are
after `subprocess.run`, which does promise the reap.

## Reproduced, then RED-verified

- **Natural**, at load ~31 with a neighbour suite churning: 12 instrumented iterations of
  the row, **1 failed** with `first_rc=None` — and at that same instant the process table
  already said `reaped`, and `returncode` never arrived across 30s of polling. That single
  observation is both the reproduction and the disproof of the "still reaping" theory.
- **Deterministic**, no load needed: delay the watcher's delivery past loop close (the
  reap still really happens, only the callback misses the loop).
  - The **original** single-read form fails there with the byte-identical filed message:
    `AssertionError: the dropped child was never reaped / assert None is not None`
  - The **new** form passes **3/3** in the same window, and `returncode` is still `None`
    after 5s of polling — which is why polling was not the fix.
  - RED was verified by restoring the file to `origin/dev` verbatim, not by hand-editing.

## Suites

- `tests/` at CI parity (`-n 4 --dist loadfile`): **3108 passed / 1 failed / 37 skipped /
  1 xfailed** (18m55s), run at load **40–86** — deliberate contention well past the 24–30
  the flake was filed at. **The pgw#858 file is green in that run**, which is the
  acceptance condition.
- The one failure is unrelated and is filed as **pgw#957**:
  `test_magic_timeouts_gw666.py::test_a_talking_engine_boots_however_long_it_takes`, whose
  fixture drives a real engine boot on a 0.3s stall window — 23/23 green alone at load 31.
  It touches nothing this diff touches.
- `tests_v2/`: **21 passed**.
- mypy `src/gen_worker`: clean (226 files). ruff `src/gen_worker`: clean. ruff on the
  changed test file reports the same 2 pre-existing findings as `origin/dev` (CI lints
  `src/gen_worker` only).