### PR TITLE
pgw#1011: the H3 acceleration matrix, as a runnable plan rather than a claim

### DIFF
--- a/changelog.d/pgw1011.md
+++ b/changelog.d/pgw1011.md
@@ -1,0 +1,27 @@
+- **pgw#1011: `gen_worker.benchmarks.engine_matrix` — an acceleration matrix
+  where an arm is DATA, not a code path.** The H3 speed program has to rank a
+  dozen published techniques whose every number was measured on hardware we do
+  not own (8xB300, 8xGB200, 4xH200), so the deliverable is a re-measurement
+  harness rather than an adoption. An `Arm` is a name + a settings fragment +
+  a payload fragment; flipping a technique is choosing an arm. Deliberately
+  **not** an env-flag surface and deliberately **not** a serving knob —
+  measurement arms have no business on the request path, and envs carry
+  secrets and config values, never logic forks.
+- **The lane is pluggable because the candidates do not share a runtime.**
+  Some techniques are engine CLI flags; the ones that rank first for H3 are
+  in-process diffusers changes (the AdaLN-branch precompute, `cache-dit`, a
+  resolution-matched warmup, an attention-backend swap). A driver that assumed
+  a server subprocess could not measure the techniques that matter most, so it
+  takes a `Lane` factory and knows nothing about either.
+- **Budget and evidence are structural.** `wall_cap_s` bounds the whole run and
+  `arm_budget_s` each arm; an arm that cannot fit is recorded as
+  `out_of_budget` **before** it opens a lane. Every row is fsynced to a JSONL
+  file the moment it completes, because RunPod exposes no container-log API and
+  a row that only reached stdout is a row we do not have.
+- **`benchmarks/plans/h3_speed.json` ships in the wheel** with the ordered
+  MiniMax-H3 matrix aimed at ie#612's measured fal bar, every arm carrying its
+  published expectation *with the citation* and its `approximate` flag. The two
+  known-defective techniques ship `skip`ped with the defect named — SageAttention
+  produces pure noise on H3 (Comfy-Org #15263, video **and** audio), and the
+  Turbo-LoRA is an author-paused preview with documented audio artifacts — so a
+  pod run cannot accidentally measure either and report a number.

--- a/src/gen_worker/benchmarks/engine_matrix.py
+++ b/src/gen_worker/benchmarks/engine_matrix.py
@@ -1,0 +1,463 @@
+"""Acceleration-matrix driver: one arm per technique, one lane per arm (pgw#1011).
+
+pgw#1011 has to answer "which acceleration technique is worth adopting on OUR
+silicon" for a model whose every published number was measured on somebody
+else's, on hardware we do not have. That is a MATRIX — technique x cell — and
+the expensive part is not the measurement, it is the pod. Three facts fix the
+shape of this harness:
+
+* **An arm is DATA.** A technique is a name plus a settings fragment plus a
+  request-payload fragment. Flipping techniques is choosing an arm — never
+  editing a serving path, and deliberately never an env flag (standing rule:
+  envs carry secrets and config VALUES, never logic forks). Measurement arms
+  have no business existing on the request path at all.
+* **The lane is pluggable, because the candidates do not share a runtime.**
+  Some techniques are server CLI flags (SGLang ``--attention-backend``,
+  ``--quantization fp8``); the ones pgw#1011 actually ranks first are
+  in-process diffusers changes (the AdaLN-branch cache, ``cache-dit``, a
+  resolution-matched warmup, a sage backend swap). A driver that assumed a
+  server subprocess could not measure the techniques we care most about, so it
+  takes an :class:`Lane` factory and knows nothing about either.
+* **Evidence must survive the pod.** RunPod exposes no container-log API, so a
+  row that only ever reached stdout is a row we do not have. Every row is
+  appended to the output file the moment it completes, before the next arm
+  opens. A killed run keeps every arm it finished.
+
+**Budget is structural, not advisory.** Every cloud GPU run is watchdog +
+wall-capped by standing policy, and an unbounded matrix is how a dead job bills
+for eight hours. ``wall_cap_s`` bounds the WHOLE run; an arm that cannot fit in
+the remaining budget is skipped with a recorded reason rather than started and
+abandoned.
+
+Usage (pod-side)::
+
+    python -m gen_worker.benchmarks.engine_matrix \\
+        --plan <plan.json> --tier tier0 --out /workspace/h3-matrix.jsonl \\
+        --wall-cap-s 5400 --lane <module>:<factory>
+
+A plan file is DATA (:mod:`gen_worker.benchmarks.plans`): the GPU lane adds an
+arm by adding a row, not by touching this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import logging
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple
+
+import msgspec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Arm",
+    "Plan",
+    "Row",
+    "ArmResult",
+    "Lane",
+    "load_plan",
+    "select_arms",
+    "run_matrix",
+    "summarize",
+]
+
+
+class Arm(msgspec.Struct, frozen=True, kw_only=True):
+    """One measurable configuration.
+
+    ``settings`` and ``payload`` are the ONLY things that vary between arms;
+    anything else differing means two arms are not comparable and the speedup
+    computed from them is not a speedup.
+    """
+
+    name: str
+    #: Tier ("tier0" config-only, "tier1" single flags, "tier2" integration).
+    tier: str = ""
+    #: Opaque lane settings — server argv for a server lane, technique names
+    #: and thresholds for an in-process one. The lane factory interprets it;
+    #: this module only records it.
+    settings: Dict[str, Any] = msgspec.field(default_factory=dict)
+    #: Request-body fragment merged over the plan's base payload (step count,
+    #: resolution, duration — the CELL half of "technique x cell").
+    payload: Dict[str, Any] = msgspec.field(default_factory=dict)
+    #: The arm this one's speedup is computed against. Empty = the plan's first
+    #: arm. A speedup with no stated denominator is not a number.
+    baseline: str = ""
+    #: Published expectation WITH its citation, so a measured/expected gap is
+    #: visible in the output rather than in someone's memory.
+    expect: str = ""
+    #: APPROXIMATE arms change the output and need a quality verdict before
+    #: adoption; LOSSLESS ones do not. Every published H3 quality number is
+    #: VIDEO-ONLY, so an approximate arm that has not been through the audio
+    #: gate (cozy-eval#8) is not adoptable whatever this harness measures.
+    approximate: bool = True
+    #: Non-empty = do not run, and say why (a kernel needing an SM this pod
+    #: lacks, a technique with a known-open upstream defect).
+    skip: str = ""
+
+
+class Plan(msgspec.Struct, frozen=True, kw_only=True):
+    """A named matrix: base payload + arms."""
+
+    name: str
+    #: Applied to every arm, then overridden by the arm's own ``payload``.
+    payload: Dict[str, Any] = msgspec.field(default_factory=dict)
+    arms: Tuple[Arm, ...] = ()
+    #: Timed repetitions per arm AFTER the warmup reps. MEDIANS, not means:
+    #: ie#612 measured 2.7x warm variance on an identical payload, and a mean
+    #: over that is a number about the tail, not about the technique.
+    reps: int = 3
+    #: Discarded reps run first. A cold first call is a different measurement
+    #: (ie#612 measured 4.4x cold/warm) and mixing them hides both.
+    warmup_reps: int = 1
+    notes: str = ""
+
+
+class Row(msgspec.Struct, frozen=True, kw_only=True):
+    """One timed repetition. Written to the output stream immediately."""
+
+    arm: str
+    rep: int
+    warmup: bool
+    wall_s: float
+    ok: bool
+    error: str = ""
+    #: Whatever residency number the lane can state. For fp8 arms the
+    #: residency IS the prize (-38% memory at 1.056x speed), so an arm that
+    #: reports no VRAM has not measured its own headline.
+    vram_bytes: int = 0
+    #: Lane-supplied per-rep facts (cache hits/misses, engaged attention
+    #: backend, degraded rung). Free-form because lanes differ; recorded
+    #: verbatim because a cache that silently no-ops looks exactly like a
+    #: cache that is not helping (see the cache-dit H3 aliasing defect).
+    detail: Dict[str, Any] = msgspec.field(default_factory=dict)
+    unix_s: float = 0.0
+
+
+class ArmResult(msgspec.Struct, frozen=True, kw_only=True):
+    """Per-arm verdict rolled up from its rows."""
+
+    arm: str
+    tier: str = ""
+    ok: bool = False
+    status: str = ""              # measured | skipped | open_failed | ...
+    reps_ok: int = 0
+    median_s: float = 0.0
+    min_s: float = 0.0
+    max_s: float = 0.0
+    open_s: float = 0.0
+    peak_vram_bytes: int = 0
+    baseline: str = ""
+    speedup_vs_baseline: float = 0.0
+    expect: str = ""
+    approximate: bool = True
+    detail: str = ""
+
+
+class Lane(Protocol):
+    """One armed configuration, ready to serve. Opened per arm, closed after.
+
+    One lane per arm is not waste: a server flag like ``--quantization`` is
+    read at engine start and an in-process technique is installed at pipeline
+    build, so re-using a warm lane across arms would measure the first arm
+    forever.
+    """
+
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Drive ONE generation to completion. Return per-rep facts (may be
+        empty). Raising fails that repetition, not the run."""
+
+    def vram_bytes(self) -> int:
+        """Best residency number this lane can state; 0 when it cannot."""
+
+    def close(self) -> None:
+        """Tear down. Must be safe to call after a failed ``run``."""
+
+
+#: ``open_lane(arm, payload) -> Lane``. Raising here fails the ARM (recorded),
+#: never the run — an unbuildable technique is a result.
+LaneFactory = Callable[[Arm, Dict[str, Any]], Lane]
+
+
+# --- plan loading -----------------------------------------------------------
+
+
+def load_plan(path: str) -> Plan:
+    """Decode a plan file. Unknown fields are a hard error — a mistyped arm key
+    that silently became a no-op would produce a real-looking number for a
+    configuration nobody ran."""
+    with open(path, "rb") as f:
+        return msgspec.json.decode(f.read(), type=Plan, strict=True)
+
+
+def select_arms(
+    plan: Plan, *, tier: str = "", names: Sequence[str] = ()
+) -> Tuple[Arm, ...]:
+    """Arms matching ``tier`` and/or ``names``, in plan order.
+
+    Each picked arm's baseline is pulled in even when it matches no filter: an
+    arm set with no denominator can produce timings but not speedups.
+    """
+    wanted = set(names)
+    picked = [
+        a for a in plan.arms
+        if (not tier or a.tier == tier) and (not wanted or a.name in wanted)
+    ]
+    if not picked:
+        return ()
+    by_name = {a.name: a for a in plan.arms}
+    have = {a.name for a in picked}
+    default_base = plan.arms[0].name if plan.arms else ""
+    for arm in list(picked):
+        base = arm.baseline or default_base
+        if base and base not in have and base in by_name:
+            have.add(base)
+    return tuple(a for a in plan.arms if a.name in have)
+
+
+# --- the run ----------------------------------------------------------------
+
+
+class _Budget:
+    """Wall cap over the WHOLE run. Standing policy: no unwatched GPU run."""
+
+    def __init__(self, wall_cap_s: float) -> None:
+        self.cap_s = float(wall_cap_s)
+        self.started = time.monotonic()
+
+    @property
+    def remaining_s(self) -> float:
+        return self.cap_s - (time.monotonic() - self.started)
+
+    def affords(self, need_s: float) -> bool:
+        return self.cap_s <= 0 or self.remaining_s >= need_s
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+class _Sink:
+    """Append-as-you-go JSONL. A killed run keeps every finished row."""
+
+    def __init__(self, path: str = "") -> None:
+        self.path = path
+        self.rows: List[Row] = []
+        self.results: List[ArmResult] = []
+
+    def row(self, row: Row) -> None:
+        self.rows.append(row)
+        self._write({"type": "row", **msgspec.structs.asdict(row)})
+
+    def result(self, result: ArmResult) -> None:
+        self.results.append(result)
+        self._write({"type": "arm", **msgspec.structs.asdict(result)})
+
+    def _write(self, obj: Dict[str, Any]) -> None:
+        line = json.dumps(obj, sort_keys=True, default=str)
+        print(line, flush=True)
+        if not self.path:
+            return
+        try:
+            with open(self.path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+        except OSError:
+            logger.exception("matrix row could not be persisted to %s", self.path)
+
+
+def run_matrix(
+    plan: Plan,
+    arms: Sequence[Arm],
+    *,
+    open_lane: LaneFactory,
+    wall_cap_s: float = 0.0,
+    arm_budget_s: float = 0.0,
+    out_path: str = "",
+) -> List[ArmResult]:
+    """Open each arm's lane, time it, tear it down, record it."""
+    budget = _Budget(wall_cap_s)
+    sink = _Sink(out_path)
+    by_name: Dict[str, ArmResult] = {}
+    default_base = arms[0].name if arms else ""
+
+    for arm in arms:
+        payload = {**plan.payload, **arm.payload}
+        baseline = arm.baseline or (default_base if arm.name != default_base else "")
+        stub = dict(
+            arm=arm.name, tier=arm.tier, baseline=baseline, expect=arm.expect,
+            approximate=arm.approximate)
+        if arm.skip:
+            sink.result(ArmResult(ok=False, status="skipped", detail=arm.skip, **stub))
+            continue
+        if not budget.affords(arm_budget_s):
+            sink.result(ArmResult(
+                ok=False, status="out_of_budget",
+                detail=(f"{budget.remaining_s:.0f}s left of a {budget.cap_s:.0f}s "
+                        f"cap, arm needs {arm_budget_s:.0f}s"), **stub))
+            continue
+
+        result = _run_arm(
+            plan, arm, stub=stub, payload=payload, open_lane=open_lane,
+            budget=budget, arm_budget_s=arm_budget_s, sink=sink)
+        base = by_name.get(baseline)
+        if base is not None and base.median_s > 0 and result.median_s > 0:
+            result = msgspec.structs.replace(
+                result,
+                speedup_vs_baseline=round(base.median_s / result.median_s, 4))
+        by_name[arm.name] = result
+        sink.result(result)
+
+    return list(sink.results)
+
+
+def _run_arm(
+    plan: Plan,
+    arm: Arm,
+    *,
+    stub: Dict[str, Any],
+    payload: Dict[str, Any],
+    open_lane: LaneFactory,
+    budget: _Budget,
+    arm_budget_s: float,
+    sink: _Sink,
+) -> ArmResult:
+    logger.info("arm %s: opening lane %s", arm.name, arm.settings or "{}")
+    started = time.monotonic()
+    lane: Optional[Lane] = None
+    try:
+        lane = open_lane(arm, payload)
+    except Exception as exc:
+        return ArmResult(
+            ok=False, status="open_failed", open_s=round(time.monotonic() - started, 3),
+            detail=f"{type(exc).__name__}: {exc}", **stub)
+
+    open_s = time.monotonic() - started
+    deadline = time.monotonic() + arm_budget_s if arm_budget_s > 0 else 0.0
+    timed: List[float] = []
+    peak_vram = 0
+    note = ""
+    try:
+        for i in range(plan.warmup_reps + plan.reps):
+            warm = i < plan.warmup_reps
+            if deadline and time.monotonic() > deadline:
+                note = f"arm budget {arm_budget_s:.0f}s exhausted after {i} reps"
+                break
+            if not budget.affords(0.0):
+                note = f"run wall cap {budget.cap_s:.0f}s exhausted after {i} reps"
+                break
+            rep_started = time.monotonic()
+            ok, err, facts = True, "", {}
+            try:
+                facts = dict(lane.run(payload) or {})
+            except Exception as exc:
+                ok, err = False, f"{type(exc).__name__}: {exc}"
+            wall = time.monotonic() - rep_started
+            try:
+                vram = int(lane.vram_bytes())
+            except Exception:
+                vram = 0
+            peak_vram = max(peak_vram, vram)
+            sink.row(Row(
+                arm=arm.name, rep=i, warmup=warm, wall_s=round(wall, 4), ok=ok,
+                error=err, vram_bytes=vram, detail=facts, unix_s=time.time()))
+            if ok and not warm:
+                timed.append(wall)
+    finally:
+        try:
+            lane.close()
+        except Exception:
+            logger.exception("arm %s: lane teardown failed", arm.name)
+
+    if not timed:
+        return ArmResult(
+            ok=False, status="no_successful_reps", open_s=round(open_s, 3),
+            peak_vram_bytes=peak_vram,
+            detail=note or "every timed repetition failed", **stub)
+    return ArmResult(
+        ok=True, status="measured", reps_ok=len(timed),
+        median_s=round(_median(timed), 4), min_s=round(min(timed), 4),
+        max_s=round(max(timed), 4), open_s=round(open_s, 3),
+        peak_vram_bytes=peak_vram, detail=note, **stub)
+
+
+def summarize(results: Sequence[ArmResult]) -> str:
+    """A markdown table, because the verdict lands in a tracker issue."""
+    lines = [
+        ("| arm | tier | status | median s | speedup | peak VRAM GiB | kind | "
+         "expected (published) |"),
+        "|---|---|---|---:|---:|---:|---|---|",
+    ]
+    for r in results:
+        speed = f"{r.speedup_vs_baseline:.2f}x" if r.speedup_vs_baseline else "—"
+        vram = (f"{r.peak_vram_bytes / float(1024 ** 3):.1f}"
+                if r.peak_vram_bytes else "—")
+        median = f"{r.median_s:.2f}" if r.median_s else "—"
+        note = r.expect
+        if r.detail:
+            note = (note + " — " if note else "") + r.detail
+        lines.append(
+            f"| `{r.arm}` | {r.tier} | {r.status} | {median} | {speed} | {vram} | "
+            f"{'approx' if r.approximate else 'LOSSLESS'} | {note} |")
+    return "\n".join(lines)
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def _resolve_lane_factory(spec: str) -> LaneFactory:
+    """``package.module:attribute`` -> the callable.
+
+    The lane lives OUTSIDE this wheel on purpose: it is the thing that knows
+    about a specific model, pipeline and technique set, and baking one in would
+    make this driver a model-specific script.
+    """
+    module_name, _, attr = spec.partition(":")
+    if not module_name or not attr:
+        raise SystemExit(f"--lane must be 'module:attribute', got {spec!r}")
+    return getattr(importlib.import_module(module_name), attr)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__ or "")
+    ap.add_argument("--plan", required=True, help="plan JSON path")
+    ap.add_argument("--lane", required=True, help="module:attribute lane factory")
+    ap.add_argument("--tier", default="", help="run only this tier")
+    ap.add_argument("--arm", action="append", default=[], help="run only these arms")
+    ap.add_argument("--out", default="", help="JSONL evidence path (append)")
+    ap.add_argument("--wall-cap-s", type=float, default=0.0,
+                    help="hard cap over the WHOLE run; 0 = uncapped (never on a pod)")
+    ap.add_argument("--arm-budget-s", type=float, default=0.0,
+                    help="per-arm cap; an arm that cannot fit is skipped, not started")
+    args = ap.parse_args(list(argv) if argv is not None else None)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    plan = load_plan(args.plan)
+    arms = select_arms(plan, tier=args.tier, names=args.arm)
+    if not arms:
+        raise SystemExit(f"plan {plan.name!r}: no arms matched tier/arm filters")
+    if args.wall_cap_s <= 0:
+        logger.warning(
+            "running UNCAPPED — standing policy requires a wall cap on every "
+            "cloud GPU run; pass --wall-cap-s")
+    results = run_matrix(
+        plan, arms, open_lane=_resolve_lane_factory(args.lane),
+        wall_cap_s=args.wall_cap_s, arm_budget_s=args.arm_budget_s,
+        out_path=args.out)
+    print(summarize(results))
+    return 0 if any(r.ok for r in results) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/gen_worker/benchmarks/engine_matrix.py
+++ b/src/gen_worker/benchmarks/engine_matrix.py
@@ -295,7 +295,7 @@ def run_matrix(
     for arm in arms:
         payload = {**plan.payload, **arm.payload}
         baseline = arm.baseline or (default_base if arm.name != default_base else "")
-        stub = dict(
+        stub: Dict[str, Any] = dict(
             arm=arm.name, tier=arm.tier, baseline=baseline, expect=arm.expect,
             approximate=arm.approximate)
         if arm.skip:

--- a/src/gen_worker/benchmarks/plans/h3_speed.json
+++ b/src/gen_worker/benchmarks/plans/h3_speed.json
@@ -1,0 +1,162 @@
+{
+  "name": "h3_speed",
+  "notes": "pgw#1011 acceleration matrix for MiniMax-H3, aimed at ie#612's measured fal bar (t2va 5s <=17.1s, 10s <=40.2s, 15s <=158.1s; i2va 5s <=20.8s; ref2va 10s <=104.0s). ORDER IS THE POINT: exact techniques first, then the cheap approximate ones, and every approximate arm is UNADOPTABLE until cozy-eval#8 returns an AUDIO verdict -- every published H3 quality number in the world is video-only, and a DBCache sweep drove audio SNR 20.67 -> 13.72 dB while SSIM still read 0.85. Speedups here are measured against arm 'base_50' on OUR card, never against a vendor's 8xB300 table. Cells are separate arms because fal's own curve is superlinear and the 5s cell is the hard one.",
+  "reps": 3,
+  "warmup_reps": 1,
+  "payload": {
+    "width": 1344,
+    "height": 768,
+    "duration_s": 5,
+    "fps": 24,
+    "steps": 50,
+    "seed": 20260807,
+    "mode": "t2va",
+    "prompt": "a fixed benchmark prompt; identical across every arm or the arms are not comparable"
+  },
+  "arms": [
+    {
+      "name": "base_50",
+      "tier": "tier0",
+      "approximate": false,
+      "expect": "THE DENOMINATOR. Reproduce a full-attention BF16 50-step baseline on our own card before any other number exists. Vendor baselines (SGLang 19.04s on 8xB300, 74.38s on 4xH200) are NOT our denominator: SGLang is a monolithic native reimplementation, its 4xH100 table's workload is unstated, and its headline numbers ride FA4+FP8 on Blackwell.",
+      "settings": {"techniques": []}
+    },
+    {
+      "name": "warmup_matched",
+      "tier": "tier0",
+      "approximate": false,
+      "expect": "~1.13x claimed (SGLang --warmup-resolutions), ~11.6% e2e independently. FREE and LOSSLESS. Our warm plan is already DERIVED from CompileAxis warm representatives (pgw#654 warmup.py), so this arm mostly asks whether our existing derivation already picks the served resolution -- if it does, the 1.13x is already banked and this arm reads 1.00x.",
+      "settings": {"techniques": ["warmup_at_served_resolution"]}
+    },
+    {
+      "name": "adaln_cache",
+      "tier": "tier0",
+      "approximate": false,
+      "expect": "OUTPUT-EXACT and model-sanctioned. te#171 proved from safetensors headers that adaln_proj is 26.02 GB / 13.01B params (39.3% of the DiT) with input dim 2688 == time_embed_dim exactly, i.e. timestep-only, so a fixed schedule collapses it to a 77-484 MB table. DiT 66.28 -> 40.20 GB. NVlabs reports the same change bit-identical, freeing 23.9 GB. This is the FIRST move: it is exact, it needs no quality gate, and it is the only lever that also changes the GPU-count answer. Blocked on te#171 Phase B.",
+      "settings": {"techniques": ["adaln_precompute"]}
+    },
+    {
+      "name": "steps_30",
+      "tier": "tier0",
+      "expect": "Step count is the single highest-value experiment. 50 is the DEFAULT, not a quality requirement (ComfyUI's own H3 template ships 20). Linear in steps, so 30 ~= 1.67x. Quality-gated, video AND audio.",
+      "payload": {"steps": 30}
+    },
+    {
+      "name": "steps_20",
+      "tier": "tier0",
+      "expect": "~2.5x if it holds. If 20 steps survives the quality bar, 2.5x is banked before a kernel is touched -- and it decides the SHAPE of the whole program, because caching's gain is a 50-step artifact that dies at low step counts.",
+      "payload": {"steps": 20}
+    },
+    {
+      "name": "steps_15",
+      "tier": "tier0",
+      "expect": "~3.3x. Expect quality to break somewhere between 20 and 10 on the base model; this arm and steps_10 find the cliff rather than assuming it.",
+      "payload": {"steps": 15}
+    },
+    {
+      "name": "steps_10",
+      "tier": "tier0",
+      "expect": "~5x. Almost certainly past the base model's cliff -- run it anyway, because where it breaks is the number that prices the Turbo-LoRA bet.",
+      "payload": {"steps": 10}
+    },
+    {
+      "name": "canvas_960x544",
+      "tier": "tier0",
+      "expect": "~2.3x per step (ie#610). A real product rung, not a footnote: 960x544 is 0.52 MP against 1344x768's 1.03 MP, so the ~2.3x is roughly the pixel ratio and attention's superlinearity together. Respect the ie#522 video product floor before this reaches a surface.",
+      "payload": {"width": 960, "height": 544}
+    },
+    {
+      "name": "fp8_w8a8",
+      "tier": "tier0",
+      "expect": "1.056x speed but -38% MEMORY (SGLang 83.6 -> 51.9 GB/GPU on B300). THE MEMORY IS THE PRIZE. Whether fp8 serves H3 on ONE card instead of two is a 2x cost win no speedup table shows, and it stacks on adaln_cache (te#171: AdaLN-skip + fp8 encoder = ~77.7 GB, one 80 GB card). Verify the fp8 path exists for sm90 at all -- SGLang's fp8 numbers are Blackwell.",
+      "settings": {"techniques": ["fp8_w8a8"]}
+    },
+    {
+      "name": "attn_cudnn",
+      "tier": "tier1",
+      "approximate": false,
+      "expect": "Pure config, lossless. On sm100 cuDNN SDPA beat FA4 CuTe by 1.31x and FA2-class torch SDPA is 2.5-6x slower. The ranking is a per-card FACT (kernel_path.py's whole thesis), so re-measure on sm90 rather than inheriting a Blackwell ordering.",
+      "settings": {"techniques": ["attention_backend"], "attention_backend": "_native_cudnn"}
+    },
+    {
+      "name": "attn_fa3",
+      "tier": "tier1",
+      "approximate": false,
+      "expect": "The sm90 comparison point for attn_cudnn. Lossless; whichever wins, wins.",
+      "settings": {"techniques": ["attention_backend"], "attention_backend": "flash_hub"}
+    },
+    {
+      "name": "cache_dit_residual",
+      "tier": "tier1",
+      "expect": "The biggest single lever at 50 steps: 1.40x audited (SGLang Cache-DiT quality:'high' on 4xH200), up to 2.58x claimed. cache-dit==1.3.0 is an INDEPENDENT PyPI library, liftable without adopting SGLang's server -- the one genuinely portable thing in that stack. Coefficient-free residual-diff only (DBCache/FBCache shape); TeaCache-style polynomial rescaling needs per-model coefficients that DO NOT EXIST for H3.",
+      "settings": {
+        "techniques": ["cache_dit"],
+        "cache_dit_version": "1.3.0",
+        "residual_diff_threshold": 0.08,
+        "assert_hits": true,
+        "clone_before_snapshot": true
+      }
+    },
+    {
+      "name": "cache_dit_residual_loose",
+      "tier": "tier1",
+      "expect": "Threshold sweep partner. Sweep AT THE STEP COUNT tier0 CHOSE, never at 50: every published H3 cache number is a 50-step number, and the DBCache arithmetic (49 decisions = 4 warmup + 11 forced + 34 hits) collapses to ~3 skippable decisions at 8 steps -- a 1.3x ceiling.",
+      "baseline": "cache_dit_residual",
+      "settings": {
+        "techniques": ["cache_dit"],
+        "cache_dit_version": "1.3.0",
+        "residual_diff_threshold": 0.15,
+        "assert_hits": true,
+        "clone_before_snapshot": true
+      }
+    },
+    {
+      "name": "sage_fp16_pv",
+      "tier": "tier1",
+      "skip": "GATED on the H3 noise defect. SageAttention currently produces PURE NOISE on H3 in both video AND audio (Comfy-Org #15263). Suspected causes: H3's PARTIAL RoPE (rope_freq_dim 16 of 128) against smooth_k's channel-mean assumption, and packed audio+video tokens sharing INT8 quantization blocks. Un-skip only after the fp16-PV variant plus per-layer exclusion has produced a non-noise frame on a cheap probe -- and note the ceiling is modest anyway (~5-7% vs FA3 at PSNR 27.7 where it does work).",
+      "expect": "~5-7% vs FA3 where it works; far below the paper headline.",
+      "settings": {
+        "techniques": ["attention_backend"],
+        "attention_backend": "sage_hub",
+        "sage_pv_dtype": "fp16",
+        "exclude_layers": []
+      }
+    },
+    {
+      "name": "turbo_lora_8",
+      "tier": "tier2",
+      "skip": "Research bet, not a plan. larryvrh/MiniMax-H3-Turbo-Lora is real and Apache-2.0 with 4-step and 8-step variants, but the author calls it a Preview, training is PAUSED, and the documented artifacts are plastic-looking skin, over-sharp grain, and AUDIO as the weak point needing a custom dual-clock sampler. Un-skip only after tier0's step sweep has priced what the base model gives for free. Per bake-permanent-branch-varying it is a BAKED + GATED FLAVOR, never a runtime branch.",
+      "expect": "4-8 steps; approaches 4.5-5.5x combined, and CONFLICTS with cache_dit (caching is ineffective at 4 steps -- DisCa/Chorus; TurboDiffusion uses no caching at all).",
+      "payload": {"steps": 8},
+      "settings": {"techniques": ["turbo_lora"], "turbo_lora_steps": 8}
+    },
+    {
+      "name": "cell_t2va_10s",
+      "tier": "cells",
+      "approximate": false,
+      "expect": "fal median 80.3s, our target <=40.2s. Run with tier0's WINNING settings, not bare.",
+      "payload": {"duration_s": 10}
+    },
+    {
+      "name": "cell_t2va_15s",
+      "tier": "cells",
+      "approximate": false,
+      "expect": "fal median 316.2s, our target <=158.1s -- the SOFT cell, because fal's own curve blows up here. THE BLOWUP IS NOT ATTENTION MATH: no compute model fits all three fal points (T(15s) measured 316s against 138s predicted from the 5s and 10s points), so it is a memory/serving cliff around n~92k tokens. MEMORY ENGINEERING BEATS SPARSITY on this cell -- measure peak activation VRAM here, not just wall time, and treat an offload/recompute change as the candidate fix. Any lane reporting 'we beat fal' using only this cell or ref2va has not.",
+      "payload": {"duration_s": 15}
+    },
+    {
+      "name": "cell_i2va_5s",
+      "tier": "cells",
+      "approximate": false,
+      "expect": "fal median 41.5s, our target <=20.8s.",
+      "payload": {"duration_s": 5, "mode": "i2va"}
+    },
+    {
+      "name": "cell_ref2va_10s",
+      "tier": "cells",
+      "approximate": false,
+      "expect": "fal median 208.1s, our target <=104.0s. fal is structurally weakest at ref2va; a separate checkpoint tree (transformer_ref) serves it, so its arms do not inherit the t2va lane's verdicts.",
+      "payload": {"duration_s": 10, "mode": "ref2va", "reference_images": 3}
+    }
+  ]
+}

--- a/tests/test_engine_matrix_pgw1011.py
+++ b/tests/test_engine_matrix_pgw1011.py
@@ -1,0 +1,197 @@
+"""pgw#1011: the acceleration-matrix driver, exercised through its real entry
+points with an in-process lane standing in for a GPU one.
+
+The lane is the ONLY thing faked, and it is faked at the seam the driver
+publishes (:class:`Lane`) rather than by patching internals — so `run_matrix`,
+`select_arms`, `load_plan`, the budget, the JSONL sink and the summary all run
+exactly as they will on a pod.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from gen_worker.benchmarks import engine_matrix as em
+
+PLAN_PATH = (
+    Path(em.__file__).resolve().parent / "plans" / "h3_speed.json"
+)
+
+
+class _Lane:
+    """A lane whose cost is declared by the arm, so timings are predictable."""
+
+    def __init__(self, arm: em.Arm, payload: Dict[str, Any], log: List[str]) -> None:
+        self.arm = arm
+        self.payload = payload
+        self.log = log
+        self.closed = False
+        self.calls = 0
+        log.append(f"open:{arm.name}")
+
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self.calls += 1
+        if self.arm.settings.get("boom"):
+            raise RuntimeError("technique refused to arm")
+        time.sleep(float(self.arm.settings.get("cost_s", 0.01)))
+        return {"steps": payload.get("steps"), "engaged": self.arm.name}
+
+    def vram_bytes(self) -> int:
+        return int(self.arm.settings.get("vram", 0))
+
+    def close(self) -> None:
+        self.closed = True
+        self.log.append(f"close:{self.arm.name}")
+
+
+def _factory(log: List[str]):
+    def open_lane(arm: em.Arm, payload: Dict[str, Any]) -> em._Lane:  # type: ignore[name-defined]
+        if arm.settings.get("unbuildable"):
+            raise ImportError("cache-dit 1.3.0 is not installed")
+        return _Lane(arm, payload, log)
+    return open_lane
+
+
+def _plan(*arms: em.Arm, **kw: Any) -> em.Plan:
+    kw.setdefault("reps", 2)
+    kw.setdefault("warmup_reps", 1)
+    kw.setdefault("payload", {"steps": 50})
+    return em.Plan(name="t", arms=tuple(arms), **kw)
+
+
+def test_shipped_h3_plan_decodes_and_every_arm_states_a_denominator() -> None:
+    """The plan the GPU lane will actually run must load under the strict
+    decoder — a mistyped arm key would otherwise become a silent no-op that
+    produces a real-looking number for a configuration nobody ran."""
+    plan = em.load_plan(str(PLAN_PATH))
+    assert plan.name == "h3_speed"
+    names = [a.name for a in plan.arms]
+    assert names[0] == "base_50", "the denominator must be the first arm"
+    assert len(names) == len(set(names)), "arm names must be unique"
+    for arm in plan.arms:
+        assert arm.expect, f"{arm.name}: an arm with no published expectation is a guess"
+        if arm.baseline:
+            assert arm.baseline in names, f"{arm.name}: baseline {arm.baseline} not in plan"
+
+    # The three arms that are output-exact must be declared as such: a lossless
+    # technique needs no quality gate, and mislabelling one as approximate
+    # would park a free win behind cozy-eval#8 forever.
+    lossless = {a.name for a in plan.arms if not a.approximate}
+    assert {"adaln_cache", "warmup_matched", "attn_cudnn"} <= lossless
+
+    # Both known-defective techniques ship SKIPPED with the defect named, so a
+    # pod run cannot accidentally measure them.
+    skipped = {a.name: a.skip for a in plan.arms if a.skip}
+    assert "sage_fp16_pv" in skipped and "15263" in skipped["sage_fp16_pv"]
+    assert "turbo_lora_8" in skipped
+
+
+def test_speedup_is_computed_against_the_named_baseline() -> None:
+    log: List[str] = []
+    plan = _plan(
+        em.Arm(name="base", tier="t0", settings={"cost_s": 0.04}),
+        em.Arm(name="fast", tier="t0", settings={"cost_s": 0.01}),
+    )
+    results = em.run_matrix(plan, plan.arms, open_lane=_factory(log))
+    by = {r.arm: r for r in results}
+    assert by["base"].ok and by["fast"].ok
+    assert by["base"].speedup_vs_baseline == 0.0, "the denominator has no speedup"
+    assert by["fast"].speedup_vs_baseline > 2.0
+    # One lane per arm, and every lane closed — an arm that leaked a lane would
+    # leave weights resident and poison the next arm's residency number.
+    assert log == ["open:base", "close:base", "open:fast", "close:fast"]
+
+
+def test_warmup_reps_are_excluded_from_the_median() -> None:
+    """A cold first call is a different measurement (ie#612 measured 4.4x) and
+    mixing it in hides both."""
+    plan = _plan(em.Arm(name="a", settings={"cost_s": 0.01}), reps=2, warmup_reps=1)
+    results = em.run_matrix(plan, plan.arms, open_lane=_factory([]))
+    assert results[0].reps_ok == 2
+
+
+def test_a_failed_arm_is_a_recorded_result_not_a_dead_run() -> None:
+    log: List[str] = []
+    plan = _plan(
+        em.Arm(name="base", settings={"cost_s": 0.01}),
+        em.Arm(name="unbuildable", settings={"unbuildable": True}),
+        em.Arm(name="refuses", settings={"boom": True}),
+        em.Arm(name="after", settings={"cost_s": 0.01}),
+    )
+    results = em.run_matrix(plan, plan.arms, open_lane=_factory(log))
+    by = {r.arm: r for r in results}
+    assert by["unbuildable"].status == "open_failed"
+    assert "cache-dit" in by["unbuildable"].detail
+    assert by["refuses"].status == "no_successful_reps"
+    assert by["after"].ok, "a failed arm must not end the matrix"
+    # The arm whose lane opened is still closed even though every rep failed.
+    assert "close:refuses" in log
+
+
+def test_skip_and_wall_cap_refuse_before_spending() -> None:
+    plan = _plan(
+        em.Arm(name="base", settings={"cost_s": 0.01}),
+        em.Arm(name="known_broken", skip="Comfy-Org #15263: pure noise on H3"),
+        em.Arm(name="expensive", settings={"cost_s": 0.01}),
+    )
+    log: List[str] = []
+    results = em.run_matrix(
+        plan, plan.arms, open_lane=_factory(log),
+        wall_cap_s=0.001, arm_budget_s=600.0)
+    by = {r.arm: r for r in results}
+    assert by["known_broken"].status == "skipped"
+    assert "15263" in by["known_broken"].detail
+    assert by["expensive"].status == "out_of_budget"
+    # Neither refused arm opened a lane: the cap has to bite BEFORE the spend,
+    # not after (standing policy — no unwatched, unbounded GPU run).
+    assert "open:known_broken" not in log and "open:expensive" not in log
+
+
+def test_rows_are_persisted_as_they_complete(tmp_path: Path) -> None:
+    """RunPod has no container-log API, so a row that only reached stdout is a
+    row we do not have. Every completed row must already be on disk."""
+    out = tmp_path / "matrix.jsonl"
+    plan = _plan(em.Arm(name="a", settings={"cost_s": 0.01, "vram": 1024}))
+    em.run_matrix(plan, plan.arms, open_lane=_factory([]), out_path=str(out))
+    written = [json.loads(line) for line in out.read_text().splitlines()]
+    rows = [r for r in written if r["type"] == "row"]
+    arms = [r for r in written if r["type"] == "arm"]
+    assert len(rows) == 3 and len(arms) == 1
+    assert rows[0]["warmup"] is True and rows[1]["warmup"] is False
+    assert rows[0]["detail"]["steps"] == 50, "lane facts ride the row verbatim"
+    assert arms[0]["peak_vram_bytes"] == 1024
+
+
+def test_select_arms_pulls_in_the_denominator_a_filter_would_drop() -> None:
+    plan = _plan(
+        em.Arm(name="base", tier="tier0"),
+        em.Arm(name="cache", tier="tier1", baseline="base"),
+        em.Arm(name="other", tier="tier2"),
+    )
+    picked = [a.name for a in em.select_arms(plan, tier="tier1")]
+    assert picked == ["base", "cache"], "a filtered arm keeps its denominator"
+    assert em.select_arms(plan, names=["nope"]) == ()
+
+
+def test_summary_marks_lossless_arms_distinctly() -> None:
+    plan = _plan(
+        em.Arm(name="base", settings={"cost_s": 0.02}),
+        em.Arm(name="exact", approximate=False, settings={"cost_s": 0.01},
+               expect="bit-identical (NVlabs AdaLN precompute)"),
+    )
+    table = em.summarize(em.run_matrix(plan, plan.arms, open_lane=_factory([])))
+    assert "LOSSLESS" in table and "approx" in table
+    assert "NVlabs" in table
+
+
+def test_cli_refuses_a_plan_with_no_matching_arms(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        em.main([
+            "--plan", str(PLAN_PATH), "--tier", "nonexistent",
+            "--lane", "gen_worker.benchmarks.engine_matrix:load_plan",
+        ])

--- a/tests/test_engine_matrix_pgw1011.py
+++ b/tests/test_engine_matrix_pgw1011.py
@@ -50,7 +50,7 @@ class _Lane:
 
 
 def _factory(log: List[str]):
-    def open_lane(arm: em.Arm, payload: Dict[str, Any]) -> em._Lane:  # type: ignore[name-defined]
+    def open_lane(arm: em.Arm, payload: Dict[str, Any]) -> _Lane:
         if arm.settings.get("unbuildable"):
             raise ImportError("cache-dit 1.3.0 is not installed")
         return _Lane(arm, payload, log)


### PR DESCRIPTION
Research + integration phase of **pgw#1011** (series head ie#611), aimed at ie#612's measured fal bar. **No GPU was spent on this lane** — the weights are not in the catalog yet (ie#613), so this produces the re-measurement instrument and the ordered plan the GPU lane executes after ingest + te#171 Phase B.

## Why a harness and not an adoption

Every published MiniMax-H3 speed number was measured on hardware we do not own — 8xB300, 8xGB200, 4xH200 — and the two stacks holding most of them are **monolithic native reimplementations**: adopting SGLang's numbers means adopting SGLang's server, which conflicts with the in-process worker model all 28 endpoint packages are built on. So the deliverable is a re-measurement instrument.

## What landed

- **`src/gen_worker/benchmarks/engine_matrix.py`** — an `Arm` is DATA: a name, a settings fragment, a payload fragment. Flipping a technique is choosing an arm, never editing a serving path — and deliberately **not** an env-flag surface (envs carry secrets and config values, never logic forks) and **not** a serving knob.
- **The lane is pluggable** because the candidates do not share a runtime. Some techniques are engine CLI flags; the ones that rank first for H3 are in-process diffusers changes (AdaLN-branch precompute, `cache-dit`, resolution-matched warmup, attention-backend swap). A driver that assumed a server subprocess could not measure them.
- **Budget + evidence are structural.** `wall_cap_s` bounds the whole run, `arm_budget_s` each arm; an arm that cannot fit is recorded `out_of_budget` *before* it opens a lane. Rows are fsynced to JSONL as they complete — RunPod has no container-log API, so a row that only reached stdout is a row we do not have.
- **`benchmarks/plans/h3_speed.json`** (ships in the wheel, verified) — the ordered matrix, each arm carrying its published expectation *with its citation* and an `approximate` flag, so a lossless technique is never parked behind the audio gate and an approximate one is never adopted without it.

## The two defects that ship SKIPPED

A pod run cannot accidentally measure these and report a number:
- **SageAttention on H3 produces pure noise** — Comfy-Org #15263, in **video and audio**. Suspects: H3's partial RoPE (`rope_freq_dim` 16/128) against `smooth_k`'s channel-mean assumption, and packed audio+video tokens sharing INT8 quantization blocks.
- **`larryvrh/MiniMax-H3-Turbo-Lora`** is Apache-2.0 and real, but an author-**paused** preview whose documented weak point is audio.

## Not in this PR, on purpose

No change to any vendored H3 pipeline — ie#615's scaffold lane owns that file and is hard-blocked on diffusers 0.40.0. Nothing here forks it.

## Tests

`tests/test_engine_matrix_pgw1011.py` — 9 passing, driving the real `run_matrix` / `select_arms` / `load_plan` / budget / sink / summary with an in-process lane at the published `Lane` seam. Includes a structural gate on the shipped plan itself (unique names, every arm states an expectation, every baseline resolves, the three output-exact arms are declared lossless, both defective arms are skipped with the defect named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xYyN7C8QtBVV6o6K2UW6y