### PR TITLE
pgw#1046: a published cell states the identity the hub needs to ARM it (th#1457 cutover precondition)

### DIFF
--- a/changelog.d/pgw1046.md
+++ b/changelog.d/pgw1046.md
@@ -1,0 +1,26 @@
+- **pgw#1046: a published cell now states the identity the hub needs to ARM
+  it — and a cell that cannot state one is refused instead of published under
+  a subset.** `fleet_cells._identity_axes` computed the publish-intent axes
+  via `cell_key.from_artifact_metadata`, which refuses `kind="aot-inductor"`
+  by name — and since pgw#1010 that is the only publishable kind, so EVERY
+  cell in the corpus fell to a six-axis fallback (`family, kind, format, sm,
+  mode, lane`) carrying neither `toolchain` nor `env_seal`, and the
+  artifact's `combined_graph_hash` reached the hub nowhere at all. th#1457's
+  RunAttempt producer builds `Arm.artifact` / `Arm.graph_contract_digest` out
+  of exactly that map and pgw#904's landed consumer refuses an
+  `ArtifactIdentity` missing any of the three, so no cell in the fleet was
+  armable — the cutover's first precondition. Three changes: (1)
+  `cell_key.from_exported_artifact_metadata` is the exported kind's
+  counterpart of `from_artifact_metadata` and the SINGLE implementation of
+  that key — `aot_mint.cell_identity(meta)` now delegates to it and lost its
+  `spec` parameter, so the key the mint stamps and the axes publish declares
+  cannot be two derivations. (2) The mint records `declared_traffic`
+  (shapes / text_lens / guidance) in the envelope: the last contract-fact
+  input that lived only in the live `ExportSpec`, without which an artifact
+  could not restate its own `contract` axis. (3) Publish declares the full ck
+  axis set plus `graph_contract` (the `combined_graph_hash`), verifies the
+  recomputed key against the `cell_key` stamp, and raises
+  `CellPublishRefused` before a byte moves when any of it is missing.
+  **No cell re-keys** — the contract-facts shape and every axis value are
+  byte-identical (measured: same digest and same axes before and after);
+  pre-fix rows carry no digests hub-side and are re-minted naturally.

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2105,7 +2105,7 @@ def _mint_cell(
         minted, timings, inductor_configs, width, progress.pool_ledger)
     _emit_phase_event(spec, phase_table)
 
-    meta["cell_key"] = key = cell_identity(meta, spec).digest
+    meta["cell_key"] = key = cell_identity(meta).digest
     t0 = time.monotonic()
     artifact = aot_serve.pack(work, out_dir / f"{key}.tar.gz", meta)
     timings["pack_s"] = round(time.monotonic() - t0, 2)
@@ -2876,6 +2876,19 @@ def shared_identity_blocks(spec: ExportSpec) -> Dict[str, Any]:
         "sm": str(cc.runtime_key().get("sm") or ""),
         env_seal.SEAL_KEY: env_seal.effective_seal(),
         "toolchain": dict(cc.toolchain_digest()),
+        # pgw#1046: the declared traffic the `contract` axis folds. It used to
+        # live ONLY in the live `ExportSpec`, so an exported cell could not
+        # restate its own contract axis — and the publish path, unable to
+        # recompute the key, fell back to a 6-axis subset carrying neither
+        # `toolchain` nor `env_seal`, which is precisely what the hub needs to
+        # mint an `ArtifactIdentity` the worker will accept. Recorded in the
+        # SHAPE `cell_key.contract_digest` consumes, so the digest — and every
+        # existing cell key — is byte-identical to before.
+        cell_key.EXPORT_TRAFFIC_KEY: {
+            "shapes": sorted([int(v) for v in row] for row in spec.shapes),
+            "text_lens": sorted({int(v) for v in spec.text_lens}),
+            "guidance": sorted(float(v) for v in spec.guidance_scales),
+        },
         # pgw#1034: no ``code_closure``. pgw#990 took source content out of the
         # key; the memo it was demoted to is `compile_cache`'s own block, read
         # by the local re-trace off ITS copy. This one had zero readers and cost
@@ -2918,83 +2931,26 @@ def _treespec_text(spec: Any) -> str:
         return repr(spec)
 
 
-def cell_identity(meta: Mapping[str, Any], spec: ExportSpec) -> cell_key.CellKey:
+def cell_identity(meta: Mapping[str, Any]) -> cell_key.CellKey:
     """The cell key a multi-graph artifact's OWN recorded facts describe.
 
-    Computed from the recorded blocks, never from separate probes, so the stamp
-    can never disagree with the axes it summarizes — the discipline
-    ``cell_key.from_artifact_metadata`` enforces for dynamo cells, mirrored for
-    the new kind. ``cell_key.from_axes`` already accepts any ``kind`` VALUE (it
-    validates axis NAMES), so no KEY_SCHEME bump: the axis set is unchanged and
-    ``kind`` does the discriminating. No dynamo cell is stranded.
+    The computation is :func:`cell_key.from_exported_artifact_metadata` — ONE
+    implementation, so the key the mint stamps and the axes the publish path
+    declares (``fleet_cells._identity_axes``) are the same object rather than
+    two derivations that can drift. pgw#1046 moved it there and dropped the
+    ``spec`` parameter: every input is now a RECORDED block (the traffic
+    contract rides ``declared_traffic``), which is what makes the recomputation
+    possible off the artifact alone. No cell re-keys — the contract-facts shape
+    and every axis value are unchanged.
 
-    The ``contract`` axis is the pgw#716 formula, IMPLEMENTED AS ANTICIPATED:
-    the cell keys on the ``combined_graph_hash`` — first 16 hex of the sha256
-    over the newline-joined SORTED per-class hashes — while the per-class
-    hashes ride ``entries[*].class_hash`` so a mismatch NAMES the class. Each
-    class hash folds that entry's ``range_digest`` (the #723 S3 requirement:
-    three exports differing ONLY in declared range produced identical node-only
-    digests) plus its coordinate and graph-interface block.
-
-    CONTRACT-FACTS SHAPE CHANGE (v1 -> v2, pgw#758): this re-keys every
-    published ``aot-inductor`` cell; single-graph format-1 cells are RETIRED —
-    correct and expected under exact identity.
-
-    CONTRACT-FACTS SHAPE CHANGE (v2 -> v3, pgw#817): ``shell_digest`` joined
-    the facts for the (since-retired) regional kind. pgw#846 retires regional
-    but deliberately KEEPS the v3 shape with ``shell_digest`` pinned ``""``
-    and the ``mode`` axis ``""`` — the whole-graph key is byte-identical to
-    what it was before and after pgw#817, so nothing re-keys.
+    A missing fact is a :class:`MintRefused` here because at mint time it means
+    this pod cannot name its own product; the same absence at publish time is a
+    publish refusal, not a fallback.
     """
-
-    sm = str(meta.get("sm") or "")
-    if not sm:
-        raise MintRefused(
-            "cannot state the compute capability (sm) of this runtime; an "
-            "exported cell has no identity without it — mint on the target GPU")
-    entries = dict(meta.get("entries") or {})
-    combined = str(meta.get("combined_graph_hash") or "")
-    if not entries or not combined:
-        raise MintRefused(
-            "the envelope recorded no entries/combined_graph_hash; a "
-            "multi-graph cell must not be keyed without its class set "
-            "(pgw#716/#758)")
-    unhashed = sorted(
-        name for name, block in entries.items()
-        if not str((block or {}).get("class_hash") or ""))
-    if unhashed:
-        raise MintRefused(
-            f"entries {unhashed[:4]!r} carry no class_hash; a class the key "
-            f"cannot name is a class a mismatch cannot name (pgw#716)")
-    contract_facts: Dict[str, Any] = {
-        "v": 3,
-        "combined_graph_hash": combined,
-        # pgw#846: always "" — kept in the v3 shape so the whole-graph
-        # contract digest (and every derived cell identity) does not move.
-        "shell_digest": "",
-        "targets": sorted({
-            str((block or {}).get("target") or "") for block in entries.values()}),
-        "shapes": sorted([int(v) for v in row] for row in spec.shapes),
-        "text_lens": sorted({int(v) for v in spec.text_lens}),
-        "guidance": sorted(float(v) for v in spec.guidance_scales),
-        "lora_bucket": int(spec.lora_bucket or 0),
-        "strict": bool(spec.strict),
-    }
-    contract = cell_key.contract_digest(contract_facts)
-    return cell_key.from_axes({
-        "format": str(meta.get("format") or ""),
-        "kind": aot_serve.ARTIFACT_KIND,
-        "family": str(meta.get("family") or ""),
-        "lane": spec.execution_lane_label(),
-        # pgw#846: an exported cell is always whole-graph again; "" is the
-        # optional-axis value `from_axes` omits, matching every pre-regional
-        # whole-graph key.
-        "mode": "",
-        "sm": sm,
-        "contract": contract,
-        "env_seal": env_seal.seal_digest(dict(meta.get(env_seal.SEAL_KEY) or {})),
-        "toolchain": cell_key.facts_digest(dict(meta.get("toolchain") or {})),
-    })
+    try:
+        return cell_key.from_exported_artifact_metadata(meta)
+    except cell_key.CellKeyError as exc:
+        raise MintRefused(str(exc)) from exc
 
 
 def _state_dict_keys(module: Any) -> Tuple[str, ...]:

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -91,6 +91,19 @@ _REQUIRED = ("format", "kind", "family", "sm", "contract", "env_seal",
 # compilation ("regional" per-block cells are different artifacts, ie#381).
 _OPTIONAL = ("lane", "mode")
 
+#: The `kind` AXIS VALUE (and envelope `kind`) of an exported .pt2 cell — the
+#: only publishable kind since pgw#1010. `from_axes` validates axis NAMES, so
+#: the value discriminates without a KEY_SCHEME bump.
+EXPORTED_KIND = "aot-inductor"
+
+#: pgw#1046: the envelope block recording an exported cell's DECLARED TRAFFIC
+#: (shapes / text_lens / guidance). It is not an axis — it is the last part of
+#: the `contract` axis's input that used to exist only in the mint's live
+#: `ExportSpec`. Recorded, the whole exported-cell key is recomputable from the
+#: artifact alone, which is what lets publish state full identity axes instead
+#: of a subset (`fleet_cells._identity_axes`).
+EXPORT_TRAFFIC_KEY = "declared_traffic"
+
 
 class CellKeyError(ValueError):
     """The runtime cannot state a required key axis."""
@@ -240,16 +253,17 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     EXPORTED (``aot-inductor``) cells are refused here BY NAME (pgw#735): they
     ride the same key space — the axis names are what :func:`from_axes`
     validates, and the kind is an envelope value, so no scheme bump was needed —
-    but their axes are not an inductor cache's, and their key is STAMPED at mint.
-    Read ``meta["cell_key"]``; do not recompute an exported cell's identity from
-    these fields.
+    but their axes are not an inductor cache's. Call
+    :func:`from_exported_artifact_metadata`, which recomputes them from the
+    blocks that kind records.
     """
     kind = str(meta.get("kind") or "")
-    if kind == "aot-inductor":
+    if kind == EXPORTED_KIND:
         raise CellKeyError(
-            "artifact kind 'aot-inductor' (exported .pt2) has a STAMPED key — "
-            "read meta['cell_key'] instead of recomputing from inductor-cache "
-            f"axes (stamped={str(meta.get('cell_key') or '') or 'MISSING'})")
+            "artifact kind 'aot-inductor' (exported .pt2) keys off its own "
+            "recorded blocks — call from_exported_artifact_metadata() instead "
+            "of recomputing from inductor-cache axes "
+            f"(stamped={str(meta.get('cell_key') or '') or 'MISSING'})")
     if kind != "torch-inductor-cache":
         raise CellKeyError(f"artifact kind {kind!r} has no cell-key identity")
 
@@ -280,6 +294,104 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
         ),
         "mode": "" if mode == "whole" else mode,
         "sm": str(meta.get("sm") or ""),
+        "contract": contract_digest(contract_facts),
+        "env_seal": env_seal.seal_digest(seal),
+        "toolchain": facts_digest(toolchain),
+    })
+
+
+def from_exported_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
+    """The key an EXPORTED (``aot-inductor``) cell's OWN recorded facts describe.
+
+    The counterpart of :func:`from_artifact_metadata` for the only publishable
+    kind (pgw#1010), and the SINGLE implementation of that key: ``aot_mint``
+    stamps what this returns and the publish path recomputes it, so the axes a
+    cell is published under cannot drift from the axes its key was minted from.
+
+    Every axis is read from a recorded block, never from a probe and never from
+    the ``cell_key`` stamp (pgw#1046 recorded ``declared_traffic`` for exactly
+    this reason — the traffic contract used to live only in the mint's
+    ``ExportSpec``, so an artifact could not restate its own ``contract`` axis
+    and publish fell back to a 6-axis subset carrying neither ``toolchain`` nor
+    ``env_seal``). Raises :class:`CellKeyError` when a fact is missing: a cell
+    that cannot name an axis has no identity, and must not be published under a
+    partial one.
+
+    The ``contract`` axis is the pgw#716 formula: the cell keys on the
+    ``combined_graph_hash`` — first 16 hex of the sha256 over the
+    newline-joined SORTED per-class hashes — while the per-class hashes ride
+    ``entries[*].class_hash`` so a mismatch NAMES the class.
+
+    CONTRACT-FACTS SHAPE (v3, pgw#758/#817/#846): ``shell_digest`` and the
+    ``mode`` axis are pinned ``""`` since regional was retired, so the
+    whole-graph key is byte-identical to what it has been since pgw#758.
+    pgw#1046 changed WHERE the facts are read from, never their shape — no
+    cell re-keys.
+    """
+    kind = str(meta.get("kind") or "")
+    if kind != EXPORTED_KIND:
+        raise CellKeyError(
+            f"artifact kind {kind!r} is not an exported cell; call "
+            "from_artifact_metadata() for an inductor cache")
+    sm = str(meta.get("sm") or "")
+    if not sm:
+        raise CellKeyError(
+            "cannot state the compute capability (sm) of this runtime; an "
+            "exported cell has no identity without it — mint on the target GPU")
+    entries = dict(meta.get("entries") or {})
+    combined = str(meta.get("combined_graph_hash") or "")
+    if not entries or not combined:
+        raise CellKeyError(
+            "the envelope recorded no entries/combined_graph_hash; a "
+            "multi-graph cell must not be keyed without its class set "
+            "(pgw#716/#758)")
+    unhashed = sorted(
+        name for name, block in entries.items()
+        if not str((block or {}).get("class_hash") or ""))
+    if unhashed:
+        raise CellKeyError(
+            f"entries {unhashed[:4]!r} carry no class_hash; a class the key "
+            f"cannot name is a class a mismatch cannot name (pgw#716)")
+    traffic = meta.get(EXPORT_TRAFFIC_KEY)
+    if not isinstance(traffic, dict) or not traffic:
+        raise CellKeyError(
+            f"artifact records no {EXPORT_TRAFFIC_KEY!r} block; its declared "
+            "traffic contract is unrecoverable, so the 'contract' axis cannot "
+            "be restated from the artifact (pgw#1046)")
+    seal = meta.get(env_seal.SEAL_KEY)
+    if not isinstance(seal, dict) or not seal:
+        raise CellKeyError(
+            "artifact records no env_seal block; no key identity — its "
+            "execution environment is unproven")
+    toolchain = meta.get("toolchain")
+    if not isinstance(toolchain, dict) or not toolchain:
+        raise CellKeyError(
+            "artifact records no toolchain block; no recipe identity")
+    contract_facts: Dict[str, Any] = {
+        "v": 3,
+        "combined_graph_hash": combined,
+        "shell_digest": "",
+        "targets": sorted({
+            str((block or {}).get("target") or "") for block in entries.values()}),
+        "shapes": sorted(
+            [int(v) for v in row] for row in (traffic.get("shapes") or ())),
+        "text_lens": sorted({int(v) for v in (traffic.get("text_lens") or ())}),
+        "guidance": sorted(float(v) for v in (traffic.get("guidance") or ())),
+        "lora_bucket": int(meta.get("lora_bucket") or 0),
+        "strict": bool(meta.get("strict_export")),
+    }
+    return from_axes({
+        "format": str(meta.get("format") or ""),
+        "kind": EXPORTED_KIND,
+        "family": str(meta.get("family") or ""),
+        "lane": _canonical_execution_lane(
+            str(meta.get("weight_lane") or ""),
+            int(meta.get("lora_bucket") or 0),
+        ),
+        # pgw#846: an exported cell is always whole-graph; "" is the
+        # optional-axis value `from_axes` omits.
+        "mode": "",
+        "sm": sm,
         "contract": contract_digest(contract_facts),
         "env_seal": env_seal.seal_digest(seal),
         "toolchain": facts_digest(toolchain),
@@ -326,12 +438,15 @@ def mismatch(meta: Mapping[str, Any], requested: "str | CellKey") -> str:
 
 __all__ = [
     "KEY_SCHEME",
+    "EXPORTED_KIND",
+    "EXPORT_TRAFFIC_KEY",
     "CellKey",
     "CellKeyError",
     "compute",
     "contract_digest",
     "facts_digest",
     "from_artifact_metadata",
+    "from_exported_artifact_metadata",
     "from_axes",
     "is_key",
     "mismatch",

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -499,7 +499,7 @@ class CellPublisher:
                 "it is fenced (pgw#712)")
         key = str(meta.get("cell_key") or "").strip()
         if not key:
-            key = cell_key.from_artifact_metadata(meta).digest
+            key = _recomputed_key(meta).digest
         axes = {
             "sku": str(meta.get("sku") or ""),
             "image_digest": self.image_digest,
@@ -635,47 +635,70 @@ def _publish_failure_phase(exc: BaseException) -> str:
     return type(exc).__name__
 
 
-def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
-    """The ck axes that hash into this cell's key, for the hub's inventory.
+#: pgw#1046: the published axis carrying the artifact's ``combined_graph_hash``
+#: — the value pgw#903's pre-dlopen fence compares against
+#: ``Arm.graph_contract_digest``, and the key tensorhub's producer reads
+#: (``runattempt.ArmFromVerifiedCell``, `axisGraphContract`). NOT a ck axis: it
+#: does not hash into the key directly, it is folded into the ``contract`` axis
+#: via the contract facts. It rides this map because this map is the only
+#: channel the hub has for facts it cannot recompute.
+GRAPH_CONTRACT_AXIS = "graph_contract"
 
-    Recomputed from the artifact's OWN recorded axes so a stamp can never
-    disagree with what it summarizes — the same rule
-    :func:`cell_key.from_artifact_metadata` enforces for the key itself.
 
-    Two artifacts legitimately cannot state them: EXPORTED (``aot-inductor``)
-    cells carry a STAMPED key whose axes are not an inductor cache's
-    (pgw#735), and pre-key artifacts record no contract block at all. Both
-    fall back to the axes the metadata does hold, so the hub still learns the
-    family, the lane and the card rather than nothing. Never raises — an
-    inventory detail must not fail a publish.
+def _recomputed_key(meta: Mapping[str, Any]) -> CellKey:
+    """The key this cell's OWN recorded facts describe, by kind.
+
+    One dispatch for the whole publish path, so the key a cell is published
+    UNDER and the axes it is published WITH can never come from two different
+    derivations of its metadata.
     """
     try:
-        return {k: str(v) for k, v in
-                cell_key.from_artifact_metadata(meta).axes_dict().items()}
-    except Exception:  # noqa: BLE001 — diagnostic only, never fatal
-        pass
-    fallback: Dict[str, str] = {}
-    for name, value in (
-        ("family", family or meta.get("family")),
-        ("kind", meta.get("kind")),
-        ("format", meta.get("format")),
-        ("sm", meta.get("sm")),
-        ("mode", meta.get("compile_mode")),
-    ):
-        text = str(value or "").strip()
-        if text:
-            fallback[name] = text
-    try:
-        base, observed = cc.execution_lane_bucket(str(meta.get("weight_lane") or ""))
-        bucket = observed or int(meta.get("lora_bucket") or 0)
-        token = cc.execution_lane_token(base)
-        execution_lane = f"{token}-lora{bucket}" if bucket and token else (
-            f"lora{bucket}" if bucket else token)
-        if execution_lane:
-            fallback["lane"] = execution_lane
-    except Exception:  # noqa: BLE001
-        pass
-    return fallback
+        if str(meta.get("kind") or "") == cell_key.EXPORTED_KIND:
+            return cell_key.from_exported_artifact_metadata(meta)
+        return cell_key.from_artifact_metadata(meta)
+    except cell_key.CellKeyError as exc:
+        raise CellPublishRefused(
+            f"cell states no computable identity ({exc}); publishing it under "
+            "partial axes would produce a row the fleet cannot arm from "
+            "(pgw#1046)") from exc
+
+
+def _identity_axes(family: str, meta: dict) -> Dict[str, str]:
+    """The identity axes the hub records for this cell, RECOMPUTED from the
+    artifact's own facts.
+
+    This is not inventory. th#1457's producer builds the worker's
+    ``ExecutionSpec`` out of exactly this map: ``ArtifactFromCellRecord`` reads
+    ``toolchain`` and ``env_seal`` from it, ``ArmFromVerifiedCell`` reads
+    ``graph_contract``, and pgw#904's landed consumer REFUSES an
+    ``ArtifactIdentity`` missing any of them. A row published without them is a
+    cell the fleet can never arm.
+
+    So this FAILS CLOSED (pgw#1046). It used to fall back for exported cells —
+    the only publishable kind since pgw#1010 — to ``{family, kind, format, sm,
+    mode, lane}``, dropping both digests, on the reasoning that "an inventory
+    detail must not fail a publish". The detail is not inventory, and a cell
+    published under a partial identity costs a whole mint to discover. A mint
+    that cannot name an axis raises :class:`CellPublishRefused` here, before a
+    byte moves.
+
+    ``graph_contract`` is the one entry that is not a ck axis; see
+    :data:`GRAPH_CONTRACT_AXIS`.
+    """
+    kind = str(meta.get("kind") or "")
+    key = _recomputed_key(meta)
+    stamped = str(meta.get("cell_key") or "").strip()
+    if stamped and stamped != key.digest:
+        raise CellPublishRefused(
+            f"cell_key stamp {stamped} disagrees with the key its recorded "
+            f"axes describe ({key.digest}); refusing to publish an identity "
+            "the artifact does not corroborate")
+    axes = {k: str(v) for k, v in key.axes_dict().items()}
+    if kind == cell_key.EXPORTED_KIND:
+        # Non-empty by construction: the key above refuses a cell whose
+        # envelope records no `combined_graph_hash` at all.
+        axes[GRAPH_CONTRACT_AXIS] = str(meta["combined_graph_hash"]).strip()
+    return axes
 
 
 #: pgw#815: publishes currently in flight, keyed by cell key. A self-mint

--- a/tests/harness/cell_meta.py
+++ b/tests/harness/cell_meta.py
@@ -1,0 +1,54 @@
+"""pgw#1046: build a REAL exported-cell envelope for the publish-path tests.
+
+The publish path recomputes a cell's identity from its own recorded blocks and
+refuses anything that cannot state one — because the axis map it declares is
+what tensorhub's RunAttempt producer builds ``Arm.artifact`` /
+``Arm.graph_contract_digest`` out of, and pgw#904's landed consumer refuses an
+``ArtifactIdentity`` missing any of them. A stub ``{"cell_key": …, "sku": …}``
+is therefore no longer a publishable cell in any tree, and a test that ships one
+proves only that an unarmable row still uploads.
+
+This is the minimal envelope that IS one: the same blocks ``aot_mint`` records
+(``aot_serve.artifact_metadata`` + ``shared_identity_blocks``), at fixture
+scale. The ``cell_key`` is COMPUTED, never invented, so the stamp and the axes
+agree — which is itself one of the publish path's refusals.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from gen_worker import aot_serve, cell_key
+
+CLASS_HASH = "a" * 16
+
+
+def exported_cell_meta(
+    *,
+    family: str = "fam",
+    sku: str = "l4",
+    sm: str = "89",
+    gen_worker: str = "0.87.0",
+    weight_lane: str = "",
+    lora_bucket: int = 0,
+    **extra: Any,
+) -> Dict[str, Any]:
+    """One exported (``aot-inductor``) cell's metadata, key stamped from it."""
+    meta: Dict[str, Any] = {
+        "family": family, "sku": sku, "sm": sm, "gen_worker": gen_worker,
+        "kind": aot_serve.ARTIFACT_KIND, "format": "pt2",
+        "weight_lane": weight_lane, "lora_bucket": int(lora_bucket),
+        "strict_export": True,
+        "entries": {"unet/main": {
+            "target": "unet", "fork": [], "class_dims": [],
+            "range_digest": "r1", "class_hash": CLASS_HASH, "graph": {"v": 2},
+        }},
+        "combined_graph_hash": aot_serve.combined_graph_hash([CLASS_HASH]),
+        "env_seal": {"v": 1, "torch": "2.9.0"},
+        "toolchain": {"torch": "2.9.0", "cuda": "12.8"},
+        "declared_traffic": {
+            "shapes": [[1024, 1024]], "text_lens": [77], "guidance": [7.5]},
+    }
+    meta.update(extra)
+    meta["cell_key"] = cell_key.from_exported_artifact_metadata(meta).digest
+    return meta

--- a/tests/test_aot_adapter_fork_pgw790.py
+++ b/tests/test_aot_adapter_fork_pgw790.py
@@ -238,7 +238,7 @@ def test_the_pipeline_is_left_armed_after_the_branchless_exports(cell) -> None:
 
 def test_the_stamped_key_is_recomputable_from_the_recorded_facts(cell) -> None:
     meta = dict(cell["result"].metadata)
-    assert aot_mint.cell_identity(meta, _spec()).digest == meta["cell_key"]
+    assert aot_mint.cell_identity(meta).digest == meta["cell_key"]
 
 
 def test_identity_is_a_function_of_the_declaration_not_of_adapter_state(

--- a/tests/test_aot_declaration_pgw739.py
+++ b/tests/test_aot_declaration_pgw739.py
@@ -650,11 +650,16 @@ def test_fork_and_row_reach_the_cell_identity() -> None:
         entry["class_hash"] = ch
         meta = {
             "sm": "sm_89", "format": 2, "family": "sdxl-shaped",
+            "kind": aot_serve.ARTIFACT_KIND,
             "entries": {"unet/main": entry},
             "combined_graph_hash": aot_serve.combined_graph_hash([ch]),
+            # pgw#1046: every key input is now a RECORDED block, so this
+            # fixture states them rather than relying on an empty-dict digest.
+            "env_seal": {"v": 1}, "toolchain": {"torch": "2.9.0"},
+            "declared_traffic": {"shapes": [], "text_lens": [], "guidance": []},
+            "lora_bucket": 0, "strict_export": True,
         }
-        spec = ExportSpec(family="sdxl-shaped", target="unet")
-        return aot_mint.cell_identity(meta, spec).digest
+        return aot_mint.cell_identity(meta).digest
 
     a = _identity([["cfg", True]], [])
     b = _identity([["cfg", False]], [])

--- a/tests/test_aot_mint_pgw723.py
+++ b/tests/test_aot_mint_pgw723.py
@@ -753,7 +753,7 @@ def test_mint_produces_a_packed_keyed_gated_cell(cell: Dict[str, Any]) -> None:
     assert meta["toolchain"] and meta["sm"] == "sm_89"
     # pgw#1034: the envelope records NO `code_closure` — nothing ever read it.
     assert "code_closure" not in meta
-    assert aot_mint.cell_identity(meta, _cell_spec()).digest == result.cell_key
+    assert aot_mint.cell_identity(meta).digest == result.cell_key
 
     # The mint-phase table (#757): the class count and the phases are data —
     # on the RESULT/published metadata, never in the packed envelope (the
@@ -899,7 +899,7 @@ def _meta_for(program: Any, package: Path, spec: aot_mint.ExportSpec) -> Dict[st
         lora_bucket=spec.lora_bucket,
     )
     meta.update(aot_mint.shared_identity_blocks(spec))
-    meta["cell_key"] = aot_mint.cell_identity(meta, spec).digest
+    meta["cell_key"] = aot_mint.cell_identity(meta).digest
     return meta
 
 
@@ -973,11 +973,11 @@ def test_cell_identity_refuses_an_artifact_with_no_class_set(
     hollow["entries"] = {}
     hollow["combined_graph_hash"] = ""
     with pytest.raises(aot_mint.MintRefused, match="entries"):
-        aot_mint.cell_identity(hollow, spec)
+        aot_mint.cell_identity(hollow)
     unhashed = json.loads(json.dumps(meta))
     unhashed["entries"][ENTRY]["class_hash"] = ""
     with pytest.raises(aot_mint.MintRefused, match="class_hash"):
-        aot_mint.cell_identity(unhashed, spec)
+        aot_mint.cell_identity(unhashed)
 
 
 def test_cell_identity_refuses_an_artifact_with_no_sm(
@@ -987,7 +987,7 @@ def test_cell_identity_refuses_an_artifact_with_no_sm(
     meta = _meta_for(_export_lifted(), packages["code_only"], spec)
     meta["sm"] = ""
     with pytest.raises(aot_mint.MintRefused, match="compute capability"):
-        aot_mint.cell_identity(meta, spec)
+        aot_mint.cell_identity(meta)
 
 
 def test_key_scheme_is_unchanged_by_the_new_kind(
@@ -997,7 +997,7 @@ def test_key_scheme_is_unchanged_by_the_new_kind(
     discriminator, so no KEY_SCHEME bump strands the dynamo cells."""
     spec = _spec()
     meta = _meta_for(_export_lifted(), packages["code_only"], spec)
-    key = aot_mint.cell_identity(meta, spec)
+    key = aot_mint.cell_identity(meta)
     assert key.axes_dict()["kind"] == aot_serve.ARTIFACT_KIND
     assert key.digest.startswith(cell_key.KEY_SCHEME + "-")
     assert cell_key.is_key(key.digest)

--- a/tests/test_aot_multigraph_pgw758.py
+++ b/tests/test_aot_multigraph_pgw758.py
@@ -150,15 +150,14 @@ def test_combined_graph_hash_is_the_verbatim_ck6_formula() -> None:
 
 def test_cell_key_folds_the_combined_hash(minted_cell) -> None:
     meta = dict(minted_cell["result"].metadata)
-    spec = aot_mint.ExportSpec(family=FAMILY, target="")
-    assert aot_mint.cell_identity(meta, spec).digest == meta["cell_key"]
+    assert aot_mint.cell_identity(meta).digest == meta["cell_key"]
     # Perturb one entry's class hash: the combined hash — and the key — move.
     meta2 = json.loads(json.dumps(meta))
     name = next(iter(meta2["entries"]))
     meta2["entries"][name]["class_hash"] = "0" * 16
     meta2["combined_graph_hash"] = aot_serve.combined_graph_hash(
         row["class_hash"] for row in meta2["entries"].values())
-    assert aot_mint.cell_identity(meta2, spec).digest != meta["cell_key"]
+    assert aot_mint.cell_identity(meta2).digest != meta["cell_key"]
 
 
 def test_per_class_hashes_ride_metadata_and_name_the_class(minted_cell) -> None:

--- a/tests/test_cell_declare_bound_th1645_pgw987.py
+++ b/tests/test_cell_declare_bound_th1645_pgw987.py
@@ -44,9 +44,14 @@ from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure, http_origin
 from gen_worker.convert.hub import HubPublishError
 from gen_worker.models import chunk_upload as cu
+from harness.cell_meta import exported_cell_meta
 
-CELL_KEY = "ck5-34b26365277a504655e6fe4f6bb42071b70df90aef1612a777325bcc"
 FAMILY = "sdxl"
+# pgw#1046: computed from `_meta()`'s identity blocks, never invented — the
+# publish path refuses a stamp its recorded axes do not describe.
+CELL_KEY = exported_cell_meta(
+    family=FAMILY, sku="rtx-4090", gen_worker="0.91.0",
+    weight_lane="w8a8", lora_bucket=64)["cell_key"]
 
 # The hub's group-wide default (internal/api/api.go: `maxRequestBodyMiddleware(32 << 20)`).
 HUB_BODY_CAP = 32 << 20
@@ -261,10 +266,13 @@ def _guard_manifest(graphs: int, rows: int) -> dict:
 def _meta() -> dict:
     """A real cell envelope: the 34 keys a published sdxl cell carries, with
     the two unbounded blocks at their measured magnitudes."""
-    meta = {
-        "cell_key": CELL_KEY, "family": FAMILY, "sku": "rtx-4090", "sm": "89",
-        "gen_worker": "0.91.0", "kind": "aot-inductor-export", "format": "pt2",
-        "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
+    # pgw#1046: the identity blocks are REAL (the publish path recomputes the
+    # key from them and refuses a cell that cannot state one); everything after
+    # them is the measured bulk this test exists to size.
+    meta = exported_cell_meta(
+        family=FAMILY, sku="rtx-4090", gen_worker="0.91.0",
+        weight_lane="w8a8", lora_bucket=64)
+    meta |= {
         "torch": "2.9.0+cu128", "triton": "3.5.0", "cuda": "12.8",
         "cuda_driver": "570.86", "storage_dtype": "fp8", "source_ref": "root/sdxl",
         "source_digest": "", "family_reason": "declared-by-endpoint",
@@ -273,8 +281,6 @@ def _meta() -> dict:
         "guidance_scales": [7.5], "content_keys": ["unet", "vae"],
         "libs": ["diffusers"], "image_digest": "sha256:" + "e" * 64,
         "graph_signature": "sha256:" + "f" * 32,
-        "env_seal": {"seal": "sha256:" + "a" * 64},
-        "toolchain": {"nvcc": "12.8", "gcc": "13.2"},
         "loaded_libs": {f"lib{i}": f"1.{i}.0" for i in range(40)},
         "code_closure": {f"fn_{i}": "sha256:" + "b" * 64 for i in range(60)},
         # The two unbounded blocks, at measured magnitude.

--- a/tests/test_cell_publish_v2_pgw807.py
+++ b/tests/test_cell_publish_v2_pgw807.py
@@ -31,13 +31,13 @@ from pathlib import Path
 
 import pytest
 
+from gen_worker import aot_serve, cell_key, env_seal
 from gen_worker import fleet_cells as fc
 from gen_worker import receipts
 from gen_worker.convert.hub import HubPublishError
 from gen_worker.models import chunk_upload as cu
 from gen_worker.procsplit import actions
 
-CELL_KEY = "ck1-" + "b" * 56
 FAMILY = "sdxl"
 
 # Small enough to keep the test in kilobytes, large enough that the artifact
@@ -228,8 +228,35 @@ def artifact(tmp_path: Path) -> Path:
     return out
 
 
+# pgw#1046: a REAL exported-cell envelope, not the identity-less stub this
+# fixture used to carry. The publish path now recomputes the cell's key from
+# these blocks and refuses anything that cannot state one, so a stub here would
+# only prove that a cell the fleet can never arm still uploads.
+_CLASS_HASH = "a" * 16
+GRAPH_CONTRACT = aot_serve.combined_graph_hash([_CLASS_HASH])
 META = {
-    "cell_key": CELL_KEY, "family": FAMILY, "sku": "l4", "sm": "89",
+    "family": FAMILY, "sku": "l4", "sm": "89",
+    "gen_worker": "0.87.0", "kind": "aot-inductor", "format": "pt2",
+    "weight_lane": "w8a8", "lora_bucket": 64, "strict_export": True,
+    "entries": {"unet/main": {
+        "target": "unet", "fork": [], "class_dims": [],
+        "range_digest": "r1", "class_hash": _CLASS_HASH, "graph": {"v": 2},
+    }},
+    "combined_graph_hash": GRAPH_CONTRACT,
+    "env_seal": {"v": 1, "torch": "2.9.0"},
+    "toolchain": {"torch": "2.9.0", "cuda": "12.8"},
+    "declared_traffic": {
+        "shapes": [[1024, 1024]], "text_lens": [77], "guidance": [7.5]},
+}
+CELL_KEY = cell_key.from_exported_artifact_metadata(META).digest
+META["cell_key"] = CELL_KEY
+
+#: The shape every cell in the corpus was published under before pgw#1046 —
+#: `_identity_axes`' six-axis FALLBACK, carrying neither identity digest. Kept
+#: as a fixture so the refusal below is pinned against the real historical row,
+#: not against an invented one.
+TODAYS_FALLBACK_META = {
+    "cell_key": "ck1-" + "b" * 56, "family": FAMILY, "sku": "l4", "sm": "89",
     "gen_worker": "0.87.0", "kind": "aot-inductor", "format": "pt2",
     "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
 }
@@ -307,6 +334,82 @@ def test_intent_carries_the_identity_axes_and_the_mint_cost(hub, artifact):
     # decodes no such fields, so sending them was a blake3 hash pass whose
     # result nothing read.
     assert set(complete) == {"family", "cell_key", "checkpoint_id", "ok"}
+
+
+# ---------------------------------------------------------------------------
+# pgw#1046 — what the hub needs to ARM the cell it just accepted
+#
+# th#1457's producer builds the worker's ExecutionSpec out of this exact map:
+# `ArtifactFromCellRecord` reads `toolchain`/`env_seal`, `ArmFromVerifiedCell`
+# reads `graph_contract`, and pgw#904's landed consumer refuses an
+# ArtifactIdentity missing any of them. Before this, EVERY published cell fell
+# to a six-axis subset that carried none — so the whole corpus was structurally
+# unarmable, and it cost a mint per pod to find out.
+# ---------------------------------------------------------------------------
+
+
+def test_publish_intent_states_the_full_arming_identity(hub, artifact):
+    """GREEN. The three axes the hub cannot recompute reach it, each recomputed
+    from the artifact's OWN recorded blocks — plus the complete ck axis set.
+
+    RED before the fix: `identity_axes` was
+    ``{family, kind, format, sm, mode, lane}`` and this asserts on three keys
+    that were not in it."""
+    _publisher(hub).publish(FAMILY, artifact, dict(META))
+    intent = next(b for p, b in hub.httpd.calls if p.endswith("publish-intent"))
+    axes = intent["identity_axes"]
+
+    # Derived from the recorded blocks, never from a second stamp.
+    assert axes["toolchain"] == cell_key.facts_digest(META["toolchain"])
+    assert axes["env_seal"] == env_seal.seal_digest(META["env_seal"])
+    assert axes[fc.GRAPH_CONTRACT_AXIS] == GRAPH_CONTRACT
+
+    # ...and the axes hash to the key the cell is published under, so the hub's
+    # row and its flavor cannot describe two different cells.
+    ck = {k: v for k, v in axes.items() if k != fc.GRAPH_CONTRACT_AXIS}
+    assert cell_key.from_axes(ck).digest == intent["cell_key"] == CELL_KEY
+    assert set(ck) == {"format", "kind", "family", "lane", "sm",
+                       "contract", "env_seal", "toolchain"}
+
+
+def test_the_pre_fix_fallback_row_shape_can_no_longer_be_published(hub, artifact):
+    """RED-CHAIN PIN. The exact envelope the corpus was published from is now
+    refused BEFORE a byte moves, by name, instead of producing the six-axis row
+    tensorhub's `TestTH1457TodaysFallbackAxesRowRefusesTyped` proves unarmable.
+
+    That hub-side test stays valid and must not be weakened: it guards the
+    REFUSAL of a row shape that already exists in the store. This test guards
+    the other end — that the worker can no longer create one."""
+    with pytest.raises(fc.CellPublishRefused) as exc:
+        _publisher(hub).publish(FAMILY, artifact, dict(TODAYS_FALLBACK_META))
+    assert "no computable identity" in str(exc.value)
+    assert not hub.httpd.calls, "refused before the intent left the pod"
+
+    # And the shape itself is unreachable: nothing in the publish path can
+    # still emit an axis map without the two identity digests.
+    with pytest.raises(fc.CellPublishRefused):
+        fc._identity_axes(FAMILY, dict(TODAYS_FALLBACK_META))
+
+
+def test_a_stamp_that_disagrees_with_the_recorded_axes_is_refused(hub, artifact):
+    """A cell whose `cell_key` does not describe its own blocks is a cell the
+    hub would index under one identity and the worker would fence on another."""
+    forged = dict(META)
+    forged["cell_key"] = "ck1-" + "9" * 56
+    with pytest.raises(fc.CellPublishRefused, match="disagrees"):
+        _publisher(hub).publish(FAMILY, artifact, forged)
+    assert not hub.httpd.calls
+
+
+def test_a_cell_with_no_graph_contract_is_refused(hub, artifact):
+    """pgw#903's pre-dlopen fence compares `Arm.graph_contract_digest` against
+    the artifact's `combined_graph_hash`; a cell that records none can never
+    pass it, so it must never reach the store."""
+    hollow = dict(META)
+    hollow["combined_graph_hash"] = ""
+    with pytest.raises(fc.CellPublishRefused):
+        _publisher(hub).publish(FAMILY, artifact, hollow)
+    assert not hub.httpd.calls
 
 
 def test_seam_authorizes_the_live_publish_payloads(hub, artifact):

--- a/tests/test_exported_proof_pgw735.py
+++ b/tests/test_exported_proof_pgw735.py
@@ -50,14 +50,20 @@ def test_proven_since_requires_new_successful_calls_and_no_revocation():
 
 def test_exported_kind_cell_key_refusals_are_named():
     """cell_key.from_artifact_metadata recomputes INDUCTOR-cache axes. An
-    exported cell rides the same key space but its key is STAMPED at mint,
-    so the refusal must say so by name instead of failing opaquely."""
+    exported cell rides the same key space but not those axes, so the refusal
+    must name the function that DOES key it instead of failing opaquely.
+
+    pgw#1046 changed what that redirect says: an exported cell's key used to be
+    readable only as the mint's stamp, and is now recomputable from the cell's
+    own recorded blocks (``from_exported_artifact_metadata``). The stamp still
+    appears in the message because a caller holding a bad envelope wants to see
+    which cell it was holding."""
     with pytest.raises(cell_key.CellKeyError) as exc:
         cell_key.from_artifact_metadata(
             {"kind": "aot-inductor", "cell_key": "ck1-" + "a" * 56})
     message = str(exc.value)
     assert "aot-inductor" in message
-    assert "cell_key" in message and "STAMPED" in message
+    assert "from_exported_artifact_metadata" in message
     assert "ck1-" + "a" * 56 in message
 
     with pytest.raises(cell_key.CellKeyError) as missing:

--- a/tests/test_fleet_cells.py
+++ b/tests/test_fleet_cells.py
@@ -35,6 +35,7 @@ from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure
 from gen_worker.models import provision
 from gen_worker.cell_adopt import AdoptOutcome
+from harness.cell_meta import exported_cell_meta
 
 
 class _Cfg:
@@ -375,7 +376,10 @@ class _FakeResp:
 
 def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     posts: list = []
-    key = "ck1-" + "c" * 56
+    # pgw#1046: a real exported-cell envelope — the publish path recomputes the
+    # key from its blocks, so an invented one is refused before the intent.
+    meta = exported_cell_meta(sku="b200", gen_worker="0.39.0")
+    key = meta["cell_key"]
 
     def _post(url, headers=None, json=None, timeout=None):
         posts.append((url, json))
@@ -432,7 +436,6 @@ def test_publisher_drives_intent_publish_v2_complete(monkeypatch, tmp_path):
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "worker-jwt",
         image_digest="sha256:img")
-    meta = {"cell_key": key, "sku": "b200", "gen_worker": "0.39.0"}
     assert pub.publish("fam", artifact, meta) == "cp-42"
 
     intent_url, intent_body = posts[0]
@@ -481,7 +484,7 @@ def test_publisher_typed_refusal_is_terminal(monkeypatch, tmp_path):
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "worker-jwt", image_digest="d")
     with pytest.raises(fc.CellPublishRefused, match="cell_publish_forged_axis"):
-        pub.publish("fam", artifact, {"cell_key": "ck1-" + "d" * 56})
+        pub.publish("fam", artifact, exported_cell_meta())
 
 
 def test_publisher_reports_commit_failure(monkeypatch, tmp_path):
@@ -515,7 +518,7 @@ def test_publisher_reports_commit_failure(monkeypatch, tmp_path):
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "worker-jwt", image_digest="d")
     with pytest.raises(RuntimeError, match="upload exploded"):
-        pub.publish("fam", artifact, {"cell_key": "ck1-" + "e" * 56})
+        pub.publish("fam", artifact, exported_cell_meta())
     complete_url, complete_body = posts[-1]
     assert complete_url.endswith("/publish-complete")
     assert complete_body["ok"] is False and "upload exploded" in complete_body["error"]

--- a/tests/test_mint_credential_expiry_th1423.py
+++ b/tests/test_mint_credential_expiry_th1423.py
@@ -35,16 +35,17 @@ import pytest
 
 from gen_worker import fleet_cells as fc
 from gen_worker.convert.hub import HubPublishError
+from harness.cell_meta import exported_cell_meta
 
 LAPSE_S = 150  # how far past `exp` the presented credential is, in the JWT
-CELL_KEY = "ck1-" + "e" * 56
 FAMILY = "sdxl"
 
-META = {
-    "cell_key": CELL_KEY, "family": FAMILY, "sku": "l4", "sm": "89",
-    "gen_worker": "0.76.6", "kind": "aot-inductor", "format": "pt2",
-    "compile_mode": "regional", "weight_lane": "w8a8", "lora_bucket": 64,
-}
+# pgw#1046: a real exported-cell envelope. The publish path recomputes the key
+# from the recorded blocks and refuses a cell that cannot state one, so the
+# credential-lapse legs below have to ride a cell that could genuinely publish.
+META = exported_cell_meta(family=FAMILY, gen_worker="0.76.6",
+                          weight_lane="w8a8", lora_bucket=64)
+CELL_KEY = META["cell_key"]
 
 
 def _jwt(*, lifetime_s: float) -> str:

--- a/tests/test_recipe_identity.py
+++ b/tests/test_recipe_identity.py
@@ -26,6 +26,7 @@ from gen_worker import compile_cache as cc
 from gen_worker import fleet_cells as fc
 from gen_worker import guard_closure as gc
 from gen_worker.registry import CompileCell
+from harness.cell_meta import exported_cell_meta
 
 FAMILY = "toyfam"
 
@@ -191,7 +192,11 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     posts: list = []
-    key = "ck1-" + "c" * 56
+    # pgw#1046: a real exported-cell envelope — publish recomputes the key from
+    # the recorded blocks and refuses a cell that cannot state one.
+    meta = exported_cell_meta(family=FAMILY, sku="l4", gen_worker="1.0.0",
+                              **{gc.MANIFEST_KEY: _manifest()})
+    key = meta["cell_key"]
 
     class _FakeResp:
         def __init__(self, code: int, body: Dict[str, Any]) -> None:
@@ -232,8 +237,6 @@ def test_publish_complete_carries_only_what_the_hub_decodes(
     monkeypatch.setattr(hub_mod, "HubClient", _FakeHub)
     artifact = tmp_path / "cell.tar.gz"
     artifact.write_bytes(b"cell-bytes")
-    meta = {"cell_key": key, "sku": "l4", "gen_worker": "1.0.0",
-            gc.MANIFEST_KEY: _manifest()}
     pub = fc.CellPublisher(
         base_url="http://hub", worker_jwt=lambda: "jwt", image_digest="")
     assert pub.publish(FAMILY, artifact, meta) == "cp-1"


### PR DESCRIPTION
**th#1457 CUTOVER-READINESS item 1.** Until this lands the coordinated cutover cannot happen: the hub cannot mint an `ArtifactIdentity` the landed pgw#904 consumer accepts, for *any* cell in the fleet.

## The gap

`fleet_cells._identity_axes` computed the publish-intent axis map through `cell_key.from_artifact_metadata`, which refuses `kind="aot-inductor"` **by name** — and since pgw#1010 that is the only publishable kind. So every published cell fell to the six-axis FALLBACK `{family, kind, format, sm, mode, lane}`: no `toolchain`, no `env_seal`. The artifact's `combined_graph_hash` reached the hub nowhere at all.

th#1457's producer reads exactly that map — `ArtifactFromCellRecord` takes `toolchain`/`env_seal`, `ArmFromVerifiedCell` takes `graph_contract` — and pgw#904's landed consumer (`plan._artifact` `_require`s the digests; pgw#903's pre-dlopen fence compares `Arm.graph_contract_digest` against `meta["combined_graph_hash"]`) refuses a spec missing any of them. Every cell in the corpus was structurally unarmable, discoverable only by paying a mint.

## The fix

1. **`cell_key.from_exported_artifact_metadata`** — the exported kind's counterpart of `from_artifact_metadata`, and the SINGLE implementation of that key. `aot_mint.cell_identity(meta)` delegates to it and **loses its `spec` parameter**, so the key the mint stamps and the axes publish declares can no longer be two derivations of one envelope.
2. **The mint records `declared_traffic`** (shapes / text_lens / guidance) — the last contract-fact input that lived only in the live `ExportSpec`, and therefore the reason an exported cell could not restate its own `contract` axis from its own recorded blocks.
3. **Publish declares the full ck axis set + `graph_contract`**, verifies the recomputed key against the `cell_key` stamp, and **fails closed** (`CellPublishRefused`, before a byte moves) when any axis cannot be named. The old "an inventory detail must not fail a publish" reasoning is gone: the map is not inventory, it is the hub's arming input.

## §1.27(g): NO CELL RE-KEYS — cost zero

The contract-facts shape and every axis value are unchanged; only *where the facts are read from* moved. Measured on the same envelope under both trees:

```
OLD  cell_identity(meta, spec) = ck1-4b31d10512b9f62db5e6ea435277be615cfc28e9703a40404d75a1ed
NEW  cell_identity(meta)       = ck1-4b31d10512b9f62db5e6ea435277be615cfc28e9703a40404d75a1ed
     axes identical: contract dbb564f5485af118 / env_seal 3eef4b647ef062dd / toolchain b4730c8c45f2d227
```

Corpus story: pre-fix rows carry no digests hub-side either way (that is the bug), so there is nothing to backfill — they are re-minted naturally. The corpus is effectively one attempt-23 row, which is why now is the cheapest moment.

## RED chain

Integration-style, over the real `CellPublisher.publish` against the localhost hub double the repo already has (real sockets, real chunked upload, real digest-enforcing store).

`fleet_cells._identity_axes` on a **fully-recorded** exported cell:

```
OLD (origin/master d1d92f39): {"family","format","kind","lane","sm"}   missing = [toolchain, env_seal, graph_contract]
NEW:                          {+contract, +env_seal, +graph_contract, +toolchain}   missing = []
```

Four new tests in `tests/test_cell_publish_v2_pgw807.py`, all backported to `d1d92f39` and **all RED there**, green here:

| test | RED on master |
|---|---|
| `test_publish_intent_states_the_full_arming_identity` | axes lack all three keys |
| `test_the_pre_fix_fallback_row_shape_can_no_longer_be_published` | DID NOT RAISE — the fallback row publishes |
| `test_a_stamp_that_disagrees_with_the_recorded_axes_is_refused` | DID NOT RAISE |
| `test_a_cell_with_no_graph_contract_is_refused` | DID NOT RAISE |

**tensorhub's `TestTH1457TodaysFallbackAxesRowRefusesTyped` stays valid and must not be weakened.** It guards the *refusal* of a row shape that already exists in the store; this PR guards the other end — the worker can no longer create one.

Publish-path test fixtures that shipped identity-less stubs (`{"cell_key": …, "sku": …}`) are upgraded to real exported-cell envelopes via a new `tests/harness/cell_meta.exported_cell_meta()`; a stub is no longer a publishable cell in any tree, so a test shipping one proved only that an unarmable row still uploads.

## Verification

- Full `tests/` suite from the worktree, `-n 4 --dist loadfile`: **zero net new failures** vs an `origin/master` baseline run in the same environment (both 29 errors / identical FAILED set — local `uv sync --extra dev` cannot install torch here, so that noise is pre-existing and identical on both sides).
- `mypy src/gen_worker`: no findings in `cell_key.py` / `aot_mint.py` / `fleet_cells.py`.
- `ruff check` clean on every changed file; `lint_http_timeouts`, `lint_config_reads`, `lint_post_connect_resolution`, `lint_unbounded_reads`, `lint_unreached_surface`, `assemble_changelog --check` all pass.

## Fences

**MASTER ONLY — this must NOT ride the v0.96.1 release vehicle** (pgw#1047's lane owns that; it is sequenced with the cutover window's wheel cut per CUTOVER-READINESS item 5). Nothing here touches `models/provision`, `artifact_meta`, `proto/`, or any release/tag/pin machinery.
