### PR TITLE
pgw#1017: the custom-Dockerfile path VERIFIES what the synthesized path establishes

### DIFF
--- a/changelog.d/pgw1017.md
+++ b/changelog.d/pgw1017.md
@@ -1,0 +1,35 @@
+- **pgw#1017: the custom-Dockerfile path now VERIFIES what the synthesized path
+  ESTABLISHES.** The audit walked `generate_dockerfile.go` line by line and
+  found four invariants a family shipping its own Dockerfile never received and
+  nothing ever asked it for. Three land here; the fourth is the hub's
+  (th#1686). The standing lesson, because it is what found them: **enumerate
+  what the synthesized file DOES, not what it INSTALLS** — two of the four are
+  not packages at all.
+- **`python -m gen_worker.cuda_root` — one line, one authority.** `g++` is
+  necessary and not sufficient: torch's `cpp_extension` also needs a CUDA root,
+  and the pytorch runtime bases ship CUDA as pip wheels without ever creating
+  `/usr/local/cuda`. An image with a compiler and no root reached the LINK step
+  and died at `CUDA_HOME` **on a pod, after paying for the export** — a paid
+  failure where the missing-compiler sibling was a free one. The new module
+  composes the root out of parts the image already ships (wheel headers and
+  libs, the real `crt/` headers, `nv/target` from `cuda-cccl` fetched into a
+  throwaway dir), writes nothing inside a pip package, no-ops on an image that
+  already has one, and never fails a build. The author still invokes it — the
+  platform does not inject layers into author-owned content — while the SDK
+  owns whether the recipe is right, instead of twenty lines of shell
+  transcribed into every Dockerfile that needs it.
+- **Two new build-time preconditions, on pgw#996's seam.** `cuda_root` refuses
+  when torch is a CUDA build, the image declares an AOT export, and the root is
+  absent or half-composed — naming which of pgw#823's three measured facts is
+  missing, and the one-line fix. `torch_singleton` refuses a duplicate
+  torch-family install, which shadows the base image's, adds ~7 GB to every pod
+  pull and desyncs the CUDA runtime the kernels were compiled against.
+- **A source refusal is now non-retryable on BOTH paths.**
+  `TENSORHUB_BUILD_INPUT_FAILURE:discovery` was echoed by a shell wrapper the
+  hub wrote into the generated Dockerfile, so an identical refusal on a custom
+  Dockerfile was RETRIED — including pgw#996's precondition refusals, whose
+  entire value is deciding once, at build: the whole image build re-ran on every
+  River attempt to reach the same verdict. `gen_worker.discovery` prints the
+  marker itself now, because it is what knows the failure is about immutable
+  source. A death that is NOT about the source (an OOM-killed step) prints
+  nothing and stays retryable, which is the right answer for it.

--- a/docs/dockerfile.md
+++ b/docs/dockerfile.md
@@ -239,15 +239,36 @@ existed the same defect cost 336 s of rented L4 time and surfaced as
 `InvalidCxxCompiler` at the link step. A guarantee you can observe beats a
 quieter one: the refusal IS the guarantee.
 
-> **On a CUDA image `g++` is necessary, not sufficient.** torch's
-> `cpp_extension` also needs a CUDA root it can discover, and the pytorch
-> runtime bases ship CUDA as pip wheels without ever creating `/usr/local/cuda`
-> — so an image with `g++` and no composed CUDA root still dies with
-> `CUDA_HOME environment variable is not set`, on a pod, after paying for the
-> export. Tensorhub's synthesized Dockerfile composes that root; a custom
-> Dockerfile has no equivalent and **no precondition covers it yet**. pgw#1017
-> owns closing that gap. Until it does, do not pod-run a custom-Dockerfile
-> family that declares an AOT export.
+### On a CUDA image, `g++` is necessary and not sufficient
+
+torch's `cpp_extension` also needs a CUDA root it can discover, and the pytorch
+runtime bases ship CUDA as pip wheels without ever creating `/usr/local/cuda`.
+An image with `g++` and no CUDA root reaches the link step and dies with
+`CUDA_HOME environment variable is not set` — three separate facts are missing,
+and none of them is a compiler.
+
+One line, after your dependency install:
+
+```dockerfile
+RUN python -m gen_worker.cuda_root
+```
+
+It composes `/usr/local/cuda` out of parts the image already ships (the
+`nvidia/*` wheels' headers and libs, the real `crt/` headers, and `nv/target`
+from `cuda-cccl` fetched into a throwaway directory). It writes nothing inside
+a pip package, is a no-op when the image already has a CUDA install, and never
+fails a build — a CPU image simply has nothing to compose.
+
+You invoke it; the SDK owns whether the recipe is right. That is deliberate:
+the alternative is twenty lines of shell transcribed into every Dockerfile that
+needs it, drifting apart the moment a base image changes.
+
+The same build-time gate covers it:
+
+```
+error: aot precondition cuda_root: torch's cpp_extension cannot host-compile on
+       this image and ['micro-diffusion'] declare an AOT export. Missing: …
+```
 
 ---
 
@@ -259,9 +280,9 @@ FROM ${BASE_IMAGE}
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# The AOT host toolchain. Drop this layer only if no endpoint in the image
-# declares a compile export — Tensorhub's own generated Dockerfile installs it
-# in every image it synthesizes.
+# The AOT host toolchain. Drop this layer and the cuda_root line below only if
+# no endpoint in the image declares a compile export — Tensorhub's own
+# generated Dockerfile does both in every image it synthesizes.
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl g++ \
@@ -281,6 +302,7 @@ COPY . /app
 
 RUN uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps --no-sources /app \
+    && python -m gen_worker.cuda_root \
     && mkdir -p /app/.tensorhub \
     && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock
 

--- a/src/gen_worker/aot_preconditions.py
+++ b/src/gen_worker/aot_preconditions.py
@@ -61,7 +61,15 @@ LIFTED_LORA_TORCH_FLOOR: Tuple[int, int] = (2, 13)
 CHECK_DECLARATION_IMPORT = "declaration_import"
 CHECK_DECLARATION_EVALUATES = "declaration_evaluates"
 CHECK_CXX_TOOLCHAIN = "cxx_toolchain"
+CHECK_CUDA_ROOT = "cuda_root"
+CHECK_TORCH_SINGLETON = "torch_singleton"
 CHECK_LIFTED_LORA_TORCH_FLOOR = "lifted_lora_torch_floor"
+
+#: Distributions that must appear at most once. A second copy of any of them
+#: silently doubles the image by ~7 GB and desyncs the CUDA runtime — the
+#: synthesized Dockerfile asserts this in-image (`torchInvariantLine`), and
+#: until pgw#1017 nothing asked it of a custom Dockerfile.
+TORCH_FAMILY: Tuple[str, ...] = ("torch", "torchvision", "torchaudio", "triton")
 
 OK = "ok"
 REFUSED = "refused"
@@ -210,6 +218,8 @@ def static_mint_preconditions(
         return tuple(rows)
 
     rows.append(_cxx_row(aot_declaring))
+    rows.append(_cuda_root_row(aot_declaring))
+    rows.append(_torch_singleton_row())
 
     version = torch_version if torch_version is not None else _torch_version()
     for family in aot_declaring:
@@ -244,6 +254,89 @@ def _cxx_row(aot_declaring: list[str]) -> Precondition:
             f"drop the export declaration and serve the dynamo/JIT lane"))
 
 
+def _torch_is_cuda_build() -> bool:
+    import torch
+
+    return bool(getattr(getattr(torch, "version", None), "cuda", None))
+
+
+def _cuda_root_row(aot_declaring: list[str]) -> Precondition:
+    """pgw#1017 GAP A: `g++` is necessary and NOT sufficient on a CUDA image.
+
+    The third instance of this issue's own defect class, and the most expensive
+    of the three: the cxx gap refused at build for $0.00, while this one refused
+    NOWHERE. The pod booted, loaded and EXPORTED — the expensive part — before
+    `cpp_extension` said "CUDA_HOME environment variable is not set". Free
+    refusal, paid failure; that asymmetry is the whole reason this row exists.
+    """
+    from . import cuda_root as cr
+
+    if not _torch_is_cuda_build():
+        return Precondition(
+            check=CHECK_CUDA_ROOT, verdict=OK,
+            detail=("torch is a CPU build, so AOTInductor's host compile needs "
+                    "no CUDA root"))
+    home = cr.torch_cuda_home()
+    gaps = cr.missing_parts(cr.Path(home)) if home else ["the root itself"]
+    if home and not gaps:
+        return Precondition(
+            check=CHECK_CUDA_ROOT, verdict=OK,
+            detail=f"AOTInductor host-compiles against {home}")
+    return Precondition(
+        check=CHECK_CUDA_ROOT, verdict=REFUSED, detail=(
+            f"torch's cpp_extension cannot host-compile on this image and "
+            f"{aot_declaring!r} declare an AOT export. Missing: "
+            f"{'; '.join(gaps)}. The pytorch runtime bases ship CUDA as pip "
+            f"wheels and never create /usr/local/cuda, so a C++ compiler alone "
+            f"gets you to the LINK step and no further (pgw#823, pgw#1017). "
+            f"Fix: add `RUN python -m gen_worker.cuda_root` to your Dockerfile "
+            f"after your dependency install — it composes the root out of parts "
+            f"the image already ships, writes nothing into site-packages, and "
+            f"is a no-op on an image that already has one. Or drop the export "
+            f"declaration and serve the dynamo/JIT lane"))
+
+
+def _torch_singleton_row() -> Precondition:
+    """pgw#1017 GAP B: one torch-family install, not two.
+
+    `torchInvariantLine` fails the SYNTHESIZED build when a second copy of a
+    torch-family distribution lands — *"silently doubles the image by ~7GB and
+    desyncs the CUDA runtime"*. A custom Dockerfile installing its deps its own
+    way (no `--no-emit-package` list, no base-image constraints file)
+    reproduces exactly that, and the hub reads no distribution's version out of
+    the image but `gen-worker`'s.
+
+    Scope, stated rather than implied: this verifies the DUPLICATE half only.
+    The synthesized file's other half — "torch has not drifted from the base
+    image's pin" — reads `/tmp/torch-constraints.txt`, which is written and
+    deleted inside the generated Dockerfile and does not exist here. That half
+    is decidable only where the base image is known, so it belongs to the hub
+    (th#1686) and is not faked here.
+    """
+    import importlib.metadata as md
+
+    counts: Dict[str, int] = {}
+    for dist in md.distributions():
+        name = str((dist.metadata["Name"] or "")).lower().replace("_", "-")
+        if name in TORCH_FAMILY:
+            counts[name] = counts.get(name, 0) + 1
+    dups = sorted(n for n, c in counts.items() if c > 1)
+    if not dups:
+        return Precondition(
+            check=CHECK_TORCH_SINGLETON, verdict=OK,
+            detail=(f"one install each of "
+                    f"{sorted(n for n in counts) or list(TORCH_FAMILY)}"))
+    return Precondition(
+        check=CHECK_TORCH_SINGLETON, verdict=REFUSED, detail=(
+            f"duplicate torch-family install: {dups}. A second copy shadows the "
+            f"base image's, adds ~7 GB to every pod's image pull and desyncs "
+            f"the CUDA runtime the compiled kernels were built against. Pin "
+            f"your dependencies against the versions the base image already "
+            f"provides, or exclude them from your install (the synthesized "
+            f"Dockerfile passes --no-emit-package for the whole torch/CUDA "
+            f"wheel set)"))
+
+
 def declared_compile_families(functions: Any) -> Dict[str, int]:
     """family -> largest declared ``lora_bucket``, over manifest functions.
 
@@ -265,13 +358,16 @@ def declared_compile_families(functions: Any) -> Dict[str, int]:
 __all__ = [
     "ABSTAINED",
     "BLOCKED",
+    "CHECK_CUDA_ROOT",
     "CHECK_CXX_TOOLCHAIN",
     "CHECK_DECLARATION_EVALUATES",
     "CHECK_DECLARATION_IMPORT",
     "CHECK_LIFTED_LORA_TORCH_FLOOR",
+    "CHECK_TORCH_SINGLETON",
     "LIFTED_LORA_TORCH_FLOOR",
     "OK",
     "REFUSED",
+    "TORCH_FAMILY",
     "Precondition",
     "declared_compile_families",
     "static_mint_preconditions",

--- a/src/gen_worker/cuda_root.py
+++ b/src/gen_worker/cuda_root.py
@@ -1,0 +1,269 @@
+"""Compose the CUDA root AOTInductor's host compile needs (pgw#1017, pgw#823).
+
+``g++`` is necessary and not sufficient. AOTInductor emits a C++ wrapper and
+links a real ``.so``, and torch's ``cpp_extension`` has to find a CUDA tree to
+do it. On the pytorch runtime bases it finds none, for three separate measured
+reasons — none of which a compiler install fixes:
+
+1. **torch finds no CUDA at all.** ``_find_cuda_home`` reads ``CUDA_HOME`` /
+   ``CUDA_PATH``, then ``which nvcc``, then ``/usr/local/cuda``. The runtime
+   bases satisfy none: CUDA arrives as pip wheels, and ``/usr/local/cuda`` is
+   on ``PATH`` but does not exist. AOTI dies with *"CUDA_HOME environment
+   variable is not set"* before compiling a line.
+2. **The cu13 wheel's ``include/`` is FLATTENED.** Its own
+   ``cuda_runtime_api.h`` does ``#include "crt/host_defines.h"`` and no
+   ``crt/`` directory ships. The top-level ``host_defines.h`` is itself a
+   forwarder INTO ``crt/``, so it cannot stand in. Triton's bundled CUDA tree
+   carries the real ``crt/`` headers.
+3. **Several cu13 headers include ``<nv/target>``**, which is CCCL and ships in
+   NO tree in the image. The ``cuda-cccl`` wheel has it.
+
+Tensorhub's SYNTHESIZED Dockerfile has composed this root since pgw#823. A
+family that ships its OWN Dockerfile got none of it, so it could install
+``g++``, pass the ``cxx_toolchain`` precondition, boot a pod, load, export —
+the expensive part — and only then die at ``CUDA_HOME``. That is a PAID
+failure where the missing-compiler sibling was a free one.
+
+The fix is this module, invoked by the author in one line:
+
+    RUN python -m gen_worker.cuda_root
+
+The author still owns invoking it — the platform never injects layers into
+author-owned content (pgw#1017's settled contract). The SDK owns the recipe's
+correctness, so there is ONE authority for it rather than twenty lines of
+shell transcribed into every Dockerfile that needs it (the pgw#988 lesson).
+``aot_preconditions.CHECK_CUDA_ROOT`` then VERIFIES the result at build time,
+so an image that declares an AOT export and skipped this refuses for $0.00
+instead of on a rented card.
+
+Nothing here fails: a CPU image has no CUDA root to compose, and an image that
+cannot AOT-compile is still a working eager-serving image. The refusal is the
+precondition's job, and it is deliberately a separate one — this step reports,
+the gate decides.
+
+``/usr/local/cuda`` is COMPOSED (a real directory of symlinks) rather than
+pointed at a wheel, so nothing is ever written inside a pip package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import shutil
+import site
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+CUDA_ROOT = Path("/usr/local/cuda")
+
+#: The header that proves the flattened-include problem is solved.
+CRT_HOST_DEFINES = Path("include/crt/host_defines.h")
+#: The CCCL header several cu13 headers include and no tree in the image ships.
+NV_TARGET = Path("include/nv/target")
+
+
+@dataclass
+class Composition:
+    """What this run did, in the vocabulary the build log should carry."""
+
+    root: str = ""
+    crt: str = ""
+    nv: str = ""
+    notes: List[str] = field(default_factory=list)
+
+    def lines(self) -> List[str]:
+        out = [f"cuda_root: {self.root or 'none'}"]
+        if self.crt:
+            out.append(f"cuda_crt: {self.crt}")
+        if self.nv:
+            out.append(f"cuda_nv: {self.nv}")
+        out.extend(self.notes)
+        return out
+
+
+def wheel_cuda_root() -> str:
+    """The single ``nvidia/*`` wheel directory that looks like a CUDA tree.
+
+    A tree qualifies when it carries ``include/cuda_runtime.h`` AND a
+    ``lib64``/``lib`` directory. Ambiguity is answered with "" rather than a
+    guess: two candidates mean the image's CUDA story is not the one this
+    recipe was measured against, and composing the wrong one is worse than
+    composing nothing (the precondition will say so by name).
+    """
+    spec = importlib.util.find_spec("nvidia")
+    roots = list(getattr(spec, "submodule_search_locations", None) or []) if spec else []
+    found: List[str] = []
+    for parent in roots:
+        try:
+            names = sorted(os.listdir(parent))
+        except OSError:
+            continue
+        for name in names:
+            cand = Path(parent) / name
+            if not (cand / "include" / "cuda_runtime.h").is_file():
+                continue
+            if (cand / "lib64").is_dir() or (cand / "lib").is_dir():
+                found.append(str(cand))
+    return found[0] if len(found) == 1 else ""
+
+
+def _donor_path(relative: Path) -> str:
+    """A ``site-packages`` file matching ``*/<relative>``, or ""."""
+    for base in site.getsitepackages():
+        try:
+            matches = sorted(Path(base).glob(f"*/**/{relative.as_posix()}"))
+        except OSError:
+            continue
+        for match in matches:
+            if match.exists():
+                return str(match)
+    return ""
+
+
+def _install_cuda_cccl(target: Path) -> str:
+    """Fetch ``cuda-cccl`` into a throwaway dir and return its ``nv/`` path.
+
+    Into ``--target``, never into ``site-packages``: the image's installed
+    environment is not this step's to modify, and only the ~56 KB ``nv/``
+    subtree is kept. ``uv`` when the image has it (tensorhub's own images do),
+    ``pip`` otherwise — the doc's minimum-viable Dockerfile installs with pip
+    and must not be excluded from the AOT lane by a tool choice.
+    """
+    uv = shutil.which("uv")
+    cmd = (
+        [uv, "pip", "install", "--target", str(target), "--no-cache", "--no-deps", "cuda-cccl"]
+        if uv
+        else [sys.executable, "-m", "pip", "install", "--target", str(target),
+              "--no-cache-dir", "--no-deps", "cuda-cccl"]
+    )
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=600)
+    except (subprocess.SubprocessError, OSError):
+        return ""
+    for match in sorted(target.glob(f"**/{NV_TARGET.as_posix()}")):
+        return str(match)
+    return ""
+
+
+def compose(root_dir: Path = CUDA_ROOT) -> Composition:
+    """Assemble ``root_dir`` out of parts the image already ships.
+
+    Idempotent by the same test the synthesized step uses: a pre-existing
+    ``/usr/local/cuda`` is left alone. An image that already has a real CUDA
+    install (a devel base, a distro package) is not one this recipe should
+    second-guess.
+    """
+    out = Composition()
+    if root_dir.exists():
+        out.root = "preexisting"
+        return out
+
+    wheel = wheel_cuda_root()
+    if not wheel:
+        out.notes.append(
+            "cuda_root: no single nvidia/* wheel carries include/cuda_runtime.h "
+            "with a lib64/lib — a CPU image has nothing to compose, and an "
+            "ambiguous one is not guessed at")
+        return out
+    wheel_path = Path(wheel)
+
+    include_dir = root_dir / "include"
+    include_dir.mkdir(parents=True, exist_ok=True)
+    for entry in sorted((wheel_path / "include").iterdir()):
+        link = include_dir / entry.name
+        if not link.exists():
+            link.symlink_to(entry)
+    for libdir in ("lib64", "lib"):
+        src = wheel_path / libdir
+        if src.is_dir() and not (root_dir / libdir).exists():
+            (root_dir / libdir).symlink_to(src)
+    out.root = wheel
+
+    if not (root_dir / CRT_HOST_DEFINES).exists():
+        donor = _donor_path(CRT_HOST_DEFINES)
+        if donor:
+            (root_dir / "include" / "crt").symlink_to(Path(donor).parent)
+        out.crt = donor or "MISSING"
+
+    if not (root_dir / NV_TARGET).exists():
+        with tempfile.TemporaryDirectory(prefix="cuda-cccl-") as tmp:
+            donor = _install_cuda_cccl(Path(tmp))
+            if donor:
+                shutil.copytree(Path(donor).parent, root_dir / "include" / "nv")
+            out.nv = donor or "MISSING"
+    return out
+
+
+def missing_parts(root_dir: Path = CUDA_ROOT) -> List[str]:
+    """Which of the three measured facts this image still fails, if any.
+
+    The one predicate ``aot_preconditions`` reads, so "is the CUDA root usable"
+    has a single implementation and the gate cannot prove something the
+    composer never did.
+    """
+    if not root_dir.is_dir():
+        return ["the root itself (/usr/local/cuda does not exist)"]
+    gaps = []
+    if not (root_dir / "include" / "cuda_runtime.h").exists():
+        gaps.append("include/cuda_runtime.h")
+    if not (root_dir / CRT_HOST_DEFINES).exists():
+        gaps.append(f"{CRT_HOST_DEFINES.as_posix()} (the cu13 wheel flattens crt/ away)")
+    if not (root_dir / NV_TARGET).exists():
+        gaps.append(f"{NV_TARGET.as_posix()} (CCCL; no tree in the image ships it)")
+    if not any((root_dir / d).exists() for d in ("lib64", "lib")):
+        gaps.append("lib64/ or lib/")
+    return gaps
+
+
+def torch_cuda_home() -> str:
+    """What torch itself would resolve, asked the way ``cpp_extension`` asks.
+
+    Same doctrine as ``compile_cache.cxx_compiler``: predict the failure by
+    calling the thing that produces it, so the predicate cannot drift from what
+    it predicts. ``_find_cuda_home`` already consults ``CUDA_HOME`` /
+    ``CUDA_PATH`` / ``which nvcc`` / ``/usr/local/cuda``, in that order —
+    reimplementing that ladder here would be a second spelling of the lookup
+    whose divergence is the entire bug class this module exists for, so there
+    is no fallback: no torch means no verdict, and the caller never asks.
+    """
+    try:
+        from torch.utils import cpp_extension
+
+        return str(cpp_extension._find_cuda_home() or "")
+    except Exception:  # noqa: BLE001 — no torch, or a private API that moved
+        return ""
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m gen_worker.cuda_root",
+        description=("Compose /usr/local/cuda for AOTInductor's host compile. "
+                     "Run it in your Dockerfile when an endpoint in the image "
+                     "declares an AOT export."))
+    parser.add_argument("--root", default=str(CUDA_ROOT),
+                        help="where to compose the root (default /usr/local/cuda)")
+    parser.add_argument("--check", action="store_true",
+                        help="report what is missing and exit nonzero; compose nothing")
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    if args.check:
+        gaps = missing_parts(root)
+        for line in (gaps or ["cuda_root: complete"]):
+            print(line, file=sys.stderr)
+        return 1 if gaps else 0
+
+    for line in compose(root).lines():
+        print(line, file=sys.stderr)
+    # Deliberately 0 on every branch: a CPU image composing nothing is not a
+    # broken build, and the AOT gate is `aot_preconditions`, not this step.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gen_worker/discovery/discover.py
+++ b/src/gen_worker/discovery/discover.py
@@ -956,6 +956,26 @@ def _strip_none(obj: Any) -> Any:
     return obj
 
 
+#: pgw#1017 GAP D. Tensorhub classifies a build failure carrying this marker as
+#: ``ErrBuildInput`` → ``river.JobCancel``: the same source bytes are never
+#: retried. It used to be emitted by a shell wrapper the hub wrote into the
+#: SYNTHESIZED Dockerfile, so a family shipping its OWN Dockerfile got the
+#: opposite classification for an identical failure — and that included
+#: pgw#996's precondition refusals, whose entire value is deciding once, at
+#: build. The whole image build re-ran on every River attempt to reach the same
+#: verdict. The knowledge lives here: discovery is what knows the failure is
+#: about immutable endpoint source, so discovery says so, on both paths.
+BUILD_INPUT_FAILURE_MARKER = "TENSORHUB_BUILD_INPUT_FAILURE:discovery"
+
+
+def _fail_build_input(*messages: str) -> None:
+    """Print the refusal, mark it non-retryable, and exit nonzero."""
+    for message in messages:
+        print(message, file=sys.stderr)
+    print(BUILD_INPUT_FAILURE_MARKER, file=sys.stderr)
+    sys.exit(1)
+
+
 def main() -> None:
     """Write the build-time endpoint manifest to stdout.
 
@@ -964,6 +984,11 @@ def main() -> None:
     is a class-shape declaration (post-#322). An old function-shape entry
     that slipped past the discovery refactor hard-fails the build with a
     pointer to the migration guide.
+
+    Every refusal below is about the endpoint SOURCE, which no retry can
+    change, so each one carries ``BUILD_INPUT_FAILURE_MARKER``. A death that
+    is NOT about the source — the process OOM-killed, the build host cut off —
+    prints nothing and stays retryable, which is the correct answer for it.
     """
     try:
         manifest = discover_manifest()
@@ -976,8 +1001,7 @@ def main() -> None:
             cause = cause.__cause__
         if cause is not None:
             traceback.print_exc(file=sys.stderr)
-        print(f"error: {e}", file=sys.stderr)
-        sys.exit(1)
+        _fail_build_input(f"error: {e}")
 
     # #328 bake-time validation gate. Old function-shape entries trip the
     # missing-class_name check; same-class slug collisions trip the route
@@ -989,9 +1013,7 @@ def main() -> None:
     for w in val.warnings:
         print(f"warning: {w}", file=sys.stderr)
     if not val.ok:
-        for err in val.errors:
-            print(f"error: {err}", file=sys.stderr)
-        sys.exit(1)
+        _fail_build_input(*(f"error: {err}" for err in val.errors))
 
     if not manifest.get("functions"):
         print("warning: no @endpoint objects found", file=sys.stderr)

--- a/tests/test_custom_dockerfile_path_parity_pgw1017.py
+++ b/tests/test_custom_dockerfile_path_parity_pgw1017.py
@@ -1,0 +1,272 @@
+"""The CUSTOM-Dockerfile path VERIFIES what the synthesized path establishes.
+
+pgw#1017's audit walked `tensorhub/internal/builder/generate_dockerfile.go` line
+by line and asked, of each invariant it writes into the generated file, whether
+anything asks it of a Dockerfile an author wrote. Four did not. These are the
+rows that close three of them; GAP C lives in the hub (th#1683), because
+`system_dependencies` never reaches this process.
+
+The lesson the audit recorded, and the reason these tests are shaped this way:
+enumerate what the synthesized file DOES, not what it INSTALLS. Two of the
+three gaps below are not packages — one is a composed directory, one is a shell
+wrapper around an exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gen_worker import aot_preconditions as ap
+from gen_worker import cuda_root as cr
+from gen_worker.discovery.discover import BUILD_INPUT_FAILURE_MARKER
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# GAP A — the composed CUDA root
+# ---------------------------------------------------------------------------
+
+def test_missing_parts_names_each_of_the_three_measured_facts(tmp_path):
+    """Absent root, flattened crt/, absent nv/target — each named separately.
+
+    pgw#823 measured three independent reasons `cpp_extension` fails on the
+    pytorch runtime bases. A predicate that collapses them into "no CUDA" sends
+    the author to fix the wrong one.
+    """
+    root = tmp_path / "cuda"
+    assert "the root itself" in " ".join(cr.missing_parts(root))
+
+    (root / "include").mkdir(parents=True)
+    (root / "lib64").mkdir()
+    (root / "include" / "cuda_runtime.h").write_text("")
+    gaps = " ".join(cr.missing_parts(root))
+    assert "crt/host_defines.h" in gaps and "flattens crt/ away" in gaps
+    assert "nv/target" in gaps and "CCCL" in gaps
+
+    (root / "include" / "crt").mkdir()
+    (root / "include" / "crt" / "host_defines.h").write_text("")
+    (root / "include" / "nv").mkdir()
+    (root / "include" / "nv" / "target").write_text("")
+    assert cr.missing_parts(root) == []
+
+
+def test_compose_leaves_a_preexisting_root_alone(tmp_path):
+    """A devel base or a distro CUDA is not this recipe's to second-guess."""
+    root = tmp_path / "cuda"
+    root.mkdir()
+    (root / "sentinel").write_text("do not touch")
+    assert cr.compose(root).root == "preexisting"
+    assert (root / "sentinel").read_text() == "do not touch"
+
+
+def test_compose_reports_and_never_raises_when_there_is_no_wheel(tmp_path,
+                                                                monkeypatch):
+    """A CPU image has nothing to compose, and that is not a failure.
+
+    The refusal is `aot_preconditions`' job. Keeping the composer silent-and-
+    successful is what lets the gate be the single place a build dies.
+    """
+    monkeypatch.setattr(cr, "wheel_cuda_root", lambda: "")
+    out = cr.compose(tmp_path / "cuda")
+    assert out.root == ""
+    assert any("nothing to compose" in n for n in out.notes)
+
+
+def test_the_cuda_root_module_is_runnable_as_the_doc_says(tmp_path):
+    """`python -m gen_worker.cuda_root` — the exact line the docs teach."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "gen_worker.cuda_root", "--root", str(tmp_path / "c")],
+        capture_output=True, text=True, timeout=300,
+        cwd=str(REPO), env={"PYTHONPATH": str(REPO / "src"), "PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "cuda_root:" in proc.stderr
+
+
+def _rows(monkeypatch, *, cuda_home, gaps, cuda_build=True):
+    monkeypatch.setattr(ap, "_torch_is_cuda_build", lambda: cuda_build)
+    monkeypatch.setattr(cr, "torch_cuda_home", lambda: cuda_home)
+    monkeypatch.setattr(cr, "missing_parts", lambda _root: list(gaps))
+    return ap._cuda_root_row(["micro-diffusion"])
+
+
+def test_a_cuda_image_with_no_root_REFUSES_and_names_the_one_line_fix(monkeypatch):
+    """RED for GAP A: the row that did not exist before pgw#1017.
+
+    This is the whole acceptance criterion. Before this row, an image with g++
+    and no CUDA root built clean, booted a pod, loaded, exported — and died at
+    CUDA_HOME. A free build-time refusal became a paid pod-time failure.
+    """
+    row = _rows(monkeypatch, cuda_home="", gaps=[])
+    assert row.check == ap.CHECK_CUDA_ROOT
+    assert row.verdict == ap.REFUSED
+    assert "python -m gen_worker.cuda_root" in row.detail
+    assert "micro-diffusion" in row.detail
+
+
+def test_a_half_composed_root_REFUSES_too(monkeypatch):
+    """CUDA_HOME resolving is not the property — compiling is.
+
+    `cpp_extension` finding a directory says nothing about `crt/host_defines.h`
+    being in it, and that is exactly the second of pgw#823's three facts.
+    """
+    row = _rows(monkeypatch, cuda_home="/usr/local/cuda",
+                gaps=["include/crt/host_defines.h (the cu13 wheel flattens crt/ away)"])
+    assert row.verdict == ap.REFUSED
+    assert "crt/host_defines.h" in row.detail
+
+
+def test_a_composed_root_passes_and_a_cpu_build_needs_none(monkeypatch):
+    assert _rows(monkeypatch, cuda_home="/usr/local/cuda", gaps=[]).verdict == ap.OK
+    cpu = _rows(monkeypatch, cuda_home="", gaps=["x"], cuda_build=False)
+    assert cpu.verdict == ap.OK and "CPU build" in cpu.detail
+
+
+# ---------------------------------------------------------------------------
+# GAP B — one torch-family install, not two
+# ---------------------------------------------------------------------------
+
+class _Dist:
+    def __init__(self, name):
+        self.metadata = {"Name": name}
+
+
+def test_a_duplicate_torch_REFUSES_with_the_cost_named(monkeypatch):
+    """RED for GAP B: ~7 GB per pod pull, and a desynced CUDA runtime."""
+    monkeypatch.setattr(
+        "importlib.metadata.distributions",
+        lambda: [_Dist("torch"), _Dist("Torch"), _Dist("torchvision")])
+    row = ap._torch_singleton_row()
+    assert row.verdict == ap.REFUSED
+    assert "torch" in row.detail and "7 GB" in row.detail
+
+
+def test_one_of_each_passes_and_underscores_normalize(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.metadata.distributions",
+        lambda: [_Dist("torch"), _Dist("torchvision"), _Dist("not-torch")])
+    assert ap._torch_singleton_row().verdict == ap.OK
+
+
+def test_the_torch_family_is_the_set_the_hub_asserts():
+    """The synthesized file's own list — one spelling, not a parallel one."""
+    assert ap.TORCH_FAMILY == ("torch", "torchvision", "torchaudio", "triton")
+
+
+# ---------------------------------------------------------------------------
+# GAP D — a source refusal is NON-RETRYABLE on both paths
+# ---------------------------------------------------------------------------
+
+def _discovery(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "gen_worker.discovery"],
+        capture_output=True, text=True, timeout=600, cwd=str(root),
+        env={"PYTHONPATH": f"{REPO / 'src'}:{root}", "PATH": "/usr/bin:/bin"},
+    )
+
+
+def test_a_missing_config_carries_the_non_retryable_marker(tmp_path):
+    """RED for GAP D, and the sting the audit found.
+
+    Tensorhub turns this marker into `ErrBuildInput` → `river.JobCancel`. It
+    used to be emitted by a shell wrapper in the SYNTHESIZED Dockerfile only,
+    so an identical refusal on a custom Dockerfile was RETRIED — and that
+    included pgw#996's precondition refusals, whose entire value is deciding
+    once, at build. The whole image build re-ran to reach the same verdict.
+
+    A tarball with no `pyproject.toml` is the plainest immutable-source
+    failure there is: no retry will grow one.
+    """
+    proc = _discovery(tmp_path)
+    assert proc.returncode != 0
+    assert "pyproject.toml not found" in proc.stderr
+    assert BUILD_INPUT_FAILURE_MARKER in proc.stderr, proc.stderr
+
+
+def test_a_broken_endpoint_module_carries_it_too(tmp_path):
+    """The other shape: the config is fine and the endpoint package raises.
+
+    Both reach `main()` by different routes — one through `discover_manifest`'s
+    except arm, one through the validation gate — and the marker has to ride
+    every one of them, not the first that got tested.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "brokenep"\nversion = "0.1.0"\n'
+        '[tool.gen_worker]\nmain = "brokenep"\n')
+    pkg = tmp_path / "brokenep"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        "raise RuntimeError('this endpoint module is broken')")
+    proc = _discovery(tmp_path)
+    assert proc.returncode != 0
+    assert BUILD_INPUT_FAILURE_MARKER in proc.stderr, proc.stderr
+
+
+def test_the_marker_is_the_string_the_hub_classifies_on():
+    """Mirrored from `tensorhub/internal/builder/k8s_backend.go:96`.
+
+    Named here so a change on that side has one place to land, rather than
+    being discovered by a build that stopped being cancelled.
+    """
+    assert BUILD_INPUT_FAILURE_MARKER == "TENSORHUB_BUILD_INPUT_FAILURE:discovery"
+
+
+@pytest.mark.parametrize("check", [
+    ap.CHECK_CXX_TOOLCHAIN, ap.CHECK_CUDA_ROOT, ap.CHECK_TORCH_SINGLETON,
+])
+def test_every_static_row_has_a_stable_name(check):
+    """The names ride out in `endpoint.lock` and into build errors."""
+    assert check and check.islower() and " " not in check
+
+
+# ---------------------------------------------------------------------------
+# WIRING — a row nothing calls is not a gate
+# ---------------------------------------------------------------------------
+
+def test_the_new_rows_are_actually_STAMPED_by_the_gate(monkeypatch):
+    """The row that closes a gap has to be reachable from the seam.
+
+    Asserting `_cuda_root_row(...)` in isolation proves the function's opinion
+    and nothing about the build: an unwired row is exactly the shape of the
+    defect this issue exists to stop — a guarantee that only ever ran on one
+    path. So this asks `static_mint_preconditions`, which is what discovery
+    calls and `validate_endpoint_lock` reads.
+    """
+    monkeypatch.setattr(ap, "has_export_declaration", lambda _f: True)
+    monkeypatch.setattr(ap, "declaration_import_failures", lambda: ())
+    monkeypatch.setattr(
+        ap, "export_declaration",
+        lambda _f: type("D", (), {"classes": (), "targets": ()})())
+    monkeypatch.setattr(ap, "_torch_is_cuda_build", lambda: True)
+    monkeypatch.setattr(cr, "torch_cuda_home", lambda: "")
+
+    rows = ap.static_mint_preconditions({"micro-diffusion": 0},
+                                        torch_available=True,
+                                        torch_version="2.13.0")
+    checks = {r.check for r in rows}
+    assert ap.CHECK_CUDA_ROOT in checks, "GAP A's row is not wired into the gate"
+    assert ap.CHECK_TORCH_SINGLETON in checks, "GAP B's row is not wired in"
+    assert ap.CHECK_CXX_TOOLCHAIN in checks
+
+    cuda = next(r for r in rows if r.check == ap.CHECK_CUDA_ROOT)
+    assert cuda.verdict == ap.REFUSED
+    # And the refusal must survive the trip into endpoint.lock, since that is
+    # where the hub reads it from.
+    assert cuda.manifest_row()["verdict"] == "refused"
+
+
+def test_a_family_that_declares_no_export_gets_no_new_rows(monkeypatch):
+    """Intake-mode JIT owes the AOT lane nothing — including these two.
+
+    The ruling this gate implements binds only endpoints that DECLARE an AOT
+    export. A CPU or JIT-only image must not start failing builds because it
+    has no CUDA root it never needed.
+    """
+    monkeypatch.setattr(ap, "has_export_declaration", lambda _f: False)
+    monkeypatch.setattr(ap, "declaration_import_failures", lambda: ())
+    assert ap.static_mint_preconditions({"plain": 0}, torch_available=True) == ()

--- a/tests/test_mint_preconditions_pgw996.py
+++ b/tests/test_mint_preconditions_pgw996.py
@@ -129,6 +129,29 @@ def toolchain(monkeypatch: pytest.MonkeyPatch):
     return _set
 
 
+@pytest.fixture(autouse=True)
+def cuda_root(monkeypatch: pytest.MonkeyPatch):
+    """The image's CUDA root, under test control (pgw#1017 GAP A).
+
+    Autouse and healthy by default, for the same reason `toolchain` stubs g++:
+    these rows are about a hypothetical endpoint IMAGE, and the box running the
+    suite is not one. Without it every row here would answer about the CI
+    runner — which carries a CUDA torch wheel and no `/usr/local/cuda`, so the
+    honest verdict is `refused` and it has nothing to do with the toy endpoint
+    under test.
+
+    Returns a setter so a row that wants the refusal can ask for it.
+    """
+    from gen_worker import cuda_root as cr
+
+    def _set(home: str, gaps: tuple[str, ...] = ()) -> None:
+        monkeypatch.setattr(cr, "torch_cuda_home", lambda: home)
+        monkeypatch.setattr(cr, "missing_parts", lambda _root: list(gaps))
+
+    _set("/usr/local/cuda")
+    return _set
+
+
 def _build(root: Path, pkg: str, declaration: str, *, bucket: int = 0,
            external: bool = False):
     _tree(root, pkg, declaration, bucket=bucket, external=external)
@@ -225,6 +248,11 @@ def test_a_healthy_declaring_image_builds_and_records_its_proof(
     assert verdicts == {
         pre.CHECK_DECLARATION_EVALUATES: pre.OK,
         pre.CHECK_CXX_TOOLCHAIN: pre.OK,
+        # pgw#1017: the two the custom-Dockerfile audit added. An exhaustive
+        # equality, deliberately — a row that stops being stamped is the exact
+        # defect this whole issue is about, and `in` would not notice.
+        pre.CHECK_CUDA_ROOT: pre.OK,
+        pre.CHECK_TORCH_SINGLETON: pre.OK,
         pre.CHECK_LIFTED_LORA_TORCH_FLOOR: pre.OK,
     }
 


### PR DESCRIPTION
The audit this issue asked for walked `generate_dockerfile.go` line by line and found **four** invariants a family shipping its own Dockerfile never received and nothing ever asked it for. Three land here; `system_dependencies` is the hub's half (th#1686, separate PR).

The lesson worth keeping, because it is what found them: **enumerate what the synthesized file DOES, not what it INSTALLS.** Two of the four are not packages at all, and the most expensive one is a composed directory.

## GAP A — `g++` is necessary and NOT sufficient

torch's `cpp_extension` also needs a CUDA root, and the pytorch runtime bases ship CUDA as pip wheels without ever creating `/usr/local/cuda`. An image with a compiler and no root reached the LINK step and died at `CUDA_HOME` **on a pod, after paying for the export** — a paid failure where the missing-compiler sibling was a free one. That asymmetry is the acceptance criterion, and it takes both halves:

- **`python -m gen_worker.cuda_root`** composes the root out of parts the image already ships (wheel headers/libs, the real `crt/` headers, `nv/target` from `cuda-cccl` fetched into a throwaway dir). Writes nothing inside a pip package, no-ops on an image that already has a CUDA install, never fails a build. **The author invokes it** — the platform does not inject layers into author-owned content, per this issue's settled contract — while **the SDK owns whether the recipe is right**, so there is ONE authority instead of twenty lines of shell transcribed into every Dockerfile that needs it.
- **an `aot_precondition cuda_root` row REFUSES at build** when torch is a CUDA build, the image declares an AOT export, and the root is absent or half-composed. It names *which* of pgw#823's three measured facts is missing, because "no CUDA" sends the author to fix the wrong one.

## GAP B — one torch-family install, not two

A duplicate shadows the base image's, adds ~7 GB to every pod pull and desyncs the CUDA runtime the kernels were compiled against.

Scope stated rather than implied: this is the **duplicate** half. The drift-from-base-pins half reads a constraints file that lives and dies inside the generated Dockerfile, so it is decidable only where the base image is known — th#1686 does it hub-side rather than faking it here.

## GAP D — a source refusal is non-retryable on BOTH paths

`TENSORHUB_BUILD_INPUT_FAILURE:discovery` was echoed by a shell wrapper the hub wrote into the generated Dockerfile, so an identical refusal on a custom Dockerfile was **retried** — including **pgw#996's own precondition refusals**, whose entire value is deciding once, at build: the whole image build re-ran on every River attempt to reach the same verdict. Discovery prints the marker itself now, because it is what knows the failure is about immutable source. A death that is NOT about the source (an OOM-killed step) prints nothing and stays retryable, deliberately.

## Verification

RED-verified per gap, and **the wiring separately** — asserting a row function in isolation proves its opinion and nothing about the build, and an unwired row is exactly the shape of defect this issue exists to stop, so the wiring test asks `static_mint_preconditions`, which is what discovery actually calls.

pgw#996's two "healthy image" rows now stub the CUDA-root axis the same way they already stub `g++`: the box running the suite is not an endpoint image, and without the fixture those rows answered about the CI runner (CUDA torch wheel, no `/usr/local/cuda` — the honest verdict is `refused` and it has nothing to do with the toy endpoint under test).

`examples/micro-diffusion` is **deliberately untouched**: the attempt-27 driver is hot-patching it mid-run with the verbatim synthesized recipe to unblock the live run, and the one-liner supersedes that afterward.

Strictly local: no pods, no RunPod calls, no deploys.