### PR TITLE
pgw#1041: load-progress heartbeats, per-component cgroup staging admission, SIGKILL postmortem (cgroup v1)

### DIFF
--- a/changelog.d/pgw1041.md
+++ b/changelog.d/pgw1041.md
@@ -1,0 +1,23 @@
+- **pgw#1041: a model load can no longer run silent, and a SIGKILL'd load
+  names where it died.** ie#615 attempt 4 ran `self_mint_compile phase=load`
+  for 94 minutes with zero telemetry, then died to an unattributable SIGKILL
+  ("cgroup_oom_kill_delta=0, memory.max=unlimited" — on a cgroup-v1 host
+  whose real limit was 233.8 GiB). Four changes, one per proven defect:
+  (1) `LoadProgressReporter` (models/load_progress.py) samples
+  `/proc/self/io` + RssAnon while `provision.load_slot` blocks, feeding the
+  existing 10s activity beat a `load:staged_bytes` counter (the th#1451
+  stall clock finally has something to hold a load to) and overwriting a
+  breadcrumb the parent attaches to the death dial as `last_load_progress`;
+  the fetch path's byte ticks now also ride an activity counter
+  (`download:bytes`). (2) Modular hydration loads ONE component at a time —
+  admission-checked against the cgroup budget before each component
+  (`InsufficientHostRamError` / `HostRamCapacityError` with the measured
+  numbers), page cache chilled after each (pgw#1026's minimal per-stage form
+  on this lane; the diagnosis pod measured the whole-tree form running the
+  cgroup AT its ceiling, max_usage == limit). (3) `postmortem` speaks
+  cgroup v1: `memory.limit_in_bytes`/`usage`/`max_usage` and the
+  `memory.oom_control` oom_kill counter fill the same report fields, so a
+  v1 OOM kill now classifies as `cause=oom` instead of `signal:SIGKILL`.
+  (4) host-RAM admission counts a component override's own materialized
+  tree in the slot's staging requirement (it under-admitted H3 by the fp8
+  encoder's 27.6 GB).

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -6649,7 +6649,8 @@ class Executor:
             # VRAM make-room may demote the old pipeline into host RAM. Admit
             # the incoming load only AFTER that transition so the probe sees
             # the actual post-demotion pressure (pgw#541).
-            await self._ensure_host_ram_for(spec, paths)
+            await self._ensure_host_ram_for(
+                spec, paths, component_paths=component_paths)
             instance = spec.cls()
             # Stamp provisional ownership BEFORE tenant setup/warmup. The
             # record is not advertised until rec.ready becomes true, but an
@@ -7897,7 +7898,12 @@ class Executor:
             )
         return advised
 
-    async def _ensure_host_ram_for(self, spec: EndpointSpec, paths: Dict[str, str]) -> None:
+    async def _ensure_host_ram_for(
+        self,
+        spec: EndpointSpec,
+        paths: Dict[str, str],
+        component_paths: Optional[Dict[str, Dict[str, str]]] = None,
+    ) -> None:
         """Owner-aware host-RAM admission (gw#407/pgw#541). ``from_pretrained``
         stages the full weight set in host RAM before placement; loading into
         a nearly-full host pushes it into reclaim-thrash that stalls the whole
@@ -7928,6 +7934,14 @@ class Executor:
         for slot, p in paths.items():
             if slot in slots:
                 slot_bytes = await asyncio.to_thread(disk_gc.tree_bytes, Path(p))
+                # pgw#1041: a pgw#617/th#980 component override stages its
+                # OWN materialized tree alongside the (narrowed) base — the
+                # slot's true staging requirement is their sum. ie#615:
+                # counting only the base under-admitted by the override's
+                # 27.6 GB.
+                for comp_path in ((component_paths or {}).get(slot) or {}).values():
+                    slot_bytes += await asyncio.to_thread(
+                        disk_gc.tree_bytes, Path(comp_path))
                 ref = wire_ref(spec.models[slot])
                 if slot_bytes > incoming:
                     incoming = slot_bytes

--- a/src/gen_worker/models/cozy_snapshot.py
+++ b/src/gen_worker/models/cozy_snapshot.py
@@ -683,6 +683,14 @@ class CozySnapshotDownloader:
                     # CPU-sampling watchdog thread (I/O-bound fills are
                     # CPU-light by design and would otherwise starve it).
                     _activity.note_progress()
+                # pgw#1041: fetched bytes as an activity COUNTER, so the 10s
+                # beat carries byte-level fetch progress to the hub (the
+                # heartbeat above proves liveness but reports no number).
+                # Activity-scoped: finished on phase change/activity end
+                # (pgw#962), re-acquired per tick.
+                act = _activity.current()
+                if act is not None:
+                    act.counter("download:bytes", "bytes").add(n)
                 d = done if total is None else min(done, total)
             if progress is not None:
                 try:

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -135,7 +135,7 @@ class LoadProgressReporter:
     def __enter__(self) -> "LoadProgressReporter":
         return self.start()
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         self.stop(clean=exc_type is None)
 
     # -- sampling -----------------------------------------------------------

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -1,0 +1,187 @@
+"""pgw#1041: byte-level progress for the model load path.
+
+The ie#615 attempt-4 load ran 94 minutes with ZERO progress telemetry and
+died to an unattributable SIGKILL. The activity/beat machinery (gw#621,
+th#1451) was already in place — what was missing is a PRODUCER during the
+load: fetch feeds counters, but staging/hydration is one long blocking
+diffusers call with nothing ticking, so the hub's stall clock had nothing
+to hold the worker to and the death dial had no "where".
+
+One reporter fixes both, riding the EXISTING channels (WORKER-CONTRACTS §1:
+no parallel heartbeat systems):
+
+* a sampler thread ticks a byte counter from ``/proc/self/io`` read_bytes
+  plus anonymous-RSS growth — real external evidence of staging progress,
+  independent of any loader hook — which the 10s app beat then carries to
+  the hub as counter advancement (``activity.on_beat``);
+* every tick overwrites a small breadcrumb file
+  (:func:`gen_worker.postmortem.write_load_progress`); a SIGKILL mid-load
+  is then attributed by the surviving parent as "died at
+  hydrate:transformer, N/M GiB" instead of a blank.
+
+Off-Linux (/proc missing) the reporter is an honest no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from .. import activity as activity_mod
+from .. import postmortem
+from .. import progress as progress_mod
+
+logger = logging.getLogger(__name__)
+
+#: One counter name for the whole load path; the hub's stall clock runs on
+#: non-advancement of whatever counter is freshest, not on the name.
+COUNTER_NAME = "load:staged_bytes"
+
+_INTERVAL_S = 5.0
+
+_lock = threading.Lock()
+_active: Optional["LoadProgressReporter"] = None
+
+
+def _proc_read_bytes() -> Optional[int]:
+    try:
+        for line in open("/proc/self/io"):
+            if line.startswith("read_bytes:"):
+                return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _proc_rss_anon_kb() -> Optional[int]:
+    try:
+        for line in open("/proc/self/status"):
+            if line.startswith("RssAnon:"):
+                return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+class LoadProgressReporter:
+    """Samples staging progress while a model load blocks the caller.
+
+    ``label`` names the load (function/ref); ``total_bytes`` is the on-disk
+    tree size about to be staged (0 = unknown; the counter then reports
+    done-only). ``phase`` is updated by the loader as it moves through
+    components (:func:`set_phase`)."""
+
+    def __init__(
+        self,
+        label: str,
+        total_bytes: int,
+        *,
+        marker_path: Optional[Path] = None,
+        interval_s: float = _INTERVAL_S,
+    ) -> None:
+        self.label = label
+        self.total_bytes = max(0, int(total_bytes))
+        self.marker_path = marker_path
+        self.interval_s = max(0.5, float(interval_s))
+        self._phase = "load"
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._io0: Optional[int] = None
+        self._started_unix = 0.0
+
+    # -- loader-facing ------------------------------------------------------
+
+    def set_phase(self, phase: str) -> None:
+        self._phase = phase
+        self._tick()
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> "LoadProgressReporter":
+        global _active
+        self._io0 = _proc_read_bytes()
+        self._started_unix = time.time()
+        with _lock:
+            _active = self
+        self._tick()
+        t = threading.Thread(
+            target=self._run, name="load-progress", daemon=True)
+        self._thread = t
+        t.start()
+        return self
+
+    def stop(self, *, clean: bool) -> None:
+        global _active
+        self._stop.set()
+        t = self._thread
+        if t is not None:
+            t.join(timeout=self.interval_s + 1.0)
+        with _lock:
+            if _active is self:
+                _active = None
+        try:
+            c = progress_mod.counter(COUNTER_NAME, "bytes", self.total_bytes)
+            c.finish()
+        except Exception:  # noqa: BLE001 - reporting must never break a load
+            pass
+        if clean:
+            postmortem.clear_load_progress(self.marker_path)
+        # An unclean stop leaves the breadcrumb for the death attribution.
+
+    def __enter__(self) -> "LoadProgressReporter":
+        return self.start()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop(clean=exc_type is None)
+
+    # -- sampling -----------------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval_s):
+            self._tick()
+
+    def _tick(self) -> None:
+        try:
+            io_now = _proc_read_bytes()
+            read = (
+                io_now - self._io0
+                if io_now is not None and self._io0 is not None else 0
+            )
+            rss_anon_kb = _proc_rss_anon_kb() or 0
+            # Bytes STAGED is evidenced by whichever is further along:
+            # cold reads show in io, page-cache-warm loads show as anon RSS.
+            done = max(0, read, rss_anon_kb * 1024)
+            c = progress_mod.counter(
+                COUNTER_NAME, "bytes",
+                max(self.total_bytes, done),
+            )
+            c.set_done(done)
+            activity_mod.note_progress()
+            postmortem.write_load_progress({
+                "label": self.label,
+                "phase": self._phase,
+                "read_bytes": read,
+                "rss_anon_kb": rss_anon_kb,
+                "staged_bytes": done,
+                "total_bytes": self.total_bytes,
+                "started_unix": self._started_unix,
+                "ts_unix": time.time(),
+                "pid": os.getpid(),
+            }, self.marker_path)
+        except Exception:  # noqa: BLE001 - reporting must never break a load
+            logger.debug("load-progress tick dropped", exc_info=True)
+
+
+def set_phase(phase: str) -> None:
+    """Update the active reporter's phase (no-op when no load is running)."""
+    with _lock:
+        rep = _active
+    if rep is not None:
+        rep.set_phase(phase)
+
+
+__all__ = ["COUNTER_NAME", "LoadProgressReporter", "set_phase"]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -25,9 +25,11 @@ import os
 import struct
 import sys
 
+from ..capability import HostRamCapacityError, InsufficientHostRamError
+from . import disk_gc, load_progress
 from .artifact_contract import CONTRACT_PLAIN_BF16, implements_contract
 from .fp8_storage import restructure_fp8_storage
-from .memory import get_available_vram_gb, meta_tensors
+from .memory import get_available_vram_gb, meta_tensors, probe_host_ram
 from .safetensors_header import header_len_ok
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
 from .w4a4 import (
@@ -1392,6 +1394,49 @@ def _weightless_model_dir(src: Path) -> bool:
     return next(src.rglob("*.safetensors"), None) is None
 
 
+_GIB = 1024 ** 3
+# Mirrors residency/staging's host-RAM floor policy (gw#407).
+_STAGING_FLOOR_GB = 8.0
+_STAGING_FLOOR_FRACTION = 0.2
+
+
+def _staging_floor_bytes(total_bytes: int) -> int:
+    if total_bytes <= 0:
+        return int(_STAGING_FLOOR_GB * _GIB)
+    return int(min(_STAGING_FLOOR_GB * _GIB,
+                   max(_GIB, total_bytes * _STAGING_FLOOR_FRACTION)))
+
+
+def _admit_component_staging(component: str, nbytes: int) -> None:
+    """pgw#1041: admit ONE component's staging against the cgroup budget.
+
+    ``probe_host_ram`` already speaks cgroup (v1 and v2) and credits clean
+    reclaimable page cache (pgw#752), so the just-fetched tree's own cache
+    never blocks its own load. A component that cannot fit an EMPTY host is
+    the structural pgw#752 verdict; one that cannot fit right now is the
+    transient one. Both carry the measured numbers. An unreadable probe
+    fails open — no worse than the unchecked load it replaces."""
+    if nbytes <= 0:
+        return
+    ram = probe_host_ram()
+    total = int(ram.total_gb * _GIB)
+    avail = int(ram.available_gb * _GIB)
+    if total <= 0:
+        return
+    floor = _staging_floor_bytes(total)
+    required = int(nbytes) + floor
+    kwargs = dict(
+        incoming_bytes=int(nbytes), floor_bytes=floor,
+        required_bytes=required, available_before_bytes=avail,
+        available_after_bytes=avail, total_bytes=total,
+    )
+    label = f"modular component {component!r}"
+    if required > total:
+        raise HostRamCapacityError(label, **kwargs)
+    if required > avail:
+        raise InsufficientHostRamError(label, **kwargs)
+
+
 def hydrate_modular_pipeline(
     pipe: Any,
     path: str | Path,
@@ -1503,12 +1548,6 @@ def hydrate_modular_pipeline(
 
     names = sorted(sources)
     if names:
-        kwargs: Dict[str, Any] = {
-            "pretrained_model_name_or_path": {n: sources[n] for n in names},
-            "subfolder": {n: "" for n in names},
-        }
-        if torch_dtype is not None:
-            kwargs["torch_dtype"] = torch_dtype
         # load_components swallows per-component load failures into a
         # diffusers logger warning and registers nothing — capture that text
         # so the typed refusal below can carry the actual cause.
@@ -1522,7 +1561,27 @@ def hydrate_modular_pipeline(
         handler = _Capture(level=logging.WARNING)
         dlog.addHandler(handler)
         try:
-            pipe.load_components(names=names, **kwargs)
+            # pgw#1041 (pgw#1026's minimal per-stage form on this lane): one
+            # component at a time, admission-checked against the CGROUP
+            # budget before it stages, page cache chilled after it lands.
+            # ie#615 attempt 4 measured the whole-tree form running the
+            # cgroup AT its ceiling (max_usage == limit, 250.0/251.0 GB):
+            # staged anon plus the tree's own read cache share one limit, so
+            # sequencing + chilling is what keeps the high-water at
+            # anon + ONE component instead of anon + the whole tree.
+            for n in names:
+                comp_src = Path(sources[n])
+                comp_bytes = disk_gc.tree_bytes(comp_src)
+                load_progress.set_phase(f"hydrate:{n}")
+                _admit_component_staging(n, comp_bytes)
+                kwargs: Dict[str, Any] = {
+                    "pretrained_model_name_or_path": {n: sources[n]},
+                    "subfolder": {n: ""},
+                }
+                if torch_dtype is not None:
+                    kwargs["torch_dtype"] = torch_dtype
+                pipe.load_components(names=[n], **kwargs)
+                disk_gc.reclaim_file_cache(comp_src)
         finally:
             dlog.removeHandler(handler)
         missing = [n for n in names if getattr(pipe, n, None) is None]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1425,16 +1425,15 @@ def _admit_component_staging(component: str, nbytes: int) -> None:
         return
     floor = _staging_floor_bytes(total)
     required = int(nbytes) + floor
-    kwargs = dict(
-        incoming_bytes=int(nbytes), floor_bytes=floor,
-        required_bytes=required, available_before_bytes=avail,
-        available_after_bytes=avail, total_bytes=total,
-    )
     label = f"modular component {component!r}"
-    if required > total:
-        raise HostRamCapacityError(label, **kwargs)
-    if required > avail:
-        raise InsufficientHostRamError(label, **kwargs)
+    cls = (HostRamCapacityError if required > total
+           else InsufficientHostRamError if required > avail else None)
+    if cls is not None:
+        raise cls(
+            label, incoming_bytes=int(nbytes), floor_bytes=floor,
+            required_bytes=required, available_before_bytes=avail,
+            available_after_bytes=avail, total_bytes=total,
+        )
 
 
 def hydrate_modular_pipeline(

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -33,6 +33,7 @@ from ..api.binding import ModelRef, wire_ref
 from ..config import Settings, current_or
 
 _STANDALONE = Settings()
+from . import disk_gc, load_progress
 from .cache_paths import tensorhub_cas_dir
 from .errors import UrlExpiredError
 from .ladder import maybe_rebind_family_fp8
@@ -151,70 +152,86 @@ def load_slot(
                 "serving at base precision")
             storage_dtype = ""
 
-    pipe = load_from_pretrained(
-        annotation, path, dtype=dtype, storage_dtype=storage_dtype,
-        components=components or None,
-        component_trees=component_trees or None,
-        declared_vram_gb=declared_vram_gb,
-    )
-    out.obj = pipe
+    # pgw#1041: byte-level staging progress + death breadcrumb for the whole
+    # load (hydration AND placement). The counter feeds the existing 10s
+    # activity beat; the breadcrumb names the phase a SIGKILL lands in.
+    staged_total = disk_gc.tree_bytes(Path(path))
+    for tree in (component_trees or {}).values():
+        staged_total += disk_gc.tree_bytes(Path(tree))
+    # `clean=True` even on a raise: a Python-level failure reports itself, so
+    # the breadcrumb clears. Only a kernel kill skips the finally — exactly
+    # the death the surviving breadcrumb is for.
+    reporter = load_progress.LoadProgressReporter(
+        f"{slot or 'slot'}:{ref or path}", staged_total).start()
+    try:
+        pipe = load_from_pretrained(
+            annotation, path, dtype=dtype, storage_dtype=storage_dtype,
+            components=components or None,
+            component_trees=component_trees or None,
+            declared_vram_gb=declared_vram_gb,
+        )
+        out.obj = pipe
 
-    # pgw#683: the composition must present ONE compute dtype to its GEMMs.
-    # Fail HERE, naming the component and the tensor, instead of at warm unit
-    # 4/18 with torch's `mat1 and mat2 must have the same dtype` — which names
-    # neither, and which cost `generate` on a live prod release.
-    assert_uniform_compute_dtype(
-        pipe, composition_compute_dtype(path, dtype), label=f"slot {slot!r} ({ref})")
+        # pgw#683: the composition must present ONE compute dtype to its GEMMs.
+        # Fail HERE, naming the component and the tensor, instead of at warm unit
+        # 4/18 with torch's `mat1 and mat2 must have the same dtype` — which names
+        # neither, and which cost `generate` on a live prod release.
+        assert_uniform_compute_dtype(
+            pipe, composition_compute_dtype(path, dtype), label=f"slot {slot!r} ({ref})")
 
-    rung = str(getattr(pipe, "_cozy_adaptive_rung", "") or "")
-    cast_failed = getattr(
-        pipe, "_cozy_fp8_storage_requested", False
-    ) and not getattr(pipe, "_cozy_fp8_storage_ok", True)
-    if rung == RUNG_NF4_UNLANDED:
-        # pgw#824: the emergency rung ENGAGED and landed on nothing. Routed
-        # through the same SlotLoad.rung path as every sibling rung, so it
-        # reaches ServePlan/FnDegraded via `_record_adaptive_rung` instead of
-        # dying in a log line. It used to clear the stamp, which suppressed the
-        # only report the ladder had — the worst outcome was the silent one.
-        out.rung = rung
-        out.rung_detail = (
-            f"adaptive fit rung 'nf4' engaged at load for slot {slot!r} "
-            f"({type(pipe).__name__}) and landed on ZERO modules; this slot "
-            f"serves FULL PRECISION over the VRAM it was budgeted, and only "
-            f"the offload ladder carries it")
-    elif rung == "nf4" or (rung == "fp8" and not cast_failed):
-        # gw#491: the loader engaged an emergency rung because free VRAM at
-        # load was tighter than planning assumed.
-        out.rung = rung
-        out.rung_detail = (
-            f"adaptive fit rung {rung!r} engaged at load for slot {slot!r} "
-            f"({type(pipe).__name__}); free VRAM below the stored-precision "
-            "footprint")
-    elif cast_failed and not rung:
-        # th#737 backstop: the RESOLUTION cast was attempted at load and
-        # failed on every target — structural report, not a silent bf16
-        # fallback. (A failed adaptive fp8 is not a plan deviation: the plan
-        # was base precision.)
-        out.cast_fail_wanted = storage_dtype or "fp8"
-        out.cast_fail_detail = (
-            f"fp8 storage failed on every component of slot {slot!r} "
-            f"({type(pipe).__name__}); serving at base precision")
-    elif (force_storage_dtype and not rung
-          and getattr(pipe, "_cozy_fp8_storage_requested", False)
-          and getattr(pipe, "_cozy_fp8_storage_ok", True)):
-        # th#1043: a joint shared-lane fit forced fp8 storage the binding
-        # never asked for — report it structurally (FnDegraded) exactly like
-        # an adaptive rung; a silent precision downgrade lies to placement.
-        out.rung = "fp8"
-        out.rung_detail = (
-            f"joint shared-lane fit forced fp8 storage for slot {slot!r} "
-            f"({type(pipe).__name__}); sibling lanes share the VRAM budget")
+        rung = str(getattr(pipe, "_cozy_adaptive_rung", "") or "")
+        cast_failed = getattr(
+            pipe, "_cozy_fp8_storage_requested", False
+        ) and not getattr(pipe, "_cozy_fp8_storage_ok", True)
+        if rung == RUNG_NF4_UNLANDED:
+            # pgw#824: the emergency rung ENGAGED and landed on nothing. Routed
+            # through the same SlotLoad.rung path as every sibling rung, so it
+            # reaches ServePlan/FnDegraded via `_record_adaptive_rung` instead of
+            # dying in a log line. It used to clear the stamp, which suppressed the
+            # only report the ladder had — the worst outcome was the silent one.
+            out.rung = rung
+            out.rung_detail = (
+                f"adaptive fit rung 'nf4' engaged at load for slot {slot!r} "
+                f"({type(pipe).__name__}) and landed on ZERO modules; this slot "
+                f"serves FULL PRECISION over the VRAM it was budgeted, and only "
+                f"the offload ladder carries it")
+        elif rung == "nf4" or (rung == "fp8" and not cast_failed):
+            # gw#491: the loader engaged an emergency rung because free VRAM at
+            # load was tighter than planning assumed.
+            out.rung = rung
+            out.rung_detail = (
+                f"adaptive fit rung {rung!r} engaged at load for slot {slot!r} "
+                f"({type(pipe).__name__}); free VRAM below the stored-precision "
+                "footprint")
+        elif cast_failed and not rung:
+            # th#737 backstop: the RESOLUTION cast was attempted at load and
+            # failed on every target — structural report, not a silent bf16
+            # fallback. (A failed adaptive fp8 is not a plan deviation: the plan
+            # was base precision.)
+            out.cast_fail_wanted = storage_dtype or "fp8"
+            out.cast_fail_detail = (
+                f"fp8 storage failed on every component of slot {slot!r} "
+                f"({type(pipe).__name__}); serving at base precision")
+        elif (force_storage_dtype and not rung
+              and getattr(pipe, "_cozy_fp8_storage_requested", False)
+              and getattr(pipe, "_cozy_fp8_storage_ok", True)):
+            # th#1043: a joint shared-lane fit forced fp8 storage the binding
+            # never asked for — report it structurally (FnDegraded) exactly like
+            # an adaptive rung; a silent precision downgrade lies to placement.
+            out.rung = "fp8"
+            out.rung_detail = (
+                f"joint shared-lane fit forced fp8 storage for slot {slot!r} "
+                f"({type(pipe).__name__}); sibling lanes share the VRAM budget")
 
-    # Worker-owned placement/offload policy: one decider for the whole
-    # worker; endpoints never write device/offload code. A CUDA OOM inside
-    # is a ladder transition, not a failure.
-    if device.strip().lower() != "cpu":
-        out.placed = place_pipeline(pipe, mode=mode, ref=ref, strict_vram=strict_vram)
+        # Worker-owned placement/offload policy: one decider for the whole
+        # worker; endpoints never write device/offload code. A CUDA OOM inside
+        # is a ladder transition, not a failure.
+        if device.strip().lower() != "cpu":
+            reporter.set_phase("place")
+            out.placed = place_pipeline(
+                pipe, mode=mode, ref=ref, strict_vram=strict_vram)
+    finally:
+        reporter.stop(clean=True)
     return out
 
 

--- a/src/gen_worker/postmortem.py
+++ b/src/gen_worker/postmortem.py
@@ -160,17 +160,45 @@ def _deepest(name: str) -> Optional[Path]:
     return None
 
 
-def oom_kill_count() -> int:
-    """``memory.events`` oom_kill for this cgroup (0 when unreadable).
+# ---- cgroup v1 (pgw#1041) --------------------------------------------------
+#
+# RunPod's AP-JP-1 H100 hosts (and any other cgroup-v1 fleet) mount the
+# memory controller at /sys/fs/cgroup/memory and have NO memory.max /
+# memory.current / memory.events. The attempt-4 H3 death report read
+# "memory.max=unlimited ... memory.events={}" on a container whose v1 limit
+# was 233.8GiB — the postmortem was blind on exactly the pod class that
+# OOM-kills. v1 spells the same facts differently:
+#     memory.limit_in_bytes / memory.usage_in_bytes / memory.max_usage_in_bytes
+#     memory.oom_control ("oom_kill N" line, kernel >= 4.13)
 
-    Counts kernel OOM kills in this cgroup since it was created. A delta
-    across a worker death is direct proof the kernel did it.
+_V1_MEM = _CGROUP_ROOT / "memory"
+# v1 "unlimited" territory (kernel reports ~0x7ffffffffffff000).
+_V1_UNLIMITED = 1 << 60
+
+
+def _v1_int(name: str) -> Optional[int]:
+    v = _read_int(_V1_MEM / name)
+    if v is None or not 0 <= v < _V1_UNLIMITED:
+        return None
+    return v
+
+
+def _v1_oom_control() -> Dict[str, int]:
+    return _read_keyed(_V1_MEM / "memory.oom_control")
+
+
+def oom_kill_count() -> int:
+    """Kernel OOM kills in this cgroup since creation (0 when unreadable).
+
+    v2: ``memory.events`` oom_kill; v1 fallback: the ``oom_kill`` counter in
+    ``memory.oom_control``. A delta across a worker death is direct proof
+    the kernel did it.
     """
     p = _deepest("memory.events")
-    if p is None:
-        return 0
-    events = _read_keyed(p)
-    return int(events.get("oom_kill", 0) or 0)
+    if p is not None:
+        events = _read_keyed(p)
+        return int(events.get("oom_kill", 0) or 0)
+    return int(_v1_oom_control().get("oom_kill", 0) or 0)
 
 
 def container_limits() -> Dict[str, Any]:
@@ -192,6 +220,15 @@ def container_limits() -> Dict[str, Any]:
     facts["memory_swap_max_bytes"] = _read_int(swap_max) if swap_max else None
     ev = _deepest("memory.events")
     facts["memory_events"] = _read_keyed(ev) if ev else {}
+    facts["cgroup_flavor"] = "v2" if mem_max is not None else "none"
+    if mem_max is None and (_V1_MEM / "memory.limit_in_bytes").exists():
+        # pgw#1041: v1 host — the same facts under their v1 names.
+        facts["cgroup_flavor"] = "v1"
+        facts["memory_max_bytes"] = _v1_int("memory.limit_in_bytes")
+        facts["memory_current_bytes"] = _v1_int("memory.usage_in_bytes")
+        facts["memory_peak_bytes"] = _v1_int("memory.max_usage_in_bytes")
+        facts["memory_swap_max_bytes"] = _v1_int("memory.memsw.limit_in_bytes")
+        facts["memory_events"] = _v1_oom_control()
     # pgw#975: the one fact that decides whether the pgw#763 split can report at
     # all. `memory.oom.group=1` makes the kernel kill the whole cgroup as a unit
     # — parent included — and `mem_cgroup_get_oom_group()` is consulted on the
@@ -482,6 +519,7 @@ def previous_boot_detail(path: Path = BOOT_RECORD_PATH) -> Optional[str]:
 _INFLIGHT_NAME = "gen-worker-inflight.json"
 _CRASH_REGISTRY_NAME = "gen-worker-crash-streaks.json"
 _FAULT_DUMP_NAME = "gen-worker-fault-dump.txt"
+_LOAD_PROGRESS_NAME = "gen-worker-load-progress.json"
 
 #: Signal deaths mid-flight on one function, on one pod, before the gate
 #: refuses it. 2 = one free retry for a genuinely transient fault.
@@ -531,6 +569,53 @@ def _local_marker_path(name: str) -> Path:
 INFLIGHT_PATH = _local_marker_path(_INFLIGHT_NAME)
 CRASH_REGISTRY_PATH = _sibling(_CRASH_REGISTRY_NAME)
 FAULT_DUMP_PATH = _local_marker_path(_FAULT_DUMP_NAME)
+LOAD_PROGRESS_PATH = _local_marker_path(_LOAD_PROGRESS_NAME)
+
+
+def group_load_progress_path(
+    ordinal: int, marker_dir: Optional[Path] = None,
+) -> Path:
+    return _group_marker_path(_LOAD_PROGRESS_NAME, ordinal, marker_dir)
+
+
+def write_load_progress(
+    record: Dict[str, Any], path: Optional[Path] = None,
+) -> None:
+    """pgw#1041: the load path's death breadcrumb — overwritten every
+    reporter tick, consumed by the death attribution. A SIGKILL mid-load
+    then names the phase/component and the last byte count instead of a
+    94-minute blank."""
+    path = path or LOAD_PROGRESS_PATH
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(record, default=str))
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def clear_load_progress(path: Optional[Path] = None) -> None:
+    path = path or LOAD_PROGRESS_PATH
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def take_load_progress(path: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Read and consume the last load-progress breadcrumb (None when absent)."""
+    path = path or LOAD_PROGRESS_PATH
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    clear_load_progress(path)
+    try:
+        record = json.loads(raw)
+    except ValueError:
+        return None
+    return record if isinstance(record, dict) else None
 
 _fault_dump_file: Optional[Any] = None
 
@@ -768,6 +853,7 @@ def attribute_signal_death(
     inflight_path: Optional[Path] = None,
     registry_path: Optional[Path] = None,
     dump_path: Optional[Path] = None,
+    load_progress_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Everything the post-mortem reporter can attach to a signal death:
     the in-flight markers (consumed), the fault-dump tail, and — for each
@@ -801,6 +887,12 @@ def attribute_signal_death(
     tail = fault_dump_tail(dump_path)
     if tail:
         extra["fault_dump_tail"] = tail
+    # pgw#1041: a death mid-load names the phase/component and last byte
+    # count — the difference between "SIGKILL" and "SIGKILL at
+    # hydrate:transformer, 48.2/94.3 GiB staged".
+    progress = take_load_progress(load_progress_path)
+    if progress:
+        extra["last_load_progress"] = progress
     return extra
 
 
@@ -856,27 +948,36 @@ def attribute_all_signal_deaths(
         "worker",
         marker_dir / _INFLIGHT_NAME if marker_dir is not None else INFLIGHT_PATH,
         marker_dir / _FAULT_DUMP_NAME if marker_dir is not None else FAULT_DUMP_PATH,
+        marker_dir / _LOAD_PROGRESS_NAME if marker_dir is not None
+        else LOAD_PROGRESS_PATH,
     )]
     pairs.extend(
-        (p.name, p / _INFLIGHT_NAME, p / _FAULT_DUMP_NAME)
+        (p.name, p / _INFLIGHT_NAME, p / _FAULT_DUMP_NAME,
+         p / _LOAD_PROGRESS_NAME)
         for p in _group_marker_dirs(marker_dir)
     )
     seen: set[tuple[Path, Path]] = set()
     inflight: list[Dict[str, Any]] = []
     streaks: Dict[str, int] = {}
     tails: list[str] = []
-    for label, inflight_path, dump_path in pairs:
+    progress_rows: Dict[str, Dict[str, Any]] = {}
+    for label, inflight_path, dump_path, progress_path in pairs:
         key = (inflight_path, dump_path)
         if key in seen:
             continue
         seen.add(key)
-        if not inflight_path.exists() and not dump_path.exists():
+        if not (inflight_path.exists() or dump_path.exists()
+                or progress_path.exists()):
             continue
         detail = attribute_signal_death(
             signal_name=signal_name,
             inflight_path=inflight_path,
             dump_path=dump_path,
+            load_progress_path=progress_path,
         )
+        row = detail.get("last_load_progress")
+        if isinstance(row, dict):
+            progress_rows[label] = row
         rows = detail.get("inflight")
         if isinstance(rows, list):
             inflight.extend(r for r in rows if isinstance(r, dict))
@@ -893,6 +994,11 @@ def attribute_all_signal_deaths(
         extra["native_crash_streaks"] = streaks
     if tails:
         extra["fault_dump_tail"] = "\n\n".join(tails)[-_FAULT_DUMP_TAIL_BYTES:]
+    if progress_rows:
+        extra["last_load_progress"] = (
+            progress_rows["worker"] if list(progress_rows) == ["worker"]
+            else progress_rows
+        )
     return extra
 
 
@@ -923,6 +1029,11 @@ __all__ = [
     "format_detail",
     "group_fault_dump_path",
     "group_inflight_path",
+    "group_load_progress_path",
+    "LOAD_PROGRESS_PATH",
+    "clear_load_progress",
+    "take_load_progress",
+    "write_load_progress",
     "native_crash_streaks",
     "note_inflight",
     "oom_kill_count",

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -281,6 +281,13 @@ class _ChildSlot:
             postmortem.group_fault_dump_path(group.ordinal, parent._postmortem_dir)
             if parent._topology.execution_groups > 1 else None
         )
+        # pgw#1041: the load path's breadcrumb — consumed on a signal death
+        # so a SIGKILL mid-load names its phase/component and byte counts.
+        self.load_progress_path = (
+            postmortem.group_load_progress_path(
+                group.ordinal, parent._postmortem_dir)
+            if parent._topology.execution_groups > 1 else None
+        )
 
         self.server: Optional[asyncio.AbstractServer] = None
         self.link: Optional[_ChildLink] = None
@@ -940,6 +947,7 @@ class _ChildSlot:
                     signal_name=str(verdict.get("signal_name") or ""),
                     inflight_path=self.inflight_marker_path,
                     dump_path=self.fault_dump_path,
+                    load_progress_path=self.load_progress_path,
                 ))
             except Exception:
                 logger.warning("signal-death attribution failed", exc_info=True)

--- a/tests/test_load_telemetry_pgw1041.py
+++ b/tests/test_load_telemetry_pgw1041.py
@@ -1,0 +1,206 @@
+"""pgw#1041: the load path reports progress, staging is admitted against the
+cgroup budget per component, and a SIGKILL'd load leaves a postmortem
+breadcrumb — the ie#615 attempt-4 defects (94 silent minutes, an
+unattributable kill on a cgroup-v1 host) each pinned by a test.
+
+Integration-style: the hydration tests run REAL diffusers modular pipelines
+(the pgw#1036 harness trees); the v1 postmortem tests read a real on-disk
+cgroup-v1 layout (the exact files measured on the AP-JP-1 H100 host)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from gen_worker import postmortem
+from gen_worker import progress as progress_mod
+from gen_worker.capability import (
+    HostRamCapacityError,
+    InsufficientHostRamError,
+)
+from gen_worker.models import load_progress, provision
+from gen_worker.models.loading import load_from_pretrained
+from gen_worker.models.memory import HostRam
+
+from harness.modular_endpoint import TinyModularPipeline, build_base_tree
+
+
+# ---------------------------------------------------------------------------
+# cgroup v1 postmortem (the attempt-4 blindness: memory.max=unlimited,
+# memory.events={} on a host whose v1 limit was 233.8GiB)
+# ---------------------------------------------------------------------------
+
+
+def _v1_tree(tmp_path: Path) -> Path:
+    v1 = tmp_path / "memory"
+    v1.mkdir()
+    (v1 / "memory.limit_in_bytes").write_text("250999996416\n")
+    (v1 / "memory.usage_in_bytes").write_text("250053111808\n")
+    (v1 / "memory.max_usage_in_bytes").write_text("250999996416\n")
+    (v1 / "memory.oom_control").write_text(
+        "oom_kill_disable 0\nunder_oom 0\noom_kill 3\n")
+    return v1
+
+
+def test_container_limits_v1_fallback(tmp_path, monkeypatch):
+    monkeypatch.setattr(postmortem, "_deepest", lambda name: None)
+    monkeypatch.setattr(postmortem, "_V1_MEM", _v1_tree(tmp_path))
+    limits = postmortem.container_limits()
+    assert limits["cgroup_flavor"] == "v1"
+    assert limits["memory_max_bytes"] == 250999996416
+    assert limits["memory_current_bytes"] == 250053111808
+    assert limits["memory_peak_bytes"] == 250999996416
+    assert limits["memory_events"]["oom_kill"] == 3
+
+
+def test_oom_kill_count_v1(tmp_path, monkeypatch):
+    monkeypatch.setattr(postmortem, "_deepest", lambda name: None)
+    monkeypatch.setattr(postmortem, "_V1_MEM", _v1_tree(tmp_path))
+    assert postmortem.oom_kill_count() == 3
+
+
+def test_v1_unlimited_sentinel_reads_none(tmp_path, monkeypatch):
+    v1 = tmp_path / "memory"
+    v1.mkdir()
+    (v1 / "memory.limit_in_bytes").write_text("9223372036854771712\n")
+    monkeypatch.setattr(postmortem, "_deepest", lambda name: None)
+    monkeypatch.setattr(postmortem, "_V1_MEM", v1)
+    limits = postmortem.container_limits()
+    assert limits["cgroup_flavor"] == "v1"
+    assert limits["memory_max_bytes"] is None
+
+
+def test_format_detail_names_v1_oom(tmp_path, monkeypatch):
+    """The attempt-4 report said 'memory.max=unlimited memory.events={}';
+    on the same host the v1 fallback must name the ceiling and the kill."""
+    monkeypatch.setattr(postmortem, "_deepest", lambda name: None)
+    monkeypatch.setattr(postmortem, "_V1_MEM", _v1_tree(tmp_path))
+    detail = postmortem.format_detail(
+        phase="compute_process_exit",
+        verdict={"signaled": True, "signal": 9, "signal_name": "SIGKILL",
+                 "exit_code": 137},
+        limits=postmortem.container_limits(),
+        oom_kill_delta=1,
+    )
+    assert "memory.max=233.76GiB" in detail
+    assert "THE KERNEL OOM-KILLED US" in detail
+
+
+# ---------------------------------------------------------------------------
+# load-progress breadcrumbs + counter
+# ---------------------------------------------------------------------------
+
+
+def test_reporter_ticks_counter_and_breadcrumb(tmp_path):
+    marker = tmp_path / "load-progress.json"
+    rep = load_progress.LoadProgressReporter(
+        "pipeline:test/ref", 1000, marker_path=marker, interval_s=0.2)
+    rep.start()
+    try:
+        rep.set_phase("hydrate:unet")
+        time.sleep(0.5)
+        record = json.loads(marker.read_text())
+        assert record["phase"] == "hydrate:unet"
+        assert record["label"] == "pipeline:test/ref"
+        assert record["staged_bytes"] >= 0
+        snaps = {s.name: s for s in progress_mod.snapshot()}
+        assert load_progress.COUNTER_NAME in snaps
+    finally:
+        rep.stop(clean=True)
+    assert not marker.exists()
+    assert load_progress.COUNTER_NAME not in {
+        s.name for s in progress_mod.snapshot()}
+
+
+def test_unclean_stop_leaves_breadcrumb_for_death_attribution(tmp_path):
+    marker = tmp_path / "load-progress.json"
+    rep = load_progress.LoadProgressReporter(
+        "pipeline:test/ref", 1000, marker_path=marker, interval_s=0.2)
+    rep.start()
+    rep.set_phase("hydrate:transformer")
+    rep.stop(clean=False)
+    assert marker.exists()
+
+    extra = postmortem.attribute_signal_death(
+        signal_name="SIGKILL",
+        inflight_path=tmp_path / "no-inflight.json",
+        registry_path=tmp_path / "no-registry.json",
+        dump_path=tmp_path / "no-dump.txt",
+        load_progress_path=marker,
+    )
+    assert extra["last_load_progress"]["phase"] == "hydrate:transformer"
+    assert not marker.exists()  # consumed
+
+
+# ---------------------------------------------------------------------------
+# per-component staging admission (pgw#1026's minimal per-stage form)
+# ---------------------------------------------------------------------------
+
+
+def _ram(total_gb: float, available_gb: float) -> HostRam:
+    return HostRam(
+        total_gb=total_gb, available_gb=available_gb,
+        meminfo_total_gb=total_gb, meminfo_available_gb=available_gb,
+        cgroup_limit_gb=total_gb, source="cgroup",
+    )
+
+
+def test_component_admission_refuses_transient(tmp_path, monkeypatch):
+    """A component that cannot fit CURRENT headroom refuses typed with the
+    measured numbers instead of dying silently to the kernel."""
+    from gen_worker.models import loading as loading_mod
+
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    monkeypatch.setattr(
+        loading_mod, "probe_host_ram", lambda: _ram(64.0, 0.001))
+    with pytest.raises(InsufficientHostRamError) as exc:
+        load_from_pretrained(TinyModularPipeline, tree)
+    assert "modular component" in str(exc.value)
+    assert exc.value.required_bytes > exc.value.available_before_bytes
+
+
+def test_component_admission_refuses_structural(tmp_path, monkeypatch):
+    """A component bigger than the whole cgroup is the pgw#752 hardware
+    verdict (disable the function here), not a retry."""
+    from gen_worker.models import loading as loading_mod
+
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    monkeypatch.setattr(
+        loading_mod, "probe_host_ram", lambda: _ram(2.0, 2.0))
+    monkeypatch.setattr(
+        loading_mod.disk_gc, "tree_bytes", lambda p: 10 * 1024**3)
+    with pytest.raises(HostRamCapacityError):
+        load_from_pretrained(TinyModularPipeline, tree)
+
+
+def test_hydration_reports_per_component_phases(tmp_path, monkeypatch):
+    """The 94-minute black box: hydration must announce each component."""
+    from gen_worker.models import loading as loading_mod
+
+    phases: list[str] = []
+    monkeypatch.setattr(
+        loading_mod.load_progress, "set_phase",
+        lambda phase: phases.append(phase))
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe = load_from_pretrained(TinyModularPipeline, tree)
+    assert pipe.unet is not None
+    hydrated = [p.split(":", 1)[1] for p in phases if p.startswith("hydrate:")]
+    assert "unet" in hydrated and "vae" in hydrated
+
+
+def test_load_slot_clears_breadcrumb_on_success(tmp_path, monkeypatch):
+    marker_dir = tmp_path / "markers"
+    marker_dir.mkdir()
+    marker = marker_dir / "load-progress.json"
+    monkeypatch.setattr(postmortem, "LOAD_PROGRESS_PATH", marker)
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    sl = provision.load_slot(
+        TinyModularPipeline, str(tree), slot="pipeline",
+        ref="test/tiny:latest", mode="auto", device="cpu")
+    assert sl.obj is not None
+    assert not marker.exists()
+    assert load_progress.COUNTER_NAME not in {
+        s.name for s in progress_mod.snapshot()}


### PR DESCRIPTION
pgw#1041 (P0 for ie#615): the request-path model load ran 94 minutes with zero
telemetry and died to an unattributable SIGKILL. Diagnosed on an instrumented
same-SKU pod (evidence: `~/cozy/samples/pgw1041-diagnosis-20260809/`), then
fixed per proven defect — the issue's three boxes plus one admission
under-count found on the way.

## Diagnosis (measured, not guessed)

- The AP-JP-1 H100 hosts are **cgroup v1** (2 TiB host meminfo, container
  limit `memory.limit_in_bytes = 233.8 GiB`). `postmortem.py` read only v2
  files, so attempt 4's death dial said `memory.max=unlimited
  memory.events={} cgroup_oom_kill_delta=0` while the v1 limit and the
  `memory.oom_control` oom_kill counter were readable the whole time.
- Fetch is exonerated: attempt 4's own stderr ring shows
  `ensure_blobs_summary network_bytes=0 cache_hit_pct=100` 45 s after
  dispatch. The 94 minutes were hydration + placement.
- The whole-composition load runs the cgroup **at its ceiling**: the repro
  measured `max_usage_in_bytes == limit_in_bytes` exactly (250.05/251.0 GB,
  RssAnon 180 GB + RssFile 60 GB) — staged anon and the tree's own page
  cache share one limit, every further read faults through direct reclaim
  (the crawl), and CUDA placement's pinned pages land on top (the kill).
- No progress producer existed on the load path: `progress.py` has had a
  240 s `load` stall window since gw#621 with nothing feeding it; the hub
  row for `self_mint_compile/load` carries `counter=''` for all 94 minutes.

## The fix

1. **Load-progress heartbeats** — `models/load_progress.py`:
   `LoadProgressReporter` samples `/proc/self/io` + RssAnon while
   `provision.load_slot` blocks and feeds the existing 10s activity beat a
   `load:staged_bytes` counter (no parallel channel; WORKER-CONTRACTS §1).
   The fetch path's byte ticks also ride an activity counter
   (`download:bytes`). Modular hydration announces per-component phases.
2. **Cgroup-aware staging admission, per component** — modular hydration
   loads ONE component at a time, admission-checks each against the
   cgroup budget (`probe_host_ram`, v1+v2) before staging, and chills the
   component's page cache after it lands (`disk_gc.reclaim_file_cache`).
   This is pgw#1026's minimal per-stage form on the modular lane — noted
   there. Refusals are the typed pgw#752 pair with measured numbers.
   Also: `_ensure_host_ram_for` now counts a component override's own
   materialized tree (it under-admitted H3 by the fp8 encoder's 27.6 GB).
3. **SIGKILL postmortem** — `postmortem.py` speaks cgroup v1
   (limit/usage/max_usage + `memory.oom_control` oom_kill), so a v1 OOM
   kill classifies as `cause=oom`; the reporter's breadcrumb file is
   consumed by the parent's death attribution as `last_load_progress`
   (phase/component + byte counts), surviving only kernel kills — a
   Python-level failure clears it because it reports itself.

## Tests

- 10 new integration-style tests (`tests/test_load_telemetry_pgw1041.py`):
  real cgroup-v1 file layouts (the exact values measured on the AP-JP-1
  host), real diffusers modular pipelines for the per-component loop,
  typed refusals both transient and structural, breadcrumb lifecycle
  through `attribute_signal_death`.
- Full suites green locally (3648+ passed; 3 pre-existing procsplit
  parallel-run flakes pass serially).
- Live two-arm validation on a rented H100 (stock 0.95.0 vs this patch,
  same trees, same SKU): see the PR thread / tracker for the banked logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
