### PR TITLE
pgw#981: break the cli.serve <-> cli.run import cycle at the edge

### DIFF
--- a/changelog.d/pgw981.md
+++ b/changelog.d/pgw981.md
@@ -1,0 +1,16 @@
+- **pgw#981: `import gen_worker.cli.serve` raised an ImportError whenever it
+  was the first module imported.** `cli/serve.py` imported `cli/run.py`, which
+  imported `DEFAULT_SOCKET_PATH` back out of `serve` — a two-module cycle, so
+  the constant did not exist yet when `run` asked for it. It was masked because
+  `cli/__init__` happens to reach `run` before `serve`, which is why
+  `gen-worker serve` always worked and "the CLI works" was never evidence about
+  `cli.serve`; `cli/invoke.py` carried the same back-edge. `serve` depends on
+  `run` legitimately (28 call sites — dispatch, exit codes, error types), so the
+  fix is the edge, not a deferred import: `DEFAULT_SOCKET_PATH` moves down to
+  `cli/transport.py`, a stdlib-only leaf that already owns listen/connect
+  addressing. Deferring the import inside a function was refused — it keeps the
+  cycle and only re-hides it. Guarded by `tests/test_import_cycles_pgw981.py`,
+  which imports each of the 230 modules in ITS OWN fresh interpreter: a
+  single-process walk pre-warms the package in one entry order and cannot see a
+  cycle at all, which is exactly how pgw#976's first harness passed 0/230 while
+  hiding two.

--- a/src/gen_worker/cli/invoke.py
+++ b/src/gen_worker/cli/invoke.py
@@ -35,7 +35,7 @@ from typing import Any, List, Optional
 
 from . import run as run_mod
 from . import transport
-from .serve import DEFAULT_SOCKET_PATH
+from .transport import DEFAULT_SOCKET_PATH
 from .args import ArgError, build_payload, looks_like_field_token
 
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -35,7 +35,7 @@ from .args import ArgError, build_payload
 from ..api.slot import resolve_slot
 from ..models import execution_lanes as lanespec
 from ..api.binding import rebind_pick
-from .serve import DEFAULT_SOCKET_PATH
+from .transport import DEFAULT_SOCKET_PATH
 from . import invoke as invoke_mod
 from .local_context import _stderr_emitter
 

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -57,11 +57,10 @@ from . import run as run_mod
 from . import transport
 from .local_context import _stderr_emitter, build_local_context
 from .protocol import PROTOCOL_VERSION, gen_worker_version
+from .transport import DEFAULT_SOCKET_PATH
 from ..api.binding import BINDING_TYPES
 from ..models import provision
 
-
-DEFAULT_SOCKET_PATH = "./.gen-worker.sock"
 
 
 # --------------------------------------------------------------------------

--- a/src/gen_worker/cli/transport.py
+++ b/src/gen_worker/cli/transport.py
@@ -17,6 +17,15 @@ import socket
 from pathlib import Path
 from typing import NamedTuple
 
+# The default listen/connect address, and the reason this module exists at the
+# bottom of the cli package: `serve` legitimately depends on `run` (it reuses
+# its dispatch, its exit codes and its errors), so `run` and `invoke` may not
+# reach back into `serve` for a constant. It lived there until pgw#981, and the
+# cycle that made cost `import gen_worker.cli.serve` an ImportError whenever it
+# was the first cli module imported.
+DEFAULT_SOCKET_PATH = "./.gen-worker.sock"
+
+
 class Address(NamedTuple):
     """("unix", path, 0) | ("tcp", host, port)."""
 

--- a/tests/test_import_cycles_pgw981.py
+++ b/tests/test_import_cycles_pgw981.py
@@ -1,0 +1,144 @@
+"""pgw#981 — every module must import when it is the FIRST module imported.
+
+An import cycle is invisible to any harness that imports the package once and
+then walks it in a single process: the first entry order pre-warms the package,
+and every later import is a cache hit. pgw#976's first sweep did exactly that,
+passed 0/230, and hid two real cycles. Only one fresh interpreter PER MODULE
+sees them, so that is what this does.
+
+The cycle this file was written for::
+
+    cli/serve.py:56   from . import run as run_mod
+    cli/run.py:38     from .serve import DEFAULT_SOCKET_PATH
+
+`serve` legitimately depends on `run` — it reuses its dispatch, its exit codes
+and its errors — so the back-edge was the defect. `import gen_worker.cli.serve`
+as a first import raised ``ImportError: cannot import name
+'DEFAULT_SOCKET_PATH' from partially initialized module``, and it was masked
+only because ``cli/__init__.py`` happens to reach `run` before `serve`. Fixed by
+moving the constant DOWN to `cli/transport.py`, a leaf, not by deferring the
+import: a deferred import keeps the cycle and hides it again.
+
+A module that cannot import because an OPTIONAL EXTRA is absent is not a cycle
+and is reported as such — 429 of this package's function-body imports exist
+precisely so `import gen_worker` works without torch (pgw#976).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Tuple
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+PKG = SRC / "gen_worker"
+
+# Substrings that identify a partially-initialized-module failure. CPython
+# phrases it two ways depending on whether the name or the module was the
+# unresolved half.
+CYCLE_MARKERS = ("partially initialized module", "circular import")
+
+
+class Outcome(NamedTuple):
+    module: str
+    returncode: int
+    stderr: str
+
+    @property
+    def cycle(self) -> bool:
+        return any(m in self.stderr for m in CYCLE_MARKERS)
+
+    @property
+    def missing_extra(self) -> Optional[str]:
+        """The absent third-party module, when that is the whole story."""
+        marker = "ModuleNotFoundError: No module named '"
+        if self.returncode == 0 or marker not in self.stderr or self.cycle:
+            return None
+        name = self.stderr.rsplit(marker, 1)[1].split("'", 1)[0]
+        return None if name.split(".")[0] == "gen_worker" else name
+
+
+def _modules() -> List[str]:
+    out: List[str] = []
+    for path in sorted(PKG.rglob("*.py")):
+        rel = path.relative_to(SRC)
+        parts = list(rel.parts)
+        if any(p.startswith((".", "_pycache")) or p == "__pycache__" for p in parts):
+            continue
+        if parts[-1] == "__init__.py":
+            parts = parts[:-1]
+        else:
+            parts[-1] = parts[-1][: -len(".py")]
+        if not parts:
+            continue
+        out.append(".".join(parts))
+    return out
+
+
+def _import_alone(module: str) -> Outcome:
+    """One fresh interpreter, this module as the very first import."""
+    proc = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        cwd=str(SRC),
+        capture_output=True,
+        text=True,
+    )
+    return Outcome(module, proc.returncode, proc.stderr)
+
+
+def _walk() -> List[Outcome]:
+    modules = _modules()
+    assert len(modules) > 100, f"module discovery found only {len(modules)} — check SRC"
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        return list(pool.map(_import_alone, modules))
+
+
+@pytest.fixture(scope="module")
+def outcomes() -> List[Outcome]:
+    return _walk()
+
+
+def test_no_module_is_unimportable_as_a_first_import(outcomes: List[Outcome]) -> None:
+    """The whole-package form: no cycle, from any entry order."""
+    cycles = [o for o in outcomes if o.cycle]
+    if cycles:
+        detail = "\n\n".join(f"--- {o.module} ---\n{o.stderr.strip()}" for o in cycles)
+        pytest.fail(
+            f"{len(cycles)} module(s) close an import cycle when imported first:\n\n{detail}\n\n"
+            "Break the cycle by moving the shared name DOWN to a leaf module. A deferred "
+            "import inside a function keeps the cycle and only hides it again."
+        )
+
+
+def test_no_module_fails_to_import_for_any_other_reason(outcomes: List[Outcome]) -> None:
+    """Anything non-zero that is not a cycle and not an absent optional extra.
+
+    Kept separate from the cycle assertion so a missing `[dev]` extra in some
+    future environment reads as what it is instead of as a cycle regression.
+    """
+    broken: List[Tuple[str, str]] = [
+        (o.module, o.stderr.strip())
+        for o in outcomes
+        if o.returncode != 0 and not o.cycle and o.missing_extra is None
+    ]
+    if broken:
+        detail = "\n\n".join(f"--- {m} ---\n{e}" for m, e in broken)
+        pytest.fail(f"{len(broken)} module(s) fail to import on their own:\n\n{detail}")
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["gen_worker.cli.serve", "gen_worker.cli.run", "gen_worker.cli.invoke", "gen_worker.cli"],
+)
+def test_cli_entry_orders(module: str) -> None:
+    """The four entry orders into the cli package, named individually.
+
+    `cli/__init__` reaching `run` before `serve` is what masked the original
+    defect, so "the CLI works" was never evidence about `cli.serve`.
+    """
+    outcome = _import_alone(module)
+    assert outcome.returncode == 0, f"{module} as a first import:\n{outcome.stderr}"


### PR DESCRIPTION
Closes pgw#981. Files pgw#982 (the sibling `preload <-> executor` layering finding) in the tracker rather than here.

## The defect

```
cli/serve.py:56   from . import run as run_mod
cli/run.py:38     from .serve import DEFAULT_SOCKET_PATH
```

```console
$ python -c "import gen_worker.cli.serve"
ImportError: cannot import name 'DEFAULT_SOCKET_PATH' from partially initialized module
'gen_worker.cli.serve' (most likely due to a circular import)
```

**Pre-existing** — pgw#976's sweep found it against a pristine `git archive` of its branch point and deliberately reported rather than fixed it. Masked because `cli/__init__._build_parser` reaches `run` before `serve`, so `gen-worker serve` always worked and "the CLI works" was never evidence about `cli.serve`. `cli/invoke.py` had the same back-edge.

## The fix is the edge, not another deferred import

`serve` -> `run` is the right direction and is used 28 times (dispatch, exit codes, error types). The back-edge carried exactly one name, so the name moves **down**: `DEFAULT_SOCKET_PATH` now lives in `cli/transport.py`, a stdlib-only leaf that already owns listen/connect addressing. Nothing imports transport's importers, so the edge cannot come back.

A function-body import was refused — it keeps the cycle and only re-hides it. No re-export from `serve`: nothing outside these three modules ever named the constant.

## Guard: one subprocess per module

`tests/test_import_cycles_pgw981.py` imports each of the 230 modules in **its own fresh interpreter**. This is the detail pgw#976 paid for: a single-process walk pre-warms the package in one entry order and cannot see a cycle at all — its first harness passed 0/230 while 57 tests failed.

Three assertions: no module closes a cycle when imported first; no module fails to import for any other reason; and the four cli entry orders named individually. A module blocked by a missing **optional extra** is classified as that, not as a cycle — 429 function-body imports exist so `import gen_worker` works without torch.

## Verification

| run | result |
|---|---|
| guard, fix reverted (RED) | 2 failed / 4 passed — the whole-package walk and `test_cli_entry_orders[gen_worker.cli.serve]` |
| guard, fix applied (GREEN) | 6 passed, ~16s |
| `pytest -k "cli or serve or invoke or transport or local_context"` | 201 passed, 8 skipped (222s) |
| ruff / mypy on the four touched modules | clean |
| `python -m gen_worker.cli --help`, `... serve --help` | render; `--socket` still defaults from the moved constant |