### PR TITLE
pgw#1024: the reap row collects the zombie itself, and the report sinks stop crossing files

### DIFF
--- a/changelog.d/pgw1024.md
+++ b/changelog.d/pgw1024.md
@@ -1,0 +1,27 @@
+- **pgw#1024: the pgw#858 reap row waited on a delivery that could never
+  arrive; now it collects the child itself.** Under CPU starvation the parent's
+  event loop closes with the compute child's exit still undelivered. The child
+  watcher drops that delivery (the drop pgw#956's own comment documents), so
+  `proc.returncode` stays `None` — and once the parent thread is gone nothing in
+  the process will ever call `wait()`, so the child sits as a zombie and the row
+  polls `exited` until its staleness window fires. Three CI runs on PR #545 — a
+  branch that changes no product code and only re-partitions `--dist loadfile`
+  — cost ~13 minutes each to this. `_reap_state` now branches on whether the
+  parent can still deliver: while it lives, LOOK (`WNOWAIT` leaves the status for
+  its loop); once it is gone, this process is the only reaper there is, so it
+  reaps with `waitpid(WNOHANG)`. No window was widened and no retry added — a
+  child that ignored the signal still reads `running` and still fails the row.
+  Scoped deliberately to the test: in production the parent's loop closes as the
+  process exits, so an undelivered reap has no consequence there; only a suite
+  that runs the parent in a thread inside a long-lived process can observe it.
+- **pgw#1024: `activity._sink` and `boot_phases._sink` are reset between tests.**
+  Both are process globals that production binds once and never unbinds. A
+  hub-double row leaves the sink pointed at a `Worker._send` whose queue stops
+  draining at teardown, and under `--dist loadfile` the next FILE in that worker
+  inherits it — reporting into a dead queue, with `boot_phases` additionally
+  replaying the previous file's buffered rows on the next bind. That is
+  cross-file state whose effect depends on which files a worker happened to get,
+  i.e. it reshuffles greens whenever suite composition changes. One autouse
+  fixture in `tests/conftest.py` is now the single authority
+  (`activity.reset_for_tests()` joins the `boot_phases` one it mirrors); the
+  private per-file copies that predate it are redundant, not wrong.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -168,6 +168,20 @@ def bind_sink(
         _sink = sink
 
 
+def reset_for_tests() -> None:
+    """Drop the bound sink and any in-flight activity. Test-only.
+
+    The sink is process-lifetime in production (one worker, one transport), so
+    nothing unbinds it. In a suite that is a leak: a bound sink outlives the
+    ``Worker`` whose queue it feeds, and under ``--dist loadfile`` the next FILE
+    in the same process reports into a queue nothing drains (pgw#1024).
+    """
+    global _sink, _current
+    with _lock:
+        _sink = None
+        _current = None
+
+
 def _next_seq() -> int:
     global _seq
     with _lock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,31 @@ def _fresh_cell_ledgers():
     _clear()
 
 
+@pytest.fixture(autouse=True)
+def _fresh_report_sinks():
+    """pgw#1024: `activity._sink` and `boot_phases._sink` are process globals
+    that production binds ONCE (`Executor.ensure_setup`, `lifecycle`) and never
+    unbinds — correct there, a leak here.
+
+    A hub-double row binds the sink to a `Worker._send` whose queue stops being
+    drained at teardown. Nothing resets it, so under `--dist loadfile` the NEXT
+    FILE runs in the same worker process holding a sink nobody empties: every
+    activity it reports is handed to a dead SendQueue, and `boot_phases`
+    additionally REPLAYS the previous file's buffered rows into it on the next
+    bind. That is cross-file state whose effect depends on which files a worker
+    happened to get — i.e. it reshuffles greens whenever suite composition
+    changes. One authority here, so no file has to remember; the private copies
+    that predate it (`test_reconnect_episode_pgw803`, the `reset_for_tests()`
+    fixtures in the boot-phase files) are redundant, not wrong.
+    """
+    from gen_worker import activity as _activity
+    from gen_worker import boot_phases as _boot
+
+    _activity.reset_for_tests()
+    _boot.reset_for_tests()
+    yield
+    _activity.reset_for_tests()
+    _boot.reset_for_tests()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pod_privilege_isolation_pgw858.py
+++ b/tests/test_pod_privilege_isolation_pgw858.py
@@ -404,24 +404,85 @@ def test_the_dropped_child_can_still_write_the_config_snapshot(dropped):
     )
 
 
-def _reap_state(proc: Any, pid: int) -> str:
-    """``running`` -> ``exited`` -> ``reaped``, read from the process table.
+def _reap_state(proc: Any, pid: int, *, parent_alive: bool) -> str:
+    """``running`` -> ``reaped``, with THIS process doing the collecting once
+    nothing else can.
 
     pgw#956: ``proc.returncode`` is asyncio bookkeeping delivered to the parent's
-    loop by the child-watcher thread, and ``ThreadedChildWatcher._do_waitpid``
-    DROPS that delivery when the loop has already closed. So it can confirm a
-    reap and never deny one — under load it stays None permanently on a child
-    the kernel did reap, which no amount of re-reading recovers.
+    loop by the child watcher, and the watcher DROPS that delivery once the loop
+    has closed. So it can confirm a reap and never deny one, and this helper must
+    read the process table instead.
+
+    pgw#1024 measured where that lands under CPU starvation: the parent thread
+    exits, its loop closes with the child's exit still undelivered, and from then
+    on there is no reaper left in this process at all — the child sits as a
+    zombie for the rest of the run and a poll on the process table reports
+    ``exited`` forever. Waiting longer cannot fix a delivery that can never
+    arrive, and a longer window would only be tolerance for it.
+
+    So: while the parent lives, its loop owns the child and we LOOK (``WNOWAIT``
+    leaves the status for it). Once the parent is gone this process is the only
+    reaper there is, so it reaps. That keeps the property this row measures — the
+    child, running at another uid, really died when root signalled it, and a
+    child that ignored the signal still reads ``running`` and still fails — and
+    drops only the bookkeeping question of which thread called wait().
     """
     if proc.returncode is not None:
         return "reaped"
+    if parent_alive:
+        try:
+            info = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+        except ChildProcessError:
+            return "reaped"      # no longer our child: somebody here reaped it
+        return "running" if info is None else "exited"
     try:
-        # WNOWAIT leaves the status for the watcher thread; ChildProcessError
-        # means it is no longer our child, i.e. somebody in this process reaped.
-        info = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+        collected, _status = os.waitpid(pid, os.WNOHANG)
     except ChildProcessError:
-        return "reaped"
-    return "running" if info is None else "exited"
+        return "reaped"          # the watcher won the race; equally collected
+    return "reaped" if collected == pid else "running"
+
+
+class _UndeliveredExit:
+    """An asyncio Process whose exit was never delivered — pgw#956's drop."""
+
+    returncode = None
+
+
+def test_a_zombie_no_loop_can_report_is_collected_here_rather_than_waited_on():
+    """pgw#1024's mechanism and its fix, without having to lose the coin flip.
+
+    The row below could only be measured on a runner that happened to starve, so
+    build the end state directly: a child NO child-watcher is tracking, i.e. what
+    a parent loop that closed before the exit arrived leaves behind. Nothing in
+    this process will ever call ``wait()`` on it, so ``exited`` is not a stage it
+    passes through — it is where it stops, and the previous helper's wait could
+    only end in its staleness window. The fix is that once the parent can no
+    longer deliver, this process collects.
+    """
+    proc = _UndeliveredExit()
+    pid = os.posix_spawn("/bin/sleep", ["sleep", "600"], {})
+    try:
+        # While a parent could still deliver, the helper LOOKS and does not take.
+        assert _reap_state(proc, pid, parent_alive=True) == "running"
+        os.kill(pid, 9)
+        await_progress(
+            lambda: _reap_state(proc, pid, parent_alive=True),
+            lambda seen: seen == "exited",
+            what="the unwatched child to become a zombie nobody collects",
+            cadence=Cadence(),
+        )
+        # ...and it STAYS there: no watcher, no loop, no later reader recovers it.
+        assert _reap_state(proc, pid, parent_alive=True) == "exited"
+
+        # The parent is gone. This process is the only reaper there is.
+        assert _reap_state(proc, pid, parent_alive=False) == "reaped"
+        assert _reap_state(proc, pid, parent_alive=False) == "reaped"
+        assert _reap_state(proc, pid, parent_alive=True) == "reaped"
+        pid = 0
+    finally:
+        if pid:
+            os.kill(pid, 9)
+            os.waitpid(pid, 0)
 
 
 @root_only
@@ -439,8 +500,15 @@ def test_the_parent_can_still_signal_and_reap_the_dropped_child(dropped):
     # and the child was reaped, so wait on THAT advancing; a hang fails by never
     # reaping, which is the actual defect.
     dropped.close()
+
+    def observe() -> tuple:
+        # One read of the parent's liveness for both halves: the answer to
+        # "may the loop still deliver?" decides whether we look or collect.
+        alive = dropped.alive
+        return alive, _reap_state(proc, pid, parent_alive=alive)
+
     await_progress(
-        lambda: (dropped.alive, _reap_state(proc, pid)),
+        observe,
         lambda seen: seen == (False, "reaped"),
         what="the parent to exit after SIGTERM and the dropped child to be reaped",
         cadence=Cadence(),

--- a/tests/test_reconnect_episode_pgw803.py
+++ b/tests/test_reconnect_episode_pgw803.py
@@ -38,23 +38,15 @@ from typing import List
 
 import pytest
 
-from gen_worker import activity as activity_mod
 from gen_worker.pb import worker_scheduler_pb2 as pb
 from gen_worker.transport import RECONNECT_EVENT, _ReconnectEpisode
 
 from harness.hub_double import hub_double
 
 
-@pytest.fixture(autouse=True)
-def _restore_activity_sink():
-    """`activity.bind_sink` is a process global with no autouse reset, and any
-    hub-double row binds it to a `Worker._send` that stops draining at teardown.
-    Under `--dist loadfile` the next FILE runs in the same process, so leaving it
-    bound hands that file a queue nothing empties. Pre-existing for every
-    hub-double row in the suite; this file at least does not add to it."""
-    before = activity_mod._sink
-    yield
-    activity_mod._sink = before
+# The private `activity._sink` restore this file used to carry is now
+# `tests/conftest.py::_fresh_report_sinks` — one authority for the whole suite,
+# not one file remembering (pgw#1024).
 
 
 def _reconnect_events(msgs: List[pb.WorkerMessage], phase: str) -> List[pb.ActivityUpdate]:


### PR DESCRIPTION
Closes the flake that is currently blocking [#545](https://github.com/cozy-creator/python-gen-worker/pull/545).

## The observable, read off #545's own failing run rather than inferred

Run [31244925899](https://github.com/cozy-creator/python-gen-worker/actions/runs/31244925899):

```
StalledError: waiting for the parent to exit after SIGTERM and the dropped child to be
reaped: nothing advanced for 30.0s ... last saw 'parent alive=False, child exited'
```

Both halves of that terminal state matter:

* `proc.returncode` is `None` because the child watcher dropped its delivery onto a loop that had already closed — the drop `_reap_state`'s own pgw#956 comment documents.
* **The parent thread is gone.** Nothing in the process will ever call `wait()` on that pid again. So `exited` is not a stage the child passes through; it is where it stops. No staleness window can close on it, and widening one would be tolerance for a delivery that cannot arrive (`no-magic-timeouts` is a hard rule).

## The fix

`_reap_state` branches on whether the parent can still deliver:

* parent alive → **look** (`waitid(..., WNOWAIT)` leaves the status for its loop);
* parent gone → **collect** (`waitpid(pid, WNOHANG)`), because this process is the only reaper there is.

No window widened, no retry count, no tolerance. A child that ignored root's signal still reads `running` and still fails the row, so the uid boundary this file exists to measure is untouched — only the bookkeeping question of *which thread called wait()* is dropped.

**pgw#956's drop is explicitly scoped rather than fixed, with the reason:** in production the parent's loop closes as the process exits, so an undelivered reap has no consequence there. Only a suite that runs the parent in a thread inside a long-lived process can observe it, so the collection belongs to the test.

## Proof by construction, not by sampling

The containerised driver is **13/13 green at `--cpus 2` and 6/6 at `--cpus 1` on master** on this box, so an "it passes now" claim from re-running it would be worth nothing. So the end state is built directly instead:

`test_a_zombie_no_loop_can_report_is_collected_here_rather_than_waited_on` spawns a child no watcher is tracking (`os.posix_spawn`), kills it, asserts it sits at `exited` **and stays there** — which is the old helper's terminal state, so the row carries its own red control — then asserts the new branch collects it. Runs everywhere, root or not, in 0.5 s.

## Second finding: the `activity._sink` cross-file leak (confirmed real)

`activity._sink` and `boot_phases._sink` are process globals production binds once (`Executor.ensure_setup`, `lifecycle`) and never unbinds. A hub-double row leaves the sink pointed at a `Worker._send` whose queue stops draining at teardown, and under `--dist loadfile` the next FILE in that worker inherits it — reporting into a dead `SendQueue`, with `boot_phases` additionally **replaying the previous file's buffered rows** on the next bind.

That is cross-file state whose effect depends on which files a worker happened to get: it reshuffles greens whenever suite composition changes, which is this issue's own trigger. `tests/conftest.py::_fresh_report_sinks` is now the single authority (`activity.reset_for_tests()` added to mirror the `boot_phases` one it sits beside), and the private copy in `test_reconnect_episode_pgw803.py` is deleted rather than left as a second interpretation.

## Local evidence

| gate | result |
|---|---|
| `tests/ -n 4 --dist loadfile` | **3615 passed, 37 skipped, 1 xfailed, 0 failed** (10:12) |
| `tests_v2/ -n 4 --dist loadfile` | 21 passed |
| ruff / mypy | clean |
| `lint_http_timeouts` / `lint_unreached_surface` / `lint_config_reads` / `lint_unbounded_reads` | exit 0 |
| `assemble_changelog.py --check` | exit 0 |
| pgw#858 container row, `--cpus 2`, CI-matched 3.12 interpreter | repeated green |