### PR TITLE
pgw#738 remainder: the re-acquire bound is REACHABILITY, not a duration — plus the dead-task reaper

### DIFF
--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -49,6 +49,24 @@ class CanceledError(WorkerError):
     """Job was canceled; do not retry."""
 
 
+class GpuSlotUnreachable(RetryableError):
+    """A mid-handler GPU-permit re-acquire (#382) can never be satisfied.
+
+    pgw#738: the #382 lease yields the permit across a blob upload and takes
+    it back before returning to tenant code. That wait has NO honest progress
+    signal of its own — FIFO position does not move while a healthy holder
+    computes for four hours, and a holder's silence is not the waiter's fault
+    (the publish phase is log-silent and GPU-idle by construction). So the
+    wait is bounded by REACHABILITY, never by a clock (gw#666): it is refused
+    only when the permit ledger proves an outstanding permit belongs to no
+    live holder — a raw acquirer outside the ledger, or a hold whose owning
+    task already finished. Neither state resolves itself.
+
+    RETRYABLE: nothing about the request is wrong and another worker (or this
+    one after a recycle) serves it fine.
+    """
+
+
 class FatalError(WorkerError):
     """Indicates the job should not be retried."""
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -47,6 +47,7 @@ from .api.errors import (
     ArtifactTransferError,
     CanceledError,
     ComponentSubstitutionError,
+    GpuSlotUnreachable,
     IllegalCombination,
     ModelSlotIdentityError,
     RetryableError,
@@ -202,6 +203,12 @@ _CANCEL_UNWIND_GRACE_S = 45.0
 #: Further wait once quarantined. Past it the process is recycled so the pod
 #: is replaced — a wedged thread cannot be reclaimed any other way.
 _CANCEL_UNWIND_RECYCLE_S = 300.0
+# pgw#738: how often a blocked #382 re-acquire OBSERVES the permit ledger.
+# An observation cadence, never a bound: nothing gives up because this much
+# time elapsed. The refusal is the ledger predicate (an outstanding permit
+# with no live holder), confirmed across two probes that span no ledger
+# transition, so a permit handed off between them can never read as leaked.
+_PERMIT_PROBE_S = 0.1
 _DOWNLOAD_RETRIES = 3
 _PROGRESS_EVENT_MIN_INTERVAL_S = 5.0
 # th#763: how long a cold tensorhub ref waits for the hub's re-minted
@@ -2989,6 +2996,104 @@ class DispatchGroupUnresolved(RetryableError):
     floored onto group 0, which is the group that is always busiest."""
 
 
+class _PermitHold:
+    """One live claim on one GPU permit."""
+
+    __slots__ = ("label", "task")
+
+    def __init__(self, label: str, task: "Optional[asyncio.Task[Any]]") -> None:
+        self.label = label
+        self.task = task
+
+    def dead(self) -> bool:
+        return self.task is not None and self.task.done()
+
+    def __str__(self) -> str:
+        return f"{self.label}{' [task already finished]' if self.dead() else ''}"
+
+
+class _PermitLedger:
+    """Who holds each GPU permit — so *can this permit ever come back?* is a
+    decidable state question instead of a guess about how long to wait.
+
+    pgw#738 / gw#666. The #382 mid-handler re-acquire has no honest progress
+    signal of its own, and the two candidates are both wrong:
+
+    * **FIFO position.** With ``per_group=1`` the queue is one deep and a
+      healthy holder computing for four hours moves it zero times. "Position
+      did not advance" is the NORMAL state of a busy card, not a stall.
+    * **The holder's heartbeat / stage progress.** A holder's silence is not
+      the waiter's fault, and this very issue proves a healthy holder can be
+      log-silent and GPU-idle by construction — the ~20 GB publish phase that
+      got 6eb50902 killed on the dead-pod signature. And if a holder really is
+      wedged, the HOLDER is the thing to condemn; pgw#687's cancel-unwind
+      watch, the request deadline and the stuck-thread recycler already own
+      that. The waiter must not second-guess them.
+
+    So the wait is bounded by REACHABILITY, not by progress and not by a
+    clock: it is refused only in the one state that cannot resolve itself —
+    an outstanding permit attributable to no live holder, i.e. a raw acquirer
+    outside this ledger or a hold whose owning task already finished.
+    """
+
+    __slots__ = ("depth", "_holds", "_next_token", "transitions")
+
+    def __init__(self, depth: int) -> None:
+        self.depth = max(1, int(depth))
+        self._holds: Dict[int, Dict[int, _PermitHold]] = {}
+        self._next_token = 0
+        # Bumped on every take/drop. Two probes spanning no transition saw a
+        # settled ledger, which is what makes the predicate safe to act on: a
+        # permit handed to another waiter between them would otherwise read as
+        # unaccounted for exactly one loop turn.
+        self.transitions = 0
+
+    def take(
+        self, sem: asyncio.Semaphore, label: str, *, owned: bool = True,
+    ) -> int:
+        """Register a hold. Call with NO await between ``sem.acquire()``
+        returning and this call, so the ledger cannot miss a grant.
+
+        ``owned=False`` for a hold whose owner is a HANDLER THREAD rather than
+        the calling task (the #382 re-acquire): the calling task there is the
+        one-shot ``run_coroutine_threadsafe`` wrapper, which finishes
+        immediately and would read as a dead owner for the rest of the job.
+        """
+        self._next_token += 1
+        token = self._next_token
+        task: Optional[asyncio.Task[Any]] = None
+        if owned:
+            try:
+                task = asyncio.current_task()
+            except RuntimeError:
+                task = None
+        self._holds.setdefault(id(sem), {})[token] = _PermitHold(label, task)
+        self.transitions += 1
+        return token
+
+    def drop(self, sem: asyncio.Semaphore, token: int) -> None:
+        if self._holds.get(id(sem), {}).pop(token, None) is not None:
+            self.transitions += 1
+
+    def unreachable(self, sem: asyncio.Semaphore) -> Optional[str]:
+        """Reason iff some outstanding permit has no live holder, else None."""
+        free = getattr(sem, "_value", None)
+        if not isinstance(free, int):
+            return None  # unknown semaphore internals: never condemn
+        outstanding = self.depth - free
+        if outstanding <= 0:
+            return None
+        holds = list(self._holds.get(id(sem), {}).values())
+        live = [h for h in holds if not h.dead()]
+        if len(live) >= outstanding:
+            return None
+        who = ", ".join(str(h) for h in holds) or "nobody this worker knows"
+        return (
+            f"{outstanding} of {self.depth} GPU permit(s) outstanding but only "
+            f"{len(live)} live holder(s): {who}"
+        )
+
+
 class _GpuSlotLease:
     """Thread-safe handle for a job's GPU slot (#382).
 
@@ -3002,11 +3107,24 @@ class _GpuSlotLease:
     hold is released at most once.
     """
 
-    __slots__ = ("_sem", "_loop", "_lock", "_held", "released_at")
+    __slots__ = (
+        "_sem", "_loop", "_lock", "_held", "released_at",
+        "_ledger", "_label", "_token",
+    )
 
-    def __init__(self, sem: asyncio.Semaphore, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(
+        self,
+        sem: asyncio.Semaphore,
+        loop: asyncio.AbstractEventLoop,
+        ledger: _PermitLedger,
+        label: str,
+        token: int,
+    ) -> None:
         self._sem = sem
         self._loop = loop
+        self._ledger = ledger
+        self._label = label
+        self._token = token
         self._lock = threading.Lock()
         self._held = True
         # Monotonic time of the FIRST release — the terminal finalize handoff
@@ -3026,21 +3144,64 @@ class _GpuSlotLease:
         except RuntimeError:
             on_loop = False
         if on_loop:
-            self._sem.release()
+            self._release_on_loop()
         else:
-            self._loop.call_soon_threadsafe(self._sem.release)
+            self._loop.call_soon_threadsafe(self._release_on_loop)
         return True
+
+    def _release_on_loop(self) -> None:
+        # Ledger drop and semaphore release in one loop callback: the ledger
+        # never describes a permit this lease no longer owns.
+        self._ledger.drop(self._sem, self._token)
+        self._sem.release()
 
     def reacquire(self) -> None:
         """Blocking re-acquire from a handler thread.
 
-        Safe because of the pgw#954 order (instance gate -> permit): this
-        runs with the job's gates still held, and no permit acquirer anywhere
-        waits on a gate, so the permit is always reachable.
+        Waits for as long as a live holder takes — no clock (gw#666), and the
+        pgw#954 order (instance gate -> permit) guarantees the permit is
+        reachable while one exists. Raises :class:`GpuSlotUnreachable` only
+        when the ledger proves no live holder can return it; see
+        :class:`_PermitLedger` for why reachability, and not progress, is the
+        honest bound here.
         """
-        asyncio.run_coroutine_threadsafe(self._sem.acquire(), self._loop).result()
-        with self._lock:
-            self._held = True
+        asyncio.run_coroutine_threadsafe(self._reacquire(), self._loop).result()
+
+    async def _reacquire(self) -> None:
+        acquire = asyncio.ensure_future(self._sem.acquire())
+        watch = asyncio.ensure_future(self._watch_unreachable())
+        try:
+            await asyncio.wait(
+                {acquire, watch}, return_when=asyncio.FIRST_COMPLETED)
+            if acquire.done() and not acquire.cancelled():
+                acquire.result()
+                self._token = self._ledger.take(
+                    self._sem, self._label, owned=False)
+                with self._lock:
+                    self._held = True
+                return
+            raise GpuSlotUnreachable(
+                f"GPU permit reacquire refused for {self._label}: "
+                f"{watch.result()}"
+            )
+        finally:
+            for task in (acquire, watch):
+                if not task.done():
+                    task.cancel()
+
+    async def _watch_unreachable(self) -> str:
+        """Return the reason once the permit provably cannot come back."""
+        while True:
+            await asyncio.sleep(_PERMIT_PROBE_S)
+            settled = self._ledger.transitions
+            if self._ledger.unreachable(self._sem) is None:
+                continue
+            await asyncio.sleep(_PERMIT_PROBE_S)
+            if self._ledger.transitions != settled:
+                continue  # a handoff happened: the ledger was mid-transition
+            reason = self._ledger.unreachable(self._sem)
+            if reason is not None:
+                return reason
 
 
 class Executor:
@@ -3102,6 +3263,10 @@ class Executor:
             for _ in range(max(1, self.topology.execution_groups))
         )
         self._gpu_permits_each = per_group
+        # pgw#738: every permit acquisition in this file registers here, so a
+        # blocked #382 re-acquire can ASK whether the permit is reachable
+        # instead of guessing how long to wait for it.
+        self._permits = _PermitLedger(per_group)
         # Group 0's permit. At G == 1 — every pod today — this IS the pool.
         self._gpu_semaphore = self._gpu_permits[0]
         # pgw#782: the slot count is also the CPU divisor. torch sizes its
@@ -5510,6 +5675,7 @@ class Executor:
             for _ in range(self._gpu_permits_each)
         ]
         acquired = 0
+        tokens: List[Tuple[asyncio.Semaphore, int]] = []
         try:
             for permit in all_permits:
                 await self._intent_await(
@@ -5520,6 +5686,8 @@ class Executor:
                     stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_GPU_SLOT,
                     reason=pb.LIFECYCLE_WAIT_REASON_GPU_SLOT,
                 )
+                tokens.append(
+                    (permit, self._permits.take(permit, "exclusive GPU warmup")))
                 acquired += 1
             self._intent_transition(
                 intent_id,
@@ -5540,7 +5708,8 @@ class Executor:
             )
             raise
         finally:
-            for permit in all_permits[:acquired]:
+            for permit, token in tokens:
+                self._permits.drop(permit, token)
                 permit.release()
 
     # ---- setup -------------------------------------------------------------
@@ -11052,7 +11221,8 @@ class Executor:
         logger.info("job admitted %s attempt=%d", run.request_id, run.attempt)
         await self._send(pb.WorkerMessage(job_accepted=pb.JobAccepted(
             request_id=run.request_id, attempt=run.attempt)))
-        job.task = asyncio.create_task(self._run_job(job, run), name=f"job-{run.request_id}")
+        job.task = asyncio.create_task(
+            self._supervise_job(job, run), name=f"job-{run.request_id}")
         # pgw#674: the serving set may have changed — re-derive what to
         # stage next while this job computes.
         self.preloader.poke()
@@ -11120,10 +11290,15 @@ class Executor:
                 return job.finished
             await asyncio.sleep(interval)
 
-    async def _enter_cancel_quarantine(self, job: _Job) -> None:
+    async def _enter_cancel_quarantine(
+        self, job: _Job, *, detail: str = "",
+    ) -> None:
         """Fail closed: stop advertising, and refuse work already parked
-        behind the wedged job instead of letting it sit eventless."""
-        detail = (
+        behind the wedged job instead of letting it sit eventless.
+
+        pgw#738: ``detail`` names the death-without-cancel face — the same
+        wedge reached without anyone cancelling anything."""
+        detail = detail or (
             f"cancel of request {job.request_id} attempt {job.attempt} has not "
             f"unwound after {_CANCEL_UNWIND_GRACE_S:.0f}s; the handler still "
             "holds the GPU permit / instance gate"
@@ -11353,9 +11528,11 @@ class Executor:
                     # did, so a mint anywhere stalled a tenant everywhere.
                     permit = self._gpu_permit_for_record(rec)
                     await permit.acquire()
+                    token = self._permits.take(permit, f"background {kind} turn")
                     try:
                         yield stole
                     finally:
+                        self._permits.drop(permit, token)
                         permit.release()
                 finally:
                     rec.turn_mutex.release()
@@ -11434,6 +11611,65 @@ class Executor:
             await self._finish(job, pb.JOB_STATUS_RETRYABLE, safe_message=safe_message)
 
     # ---- job execution -----------------------------------------------------
+
+    async def _supervise_job(self, job: _Job, run: pb.RunJob) -> None:
+        """pgw#738 never-silent guarantee: a job task that ends WITHOUT having
+        reported terminal state is reaped into one.
+
+        The 62922680 face of this issue was 3h51m of `assigned` on a live
+        heartbeat with a dead task — the worker is the only component
+        positioned to know its own task died, and it stayed silent. Every
+        escape from ``_run_job``'s own handlers lands here, as does a plain
+        return that somehow skipped ``_finish``.
+        """
+        escaped: Optional[BaseException] = None
+        try:
+            await self._run_job(job, run)
+        except asyncio.CancelledError:
+            # Worker shutdown / explicit task cancellation. The stream drop is
+            # itself a terminal signal to the hub and the loop is going away,
+            # so there is no silence to break here.
+            raise
+        except BaseException as exc:  # noqa: BLE001 — reporting IS the contract
+            escaped = exc
+            logger.exception(
+                "job task for %s attempt=%d escaped without reporting",
+                job.request_id, job.attempt)
+        if job.finished:
+            return
+        detail = (
+            f"{type(escaped).__name__}: {_sanitize(str(escaped))}"
+            if escaped is not None
+            else "the task returned with no result and no exception"
+        )
+        await self._reap_silent_job(job, detail)
+
+    async def _reap_silent_job(self, job: _Job, detail: str) -> None:
+        message = f"job task died without reporting terminal state: {detail}"[:512]
+        logger.critical(
+            "REAPED SILENT JOB %s attempt=%d: %s",
+            job.request_id, job.attempt, message)
+        try:
+            await self._finish(
+                job, pb.JOB_STATUS_RETRYABLE, safe_message=message)
+        except Exception:
+            logger.exception(
+                "failed to report the reaped terminal state for %s",
+                job.request_id)
+        # pgw#687 quarantine doctrine, DEATH-WITHOUT-CANCEL face: the task is
+        # gone but a sync handler thread cannot be killed. If it is still
+        # running it still owns the card, so the pod stops advertising and
+        # refuses the work parked behind it rather than absorbing it silently.
+        exec_task = job.exec_task
+        if job.executing and exec_task is not None and not exec_task.done():
+            await self._enter_cancel_quarantine(
+                job,
+                detail=(
+                    f"request {job.request_id} attempt {job.attempt} died "
+                    f"without reporting and its handler thread is still "
+                    f"running: {detail}"
+                ),
+            )
 
     async def _run_job(self, job: _Job, run: pb.RunJob) -> None:
         spec = job.spec
@@ -11816,12 +12052,16 @@ class Executor:
                         stage=pb.LIFECYCLE_INTENT_STAGE_WAIT_GPU_SLOT,
                         reason=pb.LIFECYCLE_WAIT_REASON_GPU_SLOT,
                     )
+                    permit_token = self._permits.take(
+                        gpu_permit, f"request {run.request_id}")
                     # th#1111: the permit wait was in NO metric — it precedes
                     # the handler window, so runtime_ms never saw it.
                     ctx._stages.record_pre(
                         "gpu_permit_wait", time.monotonic() - permit_t0)
                     self._loop = asyncio.get_running_loop()
-                    lease = _GpuSlotLease(gpu_permit, self._loop)
+                    lease = _GpuSlotLease(
+                        gpu_permit, self._loop, self._permits,
+                        f"request {run.request_id}", permit_token)
                     ctx._gpu_slot_lease = lease
                     # pgw#954: gate-holding parents may now yield. What still
                     # cannot is a job carrying per-request adapters — a

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -797,6 +797,11 @@ class RequestContext(Generic[D]):
         re-acquired slot is released again immediately: the executor's final
         release already saw ``held == False`` and skipped, so the balance
         stays exact and the freed slot isn't captured by a dying job.
+
+        pgw#738: ``reacquire`` raises ``GpuSlotUnreachable`` when the permit
+        provably cannot come back. That refusal only ever REPLACES a clean
+        exit — a failure raised by the block owns the outcome and is never
+        masked by it.
         """
         lease = self._gpu_slot_lease
         if lease is None or not lease.yield_slot():
@@ -804,10 +809,19 @@ class RequestContext(Generic[D]):
             return
         try:
             yield
-        finally:
-            lease.reacquire()
+        except BaseException:
+            try:
+                lease.reacquire()
+            except Exception:
+                logger.exception(
+                    "request %s: GPU permit unreachable while unwinding; the "
+                    "block's own failure stands", self.request_id)
             if self._canceled:
                 lease.yield_slot()
+            raise
+        lease.reacquire()
+        if self._canceled:
+            lease.yield_slot()
 
     @contextmanager
     def _child_call_wait(self) -> "Iterator[None]":

--- a/tests/test_upload_deadlock_pgw738.py
+++ b/tests/test_upload_deadlock_pgw738.py
@@ -12,7 +12,7 @@ sink (no mocks on the executor path):
   * two jobs packed on one gpu_slots=1 worker BOTH complete when the first
     saves a blob mid-handler (run_lock-first admission);
   * a permit that genuinely cannot come back fails the job TYPED
-    (GpuSlotReacquireTimeout -> RETRYABLE), never silently;
+    (GpuSlotUnreachable -> RETRYABLE), never silently;
   * a job task that dies without reporting is reaped into a terminal
     JobResult (never-silent guarantee).
 
@@ -33,25 +33,17 @@ from typing import Any, ClassVar, Optional, Tuple
 import msgspec
 import pytest
 
-# pgw#954 landed the FIRST of this file's three contract clauses —
-# gate-first admission — so `test_two_packed_jobs_survive_a_mid_handler_save`
-# (the incident shape itself: 62922680 + d0cbf910) now RUNS. The other two
-# clauses are still unimplemented and skip individually:
+# All three clauses have landed: gate-first admission (pgw#954), the typed
+# re-acquire refusal and the dead-task reaper (pgw#738 remainder). Nothing in
+# this file skips any more.
 #
-#   * a typed `GpuSlotReacquireTimeout` bound on the re-acquire. Note this
-#     clause predates the no-magic-timeouts rule (gw#666/pgw#795) — a fixed
-#     `REACQUIRE_TIMEOUT_S` is exactly the shape that rule forbids, so pgw#738
-#     should re-derive it as a progress/liveness bound before implementing.
-#   * a dead-job-task reaper turning an escaped `_run_job` into a terminal
-#     JobResult (the never-silent guarantee).
-_REACQUIRE_BOUND_LANDED = hasattr(
-    __import__("gen_worker.api.errors", fromlist=["errors"]),
-    "GpuSlotReacquireTimeout",
-)
-_needs_reacquire_bound = pytest.mark.skipif(
-    not _REACQUIRE_BOUND_LANDED,
-    reason="pgw#738 UNIMPLEMENTED: typed GpuSlotReacquireTimeout bound",
-)
+# The re-acquire clause was FILED as a fixed `_GpuSlotLease.REACQUIRE_TIMEOUT_S`
+# — exactly the shape gw#666/pgw#795 forbids — and was re-derived before it was
+# built. There is no honest PROGRESS signal for this wait (FIFO position does
+# not move while a healthy holder computes for hours, and a holder's silence is
+# the holder's problem, owned by pgw#687's unwind watch), so the bound is
+# REACHABILITY: an outstanding permit with no live holder, decided off the
+# executor's permit ledger with no seconds in it. See `_PermitLedger`.
 
 from gen_worker import executor as executor_mod
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -150,13 +142,12 @@ def test_two_packed_jobs_survive_a_mid_handler_save() -> None:
         httpd.shutdown()
 
 
-@_needs_reacquire_bound
-def test_reacquire_bound_fails_typed_never_silent() -> None:
-    """If the yielded permit genuinely cannot come back (simulated thief on
-    the semaphore), the job fails TYPED + RETRYABLE within the bound instead
-    of parking forever while the GPU bills."""
-    old = executor_mod._GpuSlotLease.REACQUIRE_TIMEOUT_S
-    executor_mod._GpuSlotLease.REACQUIRE_TIMEOUT_S = 1.0
+def test_reacquire_refuses_typed_when_the_permit_is_unreachable() -> None:
+    """If the yielded permit genuinely cannot come back — a raw acquirer
+    outside the permit ledger, i.e. nobody the worker knows holds it — the
+    job fails TYPED + RETRYABLE instead of parking forever while the GPU
+    bills. Decided off the LEDGER, not off a clock: there is no timeout to
+    shorten here and none to wait out."""
     httpd, base_url = _serve()
     thief: Optional[Any] = None
     try:
@@ -167,29 +158,69 @@ def test_reacquire_bound_fails_typed_never_silent() -> None:
             assert up.UPLOADER_STARTED.wait(timeout=10.0)
             ex = harness.worker.executor
             # Park a competing acquire; it wins the permit the moment the
-            # handler's save yields it, and never gives it back.
+            # handler's save yields it, and never gives it back. It never
+            # registers a hold, which is exactly what makes the permit
+            # provably unreachable rather than merely slow.
             thief = asyncio.run_coroutine_threadsafe(
                 ex._gpu_semaphore.acquire(), ex._loop)
             time.sleep(0.2)
             up.UPLOAD_GATE.set()
             res = _result(conn, "r-bound-a")
-            assert res is not None, "the bound must convert the hang into a result"
+            assert res is not None, "the refusal must convert the hang into a result"
             assert res.status == pb.JOB_STATUS_RETRYABLE, res.safe_message
             assert "reacquire" in res.safe_message.lower()
             if thief.done() and thief.exception() is None:
                 asyncio.run_coroutine_threadsafe(
                     _release(ex), ex._loop).result(timeout=5.0)
     finally:
-        executor_mod._GpuSlotLease.REACQUIRE_TIMEOUT_S = old
         httpd.shutdown()
+
+
+def test_a_live_holder_is_waited_out_however_long_it_takes() -> None:
+    """The discriminating half (gw#666): a permit held by a REGISTERED holder
+    is never condemned, no matter how long the re-acquire waits. Same shape as
+    the refusal above, but the competing acquire is a ledger-registered hold —
+    so the uploader waits, and completes the moment the hold is dropped."""
+    httpd, base_url = _serve()
+    try:
+        with hub_double(modules=(MODULE,), file_base_url=base_url) as (scheduler, harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            _send(conn, "r-live-a", "uploader")
+            assert up.UPLOADER_STARTED.wait(timeout=10.0)
+            ex = harness.worker.executor
+            pending = asyncio.run_coroutine_threadsafe(
+                _take_registered(ex), ex._loop)
+            time.sleep(0.2)
+            up.UPLOAD_GATE.set()
+            token = pending.result(timeout=10.0)
+            # Far longer than any probe cadence: a live holder buys unbounded
+            # patience, so there must be NO result yet.
+            assert _result(conn, "r-live-a", timeout=2.0) is None, (
+                "a live holder must never be condemned")
+            asyncio.run_coroutine_threadsafe(
+                _drop_registered(ex, token), ex._loop).result(timeout=5.0)
+            res = _result(conn, "r-live-a")
+            assert res is not None, "the job must resume once the holder lets go"
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+    finally:
+        httpd.shutdown()
+
+
+async def _take_registered(ex: Any) -> int:
+    await ex._gpu_semaphore.acquire()
+    return int(ex._permits.take(ex._gpu_semaphore, "test holder", owned=False))
+
+
+async def _drop_registered(ex: Any, token: int) -> None:
+    ex._permits.drop(ex._gpu_semaphore, token)
+    ex._gpu_semaphore.release()
 
 
 async def _release(ex: Any) -> None:
     ex._gpu_semaphore.release()
 
 
-@pytest.mark.skip(
-    reason="pgw#738 UNIMPLEMENTED: dead-job-task reaper (never-silent terminal)")
 def test_dead_job_task_reports_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     """Never-silent guarantee: a job task that dies without reporting (any
     escape from _run_job's own handlers) is reaped into a terminal


### PR DESCRIPTION
`#476` closed pgw#738's death 1 (the lock-order inversion) and deliberately left two clauses. This is the rest of pgw#738, and `tests/test_upload_deadlock_pgw738.py` now **skips nothing**.

## The spec bug, re-derived before any code

The filed clause asked for a fixed `_GpuSlotLease.REACQUIRE_TIMEOUT_S` — exactly the shape gw#666/pgw#795 forbids. #476's lane recorded that it had to be re-derived first. It was, and the answer is **not** a progress bound: neither candidate signal is honest for this wait.

* **The semaphore's FIFO position.** With `per_group=1` the queue is one deep, and a healthy holder computing for four hours moves it zero times. "Position did not advance" is the NORMAL state of a busy card.
* **The holder's heartbeat / stage progress.** A holder's silence is not the waiter's fault, and this issue is itself the proof: the ~20 GB publish phase is log-silent and GPU/CPU-idle BY CONSTRUCTION, which is how `6eb50902` got killed on the dead-pod signature. Bounding the waiter on the holder's silence re-creates the th#1157/th#1160 debounce hazard. And when a holder genuinely IS wedged, the HOLDER is the thing to condemn — pgw#687's cancel-unwind watch, the request deadline and the stuck-thread recycler already own that.

So the wait is bounded by **reachability**, not progress and not a clock. The question with an honest answer is not *"has this waited long enough?"* but *"can this permit ever come back?"* — and it cannot iff some outstanding permit is attributable to **no live holder**.

**What had to be instrumented** (it did not exist): `_PermitLedger`, which every permit acquisition registers with — `_run_job_pinned`, `_bg_turn`, `_exclusive_gpu`, and the #382 lease's own re-acquire. `unreachable(sem)` is `outstanding > live holds`, catching both a raw acquirer outside the ledger and a hold whose owning task already finished. Confirmed across two probes spanning no ledger transition, so a permit handed to another waiter never reads as leaked for the one loop turn a handoff takes. The probe cadence is an OBSERVATION rate; nothing gives up because time passed. `GpuSlotUnreachable(RetryableError)` is the typed refusal, and `_gpu_slot_yielded` never lets it mask a failure the block itself raised.

This is strictly better than the timeout it replaces: it fires immediately on the real fault and never on a slow one.

## The dead-task reaper (the never-silent terminal guarantee)

`job.task` now runs `_supervise_job`. Any escape from `_run_job`'s own handlers — or a return that skipped `_finish` — is reaped into `JOB_STATUS_RETRYABLE` with `"job task died without reporting terminal state: <exc>"`. `CancelledError` alone is re-raised untouched: worker shutdown drops the stream, which is already terminal to the hub.

**pgw#687 quarantine doctrine, death-without-cancel face:** a reaped job whose sync handler THREAD is still running enters `_enter_cancel_quarantine` with a detail naming that path — the task is gone but the thread still owns the card, so the pod stops advertising instead of absorbing the work parked behind it. `_enter_cancel_quarantine` grew an optional `detail=`; the cancel wording is unchanged.

## Test rows — all green, each red-verified against ITS OWN src half

| row | verdict |
|---|---|
| `test_two_packed_jobs_survive_a_mid_handler_save` | green (pgw#954's, unchanged) |
| `test_reacquire_refuses_typed_when_the_permit_is_unreachable` | **un-skipped**; red with `reacquire()` restored to the unbounded `sem.acquire()` |
| `test_a_live_holder_is_waited_out_however_long_it_takes` | **NEW**; red when `unreachable()` stops consulting live holds |
| `test_dead_job_task_reports_terminal` | **un-skipped**; red with `job.task` pointed back at `_run_job` |

## The phase-aware box, answered rather than built

"Phase-aware progress/liveness so a long legitimate calibration is never killed" is satisfied **by construction, negatively**: nothing added here can kill on elapsed time, so the 4h09m calibration and the silent publish are untouched. The POSITIVE watchdog stays pgw#629 / th#1064's and is deliberately not duplicated — a second, weaker progress watchdog in the executor is exactly what mis-killed `6eb50902`.

Tracker: pgw#738 "REMAINDER SHIPPED" block.