### PR TITLE
pgw#984 + pgw#985: the AOT recipe proves the endpoint's forward runs, and a deterministic arm decline is a typed refusal on both recipes

### DIFF
--- a/changelog.d/pgw984-pgw985.md
+++ b/changelog.d/pgw984-pgw985.md
@@ -1,0 +1,55 @@
+- **pgw#984: an AOT mint never ran the endpoint's own forward, so a green mint
+  proved nothing about whether the cell it sealed could serve.** Measured by
+  the pgw#978 micro-mint rig, comparing the two recipes at ~20 s a cycle: the
+  AOT recipe's phase table was `load / trace_graph / seal_publish / finalize`
+  with **no `warmup_forward` row at all**. `torch.export` traces the declared
+  modules directly, so the endpoint's handler was never called — which means
+  pgw#969's crash class (`ctx.slots["pipeline"]` unbound, 0.0 s into
+  `warmup_forward`, twice on production L40S pods) was *unreachable* on that
+  recipe. An endpoint whose forward dies on its first real request minted,
+  sealed and published an AOT cell fine. `mint_child.mint` now drives the
+  endpoint's OWN derived warm plan — the same `_run_warm_job` the dynamo
+  recipe uses, the same `warmup.plan` over the same class-scoped sibling set —
+  once, eagerly, before a byte is exported. One job and not the whole plan:
+  the export derives its own class set, so a full eager pass would buy minutes
+  and prove nothing the first forward does not. The phase table now carries
+  `warmup_forward` on both recipes, so a reader of a green mint can tell.
+  CONSEQUENCE, stated because it is a behaviour change and not only a new
+  check: an endpoint whose class carries no `@endpoint` declaration, or whose
+  derived warm plan is empty, now REFUSES an AOT mint where it used to seal
+  one. Both were already dynamo-recipe refusals; a mint that cannot prove its
+  handler runs must not publish a cell claiming it does.
+- **pgw#985: the dynamo recipe classified a deterministic refusal as a crash,
+  and named it wrong.** Same rig, one recipe flag changed:
+  `compile_cache.begin_fleet_mint` raised `RuntimeError: no compile targets
+  resolved on TinyDiffusionPipeline` — about a pipeline whose `.unet`
+  `has_compile_target` had resolved one frame earlier. Two defects in one
+  line, and each is a class:
+  - **Two computations of one fact** (§1.29, th#1616). `has_compile_target`
+    scanned `cfg.targets`, `apply` scanned them again in its own loop, and
+    `begin_fleet_mint` reported whichever declined under the first one's
+    sentence. What had actually declined was `apply`, because the process had
+    no CUDA. `compile_cache.resolve_targets` is now the ONE target authority
+    (`has_compile_target`, `apply` and `begin_fleet_mint` all read it) and
+    `compile_cache.arming_block` is the ONE precondition authority, returning
+    the named reason `apply` logs and `begin_fleet_mint` refuses with. The
+    wiring fact ("this pipeline owns no declared target") and the environment
+    fact ("this process cannot arm the targets it owns") are now separate
+    sentences. The same misnaming in `build` and `_compile_and_warm` is gone
+    with them.
+  - **A bare `RuntimeError` exits 1, which classifies `CRASHED`** — the
+    retryable class, for a fact no retry can change. On a pod that is a second
+    billed mint for a condition the first attempt already settled. Every
+    decline `begin_fleet_mint` can take is deterministic for the life of the
+    process, so it now raises the typed `compile_cache.CompileArmRefused`,
+    which the mint child turns into `MintChildRefused` -> `EXIT_REFUSED` ->
+    terminal on attempt one — exactly what the AOT recipe has always done with
+    the identical condition. A warm-forward failure is classified the same way
+    on BOTH recipes now (the hub's `self_mint_abort` event already booked
+    `phase=warmup_forward` as `deterministic` while the worker was still
+    calling it `crashed`); a resource shortfall still re-raises untouched so
+    `EXIT_RESOURCE` and pgw#848's re-budgeted retry are unaffected.
+- A refused or crashed mint's report carried `phase=""` in every case:
+  `_close_phases()` closes the open phase, and `MintReport.phase` was read
+  after it in the same call. The open phase is now captured first, so a
+  failure report says which phase it died in.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2228,11 +2228,16 @@ def resolve_targets(
 
     ``(declared name, owner, attribute, eager callable)`` per resolvable
     target, in declaration order. :func:`has_compile_target`, :func:`apply`
-    and :func:`begin_fleet_mint` all read THIS list (§1.29, one relation):
-    two computations of one fact disagree eventually, and this one did — the
-    mint's arm gate said "no compile targets resolved" on a pipeline whose
-    ``.unet`` resolved fine, because it was reporting a different fact
-    (:func:`arming_block`) under this one's sentence.
+    and :func:`begin_fleet_mint` all read THIS list (§1.29, one relation) —
+    it used to be scanned independently by the first two, which is how a
+    reader of the third could not tell which scan had spoken.
+
+    Whether the pipeline OWNS a declared target is the only question answered
+    here. Whether this process can ARM the targets it owns is a different
+    question with a different answer, and :func:`arming_block` owns it;
+    conflating the two is what let a cardless mint pod report "no compile
+    targets resolved on TinyDiffusionPipeline" about a pipeline whose
+    ``.unet`` had resolved a frame earlier (pgw#985).
     """
     out: List[Tuple[str, Any, str, Callable[..., Any]]] = []
     for target in tuple(getattr(cfg, "targets", ()) or ()):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2208,6 +2208,42 @@ def _resolve_target(pipeline: Any, target: str) -> Optional[Tuple[Any, str, Call
     return None
 
 
+class CompileArmRefused(RuntimeError):
+    """A NAMED, deterministic reason this process cannot arm this pipeline.
+
+    pgw#985: what decides whether a second pod gets bought is the
+    CLASSIFICATION, not the message. ``begin_fleet_mint`` used to raise a bare
+    ``RuntimeError`` for every decline — which the mint child let out as exit
+    1 (``CRASHED``, retryable) while the AOT recipe typed the identical
+    condition as a refusal (``EXIT_REFUSED``, terminal). Same fact, two
+    vocabularies, and the retryable one billed a second mint that could not
+    possibly succeed.
+    """
+
+
+def resolve_targets(
+    pipeline: Any, cfg: Any,
+) -> List[Tuple[str, Any, str, Callable[..., Any]]]:
+    """The declared targets ``pipeline`` actually OWNS — the ONE authority.
+
+    ``(declared name, owner, attribute, eager callable)`` per resolvable
+    target, in declaration order. :func:`has_compile_target`, :func:`apply`
+    and :func:`begin_fleet_mint` all read THIS list (§1.29, one relation):
+    two computations of one fact disagree eventually, and this one did — the
+    mint's arm gate said "no compile targets resolved" on a pipeline whose
+    ``.unet`` resolved fine, because it was reporting a different fact
+    (:func:`arming_block`) under this one's sentence.
+    """
+    out: List[Tuple[str, Any, str, Callable[..., Any]]] = []
+    for target in tuple(getattr(cfg, "targets", ()) or ()):
+        resolved = _resolve_target(pipeline, str(target))
+        if resolved is None:
+            continue
+        owner, attr, fn = resolved
+        out.append((str(target), owner, attr, fn))
+    return out
+
+
 def has_compile_target(pipeline: Any, cfg: Any) -> bool:
     """Whether ``pipeline`` owns at least one callable declared by ``cfg``.
 
@@ -2216,10 +2252,41 @@ def has_compile_target(pipeline: Any, cfg: Any) -> bool:
     is a compile-adoption target; family-wide scans must not try to wrap every
     resident model object.
     """
-    return any(
-        _resolve_target(pipeline, str(target)) is not None
-        for target in tuple(getattr(cfg, "targets", ()) or ())
-    )
+    return bool(resolve_targets(pipeline, cfg))
+
+
+def arming_block(
+    pipeline: Any, cfg: Any, *, cache_ready: bool, allow_cold: bool,
+) -> str:
+    """Why :func:`apply` would decline to arm — ``""`` when nothing blocks it.
+
+    The ONE precondition authority, for the same reason
+    :func:`resolve_targets` is the one target authority. Every reason here is
+    deterministic for the life of this process: none of them can differ on a
+    retry, so a caller that must classify (the mint child) can refuse on any
+    of them without losing a mint a second attempt would have made.
+
+    Deliberately side-effect free — :func:`apply` still owns the arming
+    mutations; this only names.
+    """
+    if _PROCESS_COMPILES_DISABLED:
+        return f"process compiles are disabled: {_PROCESS_COMPILES_DISABLED}"
+    if operator_eager_pin(pipeline):
+        return ("the hub-resolved execution lane is operator-pinned to +eager "
+                "(pgw#714 kill switch)")
+    try:
+        import torch
+    except Exception as exc:  # noqa: BLE001 — a torchless process is eager
+        return f"torch is not importable ({type(exc).__name__}: {exc})"
+    if not torch.cuda.is_available():
+        return "torch reports no CUDA device in this process"
+    if cache_ready:
+        return ""
+    if not allow_cold:
+        return "no verified cache artifact was seeded and cold compile was not requested"
+    if not toolchain_present():
+        return "cold compile was requested but no C compiler is on PATH"
+    return ""
 
 
 def _type_name(value: Any) -> str:
@@ -3102,20 +3169,18 @@ def apply(
     """
     if getattr(pipeline, _MARKER_ATTR, None) is not None:
         return True
-    if _PROCESS_COMPILES_DISABLED:
-        logger.error(
-            "compile-cache: not arming (process compiles disabled: %s); "
-            "staying eager", _PROCESS_COMPILES_DISABLED)
+    # pgw#985: ONE reading of the preconditions, named. `begin_fleet_mint`
+    # reads the same function to say WHY it refused, so the two can never
+    # again describe the same decline in two different sentences.
+    block = arming_block(
+        pipeline, cfg, cache_ready=cache_ready, allow_cold=allow_cold)
+    if block:
+        logger.log(
+            logging.ERROR if _PROCESS_COMPILES_DISABLED else logging.INFO,
+            "compile-cache: not arming (%s); staying eager", block)
         return False
-    if operator_eager_pin(pipeline):
-        logger.info(
-            "compile-cache: operator-pinned +eager execution lane — compile "
-            "arming suppressed (pgw#714 kill switch); staying eager")
-        return False
-    try:
-        import torch
-    except Exception:
-        return False
+    import torch
+
     # gw#608: cross-pod cell portability requires the (portable) FX graph
     # cache to be the lookup surface — see _disable_aot_autograd_cache.
     _disable_aot_autograd_cache()
@@ -3123,19 +3188,6 @@ def apply(
     # construction: every compile path arms through apply()):
     _install_fx_system_shim()          # SKU name -> sm token (P0, review §6.1)
     _set_semantic_cache_tag(pipeline, cfg)  # semantic identity tag (§6.3)
-    if not torch.cuda.is_available():
-        logger.info("compile-cache: no CUDA; staying eager")
-        return False
-    if not cache_ready:
-        if not allow_cold:
-            logger.info("compile-cache: no verified cache artifact; staying eager")
-            return False
-        if not toolchain_present():
-            logger.warning(
-                "compile-cache: cold compile explicitly requested but no C "
-                "compiler is on PATH; staying eager",
-            )
-            return False
 
     # Dynamo's per-code-object recompile limit defaults to 8; a preset table
     # bigger than that (LTX: 12 video graphs, ie#381) would silently fall
@@ -3178,12 +3230,7 @@ def apply(
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
     regional_mods: list[Any] = []
-    for target in cfg.targets:
-        resolved = _resolve_target(pipeline, target)
-        if resolved is None:
-            logger.debug("compile-cache: pipeline has no target %r; skipping", target)
-            continue
-        owner, attr, fn = resolved
+    for target, owner, attr, fn in resolve_targets(pipeline, cfg):
         # pgw#817/D4: computed BEFORE the branch so a declined regional target
         # falls through to the whole-forward branch (which does apply the
         # declared marks) instead of being skipped entirely.
@@ -3835,7 +3882,13 @@ def build(
     # Cold compilation is an explicit producer-library operation; serving
     # workers have no environment switch that can enter this path.
     if not apply(pipe, cfg, cache_ready=False, guard=False, allow_cold=True):
-        raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
+        # pgw#985: name the fact that actually declined — "no compile targets"
+        # was this line's answer to every one of them, including "no CUDA".
+        raise CompileArmRefused(
+            f"cannot arm {type(pipe).__name__} for a cold compile: "
+            + (arming_block(pipe, cfg, cache_ready=False, allow_cold=True)
+               or f"no compile target resolves for targets="
+                  f"{[str(t) for t in (getattr(cfg, 'targets', ()) or ())]}"))
 
     timings: Dict[str, float] = {}
     decode = any(t.startswith("vae") for t in cfg.targets)
@@ -3988,7 +4041,13 @@ def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2, say: Any = None) -
     call must fail the mint — a silently-eager capture must never be saved."""
     _say = say if callable(say) else (lambda msg: logger.info("%s", msg))
     if not apply(pipe, cfg, cache_ready=False, guard=False, allow_cold=True):
-        raise RuntimeError(f"no compile targets resolved on {type(pipe).__name__}")
+        # pgw#985: name the fact that actually declined — "no compile targets"
+        # was this line's answer to every one of them, including "no CUDA".
+        raise CompileArmRefused(
+            f"cannot arm {type(pipe).__name__} for a cold compile: "
+            + (arming_block(pipe, cfg, cache_ready=False, allow_cold=True)
+               or f"no compile target resolves for targets="
+                  f"{[str(t) for t in (getattr(cfg, 'targets', ()) or ())]}"))
     import torch
 
     decode = any(t.startswith("vae") for t in cfg.targets)
@@ -4106,9 +4165,19 @@ def begin_fleet_mint(pipe: Any, cfg: Any, capture: Path) -> None:
     other code path that could re-create serving's call shape, so the
     mint can never diverge from what it actually serves.
 
-    Raises if no compile target resolves on ``pipe`` (nothing to prove or
-    publish); the caller's miss policy applies exactly as it did for a
-    failed :func:`mint_artifact` call.
+    Raises :class:`CompileArmRefused` — typed and deterministic — when there
+    is nothing to prove or publish; the caller's miss policy applies exactly
+    as it did for a failed :func:`mint_artifact` call. pgw#985: the two facts
+    that can refuse here are DIFFERENT and are now named as such. A pipeline
+    that owns no declared target is a WIRING fact; a process that cannot arm
+    the targets it does own (no CUDA, no toolchain, an operator eager pin) is
+    an ENVIRONMENT fact. Both used to raise the wiring sentence, so a cardless
+    mint pod reported "no compile targets resolved on TinyDiffusionPipeline"
+    about a pipeline whose ``.unet`` had resolved a frame earlier.
+
+    The DECISION still has one evaluator — :func:`apply` — and this only names
+    what it declined on, through the same :func:`arming_block` ``apply``
+    itself consulted.
 
     gw#608 ROOT CAUSE lived here: the cache-dir env is PROCESS-GLOBAL, and
     this function re-pointed it BEFORE knowing the arm could succeed. On a
@@ -4121,18 +4190,30 @@ def begin_fleet_mint(pipe: Any, cfg: Any, capture: Path) -> None:
     BEFORE this call). The arm is therefore transactional now: nothing to
     arm never touches the env, and an arm failure restores it exactly.
     """
-    if not has_compile_target(pipe, cfg):
-        raise RuntimeError(
-            f"no compile targets resolved on {type(pipe).__name__}")
+    family = str(getattr(cfg, "family", "") or "(unset)")
+    owned = [name for name, *_ in resolve_targets(pipe, cfg)]
+    if not owned:
+        raise CompileArmRefused(
+            f"no compile target resolves on {type(pipe).__name__} for family "
+            f"{family!r}: declared "
+            f"targets={[str(t) for t in (getattr(cfg, 'targets', ()) or ())]}")
     prior = {
         env: os.environ.get(env)
         for env in ("TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR")
     }
     capture_env(capture)
     try:
+        # `apply` DECIDES — one call, and it reads `arming_block` for the same
+        # preconditions this refusal then names. Asking `arming_block` here
+        # first would be a second gate `apply` does not answer to, and the
+        # decision must have exactly one evaluator.
         if not apply(pipe, cfg, cache_ready=False, guard=True, allow_cold=True):
-            raise RuntimeError(
-                f"no compile targets resolved on {type(pipe).__name__}")
+            raise CompileArmRefused(
+                f"{type(pipe).__name__} owns the declared compile target(s) "
+                f"{owned} for family {family!r}, but this process cannot arm "
+                f"them: "
+                + (arming_block(pipe, cfg, cache_ready=False, allow_cold=True)
+                   or "apply() declined without naming a precondition"))
     except BaseException:
         for env, value in prior.items():
             if value is None:
@@ -4239,10 +4320,13 @@ __all__ = [
     "ARTIFACT_FORMAT",
     "AdoptError",
     "CellSelectionBugError",
+    "CompileArmRefused",
     "CompiledExecutionLaneUnavailableError",
     "build",
     "apply",
     "apply_lora_execution_lane",
+    "arming_block",
+    "resolve_targets",
     "artifact_fx_lines",
     "artifact_metadata",
     "begin_fleet_mint",

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -36,6 +36,13 @@ What it does, and why in this order
    So the child runs ``warmup.plan`` over the same sibling spec set the parent
    would have, through the endpoint's own handler. Same code, same shapes,
    same seal — a different PROCESS, not a different execution.
+
+   The AOT recipe traces with ``torch.export`` instead, so its cell is not
+   derived from these forwards — but it runs ONE of them anyway (pgw#984),
+   before exporting. A recipe that never enters the handler cannot tell a
+   working endpoint from one whose forward dies on its first request, and a
+   green mint that sealed a cell for the latter is the shape pgw#969 cost
+   four hours to find on a pod.
 6. **Pack** with ``finish_fleet_mint`` and write a typed report.
 
 The parity claim is checked, not asserted
@@ -450,6 +457,43 @@ def _run_warm_job(
                     pass
 
 
+def _drive_warm_plan(
+    instance: Any, jobs: Sequence[Any], request: MintRequest, *,
+    proof_only: bool = False,
+) -> None:
+    """Run the endpoint's OWN warm plan, framed as ``warmup_forward``.
+
+    ``proof_only`` runs ONE job (pgw#984, the AOT recipe); otherwise the whole
+    plan runs (the dynamo recipe, where these forwards ARE the compile).
+
+    Failure classification is the same on both recipes (pgw#985). A resource
+    shortfall re-raises untouched so ``main`` can exit ``EXIT_RESOURCE`` and
+    the parent can re-budget; everything else is a REFUSAL. The endpoint's
+    handler, its declared warm plan and the parent's slot bindings are all
+    fixed for the life of this request file, so a forward that raised once
+    raises identically on attempt two — the hub already books this event as
+    ``(phase=warmup_forward, deterministic)`` while the worker was still
+    calling it ``crashed`` and buying the second pod.
+    """
+    total = 1 if proof_only else len(jobs)
+    frame(phase="warmup_forward", step=0, total=total)
+    for index, job in enumerate(jobs[:total], start=1):
+        frame(phase="warmup_forward", step=index, total=total,
+              note=job.spec.name)
+        try:
+            _run_warm_job(
+                instance, job, dict(request.configs.get(job.spec.name) or {}),
+                request.execution_lane, origin=mint_identity(request))
+        except BaseException as exc:
+            if _is_resource_error(exc) or not isinstance(exc, Exception):
+                raise
+            raise MintChildRefused(
+                f"{mint_identity(request)}: the endpoint's own warm plan does "
+                f"not run — warm job {job.spec.name!r} raised "
+                f"{type(exc).__name__}: {exc}. A cell must not seal for a "
+                f"handler that cannot serve.") from exc
+
+
 def _drain_router(pipe: Any, *, poll_s: float = 0.5) -> None:
     """Wait out any hot-swap router queue before packing.
 
@@ -502,7 +546,7 @@ def _measure_execution_lane(execution_lane: str, load: Any) -> Any:
 
     kernel_path.pin(execution_lane, "mint-time A/B probe (pgw#947)")
     try:
-        pipe, spec = load(execution_lane)
+        _instance, pipe, spec = load(execution_lane)
         return kernel_path.measure(execution_lane, aot_mint.bench_step(pipe, spec))
     except Exception as exc:  # noqa: BLE001 — a candidate that cannot be
         # built or measured drops out of the ranking; it never fails the
@@ -513,12 +557,14 @@ def _measure_execution_lane(execution_lane: str, load: Any) -> Any:
             execution_lane=execution_lane, unavailable=f"build: {type(exc).__name__}: {exc}")
 
 
-def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
+def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any, Any]:
     """MEASURE which serving-kernel lane wins on THIS card (pgw#947).
 
-    Returns ``(verdict, pipeline, spec)`` — the winning lane's loaded
-    pipeline and its export spec, ready to mint, so the artifact and the
-    verdict inside it can never describe different code.
+    Returns ``(verdict, endpoint instance, pipeline, spec)`` — the winning
+    lane's loaded pipeline and its export spec, ready to mint, so the artifact
+    and the verdict inside it can never describe different code. The INSTANCE
+    rides along because the AOT recipe now proves the endpoint's own warm plan
+    runs before it exports (pgw#984), and the handler is a method on it.
 
     A "lane" is the pgw#863 COMBINATION of both axes (``fused+packed``,
     ``baseline+packed``, ...), so the ranking prices the modulation lane's
@@ -556,8 +602,8 @@ def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
             f"{detail or 'no rival'}")
         kernel_path.pin(verdict.winner, f"sole candidate: {verdict.detail}")
         frame(phase="load", note=f"kernel lane {verdict.winner} (sole)")
-        pipe, spec = load(verdict.winner)
-        return verdict, pipe, spec
+        instance, pipe, spec = load(verdict.winner)
+        return verdict, instance, pipe, spec
 
     measurements = []
     for index, execution_lane in enumerate(candidates, start=1):
@@ -580,8 +626,8 @@ def execution_lane_verdict_for(load: Any) -> Tuple[Any, Any, Any]:
     # The winner is loaded FRESH rather than kept from its probe pass: the
     # probe ran `torch.compile` over the denoiser, and the graph that gets
     # exported must come from a pipeline nothing has warmed or specialized.
-    pipe, spec = load(verdict.winner)
-    return verdict, pipe, spec
+    instance, pipe, spec = load(verdict.winner)
+    return verdict, instance, pipe, spec
 
 
 def _mint_aot(
@@ -745,9 +791,10 @@ def mint(request: MintRequest) -> MintReport:
         + (f" (+{sum(len(c) for c in overrides.values())} component "
            f"override(s))" if overrides else "")))
 
-    def _load(_execution_lane: str) -> Tuple[Any, Any]:
-        """One full endpoint load on the currently pinned kernel lane, plus
-        the export spec of the pipeline it produced."""
+    def _load(_execution_lane: str) -> Tuple[Any, Any, Any]:
+        """One full endpoint load on the currently pinned kernel lane: the
+        endpoint instance, its compile-target pipeline, and that pipeline's
+        export spec."""
         from . import fleet_cells
 
         obj = spec.cls()
@@ -758,14 +805,30 @@ def mint(request: MintRequest) -> MintReport:
         frame(phase="load", note=f"compile target on slot {_slot!r}")
         if cfg.lora_bucket:
             cc.apply_lora_execution_lane(loaded_pipe, cfg.lora_bucket)
-        return loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
+        return obj, loaded_pipe, fleet_cells.aot_export_spec(loaded_pipe, cfg)
 
     if request.recipe == RECIPE_AOT:
         # pgw#947: MEASURE the serving-kernel lane on this card before the
         # cell is exported, so the cell can carry the verdict instead of the
         # fleet re-deriving it from a hand-maintained SM tuple. The probe
         # loads once per candidate; the winner's pipeline is what gets minted.
-        verdict, pipe, aot_spec = execution_lane_verdict_for(_load)
+        verdict, instance, pipe, aot_spec = execution_lane_verdict_for(_load)
+        # pgw#984: PROVE the endpoint's own forward runs, before a byte is
+        # exported. `torch.export` traces the declared graph classes off the
+        # modules directly and never enters the handler, so an AOT mint's
+        # phase table read `load / trace_graph / seal_publish / finalize` —
+        # green, with no `warmup_forward` row, for an endpoint whose handler
+        # could not run at all. That is precisely pgw#969's crash class
+        # (`ctx.slots["pipeline"]`, 0.0 s into `warmup_forward`), and it was
+        # unreachable on this recipe.
+        #
+        # ONE forward, not the whole plan: the export derives its own class
+        # set, so a full eager pass would buy minutes and prove nothing more
+        # than the first job does. Eager — nothing is armed here, unlike the
+        # dynamo recipe where the identical call IS the compile — so it
+        # specializes no graph the export then has to trace around.
+        _drive_warm_plan(
+            instance, _warm_jobs(siblings), request, proof_only=True)
         # pgw#805: the SAME loaded pipeline, a different recipe. Deliberately
         # NOT `aot_mint.compose_for_mint` (which builds a pipeline from a
         # model ref for an operator's mint pod): the graphs this cell must
@@ -789,17 +852,20 @@ def mint(request: MintRequest) -> MintReport:
     jobs = _warm_jobs(siblings)
     # Arm COLD, pointed at our own capture dir: the warm forwards below are
     # the ONLY compile this cell will ever see (gw#587).
-    cc.begin_fleet_mint(pipe, cfg, capture)
+    #
+    # pgw#985: an arm decline is DETERMINISTIC — no target on the pipeline, no
+    # CUDA, no toolchain, an operator eager pin — and none of them can differ
+    # on a second attempt. This used to escape as a bare `RuntimeError`, exit
+    # 1, `CRASHED`, and bought a second billed pod for a sentence the first
+    # one had already settled. The AOT recipe has always typed the identical
+    # condition as a refusal; both recipes now say it the same way.
+    try:
+        cc.begin_fleet_mint(pipe, cfg, capture)
+    except cc.CompileArmRefused as exc:
+        raise MintChildRefused(f"{mint_identity(request)}: {exc}") from exc
     miss_before = cc.cache_miss_count(pipe)
 
-    frame(phase="warmup_forward", step=0, total=len(jobs))
-    for index, job in enumerate(jobs, start=1):
-        frame(
-            phase="warmup_forward", step=index, total=len(jobs),
-            note=job.spec.name)
-        _run_warm_job(
-            instance, job, dict(request.configs.get(job.spec.name) or {}),
-            request.execution_lane, origin=mint_identity(request))
+    _drive_warm_plan(instance, jobs, request)
     frame(phase="inductor_compile", note="draining any queued compiles")
     _drain_router(pipe)
 
@@ -941,21 +1007,25 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         report = mint(request)
     except MintChildRefused as exc:
         # th#1322: a refused mint's phase table is where it spent the time
-        # BEFORE refusing — the most useful half of a failed mint.
+        # BEFORE refusing — the most useful half of a failed mint. The OPEN
+        # phase is read first on purpose: `_close_phases` closes it, and
+        # reading after would report every failure as phase "".
+        died_in = _PHASE_OPEN[0]
         _write_report(report_path, MintReport(
             status="refused", detail=str(exc)[:2000],
             elapsed_s=time.monotonic() - started, phases=_close_phases(),
-            phase=_PHASE_OPEN[0], peak_vram_bytes=_peak_vram(),
+            phase=died_in, peak_vram_bytes=_peak_vram(),
             mint_phases=dict(getattr(exc, "mint_phases", None) or {})))
         print(f"REFUSED: {exc}", file=sys.stderr)
         return EXIT_REFUSED
     except BaseException as exc:  # noqa: BLE001 — every death is classified
         resource_shortfall = _is_resource_error(exc)
+        died_in = _PHASE_OPEN[0]
         _write_report(report_path, MintReport(
             status="resource" if resource_shortfall else "failed",
             detail=f"{type(exc).__name__}: {exc}"[:2000],
             elapsed_s=time.monotonic() - started, phases=_close_phases(),
-            phase=_PHASE_OPEN[0], peak_vram_bytes=_peak_vram(),
+            phase=died_in, peak_vram_bytes=_peak_vram(),
             # pgw#825: a CRASH's paid compiles are measurable too — the mint
             # attaches its partial table to whatever it died with.
             mint_phases=dict(getattr(exc, "mint_phases", None) or {})))

--- a/tests/test_kernel_lane_pgw947.py
+++ b/tests/test_kernel_lane_pgw947.py
@@ -574,7 +574,10 @@ def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
     def _load(execution_lane: str):
         loads.append(execution_lane)
         assert kl.pinned()[0] == execution_lane, "the lane must be pinned BEFORE loading"
-        return f"pipe:{execution_lane}", f"spec:{execution_lane}"
+        # pgw#984: the endpoint INSTANCE rides out with the pipeline — the AOT
+        # recipe proves the handler runs before it exports, and the handler is
+        # a method on it.
+        return f"obj:{execution_lane}", f"pipe:{execution_lane}", f"spec:{execution_lane}"
 
     monkeypatch.setattr(
         kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
@@ -592,11 +595,12 @@ def test_mint_probes_every_candidate_and_mints_the_winner_fresh(
 
     monkeypatch.setattr(kl, "measure", _measure)
 
-    verdict, pipe, spec = mint_child.execution_lane_verdict_for(_load)
+    verdict, obj, pipe, spec = mint_child.execution_lane_verdict_for(_load)
     assert verdict.winner == "baseline+dense"
     assert verdict.binding == kl.BIND_SPEED
     assert loads == ["baseline+dense", "fused+packed", "baseline+dense"]
-    assert (pipe, spec) == ("pipe:baseline+dense", "spec:baseline+dense")
+    assert (obj, pipe, spec) == (
+        "obj:baseline+dense", "pipe:baseline+dense", "spec:baseline+dense")
     assert kl.pinned()[0] == "baseline+dense"
     # Both lanes' numbers are in the record, not just the winner's.
     assert verdict.measurement("fused+packed").ms_per_step == 350.0
@@ -621,8 +625,10 @@ def test_mint_records_a_typed_verdict_when_only_one_execution_lane_can_be_built(
         kl, "measure",
         lambda *a: pytest.fail("no benchmark for a sole candidate"))
 
-    verdict, pipe, _spec = mint_child.execution_lane_verdict_for(
-        lambda execution_lane: (f"pipe:{execution_lane}", f"spec:{execution_lane}"))
+    verdict, _obj, pipe, _spec = mint_child.execution_lane_verdict_for(
+        lambda execution_lane: (
+            f"obj:{execution_lane}", f"pipe:{execution_lane}",
+            f"spec:{execution_lane}"))
     assert verdict.winner == "baseline+dense"
     assert verdict.binding == kl.BIND_SOLE_CANDIDATE
     assert "sm_89 is not Blackwell" in verdict.detail
@@ -638,7 +644,7 @@ def test_a_execution_lane_that_cannot_be_built_never_fails_the_mint(
     def _load(execution_lane: str):
         if execution_lane == "fused+packed":
             raise RuntimeError("triton kernels will not compile here")
-        return f"pipe:{execution_lane}", f"spec:{execution_lane}"
+        return f"obj:{execution_lane}", f"pipe:{execution_lane}", f"spec:{execution_lane}"
 
     monkeypatch.setattr(
         kl, "candidates_here", lambda: ("baseline+dense", "fused+packed"))
@@ -651,7 +657,7 @@ def test_a_execution_lane_that_cannot_be_built_never_fails_the_mint(
         lambda execution_lane, step: kl.Measurement(
             execution_lane=execution_lane, ms_per_step=228.0, peak_bytes=int(44.1 * GB)))
 
-    verdict, pipe, _spec = mint_child.execution_lane_verdict_for(_load)
+    verdict, _obj, pipe, _spec = mint_child.execution_lane_verdict_for(_load)
     assert verdict.winner == "baseline+dense"
     assert ("will not compile here"
             in verdict.measurement("fused+packed").unavailable)

--- a/tests/test_mint_recipe_parity_pgw984_pgw985.py
+++ b/tests/test_mint_recipe_parity_pgw984_pgw985.py
@@ -1,0 +1,361 @@
+"""pgw#984 + pgw#985 — the two mint recipes, held to one contract.
+
+Both defects were MEASURED by the pgw#978 micro-mint rig inside its first hour,
+at ~20 s a cycle, by running the same machinery twice with only
+``MintRequest.recipe`` changed. They are the same kind of finding: the two
+recipes had drifted into two different answers to one question.
+
+**pgw#984 — the AOT recipe never entered the endpoint.** A measured AOT mint's
+phase table was ``{'load': 4.4, 'trace_graph': 8.1, 'seal_publish': 0.9,
+'finalize': 0.0}`` — no ``warmup_forward`` row at all, because
+``torch.export`` traces the declared modules directly and the handler is never
+called. So a green AOT mint proved the family's graphs export and said nothing
+about whether the forward those graphs serve can run. pgw#969's crash
+(``ctx.slots["pipeline"]``, 0.0 s into ``warmup_forward``, twice on L40S pods)
+is *unreachable* on that recipe: it would have sealed and published a cell for
+an endpoint whose first real request dies.
+
+**pgw#985 — the dynamo recipe's deterministic refusal was a crash.** On the
+same box, the same pipeline, the dynamo recipe raised::
+
+    RuntimeError: no compile targets resolved on TinyDiffusionPipeline
+
+...out of ``compile_cache.begin_fleet_mint`` — about a pipeline whose ``.unet``
+``has_compile_target`` had resolved one frame earlier. Two things were wrong
+and each is a class:
+
+1. ``begin_fleet_mint`` answered TWO facts with ONE sentence. The pipeline
+   owned its declared target; what actually declined was ``apply``, because
+   the process had no CUDA. Two computations of one fact disagree eventually
+   (§1.29, th#1616) — these two had, and the survivor lied.
+2. A bare ``RuntimeError`` exits 1, which classifies ``CRASHED`` — the
+   retryable class. On a pod that is a second billed mint for a condition the
+   first attempt had already settled. The AOT recipe types the identical
+   condition ``MintChildRefused`` -> ``EXIT_REFUSED`` -> terminal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import compile_cache as cc
+from gen_worker import mint_child, mint_delegate
+from gen_worker import mint_process as mp
+from gen_worker.api.binding import ModelRef
+from gen_worker.registry import CompileCell
+
+torch = pytest.importorskip("torch")
+
+HERE = Path(__file__).resolve().parent
+ENDPOINT_MODULE = "harness.tiny_diffusion_endpoint"
+FUNCTION = "rig-generate"
+GIB = 1 << 30
+
+
+# ---------------------------------------------------------------------------
+# 1. ONE target authority, ONE precondition authority
+# ---------------------------------------------------------------------------
+
+
+class _Unet:
+    def forward(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        return None
+
+
+class _Pipe:
+    def __init__(self) -> None:
+        self.unet = _Unet()
+
+
+def _cfg(*targets: str) -> Any:
+    return SimpleNamespace(
+        targets=targets, shapes=((64, 64),), family="pgw985", regional=False,
+        dynamic=(), lora_bucket=0, guidance_scales=(), text_lens=(),
+        text_len=77)
+
+
+@pytest.fixture
+def cardless(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A process that can see no card — the rig's own condition, forced so the
+    row measures the same thing on a laptop with a card and on CI without."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+
+def test_the_two_target_resolutions_are_one_function() -> None:
+    """RED at HEAD: ``has_compile_target`` scanned ``cfg.targets`` and
+    ``apply`` scanned them AGAIN, in its own loop, and ``begin_fleet_mint``
+    called both and reported whichever failed under the first one's sentence.
+    """
+    pipe, cfg = _Pipe(), _cfg("unet")
+    rows = cc.resolve_targets(pipe, cfg)
+    assert [name for name, *_ in rows] == ["unet"]
+    owner, attr = rows[0][1], rows[0][2]
+    assert owner is pipe.unet and attr == "forward"
+    assert cc.has_compile_target(pipe, cfg) is True
+    assert cc.resolve_targets(pipe, _cfg("no_such_module")) == []
+    assert cc.has_compile_target(pipe, _cfg("no_such_module")) is False
+
+
+def test_every_target_reader_moves_with_the_one_authority(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The proof that it is ONE relation and not three that happen to agree:
+    move ``resolve_targets`` and all three readers move with it."""
+    pipe, cfg = _Pipe(), _cfg("unet")
+    monkeypatch.setattr(cc, "resolve_targets", lambda *a, **k: [])
+    assert cc.has_compile_target(pipe, cfg) is False
+    assert cc.apply(pipe, cfg, cache_ready=False, allow_cold=True) is False
+    with pytest.raises(cc.CompileArmRefused) as exc:
+        cc.begin_fleet_mint(pipe, cfg, tmp_path / "capture")
+    assert "no compile target resolves" in str(exc.value)
+
+
+def test_a_cardless_process_is_named_as_the_environment_fact_it_is(
+    cardless: None, tmp_path: Path,
+) -> None:
+    """RED at HEAD: this raised ``no compile targets resolved on _Pipe`` — the
+    WIRING sentence — about a pipeline that owns its declared target. The
+    mint child's operator then had a message that ruled out the only thing it
+    was not.
+    """
+    pipe, cfg = _Pipe(), _cfg("unet")
+    assert cc.has_compile_target(pipe, cfg) is True
+    block = cc.arming_block(pipe, cfg, cache_ready=False, allow_cold=True)
+    assert "CUDA" in block
+
+    with pytest.raises(cc.CompileArmRefused) as exc:
+        cc.begin_fleet_mint(pipe, cfg, tmp_path / "capture")
+    text = str(exc.value)
+    assert "['unet']" in text and block in text and "pgw985" in text
+    assert "no compile target resolves" not in text, (
+        f"the wiring sentence must not stand in for the environment fact: {text}")
+
+
+def test_the_refusal_leaves_the_process_global_cache_dir_where_it_was(
+    cardless: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gw#608's invariant, kept through the new refusal: a decline never
+    leaves the interpreter's inductor cache dir pointed at a directory nobody
+    will write."""
+    monkeypatch.setenv("TORCHINDUCTOR_CACHE_DIR", str(tmp_path / "seeded"))
+    with pytest.raises(cc.CompileArmRefused):
+        cc.begin_fleet_mint(_Pipe(), _cfg("unet"), tmp_path / "capture")
+    assert os.environ["TORCHINDUCTOR_CACHE_DIR"] == str(tmp_path / "seeded")
+
+
+# ---------------------------------------------------------------------------
+# 2. The child's request, built through the REAL parent chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def checkpoint(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from harness.tiny_diffusion import build_checkpoint
+
+    return build_checkpoint(tmp_path_factory.mktemp("microrig") / "checkpoint")
+
+
+def _request(
+    checkpoint: Path, workdir: Path, *, recipe: str = "aot",
+    targets: Tuple[str, ...] = ("unet",),
+) -> mp.MintRequest:
+    from harness import tiny_diffusion_endpoint as ep
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    cfg = CompileCell(
+        shapes=(ep.PIXEL_SHAPE,), targets=targets, family=ep.FAMILY,
+        regional=False, text_len=ep.TEXT_LEN, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=())
+    pending = SimpleNamespace(
+        family=ep.FAMILY, cell_key="ck5-recipe-parity", recipe=recipe, cfg=cfg,
+        capture_dir=workdir / "capture", target=workdir / "cell.tar.gz",
+        mint_root=workdir)
+    task = mint_delegate.MintTask(
+        pending=pending, pipe=None, function=FUNCTION,
+        modules=(ENDPOINT_MODULE,),
+        slots={"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
+                         tag="prod"),
+            path=str(checkpoint))},
+        device=-1, execution_lane="", configs={})
+    request = mint_delegate.build_request(task, workdir=workdir, cap_bytes=0)
+    # The boundary IS a file: round-trip it exactly as the child decodes it.
+    return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
+
+
+def _child_env(request: mp.MintRequest, *, cardless: bool) -> Dict[str, str]:
+    env = dict(mp.child_env(request))
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(HERE), str(HERE.parent / "src"), env.get("PYTHONPATH", "")])
+    if cardless:
+        # Deterministic on any host, and the honest production shape of the
+        # condition: a mint child that can see no card.
+        env["CUDA_VISIBLE_DEVICES"] = ""
+    return env
+
+
+# ---------------------------------------------------------------------------
+# 3. pgw#985 — the dynamo recipe's deterministic refusal is TERMINAL and TYPED
+# ---------------------------------------------------------------------------
+
+
+def test_the_dynamo_recipe_refuses_a_deterministic_arm_decline(
+    checkpoint: Path, tmp_path: Path,
+) -> None:
+    """The real entrypoint, in a real child, on the real request file.
+
+    RED at HEAD: exit 1, ``CRASHED``, detail ``RuntimeError: no compile
+    targets resolved on TinyDiffusionPipeline`` — the retryable class, for a
+    fact no retry can change.
+    """
+    request = _request(checkpoint, tmp_path / "w", recipe="dynamo")
+    outcome = asyncio.run(mp.run_mint(
+        request, workdir=tmp_path / "w", python=sys.executable,
+        env=_child_env(request, cardless=True)))
+
+    assert outcome.status == mp.REFUSED, (
+        f"{outcome.status}: {outcome.detail or outcome.stderr_tail}")
+    assert outcome.exit_code == mp.EXIT_REFUSED
+    assert outcome.retryable is False, "a deterministic refusal buys no second pod"
+    report = outcome.report
+    assert report is not None and report.status == "refused"
+    for fact in ("microrig", FUNCTION, "dynamo", "unet", "CUDA"):
+        assert fact in report.detail, f"{fact!r} missing from: {report.detail}"
+    assert not Path(request.target).exists()
+    # th#1322: and the phase it died in survives into the report. This was
+    # ALWAYS "" — `_close_phases()` closes the open phase, and the field was
+    # read after it in the same call.
+    assert report.phase == "load", report.phase
+
+
+def test_both_recipes_refuse_a_missing_target_in_the_same_vocabulary(
+    checkpoint: Path, tmp_path: Path,
+) -> None:
+    """One condition, two recipes, one classification. The AOT recipe has
+    always typed this; the dynamo recipe is what changed."""
+    outcomes = {}
+    for recipe in ("aot", "dynamo"):
+        workdir = tmp_path / recipe
+        request = _request(
+            checkpoint, workdir, recipe=recipe, targets=("no_such_module",))
+        outcomes[recipe] = asyncio.run(mp.run_mint(
+            request, workdir=workdir, python=sys.executable,
+            env=_child_env(request, cardless=True)))
+    for recipe, outcome in outcomes.items():
+        assert outcome.status == mp.REFUSED, (
+            f"{recipe}: {outcome.status}: "
+            f"{outcome.detail or outcome.stderr_tail}")
+        assert outcome.exit_code == mp.EXIT_REFUSED, recipe
+        assert outcome.retryable is False, recipe
+        assert "no compile target resolved" in (outcome.detail or ""), recipe
+
+
+# ---------------------------------------------------------------------------
+# 4. pgw#984 — the AOT recipe runs the endpoint's own warm plan before it seals
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def aot_without_the_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> List[Dict[str, Any]]:
+    """Everything the AOT recipe does up to the export, and nothing after.
+
+    The export + AOTInductor compile is the rig's job (and a LOCAL-ONLY row);
+    what is under test here is the ORDER — whether the endpoint's own forward
+    has run by the time a cell can be sealed.
+    """
+    from harness import tiny_diffusion_endpoint as ep
+
+    ep.reset()
+    mint_child._PHASE_SPANS.clear()
+    monkeypatch.setattr(mint_child, "_PHASE_OPEN", ("", 0.0), raising=False)
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(cc, "cxx_toolchain_present", lambda: True)
+
+    exported: List[Dict[str, Any]] = []
+
+    def _stub(request: Any, pipe: Any, cfg: Any, target: Path, **kwargs: Any):
+        exported.append({"family": cfg.family, "target": target})
+        return mp.MintReport(
+            status="minted", artifact=str(target), cell_key=request.cell_key,
+            phase="finalize", phases=mint_child._close_phases(),
+            recipe=request.recipe)
+
+    monkeypatch.setattr(mint_child, "_mint_aot", _stub)
+    return exported
+
+
+def test_the_aot_recipe_runs_the_endpoints_own_forward_before_it_exports(
+    checkpoint: Path, tmp_path: Path, aot_without_the_export: List[Any],
+) -> None:
+    """RED at HEAD: ``exported`` was populated and ``RESOLVED_REFS`` was empty
+    — the recipe reached the seal without ever entering the handler, and the
+    phase table it published had no ``warmup_forward`` row to say so.
+    """
+    from harness import tiny_diffusion_endpoint as ep
+
+    report = mint_child.mint(_request(checkpoint, tmp_path / "w", recipe="aot"))
+
+    assert ep.RESOLVED_REFS == ["rig/tiny-diffusion"], (
+        "the endpoint's own handler must have run, through ctx.slots — "
+        f"got {ep.RESOLVED_REFS}")
+    assert aot_without_the_export, "the export must still happen, after the proof"
+    assert "warmup_forward" in report.phases, (
+        f"a reader of the phase table must be able to tell: {report.phases}")
+
+
+def test_an_aot_mint_cannot_seal_for_a_handler_that_cannot_run(
+    checkpoint: Path, tmp_path: Path, aot_without_the_export: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pgw#969's crash class, made reachable on the recipe it was invisible on.
+
+    RED at HEAD: this minted. ``torch.export`` does not care that the handler
+    raises, so the cell sealed, published, and every pod that adopted it hit
+    the ValueError on its first real request instead.
+    """
+    from harness import tiny_diffusion_endpoint as ep
+
+    def _broken(self: Any, ctx: Any, data: Any) -> Any:
+        raise ValueError(
+            "slot 'pipeline': no resolved model ref for this request")
+
+    monkeypatch.setattr(ep.MicroRigEndpoint, "rig_generate", _broken)
+
+    with pytest.raises(mint_child.MintChildRefused) as exc:
+        mint_child.mint(_request(checkpoint, tmp_path / "w", recipe="aot"))
+
+    text = str(exc.value)
+    assert "warm plan does not run" in text, text
+    assert "microrig" in text and FUNCTION in text and "aot" in text, text
+    assert "no resolved model ref" in text, text
+    assert not aot_without_the_export, (
+        "nothing may be exported once the endpoint's forward has failed")
+
+
+def test_a_resource_shortfall_in_the_warm_plan_is_still_retryable(
+    checkpoint: Path, tmp_path: Path, aot_without_the_export: List[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The line the refusal must not cross. A named refusal is terminal, so
+    classifying an OOM as one would strand a mint the next attempt could make
+    at a narrower width (pgw#848)."""
+    from harness import tiny_diffusion_endpoint as ep
+
+    def _oom(self: Any, ctx: Any, data: Any) -> Any:
+        raise MemoryError("host RAM shortfall in the warm forward")
+
+    monkeypatch.setattr(ep.MicroRigEndpoint, "rig_generate", _oom)
+
+    with pytest.raises(MemoryError):
+        mint_child.mint(_request(checkpoint, tmp_path / "w", recipe="aot"))
+    assert not aot_without_the_export


### PR DESCRIPTION
Two mint-recipe correctness defects the pgw#978 micro-mint rig found inside its first hour, by running the same machinery twice with only `MintRequest.recipe` changed. Both are fixed here, RED-proved on the rig first.

## pgw#984 — a green AOT mint proved nothing about the cell it sealed

**Measured.** An AOT mint's phase table was `{'load': 4.4, 'trace_graph': 8.1, 'seal_publish': 0.9, 'finalize': 0.0}` — **no `warmup_forward` row at all**. `torch.export` traces the declared modules directly, so `mint_child._mint_aot` never called the endpoint's handler. Consequences:

* pgw#969's crash class — `ctx.slots["pipeline"]` unbound, 0.0 s into `warmup_forward`, measured twice on production L40S pods — was **unreachable** on this recipe;
* an endpoint whose forward dies on its first real request minted, sealed and published an AOT cell fine.

**Fix.** `mint_child.mint`'s AOT branch now drives the endpoint's OWN derived warm plan — the same `_run_warm_job`, the same `warmup.plan` over the same class-scoped sibling set the dynamo recipe uses — once, eagerly, before a byte is exported. ONE job and not the whole plan: the export derives its own class set, so a full eager pass buys minutes and proves nothing the first forward does not. Nothing is armed for it, so it specializes no graph the export then has to trace around.

`execution_lane_verdict_for` / `_load` now carry the endpoint INSTANCE out with the pipeline, because the handler is a method on it.

**Behaviour change, stated:** an endpoint whose class carries no `@endpoint` declaration, or whose derived warm plan is empty, now REFUSES an AOT mint where it used to seal one. Both were already dynamo-recipe refusals.

## pgw#985 — a deterministic refusal was classified as a retryable crash, and named wrong

**Measured.** Same box, same pipeline, one recipe flag changed:

```
RuntimeError: no compile targets resolved on TinyDiffusionPipeline
```

...out of `compile_cache.begin_fleet_mint` — about a pipeline whose `.unet` `has_compile_target` had resolved one frame earlier. Two defects in one line:

**1. Two computations of one fact** (§1.29, th#1616). `has_compile_target` scanned `cfg.targets`; `apply` scanned them again in its own loop; `begin_fleet_mint` called both and reported whichever declined under the first one's sentence. What had actually declined was `apply`, because the process had no CUDA — so the message ruled out the only thing it was not.

* `compile_cache.resolve_targets` is now the ONE target authority. `has_compile_target`, `apply` and `begin_fleet_mint` all read it.
* `compile_cache.arming_block` is the ONE precondition authority — side-effect free, returns the named reason `apply` logs and `begin_fleet_mint` refuses with. `apply` still DECIDES (one evaluator); `arming_block` only names.
* The wiring fact ("this pipeline owns no declared target") and the environment fact ("this process cannot arm the targets it owns") are now separate sentences. The same misnaming is gone from `build` and `_compile_and_warm`.

**2. The classification, not the message, decides the second pod.** A bare `RuntimeError` exits 1 → `CRASHED` → the retryable class, for a fact no retry can change. `begin_fleet_mint` now raises the typed `CompileArmRefused`, which the mint child turns into `MintChildRefused` → `EXIT_REFUSED` → terminal on attempt one — exactly what the AOT recipe has always done with the identical condition. Warm-forward failures are classified the same way on BOTH recipes now (the hub's `self_mint_abort` event already booked `phase=warmup_forward` as `deterministic` while the worker still called it `crashed`); a resource shortfall re-raises untouched, so `EXIT_RESOURCE` and pgw#848's re-budgeted retry are unaffected.

Also: a refused or crashed mint's report carried `phase=""` in **every** case — `_close_phases()` closes the open phase and `MintReport.phase` was read after it in the same call.

## The rig proof

`task rig:mint`, ~20 s a cycle, `--stage mint`:

| recipe | before | after |
|---|---|---|
| dynamo | `crashed`, exit 1, `RuntimeError: no compile targets resolved on TinyDiffusionPipeline`, `phase=""` | `refused`, exit 2 (`EXIT_REFUSED`), `not retryable`, ``mint family='microrig' … fn='rig-generate' recipe='dynamo': TinyDiffusionPipeline owns the declared compile target(s) ['unet'] for family 'microrig', but this process cannot arm them: torch reports no CUDA device in this process``, `phase="load"` |
| aot | phases `finalize/load/seal_publish/trace_graph` | phases `finalize/load/seal_publish/trace_graph/`**`warmup_forward`** (0.26 s) |

## Tests

`tests/test_mint_recipe_parity_pgw984_pgw985.py` — 9 rows at the real seams, no card and no compile required:

* `resolve_targets` is one relation: move it and `has_compile_target`, `apply` and `begin_fleet_mint` all move with it;
* a cardless process is named as the environment fact it is, and the wiring sentence must NOT stand in for it;
* the refusal leaves `TORCHINDUCTOR_CACHE_DIR` where it was (gw#608's invariant, kept);
* the dynamo recipe, in a REAL child on a REAL request file, exits `EXIT_REFUSED`, is not retryable, names family/function/recipe/target/why, writes no artifact, and reports the phase it died in;
* both recipes refuse a missing target in the same vocabulary;
* the AOT recipe runs the endpoint's own forward (asserted through `ctx.slots`) before it exports, and `warmup_forward` lands in the phase table;
* an AOT mint cannot seal for a handler that raises — nothing is exported;
* a `MemoryError` in the warm plan is still a resource shortfall, not a refusal.

**8 of the 9 fail on a clean detached checkout of `origin/master`.** The one that passes is the missing-target parity row — that condition was already typed on both recipes; it is the invariant, not the defect.

`tests/test_kernel_lane_pgw947.py` doubles updated for the 3-tuple `_load`.

## Verification

* `tests/` **3299 passed, 37 skipped, 1 xfailed** (`-n 4 --dist loadfile`); `tests_v2/` 21 passed.
* mypy clean (231 files), ruff clean, HTTP-timeout guard, unreached-surface guard, config-read guard all pass.
* No new skips (37 before and after).

## Filed, not fixed here: pgw#988 (P0)

The same rig cycle found that **`origin/master` cannot adopt any AOT cell it publishes**. th#1645/pgw#987 (PR #507) added `entries` to `_UNBOUNDED_ENVELOPE_BLOCKS`, but `aot_cells._discover_inner` runs `aot_serve.verify` against the DECLARE metadata, pre-download, and that verify requires the entries map:

```
aot-cells: ck5-… filtered: malformed declared contract: metadata declares no entries map
aot_cell_discovery miss: rejected by class: verify:malformed declared contract: metadata declares no entries map=1
```

Reproduced on a clean detached checkout of `c2e52f5f`; the rig's adopt leg is green at `f029593e` (before PR #507) and red at `c2e52f5f` and on this branch identically. **Not caused by and not fixed by this PR** — restoring `entries` re-creates th#1645's 413, so the fix is a contract decision for that lane. Filed as **pgw#988** with the measurement and three candidate fixes.