### PR TITLE
pgw#1041: a load says WHAT it is doing — durable per-component phase events

### DIFF
--- a/changelog.d/pgw1041.md
+++ b/changelog.d/pgw1041.md
@@ -20,4 +20,11 @@
   v1 OOM kill now classifies as `cause=oom` instead of `signal:SIGKILL`.
   (4) host-RAM admission counts a component override's own materialized
   tree in the slot's staging requirement (it under-admitted H3 by the fp8
-  encoder's 27.6 GB).
+  encoder's 27.6 GB). (5) A load also says WHAT it is doing, not only that a
+  number is moving: every phase transition emits a durable typed activity
+  event — `load_phase` on entry (naming the component and its tree size) and
+  `load_phase_done` on exit with the measured span in `duration_ms`. The
+  breadcrumb reaches the hub only through a death and the counter carries no
+  component identity, so without these a load that is merely slow — or one
+  an operator terminates — still leaves nobody able to say which component
+  ate the 94 minutes.

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -18,8 +18,22 @@ no parallel heartbeat systems):
   (:func:`gen_worker.postmortem.write_load_progress`); a SIGKILL mid-load
   is then attributed by the surviving parent as "died at
   hydrate:transformer, N/M GiB" instead of a blank.
+* every phase transition emits a typed, DURABLE activity event naming the
+  component — ``load_phase`` on entry, ``load_phase_done`` on exit with the
+  measured span in ``duration_ms``. The counter says a number is moving; the
+  events say WHAT the worker is doing, which is the half WORKER-CONTRACTS §1
+  asks for and the half a 94-minute load needs while it is still ALIVE. The
+  breadcrumb only reaches the hub through a death, and a slow load that
+  eventually succeeds leaves no death to read.
 
-Off-Linux (/proc missing) the reporter is an honest no-op.
+Why events and not the counter name or the activity's phase: the hub makes a
+RUNNING update durable only on a phase transition (th#1250), and this load
+does not own the phase of the activity it runs under — ``ensure_setup``'s
+``self_mint_compile`` does. ``emit_event`` sends a COMPLETED update, which is
+always durable, and deliberately does not touch the open activity.
+
+Off-Linux (/proc missing) the reporter still reports phases; only the byte
+sampling is an honest no-op.
 """
 
 from __future__ import annotations
@@ -41,7 +55,15 @@ logger = logging.getLogger(__name__)
 #: non-advancement of whatever counter is freshest, not on the name.
 COUNTER_NAME = "load:staged_bytes"
 
+#: A load phase STARTED (``duration_ms`` 0 — nothing is measured yet). This
+#: is the row that names the component a hung load is hung on.
+EVENT_PHASE = "load_phase"
+#: A load phase FINISHED, carrying its measured span (th#1322: the number
+#: goes in the column, never interpolated into the detail).
+EVENT_PHASE_DONE = "load_phase_done"
+
 _INTERVAL_S = 5.0
+_GIB = float(1 << 30)
 
 _lock = threading.Lock()
 _active: Optional["LoadProgressReporter"] = None
@@ -67,6 +89,10 @@ def _proc_rss_anon_kb() -> Optional[int]:
     return None
 
 
+def _gib(n: float) -> str:
+    return f"{n / _GIB:.2f} GiB"
+
+
 class LoadProgressReporter:
     """Samples staging progress while a model load blocks the caller.
 
@@ -88,6 +114,9 @@ class LoadProgressReporter:
         self.marker_path = marker_path
         self.interval_s = max(0.5, float(interval_s))
         self._phase = "load"
+        self._phase_bytes = 0
+        self._phase_started = time.monotonic()
+        self._staged = 0
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._io0: Optional[int] = None
@@ -95,9 +124,48 @@ class LoadProgressReporter:
 
     # -- loader-facing ------------------------------------------------------
 
-    def set_phase(self, phase: str) -> None:
-        self._phase = phase
+    def set_phase(self, phase: str, nbytes: int = 0) -> None:
+        """Enter ``phase`` (``nbytes`` = the tree this phase stages, when the
+        caller knows it). Closes the phase being left, so the pair of events
+        is a phase table with real spans."""
+        if phase == self._phase:
+            self._phase_bytes = max(self._phase_bytes, int(nbytes))
+            return
+        self._close_phase()
+        self._phase, self._phase_bytes = phase, max(0, int(nbytes))
+        self._phase_started = time.monotonic()
+        self._announce_phase()
         self._tick()
+
+    # -- phase events -------------------------------------------------------
+
+    def _announce_phase(self) -> None:
+        try:
+            sized = f", {_gib(self._phase_bytes)} tree" if self._phase_bytes else ""
+            activity_mod.emit_event(
+                EVENT_PHASE,
+                f"{self.label}: {self._phase}{sized}; staged "
+                f"{_gib(self._staged)} of {_gib(self.total_bytes)}",
+                phase=self._phase,
+            )
+        except Exception:  # noqa: BLE001 - reporting must never break a load
+            logger.debug("load-phase event dropped", exc_info=True)
+
+    def _close_phase(self) -> None:
+        try:
+            span_ms = int(max(0.0, time.monotonic() - self._phase_started) * 1000)
+            # "ended", never "complete": `load_slot` stops the reporter from a
+            # `finally`, so this row also closes a phase that RAISED (a typed
+            # pgw#752 refusal). The span is the honest fact either way; the
+            # outcome is the raised error's to report.
+            activity_mod.emit_event(
+                EVENT_PHASE_DONE,
+                f"{self.label}: {self._phase} ended; staged "
+                f"{_gib(self._staged)} of {_gib(self.total_bytes)}",
+                phase=self._phase, duration_ms=span_ms,
+            )
+        except Exception:  # noqa: BLE001 - reporting must never break a load
+            logger.debug("load-phase event dropped", exc_info=True)
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -105,9 +173,11 @@ class LoadProgressReporter:
         global _active
         self._io0 = _proc_read_bytes()
         self._started_unix = time.time()
+        self._phase_started = time.monotonic()
         with _lock:
             _active = self
         self._tick()
+        self._announce_phase()
         t = threading.Thread(
             target=self._run, name="load-progress", daemon=True)
         self._thread = t
@@ -123,6 +193,10 @@ class LoadProgressReporter:
         with _lock:
             if _active is self:
                 _active = None
+        # The last phase closes on ANY stop: a raise is still a span that
+        # ended, and the event names where the time went. Only a kernel kill
+        # skips this — that one is the breadcrumb's job.
+        self._close_phase()
         try:
             c = progress_mod.counter(COUNTER_NAME, "bytes", self.total_bytes)
             c.finish()
@@ -155,6 +229,7 @@ class LoadProgressReporter:
             # Bytes STAGED is evidenced by whichever is further along:
             # cold reads show in io, page-cache-warm loads show as anon RSS.
             done = max(0, read, rss_anon_kb * 1024)
+            self._staged = done
             c = progress_mod.counter(
                 COUNTER_NAME, "bytes",
                 max(self.total_bytes, done),
@@ -176,12 +251,18 @@ class LoadProgressReporter:
             logger.debug("load-progress tick dropped", exc_info=True)
 
 
-def set_phase(phase: str) -> None:
+def set_phase(phase: str, nbytes: int = 0) -> None:
     """Update the active reporter's phase (no-op when no load is running)."""
     with _lock:
         rep = _active
     if rep is not None:
-        rep.set_phase(phase)
+        rep.set_phase(phase, nbytes)
 
 
-__all__ = ["COUNTER_NAME", "LoadProgressReporter", "set_phase"]
+__all__ = [
+    "COUNTER_NAME",
+    "EVENT_PHASE",
+    "EVENT_PHASE_DONE",
+    "LoadProgressReporter",
+    "set_phase",
+]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1571,7 +1571,7 @@ def hydrate_modular_pipeline(
             for n in names:
                 comp_src = Path(sources[n])
                 comp_bytes = disk_gc.tree_bytes(comp_src)
-                load_progress.set_phase(f"hydrate:{n}")
+                load_progress.set_phase(f"hydrate:{n}", comp_bytes)
                 _admit_component_staging(n, comp_bytes)
                 kwargs: Dict[str, Any] = {
                     "pretrained_model_name_or_path": {n: sources[n]},

--- a/tests/test_load_telemetry_pgw1041.py
+++ b/tests/test_load_telemetry_pgw1041.py
@@ -9,12 +9,15 @@ cgroup-v1 layout (the exact files measured on the AP-JP-1 H100 host)."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from pathlib import Path
+from typing import List
 
 import pytest
 
+from gen_worker import activity as activity_mod
 from gen_worker import postmortem
 from gen_worker import progress as progress_mod
 from gen_worker.capability import (
@@ -24,8 +27,38 @@ from gen_worker.capability import (
 from gen_worker.models import load_progress, provision
 from gen_worker.models.loading import load_from_pretrained
 from gen_worker.models.memory import HostRam
+from gen_worker.pb import worker_scheduler_pb2 as pb
 
 from harness.modular_endpoint import TinyModularPipeline, build_base_tree
+
+
+class _PhaseEvents:
+    """The REAL activity sink the worker transport installs, drained after
+    the load — so these assertions read exactly the ActivityUpdates a hub
+    would receive, not an in-process spy."""
+
+    def __init__(self) -> None:
+        self.sent: List[pb.WorkerMessage] = []
+        self.loop = asyncio.new_event_loop()
+
+    def __enter__(self) -> "_PhaseEvents":
+        async def _send(msg: pb.WorkerMessage) -> None:
+            self.sent.append(msg)
+
+        activity_mod.bind_sink(_send, self.loop)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.loop.run_until_complete(asyncio.sleep(0.02))
+        activity_mod.bind_sink(None, None)
+        self.loop.close()
+
+    def of_kind(self, kind: str) -> List[pb.ActivityUpdate]:
+        return [
+            m.activity_update for m in self.sent
+            if m.WhichOneof("msg") == "activity_update"
+            and m.activity_update.kind == kind
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +195,31 @@ def test_component_admission_refuses_transient(tmp_path, monkeypatch):
     assert exc.value.required_bytes > exc.value.available_before_bytes
 
 
+def test_a_refused_phase_is_closed_as_ended_not_complete(tmp_path, monkeypatch):
+    """`load_slot` stops the reporter from a `finally`, so the refused phase
+    is closed by the same row a successful one is. It may not claim the
+    component completed — the span is the fact; the typed refusal is the
+    outcome, and it is raised."""
+    from gen_worker.models import loading as loading_mod
+
+    monkeypatch.setattr(postmortem, "LOAD_PROGRESS_PATH", tmp_path / "m.json")
+    monkeypatch.setattr(
+        loading_mod, "probe_host_ram", lambda: _ram(64.0, 0.001))
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+
+    with _PhaseEvents() as events:
+        with pytest.raises(InsufficientHostRamError):
+            provision.load_slot(
+                TinyModularPipeline, str(tree), slot="pipeline",
+                ref="test/tiny:latest", mode="auto", device="cpu")
+
+    done = events.of_kind(load_progress.EVENT_PHASE_DONE)
+    assert done, "the phase that refused must still close its span"
+    assert all("complete" not in ev.detail for ev in done), [
+        ev.detail for ev in done]
+    assert done[-1].phase.startswith("hydrate:")
+
+
 def test_component_admission_refuses_structural(tmp_path, monkeypatch):
     """A component bigger than the whole cgroup is the pgw#752 hardware
     verdict (disable the function here), not a retry."""
@@ -180,15 +238,105 @@ def test_hydration_reports_per_component_phases(tmp_path, monkeypatch):
     """The 94-minute black box: hydration must announce each component."""
     from gen_worker.models import loading as loading_mod
 
-    phases: list[str] = []
+    phases: list[tuple[str, int]] = []
     monkeypatch.setattr(
         loading_mod.load_progress, "set_phase",
-        lambda phase: phases.append(phase))
+        lambda phase, nbytes=0: phases.append((phase, nbytes)))
     tree = build_base_tree(tmp_path / "base", fill=1.0)
     pipe = load_from_pretrained(TinyModularPipeline, tree)
     assert pipe.unet is not None
-    hydrated = [p.split(":", 1)[1] for p in phases if p.startswith("hydrate:")]
+    hydrated = {
+        p.split(":", 1)[1]: n for p, n in phases if p.startswith("hydrate:")
+    }
     assert "unet" in hydrated and "vae" in hydrated
+    # The component's own staging size rides the phase — the admission check
+    # and the report must be talking about the same bytes.
+    assert all(n > 0 for n in hydrated.values()), hydrated
+
+
+# ---------------------------------------------------------------------------
+# the phase events: what the worker is DOING, while it is still alive
+# ---------------------------------------------------------------------------
+
+
+def test_live_load_names_each_component_to_the_hub(tmp_path, monkeypatch):
+    """The 94-minute black box, hub-side. The breadcrumb only reaches the hub
+    through a DEATH and the byte counter only says a number is moving; a load
+    that is merely slow must still name the component it is on, durably."""
+    marker = tmp_path / "load-progress.json"
+    monkeypatch.setattr(postmortem, "LOAD_PROGRESS_PATH", marker)
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+
+    with _PhaseEvents() as events:
+        sl = provision.load_slot(
+            TinyModularPipeline, str(tree), slot="pipeline",
+            ref="test/tiny:latest", mode="auto", device="cpu")
+    assert sl.obj is not None
+
+    started = events.of_kind(load_progress.EVENT_PHASE)
+    done = events.of_kind(load_progress.EVENT_PHASE_DONE)
+    # Every entry is a COMPLETED update, which is what makes it durable
+    # hub-side (th#1250: a RUNNING update survives only on a phase change,
+    # and this load does not own the enclosing activity's phase).
+    assert started and done
+    for ev in started + done:
+        assert ev.state == pb.ActivityState.ACTIVITY_STATE_COMPLETED
+
+    entered = [ev.phase for ev in started]
+    assert entered[0] == "load"
+    assert "hydrate:unet" in entered and "hydrate:vae" in entered
+    # The component's own tree size rides the entry row: the operator reading
+    # a stuck load learns WHICH component and HOW BIG without a second query.
+    unet = next(ev for ev in started if ev.phase == "hydrate:unet")
+    assert "GiB tree" in unet.detail and "test/tiny:latest" in unet.detail
+
+    # Every phase that was entered was also closed, exactly once, and the
+    # spans are measured rather than interpolated into the text (th#1322).
+    assert [ev.phase for ev in done] == entered
+    assert all(ev.duration_ms >= 0 for ev in done)
+    assert all("GiB" in ev.detail for ev in done)
+    assert all(ev.duration_ms == 0 for ev in started), (
+        "an entry row measures nothing yet; 0 means 'not measured here'")
+
+
+def test_a_phase_that_never_ends_still_announced_itself(tmp_path):
+    """The hang case: no completion event exists, but the entry event for the
+    phase the load is stuck in was already durable when it entered."""
+    marker = tmp_path / "load-progress.json"
+    rep = load_progress.LoadProgressReporter(
+        "pipeline:test/ref", 4 << 30, marker_path=marker, interval_s=0.2)
+    try:
+        with _PhaseEvents() as events:
+            rep.start()
+            rep.set_phase("hydrate:transformer", 2 << 30)
+            # ... and here the kernel kills us: no stop(), no completion event.
+    finally:
+        # Only to retire the sampler thread; the sink is already unbound, so
+        # nothing this emits can reach the assertions below.
+        rep.stop(clean=False)
+
+    entered = [ev.phase for ev in events.of_kind(load_progress.EVENT_PHASE)]
+    closed = [ev.phase for ev in events.of_kind(load_progress.EVENT_PHASE_DONE)]
+    assert entered == ["load", "hydrate:transformer"]
+    assert closed == ["load"], "the phase we died in must not report complete"
+    # And the breadcrumb agrees with the last entry event.
+    assert json.loads(marker.read_text())["phase"] == "hydrate:transformer"
+
+
+def test_repeated_set_phase_does_not_split_a_span(tmp_path):
+    """One phase, one span — a component that reports itself twice must not
+    read as two components (the th#1322 `frame()` rule, same reason)."""
+    with _PhaseEvents() as events:
+        rep = load_progress.LoadProgressReporter(
+            "pipeline:test/ref", 1000,
+            marker_path=tmp_path / "m.json", interval_s=0.2)
+        rep.start()
+        rep.set_phase("hydrate:vae", 10)
+        rep.set_phase("hydrate:vae", 20)
+        rep.stop(clean=True)
+
+    entered = [ev.phase for ev in events.of_kind(load_progress.EVENT_PHASE)]
+    assert entered == ["load", "hydrate:vae"]
 
 
 def test_load_slot_clears_breadcrumb_on_success(tmp_path, monkeypatch):


### PR DESCRIPTION
`66b77e39` (PR #556) discharged three of pgw#1041's four boxes: the load path
got a `load:staged_bytes` counter, per-component cgroup-budget admission, and
a cgroup-v1-aware SIGKILL postmortem. I verified all three by content on
`master` and re-ran the suite; they hold.

**What was still open in box 1.** The box asks the load to report "bytes
fetched / staged / **component hydrated**" through the activity channel.
Component identity reaches the hub in exactly one situation today: a SIGKILL,
via `postmortem.take_load_progress`. The breadcrumb is a local file; the
counter carries a number and no identity. So a load that is merely slow — or
one an operator terminates, which is what ie#615 attempt 4 would have been had
the kernel not stepped in — still ends with nobody able to say which component
ate the 94 minutes. That is the "what are you doing" half of WORKER-CONTRACTS
section 1, and it is the half an operator reads first.

**This PR.** Every load-phase transition emits a typed, durable activity event:

* `load_phase` on entry — names the component and its tree size,
  `duration_ms=0`. This is the row that says what a hung load is hung on,
  while it is still hanging.
* `load_phase_done` on exit — the measured span in `duration_ms`, so the
  per-component phase table is queryable in the numeric column rather than
  parsed out of prose (th#1322).

One phase, one span: a repeated `set_phase` for the same component does not
split it. The component byte count threaded to the event is the same number
the pgw#752 admission check just ruled on, so the report and the refusal
cannot describe different bytes.

**Why `emit_event` and not the counter name or the activity's phase.** The hub
makes a RUNNING update durable only on a phase transition (th#1250), and this
load does not own the phase of the `self_mint_compile` activity it runs under
— `ensure_setup` does, and `Activity.phase()` also finishes phase-scoped
counters (pgw#962). `emit_event` sends a COMPLETED update, which is always
durable, and deliberately does not touch the open activity.

**Tests** run through the REAL `activity.bind_sink` the worker transport
installs: a real tiny modular pipeline (the pgw#1036 harness) loads through
`provision.load_slot` and the assertions read the ActivityUpdates a hub would
receive — including that every one is `ACTIVITY_STATE_COMPLETED`, which is
what makes them durable. Proven RED by disabling the announcement (3 fail).

Local: `tests/` full suite, mypy + ruff clean on `src/gen_worker`, all five
hard-gate lint scripts and `assemble_changelog.py --check` exit 0. No pods, no
weights, $0.

**Box 4 (re-run the ie#615 violin-busker invoke) is NOT discharged here** and
cannot be from this box — it needs a live pod on the serve train.
