### PR TITLE
pgw#1021: the arm gate accepts the pod's own ORG, so both layers apply one rule

### DIFF
--- a/changelog.d/pgw1021.md
+++ b/changelog.d/pgw1021.md
@@ -1,0 +1,22 @@
+- **pgw#1021 (twin of th#1680): the arm gate and the hub's listing now apply ONE rule.**
+  pgw#1008 accepted `platform` tier or the same ENDPOINT; the hub's `filterCellCheckpoints`
+  accepted `platform` tier or the same ORG. The worker was stricter, so nothing unsafe passed —
+  but an org running two endpoints on one family was shown its own cell by the listing,
+  downloaded it, and was refused at arm: a wasted download plus a full cold mint, and a
+  `publisher_untrusted` that reads like an attack when it is the platform disagreeing with
+  itself. pgw#1008 implemented Paul's ruling literally because the worker had **no way to name
+  its own org**; th#1680 stamps `cell_read_org_id` on the same th#1335 grant.
+- `refuse_untrusted_publisher` now accepts `platform` tier, **or** the same owning endpoint,
+  **or** the same publisher org — with BOTH org values required non-empty, because an
+  empty-equals-empty match is the vacuous-guard shape this module refuses everywhere else.
+- **No wire change.** `publisher_org_id` already shipped in `cell-receipt-v2`, so
+  `RECEIPT_VERSION` does not move and this is additive on the GRANT only. An old SDK ignores the
+  new claim; a new SDK against a pre-th#1680 hub finds it absent and falls back to endpoint-only.
+  **Both skew directions degrade to STRICTER, never wider** — no coupled cut, unlike th#1678.
+- **The durable half is an anti-drift table.** `TH1680_ADOPTION_TABLE` (12 rows of
+  tier × publisher-org × viewer-org → verdict, one stated reason each) is the twin of tensorhub's
+  `internal/authz/cell_adoption_table_th1680_test.go`, and both layers are checked against it. A
+  second test guards the table itself: it fails if the rows ever become all-adoptable or
+  all-refused, and it pins the row count so a row added in one repo and not the other is caught.
+  The drift this issue fixes was possible only because each layer carried its own prose copy of
+  the rule.

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -181,8 +181,8 @@ def _normalize_publisher_tier(raw: object) -> str:
     return CELL_PUBLISHER_TIER_ORG
 
 
-def _self_endpoint_id(cfg: "_Config") -> str:
-    """The endpoint THIS pod serves, read out of the hub-issued worker JWT.
+def _self_grant_claim(cfg: "_Config", name: str) -> str:
+    """One hub-stamped cell-read grant claim, read out of our OWN worker JWT.
 
     The hub stamps ``cell_read_endpoint_id`` on the cell-read grant (th#1335 +
     th#1657) precisely so both ends of the exchange can name the viewer. Reading
@@ -209,14 +209,42 @@ def _self_endpoint_id(cfg: "_Config") -> str:
         return ""
     if not isinstance(payload, dict):
         return ""
-    return str(payload.get("cell_read_endpoint_id") or "").strip()
+    return str(payload.get(name) or "").strip()
 
 
-def refuse_untrusted_publisher(receipt: Receipt, self_endpoint_id: str) -> None:
+def _self_endpoint_id(cfg: "_Config") -> str:
+    """The endpoint this pod serves (th#1657)."""
+    return _self_grant_claim(cfg, "cell_read_endpoint_id")
+
+
+def _self_org_id(cfg: "_Config") -> str:
+    """The ORG that owns this pod's endpoint (th#1680).
+
+    Absent on a hub older than th#1680, and absent when the hub could not
+    resolve the org — both of which fall back to endpoint-only matching, i.e.
+    exactly pgw#1008's behaviour. Never wider.
+    """
+    return _self_grant_claim(cfg, "cell_read_org_id")
+
+
+def refuse_untrusted_publisher(
+    receipt: Receipt, self_endpoint_id: str, self_org_id: str = "",
+) -> None:
     """Raise unless this pod may adopt ``receipt``'s cell (th#1657).
 
-    THE RULE, and it is Paul's ruling verbatim: a cell must have come from THIS
-    endpoint, or from a publisher the platform vouches for.
+    THE RULE: a cell must have come from THIS endpoint, from THIS pod's OWN ORG,
+    or from a publisher the platform vouches for.
+
+    Paul's ruling is literally endpoint-scoped (*"must have come from endpoint-A
+    itself, or from a publisher that is us or a trusted party"*) and pgw#1008
+    implemented exactly that — because the worker had no way to name its own
+    org. th#1680 stamps ``cell_read_org_id`` on the grant, and the ORG is the
+    rule the hub's listing has applied all along
+    (``authz.CellAdoptable``). Until now the two layers disagreed: the listing
+    showed an org its own cell from a sibling endpoint, and this function
+    refused it, costing a wasted download plus a full cold mint and emitting a
+    ``publisher_untrusted`` that reads like an attack when it is the platform
+    disagreeing with itself.
 
     THREAT: cross-tenant native-code execution. The artifact is a ``.so`` this
     process is about to ``dlopen``. Nothing else prevents it — the digest proves
@@ -237,19 +265,34 @@ def refuse_untrusted_publisher(receipt: Receipt, self_endpoint_id: str) -> None:
         return
     owner = str(receipt.owning_endpoint_id or "").strip()
     mine = str(self_endpoint_id or "").strip()
-    if not owner:
+    owner_org = str(receipt.publisher_org_id or "").strip()
+    my_org = str(self_org_id or "").strip()
+
+    # Same endpoint: the narrowest match, and the only one a pre-th#1680 hub can
+    # support.
+    if owner and mine and owner == mine:
+        return
+    # Same org (th#1680). BOTH sides must be non-empty: an empty-equals-empty
+    # match is the vacuous-guard shape this module already refuses elsewhere —
+    # two cells neither of which can be attributed must not match each other.
+    if owner_org and my_org and owner_org == my_org:
+        return
+
+    if not owner and not owner_org:
         raise ReceiptError(
             "publisher_untrusted",
-            "org-tier receipt names no owning endpoint, so no pod may adopt it")
-    if not mine:
+            "org-tier receipt names neither an owning endpoint nor a publisher "
+            "org, so no pod may adopt it")
+    if not mine and not my_org:
         raise ReceiptError(
             "publisher_untrusted",
-            "this pod cannot name its own endpoint (no cell_read_endpoint_id on "
-            "the worker credential), so it may adopt platform-tier cells only")
-    if owner != mine:
-        raise ReceiptError(
-            "publisher_untrusted",
-            f"cell was minted for endpoint {owner} and this pod serves {mine}")
+            "this pod cannot name its own endpoint or org (no cell_read_* claim "
+            "on the worker credential), so it may adopt platform-tier cells only")
+    raise ReceiptError(
+        "publisher_untrusted",
+        f"cell was minted for endpoint {owner or '<unnamed>'} "
+        f"(org {owner_org or '<unnamed>'}) and this pod serves "
+        f"{mine or '<unnamed>'} (org {my_org or '<unnamed>'})")
 
 
 def _rsa_key_from_jwk(jwk: Mapping[str, object]) -> Optional[rsa.RSAPublicKey]:
@@ -601,7 +644,7 @@ def verify_delivered_artifact(artifact: Path, family: str) -> Receipt:
     # the signature — the tier is only meaningful once the claims are proven —
     # and deliberately before the return, because the caller's next act is to
     # arm the cell and dlopen it.
-    refuse_untrusted_publisher(receipt, _self_endpoint_id(cfg))
+    refuse_untrusted_publisher(receipt, _self_endpoint_id(cfg), _self_org_id(cfg))
 
     return receipt
 

--- a/tests/test_receipts_pgw709.py
+++ b/tests/test_receipts_pgw709.py
@@ -279,7 +279,7 @@ def hub(rsa_key: rsa.RSAPrivateKey) -> Iterator[HubStub]:
     receipts.reset()
 
 
-def worker_jwt_for(endpoint_id: str) -> str:
+def worker_jwt_for(endpoint_id: str, org_id: str = "") -> str:
     """A hub-shaped worker credential naming the endpoint this pod serves.
 
     th#1657: the pod's own identity comes from the `cell_read_endpoint_id` the
@@ -288,9 +288,12 @@ def worker_jwt_for(endpoint_id: str) -> str:
     input — so an unsigned third segment is faithful to what the gate reads.
     """
     header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
-    payload = _b64url(json.dumps({
-        "sub": "worker-1", "cell_read_endpoint_id": endpoint_id,
-    }).encode())
+    claims = {"sub": "worker-1", "cell_read_endpoint_id": endpoint_id}
+    # th#1680: the org rides the same grant. Omitted when empty, exactly as a
+    # pre-th#1680 hub (or one that could not resolve the org) leaves it out.
+    if org_id:
+        claims["cell_read_org_id"] = org_id
+    payload = _b64url(json.dumps(claims).encode())
     return header + "." + payload + ".not-checked-here"
 
 
@@ -694,3 +697,158 @@ class TestPublisherTrustTh1657:
         assert kind == "cell_receipt_refused"
         assert phase == "publisher_untrusted"
         assert FAMILY in detail
+
+
+# ---------------------------------------------------------------------------
+# th#1680 / pgw#1021 — the two layers apply ONE rule
+# ---------------------------------------------------------------------------
+
+# THE SHARED ADOPTION TABLE. Twin of tensorhub's
+# `internal/authz/cell_adoption_table_th1680_test.go` (`TH1680AdoptionTable`).
+# Same rows, same order, same verdicts — a change made to one layer and not the
+# other fails a test here instead of producing a quiet disagreement that costs a
+# cold mint per boot. Tuple order matches the Go struct's field order so the two
+# can be diffed by eye.
+#
+#   (name, tier, publisher_org, viewer_org, want_adoptable, why)
+TH1680_ADOPTION_TABLE = [
+    ("platform tier, foreign org", "platform", "org-a", "org-b", True,
+     "the platform authored that code and already runs it everywhere"),
+    ("platform tier, no publisher org", "platform", "", "org-b", True,
+     "platform tier needs no publisher identity — the tier IS the identity"),
+    ("platform tier, no viewer", "platform", "org-a", "", True,
+     "a caller we cannot name still may adopt platform cells"),
+    ("org tier, same org", "org", "org-a", "org-a", True,
+     "th#1680: same org adopts across its OWN endpoints — the case th#1657 refused"),
+    ("org tier, foreign org", "org", "org-a", "org-b", False,
+     "THE THREAT: cross-tenant native-code execution"),
+    ("org tier, no publisher org", "org", "", "org-a", False,
+     "a cell whose publisher is unresolvable is adoptable by nobody"),
+    ("org tier, no viewer org", "org", "org-a", "", False,
+     "an identity we cannot establish is not an identity that matches everyone"),
+    ("org tier, both unresolvable", "org", "", "", False,
+     "empty-equals-empty must NOT match — the vacuous-guard shape"),
+    ("empty tier is org, foreign", "", "org-a", "org-b", False,
+     "§4.24 point 4: an unset tier lands on the NARROWER rule"),
+    ("empty tier is org, same org", "", "org-a", "org-a", True,
+     "…and still adopts within its own org"),
+    ("invented tier is org", "platform-ish", "org-a", "org-b", False,
+     "only exactly `platform` widens"),
+    ("mis-cased tier is org", "PLATFORM", "org-a", "org-b", False,
+     "no case folding — the receipt is a permanent statement, normalized before signing"),
+]
+
+
+def _receipt_for(tier: str, publisher_org: str, owning_endpoint: str = "") -> receipts.Receipt:
+    """A Receipt carrying only the fields the publisher gate reads."""
+    return receipts.Receipt(
+        version=receipts.RECEIPT_VERSION, family=FAMILY, cell_key=CELL_KEY, axes={},
+        owning_endpoint_id=owning_endpoint, publisher="",
+        publisher_tier=receipts._normalize_publisher_tier(tier),
+        publisher_org_id=publisher_org,
+        snapshot_digest=SNAPSHOT, artifact_path="cell.tar.gz",
+        artifact_digest="sha256:" + SHA_HEX, artifact_size_bytes=1,
+        manifest_digest="", fingerprint_digest="", issued_at_unix=0)
+
+
+class TestSharedAdoptionTableTh1680:
+    @pytest.mark.parametrize(
+        "name,tier,publisher_org,viewer_org,want,why", TH1680_ADOPTION_TABLE)
+    def test_row(self, name: str, tier: str, publisher_org: str,
+                 viewer_org: str, want: bool, why: str) -> None:
+        # Endpoints are deliberately DIFFERENT on every row, so each row tests
+        # the ORG axis alone — the endpoint rule must not mask an org verdict.
+        receipt = _receipt_for(tier, publisher_org, owning_endpoint="ep-publisher")
+        try:
+            receipts.refuse_untrusted_publisher(receipt, "ep-viewer", viewer_org)
+            got = True
+        except receipts.ReceiptError as exc:
+            assert exc.reason == "publisher_untrusted"
+            got = False
+        assert got is want, (
+            f"{name}: adoptable={got}, want {want} — {why}. "
+            "If you changed this rule, change tensorhub's "
+            "internal/authz/cell_adoption_table_th1680_test.go too.")
+
+    def test_table_covers_both_verdicts(self) -> None:
+        """A guard on the TABLE, not the code: an all-true or all-false table
+        would pass every row above while proving nothing."""
+        adoptable = sum(1 for row in TH1680_ADOPTION_TABLE if row[4])
+        refused = len(TH1680_ADOPTION_TABLE) - adoptable
+        assert adoptable and refused, (
+            f"table must exercise both verdicts; got {adoptable}/{refused}")
+        assert len(TH1680_ADOPTION_TABLE) == 12, (
+            "tensorhub's TH1680AdoptionTable has 12 rows — add the row THERE "
+            "too, then update both counts")
+
+
+class TestOrgWideningTh1680:
+    """RED both directions, through the real receipt path."""
+
+    def test_same_org_different_endpoint_adopts(
+        self, tmp_path: Path, hub: HubStub
+    ) -> None:
+        """THE RED CASE. The hub's listing shows this cell (it is the same org);
+        before pgw#1021 the arm gate refused it, costing a wasted download and a
+        full cold mint."""
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(
+            artifact, owning_endpoint_id=OTHER_ENDPOINT,
+            publisher_tier="org", publisher_org_id=SELF_ORG)
+        receipts.configure(
+            base_url=hub.base_url,
+            worker_jwt=lambda: worker_jwt_for(SELF_ENDPOINT, org_id=SELF_ORG))
+
+        receipt = receipts.verify_delivered_artifact(artifact, FAMILY)
+        assert receipt.publisher_org_id == SELF_ORG
+        assert receipts.gate_delivered_artifact(artifact, FAMILY) is True
+
+    def test_different_org_still_refused(self, tmp_path: Path, hub: HubStub) -> None:
+        """The threat is unchanged: another ORG's native code never arms."""
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(
+            artifact, owning_endpoint_id=OTHER_ENDPOINT,
+            publisher_tier="org", publisher_org_id="99999999-0000-0000-0000-000000000000")
+        receipts.configure(
+            base_url=hub.base_url,
+            worker_jwt=lambda: worker_jwt_for(SELF_ENDPOINT, org_id=SELF_ORG))
+
+        with pytest.raises(receipts.ReceiptError) as excinfo:
+            receipts.verify_delivered_artifact(artifact, FAMILY)
+        assert excinfo.value.reason == "publisher_untrusted"
+
+    def test_hub_without_th1680_degrades_to_endpoint_only(
+        self, tmp_path: Path, hub: HubStub
+    ) -> None:
+        """THE SAFE DEGRADATION, and the reason this needs no coupled deploy:
+        a grant with no `cell_read_org_id` (a hub older than th#1680) leaves
+        this pod on pgw#1008's endpoint-only rule. Narrower, never wider."""
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(
+            artifact, owning_endpoint_id=OTHER_ENDPOINT,
+            publisher_tier="org", publisher_org_id=SELF_ORG)
+        _configure(hub, endpoint_id=SELF_ENDPOINT)  # no org stamped
+
+        with pytest.raises(receipts.ReceiptError) as excinfo:
+            receipts.verify_delivered_artifact(artifact, FAMILY)
+        assert excinfo.value.reason == "publisher_untrusted"
+
+    def test_same_endpoint_still_adopts_without_org(
+        self, tmp_path: Path, hub: HubStub
+    ) -> None:
+        """The endpoint rule survives untouched — an old hub's pods keep
+        adopting their own cells."""
+        artifact = make_artifact(tmp_path)
+        hub.serve_receipt_for(
+            artifact, owning_endpoint_id=SELF_ENDPOINT,
+            publisher_tier="org", publisher_org_id="")
+        _configure(hub, endpoint_id=SELF_ENDPOINT)
+
+        assert receipts.gate_delivered_artifact(artifact, FAMILY) is True
+
+    def test_receipt_version_did_not_move(self) -> None:
+        """th#1678's lesson: `publisher_org_id` already shipped in v2, so this
+        change is additive on the GRANT and touches no wire constant. If this
+        assertion ever needs updating, the change is a COUPLED hub+fleet cut and
+        must say so in its own body."""
+        assert receipts.RECEIPT_VERSION == "cell-receipt-v2"


### PR DESCRIPTION
Twin of **th#1680** (merged: tensorhub [`ee0c115c`](https://github.com/cozy-creator/tensorhub/pull/890)). Closes th#1657's org-widening residue.

## The inconsistency

| layer | rule |
|---|---|
| hub listing (`filterCellCheckpoints`) | `platform` tier, **or same ORG** |
| worker arm gate (pgw#1008) | `platform` tier, **or same ENDPOINT** |

The worker was **stricter**, so nothing unsafe passed — this is a consistency defect, not a security one. But an org running two endpoints on one family is shown its own cell by the listing, downloads it, and is refused at arm: a wasted download plus a full cold mint, and a `publisher_untrusted` that reads like an attack when it is the platform disagreeing with itself.

pgw#1008 implemented Paul's ruling literally (*"must have come from endpoint-A itself"*) because the worker had **no way to name its own org** — the th#1335 grant carried `cell_read_endpoint_id` and nothing else. th#1680 stamps `cell_read_org_id` on the same grant.

## The change

`refuse_untrusted_publisher` accepts `platform` tier, **or** the same owning endpoint, **or** the same publisher org.

**Both org values must be non-empty.** An empty-equals-empty match is the vacuous-guard shape `canonical_artifact_digest` already refuses by name, and here it would let two unattributable cells match each other.

## No wire change — deliberately, after th#1678

`publisher_org_id` **already** shipped in `cell-receipt-v2`, so `RECEIPT_VERSION` does not move. This is additive on the **grant** only:

- old SDK ignores the new claim;
- new SDK against a pre-th#1680 hub finds it absent and falls back to endpoint-only.

**Both skew directions degrade to stricter, never wider** — no coupled cut, no ordering requirement. `test_receipt_version_did_not_move` pins that, with the reason in its docstring: if that assertion ever needs updating, the change is a coupled hub+fleet cut and must say so.

## The durable half: an anti-drift table

`TH1680_ADOPTION_TABLE` — 12 rows of `tier × publisher-org × viewer-org → verdict`, one stated reason each — is the twin of tensorhub's `internal/authz/cell_adoption_table_th1680_test.go`. **Both layers are checked against the same table.** A second test guards the table itself: it fails if the rows ever become all-adoptable or all-refused, and it pins the row count so a row added in one repo and not the other is caught.

The drift this PR fixes was possible only because each layer carried its own prose copy of the rule.

## RED verification, both directions

With org matching disabled, **exactly the 3 same-org rows fail** — including `test_same_org_different_endpoint_adopts` — while `test_different_org_still_refused` and `test_hub_without_th1680_degrades_to_endpoint_only` keep passing. That asymmetry is what proves the fix is not simply accepting everything.

## Gates

mypy (237 files, clean) · ruff · config-read guard (74 pairs, **no new env conditional**) · unreached-surface guard · http-timeout guard · receipts suite **55 passed**.

Full suite: **3542 passed, 37 skipped, 1 xfailed**, with one failure — `test_beats_never_miss_and_eager_serving_continues_through_a_long_mint`. It **passes in isolation**, is a liveness/timing test with no relationship to this diff (which touches `receipts.py` and its tests only), and the run was at **load average 45** on a shared box. Flagged rather than hidden; CI on a quiet runner is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)