### PR TITLE
pgw#1033: the stamped key is the cell's identity — three protections stop comparing it against a computed one

### DIFF
--- a/changelog.d/pgw1033.md
+++ b/changelog.d/pgw1033.md
@@ -1,0 +1,28 @@
+- **pgw#1033: three live protections were comparing a COMPUTED cell key against
+  STAMPED reality — two disjoint digest spaces — so none of them could fire.**
+  A worker holds two key digests of identical shape: the computed one
+  (`cell_key.compute`, `kind="inductor"`) names an ARM and exists before
+  anything is compiled; the stamped one (`kind="aot-inductor"`, contract axis
+  folding the combined graph hash) is what the exported cell IS and does not
+  exist until the export finishes. (1) The pgw#672 no-second-mint memo
+  (`fleet_cells._FINALIZED`) was written under the stamped key and read under
+  the computed one, so it could never hit and every same-key re-arm in a
+  process paid a second full export; it is now indexed by the ARM key — the
+  only key its one lookup has — with the stamped identity carried in the value.
+  (2) The pgw#672 quarantine gate only asked about the computed ref, while the
+  two writers that fire on a real proof failure (the runtime guard and the boot
+  proof) record the ARMED cell's stamped ref; the gate now consults both — the
+  arm identity for a mint that died before producing anything, and, through
+  `_FINALIZED`, the stamped identity of the cell that arm already produced —
+  and the decline names which ref quarantined it. (3) `aot_serve.note_aot_key`
+  had one caller, discovery, so a SELF-MINTED cell was never registered and the
+  pgw#734/#735 kind dispatch scored this pod's own `.pt2` by FX cache hits an
+  AOTI package cannot produce; `adopt_delegated_mint` now registers the key it
+  reads off the packed envelope, and the rule is stated where the registry
+  lives: whoever reads a stamped `aot-inductor` key registers it. Plus
+  `executor._selection_for`'s pgw#805 guard, which tested a `recipe` attribute
+  pgw#1010 deleted from every mint object: it is re-expressed against the
+  mint's own state (a pending has no packed artifact), so an owed mint again
+  advertises no artifact identity instead of relying on the caller's
+  `delegated` branch to drop the computed ref it had just been handed. The
+  write-only `_BackgroundMint.selections` field that stash fed goes with it.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -243,10 +243,17 @@ def flavor_label(sku: str, version: str, precision: str) -> str:
 # Stamped cell keys this process LEARNED name aot-inductor artifacts
 # (pgw#722 F1 discovery). Published AOT cells ride the same key space as
 # their store flavor — indistinguishable from a dynamo cell's flavor by
-# string shape alone — so discovery registers each learned key here and
-# :func:`is_aot_ref` consults the set. Without this the executor's kind
-# dispatch (#734/#735) would score an armed ``.pt2`` by FX cache hits and
-# disprove every honest adoption.
+# string shape alone — so every reader of a stamped envelope registers the
+# key it learned here and :func:`is_aot_ref` consults the set. Without this
+# the executor's kind dispatch (#734/#735) would score an armed ``.pt2`` by
+# FX cache hits and disprove every honest adoption.
+#
+# THE RULE (pgw#1033): whoever reads a ``cell_key`` off an ``aot-inductor``
+# envelope registers it. There are two such readers on the serving path —
+# ``aot_cells.discover`` (a delivered cell) and
+# ``fleet_cells.adopt_delegated_mint`` (this pod's OWN mint). Only the first
+# registered, so a self-minted cell — the one artifact this process is
+# certain is exported — was the one ref ``is_aot_ref`` did not recognize.
 _KNOWN_AOT_KEYS: set[str] = set()
 _KNOWN_AOT_KEYS_LOCK = threading.Lock()
 

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -2604,31 +2604,30 @@ def _selection_for(
     minted instead, recording the delivered identity would advertise bytes
     this object does not serve (the gw#586 defect shape).
 
-    ``mint`` is either a finalized ``fleet_cells.SelfMint`` (artifact
-    already packed, digest known) or a ``fleet_cells.PendingSelfMint``
-    (gw#587 CORRECT FIX: armed for capture, not yet proven or packed — its
-    ``target`` path exists on disk only once the warmup proof finalizes
-    it, and its ``snapshot_digest`` is empty until then). Either way the
-    ``ref`` is known immediately (computed from static axes, never the
-    traced FX graph bytes), which is what the hub's self-attested dispatch
-    fence needs at advertise time; the proof loop replaces this selection
-    with the fully finalized one once it packs the proven capture.
+    ``mint`` is a finalized ``fleet_cells.SelfMint`` — an adopted cell, whose
+    ``artifact`` is packed on this disk and whose ``ref`` carries the key
+    STAMPED on that envelope. That is the only identity this function will
+    hand back for a mint.
+
+    A ``fleet_cells.PendingSelfMint`` yields the ``delivered`` selection (or
+    nothing): pgw#805 — an exported cell's key folds the COMBINED GRAPH HASH
+    of its class set, so it does not exist until the export finishes, and the
+    pending's own ``ref`` is a COMPUTED ``kind="inductor"`` key that no
+    artifact will ever carry. Advertising it would publish a self-attested ref
+    against bytes that will be stamped with a different one. Nothing is
+    advertised for an owed mint until ``adopt_delegated_mint`` reads the real
+    key off the packed envelope.
+
+    pgw#1033: that guard used to test ``mint.recipe == "aot"``, an attribute
+    pgw#1010 deleted from every mint object — so it could not fire, and only
+    the caller's ``delegated`` branch (which drops the selection it just asked
+    for) kept the computed ref off the wire. The predicate is the mint's own
+    state: a pending has no packed artifact.
     """
     if mint is not None:
-        if (getattr(mint, "recipe", "") == "aot"
-                and getattr(mint, "artifact", None) is None):
-            # pgw#805: an AOT cell's key folds the COMBINED GRAPH HASH of the
-            # exported class set, so it does not exist until the export
-            # finishes. The dynamo pending's key is computable from static
-            # axes and is therefore honest to advertise at arm time; an AOT
-            # pending's is not, and advertising the dynamo-shaped handle would
-            # publish a self-attested ref no artifact will ever carry. Nothing
-            # is advertised until `adopt_delegated_mint` reads the real key
-            # off the packed envelope.
-            return delivered
         path = getattr(mint, "artifact", None)
         if path is None:
-            path = mint.target
+            return delivered
         return _CompileArtifactSelection(
             path=Path(path), ref=str(mint.ref),
             snapshot_digest=str(getattr(mint, "snapshot_digest", "") or ""),
@@ -2833,9 +2832,6 @@ class _BackgroundMint:
     # id(pipeline) -> the actual pipeline object (id() keys alone cannot
     # keep the object alive or recover it).
     pipes: Dict[int, Any]
-    # id(pipeline) -> arm-time placeholder selection (claimed key ref,
-    # digest empty until finalize) stashed out of the foreground install.
-    selections: Dict[int, "_CompileArtifactSelection"]
     abandon: asyncio.Event = dc_field(default_factory=asyncio.Event)
     task: Optional["asyncio.Task[None]"] = None
     act: Optional[Any] = None  # the handed-over self_mint_compile Activity
@@ -4110,12 +4106,28 @@ class Executor:
         anything else is fleet-wide silent zero-adoption: the published
         cell sits armed in the store while every cold pod re-mints (the
         ie#546 burst: 10 pods, 9 simultaneous mints, 0 adoptions). Loud
-        and greppable; never fatal to serving."""
+        and greppable; never fatal to serving.
+
+        pgw#1033 (INTERIM — pgw#1032 deletes this warning together with
+        `requested_cell_key` itself): an EXPORTED cell's key is STAMPED on
+        its envelope and folds the combined graph hash of the traced class
+        set, so it can never equal the `kind="inductor"` key this runtime
+        COMPUTES — different spaces, by construction and on purpose. Since
+        pgw#1010 an AOT cell is the only cell a worker mints, so this
+        invariant was false for every self-mint there is and the ERROR fired
+        on every healthy AOT boot. It is scoped to the space it can actually
+        judge; the pgw#686 concern itself is now carried by the mint's own
+        determinism, not by comparing two key spaces. (The skip is only
+        precise because `is_aot_ref` learned this pod's own mint — the same
+        registration this issue restored.)
+        """
         with target.state_lock:
             active = str(target.active_compile_ref or "")
             self_mint = bool(target.active_self_mint)
             requested = str(target.requested_cell_key or "")
         if not (self_mint and active and requested):
+            return
+        if aot_serve.is_aot_ref(active):
             return
         if active.rpartition("#")[2] == requested:
             return
@@ -6973,23 +6985,21 @@ class Executor:
                     inj.pending_self_mints.pop(_pid, None)
             if eager_first:
 
-                mint_selections: Dict[int, _CompileArtifactSelection] = {}
                 mint_pipes: Dict[int, Any] = {}
                 for candidate in inj.compile_objects:
                     pid = id(candidate.pipeline)
                     if pid not in inj.pending_self_mints:
                         continue
-                    sel = inj.active_compile_artifacts.pop(pid, None)
-                    if sel is None:
-                        # pgw#784: a DELEGATED pending never entered
-                        # active_compile_artifacts (nothing is armed on its
-                        # pipe), but its claimed key ref is computable now from
-                        # static axes, and th#910's self-attested dispatch
-                        # fence wants it advertised while the child compiles.
-                        sel = _selection_for(
-                            None, inj.pending_self_mints.get(pid))
-                    if sel is not None:
-                        mint_selections[pid] = sel
+                    # pgw#1033: an OWED mint advertises no artifact. Every
+                    # pending is delegated (pgw#1010), so nothing is armed on
+                    # this pipe and it never entered
+                    # `active_compile_artifacts`; the arm-time placeholder
+                    # selection this loop used to stash was the pending's
+                    # COMPUTED `kind="inductor"` ref, which the cell the child
+                    # is exporting will never carry — and the only consumer of
+                    # the stash was a `_BackgroundMint` field nothing read.
+                    # The pipe serves eager until `adopt_delegated_mint` reads
+                    # the STAMPED key off the packed envelope.
                     mint_pipes[pid] = candidate.pipeline
                     hot_swap.enable(candidate.pipeline)
                     # pgw#677: the mint's own background compiles are the
@@ -7002,7 +7012,6 @@ class Executor:
                     snapshots=dict(snapshots) if snapshots else None,
                     pendings=dict(inj.pending_self_mints),
                     pipes=mint_pipes,
-                    selections=mint_selections,
                     modules=_mint_modules(spec),
                     slots=dict(resolved_slots),
                 )

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -59,7 +59,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 
 from . import activity as activity_mod
-from . import aot_cells, cell_key
+from . import aot_cells, aot_serve, cell_key
 from . import boot_phases as boot_mod
 from . import compile_cache as cc
 from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
@@ -210,10 +210,26 @@ _PENDING: Dict[str, "PendingSelfMint"] = {}
 # entries instead of opening a SECOND capture — which, with the first mint's
 # compiled code resident in dynamo's in-memory cache, would capture nothing
 # and disprove itself at finalize (the L4 churn loop).
+#
+# pgw#1033: keyed on the ARM key — the COMPUTED `cell_key.compute` digest the
+# miss path names its pending with — and NOT on the cell's own stamped key.
+# The two are different digest spaces by construction (`kind="inductor"` vs
+# the exported cell's `kind="aot-inductor"`, whose contract axis folds a
+# combined graph hash that does not exist until the export finishes), so a
+# ledger written under the stamped key could never be read by the only caller
+# there is: an arm that has computed its key and not yet minted anything. The
+# VALUE carries the stamped identity (`SelfMint.cell_key`/`.ref`) — this map
+# IS the process's arm-key -> stamped-cell index, and the quarantine gate
+# below reads it for exactly that.
 _FINALIZED: Dict[str, "SelfMint"] = {}
 
 
 def finalized_in_process(key: str) -> Optional["SelfMint"]:
+    """The cell this process already minted and adopted for ARM key ``key``.
+
+    ``key`` is a computed :func:`cell_key.compute` digest (pgw#1033); the
+    returned :class:`SelfMint` carries the artifact's own STAMPED key.
+    """
     with _PENDING_LOCK:
         return _FINALIZED.get(str(key or "").strip())
 
@@ -1030,8 +1046,6 @@ def _arming_policy(
             cache_dir=cache_dir,
         )
         if adopted is not None:
-            from . import aot_serve
-
             try:
                 aot_out, aot_row = _arm_candidate(
                     pipe, cfg, cache_dir, adopted.artifact,
@@ -1214,16 +1228,37 @@ def _arming_policy(
             phase=EagerPhase.KEY_COMPUTATION_FAILED)
 
     # pgw#672: consult the process ledgers BEFORE opening a capture.
+    #
+    # pgw#1033: TWO identities can be quarantined for one arm, and the gate
+    # has to ask about both, because the ledger holds whatever ref actually
+    # failed:
+    #   * the ARM identity — an owed mint that died before it produced
+    #     anything has no cell of its own, so the pending's computed ref is
+    #     what `executor._abandon_pending_mint`'s quarantine writes;
+    #   * the CELL identity — a serve/finalize proof fails on an ARMED
+    #     artifact, whose ref is the exported cell's STAMPED key. That is the
+    #     ref the runtime-guard and boot-proof writers record, and the arm can
+    #     only reach it through `_FINALIZED`, this process's arm-key -> cell
+    #     index. A mint is deterministic in its axes, so re-minting an arm
+    #     whose own cell was just disproven rebuilds the same disproven cell.
     key_ref = f"{cc.system_repo(family)}#{key}"
+    finalized_prior = finalized_in_process(key)
+    quarantined_ref = ""
     if cc.cell_quarantined_in_process(key_ref):
+        quarantined_ref = key_ref
+    elif (finalized_prior is not None
+            and cc.cell_quarantined_in_process(finalized_prior.ref)):
+        quarantined_ref = finalized_prior.ref
+    if quarantined_ref:
         # This exact identity already failed its serve/finalize proof in
         # this process — re-minting it is the churn loop, not recovery.
         # DEGRADE (explicit eager, mandatory lanes included): a broken
         # optimization must never kill a serving worker.
         logger.error(
-            "fleet-cells: declining self-mint for %s key=%s — this identity "
-            "was quarantined by a failed proof in this process; serving "
-            "eager (pgw#672)", family, key)
+            "fleet-cells: declining self-mint for %s key=%s (quarantined "
+            "ref=%s) — this identity was quarantined by a failed proof in "
+            "this process; serving eager (pgw#672)",
+            family, key, quarantined_ref)
         if bucket:
             cc.drop_lora_execution_lane(pipe)
         # pgw#824: the ONE eager exit in this function that never rode a typed
@@ -1232,17 +1267,17 @@ def _arming_policy(
         # is precisely the state the hub most needs named.
         activity_mod.emit_event(
             "self_mint_skipped",
-            f"family={family} key={key} lane="
-            f"{loading.pipeline_weight_lane(pipe) or 'plain'}: this identity "
-            f"was quarantined by a failed serve/finalize proof earlier in this "
-            f"process; re-minting it is the churn loop, so this worker serves "
-            f"eager for the rest of its life and publishes nothing",
+            f"family={family} key={key} quarantined_ref={quarantined_ref} "
+            f"lane={loading.pipeline_weight_lane(pipe) or 'plain'}: this "
+            f"identity was quarantined by a failed serve/finalize proof "
+            f"earlier in this process; re-minting it is the churn loop, so "
+            f"this worker serves eager for the rest of its life and "
+            f"publishes nothing",
             phase=EagerPhase.CELL_QUARANTINED,
         )
         return ArmOutcome(
             armed=False, selection_bug=selection_bug,
             eager_reason=EagerPhase.CELL_QUARANTINED)
-    finalized_prior = finalized_in_process(key)
     if finalized_prior is not None:
         # This process already minted and ADOPTED this exact cell — re-arm
         # the same artifact through the same AOT gates instead of paying a
@@ -1425,12 +1460,23 @@ def adopt_delegated_mint(
     )
     state["minted"] = minted
     state["meta"] = dict(meta)
+    # pgw#1033: this process has now READ a stamped `aot-inductor` key off a
+    # packed envelope, which is the one event that teaches a runtime that a
+    # key-flavored ref names an EXPORTED cell. `aot_cells.discover` registers
+    # the keys it learns for the same reason; a SELF-MINTED cell was the
+    # unregistered half, so the executor's #734/#735 kind dispatch scored this
+    # pod's own `.pt2` by FX cache hits it can never produce.
+    aot_serve.note_aot_key(minted.cell_key)
     # th#1355: the mint cost, banked at the moment the cell becomes real.
     state["mint_duration_ms"] = max(
         0, int((time.monotonic() - pending.armed_at) * 1000))
     _unregister(pending)
     with _PENDING_LOCK:
-        _FINALIZED[key] = minted
+        # pgw#1033: under the ARM key (see `_FINALIZED`). The stamped key is
+        # the VALUE's identity; keying the ledger by it made the memo
+        # unreadable by the only lookup there is, so every same-key re-arm in
+        # this process paid a second full export.
+        _FINALIZED[pending.cell_key] = minted
     logger.info(
         "fleet-cells: DELEGATED mint adopted for %s (key=%s, %.1f MB) — the "
         "worker served eager throughout and now serves compiled",

--- a/tests/test_cell_key_space_pgw1033.py
+++ b/tests/test_cell_key_space_pgw1033.py
@@ -1,0 +1,389 @@
+"""pgw#1033 — the STAMPED key is the cell's identity; the COMPUTED key names
+an ARM. Three live protections were comparing one against the other.
+
+A worker holds two key digests that look identical (``ck1-<56 hex>``) and are
+different spaces by construction:
+
+* the **computed** key (``cell_key.compute``, ``kind="inductor"``) — what THIS
+  runtime's static axes ask for. It exists before anything is compiled, which
+  is exactly why it can name a pending mint;
+* the **stamped** key (``aot_mint.cell_identity``, ``kind="aot-inductor"``,
+  contract axis folding the combined graph hash) — what the exported cell
+  actually IS. It does not exist until the export finishes.
+
+Every protection below was written on one side and fed from the other, so each
+one silently stopped firing. The three tests that matter are RED on
+``origin/master`` ``872f16e5``:
+
+1. ``finalized_in_process`` (the pgw#672 no-second-mint memo) read the computed
+   key while ``adopt_delegated_mint`` wrote the stamped one — the memo could
+   never hit, and every same-key re-arm in a process paid a second full export;
+2. the pgw#672 quarantine gate read the computed ref while the two writers that
+   fire on a real proof failure (``executor``'s runtime guard and boot proof)
+   record the STAMPED ref of the armed cell — so the churn-loop gate was blind
+   to the refs that actually fail;
+3. ``aot_serve.note_aot_key`` had ONE caller, discovery — so a SELF-MINTED cell
+   was never registered and the pgw#734/#735 kind dispatch scored this pod's own
+   ``.pt2`` by FX cache hits it cannot produce.
+
+Plus the dead-attribute guard: ``_selection_for`` tested ``mint.recipe ==
+"aot"``, an attribute pgw#1010 deleted from every mint object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+from gen_worker import aot_cells, aot_serve, compile_cache, fleet_cells
+from gen_worker import config as gw_config
+from gen_worker import mint_delegate
+from gen_worker.api.decorators import Compile, Dim, GraphClass, Input
+from gen_worker.api.export_contract import (
+    register_export_declaration, reset_export_declarations,
+)
+from gen_worker.cell_adopt import AdoptOutcome, EagerPhase
+
+FAMILY = "sdxl"
+#: What this runtime's axes COMPUTE — the arm identity, known before any
+#: compile has run.
+ARM_KEY = "ck1-" + "a" * 56
+#: What the child's envelope is STAMPED with — the cell identity, unknowable
+#: until the export finishes. A different digest, always.
+STAMPED_KEY = "ck1-" + "b" * 56
+
+
+class _Pipe:
+    pass
+
+
+@dataclass
+class _Cfg:
+    family: str = FAMILY
+    lora_bucket: int = 0
+    shapes: Tuple[Tuple[int, int], ...] = ((1024, 1024),)
+    targets: Tuple[str, ...] = ("unet",)
+    text_lens: Tuple[int, ...] = (77,)
+    guidance_scales: Tuple[float, ...] = (1.0, 5.0)
+    regional: bool = False
+
+
+class _Publisher:
+    base_url = "http://hub.invalid"
+
+    def enabled(self) -> bool:
+        return True
+
+    def worker_jwt(self) -> str:
+        return "jwt"
+
+
+def _declaration() -> Compile:
+    return Compile(
+        family=FAMILY,
+        targets=("unet",),
+        text_len=77,
+        shapes=((1024, 1024),),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}),),
+        inputs=(Input("sample", shape=("B", 4, 128, 128), dtype="bfloat16"),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_declarations() -> Any:
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+@pytest.fixture()
+def _events(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[str, str, str]]:
+    seen: List[Tuple[str, str, str]] = []
+
+    def _sink(kind: str, detail: str, phase: str = "", duration_ms: int = 0) -> None:
+        seen.append((kind, phase, detail))
+
+    monkeypatch.setattr(fleet_cells.activity_mod, "emit_event", _sink)
+    monkeypatch.setattr(mint_delegate.activity_mod, "emit_event", _sink)
+    return seen
+
+
+@pytest.fixture()
+def _miss(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """A mint-capable pod with no cell: the pgw#805 miss shape, one lane."""
+    gw_config.reload_for_test()
+    monkeypatch.setattr(aot_cells, "discover", lambda *a, **k: None)
+    monkeypatch.setattr(
+        fleet_cells.provision, "enable_compiled",
+        lambda pipe, cfg, cache_dir, artifact: AdoptOutcome.miss("no_cell"))
+    monkeypatch.setattr(fleet_cells.cc, "has_compile_target", lambda p, c: True)
+    monkeypatch.setattr(fleet_cells.cc, "toolchain_present", lambda: True)
+    monkeypatch.setattr(fleet_cells.cc, "mandatory_serving", lambda p: False)
+    monkeypatch.setattr(
+        fleet_cells.cc, "apply_lora_execution_lane", lambda p, b: None)
+    monkeypatch.setattr(
+        fleet_cells.cc, "drop_lora_execution_lane", lambda p: None)
+    monkeypatch.setattr(fleet_cells, "_cuda_ready", lambda: True)
+    monkeypatch.setattr(fleet_cells, "_PENDING", {})
+    # No GPU on a dev box: `sm` is a real-runtime fact and this suite is about
+    # key SPACES, not key computation.
+    monkeypatch.setattr(
+        fleet_cells.cell_key, "compute",
+        lambda *a, **k: type("_K", (), {"digest": ARM_KEY})())
+    monkeypatch.setattr(
+        fleet_cells.loading, "pipeline_weight_lane", lambda pipe: "w8a8")
+    register_export_declaration(_declaration())
+    yield
+    gw_config.reload_for_test()
+
+
+def _arm() -> Any:
+    return fleet_cells.enable_compiled(
+        _Pipe(), _Cfg(), publisher=_Publisher(), delegate=True)  # type: ignore[arg-type]
+
+
+def _adopt(
+    monkeypatch: pytest.MonkeyPatch, pending: Any, *, stamped: str = STAMPED_KEY,
+) -> Any:
+    """Run the real ``adopt_delegated_mint`` over a child cell stamped with a
+    key of the cell's OWN space — the production shape, in one line."""
+    pending.target.parent.mkdir(parents=True, exist_ok=True)
+    pending.target.write_bytes(b"packed-cell")
+    monkeypatch.setattr(
+        fleet_cells.provision, "arm_aot",
+        lambda *a, **k: AdoptOutcome.hit(f"key={stamped}"))
+    monkeypatch.setattr(
+        fleet_cells, "_packed_metadata",
+        lambda artifact: {
+            "kind": "aot-inductor", "cell_key": stamped, "family": FAMILY,
+        })
+    return fleet_cells.adopt_delegated_mint(_Pipe(), pending, pending.target)
+
+
+# ---------------------------------------------------------------------------
+# 1. The pgw#672 no-second-mint memo
+# ---------------------------------------------------------------------------
+
+
+def test_the_memo_is_keyed_on_the_arm_key_the_next_arm_can_look_up(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED at HEAD: written under the STAMPED key, read under the COMPUTED
+    one — two disjoint spaces, so the memo could never hit."""
+    pending = _arm().self_mint
+    assert pending is not None and pending.cell_key == ARM_KEY
+
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None and minted.cell_key == STAMPED_KEY
+
+    prior = fleet_cells.finalized_in_process(ARM_KEY)
+    assert prior is minted, (
+        "the arm identity this process just minted for cannot find its own "
+        "cell — every same-key re-arm pays a second full export")
+    # The VALUE still carries the cell's own identity; only the INDEX is the
+    # arm key. Nothing looks the ledger up by the stamped key.
+    assert prior.cell_key == STAMPED_KEY
+    assert prior.ref.endswith("#" + STAMPED_KEY)
+
+
+def test_a_second_arm_of_the_same_identity_re_arms_instead_of_minting_again(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The protection ITSELF, at its own call site: the second arm must serve
+    from the finalized cell and open no second mint."""
+    pending = _arm().self_mint
+    assert pending is not None
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None
+
+    again = _arm()
+
+    assert again.armed, "the re-arm did not serve from the finalized cell"
+    assert again.self_mint is minted, (
+        "the second arm opened a FRESH mint for an identity this process has "
+        "already minted and adopted — the pgw#672 churn loop")
+    assert not isinstance(again.self_mint, fleet_cells.PendingSelfMint)
+    starts = [phase for kind, phase, _ in _events if kind == "self_mint_started"]
+    assert starts == ["aot"], (
+        f"expected exactly ONE mint for this identity, saw {len(starts)}")
+
+
+# ---------------------------------------------------------------------------
+# 2. The pgw#672 quarantine gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_quarantined_STAMPED_ref_declines_the_next_arm_of_that_identity(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED at HEAD: the two writers that fire on a real proof failure
+    (``executor`` runtime guard `:4160`, boot proof `:7333`) record the ARMED
+    cell's STAMPED ref, and the gate only ever asked about the computed one —
+    so the churn-loop gate was blind to every ref that actually fails."""
+    pending = _arm().self_mint
+    assert pending is not None
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None
+
+    # Exactly what `_revoke_compiled_proof` does with the ref it was serving.
+    compile_cache.record_cell_quarantined(minted.ref)
+
+    again = _arm()
+
+    assert not again.armed
+    assert again.eager_reason == EagerPhase.CELL_QUARANTINED, (
+        "the arm re-minted an identity whose own cell was disproven seconds "
+        "ago — a deterministic recipe rebuilds the same disproven cell")
+    skipped = [
+        detail for kind, phase, detail in _events
+        if kind == "self_mint_skipped" and phase == EagerPhase.CELL_QUARANTINED
+    ]
+    assert skipped and minted.ref in skipped[0], (
+        "the decline must NAME the quarantined ref; two identities can decline "
+        "one arm and the hub cannot tell them apart from the arm key alone")
+
+
+def test_a_quarantined_ARM_ref_still_declines_the_next_arm(
+    _miss: None, _events: List[Tuple[str, str, str]],
+) -> None:
+    """The other half, unchanged: a mint that died before it produced anything
+    has no stamped identity, so `_abandon_pending_mint` quarantines the
+    PENDING's ref — the computed one. Both are consulted."""
+    pending = _arm().self_mint
+    assert pending is not None
+
+    compile_cache.record_cell_quarantined(pending.ref)
+
+    again = _arm()
+
+    assert not again.armed
+    assert again.eager_reason == EagerPhase.CELL_QUARANTINED
+
+
+# ---------------------------------------------------------------------------
+# 3. The pgw#734/#735 kind dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_a_self_minted_cell_is_registered_as_an_AOT_ref(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED at HEAD: ``note_aot_key`` had one caller — discovery. The one
+    artifact this process is CERTAIN is exported, because it just built it,
+    was the one ref ``is_aot_ref`` did not recognize; the executor then scored
+    it by FX cache hits an AOTI package cannot produce and disproved it."""
+    pending = _arm().self_mint
+    assert pending is not None
+    assert not aot_serve.is_aot_ref(pending.ref), (
+        "an OWED mint has no cell yet — nothing may claim its computed ref "
+        "names an exported artifact")
+
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None
+
+    assert aot_serve.is_aot_ref(minted.ref), (
+        "this pod's own exported cell reads as a dynamo ref, so the boot "
+        "proof scores it by FX cache hits and fails it closed")
+    assert aot_serve.is_aot_ref(minted.ref, FAMILY)
+    # The registry is the STAMPED key's, not the arm's: an arm key names no
+    # artifact and must never be classified as one.
+    assert not aot_serve.is_aot_ref(pending.ref)
+
+
+# ---------------------------------------------------------------------------
+# 4. The dead-attribute guard (pgw#805's, on an attribute pgw#1010 deleted)
+# ---------------------------------------------------------------------------
+
+
+def test_an_owed_mint_advertises_no_artifact_identity(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED at HEAD: the guard tested ``mint.recipe == "aot"`` — no mint object
+    has carried a ``recipe`` attribute since pgw#1010 — so `_selection_for`
+    handed back a selection carrying the pending's COMPUTED ref, an identity
+    no artifact will ever be stamped with. Only the caller's `delegated`
+    branch, which drops the selection it just asked for, kept it off the wire.
+    """
+    from gen_worker import executor
+
+    pending = _arm().self_mint
+    assert pending is not None
+    assert not hasattr(pending, "recipe"), (
+        "pgw#1010 deleted the recipe axis; a guard that reads one is dead")
+
+    delivered = executor._CompileArtifactSelection(
+        path=Path("/dev/null"), ref=f"root/family-{FAMILY}#ck1-" + "c" * 56,
+        snapshot_digest="sha256:c", self_mint=False)
+
+    assert executor._selection_for(None, pending) is None
+    assert executor._selection_for(delivered, pending) is delivered
+
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None
+    sel = executor._selection_for(delivered, minted)
+    assert sel is not None and sel.self_mint
+    assert sel.ref == minted.ref, (
+        "an ADOPTED cell advertises the key stamped on the bytes it serves")
+
+
+# ---------------------------------------------------------------------------
+# 5. The pgw#686 divergence warning (INTERIM — pgw#1032 deletes it outright)
+# ---------------------------------------------------------------------------
+
+
+def _target(active: str, requested: str) -> Any:
+    from gen_worker import executor
+
+    return executor._CompileTargetRecord(
+        incarnation_id="inc-1", spec=None, pipeline=object(),  # type: ignore[arg-type]
+        pipeline_weight_lane="w8a8", lora_bucket=0, contract_digest="d",
+        requested_cell_key=requested, active_compile_ref=active,
+        active_self_mint=True)
+
+
+def test_a_healthy_self_minted_AOT_boot_logs_no_key_divergence(
+    _miss: None, _events: List[Tuple[str, str, str]],
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED at HEAD: an ERROR on EVERY healthy AOT boot. The warning compared
+    the stamped key of the active cell against the computed key the runtime
+    requests — two spaces that cannot agree — and since pgw#1010 an AOT cell
+    is the only cell a worker mints."""
+    from gen_worker import executor
+
+    pending = _arm().self_mint
+    assert pending is not None
+    minted = _adopt(monkeypatch, pending)
+    assert minted is not None
+
+    with caplog.at_level("ERROR", logger="gen_worker.executor"):
+        executor.Executor._warn_cell_key_divergence(
+            "sdxl-endpoint", _target(minted.ref, ARM_KEY))
+    assert "cell_key_divergence" not in caplog.text, (
+        "a stamped cell key can never equal a computed request; this ERROR "
+        "fired on every healthy AOT boot and named a fleet-wide zero-adoption "
+        "outage that was not happening")
+
+
+def test_a_divergence_inside_one_key_space_is_still_loud(
+    _miss: None, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The judgement it CAN make stays: same space, different key."""
+    from gen_worker import executor
+
+    stale = f"root/family-{FAMILY}#ck1-" + "c" * 56
+    with caplog.at_level("ERROR", logger="gen_worker.executor"):
+        executor.Executor._warn_cell_key_divergence(
+            "sdxl-endpoint", _target(stale, ARM_KEY))
+    assert "cell_key_divergence" in caplog.text

--- a/tests/test_mint_child_composition_pgw816.py
+++ b/tests/test_mint_child_composition_pgw816.py
@@ -254,7 +254,7 @@ def test_the_parent_hands_its_resolved_overrides_across_the_wire(
 
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
-        pendings={}, pipes={}, selections={},
+        pendings={}, pipes={},
         modules=("app",),
         slots={"pipeline": resolved},
     )
@@ -275,7 +275,7 @@ def test_the_executor_records_what_it_resolved() -> None:
     and must still produce a well-formed request."""
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
-        pendings={}, pipes={}, selections={})
+        pendings={}, pipes={})
     assert bg.slots == {}
 
 

--- a/tests/test_mint_child_slot_bindings_pgw969.py
+++ b/tests/test_mint_child_slot_bindings_pgw969.py
@@ -145,7 +145,7 @@ def _request(
         mint_root=tmp_path)
     bg = _BackgroundMint(
         spec=SimpleNamespace(name=function), instance=object(), snapshots=None,
-        pendings={}, pipes={}, selections={},
+        pendings={}, pipes={},
         modules=(CATALOG_MODULE,),
         slots=({"pipeline": mp.MintSlot(ref=binding, path=str(tree))}
                if binding is not None else {}),
@@ -397,7 +397,7 @@ def test_the_default_is_empty_not_absent() -> None:
     """A hub-less or slotless boot must still produce a well-formed request."""
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=object(), snapshots=None,
-        pendings={}, pipes={}, selections={})
+        pendings={}, pipes={})
     assert bg.slots == {}
 
 

--- a/tests/test_mint_wiring_pgw784.py
+++ b/tests/test_mint_wiring_pgw784.py
@@ -166,7 +166,7 @@ def test_background_mint_carries_the_modules_and_the_resolution(
 ) -> None:
     bg = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=None, snapshots=None,
-        pendings={}, pipes={}, selections={},
+        pendings={}, pipes={},
         modules=("app",), slots={"pipeline": _slot("/cas/sdxl")})
     assert bg.modules == ("app",)
     assert bg.slots["pipeline"].path == "/cas/sdxl"
@@ -174,7 +174,7 @@ def test_background_mint_carries_the_modules_and_the_resolution(
     # Defaulted, so the in-process route is untouched by their existence.
     plain = _BackgroundMint(
         spec=SimpleNamespace(name="gen"), instance=None, snapshots=None,
-        pendings={}, pipes={}, selections={})
+        pendings={}, pipes={})
     assert plain.modules == () and plain.slots == {}
 
 
@@ -218,7 +218,7 @@ def _wired(
     bg = _BackgroundMint(
         spec=spec, instance=None, snapshots=None,
         pendings={id(p): pending for p in objs},
-        pipes={id(p): p for p in objs}, selections={},
+        pipes={id(p): p for p in objs},
         modules=("harness.toy_endpoints",),
         slots={"pipeline": _slot(str(tmp_path / "snap"))})
     monkeypatch.setattr(ex, "_served_execution_lane", lambda s, instructed="": "fp8-w8a16")


### PR DESCRIPTION
Fixes the three key-space mismatches the 2026-08-08 AOT-pipeline architecture audit filed, plus the dead-attribute guard beside them.

A worker holds two cell-key digests of identical shape and disjoint spaces: the **computed** one (`cell_key.compute`, `kind="inductor"`) names an ARM and exists before anything is compiled; the **stamped** one (`kind="aot-inductor"`, contract axis folding the combined graph hash) is what the exported cell IS and does not exist until the export finishes. Three protections were written on one side and fed from the other.

| protection | fix | RED at `872f16e5` |
|---|---|---|
| pgw#672 no-second-mint memo | `_FINALIZED` indexed by the **ARM** key (the only key its one lookup holds — the audit's own legitimate scope for a computed key); the stamped identity rides the value, making the map this process's arm-key -> cell index | `assert None is SelfMint(...)`; the second arm opened a FRESH mint |
| pgw#672 quarantine | gate consults **both** identities — the arm ref (a mint that died before producing anything) and, via `_FINALIZED`, the **stamped** ref of the cell that arm produced (the `executor:4160`/`:7333` writers). Decline names the ref | `MINT_IN_PROGRESS != CELL_QUARANTINED` — a disproven cell re-minted on the next arm |
| pgw#734/#735 kind dispatch | `adopt_delegated_mint` registers the key it reads off the packed envelope; the rule now lives with `_KNOWN_AOT_KEYS` — whoever reads a `cell_key` off an `aot-inductor` envelope registers it | `is_aot_ref(minted.ref)` False — this pod's own `.pt2` scored by FX hits it cannot produce |

`_cell_ref_identity` needed no change: it already collapses both ref FORMS to `(family, key)`. The mismatch was the key VALUE space, never the grammar.

**The dead `recipe` guard is fixed, not deleted** — re-expressed against the mint's own state (a pending has no packed `artifact`). There was no pending advertisement to make deliberate: the stash's only consumer was the write-only `_BackgroundMint.selections` (1 def, 1 write, 0 reads), deleted with it.

**Interim taken under pgw#1032's own checklist** (it authorizes #1033 to carry it if this lands first): `_warn_cell_key_divergence` is the same defect a fourth time and, since pgw#1010 made AOT the only cell a worker mints, fired an ERROR on every healthy AOT boot. It skips AOT refs and keeps the same-space judgement it can make — precise only because protection 3 is restored. pgw#1032 still deletes it with `requested_cell_key`.

## Proof

- `tests/test_cell_key_space_pgw1033.py`: **6 of 8 RED** on `872f16e5` (verified in a detached worktree at that commit), 8 green here. The 2 that pass at HEAD are deliberate regression halves — the ARM-ref quarantine (never broken) and the same-space divergence the interim guard keeps loud.
- Full `tests/` (3618 passed, 37 skipped, 1 xfailed) and `tests_v2/` (21 passed), `-n 4 --dist loadfile`, torch present.
- ruff clean; mypy clean on the changed modules; every hard CI guard green (`lint_http_timeouts`, `lint_unreached_surface`, `lint_config_reads`, `lint_post_connect_resolution`, `lint_unbounded_reads`, `assemble_changelog --check`).