### PR TITLE
pgw#975: declare the OOM victim order the pgw#763 split depends on

### DIFF
--- a/changelog.d/pgw975.md
+++ b/changelog.d/pgw975.md
@@ -1,0 +1,47 @@
+- **pgw#975: the pgw#763 split's OOM victim order was emergent, not declared —
+  and the margin was worth under 4 points out of 1000.** `entrypoint.py` has
+  claimed since gw#640 that "the OOM killer picks the fat child, not the
+  reporter", and `git grep oom_score_adj` returned nothing: every OOM mechanism
+  we own reads the kernel's verdict (`oom_kill_count`, `cgroup_oom_kills`,
+  `container_limits`) and none of them influences it. Measured (CPython 3.12):
+  the control parent is 44.4 MiB / 397 modules, a compute child that has
+  imported torch is 493.0 MiB / 1181, so deferring torch keeps 479.4 MiB out of
+  the reporter. `oom_badness()` scales the adjustment by `totalpages / 1000`, so
+  on the two RunPod shapes measured live — both `memory.max=unlimited`, domain =
+  the whole host — that entire margin is worth **0.62 points on a 755.07 GiB
+  host and 3.75 on a 124.91 GiB one**. For the 9.5-11.7s a freshly spawned child
+  spends pre-torch (pgw#833, on a real hub-launched pod) it is *negative*: 43.0
+  MiB of child against 44.4 MiB of reporter.
+  The compute child now raises its **own** `oom_score_adj`, in
+  `procsplit/oom_rank.py`, first thing in the compute-child branch of
+  `entrypoint.py`. Direction is load-bearing: raising is unprivileged, lowering
+  needs `CAP_SYS_RESOURCE` and returns `EACCES` in a hardened container. It is
+  the child's own call rather than the parent's `preexec_fn`, per the argument
+  already written at `aot_compile_pool.arm_parent_death_signal` — and because
+  pgw#932 is removing that hook. The mint child (pgw#784) and the AOT pool's
+  entry children get no knob of their own: `oom_score_adj` is inherited across
+  fork and preserved across exec, so the whole compute subtree is covered by the
+  one call, proved on a real grandchild.
+- **The value is a DELTA over the inherited baseline, computed from the domain.**
+  Found by a real spawn, not by review: `oom_score_adj` is inherited, so what a
+  child reads at boot *is* the parent's value, and an absolute set is a no-op
+  whenever the ambient baseline already exceeds it — on a desktop session
+  inheriting 200 from `gnome-terminal`, an absolute 6 ranked parent and child
+  identically. The delta is the control parent's whole declared ceiling
+  (48 MiB measured resident + `RESHIP_WINDOW` x `CONTROL_FRAME_CEILING_BYTES` =
+  112 MiB), twice over, expressed in the kernel's units: **+1 on 755 GiB, +2 on
+  125 GiB, +15 on a 14.9 GiB container, +110 on 2 GiB**. Two-sided on purpose —
+  large enough to dominate anything the parent can hold, and no larger, because
+  with no cgroup ceiling the OOM domain is a *shared host* and an oversized value
+  volunteers our paying child ahead of a co-tenant that is actually leaking.
+  A baseline already at the kernel maximum, or a `/proc` that refuses the write,
+  is a logged typed degradation naming what has stopped being protected — never
+  a silent pass.
+- **`postmortem.container_limits()` now reads `memory.oom.group`.** If it is 1
+  the kernel kills the cgroup as a unit, the reporter dies with the child, and
+  the split buys nothing for reporting — and `mem_cgroup_get_oom_group()` is
+  consulted on the global OOM path too, so `memory.max=unlimited` does not rule
+  it out. gw#640 has named that scenario in its own header since it was written
+  without ever reading the value. It now rides the existing `worker_fatal` dial
+  and the boot record, called out in the detail line when it is 1, so the next
+  real pod settles it instead of an inference from a laptop.

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -47,6 +47,16 @@ if __name__ == "__main__":
 
         os._exit(run_parent())
 
+    # pgw#975: "the OOM killer picks the fat child, not the reporter" (below)
+    # was true only by accident — the margin is the 479 MiB of torch, worth
+    # under 4 oom_score_adj points out of 1000 on a real pod and NEGATIVE for
+    # the seconds this child spends pre-torch. Declare it here, first thing and
+    # before any import of ours, so a child that dies during its own boot is
+    # already ranked. Descendants (mint child, AOT entry children) inherit.
+    from .procsplit.oom_rank import raise_own_oom_score_adj  # noqa: E402
+
+    raise_own_oom_score_adj()
+
 # gw#640: fork the supervisor BEFORE the heavy imports below. The parent stays
 # a bare interpreter (so the OOM killer picks the fat child, not the reporter)
 # and outlives the worker to report WTERMSIG / cgroup oom_kill over the wire.

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -97,7 +97,7 @@ def _default_boot_record_path() -> Path:
 BOOT_RECORD_PATH = _default_boot_record_path()
 
 
-def _cgroup_nodes(
+def cgroup_nodes(
     root: Path = _CGROUP_ROOT, proc_self_cgroup: Path = _PROC_SELF_CGROUP
 ) -> list[Path]:
     """cgroup-v2 dirs from root down to this process's own cgroup."""
@@ -151,7 +151,7 @@ def _read_keyed(path: Path) -> Dict[str, int]:
 
 
 def _deepest(name: str) -> Optional[Path]:
-    for node in reversed(_cgroup_nodes()):
+    for node in reversed(cgroup_nodes()):
         p = node / name
         if p.exists():
             return p
@@ -190,6 +190,15 @@ def container_limits() -> Dict[str, Any]:
     facts["memory_swap_max_bytes"] = _read_int(swap_max) if swap_max else None
     ev = _deepest("memory.events")
     facts["memory_events"] = _read_keyed(ev) if ev else {}
+    # pgw#975: the one fact that decides whether the pgw#763 split can report at
+    # all. `memory.oom.group=1` makes the kernel kill the whole cgroup as a unit
+    # — parent included — and `mem_cgroup_get_oom_group()` is consulted on the
+    # GLOBAL oom path too, so `memory.max=unlimited` does not rule it out. We
+    # have defended against the scenario since gw#640 (see this module's header)
+    # without ever reading the value. Now every death and every boot record
+    # carries it, so a real pod settles it instead of an inference from a laptop.
+    oom_group = _deepest("memory.oom.group")
+    facts["memory_oom_group"] = _read_int(oom_group) if oom_group else None
     cpu_max = _deepest("cpu.max")
     raw_cpu = _read_text(cpu_max) if cpu_max else None
     facts["cpu_max"] = raw_cpu
@@ -318,6 +327,17 @@ def format_detail(
             _gb(limits.get("memory_current_bytes")),
             _gb(limits.get("memory_peak_bytes")),
             _gb(limits.get("memory_swap_max_bytes")),
+        )
+    )
+    # pgw#975: `1` means the kernel kills the cgroup as a unit and this very
+    # report is only reaching you because the parent happened to outlive it.
+    oom_group = limits.get("memory_oom_group")
+    head.append(
+        "memory.oom.group=%s%s"
+        % (
+            "unreadable" if oom_group is None else oom_group,
+            "  <-- GROUP KILL: the pgw#763 reporter dies with the child"
+            if oom_group == 1 else "",
         )
     )
     head.append(

--- a/src/gen_worker/procsplit/oom_rank.py
+++ b/src/gen_worker/procsplit/oom_rank.py
@@ -1,0 +1,241 @@
+"""pgw#975: declare the OOM victim order the pgw#763 split silently depends on.
+
+The split's reporting guarantee is that the control parent OUTLIVES the compute
+child it supervises, so a kernel kill of the child is reported as ``WTERMSIG`` /
+``oom_kill`` over the wire instead of vanishing with the pod. Nothing anywhere
+told the kernel that. The parent survived because a bare interpreter (44.4 MiB,
+397 modules) happens to be smaller than one that has imported torch (493.0 MiB,
+1181) — an accident that erodes with every dependency the control plane gains,
+and that is INVERTED for the 9.5-11.7s (pgw#833, measured on a hub-launched pod)
+a freshly spawned child spends at 43.0 MiB before it reaches ``import torch``.
+
+The compute child raises its OWN score. Direction is load-bearing: raising is
+unprivileged, lowering needs ``CAP_SYS_RESOURCE`` and returns ``EACCES`` in a
+hardened container (``__set_oom_adj``, ``fs/proc/base.c``). Placement follows
+``aot_compile_pool.arm_parent_death_signal``: the child does it to itself, not
+through the parent's ``preexec_fn`` — that hook is async-signal-unsafe territory,
+forces ``fork()`` over ``posix_spawn()``, and pgw#932 is removing it.
+
+The mint child (pgw#784) and the AOT pool's entry children are descendants of a
+compute child, and ``oom_score_adj`` is inherited across fork and preserved
+across exec — so the whole compute subtree is covered by this one call. There is
+deliberately no second knob for them (§4.24 item 1): the fattest process is
+already the one the kernel picks, and every death below the parent is
+recoverable.
+
+Nothing here imports grpc or torch: this runs at the very top of the compute
+child, so a child that dies during its own imports is already ranked.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..postmortem import cgroup_nodes
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEGRADE_PHASE",
+    "OomRank",
+    "oom_domain_bytes",
+    "parent_ceiling_bytes",
+    "score_adj_delta_for_domain",
+    "raise_own_oom_score_adj",
+]
+
+#: Stable token for the degradation. Grep-able in a pod log, and the child's
+#: stderr is teed to the container log AND ring-buffered into the parent's death
+#: dial by the pgw#833 pump, so an ERROR here already reaches the wire.
+DEGRADE_PHASE = "procsplit_oom_rank_unset"
+
+#: The control parent with every control module imported, measured (44.4 MiB /
+#: 397 modules, CPython 3.12) and rounded up.
+_PARENT_RESIDENT_BYTES = 48 * 1024 * 1024
+
+#: The only thing in the parent that grows with LOAD: ``transport.RESHIP_WINDOW``
+#: (256) frames, each capped by ``seam.CONTROL_FRAME_CEILING_BYTES`` (256 KiB).
+#: Written out rather than imported because this module must not pull grpc into
+#: the child's first milliseconds; `test_pgw975_*` fails if either drifts. (The
+#: per-group stderr ring is 32 KiB x G — four orders down, ignored.)
+_PARENT_BUFFER_BYTES = 256 * 256 * 1024
+
+#: The seam ceiling is enforced REPORTED-NOT-REFUSED (``seam.py``), so the parent
+#: may legitimately exceed its declared budget transiently. One full over-run is
+#: covered; more would volunteer more of a shared host than the guarantee needs.
+_OVERRUN_ALLOWANCE = 2
+
+#: Tightest memory domain this worker has ever been observed running in (the
+#: ``ram_total_gb: 14.9`` container of the 0.56.2 report). Used only when /proc
+#: is unreadable, so an unknown domain degrades TOWARD protecting the reporter.
+_TIGHTEST_OBSERVED_DOMAIN_BYTES = 14 * 1024 ** 3
+
+_SELF_OOM_SCORE_ADJ = Path("/proc/self/oom_score_adj")
+_PROC_MEMINFO = Path("/proc/meminfo")
+
+#: Kernel range for ``oom_score_adj`` (``fs/proc/base.c``). Not ours to pick.
+_OOM_SCORE_ADJ_MIN = -1000
+_OOM_SCORE_ADJ_MAX = 1000
+
+
+@dataclass(frozen=True)
+class OomRank:
+    """What this process asked the kernel for, and what it got.
+
+    ``applied`` false is a DEGRADATION, not a detail: ``unprotected`` names the
+    guarantee that has stopped holding.
+    """
+
+    applied: bool
+    value: int
+    previous: Optional[int]
+    domain_bytes: int
+    ceiling_bytes: int
+    reason: str = ""
+    unprotected: str = ""
+
+    def format(self) -> str:
+        return (
+            f"phase={DEGRADE_PHASE} value={self.value} previous={self.previous} "
+            f"domain_bytes={self.domain_bytes} ceiling_bytes={self.ceiling_bytes} "
+            f"reason={self.reason} — {self.unprotected}"
+        )
+
+
+def parent_ceiling_bytes() -> int:
+    """Every byte the control parent can hold: measured resident set + the one
+    buffer that grows with load."""
+    return _PARENT_RESIDENT_BYTES + _PARENT_BUFFER_BYTES
+
+
+def _read_int(path: Path) -> Optional[int]:
+    try:
+        raw = path.read_text().strip()
+    except OSError:
+        return None
+    if raw in ("", "max"):
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _cgroup_memory_max() -> Optional[int]:
+    """Tightest finite ``memory.max`` on this process's cgroup chain.
+
+    None on both RunPod shapes measured live 2026-07-30 (CPU pod, 4090 SECURE):
+    the provider sets no ceiling, so the OOM domain is the whole shared host and
+    the adjudicator is the host killer — which is precisely why victim selection
+    has to be declared rather than delegated to a cgroup that does not exist.
+    """
+    best: Optional[int] = None
+    for node in cgroup_nodes():
+        value = _read_int(node / "memory.max")
+        if value is not None:
+            best = value if best is None else min(best, value)
+    return best
+
+
+def _meminfo_total_bytes() -> Optional[int]:
+    try:
+        for line in _PROC_MEMINFO.read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def oom_domain_bytes() -> int:
+    """The memory the kernel scores badness against: the cgroup ceiling when one
+    exists, otherwise the host. 0 when neither is readable."""
+    limit = _cgroup_memory_max()
+    total = _meminfo_total_bytes()
+    if limit is not None and total is not None:
+        return min(limit, total)
+    return limit or total or 0
+
+
+def score_adj_delta_for_domain(domain_bytes: int, ceiling_bytes: int) -> int:
+    """The GAP over the inherited baseline: the parent's whole footprint, twice
+    over, in the kernel's own units.
+
+    A delta, not an absolute, because ``oom_score_adj`` is inherited: whatever
+    the child reads at boot IS the control parent's own value. An absolute set
+    creates no gap at all whenever the ambient baseline already exceeds it —
+    measured, not hypothesised: on a desktop session inheriting 200 from
+    ``gnome-terminal`` an absolute 6 was a no-op and parent and child ranked
+    identically. Which baseline a container starts from is not ours to assume,
+    and assuming it is the failure this whole issue is about.
+
+    THREAT: a control parent that outweighs the compute child is the one the OOM
+    killer picks, and then the death of the process whose ONLY job is to report
+    the child's death goes unreported — the pod dies mute. Nothing else prevents
+    it: the guards upstream (mint_budget, host_move_guard, the VRAM caps) bound
+    allocation, not victim selection, and RunPod sets no cgroup ceiling to fire
+    first. Sized to the parent and no larger, because that OOM domain is a
+    SHARED host: a bigger number volunteers our paying child ahead of a
+    co-tenant's leak, which spares the actual hog and costs us the job.
+
+    ``oom_badness()`` scales the adjustment by ``totalpages / 1000``, so one
+    point is 0.1% of the domain: +1 on a 755 GiB host, +2 on a 125 GiB host,
+    +15 on a 14.9 GiB container.
+    """
+    if domain_bytes <= 0:
+        domain_bytes = _TIGHTEST_OBSERVED_DOMAIN_BYTES
+    raw = math.ceil(1000 * _OVERRUN_ALLOWANCE * ceiling_bytes / domain_bytes)
+    return max(1, min(_OOM_SCORE_ADJ_MAX, raw))
+
+
+_UNPROTECTED = (
+    "the pgw#763 control parent is no longer preferentially spared. A kernel "
+    "OOM may take the REPORTER instead of the compute child, and that death is "
+    "then reported only by the next boot's leftover post-mortem record — if the "
+    "container restarts at all"
+)
+
+
+def raise_own_oom_score_adj() -> OomRank:
+    """Make THIS process a more attractive OOM victim than the control parent.
+
+    Only ever raises, by construction: the delta is >= 1 and it is added to the
+    value we inherited. Lowering would need ``CAP_SYS_RESOURCE`` we do not have.
+    """
+    domain = oom_domain_bytes()
+    ceiling = parent_ceiling_bytes()
+    delta = score_adj_delta_for_domain(domain, ceiling)
+    previous = _read_int(_SELF_OOM_SCORE_ADJ)
+    # An unreadable baseline is not a reason to skip: the delta alone is still a
+    # raise over the kernel's own default of 0.
+    want = min(_OOM_SCORE_ADJ_MAX, (previous or 0) + delta)
+    if previous is not None and want <= previous:
+        # Only reachable at the ceiling: the parent is ALREADY maximally
+        # killable, so no child can be ranked above it.
+        rank = OomRank(
+            False, want, previous, domain, ceiling,
+            reason="baseline_at_kernel_maximum", unprotected=_UNPROTECTED,
+        )
+        logger.error("procsplit oom rank: %s", rank.format())
+        return rank
+    try:
+        _SELF_OOM_SCORE_ADJ.write_text(f"{want}\n")
+    except OSError as exc:
+        rank = OomRank(
+            False, want, previous, domain, ceiling,
+            reason=f"{type(exc).__name__}:errno={exc.errno}",
+            unprotected=_UNPROTECTED,
+        )
+        logger.error("procsplit oom rank: %s", rank.format())
+        return rank
+    logger.info(
+        "procsplit oom rank: compute child oom_score_adj %s -> %d (+%d) "
+        "(domain=%.2f GiB, parent ceiling=%.0f MiB); descendants inherit",
+        "unreadable" if previous is None else previous, want, delta,
+        domain / 1024 ** 3, ceiling / 1024 ** 2,
+    )
+    return OomRank(True, want, previous, domain, ceiling, reason="set")

--- a/tests/harness/procsplit_child_main.py
+++ b/tests/harness/procsplit_child_main.py
@@ -14,7 +14,14 @@ import sys
 def main() -> int:
     from gen_worker import postmortem
     from gen_worker.config import load_settings
+    from gen_worker.procsplit.oom_rank import raise_own_oom_score_adj
     from gen_worker.worker import Worker
+
+    # pgw#975: the production entrypoint does this first thing in the
+    # compute-child branch. The harness enters one layer lower, so reproduce it
+    # here — otherwise the split's OOM victim order is tested on a process that
+    # never declared one.
+    raise_own_oom_score_adj()
 
     # The container entrypoint installs this before constructing Worker.  The
     # harness enters one layer lower, so reproduce that production hook here

--- a/tests/test_procsplit_oom_rank_pgw975.py
+++ b/tests/test_procsplit_oom_rank_pgw975.py
@@ -1,0 +1,294 @@
+"""pgw#975: the pgw#763 split's OOM victim order, declared instead of emergent.
+
+Every assertion here is read back off a REAL process's ``/proc`` entry — never
+from the value we passed in — because "we called the setter" is exactly the
+claim that was true of nothing before this issue.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gen_worker import postmortem
+from gen_worker.procsplit import oom_rank
+
+from harness.hub_double import is_ready
+from test_procsplit_pgw763 import (  # noqa: E402  (shared real-spawn harness)
+    SplitHarness,
+    captured_dials,  # noqa: F401  (fixture)
+    isolated_postmortem,  # noqa: F401  (autouse fixture)
+)
+
+GIB = 1024 ** 3
+linux_only = pytest.mark.skipif(
+    sys.platform != "linux", reason="oom_score_adj is a Linux /proc interface"
+)
+
+
+def _read_oom_score_adj(pid: int) -> int:
+    return int(Path(f"/proc/{pid}/oom_score_adj").read_text().strip())
+
+
+@pytest.fixture()
+def split(tmp_path, captured_dials):  # noqa: F811
+    h = SplitHarness(tmp_path)
+    try:
+        yield h
+    finally:
+        h.close()
+
+
+# --------------------------------------------------------------------------
+# The property: a genuinely spawned compute child outranks its control parent
+# --------------------------------------------------------------------------
+
+
+@linux_only
+def test_a_real_compute_child_outranks_the_control_parent(split):
+    """RED before this issue: the child inherited the parent's value exactly, so
+    the reporter's survival came down to which interpreter had imported more.
+    The child is spawned by the REAL ParentControl through a real fork+exec; the
+    number is read out of the kernel's own file, not from what we passed in."""
+    split.scheduler.wait_connection(0).wait_for(is_ready)
+    proc = split.pc._proc
+    assert proc is not None, "no compute child was spawned"
+
+    child_adj = _read_oom_score_adj(proc.pid)
+    parent_adj = _read_oom_score_adj(os.getpid())
+
+    delta = oom_rank.score_adj_delta_for_domain(
+        oom_rank.oom_domain_bytes(), oom_rank.parent_ceiling_bytes()
+    )
+    assert child_adj == min(1000, parent_adj + delta), (
+        f"child oom_score_adj={child_adj}, expected parent({parent_adj}) + "
+        f"{delta} — read back off /proc/{proc.pid}/oom_score_adj"
+    )
+    assert child_adj > parent_adj, (
+        f"the compute child ({child_adj}) does not outrank the control parent "
+        f"({parent_adj}); a kernel OOM can take the reporter"
+    )
+
+
+@linux_only
+def test_the_whole_compute_subtree_inherits_it(tmp_path):
+    """The mint child (pgw#784) and the AOT pool's entry children are spawned
+    BELOW a compute child and get no call of their own. That is only correct if
+    the value survives fork and exec, so prove it on a real grandchild rather
+    than asserting the man page."""
+    child = tmp_path / "child.py"
+    child.write_text(
+        "import subprocess, sys\n"
+        "from gen_worker.procsplit.oom_rank import raise_own_oom_score_adj\n"
+        "rank = raise_own_oom_score_adj()\n"
+        "assert rank.applied, rank.format()\n"
+        "grand = subprocess.run(\n"
+        "    [sys.executable, '-c',\n"
+        "     'print(open(\"/proc/self/oom_score_adj\").read().strip())'],\n"
+        "    capture_output=True, text=True, check=True)\n"
+        "print(open('/proc/self/oom_score_adj').read().strip())\n"
+        "print(grand.stdout.strip())\n"
+    )
+    out = subprocess.run(
+        [sys.executable, str(child)],
+        capture_output=True, text=True, check=True,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(
+            [str(Path(__file__).resolve().parent.parent / "src"),
+             os.environ.get("PYTHONPATH", "")])},
+    )
+    mine, grandchild = (int(v) for v in out.stdout.split())
+    delta = oom_rank.score_adj_delta_for_domain(
+        oom_rank.oom_domain_bytes(), oom_rank.parent_ceiling_bytes()
+    )
+    assert mine == min(1000, _read_oom_score_adj(os.getpid()) + delta)
+    assert grandchild == mine, (
+        "a grandchild did not inherit the rank — the mint child and every "
+        "inductor entry child would be unranked"
+    )
+
+
+# --------------------------------------------------------------------------
+# The value: derived, not tidy
+# --------------------------------------------------------------------------
+
+
+def test_the_parent_ceiling_still_matches_the_constants_it_was_derived_from():
+    """`oom_rank` writes the reship buffer out literally so it can run before
+    grpc exists in the child. This is the anti-drift guard for that copy — if
+    either source constant moves, the ceiling is wrong and this goes red."""
+    from gen_worker.procsplit.seam import CONTROL_FRAME_CEILING_BYTES
+    from gen_worker.transport import RESHIP_WINDOW
+
+    assert oom_rank._PARENT_BUFFER_BYTES == (
+        RESHIP_WINDOW * CONTROL_FRAME_CEILING_BYTES
+    )
+
+
+@pytest.mark.parametrize(
+    "domain_gib, expected, shape",
+    [
+        (755.07, 1, "RunPod CPU pod, measured live 2026-07-30"),
+        (124.91, 2, "RunPod 4090 SECURE, measured live 2026-07-30"),
+        (14.9, 15, "tightest cgroup cap observed (0.56.2 ram_total_gb report)"),
+        (2.0, 110, "a hypothetical 2 GiB container"),
+    ],
+)
+def test_the_value_is_derived_from_the_domain_not_picked(domain_gib, expected, shape):
+    """§4.24: the number has to be re-derivable. Pinning the real shapes means a
+    future edit that rounds this to 100 or 500 goes red and has to argue."""
+    got = oom_rank.score_adj_delta_for_domain(
+        int(domain_gib * GIB), oom_rank.parent_ceiling_bytes()
+    )
+    assert got == expected, f"{shape}: expected {expected}, got {got}"
+
+
+def test_the_margin_always_covers_the_parents_whole_ceiling_twice():
+    """The property the table is an instance of: one point is 0.1% of the
+    domain, so `adj` points must be worth at least twice everything the control
+    parent can hold. Checked across six orders of magnitude of domain."""
+    ceiling = oom_rank.parent_ceiling_bytes()
+    for domain in (1 * GIB, 8 * GIB, 15 * GIB, 64 * GIB, 125 * GIB, 755 * GIB):
+        adj = oom_rank.score_adj_delta_for_domain(domain, ceiling)
+        assert adj * (domain / 1000) >= 2 * ceiling, (
+            f"domain={domain / GIB:.0f}GiB adj={adj} buys "
+            f"{adj * domain / 1000 / 1024 ** 2:.0f}MiB against a "
+            f"{ceiling / 1024 ** 2:.0f}MiB parent ceiling"
+        )
+
+
+def test_an_unreadable_domain_degrades_toward_protecting_the_reporter():
+    """Guessing the roomiest host would silently produce adj=1 on a tight
+    container. The fallback is the tightest domain we have ever run in."""
+    tight = oom_rank.score_adj_delta_for_domain(0, oom_rank.parent_ceiling_bytes())
+    assert tight == oom_rank.score_adj_delta_for_domain(
+        oom_rank._TIGHTEST_OBSERVED_DOMAIN_BYTES, oom_rank.parent_ceiling_bytes()
+    )
+    assert tight > oom_rank.score_adj_delta_for_domain(755 * GIB,
+                                                 oom_rank.parent_ceiling_bytes())
+
+
+# --------------------------------------------------------------------------
+# Failure is typed and loud
+# --------------------------------------------------------------------------
+
+
+@linux_only
+def test_a_failed_set_is_a_named_degradation_never_a_silent_pass(
+    monkeypatch, tmp_path, caplog,
+):
+    """A hardened container with a read-only /proc must not leave us believing
+    the guarantee holds. Driven by a REAL unwritable path producing a real
+    OSError, not a patched-out writer."""
+    unwritable = tmp_path / "nonexistent-dir" / "oom_score_adj"
+    monkeypatch.setattr(oom_rank, "_SELF_OOM_SCORE_ADJ", unwritable)
+
+    with caplog.at_level(logging.ERROR, logger=oom_rank.__name__):
+        rank = oom_rank.raise_own_oom_score_adj()
+
+    assert not rank.applied
+    assert rank.unprotected, "the degradation did not name what is unprotected"
+    assert "control parent" in rank.unprotected
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert oom_rank.DEGRADE_PHASE in logged, "the failure was not logged typed"
+    assert "errno" in rank.reason
+
+
+@linux_only
+def test_the_gap_is_cut_over_whatever_baseline_was_inherited(monkeypatch, tmp_path):
+    """The bug a real spawn caught: `oom_score_adj` is INHERITED, so the value
+    the child reads is the parent's own. An absolute set is a no-op whenever the
+    ambient baseline already exceeds it — this box inherits 200 from
+    `gnome-terminal` and an absolute 6 ranked parent and child identically."""
+    fake = tmp_path / "oom_score_adj"
+    fake.write_text("200\n")
+    monkeypatch.setattr(oom_rank, "_SELF_OOM_SCORE_ADJ", fake)
+
+    rank = oom_rank.raise_own_oom_score_adj()
+    delta = oom_rank.score_adj_delta_for_domain(
+        oom_rank.oom_domain_bytes(), oom_rank.parent_ceiling_bytes()
+    )
+
+    assert rank.applied
+    assert int(fake.read_text()) == 200 + delta > 200
+    assert rank.previous == 200
+
+
+@linux_only
+def test_a_baseline_already_at_the_kernel_maximum_is_reported_unprotected(
+    monkeypatch, tmp_path, caplog,
+):
+    """At 1000 the parent is already maximally killable and no child can be
+    ranked above it. Nothing can be done about that — but it must not be
+    reported as a working control (§4.24 item 2)."""
+    fake = tmp_path / "oom_score_adj"
+    fake.write_text("1000\n")
+    monkeypatch.setattr(oom_rank, "_SELF_OOM_SCORE_ADJ", fake)
+
+    with caplog.at_level(logging.ERROR, logger=oom_rank.__name__):
+        rank = oom_rank.raise_own_oom_score_adj()
+
+    assert not rank.applied
+    assert rank.reason == "baseline_at_kernel_maximum"
+    assert rank.unprotected
+    assert oom_rank.DEGRADE_PHASE in "\n".join(
+        r.getMessage() for r in caplog.records
+    )
+
+
+# --------------------------------------------------------------------------
+# memory.oom.group: the fact that decides whether any of this reports anything
+# --------------------------------------------------------------------------
+
+
+def test_the_container_facts_now_carry_memory_oom_group():
+    """Read off this box's real cgroup chain. The VALUE here proves nothing
+    about RunPod — the point is that the key now rides the existing
+    `worker_fatal` dial and boot record, so a real pod answers it."""
+    facts = postmortem.container_limits()
+    assert "memory_oom_group" in facts
+    assert facts["memory_oom_group"] in (0, 1, None)
+
+
+def test_a_group_kill_is_called_out_in_the_death_dial():
+    detail = postmortem.format_detail(
+        phase="compute_process_exit",
+        verdict={"exit_code": None, "signaled": True, "signal": 9,
+                 "signal_name": "SIGKILL", "core_dumped": False},
+        limits={"memory_oom_group": 1},
+    )
+    assert "memory.oom.group=1" in detail
+    assert "GROUP KILL" in detail
+
+    benign = postmortem.format_detail(
+        phase="compute_process_exit",
+        verdict={"exit_code": 1, "signaled": False},
+        limits={"memory_oom_group": 0},
+    )
+    assert "memory.oom.group=0" in benign
+    assert "GROUP KILL" not in benign
+
+
+# --------------------------------------------------------------------------
+# The production entrypoint really is where it runs
+# --------------------------------------------------------------------------
+
+
+def test_the_entrypoint_ranks_the_child_before_its_heavy_imports():
+    """The harness enters one layer below `entrypoint`, so the placement itself
+    is asserted on the source: a child ranked after `import torch` is unranked
+    for the seconds pgw#833 measured it dying in."""
+    src = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "gen_worker" / "entrypoint.py"
+    ).read_text()
+    call = src.index("raise_own_oom_score_adj()")
+    assert src.index("is_compute_child") < call
+    for heavy in ("from .worker import Worker", "import msgspec"):
+        assert call < src.index(heavy), (
+            f"the OOM rank is declared after {heavy!r}"
+        )


### PR DESCRIPTION
Closes the gap between what `entrypoint.py` claims and what the kernel was ever told.

## The premise, verified

> *"fork the supervisor BEFORE the heavy imports below. The parent stays a bare interpreter (so the OOM killer picks the fat child, not the reporter)"* — `entrypoint.py`

`git grep -rn oom_score_adj` over the whole repo returned **nothing**. Every OOM mechanism we own is observational — `postmortem.oom_kill_count()`, `aot_compile_pool.cgroup_oom_kills()`, `container_limits()` — we read the kernel's verdict and never influence it. The parent survived because it happened to be smaller.

## How thin, in the kernel's own units

Measured, CPython 3.12: control parent 44.4 MiB / 397 modules; compute child pre-torch **43.0 MiB** / 375; post-torch 493.0 MiB / 1181. `oom_badness()` scales the adjustment by `totalpages / 1000`, so on the two RunPod shapes measured live (both `memory.max=unlimited`, domain = the whole host):

| shape | domain | the 479 MiB torch deferral is worth |
|---|---|---|
| RunPod CPU pod | 755.07 GiB | **0.62 points** |
| RunPod 4090 SECURE | 124.91 GiB | **3.75 points** |

And for the 9.5-11.7s a fresh child spends pre-torch (pgw#833, real hub-launched pod) the ordering is **inverted** — the reporter is the fatter process.

## What changed

- `procsplit/oom_rank.py`: the compute child raises its **own** score. Raising is unprivileged; lowering needs `CAP_SYS_RESOURCE` and fails in a hardened container. Child-side, not `preexec_fn` — the argument already written at `aot_compile_pool.arm_parent_death_signal`, plus **pgw#932 is removing that hook** (`parent.py:591`), so nothing here is work that lane must undo.
- **A delta, not an absolute** — found by a real spawn, not review. `oom_score_adj` is inherited, so what the child reads at boot *is* the parent's value; an absolute set is a no-op whenever the ambient baseline already exceeds it (this box inherits 200 from `gnome-terminal`; an absolute 6 ranked parent and child identically).
- **Value:** the parent's whole declared ceiling (48 MiB measured resident + `RESHIP_WINDOW` x `CONTROL_FRAME_CEILING_BYTES` = 112 MiB), twice over, in kernel units → **+1** on 755 GiB, **+2** on 125 GiB, **+15** on 14.9 GiB, **+110** on 2 GiB. Two-sided by design (§4.24): big enough to dominate anything the parent can hold, and no larger, because with no cgroup ceiling the OOM domain is a *shared host* and an oversized value volunteers our paying child ahead of a co-tenant's leak. `1000` is exactly the tidy number that gets this wrong.
- **No second knob** for the mint child / AOT entry children / rank siblings: `oom_score_adj` is inherited across fork and preserved across exec, proved on a real grandchild. A per-tier ladder would be a bound that cannot name a threat nothing else already prevents.
- **Failure is typed and loud**: a `/proc` that refuses the write, or a baseline already at the kernel maximum, logs `phase=procsplit_oom_rank_unset` naming what has stopped being protected. The child's stderr is teed and ring-buffered by the pgw#833 pump, so it already reaches the death dial.
- `postmortem.container_limits()` reads **`memory.oom.group`** and calls it out in the detail line when it is 1.

## `memory.oom.group` — not answerable from this box, and that is stated

If it is 1 the kernel kills the cgroup as a unit, the reporter dies with the child, and the split buys nothing for reporting. This is **not** settled by `memory.max=unlimited`: `mem_cgroup_get_oom_group()` is consulted on the **global** OOM path too. gw#640's own header has named the scenario since it was written; the value was never read. This box's cgroup config is unrelated to a pod's and is not used to infer it.

**The settling observation** is a pod-side read at the deepest cgroup node that has the file. This PR ships that read on the existing carrier at zero marginal cost, so the next abnormal death on any real pod answers it for good. No pod was bought.

**Adjacent, measured, on two shapes:** RunPod imposes no cgroup `memory.max` on either the CPU shape or the 4090 SECURE shape (`memory.max=unlimited memory.events={} cgroup_oom_kill_delta=0`, live 2026-07-30). So the cgroup route to a preferential kill does not exist there, which makes `oom_score_adj` the only lever over victim selection on the shapes we run.

## Scope limit

The OOM killer is a backstop; memory is already bounded ahead of allocation by `mint_budget`, the VRAM caps, `host_move_guard` and the `ENV_HOST_SIBLINGS` divisor. **None of those is revisited.** This makes the backstop's behaviour declared rather than emergent, and nothing more.

## Verification

RED-verified against current code: with the three production hooks removed, exactly `test_a_real_compute_child_outranks_the_control_parent`, `test_the_container_facts_now_carry_memory_oom_group` and `test_the_entrypoint_ranks_the_child_before_its_heavy_imports` fail; 12 pass. Green: **78 passed** across `test_procsplit_pgw763`, `test_procsplit_security_pgw763`, `test_gw640_postmortem` and the new suite. Ruff and mypy clean.

Every value is read back off `/proc/<pid>/oom_score_adj` on a genuinely spawned child (real `ParentControl`, real fork+exec) and on a real grandchild — never asserted from what was passed in. No mocks, no fixed-duration sleeps, no `timeout=N` (gw#666).

Tracker: `python-gen-worker/progress.md` #975.