### PR TITLE
pgw#959 + pgw#960: two test waits that were clocks in disguise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Unreleased
 
+- **pgw#959: `test_cancelled_to_thread_join_releases_result` judged reachability
+  after five event-loop turns, and was watching the wrong actor.** A fixed turn
+  count is a wall clock spelled in turns; this one also gated on the loop while
+  the object was pinned by a THREAD. The holder at turn five is the
+  ThreadPoolExecutor worker: CPython's `_worker` does `work_item.run()` and only
+  then `del work_item`, so between setting the result and dropping the item the
+  cancelled load's buffer is still reachable from that thread — and whether the
+  five turns outran it was a bet on the scheduler. Measured on a purpose-built
+  probe at 80 iterations each: **11/80 still pinned** with the loop drained but
+  no proof about the worker, **0/80** once the worker is proven past its item.
+  The row now takes a default executor of KNOWN width (the process default is
+  `min(32, cpu+4)`, so a round-trip through it proves nothing) and waits on two
+  ORDERINGS: a `threading.Barrier` every worker must enter simultaneously — not
+  reachable until all of them are past that `del` — and a `call_soon` pass, which
+  runs strictly after every callback queued before it. The give-up is
+  reachability, not patience: with the loop quiesced and no task left to run,
+  nothing can still drop the reference, so the property is FALSE now rather than
+  in five turns' time. RED-verified against `origin/dev` verbatim under 48
+  spinners on 8 pinned cores: **4/20 red** pre-fix, **20/20 green** post-fix,
+  back to back.
+
+- **pgw#960: `wait_connection(0, timeout=BOOT_TIMEOUT_S)` opted the hub-double's
+  boot waits out of the progress gate — two lines under a comment saying "no
+  clock involved".** `Conn.wait_for` / `FakeScheduler.wait_connection` are
+  progress-gated by DEFAULT; passing an explicit `timeout=` takes the plain
+  deadline branch, the escape hatch pgw#795 left for rows whose assertion IS the
+  expiry. Five files were using it for events they EXPECT, on one shared 180 s
+  (or 120 s) literal. Dropping it alone would have been a regression: a dial-in
+  has no intermediate signal to advance on, so the default branch was a bare
+  30 s silence floor for split harnesses that never wired a liveness hook at
+  all. So the split harnesses now supply both gates. `worker_alive` — a parent
+  that exited can never dial in — is the definitive give-up. And the staleness
+  window is calibrated by MEASURING what a child boot costs on this runner at
+  the moment a wait is already at its floor (a fresh interpreter, the `Worker`
+  import, the child's endpoint modules), extending only while a fresh
+  measurement says the box got slower, which is self-limiting: on a steady box
+  the second sample matches the first and the wait ends. Measured here: 2.16 s
+  idle → the 30 s floor stands; **20.96 s at 48 spinners on 8 cores → a 219 s
+  window, already wider than the literal CI blew through.** `BOOT_TIMEOUT_S` is
+  deleted, along with `test_worker_outbox_pgw869.py`'s `_TIMEOUT = 20.0` doing
+  the same thing. RED-verified naturally at 96 spinners on 2 pinned cores: the
+  verbatim `origin/dev` row dies with `TimeoutError: connection #0 never arrived
+  within 180.0s (0 so far)` — the CI failure's exact shape — where the derived
+  form passes in 537 s under the identical load. Made unrepeatable: a new gw#666
+  guard row fails on any hub-double wait handed a module-level duration
+  constant, tree-wide (`BOOT_TIMEOUT_S` was defined in one module and imported by
+  four more, so a file-local scan saw one of six). It names all six pre-fix files
+  on `origin/dev` and is green here.
+
 - **pgw#957: the gw#666 guard file's own boot fixture was a bet on the runner's
   speed — the shape it exists to police.** `test_a_talking_engine_boots_however
   _long_it_takes` drove a REAL engine boot on a hardcoded 0.3 s stall window and

--- a/tests/harness/hub_double.py
+++ b/tests/harness/hub_double.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 
 import os
 import queue
+import subprocess
+import sys
 import tempfile
 import threading
 import time
 from concurrent import futures
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import grpc
 
@@ -36,6 +38,50 @@ DEFAULT_TIMEOUT_S = 15.0
 # the instant a message lands; this only bounds how stale the window estimate
 # may get when the peer is silent.
 _REEVALUATE_S = 0.25
+
+#: What a compute child pays before it can say anything: a fresh interpreter,
+#: the Worker import (torch rides in on it) and the endpoint modules the child
+#: was told to load. Nothing observes that gap from the hub side, so it is the
+#: one silence a healthy boot really produces — and it is what gets measured.
+_BOOT_PROBE_SRC = """
+import importlib, os
+from gen_worker.worker import Worker  # noqa: F401
+for m in os.environ.get("PGW763_CHILD_MODULES", "harness.procsplit_endpoints").split(","):
+    if m:
+        importlib.import_module(m)
+"""
+
+
+def measure_child_boot_cost_s(env: Optional[Mapping[str, str]] = None) -> float:
+    """Spawn-plus-import, measured on THIS runner at THIS moment (pgw#960).
+
+    Boot cost is a property of the loaded box, not of the code under test, so a
+    wait that must cover it asks rather than assumes. Called only when a wait is
+    already about to give up, so the common path pays nothing.
+    """
+    child_env: Dict[str, str] = dict(os.environ)
+    child_env.update(env or {})
+    started = time.monotonic()
+    subprocess.run(
+        [sys.executable, "-c", _BOOT_PROBE_SRC],
+        env=child_env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return time.monotonic() - started
+
+
+def _extended(cadence: Cadence, boot_cost: Optional[Callable[[], float]]) -> bool:
+    """Re-measure the runner; keep waiting only if it says the box got slower.
+
+    Self-limiting: on a steady box the second measurement matches the first, the
+    window does not move, and the wait ends. Only evidence of a genuinely slower
+    runner buys more patience — never a repeat of a literal.
+    """
+    if boot_cost is None:
+        return False
+    before = cadence.window_s
+    cadence.record(boot_cost())
+    return cadence.window_s > before
 
 
 def _label(m: pb.WorkerMessage) -> str:
@@ -56,6 +102,10 @@ class Conn:
         self._recv_cond = threading.Condition()
         self._out: "queue.Queue[Any]" = queue.Queue()
         self.client_done = threading.Event()
+        # pgw#960: set by the scheduler that made this conn. A wait that spans a
+        # child boot (Ready needs every group advertised) has no in-band signal
+        # to gate on, so its window is measured instead of assumed.
+        self.boot_cost: Optional[Callable[[], float]] = None
 
     def send(self, **oneof: Any) -> None:
         self._out.put(pb.SchedulerMessage(**oneof))
@@ -128,10 +178,19 @@ class Conn:
                     )
                 silent = now - last_advance
                 if silent >= cadence.window_s:
-                    raise StalledError(
-                        f"{describe()}: no such message in {silent:.1f}s "
-                        f"(staleness window {cadence.describe()})"
-                    )
+                    # The probe spawns a process; recording must not be blocked
+                    # behind it, or a message arriving mid-probe reads as silence.
+                    self._recv_cond.release()
+                    try:
+                        widened = _extended(cadence, self.boot_cost)
+                    finally:
+                        self._recv_cond.acquire()
+                    if not widened:
+                        raise StalledError(
+                            f"{describe()}: no such message in {silent:.1f}s "
+                            f"(staleness window {cadence.describe()})"
+                        )
+                    continue
                 self._recv_cond.wait(min(_REEVALUATE_S, cadence.window_s - silent))
 
     def wait_for(
@@ -196,6 +255,9 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
         # has EXITED can never dial in — that is the definitive give-up for
         # wait_connection, and it needs no clock.
         self.worker_alive: Optional[Callable[[], bool]] = None
+        # pgw#960: set by harnesses whose worker boots in a SUBPROCESS, where
+        # the silence a wait must tolerate is the child's spawn-plus-import.
+        self.boot_cost: Optional[Callable[[], float]] = None
 
     def Connect(self, request_iterator: Any, context: grpc.ServicerContext) -> Any:
         if self.reject_unauthenticated:
@@ -205,6 +267,7 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
         assert first.WhichOneof("msg") == "hello", "first message must be Hello"
         conn = Conn()
         conn.hello = first.hello
+        conn.boot_cost = self.boot_cost
         # Queue the HelloAck BEFORE exposing the connection: the contract says
         # HelloAck precedes all other scheduler->worker traffic.
         conn.send(hello_ack=pb.HelloAck(
@@ -240,6 +303,12 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
         A boot on a loaded runner is slow, not broken — the honest give-up is
         "the worker process is gone", which is definitive, plus a staleness
         window calibrated from the advances this run has measured.
+
+        pgw#960: a dial-in has no intermediate signal to advance on — the boot
+        is silent until it lands — so the window is calibrated from what a boot
+        COSTS on this runner, measured only when the wait is already at its
+        floor. That is the difference between a bound the box earns and the
+        180 s literal callers used to pass in to escape this branch entirely.
         """
         cadence = Cadence()
         deadline = None if timeout is None else time.monotonic() + timeout
@@ -263,11 +332,19 @@ class FakeScheduler(pb_grpc.WorkerSchedulerServicer):
                     )
                 waited = now - started
                 if waited >= cadence.window_s:
-                    raise StalledError(
-                        f"connection #{index} never arrived in {waited:.1f}s of "
-                        f"silence (staleness window {cadence.describe()}); "
-                        f"{len(self.connections)} connections so far"
-                    )
+                    # Probe outside the lock — Connect() appends under it.
+                    self._conn_cond.release()
+                    try:
+                        widened = _extended(cadence, self.boot_cost)
+                    finally:
+                        self._conn_cond.acquire()
+                    if not widened:
+                        raise StalledError(
+                            f"connection #{index} never arrived in {waited:.1f}s of "
+                            f"silence (staleness window {cadence.describe()}); "
+                            f"{len(self.connections)} connections so far"
+                        )
+                    continue
                 self._conn_cond.wait(min(_REEVALUATE_S, cadence.window_s - waited))
             return self.connections[index]
 

--- a/tests/harness/hub_double.py
+++ b/tests/harness/hub_double.py
@@ -62,12 +62,19 @@ def measure_child_boot_cost_s(env: Optional[Mapping[str, str]] = None) -> float:
     child_env: Dict[str, str] = dict(os.environ)
     child_env.update(env or {})
     started = time.monotonic()
-    subprocess.run(
+    done = subprocess.run(
         [sys.executable, "-c", _BOOT_PROBE_SRC],
-        env=child_env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-        check=False,
+        env=child_env, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+        check=False, text=True,
     )
-    return time.monotonic() - started
+    cost = time.monotonic() - started
+    # A probe that failed to import measured nothing, and a too-small sample
+    # SHRINKS the window it is supposed to widen. Say so instead.
+    assert done.returncode == 0, (
+        f"the child-boot probe could not run ({done.returncode}) — it is not "
+        f"measuring what a child boot costs:\n{done.stderr[-2000:]}"
+    )
+    return cost
 
 
 def _extended(cadence: Cadence, boot_cost: Optional[Callable[[], float]]) -> bool:

--- a/tests/test_cancelled_setup_leak_gw624.py
+++ b/tests/test_cancelled_setup_leak_gw624.py
@@ -18,6 +18,7 @@ Two guards, both revert-turns-red here:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import gc
 import threading
 import weakref
@@ -48,6 +49,51 @@ class _Buffer:
         self.cycle = self
 
 
+#: The load runs on the loop's default executor, so the test owns one of a
+#: KNOWN width — the process default is ``min(32, cpu+4)`` and a round-trip
+#: through it proves nothing about which thread served it.
+_POOL_WIDTH = 2
+
+
+async def _workers_past_their_work_items(pool: concurrent.futures.Executor) -> None:
+    """Prove every pool thread returned to ``work_queue.get()`` (pgw#959).
+
+    CPython's worker does ``work_item.run()`` -> ``del work_item``, and between
+    those two the item — hence the load's result — is still reachable from the
+    thread. A rendezvous every worker must enter simultaneously cannot be
+    reached until all of them are past that ``del``: an ordering fact, with no
+    clock and no turn count in it.
+    """
+    loop = asyncio.get_running_loop()
+    barrier = threading.Barrier(_POOL_WIDTH)
+    await asyncio.gather(*(loop.run_in_executor(pool, barrier.wait)
+                           for _ in range(_POOL_WIDTH)))
+
+
+async def _released(refs: List[weakref.ref]) -> None:
+    """Wait for the reference to go, or for proof it never can.
+
+    A ``call_soon`` queued now runs after every callback queued before it, so
+    one pass drains what is pending; when no task is left to run either, there
+    is nothing that could still drop the reference and the property is FALSE
+    now rather than in five turns' time.
+    """
+    loop = asyncio.get_running_loop()
+    me = asyncio.current_task()
+    while True:
+        drained = loop.create_future()
+        loop.call_soon(drained.set_result, None)
+        await drained
+        gc.collect()
+        if refs and refs[0]() is None:
+            return
+        if not any(t is not me for t in asyncio.all_tasks(loop)):
+            raise AssertionError(
+                "the cancelled load's result is still pinned with the loop "
+                "quiesced and every executor thread past its work item — "
+                "rollback cannot free it")
+
+
 def test_cancelled_to_thread_join_releases_result() -> None:
     """While the CancelledError (and its traceback) is still alive — the
     exact window setup rollback runs in — the joined thread's result must
@@ -64,19 +110,21 @@ def test_cancelled_to_thread_join_releases_result() -> None:
         return buf
 
     async def run() -> None:
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=_POOL_WIDTH)
+        asyncio.get_running_loop().set_default_executor(pool)
         task = asyncio.create_task(_to_thread_complete(load))
         await asyncio.to_thread(started.wait, 10)
         task.cancel()
         release.set()
         with pytest.raises(asyncio.CancelledError) as excinfo:
             await task
-        # Let shield/done callbacks drain before judging reachability.
-        for _ in range(5):
-            await asyncio.sleep(0)
-        gc.collect()
-        assert refs and refs[0]() is None, (
-            "the cancelled load's result is still pinned while the "
-            "exception lives — rollback cannot free it")
+        # pgw#959: this used to judge reachability after five event-loop turns
+        # — a wall clock spelled in turns, and the wrong clock besides. The
+        # holder at turn five is the EXECUTOR thread, which had set the result
+        # but not yet dropped its work item, so the row red whenever that
+        # thread lost the CPU (11/80 locally). Both waits below are orderings.
+        await _workers_past_their_work_items(pool)
+        await _released(refs)
         del excinfo
 
     asyncio.run(run())

--- a/tests/test_fanin_generation_pgw937.py
+++ b/tests/test_fanin_generation_pgw937.py
@@ -40,7 +40,6 @@ from gen_worker.topology import ExecutionTopology
 
 from harness.hub_double import is_ready, is_result_for
 from test_group_spawn_pgw783 import (  # the real two-process harness
-    BOOT_TIMEOUT_S,
     G2Harness,
     _dials,          # noqa: F401  (fixture)
     _isolated_postmortem,  # noqa: F401  (fixture)
@@ -85,8 +84,8 @@ def test_a_dead_groups_open_activity_is_terminated_for_the_worker(g2):
     Pre-fix this hangs on the FAILED wait: the only updates for the kind are the
     dead child's RUNNING ones.
     """
-    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = g2.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     conn.send(run_job=pb.RunJob(
         request_id="r-die-g1", attempt=1, function_name="activity-die",
@@ -124,8 +123,8 @@ def test_the_dead_generation_is_retired_and_the_respawn_starts_a_new_one(g2):
     "absent" means the live-group default again (§4.15), not an inherited fact.
     The surviving group's own entry is untouched throughout.
     """
-    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = g2.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
     pc = g2.pc
     assert pc._slots[1].generation == 1 and pc._slots[1].participating
 
@@ -155,7 +154,7 @@ def test_the_dead_generation_is_retired_and_the_respawn_starts_a_new_one(g2):
     # `_on_child_connect` calls `begin_generation()` and THEN cycles the stream
     # to re-sync the worker, so the hub's second connection is the ordered proof
     # that the new generation exists — no clock involved.
-    g2.scheduler.wait_connection(1, timeout=BOOT_TIMEOUT_S)
+    g2.scheduler.wait_connection(1)
     assert pc._slots[1].generation >= 2
     assert pc._slots[1].participating
     assert pc._group_activities.get(1, {}) == {}

--- a/tests/test_group_spawn_pgw783.py
+++ b/tests/test_group_spawn_pgw783.py
@@ -33,13 +33,18 @@ from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
 from gen_worker.procsplit.parent import DEATH_LABEL, ParentControl
 from gen_worker.topology import ExecutionTopology
 
-from harness.hub_double import FakeScheduler, is_accept_for, is_ready, is_result_for
+from harness.hub_double import (
+    FakeScheduler,
+    is_accept_for,
+    is_ready,
+    is_result_for,
+    measure_child_boot_cost_s,
+)
 from harness.progress_wait import Cadence, await_count, await_progress
 
 TESTS_DIR = Path(__file__).resolve().parent
 SRC_DIR = TESTS_DIR.parent / "src"
 CHILD_MAIN = TESTS_DIR / "harness" / "procsplit_child_main.py"
-BOOT_TIMEOUT_S = 180.0  # two children import the worker; generous but real
 
 
 class _In(msgspec.Struct):
@@ -94,6 +99,10 @@ class G2Harness:
         )
         self.exit_code: Optional[int] = None
         self._thread = threading.Thread(target=self._run, daemon=True)
+        # pgw#960: same two gates as SplitHarness — a dead parent is definitive,
+        # and TWO children's spawn-plus-import is what the silence is worth here.
+        self.scheduler.worker_alive = lambda: self.alive
+        self.scheduler.boot_cost = lambda: measure_child_boot_cost_s(child_env)
         self._thread.start()
 
     def _run(self) -> None:
@@ -149,9 +158,9 @@ def test_two_children_boot_and_each_group_serves_its_own_dispatch(g2):
     """The whole worker is READY only once BOTH groups are (the fan-in merges
     phase to the least-ready), and a dispatch to each group's rank-0 device is
     served by THAT group's child — proven by the ordinal it reports."""
-    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    conn = g2.scheduler.wait_connection(0)
     # READY requires the parent to have merged two children's state to READY.
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn.wait_for(is_ready)
 
     # Two real children exist, one per group.
     assert g2.pc.execution_groups == 2
@@ -186,8 +195,8 @@ def test_one_childs_death_is_attributed_to_its_request_siblings_keep_serving(
     """A group where one of the children dies is not a dead group: only the dead
     child's in-flight job is attributed, only its group respawns, and the sibling
     group serves throughout — the pgw#783 failure model on real processes."""
-    conn = g2.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = g2.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     slot1_pid_before = g2.pc._slots[1].proc.pid
 

--- a/tests/test_magic_timeouts_gw666.py
+++ b/tests/test_magic_timeouts_gw666.py
@@ -863,6 +863,53 @@ def test_no_new_fixed_deadline_wait_appears_in_a_test() -> None:
     )
 
 
+#: The hub-double waiters are progress-gated by DEFAULT; an explicit
+#: ``timeout=`` takes the plain-deadline branch. That escape hatch is for rows
+#: whose assertion IS the expiry ("no result within 2s"), and those spell the
+#: bound inline, at the assertion. A module-level duration constant handed to
+#: the same waiters is the opposite: one number, reused by every row in the
+#: file, none of which is probing for absence.
+_HUB_WAITERS = re.compile(r"\.(?:wait_connection|wait_for|wait_for_count)\s*\(")
+
+
+def _waits_opting_out_via_a_named_duration(root: Path) -> set:
+    # Tree-wide, not file-local: `BOOT_TIMEOUT_S` was defined in one module and
+    # IMPORTED by four more, so a per-file constant set saw only the definition
+    # site and missed most of the opt-outs.
+    per_file = {
+        path: _code_lines(path)
+        for path in sorted(root.rglob("*.py")) if path.name != Path(__file__).name
+    }
+    constants = {
+        m.group(1)
+        for lines in per_file.values()
+        for m in (_SIMPLE_CONST.match(line) for line in lines) if m
+    }
+    if not constants:
+        return set()
+    names = re.compile(r"\b(" + "|".join(sorted(constants)) + r")\b")
+    return {
+        path.relative_to(TESTS).as_posix()
+        for path, lines in per_file.items()
+        for line in lines
+        if _HUB_WAITERS.search(line) and names.search(line)
+    }
+
+
+def test_no_hub_double_wait_opts_out_of_the_progress_gate() -> None:
+    """pgw#960: `wait_connection(0, timeout=BOOT_TIMEOUT_S)` sat two lines under
+    a comment saying "no clock involved". The deadline branch is reachable only
+    by passing one, so passing a file-wide constant is how the gate gets turned
+    off wholesale — invisible to the deadline guards above, which look for the
+    place a deadline is BUILT, not the place one is handed in."""
+    found = _waits_opting_out_via_a_named_duration(TESTS)
+    assert not found, (
+        f"hub-double wait(s) opting out of the progress gate in {sorted(found)} "
+        f"— drop the `timeout=` so liveness plus the measured staleness window "
+        f"applies, or spell the bound inline if absence IS the assertion; pgw#960"
+    )
+
+
 def test_no_new_wall_clock_assertion_appears_in_a_test() -> None:
     found = _scan(TESTS, _ELAPSED_UPPER_BOUND, match=True)
     new = found - _ELAPSED_ASSERT_BURNDOWN

--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -131,7 +131,6 @@ root_only = pytest.mark.skipif(
 from harness.hub_double import is_ready, is_result_for  # noqa: E402
 from harness.progress_wait import Cadence, await_progress  # noqa: E402
 from test_procsplit_pgw763 import (  # noqa: E402,F401 — fixtures come with it
-    BOOT_TIMEOUT_S,
     SplitHarness,
     _payload,
     captured_dials,
@@ -163,8 +162,8 @@ def _split(tmp_path, *, drop: bool, monkeypatch=None) -> SplitHarness:
 
 
 def _probe(h: SplitHarness, fn: str, text: str = "") -> str:
-    conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = h.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
     rid = f"r-{fn}-{time.time_ns()}"
     conn.send(run_job=pb.RunJob(
         request_id=rid, attempt=1, function_name=fn, input_payload=_payload(text)))

--- a/tests/test_procsplit_pgw763.py
+++ b/tests/test_procsplit_pgw763.py
@@ -43,15 +43,19 @@ from gen_worker.pb import worker_scheduler_pb2_grpc as pb_grpc
 from gen_worker.procsplit import frames
 from gen_worker.procsplit.parent import DEATH_LABEL, ParentControl
 
-from harness.hub_double import FakeScheduler, is_accept_for, is_ready, is_result_for
+from harness.hub_double import (
+    FakeScheduler,
+    is_accept_for,
+    is_ready,
+    is_result_for,
+    measure_child_boot_cost_s,
+)
 from harness.progress_wait import Cadence, await_count, await_progress
 
 TESTS_DIR = Path(__file__).resolve().parent
 SRC_DIR = TESTS_DIR.parent / "src"
 CHILD_MAIN = TESTS_DIR / "harness" / "procsplit_child_main.py"
 FAKE_CHILD = TESTS_DIR / "harness" / "procsplit_fake_child.py"
-
-BOOT_TIMEOUT_S = 120.0  # child imports torch; generous but real
 
 _BOOT_RECORD_NAME = "gen-worker-boot-record.json"
 _INFLIGHT_NAME = "gen-worker-inflight.json"
@@ -129,6 +133,10 @@ class SplitHarness:
         )
         self.exit_code: Optional[int] = None
         self._thread = threading.Thread(target=self._run, daemon=True)
+        # pgw#960: a parent that exited can never dial in (definitive), and a
+        # child boot's silence is worth whatever it costs on THIS runner.
+        self.scheduler.worker_alive = lambda: self.alive
+        self.scheduler.boot_cost = lambda: measure_child_boot_cost_s(child_env)
         self._thread.start()
 
     def _run(self) -> None:
@@ -195,8 +203,8 @@ def split(tmp_path, captured_dials):
 def test_child_death_keeps_stream_attributes_job_and_respawn_serves_next(
     split, captured_dials,
 ):
-    conn0 = split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn0.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn0 = split.scheduler.wait_connection(0)
+    conn0.wait_for(is_ready)
 
     # A normal job completes through the seam.
     conn0.send(run_job=pb.RunJob(
@@ -218,8 +226,8 @@ def test_child_death_keeps_stream_attributes_job_and_respawn_serves_next(
     # The parent (and the pod) survived; the stream identity was kept and the
     # respawned child re-syncs on a fresh connection and serves the NEXT job.
     assert split.alive and split.exit_code is None
-    conn1 = split.scheduler.wait_connection(1, timeout=BOOT_TIMEOUT_S)
-    conn1.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn1 = split.scheduler.wait_connection(1)
+    conn1.wait_for(is_ready)
     conn1.send(run_job=pb.RunJob(
         request_id="r-echo-2", attempt=1, function_name="echo",
         input_payload=_payload("again")))
@@ -234,8 +242,8 @@ def test_child_death_keeps_stream_attributes_job_and_respawn_serves_next(
 
 
 def test_cancel_stays_prompt_across_the_boundary(split):
-    conn = split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
     conn.send(run_job=pb.RunJob(
         request_id="r-sleepy", attempt=1, function_name="sleepy",
         input_payload=_payload()))
@@ -324,8 +332,8 @@ def test_boot_hardware_fatal_is_terminal_reported_and_exits_1(
 def test_wedged_child_is_killed_by_watchdog_and_pod_recovers(tmp_path, captured_dials):
     h = SplitHarness(tmp_path, watchdog_budget_s=3.0)
     try:
-        conn0 = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn0.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn0 = h.scheduler.wait_connection(0)
+        conn0.wait_for(is_ready)
         conn0.send(run_job=pb.RunJob(
             request_id="r-freeze", attempt=1, function_name="freeze",
             input_payload=_payload()))
@@ -335,8 +343,8 @@ def test_wedged_child_is_killed_by_watchdog_and_pod_recovers(tmp_path, captured_
         assert died.job_result.status == pb.JOB_STATUS_FATAL
         assert DEATH_LABEL in died.job_result.safe_message
         assert "watchdog_hang" in died.job_result.safe_message
-        conn1 = h.scheduler.wait_connection(1, timeout=BOOT_TIMEOUT_S)
-        conn1.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn1 = h.scheduler.wait_connection(1)
+        conn1.wait_for(is_ready)
         conn1.send(run_job=pb.RunJob(
             request_id="r-after-freeze", attempt=1, function_name="echo",
             input_payload=_payload("thawed")))
@@ -497,8 +505,8 @@ def test_hub_drain_exits_zero_and_lets_the_child_finish(split, captured_dials):
     exits 0. The parent must exit 0 too — and must not SIGKILL the child that
     is still unloading instances just because the stream ended first.
     """
-    conn = split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
     conn.send(run_job=pb.RunJob(
         request_id="r-pre-drain", attempt=1, function_name="echo",
         input_payload=_payload("bye")))
@@ -529,8 +537,8 @@ def test_child_death_during_drain_reports_the_job_and_does_not_respawn(
     to be attributed, and that FATAL has to survive the shutdown flush that
     is running concurrently.
     """
-    conn = split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
     conn.send(run_job=pb.RunJob(
         request_id="r-drain-victim", attempt=1, function_name="sleepy",
         input_payload=_payload()))
@@ -665,8 +673,8 @@ def test_signal_death_consumes_the_inflight_marker_and_records_the_streak(
     registry = isolated_postmortem / _CRASH_REGISTRY_NAME
     h = SplitHarness(tmp_path)
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
         conn.send(run_job=pb.RunJob(
             request_id="r-marker", attempt=1, function_name="die-hard",
             input_payload=_payload()))
@@ -728,8 +736,8 @@ def test_starved_compile_is_held_while_a_dead_child_is_still_killed(
     """
     h = SplitHarness(tmp_path, watchdog_budget_s=3.0)
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
         conn.send(run_job=pb.RunJob(
             request_id="r-starve", attempt=1, function_name="starve-loop",
             input_payload=_payload("9")))   # 3x the watchdog budget
@@ -764,8 +772,8 @@ def test_parent_originates_the_beat_while_the_child_is_starved(
     """
     h = SplitHarness(tmp_path, watchdog_budget_s=60.0, beat_interval_s=1.0)
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
         before = sum(1 for m in conn.received if m.WhichOneof("msg") == "state_delta")
         conn.send(run_job=pb.RunJob(
             request_id="r-beat", attempt=1, function_name="starve-loop",
@@ -809,8 +817,8 @@ def test_wedged_child_keeps_the_stream_alive_and_is_reported_not_hidden(
         beat_interval_s=1.0,
     )
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
         before = sum(1 for m in conn.received if m.WhichOneof("msg") == "state_delta")
         conn.send(run_job=pb.RunJob(
             request_id="r-wedge-beat", attempt=1, function_name="freeze",
@@ -862,8 +870,8 @@ def test_a_waiting_job_is_never_called_stalled(tmp_path, captured_dials):
     """
     h = SplitHarness(tmp_path, watchdog_budget_s=60.0, beat_interval_s=1.0)
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-        conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
+        conn.wait_for(is_ready)
         conn.send(run_job=pb.RunJob(
             request_id="r-wait", attempt=1, function_name="async-wait",
             input_payload=_payload("8")))   # 8s of pure awaiting

--- a/tests/test_procsplit_security_pgw763.py
+++ b/tests/test_procsplit_security_pgw763.py
@@ -32,7 +32,6 @@ from gen_worker.procsplit import actions
 
 from harness.hub_double import is_ready, is_result_for
 from test_procsplit_pgw763 import (  # noqa: F401 — fixtures come with it
-    BOOT_TIMEOUT_S,
     CHILD_MAIN,
     SplitHarness,
     _payload,
@@ -130,8 +129,8 @@ def test_delta1_tenant_code_finds_no_worker_jwt_in_its_process(credentialed_spli
     handler sweeps all three routes — environment, loaded Settings, the
     transport object — and must come back with nothing.
     """
-    conn = credentialed_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     conn.send(run_job=pb.RunJob(
         request_id="r-steal", attempt=1, function_name="steal-credentials",
@@ -159,8 +158,8 @@ def test_delta1_parent_refuses_a_hub_call_the_allowlist_does_not_name(
     refused, the credential never goes on the wire, and the refusal is banked
     as a security event rather than logged and forgotten.
     """
-    conn = credentialed_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     conn.send(run_job=pb.RunJob(
         request_id="r-forge", attempt=1, function_name="forge-hub-call",
@@ -185,8 +184,8 @@ def test_delta1_parent_refuses_capability_renewal_for_a_foreign_request(
     a renewal for a request this worker was never dispatched. A path allowlist
     alone would have forwarded it and let the hub decide with less context than
     the parent has."""
-    conn = credentialed_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     conn.send(run_job=pb.RunJob(
         request_id="r-renew-forge", attempt=1,
@@ -207,8 +206,8 @@ def test_delta1_the_legitimate_mediated_call_still_works(credentialed_split, hub
     authenticated call, and the child gets the answer without ever holding the
     bearer."""
     pc = credentialed_split.pc
-    conn = credentialed_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     # Stand in for a dispatched job (the relay records exactly this).
     pc._slots[0].in_flight[("r-live", 1)] = "echo"
@@ -283,7 +282,7 @@ def test_delta2_parent_measurement_replaces_a_forged_hello(forging_split):
         FORGED_WORKER_ID,
     )
 
-    conn = forging_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    conn = forging_split.scheduler.wait_connection(0)
     hello = conn.hello
     assert hello is not None
 
@@ -318,7 +317,7 @@ def test_delta2_the_parent_measures_the_real_host(forging_split):
     """The legitimate half: the numbers on the wire are the ones this box
     actually has, produced by the parent's pre-import measurement — not zeros
     from having simply deleted the child's report."""
-    forging_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    forging_split.scheduler.wait_connection(0)
     pc = forging_split.pc
     assert pc._measurement is not None, "the parent never measured the host"
 
@@ -405,7 +404,7 @@ def test_delta3_forged_billables_are_replaced_by_the_parents_observation(
         FORGED_RUNTIME_MS,
     )
 
-    conn = billing_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+    conn = billing_split.scheduler.wait_connection(0)
     conn.send(run_job=pb.RunJob(
         request_id="r-bill", attempt=1, function_name="echo",
         input_payload=_payload()))
@@ -503,8 +502,8 @@ def test_delta5_the_child_signs_through_the_parent_holding_no_credential(
     import base64
 
     hub_http.reply = {"signature_b64": base64.b64encode(b"SIGNATURE").decode()}
-    conn = credentialed_split.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
-    conn.wait_for(is_ready, timeout=BOOT_TIMEOUT_S)
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
 
     # The handler passes a base URL of its own choosing. It is IGNORED: the
     # parent aims its own credential, at the host the hub named (th#1312).
@@ -626,7 +625,7 @@ def split_for_capability(tmp_path, captured_dials, monkeypatch):
         extra_child_env={"PGW763_FAKE_MODE": "result_then_exit"},
     )
     try:
-        conn = h.scheduler.wait_connection(0, timeout=BOOT_TIMEOUT_S)
+        conn = h.scheduler.wait_connection(0)
         yield h.pc, conn
     finally:
         h.close()

--- a/tests/test_worker_outbox_pgw869.py
+++ b/tests/test_worker_outbox_pgw869.py
@@ -59,7 +59,6 @@ from gen_worker.transport import (
 
 from harness.hub_double import hub_double, is_ready
 
-_TIMEOUT = 20.0
 _RUNNING = pb.ActivityState.ACTIVITY_STATE_RUNNING
 _COMPLETED = pb.ActivityState.ACTIVITY_STATE_COMPLETED
 
@@ -140,12 +139,12 @@ def test_hub_killed_midactivity_replays_every_fact_exactly_once() -> None:
     kind = "self_mint_compile_pgw869"
     with hub_double(worker_id="outbox-acceptance") as (scheduler, harness):
         conn0 = scheduler.wait_connection(0)
-        conn0.wait_for(is_ready, _TIMEOUT)
+        conn0.wait_for(is_ready)
         _await_live_reporting(harness)
 
         # A fact produced while the hub is up, and confirmed shipped.
         activity_mod.emit_event(kind, "entries=36 ceiling=8", phase="pool")
-        conn0.wait_for(_is_activity(kind, "pool"), _TIMEOUT)
+        conn0.wait_for(_is_activity(kind, "pool"))
 
         # The hub dies. The worker process does not — exactly the incident.
         conn0.kill()
@@ -160,9 +159,9 @@ def test_hub_killed_midactivity_replays_every_fact_exactly_once() -> None:
             activity_mod.emit_event(kind, detail, phase=phase)
 
         # The hub comes back and the worker redials on its own.
-        conn1 = scheduler.wait_connection(1, timeout=_TIMEOUT)
+        conn1 = scheduler.wait_connection(1)
         for phase, _detail in during:
-            conn1.wait_for(_is_activity(kind, phase), _TIMEOUT)
+            conn1.wait_for(_is_activity(kind, phase))
 
         replayed = [u for u in _activities(conn1, kind)]
 
@@ -201,7 +200,7 @@ def test_terminal_produced_during_the_outage_still_lands() -> None:
     kind = "forge_terminal_pgw869"
     with hub_double(worker_id="outbox-terminal") as (scheduler, harness):
         conn0 = scheduler.wait_connection(0)
-        conn0.wait_for(is_ready, _TIMEOUT)
+        conn0.wait_for(is_ready)
         _await_live_reporting(harness)
         conn0.kill()
 
@@ -209,14 +208,13 @@ def test_terminal_produced_during_the_outage_still_lands() -> None:
         act.phase("publishing")
         act.completed()
 
-        conn1 = scheduler.wait_connection(1, timeout=_TIMEOUT)
+        conn1 = scheduler.wait_connection(1)
         terminal = conn1.wait_for(
             lambda m: (
                 m.WhichOneof("msg") == "activity_update"
                 and m.activity_update.kind == kind
                 and m.activity_update.state == _COMPLETED
             ),
-            _TIMEOUT,
         )
         assert terminal.activity_update.phase == "publishing"
 
@@ -231,7 +229,7 @@ def test_a_long_outage_coalesces_beats_and_keeps_every_measurement() -> None:
     kind = "outbox_longoutage_pgw869"
     with hub_double(worker_id="outbox-longoutage") as (scheduler, harness):
         conn0 = scheduler.wait_connection(0)
-        conn0.wait_for(is_ready, _TIMEOUT)
+        conn0.wait_for(is_ready)
         _await_live_reporting(harness)
         conn0.kill()
 
@@ -243,9 +241,9 @@ def test_a_long_outage_coalesces_beats_and_keeps_every_measurement() -> None:
                 activity_mod.emit_event(
                     kind, f"measurement {i}", phase=f"m{i}")
 
-        conn1 = scheduler.wait_connection(1, timeout=_TIMEOUT)
+        conn1 = scheduler.wait_connection(1)
         for i in range(0, 64, 16):
-            conn1.wait_for(_is_activity(kind, f"m{i}"), _TIMEOUT)
+            conn1.wait_for(_is_activity(kind, f"m{i}"))
 
         got = _activities(conn1, kind)
         # Every measurement survived, with its payload.


### PR DESCRIPTION
Two load-sensitive flakes filed by the pgw#957 lane, same defect class: a give-up decision made from a literal instead of from evidence.

## pgw#959 — five event-loop turns, and the wrong actor

`test_cancelled_to_thread_join_releases_result` judged reachability after `for _ in range(5): await asyncio.sleep(0)`. A fixed turn count is a wall clock spelled in turns — but the interesting part is that the loop was never the holder.

`gc.get_referrers` finds nothing on the loop side. CPython's `ThreadPoolExecutor._worker` does `work_item.run()` and only then `del work_item`, so between the worker setting the result and dropping the item, the cancelled load's buffer is still reachable **from that thread**. Whether five turns outran that was a bet on the OS scheduler.

Measured on a purpose-built probe, 80 iterations each, same conditions back to back:

| | still pinned |
|---|---|
| loop fully drained, nothing proven about the worker | **11 / 80** |
| worker proven past its work item | **0 / 80** |

There is no progress signal for "a reference went away", so the bound is the reachability shape (pgw#738's `_PermitLedger`): two orderings, and a give-up the moment nothing could still free it.

* a default executor of KNOWN width — the process default is `min(32, cpu+4)`, so a round-trip through it proves nothing about which thread served the load;
* a `threading.Barrier` every worker must enter simultaneously, unreachable until all of them are past that `del`;
* a `call_soon` pass, which runs strictly after every callback queued before it;
* give-up: loop quiesced and no task left to run ⇒ nothing can still drop the reference ⇒ the property is FALSE **now**.

## pgw#960 — `timeout=BOOT_TIMEOUT_S` opts out of the gate it claims to use

`Conn.wait_for` / `FakeScheduler.wait_connection` are progress-gated by default; an explicit `timeout=` takes the plain-deadline branch — the escape hatch pgw#795 left for rows whose assertion IS the expiry. Five files used it for events they EXPECT, on one shared 180 s / 120 s literal, one of them two lines under a comment saying *"no clock involved"*.

**Dropping it alone would have been a regression.** A dial-in has no signal to advance on, `Cadence` is never `record()`ed in that branch, and `SplitHarness` / `G2Harness` never wired `worker_alive` at all — so the "progress-gated" default was a bare 30 s floor with no definitive give-up. 180 s → 30 s.

So the harness supplies both gates now:

* `worker_alive` — a parent that exited can never dial in. Definitive, no clock.
* the staleness window is calibrated by MEASURING what a child boot costs on this runner (fresh interpreter + the `Worker` import + the child's endpoint modules), taken only when a wait is already at its floor, and extended only while a fresh sample says the box got slower. Self-limiting: on a steady box the second sample matches the first and the wait ends.

Measured: **2.16 s idle** → the 30 s floor stands. **20.96 s at 48 spinners on 8 pinned cores → a 219 s window**, already wider than the literal CI blew through.

`BOOT_TIMEOUT_S` is deleted (49 sites, 5 files — every one an expected-event wait, none an absence probe), along with `test_worker_outbox_pgw869.py`'s `_TIMEOUT = 20.0` doing the same thing at 11 more.

Made unrepeatable: a new gw#666 guard row fails on any hub-double wait handed a module-level duration constant, scanned tree-wide — `BOOT_TIMEOUT_S` was defined in one module and imported by four more, so a file-local scan saw one of six.

## RED-verified

* **pgw#959**, 48 spinners on 8 pinned cores: verbatim `origin/dev` **4/20 red**, the fix **20/20 green**, back to back. (A second round was 20/20 both ways — it is intermittent; the 80-iteration probe above is the deterministic proof.)
* **pgw#960**, 96 spinners on 2 pinned cores, test pinned to the same cores: verbatim `origin/dev` dies `TimeoutError: connection #0 never arrived within 180.0s (0 so far)` — the CI failure's exact shape — where the derived form passes in **537 s** under the identical load.
* the new guard row names all six pre-fix files on `origin/dev` and is green here.

`mypy src/gen_worker` clean (228 files), `ruff check src/gen_worker` clean, no new ruff findings in the touched test files vs. baseline. Full `tests/` run attached below once it lands.