### PR TITLE
pgw#1042: the delegated handback — env_seal leak sealed, key seam guarded, per-entry constant-copy OOM ended

### DIFF
--- a/changelog.d/pgw1042.md
+++ b/changelog.d/pgw1042.md
@@ -1,0 +1,41 @@
+- **pgw#1042: the delegated handback — the two failures behind attempt 28's
+  "36/36 minted, nothing published", both fixed at their source.** The pod's
+  "parent/child cell-key divergence" decomposes into a definitional half and a
+  real one. Definitional: the parent's `self_mint_started` key is the COMPUTED
+  arm identity and the child returns the STAMPED cell identity — disjoint
+  spaces by formula (pgw#1032/#1033) — and one unlabeled `key=` presenting
+  both is what read as a divergence; the self-mint events now label
+  `arm_key=` and `cell_key=` separately. Real: `torch._inductor.aot_compile`
+  mutates the global `aot_inductor.metadata` config entry as a side effect
+  (machine facts: `AOTI_CPU_ISA`, `AOTI_COMPUTE_CAPABILITY`, ...), and
+  `save_config_portable()` includes it — so a child that has compiled seals a
+  DIFFERENT `env_seal` than its own boot and than every other process,
+  fracturing stamped identity per host CPU. `inductor_config_digest` now
+  excludes that torch-owned output (`_PORTABLE_VOLATILE`); `SEAL_VERSION`
+  2 -> 3, re-key cost zero (no cell was ever published under v2).
+  **`adopt_delegated_mint` now guards the seam**: `PendingSelfMint` carries
+  the full computed `arm_key`, and a child cell whose envelope diverges from
+  it on any SHARED axis (family, format, lane, sm, env_seal, toolchain)
+  refuses typed `key_axis_divergence`, naming the axis and both values,
+  before any arm runs.
+- **pgw#1042: the constants-injection failure is a VRAM multiplication, fixed,
+  and the failure class is typed.** `update_constant_buffer_func_(...) API
+  call failed at model_container_runner.cpp:289` reproduced locally
+  byte-for-byte: the copying bind (pgw#812 D3, priced at "one duplicate of
+  the weights") allocates the target's FULL constant set once per ENTRY under
+  pgw#758's multi-graph cells, and `load_and_wrap` binds all entries up
+  front — a 36-entry sdxl w8a8 cell demands ~N x 2.6 GB at arm and the
+  failing cudaMalloc surfaces as that anonymous C++ error (its real message
+  goes to a stderr no pod exposes). Entries now bind BY REFERENCE
+  (`user_managed=True`) against ONE marker-owned clone pool per target
+  (`aot_serve.target_constant_pool`) — D3's stated cost restored, whatever
+  the entry count — and any residual AOTI failure raises a typed
+  `ConstantsUnboundError("injection_failed", ...)` carrying the entry, the
+  constants' size and the card's live free/total.
+- **pgw#1042: the rig gap that hid both.** The gauntlet only ever adopted in
+  a fresh second process; the pod fails in the mint-opening PARENT. The rig
+  now seals its parent process exactly as a worker boot does
+  (`env_seal.establish()`) and runs a `handback` leg between mint-child and
+  publish — the real `fleet_cells.adopt_delegated_mint` on the parent's own
+  pipeline, pod order — for every micro-diffusion vehicle, including
+  `micro-w8a8-lora`, the exact `w8a8-lora64` lane string that failed.

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -350,6 +350,15 @@ def run_cycle(
                   f"covers={dev['covers']}")
     result.env = leg.facts
 
+    # pgw#1042: the rig parent seals exactly as a worker boot does. Without
+    # this the parent's computed key axes (env_seal above all) describe an
+    # UN-established process no pod ever runs, and the handback leg's
+    # axis guard would refuse every healthy mint.
+    from gen_worker import env_seal as _env_seal
+
+    _env_seal.establish()
+    leg.facts["env_seal"] = _env_seal.seal_digest(_env_seal.effective_seal())
+
     # -- weights -------------------------------------------------------------
     from harness.tiny_diffusion import SYNTHETIC_RUNTIME_ENV
 
@@ -462,6 +471,78 @@ def run_cycle(
     if stage == "mint":
         result.total_s = time.monotonic() - t0
         return result
+
+    # -- the handback (pgw#1042): the parent adopts its OWN child's cell -----
+    # The pod order: `adopt_delegated_mint` on the mint-opening parent's live
+    # pipeline runs BEFORE anything publishes (gw#612 — only a cell that can
+    # arm ships). The gauntlet ran green for months while this exact leg was
+    # failing on every sdxl pod, because the rig only ever adopted in a fresh
+    # SECOND process.
+    if veh.parent_pipe is not None:
+        import gc
+
+        from gen_worker import aot_serve as _aserve
+        from gen_worker import cell_key as _ck
+        from gen_worker import compile_cache as _cc
+        from gen_worker import fleet_cells as _fc
+        from gen_worker.models import loading as _loading
+
+        leg = result.add(Leg("handback"))
+        g0 = time.monotonic()
+        if dev["device_kind"] != "cuda":
+            # The parent must state the same supplied runtime the child
+            # sealed under, or the axis guard would refuse a cardless cycle
+            # on `sm` — the same rule both child processes already follow.
+            os.environ[SYNTHETIC_RUNTIME_ENV] = "1"
+            from harness.tiny_diffusion import install_synthetic_runtime_if_asked
+
+            install_synthetic_runtime_if_asked()
+        hb_root = root / "handback"
+        hb_root.mkdir(parents=True, exist_ok=True)
+        hb_artifact = hb_root / "cell.tar.gz"
+        shutil.copy2(str(outcome.artifact), hb_artifact)
+        pipe, hb_cfg = veh.parent_pipe(
+            tree, "cuda" if dev["device_kind"] == "cuda" else "cpu")
+        bucket = int(getattr(hb_cfg, "lora_bucket", 0) or 0)
+        arm = _ck.compute(
+            veh.family, _loading.pipeline_weight_lane(pipe), bucket,
+            contract=_ck.contract_digest(_cc.declared_contract_facts(hb_cfg)),
+            regional=bool(getattr(hb_cfg, "regional", False)))
+        (hb_root / "mint-root").mkdir(exist_ok=True)
+        pending = _fc.PendingSelfMint(
+            family=veh.family, cell_key=arm.digest,
+            ref=f"{_cc.system_repo(veh.family)}#{arm.digest}",
+            cfg=hb_cfg, target=hb_root / "adopted.tar.gz",
+            mint_root=hb_root / "mint-root", publisher=None,
+            cache_dir=hb_root / "cache", arm_key=arm)
+        minted = _fc.adopt_delegated_mint(pipe, pending, hb_artifact)
+        leg.seconds = time.monotonic() - g0
+        reason, why = _fc.adopt_refusal(pending)
+        leg.ok = minted is not None
+        leg.facts = {
+            "arm_key": arm.digest,
+            "cell_key": str(getattr(minted, "cell_key", "") or ""),
+            "arm_reason": reason,
+            "detail": (why or "")[:400],
+        }
+        leg.detail = (
+            f"parent adopted {leg.facts['cell_key'][:20]} "
+            f"(arm_key={arm.digest[:20]})" if leg.ok
+            else f"{reason}: {(why or '')[:200]}")
+        # Return the VRAM before the publish/adopt legs need it.
+        _aserve.unwrap(pipe)
+        del pipe
+        gc.collect()
+        try:
+            import torch as _torch
+
+            if _torch.cuda.is_available():
+                _torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 — cleanup only
+            pass
+        if not leg.ok:
+            result.total_s = time.monotonic() - t0
+            return result
 
     # -- publish -------------------------------------------------------------
     from harness.cell_hub import LocalCellHub

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -1494,6 +1494,67 @@ def resolve_constants(
     return out
 
 
+def _tensor_bytes(values: Iterable[Any]) -> int:
+    total = 0
+    for v in values:
+        try:
+            total += int(v.numel()) * int(v.element_size())
+        except Exception:  # noqa: BLE001 — sizing is context, never a gate
+            continue
+    return total
+
+
+def _device_memory_line() -> str:
+    """One human line of live device memory for a typed refusal."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return "device=cpu"
+        free, total = torch.cuda.mem_get_info()
+        return (f"device free {free / (1 << 20):.0f} MiB of "
+                f"{total / (1 << 20):.0f} MiB")
+    except Exception:  # noqa: BLE001 — context, never a gate
+        return "device=unknown"
+
+
+def target_constant_pool(
+    entry_constants: Iterable[Sequence[ConstantSpec]],
+    state_dict: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """ONE owned device copy of a target's state_dict-sourced constants,
+    shared by every entry that binds against it (pgw#1042).
+
+    pgw#812 D3 priced the whole-graph copying bind at "one duplicate of the
+    weights" — true per RUNNER, and pgw#758's multi-graph cells silently made
+    it one duplicate per ENTRY: `load_and_wrap` binds every entry before any
+    wrap, so an N-entry cell demanded N x the target's constants in device
+    memory at arm time. On sdxl w8a8-lora64 (36 entries, ~GBs per UNet entry)
+    that is more VRAM than the card has, and the failing cudaMalloc surfaced
+    as the anonymous `model_container_runner.cpp:289` API failure that killed
+    the pgw#868 A1 publish twice.
+
+    The pool restores D3's stated cost: entries bind BY REFERENCE
+    (``user_managed=True``) against clones owned by the arm marker, so the
+    artifact still never aliases resident weights (a post-arm resident
+    mutation cannot silently change an armed cell) and the whole cell costs
+    ONE duplicate per target, whatever its entry count.
+    """
+    out: Dict[str, Any] = {}
+    for specs in entry_constants:
+        for spec in specs:
+            if spec.source != SOURCE_STATE_DICT or spec.fqn in out:
+                continue
+            value = state_dict.get(spec.fqn)
+            if value is None:
+                continue  # resolve_constants names the miss, typed, per entry
+            try:
+                out[spec.fqn] = value.detach().clone()
+            except Exception:  # noqa: BLE001 — duck-typed rigs hand non-tensors
+                out[spec.fqn] = value
+    return out
+
+
 def assert_bindable(
     specs: Sequence[ConstantSpec], runner_fqns: Iterable[str],
 ) -> None:
@@ -1568,15 +1629,14 @@ class ArtifactRunner:
 
         ``user_managed=True`` binds BY REFERENCE (pgw#812 D3): the artifact
         keeps pointers to the caller's tensors instead of copying them into
-        its own constant buffer. The default False is right for a whole-graph
-        cell — one duplicate of the weights, and the artifact owns its own
-        lifetime. It is FATAL for a regional cell: N block instances each
-        load their own runner, so a copying bind means N copies of that
-        block's weights in VRAM (flux2: a second whole model). The caller
-        that passes True is asserting that the tensors outlive this runner —
-        which for a regional arm holds by construction, because the values
-        come from the resident pipeline's own ``state_dict`` and the shim
-        that calls the runner is installed ON that module.
+        its own constant buffer. A copying bind is one duplicate of the
+        weights PER RUNNER — and pgw#758's multi-graph cells bind every
+        entry up front, so an N-entry cell paid N duplicates and OOM'd the
+        sdxl arm (pgw#1042). The whole-graph arm therefore binds by
+        reference against ONE marker-owned pool per target
+        (:func:`target_constant_pool`). The caller that passes True is
+        asserting that the tensors outlive this runner — the pool rides the
+        arm marker for exactly that reason.
         """
         try:
             table = self.package.get_constant_fqns()
@@ -1612,26 +1672,46 @@ class ArtifactRunner:
         # and binding (they are derived), not to loosen this gate.
         #
         # pgw#817/D3: `user_managed` is passed only when asked for, so the
-        # whole-graph path's call shape is byte-identical to what pgw#721/#723
+        # copying path's call shape is byte-identical to what pgw#721/#723
         # measured on a pod. A torch whose `load_constants` has no such
-        # parameter is a NAMED refusal rather than a silent copy — a regional
-        # arm that silently copied would OOM the card N blocks later, which is
-        # a far worse way to learn the same fact.
-        if user_managed:
-            try:
-                self.package.load_constants(
-                    values, check_full_update=True, user_managed=True)
-            except TypeError as exc:
-                if "user_managed" not in str(exc):
-                    raise
-                raise ConstantsUnboundError(
-                    "user_managed_unsupported",
-                    f"this torch's load_constants has no user_managed "
-                    f"parameter, so every constant would be COPIED — for a "
-                    f"regional cell that is one copy of the block weights per "
-                    f"instance ({type(exc).__name__}: {exc})") from exc
-        else:
-            self.package.load_constants(values, check_full_update=True)
+        # parameter is a NAMED refusal rather than a silent copy — a caller
+        # that asked for by-reference and silently copied would OOM the card
+        # N binds later, which is a far worse way to learn the same fact.
+        #
+        # pgw#1042: the residual C++ failure is CLASSIFIED. The pod's 36/36
+        # sdxl mint died at publish as an anonymous `RuntimeError:
+        # update_constant_buffer_func_(...) API call failed at
+        # model_container_runner.cpp:289` — the real message (a cudaMalloc
+        # OOM from per-entry constant copies) went to a stderr no pod
+        # exposes. Every failure inside the AOTI update is now a typed
+        # ConstantsUnboundError carrying the entry, the constants' size and
+        # the card's live free/total, so the hub row names the failure class.
+        try:
+            if user_managed:
+                try:
+                    self.package.load_constants(
+                        values, check_full_update=True, user_managed=True)
+                except TypeError as exc:
+                    if "user_managed" not in str(exc):
+                        raise
+                    raise ConstantsUnboundError(
+                        "user_managed_unsupported",
+                        f"this torch's load_constants has no user_managed "
+                        f"parameter, so every constant would be COPIED — one "
+                        f"copy of the target weights per bound entry "
+                        f"({type(exc).__name__}: {exc})") from exc
+            else:
+                self.package.load_constants(values, check_full_update=True)
+        except (ConstantsUnboundError, TypeError):
+            raise
+        except RuntimeError as exc:
+            raise ConstantsUnboundError(
+                "injection_failed",
+                f"entry {self.entry or self.module_name or 'unknown'}: the "
+                f"artifact refused the constant update inside AOTI "
+                f"({type(exc).__name__}: {exc}); {len(values)} constants, "
+                f"{_tensor_bytes(values.values()) / (1 << 20):.0f} MiB, "
+                f"{_device_memory_line()}") from exc
         self.user_managed = bool(user_managed)
         self.bound_fqns = tuple(sorted(values))
         self.bound = True
@@ -2232,12 +2312,20 @@ def load_and_wrap(
                 raise AdoptError("contract_invalid", str(exc)) from exc
 
         # Load + bind EVERY entry before the first live mutation.
+        #
+        # pgw#1042: entries bind BY REFERENCE against ONE owned pool per
+        # target (see target_constant_pool) — the per-entry copying bind
+        # multiplied the target's constants by its entry count and OOM'd the
+        # sdxl w8a8-lora64 arm on a 48 GB card. The pools (and the literal
+        # tensors) are stored on the marker below: user_managed containers
+        # hold raw pointers, so the bound values must outlive the runners.
         dispatches: Dict[str, EntryDispatch] = {}
+        pools: Dict[str, Dict[str, Any]] = {}
         total_constants = 0
         for target, rows in groups.items():
             module, _attr = owners[target]
             state_dict = resident_constants(module)
-            runners: List[Tuple[str, ArtifactRunner]] = []
+            parsed: List[Tuple[str, Any, Tuple[ConstantSpec, ...]]] = []
             for name, block in rows:
                 try:
                     contract = contract_from_meta(block)
@@ -2248,12 +2336,19 @@ def load_and_wrap(
                 except ValueError as exc:
                     raise AdoptError(
                         "contract_invalid", f"entry {name!r}: {exc}") from exc
+                parsed.append((name, contract, constants))
+            pool = target_constant_pool(
+                (constants for _n, _c, constants in parsed), state_dict)
+            pools[target] = pool
+            runners: List[Tuple[str, ArtifactRunner]] = []
+            for name, contract, constants in parsed:
                 package = _load_package(staged.root / PACKAGE_NAME, name)
                 runner = ArtifactRunner(
                     package=package, contract=contract, constants=constants,
                     module_name=target, entry=name, family=family)
                 try:
-                    runner.bind(state_dict, literals_by_entry.get(name, {}))
+                    runner.bind(pool, literals_by_entry.get(name, {}),
+                                user_managed=True)
                 except ConstantsUnboundError as exc:
                     raise AdoptError(
                         f"constants_{exc.reason}",
@@ -2277,7 +2372,15 @@ def load_and_wrap(
                 "attr": attr,
                 "state": module_marker.get("state", {}),
             }
-        setattr(pipeline, _MARKER_ATTR, {"meta": meta, "targets": target_rows})
+        # `bound_constants` is LIFETIME, not bookkeeping (pgw#1042): every
+        # runner bound user_managed, so the containers hold raw pointers into
+        # these pools and literal tensors. They live exactly as long as the
+        # arm — unwrap drops the marker and the device memory with it.
+        setattr(pipeline, _MARKER_ATTR, {
+            "meta": meta, "targets": target_rows,
+            "bound_constants": {
+                "pools": pools, "literals": literals_by_entry},
+        })
         logger.info(
             "aot-serve: loaded+bound %d entr%s across %d target(s) in %.1fs "
             "(%d declared constants, combined_graph_hash=%s)",
@@ -2566,6 +2669,7 @@ __all__ = [
     "set_ingress_refusal_callback",
     "report_ingress_refusal",
     "split_literals",
+    "target_constant_pool",
     "torch_version",
     "unpack",
     "unpack_metadata",

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -78,7 +78,11 @@ logger = logging.getLogger(__name__)
 # is a fleet-wide recall, and a recall is a recorded operator intent with an
 # actor and a reason, which an env var on a pod is not. The hub's
 # `cell_revocations` (th#1499) is where a recall lives.
-SEAL_VERSION = 2
+#
+# pgw#1042 bumped 2 -> 3 by EXCLUDING torch's compile-injected
+# `aot_inductor.metadata` from the inductor fact (see _PORTABLE_VOLATILE).
+# RE-KEY COST: zero — no cell has ever been published under v2.
+SEAL_VERSION = 3
 SEAL_KEY = "env_seal"
 
 # Behavior-affecting global flags: ONE canonical value each, set explicitly
@@ -233,16 +237,27 @@ def establish_config(
     return effective
 
 
+# Config entries torch MUTATES as a compile side effect — outputs, not knobs.
+# `torch._inductor.aot_compile` writes machine facts (AOTI_CPU_ISA,
+# AOTI_COMPUTE_CAPABILITY, ...) into the global `aot_inductor.metadata` and
+# `save_config_portable()` includes it, so a process that has compiled digests
+# differently from its own boot — the pgw#1042 parent/child seal divergence.
+_PORTABLE_VOLATILE = ("aot_inductor.metadata",)
+
+
 def inductor_config_digest() -> str:
     """Digest of torch's PORTABLE inductor config — the codegen surface a
     cell's kernels were minted under (machine-specific entries excluded by
-    torch itself). ``"absent"`` on a torchless worker (pgw#788) — a declared
+    torch itself, torch's own compile-side-effect entries excluded here:
+    pgw#1042). ``"absent"`` on a torchless worker (pgw#788) — a declared
     fact, so the seal digest stays meaningful for CPU cells."""
     if not torch_capability.present():
         return torch_capability.ABSENT
     import torch._inductor.config as inductor_config
 
-    portable = inductor_config.save_config_portable()
+    portable = dict(inductor_config.save_config_portable())
+    for key in _PORTABLE_VOLATILE:
+        portable.pop(key, None)
     encoded = json.dumps(
         portable, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
         default=str,

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -58,7 +58,11 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 
 from . import activity as activity_mod
-from . import aot_cells, aot_serve, artifact_meta, cell_key
+from . import aot_cells, aot_serve, artifact_meta, cell_key, env_seal
+# Class import beside the module import: inside `PendingSelfMint` the field
+# named `cell_key` shadows the module, so the `arm_key` annotation needs the
+# class under its own name.
+from .cell_key import CellKey
 from . import boot_phases as boot_mod
 from . import compile_cache as cc
 from .cell_adopt import AdoptOutcome, CellAdoption, EagerPhase
@@ -139,6 +143,13 @@ class PendingSelfMint:
     mint_root: Path
     publisher: Optional["CellPublisher"]
     cache_dir: Optional[Path] = None
+    #: pgw#1042: the parent's computed ARM identity, axes and all. The
+    #: stamped key the child returns lives in a DISJOINT space (kind +
+    #: contract differ by formula — pgw#1032/#1033), but every axis the two
+    #: keys share (family, format, lane, sm, env_seal, toolchain) must be
+    #: byte-identical across the process boundary, and
+    #: ``adopt_delegated_mint`` refuses BY AXIS NAME when one is not.
+    arm_key: Optional[CellKey] = None
     #: pgw#784: this mint is built by a CHILD PROCESS, so the live pipeline
     #: was never armed and this process holds no capture. The live pipe stays
     #: plain eager until ``adopt_delegated_mint`` swaps it through the
@@ -1216,12 +1227,13 @@ def _arming_policy(
     # is known BEFORE any compile has happened.
 
     try:
-        key = cell_key.compute(
+        arm_key = cell_key.compute(
             family, loading.pipeline_weight_lane(pipe), bucket,
             contract=cell_key.contract_digest(
                 cc.declared_contract_facts(cfg)),
             regional=bool(getattr(cfg, "regional", False)),
-        ).digest
+        )
+        key = arm_key.digest
     except Exception as exc:  # noqa: BLE001 — key axes must be computable
         logger.warning("fleet-cells: self-mint key computation failed (%s)", exc)
         if bucket:
@@ -1325,6 +1337,7 @@ def _arming_policy(
         ref=f"{cc.system_repo(family)}#{key}",
         cfg=cfg, target=target,
         mint_root=mint_root, publisher=publisher, cache_dir=cache_dir,
+        arm_key=arm_key,
     )
     with _PENDING_LOCK:
         _PENDING.setdefault(key, pending)
@@ -1334,7 +1347,11 @@ def _arming_policy(
         "(pgw#784/#805)", recipe, family, key)
     activity_mod.emit_event(
         "self_mint_started",
-        f"family={family} recipe={recipe} key={key} "
+        # pgw#1042: labeled `arm_key` — the cell the child returns carries a
+        # STAMPED key in a disjoint space (kind/contract differ by formula),
+        # so an unlabeled `key=` here invited reading the two as one
+        # diverging key.
+        f"family={family} recipe={recipe} arm_key={key} "
         f"lane={loading.pipeline_weight_lane(pipe) or 'plain'}: a "
         f"compile-cell miss opened a delegated mint; this worker serves "
         f"eager throughout",
@@ -1353,6 +1370,45 @@ def _arming_policy(
 def _packed_metadata(artifact: Path) -> Dict[str, Any]:
     """The stamped metadata inside a packed cell (metadata members only)."""
     return artifact_meta.read_metadata(artifact)
+
+
+#: The key axes the computed ARM identity and the stamped cell identity
+#: SHARE. `kind` and `contract` are disjoint by formula (pgw#1032/#1033:
+#: kind "inductor" vs "aot-inductor", declared-facts digest vs traced-graph
+#: facts digest) and `mode` is "" on both sides of a whole-graph mint.
+_SHARED_KEY_AXES = ("family", "format", "lane", "sm", "env_seal", "toolchain")
+
+
+def arm_axis_divergence(
+    arm_key: CellKey, meta: Mapping[str, Any],
+) -> str:
+    """'' when the child's envelope states the parent's identity on every
+    shared axis, else the FIRST diverging axis with both values (pgw#1042).
+
+    A delegated child re-derives every environment-shaped axis in its own
+    process, so an axis that fails to survive the boundary (the measured
+    case: torch's `aot_compile` mutating global inductor config between the
+    child's establish and its metadata assembly) previously surfaced only as
+    a downstream numerics or constants error on a $3 pod. Here it is refused
+    BY NAME at the handback seam.
+    """
+    child: Dict[str, str] = {
+        "family": str(meta.get("family") or ""),
+        "format": str(meta.get("format") or ""),
+        "lane": cc.execution_lane_label(
+            str(meta.get("weight_lane") or ""),
+            int(meta.get("lora_bucket") or 0)),
+        "sm": str(meta.get("sm") or ""),
+        "env_seal": env_seal.seal_digest(
+            dict(meta.get(env_seal.SEAL_KEY) or {})),
+        "toolchain": cell_key.facts_digest(dict(meta.get("toolchain") or {})),
+    }
+    parent = arm_key.axes_dict()
+    for axis in _SHARED_KEY_AXES:
+        if parent.get(axis, "") != child.get(axis, ""):
+            return (f"{axis}: child cell states {child.get(axis, '')!r}, "
+                    f"this runtime computed {parent.get(axis, '')!r}")
+    return ""
 
 
 def adopt_delegated_mint(
@@ -1386,48 +1442,64 @@ def adopt_delegated_mint(
     # forgets to classify is visible on the wire as a gap in this function
     # instead of as an empty string that reads like "no reason exists".
     refusal: Tuple[str, str] = ("unclassified_arm_refusal", "")
-    try:
-        # pgw#805: an exported cell arms through the AOT gates (lifted-binding
-        # install -> aot_serve.enable -> rollback), not the inductor seed path.
-        # Same gates a hub-delivered `.pt2` passes; `provision.enable_compiled`
-        # itself is not reusable here because its pgw#709 receipts gate would
-        # drop a cell this pod minted seconds ago and the hub has not
-        # countersigned yet.
-        # pgw#999: the outcome is KEPT. `arm_aot` returns a classified
-        # `AdoptOutcome` (`contract_invalid`, `constants_unbound`,
-        # `no_arm_for_mode`, `numerics_refused`, …) and this call site
-        # used to spend it on `bool(...)`. That discard cost attempt 26
-        # 2 h 45 m and $2.72: a 36/36 mint sealed, finalized, and was then
-        # refused by three events that all said "could not adopt".
-        # pgw#1010: there is no second branch — a delegated mint is an AOT
-        # mint, and the inductor-seed adopt it used to fall back to armed an
-        # artifact class nothing publishes any more.
-        outcome = provision.arm_aot(
-            pipe, pending.cfg, pending.cache_dir, pending.target,
-            int(getattr(pending.cfg, "lora_bucket", 0) or 0))
-        armed = bool(outcome)
-        if not armed:
-            refusal = (outcome.reason or "unclassified_arm_refusal",
-                       outcome.detail or outcome.identity)
-    except cc.CellSelectionBugError as exc:
-        # th#883, delegated edition: the child's own cell, whose axes describe
-        # exactly this runtime, refused to arm. Loud — it is a bug in the one
-        # selection brain, not a compatibility miss.
-        logger.error(
-            "fleet-cells: cell_selection_bug adopting this pod's DELEGATED "
-            "mint (family=%s key=%s): %s",
-            pending.family, pending.cell_key, exc)
+    # pgw#1042: BEFORE any arm, the child's cell must state this parent's
+    # identity on every axis the two key spaces share. A malformed envelope
+    # is left to the arm's own classified refusal (artifact_invalid).
+    meta = artifact_meta.try_read_metadata(pending.target)
+    divergence = ""
+    if meta is not None and pending.arm_key is not None:
+        divergence = arm_axis_divergence(pending.arm_key, meta)
+    if divergence:
         armed = False
-        refusal = ("cell_selection_bug", str(exc))
-    except Exception as exc:  # noqa: BLE001 — adoption failure => eager
-        logger.warning(
-            "fleet-cells: delegated mint for %s did not adopt (%s)",
-            pending.family, exc)
-        armed = False
-        # An `AdoptError` already carries the token; anything else is named by
-        # its type rather than flattened into one word nobody can count.
-        refusal = (str(getattr(exc, "reason", "") or "") or type(exc).__name__,
-                   str(exc))
+        refusal = ("key_axis_divergence", (
+            f"the child's cell (stamped key "
+            f"{str(meta.get('cell_key') or '') if meta else 'MISSING'}) does "
+            f"not describe this runtime: {divergence}"))
+    else:
+        try:
+            # pgw#805: an exported cell arms through the AOT gates
+            # (lifted-binding install -> aot_serve.enable -> rollback), not
+            # the inductor seed path. Same gates a hub-delivered `.pt2`
+            # passes; `provision.enable_compiled` itself is not reusable here
+            # because its pgw#709 receipts gate would drop a cell this pod
+            # minted seconds ago and the hub has not countersigned yet.
+            # pgw#999: the outcome is KEPT. `arm_aot` returns a classified
+            # `AdoptOutcome` (`contract_invalid`, `constants_unbound`,
+            # `no_arm_for_mode`, `numerics_refused`, …) and this call site
+            # used to spend it on `bool(...)`. That discard cost attempt 26
+            # 2 h 45 m and $2.72: a 36/36 mint sealed, finalized, and was then
+            # refused by three events that all said "could not adopt".
+            # pgw#1010: there is no second branch — a delegated mint is an AOT
+            # mint, and the inductor-seed adopt it used to fall back to armed
+            # an artifact class nothing publishes any more.
+            outcome = provision.arm_aot(
+                pipe, pending.cfg, pending.cache_dir, pending.target,
+                int(getattr(pending.cfg, "lora_bucket", 0) or 0), meta)
+            armed = bool(outcome)
+            if not armed:
+                refusal = (outcome.reason or "unclassified_arm_refusal",
+                           outcome.detail or outcome.identity)
+        except cc.CellSelectionBugError as exc:
+            # th#883, delegated edition: the child's own cell, whose axes
+            # describe exactly this runtime, refused to arm. Loud — it is a
+            # bug in the one selection brain, not a compatibility miss.
+            logger.error(
+                "fleet-cells: cell_selection_bug adopting this pod's "
+                "DELEGATED mint (family=%s arm_key=%s): %s",
+                pending.family, pending.cell_key, exc)
+            armed = False
+            refusal = ("cell_selection_bug", str(exc))
+        except Exception as exc:  # noqa: BLE001 — adoption failure => eager
+            logger.warning(
+                "fleet-cells: delegated mint for %s did not adopt (%s)",
+                pending.family, exc)
+            armed = False
+            # An `AdoptError` already carries the token; anything else is
+            # named by its type rather than flattened into one word nobody
+            # can count.
+            refusal = (
+                str(getattr(exc, "reason", "") or "") or type(exc).__name__,
+                str(exc))
     if not armed:
         reason, detail = refusal
         # pgw#999: `phase` is the countable column, so it carries the CLASS —
@@ -1435,10 +1507,17 @@ def adopt_delegated_mint(
         # constant `delegated_adopt_failed` said only which call site fired,
         # which every reader already knew from the event kind.
         state["adopt_refusal"] = (reason, detail)
+        # pgw#1042: BOTH identities, labeled. The parent's computed ARM key
+        # and the child's stamped cell key live in disjoint spaces by
+        # formula (pgw#1032/#1033); one unlabeled `key=` carrying the arm
+        # key while the detail quoted the stamped one is what the pod lane
+        # read as "the child computed a different key".
+        stamped = str((meta or {}).get("cell_key") or "") or "unreadable"
         activity_mod.emit_event(
             "self_mint_abort",
-            f"family={pending.family} key={pending.cell_key}: the child "
-            f"process produced a cell this runtime could not adopt "
+            f"family={pending.family} arm_key={pending.cell_key} "
+            f"cell_key={stamped}: the child process produced a cell this "
+            f"runtime could not adopt "
             f"({reason}{': ' + detail if detail else ''}); serving stays "
             f"eager and nothing is published",
             phase=reason,
@@ -1449,7 +1528,7 @@ def adopt_delegated_mint(
         shutil.rmtree(pending.mint_root, ignore_errors=True)
         return None
 
-    meta = _packed_metadata(pending.target)
+    meta = dict(meta) if meta is not None else _packed_metadata(pending.target)
     key = str(meta.get("cell_key") or "").strip() or pending.cell_key
     minted = SelfMint(
         family=pending.family, cell_key=key,
@@ -1904,6 +1983,7 @@ __all__ = [
     "PendingSelfMint",
     "SelfMint",
     "abandon_self_mint",
+    "arm_axis_divergence",
     "delegation_refusal",
     "enable_compiled",
     "finalized_in_process",

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -242,7 +242,7 @@ def mint_identity(request: MintRequest) -> str:
     DB read before anyone could say which of a pod's cells had died.
     """
     return (
-        f"mint family={request.family!r} key={request.cell_key!r} "
+        f"mint family={request.family!r} arm_key={request.cell_key!r} "
         f"lane={request.execution_lane or '(unset)'!r} "
         f"fn={request.function!r}")
 

--- a/tests/harness/rig_vehicles.py
+++ b/tests/harness/rig_vehicles.py
@@ -70,6 +70,12 @@ class Vehicle:
     #: `w8a8_gemm_mode()` answers "" without CUDA — which the module class
     #: refuses — so a cardless run of these is NOT-RUN, never a red.
     gpu_only: bool = False
+    #: pgw#1042: (tree, device) -> (pipe, cfg) for the PARENT-side handback —
+    #: the rig process that opened the mint adopting its own child's cell
+    #: through `fleet_cells.adopt_delegated_mint`, exactly as a pod does
+    #: BEFORE anything publishes. None skips the leg (the tiny plumbing
+    #: vehicle has no loadable pipeline class).
+    parent_pipe: Any = None
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +335,34 @@ def _micro_adopt_source_for(bucket: int) -> Any:
     return _source
 
 
+def _micro_parent_for(bucket: int, pipeline_cls: str = "MicroPipeline",
+                      cell: Any = None) -> Any:
+    """(tree, device) -> (pipe, cfg): the mint-opening parent's own pipeline,
+    on the mint's lane — what `adopt_delegated_mint` arms on a pod
+    (pgw#1042). Mirrors the adopt sources: same class, same device rule,
+    same lane application."""
+
+    def _build(tree: Path, device: str) -> Tuple[Any, Any]:
+        import micro_diffusion.pipeline as pl
+        from gen_worker import compile_cache as cc
+
+        pipe = getattr(pl, pipeline_cls).from_pretrained(str(tree)).to(device)
+        if pipeline_cls == "MicroW8a8Pipeline":
+            # The production loader stamps the base weight lane at load
+            # (`models/w8a8.py`: `pipe._cozy_weight_lane = "w8a8"`), and the
+            # parent's arm key reads THAT stamp (`pipeline_weight_lane`).
+            # MicroW8a8Pipeline builds its denoiser directly, so the rig
+            # parent mirrors the stamp or its lane axis is "" and the
+            # pgw#1042 guard (correctly) refuses the handback.
+            pipe._cozy_weight_lane = "w8a8"
+        if bucket:
+            cc.apply_lora_execution_lane(pipe, bucket)
+        cfg = cell() if cell is not None else _micro_cell(bucket)
+        return pipe, cfg
+
+    return _build
+
+
 def _micro_checkpoint(root: Path) -> Path:
     from micro_diffusion.weights import materialize
 
@@ -359,6 +393,7 @@ MICRO = Vehicle(
     checkpoint_bytes=_micro_checkpoint_bytes,
     compile_cell=_micro_cell,
     adopt_source=_micro_adopt_source_for(0),
+    parent_pipe=_micro_parent_for(0),
     covers=("org-worker packaging: 3 export entries (2 fork arms + a second "
             "target), CONTAINER inputs with a plain input after them "
             "(pgw#993/pgw#994), a derived dynamic range, generated weights"),
@@ -389,6 +424,7 @@ MICRO_LORA = Vehicle(
     checkpoint_bytes=_micro_checkpoint_bytes,
     compile_cell=lambda: _micro_cell(MICRO_LORA_BUCKET),
     adopt_source=_micro_adopt_source_for(MICRO_LORA_BUCKET),
+    parent_pipe=_micro_parent_for(MICRO_LORA_BUCKET),
     covers=(f"everything `micro` covers, on the BRANCH-BEARING graph "
             f"(lora_bucket={MICRO_LORA_BUCKET}): the mint child applies the "
             f"LoRA execution lane before tracing and the parent's arm runs "
@@ -418,8 +454,10 @@ MICRO_LORA_PLAIN_PARENT = Vehicle(
     checkpoint_bytes=_micro_checkpoint_bytes,
     compile_cell=lambda: _micro_cell(MICRO_LORA_BUCKET),
     # The MINT is bucket 64; the ADOPTER is bucket 0. That mismatch is the
-    # whole point of the leg.
+    # whole point of the leg. The HANDBACK parent carries the mint's own
+    # bucket — the pod that opened the mint always matches its own request.
     adopt_source=_micro_adopt_source_for(0),
+    parent_pipe=_micro_parent_for(MICRO_LORA_BUCKET),
     covers=("the pgw#999 design question: a bucket-bearing cell offered to a "
             "parent on the plain lane"),
     expect="red",
@@ -541,6 +579,7 @@ MICRO_4D = Vehicle(
     checkpoint_bytes=_micro_checkpoint_bytes,
     compile_cell=_micro_4d_cell,
     adopt_source=_micro_4d_adopt_source,
+    parent_pipe=_micro_parent_for(0, "MicroGridPipeline", _micro_4d_cell),
     covers=("pgw#998's shape — a 4-D latent with BOTH spatial axes dynamic, so "
             "every matmul's M extent is NONLINEAR in the traced symbols. This "
             "is z-image's declaration, and the seam that was unlowerable "
@@ -701,6 +740,7 @@ def _w8a8_vehicle(name: str, bucket: int) -> Vehicle:
         checkpoint_bytes=_micro_checkpoint_bytes,
         compile_cell=lambda: _micro_cell(bucket),
         adopt_source=_micro_w8a8_adopt_source_for(bucket),
+        parent_pipe=_micro_parent_for(bucket, "MicroW8a8Pipeline"),
         gpu_only=True,
         covers=(f"attempt 26's lane string `{lane}` — a REAL fp8 artifact from "
                 f"the SDK's own `quantize_tree_w8a8`, loaded by "

--- a/tests/test_aot_adopt_events_pgw733.py
+++ b/tests/test_aot_adopt_events_pgw733.py
@@ -72,7 +72,10 @@ class FakePackage:
         return list(self._fqns)
 
     def load_constants(self, values: Dict[str, Any],
-                       check_full_update: bool = False) -> None:
+                       check_full_update: bool = False,
+                       user_managed: bool = False) -> None:
+        # torch 2.13's real signature carries user_managed (pgw#1042: the
+        # whole-graph arm binds by reference against the per-target pool).
         if check_full_update and set(values) != set(self._fqns):
             raise RuntimeError("partial constant update refused by torch")
         self.loaded = dict(values)

--- a/tests/test_aot_multigraph_pgw758.py
+++ b/tests/test_aot_multigraph_pgw758.py
@@ -420,7 +420,8 @@ def test_dispatch_refuses_ambiguity_by_name() -> None:
         def get_constant_fqns(self):
             return []
 
-        def load_constants(self, values, check_full_update=True):
+        def load_constants(self, values, check_full_update=True,
+                           user_managed=False):
             pass
 
         def __call__(self, *feeds):
@@ -448,11 +449,11 @@ def test_all_entries_bind_before_any_wrap(minted_cell, monkeypatch, tmp_path) ->
     real_bind = aot_serve.ArtifactRunner.bind
     calls: list = []
 
-    def bind_second_fails(self, state_dict, literals):
+    def bind_second_fails(self, state_dict, literals, **kwargs):
         calls.append(self.entry)
         if len(calls) == 2:
             raise aot_serve.ConstantsUnboundError("constant_unresolved", "boom")
-        return real_bind(self, state_dict, literals)
+        return real_bind(self, state_dict, literals, **kwargs)
 
     monkeypatch.setattr(aot_serve.ArtifactRunner, "bind", bind_second_fails)
     with pytest.raises(compile_cache.AdoptError):

--- a/tests/test_aot_serve_pgw721.py
+++ b/tests/test_aot_serve_pgw721.py
@@ -88,7 +88,9 @@ class FakePackage:
             raise RuntimeError("no constant table in this artifact")
         return list(self._fqns)
 
-    def load_constants(self, values, check_full_update=False):
+    def load_constants(self, values, check_full_update=False,
+                        user_managed=False):
+        # torch 2.13's real signature carries user_managed (pgw#1042).
         self.full_update_asked = check_full_update
         if check_full_update and set(values) != set(self._fqns):
             raise RuntimeError("partial constant update refused by torch")

--- a/tests/test_handback_key_axes_pgw1042.py
+++ b/tests/test_handback_key_axes_pgw1042.py
@@ -1,0 +1,226 @@
+"""pgw#1042 — the delegated handback seam.
+
+Attempt 28's 36/36 sdxl mint published nothing, behind two defects this file
+pins:
+
+1. The child's returned cell carried a key the parent could not relate to its
+   own (`ck1-8f498f43…` opened, `ck1-886ffbcc…` returned). The two keys live
+   in DISJOINT spaces by formula (pgw#1032/#1033) — but every axis they share
+   must be byte-identical across the process boundary, and one measurably was
+   not: `torch._inductor.aot_compile` mutates the global
+   `aot_inductor.metadata` config entry as a side effect, so a child that has
+   compiled seals a different `env_seal` than its own boot (and than every
+   other process on the pod). The seal digest now excludes that entry, and
+   `adopt_delegated_mint` refuses BY AXIS NAME when any shared axis diverges.
+
+2. The artifact failed `update_constant_buffer_func_(... ) API call failed at
+   model_container_runner.cpp:289` on the parent runtime. Reproduced locally
+   byte-for-byte: the per-entry copying bind allocates the target's FULL
+   constant set once per entry, so a 36-entry sdxl cell demanded ~N x 2.6 GB
+   at arm and the failing cudaMalloc surfaced as that anonymous C++ error.
+   Entries now bind BY REFERENCE against one marker-owned pool per target,
+   and any residual AOTI failure is a typed `injection_failed` refusal
+   carrying live device-memory context.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from gen_worker import aot_serve, cell_key, env_seal, fleet_cells
+
+
+def _seal_dict() -> Dict[str, Any]:
+    return {
+        "seal_v": env_seal.SEAL_VERSION,
+        "posture": {"grad": "off"},
+        "config": {"float32_matmul_precision": "high"},
+        "inductor": "aaaa000011112222",
+        "loaded_libs": "bbbb333344445555",
+    }
+
+
+def _arm_key(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> cell_key.CellKey:
+    return cell_key.from_axes({
+        "format": "2",
+        "kind": "inductor",
+        "family": "micro-diffusion",
+        "lane": "w8a8-lora64",
+        "sm": "sm_89",
+        "contract": "1234567890abcdef",
+        "env_seal": env_seal.seal_digest(seal),
+        "toolchain": cell_key.facts_digest(toolchain),
+    })
+
+
+def _envelope(seal: Dict[str, Any], toolchain: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "cell_key": "ck1-" + "e" * 56,
+        "kind": "aot-inductor",
+        "format": "2",
+        "family": "micro-diffusion",
+        "weight_lane": "w8a8",
+        "lora_bucket": 64,
+        "sm": "sm_89",
+        env_seal.SEAL_KEY: dict(seal),
+        "toolchain": dict(toolchain),
+    }
+
+
+TOOLCHAIN = {"libtorch.so": "cafe0123"}
+
+
+def test_shared_axes_agree_is_empty() -> None:
+    seal = _seal_dict()
+    assert fleet_cells.arm_axis_divergence(
+        _arm_key(seal, TOOLCHAIN), _envelope(seal, TOOLCHAIN)) == ""
+
+
+def test_env_seal_divergence_is_named() -> None:
+    """The pod class: the child's recorded seal differs from the parent's."""
+    parent_seal = _seal_dict()
+    child_seal = dict(parent_seal, inductor="ffff999988887777")
+    got = fleet_cells.arm_axis_divergence(
+        _arm_key(parent_seal, TOOLCHAIN), _envelope(child_seal, TOOLCHAIN))
+    assert got.startswith("env_seal: ")
+    assert env_seal.seal_digest(child_seal) in got
+    assert env_seal.seal_digest(parent_seal) in got
+
+
+@pytest.mark.parametrize("field,value,axis", [
+    ("sm", "sm_80", "sm"),
+    ("family", "other-family", "family"),
+    ("lora_bucket", 0, "lane"),
+    ("format", "1", "format"),
+])
+def test_every_shared_axis_is_guarded(field: str, value: Any, axis: str) -> None:
+    seal = _seal_dict()
+    meta = _envelope(seal, TOOLCHAIN)
+    meta[field] = value
+    got = fleet_cells.arm_axis_divergence(_arm_key(seal, TOOLCHAIN), meta)
+    assert got.startswith(f"{axis}: "), got
+
+
+def test_adopt_refuses_typed_before_any_arm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A diverging child cell must fail `key_axis_divergence` at the seam —
+    never reach the arm, whose C++ error was the pod's whole diagnostic."""
+    seal = _seal_dict()
+    child_seal = dict(seal, inductor="ffff999988887777")
+    meta = _envelope(child_seal, TOOLCHAIN)
+
+    from gen_worker import artifact_meta
+    from gen_worker.models import provision
+
+    monkeypatch.setattr(
+        artifact_meta, "try_read_metadata", lambda _p: dict(meta))
+
+    def _no_arm(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("arm_aot must not run on a diverged cell")
+
+    monkeypatch.setattr(provision, "arm_aot", _no_arm)
+
+    mint_root = tmp_path / "mint-root"
+    mint_root.mkdir()
+    artifact = tmp_path / "cell.tar.gz"
+    artifact.write_bytes(b"not-a-real-cell")
+    arm = _arm_key(seal, TOOLCHAIN)
+    pending = fleet_cells.PendingSelfMint(
+        family="micro-diffusion", cell_key=arm.digest,
+        ref=f"x#{arm.digest}", cfg=object(), target=tmp_path / "adopted.tar.gz",
+        mint_root=mint_root, publisher=None, cache_dir=tmp_path / "cache",
+        arm_key=arm)
+
+    assert fleet_cells.adopt_delegated_mint(object(), pending, artifact) is None
+    reason, detail = fleet_cells.adopt_refusal(pending)
+    assert reason == "key_axis_divergence"
+    assert "env_seal: " in detail
+    assert meta["cell_key"] in detail
+
+
+def test_inductor_digest_ignores_aot_compile_metadata() -> None:
+    """torch's aot_compile writes machine facts into global config as a side
+    effect; the seal must not move with it (the measured pgw#1042 axis)."""
+    torch = pytest.importorskip("torch")
+    import torch._inductor.config as inductor_config
+
+    before = env_seal.inductor_config_digest()
+    prior = dict(getattr(inductor_config.aot_inductor, "metadata", {}) or {})
+    try:
+        inductor_config.aot_inductor.metadata = {
+            "AOTI_DEVICE_KEY": "cuda", "AOTI_CPU_ISA": "AVX2",
+            "AOTI_COMPUTE_CAPABILITY": "89"}
+        assert env_seal.inductor_config_digest() == before
+    finally:
+        inductor_config.aot_inductor.metadata = prior
+    assert torch is not None
+
+
+class _FakeTensor:
+    def __init__(self, n: int = 4) -> None:
+        self._n = n
+
+    def numel(self) -> int:
+        return self._n
+
+    def element_size(self) -> int:
+        return 2
+
+    def detach(self) -> "_FakeTensor":
+        return self
+
+    def clone(self) -> "_FakeTensor":
+        return _FakeTensor(self._n)
+
+
+class _RefusingPackage:
+    """A package whose C++ update fails the way the pod's did."""
+
+    def get_constant_fqns(self) -> list:
+        return ["lin.weight"]
+
+    def load_constants(self, *_a: Any, **_k: Any) -> None:
+        raise RuntimeError(
+            "update_constant_buffer_func_( container_handle_, "
+            "(AOTInductorConstantMapHandle)&const_map, use_inactive, "
+            "check_full_update) API call failed at "
+            "model_container_runner.cpp, line 289")
+
+
+def test_cpp_bind_failure_is_typed_injection_failed() -> None:
+    """The pod's anonymous `API call failed` becomes a NAMED refusal with the
+    entry and live device-memory context — pgw#999's rule, one frame deeper."""
+    spec = aot_serve.ConstantSpec(
+        fqn="lin.weight", source=aot_serve.SOURCE_STATE_DICT,
+        dtype="torch.bfloat16", shape=(2, 2))
+    runner = aot_serve.ArtifactRunner(
+        package=_RefusingPackage(),
+        contract=None,  # bind never reads it
+        constants=(spec,), entry="transformer/cfg=true")
+    with pytest.raises(aot_serve.ConstantsUnboundError) as exc:
+        runner.bind({"lin.weight": _FakeTensor()}, {})
+    assert exc.value.reason == "injection_failed"
+    assert "transformer/cfg=true" in str(exc.value)
+    assert not runner.bound
+
+
+def test_target_constant_pool_is_one_clone_per_fqn() -> None:
+    """N entries share ONE owned copy — the N x constants VRAM demand that
+    OOM'd the 36-entry sdxl arm must not be reconstructible."""
+    torch = pytest.importorskip("torch")
+    spec = aot_serve.ConstantSpec(
+        fqn="w", source=aot_serve.SOURCE_STATE_DICT,
+        dtype="torch.float32", shape=(4,))
+    lit = aot_serve.ConstantSpec(
+        fqn="tbl", source=aot_serve.SOURCE_LITERAL,
+        dtype="torch.float32", shape=(4,))
+    resident = torch.arange(4, dtype=torch.float32)
+    pool = aot_serve.target_constant_pool(
+        [(spec, lit), (spec,), (spec,)], {"w": resident})
+    assert set(pool) == {"w"}  # literals ride their own payload
+    assert pool["w"] is not resident  # owned, not aliased (pgw#812 D3)
+    assert torch.equal(pool["w"], resident)


### PR DESCRIPTION
pgw#1042 (P0): a fully-successful 36/36 sdxl AOT mint published NOTHING — the delegated child returned a cell under a different key than the parent opened (`ck1-8f498f43…` vs `ck1-886ffbcc…`) and its artifact failed `update_constant_buffer_func_(...) API call failed at model_container_runner.cpp:289` on the parent runtime. Both defects root-caused at $0 on the local rig, both fixed at their source.

## Root cause 1 — the "key divergence" decomposes into a definitional half and a real half

**Definitional:** the parent's mint-open key is the COMPUTED arm identity (`cell_key.compute`, `kind="inductor"`, contract = declared-facts digest) and the child returns the STAMPED cell identity (`aot_mint.cell_identity`, `kind="aot-inductor"`, contract = v3 traced-graph facts). Disjoint spaces BY FORMULA — exactly as pgw#1032/pgw#1033 adjudicated, both of which merged AFTER the 0.94.1 wheel the pod ran. The abort event printed the arm key as an unlabeled `key=` while quoting the stamped key in its detail, which is what read as "an axis is not surviving the process boundary". The self-mint events now label `arm_key=` and `cell_key=` separately.

**Real:** one shared axis measurably DOES diverge across the process boundary. `torch._inductor.aot_compile` mutates the global `aot_inductor.metadata` config entry as a side effect (machine facts: `AOTI_CPU_ISA`, `AOTI_COMPUTE_CAPABILITY`, …) and `save_config_portable()` includes it. Bisected live: the inductor seal fact flips `4e29748b…` → `f2100795…` across one `aot_compile` call, and `f2100795…` is byte-identical to the seal recorded inside a real minted cell. A child that has compiled therefore seals a different `env_seal` than its own boot and than every fresh process — and it would fracture stamped identity per host CPU ISA (the pgw#745 driver-split class on a new axis). Per the ratified direction (any identity question → make the hash more canonical): `inductor_config_digest` now excludes the torch-owned output (`_PORTABLE_VOLATILE`); `SEAL_VERSION` 2→3, re-key cost zero (nothing was ever published under v2).

**The seam is guarded:** `PendingSelfMint` carries the full computed `arm_key`, and `adopt_delegated_mint` refuses typed `key_axis_divergence` — naming the axis and both values — when the child's envelope diverges on any SHARED axis (family, format, lane, sm, env_seal, toolchain), BEFORE any arm runs. Full pre-trace unification is impossible by construction (the stamped contract folds the traced-graph hash, which does not exist before export); whether identity should BECOME the traced graph is pgw#1031 in the NOT-AN-ENGINEER index.

## Root cause 2 — the constants failure is a VRAM multiplication, reproduced byte-for-byte

torch 2.13's copying bind (`user_managed=False`) allocates the target's FULL constant set once per ENTRY (measured: 3 entries × 128 MiB = exactly 384 MiB), and `load_and_wrap` binds all entries before any wrap. A 36-entry sdxl w8a8 cell demands ~N × 2.6 GB at arm; the failing cudaMalloc surfaces as the EXACT pod string — reproduced locally: 12 × 512 MiB entries on the 8 GB card fail at entry 10 with `update_constant_buffer_func_( container_handle_, (AOTInductorConstantMapHandle)&const_map, use_inactive, check_full_update) API call failed at …/model_container_runner.cpp, line 289`, the real message (`CUDA error: out of memory`) going to a stderr no pod exposes. pgw#812 D3 priced the copying bind at "one duplicate of the weights" — true per RUNNER, silently multiplied per ENTRY by pgw#758's multi-graph cells. This also explains attempt 26's identical adopt failure (reason then discarded — pgw#999).

**Fix:** entries bind BY REFERENCE (`user_managed=True`) against ONE marker-owned clone pool per target (`aot_serve.target_constant_pool`) — D3's stated cost restored, whatever the entry count; the pool and literal tensors ride the arm marker so the user-managed pointers outlive the runners, and unwrap frees them. Any residual AOTI failure raises a typed `ConstantsUnboundError("injection_failed", …)` carrying the entry, constants size and the card's live free/total.

## The rig gap that hid both

The gauntlet only ever adopted in a fresh SECOND process; the pod fails in the mint-opening PARENT. The rig now seals its parent process exactly as a worker boot does (`env_seal.establish()`) and runs a `handback` leg between mint-child and publish — the real `fleet_cells.adopt_delegated_mint` on the parent's own pipeline, in pod order (adopt → publish) — for every micro-diffusion vehicle, including `micro-w8a8-lora`, the exact `w8a8-lora64` lane string that failed.

## Evidence

- micro-w8a8-lora full cycle green on GPU (sm_89, torch 2.13.0+cu126) WITH the new handback leg: mint 5/5 → parent handback adopt → publish → cross-process adopt + parity.
- Full gauntlet: all 6 variants match expectation.
- `tests/test_handback_key_axes_pgw1042.py`: axis guard names each shared axis; a diverged cell refuses `key_axis_divergence` at the seam with `arm_aot` proven unreached; `inductor_config_digest` immune to the `aot_inductor.metadata` side effect; the C++ bind failure classifies `injection_failed`; the pool is one clone per fqn, never aliased.

Wheel note: the next pod run needs a release carrying this (seal v3 + bind semantics) — recommend 0.96.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCbPnV1oa913fz3i2XgJZ3
