### PR TITLE
pgw#994: the contract records WHERE a leaf lives, and the serve side replays it — one flattening rule for mint and serve

### DIFF
--- a/changelog.d/pgw994.md
+++ b/changelog.d/pgw994.md
@@ -1,0 +1,28 @@
+- **pgw#994: the ingress contract numbered its inputs after flattening and the
+  serve path matched those numbers against the call before flattening, so a
+  container family bound the wrong tensors — or refused every request.** Found
+  off-GPU by pgw#993's sweep, at no pod cost. `aot_package.input_contract`
+  counts `position` over the EXPORTED graph inputs; a container argument
+  occupies ONE caller slot and produces N of them, so for z-image's
+  `x: list[Tensor]`, `x.0` bound the whole list, `x.1` bound the NEXT argument,
+  and the last input refused `input_missing`. sdxl escaped only because
+  diffusers passes its dict by keyword (the positional branch never fired) and
+  a nested SEARCH then found `text_embeds` inside `added_cond_kwargs` —
+  two accidents, and neither could help a list. Two more things were luck, both
+  measured while fixing this: the caller-side walk sorted dict keys while
+  `torch.export` flattens dicts in INSERTION order (so any dict whose insertion
+  order is not alphabetical recorded every leaf with another leaf's dtype and
+  shape — `text_embeds` < `time_ids` hid it), and a plain input sitting after a
+  container has a flat position its own argument does not have. **New module
+  `gen_worker.aot_flatten` is now the ONE flattening rule** — the walk, the leaf
+  identity `(param, param_position, path)`, and the exported-name spelling
+  (`x_0`, `added_cond_kwargs_text_embeds`, `img_shapes_0_0`, all measured
+  against real exports). The mint flattens its example feed with it, each
+  contract row records its identity, `aot_serve.bind_call_inputs` REPLAYS that
+  identity, and pgw#993's `exported_input_names` is a special case of the same
+  naming rule rather than a second copy. **The nested search is deleted**: the
+  contract states where a value lives, so nothing hunts for it and a colliding
+  key in an unrelated kwarg can no longer decide a bind. Identity is written —
+  and keyed into `range_digest` — only when it is not derivable from the row
+  itself, so no already-published contract's ck6 key moves, and metadata
+  without the fields loads as the trivial identity it describes.

--- a/src/gen_worker/aot_flatten.py
+++ b/src/gen_worker/aot_flatten.py
@@ -1,0 +1,183 @@
+"""The ONE flattening rule, for the mint and the serve side alike (pgw#994).
+
+``torch.export`` does not take a call as written: it FLATTENS it. A container
+argument occupies one caller parameter slot and produces one graph input per
+pytree leaf. Every part of this SDK that has to line the two views up — the
+mint building an ingress contract, the serve path binding a real call to it,
+the declared-range gate resolving a declared name against an exported one —
+needs the same answer to "which leaf is this", and each one used to compute it
+for itself:
+
+* pgw#790: ``input_contract`` zipped caller-side PARAMETER names against
+  exported inputs, so sdxl's ``added_cond_kwargs`` shifted every later name by
+  one and the recorded contract named the wrong tensors.
+* pgw#993: the declared-range gate resolved ``Dim.carried_by``'s input by its
+  DECLARED name against a program whose inputs were ``x_0``/``x_1``, which
+  made a dim carried by a ``repeat=`` container unsatisfiable by construction.
+  Cost: one rented A100.
+* pgw#994 (this module): the contract recorded ``position`` as the index among
+  FLATTENED inputs while ``bind_call_inputs`` matched it against the caller's
+  PRE-flattening args, so a container family bound the whole list to element 0
+  and shifted every later input.
+
+Three instances of one defect, so the rule lives in exactly one place and
+every consumer reads it from here.
+
+MEASURED, on torch 2.13.0+cu130, because each of these had been assumed wrong
+at least once:
+
+* A sequence leaf is ``<param>_<index>``, for EVERY arity — a one-element
+  container is ``x_0``, never ``x``.
+* A mapping leaf is ``<param>_<key>`` (``added_cond_kwargs_text_embeds``).
+* Nesting composes: ``img_shapes_0_0``.
+* **Mappings flatten in INSERTION order, not sorted order.** The pre-pgw#994
+  walk sorted keys "because that is what torch's pytree does"; it does not.
+  ``{"zeta", "alpha", "mid"}`` exports as ``d_zeta, d_alpha, d_mid`` with the
+  matching shapes, so a sorted walk pairs every leaf with another leaf's dtype
+  and shape. sdxl escaped only because ``text_embeds`` < ``time_ids``.
+* Non-tensor leaves still occupy a flat slot (``user_inputs`` carries the
+  constants themselves: ``['hidden_states', 1, 4, 6, False, 'extra']``), so a
+  walk that skipped them would desynchronise from the exported order.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Sequence, Tuple, Union
+
+#: One step into a container: a sequence index or a mapping key.
+PathStep = Union[int, str]
+
+
+@dataclass(frozen=True)
+class Leaf:
+    """One exported graph input, and where it came from in the CALL.
+
+    :attr:`param` + :attr:`path` is the leaf's IDENTITY — the only thing that
+    survives the round trip from the mint's example feed to a real serve call,
+    because it describes the call's structure rather than a spelling of it.
+    :attr:`name` is the serve-facing spelling and is what the ingress contract
+    has always been keyed by; it is derived here so it cannot drift from the
+    identity it names.
+    """
+
+    param: str
+    #: Index of :attr:`param` in the traced call's parameter order — how the
+    #: serve side finds it when the pipeline passes it positionally.
+    param_position: int
+    path: Tuple[PathStep, ...]
+    value: Any = None
+
+    @property
+    def name(self) -> str:
+        """The serve-facing name (pgw#790's spelling, kept deliberately).
+
+        A mapping leaf takes its BARE KEY because that is the keyword the
+        pipeline's own forward uses; a sequence leaf takes ``<param>.<index>``.
+        This is the string the published contracts are keyed by and the one
+        ``contract_digest`` folds into ck6, so it is fixed — pgw#994 adds the
+        identity next to it rather than renaming 144 live checkpoints.
+        """
+        name = self.param
+        for step in self.path:
+            # A mapping level REPLACES the name with the bare key; a sequence
+            # level appends `.index`. Thread-through, which is pgw#790's walk
+            # restated over the identity rather than a second copy of it.
+            name = step if isinstance(step, str) else f"{name}.{step}"
+        return name
+
+    @property
+    def exported_name(self) -> str:
+        """The name ``torch.export`` gives this leaf's placeholder."""
+        return exported_name(self.param, self.path)
+
+    @property
+    def trivial(self) -> bool:
+        """True when the leaf IS its parameter — no container in between."""
+        return not self.path
+
+
+def exported_name(param: str, path: Sequence[PathStep] = ()) -> str:
+    """``torch.export``'s placeholder name for one leaf of one parameter.
+
+    ``('x', (0,)) -> 'x_0'``; ``('added_cond_kwargs', ('text_embeds',)) ->
+    'added_cond_kwargs_text_embeds'``; ``('img_shapes', (0, 0)) ->
+    'img_shapes_0_0'``. All three measured, not inferred.
+    """
+    return "_".join([str(param), *(str(step) for step in path)])
+
+
+def flatten_call(
+    param_names: Sequence[str], args: Sequence[Any], kwargs: Mapping[str, Any],
+) -> Tuple[Leaf, ...]:
+    """The call's leaves, in the order ``torch.export`` flattens them.
+
+    ``param_names`` is the traced call's parameter order (positional first,
+    then the keywords actually passed) — ``aot_mint._input_names``' output.
+    """
+    values = list(args) + [
+        kwargs[name] for name in param_names[len(args):] if name in kwargs
+    ]
+    out: List[Leaf] = []
+    for position, (param, value) in enumerate(zip(param_names, values)):
+        _walk(param, position, (), value, out)
+    return tuple(out)
+
+
+def _walk(
+    param: str, position: int, path: Tuple[PathStep, ...], value: Any,
+    out: List[Leaf],
+) -> None:
+    if isinstance(value, Mapping):
+        # INSERTION order: torch's pytree does not sort, and sorting here
+        # pairs each leaf with another leaf's tensor (measured; see module
+        # docstring).
+        for key in value:
+            _walk(param, position, path + (str(key),), value[key], out)
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _walk(param, position, path + (int(index),), item, out)
+    else:
+        out.append(Leaf(param=param, param_position=position, path=path,
+                        value=value))
+
+
+def resolve_leaf(
+    param: str, param_position: int, path: Sequence[PathStep],
+    args: Sequence[Any], kwargs: Mapping[str, Any],
+) -> Tuple[bool, Any]:
+    """``(found, value)`` for one leaf identity against a REAL call.
+
+    The serve-side half of :func:`flatten_call`: the mint recorded where a
+    leaf lives, this replays it. Keyword first, then the parameter's own
+    position — never a search, because a search is what made sdxl's dict case
+    pass by luck while z-image's list case could not pass at all.
+    """
+    if param in kwargs:
+        container: Any = kwargs[param]
+    elif 0 <= param_position < len(args):
+        container = args[param_position]
+    else:
+        return False, None
+    for step in path:
+        if isinstance(step, str):
+            if not isinstance(container, Mapping) or step not in container:
+                return False, None
+            container = container[step]
+        else:
+            if isinstance(container, (str, bytes)) or \
+                    not isinstance(container, (list, tuple)):
+                return False, None
+            if step >= len(container):
+                return False, None
+            container = container[step]
+    return True, container
+
+
+__all__ = [
+    "Leaf",
+    "PathStep",
+    "exported_name",
+    "flatten_call",
+    "resolve_leaf",
+]

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -114,6 +114,7 @@ from .compile_cache import (
 from dataclasses import replace
 import inspect
 from .models.memory import is_cuda_oom
+from . import aot_flatten
 from . import aot_inputs
 from . import aot_declaration as _decl
 from .api.export_contract import export_declaration
@@ -259,12 +260,17 @@ def exported_input_names(
     program (inputs: [… 'x_0', 'x_1'])" while the export it gated succeeded.
 
     The arity comes from the SAME class row the example feed was built from
-    (``aot_declaration.container_arities``), never re-guessed.
+    (``aot_declaration.container_arities``), never re-guessed, and the spelling
+    comes from ``aot_flatten.exported_name`` — the ONE naming rule the ingress
+    contract and the serve-side bind also read (pgw#994). A declared container
+    is the leaf path ``(0,), (1,), …`` of its parameter, so this function is a
+    special case of that rule rather than a second copy of it.
     """
     arity = (containers or {}).get(name)
     if arity is None:
-        return (str(name),)
-    return tuple(f"{name}_{index}" for index in range(int(arity)))
+        return (aot_flatten.exported_name(name),)
+    return tuple(aot_flatten.exported_name(name, (index,))
+                 for index in range(int(arity)))
 
 
 def dynamic_shapes_spec(
@@ -915,7 +921,7 @@ class _MintedEntry:
     owner: Any
     program: Any
     input_names: Tuple[str, ...]
-    flat_names: Tuple[str, ...]
+    flat_leaves: Tuple[aot_flatten.Leaf, ...]
     files: List[Any]
     timings: Dict[str, Any]
 
@@ -1099,7 +1105,7 @@ def _export_entry(
         timings["warm_s"] = _run_declared_warm(module, args, entry)
 
     input_names = _input_names(module, args, kwargs)
-    flat_names = flat_input_names(module, args, kwargs)
+    flat_leaves = flat_input_leaves(module, args, kwargs)
     # ONE arity map for this arm: the spec builder mirrors the container
     # structure with it and the gates below resolve declared names against
     # the exported ones with it (pgw#993).
@@ -1181,7 +1187,7 @@ def _export_entry(
 
     return _MintedEntry(
         name=entry, spec=espec, module=module, owner=owner, program=program,
-        input_names=input_names, flat_names=flat_names, files=files,
+        input_names=input_names, flat_leaves=flat_leaves, files=files,
         timings=timings)
 
 
@@ -2246,7 +2252,7 @@ def _entry_ingress_declaration(
     the midpoint), deduplicated. A fully specialized entry — the sdxl case —
     yields exactly one call, which is the call its class row exists to serve.
     """
-    inputs, symbols = aot_package.input_contract(row.program, row.flat_names)
+    inputs, symbols = aot_package.input_contract(row.program, row.flat_leaves)
     meta: Dict[str, Any] = {"inputs": inputs, "symbols": symbols}
     if adapter_arm(row.spec.fork) is False:
         # The NEGATIVE half of a branchless class's contract, exactly as
@@ -2514,7 +2520,7 @@ def _gate_and_declare_entry(
             "(e.g. %s)", entry, len(fused), fused[:3])
     try:
         inputs, symbols = aot_package.input_contract(
-            row.program, row.flat_names)
+            row.program, row.flat_leaves)
         constants = aot_package.constants_manifest(package, entry)
     except aot_package.PackageIntrospectionError as exc:
         raise MintRefused(f"entry {entry!r}: declaration: {exc}") from exc
@@ -3001,11 +3007,11 @@ def _input_names(
     return tuple(positional) + tuple(keyword)
 
 
-def flat_input_names(
+def flat_input_leaves(
     module: Any, args: Tuple[Any, ...], kwargs: Mapping[str, Any],
-) -> Tuple[str, ...]:
-    """ONE name per EXPORTED user input — containers FLATTENED the way export
-    flattens them.
+) -> Tuple[aot_flatten.Leaf, ...]:
+    """ONE leaf per EXPORTED user input — containers FLATTENED the way export
+    flattens them, each carrying WHERE IN THE CALL it came from.
 
     MEASURED (pgw#790 lane, real sdxl UNet, torch 2.13): `aot_package.
     input_contract` zips the caller-side parameter names against the exported
@@ -3027,29 +3033,20 @@ def flat_input_names(
     treated the symptom, but a nested lookup cannot help when the NAMES it
     searches for are the wrong ones.
 
-    Mapping leaves take their BARE KEY, which is exactly what the serve-side
-    nested resolution looks for, and dicts flatten in SORTED key order because
-    that is what torch's pytree does. Sequence leaves take `<param>.<index>`.
+    THE NAMES ARE NOT ENOUGH (pgw#994). A name says which leaf this is; it
+    does not say where the leaf LIVES in a call, and the serve side has only
+    the call. So each leaf carries its identity — parameter, that parameter's
+    position, and the path into it — and ``aot_serve.bind_call_inputs``
+    replays that identity instead of guessing. The walk itself lives in
+    ``aot_flatten``, which every consumer of the flat view reads, mint and
+    serve alike: three separate spellings of this one mapping is exactly what
+    pgw#790, pgw#993 and pgw#994 each were.
+
     ``_input_names`` is deliberately left alone: `dynamic_shapes_spec` keys on
     top-level PARAMETER names and mirrors containers structurally.
     """
-    names = _input_names(module, args, kwargs)
-    values = list(args) + [kwargs[n] for n in names[len(args):] if n in kwargs]
-    out: List[str] = []
-
-    def walk(name: str, value: Any) -> None:
-        if isinstance(value, Mapping):
-            for key in sorted(value):
-                walk(str(key), value[key])
-        elif isinstance(value, (list, tuple)):
-            for index, item in enumerate(value):
-                walk(f"{name}.{index}", item)
-        else:
-            out.append(str(name))
-
-    for name, value in zip(names, values):
-        walk(str(name), value)
-    return tuple(out)
+    return aot_flatten.flatten_call(
+        _input_names(module, args, kwargs), args, kwargs)
 
 
 def _specialization_facts(spec: ExportSpec) -> Dict[str, Any]:

--- a/src/gen_worker/aot_package.py
+++ b/src/gen_worker/aot_package.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
+from . import aot_flatten
 from .aot_serve import SOURCE_LITERAL, SOURCE_STATE_DICT
 import hashlib
 
@@ -629,7 +630,7 @@ def unbindable_constants(
 
 
 def input_contract(
-    program: Any, input_names: Sequence[str],
+    program: Any, leaves: Sequence[aot_flatten.Leaf],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, List[int]]]:
     """``(inputs, symbols)`` rows for ``aot_serve.artifact_metadata``.
 
@@ -648,13 +649,20 @@ def input_contract(
     Dtypes and shapes come off the exported program's placeholders rather than
     off the example inputs, so what is recorded is what export actually
     committed to — which is what the consumer will be checked against.
+
+    ``leaves`` are ``aot_flatten`` leaves, not names (pgw#994): each row
+    records WHERE IN THE CALL its input lives — parameter, that parameter's
+    position, and the path into it — because a name cannot tell the serve side
+    that ``x.0`` is element 0 of the single argument ``x`` rather than the
+    argument in slot 0. ``aot_serve.bind_call_inputs`` replays exactly this.
     """
     ranges = _symbol_ranges(program)
     rows: List[Dict[str, Any]] = []
     symbols: Dict[str, List[int]] = {}
-    for position, (name, val) in enumerate(
-        zip(input_names, _user_input_vals(program))
+    for position, (leaf, val) in enumerate(
+        zip(leaves, _user_input_vals(program))
     ):
+        name = leaf.name
         if val is None:
             continue
         shape: List[Any] = []
@@ -671,13 +679,32 @@ def input_contract(
                     f"have nothing to assert (pgw#704 B2)")
             symbols[text] = [bounds[0], bounds[1]]
             shape.append(text)
-        rows.append({
+        row: Dict[str, Any] = {
             "name": str(name),
             "position": position,
             "dtype": _dtype_name(getattr(val, "dtype", None)),
             "shape": shape,
             "optional": False,
-        })
+        }
+        if not leaf.trivial or leaf.param_position != position:
+            # Written only when the identity is NOT derivable from the row
+            # itself. An absent field means `param=name, param_position=
+            # position, path=()` — true exactly when the leaf IS its argument
+            # AND no earlier argument flattened into more than one leaf. The
+            # second half is the half that bites: a plain tensor sitting after
+            # a container has a flat position its ARGUMENT does not have, and
+            # a serve-side bind reading `position` would fetch the wrong one
+            # (measured — it is how pgw#994's `t` went missing). Every cell
+            # published before pgw#994 has no containers at all, so every row
+            # is derivable and no live artifact's metadata (or ck6 key) moves
+            # — see `aot_serve.range_digest`.
+            row["param"] = leaf.param
+            row["param_position"] = leaf.param_position
+            row["path"] = [
+                step if isinstance(step, str) else int(step)
+                for step in leaf.path
+            ]
+        rows.append(row)
     if not rows:
         raise PackageIntrospectionError(
             "exported program declares no user inputs; an artifact with no "

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -81,9 +81,13 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple,
+    Union,
+)
 
 from . import activity as activity_mod
+from . import aot_flatten
 from . import host_isa
 from .cell_adopt import AdoptOutcome
 from . import shape_growth
@@ -285,6 +289,14 @@ class InputContract:
     in :attr:`ArtifactContract.symbols`. ``position`` is the positional
     index in the exported call convention; ``name`` is the keyword the
     pipeline's own forward uses, so a call can be matched either way.
+
+    :attr:`param` / :attr:`param_position` / :attr:`path` are the input's
+    IDENTITY IN THE CALL (pgw#994): which argument it lives in, where that
+    argument sits, and the path into it. ``position`` counts FLATTENED graph
+    inputs and a container argument occupies one caller slot while producing
+    N of them, so position alone binds the wrong value the moment any input is
+    a list or a dict. Defaults are the trivial identity — an input that IS its
+    argument — which is what every row published before pgw#994 declares.
     """
 
     name: str
@@ -292,6 +304,31 @@ class InputContract:
     dtype: str
     shape: Tuple[Any, ...]
     optional: bool = False
+    param: str = ""
+    param_position: int = -1
+    path: Tuple[Union[int, str], ...] = ()
+
+    @property
+    def call_param(self) -> str:
+        """The argument this input lives in (itself, when trivial)."""
+        return self.param or self.name
+
+    @property
+    def call_position(self) -> int:
+        """The argument's own position (this input's, when trivial)."""
+        return self.position if self.param_position < 0 else self.param_position
+
+    @property
+    def trivial_identity(self) -> bool:
+        """True when the identity says exactly what its absence would say.
+
+        Defined on the RESOLVED identity, not on which fields were written, so
+        a row that spells its trivial identity out and one that omits it are
+        the same contract — which is what ``range_digest`` needs in order to
+        key the field without re-keying anything already published.
+        """
+        return (not self.path and self.call_param == self.name
+                and self.call_position == self.position)
 
 
 @dataclass(frozen=True)
@@ -353,12 +390,24 @@ def contract_from_meta(meta: Mapping[str, Any]) -> ArtifactContract:
                 shape.append(dim.strip())
             else:
                 raise ValueError(f"input {name!r} has a malformed dim {dim!r}")
+        raw_path = row.get("path", [])
+        if not isinstance(raw_path, list):
+            raise ValueError(f"input {name!r} has a malformed path {raw_path!r}")
+        path: List[Union[int, str]] = []
+        for step in raw_path:
+            if isinstance(step, bool) or not isinstance(step, (int, str)):
+                raise ValueError(
+                    f"input {name!r} has a malformed path step {step!r}")
+            path.append(int(step) if isinstance(step, int) else str(step))
         inputs.append(InputContract(
             name=name,
             position=int(row.get("position", idx)),
             dtype=dtype,
             shape=tuple(shape),
             optional=bool(row.get("optional", False)),
+            param=str(row.get("param") or ""),
+            param_position=int(row.get("param_position", -1)),
+            path=tuple(path),
         ))
 
     symbols: Dict[str, Tuple[int, int]] = {}
@@ -448,15 +497,30 @@ def range_digest(meta: Mapping[str, Any]) -> str:
     the contract's canonical form.
     """
     contract = contract_from_meta(meta)
+
+    def _row(s: InputContract) -> Dict[str, Any]:
+        row: Dict[str, Any] = {
+            "name": s.name,
+            "position": s.position,
+            "dtype": s.dtype,
+            "shape": list(s.shape),
+            "optional": s.optional,
+        }
+        if not s.trivial_identity:
+            # pgw#994, on the `excluded` precedent below: the call identity is
+            # part of the declared traffic (two classes that take the same
+            # tensors in different argument structures are different graphs),
+            # but it is keyed only when it is not the trivial identity. Every
+            # row published before pgw#994 is trivial, so no live cell is
+            # re-keyed by this field existing.
+            row["param"] = s.call_param
+            row["param_position"] = s.call_position
+            row["path"] = list(s.path)
+        return row
+
     canon = {
         "inputs": [
-            {
-                "name": s.name,
-                "position": s.position,
-                "dtype": s.dtype,
-                "shape": list(s.shape),
-                "optional": s.optional,
-            }
+            _row(s)
             for s in sorted(contract.inputs, key=lambda s: (s.position, s.name))
         ],
         "symbols": {k: list(v) for k, v in sorted(contract.symbols.items())},
@@ -962,38 +1026,49 @@ def _dtype_name(value: Any) -> str:
 def bind_call_inputs(
     contract: ArtifactContract, args: Sequence[Any], kwargs: Mapping[str, Any],
 ) -> Dict[str, Any]:
-    """Match one call's actual arguments to the declared inputs by keyword
-    first, then by position, then INSIDE any mapping-valued kwarg. Missing
-    non-optional input => named refusal.
+    """Match one call's actual arguments to the declared inputs by REPLAYING
+    each input's recorded identity in the call. Missing non-optional input =>
+    named refusal.
 
-    The nested lookup is the serve-side half of the mint's flat calling
-    convention (live-proven missing on the 0.76.x line, pod ae2uc81yub0gyq
-    2026-07-29): the export flattens ``added_cond_kwargs`` entries
-    (``text_embeds``, ``time_ids``) into declared inputs, but a diffusers
-    pipeline calls the denoiser with them NESTED in one dict kwarg —
-    without this resolution an armed artifact refuses every real call by
-    name (``input_missing: text_embeds``) and the cell serves nothing."""
+    THE RULE (pgw#994): an input is found at ``kwargs[param]`` — or at
+    ``args[param_position]`` — followed by its ``path`` into that argument.
+    The mint recorded that identity with ``aot_flatten.flatten_call``; this
+    replays it with ``aot_flatten.resolve_leaf``, so the two sides of the
+    flattening are one rule and not two spellings that agree by luck.
+
+    WHAT THIS REPLACES, because both halves were luck. The old resolution
+    tried ``kwargs[name]``, then ``args[position]``, then a SEARCH inside any
+    mapping-valued kwarg for ``name``.
+
+    * ``position`` counts FLATTENED graph inputs, but ``args`` is the call
+      BEFORE flattening. sdxl escaped because diffusers passes its dict by
+      keyword and the positional branch never fired. z-image, whose ``x`` is
+      a ``list[Tensor]``, could not escape: ``x.0`` bound the whole list,
+      ``x.1`` bound the NEXT argument, and the last input then refused
+      ``input_missing`` — measured off-GPU, and it is what pgw#994 filed.
+    * the nested search found ``text_embeds`` in ``added_cond_kwargs``
+      because no other kwarg happened to carry that key. It is deleted here:
+      the contract now SAYS where the value is, so nothing needs to hunt for
+      it, and a dict that carries a colliding key can no longer decide a bind.
+    """
     out: Dict[str, Any] = {}
     for spec in contract.inputs:
-        if spec.name in kwargs:
-            out[spec.name] = kwargs[spec.name]
-        elif 0 <= spec.position < len(args):
-            out[spec.name] = args[spec.position]
+        found, value = aot_flatten.resolve_leaf(
+            spec.call_param, spec.call_position, spec.path, args, kwargs)
+        if found:
+            out[spec.name] = value
+        elif spec.optional:
+            continue
         else:
-            nested = next(
-                (v[spec.name] for v in kwargs.values()
-                 if isinstance(v, Mapping) and spec.name in v),
-                None)
-            if nested is not None:
-                out[spec.name] = nested
-            elif spec.optional:
-                continue
-            else:
-                raise IngressContractError(
-                    "input_missing",
-                    f"declared input {spec.name!r} (position {spec.position}) "
-                    f"is absent from the call ({len(args)} positional, "
-                    f"kwargs {sorted(kwargs)[:8]!r})")
+            where = f"argument {spec.call_param!r}"
+            if spec.path:
+                where += " path " + "".join(
+                    f"[{step!r}]" for step in spec.path)
+            raise IngressContractError(
+                "input_missing",
+                f"declared input {spec.name!r} ({where}, position "
+                f"{spec.call_position}) is absent from the call "
+                f"({len(args)} positional, kwargs {sorted(kwargs)[:8]!r})")
     return out
 
 
@@ -1048,11 +1123,19 @@ def excluded_inputs_present(
 ) -> Tuple[str, ...]:
     """The contract's EXCLUDED inputs this call actually carries (pgw#790).
 
-    Keyword and nested-mapping only, mirroring :func:`bind_call_inputs`'
-    resolution order minus the positional leg: an excluded input has no
-    position in this graph's signature, so a positional index would name a
-    different argument entirely. A ``None`` value does not count as carrying
-    it — that is how a diffusers pipeline says "absent".
+    Keyword and nested-mapping only: an excluded input has no position in this
+    graph's signature, so a positional index would name a different argument
+    entirely. A ``None`` value does not count as carrying it — that is how a
+    diffusers pipeline says "absent".
+
+    This still SEARCHES, and deliberately (pgw#994, which deleted the search
+    in :func:`bind_call_inputs`). The two questions are not the same one: a
+    declared input has a contract row, so its location is recorded and can be
+    replayed; an EXCLUDED input has no row by definition, and the question
+    asked of it is "does this call carry such a value anywhere" — for which
+    there is nothing to replay. A diffusers pipeline can hand an adapter down
+    nested (``cross_attention_kwargs``), and a branchless class that missed it
+    would silently serve the base model.
     """
     if not contract.excluded:
         return ()

--- a/tests/test_abandoned_mint_telemetry_pgw848.py
+++ b/tests/test_abandoned_mint_telemetry_pgw848.py
@@ -242,7 +242,7 @@ def test_the_pool_ledger_is_live_not_end_of_run(tmp_path: Path) -> None:
         _MintedEntry(
             name=f"unet/row={i}", spec=None, module=None, owner=None,
             program=torch.export.export(Tiny(i), (torch.randn(4, 64),)),
-            input_names=(), flat_names=(), files=[], timings={})
+            input_names=(), flat_leaves=(), files=[], timings={})
         for i in range(2)
     ]
     width = pool.entry_workers(

--- a/tests/test_aot_adapter_fork_pgw790.py
+++ b/tests/test_aot_adapter_fork_pgw790.py
@@ -32,6 +32,8 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from gen_worker import aot_flatten
+
 torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
@@ -492,8 +494,9 @@ def test_a_flattened_container_does_not_shift_the_declared_names() -> None:
     module = NestedUNet().eval()
     args = (torch.randn(2, BUCKET), torch.tensor(1.0), None,
             {"text_embeds": torch.randn(2, 4), "time_ids": torch.randn(2, 6)})
-    flat = aot_mint.flat_input_names(module, args, {})
-    # One name per EXPORTED user input, in export's own (sorted-key) order —
+    flat = tuple(leaf.name for leaf in
+                 aot_mint.flat_input_leaves(module, args, {}))
+    # One name per EXPORTED user input, in export's own (insertion-order) order —
     # not one name per PARAMETER, which is what shifted `text_embeds` onto
     # `added_cond_kwargs` and `time_ids` onto the parameter after it.
     assert flat == ("sample", "timestep", "class_labels",
@@ -511,15 +514,17 @@ def test_the_recorded_contract_names_the_flattened_leaves(tmp_path) -> None:
     with torch.no_grad():
         program = torch.export.export(module, args, {}, strict=False)
     rows, _symbols = aot_package.input_contract(
-        program, aot_mint.flat_input_names(module, args, {}))
+        program, aot_mint.flat_input_leaves(module, args, {}))
     by_name = {r["name"]: r for r in rows}
     assert by_name["text_embeds"]["shape"] == [2, 4]
     assert by_name["time_ids"]["shape"] == [2, 6]
     assert "added_cond_kwargs" not in by_name
 
     # RED: the pre-fix derivation (parameter names) mislabels both.
-    stale, _ = aot_package.input_contract(
-        program, aot_mint._input_names(module, args, {}))
+    stale, _ = aot_package.input_contract(program, [
+        aot_flatten.Leaf(param=name, param_position=index, path=())
+        for index, name in enumerate(aot_mint._input_names(module, args, {}))
+    ])
     stale_names = {r["name"] for r in stale}
     assert "time_ids" not in stale_names
     assert "added_cond_kwargs" in stale_names
@@ -527,16 +532,24 @@ def test_the_recorded_contract_names_the_flattened_leaves(tmp_path) -> None:
 
 def test_the_serve_path_binds_the_flattened_names_from_a_nested_call() -> None:
     """The names the mint records must be the ones a diffusers-shaped call can
-    actually be resolved against — `bind_call_inputs` looks INSIDE a mapping
-    kwarg for the bare leaf key."""
+    actually be resolved against.
+
+    REWRITTEN by pgw#994. This used to pass because `bind_call_inputs`
+    SEARCHED every mapping-valued kwarg for the bare leaf key — which worked
+    only while no other kwarg carried the same key, and could not help the
+    list case at all. The contract now records where each leaf lives and the
+    serve side replays it; the search is deleted.
+    """
     contract = aot_serve.contract_from_meta({
         "inputs": [
             {"name": "sample", "position": 0, "dtype": "float32",
              "shape": [2, BUCKET]},
             {"name": "text_embeds", "position": 3, "dtype": "float32",
-             "shape": [2, 4]},
+             "shape": [2, 4], "param": "added_cond_kwargs",
+             "param_position": 3, "path": ["text_embeds"]},
             {"name": "time_ids", "position": 4, "dtype": "float32",
-             "shape": [2, 6]},
+             "shape": [2, 6], "param": "added_cond_kwargs",
+             "param_position": 3, "path": ["time_ids"]},
         ],
         "symbols": {}, "constants": [],
     })

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -31,7 +31,9 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from gen_worker import aot_mint, aot_package, aot_serve, cell_key  # noqa: E402
+from gen_worker import (  # noqa: E402
+    aot_flatten, aot_mint, aot_package, aot_serve, cell_key,
+)
 from gen_worker.api.decorators import Compile  # noqa: E402
 from gen_worker.api.errors import ValidationError  # noqa: E402
 from gen_worker.api.export_contract import (  # noqa: E402
@@ -555,12 +557,20 @@ def test_lifted_input_gate_names_an_unlifted_declaration() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _leaves(*names: str) -> tuple:
+    """Trivial `aot_flatten` leaves: these programs take plain tensors, so each
+    input IS its own argument (pgw#994's identity, in its degenerate case)."""
+    return tuple(
+        aot_flatten.Leaf(param=name, param_position=index, path=())
+        for index, name in enumerate(names))
+
+
 def test_input_contract_binds_each_symbol_to_an_input_dim() -> None:
     """Without this the consumer has nothing to assert, which is exactly the B2
     hole pgw#704 measured (2048x2048 accepted by a max=160 artifact)."""
     program = _export_lifted(lo=4, hi=24)
     inputs, symbols = aot_package.input_contract(
-        program, ("x", "lora_a", "lora_b"))
+        program, _leaves("x", "lora_a", "lora_b"))
     row = inputs[0]
     assert row["name"] == "x"
     assert row["dtype"] == "float32"
@@ -575,7 +585,7 @@ def test_input_contract_is_accepted_by_the_envelope_parser() -> None:
     """The producer and the consumer must agree on the contract's shape, so the
     rows are round-tripped through the parser that will actually read them."""
     inputs, symbols = aot_package.input_contract(
-        _export_lifted(lo=4, hi=24), ("x", "lora_a", "lora_b"))
+        _export_lifted(lo=4, hi=24), _leaves("x", "lora_a", "lora_b"))
     contract = aot_serve.contract_from_meta(
         {"inputs": inputs, "symbols": symbols})
     assert [s.name for s in contract.inputs] == ["x", "lora_a", "lora_b"]
@@ -599,7 +609,7 @@ def test_input_contract_refuses_an_unbounded_symbol(
     with pytest.raises(
         aot_package.PackageIntrospectionError, match="unbounded range",
     ):
-        aot_package.input_contract(program, ("x", "lora_a", "lora_b"))
+        aot_package.input_contract(program, _leaves("x", "lora_a", "lora_b"))
 
 
 def test_declared_range_gate_catches_a_specialized_dim() -> None:
@@ -872,7 +882,7 @@ def _meta_for(program: Any, package: Path, spec: aot_mint.ExportSpec) -> Dict[st
     """A format-2 envelope around ONE compiled program — the session
     packages are single-model archives, read with ``entry=""``."""
     inputs, symbols = aot_package.input_contract(
-        program, ("x", "lora_a", "lora_b"))
+        program, _leaves("x", "lora_a", "lora_b"))
     entries = {ENTRY: {
         "target": "forward",
         "fork": [[str(n), v] for n, v in sorted(spec.fork)],

--- a/tests/test_entry_canonicalization_pgw917.py
+++ b/tests/test_entry_canonicalization_pgw917.py
@@ -36,7 +36,7 @@ torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
 
-from gen_worker import aot_mint  # noqa: E402
+from gen_worker import aot_flatten, aot_mint  # noqa: E402
 
 FAMILY = "sdxl"
 DIM = 640
@@ -92,7 +92,9 @@ def _entry(name: str, program: Any, *, h: int, w: int, b: int = 2,
         owner=None,
         program=program,
         input_names=("hidden_states", "encoder_hidden_states"),
-        flat_names=("hidden_states", "encoder_hidden_states"),
+        flat_leaves=tuple(
+            aot_flatten.Leaf(param=n, param_position=i, path=())
+            for i, n in enumerate(("hidden_states", "encoder_hidden_states"))),
         files=[],
         timings={},
     )

--- a/tests/test_flatten_contract_pgw994.py
+++ b/tests/test_flatten_contract_pgw994.py
@@ -1,0 +1,303 @@
+"""pgw#994 — the ingress contract records WHERE a leaf lives, and the serve
+side replays that identity instead of guessing.
+
+THE DEFECT. `aot_package.input_contract` numbers `position` over the EXPORTED
+(flattened) graph inputs, while `aot_serve.bind_call_inputs` matched that
+number against the caller's args, which are the call BEFORE flattening. A
+container argument occupies ONE caller slot and produces N graph inputs, so
+for the z-image shape `x.0` bound the whole list, `x.1` bound the next
+argument, and `t` then refused `input_missing` — measured off-GPU:
+
+    row x.0  position 0 | row x.1  position 1 | row t  position 2
+    marshal_positional(contract, (x_list, t), {}) ->
+      IngressContractError: declared input 't' (position 2) is absent
+
+sdxl escaped only because diffusers passes its dict by KEYWORD (so the
+positional branch never fired) and a nested search then found `text_embeds`
+inside `added_cond_kwargs`. Two accidents, not a rule.
+
+TWO MORE THINGS THAT WERE LUCK, both measured here rather than argued:
+
+* `flat_input_names` sorted mapping keys "because that is what torch's pytree
+  does". It does NOT — torch flattens dicts in INSERTION order. A dict whose
+  insertion order is not alphabetical had every leaf recorded with another
+  leaf's dtype and shape. sdxl's `text_embeds` < `time_ids` hid it.
+* A plain input sitting AFTER a container has a flat position its argument
+  does not have, so even a container-free row cannot always be resolved from
+  `position` alone.
+
+THE FIX. `aot_flatten` owns the walk and the naming, and every consumer reads
+it: the mint flattens the example feed with it, the contract records each
+row's `(param, param_position, path)`, the serve side resolves by replaying
+that identity, and pgw#993's `exported_input_names` is a special case of the
+same naming rule. The nested search is DELETED — nothing needs to hunt for a
+value whose location the contract states.
+
+No GPU: every export below is a tiny CPU trace.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from gen_worker import aot_flatten, aot_mint, aot_package, aot_serve
+from gen_worker.aot_flatten import Leaf
+
+torch = pytest.importorskip("torch")
+
+
+# ---------------------------------------------------------------------------
+# Doubles: the three real shapes in the fleet.
+# ---------------------------------------------------------------------------
+
+
+class _ListModule(torch.nn.Module):
+    """z-image: a python LIST of per-sample tensors, then a plain tensor."""
+
+    def forward(self, x: List[Any], t: Any) -> Any:
+        return torch.stack([e.sum() for e in x]) + t.sum()
+
+
+class _DictModule(torch.nn.Module):
+    """sdxl: a tensor plus a dict of conditioning tensors."""
+
+    def forward(self, sample: Any, added_cond_kwargs: Dict[str, Any]) -> Any:
+        return (sample.sum() + added_cond_kwargs["zeta"].sum()
+                + added_cond_kwargs["alpha"].sum())
+
+
+class _MixedModule(torch.nn.Module):
+    """qwen: a tensor, a nested python-int container, a bool, a tensor."""
+
+    def forward(self, hidden_states: Any, img_shapes: List[Any],
+                return_dict: bool, extra: Any) -> Any:
+        total = 0
+        for outer in img_shapes:
+            for grp in outer:
+                total += grp[0] * grp[1]
+        return hidden_states * float(total) + extra.sum()
+
+
+def _contract(
+    module: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any],
+) -> Tuple[Any, aot_serve.ArtifactContract]:
+    program = torch.export.export(module, args, kwargs, strict=True)
+    leaves = aot_mint.flat_input_leaves(module, args, kwargs)
+    rows, symbols = aot_package.input_contract(program, leaves)
+    return program, aot_serve.contract_from_meta(
+        {"inputs": rows, "symbols": symbols})
+
+
+def _shapes(values: List[Any]) -> List[Tuple[int, ...]]:
+    return [tuple(v.shape) for v in values]
+
+
+# ---------------------------------------------------------------------------
+# 1. THE DEFECT — a container family binds a real call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("arity", [1, 2])
+def test_a_container_call_binds_element_for_element(arity: int) -> None:
+    """RED before pgw#994: N=1 bound the LIST where element 0 belonged, and
+    N=2 refused `input_missing: t` outright."""
+    module = _ListModule()
+    x = [torch.randn(4, 1, 8, 8) for _ in range(arity)]
+    t = torch.randn(2)
+    _, contract = _contract(module, (x, t), {})
+
+    feeds = aot_serve.marshal_positional(contract, (x, t), {})
+
+    assert _shapes(feeds) == _shapes(list(x) + [t])
+    # Identity, not luck: each element is ITS element object.
+    assert all(a is b for a, b in zip(feeds, list(x) + [t]))
+
+
+def test_the_input_after_a_container_keeps_its_own_value() -> None:
+    """The half a path-only fix would miss: `t` is flat position 2 and
+    ARGUMENT position 1, so a row with no path still needs its identity."""
+    module = _ListModule()
+    x = [torch.randn(4, 1, 8, 8), torch.randn(4, 1, 8, 8)]
+    t = torch.randn(2)
+    _, contract = _contract(module, (x, t), {})
+
+    row = next(s for s in contract.inputs if s.name == "t")
+
+    assert row.position == 2, "flat position, after two container leaves"
+    assert row.call_position == 1, "argument position, which is what binds"
+    assert aot_serve.bind_call_inputs(contract, (x, t), {})["t"] is t
+
+
+def test_a_container_call_that_is_short_refuses_by_name() -> None:
+    """The gate keeps its teeth: resolution names the argument and the path
+    it walked, rather than an index into a call that has been reshaped."""
+    module = _ListModule()
+    x = [torch.randn(4, 1, 8, 8), torch.randn(4, 1, 8, 8)]
+    _, contract = _contract(module, (x, torch.randn(2)), {})
+
+    with pytest.raises(aot_serve.IngressContractError) as caught:
+        aot_serve.marshal_positional(contract, ([x[0]], torch.randn(2)), {})
+
+    assert caught.value.reason == "input_missing"
+    assert "argument 'x'" in str(caught.value)
+    assert "[1]" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. THE DICT CASE — through the rule, with the search deleted
+# ---------------------------------------------------------------------------
+
+
+def test_dict_leaves_pair_with_their_own_tensors() -> None:
+    """RED before pgw#994: the walk sorted keys, torch does not. With
+    insertion order `zeta, alpha` the sorted walk recorded `alpha` with
+    zeta's [2, 1280] and `zeta` with alpha's [2, 6]."""
+    module = _DictModule()
+    sample = torch.randn(2, 4)
+    cond = {"zeta": torch.randn(2, 1280), "alpha": torch.randn(2, 6)}
+    program, contract = _contract(module, (sample,),
+                                  {"added_cond_kwargs": cond})
+
+    assert list(program.graph_signature.user_inputs) == [
+        "sample", "added_cond_kwargs_zeta", "added_cond_kwargs_alpha"]
+    by_name = {s.name: s for s in contract.inputs}
+    assert by_name["zeta"].shape == (2, 1280)
+    assert by_name["alpha"].shape == (2, 6)
+
+
+def test_the_dict_case_binds_because_the_contract_says_where() -> None:
+    """The nested search is gone (pgw#994): a decoy kwarg carrying the same
+    key must not be able to decide the bind, and the real one still resolves
+    because its identity names its argument."""
+    module = _DictModule()
+    sample = torch.randn(2, 4)
+    cond = {"zeta": torch.randn(2, 1280), "alpha": torch.randn(2, 6)}
+    _, contract = _contract(module, (sample,), {"added_cond_kwargs": cond})
+
+    decoy = {"zeta": torch.randn(9, 9), "alpha": torch.randn(9, 9)}
+    bound = aot_serve.bind_call_inputs(
+        contract, (sample,), {"decoy": decoy, "added_cond_kwargs": cond})
+
+    assert bound["zeta"] is cond["zeta"]
+    assert bound["alpha"] is cond["alpha"]
+    # And with the real argument absent it REFUSES rather than finding the
+    # decoy's key — which is exactly what the old search would have done.
+    with pytest.raises(aot_serve.IngressContractError):
+        aot_serve.bind_call_inputs(contract, (sample,), {"decoy": decoy})
+
+
+def test_a_non_tensor_argument_still_lines_the_positions_up() -> None:
+    """qwen's shape: `img_shapes` and `return_dict` produce constant leaves
+    that occupy flat slots but no contract rows."""
+    module = _MixedModule()
+    args = (torch.randn(1, 4, 6), [[(1, 4, 6)]], False, torch.randn(3))
+    _, contract = _contract(module, args, {})
+
+    bound = aot_serve.bind_call_inputs(contract, args, {})
+
+    assert bound["hidden_states"] is args[0]
+    assert bound["extra"] is args[3]
+
+
+# ---------------------------------------------------------------------------
+# 3. ONE RULE — the naming, and who reads it
+# ---------------------------------------------------------------------------
+
+
+def test_exported_name_is_what_torch_actually_emits() -> None:
+    """Measured against real exports, for all three container shapes at once
+    — the rule is not allowed to be a guess about torch."""
+    class _All(torch.nn.Module):
+        def forward(self, sample: Any, cond: Dict[str, Any], x: List[Any],
+                    nested: List[Any]) -> Any:
+            return (sample.sum() + cond["text_embeds"].sum()
+                    + cond["time_ids"].sum()
+                    + torch.stack([e.sum() for e in x]).sum()
+                    + nested[0][0].sum())
+
+    args = (torch.randn(2, 4),
+            {"text_embeds": torch.randn(2, 1280), "time_ids": torch.randn(2, 6)},
+            [torch.randn(1, 8), torch.randn(1, 8)],
+            [[torch.randn(2)]])
+    program = torch.export.export(_All(), args, {}, strict=True)
+    leaves = aot_mint.flat_input_leaves(_All(), args, {})
+
+    assert [leaf.exported_name for leaf in leaves] == \
+        [str(n) for n in program.graph_signature.user_inputs]
+    assert aot_flatten.exported_name("x", (0,)) == "x_0"
+    assert aot_flatten.exported_name("cond", ("time_ids",)) == "cond_time_ids"
+    assert aot_flatten.exported_name("nested", (0, 0)) == "nested_0_0"
+
+
+def test_the_pgw993_gate_rule_is_the_same_naming_rule() -> None:
+    """pgw#993 fixed the declaration side by expanding declared names into
+    exported ones. That expansion is now this module's naming rule applied to
+    the paths a container has, not a second copy of it."""
+    assert aot_mint.exported_input_names("x", {"x": 3}) == tuple(
+        aot_flatten.exported_name("x", (i,)) for i in range(3))
+    assert aot_mint.exported_input_names("x") == (
+        aot_flatten.exported_name("x"),)
+
+
+def test_the_serve_side_name_spelling_is_unchanged() -> None:
+    """pgw#790's spelling is load-bearing — it is what published contracts are
+    keyed by — so the identity is recorded NEXT to it, never instead of it."""
+    assert Leaf("x", 0, (0,)).name == "x.0"
+    assert Leaf("cond", 1, ("text_embeds",)).name == "text_embeds"
+    assert Leaf("img_shapes", 1, (0, 0, 2)).name == "img_shapes.0.0.2"
+    assert Leaf("cond", 1, ("k", 0)).name == "k.0"
+    assert Leaf("sample", 0, ()).name == "sample"
+
+
+# ---------------------------------------------------------------------------
+# 4. NO LIVE CELL IS RE-KEYED
+# ---------------------------------------------------------------------------
+
+
+def _meta(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {"inputs": rows, "symbols": {"s0": [8, 64]}}
+
+
+def test_a_trivial_identity_does_not_move_the_range_digest() -> None:
+    """`range_digest` feeds ck6. Spelling out an identity that says exactly
+    what its absence says must not re-key the fleet's live checkpoints."""
+    bare = [
+        {"name": "sample", "position": 0, "dtype": "bfloat16",
+         "shape": [2, 4, "s0"], "optional": False},
+        {"name": "t", "position": 1, "dtype": "bfloat16", "shape": [2],
+         "optional": False},
+    ]
+    spelled = [dict(row, param=row["name"], param_position=row["position"],
+                    path=[]) for row in bare]
+
+    assert aot_serve.range_digest(_meta(bare)) == \
+        aot_serve.range_digest(_meta(spelled))
+
+
+def test_a_container_identity_DOES_move_the_range_digest() -> None:
+    """The other direction, because it is the reason the field is keyed at
+    all: two classes taking the same tensors in different argument structures
+    are different graphs and must not share a cell key."""
+    flat = [{"name": "x.0", "position": 0, "dtype": "bfloat16",
+             "shape": [4, "s0"], "optional": False}]
+    carried = [dict(flat[0], param="x", param_position=0, path=[0])]
+
+    assert aot_serve.range_digest(_meta(flat)) != \
+        aot_serve.range_digest(_meta(carried))
+
+
+def test_metadata_without_the_fields_still_loads() -> None:
+    """Every artifact published before pgw#994 has rows with no identity, and
+    they mean the trivial one."""
+    contract = aot_serve.contract_from_meta(json.loads(json.dumps(_meta([
+        {"name": "sample", "position": 0, "dtype": "bfloat16",
+         "shape": [2, 4], "optional": False}]))))
+    (row,) = contract.inputs
+
+    assert row.call_param == "sample"
+    assert row.call_position == 0
+    assert row.path == ()
+    assert row.trivial_identity

--- a/tests/test_mint_dispatch_admission_pgw844.py
+++ b/tests/test_mint_dispatch_admission_pgw844.py
@@ -28,7 +28,7 @@ torch = pytest.importorskip("torch")
 
 import torch.nn as nn  # noqa: E402
 
-from gen_worker import aot_mint, aot_serve  # noqa: E402
+from gen_worker import aot_flatten, aot_mint, aot_serve  # noqa: E402
 
 FAMILY = "sdxl"
 IN_CH = 4
@@ -97,7 +97,9 @@ def _entry(name: str, program: Any, *, arm: bool | None = None,
         owner=None,
         program=program,
         input_names=names,
-        flat_names=names,
+        flat_leaves=tuple(
+            aot_flatten.Leaf(param=n, param_position=i, path=())
+            for i, n in enumerate(names)),
         files=[],
         timings={},
     )


### PR DESCRIPTION
**P0.** pgw#993 unified the *declaration* side of flattening; this is the *serve* side, found by that issue's own sweep — off-GPU, at no pod cost.

## The defect

`aot_package.input_contract` numbers `position` over the EXPORTED graph inputs. `aot_serve.bind_call_inputs` matched those numbers against the caller's args, which are the call **before** flattening. A container argument occupies one caller slot and produces N graph inputs:

```
row x.0 position 0 | row x.1 position 1 | row t position 2
marshal_positional(contract, (x_list, t), {}) ->
  IngressContractError: declared input 't' (position 2) is absent
```

`x.0` bound the whole list, `x.1` bound the next argument, `t` had no slot left. sdxl escaped only because diffusers passes its dict by **keyword** (so the positional branch never fired) and a nested **search** then found `text_embeds` inside `added_cond_kwargs`. Two accidents, neither of which can help a list.

**Two more things were luck**, both measured while fixing this:

* The caller-side walk sorted dict keys "because that is what torch's pytree does". It does not — torch flattens dicts in **insertion** order, so a sorted walk recorded every leaf with *another leaf's* dtype and shape. sdxl escaped again: `text_embeds` < `time_ids`.
* A plain input sitting **after** a container has a flat position its own argument does not have — so even a container-free row cannot always be resolved from `position`.

## The fix — one rule, consumed by both sides

New leaf module `gen_worker.aot_flatten` owns the walk, the leaf identity `(param, param_position, path)`, and the exported-name spelling (`x_0`, `added_cond_kwargs_text_embeds`, `img_shapes_0_0` — measured against real exports). The mint flattens its example feed with it, every contract row records its identity, `bind_call_inputs` **replays** that identity, and pgw#993's `exported_input_names` becomes a special case of the same naming rule rather than a second copy. A third spelling of this one mapping is what pgw#790, pgw#993 and pgw#994 each were.

**The nested search is deleted** — the contract says where a value lives, so nothing hunts for it and a colliding key in an unrelated kwarg can no longer decide a bind. Nothing is stranded: the tracker's own record is that this platform has never published an `aot-inductor` cell, so no live artifact carries an ingress contract. `excluded_inputs_present` keeps its search deliberately, and now says why: an excluded input has no row, so there is no identity to replay.

**Cell keys do not move.** Identity is written — and keyed into `range_digest` — only when it is not derivable from the row itself, and `trivial_identity` is defined on the *resolved* identity, so a row that spells the trivial case out and one that omits it are the same contract. Metadata without the fields loads as the trivial identity it describes. Both directions are asserted, not inspected.

## RED, off-GPU

Six behavioural failures on `origin/master`, one per defect:

```
binds_element_for_element[1]  'list' object has no attribute 'shape'
binds_element_for_element[2]  input_missing: 't' (position 2)
short_call_refuses_by_name    refusal names no argument
dict_leaves_pair_with_own     assert (2, 6) == (2, 1280)
dict_binds_because_contract   bound the DECOY's tensor
non_tensor_argument_lines_up  input_missing: 'extra' (position 5)
```

`tests/test_flatten_contract_pgw994.py`, 13 rows, every export a tiny CPU trace. pgw#790's serve-path row is rewritten rather than deleted: it used to pass through the search, and now passes through the rule.

mypy clean, ruff clean, all three lint guards green, `tests/` green locally (3333 passed).

## Sequencing

Attempt 26's **sdxl A1 run does not depend on this** (the dict case reaches the fallback and binds), so A1 must not be sequenced behind it. Only **z-image's serve/adopt leg** needs it. The release-vehicle call is recorded in the tracker: ride 0.93.3 if green in time, otherwise 0.93.3 cuts without it and this becomes 0.93.4 — no tag waits on a silence.