### PR TITLE
pgw#963 / th#1423 pgw half: an untyped 401, and a mint publisher's token frozen at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,46 @@
   invented ordinal. `EditFamily` refuses at declaration time to carry a cap
   with no stated basis or a label with no provenance: three of our caps were
   a competitor's product decision or a test-harness ceiling.
+- **pgw#963 / th#1423 pgw half: a mint that outlived its credential could not
+  say so, and the CLI publisher held a token frozen at construction.** Three
+  production failures, one shape: a 28-minute inductor compile, then
+  `/v1/worker/cells/publish-intent failed (401)` at 32m30s against a 30m worker
+  JWT TTL. The hub half (durable typed `pod_events` on every worker-JWT refusal)
+  merged separately; these are the worker's three.
+  **(1) The 401 was untyped.** `CellPublisher._post` raised a BARE `RuntimeError`
+  for every non-2xx, so `_publish_failure_phase` — which exists to read
+  `status`/`code` — had nothing, and all three landed under the phase
+  `RuntimeError`, one group with every other exception type. It now raises the
+  `HubPublishError` the v2 leg already uses, carrying the hub's `status` and
+  `error.code` (both envelope shapes: nested `{"error":{"code"}}` and the flat
+  `{"code"}` these refusals were observed with). The bearer is read ONCE per
+  call, so the token blamed is the token sent.
+  **(2) A 401 from an already-lapsed credential is now named.** `exp` is an
+  absolute instant the credential itself carries — not a duration this code
+  picked (gw#666) — so "expired" separates from "revoked/wrong-worker", which the
+  hub cannot distinguish and only the worker can. Code
+  `worker_credential_expired`, plus a `credential_expired` publish leg carrying
+  the measured lapse on the wire BEFORE the intent is spent.
+  **(3) `aot_mint._publisher_from_settings` captured its token** as
+  `worker_jwt=lambda: token`, defeating the provider `CellPublisher` takes
+  precisely so rotation is picked up per call. It reads the credential at USE
+  time now. Found while fixing it: `worker_credential.current()` answers only
+  once something HANDS it the boot token, and only `entrypoint` / the procsplit
+  parent ever do — never this CLI. So **pgw#876 §2's stated effect (WORKER_JWT
+  visible here) was never actually reached in that process**; the
+  `tensorhub_token` fallback was doing all the work. `install_bootstrap` now
+  runs there.
+  **Deliberately NOT done: "always try publish-complete".** `{ok:false}` is
+  authenticated by the same check that just refused the intent, so it is refused
+  identically — and there is no worker-JWT refresh route to call either:
+  rotation exists ONLY as `TokenRefresh` down the live gRPC scheduler stream, and
+  `worker/capability/renew` renews the *capability* token while itself requiring
+  a live worker JWT. Presenting the freshest credential the process holds, and
+  naming the lapse, is the whole of what the worker can do here.
+  RED-verified in `tests/test_mint_credential_expiry_th1423.py` against
+  `origin/dev` verbatim: all six rows fail, the production entry point
+  (`_publish_async`) emitting `('self_mint_publish_failed', 'RuntimeError')` —
+  the exact phase the three production events carried.
 
 - **pgw#957: the gw#666 guard file's own boot fixture was a bet on the runner's
   speed — the shape it exists to police.** `test_a_talking_engine_boots_however

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -3325,20 +3325,28 @@ def _publisher_from_settings() -> Any:
     settings = config.current()
     base_url = str(
         settings.tensorhub_public_url or settings.tensorhub_url or "").strip()
-    # pgw#876 §2: this read `getattr(settings, "worker_jwt", "")`, a field
-    # pgw#848 RENAMED — the getattr default swallowed the AttributeError the
-    # rename exists to raise, so WORKER_JWT was silently invisible here and
-    # `--publish` refused on every pod that had one and no TENSORHUB_TOKEN.
-    token = str(worker_credential.current()
-                or getattr(settings, "tensorhub_token", "") or "").strip()
-    if not base_url or not token:
+    # th#1423: `worker_credential.current()` only answers once someone HANDS it
+    # the boot token, and only `entrypoint` / the procsplit parent do — never
+    # this CLI. So pgw#876 §2's stated effect (WORKER_JWT visible here) was not
+    # actually reached in this process; the fallback was doing all the work.
+    worker_credential.install_bootstrap(settings)
+
+    def credential() -> str:
+        # th#1423: this was `lambda: token`, a token CAPTURED at construction.
+        # A mint runs for tens of minutes and the credential's TTL does not
+        # pause for it — the publisher must read the freshest one at USE time,
+        # which is the whole reason `CellPublisher` takes a provider.
+        return str(worker_credential.current()
+                   or getattr(settings, "tensorhub_token", "") or "").strip()
+
+    if not base_url or not credential():
         raise MintRefused(
             "cannot publish: TENSORHUB_PUBLIC_URL/TENSORHUB_URL and "
             "WORKER_JWT/TENSORHUB_TOKEN must both be set on a mint pod (the "
             "artifact was produced and is on disk)")
     publisher = CellPublisher(
         base_url=base_url,
-        worker_jwt=lambda: token,
+        worker_jwt=credential,
         image_digest=str(getattr(settings, "worker_image_digest", "") or ""),
     )
     if not publisher.enabled():

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -235,9 +235,53 @@ def finalized_in_process(key: str) -> Optional["SelfMint"]:
 ADOPTION_MARK = "equivalence_adopted"
 
 
+#: th#1423: the code a 401 gets when the credential we presented was ALREADY
+#: past its own `exp`. "Expired" and "revoked/wrong-worker" are different
+#: operator actions, and only the worker can tell them apart — the hub sees an
+#: unusable token either way.
+CREDENTIAL_EXPIRED_CODE = "worker_credential_expired"
+
+
 class CellPublishRefused(Exception):
     """Typed hub refusal (attestation / trust tier / quota). Terminal for
-    this publish attempt — never retried, never fatal to serving."""
+    this publish attempt — never retried, never fatal to serving.
+
+    Carries the hub's own ``status``/``code`` for the same reason
+    :class:`convert.hub.HubPublishError` does: a refusal reason re-derived from
+    ``str(exc)`` is prose that nothing can group by.
+    """
+
+    def __init__(self, message: str, *, status: int = 0, code: str = "") -> None:
+        super().__init__(message)
+        self.status = int(status or 0)
+        self.code = str(code or "")
+
+
+def _hub_error_code(body: Any) -> str:
+    """The hub's ``error.code``, accepting both envelope shapes it has used —
+    nested ``{"error": {"code": ...}}`` and the flat ``{"code": ...}`` the
+    worker-JWT refusals were observed with (th#1423)."""
+    if not isinstance(body, dict):
+        return ""
+    err = body.get("error")
+    if isinstance(err, dict):
+        return str(err.get("code") or "")
+    return str(body.get("code") or "")
+
+
+def _credential_lapse_s(token: str, *, now: float) -> float:
+    """Seconds ``token`` is PAST its own ``exp``; 0.0 when live or unreadable.
+
+    Not a timeout (gw#666): ``exp`` is an absolute instant the credential
+    itself carries, not a duration this code picked.
+    """
+    from .request_context._helpers import _decode_unverified_jwt_claims
+
+    try:
+        exp = float(_decode_unverified_jwt_claims(token).get("exp") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, now - exp) if exp > 0 else 0.0
 
 
 class CellPublisher:
@@ -277,6 +321,7 @@ class CellPublisher:
     # -- wire ---------------------------------------------------------------
 
     def _post(self, path: str, payload: dict, *, timeout: float) -> dict:
+        from .convert.hub import HubPublishError
 
         # pgw#763 delta 1: parent-mediated under the split — the compute child
         # holds no worker JWT, so the parent makes the attested-intent call and
@@ -284,11 +329,15 @@ class CellPublisher:
         # least-authority grant the child is explicitly allowed to hold. The
         # cell bytes still go child -> CAS directly under that token: the seam
         # carries control, not data.
+        # Read the credential ONCE: the bearer we present and the bearer whose
+        # expiry we blame must be the same string, or a rotation landing
+        # mid-call makes the diagnosis describe a token we never sent.
+        bearer = self._worker_jwt()
         resp = broker.request(
             "POST",
             path,
             base_url=self.base_url,
-            bearer=self._worker_jwt(),
+            bearer=bearer,
             json=payload,
             timeout=timeout,
         )
@@ -297,13 +346,26 @@ class CellPublisher:
             body = resp.json() if resp.text else {}
         except Exception:
             body = {}
+        code = _hub_error_code(body)
         if resp.status_code in (403, 429):
             # Typed refusals (cell_publish_forged_axis, _untrusted_tier,
             # _quota_exceeded, _family_undeclared): terminal by design.
             raise CellPublishRefused(
-                f"{path} refused ({resp.status_code}): {resp.text[:300]}")
+                f"{path} refused ({resp.status_code}): {resp.text[:300]}",
+                status=resp.status_code, code=code)
         if resp.status_code < 200 or resp.status_code >= 300:
-            raise RuntimeError(f"{path} failed ({resp.status_code}): {resp.text[:300]}")
+            # th#1423: this raised a BARE RuntimeError, so `_publish_failure_phase`
+            # had nothing to group by and three production 401s all landed under
+            # the phase `RuntimeError`. The typed carrier already exists.
+            lapse = (_credential_lapse_s(bearer, now=time.time())
+                     if resp.status_code == 401 else 0.0)
+            raise HubPublishError(
+                f"{path} failed ({resp.status_code}): {resp.text[:300]}"
+                + (f" — the credential presented was {lapse:.0f}s past its own exp"
+                   if lapse else ""),
+                status=resp.status_code,
+                code=CREDENTIAL_EXPIRED_CODE if lapse else code,
+            )
         return body if isinstance(body, dict) else {}
 
     # -- publish ------------------------------------------------------------
@@ -339,6 +401,14 @@ class CellPublisher:
             "image_digest": self.image_digest,
             "gen_worker": str(meta.get("gen_worker") or ""),
         }
+        # th#1423: a mint outliving its credential is only visible AFTER the
+        # compile, in a 401 nothing could group. The credential states its own
+        # `exp`, so the lapse is a MEASURED fact at the one moment it decides
+        # the outcome — on the wire before the intent, not inferred later.
+        lapse = _credential_lapse_s(self.worker_jwt(), now=time.time())
+        if lapse:
+            _publish_leg(family, key, "credential_expired",
+                         {"past_exp_s": int(lapse)})
         intent = self._post(
             "/v1/worker/cells/publish-intent",
             {

--- a/tests/test_mint_credential_expiry_th1423.py
+++ b/tests/test_mint_credential_expiry_th1423.py
@@ -1,0 +1,282 @@
+"""th#1423 pgw half: a mint that outlives its credential must SAY SO.
+
+Measured on the standing master stack: three `self_mint_publish_failed` events,
+all `/v1/worker/cells/publish-intent failed (401): invalid worker token` after a
+28-minute inductor compile, at 32m30s past first activity against a 30m worker
+JWT TTL. Two worker-side defects made that unreadable:
+
+* `CellPublisher._post` raised a BARE `RuntimeError`, so `_publish_failure_phase`
+  had no `status`/`code` to group by and all three landed under the phase
+  `RuntimeError` — indistinguishable from any other exception type on the wire;
+* `aot_mint._publisher_from_settings` built the publisher with
+  `worker_jwt=lambda: token`, a token CAPTURED at construction, so a rotation
+  arriving during the mint could never be picked up.
+
+These drive the REAL publisher against a localhost server speaking tensorhub's
+real refusal envelope — real sockets, real threads, a real packed cell — because
+what is under test is what the worker does with a live 401, not a mock's idea of
+one. Every wait here is a `Thread.join()` on the publish thread itself: no
+sleeps, no durations (gw#666).
+
+Run: pytest tests/test_mint_credential_expiry_th1423.py -q
+"""
+
+from __future__ import annotations
+
+import base64
+import http.server
+import json
+import threading
+import time
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from gen_worker import fleet_cells as fc
+from gen_worker.convert.hub import HubPublishError
+
+LAPSE_S = 150  # how far past `exp` the presented credential is, in the JWT
+CELL_KEY = "ck5-" + "e" * 56
+FAMILY = "sdxl"
+
+META = {
+    "cell_key": CELL_KEY, "family": FAMILY, "sku": "l4", "sm": "89",
+    "gen_worker": "0.76.6", "kind": "aot-inductor", "format": "pt2",
+    "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
+}
+
+
+def _jwt(*, lifetime_s: float) -> str:
+    """A real three-segment JWT carrying a real `exp`. Unsigned on purpose —
+    the worker never verifies its own credential, it reads what it holds.
+
+    `lifetime_s` is the credential's OWN remaining life, a claim the token
+    carries. Nothing here waits on it: no row in this file is bounded by a
+    clock (gw#666).
+    """
+    issued = time.time()
+    def seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    exp = int(issued + lifetime_s)
+    return f"{seg({'alg': 'none'})}.{seg({'exp': exp, 'sub': 'pod-1'})}.sig"
+
+
+class _Hub(http.server.BaseHTTPRequestHandler):
+    """tensorhub's worker-JWT refusal, verbatim: `authenticateWorkerJWT` writes
+    `{"error": {"code": "unauthorized", ...}}` via `httperrors.WriteOrchestrator`
+    and books its th#1423 pod_event; the wire shape is all the worker sees."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):  # noqa: D102
+        pass
+
+    def _json(self, code: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self):  # noqa: N802
+        srv = self.server
+        path = urllib.parse.urlparse(self.path).path
+        n = int(self.headers.get("Content-Length") or 0)
+        _ = self.rfile.read(n) if n else b""
+        bearer = (self.headers.get("Authorization") or "").split(" ")[-1]
+        with srv.lock:
+            srv.seen.append((path, bearer))
+        self._json(401, {"error": {
+            "code": "unauthorized",
+            "message": "invalid worker token",
+            "request_id": "req-1",
+        }})
+
+
+class _Server:
+    def __init__(self):
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Hub)
+        self.httpd.lock = threading.Lock()
+        self.httpd.seen = []
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    @property
+    def base(self) -> str:
+        host, port = self.httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture()
+def hub():
+    s = _Server()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture()
+def artifact(tmp_path: Path) -> Path:
+    from gen_worker import compile_cache as cc
+
+    root = tmp_path / "capture"
+    (root / "inductor" / "fxgraph").mkdir(parents=True)
+    (root / "inductor" / "fxgraph" / "e0.bin").write_bytes(b"\x11" * 4096)
+    out = tmp_path / "mintdir" / "cell.tar.gz"
+    out.parent.mkdir()
+    cc.pack(root, out, dict(META))
+    return out
+
+
+def _publisher(hub, token: str) -> fc.CellPublisher:
+    return fc.CellPublisher(base_url=hub.base, worker_jwt=lambda: token,
+                            image_digest="sha256:" + "1" * 64)
+
+
+# --- the wire: a 401 must arrive as a TYPED, groupable failure ---------------
+
+
+def test_intent_401_carries_the_hubs_status_and_code(hub, artifact):
+    """RED before the fix: `_post` raised a bare `RuntimeError`, so this
+    `HubPublishError` never existed and `.status`/`.code` did not either."""
+    live = _jwt(lifetime_s=900)
+    with pytest.raises(HubPublishError) as caught:
+        _publisher(hub, live).publish(FAMILY, artifact, dict(META))
+
+    exc = caught.value
+    assert exc.status == 401
+    assert exc.code == "unauthorized"
+    assert fc._publish_failure_phase(exc) == "unauthorized"
+    # The refusal was really spoken over the wire, by the credential we hold.
+    assert hub.httpd.seen == [("/v1/worker/cells/publish-intent", live)]
+
+
+def test_an_expired_credential_is_named_as_such_not_as_a_generic_401(
+        hub, artifact):
+    """The th#1423 shape exactly: a 28-minute compile hands publish-intent a
+    credential already past its own `exp`. The hub cannot tell "expired" from
+    "revoked" — the worker can, and only from the token it presented.
+
+    RED before the fix: `_publish_failure_phase` returned `RuntimeError`."""
+    dead = _jwt(lifetime_s=-LAPSE_S)
+    with pytest.raises(HubPublishError) as caught:
+        _publisher(hub, dead).publish(FAMILY, artifact, dict(META))
+
+    exc = caught.value
+    assert exc.status == 401
+    assert exc.code == fc.CREDENTIAL_EXPIRED_CODE
+    assert fc._publish_failure_phase(exc) == "worker_credential_expired"
+    assert "past its own exp" in str(exc)
+
+
+def test_the_lapse_is_on_the_wire_before_the_intent_is_spent(
+        hub, artifact, monkeypatch):
+    """The credential states its own `exp`, so "this mint outlived its
+    credential" is knowable at the one moment it decides the outcome — not
+    only afterwards from a 401 whose cause the hub cannot see."""
+    seen: list = []
+    monkeypatch.setattr(
+        fc.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: seen.append((kind, phase, detail)))
+
+    with pytest.raises(HubPublishError):
+        _publisher(hub, _jwt(lifetime_s=-LAPSE_S)).publish(
+            FAMILY, artifact, dict(META))
+
+    legs = [(k, p, d) for k, p, d in seen if p == "credential_expired"]
+    assert len(legs) == 1, seen
+    assert "past_exp_s=1" in legs[0][2]  # 150s, measured — never a constant
+
+
+def test_a_live_credential_publishes_no_lapse_leg(hub, artifact, monkeypatch):
+    """The negative half: an in-date credential must not be accused."""
+    seen: list = []
+    monkeypatch.setattr(
+        fc.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: seen.append((kind, phase)))
+
+    with pytest.raises(HubPublishError):
+        _publisher(hub, _jwt(lifetime_s=900)).publish(
+            FAMILY, artifact, dict(META))
+
+    assert not [p for _, p in seen if p == "credential_expired"]
+
+
+# --- the production entry: the event the three failures were reported as ----
+
+
+def test_the_background_publish_reports_the_grouped_phase(hub, artifact,
+                                                          monkeypatch):
+    """`_publish_async` is the path all three production failures took. Its
+    `self_mint_publish_failed` phase is the group key the hub reads back.
+
+    RED before the fix: `phase="RuntimeError"`."""
+    seen: list = []
+    monkeypatch.setattr(
+        fc.activity_mod, "emit_event",
+        lambda kind, detail, phase="", duration_ms=0: seen.append((kind, phase)))
+
+    thread = fc._publish_async(
+        _publisher(hub, _jwt(lifetime_s=-LAPSE_S)),
+        FAMILY, artifact, dict(META), cell_key_digest=CELL_KEY)
+    thread.join()  # the publish thread itself is the bound — no clock
+
+    assert ("self_mint_publish_failed", "worker_credential_expired") in seen
+    assert fc.refused_publishes()[CELL_KEY] == "worker_credential_expired"
+
+
+# --- the mint publisher must read the credential at USE time ----------------
+
+
+@pytest.fixture()
+def clean_process_credential():
+    """Restore the process-wide `Settings` and credential this test replaces —
+    both are module globals, and a leak would silently arm another test."""
+    from gen_worker import worker_credential
+    from gen_worker.config import process as config_process
+
+    prior = config_process._SETTINGS
+    prior_boot = worker_credential._BOOTSTRAP
+    try:
+        yield
+    finally:
+        config_process._SETTINGS = prior
+        worker_credential.reset()
+        worker_credential._BOOTSTRAP = prior_boot
+
+
+def test_the_mint_publisher_reads_the_credential_at_use_time(
+        monkeypatch, clean_process_credential):
+    """RED before the fix: `_publisher_from_settings` closed over
+    `worker_jwt=lambda: token`, so a rotation landing during the mint — the
+    only thing that can save a compile longer than the TTL — was invisible."""
+    from gen_worker import aot_mint, config, worker_credential
+
+    boot = _jwt(lifetime_s=60)
+    rotated = _jwt(lifetime_s=3600)
+
+    monkeypatch.setenv("WORKER_JWT", boot)
+    monkeypatch.setenv("TENSORHUB_URL", "http://127.0.0.1:1")
+    monkeypatch.delenv("TENSORHUB_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("TENSORHUB_TOKEN", raising=False)
+    config.reload_for_test()
+    # The CLI's own starting state: nothing has handed the process-wide
+    # credential source anything yet.
+    worker_credential.reset()
+    monkeypatch.setattr(worker_credential, "_BOOTSTRAP", "", raising=False)
+
+    publisher = aot_mint._publisher_from_settings()
+    # `install_bootstrap` must have run here, or the process-wide credential
+    # source is empty and the fallback is silently doing all the work.
+    assert publisher.worker_jwt() == boot
+
+    # 0.0 = expiry unknown to the installer; the token states its own.
+    worker_credential.install(rotated, 0.0)
+    assert publisher.worker_jwt() == rotated


### PR DESCRIPTION
The worker half of th#1423. The hub half — durable typed `pod_events` on every worker-JWT refusal — is already merged; this is the side that produced the refusal.

**The measured shape** (hub `pod_events`, standing master stack): three `self_mint_publish_failed` events, all `/v1/worker/cells/publish-intent failed (401): invalid worker token` after a 28-minute inductor compile, at 32m30s past first activity against a 30m worker JWT TTL. The compile outlived the credential.

## What this changes

**1. The 401 was untyped.** `CellPublisher._post` raised a BARE `RuntimeError` for every non-2xx, so `_publish_failure_phase` — which exists to read `status`/`code` — had neither, and all three landed under the phase `RuntimeError`, one group with every other exception type on the wire. It now raises the `HubPublishError` the v2 leg already uses, carrying the hub's `status` and `error.code`. `_hub_error_code` accepts both envelope shapes: nested `{"error":{"code"}}` and the flat `{"code"}` these refusals were observed with. The bearer is read ONCE per call, so the token blamed is the token sent.

**2. A 401 under an already-lapsed credential is now NAMED.** `exp` is an absolute instant the credential itself carries — not a duration this code picked (gw#666) — so "expired" separates from "revoked/wrong-worker", a distinction the hub cannot make and only the holder can. Code `worker_credential_expired`, plus a `credential_expired` publish leg carrying the measured lapse on the wire BEFORE the intent is spent. The call is still MADE, deliberately: the hub's th#1423 `pod_event` is the durable record, and refusing locally would delete it.

**3. `aot_mint._publisher_from_settings` captured its token** as `worker_jwt=lambda: token`, defeating the provider `CellPublisher` takes precisely so rotation is picked up per call. It reads the credential at USE time now. Found while fixing it: `worker_credential.current()` answers only once something HANDS it the boot token, and only `entrypoint` / the procsplit parent ever do — never this CLI. **So pgw#876 §2's stated effect (WORKER_JWT visible here) was never actually reached in that process**; the `tensorhub_token` fallback was doing all the work. `install_bootstrap` now runs there.

## One relayed premise corrected

The brief called (3) "exactly the pod type whose mint runs tens of minutes". It is not. `aot_mint.main`'s own docstring says it is the ops/testing entry point and that **production mints run in a serving pod's background — #724 rejected, there is no dedicated mint fleet**. The three `self_mint_publish_failed` events come from `fleet_cells._publish_async` on a SERVING pod (`executor._cell_publisher`), whose provider is already live. Those pods ran gen_worker **0.76.6 (2026-07-29)**, which predates pgw#848 — at that release the serving publisher really did read a frozen token, and pgw#848 already closed that half on `dev`. (3) is still a real defect and is still fixed; it is just not what caused these three.

## Deliberately not done

**"Always try publish-complete."** `{ok:false}` is authenticated by the same check that just refused the intent, so it is refused identically. Nor is there a worker-JWT refresh to call before intent: rotation exists ONLY as `TokenRefresh` down the live gRPC scheduler stream (`transport.py` is the sole caller of `worker_credential.install`), and `worker/capability/renew` renews the *capability* token while itself requiring a live worker JWT. Presenting the freshest credential the process holds, and naming the lapse, is the whole of what the worker can do here.

**Can a mint know IN ADVANCE it will outlive its credential?** Partly, and the boundary matters. "Will this compile outlive the TTL?" needs a predicted duration compared against a threshold — the gw#666 shape outright. "Is the credential I am about to spend already dead?" is answerable from the token itself, and that is what is now measured and reported.

## Verification

`tests/test_mint_credential_expiry_th1423.py` — 6 rows on the real codepath: a real `ThreadingHTTPServer` speaking tensorhub's real refusal envelope, the real `CellPublisher.publish` over real sockets, a real packed cell, and the real `_publish_async` publish thread. Every wait is `Thread.join()` on that thread: no sleeps, no durations (`test_magic_timeouts_gw666.py` green).

**RED-verified** against `origin/dev` verbatim (`git checkout origin/dev -- src/gen_worker/{fleet_cells,aot_mint}.py`): all six fail. The production entry point emits

    assert ('self_mint_publish_failed', 'worker_credential_expired') in seen
    E  AssertionError: assert (...) in [('self_mint_publish', 'started'),
                                        ('self_mint_publish_failed', 'RuntimeError')]

— the exact phase the three production events carried. The mint-publisher row fails pre-fix with `MintRefused: ... WORKER_JWT/TENSORHUB_TOKEN must both be set` **with `WORKER_JWT` set in the environment**, which is the proof for the `install_bootstrap` finding.

ruff + mypy clean on the locked 3.12 toolchain.