### PR TITLE
pgw#902: one immutable Plan, built from the ExecutionSpec and from nothing else

### DIFF
--- a/changelog.d/pgw902.md
+++ b/changelog.d/pgw902.md
@@ -1,0 +1,21 @@
+- **pgw#902: `gen_worker.plan` — one immutable execution Plan, derived from the Hub-issued
+  `ExecutionSpec` and from nothing else.** `PlanFactory` is a pure transform: it reads the generated
+  schema, refuses, and does nothing else. An import-graph test forbids it from reaching a store,
+  transport, lifecycle, cache or device module, because a factory that can import a store can fetch
+  and a factory that can fetch is a second resolver again.
+- **Refuse, never default.** An unknown `spec_version`, an unresolved lane, an AOT arm with no named
+  artifact (or a DYNAMO arm carrying one), a slot with no `snapshot_digest`, an unnamed artifact
+  publisher, an out-of-range adapter weight, a duplicate slot and an input asset with no digest are
+  each a typed `PlanRefusal` naming the field, what was expected and what arrived — raised before any
+  model acquisition. There is no coarse lane to expand and no root-slot fallback: `WeightLane` has no
+  family member, so `executor._execution_lane_effective_spec`'s expansion has nothing to expand on
+  this path, by construction rather than by a lint.
+- **Grant rotation is proven inert.** Two `RunAttempt`s differing only in `capability_token`, epoch,
+  expiry and presigned URLs produce a byte-identical Plan, and no grant secret can appear anywhere in
+  its encoding.
+- **`PlanLedger` decides replay, and only replay.** Same attempt + same digest re-acknowledges without
+  re-executing; same attempt + a different digest raises `PlanConflict` and keeps the first — a
+  changed digest never adopts earlier state.
+- **Not yet wired.** `RunJob` is still the live dispatch; `SchedulerMessage.run_attempt` is not
+  handled until pgw#904 lands the exact-artifact arming this Plan feeds. The consumer goes live
+  complete, not half — the same discipline as the hub's fenced producer.

--- a/src/gen_worker/plan.py
+++ b/src/gen_worker/plan.py
@@ -1,0 +1,676 @@
+"""The immutable execution Plan (pgw#902), derived from one Hub-issued
+``ExecutionSpec`` and from nothing else.
+
+A Plan is the worker's whole answer to "what am I running". It is built once,
+by a pure function, from the generated ``ExecutionSpec`` the hub digested; no
+later message may change it. That is the property the legacy path never had:
+``HelloAck`` calls ``apply_model_resolutions``, which mutates ``EndpointSpec``
+bindings and rehomes a live ``_ClassRecord`` after connect, so the same
+dispatch can mean different bytes depending on when a resolution arrived.
+
+Three rules make this module's shape non-negotiable, and each has a test:
+
+1. **Pure.** ``PlanFactory`` imports no store, transport, lifecycle, cache or
+   device module. It cannot fetch, resolve, substitute or probe — it can only
+   read the spec and refuse. ``test_plan_factory_is_pure`` walks the import
+   graph, so the rule survives a well-meaning future import.
+2. **Immutable.** Every struct here is ``frozen=True`` and every sequence is a
+   tuple. A grant rotation, a HelloAck, a config generation bump or a
+   residency reconcile has nowhere to write.
+3. **Refuse, never default.** A missing or unresolved required fact raises
+   :class:`PlanRefusal` BEFORE model acquisition. There is no coarse lane to
+   expand, no root-slot fallback, no "first acceptable" artifact: the hub
+   already decided, and a worker that can reconstruct a decision is a second
+   resolver (§1.31, §1.10).
+
+The Plan deliberately does NOT carry: presigned URLs, capability tokens, grant
+epochs or expiry. Those live in ``DeliveryGrant``, are keyed by content digest,
+and are rotatable precisely because they are not execution identity. Reading
+one through the Plan would put a credential back inside the thing the digest
+covers — see ``ExecutionSpec``'s own header in the proto.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import msgspec
+
+from .pb import worker_scheduler_pb2 as pb
+
+#: Spec versions this worker build understands. ``ExecutionSpec.spec_version``
+#: is the generated-schema version; an unknown one refuses the attempt rather
+#: than degrading silently, because an unknown version can carry a REQUIRED
+#: field whose absence changes what gets produced. Widening this tuple is a
+#: deliberate code change in this repo, reviewed against the schema diff.
+SUPPORTED_SPEC_VERSIONS: tuple[int, ...] = (1,)
+
+#: ``WeightLane`` enum value -> the worker's canonical lane token. The mapping
+#: exists because the enum IS the resolved lane: there is no coarse family to
+#: expand, so this is a rename and never a decision. ``WEIGHT_LANE_UNSPECIFIED``
+#: is absent on purpose — it refuses.
+_WEIGHT_LANE_TOKENS: dict[int, str] = {
+    pb.WEIGHT_LANE_BF16: "bf16",
+    pb.WEIGHT_LANE_W8A16: "w8a16",
+    pb.WEIGHT_LANE_W8A8: "w8a8",
+    pb.WEIGHT_LANE_W4A4: "w4a4",
+}
+
+_ARM_SHAPE_TOKENS: dict[int, str] = {
+    pb.ARM_SHAPE_BRANCHLESS: "branchless",
+    pb.ARM_SHAPE_ADAPTER: "adapter",
+}
+
+_BACKEND_TOKENS: dict[int, str] = {
+    pb.STEADY_BACKEND_AOT_CELL: "aot_cell",
+    pb.STEADY_BACKEND_DYNAMO: "dynamo",
+    pb.STEADY_BACKEND_EAGER_ONLY: "eager_only",
+}
+
+_OUTPUT_MODE_TOKENS: dict[int, str] = {
+    pb.OUTPUT_MODE_UNSPECIFIED: "",
+    pb.OUTPUT_MODE_URL: "url",
+    pb.OUTPUT_MODE_INLINE: "inline",
+}
+
+
+class PlanRefusal(Exception):
+    """A spec that cannot become a Plan, named exactly.
+
+    Carries ``field``/``expected``/``have`` because the fleet reads these as
+    events, not as prose: "components.unet.snapshot_digest expected non-empty,
+    have ''" is actionable by the hub team; "invalid spec" is not. Every
+    refusal in this module is raised before any model acquisition.
+    """
+
+    def __init__(self, field: str, expected: str, have: str = "") -> None:
+        self.field = field
+        self.expected = expected
+        self.have = have
+        detail = f"{field}: expected {expected}"
+        if have:
+            detail += f", have {have}"
+        super().__init__(detail)
+
+
+class AttemptRef(msgspec.Struct, frozen=True):
+    """The hub-owned fencing token. ``attempt`` is bumped by the orchestrator
+    on every (re)queue and by nothing worker-side."""
+
+    request_id: str
+    attempt: int
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return (self.request_id, self.attempt)
+
+
+class ReleaseRef(msgspec.Struct, frozen=True):
+    """The code that runs. ``image_digest``/``code_closure_id`` are what make
+    "the same release" mean the same bytes rather than the same name — and
+    they are what pgw#903 compares a compiled artifact's baked facts against."""
+
+    org: str
+    endpoint: str
+    release_id: str
+    image_digest: str
+    code_closure_id: str
+
+
+class AttributionRef(msgspec.Struct, frozen=True):
+    """Who the outputs belong to and who asked. ``org`` is the CALLER's org,
+    a different fact from :attr:`ReleaseRef.org`, the publishing org."""
+
+    org: str
+    invoker_id: str
+
+
+class LaneRef(msgspec.Struct, frozen=True):
+    """The RESOLVED numerical lane.
+
+    ``mandatory`` is the FACT that this lane has no eager form. It is not a
+    fallback policy: what a worker does when a mandatory lane's cell is
+    missing is pgw#888's open conflict with §1.12/§4.5 and Paul's to rule, so
+    nothing here reads ``mandatory`` to decide anything.
+    """
+
+    weights: str
+    mandatory: bool
+
+
+class ArtifactRef(msgspec.Struct, frozen=True):
+    """Exactly one compiled cell (th#1429, §4.26).
+
+    ``publisher_org`` is load-bearing rather than decorative: a compiled cell
+    is CODE the adopting pod ``dlopen``s, so WHO produced it is the trust
+    answer. §4.25/§4.26 forbid confirming an artifact by byte comparison — two
+    mints of one key legitimately differ (pgw#1006 measured it) — so pgw#903's
+    verification compares these declared fields and never bytes.
+    """
+
+    cell_ref: str
+    content_digest: str
+    cell_key: str
+    publisher_org: str
+    toolchain_digest: str
+    env_seal_digest: str
+
+
+class ArmRef(msgspec.Struct, frozen=True):
+    """The structured execution arm (§4.4/§4.5).
+
+    Adapter traffic is a HARD partition, so ``adapter_rank_bucket`` rides the
+    arm instead of being recovered from the adapter list. ``artifact`` is set
+    iff ``backend == "aot_cell"``: since pgw#1010 dynamo cells are neither
+    sealed nor published, so DYNAMO has no artifact to name.
+    """
+
+    graph_contract_digest: str
+    shape: str
+    adapter_rank_bucket: int
+    backend: str
+    artifact: ArtifactRef | None
+
+
+class TopologyRef(msgspec.Struct, frozen=True):
+    """Spec identity, not placement advice: the same work on a different
+    device count is different work."""
+
+    accelerator: str
+    gpu_count: int
+    execution_groups: int
+    device_ordinals: tuple[int, ...]
+
+
+class ComponentRef(msgspec.Struct, frozen=True):
+    """One already-resolved per-component substitution on a slot's base
+    composition (th#980)."""
+
+    component: str
+    ref: str
+    snapshot_digest: str
+
+
+class SlotRef(msgspec.Struct, frozen=True):
+    """One slot's final binding. ``ref`` is canonical and resolved: there is
+    no slot->ref indirection left for a worker to re-resolve, which is what
+    deletes the second resolver (pgw#904)."""
+
+    slot: str
+    ref: str
+    snapshot_digest: str
+    components: tuple[ComponentRef, ...]
+    objective: str
+    distilled: bool
+    distilled_status: str
+    inference_defaults: str
+
+
+class AdapterRef(msgspec.Struct, frozen=True):
+    """One resolved LoRA overlay. Adapters are spec identity because they
+    change the product."""
+
+    slot: str
+    ref: str
+    snapshot_digest: str
+    weight: float
+    inference_defaults: str
+
+
+class ConfigRef(msgspec.Struct, frozen=True):
+    """THIS attempt's own immutable evaluated configuration (§4.16).
+
+    ``values`` stays as the canonical msgpack bytes the hub digested. Decoding
+    is the consumer's business; keeping the bytes means the Plan holds exactly
+    what ``digest`` covers, with no re-encode in between.
+    """
+
+    values: bytes
+    digest: str
+
+
+class ContractsRef(msgspec.Struct, frozen=True):
+    """The contracts this attempt is comparable under. The graph contract is
+    NOT here — it identifies the arm, so it lives on :class:`ArmRef`."""
+
+    quality_contract_digest: str
+    runtime_formula_digest: str
+
+
+class ExplorationRef(msgspec.Struct, frozen=True):
+    """A durable operator exploration intent (§4.7). Absent means ordinary
+    traffic; it is never inferred."""
+
+    exploration_id: str
+    operator_intent_id: str
+
+
+class InputAssetRef(msgspec.Struct, frozen=True):
+    """A stored input's IDENTITY. Its presigned transport lives in
+    ``DeliveryGrant.input_assets``, joined by ``asset_id`` — the split exists
+    because a changed input that leaves the digest unmoved breaks what the
+    digest MEANS."""
+
+    asset_id: str
+    source_ref: str
+    digest: str
+    size_bytes: int
+    kind: str
+    mime_type: str
+
+
+class Plan(msgspec.Struct, frozen=True):
+    """One attempt's immutable execution plan.
+
+    ``digest`` is the execution identity: the same attempt with the same
+    digest is the same work and replays idempotently; the same attempt with a
+    DIFFERENT digest is a typed refusal, never an adoption of earlier state.
+    """
+
+    attempt: AttemptRef
+    digest: str
+    spec_version: int
+    release: ReleaseRef
+    function_name: str
+    lane: LaneRef
+    arm: ArmRef
+    topology: TopologyRef
+    slots: tuple[SlotRef, ...]
+    adapters: tuple[AdapterRef, ...]
+    config: ConfigRef
+    contracts: ContractsRef
+    attribution: AttributionRef
+    output_mode: str
+    input_assets: tuple[InputAssetRef, ...]
+    exploration: ExplorationRef | None
+
+    @property
+    def key(self) -> tuple[str, int]:
+        return self.attempt.key
+
+    @property
+    def slot_refs(self) -> Mapping[str, str]:
+        """``{slot: resolved ref}`` — the exact set, in declaration order."""
+        return {s.slot: s.ref for s in self.slots}
+
+    def snapshot_digests(self) -> tuple[str, ...]:
+        """Every content digest this plan pins, deduplicated and ordered.
+
+        This is the join key into ``DeliveryGrant.snapshots``: the grant is
+        keyed by CONTENT DIGEST rather than by ref precisely so the transport
+        cannot drift from the identity it delivers.
+        """
+        seen: dict[str, None] = {}
+        for slot in self.slots:
+            seen.setdefault(slot.snapshot_digest, None)
+            for comp in slot.components:
+                seen.setdefault(comp.snapshot_digest, None)
+        for adapter in self.adapters:
+            seen.setdefault(adapter.snapshot_digest, None)
+        seen.pop("", None)
+        return tuple(seen)
+
+
+def _require(value: str, field: str, expected: str = "a non-empty value") -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise PlanRefusal(field, expected, "''")
+    return text
+
+
+class PlanFactory:
+    """The one ``ExecutionSpec`` -> :class:`Plan` transform.
+
+    A class rather than a function only so the boundary has a name a guard can
+    assert on; it holds no state and takes no collaborators. Anything that
+    would need a store, a device or the network to answer does not belong in a
+    Plan — it belongs downstream, reading the Plan.
+    """
+
+    __slots__ = ()
+
+    @staticmethod
+    def from_run_attempt(attempt: Any) -> Plan:
+        """Build the Plan for one ``RunAttempt``.
+
+        The grant is deliberately not read here. It carries authority, not
+        identity, and rotating it must leave this value byte-identical.
+        """
+        if not attempt.HasField("attempt"):
+            raise PlanRefusal("attempt", "an AttemptId")
+        if not attempt.HasField("spec"):
+            raise PlanRefusal("spec", "an ExecutionSpec")
+        ref = AttemptRef(
+            request_id=_require(attempt.attempt.request_id, "attempt.request_id"),
+            attempt=int(attempt.attempt.attempt),
+        )
+        return PlanFactory.from_execution_spec(ref, attempt.spec)
+
+    @staticmethod
+    def from_execution_spec(attempt: AttemptRef, spec: Any) -> Plan:
+        """Pure transform. Raises :class:`PlanRefusal` and nothing else."""
+        version = int(spec.spec_version)
+        if version not in SUPPORTED_SPEC_VERSIONS:
+            raise PlanRefusal(
+                "spec.spec_version",
+                "one of " + ", ".join(str(v) for v in SUPPORTED_SPEC_VERSIONS),
+                str(version),
+            )
+        digest = _require(spec.digest, "spec.digest", "the canonical spec digest")
+        return Plan(
+            attempt=attempt,
+            digest=digest,
+            spec_version=version,
+            release=_release(spec),
+            function_name=_require(spec.function_name, "spec.function_name"),
+            lane=_lane(spec),
+            arm=_arm(spec),
+            topology=_topology(spec),
+            slots=_slots(spec),
+            adapters=_adapters(spec),
+            config=ConfigRef(values=bytes(spec.config.values), digest=str(spec.config.digest)),
+            contracts=ContractsRef(
+                quality_contract_digest=str(spec.contracts.quality_contract_digest),
+                runtime_formula_digest=str(spec.contracts.runtime_formula_digest),
+            ),
+            attribution=AttributionRef(
+                org=str(spec.attribution.org),
+                invoker_id=str(spec.attribution.invoker_id),
+            ),
+            output_mode=_output_mode(spec),
+            input_assets=_input_assets(spec),
+            exploration=_exploration(spec),
+        )
+
+
+class PlanConflict(Exception):
+    """The same attempt arrived twice under two different execution
+    identities. This is never repairable and never adopts the earlier state:
+    the hub changed what it asked for without changing the fencing token, and
+    silently running either one would make the digest meaningless."""
+
+    def __init__(self, attempt: AttemptRef, expected: str, have: str) -> None:
+        self.attempt = attempt
+        self.expected = expected
+        self.have = have
+        super().__init__(
+            f"attempt {attempt.request_id}/{attempt.attempt} was admitted with "
+            f"spec digest {expected}, and this dispatch carries {have}")
+
+
+class PlanLedger:
+    """Per-attempt Plan identity, and the only place replay is decided.
+
+    Three answers, and there is no fourth: an attempt is NEW (admit it), a
+    REPLAY of the identical digest (re-acknowledge, do not re-execute), or a
+    :class:`PlanConflict`. Retransmission is normal — the orchestrator resends
+    until it sees ``JobAccepted`` — so replay must be cheap and must not
+    depend on how far the first copy got.
+
+    Holds Plans only. No store, transport, device or lifecycle state lives
+    here, which is what lets the executor consult it before materializing
+    anything.
+    """
+
+    __slots__ = ("_plans",)
+
+    def __init__(self) -> None:
+        self._plans: dict[tuple[str, int], Plan] = {}
+
+    def admit(self, plan: Plan) -> bool:
+        """``True`` if this is the attempt's first admission, ``False`` on an
+        identical replay. Raises :class:`PlanConflict` on a changed digest."""
+        seen = self._plans.get(plan.key)
+        if seen is None:
+            self._plans[plan.key] = plan
+            return True
+        if seen.digest != plan.digest:
+            raise PlanConflict(plan.attempt, seen.digest, plan.digest)
+        return False
+
+    def get(self, attempt: AttemptRef) -> Plan | None:
+        return self._plans.get(attempt.key)
+
+    def forget(self, attempt: AttemptRef) -> None:
+        self._plans.pop(attempt.key, None)
+
+    def __len__(self) -> int:
+        return len(self._plans)
+
+
+def _release(spec: Any) -> ReleaseRef:
+    if not spec.HasField("release"):
+        raise PlanRefusal("spec.release", "an EndpointRelease")
+    rel = spec.release
+    return ReleaseRef(
+        org=_require(rel.org, "spec.release.org"),
+        endpoint=_require(rel.endpoint, "spec.release.endpoint"),
+        release_id=_require(rel.release_id, "spec.release.release_id"),
+        # The two identity axes pgw#903 verifies a compiled cell against. A
+        # release that cannot name its own bytes cannot support that check, so
+        # it is refused here rather than making the check optional there.
+        image_digest=_require(rel.image_digest, "spec.release.image_digest"),
+        code_closure_id=_require(rel.code_closure_id, "spec.release.code_closure_id"),
+    )
+
+
+def _lane(spec: Any) -> LaneRef:
+    if not spec.HasField("numerical_lane"):
+        raise PlanRefusal("spec.numerical_lane", "a resolved ExecutionLane")
+    weights = int(spec.numerical_lane.weights)
+    token = _WEIGHT_LANE_TOKENS.get(weights)
+    if token is None:
+        raise PlanRefusal(
+            "spec.numerical_lane.weights",
+            "a resolved WeightLane (" + "|".join(_WEIGHT_LANE_TOKENS.values()) + ")",
+            pb.WeightLane.Name(weights) if weights in pb.WeightLane.values() else str(weights),
+        )
+    return LaneRef(weights=token, mandatory=bool(spec.numerical_lane.mandatory))
+
+
+def _arm(spec: Any) -> ArmRef:
+    if not spec.HasField("arm"):
+        raise PlanRefusal("spec.arm", "a structured Arm")
+    arm = spec.arm
+    shape = _ARM_SHAPE_TOKENS.get(int(arm.shape))
+    if shape is None:
+        raise PlanRefusal(
+            "spec.arm.shape",
+            "|".join(_ARM_SHAPE_TOKENS.values()),
+            pb.ArmShape.Name(int(arm.shape)),
+        )
+    backend = _BACKEND_TOKENS.get(int(arm.backend))
+    if backend is None:
+        raise PlanRefusal(
+            "spec.arm.backend",
+            "|".join(_BACKEND_TOKENS.values()),
+            pb.SteadyBackend.Name(int(arm.backend)),
+        )
+    bucket = int(arm.adapter_rank_bucket)
+    # §4.4 makes adapter traffic a hard partition: a rank bucket on a
+    # branchless arm, or none on an adapter arm, is two different statements
+    # about what graph runs. Neither is repairable worker-side.
+    if shape == "adapter" and bucket <= 0:
+        raise PlanRefusal("spec.arm.adapter_rank_bucket", "a positive rank bucket", str(bucket))
+    if shape == "branchless" and bucket != 0:
+        raise PlanRefusal(
+            "spec.arm.adapter_rank_bucket", "0 on a branchless arm", str(bucket))
+    artifact: ArtifactRef | None = None
+    if arm.HasField("artifact"):
+        if backend != "aot_cell":
+            raise PlanRefusal(
+                "spec.arm.artifact",
+                "absent unless backend is aot_cell",
+                f"present with backend {backend}",
+            )
+        artifact = _artifact(arm.artifact)
+    elif backend == "aot_cell":
+        raise PlanRefusal(
+            "spec.arm.artifact", "exactly one ArtifactIdentity on an aot_cell arm", "absent")
+    return ArmRef(
+        graph_contract_digest=_require(
+            arm.graph_contract_digest, "spec.arm.graph_contract_digest"),
+        shape=shape,
+        adapter_rank_bucket=bucket,
+        backend=backend,
+        artifact=artifact,
+    )
+
+
+def _artifact(ident: Any) -> ArtifactRef:
+    return ArtifactRef(
+        cell_ref=_require(ident.cell_ref, "spec.arm.artifact.cell_ref"),
+        content_digest=_require(ident.content_digest, "spec.arm.artifact.content_digest"),
+        cell_key=_require(ident.cell_key, "spec.arm.artifact.cell_key"),
+        # Not optional: an artifact whose producer is unnamed cannot be
+        # trusted by any rule, and "unknown publisher" is not a tier.
+        publisher_org=_require(ident.publisher_org, "spec.arm.artifact.publisher_org"),
+        toolchain_digest=_require(
+            ident.toolchain_digest, "spec.arm.artifact.toolchain_digest"),
+        env_seal_digest=_require(ident.env_seal_digest, "spec.arm.artifact.env_seal_digest"),
+    )
+
+
+def _topology(spec: Any) -> TopologyRef:
+    if not spec.HasField("topology"):
+        raise PlanRefusal("spec.topology", "a Topology")
+    top = spec.topology
+    accelerator = _require(top.accelerator, "spec.topology.accelerator", '"cuda" or "none"')
+    if accelerator not in ("cuda", "none"):
+        raise PlanRefusal("spec.topology.accelerator", '"cuda" or "none"', accelerator)
+    groups = int(top.execution_groups)
+    if groups < 1:
+        raise PlanRefusal("spec.topology.execution_groups", "at least 1", str(groups))
+    return TopologyRef(
+        accelerator=accelerator,
+        gpu_count=int(top.gpu_count),
+        execution_groups=groups,
+        device_ordinals=tuple(int(o) for o in top.device_ordinals),
+    )
+
+
+def _slots(spec: Any) -> tuple[SlotRef, ...]:
+    if not spec.HasField("components"):
+        raise PlanRefusal("spec.components", "a ComponentManifest")
+    out: list[SlotRef] = []
+    seen: set[str] = set()
+    for binding in spec.components.slots:
+        slot = _require(binding.slot, "spec.components.slots[].slot")
+        if slot in seen:
+            raise PlanRefusal(
+                f"spec.components.slots[{slot}]", "one binding per slot", "a duplicate")
+        seen.add(slot)
+        out.append(SlotRef(
+            slot=slot,
+            ref=_require(binding.ref, f"spec.components.slots[{slot}].ref"),
+            # The digest is what pins the bytes. Without it the grant's
+            # digest-keyed snapshot map cannot be joined and the worker would
+            # be back to trusting a name.
+            snapshot_digest=_require(
+                binding.snapshot_digest, f"spec.components.slots[{slot}].snapshot_digest"),
+            components=tuple(
+                ComponentRef(
+                    component=_require(
+                        comp.component,
+                        f"spec.components.slots[{slot}].components[].component"),
+                    ref=_require(
+                        comp.ref, f"spec.components.slots[{slot}].components[].ref"),
+                    snapshot_digest=_require(
+                        comp.snapshot_digest,
+                        f"spec.components.slots[{slot}].components[].snapshot_digest"),
+                )
+                for comp in binding.components
+            ),
+            objective=str(binding.objective),
+            distilled=bool(binding.distilled),
+            distilled_status=str(binding.distilled_status),
+            inference_defaults=str(binding.inference_defaults),
+        ))
+    return tuple(out)
+
+
+def _adapters(spec: Any) -> tuple[AdapterRef, ...]:
+    out: list[AdapterRef] = []
+    for adapter in spec.adapters:
+        slot = _require(adapter.slot, "spec.adapters[].slot")
+        weight = float(adapter.weight)
+        # The hub validates the range; the worker mirror-checks it because an
+        # out-of-range overlay silently produces a different image, and a
+        # silent product change is the defect class this whole contract exists
+        # to close.
+        if not -4.0 <= weight <= 4.0:
+            raise PlanRefusal(
+                f"spec.adapters[{slot}].weight", "a weight in [-4, 4]", str(weight))
+        out.append(AdapterRef(
+            slot=slot,
+            ref=_require(adapter.ref, f"spec.adapters[{slot}].ref"),
+            snapshot_digest=_require(
+                adapter.snapshot_digest, f"spec.adapters[{slot}].snapshot_digest"),
+            weight=weight,
+            inference_defaults=str(adapter.inference_defaults),
+        ))
+    return tuple(out)
+
+
+def _output_mode(spec: Any) -> str:
+    token = _OUTPUT_MODE_TOKENS.get(int(spec.output_mode))
+    if token is None:
+        raise PlanRefusal(
+            "spec.output_mode", "a known OutputMode", str(int(spec.output_mode)))
+    return token
+
+
+def _input_assets(spec: Any) -> tuple[InputAssetRef, ...]:
+    out: list[InputAssetRef] = []
+    seen: set[str] = set()
+    for asset in spec.input_assets:
+        asset_id = _require(asset.asset_id, "spec.input_assets[].asset_id")
+        if asset_id in seen:
+            raise PlanRefusal(
+                f"spec.input_assets[{asset_id}]", "one entry per asset_id", "a duplicate")
+        seen.add(asset_id)
+        out.append(InputAssetRef(
+            asset_id=asset_id,
+            source_ref=str(asset.source_ref),
+            # Identity, not transport: this is the half of the input-asset
+            # split that rides the spec digest.
+            digest=_require(asset.digest, f"spec.input_assets[{asset_id}].digest"),
+            size_bytes=int(asset.size_bytes),
+            kind=str(asset.kind),
+            mime_type=str(asset.mime_type),
+        ))
+    return tuple(out)
+
+
+def _exploration(spec: Any) -> ExplorationRef | None:
+    if not spec.HasField("exploration"):
+        return None
+    return ExplorationRef(
+        exploration_id=_require(
+            spec.exploration.exploration_id, "spec.exploration.exploration_id"),
+        operator_intent_id=str(spec.exploration.operator_intent_id),
+    )
+
+
+__all__ = [
+    "SUPPORTED_SPEC_VERSIONS",
+    "AdapterRef",
+    "ArmRef",
+    "ArtifactRef",
+    "AttemptRef",
+    "AttributionRef",
+    "ComponentRef",
+    "ConfigRef",
+    "ContractsRef",
+    "ExplorationRef",
+    "InputAssetRef",
+    "LaneRef",
+    "Plan",
+    "PlanConflict",
+    "PlanFactory",
+    "PlanLedger",
+    "PlanRefusal",
+    "ReleaseRef",
+    "SlotRef",
+    "TopologyRef",
+]

--- a/tests/test_plan_pgw902.py
+++ b/tests/test_plan_pgw902.py
@@ -1,0 +1,422 @@
+"""pgw#902 — the immutable Plan, and the three properties that make it one.
+
+The defect this replaces is not hypothetical: on the RunJob path, ``HelloAck``
+calls ``apply_model_resolutions``, which mutates ``EndpointSpec.models`` and
+rehomes a live ``_ClassRecord`` AFTER connect. A dispatch therefore means
+different bytes depending on when a resolution landed. Every test here asserts
+the property that makes that unrepresentable rather than merely unusual.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import msgspec
+import pytest
+
+from gen_worker import plan as plan_mod
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.plan import (
+    Plan,
+    PlanConflict,
+    PlanFactory,
+    PlanLedger,
+    PlanRefusal,
+)
+
+SRC = pathlib.Path(plan_mod.__file__).resolve().parent
+
+
+def _spec(**over: object) -> pb.ExecutionSpec:
+    """A minimal spec that MUST convert. Every refusal test mutates exactly
+    one field of this, so a test that goes red names the axis it broke."""
+    spec = pb.ExecutionSpec(
+        digest="sha256:" + "a" * 64,
+        spec_version=1,
+        release=pb.EndpointRelease(
+            org="cozy",
+            endpoint="micro-diffusion",
+            release_id="rel_01",
+            image_digest="sha256:" + "b" * 64,
+            code_closure_id="clo_01",
+        ),
+        function_name="generate",
+        numerical_lane=pb.ExecutionLane(weights=pb.WEIGHT_LANE_W8A8, mandatory=True),
+        arm=pb.Arm(
+            graph_contract_digest="gc_01",
+            shape=pb.ARM_SHAPE_BRANCHLESS,
+            adapter_rank_bucket=0,
+            backend=pb.STEADY_BACKEND_AOT_CELL,
+            artifact=pb.ArtifactIdentity(
+                cell_ref="cozy/cells-sdxl#k1",
+                content_digest="sha256:" + "c" * 64,
+                cell_key="k1",
+                publisher_org="cozy",
+                toolchain_digest="tc_01",
+                env_seal_digest="es_01",
+            ),
+        ),
+        topology=pb.Topology(
+            accelerator="cuda", gpu_count=1, execution_groups=1, device_ordinals=[0]),
+        components=pb.ComponentManifest(slots=[
+            pb.SlotBinding(
+                slot="unet",
+                ref="cozy/sdxl@v3",
+                snapshot_digest="sha256:" + "d" * 64,
+                objective="text-to-image",
+            ),
+        ]),
+        config=pb.ConfigSnapshot(values=b"\x80", digest="cfg_01"),
+        contracts=pb.ContractIdentities(
+            quality_contract_digest="q_01", runtime_formula_digest="rf_01"),
+        attribution=pb.Attribution(org="acme", invoker_id="user_7"),
+        output_mode=pb.OUTPUT_MODE_URL,
+    )
+    for name, value in over.items():
+        if value is None:
+            spec.ClearField(name)
+        elif isinstance(value, (int, str, bytes)):
+            setattr(spec, name, value)
+        else:
+            getattr(spec, name).CopyFrom(value)  # type: ignore[arg-type]
+    return spec
+
+
+def _attempt() -> plan_mod.AttemptRef:
+    return plan_mod.AttemptRef(request_id="req_1", attempt=3)
+
+
+def _plan(**over: object) -> Plan:
+    return PlanFactory.from_execution_spec(_attempt(), _spec(**over))
+
+
+# --- the happy conversion carries EVERYTHING, or the digest lies -------------
+
+
+def test_every_spec_field_reaches_the_plan() -> None:
+    p = _plan()
+    assert p.digest == "sha256:" + "a" * 64
+    assert p.spec_version == 1
+    assert p.release.image_digest == "sha256:" + "b" * 64
+    assert p.release.code_closure_id == "clo_01"
+    assert p.function_name == "generate"
+    # The lane arrives RESOLVED. There is no family token to expand.
+    assert p.lane.weights == "w8a8"
+    assert p.lane.mandatory is True
+    assert p.arm.backend == "aot_cell"
+    assert p.arm.artifact is not None
+    assert p.arm.artifact.cell_key == "k1"
+    assert p.arm.artifact.publisher_org == "cozy"
+    assert p.topology.device_ordinals == (0,)
+    assert p.slot_refs == {"unet": "cozy/sdxl@v3"}
+    assert p.slots[0].objective == "text-to-image"
+    assert p.config.values == b"\x80"
+    assert p.attribution.org == "acme"
+    assert p.output_mode == "url"
+    assert p.exploration is None
+    assert p.snapshot_digests() == ("sha256:" + "d" * 64,)
+
+
+def test_two_conversions_of_one_spec_are_equal() -> None:
+    """Determinism is the precondition for the digest meaning anything."""
+    assert _plan() == _plan()
+
+
+# --- property 1: PURE. The factory cannot reach anything that resolves ------
+
+
+def test_plan_module_imports_nothing_that_could_resolve() -> None:
+    """A PlanFactory that can import a store can fetch; one that can import a
+    device can probe. Either makes it a second resolver again. The rule is
+    enforced on the import graph so a future edit trips it, not a reviewer.
+
+    ``pb`` is allowed and is the point: the generated schema is the ONLY
+    input. ``msgspec`` is allowed: it is the value vocabulary.
+    """
+    forbidden = {
+        "store", "models", "executor", "lifecycle", "transport", "registry",
+        "compile_cache", "aot_cells", "aot_serve", "fleet_cells", "preload",
+        "activity", "net", "convert", "cli", "procsplit", "capability",
+        "runtime_config", "intent_registry", "cell_key", "local_cells",
+    }
+    tree = ast.parse((SRC / "plan.py").read_text())
+    seen: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level:
+            seen.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("gen_worker"):
+                    seen.add(alias.name.split(".")[-1])
+    assert seen & forbidden == set(), f"plan.py reaches resolution machinery: {seen & forbidden}"
+    assert "pb" in seen, "plan.py must read the generated schema"
+
+
+def test_no_torch_or_network_import_survives_module_load() -> None:
+    import sys
+
+    assert "gen_worker.plan" in sys.modules
+    src = (SRC / "plan.py").read_text()
+    for banned in ("import torch", "import requests", "import httpx", "subprocess"):
+        assert banned not in src
+
+
+# --- property 2: IMMUTABLE. Nothing arriving later has anywhere to write ----
+
+
+def test_the_plan_and_every_nested_value_refuse_mutation() -> None:
+    p = _plan()
+    for target in (p, p.release, p.lane, p.arm, p.topology, p.slots[0], p.config):
+        with pytest.raises((AttributeError, TypeError)):
+            setattr(target, "function_name" if target is p else "org", "mutated")
+    assert isinstance(p.slots, tuple)
+    assert isinstance(p.adapters, tuple)
+    assert isinstance(p.input_assets, tuple)
+    assert isinstance(p.topology.device_ordinals, tuple)
+
+
+def test_a_grant_rotation_leaves_the_plan_byte_identical() -> None:
+    """pgw#891's acceptance, at the value layer: the grant carries authority,
+    the spec carries identity, and the Plan reads only the spec. Rotating a
+    capability token mid-attempt must not move a single byte of the Plan."""
+    spec = _spec()
+    first = pb.RunAttempt(
+        attempt=pb.AttemptId(request_id="req_1", attempt=3),
+        spec=spec,
+        grant=pb.DeliveryGrant(
+            capability_token="tok-A", expires_unix_ms=1, epoch=1),
+    )
+    rotated = pb.RunAttempt(
+        attempt=pb.AttemptId(request_id="req_1", attempt=3),
+        spec=spec,
+        grant=pb.DeliveryGrant(
+            capability_token="tok-B-completely-different",
+            expires_unix_ms=99999, epoch=2,
+            input_assets=[pb.PresignedAsset(asset_id="a1", url="https://x/y?sig=Z")],
+        ),
+    )
+    a = PlanFactory.from_run_attempt(first)
+    b = PlanFactory.from_run_attempt(rotated)
+    assert a == b
+    assert msgspec.json.encode(a) == msgspec.json.encode(b)
+
+
+def test_no_grant_secret_can_appear_anywhere_in_the_plan() -> None:
+    attempt = pb.RunAttempt(
+        attempt=pb.AttemptId(request_id="req_1", attempt=3),
+        spec=_spec(),
+        grant=pb.DeliveryGrant(
+            capability_token="SECRET-TOKEN",
+            snapshots={"sha256:" + "d" * 64: pb.PresignedSnapshot(files=[
+                pb.PresignedFile(path="m.safetensors", url="https://s3/PRESIGNED")])},
+        ),
+    )
+    encoded = msgspec.json.encode(PlanFactory.from_run_attempt(attempt))
+    assert b"SECRET-TOKEN" not in encoded
+    assert b"PRESIGNED" not in encoded
+
+
+# --- property 3: REFUSE, never default -------------------------------------
+
+
+def test_an_unknown_spec_version_refuses_before_anything_else() -> None:
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(spec_version=2)
+    assert exc.value.field == "spec.spec_version"
+    assert exc.value.have == "2"
+
+
+def test_an_unresolved_lane_refuses_instead_of_being_expanded() -> None:
+    """The enum has no coarse family member, so the only way to express one is
+    UNSPECIFIED — and the worker's answer to that is a refusal, never a ladder
+    expansion. This is `executor._execution_lane_effective_spec` deleted by
+    construction rather than by a lint."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(numerical_lane=pb.ExecutionLane(weights=pb.WEIGHT_LANE_UNSPECIFIED))
+    assert exc.value.field == "spec.numerical_lane.weights"
+    assert "WEIGHT_LANE_UNSPECIFIED" in exc.value.have
+
+
+def test_an_aot_arm_with_no_named_artifact_refuses() -> None:
+    """pgw#904's contract at the value layer: one exact identity or explicitly
+    none. 'AOT, figure out which' is the fetch-and-filter resolver returning
+    through a side door."""
+    arm = pb.Arm(
+        graph_contract_digest="gc_01",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=pb.STEADY_BACKEND_AOT_CELL,
+    )
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=arm)
+    assert exc.value.field == "spec.arm.artifact"
+
+
+def test_a_non_aot_arm_carrying_an_artifact_refuses() -> None:
+    """Since pgw#1010 a dynamo cell is neither sealed nor published, so an
+    artifact on a DYNAMO arm describes something that cannot exist."""
+    arm = pb.Arm(
+        graph_contract_digest="gc_01",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=pb.STEADY_BACKEND_DYNAMO,
+        artifact=pb.ArtifactIdentity(
+            cell_ref="r", content_digest="d", cell_key="k",
+            publisher_org="o", toolchain_digest="t", env_seal_digest="e"),
+    )
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=arm)
+    assert exc.value.field == "spec.arm.artifact"
+    assert "dynamo" in exc.value.have
+
+
+def test_an_eager_only_arm_is_a_valid_plan_with_no_artifact() -> None:
+    p = _plan(arm=pb.Arm(
+        graph_contract_digest="gc_01",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=pb.STEADY_BACKEND_EAGER_ONLY))
+    assert p.arm.backend == "eager_only"
+    assert p.arm.artifact is None
+
+
+def test_an_artifact_with_no_publisher_refuses() -> None:
+    """§4.26: a compiled cell is code this pod dlopen()s, so WHO produced it is
+    the trust answer. 'Unknown publisher' is not a tier."""
+    arm = pb.Arm(
+        graph_contract_digest="gc_01",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=pb.STEADY_BACKEND_AOT_CELL,
+        artifact=pb.ArtifactIdentity(
+            cell_ref="r", content_digest="d", cell_key="k",
+            toolchain_digest="t", env_seal_digest="e"),
+    )
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=arm)
+    assert exc.value.field == "spec.arm.artifact.publisher_org"
+
+
+@pytest.mark.parametrize(
+    "shape,bucket,field",
+    [
+        (pb.ARM_SHAPE_ADAPTER, 0, "spec.arm.adapter_rank_bucket"),
+        (pb.ARM_SHAPE_BRANCHLESS, 8, "spec.arm.adapter_rank_bucket"),
+        (pb.ARM_SHAPE_UNSPECIFIED, 0, "spec.arm.shape"),
+    ],
+)
+def test_the_adapter_partition_is_hard(shape: int, bucket: int, field: str) -> None:
+    """§4.4: adapter traffic is a partition, not a modifier. A rank bucket on a
+    branchless arm and a missing one on an adapter arm are two different
+    statements about which graph runs, and neither is repairable here."""
+    arm = pb.Arm(
+        graph_contract_digest="gc_01", shape=shape, adapter_rank_bucket=bucket,
+        backend=pb.STEADY_BACKEND_EAGER_ONLY)
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=arm)
+    assert exc.value.field == field
+
+
+def test_a_slot_without_a_snapshot_digest_refuses() -> None:
+    """Without the digest the grant's digest-keyed snapshot map cannot be
+    joined, so the worker would be back to trusting a name."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(components=pb.ComponentManifest(slots=[
+            pb.SlotBinding(slot="unet", ref="cozy/sdxl@v3")]))
+    assert exc.value.field == "spec.components.slots[unet].snapshot_digest"
+
+
+def test_a_duplicate_slot_refuses_rather_than_last_one_winning() -> None:
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(components=pb.ComponentManifest(slots=[
+            pb.SlotBinding(slot="unet", ref="a", snapshot_digest="d1"),
+            pb.SlotBinding(slot="unet", ref="b", snapshot_digest="d2"),
+        ]))
+    assert exc.value.field == "spec.components.slots[unet]"
+
+
+def test_a_release_that_cannot_name_its_own_bytes_refuses() -> None:
+    """pgw#903 verifies a compiled cell against the release's identity axes. A
+    release with no image digest cannot support that check, so it is refused
+    here rather than making the check optional there."""
+    for field in ("image_digest", "code_closure_id"):
+        rel = pb.EndpointRelease(
+            org="cozy", endpoint="e", release_id="r",
+            image_digest="sha256:x", code_closure_id="c")
+        rel.ClearField(field)
+        with pytest.raises(PlanRefusal) as exc:
+            _plan(release=rel)
+        assert exc.value.field == f"spec.release.{field}"
+
+
+def test_an_out_of_range_adapter_weight_refuses() -> None:
+    spec = _spec()
+    spec.adapters.append(pb.AdapterBinding(
+        slot="unet", ref="cozy/lora@v1", snapshot_digest="d", weight=9.0))
+    with pytest.raises(PlanRefusal) as exc:
+        PlanFactory.from_execution_spec(_attempt(), spec)
+    assert exc.value.field == "spec.adapters[unet].weight"
+
+
+def test_a_topology_with_no_execution_group_refuses() -> None:
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(topology=pb.Topology(accelerator="cuda", gpu_count=1))
+    assert exc.value.field == "spec.topology.execution_groups"
+
+
+def test_an_input_asset_without_a_digest_refuses() -> None:
+    """The identity half of the input-asset split. A changed input that leaves
+    the spec digest unmoved is two executions sharing one identity."""
+    spec = _spec()
+    spec.input_assets.append(pb.InputAssetRef(asset_id="a1", source_ref="s"))
+    with pytest.raises(PlanRefusal) as exc:
+        PlanFactory.from_execution_spec(_attempt(), spec)
+    assert exc.value.field == "spec.input_assets[a1].digest"
+
+
+def test_a_refusal_names_expected_and_have() -> None:
+    """Every refusal is read as an event by whoever owns the hub side. 'invalid
+    spec' is not actionable; the axis and both values are."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(spec_version=7)
+    assert "expected" in str(exc.value) and "have 7" in str(exc.value)
+
+
+def test_a_run_attempt_missing_its_spec_refuses() -> None:
+    with pytest.raises(PlanRefusal) as exc:
+        PlanFactory.from_run_attempt(
+            pb.RunAttempt(attempt=pb.AttemptId(request_id="r", attempt=1)))
+    assert exc.value.field == "spec"
+
+
+# --- the ledger: replay is cheap, a changed digest is never adopted ---------
+
+
+def test_same_attempt_same_digest_replays_and_never_re_executes() -> None:
+    ledger = PlanLedger()
+    p = _plan()
+    assert ledger.admit(p) is True
+    assert ledger.admit(_plan()) is False
+    assert len(ledger) == 1
+
+
+def test_same_attempt_different_digest_conflicts_and_keeps_the_first() -> None:
+    ledger = PlanLedger()
+    first = _plan()
+    ledger.admit(first)
+    with pytest.raises(PlanConflict) as exc:
+        ledger.admit(_plan(digest="sha256:" + "e" * 64))
+    assert exc.value.expected == first.digest
+    assert exc.value.have == "sha256:" + "e" * 64
+    # The earlier state stands: a conflict never adopts the newcomer.
+    seen = ledger.get(first.attempt)
+    assert seen is not None and seen.digest == first.digest
+
+
+def test_a_different_attempt_of_one_request_is_a_new_admission() -> None:
+    """The attempt integer is the fencing token: attempt 4 of the same request
+    is different work, not a replay of attempt 3."""
+    ledger = PlanLedger()
+    ledger.admit(_plan())
+    later = PlanFactory.from_execution_spec(
+        plan_mod.AttemptRef(request_id="req_1", attempt=4),
+        _spec(digest="sha256:" + "f" * 64))
+    assert ledger.admit(later) is True
+    assert len(ledger) == 2


### PR DESCRIPTION
**pgw#891 PR 3 of 5** — the first half of the ExecutionSpec consumer cutover. Schema landed in both repos (th [#915](https://github.com/cozy-creator/tensorhub/pull/915) `b849b7d7`, pgw [#547](https://github.com/cozy-creator/python-gen-worker/pull/547) `3fa6fab7`, digest `19f8367c`); this builds on the real generated bindings.

## What the defect is

Not stylistic. On the RunJob path `HelloAck` calls `apply_model_resolutions`, which mutates `EndpointSpec.models` and rehomes a live `_ClassRecord` **after connect** (`lifecycle.py:574-580` → `executor.py:3440-3528`). One dispatch therefore means different bytes depending on when a resolution arrived. `gen_worker.plan` makes that unrepresentable.

## Three properties, each with a test

1. **Pure.** `PlanFactory` reads the generated `ExecutionSpec`, refuses, and does nothing else. An import-graph test forbids it from reaching a store, transport, lifecycle, cache or device module — a factory that can import a store can fetch, and one that can fetch is a second resolver again.
2. **Immutable.** Every struct frozen, every sequence a tuple. Two `RunAttempt`s differing only in capability token, epoch, expiry and presigned URLs produce a **byte-identical** Plan, and no grant secret can appear anywhere in its encoding — pgw#891's *"grant rotation leaves execution identity unchanged"*, at the value layer.
3. **Refuse, never default.** Unknown `spec_version`; unresolved lane; AOT arm with no named artifact, or a DYNAMO arm carrying one (since pgw#1010 dynamo cells are neither sealed nor published); slot with no `snapshot_digest`; unnamed artifact publisher; duplicate slot; out-of-range adapter weight; input asset with no digest — each a typed `PlanRefusal` naming the field, the expectation and what arrived, raised before model acquisition.

`WeightLane` has no coarse-family member, so `executor._execution_lane_effective_spec`'s ladder expansion has nothing to expand **on this path** — deleted by construction rather than by a lint. §4.4's adapter partition is enforced the same way.

`PlanLedger` decides replay and only replay: same attempt + same digest re-acknowledges without re-executing; same attempt + a different digest raises `PlanConflict` and keeps the first. A changed digest never adopts earlier state.

## Not wired, deliberately

`RunJob` is still the live dispatch and `SchedulerMessage.run_attempt` is not handled here. The consumer goes live in pgw#904, once the exact-artifact arming this Plan feeds exists — complete rather than half. Same discipline as the hub's fenced producer (`TestTH1457RunAttemptHasNoProducerBeforeTheCutover`), which is the hub's to delete in its own wiring commit, not this lane's.

## Verification

- `tests/test_plan_pgw902.py` — 27 tests, **mutation-checked**: reverting the version gate, the lane refusal, the artifact requirement and `frozen=True` each turns them red.
- Full `tests/` suite: **3656 passed, 37 skipped, 1 xfailed, 0 failed**.
- `mypy src/gen_worker` clean (239 files), `ruff` clean, and every fast gate green (`lint_post_connect_resolution` still reports the frozen census: 8 sites, 2 CONNECTED).

Refs: pgw#902, pgw#891, th#1457