### PR TITLE
pgw#1060: name the two halves — `envelope` is the declared serving region, the graph digest is the traced fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Full reference: [docs/endpoint-authoring.md](docs/endpoint-authoring.md).
   `Civitai`, `ModelScope`, `ModelRef`
 - Model selection: `Model`, `ModelChoice`, `ModelDefaults`, `Slot`,
   `ResolvedSlot`, `gen_worker.families.GenerationDefaults`
-- Compile contract: `Compile`, `CompileAxis`, `AxisClass`, `DynamicDim`,
+- Compile envelope (the declared serving region — resolutions, text lengths,
+  guidance, batch): `Compile`, `CompileAxis`, `AxisClass`, `DynamicDim`,
   `pad_text_sequence`; per-request views: `ctx.for_request` / `gen_worker.view`
 - Contexts: `RequestContext` (≤15 members), `ConversionContext`,
   `DatasetContext`, `TrainingContext`
@@ -165,6 +166,8 @@ hard-fails if `gen_worker` resolves outside `src/`).
   `prefetch`, `field=value` grammar, `--offline`, exit codes.
 - [docs/dockerfile.md](docs/dockerfile.md) — bring-your-own-Dockerfile contract.
 - [docs/endpoint-envs.md](docs/endpoint-envs.md) — tenant envs/secrets.
+- [docs/compile-cache.md](docs/compile-cache.md) — compiled cells: the graph
+  digest vs the declared envelope, kernel lanes, JIT intake.
 
 ## Examples
 

--- a/changelog.d/pgw1060.md
+++ b/changelog.d/pgw1060.md
@@ -1,0 +1,26 @@
+- **pgw#1060: the vocabulary now says which half it means — `envelope` for the
+  declared serving region, "the graph digest" for the traced fact, and "the
+  weight-binding contract" for the pgw#857 state-dict rule.** Nothing
+  serialized moved. The `contract` axis fuses a MEASURED FACT (the traced-graph
+  digest) with a DECLARED PROMISE (which resolutions, text lengths, guidance
+  values and batch sizes the cell serves), and that fusion has bitten twice in
+  24 h — attempt 28's phantom key divergence and pgw#1058's entry-label drift.
+  Prose and non-serialized code now name them separately: `docs/compile-cache.md`
+  opens with the vocabulary (envelope as in a *flight* envelope — a declared
+  region of operation with graceful fallback outside it, so a request outside it
+  is served eager and named, not failed), `input_contract` is documented as
+  DERIVED from the packaged program rather than a third independent fact, and
+  refusal/log text reads "outside the declared envelope" instead of the fused
+  "out-of-contract". `docs/endpoint-authoring.md`'s `register_buffer` section is
+  retitled **the weight-binding contract** and carries the two pgw#1056
+  authoring corollaries: a GB-scale config-derived tensor is a named CAS
+  component bound like a weight (scale decides, not provenance), and `__init__`
+  must be meta-device safe for the zero-download forge. `gen_worker.api
+  .shape_contract` → `gen_worker.api.sdk_shape`: that module is the SDK's own
+  declaration-surface shape (the deleted-field table), a different thing from
+  the `shape_contract` cell-metadata block, and the shared name was the homonym.
+  **Every digest-bearing name — the `declared_traffic` block key, the `contract`
+  / `graph_contract` axes, `shape_contract`, `shape_contract_digest` and the
+  proto `*_contract_digest` fields — is UNCHANGED and deferred to pgw#1059's
+  single ck1 redefinition**, because renaming one outside that change re-keys
+  every published cell.

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -13,6 +13,33 @@
 > packing or publishing an inductor cache are history; the keying, verification
 > and lane material still applies to the cell that survived.
 
+## Vocabulary: the graph digest is a fact, the envelope is a promise
+
+A cell states two different kinds of thing about itself, and keeping them apart
+is what makes its refusals readable:
+
+- **The graph digest** — the digest of the traced graph. A MEASURED FACT about
+  the program that was exported: same computation, same digest, on any pod. One
+  derivation, used identically when the cell is stamped, looked up and admitted.
+- **The envelope** — the DECLARED serving region: which resolutions, text
+  lengths, guidance values and batch sizes the cell promises to serve. As in a
+  flight envelope: a declared region of operation, with graceful fallback
+  outside it. A request outside the envelope is not an error — it is served
+  eager and named (`request out of declared envelope, serving eager`).
+- **`input_contract`** — DERIVED, not a third fact. It is a projection of the
+  packaged program's own placeholder list and container arities, read off the
+  artifact rather than declared beside it. A label carried alongside an artifact
+  can drift from it, and a label that can drift is not an identity (pgw#1058).
+
+Widening the envelope moves the promise; it does not move the fact. The cell key
+still fuses both halves into one `contract` axis — splitting it into
+`graph` x `envelope` is a single coordinated change to the key schema (pgw#1059,
+landing pre-launch as a REDEFINITION of `ck1` with the disposable corpus purged),
+so the KEY still says `contract` while the prose already says which half it
+means. Do not rename an axis, a metadata block key or a wire field ahead of that
+change: a name that participates in a digest re-keys every published cell the
+moment it moves.
+
 Compile wins 15-34% warm latency on flux-class models but costs 20-46s per
 (model, shape) and needs a C toolchain prod worker images don't ship. The
 split:
@@ -51,10 +78,10 @@ gate + `root` is a platform-reserved slug tenants cannot claim). Tenant
 custom-code endpoints
 get per-release private caches (same-principal rule) — not implemented yet.
 
-Family keying: caches key on the traced graph + shapes, not weights — one
-artifact serves every fine-tune of a family. Add a boot `warmup()` that
-renders each declared shape (see examples/flux2-klein-image) so requests
-never see the (cache-served) compile.
+Family keying: caches key on the graph digest + the declared envelope, not on
+weights — one artifact serves every fine-tune of a family. Add a boot `warmup()`
+that renders each shape the envelope declares (see examples/flux2-klein-image)
+so requests never see the (cache-served) compile.
 
 ## Self-loading (str/Path-slot) endpoints — pgw#517
 
@@ -65,7 +92,7 @@ the worker loads itself — a slot annotated with the pipeline class (e.g.
 **self-loading**: the endpoint constructs (and places) the pipeline inside
 its own `setup()`, so the executor never sees the object and has nothing to
 arm compile on. Declaring `compile=Compile(...)` on such an endpoint used to
-be silently inert — the manifest/shape contract still got seeded, but
+be silently inert — the manifest's compile block still got seeded, but
 nothing ever compiled. Registration (`registry.py` `_validate_compile_arms`,
 at decoration time, not discovery) now raises on this combination. It is a
 best-effort source scan, so it stays silent when `inspect.getsource(setup)`

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -69,7 +69,14 @@ annotation (`FluxPipeline` → `from_pretrained`; `str`/`Path` → the local
 snapshot dir), and owns device placement and low-VRAM offload. Endpoint code
 never calls `.to("cuda")`, `enable_model_cpu_offload()`, or `empty_cache()`.
 
-## Tensor state: `register_buffer`, never a plain attribute (pgw#857)
+## The weight-binding contract: `register_buffer`, never a plain attribute (pgw#857)
+
+A compiled cell rebinds weights **by name** at load, which is what lets one cell
+serve every fine-tune of a family. That only holds if every tensor your model
+needs is reachable through `state_dict()`. **The weight-binding contract** is
+that rule: a tensor your module holds is either a named state-dict entry the CAS
+delivers and rebinds, or it is baked into the artifact — there is no third
+outcome, and you choose which one by how you assign it.
 
 If your model class holds a tensor that is **not** a learned parameter — a rope
 frequency table, a precomputed mask, any "just a cache" — **register it as a
@@ -103,6 +110,28 @@ into every compiled artifact, and you have coupled your cell identity to a
 number you probably meant to be a cache.
 
 A registered buffer costs nothing and stays a weight.
+
+### Corollary: a GB-scale derived tensor is a saved component, not a buffer (pgw#1056)
+
+The buffer rule above assumes the tensor is small enough that computing it at
+`__init__` is free. **Scale decides, not provenance.** A large tensor derived
+from config — MiniMax-H3's precomputed step-count positional tables are GBs — is
+neither an init-computed buffer nor a baked literal. It is **saved model data**:
+a named CAS component with its own safetensors header, bound by name exactly
+like a weight (the composition system already does this for fp8 overrides).
+Precompute it once, publish it as a component, and delete the generator.
+
+The test is size, not where the numbers came from: big ⇒ component; only
+trivially recomputable state stays a `register_buffer`-computed tensor.
+
+### Corollary: `__init__` must be meta-device safe (pgw#1056, coming)
+
+The zero-download forge instantiates your module on the **meta device** — code
+plus config plus the safetensors header, no tensor bytes. A module that does
+REAL tensor computation in `__init__` breaks that silently. A gate is coming
+that detects materialized real tensors at instantiation and refuses with
+authoring guidance, so the violation is caught at mint time instead of after a
+cell ships. Write `__init__` so it allocates shapes and dtypes, never values.
 
 ## Imports go at module top — including torch
 
@@ -369,7 +398,7 @@ with its real `sha256` and `size_bytes`. `ctx.log` and `ctx.progress` are
 captured at the emitter seam, so neither needs an override either.
 
 **Do not assert the SDK's own shape.** A field the SDK deleted is the SDK's
-fact: it is listed once in `gen_worker.api.shape_contract.DELETED_FIELDS`
+fact: it is listed once in `gen_worker.api.sdk_shape.DELETED_FIELDS`
 and asserted by the SDK's suite. An endpoint asserts what IT declares, and
 gets the deleted-field walk for free:
 

--- a/src/gen_worker/api/compile_axis.py
+++ b/src/gen_worker/api/compile_axis.py
@@ -123,7 +123,7 @@ class PayloadAxis:
         self._matchers = matchers
 
     def classify(self, value: Any) -> Optional[str]:
-        """The class name ``value`` falls in, or None (out of contract)."""
+        """The class name ``value`` falls in, or None (outside the envelope)."""
         for name, warm, match in zip(self.class_names, self.warm_values, self._matchers):
             if match is not None:
                 try:

--- a/src/gen_worker/api/sdk_shape.py
+++ b/src/gen_worker/api/sdk_shape.py
@@ -1,9 +1,15 @@
-"""The SDK's own declaration-shape contract (pgw#942).
+"""The shape of the SDK's OWN declaration surface (pgw#942).
+
+Nothing here concerns a served graph: this is the SDK stating which fields
+its declaration types do and do not have. It was ``api.shape_contract`` until
+pgw#1060, which took the name back — ``shape_contract`` is a cell-metadata
+block about a compiled graph, and one name for two unrelated things is what
+the naming rulings exist to stop.
 
 A field that the SDK DELETED is a fact only the SDK knows. Before this
 module, 25 of 28 endpoint packages asserted that knowledge for it — 91
 ``assert not hasattr(...)`` lines plus 46 ``for deleted in (...)`` loops,
-each naming fields the pinned SDK cannot ship. That is a shape contract
+each naming fields the pinned SDK cannot ship. That is one declaration shape
 written 25 times by the parties least able to maintain it: one rename here
 broke 25 downstream suites at once.
 
@@ -68,7 +74,7 @@ DELETED_FIELDS: Tuple[DeletedField, ...] = (
         name="regimes",
         deleted_at="0.60.0",
         reason=(
-            "SDK v2 (pgw#647): the endpoint declares one shape contract, not a set "
+            "SDK v2 (pgw#647): the endpoint declares one envelope, not a set "
             "of named operating regimes the hub had to re-derive."
         ),
     ),

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5975,8 +5975,8 @@ class Executor:
         # is proven on an object once ALL of its graph classes proved there.
         proven_keys: Dict[int, set] = {}
         # pgw#844: which objects proved through the EXPORTED lane. An exported
-        # artifact refuses an out-of-contract shape BY NAME and serves that one
-        # call eager while staying armed, so a graph class it did not serve is
+        # artifact refuses a shape outside its declared envelope BY NAME and
+        # serves that call eager while staying armed, so a class it did not serve is
         # a per-shape posture, not a silent recompile — which is what lets the
         # attribution below be per-class for this lane and stay all-or-nothing
         # for dynamo, where an unproven class means an unannounced recompile.

--- a/src/gen_worker/graph_hash.py
+++ b/src/gen_worker/graph_hash.py
@@ -21,7 +21,7 @@ the sdxl UNet exported three times differing ONLY in declared dynamic range
 (``VR[64,160]`` / ``VR[64,320]`` / ``VR[96,128]``) produced ONE node-only digest
 (``9dd33abbc7617d98``) for all three. The ranges live in
 ``ExportedProgram.range_constraints`` — a field BESIDE the graph, not in its
-nodes — so a node-only hash collides artifacts that admit DIFFERENT traffic:
+nodes — so a node-only hash collides artifacts whose declared ENVELOPES differ:
 adopt the ``[96,128]`` cell against a ``[64,160]`` key and 1024x1024 requests are
 refused by an artifact whose key promised to serve them. Symbolic ranges are the
 OPPOSITE of the non-semantic noise scrubbed below, and they are equally a defect
@@ -231,7 +231,7 @@ def _range_lines(ranges: Any, syms: _Symbols) -> List[str]:
     """Symbolic-dim RANGE lines — the pgw#704 S8 soundness fix.
 
     Emitted for every symbol the graph actually uses, in canonical symbol
-    order, so three artifacts admitting different traffic cannot collide.
+    order, so three artifacts declaring different envelopes cannot collide.
     """
     if not ranges:
         return []
@@ -240,8 +240,8 @@ def _range_lines(ranges: Any, syms: _Symbols) -> List[str]:
     for symbol, value_range in ranges.items():
         canonical = by_raw.get(str(symbol))
         if canonical is None:
-            # A constrained symbol the graph never mentions cannot change what
-            # the artifact admits; recording it would key on shape-env noise.
+            # A constrained symbol the graph never mentions cannot change the
+            # artifact's envelope; recording it would key on shape-env noise.
             continue
         lines.append(
             f"{SYM_PREFIX}{canonical} range=["

--- a/src/gen_worker/guard_closure.py
+++ b/src/gen_worker/guard_closure.py
@@ -874,7 +874,7 @@ def closure_manifest(pipeline: Any, cfg: Any, label: str = "") -> Dict[str, Any]
         lines = list(report.leaks) + [f"UNPROVEN {u}" for u in report.unproven]
         detail = (
             f"guard-closure ADVISORY ({name}): {len(report.leaks)} "
-            f"out-of-contract guard(s), {len(report.unproven)} unreadable "
+            f"guard(s) outside the declared envelope, {len(report.unproven)} unreadable "
             f"entrie(s) — recorded in the cell manifest, mint continues "
             f"(pgw#756; the consumer's own guard evaluation is the real "
             f"check):\n  " + "\n  ".join(lines))
@@ -925,7 +925,7 @@ def _canonical_tensor(t: Any, path: str, label: str, dtypes: Dict[str, str]) -> 
     if seen != str(t.dtype):
         raise GuardBoundaryError(
             f"compiled ingress {label}: {path} arrived as {t.dtype} but "
-            f"this boundary first observed {seen} — out-of-contract dtype "
+            f"this boundary first observed {seen} — undeclared dtype "
             "drift at the compiled graph boundary")
     return t
 

--- a/src/gen_worker/numerics_probe.py
+++ b/src/gen_worker/numerics_probe.py
@@ -1,7 +1,7 @@
 """The thing that MEASURES (pgw#868 cross-cutting; pgw#848 CP12).
 
 Everything this program built refuses a cell for being UNUSABLE — wrong `sm`,
-wrong torch, unbound constants, out-of-contract ingress. Nothing refused one
+wrong torch, unbound constants, ingress outside the declared envelope. Nothing refused one
 for being WRONG. :mod:`gen_worker.numerics_ladder` has owned the verdict since
 pgw#817 and `Compile.numerics_floor` has declared the bar since pgw#812, but
 ``compare_outputs`` had zero consumers: no code anywhere ran the armed cell and

--- a/src/gen_worker/shape_growth.py
+++ b/src/gen_worker/shape_growth.py
@@ -23,8 +23,9 @@ inside.  "It heals on the JIT path" is therefore not an answer.
 
 What this module owns
 ---------------------
-* the **vocabulary**: a shape gap is a named DECLARED CLASS the armed cell does
-  not cover, not a dynamo input signature — arm-agnostic by construction;
+* the **vocabulary**: a shape gap is a named DECLARED CLASS outside the armed
+  cell's ENVELOPE — the declared serving region, not a dynamo input signature —
+  so it is arm-agnostic by construction;
 * the **countable fact**: :data:`activity.KIND_SHAPE_GAP`, the AOT counterpart
   of pgw#680's ``guard_miss``, so the hub can count coverage holes on either
   arm with one grouped query;
@@ -196,8 +197,9 @@ def report(gap: ShapeGap) -> bool:
             activity_mod.KIND_SHAPE_GAP,
             f"arm={gap.arm} family={gap.family} target={gap.target} "
             f"cell={gap.cell_key or '<none>'} class={gap.declared_class}: "
-            f"the armed cell does not cover this declared graph class; the "
-            f"request is served EAGER and named at ingress"
+            f"request out of declared envelope: the armed cell does not cover "
+            f"this graph class, so the request is served EAGER and named at "
+            f"ingress"
             + (f" — {gap.detail}" if gap.detail else ""),
             phase=gap.reason,
         )

--- a/src/gen_worker/testing/__init__.py
+++ b/src/gen_worker/testing/__init__.py
@@ -63,7 +63,7 @@ from typing import (
 import msgspec
 
 from ..api.binding import ModelRef
-from ..api.shape_contract import (
+from ..api.sdk_shape import (
     DELETED_FIELDS,
     DeclarationShapeError,
     DeletedField,

--- a/src/gen_worker/text_pin.py
+++ b/src/gen_worker/text_pin.py
@@ -21,8 +21,8 @@ from typing import Any, Optional, Tuple
 
 class TextLengthExceededError(ValueError):
     """The encoded prompt is longer than the declared ``Compile(text_len=)``
-    pin — an out-of-contract request. Typed refusal (same posture as
-    over-rank LoRAs), never a silently minted graph."""
+    pin — a request outside the declared envelope. Typed refusal (same posture
+    as over-rank LoRAs), never a silently minted graph."""
 
 
 def pad_text_sequence(

--- a/tests/test_graph_hash_pgw716.py
+++ b/tests/test_graph_hash_pgw716.py
@@ -3,7 +3,7 @@
 The load-bearing test in this file is the RANGE-COLLISION one: pgw#704 measured
 three sdxl exports differing ONLY in declared dynamic range collapsing to one
 node-only digest (``9dd33abbc7617d98``), which would let a worker adopt a cell
-that refuses the traffic its key promised. Everything else here pins the
+that refuses the envelope its key promised. Everything else here pins the
 properties ck6 exists for — same graph shares a key, weight values never key,
 different graph never shares.
 """
@@ -110,8 +110,8 @@ def test_declared_range_must_not_collide_pgw704_s8():
     digests = [gh.digest_lines(each) for each in lines]
 
     # The measured finding this test exists for: the NODES are identical across
-    # all three, so a node-only hash gives one digest for three artifacts that
-    # admit different traffic.
+    # all three, so a node-only hash gives one digest for three artifacts
+    # whose declared envelopes differ.
     assert _node_lines(lines[0]) == _node_lines(lines[1]) == _node_lines(lines[2])
     node_only = {gh.digest_lines(_node_lines(each)) for each in lines}
     assert len(node_only) == 1, "premise broken: nodes were expected to collide"
@@ -119,7 +119,7 @@ def test_declared_range_must_not_collide_pgw704_s8():
     # ...and the fix: ranges are IN the canonical form, so the three keys differ.
     assert len(set(digests)) == 3, (
         "three exports admitting different shape ranges share a graph hash — "
-        "adopting one against another's key refuses traffic the key promised")
+        "adopting one against another's key refuses the envelope the key promised")
     assert len({_sym_lines(each) for each in lines}) == 3
     for line_set in lines:
         assert _sym_lines(line_set), "no range facts recorded for a dynamic dim"

--- a/tests/test_guard_closure_pgw681.py
+++ b/tests/test_guard_closure_pgw681.py
@@ -178,12 +178,12 @@ def test_noncanonical_minted_stride_is_a_leak() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Acceptance: an out-of-contract scalar leak is RECORDED, not refused
+# Acceptance: an out-of-envelope scalar leak is RECORDED, not refused
 # (pgw#756 — the classifier lost its veto; see test_guard_gate_advisory_pgw756)
 # ---------------------------------------------------------------------------
 
 
-def test_out_of_contract_scalar_is_recorded_naming_the_variable() -> None:
+def test_out_of_envelope_scalar_is_recorded_naming_the_variable() -> None:
     def forward(self: Any, x: Any, scale: float) -> Any:
         return self.lin(x) * scale
 

--- a/tests/test_guard_source_roots_pgw733.py
+++ b/tests/test_guard_source_roots_pgw733.py
@@ -181,7 +181,7 @@ def test_a_real_hierarchy_with_both_triggers_closes(monkeypatch):
             compiled(torch.randn(2, 8))
         report = gc.audit_armed(pipe, _cfg())
         assert not report.leaks, (
-            "an in-contract call on a real module hierarchy leaked: "
+            "a call inside the declared envelope on a real module hierarchy leaked: "
             + "; ".join(str(leak) for leak in report.leaks))
         gc.closure_manifest(pipe, _cfg(), label="sdxl")
         counts = report.verdict_counts()

--- a/tests/test_sdk_v2_pgw647.py
+++ b/tests/test_sdk_v2_pgw647.py
@@ -181,7 +181,7 @@ def test_enum_axis_from_literal():
     (axis,) = extract_payload_axes("owner", _LitIn)
     assert axis.class_names == ("1:1", "3:4", "16:9")
     assert axis.classify("3:4") == "3:4"
-    assert axis.classify("9:16") is None  # out of contract
+    assert axis.classify("9:16") is None  # outside the envelope
 
 
 def test_axis_warm_must_satisfy_its_own_match():


### PR DESCRIPTION
Vocabulary sweep for the naming rulings made in the pgw#1059 key-design conversation. **No serialized name moved.**

## Why

The `contract` axis fuses a MEASURED FACT (the traced-graph digest) with a DECLARED PROMISE (which resolutions, text lengths, guidance values and batch sizes a cell serves). That fusion bit twice in 24 h — attempt 28's phantom key divergence (one axis name, two derivations) and pgw#1058 (entry label vs packaged program dims, the same declared-vs-derived duality one layer down). The words now say which half they mean, ahead of the key itself.

## The four rulings, propagated

1. **`envelope`** replaces "traffic" as the name of the declared serving region. Bare noun — the flight metaphor is one sentence, in the docs only.
2. **The graph digest** is the traced fact, named separately from the envelope everywhere prose touches both.
3. **"weight-binding contract"** is the official name of the pgw#857 state-dict boundary rule.
4. **`input_contract`** keeps its name, documented as DERIVED from the packaged program.

## What changed

- `docs/compile-cache.md` opens with the vocabulary section (fact vs promise vs derived).
- `docs/endpoint-authoring.md`'s `register_buffer` section is retitled **the weight-binding contract**, with the two pgw#1056 authoring corollaries: a GB-scale config-derived tensor is a named CAS component bound like a weight (scale decides, not provenance), and `__init__` must be meta-device safe for the zero-download forge.
- `shape_growth.report` refusal text: **"request out of declared envelope: the armed cell does not cover this graph class, so the request is served EAGER and named at ingress."** Reason tokens (`shape_gap`, `no_entry_admits`) are hub-consumed and unchanged.
- Comment/docstring/test-comment renames in `graph_hash`, `api/compile_axis`, `text_pin`, `executor`, `numerics_probe`, `guard_closure` and four test modules.
- `gen_worker.api.shape_contract` → `gen_worker.api.sdk_shape`. That module is the shape of the SDK's own DECLARATION SURFACE (the deleted-field table), not anything about a served graph — the shared name was the homonym. Import-only, one internal importer, no alias left behind. The renamed test (`test_out_of_envelope_scalar_is_recorded_naming_the_variable`) was verified to still collect and run.

## The fence

`declared_traffic`, the `contract` / `graph_contract` axis strings, `shape_contract`, `shape_contract_digest`, the proto `*_contract_digest` fields, and every typed refusal token are **unchanged**. Each is on pgw#1059's ck1-redefinition checklist — renaming one outside that single coordinated change re-keys or unreads every published cell.

Files owned by live lanes were deliberately not touched; the renames they owe are recorded as notes on **pgw#1058** (`aot_serve`/`aot_package`), **pgw#1052/#1053** (`aot_mint`, compile pool) and **pgw#1059** (`cell_key`).

Tracker: pgw#1060.