### PR TITLE
pgw#903: serving verifies the artifact is the one the spec named, before dlopen

### DIFF
--- a/changelog.d/pgw903.md
+++ b/changelog.d/pgw903.md
@@ -1,0 +1,23 @@
+- **pgw#903: serving now asks whether a compiled artifact is the one the spec named — before
+  `dlopen`.** `aot_serve.verify` asks whether this runtime can execute the bytes; `verify_contract`
+  asks whether the envelope is internally consistent. Neither asked whether the cell belongs to this
+  attempt, and nothing could: before th#1457 there was no immutable spec to compare against.
+  `gen_worker.aot_identity` compares `ExecutionSpec.arm.artifact`'s cell key, toolchain digest and env
+  seal digest, plus `Arm.graph_contract_digest`, against the facts the mint baked into the artifact —
+  recomputed from those facts, never read from a separate stamp.
+- **Declared identity, never bytes.** §4.25/§4.26 forbid confirming an artifact by comparing it to
+  another mint of the same key, and pgw#1006 measured why: two mints of one key legitimately differ. A
+  test asserts the module cannot reach artifact bytes at all.
+- **Fail-closed and self-naming.** An axis the artifact is silent on is a refusal, not a skip; an
+  expectation that names no value is never a pass. `stage_artifact` raises the new
+  `expected_identity_mismatch` reason carrying `expected …, have …`. It stays distinct from
+  `key_mismatch` (cannot run here) and from `artifact_invalid` (internally corrupt) — a runnable cell
+  that is the WRONG cell is a different bug with a different owner.
+- **The closure axis is OWED, not faked.** pgw#903 asks for closure identity and the landed schema
+  carries no comparable one: `EndpointRelease.code_closure_id` is the hub's release identifier while
+  the artifact records a `{path: digest}` map, and the closure is not a `cell_key` axis either.
+  Asserting they are equal would refuse every healthy cell in the fleet. Closing it is one ruling by
+  the th#1457 lane — stamp a comparable `code_closure_digest`, or delete the block per pgw#1034's row
+  — and a test stops a later reader from inventing the equality locally.
+- **No behaviour change on the live path.** `expected` defaults to `None`, which is the pre-cutover
+  RunJob dispatch: no immutable spec exists there, so no expectation is invented.

--- a/scripts/unreached_surface_baseline.txt
+++ b/scripts/unreached_surface_baseline.txt
@@ -124,4 +124,14 @@ gen_worker.guard_closure.manifest_digest()
 #   mention of `width_for` anywhere in src/ is a COMMENT in aot_mint.py:1719
 #   explaining why it exists. Caught by this ratchet within hours of landing,
 #   which is the first time it has flagged live work rather than history.
+#
+#   pgw#903 (landed 2026-08-08) — `expected_from_plan` projects the immutable
+#   Plan's arm into the identity `stage_artifact` verifies. `verify_declared_identity`
+#   IS wired (stage_artifact calls it); this one waits on the caller that HOLDS a
+#   Plan, which is pgw#904's RunAttempt arming path. Until then RunJob is the live
+#   dispatch and no production frame has a Plan to project. **Delete this line in
+#   pgw#904's commit** — if it is still here when pgw#904 closes, the arming path
+#   is still resolving instead of arming what the hub named, and the guard was
+#   right.
 # ---------------------------------------------------------------------------
+gen_worker.aot_identity.expected_from_plan()

--- a/src/gen_worker/aot_identity.py
+++ b/src/gen_worker/aot_identity.py
@@ -1,0 +1,173 @@
+"""pgw#903 — does this compiled artifact belong to the execution the hub
+issued? Answered BEFORE ``dlopen``, by comparing DECLARED identities.
+
+An AOT cell is not data. It is a ``dlopen``-ed ELF this pod executes, built by
+some other pod against one exact toolchain, one environment seal and one traced
+graph contract. Until now the serve path verified the package against ITSELF —
+``aot_serve.verify`` rules on sm/torch/cuda/host-ISA/family, all probed from
+this runtime, and ``verify_contract`` checks the envelope's internal
+consistency. Both are necessary and neither asks the question this module asks:
+*is this the artifact the current ExecutionSpec named?*
+
+Nothing asked it because nothing could: before th#1457 there was no immutable
+spec to compare against, so the mint's baked facts (``aot_mint``'s
+``shared_identity_blocks``) had no counterpart. They do now —
+``ExecutionSpec.arm.artifact`` carries the cell key, toolchain digest and env
+seal digest, and ``ExecutionSpec.arm.graph_contract_digest`` carries the graph
+contract — so the comparison is a lookup on both sides rather than a
+reconstruction on either.
+
+**The comparison is DECLARED-IDENTITY, never bytes.** §4.25/§4.26 forbid
+confirming an artifact by comparing it to another mint of the same key: pgw#1006
+measured that two mints of one key legitimately differ, so a byte comparison
+would refuse healthy cells and prove nothing about unhealthy ones. What is
+compared here are the digests each side already committed to. (Verifying the
+DELIVERED bytes against the content digest the hub named is a different and
+legitimate check — it belongs to delivery, pgw#904, not to identity.)
+
+Every refusal names the axis, the expectation and what arrived, because these
+are read as fleet events: "toolchain_digest: expected a1b2…, have c3d4…" tells
+the hub team an image rebuilt without re-minting; "compatibility failed" tells
+them nothing. And compatibility is never a preference — a mismatch on any axis
+is a refusal, never a reason to prefer a different cell. That is the whole
+distinction between this and the fetch-and-filter resolver pgw#904 deletes.
+
+Scope note: the publisher claim is verified where the hub-signed receipt is
+read, and "this arm may materialize no artifact at all" is enforced where
+arming happens. Both are pgw#904's, at their call sites; putting them here
+would add surface this PR cannot reach.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import msgspec
+
+from . import cell_key, env_seal
+from .plan import Plan
+
+
+class ExpectedIdentity(msgspec.Struct, frozen=True):
+    """What the current ExecutionSpec says the armed artifact must be.
+
+    Projected from the immutable Plan, so it cannot drift from the execution
+    identity the hub digested. Every field is a digest that some producer
+    already committed to; none is probed from this runtime (the runtime axes
+    are ``aot_serve.verify``'s job and stay there).
+    """
+
+    cell_key: str
+    toolchain_digest: str
+    env_seal_digest: str
+    graph_contract_digest: str
+    publisher_org: str
+
+    # DELIBERATELY ABSENT: a code-closure axis.
+    #
+    # pgw#903's brief asks for closure identity, and the landed schema does not
+    # carry a comparable one. `EndpointRelease.code_closure_id` is the HUB's
+    # identifier for a release's code; the artifact records
+    # `code_closure` = {source path: content digest} from `cc.static_code_closure`.
+    # They are different quantities, and asserting they are equal would be this
+    # lane inventing a cross-repo contract on the strength of two similar names
+    # — which would then refuse every healthy cell in the fleet.
+    #
+    # Note also that the closure is not a `cell_key` axis, so it is not covered
+    # transitively either. Closing this needs ONE ruling from the th#1457 lane:
+    # either `ArtifactIdentity` gains a `code_closure_digest` the mint stamps
+    # and the hub echoes, or the closure block goes (pgw#1034 already carries a
+    # row to delete it as readerless — this is its other possible resolution,
+    # and the two lanes must not settle it independently).
+
+
+def expected_from_plan(plan: Plan) -> ExpectedIdentity | None:
+    """The expectation for a plan's arm, or ``None`` when it names no artifact.
+
+    ``None`` is a complete answer, not a gap: an ``eager_only`` or ``dynamo``
+    arm has no artifact to verify because since pgw#1010 dynamo cells are
+    neither sealed nor published. A caller that arms an artifact anyway on a
+    ``None`` expectation has re-introduced the resolver by another route —
+    pgw#904 owns that refusal, at the arming site where it can be enforced.
+    """
+    artifact = plan.arm.artifact
+    if artifact is None:
+        return None
+    return ExpectedIdentity(
+        cell_key=artifact.cell_key,
+        toolchain_digest=artifact.toolchain_digest,
+        env_seal_digest=artifact.env_seal_digest,
+        graph_contract_digest=plan.arm.graph_contract_digest,
+        publisher_org=artifact.publisher_org,
+    )
+
+
+def artifact_identity(meta: Mapping[str, Any]) -> ExpectedIdentity:
+    """The identity an artifact's own recorded facts describe.
+
+    Recomputed from the blocks the mint stored (``aot_mint``'s
+    ``shared_identity_blocks``), never read from a separate stamp — the same
+    discipline ``cell_key`` already enforces, for the same reason: a stamp that
+    is not derived from the facts it summarizes can disagree with them, and
+    then the disagreement is invisible.
+
+    ``publisher_org`` is deliberately empty here. An artifact cannot attest to
+    its own publisher — that claim lives inside the hub-signed receipt, and
+    :func:`verify_receipt_publisher` is where it is checked.
+    """
+    seal = meta.get(env_seal.SEAL_KEY)
+    toolchain = meta.get("toolchain")
+    return ExpectedIdentity(
+        cell_key=str(meta.get("cell_key") or ""),
+        toolchain_digest=(
+            cell_key.facts_digest(dict(toolchain)) if isinstance(toolchain, dict) else ""),
+        env_seal_digest=(
+            env_seal.seal_digest(dict(seal)) if isinstance(seal, dict) else ""),
+        graph_contract_digest=str(meta.get("combined_graph_hash") or ""),
+        publisher_org="",
+    )
+
+
+#: The axes compared, in the order they are reported. Order is deliberate:
+#: identity first (which cell is this), then what it was built from, then what
+#: it traced. A cell that is the wrong cell should say so before it says its
+#: toolchain differs, because the second fact is a consequence of the first.
+_COMPARED_AXES: tuple[str, ...] = (
+    "cell_key", "toolchain_digest", "env_seal_digest", "graph_contract_digest")
+
+
+def verify_declared_identity(
+    meta: Mapping[str, Any], expected: ExpectedIdentity,
+) -> str:
+    """``''`` when the artifact IS the one the spec named, else the reason.
+
+    Fail-closed on every compared axis: an axis the artifact is SILENT on is a
+    refusal, not a skip. A cell that cannot state its own toolchain cannot be
+    shown to match the toolchain the spec named, and "cannot be shown to match"
+    is exactly what a refusal means here.
+
+    There is no partial pass and no conditional axis: every axis in
+    :data:`_COMPARED_AXES` is compared, or the comparison is not one. The
+    closure axis is absent rather than optional — see :class:`ExpectedIdentity`
+    for why inventing it would be worse than owing it.
+    """
+    have = artifact_identity(meta)
+    for axis in _COMPARED_AXES:
+        want, got = getattr(expected, axis), getattr(have, axis)
+        if not want:
+            # An expectation that names no value cannot be verified, and an
+            # unverifiable expectation must not read as a pass. The Plan
+            # refuses an artifact missing any of these, so reaching this
+            # branch means a caller built an ExpectedIdentity by hand.
+            return f"{axis}: the spec named no expected value"
+        if want != got:
+            return f"{axis}: expected {want}, have {got or '<absent>'}"
+    return ""
+
+
+__all__ = [
+    "ExpectedIdentity",
+    "artifact_identity",
+    "expected_from_plan",
+    "verify_declared_identity",
+]

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -88,6 +88,7 @@ from typing import (
 
 from . import activity as activity_mod
 from . import aot_flatten
+from . import aot_identity
 from . import host_isa
 from .cell_adopt import AdoptOutcome
 from . import shape_growth
@@ -972,12 +973,20 @@ class _StagedAotArtifact:
 
 def stage_artifact(
     artifact: Path, family: str, cache_dir: Optional[Path] = None,
+    *, expected: "Optional[aot_identity.ExpectedIdentity]" = None,
 ) -> _StagedAotArtifact:
     """Extract and runtime-verify a complete artifact in an isolated tree.
 
     The live/shared cache and pipeline remain untouched on every rejection.
     Concurrent attempts use distinct trees; a process crash can leave only
     an unreferenced staging directory, never a partially published ``.pt2``.
+
+    ``expected`` (pgw#903) is the identity the current ``ExecutionSpec`` named.
+    When supplied, this artifact must BE that one — a declared-identity
+    comparison, never a byte comparison (§4.25/§4.26: two mints of one key
+    legitimately differ, pgw#1006 measured it). ``None`` is the pre-cutover
+    RunJob path, where no immutable spec exists to compare against; it leaves
+    behaviour byte-identical rather than inventing an expectation.
     """
     base = Path(cache_dir) if cache_dir else Path.home() / ".cache" / "gen-worker"
     base.mkdir(parents=True, exist_ok=True)
@@ -993,6 +1002,15 @@ def stage_artifact(
         reason = verify(meta, family=family)
         if reason:
             raise AdoptError("key_mismatch", reason)
+        # pgw#903: "can this runtime execute it" is answered above; this
+        # answers "is it the artifact the spec named", which nothing asked
+        # before there was an immutable spec to ask against. Its own reason
+        # class: a runnable cell that is the WRONG cell is a different bug,
+        # a different owner and a different fix from an unrunnable one.
+        if expected is not None:
+            mismatch = aot_identity.verify_declared_identity(meta, expected)
+            if mismatch:
+                raise AdoptError("expected_identity_mismatch", mismatch)
         # pgw#765: the GPU-architecture axis as the BYTES declare it, ruled
         # on by name before dlopen — the tier that keeps cross-SKU adoption
         # honest now that ``sku`` no longer stands in for the arch. Runs
@@ -2127,6 +2145,7 @@ def _target_owner(pipeline: Any, target: str) -> Tuple[Any, str]:
 
 def load_and_wrap(
     pipeline: Any, cfg: Any, artifact: Path, cache_dir: Optional[Path] = None,
+    *, expected: "Optional[aot_identity.ExpectedIdentity]" = None,
 ) -> Dict[str, Any]:
     """Stage + verify + load EVERY named entry + BIND all constants, then
     perform the live wraps (pgw#758: one resident artifact serves every
@@ -2137,9 +2156,14 @@ def load_and_wrap(
     bind before ANY wrap: a cell that cannot arm one of its graph classes
     arms none of them — a partially served contract would be a silent
     subset of what the cell key advertises.
+
+    ``expected`` (pgw#903) is checked inside :func:`stage_artifact`, i.e.
+    strictly before the first ``_load_package`` — the identity question must be
+    settled while the artifact is still inert bytes.
     """
     family = str(getattr(cfg, "family", "") or "")
-    staged = stage_artifact(Path(artifact), family, cache_dir=cache_dir)
+    staged = stage_artifact(
+        Path(artifact), family, cache_dir=cache_dir, expected=expected)
     try:
         meta = staged.metadata
         try:

--- a/tests/test_artifact_identity_pgw903.py
+++ b/tests/test_artifact_identity_pgw903.py
@@ -1,0 +1,321 @@
+"""pgw#903 — serving verifies AOT code identity against the current
+ExecutionSpec, before ``dlopen``.
+
+Two questions were being conflated. ``aot_serve.verify`` asks *can this runtime
+execute these bytes* (sm/torch/cuda/host ISA, all probed here).
+``verify_contract`` asks *is this envelope internally consistent*. Neither asks
+*is this the artifact the hub named for this attempt* — nothing could, before
+there was an immutable spec to ask against.
+
+The fixture is deliberately model-free: identity is a metadata question, so a
+GPU, a pipeline and a real ``.pt2`` are all irrelevant to it. Mutating exactly
+one expected fact must refuse, and the refusal must name that fact.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gen_worker import aot_identity, aot_serve, cell_key, env_seal
+from gen_worker.aot_identity import ExpectedIdentity
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.plan import AttemptRef, PlanFactory
+
+_TOOLCHAIN = {"cc": "sha256:aaa", "ld": "sha256:bbb"}
+_SEAL = {"config": "cfg16", "inductor": "ind16", "loaded_libs": "libs16"}
+_CLOSURE = {"gen_worker/executor.py": "sha256:ccc"}
+
+#: One well-formed entry, so `unpack` can parse the envelope. Identity is a
+#: metadata question — none of these values participate in it.
+_ENTRIES = {
+    "unet": {
+        "target": "unet",
+        "inputs": [{"name": "x", "dtype": "bfloat16", "shape": [1, 4]}],
+        "constants": [],
+    },
+}
+
+
+def _meta(**over: Any) -> dict[str, Any]:
+    """An artifact's ``metadata.json`` as ``aot_mint`` writes it: the stamped
+    envelope PLUS the identity blocks ``shared_identity_blocks`` merges in."""
+    meta: dict[str, Any] = {
+        "format": aot_serve.ARTIFACT_FORMAT,
+        "kind": aot_serve.ARTIFACT_KIND,
+        "family": "micro",
+        "cell_key": "aot-inductor:k1",
+        "combined_graph_hash": "gc_01",
+        "entries": {k: dict(v) for k, v in _ENTRIES.items()},
+        env_seal.SEAL_KEY: dict(_SEAL),
+        "toolchain": dict(_TOOLCHAIN),
+        "code_closure": dict(_CLOSURE),
+    }
+    meta.update(over)
+    return meta
+
+
+def _expected(**over: Any) -> ExpectedIdentity:
+    base: dict[str, Any] = {
+        "cell_key": "aot-inductor:k1",
+        "toolchain_digest": cell_key.facts_digest(_TOOLCHAIN),
+        "env_seal_digest": env_seal.seal_digest(_SEAL),
+        "graph_contract_digest": "gc_01",
+        "publisher_org": "cozy",
+    }
+    base.update(over)
+    return ExpectedIdentity(**base)
+
+
+# --- the identity an artifact's own facts describe --------------------------
+
+
+def test_identity_is_recomputed_from_the_recorded_facts_not_a_stamp() -> None:
+    """``cell_key``'s standing discipline: a digest is derived from the facts it
+    summarizes, so a stamp can never silently disagree with them."""
+    have = aot_identity.artifact_identity(_meta())
+    assert have.toolchain_digest == cell_key.facts_digest(_TOOLCHAIN)
+    assert have.env_seal_digest == env_seal.seal_digest(_SEAL)
+    assert have.graph_contract_digest == "gc_01"
+    # An artifact cannot attest to its own publisher; that claim is the
+    # hub-signed receipt's.
+    assert have.publisher_org == ""
+
+
+def test_a_matching_identity_passes() -> None:
+    assert aot_identity.verify_declared_identity(_meta(), _expected()) == ""
+
+
+# --- mutate exactly one expected fact ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "axis,mutated",
+    [
+        ("cell_key", {"cell_key": "aot-inductor:OTHER"}),
+        ("toolchain_digest", {"toolchain_digest": "0" * 16}),
+        ("env_seal_digest", {"env_seal_digest": "0" * 16}),
+        ("graph_contract_digest", {"graph_contract_digest": "gc_02"}),
+    ],
+)
+def test_one_mutated_fact_refuses_and_names_itself(axis: str, mutated: Any) -> None:
+    reason = aot_identity.verify_declared_identity(_meta(), _expected(**mutated))
+    assert reason.startswith(f"{axis}: expected ")
+    # Both values, not just the verdict: the hub team reads these as events.
+    assert "have " in reason
+    assert reason.split("expected ")[1].split(",")[0] != reason.split("have ")[1]
+
+
+@pytest.mark.parametrize(
+    "axis,dropped",
+    [
+        ("cell_key", "cell_key"),
+        ("toolchain_digest", "toolchain"),
+        ("env_seal_digest", env_seal.SEAL_KEY),
+        ("graph_contract_digest", "combined_graph_hash"),
+    ],
+)
+def test_an_artifact_silent_on_an_axis_refuses_rather_than_skipping(
+    axis: str, dropped: str,
+) -> None:
+    """Fail-closed: a cell that cannot state its own toolchain cannot be shown
+    to match the toolchain the spec named, and 'cannot be shown to match' is
+    what a refusal means. A skipped axis is a pass nobody proved."""
+    meta = _meta()
+    meta.pop(dropped)
+    reason = aot_identity.verify_declared_identity(meta, _expected())
+    assert reason.startswith(f"{axis}: ")
+    assert "<absent>" in reason
+
+
+def test_an_expectation_naming_no_value_is_never_a_pass() -> None:
+    """An unverifiable expectation must not read as verified. The Plan refuses
+    an artifact missing any of these, so reaching this means a hand-built
+    expectation — and it still refuses."""
+    reason = aot_identity.verify_declared_identity(_meta(), _expected(cell_key=""))
+    assert reason == "cell_key: the spec named no expected value"
+
+
+def test_the_closure_axis_is_absent_rather_than_invented() -> None:
+    """pgw#903 asks for closure identity and the landed schema carries no
+    comparable one: `EndpointRelease.code_closure_id` is the hub's release
+    identifier, while the artifact records a {path: digest} map. Equating them
+    on the strength of two similar names would refuse every healthy cell in the
+    fleet, so the axis is OWED, not faked.
+
+    This test exists to stop a later reader from 'finishing' it: closing the
+    gap is one ruling by the th#1457 lane (stamp a comparable
+    `code_closure_digest`, or delete the block per pgw#1034), never a local
+    equality.
+    """
+    assert "code_closure_id" not in ExpectedIdentity.__struct_fields__
+    assert "code_closure" not in aot_identity._COMPARED_AXES
+    # The release id still rides the Plan, so the day it becomes comparable
+    # nothing has to be re-plumbed to reach it.
+    assert _plan().release.code_closure_id == "clo_01"
+
+
+def test_identity_is_never_confirmed_by_comparing_bytes() -> None:
+    """§4.25/§4.26 + pgw#1006: two mints of one key legitimately differ, so a
+    byte comparison would refuse healthy cells and prove nothing about
+    unhealthy ones. The module must not reach for artifact bytes at all."""
+    src = Path(aot_identity.__file__).read_text()
+    for banned in ("read_bytes", "sha256_file", "hashlib", "open(", "Path("):
+        assert banned not in src, f"aot_identity reaches for bytes via {banned!r}"
+
+
+# --- projection from the immutable Plan -------------------------------------
+
+
+def _plan(backend: int = pb.STEADY_BACKEND_AOT_CELL) -> Any:
+    arm = pb.Arm(
+        graph_contract_digest="gc_01",
+        shape=pb.ARM_SHAPE_BRANCHLESS,
+        backend=backend,
+    )
+    if backend == pb.STEADY_BACKEND_AOT_CELL:
+        arm.artifact.CopyFrom(pb.ArtifactIdentity(
+            cell_ref="cozy/cells-micro#k1",
+            content_digest="sha256:" + "c" * 64,
+            cell_key="aot-inductor:k1",
+            publisher_org="cozy",
+            toolchain_digest=cell_key.facts_digest(_TOOLCHAIN),
+            env_seal_digest=env_seal.seal_digest(_SEAL),
+        ))
+    spec = pb.ExecutionSpec(
+        digest="sha256:" + "a" * 64,
+        spec_version=1,
+        release=pb.EndpointRelease(
+            org="cozy", endpoint="micro", release_id="r1",
+            image_digest="sha256:img", code_closure_id="clo_01"),
+        function_name="generate",
+        numerical_lane=pb.ExecutionLane(weights=pb.WEIGHT_LANE_BF16),
+        arm=arm,
+        topology=pb.Topology(accelerator="cuda", gpu_count=1, execution_groups=1),
+        components=pb.ComponentManifest(slots=[pb.SlotBinding(
+            slot="unet", ref="cozy/micro@v1", snapshot_digest="sha256:d")]),
+    )
+    return PlanFactory.from_execution_spec(AttemptRef("req", 1), spec)
+
+
+def test_the_expectation_comes_from_the_plan_and_matches_a_real_artifact() -> None:
+    expected = aot_identity.expected_from_plan(_plan())
+    assert expected is not None
+    assert aot_identity.verify_declared_identity(_meta(), expected) == ""
+    assert expected.publisher_org == "cozy"
+
+
+def test_an_arm_that_names_no_artifact_yields_no_expectation() -> None:
+    """``None`` is a complete answer, not a gap: an eager_only arm has nothing
+    to verify because it must arm nothing."""
+    assert aot_identity.expected_from_plan(
+        _plan(backend=pb.STEADY_BACKEND_EAGER_ONLY)) is None
+    assert aot_identity.expected_from_plan(_plan()) is not None
+
+
+# --- the gate runs before dlopen, on a real staged tarball ------------------
+
+
+def _artifact(tmp_path: Path, meta: dict[str, Any]) -> Path:
+    """A staging-shaped tarball. It carries no real ``.pt2``: the point is that
+    identity refuses before anything would be loaded, so there is nothing to
+    load."""
+    payload = tmp_path / "payload"
+    payload.mkdir()
+    (payload / "metadata.json").write_text(json.dumps(meta))
+    (payload / aot_serve.PACKAGE_NAME).write_bytes(b"not-a-real-package")
+    out = tmp_path / "cell.tar.gz"
+    with tarfile.open(out, "w:gz") as tar:
+        for item in sorted(payload.iterdir()):
+            tar.add(item, arcname=item.name)
+    return out
+
+
+def test_stage_artifact_refuses_a_wrong_identity_before_any_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal must land while the artifact is still inert bytes. The
+    runtime-key and sm gates are neutralized so the ONLY thing under test is
+    identity — otherwise a green run could mean 'refused for the wrong
+    reason'."""
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
+    loaded: list[Any] = []
+    monkeypatch.setattr(
+        aot_serve, "verify_package_compute_capability",
+        lambda path: loaded.append(path) or "")
+
+    meta = _meta()
+    path = _artifact(tmp_path, meta)
+
+    with pytest.raises(aot_serve.AdoptError) as exc:
+        aot_serve.stage_artifact(
+            path, "micro", cache_dir=tmp_path / "cache",
+            expected=_expected(cell_key="aot-inductor:SOMETHING-ELSE"))
+    assert exc.value.reason == "expected_identity_mismatch"
+    assert "cell_key: expected" in str(exc.value)
+    # Nothing downstream of the identity gate ran.
+    assert loaded == []
+
+
+def test_stage_artifact_with_a_matching_identity_reaches_the_load_gates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
+    reached: list[Any] = []
+    monkeypatch.setattr(
+        aot_serve, "verify_package_compute_capability",
+        lambda path: reached.append(path) or "")
+
+    path = _artifact(tmp_path, _meta())
+    staged = aot_serve.stage_artifact(
+        path, "micro", cache_dir=tmp_path / "cache", expected=_expected())
+    try:
+        assert staged.metadata["cell_key"] == "aot-inductor:k1"
+        assert len(reached) == 1
+    finally:
+        staged.close()
+
+
+def test_no_expectation_leaves_the_legacy_path_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Until the cutover, RunJob dispatches carry no immutable spec. Absent an
+    expectation the gate must not invent one — a default expectation would
+    refuse every cell the fleet serves today."""
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
+    monkeypatch.setattr(
+        aot_serve, "verify_package_compute_capability", lambda path: "")
+    meta = _meta()
+    meta.pop("toolchain")
+    meta.pop(env_seal.SEAL_KEY)
+    staged = aot_serve.stage_artifact(
+        _artifact(tmp_path, meta), "micro", cache_dir=tmp_path / "cache")
+    try:
+        assert staged.metadata["cell_key"] == "aot-inductor:k1"
+    finally:
+        staged.close()
+
+
+def test_an_internally_corrupt_artifact_keeps_its_own_distinct_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hash/signature problem inside the package is NOT an identity problem.
+    Folding them into one reason would put a supply-chain event and a stale
+    image rebuild in the same bucket."""
+    monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
+    monkeypatch.setattr(
+        aot_serve, "verify",
+        lambda meta, family="": "entry 'unet': class_hash does not match its recorded facts")
+    with pytest.raises(aot_serve.AdoptError) as exc:
+        aot_serve.stage_artifact(
+            _artifact(tmp_path, _meta()), "micro",
+            cache_dir=tmp_path / "cache", expected=_expected())
+    assert exc.value.reason == "key_mismatch"
+    assert exc.value.reason != "expected_identity_mismatch"


### PR DESCRIPTION
**pgw#891 PR 4 of 5.** Stacked on #551 (pgw#902) — base is `pgw902-immutable-plan`; retarget to `master` once #551 lands.

## The question nothing was asking

`aot_serve.verify` asks *can this runtime execute these bytes* (sm/torch/cuda/host ISA, all probed here). `verify_contract` asks *is this envelope internally consistent*. Neither asks **is this the artifact the hub named for this attempt** — and nothing could, because before th#1457 there was no immutable spec to ask against. An AOT cell is not data: it is a `dlopen`-ed ELF this pod executes, built by another pod against one toolchain, one environment seal and one traced graph.

`gen_worker.aot_identity` compares `ExecutionSpec.arm.artifact`'s cell key, toolchain digest and env seal digest, plus `Arm.graph_contract_digest`, against the facts `aot_mint.shared_identity_blocks` baked into the artifact — **recomputed from those facts, never read from a separate stamp**, which is `cell_key`'s standing discipline and exists so a stamp cannot silently disagree with what it summarizes.

Wired into `aot_serve.stage_artifact`, i.e. strictly before the first `_load_package`: the identity question is settled while the artifact is still inert bytes.

## Declared identity, never bytes

§4.25/§4.26 forbid confirming an artifact by comparing it to another mint of the same key, and pgw#1006 measured why — two mints of one key legitimately differ, so a byte comparison would refuse healthy cells and prove nothing about unhealthy ones. A test asserts the module cannot reach artifact bytes at all.

Fail-closed and self-naming: an axis the artifact is silent on is a refusal, not a skip; an expectation naming no value is never a pass. The new `expected_identity_mismatch` reason carries `expected …, have …` and stays distinct from `key_mismatch` (cannot run here) and `artifact_invalid` (internally corrupt) — a runnable cell that is the **wrong** cell is a different bug with a different owner.

## ⚠️ The closure axis is OWED, not faked — one ruling needed from th#1457

pgw#903's box 1 asks for closure identity and **the landed schema carries no comparable value.** `EndpointRelease.code_closure_id` is the hub's identifier for a release's code; the artifact records `{source path: content digest}` from `cc.static_code_closure`. Different quantities — and the closure is not a `cell_key` axis, so it is not covered transitively either. Equating them on the strength of similar names would refuse every healthy cell in the fleet.

So the axis is **absent rather than invented**, with a test that stops a later reader from "finishing" it. Two admissible answers, mutually exclusive:

- `ArtifactIdentity` gains a `code_closure_digest` the mint stamps and the hub echoes — giving the `code_closure` envelope block its first reader; **or**
- the block is deleted, which is what **pgw#1034** already carries a row to do on the grounds that it has zero readers anywhere.

One answer deletes what the other depends on, so the lanes must not settle it independently. Same shape for `Receipt.publisher`/`publisher_org_id` (pgw#1034: decoded-and-never-verified; §4.26: the trust answer). Routed to th#1457 in the tracker, and pgw#1034 is asked to hold both deletions.

## No behaviour change on the live path

`expected` defaults to `None` — the pre-cutover RunJob dispatch, where no immutable spec exists to compare against. `expected_from_plan` is baselined **IN FLIGHT** in the unreached-surface ratchet, naming pgw#904 as its caller with an instruction to delete the line there. The exact-publisher check and the "arm nothing on a non-`aot_cell` arm" refusal are deferred to pgw#904, at their call sites, rather than added here as surface this PR cannot reach.

## Verification

- `tests/test_artifact_identity_pgw903.py` — 19 tests, **mutation-checked**: removing the `stage_artifact` gate, and letting an unstated expectation pass, each turn them red.
- `mypy` clean (240 files), `ruff` clean, `lint_unreached_surface` green.

Refs: pgw#903, pgw#891, th#1457, pgw#1034