### PR TITLE
pgw#996: the AOT mint's static preconditions are refused at IMAGE BUILD, not rediscovered on a rented pod

### DIFF
--- a/changelog.d/pgw996.md
+++ b/changelog.d/pgw996.md
@@ -1,0 +1,27 @@
+- **pgw#996: the AOT mint's STATIC preconditions are now refused at IMAGE
+  BUILD, not rediscovered on a rented pod.** `fleet_cells.mint_recipe` asked
+  five decline questions, and two of them had been answered when the image was
+  built: whether it carries a C++ compiler (pgw#823) and whether its pinned
+  torch can trace the lifted-LoRA fork (pgw#723). A "no" there could only ever
+  downgrade the recipe — the fleet then serves eager forever and the evidence
+  is one `self_mint_skipped` event nobody queries. The generated Dockerfile
+  even shipped the resignation as a comment: *"Absent it a mint declines
+  (typed, cheap) and the pod serves eager forever — not fatal, just never
+  fast."* **New module `gen_worker.aot_preconditions`** is the one spelling of
+  those rows; `python -m gen_worker.discovery` (which already runs in every
+  image build, in the final image) stamps them into `endpoint.lock` and
+  `validate_endpoint_lock` turns a `refused` row into a build error — which the
+  hub already treats as a non-retryable build-input failure, so no tensorhub
+  change was needed. An image that declares an export it cannot compile no
+  longer publishes: missing C++ toolchain, a declaration module that raises at
+  import, a non-`MintRefused` declaration error, or torch below the
+  lifted-LoRA floor for a bucket-bearing endpoint all name the precondition and
+  stop the build. A family's OWN typed `MintRefused` (ltx-2.3's open
+  `MINT_BLOCKERS`) is a declared block, not a broken image: recorded as a
+  build warning, said once, instead of rediscovered by every pod that rents a
+  GPU to hear it. A torch-less manifest build abstains, out loud. `mint_recipe`
+  keeps only what a pod can answer and a build cannot — delegation
+  availability, whether the family declares an export at all (JIT stays intake
+  mode), and whether the declaration fits the pipeline this pod COMPOSED. The
+  child's own `MintChildRefused` cxx gate stays: what is deleted is the
+  parent's silent downgrade, not a typed refusal.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -107,6 +107,7 @@ from .aot_contract import (  # re-exported: the declaration layer's vocabulary
     ExportSpec,
     MintRefused,
 )
+from .aot_preconditions import LIFTED_LORA_TORCH_FLOOR, torch_version_gap
 from .compile_cache import (
     _resolve_target,
     toolchain_present,
@@ -199,39 +200,21 @@ def raise_if_device_oom(exc: BaseException, where: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-#: The lifted-LoRA mint's torch floor (pgw#723 residuals, pod 8): torch 2.9
-#: strict export refuses ``bind_views``' in-trace ``mod.lora_a = ...`` setattr
-#: ("AssertionError: Mutating module attribute lora_a during export") that
-#: 2.13 traces fine. 2.9 is NOT a valid fallback for this lane.
-LIFTED_LORA_TORCH_FLOOR = (2, 13)
-
-
 def lifted_torch_gap(spec: ExportSpec) -> str:
     """'' when torch meets the lifted-LoRA floor (or the spec has no lifted
-    fork declared), else the named refusal reason."""
+    fork declared), else the named refusal reason.
+
+    pgw#996: the floor arithmetic lives in ``aot_preconditions`` because the
+    BUILD gate asks the same question of the same image — a second spelling
+    here is how a build proves one thing and a pod discovers another. This
+    wrapper survives for the mint-request CLI, which can be handed a spec the
+    build gate never saw.
+    """
     if not (spec.lora_bucket or spec.lifted_inputs or spec.lora_fqns):
         return ""
     import torch
 
-    version = str(getattr(torch, "__version__", "") or "")
-    parts = version.split("+")[0].split(".")
-    try:
-        found = (int(parts[0]), int(parts[1]))
-    except (IndexError, ValueError):
-        return (
-            f"cannot parse torch version {version!r} to check the "
-            f"lifted-LoRA mint floor (torch >= "
-            f"{'.'.join(map(str, LIFTED_LORA_TORCH_FLOOR))})")
-    if found < LIFTED_LORA_TORCH_FLOOR:
-        floor = ".".join(map(str, LIFTED_LORA_TORCH_FLOOR))
-        return (
-            f"lifted-LoRA mint requires torch >= {floor}, got {version}: "
-            f"torch 2.9 strict export refuses bind_views' in-trace setattr "
-            f"('Mutating module attribute lora_a during export') that 2.13 "
-            f"traces fine — measured on pod 8 (pgw#723 residuals), so the "
-            f"2.13 prod floor is a mint PRECONDITION for this lane, not a "
-            f"preference")
-    return ""
+    return torch_version_gap(str(getattr(torch, "__version__", "") or ""))
 
 
 # ---------------------------------------------------------------------------

--- a/src/gen_worker/aot_preconditions.py
+++ b/src/gen_worker/aot_preconditions.py
@@ -1,0 +1,279 @@
+"""The AOT mint's STATIC preconditions — asked at IMAGE BUILD, once (pgw#996).
+
+A precondition is static when the endpoint IMAGE decides it: the C++ toolchain
+apt installed into it, the torch wheel pinned into it, the declaration module
+baked into it. ``fleet_cells.mint_recipe`` used to ask those questions on a
+rented pod, and a "no" there is a silent downgrade with a rental bill attached
+— the fleet serves eager forever and the evidence is one ``self_mint_skipped``
+event nobody queries. The generated Dockerfile said so out loud: *"Absent it a
+mint declines (typed, cheap) and the pod serves eager forever — not fatal, just
+never fast."*
+
+The ruling: a release whose image cannot AOT-compile the endpoints it DECLARES
+is a broken build, and must refuse to publish naming the precondition. An
+endpoint that declares NO export declaration is not covered — JIT is intake
+mode (ruled), and it keeps the dynamo lane.
+
+This module is the ONE spelling of those rows. ``discovery.discover`` stamps
+them into ``endpoint.lock`` and ``discovery.validation`` turns a refusal into a
+build error; ``aot_mint.lifted_torch_gap`` reads the same floor check the gate
+does, so the build cannot prove one thing and the mint another.
+
+Four verdicts, and the difference between the last three is the whole point:
+
+``ok``         the precondition holds on this image.
+``refused``    it does not, and nothing on a pod can fix it — FAIL THE BUILD.
+``blocked``    the declaration itself refused, in typed ``MintRefused``
+               vocabulary (ltx-2.3's open ``MINT_BLOCKERS``). The family said
+               why; it is a DECLARED block, not a broken image, and it does
+               not need a pod to repeat the sentence.
+``abstained``  this environment cannot decide (a torch-less manifest build).
+               Recorded, never silent — an unrecorded abstention is how a gate
+               becomes decorative.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from .api.export_contract import (
+    declaration_import_failures,
+    export_declaration,
+    has_export_declaration,
+)
+
+# Every heavier import in this module is DEFERRED into the function that needs
+# it. Discovery imports this at build time, where torch may be absent and
+# `compile_cache` (via `aot_contract`) would pull the whole model stack: a
+# precondition gate that cannot be imported in the environment it gates is not
+# a gate. The abstaining path below touches neither.
+
+logger = logging.getLogger(__name__)
+
+#: torch below this cannot trace the lifted-LoRA fork: 2.9 strict export
+#: refuses ``bind_views``' in-trace setattr ("Mutating module attribute lora_a
+#: during export") that 2.13 traces fine — measured on pod 8 (pgw#723
+#: residuals). A mint PRECONDITION for the bucket-bearing lane, not a taste.
+LIFTED_LORA_TORCH_FLOOR: Tuple[int, int] = (2, 13)
+
+CHECK_DECLARATION_IMPORT = "declaration_import"
+CHECK_DECLARATION_EVALUATES = "declaration_evaluates"
+CHECK_CXX_TOOLCHAIN = "cxx_toolchain"
+CHECK_LIFTED_LORA_TORCH_FLOOR = "lifted_lora_torch_floor"
+
+OK = "ok"
+REFUSED = "refused"
+BLOCKED = "blocked"
+ABSTAINED = "abstained"
+
+
+@dataclass(frozen=True)
+class Precondition:
+    """One named precondition verdict, addressed to the endpoint author."""
+
+    check: str
+    verdict: str
+    detail: str
+    family: str = ""
+
+    def manifest_row(self) -> Dict[str, str]:
+        row = {"check": self.check, "verdict": self.verdict,
+               "detail": self.detail}
+        if self.family:
+            row["family"] = self.family
+        return row
+
+
+def torch_version_gap(version: str) -> str:
+    """'' when ``version`` meets the lifted-LoRA floor, else the refusal.
+
+    Pure string arithmetic so the BUILD gate and the mint's own
+    ``aot_mint.lifted_torch_gap`` read one implementation. Two spellings of a
+    floor is how a build proves one thing and a pod discovers another.
+    """
+    parts = version.split("+")[0].split(".")
+    floor = ".".join(map(str, LIFTED_LORA_TORCH_FLOOR))
+    try:
+        found = (int(parts[0]), int(parts[1]))
+    except (IndexError, ValueError):
+        return (f"cannot parse torch version {version!r} to check the "
+                f"lifted-LoRA mint floor (torch >= {floor})")
+    if found < LIFTED_LORA_TORCH_FLOOR:
+        return (
+            f"lifted-LoRA mint requires torch >= {floor}, got {version}: "
+            f"torch 2.9 strict export refuses bind_views' in-trace setattr "
+            f"('Mutating module attribute lora_a during export') that 2.13 "
+            f"traces fine — measured on pod 8 (pgw#723 residuals), so the "
+            f"2.13 prod floor is a mint PRECONDITION for this lane, not a "
+            f"preference")
+    return ""
+
+
+def _torch_version() -> str:
+    import torch
+
+    return str(getattr(torch, "__version__", "") or "")
+
+
+def static_mint_preconditions(
+    declared: Mapping[str, int], *, torch_available: bool,
+    torch_version: Optional[str] = None,
+) -> Tuple[Precondition, ...]:
+    """Every static precondition verdict for the families this image declares.
+
+    ``declared`` maps a family to the largest ``lora_bucket`` any of its
+    endpoints declares (0 = no bucket-bearing lane). Families are the ones
+    carrying a ``compile=`` block; a family with no registered export
+    declaration produces NO row at all — it is intake-mode JIT and owes the
+    AOT lane nothing.
+
+    ``torch_available`` is False under discovery's heavy-dep stubs (a
+    torch-less manifest build). Every row then abstains rather than guessing:
+    a stubbed ``torch.__version__`` is absent, and a declaration that touches
+    torch at build raises for a reason that has nothing to do with the image
+    an endpoint will actually run.
+    """
+
+    rows: list[Precondition] = []
+
+    for module, exc in declaration_import_failures():
+        rows.append(Precondition(
+            check=CHECK_DECLARATION_IMPORT, verdict=REFUSED,
+            detail=(
+                f"export declaration module {module!r} raised at import "
+                f"({exc}). `import_export_declaration` swallows this so an "
+                f"endpoint still BOOTS — correct there, fatal here: the image "
+                f"would ship an endpoint that declares AOT and registers "
+                f"nothing, and on a pod that is indistinguishable from an "
+                f"endpoint which never declared one. Fix the import")))
+
+    families = sorted(f for f in declared if f and has_export_declaration(f))
+    if not families and not rows:
+        return ()
+
+    if not torch_available:
+        detail = (
+            "this discovery ran without torch (heavy-dep stubs armed), so no "
+            "static AOT precondition is decidable here — the toolchain probe, "
+            "the torch floor and every declaration that touches torch would "
+            "answer about the BUILD HOST, not about the image. The in-image "
+            "build decides them")
+        return tuple(rows) + tuple(
+            Precondition(check=CHECK_DECLARATION_EVALUATES,
+                         verdict=ABSTAINED, detail=detail, family=f)
+            for f in families)
+
+    from .aot_contract import MintRefused
+
+    aot_declaring: list[str] = []
+    for family in families:
+        try:
+            decl = export_declaration(family)
+        except MintRefused as exc:
+            # The family REFUSED, in the vocabulary built for refusing. That
+            # is a declared block (ltx-2.3's open MINT_BLOCKERS), not a broken
+            # image — and it is now said at build time instead of being
+            # rediscovered by every pod that rents a GPU to hear it.
+            rows.append(Precondition(
+                check=CHECK_DECLARATION_EVALUATES, verdict=BLOCKED,
+                family=family, detail=str(exc)))
+            continue
+        except Exception as exc:  # noqa: BLE001 — everything else is a defect
+            rows.append(Precondition(
+                check=CHECK_DECLARATION_EVALUATES, verdict=REFUSED,
+                family=family, detail=(
+                    f"the export declaration raised "
+                    f"{type(exc).__name__}: {exc}. A family that cannot mint "
+                    f"YET says so with MintRefused and carries its blockers; "
+                    f"any other exception is a broken declaration, and every "
+                    f"pod running this image would pay to rediscover it")))
+            continue
+        if decl is None:
+            rows.append(Precondition(
+                check=CHECK_DECLARATION_EVALUATES, verdict=REFUSED,
+                family=family, detail=(
+                    "the registered export declaration evaluated to None — "
+                    "there is no Compile to derive graph classes from")))
+            continue
+        rows.append(Precondition(
+            check=CHECK_DECLARATION_EVALUATES, verdict=OK, family=family,
+            detail=(f"{len(getattr(decl, 'classes', ()) or ())} declared "
+                    f"graph class(es) over targets "
+                    f"{list(getattr(decl, 'targets', ()) or [])}")))
+        aot_declaring.append(family)
+
+    if not aot_declaring:
+        # Nothing on this image will ever run an AOTI export, so the toolchain
+        # and the torch floor are not this image's obligations.
+        return tuple(rows)
+
+    rows.append(_cxx_row(aot_declaring))
+
+    version = torch_version if torch_version is not None else _torch_version()
+    for family in aot_declaring:
+        if int(declared.get(family, 0) or 0) <= 0:
+            continue
+        gap = torch_version_gap(version)
+        rows.append(Precondition(
+            check=CHECK_LIFTED_LORA_TORCH_FLOOR,
+            verdict=REFUSED if gap else OK, family=family,
+            detail=gap or (
+                f"torch {version} traces the lifted-LoRA fork (bucket "
+                f"{int(declared[family])})")))
+    return tuple(rows)
+
+
+def _cxx_row(aot_declaring: list[str]) -> Precondition:
+    from . import compile_cache as cc
+
+    found = cc.cxx_compiler()
+    if found:
+        return Precondition(
+            check=CHECK_CXX_TOOLCHAIN, verdict=OK,
+            detail=f"AOTInductor links with {found}")
+    return Precondition(
+        check=CHECK_CXX_TOOLCHAIN, verdict=REFUSED, detail=(
+            f"no C++ compiler on this image, but {aot_declaring!r} declare an "
+            f"AOT export. torch._inductor would raise InvalidCxxCompiler at "
+            f"the LINK step — measured at 336 s of L4 time to reach it "
+            f"(pgw#823). AOTInductor forces the C++ wrapper and links a "
+            f"shared object, unlike the dynamo lane's Triton + Python "
+            f"wrapper: install g++/build-essential in the endpoint image, or "
+            f"drop the export declaration and serve the dynamo/JIT lane"))
+
+
+def declared_compile_families(functions: Any) -> Dict[str, int]:
+    """family -> largest declared ``lora_bucket``, over manifest functions.
+
+    Reads the same ``functions[].compile`` block the hub keys its family-cache
+    lookups off (th#569), so "which families does this image declare" has one
+    answer at build time and no second derivation.
+    """
+    out: Dict[str, int] = {}
+    for fn in functions or ():
+        block = (fn or {}).get("compile") or {}
+        family = str(block.get("family") or "").strip()
+        if not family:
+            continue
+        bucket = int(block.get("lora_bucket") or 0)
+        out[family] = max(out.get(family, 0), bucket)
+    return out
+
+
+__all__ = [
+    "ABSTAINED",
+    "BLOCKED",
+    "CHECK_CXX_TOOLCHAIN",
+    "CHECK_DECLARATION_EVALUATES",
+    "CHECK_DECLARATION_IMPORT",
+    "CHECK_LIFTED_LORA_TORCH_FLOOR",
+    "LIFTED_LORA_TORCH_FLOOR",
+    "OK",
+    "REFUSED",
+    "Precondition",
+    "declared_compile_families",
+    "static_mint_preconditions",
+    "torch_version_gap",
+]

--- a/src/gen_worker/api/export_contract.py
+++ b/src/gen_worker/api/export_contract.py
@@ -39,6 +39,7 @@ from threading import RLock
 from typing import (
     Any,
     Dict,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -804,6 +805,12 @@ def validate_contract(compile_decl: Any) -> None:
 
 _lock = RLock()
 _declared: Dict[str, Any] = {}
+#: (module, "ExcType: message") for every declaration import that FAILED.
+#: pgw#996: the swallow is correct at boot and a lie at build time — a pod
+#: cannot tell "this endpoint declares no AOT" (intake, legitimate) from "the
+#: declaration module blew up" (broken image), because both present as
+#: `export_declaration(family) is None`. The build gate reads this and refuses.
+_import_failures: List[Tuple[str, str]] = []
 
 
 class _Thunk:
@@ -996,6 +1003,20 @@ def reset_export_declarations() -> None:
     """Drop every registration. Tests only."""
     with _lock:
         _declared.clear()
+        _import_failures.clear()
+
+
+def declaration_import_failures() -> Tuple[Tuple[str, str], ...]:
+    """Every declaration module whose import raised, as (module, exception).
+
+    :func:`import_export_declaration` deliberately swallows — an endpoint must
+    come up. The build gate (pgw#996) is where that swallow stops being
+    correct: an image whose declaration module cannot import ships an endpoint
+    that declares AOT and mints nothing, and on a pod that is indistinguishable
+    from an endpoint that never declared one.
+    """
+    with _lock:
+        return tuple(_import_failures)
 
 
 def import_export_declaration(
@@ -1018,6 +1039,9 @@ def import_export_declaration(
         importlib.import_module(module, package=package)
         return True
     except BaseException as exc:  # noqa: BLE001 — serving outranks compiling
+        with _lock:
+            _import_failures.append(
+                (str(module), f"{type(exc).__name__}: {exc}"))
         detail = (
             f"export declaration module {module!r} raised at import "
             f"({type(exc).__name__}: {exc}) — this endpoint serves EAGER and "
@@ -1050,6 +1074,7 @@ __all__ = [
     "STATIC_ROWS",
     "FORK_REASONS",
     "WEAK_FORK_REASONS",
+    "declaration_import_failures",
     "export_declaration",
     "has_export_declaration",
     "registered_entry",

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -14,6 +14,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import msgspec
 
+from gen_worker.aot_preconditions import (
+    declared_compile_families,
+    static_mint_preconditions,
+)
 from gen_worker.api.binding import Binding
 from gen_worker.api.slot import Slot
 from gen_worker.api.types import (
@@ -912,8 +916,15 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
     # decoders this image actually carries — never a hand-maintained list.
     # Runs inside the same heavy-dep stubbing the endpoint walk used, so a
     # torch-less manifest build derives the same set an in-image build does.
-    with stub_missing_heavy_deps(cfg.discovery_heavy_deps):
+    with stub_missing_heavy_deps(cfg.discovery_heavy_deps) as stubbed:
         derived = derive_execution_lanes()
+        # pgw#996: the AOT lane's STATIC preconditions, decided in the image
+        # that will run them. `validate_endpoint_lock` turns a refusal into a
+        # build error, so an endpoint that declares an export it cannot
+        # compile never reaches a pod to downgrade there.
+        preconditions = static_mint_preconditions(
+            declared_compile_families(functions),
+            torch_available="torch" not in stubbed)
     for fn in functions:
         bucket = int((fn.get("compile") or {}).get("lora_bucket") or 0)
         lanes, exclusions = execution_lanes_for_function(
@@ -930,6 +941,9 @@ def discover_manifest(root: Optional[Path] = None) -> Dict[str, Any]:
         "functions": functions,
         "execution_lanes": manifest_block(derived),
     }
+    if preconditions:
+        manifest["aot_preconditions"] = [
+            row.manifest_row() for row in preconditions]
     return manifest
 
 

--- a/src/gen_worker/discovery/validation.py
+++ b/src/gen_worker/discovery/validation.py
@@ -113,11 +113,46 @@ def validate_endpoint_lock(lock_dict: Dict[str, Any]) -> EndpointLockValidationR
             )
         slugs[slug] = py_name
 
+    _check_aot_preconditions(lock_dict, errors, warnings)
+
     return EndpointLockValidationResult(
         ok=not errors,
         errors=tuple(errors),
         warnings=tuple(warnings),
     )
+
+
+def _check_aot_preconditions(
+    lock_dict: Dict[str, Any], errors: List[str], warnings: List[str],
+) -> None:
+    """pgw#996: an image that cannot AOT-compile what it DECLARES is broken.
+
+    ``discover_manifest`` stamps ``aot_preconditions`` — the static verdicts
+    read off this very image (its C++ toolchain, its torch wheel, its
+    declaration modules). A ``refused`` row means no pod can fix it, so the
+    build stops here rather than shipping an endpoint that declares an export
+    and silently downgrades its recipe on rented hardware forever.
+
+    ``blocked`` (the family's own typed ``MintRefused``) and ``abstained`` (a
+    torch-less manifest build) are WARNINGS: both are legitimate, and both are
+    said out loud so nobody has to infer them from a pod's absence of events.
+    """
+    rows = lock_dict.get("aot_preconditions") if isinstance(lock_dict, dict) else None
+    for row in rows or ():
+        if not isinstance(row, dict):
+            errors.append(f"aot_preconditions: expected dict rows, got {row!r}")
+            continue
+        verdict = str(row.get("verdict") or "").strip()
+        family = str(row.get("family") or "").strip()
+        label = f"{row.get('check')}{f' [{family}]' if family else ''}"
+        detail = str(row.get("detail") or "")
+        if verdict == "refused":
+            errors.append(f"aot precondition {label}: {detail}")
+        elif verdict in ("blocked", "abstained"):
+            warnings.append(f"aot precondition {label} ({verdict}): {detail}")
+        elif verdict != "ok":
+            errors.append(
+                f"aot precondition {label}: unknown verdict {verdict!r}")
 
 
 _NON_SLUG_CHARS = re.compile(r"[^a-z0-9.]+")

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1888,6 +1888,14 @@ def mint_recipe(
     Every decline here is NAMED on the wire. A silent decline is the defect
     class this issue exists to kill: five real L4 pods produced no mint and no
     refusal, which is indistinguishable from a crash.
+
+    pgw#996 split the branches by WHEN they are knowable. What is left asks
+    only questions a pod can answer and a build cannot: whether delegation is
+    available right now, whether this family declares an export at all, and
+    whether the declaration fits the pipeline this pod actually COMPOSED. The
+    image's own properties — C++ toolchain, torch floor, whether the
+    declaration module even imports — are refused at build time by
+    ``aot_preconditions``; reaching a pod is proof they hold.
     """
     family = str(getattr(cfg, "family", "") or "")
 
@@ -1925,6 +1933,12 @@ def mint_recipe(
     # arrives here — as a typed `self_mint_skipped` carrying every word of the
     # blocker text — instead of as an ImportError that takes the endpoint
     # down at boot. A refusal to MINT is not a refusal to IMPORT.
+    #
+    # pgw#996: the STATIC half of this refusal (unresolved MINT_BLOCKERS) is
+    # already recorded by the build gate, so no pod discovers it for the first
+    # time. The branch survives because the other half is genuinely a pod
+    # fact: ltx-2.3's thunk reads `LTX_SERVING_TIER` off the environment, and
+    # an unknown tier there is a MintRefused the image could not have known.
     try:
         decl = export_declaration(family)
     except Exception as exc:  # noqa: BLE001 — serving outranks compiling
@@ -1959,24 +1973,14 @@ def mint_recipe(
     # the one lane the mint admitted was the one lane no AUTO pod could be on.
     # Every check below answers "can this compile physically run", never
     # "should this lane exist".
-    refusal = aot_mint.lifted_torch_gap(spec)
-    if refusal:
-        return _decline("aot_lifted_torch_gap", refusal)
-
-    # pgw#823: AOTI links a real `.so`, so it needs a C++ compiler — and the
-    # endpoint images do not have one. The parent runs the SAME image as the
-    # child, so this is answerable here, for free, instead of after the child
-    # has loaded the pipeline and exported every graph class: measured, that
-    # cost 336 s of L4 time to arrive at `InvalidCxxCompiler`. Deliberately
-    # NOT `toolchain_present()` — that one passes on the image's C compiler,
-    # and tightening it would refuse the dynamo lane, which needs no C++.
-    if not cc.cxx_toolchain_present():
-        return _decline(
-            "no_cxx_toolchain",
-            "no C++ compiler on this image (torch._inductor would raise "
-            "InvalidCxxCompiler): AOTInductor forces the C++ wrapper and "
-            "links a shared object, unlike the dynamo lane's Triton + Python "
-            "wrapper — install g++/build-essential in the endpoint image")
+    # pgw#996: the C++ toolchain (pgw#823) and the lifted-LoRA torch floor
+    # (pgw#723) USED to be asked here. Both are properties of the IMAGE — apt
+    # installed g++, the pinned torch wheel — decided long before this pod was
+    # rented, and answering them here could only ever downgrade the recipe and
+    # bill the fleet for eager serving. They are now `aot_preconditions` rows
+    # that the image build refuses on (`discovery.validate_endpoint_lock`), so
+    # an image that reaches a pod has already proven them. What survives below
+    # is the residue that a build genuinely cannot know: the COMPOSED pipeline.
 
     # pgw#822: the LAST thing checkable without renting anything. Every
     # declared graph class's input names against its target module's own

--- a/tests/test_cxx_toolchain_pgw823.py
+++ b/tests/test_cxx_toolchain_pgw823.py
@@ -92,17 +92,30 @@ def test_the_predicate_does_not_contradict_torch(
 
 
 # ---------------------------------------------------------------------------
-# The decline — before the child, before the 336 s
+# The refusal — pgw#996 moved it to the BUILD
+#
+# pgw#823 asked this question on the pod, where the only available answer was
+# a silent downgrade: decline the AOT recipe, serve eager forever, bill the
+# fleet. The toolchain is a property of the IMAGE, so the question now belongs
+# to the image build (`aot_preconditions` / `validate_endpoint_lock`, proven in
+# test_mint_preconditions_pgw996.py) and a g++-less image that declares an
+# export cannot be published at all. What survives on the mint path is the
+# CHILD's typed refusal, below: loud and terminal, never a downgrade.
 # ---------------------------------------------------------------------------
 
 
-def test_the_parent_declines_the_AOT_recipe_by_name(
+def test_the_parent_no_longer_second_guesses_the_image(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The 336 s is bought back by the build gate, not by a pod-side branch.
+    A pod that reaches this code is running an image whose build PROVED the
+    toolchain, so the parent asks nothing and mints AOT."""
     monkeypatch.setattr(fleet_cells.cc, "cxx_toolchain_present", lambda: False)
     from gen_worker import aot_mint
 
     monkeypatch.setattr(aot_mint, "lifted_torch_gap", lambda *a, **k: "")
+    monkeypatch.setattr(
+        aot_mint, "declaration_module_gaps", lambda *a, **k: [])
     monkeypatch.setattr(
         fleet_cells, "aot_export_spec", lambda *a, **k: object())
 
@@ -131,9 +144,8 @@ def test_the_parent_declines_the_AOT_recipe_by_name(
         guidance_scales=(), targets=("unet",), regional=False)
     recipe = fleet_cells.mint_recipe(object(), cfg, delegate=True)
 
-    assert recipe == fleet_cells.RECIPE_DYNAMO
-    assert events and events[-1][2]["phase"] == "no_cxx_toolchain"
-    assert "InvalidCxxCompiler" in events[-1][1]
+    assert recipe == fleet_cells.RECIPE_AOT
+    assert [e for e in events if e[2].get("phase") == "no_cxx_toolchain"] == []
 
 
 def test_the_child_refuses_the_AOT_recipe_before_reading_weights(

--- a/tests/test_mint_preconditions_pgw996.py
+++ b/tests/test_mint_preconditions_pgw996.py
@@ -1,0 +1,437 @@
+"""pgw#996 — the AOT mint's STATIC preconditions are refused at IMAGE BUILD.
+
+Two sides, both proven here:
+
+* the BUILD side — a real ``discover_manifest`` walk over a toy endpoint tree
+  that declares an export, run through the real ``validate_endpoint_lock``.
+  An image missing a static precondition FAILS, naming it.
+* the MINT side — the same condition is no longer reachable as a mint-time
+  fallback. ``mint_recipe`` on a toolchain-less, floor-violating environment
+  returns the AOT recipe and declines nothing, because the only image that can
+  reach a pod already proved both.
+
+No mocks of the thing under test: the discovery walk, the declaration
+registry, the validation gate and ``mint_recipe`` are the shipped ones.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+from gen_worker import aot_preconditions as pre
+from gen_worker import compile_cache as cc
+from gen_worker import fleet_cells
+from gen_worker.api import export_contract as ec
+from gen_worker.discovery.discover import discover_manifest
+from gen_worker.discovery.validation import validate_endpoint_lock
+
+
+# ---------------------------------------------------------------------------
+# A toy endpoint tree that DECLARES an AOT export
+# ---------------------------------------------------------------------------
+
+_DECLARATION = """
+    from gen_worker import (
+        Compile, Dim, GraphClass, Input, register_export_declaration,
+    )
+
+    FAMILY = "ep996"
+
+    DECL = register_export_declaration(Compile(
+        family=FAMILY, targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}),),
+        inputs=(Input("sample", shape=("B", 4)),),
+        shape_strategy="static-rows", warm_changes_key=False))
+"""
+
+_MAIN = """
+    import msgspec
+    from gen_worker import (
+        Compile, RequestContext, Resources, Slot, endpoint,
+        import_export_declaration,
+    )
+
+    import_export_declaration("{decl_module}")
+
+    class In_(msgspec.Struct):
+        prompt: str = ""
+        model: str = ""
+
+    class Out_(msgspec.Struct):
+        y: str = ""
+
+    class Pipe:
+        @classmethod
+        def lora_state_dict(cls, *a, **k):
+            return {{}}
+
+    @endpoint(
+        models={{"pipeline": Slot(Pipe, selected_by="model")}},
+        resources=Resources(gpu=True),
+        compile=Compile(family="ep996", shapes=((1024, 1024),), text_len=77),
+        lora_bucket={bucket},
+    )
+    class Gen:
+        def setup(self, pipeline: Pipe) -> None: ...
+
+        def generate(self, ctx: RequestContext, data: In_) -> Out_:
+            return Out_()
+"""
+
+
+def _tree(root: Path, pkg: str, declaration: str, *, bucket: int = 0,
+          external: bool = False) -> Path:
+    (root / "pyproject.toml").write_text(textwrap.dedent(f"""
+        [project]
+        name = "{pkg}"
+
+        [tool.gen_worker]
+        main = "{pkg}.main"
+    """))
+    src = root / pkg
+    src.mkdir()
+    (src / "__init__.py").write_text("")
+    # `external` puts the declaration OUTSIDE the walked package, where the
+    # discovery walk never imports it and `import_export_declaration`'s
+    # swallow is the only thing standing between a broken declaration and a
+    # published image.
+    decl_module = f"{pkg}_decl" if external else f"{pkg}.aot_declaration"
+    target = (root / f"{pkg}_decl.py") if external else (src / "aot_declaration.py")
+    target.write_text(textwrap.dedent(declaration))
+    (src / "main.py").write_text(
+        textwrap.dedent(_MAIN).format(
+            pkg=pkg, bucket=bucket, decl_module=decl_module))
+    return root
+
+
+@pytest.fixture()
+def clean_registry(monkeypatch: pytest.MonkeyPatch):
+    """The declaration registry is process-global; a build gate that inherits
+    another test's registrations is testing nothing."""
+    ec.reset_export_declarations()
+    yield
+    ec.reset_export_declarations()
+
+
+@pytest.fixture()
+def toolchain(monkeypatch: pytest.MonkeyPatch):
+    """The image's C++ toolchain, under test control."""
+
+    def _set(path: str) -> None:
+        monkeypatch.setattr(cc, "cxx_compiler", lambda: path)
+
+    _set("/usr/bin/g++")
+    return _set
+
+
+def _build(root: Path, pkg: str, declaration: str, *, bucket: int = 0,
+           external: bool = False):
+    _tree(root, pkg, declaration, bucket=bucket, external=external)
+    manifest = discover_manifest(root)
+    return manifest, validate_endpoint_lock(manifest)
+
+
+# ---------------------------------------------------------------------------
+# BUILD side — the refusals
+# ---------------------------------------------------------------------------
+
+
+def test_a_declaring_image_with_no_cxx_compiler_FAILS_THE_BUILD(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """pgw#823's 336 s of L4 time, refused for free in the image that caused
+    it. The endpoint declares an AOT export and the image cannot link one."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    toolchain("")  # no g++ anywhere
+
+    manifest, result = _build(tmp_path, "ep996_nocxx", _DECLARATION)
+
+    assert result.ok is False
+    (err,) = [e for e in result.errors if "cxx_toolchain" in e]
+    assert "InvalidCxxCompiler" in err
+    assert "install g++" in err
+    assert "ep996" in err  # names the family that declared the export
+    row = next(r for r in manifest["aot_preconditions"]
+               if r["check"] == pre.CHECK_CXX_TOOLCHAIN)
+    assert row["verdict"] == pre.REFUSED
+
+
+def test_a_declaration_module_that_cannot_IMPORT_fails_the_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """``import_export_declaration`` swallows so the endpoint still BOOTS.
+    On a pod the result is indistinguishable from "declares no export"; at
+    build time it is a broken image, and the swallow stops being correct."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manifest, result = _build(
+        tmp_path, "ep996_badimport",
+        'raise RuntimeError("the pinned lib moved")\n', external=True)
+
+    assert result.ok is False
+    (err,) = [e for e in result.errors
+              if pre.CHECK_DECLARATION_IMPORT in e]
+    assert "the pinned lib moved" in err
+    assert "ep996_badimport_decl" in err
+
+
+def test_a_declaration_below_the_lifted_lora_torch_floor_fails_the_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """The pinned torch wheel is an image property. A bucket-bearing endpoint
+    on torch 2.9 cannot trace its own lifted fork — decided at build."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(pre, "_torch_version", lambda: "2.9.0+cu121")
+
+    _manifest, result = _build(
+        tmp_path, "ep996_oldtorch", _DECLARATION, bucket=64)
+
+    assert result.ok is False
+    (err,) = [e for e in result.errors
+              if pre.CHECK_LIFTED_LORA_TORCH_FLOOR in e]
+    assert "torch >= 2.13" in err and "2.9.0+cu121" in err
+
+
+def test_the_torch_floor_is_not_asked_of_a_bucketless_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """No lifted fork is declared, so the floor is not this image's problem —
+    the gate must not refuse a build for a lane it does not run."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(pre, "_torch_version", lambda: "2.9.0+cu121")
+
+    manifest, result = _build(tmp_path, "ep996_nobucket", _DECLARATION)
+
+    assert result.ok is True, result.errors
+    assert not [r for r in manifest["aot_preconditions"]
+                if r["check"] == pre.CHECK_LIFTED_LORA_TORCH_FLOOR]
+
+
+def test_a_healthy_declaring_image_builds_and_records_its_proof(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(pre, "_torch_version", lambda: "2.13.0+cu130")
+
+    manifest, result = _build(tmp_path, "ep996_ok", _DECLARATION, bucket=64)
+
+    assert result.ok is True, result.errors
+    verdicts = {r["check"]: r["verdict"] for r in manifest["aot_preconditions"]}
+    assert verdicts == {
+        pre.CHECK_DECLARATION_EVALUATES: pre.OK,
+        pre.CHECK_CXX_TOOLCHAIN: pre.OK,
+        pre.CHECK_LIFTED_LORA_TORCH_FLOOR: pre.OK,
+    }
+
+
+def test_an_endpoint_that_declares_NO_export_owes_the_AOT_lane_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry,
+) -> None:
+    """JIT is intake mode (ruled). No declaration, no toolchain obligation —
+    a g++-less image carrying an undeclared endpoint still builds."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(cc, "cxx_compiler", lambda: "")
+
+    manifest, result = _build(
+        tmp_path, "ep996_intake", "# this family declares no export\n")
+
+    assert result.ok is True, result.errors
+    assert "aot_preconditions" not in manifest
+
+
+# ---------------------------------------------------------------------------
+# BUILD side — what is NOT a broken build
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_MintRefused_is_a_BLOCKED_family_not_a_broken_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """ltx-2.3's shape: a THUNK with open MINT_BLOCKERS. The family refused in
+    the vocabulary built for refusing, so the image is fine and the sentence
+    is said HERE — instead of on every pod that rents a GPU to hear it."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    manifest, result = _build(tmp_path, "ep996_blocked", """
+        from gen_worker import Compile, register_export_declaration
+        from gen_worker.aot_contract import MintRefused
+
+        def _thunk() -> Compile:
+            raise MintRefused("2 UNRESOLVED mint blocker(s): OQ-2, OQ-4")
+
+        register_export_declaration(_thunk, family="ep996")
+    """)
+
+    assert result.ok is True, result.errors
+    (warn,) = [w for w in result.warnings if "blocked" in w]
+    assert "UNRESOLVED mint blocker" in warn
+    (row,) = manifest["aot_preconditions"]
+    assert row["verdict"] == pre.BLOCKED and row["family"] == "ep996"
+    # A blocked family never runs an AOTI export, so the image owes no
+    # toolchain — the gate must not manufacture a second refusal from it.
+    assert row["check"] == pre.CHECK_DECLARATION_EVALUATES
+
+
+def test_any_OTHER_declaration_exception_is_a_broken_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clean_registry, toolchain,
+) -> None:
+    """The distinction is the whole point: MintRefused is a family SAYING no;
+    a TypeError is a declaration nobody has run since it was written."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    _manifest, result = _build(tmp_path, "ep996_broken", """
+        from gen_worker import Compile, register_export_declaration
+
+        def _thunk() -> Compile:
+            raise TypeError("Dim() got an unexpected keyword 'carried'")
+
+        register_export_declaration(_thunk, family="ep996")
+    """)
+
+    assert result.ok is False
+    (err,) = [e for e in result.errors
+              if pre.CHECK_DECLARATION_EVALUATES in e]
+    assert "TypeError" in err and "MintRefused" in err
+
+
+def test_a_torchless_discovery_ABSTAINS_out_loud(clean_registry) -> None:
+    """A manifest build without torch cannot decide an image's preconditions.
+    It says so — an unrecorded abstention is how a gate becomes decorative."""
+    ec.register_export_declaration(
+        _example_declaration(), family="ep996-abstain")
+    rows = pre.static_mint_preconditions(
+        {"ep996-abstain": 64}, torch_available=False)
+
+    (row,) = rows
+    assert row.verdict == pre.ABSTAINED
+    assert "without torch" in row.detail
+    lock = {"functions": [], "aot_preconditions": [r.manifest_row() for r in rows]}
+    result = validate_endpoint_lock(lock)
+    assert result.ok is True
+    assert any("abstained" in w for w in result.warnings)
+
+
+def _example_declaration():
+    from gen_worker.api.decorators import Compile
+    from gen_worker.api.export_contract import Dim, GraphClass, Input
+
+    return Compile(
+        family="ep996-abstain", targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}),),
+        inputs=(Input("sample", shape=("B", 4)),),
+        shape_strategy="static-rows", warm_changes_key=False)
+
+
+# ---------------------------------------------------------------------------
+# MINT side — the same conditions are no longer reachable as a fallback
+# ---------------------------------------------------------------------------
+
+
+def _mint_recipe_on(monkeypatch: pytest.MonkeyPatch, *, bucket: int) -> tuple:
+    """Run the real ``mint_recipe`` with a declaration and a captured event
+    stream. Returns (recipe, events)."""
+    decl = _example_declaration()
+    monkeypatch.setattr(ec, "export_declaration", lambda _f: decl)
+    monkeypatch.setattr(fleet_cells, "export_declaration", lambda _f: decl)
+    monkeypatch.setattr(fleet_cells, "aot_export_spec", lambda *a, **k: object())
+    from gen_worker import aot_mint
+
+    monkeypatch.setattr(aot_mint, "declaration_module_gaps", lambda *a, **k: [])
+
+    events: list = []
+    monkeypatch.setattr(
+        fleet_cells.activity_mod, "emit_event",
+        lambda kind, detail, **kw: events.append((kind, detail, kw)))
+
+    cfg = types.SimpleNamespace(
+        family="ep996-abstain", lora_bucket=bucket, shapes=(), text_lens=(),
+        guidance_scales=(), targets=("unet",), regional=False)
+    return fleet_cells.mint_recipe(object(), cfg, delegate=True), events
+
+
+def test_the_mint_no_longer_declines_for_a_missing_cxx_toolchain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED before pgw#996: this returned RECIPE_DYNAMO under the
+    ``no_cxx_toolchain`` phase. The image that could produce it now fails to
+    build (see the build-side proof above), so the pod stops second-guessing
+    a fact it cannot change."""
+    monkeypatch.setattr(cc, "cxx_compiler", lambda: "")
+    assert cc.cxx_toolchain_present() is False
+
+    recipe, events = _mint_recipe_on(monkeypatch, bucket=0)
+
+    assert recipe == fleet_cells.RECIPE_AOT
+    assert [e for e in events if e[2].get("phase") == "no_cxx_toolchain"] == []
+
+
+def test_the_mint_no_longer_declines_below_the_lifted_lora_torch_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED before pgw#996: ``aot_lifted_torch_gap``. The torch wheel is baked
+    into the image the build gate cleared."""
+    monkeypatch.setattr(pre, "torch_version_gap", lambda _v: "torch is ancient")
+    from gen_worker import aot_mint
+
+    monkeypatch.setattr(aot_mint, "torch_version_gap",
+                        lambda _v: "torch is ancient")
+
+    recipe, events = _mint_recipe_on(monkeypatch, bucket=64)
+
+    assert recipe == fleet_cells.RECIPE_AOT
+    assert [e for e in events
+            if e[2].get("phase") == "aot_lifted_torch_gap"] == []
+
+
+def test_the_retired_phases_are_gone_from_the_mint_path() -> None:
+    """The tokens themselves: a decline phase that still exists in the source
+    is a decline a fleet can still be told, whatever the tests say."""
+    source = Path(fleet_cells.__file__).read_text()
+    assert "no_cxx_toolchain" not in source
+    assert "aot_lifted_torch_gap" not in source
+    assert "cxx_toolchain_present" not in source
+
+
+def test_the_CHILD_still_refuses_a_toolchainless_AOT_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What is deleted is the parent's silent DOWNGRADE, not the child's typed
+    refusal. A refusal is loud and terminal; a downgrade bills the fleet for
+    eager serving and says nothing."""
+    from gen_worker import mint_child
+
+    monkeypatch.setattr(mint_child, "assert_composable", lambda *a, **k: None)
+    monkeypatch.setattr(cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(cc, "cxx_toolchain_present", lambda: False)
+
+    req = types.SimpleNamespace(
+        slots={}, recipe=mint_child.RECIPE_AOT,
+        target="/tmp/x", capture="/tmp/y", device=0, vram_cap_bytes=0,
+        modules=[], function="generate", cfg=None, configs={},
+        execution_lane="", report="/tmp/r", cell_key="")
+    with pytest.raises(mint_child.MintChildRefused, match="no C\\+\\+ compiler"):
+        mint_child.mint(req)
+
+
+def test_ONE_floor_for_the_build_gate_and_the_mint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two spellings of a precondition is how a build proves one thing and a
+    pod discovers another."""
+    from gen_worker import aot_mint
+    from gen_worker.aot_contract import ExportSpec
+
+    assert aot_mint.LIFTED_LORA_TORCH_FLOOR is pre.LIFTED_LORA_TORCH_FLOOR
+    seen: list[str] = []
+    monkeypatch.setattr(
+        aot_mint, "torch_version_gap",
+        lambda v: seen.append(v) or "")
+    aot_mint.lifted_torch_gap(ExportSpec(family="f", target="unet",
+                                         lora_bucket=64))
+    assert seen and seen[0].startswith("2.")


### PR DESCRIPTION
## The defect

`fleet_cells.mint_recipe` is the single "which mint does this miss run" decision, and it walked five decline branches. Two of them asked questions the **image** had already answered:

| branch | phase | knowable at |
|---|---|---|
| `not delegate` | `aot_requires_delegation` (+4 mapped phases) | runtime |
| `export_declaration(family)` raises | `declaration_refused` | split — MINT_BLOCKERS static, `LTX_SERVING_TIER` is a pod env read |
| `decl is None` | `no_export_declaration` | runtime, and RULED: JIT is intake mode |
| `lifted_torch_gap` | `aot_lifted_torch_gap` | **BUILD** — the pinned torch wheel × the declared `lora_bucket` |
| `cxx_toolchain_present` | `no_cxx_toolchain` | **BUILD** — `shutil.which("g++")` on the image |
| `declaration_module_gaps` | `declaration_module_mismatch` | runtime — needs the COMPOSED pipeline |

A pod that declines for a build-time reason is a silent downgrade with a rental bill attached. The generated Dockerfile shipped the resignation as a comment (`tensorhub/internal/builder/generate_dockerfile.go:78`): *"Absent it a mint declines (typed, cheap) and the pod serves eager forever — not fatal, just never fast."*

## The move

New `gen_worker.aot_preconditions` is the ONE spelling of the static rows (`aot_mint.lifted_torch_gap` now reads the same floor arithmetic, so a build cannot prove one thing and a pod discover another).

`python -m gen_worker.discovery` is the seam: it already runs in **every** image build, in the **final** image (single-stage `FROM ${BASE_IMAGE}`), and its nonzero exit already fails the build as a non-retryable `TENSORHUB_BUILD_INPUT_FAILURE:discovery` → `ErrBuildInput`. **No tensorhub change, no hub deploy, no th#683 arming.** Discovery stamps `aot_preconditions` into `endpoint.lock`; `validate_endpoint_lock` turns a `refused` row into a build error.

**Refused at build** — missing C++ toolchain on an image whose families declare an export; a declaration module that raises at import (`import_export_declaration`'s swallow is correct at boot and a lie at build: on a pod it is indistinguishable from "declares no export"); a non-`MintRefused` declaration error; torch below the lifted-LoRA floor for a bucket-bearing endpoint.

**Recorded, not refused** — a family's own typed `MintRefused` (ltx-2.3's open `MINT_BLOCKERS`) is a DECLARED block, said once at build instead of rediscovered by every pod that rents a GPU to hear it; and a torch-less manifest build, which abstains out loud.

**Kept at mint** — delegation availability, `decl is None` (JIT intake mode stays reachable, per the ruling), and `declaration_module_gaps`, whose question is "does the declaration fit the COMPOSED pipeline" — a pod fact (`_resolve_target` walks the live pipeline; sdxl's own declaration records that `setup()` swaps the VAE post-arming). `mint_child`'s cxx gate stays too: what is deleted is the parent's silent **downgrade**, not a typed refusal.

## RED proof — one script, master vs this branch

A g++-less image whose endpoint DECLARES an AOT export:

```
master:  BUILD ok=True   aot_preconditions in manifest: False   POD recipe=dynamo  phase=no_cxx_toolchain
branch:  BUILD ok=False  "aot precondition cxx_toolchain: no C++ compiler on this image, but ['ep996']
                          declare an AOT export ... install g++/build-essential"
                                                                POD recipe=aot     phase=None
```

`tests/test_mint_preconditions_pgw996.py` (14 rows) proves both sides through the shipped code — a real `discover_manifest` walk over a toy on-disk endpoint tree, the real declaration registry, the real `validate_endpoint_lock`, the real `mint_recipe`. pgw#823's parent-decline test is inverted to the new contract, and a source guard asserts the retired phase tokens are gone from `fleet_cells`.

## Gates

mypy clean (234 files), ruff clean, `lint_unreached_surface` / `lint_config_reads` / `lint_http_timeouts` clean, full `tests/` suite run locally. Strictly local — no pods, no RunPod calls, no deploys.

Tracker: `python-gen-worker/progress.md` #996.