### PR TITLE
pgw#967 (pgw#854 / pgw#868 A3): a graph class belongs to a TARGET — the vocabulary gap that made the SDK's own vae.decode default unwritable

### DIFF
--- a/changelog.d/pgw967.md
+++ b/changelog.d/pgw967.md
@@ -1,0 +1,19 @@
+- **pgw#967 (pgw#854 / pgw#868 A3): a graph class belongs to a TARGET, and the
+  two target resolvers now agree.** `Compile` scoped `Input`, `Arg` and `Fork`
+  by target but not `classes`, and `validate_contract` demanded every class row
+  state every declared dim and fork. A family adding a VAE decoder or a text
+  encoder therefore had no way to say what coordinates those targets trace:
+  `mint_plans` handed each target the whole class table, so sdxl's text encoder
+  would have minted 18 identical graphs under 18 entry names and paid for each.
+  That — not policy — is why the SDK's own `("transformer", "vae.decode")`
+  default has never been exercised by a fleet family. `GraphClass.targets` now
+  scopes a row (empty = every target, so nothing re-keys: the field is omitted
+  from `as_row` when absent and `Compile.contract_axes` is byte-identical for
+  every declaration written before it existed), `validate_contract` checks each
+  row against its own targets' dims and forks, and a declared target with no
+  scoped row is refused by name rather than silently dropped from the cell.
+  Separately, `aot_serve._target_owner` partitioned on the FIRST dot and treated
+  the remainder as a plain attribute, so `vae.decoder` resolved to
+  `(pipeline.vae, "decoder")` — the submodule — while the mint resolved the same
+  string to the decoder's `forward`; it now delegates to
+  `compile_cache._resolve_target`, so mint and arm name one callable.

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -83,6 +83,16 @@ CI-SKIPPED tests/test_llama_runtime.py|gpu smoke runs on the nightly gpu ci lane
 # 1000: every /proc read the fix denies is already denied).
 CI-SKIPPED tests/test_pod_privilege_isolation_pgw858.py|pgw#858 is a uid boundary — the containerised row above measures it
 
+# ─── CI-SKIPPED: a host capability the runner HAS, which the row needs absent ──
+# Inverse of the section above, and the only key here whose presence depends on
+# which `ubuntu-latest` machine the run draws: the two pgw#754 rows exercise the
+# genuine-lack refusal, so they skip when the host reports avx512f. GitHub's pool
+# is mixed, so this key is observed on some runs and absent on others (PRs #490
+# and #492 did not see it; #491 did, an hour later, on the same base). Classified
+# rather than left to the draw — an unclassified key that appears on a coin flip
+# fails an unrelated PR, which is what it did.
+CI-SKIPPED tests/test_host_isa_pgw754.py|host has avx-#; the genuine-lack refusal needs a host without it
+
 # ─── CI-SKIPPED: third-party availability ─────────────────────────────────────
 # Degrades to a counted skip, never a red: an unreachable third party may not
 # fail a required check.

--- a/src/gen_worker/aot_declaration.py
+++ b/src/gen_worker/aot_declaration.py
@@ -196,12 +196,27 @@ def effective_shape_strategy(decl: Compile) -> str:
     return str(decl.shape_strategy or "")
 
 
+def target_classes(decl: Compile, target: str) -> Tuple[GraphClass, ...]:
+    """The graph classes declared for one target (pgw#967).
+
+    An unscoped row serves every target — the pre-scoping rule — so a
+    single-target family reads exactly as it always did.
+    """
+    return tuple(cls for cls in decl.classes if cls.serves(target))
+
+
 def mint_plans(decl: Compile, target: str) -> Tuple[MintPlan, ...]:
     """Every artifact the declaration says to mint for one target."""
     if not decl.classes:
         raise MintRefused(
             f"family {decl.family!r} declares no graph classes — there is "
             f"no coordinate to mint")
+    classes = target_classes(decl, target)
+    if not classes:
+        raise MintRefused(
+            f"family {decl.family!r} declares target {target!r} but no graph "
+            f"class scoped to it — every target states its own coordinates "
+            f"(pgw#967), and a target with none has nothing to mint")
     strategy = effective_shape_strategy(decl)
     if not strategy:
         raise MintRefused(
@@ -210,12 +225,12 @@ def mint_plans(decl: Compile, target: str) -> Tuple[MintPlan, ...]:
             f"({STATIC_ROWS!r} for conv-bearing families, "
             f"{DYNAMIC_COLLAPSE!r} for DiTs); declare it")
     groups: Dict[Tuple[Tuple[str, Any], ...], List[GraphClass]] = {}
-    for cls in decl.classes:
+    for cls in classes:
         groups.setdefault(cls.fork, []).append(cls)
 
     plans: List[MintPlan] = []
     if strategy == STATIC_ROWS:
-        for cls in decl.classes:
+        for cls in classes:
             plans.append(MintPlan(
                 family=decl.family, target=target, fork=cls.fork,
                 rows=(cls,), seed=cls, dynamic=()))

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -91,6 +91,7 @@ from .compile_cache import (
     AdoptError,
     CompiledExecutionLaneUnavailableError,
     _clean_tarinfo,
+    _resolve_target,
     parse_cell_ref,
     sku_slug,
 )
@@ -1965,15 +1966,26 @@ def set_ingress_refusal_callback(pipeline: Any, callback: Any) -> bool:
 def _target_owner(pipeline: Any, target: str) -> Tuple[Any, str]:
     """``(owner module, attribute)`` one entry target names on a pipeline:
     ``"unet"`` -> ``(pipeline.unet, "forward")``; ``"vae.decode"`` ->
-    ``(pipeline.vae, "decode")``."""
-    owner_name, _, attr = str(target).partition(".")
-    module = getattr(pipeline, owner_name, None)
-    if module is None:
-        raise AdoptError("no_target", f"pipeline has no module {owner_name!r}")
-    attr = attr or "forward"
-    if not callable(getattr(module, attr, None)):
+    ``(pipeline.vae, "decode")``; ``"vae.decoder"`` ->
+    ``(pipeline.vae.decoder, "forward")``.
+
+    pgw#967: this delegates to ``compile_cache._resolve_target`` — ONE
+    resolver, because the two disagreed on a dotted target whose leaf is a
+    MODULE. This function partitioned on the FIRST dot and treated the rest
+    as a plain attribute, so ``vae.decoder`` resolved to
+    ``(pipeline.vae, "decoder")`` and the arm would have replaced a
+    SUBMODULE with a wrapped function, while the mint resolved the same
+    string to the decoder's ``forward`` and exported that. A cell whose
+    entries are traced from one callable and armed onto another is the
+    silent-wrongness class every gate in this stack exists to prevent, and
+    nothing would have caught it: ``vae.decode`` (a bound method) is the
+    only dotted target any family has ever named, and for it the two agreed.
+    """
+    resolved = _resolve_target(pipeline, str(target))
+    if resolved is None:
         raise AdoptError(
-            "no_target", f"module {owner_name!r} has no callable {attr!r}")
+            "no_target", f"pipeline has no callable target {target!r}")
+    module, attr, _fn = resolved
     return module, attr
 
 

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -41,6 +41,7 @@ from typing import (
     Dict,
     Mapping,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -372,10 +373,24 @@ class GraphClass(msgspec.Struct, frozen=True):
     Accepts mappings at construction (``GraphClass(fork={...}, dims={...})``,
     the LTX §2.3 draft form) and normalizes to sorted pairs, so instances
     are hashable and endpoint generators can dedupe with ``dict.fromkeys``.
+
+    ``targets`` scopes the row, exactly as it does on :class:`Input`,
+    :class:`Arg` and :class:`Fork`; empty means every target (pgw#967). A
+    cell's targets are unrelated modules with unrelated call contracts —
+    sdxl's UNet traces 9 aspect rows x 2 CFG arms, its VAE decoder traces
+    the 9 aspect rows at batch 1 (CFG has collapsed by decode time), and its
+    two text encoders trace ONE row each (77 tokens, batch 1, both
+    aspect- and CFG-invariant). Without scoping, ``mint_plans`` hands every
+    target the whole class table, so declaring a text encoder alongside the
+    denoiser would mint 18 identical text-encoder graphs under 18 different
+    entry names and pay for each. That is why the SDK's own
+    ``("transformer", "vae.decode")`` default has never been exercised by a
+    fleet family: it was not expressible, only payable.
     """
 
     dims: Any
     fork: Any = ()
+    targets: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         force = msgspec.structs.force_setattr
@@ -388,6 +403,7 @@ class GraphClass(msgspec.Struct, frozen=True):
                     f"GraphClass dim {name!r} has non-positive value {value!r}")
         force(self, "dims", tuple((n, int(v)) for n, v in dims))
         force(self, "fork", _sorted_pairs("fork", "GraphClass", self.fork))
+        force(self, "targets", tuple(str(t).strip() for t in self.targets))
 
     @property
     def dim_map(self) -> Dict[str, int]:
@@ -397,8 +413,21 @@ class GraphClass(msgspec.Struct, frozen=True):
     def fork_map(self) -> Dict[str, ForkValue]:
         return dict(self.fork)
 
+    def serves(self, target: str) -> bool:
+        """Whether this row is one of ``target``'s coordinates."""
+        return not self.targets or str(target) in self.targets
+
     def as_row(self) -> Dict[str, Any]:
-        return {"dims": dict(self.dims), "fork": dict(self.fork)}
+        row: Dict[str, Any] = {"dims": dict(self.dims), "fork": dict(self.fork)}
+        # pgw#846 discipline: an absent field is OMITTED, so every
+        # declaration written before this vocabulary existed serialises
+        # byte-identically and no published cell re-keys on the SDK change
+        # alone (`Compile.contract_axes` feeds the cell key's contract
+        # digest). A declaration that ADOPTS scoping re-keys, correctly: it
+        # is a different class set.
+        if self.targets:
+            row["targets"] = list(self.targets)
+        return row
 
 
 class Input(msgspec.Struct, frozen=True):
@@ -539,6 +568,59 @@ class Arg(msgspec.Struct, frozen=True):
         return row
 
 
+def _carrier_names(
+    inputs: Tuple[Input, ...], args: Tuple[Arg, ...], targets: Sequence[str],
+) -> set:
+    """Every name a dim may be carried by, for the given target scope."""
+    names: set = set()
+    for target in targets:
+        for inp in inputs:
+            if not inp.targets or target in inp.targets:
+                names.add(inp.name)
+                names.add(inp.top_name)
+        for arg in args:
+            if arg.template is not None and (not arg.targets or target in arg.targets):
+                names.add(arg.name)
+    return names
+
+
+def dims_for_targets(
+    dims: Tuple[Dim, ...],
+    inputs: Tuple[Input, ...],
+    args: Tuple[Arg, ...],
+    targets: Sequence[str],
+) -> set:
+    """The dim NAMES a target-scoped graph class must state (pgw#967).
+
+    A dim belongs to a target when one of its ``carried_by`` bindings names
+    an :class:`Input` (or a templated :class:`Arg`) that target declares.
+    That relation is already written down — deriving it beats adding a
+    second place for an endpoint to say the same thing and drift.
+
+    Unscoped rows, and any declaration carrying no input templates, keep the
+    original rule: every row states every declared dim.
+    """
+    all_names = {d.name for d in dims}
+    if not targets or not inputs:
+        return all_names
+    known = _carrier_names(inputs, args, targets)
+    scoped: set = set()
+    for d in dims:
+        for bound, _axis in d.carried_by:
+            if bound in known or bound.split(".", 1)[0] in known:
+                scoped.add(d.name)
+                break
+    return scoped
+
+
+def forks_for_targets(forks: Tuple[Fork, ...], targets: Sequence[str]) -> set:
+    """The fork NAMES a target-scoped graph class must state (pgw#967)."""
+    if not targets:
+        return {f.name for f in forks}
+    want = set(targets)
+    return {f.name for f in forks if not f.targets or (set(f.targets) & want)}
+
+
 def validate_contract(compile_decl: Any) -> None:
     """Cross-validate the #739 declaration fields on a ``Compile``.
 
@@ -583,6 +665,12 @@ def validate_contract(compile_decl: Any) -> None:
             raise DeclarationError(
                 f"{type(row).__name__} {row.name!r} names target(s) {bad!r} "
                 f"not in Compile.targets {list(targets)!r}")
+    for i, cls in enumerate(classes):
+        bad = sorted(set(cls.targets) - set(targets))
+        if bad:
+            raise DeclarationError(
+                f"graph class #{i} names target(s) {bad!r} not in "
+                f"Compile.targets {list(targets)!r}")
 
     if classes and not dims:
         raise DeclarationError(
@@ -596,7 +684,12 @@ def validate_contract(compile_decl: Any) -> None:
         if cls in seen:
             raise DeclarationError(f"Compile.classes repeats row #{i}: {cls.as_row()!r}")
         seen.add(cls)
-        missing = sorted(set(dim_names) - set(cls.dim_map))
+        # pgw#967: a row scoped to a target states that TARGET's dims and
+        # forks. An unscoped row states all of them — the original rule,
+        # unchanged for every declaration written before scoping existed.
+        want_dims = dims_for_targets(dims, inputs, args, cls.targets)
+        want_forks = forks_for_targets(forks, cls.targets)
+        missing = sorted(want_dims - set(cls.dim_map))
         if missing:
             raise DeclarationError(
                 f"graph class #{i} omits declared dim(s) {missing!r}")
@@ -604,11 +697,18 @@ def validate_contract(compile_decl: Any) -> None:
         if unknown:
             raise DeclarationError(
                 f"graph class #{i} carries undeclared dim(s) {unknown!r}")
+        extra = sorted(set(cls.dim_map) - want_dims)
+        if extra:
+            raise DeclarationError(
+                f"graph class #{i} is scoped to target(s) {list(cls.targets)!r} "
+                f"and carries dim(s) {extra!r} that no input those targets "
+                f"declare can carry — a coordinate the traced call cannot "
+                f"receive is not a coordinate")
         # The omitted-fork refusal (#739 red test): a coordinate that varies
         # on a flag the vocabulary does not declare would be silently
         # exported into one class; a declared flag a coordinate does not
         # state is the same defect read the other way.
-        missing_f = sorted(set(fork_names) - set(cls.fork_map))
+        missing_f = sorted(want_forks - set(cls.fork_map))
         if missing_f:
             raise DeclarationError(
                 f"graph class #{i} omits declared fork(s) {missing_f!r} — "
@@ -620,6 +720,13 @@ def validate_contract(compile_decl: Any) -> None:
                 f"graph class #{i} carries fork(s) {unknown_f!r} that "
                 f"Compile.forks does not declare — declare the forking flag "
                 f"by name rather than silently exporting into one class")
+        extra_f = sorted(set(cls.fork_map) - want_forks - set(unknown_f))
+        if extra_f:
+            raise DeclarationError(
+                f"graph class #{i} is scoped to target(s) {list(cls.targets)!r} "
+                f"and carries fork(s) {extra_f!r} that Compile.forks scopes "
+                f"to other targets — a fork the target does not take splits "
+                f"its entries on nothing")
         for name, value in cls.fork:
             if value in unserved_by_fork.get(name, set()):
                 raise DeclarationError(

--- a/tests/test_target_scoped_classes_pgw967.py
+++ b/tests/test_target_scoped_classes_pgw967.py
@@ -1,0 +1,385 @@
+"""pgw#967 — a graph class belongs to a TARGET, not to the whole cell.
+
+pgw#854 recorded that no fleet family compiles anything but its denoiser and
+that the SDK's own ``("transformer", "vae.decode")`` default is exercised by
+nobody. This module pins the reason, which is not policy: until now the
+vocabulary could not EXPRESS a second target's coordinates.
+
+``Compile`` scopes ``Input``, ``Arg`` and ``Fork`` by target but not
+``classes``, and ``validate_contract`` required every class row to state every
+declared dim and fork. So a family adding its VAE decoder or text encoders had
+exactly two options, both wrong: declare one flat class table and have
+``mint_plans`` hand all of it to every target (sdxl: 18 identical text-encoder
+graphs under 18 entry names, each compiled and paid for), or declare dims the
+text encoder cannot receive.
+
+Red-verified against the pre-change tree:
+
+- the sdxl-shaped three-target declaration raises ``DeclarationError`` at
+  construction ("graph class #18 omits declared dim(s) ['H_lat', 'W_lat']"),
+  so the entry-count assertions below could not even be reached;
+- with the row-scope check removed but scoping honoured nowhere, every target
+  gets 18 plans and the totals below fail.
+
+The unscoped path is pinned too, because it is what protects every published
+cell: a declaration that does not scope must serialise byte-identically, or
+``Compile.contract_axes`` re-keys artifacts that did not change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import aot_declaration
+from gen_worker.api.decorators import Compile
+from gen_worker.api.export_contract import (
+    Arg,
+    DeclarationError,
+    Dim,
+    Fork,
+    GraphClass,
+    Input,
+)
+
+_TEXT_LEN = 77
+_VAE_SCALE = 8
+
+#: sdxl's declared payload bucket table (ie#345), trimmed to three rows — the
+#: arithmetic under test is per-row, not per-table.
+_ASPECT_ROWS: tuple[tuple[int, int], ...] = ((1216, 832), (1024, 1024), (832, 1216))
+
+
+def _sdxl_shaped(scoped: bool) -> Compile:
+    """An sdxl-shaped declaration over three targets with unrelated call
+    contracts: the UNet (aspect x CFG), the VAE decoder (aspect only — CFG has
+    collapsed into one latent by decode time) and a CLIP text encoder (neither
+    — 77 tokens at batch 1, whatever the request asks for)."""
+    unet_scope = ("unet",) if scoped else ()
+    vae_scope = ("vae.decode",) if scoped else ()
+    te_scope = ("text_encoder",) if scoped else ()
+
+    classes: list[GraphClass] = []
+    for w, h in _ASPECT_ROWS:
+        for cfg, batch in ((True, 2), (False, 1)):
+            classes.append(GraphClass(
+                dims={"B": batch, "H_lat": h // _VAE_SCALE,
+                      "W_lat": w // _VAE_SCALE, "T_txt": _TEXT_LEN},
+                fork={"cfg": cfg}, targets=unet_scope))
+    for w, h in _ASPECT_ROWS:
+        classes.append(GraphClass(
+            dims={"B_img": 1, "H_lat": h // _VAE_SCALE, "W_lat": w // _VAE_SCALE},
+            targets=vae_scope))
+    classes.append(GraphClass(dims={"B_txt": 1, "T_txt": _TEXT_LEN}, targets=te_scope))
+
+    return Compile(
+        family="sdxl-shaped",
+        targets=("unet", "vae.decode", "text_encoder"),
+        text_len=_TEXT_LEN,
+        shapes=_ASPECT_ROWS,
+        dims=(
+            Dim("B", carried_by=(("sample", 0), ("encoder_hidden_states", 0))),
+            Dim("H_lat", carried_by=(("sample", 2), ("z", 2)), multiple_of=8),
+            Dim("W_lat", carried_by=(("sample", 3), ("z", 3)), multiple_of=8),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),
+                                     ("input_ids", 1))),
+            Dim("B_img", carried_by=(("z", 0),)),
+            Dim("B_txt", carried_by=(("input_ids", 0),)),
+        ),
+        forks=(Fork("cfg", served=(True, False), targets=("unet",),
+                    why="CFG is ONE batch-2 forward; the decoder sees one latent"),),
+        classes=tuple(classes),
+        inputs=(
+            Input("sample", shape=("B", 4, "H_lat", "W_lat"), targets=("unet",)),
+            Input("timestep", shape=(), value=1.0, targets=("unet",)),
+            Input("encoder_hidden_states", shape=("B", "T_txt", 2048),
+                  targets=("unet",)),
+            Input("z", shape=("B_img", 4, "H_lat", "W_lat"), targets=("vae.decode",)),
+            Input("input_ids", shape=("B_txt", "T_txt"), dtype="int64",
+                  targets=("text_encoder",)),
+        ),
+        args=(Arg("return_dict", False, targets=("unet", "vae.decode")),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    )
+
+
+def test_each_target_mints_only_its_own_coordinates() -> None:
+    """The count IS the finding: 6 + 3 + 1, not 10 + 10 + 10."""
+    decl = _sdxl_shaped(scoped=True)
+
+    assert len(aot_declaration.mint_plans(decl, "unet")) == 6
+    assert len(aot_declaration.mint_plans(decl, "vae.decode")) == 3
+    assert len(aot_declaration.mint_plans(decl, "text_encoder")) == 1
+
+    plans = aot_declaration.cell_plans(decl)
+    assert len(plans) == 10
+    names = {aot_declaration.plan_entry_name(p) for p in plans}
+    assert "text_encoder/B_txt=1,T_txt=77" in names
+    assert "vae.decode/B_img=1,H_lat=128,W_lat=128" in names
+    assert "unet/cfg=true/B=2,H_lat=128,T_txt=77,W_lat=128" in names
+    # No target inherits another's fork: the decoder and the encoder carry no
+    # `cfg=` segment at all, so neither pays for a second arm of a flag it
+    # does not take.
+    assert not [n for n in names if n.startswith(("vae.", "text_")) and "cfg=" in n]
+
+
+def test_unscoped_declaration_is_unchanged_and_serialises_identically() -> None:
+    """The no-re-key guarantee. A declaration that does not scope keeps the
+    old rule (every row states every dim and fork) and emits no `targets` key,
+    so `Compile.contract_axes` — which feeds the cell key's contract digest —
+    is byte-identical to what it was before scoping existed."""
+    row = GraphClass(dims={"B": 2, "T_txt": 77}, fork={"cfg": True})
+    assert row.as_row() == {"dims": {"B": 2, "T_txt": 77}, "fork": {"cfg": True}}
+    assert row.serves("anything")
+
+    decl = Compile(
+        family="single-target",
+        targets=("unet",),
+        text_len=77,
+        shapes=((1024, 1024),),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 1}), GraphClass(dims={"B": 2})),
+        inputs=(Input("sample", shape=("B", 4, 128, 128)),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    )
+    assert "targets" not in decl.contract_axes()["classes"][0]
+    assert len(aot_declaration.mint_plans(decl, "unet")) == 2
+
+
+def test_a_scoped_row_may_not_carry_a_dim_its_target_cannot_receive() -> None:
+    """The check that makes scoping a contract rather than a comment: the text
+    encoder takes `input_ids` only, so a latent-spatial coordinate on its row
+    describes a call it can never be handed."""
+    with pytest.raises(DeclarationError, match=r"carries dim\(s\) \['H_lat'\]"):
+        Compile(
+            family="bad-scope",
+            targets=("unet", "text_encoder"),
+            text_len=77,
+            shapes=((1024, 1024),),
+            dims=(
+                Dim("B", carried_by=(("sample", 0),)),
+                Dim("H_lat", carried_by=(("sample", 2),), multiple_of=8),
+                Dim("B_txt", carried_by=(("input_ids", 0),)),
+            ),
+            classes=(
+                GraphClass(dims={"B": 2, "H_lat": 128}, targets=("unet",)),
+                GraphClass(dims={"B_txt": 1, "H_lat": 128},
+                           targets=("text_encoder",)),
+            ),
+            inputs=(
+                Input("sample", shape=("B", 4, "H_lat", 128), targets=("unet",)),
+                Input("input_ids", shape=("B_txt", 77), dtype="int64",
+                      targets=("text_encoder",)),
+            ),
+            shape_strategy="static-rows",
+            warm_changes_key=False,
+        )
+
+
+def test_a_target_with_no_class_row_is_refused_by_name() -> None:
+    """A declared target nobody gave coordinates to is a declaration defect,
+    not an empty plan list that silently drops the target from the cell."""
+    decl = Compile(
+        family="orphan-target",
+        targets=("unet", "vae.decode"),
+        text_len=77,
+        shapes=((1024, 1024),),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}, targets=("unet",)),),
+        inputs=(Input("sample", shape=("B", 4, 128, 128), targets=("unet",)),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    )
+    with pytest.raises(aot_declaration.MintRefused, match="no graph class scoped"):
+        aot_declaration.cell_plans(decl)
+
+
+def test_a_class_row_may_not_name_an_undeclared_target() -> None:
+    with pytest.raises(DeclarationError, match=r"names target\(s\) \['vae.decode'\]"):
+        Compile(
+            family="unknown-target",
+            targets=("unet",),
+            text_len=77,
+            shapes=((1024, 1024),),
+            dims=(Dim("B", carried_by=(("sample", 0),)),),
+            classes=(GraphClass(dims={"B": 2}, targets=("vae.decode",)),),
+            inputs=(Input("sample", shape=("B", 4, 128, 128)),),
+            shape_strategy="static-rows",
+            warm_changes_key=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# One resolver. The mint and the arm must name the same callable.
+# ---------------------------------------------------------------------------
+
+
+def test_mint_and_arm_resolve_a_dotted_module_target_to_the_same_callable() -> None:
+    """RED on the pre-change tree: ``aot_serve._target_owner`` partitioned on
+    the FIRST dot, so ``vae.decoder`` resolved to ``(vae, "decoder")`` — the
+    submodule ATTRIBUTE — while ``compile_cache._resolve_target`` resolved the
+    same string to ``(decoder, "forward")``. Arming would have replaced a
+    submodule with a function on a graph traced from a different callable.
+
+    ``vae.decoder`` is not hypothetical: it is the only SDXL VAE target that is
+    declarable at all. ``vae.decode`` is wrapped by diffusers'
+    ``apply_forward_hook``, whose ``wrapper(self, *args, **kwargs)`` carries no
+    ``functools.wraps``, so its signature is irrecoverable and the traced
+    callable would bake away both the tiling dispatch and the accelerate-hook
+    branch.
+    """
+    torch = pytest.importorskip("torch")
+    from gen_worker import aot_serve
+    from gen_worker.compile_cache import _resolve_target
+
+    class _Decoder(torch.nn.Module):
+        def forward(self, sample):  # type: ignore[no-untyped-def]
+            return sample
+
+    class _Vae(torch.nn.Module):
+        def __init__(self):  # type: ignore[no-untyped-def]
+            super().__init__()
+            self.decoder = _Decoder()
+
+        def decode(self, z):  # type: ignore[no-untyped-def]
+            return self.decoder(z)
+
+    class _Pipe:
+        def __init__(self):  # type: ignore[no-untyped-def]
+            self.vae = _Vae()
+            self.unet = _Decoder()
+
+    pipe = _Pipe()
+    for target in ("unet", "vae.decode", "vae.decoder"):
+        mint = _resolve_target(pipe, target)
+        assert mint is not None
+        arm_module, arm_attr = aot_serve._target_owner(pipe, target)
+        assert (arm_module, arm_attr) == (mint[0], mint[1]), target
+        assert getattr(arm_module, arm_attr) == mint[2]
+
+    assert aot_serve._target_owner(pipe, "vae.decoder")[0] is pipe.vae.decoder
+
+
+# ---------------------------------------------------------------------------
+# The proposed sdxl declaration, exactly — proven constructible here because
+# the endpoint pins `gen-worker==0.91.4` and cannot carry it until this ships.
+# ---------------------------------------------------------------------------
+
+#: mirrors sdxl/src/sdxl/main.py `_SDXL_ASPECT_RATIOS` (ie#345 payload buckets)
+_SDXL_ASPECTS: tuple[tuple[int, int], ...] = (
+    (1536, 640), (1344, 768), (1216, 832), (1152, 896), (1024, 1024),
+    (896, 1152), (832, 1216), (768, 1344), (640, 1536),
+)
+
+
+def _sdxl_with_decoder() -> Compile:
+    """sdxl's live declaration plus its VAE DECODER — the exact proposal.
+
+    ``vae.decoder``, not ``vae.decode``:
+
+    * ``AutoencoderKL.decode`` is wrapped by diffusers'
+      ``apply_forward_hook``, whose ``wrapper(self, *args, **kwargs)`` carries
+      no ``functools.wraps``. Its signature is irrecoverably ``(*args,
+      **kwargs)``, so pgw#822's pre-flight name check — the gate that exists
+      so a pod is never rented to learn a sentence — is VACUOUS on it.
+    * That wrapper is also where ``self._hf_hook.pre_forward(self)`` is
+      called, and where ``_decode`` dispatches to ``tiled_decode``. Exporting
+      through it bakes both branches away at trace time.
+    * ``vae.decoder`` is the raw ``Decoder`` module: a real named signature
+      (``forward(sample, latent_embeds=None)``), a plain-Tensor return, no
+      hook, no dispatch. Tiling still works — ``tiled_decode`` calls
+      ``self.decoder`` per tile, at tile shapes the cell does not declare, so
+      an offloaded pod misses the entry and degrades to eager observably
+      instead of serving a graph that skipped its own onload.
+
+    No TEXT ENCODER target. Under the pinned ``transformers>=5.13,<6``,
+    ``CLIPTextModel.forward`` is ``(input_ids, attention_mask, position_ids,
+    **kwargs)`` returning ``BaseModelOutputWithPooling``. The SDXL pipeline
+    needs ``output_hidden_states=True`` (it reads ``hidden_states[-2]``),
+    which is expressible only as a KEYWORD — against the all-positional mint
+    obligation — and there is no ``return_dict`` parameter left to escape the
+    dataclass output with. ``CLIPTextTransformer`` was flattened away in v5,
+    so there is no inner named-signature module to target either. Two
+    independent structural blockers, for the smallest of the three prizes.
+    """
+    classes: list[GraphClass] = []
+    for w, h in _SDXL_ASPECTS:
+        for cfg, batch in ((True, 2), (False, 1)):
+            classes.append(GraphClass(
+                dims={"B": batch, "H_lat": h // _VAE_SCALE,
+                      "W_lat": w // _VAE_SCALE, "T_txt": _TEXT_LEN},
+                fork={"cfg": cfg}, targets=("unet",)))
+    for w, h in _SDXL_ASPECTS:
+        # CFG has collapsed by decode time: one latent, whatever the guidance.
+        classes.append(GraphClass(
+            dims={"B": 1, "H_lat": h // _VAE_SCALE, "W_lat": w // _VAE_SCALE},
+            targets=("vae.decoder",)))
+
+    return Compile(
+        family="sdxl",
+        targets=("unet", "vae.decoder"),
+        text_len=_TEXT_LEN,
+        shapes=_SDXL_ASPECTS,
+        dims=(
+            Dim("B", carried_by=(("sample", 0), ("encoder_hidden_states", 0),
+                                 ("added_cond_kwargs.text_embeds", 0),
+                                 ("added_cond_kwargs.time_ids", 0))),
+            Dim("H_lat", carried_by=(("sample", 2),), multiple_of=8),
+            Dim("W_lat", carried_by=(("sample", 3),), multiple_of=8),
+            Dim("T_txt", carried_by=(("encoder_hidden_states", 1),)),
+        ),
+        forks=(Fork("cfg", served=(True, False), targets=("unet",),
+                    why="CFG is ONE batch-2 forward (ie#345); turbo pins the "
+                        "no-CFG batch-1 graph. The DECODER never forks on it"),),
+        classes=tuple(classes),
+        inputs=(
+            Input("sample", shape=("B", ("config", "in_channels"), "H_lat", "W_lat"),
+                  targets=("unet",)),
+            Input("timestep", shape=(), value=1.0, targets=("unet",)),
+            Input("encoder_hidden_states",
+                  shape=("B", "T_txt", ("config", "cross_attention_dim")),
+                  targets=("unet",)),
+            Input("added_cond_kwargs.text_embeds", shape=("B", 1280),
+                  targets=("unet",)),
+            Input("added_cond_kwargs.time_ids", shape=("B", 6), targets=("unet",)),
+            # Decoder.forward(sample, latent_embeds=None); `latent_embeds` is
+            # the temporal-decoder argument SDXL never passes.
+            Input("sample", shape=("B", ("config", "in_channels"), "H_lat", "W_lat"),
+                  targets=("vae.decoder",)),
+        ),
+        # `Decoder.forward` has no `return_dict` parameter — the UNet's escape
+        # is the UNet's alone.
+        args=(Arg("return_dict", False, targets=("unet",)),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+        numerics_floor=0.995,
+        numerics_warn=0.999,
+    )
+
+
+def test_the_proposed_sdxl_declaration_costs_nine_entries_not_eighteen() -> None:
+    """A4's bill, exactly: the cell goes 36 -> 45 entries, +25%.
+
+    36 = 18 UNet classes x 2 adapter arms (pgw#790's branchless/lora64 fork,
+    synthesized by the SDK). The decoder is not lift-capable, so it forks into
+    nothing and contributes its 9 rows once. Without row scoping it would
+    contribute 18 — nine of them duplicate graphs under distinct entry names,
+    each one a full compile paid for a second time.
+    """
+    decl = _sdxl_with_decoder()
+    unet = aot_declaration.mint_plans(decl, "unet")
+    dec = aot_declaration.mint_plans(decl, "vae.decoder")
+    assert len(unet) == 18
+    assert len(dec) == 9
+    assert all(p.dynamic == () for p in (*unet, *dec))
+    assert len(aot_declaration.cell_plans(decl)) == 27
+
+    names = {aot_declaration.plan_entry_name(p) for p in dec}
+    assert names == {
+        f"vae.decoder/B=1,H_lat={h // 8},W_lat={w // 8}"
+        for w, h in _SDXL_ASPECTS
+    }
+    # Every declared aspect the payload enum admits, and nothing else: the
+    # decoder's coordinate set IS the shape bucket table (ie#345).
+    assert len(names) == len(_SDXL_ASPECTS)


### PR DESCRIPTION
Enabling half of the TE/VAE compile-scope question (pgw#854, under pgw#868 A3). **No mint, no GPU, nothing rented.** The endpoint-side declaration is specified in the tracker issue and cannot land until this ships — `inference-endpoints/sdxl` pins `gen-worker==0.91.4`.

## What was actually wrong

`Compile` scopes `Input`, `Arg` and `Fork` by target but **not** `classes`, and `validate_contract` required every class row to state every declared dim and every declared fork. A family naming a second target with a different call contract therefore had two options, both wrong: declare one flat class table and let `mint_plans` hand all of it to every target, or declare dims that target can never receive.

For sdxl the first option means the text encoder mints **18 identical graphs under 18 entry names**, each a full compile paid for. That — not policy — is why the SDK's own `("transformer", "vae.decode")` default has never been exercised by a fleet family. It was never refused; it was unaffordable.

## The change

* `GraphClass.targets` scopes a row. Empty means every target, which is the pre-existing rule, so **every declaration written before this is unchanged**. `as_row` omits the field when absent, so `Compile.contract_axes` — which feeds the cell key's contract digest — stays byte-identical and no published cell re-keys on the SDK change alone. A declaration that *adopts* scoping re-keys, correctly: it is a different class set.
* The dim scope is **derived, not declared twice**: a dim belongs to a target when one of its `carried_by` bindings names an `Input` (or templated `Arg`) that target declares. That relation is already written down.
* Three new refusals, each by name: a scoped row carrying a dim no input of its targets can carry; a scoped row carrying a fork scoped to other targets; a declared target with no scoped class row (previously an empty plan list that silently dropped the target from the cell).
* `aot_serve._target_owner` partitioned on the **first** dot and treated the remainder as a plain attribute, so `vae.decoder` resolved to `(pipeline.vae, "decoder")` — the submodule — while `compile_cache._resolve_target` resolved the same string to the decoder's `forward`. Arming would have replaced a submodule with a function, on a graph traced from a different callable. Nothing would have caught it: `vae.decode` is the only dotted target any family has ever named, and for a bound method the two agreed. One resolver now.

## Why `vae.decoder` and not `vae.decode`

`AutoencoderKL.decode` is wrapped by diffusers' `apply_forward_hook`, whose `wrapper(self, *args, **kwargs)` carries no `functools.wraps` — its signature is irrecoverably `(*args, **kwargs)`, so pgw#822's pre-flight name check (the gate whose entire purpose is to avoid renting a pod to learn a sentence) is **vacuous** on it. That same wrapper is where `self._hf_hook.pre_forward(self)` is called and where `_decode` dispatches to `tiled_decode`; exporting through it freezes both branches at trace time. `vae.decoder` is the raw `Decoder`: named signature, plain-Tensor return, no hook, no dispatch.

## Tests

`tests/test_target_scoped_classes_pgw967.py`, 7 rows, **red-verified against `origin/dev` — all 7 fail there**, including the resolver row with the exact `_Vae(...) != _Decoder()` divergence. The last row builds the **exact proposed sdxl declaration** and proves 18 UNet + 9 decoder plans (cell 36 -> 45 entries, +25%; without scoping it would have been 90).

Ruff and mypy clean on the touched modules. `tests/test_aot_declaration_pgw739.py`, `test_export_contract_pgw739.py`, `test_declaration_containers_pgw853.py`, `test_declaration_cannot_break_serving_pgw853.py`, `test_registry_contract_pgw740.py`: 83 passed. `test_aot_multigraph_pgw758.py`: 24 passed **serially**; that suite is not xdist-safe on either tree (`origin/dev` errors 9 of its rows under `-n 2` — pre-existing, not from this change).