### PR TITLE
pgw#1013: the download size check moves inside the loop, at all four sites

### DIFF
--- a/changelog.d/pgw1013.md
+++ b/changelog.d/pgw1013.md
@@ -16,3 +16,32 @@
   `_recv_exact` accumulates into a `bytearray`. RED-verified through a real
   `AF_UNIX` socket: without the check the reader hangs until the socket
   timeout, because `settimeout` bounds each `recv` and not the accumulation.
+- **pgw#1013: four downloaders checked the size AFTER the loop; now all of them
+  check inside it.** Seven downloaders stream a remote body to disk. Three
+  compared the running byte count to the declared size per chunk and aborted at
+  the first excess byte; four wrote the whole body first and compared sizes once
+  it had ended — which is not a bound, it is a report on how far past the bound
+  the process already went. `gen_worker.bounded_stream.copy_bounded` is now the
+  single in-loop implementation, and `request_context._download_blob_by_digest`,
+  the `aot_cells` whole-file branch, `models/download._civitai_stream_one` and
+  `request_context/_datasets._download_url_streamed` all go through it. It takes
+  no default bound and refuses a non-positive one: a caller without a
+  declaration must derive one (`free_space_bound`) or refuse, so the vacuous
+  `if expected_size and total > expected_size` shape has no spelling.
+- **pgw#1013: `ctx.materialize_blob` had NO cap and NO verification, on the path
+  its own docstring calls "the untrusted case".** It now caps the transfer at the
+  response's declared length (demanding `identity` encoding, so an expanding
+  `Content-Encoding` cannot outgrow the number that bounded it), refuses a
+  response that declares no length at all, verifies the bytes against the digest
+  that addressed them in the same pass, and lands via a `.part` rename so a
+  refused fetch leaves nothing behind. The `aot_cells` whole-file branch had the
+  same `size_bytes` its chunked sibling passes to `download_chunked_file` and
+  ignored it; an entry that declares no size is now a typed miss.
+- **pgw#1013: the guard learned the shape the sweep tabled.**
+  `lint_unbounded_reads.py` now also refuses a loop that streams external bytes
+  into a sink without comparing the bytes-so-far against a limit inside the loop.
+  Calibrated against the four in-loop siblings so all four pass, and verified to
+  fire on all four defective sites as they stood at `d7881b40`. It found the two
+  CLI NDJSON readers (`cli/serve`, `cli/invoke`) buffering to a newline with
+  nothing counting — bounded now by `transport.MAX_NDJSON_LINE_BYTES`, which is
+  not "local dev only": the same reader serves `--listen tcp://0.0.0.0:PORT`.

--- a/scripts/lint_unbounded_reads.py
+++ b/scripts/lint_unbounded_reads.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """pgw#1013 / th#1662: a length read off external bytes may not size a read
-until something has bounded it.
+until something has bounded it, and a stream may not be copied without a bound
+checked INSIDE the loop.
 
 WHY THIS GUARD EXISTS. The §4.24 bounds census (pgw#973 / th#1620) enumerated
 every numeric constant and adjudicated each against "name the runaway you
@@ -36,13 +37,43 @@ Two ways, deliberately: §4.24 asks for a bound OR a stated reason none is
 needed, and a guard that only accepts the bound would push honest exemptions
 into silence.
 
-WHAT IT DOES NOT CATCH, stated so nobody reads a green run as proof of absence:
-this matches the SHAPE the specimens had — a binary length prefix feeding a read
-in the SAME function. A size that arrives via a return value, an attribute, a
-JSON field, or a DB column is out of reach of a rule this cheap. Widening it
-means dataflow analysis, and a noisy guard gets suppressed, which is worse than
-a narrow one that holds. The broader enumeration is the issue's job; this is the
-ratchet under it.
+RULE 2 — THE STREAMING-COPY LOOP ("check after the loop"). The dominant residual
+class the wave-1 sweep tabled. Seven downloaders copy a remote body to disk;
+three checked the running byte count inside the loop and aborted at the first
+excess byte, four wrote the whole body and compared sizes AFTER it ended. A
+check after the loop is not a bound — the bytes are already on disk, and the
+pod can be dead before the comparison runs.
+
+So: a loop that pulls a stream and sinks the bytes must, in the loop body,
+compare a running byte count against something. Concretely, the loop must
+
+  * hold a counter accumulated with ``total += len(chunk)``; and
+  * compare that counter directly (``total > cap``, ``cap < total``) somewhere
+    in the same loop body,
+
+or carry a ``# bound-justified:`` comment, exactly as rule 1 does. Loops that
+delegate to ``bounded_stream.copy_bounded`` have no loop here to inspect, which
+is the point of that helper existing.
+
+THIS RULE IS CALIBRATED, NOT GUESSED. The repo contains four correct in-loop
+implementations — ``models/chunk_cas``, ``models/cozy_cas``, ``input_assets``,
+``url_fetch`` — and the rule is written to pass all four and fail the four that
+were fixed under this issue. The counter must be a DIRECT operand of the
+compare: ``cozy_cas`` also compares ``downloaded - last_log >= log_every`` for
+progress logging, and a rule that accepted a counter buried in a sub-expression
+would have taken that for the bound.
+
+WHAT NEITHER RULE CATCHES, stated so nobody reads a green run as proof of
+absence. Rule 1 matches the SHAPE the specimens had — a binary length prefix
+feeding a read in the SAME function. A size arriving via a return value, an
+attribute, a JSON field, or a DB column is out of reach of a rule this cheap.
+Rule 2 sees loops; it does NOT see ``shutil.copyfileobj``, which is the same
+defect with the loop inside the stdlib, nor a sizeless ``.read()`` on a tar
+member (the 12-site family this issue still has tabled). Both were left out
+deliberately: ``copyfileobj`` in this tree is local file-to-file work, and
+folding the tar family in here would fire on sites another remainder owns.
+Widening either rule means dataflow analysis, and a noisy guard gets
+suppressed, which is worse than a narrow one that holds.
 
 Usage: scripts/lint_unbounded_reads.py   (exit 1 on any finding)
 """
@@ -69,6 +100,24 @@ JUSTIFICATION = "bound-justified:"
 
 # How far above the read line a justification comment may sit.
 JUSTIFICATION_LOOKBACK = 8
+
+# ---------------------------------------------------------------------------
+# Rule 2: the streaming-copy loop
+# ---------------------------------------------------------------------------
+
+# Iterators that yield a remote body a block at a time.
+STREAM_ITERATORS = {"iter_content", "iter_bytes", "iter_chunks", "iter_raw"}
+
+# Blocking block reads that, inside a `while`, form the same loop by hand.
+STREAM_READERS = {"read", "read1", "recv", "recv_into", "readinto"}
+
+# Calls that put the block somewhere it accumulates: a file, a list, a buffer.
+SINK_METHODS = {"write", "writelines", "append", "extend", "send", "put"}
+
+# Free functions that write a block through to storage (chunk_cas's positional
+# write). Named explicitly rather than matched by shape — a bare call is not
+# evidence of a sink.
+SINK_FUNCTIONS = {"_pwrite_all", "pwrite"}
 
 
 def _iter_targets(node: ast.AST):
@@ -124,6 +173,262 @@ class FunctionScan(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+ORDERING_OPS = (ast.Lt, ast.LtE, ast.Gt, ast.GtE)
+
+
+def _local_file_handles(fn: ast.AST) -> set[str]:
+    """Names this function bound to a file IT opened.
+
+    A handle the function opened itself is local IO, not an external stream:
+    every upload path in this repo reads its own artifact back in blocks, and
+    those loops are the bulk of what a `.read()`-shaped rule would flag. The
+    remote sources are the ones the function was HANDED (a socket parameter, a
+    guarded-stream context manager).
+    """
+    handles: set[str] = set()
+
+    def _opens(value: ast.AST) -> bool:
+        return isinstance(value, ast.Call) and _call_func_name(value) == "open"
+
+    for sub in _walk_scope(fn):
+        if isinstance(sub, ast.withitem):
+            if _opens(sub.context_expr) and isinstance(sub.optional_vars, ast.Name):
+                handles.add(sub.optional_vars.id)
+        elif isinstance(sub, ast.Assign) and _opens(sub.value):
+            for t in sub.targets:
+                handles.update(_iter_targets(t))
+    return handles
+
+
+def _walk_scope(node: ast.AST):
+    """`ast.walk` that stops at a nested function — one scope's own statements."""
+    stack = list(ast.iter_child_nodes(node))
+    while stack:
+        cur = stack.pop()
+        yield cur
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        stack.extend(ast.iter_child_nodes(cur))
+
+
+def _stream_block_name(node: ast.AST, local_handles: set[str]) -> "str | None":
+    """The name each iteration binds to the block of external bytes, or None.
+
+    None means "not an external stream loop" — either the loop is not one of
+    the two shapes, or it reads a handle this function opened itself.
+    """
+    if isinstance(node, ast.For):
+        it = node.iter
+        if (
+            isinstance(it, ast.Call)
+            and _call_func_name(it) in STREAM_ITERATORS
+            and isinstance(node.target, ast.Name)
+        ):
+            return node.target.id
+        return None
+    if isinstance(node, ast.While):
+        for sub in ast.walk(node):
+            if not (
+                isinstance(sub, ast.Assign)
+                and isinstance(sub.value, ast.Call)
+                and isinstance(sub.value.func, ast.Attribute)
+                and sub.value.func.attr in STREAM_READERS
+                and sub.value.args  # a sized block read, not a slurp
+            ):
+                continue
+            src = sub.value.func.value
+            if isinstance(src, ast.Name) and src.id in local_handles:
+                continue
+            if len(sub.targets) == 1 and isinstance(sub.targets[0], ast.Name):
+                return sub.targets[0].id
+    return None
+
+
+def _loop_condition_bounds_it(node: ast.AST) -> bool:
+    """`while remaining > 0` / `while len(buf) < n` — the test IS the bound.
+
+    A loop whose own condition is an ordering comparison stops on a size, and
+    reading its body for a second bound would flag the budget shape that is
+    already correct. `while True`, `while b"\\n" not in buf` and
+    `while terminal is None` bound nothing and are not covered by this.
+    """
+    if not isinstance(node, ast.While):
+        return False
+    test = node.test
+    return isinstance(test, ast.Compare) and any(
+        isinstance(op, ORDERING_OPS) for op in test.ops
+    )
+
+
+def _sink_names(body: list[ast.stmt], block: str) -> set[str]:
+    """The things the loop puts THAT BLOCK into, if any.
+
+    The block itself must be the argument. `chunks.append(ChunkPlan(...))`
+    accumulates plans derived from the bytes and drops the bytes; `f.write(
+    chunk)`, `buf.extend(chunk)` and `_pwrite_all(fd, b, pos)` accumulate the
+    bytes themselves, and only the second kind can run away. An empty result
+    means the loop does not accumulate and needs no bound.
+    """
+    sinks: set[str] = set()
+    for stmt in body:
+        for sub in ast.walk(stmt):
+            if isinstance(sub, ast.Call):
+                name = _call_func_name(sub)
+                if name in SINK_METHODS or name in SINK_FUNCTIONS:
+                    if any(isinstance(a, ast.Name) and a.id == block for a in sub.args):
+                        target = sub.func.value if isinstance(sub.func, ast.Attribute) else None
+                        sinks.add(target.id if isinstance(target, ast.Name) else name)
+            # `buf += chunk` — the quadratic accumulate the frame reader had.
+            if (
+                isinstance(sub, ast.AugAssign)
+                and isinstance(sub.op, ast.Add)
+                and isinstance(sub.value, ast.Name)
+                and sub.value.id == block
+                and isinstance(sub.target, ast.Name)
+            ):
+                sinks.add(sub.target.id)
+    return sinks
+
+
+def _byte_counters(body: list[ast.stmt]) -> set[str]:
+    """Names accumulated with `n += len(...)` — the running byte count."""
+    counters: set[str] = set()
+    for stmt in body:
+        for sub in ast.walk(stmt):
+            if (
+                isinstance(sub, ast.AugAssign)
+                and isinstance(sub.op, ast.Add)
+                and isinstance(sub.target, ast.Name)
+                and isinstance(sub.value, ast.Call)
+                and _call_func_name(sub.value) == "len"
+            ):
+                counters.add(sub.target.id)
+    return counters
+
+
+def _is_trivial_limit(node: ast.AST) -> bool:
+    """`> 0` / `>= 1` is an emptiness test, never a bound."""
+    return isinstance(node, ast.Constant) and node.value in (0, 1, None, True, False)
+
+
+def _measures_growth(node: ast.AST, counters: set[str], sinks: set[str]) -> bool:
+    """Does this side of a comparison hold how much has arrived so far?
+
+    Two spellings, because the repo legitimately uses both. An accumulated
+    counter (`total += len(chunk)`) must be a DIRECT operand — a counter buried
+    in a sub-expression is a progress log (`downloaded - last_log >=
+    log_every`), not a bound. A `len(sink)` reading may sit inside an
+    expression (`len(buf) + len(chunk) > cap`), because the `len()` call is
+    itself the unambiguous measurement, and a buffer that is DRAINED as it goes
+    cannot be tracked by an accumulator at all.
+    """
+    if isinstance(node, ast.Name) and node.id in counters:
+        return True
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Call)
+            and _call_func_name(sub) == "len"
+            and len(sub.args) == 1
+            and isinstance(sub.args[0], ast.Name)
+            and sub.args[0].id in (counters | sinks)
+        ):
+            return True
+    return False
+
+
+def _counter_is_bounded(body: list[ast.stmt], counters: set[str], sinks: set[str]) -> bool:
+    """Is the arrived-so-far quantity compared against a real limit in-loop?"""
+    for stmt in body:
+        for sub in ast.walk(stmt):
+            if not isinstance(sub, ast.Compare):
+                continue
+            for op, right in zip(sub.ops, sub.comparators):
+                if isinstance(op, (ast.Gt, ast.GtE)):
+                    grew, limit = sub.left, right
+                elif isinstance(op, (ast.Lt, ast.LtE)):
+                    grew, limit = right, sub.left
+                else:
+                    continue
+                if _measures_growth(grew, counters, sinks) and not _is_trivial_limit(limit):
+                    return True
+    return False
+
+
+def _justified_near(lines: list[str], lineno: int) -> bool:
+    start = max(0, lineno - 1 - JUSTIFICATION_LOOKBACK)
+    return any(JUSTIFICATION in ln for ln in lines[start:lineno])
+
+
+def _scan_stream_loops(path: Path, tree: ast.AST, lines: list[str]) -> list[str]:
+    # Handles are collected per scope and unioned DOWN the enclosing chain: a
+    # `with open(...)` in an enclosing function still names local IO inside a
+    # closure it defines, and a name opened in an unrelated function must not
+    # silence a socket that happens to share it.
+    parents: dict[int, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[id(child)] = node
+    handles_of: dict[int, set[str]] = {}
+
+    def _handles_for(node: ast.AST) -> set[str]:
+        scopes: list[ast.AST] = []
+        cur: "ast.AST | None" = node
+        while cur is not None:
+            if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Module)):
+                scopes.append(cur)
+            cur = parents.get(id(cur))
+        acc: set[str] = set()
+        for scope in scopes:
+            if id(scope) not in handles_of:
+                handles_of[id(scope)] = _local_file_handles(scope)
+            acc |= handles_of[id(scope)]
+        return acc
+
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.For, ast.While)):
+            continue
+        findings.extend(_scan_one_loop(path, node, lines, _handles_for(node)))
+    return findings
+
+
+def _scan_one_loop(
+    path: Path, node: ast.AST, lines: list[str], local_handles: set[str]
+) -> list[str]:
+    block = _stream_block_name(node, local_handles)
+    if block is None:
+        return []
+    body = node.body  # type: ignore[union-attr]
+    sinks = _sink_names(body, block)
+    if not sinks:
+        return []  # counts, hashes or discards; the bytes do not pile up
+    if _loop_condition_bounds_it(node):
+        return []  # the loop's own test is the bound
+    if _justified_near(lines, node.lineno):
+        return []
+    # A justification may also sit inside the loop, next to the write.
+    end = getattr(node, "end_lineno", node.lineno) or node.lineno
+    if any(JUSTIFICATION in ln for ln in lines[node.lineno - 1 : end]):
+        return []
+    rel = path.relative_to(SRC_ROOT.parent.parent)
+    counters = _byte_counters(body)
+    if _counter_is_bounded(body, counters, sinks):
+        return []
+    how = (
+        f"`{'`, `'.join(sorted(counters))}` counts the bytes but nothing compares it"
+        if counters
+        else "it keeps no running byte count"
+    )
+    return [
+        f"{rel}:{node.lineno}: this loop streams external bytes into "
+        f"`{'`, `'.join(sorted(sinks))}` and {how} inside the loop — any size check "
+        f"happens only after every byte is already written.\n"
+        f"    Fix: use `bounded_stream.copy_bounded`, or compare the bytes-so-far "
+        f"against the declared size IN the loop body, or state why no bound is needed "
+        f"with a `# {JUSTIFICATION} ...` comment."
+    ]
+
+
 def scan_file(path: Path, src: str) -> list[str]:
     try:
         tree = ast.parse(src, filename=str(path))
@@ -159,6 +464,8 @@ def scan_file(path: Path, src: str) -> list[str]:
                 f"    Fix: call a sanctioned validator ({', '.join(sorted(SANCTIONED_VALIDATORS))}) "
                 f"on it, or state why none is needed with a `# {JUSTIFICATION} ...` comment."
             )
+
+    findings.extend(_scan_stream_loops(path, tree, lines))
     return findings
 
 
@@ -177,7 +484,8 @@ def main() -> int:
         )
         return 1
 
-    print("unbounded-read guard: OK — every external length feeding a read is bounded or justified.")
+    print("unbounded-read guard: OK — every external length feeding a read, and every\n"
+          "streaming copy loop, is bounded or justified.")
     return 0
 
 

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -125,6 +125,16 @@ CI-SKIPPED tests/test_mint_oom_classification_pgw848.py|the memory cap did not o
 # it is counted here rather than left to look like a passing row.
 CI-SKIPPED tests/test_topology_fuzz_pgw867.py|got empty parameter set for (vector)
 
+# pgw#1013 wave 2. `test_rule_2_fires_on_all_four_filed_sites_as_they_were`
+# re-reads all four defective downloaders from `d7881b40` and asserts the guard
+# fires on each — `actions/checkout@v4` is shallow, so the commit is not in the
+# CI clone. WHERE THE PROPERTY IS MEASURED IN CI:
+# `test_rule_2_fires_on_each_filed_shape`, four parametrized rows carrying the
+# same four loops transcribed verbatim, which run everywhere. The git-backed row
+# is what keeps those transcriptions honest against the real files, and it runs
+# on every developer box.
+CI-SKIPPED tests/test_unbounded_read_guard_pgw1013.py|<hex> not in this checkout (shallow clone)
+
 # ─── LOCAL-ONLY ───────────────────────────────────────────────────────────────
 LOCAL-ONLY tests/test_lora_lifted_pgw725.py|set gen_worker_aot_pack_tests=# (packs a real .pt#; needs g++)
 LOCAL-ONLY tests/test_chunk_cas_parallel_th1362.py|multi-gb throughput measurement; set chunk_cas_bench=#

--- a/src/gen_worker/aot_cells.py
+++ b/src/gen_worker/aot_cells.py
@@ -56,6 +56,7 @@ from . import activity as activity_mod
 from . import aot_serve, cell_key
 from . import boot_phases as boot_mod
 from . import compile_cache as cc
+from .bounded_stream import copy_bounded
 from .procsplit import broker
 from .models.chunk_cas import sha256_file
 from .models.chunk_cas import (
@@ -340,6 +341,18 @@ def _download_artifact_inner(
         _emit("resolve_failed",
               f"family={family} key={key}: manifest entry has no URL")
         return None
+    # pgw#1013: the whole-file branch below had the SAME `size_bytes` field its
+    # chunked sibling passes to `download_chunked_file` as `total_size`, and
+    # ignored it — one manifest entry, two verdicts on the same declaration. A
+    # cell artifact is compiled code fetched before the pod serves anything;
+    # an entry that cannot say how big it is cannot be sized against the pod's
+    # disk, so it is a typed MISS here rather than an unbounded write.
+    declared_size = int(entry.get("size_bytes") or 0)
+    if not chunks and declared_size <= 0:
+        _emit("resolve_failed",
+              f"family={family} key={key}: manifest entry declares no size_bytes "
+              "— refusing an unbounded artifact fetch")
+        return None
     dest_dir.mkdir(parents=True, exist_ok=True)
     tmp = dest.with_suffix(".part")
     try:
@@ -351,7 +364,7 @@ def _download_artifact_inner(
                  for c in chunks],
                 tmp,
                 whole_digest=want_ref,
-                total_size=int(entry.get("size_bytes") or 0),
+                total_size=declared_size,
                 chunk_size_bytes=(
                     int(entry.get("chunk_size_bytes") or 0)
                     or CAS_CHUNK_SIZE_BYTES),
@@ -360,8 +373,13 @@ def _download_artifact_inner(
             with requests.get(url, timeout=_DOWNLOAD_TIMEOUT_S, stream=True) as dl:
                 dl.raise_for_status()
                 with open(tmp, "wb") as f:
-                    for chunk in dl.iter_content(1 << 20):
-                        f.write(chunk)
+                    got = copy_bounded(
+                        dl.iter_content(1 << 20), f.write,
+                        limit_bytes=declared_size,
+                        what=f"cell artifact family={family} key={key}")
+            if got != declared_size:
+                raise ValueError(
+                    f"truncated: manifest declares {declared_size} bytes, got {got}")
             verify_file_digest(tmp, want_ref)
     except (ValueError, RuntimeError) as exc:
         tmp.unlink(missing_ok=True)

--- a/src/gen_worker/bounded_stream.py
+++ b/src/gen_worker/bounded_stream.py
@@ -1,0 +1,135 @@
+"""pgw#1013: the one in-loop implementation of "a stream may not exceed its
+declared size", so there is not a fifth hand-rolled copy of it.
+
+THE DEFECT CLASS THIS CLOSES. Seven downloaders in this repo stream a remote
+body to disk. Three checked the running byte count INSIDE the loop and aborted
+at the first excess byte (`models/chunk_cas._fetch_chunk_to_offset`,
+`models/cozy_cas._stream`, `input_assets._download`, `url_fetch._read_capped`).
+Four wrote the whole body first and compared sizes AFTER the loop ended
+(`request_context._download_blob_by_digest`, `aot_cells` whole-file branch,
+`models/download._civitai_stream_one`, `request_context/_datasets.
+_download_url_streamed`). Same threat, two verdicts.
+
+A check after the loop is not a bound. It is a report on how far past the bound
+the process already went: the bytes are on disk, the disk may be full, and the
+pod may be dead before the comparison is reached. The declared size is known
+before the first byte arrives, so the only place the check belongs is the loop.
+
+WHY `limit_bytes` HAS NO DEFAULT AND MAY NOT BE ZERO. The sibling that was
+already in-loop but written `if expected_size and downloaded > expected_size`
+shows what a defaultable bound decays into: a manifest that omits its size
+yields 0, the guard evaluates false, and the site is unbounded again while
+still reading as guarded. Here the caller must produce a positive bound — from
+the declaration when it has one, from :func:`free_space_bound` when it does
+not, or by refusing the transfer. There is no spelling of "unbounded".
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+__all__ = [
+    "StreamTooLarge",
+    "copy_bounded",
+    "free_space_bound",
+    "DISK_RESERVE_BYTES",
+]
+
+#: Left unwritten on the destination filesystem by :func:`free_space_bound`.
+#: A transfer that fills a pod's disk to the last byte takes down every other
+#: writer on it — the model cache, the output staging dir, the logs.
+DISK_RESERVE_BYTES = 1 << 30  # 1 GiB, matching cozy_snapshot's headroom
+
+
+class StreamTooLarge(ValueError):
+    """A source sent more bytes than its declaration allows.
+
+    ``ValueError`` so the download retry loops already in this repo classify it
+    as a verification failure (permanent, strike-limited) rather than a
+    transport hiccup they should retry forever.
+    """
+
+    def __init__(self, what: str, limit_bytes: int, delivered: int) -> None:
+        super().__init__(
+            f"{what}: source sent more than its {limit_bytes}-byte declared "
+            f"size (aborted at {delivered} bytes)"
+        )
+        self.what = what
+        self.limit_bytes = limit_bytes
+        self.delivered = delivered
+
+
+def copy_bounded(
+    chunks: Iterable[bytes],
+    write: Callable[[bytes], Any],
+    *,
+    limit_bytes: int,
+    what: str,
+    hasher: Optional[Any] = None,
+    on_bytes: Optional[Callable[[int], None]] = None,
+    exceeded: Optional[Callable[[int, int], BaseException]] = None,
+) -> int:
+    """Copy ``chunks`` into ``write``, refusing at the byte that passes the cap.
+
+    Returns the number of bytes written. Raises before writing the chunk that
+    would take the total past ``limit_bytes`` — nothing beyond the cap reaches
+    the sink, and the source connection is abandoned by the caller's ``with``.
+
+    ``hasher`` is updated with every accepted chunk, so a caller verifying a
+    digest does it in the same pass rather than re-reading the file.
+    ``exceeded`` lets a caller keep its own error vocabulary; the default is
+    :class:`StreamTooLarge`.
+    """
+    if limit_bytes <= 0:
+        raise ValueError(
+            f"{what}: copy_bounded needs a positive byte bound; a caller with "
+            "no declared size must derive one (free_space_bound) or refuse"
+        )
+    total = 0
+    for chunk in chunks:
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > limit_bytes:
+            if exceeded is not None:
+                raise exceeded(limit_bytes, total)
+            raise StreamTooLarge(what, limit_bytes, total)
+        write(chunk)
+        if hasher is not None:
+            hasher.update(chunk)
+        if on_bytes is not None:
+            on_bytes(len(chunk))
+    return total
+
+
+def free_space_bound(path: "Path | str", *, reserve_bytes: int = DISK_RESERVE_BYTES) -> int:
+    """The bound of last resort for a transfer whose source declared no size.
+
+    Not a policy number: it is the resource that actually runs out, measured on
+    the filesystem the bytes are landing on. A transfer allowed to exceed it
+    does not merely overrun a budget, it ENOSPCs every other writer on the pod.
+
+    Raises :class:`~gen_worker.capability.InsufficientDiskError` when the
+    filesystem is already inside the reserve, because the honest answer there
+    is "do not start" rather than a bound of zero.
+    """
+    from .capability import InsufficientDiskError
+
+    root = Path(path)
+    try:
+        free = int(shutil.disk_usage(root).free)
+    except OSError as exc:
+        raise InsufficientDiskError(
+            f"cannot measure free space at {root}: {exc}", path=str(root)
+        ) from exc
+    bound = free - reserve_bytes
+    if bound <= 0:
+        raise InsufficientDiskError(
+            f"no room at {root}: {free} bytes free, {reserve_bytes} reserved",
+            available_bytes=free,
+            required_bytes=reserve_bytes,
+            path=str(root),
+        )
+    return bound

--- a/src/gen_worker/cli/invoke.py
+++ b/src/gen_worker/cli/invoke.py
@@ -339,6 +339,14 @@ def _send_request(
                 continue
             if not chunk:
                 break
+            if len(buf) + len(chunk) > transport.MAX_NDJSON_LINE_BYTES:
+                # pgw#1013: the same bound the server applies to the request
+                # line, applied to the response — a serve process that never
+                # sends `\n` must not grow this buffer without end.
+                raise run_mod._UsageError(
+                    f"serve sent more than {transport.MAX_NDJSON_LINE_BYTES} bytes "
+                    "without completing a response line"
+                )
             buf.extend(chunk)
     finally:
         if canceler is not None:

--- a/src/gen_worker/cli/serve.py
+++ b/src/gen_worker/cli/serve.py
@@ -845,6 +845,10 @@ def _handle_conn(endpoint: _Endpoint, conn: socket.socket) -> None:
             chunk = conn.recv(65536)
             if not chunk:
                 break
+            if len(buf) + len(chunk) > transport.MAX_NDJSON_LINE_BYTES:
+                # pgw#1013: refuse at the byte that passes the bound, not after
+                # the peer has finished deciding how much to send.
+                return
             buf.extend(chunk)
     except (socket.timeout, OSError):
         return

--- a/src/gen_worker/cli/transport.py
+++ b/src/gen_worker/cli/transport.py
@@ -25,6 +25,22 @@ from typing import NamedTuple
 # was the first cli module imported.
 DEFAULT_SOCKET_PATH = "./.gen-worker.sock"
 
+#: pgw#1013 — the largest NDJSON line either end will buffer before refusing.
+#:
+#: Both ends read bytes into a `bytearray` until a newline arrives, and neither
+#: end counted them: a peer that never sends `\n` grows that buffer until the
+#: process dies. The socket timeout does not bound it — `settimeout` bounds one
+#: `recv`, and a peer dribbling one byte per second resets it forever.
+#:
+#: This bound is NOT downgraded by "it is only the local dev socket": the same
+#: reader serves `--listen tcp://0.0.0.0:PORT`, where the peer is whoever
+#: reached the port.
+#:
+#: 256 MiB sits above the largest envelope this protocol legitimately carries
+#: (a multi-image result inlined as base64) and far below the memory of a host
+#: that can run the models behind it.
+MAX_NDJSON_LINE_BYTES = 256 << 20
+
 
 class Address(NamedTuple):
     """("unix", path, 0) | ("tcp", host, port)."""

--- a/src/gen_worker/models/download.py
+++ b/src/gen_worker/models/download.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional, Sequen
 from urllib.parse import parse_qs, urlparse
 
 from ..api.errors import ValidationError
+from ..bounded_stream import copy_bounded, free_space_bound
 from ..config import Settings, current_or
 
 _STANDALONE = Settings()
@@ -732,6 +733,13 @@ _CIVITAI_AUTH_HOSTS = {"civitai.com", "www.civitai.com", "api.civitai.com"}
 _CIVITAI_CHUNK = 4 * 1024 * 1024
 _CIVITAI_JSON_TIMEOUT = (30.0, 120.0)    # (connect, read) seconds
 _CIVITAI_STREAM_TIMEOUT = (60.0, 180.0)  # read timeout doubles as stall bound
+#: How far a civitai stream may exceed its declared `sizeBytes` before it is
+#: refused. Not slack for its own sake: the declaration is derived from
+#: `sizeKB`, a rounded float, so the true byte count is legitimately off by up
+#: to a kilobyte. The in-loop cap and the post-transfer size check use this one
+#: number, because a cap tighter than the acceptance rule refuses files the
+#: acceptance rule would accept.
+_CIVITAI_SIZE_SLACK = 1024
 
 
 def _civitai_attempts() -> int:
@@ -898,26 +906,42 @@ def _civitai_stream_one(
     dst.parent.mkdir(parents=True, exist_ok=True)
     tmp = dst.with_suffix(dst.suffix + ".part")
     h = hashlib.sha256()
-    written = 0
+    # pgw#1013. This is the THIRD-PARTY origin in the set — civitai chooses
+    # both the byte stream and the `sizeBytes` we would check it against — and
+    # its size check ran only after the whole body was on disk, where it is a
+    # report rather than a bound. Two bounds, because the declaration is
+    # optional here in a way it is not on our own surfaces:
+    #   * declared: the cap is the declaration plus the SAME 1 KiB tolerance
+    #     the post-check has always applied (sizeKB is a rounded float, live:
+    #     wan i2v 19224728441 vs actual ...442, e2e #112). One tolerance, used
+    #     twice — a cap tighter than the acceptance check would refuse files
+    #     the very next line accepts.
+    #   * undeclared: civitai omits `sizeBytes` on real files, so refusing is
+    #     not available. The bound is the destination filesystem, which is the
+    #     resource an unbounded weights download actually exhausts.
+    if expected_size:
+        cap = int(expected_size) + _CIVITAI_SIZE_SLACK
+    else:
+        cap = free_space_bound(tmp.parent)
     with requests.get(url, headers=headers, stream=True, timeout=_CIVITAI_STREAM_TIMEOUT) as resp:
         if resp.status_code in (401, 403):
             raise ValueError("civitai_access_denied")
         if resp.status_code == 404:
             raise ValueError("civitai_not_found")
         resp.raise_for_status()
-        with open(tmp, "wb") as f:
-            for chunk in resp.iter_content(chunk_size=_CIVITAI_CHUNK):
-                if not chunk:
-                    continue
-                f.write(chunk)
-                h.update(chunk)
-                written += len(chunk)
-                on_bytes(len(chunk))
-    # civitai's file size often comes from `sizeKB`, a ROUNDED float — the
-    # derived byte count can be off by ±1KB (live: wan i2v 19224728441 vs
-    # actual ...442, e2e #112). Integrity is the sha256 check below; the size
-    # check only catches truncated streams.
-    if expected_size and abs(written - expected_size) > 1024:
+        try:
+            with open(tmp, "wb") as f:
+                written = copy_bounded(
+                    resp.iter_content(chunk_size=_CIVITAI_CHUNK), f.write,
+                    limit_bytes=cap, what=f"civitai file {dst.name}",
+                    hasher=h, on_bytes=on_bytes,
+                )
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+    # Integrity is the sha256 check below; the size check only catches
+    # truncated streams (an overlong one never reaches here any more).
+    if expected_size and abs(written - expected_size) > _CIVITAI_SIZE_SLACK:
         tmp.unlink(missing_ok=True)
         raise ValueError(f"civitai size mismatch for {dst.name}: expected {expected_size}, got {written}")
     if expected_sha256 and h.hexdigest().lower() != expected_sha256:

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -176,6 +176,49 @@ def _parse_cas_digest(digest: str, *, origin: str) -> str:
     return f"{algo}:{hexpart.lower()}"
 
 
+def _cas_hasher(algo: str) -> Any:
+    """A hasher for a CAS algorithm ``_parse_cas_digest`` already accepted.
+
+    Every entry in :data:`_CAS_DIGEST_WIDTHS` must be constructible here: a
+    digest this repo can address but not hash is a download it would have to
+    take on trust, which is the shape pgw#882 and th#1303 S1 both refused.
+    """
+    if algo == "sha256":
+        return hashlib.sha256()
+    if algo == "blake3":
+        import blake3 as _blake3
+
+        return _blake3.blake3()
+    raise RuntimeError(f"no hasher for CAS algorithm {algo!r} — cannot verify the bytes")
+
+
+def _refuse_without_disk_room(root: Path, declared_bytes: int, what: str) -> None:
+    """Refuse a transfer the destination filesystem cannot hold.
+
+    A cap equal to the declared size stops a source that LIES; it does nothing
+    about a source that truthfully declares more bytes than the pod has. That
+    is the same runaway with a slower fuse — the write ENOSPCs, and it takes
+    every other writer on the pod with it. Deciding before the first byte turns
+    it into a typed refusal.
+    """
+    from ..bounded_stream import DISK_RESERVE_BYTES
+    from ..capability import InsufficientDiskError
+
+    try:
+        free = int(shutil.disk_usage(root).free)
+    except OSError:
+        return  # unmeasurable: the in-loop cap is still enforced
+    required = declared_bytes + DISK_RESERVE_BYTES
+    if required > free:
+        raise InsufficientDiskError(
+            f"insufficient disk for {what}: needs {declared_bytes} bytes "
+            f"(+{DISK_RESERVE_BYTES} reserve), {free} free at {root}",
+            available_bytes=free,
+            required_bytes=required,
+            path=str(root),
+        )
+
+
 def _as_asset(asset: Asset, cls: type) -> Any:
     """Re-type a plain Asset as a media Asset subclass (same fields)."""
     kw = {f: getattr(asset, f) for f in asset.__struct_fields__}
@@ -1646,17 +1689,41 @@ class _PublisherMixin:
         ``origin`` is the th#1259 provenance of the ADDRESS, and it is the
         only thing that decides how a terminal miss classifies. See
         :data:`REF_ORIGIN_PAYLOAD`.
+
+        pgw#1013 — this reader used to have NO cap and NO verification at all,
+        on the path its own public wrapper's docstring calls "the untrusted
+        case": a tenant handing a digest to ``materialize_blob`` got whatever
+        bytes arrived, in whatever quantity, written straight over ``dest``.
+        Both halves are fixed here and both are enforced DURING the stream:
+
+        * the response's declared length is the cap, checked per chunk. A
+          source with no ``Content-Length`` is refused — both arms of the hub's
+          by-digest route declare one (a 302 to a presigned object, or
+          ``DataFromReader`` with the object's size), so its absence means the
+          responder is not the one this contract describes. ``identity``
+          encoding is demanded so the declared length and the delivered length
+          are the same quantity, which also makes a gzip-bomb body impossible
+          rather than merely detectable.
+        * the digest ADDRESSES the bytes, so hashing them costs one pass and
+          refusing a mismatch costs nothing. It lands via a ``.part`` rename,
+          so a refused fetch cannot leave a partial file that a resume check
+          would read as complete.
         """
         # lazy: request_context is on the `import gen_worker` path, which the
         # `python -m gen_worker.discover` build step must keep requests-free.
         import requests
 
+        from ..bounded_stream import copy_bounded
+
         base = (self._file_api_base_url or "").strip().rstrip("/")
         token = self._get_worker_capability_token()
         digest_norm = _parse_cas_digest(digest, origin=origin)
         url = f"{base}/api/v1/blobs/{urllib.parse.quote(digest_norm, safe=':')}/content"
-        headers = {"Authorization": f"Bearer {token}"}
+        headers = {"Authorization": f"Bearer {token}", "Accept-Encoding": "identity"}
         caller_supplied = origin == REF_ORIGIN_PAYLOAD
+        algo, _, want_hex = digest_norm.partition(":")
+        hasher = _cas_hasher(algo)
+        tmp = dest.with_name(dest.name + ".part")
         with requests.get(url, headers=headers, stream=True, timeout=300) as resp:
             if resp.status_code in (401, 403):
                 if caller_supplied:
@@ -1668,10 +1735,40 @@ class _PublisherMixin:
                 raise RuntimeError(f"blob fetch 404 for digest={digest}")
             if resp.status_code < 200 or resp.status_code >= 300:
                 raise RuntimeError(f"blob fetch failed ({resp.status_code}) digest={digest}: {resp.text[:256]}")
-            with open(dest, "wb") as f:
-                for chunk in resp.iter_content(chunk_size=1024 * 1024):
-                    if chunk:
-                        f.write(chunk)
+            raw_length = str(resp.headers.get("Content-Length") or "").strip()
+            if not raw_length.isdigit() or int(raw_length) <= 0:
+                raise RuntimeError(
+                    f"blob fetch refused: digest={digest_norm} came back with no "
+                    f"declared length ({raw_length!r}) — nothing bounds the transfer"
+                )
+            declared = int(raw_length)
+            _refuse_without_disk_room(tmp.parent, declared, digest_norm)
+            try:
+                with open(tmp, "wb") as f:
+                    total = copy_bounded(
+                        resp.iter_content(chunk_size=1024 * 1024),
+                        f.write,
+                        limit_bytes=declared,
+                        what=f"blob {digest_norm}",
+                        hasher=hasher,
+                    )
+            except BaseException:
+                tmp.unlink(missing_ok=True)
+                raise
+        if total != declared:
+            tmp.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"blob fetch truncated: digest={digest_norm} declared {declared} "
+                f"bytes, delivered {total}"
+            )
+        got = hasher.hexdigest()
+        if got != want_hex:
+            tmp.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"blob digest mismatch: {digest_norm} addresses bytes that hash "
+                f"to {algo}:{got[:16]}…"
+            )
+        tmp.replace(dest)
 
     def _fetch_platform_blob(self, digest: str, dest: Path) -> None:
         """`_download_blob_by_digest` bound to PLATFORM provenance — for
@@ -1694,6 +1791,10 @@ class _PublisherMixin:
         the untrusted case and the safe default (th#1259): a bad address
         fails the REQUEST typed rather than indicting the release. Pass
         :data:`REF_ORIGIN_PLATFORM` for a digest the platform produced.
+
+        The bytes are capped at the response's declared length and verified
+        against the digest before ``dest`` exists (pgw#1013) — "the untrusted
+        case" is now a claim the code enforces rather than one it documents.
         """
         dest_path = Path(os.fspath(dest))
         dest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1736,7 +1736,7 @@ class _PublisherMixin:
             if resp.status_code < 200 or resp.status_code >= 300:
                 raise RuntimeError(f"blob fetch failed ({resp.status_code}) digest={digest}: {resp.text[:256]}")
             raw_length = str(resp.headers.get("Content-Length") or "").strip()
-            if not raw_length.isdigit() or int(raw_length) <= 0:
+            if not raw_length.isdigit():
                 raise RuntimeError(
                     f"blob fetch refused: digest={digest_norm} came back with no "
                     f"declared length ({raw_length!r}) — nothing bounds the transfer"
@@ -1745,7 +1745,11 @@ class _PublisherMixin:
             _refuse_without_disk_room(tmp.parent, declared, digest_norm)
             try:
                 with open(tmp, "wb") as f:
-                    total = copy_bounded(
+                    # An empty blob is a legal object with a real digest, and
+                    # zero is not a bound `copy_bounded` will accept — writing
+                    # the file and letting the digest check speak is the whole
+                    # of the work here.
+                    total = 0 if declared == 0 else copy_bounded(
                         resp.iter_content(chunk_size=1024 * 1024),
                         f.write,
                         limit_bytes=declared,

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..api.errors import AuthError, SnapshotBuildFailedError
+from ..bounded_stream import copy_bounded, free_space_bound
 from ..stall import SilenceWindow
 import requests
 
@@ -285,6 +286,12 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
 
     Writes to ``dest.tmp`` then renames, so a partial download can never be
     mistaken for a complete shard.
+
+    pgw#1013: the size comparison used to sit after the loop, where the bytes
+    are already on disk and the only thing it can report is how far past the
+    declaration the shard went. The declared size is known before the first
+    byte, so it caps the stream; an entry that declares none falls back to the
+    destination filesystem, which is what an unbounded shard exhausts.
     """
 
     tmp = dest.with_name(dest.name + ".tmp")
@@ -292,17 +299,21 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
     # Not `.get(...) or None`: an unverifiable download must be unreachable,
     # and the way that guarantee dies is a hasher that is allowed to be absent.
     hasher = _DIGEST_HASHERS[algo]()
-    total = 0
+    declared = int(expected_size) if expected_size is not None else 0
+    cap = declared if declared > 0 else free_space_bound(tmp.parent)
     with requests.get(url, stream=True, timeout=300) as resp:
         if resp.status_code < 200 or resp.status_code >= 300:
             raise RuntimeError(f"shard download failed ({resp.status_code}) url={url[:128]}")
-        with open(tmp, "wb") as f:
-            for chunk in resp.iter_content(chunk_size=_CHUNK_BYTES):
-                if not chunk:
-                    continue
-                f.write(chunk)
-                total += len(chunk)
-                hasher.update(chunk)
+        try:
+            with open(tmp, "wb") as f:
+                total = copy_bounded(
+                    resp.iter_content(chunk_size=_CHUNK_BYTES), f.write,
+                    limit_bytes=cap, what=f"dataset shard {dest.name}",
+                    hasher=hasher,
+                )
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
     if expected_size is not None and total != int(expected_size):
         tmp.unlink(missing_ok=True)
         raise RuntimeError(f"shard size mismatch: got {total}, want {expected_size}")

--- a/tests/test_blob_digest_qualified_pgw991.py
+++ b/tests/test_blob_digest_qualified_pgw991.py
@@ -14,6 +14,7 @@ worker-side assertion about it.
 """
 from __future__ import annotations
 
+import hashlib
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -21,6 +22,7 @@ from typing import Iterator
 from urllib.parse import unquote
 
 import pytest
+from blake3 import blake3
 
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.api.errors import (
@@ -34,10 +36,15 @@ from gen_worker.request_context import (
     ConversionContext,
 )
 
-BARE_HEX = "6f3306ab3b849905dd21c6e3073a2f88a4ae34ac4ee5f3af4bda597f559e9d17"
-SHA256_DIGEST = f"sha256:{BARE_HEX}"
-BLAKE3_DIGEST = "blake3:" + "aa" * 32
 BLOB_BYTES = b"real blob bytes"
+# pgw#1013: both addresses are derived from the bytes the rig serves, because
+# `_download_blob_by_digest` now verifies that the bytes hash to the digest
+# that named them. The subject of this file is unchanged — which ADDRESSES are
+# well-formed — but a rig serving one blob under an unrelated digest describes
+# a content-addressed store that does not content-address.
+BARE_HEX = hashlib.sha256(BLOB_BYTES).hexdigest()
+SHA256_DIGEST = f"sha256:{BARE_HEX}"
+BLAKE3_DIGEST = "blake3:" + blake3(BLOB_BYTES).hexdigest()
 
 # Every algorithm tensorhub `storage.casSupportedAlgos` keys on, and its width.
 _SUPPORTED = {"blake3": 64, "sha256": 64}

--- a/tests/test_payload_ref_provenance_th1259.py
+++ b/tests/test_payload_ref_provenance_th1259.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+from blake3 import blake3
 
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.api.errors import (
@@ -36,10 +37,14 @@ from gen_worker.request_context import (
     ConversionContext,
 )
 
-GOOD_DIGEST = "blake3:" + "aa" * 32
+BLOB_BYTES = b"real blob bytes"
+# pgw#1013: the digest ADDRESSES the bytes, and `_download_blob_by_digest`
+# now verifies that. A rig that serves one blob under an arbitrary digest is
+# describing a hub that cannot exist, so the "good" address is derived from the
+# bytes it names.
+GOOD_DIGEST = "blake3:" + blake3(BLOB_BYTES).hexdigest()
 MISSING_DIGEST = "sha256:6f3306ab3b849905dd21c6e3073a2f88a4ae34ac4ee5f3af4bda597f559e9d17"
 FORBIDDEN_DIGEST = "blake3:" + "bb" * 32
-BLOB_BYTES = b"real blob bytes"
 
 
 class _Hub(BaseHTTPRequestHandler):

--- a/tests/test_stream_bounds_pgw1013.py
+++ b/tests/test_stream_bounds_pgw1013.py
@@ -1,0 +1,508 @@
+"""pgw#1013 — the size check moves INSIDE the download loop, at four sites.
+
+THE DEFECT. Seven downloaders in this repo stream a remote body to disk. Three
+compared the running byte count to the declared size inside the loop and
+aborted at the first excess byte. Four wrote the whole body first and compared
+sizes after the loop had ended, which is not a bound: by the time the
+comparison runs the bytes are on disk, the disk may be full, and the pod may be
+gone. The worst of the four, `RequestContext._download_blob_by_digest`, had
+NEITHER a cap NOR any verification, on the path its own public wrapper
+(`materialize_blob`) documents as "the untrusted case".
+
+WHAT THESE TESTS ASSERT, and why it is not just "an error is raised". An error
+after the fact is exactly what the old code produced for three of the four
+sites. So every refusal below is checked for WHEN it happened: the rig servers
+count the bytes they managed to push, and an oversized transfer must be
+abandoned after roughly its declared size — not after the whole 32 MiB body.
+That difference is the entire issue.
+
+No mocks: every case runs a real `requests` client against a real
+`ThreadingHTTPServer` over a real socket, through the shipping download
+functions.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import http.server
+import json
+import threading
+import urllib.parse
+from pathlib import Path
+from typing import Any, Dict, Iterator, NamedTuple, Optional
+
+import pytest
+from blake3 import blake3
+
+from gen_worker.bounded_stream import StreamTooLarge, copy_bounded, free_space_bound
+from gen_worker.request_context import ConversionContext
+from gen_worker.request_context._datasets import _download_url_streamed
+
+# The rig always OFFERS this much body. A site that only checks after the loop
+# writes all of it; a site that checks in-loop abandons the connection early.
+BODY_BYTES = 32 << 20
+DECLARED_BYTES = 1 << 20
+
+# WHY THE OVERSIZE CASES DECLARE AN HONEST Content-Length. urllib3 enforces
+# Content-Length itself and stops reading at it, so a server that UNDER-declares
+# cannot be used to demonstrate anything — the excess never reaches our code.
+# The runaway that actually exists is the one these tests build: the transport
+# is honest about a large body, and it is the MANIFEST (the dataset entry, the
+# civitai `sizeBytes`, the cell entry's `size_bytes`) that says the file is
+# small. That declaration is what the four sites compared against after the
+# loop and now compare against inside it.
+#
+# `materialize_blob` is the exception and gets its own shape: its declaration
+# IS the transport length, so the only way past it is a `Content-Encoding` that
+# expands — see the gzip-bomb case.
+#: How far past its declared size a transfer may get before we call it
+#: "checked after the loop". Generous on purpose — kernel socket buffers on
+#: both ends carry bytes the client never asked for — but two orders of
+#: magnitude below the full body, which is what the old code wrote.
+ABORT_SLACK = 8 << 20
+
+
+# ---------------------------------------------------------------------------
+# Rig
+# ---------------------------------------------------------------------------
+
+class _Rig(http.server.ThreadingHTTPServer):
+    """Serves scripted bodies and records how many bytes each response got
+    onto the socket before the client hung up."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    routes: Dict[str, "_Route"]
+    served: Dict[str, int]
+    lock: threading.Lock
+
+
+class _Route(NamedTuple):
+    payload: bytes
+    declared: Optional[int] = None   # a Content-Length that lies about payload
+    chunked: bool = False            # no Content-Length at all
+    encoding: str = ""               # a Content-Encoding the client decodes
+    status: int = 200
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_a: Any) -> None:
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        srv: _Rig = self.server  # type: ignore[assignment]
+        path = urllib.parse.urlparse(self.path).path
+        route = srv.routes.get(path)
+        if route is None:
+            body = b'{"error":{"code":"not_found"}}'
+            self.send_response(404)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        payload, declared, chunked, encoding, status = route
+        if not chunked and declared is not None and declared != len(payload):
+            # A response whose body disagrees with its own Content-Length can
+            # only end by closing the connection — keep-alive would leave the
+            # client waiting for bytes that are never coming, which is the rig
+            # hanging rather than the code under test being wrong.
+            self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", "application/octet-stream")
+        if encoding:
+            self.send_header("Content-Encoding", encoding)
+        if chunked:
+            # No Content-Length at all — the shape a hub arm never produces.
+            self.send_header("Transfer-Encoding", "chunked")
+        else:
+            self.send_header(
+                "Content-Length",
+                str(len(payload) if declared is None else declared),
+            )
+        self.end_headers()
+        sent = 0
+        block = 64 << 10
+        try:
+            for off in range(0, len(payload), block):
+                piece = payload[off : off + block]
+                if chunked:
+                    self.wfile.write(b"%x\r\n" % len(piece) + piece + b"\r\n")
+                else:
+                    self.wfile.write(piece)
+                sent += len(piece)
+            if chunked:
+                self.wfile.write(b"0\r\n\r\n")
+        except (BrokenPipeError, ConnectionResetError):
+            # The client refused mid-transfer. That is the assertion.
+            self.close_connection = True
+        finally:
+            with srv.lock:
+                srv.served[path] = max(srv.served.get(path, 0), sent)
+
+
+@pytest.fixture()
+def rig() -> Iterator[_Rig]:
+    srv = _Rig(("127.0.0.1", 0), _Handler)
+    srv.routes = {}
+    srv.served = {}
+    srv.lock = threading.Lock()
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _url(rig: _Rig, path: str) -> str:
+    return f"http://127.0.0.1:{rig.server_port}{path}"
+
+
+def _serve(
+    rig: _Rig,
+    path: str,
+    payload: bytes,
+    *,
+    declared: Optional[int] = None,
+    chunked: bool = False,
+    encoding: str = "",
+    status: int = 200,
+) -> str:
+    rig.routes[path] = _Route(payload, declared, chunked, encoding, status)
+    return _url(rig, path)
+
+
+def _served(rig: _Rig, path: str) -> int:
+    with rig.lock:
+        return rig.served.get(path, 0)
+
+
+def _aborted_early(rig: _Rig, path: str) -> None:
+    """The refusal happened DURING the transfer, not after it."""
+    got = _served(rig, path)
+    assert got < ABORT_SLACK, (
+        f"{path}: the server pushed {got} bytes of a {BODY_BYTES}-byte body — "
+        "the check ran after the loop, not inside it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The shared helper: an unbounded copy has no spelling
+# ---------------------------------------------------------------------------
+
+def test_copy_bounded_refuses_a_zero_bound() -> None:
+    """The vacuous-guard shape (`if expected_size and total > expected_size`)
+    became unbounded whenever the manifest omitted the size. Here a caller
+    without a declaration cannot reach the loop at all."""
+    sink: list[bytes] = []
+    for bad in (0, -1):
+        with pytest.raises(ValueError) as ei:
+            copy_bounded([b"x"], sink.append, limit_bytes=bad, what="t")
+        assert "positive byte bound" in str(ei.value)
+    assert sink == []
+
+
+def test_copy_bounded_stops_at_the_byte_that_passes_the_cap() -> None:
+    sink: list[bytes] = []
+    with pytest.raises(StreamTooLarge):
+        copy_bounded([b"a" * 8, b"b" * 8, b"c" * 8], sink.append,
+                     limit_bytes=10, what="t")
+    # The chunk that would have crossed the cap never reached the sink.
+    assert b"".join(sink) == b"a" * 8
+
+
+def test_free_space_bound_is_positive_and_below_the_disk(tmp_path: Path) -> None:
+    import shutil
+
+    bound = free_space_bound(tmp_path)
+    assert 0 < bound < shutil.disk_usage(tmp_path).free
+
+
+# ---------------------------------------------------------------------------
+# materialize_blob — the worst of the four
+# ---------------------------------------------------------------------------
+
+BLOB = b"the addressed bytes" * 64
+BLOB_DIGEST = "sha256:" + hashlib.sha256(BLOB).hexdigest()
+
+
+def _blob_path(digest: str) -> str:
+    return f"/api/v1/blobs/{urllib.parse.quote(digest, safe=':')}/content"
+
+
+def _ctx(rig: _Rig) -> ConversionContext:
+    ctx = ConversionContext(request_id="r-pgw1013")
+    ctx._file_api_base_url = _url(rig, "")
+    ctx._worker_capability_token = "test-token"
+    return ctx
+
+
+def test_blob_legitimate_transfer_is_unaffected(rig: _Rig, tmp_path: Path) -> None:
+    path = _blob_path(BLOB_DIGEST)
+    _serve(rig, path, BLOB)
+    out = _ctx(rig).materialize_blob(BLOB_DIGEST, tmp_path / "ok.bin")
+    assert out.read_bytes() == BLOB
+    assert not (tmp_path / "ok.bin.part").exists()
+
+
+def test_blob_expanding_body_is_refused_at_the_declared_length(
+    rig: _Rig, tmp_path: Path
+) -> None:
+    """The filed defect: no cap at all, on the path documented as untrusted.
+
+    `Content-Encoding` is how a body outgrows the length that declared it — 32
+    MiB of zeros ships as a few KiB and the client decompresses it. The old
+    reader wrote every one of those 32 MiB to disk and compared nothing, ever.
+    The cap now stops it at the declared length, so the bomb costs the pod one
+    read block instead of its whole disk.
+    """
+    path = _blob_path(BLOB_DIGEST)
+    bomb = gzip.compress(b"\0" * BODY_BYTES)
+    _serve(rig, path, bomb, encoding="gzip")
+    assert len(bomb) < BODY_BYTES // 100, "rig is not actually a compression bomb"
+
+    with pytest.raises(StreamTooLarge) as ei:
+        _ctx(rig).materialize_blob(BLOB_DIGEST, tmp_path / "bomb.bin")
+
+    assert ei.value.limit_bytes == len(bomb)
+    assert ei.value.delivered <= len(bomb) + (1 << 20), (
+        "the refusal must land at the cap, not after the body expanded"
+    )
+    assert not (tmp_path / "bomb.bin").exists()
+    assert not (tmp_path / "bomb.bin.part").exists()
+
+
+def test_blob_without_a_declared_length_is_refused(rig: _Rig, tmp_path: Path) -> None:
+    """The uncapped case. Both arms of the hub's by-digest route declare a
+    length — a 302 to a presigned object, or `DataFromReader` with the object's
+    size — so a response that declares none is not the responder this contract
+    describes, and there is nothing left to bound the transfer with."""
+    path = _blob_path(BLOB_DIGEST)
+    _serve(rig, path, BLOB, chunked=True)
+
+    with pytest.raises(RuntimeError) as ei:
+        _ctx(rig).materialize_blob(BLOB_DIGEST, tmp_path / "nolen.bin")
+
+    assert "no declared length" in str(ei.value)
+    assert not (tmp_path / "nolen.bin").exists()
+    assert not (tmp_path / "nolen.bin.part").exists(), (
+        "the refusal must come before the file is opened, not after it is filled"
+    )
+
+
+def test_blob_digest_mismatch_is_refused(rig: _Rig, tmp_path: Path) -> None:
+    """The other missing half: the digest ADDRESSES the bytes, and nothing
+    checked that the bytes hashed to it. A content-addressed read that accepts
+    whatever arrives is not content-addressed."""
+    path = _blob_path(BLOB_DIGEST)
+    _serve(rig, path, b"different bytes entirely")
+
+    with pytest.raises(RuntimeError) as ei:
+        _ctx(rig).materialize_blob(BLOB_DIGEST, tmp_path / "bad.bin")
+
+    assert "digest mismatch" in str(ei.value)
+    assert not (tmp_path / "bad.bin").exists()
+    assert not (tmp_path / "bad.bin.part").exists()
+
+
+def test_blob_truncated_stream_leaves_nothing_behind(rig: _Rig, tmp_path: Path) -> None:
+    """Under the declared size rather than over it.
+
+    Which refusal fires is not the point and is not asserted: urllib3 enforces
+    Content-Length itself and usually raises first, with the post-loop
+    `total != declared` check as the backstop for a stream that ends cleanly
+    short. What IS the invariant, and what the old code did not have, is that
+    a refused fetch leaves no file — not the destination, and not a `.part`
+    that a later resume check would read as complete.
+    """
+    path = _blob_path(BLOB_DIGEST)
+    _serve(rig, path, BLOB[:20], declared=len(BLOB))
+
+    with pytest.raises(Exception):
+        _ctx(rig).materialize_blob(BLOB_DIGEST, tmp_path / "short.bin")
+
+    assert not (tmp_path / "short.bin").exists()
+    assert not (tmp_path / "short.bin.part").exists()
+
+
+def test_blob_verification_covers_the_blake3_namespace(rig: _Rig, tmp_path: Path) -> None:
+    """Both CAS algorithms the address parser accepts must be hashable here —
+    a digest this repo can address but not verify would be a download taken on
+    trust, which is the shape th#1303 S1 and pgw#882 both refused."""
+    digest = "blake3:" + blake3(BLOB).hexdigest()
+    path = _blob_path(digest)
+    _serve(rig, path, BLOB)
+    assert _ctx(rig).materialize_blob(digest, tmp_path / "b3.bin").read_bytes() == BLOB
+
+
+# ---------------------------------------------------------------------------
+# dataset shards
+# ---------------------------------------------------------------------------
+
+SHARD = b"shard payload" * 32
+SHARD_DIGEST = "sha256:" + hashlib.sha256(SHARD).hexdigest()
+
+
+def test_shard_legitimate_transfer_is_unaffected(rig: _Rig, tmp_path: Path) -> None:
+    url = _serve(rig, "/shard-ok", SHARD)
+    dest = tmp_path / "train.jsonl"
+    _download_url_streamed(
+        url, dest, expected_digest=SHARD_DIGEST, expected_size=len(SHARD))
+    assert dest.read_bytes() == SHARD
+
+
+def test_shard_oversized_stream_is_abandoned_mid_transfer(rig: _Rig, tmp_path: Path) -> None:
+    """The manifest entry says 1 MiB; the presigned URL hands back 32 MiB. The
+    old code wrote all 32 and then said so."""
+    url = _serve(rig, "/shard-big", b"\0" * BODY_BYTES)
+    dest = tmp_path / "big.jsonl"
+
+    with pytest.raises(StreamTooLarge):
+        _download_url_streamed(
+            url, dest, expected_digest=SHARD_DIGEST, expected_size=DECLARED_BYTES)
+
+    _aborted_early(rig, "/shard-big")
+    assert not dest.exists()
+    assert not dest.with_name(dest.name + ".tmp").exists()
+
+
+def test_shard_without_a_declared_size_is_still_bounded(rig: _Rig, tmp_path: Path) -> None:
+    """`size_bytes` is optional on a manifest entry, so refusing is not
+    available — the destination filesystem is the bound instead, and the
+    digest still has the final word."""
+    url = _serve(rig, "/shard-nosize", SHARD)
+    dest = tmp_path / "nosize.jsonl"
+    _download_url_streamed(
+        url, dest, expected_digest=SHARD_DIGEST, expected_size=None)
+    assert dest.read_bytes() == SHARD
+
+
+# ---------------------------------------------------------------------------
+# civitai — the third-party origin
+# ---------------------------------------------------------------------------
+
+WEIGHTS = b"safetensors-ish" * 100
+WEIGHTS_SHA = hashlib.sha256(WEIGHTS).hexdigest()
+
+
+def _civitai(url: str, dst: Path, *, expected_size: int, sha: str = "") -> int:
+    from gen_worker.models.download import _civitai_stream_one
+
+    return _civitai_stream_one(
+        url, dst, api_key="", expected_size=expected_size,
+        expected_sha256=sha or WEIGHTS_SHA, on_bytes=lambda _n: None,
+    )
+
+
+def test_civitai_legitimate_transfer_is_unaffected(rig: _Rig, tmp_path: Path) -> None:
+    url = _serve(rig, "/civ-ok", WEIGHTS)
+    assert _civitai(url, tmp_path / "m.safetensors", expected_size=len(WEIGHTS))
+    assert (tmp_path / "m.safetensors").read_bytes() == WEIGHTS
+
+
+def test_civitai_keeps_its_rounded_size_tolerance(rig: _Rig, tmp_path: Path) -> None:
+    """`sizeBytes` is derived from `sizeKB`, a rounded float, so the true count
+    is legitimately off by up to a kilobyte (live: wan i2v ...441 vs ...442).
+    The in-loop cap must not be tighter than the acceptance rule, or it refuses
+    files the next line would accept."""
+    url = _serve(rig, "/civ-round", WEIGHTS)
+    assert _civitai(url, tmp_path / "r.safetensors", expected_size=len(WEIGHTS) - 900)
+
+
+def test_civitai_oversized_stream_is_abandoned_mid_transfer(rig: _Rig, tmp_path: Path) -> None:
+    """civitai's API says `sizeBytes` is 1 MiB and its CDN hands back 32 MiB —
+    the third-party origin choosing both halves, which is exactly why the check
+    could not be left until the body had landed."""
+    url = _serve(rig, "/civ-big", b"\0" * BODY_BYTES)
+    dst = tmp_path / "big.safetensors"
+
+    with pytest.raises(StreamTooLarge):
+        _civitai(url, dst, expected_size=DECLARED_BYTES)
+
+    _aborted_early(rig, "/civ-big")
+    assert not dst.exists()
+    assert not dst.with_suffix(dst.suffix + ".part").exists()
+
+
+def test_civitai_sizeless_stream_is_still_bounded(rig: _Rig, tmp_path: Path) -> None:
+    """civitai really does omit `sizeBytes`, which made the old post-loop check
+    vacuous. The transfer still completes — and is still bounded, by the disk
+    it is landing on."""
+    url = _serve(rig, "/civ-nosize", WEIGHTS)
+    assert _civitai(url, tmp_path / "n.safetensors", expected_size=0) == len(WEIGHTS)
+
+
+# ---------------------------------------------------------------------------
+# AOT cell artifacts
+# ---------------------------------------------------------------------------
+
+ARTIFACT = b"cell-tarball-bytes" * 64
+ARTIFACT_DIGEST = "sha256:" + hashlib.sha256(ARTIFACT).hexdigest()
+
+
+def _resolve_route(rig: _Rig, repo: str, entry: Dict[str, Any]) -> None:
+    body = json.dumps({"files": [entry]}).encode()
+    rig.routes[f"/api/v1/repos/{repo}/resolve"] = _Route(body)
+
+
+def _fetch_cell(rig: _Rig, cache: Path, key: str) -> Optional[Path]:
+    from gen_worker import aot_cells
+    from gen_worker import aot_serve
+    from gen_worker import boot_phases as boot_mod
+
+    with boot_mod.span(
+        boot_mod.PHASE_CELL_FETCH,
+        artifact_kind=aot_serve.ARTIFACT_KIND,
+        artifact_key=key,
+    ) as fetch:
+        return aot_cells._download_artifact_inner(
+            _url(rig, ""), "bearer", "fam", "ckpt-1", key, cache, fetch)
+
+
+def _repo_for(family: str = "fam") -> str:
+    from gen_worker import compile_cache as cc
+
+    return cc.system_repo(family)
+
+
+def test_cell_artifact_legitimate_transfer_is_unaffected(rig: _Rig, tmp_path: Path) -> None:
+    url = _serve(rig, "/cell.tar.gz", ARTIFACT)
+    _resolve_route(rig, _repo_for(), {
+        "path": "cell.tar.gz", "url": url,
+        "digest": ARTIFACT_DIGEST, "size_bytes": len(ARTIFACT),
+    })
+    out = _fetch_cell(rig, tmp_path, "k-ok")
+    assert out is not None and out.read_bytes() == ARTIFACT
+
+
+def test_cell_artifact_without_size_bytes_is_a_typed_miss(rig: _Rig, tmp_path: Path) -> None:
+    """The chunked sibling branch passes this exact field to
+    `download_chunked_file` as `total_size`; the whole-file branch had it and
+    ignored it. An entry that cannot say how big it is now costs the pilot lane
+    a miss rather than an unbounded fetch — a cell miss self-mints, so failing
+    closed here is free."""
+    url = _serve(rig, "/cell-nosize.tar.gz", ARTIFACT)
+    _resolve_route(rig, _repo_for(), {
+        "path": "cell-nosize.tar.gz", "url": url, "digest": ARTIFACT_DIGEST,
+    })
+    assert _fetch_cell(rig, tmp_path, "k-nosize") is None
+    assert _served(rig, "/cell-nosize.tar.gz") == 0, "no bytes fetched at all"
+
+
+def test_cell_artifact_oversized_stream_is_abandoned_mid_transfer(
+    rig: _Rig, tmp_path: Path
+) -> None:
+    url = _serve(rig, "/cell-big.tar.gz", b"\0" * BODY_BYTES)
+    _resolve_route(rig, _repo_for(), {
+        "path": "cell-big.tar.gz", "url": url,
+        "digest": ARTIFACT_DIGEST, "size_bytes": DECLARED_BYTES,
+    })
+
+    assert _fetch_cell(rig, tmp_path, "k-big") is None
+    _aborted_early(rig, "/cell-big.tar.gz")
+    assert not (tmp_path / "aot-cells" / "k-big.tar.gz").exists()
+    assert not (tmp_path / "aot-cells" / "k-big.part").exists()

--- a/tests/test_stream_bounds_pgw1013.py
+++ b/tests/test_stream_bounds_pgw1013.py
@@ -329,6 +329,17 @@ def test_blob_truncated_stream_leaves_nothing_behind(rig: _Rig, tmp_path: Path) 
     assert not (tmp_path / "short.bin.part").exists()
 
 
+def test_blob_empty_blob_is_a_legal_object(rig: _Rig, tmp_path: Path) -> None:
+    """Zero bytes is a real object with a real digest, and zero is not a bound
+    `copy_bounded` accepts. The declared-length refusal must not swallow it —
+    a cap that refuses the empty file is a cap that broke a legal read."""
+    digest = "sha256:" + hashlib.sha256(b"").hexdigest()
+    path = _blob_path(digest)
+    _serve(rig, path, b"")
+    out = _ctx(rig).materialize_blob(digest, tmp_path / "empty.bin")
+    assert out.read_bytes() == b""
+
+
 def test_blob_verification_covers_the_blake3_namespace(rig: _Rig, tmp_path: Path) -> None:
     """Both CAS algorithms the address parser accepts must be hashable here —
     a digest this repo can address but not verify would be a download taken on

--- a/tests/test_unbounded_read_guard_pgw1013.py
+++ b/tests/test_unbounded_read_guard_pgw1013.py
@@ -331,12 +331,76 @@ def test_rule_2_no_false_positive(src: str):
     assert _scan(src) == []
 
 
-def test_rule_2_fires_on_all_four_filed_sites_as_they_were():
-    """The ratchet, proved against history rather than against a fixture.
+# The four loops as they stood at d7881b40, transcribed verbatim from the
+# shipping files (imports and surrounding logic dropped; the loop and the check
+# around it are byte-for-byte). This is the CI-runnable half of the proof — the
+# git-backed test below reads the real files and can only run on a full clone.
+PRE_FIX_SHAPES = {
+    "request_context._download_blob_by_digest": (
+        "def fetch(resp, dest):\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1024 * 1024):\n"
+        "            if chunk:\n"
+        "                f.write(chunk)\n"
+    ),
+    "aot_cells whole-file branch": (
+        "def fetch(dl, tmp, want_ref):\n"
+        "    with open(tmp, 'wb') as f:\n"
+        "        for chunk in dl.iter_content(1 << 20):\n"
+        "            f.write(chunk)\n"
+        "    verify_file_digest(tmp, want_ref)\n"
+    ),
+    "models/download._civitai_stream_one": (
+        "def fetch(resp, tmp, h, on_bytes, expected_size, dst):\n"
+        "    written = 0\n"
+        "    with open(tmp, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=4 * 1024 * 1024):\n"
+        "            if not chunk:\n"
+        "                continue\n"
+        "            f.write(chunk)\n"
+        "            h.update(chunk)\n"
+        "            written += len(chunk)\n"
+        "            on_bytes(len(chunk))\n"
+        "    if expected_size and abs(written - expected_size) > 1024:\n"
+        "        raise ValueError('size mismatch')\n"
+    ),
+    "_datasets._download_url_streamed": (
+        "def fetch(resp, tmp, hasher, expected_size):\n"
+        "    total = 0\n"
+        "    with open(tmp, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            if not chunk:\n"
+        "                continue\n"
+        "            f.write(chunk)\n"
+        "            total += len(chunk)\n"
+        "            hasher.update(chunk)\n"
+        "    if expected_size is not None and total != int(expected_size):\n"
+        "        raise RuntimeError('shard size mismatch')\n"
+    ),
+}
 
-    Every one of the four sites this issue names is re-read from `origin/master`
-    and run through the guard. A rule that only passes on the fixed tree proves
-    nothing about whether it would have caught the defect.
+
+@pytest.mark.parametrize("site", sorted(PRE_FIX_SHAPES))
+def test_rule_2_fires_on_each_filed_shape(site: str):
+    """The ratchet, on every shape this issue closed.
+
+    A rule that only passes on the fixed tree proves nothing about whether it
+    would have caught the defect. Each of these is the loop the defect actually
+    had, including the post-loop comparison that made it LOOK checked.
+    """
+    findings = _scan(PRE_FIX_SHAPES[site])
+    assert len(findings) == 1, f"{site}: {findings}"
+    assert "streams external bytes" in findings[0]
+
+
+def test_rule_2_fires_on_all_four_filed_sites_as_they_were():
+    """The same proof against the REAL files, which is what keeps the
+    transcriptions above honest — a fixture that drifted from the code it
+    quotes would assert about a shape that never existed.
+
+    Needs the pre-fix commit, so it cannot run on CI's shallow checkout; the
+    parametrized test above is where this property is measured there. That
+    disposition is recorded in `scripts/skip_census.txt`.
     """
     # Pinned rather than derived: `merge-base HEAD origin/master` moves to the
     # fix itself the moment this lands, and the test would then assert the

--- a/tests/test_unbounded_read_guard_pgw1013.py
+++ b/tests/test_unbounded_read_guard_pgw1013.py
@@ -177,3 +177,185 @@ def test_a_distant_justification_does_NOT_carry():
 ])
 def test_no_false_positive(src: str):
     assert _scan(src) == []
+
+
+# --------------------------------------------------------------------------
+# Rule 2 — the streaming-copy loop ("check AFTER the loop")
+#
+# The dominant residual class the wave-1 sweep tabled: four downloaders wrote
+# a whole remote body to disk and compared sizes only once it had ended. The
+# rule is calibrated against the four siblings that already checked in-loop —
+# it must pass every one of them and fail every one of the four that were
+# fixed, which the "real tree" and "against the pre-fix sources" tests below
+# assert with the shipping code rather than with fixtures.
+# --------------------------------------------------------------------------
+
+def test_catches_the_check_after_the_loop_shape():
+    """The exact shape of `_download_url_streamed` and `_civitai_stream_one`:
+    a counter that exists, and is compared one line too late."""
+    findings = _scan(
+        "def fetch(resp, dest, expected):\n"
+        "    total = 0\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            f.write(chunk)\n"
+        "            total += len(chunk)\n"
+        "    if total != expected:\n"
+        "        raise ValueError('too big')\n"
+    )
+    assert len(findings) == 1, findings
+    assert "`total` counts the bytes" in findings[0]
+
+
+def test_catches_a_stream_loop_with_no_count_at_all():
+    """`_download_blob_by_digest` — the worst of the four. Nothing to compare,
+    because nothing was counted."""
+    findings = _scan(
+        "def fetch(resp, dest):\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            if chunk:\n"
+        "                f.write(chunk)\n"
+    )
+    assert len(findings) == 1, findings
+    assert "no running byte count" in findings[0]
+
+
+def test_the_in_loop_check_satisfies_rule_2():
+    """The siblings' shape, which is the authority the fix copied."""
+    findings = _scan(
+        "def fetch(resp, dest, cap):\n"
+        "    total = 0\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            total += len(chunk)\n"
+        "            if total > cap:\n"
+        "                raise ValueError('too big')\n"
+        "            f.write(chunk)\n"
+    )
+    assert findings == []
+
+
+def test_a_len_reading_of_a_drained_buffer_counts_as_the_bound():
+    """The CLI's NDJSON readers drain the buffer as lines complete, so an
+    accumulator would overcount across drains and `len(buf)` is the only honest
+    measurement. Rule 2 accepts it — a rule that demanded one spelling would
+    have pushed those two sites into a wrong fix."""
+    findings = _scan(
+        "def read_line(conn, cap):\n"
+        "    buf = bytearray()\n"
+        "    while b'\\n' not in buf:\n"
+        "        chunk = conn.recv(65536)\n"
+        "        if not chunk:\n"
+        "            break\n"
+        "        if len(buf) + len(chunk) > cap:\n"
+        "            return None\n"
+        "        buf.extend(chunk)\n"
+        "    return buf\n"
+    )
+    assert findings == []
+
+
+def test_a_progress_log_is_not_mistaken_for_a_bound():
+    """`cozy_cas` compares `downloaded - last_log >= log_every` to decide when
+    to log. A rule that accepted a counter anywhere inside a comparison would
+    have read that as the bound and passed an unbounded loop."""
+    findings = _scan(
+        "def fetch(resp, dest, log_every):\n"
+        "    total = 0\n"
+        "    last = 0\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            f.write(chunk)\n"
+        "            total += len(chunk)\n"
+        "            if total - last >= log_every:\n"
+        "                last = total\n"
+    )
+    assert len(findings) == 1, findings
+
+
+def test_an_emptiness_test_is_not_a_bound():
+    findings = _scan(
+        "def fetch(resp, dest):\n"
+        "    total = 0\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            total += len(chunk)\n"
+        "            if total > 0:\n"
+        "                f.write(chunk)\n"
+    )
+    assert len(findings) == 1, findings
+
+
+def test_rule_2_takes_the_justification_comment_too():
+    findings = _scan(
+        "def fetch(resp, dest):\n"
+        "    with open(dest, 'wb') as f:\n"
+        "        # bound-justified: the body is this process's own output,\n"
+        "        # read back over loopback from a server it started.\n"
+        "        for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+        "            f.write(chunk)\n"
+    )
+    assert findings == []
+
+
+@pytest.mark.parametrize("src", [
+    # A budget loop: the loop's own test is the bound (`chunk_cas._take`,
+    # `procsplit.child._recv_exact`).
+    "def take(src, fd, remaining):\n"
+    "    buf = bytearray()\n"
+    "    while len(buf) < remaining:\n"
+    "        b = src.recv(4096)\n"
+    "        if not b:\n"
+    "            break\n"
+    "        buf.extend(b)\n"
+    "    return buf\n",
+    # A handle THIS function opened is local IO, not an external stream —
+    # every upload path in the repo reads its own artifact back in blocks.
+    "def upload(path, stream):\n"
+    "    with open(path, 'rb') as fin:\n"
+    "        while True:\n"
+    "            chunk = fin.read(8 << 20)\n"
+    "            if not chunk:\n"
+    "                break\n"
+    "            stream.write(chunk)\n",
+    # The loop derives facts and drops the bytes; nothing accumulates.
+    "def plan(resp, out):\n"
+    "    import hashlib\n"
+    "    h = hashlib.sha256()\n"
+    "    for chunk in resp.iter_content(chunk_size=1 << 20):\n"
+    "        h.update(chunk)\n"
+    "        out.append(len(chunk))\n",
+])
+def test_rule_2_no_false_positive(src: str):
+    assert _scan(src) == []
+
+
+def test_rule_2_fires_on_all_four_filed_sites_as_they_were():
+    """The ratchet, proved against history rather than against a fixture.
+
+    Every one of the four sites this issue names is re-read from `origin/master`
+    and run through the guard. A rule that only passes on the fixed tree proves
+    nothing about whether it would have caught the defect.
+    """
+    # Pinned rather than derived: `merge-base HEAD origin/master` moves to the
+    # fix itself the moment this lands, and the test would then assert the
+    # guard fires on code that no longer has the defect. This sha is the commit
+    # the fix branched from and is immutable. CI checks out shallow, so a miss
+    # is a skip, not a failure — the local run is where this earns its keep.
+    PRE_FIX = "d7881b40"
+    sites = [
+        "src/gen_worker/request_context/__init__.py",
+        "src/gen_worker/aot_cells.py",
+        "src/gen_worker/models/download.py",
+        "src/gen_worker/request_context/_datasets.py",
+    ]
+    for site in sites:
+        proc = subprocess.run(
+            ["git", "show", f"{PRE_FIX}:{site}"],
+            capture_output=True, text=True, cwd=REPO)
+        if proc.returncode != 0 or not proc.stdout:
+            pytest.skip(f"{PRE_FIX} not in this checkout (shallow clone)")
+        findings = scan_file(REPO / site, proc.stdout)
+        loop_findings = [f for f in findings if "streams external bytes" in f]
+        assert loop_findings, f"the guard would have walked past {site}"


### PR DESCRIPTION
Closes the dominant residual class pgw#1013's wave 1 tabled.

## The defect

Seven downloaders in this repo stream a remote body to disk. Three compared the
running byte count to the declared size **per chunk** and aborted at the first
excess byte. Four wrote the whole body first and compared sizes **after** the
loop ended. Same threat, two verdicts.

A check after the loop is not a bound. It is a report on how far past the bound
the process already went: the bytes are on disk, the disk may be full, and the
pod may be dead before the comparison is reached.

| site | had | now |
|---|---|---|
| `request_context._download_blob_by_digest` | **no cap AND no verification**, reachable from tenant code as `materialize_blob(..., origin=REF_ORIGIN_PAYLOAD)` — whose own docstring calls that "the untrusted case" | capped at the declared length, digest-verified in the same pass, `.part` rename |
| `aot_cells` whole-file branch | ignored the `size_bytes` its chunked sibling passes as `total_size` | in-loop cap; an entry declaring no size is a typed miss |
| `models/download._civitai_stream_one` | third-party origin, post-loop check, vacuous when civitai omits `sizeBytes` | in-loop cap at `sizeBytes + 1 KiB` (the same rounding tolerance the acceptance check already applied), `free_space_bound` when undeclared |
| `_datasets._download_url_streamed` | post-loop size check | in-loop cap; `free_space_bound` when the entry declares none |

## One implementation, not a fourth copy

`gen_worker/bounded_stream.py` — `copy_bounded(chunks, write, *, limit_bytes,
what, hasher=None, ...)`. It takes **no default bound and refuses a
non-positive one**, so the vacuous `if expected_size and total > expected_size`
shape (unbounded exactly when the manifest omits the size) has no spelling: a
caller without a declaration derives one from `free_space_bound` — the resource
that actually runs out — or refuses.

## materialize_blob's missing cap, per §4.24

Its declaration is the response's `Content-Length`, and both arms of the hub's
by-digest route produce one (a 302 to a presigned object, or `DataFromReader`
with the object's size), so a response declaring none is **refused** — the
uncapped case has no legitimate instance to justify. `Accept-Encoding: identity`
is demanded so the declared length and the delivered length are the same
quantity, which makes an expanding `Content-Encoding` impossible rather than
merely detectable. A `declared > free space` transfer is refused before the
first byte, since a cap equal to a truthful declaration does nothing about a
body the pod cannot hold. And the digest **addresses** the bytes, so it is
verified in the same pass — that check was simply absent.

## The guard learned the shape (rule 2)

`scripts/lint_unbounded_reads.py` now also refuses a loop that streams external
bytes into a sink without comparing the bytes-so-far to a limit inside the loop.

Calibrated, not guessed: the counter must be a **direct** operand of the
comparison, because `cozy_cas` also compares `downloaded - last_log >=
log_every` for progress logging and a looser rule would have taken that for the
bound. Budget loops (`while remaining > 0`, `while len(buf) < n`) and handles
the function opened itself are excluded — that is what keeps every upload path
out of it. Its first run produced exactly two findings beyond the four filed
sites, both real: the CLI NDJSON readers in `cli/serve` and `cli/invoke`,
buffering to a newline with nothing counting. Bounded now by
`transport.MAX_NDJSON_LINE_BYTES`. That closes the tabled `cli/serve.py:839`
remainder, and corrects its "local dev-CLI socket only" downgrade: the same
reader serves `--listen tcp://0.0.0.0:PORT`.

`test_rule_2_fires_on_all_four_filed_sites_as_they_were` re-reads all four
files from `d7881b40` and asserts the guard fires on each. A rule that only
passes on the fixed tree proves nothing about whether it would have caught the
defect.

## RED — real sockets, no mocks of the reader

`tests/test_stream_bounds_pgw1013.py`: a real `ThreadingHTTPServer` and a real
`requests` client through the shipping functions. The rig **counts the bytes it
got onto the wire**, and every oversize case asserts the transfer was abandoned
after roughly its declared size rather than after the whole 32 MiB body — "an
error was raised" is what the old code already did for three of the four.

Note recorded in the test file: urllib3 enforces `Content-Length` itself, so an
under-declaring transport cannot demonstrate anything. The runaway that exists
is the transport being honest about a large body while the **manifest** says
the file is small — which is the declaration all four sites were comparing
against too late. `materialize_blob` gets its own shape (a gzip bomb) because
its declaration *is* the transport length.

Two existing rigs had to be corrected: `pgw#991` and `th#1259` served one blob
under an arbitrary digest. That describes a content-addressed store that does
not content-address, and their subject (which addresses are well-formed) is
unchanged.

## Verified locally

- `mypy src/gen_worker` — clean, 239 files
- `lint_unbounded_reads` / `lint_http_timeouts` / `lint_unreached_surface` / `lint_config_reads` — exit 0
- `assemble_changelog.py --check` — OK
- new: 19 stream-bound tests, 22 guard tests (11 new for rule 2)

Strictly local: no pods, no deploys, no GPU.