### PR TITLE
pgw#1036: modular-pipeline hydration — local-tree only, overrides land or refuse typed

### DIFF
--- a/changelog.d/pgw1036.md
+++ b/changelog.d/pgw1036.md
@@ -1,0 +1,23 @@
+- **pgw#1036: the worker can now hydrate a `ModularPipeline` slot — from the
+  LOCAL tree only.** `from_pretrained` on a modular repo returns a shell
+  (diffusers registers every `from_pretrained` component as `None`; weights
+  load only in `load_components()`, which nothing called), and every spec's
+  `pretrained_model_name_or_path` names the UPSTREAM repo id verbatim out of
+  the mirror's index, so any naive fix would fetch ~200 GB from
+  huggingface.co and look like success. `load_from_pretrained` now takes a
+  modular lane: construct, re-point EVERY component spec at the local
+  snapshot, hydrate via `load_components` with per-component path routing,
+  and refuse typed (`ModularHydrationError`) when a component the index names
+  has no local source. A config-only weight-bearing dir is the unselected
+  partition (H3's `transformer_ref` shape) and stays excluded.
+- **th#980/pgw#617 component overrides land on modular slots instead of
+  silently vanishing.** `ModularPipeline.__init__` discards the `components=`
+  kwarg with a warning, so the old injection was a no-op. The executor now
+  routes a modular slot's overrides as `component_trees` (paths), and the
+  loader points each override component's spec at its own materialized tree;
+  gw#479 shared modules register via `update_components` post-hydration.
+  `load_components`' swallowed per-component failures are re-checked: every
+  requested component must arrive non-`None` or the load refuses typed with
+  the captured cause. Provenance is stamped on the pipe
+  (`_cozy_modular_hydration`) and emitted as a `modular_hydration` activity
+  event, so the hydration guard's proof is bankable hub-side.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -92,6 +92,10 @@ KIND_LORA_FIDELITY = "lora_fidelity"
 # eager) that nothing in the worker would have noticed, which is why the
 # verdict has to reach the hub whether or not it refuses.
 KIND_CELL_NUMERICS = "cell_numerics"
+# pgw#1036: modular-pipeline hydration provenance — one event per slot load,
+# detail lists component<-local_source pairs (the hydration guard's proof that
+# every weight came from OUR tree, bankable hub-side; phase=hydrated).
+KIND_MODULAR_HYDRATION = "modular_hydration"
 KIND_ROTATION_PRELOAD = "rotation_preload"
 KIND_CAPABILITY_RENEWAL = "capability_renewal"
 KIND_RESIDENCY_FAULT = "residency_fault"

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -8666,11 +8666,16 @@ class Executor:
                         slot_share = {}
                     res = self.store.residency
                     injected: Dict[str, Any] = {}
+                    override_trees: Dict[str, str] = {}
                     if overrides:
                         # pgw#617 load-then-substitute: each override component
                         # loads from its OWN materialized tree and rides the
                         # same from_pretrained components= injection as gw#479
                         # shared modules. Unknown names refuse typed at setup.
+                        # pgw#1036: a MODULAR slot's overrides ride the
+                        # hydration guard's spec routing instead — the
+                        # components= kwarg is what ModularPipeline.__init__
+                        # silently discards.
                         valid = self._model_index_components(path)
                         unknown = sorted(set(overrides) - valid)
                         if unknown:
@@ -8682,12 +8687,21 @@ class Executor:
                             # An overridden component never rides the shared
                             # cache: its bytes differ from the base's.
                             slot_share.pop(comp, None)
-                        from .models.loading import load_component_override
+                        from .models.loading import (
+                            is_modular_pipeline_class,
+                            load_component_override,
+                        )
 
-                        for comp, comp_path in sorted(overrides.items()):
-                            injected[comp] = await _to_thread_complete(
-                                load_component_override, path, comp, comp_path,
-                                dtype=str(getattr(binding, "dtype", "") or ""))
+                        if is_modular_pipeline_class(ann):
+                            override_trees = {
+                                comp: str(p) for comp, p in overrides.items()}
+                        else:
+                            for comp, comp_path in sorted(overrides.items()):
+                                injected[comp] = await _to_thread_complete(
+                                    load_component_override, path, comp,
+                                    comp_path,
+                                    dtype=str(
+                                        getattr(binding, "dtype", "") or ""))
                     if slot_share:
                         valid = self._model_index_components(path)
                         for comp, key in list(slot_share.items()):
@@ -8713,6 +8727,7 @@ class Executor:
                         sl = await _to_thread_complete(
                             provision.load_slot, ann, path, binding=binding,
                             slot=slot, ref=ref, mode=mode, components=injected,
+                            component_trees=override_trees or None,
                             declared_vram_gb=float(
                                 spec.resources.vram_gb_hint or 0),
                             force_storage_dtype=(
@@ -8740,6 +8755,7 @@ class Executor:
                         sl = await _to_thread_complete(
                             provision.load_slot, ann, path, binding=binding,
                             slot=slot, ref=ref, mode=mode, components=injected,
+                            component_trees=override_trees or None,
                             declared_vram_gb=float(
                                 spec.resources.vram_gb_hint or 0),
                             force_storage_dtype=(

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1338,6 +1338,227 @@ def load_component_override(
         base_path, component, dtype=dtype, weights_tree=override_path)
 
 
+class ModularHydrationError(RuntimeError):
+    """A ModularPipeline slot could not be hydrated from the LOCAL tree
+    (pgw#1036). Typed so the failure is a refusal at load — never a silent
+    shell handed to ``setup()``, and never a fetch from the repo id the
+    snapshot's index happens to name."""
+
+
+def is_modular_pipeline_class(cls: Any) -> bool:
+    """Duck-typed: a modular pipeline class exposes ``load_components``
+    (weights hydrate AFTER construction) — ``DiffusionPipeline`` does not."""
+    return (
+        isinstance(cls, type)
+        and callable(getattr(cls, "from_pretrained", None))
+        and callable(getattr(cls, "load_components", None))
+    )
+
+
+def _is_modular_pipeline(obj: Any) -> bool:
+    return (
+        hasattr(obj, "_component_specs")
+        and callable(getattr(obj, "load_components", None))
+    )
+
+
+def _resolve_override_tree(root: Path, component: str) -> Path:
+    """Override-tree layout convention (same as :func:`load_component`): the
+    tree's ``<component>/`` subtree when present, else its root."""
+    sub = root / component
+    return sub if sub.is_dir() else root
+
+
+def _local_component_dir(base: Path, spec: Any, name: str) -> Optional[Path]:
+    """The LOCAL snapshot dir for a component spec: the spec's subfolder
+    under the snapshot root (falling back to the component name). None when
+    the snapshot has no such dir at all."""
+    for sub in (str(getattr(spec, "subfolder", "") or ""), name):
+        if not sub:
+            continue
+        cand = base / sub
+        if cand.is_dir():
+            return cand
+    return None
+
+
+def _weightless_model_dir(src: Path) -> bool:
+    """True for a config-only weight-bearing dir — the deliberate-partition
+    shape (ie#613 pins by FILE SET and keeps ``config.json`` for the
+    unselected partition, e.g. H3's ``transformer_ref/``): the component is
+    EXCLUDED from this slot, not missing."""
+    if not (src / "config.json").is_file():
+        return False  # tokenizer/processor/scheduler dirs: no model config
+    return next(src.rglob("*.safetensors"), None) is None
+
+
+def hydrate_modular_pipeline(
+    pipe: Any,
+    path: str | Path,
+    *,
+    torch_dtype: Any = None,
+    component_trees: Optional[Dict[str, str]] = None,
+    preloaded: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Hydrate a freshly constructed ``ModularPipeline`` from the LOCAL
+    snapshot tree (pgw#1036).
+
+    ``ModularPipeline.__init__`` registers every ``from_pretrained``
+    component as ``None`` and copies each spec's
+    ``pretrained_model_name_or_path`` verbatim out of the snapshot's index —
+    which on a mirrored repo names the UPSTREAM repo id. This function is the
+    hydration guard: every spec is re-pointed at the local tree BEFORE
+    ``load_components`` runs, so neither this load nor any later endpoint-side
+    ``pipe.load_components()`` can reach huggingface.co.
+
+    - base components load from ``<snapshot>/<subfolder>``;
+    - ``component_trees`` (th#980/pgw#617 overrides) re-route a component to
+      its OWN materialized tree (``<tree>/<component>/`` or the tree root);
+    - a config-only weight-bearing dir is the unselected partition: SKIPPED,
+      its spec neutralized so nothing can ever fetch it;
+    - a component the index names but the snapshot does not carry refuses
+      typed (:class:`ModularHydrationError`) — never a fetch;
+    - ``preloaded`` modules (gw#479 shared components) are registered via
+      ``update_components`` instead of the ``from_pretrained`` kwarg
+      ``ModularPipeline.__init__`` silently discards.
+
+    Returns ``{component: source_path}`` for everything hydrated. The result
+    is verified: ``load_components`` swallows load errors into a logger
+    warning, so every requested component is re-checked non-``None`` and a
+    miss raises typed with the captured diffusers log text."""
+    base = Path(path)
+    specs = dict(getattr(pipe, "_component_specs", None) or {})
+    trees = dict(component_trees or {})
+    pre = dict(preloaded or {})
+
+    unknown = sorted(set(trees) - set(specs))
+    if unknown:
+        raise ModularHydrationError(
+            f"component override {unknown[0]!r} is not a component of "
+            f"{type(pipe).__name__} (specs: {sorted(specs)})")
+    both = sorted(set(trees) & set(pre))
+    if both:
+        raise ModularHydrationError(
+            f"component {both[0]!r} arrived as BOTH an override tree and a "
+            f"preloaded module; one delivery mechanism per component")
+
+    sources: Dict[str, str] = {}
+    skipped: List[str] = []
+    for name, spec in specs.items():
+        if getattr(spec, "default_creation_method", "") != "from_pretrained":
+            continue
+        if name in pre:
+            continue
+        if name in trees:
+            root = Path(trees[name])
+            if not root.is_dir():
+                raise ModularHydrationError(
+                    f"override tree for component {name!r} does not exist: "
+                    f"{root}")
+            sources[name] = str(_resolve_override_tree(root, name))
+            continue
+        src = _local_component_dir(base, spec, name)
+        if src is None:
+            raise ModularHydrationError(
+                f"component {name!r} is named by the snapshot's index "
+                f"(pretrained_model_name_or_path="
+                f"{getattr(spec, 'pretrained_model_name_or_path', None)!r}) "
+                f"but the local tree {base} has no {name!r} dir — refusing "
+                f"rather than fetching from the index's repo id")
+        if _weightless_model_dir(src):
+            skipped.append(name)
+            continue
+        sources[name] = str(src)
+
+    # Re-point the SPECS first: a later bare `pipe.load_components()` (e.g.
+    # endpoint-side) must be equally incapable of reaching the index's repo
+    # id. Skipped partitions get None — load_components ignores a spec with
+    # no path, and spec.load() refuses one outright.
+    for name in sources:
+        spec = specs[name]
+        spec.pretrained_model_name_or_path = sources[name]
+        spec.subfolder = ""
+    for name in skipped:
+        specs[name].pretrained_model_name_or_path = None
+    for name in pre:
+        # A preloaded (gw#479 shared) module loads from no path at all;
+        # update_components below replaces its spec, but neutralize first so
+        # the guard can never read its stale upstream id as a fetch source.
+        if name in specs:
+            specs[name].pretrained_model_name_or_path = None
+
+    for name, spec in specs.items():
+        if getattr(spec, "default_creation_method", "") != "from_pretrained":
+            continue
+        p = getattr(spec, "pretrained_model_name_or_path", None)
+        if p is not None and not Path(str(p)).exists():
+            try:
+                listing = sorted(q.name for q in base.iterdir())
+            except OSError:
+                listing = ["<unreadable>"]
+            raise ModularHydrationError(
+                f"component {name!r} spec still names a non-local source "
+                f"{p!r} after re-pointing — refusing rather than fetching "
+                f"(base tree {base} holds: {listing})")
+
+    names = sorted(sources)
+    if names:
+        kwargs: Dict[str, Any] = {
+            "pretrained_model_name_or_path": {n: sources[n] for n in names},
+            "subfolder": {n: "" for n in names},
+        }
+        if torch_dtype is not None:
+            kwargs["torch_dtype"] = torch_dtype
+        # load_components swallows per-component load failures into a
+        # diffusers logger warning and registers nothing — capture that text
+        # so the typed refusal below can carry the actual cause.
+        records: List[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        dlog = logging.getLogger("diffusers")
+        handler = _Capture(level=logging.WARNING)
+        dlog.addHandler(handler)
+        try:
+            pipe.load_components(names=names, **kwargs)
+        finally:
+            dlog.removeHandler(handler)
+        missing = [n for n in names if getattr(pipe, n, None) is None]
+        if missing:
+            detail = "\n".join(r for r in records if missing[0] in r) or \
+                "\n".join(records[-3:])
+            raise ModularHydrationError(
+                f"modular hydration failed for component(s) {missing} of "
+                f"{type(pipe).__name__} from local source(s) "
+                f"{ {n: sources[n] for n in missing} }: {detail}")
+
+    if pre:
+        pipe.update_components(**pre)
+        for name in pre:
+            if getattr(pipe, name, None) is None:
+                raise ModularHydrationError(
+                    f"preloaded component {name!r} did not register on "
+                    f"{type(pipe).__name__}")
+            sources[name] = "<preloaded shared module>"
+
+    try:
+        pipe._cozy_modular_hydration = dict(sources)
+    except Exception:  # noqa: BLE001
+        pass
+    detail = " ".join(f"{n}<-{sources[n]}" for n in sorted(sources))
+    logger.info("modular hydration (%s): %s; skipped partitions: %s",
+                type(pipe).__name__, detail, skipped or "none")
+    activity_mod.emit_event(
+        activity_mod.KIND_MODULAR_HYDRATION,
+        f"pipeline={type(pipe).__name__} base={base} {detail}"
+        + (f" skipped={','.join(skipped)}" if skipped else ""),
+        phase="hydrated",
+    )
+    return sources
+
+
 def _safetensors_data_bytes(p: Path) -> int:
 
     with open(p, "rb") as f:
@@ -1554,6 +1775,62 @@ def _adaptive_fit_rung(
     return "nf4", qc
 
 
+def _load_modular_pipeline(
+    cls: Any,
+    path: str,
+    *,
+    dtype: str = "",
+    storage_dtype: str = "",
+    components: Optional[Dict[str, Any]] = None,
+    component_trees: Optional[Dict[str, str]] = None,
+) -> Any:
+    """The modular lane of :func:`load_from_pretrained` (pgw#1036):
+    ``cls.from_pretrained(path)`` builds a SHELL (every weight-bearing
+    component ``None``, specs naming the index's repo id verbatim), then
+    :func:`hydrate_modular_pipeline` re-points every spec at the local tree
+    and loads the weights. The quant/storage rungs (svdq/w8a8/w4a4/gguf,
+    fp8 storage, the adaptive fit ladder) are pipeline-lane mechanisms and do
+    not apply here v1 — a quantized modular component arrives as its own
+    self-describing component tree (e.g. a transformers FineGrainedFP8
+    artifact) and loads natively through its spec."""
+    if storage_dtype:
+        logger.warning(
+            "storage_dtype=%s ignored on the modular lane (component "
+            "precision is a per-component artifact fact)", storage_dtype)
+    scalar_dtype: Any = None
+    wanted = dtype or {
+        "bf16": "bf16", "fp16": "fp16", "fp8": "bf16",
+    }.get(detect_on_disk_dtype(Path(path)), "")
+    if wanted:
+        try:
+            scalar_dtype = get_torch_dtype(wanted)
+        except ImportError:
+            pass  # torch-less environment: loaders fail on their own terms
+    torch_dtype: Any = scalar_dtype
+    per_component = _component_dtype_map(cls, path, scalar_dtype)
+    if per_component:
+        # Same {"default": ..., part: ...} shape load_components' dict
+        # routing understands (pgw#667 widened parts included).
+        torch_dtype = per_component
+    pipe = cls.from_pretrained(path)
+    if not _is_modular_pipeline(pipe):
+        raise ModularHydrationError(
+            f"{getattr(cls, '__name__', cls)}.from_pretrained returned "
+            f"{type(pipe).__name__} without _component_specs/load_components;"
+            f" cannot hydrate")
+    hydrate_modular_pipeline(
+        pipe, Path(path), torch_dtype=torch_dtype,
+        component_trees=component_trees, preloaded=components,
+    )
+    unmaterialized = meta_tensors(pipe)
+    if unmaterialized:
+        raise RuntimeError(
+            f"{type(pipe).__name__} load left {len(unmaterialized)} "
+            f"unmaterialized meta tensors (e.g. {unmaterialized[:3]})"
+        )
+    return pipe
+
+
 @implements_contract(
     contract=CONTRACT_PLAIN_BF16,
     serves=("bf16-w16a16", "fp8-w8a16"),
@@ -1571,6 +1848,7 @@ def load_from_pretrained(
     attrs: Optional[Dict[str, str]] = None,
     storage_dtype: str = "",
     components: Optional[Dict[str, Any]] = None,
+    component_trees: Optional[Dict[str, str]] = None,
     declared_vram_gb: float = 0.0,
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
@@ -1586,8 +1864,23 @@ def load_from_pretrained(
     components, gw#479) forwarded to ``from_pretrained`` — diffusers skips
     loading those from disk and wires the given objects in. Used by the
     executor to satisfy pipeline-typed ``setup()`` annotations; endpoints may
-    also call it."""
+    also call it. A modular pipeline class (pgw#1036: exposes
+    ``load_components``) takes its own lane — construct, re-point every
+    component spec at the LOCAL tree, hydrate; ``component_trees`` routes
+    th#980/pgw#617 component overrides to their own materialized trees on
+    that lane (the ``components=`` kwarg is what ``ModularPipeline.__init__``
+    silently discards)."""
     path = str(path)
+    if is_modular_pipeline_class(cls):
+        return _load_modular_pipeline(
+            cls, path, dtype=dtype, storage_dtype=storage_dtype,
+            components=components, component_trees=component_trees,
+        )
+    if component_trees:
+        raise ModularHydrationError(
+            f"component_trees is the MODULAR delivery mechanism and "
+            f"{getattr(cls, '__name__', cls)} is not a modular pipeline "
+            f"class; non-modular overrides ride components= (pgw#617)")
     # SVDQuant/nunchaku 4-bit flavors (gw#415): self-describing snapshots take
     # the svdq lane — a nunchaku transformer swapped into the standard
     # pipeline. Detection precedes every other rung; failures are typed
@@ -1855,5 +2148,8 @@ __all__ = [
     "model_index_component_classes",
     "snapshot_component_weight_bytes",
     "load_from_pretrained",
+    "is_modular_pipeline_class",
+    "hydrate_modular_pipeline",
+    "ModularHydrationError",
     "load_gguf_pipeline",
 ]

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -100,6 +100,7 @@ def load_slot(
     ref: str = "",
     mode: str = "auto",
     components: Optional[Dict[str, Any]] = None,
+    component_trees: Optional[Dict[str, str]] = None,
     device: str = "",
     declared_vram_gb: float = 0.0,
     force_storage_dtype: str = "",
@@ -151,7 +152,9 @@ def load_slot(
 
     pipe = load_from_pretrained(
         annotation, path, dtype=dtype, storage_dtype=storage_dtype,
-        components=components or None, declared_vram_gb=declared_vram_gb,
+        components=components or None,
+        component_trees=component_trees or None,
+        declared_vram_gb=declared_vram_gb,
     )
     out.obj = pipe
 

--- a/tests/harness/modular_endpoint.py
+++ b/tests/harness/modular_endpoint.py
@@ -1,0 +1,172 @@
+"""pgw#1036 harness: a REAL tiny diffusers ModularPipeline (0.39 modular
+API, real safetensors, CPU) plus an endpoint serving it, for the modular
+hydration guard's integration tests.
+
+The trees this builds reproduce the mirror disease exactly: every component
+spec's ``pretrained_model_name_or_path`` in ``modular_model_index.json``
+names an UPSTREAM repo id (``upstream/pgw1036-owned-by-hf``) that does not
+exist — any load that is not re-pointed at the local tree fails loudly, and
+the tests additionally run under ``HF_HUB_OFFLINE=1``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import diffusers
+from diffusers import AutoencoderKL, DDPMScheduler, UNet2DConditionModel
+from diffusers.modular_pipelines import ModularPipeline
+from diffusers.modular_pipelines.modular_pipeline import ModularPipelineBlocks
+from diffusers.modular_pipelines.modular_pipeline_utils import ComponentSpec
+
+from gen_worker import RequestContext, Slot, endpoint
+from gen_worker.api.binding import Hub
+
+from .toy_endpoints import EchoIn, EchoOut, _ToyDefaults
+
+UPSTREAM_REPO_ID = "upstream/pgw1036-owned-by-hf"
+
+
+class TinyBlocks(ModularPipelineBlocks):
+    """Blocks that only declare component expectations — construction and
+    hydration are what pgw#1036 tests, never a denoise."""
+
+    # Truth-tested by ModularPipeline.__init__'s blocks resolution.
+    block_classes = ["tiny"]
+
+    @property
+    def expected_components(self) -> List[ComponentSpec]:
+        return [
+            ComponentSpec(name="unet", type_hint=UNet2DConditionModel),
+            ComponentSpec(name="vae", type_hint=AutoencoderKL),
+            ComponentSpec(name="vae_ref", type_hint=AutoencoderKL),
+            ComponentSpec(name="scheduler", type_hint=DDPMScheduler),
+        ]
+
+
+class TinyModularPipeline(ModularPipeline):
+    default_blocks_name = "TinyBlocks"
+
+
+# ModularPipeline.__init__ resolves the blocks class from the DIFFUSERS
+# namespace — the vendored-package registration pattern (minimax-h3 does the
+# same for MiniMaxH3Blocks).
+diffusers.TinyBlocks = TinyBlocks
+diffusers.TinyModularPipeline = TinyModularPipeline
+
+
+def tiny_unet(fill: float) -> UNet2DConditionModel:
+    m = UNet2DConditionModel(
+        sample_size=8, in_channels=4, out_channels=4, layers_per_block=1,
+        block_out_channels=(4, 8), norm_num_groups=4, cross_attention_dim=8,
+        attention_head_dim=2,
+        down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+        up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+    )
+    for p in m.parameters():
+        p.data.fill_(fill)
+    return m
+
+
+def tiny_vae(fill: float) -> AutoencoderKL:
+    m = AutoencoderKL(
+        in_channels=3, out_channels=3, latent_channels=4, sample_size=8,
+        layers_per_block=1, block_out_channels=(4,), norm_num_groups=4,
+        down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+    )
+    for p in m.parameters():
+        p.data.fill_(fill)
+    return m
+
+
+def _spec_entry(class_name: str, subfolder: str) -> list:
+    return ["diffusers", class_name, {
+        "pretrained_model_name_or_path": UPSTREAM_REPO_ID,
+        "subfolder": subfolder,
+        "variant": None,
+        "revision": None,
+        "type_hint": ["diffusers", class_name],
+    }]
+
+
+def build_base_tree(root: Path, *, fill: float = 1.0) -> Path:
+    """The mirror shape: full components locally, every index spec naming
+    the upstream repo id, and ``vae_ref`` as the config-only unselected
+    partition (H3's ``transformer_ref`` shape)."""
+    root.mkdir(parents=True, exist_ok=True)
+    tiny_unet(fill).save_pretrained(root / "unet")
+    vae = tiny_vae(fill)
+    vae.save_pretrained(root / "vae")
+    DDPMScheduler().save_pretrained(root / "scheduler")
+    # config-only partition: config.json, no weights
+    (root / "vae_ref").mkdir(exist_ok=True)
+    (root / "vae_ref" / "config.json").write_text(
+        (root / "vae" / "config.json").read_text())
+    index = {
+        "_class_name": "TinyModularPipeline",
+        "_diffusers_version": diffusers.__version__,
+        "_blocks_class_name": "TinyBlocks",
+        "unet": _spec_entry("UNet2DConditionModel", "unet"),
+        "vae": _spec_entry("AutoencoderKL", "vae"),
+        "vae_ref": _spec_entry("AutoencoderKL", "vae_ref"),
+        "scheduler": _spec_entry("DDPMScheduler", "scheduler"),
+    }
+    (root / "modular_model_index.json").write_text(json.dumps(index))
+    # model_index.json too — the executor's override-name validation and the
+    # loader's dtype/component helpers read it (the real mirror carries both).
+    (root / "model_index.json").write_text(json.dumps({
+        "_class_name": "TinyModularPipeline",
+        "_diffusers_version": diffusers.__version__,
+        "unet": ["diffusers", "UNet2DConditionModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+        "vae_ref": ["diffusers", "AutoencoderKL"],
+        "scheduler": ["diffusers", "DDPMScheduler"],
+    }))
+    return root
+
+
+def build_override_vae_tree(root: Path, *, fill: float = 2.0,
+                            subdir: bool = True) -> Path:
+    """A th#980 component-override tree: ``<root>/vae/`` (subdir layout) or
+    the component at the root (both platform conventions; deliberately NO
+    model_index.json — the encoder-trunc-fp8 shape)."""
+    dest = (root / "vae") if subdir else root
+    tiny_vae(fill).save_pretrained(dest)
+    return root
+
+
+def tree_files(root: Path) -> Dict[str, bytes]:
+    return {
+        str(p.relative_to(root)): p.read_bytes()
+        for p in sorted(root.rglob("*")) if p.is_file()
+    }
+
+
+MODULAR_DECLARED = Hub("harness/tiny-modular", tag="prod")
+
+
+@endpoint(models={
+    "pipeline": Slot(TinyModularPipeline, default_checkpoint=MODULAR_DECLARED),
+})
+class ModularEndpoint:
+    """Reports the hydration outcome so the wire result IS the assertion."""
+
+    def setup(self, pipeline: TinyModularPipeline) -> None:
+        self.pipe = pipeline
+
+    def modular_echo(self, ctx: RequestContext[_ToyDefaults],
+                     data: EchoIn) -> EchoOut:
+        p = self.pipe
+        vae_fill = float(next(iter(p.vae.parameters())).flatten()[0]) \
+            if p.vae is not None else float("nan")
+        prov = dict(getattr(p, "_cozy_modular_hydration", {}) or {})
+        return EchoOut(response=(
+            f"unet={'set' if p.unet is not None else 'none'}"
+            f"|vae_fill={vae_fill:g}"
+            f"|vae_ref={'set' if p.vae_ref is not None else 'none'}"
+            f"|scheduler={'set' if p.scheduler is not None else 'none'}"
+            f"|prov_vae={prov.get('vae', '')}"
+        ))

--- a/tests/test_modular_hydration_pgw1036.py
+++ b/tests/test_modular_hydration_pgw1036.py
@@ -1,0 +1,243 @@
+"""pgw#1036: the worker hydrates a ``ModularPipeline`` slot from the LOCAL
+tree, refuses an un-repointed spec typed, and delivers th#980/pgw#617
+component overrides through the spec routing ``ModularPipeline.__init__``
+cannot silently discard.
+
+Integration-style against REAL diffusers 0.39 modular pipelines (real
+safetensors on disk, CPU): the harness trees reproduce the mirror disease —
+every index spec names an upstream repo id — and the whole module runs under
+``HF_HUB_OFFLINE=1``, so any fetch attempt is a loud failure, not a silent
+success (the ie#615 hydration-guard hazard, verified rather than assumed).
+"""
+
+from __future__ import annotations
+
+import msgspec
+import pytest
+import torch
+
+from gen_worker.models import provision
+from gen_worker.models.loading import (
+    ModularHydrationError,
+    is_modular_pipeline_class,
+    load_from_pretrained,
+)
+from gen_worker.pb import worker_scheduler_pb2 as pb
+
+from harness.blob_host import BlobHost
+from harness.hub_double import hub_double, is_ready, is_result_for
+from harness.modular_endpoint import (
+    MODULAR_DECLARED,
+    TinyModularPipeline,
+    UPSTREAM_REPO_ID,
+    build_base_tree,
+    build_override_vae_tree,
+    tiny_vae,
+    tree_files,
+)
+from harness.toy_endpoints import EchoIn, EchoOut
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_HUB_DISABLE_TELEMETRY", "1")
+
+
+def _fill(mod) -> float:
+    return float(next(iter(mod.parameters())).flatten()[0])
+
+
+def test_detection_is_class_shaped() -> None:
+    from diffusers import DiffusionPipeline
+
+    assert is_modular_pipeline_class(TinyModularPipeline)
+    assert not is_modular_pipeline_class(DiffusionPipeline)
+    assert not is_modular_pipeline_class(str)
+
+
+def test_hydrates_every_component_from_local_tree(tmp_path) -> None:
+    """(a) the slot arrives with every needed component non-None, weights
+    from OUR tree; (d) no network egress — the index repo id does not exist
+    and HF_HUB_OFFLINE=1, so a fetch would fail the test."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe = load_from_pretrained(TinyModularPipeline, tree)
+
+    assert pipe.unet is not None and _fill(pipe.unet) == 1.0
+    assert pipe.vae is not None and _fill(pipe.vae) == 1.0
+    assert pipe.scheduler is not None
+    # the unselected partition (config-only dir) stays excluded — the
+    # 144 GB bound-checkpoint accounting's assumption, preserved
+    assert pipe.vae_ref is None
+
+    # every spec re-pointed local (or neutralized): a later endpoint-side
+    # bare load_components() must be equally incapable of fetching
+    for name, spec in pipe._component_specs.items():
+        if spec.default_creation_method != "from_pretrained":
+            continue
+        p = spec.pretrained_model_name_or_path
+        assert p is None or str(tree) in str(p), (name, p)
+        assert p is None or UPSTREAM_REPO_ID not in str(p), (name, p)
+
+    prov = pipe._cozy_modular_hydration
+    assert set(prov) == {"unet", "vae", "scheduler"}
+    assert all(str(tree) in src for src in prov.values())
+
+
+def test_unrepointable_spec_refuses_typed(tmp_path) -> None:
+    """(b) an index naming a component the local tree does not carry refuses
+    typed — never a fetch from the index's repo id."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    import shutil
+
+    shutil.rmtree(tree / "unet")  # named by the index, absent locally
+    with pytest.raises(ModularHydrationError) as exc:
+        load_from_pretrained(TinyModularPipeline, tree)
+    assert "unet" in str(exc.value)
+    assert UPSTREAM_REPO_ID in str(exc.value)
+
+
+def test_override_tree_replaces_default_subdir_layout(tmp_path) -> None:
+    """(c) a th#980 component override against a modular slot LANDS: the
+    loaded module's bytes come from the override tree, not the base."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=2.0, subdir=True)
+    pipe = load_from_pretrained(
+        TinyModularPipeline, tree, component_trees={"vae": str(override)})
+    assert pipe.vae is not None and _fill(pipe.vae) == 2.0  # override bytes
+    assert pipe.unet is not None and _fill(pipe.unet) == 1.0  # base bytes
+    assert str(override) in pipe._cozy_modular_hydration["vae"]
+
+
+def test_override_tree_replaces_default_root_layout(tmp_path) -> None:
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=3.0, subdir=False)
+    pipe = load_from_pretrained(
+        TinyModularPipeline, tree, component_trees={"vae": str(override)})
+    assert pipe.vae is not None and _fill(pipe.vae) == 3.0
+
+
+def test_dtype_lands_on_hydrated_components(tmp_path) -> None:
+    """(c) dtype half of the assertion: the binding's declared dtype reaches
+    the hydrated modules through load_components' routing."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe = load_from_pretrained(TinyModularPipeline, tree, dtype="fp16")
+    assert pipe.unet.dtype == torch.float16
+    assert pipe.vae.dtype == torch.float16
+
+
+def test_unknown_override_component_refuses_typed(tmp_path) -> None:
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=2.0)
+    with pytest.raises(ModularHydrationError, match="text_encoder"):
+        load_from_pretrained(
+            TinyModularPipeline, tree,
+            component_trees={"text_encoder": str(override)})
+
+
+def test_component_trees_on_non_modular_class_refuses_typed(tmp_path) -> None:
+    """The delivery mechanisms must never cross silently — the silent-drop
+    class of bug this issue exists to close."""
+    class NotModular:
+        @classmethod
+        def from_pretrained(cls, path, **kw):  # pragma: no cover
+            return cls()
+
+    with pytest.raises(ModularHydrationError, match="not a modular"):
+        load_from_pretrained(
+            NotModular, tmp_path, component_trees={"vae": str(tmp_path)})
+
+
+def test_load_slot_carries_component_trees(tmp_path) -> None:
+    """The production entry the executor calls: provision.load_slot routes
+    component_trees through to the hydration guard."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=4.0)
+    sl = provision.load_slot(
+        TinyModularPipeline, str(tree), slot="pipeline",
+        ref="harness/tiny-modular:prod",
+        component_trees={"vae": str(override)}, device="cpu",
+    )
+    pipe = sl.obj
+    assert pipe.vae is not None and _fill(pipe.vae) == 4.0
+    assert pipe.unet is not None and _fill(pipe.unet) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Executor-level: the full dispatch path (real worker/lifecycle/executor over
+# the hub double), the acceptance's "modular slot arrives at setup()" bar.
+# ---------------------------------------------------------------------------
+
+BASE_REF = "harness/tiny-modular"
+OVR_REF = "harness/tiny-modular-vae-fp8"
+
+
+def _snapshot(blobs: BlobHost, snap_id: str, root) -> pb.Snapshot:
+    return blobs.snapshot(snap_id, [
+        blobs.file(f"{snap_id}-{i}", data, path_in_snapshot=rel)
+        for i, (rel, data) in enumerate(tree_files(root).items())
+    ])
+
+
+def _run(conn, rid: str, models, snapshots) -> pb.JobResult:
+    conn.send(run_job=pb.RunJob(
+        request_id=rid, attempt=1, function_name="modular-echo",
+        input_payload=msgspec.msgpack.encode(EchoIn()),
+        models=models, snapshots=snapshots,
+    ))
+    return conn.wait_for(is_result_for(rid)).job_result
+
+
+def _decode(data: bytes) -> EchoOut:
+    return msgspec.msgpack.decode(data, type=EchoOut)
+
+
+def test_executor_hydrates_and_substitutes(tmp_path) -> None:
+    assert MODULAR_DECLARED  # endpoint module imported, slot declared
+    base = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=2.0)
+    blobs = BlobHost(tmp_path / "blobs")
+    try:
+        base_snap = _snapshot(blobs, "snap-tiny-modular", base)
+        ovr_snap = _snapshot(blobs, "snap-tiny-modular-vae", override)
+        flat = [pb.ModelBinding(slot="pipeline", ref=BASE_REF)]
+        subst = [pb.ModelBinding(
+            slot="pipeline", ref=BASE_REF, components={"vae": OVR_REF})]
+        with hub_double(modules=(
+            "harness.toy_endpoints", "harness.modular_endpoint",
+        )) as (scheduler, _harness):
+            conn = scheduler.wait_connection(0)
+            conn.wait_for(is_ready)
+
+            res = _run(conn, "r-mod-flat", flat, {BASE_REF: base_snap})
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            out = _decode(res.inline).response
+            assert "unet=set" in out
+            assert "vae_fill=1" in out
+            assert "vae_ref=none" in out       # partition stays excluded
+            assert "scheduler=set" in out
+
+            res = _run(conn, "r-mod-subst", subst,
+                       {BASE_REF: base_snap, OVR_REF: ovr_snap})
+            assert res.status == pb.JOB_STATUS_OK, res.safe_message
+            out = _decode(res.inline).response
+            assert "vae_fill=2" in out          # override bytes landed
+            assert "unet=set" in out
+            assert "prov_vae=" in out and "snap-tiny-modular-vae" in out
+    finally:
+        blobs.shutdown()
+
+
+def test_fp8_stored_override_tree_loads_without_upcast_config(tmp_path) -> None:
+    """The encoder-trunc-fp8 shape is a transformers FineGrainedFP8 artifact
+    that loads natively through its own config — nothing for the worker to
+    do. This CPU test covers the nearest loadable analogue: an override tree
+    whose stored dtype differs from the base (fp16 vs fp32) keeps its own
+    precision fact when no binding dtype narrows it."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    ovr_root = tmp_path / "ovr"
+    vae = tiny_vae(5.0).to(torch.float16)
+    vae.save_pretrained(ovr_root / "vae")
+    pipe = load_from_pretrained(
+        TinyModularPipeline, tree, component_trees={"vae": str(ovr_root)})
+    assert pipe.vae is not None and _fill(pipe.vae) == 5.0


### PR DESCRIPTION
P0 for ie#615 (H3 first production serve). gen-worker 0.94.1 has zero modular-pipeline awareness: `ModularPipeline.from_pretrained` returns a shell (every weight-bearing component `None`), the specs name the UPSTREAM repo id verbatim from the mirror's index (a naive `load_components()` fetches ~200 GB from huggingface.co and looks like success), and the `components=` kwarg th#980/pgw#617 overrides ride is silently discarded by `ModularPipeline.__init__`.

**The fix (pgw#1036's sketch, followed):**
- `load_from_pretrained` gains a modular lane: construct, re-point EVERY component spec at the LOCAL snapshot tree, hydrate via `load_components` with per-component `pretrained_model_name_or_path` routing. An index-named component with no local source refuses typed (`ModularHydrationError`) — never a fetch. Config-only weight-bearing dirs are the unselected partition (H3 `transformer_ref`) and stay excluded.
- Executor routes a modular slot's overrides as `component_trees` (paths) through `provision.load_slot` instead of loading modules destined for the discarded kwarg; gw#479 shared modules register via `update_components` post-hydration. `component_trees` on a non-modular class refuses typed.
- `load_components` swallows per-component failures into a logger warning — every requested component is re-checked non-`None` or the load refuses typed with the captured cause.
- Provenance: `pipe._cozy_modular_hydration` + one `modular_hydration` activity event, so the hydration guard's proof is bankable in `worker_activity_events`.

**Tests:** 11 in `tests/test_modular_hydration_pgw1036.py` against REAL diffusers 0.39 modular pipelines (real safetensors, CPU, `HF_HUB_OFFLINE=1` + nonexistent upstream repo ids so any fetch fails loudly), including a full executor-level dispatch through the hub double (flat → override → provenance on the wire). Full suite local: 3621 passed. mypy 238 files clean; all CI guard scripts green locally.

Deviations from the issue's sketch are written back into pgw#1036 in the tracker (skip-vs-refuse rule, swallowed-failure re-check, shared-module registration, class-duck-typed executor detection, quant rungs out of scope v1).

Train position: leg 1 of the ie#615 serve train (pgw#1036 → publish 0.95.0 + fleet repin → th#1708 → minimax-h3 0.2.0 rebuild → violin-busker proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)