### PR TITLE
pgw#767: the result envelope is always really uploaded, whatever the client asked for media

### DIFF
--- a/changelog.d/pgw767.md
+++ b/changelog.d/pgw767.md
@@ -15,6 +15,13 @@
   its own ceiling — the client's media preference has no business being consulted twice. The
   executor additionally refuses an envelope that came back with `inline_bytes`, so the invariant
   fails loudly rather than re-emerging by a future path.
+- **Two existing suites were green only BECAUSE of the bug, and that is the finding worth keeping.**
+  `tests/test_th1111_stage_timing.py` and `tests_v2/test_dispatch.py`'s `r-stage` row dispatch a
+  ~200 KiB image result under `OUTPUT_MODE_INLINE` **with no file API and no capability token** —
+  they could do that only because the inline shortcut made the whole path upload-free. Fixing the
+  envelope turned both red with `worker_capability_token is required` / `missing owner`. They now
+  run against a real upload sink and prove the storage they always implied. A defect that removes
+  a test's need for infrastructure is invisible in exactly the place you would look for it.
 - **Proven RED first on the real dispatch path** (`tests/test_inline_envelope_pgw767.py`): a real
   hub double plus a real local upload sink, so "was it uploaded" is answered by the sink being
   hit rather than by a mock. Before the fix the sink is never touched and the returned `blob_ref`

--- a/changelog.d/pgw767.md
+++ b/changelog.d/pgw767.md
@@ -1,0 +1,21 @@
+- **pgw#767: `OUTPUT_MODE_INLINE` no longer decides whether the result envelope's blob exists.**
+  `Prefer: bytes=inline` is a hint about MEDIA outputs, but it reached the result envelope:
+  `_serialize_output` called `ctx.save_bytes`, which under that hint returns bytes-in-memory
+  **without uploading**, and the executor kept only `asset.ref`. Every result over the envelope
+  ceiling shipped a `blob_ref` naming a blob no consumer could ever fetch — silent wrong-output
+  on every image endpoint under inline dispatch.
+- **The affected band is corrected**, because the issue's "any result >64 KiB" is wrong in the
+  direction that matters. It is exactly `(INLINE_RESULT_MAX_BYTES = 64 KiB,
+  _SAVE_BYTES_INLINE_THRESHOLD = 4 MiB]`: below 64 KiB the result rides inline and never asks for
+  a ref, and above 4 MiB the inline shortcut already declines and the real upload runs. A reader
+  who took the filed band would have looked for the defect where it cannot occur.
+- **The fix is a boundary, not a threshold.** `RequestContext._save_result_envelope` stores the
+  worker→orchestrator transport blob unconditionally; `save_bytes` keeps the client-facing inline
+  shortcut it exists to provide. `JobResult` already owns its own inline-vs-`blob_ref` choice at
+  its own ceiling — the client's media preference has no business being consulted twice. The
+  executor additionally refuses an envelope that came back with `inline_bytes`, so the invariant
+  fails loudly rather than re-emerging by a future path.
+- **Proven RED first on the real dispatch path** (`tests/test_inline_envelope_pgw767.py`): a real
+  hub double plus a real local upload sink, so "was it uploaded" is answered by the sink being
+  hit rather than by a mock. Before the fix the sink is never touched and the returned `blob_ref`
+  names nothing.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -12333,12 +12333,17 @@ class Executor:
         if len(data) <= INLINE_RESULT_MAX_BYTES:
             return data, None
         try:
+            # pgw#767: the ENVELOPE, never ctx.save_bytes — the client's
+            # `Prefer: bytes=inline` media hint must not decide whether the
+            # transport blob this ref names actually exists.
             asset = await asyncio.to_thread(
-                ctx.save_bytes, f"results/{run.request_id}.msgpack", data
+                ctx._save_result_envelope, f"results/{run.request_id}.msgpack", data
             )
             ref = getattr(asset, "ref", "") or ""
             if not ref:
                 raise RuntimeError("upload returned no ref")
+            if getattr(asset, "inline_bytes", None):
+                raise RuntimeError("result envelope was not uploaded")
             return None, ref
         except Exception as exc:
             logger.warning("result blob upload failed for %s: %s", run.request_id, exc)

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -1115,6 +1115,22 @@ class RequestContext(Generic[D]):
     _SAVE_BYTES_INLINE_THRESHOLD = 4 * 1024 * 1024
 
     def save_bytes(self, ref: str, data: bytes) -> Asset:
+        return self._save_bytes(ref, data, allow_inline=True)
+
+    def _save_result_envelope(self, ref: str, data: bytes) -> Asset:
+        """Store the RESULT ENVELOPE blob, always as a real upload.
+
+        The envelope is worker->orchestrator transport, not a client-visible
+        media output: `JobResult` owns its own inline-vs-blob_ref choice at
+        its own ceiling (`executor.INLINE_RESULT_MAX_BYTES`). The client's
+        `Prefer: bytes=inline` hint is about MEDIA and must not reach here —
+        pgw#767: it did, so every result in
+        (INLINE_RESULT_MAX_BYTES, _SAVE_BYTES_INLINE_THRESHOLD] returned a
+        `blob_ref` naming a blob that was never uploaded.
+        """
+        return self._save_bytes(ref, data, allow_inline=False)
+
+    def _save_bytes(self, ref: str, data: bytes, *, allow_inline: bool) -> Asset:
         if not isinstance(data, (bytes, bytearray)):
             raise TypeError("save_bytes expects bytes")
         data = bytes(data)
@@ -1146,7 +1162,11 @@ class RequestContext(Generic[D]):
         output_format = str(
             (self._execution_hints or {}).get("output_format", "")
         ).strip().lower()
-        if output_format == "inline" and len(data) <= self._SAVE_BYTES_INLINE_THRESHOLD:
+        if (
+            allow_inline
+            and output_format == "inline"
+            and len(data) <= self._SAVE_BYTES_INLINE_THRESHOLD
+        ):
             return Asset(
                 ref=ref,
                 owner=self._owner,

--- a/tests/harness/upload_sink.py
+++ b/tests/harness/upload_sink.py
@@ -1,0 +1,51 @@
+"""A real local stand-in for tensorhub's `/api/v1/media/:owner/uploads`.
+
+Answers a dedup create, so a test needs no S3 part-PUT scripting to prove that
+an upload really happened. `requests_seen` being non-empty is the observable:
+it distinguishes "uploaded" from "returned a ref for bytes that never left the
+process", which is the pgw#767 defect class and cannot be told apart from the
+result envelope alone.
+
+The v2 suite has its own richer `UploadSink` fixture (`tests_v2/conftest.py`,
+with a `status=` knob for refusal rows). This is the v1 suite's minimal twin —
+kept separate deliberately, because a cross-suite import would make the v2
+fixture surface load-bearing for v1 tests.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Dict, List, Tuple
+
+
+class DedupUploadSink(BaseHTTPRequestHandler):
+    requests_seen: ClassVar[List[Tuple[str, Dict[str, Any]]]] = []
+
+    def log_message(self, *_args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).requests_seen.append((self.path, body))
+        resp = json.dumps({
+            "dedup": True, "ref": body.get("ref") or "", "filename": "out.bin",
+            "blake3": body.get("blake3") or "", "size_bytes": body.get("size_bytes") or 0,
+            "mime_type": "application/octet-stream", "media_id": "m1",
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+def serve_upload_sink() -> Tuple[ThreadingHTTPServer, str]:
+    """Start the sink on an ephemeral port. Caller shuts it down and resets
+    `DedupUploadSink.requests_seen`."""
+    DedupUploadSink.requests_seen = []
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), DedupUploadSink)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"

--- a/tests/test_inline_envelope_pgw767.py
+++ b/tests/test_inline_envelope_pgw767.py
@@ -16,52 +16,20 @@ sink being hit, not by a mock assertion.
 
 from __future__ import annotations
 
-import json
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, ClassVar, Dict, List, Tuple
-
 import msgspec
 
 from gen_worker.pb import worker_scheduler_pb2 as pb
 
 from harness.hub_double import hub_double, is_ready, is_result_for
 from harness.toy_endpoints import EchoIn
-
-
-class _DedupUploadSink(BaseHTTPRequestHandler):
-    requests_seen: ClassVar[List[Tuple[str, Dict[str, Any]]]] = []
-
-    def log_message(self, *_args: Any) -> None:
-        pass
-
-    def do_POST(self) -> None:  # noqa: N802
-        length = int(self.headers.get("Content-Length", "0"))
-        body = json.loads(self.rfile.read(length) or b"{}")
-        type(self).requests_seen.append((self.path, body))
-        resp = json.dumps({
-            "dedup": True, "ref": body.get("ref") or "", "filename": "out.msgpack",
-            "blake3": body.get("blake3") or "", "size_bytes": body.get("size_bytes") or 0,
-            "mime_type": "application/octet-stream", "media_id": "m1",
-        }).encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(resp)))
-        self.end_headers()
-        self.wfile.write(resp)
-
-
-def _serve() -> Tuple[ThreadingHTTPServer, str]:
-    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _DedupUploadSink)
-    threading.Thread(target=httpd.serve_forever, daemon=True).start()
-    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+from harness.upload_sink import DedupUploadSink, serve_upload_sink
 
 
 def test_inline_dispatch_over_the_envelope_ceiling_still_really_uploads() -> None:
     """RED before the fix: the sink is never hit and the returned blob_ref
     names nothing. `large_usage` emits ~195 KiB — inside the affected band."""
     org_id = "00000000-0000-0000-0000-000000000001"
-    httpd, base_url = _serve()
+    httpd, base_url = serve_upload_sink()
     try:
         with hub_double(file_base_url=base_url) as (scheduler, _harness):
             conn = scheduler.wait_connection(0)
@@ -76,16 +44,16 @@ def test_inline_dispatch_over_the_envelope_ceiling_still_really_uploads() -> Non
             assert res.status == pb.JOB_STATUS_OK, res.safe_message
             assert res.blob_ref, "over the envelope ceiling the result ships a ref"
             assert not res.inline
-            assert _DedupUploadSink.requests_seen, (
+            assert DedupUploadSink.requests_seen, (
                 "a returned blob_ref must name a blob that was REALLY uploaded — "
                 "the inline media hint must not reach the result envelope"
             )
-            path, body = _DedupUploadSink.requests_seen[-1]
+            path, body = DedupUploadSink.requests_seen[-1]
             assert path.startswith(f"/api/v1/media/{org_id}/uploads")
             assert body["size_bytes"] > 64 * 1024
     finally:
         httpd.shutdown()
-        _DedupUploadSink.requests_seen = []
+        DedupUploadSink.requests_seen = []
 
 
 def test_save_bytes_still_inlines_media_for_the_client() -> None:

--- a/tests/test_inline_envelope_pgw767.py
+++ b/tests/test_inline_envelope_pgw767.py
@@ -1,0 +1,122 @@
+"""pgw#767: OUTPUT_MODE_INLINE must not decide whether the result envelope's
+blob actually exists.
+
+The client's `Prefer: bytes=inline` hint is about MEDIA outputs. It reached
+`ctx.save_bytes`, which under that hint returns bytes-in-memory WITHOUT
+uploading — and `executor._serialize_output` kept only `asset.ref`. Every
+result in (INLINE_RESULT_MAX_BYTES=64 KiB, _SAVE_BYTES_INLINE_THRESHOLD=4 MiB]
+therefore shipped a `blob_ref` naming a blob no consumer could ever fetch.
+That is the exact band, corrected from the issue's "any result >64 KiB":
+above 4 MiB the inline shortcut declines and the real upload already ran.
+
+Same real-codepath shape as test_p9_result_upload_metrics.py — a real hub
+double plus a real local upload sink, so "was it uploaded" is answered by the
+sink being hit, not by a mock assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Dict, List, Tuple
+
+import msgspec
+
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.hub_double import hub_double, is_ready, is_result_for
+from harness.toy_endpoints import EchoIn
+
+
+class _DedupUploadSink(BaseHTTPRequestHandler):
+    requests_seen: ClassVar[List[Tuple[str, Dict[str, Any]]]] = []
+
+    def log_message(self, *_args: Any) -> None:
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).requests_seen.append((self.path, body))
+        resp = json.dumps({
+            "dedup": True, "ref": body.get("ref") or "", "filename": "out.msgpack",
+            "blake3": body.get("blake3") or "", "size_bytes": body.get("size_bytes") or 0,
+            "mime_type": "application/octet-stream", "media_id": "m1",
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+def _serve() -> Tuple[ThreadingHTTPServer, str]:
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _DedupUploadSink)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+def test_inline_dispatch_over_the_envelope_ceiling_still_really_uploads() -> None:
+    """RED before the fix: the sink is never hit and the returned blob_ref
+    names nothing. `large_usage` emits ~195 KiB — inside the affected band."""
+    org_id = "00000000-0000-0000-0000-000000000001"
+    httpd, base_url = _serve()
+    try:
+        with hub_double(file_base_url=base_url) as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(run_job=pb.RunJob(
+                request_id="r-inline-big", attempt=1, function_name="large-usage",
+                input_payload=msgspec.msgpack.encode(EchoIn(text="x")),
+                org=org_id, capability_token="cap-token",
+                output_mode=pb.OUTPUT_MODE_INLINE,
+            ))
+            res = conn.wait_for(is_result_for("r-inline-big")).job_result
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            assert res.blob_ref, "over the envelope ceiling the result ships a ref"
+            assert not res.inline
+            assert _DedupUploadSink.requests_seen, (
+                "a returned blob_ref must name a blob that was REALLY uploaded — "
+                "the inline media hint must not reach the result envelope"
+            )
+            path, body = _DedupUploadSink.requests_seen[-1]
+            assert path.startswith(f"/api/v1/media/{org_id}/uploads")
+            assert body["size_bytes"] > 64 * 1024
+    finally:
+        httpd.shutdown()
+        _DedupUploadSink.requests_seen = []
+
+
+def test_save_bytes_still_inlines_media_for_the_client() -> None:
+    """The fix is scoped to the envelope: the public media path keeps the
+    `Prefer: bytes=inline` shortcut it exists to provide."""
+    from gen_worker import RequestContext
+
+    ctx = RequestContext(
+        request_id="req-inline", owner="org",
+        execution_hints={"output_format": "inline"},
+    )
+    asset = ctx.save_bytes("samples/small.bin", b"payload")
+    assert asset.inline_bytes == b"payload"
+
+
+def test_result_envelope_helper_ignores_the_inline_hint() -> None:
+    """The envelope helper never takes the shortcut: it either uploads or
+    refuses, but it must not hand back bytes-in-memory under a ref.
+
+    Asserted without `pytest.raises(Exception)`, which would also pass on the
+    `AttributeError` of the helper simply not existing.
+    """
+    from gen_worker import RequestContext
+
+    ctx = RequestContext(
+        request_id="req-envelope", owner="org",
+        execution_hints={"output_format": "inline"},
+    )
+    assert hasattr(ctx, "_save_result_envelope")
+    try:
+        asset = ctx._save_result_envelope("results/req-envelope.msgpack", b"payload")
+    except Exception:
+        return  # refused with no upload endpoint configured — correct
+    assert not asset.inline_bytes

--- a/tests/test_th1111_stage_timing.py
+++ b/tests/test_th1111_stage_timing.py
@@ -20,6 +20,7 @@ from gen_worker.stage_timing import StageTimer, reconciliation, stage_ms_for_met
 
 from harness.hub_double import hub_double, is_ready, is_result_for
 from harness.stage_endpoints import DECODE_S, STEP_S, STEPS, TEXT_ENCODE_S
+from harness.upload_sink import DedupUploadSink, serve_upload_sink
 
 import msgspec
 
@@ -29,13 +30,27 @@ def _payload() -> bytes:
 
 
 def test_stage_map_reconciles_with_runtime_ms_on_the_real_serve_path() -> None:
-    with hub_double(modules=("harness.stage_endpoints",)) as (scheduler, _h):
-        conn = scheduler.wait_connection(0)
-        conn.wait_for(is_ready)
-        conn.send(run_job=pb.RunJob(
-            request_id="r-stage", attempt=1, function_name="staged-generate",
-            input_payload=_payload(), output_mode=pb.OUTPUT_MODE_INLINE))
-        res = conn.wait_for(is_result_for("r-stage")).job_result
+    # pgw#767: this test used to need no file API at all. Under
+    # OUTPUT_MODE_INLINE the image AND the (~200 KiB) result envelope both took
+    # the inline shortcut, and the envelope's shortcut was the defect — it
+    # returned a ref for bytes that were never uploaded. With the envelope now
+    # always really stored, the stage-timing path needs a real upload sink like
+    # any other large-result dispatch. The test was green because of the bug.
+    httpd, base_url = serve_upload_sink()
+    try:
+        with hub_double(modules=("harness.stage_endpoints",),
+                        file_base_url=base_url) as (scheduler, _h):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+            conn.send(run_job=pb.RunJob(
+                request_id="r-stage", attempt=1, function_name="staged-generate",
+                input_payload=_payload(), output_mode=pb.OUTPUT_MODE_INLINE,
+                org="00000000-0000-0000-0000-000000000001",
+                capability_token="cap-token"))
+            res = conn.wait_for(is_result_for("r-stage")).job_result
+    finally:
+        httpd.shutdown()
+        DedupUploadSink.requests_seen = []
 
     assert res.status == pb.JOB_STATUS_OK, res.safe_message
     stages = dict(res.metrics.stage_ms)

--- a/tests_v2/test_dispatch.py
+++ b/tests_v2/test_dispatch.py
@@ -123,7 +123,13 @@ def test_dispatch_load_serve_and_upload_walk(hub, blob_host, upload_sink) -> Non
         conn.send(run_job=pb.RunJob(
             request_id="r-stage", attempt=1, function_name="staged-generate",
             input_payload=catalog.row("staged-generate").input_bytes(prompt="a cat"),
-            output_mode=pb.OUTPUT_MODE_INLINE))
+            output_mode=pb.OUTPUT_MODE_INLINE,
+            # pgw#767: the ~200 KiB result envelope is now always really
+            # stored, so this dispatch needs the capability token every other
+            # large-result dispatch needs. It passed without one only because
+            # the inline shortcut skipped the upload and handed back a ref for
+            # bytes that never left the process.
+            org=ORG, capability_token="cap-token"))
         res = conn.wait_for(is_result_for("r-stage")).job_result
         assert res.status == pb.JOB_STATUS_OK, res.safe_message
         stages = dict(res.metrics.stage_ms)


### PR DESCRIPTION
## The defect

\`Prefer: bytes=inline\` is a hint about **media outputs**. It reached the **result envelope**: \`executor._serialize_output\` called \`ctx.save_bytes\`, which under that hint returns bytes-in-memory **without uploading**, and the executor kept only \`asset.ref\`. The result then shipped a \`blob_ref\` naming a blob no consumer could ever fetch — silent wrong-output on every image endpoint under inline dispatch.

## The band is corrected, and the correction matters

The issue says "any result >64 KiB". That is wrong in the direction that costs a reader time. The real band is exactly:

    (INLINE_RESULT_MAX_BYTES = 64 KiB, _SAVE_BYTES_INLINE_THRESHOLD = 4 MiB]

Below 64 KiB the result rides inline and never asks for a ref. Above 4 MiB the inline shortcut already declines and the real upload runs. Someone taking the filed band would have hunted the defect where it cannot occur.

## The fix is a boundary, not a threshold

`RequestContext._save_result_envelope` stores the worker→orchestrator transport blob unconditionally; `save_bytes` keeps the client-facing inline shortcut it exists to provide. `JobResult` already owns its own inline-vs-`blob_ref` choice at its own ceiling — the client's media preference has no business being consulted twice. The executor additionally refuses an envelope that came back carrying `inline_bytes`, so the invariant fails loudly rather than re-emerging by a future path.

## Evidence

Proven **RED first** on the real dispatch path (`tests/test_inline_envelope_pgw767.py`): a real hub double plus a real local upload sink, so *"was it uploaded"* is answered by the sink being hit, not by a mock assertion. Before the fix the sink is never touched and the returned `blob_ref` names nothing:

```
E  AssertionError: a returned blob_ref must name a blob that was REALLY uploaded
E  assert [] == _DedupUploadSink.requests_seen
```

The third test was tightened after it passed for the wrong reason — `pytest.raises(Exception)` also passes on the `AttributeError` of the helper simply not existing.

- RED → GREEN on the new file (3 passed)
- 63 neighbouring upload / envelope / media / deferred-tail tests green
- `mypy src/gen_worker` clean (239 files), `ruff` clean

## Tracker

Discharges pgw#767. Filed as a child of pgw#891, but **it is not gated on ExecutionSpec** — it is a result-envelope defect, independent of the protocol cut. De-parented in the same tracker pass that landed pgw#891's shared spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)