### PR TITLE
pgw#891/pgw#904: enumerate and freeze the post-connect resolution surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,14 @@ jobs:
       - name: pgw#931 guard - config reads outside the pipeline
         run: uv run python scripts/lint_config_reads.py
 
+      # GATING (pgw#891/pgw#904): a connected worker may not reconstruct or
+      # substitute a Hub decision. The real repair is pgw#891's exact
+      # ExecutionSpec and its schema half is th#1457's, so the deletion cannot
+      # land yet — this freezes the SIZE of the job so pgw#904 stays a bounded
+      # list instead of an open-ended hunt. Fails on ADDITION only.
+      - name: pgw#891 guard - the post-connect resolution surface may not grow
+        run: uv run python scripts/lint_post_connect_resolution.py
+
       # GATING (pgw#1013 / th#1662): a length read off external bytes may not
       # size a read until something bounds it. The §4.24 census enumerated the
       # bounds that EXIST, so it could not see a site that needs one and has

--- a/changelog.d/pgw891.md
+++ b/changelog.d/pgw891.md
@@ -1,0 +1,22 @@
+- **pgw#891/pgw#904: the post-connect resolution surface is now enumerated and frozen.**
+  A connected worker that can reconstruct or substitute a Hub decision is a SECOND RESOLVER —
+  it can serve a different checkpoint, lane, arm or artifact than the one that was billed,
+  ranked and recorded, silently, because both answers look plausible from outside. The real
+  repair is pgw#891's exact `ExecutionSpec`, whose schema half is th#1457's, so the deletion
+  cannot land yet. `scripts/lint_post_connect_resolution.py` protects the SIZE of the job
+  instead: **8 sites, classified, and it fails on addition only.**
+- **The census is smaller than the issue implied, and two of its assumptions were wrong.**
+  Only **2 sites are CONNECTED** — `executor.py`'s coarse-family lane expansion (§1.31 layer-1/2
+  authority running in the worker) and `fleet_cells.py`'s `aot_cells.discover` catalog scan
+  (pgw#904's headline). The other 6 are CLI/hub-less or publish-time. In particular
+  **pgw#904's box 5 is already satisfied for the ladder fold**: `maybe_rebind_family_fp8` is
+  reached only through `resolve_bindings`, the CLI's half, exactly as its docstring claims.
+- **Every accepted line names its classification and its reason**, and a `CONNECTED` line must
+  say what blocks its deletion — that is what stops the file decaying into prose. Keyed on
+  `<path>::<callee>`, never a line number: `lint_config_reads.py` learned that the hard way when
+  its line-keyed first cut went red within the hour on unrelated merges.
+- **The gate is proven able to go RED.** Six tests drive it against synthetic trees: a new call
+  site fails, the same site passes once classified, a STALE allowlist entry fails (an exemption
+  outliving its site would silently re-permit it), an unknown classification and a reason-less
+  line are both refused, and the real tree's census is asserted NON-EMPTY — a walk that silently
+  found nothing would also have been "green".

--- a/scripts/lint_post_connect_resolution.py
+++ b/scripts/lint_post_connect_resolution.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""pgw#891 / pgw#904: the post-connect resolution surface may not GROW.
+
+The threat, named as DESIGN-RULINGS §4.24 requires
+-------------------------------------------------
+A connected worker that can reconstruct or substitute a Hub decision is a
+SECOND RESOLVER. The Hub issues one execution decision; a worker that re-derives
+any part of it can serve a different checkpoint, lane, arm or artifact than the
+one that was billed, ranked and recorded — silently, because both answers look
+plausible from the outside. §1.10 and §1.31 put lane authority in the endpoint's
+declaration and the owner's ladder, never in worker code; the wire contract says
+outright that *"the worker never calls tensorhub for ref resolution; the
+orchestrator is the only resolver"* (`proto/worker_scheduler.proto`, `Snapshot`).
+
+Why a gate now, when the fix is pgw#891
+---------------------------------------
+The real repair is pgw#891's exact `ExecutionSpec`, and its schema half is
+th#1457's — so the deletion cannot land yet. What CAN be protected today is the
+SIZE of the job: this gate freezes the census at its current, enumerated set so
+pgw#904's deletion stays a bounded list rather than an open-ended hunt. It is
+deliberately not a behaviour change, and it fails on ADDITION only.
+
+That is the whole claim. This gate does not prevent the second resolver from
+running — the accepted `CONNECTED` sites below run on every boot today. It
+prevents a ninth one appearing while the replacement is built.
+
+What is watched, and why each one
+---------------------------------
+    discover / _discover_inner / _candidates   catalog listing + sibling ranking
+                                               after the Hub already chose
+                                               (pgw#904's `rows[0]` resolver)
+    resolve_repo                               worker-side ref resolution
+    maybe_rebind_family_fp8 / pick_family_..   worker-AUTHORED flavour choice
+    parse_execution_lane_spec                  the DUAL-form parse; its FAMILY
+                                               branch is the coarse-family
+                                               expansion §1.31 forbids
+
+Keyed on `<path>::<callee>`, never on a line number. That is not a style
+preference — `scripts/lint_config_reads.py` learned it the hard way: its first
+cut keyed `path:line` and went red within the hour when two sibling PRs shifted
+lines in files nobody in that change had touched. A line number is a fact other
+people change independently.
+
+Every accepted site must NAME ITS CLASSIFICATION, which is what stops the
+allowlist decaying into prose:
+
+    CONNECTED    reachable from the connected dispatcher — a real second
+                 resolver. Replacement-gated on pgw#891/pgw#904; every line
+                 must say what blocks its deletion.
+    STANDALONE   CLI / hub-less only, unreachable from the connected
+                 dispatcher. This is pgw#904's box 5 and it is LEGITIMATE.
+    PUBLISH      publish/declaration-time validation vocabulary, which pgw#891
+                 explicitly retains ("declarations stay as capability
+                 vocabulary for publish/mint validation only").
+    VOCABULARY   parsing/definition with no resolution effect.
+
+Only CONNECTED is a defect. Baselined green on arrival, following th#1383's
+precedent — a gate that fails on day one gets switched off.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO / "src" / "gen_worker"
+ALLOWLIST = REPO / "scripts" / "post_connect_resolution_allowlist.txt"
+
+CLASSIFICATIONS = {"CONNECTED", "STANDALONE", "PUBLISH", "VOCABULARY"}
+
+#: Callees whose invocation is a post-connect resolution act. Name-keyed: a
+#: single-file AST walk cannot resolve an import chain, and the identifier is
+#: the stable key regardless. A same-named callee elsewhere simply needs its own
+#: classified line — which makes the census MORE honest, not less.
+WATCHED = frozenset({
+    "discover",
+    "_discover_inner",
+    "_candidates",
+    "resolve_repo",
+    "maybe_rebind_family_fp8",
+    "pick_family_fp8_flavor",
+    "parse_execution_lane_spec",
+})
+
+#: Modules that DEFINE the watched surface. A call inside its own definition
+#: module is an implementation detail, not a consumer reaching for a resolver.
+DEFINING_MODULES = frozenset({
+    "aot_cells.py",
+    "hub_client.py",
+    "ladder.py",
+    "execution_lanes.py",
+})
+
+
+def _callee(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def census() -> set[str]:
+    """Every `<relpath>::<callee>` reaching the watched surface."""
+    found: set[str] = set()
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if path.name in DEFINING_MODULES:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:  # a parse failure must not read as "clean"
+            print(f"error: cannot parse {path}: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _callee(node) in WATCHED:
+                found.add(f"{path.relative_to(REPO).as_posix()}::{_callee(node)}")
+    return found
+
+
+def allowed() -> dict[str, str]:
+    """`<path>::<callee>` -> classification, from the allowlist file."""
+    out: dict[str, str] = {}
+    if not ALLOWLIST.exists():
+        return out
+    for raw in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 2:
+            print(f"error: malformed allowlist line: {raw}", file=sys.stderr)
+            raise SystemExit(2)
+        key, classification = parts[0], parts[1]
+        if classification not in CLASSIFICATIONS:
+            print(
+                f"error: unknown classification {classification!r} for {key} "
+                f"(want one of {', '.join(sorted(CLASSIFICATIONS))})",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        if len(parts) < 3 or not parts[2].strip():
+            print(f"error: {key} has no reason — every line must name one",
+                  file=sys.stderr)
+            raise SystemExit(2)
+        out[key] = classification
+    return out
+
+
+def main() -> int:
+    found, accepted = census(), allowed()
+
+    new = sorted(found - set(accepted))
+    stale = sorted(set(accepted) - found)
+
+    if new:
+        print(
+            "post-connect resolution surface GREW — pgw#891/pgw#904.\n"
+            "\n"
+            "A connected worker may not reconstruct or substitute a Hub\n"
+            "decision. If this site is CLI/hub-less only, classify it\n"
+            "STANDALONE with the reason it is unreachable from the connected\n"
+            "dispatcher. If it is genuinely on the connected path, it is a new\n"
+            "second resolver and needs a ruling, not an allowlist line.\n",
+            file=sys.stderr,
+        )
+        for key in new:
+            print(f"  + {key}", file=sys.stderr)
+        return 1
+
+    if stale:
+        # A site that went away is good news, but the allowlist must not keep
+        # carrying it: a stale exemption silently re-permits the site if it
+        # ever comes back. Same defect class the gate exists to police.
+        print("allowlist has entries with no matching call site — delete them:",
+              file=sys.stderr)
+        for key in stale:
+            print(f"  - {key}", file=sys.stderr)
+        return 1
+
+    connected = sum(1 for c in accepted.values() if c == "CONNECTED")
+    print(
+        f"post-connect resolution surface: {len(found)} sites, "
+        f"{connected} CONNECTED (pgw#904's replacement-gated deletion set)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/post_connect_resolution_allowlist.txt
+++ b/scripts/post_connect_resolution_allowlist.txt
@@ -1,0 +1,42 @@
+# pgw#891 / pgw#904 — the post-connect resolution census, classified.
+# Enforced by scripts/lint_post_connect_resolution.py.
+#
+# A connected worker may not reconstruct or substitute a Hub decision. This file
+# is the enumerated set of places that today CAN. It exists so pgw#904's
+# deletion stays a bounded list while pgw#891's exact ExecutionSpec is built,
+# not so the sites below become acceptable.
+#
+# FORMAT:  <path>::<callee>  <CLASSIFICATION>  <reason>
+#
+# Keyed on the CALLEE, never on a line number — see the header of
+# scripts/lint_config_reads.py for what a line-keyed allowlist cost us.
+#
+#   CONNECTED    reachable from the connected dispatcher: a real second
+#                resolver. Replacement-gated on pgw#891/pgw#904. Every line
+#                must say what blocks its deletion. THIS IS THE DEFECT CLASS.
+#   STANDALONE   CLI / hub-less only, unreachable from the connected
+#                dispatcher. pgw#904's box 5, and legitimate.
+#   PUBLISH      publish/declaration-time validation vocabulary, which pgw#891
+#                explicitly retains.
+#   VOCABULARY   parsing/definition with no resolution effect.
+
+# --- CONNECTED: the two real second resolvers, both deletion-gated ------------
+
+src/gen_worker/executor.py::parse_execution_lane_spec  CONNECTED  _execution_lane_effective_spec expands a COARSE FAMILY ("bf16"|"fp8"|"4bit") into a concrete binding, and falls back to the local cast lane when no stored fp8 pick exists. That is layer-1/layer-2 lane authority (§1.31) executing in the worker. Blocked on: ExecutionSpec.numerical_lane carrying the RESOLVED lane only, so the family form has nowhere to arrive from.
+src/gen_worker/fleet_cells.py::discover  CONNECTED  enable_compiled calls aot_cells.discover on the connected serving path: it lists /api/v1/repos/{repo}/checkpoints and ranks siblings (aot_cells._candidates), i.e. it re-chooses an artifact after the Hub already chose one. This is pgw#904's headline. Blocked on: ExecutionSpec naming one exact artifact identity or explicitly naming none.
+
+# --- STANDALONE: hub-less / CLI only ------------------------------------------
+# All four reach resolution only through models/provision.py::resolve_bindings,
+# whose docstring states it: "Standalone (hub-less) resolution — the CLI's half.
+# The executor's bytes come from orchestrator-resolved snapshots via
+# ModelStore.ensure_local." Verified 2026-08-07: no connected path reaches them.
+
+src/gen_worker/cli/listing.py::resolve_repo  STANDALONE  `cozy` CLI listing surface; no dispatcher path reaches it.
+src/gen_worker/cli/run.py::parse_execution_lane_spec  STANDALONE  `cozy run --lane` is an operator naming a lane locally, which is §1.31 layer 3 (per-invoke override) exercised by hand, not the worker authoring one.
+src/gen_worker/models/gguf_local.py::resolve_repo  STANDALONE  maybe_rebind_gguf, reached only from provision._local_flavor_fold.
+src/gen_worker/models/provision.py::maybe_rebind_family_fp8  STANDALONE  _local_flavor_fold; the th#964 AUTO fold's own docstring says "Production resolution remains hub-owned".
+src/gen_worker/models/provision.py::resolve_repo  STANDALONE  _local_flavor_fold's own resolve, same containment.
+
+# --- PUBLISH ------------------------------------------------------------------
+
+src/gen_worker/convert/publish.py::resolve_repo  PUBLISH  reads the SOURCE repo's classification to stamp the published artifact; best-effort, and the hub's classification gate stays the enforcement. Publish-time metadata, not execution resolution.

--- a/tests/test_post_connect_resolution_gate_pgw891.py
+++ b/tests/test_post_connect_resolution_gate_pgw891.py
@@ -1,0 +1,101 @@
+"""pgw#891: the post-connect resolution gate must be able to go RED.
+
+A gate nobody has watched fail is not a gate — it is a green light of unknown
+provenance. `scripts/lint_post_connect_resolution.py` is green on arrival by
+construction (it is baselined against today's tree), so the only evidence that
+it works is driving it against trees that MUST fail.
+
+Both failure directions are covered, because they are different defects:
+a NEW call site is the surface growing (the thing the gate exists to stop), and
+a STALE allowlist entry is an exemption outliving its site — which would
+silently re-permit that site if it ever came back.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "lint_post_connect_resolution.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pgw891_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tree(tmp_path: Path, source: str, allowlist: str) -> ModuleType:
+    src = tmp_path / "src" / "gen_worker"
+    src.mkdir(parents=True)
+    (src / "consumer.py").write_text(source, encoding="utf-8")
+    (tmp_path / "scripts").mkdir()
+    allow = tmp_path / "scripts" / "allow.txt"
+    allow.write_text(allowlist, encoding="utf-8")
+
+    mod = _load()
+    mod.REPO = tmp_path
+    mod.SRC_ROOT = src
+    mod.ALLOWLIST = allow
+    return mod
+
+
+CALLS_DISCOVER = "from x import aot_cells\n\ndef f():\n    return aot_cells.discover(1)\n"
+
+
+def test_a_new_call_site_fails(tmp_path: Path) -> None:
+    mod = _tree(tmp_path, CALLS_DISCOVER, "# nothing accepted\n")
+    assert mod.main() == 1
+
+
+def test_the_same_site_passes_once_classified(tmp_path: Path) -> None:
+    mod = _tree(
+        tmp_path, CALLS_DISCOVER,
+        "src/gen_worker/consumer.py::discover  CONNECTED  gated on pgw#891\n",
+    )
+    assert mod.main() == 0
+
+
+def test_a_stale_allowlist_entry_fails(tmp_path: Path) -> None:
+    """The site is gone; the exemption must not outlive it."""
+    mod = _tree(
+        tmp_path, "def f():\n    return 1\n",
+        "src/gen_worker/consumer.py::discover  CONNECTED  gated on pgw#891\n",
+    )
+    assert mod.main() == 1
+
+
+def test_an_unknown_classification_is_refused(tmp_path: Path) -> None:
+    mod = _tree(
+        tmp_path, CALLS_DISCOVER,
+        "src/gen_worker/consumer.py::discover  PROBABLY_FINE  hand-wave\n",
+    )
+    with pytest.raises(SystemExit):
+        mod.main()
+
+
+def test_a_line_with_no_reason_is_refused(tmp_path: Path) -> None:
+    """The reason column is the whole point — an unreasoned exemption is how an
+    allowlist decays into prose that nobody can re-derive."""
+    mod = _tree(
+        tmp_path, CALLS_DISCOVER,
+        "src/gen_worker/consumer.py::discover  CONNECTED\n",
+    )
+    with pytest.raises(SystemExit):
+        mod.main()
+
+
+def test_the_real_tree_is_green_and_the_census_is_not_empty() -> None:
+    """Baseline: the shipped allowlist matches the shipped tree. The
+    non-emptiness assert matters — a census that silently found nothing would
+    also be 'green', and would prove nothing at all."""
+    mod = _load()
+    found = mod.census()
+    assert found, "the watched surface cannot be empty — the walk would be broken"
+    assert mod.main() == 0
+    assert set(found) == set(mod.allowed())


### PR DESCRIPTION
## Why now, when the fix is pgw#891

A connected worker that can reconstruct or substitute a Hub decision is a **second resolver**: it can serve a different checkpoint, lane, arm or artifact than the one that was billed, ranked and recorded — silently, because both answers look plausible from outside.

The real repair is pgw#891's exact `ExecutionSpec`, and **its schema half belongs to th#1457**, so the deletion cannot land yet. What can be protected today is the *size* of the job. This enumerates the surface and freezes it, so pgw#904's deletion stays a bounded list rather than an open-ended hunt.

**This is not a behaviour change.** The accepted `CONNECTED` sites run on every boot today. The gate fails on **addition only**.

## The census is smaller than the issue implied — and corrects two assumptions

**8 sites; only 2 are `CONNECTED`:**

| site | why |
|---|---|
| `executor.py::parse_execution_lane_spec` | `_execution_lane_effective_spec` expands a **coarse family** (`"bf16"｜"fp8"｜"4bit"`) into a concrete binding, and falls back to the local cast lane when no stored fp8 pick exists — layer-1/layer-2 lane authority (§1.31) executing in the worker |
| `fleet_cells.py::discover` | `enable_compiled` lists `/api/v1/repos/{repo}/checkpoints` and ranks siblings, re-choosing an artifact after the Hub already chose — pgw#904's headline |

The other six are CLI/hub-less or publish-time. Notably: **pgw#904's box 5 is already satisfied for the ladder fold.** `maybe_rebind_family_fp8` is reached only through `resolve_bindings`, the CLI's half, exactly as its docstring claims — so nobody needs to re-derive that.

## Design notes

- **Keyed on `<path>::<callee>`, never a line number.** `scripts/lint_config_reads.py` learned that the hard way: its line-keyed first cut went red within the hour when sibling PRs shifted lines in files nobody had touched.
- **Every line names a classification AND a reason**; a `CONNECTED` line must say what blocks its deletion. That is what stops the file decaying into prose.
- **A stale entry is also a failure.** An exemption outliving its site would silently re-permit that site if it came back — the same defect class the gate polices.
- Baselined green on arrival (th#1383's precedent: a gate that fails on day one gets switched off).

## The gate is proven able to go RED

Six tests drive it against synthetic trees — a new site fails, the same site passes once classified, a stale entry fails, an unknown classification and a reason-less line are both refused. The real-tree test asserts the census is **non-empty**: a walk that silently found nothing would also have been "green", and would have proven nothing.

```
post-connect resolution surface: 8 sites, 2 CONNECTED (pgw#904's replacement-gated deletion set).
```

6 passed. `ruff` clean. The three existing `fast gates` lints re-verified still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)