### PR TITLE
pgw#988 (P0): the publish declare and the discovery filter are ONE contract

### DIFF
--- a/changelog.d/pgw988.md
+++ b/changelog.d/pgw988.md
@@ -1,0 +1,35 @@
+- **pgw#988 (P0 regression, fixed): a published AOT cell is adoptable again —
+  the declare and the discovery filter are now ONE contract.** th#1645 shrank
+  the cell publish declare to control-plane size by stripping the four blocks
+  that grow with the model, `entries` among them. It was right about size and it
+  fixed a real 413. But `aot_cells._candidates` verified the hub LISTING
+  metadata — which IS that declare body — with the FULL `aot_serve.verify`,
+  entries map and all, so from `c2e52f5f` every AOT cell published by any worker
+  was rejected on every pod as `verify:malformed declared contract: metadata
+  declares no entries map`. A pod that finds no cell mints its own: the fleet
+  re-minted on every cold boot, forever, and the failure presented as COST
+  rather than as an error. Found by the pgw#978 rig, whose cycle
+  (mint -> publish -> a second process adopting) is the only thing in-tree that
+  crossed the seam.
+
+  `aot_serve.verify` splits along the line the transport already drew.
+  `verify_declared` rules on `DECLARED_AXES` — format, kind, the code-only flag,
+  sm/torch/cuda, host ISA, family: everything a BOUNDED control-plane declare
+  carries, and therefore everything discovery may refuse a cell for before it
+  moves a byte. `verify_contract` rules on the `entries` map, which is unbounded
+  in the model, ships inside the artifact, and is verified by `stage_artifact`
+  on the unpacked `metadata.json` — where `aot_serve` has always read it from to
+  serve. `verify` is both, for callers holding a full envelope. Nothing is
+  checked less than before; one check moved to the side of the fetch that has
+  the data.
+
+  The cause was two independent computations of one fact — what a declare must
+  carry — with no single authority, so a change to one side could not see the
+  other. There is an authority now: `aot_cells.DECLARE_CONTRACT_KEYS` is every
+  key the pre-download filter reads, and `fleet_cells.assert_declare_contract`
+  checks at import that nothing `control_plane_metadata` strips appears in it.
+  The next block that moves fails every test run instead of a fleet.
+  `tests/test_cell_declare_verify_split_pgw988.py` is the rig's own seam as a
+  CI row: a real `CellPublisher.publish` over a real socket into a hub that
+  stores the declare it received, then a real `aot_cells.discover` reading it
+  back off a real checkpoint listing and pulling the real uploaded bytes.

--- a/src/gen_worker/aot_cells.py
+++ b/src/gen_worker/aot_cells.py
@@ -23,8 +23,11 @@ needs a hub tie-break first; the runbook records the hazard.
 Filter (SDXL-AOT-PILOT-RUNBOOK.md §3 F1):
 
 * ``kind == aot-inductor`` with a stamped ck5 ``cell_key``;
-* runtime-key + contract check via ``aot_serve.verify`` (sm, torch,
-  cuda, family, code-only flag, contract/constants parse);
+* runtime-key check via ``aot_serve.verify_declared`` (sm, torch, cuda,
+  family, host ISA, code-only flag) — the DECLARE half only. The ``entries``
+  contract is unbounded in the model, does not ride the control-plane declare
+  (th#1645), and is verified on the staged artifact by ``aot_serve.verify``
+  after the fetch (pgw#988);
 * canonical lane/bucket match against THIS pipeline's traced lane;
 * preference: same SKU first (autotune affinity), then a stamped ``sm``,
   then newest (checkpoint ``updated_at``; key digest tie-break). SKU is a
@@ -79,6 +82,19 @@ EVENT = "aot_cell_discovery"
 # read grant on a platform cell repo; 401 covers a credential the hub could not
 # verify at all.
 _NOT_AUTHORIZED = (401, 403)
+
+#: Every metadata key the PRE-DOWNLOAD filter (:func:`_candidates`) reads off a
+#: hub listing row. A listing row's ``metadata`` IS the publish declare body,
+#: so this set is the consumer half of the declare contract whose producer half
+#: is ``fleet_cells.control_plane_metadata``. That module asserts at import
+#: that nothing it strips from the declare appears here — the check pgw#988
+#: cost a day of unadoptable cells for not existing.
+DECLARE_CONTRACT_KEYS = frozenset(aot_serve.DECLARED_AXES) | frozenset({
+    "cell_key",       # ck5 identity + the artifact cache name
+    "weight_lane",    # \_ the canonical execution lane this pipeline needs
+    "lora_bucket",    # /
+    "sku",            # selection PREFERENCE, never a filter (pgw#765)
+})
 
 
 def prefer_aot(settings: Optional[Settings] = None) -> bool:
@@ -151,8 +167,9 @@ def _candidates(
     """(updated_at, checkpoint_id, metadata) rows that pass the filter, best
     candidate first.
 
-    The filter is the REAL identity (``aot_serve.verify``: sm/torch/cuda,
-    host ISA, family, contract) — never ``sku`` (pgw#765). SKU is the
+    The filter is the REAL identity as the DECLARE carries it
+    (:data:`DECLARE_CONTRACT_KEYS` / ``aot_serve.verify_declared``:
+    sm/torch/cuda, host ISA, family) — never ``sku`` (pgw#765). SKU is the
     SELECTION PREFERENCE below: a same-SKU cell was autotuned on this exact
     board, so it is preferred when one exists, and a same-sm cell from
     another SKU is adopted rather than refused when one does not.
@@ -191,7 +208,13 @@ def _candidates(
             logger.debug("aot-cells: %s filtered: no host_isa stamp", key)
             _reject(aot_serve.NO_HOST_ISA_STAMP)
             continue
-        reason = aot_serve.verify(meta, family=family)
+        # pgw#988: the DECLARE half only. `entries` is unbounded in the model
+        # and left the control-plane declare with th#1645; demanding it here
+        # rejected every cell published after that as `malformed declared
+        # contract`, and a pod that finds no cell mints its own. The contract
+        # is verified where the data is — `aot_serve.stage_artifact`, on the
+        # unpacked `metadata.json`, before anything is dlopen'd.
+        reason = aot_serve.verify_declared(meta, family=family)
         if reason:
             logger.debug("aot-cells: %s filtered: %s", key, reason)
             # The verify reason is already a classified token — keep it, so a
@@ -478,6 +501,7 @@ def _discover_inner(
 
 
 __all__ = [
+    "DECLARE_CONTRACT_KEYS",
     "AdoptedAotCell",
     "EVENT",
     "discover",

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -600,16 +600,39 @@ def artifact_metadata(
     return meta
 
 
-def verify(meta: Dict[str, Any], *, family: str = "") -> str:
-    """'' when the artifact matches this runtime, else the mismatch reason.
+#: The metadata keys :func:`verify_declared` rules on — every axis a cell's
+#: publish DECLARE carries, and therefore everything discovery may refuse a
+#: cell for before it has downloaded a byte.
+#:
+#: pgw#988: this set and ``fleet_cells.control_plane_metadata`` are two halves
+#: of ONE contract, and they used to be two independent computations of it.
+#: th#1645 moved ``entries`` out of the declare (correctly — it is unbounded in
+#: the model and the declare is control-plane) while the pre-download filter
+#: still demanded it, so every AOT cell published for the next day was rejected
+#: as ``malformed declared contract`` by every pod, and a pod that finds no cell
+#: mints its own — the fleet paid a full compile per cold boot and the symptom
+#: presented as cost, not as an error. ``fleet_cells`` now asserts at import
+#: that nothing it strips appears here.
+DECLARED_AXES: Tuple[str, ...] = (
+    "format", "kind", "package_constants_in_so", *IDENTITY_AXES,
+    "host_isa", "family",
+)
+
+
+def verify_declared(meta: Dict[str, Any], *, family: str = "") -> str:
+    """'' when a cell's DECLARE matches this runtime, else the reason.
+
+    The pre-download half of :func:`verify`: exactly the axes a bounded
+    control-plane declare carries (:data:`DECLARED_AXES`). Discovery rules on
+    this against the hub listing row, so an unloadable cell costs no bytes.
 
     An AOTI ``.pt2`` is a ``dlopen``-ed ELF built against one exact torch
     C++ ABI on one compute capability — the FULL torch version must match,
     not maj.min, or the load either fails obscurely or is undefined.
 
-    Fail-closed on every REAL axis (:data:`IDENTITY_AXES` + host ISA +
-    contract hashes), each of them STRICTLY — an axis a cell is silent on is
-    refused by name, never skipped. Never on ``sku`` (pgw#765): a cell minted on an l4
+    Fail-closed on every REAL axis (:data:`IDENTITY_AXES` + host ISA), each of
+    them STRICTLY — an axis a cell is silent on is refused by name, never
+    skipped. Never on ``sku`` (pgw#765): a cell minted on an l4
     and a cell minted on an rtx-4090 are the same sm_89 compiled code, and
     refusing the cross-SKU adoption discards the whole point of the pgw#691
     collapse, the FX inner-key shim, and the pgw#754 ISA clamp. The JIT lane
@@ -640,6 +663,19 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     want_fam = str(meta.get("family") or "")
     if family and want_fam and want_fam != family:
         return f"family {want_fam!r} != {family!r}"
+    return ""
+
+
+def verify_contract(meta: Dict[str, Any]) -> str:
+    """'' when the artifact's ``entries`` contract is self-consistent, else
+    the reason.
+
+    The post-download half of :func:`verify`. ``entries`` is unbounded in the
+    size of the model and rides INSIDE the artifact — :func:`unpack` reads it
+    off ``metadata.json``, which is where ``aot_serve`` has always served it
+    from. It is verified HERE, on the staged bytes, and never against a
+    control-plane declare that is not required to carry it (pgw#988).
+    """
     try:
         entries = entries_from_meta(meta)
     except ValueError as exc:
@@ -662,6 +698,16 @@ def verify(meta: Dict[str, Any], *, family: str = "") -> str:
     if stamped_combined and stamped_combined != combined_graph_hash(hashes):
         return "combined_graph_hash does not match the per-entry class hashes"
     return ""
+
+
+def verify(meta: Dict[str, Any], *, family: str = "") -> str:
+    """'' when a cell's FULL metadata matches this runtime, else the reason.
+
+    Both halves, for callers holding an artifact's own ``metadata.json``
+    (:func:`stage_artifact`). Discovery, which holds only a declare, calls
+    :func:`verify_declared` and reaches this one after the fetch.
+    """
+    return verify_declared(meta, family=family) or verify_contract(meta)
 
 
 #: :func:`host_isa_reason`'s refusal for a cell that stamped no requirement.
@@ -2340,6 +2386,7 @@ __all__ = [
     "ArtifactRunner",
     "ConstantSpec",
     "ConstantsUnboundError",
+    "DECLARED_AXES",
     "EntryDispatch",
     "IDENTITY_AXES",
     "IngressContractError",
@@ -2393,6 +2440,8 @@ __all__ = [
     "unpack_metadata",
     "unwrap",
     "verify",
+    "verify_contract",
+    "verify_declared",
     "verify_package_compute_capability",
     "wrap_module",
 ]

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -319,6 +319,36 @@ _UNBOUNDED_ENVELOPE_BLOCKS = frozenset({
     "weight_contract",  # per-tensor weight rows
 })
 
+# pgw#988 — the OTHER half of this decision, asserted rather than assumed.
+#
+# What the declare carries and what the consumer verifies off it are two halves
+# of ONE contract, and until now they were two independent computations of it in
+# two modules. th#1645 dropped `entries` here — right about SIZE — while
+# `aot_cells._candidates` still refused any cell whose declare had no entries
+# map, so 100% of AOT cells published from that commit on were undiscoverable on
+# every pod. A pod that finds no cell mints its own, so the fleet paid a full
+# compile per cold boot and the failure presented as COST, never as an error.
+#
+# Checked at import, over two frozensets, so the next block that moves fails
+# every test run rather than a fleet.
+def assert_declare_contract(
+    dropped: "frozenset[str]" = _UNBOUNDED_ENVELOPE_BLOCKS,
+    read: "frozenset[str]" = aot_cells.DECLARE_CONTRACT_KEYS,
+) -> None:
+    """Raise when the declare strips a key its consumer still verifies."""
+    breach = sorted(dropped & read)
+    if breach:
+        raise RuntimeError(
+            f"cell declare contract broken (pgw#988): {breach!r} is stripped "
+            "from the publish declare but is still read off it by "
+            "aot_cells._candidates — every cell published this way would be "
+            "undiscoverable, and every pod would re-mint. Either keep the "
+            "block in the declare or stop verifying against it before the "
+            "download.")
+
+
+assert_declare_contract()
+
 # The stated ceiling on a cell's CONTROL-plane declare (§4.24). Measured
 # basis: the same real cell's metadata minus the blocks above is 285 KB, and
 # the AOT lane's phase table adds tens of KB — so 4 MiB is roughly an order

--- a/tests/test_cell_declare_verify_split_pgw988.py
+++ b/tests/test_cell_declare_verify_split_pgw988.py
@@ -1,0 +1,505 @@
+"""pgw#988: the publish declare and the discovery filter are ONE contract.
+
+th#1645 shrank the cell publish declare to control-plane size by stripping the
+four blocks that grow with the model — correct about SIZE, and it fixed a real
+413. But `aot_cells._candidates` verified the hub LISTING metadata, which IS
+that declare body, with `aot_serve.verify` — the full check, `entries` map and
+all. So from `c2e52f5f` every AOT cell published by any worker was rejected on
+every pod as::
+
+    malformed declared contract: metadata declares no entries map
+
+and a pod that finds no cell mints its own. The fleet re-minted forever, per
+cold boot, and the failure presented as COST rather than as an error.
+
+The rig (pgw#978) found it because it runs the whole seam — mint, publish, and a
+SECOND process adopting. This file is that seam as a CI row, minus the card: a
+real `CellPublisher.publish` over a real socket into a hub that stores the
+declare it actually received, then a real `aot_cells.discover` reading it back
+off a real checkpoint listing and pulling the real artifact bytes the publisher
+uploaded. Nothing between the two halves is stubbed, because the defect lived
+exactly between them — each half was correct alone.
+
+Only the two hardware probes are pinned (`aot_serve.runtime_key` and the torch
+read inside `host_isa.stamp`): CI has neither a GPU nor torch, and the property
+under test is a contract between two modules, not device detection. The ISA
+stamp is still THIS host's real one, so `host_isa_reason` rules on it for real.
+
+Run: pytest tests/test_cell_declare_verify_split_pgw988.py -q
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import threading
+import urllib.parse
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker import aot_cells, aot_serve, compile_cache as cc
+from gen_worker import fleet_cells as fc
+from gen_worker import guard_closure, host_isa
+
+FAMILY = "sdxl"
+CELL_KEY = "ck5-" + ("9f4c1d" * 10)[:56]
+RUNTIME = {"sku": "l4", "sm": "sm_89", "torch": "2.13.0+cu130", "cuda": "13.0"}
+
+INPUTS = [
+    {"name": "sample", "position": 0, "dtype": "bfloat16",
+     "shape": [2, 4, 128, 128]},
+    {"name": "timestep", "position": 1, "dtype": "int64", "shape": []},
+]
+CONSTANTS = [
+    {"fqn": "conv_in.weight", "source": aot_serve.SOURCE_STATE_DICT,
+     "dtype": "bfloat16", "shape": [320, 4, 3, 3]},
+]
+
+
+# ---------------------------------------------------------------------------
+# One hub: the publish surface AND the catalog read surface, same store
+# ---------------------------------------------------------------------------
+
+
+class _Hub(http.server.BaseHTTPRequestHandler):
+    """tensorhub's cell surfaces against ONE state.
+
+    The point of serving both from one object: the metadata `aot_cells` reads
+    back is the metadata `CellPublisher` sent, byte for byte, rather than a
+    fixture that could stay green while the wire disagreed. That gap is the
+    whole defect — every existing discovery test hands `_candidates` a full
+    envelope no publisher has ever put on the wire.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a: Any) -> None:  # noqa: D102
+        pass
+
+    def _json(self, code: int, body: dict) -> None:
+        self._send(code, json.dumps(body).encode(), "application/json")
+
+    def _send(self, code: int, raw: bytes, ctype: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        try:
+            return json.loads(self.rfile.read(n) or b"{}")
+        except ValueError:
+            return {}
+
+    # -- read surface (what a booting pod sees) -----------------------------
+
+    def do_GET(self) -> None:  # noqa: N802
+        srv = self.server
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path.endswith("/checkpoints"):
+            with srv.lock:
+                items = list(srv.checkpoints)
+            self._json(200, {"items": items})
+            return
+        if parsed.path.endswith("/resolve"):
+            query = urllib.parse.parse_qs(parsed.query)
+            digest = (query.get("digest") or [""])[0]
+            with srv.lock:
+                row = srv.manifests.get(digest)
+            if row is None:
+                self._json(404, {"error": {"code": "not_found"}})
+                return
+            self._json(200, {"files": [{
+                "path": row["path"],
+                "size_bytes": row["size_bytes"],
+                # th#1303: manifest v2 — algorithm-tagged, never a bare hex
+                # mirror. A cell artifact is compiled code; the digest the
+                # consumer checks against must state its own algorithm.
+                "digest": row["digest"],
+                "url": f"{srv.base}/blob/{row['digest'].split(':', 1)[1]}",
+            }]})
+            return
+        if parsed.path.startswith("/blob/"):
+            want = parsed.path[len("/blob/"):]
+            with srv.lock:
+                blob = srv.assemble(want)
+            if blob is None:
+                self._json(404, {"error": {"code": "not_found"}})
+                return
+            self._send(200, blob, "application/octet-stream")
+            return
+        self._json(404, {"error": {"code": "not_found"}})
+
+    # -- write surface (what a minting pod does) ----------------------------
+
+    def do_PUT(self) -> None:  # noqa: N802
+        srv = self.server
+        digest = urllib.parse.urlparse(self.path).path.rsplit("/", 1)[-1]
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n) if n else b""
+        # The digest is signed into the grant: R2 refuses bytes that do not
+        # hash to it, and so does this.
+        if hashlib.sha256(raw).hexdigest() != digest:
+            self._json(400, {"error": {"code": "digest_mismatch"}})
+            return
+        with srv.lock:
+            srv.objects["sha256:" + digest] = raw
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self) -> None:  # noqa: N802
+        srv = self.server
+        path = urllib.parse.urlparse(self.path).path
+        body = self._body()
+
+        if path.endswith("/v1/worker/cells/publish-intent"):
+            self._json(200, {"capability_token": "cap-token",
+                             "repo": cc.system_repo(str(body.get("family")))})
+            return
+        if path.endswith("/v1/worker/cells/publish-complete"):
+            with srv.lock:
+                srv.completes.append(dict(body))
+            self._json(200, {"recorded": True})
+            return
+        if path.endswith("/publishes"):
+            need, plan = [], {}
+            for f in body.get("files") or []:
+                chunks = f.get("chunks") or []
+                whole = str(f.get("digest") or "")
+                plan[whole] = {
+                    "path": str(f.get("path") or ""),
+                    "size_bytes": int(f.get("size_bytes") or 0),
+                    "parts": ["sha256:" + c["digest"] for c in chunks] or [whole],
+                }
+                for want, size in (
+                    [("sha256:" + c["digest"], int(c["len"])) for c in chunks]
+                    or [(whole, int(f.get("size_bytes") or 0))]
+                ):
+                    need.append({
+                        "digest": want, "size_bytes": size,
+                        "put_url": f"{srv.base}/cas/{want.split(':', 1)[1]}",
+                        "headers": {"x-amz-checksum-sha256": want}})
+            pid = str(uuid.uuid4())
+            with srv.lock:
+                srv.declares.append(dict(body))
+                srv.declare_lengths.append(
+                    int(self.headers.get("Content-Length") or 0))
+                srv.sessions[pid] = plan
+            self._json(201, {"publish_id": pid, "have": [], "need": need,
+                             "distinct_objects": len(need),
+                             "resident_objects": 0})
+            return
+        if path.endswith("/grants"):
+            self._json(200, {"need": [], "have": []})
+            return
+        if path.endswith("/complete"):
+            pid = path.split("/publishes/")[1].split("/")[0]
+            with srv.lock:
+                plan = srv.sessions.get(pid) or {}
+                missing = [d for row in plan.values() for d in row["parts"]
+                           if d not in srv.objects]
+                if missing:
+                    self._json(409, {"status": {
+                        "stage": "repudiated", "terminal": True,
+                        "failure": {"code": "objects_missing",
+                                    "retryable": False,
+                                    "message": f"{len(missing)} never landed"}}})
+                    return
+                checkpoint = "sha256:" + hashlib.sha256(pid.encode()).hexdigest()
+                # The checkpoint the catalog will serve carries the DECLARE
+                # body as its metadata — exactly what tensorhub stores and
+                # hands back on the listing route.
+                declare = srv.declares[-1]
+                for whole, row in plan.items():
+                    srv.manifests[checkpoint] = {**row, "digest": whole}
+                srv.checkpoints.append({
+                    "checkpoint_id": checkpoint,
+                    "updated_at": "2026-08-06T00:00:00Z",
+                    "metadata": dict(declare.get("metadata") or {}),
+                })
+            self._json(200, {"checkpoint": {"checkpoint_id": checkpoint}})
+            return
+        self._json(404, {"error": {"code": "not_found"}})
+
+
+class _Server:
+    def __init__(self) -> None:
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Hub)
+        self.httpd.lock = threading.Lock()
+        self.httpd.objects = {}
+        self.httpd.sessions = {}
+        self.httpd.manifests = {}
+        self.httpd.checkpoints = []
+        self.httpd.declares = []
+        self.httpd.declare_lengths = []
+        self.httpd.completes = []
+        self.httpd.base = self.base
+        self.httpd.assemble = self._assemble
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+
+    def _assemble(self, hex_digest: str) -> Optional[bytes]:
+        """The whole file, from the objects that actually landed in the CAS."""
+        for row in self.httpd.manifests.values():
+            if row["digest"] != "sha256:" + hex_digest:
+                continue
+            parts = [self.httpd.objects.get(d) for d in row["parts"]]
+            if any(p is None for p in parts):
+                return None
+            return b"".join(p for p in parts if p is not None)
+        return None
+
+    @property
+    def base(self) -> str:
+        host, port = self.httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture()
+def hub():
+    s = _Server()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture(autouse=True)
+def _isa(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`host_isa.stamp` reads `torch._inductor.config.cpp` for the mint's
+    imposed march; CI has no torch. The MACHINE and LEVEL stay this host's real
+    ones, so the ISA gate that refuses an unexecutable cell still rules for
+    real — only the unclamped-march read is stood in for."""
+    monkeypatch.setattr(host_isa, "stamp", lambda: {
+        "machine": host_isa.machine(), "march": "", "simdlen": 0,
+        "level": host_isa.host_level() if host_isa.machine() == "x86_64" else "",
+    })
+
+
+@pytest.fixture()
+def _runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: dict(RUNTIME))
+
+
+@pytest.fixture()
+def _lane(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cc, "cell_base_execution_lane", lambda pipe: "w8a8")
+
+
+class _FakePipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = FAMILY
+    lora_bucket: int = 64
+
+
+def _meta() -> Dict[str, Any]:
+    """A real AOT cell envelope: `artifact_metadata` builds it, so `entries`
+    carries stamped `range_digest`/`class_hash` and the ck6 combined hash —
+    the very block th#1645 removed from the declare."""
+    meta = aot_serve.artifact_metadata(
+        family=FAMILY, precision="bf16", cell_key=CELL_KEY,
+        entries={"unet/g": {
+            "target": "unet", "fork": [], "class_dims": [],
+            "inputs": [dict(r) for r in INPUTS], "symbols": {},
+            "constants": [dict(r) for r in CONSTANTS], "graph": {},
+        }},
+        lora_bucket=64)
+    meta["weight_lane"] = "w8a8"
+    meta["gen_worker"] = "0.93.1"
+    # The other unbounded block, at a magnitude that would have re-broken the
+    # 413 had the fix been "put it all back": one real sdxl cell measured
+    # 13,092,487 bytes of guard manifest.
+    meta[guard_closure.MANIFEST_KEY] = {
+        "v": 2,
+        "graphs": {f"graph_{g}": {"guards": [f"L['x'].size()[{i}] == 128"
+                                             for i in range(200)]}
+                   for g in range(400)},
+    }
+    return meta
+
+
+def _artifact(meta: Dict[str, Any], tmp_path: Path) -> Path:
+    content = tmp_path / "content"
+    content.mkdir(parents=True, exist_ok=True)
+    (content / aot_serve.PACKAGE_NAME).write_bytes(b"fake-pt2" * 4096)
+    return aot_serve.pack(content, tmp_path / f"{CELL_KEY}.tar.gz", meta)
+
+
+def _publish(hub: _Server, artifact: Path, meta: Dict[str, Any]) -> str:
+    return fc.CellPublisher(
+        base_url=hub.base,
+        worker_jwt=lambda: "worker-jwt",
+        image_digest="sha256:" + "e" * 64,
+    ).publish(FAMILY, artifact, meta, 1234)
+
+
+# ---------------------------------------------------------------------------
+# THE ROW — publish through the real publisher, adopt through the real filter
+# ---------------------------------------------------------------------------
+
+
+def test_a_published_cell_is_adopted_and_not_re_minted(
+    hub: _Server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    _runtime: None, _lane: None,
+) -> None:
+    """The rig's `adopt ok`, as a CI row. RED on `c2e52f5f`: discovery returned
+    None with `verify:malformed declared contract: metadata declares no entries
+    map`, and the caller's miss policy is a self-mint."""
+    monkeypatch.setattr(fc.broker, "active", lambda: False)
+    meta = _meta()
+    artifact = _artifact(meta, tmp_path)
+
+    checkpoint = _publish(hub, artifact, meta)
+    assert checkpoint
+    assert hub.httpd.completes[-1]["ok"] is True
+
+    adopted = aot_cells.discover(
+        _FakePipe(), _Cfg(), base_url=hub.base,
+        worker_jwt=lambda: "worker-jwt", cache_dir=tmp_path / "cache")
+
+    assert adopted is not None, (
+        "the cell this very test published is undiscoverable — pgw#988: the "
+        "publisher declares a bounded subset and the consumer verifies a "
+        "superset of it, so every pod re-mints")
+    assert adopted.cell_key == CELL_KEY
+    assert adopted.family == FAMILY
+    # The bytes the pod pulled are the bytes the publisher uploaded, whole-file
+    # digest verified by the real `verify_file_digest` on the way in.
+    assert adopted.artifact.read_bytes() == artifact.read_bytes()
+    assert adopted.snapshot_digest == "sha256:" + hashlib.sha256(
+        artifact.read_bytes()).hexdigest()
+
+
+def test_the_adopted_declare_still_never_carries_the_unbounded_blocks(
+    hub: _Server, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    _runtime: None, _lane: None,
+) -> None:
+    """The fix is a SPLIT, not a revert. th#1645's property has to hold on the
+    same wire that now yields an adoption: had `entries` gone back into the
+    declare, this cell would publish and adopt and the next 200 MB one would
+    413 again."""
+    monkeypatch.setattr(fc.broker, "active", lambda: False)
+    meta = _meta()
+    _publish(hub, _artifact(meta, tmp_path), meta)
+
+    declared = hub.httpd.declares[-1]["metadata"]
+    for block in sorted(fc._UNBOUNDED_ENVELOPE_BLOCKS):
+        assert block not in declared, f"{block} is data; it must not ride the declare"
+    assert hub.httpd.declare_lengths[-1] < fc.CELL_DECLARE_MAX_BYTES
+    # And the listing a pod reads is that same body — the premise of the row
+    # above, asserted rather than assumed.
+    assert hub.httpd.checkpoints[-1]["metadata"] == declared
+
+    adopted = aot_cells.discover(
+        _FakePipe(), _Cfg(), base_url=hub.base,
+        worker_jwt=lambda: "worker-jwt", cache_dir=tmp_path / "cache")
+    assert adopted is not None
+
+
+# ---------------------------------------------------------------------------
+# The contract is ONE thing now, and it is checked
+# ---------------------------------------------------------------------------
+
+
+def test_the_declared_and_the_verified_key_sets_are_one_contract() -> None:
+    """Two computations of one fact with no single authority is the defect
+    class (pgw#985, one layer up). The two sets are now checked against each
+    other at import — this asserts the check exists and holds."""
+    fc.assert_declare_contract()
+    assert not (fc._UNBOUNDED_ENVELOPE_BLOCKS & aot_cells.DECLARE_CONTRACT_KEYS)
+    # Everything the pre-download filter reads survives the projection.
+    kept = fc.control_plane_metadata(_meta())
+    assert aot_cells.DECLARE_CONTRACT_KEYS <= set(kept)
+
+
+def test_moving_a_verified_block_out_of_the_declare_now_fails_loudly() -> None:
+    """The acceptance condition: the next block that moves fails a test run,
+    not a fleet. This is th#1645's exact edit, replayed."""
+    with pytest.raises(RuntimeError) as excinfo:
+        fc.assert_declare_contract(
+            dropped=fc._UNBOUNDED_ENVELOPE_BLOCKS | {"host_isa"},
+            read=aot_cells.DECLARE_CONTRACT_KEYS)
+    assert "host_isa" in str(excinfo.value)
+    assert "pgw#988" in str(excinfo.value)
+
+
+def test_the_entries_contract_is_verified_on_the_artifact_not_the_declare(
+    tmp_path: Path, _runtime: None,
+) -> None:
+    """The check MOVED; it did not go away. A declare-shaped metadata (no
+    `entries`) passes the pre-download filter, and the same metadata is still
+    refused by the full check — which is what the staged artifact gets."""
+    meta = _meta()
+    declare = fc.control_plane_metadata(meta)
+
+    assert aot_serve.verify_declared(declare, family=FAMILY) == ""
+    assert "no entries map" in aot_serve.verify(declare, family=FAMILY)
+
+    # And a tampered contract inside the artifact is still refused at staging,
+    # by name, before anything is dlopen'd.
+    bad = dict(meta)
+    bad["entries"] = {
+        name: {**block, "class_hash": "0" * 16}
+        for name, block in meta["entries"].items()}
+    artifact = _artifact(bad, tmp_path / "bad")
+    with pytest.raises(aot_serve.AdoptError) as excinfo:
+        aot_serve.stage_artifact(artifact, FAMILY, cache_dir=tmp_path / "stage")
+    assert "class_hash" in str(excinfo.value)
+
+
+def test_a_declare_with_no_entries_is_no_longer_a_discovery_rejection(
+    _runtime: None,
+) -> None:
+    """The rejection class that ate the fleet, asserted absent at the unit
+    seam: `_candidates` counted `verify:malformed declared contract: metadata
+    declares no entries map=N` for every published cell."""
+    declare = fc.control_plane_metadata(_meta())
+    rejected: Dict[str, int] = {}
+    rows = aot_cells._candidates(
+        [{"checkpoint_id": "cafe01", "updated_at": "2026-08-06T00:00:00Z",
+          "metadata": declare}],
+        FAMILY, "w8a8-lora64", rejected)
+    assert rejected == {}, rejected
+    assert [r[1] for r in rows] == ["cafe01"]
+
+
+def test_a_genuinely_unloadable_cell_is_still_refused_before_download(
+    _runtime: None,
+) -> None:
+    """The split must not have loosened the pre-download filter into a pass.
+    Every axis a declare CAN carry still refuses, by its own class, with no
+    bytes moved."""
+    base = fc.control_plane_metadata(_meta())
+    cases = {
+        "sm": ({**base, "sm": "sm_80"}, "verify:sm"),
+        "torch": ({**base, "torch": "2.9.0+cu128"}, "verify:torch"),
+        "kind": ({**base, "kind": "torch-inductor-cache"}, "not_an_aot_cell"),
+        "host_isa": ({k: v for k, v in base.items() if k != "host_isa"},
+                     aot_serve.NO_HOST_ISA_STAMP),
+        "baked": ({**base, "package_constants_in_so": True},
+                  "verify:artifact was minted"),
+        "lane": ({**base, "weight_lane": "w8a16"}, "lane_mismatch"),
+    }
+    for axis, (meta, want) in cases.items():
+        rejected: Dict[str, int] = {}
+        rows = aot_cells._candidates(
+            [{"checkpoint_id": "x", "updated_at": "2026-08-06T00:00:00Z",
+              "metadata": meta}], FAMILY, "w8a8-lora64", rejected)
+        assert rows == [], f"{axis} was admitted"
+        classes: List[str] = list(rejected)
+        assert any(c.startswith(want) for c in classes), (axis, classes)


### PR DESCRIPTION
## The regression

`c2e52f5f` (th#1645 + pgw#987, PR #507) added `entries` to
`fleet_cells._UNBOUNDED_ENVELOPE_BLOCKS`, so `control_plane_metadata` strips it
from the publish declare. That is correct about SIZE — `entries` is unbounded in
the model, the declare is a control-plane call, and the change fixed a real 413
that had refused every AOT cell publish thirty-two times across two cards.

But `aot_cells._candidates` verifies the hub **listing** metadata — which IS the
declare body — with the FULL `aot_serve.verify`, entries map and all. So from
`c2e52f5f` **every AOT cell published by any worker is rejected on every pod**:

```
aot-cells: ck5-… filtered: malformed declared contract: metadata declares no entries map
aot_cell_discovery miss: no matching aot-inductor cell among 1 checkpoint(s)
    — rejected by class: verify:malformed declared contract: metadata declares no entries map=1
```

A pod that finds no cell mints its own, so the fleet re-mints on every cold boot
and the failure presents as **cost**, not as an error. Found by the pgw#978 rig,
whose cycle (mint → publish → a second process adopting) is the only thing
in-tree that crosses the seam.

## The fix — a split, not a revert

Restoring `entries` to the declare re-creates th#1645, so the check moves to the
side of the fetch that has the data:

| | rules on | called from |
|---|---|---|
| `aot_serve.verify_declared` | `DECLARED_AXES`: format, kind, code-only flag, sm/torch/cuda, host ISA, family | `aot_cells._candidates`, pre-download |
| `aot_serve.verify_contract` | the `entries` map + per-entry `range_digest`/`class_hash` + ck6 combined hash | `stage_artifact`, on the unpacked `metadata.json` |
| `aot_serve.verify` | both | callers holding a full envelope |

Nothing is checked less than before. `entries` rides inside the artifact and
`aot_serve` has always read it from there to serve; it is now verified there
too, before anything is `dlopen`'d. The pre-download filter still refuses every
axis a declare CAN carry, by its own class, with no bytes moved (asserted).

## The authority the contract lacked

The cause is two independent computations of one fact — what a declare must
carry — in two modules, so a change to one side could not see the other (the
pgw#985 defect class, one layer up). Now:

- `aot_cells.DECLARE_CONTRACT_KEYS` — every key the pre-download filter reads;
- `fleet_cells.assert_declare_contract()` — runs at import, raises when
  `_UNBOUNDED_ENVELOPE_BLOCKS` intersects it.

The next block that moves fails every test run rather than a fleet.

## Test evidence

`tests/test_cell_declare_verify_split_pgw988.py` — the rig's own seam as a CI
row, minus the card: a real `CellPublisher.publish` over a real socket into a
hub that stores the declare it actually received, then a real
`aot_cells.discover` reading that same body back off a real checkpoint listing
and pulling the real artifact bytes the publisher uploaded. Nothing between the
two halves is stubbed; only the two hardware probes (`runtime_key`, the torch
read inside `host_isa.stamp`) are pinned, and the ISA machine/level stay this
host's real ones.

Every existing discovery test hands `_candidates` a full envelope no publisher
has ever put on the wire — which is why the whole suite stayed green through the
regression.

- **RED** on a clean `origin/master` src tree: **7/7 fail**, with the verbatim
  reject class `verify:malformed declared contract: metadata declares no entries map`.
- **GREEN** here: 7/7 pass.

Also asserted: the declare still carries none of the four unbounded blocks and
stays under `CELL_DECLARE_MAX_BYTES` on the same wire that now yields an
adoption — the fix does not undo th#1645.

## Gates (run locally; GitHub Actions is in a major outage)

- `pytest tests/ -n 4 --dist loadfile` — **3300 passed, 37 skipped, 1 xfailed**
- `pytest tests_v2/ -n 4 --dist loadfile` — **21 passed**
- `mypy src/gen_worker` — clean, 231 files
- `ruff check src/gen_worker tests/test_cell_declare_verify_split_pgw988.py` — clean
- `scripts/lint_http_timeouts.py`, `scripts/lint_unreached_surface.py`,
  `scripts/lint_config_reads.py` — all exit 0

## Release

No version bump in this PR. **This needs to reach the fleet**: unadoptable cells
cost a full compile per cold boot on every serving pod, so it should ride the
next release train (0.93.2, already queued for the attempt-24 gate hardcut and
ck5→ck6) rather than be published solo. Recorded in the tracker.

Closes pgw#988.