### PR TITLE
pgw#1049: the single settings authority — seal from DECLARATION; ambient mutation cannot move cell identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,21 @@ jobs:
       - name: pgw#931 guard - config reads outside the pipeline
         run: uv run python scripts/lint_config_reads.py
 
+      # GATING (pgw#1049): exactly ONE authority writes torch settings
+      # (`us -> pytorch settings`). Any write outside the authority modules
+      # needs a CLASSIFIED line in scripts/settings_writers_allowlist.txt;
+      # stale rows are red too.
+      - name: pgw#1049 guard - torch-settings writes outside the authority
+        run: uv run python scripts/lint_settings_writers.py
+
+      # GATING (pgw#1049): the ambient-input census's structural claims —
+      # IMPOSED rows exist in DECLARED_ENV, NEUTRALIZED rows are actually
+      # scrub-covered, watched env literals in the tree are classified. The
+      # completeness half (against the INSTALLED torch) runs in `tests` as
+      # tests/test_ambient_census_pgw1049.py.
+      - name: pgw#1049 guard - ambient-input census structural claims
+        run: uv run python scripts/lint_ambient_census.py
+
       # GATING (pgw#891/pgw#904): a connected worker may not reconstruct or
       # substitute a Hub decision. The real repair is pgw#891's exact
       # ExecutionSpec and its schema half is th#1457's, so the deletion cannot

--- a/changelog.d/pgw1049.md
+++ b/changelog.d/pgw1049.md
@@ -1,0 +1,46 @@
+- **pgw#1049: the single settings authority — cell identity derives from OUR
+  DECLARATION, and ambient mutation is structurally unable to move it.**
+  Paul's directive: `us -> pytorch settings`, never
+  `[us, random other things] -> pytorch settings`. Three parts, each against
+  a shipped incident class:
+  (1) `settings_authority.py` declares the full imposed configuration —
+  process env (incl. `PYTHONHASHSEED=0`, imposed by entrypoint re-exec,
+  executing the pgw#1034 HUMAN_MUST_DO decision; revert = one declaration
+  entry), torch flags (+ typed knobs), the v2 dynamo shape posture (moved
+  out of compile_cache — it was a second writer, and thread-local: now
+  imposed at the process-wide default layer with a foreign-thread verify),
+  and the host-ISA clamp. It is the ONLY writer of torch settings —
+  `scripts/lint_settings_writers.py` fences the tree (unclassified write =
+  red, stale allowlist row = red); the stray writers it found (executor's
+  pgw#654 TF32 bootstrap, group.py's NVLS disable, compile_cache's autograd
+  cache/semantic tag/recompile-limit writes) now route through the
+  authority.
+  (2) **Seal v3 -> v4**: `env_seal.effective_seal()` digests the
+  DECLARATION, not a read-back — the pgw#1042 class (torch's own
+  `aot_compile` mutating global `aot_inductor.metadata` mid-mint moved the
+  child's sealed identity) is dead by construction, RED-proven against
+  v3's read-back digest. The pgw#719 boot-vs-point-of-use tripwire is KEPT
+  as read-back (now covering dynamo facts and the full portable inductor
+  digest) and re-pointed: boot verifies read-back == declaration fail-closed,
+  so ambient mutation becomes a named pre-trace refusal, never a different
+  key. `aot_mint.mint` now asserts it too. Re-key cost per §1.27(g): every
+  v3 cell re-mints once per (family, lane, sm); the corpus is effectively
+  empty (see the tracker entry for the measured count).
+  (3) Ambient-input census (`scripts/ambient_inputs_census.txt` +
+  `lint_ambient_census.py` + `test_ambient_census_pgw1049.py`, th#1678's
+  enforcement shape): every env input the INSTALLED torch/triton consult is
+  classified IMPOSED / NEUTRALIZED / PLUMBING / IRRELEVANT; an unclassified
+  input — including one a torch upgrade introduces — is red. The census
+  drove real hardening: `SCRUB_PREFIXES` now erases `NCCL_*`, `ATEN_*`,
+  `AOTI*`/`AOT_INDUCTOR*`, `INDUCTOR_*`, `CUTLASS_*`, `KMP_*`,
+  `CUDA_LAUNCH_BLOCKING`, `CUDA_MODULE_LOADING` and the TMA/partitioner/fx
+  behavior knobs, and found `PYTORCH_CUDA_ALLOC_CONF` was silently DEAD
+  (the entrypoint's setdefault was erased by its own scrub before first
+  cudaMalloc) — the declared value is now re-imposed post-scrub, so
+  `expandable_segments` is real for the first time.
+  Also: the vestigial `mode` cell-key axis is DELETED per Paul 2026-08-09 —
+  pinned `""` since regional died and empty optionals never entered the
+  canonical form, so zero digests move and no KEY_SCHEME bump is needed
+  (regional discrimination rides the `contract` axis via
+  `declared_contract_facts`); a stale caller shipping `mode` gets
+  `from_axes`' typed unknown-axis refusal.

--- a/scripts/ambient_inputs_census.txt
+++ b/scripts/ambient_inputs_census.txt
@@ -1,0 +1,149 @@
+# pgw#1049 — the AMBIENT-INPUT CENSUS: every env input torch/triton consult,
+# classified. Enforced two ways (the th#1678 wirecontract shape):
+#
+#   * scripts/lint_ambient_census.py (fast gates, no torch): row syntax;
+#     IMPOSED rows exist in settings_authority.DECLARED_ENV; NEUTRALIZED
+#     rows are covered by env_seal.SCRUB_PREFIXES; every watched-namespace
+#     env literal in src/gen_worker is classified.
+#   * tests/test_ambient_census_pgw1049.py (with torch): scans the INSTALLED
+#     torch/triton tree for env reads — an input this file does not classify
+#     is RED. A torch upgrade that consults a new input fails until a human
+#     classifies it. That is the point.
+#
+# FORMAT: <PATTERN>  <CLASS>  <reason>   (fnmatch pattern, FIRST match wins)
+#
+#   IMPOSED      we set it (settings_authority.DECLARED_ENV); ambient values
+#                are erased and replaced
+#   NEUTRALIZED  erased wholesale by env_seal.scrub_env before torch imports;
+#                cannot reach torch
+#   PLUMBING     a path / device assignment / process-group formation input —
+#                where things are, never what is computed
+#   IRRELEVANT   consulted only on surfaces we do not run (absent backends,
+#                torch's own test/CI/profiling harnesses) or affecting log
+#                output only; the reason must say which
+
+# ── IMPOSED (order matters: these sit inside neutralized namespaces) ──────────
+PYTHONHASHSEED  IMPOSED  interpreter hash seed; entrypoint re-execs (pgw#1049, executes the pgw#1034 decision)
+PYTORCH_CUDA_ALLOC_CONF  IMPOSED  allocator layout; declared expandable_segments
+TORCHINDUCTOR_AUTOGRAD_CACHE  IMPOSED  gw#608 AOT autograd cache off (portable FxGraphCache is the lookup surface)
+NCCL_NVLS_ENABLE  IMPOSED  pgw#929: NVLS cannot bind in our containers; nobody's choice
+TORCHINDUCTOR_CACHE_DIR  PLUMBING  SDK-imposed capture/seed redirect (compile_cache.capture_env, entrypoint pgw#783); content-addressed entries
+TRITON_CACHE_DIR  PLUMBING  same redirect, triton half
+
+# ── NEUTRALIZED namespaces (verified against env_seal.SCRUB_PREFIXES) ─────────
+TORCH*  NEUTRALIZED  the TORCH_*/TORCHINDUCTOR_*/TORCHDYNAMO_*/TORCHELASTIC_* behavior surface
+PYTORCH*  NEUTRALIZED  incl. JIT/ROCM/testing knobs
+TRITON*  NEUTRALIZED  incl. TRITON_PTXAS_PATH (silently different cubins)
+CUBLAS*  NEUTRALIZED  workspace config alters kernel splits
+CUDNN*  NEUTRALIZED  incl. CUDNN_HOME discovery
+NVIDIA_TF32*  NEUTRALIZED  flips numerics under every torch flag
+OMP_*  NEUTRALIZED  thread counts enter cpp codegen
+MKL_*  NEUTRALIZED  same
+KMP_*  NEUTRALIZED  Intel OpenMP runtime
+NCCL_*  NEUTRALIZED  collective transport behavior; what we need is re-imposed (NVLS) or probe-scoped (host_canary)
+ATEN_*  NEUTRALIZED  CPU kernel dispatch (ATEN_CPU_CAPABILITY)
+AOT_INDUCTOR*  NEUTRALIZED  AOTI build/debug knobs (opt level, LTO, symbols)
+AOTINDUCTOR*  NEUTRALIZED  AOTI repro knobs
+AOTI_*  NEUTRALIZED  AOTI runtime knobs
+AOT_PARTITIONER_DEBUG  NEUTRALIZED  partitioner debug
+INDUCTOR_*  NEUTRALIZED  inductor dump/provenance/test knobs
+CUTLASS_*  NEUTRALIZED  kernel-backend tuning
+CUTEDSL_*  NEUTRALIZED  kernel-backend tuning
+CUDA_LAUNCH_BLOCKING  NEUTRALIZED  serializes launches — behavior
+CUDA_MODULE_LOADING  NEUTRALIZED  lazy/eager load behavior
+CUDA_PROFILE  NEUTRALIZED  legacy profiler toggle
+ENABLE_PERSISTENT_TMA_MATMUL  NEUTRALIZED  matmul kernel selection
+ENABLE_TEMPLATE_TMA_STORE  NEUTRALIZED  template store selection
+ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE  NEUTRALIZED  template load selection
+TENSORIFY_PYTHON_SCALARS  NEUTRALIZED  dynamo scalar handling
+FAKE_ALLOW_META  NEUTRALIZED  fake-tensor behavior
+FX_PATCH_GETITEM  NEUTRALIZED  fx tracing behavior
+PARTITIONER_MEMORY_BUDGET_PARETO*  NEUTRALIZED  aot_autograd partitioner behavior
+UNSAFE_SKIP_FSDP_MODULE_GUARDS  NEUTRALIZED  dynamo guard behavior
+
+# ── PLUMBING (paths, device assignment, group formation) ──────────────────────
+CUDA_VISIBLE_DEVICES  PLUMBING  device assignment; procsplit/topology own it, deliberately unscrubbed
+CUDA_HOME  PLUMBING  toolchain discovery (cpp_extension/AOTI link); content rides the image
+CUDA_PATH  PLUMBING  same
+CUDA_INC_PATH  PLUMBING  same
+CUDACXX  PLUMBING  same
+WINDOWS_CUDA_HOME  PLUMBING  windows toolchain discovery (not our OS)
+NVTOOLSEXT_PATH  PLUMBING  nvtx discovery
+NVSHMEM_LIB_DIR  PLUMBING  lib discovery (symmetric memory; unused lane)
+ROCSHMEM_LIB_DIR  PLUMBING  ROCm twin of the above
+CC  PLUMBING  compiler discovery for cpp builds
+CXX  PLUMBING  same
+CPLUS_INCLUDE_PATH  PLUMBING  include discovery
+PATH  PLUMBING  executable discovery
+MAX_JOBS  PLUMBING  cpp_extension build parallelism
+LD_LIBRARY_PATH  PLUMBING  loader input — the pgw#719 loaded-libs digest is the integrity check for what it changes
+LD_PRELOAD  PLUMBING  loader input — same mitigation, named per-library at boot and point-of-use
+CONDA_EXE  PLUMBING  env discovery
+CONDA_PREFIX  PLUMBING  env discovery
+VIRTUAL_ENV  PLUMBING  env discovery
+XDG_*  PLUMBING  cache/config dir discovery
+TEMP_DIR  PLUMBING  torch testing tmp dir
+USER  PLUMBING  identity string in cache paths
+USERNAME  PLUMBING  same, windows
+SYSTEMROOT  PLUMBING  windows
+PROGRAMFILES  PLUMBING  windows
+ProgramFiles  PLUMBING  windows
+VCToolsInstallDir  PLUMBING  windows toolchain
+PYTHON_EXEC  PLUMBING  interpreter discovery (torch build tooling)
+PIP_DISABLE_PIP_VERSION_CHECK  PLUMBING  pip behavior in torch build tooling
+MASTER_ADDR  PLUMBING  process-group formation; our group/canary code sets it per spawn
+MASTER_PORT  PLUMBING  same
+RANK  PLUMBING  torchrun rendezvous input; our workers form groups explicitly
+LOCAL_RANK  PLUMBING  same
+WORLD_SIZE  PLUMBING  same
+LOCAL_WORLD_SIZE  PLUMBING  same
+ROLE_RANK  PLUMBING  same
+INIT_METHOD  PLUMBING  same
+USE_LIBUV  PLUMBING  TCPStore transport selection at group formation
+RPC_INIT_WITH_TCP  PLUMBING  torch RPC tests' rendezvous
+
+# ── IRRELEVANT (absent backends; torch's own test/CI/profiling harnesses) ─────
+HIP_*  IRRELEVANT  ROCm backend absent from our images
+ROCM_HOME  IRRELEVANT  ROCm absent
+ROCM_PATH  IRRELEVANT  ROCm absent
+ROCR_VISIBLE_DEVICES  IRRELEVANT  ROCm absent
+HALIDE_*  IRRELEVANT  halide backend never enabled
+TVM_SCHEDULER  IRRELEVANT  tvm backend never enabled
+LTC_MAX_ASYNC_QUEUE  IRRELEVANT  lazy-tensor backend never enabled
+LEVEL_ZERO_V1_SDK_PATH  IRRELEVANT  XPU absent
+ONEAPI_ROOT  IRRELEVANT  XPU absent
+ZE_AFFINITY_MASK  IRRELEVANT  XPU absent
+ZE_FLAT_DEVICE_HIERARCHY  IRRELEVANT  XPU absent
+QUACK_*  IRRELEVANT  cuteDSL quack kernels not shipped
+CI  IRRELEVANT  torch's own CI harness gates
+IS_FBCODE  IRRELEVANT  meta-internal
+INSIDE_RE_WORKER  IRRELEVANT  meta-internal remote execution
+MAST_HPC_JOB_NAME  IRRELEVANT  meta-internal scheduler
+TW_JOB_USER  IRRELEVANT  meta-internal
+BACKEND  IRRELEVANT  torch testing harness's dist-backend selector
+BENCHMARK_USE_DEV_SHM  IRRELEVANT  torch benchmark harness storage choice
+DISABLED_TESTS_FILE  IRRELEVANT  torch test harness
+SLOW_TESTS_FILE  IRRELEVANT  torch test harness
+DISTRIBUTED_TESTS_DEFAULT_TIMEOUT  IRRELEVANT  torch test harness
+TEST_REPORT_SOURCE_OVERRIDE  IRRELEVANT  torch test harness
+OPINFO_RESTRICT_TO_DSL  IRRELEVANT  torch test harness
+STRICT_DEFAULT  IRRELEVANT  torch testing internal export-strictness default
+NUM_PARALLEL_PROCS  IRRELEVANT  torch test harness
+LOGLEVEL  IRRELEVANT  log verbosity only
+NO_COLOR  IRRELEVANT  log formatting only
+LOG_AUTOTUNE_RESULTS  IRRELEVANT  autotune LOGGING only, not selection
+FR_TRACE_VERBOSE_OUTPUT  IRRELEVANT  flight-recorder log verbosity
+FX_GRAPH_SHOW_*  IRRELEVANT  debug dump formatting
+DUMP_AOTI_MINIFIER  IRRELEVANT  debug dump
+INDUCTOR_TEST_DISABLE_FRESH_CACHE  IRRELEVANT  torch test harness (also INDUCTOR_-scrubbed)
+COMPILE_STROBELIGHT_*  IRRELEVANT  meta-internal profiler
+ENABLE_PYTORCH_EXECUTION_TRACE  IRRELEVANT  profiler trace capture
+ENABLE_PYTORCH_EXECUTION_TRACE_EXTRAS  IRRELEVANT  profiler trace capture
+KINETO_*  IRRELEVANT  profiler daemon hooks
+TEARDOWN_CUPTI  IRRELEVANT  profiler lifecycle
+DISABLE_CUPTI_LAZY_REINIT  IRRELEVANT  profiler lifecycle
+DCP_*  IRRELEVANT  distributed checkpointing, unused lane
+PT2_COMPILE_ID_PREFIX  IRRELEVANT  log label only
+_SPLITTER_MERGE_OVERLAPPING_FUSIONS  IRRELEVANT  fx acc-splitter (fx2trt lineage), unused lane
+_TORCHINDUCTOR_PYOBJECT_TENSOR_DATA_PTR  IRRELEVANT  torch test-only hook
+debug_extract_compiled_graph  IRRELEVANT  lazy-tensor debug hook, backend absent

--- a/scripts/config_reads_allowlist.txt
+++ b/scripts/config_reads_allowlist.txt
@@ -70,8 +70,7 @@ src/gen_worker/procsplit/parent.py::<unresolved> VIOLATION `dict(os.environ)` th
 # ---------------------------------------------------------------------------
 # BOOTSTRAP — six sites. The one thing this repo already gets right.
 # ---------------------------------------------------------------------------
-src/gen_worker/entrypoint.py::PYTORCH_CUDA_ALLOC_CONF BOOTSTRAP PYTORCH_CUDA_ALLOC_CONF setdefault must precede any torch import; the reason is given at the site and is load-bearing.
-src/gen_worker/entrypoint.py::TORCHINDUCTOR_AUTOGRAD_CACHE BOOTSTRAP TORCHINDUCTOR_AUTOGRAD_CACHE setdefault, same pre-import constraint.
+src/gen_worker/settings_authority.py::$DECLARED_ENV BOOTSTRAP the pgw#1049 settings authority imposing its declared env (pre-torch-import at the entrypoint, post-scrub at establish); the values are code, the env is the only API torch/NCCL offer.
 src/gen_worker/procsplit/__init__.py::GEN_WORKER_COMPUTE_CHILD BOOTSTRAP GEN_WORKER_COMPUTE_CHILD decides WHICH OF TWO PROGRAMS this process is, before _run_main and before any config exists.
 src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISOR BOOTSTRAP pre-fork supervisor predicate; runs before the worker process entry.
 src/gen_worker/supervisor.py::GEN_WORKER_SUPERVISED BOOTSTRAP pre-fork re-entry guard, same.
@@ -104,7 +103,7 @@ src/gen_worker/procsplit/parent.py::$ENV_WATCHDOG_PING_S IPC watchdog ping caden
 # inspectable Settings-derived builder.
 # ---------------------------------------------------------------------------
 src/gen_worker/compile_cache.py::$env LIBRARY reads the inductor/triton env block for the seal snapshot.
-src/gen_worker/compile_cache.py::TORCHINDUCTOR_AUTOGRAD_CACHE LIBRARY TORCHINDUCTOR_AUTOGRAD_CACHE=0; torch offers no other API.
+src/gen_worker/settings_authority.py::TORCHINDUCTOR_AUTOGRAD_CACHE LIBRARY TORCHINDUCTOR_AUTOGRAD_CACHE=0 (gw#608, moved from compile_cache by pgw#1049); torch offers no other API.
 src/gen_worker/compile_cache.py::CXX LIBRARY CXX host-compiler discovery, the toolchain's own convention.
 src/gen_worker/compile_cache.py::TORCHINDUCTOR_CACHE_DIR LIBRARY reads back the inductor cache dir torch was steered to.
 src/gen_worker/host_canary.py::NCCL_P2P_DISABLE LIBRARY reads NCCL_P2P_DISABLE for the canary's recorded facts.

--- a/scripts/lint_ambient_census.py
+++ b/scripts/lint_ambient_census.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""pgw#1049: the ambient-input census — structural half (no torch needed).
+
+`scripts/ambient_inputs_census.txt` classifies every env input torch/triton
+consult. This lint verifies the claims that are checkable from the tree
+alone; `tests/test_ambient_census_pgw1049.py` verifies completeness against
+the INSTALLED torch (an unclassified input is red — the th#1678 shape).
+
+Checked here:
+
+1. row syntax + known classes;
+2. every IMPOSED row names a key in `settings_authority.DECLARED_ENV`
+   (AST-extracted — the census may not claim an imposition that does not
+   exist), and every DECLARED_ENV key has an IMPOSED row (an imposition the
+   census does not name is an unclassified input);
+3. every NEUTRALIZED row is COVERED by `env_seal.SCRUB_PREFIXES` — the
+   pattern's fixed stem must start with a scrub prefix, so "erased before
+   torch imports" is a fact, not a hope;
+4. every watched-namespace env literal in `src/gen_worker` (reads and
+   writes) is classified by some row.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO / "src" / "gen_worker"
+CENSUS = REPO / "scripts" / "ambient_inputs_census.txt"
+
+CLASSES = {"IMPOSED", "NEUTRALIZED", "PLUMBING", "IRRELEVANT"}
+
+#: Env namespaces whose literals in OUR tree must be classified.
+WATCHED = ("TORCH", "PYTORCH", "TRITON", "CUBLAS", "CUDNN", "CUDA_", "NCCL",
+           "NVIDIA", "OMP_", "MKL_", "KMP_", "ATEN_", "AOTI", "AOT_",
+           "INDUCTOR_", "CUTLASS_", "CUTEDSL_", "PYTHONHASHSEED")
+
+
+def load_census(
+    path: Path = CENSUS,
+) -> Tuple[List[Tuple[str, str, str]], List[str]]:
+    """[(pattern, class, reason)] in file order; first match wins."""
+    rows: List[Tuple[str, str, str]] = []
+    errors: List[str] = []
+    if not path.is_file():
+        return rows, [f"{path} is missing"]
+    for num, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            errors.append(f"{path.name}:{num}: need '<PATTERN> <CLASS> "
+                          f"<reason>', got {line!r}")
+            continue
+        pattern, klass, reason = parts
+        if klass not in CLASSES:
+            errors.append(f"{path.name}:{num}: unknown class {klass!r} "
+                          f"(want one of {sorted(CLASSES)})")
+            continue
+        rows.append((pattern, klass, reason))
+    return rows, errors
+
+
+def classify(name: str, rows: List[Tuple[str, str, str]]) -> Optional[str]:
+    for pattern, klass, _ in rows:
+        if fnmatch.fnmatchcase(name, pattern):
+            return klass
+    return None
+
+
+def _module_str_tuple(path: Path, symbol: str) -> Tuple[str, ...]:
+    """AST-extract a module-level tuple/dict of string constants."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        target = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target, value = node.target, node.value
+        else:
+            continue
+        if not (isinstance(target, ast.Name) and target.id == symbol):
+            continue
+        if isinstance(value, (ast.Tuple, ast.List)):
+            return tuple(e.value for e in value.elts
+                         if isinstance(e, ast.Constant)
+                         and isinstance(e.value, str))
+        if isinstance(value, ast.Dict):
+            return tuple(k.value for k in value.keys
+                         if isinstance(k, ast.Constant)
+                         and isinstance(k.value, str))
+    return ()
+
+
+def scrub_prefixes() -> Tuple[str, ...]:
+    return _module_str_tuple(SRC_ROOT / "env_seal.py", "SCRUB_PREFIXES")
+
+
+def declared_env_keys() -> Tuple[str, ...]:
+    return _module_str_tuple(
+        SRC_ROOT / "settings_authority.py", "DECLARED_ENV")
+
+
+def _pattern_stem(pattern: str) -> str:
+    """The fixed prefix of an fnmatch pattern (up to the first wildcard)."""
+    return re.split(r"[*?\[]", pattern, 1)[0]
+
+
+_ENV_LITERAL = re.compile(
+    r'["\']([A-Z][A-Z0-9_]{2,})["\']')
+
+
+def src_watched_literals() -> Dict[str, str]:
+    """Watched-namespace env-var literals in our tree: {name: first path}.
+
+    Regex over string literals, not an AST env-read walk — the census cares
+    about every place a watched NAME appears (child env dicts, scrub lists,
+    docs-in-code aside), and a false positive costs one census row while a
+    false negative hides an input."""
+    out: Dict[str, str] = {}
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for m in _ENV_LITERAL.finditer(text):
+            name = m.group(1)
+            if name.startswith(WATCHED):
+                out.setdefault(name, str(path.relative_to(REPO)))
+    return out
+
+
+#: Literal env-read shapes in torch/triton source. Dynamic reads (inductor's
+#: env_name_default machinery constructs names at config install) are covered
+#: by the NAMESPACE rows — the constructed names all live in TORCHINDUCTOR_*/
+#: TORCHDYNAMO_* etc., which are scrubbed wholesale.
+_TORCH_READS = (
+    re.compile(r'os\.environ\.get\(\s*["\']([A-Za-z_][A-Za-z0-9_]*)'),
+    re.compile(r'os\.environ\[\s*["\']([A-Za-z_][A-Za-z0-9_]*)'),
+    re.compile(r'os\.getenv\(\s*["\']([A-Za-z_][A-Za-z0-9_]*)'),
+    re.compile(r'\bgetenv\(\s*["\']([A-Za-z_][A-Za-z0-9_]*)'),
+)
+
+
+def scan_installed_tree(
+    packages: Tuple[str, ...] = ("torch", "triton", "functorch"),
+) -> Dict[str, str]:
+    """Every literal env name the INSTALLED packages read: {name: rel path}.
+    Enumerated from source on disk — no import, so no side effects."""
+    import importlib.util
+
+    out: Dict[str, str] = {}
+    for pkg in packages:
+        try:
+            spec = importlib.util.find_spec(pkg)
+        except (ImportError, ValueError):
+            continue
+        if spec is None or not spec.submodule_search_locations:
+            continue
+        for root in spec.submodule_search_locations:
+            for path in sorted(Path(root).rglob("*.py")):
+                try:
+                    text = path.read_text(errors="replace")
+                except OSError:
+                    continue
+                for pat in _TORCH_READS:
+                    for m in pat.finditer(text):
+                        out.setdefault(m.group(1), f"{pkg}/{path.name}")
+    return out
+
+
+def check(census_path: Path = CENSUS) -> List[str]:
+    rows, problems = load_census(census_path)
+    if problems:
+        return problems
+    prefixes = scrub_prefixes()
+    declared = declared_env_keys()
+    if not prefixes:
+        problems.append("could not extract SCRUB_PREFIXES from env_seal.py")
+    if not declared:
+        problems.append(
+            "could not extract DECLARED_ENV from settings_authority.py")
+
+    imposed_rows = [p for p, k, _ in rows if k == "IMPOSED"]
+    for pattern in imposed_rows:
+        if pattern not in declared:
+            problems.append(
+                f"census row {pattern!r} claims IMPOSED but "
+                "settings_authority.DECLARED_ENV has no such key — the "
+                "census may not claim an imposition that does not exist")
+    for key in declared:
+        if key not in imposed_rows:
+            problems.append(
+                f"DECLARED_ENV[{key!r}] has no IMPOSED census row — an "
+                "imposition the census does not name is an unclassified "
+                "input")
+
+    for pattern, klass, _ in rows:
+        if klass != "NEUTRALIZED":
+            continue
+        stem = _pattern_stem(pattern)
+        if not any(stem.startswith(p) for p in prefixes):
+            problems.append(
+                f"census row {pattern!r} claims NEUTRALIZED but no "
+                f"env_seal.SCRUB_PREFIXES entry covers stem {stem!r} — "
+                "'erased before torch imports' must be a fact")
+
+    for name, where in sorted(src_watched_literals().items()):
+        if classify(name, rows) is None:
+            problems.append(
+                f"{where}: watched env name {name!r} appears in the tree "
+                "but has no census row — classify it in "
+                "scripts/ambient_inputs_census.txt")
+    return problems
+
+
+def main() -> int:
+    problems = check()
+    if problems:
+        print("\n".join(problems), file=sys.stderr)
+        return 1
+    rows, _ = load_census()
+    print(f"ambient-input census: {len(rows)} row(s), structural claims hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_settings_writers.py
+++ b/scripts/lint_settings_writers.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""pgw#1049: exactly ONE authority writes torch settings.
+
+Paul's directive (2026-08-09): "everything has to go through _us_ …
+`us -> pytorch settings`, not `[us, random other things] -> pytorch
+settings`." The settings authority (`gen_worker.settings_authority` and the
+modules it names in `AUTHORITY_MODULES`) is the only sanctioned writer of
+torch/dynamo/inductor process settings. Any OTHER write site in
+`src/gen_worker` must appear in `scripts/settings_writers_allowlist.txt`
+with a classification, or this script fails — the same enforcement shape as
+`lint_config_reads.py` (§1.18) and th#1678's wirecontract census:
+an unclassified site is red, and a stale allowlist row is red.
+
+What counts as a WRITE:
+
+* an attribute assignment whose dotted path roots in a torch settings
+  surface: ``torch.backends.*``, ``torch._dynamo.config.*``,
+  ``torch._inductor.config.*``, ``torch._functorch.config.*``,
+  ``torch.compiler.config.*`` — including through import aliases
+  (``import torch._inductor.config as inductor_config``);
+* a call to a global torch setter: ``set_float32_matmul_precision``,
+  ``set_grad_enabled``, ``use_deterministic_algorithms``,
+  ``set_default_device``;
+* a ``.patch(...)`` call on a torch config module (scoped, restores on
+  exit — classified SCOPED so every one is visible, never silent);
+* an ``os.environ`` write (``[...] =``, ``.setdefault``, ``.update``,
+  ``.pop``) whose key literal lands in a torch-consulted namespace
+  (`WATCHED_ENV`).
+
+Classifications:
+
+    SCOPED     a context-managed ``config.patch`` that restores on exit;
+               the serving window it opens is covered by dynamo's
+               GlobalStateGuard + the pgw#680 guard-miss doctrine
+    PLUMBING   a cache/path redirect (TORCHINDUCTOR_CACHE_DIR, ...) —
+               points where bytes land, never what bytes are generated;
+               inductor entries are content-addressed
+    SCRUB      an erase (``os.environ.pop`` in a scrub loop) — removal of
+               ambient input, the opposite of a second writer
+
+There is deliberately NO general-purpose exemption class: a write that is
+none of the above moves into the authority, it does not get a new label.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO / "src" / "gen_worker"
+ALLOWLIST = REPO / "scripts" / "settings_writers_allowlist.txt"
+
+CLASSIFICATIONS = {"SCOPED", "PLUMBING", "SCRUB"}
+
+#: Modules whose writes ARE the authority (kept in sync with
+#: gen_worker.settings_authority.AUTHORITY_MODULES by test_settings_fence).
+AUTHORITY_FILES = {
+    "settings_authority.py",
+    "env_seal.py",
+    "host_isa.py",
+    "guard_closure.py",
+}
+
+#: Dotted prefixes that name a torch settings surface.
+SETTINGS_ROOTS: Tuple[str, ...] = (
+    "torch.backends",
+    "torch._dynamo.config",
+    "torch._inductor.config",
+    "torch._functorch.config",
+    "torch.compiler.config",
+)
+
+#: Global torch setter calls (write-equivalent).
+SETTER_CALLS: Tuple[str, ...] = (
+    "torch.set_float32_matmul_precision",
+    "torch.set_grad_enabled",
+    "torch.use_deterministic_algorithms",
+    "torch.set_default_device",
+)
+
+#: Env namespaces torch (or its toolchain) consults for BEHAVIOR.
+WATCHED_ENV: Tuple[str, ...] = (
+    "TORCH", "PYTORCH", "TRITON", "CUBLAS", "CUDNN", "CUDA_", "NCCL",
+    "NVIDIA", "OMP_", "MKL_", "PYTHONHASHSEED",
+)
+
+
+class _Aliases(ast.NodeVisitor):
+    """Import-alias map: local name -> dotted module path."""
+
+    def __init__(self) -> None:
+        self.names: Dict[str, str] = {}
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.names[alias.asname or alias.name.split(".")[0]] = (
+                alias.name if alias.asname else alias.name.split(".")[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module and not node.level:
+            for alias in node.names:
+                self.names[alias.asname or alias.name] = (
+                    f"{node.module}.{alias.name}")
+
+
+def _dotted(node: ast.AST, aliases: Dict[str, str]) -> str:
+    """Resolve an attribute chain to its dotted path, expanding aliases."""
+    parts: List[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(aliases.get(node.id, node.id))
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _settings_root(path: str) -> Optional[str]:
+    for root in SETTINGS_ROOTS:
+        if path == root or path.startswith(root + "."):
+            return root
+    return None
+
+
+class _Writes(ast.NodeVisitor):
+    """Every torch-settings write in one module."""
+
+    def __init__(self, aliases: Dict[str, str],
+                 consts: Optional[Dict[str, str]] = None) -> None:
+        self.aliases = aliases
+        self.consts = consts or {}
+        self.hits: List[Tuple[int, str]] = []  # (line, site key)
+
+    def _env_key(self, node: ast.AST) -> str:
+        """A static env-var name for a key expression: a string literal, or a
+        module-level string constant (`_NVLS_ENV`); "" when computed."""
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            return self.consts.get(node.id, "")
+        return ""
+
+    def _check_target(self, target: ast.AST, lineno: int) -> None:
+        if isinstance(target, ast.Attribute):
+            path = _dotted(target, self.aliases)
+            root = _settings_root(path)
+            if root:
+                self.hits.append((lineno, path))
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                self._check_target(elt, lineno)
+        elif isinstance(target, ast.Subscript):
+            # os.environ["X"] = ... — and settings-module item writes.
+            base = _dotted(target.value, self.aliases)
+            if base.endswith("os.environ") or base == "os.environ":
+                name = self._env_key(target.slice)
+                if not name:
+                    # A computed key could be ANY namespace — classify it.
+                    self.hits.append((lineno, "os.environ[<dynamic>]"))
+                elif name.startswith(WATCHED_ENV):
+                    self.hits.append((lineno, f"os.environ[{name}]"))
+            elif _settings_root(base):
+                self.hits.append((lineno, base + "[...]"))
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        for target in node.targets:
+            self._check_target(target, node.lineno)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._check_target(node.target, node.lineno)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self._check_target(node.target, node.lineno)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        path = _dotted(node.func, self.aliases)
+        if path in SETTER_CALLS:
+            self.hits.append((node.lineno, path))
+        elif path.endswith(".patch") and _settings_root(path[: -len(".patch")]):
+            self.hits.append((node.lineno, path))
+        elif path in ("os.environ.setdefault", "os.environ.update",
+                      "os.environ.pop"):
+            name = self._env_key(node.args[0]) if node.args else ""
+            if path.endswith("update") or name.startswith(WATCHED_ENV):
+                self.hits.append(
+                    (node.lineno, f"{path}({name or '<dynamic>'})"))
+        self.generic_visit(node)
+
+
+def scan(root: Path = SRC_ROOT) -> Dict[Tuple[str, str], int]:
+    """Every write site outside the authority, keyed (path, site) — never by
+    line number (a line is a fact other people change; pgw#931's lesson)."""
+    sites: Dict[Tuple[str, str], int] = {}
+    for path in sorted(root.rglob("*.py")):
+        if path.name in AUTHORITY_FILES and path.parent == root:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        aliases = _Aliases()
+        aliases.visit(tree)
+        consts: Dict[str, str] = {}
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Name)
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)):
+                consts[node.targets[0].id] = node.value.value
+        writes = _Writes(aliases.names, consts)
+        writes.visit(tree)
+        try:
+            rel = str(path.relative_to(REPO))
+        except ValueError:
+            rel = str(path)
+        for lineno, site in writes.hits:
+            sites.setdefault((rel, site), lineno)
+    return sites
+
+
+def load_allowlist(
+    path: Path = ALLOWLIST,
+) -> Tuple[Dict[Tuple[str, str], str], List[str]]:
+    """Parse ``<path>::<site>  <CLASSIFICATION>  <reason>`` lines."""
+    allowed: Dict[Tuple[str, str], str] = {}
+    errors: List[str] = []
+    if not path.is_file():
+        return allowed, [f"{path} is missing"]
+    for num, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            errors.append(f"{path.name}:{num}: need '<path>::<site> "
+                          f"<CLASSIFICATION> <reason>', got {line!r}")
+            continue
+        key, classification = parts[0], parts[1]
+        if "::" not in key:
+            errors.append(f"{path.name}:{num}: site key {key!r} lacks '::'")
+            continue
+        if classification not in CLASSIFICATIONS:
+            errors.append(
+                f"{path.name}:{num}: unknown classification "
+                f"{classification!r} (want one of {sorted(CLASSIFICATIONS)})")
+            continue
+        file_part, site = key.split("::", 1)
+        allowed[(file_part, site)] = classification
+    return allowed, errors
+
+
+def check(
+    sites: Dict[Tuple[str, str], int],
+    allowed: Dict[Tuple[str, str], str],
+) -> List[str]:
+    problems: List[str] = []
+    for (rel, site), lineno in sorted(sites.items()):
+        if (rel, site) not in allowed:
+            problems.append(
+                f"{rel}:{lineno}: UNCLASSIFIED torch-settings write: {site} — "
+                "a second writer is a defect (pgw#1049). Move the write into "
+                "the settings authority, or classify it in "
+                "scripts/settings_writers_allowlist.txt")
+    live = set(sites)
+    for key in sorted(set(allowed) - live):
+        problems.append(
+            f"stale allowlist row {key[0]}::{key[1]} matches no write site — "
+            "delete it (a row matching nothing is a boundary that lies)")
+    return problems
+
+
+def main() -> int:
+    sites = scan()
+    allowed, errors = load_allowlist()
+    problems = errors + check(sites, allowed)
+    if problems:
+        print("\n".join(problems), file=sys.stderr)
+        return 1
+    print(f"settings-writer fence: {len(sites)} classified site(s), "
+          f"authority = {sorted(AUTHORITY_FILES)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -506,8 +506,7 @@ def run_cycle(
         bucket = int(getattr(hb_cfg, "lora_bucket", 0) or 0)
         arm = _ck.compute(
             veh.family, _loading.pipeline_weight_lane(pipe), bucket,
-            contract=_ck.contract_digest(_cc.declared_contract_facts(hb_cfg)),
-            regional=bool(getattr(hb_cfg, "regional", False)))
+            contract=_ck.contract_digest(_cc.declared_contract_facts(hb_cfg)))
         (hb_root / "mint-root").mkdir(exist_ok=True)
         pending = _fc.PendingSelfMint(
             family=veh.family, cell_key=arm.digest,
@@ -717,6 +716,13 @@ def _adopt_miss_log(stderr: str) -> str:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    # pgw#1049: the rig parent seals as a worker boot does (establish below),
+    # and establish now fail-closes on an interpreter outside the declared
+    # env — this is the STANDALONE entry's sanctioned imposition (one
+    # re-exec, same as the worker entrypoint's).
+    from gen_worker.settings_authority import ensure_interpreter_env
+
+    ensure_interpreter_env()
     parser = argparse.ArgumentParser(
         prog="micro_mint_rig",
         description="pgw#978 — run the whole mint machinery locally.")

--- a/scripts/settings_writers_allowlist.txt
+++ b/scripts/settings_writers_allowlist.txt
@@ -1,0 +1,25 @@
+# pgw#1049 — torch-settings write sites OUTSIDE the authority, classified.
+# Enforced by scripts/lint_settings_writers.py: an unclassified write is red,
+# a row matching nothing is red. Keyed on <path>::<site>, never a line number.
+#
+# There is NO general exemption class. A write that is not SCOPED (restores on
+# exit), PLUMBING (a path, not a behavior) or SCRUB (an erase) moves into
+# gen_worker/settings_authority.py.
+
+# The pgw#680 guard-miss doctrine's fail-on-recompile window and the pgw#756
+# dynamo-disable window: thread-local `config.patch` context managers, restored
+# on exit; the serving window is covered by dynamo's GlobalStateGuard.
+src/gen_worker/compile_cache.py::torch._dynamo.config.patch  SCOPED  pgw#680/pgw#756 thread-local patch windows, restored on exit
+
+# The topology canary's differential NCCL probe: sets/clears P2P for a bounded
+# mp.spawn probe and restores the saved value in its finally block — a
+# measurement of transport behavior, never serving state.
+src/gen_worker/host_canary.py::os.environ[NCCL_P2P_DISABLE]  SCOPED  differential probe env, saved/restored around mp.spawn
+src/gen_worker/host_canary.py::os.environ.pop(NCCL_P2P_DISABLE)  SCOPED  the probe's clear half of the same save/restore
+src/gen_worker/host_canary.py::os.environ[<dynamic>]  SCOPED  the probe's restore loop writing the SAVED values back
+
+# Cache-dir redirects: where compile bytes land, never what bytes are
+# generated (inductor entries are content-addressed). The sanctioned window
+# is post-scrub (env_seal docstring).
+src/gen_worker/compile_cache.py::os.environ[<dynamic>]  PLUMBING  capture_env's TORCHINDUCTOR_CACHE_DIR/TRITON_CACHE_DIR redirect (gw#391)
+src/gen_worker/entrypoint.py::os.environ[<dynamic>]  PLUMBING  pgw#783 per-group inductor/triton cache isolation dirs

--- a/src/gen_worker/aot_compile_child.py
+++ b/src/gen_worker/aot_compile_child.py
@@ -162,7 +162,7 @@ def run(job: EntryJob) -> int:
     # an axis nobody changed (pgw#784's rule, same reason).
     # NOT reordered to put `import torch` first, tempting as that is for the
     # attribution: `scrub_env()` must run before torch reads the environment
-    # (env_seal's whole contract), and `establish_config` imports torch itself.
+    # (env_seal's whole contract), and the torch imposition imports torch.
     # So the seal legitimately OWNS the torch import, and the split below —
     # published by env_seal as telemetry — is how it gets named anyway.
     with ledger.span("child_seal_s"):

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2258,7 +2258,7 @@ def _compile_entries_parallel(
         # member and its SPLIT is an overlay — and the split is the whole
         # answer to "what is the seal still costing": pgw#832 cut the library
         # hash to ~0.07 s (measured), while the child's `import torch`, which
-        # `establish_config` owns, is the rest. Without the overlay a reader
+        # the torch imposition owns, is the rest. Without the overlay a reader
         # sees only the sum and re-opens a closed question.
         overlays = pool.entry_overlays.get(row.name) or {}
         if overlays:

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1509,6 +1509,10 @@ def mint(
     # a beat fires would announce the problem after the expensive part has
     # started; reporting it here makes a broken handoff visible at boot.
     report_podguard_status()
+    # pgw#719/pgw#1049: the tripwire, before ANY trace — drifted settings
+    # refuse by name here; they can no longer move the (declaration-derived)
+    # seal, so this is the only place ambient mutation can surface.
+    env_seal.assert_seal_unchanged("aot_mint")
     progress = MintProgress(
         inductor_configs=inductor_configs, on_progress=on_progress)
     if phase_snapshot is not None:

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -87,9 +87,15 @@ _DIGEST_HEX = 56
 _REQUIRED = ("format", "kind", "family", "sm", "contract", "env_seal",
              "toolchain")
 # Axes that may be legitimately absent ("" => omitted from canonical form):
-# lane "" is the plain-resident graph family; mode "" is whole-graph
-# compilation ("regional" per-block cells are different artifacts, ie#381).
-_OPTIONAL = ("lane", "mode")
+# lane "" is the plain-resident graph family.
+#
+# `mode` DELETED per Paul 2026-08-09 (pgw#1049): pinned "" since regional
+# died (#846), and empty optionals never enter the canonical form, so no
+# minted key ever contained it — zero re-key by construction, no scheme
+# bump. Regional discrimination was redundant anyway: `regional` is a
+# declared-contract fact, so it rides the `contract` axis. A stale caller
+# passing `mode` now gets from_axes' typed unknown-axis refusal.
+_OPTIONAL = ("lane",)
 
 #: The `kind` AXIS VALUE (and envelope `kind`) of an exported .pt2 cell — the
 #: only publishable kind since pgw#1010. `from_axes` validates axis NAMES, so
@@ -215,13 +221,14 @@ def compute(
     lora_bucket: int = 0,
     *,
     contract: str,
-    regional: bool = False,
 ) -> CellKey:
     """The key THIS runtime wants for ``family`` on ``weight_lane`` —
     computed purely statically (no trace, no execution): live probes for
     sm/posture/config, dist-info + binary content for the toolchain.
     (pgw#1030: the ``closure_roots`` parameter is deleted — pgw#990 removed
-    code identity from the key and the body never read it.) Raises
+    code identity from the key and the body never read it; pgw#1049 deleted
+    the vestigial ``regional`` parameter with the ``mode`` axis — regional
+    is a declared-contract fact and rides ``contract``.) Raises
     :class:`CellKeyError` when a required axis is unavailable — callers on
     non-CUDA runtimes simply have no key."""
     from . import compile_cache as cc  # cycle: compile_cache imports cell_key
@@ -232,7 +239,6 @@ def compute(
         "kind": "inductor",
         "family": str(family or ""),
         "lane": _canonical_execution_lane(weight_lane, lora_bucket),
-        "mode": "regional" if regional else "",
         "sm": rt["sm"],
         "contract": str(contract or ""),
         "env_seal": env_seal.seal_digest(env_seal.effective_seal()),
@@ -267,7 +273,6 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
     if kind != "torch-inductor-cache":
         raise CellKeyError(f"artifact kind {kind!r} has no cell-key identity")
 
-    mode = str(meta.get("compile_mode") or "whole")
     contract_facts = meta.get("shape_contract")
     if not isinstance(contract_facts, dict) or not contract_facts:
         raise CellKeyError(
@@ -292,7 +297,6 @@ def from_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
             str(meta.get("weight_lane") or ""),
             int(meta.get("lora_bucket") or 0),
         ),
-        "mode": "" if mode == "whole" else mode,
         "sm": str(meta.get("sm") or ""),
         "contract": contract_digest(contract_facts),
         "env_seal": env_seal.seal_digest(seal),
@@ -388,9 +392,6 @@ def from_exported_artifact_metadata(meta: Mapping[str, Any]) -> CellKey:
             str(meta.get("weight_lane") or ""),
             int(meta.get("lora_bucket") or 0),
         ),
-        # pgw#846: an exported cell is always whole-graph; "" is the
-        # optional-axis value `from_axes` omits.
-        "mode": "",
         "sm": sm,
         "contract": contract_digest(contract_facts),
         "env_seal": env_seal.seal_digest(seal),

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -27,9 +27,11 @@ exist for this runtime.
     contract      digest of the DECLARED shape contract (SDK v2, pgw#647):
                   shapes, targets, text_len, dynamic dims, regional mode,
                   lora bucket, warm guidance classes
-    env_seal      digest of the execution-environment seal (pgw#696):
-                  process posture + frozen config flags + portable inductor
-                  config (+ operator epoch). Internally versioned (seal_v)
+    env_seal      digest of the execution-environment seal — since
+                  pgw#1049 a digest of the settings DECLARATION (env, torch
+                  flags + knobs, dynamo posture, host-ISA clamp, process
+                  posture) plus the toolchain library content fact.
+                  Internally versioned (seal_v)
     toolchain     CONTENT digest of the compile stack (pgw#710): dist-info
                   RECORDs of torch/triton/nvidia-*/diffusers/transformers
                   + the bundled ptxas/nvdisasm binaries. Replaces the old

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -71,7 +71,7 @@ import inspect
 import pickle
 import sys
 
-from . import cell_key, env_seal, guard_closure, hot_swap
+from . import cell_key, env_seal, guard_closure, hot_swap, settings_authority
 from .api.errors import RetryableError
 from .models import w8a8_lora
 from .models.loading import pipeline_weight_lane
@@ -1308,13 +1308,9 @@ def _set_semantic_cache_tag(pipeline: Any, cfg: Any) -> None:
     (torch.compiler.config), set at every arm before its warm compiles; a
     later cross-family arm in the same process retags before its own
     compiles — a mid-serve heal recompile under the newer tag can only
-    MISS, never cross-consume."""
-    try:
-        import torch.compiler.config as compiler_config
-
-        compiler_config.cache_key_tag = _semantic_cache_tag(pipeline, cfg)
-    except Exception:
-        logger.debug("semantic cache tag: unavailable", exc_info=True)
+    MISS, never cross-consume. The write itself is the authority's
+    (pgw#1049 fence)."""
+    settings_authority.set_compiler_cache_tag(_semantic_cache_tag(pipeline, cfg))
 
 
 def capture_env(root: Path) -> Path:
@@ -1327,50 +1323,12 @@ def capture_env(root: Path) -> Path:
         d = root / sub
         d.mkdir(parents=True, exist_ok=True)
         os.environ[env] = str(d)
-    _disable_aot_autograd_cache()
+    # gw#608: portability needs the (portable) FxGraphCache as the lookup
+    # surface — the authority owns the write (settings_authority docstring
+    # carries the full ASLR/thread-local history).
+    settings_authority.disable_autograd_cache()
     _reset_inductor_latch()
     return root
-
-
-def _disable_aot_autograd_cache() -> None:
-    """gw#608: the AOTAutogradCache key hashes ``fx_kwargs[get_decomp_fn]``
-    via the function's REPR — which embeds the process memory address
-    (ASLR), so AOT keys can NEVER match across processes/pods. On the
-    consumer, the AOT-layer miss recompiles without consulting the on-disk
-    FX entries, so a byte-portable cell reports cache_hits=0 (live: two
-    hosts, 8/8 misses on graphs whose FxGraphCache keys were bit-identical
-    across three independent mints). Compiled-cell portability therefore
-    requires the FX cache to be the lookup surface: disable the AOT layer
-    symmetrically for producer capture and consumer seeding. Costs a cheap
-    AOT re-analysis per fresh process; the expensive inductor compile still
-    serves from the (portable) FX entries.
-
-    LIVE DISPROOF of the 0.40.4/0.40.5 shape (2026-07-21, B200 pods,
-    gen-worker 0.40.5): the mint capture still packed 8 ASLR-keyed
-    ``aotautograd/`` entries and the store-served sibling still failed 8/8
-    — because in torch 2.13 ``ConfigModule`` user overrides are a
-    ContextVar, i.e. THREAD-LOCAL: the assignment below ran on the arming
-    thread while the warmup compile ran on another thread that still saw
-    the default True. The env var is no rescue post-import
-    (``env_name_force`` is read once at config install). Process-global
-    disable therefore needs BOTH: the pre-torch-import env in the
-    entrypoint (fresh processes, incl. compile-worker subprocesses) and
-    the installed config entry's ``env_value_force`` mutated here (torch
-    already imported — tools, tests, embedders)."""
-    os.environ["TORCHINDUCTOR_AUTOGRAD_CACHE"] = "0"
-
-    if "torch" not in sys.modules:
-        return
-    try:
-        import torch._functorch.config as fconf
-
-        fconf.enable_autograd_cache = False  # this thread (fast path, public API)
-        # Process-global: user overrides are thread-local ContextVars in
-        # torch>=2.13; the entry-level env force is consulted by every
-        # thread with top precedence.
-        fconf._config["enable_autograd_cache"].env_value_force = False  # type: ignore[attr-defined]
-    except Exception:
-        logger.debug("compile-cache: AOT autograd cache disable unavailable", exc_info=True)
 
 
 def _reset_inductor_latch() -> None:
@@ -2298,24 +2256,6 @@ def _regional_dynamic_decline(cfg: Any, target: str) -> str:
         f"RESULT 3: free on a conv-free region)")
 
 
-def _apply_declared_shape_config(cfg: Any) -> None:
-    """The v2 dynamo posture: nothing becomes dynamic by accident.
-
-    ``automatic_dynamic_shapes=False`` — never promote a dim on change (a
-    novel signature is a guard miss routed by the consumer guards, never a
-    silent recompile-to-dynamic); ``assume_static_by_default=True`` —
-    unmarked dims are static. Declared dynamism arrives ONLY through
-    explicit ``mark_dynamic`` marks (``_with_declared_marks``)."""
-    try:
-        import torch._dynamo
-
-        torch._dynamo.config.automatic_dynamic_shapes = False
-        torch._dynamo.config.assume_static_by_default = True
-    except Exception:
-        logger.debug("compile-cache: could not set dynamo shape config",
-                     exc_info=True)
-
-
 def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callable[..., Any]:
     """Wrap a compiled callable so every call marks the DECLARED dynamic
     dims on its tensor inputs before dynamo sees them.
@@ -2964,8 +2904,8 @@ def apply(
     import torch
 
     # gw#608: cross-pod cell portability requires the (portable) FX graph
-    # cache to be the lookup surface — see _disable_aot_autograd_cache.
-    _disable_aot_autograd_cache()
+    # cache to be the lookup surface.
+    settings_authority.disable_autograd_cache()
     # The two inner-key alignments (both symmetric mint/consumer by
     # construction: every compile path arms through apply()):
     _install_fx_system_shim()          # SKU name -> sm token (P0, review §6.1)
@@ -2975,17 +2915,7 @@ def apply(
     # bigger than that (LTX: 12 video graphs, ie#381) would silently fall
     # back to eager for every shape past the limit. Size it to the declared
     # shape set — never lower an operator-raised value.
-    try:
-        import torch._dynamo
-
-        want = len(tuple(cfg.shapes)) + 8
-        torch._dynamo.config.cache_size_limit = max(
-            int(torch._dynamo.config.cache_size_limit), want)
-        if hasattr(torch._dynamo.config, "recompile_limit"):
-            torch._dynamo.config.recompile_limit = max(
-                int(torch._dynamo.config.recompile_limit), want)
-    except Exception:
-        logger.debug("compile-cache: could not raise recompile limit", exc_info=True)
+    settings_authority.raise_dynamo_cache_limits(len(tuple(cfg.shapes)) + 8)
 
     regional = bool(getattr(cfg, "regional", False))
 
@@ -3030,7 +2960,7 @@ def apply(
             # casting + much cheaper cold compile. Blocks are compiled in
             # place; the guard wrapper clears them on the first failure.
             #
-            _apply_declared_shape_config(cfg)
+            settings_authority.impose_dynamo()
             owner.compile_repeated_blocks(dynamic=None)
             # pgw#681: regional entry crosses the same canonical boundary as
             # whole-graph entry — block guards mint over canonical inputs.
@@ -3069,7 +2999,7 @@ def apply(
         # ONLY dynamism. `dynamic=False` + mark_dynamic is NOT expressible
         # (torch raises ConstraintViolationError), so the global guard is
         # the config pair + dynamic=None, never dynamic=False.
-        _apply_declared_shape_config(cfg)
+        settings_authority.impose_dynamo()
         compiled = torch.compile(fn, dynamic=None)
         declared_dynamic = tuple(getattr(cfg, "dynamic", ()) or ())
         if declared_dynamic:
@@ -3346,7 +3276,6 @@ def enable(
                         contract=cell_key.contract_digest(
                             declared_contract_facts(
                                 cfg, lora_bucket_override=eff_bucket)),
-                        regional=bool(getattr(cfg, "regional", False)),
                     )
                     if not cell_key.mismatch(meta, want):
                         self_key = want.digest

--- a/src/gen_worker/entrypoint.py
+++ b/src/gen_worker/entrypoint.py
@@ -12,27 +12,16 @@ import os
 import faulthandler
 import signal
 
-# Reduce CUDA allocator fragmentation for tight-VRAM worker processes.
-# Set BEFORE any module imports torch (PyTorch reads this env var only at
-# first cudaMalloc; setting it later is a no-op). gen-worker entrypoint is
-# the first module loaded in every worker process, so putting it here gives
-# library-wide coverage across conversion / inference / training workers.
-#
-# `setdefault` so an operator-set value (Dockerfile ENV or docker-compose env)
-# overrides. The flag uses CUDA's virtual-memory APIs to grow allocator
-# segments on demand, recovering hundreds of MiB of "reserved-but-unallocated"
-# headroom that the default fixed-segment allocator wastes. See:
-# https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf
-os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+# pgw#1049: the declared process env (PYTORCH_CUDA_ALLOC_CONF, the autograd
+# cache disable, PYTHONHASHSEED for children), imposed BEFORE any module
+# imports torch — several are read at torch import / first cudaMalloc. The
+# entrypoint is the first module loaded in every worker process, so this is
+# library-wide coverage; the values and their rationales live in ONE place,
+# settings_authority.DECLARED_ENV. Imposed, not setdefault'd: an ambient
+# value would be erased by env_seal.scrub_env anyway (never honored).
+from .settings_authority import impose_process_env  # noqa: E402
 
-# gw#608: compile-cell portability requires the (portable) FxGraphCache to be
-# the lookup surface — the AOTAutogradCache key embeds a process memory
-# address (ASLR) and can never hit across pods. TORCHINDUCTOR_AUTOGRAD_CACHE
-# is an `env_name_force` config read ONCE at torch import, and runtime config
-# assignments are thread-local (ContextVar) in torch>=2.13, so this must be
-# set here, before any torch import, to bind every thread and every
-# compile-worker subprocess. See compile_cache._disable_aot_autograd_cache.
-os.environ.setdefault("TORCHINDUCTOR_AUTOGRAD_CACHE", "0")
+impose_process_env()
 
 # pgw#763: this process becomes the CONTROL PARENT — gRPC stream, identity,
 # JWT, child supervision — and must run BEFORE the heavy imports below so it
@@ -40,6 +29,13 @@ os.environ.setdefault("TORCHINDUCTOR_AUTOGRAD_CACHE", "0")
 # with GEN_WORKER_COMPUTE_CHILD=1) and only ever exits deliberately. The split
 # is unconditional; only a compute child falls through to the imports below.
 if __name__ == "__main__":
+    # pgw#1049: interpreter-level declared env (PYTHONHASHSEED) — CPython
+    # read it at interpreter start, so a pod whose image env lacks it gets
+    # ONE re-exec here, before the procsplit fork; every child inherits it.
+    from .settings_authority import ensure_interpreter_env  # noqa: E402
+
+    ensure_interpreter_env()
+
     from .procsplit import is_compute_child  # noqa: E402
 
     if not is_compute_child():

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -88,9 +88,11 @@ logger = logging.getLogger(__name__)
 # become the declared tables, and the declared env (incl. the imposed
 # PYTHONHASHSEED=0, executing the pgw#1034 HUMAN_MUST_DO decision) is sealed.
 # RE-KEY COST, stated per §1.27(g): every cell minted under seal v3 stops
-# matching and is re-minted once, per (family, lane, sm). The corpus is
-# effectively empty (see the PR/tracker for the measured row count), so this
-# is the cheapest moment the fleet will ever have for it.
+# matching and is re-minted once, per (family, lane, sm). MEASURED
+# 2026-08-09: the published corpus is ONE `cell_receipts` row fleet-wide
+# (e2e-dev stack; a `ck5-…` key from before the pgw#958 scheme reset, so it
+# matches no ck1 runtime under ANY seal version) plus A1's in-flight mint —
+# zero live matches stranded, the cheapest re-key this fleet will ever have.
 SEAL_VERSION = 4
 SEAL_KEY = "env_seal"
 
@@ -139,8 +141,9 @@ SCRUB_PREFIXES = (
 
 
 class EnvSealError(RuntimeError):
-    """The environment could not be imposed (a canonical flag did not take
-    effect, an unknown knob was declared) or drifted after boot."""
+    """The live settings drifted from the boot/declared state (the pgw#719
+    tripwire), or the host-ISA clamp could not be imposed. Imposition
+    failures raise ``settings_authority.SettingsImpositionError``."""
 
 
 def scrub_env() -> List[str]:
@@ -315,13 +318,14 @@ def write_library_memo(path: Path) -> int:
     whether that is worth a typed event; children fall back to the full
     rehash either way."""
     digests: Dict[str, str] = {}
-    for _base, lib_path in sorted(_toolchain_lib_paths().items()):
-        try:
-            st = os.stat(lib_path)
-            digests[_memo_key(lib_path, st.st_mtime_ns, st.st_size)] = (
-                _lib_digest_memoized(lib_path, st.st_mtime_ns, st.st_size))
-        except OSError:
-            continue  # the child will record <unreadable> on its own stat
+    for _base, lib_paths in sorted(_toolchain_lib_paths().items()):
+        for lib_path in lib_paths:
+            try:
+                st = os.stat(lib_path)
+                digests[_memo_key(lib_path, st.st_mtime_ns, st.st_size)] = (
+                    _lib_digest_memoized(lib_path, st.st_mtime_ns, st.st_size))
+            except OSError:
+                continue  # the child will record <unreadable> on its own stat
     encoded = json.dumps(
         {"memo_v": _MEMO_V, "digests": digests},
         sort_keys=True, separators=(",", ":"), ensure_ascii=True)
@@ -405,10 +409,17 @@ def _toolchain_lib_dirs() -> Tuple[Path, ...]:
     return tuple(dirs)
 
 
-def _toolchain_lib_paths() -> Dict[str, str]:
-    """{basename: path} of every toolchain native lib the python env ships.
-    Duplicate basenames resolve by sorted path (deterministic)."""
-    paths: Dict[str, str] = {}
+def _toolchain_lib_paths(
+    all_copies: bool = False,
+) -> Dict[str, List[str]]:
+    """{basename: [paths]} of every toolchain native lib the python env
+    ships. Identity uses the FIRST path per basename (sorted-root order,
+    deterministic); ``all_copies`` keeps every one — an env can ship the
+    same basename twice with different bytes (cu126: triton/backends and
+    nvidia/cuda_cupti both carry a ``libcupti.so.12``), and the live
+    substitution check must not read the env's own second copy as an
+    LD_PRELOAD (pgw#1049, found by aot_mint's new pre-trace tripwire)."""
+    paths: Dict[str, List[str]] = {}
     for root in _toolchain_lib_dirs():
         if not root.is_dir():
             continue
@@ -420,7 +431,9 @@ def _toolchain_lib_paths() -> Dict[str, str]:
                 continue  # defense in depth; see pgw#745
             if path.is_symlink() or not path.is_file():
                 continue  # digest real files once; alias links add nothing
-            paths.setdefault(base, str(path))
+            bucket = paths.setdefault(base, [])
+            if all_copies or not bucket:
+                bucket.append(str(path))
     return paths
 
 
@@ -435,12 +448,29 @@ def toolchain_library_digests() -> Tuple[Tuple[str, str], ...]:
     paths = _toolchain_lib_paths()
     for base in sorted(paths):
         try:
-            st = os.stat(paths[base])
+            st = os.stat(paths[base][0])
             out[base] = _lib_digest_memoized(
-                paths[base], st.st_mtime_ns, st.st_size)
+                paths[base][0], st.st_mtime_ns, st.st_size)
         except OSError:
             out[base] = "<unreadable>"
     return tuple(sorted(out.items()))
+
+
+def _shipped_digest_sets() -> Dict[str, Tuple[str, ...]]:
+    """EVERY digest the env ships per basename — the live substitution
+    check's reference set. Identity keeps the deterministic first copy; a
+    mapped lib matching ANY shipped copy is the env's own file, not an
+    LD_PRELOAD substitution."""
+    out: Dict[str, List[str]] = {}
+    for base, lib_paths in _toolchain_lib_paths(all_copies=True).items():
+        for lib_path in lib_paths:
+            try:
+                st = os.stat(lib_path)
+                out.setdefault(base, []).append(_lib_digest_memoized(
+                    lib_path, st.st_mtime_ns, st.st_size))
+            except OSError:
+                continue
+    return {base: tuple(v) for base, v in out.items()}
 
 
 # The identity manifest is FROZEN at first computation: the disk content is
@@ -556,12 +586,16 @@ def assert_seal_unchanged(label: str = "") -> None:
     snapshot = dict(frozen_library_digests())
     if snapshot:
         current = dict(loaded_library_digests())
+        shipped = _shipped_digest_sets()
         for base in sorted(snapshot):
             now = current.get(base)
-            if now is not None and now != snapshot[base]:
-                diffs.append(
-                    f"loaded lib {base}: boot {snapshot[base]} != now {now} "
-                    "(native library substituted after boot)")
+            if now is None or now == snapshot[base]:
+                continue
+            if now in shipped.get(base, ()):
+                continue  # the env's own alternate copy, not a substitution
+            diffs.append(
+                f"loaded lib {base}: boot {snapshot[base]} != now {now} "
+                "(native library substituted after boot)")
     if diffs:
         raise EnvSealError(
             f"environment drifted since boot ({label or 'point-of-use'}): "

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -1,10 +1,12 @@
-"""Execution-environment seal — ERASE AND IMPOSE (pgw#718/#719).
+"""Execution-environment seal — ERASE, IMPOSE, SEAL THE DECLARATION
+(pgw#718/#719, re-pointed by pgw#1049).
 
 Paul's env contract: the worker OWNS its process environment. We do not
 audit the world's env vars and refuse on surprises (the superseded #696
 allowlist — it bit a 0.70.3 boot on an informational base-image var); we
-ERASE the behavior namespaces wholesale and IMPOSE the canonical
-configuration as code:
+ERASE the behavior namespaces wholesale and IMPOSE the declared
+configuration (``settings_authority`` — the single writer of torch
+settings):
 
 * :func:`scrub_env` — delete every var in the behavior namespaces
   (``TORCH*``/``PYTORCH*``/``TRITON*``/``CUBLAS*``/``CUDNN*``/
@@ -12,34 +14,31 @@ configuration as code:
   names; NEVER fail. Load-bearing order: the entrypoint calls it BEFORE
   torch imports (many vars are read at import/CUDA-init time). Plumbing
   (CUDA_VISIBLE_DEVICES, paths, credentials) is untouched.
-* :data:`CANONICAL_CONFIG` + :func:`establish_config` — impose every
-  behavior flag explicitly via torch APIs and verify the read-back. The
-  canonical values ARE the ratified serving posture (pgw#654 TF32-on; see
-  the table comment) — the point is that CODE decides them, never a
-  library default and never an env var, and mint==serve by construction.
-  The ONLY route to non-canonical behavior is a typed knob:
-  ``establish_config(overrides=...)`` with keys validated against the
-  canonical table — sealed, therefore keyed. One-way door: a scrubbed var
-  that turns out to be needed becomes a knob, never an unscrub.
-* :func:`effective_seal` — {seal_v, epoch, posture, config read-back,
-  portable inductor digest, loaded-library digest (pgw#719: the native
-  ``.so`` set actually mapped into the process — closes the
-  LD_PRELOAD/LD_LIBRARY_PATH substitution hole that env vars and package
-  RECORDs cannot see)}. After scrub+impose the seal is a pure function of
-  (SDK build x declared knobs). Its :func:`seal_digest` is the ``env_seal``
-  key axis; ``seal_v`` versions the dict, so new sealed facts change
-  digest VALUES only, never the axis set.
-* :func:`assert_seal_unchanged` — boot-vs-point-of-use (pgw#719): the boot
-  seal is stored at :func:`establish`; every mint trace re-reads the
-  effective state first and REFUSES on drift, naming the fact and both
-  values (endpoint code mutating config/env behind our back becomes a
-  named error, never a silently different graph). The per-call serving
-  window is covered by dynamo's GlobalStateGuard + the pgw#680 guard-miss
-  doctrine.
+* :func:`establish` — impose the declaration (env, torch flags + declared
+  knobs, dynamo shape posture, host-ISA clamp, process posture), verify
+  every read-back against it, fail closed on mismatch.
+* :func:`effective_seal` — the seal is a digest of the DECLARATION
+  (pgw#1049): ``settings_authority.declaration()`` facts plus the
+  loaded-library digest (pgw#719: the native ``.so`` set the python env
+  ships — closes the LD_PRELOAD/LD_LIBRARY_PATH substitution hole that env
+  vars and package RECORDs cannot see). Ambient mutation is structurally
+  unable to move the digest — torch wheel defaults ride the ``toolchain``
+  key axis, and everything else in the codegen surface is either declared
+  (sealed) or erased. ``seal_v`` versions the dict, so new sealed facts
+  change digest VALUES only, never the axis set.
+* :func:`assert_seal_unchanged` — the runtime TRIPWIRE (pgw#719, kept
+  deliberately as read-back where the seal itself no longer is): boot
+  stores the live read-back (posture, torch flags, dynamo facts, FULL
+  portable inductor digest); every mint trace re-reads and REFUSES on
+  drift, naming the fact and both values. Since boot verified read-back ==
+  declaration, any trip is also a declaration mismatch: ambient mutation
+  becomes a named refusal, never a silently different graph — and never a
+  different key. The per-call serving window is covered by dynamo's
+  GlobalStateGuard + the pgw#680 guard-miss doctrine.
 
 The seal dict rides cell metadata verbatim (``artifact_metadata``), so
 ``cell_key.from_artifact_metadata`` recomputes the axis from recorded facts
-and a stamp can never disagree with the environment it summarizes.
+and a stamp can never disagree with the declaration it summarizes.
 """
 
 from __future__ import annotations
@@ -54,7 +53,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-from . import guard_closure, host_isa, torch_capability
+from . import guard_closure, host_isa, settings_authority, torch_capability
 import importlib.util
 
 logger = logging.getLogger(__name__)
@@ -82,28 +81,18 @@ logger = logging.getLogger(__name__)
 # pgw#1042 bumped 2 -> 3 by EXCLUDING torch's compile-injected
 # `aot_inductor.metadata` from the inductor fact (see _PORTABLE_VOLATILE).
 # RE-KEY COST: zero — no cell has ever been published under v2.
-SEAL_VERSION = 3
-SEAL_KEY = "env_seal"
-
-# Behavior-affecting global flags: ONE canonical value each, set explicitly
-# by establish_config() and read back effective. String-valued for JSON
-# determinism.
 #
-# The canonical values ARE the ratified SERVING posture, not a preference:
-# pgw#654 sets TF32 ON at executor bootstrap (bf16 compute path; TF32
-# touches residual fp32 matmuls only), and inductor hashes the TF32 state
-# (`cuda_matmul_settings`) into every inner FX key — so a mint sealed with
-# TF32 off could never HIT in a pgw#654 serving process. The #719 drift
-# check surfaced exactly that divergence live (every suite mint refused
-# once an executor bootstrap ran); the seal's job is mint==serve
-# consistency, so the table matches pgw#654. Note the 2.13 coupling:
-# allow_tf32=True implies float32_matmul_precision "high".
-CANONICAL_CONFIG: Dict[str, str] = {
-    "float32_matmul_precision": "high",
-    "cuda_matmul_allow_tf32": "True",
-    "cudnn_allow_tf32": "True",
-    "cudnn_benchmark": "False",
-}
+# pgw#1049 bumped 3 -> 4: the seal derives from settings_authority's
+# DECLARATION, not from read-back — the `inductor` fact becomes the declared
+# codegen clamp instead of a save_config_portable() digest, `posture`/`config`
+# become the declared tables, and the declared env (incl. the imposed
+# PYTHONHASHSEED=0, executing the pgw#1034 HUMAN_MUST_DO decision) is sealed.
+# RE-KEY COST, stated per §1.27(g): every cell minted under seal v3 stops
+# matching and is re-minted once, per (family, lane, sm). The corpus is
+# effectively empty (see the PR/tracker for the measured row count), so this
+# is the cheapest moment the fleet will ever have for it.
+SEAL_VERSION = 4
+SEAL_KEY = "env_seal"
 
 # The behavior namespaces scrub_env ERASES wholesale (pgw#718). Known or
 # unknown, hostile or informational: after the scrub, torch behavior is
@@ -122,6 +111,30 @@ SCRUB_PREFIXES = (
     "NVIDIA_TF32",  # flips numerics under every torch flag
     "OMP_",        # thread counts enter cpp codegen decisions
     "MKL_",
+    # pgw#1049 ambient-input census: the behavior namespaces the census scan
+    # of the installed torch/triton tree proved are CONSULTED and were not
+    # yet erased. Same doctrine — an ambient value is deleted, never honored;
+    # what we need post-scrub is imposed (settings_authority.DECLARED_ENV).
+    "NCCL_",       # collective transport behavior (NVLS/P2P re-imposed by us)
+    "ATEN_",       # ATEN_CPU_CAPABILITY flips CPU kernel dispatch
+    "AOT_INDUCTOR",   # AOTI build/debug knobs (opt level, LTO, debug symbols)
+    "AOTINDUCTOR",    # AOTI repro knobs
+    "AOTI_",          # AOTI runtime knobs
+    "AOT_PARTITIONER_DEBUG",
+    "INDUCTOR_",   # inductor dump/provenance/test knobs
+    "CUTLASS_", "CUTEDSL_",   # kernel-backend tuning
+    "KMP_",        # Intel OpenMP runtime (same family as OMP_/MKL_)
+    "CUDA_LAUNCH_BLOCKING",   # serializes every launch — behavior, not a path
+    "CUDA_MODULE_LOADING",    # lazy/eager module load behavior
+    "CUDA_PROFILE",
+    "ENABLE_PERSISTENT_TMA_MATMUL",   # matmul kernel selection
+    "ENABLE_TEMPLATE_TMA_STORE",
+    "ENABLE_TMA_LOAD_FOR_TEMPLATE_EPILOGUE",
+    "TENSORIFY_PYTHON_SCALARS",       # dynamo scalar handling
+    "FAKE_ALLOW_META",                # functorch fake-tensor behavior
+    "FX_PATCH_GETITEM",               # fx tracing behavior
+    "PARTITIONER_MEMORY_BUDGET_PARETO",  # aot_autograd partitioner behavior
+    "UNSAFE_SKIP_FSDP_MODULE_GUARDS",    # dynamo guard behavior
 )
 
 
@@ -151,90 +164,23 @@ def scrub_env() -> List[str]:
 
 
 def effective_config() -> Dict[str, str]:
-    """The live values of every sealed config flag (read back, never
-    assumed). Post-scrub these are a pure function of (SDK build x
-    declared knobs) — no env var can reach them. The hash-seed facts
-    record interpreter-level ordering entropy (pgw#719). They are RECORDED,
-    not imposed, and that is deliberate rather than unfinished: ``PYTHONHASHSEED``
-    is read by CPython at interpreter startup, so imposing it means re-exec'ing
-    the entrypoint — a boot-path change with its own proof owed (pgw#1034 left
-    it as a named decision). ``SCRUB_PREFIXES`` does not cover ``PYTHON``, so an
-    operator CAN set a seed here; recording it is what makes that divergence
-    visible in the key instead of silently forking the traced graph.
+    """The LIVE values of the sealed config surface — the TRIPWIRE's config
+    fact, never the seal's (pgw#1049: the seal digests the declaration).
+    The hash-seed facts record what this interpreter actually booted with;
+    :func:`establish` refuses when they diverge from the declared
+    ``PYTHONHASHSEED=0`` (imposition is the entrypoint's re-exec —
+    ``settings_authority.ensure_interpreter_env``).
 
     pgw#788: a torchless worker has no matmul/cudnn surface to read back, so it
-    seals the ABSENCE as a fact instead of crashing on the import."""
-    torch = torch_capability.torch_or_none()
-    if torch is None:
-        return {
-            "torch": torch_capability.ABSENT,
-            "python_hash_seed": os.environ.get("PYTHONHASHSEED", ""),
-            "hash_randomization": str(sys.flags.hash_randomization),
-            **host_isa.effective(),
-        }
-
-    return {
-        "float32_matmul_precision": str(torch.get_float32_matmul_precision()),
-        "cuda_matmul_allow_tf32": str(torch.backends.cuda.matmul.allow_tf32),
-        "cudnn_allow_tf32": str(torch.backends.cudnn.allow_tf32),
-        "cudnn_benchmark": str(torch.backends.cudnn.benchmark),
+    reads the ABSENCE as a fact instead of crashing on the import."""
+    base = {
         "python_hash_seed": os.environ.get("PYTHONHASHSEED", ""),
         "hash_randomization": str(sys.flags.hash_randomization),
-        # pgw#754: the host codegen target. Named here (beyond the opaque
-        # inductor digest, which also covers cpp.march/cpp.simdlen) so a
-        # cohort split is legible in the seal itself.
+        # pgw#754: the host codegen target, read back live so a drifted clamp
+        # is named legibly (beyond the opaque inductor digest below).
         **host_isa.effective(),
     }
-
-
-def establish_config(
-    overrides: Optional[Mapping[str, str]] = None,
-) -> Dict[str, str]:
-    """Impose the canonical table (plus DECLARED knob overrides) via torch
-    APIs, then verify the read-back. ``overrides`` is the typed-knob
-    surface (pgw#718): keys must exist in :data:`CANONICAL_CONFIG` — the
-    only route to non-canonical behavior is a declared knob, which is
-    sealed and therefore keyed. An unknown knob refuses, named.
-
-    pgw#788: on a torchless worker there is nothing to impose. The knob names are
-    still validated (that contract is torch-free) and the seal records
-    ``torch: "absent"``. A DECLARED knob is a different matter: every canonical
-    knob is a torch flag, so an endpoint that declares one in a torchless image
-    is misconfigured, and honouring it silently would fork cell identity — so
-    that refuses, named."""
-    table = dict(CANONICAL_CONFIG)
-    if overrides:
-        unknown = sorted(set(overrides) - set(table))
-        if unknown:
-            raise EnvSealError(
-                f"unknown config knob(s) {unknown!r}: not in the canonical "
-                "table (env_seal.CANONICAL_CONFIG) — declare the knob "
-                "there first (one-way door: knobs in, env vars never)")
-        table.update({k: str(v) for k, v in overrides.items()})
-    torch = torch_capability.torch_or_none()
-    if torch is None:
-        if overrides:
-            raise EnvSealError(
-                f"config knob(s) {sorted(overrides)!r} declared on a TORCHLESS "
-                "worker: every canonical knob is a torch flag, so there is "
-                "nothing to impose them on. Either ship torch in this image or "
-                "drop the knob — honouring it silently would fork cell "
-                "identity (pgw#788)")
-        return effective_config()
-    torch.set_float32_matmul_precision(table["float32_matmul_precision"])
-    torch.backends.cuda.matmul.allow_tf32 = (
-        table["cuda_matmul_allow_tf32"] == "True")
-    torch.backends.cudnn.allow_tf32 = (table["cudnn_allow_tf32"] == "True")
-    torch.backends.cudnn.benchmark = (table["cudnn_benchmark"] == "True")
-    effective = effective_config()
-    diffs: List[str] = [
-        f"{name}: imposed {want!r} != effective {effective.get(name)!r}"
-        for name, want in table.items()
-        if effective.get(name) != want
-    ]
-    if diffs:
-        raise EnvSealError("config freeze failed: " + "; ".join(diffs))
-    return effective
+    return {**settings_authority.torch_readback(), **base}
 
 
 # Config entries torch MUTATES as a compile side effect — outputs, not knobs.
@@ -519,20 +465,27 @@ def frozen_library_digests() -> Tuple[Tuple[str, str], ...]:
     return _LIB_SNAPSHOT
 
 
+#: Declared knob overrides this process was established with — part of the
+#: declaration, therefore part of the seal (a knob is keyed identity).
+_ESTABLISHED_OVERRIDES: Optional[Dict[str, str]] = None
+
+
 def effective_seal() -> Dict[str, Any]:
-    """The live seal dict — recorded verbatim in cell metadata. The
-    loaded-libs FACT is the combined digest of the BOOT-frozen library
-    snapshot (identity); the per-library list rides metadata via
-    ``compile_cache.artifact_metadata`` so a mismatch names the library."""
+    """The seal dict — a digest of the DECLARATION (pgw#1049), recorded
+    verbatim in cell metadata. Its settings facts come from
+    ``settings_authority.declaration()``; ambient mutation cannot move them
+    (it trips :func:`assert_seal_unchanged` instead). The one measured fact
+    is ``loaded_libs`` — the combined digest of the BOOT-frozen library
+    snapshot (toolchain CONTENT, not a setting; the per-library list rides
+    metadata via ``compile_cache.artifact_metadata`` so a mismatch names the
+    library)."""
     libs_encoded = json.dumps(
         dict(frozen_library_digests()), sort_keys=True,
         separators=(",", ":"), ensure_ascii=True,
     ).encode()
     return {
         "seal_v": SEAL_VERSION,
-        "posture": guard_closure.posture_snapshot(),
-        "config": effective_config(),
-        "inductor": inductor_config_digest(),
+        **settings_authority.declaration(_ESTABLISHED_OVERRIDES),
         "loaded_libs": hashlib.sha256(libs_encoded).hexdigest()[:16],
     }
 
@@ -545,9 +498,27 @@ def seal_digest(seal: Mapping[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()[:16]
 
 
-# The boot seal (pgw#719): stored by establish(); every mint trace asserts
-# the live state against it before tracing.
-_BOOT_SEAL: Optional[Dict[str, Any]] = None
+def settings_readback() -> Dict[str, Any]:
+    """The live settings state — the TRIPWIRE surface (pgw#719/pgw#1049).
+
+    Deliberately read-back where :func:`effective_seal` no longer is: the
+    seal states the declaration; this states the process. The ``inductor``
+    fact is the digest of the FULL portable config (wheel defaults included,
+    torch-owned compile outputs excluded — ``_PORTABLE_VOLATILE``), so a
+    mutation of an entry the declaration never names is still caught and
+    refused by name, instead of silently forking the traced graph."""
+    return {
+        "posture": guard_closure.posture_snapshot(),
+        "config": effective_config(),
+        "dynamo": settings_authority.dynamo_readback(),
+        "inductor": inductor_config_digest(),
+    }
+
+
+# The boot read-back (pgw#719): stored by establish() AFTER read-back was
+# verified == declaration; every mint trace asserts the live state against
+# it before tracing.
+_BOOT_READBACK: Optional[Dict[str, Any]] = None
 
 
 def _seal_diff(boot: Mapping[str, Any], live: Mapping[str, Any]) -> List[str]:
@@ -565,20 +536,23 @@ def _seal_diff(boot: Mapping[str, Any], live: Mapping[str, Any]) -> List[str]:
 
 
 def assert_seal_unchanged(label: str = "") -> None:
-    """Point-of-use enforcement (pgw#719): the effective environment must
-    still be the BOOT environment. First call without an established boot
-    seal adopts the current state as boot (embedders/tests); any later
-    drift refuses, naming the fact and both values — endpoint code
-    mutating config/env behind our back becomes a named error, never a
-    silently different graph. The boot-frozen library snapshot is
-    re-digested LIVE here: a substituted native lib (LD_PRELOAD-style,
-    post-boot) is named even though the seal fact itself is frozen."""
-    global _BOOT_SEAL
-    live = effective_seal()
-    if _BOOT_SEAL is None:
-        _BOOT_SEAL = live
+    """Point-of-use enforcement (pgw#719): the LIVE settings must still be
+    the BOOT settings — and boot verified those against the declaration, so
+    a trip is a declaration mismatch by transitivity. First call without an
+    established boot read-back adopts the current state as boot
+    (embedders/tests); any later drift refuses, naming the fact and both
+    values — code mutating config/env behind our back becomes a named error,
+    never a silently different graph, and NEVER a different key (pgw#1049:
+    the seal derives from the declaration and cannot follow the drift). The
+    boot-frozen library snapshot is re-digested LIVE here: a substituted
+    native lib (LD_PRELOAD-style, post-boot) is named even though the seal
+    fact itself is frozen."""
+    global _BOOT_READBACK
+    live = settings_readback()
+    if _BOOT_READBACK is None:
+        _BOOT_READBACK = live
         return
-    diffs = _seal_diff(_BOOT_SEAL, live)
+    diffs = _seal_diff(_BOOT_READBACK, live)
     snapshot = dict(frozen_library_digests())
     if snapshot:
         current = dict(loaded_library_digests())
@@ -608,10 +582,14 @@ LAST_ESTABLISH_SPANS: Dict[str, float] = {}
 
 def establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     """The boot entry (entrypoint wiring): SCRUB the behavior namespaces,
-    IMPOSE the canonical config (+ declared knobs) and posture, store the
-    boot seal, return it. Never refuses on env content — only on an
-    imposition that does not take effect or an undeclared knob."""
-    global _BOOT_SEAL
+    IMPOSE the declaration (env, torch flags + declared knobs, dynamo shape
+    posture, host-ISA clamp, process posture), verify every read-back
+    against it, store the boot read-back for the tripwire, return the seal.
+    Never refuses on ambient env content — only on an imposition that does
+    not take effect, an undeclared knob, or an interpreter that booted
+    outside the declared env (``settings_authority.ensure_interpreter_env``
+    is the imposition for that one)."""
+    global _BOOT_READBACK, _ESTABLISHED_OVERRIDES
 
     spans: Dict[str, float] = {}
     marks = [time.monotonic()]
@@ -621,18 +599,27 @@ def establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
         spans[name] = round(marks[-1] - marks[-2], 3)
 
     scrub_env()
+    # Re-impose OUR declared env after the scrub erased the whole namespace
+    # (an ambient value is deleted, never honored), and refuse if the
+    # interpreter itself booted outside the declaration (hash seed).
+    settings_authority.impose_process_env()
+    settings_authority.verify_interpreter_env()
     mark("seal_scrub_s")
-    establish_config(overrides)
+    settings_authority.impose_torch(overrides)
     mark("seal_config_s")
     try:
         host_isa.impose()
     except host_isa.HostIsaError as exc:
         raise EnvSealError(str(exc)) from exc
     mark("seal_isa_s")
+    settings_authority.impose_dynamo()
+    mark("seal_dynamo_s")
     guard_closure.establish_posture()
     mark("seal_posture_s")
     cold_libs = _LIB_SNAPSHOT is None
-    _BOOT_SEAL = effective_seal()
+    _ESTABLISHED_OVERRIDES = dict(overrides) if overrides else None
+    _BOOT_READBACK = settings_readback()
+    seal = effective_seal()
     mark("seal_effective_s")
     # The library pass is timed where it runs (frozen_library_digests), not
     # inferred from `seal_effective_s`: with a pgw#832 memo the pass shrinks
@@ -643,11 +630,10 @@ def establish(overrides: Optional[Mapping[str, str]] = None) -> Dict[str, Any]:
     spans["seal_libhash_s"] = _LAST_LIBHASH_S if cold_libs else 0.0
     LAST_ESTABLISH_SPANS.clear()
     LAST_ESTABLISH_SPANS.update(spans)
-    return dict(_BOOT_SEAL)
+    return seal
 
 
 __all__ = [
-    "CANONICAL_CONFIG",
     "LAST_ESTABLISH_SPANS",
     "EnvSealError",
     "SCRUB_PREFIXES",
@@ -658,11 +644,11 @@ __all__ = [
     "effective_config",
     "effective_seal",
     "establish",
-    "establish_config",
     "inductor_config_digest",
     "frozen_library_digests",
     "loaded_library_digests",
     "scrub_env",
     "seal_digest",
+    "settings_readback",
     "write_library_memo",
 ]

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -48,6 +48,7 @@ from .transport import FatalTransportError
 from . import cpu_budget
 from . import kernel_path
 from . import mint_budget
+from . import settings_authority
 from . import progress as progress_mod
 from . import serving_mode as serving_mode_mod
 from . import warmup
@@ -3266,11 +3267,12 @@ class Executor:
         self._settings = settings
         self.store = store or ModelStore(send)
         # pgw#654: TF32 is PROCESS-GLOBAL state — set once at executor
-        # bootstrap, never inside per-instance endpoint setup. Largely moot
-        # on the bf16 compute path (it affects residual fp32 matmuls only).
-        if torch is not None and torch.cuda.is_available():
-            torch.backends.cuda.matmul.allow_tf32 = True
-            torch.backends.cudnn.allow_tf32 = True
+        # bootstrap, never inside per-instance endpoint setup. pgw#1049: the
+        # write is the settings authority's (its declared table IS the
+        # pgw#654 posture); calling it here keeps embedder/test processes
+        # that never ran env_seal.establish on the declared posture too.
+        if torch is not None:
+            settings_authority.impose_torch()
         self.intent_registry: Optional[IntentRegistry] = None
         for s in specs:
             for b in s.models.values():

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1287,7 +1287,6 @@ def _arming_policy(
             family, loading.pipeline_weight_lane(pipe), bucket,
             contract=cell_key.contract_digest(
                 cc.declared_contract_facts(cfg)),
-            regional=bool(getattr(cfg, "regional", False)),
         )
         key = arm_key.digest
     except Exception as exc:  # noqa: BLE001 — key axes must be computable

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -1430,7 +1430,7 @@ def _packed_metadata(artifact: Path) -> Dict[str, Any]:
 #: The key axes the computed ARM identity and the stamped cell identity
 #: SHARE. `kind` and `contract` are disjoint by formula (pgw#1032/#1033:
 #: kind "inductor" vs "aot-inductor", declared-facts digest vs traced-graph
-#: facts digest) and `mode` is "" on both sides of a whole-graph mint.
+#: facts digest); the vestigial `mode` axis is DELETED (pgw#1049).
 _SHARED_KEY_AXES = ("family", "format", "lane", "sm", "env_seal", "toolchain")
 
 

--- a/src/gen_worker/host_isa.py
+++ b/src/gen_worker/host_isa.py
@@ -36,7 +36,6 @@ from functools import lru_cache
 from typing import Dict, FrozenSet, Mapping, Optional, Sequence, Tuple, Union
 
 from . import torch_capability
-import threading
 
 logger = logging.getLogger(__name__)
 
@@ -134,41 +133,22 @@ def mint_simdlen(march: Optional[str]) -> Optional[int]:
 
 
 def _impose_default(inductor_config: object, key: str, value: object) -> None:
-    """Write the PROCESS-WIDE fallback for an inductor config key.
+    """Process-wide fallback write, via the ONE shared mechanism
+    (``settings_authority.impose_config_default`` — pgw#1049), wrapped so
+    this module's callers keep their typed :class:`HostIsaError`."""
+    from . import settings_authority
 
-    ``inductor_config.cpp.march = x`` sets a ``user_override``, and torch
-    documents that layer as thread-local — it is a ``ContextVar``, so only
-    the thread that assigned it ever reads it back. Every OTHER thread falls
-    through the precedence chain to ``default``, which is the layer this
-    writes. Nothing else in the chain is settable at runtime: ``alias`` and
-    the two ``env_value_*`` layers are resolved once at install time.
-    """
-    entry = getattr(inductor_config, "_config", {}).get(key)
-    if entry is None:
+    try:
+        settings_authority.impose_config_default(inductor_config, key, value)
+    except settings_authority.SettingsImpositionError as exc:
         raise HostIsaError(
-            f"isa clamp cannot reach a process-wide target: torch's inductor "
-            f"config has no {key!r} entry to set a default on. torch's config "
-            f"internals changed; the clamp must be re-seated before any host "
-            f"compile can be trusted to be portable.")
-    entry.default = value
+            f"isa clamp cannot reach a process-wide target: {exc}") from exc
 
 
 def _read_in_fresh_thread(fn: object) -> object:
-    """Run ``fn`` on a brand-new thread and return its value.
+    from . import settings_authority
 
-    A fresh thread starts with an empty ``ContextVar`` context, so this reads
-    exactly what a background compile thread would read.
-    """
-
-    box: Dict[str, object] = {}
-
-    def _run() -> None:
-        box["v"] = fn()  # type: ignore[operator]
-
-    t = threading.Thread(target=_run, name="host-isa-readback", daemon=True)
-    t.start()
-    t.join()
-    return box.get("v")
+    return settings_authority.read_in_fresh_thread(fn)  # type: ignore[arg-type]
 
 
 def impose() -> Dict[str, str]:

--- a/src/gen_worker/local_cells.py
+++ b/src/gen_worker/local_cells.py
@@ -113,7 +113,6 @@ def store_verdict(artifact: Path, family: str, pipe: Any, cfg: Any) -> str:
             family, cc.cell_base_execution_lane(pipe),
             int(getattr(cfg, "lora_bucket", 0) or 0),
             contract=cell_key.contract_digest(cc.declared_contract_facts(cfg)),
-            regional=bool(getattr(cfg, "regional", False)),
         )
     except cell_key.CellKeyError:
         reason = cc.verify(meta, family=family)

--- a/src/gen_worker/parallel/group.py
+++ b/src/gen_worker/parallel/group.py
@@ -51,6 +51,8 @@ from datetime import timedelta
 from typing import Any, Callable, List, Optional, Sequence, Tuple, cast
 import multiprocessing as mp
 
+from .. import settings_authority
+
 logger = logging.getLogger(__name__)
 
 # A follower that has not reached the store rendezvous by this deadline is
@@ -180,7 +182,9 @@ def _refuse_nvls_multicast() -> None:
     refusing.
     """
     previous = os.environ.get(_NVLS_ENV)
-    os.environ[_NVLS_ENV] = "0"
+    # pgw#1049: the write is the settings authority's (NCCL_NVLS_ENABLE=0 is
+    # in DECLARED_ENV); this site keeps the drop-an-override warning below.
+    settings_authority.impose_process_env()
     if previous not in (None, "0"):
         logger.warning(
             "%s was %r; overwritten to 0. NVLS multicast cannot be bound in "

--- a/src/gen_worker/settings_authority.py
+++ b/src/gen_worker/settings_authority.py
@@ -1,0 +1,471 @@
+"""THE single settings authority (pgw#1049, Paul's directive 2026-08-09).
+
+``us -> pytorch settings``, never ``[us, ambient world] -> pytorch settings``:
+every torch/dynamo/inductor process setting this worker runs under is DECLARED
+in this module's tables, imposed from here, and verified against the
+declaration. Cell identity (``env_seal``) derives from :func:`declaration` —
+the seal digests what WE declared, never a read-back of whatever the process
+happens to hold — so ambient mutation is structurally unable to move identity.
+It can only trip the pgw#719 drift tripwire (kept in ``env_seal`` as the
+runtime detector), which refuses typed before any trace runs under it.
+
+The disease this cures, named by shipped incidents: pgw#1042 (torch's own
+``aot_compile`` mutated global ``aot_inductor.metadata`` mid-mint and the
+read-back seal faithfully recorded the contamination — the child sealed a
+different identity than its own boot) and pgw#754 (``cpp.march=None`` hashed
+identically on every host while the emitted code differed per host). A
+read-back is a mirror; a declaration is an authority.
+
+Write fence: ``scripts/lint_settings_writers.py`` holds the modules in
+:data:`AUTHORITY_MODULES` to be the ONLY writers of torch settings. A write
+anywhere else in ``src/gen_worker`` is red unless classified in
+``scripts/settings_writers_allowlist.txt`` — a second writer is a defect, the
+same way a stray ``os.environ`` read is under §1.18.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+from . import torch_capability
+
+logger = logging.getLogger(__name__)
+
+
+class SettingsImpositionError(RuntimeError):
+    """The declared settings could not be imposed, or an undeclared knob was
+    asked for. Fail-closed: a process that cannot carry the declaration must
+    not mint or serve under its identity."""
+
+
+#: Modules allowed to WRITE torch settings (the fence's allowed set). Paths
+#: relative to ``src/gen_worker``. host_isa and guard_closure hold the
+#: ISA-clamp and posture halves of the declaration; env_seal orchestrates
+#: boot; everything else calls functions here.
+AUTHORITY_MODULES: Tuple[str, ...] = (
+    "settings_authority.py",
+    "env_seal.py",
+    "host_isa.py",
+    "guard_closure.py",
+)
+
+# ---------------------------------------------------------------------------
+# The declaration
+# ---------------------------------------------------------------------------
+
+#: Process env WE impose, re-imposed after ``env_seal.scrub_env`` erases the
+#: behavior namespaces — an ambient value is deleted, never honored, and the
+#: value below is what every child (mint child, AOT entry child, torch's own
+#: compile subprocesses) inherits.
+#:
+#: PYTHONHASHSEED=0: the pgw#1034 / HUMAN_MUST_DO decision, EXECUTED here per
+#: Paul's pgw#1049 directive (imposition is the pure-declaration answer; the
+#: cost note said to bundle it with a seal change, and seal v4 is that
+#: change). CPython reads it at interpreter start, so imposition for the
+#: CURRENT interpreter is :func:`ensure_interpreter_env`'s re-exec; children
+#: inherit it from this table. REVERT = delete the entry here and its census
+#: row — nothing else refers to the seed.
+#:
+#: PYTORCH_CUDA_ALLOC_CONF: pgw#1049 found the entrypoint's old ``setdefault``
+#: was DEAD — ``scrub_env`` erased it (``PYTORCH`` prefix) before the first
+#: cudaMalloc ever read it, so ``expandable_segments`` was silently off on
+#: every worker. Imposing it post-scrub is what makes it real.
+#:
+#: TORCHINDUCTOR_AUTOGRAD_CACHE=0: gw#608 — the AOTAutogradCache key embeds a
+#: process address (ASLR) and can never hit across pods; cell portability
+#: needs the portable FxGraphCache to be the lookup surface.
+#:
+#: NCCL_NVLS_ENABLE=0: pgw#929 §1.17 AMBIGUOUS #3 — NVLS multicast cannot be
+#: bound in our containers (measured: CUDA 401 on the first all-to-all of
+#: every group) and Ulysses does not use it. The env survives only as NCCL's
+#: own handoff mechanism; it is nobody's choice (``parallel/group.py`` warns
+#: at communicator creation if an ambient override was dropped).
+DECLARED_ENV: Dict[str, str] = {
+    "PYTHONHASHSEED": "0",
+    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+    "TORCHINDUCTOR_AUTOGRAD_CACHE": "0",
+    "NCCL_NVLS_ENABLE": "0",
+}
+
+#: Behavior-affecting torch global flags: ONE canonical value each, imposed by
+#: :func:`impose_torch` and verified by read-back. The canonical values ARE
+#: the ratified SERVING posture, not a preference: pgw#654 sets TF32 ON at
+#: executor bootstrap (bf16 compute path; TF32 touches residual fp32 matmuls
+#: only), and inductor hashes the TF32 state (``cuda_matmul_settings``) into
+#: every inner FX key — so a mint sealed with TF32 off could never HIT in a
+#: pgw#654 serving process. Note the 2.13 coupling: allow_tf32=True implies
+#: float32_matmul_precision "high".
+DECLARED_TORCH: Dict[str, str] = {
+    "float32_matmul_precision": "high",
+    "cuda_matmul_allow_tf32": "True",
+    "cudnn_allow_tf32": "True",
+    "cudnn_benchmark": "False",
+}
+
+#: The v2 dynamo shape posture (moved from ``compile_cache`` per pgw#1049 —
+#: it was a second writer): nothing becomes dynamic by accident.
+#: ``automatic_dynamic_shapes=False`` — never promote a dim on change (a novel
+#: signature is a guard miss routed by the consumer guards, never a silent
+#: recompile-to-dynamic); ``assume_static_by_default=True`` — unmarked dims
+#: are static. Declared dynamism arrives ONLY through explicit
+#: ``mark_dynamic`` marks (``compile_cache._with_declared_marks``).
+DECLARED_DYNAMO: Dict[str, str] = {
+    "automatic_dynamic_shapes": "False",
+    "assume_static_by_default": "True",
+}
+
+
+def declaration(
+    overrides: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Any]:
+    """The full declared settings — the ONLY input the env seal digests.
+
+    Facts here are what WE state, never what the process reads back: the env
+    table, the torch flag table (+ declared knob overrides), the dynamo shape
+    posture, the host-ISA codegen clamp (a declared rule of the host —
+    ``min(host level, BASELINE)``, pgw#754 — like ``sm``, not a config
+    read-back), and the canonical process posture. A torchless worker
+    declares the absence itself as the fact (pgw#788)."""
+    from . import guard_closure, host_isa  # lazy: keep this module light
+
+    if torch_capability.present():
+        config = validated_table(overrides)
+        dynamo = dict(DECLARED_DYNAMO)
+        posture = dict(guard_closure.CANONICAL_POSTURE)
+        march = host_isa.mint_march()
+        inductor = (
+            {"cpp.march": march, "cpp.simdlen": str(host_isa.mint_simdlen(march))}
+            if march is not None else {}
+        )
+    else:
+        # Knob names are still validated (torch-free contract); a DECLARED
+        # knob on a torchless image refuses — honouring it silently would
+        # fork cell identity (pgw#788).
+        validated_table(overrides)
+        if overrides:
+            raise SettingsImpositionError(
+                f"config knob(s) {sorted(overrides)!r} declared on a "
+                "TORCHLESS worker: every canonical knob is a torch flag, so "
+                "there is nothing to impose them on. Either ship torch in "
+                "this image or drop the knob (pgw#788)")
+        absent = {"torch": torch_capability.ABSENT}
+        config, dynamo, posture, inductor = absent, dict(absent), dict(absent), {}
+    return {
+        "env": dict(DECLARED_ENV),
+        "config": config,
+        "dynamo": dynamo,
+        "inductor": inductor,
+        "posture": posture,
+    }
+
+
+def validated_table(
+    overrides: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """:data:`DECLARED_TORCH` with DECLARED knob overrides folded in — the
+    typed-knob surface (pgw#718): keys must exist in the canonical table, so
+    the only route to non-canonical behavior is a declared knob, which is
+    part of the declaration and therefore keyed. An unknown knob refuses,
+    named. One-way door: a scrubbed env var that turns out to be needed
+    becomes a knob, never an unscrub."""
+    table = dict(DECLARED_TORCH)
+    if overrides:
+        unknown = sorted(set(overrides) - set(table))
+        if unknown:
+            raise SettingsImpositionError(
+                f"unknown config knob(s) {unknown!r}: not in the canonical "
+                "table (settings_authority.DECLARED_TORCH) — declare the "
+                "knob there first (one-way door: knobs in, env vars never)")
+        table.update({k: str(v) for k, v in overrides.items()})
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Imposition — process env
+# ---------------------------------------------------------------------------
+
+
+def impose_process_env() -> None:
+    """Write :data:`DECLARED_ENV` into ``os.environ`` — unconditionally, so
+    an ambient value never survives. Called at entrypoint import (pre-torch,
+    covers children) and again by ``env_seal.establish`` after the scrub
+    (the scrub erases the whole namespace, including our own entries)."""
+    os.environ.update(DECLARED_ENV)
+
+
+def _interpreter_env_diffs() -> List[str]:
+    """Declared entries CPython consumed at interpreter start, checked by
+    their EFFECT — the env var alone proves nothing once the interpreter is
+    running. PYTHONHASHSEED=0 must have disabled hash randomization."""
+    diffs: List[str] = []
+    want = DECLARED_ENV.get("PYTHONHASHSEED")
+    if want == "0" and sys.flags.hash_randomization != 0:
+        diffs.append(
+            "PYTHONHASHSEED: declared '0' but this interpreter booted with "
+            "hash randomization ON")
+    return diffs
+
+
+def ensure_interpreter_env() -> None:
+    """Impose the interpreter-level declared env on the CURRENT process,
+    re-exec'ing once if the interpreter booted without it.
+
+    CPython reads ``PYTHONHASHSEED`` at interpreter start, so a running
+    process cannot adopt it in place — the sanctioned imposition is exec:
+    set the declared env and replace this process with itself
+    (``sys.orig_argv``). The re-exec'd interpreter sees the declared env at
+    start, so the check passes and the exec runs at most once. Call sites:
+    the worker entrypoint's ``__main__`` (before the procsplit fork), test
+    ``conftest``, and any embedder that mints — BEFORE torch is imported."""
+    if not _interpreter_env_diffs():
+        impose_process_env()
+        return
+    if sys.flags.ignore_environment:
+        raise SettingsImpositionError(
+            "cannot impose the declared interpreter env: python was started "
+            "with -E/-I (ignore_environment), so a re-exec cannot deliver "
+            "PYTHONHASHSEED. Drop the flag or set the declared env at launch.")
+    impose_process_env()
+    logger.info("settings authority: re-exec to impose interpreter env "
+                "(PYTHONHASHSEED=%s)", DECLARED_ENV.get("PYTHONHASHSEED"))
+    os.execv(sys.executable, list(sys.orig_argv))
+
+
+def verify_interpreter_env() -> None:
+    """Fail-closed check that the declared interpreter env is IN EFFECT —
+    ``env_seal.establish`` calls this, so a process that skipped
+    :func:`ensure_interpreter_env` cannot seal an identity claiming the
+    declared hash seed it does not have."""
+    diffs = _interpreter_env_diffs()
+    if diffs:
+        raise SettingsImpositionError(
+            "declared interpreter env is not in effect: "
+            + "; ".join(diffs)
+            + " — the entrypoint imposes it by re-exec; embedders/tests call "
+            "settings_authority.ensure_interpreter_env() before torch")
+
+
+# ---------------------------------------------------------------------------
+# Imposition — torch globals
+# ---------------------------------------------------------------------------
+
+
+def torch_readback() -> Dict[str, str]:
+    """Live values of the :data:`DECLARED_TORCH` flags (tripwire surface)."""
+    torch = torch_capability.torch_or_none()
+    if torch is None:
+        return {"torch": torch_capability.ABSENT}
+    return {
+        "float32_matmul_precision": str(torch.get_float32_matmul_precision()),
+        "cuda_matmul_allow_tf32": str(torch.backends.cuda.matmul.allow_tf32),
+        "cudnn_allow_tf32": str(torch.backends.cudnn.allow_tf32),
+        "cudnn_benchmark": str(torch.backends.cudnn.benchmark),
+    }
+
+
+def impose_torch(
+    overrides: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """Impose the declared torch table (+ declared knobs), then verify the
+    read-back. Torch's backend flags are C-level process globals, so a
+    same-thread read-back is a process-wide proof. Returns the read-back.
+
+    On a torchless worker there is nothing to impose; knob names are still
+    validated and a declared knob refuses (pgw#788)."""
+    table = validated_table(overrides)
+    torch = torch_capability.torch_or_none()
+    if torch is None:
+        if overrides:
+            raise SettingsImpositionError(
+                f"config knob(s) {sorted(overrides)!r} declared on a "
+                "TORCHLESS worker: every canonical knob is a torch flag, so "
+                "there is nothing to impose them on (pgw#788)")
+        return torch_readback()
+    torch.set_float32_matmul_precision(table["float32_matmul_precision"])
+    torch.backends.cuda.matmul.allow_tf32 = (
+        table["cuda_matmul_allow_tf32"] == "True")
+    torch.backends.cudnn.allow_tf32 = (table["cudnn_allow_tf32"] == "True")
+    torch.backends.cudnn.benchmark = (table["cudnn_benchmark"] == "True")
+    effective = torch_readback()
+    diffs = [
+        f"{name}: imposed {want!r} != effective {effective.get(name)!r}"
+        for name, want in table.items()
+        if effective.get(name) != want
+    ]
+    if diffs:
+        raise SettingsImpositionError(
+            "torch settings freeze failed: " + "; ".join(diffs))
+    return effective
+
+
+# ---------------------------------------------------------------------------
+# Imposition — ConfigModule-backed settings (dynamo/inductor/functorch)
+# ---------------------------------------------------------------------------
+
+
+def impose_config_default(
+    config_module: object, key: str, value: object,
+) -> None:
+    """Write the PROCESS-WIDE fallback for a torch ConfigModule key.
+
+    A plain ``module.key = x`` assignment sets a ``user_override``, and torch
+    documents that layer as thread-local (a ``ContextVar``) — only the
+    assigning thread ever reads it back. Every OTHER thread falls through the
+    precedence chain to ``default``, which is the layer this writes. Nothing
+    else in the chain is settable at runtime: ``alias`` and the two
+    ``env_value_*`` layers are resolved once at config install."""
+    entry = getattr(config_module, "_config", {}).get(key)
+    if entry is None:
+        raise SettingsImpositionError(
+            f"declared setting cannot reach a process-wide target: torch's "
+            f"config has no {key!r} entry to set a default on. torch's "
+            f"config internals changed; re-seat the authority before any "
+            f"compile can be trusted.")
+    entry.default = value
+
+
+def read_in_fresh_thread(fn: Callable[[], Any]) -> Any:
+    """Run ``fn`` on a brand-new thread and return its value. A fresh thread
+    starts with an empty ``ContextVar`` context, so this reads exactly what a
+    background compile thread would read."""
+    box: Dict[str, Any] = {}
+
+    def _run() -> None:
+        box["v"] = fn()
+
+    t = threading.Thread(target=_run, name="settings-readback", daemon=True)
+    t.start()
+    t.join()
+    return box.get("v")
+
+
+def dynamo_readback() -> Dict[str, str]:
+    """Live values of the declared dynamo facts, read on THIS thread — the
+    mint/serve thread is exactly where a stray thread-local override would
+    sit, and a fresh thread would read the (imposed) default anyway."""
+    if not torch_capability.present():
+        return {"torch": torch_capability.ABSENT}
+    import torch._dynamo
+
+    return {
+        name: str(getattr(torch._dynamo.config, name))
+        for name in DECLARED_DYNAMO
+    }
+
+
+def impose_dynamo() -> Dict[str, str]:
+    """Impose the declared dynamo shape posture process-wide (default layer +
+    this thread's own override), verify on a FOREIGN thread — the same
+    mechanism and reasoning as ``host_isa.impose``. No-op on torchless."""
+    if not torch_capability.present():
+        return {}
+    import torch._dynamo
+
+    want = {name: value == "True" for name, value in DECLARED_DYNAMO.items()}
+    for name, value in want.items():
+        impose_config_default(torch._dynamo.config, name, value)
+        setattr(torch._dynamo.config, name, value)
+    foreign = read_in_fresh_thread(
+        lambda: {n: bool(getattr(torch._dynamo.config, n)) for n in want})
+    if foreign != want:
+        raise SettingsImpositionError(
+            f"dynamo shape posture is thread-local only: imposed {want!r}, "
+            f"a fresh thread reads {foreign!r}")
+    return dict(DECLARED_DYNAMO)
+
+
+# ---------------------------------------------------------------------------
+# Routed writes — settings mutations other modules NEED, performed here so
+# the fence stays airtight. Each names its caller and its invariant.
+# ---------------------------------------------------------------------------
+
+
+def disable_autograd_cache() -> None:
+    """gw#608: the AOTAutogradCache key hashes ``fx_kwargs[get_decomp_fn]``
+    via the function's REPR — a process memory address (ASLR), so AOT keys
+    can NEVER match across processes/pods. Cell portability requires the
+    (portable) FxGraphCache to be the lookup surface: disable the AOT layer
+    symmetrically for producer capture and consumer seeding.
+
+    Process-global disable needs BOTH halves: the pre-torch-import env
+    (:data:`DECLARED_ENV`, fresh processes incl. compile-worker subprocesses)
+    and, torch already imported, the installed config entry's
+    ``env_value_force`` — user overrides are thread-local ContextVars in
+    torch>=2.13, and the entry-level env force is consulted by every thread
+    with top precedence (the 0.40.5 live disproof: the assignment ran on the
+    arming thread while the warmup compile ran on another)."""
+    os.environ["TORCHINDUCTOR_AUTOGRAD_CACHE"] = (
+        DECLARED_ENV["TORCHINDUCTOR_AUTOGRAD_CACHE"])
+    if "torch" not in sys.modules:
+        return
+    try:
+        import torch._functorch.config as fconf
+
+        fconf.enable_autograd_cache = False  # this thread (public API)
+        fconf._config["enable_autograd_cache"].env_value_force = False  # type: ignore[attr-defined]
+    except Exception:
+        logger.debug("settings authority: AOT autograd cache disable "
+                     "unavailable", exc_info=True)
+
+
+def set_compiler_cache_tag(tag: str) -> None:
+    """Install ``compile_cache``'s semantic tag for an arm's compiles.
+    Process-global (torch.compiler.config), retagged at every arm; a
+    mid-serve heal recompile under a newer tag can only MISS, never
+    cross-consume. Inner-cache identity, not process behavior — deliberately
+    NOT in the declaration or the seal."""
+    try:
+        import torch.compiler.config as compiler_config
+
+        compiler_config.cache_key_tag = tag
+    except Exception:
+        logger.debug("settings authority: semantic cache tag unavailable",
+                     exc_info=True)
+
+
+def raise_dynamo_cache_limits(want: int) -> None:
+    """Size dynamo's per-code-object recompile ceiling to the declared shape
+    set (``compile_cache.apply``: LTX declares 12 video graphs against a
+    default of 8, ie#381) — never lower an operator-raised value. Cache
+    ADMISSION, not codegen: changes whether dynamo keeps compiling, never
+    what it emits, so it is not a seal fact."""
+    if not torch_capability.present():
+        return
+    try:
+        import torch._dynamo
+
+        torch._dynamo.config.cache_size_limit = max(
+            int(torch._dynamo.config.cache_size_limit), want)
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                int(torch._dynamo.config.recompile_limit), want)
+    except Exception:
+        logger.debug("settings authority: could not raise recompile limit",
+                     exc_info=True)
+
+
+__all__ = [
+    "AUTHORITY_MODULES",
+    "DECLARED_DYNAMO",
+    "DECLARED_ENV",
+    "DECLARED_TORCH",
+    "SettingsImpositionError",
+    "declaration",
+    "disable_autograd_cache",
+    "dynamo_readback",
+    "ensure_interpreter_env",
+    "impose_config_default",
+    "impose_dynamo",
+    "impose_process_env",
+    "impose_torch",
+    "raise_dynamo_cache_limits",
+    "read_in_fresh_thread",
+    "set_compiler_cache_tag",
+    "torch_readback",
+    "validated_table",
+    "verify_interpreter_env",
+]

--- a/src/gen_worker/torch_capability.py
+++ b/src/gen_worker/torch_capability.py
@@ -5,7 +5,7 @@ A worker with no torch is a first-class shape, not a degenerate GPU worker
 bare-imported torch with no guard —
 
     entrypoint.py -> env_seal.establish()
-                  -> establish_config()            (env_seal)
+                  -> settings_authority.impose_torch()
                   -> host_isa.impose()
                   -> guard_closure.establish_posture()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,28 @@ if str(Path(__file__).parent) not in sys.path:
 
 import gen_worker  # noqa: E402
 
+# pgw#1049: the suite runs under the DECLARED interpreter env — the exact
+# imposition the entrypoint performs at boot (PYTHONHASHSEED=0; env_seal.
+# establish refuses without it). CPython read the seed at interpreter start,
+# so a pytest launched without it gets ONE re-exec, in pytest_configure
+# below — import time is too late to own the terminal: global fd capture is
+# already live, and an exec under it inherits the capture tmpfiles as
+# stdout/stderr, so the whole re-exec'd run reports silently (observed:
+# green run, zero bytes of output). Capture is stopped first, then exec.
+from gen_worker.settings_authority import (  # noqa: E402
+    _interpreter_env_diffs, ensure_interpreter_env, impose_process_env)
+
+impose_process_env()  # children spawned by tests inherit the declared env
+
+
+def pytest_configure(config):
+    if not _interpreter_env_diffs():
+        return
+    capman = config.pluginmanager.getplugin("capturemanager")
+    if capman is not None:
+        capman.stop_global_capturing()
+    ensure_interpreter_env()  # execs; never returns (or raises for -E)
+
 # Deterministic CPU encode wherever the suite runs (gw#476): never probe or
 # engage NVENC from tests — CI has no GPU, and dev boxes that have one must
 # not do GPU work from the unit suite. Selection tests override + refresh
@@ -186,9 +208,9 @@ def _fresh_boot_seal():
     against a boot seal adopted under another test's transient flags."""
     from gen_worker import env_seal as _es
 
-    _es._BOOT_SEAL = None
+    _es._BOOT_READBACK = None
     yield
-    _es._BOOT_SEAL = None
+    _es._BOOT_READBACK = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_adoption_key_pgw686.py
+++ b/tests/test_adoption_key_pgw686.py
@@ -124,7 +124,6 @@ def _requested(weight_lane: str) -> str:
     return ck.compute(
         "sdxl", weight_lane, 64,
         contract=ck.contract_digest(_SHAPE_CONTRACT),
-        regional=False,
     ).digest
 
 

--- a/tests/test_ambient_census_pgw1049.py
+++ b/tests/test_ambient_census_pgw1049.py
@@ -1,0 +1,94 @@
+"""pgw#1049: the ambient-input census, enforced against the INSTALLED torch.
+
+The th#1678 wirecontract shape, python-side: the census file classifies
+every env input torch/triton consult; this test scans the installed tree and
+goes RED on any input the census does not classify — including the inputs a
+future torch upgrade introduces. That red is the feature.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load_lint() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "lint_ambient_census", REPO / "scripts" / "lint_ambient_census.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_every_installed_torch_input_is_classified() -> None:
+    lint = _load_lint()
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("no torch installed to census")
+    rows, errors = lint.load_census()
+    assert errors == [], errors
+    found = lint.scan_installed_tree()
+    assert found, "scan found nothing — the scanner itself is broken"
+    unclassified = sorted(
+        f"{name}  (read at {where})" for name, where in found.items()
+        if lint.classify(name, rows) is None)
+    assert unclassified == [], (
+        "torch consults ambient inputs the census does not classify — add "
+        "rows to scripts/ambient_inputs_census.txt:\n"
+        + "\n".join(unclassified))
+
+
+def test_neutralized_claims_are_scrub_facts() -> None:
+    """Every input classified NEUTRALIZED must actually be erased by
+    scrub_env — checked against the live SCRUB_PREFIXES, not the census's
+    own claim about them."""
+    lint = _load_lint()
+    from gen_worker import env_seal
+
+    rows, _ = lint.load_census()
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("no torch installed to census")
+    for name in lint.scan_installed_tree():
+        if lint.classify(name, rows) == "NEUTRALIZED":
+            assert name.startswith(env_seal.SCRUB_PREFIXES), (
+                f"{name} is classified NEUTRALIZED but scrub_env would not "
+                "erase it")
+
+
+def test_unclassified_input_is_red() -> None:
+    """RED-proof: a name outside every row classifies to None — the exact
+    condition the completeness test fails on."""
+    lint = _load_lint()
+    rows, _ = lint.load_census()
+    assert lint.classify("CUDA_BRAND_NEW_BEHAVIOR_KNOB", rows) is None
+    assert lint.classify("TORCHINDUCTOR_MAX_AUTOTUNE", rows) == "NEUTRALIZED"
+    assert lint.classify("PYTHONHASHSEED", rows) == "IMPOSED"
+    assert lint.classify("CUDA_VISIBLE_DEVICES", rows) == "PLUMBING"
+
+
+def test_structural_lies_are_red(tmp_path: Path) -> None:
+    """A census that CLAIMS an imposition or a scrub that does not exist is
+    itself red — the manifest may never outrun the tree."""
+    lint = _load_lint()
+    lying = tmp_path / "census.txt"
+    lying.write_text(
+        "TOTALLY_FAKE_VAR  IMPOSED  claims an imposition that does not exist\n"
+        "SOMETHING_ELSE_*  NEUTRALIZED  claims a scrub that does not exist\n")
+    problems = lint.check(census_path=lying)
+    assert any("claims IMPOSED" in p for p in problems), problems
+    assert any("claims NEUTRALIZED" in p for p in problems), problems
+    # And an incomplete census (missing IMPOSED rows for DECLARED_ENV) is
+    # itself named:
+    assert any("has no IMPOSED census row" in p for p in problems), problems
+
+
+def test_shipped_census_is_green() -> None:
+    lint = _load_lint()
+    assert lint.check() == []

--- a/tests/test_candidate_publish_parity_pgw749.py
+++ b/tests/test_candidate_publish_parity_pgw749.py
@@ -65,7 +65,7 @@ def _pinned_runtime(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         cc, "static_code_closure",
         lambda roots=(): (("gen_worker/compile_cache.py", "3" * 16),))
     monkeypatch.setattr(cc, "content_keys", lambda: ())
-    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
     monkeypatch.setattr(env_seal, "_LIB_SNAPSHOT", None)
     yield
 

--- a/tests/test_candidate_publish_parity_pgw749.py
+++ b/tests/test_candidate_publish_parity_pgw749.py
@@ -122,8 +122,7 @@ def test_cold_candidate_key_equals_warm_published_key(
     # `cell_lookups()` advertisement of the same digest, not the digest).
     _phase(monkeypatch, tmp_path, "cold", _COLD_LIBS)
     candidate = ck.compute(
-        "sdxl", "w8a8", 64,
-        contract=cfg.contract_digest(), regional=False,
+        "sdxl", "w8a8", 64, contract=cfg.contract_digest(),
     ).digest
 
     # Warm phase, fresh snapshot — the mint stamping its artifact.

--- a/tests/test_cell_key.py
+++ b/tests/test_cell_key.py
@@ -72,8 +72,8 @@ def test_key_deterministic_and_axis_sensitive():
 
 
 def test_empty_optional_axis_equals_absent():
-    absent = {k: v for k, v in _AXES.items() if k not in ("lane", "mode")}
-    empty = dict(absent, lane="", mode="")
+    absent = {k: v for k, v in _AXES.items() if k != "lane"}
+    empty = dict(absent, lane="")
     assert ck.from_axes(absent).digest == ck.from_axes(empty).digest
 
 
@@ -163,19 +163,28 @@ def test_execution_lane_canonicalization(fixed_runtime):
             != ck.compute("f", "", contract=_CONTRACT).digest)
 
 
-def test_regional_mode_is_identity(fixed_runtime):
-    """Regional per-block cells are different artifacts (ie#381)."""
-    assert (ck.compute("f", regional=True, contract=_CONTRACT).digest
-            != ck.compute("f", contract=_CONTRACT).digest)
-    assert (ck.from_axes(dict(_AXES, mode="regional")).digest
-            != ck.from_axes(_AXES).digest)
+def test_mode_axis_is_deleted_and_regional_rides_the_contract(fixed_runtime):
+    """`mode` deleted per Paul 2026-08-09 (pgw#1049): pinned "" since
+    regional died, and empty optionals never entered the canonical form, so
+    the deletion moves ZERO digests. Regional discrimination was never lost
+    — `regional` is a declared-contract fact, so it rides the `contract`
+    axis. A stale caller shipping `mode` gets a TYPED refusal, never a
+    silent drop."""
+    with pytest.raises(ck.CellKeyError, match="unknown cell-key axis 'mode'"):
+        ck.from_axes(dict(_AXES, mode="regional"))
+    with pytest.raises(ck.CellKeyError, match="unknown cell-key axis 'mode'"):
+        ck.from_axes(dict(_AXES, mode=""))
+    plain = cc.declared_contract_facts(_ContractCfg(regional=False))
+    regional = cc.declared_contract_facts(_ContractCfg(regional=True))
+    assert (ck.compute("f", contract=ck.contract_digest(regional)).digest
+            != ck.compute("f", contract=ck.contract_digest(plain)).digest)
     facts = cc.declared_contract_facts(_ContractCfg(regional=True))
     meta = cc.artifact_metadata(
         family="f", shapes=((768, 768),), targets=("transformer",),
         compile_mode="regional", shape_contract=facts,
     )
     assert meta["cell_key"] == ck.compute(
-        "f", regional=True, contract=ck.contract_digest(facts)).digest
+        "f", contract=ck.contract_digest(facts)).digest
 
 
 def test_contract_axis_fences_newer_contract(fixed_runtime):

--- a/tests/test_computed_key_demand_retired_pgw1032.py
+++ b/tests/test_computed_key_demand_retired_pgw1032.py
@@ -41,7 +41,6 @@ _SHARED_AXES: Dict[str, str] = {
     "format": "2",
     "family": FAMILY,
     "lane": "w8a8",
-    "mode": "",
     "sm": "89",
     "contract": "0123456789abcdef",
     "env_seal": "fedcba9876543210",

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -219,17 +219,23 @@ def test_establish_config_imposes_the_serving_posture() -> None:
         sa.impose_torch()
 
 
-def test_seal_digest_tracks_config_flags() -> None:
-    """Flipping one sealed flag changes the seal digest — and therefore the
-    key (red pre-fix: no env_seal axis, keys blind to config)."""
+def test_seal_digest_tracks_the_declaration_not_live_flags() -> None:
+    """pgw#1049 REVERSES this test's original claim: the seal digests the
+    DECLARATION, so a behind-our-back flag flip can no longer move it — it
+    trips the pgw#719 wire instead. A DECLARED change (a knob) still moves
+    the digest, which is what keeps config in the key."""
+    from gen_worker import settings_authority as sa
+
     baseline = _env_seal().seal_digest(_env_seal().effective_seal())
     before = torch.backends.cudnn.benchmark
     try:
         torch.backends.cudnn.benchmark = not before
-        assert _env_seal().seal_digest(_env_seal().effective_seal()) != baseline
+        assert _env_seal().seal_digest(_env_seal().effective_seal()) == baseline
     finally:
         torch.backends.cudnn.benchmark = before
-    assert _env_seal().seal_digest(_env_seal().effective_seal()) == baseline
+    knobbed = dict(_env_seal().effective_seal())
+    knobbed["config"] = sa.validated_table({"cudnn_benchmark": "True"})
+    assert _env_seal().seal_digest(knobbed) != baseline
 
 
 def test_ck1_requires_and_recomputes_the_env_seal(monkeypatch: Any) -> None:

--- a/tests/test_determinism_pgw694.py
+++ b/tests/test_determinism_pgw694.py
@@ -204,17 +204,19 @@ def test_establish_config_imposes_the_serving_posture() -> None:
     """The canonical table IS the pgw#654 serving posture (TF32 on):
     establish must impose it from ANY prior state and verify the read-back
     — code decides the flags, never a library default or an env var."""
+    from gen_worker import settings_authority as sa
+
     before = torch.backends.cudnn.allow_tf32
     try:
         torch.backends.cudnn.allow_tf32 = False  # non-canonical prior state
-        effective = _env_seal().establish_config()
+        effective = sa.impose_torch()
         assert effective["cudnn_allow_tf32"] == "True"
         assert torch.backends.cudnn.allow_tf32 is True
         assert effective["float32_matmul_precision"] == "high"
-        assert _env_seal().effective_config() == effective
+        assert sa.torch_readback() == effective
     finally:
         torch.backends.cudnn.allow_tf32 = before
-        _env_seal().establish_config()
+        sa.impose_torch()
 
 
 def test_seal_digest_tracks_config_flags() -> None:

--- a/tests/test_driver_cohort_seal_pgw745.py
+++ b/tests/test_driver_cohort_seal_pgw745.py
@@ -26,7 +26,7 @@ from gen_worker import env_seal
 @pytest.fixture(autouse=True)
 def _fresh_snapshot(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setattr(env_seal, "_LIB_SNAPSHOT", None)
-    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
     yield
 
 

--- a/tests/test_env_contract_pgw718.py
+++ b/tests/test_env_contract_pgw718.py
@@ -21,9 +21,9 @@ from gen_worker.registry import CompileCell
 
 @pytest.fixture(autouse=True)
 def _reset_boot_seal(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
     yield
-    env_seal._BOOT_SEAL = None
+    env_seal._BOOT_READBACK = None
 
 
 @pytest.fixture(autouse=True)
@@ -90,26 +90,32 @@ def test_establish_scrubs_then_imposes_and_is_pure(
     assert "CUBLAS_WORKSPACE_CONFIG" not in os.environ
     # No env-derived facts survive in the config block.
     assert "CUBLAS_WORKSPACE_CONFIG" not in seal_a["config"]
-    env_seal._BOOT_SEAL = None
+    env_seal._BOOT_READBACK = None
     seal_b = env_seal.establish()
     assert env_seal.seal_digest(seal_a) == env_seal.seal_digest(seal_b)
 
 
 def test_typed_knob_is_sealed_and_unknown_knob_refuses() -> None:
+    from gen_worker import settings_authority as sa
+
     try:
-        default = env_seal.establish_config()
+        default = sa.impose_torch()
         assert default["cudnn_benchmark"] == "False"
-        base_digest = env_seal.seal_digest(env_seal.effective_seal())
-        knobbed = env_seal.establish_config(
+        base_digest = env_seal.seal_digest(env_seal.establish())
+        env_seal._BOOT_READBACK = None
+        knobbed_seal = env_seal.establish(
             overrides={"cudnn_benchmark": "True"})
-        assert knobbed["cudnn_benchmark"] == "True"
+        assert knobbed_seal["config"]["cudnn_benchmark"] == "True"
         assert torch.backends.cudnn.benchmark is True
-        # The knob is SEALED — a knobbed process has a different identity.
-        assert env_seal.seal_digest(env_seal.effective_seal()) != base_digest
-        with pytest.raises(env_seal.EnvSealError, match="not_a_real_knob"):
-            env_seal.establish_config(overrides={"not_a_real_knob": "1"})
+        # The knob is SEALED — a knobbed process has a different identity
+        # (pgw#1049: because it is part of the DECLARATION, not because a
+        # read-back happened to see it).
+        assert env_seal.seal_digest(knobbed_seal) != base_digest
+        with pytest.raises(sa.SettingsImpositionError, match="not_a_real_knob"):
+            sa.impose_torch(overrides={"not_a_real_knob": "1"})
     finally:
-        env_seal.establish_config()  # restore canonical
+        env_seal._BOOT_READBACK = None
+        env_seal.establish()  # restore canonical
 
 
 def test_hash_seed_facts_ride_the_seal() -> None:

--- a/tests/test_env_seal_boot_pgw694.py
+++ b/tests/test_env_seal_boot_pgw694.py
@@ -47,9 +47,11 @@ def test_entrypoint_establishes_effective_seal() -> None:
     assert torch.backends.cudnn.allow_tf32 is True
     assert torch.backends.cuda.matmul.allow_tf32 is True
     assert torch.get_float32_matmul_precision() == "high"
-    # Every canonical entry is effective in the seal (the seal also records
-    # interpreter facts like the hash-seed pair, pgw#719).
-    assert env_seal.CANONICAL_CONFIG.items() <= seal["config"].items()
+    # Every canonical entry is stated by the seal — pgw#1049: as the
+    # DECLARATION (boot verified the read-back against it).
+    from gen_worker import settings_authority as sa
+
+    assert sa.DECLARED_TORCH.items() <= seal["config"].items()
     # The digest is the env_seal key axis and is deterministic.
     assert env_seal.seal_digest(seal) == env_seal.seal_digest(
         entrypoint._establish_env_seal())

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -1325,13 +1325,13 @@ def test_second_checkpoint_served_from_dynamo_inmemory_cache_proves(
     import torch
     from torch._dynamo import eval_frame
 
-    from gen_worker import env_seal
+    from gen_worker import settings_authority
 
     # Production boot order (pgw#719): the canonical config is imposed
     # BEFORE any mint/artifact exists, so the cell's recorded seal and the
     # post-bootstrap arm state agree (the executor's pgw#654 TF32 bootstrap
     # is a no-op re-assertion of the same canonical values).
-    env_seal.establish_config()
+    settings_authority.impose_torch()
     artifact = _artifact(tmp_path)
     model_dir = tmp_path / "family-checkpoints"
     model_dir.mkdir()

--- a/tests/test_host_isa_pgw754.py
+++ b/tests/test_host_isa_pgw754.py
@@ -87,7 +87,8 @@ def test_establish_wires_the_clamp(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(inductor_config.cpp, "simdlen", None)
     monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
     seal = env_seal.establish()
-    assert seal["config"]["cpp_march"] == host_isa.mint_march()
+    # pgw#1049: the clamp is a DECLARED inductor fact in the seal.
+    assert seal["inductor"]["cpp.march"] == host_isa.mint_march()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_host_isa_pgw754.py
+++ b/tests/test_host_isa_pgw754.py
@@ -85,7 +85,7 @@ def test_establish_wires_the_clamp(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(inductor_config.cpp, "march", None)
     monkeypatch.setattr(inductor_config.cpp, "simdlen", None)
-    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
     seal = env_seal.establish()
     assert seal["config"]["cpp_march"] == host_isa.mint_march()
 

--- a/tests/test_settings_authority_pgw1049.py
+++ b/tests/test_settings_authority_pgw1049.py
@@ -1,0 +1,254 @@
+"""pgw#1049: the single settings authority — seal from DECLARATION.
+
+The headline RED-proof: replay the pgw#1042 mutation class (torch's own
+``aot_compile`` mutating global inductor config mid-process) on the real
+seal/mint seams and show the seal digest CANNOT move where seal-v3's
+read-back would have — ambient mutation now trips the pgw#719 tripwire (a
+named refusal) instead of moving identity.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import env_seal
+from gen_worker import settings_authority as sa
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_boot(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None)
+    monkeypatch.setattr(env_seal, "_ESTABLISHED_OVERRIDES", None)
+    yield
+    env_seal._BOOT_READBACK = None
+    env_seal._ESTABLISHED_OVERRIDES = None
+
+
+@pytest.fixture()
+def _restore_inductor() -> Iterator[None]:
+    import torch._inductor.config as ic
+
+    max_autotune = ic.max_autotune
+    metadata = dict(ic.aot_inductor.metadata)
+    yield
+    ic.max_autotune = max_autotune
+    ic.aot_inductor.metadata = metadata
+
+
+# ---------------------------------------------------------------------------
+# The headline: ambient mutation cannot move the seal; the tripwire trips
+# ---------------------------------------------------------------------------
+
+
+def test_pgw1042_mutation_cannot_move_the_seal(_restore_inductor: None) -> None:
+    """The pgw#1042 replay, against v4: mutate global inductor config the way
+    a mid-mint library side effect does. Under seal v3 the READ-BACK digest
+    moved (that is how the child sealed a different identity than its own
+    boot); under v4 the seal digest is declaration-derived and CANNOT move —
+    the mutation surfaces as the pgw#719 tripwire's named refusal on the
+    mint seams instead."""
+    import torch._inductor.config as ic
+
+    env_seal.establish()
+    sealed = env_seal.seal_digest(env_seal.effective_seal())
+    readback_before = env_seal.inductor_config_digest()
+
+    # The mutation class: a global entry OUTSIDE _PORTABLE_VOLATILE (the
+    # pgw#1042 fix excluded exactly one entry; the DISEASE was never that
+    # one entry — this is the cure for the class).
+    ic.max_autotune = True
+
+    # v3's seal would have moved: the read-back digest demonstrably does.
+    assert env_seal.inductor_config_digest() != readback_before
+    # v4's seal did not: identity derives from the declaration.
+    assert env_seal.seal_digest(env_seal.effective_seal()) == sealed
+    # And the mint seams refuse by name — the JIT mint's pre-trace assert
+    # and aot_mint's (both call assert_seal_unchanged).
+    with pytest.raises(env_seal.EnvSealError, match="inductor"):
+        env_seal.assert_seal_unchanged("mint")
+
+
+def test_torch_owned_compile_output_is_not_drift(_restore_inductor: None) -> None:
+    """The OTHER half of pgw#1042: ``aot_compile`` legitimately writes
+    machine facts into ``aot_inductor.metadata``. That torch-owned output
+    must neither move the seal NOR trip the wire — a mint that has compiled
+    once must still be able to trace its next entry."""
+    import torch._inductor.config as ic
+
+    env_seal.establish()
+    sealed = env_seal.seal_digest(env_seal.effective_seal())
+    ic.aot_inductor.metadata["AOTI_CPU_ISA"] = "AVX2"  # what aot_compile does
+    assert env_seal.seal_digest(env_seal.effective_seal()) == sealed
+    env_seal.assert_seal_unchanged("post-compile")  # no refusal
+
+
+def test_backend_flag_mutation_trips_but_cannot_rekey() -> None:
+    env_seal.establish()
+    sealed = env_seal.seal_digest(env_seal.effective_seal())
+    before = torch.backends.cudnn.benchmark
+    try:
+        torch.backends.cudnn.benchmark = True
+        assert env_seal.seal_digest(env_seal.effective_seal()) == sealed
+        with pytest.raises(env_seal.EnvSealError, match="cudnn_benchmark"):
+            env_seal.assert_seal_unchanged("mint")
+    finally:
+        torch.backends.cudnn.benchmark = before
+
+
+# ---------------------------------------------------------------------------
+# The declaration IS the seal
+# ---------------------------------------------------------------------------
+
+
+def test_seal_v4_states_the_declaration() -> None:
+    seal = env_seal.establish()
+    assert seal["seal_v"] == env_seal.SEAL_VERSION == 4
+    decl = sa.declaration()
+    for fact in ("env", "config", "dynamo", "inductor", "posture"):
+        assert seal[fact] == decl[fact], fact
+    assert seal["env"]["PYTHONHASHSEED"] == "0"
+    assert len(seal["loaded_libs"]) == 16  # the one measured (content) fact
+
+
+def test_declared_knob_moves_identity_by_declaration() -> None:
+    base = env_seal.seal_digest(env_seal.establish())
+    env_seal._BOOT_READBACK = None
+    try:
+        knobbed = env_seal.establish(overrides={"cudnn_benchmark": "True"})
+        assert knobbed["config"]["cudnn_benchmark"] == "True"
+        assert env_seal.seal_digest(knobbed) != base
+    finally:
+        env_seal._BOOT_READBACK = None
+        env_seal.establish()
+
+
+def test_dynamo_shape_posture_is_process_wide() -> None:
+    """The v2 dynamo posture moved into the authority (it was a second
+    writer in compile_cache): imposed at the default layer, so a FRESH
+    thread — where warm compiles actually run — reads the declared values."""
+    import torch._dynamo
+
+    sa.impose_dynamo()
+    got = sa.read_in_fresh_thread(
+        lambda: (bool(torch._dynamo.config.automatic_dynamic_shapes),
+                 bool(torch._dynamo.config.assume_static_by_default)))
+    assert got == (False, True)
+    assert sa.dynamo_readback() == sa.DECLARED_DYNAMO
+
+
+# ---------------------------------------------------------------------------
+# PYTHONHASHSEED: imposed, verified fail-closed (HUMAN_MUST_DO executed)
+# ---------------------------------------------------------------------------
+
+
+def _run(code: str, *, seed_env: dict) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONHASHSEED"}
+    env.update(seed_env)
+    env["PYTHONPATH"] = str(REPO / "src")
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        env=env, capture_output=True, text=True, timeout=120)
+
+
+def test_establish_refuses_undeclared_hash_seed() -> None:
+    """Fail-closed: a process whose interpreter booted outside the declared
+    env cannot seal an identity that claims it."""
+    code = """
+    from gen_worker import env_seal
+    try:
+        env_seal.establish()
+    except Exception as exc:
+        print(f"REFUSED: {type(exc).__name__}: {exc}")
+    else:
+        print("ESTABLISHED")
+    """
+    out = _run(code, seed_env={})
+    assert "REFUSED: SettingsImpositionError" in out.stdout, out.stdout + out.stderr
+    assert "PYTHONHASHSEED" in out.stdout
+    ok = _run(code, seed_env={"PYTHONHASHSEED": "0"})
+    assert "ESTABLISHED" in ok.stdout, ok.stdout + ok.stderr
+
+
+def test_ensure_interpreter_env_reexecs_once() -> None:
+    """The sanctioned imposition: a process launched without the declared
+    seed re-execs itself (sys.orig_argv) and comes back with hash
+    randomization OFF — the entrypoint/conftest path."""
+    code = """
+    import sys
+    from gen_worker.settings_authority import ensure_interpreter_env
+    ensure_interpreter_env()
+    print(f"flag={sys.flags.hash_randomization} "
+          f"seed={__import__('os').environ.get('PYTHONHASHSEED')}")
+    """
+    out = _run(code, seed_env={})
+    assert "flag=0 seed=0" in out.stdout, out.stdout + out.stderr
+
+
+def test_children_inherit_the_declared_seed() -> None:
+    """impose_process_env is what every spawned child inherits — the mint
+    child and AOT entry children boot with the seed already at interpreter
+    start, so their establish() verifies instead of re-exec'ing."""
+    sa.impose_process_env()
+    assert os.environ["PYTHONHASHSEED"] == "0"
+    child = subprocess.run(
+        [sys.executable, "-c",
+         "import sys; print(sys.flags.hash_randomization)"],
+        capture_output=True, text=True, timeout=60)
+    assert child.stdout.strip() == "0"
+
+
+def test_revert_is_one_declaration_entry() -> None:
+    """The HUMAN_MUST_DO record promises the imposition is trivially
+    revertible: with the entry removed, ensure/verify have nothing to check
+    and impose nothing — no second site knows about the seed."""
+    saved = dict(sa.DECLARED_ENV)
+    try:
+        del sa.DECLARED_ENV["PYTHONHASHSEED"]
+        assert sa._interpreter_env_diffs() == []
+        sa.verify_interpreter_env()  # no refusal without the entry
+    finally:
+        sa.DECLARED_ENV.clear()
+        sa.DECLARED_ENV.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Scrub extensions (census-driven)
+# ---------------------------------------------------------------------------
+
+
+def test_census_namespaces_are_actually_scrubbed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in ("NCCL_SOMETHING", "ATEN_CPU_CAPABILITY",
+                 "INDUCTOR_PROVENANCE", "AOT_INDUCTOR_ENABLE_LTO",
+                 "CUDA_LAUNCH_BLOCKING", "CUTLASS_EPILOGUE_FUSION",
+                 "TENSORIFY_PYTHON_SCALARS"):
+        monkeypatch.setenv(name, "1")
+    erased = env_seal.scrub_env()
+    for name in ("NCCL_SOMETHING", "ATEN_CPU_CAPABILITY",
+                 "INDUCTOR_PROVENANCE", "AOT_INDUCTOR_ENABLE_LTO",
+                 "CUDA_LAUNCH_BLOCKING", "CUTLASS_EPILOGUE_FUSION",
+                 "TENSORIFY_PYTHON_SCALARS"):
+        assert name in erased and name not in os.environ, name
+
+
+def test_scrub_then_impose_keeps_declared_env() -> None:
+    """The order establish() runs: scrub erases the whole namespace
+    (including our own entries), impose puts the DECLARED values back — so
+    the allocator conf is REAL (the old entrypoint setdefault died at the
+    scrub and expandable_segments was silently off, found by pgw#1049)."""
+    seal = env_seal.establish()
+    for key, value in sa.DECLARED_ENV.items():
+        assert os.environ.get(key) == value, key
+    assert seal["env"] == dict(sa.DECLARED_ENV)

--- a/tests/test_settings_fence_pgw1049.py
+++ b/tests/test_settings_fence_pgw1049.py
@@ -1,0 +1,110 @@
+"""pgw#1049: the second-writer fence, RED-proven.
+
+`scripts/lint_settings_writers.py` is the CI gate; these tests prove it can
+actually go red (a green gate that could never fail proves nothing) and that
+its authority set cannot drift from the authority module's own declaration.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load_lint() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "lint_settings_writers", REPO / "scripts" / "lint_settings_writers.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _scan_tree(tmp_path: Path, source: str) -> dict:
+    lint = _load_lint()
+    (tmp_path / "offender.py").write_text(textwrap.dedent(source))
+    return lint.scan(root=tmp_path)
+
+
+def test_direct_backend_write_is_red(tmp_path: Path) -> None:
+    sites = _scan_tree(tmp_path, """
+        import torch
+        torch.backends.cuda.matmul.allow_tf32 = True
+    """)
+    assert any("torch.backends.cuda.matmul.allow_tf32" in site
+               for _, site in sites), sites
+
+
+def test_aliased_config_write_is_red(tmp_path: Path) -> None:
+    sites = _scan_tree(tmp_path, """
+        import torch._inductor.config as inductor_config
+        inductor_config.cpp.march = "native"
+    """)
+    assert any("torch._inductor.config.cpp.march" in site
+               for _, site in sites), sites
+
+
+def test_dynamo_config_write_and_setter_are_red(tmp_path: Path) -> None:
+    sites = _scan_tree(tmp_path, """
+        import torch
+        import torch._dynamo
+        torch._dynamo.config.automatic_dynamic_shapes = True
+        torch.set_float32_matmul_precision("highest")
+    """)
+    joined = {site for _, site in sites}
+    assert "torch._dynamo.config.automatic_dynamic_shapes" in joined
+    assert "torch.set_float32_matmul_precision" in joined
+
+
+def test_watched_env_write_is_red_including_constants(tmp_path: Path) -> None:
+    sites = _scan_tree(tmp_path, """
+        import os
+        _KNOB = "TORCHINDUCTOR_MAX_AUTOTUNE"
+        os.environ["TRITON_PTXAS_PATH"] = "/tmp/ptxas"
+        os.environ[_KNOB] = "1"
+        os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "native")
+    """)
+    joined = {site for _, site in sites}
+    assert "os.environ[TRITON_PTXAS_PATH]" in joined
+    assert "os.environ[TORCHINDUCTOR_MAX_AUTOTUNE]" in joined
+    assert "os.environ.setdefault(PYTORCH_CUDA_ALLOC_CONF)" in joined
+
+
+def test_unclassified_site_reports_and_classified_passes(tmp_path: Path) -> None:
+    lint = _load_lint()
+    sites = _scan_tree(tmp_path, """
+        import torch
+        torch.backends.cudnn.benchmark = True
+    """)
+    problems = lint.check(sites, {})
+    assert problems and "UNCLASSIFIED" in problems[0]
+    key = next(iter(sites))
+    assert lint.check(sites, {key: "SCOPED"}) == []
+
+
+def test_stale_allowlist_row_is_red() -> None:
+    lint = _load_lint()
+    problems = lint.check({}, {("src/gen_worker/gone.py", "torch.backends.x"): "SCOPED"})
+    assert problems and "stale allowlist row" in problems[0]
+
+
+def test_real_tree_is_green() -> None:
+    """The shipped tree + shipped allowlist: zero problems — and this stays
+    meaningful because the tests above prove the scanner can go red."""
+    lint = _load_lint()
+    problems = lint.load_allowlist()[1] + lint.check(
+        lint.scan(), lint.load_allowlist()[0])
+    assert problems == [], problems
+
+
+def test_fence_authority_set_matches_the_module() -> None:
+    from gen_worker import settings_authority as sa
+
+    lint = _load_lint()
+    assert set(lint.AUTHORITY_FILES) == set(sa.AUTHORITY_MODULES)

--- a/tests/test_torchless_boot_pgw788.py
+++ b/tests/test_torchless_boot_pgw788.py
@@ -61,7 +61,7 @@ def torchless(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_torchless_worker_completes_the_boot_seal(torchless, monkeypatch):
-    monkeypatch.setattr(env_seal, "_BOOT_SEAL", None, raising=False)
+    monkeypatch.setattr(env_seal, "_BOOT_READBACK", None, raising=False)
     seal = env_seal.establish()
 
     assert seal["config"]["torch"] == torch_capability.ABSENT
@@ -99,16 +99,20 @@ def test_torchless_posture_assertion_agrees_with_its_own_seal(torchless):
 def test_declared_knob_on_a_torchless_worker_refuses_by_name(torchless):
     """Every canonical knob is a torch flag. Silently ignoring one would fork
     cell identity, so a torchless worker that declares one refuses."""
-    with pytest.raises(env_seal.EnvSealError) as exc:
-        env_seal.establish_config({"cudnn_benchmark": "True"})
+    from gen_worker import settings_authority as sa
+
+    with pytest.raises(sa.SettingsImpositionError) as exc:
+        sa.impose_torch({"cudnn_benchmark": "True"})
     assert "TORCHLESS" in str(exc.value)
     assert "cudnn_benchmark" in str(exc.value)
 
 
 def test_unknown_knob_still_refuses_without_torch(torchless):
     """The knob-name contract is torch-free and must not be skipped."""
-    with pytest.raises(env_seal.EnvSealError) as exc:
-        env_seal.establish_config({"not_a_knob": "1"})
+    from gen_worker import settings_authority as sa
+
+    with pytest.raises(sa.SettingsImpositionError) as exc:
+        sa.impose_torch({"not_a_knob": "1"})
     assert "not_a_knob" in str(exc.value)
 
 

--- a/tests/test_torchless_boot_pgw788.py
+++ b/tests/test_torchless_boot_pgw788.py
@@ -65,7 +65,9 @@ def test_torchless_worker_completes_the_boot_seal(torchless, monkeypatch):
     seal = env_seal.establish()
 
     assert seal["config"]["torch"] == torch_capability.ABSENT
-    assert seal["inductor"] == torch_capability.ABSENT
+    # pgw#1049: torchless declares NO codegen clamp — an empty declared
+    # inductor block, same as a non-x86 host (absence rides `config`).
+    assert seal["inductor"] == {}
     assert seal["posture"] == {"torch": torch_capability.ABSENT}
     # A seal that states the absence is still a KEY: it digests, and the
     # boot-vs-point-of-use check agrees with itself.

--- a/tests/test_worker_goals_pgw930.py
+++ b/tests/test_worker_goals_pgw930.py
@@ -126,9 +126,10 @@ def test_the_goal_declaration_is_not_a_sealed_knob() -> None:
     destroy the single property the forge exists to have. Same reasoning that
     keeps ``GEN_WORKER_PREFER_AOT`` out of the table.
     """
-    assert "WORKER_MODE" not in env_seal.CANONICAL_CONFIG
-    assert not any(
-        "WORKER_MODE" in str(k) for k in env_seal.CANONICAL_CONFIG)
+    from gen_worker import settings_authority as sa
+
+    assert "WORKER_MODE" not in sa.DECLARED_TORCH
+    assert not any("WORKER_MODE" in str(k) for k in sa.DECLARED_TORCH)
 
 
 def test_goals_do_not_move_the_env_seal(

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -134,13 +134,29 @@ def _fresh_process_settings():
     gw_worker_goals.reset_for_test()
 
 
+def pytest_configure(config):
+    # pgw#1049: same treatment as tests/conftest.py — the declared
+    # interpreter env (PYTHONHASHSEED=0), imposed by ONE re-exec with global
+    # capture stopped first so the re-exec'd run still owns the terminal.
+    # xdist workers inherit the env from the re-exec'd master.
+    from gen_worker.settings_authority import (
+        _interpreter_env_diffs, ensure_interpreter_env)
+
+    if not _interpreter_env_diffs():
+        return
+    capman = config.pluginmanager.getplugin("capturemanager")
+    if capman is not None:
+        capman.stop_global_capturing()
+    ensure_interpreter_env()  # execs; never returns (or raises for -E)
+
+
 @pytest.fixture(autouse=True)
 def _fresh_boot_seal():
     from gen_worker import env_seal
 
-    env_seal._BOOT_SEAL = None
+    env_seal._BOOT_READBACK = None
     yield
-    env_seal._BOOT_SEAL = None
+    env_seal._BOOT_READBACK = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests_v2/test_boot.py
+++ b/tests_v2/test_boot.py
@@ -141,7 +141,9 @@ def test_env_seal_imposes_canonical_config_and_refuses_drift(monkeypatch) -> Non
         assert torch.backends.cudnn.allow_tf32 is True
         assert torch.get_float32_matmul_precision() == "high"
         assert torch.backends.cudnn.benchmark is False
-        assert env_seal.CANONICAL_CONFIG.items() <= seal["config"].items()
+        from gen_worker import settings_authority as sa
+
+        assert sa.DECLARED_TORCH.items() <= seal["config"].items()
 
         # The digest is the env_seal cell-key axis: deterministic.
         digest = env_seal.seal_digest(seal)
@@ -149,8 +151,8 @@ def test_env_seal_imposes_canonical_config_and_refuses_drift(monkeypatch) -> Non
         assert digest == env_seal.seal_digest(entrypoint._establish_env_seal())
 
         # Refusal 1: an undeclared knob refuses BY NAME (one-way door).
-        with pytest.raises(env_seal.EnvSealError, match="not_a_knob"):
-            env_seal.establish_config(overrides={"not_a_knob": "1"})
+        with pytest.raises(sa.SettingsImpositionError, match="not_a_knob"):
+            sa.impose_torch(overrides={"not_a_knob": "1"})
 
         # Refusal 2: point-of-use drift refuses, naming the fact and both
         # values — endpoint code mutating config behind our back is a named
@@ -412,10 +414,12 @@ def test_seal_order_is_settings_then_seal_then_probe(monkeypatch) -> None:
 def test_torchless_declared_knob_refuses_by_name(torchless) -> None:
     """Every canonical knob is a torch flag; honouring one on a torchless
     worker would silently fork cell identity — refuse, naming the knob."""
-    with pytest.raises(env_seal.EnvSealError, match="cudnn_benchmark"):
-        env_seal.establish_config(overrides={"cudnn_benchmark": "False"})
-    with pytest.raises(env_seal.EnvSealError, match="TORCHLESS"):
-        env_seal.establish_config(overrides={"cudnn_benchmark": "False"})
+    from gen_worker import settings_authority as sa
+
+    with pytest.raises(sa.SettingsImpositionError, match="cudnn_benchmark"):
+        sa.impose_torch(overrides={"cudnn_benchmark": "False"})
+    with pytest.raises(sa.SettingsImpositionError, match="TORCHLESS"):
+        sa.impose_torch(overrides={"cudnn_benchmark": "False"})
     # The torchless seal itself still stands: absence is a keyable fact.
     cfg = env_seal.effective_config()
     assert cfg.get("torch") == "absent"


### PR DESCRIPTION
Paul's directive (2026-08-09): **`us → pytorch settings`, never `[us, random other things] → pytorch settings`.** Cell identity now derives from OUR DECLARATION; ambient mutation is structurally unable to move it — it can only trip the (kept) pgw#719 tripwire, a named pre-trace refusal.

## The three parts

1. **`settings_authority.py` — THE declaration + the only writer.** `DECLARED_ENV` (incl. `PYTHONHASHSEED=0` — the pgw#1034 HUMAN_MUST_DO decision EXECUTED: entrypoint re-exec via `sys.orig_argv`, fail-closed at `establish`, one-entry revert), `DECLARED_TORCH` (pgw#654 posture + typed knobs), `DECLARED_DYNAMO` (the v2 shape posture, moved out of compile_cache — a second writer whose plain assignment was thread-local; now imposed at the config `default` layer with foreign-thread verify), host-ISA clamp. The second-writer fence (`scripts/lint_settings_writers.py`, in fast gates) reds any unclassified torch-settings write and any stale allowlist row; the stray writers it found (executor TF32 bootstrap, group.py NVLS, compile_cache autograd-cache/semantic-tag/recompile-limit) now route through the authority.
2. **Seal v3→v4: `effective_seal()` digests the declaration** — the seal dict is literally readable as {env, config, dynamo, inductor, posture} + `loaded_libs`. RED-proven: the pgw#1042 mutation class (global inductor config mutated mid-mint) moves the v3-style read-back digest in the test and CANNOT move the v4 seal; the tripwire refuses naming the fact. `aot_mint.mint` now asserts the tripwire pre-trace (the AOT path never did). **Re-key cost (§1.27(g)), measured:** corpus = ONE `cell_receipts` row fleet-wide (e2e-dev, a `ck5-…` key predating the pgw#958 scheme reset — matches no ck1 runtime under any seal version), 0 on e2e-master. Zero live matches stranded.
3. **Ambient-input census** (th#1678 shape): `scripts/ambient_inputs_census.txt` classifies every env input the INSTALLED torch/triton consult (442 scanned); `lint_ambient_census.py` (fast gates) verifies the structural claims, `test_ambient_census_pgw1049.py` reds on any unclassified input — including ones a torch upgrade introduces. Census-driven hardening: `SCRUB_PREFIXES` grows `NCCL_`/`ATEN_`/`AOTI*`/`INDUCTOR_`/`CUTLASS_`/`KMP_`/`CUDA_LAUNCH_BLOCKING`/`CUDA_MODULE_LOADING`/TMA/partitioner/fx knobs.

## Paul order folded in mid-lane

**`mode` cell-key axis DELETED** — pinned `""` since regional died; empty optionals never entered the canonical form, so zero digests move and no KEY_SCHEME bump. `regional` was redundant even in principle (it rides the `contract` axis via `declared_contract_facts`). A stale caller shipping `mode` gets `from_axes`' typed unknown-axis refusal (RED test). The envelope `mode` FIELD survives — `models/provision.py` reads it for arm routing (pgw#827), a different noun.

## Two real defects found by the work itself

- **`PYTORCH_CUDA_ALLOC_CONF` was silently dead fleet-wide**: the entrypoint's `setdefault` was erased by its own scrub (`PYTORCH` prefix) before first cudaMalloc — `expandable_segments` has been off since pgw#718. Post-scrub re-imposition makes it real.
- **The new aot_mint tripwire caught a latent pgw#719 false positive on its first GPU run**: cu126 ships `libcupti.so.12` twice with different bytes (triton/backends vs nvidia/cuda_cupti); the live substitution check read the env's own second copy as an LD_PRELOAD. It now consults every shipped copy; identity still keys the deterministic first copy.

## Verification

- Micro gauntlet on the real RTX 4070 (sm_89, cu126), 6 variants + handback leg.
- Full suite green locally from the worktree; mypy clean (244 files), ruff clean, all six lint gates green.
- RED proofs in-tree: `test_settings_authority_pgw1049.py`, `test_settings_fence_pgw1049.py`, `test_ambient_census_pgw1049.py`, `test_cell_key.py::test_mode_axis_is_deleted_and_regional_rides_the_contract`.

Rides master only — no release vehicle, no deploy, no pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)