### PR TITLE
pgw#972: chunk-granular cross-pod download resume

### DIFF
--- a/changelog.d/pgw972.md
+++ b/changelog.d/pgw972.md
@@ -1,0 +1,41 @@
+- **pgw#972: download resume now crosses PODS, at chunk granularity.** The
+  chunk journal was pod-local, so *"a pod that dies 90% into a 35 GB component
+  leaves its successor to refetch all 35 GB from R2."* Per Paul's ruling of
+  2026-08-07 — which retracted the "partial files must stay pod-local"
+  attribution as folklore — the endpoint volume now carries an incomplete file's
+  **individually-verified chunks**, never unverified bytes: each chunk is copied
+  to `chunks/<algo>/aa/bb/<file>/<index>-<chunkdigest>` the moment its own
+  sha256 verifies, and a successor pod builds those names straight from the
+  manifest, **re-hashes every chunk it adopts** before trusting it, and fetches
+  only what is missing, in any order. Adoption can waste a hash pass; it can
+  never inject bytes — a corrupt or truncated object is rejected, unlinked and
+  refetched. Measured on the integration rig: an interrupted 8-chunk file costs
+  its successor **1 chunk instead of 8**, against a control arm that refetches
+  every byte.
+- **pgw#972: the chunk name is the whole concurrency story.** It carries all
+  three coordinates a chunk has — file (directory), position (index), content
+  (digest) — so a write is idempotent (two pods reaching that name wrote the
+  same bytes, and a duplicate is a no-op over an atomic rename), an adopter needs
+  no directory inventory and no mapping file, and a file re-chunked at a
+  different size addresses different names and cannot be adopted by accident.
+  That is what dissolves the two-writers objection to putting resume state on
+  shared storage.
+- **pgw#972: cleanup has one rule and no clock.** Whoever establishes that the
+  volume holds the COMPLETE blob under its digest name drops that file's chunk
+  objects — the tee publisher, the copy publisher, and a pod that finds the blob
+  already published. So the only chunk sets that survive belong to files no pod
+  has ever completed on that volume, and the first pod that completes one
+  collects them: no age sweep, no owner registry, nothing for `stall.py` to
+  argue with. `unlink` is a namespace operation, so a drop concurrent with an
+  adoption cannot truncate what that adopter is already reading.
+- **pgw#972: no new transport code, deliberately.** A library survey ran before
+  implementation (recorded in the tracker) and found none that fits: each chunk
+  is its own R2 object under its own presigned URL — the hub sets `f.URL = ""`
+  for a chunked entry and presigns per chunk — while boto3/`s3transfer`,
+  `obstore` and `hf_transfer` are all built for *one object, many byte ranges,
+  credential auth*. Probed, not recalled: `download_file` has no URL parameter at
+  all; `obstore` percent-encodes a signed query into the object key, and its
+  default `retry_timeout: 180s` would have put a wall clock under our loop.
+  `_fetch_chunk_to_offset` and `_Mirror` are untouched, PR #495's three-way
+  backoff classification is unchanged, and the parallel chunk fetch plus
+  prefix-following hasher are th#1362's, already shipped.

--- a/src/gen_worker/models/chunk_cas.py
+++ b/src/gen_worker/models/chunk_cas.py
@@ -45,6 +45,17 @@ to actually live.
     is published only after the LOCAL file passes its whole-file digest, so a
     half-written volume blob is never readable under the digest name, and any
     mirror failure disables the mirror rather than failing the fetch.
+*   **Resume crosses PODS, at chunk granularity** (pgw#972). Each chunk is
+    copied onto the volume the moment its own sha256 verifies, under the
+    content-addressed name ``chunks/<algo>/aa/bb/<file>/<index>-<chunk>``. So
+    the volume never holds unverified bytes under a name anyone reads: it holds
+    individually-VERIFIED chunks of an incomplete file. A successor pod builds
+    those names straight from the manifest, RE-HASHES every chunk it adopts
+    before trusting it, and fetches only what is missing — in any order, since
+    a CAS file's chunks have none. The names are content-addressed, so two pods
+    writing one chunk write identical bytes to one name and a duplicate write
+    is a no-op. Cleanup is targeted and clock-free: whoever establishes that the
+    volume holds the COMPLETE blob drops that file's chunk objects.
 *   Disk is proven UP FRONT with ``posix_fallocate``, so a 2 TB file that will
     not fit fails in milliseconds instead of 90% of the way through.
 """
@@ -78,11 +89,13 @@ __all__ = [
     "chunk_count_for",
     "chunk_len_at",
     "download_chunked_file",
+    "drop_volume_chunks",
     "hash_file",
     "hasher_for",
     "parse_cas_ref",
     "sha256_file",
     "verify_file_digest",
+    "volume_chunk_dir",
 ]
 
 _log = logging.getLogger(__name__)
@@ -339,6 +352,219 @@ class _Mirror:
             self.tmp.unlink(missing_ok=True)
 
 
+def volume_chunk_dir(chunks_root: Path, ref: str) -> Path:
+    """Where one file's verified chunk objects live on the endpoint volume.
+
+    ``chunks/<algo>/aa/bb/<filehex>/`` — the same fanout as ``blobs/``, and a
+    SIBLING of it rather than a tenant inside it, so nothing that walks the blob
+    tree can mistake a chunk for a blob. Scoping the directory by the FILE
+    digest is what makes cleanup a single unambiguous act by a single owner: the
+    set of objects belonging to a completed file is exactly one directory, not a
+    query over a shared pool.
+    """
+    algo, hexpart = parse_cas_ref(ref)
+    return chunks_root / algo / hexpart[:2] / hexpart[2:4] / hexpart
+
+
+def _chunk_object_name(index: int, sha256: str) -> str:
+    """``<index>-<chunk digest>``, zero-padded so the directory sorts numerically.
+
+    All three coordinates a chunk has are in the name: the file (the directory),
+    its position (the index) and its content (the digest). The digest is what
+    makes a write IDEMPOTENT — two pods that reach this name wrote the same
+    bytes — and the index is what lets an adopter build the name straight from
+    the manifest instead of inventorying the directory. A file re-chunked at a
+    different size therefore addresses different names and cannot be adopted by
+    accident.
+    """
+    return f"{index:08d}-{sha256}"
+
+
+def drop_volume_chunks(directory: Path) -> int:
+    """Remove one file's chunk objects; the volume now holds the whole blob.
+
+    **Who and when:** whoever ESTABLISHES that the volume holds the complete
+    blob under its digest name — the pod that publishes it (tee or copy), or a
+    pod that finds it already published. Every such site calls this, so the only
+    chunk sets that survive are those of a file no pod has ever completed on
+    this volume, and the moment one does they go. That needs no sweep, no owner
+    registry and no age clock.
+
+    **Under concurrency:** ``unlink`` is a NAMESPACE operation, so an adopter
+    that already opened an object keeps reading its inode to the end, and one
+    that opens after the unlink simply misses and refetches that chunk. Neither
+    can read WRONG bytes — every adopted chunk is re-hashed regardless. In-flight
+    writers' staged files are left alone (they are dot-prefixed and
+    writer-unique); the ``rmdir`` then fails and is ignored, and the next
+    completion collects the directory.
+    """
+    removed = 0
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if entry.name.startswith("."):
+            continue  # another writer's staged chunk, still being written
+        try:
+            entry.unlink()
+            removed += 1
+        except OSError:
+            pass
+    with contextlib.suppress(OSError):
+        directory.rmdir()
+    if removed:
+        _log.info("volume_chunks_dropped path=%s objects=%d", directory.name[:16], removed)
+    return removed
+
+
+class _VolumeChunks:
+    """The endpoint volume's verified-chunk store for ONE incomplete file.
+
+    pgw#972's cross-pod half. Best effort in exactly ``_Mirror``'s sense: the
+    first error of any kind disables the store for this file and is never
+    propagated, because a volume that is full, slow, read-only or absent must
+    cost the request nothing.
+
+    The volume is mounted by ONE endpoint, so a bad chunk here is self-inflicted
+    rather than hostile — which is why a rejected object is simply unlinked and
+    refetched. It is NOT single-writer, though: two pods of that endpoint are
+    concurrent, so every write stages writer-unique and renames atomically, and
+    every read re-hashes.
+    """
+
+    __slots__ = ("dir", "_ok", "_lock")
+
+    def __init__(self, directory: Path) -> None:
+        self.dir = directory
+        self._ok = True
+        self._lock = threading.Lock()
+
+    @property
+    def ok(self) -> bool:
+        return self._ok
+
+    def disable(self, why: BaseException) -> None:
+        with self._lock:
+            if not self._ok:
+                return
+            self._ok = False
+        _log.warning("volume_chunks_disabled path=%s: %s", self.dir.name[:16], why)
+
+    def path_for(self, index: int, sha256: str) -> Path:
+        return self.dir / _chunk_object_name(index, sha256)
+
+    def publish(self, index: int, spec: ChunkSpec, fd: int, offset: int) -> bool:
+        """Copy one VERIFIED chunk from the local part file onto the volume.
+
+        The read is of bytes this process wrote moments ago, so it comes off the
+        page cache; the cost is one volume write, taken while the pool is still
+        waiting on the network. Staged writer-unique and renamed, so the final
+        name only ever appears with complete bytes — the volume holds verified
+        chunks, never a partial one.
+        """
+        if not self._ok:
+            return False
+        final = self.path_for(index, spec.sha256)
+        tmp = self.dir / f".{final.name}.part-{os.getpid()}-{uuid.uuid4().hex}"
+        try:
+            self.dir.mkdir(parents=True, exist_ok=True)
+            with open(tmp, "xb") as out:
+                pos, remaining = offset, spec.length
+                while remaining > 0:
+                    b = os.pread(fd, min(_READ_CHUNK_BYTES, remaining), pos)
+                    if not b:
+                        raise OSError(f"short read publishing chunk {index}")
+                    out.write(b)
+                    pos += len(b)
+                    remaining -= len(b)
+            # Idempotent by construction: the name fixes the content, so a
+            # racing pod's replace puts the SAME bytes there. Atomic, so a
+            # concurrent reader sees one complete version or the other.
+            os.replace(tmp, final)
+            return True
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            self.disable(exc)
+            return False
+
+    def adopt(
+        self,
+        chunks: Sequence[ChunkSpec],
+        offsets: Sequence[int],
+        wanted: Sequence[int],
+        fd: int,
+        mirror: Optional["_Mirror"],
+        window: int,
+    ) -> set[int]:
+        """Take the chunks a PREVIOUS POD verified and left on the volume.
+
+        Every adopted chunk is RE-HASHED here before it is trusted: the name is
+        a claim, not a proof, so a corrupt or truncated object costs a wasted
+        hash pass and can never inject bytes. Rejected objects are unlinked, so
+        the next pod does not pay the same pass again.
+
+        Bytes go into the local part file (and the mirror) as they are hashed.
+        Writing before the verdict is safe for the same reason a failed fetch
+        attempt is: the range belongs to this chunk alone and nothing reads it
+        until the chunk is marked done, so a rejected adoption is simply
+        overwritten by the refetch.
+        """
+        if not self._ok or not wanted:
+            return set()
+
+        def _take(i: int) -> Optional[int]:
+            spec = chunks[i]
+            src = self.path_for(i, spec.sha256)
+            h = hashlib.sha256()
+            pos, remaining = offsets[i], spec.length
+            try:
+                with open(src, "rb") as f:
+                    while remaining > 0:
+                        b = f.read(min(_READ_CHUNK_BYTES, remaining))
+                        if not b:
+                            return None
+                        h.update(b)
+                        _pwrite_all(fd, b, pos)
+                        if mirror is not None:
+                            mirror.write(b, pos)
+                        pos += len(b)
+                        remaining -= len(b)
+                    if f.read(1):
+                        return None  # longer than the manifest says it is
+            except FileNotFoundError:
+                return None
+            except OSError as exc:
+                self.disable(exc)
+                return None
+            if h.hexdigest() != spec.sha256:
+                _log.warning(
+                    "volume_chunk_corrupt path=%s index=%d: re-hash rejected it; refetching",
+                    self.dir.name[:16], i,
+                )
+                with contextlib.suppress(OSError):
+                    src.unlink()
+                return None
+            return i
+
+        with ThreadPoolExecutor(max_workers=max(1, min(window, len(wanted)))) as pool:
+            kept = {i for i in pool.map(_take, wanted) if i is not None}
+        adopted_bytes = sum(chunks[i].length for i in kept)
+        _log.info(
+            "chunk_resume source=volume path=%s adopted=%d/%d chunks bytes=%d",
+            self.dir.name[:16], len(kept), len(wanted), adopted_bytes,
+        )
+        return kept
+
+    def drop(self) -> int:
+        return drop_volume_chunks(self.dir)
+
+
+def _open_volume_chunks(directory: Optional[Path]) -> Optional["_VolumeChunks"]:
+    return None if directory is None else _VolumeChunks(directory)
+
+
 def _retry_delay(strikes: int) -> float:
     """Full-jitter exponential backoff, capped. Same shape as the whole-file
     loop in ``cozy_cas`` — the chunked path was the only transfer in the SDK
@@ -501,6 +727,7 @@ def download_chunked_file(
     on_bytes: Optional[Callable[[int], None]] = None,
     session_factory: Callable[[], requests.Session] = requests.Session,
     mirror_dst: Optional[Path] = None,
+    mirror_chunk_dir: Optional[Path] = None,
 ) -> bool:
     """Reassemble a chunked file, verifying every chunk AND the whole-file hash.
 
@@ -513,6 +740,12 @@ def download_chunked_file(
     every byte. Returns whether that mirror was published; ``False`` (including
     always when ``mirror_dst`` is ``None``) means the caller still owes the
     volume a copy.
+
+    ``mirror_chunk_dir`` (pgw#972) is that file's chunk-object directory on the
+    same volume — see :func:`volume_chunk_dir`. Verified chunks are published
+    there as they land and adopted from there on the next pod, so a pod that
+    dies 90% into a 35 GB component leaves its successor 3.5 GB to fetch instead
+    of 35 GB.
     """
     if not chunks:
         raise ValueError("download_chunked_file: no chunks")
@@ -558,7 +791,7 @@ def download_chunked_file(
         return _download_chunked_locked(
             chunks, dst, want_whole=want_whole, total_size=total_size,
             window=window, on_bytes=on_bytes, session_factory=session_factory,
-            mirror_dst=mirror_dst,
+            mirror_dst=mirror_dst, mirror_chunk_dir=mirror_chunk_dir,
         )
 
 
@@ -786,6 +1019,7 @@ def _download_chunked_locked(
     on_bytes: Optional[Callable[[int], None]],
     session_factory: Callable[[], requests.Session],
     mirror_dst: Optional[Path] = None,
+    mirror_chunk_dir: Optional[Path] = None,
 ) -> bool:
     """The reassembly itself, run while holding the cross-process CAS fetch lock
     (``download_chunked_file`` does the shape checks and the dedup)."""
@@ -820,6 +1054,18 @@ def _download_chunked_locked(
             # would publish a file with holes.
             _seed_mirror(fd, mirror, chunks, offsets, already)
 
+        # pgw#972: whatever THIS pod's local journal could not supply, a
+        # PREVIOUS pod may have left verified on the volume. Local disk wins
+        # (no volume read is owed for a chunk we already hold); everything else
+        # is adopted here, re-hashed, and never fetched again.
+        vol_chunks = _open_volume_chunks(mirror_chunk_dir)
+        if vol_chunks is not None:
+            already = already | vol_chunks.adopt(
+                chunks, offsets,
+                [i for i in range(len(chunks)) if i not in already],
+                fd, mirror, max_inflight,
+            )
+
         prefix = _Prefix(len(chunks))
         for i in sorted(already):
             prefix.mark(i)
@@ -844,7 +1090,7 @@ def _download_chunked_locked(
                 chunks, offsets, prefix, jfd, fd, dst,
                 already=already, max_inflight=max_inflight,
                 on_bytes=on_bytes, session_factory=session_factory,
-                mirror=mirror,
+                mirror=mirror, vol_chunks=vol_chunks,
             )
         except BaseException:
             prefix.abort()
@@ -864,6 +1110,12 @@ def _download_chunked_locked(
             _log.info("blob_fill_publish source=r2 destination=volume mode=tee "
                       "digest=%s bytes=%d published=%s",
                       want_whole[:16], total_size, published)
+        # pgw#972 cleanup: the volume now holds the COMPLETE blob under its
+        # digest name, so this file's chunk objects are garbage. `exists()`
+        # rather than `published` — a concurrent pod may have published it
+        # first, and the chunks are just as dead either way.
+        if vol_chunks is not None and mirror_dst is not None and mirror_dst.exists():
+            vol_chunks.drop()
         return published
     finally:
         if mirror is not None:
@@ -886,6 +1138,7 @@ def _fetch_pending(
     on_bytes: Optional[Callable[[int], None]],
     session_factory: Callable[[], requests.Session],
     mirror: Optional["_Mirror"] = None,
+    vol_chunks: Optional["_VolumeChunks"] = None,
 ) -> None:
     pending = [i for i in range(len(chunks)) if i not in already]
     if not pending:
@@ -918,6 +1171,11 @@ def _fetch_pending(
         # needs no lock of its own.
         os.write(jfd, f"{i}\n".encode())
         prefix.mark(i)
+        # pgw#972: the chunk has proved its own digest, so it is publishable
+        # on its own — AFTER the mark, which keeps the whole-file hasher
+        # moving while this worker pays the volume write.
+        if vol_chunks is not None:
+            vol_chunks.publish(i, chunks[i], fd, offsets[i])
 
     try:
         with ThreadPoolExecutor(max_workers=max_inflight) as pool:

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -18,10 +18,12 @@ from .chunk_cas import (
     CAS_CHUNK_SIZE_BYTES,
     ChunkSpec,
     download_chunked_file,
+    drop_volume_chunks,
     hash_file,
     hasher_for,
     parse_cas_ref,
     verify_file_digest,
+    volume_chunk_dir,
 )
 from .cozy_cas import _download_one_file as _download_one_file
 from .cozy_cas import _norm_rel_path, fsync_dir, fsync_file
@@ -447,6 +449,10 @@ class CozySnapshotDownloader:
         blobs_root.mkdir(parents=True, exist_ok=True)
         snaps_root.mkdir(parents=True, exist_ok=True)
         fill_blobs_root = fill_source_dir / "blobs" if fill_source_dir is not None else None
+        # pgw#972: the volume's chunk-object tree, a SIBLING of `blobs/` — an
+        # incomplete file's verified chunks, so a replacement pod resumes it
+        # instead of refetching it whole.
+        fill_chunks_root = fill_source_dir / "chunks" if fill_source_dir is not None else None
 
         if resolved is None:
             # Workers don't resolve via HTTP — the orchestrator pre-resolves
@@ -522,6 +528,7 @@ class CozySnapshotDownloader:
                 res.files,
                 progress=progress,
                 fill_blobs_root=fill_blobs_root,
+                fill_chunks_root=fill_chunks_root,
                 publishes=publishes,
             )
             # Materialization copies/concatenates multi-GB trees — strictly
@@ -602,6 +609,7 @@ class CozySnapshotDownloader:
         *,
         progress: Optional[ProgressFn] = None,
         fill_blobs_root: Optional[Path] = None,
+        fill_chunks_root: Optional[Path] = None,
         publishes: Optional[List["asyncio.Task"]] = None,
     ) -> None:
         # pgw#971: background volume write-throughs land here; the caller joins
@@ -695,6 +703,18 @@ class CozySnapshotDownloader:
         sem = asyncio.Semaphore(max_conc)
         blobs_root_id = str(blobs_root.resolve())
 
+        def _drop_chunks(digest: str) -> None:
+            """pgw#972 cleanup, and the whole of it: the volume holds the
+            COMPLETE blob under its digest name, so that file's chunk objects
+            are garbage. Every site that ESTABLISHES that fact calls this — the
+            copy publisher below, the pod that finds it already published, and
+            the tee publisher inside `download_chunked_file` — so the only
+            chunk sets that survive belong to files no pod has ever completed
+            here, and the first pod that completes one collects it. No sweep,
+            no owner registry, no age clock."""
+            if fill_chunks_root is not None:
+                drop_volume_chunks(volume_chunk_dir(fill_chunks_root, digest))
+
         async def _blob_trusted(dst: Path, f: WorkerResolvedRepoFile, digest: str) -> bool:
             """Reusable AND digest-trusted (gw#598): size gate as before, plus
             a full content-hash check once per (root, digest) per process —
@@ -741,6 +761,9 @@ class CozySnapshotDownloader:
                     digest[:16], int(f.size_bytes or 0),
                     int((time.monotonic() - started) * 1000),
                 )
+                # Another pod completed this file; any chunk objects a third
+                # left behind for it are now dead.
+                await asyncio.to_thread(_drop_chunks, digest)
                 return True
             _log.info("blob_cache_miss source=volume digest=%s", digest[:16])
             return False
@@ -774,6 +797,8 @@ class CozySnapshotDownloader:
                 "digest=%s bytes=%d published=%s",
                 digest[:16], int(f.size_bytes or 0), published,
             )
+            if published:
+                await asyncio.to_thread(_drop_chunks, digest)
 
         async def _dl(f: WorkerResolvedRepoFile) -> None:
             digest = f.cas_ref()
@@ -826,6 +851,14 @@ class CozySnapshotDownloader:
                         mirror_dst=(
                             _blob_path(fill_blobs_root, digest)
                             if fill_blobs_root is not None else None
+                        ),
+                        # pgw#972: verified chunks land here as they arrive and
+                        # are adopted from here by the next pod, so a pod that
+                        # dies 90% in costs its successor 10% of the bytes, not
+                        # 100%.
+                        mirror_chunk_dir=(
+                            volume_chunk_dir(fill_chunks_root, digest)
+                            if fill_chunks_root is not None else None
                         ),
                     )
                 else:

--- a/tests/test_chunk_resume_pgw972.py
+++ b/tests/test_chunk_resume_pgw972.py
@@ -1,0 +1,552 @@
+"""pgw#972: chunk-granular resume that crosses PODS.
+
+Paul's ruling: the endpoint volume never holds unverified bytes — it holds
+individually-VERIFIED chunks of an incomplete file. A successor pod inventories
+them, RE-HASHES every one it adopts, and fetches only what is missing, in any
+order.
+
+Everything here runs through the real `download_chunked_file` /
+`ensure_snapshot_async` against a real threaded HTTP server on localhost: real
+sockets, real bodies, real threads, real files on two real directory trees
+standing in for local CAS and the volume. Every property under test is a
+property of concurrency and IO, so a mock would assert nothing.
+
+The evidence is always a COUNT — which chunks the server was asked for, which
+objects exist, which bytes they hold. Never a clock (pgw#795).
+
+Run: pytest tests/test_chunk_resume_pgw972.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import http.server
+import socketserver
+import threading
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import pytest
+
+import gen_worker.models.chunk_cas as cc
+from gen_worker.models.chunk_cas import (
+    ChunkSpec,
+    download_chunked_file,
+    drop_volume_chunks,
+    volume_chunk_dir,
+)
+from gen_worker.models.cozy_snapshot import ensure_snapshot_async
+from gen_worker.models.hub_client import (
+    WorkerResolvedChunk,
+    WorkerResolvedRepo,
+    WorkerResolvedRepoFile,
+)
+from gen_worker.models.refs import TensorhubRef
+
+CS = 8192  # chunk size: the ARITHMETIC is under test, not the volume
+
+
+def _sha(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def _body(total: int, seed: int = 11) -> bytes:
+    out = bytearray(total)
+    x = (seed * 2654435761 + 1) & 0xFFFFFFFF
+    for i in range(total):
+        x = (x * 1664525 + 1013904223) & 0xFFFFFFFF
+        out[i] = (x >> 24) & 0xFF
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# A real HTTP server serving chunk objects by digest, one URL per chunk —
+# which is the production shape: the hub presigns every chunk separately and a
+# chunked file has NO whole-file object to range over.
+# ---------------------------------------------------------------------------
+
+class _Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+    block_on_close = False
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):  # noqa: D102
+        pass
+
+    def do_GET(self):  # noqa: N802
+        srv = self.server
+        key = self.path.rsplit("/", 1)[-1]
+        with srv.lock:
+            srv.hits[key] = srv.hits.get(key, 0) + 1
+            blob = srv.blobs.get(key)
+            dead = key in srv.dead
+        if blob is None:
+            self.send_error(404)
+            return
+        if dead:
+            self.close_connection = True
+            try:
+                self.connection.close()
+            except OSError:
+                pass
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(blob)))
+        self.end_headers()
+        self.wfile.write(blob)
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch):
+    """Shrink the RETRY SCHEDULE, not the policy. The tests that kill a source
+    walk the full `_CHUNK_MAX_ATTEMPTS` ladder by design (pgw#972's give-up is a
+    COUNT), and at the production cap that is ~45-90s of real sleeping per dead
+    chunk. Nothing here asserts on a duration — the schedule is shrunk so the
+    COUNTS the tests do assert on are reachable in a suite."""
+    monkeypatch.setattr(cc, "_CHUNK_BACKOFF_CAP_S", 0.02)
+
+
+@pytest.fixture()
+def server():
+    srv = _Server(("127.0.0.1", 0), _Handler)
+    srv.blobs: Dict[str, bytes] = {}
+    srv.hits: Dict[str, int] = {}
+    srv.dead: set[str] = set()
+    srv.lock = threading.Lock()
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _publish(srv, payload: bytes) -> List[ChunkSpec]:
+    specs: List[ChunkSpec] = []
+    base = f"http://127.0.0.1:{srv.server_address[1]}/chunk"
+    for off in range(0, len(payload), CS):
+        part = payload[off:off + CS]
+        d = _sha(part)
+        with srv.lock:
+            srv.blobs[d] = part
+        specs.append(ChunkSpec(sha256=d, url=f"{base}/{d}", length=len(part)))
+    return specs
+
+
+def _fetched(srv, specs: Iterable[ChunkSpec]) -> Dict[str, int]:
+    with srv.lock:
+        return {s.sha256: srv.hits.get(s.sha256, 0) for s in specs}
+
+
+def _bytes_fetched(srv, specs: List[ChunkSpec]) -> int:
+    """How many BYTES the source was asked for. The measured quantity resume
+    exists to reduce, and it is a count of served bodies, not a duration."""
+    hits = _fetched(srv, specs)
+    return sum(hits[s.sha256] * s.length for s in specs)
+
+
+def _seed_volume_chunks(
+    chunks_root: Path, whole_digest: str, specs: List[ChunkSpec],
+    payload: bytes, indices: Iterable[int],
+) -> Path:
+    """Stand in for a previous pod that verified and published these chunks."""
+    d = volume_chunk_dir(chunks_root, whole_digest)
+    d.mkdir(parents=True, exist_ok=True)
+    for i in indices:
+        (d / f"{i:08d}-{specs[i].sha256}").write_bytes(payload[i * CS:(i + 1) * CS])
+    return d
+
+
+# ---------------------------------------------------------------------------
+# (a) A successor pod adopts what the volume holds and fetches only the rest
+# ---------------------------------------------------------------------------
+
+def test_a_successor_pod_fetches_only_the_chunks_the_volume_lacks(
+    tmp_path: Path, server,
+) -> None:
+    """The whole point of the issue, driven end to end through TWO real
+    downloads: pod 1 dies part-way, pod 2 starts with an EMPTY local CAS and
+    the volume pod 1 left behind, and pays only for the missing chunks.
+
+    "A pod that dies 90% into a 35 GB component leaves its successor to refetch
+    all 35 GB from R2" — this is that sentence, falsified.
+    """
+    payload = _body(CS * 8)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+    chunk_dir = volume_chunk_dir(volume / "chunks", whole)
+
+    # --- pod 1: the LAST chunk's source is dead, so the file never assembles.
+    with server.lock:
+        server.dead.add(specs[7].sha256)
+    with pytest.raises(Exception):
+        download_chunked_file(
+            specs, tmp_path / "pod1" / "blob", whole_digest=whole,
+            total_size=len(payload), chunk_size_bytes=CS, window=2,
+            mirror_dst=volume / "blobs" / "blob",
+            mirror_chunk_dir=chunk_dir,
+        )
+    # It published every chunk it VERIFIED, and nothing it did not.
+    left = sorted(p.name for p in chunk_dir.iterdir())
+    assert left == [f"{i:08d}-{specs[i].sha256}" for i in range(7)], left
+    # And no whole-file blob — the local file never proved its digest.
+    assert not (volume / "blobs" / "blob").exists()
+    after_pod1 = _fetched(server, specs)
+
+    # --- pod 2: a REPLACEMENT pod. Empty local CAS, same volume, live source.
+    with server.lock:
+        server.dead.clear()
+    local2 = tmp_path / "pod2" / "blob"
+    published = download_chunked_file(
+        specs, local2, whole_digest=whole,
+        total_size=len(payload), chunk_size_bytes=CS, window=2,
+        mirror_dst=volume / "blobs" / "blob",
+        mirror_chunk_dir=chunk_dir,
+    )
+
+    assert local2.read_bytes() == payload
+    assert published is True
+    after_pod2 = _fetched(server, specs)
+    # The seven adopted chunks were NOT asked for again; only the missing one.
+    for i in range(7):
+        assert after_pod2[specs[i].sha256] == after_pod1[specs[i].sha256], i
+    assert after_pod2[specs[7].sha256] == after_pod1[specs[7].sha256] + 1
+
+
+def test_the_adopted_set_may_be_any_subset_in_any_order(
+    tmp_path: Path, server,
+) -> None:
+    """"This can happen out of order too; the chunks of a repo-CAS file do not
+    need to be downloaded in some logical order." A non-contiguous adoption is
+    the normal case, not a degenerate one — the verified prefix the whole-file
+    hasher follows is rebuilt from whatever landed."""
+    payload = _body(CS * 6, seed=4)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+    _seed_volume_chunks(volume / "chunks", whole, specs, payload, [0, 2, 5])
+
+    local = tmp_path / "local" / "blob"
+    download_chunked_file(
+        specs, local, whole_digest=whole,
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_chunk_dir=volume_chunk_dir(volume / "chunks", whole),
+    )
+
+    assert local.read_bytes() == payload
+    hits = _fetched(server, specs)
+    assert [hits[s.sha256] for s in specs] == [0, 1, 0, 1, 1, 0]
+
+
+def test_without_a_volume_the_successor_refetches_everything(
+    tmp_path: Path, server,
+) -> None:
+    """The CONTROL arm, and the measurement: the same interrupted-then-resumed
+    sequence with no volume attached pays for every byte a second time. This is
+    what the numbers in the test above are relative to."""
+    payload = _body(CS * 8)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+
+    with server.lock:
+        server.dead.add(specs[7].sha256)
+    with pytest.raises(Exception):
+        download_chunked_file(
+            specs, tmp_path / "pod1" / "blob", whole_digest=whole,
+            total_size=len(payload), chunk_size_bytes=CS, window=2,
+        )
+    with server.lock:
+        server.dead.clear()
+    before = _bytes_fetched(server, specs)
+
+    local2 = tmp_path / "pod2" / "blob"
+    download_chunked_file(
+        specs, local2, whole_digest=whole,
+        total_size=len(payload), chunk_size_bytes=CS, window=2,
+    )
+    assert local2.read_bytes() == payload
+    # Eight chunks fetched again, where the volume-backed successor fetched one.
+    assert _bytes_fetched(server, specs) - before == len(payload)
+
+
+# ---------------------------------------------------------------------------
+# (b) An adopted chunk is RE-HASHED, so a corrupt one is caught and refetched
+# ---------------------------------------------------------------------------
+
+def test_a_corrupted_volume_chunk_is_rejected_on_adopt_and_refetched(
+    tmp_path: Path, server, caplog,
+) -> None:
+    """The name on the volume is a CLAIM, not a proof. Adoption re-hashes every
+    range it takes, so a corrupt object costs a wasted hash pass and can never
+    inject bytes — and it is unlinked, so the next pod does not pay again."""
+    caplog.set_level("WARNING", logger="gen_worker.models.chunk_cas")
+    payload = _body(CS * 5, seed=7)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+    chunk_dir = _seed_volume_chunks(
+        volume / "chunks", whole, specs, payload, [0, 1, 2, 3, 4]
+    )
+    # Rot one object in place: right name, right LENGTH, wrong bytes. A
+    # size-only check would wave it straight into the file.
+    victim = chunk_dir / f"{2:08d}-{specs[2].sha256}"
+    victim.write_bytes(_body(CS, seed=999))
+
+    local = tmp_path / "local" / "blob"
+    # No `mirror_dst`, so no whole-file blob is published and the cleanup rule
+    # does not fire — this test is about the chunk objects themselves.
+    download_chunked_file(
+        specs, local, whole_digest=whole,
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_chunk_dir=chunk_dir,
+    )
+
+    # The file is right, and exactly one chunk was bought.
+    assert local.read_bytes() == payload
+    hits = _fetched(server, specs)
+    assert [hits[s.sha256] for s in specs] == [0, 0, 1, 0, 0]
+    assert "volume_chunk_corrupt" in caplog.text
+    # The refetch republished it, so the volume now holds honest bytes.
+    assert victim.read_bytes() == payload[CS * 2:CS * 3]
+
+
+def test_a_truncated_volume_chunk_is_rejected_too(tmp_path: Path, server) -> None:
+    """A short object is the ENOSPC shape, and it must not be adopted as a
+    partial range — the manifest's length is checked by the hash covering it."""
+    payload = _body(CS * 3, seed=8)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    chunk_dir = _seed_volume_chunks(
+        tmp_path / "volume" / "chunks", whole, specs, payload, [0, 1, 2]
+    )
+    (chunk_dir / f"{1:08d}-{specs[1].sha256}").write_bytes(payload[CS:CS + 64])
+
+    local = tmp_path / "local" / "blob"
+    download_chunked_file(
+        specs, local, whole_digest=whole, total_size=len(payload),
+        chunk_size_bytes=CS, window=2, mirror_chunk_dir=chunk_dir,
+    )
+    assert local.read_bytes() == payload
+    hits = _fetched(server, specs)
+    assert [hits[s.sha256] for s in specs] == [0, 1, 0]
+
+
+# ---------------------------------------------------------------------------
+# (c) Duplicate concurrent writes of one chunk are harmless
+# ---------------------------------------------------------------------------
+
+def test_two_pods_writing_the_same_chunks_at_once_are_harmless(
+    tmp_path: Path, server,
+) -> None:
+    """The name is content-addressed, so two pods that reach it wrote the SAME
+    bytes and a duplicate write is a no-op. That — plus writer-unique staging
+    and an atomic rename — is what dissolves the two-writers objection to
+    putting resume state on shared storage.
+
+    Two REAL concurrent downloads of one file into two local CAS roots (as two
+    pods of one endpoint have) sharing one volume chunk directory.
+    """
+    payload = _body(CS * 6, seed=13)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    chunk_dir = volume_chunk_dir(tmp_path / "volume" / "chunks", whole)
+
+    errors: List[BaseException] = []
+    start = threading.Barrier(2)
+
+    def _pod(name: str) -> None:
+        try:
+            start.wait(timeout=30)
+            download_chunked_file(
+                specs, tmp_path / name / "blob", whole_digest=whole,
+                total_size=len(payload), chunk_size_bytes=CS, window=6,
+                mirror_chunk_dir=chunk_dir,
+            )
+        except BaseException as exc:  # noqa: BLE001 - reported below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_pod, args=(n,)) for n in ("podA", "podB")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=120)
+
+    assert not errors, errors
+    assert (tmp_path / "podA" / "blob").read_bytes() == payload
+    assert (tmp_path / "podB" / "blob").read_bytes() == payload
+    # One object per chunk, each holding its own bytes — no doubling, no
+    # interleaving, and no staging litter from the loser of any race.
+    names = sorted(p.name for p in chunk_dir.iterdir())
+    assert names == [f"{i:08d}-{specs[i].sha256}" for i in range(6)], names
+    for i in range(6):
+        obj = chunk_dir / f"{i:08d}-{specs[i].sha256}"
+        assert _sha(obj.read_bytes()) == specs[i].sha256
+
+
+# ---------------------------------------------------------------------------
+# (d) Completed-file cleanup, and its concurrency story
+# ---------------------------------------------------------------------------
+
+def test_publishing_the_whole_blob_drops_the_chunk_garbage(
+    tmp_path: Path, server,
+) -> None:
+    """Once the volume holds the COMPLETE blob under its digest name, that
+    file's chunk objects are garbage and the publisher removes them. Steady
+    state on the volume is therefore exactly what it was before pgw#972 — only
+    files still in flight carry chunk objects."""
+    payload = _body(CS * 4, seed=21)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+    chunk_dir = volume_chunk_dir(volume / "chunks", whole)
+
+    published = download_chunked_file(
+        specs, tmp_path / "local" / "blob", whole_digest=whole,
+        total_size=len(payload), chunk_size_bytes=CS, window=4,
+        mirror_dst=volume / "blobs" / "blob", mirror_chunk_dir=chunk_dir,
+    )
+
+    assert published is True
+    assert (volume / "blobs" / "blob").read_bytes() == payload
+    assert not chunk_dir.exists()
+
+
+def test_an_adopter_already_reading_an_object_is_not_racing_the_drop(
+    tmp_path: Path, server,
+) -> None:
+    """`unlink` is a NAMESPACE operation: a reader that already opened an
+    object keeps its inode to the end. So a drop concurrent with an adoption
+    cannot truncate what that adopter is reading — the worst case anywhere in
+    this design is a wasted refetch, never wrong bytes."""
+    payload = _body(CS * 3, seed=31)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    chunk_dir = _seed_volume_chunks(
+        tmp_path / "volume" / "chunks", whole, specs, payload, [0, 1, 2]
+    )
+
+    with open(chunk_dir / f"{1:08d}-{specs[1].sha256}", "rb") as held:
+        first = held.read(16)
+        assert drop_volume_chunks(chunk_dir) == 3
+        assert not chunk_dir.exists()
+        # The open handle still sees the whole, correct object.
+        assert first + held.read() == payload[CS:CS * 2]
+
+    # An adopter that arrives AFTER the drop simply misses and refetches.
+    local = tmp_path / "local" / "blob"
+    download_chunked_file(
+        specs, local, whole_digest=whole, total_size=len(payload),
+        chunk_size_bytes=CS, window=2, mirror_chunk_dir=chunk_dir,
+    )
+    assert local.read_bytes() == payload
+    assert [_fetched(server, specs)[s.sha256] for s in specs] == [1, 1, 1]
+
+
+def test_the_drop_leaves_an_inflight_writers_staged_object_alone(
+    tmp_path: Path,
+) -> None:
+    """Staged chunks are dot-prefixed and writer-unique; they belong to a live
+    writer, so the drop skips them and the `rmdir` fails harmlessly. The next
+    pod to complete this file collects the directory."""
+    d = tmp_path / "volume" / "chunks" / "sha256" / "aa" / "bb" / ("aa" * 32)
+    d.mkdir(parents=True)
+    (d / ("00000000-" + "c" * 64)).write_bytes(b"done")
+    staged = d / ".00000001-x.part-999-deadbeef"
+    staged.write_bytes(b"in flight")
+
+    assert drop_volume_chunks(d) == 1
+    assert d.exists() and staged.read_bytes() == b"in flight"
+    assert drop_volume_chunks(d) == 0  # nothing left to collect but the stage
+
+
+def test_dropping_a_directory_that_was_never_created_is_a_no_op(
+    tmp_path: Path,
+) -> None:
+    """Cleanup runs on every path that establishes a complete volume blob,
+    including the overwhelmingly common one where no pod ever died."""
+    assert drop_volume_chunks(tmp_path / "nope") == 0
+
+
+# ---------------------------------------------------------------------------
+# The third cleanup site, through the real snapshot path
+# ---------------------------------------------------------------------------
+
+def _resolved(payload: bytes, specs: List[ChunkSpec]) -> WorkerResolvedRepo:
+    return WorkerResolvedRepo(
+        snapshot_digest="sha256:" + ("c7" * 32),
+        files=[
+            WorkerResolvedRepoFile(
+                path="model.safetensors",
+                size_bytes=len(payload),
+                url=None,
+                digest="sha256:" + _sha(payload),
+                chunk_size_bytes=CS,
+                chunks=tuple(
+                    WorkerResolvedChunk(sha256=s.sha256, url=s.url, length=s.length)
+                    for s in specs
+                ),
+            ),
+        ],
+    )
+
+
+def test_a_volume_blob_hit_collects_a_dead_pods_chunk_garbage(
+    tmp_path: Path, server,
+) -> None:
+    """The third owner of the cleanup rule: a pod that finds the whole blob
+    ALREADY on the volume knows the chunk objects are dead, even though it
+    published neither. Driven through `ensure_snapshot_async` so the fill-source
+    wiring is the production one."""
+    payload = _body(CS * 5, seed=41)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+    chunk_dir = _seed_volume_chunks(
+        volume / "chunks", whole, specs, payload, [0, 1, 2]
+    )
+    # A previous pod completed the file and published the blob, but died before
+    # collecting its chunks (or a third pod's chunks outlived it).
+    blob = volume / "blobs" / "sha256" / whole[7:9] / whole[9:11] / whole[7:]
+    blob.parent.mkdir(parents=True, exist_ok=True)
+    blob.write_bytes(payload)
+
+    snap = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path / "local",
+        ref=TensorhubRef(owner="org", repo="model"),
+        resolved=_resolved(payload, specs),
+        fill_source_dir=volume,
+    ))
+
+    assert (snap / "model.safetensors").read_bytes() == payload
+    # Filled from the volume — not one chunk was bought from the source.
+    assert all(v == 0 for v in _fetched(server, specs).values())
+    assert not chunk_dir.exists()
+
+
+def test_a_cold_snapshot_fetch_leaves_no_chunk_garbage_on_the_volume(
+    tmp_path: Path, server,
+) -> None:
+    """End to end on the ordinary path: a cold chunked fetch warms the volume
+    with the whole blob and leaves the chunk tree empty behind it."""
+    payload = _body(CS * 5, seed=43)
+    whole = "sha256:" + _sha(payload)
+    specs = _publish(server, payload)
+    volume = tmp_path / "volume"
+
+    snap = asyncio.run(ensure_snapshot_async(
+        base_dir=tmp_path / "local",
+        ref=TensorhubRef(owner="org", repo="model"),
+        resolved=_resolved(payload, specs),
+        fill_source_dir=volume,
+    ))
+
+    assert (snap / "model.safetensors").read_bytes() == payload
+    blobs = sorted(p.name for p in (volume / "blobs").rglob("*") if p.is_file())
+    assert blobs == [whole[7:]]
+    assert not volume_chunk_dir(volume / "chunks", whole).exists()


### PR DESCRIPTION
Builds pgw#972's open half, per Paul's ruling of 2026-08-07 (recorded verbatim in the tracker, which retracts the old "partials must stay pod-local" attribution as folklore).

## The defect

The chunk journal (`.chunkpart` / `.chunkdone`) lives in the pod-local CAS, so resume worked **within a boot only**. A pod that died 90% into a 35 GB component left its successor to refetch all 35 GB from R2.

## The shape

**Chunk-granular, not partial-file.** The volume never holds unverified bytes under a name anyone reads; it holds individually-VERIFIED chunks of an incomplete file.

* Each chunk is copied to `chunks/<algo>/aa/bb/<filehex>/<index>-<chunkdigest>` — a sibling of `blobs/` — the moment its own sha256 verifies.
* A successor pod builds those names **straight from the manifest** (no inventory, no mapping file), **re-hashes every chunk it adopts**, and fetches only the missing ones, in any order.
* Local journal wins over the volume, so a chunk already on local disk owes no volume read.

**The name is the concurrency story.** It carries all three coordinates a chunk has — file, position, content. The digest makes a write idempotent (two pods reaching that name wrote the same bytes; a duplicate is a no-op over an atomic rename), the index makes adoption a direct lookup, and a file re-chunked at a different size addresses different names and cannot be adopted by accident.

**Cleanup: one rule, no clock.** *Whoever establishes that the volume holds the COMPLETE blob under its digest name drops that file's chunk objects* — the tee publisher, the copy publisher (`_fill_to_volume`), and a pod that finds the blob already published (`_fill_from_volume`). The only sets that survive belong to files no pod has ever completed there, and the first pod that completes one collects them. No age sweep, no owner registry, nothing for `stall.py` to argue with. `unlink` is a namespace operation, so a drop concurrent with an adoption cannot truncate what that adopter is already reading; in-flight writers' dot-prefixed staged objects are skipped.

## Invariants preserved

* Whole-file publish still happens only after the LOCAL file passes its full-digest verification.
* `GEN_WORKER_HOST_MOVE_GUARD` untouched.
* PR #495's backoff policy untouched — `_fetch_chunk_to_offset` and `_Mirror` have **no diff**.
* Parallel chunk fetch and the prefix-following hasher are th#1362's, already shipped; adoption feeds the same `_Prefix`, so a non-contiguous adopted set is the normal case.

## Library survey (Paul's constraint 1) — ran BEFORE implementation

Recorded in the tracker with evidence. **No transfer library fits**, and the reason is structural: each chunk is its own R2 object under its own presigned URL (`internal/domain/catalog/service.go` sets `f.URL = ""` for a chunked entry and presigns per chunk ref), while every candidate is built for *one object, many byte ranges, credential auth*. Probed, not recalled:

| candidate | finding |
|---|---|
| boto3 / `s3transfer` | `download_file(Bucket, Key, Filename, …)` — no URL parameter at all; cannot consume a presigned URL. Its own ranged split is blind to our per-chunk digests, i.e. it deletes the property this PR is built on. |
| `obstore` 0.11 | Works only as one `HTTPStore` per presigned URL (probed: PASS over TLS). Sharing one store is impossible — it percent-encodes a signed `?` into `%3F` (probed: the server saw `deadbeef%3FX-Amz-Signature=…`). Default `max_retries: 10, retry_timeout: 180s` would put a WALL CLOCK under our loop. |
| `hf_transfer` | One URL, parallel ranged GETs of it, its own exponentially-backed-off retry. No per-range digest verification. |
| `urllib3.Retry` | Cannot see a `DigestMismatch` or a `ProgressFloor`, cannot restart a body already streaming; would only cover connect and would multiply with ours. Live default today is `Retry(total=0, …)` — one retry layer, which is the property to keep. |

Net: **this PR adds no transport code.** The byte-moving machinery is `requests`/`urllib3`, `hashlib`, `concurrent.futures`, `os.pwrite`/`os.replace`. What is ours is the domain logic Paul carved out — chunk-digest verification, journal, CAS naming, volume adoption.

## Tests — `tests/test_chunk_resume_pgw972.py`, 12 integration-grade

Real threaded HTTP server, real sockets, real bodies, real threads, two real directory trees standing in for local CAS and the volume. Every assertion is a COUNT — which chunks the source was asked for, which objects exist, which bytes they hold. **No wall-clock assertions** (pgw#795); the shared `_fast_backoff` fixture shrinks the retry *schedule* so the counts are reachable in a suite, and asserts nothing about duration.

* `test_a_successor_pod_fetches_only_the_chunks_the_volume_lacks` — two real downloads: pod 1 dies on chunk 7, pod 2 starts with an EMPTY local CAS and pays for **1 chunk of 8**.
* `test_the_adopted_set_may_be_any_subset_in_any_order` — adopts `{0,2,5}`, fetches `{1,3,4}`; hits are exactly `[0,1,0,1,1,0]`.
* `test_without_a_volume_the_successor_refetches_everything` — the control arm and the measurement: the same sequence with no volume refetches `len(payload)`.
* `test_a_corrupted_volume_chunk_is_rejected_on_adopt_and_refetched` — right name, right length, wrong bytes: rejected by re-hash, refetched, republished honest.
* `test_a_truncated_volume_chunk_is_rejected_too` — the ENOSPC shape.
* `test_two_pods_writing_the_same_chunks_at_once_are_harmless` — two concurrent real downloads into two local roots sharing one chunk directory.
* `test_publishing_the_whole_blob_drops_the_chunk_garbage`, `test_an_adopter_already_reading_an_object_is_not_racing_the_drop`, `test_the_drop_leaves_an_inflight_writers_staged_object_alone`, `test_dropping_a_directory_that_was_never_created_is_a_no_op`.
* `test_a_volume_blob_hit_collects_a_dead_pods_chunk_garbage`, `test_a_cold_snapshot_fetch_leaves_no_chunk_garbage_on_the_volume` — the other two cleanup owners, through the real `ensure_snapshot_async`.

RED against `origin/master`, GREEN here. **78 passed, 1 skipped** across `test_chunk_resume_pgw972` + `test_volume_tee_pgw971` + `test_chunk_cas_parallel_th1362` + `test_chunk_cas_pgw781` + `test_magic_timeouts_gw666` (the pgw#795 gate). mypy and ruff clean; `lint_http_timeouts.py` silent; `lint_unreached_surface.py` exit 0 at the existing baseline.

## Flagged, not taken

A cold chunked fetch now writes the volume twice — chunk objects (read back from local page cache) plus the pgw#971 whole-file mirror. The 1x alternative is to make the chunk set the volume's canonical form for chunked files and teach the fill READ side to assemble from it; that changes what th#850/gw#599's fill source contains, so it is Paul's call, not a lane's. Recorded in the tracker.

**No version bump** — this rides the next release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)