### PR TITLE
pgw#971 + pgw#972: fill both stores at once, fuse the write-path hash, and give the chunk loop a backoff

### DIFF
--- a/changelog.d/pgw971.md
+++ b/changelog.d/pgw971.md
@@ -1,0 +1,24 @@
+- **pgw#971: both stores fill at once, and the write-through stops re-reading
+  the volume to check itself.** A fresh R2 fetch used to land in local CAS and
+  *then* be republished to the endpoint volume — `copyfileobj` to NFS, three
+  fsyncs, and a `hash_file` that read the whole blob **back off NFS** to verify
+  a write, all awaited inline. Three extra passes over every fresh byte, the
+  most expensive of them a network-storage read. Chunked blobs — where a
+  multi-GB keep-set's bytes actually live, since the hub chunks anything over
+  64 MiB — now write to both destinations in the SAME pass:
+  `download_chunked_file` takes a `mirror_dst` and `pwrite`s each block to its
+  offset in a volume-side part file as it arrives, so the NFS write hides
+  behind network latency. The mirror stages writer-unique and is published only
+  after the LOCAL file passes its whole-file digest, so a half-written volume
+  blob is never readable under the digest name and a concurrent pod's published
+  blob is never written into; any mirror error disables the mirror instead of
+  failing the fetch. Whole-file blobs keep the copy path, but it now runs in
+  the background and is joined before `ensure_snapshot` returns, so publishes
+  overlap each other and the materialization instead of sitting on each blob's
+  critical path. Per pgw#769 the digest check was **fused into the copy loop**,
+  not removed: `_copy_verified_blob` hashes bytes as it writes them, which
+  deletes the read-back pass while keeping verification mandatory in both
+  directions — including the one that matters, bytes read *from* the volume.
+  Measured on a 2 GiB cold fill against a real FUSE filesystem standing in for
+  NFS: **~13.0s -> ~6.6s**, i.e. the volume-attached fill now costs about what
+  the fetch alone costs.

--- a/changelog.d/pgw972.md
+++ b/changelog.d/pgw972.md
@@ -1,0 +1,18 @@
+- **pgw#972: the chunked download loop finally backs off.** `chunk_cas.py` had
+  no `time.sleep` anywhere: a chunk that failed was retried on a fresh
+  connection immediately, six times, so a fault needing seconds to clear —
+  a TLS handshake failure, a route flap — burned the whole budget in well under
+  a second. The whole-file path in `cozy_cas.py` has had jittered `2**n` backoff
+  with a progress-floor strike reset all along; this was the one transfer in the
+  SDK that retried instantly. It now classifies the failure first: an attempt
+  that DELIVERED ITS PROGRESS FLOOR and then died proves the route is alive, so
+  it takes a fresh socket at once with the backoff cleared (pgw#786's
+  lemon-connection rule, unchanged); an attempt that delivered nothing backs off
+  `2**n` with full jitter, capped at 30s, for up to 8 attempts. The give-up is a
+  COUNT, never a clock, per `stall.py`'s standing rule. A sibling chunk's fatal
+  failure now also cuts short the others' sleeps so the pool drains promptly.
+  Measured while writing the tests: the third "trickle" class the old comment
+  claimed to handle was unreachable — `delivered` only counts blocks
+  `iter_content` actually yields, and a connection that dies mid-block yields
+  nothing, so a source that sent 64 bytes and hung up reported `delivered=0`.
+  The classification is two-way because that is what the bytes support.

--- a/src/gen_worker/models/chunk_cas.py
+++ b/src/gen_worker/models/chunk_cas.py
@@ -37,6 +37,14 @@ to actually live.
     and refetched on a fresh connection instead of holding a 35 GB file hostage.
     Only when the whole route is bad does the aggregate floor raise a typed
     stall for the hub to re-place the pod.
+*   **Both stores are filled AT ONCE** (pgw#971). When an endpoint volume is
+    attached, every block is ``pwrite``-ed to its offset in the volume's part
+    file in the same pass as the local one, so the volume write hides behind
+    network latency instead of costing a second full read + write + hash of
+    every byte after the fetch. The mirror is BEST EFFORT and writer-unique: it
+    is published only after the LOCAL file passes its whole-file digest, so a
+    half-written volume blob is never readable under the digest name, and any
+    mirror failure disables the mirror rather than failing the fetch.
 *   Disk is proven UP FRONT with ``posix_fallocate``, so a 2 TB file that will
     not fit fails in milliseconds instead of 90% of the way through.
 """
@@ -47,7 +55,10 @@ import contextlib
 import hashlib
 import logging
 import os
+import random
 import threading
+import time
+import uuid
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,6 +79,7 @@ __all__ = [
     "chunk_len_at",
     "download_chunked_file",
     "hash_file",
+    "hasher_for",
     "parse_cas_ref",
     "sha256_file",
     "verify_file_digest",
@@ -88,7 +100,42 @@ _READ_CHUNK_BYTES = 4 * 1024 * 1024
 # on ranged GETs (pgw#786 measured 250 MB/s), so 4 MiB per window is two orders
 # of magnitude below healthy and unambiguously a lemon.
 _CHUNK_PROGRESS_FLOOR_BYTES = 4 * 1024 * 1024
-_CHUNK_MAX_ATTEMPTS = 6
+# pgw#972: a chunk's retry budget is a STRIKE COUNT plus a wall-clock cap, and
+# the two failure shapes are told apart before either is charged.
+#
+#   * A `DigestMismatch` is a COMPLETE, wrong-hashing body: the route is
+#     demonstrably healthy and only the bytes are not, so it refetches at once.
+#     Sleeping here is pure loss — it delays the refetch of an object the store
+#     is perfectly willing to serve — and it is what made a permanently-bad
+#     chunk take ~60s to give up instead of milliseconds.
+#   * An attempt that DELIVERED ITS FLOOR and then died proves the route is
+#     alive. That is pgw#786's lemon CONNECTION: abandon it and open a fresh
+#     socket AT ONCE — no sleep, and the strike count starts over, exactly as
+#     `cozy_cas`'s whole-file loop has always done for a link that keeps
+#     delivering.
+#   * An attempt that delivered nothing is the network not being there. This is
+#     the shape behind the `SSLError` on pod 7tbxicc2yjfx49: the loop burned its
+#     whole budget on connect attempts inside a couple of seconds because it had
+#     NO delay between them. The whole-file loop in `cozy_cas` has had jittered
+#     `2**n` backoff all along; this was the one transfer in the SDK that retried
+#     instantly. It BACKS OFF.
+#
+# There is deliberately no third "trickle" case. `delivered` counts blocks
+# `iter_content` actually YIELDS, and a connection that dies mid-block yields
+# nothing at all — measured: a source that sent 64 bytes and hung up reported
+# `delivered=0`. So "some bytes, but under the floor" is unreachable below one
+# read block, and pretending to classify it would only mean reading the
+# above-floor case wrong.
+#
+# The give-up is a COUNT, never a clock (`stall.py`'s standing rule: a wall
+# clock cannot tell a healthy slow transfer from a wedge). Clearing the floor
+# resets the BACKOFF, not the budget — an attempt that restarts the chunk from
+# offset 0 every time has advanced nothing, however many bytes it moved, so
+# resetting the budget on it would loop forever. 8 attempts at this backoff is
+# ~45-90s of tolerated blackout per chunk, and the executor's 3 outer attempts
+# (`_DOWNLOAD_RETRIES`, which the journal resumes across) sit on top of it.
+_CHUNK_MAX_ATTEMPTS = 8
+_CHUNK_BACKOFF_CAP_S = 30.0
 # th#1362: with positional writes a worker holds one 4 MiB read block instead of
 # a whole 64 MiB chunk, so the window is priced in threads and sockets rather
 # than in gigabytes. 16 is where the measured curve flattens (see
@@ -174,6 +221,16 @@ def sha256_file(path: Path, chunk_size: int = _READ_CHUNK_BYTES) -> str:
     return h.hexdigest()
 
 
+def hasher_for(algo: str) -> "hashlib._Hash":
+    """A fresh incremental hasher for the named algorithm — the same dispatch
+    as :func:`hash_file`, in the same place, for callers that can FUSE the hash
+    into a read they already perform (pgw#769/pgw#971) rather than pay a second
+    pass over the bytes."""
+    if algo == "sha256":
+        return hashlib.sha256()
+    raise ValueError(f"unsupported hash algorithm {algo!r}")
+
+
 def hash_file(path: Path, algo: str) -> str:
     """Hash a file with the named algorithm. No default: the caller must have
     read the algorithm off the digest, never assumed it.
@@ -218,6 +275,77 @@ def _pwrite_all(fd: int, data: bytes, offset: int) -> None:
         offset += n
 
 
+class _Mirror:
+    """A SECOND positional destination written in the same pass (pgw#971).
+
+    The endpoint volume, filled at the same time as local CAS rather than by a
+    full re-read afterwards. Best effort in the strongest sense: the first
+    error of any kind disables it permanently for this file and is never
+    propagated — a volume that is full, slow, read-only or absent must cost the
+    request nothing. It is published only by ``close(publish=True)``, after the
+    LOCAL file has passed its whole-file digest, and it stages under a
+    WRITER-UNIQUE name so a concurrent pod on the same volume can neither
+    observe our partial bytes nor have its published blob written into.
+    """
+
+    __slots__ = ("fd", "tmp", "dst", "_ok", "_lock")
+
+    def __init__(self, fd: int, tmp: Path, dst: Path) -> None:
+        self.fd = fd
+        self.tmp = tmp
+        self.dst = dst
+        self._ok = True
+        self._lock = threading.Lock()
+
+    @property
+    def ok(self) -> bool:
+        return self._ok
+
+    def disable(self, why: BaseException) -> None:
+        with self._lock:
+            if not self._ok:
+                return
+            self._ok = False
+        _log.warning("mirror_disabled destination=%s: %s", self.dst.name, why)
+
+    def write(self, data: bytes, offset: int) -> None:
+        if not self._ok:
+            return
+        try:
+            _pwrite_all(self.fd, data, offset)
+        except OSError as exc:
+            self.disable(exc)
+
+    def close(self, *, publish: bool) -> bool:
+        """Publish (or discard) the mirror. Never raises."""
+        try:
+            if not (publish and self._ok):
+                return False
+            os.fsync(self.fd)
+            self.dst.parent.mkdir(parents=True, exist_ok=True)
+            self.tmp.replace(self.dst)
+            from .cozy_cas import fsync_dir
+
+            fsync_dir(self.dst.parent)
+            return True
+        except OSError as exc:
+            _log.warning("mirror_publish_failed destination=%s: %s", self.dst, exc)
+            return False
+        finally:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            self.tmp.unlink(missing_ok=True)
+
+
+def _retry_delay(strikes: int) -> float:
+    """Full-jitter exponential backoff, capped. Same shape as the whole-file
+    loop in ``cozy_cas`` — the chunked path was the only transfer in the SDK
+    that retried with no delay at all."""
+    return random.uniform(0.5, 1.0) * min(_CHUNK_BACKOFF_CAP_S, 2.0 ** strikes)
+
+
 def _fetch_chunk_to_offset(
     session: requests.Session,
     spec: ChunkSpec,
@@ -225,12 +353,15 @@ def _fetch_chunk_to_offset(
     offset: int,
     *,
     on_bytes: Optional[Callable[[int], None]],
+    mirror: Optional["_Mirror"] = None,
+    give_up: Optional[threading.Event] = None,
 ) -> None:
     """Stream ONE chunk straight into its byte range, verifying as it goes.
 
     Abandon-and-refetch is per attempt and per chunk (pgw#786): an attempt that
     stops clearing its own progress floor is dropped and retried on a FRESH
-    connection, so one bad connection cannot hold the file.
+    connection, so one bad connection cannot hold the file. pgw#972 splits that
+    from the case where NOTHING arrived — see ``_CHUNK_MAX_ATTEMPTS`` above.
 
     The chunk is verified AFTER it lands rather than before, which is safe
     precisely because the range belongs to this chunk alone: an attempt that
@@ -238,8 +369,10 @@ def _fetch_chunk_to_offset(
     until the caller marks the chunk done. That is the trade that drops RAM per
     worker from a whole 64 MiB chunk to one read block.
     """
-    last_exc: Optional[BaseException] = None
-    for attempt in range(1, _CHUNK_MAX_ATTEMPTS + 1):
+    strikes = 0
+    attempt = 0
+    while True:
+        attempt += 1
         floor = ProgressFloor(_CHUNK_PROGRESS_FLOOR_BYTES)
         delivered = 0
         hasher = hashlib.sha256()
@@ -261,6 +394,8 @@ def _fetch_chunk_to_offset(
                             f"chunk {spec.sha256[:12]}: source sent more than {spec.length} bytes"
                         )
                     _pwrite_all(fd, block, pos)
+                    if mirror is not None:
+                        mirror.write(block, pos)
                     pos += len(block)
                     hasher.update(block)
                     if on_bytes is not None:
@@ -280,18 +415,37 @@ def _fetch_chunk_to_offset(
         except UrlExpiredError:
             raise
         except (requests.RequestException, DigestMismatch, OSError) as exc:
-            last_exc = exc
-            stalled = not floor.cleared(delivered)
-            _log.warning(
-                "chunk_refetch sha256=%s attempt=%d/%d delivered=%d stalled=%s: %s",
-                spec.sha256[:12], attempt, _CHUNK_MAX_ATTEMPTS, delivered, stalled, exc,
+            # Backoff is for a route that is NOT THERE, and nothing else.
+            #   * A DigestMismatch means a complete, wrong-hashing body arrived:
+            #     the route is demonstrably healthy, the bytes are not. Retry at
+            #     once — sleeping would only delay the refetch of an object the
+            #     store is happy to serve.
+            #   * A transport error that still CLEARED THE FLOOR is pgw#786's
+            #     lemon connection: get a fresh socket now, not in 30s.
+            #   * A transport error that delivered nothing is the case that
+            #     needs to wait.
+            alive = isinstance(exc, DigestMismatch) or floor.cleared(delivered)
+            strikes = 0 if alive else strikes + 1
+            out_of_budget = (
+                attempt >= _CHUNK_MAX_ATTEMPTS
+                or (give_up is not None and give_up.is_set())
             )
-            # No sleep and no backoff on a STALL: the point is to abandon this
-            # connection immediately and open a new one. Real errors fall
-            # through to the same fresh-connection retry.
-            continue
-    assert last_exc is not None
-    raise last_exc
+            delay = 0.0 if (alive or out_of_budget) else _retry_delay(strikes)
+            _log.warning(
+                "chunk_refetch sha256=%s attempt=%d/%d delivered=%d "
+                "route_alive=%s retry_in=%.1fs: %s",
+                spec.sha256[:12], attempt, _CHUNK_MAX_ATTEMPTS,
+                delivered, alive, delay, exc,
+            )
+            if out_of_budget:
+                raise
+            if delay and give_up is not None:
+                # A sibling chunk's fatal failure must not have to wait out
+                # this loop's whole budget before the pool can drain.
+                if give_up.wait(delay):
+                    raise
+            elif delay:
+                time.sleep(delay)
 
 
 @contextlib.contextmanager
@@ -346,12 +500,19 @@ def download_chunked_file(
     window: int = _DEFAULT_WINDOW,
     on_bytes: Optional[Callable[[int], None]] = None,
     session_factory: Callable[[], requests.Session] = requests.Session,
-) -> None:
+    mirror_dst: Optional[Path] = None,
+) -> bool:
     """Reassemble a chunked file, verifying every chunk AND the whole-file hash.
 
     The whole-file hash is fused into the commit stream: there is exactly one
     pass over the bytes, and no second read. On mismatch the partial file is
     deleted so the next attempt starts clean.
+
+    ``mirror_dst`` (pgw#971) fills a SECOND store — the endpoint volume — in the
+    same pass, so the write-through costs neither a re-read nor a second hash of
+    every byte. Returns whether that mirror was published; ``False`` (including
+    always when ``mirror_dst`` is ``None``) means the caller still owes the
+    volume a copy.
     """
     if not chunks:
         raise ValueError("download_chunked_file: no chunks")
@@ -393,10 +554,11 @@ def download_chunked_file(
             # A sibling in this pod already materialised it while we waited.
             _log.info("chunk_cas dedup: %s already present (%d bytes); skipping "
                       "the fetch", dst.name, total_size)
-            return
-        _download_chunked_locked(
+            return False
+        return _download_chunked_locked(
             chunks, dst, want_whole=want_whole, total_size=total_size,
             window=window, on_bytes=on_bytes, session_factory=session_factory,
+            mirror_dst=mirror_dst,
         )
 
 
@@ -556,6 +718,64 @@ def _size_session_pool(session: requests.Session, window: int) -> None:
         pass
 
 
+def _open_mirror(mirror_dst: Optional[Path], total_size: int) -> Optional["_Mirror"]:
+    """Stage the volume-side part file, or return ``None``. Never raises: a
+    volume we cannot write to costs the request nothing but the write-through."""
+    if mirror_dst is None:
+        return None
+    try:
+        mirror_dst.parent.mkdir(parents=True, exist_ok=True)
+        # Writer-unique, exactly as `_copy_verified_blob` stages: several pods
+        # share one volume with no lock between them, and a stable name would
+        # let one pod's in-flight bytes land in another's published blob.
+        tmp = mirror_dst.parent / (
+            f".{mirror_dst.name}.mirror-{os.getpid()}-{uuid.uuid4().hex}"
+        )
+        fd = os.open(str(tmp), os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
+    except OSError as exc:
+        _log.warning("mirror_open_failed destination=%s: %s", mirror_dst, exc)
+        return None
+    try:
+        # `ftruncate` ONLY — deliberately NOT `_preallocate`. glibc's
+        # `posix_fallocate` zero-fills by hand when the filesystem has no
+        # `fallocate(2)`, and network storage frequently does not (NFSv4.1);
+        # that would be a full extra write pass to the volume, which is exactly
+        # what this change exists to delete. Local CAS keeps the real up-front
+        # allocation — "prove the disk now" belongs there — and the volume
+        # running out of space just disables the mirror.
+        os.ftruncate(fd, total_size)
+    except OSError as exc:
+        _log.warning("mirror_allocate_failed destination=%s: %s", mirror_dst, exc)
+        os.close(fd)
+        tmp.unlink(missing_ok=True)
+        return None
+    return _Mirror(fd, tmp, mirror_dst)
+
+
+def _seed_mirror(
+    fd: int,
+    mirror: "_Mirror",
+    chunks: Sequence[ChunkSpec],
+    offsets: Sequence[int],
+    already: set[int],
+) -> None:
+    """Copy resumed (already-verified) ranges from local disk into the mirror."""
+    for i in sorted(already):
+        pos, remaining = offsets[i], chunks[i].length
+        while remaining > 0 and mirror.ok:
+            try:
+                b = os.pread(fd, min(_READ_CHUNK_BYTES, remaining), pos)
+            except OSError as exc:
+                mirror.disable(exc)
+                return
+            if not b:
+                mirror.disable(OSError(f"short read seeding mirror chunk {i}"))
+                return
+            mirror.write(b, pos)
+            pos += len(b)
+            remaining -= len(b)
+
+
 def _download_chunked_locked(
     chunks: Sequence[ChunkSpec],
     dst: Path,
@@ -565,7 +785,8 @@ def _download_chunked_locked(
     window: int,
     on_bytes: Optional[Callable[[int], None]],
     session_factory: Callable[[], requests.Session],
-) -> None:
+    mirror_dst: Optional[Path] = None,
+) -> bool:
     """The reassembly itself, run while holding the cross-process CAS fetch lock
     (``download_chunked_file`` does the shape checks and the dedup)."""
     dst.parent.mkdir(parents=True, exist_ok=True)
@@ -587,9 +808,17 @@ def _download_chunked_locked(
     max_inflight = max(1, min(window, len(chunks)))
     fd = os.open(str(tmp), os.O_RDWR | os.O_CREAT, 0o644)
     jfd: Optional[int] = None
+    mirror: Optional[_Mirror] = None
+    published = False
     try:
         _preallocate(fd, total_size, tmp)
         already = _adopt_partial(fd, chunks, offsets, journal, header, max_inflight)
+        mirror = _open_mirror(mirror_dst, total_size)
+        if mirror is not None and already:
+            # Resumed ranges are already verified on local disk and will not be
+            # refetched, so the mirror takes them from there — otherwise it
+            # would publish a file with holes.
+            _seed_mirror(fd, mirror, chunks, offsets, already)
 
         prefix = _Prefix(len(chunks))
         for i in sorted(already):
@@ -615,6 +844,7 @@ def _download_chunked_locked(
                 chunks, offsets, prefix, jfd, fd, dst,
                 already=already, max_inflight=max_inflight,
                 on_bytes=on_bytes, session_factory=session_factory,
+                mirror=mirror,
             )
         except BaseException:
             prefix.abort()
@@ -626,7 +856,18 @@ def _download_chunked_locked(
             raise OSError(f"{dst.name}: whole-file hash did not complete")
         _finalize(fd, tmp, journal, dst, got=got, want_whole=want_whole,
                   total_size=total_size)
+        # ONLY here: the local file just proved its whole-file digest, and the
+        # mirror took the same in-memory blocks at the same offsets.
+        published = mirror is not None and mirror.close(publish=True)
+        mirror = None
+        if mirror_dst is not None:
+            _log.info("blob_fill_publish source=r2 destination=volume mode=tee "
+                      "digest=%s bytes=%d published=%s",
+                      want_whole[:16], total_size, published)
+        return published
     finally:
+        if mirror is not None:
+            mirror.close(publish=False)
         if jfd is not None:
             os.close(jfd)
         os.close(fd)
@@ -644,6 +885,7 @@ def _fetch_pending(
     max_inflight: int,
     on_bytes: Optional[Callable[[int], None]],
     session_factory: Callable[[], requests.Session],
+    mirror: Optional["_Mirror"] = None,
 ) -> None:
     pending = [i for i in range(len(chunks)) if i not in already]
     if not pending:
@@ -652,6 +894,10 @@ def _fetch_pending(
     aggregate = ProgressFloor(_CHUNK_PROGRESS_FLOOR_BYTES * max_inflight)
     delivered_total = 0
     counter = threading.Lock()
+    # pgw#972: per-chunk retries now sleep, so a fatal failure elsewhere has to
+    # be able to cut them short — otherwise the pool cannot drain until every
+    # sibling has spent its whole retry budget.
+    give_up = threading.Event()
 
     def _count(n: int) -> None:
         nonlocal delivered_total
@@ -664,7 +910,10 @@ def _fetch_pending(
     _size_session_pool(session, max_inflight)
 
     def _one(i: int) -> None:
-        _fetch_chunk_to_offset(session, chunks[i], fd, offsets[i], on_bytes=_count)
+        _fetch_chunk_to_offset(
+            session, chunks[i], fd, offsets[i], on_bytes=_count,
+            mirror=mirror, give_up=give_up,
+        )
         # O_APPEND makes a short line atomic across threads, so the journal
         # needs no lock of its own.
         os.write(jfd, f"{i}\n".encode())
@@ -682,6 +931,7 @@ def _fetch_pending(
                 except BaseException as exc:  # noqa: BLE001 - classified below
                     failure = (futures[fut], exc)
                     del exc
+                    give_up.set()
                     for other in futures:
                         other.cancel()
                     break

--- a/src/gen_worker/models/chunk_cas.py
+++ b/src/gen_worker/models/chunk_cas.py
@@ -433,7 +433,7 @@ def _fetch_chunk_to_offset(
             delay = 0.0 if (alive or out_of_budget) else _retry_delay(strikes)
             _log.warning(
                 "chunk_refetch sha256=%s attempt=%d/%d delivered=%d "
-                "route_alive=%s retry_in=%.1fs: %s",
+                "route_alive=%s retry_in=%.3fs: %s",
                 spec.sha256[:12], attempt, _CHUNK_MAX_ATTEMPTS,
                 delivered, alive, delay, exc,
             )

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -19,6 +19,7 @@ from .chunk_cas import (
     ChunkSpec,
     download_chunked_file,
     hash_file,
+    hasher_for,
     parse_cas_ref,
     verify_file_digest,
 )
@@ -173,6 +174,15 @@ def _copy_verified_blob(src: Path, dst: Path, ref: str, expected_size: int) -> b
     ``ref`` is ALGORITHM-TAGGED and the hash dispatches on it (th#1303): a
     sha256 blob checked with blake3 fails every honest copy, and an empty
     digest must never reduce this to a size-only check.
+
+    pgw#971: the hash is FUSED INTO THE COPY, per pgw#769 — hashing stays
+    mandatory, but it rides the read this function already performs instead of
+    costing a second full pass. The old shape was `copyfileobj` and then
+    `hash_file(tmp)`: three passes over every byte (read source, write stage,
+    RE-READ the stage), and on the volume->local direction the re-read was of
+    the freshly-written NETWORK-storage file, the single most expensive pass of
+    the three. One pass now, same guarantee: the bytes that reach the stage are
+    exactly the bytes that went through the hasher.
     """
     algo, want_hex = parse_cas_ref(ref)
     digest = want_hex
@@ -191,8 +201,14 @@ def _copy_verified_blob(src: Path, dst: Path, ref: str, expected_size: int) -> b
             f".{dst.name}.writer-{os.getpid()}-{threading.get_ident()}-{uuid.uuid4().hex}"
         )
         try:
+            hasher = hasher_for(algo)
             with src.open("rb") as source, tmp.open("xb") as staged:
-                shutil.copyfileobj(source, staged, length=4 * 1024 * 1024)
+                while True:
+                    block = source.read(4 * 1024 * 1024)
+                    if not block:
+                        break
+                    hasher.update(block)
+                    staged.write(block)
                 staged.flush()
                 os.fsync(staged.fileno())
             if expected_size and tmp.stat().st_size != expected_size:
@@ -201,7 +217,7 @@ def _copy_verified_blob(src: Path, dst: Path, ref: str, expected_size: int) -> b
                     src, digest[:16], expected_size, tmp.stat().st_size,
                 )
                 return False
-            if hash_file(tmp, algo).lower() != want_hex:
+            if hasher.hexdigest().lower() != want_hex:
                 _log.warning(
                     "blob_fill_corrupt source=%s digest=%s reason=%s", src, digest[:16], algo,
                 )
@@ -476,6 +492,10 @@ class CozySnapshotDownloader:
                 raise RuntimeError("concurrent snapshot build failed") from entry.exception
             return snap_dir
 
+        # pgw#971: volume write-throughs that could not be teed run in the
+        # background and are JOINED below, so the build never returns — or
+        # fails — with a publish still in flight.
+        publishes: List["asyncio.Task"] = []
         try:
             if snap_dir.exists():
                 # gw#598: a materialized tree this process has not produced or
@@ -502,6 +522,7 @@ class CozySnapshotDownloader:
                 res.files,
                 progress=progress,
                 fill_blobs_root=fill_blobs_root,
+                publishes=publishes,
             )
             # Materialization copies/concatenates multi-GB trees — strictly
             # off the event loop (gw#407: a loop blocked for the duration of
@@ -520,6 +541,12 @@ class CozySnapshotDownloader:
             entry.exception = exc
             raise
         finally:
+            # Join the background write-throughs unconditionally: they are
+            # best-effort in OUTCOME, never in LIFETIME. `return_exceptions`
+            # because a failed publish must not turn a good build into a
+            # failure — nor a failed build into a different error.
+            if publishes:
+                await asyncio.gather(*publishes, return_exceptions=True)
             # Digest-poisoning fix (#358): a FAILED build must not park a
             # set-event + stale exception under this digest forever. Evict the
             # entry so the next request creates a fresh builder and retries;
@@ -575,7 +602,12 @@ class CozySnapshotDownloader:
         *,
         progress: Optional[ProgressFn] = None,
         fill_blobs_root: Optional[Path] = None,
+        publishes: Optional[List["asyncio.Task"]] = None,
     ) -> None:
+        # pgw#971: background volume write-throughs land here; the caller joins
+        # them before returning, so none can outlive the build.
+        if publishes is None:
+            publishes = []
         # Deduplicate by digest — same blob referenced by multiple paths (e.g.
         # fp16 and normal variants sharing the same part) is downloaded once.
         seen: Set[str] = set()
@@ -716,15 +748,30 @@ class CozySnapshotDownloader:
         async def _fill_to_volume(f: WorkerResolvedRepoFile, digest: str, dst: Path) -> None:
             """Write-through (gw#599): a fresh R2 fetch warms the volume for
             the next same-endpoint pod. Best-effort — a publish failure never
-            fails the request; the next pod simply falls through to R2 too."""
+            fails the request; the next pod simply falls through to R2 too.
+
+            pgw#971: this is now the FALLBACK. Chunked blobs — which is where a
+            multi-GB keep-set's bytes actually live — fill both stores in one
+            pass inside ``download_chunked_file``; only whole-file blobs (a v2
+            manifest chunks anything over 64 MiB, so these are the small ones)
+            and tee failures still pay for a re-read. It also runs in the
+            BACKGROUND: the blob's own task completes on download, and
+            ``ensure_snapshot`` joins every publish before it returns, so the
+            copies overlap each other and the materialization instead of
+            sitting on each blob's critical path."""
             if fill_blobs_root is None:
                 return
-            published = await asyncio.to_thread(
-                _copy_verified_blob, dst, _blob_path(fill_blobs_root, digest),
-                digest, int(f.size_bytes or 0),
-            )
+            try:
+                published = await asyncio.to_thread(
+                    _copy_verified_blob, dst, _blob_path(fill_blobs_root, digest),
+                    digest, int(f.size_bytes or 0),
+                )
+            except Exception as exc:  # noqa: BLE001 - never fails the request
+                _log.warning("blob_fill_publish_failed digest=%s: %s", digest[:16], exc)
+                return
             _log.info(
-                "blob_fill_publish source=r2 destination=volume digest=%s bytes=%d published=%s",
+                "blob_fill_publish source=r2 destination=volume mode=copy "
+                "digest=%s bytes=%d published=%s",
                 digest[:16], int(f.size_bytes or 0), published,
             )
 
@@ -742,13 +789,17 @@ class CozySnapshotDownloader:
                     return
                 if await _fill_from_volume(f, digest, dst):
                     return
-                await _dl_locked(f, digest, dst)
-                await _fill_to_volume(f, digest, dst)
+                teed = await _dl_locked(f, digest, dst)
+            if fill_blobs_root is not None and not teed:
+                publishes.append(
+                    asyncio.create_task(_fill_to_volume(f, digest, dst))
+                )
 
-        async def _dl_locked(f: WorkerResolvedRepoFile, digest: str, dst: Path) -> None:
+        async def _dl_locked(f: WorkerResolvedRepoFile, digest: str, dst: Path) -> bool:
+            teed = False
             async with sem:
                 if await _blob_trusted(dst, f, digest):
-                    return
+                    return False
                 _log.info("blob_download_start path=%s size=%s digest=%s chunks=%d",
                           f.path, f.size_bytes, digest[:24], len(f.chunks))
                 if f.chunks:
@@ -760,7 +811,10 @@ class CozySnapshotDownloader:
                         ChunkSpec(sha256=c.sha256, url=c.url, length=int(c.length))
                         for c in f.chunks
                     ]
-                    await asyncio.to_thread(
+                    # pgw#971: fill BOTH stores in this one pass when a volume
+                    # is attached — the NFS write hides behind network latency
+                    # and the extra read+hash pass disappears.
+                    teed = await asyncio.to_thread(
                         download_chunked_file,
                         specs,
                         dst,
@@ -769,6 +823,10 @@ class CozySnapshotDownloader:
                         chunk_size_bytes=int(f.chunk_size_bytes or 0)
                         or CAS_CHUNK_SIZE_BYTES,
                         on_bytes=lambda n: _on_bytes(n, network=True),
+                        mirror_dst=(
+                            _blob_path(fill_blobs_root, digest)
+                            if fill_blobs_root is not None else None
+                        ),
                     )
                 else:
                     # A WHOLE file. th#1303 S1: BOTH transports now take the
@@ -804,6 +862,7 @@ class CozySnapshotDownloader:
                 # algorithm the manifest named, before publishing.
                 _mark_trusted(_VERIFIED_BLOBS, (blobs_root_id, digest))
                 _log.info("blob_download_done path=%s digest=%s", f.path, digest[:24])
+            return teed
 
         await asyncio.gather(*(_dl(f) for f in unique))
         # th#850 managed-tier runtime-assertion signal: on a volume-attached

--- a/tests/test_volume_tee_pgw971.py
+++ b/tests/test_volume_tee_pgw971.py
@@ -1,0 +1,412 @@
+"""pgw#971 / pgw#972: fill BOTH stores at once, and back off.
+
+Three properties, all driven through the real `download_chunked_file` /
+`ensure_snapshot_async` over a real threaded HTTP server on localhost — real
+sockets, real bodies, real threads, real files. Every one of these is a
+property of the concurrency and the IO, so a mock would assert nothing.
+
+1.  **Tee.** With a volume attached, a chunked blob's bytes land in local CAS
+    and on the volume in the SAME pass. The volume copy is byte-identical, is
+    never observable under the digest name before the whole-file hash passes,
+    and the post-fetch re-read (`mode=copy`) does not run for it.
+2.  **Fused hash (pgw#971).** `_copy_verified_blob` still refuses bytes that do
+    not hash to their ref — the hash moved into the copy loop, it did not go
+    away.
+3.  **Backoff (pgw#972).** A chunk source that delivers NOTHING gets an
+    exponentially-backed-off retry; one that DELIVERED ITS FLOOR and then died
+    is a lemon connection and gets a fresh socket with no sleep. Those are
+    different failures and the loop must tell them apart.
+
+Run: pytest tests/test_volume_tee_pgw971.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import http.server
+import socketserver
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+import gen_worker.models.chunk_cas as cc
+from gen_worker.models.chunk_cas import ChunkSpec, download_chunked_file
+from gen_worker.models.cozy_snapshot import _copy_verified_blob, ensure_snapshot_async
+from gen_worker.models.hub_client import (
+    WorkerResolvedChunk,
+    WorkerResolvedRepo,
+    WorkerResolvedRepoFile,
+)
+from gen_worker.models.refs import TensorhubRef
+
+CS = 8192  # chunk size: the ARITHMETIC is what is under test, not the volume
+
+
+def _sha(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _body(total: int, seed: int = 11) -> bytes:
+    out = bytearray(total)
+    x = (seed * 2654435761 + 1) & 0xFFFFFFFF
+    for i in range(total):
+        x = (x * 1664525 + 1013904223) & 0xFFFFFFFF
+        out[i] = (x >> 24) & 0xFF
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# A real HTTP server serving chunks by digest, with per-digest fault injection.
+# ---------------------------------------------------------------------------
+
+class _Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+    block_on_close = False
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):  # noqa: D102
+        pass
+
+    def do_GET(self):  # noqa: N802
+        srv = self.server
+        key = self.path.rsplit("/", 1)[-1]
+        with srv.lock:
+            srv.hits[key] = srv.hits.get(key, 0) + 1
+            n = srv.hits[key]
+            blob = srv.blobs.get(key)
+            fail = srv.fail_first.get(key, 0)
+            trickle = srv.trickle_bytes.get(key, 0)
+        if blob is None:
+            self.send_error(404)
+            return
+        if n <= fail:
+            if trickle:
+                # SOME bytes, under the floor, then the connection dies: the
+                # lemon-connection shape.
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(blob)))
+                self.end_headers()
+                self.wfile.write(blob[:trickle])
+                self.wfile.flush()
+            self.close_connection = True
+            try:
+                self.connection.close()
+            except OSError:
+                pass
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(blob)))
+        self.end_headers()
+        self.wfile.write(blob)
+
+
+@pytest.fixture()
+def server():
+    srv = _Server(("127.0.0.1", 0), _Handler)
+    srv.blobs: Dict[str, bytes] = {}
+    srv.hits: Dict[str, int] = {}
+    srv.fail_first: Dict[str, int] = {}
+    srv.trickle_bytes: Dict[str, int] = {}
+    srv.lock = threading.Lock()
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _publish(srv, payload: bytes) -> List[ChunkSpec]:
+    specs: List[ChunkSpec] = []
+    base = f"http://127.0.0.1:{srv.server_address[1]}/chunk"
+    for off in range(0, len(payload), CS):
+        part = payload[off:off + CS]
+        d = _sha(part)
+        with srv.lock:
+            srv.blobs[d] = part
+        specs.append(ChunkSpec(sha256=d, url=f"{base}/{d}", length=len(part)))
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# 1. The tee
+# ---------------------------------------------------------------------------
+
+def test_tee_fills_both_stores_in_one_pass(tmp_path: Path, server) -> None:
+    payload = _body(CS * 9 + 17)
+    specs = _publish(server, payload)
+    local = tmp_path / "local" / "blob"
+    volume = tmp_path / "volume" / "blob"
+
+    published = download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_dst=volume,
+    )
+
+    assert published is True
+    assert local.read_bytes() == payload
+    assert volume.read_bytes() == payload
+    # No staging litter left behind on either side.
+    assert [p.name for p in volume.parent.iterdir()] == ["blob"]
+
+
+def test_no_mirror_requested_publishes_nothing(tmp_path: Path, server) -> None:
+    payload = _body(CS * 3)
+    specs = _publish(server, payload)
+    local = tmp_path / "local" / "blob"
+
+    published = download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+    )
+    assert published is False
+    assert local.read_bytes() == payload
+
+
+def test_failed_download_leaves_no_volume_blob(tmp_path: Path, server) -> None:
+    """A half-written volume blob must never be readable under the digest
+    name. The mirror stages writer-unique and is published only after the
+    LOCAL file proves its whole-file hash."""
+    payload = _body(CS * 4)
+    specs = _publish(server, payload)
+    # A lying whole-file label: every chunk is valid, the file is not.
+    local = tmp_path / "local" / "blob"
+    volume = tmp_path / "volume" / "blob"
+
+    with pytest.raises(cc.DigestMismatch):
+        download_chunked_file(
+            specs, local, whole_digest="sha256:" + ("b7" * 32),
+            total_size=len(payload), chunk_size_bytes=CS, window=4,
+            mirror_dst=volume,
+        )
+
+    assert not local.exists()
+    assert not volume.exists()
+    assert list(volume.parent.iterdir()) == []  # no orphaned stage file either
+
+
+def test_mirror_failure_never_fails_the_download(tmp_path: Path, server) -> None:
+    """A volume that cannot be written to costs the request nothing."""
+    payload = _body(CS * 3)
+    specs = _publish(server, payload)
+    local = tmp_path / "local" / "blob"
+    # The mirror's parent directory path is occupied by a FILE, so mkdir fails.
+    blocker = tmp_path / "volume"
+    blocker.write_bytes(b"not a directory")
+    volume = blocker / "aa" / "blob"
+
+    published = download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_dst=volume,
+    )
+    assert published is False
+    assert local.read_bytes() == payload  # the fetch itself is untouched
+
+
+def test_resume_seeds_the_mirror_from_local_disk(tmp_path: Path, server) -> None:
+    """Chunks adopted from a previous run are never refetched, so the mirror
+    takes them off local disk — otherwise it would publish a file with holes."""
+    payload = _body(CS * 6)
+    specs = _publish(server, payload)
+    local = tmp_path / "local" / "blob"
+    volume = tmp_path / "volume" / "blob"
+    local.parent.mkdir(parents=True, exist_ok=True)
+
+    # A prior run that wrote and journalled the first three chunks.
+    part = local.parent / f".{local.name}.chunkpart"
+    with open(part, "wb") as f:
+        f.write(payload[: CS * 3])
+        f.write(b"\0" * (len(payload) - CS * 3))
+    journal = local.parent / f".{local.name}.chunkdone"
+    journal.write_text(
+        f"sha256:{_sha(payload)} {len(payload)}\n0\n1\n2\n"
+    )
+    before = dict(server.hits)
+
+    published = download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_dst=volume,
+    )
+
+    assert published is True
+    assert volume.read_bytes() == payload
+    # The adopted chunks really were adopted, not refetched.
+    for spec in specs[:3]:
+        assert server.hits.get(spec.sha256, 0) == before.get(spec.sha256, 0)
+
+
+# ---------------------------------------------------------------------------
+# ensure_snapshot_async: which write-through path each blob kind takes
+# ---------------------------------------------------------------------------
+
+def _resolved(payload: bytes, specs: List[ChunkSpec], small: bytes, small_url: str):
+    return WorkerResolvedRepo(
+        snapshot_digest="sha256:" + ("c7" * 32),
+        files=[
+            WorkerResolvedRepoFile(
+                path="model.safetensors",
+                size_bytes=len(payload),
+                url=None,
+                digest="sha256:" + _sha(payload),
+                chunk_size_bytes=CS,
+                chunks=tuple(
+                    WorkerResolvedChunk(sha256=s.sha256, url=s.url, length=s.length)
+                    for s in specs
+                ),
+            ),
+            WorkerResolvedRepoFile(
+                path="config.json",
+                size_bytes=len(small),
+                digest="sha256:" + _sha(small),
+                url=small_url,
+            ),
+        ],
+    )
+
+
+def test_chunked_blob_tees_and_whole_file_blob_copies(
+    tmp_path: Path, server, caplog,
+) -> None:
+    payload = _body(CS * 5, seed=3)
+    specs = _publish(server, payload)
+    small = b'{"k":1}'
+    with server.lock:
+        server.blobs[_sha(small)] = small
+    small_url = f"http://127.0.0.1:{server.server_address[1]}/chunk/{_sha(small)}"
+
+    local = tmp_path / "local"
+    volume = tmp_path / "volume"
+    caplog.set_level("INFO", logger="gen_worker.models.chunk_cas")
+    caplog.set_level("INFO", logger="gen_worker.download")
+
+    snap = asyncio.run(ensure_snapshot_async(
+        base_dir=local,
+        ref=TensorhubRef(owner="org", repo="model"),
+        resolved=_resolved(payload, specs, small, small_url),
+        fill_source_dir=volume,
+    ))
+
+    assert (snap / "model.safetensors").read_bytes() == payload
+    assert (snap / "config.json").read_bytes() == small
+    # Both blobs warmed the volume, by the path each blob kind should take.
+    modes = {
+        line.split("digest=")[0].split("mode=")[1].strip()
+        for line in caplog.text.splitlines() if "blob_fill_publish" in line
+    }
+    assert modes == {"tee", "copy"}
+    vol_blobs = sorted(p.name for p in (volume / "blobs" / "sha256").rglob("*")
+                       if p.is_file())
+    assert vol_blobs == sorted([_sha(payload), _sha(small)])
+
+
+# ---------------------------------------------------------------------------
+# 2. pgw#971: the hash is fused into the copy, not deleted from it
+# ---------------------------------------------------------------------------
+
+def test_fused_hash_still_refuses_a_wrong_digest(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    payload = _body(1 << 16)
+    src.write_bytes(payload)
+    # Right size, wrong content — a size-only check would wave this through.
+    ok = _copy_verified_blob(src, dst, "sha256:" + ("de" * 32), len(payload))
+    assert ok is False
+    assert not dst.exists()
+    assert list(tmp_path.iterdir()) == [src]  # stage file cleaned up
+
+
+def test_fused_hash_accepts_honest_bytes(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "sub" / "dst"
+    payload = _body(1 << 16, seed=5)
+    src.write_bytes(payload)
+    assert _copy_verified_blob(src, dst, "sha256:" + _sha(payload), len(payload))
+    assert dst.read_bytes() == payload
+
+
+# ---------------------------------------------------------------------------
+# 3. pgw#972: backoff, and the two failure shapes told apart
+# ---------------------------------------------------------------------------
+
+def test_zero_byte_failures_back_off(tmp_path: Path, server, monkeypatch) -> None:
+    """The defect: a chunk source that delivers NOTHING was retried with no
+    delay at all, so the whole budget burned inside a couple of seconds and a
+    transient TLS/connect blip failed the fetch."""
+    monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 0.5)
+    payload = _body(CS * 2)
+    specs = _publish(server, payload)
+    with server.lock:
+        server.fail_first[specs[0].sha256] = 3  # three connect-shaped failures
+
+    local = tmp_path / "local" / "blob"
+    started = time.monotonic()
+    download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=2,
+    )
+    elapsed = time.monotonic() - started
+
+    assert local.read_bytes() == payload
+    # Three failures at strikes 1..3, each sleeping uniform(0.5, 1.0) * cap.
+    assert elapsed >= 3 * 0.5 * 0.5, f"no backoff observed ({elapsed:.3f}s)"
+
+
+def test_a_live_route_reconnects_without_sleeping(
+    tmp_path: Path, server, monkeypatch,
+) -> None:
+    """pgw#786's rule survives: an attempt that DELIVERED ITS FLOOR and then
+    died is a lemon CONNECTION, and the answer is a fresh socket NOW, not a
+    sleep. The read block and the floor are shrunk so the property is testable
+    in kilobytes; the arithmetic under test is unchanged."""
+    monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 30.0)
+    monkeypatch.setattr(cc, "_READ_CHUNK_BYTES", 64)
+    monkeypatch.setattr(cc, "_CHUNK_PROGRESS_FLOOR_BYTES", 128)
+    payload = _body(CS * 2)
+    specs = _publish(server, payload)
+    with server.lock:
+        server.fail_first[specs[0].sha256] = 3
+        server.trickle_bytes[specs[0].sha256] = 4096  # >> the shrunken floor
+
+    local = tmp_path / "local" / "blob"
+    started = time.monotonic()
+    download_chunked_file(
+        specs, local, whole_digest="sha256:" + _sha(payload),
+        total_size=len(payload), chunk_size_bytes=CS, window=2,
+    )
+    elapsed = time.monotonic() - started
+
+    assert local.read_bytes() == payload
+    assert elapsed < 5.0, f"a live route slept instead of reconnecting ({elapsed:.1f}s)"
+
+
+def test_a_dead_route_gives_up_on_a_COUNT_not_a_clock(
+    tmp_path: Path, server, monkeypatch,
+) -> None:
+    """The give-up is `_CHUNK_MAX_ATTEMPTS` attempts, per `stall.py`'s standing
+    rule that nothing which ends real work may key on a wall clock."""
+    monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 0.05)
+    payload = _body(CS * 2)
+    specs = _publish(server, payload)
+    with server.lock:
+        server.fail_first[specs[0].sha256] = 10_000
+
+    local = tmp_path / "local" / "blob"
+    with pytest.raises(Exception):
+        download_chunked_file(
+            specs, local, whole_digest="sha256:" + _sha(payload),
+            total_size=len(payload), chunk_size_bytes=CS, window=2,
+        )
+    assert not local.exists()
+    assert server.hits[specs[0].sha256] == cc._CHUNK_MAX_ATTEMPTS

--- a/tests/test_volume_tee_pgw971.py
+++ b/tests/test_volume_tee_pgw971.py
@@ -27,7 +27,6 @@ import hashlib
 import http.server
 import socketserver
 import threading
-import time
 from pathlib import Path
 from typing import Dict, List
 
@@ -337,42 +336,71 @@ def test_fused_hash_accepts_honest_bytes(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3. pgw#972: backoff, and the two failure shapes told apart
+# 3. pgw#972: which retry branch each failure shape takes
+#
+# These assert the DECISION, never the runner's speed (pgw#795): the loop logs
+# the classification it made and the delay it scheduled, so the branch taken is
+# the work's product and is observable without a clock. Timing the download and
+# comparing to a constant would measure the CI runner, and would go red on a
+# loaded box while the policy was perfectly correct.
 # ---------------------------------------------------------------------------
 
-def test_zero_byte_failures_back_off(tmp_path: Path, server, monkeypatch) -> None:
+def _decisions(caplog, sha256: str):
+    """(route_alive, retry_in) for each retry decision about one chunk."""
+    out = []
+    for line in caplog.text.splitlines():
+        if "chunk_refetch" not in line or sha256[:12] not in line:
+            continue
+        alive = line.split("route_alive=")[1].split()[0] == "True"
+        delay = float(line.split("retry_in=")[1].split("s")[0])
+        out.append((alive, delay))
+    return out
+
+
+def test_a_route_that_delivers_nothing_is_made_to_wait(
+    tmp_path: Path, server, monkeypatch, caplog,
+) -> None:
     """The defect: a chunk source that delivers NOTHING was retried with no
-    delay at all, so the whole budget burned inside a couple of seconds and a
-    transient TLS/connect blip failed the fetch."""
+    delay at all, so a transient TLS/connect blip burned the whole budget in
+    well under a second. Each such failure must now schedule a real delay, and
+    the delays must ESCALATE."""
     monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 0.5)
+    caplog.set_level("WARNING", logger="gen_worker.models.chunk_cas")
     payload = _body(CS * 2)
     specs = _publish(server, payload)
     with server.lock:
         server.fail_first[specs[0].sha256] = 3  # three connect-shaped failures
 
     local = tmp_path / "local" / "blob"
-    started = time.monotonic()
     download_chunked_file(
         specs, local, whole_digest="sha256:" + _sha(payload),
         total_size=len(payload), chunk_size_bytes=CS, window=2,
     )
-    elapsed = time.monotonic() - started
 
-    assert local.read_bytes() == payload
-    # Three failures at strikes 1..3, each sleeping uniform(0.5, 1.0) * cap.
-    assert elapsed >= 3 * 0.5 * 0.5, f"no backoff observed ({elapsed:.3f}s)"
+    assert local.read_bytes() == payload  # it still succeeds
+    decisions = _decisions(caplog, specs[0].sha256)
+    assert len(decisions) == 3
+    assert all(not alive for alive, _ in decisions), decisions
+    assert all(delay > 0 for _, delay in decisions), decisions
+    # Each scheduled delay lies in the window its own strike defines. The bound
+    # is DERIVED from the schedule, not a guess about how fast the box is.
+    cap = cc._CHUNK_BACKOFF_CAP_S
+    for strike, (_, delay) in enumerate(decisions, start=1):
+        window = min(cap, 2.0 ** strike)
+        assert 0.5 * window <= delay <= window, (strike, delay, decisions)
 
 
-def test_a_live_route_reconnects_without_sleeping(
-    tmp_path: Path, server, monkeypatch,
+def test_a_live_route_reconnects_at_once(
+    tmp_path: Path, server, monkeypatch, caplog,
 ) -> None:
     """pgw#786's rule survives: an attempt that DELIVERED ITS FLOOR and then
     died is a lemon CONNECTION, and the answer is a fresh socket NOW, not a
-    sleep. The read block and the floor are shrunk so the property is testable
+    sleep. The read block and the floor are shrunk so the property is reachable
     in kilobytes; the arithmetic under test is unchanged."""
     monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 30.0)
     monkeypatch.setattr(cc, "_READ_CHUNK_BYTES", 64)
     monkeypatch.setattr(cc, "_CHUNK_PROGRESS_FLOOR_BYTES", 128)
+    caplog.set_level("WARNING", logger="gen_worker.models.chunk_cas")
     payload = _body(CS * 2)
     specs = _publish(server, payload)
     with server.lock:
@@ -380,22 +408,52 @@ def test_a_live_route_reconnects_without_sleeping(
         server.trickle_bytes[specs[0].sha256] = 4096  # >> the shrunken floor
 
     local = tmp_path / "local" / "blob"
-    started = time.monotonic()
     download_chunked_file(
         specs, local, whole_digest="sha256:" + _sha(payload),
         total_size=len(payload), chunk_size_bytes=CS, window=2,
     )
-    elapsed = time.monotonic() - started
 
     assert local.read_bytes() == payload
-    assert elapsed < 5.0, f"a live route slept instead of reconnecting ({elapsed:.1f}s)"
+    decisions = _decisions(caplog, specs[0].sha256)
+    assert decisions, "no retry was recorded"
+    assert all(alive for alive, _ in decisions), decisions
+    assert all(delay == 0.0 for _, delay in decisions), decisions
+
+
+def test_a_digest_mismatch_refetches_at_once(
+    tmp_path: Path, server, monkeypatch, caplog,
+) -> None:
+    """A complete, wrong-hashing body proves the ROUTE is healthy and only the
+    bytes are not. Backing off there is pure loss — and it made an existing
+    permanently-bad-chunk test walk the whole ladder instead of failing fast."""
+    monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 30.0)
+    caplog.set_level("WARNING", logger="gen_worker.models.chunk_cas")
+    payload = _body(CS * 2)
+    specs = _publish(server, payload)
+    # Serve chunk 0 under a digest it does not hash to: every fetch is complete
+    # and every fetch mismatches.
+    with server.lock:
+        server.blobs[specs[0].sha256] = _body(CS, seed=99)
+
+    local = tmp_path / "local" / "blob"
+    with pytest.raises(Exception):
+        download_chunked_file(
+            specs, local, whole_digest="sha256:" + _sha(payload),
+            total_size=len(payload), chunk_size_bytes=CS, window=2,
+        )
+
+    decisions = _decisions(caplog, specs[0].sha256)
+    assert decisions, "no retry was recorded"
+    assert all(alive for alive, _ in decisions), decisions
+    assert all(delay == 0.0 for _, delay in decisions), decisions
 
 
 def test_a_dead_route_gives_up_on_a_COUNT_not_a_clock(
     tmp_path: Path, server, monkeypatch,
 ) -> None:
     """The give-up is `_CHUNK_MAX_ATTEMPTS` attempts, per `stall.py`'s standing
-    rule that nothing which ends real work may key on a wall clock."""
+    rule that nothing which ends real work may key on a wall clock. The
+    evidence is the SERVER's hit count, which no amount of box load can move."""
     monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 0.05)
     payload = _body(CS * 2)
     specs = _publish(server, payload)


### PR DESCRIPTION
Closes the buildable parts of **pgw#971** and **pgw#972**.

> Paul: *"It should not be synchronous; ideally we should be filling both stores (local-volume, NFS volume) at the same time as fast as possible."*

## pgw#971 — the volume write-through

A fresh R2 fetch landed in local CAS and was **then** republished to the endpoint volume: `copyfileobj` to NFS, three fsyncs, and a `hash_file` that read the whole blob **back off NFS** to verify a write we had just performed. Three extra passes over every fresh byte, the most expensive of them a network-storage read, all awaited inline.

**Tee.** `download_chunked_file` takes `mirror_dst` and `pwrite`s every block to its offset in a volume-side part file in the same loop that writes the local one, so the volume write hides behind network latency. Chunked blobs are where a multi-GB keep-set's bytes live (the hub chunks anything over 64 MiB).

The in-order-commit worry in the issue was **stale**: th#1362 already replaced in-order commit with positional materialisation plus a prefix-following hasher, so teeing is one extra `pwrite` and nothing more — no second journal, no buffering. Invariants held rather than weakened:

* the mirror stages **writer-unique** (`.<blob>.mirror-<pid>-<uuid>`) and is renamed to the digest name **only after the LOCAL file passes its whole-file sha256** — a half-written volume blob is never readable as complete, and a concurrent pod's published blob is never written into;
* resume still works — adopted chunks are not refetched, so `_seed_mirror` copies those already-verified ranges off local disk; a mirror with holes cannot happen;
* every mirror failure (open / allocate / write / publish) disables the mirror and is never propagated.

**Background the fallback.** Whole-file and un-teed blobs still take `_fill_to_volume`, but as a task collected in `ensure_snapshot` and joined in its `finally` with `return_exceptions=True`. Best-effort in OUTCOME, never in LIFETIME.

**Fuse the write-path hash, do not delete it** (pgw#769). `_copy_verified_blob` hashes each block as it writes it. Verification stays mandatory in both directions — including the one that matters, bytes read *from* the volume — and only the read-back pass goes.

**Do not preallocate the mirror.** glibc's `posix_fallocate` zero-fills by hand where the filesystem has no `fallocate(2)`, which network storage frequently does not; that would be a full extra write pass to the volume. `ftruncate` only. Local CAS keeps the real allocation.

## pgw#972 — backoff

`chunk_cas.py` contained no `time.sleep` at all: a failed chunk was retried immediately, six times, so a fault needing seconds to clear burned the whole budget in well under a second. The whole-file path in `cozy_cas.py` has had jittered `2**n` backoff all along. Now it classifies first:

* **`DigestMismatch`** — a complete, wrong-hashing body. The route is demonstrably healthy; refetch **at once**.
* **transport error that cleared the progress floor** — pgw#786's lemon connection. Fresh socket **at once**, backoff cleared.
* **transport error that delivered nothing** — the network is not there. Back off `uniform(0.5,1.0) * min(30, 2**n)`, up to 8 attempts.

The give-up is a **COUNT, never a clock** (`stall.py`'s standing rule). A sibling's fatal failure sets an event that cuts short the others' sleeps so the pool drains promptly.

Two corrections to the issue text, both measured:
* there is no third *"trickle"* class — `delivered` counts blocks `iter_content` actually yields, and a connection dying mid-block yields nothing (a source that sent 64 bytes and hung up reported `delivered=0`);
* backing off on `DigestMismatch` made `test_a_bad_chunk_is_abandoned_and_refetched` take ~60 s instead of milliseconds. Caught by the existing suite, fixed by the classification above.

**Cross-pod resume is NOT built** — see the tracker. The volume *can* carry partial chunk state safely (`_adopt_partial` re-hashes every claimed range), but it would need a stable cross-pod name, and today the volume holds only complete digest-verified blobs by the th#850/gw#599 ruling. That is Paul's call, not a lane's; the recommended shape is recorded in pgw#972.

## Measurement — method and limits

Real `ensure_snapshot_async`; real threaded HTTP server serving 64 MiB CAS chunks at a capped 150 MB/s per connection; 2.00 GiB payload as 4 x 512 MiB; local CAS cold every run. The "volume" is a **real FUSE passthrough filesystem** with injected write bandwidth and fsync latency, standing in for NFS — every operation on it is a real syscall. Before-arm is a detached worktree at the pre-change commit, not a re-implementation.

**Deterministic, load-independent — volume traffic per 2.00 GiB fill:**

| arm | volume writes | volume READS | fsyncs |
|---|---|---|---|
| before | 2.00 GiB | **2.00 GiB** | 8 |
| after | 2.00 GiB | **0.00 GiB** | 4 |

**Wall clock** (shared box, 1-min load 4-22, reported as a spread): fetch alone 3.2-4.0 s; before 8.5-20.3 s; after 6.6-9.8 s (plus one 41 s outlier at load 22, reported not dropped).

**Limits, stated plainly.** A Python FUSE passthrough is not NFS, and two of its limits cut *against* this change: it charges per-request latency rather than a shared link (an aggregate token bucket was tried and wedged the FUSE worker pool; the one sample taken before it wedged put the before-arm at **16.35 s**), and the before-arm's re-read is served partly from the backing filesystem's page cache. The byte-count table does not depend on the stand-in at all.

## CI round 1 caught a real test-quality defect (fixed in commit 2)

The first push went red on `tests/test_magic_timeouts_gw666.py` — the standing **pgw#795** gate against new elapsed-vs-constant assertions. **The gate was right.** Both backoff tests timed the download and compared to a literal (`assert elapsed >= 3 * 0.5 * 0.5`), which measures the CI runner rather than the retry policy, and would go red on a loaded box while the code was perfectly correct.

Fixed by asserting the **decision** instead of the clock. The loop already logs `route_alive=` and `retry_in=`, so the branch taken is the work's product and is observable with no clock at all:

* nothing delivered -> `route_alive=False`, a delay is scheduled, and each delay falls inside the window its own strike defines (bound **derived** from the schedule and the monkeypatched cap);
* floor cleared -> `route_alive=True`, `retry_in=0`;
* `DigestMismatch` -> `route_alive=True`, `retry_in=0` — a new test, and the one that catches the ~60 s stall that backing off on a mismatch reintroduces.

The give-up test already asserted the server's hit count `== _CHUNK_MAX_ATTEMPTS`, a count no box load can move; unchanged. No burn-down entry was added — the assertion was rewritten.

`retry_in` also went `%.1f` -> `%.3f`: sub-100 ms delays rendered as `0.0s` are useless in forensics, and that rounding is what made the first rewrite of these tests read a real delay as none.

## Tests — RED then GREEN

`tests/test_volume_tee_pgw971.py`, 11 integration tests over the real threaded HTTP server. Four independent RED proofs, each reverting one change and each failing the tests that assert it:

| reverted | red |
|---|---|
| tee disabled (`_open_mirror` -> `None`) | 3 failed |
| fused hash removed | 1 failed |
| backoff removed | 1 failed |
| partial mirror published on failure | 1 failed |
| backoff removed (rewritten test) | 1 failed |
| `DigestMismatch` arm removed | 1 failed — and the run takes 94s vs 19s green, the stall itself |

GREEN: `119 passed, 1 skipped` across `test_volume_tee_pgw971`, `test_chunk_cas_parallel_th1362`, `test_chunk_cas_pgw781`, `test_managed_tier_fill_source`, `test_snapshot_v2_fill_pgw781`, `test_snapshot_verify_pgw781`, `test_p4_cas_multiwriter_integrity`, `test_chunk_upload_pgw781`, plus `test_magic_timeouts_gw666` (the gate itself). `mypy src/gen_worker` clean (230 files); `ruff check src/gen_worker` clean; `lint_http_timeouts.py` and `lint_unreached_surface.py` exit 0.

No version bump — `pyproject.toml`, `uv.lock` and `fleet-floors.toml` are untouched. If this needs a release, sequence it separately.