### PR TITLE
pgw#962: scope activity counters to the phase that feeds them

### DIFF
--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -198,18 +198,36 @@ class Activity:
         self._step = 0
         self._total = 0
         self._done = False
-        self._counters: list[progress_mod.Counter] = []
+        # name -> (phase that registered it, counter). PHASE-scoped: see counter().
+        self._counters: dict[str, tuple[str, progress_mod.Counter]] = {}
 
     def counter(
         self, name: str, unit: str, total: float = 0.0,
     ) -> progress_mod.Counter:
-        """Register-or-get a progress counter owned by this activity —
-        finished automatically when the activity ends, so a reused name
-        never carries a stale age into the next activity (gw#621)."""
+        """Register-or-get a progress counter owned by this activity's CURRENT
+        PHASE — finished when the phase changes, and again when the activity
+        ends (gw#621).
+
+        pgw#962: activity-scoped lifetime was too long. `self_mint_compile`
+        spans load -> warmup_forward -> load for every function on the pod, so
+        `infer:steps` stayed open and frozen after its warmup finished; the
+        next phase has no counter producer, `progress.self_diagnosis()` is a
+        registry-wide min-age query, and the beat confessed `self_stalled`
+        about work that had already succeeded. The hub kills on that confession
+        without waiting out its own window. Producers re-acquire per tick, so a
+        counter that is still being fed is simply re-registered under the new
+        phase."""
         c = progress_mod.counter(name, unit, total)
-        if c not in self._counters:
-            self._counters.append(c)
+        self._counters[name] = (self._phase, c)
         return c
+
+    def _finish_counters(self, keep_phase: Optional[str] = None) -> None:
+        """Close counters the given phase does not own (all of them when None)."""
+        for name, (phase, c) in list(self._counters.items()):
+            if keep_phase is not None and phase == keep_phase:
+                continue
+            c.finish()
+            del self._counters[name]
 
     def _report(self, state: "pb.ActivityState", error: str = "", detail: str = "") -> None:
         _emit(pb.ActivityUpdate(
@@ -221,6 +239,7 @@ class Activity:
 
     def phase(self, phase: str, step: int = 0, total: int = 0) -> None:
         self._phase, self._step, self._total = phase, step, total
+        self._finish_counters(keep_phase=phase)
         self._report(pb.ActivityState.ACTIVITY_STATE_RUNNING)
 
     def heartbeat(self) -> None:
@@ -357,9 +376,7 @@ def _end(act: Activity) -> None:
     with _lock:
         if _current is act:
             _current = None
-    for c in act._counters:
-        c.finish()
-    act._counters = []
+    act._finish_counters()
 
 
 def current() -> Optional[Activity]:

--- a/src/gen_worker/progress.py
+++ b/src/gen_worker/progress.py
@@ -152,9 +152,15 @@ def freshest() -> Optional[Snapshot]:
 
 
 def self_diagnosis() -> Optional[Snapshot]:
-    """Non-None when EVERY open counter is stale past its own window (i.e.
-    even the freshest one) — the typed self_stalled confession the beat
-    reports so the hub kills on fact, not inference."""
+    """Non-None when even the FRESHEST open counter is stale past its own
+    window — the typed self_stalled confession the beat reports so the hub
+    kills on fact, not inference.
+
+    Registry-wide by design (any advancing counter proves the process is
+    alive), which is why counter LIFETIME has to be honest: a counter left
+    open after its producer's phase ended is the min-age counter of a phase it
+    knows nothing about, and confesses for it. `Activity.counter()` scopes
+    them to the phase for that reason (pgw#962)."""
     fresh = freshest()
     if fresh is not None and fresh.age_s > fresh.window_s:
         return fresh

--- a/tests/test_phase_scoped_counters_pgw962.py
+++ b/tests/test_phase_scoped_counters_pgw962.py
@@ -1,0 +1,117 @@
+"""pgw#962: a counter outlived the phase that fed it, and then confessed.
+
+Counters registered through `Activity.counter()` were finished only when the
+whole ACTIVITY ended. `self_mint_compile` spans load -> warmup_forward ->
+load -> ... for every function on the pod, so `infer:steps` (fed one tick per
+warmup ctx event) and `warmup:jobs` stayed open and frozen for the rest of the
+mint. `progress.self_diagnosis()` is a registry-wide min-age query, so once the
+next phase — which has no counter producer of its own; nothing in the SDK emits
+a `load:` or `compile:` family counter — went quiet, the freshest OPEN counter
+was the dead one, and the beat confessed `self_stalled` about work that had
+already finished successfully.
+
+The hub kills on that confession IMMEDIATELY (`legacyWorkerVerdicts`:
+`case freshest.SelfStalled` fires without waiting out the hub's own window), so
+a false confession destroys a healthy pod mid-load.
+
+Observed in production, `master` stack, 2026-07-29 05:44:00Z, pod
+g9f8f3nycoyueh (L4, gen-worker 0.76.5) — the ONLY self_stalled row in 616
+durable activity rows:
+
+    kind=self_mint_compile phase=load counter=infer:steps counter_done=30
+    self_stalled=t stalled_for_ms=303614
+
+phase `load`, counter `infer:steps`: the confession named a counter belonging
+to a phase that had ended.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import activity, progress
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    progress.reset()
+    yield
+    progress.reset()
+    with activity._lock:
+        activity._sink = None
+        activity._current = None
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def test_a_finished_phases_counter_cannot_confess(monkeypatch):
+    """The production shape, replayed."""
+    clk = _Clock()
+    monkeypatch.setattr(progress, "_now", clk)
+
+    act = activity.begin(activity.KIND_SELF_MINT_COMPILE, activity.PHASE_LOAD)
+    # Warmup forwards run and finish cleanly: 30 ctx events, one per step.
+    act.phase(activity.PHASE_WARMUP_FORWARD, 1, 1)
+    for _ in range(30):
+        act.counter("infer:steps", progress.UNIT_STEPS).add(1)
+        clk.t += 1
+
+    # The mint moves on to the NEXT function's load. That phase has no counter
+    # producer, so nothing new is registered.
+    act.phase(activity.PHASE_LOAD)
+    clk.t += progress.DEFAULT_STALL_WINDOW_S + 5
+
+    assert progress.self_diagnosis() is None, (
+        "a counter whose phase ended must not be able to confess for the "
+        "phase that replaced it")
+
+
+def test_the_current_phases_counter_still_confesses(monkeypatch):
+    """The guard must stay armed for the phase that actually owns a counter —
+    scoping is not a mute button."""
+    clk = _Clock()
+    monkeypatch.setattr(progress, "_now", clk)
+
+    act = activity.begin(activity.KIND_SELF_MINT_COMPILE, activity.PHASE_LOAD)
+    act.phase(activity.PHASE_WARMUP_FORWARD, 1, 4)
+    act.counter("warmup:jobs", progress.UNIT_STEPS, total=4).set_done(1)
+    clk.t += progress.STALL_WINDOW_S["warmup"] + 5
+
+    snap = progress.self_diagnosis()
+    assert snap is not None and snap.name == "warmup:jobs"
+
+
+def test_registry_counters_are_not_phase_scoped(monkeypatch):
+    """`progress.counter()` (the watchdog's `evidence:` counter, the model
+    download counter) deliberately spans phases and owns its own finish() —
+    phase scoping must not touch it, or a long load loses its only signal."""
+    clk = _Clock()
+    monkeypatch.setattr(progress, "_now", clk)
+
+    act = activity.begin(activity.KIND_SELF_MINT_COMPILE, activity.PHASE_LOAD)
+    ev = progress.counter("evidence:self_mint_compile", progress.UNIT_EVIDENCE)
+    ev.set_done(1.0)
+    act.phase(activity.PHASE_WARMUP_FORWARD, 1, 1)
+    clk.t += 5
+    ev.set_done(2.0)
+
+    fresh = progress.freshest()
+    assert fresh is not None and fresh.name == "evidence:self_mint_compile"
+    assert fresh.age_s == 0.0
+
+
+def test_activity_end_still_finishes_everything(monkeypatch):
+    """gw#621's original guarantee is unchanged."""
+    clk = _Clock()
+    monkeypatch.setattr(progress, "_now", clk)
+
+    act = activity.begin(activity.KIND_WARMUP, activity.PHASE_WARMUP_FORWARD)
+    act.counter("warmup:jobs", progress.UNIT_STEPS).set_done(1)
+    act.completed()
+    assert progress.snapshot() == []


### PR DESCRIPTION
## The brief said the guard never fires. It fires — and the one time it fired in production it was wrong.

`worker_activity_events`, `master` stack, 2026-07-29 05:44:00Z, pod `g9f8f3nycoyueh` (L4,
gen-worker 0.76.5) — the **only** `self_stalled` row in 616 durable activity rows (dev: 0 in 1138):

```
kind=self_mint_compile  phase=load  counter=infer:steps  counter_done=30
self_stalled=t  stalled_for_ms=303614
```

Phase `load`, counter `infer:steps`. The confession named a counter belonging to a phase that had
already ended, successfully. The same pod's rows show `self_mint_compile` alternating
`load`/`warmup_forward` with `self_mint_abort` between them for the preceding 28 minutes.

## Cause

`Activity.counter()` scoped a counter's lifetime to the whole ACTIVITY. `self_mint_compile` spans
`load -> warmup_forward -> load` once per function on the pod, so `infer:steps` (and
`warmup:jobs`, `upload:bytes`) stayed **open and frozen** for the rest of the mint.
`progress.self_diagnosis()` is a registry-wide min-age query, and **no producer in the SDK emits a
`load:` or `compile:` family counter** — so once the next phase went quiet, the freshest OPEN
counter was the dead one, and after its own 300 s window the beat confessed.

Whether the false confession fires at all depends on whether an unrelated
`with activity_mod.watchdog(act)` bracket happens to be open, since its `evidence:` counter is
fresher. That is luck, not a design.

**The hub kills on it without waiting out its own window** — `runtimestore/worker_health.go`
`legacyWorkerVerdicts`, `case freshest.SelfStalled:` -> `fireActivityStall`. A healthy pod 300 s
into a long `load` is condemned on evidence about a phase that is over. That is pgw#846 attempt
sixteen's loss class arriving through the mechanism built to prevent it. The typed protocol-v5 path
consumes the same fact as an exclusion (`LastProgressLocked` skips `SelfStalled` activities), so the
pod loses its progress defence there too.

## Change

Counters registered through `Activity.counter()` are **phase-scoped**: `Activity.phase()` finishes
the ones the outgoing phase owned. All three producers re-acquire per tick, so a counter still being
fed is simply re-registered under the new phase. Counters registered directly through
`progress.counter()` — the watchdog's `evidence:` counter, the model-download counter —
deliberately span phases and own their own `finish()`; untouched, which matters because `evidence:`
is the only signal a long `load` has.

`freshest()` is unchanged: liveness stays registry-wide, any advancing counter proves the process is
alive. `self_diagnosis()`'s docstring claimed "EVERY open counter is stale past its own window"; it
has only ever checked the freshest against its own window, and now says so.

## Tests — RED reproduces the production row to the digit

```
assert Snapshot(name='infer:steps', done=30.0, age_s=306.0, window_s=300.0) is None
```

(production: `counter=infer:steps counter_done=30 stalled_for_ms=303614`, window 300 s).

GREEN: `21 passed` with `test_progress_gw621.py` (incl. its end-to-end hub-double confession) and
`test_activity_gw601.py`; `88 passed` across `test_fanin_generation_pgw937.py`,
`test_worker_outbox_pgw869.py`, `test_group_processes_pgw783.py`; full unit suite
`3151 passed, 37 skipped, 1 xfailed` — one `-n 4` load flake
(`test_probe_failure_hub_unreachable_still_exits_without_hanging`, the pgw#955-960 class) which
passes serially and touches nothing this PR changes.

No `pyproject.toml` / `uv.lock` / `fleet-floors.toml` diff.

Tracker: pgw#962. Hub half (the confession `fleet-status` never serialized): th#1602 / tensorhub #835.