### PR TITLE
pgw#1040: one reader for a packed envelope, one parse of `entries` per arm, one lane-token rule

### DIFF
--- a/changelog.d/pgw1040.md
+++ b/changelog.d/pgw1040.md
@@ -1,0 +1,29 @@
+- **pgw#1040: ONE reader for a cell's packed envelope, ONE parse of its
+  `entries` per arm, ONE lane-token rule.** Eight call sites each carried their
+  own `tarfile.open` / member scan / `json.loads` of the `metadata.json` every
+  artifact kind packs at its tar root, agreeing on the format by convention and
+  disagreeing on the rest: which members counted, whether a non-object payload
+  was a value or an error, and what a missing member raised (`ValueError`,
+  `RuntimeError`, `KeyError`, a verdict string, or nothing at all). They are now
+  `artifact_meta.read_metadata` / `try_read_metadata` — **stdlib only**, which is
+  what lets `receipts` (must not import the compile stack before verifying a
+  delivered artifact) and `guard_closure` (sits inside the
+  `env_seal -> guard_closure -> compile_cache -> registry -> cell_key -> env_seal`
+  cycle, so its read had to be a function-local import) share it. Callers keep
+  their own refusal vocabulary and `ArtifactMetadataError` subclasses
+  `ValueError`, so every site that already classified on `ValueError` is
+  unchanged. `models/provision`'s kind sniff no longer reads an AOT envelope
+  through `trt_engine`, and `kernel_path.adopt_from_artifact` loses its
+  function-local `import json, tarfile`. **The arm now parses `entries` once**
+  instead of three times over the same dict — `unpack` (literal-payload check),
+  `verify_contract` and `load_and_wrap` each re-ran `entries_from_meta`, which
+  re-parses every entry's full contract and constant table; the staged artifact
+  carries the one validated map and threads it. `load_and_wrap`'s
+  `contract_invalid` arm went with it: `stage_artifact` could not have returned
+  without that same parse succeeding, so the branch was unreachable.
+  **`cell_key._canonical_execution_lane` and
+  `aot_contract.ExportSpec.execution_lane_label` were the same six lines, twice**
+  — one produces a cell-key AXIS, the other the label stamped into a cell's
+  metadata, so drift between them does not degrade, it mints cells under one
+  name and looks them up under another. Both now call
+  `compile_cache.execution_lane_label`.

--- a/src/gen_worker/aot_contract.py
+++ b/src/gen_worker/aot_contract.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional, Tuple
 
-from .compile_cache import execution_lane_bucket, execution_lane_token
+from .compile_cache import execution_lane_label as _execution_lane_label
 
 
 class MintRefused(RuntimeError):
@@ -140,12 +140,9 @@ class ExportSpec:
     source_digest: str = ""
 
     def execution_lane_label(self) -> str:
-        base, observed = execution_lane_bucket(self.weight_lane)
-        bucket = observed or self.lora_bucket
-        token = execution_lane_token(base)
-        if bucket:
-            return f"{token}-lora{bucket}" if token else f"lora{bucket}"
-        return token
+        """This spec's lane label — ONE implementation, shared with the
+        cell-key axis it has to agree with (pgw#1040)."""
+        return _execution_lane_label(self.weight_lane, self.lora_bucket)
 
 
 __all__ = ["ADAPTER_FORK", "DynamicDim", "ExportSpec", "MintRefused"]

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -89,6 +89,7 @@ from typing import (
 from . import activity as activity_mod
 from . import aot_flatten
 from . import aot_identity
+from . import artifact_meta
 from . import host_isa
 from .cell_adopt import AdoptOutcome
 from . import shape_growth
@@ -724,7 +725,11 @@ def verify_declared(meta: Dict[str, Any], *, family: str = "") -> str:
     return ""
 
 
-def verify_contract(meta: Dict[str, Any]) -> str:
+def verify_contract(
+    meta: Dict[str, Any],
+    *,
+    entries: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> str:
     """'' when the artifact's ``entries`` contract is self-consistent, else
     the reason.
 
@@ -733,11 +738,17 @@ def verify_contract(meta: Dict[str, Any]) -> str:
     off ``metadata.json``, which is where ``aot_serve`` has always served it
     from. It is verified HERE, on the staged bytes, and never against a
     control-plane declare that is not required to carry it (pgw#988).
+
+    ``entries`` is the already-validated map from :func:`_unpack` when the arm
+    path has one (pgw#1040 — same pure parse, threaded rather than repeated);
+    ``None`` parses it here, which is what a caller holding only a metadata
+    dict does.
     """
-    try:
-        entries = entries_from_meta(meta)
-    except ValueError as exc:
-        return f"malformed declared contract: {exc}"
+    if entries is None:
+        try:
+            entries = entries_from_meta(meta)
+        except ValueError as exc:
+            return f"malformed declared contract: {exc}"
     strict = bool(meta.get("strict_export", True))
     bucket = int(meta.get("lora_bucket") or 0)
     hashes: List[str] = []
@@ -758,14 +769,23 @@ def verify_contract(meta: Dict[str, Any]) -> str:
     return ""
 
 
-def verify(meta: Dict[str, Any], *, family: str = "") -> str:
+def verify(
+    meta: Dict[str, Any],
+    *,
+    family: str = "",
+    entries: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> str:
     """'' when a cell's FULL metadata matches this runtime, else the reason.
 
     Both halves, for callers holding an artifact's own ``metadata.json``
     (:func:`stage_artifact`). Discovery, which holds only a declare, calls
     :func:`verify_declared` and reaches this one after the fetch.
+
+    ``entries`` threads the already-validated map through to
+    :func:`verify_contract` (pgw#1040).
     """
-    return verify_declared(meta, family=family) or verify_contract(meta)
+    return (verify_declared(meta, family=family)
+            or verify_contract(meta, entries=entries))
 
 
 #: :func:`host_isa_reason`'s refusal for a cell that stamped no requirement.
@@ -888,6 +908,21 @@ def pack(content_dir: Path, out_path: Path, metadata: Dict[str, Any]) -> Path:
 
 def unpack(artifact: Path, dest_root: Path) -> Dict[str, Any]:
     """Extract the fixed member set into ``dest_root``; returns metadata."""
+    return _unpack(artifact, dest_root)[0]
+
+
+def _unpack(
+    artifact: Path, dest_root: Path,
+) -> Tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]:
+    """:func:`unpack`, also handing back the ``entries`` map it had to parse.
+
+    pgw#1040: one arm used to run :func:`entries_from_meta` three times over
+    the same bytes — here for the literal-payload check, again in
+    :func:`verify_contract`, and a third time in :func:`load_and_wrap` — and
+    each pass re-parses every entry's full contract and constant table. The
+    parse is the same pure function of the same dict every time, so the arm
+    path threads ONE result from here instead.
+    """
     dest_root = Path(dest_root)
     dest_root.mkdir(parents=True, exist_ok=True)
     meta: Dict[str, Any] = {}
@@ -915,15 +950,16 @@ def unpack(artifact: Path, dest_root: Path) -> Dict[str, Any]:
         raise ValueError(f"{ARTIFACT_KIND} artifact {artifact} has no {METADATA_NAME}")
     # A literal-sourced constant with no payload member would only be
     # discovered at bind time, mid-arm. Name it (and its entry) here.
+    entries = entries_from_meta(meta)
     literals = [
         f"{name}{LITERAL_SEP}{s.fqn}"
-        for name, block in entries_from_meta(meta).items()
+        for name, block in entries.items()
         for s in constants_from_meta(block) if s.source == SOURCE_LITERAL]
     if literals and LITERALS_NAME not in seen:
         raise ValueError(
             f"{ARTIFACT_KIND} artifact {artifact} declares literal constants "
             f"{sorted(literals)[:4]!r} but carries no {LITERALS_NAME}")
-    return meta
+    return meta, entries
 
 
 #: Read the packed envelope without unpacking the cell.
@@ -934,6 +970,14 @@ def unpack(artifact: Path, dest_root: Path) -> Dict[str, Any]:
 #: real minted tarballs. ``trt_engine.unpack_metadata`` is byte-identical; that
 #: dedup belongs to the TRT-engine ratification, not here, because whichever
 #: module survives owns the shared one.
+#:
+#: pgw#1040 collapsed the OTHER seven envelope readers into
+#: :func:`artifact_meta.read_metadata` and left this one alone ON PURPOSE.
+#: Delegating it makes it a one-line alias, which the pgw#849 ratchet then
+#: reports as a STALE baseline entry — an edit to
+#: ``scripts/unreached_surface_baseline.txt``, which a live sibling lane is
+#: rewriting. It costs nothing to wait: this function and its baseline line die
+#: together in whichever cut settles the TRT ratification.
 def unpack_metadata(artifact: Path) -> Dict[str, Any]:
     """Read ONLY metadata.json from an artifact (kind sniffing — cheap)."""
     with tarfile.open(artifact, mode="r:*") as tar:
@@ -948,6 +992,9 @@ def unpack_metadata(artifact: Path) -> Dict[str, Any]:
 @dataclass
 class _StagedAotArtifact:
     metadata: Dict[str, Any]
+    #: The validated ``entries`` map of :attr:`metadata`, parsed ONCE while
+    #: staging (pgw#1040) and threaded to every consumer in the arm.
+    entries: Dict[str, Dict[str, Any]]
     root: Path
     temporary: "tempfile.TemporaryDirectory[str]"
 
@@ -977,13 +1024,13 @@ def stage_artifact(
     temporary = tempfile.TemporaryDirectory(prefix="aot-stage-", dir=base)
     root = Path(temporary.name)
     try:
-        meta = unpack(Path(artifact), root)
+        meta, entries = _unpack(Path(artifact), root)
         # pgw#754: rule on host-CPU executability FIRST and by name — the
         # one failure mode that must never reach dlopen.
         isa_reason = host_isa_reason(meta)
         if isa_reason:
             raise AdoptError("host_isa_unsupported", isa_reason)
-        reason = verify(meta, family=family)
+        reason = verify(meta, family=family, entries=entries)
         if reason:
             raise AdoptError("key_mismatch", reason)
         # pgw#903: "can this runtime execute it" is answered above; this
@@ -1002,7 +1049,7 @@ def stage_artifact(
         sm_reason = verify_package_compute_capability(root / PACKAGE_NAME)
         if sm_reason:
             raise AdoptError("sm_mismatch", sm_reason)
-        return _StagedAotArtifact(meta, root, temporary)
+        return _StagedAotArtifact(meta, entries, root, temporary)
     except AdoptError:
         temporary.cleanup()
         raise
@@ -2142,10 +2189,8 @@ def load_and_wrap(
         Path(artifact), family, cache_dir=cache_dir, expected=expected)
     try:
         meta = staged.metadata
-        try:
-            entries = entries_from_meta(meta)
-        except ValueError as exc:
-            raise AdoptError("contract_invalid", str(exc)) from exc
+        # pgw#1040: parsed and validated once, while staging.
+        entries = staged.entries
 
         # Group the entries by target and resolve every owner module first —
         # an unresolvable target must refuse before any package is dlopen'd.
@@ -2248,18 +2293,10 @@ def _adopt_identity(artifact: Path) -> str:
     """Best-effort ``family=… key=…`` from the artifact's own metadata for
     the typed adopt event — a refusal must name the candidate cell even when
     the refusal itself is a metadata problem."""
-    try:
-        with tarfile.open(artifact, mode="r:*") as tar:
-            for member in tar:
-                if member.name == METADATA_NAME and member.isfile():
-                    src = tar.extractfile(member)
-                    assert src is not None
-                    meta = json.loads(src.read().decode())
-                    return (f"family={meta.get('family')} "
-                            f"key={meta.get('cell_key')}")
-    except Exception:  # noqa: BLE001 — identity is best-effort by contract
-        pass
-    return f"artifact={artifact.name}"
+    meta = artifact_meta.try_read_metadata(artifact)
+    if meta is None:
+        return f"artifact={artifact.name}"
+    return f"family={meta.get('family')} key={meta.get('cell_key')}"
 
 
 def enable(

--- a/src/gen_worker/artifact_meta.py
+++ b/src/gen_worker/artifact_meta.py
@@ -1,0 +1,89 @@
+"""The ONE reader of the ``metadata.json`` packed at the root of a cell tarball.
+
+Every artifact kind this worker handles — AOT (``aot_serve``), inductor-cache
+(``compile_cache``), TRT (``trt_engine``) — packs its envelope as a
+``metadata.json`` member at the tar root. Eight call sites had each grown their
+own ``tarfile.open`` / member scan / ``json.loads`` loop, agreeing on the format
+by convention and disagreeing on everything else: which members count, whether a
+non-``dict`` payload is a value or an error, and what a missing member raises.
+
+STDLIB ONLY, and deliberately so — that is what makes it usable from the two
+modules that must not import the compile stack:
+
+* ``receipts`` verifies a delivered artifact before anything imports torch;
+* ``guard_closure`` sits inside the ``env_seal -> guard_closure -> compile_cache
+  -> registry -> cell_key -> env_seal`` cycle, so its own metadata read had to be
+  a function-local import.
+
+Callers keep their own refusal vocabulary (``AdoptError``, ``ReceiptError``, a
+store-verdict string); this module only answers "what does the envelope say", and
+:class:`ArtifactMetadataError` subclasses :class:`ValueError` so the call sites
+that already classify on ``ValueError`` are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+#: The packed envelope's member name, at the tar root, for every artifact kind.
+METADATA_NAME = "metadata.json"
+
+
+class ArtifactMetadataError(ValueError):
+    """An artifact carries no readable :data:`METADATA_NAME`."""
+
+
+def read_metadata(artifact: Union[str, Path]) -> Dict[str, Any]:
+    """The packed envelope of ``artifact``, WITHOUT unpacking the cell.
+
+    Reads the one member and stops — kind sniffing and every metadata-only
+    gate (host ISA, runtime key, store verdict) run off this, so none of them
+    pays for the multi-GiB payload beside it.
+
+    Raises :class:`ArtifactMetadataError` naming the artifact when the member is
+    absent, the tar is unreadable, or the payload is not a JSON object.
+    """
+    path = Path(artifact)
+    try:
+        with tarfile.open(path, mode="r:*") as tar:
+            for member in tar:
+                if member.name != METADATA_NAME or not member.isfile():
+                    continue
+                src = tar.extractfile(member)
+                if src is None:
+                    break
+                loaded = json.loads(src.read().decode("utf-8"))
+                if not isinstance(loaded, dict):
+                    raise ArtifactMetadataError(
+                        f"artifact {path} carries a {METADATA_NAME} that is "
+                        f"not an object ({type(loaded).__name__})")
+                return dict(loaded)
+    except ArtifactMetadataError:
+        raise
+    except (OSError, tarfile.TarError, ValueError, UnicodeDecodeError) as exc:
+        raise ArtifactMetadataError(f"artifact {path} is unreadable: {exc}") from exc
+    raise ArtifactMetadataError(f"artifact {path} has no {METADATA_NAME}")
+
+
+def try_read_metadata(artifact: Union[str, Path]) -> Optional[Dict[str, Any]]:
+    """:func:`read_metadata`, or ``None`` when it cannot be read.
+
+    For the best-effort readers whose contract is that they never fail: an
+    adopt-event identity line, a lane verdict that falls back to a named
+    default. They report the absence themselves; this only refuses to raise.
+    """
+    try:
+        return read_metadata(artifact)
+    except ArtifactMetadataError:
+        return None
+
+
+__all__ = [
+    "METADATA_NAME",
+    "ArtifactMetadataError",
+    "read_metadata",
+    "try_read_metadata",
+]

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -170,12 +170,7 @@ def from_axes(axes: Mapping[str, str]) -> CellKey:
 def _canonical_execution_lane(weight_lane: str, lora_bucket: int = 0) -> str:
     from . import compile_cache as cc  # cycle: compile_cache imports cell_key
 
-    base, observed = cc.execution_lane_bucket(str(weight_lane or ""))
-    bucket = observed or int(lora_bucket or 0)
-    token = cc.execution_lane_token(base)
-    if bucket:
-        return f"{token}-lora{bucket}" if token else f"lora{bucket}"
-    return token
+    return cc.execution_lane_label(weight_lane, lora_bucket)
 
 
 def facts_digest(facts: Mapping[str, Any]) -> str:

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -608,6 +608,27 @@ def execution_lane_token(weight_lane: str) -> str:
     return tok
 
 
+def execution_lane_label(weight_lane: str, lora_bucket: int = 0) -> str:
+    """:func:`execution_lane_token` with a DECLARED bucket fallback: the
+    label for a lane whose bucket rides beside the lane string rather than
+    inside it (``("w8a8", 128)`` -> ``"w8a8-lora128"``). A bucket the lane
+    string already carries wins — it is what was actually traced.
+
+    pgw#1040: this body existed twice, byte for byte, as
+    ``cell_key._canonical_execution_lane`` and
+    ``aot_contract.ExportSpec.execution_lane_label``. One produces a cell-key
+    AXIS and the other the label stamped into a cell's metadata, so the two
+    copies drifting apart does not degrade — it mints cells under one name and
+    looks them up under another. Both now call this.
+    """
+    base, observed = execution_lane_bucket(str(weight_lane or ""))
+    bucket = observed or int(lora_bucket or 0)
+    token = execution_lane_token(base)
+    if bucket:
+        return f"{token}-lora{bucket}" if token else f"lora{bucket}"
+    return token
+
+
 def cell_base_execution_lane(pipeline: Any) -> str:
     """Base weight lane for CELL-IDENTITY computation (advertised requested
     keys, pull-by-key lookups, local-store lookups): the pipeline probe

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -49,7 +49,6 @@ import json
 import logging
 import os
 import shutil
-import tarfile
 import tempfile
 import threading
 import time
@@ -59,7 +58,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 
 from . import activity as activity_mod
-from . import aot_cells, aot_serve, cell_key
+from . import aot_cells, aot_serve, artifact_meta, cell_key
 from . import boot_phases as boot_mod
 from . import compile_cache as cc
 from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
@@ -1353,11 +1352,7 @@ def _arming_policy(
 
 def _packed_metadata(artifact: Path) -> Dict[str, Any]:
     """The stamped metadata inside a packed cell (metadata members only)."""
-    with tarfile.open(artifact, mode="r:*") as tar:
-        member = tar.extractfile(cc.METADATA_NAME)
-        if member is None:
-            raise RuntimeError(f"{artifact} carries no {cc.METADATA_NAME}")
-        return dict(json.loads(member.read().decode()))
+    return artifact_meta.read_metadata(artifact)
 
 
 def adopt_delegated_mint(

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -94,13 +94,13 @@ import hashlib
 import json
 import logging
 import re
-import tarfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
                     Sequence, Tuple)
 
 from . import activity as activity_mod
+from . import artifact_meta
 from . import torch_capability
 import argparse
 
@@ -1084,16 +1084,13 @@ def load_manifest(path: Path) -> Dict[str, Any]:
         data = json.loads(path.read_text())
         found = data.get(MANIFEST_KEY, data) if isinstance(data, dict) else None
     else:
-        # CYCLE: env_seal -> guard_closure -> compile_cache -> registry -> cell_key
-        # -> env_seal. This is the edge that must not be static.
-        from . import compile_cache as cc
-
-        found = None
-        with tarfile.open(path, mode="r:*") as tar:
-            member = tar.getmember(cc.METADATA_NAME)
-            f = tar.extractfile(member)
-            meta = json.loads(f.read().decode()) if f else {}
-            found = meta.get(MANIFEST_KEY)
+        # `artifact_meta` is stdlib-only, which is why the read is a plain
+        # top-level import here: the function-local `compile_cache` import this
+        # replaces existed to keep the
+        # env_seal -> guard_closure -> compile_cache -> registry -> cell_key
+        # -> env_seal cycle out of module scope, and the shared reader closes
+        # that edge outright.
+        found = artifact_meta.read_metadata(path).get(MANIFEST_KEY)
     if not isinstance(found, dict) or not found.get("graphs"):
         raise GuardClosureError(
             f"{path} carries no guard manifest — pre-pgw#681 cell or bare "

--- a/src/gen_worker/kernel_path.py
+++ b/src/gen_worker/kernel_path.py
@@ -77,6 +77,8 @@ from typing import (
 
 import msgspec
 
+from . import artifact_meta
+
 logger = logging.getLogger(__name__)
 
 # --- vocabulary -------------------------------------------------------------
@@ -956,18 +958,9 @@ def adopt_from_artifact(artifact: Any, *, source: str = "") -> str:
     if artifact is None:
         return adopt(None, source=source)
     try:
-        import json
-        import tarfile
-
-        with tarfile.open(str(artifact), "r:*") as tar:
-            for member in tar:
-                if member.name == "metadata.json" and member.isfile():
-                    fh = tar.extractfile(member)
-                    if fh is None:
-                        break
-                    meta = json.loads(fh.read().decode())
-                    return adopt(meta, source=source or str(artifact))
-        raise ExecutionLaneProbeError("artifact has no metadata.json")
+        return adopt(
+            artifact_meta.read_metadata(artifact),
+            source=source or str(artifact))
     except Exception as exc:  # noqa: BLE001 — never fails a load
         pin(DEFAULT_EXECUTION_LANE, (
             f"{REASON_UNREADABLE}: cannot read the verdict from "

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -48,17 +48,16 @@ The store root is ``$GEN_WORKER_LOCAL_CELLS_DIR`` (exported by cozy-local's
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import shutil
 import sys
-import tarfile
 import time
 from pathlib import Path
 from typing import Any, Optional
 
 from . import activity as activity_mod
+from . import artifact_meta
 from . import compile_cache as cc
 from .models.loading import pipeline_weight_lane
 from .models import provision
@@ -88,14 +87,9 @@ def cell_path(family: str, weight_lane: str = "", root: Optional[Path] = None) -
 def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
     """'' when the stored cell is adoptable by this runtime + pipeline, else
     the mismatch reason (production verify() + drift parity, verbatim)."""
-    try:
-        with tarfile.open(artifact, mode="r:*") as tar:  # metadata only
-            member = tar.extractfile(cc.METADATA_NAME)
-            if member is None:
-                return "no metadata.json"
-            meta = json.loads(member.read().decode())
-    except Exception as exc:  # noqa: BLE001 — any unreadable cell re-mints
-        return f"unreadable artifact ({exc})"
+    meta = artifact_meta.try_read_metadata(artifact)
+    if meta is None:
+        return f"unreadable artifact ({artifact})"
     # th#883/gw#581: ONE compatibility brain when a key exists on both sides —
     # the exact key comparison fleet workers use.
     #

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
+from .. import artifact_meta
 from ..cell_adopt import AdoptOutcome
 from ..component_vocab import denoiser_components
 from ..api.binding import ModelRef, wire_ref
@@ -264,15 +265,12 @@ def arm_aot(
     proven order). Rolled back on a failed arm so a dynamo fallthrough never
     traces a lifted forward it did not ask for.
     """
-    # Deferred: hoisting drags aot_serve + trt_engine onto the
-    # `import gen_worker` path (+39 modules).
-    from .. import aot_serve, trt_engine
+    # Deferred: hoisting drags aot_serve onto the `import gen_worker` path
+    # (+39 modules).
+    from .. import aot_serve
 
     if meta is None:
-        try:
-            meta = trt_engine.unpack_metadata(Path(artifact))
-        except Exception:
-            meta = None
+        meta = artifact_meta.try_read_metadata(artifact)
     lifted_target: Any = None
     lifted_installed = False
     #: pgw#999: why the lifted-binding install failed, if it did. Carried into
@@ -525,10 +523,7 @@ def enable_compiled(
         # the shared envelope member across all artifact kinds (the pgw#709
         # receipts gate above reads it from the same place), so `kind` is the
         # dispatch key: absent/unknown falls through to the inductor lane.
-        try:
-            meta = trt_engine.unpack_metadata(Path(artifact))
-        except Exception:
-            meta = None
+        meta = artifact_meta.try_read_metadata(artifact)
         kind = str((meta or {}).get("kind") or "")
         if kind == aot_serve.ARTIFACT_KIND:
             aot = arm_aot(pipe, cfg, cache_dir, Path(artifact), bucket, meta)

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -47,7 +47,6 @@ import binascii
 import hashlib
 import json
 import logging
-import tarfile
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -59,6 +58,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from . import activity as activity_mod
+from . import artifact_meta
 from .procsplit import broker
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,6 @@ RECEIPT_PATH = "/v1/worker/cells/receipt"
 REVOCATIONS_PATH = "/v1/worker/cells/revocations"
 
 _HTTP_TIMEOUT_S = 30
-_METADATA_NAME = "metadata.json"
 
 
 class ReceiptError(RuntimeError):
@@ -545,20 +544,12 @@ def artifact_digest(path: Path) -> str:
 
 
 def _embedded_meta(artifact: Path) -> Dict[str, object]:
-    """The artifact's packed ``metadata.json`` — read directly (stdlib
-    tarfile) so this module never imports the compile stack."""
+    """The artifact's packed ``metadata.json``, through the one stdlib-only
+    reader — so this module still never imports the compile stack."""
     try:
-        with tarfile.open(artifact, mode="r:*") as tar:
-            for member in tar:
-                if member.name == _METADATA_NAME and member.isfile():
-                    f = tar.extractfile(member)
-                    if f is None:
-                        break
-                    loaded = json.loads(f.read().decode("utf-8"))
-                    return dict(loaded) if isinstance(loaded, dict) else {}
-    except (OSError, tarfile.TarError, ValueError, UnicodeDecodeError) as exc:
+        return dict(artifact_meta.read_metadata(artifact))
+    except artifact_meta.ArtifactMetadataError as exc:
         raise ReceiptError("artifact_unreadable", f"{artifact.name}: {exc}") from exc
-    raise ReceiptError("artifact_unreadable", f"{artifact.name}: no {_METADATA_NAME}")
 
 
 def verify_delivered_artifact(artifact: Path, family: str) -> Receipt:

--- a/src/gen_worker/trt_engine.py
+++ b/src/gen_worker/trt_engine.py
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from . import activity as activity_mod
+from . import artifact_meta
 from .cell_adopt import AdoptOutcome
 from .compile_cache import (
     AdoptError,
@@ -261,14 +262,12 @@ def stage_artifact(
 
 
 def unpack_metadata(artifact: Path) -> Dict[str, Any]:
-    """Read ONLY metadata.json from an artifact (kind sniffing — cheap)."""
-    with tarfile.open(artifact, mode="r:*") as tar:
-        for member in tar:
-            if member.name == METADATA_NAME and member.isfile():
-                src = tar.extractfile(member)
-                assert src is not None
-                return json.loads(src.read().decode())
-    raise ValueError(f"artifact {artifact} has no {METADATA_NAME}")
+    """Read ONLY metadata.json from an artifact (kind sniffing — cheap).
+
+    The shared :mod:`artifact_meta` reader; the refusal stays a
+    :class:`ValueError` subclass, which is what every caller classifies on.
+    """
+    return artifact_meta.read_metadata(artifact)
 
 
 def find_artifact(root: Path) -> Optional[Path]:

--- a/tests/test_aot_flip_pgw722.py
+++ b/tests/test_aot_flip_pgw722.py
@@ -685,12 +685,14 @@ def _arm_aot(
     """Drive provision.enable_compiled at an AOT artifact; returns the
     lifted-binding observations recorded at aot_serve.enable call time."""
     from gen_worker import compile_cache as cc
-    from gen_worker import trt_engine
+    from gen_worker import artifact_meta
 
     monkeypatch.setattr(cc, "has_compile_target", lambda p, c: True)
     monkeypatch.setattr(cc, "enable", lambda *a, **k: False)
+    # pgw#1040: the arm's kind sniff reads the envelope through the ONE
+    # stdlib reader, not through `trt_engine.unpack_metadata`.
     monkeypatch.setattr(
-        trt_engine, "unpack_metadata",
+        artifact_meta, "try_read_metadata",
         lambda p: {"kind": aot_serve.ARTIFACT_KIND, "module": "unet"})
     observed: List[bool] = []
 

--- a/tests/test_artifact_identity_pgw903.py
+++ b/tests/test_artifact_identity_pgw903.py
@@ -242,7 +242,7 @@ def test_stage_artifact_refuses_a_wrong_identity_before_any_load(
     runtime-key and sm gates are neutralized so the ONLY thing under test is
     identity — otherwise a green run could mean 'refused for the wrong
     reason'."""
-    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, **kw: "")
     monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
     loaded: list[Any] = []
     monkeypatch.setattr(
@@ -265,7 +265,7 @@ def test_stage_artifact_refuses_a_wrong_identity_before_any_load(
 def test_stage_artifact_with_a_matching_identity_reaches_the_load_gates(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, **kw: "")
     monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
     reached: list[Any] = []
     monkeypatch.setattr(
@@ -288,7 +288,7 @@ def test_no_expectation_leaves_the_legacy_path_byte_identical(
     """Until the cutover, RunJob dispatches carry no immutable spec. Absent an
     expectation the gate must not invent one — a default expectation would
     refuse every cell the fleet serves today."""
-    monkeypatch.setattr(aot_serve, "verify", lambda meta, family="": "")
+    monkeypatch.setattr(aot_serve, "verify", lambda meta, **kw: "")
     monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
     monkeypatch.setattr(
         aot_serve, "verify_package_compute_capability", lambda path: "")
@@ -312,7 +312,7 @@ def test_an_internally_corrupt_artifact_keeps_its_own_distinct_refusal(
     monkeypatch.setattr(aot_serve, "host_isa_reason", lambda meta: "")
     monkeypatch.setattr(
         aot_serve, "verify",
-        lambda meta, family="": "entry 'unet': class_hash does not match its recorded facts")
+        lambda meta, **kw: "entry 'unet': class_hash does not match its recorded facts")
     with pytest.raises(aot_serve.AdoptError) as exc:
         aot_serve.stage_artifact(
             _artifact(tmp_path, _meta()), "micro",

--- a/tests/test_delegated_adopt_reason_pgw999.py
+++ b/tests/test_delegated_adopt_reason_pgw999.py
@@ -292,10 +292,10 @@ def test_a_failed_lifted_install_reaches_the_refusal_it_causes(
     # `arm_aot` imports these INSIDE the function body (they drag 39 modules
     # onto the `import gen_worker` path), so they are patched on their own
     # modules rather than as attributes of `provision`.
-    from gen_worker import aot_serve, trt_engine
+    from gen_worker import aot_serve, artifact_meta
 
     monkeypatch.setattr(
-        trt_engine, "unpack_metadata",
+        artifact_meta, "try_read_metadata",
         lambda p: {"targets": ["unet"], "module": "unet", "mode": ""})
     monkeypatch.setattr(provision, "arm_route", lambda mode: object())
 

--- a/tests/test_lifted_arm_pgw1001.py
+++ b/tests/test_lifted_arm_pgw1001.py
@@ -94,10 +94,11 @@ def _meta_with_entries_only() -> Dict[str, Any]:
 @pytest.fixture()
 def armed(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
     """Record which module `arm_aot` installed the lifted binding on."""
-    from gen_worker import aot_serve, trt_engine
+    from gen_worker import aot_serve, artifact_meta
 
     monkeypatch.setattr(
-        trt_engine, "unpack_metadata", lambda p: _meta_with_entries_only())
+        artifact_meta, "try_read_metadata",
+        lambda p: _meta_with_entries_only())
     monkeypatch.setattr(provision, "arm_route", lambda mode: object())
     monkeypatch.setattr(
         aot_serve, "enable", lambda *a, **k: AdoptOutcome.hit("armed"))


### PR DESCRIPTION
pgw#1040's arm-path dedup row, plus the one item of its mint-lane residue row that needed no measurement. The other rows are adjudicated in the tracker rather than implemented — two are Paul's and are indexed in `HUMAN_MUST_DO.md`, one has a refuted premise, and two are deferred behind a live sibling lane.

## What this changes

**One reader for a cell's packed envelope.** Eight call sites each carried their own `tarfile.open` / member scan / `json.loads` of the `metadata.json` every artifact kind packs at its tar root — agreeing on the format by convention and disagreeing on the rest: which members counted, whether a non-object payload was a value or an error, and what a missing member raised (`ValueError`, `RuntimeError`, `KeyError`, a verdict string, or nothing).

`artifact_meta.read_metadata` / `try_read_metadata` is now that reader, and it is **stdlib only** on purpose — that is what lets `receipts` (must not import the compile stack before verifying a delivered artifact) and `guard_closure` (inside the `env_seal -> guard_closure -> compile_cache -> registry -> cell_key -> env_seal` cycle, so its read had to be a function-local import) share one implementation. `ArtifactMetadataError` subclasses `ValueError`, so every site that already classified on `ValueError` is unchanged.

`models/provision`'s kind sniff no longer reads an AOT envelope through `trt_engine` — which is what three test files were monkeypatching to steer the AOT arm — and `kernel_path.adopt_from_artifact` loses its function-local `import json, tarfile`.

**`aot_serve.unpack_metadata` is the eighth reader and is deliberately left alone.** It is baselined in `scripts/unreached_surface_baseline.txt`; delegating it makes it a one-line alias, which flips the pgw#849 ratchet to `STALE baseline entry` and forces an edit to that baseline file — the file a live sibling lane is rewriting. It costs nothing to wait: that function and its baseline line die together in whichever cut settles the TRT ratification.

**`entries` is parsed once per arm, not three times.** `unpack` (the literal-payload check), `verify_contract` and `load_and_wrap` each re-ran `entries_from_meta`, which re-parses every entry's full contract and constant table. The staged artifact carries the one validated map and threads it. `load_and_wrap`'s `contract_invalid` arm went with it: `stage_artifact` cannot return without that same parse succeeding, so the branch was already unreachable.

**One lane-token rule.** `cell_key._canonical_execution_lane` and `aot_contract.ExportSpec.execution_lane_label` were the same six lines, byte for byte. One produces a cell-key AXIS, the other the label stamped into a cell's metadata — drift between them does not degrade, it mints cells under one name and looks them up under another. Both call `compile_cache.execution_lane_label` now.

## What this deliberately does NOT change

- **The host-ISA de-shadowing** (the gate is ruled 4x per adopt, 2 unreachable — confirmed). It was written and then reverted: the fix lands in `src/gen_worker/aot_cells.py`, which the pgw#904 ExecutionSpec cutover lane is deleting outright. Re-file against the post-#904 tree.
- **The three ingress measurements.** The row's premise is refuted: two of the three facts already reach the hub as typed events (`aot_input_realigned`, `aot_ingress_refused` + `FALLBACK_INGRESS_REFUSED` on JobMetrics). A roll-up carrying all three would be a second producer of facts already on the wire. Details in the tracker.
- **`scripts/unreached_surface_baseline.txt`** — untouched, and the guard's finding set is byte-identical to master's 13.

## Tests

`tests/` 3641 passed / 37 skipped / 1 xfailed; `tests_v2/` 21 passed. `mypy src/gen_worker` clean, `ruff check src/gen_worker` clean, all four hard-gate lint scripts exit 0. Strictly local, $0, no pods.

Four test files patched the seams this moved; three of them had been patching `trt_engine.unpack_metadata` to inject the AOT arm's metadata, which is exactly the cross-module coupling this removes.