### PR TITLE
pgw#974: one resolution per slot — the mint boundary stops carrying three views of it

### DIFF
--- a/changelog.d/pgw974.md
+++ b/changelog.d/pgw974.md
@@ -1,0 +1,22 @@
+- **pgw#974: one resolution per slot on the mint boundary, so the shape that
+  cost two L40S pods cannot be written down.** `MintRequest` carried three
+  parallel slot-keyed dicts — `snapshots` (bytes), `slot_bindings` (identity,
+  pgw#969) and `component_paths` (composition, pgw#816) — written by three
+  separate statements and each independently allowed to be empty.
+  `{"pipeline": "/tmp/x"}` with no binding decoded, type-checked and looked
+  complete; that is exactly the request pgw#969 was filed for. All three fields
+  are deleted and replaced by `slots: Dict[str, MintSlot]`, where `MintSlot`
+  carries `ref` and `path` with **no defaults** plus the per-component
+  overrides. A slot with bytes and no identity now fails at the constructor
+  *and* at `msgspec` decode, so the boundary file itself rejects it; a slot the
+  parent did not resolve is ABSENT, and `mint_child.assert_slots_resolvable`
+  still refuses that by name before a weight is read.
+
+- **pgw#974: the producer writes the resolution once.** `_setup_locked_inner`
+  built the path, the binding and the overrides in one loop and then published
+  them as three fields that could drift; it now emits one `MintSlot` per slot,
+  and the plain path / plain override views the in-process loaders take are
+  derived from it rather than maintained beside it. `_BackgroundMint`,
+  `MintTask` and `MintRequest` each lost three fields and gained one.
+  `bind_slots` and `assert_composable` read the single source. Pre-launch
+  hardcut: no dual-read and no acceptance of the old wire.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -43,6 +43,7 @@ from . import worker_credential
 from . import mint_goal as mint_goal_mod
 from . import worker_goals
 from .api.binding import ModelRef, wire_ref
+from .mint_process import MintSlot
 from .api.errors import (
     ArtifactTransferError,
     CanceledError,
@@ -2812,25 +2813,15 @@ class _BackgroundMint:
     seed_ctx: Optional[Any] = None
     # pgw#784: the two facts a DELEGATED mint's child process needs and cannot
     # rediscover for itself — the endpoint module(s) to walk (the child re-runs
-    # discovery in a fresh interpreter) and the ALREADY-materialized local
-    # snapshot path per setup slot. The paths matter: a mint is compute, and a
-    # mint process that could download is a mint process that can stall on a
-    # lemon host (pgw#786).
+    # discovery in a fresh interpreter) and the parent's own RESOLUTION of each
+    # setup slot: identity, already-materialized local tree, and pgw#617
+    # composition, in ONE value per slot (pgw#974, `mint_process.MintSlot`).
+    # The paths matter because a mint is compute, and a mint process that could
+    # download is one that can stall on a lemon host (pgw#786); the refs matter
+    # because `ctx.slots` is built from bindings and the child rediscovers none
+    # for a hub-catalog slot (pgw#969).
     modules: Tuple[str, ...] = ()
-    snapshot_paths: Dict[str, str] = dc_field(default_factory=dict)
-    # pgw#816: and the THIRD fact, which the first delegated mint in
-    # production died without — the resolved component overrides (pgw#617),
-    # slot -> comp -> local tree. th#1330 B2 excludes an overridden
-    # component's files from the base fetch, so `snapshot_paths` alone names
-    # a narrowed tree (`<digest>__x<fp>`) that no loader can open.
-    component_paths: Dict[str, Dict[str, str]] = dc_field(default_factory=dict)
-    # pgw#969: and the FOURTH — slot -> the RESOLVED ModelRef behind that
-    # path. `snapshot_paths` says which bytes to load; `ctx.slots` is built
-    # from bindings, and the child re-runs discovery, so a hub-catalog slot
-    # (no code `default_checkpoint=`) rediscovers NOTHING. Its warm request
-    # reached the endpoint's own handler unbound and died at
-    # `ctx.slots["pipeline"]` 0.0s into `warmup_forward`.
-    slot_bindings: Dict[str, ModelRef] = dc_field(default_factory=dict)
+    slots: Dict[str, MintSlot] = dc_field(default_factory=dict)
     # th#1299: WHY this mint was asked to stop. The abort event used to report
     # "(adopt-on-arm / vacate / shutdown)" — three unrelated causes in one
     # string — so a mint that died could not be told from a mint that was
@@ -6737,14 +6728,13 @@ class Executor:
             slot: wire_ref(spec.models[slot]) for slot in setup_slots
         }
         slot_identities: Dict[str, _ResidencyIdentity] = {}
-        paths: Dict[str, str] = {}
-        # pgw#969: the BINDING behind each of those paths, kept in step with
-        # `paths` by construction — the two are one resolution, and a mint
-        # child handed only the paths cannot say which checkpoint they are.
-        slot_bindings: Dict[str, ModelRef] = {}
-        # pgw#617: component-override materializations, slot -> comp -> local
-        # path, plus per-override-ref snapshot digests (identity facts).
-        component_paths: Dict[str, Dict[str, str]] = {}
+        # pgw#974: ONE resolution per slot — the binding, the tree its bytes
+        # were materialized into, and the pgw#617 component overrides that
+        # complete the composition. Written by a single statement per slot, so
+        # the three cannot drift apart or arrive without one another; the
+        # plain-path and plain-override views the local loaders take are
+        # DERIVED from it below, never maintained beside it.
+        resolved_slots: Dict[str, MintSlot] = {}
         override_digests: Dict[str, str] = {}
         self._intent_transition(
             intent_id,
@@ -6757,9 +6747,8 @@ class Executor:
             snap = (snapshots or {}).get(ref)
             materialized = await self.store._materialize_local(
                 ref, snap, binding=binding)
-            paths[slot] = str(materialized.path)
-            slot_bindings[slot] = binding
             slot_identities[slot] = materialized.identity
+            comps: Dict[str, str] = {}
             for comp, comp_ref in _component_overrides(binding):
                 try:
                     comp_binding = self._hub_binding(comp_ref)
@@ -6771,9 +6760,17 @@ class Executor:
                 comp_mat = await self.store._materialize_local(
                     comp_ref, (snapshots or {}).get(comp_ref),
                     binding=comp_binding)
-                component_paths.setdefault(slot, {})[comp] = str(comp_mat.path)
+                comps[comp] = str(comp_mat.path)
                 if comp_mat.identity[0]:
                     override_digests[comp_ref] = comp_mat.identity[0]
+            resolved_slots[slot] = MintSlot(
+                ref=binding, path=str(materialized.path),
+                component_paths=comps)
+        paths: Dict[str, str] = {
+            slot: res.path for slot, res in resolved_slots.items()}
+        component_paths: Dict[str, Dict[str, str]] = {
+            slot: dict(res.component_paths)
+            for slot, res in resolved_slots.items() if res.component_paths}
         eager_only = self._eager_only_reason()
         if eager_only and spec.compile is not None:
             logger.info("%s: %s", spec.name, eager_only)
@@ -7014,12 +7011,7 @@ class Executor:
                     pipes=mint_pipes,
                     selections=mint_selections,
                     modules=_mint_modules(spec),
-                    snapshot_paths=dict(paths),
-                    slot_bindings=dict(slot_bindings),
-                    component_paths={
-                        slot: dict(comps)
-                        for slot, comps in component_paths.items() if comps
-                    },
+                    slots=dict(resolved_slots),
                 )
                 logger.info(
                     "eager-first boot for %s (pgw#671): READY at eager tier "
@@ -10076,12 +10068,7 @@ class Executor:
                     pipe=pipe,
                     function=spec.name,
                     modules=bg.modules or _mint_modules(spec),
-                    snapshots=dict(bg.snapshot_paths),
-                    slot_bindings=dict(bg.slot_bindings),
-                    component_paths={
-                        slot: dict(comps)
-                        for slot, comps in bg.component_paths.items()
-                    },
+                    slots=dict(bg.slots),
                     weight_lane=compile_cache.cell_base_execution_lane(pipe),
                     execution_lane=self._served_execution_lane(spec),
                     configs={spec.name: self._effective_config(spec)},

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -69,6 +69,7 @@ from .mint_process import (
     EXIT_RESOURCE,
     MintReport,
     MintRequest,
+    MintSlot,
     frame_line,
 )
 
@@ -264,7 +265,7 @@ def mint_identity(request: MintRequest) -> str:
         f"fn={request.function!r} recipe={request.recipe!r}")
 
 
-def bind_slots(specs: Sequence[Any], bindings: Mapping[str, Any]) -> None:
+def bind_slots(specs: Sequence[Any], resolved: Mapping[str, MintSlot]) -> None:
     """Install the PARENT's resolved slot bindings onto rediscovered specs.
 
     The child re-runs discovery in a fresh interpreter, so ``spec.models``
@@ -279,12 +280,10 @@ def bind_slots(specs: Sequence[Any], bindings: Mapping[str, Any]) -> None:
     would move its key out from under its siblings and silently narrow the
     class-scoped warm plan (pgw#654) to one lane.
     """
-    if not bindings:
-        return
     for spec in specs:
-        for slot, binding in bindings.items():
+        for slot, res in resolved.items():
             if slot in spec.slots or slot in spec.models:
-                spec.models[slot] = binding
+                spec.models[slot] = res.ref
 
 
 def assert_slots_resolvable(
@@ -307,7 +306,7 @@ def assert_slots_resolvable(
     """
     from . import warmup as warmup_mod
 
-    bound = set(request.slot_bindings)
+    bound = set(request.slots)
     problems: List[str] = []
     for spec in specs:
         missing = sorted(
@@ -321,14 +320,15 @@ def assert_slots_resolvable(
                 f"slot {name!r} of {spec.name!r}: the parent sent no resolved "
                 f"binding for it and the endpoint declares no "
                 f"default_checkpoint, so this child has no checkpoint to "
-                f"trace (MintRequest.slot_bindings carries "
+                f"trace (MintRequest.slots carries "
                 f"{sorted(bound) or '(nothing)'})")
         errors = warmup_mod.resolved_slots_kwargs(spec, None)["slot_errors"]
         for name, why in sorted(errors.items()):
-            if name in bound:
+            resolved = request.slots.get(name)
+            if resolved is not None:
                 problems.append(
                     f"slot {name!r} of {spec.name!r}: the parent's binding "
-                    f"{getattr(request.slot_bindings.get(name), 'path', '')!r} "
+                    f"{resolved.ref.path!r} "
                     f"crossed but does not resolve in this process — {why}")
     if not problems:
         return
@@ -339,9 +339,7 @@ def assert_slots_resolvable(
           "to load.")
 
 
-def assert_composable(
-    snapshots: Dict[str, str], overrides: Dict[str, Dict[str, str]],
-) -> None:
+def assert_composable(resolved: Mapping[str, MintSlot]) -> None:
     """pgw#816: refuse a request that describes a tree this child cannot load.
 
     A materialized snapshot path is not self-describing except in one
@@ -359,8 +357,8 @@ def assert_composable(
     from .models.cozy_snapshot import dir_key_excludes_components
 
     bad = sorted(
-        slot for slot, path in snapshots.items()
-        if dir_key_excludes_components(path) and not overrides.get(slot)
+        slot for slot, res in resolved.items()
+        if dir_key_excludes_components(res.path) and not res.component_paths
     )
     if not bad:
         return
@@ -369,7 +367,7 @@ def assert_composable(
         f"(the overridden component's files were excluded from the fetch) "
         f"but this request carries no component override for them, so the "
         f"composition cannot be rebuilt: "
-        + "; ".join(f"{slot}={snapshots[slot]}" for slot in bad))
+        + "; ".join(f"{slot}={resolved[slot].path}" for slot in bad))
 
 
 def _pick_compile_target(loaded: Dict[str, Any], cfg: Any) -> Tuple[str, Any]:
@@ -689,14 +687,17 @@ def _mint_aot(
 
 def mint(request: MintRequest) -> MintReport:
     """Build the cell. Raises ``MintChildRefused`` for a named refusal."""
+    # The two views ``cli.run.run_setup`` takes, both DERIVED from the one
+    # resolution (pgw#974) rather than carried beside it.
+    paths = {slot: res.path for slot, res in request.slots.items()}
     overrides = {
-        slot: dict(comps)
-        for slot, comps in request.component_paths.items() if comps
+        slot: dict(res.component_paths)
+        for slot, res in request.slots.items() if res.component_paths
     }
     # pgw#816: the request's SHAPE is checked before anything heavy is
     # imported or a single weight is read — a composition this child cannot
     # rebuild is a wiring refusal, not a load crash eight seconds in.
-    assert_composable(dict(request.snapshots), overrides)
+    assert_composable(request.slots)
 
     from . import compile_cache as cc
     from . import env_seal
@@ -733,7 +734,7 @@ def mint(request: MintRequest) -> MintReport:
     spec, siblings = select_specs(specs, request.function)
     # pgw#969: the parent's resolution, installed on the rediscovered specs
     # BEFORE anything is loaded — and the refusal, if it cannot be.
-    bind_slots(siblings, request.slot_bindings)
+    bind_slots(siblings, request.slots)
     assert_slots_resolvable(siblings, request)
     cfg = compile_cfg(request.cfg)
 
@@ -749,7 +750,7 @@ def mint(request: MintRequest) -> MintReport:
 
         obj = spec.cls()
         got = run_setup(
-            obj, dict(request.snapshots), arm_compile=False,
+            obj, dict(paths), arm_compile=False,
             return_loaded=True, component_paths=overrides) or {}
         _slot, loaded_pipe = _pick_compile_target(got, cfg)
         frame(phase="load", note=f"compile target on slot {_slot!r}")
@@ -775,7 +776,7 @@ def mint(request: MintRequest) -> MintReport:
 
     instance = spec.cls()
     loaded = run_setup(
-        instance, dict(request.snapshots), arm_compile=False,
+        instance, dict(paths), arm_compile=False,
         return_loaded=True, component_paths=overrides) or {}
     slot, pipe = _pick_compile_target(loaded, cfg)
     frame(phase="load", note=f"compile target on slot {slot!r}")

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -95,17 +95,11 @@ class MintTask:
     pipe: Any
     function: str
     modules: Tuple[str, ...]
-    snapshots: Dict[str, str] = field(default_factory=dict)
-    # pgw#816: the parent's RESOLVED component overrides, slot -> comp ->
-    # local tree. Part of the composition, not a detail: the base snapshot is
-    # fetched with these components EXCLUDED (th#1330 B2), so a child handed
-    # only `snapshots` is handed a tree that cannot load.
-    component_paths: Dict[str, Dict[str, str]] = field(default_factory=dict)
-    # pgw#969: and the FOURTH — the resolved binding behind each of those
-    # paths. `snapshots` names bytes; only a binding names a checkpoint, and
-    # `ctx.slots` is built from bindings. Resolved by the parent in
-    # `_setup_locked_inner`, in the same loop that produced `snapshots`.
-    slot_bindings: Dict[str, Any] = field(default_factory=dict)
+    # pgw#974: the parent's resolution of each setup slot — identity, bytes and
+    # pgw#617 composition in ONE value, resolved together in
+    # `_setup_locked_inner` and carried together from here to the child. See
+    # `mint_process.MintSlot`.
+    slots: Dict[str, mint_process.MintSlot] = field(default_factory=dict)
     weight_lane: str = ""
     execution_lane: str = ""
     configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
@@ -201,12 +195,7 @@ def build_request(
         # later boot — finds the same bank.
         resume=str(aot_resume.bank_root(pending.cell_key)),
         cfg=cfg_spec(pending.cfg),
-        snapshots=dict(task.snapshots),
-        slot_bindings=dict(task.slot_bindings),
-        component_paths={
-            slot: dict(comps)
-            for slot, comps in task.component_paths.items() if comps
-        },
+        slots=dict(task.slots),
         device=-1 if task.device is None else int(task.device),
         vram_cap_bytes=int(cap_bytes),
         execution_lane=task.execution_lane,

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -70,7 +70,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
-from .api.binding import ModelRef
+from .api.binding import ModelRef, wire_ref
 from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
@@ -160,13 +160,53 @@ class CompileCellSpec(msgspec.Struct, frozen=True, kw_only=True):
     text_lens: Tuple[int, ...] = ()
 
 
-class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
-    """Everything the child needs, and nothing live.
+class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
+    """One setup slot, as the parent resolved it. Present and complete, or absent.
 
-    ``snapshots`` are LOCAL paths the parent already materialized, so the
-    child never touches the network: a mint is compute, and a mint process
-    that could download is a mint process that can stall on a lemon host.
+    pgw#974. This used to be THREE parallel slot-keyed dicts on
+    ``MintRequest`` — ``snapshots`` (bytes), ``slot_bindings`` (identity,
+    pgw#969) and ``component_paths`` (composition, pgw#816) — written by three
+    separate statements, each independently allowed to be empty. Two of the
+    three combinations that describes are incoherent, and one of them cost two
+    L40S pods: ``{"pipeline": "/tmp/x"}`` with no binding decoded, type-checked
+    and looked complete, and the child died 0.0 s into ``warmup_forward`` at
+    ``ctx.slots["pipeline"]``. ``ref`` and ``path`` therefore carry no
+    defaults: a slot with bytes and no identity cannot be constructed and
+    cannot be decoded.
+
+    A slot the parent did not resolve is ABSENT from the map — never a present
+    entry with a hole in it. ``mint_child.assert_slots_resolvable`` still
+    refuses one that the endpoint declares and does not mark optional.
+
+    * ``ref`` — WHICH checkpoint. ``ctx.slots`` is built from bindings, and a
+      child re-runs discovery, so a hub-catalog slot (``Slot(selected_by=...)``
+      with no ``default_checkpoint=``, which is sdxl's shape) rediscovers
+      nothing at all. A slot WITH a code default is the quieter half of the
+      same defect: the child resolves the DECLARED checkpoint while the parent
+      serves the hub's pick, and traces graphs for a model this pod never runs.
+    * ``path`` — WHERE its bytes already are, materialized by the parent, so
+      the child never touches the network: a mint is compute, and a mint
+      process that could download is one that can stall on a lemon host.
+    * ``component_paths`` — pgw#617 per-component overrides, comp -> that
+      component's own local tree. Empty for most slots and part of the
+      composition when not: th#1330 B2 EXCLUDES an overridden component's
+      files from the base fetch, so ``path`` alone then names a narrowed tree
+      (``<digest>__x<fp>``) that no loader can open.
     """
+
+    ref: ModelRef
+    path: str
+    component_paths: Dict[str, str] = {}
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError(
+                f"a resolved slot must name the tree its bytes are in; got an "
+                f"empty path for {wire_ref(self.ref)!r}")
+
+
+class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
+    """Everything the child needs, and nothing live."""
 
     function: str
     modules: Tuple[str, ...]
@@ -176,33 +216,9 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     capture: str         # TORCHINDUCTOR_CACHE_DIR / TRITON_CACHE_DIR root
     report: str          # typed terminal report the child writes
     cfg: CompileCellSpec
-    snapshots: Dict[str, str] = {}
-    #: pgw#969: the parent's RESOLVED per-slot bindings, slot -> ModelRef —
-    #: the same objects ``spec.models`` held when the parent materialized
-    #: ``snapshots`` above, so the two halves of one resolution travel
-    #: together.
-    #:
-    #: A path says which BYTES to load; a binding says which CHECKPOINT the
-    #: request is for, and only the second one reaches ``ctx.slots``. The
-    #: child re-runs discovery, so its ``spec.models`` holds only what the
-    #: DECORATOR declared — and a hub-catalog slot (``Slot(selected_by=...)``
-    #: with no ``default_checkpoint=``, which is the sdxl shape) declares
-    #: nothing at all. Its warmup request therefore reached the endpoint's own
-    #: handler with the slot unbound and died at ``ctx.slots["pipeline"]``
-    #: 0.0 s into ``warmup_forward``, twice, on two independent L40S pods.
-    #:
-    #: A slot WITH a code default is the quieter half of the same defect: the
-    #: child would resolve the DECLARED checkpoint while the parent serves the
-    #: hub's pick, and trace graphs for a model this pod never runs.
-    slot_bindings: Dict[str, ModelRef] = {}
-    #: pgw#816: slot -> component -> the OVERRIDE component's own local tree
-    #: (pgw#617 hierarchical bindings). A directory path alone does not
-    #: describe the composition: th#1330 B2 EXCLUDES an overridden
-    #: component's files from the base fetch, so the base tree the parent
-    #: hands over is narrowed (`<digest>__x<fp>`) and is not loadable on its
-    #: own. The parent resolved these; the child must load the same ones or
-    #: it is not compiling the pipeline the parent serves.
-    component_paths: Dict[str, Dict[str, str]] = {}
+    #: The parent's resolution, whole — slot -> identity + bytes + composition.
+    #: See ``MintSlot``: the three views this replaced could disagree.
+    slots: Dict[str, MintSlot] = {}
     device: int = -1     # CUDA ordinal; -1 = leave the child's default
     vram_cap_bytes: int = 0   # 0 = uncapped (see mint_budget.co_residency)
     #: pgw#848: where the child rewrites its live phase table, so a mint the

--- a/tests/test_cxx_toolchain_pgw823.py
+++ b/tests/test_cxx_toolchain_pgw823.py
@@ -145,7 +145,7 @@ def test_the_child_refuses_the_AOT_recipe_before_reading_weights(
     monkeypatch.setattr(cc, "cxx_toolchain_present", lambda: False)
 
     req = types.SimpleNamespace(
-        snapshots={}, component_paths={}, recipe=mint_child.RECIPE_AOT,
+        slots={}, recipe=mint_child.RECIPE_AOT,
         target="/tmp/x", capture="/tmp/y", device=0, vram_cap_bytes=0,
         modules=[], function="generate", cfg=None, configs={}, execution_lane="",
         report="/tmp/r", cell_key="")
@@ -174,7 +174,7 @@ def test_the_dynamo_recipe_is_NOT_refused_by_the_cxx_gate(
     monkeypatch.setattr(registry, "collect_endpoints", _reached)
 
     req = types.SimpleNamespace(
-        snapshots={}, component_paths={}, recipe=mint_child.RECIPE_DYNAMO,
+        slots={}, recipe=mint_child.RECIPE_DYNAMO,
         target="/tmp/x", capture="/tmp/y", device=0, vram_cap_bytes=0,
         modules=[], function="generate", cfg=None, configs={}, execution_lane="",
         report="/tmp/r", cell_key="")

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -43,7 +43,7 @@ import pytest
 
 from gen_worker import fleet_cells, mint_child, mint_delegate
 from gen_worker import mint_process as mp
-from gen_worker.api.binding import wire_ref
+from gen_worker.api.binding import ModelRef, wire_ref
 from gen_worker.cli import run as cli_run
 from gen_worker.executor import _BackgroundMint
 from gen_worker.models import provision
@@ -248,27 +248,27 @@ def test_the_parent_hands_its_resolved_overrides_across_the_wire(
                         text_lens=()),
         capture_dir=tmp_path / "capture", target=tmp_path / "cell.tar.gz",
         mint_root=tmp_path, recipe="aot")
-    overrides = {"pipeline": {"vae": "/cas/snapshots/sha256:beef"}}
+    resolved = mp.MintSlot(
+        ref=ModelRef(source="tensorhub", path="harness/composed", tag="prod"),
+        path="/cas/snapshots/sha256:cafe__xdeadbeef",
+        component_paths={"vae": "/cas/snapshots/sha256:beef"})
 
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
         pendings={}, pipes={}, selections={},
         modules=("app",),
-        snapshot_paths={"pipeline": "/cas/snapshots/sha256:cafe__xdeadbeef"},
-        component_paths=overrides,
+        slots={"pipeline": resolved},
     )
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function="gen",
-        modules=bg.modules, snapshots=dict(bg.snapshot_paths),
-        component_paths={k: dict(v) for k, v in bg.component_paths.items()},
+        modules=bg.modules, slots=dict(bg.slots),
         execution_lane="fp8-w8a16", device=0)
     request = mint_delegate.build_request(
         task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
 
     wire = msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
-    assert wire.component_paths == overrides, (
+    assert wire.slots == {"pipeline": resolved}, (
         "the child cannot rediscover an override it was never told about")
-    assert wire.snapshots == dict(bg.snapshot_paths)
 
 
 def test_the_executor_records_what_it_resolved() -> None:
@@ -277,7 +277,7 @@ def test_the_executor_records_what_it_resolved() -> None:
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
         pendings={}, pipes={}, selections={})
-    assert bg.component_paths == {}
+    assert bg.slots == {}
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +293,10 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
     single weight is read."""
     base, _vae = trees
     with pytest.raises(mint_child.MintChildRefused) as exc:
-        mint_child.assert_composable({"pipeline": str(base)}, {})
+        mint_child.assert_composable({"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/composed",
+                         tag="prod"),
+            path=str(base))})
     assert "pipeline" in str(exc.value)
     assert "override-narrowed" in str(exc.value)
     assert base.name in str(exc.value)
@@ -308,7 +311,10 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
         report=str(tmp_path / mp.REPORT_NAME),
         cfg=mp.CompileCellSpec(family="sdxl", shapes=((1024, 1024),),
                                targets=("unet",)),
-        snapshots={"pipeline": str(base)},
+        slots={"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/composed",
+                         tag="prod"),
+            path=str(base))},
     )
     with pytest.raises(mint_child.MintChildRefused):
         mint_child.mint(request)
@@ -319,18 +325,23 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
 def test_a_complete_tree_never_demands_overrides(tmp_path: Path) -> None:
     """The guard keys on the narrowing marker our own materializer writes —
     a bare-digest (complete) tree is loadable alone and must stay that way."""
+    ref = ModelRef(source="tensorhub", path="harness/composed", tag="prod")
+
+    def _one(key: str, **comps: str) -> Dict[str, mp.MintSlot]:
+        return {"pipeline": mp.MintSlot(
+            ref=ref, path=f"/cas/{key}", component_paths=dict(comps))}
+
     complete = snapshot_dir_key("sha256:cafe")
     subset = snapshot_dir_key("sha256:cafe", components=("vae",))
     narrowed = snapshot_dir_key("sha256:cafe", exclude=("vae",))
     assert complete == "sha256:cafe"
-    mint_child.assert_composable({"pipeline": f"/cas/{complete}"}, {})
+    mint_child.assert_composable(_one(complete))
     # A component-SCOPED subset is what the caller asked to fetch; loadable.
-    mint_child.assert_composable({"pipeline": f"/cas/{subset}"}, {})
+    mint_child.assert_composable(_one(subset))
     with pytest.raises(mint_child.MintChildRefused):
-        mint_child.assert_composable({"pipeline": f"/cas/{narrowed}"}, {})
+        mint_child.assert_composable(_one(narrowed))
     # With the override in hand, the same tree is composable.
-    mint_child.assert_composable(
-        {"pipeline": f"/cas/{narrowed}"}, {"pipeline": {"vae": "/cas/x"}})
+    mint_child.assert_composable(_one(narrowed, vae="/cas/x"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -130,7 +130,12 @@ def _request(
     tree: Path, binding: Any, tmp_path: Path, *, function: str = "catalog-generate",
 ) -> mp.MintRequest:
     """The child's request, built through the REAL parent chain and
-    round-tripped through msgspec — the boundary IS a file."""
+    round-tripped through msgspec — the boundary IS a file.
+
+    ``binding=None`` no longer means "a path with no ref" — pgw#974 made that
+    unrepresentable. It now means the parent resolved this slot not at all, so
+    the slot is ABSENT, which is the only shape a wiring gap can still take.
+    """
     pending = SimpleNamespace(
         family="pgw969", cell_key="ck5-catalog", recipe="dynamo",
         cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
@@ -143,14 +148,13 @@ def _request(
         spec=SimpleNamespace(name=function), instance=object(), snapshots=None,
         pendings={}, pipes={}, selections={},
         modules=(CATALOG_MODULE,),
-        snapshot_paths={"pipeline": str(tree)},
-        slot_bindings=({"pipeline": binding} if binding is not None else {}),
+        slots=({"pipeline": mp.MintSlot(ref=binding, path=str(tree))}
+               if binding is not None else {}),
     )
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function=function,
-        modules=bg.modules, snapshots=dict(bg.snapshot_paths),
-        slot_bindings=dict(bg.slot_bindings),
-        component_paths={}, execution_lane="w8a8-lora64", device=-1)
+        modules=bg.modules, slots=dict(bg.slots),
+        execution_lane="w8a8-lora64", device=-1)
     request = mint_delegate.build_request(
         task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
     return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
@@ -162,7 +166,7 @@ def _child_specs(request: mp.MintRequest) -> Tuple[Any, List[Any]]:
     bindings, and refuse if they cannot resolve."""
     specs = registry.collect_endpoints(list(request.modules))
     chosen, siblings = mint_child.select_specs(specs, request.function)
-    mint_child.bind_slots(siblings, request.slot_bindings)
+    mint_child.bind_slots(siblings, request.slots)
     mint_child.assert_slots_resolvable(siblings, request)
     return chosen, siblings
 
@@ -223,7 +227,8 @@ def test_the_child_warms_the_checkpoint_THE_PARENT_SERVED(
 
     instance = chosen.cls()
     loaded = cli_run.run_setup(
-        instance, dict(request.snapshots), arm_compile=False,
+        instance, {s: r.path for s, r in request.slots.items()},
+        arm_compile=False,
         return_loaded=True) or {}
     assert loaded["pipeline"] == str(tree)
 
@@ -267,7 +272,7 @@ def test_the_binding_crosses_the_wire_whole(
         binding, flavor="fp8", storage_dtype="fp8",
         component_overrides=(("vae", "harness/override-vae:prod"),))
     request = _request(tree, binding, tmp_path)
-    assert request.slot_bindings["pipeline"] == binding
+    assert request.slots["pipeline"].ref == binding
     _chosen, siblings = _child_specs(request)
     assert siblings[0].models["pipeline"].storage_dtype == "fp8"
     assert siblings[0].models["pipeline"].component_overrides == (
@@ -344,8 +349,9 @@ def test_a_bound_slot_that_still_fails_names_the_divergence(
         tmp_path, ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
         tmp_path)
     request = msgspec.structs.replace(
-        request, slot_bindings={"nonexistent-slot": ModelRef(
-            source="tensorhub", path="harness/pick", tag="prod")})
+        request, slots={"nonexistent-slot": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
+            path=str(tmp_path))})
     with pytest.raises(mint_child.MintChildRefused) as exc:
         _child_specs(request)
     assert "sent no resolved binding" in str(exc.value)
@@ -374,7 +380,8 @@ def test_a_code_default_never_stands_in_for_the_parents_pick(
     chosen, siblings = mint_child.select_specs(specs, "juggle-echo")
     assert wire_ref(chosen.models["pipeline"]) == declared
 
-    mint_child.bind_slots(siblings, {"pipeline": picked})
+    mint_child.bind_slots(siblings, {"pipeline": mp.MintSlot(
+        ref=picked, path=str(tmp_path))})
     with __import__("tempfile").TemporaryDirectory() as tmp:
         ctx = warmup.warm_context(
             chosen, request_id="mint-child-x", local_output_dir=tmp)
@@ -392,7 +399,7 @@ def test_the_default_is_empty_not_absent() -> None:
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
         pendings={}, pipes={}, selections={})
-    assert bg.slot_bindings == {}
+    assert bg.slots == {}
 
 
 def test_the_paths_and_the_bindings_travel_together(
@@ -403,5 +410,58 @@ def test_the_paths_and_the_bindings_travel_together(
     without the other is the shape this issue exists to make impossible."""
     tree, binding = served
     request = _request(tree, binding, tmp_path)
-    assert set(request.snapshots) == set(request.slot_bindings)
-    assert wire_ref(request.slot_bindings["pipeline"]) == PICK_REF
+    assert wire_ref(request.slots["pipeline"].ref) == PICK_REF
+    assert request.slots["pipeline"].path == str(tree)
+
+
+# ---------------------------------------------------------------------------
+# 6. pgw#974: the assertion above is now a TYPE, and the pod's request cannot
+#    be written down at all
+# ---------------------------------------------------------------------------
+
+
+def test_a_slot_with_bytes_and_no_identity_cannot_be_constructed() -> None:
+    """The pod's request, at the constructor.
+
+    pgw#969 made the binding travel; it could not stop a producer from
+    forgetting it, because ``snapshots`` and ``slot_bindings`` were two fields
+    with two defaults. ``ref`` and ``path`` now have none.
+    """
+    with pytest.raises(TypeError):
+        mp.MintSlot(path="/cas/snapshots/sha256:cafe")   # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        mp.MintSlot(ref=ModelRef(                        # type: ignore[call-arg]
+            source="tensorhub", path="harness/pick", tag="prod"))
+    # ...and the degenerate spelling of the same lie.
+    with pytest.raises(ValueError):
+        mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/pick", tag="prod"),
+            path="")
+
+
+def test_the_pods_wire_no_longer_decodes(
+    served: Tuple[Path, ModelRef], tmp_path: Path,
+) -> None:
+    """The decisive negative, on a REAL request off the real producer chain.
+
+    The boundary is a JSON file the child decodes, so the constructor above is
+    only half the guard: strip the identity out of a request the parent
+    actually built and the file must be REFUSED, not accepted as a complete
+    resolution the way the two L40S pods' was.
+    """
+    tree, binding = served
+    doc = msgspec.json.decode(msgspec.json.encode(_request(tree, binding, tmp_path)))
+    assert doc["slots"]["pipeline"]["path"] == str(tree)
+
+    del doc["slots"]["pipeline"]["ref"]
+    with pytest.raises(msgspec.ValidationError) as exc:
+        msgspec.json.decode(msgspec.json.encode(doc), type=mp.MintRequest)
+    assert "ref" in str(exc.value)
+
+    # The whole slot may still be absent — that is a resolution the parent did
+    # not make, and `assert_slots_resolvable` is what refuses it, by name.
+    doc["slots"] = {}
+    empty = msgspec.json.decode(msgspec.json.encode(doc), type=mp.MintRequest)
+    assert empty.slots == {}
+    with pytest.raises(mint_child.MintChildRefused):
+        _child_specs(empty)

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -34,6 +34,7 @@ import torch
 from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells, mint_budget, mint_delegate
 from gen_worker import mint_process as mp
+from gen_worker.api.binding import ModelRef
 from gen_worker.api.decorators import DynamicDim
 from gen_worker.registry import CompileCell
 from gen_worker.cell_adopt import AdoptOutcome
@@ -156,13 +157,15 @@ def test_the_request_carries_the_execution_lane_and_the_effective_config(
         mint_root=tmp_path)
     task = mint_delegate.MintTask(
         pending=pending, pipe=object(), function="gen",
-        modules=("app",), snapshots={"pipeline": "/cas/sdxl"},
+        modules=("app",), slots={"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="harness/sdxl",
+                         tag="prod"), path="/cas/sdxl")},
         execution_lane="fp8-w8a16", configs={"gen": {"steps": 28}}, device=3)
     req = mint_delegate.build_request(
         task, workdir=tmp_path / "w", cap_bytes=7 * GIB)
     assert req.execution_lane == "fp8-w8a16"
     assert req.configs == {"gen": {"steps": 28}}
-    assert req.snapshots == {"pipeline": "/cas/sdxl"}
+    assert req.slots["pipeline"].path == "/cas/sdxl"
     assert req.device == 3 and req.vram_cap_bytes == 7 * GIB
     assert req.capture == str(tmp_path / "capture")
 

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -34,6 +34,7 @@ import pytest
 
 import gen_worker.executor as executor_mod
 from gen_worker import fleet_cells, mint_budget, mint_delegate
+from gen_worker.api.binding import ModelRef
 from gen_worker import mint_process as mp
 from gen_worker.executor import (
     Executor,
@@ -51,6 +52,13 @@ from gen_worker.cell_adopt import AdoptOutcome
 
 GIB = 1 << 30
 STUB_MODULE = "harness.mint_child_stub"
+SDXL_REF = ModelRef(source="tensorhub", path="harness/sdxl", tag="prod")
+
+
+def _slot(path: str) -> mp.MintSlot:
+    """One resolved slot. ``ref`` has no default (pgw#974), so a test cannot
+    describe bytes without saying whose they are either."""
+    return mp.MintSlot(ref=SDXL_REF, path=path)
 
 
 class _Pipe:
@@ -156,20 +164,21 @@ def test_mint_modules_derives_from_the_declaring_module() -> None:
     assert _mint_modules(SimpleNamespace(module="")) == ()
 
 
-def test_background_mint_carries_the_modules_and_snapshot_paths(
+def test_background_mint_carries_the_modules_and_the_resolution(
     tmp_path: Path,
 ) -> None:
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=None, snapshots=None,
         pendings={}, pipes={}, selections={},
-        modules=("app",), snapshot_paths={"pipeline": "/cas/sdxl"})
+        modules=("app",), slots={"pipeline": _slot("/cas/sdxl")})
     assert bg.modules == ("app",)
-    assert bg.snapshot_paths == {"pipeline": "/cas/sdxl"}
+    assert bg.slots["pipeline"].path == "/cas/sdxl"
+    assert bg.slots["pipeline"].ref == SDXL_REF
     # Defaulted, so the in-process route is untouched by their existence.
     plain = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=None, snapshots=None,
         pendings={}, pipes={}, selections={})
-    assert plain.modules == () and plain.snapshot_paths == {}
+    assert plain.modules == () and plain.slots == {}
 
 
 # ------------------------------------- 3 + 4. the route and its outcomes
@@ -214,7 +223,7 @@ def _wired(
         pendings={id(p): pending for p in objs},
         pipes={id(p): p for p in objs}, selections={},
         modules=("harness.toy_endpoints",),
-        snapshot_paths={"pipeline": str(tmp_path / "snap")})
+        slots={"pipeline": _slot(str(tmp_path / "snap"))})
     monkeypatch.setattr(ex, "_served_execution_lane", lambda s, instructed="": "fp8-w8a16")
     monkeypatch.setattr(ex, "_effective_config", lambda s, run=None: {"steps": 28})
     monkeypatch.setattr(


### PR DESCRIPTION
## The gap this closes

`MintRequest` crossed the mint-delegation process boundary carrying **three parallel slot-keyed dicts**:

```python
snapshots:       Dict[str, str]              # slot -> local path
slot_bindings:   Dict[str, ModelRef]         # slot -> resolved checkpoint  (pgw#969)
component_paths: Dict[str, Dict[str, str]]   # slot -> component -> path    (pgw#816)
```

Three views of ONE resolution, written by three separate statements, each independently allowed to be empty. `{"pipeline": "/tmp/x"}` with no binding was a valid `MintRequest` — it decoded, it type-checked, it looked complete. It is also exactly the request that died `0.0s into warmup_forward` at `ctx.slots["pipeline"]`, twice, on two independent L40S pods, at $0.51.

pgw#969 made the binding travel. It could not stop a producer from forgetting it, because the two halves were two fields with two defaults. **This PR makes the gap unrepresentable.**

## The change

```python
class MintSlot(msgspec.Struct, frozen=True, kw_only=True):
    ref: ModelRef                            # WHICH checkpoint
    path: str                                # WHERE its bytes already are
    component_paths: Dict[str, str] = {}     # pgw#617 per-component overrides

class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
    slots: Dict[str, MintSlot] = {}
```

`ref` and `path` carry no defaults, and `__post_init__` rejects an empty `path` (the degenerate spelling of the same lie). The three fields are **deleted** — pre-launch hardcut, no dual-read, no acceptance of the old wire.

**Named `MintSlot`, not `ResolvedSlot`:** `ResolvedSlot` is already the public tenant-facing type `ctx.slots[...]` returns (`gen_worker.api.slot`). Two different `ResolvedSlot`s in one process would be its own trap.

### Is a path ever legitimately absent while a ref exists?

No, and the code says so rather than the comment: `_setup_slots` is `list(spec.models)` for any class with a `setup()`, and `_setup_locked_inner` materializes **every** one of them in a single loop — a setup slot always has both. Per-call handler-injected models are resolved elsewhere and were never on this wire. A slot the parent did not resolve is **ABSENT** from the map, never a present entry with a hole in it, and `assert_slots_resolvable` still refuses that by name (respecting `optional`), before a weight is read. That is the only wiring gap still representable, and it is the honest one.

### Does every consumer need all three together?

`cli.run.run_setup` legitimately wants `Dict[slot, path]` — it loads bytes and has no use for identity. It still does: `mint_child.mint` and `_setup_locked_inner` **derive** that view (and the plain overrides view) from the one resolution in a single expression, instead of maintaining it beside them. Derivation from one source is not the failure mode; three independently-writable sources was.

## What moved

* **Producer** — `_setup_locked_inner` already computed binding, path and overrides in the same loop; it now emits one `MintSlot` per slot. `_BackgroundMint`, `mint_delegate.MintTask` and `MintRequest` each lost three fields and gained one.
* **Consumers** — `bind_slots(specs, Mapping[str, MintSlot])`, `assert_composable(Mapping[str, MintSlot])` (it reads `res.component_paths` directly, so the "narrowed tree with no override" refusal now cannot be handed mismatched halves), `assert_slots_resolvable` reads `request.slots`.
* `aot_resume` / `aot_mint` / `mint_budget` never read these dicts — they reference `MintRequest.capture`, `.resume` and the peak-bytes fields only. No change needed there.

## Verification

`570 passed, 2 skipped` over the whole `-k "mint or executor or warm or slot"` slice (py3.12).

**The decisive test is the negative one**, and it is RED-proved in both directions.

With `src/gen_worker` restored to `origin/dev`, the pod's request is fine:

```
CONSTRUCTED OK   : {'pipeline': '/tmp/x'} | bindings: {}
DECODED OK       : {'pipeline': '/tmp/x'} | bindings: {}
the two views disagree, and nothing said so: True
```

On this branch it does not exist:

```
CONSTRUCT REFUSED: Missing required argument 'ref'
DECODE REFUSED   : Object missing required field `ref` - at `$.slots[...]`
```

Both halves matter because the boundary **is a JSON file** — `test_the_pods_wire_no_longer_decodes` takes a real request off the real `_BackgroundMint` -> `MintTask` -> `build_request` -> msgspec chain, strips `ref` out of the encoded document, and asserts the decode is refused; then empties `slots` entirely and asserts that shape still decodes but is refused **by name** by `assert_slots_resolvable`.

pgw#969's own suite is green and grew from 11 rows to 13 — its final row, `test_the_paths_and_the_bindings_travel_together`, was an assertion that the two halves agreed. It is now a type. Running the new suite against `origin/dev`'s `src`: **11 failed, 2 passed** (the two survivors are the characterization rows, one of which reproduces the pod's exact `ValueError`).

No mocks, no fixed-duration sleeps, no `timeout=N`.

## Base branch

Branched from `origin/dev`, not `origin/master`: `origin/master` does not contain pgw#969 at all (`git grep slot_bindings origin/master -- src/` is empty — PR #494 landed on `dev` and has not been promoted). There is nothing to collapse on `master` yet.