### PR TITLE
pgw#978/#980: invert the dev loop — local micro-mint rig (~21s), and a probe that cannot poison the store

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,10 +9,49 @@ tasks:
       - uv build
 
   publish:
-    desc: Publish to PyPI (uses UV_PUBLISH_TOKEN from .env)
+    desc: |
+      Publish to PyPI (uses UV_PUBLISH_TOKEN from .env).
+
+      pgw#978 — the ORDER matters. Paul, 2026-08-06: "we want to release new
+      versions of python-gen-worker to pypi only after we've proven they work."
+      Run `task rig:mint` first; a version that has never completed a local
+      machinery cycle has not been proven by anything.
     deps: [build]
     cmds:
       - sh -c 'unset UV_PUBLISH_USERNAME; uv publish'
+
+  rig:mint:
+    desc: |
+      pgw#978 — run the whole mint machinery locally against a toy model:
+      resolve -> MintSlot handoff -> child spawn -> load -> warmup_forward ->
+      torch.export + AOTInductor -> seal -> publish to a local hub -> a SECOND
+      process adopting the cell.
+
+      Seconds per iteration instead of the publish->build->buy loop. Bounded by
+      the workspace policy's local-inference carve-out (generated weights under
+      500 MB, a 4 GiB budget split across processes, nice, a load gate at 24,
+      and GEN_WORKER_HOST_MOVE_GUARD untouched) — the driver enforces all five.
+    cmds:
+      - nice -n 10 uv run python scripts/micro_mint_rig.py {{.CLI_ARGS}}
+
+  rig:test:
+    desc: |
+      pgw#978 — the rig as a pytest row, including the full cycle (opt-in via
+      PGW978_RIG so CI's cardless runner never reads it as coverage; classified
+      LOCAL-ONLY in scripts/skip_census.txt).
+    env:
+      PGW978_RIG: '1'
+    cmds:
+      - nice -n 10 uv run --extra dev pytest tests/test_micro_mint_rig_pgw978.py -p no:randomly -rs
+
+  probe:sync:
+    desc: |
+      pgw#980 — rsync src/gen_worker onto a held probe pod and respawn its
+      compute child. Code only; weights stay pod-side.
+      Usage: task probe-sync -- <ssh-target>
+      See docs/probe-worker.md — buy ONE pod, hold it, iterate, terminate.
+    cmds:
+      - scripts/probe_sync.sh {{.CLI_ARGS}}
 
   proto-vendor:
     desc: |

--- a/changelog.d/pgw978.md
+++ b/changelog.d/pgw978.md
@@ -1,0 +1,40 @@
+- **pgw#978: the dev loop is inverted — a local micro-mint rig runs the whole
+  mint machinery on a developer box in seconds.** The loop it replaces was
+  change code -> publish to PyPI -> build an image on the published version ->
+  spawn a pod -> observe for the FIRST time. Paul, 2026-08-06: *"we want to
+  release new versions of python-gen-worker to pypi only after we've proven they
+  work."* Attempt twenty burned ~4 h of that loop to learn one `ValueError` that
+  fired 0.0 s into `warmup_forward`; 9 of that arc's 12 walls were PLUMBING.
+  `task rig:mint` now drives the real path end to end against a
+  randomly-initialized toy latent-diffusion model built on the box: parent
+  resolve -> a real `MintSlot` -> `mint_delegate.build_request` -> a real
+  `mint_process` child interpreter -> `run_setup` -> `warmup_forward` -> real
+  `torch.export` + AOTInductor -> seal -> the real `CellPublisher` wire to a
+  local hub -> a SECOND OS process adopting the cell through the real
+  `aot_cells.discover`. The only stand-ins are the hub (a double speaking the
+  real seven-call protocol, including the store's digest refusal) and the model,
+  which is generated locally and never served to anyone.
+
+- **pgw#978: the rig enforces its own carve-out rather than documenting it.**
+  Paul amended his local-inference rule the same day (recorded in
+  `WORKSPACE-GIT-POLICY.md`); the driver refuses to start outside it. Generated
+  weights under 500 MB and never downloaded; a 4 GiB device budget SPLIT
+  explicitly between the mint child and the adopting process, dogfooding
+  `MintRequest.vram_cap_bytes`/`mint_budget` rather than reimplementing them;
+  `nice`; a load gate at 1-minute load 24 (the box is shared with several agent
+  sessions); and a hard refusal if `GEN_WORKER_HOST_MOVE_GUARD=0` — a green
+  cycle under a configuration production forbids is worse than no cycle.
+
+- **pgw#978: the rig REPORTS the coverage it did not get.** `resolve_device`
+  falls back to CPU when no compatible CUDA build is present and says exactly
+  which properties that costs (no VRAM cap, no placement, no measured kernel
+  lane, an `sm` from a probe rather than a card). `--device cuda` turns the
+  fallback into a named refusal. A report whose green line implies device
+  coverage it never had is the failure this field exists to prevent.
+
+- **pgw#978: classified `LOCAL-ONLY`, not skipped into silence.** The full cycle
+  is opt-in everywhere including CI (a runner has no card) and carries a stable
+  reason keyed in `scripts/skip_census.txt` under pgw#966. The rest of the row —
+  the gates, the carve-out bounds, the handoff round-trip and the pgw#980 probe
+  disarm — is pure Python and runs in CI, because those are precisely the checks
+  that must not rot.

--- a/changelog.d/pgw980.md
+++ b/changelog.d/pgw980.md
@@ -1,0 +1,31 @@
+- **pgw#980: a live-edit probe pod cannot publish a cell, structurally.** The
+  probe workflow (`scripts/probe_sync.sh`, `docs/probe-worker.md`) rsyncs
+  `src/gen_worker` onto a held pod and respawns its compute child, so one
+  iteration costs seconds instead of an image build and a pod spawn. That means
+  a probe runs code which is, by construction, not any released version and not
+  any built image: its mints carry a `gen_worker` version read from dist-info,
+  which rsync does not move and which therefore *lies*, and a `code_closure`
+  cell-key axis no other pod can reproduce. A cell published from a probe into
+  the shared family namespace is one every later pod may adopt and none can
+  explain. `GEN_WORKER_PROBE=1` now removes `cells.publish_intent` /
+  `cells.publish_complete` from the parent's action allowlist
+  (`procsplit/actions.py`). The compute child holds no credential and reaches
+  the hub only through that allowlist, so nothing rsync'd into the child can
+  re-arm publishing — the guard runs in the one process the swapped code cannot
+  touch. Discovery is deliberately untouched: a probe must still be able to
+  ADOPT. Arming is a second, separate decision
+  (`GEN_WORKER_PROBE_PUBLISH_ARMED=1`), because "this is a probe" and "this
+  probe may write to the store" must not be reachable by forgetting the first.
+  A refusal, never a silent drop: the parent counts, logs and dials every
+  `ActionRefused`, so an operator who MEANT to publish learns it from a named
+  refusal rather than from a cell that never appeared.
+
+- **pgw#980: `SIGTERM` is the wrong respawn signal, and the script says so.**
+  The compute child installs `SIGTERM` as `lifecycle.start_drain`, which is
+  terminal for the WHOLE pod — you would lose the pod you are paying to hold.
+  A non-zero exit is what the parent's supervision loop recovers from, so
+  `kill -9` is the sanctioned trigger. The sync also uses `rsync --checksum`
+  rather than mtime (preserving local mtimes can hand a pod a file older than
+  its cached `.pyc`, and the interpreter would keep serving stale bytecode),
+  discovers the pod-side install path instead of assuming it, and waits for the
+  new child by OBSERVING for a fresh pid rather than sleeping (gw#666).

--- a/docs/probe-worker.md
+++ b/docs/probe-worker.md
@@ -1,0 +1,117 @@
+# The live-edit probe worker (pgw#980)
+
+Buy **one** pod, hold it, iterate on it live, terminate it deliberately.
+
+One iteration is an `rsync` and a child respawn — seconds — instead of a PyPI
+release, an image build and a pod spawn. Weights never move; only code does.
+
+## When to reach for it
+
+Tier by tier, cheapest first:
+
+| Tier | Cost per iteration | Covers |
+|---|---|---|
+| `task rig:mint` (pgw#978) | seconds, free | resolve, handoff, spawn, load, warm, export, compile, seal, publish, adopt — on a toy model |
+| experimental image (pgw#979) | one image build | the real image, the real deps, a real pod, a real family |
+| **probe pod (this doc)** | seconds, on a pod you already hold | everything above, on real weights and a real card, iterating |
+
+Reach for a probe when the rig has run out of things it can tell you: when the
+question is about *this* GPU, *these* weights, or a wall the toy model cannot
+reach. Do not reach for it first — it costs $/hr for as long as you hold it, and
+almost every plumbing defect dies to the rig.
+
+## Bringing one up
+
+Two environment variables, both required, and the sync script refuses a pod
+without the first:
+
+```bash
+GEN_WORKER_PROBE=1      # marks the pod a probe; DISARMS cell publish
+WORKER_MODE=forge       # serve=False -> the hub excludes it from dispatch and
+                        # the worker itself refuses tenant jobs
+```
+
+`GEN_WORKER_PROBE=1` is not advisory. It is read by the **control parent**, in
+`procsplit/actions.py`, and it removes `cells.publish_intent` /
+`cells.publish_complete` from the set of hub calls the parent will make on the
+compute child's behalf. The compute child holds no credential and can reach the
+hub only through that allowlist, so **nothing you rsync into the child can
+re-arm publishing.** That is the guarantee: it is structural, not procedural.
+
+Why it matters: a probe runs code that is, by construction, not any released
+version and not any built image. Its mints are stamped with a `gen_worker`
+version read from dist-info — which rsync does not move, so it *lies* — and a
+`code_closure` cell-key axis no other pod can reproduce. A cell published from a
+probe into the shared family namespace is a cell that every later pod may adopt
+and none can explain.
+
+Arming it is a second, separate decision:
+
+```bash
+GEN_WORKER_PROBE_PUBLISH_ARMED=1
+```
+
+Two names rather than one truthy flag: "this is a probe" and "this probe may
+write to the store" are different decisions, and the second must never be
+reachable by forgetting the first.
+
+## The loop
+
+```bash
+task probe-sync -- my-probe-pod              # sync + respawn
+task probe-sync -- my-probe-pod --dry-run    # what would move
+task probe-sync -- my-probe-pod --no-respawn # sync only
+```
+
+`my-probe-pod` is best kept as an `~/.ssh/config` alias.
+
+What the script does, in order:
+
+1. **Refuses a pod that is not marked a probe** — it reads `GEN_WORKER_PROBE`
+   out of the running parent's `/proc/<pid>/environ`, because the guard runs in
+   that process and nowhere else.
+2. **Discovers the install path pod-side** with
+   `python3 -c 'import gen_worker, os; print(os.path.dirname(gen_worker.__file__))'`.
+   Never assumed: the image contract says gen-worker is *importable*; where it
+   landed is the interpreter's business.
+3. **Syncs with `--checksum`, not mtime.** rsync preserving your local mtimes can
+   hand the pod a file older than the `.pyc` already cached for it, and the
+   interpreter would keep serving stale bytecode. It also clears
+   `/var/lib/gen-worker/compute/pycache`.
+4. **Respawns the compute child with `SIGKILL`.**
+5. **Waits by observing** for a child pid that is not one it killed — no fixed
+   sleep decides anything (gw#666).
+
+### SIGTERM is the wrong signal
+
+The compute child installs `SIGTERM` as `lifecycle.start_drain`. A drain is
+terminal for the **whole pod**: it flushes and the worker exits. You would lose
+the pod you are paying to hold.
+
+A non-zero exit is what the parent's supervision loop treats as a death to
+recover from, so `kill -9` is the sanctioned respawn trigger. The parent
+respawns after ~1 s of backoff, reports the death as a typed
+`ComputeProcessDied` for any in-flight job (a probe has none), and at one
+execution group cycles the hub connection so residency is re-driven.
+
+### What a respawn does NOT reload
+
+Only the **compute child** re-imports your code. The control parent keeps
+running what it booted with. So edits to any of:
+
+- `procsplit/parent.py`, `procsplit/transport.py`, `procsplit/actions.py`
+- `config/`, `worker_credential.py`
+
+need a **pod restart**, not a sync. The script says so on the way out rather
+than letting you chase a change that never loaded.
+
+One more consequence worth knowing: the `code_closure` cell-key axis is
+`lru_cache`d over source content, so within a live process your swap does not
+move any cell key — after the respawn it does. Two mints across a sync are two
+different cells by design.
+
+## Terminating
+
+Deliberately, and by hand. A probe has no idle timeout; that is the trade for
+holding it. When the session is done, terminate the pod and say so in the
+tracker issue. A forgotten probe is the most expensive thing in this document.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,14 @@ ignore = ["E402"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-markers = ["integration: network tests against real tiny HF models"]
+markers = [
+  "integration: network tests against real tiny HF models",
+  # pgw#978. LOCAL-ONLY by classification, not by accident: CI has no GPU and
+  # no card-side anything, and scripts/skip_census.txt carries these rows as
+  # LOCAL-ONLY so a green CI never reads as coverage of them.
+  "localrig: the local micro-mint rig (pgw#978) — run by hand, never in CI",
+  "slow: a full machinery cycle; minutes, not seconds",
+]
 # Prefer the working-tree source so a bare `pytest` never tests a stale wheel.
 # The supported command is still `uv run --extra dev pytest` (pytest is a dev
 # extra); tests/conftest.py hard-fails if gen_worker resolves outside src/.

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -77,6 +77,8 @@ src/gen_worker/procsplit/__init__.py::GEN_WORKER_COMPUTE_CHILD BOOTSTRAP GEN_WOR
 src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISOR BOOTSTRAP pre-fork supervisor predicate; runs before the worker process entry.
 src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISED BOOTSTRAP pre-fork re-entry guard, same.
 src/gen_worker/aot_compile_child.py::GEN_WORKER_LOG_LEVEL BOOTSTRAP child log level, applied before the child has any config.
+src/gen_worker/procsplit/actions.py::GEN_WORKER_PROBE BOOTSTRAP pgw#980: marks the pod a live-edit probe and DISARMS cell publish in the parent's action allowlist. It must be readable with no Settings in hand, because `authorize` is the security boundary and a guard that depends on a config load having succeeded is a guard with an unarmed window. Deliberately not a Settings field for the same reason the C2PA key is not: the value must not be reachable through the config surface tenant-adjacent code can read.
+src/gen_worker/procsplit/actions.py::GEN_WORKER_PROBE_PUBLISH_ARMED BOOTSTRAP pgw#980: the second, separate decision that re-arms publish on a marked probe. Same reasoning as its sibling above; two names so that "this is a probe" and "this probe may write to the store" can never be satisfied by one value.
 
 # ---------------------------------------------------------------------------
 # IPC — parent to child across exec. §1.17 routes these to argv (pgw#929).

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -107,7 +107,7 @@ def assert_load_gate(limit: float = MAX_START_LOAD_1MIN) -> float:
 def resolve_device(want: str = "auto") -> Dict[str, Any]:
     """Which device this cycle runs on, and — when it is not the card — WHY.
 
-    pgw#981, found by this rig's first run: the repo pins `torch==2.13.0+cu130`
+    pgw#983, found by this rig's first run: the repo pins `torch==2.13.0+cu130`
     and this box's NVIDIA driver is 570.211.01 (CUDA 12.8). A cu130 build needs
     a 580-series driver, so `torch.cuda.is_available()` is False here and the
     box cannot execute the fleet's own pinned torch at all.
@@ -129,7 +129,7 @@ def resolve_device(want: str = "auto") -> Dict[str, Any]:
     if want == "cuda" and not available:
         raise RigRefused(
             f"--device cuda requested but torch {torch.__version__} reports no "
-            f"CUDA device on this box (see pgw#981: driver is CUDA 12.8, the "
+            f"CUDA device on this box (see pgw#983: driver is CUDA 12.8, the "
             f"pinned torch is cu130 and needs a 580-series driver)")
     if available and want in ("auto", "cuda"):
         major, minor = torch.cuda.get_device_capability(0)
@@ -153,7 +153,7 @@ def resolve_device(want: str = "auto") -> Dict[str, Any]:
         "covers": "plumbing only — NO VRAM cap, NO placement, NO measured lane",
         "why_not_cuda": (
             f"torch {torch.__version__} reports no CUDA device "
-            f"(pgw#981: cu130 build vs a CUDA 12.8 driver)"),
+            f"(pgw#983: cu130 build vs a CUDA 12.8 driver)"),
     }
 
 
@@ -343,7 +343,7 @@ def run_cycle(
         [str(REPO / "tests"), str(REPO / "src"), env.get("PYTHONPATH", "")])
     env["PGW978_CHECKPOINT"] = str(tree)
     if dev["device_kind"] != "cuda":
-        # pgw#981: a cell key needs an `sm` and this box can state none. The
+        # pgw#983: a cell key needs an `sm` and this box can state none. The
         # probes are supplied, LOUDLY — see `install_synthetic_runtime_if_asked`
         # and the `synthetic_runtime` fact this leg reports.
         env[SYNTHETIC_RUNTIME_ENV] = "1"

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""pgw#978 — the local micro-mint rig: the whole mint machinery, on this box.
+
+    python scripts/micro_mint_rig.py            # full cycle
+    python scripts/micro_mint_rig.py --stage mint   # stop after the child
+    python scripts/micro_mint_rig.py --json out.json
+
+WHAT THIS REPLACES. The loop it exists to invert is: change code -> publish to
+PyPI -> build an image on the published version -> spawn a pod -> observe for the
+FIRST time. Paul, 2026-08-06: *"we want to release new versions of
+python-gen-worker to pypi only after we've proven they work."* Attempt twenty
+burned ~4 h of that loop to learn one `ValueError` that fired 0.0 s into
+`warmup_forward`.
+
+WHAT IT ACTUALLY RUNS. Every leg below is the production code path, against a
+randomly-initialized toy latent-diffusion model on this box's card:
+
+  1. resolve      — the parent builds a real `MintSlot` (identity + bytes)
+  2. handoff      — `mint_delegate.build_request` -> `MintRequest` -> a JSON file
+  3. spawn        — `mint_process.run_mint` starts a REAL child interpreter
+  4. load         — the child re-runs discovery and `run_setup` from scratch
+  5. warm         — `warmup_forward` over the endpoint's own declared plan
+  6. export       — real `torch.export` + real AOTInductor compile + link
+  7. seal         — real cell key, real packed artifact, real envelope
+  8. publish      — the real `CellPublisher` wire to a LOCAL hub (7 HTTP calls)
+  9. adopt        — a SECOND OS process discovers and adopts the cell
+
+Legs 1-5 are where 9 of attempt twenty's 12 walls were.
+
+THE BOUNDS (Paul's amendment to his own local-inference rule, 2026-08-06 —
+recorded in `WORKSPACE-GIT-POLICY.md`). These are hard and this script enforces
+them rather than trusting the operator:
+
+  * weights under 500 MB, generated locally, never downloaded;
+  * a 4 GiB device budget, SPLIT deliberately between the mint child and the
+    adopting process (they run at different times but the split is stated, not
+    assumed, so neither leg is written against "the whole card");
+  * `nice`, so a compile cannot starve the box's other agents;
+  * a load gate: refuse to start above 1-min load 24;
+  * `GEN_WORKER_HOST_MOVE_GUARD` untouched — the rig never disables it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tests"))
+sys.path.insert(0, str(REPO / "src"))
+
+GIB = 1 << 30
+
+#: The whole-rig device budget. Never raise this without re-reading the policy
+#: carve-out — 4 GiB is half this box's 8 GiB card, which is what keeps a rig
+#: run compatible with a desktop session and another agent's work.
+RIG_VRAM_BUDGET_BYTES = 4 * GIB
+
+#: The split. The mint child does the export and the compile, so it gets the
+#: larger share; the adopting process only loads a packed cell and runs one
+#: forward. Stated here rather than left to each leg's own idea of "the card":
+#: the ENV_HOST_SIBLINGS divisor pattern in procsplit exists for the same
+#: reason — two processes on one device must agree on the division up front.
+MINT_VRAM_BYTES = 3 * GIB
+ADOPT_VRAM_BYTES = RIG_VRAM_BUDGET_BYTES - MINT_VRAM_BYTES
+
+#: Refuse to start above this 1-minute load. The box is shared with several
+#: agent sessions; a compile that starts at load 30 finishes slower AND makes
+#: everyone else slower.
+MAX_START_LOAD_1MIN = 24.0
+
+#: The size ceiling the policy carve-out states. Enforced, not documented.
+MAX_WEIGHTS_BYTES = 500 * 1000 * 1000
+
+ENDPOINT_MODULE = "harness.tiny_diffusion_endpoint"
+FUNCTION = "rig-generate"
+
+
+# ---------------------------------------------------------------------------
+# Gates — refusals, before anything expensive
+# ---------------------------------------------------------------------------
+
+
+class RigRefused(RuntimeError):
+    """A named precondition failure. Terminal, and never a rig defect."""
+
+
+def assert_load_gate(limit: float = MAX_START_LOAD_1MIN) -> float:
+    load1 = os.getloadavg()[0]
+    if load1 > limit:
+        raise RigRefused(
+            f"1-minute load is {load1:.1f} (> {limit:.0f}); this box is shared "
+            f"with other agent sessions. Wait, or run with --force-load.")
+    return load1
+
+
+def resolve_device(want: str = "auto") -> Dict[str, Any]:
+    """Which device this cycle runs on, and — when it is not the card — WHY.
+
+    pgw#981, found by this rig's first run: the repo pins `torch==2.13.0+cu130`
+    and this box's NVIDIA driver is 570.211.01 (CUDA 12.8). A cu130 build needs
+    a 580-series driver, so `torch.cuda.is_available()` is False here and the
+    box cannot execute the fleet's own pinned torch at all.
+
+    That does NOT stop the rig from being worth running. The nine walls of
+    attempt twenty that this exists to catch were PLUMBING — endpoint
+    discovery, slot binding across the delegation boundary, the child spawn,
+    the declaration, the publish wire, the adopt filter — and every one of them
+    runs identically on CPU. What CPU does not cover is stated rather than
+    quietly implied: no VRAM cap enforcement, no device placement, no measured
+    kernel lane, and an `sm` axis that comes from a probe rather than a card.
+
+    So the device is RESOLVED and REPORTED, never assumed. `--device cuda`
+    turns the fallback into a refusal for the day the driver is current.
+    """
+    import torch
+
+    available = torch.cuda.is_available()
+    if want == "cuda" and not available:
+        raise RigRefused(
+            f"--device cuda requested but torch {torch.__version__} reports no "
+            f"CUDA device on this box (see pgw#981: driver is CUDA 12.8, the "
+            f"pinned torch is cu130 and needs a 580-series driver)")
+    if available and want in ("auto", "cuda"):
+        major, minor = torch.cuda.get_device_capability(0)
+        props = torch.cuda.get_device_properties(0)
+        return {
+            "device_kind": "cuda",
+            "device": props.name,
+            "sm": f"sm_{major}{minor}",
+            "total_bytes": int(props.total_memory),
+            "torch": torch.__version__,
+            "device_ordinal": 0,
+            "covers": "plumbing + device (VRAM cap, placement, measured lane)",
+        }
+    return {
+        "device_kind": "cpu",
+        "device": "cpu",
+        "sm": "(probe)",
+        "total_bytes": 0,
+        "torch": torch.__version__,
+        "device_ordinal": -1,
+        "covers": "plumbing only — NO VRAM cap, NO placement, NO measured lane",
+        "why_not_cuda": (
+            f"torch {torch.__version__} reports no CUDA device "
+            f"(pgw#981: cu130 build vs a CUDA 12.8 driver)"),
+    }
+
+
+def assert_host_move_guard() -> str:
+    """The one env the rig must never have turned off.
+
+    `GEN_WORKER_HOST_MOVE_GUARD` is on by default and disabled with `=0`. A rig
+    that ran with it off would be exercising a placement path production
+    forbids, and would report a green cycle for a configuration no pod runs.
+    """
+    value = os.environ.get("GEN_WORKER_HOST_MOVE_GUARD", "")
+    if value.strip() == "0":
+        raise RigRefused(
+            "GEN_WORKER_HOST_MOVE_GUARD=0 is set. The rig refuses to run with "
+            "the host-move guard disabled — see the workspace policy.")
+    return value or "(default: on)"
+
+
+# ---------------------------------------------------------------------------
+# The cycle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Leg:
+    name: str
+    ok: bool = False
+    seconds: float = 0.0
+    detail: str = ""
+    facts: Dict[str, Any] = field(default_factory=dict)
+
+    def line(self) -> str:
+        mark = "ok " if self.ok else "FAIL"
+        return f"  {mark} {self.name:<14} {self.seconds:7.2f}s  {self.detail}"
+
+
+@dataclass
+class RigResult:
+    legs: List[Leg] = field(default_factory=list)
+    env: Dict[str, Any] = field(default_factory=dict)
+    total_s: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.legs) and all(leg.ok for leg in self.legs)
+
+    def add(self, leg: Leg) -> Leg:
+        self.legs.append(leg)
+        return leg
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "total_s": round(self.total_s, 2),
+            "env": self.env,
+            "legs": [
+                {"name": lg.name, "ok": lg.ok, "seconds": round(lg.seconds, 3),
+                 "detail": lg.detail, "facts": lg.facts}
+                for lg in self.legs
+            ],
+        }
+
+    def report(self) -> str:
+        head = "MICRO-MINT RIG — " + ("CYCLE COMPLETE" if self.ok else "CYCLE FAILED")
+        body = "\n".join(leg.line() for leg in self.legs)
+        return (
+            f"{head}\n{body}\n"
+            f"  ---- full machinery cycle: {self.total_s:.1f}s "
+            f"(the number that replaces 4 hours)")
+
+
+def _mint_slot(tree: Path) -> Any:
+    """The parent's resolution: WHICH checkpoint, and WHERE its bytes are.
+
+    Built through the real `ModelRef`/`MintSlot` types, because pgw#974's whole
+    point is that a slot with bytes and no identity must be unconstructable —
+    a rig that hand-rolled a dict would route around the guard it exists to
+    exercise.
+    """
+    from gen_worker.api.binding import ModelRef
+    from gen_worker.mint_process import MintSlot
+
+    return MintSlot(
+        ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion", tag="prod"),
+        path=str(tree),
+    )
+
+
+def _mint_request(
+    workdir: Path, tree: Path, capture: Path, *,
+    ordinal: int = 0, cap_bytes: int = MINT_VRAM_BYTES,
+) -> Any:
+    """Built through `mint_delegate.build_request` — the REAL parent chain.
+
+    Not a hand-written `MintRequest`: the thing under test is the handoff, and
+    a hand-written request is the one shape the handoff can never produce.
+    """
+    from gen_worker import mint_delegate
+    from gen_worker.mint_delegate import MintTask
+    from gen_worker.registry import CompileCell
+
+    from harness import tiny_diffusion_endpoint as ep
+
+    cfg = CompileCell(
+        shapes=(ep.PIXEL_SHAPE,), targets=("unet",), family=ep.FAMILY,
+        regional=False, text_len=ep.TEXT_LEN, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=())
+    pending = SimpleNamespace(
+        family=ep.FAMILY, cell_key="", recipe=os.environ.get("PGW978_RECIPE", "aot"), cfg=cfg,
+        capture_dir=capture, target=workdir / "cell.tar.gz", mint_root=workdir)
+    # The key is the REAL one, derived the way the arming brain derives it, so
+    # the child's own recomputation has something to agree with.
+    task = MintTask(
+        pending=pending, pipe=None,
+        function=FUNCTION, modules=(ENDPOINT_MODULE,),
+        slots={"pipeline": _mint_slot(tree)}, device=ordinal,
+        execution_lane="", configs={})
+    return mint_delegate.build_request(
+        task, workdir=workdir, cap_bytes=cap_bytes)
+
+
+def run_cycle(
+    root: Path, *, stage: str = "all", force_load: bool = False,
+    device: str = "auto",
+) -> RigResult:
+    result = RigResult()
+    t0 = time.monotonic()
+
+    # -- gates ---------------------------------------------------------------
+    leg = result.add(Leg("gates"))
+    g0 = time.monotonic()
+    load1 = 0.0 if force_load else assert_load_gate()
+    guard = assert_host_move_guard()
+    dev = resolve_device(device)
+    leg.ok, leg.seconds = True, time.monotonic() - g0
+    leg.facts = {"load1": load1, "host_move_guard": guard, **dev,
+                 "mint_vram_bytes": MINT_VRAM_BYTES,
+                 "adopt_vram_bytes": ADOPT_VRAM_BYTES}
+    leg.detail = (f"{dev['device']} {dev['sm']} torch={dev['torch']} "
+                  f"load={load1:.1f} covers={dev['covers']}")
+    result.env = leg.facts
+
+    # -- weights -------------------------------------------------------------
+    from harness.tiny_diffusion import (
+        SYNTHETIC_RUNTIME_ENV, build_checkpoint, checkpoint_bytes,
+    )
+
+    leg = result.add(Leg("weights"))
+    g0 = time.monotonic()
+    tree = build_checkpoint(root / "checkpoint")
+    size = checkpoint_bytes(tree)
+    if size > MAX_WEIGHTS_BYTES:
+        raise RigRefused(
+            f"generated checkpoint is {size / 1e6:.1f} MB, over the "
+            f"{MAX_WEIGHTS_BYTES / 1e6:.0f} MB carve-out ceiling")
+    leg.ok, leg.seconds = True, time.monotonic() - g0
+    leg.facts = {"bytes": size, "tree": str(tree)}
+    leg.detail = f"{size / 1e6:.1f} MB generated locally (no download)"
+
+    # -- the handoff ---------------------------------------------------------
+    workdir = root / "mint"
+    workdir.mkdir(parents=True, exist_ok=True)
+    capture = root / "capture"
+
+    leg = result.add(Leg("handoff"))
+    g0 = time.monotonic()
+    request = _mint_request(workdir, tree, capture,
+                            ordinal=int(dev["device_ordinal"]),
+                            cap_bytes=(MINT_VRAM_BYTES
+                                       if dev["device_kind"] == "cuda" else 0))
+    leg.ok, leg.seconds = True, time.monotonic() - g0
+    leg.facts = {"family": request.family, "recipe": request.recipe,
+                 "slots": sorted(request.slots),
+                 "cell_key": request.cell_key,
+                 "vram_cap_bytes": request.vram_cap_bytes}
+    leg.detail = (f"family={request.family} recipe={request.recipe} "
+                  f"slots={sorted(request.slots)}")
+
+    # -- the child -----------------------------------------------------------
+    from gen_worker import mint_process as mp
+
+    leg = result.add(Leg("mint-child"))
+    g0 = time.monotonic()
+    phases: List[str] = []
+    env = dict(mp.child_env(request))
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO / "tests"), str(REPO / "src"), env.get("PYTHONPATH", "")])
+    env["PGW978_CHECKPOINT"] = str(tree)
+    if dev["device_kind"] != "cuda":
+        # pgw#981: a cell key needs an `sm` and this box can state none. The
+        # probes are supplied, LOUDLY — see `install_synthetic_runtime_if_asked`
+        # and the `synthetic_runtime` fact this leg reports.
+        env[SYNTHETIC_RUNTIME_ENV] = "1"
+    outcome = asyncio.run(mp.run_mint(
+        request, workdir=workdir, env=env, observe_interval_s=2.0,
+        on_frame=lambda f: phases.append(f.phase) if f.phase else None))
+    leg.seconds = time.monotonic() - g0
+    leg.ok = outcome.status == mp.MINTED
+    report = outcome.report
+    leg.facts = {
+        "status": outcome.status,
+        "exit_code": outcome.exit_code,
+        "phases_seen": sorted(set(phases)),
+        "phase_seconds": dict(report.phases) if report else {},
+        "peak_vram_bytes": int(report.peak_vram_bytes) if report else 0,
+        "cell_key": str(report.cell_key) if report else "",
+        "artifact": str(outcome.artifact or ""),
+        "detail": outcome.detail[:500],
+        "stderr_tail": outcome.stderr_tail[-1200:],
+        # Never implied away: a cell sealed under a supplied `sm` is a PLUMBING
+        # artifact and must never reach a shared namespace.
+        "synthetic_runtime": env.get(SYNTHETIC_RUNTIME_ENV) == "1",
+    }
+    if not leg.ok:
+        leg.detail = f"{outcome.status}: {outcome.detail[:220]}"
+        result.total_s = time.monotonic() - t0
+        return result
+    warm = float((report.phases if report else {}).get("warmup_forward", 0.0))
+    leg.detail = (
+        f"minted {Path(outcome.artifact or '').name} "
+        f"key={(report.cell_key if report else '')[:20]} "
+        f"warm={warm:.2f}s peak={leg.facts['peak_vram_bytes'] / 1e9:.2f}GB")
+
+    if stage == "mint":
+        result.total_s = time.monotonic() - t0
+        return result
+
+    # -- publish -------------------------------------------------------------
+    from harness.cell_hub import LocalCellHub
+
+    hub = LocalCellHub()
+    try:
+        leg = result.add(Leg("publish"))
+        g0 = time.monotonic()
+        checkpoint_id = _publish(hub, request, Path(outcome.artifact or ""))
+        leg.ok, leg.seconds = True, time.monotonic() - g0
+        leg.facts = {"checkpoint_id": checkpoint_id,
+                     "routes": hub.routes(),
+                     "cas_bytes": hub.artifact_bytes()}
+        leg.detail = (f"checkpoint={checkpoint_id[:22]} over "
+                      f"{len(hub.routes())} real HTTP calls")
+
+        if stage == "publish":
+            result.total_s = time.monotonic() - t0
+            return result
+
+        # -- adopt, in a SECOND process --------------------------------------
+        leg = result.add(Leg("adopt"))
+        g0 = time.monotonic()
+        adopted = _adopt_in_subprocess(
+            hub.base, root,
+            synthetic_runtime=bool(
+                next(lg for lg in result.legs
+                     if lg.name == "mint-child").facts.get("synthetic_runtime")))
+        leg.seconds = time.monotonic() - g0
+        leg.ok = bool(adopted.get("ok"))
+        leg.facts = adopted
+        leg.detail = (
+            f"pid={adopted.get('pid')} adopted {str(adopted.get('cell_key'))[:20]} "
+            f"({adopted.get('artifact_bytes', 0) / 1e6:.1f} MB)"
+            if leg.ok else
+            (str(adopted.get("error") or adopted.get("miss_log") or "")[-400:]))
+    finally:
+        hub.close()
+
+    result.total_s = time.monotonic() - t0
+    return result
+
+
+def _publish(hub: Any, request: Any, artifact: Path) -> str:
+    """The real `CellPublisher`, against the local hub."""
+    from gen_worker import aot_serve, fleet_cells
+
+    # The cell's OWN recorded envelope, read back off the packed tarball —
+    # never a dict rebuilt here. `CellPublisher` derives the key, the axes and
+    # the identity axes from it, so a hand-built stand-in would publish a cell
+    # describing something other than the bytes beside it.
+    meta = aot_serve.unpack_metadata(artifact)
+    publisher = fleet_cells.CellPublisher(
+        base_url=hub.base,
+        worker_jwt=lambda: "local-rig-worker-jwt",
+        image_digest="sha256:" + "0" * 64,
+    )
+    if not publisher.enabled():
+        raise RigRefused("the publisher reports no sink; the local hub is up")
+    return publisher.publish(request.family, artifact, meta)
+
+
+ADOPT_CHILD = """
+import json, os, sys
+sys.path.insert(0, %(tests)r)
+sys.path.insert(0, %(src)r)
+from pathlib import Path
+from types import SimpleNamespace
+from gen_worker import aot_cells
+from gen_worker.registry import CompileCell
+from harness import tiny_diffusion_endpoint as ep
+from harness.tiny_diffusion import TinyUNet
+
+cfg = CompileCell(
+    shapes=(ep.PIXEL_SHAPE,), targets=("unet",), family=ep.FAMILY,
+    regional=False, text_len=ep.TEXT_LEN, dynamic=(), lora_bucket=0,
+    guidance_scales=(), text_lens=())
+pipe = SimpleNamespace(unet=TinyUNet().eval())
+cell = aot_cells.discover(
+    pipe, cfg, base_url=%(base)r,
+    worker_jwt=lambda: "local-rig-worker-jwt",
+    cache_dir=Path(%(cache)r))
+out = {"pid": os.getpid(), "ok": cell is not None}
+if cell is not None:
+    out.update({
+        "cell_key": cell.cell_key, "family": cell.family, "ref": cell.ref,
+        "snapshot_digest": cell.snapshot_digest,
+        "artifact_bytes": Path(cell.artifact).stat().st_size,
+    })
+print("RIG_ADOPT " + json.dumps(out))
+"""
+
+
+def _adopt_in_subprocess(
+    base: str, root: Path, *, synthetic_runtime: bool = False,
+) -> Dict[str, Any]:
+    """A SECOND OS process doing the discovery.
+
+    In-process adoption would be a different test: the whole cross-pod claim is
+    that a cell minted by one interpreter is servable by another that shares
+    nothing but the hub and the card. A fresh interpreter is the cheapest
+    honest stand-in for the second pod.
+    """
+    cache = root / "adopt-cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    src = ADOPT_CHILD % {
+        "tests": str(REPO / "tests"), "src": str(REPO / "src"),
+        "base": base, "cache": str(cache)}
+    from harness.tiny_diffusion import SYNTHETIC_RUNTIME_ENV
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO / "tests"), str(REPO / "src"), env.get("PYTHONPATH", "")])
+    if synthetic_runtime:
+        # The adopting side runs `aot_serve.verify`, which compares the cell's
+        # stamped sm/torch/cuda against THIS runtime's. A second process that
+        # did not get the same supplied probes would reject the cell the first
+        # one just minted — and report it as a filter miss, which is exactly the
+        # wrong diagnosis. Both sides state the same runtime or neither does.
+        env[SYNTHETIC_RUNTIME_ENV] = "1"
+    proc = subprocess.run(
+        [sys.executable, "-c", src], capture_output=True, text=True, env=env)
+    for line in proc.stdout.splitlines():
+        if line.startswith("RIG_ADOPT "):
+            out = json.loads(line[len("RIG_ADOPT "):])
+            if not out.get("ok"):
+                # A MISS is not a crash, and its reason lives in the typed
+                # `aot-cells` events on stderr. Carrying it out is the whole
+                # difference between "no cell" and "twelve cells, all rejected
+                # on one axis" (pgw#824).
+                out["miss_log"] = _adopt_miss_log(proc.stderr)
+            return out
+    return {"ok": False,
+            "error": (proc.stderr or proc.stdout or "no adopt line")[-1500:]}
+
+
+def _adopt_miss_log(stderr: str) -> str:
+    lines = [ln for ln in stderr.splitlines()
+             if "aot-cells" in ln or "aot_cells" in ln or "verify" in ln]
+    return "\n".join(lines[-12:]) or stderr[-800:]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="micro_mint_rig",
+        description="pgw#978 — run the whole mint machinery locally.")
+    parser.add_argument(
+        "--root", type=Path, default=Path(os.environ.get(
+            "PGW978_ROOT", str(Path.home() / ".cache" / "gen-worker" / "micro-rig"))),
+        help="scratch root (checkpoint is cached here between runs)")
+    parser.add_argument(
+        "--stage", choices=("mint", "publish", "all"), default="all",
+        help="stop after this leg")
+    parser.add_argument("--json", type=Path, default=None,
+                        help="write the machine-readable result here")
+    parser.add_argument("--force-load", action="store_true",
+                        help="skip the shared-box load gate (say why)")
+    parser.add_argument(
+        "--device", choices=("auto", "cuda", "cpu"), default="auto",
+        help="auto falls back to CPU and SAYS SO; cuda refuses instead")
+    parser.add_argument("--clean", action="store_true",
+                        help="discard the scratch root first")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(args.root)
+    if args.clean and root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result = run_cycle(root, stage=args.stage, force_load=args.force_load,
+                           device=args.device)
+    except RigRefused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 2
+    print(result.report())
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(result.as_dict(), indent=2, sort_keys=True, default=str))
+    if not result.ok:
+        for leg in result.legs:
+            if not leg.ok and leg.facts.get("stderr_tail"):
+                print("\n--- mint child stderr tail ---", file=sys.stderr)
+                print(leg.facts["stderr_tail"], file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_sync.sh
+++ b/scripts/probe_sync.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# pgw#980 — push this working tree's `src/gen_worker` onto a held probe pod and
+# respawn its compute child, so one iteration costs seconds instead of an image
+# build and a pod spawn.
+#
+#   scripts/probe_sync.sh <ssh-target>            # sync + respawn
+#   scripts/probe_sync.sh <ssh-target> --dry-run  # show what would move
+#   scripts/probe_sync.sh <ssh-target> --no-respawn
+#
+# <ssh-target> is anything ssh accepts (`root@1.2.3.4 -p 12345` works if you
+# quote it, or use an ~/.ssh/config alias — preferred).
+#
+# WHAT MOVES: code only. Weights stay pod-side; the weights-locality rule is
+# untouched by design, and this script has no path that would move a checkpoint.
+#
+# WHAT DOES NOT REFRESH: the control PARENT. A compute-child respawn re-imports
+# `gen_worker` in a fresh interpreter, which is what picks up your edit — but the
+# parent process (procsplit/parent.py, transport.py, config/, worker_credential.py)
+# keeps running the code it booted with. Editing those needs a pod restart, and
+# this script says so rather than letting you chase a change that never loaded.
+set -euo pipefail
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+  echo "usage: $0 <ssh-target> [--dry-run] [--no-respawn]" >&2
+  exit 2
+fi
+shift || true
+
+DRY_RUN=0
+RESPAWN=1
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --no-respawn) RESPAWN=0 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO/src/gen_worker"
+[ -d "$SRC" ] || { echo "no $SRC — run this from the python-gen-worker tree" >&2; exit 2; }
+
+say() { printf '\033[1m==>\033[0m %s\n' "$*"; }
+
+# --- 1. Refuse a pod that is not marked a probe ------------------------------
+# GEN_WORKER_PROBE is what disarms cell publish in the parent's action
+# allowlist (procsplit/actions.py). Syncing onto a pod without it would put
+# unreleased code on a worker whose mints can still reach the shared family
+# namespace — the exact poisoning pgw#980 exists to make impossible. The check
+# reads the PARENT's environment, because that is the process the guard runs in.
+say "checking $TARGET is marked a probe"
+PARENT_PID="$(ssh $TARGET "pgrep -f 'gen_worker.entrypoint' | head -1" || true)"
+if [ -z "$PARENT_PID" ]; then
+  echo "no gen_worker process on $TARGET — is the worker running?" >&2
+  exit 3
+fi
+if ! ssh $TARGET "tr '\0' '\n' < /proc/$PARENT_PID/environ | grep -qx 'GEN_WORKER_PROBE=1'"; then
+  cat >&2 <<'EOF'
+REFUSED: this pod is not marked a live-edit probe.
+
+Its worker was not started with GEN_WORKER_PROBE=1, so the parent's cell-publish
+disarm (pgw#980) is not in force and a mint from rsync'd code could reach the
+shared family namespace. Bring the pod up with:
+
+    GEN_WORKER_PROBE=1 WORKER_MODE=forge   # forge => no tenant dispatch either
+
+and re-run. Do not "just this once" a sync onto a serving pod.
+EOF
+  exit 3
+fi
+
+# --- 2. Discover the install path, pod-side ----------------------------------
+# Never assumed. The image contract says gen-worker is importable; WHERE it
+# landed is the interpreter's business, and an endpoint image that used an
+# editable install puts it somewhere /usr/lib guesswork would miss.
+say "discovering the pod-side gen_worker path"
+DEST="$(ssh $TARGET "python3 -c 'import gen_worker, os; print(os.path.dirname(gen_worker.__file__))'")"
+[ -n "$DEST" ] || { echo "could not resolve gen_worker on the pod" >&2; exit 3; }
+say "  -> $DEST"
+
+# --- 3. Sync -----------------------------------------------------------------
+# --checksum, NOT mtime: rsync preserving OUR mtimes can hand the pod a file
+# whose timestamp is OLDER than the .pyc already cached for it, and the
+# interpreter would then keep serving the stale bytecode. Content decides.
+RSYNC_ARGS=(-rlv --checksum --delete
+            --exclude '__pycache__/' --exclude '*.pyc' --exclude '*.so')
+[ "$DRY_RUN" = "1" ] && RSYNC_ARGS+=(--dry-run)
+say "syncing src/gen_worker/ -> $DEST/"
+rsync "${RSYNC_ARGS[@]}" -e "ssh" "$SRC/" "$TARGET:$DEST/"
+
+if [ "$DRY_RUN" = "1" ]; then
+  say "dry run — nothing changed, no respawn"
+  exit 0
+fi
+
+# Drop any bytecode the pod cached under PYTHONPYCACHEPREFIX. Cheap, and it
+# removes the one class of "my edit did not take" that is not the parent.
+ssh $TARGET "rm -rf /var/lib/gen-worker/compute/pycache 2>/dev/null || true"
+
+if [ "$RESPAWN" = "0" ]; then
+  say "synced; respawn skipped (--no-respawn)"
+  exit 0
+fi
+
+# --- 4. Respawn the compute child -------------------------------------------
+# SIGTERM IS THE WRONG SIGNAL and it is a trap worth naming: the compute child
+# installs SIGTERM as `lifecycle.start_drain`, which flushes and takes the WHOLE
+# worker down — you would lose the pod you are paying to hold. A non-zero exit
+# is what the parent's supervision loop treats as a death to recover from, so
+# SIGKILL is the sanctioned respawn trigger. In-flight jobs on that group get a
+# typed FATAL; a probe has none.
+say "respawning the compute child (SIGKILL — SIGTERM would drain the pod)"
+CHILD_PIDS="$(ssh $TARGET "pgrep -f 'gen_worker.entrypoint' | grep -v '^$PARENT_PID\$'" || true)"
+if [ -z "$CHILD_PIDS" ]; then
+  echo "no compute child found beside parent $PARENT_PID; nothing to respawn" >&2
+  exit 4
+fi
+# shellcheck disable=SC2086
+ssh $TARGET "kill -9 $CHILD_PIDS"
+say "killed child pid(s): $(echo $CHILD_PIDS | tr '\n' ' ')"
+
+# --- 5. Wait for the new child, by OBSERVING it, not by sleeping -------------
+# gw#666: no fixed-duration wait decides anything here. The loop watches for a
+# child pid that is not one we just killed, and gives up only when the parent
+# itself is gone (which would mean the death was not recoverable).
+say "waiting for the parent to respawn a child"
+while :; do
+  if ! ssh $TARGET "kill -0 $PARENT_PID" 2>/dev/null; then
+    echo "the control parent exited — the child death was not recoverable." >&2
+    echo "Check the pod's logs; a pre-Hello death loop exits the worker by design." >&2
+    exit 5
+  fi
+  NEW="$(ssh $TARGET "pgrep -f 'gen_worker.entrypoint' | grep -v '^$PARENT_PID\$'" || true)"
+  FRESH=""
+  for pid in $NEW; do
+    case " $(echo $CHILD_PIDS | tr '\n' ' ') " in
+      *" $pid "*) ;;
+      *) FRESH="$pid" ;;
+    esac
+  done
+  if [ -n "$FRESH" ]; then
+    say "new compute child: pid $FRESH — running your tree"
+    break
+  fi
+done
+
+say "done. Parent still runs its BOOT-TIME code: edits to procsplit/parent.py,"
+say "transport.py, config/ or worker_credential.py need a pod restart to load."

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -130,6 +130,15 @@ LOCAL-ONLY tests/test_lora_lifted_pgw725.py|set gen_worker_aot_pack_tests=# (pac
 LOCAL-ONLY tests/test_chunk_cas_parallel_th1362.py|multi-gb throughput measurement; set chunk_cas_bench=#
 LOCAL-ONLY tests/test_aot_run_impl_split_pgw811.py|banked pgw#793 wrapper not present
 LOCAL-ONLY tests/test_topology_fuzz_pgw867.py|tensorhub checkout not present
+# pgw#978. The full local mint cycle: a real child spawn, a real torch.export +
+# AOTInductor compile, a real publish over the wire and a real second-process
+# adopt. It is opt-in EVERYWHERE, CI included — not because CI could run it and
+# we chose not to, but because it is the developer's inner loop and a CI runner
+# has no card. The rest of that file (the gates, the carve-out bounds, the
+# handoff round-trip, the pgw#980 probe disarm) is pure Python and RUNS in CI;
+# only this row is opt-in, which is the point of classifying it rather than
+# marking the whole module.
+LOCAL-ONLY tests/test_micro_mint_rig_pgw978.py|the pgw#978 micro-mint rig is opt-in: it runs a full local mint cycle (set pgw#_rig=#)
 
 # ─── STAGED ───────────────────────────────────────────────────────────────────
 STAGED tests/test_p1_stream_lifecycle.py|pgw#605 open: hello.idle_heartbeat_interval_ms / workermessage.heartbeat proto fields are not generated in this tree yet

--- a/src/gen_worker/config/loader.py
+++ b/src/gen_worker/config/loader.py
@@ -116,6 +116,12 @@ _OWNED_NON_SETTINGS: frozenset[str] = frozenset({
     "GEN_WORKER_SEAL_LIB_MEMO",
     "GEN_WORKER_SUPERVISED",
     "WORKER_EXECUTION_TOPOLOGY",
+    # pgw#980: the live-edit probe marking and its separate publish arming.
+    # Read by `procsplit.actions` — the PARENT's security boundary, which must
+    # be readable with no Settings in hand, and which tenant-adjacent code in
+    # the compute child must not be able to reach through the config surface.
+    "GEN_WORKER_PROBE",
+    "GEN_WORKER_PROBE_PUBLISH_ARMED",
     # pgw#929 library/standalone-tool knobs; see scripts/config_reads_allowlist.txt.
     "GEN_WORKER_LOG_LEVEL",
     "GEN_WORKER_LOCAL_CELLS_DIR",

--- a/src/gen_worker/procsplit/actions.py
+++ b/src/gen_worker/procsplit/actions.py
@@ -215,9 +215,9 @@ def publish_disarmed() -> bool:
     site-packages can reach either. Disarming here is structural — a probe
     cannot publish by editing the code it is running.
     """
-    return probe_pod() and not (
+    return probe_pod() and (
         str(os.environ.get(_PROBE_PUBLISH_ARM_ENV, "")).strip().lower()
-        in ("1", "true", "yes"))
+        not in ("1", "true", "yes"))
 
 
 def authorize(req: Dict[str, Any]) -> Tuple[HubAction, Dict[str, Any], Optional[Dict[str, Any]]]:

--- a/src/gen_worker/procsplit/actions.py
+++ b/src/gen_worker/procsplit/actions.py
@@ -32,6 +32,7 @@ event, not a 404.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
@@ -182,6 +183,43 @@ _MAX_JSON_BYTES = 256 * 1024
 CONTROL_BODY_CEILING_BYTES = _MAX_JSON_BYTES
 
 
+#: pgw#980: the two actions that WRITE a cell into a shared family namespace.
+#: Every other action in the table reads, renews or reports.
+PUBLISH_ACTIONS = frozenset({"cells.publish_intent", "cells.publish_complete"})
+
+#: pgw#980: the env that marks a pod a LIVE-EDIT PROBE. A probe runs code that
+#: was rsync'd onto it — code that is, by construction, not any released
+#: version and not any built image. Its mints are therefore stamped with a
+#: `gen_worker` version that lies (the dist-info does not move with the source)
+#: and a `code_closure` axis no other pod can reproduce. A probe publishing into
+#: the shared family namespace poisons every pod that later adopts from it.
+_PROBE_ENV = "GEN_WORKER_PROBE"
+
+#: And the deliberate, explicit arming. Two names rather than one truthy flag:
+#: "this is a probe" and "this probe may write to the store" are different
+#: decisions, and the second must never be reachable by forgetting the first.
+_PROBE_PUBLISH_ARM_ENV = "GEN_WORKER_PROBE_PUBLISH_ARMED"
+
+
+def probe_pod() -> bool:
+    """Whether this pod is a live-edit probe (pgw#980)."""
+    return str(os.environ.get(_PROBE_ENV, "")).strip().lower() in ("1", "true", "yes")
+
+
+def publish_disarmed() -> bool:
+    """Whether cell publish is disarmed for this pod.
+
+    Read in the PARENT, which is the point. The compute child is where the
+    swapped code runs and where a tenant endpoint executes; the parent holds
+    the credential and owns this table, and nothing rsync'd into the child's
+    site-packages can reach either. Disarming here is structural — a probe
+    cannot publish by editing the code it is running.
+    """
+    return probe_pod() and not (
+        str(os.environ.get(_PROBE_PUBLISH_ARM_ENV, "")).strip().lower()
+        in ("1", "true", "yes"))
+
+
 def authorize(req: Dict[str, Any]) -> Tuple[HubAction, Dict[str, Any], Optional[Dict[str, Any]]]:
     """Validate one child action request against the table.
 
@@ -206,6 +244,17 @@ def authorize(req: Dict[str, Any]) -> Tuple[HubAction, Dict[str, Any], Optional[
             f"{method} {path[:200]} is not an allowlisted parent-mediated action "
             "(the compute child holds no credential and may not name arbitrary "
             "hub calls)"
+        )
+    if match.name in PUBLISH_ACTIONS and publish_disarmed():
+        # Refused, not dropped: the parent counts, logs and dials every
+        # ActionRefused, so a probe whose operator MEANT to publish learns it
+        # from a named refusal rather than from a cell that never appeared.
+        raise ActionRefused(
+            f"{match.name} is disarmed on this pod: {_PROBE_ENV} marks it a "
+            f"live-edit probe running rsync'd code, whose cells carry a "
+            f"`gen_worker` version that does not describe them and a "
+            f"`code_closure` no other pod can reproduce. Set "
+            f"{_PROBE_PUBLISH_ARM_ENV}=1 to arm it deliberately (pgw#980)."
         )
 
     raw_query = req.get("query") or {}

--- a/tests/harness/cell_hub.py
+++ b/tests/harness/cell_hub.py
@@ -1,0 +1,347 @@
+"""pgw#978: a LOCAL hub that speaks the real cell publish + discover wire.
+
+Promoted out of ``test_cell_publish_v2_pgw807.py``'s ``_Hub``, which already
+implemented tensorhub's v2 publish contract exactly (including the R2 digest
+enforcement that makes the protocol worth having) — and extended with the half
+that test did not need: the DISCOVER side a second worker adopts through.
+
+Why a double rather than a compose tensorhub: the rig's value is that a full
+machinery cycle costs seconds on a laptop. A stack with Postgres, MinIO and
+Vault costs minutes to boot and is a second thing that can be broken. What
+matters is that the WIRE is real — every route below is the one
+``fleet_cells.CellPublisher`` and ``aot_cells.discover`` actually call, with the
+same status codes and the same envelope shapes, and the store really refuses
+bytes that do not hash to their digest. A cell published here and adopted here
+crossed the same seven HTTP calls it would cross in production.
+
+What this deliberately does NOT model: attestation, trust tiers, quota, and the
+hub-side stamping of ``cell_store`` from the token claim. Those are refusals the
+hub owns; a double that invented its own version of them would be testing the
+double. Publish-intent here always grants.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import http.server
+import json
+import threading
+import urllib.parse
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    """tensorhub's v2 publish contract + the checkpoint/resolve read surface."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    # -- helpers ------------------------------------------------------------
+
+    def _json(self, code: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _bytes(self, code: int, raw: bytes) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        try:
+            return json.loads(raw or b"{}")
+        except ValueError:
+            return {}
+
+    # -- PUT: the CAS object store ------------------------------------------
+
+    def do_PUT(self) -> None:  # noqa: N802
+        srv = self.server
+        digest = urllib.parse.urlparse(self.path).path.rsplit("/", 1)[-1]
+        n = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(n) if n else b""
+        # The digest is signed into the grant, so the STORE refuses bytes that
+        # do not hash to it. Integrity must never depend on the sender being
+        # honest — this is the property the whole chunked protocol is for.
+        if hashlib.sha256(body).hexdigest() != digest:
+            self._json(400, {"error": {"code": "digest_mismatch"}})
+            return
+        with srv.lock:  # type: ignore[attr-defined]
+            srv.objects["sha256:" + digest] = body  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    # -- GET: CAS reads + the discover surface ------------------------------
+
+    def do_GET(self) -> None:  # noqa: N802
+        srv = self.server
+        parsed = urllib.parse.urlparse(self.path)
+        path, query = parsed.path, urllib.parse.parse_qs(parsed.query)
+        with srv.lock:  # type: ignore[attr-defined]
+            srv.calls.append((path, dict(query)))  # type: ignore[attr-defined]
+
+        if path.startswith("/cas/"):
+            digest = "sha256:" + path.rsplit("/", 1)[-1]
+            with srv.lock:  # type: ignore[attr-defined]
+                blob = srv.objects.get(digest)  # type: ignore[attr-defined]
+            if blob is None:
+                self._json(404, {"error": {"code": "not_found"}})
+                return
+            self._bytes(200, blob)
+            return
+
+        # aot_cells._discover_inner: GET /api/v1/repos/<repo>/checkpoints
+        if path.endswith("/checkpoints"):
+            repo = path.split("/api/v1/repos/", 1)[-1].rsplit("/checkpoints", 1)[0]
+            with srv.lock:  # type: ignore[attr-defined]
+                items = [
+                    dict(row) for row in srv.checkpoints  # type: ignore[attr-defined]
+                    if row["repo"] == repo
+                ]
+            self._json(200, {"items": [
+                {"checkpoint_id": r["checkpoint_id"],
+                 "updated_at": r["updated_at"],
+                 "metadata": r["metadata"]}
+                for r in items]})
+            return
+
+        # aot_cells._download_artifact_inner: GET /api/v1/repos/<repo>/resolve
+        if path.endswith("/resolve"):
+            repo = path.split("/api/v1/repos/", 1)[-1].rsplit("/resolve", 1)[0]
+            want = (query.get("digest") or [""])[0]
+            with srv.lock:  # type: ignore[attr-defined]
+                row = next(
+                    (r for r in srv.checkpoints  # type: ignore[attr-defined]
+                     if r["repo"] == repo and r["checkpoint_id"] == want), None)
+            if row is None:
+                self._json(404, {"error": {"code": "not_found"}})
+                return
+            self._json(200, {"files": row["files"]})
+            return
+
+        self._json(404, {"error": {"code": "not_found"}})
+
+    # -- POST: the publish protocol -----------------------------------------
+
+    def do_POST(self) -> None:  # noqa: N802
+        srv = self.server
+        path = urllib.parse.urlparse(self.path).path
+        body = self._body()
+        with srv.lock:  # type: ignore[attr-defined]
+            srv.calls.append((path, body))  # type: ignore[attr-defined]
+
+        if path.endswith("/v1/worker/cells/publish-intent"):
+            family = str(body.get("family") or "")
+            with srv.lock:  # type: ignore[attr-defined]
+                srv.intents.append(dict(body))  # type: ignore[attr-defined]
+            self._json(200, {"capability_token": "local-rig-cap",
+                             "repo": f"root/family-{family}"})
+            return
+
+        if path.endswith("/v1/worker/cells/publish-complete"):
+            with slock(srv):
+                srv.completes.append(dict(body))  # type: ignore[attr-defined]
+            self._json(200, {"recorded": True})
+            return
+
+        if path.endswith("/publishes"):
+            files = body.get("files") or []
+            declared: Dict[str, int] = {}
+            for f in files:
+                for c in f.get("chunks") or []:
+                    declared["sha256:" + c["digest"]] = int(c["len"])
+                if not f.get("chunks"):
+                    declared[f["digest"]] = int(f["size_bytes"])
+            need, have = [], []
+            with slock(srv):
+                for digest, size in declared.items():
+                    if digest in srv.objects:  # type: ignore[attr-defined]
+                        have.append(digest)
+                    else:
+                        need.append(self._grant(srv, digest, size))
+                pid = str(uuid.uuid4())
+                srv.sessions[pid] = (declared, dict(body))  # type: ignore[attr-defined]
+            self._json(201, {"publish_id": pid, "have": have, "need": need,
+                             "distinct_objects": len(declared),
+                             "resident_objects": len(have)})
+            return
+
+        if path.endswith("/grants"):
+            pid = path.split("/publishes/")[1].split("/")[0]
+            with slock(srv):
+                declared = (srv.sessions.get(pid) or ({}, {}))[0]  # type: ignore[attr-defined]
+                need = [
+                    self._grant(srv, d, s) for d, s in declared.items()
+                    if d not in srv.objects  # type: ignore[attr-defined]
+                ]
+            self._json(200, {"need": need, "have": []})
+            return
+
+        if path.endswith("/complete"):
+            pid = path.split("/publishes/")[1].split("/")[0]
+            repo = path.split("/api/v1/repos/", 1)[-1].split("/publishes/")[0]
+            with slock(srv):
+                declared, plan = srv.sessions.get(pid) or ({}, {})  # type: ignore[attr-defined]
+                missing = [d for d in declared
+                           if d not in srv.objects]  # type: ignore[attr-defined]
+            if missing:
+                self._json(409, {"status": {
+                    "stage": "repudiated", "terminal": True,
+                    "failure": {"code": "objects_missing", "retryable": False,
+                                "message": f"{len(missing)} object(s) never landed"}}})
+                return
+            checkpoint_id = srv.record_checkpoint(repo, plan)  # type: ignore[attr-defined]
+            self._json(200, {"checkpoint": {"checkpoint_id": checkpoint_id}})
+            return
+
+        self._json(404, {"error": {"code": "not_found"}})
+
+    @staticmethod
+    def _grant(srv: Any, digest: str, size: int) -> dict:
+        return {"digest": digest, "size_bytes": size,
+                "put_url": f"{srv.base}/cas/{digest.split(':', 1)[1]}",
+                "headers": {"x-amz-checksum-sha256": digest}}
+
+
+def slock(srv: Any) -> Any:
+    return srv.lock
+
+
+class LocalCellHub:
+    """A running local hub. ``base`` is what a ``CellPublisher`` /
+    ``aot_cells.discover`` takes as its ``base_url``."""
+
+    def __init__(self) -> None:
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.httpd.lock = threading.Lock()  # type: ignore[attr-defined]
+        self.httpd.objects = {}  # type: ignore[attr-defined]
+        self.httpd.sessions = {}  # type: ignore[attr-defined]
+        self.httpd.calls = []  # type: ignore[attr-defined]
+        self.httpd.intents = []  # type: ignore[attr-defined]
+        self.httpd.completes = []  # type: ignore[attr-defined]
+        self.httpd.checkpoints = []  # type: ignore[attr-defined]
+        self.httpd.base = self.base  # type: ignore[attr-defined]
+        self.httpd.record_checkpoint = self._record_checkpoint  # type: ignore[attr-defined]
+        self._seq = 0
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    # -- state a test reads --------------------------------------------------
+
+    @property
+    def base(self) -> str:
+        host, port = self.httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    @property
+    def intents(self) -> List[dict]:
+        return list(self.httpd.intents)  # type: ignore[attr-defined]
+
+    @property
+    def completes(self) -> List[dict]:
+        return list(self.httpd.completes)  # type: ignore[attr-defined]
+
+    @property
+    def checkpoints(self) -> List[dict]:
+        return list(self.httpd.checkpoints)  # type: ignore[attr-defined]
+
+    @property
+    def calls(self) -> List[Tuple[str, Any]]:
+        return list(self.httpd.calls)  # type: ignore[attr-defined]
+
+    def routes(self) -> List[str]:
+        return [p for p, _ in self.calls]
+
+    # -- the publish -> discover join ---------------------------------------
+
+    def _record_checkpoint(self, repo: str, plan: dict) -> str:
+        """Turn a completed publish into a listable checkpoint.
+
+        This is the join the discover side reads, and it is the ONE place the
+        double has to model hub bookkeeping: the manifest a ``resolve`` returns
+        has to describe the very objects the publish landed, or an adopting
+        worker downloads bytes that hash to nothing.
+        """
+        files = []
+        for f in plan.get("files") or []:
+            digest = str(f.get("digest") or "")
+            chunks = f.get("chunks") or []
+            entry: Dict[str, Any] = {
+                "path": str(f.get("path") or ""),
+                "size_bytes": int(f.get("size_bytes") or 0),
+                "sha256": digest.split(":", 1)[-1] if digest else "",
+                "digest": digest,
+            }
+            if chunks:
+                entry["chunks"] = [
+                    {"sha256": c["digest"], "len": int(c["len"]),
+                     "url": f"{self.base}/cas/{c['digest']}"}
+                    for c in chunks
+                ]
+                entry["chunk_size_bytes"] = int(chunks[0]["len"])
+            else:
+                entry["url"] = f"{self.base}/cas/{digest.split(':', 1)[-1]}"
+            files.append(entry)
+        self._seq += 1
+        checkpoint_id = "sha256:" + hashlib.sha256(
+            f"{repo}/{plan.get('flavor')}/{self._seq}".encode()).hexdigest()
+        row = {
+            "repo": repo,
+            "checkpoint_id": checkpoint_id,
+            "updated_at": f"2026-08-06T00:00:{self._seq:02d}Z",
+            "metadata": dict(plan.get("metadata") or {}),
+            "files": files,
+        }
+        with self.httpd.lock:  # type: ignore[attr-defined]
+            self.httpd.checkpoints.append(row)  # type: ignore[attr-defined]
+        return checkpoint_id
+
+    def artifact_bytes(self) -> int:
+        return sum(len(v) for v in self.httpd.objects.values())  # type: ignore[attr-defined]
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@contextlib.contextmanager
+def local_cell_hub() -> Iterator[LocalCellHub]:
+    hub = LocalCellHub()
+    try:
+        yield hub
+    finally:
+        hub.close()
+
+
+def dump_state(hub: LocalCellHub, path: Optional[Path] = None) -> dict:
+    """Everything the rig's driver reports about the hub leg."""
+    state = {
+        "base": hub.base,
+        "routes": hub.routes(),
+        "intents": hub.intents,
+        "completes": hub.completes,
+        "checkpoints": [
+            {k: v for k, v in row.items() if k != "files"}
+            for row in hub.checkpoints
+        ],
+        "cas_bytes": hub.artifact_bytes(),
+    }
+    if path is not None:
+        Path(path).write_text(json.dumps(state, indent=2, sort_keys=True, default=str))
+    return state
+
+
+__all__ = ["LocalCellHub", "dump_state", "local_cell_hub"]

--- a/tests/harness/tiny_diffusion.py
+++ b/tests/harness/tiny_diffusion.py
@@ -1,0 +1,336 @@
+"""pgw#978: a randomly-initialized latent-diffusion toy, built on this box.
+
+The micro-mint rig needs a model that is *shaped* like the thing the fleet
+mints — a cross-attention denoiser over a 4-channel latent, plus a decoder —
+and is small enough that a whole mint fits inside a 4 GiB cap on a laptop card.
+It must also need NO download: a rig whose first step is a network fetch is a
+rig that stops working on a bad night, and the weights-locality rule
+(Paul, amended 2026-08-06) bounds what may exist on this box by SIZE, so the
+cheapest way to stay inside it is to never fetch anything.
+
+So the checkpoint is *generated*: ``build_checkpoint`` seeds a generator, writes
+the state dict and a small ``config.json``, and the whole tree is under 20 MB.
+Two runs with the same seed produce byte-identical weights, which is what lets a
+cell key mean anything across processes.
+
+What is deliberately REAL here: the module is a ``torch.nn.Module`` with a
+cross-attention block and a timestep embedding, so ``torch.export`` traces
+something with branches, broadcasts and a matmul chain rather than a single
+Linear. What is deliberately fake: there is no text encoder, no tokenizer and no
+scheduler worth the name — the rig measures the MACHINERY, and a real sampler
+would only add wall-clock.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+from torch import nn
+
+#: Latent channels, matching the SD-class convention the declaration mirrors.
+LATENT_CHANNELS = 4
+#: Latent grid the rig exports at. 32x32 is a 256x256 image at the usual /8.
+LATENT_SIZE = 32
+#: Cross-attention context width and its pinned token count.
+CONTEXT_DIM = 64
+TEXT_LEN = 77
+#: Model width. Small enough that a full export + AOTI link is seconds, wide
+#: enough that inductor has a real fusion decision to make.
+WIDTH = 64
+
+#: Fixed, so a checkpoint built twice is byte-identical and a cell key computed
+#: on two boots agrees.
+SEED = 978
+
+WEIGHTS_NAME = "diffusion_pytorch_model.bin"
+CONFIG_NAME = "config.json"
+
+
+class _TimestepEmbedding(nn.Module):
+    """Sinusoidal features -> two Linears. The usual shape, at toy width."""
+
+    def __init__(self, width: int) -> None:
+        super().__init__()
+        self.width = width
+        self.lin1 = nn.Linear(width, width * 2)
+        self.lin2 = nn.Linear(width * 2, width)
+
+    def forward(self, timestep: torch.Tensor) -> torch.Tensor:
+        half = self.width // 2
+        freqs = torch.exp(
+            -torch.arange(half, dtype=torch.float32, device=timestep.device)
+            * (9.21034037 / max(1, half - 1)))
+        angles = timestep.float()[:, None] * freqs[None, :]
+        feats = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        return self.lin2(torch.nn.functional.silu(self.lin1(feats)))
+
+
+class _CrossAttention(nn.Module):
+    """Single-head cross attention from the latent grid onto the context.
+
+    Single-head on purpose: the rig is measuring export/compile/publish, and a
+    multi-head reshape adds trace nodes without adding a code path the mint
+    treats differently.
+    """
+
+    def __init__(self, width: int, context_dim: int) -> None:
+        super().__init__()
+        self.scale = width ** -0.5
+        self.to_q = nn.Linear(width, width, bias=False)
+        self.to_k = nn.Linear(context_dim, width, bias=False)
+        self.to_v = nn.Linear(context_dim, width, bias=False)
+        self.to_out = nn.Linear(width, width)
+        self.norm = nn.LayerNorm(width)
+
+    def forward(self, x: torch.Tensor, context: torch.Tensor) -> torch.Tensor:
+        b, c, h, w = x.shape
+        flat = self.norm(x.reshape(b, c, h * w).transpose(1, 2))
+        q = self.to_q(flat)
+        k = self.to_k(context)
+        v = self.to_v(context)
+        attn = torch.softmax((q @ k.transpose(1, 2)) * self.scale, dim=-1)
+        out = self.to_out(attn @ v)
+        return x + out.transpose(1, 2).reshape(b, c, h, w)
+
+
+class TinyUNet(nn.Module):
+    """The denoiser. Signature mirrors diffusers' ``UNet2DConditionModel``:
+    ``(sample, timestep, encoder_hidden_states)`` positionally, which is what
+    the export declaration's input rows bind to.
+    """
+
+    def __init__(
+        self,
+        width: int = WIDTH,
+        context_dim: int = CONTEXT_DIM,
+        latent_channels: int = LATENT_CHANNELS,
+    ) -> None:
+        super().__init__()
+        self.width = width
+        self.context_dim = context_dim
+        self.latent_channels = latent_channels
+        self.conv_in = nn.Conv2d(latent_channels, width, 3, padding=1)
+        self.time_embed = _TimestepEmbedding(width)
+        self.down = nn.Conv2d(width, width, 3, stride=2, padding=1)
+        self.mid_norm = nn.GroupNorm(8, width)
+        self.mid = nn.Conv2d(width, width, 3, padding=1)
+        self.attn = _CrossAttention(width, context_dim)
+        self.up = nn.ConvTranspose2d(width, width, 4, stride=2, padding=1)
+        self.out_norm = nn.GroupNorm(8, width)
+        self.conv_out = nn.Conv2d(width, latent_channels, 3, padding=1)
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        h = self.conv_in(sample)
+        temb = self.time_embed(timestep)[:, :, None, None]
+        h = h + temb
+        skip = h
+        h = self.down(h)
+        h = torch.nn.functional.silu(self.mid_norm(self.mid(h)))
+        h = self.attn(h, encoder_hidden_states)
+        h = self.up(h) + skip
+        return self.conv_out(torch.nn.functional.silu(self.out_norm(h)))
+
+
+class TinyDecoder(nn.Module):
+    """Latent -> pixels. Present so the pipeline has a second component and the
+    rig can prove the mint picks the DECLARED target rather than the first
+    module it finds."""
+
+    def __init__(self, width: int = WIDTH, latent_channels: int = LATENT_CHANNELS) -> None:
+        super().__init__()
+        self.conv_in = nn.Conv2d(latent_channels, width, 3, padding=1)
+        self.up = nn.ConvTranspose2d(width, width, 4, stride=2, padding=1)
+        self.conv_out = nn.Conv2d(width, 3, 3, padding=1)
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        h = torch.nn.functional.silu(self.conv_in(latent))
+        return torch.tanh(self.conv_out(self.up(h)))
+
+
+class TinyDiffusionPipeline:
+    """A diffusers-SHAPED holder: ``.unet`` is the compile target, ``.vae`` is
+    the support object beside it.
+
+    ``from_pretrained`` is the real contract the SDK's slot loader calls, and it
+    reads only from the local tree it is handed — the rig never resolves a hub
+    ref for weights.
+    """
+
+    def __init__(self, unet: TinyUNet, vae: TinyDecoder, source: str = "") -> None:
+        self.unet = unet
+        self.vae = vae
+        self.source = source
+
+    @classmethod
+    def from_pretrained(cls, path: str, **_kw: Any) -> "TinyDiffusionPipeline":
+        root = Path(path)
+        config = json.loads((root / CONFIG_NAME).read_text())
+        unet = TinyUNet(
+            width=int(config["width"]),
+            context_dim=int(config["context_dim"]),
+            latent_channels=int(config["latent_channels"]))
+        vae = TinyDecoder(
+            width=int(config["width"]),
+            latent_channels=int(config["latent_channels"]))
+        state = torch.load(root / WEIGHTS_NAME, map_location="cpu", weights_only=True)
+        unet.load_state_dict(state["unet"])
+        vae.load_state_dict(state["vae"])
+        return cls(unet.eval(), vae.eval(), source=str(root))
+
+    def to(self, device: Any) -> "TinyDiffusionPipeline":
+        self.unet.to(device)
+        self.vae.to(device)
+        return self
+
+    def __call__(
+        self,
+        latents: torch.Tensor,
+        context: torch.Tensor,
+        steps: int = 2,
+    ) -> torch.Tensor:
+        """A two-step Euler-ish loop. Enough to be a forward pass with a real
+        sampler's shape; not enough to cost anything."""
+        x = latents
+        for i in reversed(range(steps)):
+            t = torch.full((x.shape[0],), float(i * 100), device=x.device)
+            x = x - self.unet(x, t, context) / max(1, steps)
+        return self.vae(x)
+
+
+def example_inputs(
+    batch: int = 1,
+    device: str = "cpu",
+    dtype: torch.dtype = torch.float32,
+) -> Dict[str, torch.Tensor]:
+    """One legal call's tensors — the same shapes the declaration states."""
+    gen = torch.Generator().manual_seed(SEED)
+    return {
+        "sample": torch.randn(
+            batch, LATENT_CHANNELS, LATENT_SIZE, LATENT_SIZE, generator=gen,
+        ).to(device=device, dtype=dtype),
+        "timestep": torch.full((batch,), 100.0, device=device, dtype=dtype),
+        "encoder_hidden_states": torch.randn(
+            batch, TEXT_LEN, CONTEXT_DIM, generator=gen,
+        ).to(device=device, dtype=dtype),
+    }
+
+
+#: pgw#978/pgw#981: the env that installs a SYNTHETIC runtime key so a cardless
+#: box can complete the seal, publish and adopt legs.
+SYNTHETIC_RUNTIME_ENV = "PGW978_SYNTHETIC_RUNTIME"
+
+#: The values it installs. Every one is a real fact of a real runtime (an L4 at
+#: sm_89, cuda 13.0) — nothing about how they are COMBINED into a cell key is
+#: faked, which is the same seam `test_aot_mint_pgw723._gpu_runtime` has used
+#: since pgw#723. sm_89 specifically because it is this box's own compute
+#: capability; the box simply cannot execute cu130 today (pgw#981).
+SYNTHETIC_RUNTIME = {
+    "sku": "l4", "sm": "sm_89", "triton": "3.6.0", "cuda": "13.0",
+    "cuda_driver": "13000", "image_digest": "sha256:" + "ab" * 32,
+}
+
+
+def install_synthetic_runtime_if_asked() -> bool:
+    """Patch the runtime PROBES — and nothing else — when the env asks.
+
+    A cell key requires an ``sm``, and a box with no usable CUDA build can state
+    none: the mint refuses at seal with *"cannot state the compute capability
+    (sm) of this runtime; an exported cell has no identity without it"*. That
+    refusal is correct and must stay correct, so this does not weaken it — it
+    supplies the one fact the box cannot measure, exactly the way pgw#723's
+    tests have, and ONLY when explicitly asked.
+
+    What this buys: the seal, publish and adopt legs run at all. Those are where
+    the hub wire and the cross-pod filter live, and skipping them would remove
+    most of what is left after the export. What it costs is stated in the rig's
+    report and must never be implied away — the resulting cell's ``sm`` axis is
+    a claim about a runtime this process is not, so a cell minted this way is a
+    PLUMBING artifact and must never reach a shared namespace.
+
+    Called at endpoint-module import time, which is the only hook the mint child
+    (a fresh interpreter that shares nothing with the parent) offers.
+    """
+    import os
+
+    if str(os.environ.get(SYNTHETIC_RUNTIME_ENV, "")).strip() not in ("1", "true", "yes"):
+        return False
+    import torch as _torch
+
+    from gen_worker import aot_serve, compile_cache
+
+    full = dict(SYNTHETIC_RUNTIME, torch=str(_torch.__version__))
+    compile_cache.runtime_key = lambda: dict(full)  # type: ignore[assignment]
+    aot_serve.runtime_key = lambda: {  # type: ignore[assignment]
+        "sku": full["sku"], "sm": full["sm"], "torch": full["torch"],
+        "cuda": full["cuda"]}
+    return True
+
+
+def build_checkpoint(root: Path, *, seed: int = SEED) -> Path:
+    """Write a deterministic random checkpoint under ``root``; return the tree.
+
+    Idempotent: an existing tree with the same config is left alone, so the rig
+    re-runs without re-serializing.
+    """
+    root = Path(root)
+    config = {
+        "width": WIDTH,
+        "context_dim": CONTEXT_DIM,
+        "latent_channels": LATENT_CHANNELS,
+        "latent_size": LATENT_SIZE,
+        "text_len": TEXT_LEN,
+        "seed": int(seed),
+        "_class_name": "TinyDiffusionPipeline",
+    }
+    cfg_path = root / CONFIG_NAME
+    if cfg_path.is_file() and (root / WEIGHTS_NAME).is_file():
+        try:
+            if json.loads(cfg_path.read_text()) == config:
+                return root
+        except ValueError:
+            pass
+    root.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(int(seed))
+    unet = TinyUNet(WIDTH, CONTEXT_DIM, LATENT_CHANNELS)
+    vae = TinyDecoder(WIDTH, LATENT_CHANNELS)
+    torch.save({"unet": unet.state_dict(), "vae": vae.state_dict()},
+               root / WEIGHTS_NAME)
+    cfg_path.write_text(json.dumps(config, indent=2, sort_keys=True))
+    return root
+
+
+def checkpoint_bytes(root: Path) -> int:
+    """Total size of the built tree — the number the size carve-out bounds."""
+    return sum(p.stat().st_size for p in Path(root).rglob("*") if p.is_file())
+
+
+def parameter_count(module: Optional[nn.Module] = None) -> int:
+    module = module if module is not None else TinyUNet()
+    return sum(p.numel() for p in module.parameters())
+
+
+__all__ = [
+    "CONFIG_NAME",
+    "CONTEXT_DIM",
+    "LATENT_CHANNELS",
+    "LATENT_SIZE",
+    "SEED",
+    "TEXT_LEN",
+    "WEIGHTS_NAME",
+    "WIDTH",
+    "TinyDecoder",
+    "TinyDiffusionPipeline",
+    "TinyUNet",
+    "build_checkpoint",
+    "checkpoint_bytes",
+    "example_inputs",
+    "parameter_count",
+]

--- a/tests/harness/tiny_diffusion.py
+++ b/tests/harness/tiny_diffusion.py
@@ -223,7 +223,7 @@ def example_inputs(
     }
 
 
-#: pgw#978/pgw#981: the env that installs a SYNTHETIC runtime key so a cardless
+#: pgw#978/pgw#983: the env that installs a SYNTHETIC runtime key so a cardless
 #: box can complete the seal, publish and adopt legs.
 SYNTHETIC_RUNTIME_ENV = "PGW978_SYNTHETIC_RUNTIME"
 
@@ -231,7 +231,7 @@ SYNTHETIC_RUNTIME_ENV = "PGW978_SYNTHETIC_RUNTIME"
 #: sm_89, cuda 13.0) — nothing about how they are COMBINED into a cell key is
 #: faked, which is the same seam `test_aot_mint_pgw723._gpu_runtime` has used
 #: since pgw#723. sm_89 specifically because it is this box's own compute
-#: capability; the box simply cannot execute cu130 today (pgw#981).
+#: capability; the box simply cannot execute cu130 today (pgw#983).
 SYNTHETIC_RUNTIME = {
     "sku": "l4", "sm": "sm_89", "triton": "3.6.0", "cuda": "13.0",
     "cuda_driver": "13000", "image_digest": "sha256:" + "ab" * 32,

--- a/tests/harness/tiny_diffusion_endpoint.py
+++ b/tests/harness/tiny_diffusion_endpoint.py
@@ -1,0 +1,166 @@
+"""pgw#978: the endpoint the micro-mint rig mints, in the SDXL shape.
+
+Two things about this module are load-bearing and neither is incidental.
+
+**The slot is a CATALOG slot** — ``Slot(TinyDiffusionPipeline, selected_by="model")``
+with no ``default_checkpoint=``. That is sdxl's shape and it is the shape pgw#969
+died on: the mint child re-runs discovery in a fresh interpreter, so a catalog
+slot rediscovers NOTHING and ``ctx.slots["pipeline"]`` raises unless the parent's
+``MintSlot`` crossed the boundary intact. A rig whose endpoint declared a code
+default would resolve in the child by accident and prove nothing about the wire.
+
+**The handler dereferences ``ctx.slots``.** pgw#828's regression endpoint did the
+same and still missed pgw#969, because its slot had a declared default. Here the
+dereference is over a catalog slot, so the warm forward the mint child runs is
+the exact call that crashed on two L40S pods.
+
+The export declaration is registered at IMPORT time, which is how a real endpoint
+package does it — the mint child imports this module by name off
+``MintRequest.modules`` and the declaration has to already exist when
+``aot_declaration.load_declaration`` looks for the family.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import msgspec
+
+from gen_worker import RequestContext, Resources, Slot, endpoint
+from gen_worker.api.decorators import Compile
+from gen_worker.api.export_contract import (
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+)
+from gen_worker.families.base import GenerationDefaults, family
+
+from harness.tiny_diffusion import (
+    CONTEXT_DIM,
+    LATENT_CHANNELS,
+    LATENT_SIZE,
+    TEXT_LEN,
+    TinyDiffusionPipeline,
+    install_synthetic_runtime_if_asked,
+)
+
+# pgw#981: the mint child is a fresh interpreter, so import time is the only
+# hook the rig has to supply the one runtime fact a cardless box cannot state.
+# No-op unless PGW978_SYNTHETIC_RUNTIME asks; see the function's docstring for
+# what it does and does not buy.
+SYNTHETIC_RUNTIME_INSTALLED = install_synthetic_runtime_if_asked()
+
+FAMILY = "microrig"
+
+#: The pixel shape row the latent grid corresponds to. Part of the cell key's
+#: contract axis, so it is stated once here and nowhere else.
+PIXEL_SHAPE = (LATENT_SIZE * 8, LATENT_SIZE * 8)
+
+#: The CFG batch. Two, because a classifier-free pass is the fleet's real graph
+#: class and a batch-1 export would trace a shape production never runs.
+CFG_BATCH = 2
+
+#: Every ref this process resolved, so the rig can prove WHICH checkpoint the
+#: child traced rather than trusting that it traced one.
+RESOLVED_REFS: List[str] = []
+
+
+@family(FAMILY)
+class MicroRigDefaults(GenerationDefaults, frozen=True):
+    steps: int = 2
+
+
+class RigIn(msgspec.Struct):
+    prompt: str = ""
+    #: ``selected_by="model"`` binds the catalog slot off this field.
+    model: str = ""
+
+
+class RigOut(msgspec.Struct):
+    response: str = ""
+
+
+DECLARATION = Compile(
+    family=FAMILY,
+    targets=("unet",),
+    shapes=(PIXEL_SHAPE,),
+    # A pinned text length, declared rather than discovered — the ie#544 axis.
+    text_len=TEXT_LEN,
+    dims=(Dim("B", carried_by=(
+        ("sample", 0), ("timestep", 0), ("encoder_hidden_states", 0))),),
+    classes=(GraphClass(dims={"B": CFG_BATCH}),),
+    inputs=(
+        Input("sample", shape=("B", LATENT_CHANNELS, LATENT_SIZE, LATENT_SIZE),
+              dtype="float32"),
+        Input("timestep", shape=("B",), dtype="float32", value=100.0),
+        Input("encoder_hidden_states", shape=("B", TEXT_LEN, CONTEXT_DIM),
+              dtype="float32"),
+    ),
+    shape_strategy="static-rows",
+    # Measured, never defaulted: whether pre-warm changes the traced graph is a
+    # per-family FACT (sdxl False, z-image True). The toy pipeline has no
+    # pre-warm at all, so False is the measurement rather than a guess.
+    warm_changes_key=False,
+)
+
+register_export_declaration(DECLARATION, replace=True)
+
+
+@endpoint(
+    models={"pipeline": Slot(TinyDiffusionPipeline, selected_by="model")},
+    compile=Compile(
+        family=FAMILY, targets=("unet",), shapes=(PIXEL_SHAPE,),
+        text_len=TEXT_LEN),
+    resources=Resources(gpu=True),
+)
+class MicroRigEndpoint:
+    def setup(self, pipeline: TinyDiffusionPipeline) -> None:
+        self.pipe = pipeline
+
+    def rig_generate(
+        self, ctx: RequestContext[MicroRigDefaults], data: RigIn,
+    ) -> RigOut:
+        """The pgw#969 call, verbatim in shape: the FIRST thing a warm forward
+        does is dereference the catalog slot. A child that was handed bytes and
+        no identity dies here, 0.0 s in, exactly as production did."""
+        import torch
+
+        from harness.tiny_diffusion import example_inputs
+
+        resolved = ctx.slots["pipeline"]
+        RESOLVED_REFS.append(str(resolved.ref.path))
+        device = next(self.pipe.unet.parameters()).device
+        batch = CFG_BATCH
+        tensors = example_inputs(batch=batch, device=str(device))
+        with torch.no_grad():
+            out = self.pipe.unet(
+                tensors["sample"], tensors["timestep"],
+                tensors["encoder_hidden_states"])
+        return RigOut(response=f"{resolved.ref.path}|{tuple(out.shape)}")
+
+
+def reset() -> None:
+    RESOLVED_REFS.clear()
+
+
+def checkpoint_root() -> str:
+    """Where the rig put the generated tree. Env-carried because the mint child
+    is a fresh interpreter that shares nothing else with the parent."""
+    return os.environ.get("PGW978_CHECKPOINT", "")
+
+
+__all__ = [
+    "CFG_BATCH",
+    "DECLARATION",
+    "FAMILY",
+    "PIXEL_SHAPE",
+    "RESOLVED_REFS",
+    "MicroRigDefaults",
+    "MicroRigEndpoint",
+    "RigIn",
+    "RigOut",
+    "checkpoint_root",
+    "reset",
+]

--- a/tests/harness/tiny_diffusion_endpoint.py
+++ b/tests/harness/tiny_diffusion_endpoint.py
@@ -46,7 +46,7 @@ from harness.tiny_diffusion import (
     install_synthetic_runtime_if_asked,
 )
 
-# pgw#981: the mint child is a fresh interpreter, so import time is the only
+# pgw#983: the mint child is a fresh interpreter, so import time is the only
 # hook the rig has to supply the one runtime fact a cardless box cannot state.
 # No-op unless PGW978_SYNTHETIC_RUNTIME asks; see the function's docstring for
 # what it does and does not buy.

--- a/tests/test_micro_mint_rig_pgw978.py
+++ b/tests/test_micro_mint_rig_pgw978.py
@@ -82,7 +82,7 @@ def test_the_rig_refuses_to_run_with_the_host_move_guard_off(
 
 
 def test_the_device_is_resolved_and_reported_never_assumed() -> None:
-    """pgw#981: this box's driver is CUDA 12.8 and the pinned torch is cu130, so
+    """pgw#983: this box's driver is CUDA 12.8 and the pinned torch is cu130, so
     the rig falls back to CPU — and must SAY which coverage it lost. A report
     whose green line implies device coverage it never had is the failure this
     field exists to prevent."""
@@ -205,7 +205,7 @@ def test_the_full_machinery_cycle_runs_on_this_box(tmp_path: Path) -> None:
     phases = mint.facts["phase_seconds"]
     # The child really loaded the endpoint through `run_setup` — not a stub.
     assert float(phases.get("load", 0.0)) > 0.0
-    # ...and really traced + compiled. pgw#982: the AOT recipe emits
+    # ...and really traced + compiled. pgw#984: the AOT recipe emits
     # `trace_graph`/`seal_publish`/`finalize` and NO `warmup_forward`, because
     # it exports rather than capturing a warm run. Asserting `warmup_forward`
     # here would be asserting a phase this recipe does not have.

--- a/tests/test_micro_mint_rig_pgw978.py
+++ b/tests/test_micro_mint_rig_pgw978.py
@@ -1,0 +1,284 @@
+"""pgw#978 — the local micro-mint rig, as a row.
+
+LOCAL-ONLY by classification, not by accident. CI has no GPU and no card-side
+anything, and `scripts/skip_census.txt` carries these rows as `LOCAL-ONLY` so a
+green CI never reads as coverage of them (pgw#966). Run them by hand:
+
+    pytest tests/test_micro_mint_rig_pgw978.py -m localrig -p no:randomly
+
+The rig's own driver (`scripts/micro_mint_rig.py`) is the thing under test. That
+is deliberate: the driver is what a developer actually runs in the loop, so a
+test that reimplemented the cycle beside it would drift from the thing it claims
+to guard, and the first person to notice would be on a pod.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+torch = pytest.importorskip("torch")
+
+#: pgw#966: the full cycle is OPT-IN, and its skip reason is stable so
+#: `scripts/skip_census.txt` can classify it LOCAL-ONLY. Everything else in this
+#: file is pure Python and RUNS IN CI — the gates, the carve-out bounds, the
+#: handoff round-trip and the probe disarm are exactly the rows that must not
+#: rot, and none of them needs a card.
+RIG_OPT_IN = "PGW978_RIG"
+_CYCLE_REASON = (
+    "the pgw#978 micro-mint rig is opt-in: it runs a full local mint cycle "
+    "(set PGW978_RIG=1)")
+
+
+def _rig():
+    import micro_mint_rig as rig
+
+    return rig
+
+
+def _gate() -> None:
+    """The rig's own gates, applied to the test session.
+
+    A row that ran the box over its load ceiling would be the same defect the
+    rig refuses in its driver, so the refusal is honoured here rather than
+    routed around with `--force-load`.
+    """
+    rig = _rig()
+    try:
+        rig.assert_load_gate()
+        rig.assert_host_move_guard()
+    except rig.RigRefused as exc:
+        pytest.skip(f"micro-rig gate: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# The gates are real refusals, and they are cheap to prove
+# ---------------------------------------------------------------------------
+
+
+def test_the_load_gate_refuses_a_busy_box() -> None:
+    """The box is shared with several agent sessions; a compile started at load
+    30 makes everyone slower including itself."""
+    rig = _rig()
+    with pytest.raises(rig.RigRefused, match="load"):
+        rig.assert_load_gate(limit=-1.0)
+
+
+def test_the_rig_refuses_to_run_with_the_host_move_guard_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A green cycle under a configuration production forbids is worse than no
+    cycle. `GEN_WORKER_HOST_MOVE_GUARD=0` is a refusal, never a warning."""
+    rig = _rig()
+    monkeypatch.setenv("GEN_WORKER_HOST_MOVE_GUARD", "0")
+    with pytest.raises(rig.RigRefused, match="HOST_MOVE_GUARD"):
+        rig.assert_host_move_guard()
+
+
+def test_the_device_is_resolved_and_reported_never_assumed() -> None:
+    """pgw#981: this box's driver is CUDA 12.8 and the pinned torch is cu130, so
+    the rig falls back to CPU — and must SAY which coverage it lost. A report
+    whose green line implies device coverage it never had is the failure this
+    field exists to prevent."""
+    rig = _rig()
+    dev = rig.resolve_device("auto")
+    assert dev["device_kind"] in ("cuda", "cpu")
+    assert dev["covers"]
+    if dev["device_kind"] == "cpu":
+        assert "NO VRAM cap" in dev["covers"]
+        assert dev["why_not_cuda"]
+
+
+# ---------------------------------------------------------------------------
+# The toy checkpoint stays inside the policy carve-out
+# ---------------------------------------------------------------------------
+
+
+def test_the_generated_checkpoint_stays_under_the_carve_out_ceiling(
+    tmp_path: Path,
+) -> None:
+    """The workspace policy's local-inference carve-out bounds the rig by SIZE
+    and by ORIGIN. Both are enforced here rather than trusted: the tree is
+    generated, and it is small."""
+    from harness.tiny_diffusion import build_checkpoint, checkpoint_bytes
+
+    rig = _rig()
+    tree = build_checkpoint(tmp_path / "ckpt")
+    size = checkpoint_bytes(tree)
+    assert 0 < size < rig.MAX_WEIGHTS_BYTES
+    # Deterministic: two builds agree, which is what lets a cell key mean
+    # anything across the two processes the rig runs.
+    again = build_checkpoint(tmp_path / "ckpt2")
+    assert checkpoint_bytes(again) == size
+
+
+def test_the_device_budget_is_split_rather_than_assumed() -> None:
+    """Two processes on one card must agree on the division up front. A leg
+    written against 'the whole card' is how a co-resident pair OOMs the one that
+    was merely second."""
+    rig = _rig()
+    assert rig.MINT_VRAM_BYTES + rig.ADOPT_VRAM_BYTES == rig.RIG_VRAM_BUDGET_BYTES
+    assert rig.MINT_VRAM_BYTES > 0 and rig.ADOPT_VRAM_BYTES > 0
+
+
+# ---------------------------------------------------------------------------
+# The handoff is the real one — this is the pgw#969 guard
+# ---------------------------------------------------------------------------
+
+
+def test_a_slot_with_bytes_and_no_identity_cannot_reach_the_child() -> None:
+    """pgw#969/pgw#974 in one row, at rig cost.
+
+    The production crash was a request carrying a slot's PATH and no REF: it
+    decoded, type-checked and looked complete, and the child died 0.0 s into
+    `warmup_forward` at `ctx.slots["pipeline"]` on two L40S pods. The rig builds
+    its slot through the real `MintSlot`, so the shape is unconstructable — and
+    this row is what proves the rig did not route around the guard by
+    hand-rolling a dict.
+    """
+    from gen_worker.mint_process import MintSlot
+
+    with pytest.raises(TypeError):
+        MintSlot(path="/tmp/x")  # type: ignore[call-arg]  # no ref
+
+
+def test_the_request_the_rig_hands_the_child_carries_a_resolved_slot(
+    tmp_path: Path,
+) -> None:
+    """Built through `mint_delegate.build_request` — the REAL parent chain, not
+    a hand-written `MintRequest`. A hand-written request is the one shape the
+    handoff can never produce, so it could not catch a handoff defect."""
+    import msgspec
+
+    from gen_worker.mint_process import MintRequest
+    from harness.tiny_diffusion import build_checkpoint
+
+    rig = _rig()
+    tree = build_checkpoint(tmp_path / "ckpt")
+    request = rig._mint_request(
+        tmp_path / "mint", tree, tmp_path / "capture", ordinal=-1, cap_bytes=0)
+    # The boundary IS a JSON file, so round-trip it the way the child will.
+    raw = msgspec.json.encode(request)
+    decoded = msgspec.json.decode(raw, type=MintRequest)
+    assert set(decoded.slots) == {"pipeline"}
+    slot = decoded.slots["pipeline"]
+    assert slot.ref.path == "rig/tiny-diffusion"
+    assert slot.path == str(tree)
+    assert decoded.recipe == "aot"
+    assert decoded.family == "microrig"
+
+
+# ---------------------------------------------------------------------------
+# The cycle itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.localrig
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get(RIG_OPT_IN), reason=_CYCLE_REASON)
+def test_the_full_machinery_cycle_runs_on_this_box(tmp_path: Path) -> None:
+    """resolve -> handoff -> spawn -> load -> warm -> export -> seal -> publish
+    -> adopt, end to end, in one process tree on this machine.
+
+    This is the row that replaces four hours of publish/build/buy. Every leg is
+    the production path; the only stand-ins are the hub (a local double speaking
+    the real wire) and the model (generated, tiny, and never served to anyone).
+    """
+    _gate()
+    rig = _rig()
+    result = rig.run_cycle(tmp_path / "rig")
+
+    names = [leg.name for leg in result.legs]
+    assert names == ["gates", "weights", "handoff", "mint-child", "publish", "adopt"], (
+        "a cycle that stops early must fail loudly, not silently report fewer legs: "
+        + "\n".join(leg.line() for leg in result.legs))
+    assert result.ok, "\n" + result.report()
+
+    mint = next(leg for leg in result.legs if leg.name == "mint-child")
+    phases = mint.facts["phase_seconds"]
+    # The child really loaded the endpoint through `run_setup` — not a stub.
+    assert float(phases.get("load", 0.0)) > 0.0
+    # ...and really traced + compiled. pgw#982: the AOT recipe emits
+    # `trace_graph`/`seal_publish`/`finalize` and NO `warmup_forward`, because
+    # it exports rather than capturing a warm run. Asserting `warmup_forward`
+    # here would be asserting a phase this recipe does not have.
+    assert float(phases.get("trace_graph", 0.0)) > 0.0
+    assert float(phases.get("seal_publish", 0.0)) > 0.0
+    assert mint.facts["cell_key"], "the child sealed no cell key"
+
+    publish = next(leg for leg in result.legs if leg.name == "publish")
+    routes = publish.facts["routes"]
+    # The real seven-call publish protocol, not a one-shot POST.
+    assert any(r.endswith("/publish-intent") for r in routes)
+    assert any(r.endswith("/publishes") for r in routes)
+    assert any(r.endswith("/complete") for r in routes)
+    assert any(r.endswith("/publish-complete") for r in routes)
+    assert publish.facts["cas_bytes"] > 0, "no cell bytes reached the store"
+
+    adopt = next(leg for leg in result.legs if leg.name == "adopt")
+    assert adopt.facts["pid"] != os.getpid(), (
+        "the adopt must run in a SECOND process — in-process adoption proves "
+        "nothing about a cell crossing pods")
+    assert adopt.facts["cell_key"] == mint.facts["cell_key"], (
+        "the cell the second process adopted is not the cell the first minted")
+
+
+# ---------------------------------------------------------------------------
+# pgw#980: the probe's publish disarm is structural
+# ---------------------------------------------------------------------------
+
+
+def test_a_probe_pod_cannot_publish_a_cell(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A live-edit probe runs rsync'd code whose `gen_worker` version lies and
+    whose `code_closure` no other pod can reproduce. Publishing from it would
+    poison every pod that later adopts — so the refusal lives in the PARENT's
+    action allowlist, which nothing swapped into the child can reach."""
+    from gen_worker.procsplit import actions
+
+    monkeypatch.setenv("GEN_WORKER_PROBE", "1")
+    monkeypatch.delenv("GEN_WORKER_PROBE_PUBLISH_ARMED", raising=False)
+    for path in ("/v1/worker/cells/publish-intent",
+                 "/v1/worker/cells/publish-complete"):
+        with pytest.raises(actions.ActionRefused, match="disarmed"):
+            actions.authorize({"method": "POST", "path": path, "json": {}})
+    # Discovery is untouched: a probe must still be able to ADOPT.
+    action, _q, _b = actions.authorize({
+        "method": "GET", "path": "/api/v1/repos/root/family-microrig/checkpoints",
+        "query": {"limit": "50"}})
+    assert action.name == "repo.checkpoints"
+
+
+def test_arming_a_probes_publish_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two names, not one truthy flag: 'this is a probe' and 'this probe may
+    write to the store' are different decisions, and the second must never be
+    reachable by forgetting the first."""
+    from gen_worker.procsplit import actions
+
+    monkeypatch.setenv("GEN_WORKER_PROBE", "1")
+    monkeypatch.setenv("GEN_WORKER_PROBE_PUBLISH_ARMED", "1")
+    action, _q, _b = actions.authorize({
+        "method": "POST", "path": "/v1/worker/cells/publish-intent",
+        "json": {"family": "microrig", "cell_key": "ck5-" + "a" * 56,
+                 "axes": {}, "identity_axes": {}, "mint_duration_ms": 1}})
+    assert action.name == "cells.publish_intent"
+
+
+def test_a_normal_pod_is_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard must cost a serving pod nothing. No probe marking, no change."""
+    from gen_worker.procsplit import actions
+
+    monkeypatch.delenv("GEN_WORKER_PROBE", raising=False)
+    monkeypatch.delenv("GEN_WORKER_PROBE_PUBLISH_ARMED", raising=False)
+    assert not actions.publish_disarmed()
+    action, _q, _b = actions.authorize({
+        "method": "POST", "path": "/v1/worker/cells/publish-complete",
+        "json": {"family": "microrig", "cell_key": "ck5-" + "a" * 56,
+                 "checkpoint_id": "sha256:" + "b" * 64, "ok": True}})
+    assert action.name == "cells.publish_complete"


### PR DESCRIPTION
Paul, 2026-08-06: *"we want to release new versions of python-gen-worker to pypi only after we've proven they work."* and *"yeah I'm down for this. please work on this; it should accelerate development a lot, so that we discover more problems as we go."*

## The loop this replaces

change code → publish to PyPI → build an image on the published version → spawn a pod → observe **for the first time**. Attempt twenty burned ~4 h of it to learn one `ValueError` that fired 0.0 s into `warmup_forward`. Nine of that arc's twelve walls were plumbing.

## pgw#978 — `task rig:mint`

One command, ~21 s, on this box. Every leg is the production path:

| leg | measured |
|---|---|
| resolve → a real `MintSlot` | — |
| handoff via `mint_delegate.build_request` → a JSON file | 0.10 s |
| **a real `mint_process` child interpreter** | spawned |
| `run_setup` on a real endpoint the child rediscovered | 5.1 s |
| **real `torch.export`** | 0.79 s |
| **real AOTInductor compile + link** | 12.6 s |
| seal → a real ck5 key | 1.1 s |
| **real `CellPublisher` wire** to a local hub (4-call protocol) | 0.19 s |
| **a SECOND OS process** adopting via real `aot_cells.discover` | 1.65 s |

The adopting process returns the same `ck5-72865e63…` key the child sealed.

The model is generated on the box (1.0 MB, **no download**). The hub is a double speaking the real wire — including the store's digest refusal, which is the property the chunked protocol exists for.

### It enforces its carve-out rather than documenting it

Paul amended his own local-inference rule the same day (recorded in `WORKSPACE-GIT-POLICY.md`). The driver refuses to start outside it: generated weights under 500 MB, a 4 GiB device budget **split explicitly** across processes, `nice`, a load gate at 1-min load 24, and a hard refusal on `GEN_WORKER_HOST_MOVE_GUARD=0`.

### It reports the coverage it did NOT get

`resolve_device` falls back to CPU and says exactly what that costs (no VRAM cap, no placement, no measured kernel lane). `--device cuda` turns the fallback into a named refusal. A green line that implies device coverage it never had is the failure this field prevents.

## pgw#980 — the live-edit probe cannot publish

`scripts/probe_sync.sh` rsyncs `src/gen_worker` onto a held pod and respawns its compute child. Weights never move; only code does.

`GEN_WORKER_PROBE=1` removes `cells.publish_intent` / `cells.publish_complete` from the **parent's** action allowlist. The compute child holds no credential and reaches the hub only through that allowlist, so **nothing rsync'd into the child can re-arm publishing** — the guard runs in the one process the swapped code cannot touch. Arming is a second, separate env (`GEN_WORKER_PROBE_PUBLISH_ARMED=1`). Discovery is deliberately untouched: a probe must still be able to *adopt*.

Why it matters: a probe's mints carry a `gen_worker` version read from dist-info, which rsync does not move and which therefore lies, plus a `code_closure` axis no other pod can reproduce.

Also named in the script and the doc: **SIGTERM is the wrong respawn signal** — the child installs it as `lifecycle.start_drain`, which takes the whole pod down. `kill -9` is what the supervision loop recovers from.

## Testing

- `11 passed` including the full cycle (`PGW978_RIG=1`).
- The full cycle is opt-in everywhere including CI and classified **LOCAL-ONLY** in `scripts/skip_census.txt` (pgw#966) — a cardless runner must never read it as coverage. `scripts/lint_skip_census.py` is green on it.
- The gates, the carve-out bounds, the handoff round-trip and the probe disarm are pure Python and **run in CI**.
- The disarm rows were **RED-verified** against the unmodified allowlist (2 failed → pass).

## What the first cycles already found

Filed separately: pgw#983 (this box cannot execute the pinned cu130 torch), pgw#984 (the AOT recipe never runs the endpoint's warm plan), pgw#985 (the dynamo path classifies a deterministic no-compile-target as `crashed`, so the parent retries it).