### PR TITLE
pgw#1016 + pgw#1017: the documented Dockerfile is one the hub accepts, and the AOT toolchain is the author's to install

### DIFF
--- a/changelog.d/pgw1016-pgw1017.md
+++ b/changelog.d/pgw1016-pgw1017.md
@@ -1,0 +1,33 @@
+- **pgw#1016: `docs/dockerfile.md` documented a Dockerfile the hub REFUSES.**
+  The canonical org Dockerfile — the one an endpoint author is told to copy —
+  carried a BuildKit cache mount under a shared id, twice, and tensorhub's
+  publish validator bans the directive outright (`ErrBuildKitCache`), so an org
+  that followed the documentation got `400 invalid_tarball`. It went unnoticed
+  because the documented path has **no first-party consumer**: every
+  `inference-endpoints` family ships no Dockerfile at all and lets the hub
+  synthesize one. The first family to actually follow the doc hit it on its
+  first publish.
+- **The ban is correct and the doc taught a vulnerability.** A cache id common
+  to every org's Dockerfile is one mutable directory shared across tenant
+  builds: org A seeds a poisoned wheel, org B's build mounts the same id and
+  installs it — build-time code injection across a tenant boundary, the same
+  shape of trust failure as adopting a foreign compile cell, one layer down. The
+  doc now installs uncached and says why in the same breath. If speed ever
+  justifies a cache the answer is a per-org **namespaced** id the validator
+  enforces, never an unbanned shared one.
+- **pgw#1017: the AOT host toolchain is the author's to install and the
+  platform's to verify.** A family shipping its own Dockerfile never received
+  the `g++` layer pgw#823 added to the SYNTHESIZED Dockerfile, so it could
+  declare an AOT export and never mint one. The docs and the canonical example
+  now install it (`ca-certificates curl g++`, recommends-off, no
+  `build-essential`; +80 MB measured) and pgw#996's build-time precondition is
+  what makes it a guarantee: the refusal names the families, at the build, for
+  \$0.00, against the 336 s of rented L4 the same defect cost before the check
+  existed. Injecting the layer was rejected on principle — a custom Dockerfile
+  is author-owned content, and a guarantee you cannot observe is not a stronger
+  guarantee, only a quieter one.
+- **A guard so the two sides cannot drift again.** The doc's fenced Dockerfile
+  blocks and every `examples/*/Dockerfile` are checked against the hub's own
+  pattern, including the prose — the validator reads comments too, so a `why`
+  paragraph that spells the banned directive is refused the moment an author
+  pastes it into a comment.

--- a/docs/dockerfile.md
+++ b/docs/dockerfile.md
@@ -153,11 +153,11 @@ presence as your signal in the build script that drives `docker build`.
 
 ---
 
-## Caching: tenant-controlled
+## Caching: tenant-controlled, with one platform ban
 
 `BUILD_NONCE`, `DEPS_NONCE`, endpoint-specific commit pins — these are your
-cache-bust knobs, unrelated to versioning. Tensorhub does not impose any
-caching strategy.
+cache-bust knobs, unrelated to versioning. Layer caching is yours; Tensorhub
+imposes no caching strategy.
 
 ```dockerfile
 ARG BUILD_NONCE=2026-04-23-default
@@ -165,6 +165,89 @@ RUN echo "build-nonce=${BUILD_NONCE}" \
     && mkdir -p /app/.tensorhub \
     && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock
 ```
+
+### BuildKit cache mounts are refused
+
+A Dockerfile that asks BuildKit for a persistent cache directory is rejected at
+publish:
+
+```
+400 invalid_tarball
+     buildkit cache mounts are not allowed in org Dockerfiles
+```
+
+**Why.** The builder is multi-tenant, and such a cache is addressed by an id.
+The obvious id is a constant — every org copies the same one off a page like
+this one — and a constant id is one mutable directory shared across tenant
+builds. Org A seeds a poisoned wheel into it; org B's build mounts the same id
+and installs it. That is build-time code injection across a tenant boundary:
+the same shape of trust failure as adopting a foreign compile cell, one layer
+down.
+
+Install uncached instead — `uv pip install --no-cache`. The ordinary layer
+cache still covers the common case, and a cold dependency install is a
+build-time cost paid once per release, not a per-pod one.
+
+If build speed later justifies a real cache, the answer is a per-org
+**namespaced** id the validator enforces (the id must embed the org; the
+validator rewrites or refuses). Never a shared one — speed does not reopen a
+cross-tenant channel.
+
+> The validator matches the raw bytes of the whole Dockerfile, **comments
+> included**. Do not paste the banned directive into your file even to explain
+> why it is banned: an explanatory comment is refused exactly like a live
+> instruction. Fail-closed is deliberate here.
+
+---
+
+## The AOT host toolchain — yours to install, the platform's to verify
+
+AOTInductor is the only lane that host-compiles: it emits a C++ wrapper and
+links a real `.so`, on the machine running the mint. The dynamo/JIT lane does
+not — it emits Triton kernels behind a Python wrapper — so an endpoint that
+declares no `compile=` export never needs any of this.
+
+If any of your endpoints DOES declare an AOT export, the image must carry a C++
+compiler. The pytorch runtime bases ship a C compiler and no C++ one. Install
+it yourself: your Dockerfile is author-owned content and the platform never
+injects layers into it.
+
+```dockerfile
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl g++ \
+ && rm -rf /var/lib/apt/lists/*
+```
+
+`g++`, recommends-off, and **not** `build-essential` — the latter drags ~250 MB
+of make/dpkg-dev the wrapper compile never invokes. Measured cost of this layer
+on a ~9.2 GB endpoint image: **+80 MB**.
+
+**The platform verifies it rather than establishing it.** `python -m
+gen_worker.discovery` already runs inside your final image, so it can ask the
+question about the image that will actually serve. An image whose endpoints
+declare an AOT export and whose PATH holds no C++ compiler fails the build, by
+name:
+
+```
+error: aot precondition cxx_toolchain: no C++ compiler on this image, but
+       ['micro-4d', 'micro-diffusion'] declare an AOT export
+```
+
+That refusal costs $0.00, at the build, naming the families. Before the check
+existed the same defect cost 336 s of rented L4 time and surfaced as
+`InvalidCxxCompiler` at the link step. A guarantee you can observe beats a
+quieter one: the refusal IS the guarantee.
+
+> **On a CUDA image `g++` is necessary, not sufficient.** torch's
+> `cpp_extension` also needs a CUDA root it can discover, and the pytorch
+> runtime bases ship CUDA as pip wheels without ever creating `/usr/local/cuda`
+> — so an image with `g++` and no composed CUDA root still dies with
+> `CUDA_HOME environment variable is not set`, on a pod, after paying for the
+> export. Tensorhub's synthesized Dockerfile composes that root; a custom
+> Dockerfile has no equivalent and **no precondition covers it yet**. pgw#1017
+> owns closing that gap. Until it does, do not pod-run a custom-Dockerfile
+> family that declares an AOT export.
 
 ---
 
@@ -176,21 +259,27 @@ FROM ${BASE_IMAGE}
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# The AOT host toolchain. Drop this layer only if no endpoint in the image
+# declares a compile export — Tensorhub's own generated Dockerfile installs it
+# in every image it synthesizes.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl g++ \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY pyproject.toml uv.lock /app/
 
-RUN --mount=type=cache,id=cozy-uv-cache,target=/var/cache/uv,sharing=locked \
-    uv export --cache-dir /var/cache/uv --link-mode copy \
+RUN uv export --no-cache --link-mode copy \
       --no-dev --no-hashes --no-sources --no-emit-project --no-emit-local \
       -o /tmp/requirements.txt \
-    && uv pip install --cache-dir /var/cache/uv --link-mode copy \
+    && uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps -r /tmp/requirements.txt
 
 COPY . /app
 
-RUN --mount=type=cache,id=cozy-uv-cache,target=/var/cache/uv,sharing=locked \
-    uv pip install --cache-dir /var/cache/uv --link-mode copy \
+RUN uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps --no-sources /app \
     && mkdir -p /app/.tensorhub \
     && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock

--- a/examples/micro-diffusion/Dockerfile
+++ b/examples/micro-diffusion/Dockerfile
@@ -11,21 +11,37 @@ FROM ${BASE_IMAGE}
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# The AOT host toolchain. This family declares a compile export, so its image
+# must be able to link the C++ wrapper AOTInductor emits — the pytorch runtime
+# bases carry a C compiler and no C++ one. Recommends-off and no
+# build-essential: +80 MB measured, against ~250 MB of make/dpkg-dev the
+# wrapper compile never invokes. `gen_worker.discovery` below verifies this at
+# build time and refuses the image if it is missing (pgw#996, pgw#1017).
+#
+# NOT SUFFICIENT ON ITS OWN, and this family is not pod-ready until pgw#1017
+# closes it: torch's cpp_extension also needs a discoverable CUDA root, which
+# this base does not have (CUDA arrives as pip wheels and /usr/local/cuda is
+# never created). Tensorhub's synthesized Dockerfile composes that root; a
+# custom Dockerfile has no equivalent and no precondition covers it yet, so a
+# mint on this image would die at CUDA_HOME after paying for the export.
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl g++ \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY pyproject.toml uv.lock /app/
 
-RUN --mount=type=cache,id=cozy-uv-cache,target=/var/cache/uv,sharing=locked \
-    uv export --cache-dir /var/cache/uv --link-mode copy \
+RUN uv export --no-cache --link-mode copy \
       --no-dev --no-hashes --no-sources --no-emit-project --no-emit-local \
       -o /tmp/requirements.txt \
-    && uv pip install --cache-dir /var/cache/uv --link-mode copy \
+    && uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps -r /tmp/requirements.txt
 
 COPY . /app
 
-RUN --mount=type=cache,id=cozy-uv-cache,target=/var/cache/uv,sharing=locked \
-    uv pip install --cache-dir /var/cache/uv --link-mode copy \
+RUN uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps --no-sources /app
 
 # The checkpoint, generated and VERIFIED in the same layer. `--verify`

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -97,6 +97,12 @@ Preconditions (all verified before step 1, none assumed):
   platform-paid work).
 - The wheel is a version that has completed a local `task rig:micro` cycle.
   A wheel nothing has proven locally is what this whole family exists to stop.
+- **pgw#1017's `cuda_root` gap is closed.** ⛔ It is not, today. This family
+  ships its own Dockerfile, so it gets no composed `/usr/local/cuda`, and
+  torch's `cpp_extension` finds no CUDA on the pytorch runtime base. The mint
+  would boot, load, export and then die at `CUDA_HOME environment variable is
+  not set` — a paid failure where the missing-`g++` sibling was a free one.
+  **The pod runbook is blocked on that, independently of Paul's go.**
 
 ### 1. Wheel — pin the endpoint at the version under test
 
@@ -112,21 +118,19 @@ proof artifact, not a fleet pin.
 > the run would burn a pod to rediscover a fixed defect. The local rig runs
 > against master and its parity leg is a green proof of that fix.
 
-### 2. Create the endpoint (first time only)
+### 2. Publish the release
 
-```
-POST /api/v1/endpoints  {"owner":"tensorhub","name":"micro-diffusion"}
-```
-
-Auth: `POST /api/v1/password/login` → **`access_token`** (not `access`),
-15-minute expiry — refresh it around the build.
-
-### 3. Publish the release
+There is no endpoint-creation call to make first. `POST /api/v1/endpoints` does
+not exist; publishing a release auto-creates the endpoint. A runbook step that
+posts it has nothing to hit.
 
 ```
 POST /api/v1/endpoints/tensorhub/micro-diffusion/releases?dev=true&skip_profiling=true
 Content-Type: application/gzip     (raw tarball body)
 ```
+
+Auth: `POST /api/v1/password/login` → **`access_token`** (not `access`),
+15-minute expiry — refresh it around the build.
 
 202 → `{build_id, proposed_release_id}`; `200 {"status":"noop"}` is also
 success. Poll `GET /api/v1/endpoint-builds/{id}` to `succeeded`.
@@ -134,7 +138,7 @@ success. Poll `GET /api/v1/endpoint-builds/{id}` to `succeeded`.
 diffusers/transformers/accelerate and its weight-generation layer is ~1 s, so
 the delta is the dependency install).
 
-### 4. Tag `prod` — BEFORE the buy
+### 3. Tag `prod` — BEFORE the buy
 
 ```
 PUT /api/v1/endpoints/tensorhub/micro-diffusion/tags/prod  {"release_id": …}
@@ -145,7 +149,7 @@ answers `409 no_compile_declaration` for a release the runtime has not loaded.
 That 409 has twice been misread as a missing declaration; it is a cold cache.
 **ESTIMATE: seconds.**
 
-### 5. Arm mint boots
+### 4. Arm mint boots
 
 `TENSORHUB_COMPILE_OBLIGATION_MINT_BOOTS=true`, restart the hub **process
 alone**. Confirm from the LOG, not the API:
@@ -153,7 +157,7 @@ alone**. Confirm from the LOG, not the API:
 `compile-cells` 202 reads current config, not the running loop's snapshot, and
 will lie to you. **ESTIMATE: < 1 min.**
 
-### 6. Buy
+### 5. Buy
 
 ```
 POST /v1/admin/compile-cells  {"release_id":…, "gpu_model":"L40S", "coverage":"warmup"}
@@ -165,7 +169,7 @@ un-parks (its `ON CONFLICT (release_id, sku) DO UPDATE` resets `status`,
 `attempts`, `discharged_at`, `not_before`). **Buy it as FORGE** — 12 h worker
 JWT instead of 30 min, plus the activity-backstop and idle-turnover exemptions.
 
-### 7. Watch
+### 6. Watch
 
 ```
 GET /v1/admin/mints?release=…
@@ -183,12 +187,12 @@ GET /v1/admin/fleet-status | .compile_cells
 | export + AOTI compile | ~90 min / 36 entries | ~2-3 min / 3 entries | 12x fewer entries, tiny graphs |
 | seal + publish | ~1 min | seconds | the cell is small |
 
-### 8. Adopt
+### 7. Adopt
 
 Drive demand so a SECOND pod boots cold and adopts the published cell from the
 hub. Bank the eager arm on a pod that is NOT concurrently minting.
 
-### 9. Safety half
+### 8. Safety half
 
 The mint is sm_89 (L40S). Boot an `a100-sxm4-80gb` (sm_80) and record the TYPED
 refusal — an untested refusal is not a guarantee.

--- a/tests/test_dockerfile_doc_contract_pgw1016.py
+++ b/tests/test_dockerfile_doc_contract_pgw1016.py
@@ -1,0 +1,102 @@
+"""The Dockerfile the docs teach must be one the hub will accept (pgw#1016).
+
+`docs/dockerfile.md` presents the canonical org Dockerfile — the file an
+endpoint author is told to copy. It taught a BuildKit cache mount, and
+tensorhub's publish validator refuses one outright
+(`builder/validation.go`: `ErrBuildKitCache`), so an org that followed the
+documentation could not publish: `400 invalid_tarball`. The doc had no
+first-party consumer — every `inference-endpoints` family lets the hub
+synthesize its Dockerfile — so nothing ever exercised it.
+
+This is the guard that keeps the two sides from drifting apart again from
+THIS repo, which is where the doc lives. It mirrors the hub's pattern rather
+than importing it (separate repo, different language); the mirrored source is
+named above so a change there has a place to land.
+
+The hub matches the RAW BYTES of the whole Dockerfile, comments included, so
+these checks deliberately do not strip comments either: a file that merely
+mentions the directive while explaining the ban is refused exactly like one
+that uses it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+# tensorhub/internal/builder/validation.go: reBuildKitCacheMount
+RE_BUILDKIT_CACHE_MOUNT = re.compile(r"(?i)--mount\s*=\s*type\s*=\s*cache\b")
+
+DOC = REPO / "docs" / "dockerfile.md"
+FENCED_DOCKERFILE = re.compile(r"```dockerfile\n(.*?)```", re.DOTALL)
+
+
+def _example_dockerfiles() -> list[Path]:
+    return sorted((REPO / "examples").rglob("Dockerfile"))
+
+
+def test_doc_dockerfile_blocks_pass_the_hub_validator() -> None:
+    blocks = FENCED_DOCKERFILE.findall(DOC.read_text())
+    assert blocks, "docs/dockerfile.md has no dockerfile blocks to check"
+    for block in blocks:
+        assert not RE_BUILDKIT_CACHE_MOUNT.search(block), (
+            "a documented Dockerfile block carries a BuildKit cache mount; the "
+            "hub refuses it at publish (400 invalid_tarball). Shared cache ids "
+            "are a cross-tenant poisoning channel — install uncached, or "
+            "namespace the id per org and teach the validator to enforce it"
+        )
+
+
+def test_the_ban_is_explained_without_spelling_the_directive() -> None:
+    """The prose must survive its own copy-paste.
+
+    The validator reads comments too, so a `why` paragraph that spells the
+    directive becomes a refusal the moment an author pastes it into a comment.
+    """
+    assert not RE_BUILDKIT_CACHE_MOUNT.search(DOC.read_text()), (
+        "docs/dockerfile.md spells the banned directive in prose; pasting that "
+        "sentence into a Dockerfile comment is refused exactly like using it"
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _example_dockerfiles(), ids=lambda p: p.parent.name
+)
+def test_example_dockerfiles_pass_the_hub_validator(path: Path) -> None:
+    assert not RE_BUILDKIT_CACHE_MOUNT.search(path.read_text()), (
+        f"{path.relative_to(REPO)} carries a BuildKit cache mount and cannot "
+        f"be published"
+    )
+
+
+def test_the_canonical_example_carries_the_aot_host_toolchain() -> None:
+    """pgw#1017: the AUTHOR installs it, and the docs must say so.
+
+    A custom Dockerfile is author-owned content — the platform verifies the
+    toolchain at build time (`aot_preconditions.CHECK_CXX_TOOLCHAIN`) rather
+    than injecting a layer into someone else's file. That only works if the
+    canonical file an author copies has the layer.
+    """
+    path = REPO / "examples" / "micro-diffusion" / "Dockerfile"
+    content = path.read_text()
+    assert "ca-certificates curl g++" in content, (
+        "micro-diffusion declares an AOT export, so its image must carry a C++ "
+        "compiler; the build refuses without one (aot precondition "
+        "cxx_toolchain)"
+    )
+    assert "--no-install-recommends" in content
+    instructions = "\n".join(
+        line for line in content.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "build-essential" not in instructions, (
+        "build-essential drags ~250 MB of make/dpkg-dev the AOTI wrapper "
+        "compile never invokes; g++ with recommends off is +80 MB"
+    )
+    assert "ca-certificates curl g++" in DOC.read_text(), (
+        "the doc and the example must teach the same toolchain layer"
+    )


### PR DESCRIPTION
Both defects have one shape: **the custom-Dockerfile path has no first-party consumer**, so platform guarantees have only ever been implemented on the SYNTHESIZED path. One commit, because both edit `docs/dockerfile.md`.

## pgw#1016 — the doc taught a Dockerfile the hub refuses

`docs/dockerfile.md`'s canonical org Dockerfile carried a BuildKit cache mount under a shared id, twice. `builder/validation.go` bans the directive outright, so publishing the documented file returned `400 invalid_tarball`.

**The ban is correct and the doc taught a vulnerability.** A cache id common to every org's Dockerfile is one mutable directory shared across tenant builds: org A seeds a poisoned wheel, org B's build mounts the same id and installs it — build-time code injection across a tenant boundary, the same shape of trust failure as adopting a foreign compile cell, one layer down. The doc now installs uncached and says why. If speed ever justifies a cache the answer is a per-org **namespaced** id the validator enforces, never an unbanned shared one.

## pgw#1017 — the AOT toolchain is the author's to install, the platform's to verify

A family shipping its own Dockerfile never received the `g++` layer pgw#823 added to the synthesized file, so it could declare an AOT export and never mint one. The docs and the canonical example now install it (`ca-certificates curl g++`, recommends-off, no `build-essential`; +80 MB measured), and pgw#996's build-time precondition is what makes it a guarantee — the refusal names the families, at the build, for \$0.00, against 336 s of rented L4 before the check existed.

Injection was rejected on principle: a custom Dockerfile is author-owned content, and a guarantee you cannot observe is not a stronger guarantee, only a quieter one.

## Recorded, not papered over: `g++` is necessary and NOT sufficient

torch's `cpp_extension` also needs a discoverable CUDA root. The pytorch runtime bases ship CUDA as pip wheels and never create `/usr/local/cuda`; only the synthesized Dockerfile composes one. A custom image with `g++` and no CUDA root dies at `CUDA_HOME environment variable is not set` **on a pod, after paying for the export** — a paid failure where the missing-`g++` sibling was a free one. The doc, the example and the runbook preconditions all say so, and the micro-diffusion pod runbook is blocked on it independently of Paul's go. Closing it is the top row of pgw#1017's audit.

## Also

The runbook's step 2 posted `POST /api/v1/endpoints`, which does not exist — releases auto-create the endpoint. Deleted, steps renumbered.

## The guard

`tests/test_dockerfile_doc_contract_pgw1016.py` checks the doc's fenced Dockerfile blocks and every `examples/*/Dockerfile` against the hub's own pattern — and the prose too, because the validator matches raw bytes including comments, so a `why` paragraph that spells the banned directive is refused the moment an author pastes it into a comment. RED-verified by reintroducing a mount and watching the example test fail.

Strictly local: no pods, no RunPod calls, no deploys.