### PR TITLE
pgw#1019: the branch-dtype fallback REFUSES, and the compute_dtype census over every quantized leaf

### DIFF
--- a/changelog.d/pgw1019.md
+++ b/changelog.d/pgw1019.md
@@ -1,0 +1,27 @@
+### Changed
+
+- **`adapter_fidelity.branch_compute_dtype` REFUSES instead of defaulting to
+  bf16 (pgw#1019, closing pgw#1015's open items).** A LoRA branch buffer
+  allocated on a guess is the pgw#1015 defect: a bias-free fp8 layer silently
+  took bf16 while its bias-bearing siblings in the SAME module set took
+  float32, and the first branch-bearing forward died inside torch on `expected
+  mat1 and mat2 to have the same dtype`. The branch-capable universe is closed
+  — `w8a8_lora.branch_modules` admits `_Fp8ScaledLinear` and modules whose
+  `fp8_storage.structural_base` is `nn.Linear`/`nn.Conv2d` — and every member
+  of it can state a compute dtype (a plain leaf via its weight, a pgw#727
+  fp8-storage leaf via the `compute_dtype` its own `forward` upcasts to,
+  `_Fp8ScaledLinear` via pgw#1015's record). So a default could only ever be a
+  leaf that forgot, and it now raises
+  `adapter_fidelity.UnknownComputeDtypeError` naming the fix. A LIVE branch
+  buffer still outranks the rule, so `branch_grid_dtype` is unchanged for
+  armed modules.
+
+### Fixed
+
+- **Every quantized leaf records its `compute_dtype` (pgw#1019 sweep).**
+  `_W4A4Linear`, `_SvdqLinear`, `_SvdqFusedLinear` and `_AwqPackedLinear` took
+  the parameter, spent it on optional buffers, and kept no record — so a
+  bias-free `_W4A4Linear` lost the fact entirely. None was a live bug (none is
+  branch-capable today), but all four carried pgw#1015's recoverability cliff.
+  A census test now discovers leaf classes by accessor, so a future leaf that
+  accepts `compute_dtype` and drops it fails CI rather than a pod.

--- a/src/gen_worker/models/adapter_fidelity.py
+++ b/src/gen_worker/models/adapter_fidelity.py
@@ -177,6 +177,30 @@ def _dtype_name(dtype: Any) -> str:
     return str(dtype).replace("torch.", "")
 
 
+class UnknownComputeDtypeError(RuntimeError):
+    """A branch-capable module cannot state the dtype its arithmetic lands in.
+
+    pgw#1019's ruling on pgw#1015. The branch-capable universe is CLOSED —
+    ``w8a8_lora.branch_modules`` admits exactly ``_Fp8ScaledLinear`` and
+    modules whose ``fp8_storage.structural_base`` is ``nn.Linear``/
+    ``nn.Conv2d`` — and every member of it can state a compute dtype:
+
+    * a plain ``nn.Linear``/``nn.Conv2d`` computes in its weight's dtype, by
+      definition;
+    * a pgw#727 fp8-storage leaf records ``compute_dtype`` at restructure
+      (``fp8_storage.restructure_fp8_storage``), because its own ``forward``
+      upcasts to it;
+    * ``_Fp8ScaledLinear`` records it in ``__init__`` (pgw#1015).
+
+    So there is no dtype-less caller left, and a default here can only be a
+    module that FORGOT to record the fact — which is exactly what pgw#1015
+    was: a bias-free fp8 layer silently taking bf16 while its bias-bearing
+    siblings in the same module set took float32, and the first
+    branch-bearing forward dying on ``expected mat1 and mat2 to have the same
+    dtype``. "Nobody could tell" is not "bf16".
+    """
+
+
 def branch_compute_dtype(mod: Any) -> Any:
     """The dtype a branch buffer is allocated in for this module.
 
@@ -185,6 +209,10 @@ def branch_compute_dtype(mod: Any) -> Any:
     tensors compute in the module's COMPUTE dtype, never its storage dtype: on
     the fp8-storage lane weight AND bias rest in fp8, and a pgw#727 leaf
     declares ``compute_dtype`` for exactly this question.
+
+    REFUSES rather than defaulting (pgw#1019) — see
+    :class:`UnknownComputeDtypeError` for why every legitimate caller can
+    answer.
     """
     import torch
 
@@ -198,7 +226,19 @@ def branch_compute_dtype(mod: Any) -> Any:
         # weight is skipped here by the membership test itself.
         if cand in compute:
             return cand
-    return torch.bfloat16
+    raise UnknownComputeDtypeError(
+        f"{type(mod).__name__} states no compute dtype: `compute_dtype` is "
+        f"{getattr(mod, 'compute_dtype', None)!r}, weight is "
+        f"{_dtype_name(getattr(weight, 'dtype', None))}, bias is "
+        f"{_dtype_name(getattr(bias, 'dtype', None))} — none of them a "
+        "compute dtype (float16/bfloat16/float32). A LoRA branch allocated "
+        "on a guess is the pgw#1015 defect: bias-bearing and bias-free "
+        "layers of one module set land in DIFFERENT dtypes and the first "
+        "branch-bearing forward dies inside torch. FIX: record it — "
+        f"`self.compute_dtype = compute_dtype` in {type(mod).__name__}"
+        ".__init__ (every quantized leaf in gen_worker.models already takes "
+        "the parameter), or set it on the instance where the lane is armed, "
+        "the way `fp8_storage.restructure_fp8_storage` does.")
 
 
 def branch_grid_dtype(mod: Any) -> Any:
@@ -619,6 +659,7 @@ __all__ = [
     "PHASE_DEGRADED", "PHASE_REFUSED", "PATH_BRANCH", "PATH_FUSE",
     "VERDICT_DEGRADED", "VERDICT_DESTROYED", "VERDICT_HEALTHY",
     "AdapterSurvival", "ModuleSurvival", "TargetGrid",
+    "UnknownComputeDtypeError",
     "branch_compute_dtype", "branch_grid_dtype", "evaluate_branch",
     "evaluate_fuse", "gate",
     "gate_branch", "gate_fuse", "grid_of_module", "quantizer_for",

--- a/src/gen_worker/models/svdq_awq_packed.py
+++ b/src/gen_worker/models/svdq_awq_packed.py
@@ -166,6 +166,8 @@ def _build_awq_linear_class() -> type:
         def __init__(self, in_features: int, out_features: int, *,
                      bias: bool, compute_dtype: Any) -> None:
             super().__init__()
+            # pgw#1019: record it (twin of _SvdqLinear).
+            self.compute_dtype = compute_dtype
             self.in_features = int(in_features)
             self.out_features = int(out_features)
             if not awq_packed_supported(out_features, in_features):

--- a/src/gen_worker/models/svdq_fused.py
+++ b/src/gen_worker/models/svdq_fused.py
@@ -578,6 +578,8 @@ def _build_fused_linear_class() -> type:
                      rank: int, bias: bool, compute_dtype: Any,
                      per_channel_scale: bool, smooth: bool) -> None:
             super().__init__()
+            # pgw#1019: record it (twin of _SvdqLinear).
+            self.compute_dtype = compute_dtype
             self.in_features = int(in_features)
             self.out_features = int(out_features)
             self.rank = int(rank)

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -159,6 +159,10 @@ def _build_svdq_linear_class() -> type:
                      rank: int, bias: bool, compute_dtype: Any,
                      per_channel_scale: bool, smooth: bool) -> None:
             super().__init__()
+            # pgw#1019: record it — the packed weight is uint8 and every
+            # compute-dtype tensor here (smooth_factor, proj_*, bias) is
+            # optional, so a rank-0 bias-free instance states it nowhere else.
+            self.compute_dtype = compute_dtype
             self.in_features = int(in_features)
             self.out_features = int(out_features)
             self.rank = int(rank)

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -383,6 +383,10 @@ def _build_module_class() -> type:
                      static_input_scale: bool,
                      pre_quant_scale: bool = False) -> None:
             super().__init__()
+            # pgw#1019: a quantized leaf is the ONLY thing that knows its
+            # compute dtype — the weight is uint8 and the bias is optional,
+            # so bias-free instances leave no trace of it. Record it.
+            self.compute_dtype = compute_dtype
             self.in_features = int(in_features)
             self.out_features = int(out_features)
             if in_features % _K_ALIGN or out_features % _N_ALIGN:

--- a/tests/test_compute_dtype_sweep_pgw1019.py
+++ b/tests/test_compute_dtype_sweep_pgw1019.py
@@ -1,0 +1,192 @@
+"""pgw#1019 — the pgw#1015 defect class, closed at both ends.
+
+pgw#1015 was one leaf (`_Fp8ScaledLinear`) accepting `compute_dtype` and
+throwing it away, so `adapter_fidelity.branch_compute_dtype` fell back to
+bf16 on bias-free layers while their bias-bearing siblings in the SAME module
+set got float32 — two dtypes in one module set, and the first branch-bearing
+forward dying inside torch.
+
+Two halves here, and neither is a mock: every module below is the real class
+the serving lanes materialize, built through its real accessor.
+
+1. THE CONSUMER REFUSES. `branch_compute_dtype` no longer defaults. The
+   branch-capable universe (`w8a8_lora.branch_modules`) is closed and every
+   member of it can state a compute dtype, so a default could only ever be a
+   leaf that forgot to record one.
+
+2. THE PRODUCERS RECORD. Every quantized leaf in `gen_worker.models` takes a
+   `compute_dtype` and now stores it, checked bias-free — the shape in which
+   the fact is recoverable from nothing else. Discovery is by accessor, so a
+   NEW leaf that skips it fails here instead of on a pod.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+from gen_worker.models import adapter_fidelity as af  # noqa: E402
+from gen_worker.models.fp8_storage import (  # noqa: E402
+    restructure_fp8_storage,
+)
+from gen_worker.models.svdq_awq_packed import awq_packed_linear_class  # noqa: E402
+from gen_worker.models.svdq_fused import svdq_fused_linear_class  # noqa: E402
+from gen_worker.models.svdq_native import svdq_linear_class  # noqa: E402
+from gen_worker.models.w4a4 import w4a4_linear_class  # noqa: E402
+from gen_worker.models.w8a8 import fp8_scaled_linear_class  # noqa: E402
+from gen_worker.models.w8a8_lora import alloc_branch_buffers  # noqa: E402
+
+#: The lane dtype under test is deliberately NOT bf16: bf16 is what the old
+#: fallback returned, so a bf16 lane cannot tell a recorded fact from a guess.
+#: This is why pgw#1015 was invisible on sdxl for as long as it was.
+LANE = torch.float32
+
+#: The census, as constructor calls. Every leaf is built BIAS-FREE and with
+#: every optional compute-dtype tensor absent — the shape in which nothing but
+#: an explicit record can answer. `dims` satisfy each lane's own alignment
+#: contract (fp4 K/N alignment, awq out%16/in%128, fused rank%16).
+LEAVES = {
+    "_Fp8ScaledLinear": (fp8_scaled_linear_class, dict(
+        in_features=128, out_features=128, bias=False, compute_dtype=LANE,
+        static_input_scale=False, gemm_mode="pertensor")),
+    "_W4A4Linear": (w4a4_linear_class, dict(
+        in_features=128, out_features=128, bias=False, compute_dtype=LANE,
+        static_input_scale=False, pre_quant_scale=False)),
+    "_SvdqLinear": (svdq_linear_class, dict(
+        in_features=128, out_features=128, rank=0, bias=False,
+        compute_dtype=LANE, per_channel_scale=False, smooth=False)),
+    "_SvdqFusedLinear": (svdq_fused_linear_class, dict(
+        in_features=128, out_features=128, rank=16, bias=False,
+        compute_dtype=LANE, per_channel_scale=False, smooth=False)),
+    "_AwqPackedLinear": (awq_packed_linear_class, dict(
+        in_features=128, out_features=128, bias=False, compute_dtype=LANE)),
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. The consumer refuses
+# ---------------------------------------------------------------------------
+
+
+def test_a_leaf_that_states_no_compute_dtype_is_refused_by_name() -> None:
+    """The pgw#1015 module, exactly as it shipped before b03b6703: a real
+    `_Fp8ScaledLinear` on an fp32 lane with no bias and no recorded fact. It
+    used to answer `torch.bfloat16` — silently, and wrongly."""
+    cls, kwargs = LEAVES["_Fp8ScaledLinear"]
+    mod = cls()(**kwargs)
+    del mod.compute_dtype  # the pre-pgw#1015 state of this very class
+
+    with pytest.raises(af.UnknownComputeDtypeError) as excinfo:
+        af.branch_compute_dtype(mod)
+
+    msg = str(excinfo.value)
+    # The refusal names the module, what it was asked, and the FIX — a
+    # refusal that does not say what to do is a different failure.
+    assert "_Fp8ScaledLinear" in msg
+    assert "float8_e4m3fn" in msg          # what the weight actually holds
+    assert "self.compute_dtype = compute_dtype" in msg
+    assert "pgw#1015" in msg
+
+
+def test_the_allocator_refuses_too_because_it_shares_the_definition() -> None:
+    """`alloc_branch_buffers` and the pgw#794 gate read ONE definition, so
+    the refusal reaches the allocator without a second edit."""
+    cls, kwargs = LEAVES["_Fp8ScaledLinear"]
+    mod = cls()(**kwargs)
+    del mod.compute_dtype
+    with pytest.raises(af.UnknownComputeDtypeError):
+        alloc_branch_buffers(mod, 16)
+    with pytest.raises(af.UnknownComputeDtypeError):
+        af.grid_of_module(mod, path=af.PATH_BRANCH)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_every_branch_capable_kind_answers_without_the_fallback(dtype) -> None:
+    """The closed universe `w8a8_lora.branch_modules` admits, on every compute
+    dtype — this is the evidence the refusal is safe. Nothing here relies on
+    the removed default."""
+    plain = nn.Linear(8, 8, dtype=dtype)
+    assert af.branch_compute_dtype(plain) is dtype
+
+    conv = nn.Conv2d(4, 4, 3, dtype=dtype)
+    assert af.branch_compute_dtype(conv) is dtype
+
+    # A pgw#727 fp8-storage leaf: weight AND bias rest in fp8, so ONLY the
+    # recorded fact can answer. This is the case the fallback was written for
+    # and the case that proves the record already exists.
+    leaf = nn.Linear(8, 8, dtype=dtype)
+    holder = nn.Module()
+    holder.inner = leaf
+    restructure_fp8_storage(holder, storage_dtype=torch.float8_e4m3fn,
+                            compute_dtype=dtype)
+    assert leaf.weight.dtype is torch.float8_e4m3fn
+    assert leaf.bias.dtype is torch.float8_e4m3fn
+    assert af.branch_compute_dtype(leaf) is dtype
+
+    scaled = fp8_scaled_linear_class()(
+        128, 128, bias=False, compute_dtype=dtype,
+        static_input_scale=False, gemm_mode="pertensor")
+    assert af.branch_compute_dtype(scaled) is dtype
+
+
+def test_a_live_branch_buffer_still_outranks_the_rule() -> None:
+    """`branch_grid_dtype` reads the destination first; only the unarmed case
+    falls through to the (now refusing) rule."""
+    lin = nn.Linear(8, 8, dtype=torch.bfloat16)
+    alloc_branch_buffers(lin, 16)
+    lin.lora_a = lin.lora_a.to(torch.float8_e4m3fn)
+    lin.lora_b = lin.lora_b.to(torch.float8_e4m3fn)
+    assert af.branch_grid_dtype(lin) is torch.float8_e4m3fn
+
+
+# ---------------------------------------------------------------------------
+# 2. The producers record — the sweep, as an invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(LEAVES))
+def test_every_quantized_leaf_records_its_compute_dtype(name: str) -> None:
+    cls, kwargs = LEAVES[name]
+    mod = cls()(**kwargs)
+    assert type(mod).__name__ == name
+    assert mod.bias is None, "the census shape is bias-free on purpose"
+    assert mod.compute_dtype is LANE
+    assert af.branch_compute_dtype(mod) is LANE
+
+
+def test_the_census_covers_every_leaf_accessor_in_models() -> None:
+    """Discovery, so a NEW quantized leaf cannot be added without a row.
+
+    Every `*_class()` accessor under `gen_worker.models` that returns a
+    module class taking `compute_dtype` must appear in :data:`LEAVES`.
+    """
+    import gen_worker.models as models_pkg
+
+    found: dict[str, str] = {}
+    for info in pkgutil.iter_modules(models_pkg.__path__):
+        mod = importlib.import_module(f"{models_pkg.__name__}.{info.name}")
+        for fname, fn in vars(mod).items():
+            if not (fname.endswith("_class") and inspect.isfunction(fn)):
+                continue
+            if inspect.signature(fn).parameters:
+                continue
+            try:
+                cls = fn()
+            except Exception:  # an accessor needing a live card is not a leaf
+                continue
+            if not (inspect.isclass(cls) and issubclass(cls, nn.Module)):
+                continue
+            if "compute_dtype" in inspect.signature(cls.__init__).parameters:
+                found[cls.__name__] = f"{info.name}.{fname}"
+
+    assert set(found) == set(LEAVES), (
+        f"census drift: {sorted(set(found) - set(LEAVES))} accept "
+        f"compute_dtype but are not in LEAVES ({found}); "
+        f"{sorted(set(LEAVES) - set(found))} are listed but no longer exist"
+    )


### PR DESCRIPTION
Closes pgw#1015's two open items. Files pgw#1020 (found, not fixed).

## A. The bf16 FALLBACK is a defect class, so it refuses

`adapter_fidelity.branch_compute_dtype` no longer defaults. **Decided by survey, not by taste.** Its only callers are `w8a8_lora.alloc_branch_buffers` and `adapter_fidelity.branch_grid_dtype` (→ `grid_of_module` → `evaluate_branch`), and both are fed from ONE selector — `w8a8_lora.branch_modules`, which admits exactly `_Fp8ScaledLinear` and modules whose `fp8_storage.structural_base` is `nn.Linear`/`nn.Conv2d`. That universe is closed, and every member of it can state a compute dtype:

| branch-capable kind | how it states its compute dtype |
|---|---|
| plain `nn.Linear` / `nn.Conv2d` | its weight's dtype — a plain module computes in it by definition |
| pgw#727 fp8-storage punned leaf | `leaf.compute_dtype`, set by `restructure_fp8_storage`; its own `forward` upcasts to it, so it cannot be missing |
| `_Fp8ScaledLinear` | `self.compute_dtype`, recorded since pgw#1015 |

The two lanes that could have supplied a dtype-less module do not: the other quantized leaves are not branch targets at all (an adapter naming one fails typed in `map_adapter`), and a cast TEXT ENCODER — the one place plain `nn.Linear`s rest in fp8 with fp8 biases — is refused outright for adapters by `utils.lora._reject_te_keys_on_cast_te` (ie#374).

So a default could only ever be a leaf that forgot. `UnknownComputeDtypeError` carries the named fix. A LIVE branch buffer still outranks the rule, so `branch_grid_dtype` is unchanged for armed modules.

## B. THE SWEEP — the census, closed

AST diff of constructor params against attributes assigned in `__init__`, over every class in `src/gen_worker/` that registers buffers or parameters. **Exactly five quantized leaves exist**; four dropped `compute_dtype`.

| leaf | file | consumed at ctor for | recorded before | recoverable post-hoc? | external consumer today | action |
|---|---|---|---|---|---|---|
| `_Fp8ScaledLinear` | `models/w8a8.py:391` | `bias` (opt) | **YES** (pgw#1015) | no when bias-free | **YES** — `branch_compute_dtype` | already fixed |
| `Fp8Storage*` punned | `models/fp8_storage.py:333` | n/a — set at restructure | **YES** | no (weight AND bias fp8) | **YES** — own `forward` | correct already |
| `_W4A4Linear` | `models/w4a4.py:381` | `pre_quant_scale` (opt), `bias` (opt) | NO | **NO — no trace at all** | none (not branch-targeted) | **RECORD** |
| `_SvdqLinear` | `models/svdq_native.py:158` | `smooth_factor` (opt), `proj_*` (rank>0), `bias` (opt) | NO | only rank > 0 | none | **RECORD** |
| `_SvdqFusedLinear` | `models/svdq_fused.py:577` | `smooth_factor` (opt), `proj_*` (always) | NO | via `proj_down` | none | **RECORD** |
| `_AwqPackedLinear` | `models/svdq_awq_packed.py:166` | `wscales`/`wzeros` (always), `bias` (opt) | NO | via `wscales` | none | **RECORD** |

**The honest verdict on the four:** `compute_dtype` DOES reach a consumer in each — the buffer allocation — so none is a live wrong-dtype bug today, because none is branch-capable. What each carries is pgw#1015's *recoverability cliff*: the fact exists only for the length of `__init__`, and a bias-free `_W4A4Linear` loses it entirely.

## C. Every OTHER constructor param in those leaves REACHES

`static_input_scale` → `self.input_scale is not None` (read by `compile_cache.execution_contract` to stamp `activation=static`); `smooth` → `self.smooth_factor is not None` (read by both forwards). **No second dropped parameter exists.**

## RED

Measured on the **fp32** lane — bf16 cannot tell a record from a guess, which is why this was invisible on sdxl:

```
pre-pgw#1015 _Fp8ScaledLinear (bias-free, fp32) -> torch.bfloat16   <-- silent, and WRONG
_W4A4Linear            attr=<ABSENT>            -> torch.bfloat16
_SvdqLinear(rank=0)    attr=<ABSENT>            -> torch.bfloat16
_SvdqFusedLinear       attr=<ABSENT>            -> torch.bfloat16
_AwqPackedLinear       attr=<ABSENT>            -> torch.bfloat16
```

The new suite is **6 failed / 6 passed against `origin/master`** and **12 passed here** — same test file, run against a pristine `origin/master` tree. Its last row DISCOVERS leaf classes by accessor, so a future leaf that accepts `compute_dtype` and drops it fails CI instead of a pod.

## Found, NOT fixed — pgw#1020

`loading._gemm_param_dtypes` selects by `isinstance(leaf, (nn.Linear, nn.Conv*))`, and all five quantized leaves subclass `nn.Module` directly, so **pgw#683's mixed-compute-dtype guard cannot see a quantized denoiser at all**. Measured cardless: a w8a8 fp16 denoiser inside a bf16 composition yields `{}` and PASSES. Newly fixable because of (B) — but widening a fail-closed load-time refusal inside an unrelated PR is how a lane ships a surprise.

## Gates, run locally

mypy clean (237 files) · ruff clean · http-timeout / unreached-surface / config-read guards clean · `tests/` **3537 passed, 37 skipped, 1 xfailed** · `tests_v2/` **21 passed**