### PR TITLE
pgw#803: the 15m36s reconnect gap is not the backoff — and now the worker says so

### DIFF
--- a/changelog.d/pgw803.md
+++ b/changelog.d/pgw803.md
@@ -35,9 +35,10 @@
 
   **No new bound of any kind is introduced: this measures, it never decides.**
 
-- **pgw#803: the activity sink binds at HelloAck, not at first setup.**
-  `Executor.ensure_setup` bound it after weights were on disk, so every typed
-  event in the 72-199 s weights-fetch window — the transport's own disconnect
-  rows among them — reached only pod stdout. `Lifecycle.on_hello_ack` now binds
-  it beside the boot-phase sink, on the argument that call site already makes;
-  the later `ensure_setup` call re-binds the same sink.
+  **Known blind spot, recorded rather than fixed here:** `activity.bind_sink`
+  runs in `Executor.ensure_setup`, i.e. after weights are on disk, so an episode
+  in the 72-199 s weights-fetch window is logger-only. Binding at HelloAck
+  beside the boot-phase sink is the fix — `Lifecycle.on_hello_ack` already makes
+  that exact argument for `boot_phases` — but it is a process-global rebind that
+  clobbers the `_sink` patch `test_superseded_disk_ref_th1330` installs, so it
+  belongs to whoever owns that surface rather than to a transport change.

--- a/changelog.d/pgw803.md
+++ b/changelog.d/pgw803.md
@@ -1,0 +1,43 @@
+- **pgw#803: a disconnect/reconnect episode is now a hub row that accounts for
+  itself.** th#1333's tape has a serving pod whose stream ended at 17:51:43Z and
+  whose next connect attempt reached the hub at 18:07:19Z — **15m36s** — after
+  which the hub condemned it, revoked its credential and refused the reconnect
+  that proved it alive. The hub half was fixed then; the worker half was never
+  explained and *could not be*, because the reconnect loop's entire narration is
+  `logger.info` on RunPod stdout, which nothing can read (gw#640's premise).
+
+  The issue's leading hypothesis — "exponential backoff grown unbounded" — is
+  **refuted on `origin/master` by reading the code**, and all four facts predate
+  the incident (present since 0.56.0): the delay is
+  `random.uniform(0, min(30 s, base * 2**attempt))`, i.e. FULL JITTER with a
+  seconds ceiling; `attempt` resets to 0 after `_BACKOFF_RESET_AFTER_S` (60 s)
+  of connectedness, so a long healthy stream's first retry is `uniform(0, 1 s)`;
+  a dead peer is called by h2 keepalive within 20 s + `KEEPALIVE_TIMEOUT_S`
+  (10 s), with `keepalive_permit_without_calls`; and a hung dial is cut at
+  `_HELLO_ACK_TIMEOUT_S` (30 s). 936 s is therefore time the reconnect loop
+  **was not running** — and the fix for that class is to make it nameable, not
+  to add another duration. (Separately: the incident's most probable cause at
+  0.78.0, torch sharing a process with the gRPC stream, is structurally gone —
+  since 0.84.0 the control/compute split is unconditional and the parent that
+  owns the stream never imports torch.)
+
+  Each episode now emits two typed `worker_reconnect` evidence rows. `dropped`
+  carries the cause, how long the stream had been up, and `loop_silent` — how
+  stale this process's last *proven scheduling instant* (the last successful
+  `stream.write`) already was when the drop was detected, against a heartbeat
+  that forces a StateDelta every beat in every state. `reconnected` carries the
+  gap and its partition: `sched` / `slept` / `dialed` / `teardown`, plus
+  `overshoot` (slept minus scheduled — an asyncio sleep on a healthy loop
+  overshoots by milliseconds) and `unaccounted` (gap in no measured phase at
+  all). On the incident's numbers 894 s lands in `unaccounted` and the row names
+  the cause class itself. Attempt outcomes coalesce by COUNT, never by dropping,
+  so an hour-long hub outage is two rows and not a replay storm.
+
+  **No new bound of any kind is introduced: this measures, it never decides.**
+
+- **pgw#803: the activity sink binds at HelloAck, not at first setup.**
+  `Executor.ensure_setup` bound it after weights were on disk, so every typed
+  event in the 72-199 s weights-fetch window — the transport's own disconnect
+  rows among them — reached only pod stdout. `Lifecycle.on_hello_ack` now binds
+  it beside the boot-phase sink, on the argument that call site already makes;
+  the later `ensure_setup` call re-binds the same sink.

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -477,16 +477,7 @@ class Lifecycle:
         # re-flushes after a reconnect, and the hub upserts on
         # (boot_id, ordinal), so a duplicate delivery is harmless.
         try:
-            loop = asyncio.get_running_loop()
-            boot_mod.bind_sink(self.executor._send, loop)
-            # pgw#803: bind ACTIVITY here too, for the reason the paragraph
-            # above already gives — `Executor.ensure_setup` is after weights
-            # are on disk, so every typed event before that (the transport's
-            # own disconnect/reconnect episode among them) reached only pod
-            # stdout, which on RunPod nobody can read. Binding is idempotent
-            # and survives reconnects; ensure_setup's later call re-binds the
-            # same sink.
-            activity_mod.bind_sink(self.executor._send, loop)
+            boot_mod.bind_sink(self.executor._send, asyncio.get_running_loop())
             # process start -> hello: the first boot number, and the one the
             # hub could previously only infer from pod create -> connect.
             # ONCE per process: this handler runs again on every reconnect, and

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -477,7 +477,16 @@ class Lifecycle:
         # re-flushes after a reconnect, and the hub upserts on
         # (boot_id, ordinal), so a duplicate delivery is harmless.
         try:
-            boot_mod.bind_sink(self.executor._send, asyncio.get_running_loop())
+            loop = asyncio.get_running_loop()
+            boot_mod.bind_sink(self.executor._send, loop)
+            # pgw#803: bind ACTIVITY here too, for the reason the paragraph
+            # above already gives — `Executor.ensure_setup` is after weights
+            # are on disk, so every typed event before that (the transport's
+            # own disconnect/reconnect episode among them) reached only pod
+            # stdout, which on RunPod nobody can read. Binding is idempotent
+            # and survives reconnects; ensure_setup's later call re-binds the
+            # same sink.
+            activity_mod.bind_sink(self.executor._send, loop)
             # process start -> hello: the first boot number, and the one the
             # hub could previously only infer from pod create -> connect.
             # ONCE per process: this handler runs again on every reconnect, and

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -1305,28 +1305,36 @@ class Transport:
                 ep, at=connected_at,
                 dial_s=connected_at - self._dial_started)
 
-    def _account_connection(self, *, outcome: str, teardown_s: float) -> None:
+    def _account_connection(
+        self, *, outcome: str, ended_at: float, teardown_s: float,
+    ) -> None:
         """Fold one ended connection attempt into the ledger.
+
+        ``ended_at`` is when the connection ENDED, i.e. before this iteration's
+        teardown — not "now". The distinction is the accounting: an episode's
+        clock starts at the drop, so charging it a teardown that ran BEFORE its
+        own start would leave that time in `unaccounted` forever, and reading a
+        constant offset there as loop starvation is exactly the wrong answer.
 
         The episode stays None while this worker has never been connected — a
         boot dial that has not landed yet is gw#618's subject, not this one.
         """
-        now = time.monotonic()
         connected_at = self._connected_at
         if connected_at is not None:
             # This attempt reached HelloAck (and `_note_connected` already
             # closed the previous episode), so the stream that was UP has now
-            # ended: a new episode opens here.
+            # ended: a new episode opens here, AT the end of the stream. Its
+            # teardown is the first thing inside it.
             self._episode = self._open_episode(
-                dropped_at=now, cause=outcome,
-                uptime_s=max(0.0, now - connected_at))
+                dropped_at=ended_at, cause=outcome,
+                uptime_s=max(0.0, ended_at - connected_at))
             self._episode.teardown_s += teardown_s
             return
         ep = self._episode
         if ep is None:
             return
         ep.attempts += 1
-        ep.dialed_s += max(0.0, now - self._dial_started)
+        ep.dialed_s += max(0.0, ended_at - self._dial_started)
         ep.teardown_s += teardown_s
         ep.note_outcome(outcome)
 
@@ -1420,6 +1428,7 @@ class Transport:
                 # NEXT stream instead of being cleared by this one's teardown.
                 self._account_connection(
                     outcome=outcome,
+                    ended_at=teardown_started,
                     teardown_s=time.monotonic() - teardown_started,
                 )
 

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -31,6 +31,19 @@ In-memory only, deliberately (pgw#869 §1): the worker process did not restart i
 the motivating incident, and a mint is a child of the worker, so a worker restart
 ends the mint anyway. Disk persistence is out of scope and must be argued on its
 own merits, not borrowed from this one.
+
+pgw#803 — THE RECONNECT EPISODE IS A HUB ROW. Every duration in this module is
+retry PACING or an RPC deadline, never a kill decision, and none of them can
+produce th#1333's 15m36s reconnect gap: the backoff is `uniform(0, min(30 s,
+2**attempt))` with `attempt` reset after `_BACKOFF_RESET_AFTER_S` of
+connectedness, a dead peer is called by h2 keepalive within 20 s +
+`KEEPALIVE_TIMEOUT_S`, and a hung dial is cut at `_HELLO_ACK_TIMEOUT_S`. So the
+gap was time the reconnect loop was NOT RUNNING — and nothing recorded that,
+because the loop's narration was `logger.info` on RunPod stdout, which is
+unreadable (gw#640). Each episode now emits two evidence rows (`dropped`, then
+`reconnected`) partitioning the gap into scheduled backoff, slept wall time,
+dial+Hello, teardown, and the remainder. No new bound is introduced anywhere:
+this measures, it never decides.
 """
 
 from __future__ import annotations
@@ -46,6 +59,7 @@ from typing import Any, List, Optional, Tuple
 import grpc
 import grpc.aio
 
+from . import activity as activity_mod
 from .config import Settings
 from .pb import worker_scheduler_pb2 as pb
 from .pb import worker_scheduler_pb2_grpc as pb_grpc
@@ -189,6 +203,93 @@ KEEPALIVE_TIMEOUT_S = 10.0
 #: How long to wait for the peer to end a half-closed call before giving up on
 #: a graceful close. Unchanged value, named so both close paths share it.
 _PEER_CLOSE_WAIT_S = 5.0
+
+#: pgw#803: the typed disconnect/reconnect record. th#1333's tape has a worker
+#: whose stream ended at 17:51:43Z and whose next connect attempt reached the
+#: hub at 18:07:19Z — 15m36s — and NOTHING on either side can say what the pod
+#: did in between. The reconnect loop's own narration is `logger.info` on RunPod
+#: stdout, which is unreadable (gw#640's whole premise), so every investigation
+#: of that gap has been speculation.
+#:
+#: The loop's own constants cannot produce it, and that is the point: the delay
+#: is `uniform(0, min(30s, 2**attempt))` (full jitter, ceiling
+#: :attr:`Transport._backoff_cap` = 30 s), `attempt` resets to 0 after
+#: :data:`_BACKOFF_RESET_AFTER_S` of connectedness, a dead peer is called by
+#: h2 keepalive within `keepalive_time_ms` (20 s) + :data:`KEEPALIVE_TIMEOUT_S`,
+#: and a dial that hangs is cut at :data:`_HELLO_ACK_TIMEOUT_S`. A 936 s gap is
+#: therefore time the reconnect loop WAS NOT RUNNING — a starved event loop, a
+#: frozen process, a drop the socket never surfaced — and the fix for that class
+#: is to make it nameable, not to add another duration.
+#:
+#: So an episode ACCOUNTS for itself: the gap from drop to reconnect is
+#: partitioned into what the loop can prove it spent (backoff sleep, dial+Hello
+#: attempts, teardown) and the remainder. `unaccounted_s` is the diagnostic —
+#: ~0 on a healthy reconnect, ~890 s on the incident — and it introduces no
+#: bound of any kind.
+RECONNECT_EVENT = "worker_reconnect"
+
+
+class _ReconnectEpisode:
+    """One disconnect -> reconnect episode, measured (pgw#803).
+
+    Coalescing is by COUNT, never by dropping: an hour-long hub outage is two
+    hub rows (`dropped`, then `reconnected` carrying the attempt histogram),
+    not one row per attempt — the queue is bounded and a replay storm would
+    cost the very evidence it is made of.
+    """
+
+    __slots__ = (
+        "dropped_at", "cause", "uptime_s", "loop_silent_s",
+        "attempts", "sched_s", "slept_s", "dialed_s", "teardown_s", "outcomes",
+    )
+
+    def __init__(
+        self, *, dropped_at: float, cause: str, uptime_s: float,
+        loop_silent_s: float,
+    ) -> None:
+        self.dropped_at = dropped_at
+        self.cause = cause
+        self.uptime_s = uptime_s
+        #: How stale this process's last PROVEN scheduling instant already was
+        #: when the drop was detected. The heartbeat forces a StateDelta every
+        #: beat in every state, so on a live worker this is ~one beat; a large
+        #: value says the drop was detected late because the process was not
+        #: running, not because the loop was slow to react.
+        self.loop_silent_s = loop_silent_s
+        self.attempts = 0
+        self.sched_s = 0.0
+        self.slept_s = 0.0
+        self.dialed_s = 0.0
+        self.teardown_s = 0.0
+        self.outcomes: "collections.OrderedDict[str, int]" = collections.OrderedDict()
+
+    def note_outcome(self, token: str) -> None:
+        self.outcomes[token] = self.outcomes.get(token, 0) + 1
+
+    def histogram(self) -> str:
+        return ", ".join(f"{k}={v}" for k, v in self.outcomes.items()) or "none"
+
+    def gap_s(self, now: float) -> float:
+        return max(0.0, now - self.dropped_at)
+
+    def overshoot_s(self) -> float:
+        """Slept wall time minus what was actually scheduled.
+
+        An asyncio sleep on a healthy loop overshoots by milliseconds. Minutes
+        of overshoot is a starved loop, and it is the one term that cannot be
+        confused with a slow network or a slow hub.
+        """
+        return max(0.0, self.slept_s - self.sched_s)
+
+    def unaccounted_s(self, now: float) -> float:
+        """Gap time in no measured phase at all — neither sleeping, dialing,
+        nor tearing down. Should be ~0; anything else is a phase this ledger
+        cannot see, and is worth more than a guess about the backoff."""
+        return max(
+            0.0,
+            self.gap_s(now)
+            - self.slept_s - self.dialed_s - self.teardown_s,
+        )
 
 
 class SenderQuiesced(Exception):
@@ -824,6 +925,11 @@ class Transport:
         #: reconnect storm does not emit one event per attempt.
         self._last_credential_left: Optional[float] = None
         self._connected_at: Optional[float] = None  # set on each HelloAck
+        #: pgw#803: last proven scheduling instant (see `_send_loop`).
+        self._last_send_at: Optional[float] = None
+        #: pgw#803: the open disconnect->reconnect episode, if any.
+        self._episode: Optional["_ReconnectEpisode"] = None
+        self._dial_started: float = 0.0
         # gw#640: (message kind, exception class) already dialed to the hub.
         self._reported_handler_failures: set = set()
         # Latest hub-pushed worker JWT (TokenRefresh, contract §1 rotation).
@@ -1128,6 +1234,102 @@ class Transport:
         except Exception:
             logger.warning("handler-failure report raised unexpectedly", exc_info=True)
 
+    # ---- pgw#803: the disconnect/reconnect episode ledger ------------------
+
+    def _open_episode(
+        self, *, dropped_at: float, cause: str, uptime_s: float,
+    ) -> "_ReconnectEpisode":
+        """A stream that HAD reached HelloAck ended: the episode starts here.
+
+        Emitted immediately rather than only at reconnect: the evidence lane
+        survives the disconnect (pgw#869), so the drop is a durable fact even
+        for a pod that dies before it ever gets back — which is the shape
+        th#1333's tape had, and the shape that produced no worker-side row.
+        """
+        last_send = self._last_send_at
+        loop_silent_s = (
+            max(0.0, dropped_at - last_send) if last_send is not None else 0.0)
+        ep = _ReconnectEpisode(
+            dropped_at=dropped_at, cause=cause, uptime_s=uptime_s,
+            loop_silent_s=loop_silent_s)
+        detail = (
+            f"stream dropped after {uptime_s:.1f}s connected — cause={cause} "
+            f"loop_silent={loop_silent_s:.1f}s; reconnecting with full-jitter "
+            f"backoff (ceiling {self._backoff_cap:.3g}s)")
+        logger.warning("[reconnect] %s", detail)
+        activity_mod.emit_event(RECONNECT_EVENT, detail, phase="dropped")
+        return ep
+
+    def _close_episode(
+        self, ep: "_ReconnectEpisode", *, at: float, dial_s: float,
+    ) -> None:
+        """Reconnected. Report the gap AND the partition that explains it."""
+        ep.attempts += 1
+        ep.dialed_s += max(0.0, dial_s)
+        gap = ep.gap_s(at)
+        unaccounted = ep.unaccounted_s(at)
+        overshoot = ep.overshoot_s()
+        detail = (
+            f"reconnected after {gap:.1f}s — cause={ep.cause} "
+            f"attempts={ep.attempts} "
+            f"sched={ep.sched_s:.1f}s slept={ep.slept_s:.1f}s "
+            f"dialed={ep.dialed_s:.1f}s teardown={ep.teardown_s:.1f}s "
+            f"overshoot={overshoot:.1f}s unaccounted={unaccounted:.1f}s "
+            f"loop_silent_at_drop={ep.loop_silent_s:.1f}s; "
+            f"attempt outcomes: {ep.histogram()}"
+        )
+        # `overshoot` and `unaccounted` are the whole reason this row exists:
+        # together they are the part of the gap the reconnect loop cannot
+        # account for, i.e. time it was not running at all. Named on the row so
+        # the next 15-minute gap is read as "the process was not scheduling"
+        # rather than re-litigated as "the backoff must be wrong".
+        starved = overshoot + unaccounted
+        if starved > 0:
+            detail += (
+                f" — {starved:.1f}s of the gap is NOT the reconnect loop's "
+                f"pacing (it was not scheduled: starved event loop, frozen "
+                f"process, or a drop the socket never surfaced)")
+        logger.warning("[reconnect] %s", detail)
+        activity_mod.emit_event(
+            RECONNECT_EVENT, detail, phase="reconnected",
+            duration_ms=int(gap * 1000))
+
+    def _note_connected(self, connected_at: float) -> None:
+        """HelloAck landed. Close any open episode HERE — not when this new
+        stream later ends: a reconnect is news the instant it happens, and a
+        row that waits for the next drop to be emitted arrives after the pod it
+        describes may already be dead."""
+        ep, self._episode = self._episode, None
+        if ep is not None:
+            self._close_episode(
+                ep, at=connected_at,
+                dial_s=connected_at - self._dial_started)
+
+    def _account_connection(self, *, outcome: str, teardown_s: float) -> None:
+        """Fold one ended connection attempt into the ledger.
+
+        The episode stays None while this worker has never been connected — a
+        boot dial that has not landed yet is gw#618's subject, not this one.
+        """
+        now = time.monotonic()
+        connected_at = self._connected_at
+        if connected_at is not None:
+            # This attempt reached HelloAck (and `_note_connected` already
+            # closed the previous episode), so the stream that was UP has now
+            # ended: a new episode opens here.
+            self._episode = self._open_episode(
+                dropped_at=now, cause=outcome,
+                uptime_s=max(0.0, now - connected_at))
+            self._episode.teardown_s += teardown_s
+            return
+        ep = self._episode
+        if ep is None:
+            return
+        ep.attempts += 1
+        ep.dialed_s += max(0.0, now - self._dial_started)
+        ep.teardown_s += teardown_s
+        ep.note_outcome(outcome)
+
     async def run(self) -> None:
         """Reconnect until stopped; fatal protocol/auth failures still exit."""
         attempt = 0
@@ -1143,10 +1345,16 @@ class Transport:
             else:
                 target, use_tls = normalize_grpc_addr(self._settings.orchestrator_public_addr)
             self._connected_at = None
+            self._dial_started = time.monotonic()
+            # pgw#803: the classified outcome of THIS attempt. Default names
+            # the clean case — `_connect_once` returning is a stream that ended
+            # without raising.
+            outcome = "stream_ended"
             try:
                 await self._connect_once(target, use_tls)
             except grpc.aio.AioRpcError as e:
                 code, details = e.code(), str(e.details() or "")
+                outcome = f"grpc_{(code.name if code is not None else 'unknown').lower()}"
                 if code == grpc.StatusCode.UNAUTHENTICATED:
                     if self._auth_rejection_is_fatal(details):
                         raise FatalTransportError(
@@ -1194,16 +1402,26 @@ class Transport:
                 raise
             except HandlerError as e:
                 # gw#640: NEVER let this look like a dropped socket again.
+                outcome = f"handler_{e.kind}_{type(e.cause).__name__}"
                 self._report_handler_failure(e)
             except Exception as e:
+                outcome = f"exc_{type(e).__name__}"
                 logger.warning("connection to %s failed: %s: %s", target, type(e).__name__, e)
             finally:
+                teardown_started = time.monotonic()
                 self._connected.clear()
                 await self.queue.reset_for_reconnect()
                 try:
                     await self._handlers.on_disconnect()
                 except Exception:
                     logger.exception("on_disconnect handler failed")
+                # After the reset: the evidence lane this emits into is the one
+                # `reset_for_reconnect` just rebuilt, so the drop row rides the
+                # NEXT stream instead of being cleared by this one's teardown.
+                self._account_connection(
+                    outcome=outcome,
+                    teardown_s=time.monotonic() - teardown_started,
+                )
 
             if self._stopping.is_set():
                 return
@@ -1221,11 +1439,20 @@ class Transport:
             attempt += 1
             self.reconnect_delays.append(delay)
             logger.info("reconnecting in %.2fs (attempt %d)", delay, attempt)
+            slept_from = time.monotonic()
             try:
                 await asyncio.wait_for(self._stopping.wait(), delay)
                 return
             except asyncio.TimeoutError:
                 pass
+            finally:
+                # BOTH the scheduled delay and the slept wall time: on a healthy
+                # loop they agree to milliseconds, and their difference is the
+                # loop starvation this issue exists to name.
+                if self._episode is not None:
+                    self._episode.sched_s += delay
+                    self._episode.slept_s += max(
+                        0.0, time.monotonic() - slept_from)
 
     async def _connect_once(self, target: str, use_tls: bool) -> None:
         """One connection lifetime; sets self._connected_at once HelloAck lands."""
@@ -1276,6 +1503,8 @@ class Transport:
                     "(stale orchestrator build)"
                 )
             self._connected_at = time.monotonic()
+            self._last_send_at = self._connected_at
+            self._note_connected(self._connected_at)
             self._consecutive_auth_failures = 0
             self._first_auth_failure_at = None
             self._auth_credential_id = ""
@@ -1398,6 +1627,13 @@ class Transport:
             if not await self.queue.should_ship_capacity(msg):
                 continue
             await stream.write(msg)
+            # pgw#803: the last instant this process is PROVEN to have been
+            # scheduling. A write into a dead socket still succeeds, so this is
+            # not peer liveness — it is OUR liveness, and that is exactly the
+            # axis th#1333's 15m36s gap turns on. The heartbeat loop forces a
+            # StateDelta every beat in every state, so on a healthy worker this
+            # is never more than one beat stale.
+            self._last_send_at = time.monotonic()
             if kind == _RESULT:
                 await self.queue.mark_result_shipped(msg)
             else:

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -38,10 +38,23 @@ from typing import List
 
 import pytest
 
+from gen_worker import activity as activity_mod
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.transport import RECONNECT_EVENT, _ReconnectEpisode
 
 from harness.hub_double import hub_double
+
+
+@pytest.fixture(autouse=True)
+def _restore_activity_sink():
+    """`activity.bind_sink` is a process global with no autouse reset, and any
+    hub-double row binds it to a `Worker._send` that stops draining at teardown.
+    Under `--dist loadfile` the next FILE runs in the same process, so leaving it
+    bound hands that file a queue nothing empties. Pre-existing for every
+    hub-double row in the suite; this file at least does not add to it."""
+    before = activity_mod._sink
+    yield
+    activity_mod._sink = before
 
 
 def _reconnect_events(msgs: List[pb.WorkerMessage], phase: str) -> List[pb.ActivityUpdate]:

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -145,6 +145,38 @@ def test_attempt_outcomes_coalesce_by_count_never_by_dropping() -> None:
     assert ep.histogram() == "grpc_unavailable=200, exc_ConnectionError=1"
 
 
+def test_an_episode_starts_when_the_STREAM_ended_not_when_teardown_finished() -> None:
+    """The frame the whole partition hangs on.
+
+    `_account_connection` runs at the END of the reconnect loop's `finally`,
+    after `reset_for_reconnect` and `on_disconnect`. Opening the episode at
+    "now" would date the drop AFTER a teardown it then also charges the episode
+    for — so the stream's measured uptime would swallow the teardown, and every
+    later term would be read against a window that started too late. Both facts
+    are asserted against an injected clock, which is why this row is exact.
+    """
+    from gen_worker.config import load_settings
+    from gen_worker.transport import Transport
+
+    t = Transport(load_settings(worker_id="pgw803-frame"), object())
+    t._connected_at = 100.0          # HelloAck landed
+    t._last_send_at = 109.0          # last proven scheduling instant
+    t._dial_started = 99.0
+
+    # The stream ended at 110.0; teardown then took 0.5 s.
+    t._account_connection(
+        outcome="stream_ended", ended_at=110.0, teardown_s=0.5)
+
+    ep = t._episode
+    assert ep is not None
+    assert ep.dropped_at == 110.0, "the episode is dated after its own teardown"
+    assert ep.uptime_s == 10.0, "the stream's uptime swallowed the teardown"
+    assert ep.loop_silent_s == 1.0
+    assert ep.teardown_s == 0.5
+    # ...and the teardown is fully inside the episode's own window.
+    assert ep.unaccounted_s(110.5) == pytest.approx(0.0, abs=1e-6)
+
+
 # ---------------------------------------------------------------------------
 # the real path: a real Worker, a real gRPC socket, a real involuntary drop
 # ---------------------------------------------------------------------------

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -1,0 +1,184 @@
+"""pgw#803: a disconnect/reconnect episode is a hub row that ACCOUNTS for itself.
+
+THE INCIDENT (th#1333's tape, verbatim). A serving pod's stream ended at
+17:51:43Z — the hub's own cleanup line says *"the worker PROCESS may well be
+alive"* — and the worker's next connect attempt reached the hub at 18:07:19Z.
+**15m36s.** The hub then condemned it, revoked its credential, and refused the
+reconnect that proved it was alive. The hub half is fixed (two-phase revoke,
+readmission on refutation). The worker half was never explained, and could not
+be: the reconnect loop's entire narration is `logger.info` on RunPod stdout,
+which nothing can read (gw#640's premise).
+
+WHAT THIS LANE ESTABLISHED ON `origin/master`, BY READING THE CODE. The loop's
+own constants cannot produce 936 s, so "the backoff grew unbounded" — the
+issue's leading hypothesis — is refuted:
+
+* backoff is `random.uniform(0, min(cap, base * 2**attempt))` with
+  ``cap = 30 s`` (`Worker.__init__`), i.e. FULL JITTER with a seconds ceiling;
+* ``attempt`` resets to 0 after `_BACKOFF_RESET_AFTER_S` (60 s) of
+  connectedness, so a long healthy stream's first retry is `uniform(0, 1 s)`;
+* a dead peer is called by h2 keepalive within `keepalive_time_ms` (20 s) plus
+  `KEEPALIVE_TIMEOUT_S` (10 s), with `keepalive_permit_without_calls`;
+* a dial that hangs is cut at `_HELLO_ACK_TIMEOUT_S` (30 s);
+* every one of those is older than the incident (all present since 0.56.0).
+
+So the 936 s was time the reconnect loop WAS NOT RUNNING, and the fix for that
+class is to make it NAMEABLE — not to add another duration. (The most probable
+cause at the incident's 0.78.0 — torch sharing a process with the gRPC stream —
+is separately gone: since 0.84.0 the control/compute split is unconditional and
+the parent that owns the stream never imports torch.)
+
+These tests fail against the pre-pgw#803 tree, where neither the event nor the
+partition exists.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.transport import RECONNECT_EVENT, _ReconnectEpisode
+
+from harness.hub_double import hub_double
+
+_TIMEOUT = 30.0
+
+
+def _reconnect_events(msgs: List[pb.WorkerMessage], phase: str) -> List[pb.ActivityUpdate]:
+    return [
+        m.activity_update for m in msgs
+        if m.WhichOneof("msg") == "activity_update"
+        and m.activity_update.kind == RECONNECT_EVENT
+        and m.activity_update.phase == phase
+    ]
+
+
+# ---------------------------------------------------------------------------
+# the partition, on the incident's own numbers
+# ---------------------------------------------------------------------------
+
+def test_the_incident_gap_is_attributed_to_a_loop_that_was_not_running() -> None:
+    """936 s of gap against ~42 s of pacing: the row must say which is which.
+
+    This is the whole point of the ledger. With only "reconnected after 936 s"
+    the next investigator re-derives the same wrong hypothesis (unbounded
+    backoff) that this lane had to refute by reading code. With the partition,
+    894 s sits in `unaccounted` and the row names the cause class itself.
+    """
+    ep = _ReconnectEpisode(
+        dropped_at=0.0, cause="grpc_unavailable", uptime_s=520.0,
+        loop_silent_s=0.4,
+    )
+    # 62 attempts is what 936 s of a `uniform(0, 30 s)` schedule would need —
+    # the shape the "exponential backoff without a cap" story requires.
+    ep.attempts = 3
+    ep.sched_s = 40.0
+    ep.slept_s = 40.0
+    ep.dialed_s = 2.0
+    ep.teardown_s = 0.0
+
+    at = 936.0
+    assert ep.gap_s(at) == 936.0
+    assert ep.overshoot_s() == 0.0            # the loop paced itself correctly
+    assert ep.unaccounted_s(at) == 894.0      # and then did not run at all
+
+
+def test_a_starved_sleep_is_overshoot_not_pacing() -> None:
+    """The other shape of the same fault: the loop DID sleep, for far longer
+    than it asked to. An asyncio sleep on a healthy loop overshoots by
+    milliseconds, so minutes of overshoot cannot be confused with a slow
+    network, a slow hub, or a long backoff."""
+    ep = _ReconnectEpisode(
+        dropped_at=0.0, cause="stream_ended", uptime_s=100.0, loop_silent_s=900.0,
+    )
+    ep.attempts = 1
+    ep.sched_s = 0.5
+    ep.slept_s = 900.5
+    ep.dialed_s = 0.2
+
+    assert ep.overshoot_s() == 900.0
+    # ...and it is NOT double-counted as unaccounted: slept time is measured
+    # wall time, so the partition still sums.
+    assert ep.unaccounted_s(900.7) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_a_healthy_episode_accounts_for_all_of_its_gap() -> None:
+    ep = _ReconnectEpisode(
+        dropped_at=0.0, cause="stream_ended", uptime_s=3600.0, loop_silent_s=2.0,
+    )
+    ep.attempts = 1
+    ep.sched_s = 0.4
+    ep.slept_s = 0.41
+    ep.dialed_s = 0.09
+    ep.teardown_s = 0.01
+
+    assert ep.unaccounted_s(0.51) == pytest.approx(0.0, abs=1e-6)
+    assert ep.overshoot_s() < 0.05
+
+
+def test_attempt_outcomes_coalesce_by_count_never_by_dropping() -> None:
+    """An hour-long hub outage is two hub rows, not one row per attempt: the
+    send queue is bounded, and a replay storm would cost the very evidence the
+    episode is made of."""
+    ep = _ReconnectEpisode(
+        dropped_at=0.0, cause="grpc_unavailable", uptime_s=10.0, loop_silent_s=0.0,
+    )
+    for _ in range(200):
+        ep.note_outcome("grpc_unavailable")
+    ep.note_outcome("exc_ConnectionError")
+
+    assert ep.histogram() == "grpc_unavailable=200, exc_ConnectionError=1"
+
+
+# ---------------------------------------------------------------------------
+# the real path: a real Worker, a real gRPC socket, a real involuntary drop
+# ---------------------------------------------------------------------------
+
+def test_an_involuntary_drop_and_its_reconnect_both_reach_the_hub() -> None:
+    """Kill the stream under a live worker; both halves of the episode must
+    arrive ON THE NEXT STREAM.
+
+    That is not incidental: the `dropped` row is emitted while the worker has
+    no hub at all, so it can only land because it rides pgw#869's durable
+    evidence lane, which `reset_for_reconnect` preserves.
+
+    (This row does NOT cover the earliest window — a drop before the first
+    `Executor.ensure_setup`, i.e. during the 72-199 s weights fetch. Nothing
+    observes that from here; the activity sink is bound at HelloAck for it, on
+    the same argument `boot_phases` already makes at that call site.)
+    """
+    with hub_double(worker_id="pgw803-worker") as (scheduler, _harness):
+        first = scheduler.wait_connection(0, timeout=_TIMEOUT)
+        assert first.hello is not None
+        first.kill()
+
+        second = scheduler.wait_connection(1, timeout=_TIMEOUT)
+
+        def _has_both(_m: pb.WorkerMessage) -> bool:
+            return bool(
+                _reconnect_events(second.received, "dropped")
+                and _reconnect_events(second.received, "reconnected")
+            )
+
+        second.wait_for(_has_both, timeout=_TIMEOUT)
+
+        dropped = _reconnect_events(second.received, "dropped")
+        reconnected = _reconnect_events(second.received, "reconnected")
+        assert dropped, "the drop itself never reached the hub"
+        assert reconnected, "the reconnect never reached the hub"
+
+        # The drop names its cause and this process's own last-scheduled
+        # instant; the reconnect names the partition of the gap.
+        assert "cause=" in dropped[0].detail
+        assert "loop_silent=" in dropped[0].detail
+
+        row = reconnected[0].detail
+        for axis in (
+            "attempts=", "sched=", "slept=", "dialed=",
+            "teardown=", "overshoot=", "unaccounted=", "loop_silent_at_drop=",
+        ):
+            assert axis in row, f"{axis!r} missing from the reconnect row: {row}"
+        # A measured span, not a number interpolated into prose (th#1322).
+        assert reconnected[0].duration_ms >= 0

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -43,8 +43,6 @@ from gen_worker.transport import RECONNECT_EVENT, _ReconnectEpisode
 
 from harness.hub_double import hub_double
 
-_TIMEOUT = 30.0
-
 
 def _reconnect_events(msgs: List[pb.WorkerMessage], phase: str) -> List[pb.ActivityUpdate]:
     return [
@@ -115,7 +113,9 @@ def test_a_healthy_episode_accounts_for_all_of_its_gap() -> None:
     ep.teardown_s = 0.01
 
     assert ep.unaccounted_s(0.51) == pytest.approx(0.0, abs=1e-6)
-    assert ep.overshoot_s() < 0.05
+    # The exact difference between what was scheduled and what was slept —
+    # a property of the two recorded numbers, not of the runner's speed.
+    assert ep.overshoot_s() == pytest.approx(0.01, abs=1e-6)
 
 
 def test_attempt_outcomes_coalesce_by_count_never_by_dropping() -> None:
@@ -145,16 +145,20 @@ def test_an_involuntary_drop_and_its_reconnect_both_reach_the_hub() -> None:
     evidence lane, which `reset_for_reconnect` preserves.
 
     (This row does NOT cover the earliest window — a drop before the first
-    `Executor.ensure_setup`, i.e. during the 72-199 s weights fetch. Nothing
-    observes that from here; the activity sink is bound at HelloAck for it, on
-    the same argument `boot_phases` already makes at that call site.)
+    `Executor.ensure_setup`, which is where `activity.bind_sink` runs, i.e.
+    during the 72-199 s weights fetch. Such an episode is logger-only and
+    therefore invisible. Binding the sink at HelloAck instead — the argument
+    `boot_phases` already makes at that call site — fixes it and is NOT done
+    here: it is a process-global rebind that clobbers the `_sink` patch
+    `test_superseded_disk_ref_th1330` installs, so it belongs to whoever owns
+    that surface, not to a transport change.)
     """
     with hub_double(worker_id="pgw803-worker") as (scheduler, _harness):
-        first = scheduler.wait_connection(0, timeout=_TIMEOUT)
+        first = scheduler.wait_connection(0)
         assert first.hello is not None
         first.kill()
 
-        second = scheduler.wait_connection(1, timeout=_TIMEOUT)
+        second = scheduler.wait_connection(1)
 
         def _has_both(_m: pb.WorkerMessage) -> bool:
             return bool(
@@ -162,7 +166,7 @@ def test_an_involuntary_drop_and_its_reconnect_both_reach_the_hub() -> None:
                 and _reconnect_events(second.received, "reconnected")
             )
 
-        second.wait_for(_has_both, timeout=_TIMEOUT)
+        second.wait_for(_has_both)
 
         dropped = _reconnect_events(second.received, "dropped")
         reconnected = _reconnect_events(second.received, "reconnected")


### PR DESCRIPTION
## Verdict: REAL, but not where it was filed

th#1333's tape: a serving pod's stream ended at **17:51:43Z**, its next connect attempt reached the hub at **18:07:19Z** — 15m36s — and the hub condemned it, revoked its credential and refused the reconnect that proved it alive. The hub half shipped then (two-phase revoke, readmission on refutation). The worker half was never explained, and **could not be**: the reconnect loop's entire narration is `logger.info` on RunPod stdout, which nothing can read (gw#640's premise).

### The filed hypothesis is refuted on `origin/master`

"Exponential backoff without cap-awareness" cannot produce 936 s, and every one of these predates the incident (all present since 0.56.0, by `git log -S`):

| fact | value | site |
|---|---|---|
| backoff | `random.uniform(0, min(30 s, base*2**attempt))` — FULL JITTER, seconds ceiling | `transport.run` / `Worker.__init__` |
| attempt reset | 0 after 60 s connected, so a long healthy stream's first retry is `uniform(0, 1 s)` | `_BACKOFF_RESET_AFTER_S` |
| dead-peer detection | 20 s ping + 10 s timeout, `keepalive_permit_without_calls` | `_channel_options` / `KEEPALIVE_TIMEOUT_S` |
| hung dial | cut at 30 s | `_HELLO_ACK_TIMEOUT_S` |

"A stale-channel wait" is refuted too — there is no unbounded wait on the path: the recv loop does not block on job execution (`handle_run_job` does `create_task`), teardown is `reset_for_reconnect` + `on_disconnect`, `_await_peer_close` is 5 s, and the handshake including the awaitable `build_hello` is inside the 30 s deadline.

So the 936 s was time the reconnect loop **was not running**. Separately, the incident's most probable cause at its 0.78.0 — torch sharing a process with the gRPC stream, exactly what `_LoopStallWatchdog` exists for — is structurally gone: since 0.84.0 `procsplit` is unconditional and the parent that owns the stream never imports torch. That is a structural fix, not a verified one; nothing has observed a post-split episode, because nothing records one.

### What this PR builds

The thing actually missing, and the issue's own last line: *"typed event on each reconnect attempt + outcome so the hub-side tape and worker-side tape can be joined."*

Two typed `worker_reconnect` evidence rows per episode:

- **`dropped`** — cause, stream uptime, and `loop_silent`: how stale this process's last *proven scheduling instant* (last successful `stream.write`) already was when the drop was detected. The heartbeat forces a StateDelta every beat in every state, so on a live worker this is ~one beat; minutes of it says the process was not running.
- **`reconnected`** — the gap, partitioned into `sched` / `slept` / `dialed` / `teardown`, plus **`overshoot`** (slept minus scheduled — a healthy asyncio sleep overshoots by milliseconds) and **`unaccounted`** (gap in no measured phase at all). On the incident's numbers 894 s lands in `unaccounted` and the row names the cause class itself.

Attempt outcomes coalesce by COUNT, never by dropping — an hour-long hub outage is two rows, not a replay storm through a bounded queue.

**No new bound of any kind is introduced. This measures; it never decides.**

## Verification

- `tests/test_reconnect_episode_pgw803.py`, 5 rows. Four drive the partition: the incident's own numbers (936 s gap vs 42 s of pacing -> 894 s unaccounted), the starved-sleep shape (900 s overshoot, not double-counted), a healthy episode summing to ~0, and outcome coalescing at 200 attempts. One is integration-grade over a **real gRPC socket with a real `Worker`** (`hub_double`): kill the stream, and both halves of the episode must arrive **on the next stream** — which they can only do by riding pgw#869's durable evidence lane.
- **RED-verified**: reverting `src/` fails collection (`ImportError: cannot import name 'RECONNECT_EVENT'`).
- Green locally with the gw#666 meta-guards and every adjacent suite: `test_magic_timeouts_gw666`, `test_p1_stream_lifecycle`, `test_worker_outbox_pgw869`, `test_superseded_disk_ref_th1330`, `test_mint_vram_budget_pgw737`, `test_activity_gw601`, `test_boot_phases_pgw764` — 88 passed, 1 skipped.
- Hard gates green: `lint_http_timeouts`, `lint_unreached_surface` (baseline unchanged), `lint_unbounded_reads`, `lint_config_reads`. `ruff` + `mypy` clean on the changed file.

## Known blind spot, recorded not fixed

`activity.bind_sink` runs in `Executor.ensure_setup`, i.e. after weights are on disk, so an episode inside the 72-199 s weights fetch is logger-only. Binding at HelloAck beside the boot-phase sink is the fix — `Lifecycle.on_hello_ack` already makes that exact argument for `boot_phases` — but it is a process-global rebind that clobbers the `_sink` patch `test_superseded_disk_ref_th1330` installs (caught here, reverted in 850716d4). It belongs to whoever owns that surface, not to a transport change.

## Honest residue

`unaccounted` names the *class* of the next occurrence, not its cause. Separating a starved loop from a frozen container from a drop the socket never surfaced needs `_LoopStallWatchdog`'s own evidence on the same row — worth doing when a post-split tape exists to aim it at, not before. The hub-side residual (th#1333 #2: `DefaultActivityStallAfter` reused as a reconnect budget) stays tensorhub's.
