### PR TITLE
pgw#973/§4.24: an absent stall window is a refusal, not an infinite one (+ the 383-bound census)

### DIFF
--- a/changelog.d/pgw973.md
+++ b/changelog.d/pgw973.md
@@ -1,0 +1,16 @@
+- **pgw#973: an absent stall window silently deleted the download watchdog.**
+  `_run_with_stall_watchdog` built its silence window as
+  `SilenceWindow(stall_timeout if stall_timeout > 0 else math.inf)`.
+  `SilenceWindow.__init__` raises `ValueError("window_s must be positive")`
+  precisely so a zero cannot delete the watchdog — that expression caught the
+  refusal and substituted an infinite window instead, so a caller passing 0 (or
+  a computed budget that came out 0) got a model download with *no stall
+  detection at all*: the unbounded `DOWNLOADING_MODELS` hang gw#456/pgw#655
+  exist to prevent, reached through the guard written to prevent it. Both
+  production call sites pass `_HF_DOWNLOAD_STALL_TIMEOUT_S`, so this was latent
+  — one keyword argument from live, and the module's own comment already
+  records that the sibling wall-clock bound "sat at 0.0 for its whole life",
+  i.e. this exact collapse happened once in production and went unnoticed. The
+  guard now refuses, per DESIGN-RULINGS §4.24 item 4: an unset limit is a typed
+  default or a refusal, never an emergent one. RED-verified — restoring the
+  `math.inf` expression fails all three absence cases.

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import math
 import os
 import re
 import threading
@@ -538,7 +537,13 @@ def _run_with_stall_watchdog(
     # what counts as an advance (a trickle never does), the window decides how
     # long an unadvanced loop may run. Same pair now guards the CAS fetch.
     floor = ProgressFloor(max(int(min_window_bytes), 1))
-    window = SilenceWindow(stall_timeout if stall_timeout > 0 else math.inf)
+    # DESIGN-RULINGS §4.24 item 4: an unset limit is a REFUSAL, never an
+    # emergent one. This used to read `stall_timeout if stall_timeout > 0 else
+    # math.inf`, which defeated SilenceWindow's own `window_s must be positive`
+    # guard — the guard exists precisely so a zero cannot silently delete the
+    # watchdog and hand a wedged download the unbounded hang gw#456 was filed
+    # for. Let it refuse.
+    window = SilenceWindow(stall_timeout)
     while not holder.get("done"):
         dl_thread.join(timeout=poll_interval)
         if holder.get("done"):

--- a/tests/test_absent_stall_window_refuses_pgw973.py
+++ b/tests/test_absent_stall_window_refuses_pgw973.py
@@ -1,0 +1,95 @@
+"""pgw#973 / DESIGN-RULINGS §4.24 item 4 — an unset limit is a REFUSAL.
+
+`_run_with_stall_watchdog` built its silence window as::
+
+    window = SilenceWindow(stall_timeout if stall_timeout > 0 else math.inf)
+
+`SilenceWindow.__init__` raises ``ValueError("window_s must be positive")``
+precisely so a zero cannot delete the watchdog. That expression caught the
+refusal and substituted an infinite window instead — so a caller passing 0 (or
+a computed budget that came out 0) got a download with *no stall detection at
+all*: the unbounded DOWNLOADING_MODELS hang gw#456/pgw#655 exist to prevent,
+reached through the very guard written to prevent it.
+
+This is the th#1615 shape — absence collapsing to "unlimited" — one keyword
+argument away from live. Both production call sites
+(``download.py`` HF snapshot, ``convert/ingest.py``) pass
+``_HF_DOWNLOAD_STALL_TIMEOUT_S``, so nothing changes for them; what changes is
+that a future caller that forgets is told, at the call, instead of silently
+running unbounded.
+
+No sleeps, no fixed durations: the stall assertion below drives the watchdog's
+own progress signal to a standstill and reads its verdict.
+
+Run: pytest tests/test_absent_stall_window_refuses_pgw973.py -v
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from gen_worker.models.download import DownloadStalledError, _run_with_stall_watchdog
+
+
+def _watchdog(byte_totals: Iterator[int], *, stall_timeout: float) -> str:
+    """Drive the real watchdog with a scripted bytes-on-disk signal."""
+    done = threading.Event()
+    last = [0]
+
+    def _download() -> str:
+        done.wait(timeout=30.0)
+        return "/tmp/pgw973-done"
+
+    def _scan(_root: Path) -> int:
+        try:
+            last[0] = next(byte_totals)
+        except StopIteration:
+            done.set()
+        return last[0]
+
+    try:
+        return _run_with_stall_watchdog(
+            _download,
+            label="pgw973",
+            progress_root=Path("/nonexistent"),
+            progress_callback=None,
+            total_hint=None,
+            stall_timeout=stall_timeout,
+            min_window_bytes=1024,
+            scan_bytes=_scan,
+            poll_interval=0.01,
+        )
+    finally:
+        done.set()
+
+
+@pytest.mark.parametrize("absent", [0, 0.0, -1.0])
+def test_an_absent_stall_window_is_refused_not_silently_infinite(absent: float) -> None:
+    """The bug: 0 used to mean math.inf — the limit stopped existing."""
+    with pytest.raises(ValueError) as exc:
+        _watchdog(iter([1, 2, 3]), stall_timeout=absent)
+    assert "window_s must be positive" in str(exc.value), (
+        "a non-positive stall window must be refused by SilenceWindow's own guard; "
+        "substituting an unbounded window is how a watchdog silently stops existing"
+    )
+
+
+def test_the_watchdog_still_catches_the_runaway_it_exists_for() -> None:
+    """The surviving bound, unchanged: a trickle below the progress floor is a
+    stall however long it keeps dribbling. Deleting the math.inf escape hatch
+    must not have weakened this."""
+    trickle = (n for n in range(1, 10_000))
+    with pytest.raises(DownloadStalledError) as exc:
+        _watchdog(trickle, stall_timeout=0.2)
+    assert "stalled" in str(exc.value)
+
+
+def test_a_healthy_transfer_is_still_admitted() -> None:
+    """And a transfer clearing the floor every window runs to completion —
+    the refusal above is on absence, not on slow-but-advancing work."""
+    healthy = iter([2048 * n for n in range(1, 6)])
+    assert _watchdog(healthy, stall_timeout=5.0) == "/tmp/pgw973-done"


### PR DESCRIPTION
Applies **DESIGN-RULINGS §4.24**. Tracker: **pgw#973** (sibling **th#1620**, which carries the cross-repo count and the delegated-RPM re-examination).

## The fix

`_run_with_stall_watchdog` built its silence window as

```python
window = SilenceWindow(stall_timeout if stall_timeout > 0 else math.inf)
```

`SilenceWindow.__init__` raises `ValueError("window_s must be positive")` **precisely so a zero cannot delete the watchdog**. That expression caught the refusal and substituted an infinite window instead — so a caller passing 0, or a computed budget that came out 0, got a model download with *no stall detection at all*: the unbounded `DOWNLOADING_MODELS` hang gw#456 / pgw#655 exist to prevent, reached through the guard written to prevent it.

This is the th#1615 shape (absence collapsing to "unlimited"). Latent, not live — both production call sites (`download.py` HF snapshot, `convert/ingest.py`) pass `_HF_DOWNLOAD_STALL_TIMEOUT_S`. But it is one keyword argument away, and `download.py`'s own comment records that the sibling wall-clock bound *"sat at 0.0 for its whole life"*: this collapse has already happened once here and went unnoticed.

Per §4.24 item 4 — an unset limit is a typed stated default or a refusal, never an emergent one — the guard now refuses.

## Proof

`tests/test_absent_stall_window_refuses_pgw973.py` drives the real watchdog:

- `0`, `0.0`, `-1.0` are refused at the call;
- the trickle-is-a-stall runaway the watchdog exists for is still caught;
- a slow-but-advancing transfer is still admitted — so the refusal is on absence, not on slowness.

No sleeps, no fixed durations: the stall assertion drives the watchdog's own progress signal to a standstill and reads its verdict.

**RED verified** — restoring the `math.inf` expression fails all three absence cases with `DID NOT RAISE ValueError`. Green with the existing pgw#655 suite (11 passed, Python 3.12).

## Census result — filed on pgw#973, not in this PR

**~383 numeric bounds** in `src/gen_worker/**`; 61 of 298 named constants state no threat; 97% hardcoded (exactly 10 env-tunable).

**Shape C is clean.** A programmatic reference count over all 416 uppercase numeric constants finds **zero** that are referenced only from tests — pgw#892 closed that shape. One dead constant survives (`models/memory.py:43`).

**The headline open finding:** `parallel/group.py:66` `_ARM_TIMEOUT_S = 1800.0` bounds a follower's full cold model load on a flat deadline, with `check_alive()` ("has this process exited yet") as its only liveness test — while `runtimes/server.py:30-43`, in the same package, rejects that exact construction by name and calls `boot_timeout_s=1800` *"the same mistake with a bigger number"*, having been rewritten to a `SilenceWindow`. The SP lane was never migrated. **Not fixed here on purpose:** the leader has no progress signal to build a window over (`FollowerChannel.ready` carries one terminal event), so the real fix is a follower-side progress marker during materialization — a protocol change that wants its own issue and tests, not a census lane's drive-by.

Also filed: five more fixed-duration kills (and the ones that are explicitly *not* violations, recorded so they are not re-litigated), five more absence-collapses including a two-collapses-in-one-line `or` chain in `aot_resume.py:150`, and the redundancy set — six copies of the safetensors header cap, one disagreeing by 5x.

Branches from and targets `dev` (85 commits ahead of `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)