### PR TITLE
pgw#969: a path is not a resolution — the delegated mint child gets the parent's slot BINDINGS

### DIFF
--- a/changelog.d/pgw969.md
+++ b/changelog.d/pgw969.md
@@ -1,0 +1,40 @@
+- **pgw#969: the delegated mint child carries the parent's RESOLVED slot
+  bindings, not just its snapshot paths.** Measured twice on two independent
+  RunPod L40S pods 80 minutes apart (release `50ff5bdf5ace8a075fbe6255`, sdxl
+  `v0.2.30+gecc868d7`, gen-worker 0.92.1): the child loaded in 9.49 s / 10.69 s
+  and died **0.0 s into `warmup_forward`**, exit 1, deterministic, at
+  `sdxl/main.py:316` — `ValueError: slot 'pipeline': no resolved model ref for
+  this request`. `MintRequest` carried `snapshots` (slot -> local tree) and
+  nothing else about the resolution. A path says which BYTES to load; only a
+  binding says which CHECKPOINT the request is for, and `ctx.slots` is built
+  from bindings. The child re-runs discovery, so its `spec.models` holds only
+  what `@endpoint` declared — and sdxl's slot is
+  `Slot(StableDiffusionXLPipeline, selected_by="model")` with no
+  `default_checkpoint=`, which declares nothing at all. The parent now records
+  the binding beside every path it materializes (`_setup_locked_inner`), and it
+  rides `_BackgroundMint` -> `MintTask` -> `MintRequest.slot_bindings` ->
+  `mint_child.bind_slots`. Whole `ModelRef`, so the pick's flavor,
+  `storage_dtype` and pgw#617 component overrides cross with it; applied to the
+  whole class-scoped sibling set, because `instance_key` is a live property over
+  `spec.models`. Not an ordering problem and not a serialisation gap — a field
+  the handoff struct never had.
+
+- **pgw#969: a code `default_checkpoint=` was never a substitute for the
+  parent's pick.** The quiet half of the same defect: a catalog slot that DOES
+  carry a declared ref resolved fine in the child — to the declared checkpoint,
+  while the parent serves the hub's — so the mint traced graphs for a model the
+  pod never runs and the crash class became a silent-wrongness class. This is
+  also why pgw#828's regression test was green on a shape that cannot exhibit
+  either: its harness endpoint declares `default_checkpoint=`. The new harness
+  endpoint is the production shape.
+
+- **pgw#969: a mint that cannot resolve a slot now says which mint, and refuses
+  before it reads a weight.** A wiring gap is deterministic, so it exits
+  `EXIT_REFUSED` (terminal on the first attempt) instead of exiting 1 as a crash
+  the parent retries — a second billed pod for the same sentence. The refusal
+  names family, cell key, lane, function, the slot, and what the request DID
+  carry; a bound slot that still fails to resolve is reported as divergence
+  rather than as the same wire gap. `warmup.warm_context(origin=…)` prefixes the
+  same identity onto deferred `ctx.slots[...]` errors on both mint paths, so a
+  residual failure no longer has to be reconstructed from a truncated activity
+  row plus a DB read.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2824,6 +2824,13 @@ class _BackgroundMint:
     # component's files from the base fetch, so `snapshot_paths` alone names
     # a narrowed tree (`<digest>__x<fp>`) that no loader can open.
     component_paths: Dict[str, Dict[str, str]] = dc_field(default_factory=dict)
+    # pgw#969: and the FOURTH — slot -> the RESOLVED ModelRef behind that
+    # path. `snapshot_paths` says which bytes to load; `ctx.slots` is built
+    # from bindings, and the child re-runs discovery, so a hub-catalog slot
+    # (no code `default_checkpoint=`) rediscovers NOTHING. Its warm request
+    # reached the endpoint's own handler unbound and died at
+    # `ctx.slots["pipeline"]` 0.0s into `warmup_forward`.
+    slot_bindings: Dict[str, ModelRef] = dc_field(default_factory=dict)
     # th#1299: WHY this mint was asked to stop. The abort event used to report
     # "(adopt-on-arm / vacate / shutdown)" — three unrelated causes in one
     # string — so a mint that died could not be told from a mint that was
@@ -2832,6 +2839,17 @@ class _BackgroundMint:
     # handler; a code (queryable) and the human sentence beside it.
     abandon_code: str = "unspecified"
     abandon_reason: str = ""
+
+
+def _mint_origin(bg: "_BackgroundMint", spec: EndpointSpec) -> str:
+    """WHICH mint a warm context belongs to (pgw#969), for the deferred
+    slot-resolution errors it may raise. The delegated child's twin is
+    ``mint_child.mint_identity``; both exist because ``ValueError: slot
+    'pipeline': no resolved model ref`` named a symptom and no mint."""
+    keys = sorted({str(getattr(p, "cell_key", "")) for p in bg.pendings.values()})
+    return (
+        f"in-process mint fn={spec.name!r} "
+        f"key={(keys[0] if len(keys) == 1 else keys) or '(none)'!r}")
 
 
 def _mint_modules(spec: EndpointSpec) -> Tuple[str, ...]:
@@ -6720,6 +6738,10 @@ class Executor:
         }
         slot_identities: Dict[str, _ResidencyIdentity] = {}
         paths: Dict[str, str] = {}
+        # pgw#969: the BINDING behind each of those paths, kept in step with
+        # `paths` by construction — the two are one resolution, and a mint
+        # child handed only the paths cannot say which checkpoint they are.
+        slot_bindings: Dict[str, ModelRef] = {}
         # pgw#617: component-override materializations, slot -> comp -> local
         # path, plus per-override-ref snapshot digests (identity facts).
         component_paths: Dict[str, Dict[str, str]] = {}
@@ -6736,6 +6758,7 @@ class Executor:
             materialized = await self.store._materialize_local(
                 ref, snap, binding=binding)
             paths[slot] = str(materialized.path)
+            slot_bindings[slot] = binding
             slot_identities[slot] = materialized.identity
             for comp, comp_ref in _component_overrides(binding):
                 try:
@@ -6992,6 +7015,7 @@ class Executor:
                     selections=mint_selections,
                     modules=_mint_modules(spec),
                     snapshot_paths=dict(paths),
+                    slot_bindings=dict(slot_bindings),
                     component_paths={
                         slot: dict(comps)
                         for slot, comps in component_paths.items() if comps
@@ -9703,7 +9727,10 @@ class Executor:
                     wj.spec, request_id=f"bg-mint-{wj.spec.name}",
                     local_output_dir=tmp,
                     execution_lane=self._served_execution_lane(wj.spec),
-                    config=self._effective_config(wj.spec))
+                    config=self._effective_config(wj.spec),
+                    # pgw#969: the in-process mint is a mint too — a slot that
+                    # cannot resolve here must say which one it killed.
+                    origin=_mint_origin(bg, wj.spec))
                 if preemptible:
                     bg.seed_ctx = ctx
                     # Registration race: demand that arrived after the turn
@@ -10050,6 +10077,7 @@ class Executor:
                     function=spec.name,
                     modules=bg.modules or _mint_modules(spec),
                     snapshots=dict(bg.snapshot_paths),
+                    slot_bindings=dict(bg.slot_bindings),
                     component_paths={
                         slot: dict(comps)
                         for slot, comps in bg.component_paths.items()

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -17,10 +17,18 @@ What it does, and why in this order
    this is what makes that reservation an ENFORCED bound instead of a hope.
    A child that wants more OOMs ITSELF — a failed mint reported by a live
    worker — rather than stealing the peak out from under a live request.
-3. **Load the endpoint's own pipeline**, through ``cli.run.run_setup``: the
+3. **Install the parent's RESOLVED slot bindings** (pgw#969) onto the specs
+   this process rediscovered, before a weight is read. Rediscovery yields
+   only what ``@endpoint`` DECLARED, and a hub-catalog slot
+   (``Slot(selected_by=...)`` with no ``default_checkpoint=``) declares
+   nothing — so without this the endpoint's own handler reaches
+   ``ctx.slots["pipeline"]`` unbound and the mint dies 0.0 s into
+   ``warmup_forward``. A request that still cannot resolve a declared slot
+   REFUSES here, by name, rather than nine seconds later inside the endpoint.
+4. **Load the endpoint's own pipeline**, through ``cli.run.run_setup``: the
    endpoint's real ``setup()``/``warmup()``, the production ``provision``
    loader, the same already-materialized weights on local disk. No network.
-4. **Arm COLD and drive the endpoint's OWN derived warm plan** — never
+5. **Arm COLD and drive the endpoint's OWN derived warm plan** — never
    ``mint_artifact``'s producer-style ``_compile_and_warm``. That distinction
    is gw#586/gw#587's whole lesson: a synthetic single-stage warm call can
    trace DIFFERENT FX graphs than a conditioned/two-stage endpoint's real
@@ -28,7 +36,7 @@ What it does, and why in this order
    So the child runs ``warmup.plan`` over the same sibling spec set the parent
    would have, through the endpoint's own handler. Same code, same shapes,
    same seal — a different PROCESS, not a different execution.
-5. **Pack** with ``finish_fleet_mint`` and write a typed report.
+6. **Pack** with ``finish_fleet_mint`` and write a typed report.
 
 The parity claim is checked, not asserted
 -----------------------------------------
@@ -241,6 +249,96 @@ def select_specs(
     return chosen, siblings
 
 
+def mint_identity(request: MintRequest) -> str:
+    """One sentence naming WHICH mint a message belongs to (pgw#969).
+
+    A mint child holds no orchestrator session, so its only channel is the
+    text of whatever it raises. ``ValueError: slot 'pipeline': no resolved
+    model ref`` named a symptom and no mint: family, cell key, lane and
+    function all had to be reconstructed from a truncated activity row plus a
+    DB read before anyone could say which of a pod's cells had died.
+    """
+    return (
+        f"mint family={request.family!r} key={request.cell_key!r} "
+        f"lane={request.execution_lane or '(unset)'!r} "
+        f"fn={request.function!r} recipe={request.recipe!r}")
+
+
+def bind_slots(specs: Sequence[Any], bindings: Mapping[str, Any]) -> None:
+    """Install the PARENT's resolved slot bindings onto rediscovered specs.
+
+    The child re-runs discovery in a fresh interpreter, so ``spec.models``
+    comes back holding only what ``@endpoint`` declared. For a hub-catalog
+    slot — ``Slot(cls, selected_by="model")`` with no ``default_checkpoint=``,
+    which is sdxl's shape and every multi-checkpoint family's — the decorator
+    declares no ref at all, and the resolution chain then has nothing to
+    resolve: ``ctx.slots["pipeline"]`` raises before a graph is traced.
+
+    Applied to the WHOLE sibling set, never one spec: ``instance_key`` is a
+    live property over ``spec.models``, so binding the chosen function alone
+    would move its key out from under its siblings and silently narrow the
+    class-scoped warm plan (pgw#654) to one lane.
+    """
+    if not bindings:
+        return
+    for spec in specs:
+        for slot, binding in bindings.items():
+            if slot in spec.slots or slot in spec.models:
+                spec.models[slot] = binding
+
+
+def assert_slots_resolvable(
+    specs: Sequence[Any], request: MintRequest,
+) -> None:
+    """pgw#969: refuse a request whose slots cannot resolve — before the load.
+
+    Two distinct failures, both named rather than deferred to a handler's
+    first dereference nine seconds later:
+
+    * the parent sent no binding for a declared, non-optional slot (the wire
+      gap this issue exists for), and
+    * a slot the parent DID bind still fails the resolution chain here, which
+      is real divergence between the two processes and never a normal path.
+
+    An OPTIONAL slot the parent did not bind is deliberately silent: the
+    parent's own warm context resolves it exactly this way (the deploy chose
+    not to serve that lane), and refusing here would refuse a mint the parent
+    can serve.
+    """
+    from . import warmup as warmup_mod
+
+    bound = set(request.slot_bindings)
+    problems: List[str] = []
+    for spec in specs:
+        missing = sorted(
+            name for name, slot in spec.slots.items()
+            if name not in bound
+            and name not in spec.models
+            and not getattr(slot, "optional", False)
+        )
+        for name in missing:
+            problems.append(
+                f"slot {name!r} of {spec.name!r}: the parent sent no resolved "
+                f"binding for it and the endpoint declares no "
+                f"default_checkpoint, so this child has no checkpoint to "
+                f"trace (MintRequest.slot_bindings carries "
+                f"{sorted(bound) or '(nothing)'})")
+        errors = warmup_mod.resolved_slots_kwargs(spec, None)["slot_errors"]
+        for name, why in sorted(errors.items()):
+            if name in bound:
+                problems.append(
+                    f"slot {name!r} of {spec.name!r}: the parent's binding "
+                    f"{getattr(request.slot_bindings.get(name), 'path', '')!r} "
+                    f"crossed but does not resolve in this process — {why}")
+    if not problems:
+        return
+    raise MintChildRefused(
+        f"{mint_identity(request)}: cannot build the warmup request — "
+        + "; ".join(problems)
+        + ". A mint cannot trace a graph for a pipeline it was never told "
+          "to load.")
+
+
 def assert_composable(
     snapshots: Dict[str, str], overrides: Dict[str, Dict[str, str]],
 ) -> None:
@@ -307,7 +405,10 @@ def _warm_jobs(specs: Sequence[Any]) -> List[Any]:
     return jobs
 
 
-def _run_warm_job(instance: Any, job: Any, config: Dict[str, Any], execution_lane: str) -> None:
+def _run_warm_job(
+    instance: Any, job: Any, config: Dict[str, Any], execution_lane: str,
+    origin: str = "",
+) -> None:
     """One warm forward through the endpoint's OWN handler.
 
     Mirrors the executor's ``_invoke_warmup`` (bound handler, ctx+payload
@@ -330,7 +431,8 @@ def _run_warm_job(instance: Any, job: Any, config: Dict[str, Any], execution_lan
         # nothing.
         ctx = warmup.warm_context(
             spec, request_id=f"mint-child-{spec.name}",
-            local_output_dir=tmp, execution_lane=execution_lane, config=config)
+            local_output_dir=tmp, execution_lane=execution_lane, config=config,
+            origin=origin)
         bound = getattr(instance, spec.attr_name)
         kwargs = {spec.ctx_param: ctx, spec.payload_param: payload}
         if spec.is_async_gen:
@@ -629,6 +731,10 @@ def mint(request: MintRequest) -> MintReport:
     frame(phase="load", note=f"discover {list(request.modules)}")
     specs = collect_endpoints(list(request.modules))
     spec, siblings = select_specs(specs, request.function)
+    # pgw#969: the parent's resolution, installed on the rediscovered specs
+    # BEFORE anything is loaded — and the refusal, if it cannot be.
+    bind_slots(siblings, request.slot_bindings)
+    assert_slots_resolvable(siblings, request)
     cfg = compile_cfg(request.cfg)
 
     frame(phase="load", note=(
@@ -690,7 +796,7 @@ def mint(request: MintRequest) -> MintReport:
             note=job.spec.name)
         _run_warm_job(
             instance, job, dict(request.configs.get(job.spec.name) or {}),
-            request.execution_lane)
+            request.execution_lane, origin=mint_identity(request))
     frame(phase="inductor_compile", note="draining any queued compiles")
     _drain_router(pipe)
 
@@ -818,5 +924,6 @@ if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
 
 
-__all__ = ["MintChildRefused", "assert_composable", "cap_vram", "compile_cfg",
-           "frame", "main", "mint", "select_specs"]
+__all__ = ["MintChildRefused", "assert_composable", "assert_slots_resolvable",
+           "bind_slots", "cap_vram", "compile_cfg", "frame", "main",
+           "mint_identity", "mint", "select_specs"]

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -101,6 +101,11 @@ class MintTask:
     # fetched with these components EXCLUDED (th#1330 B2), so a child handed
     # only `snapshots` is handed a tree that cannot load.
     component_paths: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    # pgw#969: and the FOURTH — the resolved binding behind each of those
+    # paths. `snapshots` names bytes; only a binding names a checkpoint, and
+    # `ctx.slots` is built from bindings. Resolved by the parent in
+    # `_setup_locked_inner`, in the same loop that produced `snapshots`.
+    slot_bindings: Dict[str, Any] = field(default_factory=dict)
     weight_lane: str = ""
     execution_lane: str = ""
     configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
@@ -197,6 +202,7 @@ def build_request(
         resume=str(aot_resume.bank_root(pending.cell_key)),
         cfg=cfg_spec(pending.cfg),
         snapshots=dict(task.snapshots),
+        slot_bindings=dict(task.slot_bindings),
         component_paths={
             slot: dict(comps)
             for slot, comps in task.component_paths.items() if comps

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -70,6 +70,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
+from .api.binding import ModelRef
 from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
@@ -176,6 +177,24 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     report: str          # typed terminal report the child writes
     cfg: CompileCellSpec
     snapshots: Dict[str, str] = {}
+    #: pgw#969: the parent's RESOLVED per-slot bindings, slot -> ModelRef —
+    #: the same objects ``spec.models`` held when the parent materialized
+    #: ``snapshots`` above, so the two halves of one resolution travel
+    #: together.
+    #:
+    #: A path says which BYTES to load; a binding says which CHECKPOINT the
+    #: request is for, and only the second one reaches ``ctx.slots``. The
+    #: child re-runs discovery, so its ``spec.models`` holds only what the
+    #: DECORATOR declared — and a hub-catalog slot (``Slot(selected_by=...)``
+    #: with no ``default_checkpoint=``, which is the sdxl shape) declares
+    #: nothing at all. Its warmup request therefore reached the endpoint's own
+    #: handler with the slot unbound and died at ``ctx.slots["pipeline"]``
+    #: 0.0 s into ``warmup_forward``, twice, on two independent L40S pods.
+    #:
+    #: A slot WITH a code default is the quieter half of the same defect: the
+    #: child would resolve the DECLARED checkpoint while the parent serves the
+    #: hub's pick, and trace graphs for a model this pod never runs.
+    slot_bindings: Dict[str, ModelRef] = {}
     #: pgw#816: slot -> component -> the OVERRIDE component's own local tree
     #: (pgw#617 hierarchical bindings). A directory path alone does not
     #: describe the composition: th#1330 B2 EXCLUDES an overridden

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -863,6 +863,7 @@ def warm_context(
     local_output_dir: str,
     execution_lane: str = "",
     config: Optional[Mapping[str, Any]] = None,
+    origin: str = "",
 ) -> Any:
     """The ``RequestContext`` a WARM forward runs under — one construction.
 
@@ -883,15 +884,28 @@ def warm_context(
     It lives in ``warmup`` rather than in ``executor`` on purpose: the child
     already derives its warm plan from here, and it must never import the
     executor's whole arming brain to build a context.
+
+    ``origin`` (pgw#969) names the warm this context belongs to and is
+    prefixed onto every deferred slot-resolution error, so a handler's
+    ``ctx.slots[...]`` failure says WHICH warm it killed. A mint child holds
+    no orchestrator session; the text it raises is its only channel, and
+    ``ValueError: slot 'pipeline': no resolved model ref`` named a symptom
+    and no mint.
     """
     from .api.binding import wire_ref
     from .request_context import RequestContext
 
+    slot_kwargs = resolved_slots_kwargs(spec, None)
+    if origin:
+        slot_kwargs["slot_errors"] = {
+            name: f"{origin}: {why}"
+            for name, why in slot_kwargs["slot_errors"].items()
+        }
     ctx: Any = RequestContext(
         request_id=str(request_id),
         local_output_dir=local_output_dir,
         models={slot: wire_ref(b) for slot, b in spec.models.items()},
-        **resolved_slots_kwargs(spec, None),
+        **slot_kwargs,
         boot_warmup=True,
     )
     if execution_lane:

--- a/tests/harness/mint_catalog_slot_pgw969.py
+++ b/tests/harness/mint_catalog_slot_pgw969.py
@@ -1,0 +1,84 @@
+"""pgw#969: the sdxl SHAPE — a hub-CATALOG slot with no code default.
+
+``sdxl/main.py`` declares::
+
+    models={"pipeline": Slot(StableDiffusionXLPipeline, selected_by="model")}
+
+No ``default_checkpoint=``. Every checkpoint it serves is a hub-catalog row,
+so the decorator declares no ref at all and ``spec.models`` is EMPTY until the
+parent binds it from the hub's pick.
+
+pgw#828's harness endpoint (``WarmSlotEndpoint``) carries
+``default_checkpoint=WARM_SLOT_PIPELINE``, which is why its regression test
+was green on a shape that cannot exhibit this defect: a declared ref survives
+rediscovery in the mint child, a catalog pick does not.
+
+Two handlers on ONE class, like sdxl's ``generate``/``generate-turbo``: the
+warm plan is class-scoped (pgw#654), and ``instance_key`` is a live property
+over ``spec.models`` — so a fix that bound the invoked function alone would
+move its key out from under its sibling and silently narrow the mint.
+
+This module is deliberately isolated (the ``toy_endpoints_slot_only``
+precedent): the mint child walks ``request.modules`` and re-runs discovery
+over it, so what else lives beside it is part of the test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import msgspec
+
+from gen_worker import RequestContext, Resources, Slot, endpoint
+from gen_worker.api.binding import wire_ref
+from gen_worker.families.base import GenerationDefaults, family
+
+
+@family("harness-pgw969-catalog")
+class CatalogDefaults(GenerationDefaults, frozen=True):
+    steps: int = 5
+
+
+class CatalogIn(msgspec.Struct):
+    text: str = ""
+    #: the ``selected_by="model"`` branch field
+    model: str = ""
+
+
+class CatalogOut(msgspec.Struct):
+    response: str
+
+
+#: One entry per handler call, base and turbo alike: the wire ref the
+#: RESOLVED slot carried. The parent's serving path and the mint child's warm
+#: forward both write here, which is what makes "the same checkpoint" an
+#: assertion rather than a claim.
+RESOLVED_REFS: List[str] = []
+
+
+def _ref_of(ctx: RequestContext[CatalogDefaults]) -> str:
+    wire = wire_ref(ctx.slots["pipeline"].ref)
+    RESOLVED_REFS.append(wire)
+    return wire
+
+
+@endpoint(
+    models={"pipeline": Slot(str, selected_by="model")},
+    resources=Resources(gpu=True),
+)
+class CatalogSlotEndpoint:
+    def setup(self, pipeline: str) -> None:
+        self.pipeline_path = pipeline
+
+    def catalog_generate(
+        self, ctx: RequestContext[CatalogDefaults], data: CatalogIn,
+    ) -> CatalogOut:
+        wire = _ref_of(ctx)
+        weights = Path(self.pipeline_path) / "weights.txt"
+        return CatalogOut(response=f"{wire}|{weights.read_text()}")
+
+    def catalog_generate_turbo(
+        self, ctx: RequestContext[CatalogDefaults], data: CatalogIn,
+    ) -> CatalogOut:
+        return CatalogOut(response=f"turbo|{_ref_of(ctx)}")

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -1,0 +1,407 @@
+"""pgw#969 — the delegated mint child gets the parent's RESOLVED slot refs.
+
+Measured twice, on two independent RunPod L40S pods, ~80 minutes apart
+(release ``50ff5bdf5ace8a075fbe6255``, sdxl ``v0.2.30+gecc868d7``, gen-worker
+0.92.1, ``torch=2.13.0+cu130``). The child loaded the pipeline in 9.49 s /
+10.69 s and then died **0.0 s into ``warmup_forward``**, exit 1,
+self-classified ``deterministic``, with the same traceback both times::
+
+    site-packages/sdxl/main.py", line 316, in generate
+        resolved = ctx.slots["pipeline"]
+      File ".../gen_worker/request_context/__init__.py", line 115, in __getitem__
+        raise ValueError(self._errors[key])
+    ValueError: slot 'pipeline': no resolved model ref for this request
+                 (no Slot(default_checkpoint=...) and no hub resolution)
+
+    jit_compile aborted status=crashed phases={'load': 10.689, 'warmup_forward': 0.0}
+
+**The mechanism.** ``MintRequest`` carries ``snapshots`` — slot -> local
+tree — and nothing else about the resolution. A path says which BYTES to
+load; only a binding says which CHECKPOINT the request is for, and
+``ctx.slots`` is built from bindings. The child re-runs discovery in a fresh
+interpreter, so its ``spec.models`` holds only what ``@endpoint`` declared,
+and sdxl's slot is a hub-catalog slot::
+
+    models={"pipeline": Slot(StableDiffusionXLPipeline, selected_by="model")}
+
+— no ``default_checkpoint=``, so rediscovery yields ``spec.models == {}`` and
+the resolution chain has nothing to resolve. Not an ordering problem (the
+parent resolved these long before the spawn) and not a serialisation gap
+(``ModelRef`` is already a ``msgspec.Struct``): a field the handoff struct
+never had.
+
+**Why pgw#828's regression test could not have caught it.** That fix removed a
+child ctx with *no slots at all*; its harness endpoint declares
+``default_checkpoint=WARM_SLOT_PIPELINE``, and a declared ref survives
+rediscovery. The production shape — a catalog slot — has none. The endpoint
+under test here is that shape, and it is also the *quiet* half of the same
+defect: a catalog slot WITH a code default would have resolved in the child,
+to the DECLARED checkpoint, while the parent serves the hub's pick — a mint
+tracing graphs for a model this pod never runs (``JuggleEndpoint`` below).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import mint_child, mint_delegate, registry, warmup
+from gen_worker import mint_process as mp
+from gen_worker.api.binding import ModelRef, wire_ref
+from gen_worker.cli import run as cli_run
+from gen_worker.executor import _BackgroundMint, _hub_binding_for_wire_ref
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import CompileCell
+
+from harness import mint_catalog_slot_pgw969 as catalog
+from harness.blob_host import BlobHost
+from harness.hub_double import hub_double, is_ready, is_result_for
+
+CATALOG_MODULE = "harness.mint_catalog_slot_pgw969"
+#: The hub's pick for this dispatch. Nothing in the endpoint's code names it.
+PICK_REF = wire_ref(_hub_binding_for_wire_ref("harness/catalog-pick:prod"))
+GIB = 1 << 30
+
+
+# ---------------------------------------------------------------------------
+# The parent half: one REAL dispatch that binds the catalog slot and serves it
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def served(tmp_path: Path) -> Tuple[Path, ModelRef]:
+    """Run one real dispatch through the real executor and the real CAS
+    downloader; return the materialized tree and the binding behind it.
+
+    This is where the parent's resolution comes from — not a hand-built
+    ``ModelRef``. The endpoint declares no checkpoint, so a served response
+    naming ``PICK_REF`` proves the binding is the hub's and the parent's.
+    """
+    cli_run._INJECTED_CACHE.clear()
+    catalog.RESOLVED_REFS.clear()
+    cache_dir = tmp_path / "cas"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    blobs = BlobHost(tmp_path)
+    try:
+        snap = blobs.snapshot("snap-catalog-pick", [
+            blobs.file("w", b"pick-weights", path_in_snapshot="weights.txt"),
+        ])
+        with hub_double(
+            modules=(CATALOG_MODULE,), cache_dir=cache_dir,
+        ) as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(run_job=pb.RunJob(
+                request_id="r-969", attempt=1,
+                function_name="catalog-generate",
+                input_payload=msgspec.msgpack.encode(catalog.CatalogIn()),
+                models=[pb.ModelBinding(slot="pipeline", ref=PICK_REF)],
+                snapshots={PICK_REF: snap},
+            ))
+            res = conn.wait_for(is_result_for("r-969")).job_result
+        assert res.status == pb.JOB_STATUS_OK, res.safe_message
+        served_out = msgspec.msgpack.decode(res.inline, type=catalog.CatalogOut)
+    finally:
+        blobs.shutdown()
+
+    assert served_out.response == f"{PICK_REF}|pick-weights", served_out
+    # Both the parent's boot warm and its served dispatch land here.
+    assert set(catalog.RESOLVED_REFS) == {PICK_REF}, (
+        "the PARENT must resolve the catalog slot to the hub's pick")
+
+    trees = sorted(
+        p for p in (cache_dir / "cas" / "snapshots").iterdir() if p.is_dir())
+    assert len(trees) == 1, trees
+    cli_run._INJECTED_CACHE.clear()
+    catalog.RESOLVED_REFS.clear()
+    # The binding the executor itself mints for a hub-picked slot ref — the
+    # same call `_slot_dispatch_binding` made to serve the dispatch above.
+    return trees[0], _hub_binding_for_wire_ref(PICK_REF)
+
+
+def _request(
+    tree: Path, binding: Any, tmp_path: Path, *, function: str = "catalog-generate",
+) -> mp.MintRequest:
+    """The child's request, built through the REAL parent chain and
+    round-tripped through msgspec — the boundary IS a file."""
+    pending = SimpleNamespace(
+        family="pgw969", cell_key="ck5-catalog", recipe="dynamo",
+        cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
+                        family="pgw969", regional=False, text_len=77,
+                        dynamic=(), lora_bucket=0, guidance_scales=(),
+                        text_lens=()),
+        capture_dir=tmp_path / "capture", target=tmp_path / "cell.tar.gz",
+        mint_root=tmp_path)
+    bg = _BackgroundMint(
+        spec=SimpleNamespace(name=function), instance=object(), snapshots=None,
+        pendings={}, pipes={}, selections={},
+        modules=(CATALOG_MODULE,),
+        snapshot_paths={"pipeline": str(tree)},
+        slot_bindings=({"pipeline": binding} if binding is not None else {}),
+    )
+    task = mint_delegate.MintTask(
+        pending=pending, pipe=object(), function=function,
+        modules=bg.modules, snapshots=dict(bg.snapshot_paths),
+        slot_bindings=dict(bg.slot_bindings),
+        component_paths={}, execution_lane="w8a8-lora64", device=-1)
+    request = mint_delegate.build_request(
+        task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
+    return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
+
+
+def _child_specs(request: mp.MintRequest) -> Tuple[Any, List[Any]]:
+    """Exactly what ``mint_child.mint`` does before it reads a weight:
+    rediscover, select the class-scoped sibling set, install the parent's
+    bindings, and refuse if they cannot resolve."""
+    specs = registry.collect_endpoints(list(request.modules))
+    chosen, siblings = mint_child.select_specs(specs, request.function)
+    mint_child.bind_slots(siblings, request.slot_bindings)
+    mint_child.assert_slots_resolvable(siblings, request)
+    return chosen, siblings
+
+
+# ---------------------------------------------------------------------------
+# 1. The pod's crash, at the frame it happened at
+# ---------------------------------------------------------------------------
+
+
+def test_a_rediscovered_catalog_slot_carries_no_ref_at_all() -> None:
+    """The whole defect in one assertion, and the reason a path is not enough.
+
+    Green before and after the fix: rediscovery cannot invent a checkpoint
+    the decorator never named. That is precisely why the binding has to
+    cross.
+    """
+    specs = registry.collect_endpoints([CATALOG_MODULE])
+    for spec in specs:
+        assert spec.slots["pipeline"] is not None
+        assert spec.models == {}, (
+            "a catalog slot declares no ref; only the parent has one")
+
+
+def test_the_production_traceback_reproduced(tmp_path: Path) -> None:
+    """The pod's sentence, byte-for-byte, from an unbound warm context — the
+    exact ``_run_warm_job`` -> handler -> ``ctx.slots`` frame that crashed."""
+    spec = next(
+        s for s in registry.collect_endpoints([CATALOG_MODULE])
+        if s.name == "catalog-generate")
+    instance = spec.cls()
+    instance.pipeline_path = str(tmp_path)
+    job = next(j for j in mint_child._warm_jobs([spec])
+               if j.spec.name == spec.name)
+    with pytest.raises(ValueError) as exc:
+        mint_child._run_warm_job(instance, job, {}, "w8a8-lora64")
+    assert "slot 'pipeline': no resolved model ref for this request" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. The fix, end to end: parent dispatch -> wire -> child -> warm forward
+# ---------------------------------------------------------------------------
+
+
+def test_the_child_warms_the_checkpoint_THE_PARENT_SERVED(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """RED at HEAD. The child's own warm forward, through the endpoint's own
+    handler, on the tree a real dispatch materialized — and it must resolve
+    the SAME checkpoint the parent answered that dispatch with.
+
+    Not "resolves something": the ref is compared against what the serving
+    path recorded, because a child that traced a different checkpoint would
+    pack a cell the parent's proof then misses (pgw#815's silent class).
+    """
+    tree, binding = served
+    request = _request(tree, binding, tmp_path)
+    chosen, siblings = _child_specs(request)
+
+    instance = chosen.cls()
+    loaded = cli_run.run_setup(
+        instance, dict(request.snapshots), arm_compile=False,
+        return_loaded=True) or {}
+    assert loaded["pipeline"] == str(tree)
+
+    catalog.RESOLVED_REFS.clear()
+    for job in mint_child._warm_jobs(siblings):
+        mint_child._run_warm_job(
+            instance, job, {}, request.execution_lane,
+            origin=mint_child.mint_identity(request))
+
+    assert catalog.RESOLVED_REFS, "the child ran no warm forward at all"
+    assert set(catalog.RESOLVED_REFS) == {PICK_REF}, (
+        "the child must trace the parent's checkpoint, not a rediscovered one")
+
+
+def test_both_siblings_are_bound_so_the_warm_plan_stays_class_scoped(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """``instance_key`` is a live property over ``spec.models``. Binding the
+    invoked function alone would move its key out from under its sibling and
+    narrow a class-scoped mint (pgw#654) to one lane — silently."""
+    tree, binding = served
+    request = _request(tree, binding, tmp_path)
+    chosen, siblings = _child_specs(request)
+
+    assert {s.name for s in siblings} == {
+        "catalog-generate", "catalog-generate-turbo"}
+    keys = {s.instance_key for s in siblings}
+    assert len(keys) == 1, "the sibling set must still share ONE instance key"
+    for spec in siblings:
+        assert wire_ref(spec.models["pipeline"]) == PICK_REF
+
+
+def test_the_binding_crosses_the_wire_whole(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """Identity, not just a path string: source, tag, flavor, storage dtype
+    and the pgw#617 component overrides all ride the same struct, so the
+    child cannot be handed a narrowed half of a resolution again."""
+    tree, binding = served
+    binding = msgspec.structs.replace(
+        binding, flavor="fp8", storage_dtype="fp8",
+        component_overrides=(("vae", "harness/override-vae:prod"),))
+    request = _request(tree, binding, tmp_path)
+    assert request.slot_bindings["pipeline"] == binding
+    _chosen, siblings = _child_specs(request)
+    assert siblings[0].models["pipeline"].storage_dtype == "fp8"
+    assert siblings[0].models["pipeline"].component_overrides == (
+        ("vae", "harness/override-vae:prod"),)
+
+
+# ---------------------------------------------------------------------------
+# 3. A child that still cannot resolve a slot says WHICH mint, and refuses
+#    before it reads a weight
+# ---------------------------------------------------------------------------
+
+
+def test_an_unbound_required_slot_refuses_by_name_before_the_load(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """The honest-failure half. ``ValueError: slot 'pipeline': no resolved
+    model ref`` named a symptom and no mint: family, key, lane and function
+    all had to be reconstructed from a truncated activity row plus a DB read.
+    """
+    tree, _binding = served
+    request = _request(tree, None, tmp_path)
+    with pytest.raises(mint_child.MintChildRefused) as exc:
+        _child_specs(request)
+    text = str(exc.value)
+    for fact in ("pgw969", "ck5-catalog", "w8a8-lora64", "catalog-generate",
+                 "'pipeline'", "sent no resolved binding"):
+        assert fact in text, f"{fact!r} missing from: {text}"
+
+
+def test_the_refusal_is_the_childs_terminal_word_on_a_real_subprocess(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """The real entrypoint: ``python -m gen_worker.mint_child request.json``,
+    spawned by the parent's real supervisor, against a request whose slot
+    binding is missing.
+
+    RED at HEAD — the child got as far as the endpoint's handler and exited
+    ``1`` (a CRASH the parent retries once, burning a second pod) with a bare
+    ``ValueError``. A wiring gap is deterministic, so it must be
+    ``EXIT_REFUSED``: terminal on the first attempt, and the report must name
+    the mint.
+    """
+    tree, _binding = served
+    request = _request(tree, None, tmp_path)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(Path(__file__).resolve().parent), env.get("PYTHONPATH", "")])
+    outcome = asyncio.run(mp.run_mint(
+        request, workdir=tmp_path / "w", python=sys.executable, env=env))
+
+    assert outcome.status == mp.REFUSED, (
+        f"{outcome.status}: {outcome.detail or outcome.stderr_tail}")
+    assert outcome.exit_code == mp.EXIT_REFUSED
+    report = outcome.report
+    assert report is not None and report.status == "refused"
+    for fact in ("pgw969", "ck5-catalog", "'pipeline'", "catalog-generate"):
+        assert fact in report.detail, f"{fact!r} missing from: {report.detail}"
+    # The refusal precedes every side effect the CHILD could have: it wrote no
+    # artifact, and it never reached the toolchain probe or a weight.
+    assert not Path(request.target).exists()
+    assert "warmup_forward" not in report.phases, (
+        "the refusal must land before the endpoint's own handler runs — "
+        f"phases={report.phases}")
+
+
+def test_a_bound_slot_that_still_fails_names_the_divergence(
+    tmp_path: Path,
+) -> None:
+    """The other half of the refusal: the parent's binding DID cross and the
+    child still cannot resolve it. That is real divergence between the two
+    processes, never a normal path, and it must not read like the wire gap
+    above."""
+    request = _request(
+        tmp_path, ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
+        tmp_path)
+    request = msgspec.structs.replace(
+        request, slot_bindings={"nonexistent-slot": ModelRef(
+            source="tensorhub", path="harness/pick", tag="prod")})
+    with pytest.raises(mint_child.MintChildRefused) as exc:
+        _child_specs(request)
+    assert "sent no resolved binding" in str(exc.value)
+    assert "nonexistent-slot" in str(exc.value), (
+        "the refusal must show what the parent DID send")
+
+
+# ---------------------------------------------------------------------------
+# 4. The quiet half: a code default is not a substitute for a resolution
+# ---------------------------------------------------------------------------
+
+
+def test_a_code_default_never_stands_in_for_the_parents_pick(
+    tmp_path: Path,
+) -> None:
+    """``JuggleEndpoint`` is the catalog shape WITH a ``default_checkpoint=``.
+    Before this fix such a child resolved — to the DECLARED repo — while the
+    parent served the hub's pick, so the mint traced graphs for a checkpoint
+    the pod never runs and the crash class became a silent-wrongness class.
+    """
+    from harness import toy_endpoints as toy
+
+    declared = wire_ref(toy.JUGGLE_DECLARED)
+    picked = ModelRef(source="tensorhub", path="harness/juggle-pick", tag="prod")
+    specs = registry.collect_endpoints(["harness.toy_endpoints"])
+    chosen, siblings = mint_child.select_specs(specs, "juggle-echo")
+    assert wire_ref(chosen.models["pipeline"]) == declared
+
+    mint_child.bind_slots(siblings, {"pipeline": picked})
+    with __import__("tempfile").TemporaryDirectory() as tmp:
+        ctx = warmup.warm_context(
+            chosen, request_id="mint-child-x", local_output_dir=tmp)
+    assert wire_ref(ctx.slots["pipeline"].ref) == wire_ref(picked)
+    assert wire_ref(ctx.slots["pipeline"].ref) != declared
+
+
+# ---------------------------------------------------------------------------
+# 5. The structural pin: the parent RECORDS what it resolved
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_is_empty_not_absent() -> None:
+    """A hub-less or slotless boot must still produce a well-formed request."""
+    bg = _BackgroundMint(
+        spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
+        pendings={}, pipes={}, selections={})
+    assert bg.slot_bindings == {}
+
+
+def test_the_paths_and_the_bindings_travel_together(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """One resolution, two halves. Every slot the parent materialized a tree
+    for must arrive with the binding that named it — a request carrying one
+    without the other is the shape this issue exists to make impossible."""
+    tree, binding = served
+    request = _request(tree, binding, tmp_path)
+    assert set(request.snapshots) == set(request.slot_bindings)
+    assert wire_ref(request.slot_bindings["pipeline"]) == PICK_REF


### PR DESCRIPTION
## The defect, measured twice

Two independent RunPod L40 pods, 80 minutes apart, release `50ff5bdf5ace8a075fbe6255`
(sdxl `v0.2.30+gecc868d7`, gen-worker 0.92.1, `torch=2.13.0+cu130`). Both loaded and both died
**0.0 s into `warmup_forward`**, exit 1, self-classified `deterministic`, same file, same line,
same cell key:

```
kind=jit_compile     aborted  attempt=1 status=crashed total_s=10.77
                              phases={'load': 10.689, 'warmup_forward': 0.0}
site-packages/sdxl/main.py", line 316, in generate
    resolved = ctx.slots["pipeline"]
ValueError: slot 'pipeline': no resolved model ref for this request
             (no Slot(default_checkpoint=...) and no hub resolution)
```

`w9fxny03xs7ex1` at 14:07:04Z ($0.0354) and `0iqqqyeo2c122k` at 15:24:56Z ($0.4771). The second
was the determinism control and it reproduced byte-for-byte. Zero pod leak.

## The mechanism, read off the code

**A field the handoff struct never had** — not an ordering problem, not a serialisation gap.

- `MintRequest` carried `snapshots` (slot -> local tree) and `component_paths`, and nothing else
  about the resolution. A path says which BYTES to load; only a binding says which CHECKPOINT
  the request is for, and `ctx.slots` is built from bindings
  (`warmup.resolved_slots_kwargs` -> `resolve_slot(ref=spec.models.get(name))`).
- The child re-runs discovery in a fresh interpreter, so `spec.models` comes back holding only
  what `@endpoint` DECLARED. sdxl declares
  `models={"pipeline": Slot(StableDiffusionXLPipeline, selected_by="model")}` — a hub-catalog
  slot with **no `default_checkpoint=`** — so `_split_slot_like` contributes nothing to
  `decl.models` and rediscovery yields `spec.models == {}`.
- The parent already held the binding at exactly the place it computed the paths the child DOES
  get: `_setup_locked_inner`, `binding = spec.models[slot]` in the same loop that writes
  `paths[slot]`. It sent the path and dropped the ref.

**pgw#964's delegation is untouched.** The liveness property that ended eighteen attempts' worth
of false kills stays exactly as it is; this closes the layer below it.

**Why pgw#828's regression test could not have caught it.** Its harness endpoint declares
`default_checkpoint=WARM_SLOT_PIPELINE`. A declared ref survives rediscovery; a catalog pick does
not.

## Sibling audit — the quiet half

A catalog slot that DOES carry a code default resolved fine in the child, **to the DECLARED
checkpoint, while the parent serves the hub's pick**: a mint tracing graphs for a model the pod
never runs. Same defect, no crash. Everything else on the boundary was already at parity — the
parent's own warm context also passes `run=None`, so lora overlays, catalog inference-defaults
and objective/distilled stamps are absent on BOTH sides by construction.

## The fix

`_setup_locked_inner` records the binding beside every path it materializes; it rides
`_BackgroundMint.slot_bindings` -> `MintTask` -> `MintRequest.slot_bindings` ->
`mint_child.bind_slots`. The **whole `ModelRef`** crosses, so the pick's flavor, `storage_dtype`
and pgw#617 `component_overrides` travel with it, and it is applied to the **whole class-scoped
sibling set** — `instance_key` is a live property over `spec.models`, so binding one handler
alone would silently narrow a class-scoped mint (pgw#654) to one lane.

### Honest failure

`mint_child.assert_slots_resolvable` refuses BEFORE the load. A wiring gap is deterministic, so
it exits `EXIT_REFUSED` (terminal on the first attempt) rather than exit 1 as a crash the parent
retries on a second billed pod. The refusal names family, cell key, lane, function, the slot,
and what the request DID carry; a bound slot that still fails is reported as *divergence*, not as
the same wire gap. `warmup.warm_context(origin=...)` prefixes that identity onto deferred
`ctx.slots[...]` errors on both mint paths (delegated child and in-process mint), so a residual
failure no longer has to be reconstructed from a truncated activity row plus a DB read.

## Verification

`tests/test_mint_child_slot_bindings_pgw969.py` — 11 rows, on the real codepath:

- a **real hub-double dispatch** binds a catalog slot and SERVES it (real executor, real blake3
  CAS downloader, real materialized tree);
- the request crosses the **real** `_BackgroundMint` -> `MintTask` -> `build_request` ->
  msgspec-JSON chain;
- the child's own `_run_warm_job` drives the **endpoint's own handler** and must resolve the
  SAME wire ref the serving path recorded — not "resolves something";
- the real `python -m gen_worker.mint_child` subprocess runs under the parent's real `run_mint`
  supervisor for the refusal row.

**RED-verified**: with `src/gen_worker` restored to `origin/dev`, 9 of the 11 rows fail. The two
that pass are the characterization rows, one of which reproduces the pod's exact `ValueError`
sentence from an unbound context. No mocks, no fixed-duration sleeps, no `timeout=N`.

Green: 76 focused mint/warm rows, `ruff check src/gen_worker`, `mypy src/gen_worker`
(230 files).

## Scope

The delegation boundary only. The second finding on the same run — the LANE MISMATCH
(`w8a8-lora64` minted against a `bf16-w16a16+compiled` serving pick) — was **adjudicated a false
page by th#1616** while this lane was implementing: the minted key would have been adopted, and
the reconciliation th#1616 ships is the real remaining work there. pgw#969 acceptance item 2 is
owned by that adjudication, not by this PR.

## Still open after this merge

The live-pod half of acceptance item 1: a forge boot on the real sdxl release image reaching
`warmup_forward > 0.0 s`. That needs 0.92.2 published and an attempt twenty-one.