### PR TITLE
pgw#964: a reaped descendant's CPU is still CPU — the mint stall monitor stops killing mints for finishing an entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,47 @@
   constant, tree-wide (`BOOT_TIMEOUT_S` was defined in one module and imported by
   four more, so a file-local scan saw one of six). It names all six pre-fix files
   on `origin/dev` and is green here.
+- **pgw#964: the mint stall monitor threw away a REAPED descendant's CPU, so
+  finishing a compile entry looked exactly like dying.** `_tree_cpu_seconds`
+  walked `psutil.Process(pid).children(recursive=True)` and summed
+  `cpu_times().user + .system` over the LIVE members only. On Linux a process's
+  CPU leaves its own `utime/stime` and enters its parent's `cutime/cstime` the
+  instant the parent reaps it, so that total is a **sawtooth**: an entry compile
+  child that FINISHES subtracts its whole lifetime from the tree. `_observe`
+  ratchets against a high-water mark, so one finished entry digs a hole one
+  entry deep and a fresh entry must burn all of it again before a single
+  `touch()` lands — at K=2 with ~390 s entries, a race the 300 s window loses by
+  construction. Two further compounding defects: a `psutil` miss returned `0.0`
+  (a manufactured cliff) rather than "unknown", and CPU-seconds were **added to**
+  capture-MiB, so a fall in the non-monotonic term vetoed growth in the other —
+  the exact inverse of `activity._default_evidence`'s own stated contract,
+  *"Either source alone advancing proves genuine life"*.
+  This is what SIGTERM'd pgw#868 attempt eighteen: `self_mint_abort /
+  delegated_crashed … exit=-15 … no measured progress for 301s … no process-tree
+  CPU and no capture bytes`, twice, on two independent L40S pods 2.5 h apart,
+  byte-identically — while the pool ledger the dying process was itself writing
+  recorded `peak_concurrency: 2` and `idle_other_s: 0.069`, i.e. two live entry
+  compile children and essentially no free slot across the entire 301 s window.
+  (`pool_busy_s`/`pool_capacity_s`/`pool_wall_s` reading `0.0` on that row are
+  **not** measurements: they are assigned only in `compile()`'s `finally`, which
+  a SIGTERMed process never runs.)
+  Now: the tree sum includes `children_user + children_system` at every member,
+  so it is monotonic while the root lives; an unsamplable tree reads `None` and
+  is skipped, never zero; and the two signals are carried as a **pair** with
+  their own high-water marks, an advance in EITHER counting as progress — so
+  capture-byte silence during a long single-threaded `g++` can no longer vote
+  for a kill. Same defect class fixed at its two sibling sites,
+  `activity._process_cpu_evidence` and `procsplit.parent._child_evidence`.
+  Doctrine (gw#666): a 300 s `SilenceWindow` is legitimate only over a signal
+  that can register the work being done — over one that goes DOWN when work
+  completes it was a fixed-duration kill in a progress-staleness costume, and
+  raising the number would have fixed nothing.
+  RED-verified against `origin/dev` verbatim, with real processes and a real
+  CPU-burning grandchild: `process-tree CPU went BACKWARDS when a grandchild was
+  reaped: 0.49s while it ran -> 0.20s after wait()`, and `_observe` reproducing
+  the pod's abort string on a laptop — *"the mint process made no measured
+  progress for 310s (window 300s): no process-tree CPU and no capture bytes"* —
+  against a tree that was burning a full core throughout.
 
 - **pgw#957: the gw#666 guard file's own boot fixture was a bet on the runner's
   speed — the shape it exists to police.** `test_a_talking_engine_boots_however

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -461,10 +461,15 @@ def _process_cpu_evidence() -> float:
 
     Best-effort: a child that can't be inspected (raced exit, permissions)
     just doesn't contribute — never fatal to the heartbeat."""
-    times = _this_process.cpu_times()
-    total = float(times.user) + float(times.system)
-    total += float(getattr(times, "children_user", 0.0) or 0.0)
-    total += float(getattr(times, "children_system", 0.0) or 0.0)
+    try:
+        times = _this_process.cpu_times()
+        total = float(times.user) + float(times.system)
+        total += float(getattr(times, "children_user", 0.0) or 0.0)
+        total += float(getattr(times, "children_system", 0.0) or 0.0)
+    except psutil.Error:
+        # Self is always readable in practice; if it somehow is not, fall back
+        # to the interpreter's own accounting rather than to zero.
+        total = time.process_time()
     try:
         children = _this_process.children(recursive=True)
     except psutil.Error:

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -444,15 +444,27 @@ _this_process = psutil.Process()
 
 
 def _process_cpu_evidence() -> float:
-    """Process CPU seconds, including LIVE (not just reaped) child
-    processes. torch's async_compile forks subprocess compile workers for
-    inductor phases — resource.getrusage(RUSAGE_CHILDREN) only accounts for
-    children that have already exited, which is useless for an in-flight
-    compile burning real CPU in a still-running child. psutil reads /proc
-    directly, so a live child's usage counts immediately. Best-effort: a
-    child that can't be inspected (raced exit, permissions) just doesn't
-    contribute — never fatal to the heartbeat."""
-    total = time.process_time()
+    """Process CPU seconds, counting live AND already-reaped descendants.
+
+    torch's async_compile forks subprocess compile workers for inductor
+    phases, so ``resource.getrusage(RUSAGE_CHILDREN)`` alone is useless for an
+    in-flight compile burning real CPU in a still-running child; psutil reads
+    /proc directly, so a live child's usage counts immediately.
+
+    pgw#964: it took BOTH. Counting only the live tree makes this a sawtooth —
+    a child's CPU leaves its own ``utime/stime`` and enters its parent's
+    ``cutime/cstime`` the instant it is reaped, so a finishing compile worker
+    SUBTRACTS its whole lifetime from the total. Every consumer here compares
+    against a high-water mark, so that reads as a pod that stopped working. A
+    process's CPU lives in exactly one of the two places and never both, so
+    adding the reaped counters is a clean sum and makes this monotonic.
+
+    Best-effort: a child that can't be inspected (raced exit, permissions)
+    just doesn't contribute — never fatal to the heartbeat."""
+    times = _this_process.cpu_times()
+    total = float(times.user) + float(times.system)
+    total += float(getattr(times, "children_user", 0.0) or 0.0)
+    total += float(getattr(times, "children_system", 0.0) or 0.0)
     try:
         children = _this_process.children(recursive=True)
     except psutil.Error:
@@ -462,7 +474,9 @@ def _process_cpu_evidence() -> float:
             ct = child.cpu_times()
         except psutil.Error:
             continue
-        total += ct.user + ct.system
+        total += float(ct.user) + float(ct.system)
+        total += float(getattr(ct, "children_user", 0.0) or 0.0)
+        total += float(getattr(ct, "children_system", 0.0) or 0.0)
     return total
 
 

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -361,38 +361,62 @@ def _decode_report(path: Path) -> Optional[MintReport]:
         return None
 
 
-def _tree_cpu_seconds(pid: int) -> float:
-    """The child's process-tree CPU seconds.
+def _tree_cpu_seconds(pid: int) -> Optional[float]:
+    """The child's process-tree CPU seconds — INCLUDING descendants that have
+    already exited.
 
-    Inductor forks its own compile workers, so the tree — not the child
-    alone — is what burns the CPU a mint is made of. Best-effort: a raced
-    exit contributes nothing rather than raising.
+    Inductor forks its own compile workers and a ``g++`` under each of those,
+    so the tree — not the child alone — is what burns the CPU a mint is made
+    of. The subtle half is the word *already*: on Linux a process's CPU leaves
+    its own ``utime/stime`` and lands in its parent's ``cutime/cstime`` the
+    instant the parent reaps it (recursively — a reaped subtree rolls all the
+    way up). Summing only the live members' ``user + system`` therefore makes
+    this quantity a SAWTOOTH: an entry compile child that FINISHES subtracts
+    its entire lifetime CPU from the total.
+
+    That is not a cosmetic wobble. ``_observe`` ratchets against a high-water
+    mark, so a finishing entry digs a hole one whole entry deep, and the mint
+    is killed for the crime of completing something (pgw#964; it killed
+    pgw#868 attempt eighteen twice, byte-identically, on two independent pods).
+    Adding the reaped-children counters makes the total monotonic for as long
+    as ``pid`` lives, which is exactly as long as it is consulted.
+
+    Returns ``None`` when the tree could not be sampled at all. A failure is
+    NOT zero: reporting zero would manufacture the same cliff from a transient
+    ``/proc`` race.
     """
     try:
         import psutil
     except Exception:  # pragma: no cover - psutil is a hard dep in practice
-        return 0.0
-    total = 0.0
+        return None
     try:
         proc = psutil.Process(pid)
         members = [proc] + proc.children(recursive=True)
     except Exception:
-        return 0.0
+        return None
+    total = 0.0
     for member in members:
         try:
             times = member.cpu_times()
         except Exception:
             continue
+        # A member's own time, plus the time of every descendant IT has
+        # already waited for. No double count: a process's CPU is in exactly
+        # one of the two places, never both.
         total += float(times.user) + float(times.system)
+        total += float(getattr(times, "children_user", 0.0) or 0.0)
+        total += float(getattr(times, "children_system", 0.0) or 0.0)
     return total
 
 
-def _capture_mib(capture: Path) -> float:
+def _capture_mib(capture: Path) -> Optional[float]:
     """MiB the child has written into its capture dir.
 
-    A compile whose CPU is briefly parked in a C++ toolchain still grows this,
-    and vice versa, so the two together are a much harder liveness signal than
-    either alone.
+    The inductor/triton cache root, not a stdio buffer. It grows in BURSTS —
+    generated sources land, then a single-threaded ``g++`` chews on them for
+    minutes writing nothing. So its growth proves work and its silence proves
+    nothing, which is why ``_observe`` treats it as an independent positive
+    signal that can never, on its own, vote to kill.
     """
     total = 0
     try:
@@ -403,12 +427,17 @@ def _capture_mib(capture: Path) -> float:
             except OSError:
                 continue
     except OSError:
-        return 0.0
+        return None
     return total / (1 << 20)
 
 
-def _evidence(pid: int, capture: Path) -> float:
-    return _tree_cpu_seconds(pid) + _capture_mib(capture)
+#: The measured signals, sampled together. Deliberately a PAIR and never a
+#: sum: they have different failure modes and different units, and adding them
+#: lets a fall in one cancel a rise in the other. That is precisely how a
+#: healthy mint died — a reaped entry's CPU drop swallowed the capture bytes
+#: its successor was writing.
+def _evidence(pid: int, capture: Path) -> Tuple[Optional[float], Optional[float]]:
+    return _tree_cpu_seconds(pid), _capture_mib(capture)
 
 
 def child_argv(request_path: Path, *, python: str = "") -> Sequence[str]:
@@ -514,25 +543,42 @@ async def _observe(
     interval_s: float,
 ) -> str:
     """Watch the child's MEASURED progress. Returns the stall reason, or ''
-    when cancelled because the child exited."""
-    last = _evidence(pid, capture)
+    when cancelled because the child exited.
+
+    Each signal keeps its OWN high-water mark and an advance in EITHER is
+    progress (pgw#964). Two properties fall out, and both are load-bearing:
+
+    * a signal that cannot be sampled this poll contributes nothing rather
+      than a cliff, and
+    * a signal that is merely quiet — capture bytes during a long ``g++`` —
+      cannot cancel one that is moving. Only the absence of BOTH advances is
+      silence, which is the only thing this window is entitled to judge.
+    """
+    cpu, mib = _evidence(pid, capture)
     window.touch()
     while True:
         await asyncio.sleep(interval_s)
-        now = _evidence(pid, capture)
-        if now - last >= _EVIDENCE_EPS:
-            last = now
+        now_cpu, now_mib = _evidence(pid, capture)
+        advanced = False
+        if now_cpu is not None and (cpu is None or now_cpu - cpu >= _EVIDENCE_EPS):
+            cpu, advanced = now_cpu, True
+        if now_mib is not None and (mib is None or now_mib - mib >= _EVIDENCE_EPS):
+            mib, advanced = now_mib, True
+        if advanced:
             window.touch()
             if on_evidence is not None:
                 try:
-                    on_evidence(now)
+                    on_evidence((cpu or 0.0) + (mib or 0.0))
                 except Exception:
                     logger.exception("mint evidence callback failed")
         elif window.stalled():
             return (
                 f"the mint process made no measured progress for "
                 f"{window.silent_for():.0f}s (window {window.window_s:.0f}s): "
-                f"no process-tree CPU and no capture bytes")
+                f"process-tree CPU {'unreadable' if now_cpu is None else f'{now_cpu:.1f}s'} "
+                f"and capture "
+                f"{'unreadable' if now_mib is None else f'{now_mib:.1f}MiB'} "
+                f"both flat")
 
 
 def _terminate_group(pid: int, *, grace_s: float = 10.0) -> None:

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -1067,17 +1067,30 @@ class _ChildSlot:
                 pass
 
     def _child_evidence(self, pid: int) -> Optional[float]:
-        """This child tree's kernel-accounted work: process+LIVE-children CPU
-        seconds plus process disk I/O MB (the same combination
-        ``activity._default_evidence`` trusts, measured from /proc)."""
+        """This child tree's kernel-accounted work: CPU seconds for the whole
+        tree — live AND already-reaped descendants (pgw#964) — plus process
+        disk I/O MB (the same combination ``activity._default_evidence``
+        trusts, measured from /proc).
+
+        The reaped half is not optional. A descendant's CPU moves into its
+        parent's ``cutime/cstime`` when it is waited for, so a tree summed
+        over live members only goes DOWN whenever a subprocess finishes, and
+        every caller compares this against a high-water mark."""
         try:
             import psutil
         except Exception:
             return None
+
+        def _cpu(p: Any) -> float:
+            t = p.cpu_times()
+            return (
+                float(t.user) + float(t.system)
+                + float(getattr(t, "children_user", 0.0) or 0.0)
+                + float(getattr(t, "children_system", 0.0) or 0.0))
+
         try:
             proc = psutil.Process(pid)
-            times = proc.cpu_times()
-            total = float(times.user + times.system)
+            total = _cpu(proc)
             try:
                 io = proc.io_counters()
                 total += (io.read_bytes + io.write_bytes) / float(1 << 20)
@@ -1085,10 +1098,9 @@ class _ChildSlot:
                 pass
             for child in proc.children(recursive=True):
                 try:
-                    ct = child.cpu_times()
+                    total += _cpu(child)
                 except psutil.Error:
                     continue
-                total += float(ct.user + ct.system)
             return total
         except psutil.Error:
             return None

--- a/tests/test_mint_liveness_pgw964.py
+++ b/tests/test_mint_liveness_pgw964.py
@@ -1,0 +1,255 @@
+"""pgw#964: finishing an entry is not dying.
+
+The mint stall monitor sampled its child's process-tree CPU by summing
+``user + system`` over the LIVE members of the tree. On Linux a process's CPU
+leaves its own ``utime/stime`` and enters its parent's ``cutime/cstime`` the
+instant the parent reaps it, so that sum goes DOWN by a whole child's lifetime
+every time a child finishes — and ``_observe`` compares against a high-water
+mark. An AOT mint whose compile pool completes one ~390-second entry therefore
+falls into a hole one entry deep and is SIGTERMed for making progress.
+
+Not hypothetical: it killed pgw#868 attempt eighteen twice, on two independent
+L40S pods 2.5 h apart, with a byte-identical abort string — while the very
+pool ledger the dying process was writing recorded ``peak_concurrency: 2`` and
+``idle_other_s: 0.069``, i.e. two live entry compile children and essentially
+zero free slots across the whole 301-second "no process-tree CPU" window.
+
+Both tapes below run REAL processes and a REAL grandchild that burns REAL CPU
+and then exits, because the property under test is exactly what ``/proc`` says
+after a ``wait()`` — which no mock can tell you. No wait here is a clock: they
+key on markers the children write and on measured advances (gw#666).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, List, Optional
+
+from gen_worker.mint_process import _evidence, _observe, _tree_cpu_seconds
+from gen_worker.stall import SilenceWindow
+from harness.progress_wait import Cadence, await_progress
+
+# One grandchild burn, sized in ITERATIONS rather than seconds so a loaded
+# runner makes the tape slower, never wrong. ~1-3 CPU-seconds here.
+_BURN_ITERS = 24_000_000
+
+# CPU-seconds of grandchild work the tape insists on OBSERVING before it lets
+# the reap happen. A threshold on measured work, not on the clock.
+_LIVE_CPU_FLOOR_S = 0.4
+
+_WORKER = '''
+import os, subprocess, sys
+
+state, iters = sys.argv[1], sys.argv[2]
+
+# The entry compile child: burns hard, then EXITS. Its exit is the event the
+# old monitor read as death.
+g = subprocess.Popen([
+    sys.executable, "-c",
+    "import sys\\nx = 0\\nfor _ in range(int(sys.argv[1])): x = (x + 1) & 65535\\n",
+    iters])
+g.wait()   # reaped -> the grandchild's CPU moves into OUR cutime/cstime
+open(os.path.join(state, "reaped"), "w").write("1")
+
+# The replacement entry the pool spawns straight after. Still working — and
+# under the old sampler still invisible, because the tree total is sitting in
+# a hole as deep as the grandchild that just finished.
+x = 0
+while True:
+    x = (x + 1) & 65535
+'''
+
+
+def _spawn_tree(tmp_path: Path) -> subprocess.Popen:
+    state = tmp_path / "state"
+    state.mkdir(exist_ok=True)
+    script = tmp_path / "worker.py"
+    script.write_text(_WORKER)
+    return subprocess.Popen(
+        [sys.executable, str(script), str(state), str(_BURN_ITERS)],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        start_new_session=True)
+
+
+def _reap_tree(proc: subprocess.Popen) -> None:
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    with contextlib.suppress(Exception):
+        proc.wait()
+
+
+def _gone(proc: subprocess.Popen) -> Optional[str]:
+    return None if proc.poll() is None else f"the child exited {proc.poll()}"
+
+
+def test_tree_cpu_survives_a_reaped_grandchild(tmp_path: Path) -> None:
+    """The measured total must never go backwards when a grandchild finishes.
+
+    RED on the pre-pgw#964 sampler: the post-reap sample loses the whole burn.
+    """
+    proc = _spawn_tree(tmp_path)
+    reaped = tmp_path / "state" / "reaped"
+    try:
+        # 1. A live grandchild's CPU must be visible. (This half always
+        #    worked; asserting it keeps the fix honest — the job is to ADD the
+        #    reaped counters, not to trade one blindness for another.)
+        live = await_progress(
+            lambda: _tree_cpu_seconds(proc.pid) or 0.0,
+            lambda cpu: cpu >= _LIVE_CPU_FLOOR_S,
+            what="a live grandchild's CPU to reach the floor",
+            cadence=Cadence(floor_s=60.0),
+            gone=lambda: _gone(proc),
+            render=lambda cpu: f"{cpu:.2f} CPU-s of {_LIVE_CPU_FLOOR_S}",
+        )
+
+        # 2. Let it finish and be waited for.
+        await_progress(
+            reaped.exists,
+            bool,
+            what="the grandchild to be reaped",
+            cadence=Cadence(floor_s=60.0),
+            gone=lambda: _gone(proc),
+        )
+
+        after = _tree_cpu_seconds(proc.pid)
+        assert after is not None, "a live tree must be samplable"
+        assert after >= live, (
+            "process-tree CPU went BACKWARDS when a grandchild was reaped: "
+            f"{live:.2f}s while it ran -> {after:.2f}s after wait(). The "
+            "reaped child's CPU is in its parent's cutime/cstime and the "
+            "sampler is dropping it — which is what SIGTERM'd pgw#868 "
+            "attempt eighteen.")
+    finally:
+        _reap_tree(proc)
+
+
+class _Ticks:
+    """A clock the TAPE drives, so the window is exercised with no wall time.
+
+    Every read costs ``step`` seconds, so ``SilenceWindow(300)`` gives up after
+    30 consecutive non-advancing polls — and never after a single slow one.
+    """
+
+    def __init__(self, step: float = 10.0) -> None:
+        self.step = float(step)
+        self.t = 0.0
+
+    def now(self) -> float:
+        self.t += self.step
+        return self.t
+
+
+async def _await(
+    settled: Callable[[], bool],
+    advance: Callable[[], Any],
+    watch: "asyncio.Future[str]",
+    proc: subprocess.Popen,
+    *,
+    what: str,
+) -> None:
+    """Wait for ``settled()``; give up only on a measured stall or a death.
+
+    ``watch`` finishing is a DEFINITIVE end, not a stall: the monitor issued
+    its kill verdict, so there is nothing left to wait for and the caller's
+    assertion gets to report it verbatim. No duration bounds this (gw#666).
+    """
+    cadence = Cadence(floor_s=60.0)
+    window = SilenceWindow(cadence.window_s)
+    mark, last = advance(), time.monotonic()
+    while not settled():
+        if watch.done() or proc.poll() is not None:
+            return
+        await asyncio.sleep(0.02)
+        now, fresh = time.monotonic(), advance()
+        if fresh != mark:
+            cadence.record(now - last)
+            mark, last = fresh, now
+            window.window_s = cadence.window_s
+            window.touch()
+            continue
+        window.window_s = cadence.window_s
+        if window.stalled():
+            raise AssertionError(
+                f"waiting for {what}: nothing advanced for "
+                f"{window.silent_for():.1f}s ({cadence.describe()}); "
+                f"last saw {mark!r}")
+
+
+def test_observe_does_not_kill_a_pool_that_finished_an_entry(
+    tmp_path: Path,
+) -> None:
+    """The real ``_observe`` against a real tree that reaps a real grandchild.
+
+    RED on the pre-pgw#964 monitor: ``_observe`` returns its stall reason and
+    the tape reports the false kill verbatim.
+    """
+    proc = _spawn_tree(tmp_path)
+    reaped = tmp_path / "state" / "reaped"
+    # An EMPTY capture dir that never grows. The other half of the predicate
+    # is pinned at zero deliberately: during a long single-threaded
+    # `g++ -O1 -c wrapper.cpp` that is exactly what a healthy mint's capture
+    # dir does, so capture silence must not be able to vote for a kill.
+    capture = tmp_path / "capture"
+    capture.mkdir()
+
+    async def drive() -> None:
+        seen: List[float] = []
+        window = SilenceWindow(300.0, now=_Ticks().now)
+        watch = asyncio.ensure_future(
+            _observe(proc.pid, capture, window, seen.append, 0.15))
+        try:
+            await _await(
+                reaped.exists, lambda: len(seen), watch, proc,
+                what="the grandchild to be reaped")
+            assert not watch.done(), (
+                "_observe killed the mint before its entry even finished: "
+                f"{watch.result()!r}")
+
+            floor = len(seen) + 5
+            await _await(
+                lambda: len(seen) >= floor, lambda: len(seen), watch, proc,
+                what="evidence to advance again after the entry finished")
+
+            assert not watch.done(), (
+                "FALSE KILL: _observe SIGTERM'd a mint whose replacement "
+                "entry was burning real CPU the whole time — "
+                f"{watch.result()!r}")
+        finally:
+            watch.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watch
+
+    try:
+        asyncio.run(drive())
+    finally:
+        _reap_tree(proc)
+
+
+def test_the_two_signals_cannot_cancel_each_other(tmp_path: Path) -> None:
+    """``_evidence`` reports a PAIR, never a sum.
+
+    Summing CPU-seconds and capture-MiB is how a falling term vetoed a rising
+    one. The shape IS the guarantee, so it is asserted directly.
+    """
+    sample = _evidence(os.getpid(), tmp_path)
+    assert isinstance(sample, tuple) and len(sample) == 2, (
+        "the mint's measured evidence must stay two independent signals — "
+        "adding them lets a reaped child's CPU drop swallow the capture bytes "
+        "its successor is writing")
+
+
+def test_an_unsamplable_tree_is_not_a_zero() -> None:
+    """A ``/proc`` miss reads as UNKNOWN, never as a cliff to zero.
+
+    A sampler that answers 0.0 on a transient error manufactures the same
+    hole the reaped-child bug did, from nothing at all.
+    """
+    assert _tree_cpu_seconds(0) is None
+    assert _tree_cpu_seconds(1 << 30) is None


### PR DESCRIPTION
**Verdict on pgw#868 attempt eighteen's terminus: FALSE KILL.**

## The predicate

`src/gen_worker/mint_process.py`:

```
_evidence(pid, capture) = _tree_cpu_seconds(pid) + _capture_mib(capture)

_observe: last = _evidence(); every 5s: now = _evidence()
          if now - last >= 0.05: last = now; window.touch()
          elif window.stalled():                  # SilenceWindow(300.0)
              -> SIGTERM the child's process GROUP
```

## What is wrong with it

1. **`_tree_cpu_seconds` is not monotonic.** It walks `psutil.Process(pid).children(recursive=True)` and sums `cpu_times().user + .system` — **live members only**. On Linux a process's CPU leaves its own `utime/stime` and enters its parent's `cutime/cstime` the instant it is reaped (recursively; a reaped subtree rolls all the way up). So **an entry compile child that FINISHES subtracts its whole lifetime CPU from the total.** The two counters that hold the missing half, `children_user`/`children_system`, sit right there in the same namedtuple and were never read.

2. **`_observe` ratchets.** `last` is rebased only on an advance, i.e. it is a high-water mark. After a reap the total sits in a hole one entry deep, and a *fresh* entry must burn that much again before one `touch()` lands. At K=2 with ~390 s entries that race is lost by construction — and lost **deterministically**, which is why two independent pods 2.5 h apart produced a byte-identical abort string.

3. **The two signals were summed.** CPU-seconds + capture-MiB into one scalar, so a fall in the non-monotonic term vetoes growth in the monotonic one. `activity._default_evidence`'s own docstring states the intended contract — *"Either source alone advancing proves genuine life"* — and the implementation contradicted it.

4. **A `psutil` miss returned `0.0`**, manufacturing the same cliff from a transient `/proc` race.

## The evidence that the children were alive

`aot_mint_phases / pool` for pod `rtwrow8cj58ep6`, read live from the dev stack:

```
peak_concurrency: 2      idle_other_s: 0.069      idle_drain_s: 0.0
```

`idle_other_s` is charged every 0.25 s poll as `(elapsed x free_slots)`. A slot that had gone free would have accrued **hundreds** of worker-seconds across a 301 s wait. **0.069 worker-seconds of free capacity across the whole window = two live entry compile children throughout the window the monitor called "no process-tree CPU".**

### Correction to the previously-recorded root cause

WALL #9 in the tracker attributed this to a silent *staging* phase, citing `pool_busy_s = 0.00 / pool_capacity_s = 0.00 / pool_efficiency = 0.0`. Those — with `pool_wall_s` — are assigned **only in `PoolEntryCompiler.compile`'s `finally`**, which a SIGTERMed process never runs. They are unwritten defaults, not measurements. `idle_staging_s` and `stage_total_s` ARE live, and their ratio (283.314 / 170.407 = **1.663**, against `workers=2`) says staging ran partly at `free=1` — an entry had already completed and been reaped. That reap is the event the monitor mistook for death.

## The fix

- `_tree_cpu_seconds` sums `user + system + children_user + children_system` at every live member. No double count: a process's CPU is in exactly one of the two places, never both. Monotonic for as long as the root lives, which is exactly as long as it is consulted.
- An unsamplable tree returns `None` (sample skipped), never `0.0`.
- `_evidence` returns a **pair**. Each signal keeps its own high-water mark and an advance in **either** is progress — so capture-byte silence during a long single-threaded `g++ -O1 -c wrapper.cpp` (which by construction writes nothing into the inductor cache for minutes) can no longer vote for a kill.
- Same defect class fixed at its two sibling sites: `activity._process_cpu_evidence` and `procsplit.parent._child_evidence`. Both sum CPU with a monotonic IO-bytes term, so making CPU monotonic removes the masking there too.

## Doctrine (gw#666)

A 300 s `SilenceWindow` is legitimate only if the signal it consults can register the work being done. Over a signal that goes **down** when work completes, the window was a fixed-duration kill wearing a progress-staleness costume. Raising it would have fixed nothing.

## Tests — real processes, RED-verified against `origin/dev` verbatim

`tests/test_mint_liveness_pgw964.py` runs a real child that spawns a real CPU-burning grandchild, reaps it, and keeps working — the pool's exact shape. No sleeps bound anything; the waits key on markers the children write and on measured advances.

RED on `origin/dev`:

```
process-tree CPU went BACKWARDS when a grandchild was reaped:
  0.49s while it ran -> 0.20s after wait()

FALSE KILL: _observe SIGTERM'd a mint whose replacement entry was burning
real CPU the whole time — 'the mint process made no measured progress for
310s (window 300s): no process-tree CPU and no capture bytes'
```

That second line is attempt eighteen's abort string, reproduced on a laptop for $0.

GREEN on this branch. `450 passed, 1 skipped` across the mint/procsplit/stall/activity surface; `ruff` and `mypy` clean.

Tracker: `python-gen-worker/progress.md` #964 (pgw#868 A1).