### PR TITLE
pgw#1013 §4.24 absence sweep: a guard for the class the bounds census cannot see, and the frame bound one reader skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,15 @@ jobs:
       - name: pgw#931 guard - config reads outside the pipeline
         run: uv run python scripts/lint_config_reads.py
 
+      # GATING (pgw#1013 / th#1662): a length read off external bytes may not
+      # size a read until something bounds it. The §4.24 census enumerated the
+      # bounds that EXIST, so it could not see a site that needs one and has
+      # none — it walked past two real ones in files it had already swept.
+      # Either bound the length with a sanctioned validator, or state why it
+      # needs none with a `# bound-justified:` comment.
+      - name: pgw#1013 guard - an external length sizes a read with no bound
+        run: uv run python scripts/lint_unbounded_reads.py
+
       # Cheap (2s) and it belongs with the gates, not behind the suite: a
       # broken sdist/wheel build is a publish-time failure, and publish.yml
       # gates on a green run of THIS workflow.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,6 +144,10 @@ tasks:
       # Ratcheted against scripts/unreached_surface_baseline.txt: new entries
       # fail, and so does a baseline line that is now wired up.
       - cmd: uv run python scripts/lint_unreached_surface.py
+      # Hard gate (matches CI): pgw#1013 / th#1662 — an external length prefix
+      # may not size a read unless a validator bounds it or a
+      # `# bound-justified:` comment says why none is needed.
+      - cmd: uv run python scripts/lint_unbounded_reads.py
 
   test:
     desc: Run tests (both suites, as CI does)

--- a/changelog.d/pgw1013.md
+++ b/changelog.d/pgw1013.md
@@ -1,0 +1,18 @@
+- **pgw#1013 / th#1662: the bounds census could not see a missing bound, so the
+  absence now has its own sweep and its own guard.** The §4.24 census (pgw#973)
+  enumerated every numeric bound and adjudicated it — a procedure that can only
+  inspect bounds that EXIST. `scripts/lint_unbounded_reads.py` inverts it: a
+  length read off external bytes (`struct.unpack` / `int.from_bytes`) may not
+  size a read until a sanctioned validator bounds it or a `# bound-justified:`
+  comment states why none is needed. It found a **third** unguarded safetensors
+  reader on its first run, in a file the census had already swept twice.
+- **pgw#1013: the boot-fatal ack reader ignored the frame bound its own module
+  enforces.** `procsplit/frames.py` declares `MAX_FRAME_BYTES = 128 MiB` and
+  both ends of the normal path refuse an oversized frame, but
+  `child._wait_boot_fatal_ack` is a hand-rolled reader that never compared the
+  4-byte declared length to anything — up to 4 GiB, accumulated with a
+  quadratic `buf += chunk`. The bound existed and one site skipped it, which is
+  precisely the class a bounds inventory cannot detect. Now refused, and
+  `_recv_exact` accumulates into a `bytearray`. RED-verified through a real
+  `AF_UNIX` socket: without the check the reader hangs until the socket
+  timeout, because `settimeout` bounds each `recv` and not the accumulation.

--- a/scripts/lint_unbounded_reads.py
+++ b/scripts/lint_unbounded_reads.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""pgw#1013 / th#1662: a length read off external bytes may not size a read
+until something has bounded it.
+
+WHY THIS GUARD EXISTS. The §4.24 bounds census (pgw#973 / th#1620) enumerated
+every numeric constant and adjudicated each against "name the runaway you
+prevent". That procedure can only inspect bounds that EXIST, so it is blind by
+construction to a read site that needs one and has none — and it walked past two
+real ones in files it had already swept:
+
+    convert/writer.component_stored_tensor_names   json.loads(fh.read(header_len))
+    models/loading  (deshard path)                 json.loads(f.read(n))
+
+Both took the attacker-controlled 8-byte safetensors prefix and allocated on it.
+RED, measured: `OverflowError: byte string is too large` attempting a 2**63-byte
+allocation. Fixed in pgw#973 wave 2 — this guard is what stops the class coming
+back, because the census that missed them cannot be re-run to catch a new one.
+
+THE RULE. Inside a function, if a name is bound from a binary length prefix —
+
+    (n,) = struct.unpack("<Q", ...)      n = struct.unpack(...)[0]
+    n = int.from_bytes(prefix, "little")
+
+— and that same name is later used to size a read or an allocation —
+
+    f.read(n)      os.read(fd, n)      bytearray(n)      b"\\x00" * n
+
+— then the function must also bound it, in one of two ways:
+
+  1. call a sanctioned validator on it, e.g. ``header_len_ok(n)``; or
+  2. carry an explicit justification comment, on the read line or in the
+     comment block just above it (see JUSTIFICATION_LOOKBACK):
+         ``# bound-justified: <why this cannot run away>``
+
+Two ways, deliberately: §4.24 asks for a bound OR a stated reason none is
+needed, and a guard that only accepts the bound would push honest exemptions
+into silence.
+
+WHAT IT DOES NOT CATCH, stated so nobody reads a green run as proof of absence:
+this matches the SHAPE the specimens had — a binary length prefix feeding a read
+in the SAME function. A size that arrives via a return value, an attribute, a
+JSON field, or a DB column is out of reach of a rule this cheap. Widening it
+means dataflow analysis, and a noisy guard gets suppressed, which is worse than
+a narrow one that holds. The broader enumeration is the issue's job; this is the
+ratchet under it.
+
+Usage: scripts/lint_unbounded_reads.py   (exit 1 on any finding)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+# Calls whose result is a length taken from bytes the process did not compute.
+LENGTH_SOURCES = {"unpack", "unpack_from", "from_bytes"}
+
+# Names that, called on the length, count as bounding it. A project adds to this
+# set when it grows another validator — it is deliberately explicit.
+SANCTIONED_VALIDATORS = {"header_len_ok"}
+
+# Call/expression shapes that turn a length into memory or IO.
+SIZING_METHODS = {"read", "readinto", "recv", "pread"}
+
+JUSTIFICATION = "bound-justified:"
+
+# How far above the read line a justification comment may sit.
+JUSTIFICATION_LOOKBACK = 8
+
+
+def _iter_targets(node: ast.AST):
+    """Names bound by an assignment target, including tuple unpacking."""
+    if isinstance(node, ast.Name):
+        yield node.id
+    elif isinstance(node, (ast.Tuple, ast.List)):
+        for elt in node.elts:
+            yield from _iter_targets(elt)
+
+
+def _call_func_name(call: ast.Call) -> str:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    if isinstance(f, ast.Name):
+        return f.id
+    return ""
+
+
+def _is_length_source(value: ast.AST) -> bool:
+    """struct.unpack(...)  /  int.from_bytes(...)  possibly subscripted."""
+    node = value
+    if isinstance(node, ast.Subscript):
+        node = node.value
+    return isinstance(node, ast.Call) and _call_func_name(node) in LENGTH_SOURCES
+
+
+class FunctionScan(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.tainted: set[str] = set()
+        self.validated: set[str] = set()
+        self.sized: list[tuple[str, int]] = []  # (name, lineno)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if _is_length_source(node.value):
+            for t in node.targets:
+                self.tainted.update(_iter_targets(t))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = _call_func_name(node)
+        # A sanctioned validator applied to a tainted name bounds it.
+        if name in SANCTIONED_VALIDATORS:
+            for a in node.args:
+                if isinstance(a, ast.Name):
+                    self.validated.add(a.id)
+        # A read/alloc sized by a tainted name is the site we care about.
+        if name in SIZING_METHODS:
+            for a in node.args:
+                if isinstance(a, ast.Name):
+                    self.sized.append((a.id, node.lineno))
+        self.generic_visit(node)
+
+
+def scan_file(path: Path, src: str) -> list[str]:
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}: unparseable ({exc})"]
+
+    lines = src.splitlines()
+    findings: list[str] = []
+
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        scan = FunctionScan()
+        for stmt in fn.body:
+            scan.visit(stmt)
+        for name, lineno in scan.sized:
+            if name not in scan.tainted:
+                continue
+            if name in scan.validated:
+                continue
+            # The justification may sit on the read line or in the comment
+            # block immediately above it. A one-line-only rule would push a
+            # real reason into a cramped trailing comment, which is how
+            # justifications become noise nobody reads.
+            start = max(0, lineno - 1 - JUSTIFICATION_LOOKBACK)
+            window = lines[start:lineno]
+            if any(JUSTIFICATION in ln for ln in window):
+                continue
+            rel = path.relative_to(SRC_ROOT.parent.parent)
+            findings.append(
+                f"{rel}:{lineno}: `{name}` is a length read off external bytes and sizes a "
+                f"read in `{fn.name}()` with nothing bounding it.\n"
+                f"    Fix: call a sanctioned validator ({', '.join(sorted(SANCTIONED_VALIDATORS))}) "
+                f"on it, or state why none is needed with a `# {JUSTIFICATION} ...` comment."
+            )
+    return findings
+
+
+def main() -> int:
+    findings: list[str] = []
+    for py in sorted(SRC_ROOT.rglob("*.py")):
+        findings.extend(scan_file(py, py.read_text(encoding="utf-8")))
+
+    if findings:
+        print("unbounded-read guard: an external length sizes a read with no bound\n")
+        for f in findings:
+            print(f)
+        print(
+            "\npgw#1013 / th#1662: the bounds census could not see these — it enumerated "
+            "bounds that exist, not sites that need one."
+        )
+        return 1
+
+    print("unbounded-read guard: OK — every external length feeding a read is bounded or justified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -1642,6 +1642,11 @@ def deshard_indexed_safetensors(index_path: Path) -> Path:
     # here, at ingest, instead of at load time on a GPU pod.
     with open(merged, "rb") as f:
         header_len = int.from_bytes(f.read(8), "little")
+        # bound-justified: `merged` was written by merge_safetensors_by_offset in
+        # this same call, from shard headers each already refused by
+        # header_len_ok. This length is our own output, not external input, so a
+        # second check here would bound us rather than an attacker (§4.24: a
+        # limit must name a runaway nothing else prevents).
         header = json.loads(f.read(header_len).decode("utf-8"))
     got = {k for k in header if k != "__metadata__"}
     want = {str(k) for k in weight_map}

--- a/src/gen_worker/procsplit/child.py
+++ b/src/gen_worker/procsplit/child.py
@@ -84,6 +84,19 @@ def _wait_boot_fatal_ack(sock: socket.socket) -> None:
     while True:
         header = _recv_exact(sock, 5)
         ftype, length = header[0], int.from_bytes(header[1:5], "big")
+        # pgw#1013 (§4.24, ABSENCE sweep): `length` is 4 attacker-supplied bytes
+        # off the control socket, so it may declare up to 4 GiB. The bound
+        # already exists — frames.MAX_FRAME_BYTES, enforced by BOTH ends of the
+        # normal path (frames.read_frame and FrameWriter.frame). This reader is
+        # hand-rolled for the boot-fatal ack and skipped it, so one route into
+        # the child had no ceiling while its siblings did.
+        #
+        # The docstring's claim that this is "bounded by the socket timeout"
+        # was wrong in a way worth naming: settimeout bounds each recv, not the
+        # accumulation, so a peer that dribbles bytes resets the clock forever.
+        if length > frames.MAX_FRAME_BYTES:
+            raise ValueError(
+                f"frame of {length} bytes exceeds {frames.MAX_FRAME_BYTES}")
         if length:
             _recv_exact(sock, length)
         if ftype == frames.T_BOOT_FATAL_ACK:
@@ -91,13 +104,17 @@ def _wait_boot_fatal_ack(sock: socket.socket) -> None:
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes:
-    buf = b""
+    # pgw#1013: accumulate into a bytearray, not `buf += chunk`. The old form
+    # reallocated and copied the whole buffer per chunk, so a large frame cost
+    # O(n^2) — the length bound above caps n, but quadratic copying at 128 MiB
+    # is still a stall, and there is no reason to pay it.
+    buf = bytearray()
     while len(buf) < n:
         chunk = sock.recv(n - len(buf))
         if not chunk:
             raise OSError("socket closed before the boot-fatal ack arrived")
-        buf += chunk
-    return buf
+        buf.extend(chunk)
+    return bytes(buf)
 
 
 def _ping_interval() -> float:

--- a/tests/test_boot_fatal_frame_bound_pgw1013.py
+++ b/tests/test_boot_fatal_frame_bound_pgw1013.py
@@ -1,0 +1,124 @@
+"""pgw#1013 (§4.24 absence sweep): the boot-fatal ack reader honours the frame
+bound its own module already enforces.
+
+`procsplit/frames.py` declares `MAX_FRAME_BYTES = 128 MiB` and BOTH ends of the
+normal path enforce it — `read_frame` refuses an oversized declaration and
+`FrameWriter.frame` refuses to emit one. `child._wait_boot_fatal_ack` is a
+hand-rolled reader for one message type, and it skipped the check: a 4-byte
+big-endian length off the control socket could declare up to 4 GiB, and the
+reader would sit there accumulating it.
+
+This is the shape the bounds census could not see. The bound EXISTS and is
+correctly stated; what was missing was its application at one site — so an
+inventory of bounds finds nothing wrong, and only an inventory of READ SITES
+does.
+
+Driven through a real `AF_UNIX` socket against the real reader — no mock, no
+monkeypatched constant.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+from gen_worker.procsplit import frames
+from gen_worker.procsplit.child import _recv_exact, _wait_boot_fatal_ack
+
+
+def _socketpair():
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    return a, b
+
+
+def _frame_header(ftype: int, length: int) -> bytes:
+    return bytes([ftype]) + length.to_bytes(4, "big")
+
+
+def test_oversized_declared_frame_is_refused_before_it_is_read():
+    """The runaway: a peer declares ~4 GiB on the control socket.
+
+    RED (before the fix): the reader loops in _recv_exact accumulating whatever
+    the peer sends, with no ceiling — the declared length is never compared to
+    anything.
+    """
+    ours, theirs = _socketpair()
+    try:
+        ours.settimeout(5.0)
+        # Declare the largest length the 4-byte field can express, then send a
+        # trickle. A correct reader refuses on the DECLARATION and never waits
+        # for the bytes.
+        theirs.sendall(_frame_header(frames.T_HELLO_REQ, 0xFFFFFFFF))
+        theirs.sendall(b"\x00" * 64)
+
+        with pytest.raises(ValueError, match="exceeds"):
+            _wait_boot_fatal_ack(ours)
+    finally:
+        ours.close()
+        theirs.close()
+
+
+def test_the_bound_is_the_module_s_own_constant_not_a_new_number():
+    """§4.24: one threat, one number.
+
+    The refusal must quote frames.MAX_FRAME_BYTES. If this site grew its own
+    constant, the two could drift and the sibling readers would disagree about
+    what a legal frame is.
+    """
+    ours, theirs = _socketpair()
+    try:
+        ours.settimeout(5.0)
+        theirs.sendall(_frame_header(frames.T_HELLO_REQ, frames.MAX_FRAME_BYTES + 1))
+        with pytest.raises(ValueError) as exc:
+            _wait_boot_fatal_ack(ours)
+        assert str(frames.MAX_FRAME_BYTES) in str(exc.value)
+    finally:
+        ours.close()
+        theirs.close()
+
+
+def test_a_legal_frame_still_passes_through_and_the_ack_is_seen():
+    """The bound must not have made the reader stricter than the protocol.
+
+    An unrelated frame ahead of the ack is legal (the docstring says so) and
+    must still be skipped, then the ack must terminate the loop.
+    """
+    ours, theirs = _socketpair()
+    try:
+        ours.settimeout(5.0)
+        payload = b"x" * 1024
+        theirs.sendall(_frame_header(frames.T_HELLO_REQ, len(payload)) + payload)
+        theirs.sendall(_frame_header(frames.T_BOOT_FATAL_ACK, 0))
+
+        _wait_boot_fatal_ack(ours)  # returns cleanly
+    finally:
+        ours.close()
+        theirs.close()
+
+
+def test_recv_exact_returns_bytes_and_accumulates_across_chunks():
+    """The O(n^2) `buf += chunk` became a bytearray; the contract must not move.
+
+    Callers index and compare the result, so it has to stay `bytes`.
+    """
+    ours, theirs = _socketpair()
+    try:
+        ours.settimeout(5.0)
+
+        def dribble():
+            for i in range(8):
+                theirs.sendall(bytes([i]) * 4)
+
+        t = threading.Thread(target=dribble, daemon=True)
+        t.start()
+        got = _recv_exact(ours, 32)
+        t.join(timeout=5)
+
+        assert isinstance(got, bytes)
+        assert len(got) == 32
+        assert got[:4] == b"\x00\x00\x00\x00"
+    finally:
+        ours.close()
+        theirs.close()

--- a/tests/test_unbounded_read_guard_pgw1013.py
+++ b/tests/test_unbounded_read_guard_pgw1013.py
@@ -1,0 +1,179 @@
+"""pgw#1013 / th#1662 — the ratchet under the absence sweep.
+
+The §4.24 bounds census enumerated bounds that EXIST and adjudicated each. It is
+blind by construction to a read site that needs a bound and has none, and it
+proved that by walking past two real ones in files it had already swept.
+
+`scripts/lint_unbounded_reads.py` is what stops the class returning. This file
+tests the guard itself, because a guard nobody tests is a guard that silently
+stops guarding — and this one is the only thing standing between the repo and a
+defect class that a full census could not see.
+
+The synthetic cases below are deliberately NOT drawn from the real tree: the
+guard must be provably correct on shapes that do not exist yet, or it only
+documents the past.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+GUARD = REPO / "scripts" / "lint_unbounded_reads.py"
+
+sys.path.insert(0, str(REPO / "scripts"))
+from lint_unbounded_reads import scan_file  # noqa: E402
+
+
+def _scan(src: str) -> list[str]:
+    """Run the guard's analyser over a synthetic module."""
+    return scan_file(REPO / "src" / "gen_worker" / "_synthetic.py", src)
+
+
+# --------------------------------------------------------------------------
+# The guard holds on the real tree
+# --------------------------------------------------------------------------
+
+def test_guard_passes_on_the_real_tree():
+    """Every external length feeding a read in src/ is bounded or justified.
+
+    This is the assertion the sweep exists to make true, run against the
+    shipping code rather than a fixture.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(GUARD)], capture_output=True, text=True, cwd=REPO)
+    assert proc.returncode == 0, (
+        "the unbounded-read guard found a regression:\n"
+        f"{proc.stdout}\n{proc.stderr}")
+
+
+# --------------------------------------------------------------------------
+# It catches the shape the census could not see
+# --------------------------------------------------------------------------
+
+def test_catches_struct_unpack_length_sizing_a_read():
+    """The exact shape of both original specimens."""
+    findings = _scan(
+        "import struct, json\n"
+        "def parse(f):\n"
+        "    (n,) = struct.unpack('<Q', f.read(8))\n"
+        "    return json.loads(f.read(n))\n"
+    )
+    assert len(findings) == 1, findings
+    assert "`n`" in findings[0]
+    assert "parse()" in findings[0]
+
+
+def test_catches_int_from_bytes_length_sizing_a_read():
+    """The other prefix idiom in this repo."""
+    findings = _scan(
+        "import json\n"
+        "def parse(f):\n"
+        "    header_len = int.from_bytes(f.read(8), 'little')\n"
+        "    return json.loads(f.read(header_len))\n"
+    )
+    assert len(findings) == 1, findings
+    assert "`header_len`" in findings[0]
+
+
+def test_catches_subscripted_unpack():
+    findings = _scan(
+        "import struct\n"
+        "def parse(f):\n"
+        "    n = struct.unpack('<Q', f.read(8))[0]\n"
+        "    return f.read(n)\n"
+    )
+    assert len(findings) == 1, findings
+
+
+# --------------------------------------------------------------------------
+# It accepts BOTH answers §4.24 allows — a bound, or a stated reason
+# --------------------------------------------------------------------------
+
+def test_sanctioned_validator_satisfies_the_guard():
+    findings = _scan(
+        "import struct, json\n"
+        "from .models.safetensors_header import header_len_ok\n"
+        "def parse(f):\n"
+        "    (n,) = struct.unpack('<Q', f.read(8))\n"
+        "    if not header_len_ok(n):\n"
+        "        raise ValueError('bad')\n"
+        "    return json.loads(f.read(n))\n"
+    )
+    assert findings == []
+
+
+def test_justification_comment_satisfies_the_guard():
+    """§4.24 asks for a bound OR a stated reason none is needed.
+
+    A guard that accepted only the bound would push honest exemptions into
+    silence — or worse, into a bound added just to quiet the linter, which is
+    the 'defence in depth' anti-pattern the ruling rejects.
+    """
+    findings = _scan(
+        "import struct, json\n"
+        "def parse(f):\n"
+        "    (n,) = struct.unpack('<Q', f.read(8))\n"
+        "    # bound-justified: n was written by this process moments ago.\n"
+        "    return json.loads(f.read(n))\n"
+    )
+    assert findings == []
+
+
+def test_justification_may_sit_a_few_lines_above():
+    findings = _scan(
+        "import struct, json\n"
+        "def parse(f):\n"
+        "    (n,) = struct.unpack('<Q', f.read(8))\n"
+        "    # bound-justified: a real reason usually needs more than one line,\n"
+        "    # so the guard reads the comment block above the read too.\n"
+        "    #\n"
+        "    payload = f.read(n)\n"
+        "    return json.loads(payload)\n"
+    )
+    assert findings == []
+
+
+def test_a_distant_justification_does_NOT_carry():
+    """The escape hatch must not be inheritable.
+
+    If a justification written for one read silently excused every later read in
+    the same function, the hatch would widen itself over time — which is how an
+    exemption mechanism becomes a blanket.
+    """
+    body = (
+        "import struct, json\n"
+        "def parse(f):\n"
+        "    (n,) = struct.unpack('<Q', f.read(8))\n"
+        "    # bound-justified: this excuse belongs to the read directly below.\n"
+        "    first = f.read(n)\n"
+        + "    x = 1\n" * 20
+        + "    second = f.read(n)\n"
+        "    return first, second\n"
+    )
+    findings = _scan(body)
+    assert len(findings) == 1, findings
+    assert "`n`" in findings[0]
+
+
+# --------------------------------------------------------------------------
+# It stays quiet where it should
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("src", [
+    # A literal length is not external input.
+    "def parse(f):\n    return f.read(8)\n",
+    # A length that never sizes anything is not this guard's business.
+    "import struct\n"
+    "def parse(f):\n"
+    "    (n,) = struct.unpack('<Q', f.read(8))\n"
+    "    return n > 0\n",
+    # A name that was never a length prefix.
+    "def parse(f, n):\n    return f.read(n)\n",
+])
+def test_no_false_positive(src: str):
+    assert _scan(src) == []


### PR DESCRIPTION
The §4.24 census (pgw#973) enumerated every numeric bound and adjudicated each. **That procedure can only inspect bounds that EXIST**, so "~383 bounds counted, 97% hardcoded" was never evidence that every site needing one has one — and it walked past two unguarded safetensors readers in files it had already swept. This is the inverse sweep. Sibling: **th#1662** (merged as `69c7b5cb`).

## The guard

`scripts/lint_unbounded_reads.py`, wired into `fast gates` and the Taskfile. A length read off external bytes (`struct.unpack` / `int.from_bytes`) may not size a read until either a sanctioned validator bounds it, **or** a `# bound-justified:` comment states why none is needed.

Two answers deliberately: §4.24 asks for a bound **or** a stated reason. A guard accepting only the bound would push honest exemptions into silence — or worse, into a bound added purely to quiet the linter, which is the "defence in depth" anti-pattern the ruling rejects.

**It earned its keep on the first run**, finding a *third* unguarded reader (`convert/writer.deshard_indexed_safetensors`) in a file the census had swept and that I had re-verified by hand a session earlier.

**And then it corrected me.** My first instinct was to bound that read. Tracing the provenance showed `merged` is written by `merge_safetensors_by_offset` in the same call, from shard headers *already* refused by `header_len_ok` — bounding it would have bounded our own output, not an attacker. It carries a `# bound-justified:` comment instead. The escape hatch used for exactly its intended purpose, on the first case that needed it.

## The defect

`procsplit/frames.py` declares `MAX_FRAME_BYTES = 128 MiB` and **both ends of the normal path enforce it** (`read_frame`, `FrameWriter.frame`). `child._wait_boot_fatal_ack` hand-rolls a reader for one message type and never compared the 4-byte declared length to anything — up to 4 GiB, accumulated with a quadratic `buf += chunk`.

The bound existed and one site skipped it. **A bounds census sees a correctly-stated constant and moves on** — this is the class in one sentence.

Its docstring claimed the read was *"bounded by the socket timeout the caller set"*, which is wrong in a way worth naming: `settimeout` bounds each `recv`, not the accumulation, so a peer that dribbles resets the clock forever.

RED-verified through a real `AF_UNIX` socketpair — without the check the reader hangs to the timeout. `_recv_exact` now accumulates into a `bytearray`.

## Tests

- **11 guard tests**, including that a *distant* justification does **not** carry — the escape hatch must not be inheritable, or it widens itself into a blanket over time.
- **4 real-socket tests** for the frame bound, asserting the refusal quotes `frames.MAX_FRAME_BYTES` rather than a new number, and that a legal frame ahead of the ack is still skipped.

## Gates

Python 3.12. mypy clean (237 files) · `lint_http_timeouts` / `lint_unreached_surface` / `lint_config_reads` / `lint_unbounded_reads` all exit 0 · full `tests/` suite running. Commit signature-verified. Strictly local — no deploys, no pods.

## Deliberately not here

The sweep's full findings are recorded in pgw#1013. The largest residual class is **"check after the loop, not inside it"**: four downloaders validate size/digest only once the stream ends, while three siblings check during it — same threat, two verdicts. Most of those files are owned by live lanes right now (`972-chunk-resume`, `991-blob-digest-qualified`, `1010-dynamo-no-publish`), so they are tabled with owners rather than swept in a cross-lane diff.