### PR TITLE
ie#600/ie#605: gen_worker.references — declared edit/compose mode, named references, per-family caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **ie#600/ie#605: `gen_worker.references` — edit/compose mode, named
+  references, and a reference cap that states OUR reason.** An edit model is a
+  generator that takes references, and the pipeline sees one undifferentiated
+  ordered list — so mode is our declaration, not an inference, and it is what
+  `fit_to_native` needs to know whose framing to preserve. `plan_edit(family=,
+  mode=EDIT|COMPOSE, image=, references=)` normalizes list OR name->asset map
+  into one ordered list (map form by sorted key, matching the asset walker and
+  the hub's `*` traversal), rewrites `{name}` into the family's rendered
+  positional label, and refuses — never truncates — over the cap, before
+  dispatch. `fit_edit_request` is the other half of the one stage.
+  `EditFamily` is DATA the endpoint declares, the `FamilyGeometry` split.
+  **Its label domain admits `None`** (ie#603): Qwen renders `Picture {n}`
+  (proven in the token stream), Klein `image {n}` (BFL-documented user
+  convention, training basis unpublished), and HiDream-O1 renders NOTHING —
+  it has no index channel and its own report publishes an entity-description
+  caption recipe, so a `{name}` there is a typed refusal rather than an
+  invented ordinal. `EditFamily` refuses at declaration time to carry a cap
+  with no stated basis or a label with no provenance: three of our caps were
+  a competitor's product decision or a test-harness ceiling.
+
 - **pgw#957: the gw#666 guard file's own boot fixture was a bet on the runner's
   speed — the shape it exists to police.** `test_a_talking_engine_boots_however
   _long_it_takes` drove a REAL engine boot on a hardcoded 0.3 s stall window and

--- a/src/gen_worker/__init__.py
+++ b/src/gen_worker/__init__.py
@@ -51,6 +51,18 @@ from .geometry import (
     restore,
     set_upscaler,
 )
+from .references import (
+    EditFamily,
+    EditRequest,
+    PromptRewrite,
+    Reference,
+    ReferenceRefusal,
+    condition_tokens,
+    fit_edit_request,
+    normalize_references,
+    plan_edit,
+    rewrite_prompt,
+)
 from .url_fetch import FetchedUrl, fetch_bytes, fetch_image
 from .view import for_request
 from .api.errors import (
@@ -131,6 +143,17 @@ __all__ = [
     "nearest_bucket",
     "restore",
     "set_upscaler",
+    # ie#600 edit/compose references: mechanism here, EditFamily row in the family.
+    "EditFamily",
+    "EditRequest",
+    "PromptRewrite",
+    "Reference",
+    "ReferenceRefusal",
+    "condition_tokens",
+    "fit_edit_request",
+    "normalize_references",
+    "plan_edit",
+    "rewrite_prompt",
     "pad_text_sequence",
     "TextLengthExceededError",
     "HF",

--- a/src/gen_worker/references.py
+++ b/src/gen_worker/references.py
@@ -1,0 +1,483 @@
+"""Edit/compose reference handling (ie#600) — mode, named references, caps.
+
+An edit model is a GENERATOR THAT TAKES REFERENCES. The pipeline sees one
+undifferentiated ordered list, so "which image is being edited" exists only
+as OUR declaration, and it is exactly what :mod:`gen_worker.geometry` needs
+to know whose framing to preserve. Hence two functions, never one inferred
+mode::
+
+    edit(image, references=[...])   # image carries the framing
+    compose(references=[...])       # output geometry is free
+
+The library owns the MECHANISM; the family declares the DATA
+(:class:`EditFamily`) — the same split :class:`~gen_worker.geometry.FamilyGeometry`
+uses. Only four things vary per family: the reference budget, the rendered
+positional label (**or none**), whether an edit-target slot exists, and how
+many references the pipeline appends behind our back.
+
+Named references (``{pose}``) are a REQUEST-BOUNDARY REWRITE into the label
+the family was conditioned on. They are never a model input: no pipeline in
+the fleet has a per-image name channel.
+
+**The label domain admits "none", and that is load-bearing (ie#603).** The
+three families have different index channels:
+
+* Qwen-Image-Edit: ``Picture N:`` is literally in the token stream, plus a
+  per-reference RoPE block. Rendered label ``Picture {n}``.
+* FLUX.2 Klein: one channel only (the ``t_coords`` RoPE offset); the text
+  encoder is text-only. ``image {n}`` is a BFL-documented USER convention
+  whose training basis is unpublished.
+* HiDream-O1: no index channel at all, and its report §2.4 publishes an
+  entity-description caption recipe — the opposite of an ordinal. Rendering
+  ``image 2`` there would invent a convention against a published
+  counter-indication, so its label is ``None`` and ``{name}`` is REFUSED.
+
+DreamOmni2 (arXiv 2510.06679 §3.2) is why this matters: *"in DiT, positional
+encoding alone cannot accurately distinguish the index of reference images"*.
+Positional prose does not bind for free.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any, Mapping, Optional, Sequence, Union
+
+import msgspec
+
+from .api.errors import ValidationError
+from .geometry import FamilyGeometry, FitMode, FitPlan, OutputSize, fit_to_native
+
+__all__ = [
+    "EditFamily",
+    "Reference",
+    "PromptRewrite",
+    "EditRequest",
+    "ReferenceRefusal",
+    "NAME_GRAMMAR",
+    "canonical_name",
+    "normalize_references",
+    "rewrite_prompt",
+    "plan_edit",
+    "fit_edit_request",
+    "condition_tokens",
+]
+
+#: ``{name}`` grammar: lowercase canonical, 2-32 chars. Lowercase-canonical so
+#: ``{Face}`` and ``{face}`` cannot be two references. Runway's 3-16 is
+#: needlessly tight.
+NAME_GRAMMAR = re.compile(r"^[a-z][a-z0-9_]{1,31}$")
+
+# One scan handles escapes and placeholders together: a two-brace run is a
+# literal brace, a single brace opens a placeholder. Scanning for `{name}`
+# alone would mis-read `{{face}}`.
+_TOKEN = re.compile(r"\{\{|\}\}|\{([^{}]*)\}|\{|\}")
+
+ReferenceInput = Union[Sequence[Any], Mapping[str, Any]]
+
+
+class ReferenceRefusal(ValidationError):
+    """A typed, fail-closed refusal at the request boundary.
+
+    ``str(exc)`` is ``"<code>: <detail>"`` so the code survives the
+    ``safe_message`` wire hop into the request's ``error.code`` — the
+    :class:`~gen_worker.api.errors.PayloadRefError` shape. Every refusal here
+    happens BEFORE upload, billing or dispatch: a silently-unsubstituted
+    ``{face}`` reaching the text encoder is the worst outcome, a plausible
+    render that ignored the user's intent.
+    """
+
+    def __init__(self, detail: str, *, code: str, name: str = "") -> None:
+        self.code = code
+        self.name = str(name or "")
+        super().__init__(f"{code}: {detail}")
+
+
+def canonical_name(raw: str) -> str:
+    """NFC-normalize + casefold a reference name for lookup and dedup."""
+    return unicodedata.normalize("NFC", str(raw or "")).strip().casefold()
+
+
+class EditFamily(msgspec.Struct, frozen=True, kw_only=True):
+    """One family's reference facts. DATA, declared by the endpoint package.
+
+    ``max_references`` is **OUR cost/shape budget, never a quality limit**. We
+    self-host: no vendor number binds us, and no published count is a
+    capability statement (ie#605 traced every one of ours to a competitor's
+    product decision or a test-set artifact). It stays FINITE for two reasons
+    that ARE ours — each ``N`` is a distinct compiled graph (ie#550) and VRAM.
+    ``budget_basis`` must say so in the family's own words; it is rendered into
+    the over-cap refusal, so the caller reads the real reason.
+
+    ``reference_label`` is a ``str.format``-style template taking ``n`` (the
+    1-based position in the marshalled list), or ``None`` for a family with no
+    index channel — see the module docstring. ``None`` makes ``{name}``
+    references a refusal rather than an invented ordinal.
+
+    ``pipeline_appended_references`` is the count the PIPELINE adds behind our
+    back for a given call shape (HiDream's ``create_layout_reference_images``
+    appends a synthetic layout canvas when ``layout_bboxes`` is set). It is
+    passed per request, not declared here, because it depends on the payload —
+    this field is only the family's declared maximum, for documentation.
+    """
+
+    name: str
+    #: Total references the model may see, INCLUDING the edit target and any
+    #: pipeline-appended synthetic reference (see :func:`plan_edit`).
+    max_references: int
+    #: Why THIS number, in our terms. Required — an uncited cap is how three
+    #: foreign product decisions became our schema (ie#605).
+    budget_basis: str
+    #: ``"Picture {n}"`` / ``"image {n}"`` / ``None`` (no index channel).
+    reference_label: Optional[str] = None
+    #: Provenance of the label. Required when a label exists.
+    label_basis: str = ""
+    #: False for a family that has no edit-target slot (compose-only).
+    has_edit_target: bool = True
+    #: Fixed latent tokens each reference adds, when it IS fixed. ``None`` for
+    #: a family that resizes references as the count grows (HiDream).
+    marginal_latent_tokens: Optional[int] = None
+    #: Text-stream tokens each reference adds (Qwen's ~188 vision tokens).
+    marginal_text_tokens: int = 0
+    #: Largest number of synthetic references the pipeline may append.
+    pipeline_appended_references: int = 0
+
+    def __post_init__(self) -> None:
+        if not str(self.name or "").strip():
+            raise ValueError("EditFamily requires a name")
+        if self.max_references < 1:
+            raise ValueError(f"{self.name}: max_references must be >= 1")
+        if not str(self.budget_basis or "").strip():
+            raise ValueError(
+                f"{self.name}: budget_basis is required — a reference cap must "
+                "state OUR cost/shape reason, never a vendor's number (ie#605)"
+            )
+        if self.reference_label is not None:
+            if "{n}" not in self.reference_label:
+                raise ValueError(
+                    f"{self.name}: reference_label {self.reference_label!r} must "
+                    "contain '{n}', the 1-based marshalled position"
+                )
+            if not str(self.label_basis or "").strip():
+                raise ValueError(
+                    f"{self.name}: a rendered label needs label_basis — whether it "
+                    "is proven in the token stream or a vendor-documented "
+                    "convention is exactly what a reader needs (ie#603)"
+                )
+
+    @property
+    def labels_positions(self) -> bool:
+        """Whether ``{name}`` can be rewritten at all for this family."""
+        return self.reference_label is not None
+
+    def render_label(self, position: int) -> str:
+        if self.reference_label is None:
+            raise ReferenceRefusal(
+                f"{self.name} has no positional reference label, so a name cannot "
+                "be rendered",
+                code="positional_labels_unsupported",
+            )
+        return self.reference_label.format(n=int(position))
+
+
+class Reference(msgspec.Struct, frozen=True, kw_only=True):
+    """One reference, with the position the model will see it at."""
+
+    #: Canonical name, or ``None`` in list form.
+    name: Optional[str]
+    asset: Any
+    #: 1-based position in the marshalled list (the edit target is 1).
+    position: int
+
+
+class PromptRewrite(msgspec.Struct, frozen=True, kw_only=True):
+    """Both prompts, because a run must be reproducible from its record.
+
+    Every edit-quality artifact we own binds by INSTRUCTION (te#156) — bind
+    those to ``original``, and stamp ``rendered`` as provenance.
+    """
+
+    original: str
+    rendered: str
+    #: ``(name, position)`` pairs actually substituted, in prompt order.
+    substitutions: tuple[tuple[str, int], ...] = ()
+    #: Declared names the prompt never mentions. Legitimate (an untagged style
+    #: reference is a real workflow) — the endpoint should emit a warning
+    #: event, not refuse.
+    unreferenced: tuple[str, ...] = ()
+
+    @property
+    def rewritten(self) -> bool:
+        return self.rendered != self.original
+
+
+class EditRequest(msgspec.Struct, frozen=True, kw_only=True):
+    """One normalized edit/compose request: what the model actually receives."""
+
+    family: EditFamily
+    mode: FitMode
+    prompt: PromptRewrite
+    #: The marshalled ordered list. In ``edit`` mode index 0 is the target.
+    images: tuple[Any, ...]
+    references: tuple[Reference, ...]
+    #: Synthetic references the pipeline will append, charged to the cap.
+    pipeline_appends: int = 0
+
+    @property
+    def named(self) -> bool:
+        return any(r.name is not None for r in self.references)
+
+    @property
+    def total_references(self) -> int:
+        return len(self.images) + int(self.pipeline_appends)
+
+    @property
+    def primary(self) -> int:
+        """Index of the framing-carrying image; ``0`` in edit, unused in compose."""
+        return 0
+
+
+def normalize_references(
+    references: Optional[ReferenceInput],
+    *,
+    offset: int = 0,
+) -> tuple[Reference, ...]:
+    """List OR name->asset map to ONE ordered list — all the model has.
+
+    List form keeps the caller's order. **Map form is ordered by sorted key**,
+    matching what gen-worker's asset walker and the hub's ``*`` map-values
+    traversal already do, so ordering agrees with the transport layer instead
+    of inventing a second convention.
+
+    ``offset`` is how many images precede these in the marshalled list (1 when
+    an edit target occupies position 1).
+    """
+    if references is None:
+        return ()
+    if isinstance(references, Mapping):
+        canonical: dict[str, Any] = {}
+        for raw_name, asset in references.items():
+            name = canonical_name(raw_name)
+            if not NAME_GRAMMAR.match(name):
+                raise ReferenceRefusal(
+                    f"reference name {raw_name!r} is not a legal name: 2-32 chars "
+                    "matching [a-z][a-z0-9_]*, case-insensitive",
+                    code="malformed_reference_name", name=str(raw_name),
+                )
+            if name in canonical:
+                raise ReferenceRefusal(
+                    f"reference name {name!r} is declared twice: names are "
+                    f"case-insensitive and NFC-normalized, so {raw_name!r} "
+                    "collides with an earlier key",
+                    code="duplicate_reference_name", name=name,
+                )
+            canonical[name] = asset
+        return tuple(
+            Reference(name=name, asset=canonical[name], position=offset + i + 1)
+            for i, name in enumerate(sorted(canonical))
+        )
+    if isinstance(references, (str, bytes)):
+        raise ReferenceRefusal(
+            "references must be a list of images or a name->image map",
+            code="malformed_references",
+        )
+    return tuple(
+        Reference(name=None, asset=asset, position=offset + i + 1)
+        for i, asset in enumerate(references)
+    )
+
+
+def rewrite_prompt(
+    prompt: str, references: Sequence[Reference], family: EditFamily
+) -> PromptRewrite:
+    """Rewrite ``{name}`` into the family's rendered positional label.
+
+    ``{{`` and ``}}`` are literal braces — required, or a prompt containing
+    JSON or code becomes unsendable. Any OTHER unescaped brace is significant:
+    a lone ``{`` or a ``{not a name}`` is a refusal, never a passthrough,
+    because a typo'd placeholder that ships silently produces a confident
+    render of the wrong thing.
+    """
+    original = str(prompt or "")
+    declared = {r.name: r for r in references if r.name is not None}
+
+    substitutions: list[tuple[str, int]] = []
+    out: list[str] = []
+    cursor = 0
+    for match in _TOKEN.finditer(original):
+        out.append(original[cursor : match.start()])
+        cursor = match.end()
+        token = match.group(0)
+        if token == "{{":
+            out.append("{")
+            continue
+        if token == "}}":
+            out.append("}")
+            continue
+        if token in ("{", "}"):
+            raise ReferenceRefusal(
+                f"unbalanced {token!r} at offset {match.start()}: braces are "
+                "reference placeholders; write '{{' or '}}' for a literal brace",
+                code="malformed_reference_name",
+            )
+        name = canonical_name(match.group(1))
+        if not NAME_GRAMMAR.match(name):
+            raise ReferenceRefusal(
+                f"{{{match.group(1)}}} is not a reference placeholder: names are "
+                "2-32 chars matching [a-z][a-z0-9_]*. Write '{{' and '}}' for "
+                "literal braces",
+                code="malformed_reference_name", name=match.group(1),
+            )
+        if not declared:
+            raise ReferenceRefusal(
+                f"the prompt names reference {{{name}}} but the payload sent "
+                "references as a LIST, which declares no names — send a "
+                "name->image map, or write the position in ordinary prose",
+                code="named_references_not_declared", name=name,
+            )
+        if not family.labels_positions:
+            raise ReferenceRefusal(
+                f"{family.name} has no positional reference label to rewrite "
+                f"{{{name}}} into: its condition tokens carry no index channel and "
+                "its published caption recipe is entity descriptions, not ordinals "
+                "(ie#603). Name the subjects in the prompt and send references as "
+                "a list",
+                code="positional_labels_unsupported", name=name,
+            )
+        reference = declared.get(name)
+        if reference is None:
+            known = ", ".join(sorted(declared)) or "(none)"
+            raise ReferenceRefusal(
+                f"the prompt names reference {{{name}}}, which the payload does not "
+                f"declare; declared names are: {known}",
+                code="unknown_reference_name", name=name,
+            )
+        out.append(family.render_label(reference.position))
+        substitutions.append((name, reference.position))
+    out.append(original[cursor:])
+
+    used = {name for name, _ in substitutions}
+    return PromptRewrite(
+        original=original,
+        rendered="".join(out),
+        substitutions=tuple(substitutions),
+        unreferenced=tuple(sorted(set(declared) - used)),
+    )
+
+
+def plan_edit(
+    *,
+    family: EditFamily,
+    mode: FitMode,
+    prompt: str,
+    image: Any = None,
+    references: Optional[ReferenceInput] = None,
+    pipeline_appends: int = 0,
+) -> EditRequest:
+    """Normalize one edit/compose request. Refuses before dispatch, never truncates.
+
+    ``pipeline_appends`` is charged to the cap, so the count is what the MODEL
+    sees: HiDream's ``create_layout_reference_images`` appends a synthetic
+    layout canvas when ``layout_bboxes`` is set, and a pre-append cap would let
+    that push the pipeline across a ``get_sizes`` bucket and silently shrink
+    every reference. The cap exists for compiled-shape count and VRAM — both
+    properties of what reaches the model — so it is counted POST-append.
+    """
+    mode = FitMode(mode)
+    if mode is FitMode.EDIT:
+        if not family.has_edit_target:
+            raise ReferenceRefusal(
+                f"{family.name} has no edit-target slot; use compose",
+                code="edit_mode_unsupported",
+            )
+        if image is None:
+            raise ReferenceRefusal(
+                "edit requires the image being edited: it is what carries the "
+                "framing the output preserves (ie#599), and the payload cannot "
+                "reveal which reference that would be",
+                code="edit_target_missing",
+            )
+        offset = 1
+    else:
+        if image is not None:
+            raise ReferenceRefusal(
+                "compose takes references only: there is no image being edited, "
+                "so output geometry is a free parameter",
+                code="compose_takes_no_edit_target",
+            )
+        offset = 0
+
+    normalized = normalize_references(references, offset=offset)
+    if mode is FitMode.COMPOSE and not normalized:
+        raise ReferenceRefusal(
+            "compose requires at least one reference",
+            code="references_missing",
+        )
+
+    appends = max(0, int(pipeline_appends))
+    total = offset + len(normalized) + appends
+    if total > family.max_references:
+        detail = (
+            f"this request sends {offset + len(normalized)} images"
+            + (f" and the pipeline appends {appends} more" if appends else "")
+            + f", for {total} references; {family.name} accepts at most "
+            f"{family.max_references}. {family.budget_basis}"
+        )
+        raise ReferenceRefusal(detail, code="too_many_references")
+
+    rewrite = rewrite_prompt(prompt, normalized, family)
+    images = tuple([image] if offset else []) + tuple(r.asset for r in normalized)
+    return EditRequest(
+        family=family,
+        mode=mode,
+        prompt=rewrite,
+        images=images,
+        references=normalized,
+        pipeline_appends=appends,
+    )
+
+
+def fit_edit_request(
+    request: EditRequest,
+    images: Sequence[Any],
+    geometry: FamilyGeometry,
+    *,
+    output_size: OutputSize = OutputSize.MATCH_INPUT,
+    preset: Optional[tuple[int, int]] = None,
+) -> FitPlan:
+    """The other half of the one stage: fit this request's images to native.
+
+    ``images`` are the decoded PIL images in ``request.images`` order — the
+    normalization above is asset-shaped and never opens a file. ``edit`` fits
+    the target's framing; ``compose`` refuses to inherit ``references[0]``'s
+    aspect and requires an explicit output bucket (ie#599's contract).
+    """
+    if len(images) != len(request.images):
+        raise ValidationError(
+            f"fit_edit_request: got {len(images)} decoded images for "
+            f"{len(request.images)} marshalled references"
+        )
+    return fit_to_native(
+        images,
+        geometry,
+        mode=request.mode,
+        output_size=output_size,
+        preset=preset,
+        primary=request.primary,
+    )
+
+
+def condition_tokens(family: EditFamily, count: int) -> Optional[int]:
+    """Conditioning tokens ``count`` references add, when the family has a
+    constant marginal cost. ``None`` when it does not (HiDream resizes every
+    reference as K grows, so its marginal cost is sub-linear by construction).
+
+    The attention term is quadratic in total sequence length, so this is the
+    input to a per-reference price, not the price itself: Qwen's fixed
+    +4096 latent +~188 text per reference makes 6 references ~12x the 1-reference
+    attention term at 1024².
+    """
+    if family.marginal_latent_tokens is None:
+        return None
+    n = max(0, int(count))
+    return n * (family.marginal_latent_tokens + family.marginal_text_tokens)

--- a/tests/test_references_ie600.py
+++ b/tests/test_references_ie600.py
@@ -1,0 +1,438 @@
+"""ie#600 / ie#605: edit/compose references — mechanism tests.
+
+Real payloads through the real validation path; no mocks. The four family
+rows below are the ones the endpoint packages declare, so the per-family
+behaviour under test is the shipped behaviour — including HiDream rendering
+NO label.
+"""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+from gen_worker import (
+    EditFamily,
+    FamilyGeometry,
+    FitMode,
+    OutputSize,
+    ReferenceRefusal,
+    condition_tokens,
+    fit_edit_request,
+    normalize_references,
+    plan_edit,
+)
+
+
+# -- the fleet's four rows (ie#603 label provenance, ie#605 budgets) --------
+
+QWEN = EditFamily(
+    name="qwen-image-edit-2511",
+    max_references=6,
+    budget_basis=(
+        "OUR compiled-shape and VRAM budget: every reference is resized to a "
+        "constant 1024^2 area, so each adds a FIXED +4096 latent +~188 text "
+        "tokens and the attention term grows quadratically (6 refs is ~12x the "
+        "1-ref term at 1024^2). Not a validated quality limit"
+    ),
+    reference_label="Picture {n}",
+    label_basis=(
+        "proven in the token stream: pipeline_qwenimage_edit_plus.py:239-252 "
+        "injects 'Picture N: <|vision_start|>...' before the user text"
+    ),
+    marginal_latent_tokens=4096,
+    marginal_text_tokens=188,
+)
+
+KLEIN = EditFamily(
+    name="flux2-klein",
+    max_references=8,
+    budget_basis=(
+        "OUR compiled-shape and VRAM budget. BFL's 4 is their hosted-API slot "
+        "count (Flux2KleinInputs stops at input_image_4) and does not bind the "
+        "open weights we run"
+    ),
+    reference_label="image {n}",
+    label_basis=(
+        "BFL-documented USER convention "
+        "(docs.bfl.ml/guides/prompting_editing_multi_reference); training basis "
+        "UNPUBLISHED. Architecturally supported by the t_coords index channel"
+    ),
+    marginal_latent_tokens=1024,
+)
+
+HIDREAM = EditFamily(
+    name="hidream-o1",
+    max_references=11,
+    budget_basis=(
+        "the largest count the HiDream report publishes a measurement for "
+        "(UniSubject '9-11 Subjects', arXiv 2605.11061 section 8) — an "
+        "evaluation envelope we adopt as our budget, not a capability limit"
+    ),
+    reference_label=None,
+    pipeline_appended_references=1,
+)
+
+COMPOSE_ONLY = EditFamily(
+    name="compose-only",
+    max_references=4,
+    budget_basis="test row",
+    has_edit_target=False,
+)
+
+
+def _image(width: int = 64, height: int = 64) -> Image.Image:
+    return Image.new("RGB", (width, height), (128, 64, 32))
+
+
+A, B, C = "asset-a", "asset-b", "asset-c"
+
+
+# -- the declaration itself is gated ---------------------------------------
+
+
+def test_a_cap_with_no_stated_reason_is_refused_at_declaration():
+    with pytest.raises(ValueError, match="budget_basis"):
+        EditFamily(name="x", max_references=3, budget_basis="  ")
+
+
+def test_a_rendered_label_needs_its_provenance():
+    with pytest.raises(ValueError, match="label_basis"):
+        EditFamily(
+            name="x", max_references=3, budget_basis="ours",
+            reference_label="image {n}",
+        )
+
+
+def test_a_label_must_carry_the_position():
+    with pytest.raises(ValueError, match=r"\{n\}"):
+        EditFamily(
+            name="x", max_references=3, budget_basis="ours",
+            reference_label="Picture", label_basis="test",
+        )
+
+
+# -- normalization: both forms, one ordered list ---------------------------
+
+
+def test_list_form_keeps_the_callers_order():
+    refs = normalize_references([A, B, C], offset=1)
+    assert [r.asset for r in refs] == [A, B, C]
+    assert [r.position for r in refs] == [2, 3, 4]
+    assert all(r.name is None for r in refs)
+
+
+def test_map_form_is_ordered_by_sorted_key():
+    refs = normalize_references({"pose": A, "background": B, "face": C}, offset=1)
+    assert [r.name for r in refs] == ["background", "face", "pose"]
+    assert [r.asset for r in refs] == [B, C, A]
+    assert [r.position for r in refs] == [2, 3, 4]
+
+
+def test_duplicate_name_is_refused():
+    with pytest.raises(ReferenceRefusal) as exc:
+        normalize_references({"Face": A, "face": B})
+    assert exc.value.code == "duplicate_reference_name"
+
+
+def test_illegal_name_is_refused():
+    with pytest.raises(ReferenceRefusal) as exc:
+        normalize_references({"1st-image": A})
+    assert exc.value.code == "malformed_reference_name"
+
+
+# -- the {name} rewrite, per family ----------------------------------------
+
+
+def test_qwen_renders_picture_n_with_the_edit_target_at_position_1():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT,
+        prompt="the woman in the pose of {pose}, face from {face}, on {background}",
+        image="target",
+        references={"pose": A, "face": B, "background": C},
+    )
+    # sorted keys -> background=2, face=3, pose=4
+    assert request.prompt.rendered == (
+        "the woman in the pose of Picture 4, face from Picture 3, on Picture 2"
+    )
+    assert request.images == ("target", C, B, A)
+    assert request.prompt.original.startswith("the woman in the pose of {pose}")
+
+
+def test_klein_renders_image_n():
+    request = plan_edit(
+        family=KLEIN, mode=FitMode.EDIT,
+        prompt="apply the pattern from {pattern} onto the plate",
+        image="target", references={"pattern": A},
+    )
+    assert request.prompt.rendered == "apply the pattern from image 2 onto the plate"
+
+
+def test_hidream_renders_no_label_and_refuses_the_rewrite():
+    # ie#603: HiDream's condition tokens carry no index channel, and its own
+    # paper section 2.4 publishes an entity-description caption recipe. An
+    # ordinal there would be invented against a published counter-indication.
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=HIDREAM, mode=FitMode.EDIT,
+            prompt="place the subject from {subject} in a garden",
+            image="target", references={"subject": A},
+        )
+    assert exc.value.code == "positional_labels_unsupported"
+    assert "entity descriptions" in str(exc.value)
+
+
+def test_hidream_list_form_still_works_naming_is_strictly_additive():
+    request = plan_edit(
+        family=HIDREAM, mode=FitMode.EDIT,
+        prompt="place the woman in the red coat into the garden",
+        image="target", references=[A, B],
+    )
+    assert request.images == ("target", A, B)
+    assert not request.prompt.rewritten
+
+
+# -- escaping ---------------------------------------------------------------
+
+
+def test_double_braces_are_literal_braces():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT,
+        prompt='render the JSON {{"a": 1}} onto the sign from {logo}',
+        image="target", references={"logo": A},
+    )
+    assert request.prompt.rendered == 'render the JSON {"a": 1} onto the sign from Picture 2'
+
+
+def test_an_unescaped_json_prompt_is_refused_not_silently_passed():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.EDIT, prompt='render {"a": 1} on the sign',
+            image="target", references={"logo": A},
+        )
+    assert exc.value.code == "malformed_reference_name"
+
+
+def test_a_lone_brace_is_refused():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.EDIT, prompt="a 50% } discount",
+            image="target", references={"logo": A},
+        )
+    assert exc.value.code == "malformed_reference_name"
+
+
+# -- refusals happen BEFORE dispatch ---------------------------------------
+
+
+def test_unknown_name_is_refused_and_lists_the_declared_ones():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.EDIT, prompt="use the {fase} from here",
+            image="target", references={"face": A, "pose": B},
+        )
+    assert exc.value.code == "unknown_reference_name"
+    assert exc.value.name == "fase"
+    assert "face, pose" in str(exc.value)
+
+
+def test_a_name_in_the_prompt_with_a_list_payload_is_refused():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.EDIT, prompt="use the {face} from here",
+            image="target", references=[A, B],
+        )
+    assert exc.value.code == "named_references_not_declared"
+
+
+def test_declared_but_unreferenced_is_accepted_and_reported():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt="in the pose of {pose}",
+        image="target", references={"pose": A, "style": B},
+    )
+    assert request.prompt.unreferenced == ("style",)
+    assert request.prompt.substitutions == (("pose", 2),)
+
+
+def test_names_are_case_insensitive_on_lookup():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt="in the pose of {POSE}",
+        image="target", references={"Pose": A},
+    )
+    assert request.prompt.rendered == "in the pose of Picture 2"
+
+
+# -- caps: reject, never truncate ------------------------------------------
+
+
+def test_over_cap_is_refused_not_truncated():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.EDIT, prompt="x",
+            image="target", references=[A] * 6,
+        )
+    assert exc.value.code == "too_many_references"
+    # The refusal states OUR reason, not a vendor's number.
+    assert "compiled-shape and VRAM budget" in str(exc.value)
+
+
+def test_at_cap_is_accepted():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt="x", image="target",
+        references=[A] * 5,
+    )
+    assert len(request.images) == 6
+
+
+def test_klein_accepts_eight():
+    request = plan_edit(
+        family=KLEIN, mode=FitMode.EDIT, prompt="x", image="target",
+        references=[A] * 7,
+    )
+    assert len(request.images) == 8
+
+
+def test_the_hidream_cap_counts_the_pipeline_appended_layout_image():
+    # create_layout_reference_images APPENDS a synthetic layout canvas, so with
+    # layout_bboxes set the pipeline sees N+1. The cap is POST-append: 11 total
+    # means 10 user references when a layout is requested.
+    ten = plan_edit(
+        family=HIDREAM, mode=FitMode.EDIT, prompt="x", image="target",
+        references=[A] * 9, pipeline_appends=1,
+    )
+    assert ten.total_references == 11
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=HIDREAM, mode=FitMode.EDIT, prompt="x", image="target",
+            references=[A] * 10, pipeline_appends=1,
+        )
+    assert exc.value.code == "too_many_references"
+    assert "the pipeline appends 1 more" in str(exc.value)
+
+
+def test_without_layout_the_same_family_takes_eleven_user_images():
+    request = plan_edit(
+        family=HIDREAM, mode=FitMode.EDIT, prompt="x", image="target",
+        references=[A] * 10,
+    )
+    assert request.total_references == 11
+
+
+# -- mode is declared, never inferred --------------------------------------
+
+
+def test_edit_without_a_target_is_refused():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(family=QWEN, mode=FitMode.EDIT, prompt="x", references=[A])
+    assert exc.value.code == "edit_target_missing"
+
+
+def test_compose_refuses_an_edit_target():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=QWEN, mode=FitMode.COMPOSE, prompt="x", image="target",
+            references=[A],
+        )
+    assert exc.value.code == "compose_takes_no_edit_target"
+
+
+def test_compose_needs_at_least_one_reference():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(family=QWEN, mode=FitMode.COMPOSE, prompt="x", references=[])
+    assert exc.value.code == "references_missing"
+
+
+def test_compose_positions_start_at_one():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.COMPOSE, prompt="{left} beside {right}",
+        references={"left": A, "right": B},
+    )
+    assert request.prompt.rendered == "Picture 1 beside Picture 2"
+    assert request.images == (A, B)
+
+
+def test_a_compose_only_family_refuses_edit():
+    with pytest.raises(ReferenceRefusal) as exc:
+        plan_edit(
+            family=COMPOSE_ONLY, mode=FitMode.EDIT, prompt="x", image="target",
+        )
+    assert exc.value.code == "edit_mode_unsupported"
+
+
+# -- reproducibility: both prompts survive ---------------------------------
+
+
+def test_both_prompts_are_carried_so_a_run_is_reproducible_from_its_record():
+    original = "the woman in the pose of {pose} on {background}"
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt=original, image="target",
+        references={"pose": A, "background": B},
+    )
+    assert request.prompt.original == original
+    assert request.prompt.rendered != original
+    # name -> marshalled position, so the run can be replayed exactly.
+    assert dict(request.prompt.substitutions) == {"pose": 3, "background": 2}
+
+
+# -- the ie#599 seam: one stage over one normalized request ----------------
+
+GEOMETRY = FamilyGeometry(
+    name="qwen-image-edit-2511",
+    native_area=1024 * 1024,
+    buckets=((1024, 1024), (1248, 832), (832, 1248)),
+)
+
+
+def test_edit_fits_the_targets_framing():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt="brighten it", image="target",
+        references=[A],
+    )
+    plan = fit_edit_request(request, [_image(1500, 1000), _image(600, 600)], GEOMETRY)
+    assert plan.mode is FitMode.EDIT
+    assert plan.bucket == (1248, 832)
+    assert plan.source_size == (1500, 1000)
+
+
+def test_compose_refuses_to_inherit_the_first_references_aspect():
+    from gen_worker.api.errors import ValidationError
+
+    request = plan_edit(
+        family=QWEN, mode=FitMode.COMPOSE, prompt="x", references=[A, B],
+    )
+    with pytest.raises(ValidationError, match="owns output geometry"):
+        fit_edit_request(request, [_image(1500, 1000), _image(600, 600)], GEOMETRY)
+
+
+def test_compose_takes_an_explicit_output_bucket():
+    request = plan_edit(
+        family=QWEN, mode=FitMode.COMPOSE, prompt="x", references=[A, B],
+    )
+    plan = fit_edit_request(
+        request, [_image(1500, 1000), _image(600, 600)], GEOMETRY,
+        output_size=OutputSize.NATIVE, preset=(1024, 1024),
+    )
+    assert plan.bucket == (1024, 1024)
+
+
+def test_decoded_image_count_must_match_the_marshalled_list():
+    from gen_worker.api.errors import ValidationError
+
+    request = plan_edit(
+        family=QWEN, mode=FitMode.EDIT, prompt="x", image="target", references=[A],
+    )
+    with pytest.raises(ValidationError, match="marshalled references"):
+        fit_edit_request(request, [_image()], GEOMETRY)
+
+
+# -- cost ------------------------------------------------------------------
+
+
+def test_qwen_marginal_cost_is_constant_per_reference():
+    assert condition_tokens(QWEN, 1) == 4284
+    assert condition_tokens(QWEN, 6) == 6 * 4284
+
+
+def test_hidream_has_no_constant_marginal_cost():
+    # It resizes every reference as K grows, so a linear estimate would lie.
+    assert condition_tokens(HIDREAM, 4) is None


### PR DESCRIPTION
Implements ie#600 §5.3/§5.4/§5.6 and the library half of ie#605, beside ie#599's `fit_to_native` (PR #475) rather than copied into 28 endpoints.

## What lands

`src/gen_worker/references.py` — the MECHANISM. The family declares the DATA (`EditFamily`), exactly the `FamilyGeometry` split.

- **Mode is declared, never inferred.** `plan_edit(family=, mode=FitMode.EDIT|COMPOSE, prompt=, image=, references=)`. The payload cannot reveal which image carries the framing, and the model does not report which it did — so an inferred mode makes ie#599's geometry rule unappliable. `edit` requires an `image`; `compose` refuses one.
- **Dual-form arguments, one ordered list.** List form keeps the caller's order; map form is ordered by **sorted key**, matching gen-worker's asset walker and the hub's `*` map-values traversal, so ordering agrees with the transport layer instead of inventing a second convention. In `edit`, the target is always position 1.
- **`{name}` is a request-boundary rewrite, never a model input.** `{{`/`}}` escape to literal braces. Any other unescaped brace is a refusal, not a passthrough — a typo'd placeholder that ships silently produces a confident render of the wrong thing.
- **The rendered label is a per-family constant whose domain admits `None`** (ie#603). Qwen → `Picture {n}` (proven in the token stream). Klein → `image {n}` (BFL-documented *user* convention; training basis unpublished). **HiDream-O1 → no label**: it has no index channel and its own report §2.4 publishes an entity-description caption recipe, so `{name}` there is a typed `positional_labels_unsupported` refusal rather than an invented ordinal. Unnamed list-form references still work on every family — naming is strictly additive.
- **Caps reject, never truncate**, and `EditFamily` refuses at declaration time to carry a cap with no `budget_basis` or a label with no `label_basis`. The over-cap refusal renders the family's own basis sentence, so the caller reads OUR cost/shape reason and not a vendor's number.
- **The cap counts POST pipeline-append.** HiDream's `create_layout_reference_images` appends a synthetic layout canvas when `layout_bboxes` is set; a pre-append cap would let that push the pipeline across a `get_sizes` bucket and silently shrink every reference. `plan_edit(..., pipeline_appends=1)` charges it, and the refusal names it.
- **Both prompts are carried** (`PromptRewrite.original` / `.rendered` + the name→position map), so a run is reproducible from its record. Existing edit-quality artifacts bind by INSTRUCTION — bind those to `original`, stamp `rendered` as provenance.
- `fit_edit_request` is the other half of the single stage: one normalized request into `fit_to_native`, with `compose` still refusing to inherit `references[0]`'s aspect.

## Typed refusals, all before upload/billing/dispatch

`unknown_reference_name`, `duplicate_reference_name`, `malformed_reference_name`, `named_references_not_declared`, `positional_labels_unsupported`, `too_many_references`, `edit_target_missing`, `compose_takes_no_edit_target`, `references_missing`, `edit_mode_unsupported`. `str(exc)` is `"<code>: <detail>"`, the `PayloadRefError` shape, so the code survives the `safe_message` wire hop into `error.code`.

## Tests

`tests/test_references_ie600.py` — 35 rows, real payloads through the real validation path, driven by the four family rows the endpoints will declare. **35 passed.** `mypy` clean, `ruff` clean, and the 29 `fit_to_native` rows still pass alongside.

## Not in this PR

Endpoint adoption (the `edit`/`compose` function split on qwen-image / flux.2-klein-{4b,9b} / hidream-o1-image) is gated on 0.92.0 being published and the fleet repinned — a separate lane. This PR touches no `pyproject.toml`, `uv.lock` or `fleet-floors.toml`.