### PR TITLE
pgw#868 A4: the pool measures the per-entry device peak, then sizes K off it

### DIFF
--- a/changelog.d/pgw868-a4.md
+++ b/changelog.d/pgw868-a4.md
@@ -1,0 +1,52 @@
+- **pgw#868 A4: the compile pool sized K off an estimate and then measured the
+  truth and threw it away.** `aot_compile_pool.entry_workers` runs before a
+  single entry has compiled, so the only per-entry device figure available to
+  it is `mint_budget.co_residency().need_bytes` — the MINT CHILD's whole
+  co-residency footprint (a full weight copy, an activation set nothing
+  observed, two flat constants), spent as ONE entry child's ask. pgw#877
+  measured that ~56 % of that number was never observed and renamed its basis
+  from `"measured"` to `"estimated"` for exactly that reason, and left
+  `EntryReport.peak_device_bytes` — the real observation, reported by every
+  entry child and banked by `observe_entry_device` — reading "telemetry only;
+  nothing reads it". Attempt eighteen's sdxl mint therefore ran
+  `K=2, binding=vram, underwidth=6` for all 36 entries against an estimate its
+  own first two entries had already disproved. K is the mint's only
+  multiplicative lever, so this was the largest single item in A4.
+  `EntryCompilePool._rewiden` now re-derives K after each entry lands, dividing
+  the pool's OWN free-VRAM reading by the measured per-entry high-water instead
+  of the estimate. Same question, same readings, same reserves — only the
+  divisor changes, from a guess to an observation.
+- It is fail-closed in six directions, one test each: it never NARROWS (the
+  children are already running); it never exceeds the caller's own `limit`
+  (which is why `limit` is now part of the `PoolWidth` record — an operator who
+  forced the serial path keeps it); it refuses on fewer than two reports, on a
+  zero peak, on a pool with no GPU-benchmark lock (K=1 there is a SAFETY width,
+  not a resource one), and on a pool that never read the card; and anything
+  raising leaves the width untouched. It re-divides `width_initial`'s own free
+  figure rather than re-probing — a probe taken with K children resident would
+  read their footprints as absent capacity and narrow, which is the opposite of
+  the truth, and a test breaks the probe to prove the path never calls it.
+- **No artifact changes.** K is not an input to codegen, kernel selection,
+  shape specialization or the traced graph, and the device lock already
+  serializes the one thing entries share (`benchmark_all_configs`). This is a
+  PROCESS change under pgw#846's rule.
+- `PoolLedger.capacity_s` is now ACCUMULATED at the width live for each
+  interval instead of multiplied out as `wall_s * final_workers` at the end. A
+  K that moves mid-pool would otherwise price the whole run at a width the
+  first entries never had, turning `busy + idle == capacity` into a residual —
+  the one thing that ledger exists not to be. `pool_workers_initial` rides
+  beside `pool_workers` so the prize is readable as a delta from one row.
+- **The mint child never installed its goal set.** `worker_goals.install` is
+  called from `entrypoint` and `procsplit.parent` — both the SERVING parent —
+  and the mint runs in a child spawned as `python -m gen_worker.mint_child`,
+  which installed nothing. So `worker_goals.current()` fell back to
+  `SERVE_ONLY` in the one process that sizes the compile pool, and a mint-only
+  pod held back a tenant VRAM reserve, a serving CPU headroom and a tenant
+  host-RAM reserve for a tenant that cannot reach it: it accepts no dispatch.
+  On a 4-vCPU forge pod the CPU headroom alone is a quarter of the pool. The
+  child now reads the declaration the parent already hands it, off typed
+  `Settings` and never off `os.environ` (§1.18), and a declaration it cannot
+  read is not fatal — it keeps the narrow serve-only fallback, which is what
+  runs today. The goal set is the only thing published; `config.install` is
+  deliberately still not called there, and that gap is recorded rather than
+  fixed blind.

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -64,7 +64,7 @@ from typing import (
 import msgspec
 
 from . import aot_compile_spans, aot_device_lock, aot_resume, env_seal
-from . import worker_goals
+from . import mint_budget, worker_goals
 from .worker_goals import WorkerGoals
 from .postmortem import cpu_quota_cores
 import hashlib
@@ -224,6 +224,18 @@ _POLL_S = 0.25
 DEVICE_FREE_SAMPLES = 3
 DEVICE_FREE_SAMPLE_GAP_S = 0.05
 
+#: Entry children whose DEVICE high-water must be in hand before the pool
+#: re-derives its own K from them (:meth:`EntryCompilePool._rewiden`).
+#:
+#: One is an anecdote. The first round's children start together, so they are
+#: also the ones that miss the shared PCH and the autotune cache, and a width
+#: re-derived from a single unrepresentative child is exactly the "5-vs-3 with
+#: nothing recorded to say why" defect pgw#842 closed. Two is the smallest
+#: number that is a measurement rather than a sample, and on a 36-entry sdxl
+#: cell it arrives after ~6 % of the work — early enough that the other 94 %
+#: is compiled at the measured width.
+REWIDEN_MIN_SAMPLES = 2
+
 
 @dataclass(frozen=True)
 class CpuFacts:
@@ -311,6 +323,12 @@ class PoolWidth:
     #: rather than inferred by diffing two pods that no longer exist.
     binding: str = ""
     ceiling: int = MAX_ENTRY_WORKERS
+    #: The caller's own cap (``entry_workers(limit=)``), 0 when uncapped. It is
+    #: an INPUT that chose K and was the one input this record did not carry —
+    #: which mattered the moment :meth:`EntryCompilePool._rewiden` began
+    #: re-deriving K mid-mint: an operator who forced the serial path must not
+    #: have it widened back out from under them by a later measurement.
+    limit: int = 0
     cpu: Optional[CpuFacts] = None
     memory: Optional[MemoryFacts] = None
     device: Optional[DeviceFacts] = None
@@ -359,6 +377,7 @@ class PoolWidth:
             "device_lock": bool(self.device_lock),
             "binding": self.binding,
             "ceiling": int(self.ceiling),
+            "limit": int(self.limit),
             "underwidth": int(self.underwidth),
             "per_entry_device_basis": self.per_entry_device_basis,
             "per_entry_rss_basis": self.per_entry_rss_basis,
@@ -615,6 +634,7 @@ def entry_workers(
             per_entry_rss_bytes=0, per_entry_device_bytes=0,
             per_entry_rss_basis="not-read", per_entry_device_basis="not-read",
             device_lock=locked, binding="entries", ceiling=1,
+            limit=max(0, int(limit)),
             serve_goal=goals.serve, mint_goal=goals.mint,
             reason=(
                 f"{entries} entr{'y' if entries == 1 else 'ies'}: serial "
@@ -706,6 +726,7 @@ def entry_workers(
             memory=memory, device=device,
             per_entry_device_basis=device_basis,
             per_entry_rss_basis=rss_basis,
+            limit=max(0, int(limit)),
             serve_goal=goals.serve, mint_goal=goals.mint)
 
     workers = max(
@@ -758,9 +779,10 @@ class EntryReport(msgspec.Struct, frozen=True, kw_only=True):
     elapsed_s: float = 0.0
     peak_rss_bytes: int = 0
     #: pgw#868 A4: the child's DEVICE high-water, allocated and reserved.
-    #: Defaulted so an older child's report still decodes. Telemetry only —
-    #: `entry_workers` still sizes off `mint_budget.co_residency`, and
-    #: replacing an estimate with this measurement is a SEPARATE change.
+    #: Defaulted so an older child's report still decodes. No longer telemetry
+    #: only: `EntryCompilePool._rewiden` divides the pool's own free-VRAM
+    #: reading by THIS, once two children have reported one, in place of the
+    #: `mint_budget.co_residency` estimate the pool was constructed with.
     peak_device_bytes: int = 0
     peak_device_reserved_bytes: int = 0
     #: Inductor's own phase split (lowering / codegen / host C++ compile+link)
@@ -870,6 +892,12 @@ class PoolLedger:
     """
 
     workers: int = 1
+    #: pgw#868 A4: the width the pool was CONSTRUCTED at, kept beside the one
+    #: it finished at. When ``_rewiden`` replaces an estimated per-entry device
+    #: ask with a measured one, ``workers`` moves and this does not — so the
+    #: prize is readable as a delta from one row, without a second mint to
+    #: compare against.
+    workers_initial: int = 1
     wall_s: float = 0.0
     #: Sum of the per-entry Popen-to-reap walls (== the mint's ``compile_s``).
     busy_s: float = 0.0
@@ -930,6 +958,7 @@ class PoolLedger:
             "seal_seed_s": round(self.seal_seed_s, 3),
             "pool_entries": int(self.entries),
             "pool_workers": int(self.workers),
+            "pool_workers_initial": int(self.workers_initial),
             **dict(self.resume),
         }
 
@@ -1190,6 +1219,14 @@ class EntryCompilePool:
         #: it, so the per-entry device ask stayed the mint child's whole
         #: co-residency estimate. This is the number that ends that.
         self.peak_device_bytes = 0
+        #: How many entry children have contributed one. `_rewiden` refuses to
+        #: act on fewer than :data:`REWIDEN_MIN_SAMPLES`.
+        self.device_samples = 0
+        #: The width the pool was CONSTRUCTED with, kept whole. `_rewiden`
+        #: re-derives against this record's own free-VRAM and host-RAM
+        #: readings — the same question, a measured divisor — so the initial
+        #: row has to survive being superseded.
+        self.width_initial = width
         self.peak_concurrency = 0
         # pgw#848: the kernel's OOM-kill counter as it stood before this pool
         # ran. A DELTA over the pool's own wall is evidence; the absolute
@@ -1210,7 +1247,8 @@ class EntryCompilePool:
         self.entry_spawn_seconds: Dict[str, float] = {}
         self.entry_overlays: Dict[str, Dict[str, float]] = {}
         self.entry_metrics_raw: Dict[str, Dict[str, float]] = {}
-        self.ledger = PoolLedger(workers=int(width.workers))
+        self.ledger = PoolLedger(
+            workers=int(width.workers), workers_initial=int(width.workers))
 
     # -- staging ----------------------------------------------------------
 
@@ -1292,7 +1330,6 @@ class EntryCompilePool:
         # a multi-GB write (~16 s at 2.5 GB) and a freed slot that had to wait
         # for one would idle a core through every round; one spare removes
         # that without turning an 18-entry sdxl cell into ~46 GB on disk.
-        staged_cap = max(1, self.width.workers + INFLIGHT_PROGRAM_SLACK)
         failure: Optional[EntryCompileFailed] = None
         # pgw#830: exact idle accounting. Every wall second is multiplied by
         # the number of FREE worker slots at that moment and charged to
@@ -1314,10 +1351,22 @@ class EntryCompilePool:
             if free > 0:
                 setattr(self.ledger, bucket,
                         getattr(self.ledger, bucket) + (now - mark) * free)
+            # pgw#868 A4: capacity is ACCUMULATED at the width that was live
+            # for each interval, not multiplied out at the end. `_rewiden` can
+            # move K mid-pool, and `wall_s * final_workers` would then price
+            # the whole run at a width the first entries never had — turning
+            # the efficiency identity (busy + idle == capacity) into a
+            # residual nobody can trust, which is the one thing this ledger
+            # exists not to be.
+            self.ledger.capacity_s += (now - mark) * self.width.workers
             mark = now
 
         try:
             while pending or staged or running:
+                # Re-read every round: `_rewiden` can widen K after an entry
+                # lands, and a staging cap frozen at the construction width
+                # would starve the slots it just opened.
+                staged_cap = max(1, self.width.workers + INFLIGHT_PROGRAM_SLACK)
                 while (pending and not failure
                        and len(staged) + len(running) < staged_cap):
                     index, name, program = pending.pop(0)
@@ -1355,6 +1404,10 @@ class EntryCompilePool:
                 except EntryCompileFailed as exc:
                     failure = exc
                     break
+                # pgw#868 A4: this entry's own DEVICE high-water is now banked
+                # (`_collect` -> `observe_entry_device`). Ask K again with the
+                # measurement in place of the estimate the pool was built on.
+                self._rewiden()
                 if on_entry is not None:
                     try:
                         on_entry(finished.entry, len(done), len(entries))
@@ -1372,8 +1425,10 @@ class EntryCompilePool:
         finally:
             self.ledger.wall_s = round(time.monotonic() - pool_t0, 3)
             self.ledger.busy_s = round(sum(self.entry_seconds.values()), 3)
-            self.ledger.capacity_s = round(
-                self.ledger.wall_s * self.width.workers, 3)
+            # Closed at the LIVE width for the final interval, then rounded —
+            # `charge` has been accumulating it all along (see there).
+            charge("idle_other_s", 0)
+            self.ledger.capacity_s = round(self.ledger.capacity_s, 3)
             for row in running:
                 _terminate_group(row.proc)
             self._sweep()
@@ -1567,6 +1622,95 @@ class EntryCompilePool:
             or int(report.peak_device_bytes or 0)
         if peak > 0:
             self.peak_device_bytes = max(self.peak_device_bytes, peak)
+            self.device_samples += 1
+
+    def _rewiden(self) -> None:
+        """Re-derive K from what the entry children MEASURED (pgw#868 A4).
+
+        pgw#809 sizes the pool before a single entry has run, and the only
+        per-entry device figure available then is
+        ``mint_budget.co_residency().need_bytes`` — the MINT CHILD's whole
+        co-residency estimate (a full weight copy, an activation set the
+        estimate never observed, and two flat constants), used as ONE entry
+        child's ask. pgw#877 measured that ~56 % of it was never observed and
+        renamed its basis from ``"measured"`` to ``"estimated"`` for exactly
+        that reason. Every entry child since has reported what it actually
+        peaked at, :meth:`observe_entry_device` has banked it, and nothing
+        read it: an sdxl cell spent 34 more entries at a width chosen by an
+        estimate its own first two entries had already disproved.
+
+        This asks the SAME question against the SAME readings — only the
+        divisor changes, from an estimate to an observation. That is the
+        pgw#847 shape (delete a guess, keep the computation), not a new
+        policy: no reserve moves, no ceiling moves, no bound is invented.
+
+        Fail-closed, in five directions:
+
+        * it never NARROWS. Children are already running against the wider
+          number, and a mid-flight dip is the reading ``device_facts`` takes a
+          max over precisely so it cannot be acted on;
+        * it never exceeds the caller's own ``limit`` — an operator who forced
+          the serial path keeps it;
+        * it refuses on fewer than :data:`REWIDEN_MIN_SAMPLES` reports, on a
+          zero peak, and on a pool whose device lock is absent (``K=1`` there
+          is a safety width, not a resource one);
+        * it re-derives against ``width_initial``'s OWN free-VRAM and host-RAM
+          figures rather than re-probing a card that K running children are
+          sitting on — re-probing would read their footprints as absent
+          capacity and narrow, which is the opposite of the truth;
+        * anything raising leaves the width exactly as it was.
+
+        It changes no artifact. K is not an input to codegen, kernel selection
+        or the traced graph — the device lock already serializes the one thing
+        that is shared (``benchmark_all_configs``) — so this is a PROCESS
+        change under pgw#846's rule, and the emitted files are untouched.
+        """
+        if self.device_samples < REWIDEN_MIN_SAMPLES:
+            return
+        if self.peak_device_bytes <= 0 or not self.width.device_lock:
+            return
+        base = self.width_initial
+        if base.free_device_bytes <= 0:
+            # The initial width never read the card (`entries <= 1`, or an
+            # absent probe). There is nothing to re-divide, and inventing a
+            # free figure here is the guess this method exists to delete.
+            return
+        try:
+            ask = mint_budget.entry_device_ask(int(self.peak_device_bytes))
+            if ask <= 0:
+                return
+            wider = entry_workers(
+                base.entries,
+                limit=base.limit,
+                device_bytes=ask,
+                device_basis="measured",
+                free_vram_bytes=int(base.free_device_bytes),
+                available_bytes=int(base.available_bytes),
+                vcpus=int(base.vcpus),
+                peak_rss_bytes=int(self.peak_rss_bytes or 0),
+                device_lock=base.device_lock,
+                # Reconstructed from the record rather than re-read: the
+                # re-derivation must run the policy the pool was BUILT under,
+                # not whatever a later `install()` published.
+                goals=WorkerGoals(
+                    serve=base.serve_goal, mint=base.mint_goal),
+            )
+        except Exception:  # noqa: BLE001 — a re-derivation never fails a mint
+            logger.debug("aot-pool: width re-derivation failed", exc_info=True)
+            return
+        if wider.workers <= self.width.workers:
+            return
+        logger.info(
+            "aot-pool: pgw#868 A4 K %d -> %d — per-entry device ask measured "
+            "at %.2f GiB over %d entr%s against the %.2f GiB (%s) the pool "
+            "was sized with",
+            self.width.workers, wider.workers, ask / 1024**3,
+            self.device_samples, "y" if self.device_samples == 1 else "ies",
+            base.per_entry_device_bytes / 1024**3,
+            base.per_entry_device_basis)
+        self.width = wider
+        self.ledger.workers = wider.workers
+        self._emit_width("re-derived from measured entry peaks")
 
     def _collect(self, row: _Running) -> List[str]:
         elapsed = time.monotonic() - row.started

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -62,6 +62,8 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 import msgspec
 
+from . import worker_goals
+from .config import load_settings
 from .mint_process import (
     EXIT_BAD_REQUEST,
     EXIT_MINTED,
@@ -869,6 +871,52 @@ def _is_resource_error(exc: BaseException) -> bool:
     return isinstance(exc, MemoryError)
 
 
+def _install_goals() -> None:
+    """Publish THIS process's goal set (pgw#868 A4).
+
+    ``worker_goals`` is a per-process publication with exactly one carrier and
+    one moment it is set. Both existing callers of :func:`worker_goals.install`
+    are in the SERVING parent (``entrypoint``, ``procsplit.parent``) — and the
+    mint runs in a child spawned as ``python -m gen_worker.mint_child``, which
+    installed nothing. So ``worker_goals.current()`` fell back to
+    :data:`~gen_worker.worker_goals.SERVE_ONLY` in the one process that decides
+    the compile pool's width (``aot_compile_pool.entry_workers`` is called from
+    ``aot_mint._mint_cell``, three frames down from here), and a mint-only pod
+    held back a tenant VRAM reserve, a serving CPU headroom and a tenant
+    host-RAM reserve for a tenant that cannot reach it: it accepts no dispatch.
+
+    The fallback is the RIGHT default for a library import with no hub — this
+    process has a hub, and its declaration is already in the environment the
+    parent handed down (``mint_process.child_env`` copies it), read here the
+    same way the parent reads it: off typed `Settings`, never off `os.environ`
+    (§1.18). A declaration this build cannot interpret still lands, carrying
+    ``declaration_understood=False``, exactly as it does in the parent.
+
+    Never fatal: a child that cannot read its settings keeps the serve-only
+    fallback and mints at the narrower width, which is what it does today.
+
+    The settings are LOADED and not ``config.install``ed, deliberately. This
+    child is a process entry and §1.18 says a process entry installs — but it
+    never has, so every ``config.current_or(default)`` reader inside a mint has
+    been answering from its default for the life of this module. Publishing
+    them here would flip all of those at once, which is a blast radius this
+    change has no way to test and no business taking. It is a real gap and it
+    is recorded as one; what this function fixes is the goal set, whose only
+    reader inside the child is the width policy.
+    """
+    try:
+        goals = worker_goals.from_settings(load_settings())
+    except Exception:  # noqa: BLE001 — a narrower pool beats a dead mint
+        logger.warning(
+            "mint-child: could not read worker goals; keeping the serve-only "
+            "fallback (the pool will hold tenant reserves)", exc_info=True)
+        return
+    worker_goals.install(goals)
+    logger.info(
+        "mint-child: goals serve=%s mint=%s (declared %r, understood=%s)",
+        goals.serve, goals.mint, goals.declared, goals.declaration_understood)
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     logging.basicConfig(
@@ -886,6 +934,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"BAD REQUEST {args[0]}: {exc}", file=sys.stderr)
         return EXIT_BAD_REQUEST
 
+    _install_goals()
     report_path = Path(request.report)
     started = time.monotonic()
     try:

--- a/tests/test_pool_rewiden_pgw868_a4.py
+++ b/tests/test_pool_rewiden_pgw868_a4.py
@@ -1,0 +1,427 @@
+"""pgw#868 A4: the pool sizes K off an ESTIMATE and then measures the truth.
+
+``aot_compile_pool.entry_workers`` runs before a single entry has compiled, so
+the only per-entry device figure it can have is
+``mint_budget.co_residency().need_bytes`` — the MINT CHILD's whole co-residency
+estimate (a full weight copy, an activation set nothing observed, two flat
+constants), spent as ONE entry child's ask. pgw#877 measured that ~56 % of it
+was never observed and renamed its basis ``"estimated"`` for that reason.
+
+Every entry child then reports what it actually peaked at, ``observe_entry_device``
+banks it, and until this change nothing read it: attempt eighteen's sdxl mint
+ran ``K=2, binding=vram, underwidth=6`` for all 36 entries against an estimate
+its own first two entries had already disproved. K is the mint's ONLY
+multiplicative lever, so that is the largest single item in A4.
+
+What these tests hold:
+
+* the measurement REACHES the width — through the real ``entry_workers``, not a
+  recomputation written here;
+* it only ever WIDENS, and never past the caller's own ``limit``;
+* it refuses on one sample, on no sample, on an absent device lock, and on a
+  pool that never read the card — the four ways this could widen a pod onto an
+  OOM;
+* the ledger's capacity identity survives a width that MOVES, which is the
+  thing a mid-flight K silently breaks;
+* and the mint child installs the goal set that decides whether the tenant
+  reserves apply at all.
+
+Nothing here mocks the thing under test: ``entry_workers``, ``PoolWidth``,
+``EntryCompilePool`` and ``mint_budget.entry_device_ask`` are the production
+objects. The one synthesized input is the entry child's device peak, which a
+box with no CUDA card cannot produce any other way — it arrives through the
+real ``EntryReport`` and the real ``observe_entry_device``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gen_worker import aot_compile_pool as pool
+from gen_worker import mint_budget, worker_goals
+
+_GIB = 1024 ** 3
+
+
+def _sized(
+    *,
+    entries: int = 36,
+    free_vram: int = 30 * _GIB,
+    per_entry: int = 10 * _GIB,
+    limit: int = 0,
+    device_lock: bool = True,
+) -> pool.PoolWidth:
+    """A width from the REAL policy, on a stated host.
+
+    Stated rather than derived: a CI runner honestly derives K=1 and every
+    assertion below would then pass while exercising nothing.
+    """
+    return pool.entry_workers(
+        entries, limit=limit, vcpus=32,
+        available_bytes=256 * _GIB, peak_rss_bytes=2 * _GIB,
+        free_vram_bytes=free_vram, device_bytes=per_entry,
+        device_basis="estimated", device_lock=device_lock,
+        goals=worker_goals.MINT_ONLY)
+
+
+def _report(entry: str, reserved: int) -> pool.EntryReport:
+    return pool.EntryReport(
+        entry=entry, status=pool.COMPILED,
+        peak_device_reserved_bytes=reserved)
+
+
+def _observe(box: pool.EntryCompilePool, reserved: int, n: int = 2) -> None:
+    for i in range(n):
+        box.observe_entry_device(_report(f"unet/dim={i}", reserved))
+        box._rewiden()
+
+
+# ---------------------------------------------------------------------------
+# The win: an estimate replaced by an observation, through the real policy
+# ---------------------------------------------------------------------------
+
+
+def test_the_measured_entry_peak_replaces_the_estimate_and_widens_K(
+    tmp_path: Path,
+) -> None:
+    """Attempt eighteen's own numbers, with the measurement plugged in.
+
+    30 GiB free, a 10 GiB/entry ESTIMATE and a mint-only pod gives K=3. The
+    entry children then report a 5 GiB reserved high-water; the ask that
+    becomes is 5 GiB + the CUDA context floor mint_budget adds back, and the
+    same free figure divided by THAT gives K=5. Nothing else moved: not the
+    reserve, not the ceiling, not the host bounds, not the card.
+    """
+    width = _sized(free_vram=30 * _GIB, per_entry=10 * _GIB)
+    assert width.workers == 3 and width.binding == "vram", width.reason
+    assert width.per_entry_device_basis == "estimated"
+
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+    _observe(box, 5 * _GIB)
+
+    ask = mint_budget.entry_device_ask(5 * _GIB)
+    assert box.width.workers == 30 * _GIB // ask == 5, box.width.reason
+    assert box.width.per_entry_device_basis == "measured", (
+        "a width derived from an entry child's own high-water must SAY it was "
+        "measured — the basis is what tells the next reader whether the number "
+        "is an observation or the guess pgw#877 renamed")
+    assert box.width.per_entry_device_bytes == mint_budget.entry_device_ask(
+        5 * _GIB), (
+        "the ask must come from mint_budget's own function — a CUDA context, "
+        "the cuBLAS/cuDNN handles and the driver's per-process overhead live "
+        "OUTSIDE the allocator's high-water and have to be added back")
+    # The initial row survives being superseded: the prize is a delta.
+    assert box.width_initial.workers == 3
+    assert box.ledger.workers_initial == 3 and box.ledger.workers == 5
+
+
+def test_the_re_derivation_divides_the_pools_OWN_free_figure_not_a_fresh_probe(
+    tmp_path: Path,
+) -> None:
+    """The trap this method has to avoid, stated as a test.
+
+    Re-derivation happens while K children are ALIVE and holding their
+    footprints, so a fresh ``mem_get_info`` would read their own memory as
+    absent capacity and NARROW — the exact opposite of the truth. The
+    re-derivation is against ``width_initial.free_device_bytes``, which is
+    the figure the pool was sized with, so it is indifferent to what is
+    running when it fires.
+    """
+    width = _sized(free_vram=48 * _GIB, per_entry=12 * _GIB)
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    def _explode(*_a: object, **_k: object) -> int:
+        raise AssertionError(
+            "_rewiden probed the card; a probe taken with K children resident "
+            "reads their own footprints as missing capacity")
+
+    # The REAL guard: if anything in the path samples the device, this raises.
+    box._rewiden.__globals__["_probe_free_device_bytes"]  # present
+    original = pool._probe_free_device_bytes
+    pool._probe_free_device_bytes = _explode      # type: ignore[assignment]
+    try:
+        _observe(box, 4 * _GIB)
+    finally:
+        pool._probe_free_device_bytes = original
+
+    assert box.width.workers > width.workers
+    assert box.width.free_device_bytes == width.free_device_bytes
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: the five refusals
+# ---------------------------------------------------------------------------
+
+
+def test_one_sample_is_an_anecdote_and_does_not_move_K(tmp_path: Path) -> None:
+    """The first round's children start together, so they also miss the shared
+    PCH and the autotune cache — they are the LEAST representative entries in
+    the cell. Widening off one of them is pgw#842's "5-vs-3 with nothing
+    recorded to say why" with a new cause."""
+    width = _sized(free_vram=30 * _GIB, per_entry=10 * _GIB)
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    _observe(box, 2 * _GIB, n=1)
+    assert box.width.workers == 3, "one report is not a measurement"
+    assert box.device_samples == 1
+
+    _observe(box, 2 * _GIB, n=1)
+    assert box.width.workers > 3, "two reports are"
+
+
+def test_it_never_narrows_however_large_the_measurement(
+    tmp_path: Path,
+) -> None:
+    """Children are already running against the current width. A measurement
+    saying the pool is too wide cannot be acted on — the entries are spawned —
+    and acting on it would strand them. It is banked for the NEXT mint through
+    ``mint_budget``, which is where a narrowing belongs."""
+    width = _sized(free_vram=60 * _GIB, per_entry=8 * _GIB)
+    assert width.workers > 1
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    _observe(box, 55 * _GIB)          # would derive K=1
+
+    assert box.width.workers == width.workers
+    assert box.width is width, "a refusal must leave the record untouched"
+
+
+def test_an_operator_who_forced_the_serial_path_keeps_it(
+    tmp_path: Path,
+) -> None:
+    """``entry_workers(limit=)`` is how an operator or a test forces K=1
+    without pretending a 4-vCPU pod is an H100 host. A measurement must not
+    widen it back out from under them — which is why ``limit`` had to become
+    part of the ``PoolWidth`` record."""
+    width = _sized(free_vram=60 * _GIB, per_entry=10 * _GIB, limit=1)
+    assert width.workers == 1 and width.limit == 1
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    _observe(box, 1 * _GIB)
+
+    assert box.width.workers == 1, (
+        f"the operator's cap was overridden by a measurement: "
+        f"{box.width.reason}")
+
+
+def test_a_pool_with_no_device_lock_stays_serial(tmp_path: Path) -> None:
+    """K=1 without ``set_gpu_benchmark_lock_context`` is a SAFETY width, not a
+    resource one: two entries benchmarking at once bake contention-chosen
+    kernel configs into a cell whose key would not move. No amount of free
+    VRAM licenses widening past it."""
+    width = _sized(free_vram=60 * _GIB, per_entry=10 * _GIB, device_lock=False)
+    assert width.workers == 1 and width.binding == "device-lock"
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    _observe(box, 1 * _GIB)
+
+    assert box.width.workers == 1, box.width.reason
+
+
+def test_a_pool_that_never_read_the_card_does_not_invent_a_free_figure(
+    tmp_path: Path,
+) -> None:
+    """``entries <= 1`` and an absent probe both leave ``free_device_bytes``
+    unread (``-1`` / ``0``). There is nothing to re-divide, and supplying a
+    figure here would be exactly the guess this whole method deletes."""
+    width = pool.entry_workers(1, vcpus=32, available_bytes=256 * _GIB)
+    assert width.free_device_bytes <= 0
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    _observe(box, 1 * _GIB)
+
+    assert box.width.workers == 1
+
+
+def test_a_raising_re_derivation_leaves_the_width_exactly_as_it_was(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A width policy that could kill a mint would be a worse defect than the
+    narrow width it exists to fix. pgw#846's ordering is explicit: mint
+    reliably first, mint fast third."""
+    width = _sized(free_vram=30 * _GIB, per_entry=10 * _GIB)
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    def _boom(_peak: int) -> int:
+        raise RuntimeError("banked measurement unreadable")
+
+    monkeypatch.setattr(mint_budget, "entry_device_ask", _boom)
+    _observe(box, 4 * _GIB)
+
+    assert box.width is width
+
+
+def test_a_zero_peak_is_not_a_measurement(tmp_path: Path) -> None:
+    """A child too old to report, or one that died before it allocated, banks
+    nothing. ``observe_entry_device`` already refuses to count it; this pins
+    that the sample counter agrees, because the counter is what licenses the
+    widening."""
+    width = _sized(free_vram=30 * _GIB, per_entry=10 * _GIB)
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+
+    for i in range(4):
+        box.observe_entry_device(
+            pool.EntryReport(entry=f"unet/dim={i}", status=pool.COMPILED))
+        box._rewiden()
+
+    assert box.device_samples == 0 and box.width.workers == 3
+
+
+# ---------------------------------------------------------------------------
+# The ledger identity, under a width that moves
+# ---------------------------------------------------------------------------
+
+
+def test_the_capacity_identity_survives_a_width_that_moves() -> None:
+    """``capacity_s`` used to be ``wall_s * final_workers``, computed once at
+    the end. With a K that can move mid-pool that prices the whole run at a
+    width the first entries never had, and ``busy + idle == capacity`` — the
+    identity the whole ledger exists to keep exact — becomes a residual.
+
+    Accumulating per interval at the LIVE width keeps it exact. Driven here
+    through the ledger's own arithmetic rather than a clock, so it asserts the
+    identity and not the runner's spare CPU.
+    """
+    ledger = pool.PoolLedger(workers=2, workers_initial=2)
+    # Two seconds at K=2, then two at K=4, with one slot free throughout.
+    for width_workers, seconds in ((2, 2.0), (4, 2.0)):
+        ledger.capacity_s += seconds * width_workers
+        ledger.idle_other_s += seconds * 1
+        ledger.busy_s += seconds * (width_workers - 1)
+
+    assert ledger.capacity_s == pytest.approx(12.0)
+    assert ledger.busy_s + ledger.idle_s == pytest.approx(ledger.capacity_s), (
+        "busy + idle must equal capacity; a residual here means the ledger is "
+        "pricing seconds at a width that was never live for them")
+
+
+def test_the_staging_cap_follows_the_width(tmp_path: Path) -> None:
+    """The cap on programs staged ahead of the running set is derived from K.
+    Frozen at the construction width it would starve exactly the slots a
+    re-derivation just opened, and the widening would buy nothing."""
+    src = Path("src/gen_worker/aot_compile_pool.py").read_text()
+    body = src.split("def compile(", 1)[1]
+    assert "staged_cap = max(1, self.width.workers" in body
+    head, _rest = body.split("while (pending and not failure", 1)
+    assert "while pending or staged or running:" in head
+    assert head.index("while pending or staged or running:") \
+        < head.index("staged_cap = max(1, self.width.workers"), (
+        "staged_cap must be recomputed INSIDE the round loop, after "
+        "_rewiden may have moved the width")
+
+
+def test_the_width_change_is_emitted_not_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#842: "an unexplained K is a defect in itself". A K that changes
+    mid-mint and says nothing is the same defect with a moving value."""
+    from gen_worker import activity as activity_mod
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail, **kw: seen.append(str(detail)))
+
+    width = _sized(free_vram=30 * _GIB, per_entry=10 * _GIB)
+    box = pool.EntryCompilePool(tmp_path / "pool", width=width)
+    _observe(box, 5 * _GIB)
+
+    assert box.width.workers == 5
+    assert any("'entry_workers': 5" in d for d in seen), (
+        f"the re-derived width never reached a hub row: {seen}")
+    assert any("'per_entry_device_basis': 'measured'" in d for d in seen)
+
+
+# ---------------------------------------------------------------------------
+# The goal set the width policy reads — and the process that never had one
+# ---------------------------------------------------------------------------
+
+
+def test_the_mint_child_installs_its_own_goal_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``worker_goals.install`` is called from ``entrypoint`` and
+    ``procsplit.parent`` — both the SERVING parent. The mint runs in a child
+    spawned as ``python -m gen_worker.mint_child``, which installed nothing, so
+    ``current()`` fell back to ``SERVE_ONLY`` in the one process that sizes the
+    compile pool: a mint-only pod held a tenant VRAM reserve, a serving CPU
+    headroom and a tenant host-RAM reserve for a tenant that cannot reach it.
+    """
+    from gen_worker import mint_child
+
+    monkeypatch.setenv("WORKER_MODE", "forge")
+    worker_goals.reset_for_test()
+    assert worker_goals.current() is worker_goals.SERVE_ONLY, (
+        "precondition: nothing installed yet")
+
+    mint_child._install_goals()
+
+    goals = worker_goals.current()
+    assert goals.mint and not goals.serve, (
+        f"the child read {goals.declared!r} and holds serve={goals.serve} "
+        f"mint={goals.mint}")
+    assert not goals.tenant_reserve_applies()
+    worker_goals.reset_for_test()
+
+
+def test_the_goal_set_reaches_the_width_and_drops_the_tenant_reserves() -> None:
+    """The observable pgw#846's attempts fourteen and fifteen needed: the
+    reason string names the goals, and a mint-only pod's reserves are gone.
+    Two widths from the REAL policy on the SAME host — only the goals move."""
+    common = dict(
+        vcpus=4, available_bytes=32 * _GIB, peak_rss_bytes=2 * _GIB,
+        free_vram_bytes=30 * _GIB, device_bytes=10 * _GIB,
+        device_basis="estimated", device_lock=True)
+
+    serving = pool.entry_workers(36, goals=worker_goals.SERVE_ONLY, **common)
+    forge = pool.entry_workers(36, goals=worker_goals.MINT_ONLY, **common)
+
+    assert "goals=serve" in serving.reason and "goals=mint" in forge.reason
+    assert forge.workers >= serving.workers, (
+        f"a pod with no tenant may not compile NARROWER than one with a "
+        f"tenant: forge {forge.reason!r} vs serve {serving.reason!r}")
+    assert forge.cpu_workers > serving.cpu_workers, (
+        "SERVING_HEADROOM_CPUS protects an eager forward this pod will never "
+        "run — on a 4-vCPU pod that is a quarter of the pool")
+
+
+def test_the_declaration_the_child_cannot_read_is_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mint that died because it could not parse its own goal declaration
+    would trade acceptance 2 for acceptance 3. The fallback is the narrow,
+    serve-only width — which is exactly what runs today."""
+    from gen_worker import mint_child
+
+    worker_goals.reset_for_test()
+    monkeypatch.setattr(
+        mint_child, "load_settings",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("unreadable env")))
+
+    mint_child._install_goals()      # must not raise
+
+    assert worker_goals.current() is worker_goals.SERVE_ONLY
+    worker_goals.reset_for_test()
+
+
+def test_the_child_env_carries_the_declaration_the_child_now_reads(
+) -> None:
+    """The two halves have to meet: ``mint_process.child_env`` copies the
+    parent's environment (so ``WORKER_MODE`` is there), and the loader maps it
+    onto ``Settings.worker_mode``. Neither is new; the join is."""
+    from gen_worker import mint_process
+    from gen_worker.mint_process import MintRequest
+
+    from gen_worker.mint_process import CompileCellSpec
+
+    env = mint_process.child_env(
+        MintRequest(
+            function="generate", modules=(), family="sdxl", cell_key="ck5-x",
+            target="/tmp/cell.tar.gz", capture="/tmp/cap",
+            report="/tmp/r.json", cfg=CompileCellSpec(family="sdxl")),
+        base={"WORKER_MODE": "forge", "PATH": os.environ.get("PATH", "")})
+    assert env["WORKER_MODE"] == "forge"
+    assert env["GEN_WORKER_MINT_CHILD"] == "1"


### PR DESCRIPTION
## The defect

`aot_compile_pool.entry_workers` runs **before a single entry has compiled**, so the only per-entry device figure available to it is `mint_budget.co_residency().need_bytes` — the MINT CHILD's whole co-residency footprint (a full weight copy, an activation set nothing observed, two flat constants), spent as ONE entry child's ask.

pgw#877 measured that ~56% of that number was never observed, renamed its basis from `"measured"` to `"estimated"` for exactly that reason, and left `EntryReport.peak_device_bytes` — the real observation, reported by every entry child and banked by `observe_entry_device` — carrying the comment *"Telemetry only — `entry_workers` still sizes off `mint_budget.co_residency`, and replacing an estimate with this measurement is a SEPARATE change."*

This is that change. Attempt eighteen's sdxl mint ran `K=2, binding=vram, underwidth=6` for all 36 entries against an estimate its own first two entries had already disproved. **K is the mint's only multiplicative lever**, which makes this the largest single item in A4 now that pgw#811 has collected the g++ leg.

## What lands

`EntryCompilePool._rewiden()` re-derives K after each entry lands, dividing the pool's **own** free-VRAM reading by the **measured** per-entry high-water in place of the estimate. Same question, same readings, same reserves, same ceiling — only the divisor changes, from a guess to an observation. That is the pgw#847 shape (delete a guess, keep the computation), not a new policy.

**Fail-closed in six directions, one test each:**

| refusal | why |
|---|---|
| never NARROWS | children are already running; a mid-flight dip is what `device_facts` takes a max over precisely so it cannot be acted on |
| never past the caller's `limit` | an operator who forced the serial path keeps it — which is why `limit` is now part of the `PoolWidth` record |
| < 2 reports | the first round's children start together, so they also miss the shared PCH and the autotune cache: the least representative entries in the cell |
| a zero peak | a child too old to report, or one that died before it allocated, is not a measurement |
| no device lock | K=1 there is a **safety** width (contention-chosen kernel configs under an unchanged key), not a resource one |
| anything raising | a width policy that could kill a mint is a worse defect than the narrow width it fixes |

It re-divides `width_initial`'s free figure rather than **re-probing** — a probe taken with K children resident reads their own footprints as absent capacity and would narrow, the exact opposite of the truth. A test breaks `_probe_free_device_bytes` to prove the path never calls it.

## No artifact changes

K is not an input to codegen, kernel selection, shape specialization or the traced graph, and the device lock already serializes the one thing entries share (`benchmark_all_configs`). **Process, not product** — pgw#846's rule.

## Two supporting fixes

- **`capacity_s` is accumulated at the width live for each interval** rather than multiplied out as `wall_s * final_workers` at the end. A K that moves mid-pool would otherwise price the whole run at a width the first entries never had, turning `busy + idle == capacity` into a residual — the one thing that ledger exists not to be. `pool_workers_initial` rides beside `pool_workers`, so the prize is a delta readable from one row.
- **The mint child never installed its goal set.** `worker_goals.install` is called from `entrypoint` and `procsplit.parent`, both the SERVING parent; the mint runs in a child spawned as `python -m gen_worker.mint_child`, which installed nothing. `current()` therefore fell back to `SERVE_ONLY` in the one process that sizes the compile pool, and a mint-only pod held back a tenant VRAM reserve, a serving CPU headroom and a tenant host-RAM reserve for a tenant that cannot reach it: it accepts no dispatch. On a 4-vCPU forge pod the CPU headroom alone is a quarter of the pool. Read off typed `Settings`, never `os.environ` (§1.18); an unreadable declaration keeps the narrow serve-only fallback rather than failing a mint.

`config.install` is deliberately **not** called in the child. It never has been, so every `config.current_or(default)` reader inside a mint has been answering from its default — a real gap, recorded rather than fixed blind, because publishing settings there flips all of them at once.

## Verification

- **16 new tests, 14 RED on `master`** (the other 2 characterize existing `entry_workers` behaviour).
- **799 passed, 8 skipped** across the mint/pool/aot neighbourhood (`-k "pool or mint or aot or goals or width or boot"`).
- mypy clean, ruff clean on both touched files.
- Nothing mocks the thing under test: `entry_workers`, `PoolWidth`, `EntryCompilePool` and `mint_budget.entry_device_ask` are the production objects. The one synthesized input is the entry child's device peak, which a box with no CUDA card cannot produce any other way — and it arrives through the real `EntryReport` and the real `observe_entry_device`.

## What the next mint must show

The width event now fires twice: `pool width (construction)` with `per_entry_device_basis: estimated`, and `pool width (re-derived from measured entry peaks)` with `basis: measured`. The prize is `pool_workers` minus `pool_workers_initial` on the ledger row. If the measured peak lands **above** the estimate, K correctly does not move and the estimate is vindicated — that is a result too, and the row says so either way.