### PR TITLE
pgw#958: the three cell-identity counters restart at v1, and ck6 is reverted

### DIFF
--- a/changelog.d/pgw958.md
+++ b/changelog.d/pgw958.md
@@ -1,0 +1,28 @@
+- **pgw#958 (DESIGN-RULINGS §1.27(g)): the three cell-identity counters restart
+  at 1.** `cell_key.KEY_SCHEME` `ck6` -> `ck1`, `env_seal.SEAL_VERSION` `6` ->
+  `1`, `guard_closure.MANIFEST_VERSION` `3` -> `1`. Paul ruled on the collision
+  with pgw#990's `ck5` -> `ck6` bump on 2026-08-07 — *"the ck6 is wrong and can
+  be removed / deleted just fine. The v1 is the correct one"* — so `ck6` is
+  reverted rather than carried, and the cells it keyed join the purge as the
+  deletable artifacts they are. pgw#990's two INDEPENDENT decisions are
+  untouched and deliberately kept: `code_closure` stays out of the key, and
+  `is_key` stays scheme-AGNOSTIC (byte-identical to tensorhub's
+  `compilecache.IsCellKey`, for the reason th#1183 gives) — a foreign-scheme
+  token is still key-SHAPED and is ruled on by axes, never by its label. All
+  three counters feed the cell-key
+  digest, so this re-keys every cell in one cut rather than three; the failure
+  mode is a MISS (eager serve + demand + forge), never a refusal, and the hub's
+  `IsCellKey` validates key SHAPE only (th#1183), so `ck1-…` publishes and
+  resolves unchanged. Unlike the protocol enum, the lower numbers here were
+  really used and really minted cells, so re-issuing 1 is only honest once the
+  old corpus is gone: the reset is paired with a counted purge of every
+  pre-existing `ck1..ck6` cell row and its CAS objects — tensorhub migration
+  `20260806T064516Z-e68cfe98` (th#1636), applied to both standing stacks on
+  2026-08-06, with `cas-gc` the operator follow-up.
+  `COZY_CELL_EPOCH` remains the designed disown-everything lever; these
+  counters never move for recall reasons again. No ordering comparison anywhere
+  read any of the three — the only version compare in the tree is
+  `aot_resume.BANK_V`, already an equality check at 1. The
+  `aot_wrapper_split` telemetry label `version="v2"` became `lever="runimpl"`
+  (`runimpl_applied` / `runimpl_declined`): it names which split fired, and was
+  never a version.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -21,7 +21,7 @@
 #       (`c47dc46`) gave all three their first production callers, the guard went
 #       red on STALE, and the lines came out. A symbol ceasing to be dead code is
 #       this guard's nicest failure mode, and the ratchet turned the right way.
-#     compile_cache.assert_closure_complete — the ck5 code-closure completeness
+#     compile_cache.assert_closure_complete — the code-closure completeness
 #       gate ("a dynamic import is hiding trace-relevant code from the recipe
 #       key"). Its only caller is a test.
 #     aot_serve.is_aot_artifact — its own docstring says "kind sniff for the

--- a/src/gen_worker/aot_cells.py
+++ b/src/gen_worker/aot_cells.py
@@ -22,7 +22,7 @@ needs a hub tie-break first; the runbook records the hazard.
 
 Filter (SDXL-AOT-PILOT-RUNBOOK.md §3 F1):
 
-* ``kind == aot-inductor`` with a stamped ck5 ``cell_key``;
+* ``kind == aot-inductor`` with a stamped ``cell_key``;
 * runtime-key check via ``aot_serve.verify_declared`` (sm, torch, cuda,
   family, host ISA, code-only flag) — the DECLARE half only. The ``entries``
   contract is unbounded in the model, does not ride the control-plane declare
@@ -88,7 +88,7 @@ _NOT_AUTHORIZED = (401, 403)
 #: that nothing it strips from the declare appears here — the check pgw#988
 #: cost a day of unadoptable cells for not existing.
 DECLARE_CONTRACT_KEYS = frozenset(aot_serve.DECLARED_AXES) | frozenset({
-    "cell_key",       # ck5 identity + the artifact cache name
+    "cell_key",       # cell identity + the artifact cache name
     "weight_lane",    # \_ the canonical execution lane this pipeline needs
     "lora_bucket",    # /
     "sku",            # selection PREFERENCE, never a filter (pgw#765)
@@ -108,7 +108,7 @@ class AdoptedAotCell:
 
     family: str
     cell_key: str
-    ref: str  # "root/family-<f>#<stamped ck5 key>"
+    ref: str  # "root/family-<f>#<stamped cell key>"
     snapshot_digest: str  # "sha256:<hex>" of the artifact tarball
     artifact: Path
 
@@ -465,7 +465,7 @@ def _discover_inner(
         if artifact is None:
             return None
         # From this moment the executor's kind dispatch (#734/#735) must
-        # recognize the ck5-flavored ref as an exported cell.
+        # recognize the key-flavored ref as an exported cell.
         aot_serve.note_aot_key(key)
         adopted = AdoptedAotCell(
             family=family,

--- a/src/gen_worker/aot_flatten.py
+++ b/src/gen_worker/aot_flatten.py
@@ -75,7 +75,7 @@ class Leaf:
         A mapping leaf takes its BARE KEY because that is the keyword the
         pipeline's own forward uses; a sequence leaf takes ``<param>.<index>``.
         This is the string the published contracts are keyed by and the one
-        ``contract_digest`` folds into ck6, so it is fixed — pgw#994 adds the
+        ``contract_digest`` folds into the key, so it is fixed — pgw#994 adds the
         identity next to it rather than renaming 144 live checkpoints.
         """
         name = self.param

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2788,7 +2788,7 @@ def entry_graph_block(
 
 
 def shared_identity_blocks(spec: ExportSpec) -> Dict[str, Any]:
-    """The cell-level ck5 identity facts an exported cell must record.
+    """The cell-level identity facts an exported cell must record.
 
     ``aot_serve.artifact_metadata`` takes ``cell_key`` as a STRING, so the
     envelope on its own would carry a stamp WITHOUT the axes the stamp
@@ -2870,7 +2870,7 @@ def cell_identity(meta: Mapping[str, Any], spec: ExportSpec) -> cell_key.CellKey
 
     CONTRACT-FACTS SHAPE CHANGE (v1 -> v2, pgw#758): this re-keys every
     published ``aot-inductor`` cell; single-graph format-1 cells are RETIRED —
-    correct and expected under ck5 exact identity.
+    correct and expected under exact identity.
 
     CONTRACT-FACTS SHAPE CHANGE (v2 -> v3, pgw#817): ``shell_digest`` joined
     the facts for the (since-retired) regional kind. pgw#846 retires regional

--- a/src/gen_worker/aot_package.py
+++ b/src/gen_worker/aot_package.py
@@ -696,7 +696,7 @@ def input_contract(
             # a serve-side bind reading `position` would fetch the wrong one
             # (measured — it is how pgw#994's `t` went missing). Every cell
             # published before pgw#994 has no containers at all, so every row
-            # is derivable and no live artifact's metadata (or ck6 key) moves
+            # is derivable and no live artifact's metadata (or cell key) moves
             # — see `aot_serve.range_digest`.
             row["param"] = leaf.param
             row["param_position"] = leaf.param_position

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -123,7 +123,7 @@ REALIGN_EVENT = "aot_input_realigned"
 AOTI_ALIGNMENT = 16
 #: Format 2 = multi-graph cells (pgw#758): the envelope carries an
 #: ``entries`` map instead of one flat contract. Format-1 cells are RETIRED
-#: (ck5 exact identity: a recipe change strands old cells, which is fine).
+#: (exact identity: a recipe change strands old cells, which is fine).
 ARTIFACT_FORMAT = 2
 #: Separator between the entry name and the constant FQN in
 #: ``constants.safetensors`` keys. Entry names never contain it (targets are
@@ -240,8 +240,8 @@ def flavor_label(sku: str, version: str, precision: str) -> str:
     return f"aot-{sku}-torch{mm}-{precision}"
 
 
-# Stamped ck5 cell keys this process LEARNED name aot-inductor artifacts
-# (pgw#722 F1 discovery). Published AOT cells ride the ck5 key space as
+# Stamped cell keys this process LEARNED name aot-inductor artifacts
+# (pgw#722 F1 discovery). Published AOT cells ride the same key space as
 # their store flavor — indistinguishable from a dynamo cell's flavor by
 # string shape alone — so discovery registers each learned key here and
 # :func:`is_aot_ref` consults the set. Without this the executor's kind
@@ -252,7 +252,7 @@ _KNOWN_AOT_KEYS_LOCK = threading.Lock()
 
 
 def note_aot_key(cell_key: str) -> None:
-    """Record that ``cell_key`` (a stamped ck5 digest) is an AOT cell."""
+    """Record that ``cell_key`` (a stamped cell-key digest) is an AOT cell."""
     key = str(cell_key or "").strip()
     if not key:
         return
@@ -264,7 +264,7 @@ def is_aot_ref(ref: str, family: str = "") -> bool:
     """True when ``ref`` names an AOTI cell (optionally of one family).
 
     Recognizes both the label form (``#aot-<sku>-...``) and any stamped
-    ck5 key this process learned via :func:`note_aot_key`.
+    cell key this process learned via :func:`note_aot_key`.
     """
     fam, flavor = parse_cell_ref(ref)
     if not fam or (family and fam != family):
@@ -488,7 +488,7 @@ def constants_from_meta(meta: Mapping[str, Any]) -> Tuple[ConstantSpec, ...]:
 def range_digest(meta: Mapping[str, Any]) -> str:
     """Canonical digest of the DECLARED admissible traffic of one artifact.
 
-    Owed to the ck6 identity lane (pgw#716/#717): declared dim ranges live
+    Owed to the exact-identity lane (pgw#716/#717): declared dim ranges live
     in ``ep.range_constraints``, NOT in the graph nodes — three exports
     differing only in declared range produced the identical node-only
     digest. A node-only ``graph_hashes`` therefore collides artifacts that
@@ -527,7 +527,7 @@ def range_digest(meta: Mapping[str, Any]) -> str:
     }
     # pgw#790: the NEGATIVE half of the declared admissible traffic. Two
     # classes that differ only in what they REFUSE admit different traffic,
-    # so the digest must see it or the ck6 collision this function exists to
+    # so the digest must see it or the collision this function exists to
     # close reopens for adapter forks. Keyed only when non-empty: a contract
     # that excludes nothing is the contract every already-published cell
     # declares, and re-keying the fleet's 144 live checkpoints to add a field
@@ -566,7 +566,7 @@ def class_hash(
 
 
 def combined_graph_hash(hashes: Iterable[str]) -> str:
-    """The ck6 combined hash, VERBATIM per pgw#716: the first 16 hex chars
+    """The combined hash, VERBATIM per pgw#716: the first 16 hex chars
     of the sha256 over the newline-joined SORTED per-class hash values
     (sorted by the hash string itself, single ``\\n`` joins, no trailing
     newline, UTF-8 bytes)."""
@@ -624,7 +624,7 @@ def artifact_metadata(
     into two interpretations of the same bytes. Each entry block carries
     ``target``/``fork``/``class_dims``/``inputs``/``symbols``/``constants``
     (+ ``graph``); this function validates every one, stamps its
-    ``range_digest`` and ``class_hash``, and stamps the ck6
+    ``range_digest`` and ``class_hash``, and stamps the
     ``combined_graph_hash`` over the sorted per-class hashes. A malformed
     contract must fail at MINT, on the pod, not at serve time on a paying
     request.

--- a/src/gen_worker/aot_wrapper_split.py
+++ b/src/gen_worker/aot_wrapper_split.py
@@ -45,7 +45,7 @@ from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
 from . import host_isa
-from . import aot_run_impl_split as v2
+from . import aot_run_impl_split as runimpl
 
 logger = logging.getLogger(__name__)
 
@@ -298,11 +298,11 @@ def _reinline(source: str) -> str:
 
 #: Env kill-switch. Not a sealed config knob and not an inductor config —
 #: see :func:`install` for why that distinction is what keeps cell identity
-#: untouched. Kills v1 and v2 together.
+#: untouched. Kills the ctor and run_impl levers together.
 DISABLE_ENV = "GEN_WORKER_AOT_WRAPPER_SPLIT_OFF"
 
 #: Kill switch for the pgw#811 ``run_impl`` split alone, so the (much older,
-#: much better travelled) v1 ctor split can stay on if v2 ever has to go off.
+#: much better travelled) ctor split can stay on if run_impl ever goes off.
 DISABLE_V2_ENV = "GEN_WORKER_AOT_RUN_IMPL_SPLIT_OFF"
 
 #: How many of the K+1 part compiles may run at once. pgw#809's pool owns
@@ -340,11 +340,16 @@ def host_compile_jobs(tus: int) -> int:
     return max(1, min(tus, budget))
 
 
-def _emit(outcome: SplitOutcome, version: str = "") -> None:
-    """One typed row per wrapper compile. ``version`` distinguishes the
-    pgw#811 ``run_impl`` split (``v2_applied`` / ``v2_declined``) from v1's
-    original ``applied`` / ``declined``, so a fleet can tell which of the two
-    levers fired on any given mint."""
+#: Phase-label prefix for the pgw#811 run_impl lever (pgw#958: a name,
+#: never a version number).
+_RUNIMPL = "runimpl"
+
+
+def _emit(outcome: SplitOutcome, lever: str = "") -> None:
+    """One typed row per wrapper compile. ``lever`` names WHICH split fired:
+    the pgw#811 ``run_impl`` split (``runimpl_applied`` / ``runimpl_declined``)
+    versus the original ctor split (bare ``applied`` / ``declined``). A phase
+    label, deliberately non-numeric — it is not a version counter."""
     try:
         from . import activity as activity_mod
 
@@ -352,7 +357,7 @@ def _emit(outcome: SplitOutcome, version: str = "") -> None:
         activity_mod.emit_event(
             EVENT,
             outcome.detail(),
-            phase=f"{version}_{state}" if version else state,
+            phase=f"{lever}_{state}" if lever else state,
         )
     except Exception:  # pragma: no cover - telemetry must never break a mint
         logger.debug("aot-wrapper-split: activity emit failed", exc_info=True)
@@ -408,7 +413,7 @@ def transform_command(cmd_line: str) -> Tuple[str, Optional[SplitOutcome]]:
 
 
 # ---------------------------------------------------------------------------
-# v2: the run_impl K-way split, driven over K+1 real compiles
+# run_impl: the K-way split, driven over K+1 real compiles
 # ---------------------------------------------------------------------------
 
 def _object_arg(argv: Sequence[str]) -> Optional[int]:
@@ -455,9 +460,9 @@ def split_and_compile(cmd_line: str, cwd: str,
         text = source.read_text()
     except OSError as exc:
         _emit(SplitOutcome(False, f"unreadable source: {exc}",
-                           source=str(source)), version="v2")
+                           source=str(source)), lever=_RUNIMPL)
         return None
-    split = v2.split_run_impl(text)
+    split = runimpl.split_run_impl(text)
     if not split.applied:
         _emit(SplitOutcome(False, split.reason, source=str(source)))
         return None
@@ -562,13 +567,13 @@ def install() -> bool:
             return
         _emit(outcome)
 
-        # v2 (pgw#811) splits run_impl out of whatever source v1 left behind
+        # pgw#811 splits run_impl out of whatever source the ctor split left
         # — inductor's own when v1 declined, v1's regrouped one when it did
         # not. It subsumes the single compile: when it fires it drives every
         # compile itself and there is no monolith left to run.
         if not os.environ.get(DISABLE_V2_ENV, "").strip():
             try:
-                v2_outcome = split_and_compile(new_cmd, cwd, original)
+                runimpl_outcome = split_and_compile(new_cmd, cwd, original)
             except Exception as exc:
                 _emit(
                     SplitOutcome(
@@ -577,14 +582,14 @@ def install() -> bool:
                         f"{type(exc).__name__}: {exc}",
                         source=outcome.source,
                     ),
-                    version="v2",
+                    lever=_RUNIMPL,
                 )
                 logger.warning(
                     "aot-wrapper-split: pgw#811 split failed (%s); recompiling "
                     "the whole wrapper", type(exc).__name__, exc_info=True)
             else:
-                if v2_outcome is not None:
-                    _emit(v2_outcome, version="v2")
+                if runimpl_outcome is not None:
+                    _emit(runimpl_outcome, lever=_RUNIMPL)
                     return
 
         if not outcome.applied:

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -11,7 +11,7 @@ and every consumer of cell identity uses the same code:
 * cozy-local's self-mint (gw#555) looks up / saves its store by the same
   key.
 
-The key is the RECIPE DIGEST (ck5, Paul's exact-identity ruling): "look at
+The key is the RECIPE DIGEST (Paul's exact-identity ruling): "look at
 our code and say 'this is the graph we need' — that is our unique
 identifier. If the recipe changes it gets a new identifier, stranding the
 old ones, which is fine." No version comparison, no relaxable axes, no
@@ -36,7 +36,7 @@ exist for this runtime.
                   torch/triton/cuda/diffusers/transformers VERSION axes —
                   content, never version strings
 
-ck6 (pgw#990) DROPS ``code_closure`` from the key. It is still RECORDED on
+pgw#990 DROPS ``code_closure`` from the key. It is still RECORDED on
 every artifact and still drives ``compile_cache``'s local re-trace memo, but
 it is not identity: Paul's final ruling is that identity is the COMPUTATION
 (traced graph x sm x toolchain x env_seal) and "code hashes are a memo, never
@@ -49,7 +49,7 @@ Axes deliberately NOT in the key, recorded in metadata for observability
 and runtime compat checks (``compile_cache.verify``) only: ``sku`` (pgw#691
 — no guard or artifact fact observes it), ``cuda_driver`` (gw#577),
 ``torch``/``triton``/``cuda``/``gen_worker``/``diffusers``/``transformers``
-version strings and ``image_digest`` (ck5 — their CONTENT rides the
+version strings and ``image_digest`` (exact identity — their CONTENT rides the
 toolchain and code_closure axes; version strings and image identity are
 observability, not identity).
 
@@ -68,12 +68,14 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Tuple
 from . import env_seal
 
-# ck2 -> ck3 (pgw#691): sku left. ck3 -> ck4 (pgw#696): env_seal joined.
-# ck4 -> ck5 (Paul's exact-identity ruling): the key became the RECIPE
-# digest — toolchain + code_closure content joined; every version axis
-# left. ck5 is FINAL: new identity facts ride the content digests (seal_v /
-# closure/toolchain values), never new axes.
-KEY_SCHEME = "ck6"
+# pgw#958 (DESIGN-RULINGS §1.27(g); Paul 2026-08-04, reaffirmed 2026-08-07
+# over pgw#990's ck6 — "the ck6 is wrong and can be removed, the v1 is the
+# correct one"): the counter restarts at 1, and the pre-existing ck1..ck6
+# corpus is PURGED in the same cut (th#1636), so no two cells ever share a
+# scheme token with different meanings. ck1 is the only live scheme; new
+# identity facts ride the content digests (seal_v / closure / toolchain
+# values), never new axes and never a new scheme number.
+KEY_SCHEME = "ck1"
 _PREFIX = KEY_SCHEME + "-"
 # The key digest doubles as the store flavor token, whose shared grammar
 # (th#597 C5: [a-z0-9][a-z0-9._-]{0,63}, Go+Py identical) caps tokens at 64
@@ -243,7 +245,7 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     store. A cell with no computable key is refused and re-minted.
 
     EXPORTED (``aot-inductor``) cells are refused here BY NAME (pgw#735): they
-    ride the same ck5 key space — the axis names are what :func:`from_axes`
+    ride the same key space — the axis names are what :func:`from_axes`
     validates, and the kind is an envelope value, so no scheme bump was needed —
     but their axes are not an inductor cache's, and their key is STAMPED at mint.
     Read ``meta["cell_key"]``; do not recompute an exported cell's identity from

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -730,7 +730,7 @@ def is_cache_ref(ref: str, family: str = "") -> bool:
     """True when ``ref`` names an inductor compile-cache cell (optionally of
     one specific family). Cells are flavored either with the legacy human
     label (``inductor-<sku>-torch<mm>[-lane]``) or, post-th#883, with the
-    worker-computed cell key itself (``ck2-<sha256>`` — pull-by-key)."""
+    worker-computed cell key itself (``ck1-<sha256>`` — pull-by-key)."""
 
     fam, flavor = parse_cell_ref(ref)
     if not fam or (family and fam != family):
@@ -767,7 +767,7 @@ def declared_contract_facts(cfg: Any, *, lora_bucket_override: Optional[int] = N
     }
 
 
-# --- static code closure (ck5 recipe identity, Paul's exact-identity
+# --- static code closure (recipe identity, Paul's exact-identity
 # ruling) -------------------------------------------------------------------
 #
 # "Look at our code and say 'this is the graph we need', ideally with pure
@@ -775,7 +775,7 @@ def declared_contract_facts(cfg: Any, *, lora_bucket_override: Optional[int] = N
 # import graph reachable from the compile/composition entrypoints, resolved
 # by AST inspection only (no execution): every reached source file is
 # content-digested, and the sorted (module-path, digest) list digests into
-# the ck5 ``code_closure`` axis. Paul's root-imports convention (top-of-file
+# the ``code_closure`` axis. Paul's root-imports convention (top-of-file
 # imports, no runtime imports) is exactly what makes this static graph
 # SOUND — and the mint-time completeness gate below turns that convention
 # into a hard check where the key's honesty depends on it.
@@ -875,7 +875,7 @@ def static_code_closure(roots: Tuple[str, ...] = ()) -> Tuple[Tuple[str, str], .
 
 def closure_completeness_gap(roots: Tuple[str, ...] = ()) -> List[str]:
     """Loaded modules inside the composition namespaces that the static
-    import walk cannot see. NOT a mint gate (Paul's ck6 ruling demoted the
+    import walk cannot see. NOT a mint gate (Paul's pgw#990 ruling demoted the
     closure to a possible future memo — this check's only job was memo
     honesty, so it rides the deferred memo issue): kept as diagnostics for
     that issue. Note the live finding it produced: executor-side models/*
@@ -906,7 +906,7 @@ def assert_closure_complete(roots: Tuple[str, ...] = ()) -> None:
     gaps = closure_completeness_gap(roots)
     if gaps:
         raise RuntimeError(
-            f"code-closure completeness gate (ck5): {len(gaps)} loaded "
+            f"code-closure completeness gate: {len(gaps)} loaded "
             f"module(s) outside the static import closure — a dynamic "
             f"import is hiding trace-relevant code from the recipe key: "
             f"{gaps[:10]!r}")
@@ -931,7 +931,7 @@ def toolchain_digest() -> Tuple[Tuple[str, str], ...]:
     try:
         import importlib.metadata
 
-        # ck5: diffusers/transformers/peft ride here at package granularity
+        # diffusers/transformers/peft ride here at package granularity
         # (their VERSION axes left the key; content replaces them).
         wanted = ("torch", "triton", "diffusers", "transformers", "peft")
         for dist in importlib.metadata.distributions():
@@ -960,7 +960,7 @@ def content_keys() -> Tuple[Tuple[str, str], ...]:
     """torch/triton CONTENT identity as upstream computes it (cache-design
     review §6.5: ``torch_key`` hashes the whole torch package's bytes;
     ``triton_key`` per-file shas + the libtriton binary). Recorded in
-    metadata for observability/forensics — the ck5 key's content identity
+    metadata for observability/forensics — the key's content identity
     for the same stack rides the ``toolchain`` axis (dist-info RECORDs +
     tool binaries), which is cheaper and covers the cuda runtime too."""
     out: Dict[str, str] = {"torch": "", "triton": ""}
@@ -1034,10 +1034,10 @@ def artifact_metadata(
         # pgw#697: per-module fingerprint rows so an adoption refusal can
         # name the exact drifted module, not just a digest mismatch.
         "composition": [[str(p), str(d)] for p, d in composition],
-        # pgw#696: the execution-environment seal rides verbatim — the ck4
+        # pgw#696: the execution-environment seal rides verbatim — the
         # env_seal axis is recomputed FROM it, never trusted as a stamp.
         env_seal.SEAL_KEY: env_seal.effective_seal(),
-        # ck5 recipe facts: toolchain + static code closure feed the key
+        # recipe facts: toolchain + static code closure feed the key
         # axes (recomputed from these blocks, never trusted as stamps);
         # content_keys stay observability (review §6.5). Endpoint closure
         # roots ride in when the executor passes them (train-lane wiring).
@@ -1410,7 +1410,7 @@ def _semantic_cache_tag(pipeline: Any, cfg: Any) -> str:
     ``cache_key_tag`` (review §6.3), so a delivered cell's entries are
     mechanically unconsumable by a process whose declared semantic identity
     differs. Environment facts are deliberately excluded: the inner FX key
-    already hashes them natively (system info, config, dtypes) and the ck5
+    already hashes them natively (system info, config, dtypes) and the
     outer key pins them via env_seal/toolchain/code_closure — the tag's job
     is semantics only."""
     execution_lane = cell_key._canonical_execution_lane(

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -288,7 +288,7 @@ def _establish_env_seal() -> Dict[str, Any]:
     ``TORCH*`` env vars, pin the canonical config surface, and record the
     effective seal — BEFORE the CUDA probe or any model/compile work, so
     every graph this process ever mints or serves runs under the sealed
-    posture and the ck4 ``env_seal`` axis describes reality. A process that
+    posture and the ``env_seal`` axis describes reality. A process that
     cannot be sealed must not advertise: the caller exits typed."""
     from . import env_seal
 
@@ -312,7 +312,7 @@ def _isolate_group_inductor_cache() -> None:
     Set AFTER the seal — env_seal scrubs the whole ``TORCH*``/``TRITON*``
     namespace at boot, and the sanctioned window to point the SDK's own capture
     redirects is after that scrub (same as cell ``capture_env``). A per-group
-    PATH is plumbing, not a behaviour flag, so it does not touch the ck4 seal
+    PATH is plumbing, not a behaviour flag, so it does not touch the seal
     digest or minted kernels (inductor keys are content-addressed).
 
     Gated on ``host_siblings() > 1``: a single child (or no split) keeps torch's

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -59,17 +59,14 @@ import importlib.util
 
 logger = logging.getLogger(__name__)
 
-# v3 (pgw#718/#719 erase-and-impose): recorded-env facts left (scrubbed
-# vars are constants by construction); + hash-seed facts + loaded-library
-# digest. v2 added the operator `epoch` salt. v4 (pgw#745): host driver
-# libs excluded from the loaded-lib manifest (gw#577: driver is never
-# identity). v5 (pgw#749): the identity manifest is the python env's
-# toolchain libs ON DISK — phase-independent — never the mapped set.
-# Adding/changing sealed facts bumps THIS version only — never the
-# key-axis set. v6 (pgw#754): host-ISA codegen clamp facts (cpp_march /
-# cpp_simdlen) — deliberately retires every pre-clamp cell: they were
-# compiled -march=native for their mint host's CPU and are not portable.
-SEAL_VERSION = 6
+# pgw#958 (§1.27(g)): restarted at 1 alongside KEY_SCHEME, with the
+# pre-existing cell corpus purged in the same cut — v1..v6 minted real cells
+# and re-issuing 1 is only honest once none of them survive. The seal dict
+# carries every sealed fact accumulated through the old v6 (epoch salt,
+# hash-seed + loaded-library digests, driver libs excluded, on-disk toolchain
+# manifest, host-ISA codegen clamp). Adding/changing sealed facts bumps THIS
+# version only — never the key-axis set.
+SEAL_VERSION = 1
 SEAL_KEY = "env_seal"
 
 # R2: the operator-settable generation salt. Bumping it disowns every cell

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -676,7 +676,7 @@ def _cell_execution_lane_matches(
     lora_bucket endpoint needs exactly a ``-lora<bucket>`` cell of its base
     lane, and a branchless endpoint must never fetch one (either mismatch is
     a guaranteed lane_drift that would shadow the right cell and serve
-    eager). Key-flavored cells (th#883 pull-by-key, ``#ck2-…``) match only
+    eager). Key-flavored cells (th#883 pull-by-key, ``#ck1-…``) match only
     when their key is one this runtime computed for itself."""
 
     if not compile_cache.is_cache_ref(ref, family):

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -235,7 +235,7 @@ def finalized_in_process(key: str) -> Optional["SelfMint"]:
 
 
 # pgw#712 fence marker (see publish()): presence in metadata refuses
-# republication. Nothing in-tree stamps it post-ck5.
+# republication. Nothing in-tree stamps it under exact identity.
 ADOPTION_MARK = "equivalence_adopted"
 
 
@@ -498,11 +498,11 @@ class CellPublisher:
         treats every raise as non-fatal to serving.
         """
 
-        # pgw#712 (kept under the ck5 exact-identity ruling as
+        # pgw#712 (kept under the exact-identity ruling as
         # defense-in-depth): a cell whose metadata carries a foreign
         # adoption provenance must never republish under this worker's
         # key. Nothing in-tree stamps the mark anymore (equivalence
-        # adoption was deleted with ck5); a marked cell can only be a
+        # adoption was deleted with exact identity); a marked cell can only be a
         # foreign/hand-copied artifact — refuse it.
         mark = meta.get(ADOPTION_MARK)
         if mark:

--- a/src/gen_worker/graph_hash.py
+++ b/src/gen_worker/graph_hash.py
@@ -1,4 +1,4 @@
-"""Canonical GRAPH identity — the ck6 key input (pgw#716).
+"""Canonical GRAPH identity — the cell-key input (pgw#716).
 
 Paul's ruling: "I'd rather key on the graph that is changed, not hash on code
 changes... look at some code and be like 'oh this is graph-ABC' and that is the

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -106,9 +106,11 @@ import argparse
 
 logger = logging.getLogger(__name__)
 
-# v2 (pgw#695): + "posture" process-seal block
-# v3 (pgw#756): advisory gate — + "unproven" rows, + "gate" disposition
-MANIFEST_VERSION = 3
+# pgw#958 (§1.27(g)): restarted at 1 alongside KEY_SCHEME / SEAL_VERSION,
+# with the pre-existing cell corpus purged in the same cut. The manifest
+# shape is the one the old v3 reached (posture process-seal block, advisory
+# gate, "unproven" rows).
+MANIFEST_VERSION = 1
 MANIFEST_KEY = "guard_manifest"
 POSTURE_KEY = "posture"
 GATE_KEY = "gate"

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -797,7 +797,7 @@ def _merge_sharded_checkpoint(snapshot_dir: Path, index_path: Path) -> Path:
 # `bf16_resident_fits` / BF16_RESIDENT_MARGIN_GB) is REMOVED, ruled by Paul on
 # pgw#772. The serving lane is deterministic per (release x declared config)
 # — never a function of the individual card's free VRAM. The probe made
-# `lane` the only GPU-dependent axis of the ck5 cell key: a 4090's ~1.5 GiB
+# `lane` the only GPU-dependent axis of the cell key: a 4090's ~1.5 GiB
 # VRAM surplus over an L4 (same release/image/sm_89) flipped it to base lane
 # "", a lane NOTHING mints for, so the better card missed all 144 published
 # checkpoints INCLUDING its own same-SKU cell and served eager for life

--- a/src/gen_worker/serving_mode.py
+++ b/src/gen_worker/serving_mode.py
@@ -94,7 +94,7 @@ def classify_mode(active_compile_ref: str, pipeline: Any = None) -> str:
     """``eager`` | ``jit_cell`` | ``aot_cell``.
 
     The discriminator is the ARMED artifact, never the lane string: both cell
-    kinds set ``active_compile_ref``, and stamped ck5 keys are string-shape
+    kinds set ``active_compile_ref``, and stamped cell keys are string-shape
     identical, so the ref alone cannot be pattern-matched. ``aot_serve`` owns
     the answer (``is_aot_ref`` for the recorded kind, the ``_cozy_aot`` marker
     for what is live on the pipeline right now).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def _fresh_process_settings():
 def _fresh_learned_aot_keys():
     """`aot_serve.note_aot_key` learns into a process-global set. A key one
     test teaches must never reclassify another test's dynamo refs as AOT —
-    the pgw#722 discovery suite's `ck5-999…` collided with the adopt suite's
+    the pgw#722 discovery suite's `ck1-999…` collided with the adopt suite's
     stubbed mint digest and silently flipped its whole proof lane."""
     from gen_worker import aot_serve
 

--- a/tests/harness/mint_endpoints_pgw784.py
+++ b/tests/harness/mint_endpoints_pgw784.py
@@ -55,7 +55,7 @@ def _request(workdir: Path) -> mp.MintRequest:
     workdir.mkdir(parents=True, exist_ok=True)
     return mp.MintRequest(
         function="gen", modules=("harness.toy_endpoints",),
-        family="pgw784", cell_key="ck5-liveness",
+        family="pgw784", cell_key="ck1-liveness",
         target=str(workdir / "cell.tar.gz"),
         capture=str(workdir / "capture"),
         report=str(workdir / mp.REPORT_NAME),

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -67,9 +67,9 @@ _BURST_META: Dict[str, Any] = {
     "image_digest": _IMAGE_DIGEST,
     "libs": {"diffusers": "0.39.0", "transformers": "5.13.1"},
     "shape_contract": _SHAPE_CONTRACT,
-    # Reconstruction: the ck2-era burst pre-dates env sealing and recipe
+    # Reconstruction: the recorded burst pre-dates env sealing and recipe
     # identity; fixed representative blocks keep the lane-only-divergence
-    # relations provable under ck5 (burst_runtime pins effective_seal /
+    # relations provable under exact identity (burst_runtime pins effective_seal /
     # toolchain_digest / static_code_closure to THESE dicts, exactly as it
     # pins every other runtime probe).
     "env_seal": {

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -42,7 +42,7 @@ _MEASURED_ARM_FLOOR_MS = int(_INDUCED_ARM_S * 1000 * 0.75)
 FAMILY = "sdxl"
 RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130",
            "cuda": "13.0"}
-KEY = "ck5-" + "a" * 56
+KEY = "ck1-" + "a" * 56
 
 INPUTS = [
     {"name": "sample", "position": 0, "dtype": "bfloat16",
@@ -339,7 +339,7 @@ def test_fleet_did_not_arm_is_a_measured_refusal_naming_the_candidate(
     outcome = fleet_cells.enable_compiled(
         _FleetPipe(), _FleetCfg(), artifact=delivered,
         publisher=_StubPublisher(),  # type: ignore[arg-type]
-        delivered_ref="root/family-sdxl#ck5-delivered",
+        delivered_ref="root/family-sdxl#ck1-delivered",
         delivered_digest="blake3:" + "7" * 64)
     assert outcome.armed and outcome.self_mint is None
     # BOTH attempts are on the ledger, in order: the discovered cell that
@@ -349,7 +349,7 @@ def test_fleet_did_not_arm_is_a_measured_refusal_naming_the_candidate(
     assert outcome.adoptions[0].ref == _f1.ref
     assert not outcome.adoptions[0].armed
     assert outcome.adoptions[1].armed
-    assert outcome.adoptions[1].ref == "root/family-sdxl#ck5-delivered"
+    assert outcome.adoptions[1].ref == "root/family-sdxl#ck1-delivered"
 
 
 def test_fleet_armed_other_path_never_advertises_aot(

--- a/tests/test_aot_boot_proof_gap_pgw735.py
+++ b/tests/test_aot_boot_proof_gap_pgw735.py
@@ -158,7 +158,7 @@ def _rig(monkeypatch: pytest.MonkeyPatch, *, seed: str, exercise: bool,
     RIG["exercise"] = exercise
     if weight_lane:
         RIG["weight_lane"] = weight_lane
-    key = "ck5-" + (seed * 56)[:56]
+    key = "ck1-" + (seed * 56)[:56]
     ref = f"root/family-{FAMILY}#{key}"
     monkeypatch.setattr(fleet_cells, "enable_compiled", _fake_arm(key, ref))
     return key, ref

--- a/tests/test_aot_flip_pgw722.py
+++ b/tests/test_aot_flip_pgw722.py
@@ -58,7 +58,7 @@ CONSTANTS = [
 
 
 def _key(seed: str) -> str:
-    return "ck5-" + (seed * 56)[:56]
+    return "ck1-" + (seed * 56)[:56]
 
 
 @pytest.fixture()
@@ -306,7 +306,7 @@ def test_discover_downloads_newest_and_registers_key(
         assert adopted.snapshot_digest == (
             "sha256:" + hashlib.sha256(blob).hexdigest())
         # The executor's kind dispatch (#734/#735) must now classify the
-        # ck5-flavored ref as an exported cell.
+        # ck1-flavored ref as an exported cell.
         assert aot_serve.is_aot_ref(adopted.ref)
         # Re-discovery serves from the local cache (no second download).
         blob_requests = [p for p, _ in hub.requests if p.startswith("/blob/")]

--- a/tests/test_aot_mint_unblock_pgw813_pgw815.py
+++ b/tests/test_aot_mint_unblock_pgw813_pgw815.py
@@ -168,7 +168,7 @@ def _w8a8_miss(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
     monkeypatch.setattr(
         fleet_cells.cell_key, "compute",
-        lambda *a, **k: type("_K", (), {"digest": "ck5-" + "a" * 56})())
+        lambda *a, **k: type("_K", (), {"digest": "ck1-" + "a" * 56})())
     monkeypatch.setattr(
         fleet_cells.cc, "begin_fleet_mint", lambda p, c, capture: None)
     # THE lane: sdxl's mixed fp8 checkpoint stamps `w8a8-lora64` (pgw#686 cell
@@ -354,7 +354,7 @@ def test_eager_first_admits_a_DELEGATED_pending_with_no_router(
         "name": "generate",
     })()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-" + "a" * 56, ref="r", cfg=cfg,
+        family=FAMILY, cell_key="ck1-" + "a" * 56, ref="r", cfg=cfg,
         target=tmp_path / "c.tar.gz", capture_dir=tmp_path / "cap",
         mint_root=tmp_path, publisher=None, delegated=True,
         recipe=fleet_cells.RECIPE_AOT)
@@ -382,7 +382,7 @@ def test_eager_first_still_requires_a_router_for_an_IN_PROCESS_capture(
         "name": "generate",
     })()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-" + "b" * 56, ref="r", cfg=cfg,
+        family=FAMILY, cell_key="ck1-" + "b" * 56, ref="r", cfg=cfg,
         target=tmp_path / "c.tar.gz", capture_dir=tmp_path / "cap",
         mint_root=tmp_path, publisher=None, delegated=False)
     inj = _Inj(compile_objects=[_Candidate(pipe)],
@@ -398,7 +398,7 @@ def test_eager_first_still_requires_a_router_for_an_IN_PROCESS_capture(
 
 def _finalized_pending(tmp_path: Path, publisher: Any) -> Any:
     """A pending that has been packed — a real file, a real key, real bytes."""
-    key = "ck5-" + "c" * 56
+    key = "ck1-" + "c" * 56
     target = tmp_path / "cell.tar.gz"
     target.write_bytes(b"x" * 4096)
     pending = fleet_cells.PendingSelfMint(
@@ -458,7 +458,7 @@ def test_a_publish_gate_with_nothing_packed_is_NAMED(
     pendings it believes it packed, so reaching it with nothing packed is a
     real defect and must not be a no-op."""
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-" + "d" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, cell_key="ck1-" + "d" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", capture_dir=tmp_path / "cap",
         mint_root=tmp_path / "root2", publisher=_Publisher())
 
@@ -472,7 +472,7 @@ def test_a_withhold_with_nothing_packed_is_NAMED(
     tmp_path: Path, _events: List[Tuple[str, str, str]],
 ) -> None:
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-" + "e" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, cell_key="ck1-" + "e" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", capture_dir=tmp_path / "cap",
         mint_root=tmp_path / "root3", publisher=_Publisher())
 
@@ -520,7 +520,7 @@ def test_a_boot_that_resolves_NOTHING_confesses(
     ex = _executor(tmp_path)
     spec = type("_S", (), {"name": "generate"})()
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-" + "f" * 56, ref="r", cfg=_Cfg(),
+        family=FAMILY, cell_key="ck1-" + "f" * 56, ref="r", cfg=_Cfg(),
         target=tmp_path / "c.tar.gz", capture_dir=tmp_path / "cap",
         mint_root=tmp_path / "root4", publisher=_Publisher())
     pending.mint_root.mkdir(parents=True, exist_ok=True)

--- a/tests/test_aot_selfmint_pgw805.py
+++ b/tests/test_aot_selfmint_pgw805.py
@@ -132,11 +132,11 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
     monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
-    # No GPU on a dev box: the ck5 `sm` axis is a real-runtime fact, and this
+    # No GPU on a dev box: the `sm` axis is a real-runtime fact, and this
     # test is about the RECIPE decision, not key computation.
     monkeypatch.setattr(
         fleet_cells.cell_key, "compute",
-        lambda *a, **k: type("_K", (), {"digest": "ck5-" + "a" * 56})())
+        lambda *a, **k: type("_K", (), {"digest": "ck1-" + "a" * 56})())
     # w8a8 is the migration's first lane (pgw#704 parity); its mandatory
     # serving refusal is a separate policy, exercised in its own test.
     monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda p: False)
@@ -435,7 +435,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
     from gen_worker import mint_child
 
     target = tmp_path / "cell.tar.gz"
-    packed = tmp_path / "aot" / "ck5-abc.tar.gz"
+    packed = tmp_path / "aot" / "ck1-abc.tar.gz"
     seen: Dict[str, Any] = {}
 
     def _fake_mint(pipe: Any, spec: Any, out_dir: Path, **kw: Any) -> Any:
@@ -446,7 +446,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
         packed.write_bytes(b"packed-cell")
         return aot_mint.MintResult(
             artifact=packed,
-            metadata={"cell_key": "ck5-abc", "entries": {"unet/cfg": {}},
+            metadata={"cell_key": "ck1-abc", "entries": {"unet/cfg": {}},
                       "mint_phases": {"totals": {"total_s": 1.0}}},
             timings={"total_s": 1.0})
 
@@ -459,7 +459,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
 
     request = MintRequest(
         function="generate", modules=("sdxl.main",), family=FAMILY,
-        cell_key="ck5-parent", target=str(target),
+        cell_key="ck1-parent", target=str(target),
         capture=str(tmp_path / "cap"), report=str(tmp_path / "report.json"),
         cfg=cfg_spec(_Cfg()), recipe="aot")
     report = mint_child._mint_aot(
@@ -468,7 +468,7 @@ def test_the_child_runs_the_exporter_for_the_aot_recipe(
 
     assert report.status == "minted"
     assert report.recipe == "aot"
-    assert report.cell_key == "ck5-abc"
+    assert report.cell_key == "ck1-abc"
     assert report.mint_phases == {"totals": {"total_s": 1.0}}
     assert target.read_bytes() == b"packed-cell"
     # The spec the exporter got describes the LIVE pipeline, not a re-compose.
@@ -526,14 +526,14 @@ def test_a_self_minted_aot_cell_arms_through_the_aot_gates(
         lambda *a, **k: (calls.append("dynamo"), True)[1])
     monkeypatch.setattr(
         fleet_cells, "_packed_metadata",
-        lambda artifact: {"cell_key": "ck5-real", "kind": "aot-inductor"})
+        lambda artifact: {"cell_key": "ck1-real", "kind": "aot-inductor"})
     monkeypatch.setattr(fleet_cells, "sha256_file", lambda p: "beef")
     monkeypatch.setattr(fleet_cells, "_unregister", lambda p: None)
 
     artifact = tmp_path / "cell.tar.gz"
     artifact.write_bytes(b"cell")
     pending = fleet_cells.PendingSelfMint(
-        family=FAMILY, cell_key="ck5-handle", ref="root/family-sdxl#ck5-handle",
+        family=FAMILY, cell_key="ck1-handle", ref="root/family-sdxl#ck1-handle",
         cfg=_Cfg(), target=artifact, capture_dir=tmp_path / "cap",
         mint_root=tmp_path, publisher=None, delegated=True,
         recipe=fleet_cells.RECIPE_AOT)
@@ -544,4 +544,4 @@ def test_a_self_minted_aot_cell_arms_through_the_aot_gates(
     assert minted is not None
     # The REAL key comes off the packed envelope — an AOT key folds the
     # combined graph hash and cannot be known before the export runs.
-    assert minted.cell_key == "ck5-real"
+    assert minted.cell_key == "ck1-real"

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -521,7 +521,7 @@ def test_labels_and_refs():
     # A dynamo cache ref must not be mistaken for an exported cell (pgw#735:
     # it would then be scored by FX hits).
     assert aot.is_aot_ref(
-        f"root/family-{FAMILY}#ck5-0123456789abcdef") is False
+        f"root/family-{FAMILY}#ck1-0123456789abcdef") is False
 
 
 def test_verify_refuses_baked_weights(stub_runtime):

--- a/tests/test_benchmark_telemetry_pgw789.py
+++ b/tests/test_benchmark_telemetry_pgw789.py
@@ -110,7 +110,7 @@ def test_a_guard_missed_request_reports_the_fallback_not_the_tier() -> None:
     class: `volatile` means permanently eager for this shape, and downgrading
     it to `guard_miss` loses that."""
     served = serving_mode.resolve(
-        active_compile_ref="root/family-sdxl#ck5",
+        active_compile_ref="root/family-sdxl#ck1",
         guard_missed=True,
         verdict=serving_mode.FALLBACK_VOLATILE,
         sm="sm_89",

--- a/tests/test_boot_phases_arm_pgw764.py
+++ b/tests/test_boot_phases_arm_pgw764.py
@@ -58,7 +58,7 @@ def test_a_refused_arm_rides_a_boot_row_with_its_reason(
         raise AdoptError("key_mismatch", "cell was minted for sm_90, host is sm_89")
 
     monkeypatch.setattr(aot_serve, "load_and_wrap", refuse)
-    artifact = tmp_path / "ck5_deadbeef.tar.gz"
+    artifact = tmp_path / "ck1_deadbeef.tar.gz"
     artifact.write_bytes(b"not-a-real-artifact")
 
     # Behaviour is unchanged: a refused arm stays eager and returns False.
@@ -73,16 +73,16 @@ def test_a_refused_arm_rides_a_boot_row_with_its_reason(
     assert row.reason == "key_mismatch"
     assert "sm_90" in row.detail
     assert row.artifact_kind == aot_serve.ARTIFACT_KIND
-    assert row.artifact_key == "ck5_deadbeef"
+    assert row.artifact_key == "ck1_deadbeef"
 
 
 def test_an_armed_cell_rides_an_ok_boot_row(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    meta = {"family": "sdxl", "cell_key": "ck5_feed", "entries": {"unet": {}},
+    meta = {"family": "sdxl", "cell_key": "ck1_feed", "entries": {"unet": {}},
             "sku": "rtx-4090", "torch": "2.13", "precision": "w8a8"}
     monkeypatch.setattr(aot_serve, "load_and_wrap", lambda *a, **k: meta)
-    artifact = tmp_path / "ck5_feed.tar.gz"
+    artifact = tmp_path / "ck1_feed.tar.gz"
     artifact.write_bytes(b"x")
 
     assert aot_serve.enable(object(), object(), artifact=artifact).armed is True
@@ -90,6 +90,6 @@ def test_an_armed_cell_rides_an_ok_boot_row(
             if r.terminal and r.phase == boot_phases.PHASE_CELL_ARM]
     assert len(arms) == 1
     assert arms[0].outcome == boot_phases.OUTCOME_OK
-    assert "key=ck5_feed" in arms[0].detail
+    assert "key=ck1_feed" in arms[0].detail
 
 

--- a/tests/test_boot_phases_pgw764.py
+++ b/tests/test_boot_phases_pgw764.py
@@ -163,11 +163,11 @@ def test_a_typed_refusal_is_recorded_as_refused_not_failed() -> None:
     with boot_phases.span(
         boot_phases.PHASE_CELL_ARM,
         artifact_kind=aot_serve.ARTIFACT_KIND,
-        artifact_key="ck5_deadbeef",
+        artifact_key="ck1_deadbeef",
     ) as arm:
         # The shape aot_serve.enable uses: classified reason token + the
         # identifiers and the exception in detail (pgw#760 doctrine).
-        arm.refused(str(exc.reason), f"key=ck5_deadbeef: {type(exc).__name__}: {exc}")
+        arm.refused(str(exc.reason), f"key=ck1_deadbeef: {type(exc).__name__}: {exc}")
 
     row = [r for r in boot_phases.recorded_rows()
            if r.terminal and r.phase == boot_phases.PHASE_CELL_ARM][0]
@@ -176,7 +176,7 @@ def test_a_typed_refusal_is_recorded_as_refused_not_failed() -> None:
     assert row.reason == "key_mismatch"
     assert "sm_90" in row.detail
     assert row.artifact_kind == aot_serve.ARTIFACT_KIND
-    assert row.artifact_key == "ck5_deadbeef"
+    assert row.artifact_key == "ck1_deadbeef"
 
 
 def test_a_cumulative_milestone_is_not_summed_as_a_phase() -> None:
@@ -237,9 +237,9 @@ def test_serving_mode_distinguishes_aot_from_jit_from_eager(
     # Both cell kinds set active_compile_ref, so the ref alone cannot be
     # pattern-matched — aot_serve owns the discrimination.
     monkeypatch.setattr(aot_serve, "is_aot_ref", lambda ref: ref.endswith("aot"))
-    assert serving_mode.classify_mode("root/family-sdxl#ck5aot") == \
+    assert serving_mode.classify_mode("root/family-sdxl#ck1aot") == \
         serving_mode.MODE_AOT_CELL
-    assert serving_mode.classify_mode("root/family-sdxl#ck5jit") == \
+    assert serving_mode.classify_mode("root/family-sdxl#ck1jit") == \
         serving_mode.MODE_JIT_CELL
 
 
@@ -247,13 +247,13 @@ def test_a_guard_miss_request_is_not_counted_as_compiled() -> None:
     """The defect this closes: a compiled lane that served ONE request eager
     still reported lane=...+compiled, contaminating every comparison."""
     served = serving_mode.resolve(
-        active_compile_ref="root/family-sdxl#ck5", guard_missed=True, sm="sm_89")
+        active_compile_ref="root/family-sdxl#ck1", guard_missed=True, sm="sm_89")
     assert served.served_eager_fallback is True
     assert served.fallback_reason == serving_mode.FALLBACK_GUARD_MISS
     assert served.sm == "89"  # matches WorkerResources.gpu_sm spelling
 
     clean = serving_mode.resolve(
-        active_compile_ref="root/family-sdxl#ck5", sm="89")
+        active_compile_ref="root/family-sdxl#ck1", sm="89")
     assert clean.served_eager_fallback is False
     assert clean.fallback_reason == ""
 

--- a/tests/test_candidate_publish_parity_pgw749.py
+++ b/tests/test_candidate_publish_parity_pgw749.py
@@ -1,8 +1,8 @@
 """pgw#749: a cold-boot CANDIDATE key must equal the key a mint on the same
 runtime PUBLISHES — otherwise boot-attach adoption can never fire and every
 cold pod starts a mint it did not need (live: every sdxl 0.2.14 pod
-demanded ck5-4c7e494b/ck5-ad5fdb4b while every mint published
-ck5-41b367ab/ck5-e6e3be89; ADOPT-WITHOUT-MINT = 0 across a 13-worker
+demanded ck1-4c7e494b/ck1-ad5fdb4b while every mint published
+ck1-41b367ab/ck1-e6e3be89; ADOPT-WITHOUT-MINT = 0 across a 13-worker
 burst).
 
 Mechanism (verified against the banked artifacts): the seal's loaded-lib

--- a/tests/test_cell_adoption_measurement_pgw923.py
+++ b/tests/test_cell_adoption_measurement_pgw923.py
@@ -31,7 +31,7 @@ from gen_worker.cell_adopt import AdoptOutcome, CellAdoption
 from gen_worker.executor import Executor, _InjectionResult
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
-REF = "root/family-sdxl#ck5-" + "b" * 56
+REF = "root/family-sdxl#ck1-" + "b" * 56
 DIGEST = "blake3:" + "c" * 64
 
 #: The arm is INDUCED to take this long, and the floor asserted against it is a
@@ -163,7 +163,7 @@ def test_the_arm_is_measured_and_recorded_as_the_cell_arm_boot_phase(
 
     def _slow_arm(pipe: Any, cfg: Any, cache_dir: Any, art: Any) -> AdoptOutcome:
         time.sleep(_INDUCED_ARM_S)
-        return AdoptOutcome.hit("family=sdxl key=ck5-abc")
+        return AdoptOutcome.hit("family=sdxl key=ck1-abc")
 
     monkeypatch.setattr(fleet_cells.provision, "enable_compiled", _slow_arm)
     outcome = fleet_cells.enable_compiled(

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -34,7 +34,7 @@ class _ContractCfg:
 _FACTS = cc.declared_contract_facts(_ContractCfg())
 _CONTRACT = ck.contract_digest(_FACTS)
 
-# ck6 recipe axes: version strings and image identity live in METADATA only
+# Recipe axes: version strings and image identity live in METADATA only
 # (observability); content digests carry the identity. pgw#990 dropped
 # `code_closure` — a source-file content hash is a MEMO, never identity.
 _AXES = {
@@ -83,7 +83,7 @@ def test_unknown_and_missing_axes_refuse():
     with pytest.raises(ck.CellKeyError):
         ck.from_axes(dict(_AXES, sku="b200"))  # demoted to metadata (pgw#691)
     with pytest.raises(ck.CellKeyError):
-        ck.from_axes(dict(_AXES, torch="2.13.0"))  # version axes left in ck5
+        ck.from_axes(dict(_AXES, torch="2.13.0"))  # version axes are gone
     with pytest.raises(ck.CellKeyError):
         ck.from_axes({k: v for k, v in _AXES.items() if k != "toolchain"})
 
@@ -112,29 +112,31 @@ def test_sku_is_not_identity(fixed_runtime):
     assert _meta("a40", sm="sm_89")["cell_key"] != a40["cell_key"]
 
 
-def test_key_scheme_ck6_old_keys_never_half_match():
-    """Each axis-set change bumps the scheme (sku collapse -> ck3, env_seal
-    -> ck4, recipe identity -> ck5, code_closure OUT -> ck6): an older digest
-    can never collide with a current one — a clean MISS, never a half-match.
+def test_key_scheme_ck1_foreign_keys_never_half_match():
+    """pgw#958 (§1.27(g), Paul 2026-08-07 over pgw#990's ck6): ck1 is the only
+    scheme this runtime mints, and the pre-existing ck1..ck6 corpus was purged
+    (th#1636) so the token cannot mean two things. A digest under any other
+    scheme token can never collide with a current one — a clean MISS, never a
+    half-match.
 
-    pgw#990: shape is scheme-AGNOSTIC, byte-identical to tensorhub's
+    pgw#990: shape stays scheme-AGNOSTIC, byte-identical to tensorhub's
     `compilecache.IsCellKey`, for the reason th#1183 gives — pinning the
     current scheme in the shape check turns every other-scheme cell into
-    `unreadable_cell_key`, which is a lie and a filter no axis justifies. An
-    old-scheme token IS key-shaped; it simply names no artifact this runtime
-    computes, and `mismatch` says so on the axes.
+    `unreadable_cell_key`, which is a lie and a filter no axis justifies. A
+    foreign-scheme token IS key-shaped; it simply names no artifact this
+    runtime computes, and `mismatch` says so on the axes.
     """
     key = ck.from_axes(_AXES).digest
-    assert key.startswith("ck6-")
-    for dead in ("ck2-", "ck3-", "ck4-", "ck5-"):
+    assert key.startswith("ck1-")
+    for dead in ("ck2-", "ck3-", "ck4-", "ck5-", "ck6-"):
         token = dead + "a" * 56
-        assert ck.is_key(token), "an old-scheme token is still key-SHAPED"
+        assert ck.is_key(token), "a foreign-scheme token is still key-SHAPED"
         assert token != key
         # No artifact metadata => no computable key => a named miss, never ''.
         assert ck.mismatch({}, token) != ""
     assert not ck.is_key("ck-" + "a" * 56)      # no scheme digits
-    assert not ck.is_key("ck6-" + "a" * 55)     # wrong digest width
-    assert not ck.is_key("ck6-" + "A" * 56)     # uppercase hex
+    assert not ck.is_key("ck1-" + "a" * 55)     # wrong digest width
+    assert not ck.is_key("ck1-" + "A" * 56)     # uppercase hex
 
 
 def test_compute_matches_artifact_metadata_stamp(fixed_runtime):
@@ -199,7 +201,7 @@ def test_contract_axis_fences_newer_contract(fixed_runtime):
     reason = ck.mismatch(meta_b, want_a)
     assert reason.startswith("contract:")  # the named-axis refusal
 
-    # Pre-ck2 cells record no shape_contract: deliberately NO ck2 identity —
+    # Cells recording no shape_contract have deliberately NO identity —
     # never a stamped key, never a self-requested match.
     legacy = cc.artifact_metadata(
         family="ltx-2.3", shapes=((768, 768),), targets=("transformer",))

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -37,7 +37,7 @@ from gen_worker.convert.hub import HubPublishError
 from gen_worker.models import chunk_upload as cu
 from gen_worker.procsplit import actions
 
-CELL_KEY = "ck5-" + "b" * 56
+CELL_KEY = "ck1-" + "b" * 56
 FAMILY = "sdxl"
 
 # Small enough to keep the test in kilobytes, large enough that the artifact

--- a/tests/test_declaration_cannot_break_serving_pgw853.py
+++ b/tests/test_declaration_cannot_break_serving_pgw853.py
@@ -256,7 +256,7 @@ def _miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     monkeypatch.setattr(fleet_cells, "_PENDING", {})
     monkeypatch.setattr(
         fleet_cells.cell_key, "compute",
-        lambda *a, **k: type("_K", (), {"digest": "ck5-" + "a" * 56})())
+        lambda *a, **k: type("_K", (), {"digest": "ck1-" + "a" * 56})())
     monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda p: False)
     monkeypatch.setattr(
         fleet_cells.cc, "begin_fleet_mint", lambda p, c, capture: None)

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -1,4 +1,4 @@
-"""pgw#694 determinism hardening: posture seal (#695), env seal + ck4
+"""pgw#694 determinism hardening: posture seal (#695), env seal
 (#696), composition fingerprint (#697), cubin gate (#698).
 
 Red-verified against real torch state and real file trees — no mocks of
@@ -125,7 +125,8 @@ def test_mint_manifest_carries_the_posture_seal() -> None:
 
     manifest = gc.closure_manifest(pipe, _cfg(), label="toyfam")
     assert manifest[gc.POSTURE_KEY] == gc.CANONICAL_POSTURE
-    assert gc.MANIFEST_VERSION == 3 and manifest["v"] == 3
+    # pgw#958 §1.27(g): one live manifest version, and it is 1.
+    assert gc.MANIFEST_VERSION == 1 and manifest["v"] == 1
 
     # A mint attempted in a non-canonical posture fails red, named.
     with torch.no_grad():
@@ -181,7 +182,7 @@ def test_consolidate_flags_posture_divergence() -> None:
 
 
 # ---------------------------------------------------------------------------
-# #696: env seal + ck4
+# #696: env seal joins the key
 # ---------------------------------------------------------------------------
 
 
@@ -218,7 +219,7 @@ def test_establish_config_imposes_the_serving_posture() -> None:
 
 def test_seal_digest_tracks_config_flags() -> None:
     """Flipping one sealed flag changes the seal digest — and therefore the
-    ck4 key (red pre-fix: no env_seal axis, keys blind to config)."""
+    key (red pre-fix: no env_seal axis, keys blind to config)."""
     baseline = _env_seal().seal_digest(_env_seal().effective_seal())
     before = torch.backends.cudnn.benchmark
     try:
@@ -229,7 +230,7 @@ def test_seal_digest_tracks_config_flags() -> None:
     assert _env_seal().seal_digest(_env_seal().effective_seal()) == baseline
 
 
-def test_ck5_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:
+def test_ck1_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:
     monkeypatch.setattr(cc, "runtime_key", lambda: {
         "sku": "l4", "sm": "sm_89", "cuda": "13.0", "cuda_driver": "13000",
         "torch": "2.13.0+cu130", "triton": "3.7.1", "image_digest": "",
@@ -240,8 +241,8 @@ def test_ck5_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:
 
     facts = cc.declared_contract_facts(_cfg())
     want = ck.compute("toyfam", contract=ck.contract_digest(facts))
-    assert want.digest.startswith("ck6-")
-    # pgw#990: an older scheme is key-SHAPED and simply names nothing this
+    assert want.digest.startswith("ck1-")
+    # pgw#990: a foreign scheme is key-SHAPED and simply names nothing this
     # runtime computes — refused on axes, not on its label.
     assert ck.is_key("ck3-" + "a" * 56)
     assert want.digest != "ck3-" + "a" * 56
@@ -263,14 +264,14 @@ def test_ck5_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:
     assert ck.from_artifact_metadata(drifted).digest != want.digest
     assert ck.mismatch(drifted, want).startswith("env_seal:")
 
-    # No env_seal block = pre-ck4 cell = no identity.
+    # No env_seal block = no sealed environment = no identity.
     unsealed = {k: v for k, v in meta.items() if k != _env_seal().SEAL_KEY}
     with pytest.raises(ck.CellKeyError, match="env_seal"):
         ck.from_artifact_metadata(unsealed)
 
 
 def test_verify_no_longer_pins_sku(monkeypatch: Any) -> None:
-    """ck3 completion (pgw#691): sku left the identity axes, but verify()
+    """pgw#691: sku left the identity axes, but verify()
     still hard-required it — a same-sm cell minted on a different SKU
     refused to arm, structurally undoing the collapse."""
     monkeypatch.setattr(cc, "runtime_key", lambda: {

--- a/tests/test_eager_first_boot_pgw671.py
+++ b/tests/test_eager_first_boot_pgw671.py
@@ -183,8 +183,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'a' * 56}",
+            family=FAMILY, cell_key="ck1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1191,7 +1191,7 @@ def test_self_mint_boot_serves_compiled_after_own_warmup_proof(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck5-" + "d" * 56
+    mint_key = "ck1-" + "d" * 56
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
@@ -1269,7 +1269,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
     model_dir.mkdir()
     spec = _cold_spec(Hub("acme/klein-finetune", flavor="fp8-w8a8"))
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck5-" + "a1" * 28
+    mint_key = "ck1-" + "a1" * 28
     mint_ref = f"root/family-{FAMILY}#{mint_key}"
     mint_digest = "blake3:" + "e" * 64
     store_digest = "blake3:" + "f" * 64  # the store's snapshot-manifest form
@@ -1336,7 +1336,7 @@ def test_hub_redelivery_of_own_minted_key_is_a_noop_rearm(
         "advertised digest must align to the store's form")
 
     # A genuinely DIFFERENT key still vacates (identity actually moved).
-    other_key = "ck5-" + "b2" * 28
+    other_key = "ck1-" + "b2" * 28
     other_ref = f"root/family-{FAMILY}#{other_key}"
 
     class _OtherKey:
@@ -1381,7 +1381,7 @@ def test_self_mint_boot_without_warmup_proof_never_reaches_serving(
         compile=Compile(shapes=((768, 768),), family=FAMILY, text_len=0),
     )
     model_ref = wire_ref(spec.models["pipeline"])
-    mint_key = "ck5-" + "f" * 56
+    mint_key = "ck1-" + "f" * 56
     mint_artifact = tmp_path / "selfmint" / "cell.tar.gz"
     mint_artifact.parent.mkdir()
     mint_artifact.write_bytes(b"cell-bytes")
@@ -1452,7 +1452,7 @@ def _pending_mint_rig(tmp_path, monkeypatch, *, pipe, publisher):
     monkeypatch.setattr(cc, "toolchain_present", lambda: True)
 
     class _Key:
-        digest = "ck5-" + "9" * 56
+        digest = "ck1-" + "9" * 56
 
     monkeypatch.setattr(cell_key_mod, "compute", lambda *a, **k: _Key())
     captured: dict = {}
@@ -3826,7 +3826,7 @@ def test_fresh_boot_advertises_candidate_cell_lookups(monkeypatch):
     computed: list = []
 
     class _Key:
-        digest = "ck5-" + "5" * 56
+        digest = "ck1-" + "5" * 56
 
     def _compute(family, execution_lane="", bucket=0, **kw):
         computed.append((family, execution_lane))

--- a/tests/test_exported_proof_pgw735.py
+++ b/tests/test_exported_proof_pgw735.py
@@ -50,15 +50,15 @@ def test_proven_since_requires_new_successful_calls_and_no_revocation():
 
 def test_exported_kind_cell_key_refusals_are_named():
     """cell_key.from_artifact_metadata recomputes INDUCTOR-cache axes. An
-    exported cell rides the same ck5 key space but its key is STAMPED at mint,
+    exported cell rides the same key space but its key is STAMPED at mint,
     so the refusal must say so by name instead of failing opaquely."""
     with pytest.raises(cell_key.CellKeyError) as exc:
         cell_key.from_artifact_metadata(
-            {"kind": "aot-inductor", "cell_key": "ck5-" + "a" * 56})
+            {"kind": "aot-inductor", "cell_key": "ck1-" + "a" * 56})
     message = str(exc.value)
     assert "aot-inductor" in message
     assert "cell_key" in message and "STAMPED" in message
-    assert "ck5-" + "a" * 56 in message
+    assert "ck1-" + "a" * 56 in message
 
     with pytest.raises(cell_key.CellKeyError) as missing:
         cell_key.from_artifact_metadata({"kind": "aot-inductor"})

--- a/tests/test_guard_miss_pgw680.py
+++ b/tests/test_guard_miss_pgw680.py
@@ -449,7 +449,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck5-" + digest, axes={})
+    return SimpleNamespace(digest="ck1-" + digest, axes={})
 
 
 SHAPE = (768, 768)

--- a/tests/test_lane_determinism_pgw772.py
+++ b/tests/test_lane_determinism_pgw772.py
@@ -2,7 +2,7 @@
 
 The gw#534 voluntary bf16-resident upgrade probed LIVE free VRAM
 (`bf16_resident_fits` / BF16_RESIDENT_MARGIN_GB) and made `lane` — the only
-GPU-dependent axis of the ten in the ck5 cell key — a function of the
+GPU-dependent axis of the ten in the cell key — a function of the
 individual card's headroom: an RTX 4090's ~1.5 GiB surplus over an L4 (same
 release, same image, both sm_89) flipped its base lane to "", a lane nothing
 mints for, so the better card missed all 144 published checkpoints INCLUDING

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -241,7 +241,7 @@ def test_the_parent_hands_its_resolved_overrides_across_the_wire(
     child. Round-tripped through the real msgspec encode/decode, because the
     boundary IS a file."""
     pending = SimpleNamespace(
-        family="sdxl", cell_key="ck5-abc",
+        family="sdxl", cell_key="ck1-abc",
         cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
                         family="sdxl", regional=False, text_len=77,
                         dynamic=(), lora_bucket=0, guidance_scales=(),
@@ -305,7 +305,7 @@ def test_a_narrowed_tree_with_no_override_refuses_by_name(
     # no discovery, no toolchain probe and no weights read.
     request = mp.MintRequest(
         function="composed-echo", modules=("harness.toy_endpoints",),
-        family="sdxl", cell_key="ck5-abc",
+        family="sdxl", cell_key="ck1-abc",
         target=str(tmp_path / "cell.tar.gz"),
         capture=str(tmp_path / "capture"),
         report=str(tmp_path / mp.REPORT_NAME),
@@ -422,7 +422,7 @@ def _fake_card(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _task(tmp_path: Path) -> mint_delegate.MintTask:
     pending = fleet_cells.PendingSelfMint(
-        family="sdxl", cell_key="ck5-abc", ref="root/family-sdxl#ck5-abc",
+        family="sdxl", cell_key="ck1-abc", ref="root/family-sdxl#ck1-abc",
         cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
                         family="sdxl", regional=False, text_len=77,
                         dynamic=(), lora_bucket=0, guidance_scales=(),

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -137,7 +137,7 @@ def _request(
     the slot is ABSENT, which is the only shape a wiring gap can still take.
     """
     pending = SimpleNamespace(
-        family="pgw969", cell_key="ck5-catalog", recipe="dynamo",
+        family="pgw969", cell_key="ck1-catalog", recipe="dynamo",
         cfg=CompileCell(shapes=((1024, 1024),), targets=("unet",),
                         family="pgw969", regional=False, text_len=77,
                         dynamic=(), lora_bucket=0, guidance_scales=(),
@@ -297,7 +297,7 @@ def test_an_unbound_required_slot_refuses_by_name_before_the_load(
     with pytest.raises(mint_child.MintChildRefused) as exc:
         _child_specs(request)
     text = str(exc.value)
-    for fact in ("pgw969", "ck5-catalog", "w8a8-lora64", "catalog-generate",
+    for fact in ("pgw969", "ck1-catalog", "w8a8-lora64", "catalog-generate",
                  "'pipeline'", "sent no resolved binding"):
         assert fact in text, f"{fact!r} missing from: {text}"
 
@@ -328,7 +328,7 @@ def test_the_refusal_is_the_childs_terminal_word_on_a_real_subprocess(
     assert outcome.exit_code == mp.EXIT_REFUSED
     report = outcome.report
     assert report is not None and report.status == "refused"
-    for fact in ("pgw969", "ck5-catalog", "'pipeline'", "catalog-generate"):
+    for fact in ("pgw969", "ck1-catalog", "'pipeline'", "catalog-generate"):
         assert fact in report.detail, f"{fact!r} missing from: {report.detail}"
     # The refusal precedes every side effect the CHILD could have: it wrote no
     # artifact, and it never reached the toolchain probe or a weight.

--- a/tests/test_mint_credential_expiry_th1423.py
+++ b/tests/test_mint_credential_expiry_th1423.py
@@ -37,7 +37,7 @@ from gen_worker import fleet_cells as fc
 from gen_worker.convert.hub import HubPublishError
 
 LAPSE_S = 150  # how far past `exp` the presented credential is, in the JWT
-CELL_KEY = "ck5-" + "e" * 56
+CELL_KEY = "ck1-" + "e" * 56
 FAMILY = "sdxl"
 
 META = {

--- a/tests/test_mint_delegate_pgw784.py
+++ b/tests/test_mint_delegate_pgw784.py
@@ -108,7 +108,7 @@ def test_the_delegated_arm_never_touches_the_live_pipeline(
     # is not what this test is about.
     monkeypatch.setattr(
         fleet_cells.cell_key, "compute",
-        lambda *a, **k: SimpleNamespace(digest="ck5-test"))
+        lambda *a, **k: SimpleNamespace(digest="ck1-test"))
 
     prior = dict(os.environ)
     outcome = fleet_cells.enable_compiled(
@@ -152,7 +152,7 @@ def test_the_request_carries_the_execution_lane_and_the_effective_config(
     a child warming at different config traces different graphs and the
     parent's own proof then misses."""
     pending = SimpleNamespace(
-        family="sdxl", cell_key="ck5-abc", cfg=_cfg(),
+        family="sdxl", cell_key="ck1-abc", cfg=_cfg(),
         capture_dir=tmp_path / "capture", target=tmp_path / "cell.tar.gz",
         mint_root=tmp_path)
     task = mint_delegate.MintTask(
@@ -174,8 +174,8 @@ def test_the_request_carries_the_execution_lane_and_the_effective_config(
 
 def _task(tmp_path: Path, **over: Any) -> mint_delegate.MintTask:
     pending = fleet_cells.PendingSelfMint(
-        family="sdxl", cell_key="ck5-abc",
-        ref="root/family-sdxl#ck5-abc", cfg=_cfg(),
+        family="sdxl", cell_key="ck1-abc",
+        ref="root/family-sdxl#ck1-abc", cfg=_cfg(),
         target=tmp_path / "cell.tar.gz", capture_dir=tmp_path / "capture",
         mint_root=tmp_path / "root", publisher=None, cache_dir=tmp_path,
         delegated=True)
@@ -221,7 +221,7 @@ def test_a_minted_child_is_adopted_through_the_delivered_cell_path(
     def _adopt(pipe: Any, pending: Any, artifact: Path) -> Any:
         adopted.append(Path(artifact))
         return fleet_cells.SelfMint(
-            family="sdxl", cell_key="ck5-abc", ref="r#k",
+            family="sdxl", cell_key="ck1-abc", ref="r#k",
             snapshot_digest="blake3:x", artifact=Path(artifact))
 
     monkeypatch.setattr(fleet_cells, "adopt_delegated_mint", _adopt)

--- a/tests/test_mint_gate_pgw677.py
+++ b/tests/test_mint_gate_pgw677.py
@@ -205,8 +205,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'a' * 56}",
+            family=FAMILY, cell_key="ck1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_mint_process_pgw784.py
+++ b/tests/test_mint_process_pgw784.py
@@ -45,7 +45,7 @@ def _request(tmp_path: Path, **over: Any) -> mp.MintRequest:
         function="gen",
         modules=("harness.toy_endpoints",),
         family="sdxl",
-        cell_key="ck5-deadbeef",
+        cell_key="ck1-deadbeef",
         target=str(tmp_path / "cell.tar.gz"),
         capture=str(tmp_path / "capture"),
         report=str(tmp_path / mp.REPORT_NAME),
@@ -129,7 +129,7 @@ def test_a_minted_cell_comes_back_as_a_path_and_a_digest(tmp_path: Path) -> None
     assert out.artifact == tmp_path / "cell.tar.gz"
     assert out.artifact.read_bytes() == b"stub-cell-bytes"
     assert out.report is not None and out.report.digest == "blake3:stub"
-    assert out.report.cell_key == "ck5-deadbeef"
+    assert out.report.cell_key == "ck1-deadbeef"
     assert not out.retryable
     assert "status=minted" in out.line()
 

--- a/tests/test_mint_reopen_pgw677.py
+++ b/tests/test_mint_reopen_pgw677.py
@@ -212,8 +212,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'a' * 56}",
+            family=FAMILY, cell_key="ck1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,
@@ -547,8 +547,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root = tmp_path / "m"
         (mint_root / "capture").mkdir(parents=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "b" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'b' * 56}",
+            family=FAMILY, cell_key="ck1-" + "b" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'b' * 56}",
             cfg=None, target=mint_root / "cell.tar.gz",
             capture_dir=mint_root / "capture", mint_root=mint_root,
             publisher=None, cache_dir=None,
@@ -568,8 +568,8 @@ def test_withhold_and_no_sink_reach_the_wire(tmp_path: Path) -> None:
         mint_root2 = tmp_path / "m2"
         (mint_root2 / "capture").mkdir(parents=True)
         pending2 = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "c" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'c' * 56}",
+            family=FAMILY, cell_key="ck1-" + "c" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'c' * 56}",
             cfg=None, target=mint_root2 / "cell.tar.gz",
             capture_dir=mint_root2 / "capture", mint_root=mint_root2,
             publisher=None, cache_dir=None,

--- a/tests/test_mint_resume_pgw848.py
+++ b/tests/test_mint_resume_pgw848.py
@@ -463,7 +463,7 @@ def test_the_bank_outlives_an_abandoned_mint(
     monkeypatch.setenv(local_cells.ENV_STORE_DIR, str(tmp_path / "store"))
     mint_root = tmp_path / "selfmint-abc"
     (mint_root / "capture").mkdir(parents=True)
-    key = "ck5:sdxl:deadbeef"
+    key = "ck1:sdxl:deadbeef"
 
     # 1. The request the parent actually builds points OUTSIDE the mint tree.
     request = mint_delegate.build_request(

--- a/tests/test_mint_vram_budget_pgw737.py
+++ b/tests/test_mint_vram_budget_pgw737.py
@@ -225,8 +225,8 @@ class _Harness:
         capture = mint_root / "capture"
         (capture / "inductor" / "fxgraph").mkdir(parents=True, exist_ok=True)
         pending = fleet_cells.PendingSelfMint(
-            family=FAMILY, cell_key="ck5-" + "a" * 56,
-            ref=f"{cc.system_repo(FAMILY)}#ck5-{'a' * 56}",
+            family=FAMILY, cell_key="ck1-" + "a" * 56,
+            ref=f"{cc.system_repo(FAMILY)}#ck1-{'a' * 56}",
             cfg=cfg, target=mint_root / "cell.tar.gz",
             capture_dir=capture, mint_root=mint_root,
             publisher=None, cache_dir=cache_dir,

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -83,7 +83,7 @@ def _stub_child(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _pending(tmp_path: Path, *, delegated: bool = True) -> Any:
     return fleet_cells.PendingSelfMint(
-        family="sdxl", cell_key="ck5-abc", ref="root/family-sdxl#ck5-abc",
+        family="sdxl", cell_key="ck1-abc", ref="root/family-sdxl#ck1-abc",
         cfg=_cfg(), target=tmp_path / "cell.tar.gz",
         capture_dir=tmp_path / "capture", mint_root=tmp_path / "root",
         publisher=None, cache_dir=tmp_path, delegated=delegated)
@@ -126,7 +126,7 @@ def test_the_arm_returns_armed_false_with_a_delegated_pending(
         fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "fp8")
     monkeypatch.setattr(
         fleet_cells.cell_key, "compute",
-        lambda *a, **k: SimpleNamespace(digest="ck5-wired"))
+        lambda *a, **k: SimpleNamespace(digest="ck1-wired"))
     monkeypatch.delenv(mint_delegate.ENV_IN_PROCESS, raising=False)
 
     outcome = fleet_cells.enable_compiled(_Pipe(), _cfg(), tmp_path)
@@ -244,8 +244,8 @@ def test_the_delegated_route_mints_in_a_child_adopts_and_advertises(
     def _adopt(pipe: Any, pending: Any, artifact: Path) -> Any:
         adopted.append(Path(artifact))
         return fleet_cells.SelfMint(
-            family="sdxl", cell_key="ck5-abc",
-            ref="root/family-sdxl#ck5-abc", snapshot_digest="blake3:aa",
+            family="sdxl", cell_key="ck1-abc",
+            ref="root/family-sdxl#ck1-abc", snapshot_digest="blake3:aa",
             artifact=Path(artifact))
 
     monkeypatch.setattr(fleet_cells, "adopt_delegated_mint", _adopt)
@@ -269,7 +269,7 @@ def test_the_delegated_route_mints_in_a_child_adopts_and_advertises(
     # Phase 4, shared with the in-process route: the target now advertises the
     # worker's OWN key (th#910's self-attested fence).
     target = rec.compile_targets["t0"]
-    assert target.active_compile_ref == "root/family-sdxl#ck5-abc"
+    assert target.active_compile_ref == "root/family-sdxl#ck1-abc"
     assert target.active_compile_snapshot_digest == "blake3:aa"
     assert target.active_self_mint is True
     assert "finalize" in act.phases

--- a/tests/test_partial_shape_coverage_pgw844.py
+++ b/tests/test_partial_shape_coverage_pgw844.py
@@ -324,7 +324,7 @@ def _boot(
             (kind, phase, detail)))
     if exported:
         # The exported lane is identified by the ref the hub delivers; a
-        # stamped ck5 key is only computable on CUDA, so this process is TOLD
+        # stamped cell key is only computable on CUDA, so this process is TOLD
         # the flavor is an AOT cell exactly as `aot_cells.discover` tells a
         # pod. Everything downstream of that classification is production code.
         aot_serve.note_aot_key(FLAVOR)

--- a/tests/test_procsplit_security_pgw763.py
+++ b/tests/test_procsplit_security_pgw763.py
@@ -717,7 +717,7 @@ def test_action_table_admits_exactly_the_named_actions():
         {"method": "GET", "path": "/api/v1/repos/root/system-sdxl/checkpoints",
          "query": {"limit": "50"}},
         {"method": "GET", "path": "/api/v1/repos/root/system-sdxl/resolve",
-         "query": {"digest": "ck5-abc"}},
+         "query": {"digest": "ck1-abc"}},
     ):
         actions.authorize(req)
 

--- a/tests/test_publish_durability_pgw848_th1359.py
+++ b/tests/test_publish_durability_pgw848_th1359.py
@@ -34,9 +34,9 @@ def _reset() -> None:
 def test_a_new_key_starting_its_upload_is_durable_progress() -> None:
     _reset()
     before = fleet_cells.publish_durable_progress()
-    fleet_cells._note_durable("ck5-a", "started")
+    fleet_cells._note_durable("ck1-a", "started")
     assert fleet_cells.publish_durable_progress() == before + 1
-    fleet_cells._note_durable("ck5-a", "published")
+    fleet_cells._note_durable("ck1-a", "published")
     assert fleet_cells.publish_durable_progress() == before + 2
 
 
@@ -45,10 +45,10 @@ def test_a_retry_of_the_SAME_key_is_not_progress() -> None:
     never advance the counter, or the activity never goes stale and the pod is
     never reaped."""
     _reset()
-    fleet_cells._note_durable("ck5-a", "started")
+    fleet_cells._note_durable("ck1-a", "started")
     baseline = fleet_cells.publish_durable_progress()
     for _ in range(50):  # fifty failed attempts at the same key
-        fleet_cells._note_durable("ck5-a", "started")
+        fleet_cells._note_durable("ck1-a", "started")
     assert fleet_cells.publish_durable_progress() == baseline, (
         "a failing publish retry loop advanced durable progress — the activity "
         "would read as progressing forever on a paid card"
@@ -57,10 +57,10 @@ def test_a_retry_of_the_SAME_key_is_not_progress() -> None:
 
 def test_failure_is_not_durable_progress() -> None:
     _reset()
-    fleet_cells._note_durable("ck5-a", "started")
+    fleet_cells._note_durable("ck1-a", "started")
     baseline = fleet_cells.publish_durable_progress()
     with fleet_cells._IN_FLIGHT_LOCK:
-        fleet_cells._REFUSED["ck5-a"] = "cell_publish_untrusted_compute"
+        fleet_cells._REFUSED["ck1-a"] = "cell_publish_untrusted_compute"
     assert fleet_cells.publish_durable_progress() == baseline
 
 
@@ -78,7 +78,7 @@ def test_the_wait_beats_the_activity_ONLY_on_durable_movement(monkeypatch) -> No
     def _in_flight():
         ticks["n"] += 1
         if ticks["n"] <= 6:
-            return {"ck5-a": ("sdxl", 0.0)}
+            return {"ck1-a": ("sdxl", 0.0)}
         return {}
 
     monkeypatch.setattr(fleet_cells, "publishes_in_flight", _in_flight)
@@ -106,7 +106,7 @@ def test_a_stuck_publish_never_beats_the_activity(monkeypatch) -> None:
 
     def _in_flight():
         polls["n"] += 1
-        return {} if polls["n"] > 20 else {"ck5-a": ("sdxl", 0.0)}
+        return {} if polls["n"] > 20 else {"ck1-a": ("sdxl", 0.0)}
 
     monkeypatch.setattr(fleet_cells, "publishes_in_flight", _in_flight)
     monkeypatch.setattr(fleet_cells, "publish_durable_progress", lambda: 7)

--- a/tests/test_receipts_pgw709.py
+++ b/tests/test_receipts_pgw709.py
@@ -27,7 +27,7 @@ from gen_worker import receipts
 
 KID = "test-kid-1"
 FAMILY = "sdxl"
-CELL_KEY = "ck5-0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+CELL_KEY = "ck1-0123456789abcdef0123456789abcdef0123456789abcdef01234567"
 SNAPSHOT = "snapdigest-abc123"
 B3_HEX = "ab12cd34" * 8
 SHA_HEX = "12ab34cd" * 8
@@ -136,7 +136,7 @@ class TestVerifyReceiptJWS:
         # poisoning move receipts exist to prevent.
         jws = sign_receipt(rsa_key, make_claims("sha256:" + SHA_HEX, 4096))
         head, _, sig = jws.split(".")
-        forged_claims = make_claims("sha256:" + SHA_HEX, 4096, cell_key="ck5-" + "f" * 56)
+        forged_claims = make_claims("sha256:" + SHA_HEX, 4096, cell_key="ck1-" + "f" * 56)
         forged = head + "." + _b64url(json.dumps(forged_claims).encode()) + "." + sig
         with pytest.raises(receipts.ReceiptError) as exc:
             receipts.verify_receipt_jws(forged, pub_map)
@@ -313,7 +313,7 @@ class TestGateDeliveredArtifact:
         # Nix Deriver lesson — key binding must be inside the signature.
         artifact = make_artifact(tmp_path)
         ref = "sha256:" + receipts.artifact_digests(artifact)["sha256"]
-        claims = make_claims(ref, artifact.stat().st_size, cell_key="ck5-" + "e" * 56)
+        claims = make_claims(ref, artifact.stat().st_size, cell_key="ck1-" + "e" * 56)
         hub.receipts[(ref, CELL_KEY)] = sign_receipt(hub.key, claims)
         _configure(hub)
         assert receipts.gate_delivered_artifact(artifact, FAMILY) is False
@@ -335,7 +335,7 @@ class TestGateDeliveredArtifact:
     def test_other_revocation_does_not_block(self, tmp_path: Path, hub: HubStub) -> None:
         artifact = make_artifact(tmp_path)
         hub.serve_receipt_for(artifact)
-        hub.revoked.append({"cell_key": "ck5-" + "d" * 56, "snapshot_digest": "other", "reason": "x"})
+        hub.revoked.append({"cell_key": "ck1-" + "d" * 56, "snapshot_digest": "other", "reason": "x"})
         _configure(hub)
         assert receipts.gate_delivered_artifact(artifact, FAMILY) is True
 

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -1,4 +1,4 @@
-"""ck5 recipe identity (Paul's exact-identity ruling) + kept trust pieces.
+"""Recipe identity (Paul's exact-identity ruling) + kept trust pieces.
 
 The key IS the recipe: family + contract + sm + lane/mode + env_seal +
 toolchain CONTENT + static code-closure CONTENT. No version axes, no
@@ -117,15 +117,15 @@ def test_completeness_diagnostic_names_dynamic_imports() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ck5: the recipe digest
+# ck1: the recipe digest
 # ---------------------------------------------------------------------------
 
 
-def test_ck5_axes_are_the_recipe(pinned_runtime: None,
+def test_ck1_axes_are_the_recipe(pinned_runtime: None,
                                  monkeypatch: pytest.MonkeyPatch) -> None:
     facts = cc.declared_contract_facts(_cfg())
     key = ck.compute(FAMILY, contract=ck.contract_digest(facts))
-    assert key.digest.startswith("ck6-")
+    assert key.digest.startswith("ck1-")
     axes = key.axes_dict()
     assert set(axes) == {"format", "kind", "family", "sm", "contract",
                          "env_seal", "toolchain"}
@@ -135,10 +135,10 @@ def test_ck5_axes_are_the_recipe(pinned_runtime: None,
     monkeypatch.setenv("WORKER_IMAGE_DIGEST", "sha256:other")
     assert ck.compute(
         FAMILY, contract=ck.contract_digest(facts)).digest == key.digest
-    # Older schemes can never collide with a current key; they stay
+    # Foreign schemes can never collide with a current key; they stay
     # key-SHAPED (pgw#990 — is_key mirrors tensorhub's scheme-agnostic
     # IsCellKey) and are ruled on by axes, not by their label.
-    for dead in ("ck2-", "ck3-", "ck4-", "ck5-"):
+    for dead in ("ck2-", "ck3-", "ck4-", "ck5-", "ck6-"):
         assert ck.is_key(dead + "a" * 56)
         assert key.digest != dead + "a" * 56
     # Version-string axes are rejected outright.
@@ -225,7 +225,7 @@ def test_marked_cell_never_republishes(monkeypatch: pytest.MonkeyPatch,
     artifact.write_bytes(b"bytes")
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "jwt", image_digest="")
-    meta = {"cell_key": "ck5-" + "a" * 56, fc.ADOPTION_MARK: ["foreign"]}
+    meta = {"cell_key": "ck1-" + "a" * 56, fc.ADOPTION_MARK: ["foreign"]}
     with pytest.raises(fc.CellPublishRefused, match="pgw#712"):
         pub.publish(FAMILY, artifact, meta)
 
@@ -234,7 +234,7 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     posts: list = []
-    key = "ck5-" + "c" * 56
+    key = "ck1-" + "c" * 56
 
     class _FakeResp:
         def __init__(self, code: int, body: Dict[str, Any]) -> None:

--- a/tests/test_serve_finalize_pgw672.py
+++ b/tests/test_serve_finalize_pgw672.py
@@ -185,7 +185,7 @@ def _fake_key_compute(family: str, weight_lane: str = "", lora_bucket: int = 0,
     digest = hashlib.blake2s(
         f"{family}|{weight_lane}|{lora_bucket}|{contract}|{regional}".encode()
     ).hexdigest()[:56]
-    return SimpleNamespace(digest="ck5-" + digest, axes={})
+    return SimpleNamespace(digest="ck1-" + digest, axes={})
 
 
 def _endpoint_cls(shapes: tuple) -> type:
@@ -329,7 +329,7 @@ def test_second_same_family_arm_mints_its_own_graphs_and_finalizes(
     }
     assert len(refs) == 2, "two distinct cells, each proven by its own boot"
     for ref in refs:
-        assert ref.startswith(f"root/family-{FAMILY}#ck5-")
+        assert ref.startswith(f"root/family-{FAMILY}#ck1-")
         assert cc.cell_proven_in_process(ref)
     with fleet_cells._PENDING_LOCK:
         assert fleet_cells._PENDING == {}

--- a/tests/test_shape_growth_pgw916.py
+++ b/tests/test_shape_growth_pgw916.py
@@ -97,7 +97,7 @@ def test_an_aot_shape_gap_is_a_countable_typed_fact(events):
         arm=shape_growth.ARM_AOT, family="sdxl", target="unet",
         declared_class="unet/sample=bfloat16[2,4,112,144]",
         reason=shape_growth.REASON_UNCOVERED,
-        cell_key="ck5-0d945144")
+        cell_key="ck1-0d945144")
     assert shape_growth.report(gap) is True
     kinds = [(k, p) for k, p, _d in events]
     assert (activity_mod.KIND_SHAPE_GAP, "no_entry_admits") in kinds

--- a/tests/test_shared_lane_precision_th1043.py
+++ b/tests/test_shared_lane_precision_th1043.py
@@ -58,7 +58,7 @@ def test_no_shared_components_never_forces():
 # th#1043 second layer (found live, pod 4xh4m999n26u5f): the gw#534
 # bf16-resident upcast made a SINGLE-lane fit call against current free VRAM
 # and silently un-forced the group's fp8 decision. pgw#772 removed that
-# voluntary upcast entirely (it also forked the ck5 `lane` axis per-card);
+# voluntary upcast entirely (it also forked the `lane` axis per-card);
 # both the unforced and the forced load now stay on the fp8 storage lane.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sku_relaxation_pgw765.py
+++ b/tests/test_sku_relaxation_pgw765.py
@@ -58,7 +58,7 @@ def on_4090(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _key(seed: str) -> str:
-    return "ck5-" + (seed * 56)[:56]
+    return "ck1-" + (seed * 56)[:56]
 
 
 def _meta(key: str, **over: Any) -> Dict[str, Any]:

--- a/tests/test_worker_goals_pgw930.py
+++ b/tests/test_worker_goals_pgw930.py
@@ -235,7 +235,7 @@ def test_serving_worker_never_runs_the_driver(
 def test_published_cell_is_a_typed_terminal_then_retire(
         monkeypatch: pytest.MonkeyPatch, events: List[Tuple[str, str, str]]) -> None:
     _declare(monkeypatch, "forge")
-    _ledger(monkeypatch, {"ck5-abc": "sha256:deadbeef"}, {})
+    _ledger(monkeypatch, {"ck1-abc": "sha256:deadbeef"}, {})
     lc = _FakeLifecycle()
     _run(lc)
     kinds = [(k, p) for k, _, p in events]
@@ -248,7 +248,7 @@ def test_refused_publish_is_distinguished_from_no_cell(
     """"minted but the hub said no" and "never produced a cell" are different
     operational facts and must not share a terminal."""
     _declare(monkeypatch, "forge")
-    _ledger(monkeypatch, {}, {"ck5-abc": "cell_publish_untrusted_compute"})
+    _ledger(monkeypatch, {}, {"ck1-abc": "cell_publish_untrusted_compute"})
     lc = _FakeLifecycle()
     _run(lc)
     assert (mint_goal.KIND_MINT_GOAL, mint_goal.TERMINAL_REFUSED) in [
@@ -289,11 +289,11 @@ def test_driver_waits_for_the_publish_to_land(
     def _in_flight() -> Dict[str, Any]:
         if state["n"] > 0:
             state["n"] -= 1
-            return {"ck5-abc": ("sdxl", 0.0)}
+            return {"ck1-abc": ("sdxl", 0.0)}
         return {}
 
     monkeypatch.setattr(fleet_cells, "publishes_in_flight", _in_flight)
-    monkeypatch.setattr(fleet_cells, "published_cells", lambda: {"ck5-abc": "cp"})
+    monkeypatch.setattr(fleet_cells, "published_cells", lambda: {"ck1-abc": "cp"})
     monkeypatch.setattr(fleet_cells, "refused_publishes", lambda: {})
     lc = _FakeLifecycle()
     _run(lc)
@@ -334,7 +334,7 @@ def test_dual_goal_pod_states_its_terminal_but_does_NOT_retire(
     moment its mint finished.
     """
     _goals(serve=True, mint=True, declared="serve")
-    _ledger(monkeypatch, {"ck5-abc": "sha256:deadbeef"}, {})
+    _ledger(monkeypatch, {"ck1-abc": "sha256:deadbeef"}, {})
     lc = _FakeLifecycle()
     _run(lc)
     assert (mint_goal.KIND_MINT_GOAL, mint_goal.TERMINAL_PUBLISHED) in [

--- a/tests/test_worker_outbox_pgw869.py
+++ b/tests/test_worker_outbox_pgw869.py
@@ -153,7 +153,7 @@ def test_hub_killed_midactivity_replays_every_fact_exactly_once() -> None:
         during = [
             ("trace_graph", "26 evidence @ 0.99/s"),
             ("autotune", "per_entry_device_bytes=11881591040 basis=measured"),
-            ("publish", "cell ck5-aeed10f6 published"),
+            ("publish", "cell ck1-aeed10f6 published"),
         ]
         for phase, detail in during:
             activity_mod.emit_event(kind, detail, phase=phase)


### PR DESCRIPTION
**Rebased onto `master` and rewritten for Paul's 2026-08-07 ruling.** This PR was held by pgw#958's own step-3 sequencing; that hold is now released (see *Purge* below).

## The ruling this executes

> *"The ck6 is wrong and can be removed / deleted just fine. The v1 is the correct one."* — Paul, 2026-08-07

PR #512 landed `ck5` → `ck6` on master (`88ee1709`) while this branch was blocked. That bump is **reverted, not carried forward**, and the cells it keyed are the deletable artifacts the ruling says they are.

`cell_key.KEY_SCHEME` `ck6`→`ck1`, `env_seal.SEAL_VERSION` `6`→`1`, `guard_closure.MANIFEST_VERSION` `3`→`1` — in **one** commit with every test pin that moves with them, because all three are digest inputs and splitting them means three fleet-wide re-keys instead of one. DESIGN-RULINGS §1.27(g).

## pgw#990's other two decisions are deliberately KEPT

The ruling is about the counter's **value**, not about these, and both are load-bearing. The three test-file conflicts were resolved to preserve them:

* **`code_closure` stays OUT of the key.** Identity is the COMPUTATION; a 147-file content hash re-keyed the whole fleet for edits that cannot change a traced graph.
* **`is_key` stays scheme-AGNOSTIC**, byte-identical to tensorhub's `compilecache.IsCellKey`, for the reason th#1183 gives. Reverting it to the ck1-only check this branch carried *before* the rebase would answer every foreign-scheme cell `unreadable_cell_key` — a refusal on a **label** that no axis justifies. So: `ck1` is what this runtime MINTS, while `ck2..ck6` tokens stay key-SHAPED and are ruled on by axes.

## The purge is DONE, not assumed

Re-issuing `ck1` is only honest once the corpus that already used it is gone — the corrected census found **71 ck1 cells on the master stack and 2 on dev**, minted 2026-07-21..29, so the collision this issue was filed about was already on disk. §1.27(g) requires a persisted counter be reset **by migration**, and the hub exposes no `DELETE` for `cell_store` at all, so this could never be a pgw action.

It is tensorhub migration `20260806T064516Z-e68cfe98` (th#1636, merged `b424c1eb`), and it **has applied to both standing stacks** — verified in `public.migrations`, not inferred from the merge:

| stack | migration applied | cell_store | receipts | demand | revocations |
|---|---|---|---|---|---|
| master | 2026-08-06 20:34:11Z | 0 | 0 | 0 | 0 |
| dev | 2026-08-06 07:11:33Z | 1 (`ck5-a53e02a7…`) | 1 | 1 | 0 |

Dev's single row was re-minted 2026-08-06 14:43 by a 0.93.1 pod, *after* the purge. Under `ck1` it can only **MISS** (`cell_key.py:55-59` — a wrong key is never a refusal), so it is left for the `cas-gc` operator follow-up rather than a second migration. `cell_mint_obligations` is deliberately untouched: no `cell_key` column, no ambiguity. **No bucket outside the cell prefix is touched by anything here.**

## Also in this sweep

`aot_wrapper_split`'s telemetry label `version="v2"` → `lever="runimpl"` (it names which split fired and was never a version), and the `ck5`/`ck6` numerals left in prose across `aot_cells`, `aot_serve`, `aot_package`, `aot_flatten`, `graph_hash`, `compile_cache` and the unreached-surface baseline are retired. `warm_spans.py` keeps its `ck5-a53e02a7…` verbatim — that is a quoted pod observation, not a live scheme reference.

No ordering comparison anywhere reads any of the three; the only version compare in the tree is `aot_resume.BANK_V`, already an equality check at 1. `COZY_CELL_EPOCH` remains the designed disown-everything lever, so these counters never move for recall reasons again.

## Gates

Conflicted files re-run after resolution: `test_cell_key.py` + `test_determinism_pgw694.py` + `test_recipe_identity.py` — **47 passed**. Full `tests/` + `tests_v2/` reported in a follow-up comment.

No version bump and no `CHANGELOG.md` edit — `changelog.d/pgw958.md` is this lane's fragment.
