### PR TITLE
th#1645 + pgw#987: the cell publish declare carries CONTROL, and a 413 is a verdict

### DIFF
--- a/changelog.d/pgw987.md
+++ b/changelog.d/pgw987.md
@@ -1,0 +1,63 @@
+- **th#1645: the cell publish declare carried the whole envelope, so no AOT
+  cell was ever publishable.** `fleet_cells.CellPublisher.publish` forwarded
+  `dict(meta)` verbatim as the publish-v2 declare's `metadata`. That dict is a
+  cell's ENVELOPE, and two of its blocks are unbounded in the size of the
+  model: `guard_manifest` (JIT lane) and `entries` (AOT lane), plus
+  `composition` and `weight_contract`. Measured on a real published sdxl cell
+  — checkpoint `sha256:926bc9f5…`, 69,045,459-byte artifact — `guard_manifest`
+  alone is **13,092,487 of 13,377,167 metadata bytes (98%)**; everything else
+  together is 285 KB. The declare therefore grew with the ARTIFACT, and at
+  attempt twenty-two's ~202.5 MB AOT cell it reached **38,991,725 bytes**
+  against tensorhub's 32 MiB route cap. The hub answered **413 in 25
+  microseconds**, thirty-two times across two cards, without reading a byte —
+  the mint was otherwise green end to end, with the key byte-identical on both
+  pods.
+- The bytes were never the problem: a cell's artifact has always gone worker →
+  R2 over presigned, digest-bound PUTs (th#1303). What crossed the cap was
+  CONTROL-plane JSON mirroring data that (a) already ships inside the artifact
+  and is read from there (`guard_closure.load_manifest` opens the tarball;
+  `aot_serve` reads `entries` off the unpacked package), and (b) had exactly
+  one hub-side reader — `api/cell_receipts.go` hashing it into two `omitempty`
+  audit claims that nothing verifies, over content already bound by
+  `snapshot_digest`. `control_plane_metadata` now drops those four blocks and
+  forwards every other key byte-identically. Nothing selects a cell on the
+  dropped data: `cell_store`'s own columns (family, key, sm, sku, image digest,
+  gen_worker, lane) are populated from the publish-INTENT call.
+- **A stated bound replaces an inherited one.** `CELL_DECLARE_MAX_BYTES`
+  (4 MiB — an order of magnitude over the 285 KB observed, two orders under
+  the route's cap) refuses on the POD, before the wire, and NAMES the block
+  that broke it. The failure mode it exists to prevent is the one that just
+  cost twenty-two attempts: the next unbounded block someone adds to the
+  envelope produces a 413 that names no key, ten minutes into a paid pod, and
+  a P0 filed against the wrong subsystem.
+- **pgw#987: a 413 is a verdict, and the client read thirty-two of them as
+  silence.** `http_origin.is_definite_hub_answer` answered False to every one,
+  because gin's `AbortWithStatusJSON` envelope carries a bare string `error`
+  with no `message` and matches neither shape `response_is_from_hub` knows. So
+  a permanently-refused body was re-sent for 609 seconds of a \$0.74/hr pod,
+  and the typed `self_mint_publish_failed` event that reached the hub said
+  *"network, no definite hub answer"* while the hub's own access log said
+  `413`. That mislabelled error did not merely fail to help — it produced a
+  wrong P0 (th#1644, filed against a config-roll drain that had nothing to do
+  with it).
+- The fix is narrow on purpose. `REQUEST_DETERMINED_STATUSES = {413}`:
+  statuses whose cause is a property of the request WE sent, not of who
+  answered. `Content-Length` is byte-identical on every retry, so no origin
+  can make retrying useful, and the retry-biased default — which rests on
+  retrying being the cheap direction — does not apply. **pgw#743's doctrine is
+  untouched**: a 404 can still be a proxy with no healthy backend, a 403 a
+  token about to rotate, a 409 a race; none are determined by our own bytes,
+  and a blanket "4xx is terminal" would revert the fix that exists because
+  ngrok's offline page cost two 58-minute clones. Guarded by a test.
+- `_error_code_of` and `_hub_error_code` now also read the STRING-shaped
+  `error`, so the typed event carries `request_body_too_large` — the hub's own
+  name for the fault — instead of `http_413`, which cannot be grouped.
+- Proof: `tests/test_cell_declare_bound_th1645_pgw987.py` drives the real
+  `CellPublisher.publish` against a real socket, a real body cap enforced on
+  the declared `Content-Length` exactly as the hub's middleware does, and a
+  **real 202,500,000-byte artifact** — every megabyte distinct, so the CAS
+  cannot dedup the proof away. All four 64 MiB chunks upload and are refused
+  unless they hash to the digest signed into their grant. RED-verified both
+  ways: restoring the old declare reproduces the incident verbatim
+  (`413 … "max_body_bytes": 33554432, "declared_length": 38991725`), and
+  removing the 413 rule reproduces the retry storm.

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -140,9 +140,15 @@ def _error_code_of(resp: requests.Response) -> str:
     if not isinstance(body, dict):
         return ""
     err = body.get("error")
-    if not isinstance(err, dict):
-        return ""
-    return str(err.get("code") or "")
+    if isinstance(err, dict):
+        return str(err.get("code") or "")
+    # pgw#987: the publish envelope (`publishError.body()`) and gin's
+    # `AbortWithStatusJSON` both emit the code as a STRING. Dropping it left
+    # `_publish_failure_phase` with only `http_413` to group 32 identical
+    # refusals by, when the hub had named the fault exactly.
+    if isinstance(err, str) and err.strip():
+        return err.strip()
+    return ""
 
 
 # pgw#738/#743: how long _send_with_retries tolerates hearing nothing

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -61,7 +61,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 
 from . import activity as activity_mod
@@ -270,7 +270,12 @@ def _hub_error_code(body: Any) -> str:
     err = body.get("error")
     if isinstance(err, dict):
         return str(err.get("code") or "")
-    return str(body.get("code") or "")
+    flat = str(body.get("code") or "")
+    # pgw#987: gin's `AbortWithStatusJSON` (the body-cap middleware) emits the
+    # code as a bare string under `error` and carries no `code` at all, so a
+    # `request_body_too_large` refusal named itself and the client dropped the
+    # name.
+    return flat or (err.strip() if isinstance(err, str) else "")
 
 
 def _credential_lapse_s(token: str, *, now: float) -> float:
@@ -285,6 +290,85 @@ def _credential_lapse_s(token: str, *, now: float) -> float:
     except (TypeError, ValueError):
         return 0.0
     return max(0.0, now - exp) if exp > 0 else 0.0
+
+
+# th#1645/pgw#987: the blocks a cell's envelope carries that are UNBOUNDED in
+# the size of the model, and that the publish declare must therefore not
+# forward.
+#
+# Every one of them already ships INSIDE the artifact (`metadata.json` in the
+# .tar.gz) and is read from there — `guard_closure.load_manifest` opens the
+# tarball, `aot_serve` reads `entries` off the unpacked package. The copy in
+# the declare body had exactly one hub-side reader,
+# `api/cell_receipts.go:242-248`, which hashes it into two `omitempty` audit
+# claims that nothing verifies against anything (the worker parses
+# `manifest_digest`/`fingerprint_digest` into a dataclass field and never
+# reads them) — and the content is already bound by `snapshot_digest`, as
+# that file's own header says.
+#
+# THE MEASUREMENT that makes this a bound and not a preference: on a REAL
+# published sdxl cell (checkpoint sha256:926bc9f5…, artifact 69,045,459 B),
+# `guard_manifest` alone is 13,092,487 bytes of the 13,377,167-byte metadata
+# — 98%. Everything else together is 285 KB. The declare body therefore grew
+# with the ARTIFACT, and at ~200 MB (a real AOT cell) it crossed the 32 MiB
+# route cap and the hub answered 413 thirty-two times.
+_UNBOUNDED_ENVELOPE_BLOCKS = frozenset({
+    "guard_manifest",   # JIT lane: per-graph guard closures
+    "entries",          # AOT lane: per-class contracts + constant manifests
+    "composition",      # pgw#697 composition fingerprint rows
+    "weight_contract",  # per-tensor weight rows
+})
+
+# The stated ceiling on a cell's CONTROL-plane declare (§4.24). Measured
+# basis: the same real cell's metadata minus the blocks above is 285 KB, and
+# the AOT lane's phase table adds tens of KB — so 4 MiB is roughly an order
+# of magnitude of headroom over anything observed, while staying far below
+# the route's 32 MiB.
+#
+# THREAT: without it, the next unbounded block someone adds to the envelope
+# re-creates th#1645 exactly — a publish that cannot succeed, discovered as a
+# 413 that names no key, ten minutes into a paid pod. This bound fails on the
+# POD, before the wire, and NAMES the block that broke it.
+CELL_DECLARE_MAX_BYTES = 4 << 20
+
+#: The groupable phase a declare-bound refusal reports. Its own token, not the
+#: generic `refused`: this refusal means "someone added an unbounded block to
+#: the envelope", which is a code defect with a named owner, and it must not
+#: land in the same bucket as the hub's trust-tier and quota decisions.
+CELL_DECLARE_OVERSIZE_CODE = "cell_declare_oversize"
+
+
+def control_plane_metadata(meta: Mapping[str, Any]) -> Dict[str, Any]:
+    """The bounded subset of a cell envelope the publish declare may carry.
+
+    The seam carries CONTROL, not DATA (pgw#763/#783). A cell's bulk envelope
+    is data: it rides the artifact, over presigned PUTs, digest-bound. What
+    the hub actually selects a cell on — family, key, sm, sku, image digest,
+    gen_worker version, lane — reaches it on the publish-INTENT call and is
+    stored in `cell_store`'s own columns; none of it is read back out of this
+    dict.
+
+    Raises :class:`CellPublishRefused` when what survives still exceeds
+    :data:`CELL_DECLARE_MAX_BYTES`, naming the largest surviving key — a new
+    unbounded block must be a named refusal here, not a 413 later.
+    """
+    kept = {
+        k: v for k, v in dict(meta).items()
+        if v is not None and k not in _UNBOUNDED_ENVELOPE_BLOCKS
+    }
+    encoded = len(json.dumps(kept, sort_keys=True, default=str).encode())
+    if encoded > CELL_DECLARE_MAX_BYTES:
+        widest = max(
+            kept,
+            key=lambda k: len(json.dumps(kept[k], sort_keys=True, default=str)),
+            default="")
+        raise CellPublishRefused(
+            f"cell declare is {encoded} bytes, over the "
+            f"{CELL_DECLARE_MAX_BYTES}-byte control-plane bound (th#1645); "
+            f"the largest block is {widest!r} — it belongs in the artifact, "
+            "not in the declare",
+            code=CELL_DECLARE_OVERSIZE_CODE)
+    return kept
 
 
 class CellPublisher:
@@ -460,7 +544,8 @@ class CellPublisher:
                 files=[CommitFile(path=artifact.name, local_path=artifact)],
                 mode="replace",
                 flavor=key,
-                metadata={k: v for k, v in dict(meta).items() if v is not None},
+                # th#1645: CONTROL only. The bulk envelope is in the artifact.
+                metadata=control_plane_metadata(meta),
                 on_stage=lambda stage, facts: _publish_leg(
                     family, key, stage, facts),
             )
@@ -681,7 +766,11 @@ def _publish_async(
             activity_mod.emit_event(
                 "self_mint_publish_failed",
                 f"family={family} key={key}: hub refused the publish: {exc}",
-                phase="refused",
+                # th#1645: the hub's own code when it named one (and the
+                # declare-bound's own token when the refusal never reached the
+                # hub at all) — `refused` alone puts a code defect, a trust
+                # tier and a quota in one bucket.
+                phase=_publish_failure_phase(exc) or "refused",
             )
         except Exception as exc:  # noqa: BLE001 — reported, never fatal
             logger.warning("fleet-cells: publish failed; the next worker on this key re-mints", exc_info=True)

--- a/src/gen_worker/http_origin.py
+++ b/src/gen_worker/http_origin.py
@@ -41,7 +41,26 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["response_is_from_hub", "is_proxy_outage", "is_definite_hub_answer"]
+__all__ = [
+    "response_is_from_hub",
+    "is_proxy_outage",
+    "is_definite_hub_answer",
+    "REQUEST_DETERMINED_STATUSES",
+]
+
+# pgw#987: statuses whose cause is a property of the REQUEST WE SENT, not of
+# who answered. The same bytes earn the same refusal from the hub, from a
+# proxy, and from anything else in the path, forever — so "did the hub itself
+# answer?" is not the question, and the retry-biased default below (which
+# rests on retrying being the cheap direction) does not hold: retrying is
+# pure cost with a guaranteed identical outcome.
+#
+# 413 only, deliberately. A 404 can be a proxy with no healthy backend
+# (pgw#743, two 58-minute clones), a 403 can be a token that will be rotated,
+# a 409 can be a race — none of those are determined by our own bytes. A
+# Content-Length refusal is: `Content-Length` is byte-identical on every
+# retry.
+REQUEST_DETERMINED_STATUSES = frozenset({413})
 
 
 def _content_type(resp: Any) -> str:
@@ -122,5 +141,15 @@ def is_definite_hub_answer(resp: Any) -> bool:
     except Exception:  # noqa: BLE001 - an unreadable status is not a verdict
         return False
     if 200 <= code < 400:
+        return True
+    if code in REQUEST_DETERMINED_STATUSES:
+        # pgw#987. The measured failure: the hub refused 32 cell publishes with
+        # `413 request_body_too_large` in 25 microseconds each, and this
+        # function answered False every time — because gin's
+        # `AbortWithStatusJSON` envelope carries a STRING `error` with no
+        # `message`, matching neither shape below. Ten minutes of a paid pod
+        # re-sending a body that could never be accepted, and the typed event
+        # that reached the hub said "network" while the hub's own log said
+        # `413`. That mislabelled error produced a wrong P0 (th#1644).
         return True
     return response_is_from_hub(resp)

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -1,0 +1,466 @@
+"""th#1645 + pgw#987: the cell publish declare is CONTROL, and a 413 is final.
+
+Two defects, one incident. On 2026-08-06 a fully-minted AOT cell — sealed,
+key byte-identical across two cards — could not be published by any worker on
+any card:
+
+  * **th#1645.** The declare body carried the cell's ENTIRE envelope. On a real
+    published sdxl cell the `guard_manifest` block alone measured 13,092,487 of
+    13,377,167 metadata bytes (98%) against a 69 MB artifact; at a ~200 MB AOT
+    cell the body crossed the hub's 32 MiB route cap and
+    `POST /api/v1/repos/:org/:name/publishes` answered **413 in 25 µs**, before
+    reading a byte. The bytes themselves were never the problem — they go
+    worker -> R2 over presigned PUTs and always did.
+
+  * **pgw#987.** The client read those 32 definite refusals as *"network, no
+    definite hub answer for 609s"* and re-sent a permanently-refused body for
+    ten minutes of a paid pod, because gin's `AbortWithStatusJSON` envelope
+    carries a STRING `error` with no `message` and matched neither shape
+    `http_origin.response_is_from_hub` knows.
+
+Everything here is real: a real socket, a real body cap enforced on the
+declared `Content-Length` exactly as the hub's middleware does, a real
+~200 MB artifact hashed and chunked by the real chunker and uploaded over real
+presigned PUTs by the real `CellPublisher.publish`. Nothing about the transport
+is stubbed, because every property under test is a property of the IO.
+
+Run: pytest tests/test_cell_declare_bound_th1645_pgw987.py -q
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import os
+import threading
+import urllib.parse
+import uuid
+from pathlib import Path
+
+import pytest
+
+from gen_worker import fleet_cells as fc
+from gen_worker import guard_closure, http_origin
+from gen_worker.convert.hub import HubPublishError
+from gen_worker.models import chunk_upload as cu
+
+CELL_KEY = "ck5-34b26365277a504655e6fe4f6bb42071b70df90aef1612a777325bcc"
+FAMILY = "sdxl"
+
+# The hub's group-wide default (internal/api/api.go: `maxRequestBodyMiddleware(32 << 20)`).
+HUB_BODY_CAP = 32 << 20
+
+# Attempt twenty-two's two mints measured 202,5xx,xxx and 204,7xx,xxx bytes.
+# The artifact is REAL at that size here: a declare that fits is only half the
+# proof if the bytes it describes were never moved.
+ARTIFACT_BYTES = 202_500_000
+
+
+class _Hub(http.server.BaseHTTPRequestHandler):
+    """tensorhub's v2 publish contract behind the REAL body cap.
+
+    `maxRequestBodyMiddleware` aborts on the DECLARED `Content-Length` alone,
+    before reading the body — which is why the hub answered in 25 µs and why
+    the client, still writing 200 MB into a stream the peer had finished with,
+    saw an SSL EOF and called it a network fault. Reproduced faithfully: the
+    cap is checked against the header, and the request body is NOT drained.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):  # noqa: D102
+        pass
+
+    def _json(self, code: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _over_cap(self) -> bool:
+        declared = int(self.headers.get("Content-Length") or 0)
+        cap = self.server.body_cap
+        if declared <= cap:
+            return False
+        with self.server.lock:
+            self.server.refusals.append((self.path, declared))
+        # VERBATIM the shape the deployed hub emits today (gin
+        # `AbortWithStatusJSON`): a bare string `error`, no `message`. The
+        # client must terminate on this WITHOUT needing a hub deploy — old
+        # hubs exist, and a classifier that can only read the fixed envelope
+        # would have left this incident live until both sides shipped.
+        self._json(413, {"error": "request_body_too_large",
+                         "max_body_bytes": cap,
+                         "declared_length": declared})
+        self.close_connection = True
+        return True
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        try:
+            return json.loads(raw or b"{}")
+        except ValueError:
+            return {}
+
+    def do_PUT(self):  # noqa: N802
+        srv = self.server
+        digest = urllib.parse.urlparse(self.path).path.rsplit("/", 1)[-1]
+        n = int(self.headers.get("Content-Length") or 0)
+        h = hashlib.sha256()
+        left = n
+        while left > 0:
+            block = self.rfile.read(min(1 << 20, left))
+            if not block:
+                break
+            h.update(block)
+            left -= len(block)
+        # The digest is signed into the grant: R2 refuses bytes that do not
+        # hash to it. Enforced here for the same reason it is enforced there.
+        if h.hexdigest() != digest:
+            self._json(400, {"error": {"code": "digest_mismatch"}})
+            return
+        with srv.lock:
+            srv.objects.add("sha256:" + digest)
+            srv.put_bytes += n
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self):  # noqa: N802
+        srv = self.server
+        path = urllib.parse.urlparse(self.path).path
+        if path.endswith("/publishes") and self._over_cap():
+            return
+        body = self._body()
+
+        if path.endswith("/v1/worker/cells/publish-intent"):
+            self._json(200, {"capability_token": "cap-token",
+                             "repo": f"root/family-{body.get('family')}"})
+            return
+        if path.endswith("/v1/worker/cells/publish-complete"):
+            with srv.lock:
+                srv.completes.append(dict(body))
+            self._json(200, {"recorded": True})
+            return
+        if path.endswith("/publishes"):
+            declared = {}
+            for f in body.get("files") or []:
+                for c in f.get("chunks") or []:
+                    declared["sha256:" + c["digest"]] = int(c["len"])
+                if not f.get("chunks"):
+                    declared[f["digest"]] = int(f["size_bytes"])
+            with srv.lock:
+                srv.declares.append(dict(body))
+                srv.declare_lengths.append(
+                    int(self.headers.get("Content-Length") or 0))
+                have = [d for d in declared if d in srv.objects]
+                need = [
+                    {"digest": d, "size_bytes": s,
+                     "put_url": f"{srv.base}/cas/{d.split(':', 1)[1]}",
+                     "headers": {"x-amz-checksum-sha256": d}}
+                    for d, s in declared.items() if d not in srv.objects
+                ]
+                pid = str(uuid.uuid4())
+                srv.sessions[pid] = declared
+            self._json(201, {"publish_id": pid, "have": have, "need": need,
+                             "distinct_objects": len(declared),
+                             "resident_objects": len(have)})
+            return
+        if path.endswith("/grants"):
+            pid = path.split("/publishes/")[1].split("/")[0]
+            with srv.lock:
+                declared = srv.sessions.get(pid) or {}
+                need = [
+                    {"digest": d, "size_bytes": s,
+                     "put_url": f"{srv.base}/cas/{d.split(':', 1)[1]}",
+                     "headers": {}}
+                    for d, s in declared.items() if d not in srv.objects
+                ]
+            self._json(200, {"need": need, "have": []})
+            return
+        if path.endswith("/complete"):
+            pid = path.split("/publishes/")[1].split("/")[0]
+            with srv.lock:
+                missing = [d for d in (srv.sessions.get(pid) or {})
+                           if d not in srv.objects]
+            if missing:
+                self._json(409, {"status": {
+                    "stage": "repudiated", "terminal": True,
+                    "failure": {"code": "objects_missing", "retryable": False,
+                                "message": f"{len(missing)} object(s) never landed"}}})
+                return
+            self._json(200, {"checkpoint": {"checkpoint_id": "sha256:" + "c" * 64}})
+            return
+        self._json(404, {"error": {"code": "not_found"}})
+
+
+class _Server:
+    def __init__(self, body_cap: int = HUB_BODY_CAP):
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Hub)
+        self.httpd.lock = threading.Lock()
+        self.httpd.body_cap = body_cap
+        self.httpd.objects = set()
+        self.httpd.sessions = {}
+        self.httpd.declares = []
+        self.httpd.declare_lengths = []
+        self.httpd.refusals = []
+        self.httpd.completes = []
+        self.httpd.put_bytes = 0
+        self.httpd.base = self.base
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    @property
+    def base(self) -> str:
+        host, port = self.httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture()
+def hub():
+    s = _Server()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _guard_manifest(graphs: int, rows: int) -> dict:
+    """A guard manifest the size the real one is.
+
+    Not padding: the shape is the real one (`graphs` -> per-graph guard rows),
+    scaled from the MEASURED block on a real published sdxl cell — checkpoint
+    sha256:926bc9f5…, 13,092,487 bytes of guard manifest against a 69,045,459
+    byte artifact. The envelope grows with the artifact, so attempt
+    twenty-two's ~202.5 MB cell puts it near 38 MB, which is the number that
+    crossed the 32 MiB cap. That is what this reproduces.
+    """
+    return {
+        "v": 2,
+        "graphs": {
+            f"graph_{g}": {
+                "guards": [
+                    f"L['kwargs']['x'].size()[{i}] == 128  # {'g' * 96}"
+                    for i in range(rows)
+                ],
+                "code_hash": hashlib.sha256(str(g).encode()).hexdigest(),
+            }
+            for g in range(graphs)
+        },
+        "composition": {f"mod_{i}": "sha256:" + "d" * 64 for i in range(400)},
+    }
+
+
+def _meta() -> dict:
+    """A real cell envelope: the 34 keys a published sdxl cell carries, with
+    the two unbounded blocks at their measured magnitudes."""
+    meta = {
+        "cell_key": CELL_KEY, "family": FAMILY, "sku": "rtx-4090", "sm": "89",
+        "gen_worker": "0.91.0", "kind": "aot-inductor-export", "format": "pt2",
+        "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
+        "torch": "2.9.0+cu128", "triton": "3.5.0", "cuda": "12.8",
+        "cuda_driver": "570.86", "storage_dtype": "fp8", "source_ref": "root/sdxl",
+        "source_digest": "", "family_reason": "declared-by-endpoint",
+        "low_vram_mode": False, "shapes": {"h": 1024, "w": 1024},
+        "shape_contract": {"strategy": "dynamic"}, "targets": ["unet"],
+        "guidance_scales": [7.5], "content_keys": ["unet", "vae"],
+        "libs": ["diffusers"], "image_digest": "sha256:" + "e" * 64,
+        "graph_signature": "sha256:" + "f" * 32,
+        "env_seal": {"seal": "sha256:" + "a" * 64},
+        "toolchain": {"nvcc": "12.8", "gcc": "13.2"},
+        "loaded_libs": {f"lib{i}": f"1.{i}.0" for i in range(40)},
+        "code_closure": {f"fn_{i}": "sha256:" + "b" * 64 for i in range(60)},
+        # The two unbounded blocks, at measured magnitude.
+        guard_closure.MANIFEST_KEY: _guard_manifest(graphs=700, rows=400),
+        "weight_contract": {f"unet.block{i}.weight": [1280, 1280, "fp8"]
+                            for i in range(700)},
+    }
+    return meta
+
+
+@pytest.fixture()
+def artifact(tmp_path: Path) -> Path:
+    """A REAL ~200 MB cell artifact — the size attempt twenty-two produced."""
+    out = tmp_path / f"{CELL_KEY}.tar.gz"
+    # Every megabyte distinct. A repeating block would make all four 64 MiB
+    # chunks hash the same, the CAS would dedup three of them, and the test
+    # would silently prove a 68 MB upload instead of a 200 MB one.
+    block = bytearray(os.urandom(1 << 20))
+    with out.open("wb") as fh:
+        written = 0
+        while written < ARTIFACT_BYTES:
+            block[:8] = (written // (1 << 20)).to_bytes(8, "big")
+            n = min(len(block), ARTIFACT_BYTES - written)
+            fh.write(bytes(block[:n]))
+            written += n
+    return out
+
+
+def _publisher(hub: _Server) -> fc.CellPublisher:
+    return fc.CellPublisher(
+        base_url=hub.base,
+        worker_jwt=lambda: "worker-jwt",
+        image_digest="sha256:" + "e" * 64,
+    )
+
+
+# --------------------------------------------------------------------------
+# th#1645 — the declare is CONTROL
+# --------------------------------------------------------------------------
+
+
+def test_the_envelope_that_broke_the_hub_is_over_the_cap():
+    """The premise, measured rather than asserted: the OLD declare body — the
+    whole envelope, which is what shipped — really does exceed 32 MiB."""
+    old_body = {k: v for k, v in _meta().items() if v is not None}
+    encoded = len(json.dumps({"mode": "replace", "files": [], "flavor": CELL_KEY,
+                              "metadata": old_body}).encode())
+    assert encoded > HUB_BODY_CAP, (
+        f"the fixture no longer reproduces the incident: {encoded} bytes is "
+        f"under the {HUB_BODY_CAP}-byte cap")
+
+
+def test_control_plane_metadata_drops_only_the_unbounded_blocks():
+    meta = _meta()
+    kept = fc.control_plane_metadata(meta)
+
+    for block in (guard_closure.MANIFEST_KEY, "weight_contract"):
+        assert block not in kept, f"{block} is data; it must not ride the declare"
+    # Everything else survives byte-identically — this is a projection, not a
+    # rewrite, so the hub still receives every fact it ever received that is
+    # bounded in size.
+    for key, value in meta.items():
+        if key in fc._UNBOUNDED_ENVELOPE_BLOCKS:
+            continue
+        assert kept[key] == value, f"{key} was altered on the way to the declare"
+
+    encoded = len(json.dumps(kept, sort_keys=True, default=str).encode())
+    assert encoded < fc.CELL_DECLARE_MAX_BYTES
+    # And by two orders of magnitude under the hub's route cap, so the bound
+    # that broke A1 is no longer anywhere near the traffic.
+    assert encoded * 100 < HUB_BODY_CAP
+
+
+def test_a_new_unbounded_block_is_refused_on_the_pod_and_named():
+    """The bound has to fail LOUDLY and name the culprit. The alternative is
+    what happened: a 413 that named no key, ten minutes into a paid pod, and a
+    P0 filed against the wrong subsystem."""
+    meta = _meta()
+    meta["autotune_log"] = {f"kernel_{i}": "x" * 512 for i in range(20_000)}
+
+    with pytest.raises(fc.CellPublishRefused) as excinfo:
+        fc.control_plane_metadata(meta)
+    assert "autotune_log" in str(excinfo.value)
+    assert "th#1645" in str(excinfo.value)
+    # Its own groupable token: a code defect must not land in the same bucket
+    # as the hub's trust-tier and quota refusals.
+    assert excinfo.value.code == fc.CELL_DECLARE_OVERSIZE_CODE
+    assert fc._publish_failure_phase(excinfo.value) == "cell_declare_oversize"
+
+
+def test_a_real_200mb_cell_publishes_through_the_real_cap(hub, artifact, monkeypatch):
+    """THE proof: the exact artifact size and the exact envelope that produced
+    32 × 413, now landing — declare accepted under the real cap, every chunk
+    uploaded and digest-verified, publish-complete recorded ok."""
+    monkeypatch.setattr(fc.broker, "active", lambda: False)
+    assert artifact.stat().st_size == ARTIFACT_BYTES
+
+    checkpoint = _publisher(hub).publish(FAMILY, artifact, _meta(), 354_450)
+
+    assert checkpoint == "sha256:" + "c" * 64
+    assert hub.httpd.refusals == [], (
+        f"the cap refused the publish: {hub.httpd.refusals}")
+
+    # The declare was CONTROL-sized...
+    assert len(hub.httpd.declares) == 1
+    assert hub.httpd.declare_lengths[0] < fc.CELL_DECLARE_MAX_BYTES
+    declared_meta = hub.httpd.declares[0]["metadata"]
+    assert guard_closure.MANIFEST_KEY not in declared_meta
+    assert declared_meta["cell_key"] == CELL_KEY
+
+    # ...and the DATA still moved, all of it, over presigned PUTs, every
+    # object refused unless it hashed to the digest signed into its grant.
+    assert hub.httpd.put_bytes == ARTIFACT_BYTES
+    expected_chunks = -(-ARTIFACT_BYTES // cu.CAS_CHUNK_SIZE_BYTES)
+    assert len(hub.httpd.objects) == expected_chunks
+
+    assert hub.httpd.completes[-1]["ok"] is True
+    assert hub.httpd.completes[-1]["cell_key"] == CELL_KEY
+
+
+# --------------------------------------------------------------------------
+# pgw#987 — a 413 is a verdict, not silence
+# --------------------------------------------------------------------------
+
+
+def test_the_hubs_413_envelope_is_a_definite_answer():
+    """Directly against the shape the deployed hub emits. Before this, both
+    envelope tests failed on it and the loop treated a verdict as silence."""
+
+    class _Resp:
+        status_code = 413
+        headers = {"Content-Type": "application/json"}
+        text = '{"error":"request_body_too_large"}'
+
+        def json(self):
+            return {"error": "request_body_too_large",
+                    "max_body_bytes": HUB_BODY_CAP, "declared_length": 39_000_000}
+
+    resp = _Resp()
+    # The envelope test still says "not the hub's shape" — that is the hub's
+    # bug (fixed in tensorhub separately) and NOT what makes this terminal.
+    assert http_origin.response_is_from_hub(resp) is False
+    # Terminal anyway: 413 is determined by our own Content-Length, which is
+    # byte-identical on every retry, so no origin can make retrying useful.
+    assert http_origin.is_definite_hub_answer(resp) is True
+
+
+def test_a_proxy_404_is_still_indefinite():
+    """The guard on the pgw#743 doctrine this must not weaken: ngrok's offline
+    page cost two 58-minute clones when it was read as a verdict."""
+
+    class _Resp:
+        status_code = 404
+        headers = {"Content-Type": "text/html"}
+        text = "<!DOCTYPE html><html>ngrok</html>"
+
+        def json(self):
+            raise ValueError("not json")
+
+    assert http_origin.is_definite_hub_answer(_Resp()) is False
+
+
+def test_an_oversized_publish_stops_on_the_first_refusal(artifact, monkeypatch):
+    """One attempt, a typed terminal naming the hub's own code, no retry.
+
+    Attempt twenty-two sent this body 23 times over 609 seconds and reported
+    `network, no definite hub answer`. The pod cost is the smaller half; the
+    larger half is that the typed event named the wrong subsystem and a P0 was
+    filed against a config-roll drain that had nothing to do with it.
+    """
+    monkeypatch.setattr(fc.broker, "active", lambda: False)
+    # A cap BELOW the (now bounded) declare, so the refusal is real rather
+    # than simulated: the hub answers 413 on Content-Length exactly as it does
+    # in production, while the client is still writing.
+    hub = _Server(body_cap=2048)
+    try:
+        with pytest.raises(HubPublishError) as excinfo:
+            _publisher(hub).publish(FAMILY, artifact, _meta(), 0)
+    finally:
+        hub.close()
+
+    exc = excinfo.value
+    assert exc.status == 413
+    assert exc.code == "request_body_too_large", (
+        "the typed event must carry the hub's own code — `http_413` cannot be "
+        "grouped and a transport string is a lie")
+    assert fc._publish_failure_phase(exc) == "request_body_too_large"
+    assert len(hub.httpd.refusals) == 1, (
+        f"a permanent refusal was retried {len(hub.httpd.refusals)} times")


### PR DESCRIPTION
**Unblocks pgw#868 A1.** No AOT cell has ever been publishable, for any family.

## th#1645 — the declare was 38,991,725 bytes against a 32 MiB cap

`CellPublisher.publish` forwarded `dict(meta)` — a cell's whole **envelope** — as the publish-v2 declare's `metadata`. Two of its blocks are unbounded in the size of the model (`guard_manifest` on the JIT lane, `entries` on the AOT lane), plus `composition` and `weight_contract`.

Measured on a real published sdxl cell in the standing hub (checkpoint `sha256:926bc9f5…`, 69,045,459-byte artifact):

| metadata key | bytes |
|---|---|
| `guard_manifest` | **13,092,487** |
| `composition` | 159,408 |
| `weight_contract` | 114,441 |
| all 31 others together | ~11,000 |

The declare grew with the **artifact** (19% of it). Attempt twenty-two's ~202.5 MB AOT cell put it at **38,991,725 bytes**, and the hub answered **413 in 25 µs**, thirty-two times across two cards, without reading a byte.

**Raising the route cap would have been the wrong fix.** Cell bytes have gone worker → R2 over presigned, digest-bound PUTs since th#1303 — the seam already carries control, not data. What crossed the cap was control-plane JSON mirroring data that already ships inside the artifact and is read from there (`guard_closure.load_manifest` opens the tarball; `aot_serve` reads `entries` off the unpacked package). A raise licenses that mirror to keep growing, through `io.ReadAll` + two JSON decodes into a Postgres `jsonb` column. A cap chosen today lies tomorrow.

So the payload shrinks instead. `control_plane_metadata` drops the four unbounded blocks and forwards every other key byte-identically. **Nothing is lost:** all four are packed *into* the artifact before publish (`cc.pack` / `aot_serve.pack` take the same `meta`), and the declare copy had exactly one hub-side reader — `api/cell_receipts.go:242-248`, hashing it into `manifest_digest`/`fingerprint_digest`: both `omitempty`, both over content the worker supplied anyway, both over content already bound by `snapshot_digest`, and both parsed by the worker into a dataclass field that nothing reads. Cell selection never touched them — `cell_store`'s columns come from publish-**intent**.

For scale: the largest metadata this hub has ever stored is that 13.4 MB cell, and its largest model snapshot is 288 files (~43 KB of manifest). The cell envelope was the only thing anywhere near the bound.

`CELL_DECLARE_MAX_BYTES` (4 MiB) replaces an inherited bound with a stated one: it refuses on the pod, before the wire, and **names** the offending block under its own phase `cell_declare_oversize`.

## pgw#987 — thirty-two verdicts read as silence

`is_definite_hub_answer` answered False to every refusal, because gin's `AbortWithStatusJSON` envelope carries a bare string `error` with no `message` and matches neither shape `response_is_from_hub` knows. A permanently-refused body was re-sent for 609 s, and the typed event said *"network, no definite hub answer"* while the hub's log said `413` — which is how th#1644 came to be filed against a config-roll drain that had nothing to do with it. The tracker's suspected mechanism (urllib3 never handing over the response) is wrong, or at most secondary: reproduced here on a real socket with the response in hand.

The fix is deliberately narrow. `REQUEST_DETERMINED_STATUSES = {413}` — statuses whose cause is a property of the request *we* sent. `Content-Length` is byte-identical on every retry, so no origin can make retrying useful. **Not widened to "all 4xx":** pgw#743 exists because a proxy-issued 404 cost two 58-minute clones; a 403 can be a token about to rotate, a 409 a race. `test_a_proxy_404_is_still_indefinite` guards the doctrine.

`_error_code_of` / `_hub_error_code` now also read the string-shaped `error`, so `_publish_failure_phase` returns `request_body_too_large` instead of the ungroupable `http_413`.

## Proof

`tests/test_cell_declare_bound_th1645_pgw987.py` — real socket, real cap on the declared `Content-Length` exactly as the middleware does it, real **202,500,000-byte** artifact with every megabyte distinct so the CAS cannot dedup the proof away. All four 64 MiB chunks upload and are refused unless they hash to the digest signed into their grant.

RED-verified both ways:
- restoring the old declare reproduces the incident verbatim — `413 … "max_body_bytes": 33554432, "declared_length": 38991725`
- removing the 413 rule reproduces the retry storm — `a permanent refusal was retried 4 times`, `attempt 1..3 status=413`

Gate: **3290 passed, 37 skipped, 1 xfailed** (`pytest tests/ -n 4 --dist loadfile`); mypy clean over 231 files; ruff clean; both lint scripts exit 0.

Paired with the tensorhub half (the 413 envelope + the discharge-ordering fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)