### PR TITLE
pgw#1052+pgw#1053: overlap export with the compile pool; release the mint's dead residents

### DIFF
--- a/changelog.d/pgw1052.md
+++ b/changelog.d/pgw1052.md
@@ -1,0 +1,7 @@
+- pgw#1052: the AOT mint overlaps export with the entry-compile pool — the
+  pool is constructed before the first row exports and consumes each row as it
+  arrives (`EntryCompilePool.compile` now accepts a producer iterator; the
+  pgw#917 merge/refuse decision moves to arrival with the batch gate re-run at
+  drain as a safety net; producer time is charged to the new `idle_source_s`
+  ledger bucket; a live per-spawn simultaneity check prices export-phase
+  growth). Process change only: cell keys are byte-identical to a serial mint.

--- a/changelog.d/pgw1053.md
+++ b/changelog.d/pgw1053.md
@@ -1,0 +1,9 @@
+- pgw#1053: the mint's dead residents are released. The mint child (and the
+  operator CLI) surrender their pipeline after the last export
+  (`release_residents=True` → code-only projection: weights to meta, literals
+  keep their bytes, every gate still runs) and the pool re-derives K against
+  the freed budget (`note_residents_released`, same pgw#992-bounded
+  arithmetic). On a pod with no serve goal, the serving parent parks its eager
+  pipeline to host RAM for the life of a delegated mint and restores it before
+  adopt (`mint_delegate.maybe_park_eager` — decided by the goals machinery;
+  serving pods keep eager resident and hot).

--- a/scripts/micro_mint_rig.py
+++ b/scripts/micro_mint_rig.py
@@ -266,11 +266,18 @@ def _mint_slot(tree: Path, ref_path: str) -> Any:
 def _mint_request(
     workdir: Path, tree: Path, veh: Any, *,
     ordinal: int = 0, cap_bytes: int = MINT_VRAM_BYTES,
+    entry_device_peak_bytes: int = 0,
 ) -> Any:
     """Built through `mint_delegate.build_request` — the REAL parent chain.
 
     Not a hand-written `MintRequest`: the thing under test is the handoff, and
     a hand-written request is the one shape the handoff can never produce.
+
+    ``entry_device_peak_bytes`` is the pgw#877 banked measurement a serving
+    parent would hand down after a previous mint on the pod — the rig
+    forwards an operator-supplied value so a GPU cycle can open on the
+    measured basis and take the pool path (K>1), which is where pgw#1052's
+    overlap and pgw#1053's release are observable.
     """
     from gen_worker import mint_delegate
     from gen_worker.mint_delegate import MintTask
@@ -287,7 +294,8 @@ def _mint_request(
         slots={"pipeline": _mint_slot(tree, veh.ref_path)}, device=ordinal,
         execution_lane="", configs={})
     return mint_delegate.build_request(
-        task, workdir=workdir, cap_bytes=cap_bytes)
+        task, workdir=workdir, cap_bytes=cap_bytes,
+        entry_device_peak_bytes=int(entry_device_peak_bytes))
 
 
 #: What the rig's endpoint function DECLARES, the way a real build reads it off
@@ -323,6 +331,7 @@ def run_cycle(
     device: str = "auto", vehicle: str = DEFAULT_VEHICLE,
     hub_env_mode: bool = False,
     hub_env_entries: Optional[Dict[str, str]] = None,
+    entry_device_peak_bytes: int = 0,
 ) -> RigResult:
     from harness import rig_vehicles
 
@@ -383,7 +392,8 @@ def run_cycle(
     request = _mint_request(workdir, tree, veh,
                             ordinal=int(dev["device_ordinal"]),
                             cap_bytes=(MINT_VRAM_BYTES
-                                       if dev["device_kind"] == "cuda" else 0))
+                                       if dev["device_kind"] == "cuda" else 0),
+                            entry_device_peak_bytes=entry_device_peak_bytes)
     leg.ok, leg.seconds = True, time.monotonic() - g0
     entries = _declared_entries(veh)
     leg.facts = {"family": request.family,
@@ -756,6 +766,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--hub-env-entry", action="append", default=[], metavar="NAME=VALUE",
         help="an endpoint_env_entries row the operator has set; repeatable. "
              "Only names the release DECLARES are delivered.")
+    parser.add_argument(
+        "--entry-device-peak-bytes", type=int, default=0,
+        help="pgw#877/#1052: hand the child a banked per-entry device peak, "
+             "as a serving parent would after a previous mint on the pod — "
+             "opens the width on the measured basis so a GPU cycle takes the "
+             "pool path (K>1), where the overlap and the residents release "
+             "are observable")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     root = Path(args.root)
@@ -773,7 +790,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         result = run_cycle(root, stage=args.stage, force_load=args.force_load,
                            device=args.device, vehicle=args.vehicle,
                            hub_env_mode=args.hub_env,
-                           hub_env_entries=entries)
+                           hub_env_entries=entries,
+                           entry_device_peak_bytes=args.entry_device_peak_bytes)
     except RigRefused as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 2

--- a/scripts/skip_census.txt
+++ b/scripts/skip_census.txt
@@ -74,6 +74,10 @@ CI-SKIPPED tests/test_svdq_native_pgw685.py|needs a cuda device
 CI-SKIPPED tests/test_nvfp4_fused_quant_pgw685.py|needs a cuda device
 CI-SKIPPED tests/test_aot_input_alignment_pgw791.py|cpu aoti wrapper emits no alignment check (gpu wrapper only); the pointer contract is asserted directly below
 CI-SKIPPED tests/test_llama_runtime.py|gpu smoke runs on the nightly gpu ci lane
+# pgw#1053: the real-card park/restore leg. Measured by hand on the rig box's
+# RTX 4070 via .venv-cu126 (2026-08-09); the cardless rows above it assert the
+# goals decision and the move/restore symmetry.
+CI-SKIPPED tests/test_mint_residents_pgw1053.py|needs a real card
 
 # ─── CI-SKIPPED: host capability the runner genuinely lacks ───────────────────
 # Each is measured on a developer box or a pod; none is a property of the code

--- a/src/gen_worker/aot_compile_pool.py
+++ b/src/gen_worker/aot_compile_pool.py
@@ -59,7 +59,8 @@ import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import (
-    Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple)
+    Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional,
+    Sequence, Tuple)
 
 import msgspec
 
@@ -382,6 +383,26 @@ def card_census(device: int = -1) -> CardCensus:
             "sampled")
     except Exception:  # noqa: BLE001 — an unreadable card licenses nothing
         return CardCensus(0, 0, 0, "unreadable")
+
+
+def own_reserved_now(device: int = -1) -> int:
+    """This process's CURRENT reserved bytes (-1 = unreadable).
+
+    pgw#1053: the post-release floor. Distinct from
+    :func:`own_device_high_water` on purpose — the high-water answers "what
+    did this process ever hold" and can only be re-baselined through
+    ``reset_peak_memory_stats``; this answers "what does it hold NOW", which
+    is what the released budget re-derives from.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return -1
+        dev = torch.cuda.current_device() if device < 0 else int(device)
+        return int(torch.cuda.memory_reserved(dev))
+    except Exception:  # noqa: BLE001 — unreadable regrants nothing
+        return -1
 
 
 def own_device_high_water(device: int = -1) -> int:
@@ -1024,6 +1045,14 @@ class PoolLedger:
     #: The pool refills a freed slot only after staging the next program, so
     #: this is export-vs-compile SERIALIZATION, measured.
     idle_staging_s: float = 0.0
+    #: pgw#1052: free-slot seconds while the parent was PULLING the entry
+    #: source — which, on the overlapped mint path, is the export itself
+    #: (``torch.export`` runs in the parent when the pool asks for the next
+    #: entry). This is the producer-side half of the serialization
+    #: ``idle_staging_s`` measures on the save side: it prices exactly how
+    #: much the single-threaded producer starved the pool, which is the
+    #: number that says when the fused export child (pgw#1000) is owed.
+    idle_source_s: float = 0.0
     #: Free-slot seconds with nothing left to start: the straggler tail.
     idle_drain_s: float = 0.0
     #: Free-slot seconds inside ``Popen`` itself.
@@ -1052,7 +1081,7 @@ class PoolLedger:
     @property
     def idle_s(self) -> float:
         return round(
-            self.idle_staging_s + self.idle_drain_s
+            self.idle_staging_s + self.idle_source_s + self.idle_drain_s
             + self.idle_spawn_s + self.idle_other_s, 3)
 
     @property
@@ -1067,6 +1096,7 @@ class PoolLedger:
             "pool_idle_s": self.idle_s,
             "pool_efficiency": self.efficiency,
             "idle_staging_s": round(self.idle_staging_s, 3),
+            "idle_source_s": round(self.idle_source_s, 3),
             "idle_drain_s": round(self.idle_drain_s, 3),
             "idle_spawn_s": round(self.idle_spawn_s, 3),
             "idle_other_s": round(self.idle_other_s, 3),
@@ -1303,6 +1333,21 @@ class EntryCompilePool:
         #: census it cannot read refuses the widen rather than assuming an
         #: empty card.
         self.census = card_census()
+        #: pgw#1053: the OWN term's floor in the simultaneity budget. Seeded
+        #: from the construction census (the resident pipeline), and
+        #: re-baselined by :meth:`note_residents_released` when the mint
+        #: parent provably hands its residents back — the ONE way the budget's
+        #: own term is ever allowed to shrink. Without an explicit floor,
+        #: ``max(own_device_high_water(), census.own_reserved_bytes)`` pins
+        #: the budget to the construction-time pipeline forever, and a release
+        #: frees bytes the arithmetic can never grant.
+        self._own_floor_bytes = int(self.census.own_reserved_bytes)
+        #: pgw#1053: bytes the release handed back, added to the CONSTRUCTION
+        #: free reading when K is re-derived. ``_rewiden`` deliberately never
+        #: re-probes a card K children are sitting on; the release's gain is
+        #: instead reconstructed as "the construction free figure plus what
+        #: the residents measurably returned", which children cannot distort.
+        self._free_gain_bytes = 0
         #: The terms of the last simultaneity decision, merged into the width
         #: row so a future OOM names WHICH term was wrong instead of leaving a
         #: reader to diff two pods that no longer exist.
@@ -1434,8 +1479,9 @@ class EntryCompilePool:
     # -- the run ----------------------------------------------------------
 
     def compile(
-        self, entries: Sequence[Tuple[str, Any]],
+        self, entries: Iterable[Tuple[str, Any]],
         *, on_entry: Optional[Callable[[str, int, int], None]] = None,
+        expected_total: int = 0,
     ) -> Dict[str, List[str]]:
         """``[(entry, ExportedProgram)] -> {entry: [file, ...]}``.
 
@@ -1444,6 +1490,20 @@ class EntryCompilePool:
         entry NAME, never by completion, so the packaged cell cannot depend
         on which child finished first.
 
+        ``entries`` may be a SEQUENCE (every entry already exported — the
+        pre-pgw#1052 shape, unchanged) or an ITERATOR that produces entries
+        as they become ready. Pulling from an iterator runs the PRODUCER's
+        own work on this thread — on the overlapped mint path that is a
+        ``torch.export`` of the next declared row — while the children keep
+        compiling in their own processes. That single sentence is the whole
+        of pgw#1052: the phases were sequential by code, not by necessity.
+        The iterator contract is deliberately narrow — ``(name, program)``
+        pairs, staged internally — so a later producer that ships structure
+        instead of a full program (pgw#1056's fake-weight mint) changes
+        ``_stage``, not this orchestration. ``expected_total`` is the
+        producer's best count for progress reporting; the ledger records the
+        REAL count once the source is exhausted.
+
         ``on_entry(name, done, total)`` (pgw#824) fires as each entry lands.
         This loop is the longest wire-silent stretch of a mint — an 18-entry
         sdxl cell spends the bulk of its wall clock right here — and until now
@@ -1451,8 +1511,6 @@ class EntryCompilePool:
         reporting is best-effort by construction: a raising callback must never
         cost the mint the entries it already has.
         """
-        pending: List[Tuple[int, str, Any]] = [
-            (i, name, prog) for i, (name, prog) in enumerate(entries)]
         staged: List[Tuple[EntryJob, Path]] = []
         running: List[_Running] = []
         done: Dict[str, List[str]] = {}
@@ -1461,18 +1519,47 @@ class EntryCompilePool:
         # for one would idle a core through every round; one spare removes
         # that without turning an 18-entry sdxl cell into ~46 GB on disk.
         failure: Optional[EntryCompileFailed] = None
+        # pgw#832: seed BEFORE the pool wall starts, so the cost is its own
+        # named line (`seal_seed_s`) and never inside the capacity identity.
+        self._seed_seal_memo()
+        streamed = not isinstance(entries, (list, tuple))
+        if streamed:
+            source: Iterator[Tuple[str, Any]] = iter(entries)
+            total = max(0, int(expected_total))
+            pulled = 0
+        else:
+            pending = [(i, name, prog)
+                       for i, (name, prog) in enumerate(entries)]
+            total = len(pending)
+            self.ledger.entries = total
+            # pgw#848 item 5: admission BEFORE the wall on the sequence path.
+            # It is parent-serial and occupies no worker slot, so charging it
+            # to the pool's capacity would price a recovered 626 s entry as
+            # pool idle. (The streamed path admits per pull instead — the
+            # entry does not exist before the pull, and the pull is already
+            # inside the wall by construction.)
+            pending = self._admit_banked(pending, done, on_entry, total)
+            source = iter([(name, prog) for _i, name, prog in pending])
+            pulled = total - len(pending)
+        exhausted = False
+
+        def _known_total() -> int:
+            if not streamed:
+                return total
+            return pulled if exhausted else max(total, pulled)
+
+        def _cb(name: str) -> None:
+            if on_entry is not None:
+                try:
+                    on_entry(name, len(done), _known_total())
+                except Exception:  # noqa: BLE001 — telemetry never fails a mint
+                    logger.debug(
+                        "entry-pool progress callback failed", exc_info=True)
+
         # pgw#830: exact idle accounting. Every wall second is multiplied by
         # the number of FREE worker slots at that moment and charged to
         # whatever the parent was doing — so `pool_idle_s` is not a residual
         # anybody has to trust, it is a sum with named causes.
-        self.ledger.entries = len(entries)
-        # pgw#832: seed BEFORE the pool wall starts, so the cost is its own
-        # named line (`seal_seed_s`) and never inside the capacity identity.
-        self._seed_seal_memo()
-        # pgw#848 item 5: likewise BEFORE the wall. Admission is parent-serial
-        # and occupies no worker slot, so charging it to the pool's capacity
-        # would price a recovered 626 s entry as pool idle.
-        pending = self._admit_banked(pending, done, on_entry, len(entries))
         pool_t0 = mark = time.monotonic()
 
         def charge(bucket: str, free: int) -> None:
@@ -1492,35 +1579,68 @@ class EntryCompilePool:
             mark = now
 
         try:
-            while pending or staged or running:
+            while True:
                 # Re-read every round: `_rewiden` can widen K after an entry
                 # lands, and a staging cap frozen at the construction width
                 # would starve the slots it just opened.
                 staged_cap = max(1, self.width.workers + INFLIGHT_PROGRAM_SLACK)
-                while (pending and not failure
-                       and len(staged) + len(running) < staged_cap):
-                    index, name, program = pending.pop(0)
-                    free = self.width.workers - len(running)
-                    staged.append(self._stage(name, program, index))
-                    # The freed slot waits for the NEXT program to be written
-                    # before it can be refilled: export-vs-compile
-                    # serialization, charged where it happens.
-                    charge("idle_staging_s", free)
+                # SPAWN first: a freed slot takes already-staged work before
+                # the parent disappears into a source pull that, on the
+                # overlapped path, can be minutes of export.
                 while staged and not failure \
-                        and len(running) < self.width.workers:
+                        and len(running) < self.width.workers \
+                        and self._spawn_admitted(len(running)):
                     job, job_path = staged.pop(0)
                     free = self.width.workers - len(running)
                     running.append(
                         self._spawn(job, job_path, Path(job.program)))
                     charge("idle_spawn_s", free)
+                # PULL one entry when there is stage room. The pull IS the
+                # producer's work (pgw#1052); the fresh program spawns at the
+                # top of the next iteration.
+                if not exhausted and not failure \
+                        and len(staged) + len(running) < staged_cap:
+                    free = self.width.workers - len(running)
+                    try:
+                        name, program = next(source)
+                    except StopIteration:
+                        exhausted = True
+                        self.ledger.entries = pulled
+                        charge("idle_source_s", free)
+                        continue
+                    charge("idle_source_s", free)
+                    pulled += 1
+                    if streamed:
+                        self.ledger.entries = pulled
+                        if self.bank is not None:
+                            # pgw#848 item 5 on the streamed path: per-pull
+                            # admission, same order-of-operations safety (the
+                            # graph hash is re-derived from THIS export).
+                            admission = self.bank.admit(name, program)
+                            if admission.ok:
+                                done[name] = list(admission.files)
+                                self._refresh_resume_facts()
+                                _cb(name)
+                                continue
+                    free = self.width.workers - len(running)
+                    staged.append(self._stage(name, program, pulled - 1))
+                    # The freed slot waits for the NEXT program to be written
+                    # before it can be refilled: export-vs-compile
+                    # serialization, charged where it happens.
+                    charge("idle_staging_s", free)
+                    continue
                 if not running:
-                    break
+                    if failure is not None or (exhausted and not staged):
+                        break
+                    continue
                 free = self.width.workers - len(running)
                 # Nothing left to start: the free slots are the straggler
                 # tail, which is a SCHEDULING loss and not a compile cost.
                 # pgw#829's entry collapse moves this number; nothing about
-                # the compiler does.
-                bucket = "idle_drain_s" if not (pending or staged) \
+                # the compiler does. A slot held by the LIVE simultaneity
+                # bound (`_spawn_admitted`) lands in `idle_other_s` with the
+                # holding terms recorded on `simultaneity`.
+                bucket = "idle_drain_s" if exhausted and not staged \
                     else "idle_other_s"
                 finished = self._reap(running)
                 if finished is None:
@@ -1538,12 +1658,7 @@ class EntryCompilePool:
                 # (`_collect` -> `observe_entry_device`). Ask K again with the
                 # measurement in place of the estimate the pool was built on.
                 self._rewiden()
-                if on_entry is not None:
-                    try:
-                        on_entry(finished.entry, len(done), len(entries))
-                    except Exception:  # noqa: BLE001 — telemetry never fails a mint
-                        logger.debug(
-                            "entry-pool progress callback failed", exc_info=True)
+                _cb(finished.entry)
                 # Collection (report read, program unlink) and pgw#824's
                 # progress callback both run with the slot ALREADY FREE, so
                 # they are charged as idle rather than left outside the split
@@ -1816,8 +1931,16 @@ class EntryCompilePool:
         if not self.census.readable or ask <= 0:
             terms["simultaneity_verdict"] = "unreadable — no widen"
             return None, terms
-        own_peak = max(
-            own_device_high_water(), int(self.census.own_reserved_bytes))
+        # pgw#1053: the floor is `_own_floor_bytes`, not the construction
+        # census verbatim — identical until `note_residents_released`
+        # re-baselines it, which the caller may only do after a real release
+        # plus `reset_peak_memory_stats` (so the high-water restarts from the
+        # released level rather than remembering the pipeline).
+        own_peak = max(own_device_high_water(), int(self._own_floor_bytes))
+        if self._free_gain_bytes > 0:
+            # pgw#1053: the release rides every later decision row — a widen
+            # or a hold after it must say the budget it ran against moved.
+            terms["residents_released_bytes"] = int(self._free_gain_bytes)
         reserve = DEVICE_RESERVE_BYTES \
             if WorkerGoals(serve=self.width.serve_goal,
                            mint=self.width.mint_goal).tenant_reserve_applies() \
@@ -1883,7 +2006,76 @@ class EntryCompilePool:
             reason=(f"K={capped} (simultaneity-bound): {self.width.reason} — "
                     f"narrowed to what the card holds at once"))
 
-    def _rewiden(self) -> None:
+    def note_residents_released(self) -> None:
+        """pgw#1053: the mint parent PROVABLY handed its residents back.
+
+        Called by the mint after the last row exports, once it has dropped its
+        pipeline and the retained programs' weight aliases, run
+        ``empty_cache()`` AND ``reset_peak_memory_stats()`` — the reset is
+        load-bearing: it is what lets ``own_device_high_water`` restart from
+        the released level instead of remembering the pipeline forever.
+
+        Two things happen, both measured rather than asserted:
+
+        * the OWN floor of the simultaneity budget re-baselines to what this
+          process holds NOW (the delta is exactly what the driver got back);
+        * K is re-derived through the SAME pgw#992-bounded path a measured
+          entry peak takes — with the construction ask when fewer than
+          :data:`REWIDEN_MIN_SAMPLES` children have reported, because the
+          release moved the BUDGET, not the divisor, and holding a freed card
+          at the resident-priced K would be pgw#842's underwidth defect with a
+          receipt attached.
+
+        A no-op on a cardless pool (nothing was priced off a card) and after a
+        release that freed nothing (the floor only ever re-baselines DOWN).
+        """
+        if not self.census.readable:
+            return
+        now = own_reserved_now()
+        if now < 0:
+            return
+        freed = max(0, int(self._own_floor_bytes) - now)
+        if freed <= 0:
+            return
+        self._own_floor_bytes = now
+        self._free_gain_bytes += freed
+        logger.info(
+            "aot-pool: pgw#1053 residents released %.2f GiB back to the "
+            "simultaneity budget (own floor %.2f GiB)",
+            freed / 1024**3, now / 1024**3)
+        self._rewiden(trigger="release")
+
+    def _spawn_admitted(self, running_count: int) -> bool:
+        """May a (``running_count + 1``)-th child exist on this card NOW?
+
+        pgw#992 continued under pgw#1052. The construction-time simultaneity
+        bound prices the residents as they stood when the pool was BUILT — and
+        the overlapped mint builds the pool before the export phase, whose own
+        device growth (measured 9.0 -> 15.6 GiB reserved across a 36-row sdxl
+        export) arrives after that reading. This re-asks the SAME budget with
+        the live own high-water before every spawn: a spawn the budget cannot
+        hold WAITS — for a sibling to exit, or for the pgw#1053 release to
+        grow the budget — instead of being priced against a reading it
+        postdates. Nothing narrows and nothing is killed; a spawn is deferred
+        to a boundary the card admits. Floor 1: the serial path must always
+        be reachable or the pool deadlocks against its own bound.
+        """
+        if running_count <= 0:
+            return True
+        ask = int(self.width.per_entry_device_bytes or 0)
+        if ask <= 0 or not self.census.readable:
+            return True
+        budget, terms = self.entry_budget_bytes(ask)
+        if budget is None:
+            return True
+        k_cap = max(1, int(terms["simultaneity_k_cap"]))
+        if running_count < k_cap:
+            return True
+        terms["simultaneity_spawn_held_at"] = int(running_count)
+        self.simultaneity = terms
+        return False
+
+    def _rewiden(self, *, trigger: str = "measured") -> None:
         """Re-derive K from what the entry children MEASURED (pgw#868 A4),
         bounded by what the CARD can hold at once (pgw#992).
 
@@ -1929,10 +2121,19 @@ class EntryCompilePool:
         or the traced graph — the device lock already serializes the one thing
         that is shared (``benchmark_all_configs``) — so this is a PROCESS
         change under pgw#846's rule, and the emitted files are untouched.
+
+        ``trigger="release"`` (pgw#1053) is the residents-release re-ask: the
+        budget's own term just shrank by a MEASURED amount, so the same
+        derivation runs even before :data:`REWIDEN_MIN_SAMPLES` children have
+        reported — the divisor then stays the CONSTRUCTION ask on the
+        construction basis (never a new guess), and only the budget moved.
         """
-        if self.device_samples < REWIDEN_MIN_SAMPLES:
+        released = trigger == "release"
+        if not self.width.device_lock:
             return
-        if self.peak_device_bytes <= 0 or not self.width.device_lock:
+        measured = (self.device_samples >= REWIDEN_MIN_SAMPLES
+                    and self.peak_device_bytes > 0)
+        if not measured and not released:
             return
         base = self.width_initial
         if base.free_device_bytes <= 0:
@@ -1941,7 +2142,12 @@ class EntryCompilePool:
             # free figure here is the guess this method exists to delete.
             return
         try:
-            ask = mint_budget.entry_device_ask(int(self.peak_device_bytes))
+            if measured:
+                ask = mint_budget.entry_device_ask(int(self.peak_device_bytes))
+                basis = "measured"
+            else:
+                ask = int(base.per_entry_device_bytes or 0)
+                basis = base.per_entry_device_basis
             if ask <= 0:
                 return
             # pgw#992: the cap comes FIRST and is recorded whether or not the
@@ -1960,8 +2166,13 @@ class EntryCompilePool:
                 base.entries,
                 limit=base.limit,
                 device_bytes=ask,
-                device_basis="measured",
-                free_vram_bytes=int(base.free_device_bytes),
+                device_basis=basis,
+                # pgw#1053: the construction reading plus what the release
+                # measurably returned — never a re-probe of a card K running
+                # children are sitting on (their footprints would read as
+                # absent capacity).
+                free_vram_bytes=int(
+                    base.free_device_bytes + self._free_gain_bytes),
                 available_bytes=int(base.available_bytes),
                 vcpus=int(base.vcpus),
                 peak_rss_bytes=int(self.peak_rss_bytes or 0),
@@ -1996,16 +2207,18 @@ class EntryCompilePool:
             return
         wider = replace(wider, workers=granted)
         logger.info(
-            "aot-pool: pgw#868 A4 K %d -> %d — per-entry device ask measured "
-            "at %.2f GiB over %d entr%s against the %.2f GiB (%s) the pool "
-            "was sized with, within a %.2f GiB simultaneous budget (pgw#992)",
-            self.width.workers, wider.workers, ask / 1024**3,
-            self.device_samples, "y" if self.device_samples == 1 else "ies",
+            "aot-pool: K %d -> %d (%s) — per-entry device ask %.2f GiB (%s, "
+            "%d report(s)) against the %.2f GiB (%s) the pool was sized "
+            "with, within a %.2f GiB simultaneous budget (pgw#992/pgw#1053)",
+            self.width.workers, wider.workers, trigger, ask / 1024**3,
+            basis, self.device_samples,
             base.per_entry_device_bytes / 1024**3,
             base.per_entry_device_basis, budget / 1024**3)
         self.width = wider
         self.ledger.workers = wider.workers
-        self._emit_width("re-derived from measured entry peaks")
+        self._emit_width(
+            "re-derived from measured entry peaks" if trigger == "measured"
+            else "re-derived after residents release (pgw#1053)")
 
     def _collect(self, row: _Running) -> List[str]:
         elapsed = time.monotonic() - row.started

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -97,7 +97,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import (
-    Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple)
+    Any, Callable, Dict, Generator, Iterator, List, Mapping, Optional,
+    Sequence, Tuple)
 
 from . import activity as activity_mod
 from . import (
@@ -1486,8 +1487,17 @@ def mint(
     on_progress: Optional[Callable[[str, int, int, str], None]] = None,
     phase_snapshot: Optional[Path] = None,
     execution_lane_verdict: Optional[kernel_path.Verdict] = None,
+    release_residents: bool = False,
 ) -> MintResult:
     """:func:`_mint_cell`, with the phase table attached to EVERY terminus.
+
+    ``release_residents`` (pgw#1053) is the CALLER's statement that it has no
+    further use for ``pipeline`` after the last row exports — the mint then
+    projects the pipeline and the retained programs to code-only and hands
+    the device memory back to the compile pool's budget. The mint child and
+    the operator CLI say True (their pipeline dies with the process); library
+    callers and tests that keep using the pipeline afterwards default False.
+    A lifecycle fact stated by the owner, not a tuning knob.
 
     pgw#825: an aborted mint used to report a wall-clock total and nothing
     else — `compile_s`, `export_s` and `n_entries` all parsed to `-` — so a
@@ -1544,6 +1554,7 @@ def mint(
             entry_peak_rss_bytes=entry_peak_rss_bytes,
             entry_device_peak_bytes=entry_device_peak_bytes,
             execution_lane_verdict=execution_lane_verdict,
+            release_residents=release_residents,
             progress=progress)
     except BaseException as exc:
         _attach_partial_phases(exc, progress)
@@ -1833,6 +1844,7 @@ def _mint_cell(
     entry_peak_rss_bytes: int = 0,
     entry_device_peak_bytes: int = 0,
     execution_lane_verdict: Optional[kernel_path.Verdict] = None,
+    release_residents: bool = False,
     progress: Optional[MintProgress] = None,
 ) -> MintResult:
     """Export + compile EVERY declared graph class and pack them as ONE
@@ -1935,7 +1947,6 @@ def _mint_cell(
     progress.width = width
 
     minted = progress.minted
-    disarmed = False
     # pgw#822: the adapter-BEARING classes are exported from the lifted
     # forward. Arming it is this function's job, not the caller's — see
     # `_arm_branches`.
@@ -1951,6 +1962,9 @@ def _mint_cell(
     # terms are INDUCTOR'S, and ~56 % of which was never observed — does not
     # describe it. A probe: it reads and clears a counter and decides
     # nothing (pgw#830 — instrument first, optimise never in the same change).
+    # Still honest under pgw#1052's overlap: the compile children are separate
+    # OS processes, so their device use never lands in THIS allocator's
+    # counters — the export figures stay the export's.
     try:
         import torch as _t
         if _t.cuda.is_available():
@@ -1965,49 +1979,44 @@ def _mint_cell(
     progress.beat(
         PHASE_TRACE_GRAPH, 0, len(rows),
         f"{len(rows)} declared class row(s)")
-    try:
-        for index, (plan, arm) in enumerate(rows, start=1):
-            if arm is False and not disarmed:
-                # ONE toggle for the whole branchless group (the rows are
-                # ordered adapter-bearing first): disable/enable reallocates
-                # every leaf's branch container, and doing it per entry would
-                # be N times the VRAM churn for the same graphs.
-                _disarm_branches(pipeline)
-                disarmed = True
-            # Reported BEFORE the work, not after: a row that never returns
-            # is the one a reader most needs named, and an after-the-fact tick
-            # names only the rows that finished.
-            progress.beat(
-                PHASE_TRACE_GRAPH, index, len(rows),
-                _decl.plan_entry_name(plan))
-            with export_footprint.row():
-                minted.append(_export_entry(
-                    pipeline, spec, plan, decl,
-                    inductor_configs=inductor_configs,
-                    compile_now=not parallel))
-    finally:
-        if disarmed:
-            _arm_branches(pipeline, int(spec.lora_bucket or 0))
-    # Asked of the EXPORTED programs: a cell whose entries cannot be told
-    # apart at dispatch must cost seconds to refuse, not a full compile bill
-    # (the pgw#825 discipline, one gate over). Exact on the parallel path,
-    # which is every real mint — pgw#809 sizes width off the pod's own budget
-    # and the pool has not built a kernel yet. A width-1 serial mint has
-    # already compiled as it exported, so there it refuses late; correct
-    # either way, cheap where it matters.
-    #
-    # pgw#917: and it MERGES before it refuses. Declared rows that reduce to
-    # one ingress contract over one target with byte-identical code are one
-    # dispatchable class — compiling each of them separately buys nothing and
-    # makes the cell undispatchable, which is the same fact twice.
-    minted, class_aliases = canonicalize_dispatch_classes(minted)
-    timings["canonicalized_entries"] = float(
-        sum(len(rows) for rows in class_aliases.values()))
 
-    if parallel:
+    def _rows_source() -> Iterator[_MintedEntry]:
+        """Export every declared row IN ORDER — serial, in this process,
+        inside the one branch-arm toggle (pgw#790). One body for the serial
+        and the overlapped paths: pgw#1052 changes the HANDOFF time of each
+        exported row, never the export order or its gates."""
+        disarmed = False
+        try:
+            for index, (plan, arm) in enumerate(rows, start=1):
+                if arm is False and not disarmed:
+                    # ONE toggle for the whole branchless group (the rows are
+                    # ordered adapter-bearing first): disable/enable
+                    # reallocates every leaf's branch container, and doing it
+                    # per entry would be N times the VRAM churn for the same
+                    # graphs.
+                    _disarm_branches(pipeline)
+                    disarmed = True
+                # Reported BEFORE the work, not after: a row that never
+                # returns is the one a reader most needs named, and an
+                # after-the-fact tick names only the rows that finished.
+                progress.beat(
+                    PHASE_TRACE_GRAPH, index, len(rows),
+                    _decl.plan_entry_name(plan))
+                with export_footprint.row():
+                    entry = _export_entry(
+                        pipeline, spec, plan, decl,
+                        inductor_configs=inductor_configs,
+                        compile_now=not parallel)
+                minted.append(entry)
+                yield entry
+        finally:
+            if disarmed:
+                _arm_branches(pipeline, int(spec.lora_bucket or 0))
+
+    def _close_export_phase() -> None:
         timings["export_all_s"] = round(time.monotonic() - t_export, 2)
-        # Sampled BEFORE the pool is built, so no inductor allocation can be
-        # attributed to export. Reported even when zero (no CUDA / probe
+        # Sampled the moment the LAST row exports — before pgw#1053's release
+        # can reset the counters. Reported even when zero (no CUDA / probe
         # failed), because a missing key and a measured zero are different
         # facts and the width rule must be able to tell them apart.
         try:
@@ -2024,24 +2033,95 @@ def _mint_cell(
         # sizes a pool — and the width rule spent its whole life dividing by
         # the first one, which is why it always answered 1.
         timings.update(export_footprint.facts())
-        # pgw#1030: `aot_export_parallel.decide(...)` was recorded here —
-        # six floats describing the width a PARALLEL export would have run
-        # at. Export is unconditionally serial (the loop above), nothing
-        # ever consumed the decision, and the module duplicated the compile
-        # pool's card-budget logic. Deleted with the module.
+
+    if parallel:
+        # pgw#1052: the pool exists BEFORE the first row exports, and each row
+        # is handed to it AS IT EXPORTS — producer ~113 s/row against a pool
+        # consuming ~127 s/row at K=2 (attempt 30), so the two phases shadow
+        # each other and the wall collapses toward max(export, compile).
+        # The census inside the pool is still taken before any child exists
+        # (pgw#992's requirement); the export phase's own growth after that
+        # reading is priced per spawn by `_spawn_admitted`.
+        #
+        # pgw#917 runs TWICE, deliberately: an arriving row that duplicates an
+        # earlier row's ingress+identity is aliased at arrival (no compile
+        # spent, and a same-ingress DIFFERENT-identity collision refuses at
+        # row N — bounded waste on the refusal path buys the overlap on every
+        # green mint); the original batch gate re-runs over the kept rows at
+        # drain as the safety net for clusters only visible transitively.
+        arrival = _ArrivalCanon()
+        arrival_aliases: Dict[str, List[_MintedEntry]] = {}
+        kept: List[_MintedEntry] = []
+
+        pool = aot_compile_pool.EntryCompilePool(
+            # A SIBLING of work/, never inside it — see the note on
+            # `_compile_entries_parallel`.
+            work.parent / "entry-pool", width=width,
+            inductor_configs=inductor_configs)
+        t_pool = time.monotonic()
+
+        def _feed() -> "Generator[Tuple[str, Any], None, None]":
+            for entry in _rows_source():
+                keeper = arrival.admit(entry)
+                if keeper is not None:
+                    arrival_aliases.setdefault(keeper.name, []).append(entry)
+                    continue
+                kept.append(entry)
+                yield entry.name, entry.program
+            # The producer is exhausted: close the export phase's books, then
+            # — when the caller surrendered the pipeline — hand the dead
+            # residents back and let the pool re-derive K against the freed
+            # budget (pgw#1053).
+            _close_export_phase()
+            if release_residents:
+                t0 = time.monotonic()
+                timings.update(_release_mint_residents(pipeline, minted))
+                timings["residents_release_s"] = round(
+                    time.monotonic() - t0, 2)
+                pool.note_residents_released()
+
         progress.beat(
-            PHASE_INDUCTOR_COMPILE, 0, len(minted),
-            f"{len(minted)} entries, {width.workers} wide")
-        progress.pool_ledger = _compile_entries_parallel(
-            minted, work, width, inductor_configs=inductor_configs,
-            progress=progress,
-            on_entry=lambda name, done, total: progress.beat(
-                PHASE_INDUCTOR_COMPILE, done, total, name))
-        # NOTE: `_compile_entries_parallel` refreshes `progress.pool_ledger`
-        # on every completed entry (pgw#848), so the snapshot each beat writes
-        # already carries a LIVE ledger — K, its binding, efficiency, peaks —
-        # rather than only the width. An abandoned mint's row is the one that
-        # needs it most.
+            PHASE_INDUCTOR_COMPILE, 0, len(rows),
+            f"pool up front, {width.workers} wide — overlapped with export "
+            f"(pgw#1052)")
+        source = _feed()
+        try:
+            by_entry = _drive_pool(
+                pool, source, expected_total=len(rows), progress=progress,
+                on_entry=lambda name, done, total: progress.beat(
+                    PHASE_INDUCTOR_COMPILE, done, total, name))
+        finally:
+            source.close()
+        # NOTE: `_drive_pool` refreshes `progress.pool_ledger` on every
+        # completed entry (pgw#848), so the snapshot each beat writes already
+        # carries a LIVE ledger — K, its binding, efficiency, peaks — rather
+        # than only the width. An abandoned mint's row is the one that needs
+        # it most.
+        minted, late_aliases = canonicalize_dispatch_classes(kept)
+        class_aliases = _merge_alias_maps(arrival_aliases, late_aliases)
+        if arrival_aliases:
+            _emit_arrival_alias_event(arrival_aliases, len(rows))
+        _fold_pool_results(minted, pool, by_entry)
+        logger.info(
+            "aot-mint: pgw#809/pgw#1052 pool compiled %d entr%s at K=%d in "
+            "%.0fs overlapped with export (sum of entry seconds %.0fs, peak "
+            "child RSS %.1f GiB)",
+            len(minted), "y" if len(minted) == 1 else "ies",
+            pool.width.workers, time.monotonic() - t_pool,
+            sum(pool.entry_seconds.values()), pool.peak_rss_bytes / 1024**3)
+        progress.pool_ledger = _pool_facts(pool)
+    else:
+        for _entry in _rows_source():
+            pass
+        # Asked of the EXPORTED programs: a cell whose entries cannot be told
+        # apart at dispatch must cost seconds to refuse, not a full compile
+        # bill (the pgw#825 discipline, one gate over). A width-1 serial mint
+        # has already compiled as it exported, so here it refuses late;
+        # correct either way — the parallel path refuses at ARRIVAL
+        # (pgw#1052), which is where it matters.
+        minted, class_aliases = canonicalize_dispatch_classes(minted)
+    timings["canonicalized_entries"] = float(
+        sum(len(rows) for rows in class_aliases.values()))
     timings["entry_workers"] = float(width.workers)
 
     t0 = time.monotonic()
@@ -2180,36 +2260,20 @@ def _entry_device_bytes(
     return int(budget.need_bytes), "estimated"
 
 
-def _compile_entries_parallel(
-    minted: List[_MintedEntry],
-    work: Path,
-    width: aot_compile_pool.PoolWidth,
+def _drive_pool(
+    pool: aot_compile_pool.EntryCompilePool,
+    entries: Any,
     *,
-    inductor_configs: Optional[Mapping[str, Any]] = None,
+    expected_total: int = 0,
     on_entry: Optional[Callable[[str, int, int], None]] = None,
     progress: Optional["MintProgress"] = None,
-) -> Dict[str, Any]:
-    """pgw#809: fill every entry's ``files`` K-wide, out of process.
+) -> Dict[str, List[str]]:
+    """Run one :class:`~gen_worker.aot_compile_pool.EntryCompilePool` and map
+    its failures onto the mint's own vocabulary.
 
-    Returns the pool's own ledger (pgw#830) so it reaches the phase table:
-    the pool emits it as a typed event too, but that emission happens in the
-    mint CHILD, which holds no orchestrator session — pgw#842.
-
-    Mutates ``minted`` in place, and every entry MUST come back with files —
-    a pool that quietly returned fewer entries than it was given would pack a
-    short cell. Assembly is by entry NAME: ``package_cell`` reads
-    ``{row.name: row.files}`` in the order ``minted`` already holds (the
-    declaration's order), so completion order is not observable in the
-    artifact.
+    ``entries`` is either the fully-exported list (the serial-export shape the
+    pgw#848 tests drive) or pgw#1052's live producer iterator.
     """
-    # A SIBLING of work/, never inside it. pack() only copies a fixed member
-    # set so debris there would be harmless today, but a pool workdir living
-    # inside the directory that becomes the artifact is one refactor away from
-    # putting job files and stderr tails into a cell.
-    pool = aot_compile_pool.EntryCompilePool(
-        work.parent / "entry-pool", width=width,
-        inductor_configs=inductor_configs)
-    t0 = time.monotonic()
 
     def _tick(name: str, done: int, total: int) -> None:
         # pgw#848: refresh the ledger BEFORE the beat, so the snapshot the
@@ -2222,8 +2286,8 @@ def _compile_entries_parallel(
             on_entry(name, done, total)
 
     try:
-        by_entry = pool.compile(
-            [(row.name, row.program) for row in minted], on_entry=_tick)
+        return pool.compile(
+            entries, on_entry=_tick, expected_total=expected_total)
     except aot_compile_pool.EntryCompileFailed as exc:
         # pgw#848: the pool's ledger and its MEASURED peak have to survive the
         # failure, because the aborted phase table is what the parent banks
@@ -2239,7 +2303,23 @@ def _compile_entries_parallel(
                 str(exc), entry=exc.entry, basis=exc.basis,
                 peak_rss_bytes=exc.peak_rss_bytes) from exc
         raise MintRefused(str(exc)) from exc
-    wall = time.monotonic() - t0
+
+
+def _fold_pool_results(
+    minted: Sequence[_MintedEntry],
+    pool: aot_compile_pool.EntryCompilePool,
+    by_entry: Mapping[str, List[str]],
+) -> None:
+    """Fold the pool's results back onto the entries that will PACK.
+
+    Every packed entry MUST have files — a pool that quietly returned fewer
+    entries than the cell declares would pack a short cell. Assembly is by
+    entry NAME: ``package_cell`` reads ``{row.name: row.files}`` in the order
+    ``minted`` already holds (the declaration's order), so completion order is
+    not observable in the artifact. An entry the drain-time pgw#917 pass
+    merged away may have compiled files nobody folds; its work is the bounded
+    waste pgw#1052 states, never a packing input.
+    """
     missing = [row.name for row in minted if row.name not in by_entry]
     if missing:
         raise MintRefused(
@@ -2263,6 +2343,36 @@ def _compile_entries_parallel(
         overlays = pool.entry_overlays.get(row.name) or {}
         if overlays:
             row.timings["overlays"] = dict(overlays)
+
+
+def _compile_entries_parallel(
+    minted: List[_MintedEntry],
+    work: Path,
+    width: aot_compile_pool.PoolWidth,
+    *,
+    inductor_configs: Optional[Mapping[str, Any]] = None,
+    on_entry: Optional[Callable[[str, int, int], None]] = None,
+    progress: Optional["MintProgress"] = None,
+) -> Dict[str, Any]:
+    """pgw#809: fill every entry's ``files`` K-wide, out of process — the
+    already-exported-list shape. The production mint overlaps export with the
+    pool instead (pgw#1052, in ``_mint_cell``); this survives as the driver
+    for a pre-exported entry set and returns the pool's own ledger (pgw#830)
+    so it reaches the phase table.
+    """
+    # A SIBLING of work/, never inside it. pack() only copies a fixed member
+    # set so debris there would be harmless today, but a pool workdir living
+    # inside the directory that becomes the artifact is one refactor away from
+    # putting job files and stderr tails into a cell.
+    pool = aot_compile_pool.EntryCompilePool(
+        work.parent / "entry-pool", width=width,
+        inductor_configs=inductor_configs)
+    t0 = time.monotonic()
+    by_entry = _drive_pool(
+        pool, [(row.name, row.program) for row in minted],
+        on_entry=on_entry, progress=progress)
+    wall = time.monotonic() - t0
+    _fold_pool_results(minted, pool, by_entry)
     logger.info(
         "aot-mint: pgw#809 pool compiled %d entr%s at K=%d in %.0fs "
         "(sum of entry seconds %.0fs, peak child RSS %.1f GiB)",
@@ -2553,6 +2663,241 @@ def canonicalize_dispatch_classes(
             phase="entry_merged",
         )
     return [row for row in minted if row.name not in dropped], aliases
+
+
+class _ArrivalCanon:
+    """pgw#917's merge-or-refuse decision, taken when the entry ARRIVES.
+
+    pgw#1052 overlaps export with the compile pool, so the batch gate's
+    moment — "after the last export, before the first compile" — no longer
+    exists. The decision moves to arrival: a row that duplicates an earlier
+    kept row's ingress contract AND identity is aliased onto it (no compile is
+    ever spent on it), and a same-ingress DIFFERENT-identity collision refuses
+    at row N — bounded waste on the refusal path (at most N-1 compiles, on a
+    mint that was going to refuse anyway) buys the 65-minute overlap on every
+    green mint. That trade is pgw#1052's, stated here and in its tracker row.
+
+    Deliberately NOT a replacement for :func:`canonicalize_dispatch_classes`:
+    the batch gate re-runs over the kept rows at drain as the safety net for
+    the one shape this incremental view cannot see — a cluster whose members
+    admit each other only TRANSITIVELY through a later row. Its survivor is
+    then chosen exactly as before; an arrival alias's survivor is the row that
+    arrived first, which for every family measured (sdxl's area-preserving
+    aspect rows all mutually admit directly) is the same cluster either way.
+    """
+
+    def __init__(self) -> None:
+        self._kept: Dict[Tuple[str, Any], List[
+            Tuple[_MintedEntry, Any, Tuple[Dict[str, Any], ...],
+                  Dict[str, Any]]]] = {}
+
+    def admit(self, row: _MintedEntry) -> Optional[_MintedEntry]:
+        """The kept sibling ``row`` aliases onto, or ``None`` (compile it).
+
+        Raises :class:`MintRefused` on a same-ingress different-identity
+        collision, naming the pair and the differing axes (pgw#917's
+        sentence, at arrival time).
+        """
+        fork = {str(n): v for n, v in tuple(row.spec.fork)}
+        group = (str(row.spec.target), fork.get(ADAPTER_FORK))
+        try:
+            contract, calls, meta = _entry_ingress_declaration(row)
+        except (aot_package.PackageIntrospectionError, ValueError) as exc:
+            # An unreadable declaration is not "probably fine": it is a cell
+            # whose dispatchability nobody can prove.
+            raise MintRefused(
+                f"entry {row.name!r}: dispatch-ambiguity gate cannot read "
+                f"the declared ingress contract, so this cell cannot be "
+                f"shown to be dispatchable at all: {exc}") from exc
+        for kept_row, kept_contract, kept_calls, kept_meta in \
+                self._kept.get(group, ()):
+            if not (any(_admits(kept_contract, call) for call in calls)
+                    or any(_admits(contract, call) for call in kept_calls)):
+                continue
+            identities = {
+                kept_row.name: _class_identity(kept_row, kept_meta),
+                row.name: _class_identity(row, meta),
+            }
+            axes = _differing_axes(identities)
+            if axes:
+                raise MintRefused(
+                    f"dispatch-ambiguity gate: {sorted(identities)!r} collide "
+                    f"at ingress but are NOT one class — they differ on "
+                    f"{list(axes)!r}, so every call they carry would be "
+                    f"refused 'entry_ambiguous' and served EAGER. Fix the "
+                    f"declaration so every entry's ingress contract is "
+                    f"uniquely admitting (pgw#917; refused at ARRIVAL under "
+                    f"pgw#1052 — the rows already exported are the bounded "
+                    f"waste that refusal costs)")
+            logger.info(
+                "aot-mint: pgw#917 declared class row %r aliased onto %r at "
+                "arrival — identical ingress contract, target and code, so "
+                "no compile is spent on it (pgw#1052)",
+                row.name, kept_row.name)
+            return kept_row
+        self._kept.setdefault(group, []).append((row, contract, calls, meta))
+        return None
+
+
+def _merge_alias_maps(
+    arrival: Mapping[str, List["_MintedEntry"]],
+    late: Mapping[str, Tuple["_MintedEntry", ...]],
+) -> Dict[str, Tuple["_MintedEntry", ...]]:
+    """One alias map out of the arrival-time and drain-time pgw#917 passes.
+
+    A drain-time merge can drop a keeper that itself collected arrival
+    aliases; those re-home onto the surviving entry so no declared class row
+    ever falls out of the envelope's ``aliases`` audit trail.
+    """
+    surviving_by_dropped = {
+        dropped.name: keep
+        for keep, dropped_rows in late.items() for dropped in dropped_rows}
+    merged: Dict[str, List["_MintedEntry"]] = {
+        keep: list(rows) for keep, rows in late.items()}
+    for keeper_name, rows in arrival.items():
+        home = surviving_by_dropped.get(keeper_name, keeper_name)
+        merged.setdefault(home, []).extend(rows)
+    return {keep: tuple(rows) for keep, rows in merged.items()}
+
+
+def _emit_arrival_alias_event(
+    arrival: Mapping[str, List["_MintedEntry"]], declared: int,
+) -> None:
+    """The pgw#917 canonicalization event for arrival-time merges — the batch
+    gate emits its own for drain-time ones, and both are telemetry."""
+    try:
+        dropped = sum(len(rows) for rows in arrival.values())
+        activity_mod.emit_event(
+            "aot_class_canonicalized",
+            f"{dropped} of {declared} declared class rows reduce to an "
+            f"ingress contract a sibling already declares; aliased AT ARRIVAL "
+            f"(pgw#1052) instead of compiling a class the dispatch could "
+            f"never select: "
+            + "; ".join(
+                f"{keep} <- {[r.name for r in rows]}"
+                for keep, rows in sorted(arrival.items())[:4]),
+            phase="entry_merged",
+        )
+    except Exception:  # pragma: no cover — telemetry never fails a mint
+        logger.debug("aot-mint: arrival alias event failed", exc_info=True)
+
+
+def _release_mint_residents(
+    pipeline: Any, minted: Sequence["_MintedEntry"],
+) -> Dict[str, float]:
+    """pgw#1053: hand the mint parent's dead residents back to the card.
+
+    From the moment the LAST row exports, neither the composed pipeline nor
+    the retained programs' weight aliases do anything for the rest of the mint
+    — measured at 16.2 GiB held through the entire 97-minute compile phase on
+    the L40S (attempt 30), which with the pgw#992 budget is most of what held
+    K at 2. This is the MINT PARENT'S OWN copy: the serving worker's eager
+    pipeline lives in a different process and is untouched here (its
+    forge-pod release is ``mint_delegate``'s, and a serving pod keeps eager
+    resident per Paul's ruling — GPU hot, eager minimally disrupted).
+
+    Projection, not deletion. Every retained ``ExportedProgram`` keeps its
+    graph, signature, placeholders and LITERAL values (a literal ships inside
+    the artifact and is keyed by VALUE — pgw#857), while its state_dict-
+    sourced constants — device aliases of the pipeline weights — become meta
+    tensors of the same shape and dtype. Every parent-side gate that still
+    runs (``program_package_drift``, ``unbindable_constants``,
+    ``input_contract``, ``entry_graph_block``, ``_write_literals``, the
+    drain-time pgw#917 pass) reads names, shapes and literal bytes only, so
+    NO gate is dropped; each runs against the code-only projection. The
+    compile children read the STAGED programs from disk, written before this
+    runs, byte for byte — nothing about the artifact can move (pgw#846).
+
+    Best-effort in every direction: a tensor or module that refuses the
+    projection is skipped, and the release reports what it actually freed. A
+    partially released card still widens by what came back. Superseded by
+    construction once pgw#1056's fake-weight mint lands (there is then no
+    resident to release); the pool-side regrant it feeds
+    (``note_residents_released``) is exactly what that mint's verification
+    load will use too.
+    """
+    facts: Dict[str, float] = {}
+    try:
+        import gc
+
+        import torch
+    except Exception:  # noqa: BLE001 — no torch, nothing resident
+        return facts
+    cuda = False
+    before = 0
+    try:
+        cuda = torch.cuda.is_available()
+        if cuda:
+            before = int(torch.cuda.memory_reserved())
+    except Exception:  # noqa: BLE001 — a probe never changes an outcome
+        cuda = False
+
+    def _meta(value: Any) -> Any:
+        try:
+            if isinstance(value, torch.Tensor) and value.device.type != "meta":
+                return value.to("meta")
+        except Exception:  # noqa: BLE001 — an unmovable tensor stays
+            pass
+        return value
+
+    for row in minted:
+        program = row.program
+        weights = set(aot_package.program_state_dict_fqns(program))
+        state = getattr(program, "state_dict", None)
+        if isinstance(state, dict):
+            for fqn in list(state):
+                state[fqn] = _meta(state[fqn])
+        constants = getattr(program, "constants", None)
+        if isinstance(constants, dict):
+            # Only the state_dict-sourced entries: everything else is a
+            # LITERAL whose bytes still have to reach `_write_literals`.
+            for fqn in list(constants):
+                if fqn in weights:
+                    constants[fqn] = _meta(constants[fqn])
+    modules: List[Any] = []
+    candidates: List[Any] = [pipeline]
+    try:
+        candidates.extend(vars(pipeline).values())
+    except TypeError:
+        pass
+    candidates.extend(row.owner for row in minted)
+    for obj in candidates:
+        if isinstance(obj, torch.nn.Module) \
+                and all(obj is not m for m in modules):
+            modules.append(obj)
+    refused = 0
+    for module in modules:
+        try:
+            module.to("meta")
+        except Exception:  # noqa: BLE001 — best effort, reported below
+            refused += 1
+            logger.debug(
+                "aot-mint: pgw#1053 module %s refused the meta projection; "
+                "its storage stays resident", type(module).__name__,
+                exc_info=True)
+    gc.collect()
+    facts["residents_release_modules"] = float(len(modules) - refused)
+    if cuda:
+        try:
+            torch.cuda.empty_cache()
+            after = int(torch.cuda.memory_reserved())
+            facts["residents_released_bytes"] = float(max(0, before - after))
+            # The TRUE mint peak, banked before the reset erases it: the
+            # parent's `record_child_peak` loop must keep learning what this
+            # process really held, not what it held after surrendering.
+            facts["peak_vram_before_release_bytes"] = float(
+                torch.cuda.max_memory_allocated())
+            # Load-bearing: the pool's own high-water must restart from the
+            # released level or `note_residents_released` can regrant nothing.
+            torch.cuda.reset_peak_memory_stats()
+        except Exception:  # noqa: BLE001 — a probe never changes an outcome
+            pass
+    logger.info(
+        "aot-mint: pgw#1053 mint residents released — %d module(s) projected "
+        "to meta, %.2f GiB handed back",
+        len(modules) - refused,
+        facts.get("residents_released_bytes", 0.0) / 1024**3)
+    return facts
 
 
 def _gate_and_declare_entry(
@@ -3327,7 +3672,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 3
     try:
         pipeline, _build_inputs = compose_for_mint(model, spec, body)
-        result = mint(pipeline, spec, Path(args.out))
+        # pgw#1053: an operator mint's pipeline is composed for the mint and
+        # dies with the process — surrender it once the last row exports.
+        result = mint(pipeline, spec, Path(args.out), release_residents=True)
     except MintRefused as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 2

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -2092,6 +2092,10 @@ def _mint_cell(
                     PHASE_INDUCTOR_COMPILE, done, total, name))
         finally:
             source.close()
+            # On EVERY terminus — a producer refusal at row N leaves the rows
+            # already compiled priced in the snapshot (pgw#848's discipline,
+            # extended to the overlapped shape).
+            progress.pool_ledger = _pool_facts(pool)
         # NOTE: `_drive_pool` refreshes `progress.pool_ledger` on every
         # completed entry (pgw#848), so the snapshot each beat writes already
         # carries a LIVE ledger — K, its binding, efficiency, peaks — rather

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -657,7 +657,11 @@ def _mint_aot(
             # pgw#947: the MEASURED serving-kernel lane for this card. The
             # discrete verdict lands in the packed envelope (serving reads it
             # instead of an SM tuple); the numbers ride the result metadata.
-            execution_lane_verdict=execution_lane_verdict)
+            execution_lane_verdict=execution_lane_verdict,
+            # pgw#1053: this process exits when the mint ends — its pipeline
+            # serves nobody after the last export, so surrender it and let
+            # the compile pool re-derive K against the freed card.
+            release_residents=True)
     except aot_mint.MintRefused as exc:
         # A named export refusal is a REFUSAL, not a crash: the parent must
         # not retry it, and the sentence is the whole diagnostic on a pod
@@ -675,7 +679,13 @@ def _mint_aot(
         os.replace(artifact, target)
     frame(phase="finalize", note=f"cell {result.cell_key}")
 
-    peak = _peak_vram()
+    # pgw#1053: the release resets the allocator's high-water so the pool can
+    # regrant K — the TRUE peak was banked into the timings first, and the
+    # report must carry it or `record_child_peak` learns the post-release
+    # residue instead of what the mint really held.
+    peak = max(
+        _peak_vram(),
+        int(result.timings.get("peak_vram_before_release_bytes", 0) or 0))
     return MintReport(
         status="minted",
         artifact=str(target),

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -390,188 +390,173 @@ async def build_cell(
 ) -> DelegatedResult:
     """Build and adopt one cell in a child process. Never raises for a mint
     failure — the worker must never die with its mint."""
-    device = (
-        task.device if task.device is not None
-        else mint_budget.device_of(task.pipe))
-    # pgw#1053: with no serve goal there is no tenant, and the eager pipeline
-    # is a 9.54 GiB co-tenant of its own mint. Parked BEFORE the first budget
-    # probe so `co_residency` prices the freed card; restored before ADOPT,
-    # which needs the real weights (and unconditionally on the way out, so
-    # this process is left as it was found whatever the outcome).
-    parked_ref: list = [maybe_park_eager(task.pipe)]
-    try:
-        return await _build_cell_attempts(
-            task, act=act, abandon=abandon, max_attempts=max_attempts,
-            device=device, parked_ref=parked_ref)
-    finally:
-        if parked_ref[0] is not None:
-            restore_eager_pipeline(parked_ref[0])
-            parked_ref[0] = None
-
-
-async def _build_cell_attempts(
-    task: MintTask,
-    *,
-    act: Any,
-    abandon: Any,
-    max_attempts: int,
-    device: Optional[int],
-    parked_ref: list,
-) -> DelegatedResult:
     from . import fleet_cells
 
     pending = task.pending
+    device = (
+        task.device if task.device is not None
+        else mint_budget.device_of(task.pipe))
     family = str(pending.family)
     attempts = 0
     budget: Optional[mint_budget.MintBudget] = None
     last = ""
+    # pgw#1053: with no serve goal there is no tenant, and the eager pipeline
+    # is a 9.54 GiB co-tenant of its own mint. Parked BEFORE the first budget
+    # probe so `co_residency` prices the freed card; restored before ADOPT,
+    # which needs the real weights (and unconditionally in the `finally`, so
+    # this process is left as it was found whatever the outcome).
+    parked = maybe_park_eager(task.pipe)
+    try:
+        while attempts < max(1, max_attempts):
+            attempts += 1
+            # Re-budget EVERY attempt. The first shortfall may have been the
+            # tenant's peak; the second may be a card that genuinely cannot hold a
+            # co-resident child, and that must decline rather than retry.
+            budget = mint_budget.co_residency(
+                device, family=family, weight_lane=task.weight_lane)
+            if not budget.fits:
+                reason = (
+                    "insufficient_vram" if attempts == 1
+                    else "insufficient_vram_after_retry")
+                detail = budget.line("self_mint_skipped", reason)
+                logger.info("mint-delegate: %s", detail)
+                activity_mod.emit_event("self_mint_skipped", detail, phase=reason)
+                return DelegatedResult(
+                    status=DECLINED, detail=detail, attempts=attempts,
+                    budget=budget)
 
-    while attempts < max(1, max_attempts):
-        attempts += 1
-        # Re-budget EVERY attempt. The first shortfall may have been the
-        # tenant's peak; the second may be a card that genuinely cannot hold a
-        # co-resident child, and that must decline rather than retry.
-        budget = mint_budget.co_residency(
-            device, family=family, weight_lane=task.weight_lane)
-        if not budget.fits:
-            reason = (
-                "insufficient_vram" if attempts == 1
-                else "insufficient_vram_after_retry")
-            detail = budget.line("self_mint_skipped", reason)
-            logger.info("mint-delegate: %s", detail)
-            activity_mod.emit_event("self_mint_skipped", detail, phase=reason)
-            return DelegatedResult(
-                status=DECLINED, detail=detail, attempts=attempts,
-                budget=budget)
+            workdir = Path(pending.mint_root) / f"child-{attempts}"
+            workdir.mkdir(parents=True, exist_ok=True)
+            request = build_request(
+                # pgw#848: the CEILING, not the estimate. `need_bytes` answers
+                # "should this start"; handing it to the child as a hard cap is
+                # what pinned two mints at 11.09 GiB on cards with 21.48 GiB free.
+                task, workdir=workdir, cap_bytes=budget.cap_bytes,
+                # pgw#848: whatever a previous mint on this pod measured one entry
+                # child to peak at. Read here rather than in the child because the
+                # child is the thing that dies.
+                entry_peak_rss_bytes=mint_budget.entry_peak_rss(
+                    family, task.weight_lane),
+                # pgw#877: and the DEVICE measurement, which until now had no way
+                # to reach the process that sizes K.
+                entry_device_peak_bytes=mint_budget.entry_device_peak(
+                    family, task.weight_lane))
+            act.phase(activity_mod.PHASE_LOAD)
+            outcome = await mint_process.run_mint(
+                request, workdir=workdir, on_frame=_on_frame(act),
+                on_evidence=_on_evidence(act), abandon=abandon)
+            last = outcome.detail
 
-        workdir = Path(pending.mint_root) / f"child-{attempts}"
-        workdir.mkdir(parents=True, exist_ok=True)
-        request = build_request(
-            # pgw#848: the CEILING, not the estimate. `need_bytes` answers
-            # "should this start"; handing it to the child as a hard cap is
-            # what pinned two mints at 11.09 GiB on cards with 21.48 GiB free.
-            task, workdir=workdir, cap_bytes=budget.cap_bytes,
-            # pgw#848: whatever a previous mint on this pod measured one entry
-            # child to peak at. Read here rather than in the child because the
-            # child is the thing that dies.
-            entry_peak_rss_bytes=mint_budget.entry_peak_rss(
-                family, task.weight_lane),
-            # pgw#877: and the DEVICE measurement, which until now had no way
-            # to reach the process that sizes K.
-            entry_device_peak_bytes=mint_budget.entry_device_peak(
-                family, task.weight_lane))
-        act.phase(activity_mod.PHASE_LOAD)
-        outcome = await mint_process.run_mint(
-            request, workdir=workdir, on_frame=_on_frame(act),
-            on_evidence=_on_evidence(act), abandon=abandon)
-        last = outcome.detail
-
-        if outcome.report is not None:
-            # pgw#848: banked on EVERY outcome, not only a minted one. This
-            # was gated on a truthy `peak_vram_bytes`, which a child dying
-            # inside `torch.export` never produced — so attempt N+1 re-asked
-            # identically, forever, which is most of why the failure presented
-            # as deterministic. The device side now has the shape the host
-            # side got below: the attempt that FAILED is exactly the attempt
-            # whose measurement the next one needs.
-            mint_budget.record_child_peak(
-                family, task.weight_lane,
-                int(outcome.report.peak_vram_bytes or 0))
-            # pgw#848: the host half of the same loop. The pool has always
-            # measured `peak_child_rss_bytes` and put it in the phase table
-            # that rides `mint_phases`; nothing has ever read it, so every
-            # mint sized `mem_workers` off a 3 GiB constant. Banked on EVERY
-            # outcome, not just a minted one: an aborted mint's entries still
-            # peaked where they peaked, and the attempt that follows it is
-            # exactly the one that needs the fact.
+            if outcome.report is not None:
+                # pgw#848: banked on EVERY outcome, not only a minted one. This
+                # was gated on a truthy `peak_vram_bytes`, which a child dying
+                # inside `torch.export` never produced — so attempt N+1 re-asked
+                # identically, forever, which is most of why the failure presented
+                # as deterministic. The device side now has the shape the host
+                # side got below: the attempt that FAILED is exactly the attempt
+                # whose measurement the next one needs.
+                mint_budget.record_child_peak(
+                    family, task.weight_lane,
+                    int(outcome.report.peak_vram_bytes or 0))
+                # pgw#848: the host half of the same loop. The pool has always
+                # measured `peak_child_rss_bytes` and put it in the phase table
+                # that rides `mint_phases`; nothing has ever read it, so every
+                # mint sized `mem_workers` off a 3 GiB constant. Banked on EVERY
+                # outcome, not just a minted one: an aborted mint's entries still
+                # peaked where they peaked, and the attempt that follows it is
+                # exactly the one that needs the fact.
+                mint_budget.record_entry_peak_rss(
+                    family, task.weight_lane,
+                    _pool_stat(outcome.report.mint_phases,
+                               "peak_child_rss_bytes"))
+                # pgw#877 #1/#2: the DEVICE half of the same loop, banked on the
+                # same terms. pgw#868 A4 measured this and left it telemetry-only;
+                # this is the read that makes it a decision.
+                mint_budget.record_entry_device_peak(
+                    family, task.weight_lane,
+                    _pool_stat(outcome.report.mint_phases,
+                               "peak_child_device_bytes"))
+            # pgw#848: ...and from the SNAPSHOT when the child never wrote a
+            # report at all, which is every killed and every abandoned mint.
             mint_budget.record_entry_peak_rss(
                 family, task.weight_lane,
-                _pool_stat(outcome.report.mint_phases,
-                           "peak_child_rss_bytes"))
-            # pgw#877 #1/#2: the DEVICE half of the same loop, banked on the
-            # same terms. pgw#868 A4 measured this and left it telemetry-only;
-            # this is the read that makes it a decision.
+                _pool_stat(outcome.partial_phases, "peak_child_rss_bytes"))
             mint_budget.record_entry_device_peak(
                 family, task.weight_lane,
-                _pool_stat(outcome.report.mint_phases,
-                           "peak_child_device_bytes"))
-        # pgw#848: ...and from the SNAPSHOT when the child never wrote a
-        # report at all, which is every killed and every abandoned mint.
-        mint_budget.record_entry_peak_rss(
-            family, task.weight_lane,
-            _pool_stat(outcome.partial_phases, "peak_child_rss_bytes"))
-        mint_budget.record_entry_device_peak(
-            family, task.weight_lane,
-            _pool_stat(outcome.partial_phases, "peak_child_device_bytes"))
-        # pgw#1010: every delegated mint is an AOT mint, so there is one
-        # phase emitter. The JIT twin measured a child recipe that no longer
-        # exists.
-        _emit_aot_phases(
-            outcome, family=family, execution_lane=task.weight_lane)
+                _pool_stat(outcome.partial_phases, "peak_child_device_bytes"))
+            # pgw#1010: every delegated mint is an AOT mint, so there is one
+            # phase emitter. The JIT twin measured a child recipe that no longer
+            # exists.
+            _emit_aot_phases(
+                outcome, family=family, execution_lane=task.weight_lane)
 
-        if outcome.status == mint_process.ABANDONED:
-            return DelegatedResult(
-                status=ABANDONED, detail=outcome.detail, attempts=attempts,
-                budget=budget)
-
-        if outcome.minted and outcome.artifact is not None:
-            # pgw#1053: adoption binds constants from the RESIDENT weights and
-            # runs the parity proof against them — the parked pipeline comes
-            # back first, or the adopt would prove against host-RAM ghosts.
-            if parked_ref[0] is not None:
-                restored = restore_eager_pipeline(parked_ref[0])
-                parked_ref[0] = None
-                if not restored:
-                    fleet_cells.abandon_self_mint(pending)
-                    return DelegatedResult(
-                        status=FAILED, attempts=attempts, budget=budget,
-                        reason="eager_restore_failed",
-                        detail=(
-                            "the parked eager pipeline did not fully restore "
-                            "to its device after the mint (pgw#1053) — "
-                            "adoption is refused rather than proven against "
-                            "a half-resident pipeline"))
-            act.phase(activity_mod.PHASE_SEAL_PUBLISH)
-            minted = fleet_cells.adopt_delegated_mint(
-                task.pipe, pending, outcome.artifact)
-            if minted is not None:
-                # pgw#848 item 5: the ONE terminus where the bank's job is
-                # finished. It survives every failure (that is the point) and
-                # is dropped on success, which is what keeps a healthy pod's
-                # resume area from being the only thing that grows.
-                aot_resume.discard(str(pending.cell_key))
+            if outcome.status == mint_process.ABANDONED:
                 return DelegatedResult(
-                    status=ADOPTED, minted=minted, attempts=attempts,
+                    status=ABANDONED, detail=outcome.detail, attempts=attempts,
                     budget=budget)
-            # The child produced bytes this runtime could not adopt.
-            # `adopt_delegated_mint` emitted the typed abort and cleaned up;
-            # retrying cannot change a verify()/drift verdict.
-            #
-            # pgw#999: it also RECORDED why, and this is where that used to
-            # die. The sentence below was the whole of what the wire got.
-            reason, why = fleet_cells.adopt_refusal(pending)
-            return DelegatedResult(
-                status=FAILED, attempts=attempts, budget=budget,
-                reason=reason,
-                detail=(
-                    f"the child's cell did not adopt on this runtime "
-                    f"({reason}{': ' + why if why else ''})"
-                    if reason else
-                    "the child's cell did not adopt on this runtime"))
 
-        _emit_abort(outcome, family, pending.cell_key, attempts)
-        if not (outcome.retryable and attempts < max(1, max_attempts)):
-            fleet_cells.abandon_self_mint(pending)
-            return DelegatedResult(
-                status=FAILED, detail=outcome.detail, attempts=attempts,
-                budget=budget)
-        logger.info(
-            "mint-delegate: retrying the mint for %s (attempt %d/%d) after a "
-            "%s outcome", family, attempts + 1, max_attempts, outcome.status)
+            if outcome.minted and outcome.artifact is not None:
+                # pgw#1053: adoption binds constants from the RESIDENT weights and
+                # runs the parity proof against them — the parked pipeline comes
+                # back first, or the adopt would prove against host-RAM ghosts.
+                if parked is not None:
+                    restored = restore_eager_pipeline(parked)
+                    parked = None
+                    if not restored:
+                        fleet_cells.abandon_self_mint(pending)
+                        return DelegatedResult(
+                            status=FAILED, attempts=attempts, budget=budget,
+                            reason="eager_restore_failed",
+                            detail=(
+                                "the parked eager pipeline did not fully restore "
+                                "to its device after the mint (pgw#1053) — "
+                                "adoption is refused rather than proven against "
+                                "a half-resident pipeline"))
+                act.phase(activity_mod.PHASE_SEAL_PUBLISH)
+                minted = fleet_cells.adopt_delegated_mint(
+                    task.pipe, pending, outcome.artifact)
+                if minted is not None:
+                    # pgw#848 item 5: the ONE terminus where the bank's job is
+                    # finished. It survives every failure (that is the point) and
+                    # is dropped on success, which is what keeps a healthy pod's
+                    # resume area from being the only thing that grows.
+                    aot_resume.discard(str(pending.cell_key))
+                    return DelegatedResult(
+                        status=ADOPTED, minted=minted, attempts=attempts,
+                        budget=budget)
+                # The child produced bytes this runtime could not adopt.
+                # `adopt_delegated_mint` emitted the typed abort and cleaned up;
+                # retrying cannot change a verify()/drift verdict.
+                #
+                # pgw#999: it also RECORDED why, and this is where that used to
+                # die. The sentence below was the whole of what the wire got.
+                reason, why = fleet_cells.adopt_refusal(pending)
+                return DelegatedResult(
+                    status=FAILED, attempts=attempts, budget=budget,
+                    reason=reason,
+                    detail=(
+                        f"the child's cell did not adopt on this runtime "
+                        f"({reason}{': ' + why if why else ''})"
+                        if reason else
+                        "the child's cell did not adopt on this runtime"))
 
-    fleet_cells.abandon_self_mint(pending)
-    return DelegatedResult(
-        status=FAILED, detail=last, attempts=attempts, budget=budget)
+            _emit_abort(outcome, family, pending.cell_key, attempts)
+            if not (outcome.retryable and attempts < max(1, max_attempts)):
+                fleet_cells.abandon_self_mint(pending)
+                return DelegatedResult(
+                    status=FAILED, detail=outcome.detail, attempts=attempts,
+                    budget=budget)
+            logger.info(
+                "mint-delegate: retrying the mint for %s (attempt %d/%d) after a "
+                "%s outcome", family, attempts + 1, max_attempts, outcome.status)
+
+        fleet_cells.abandon_self_mint(pending)
+        return DelegatedResult(
+            status=FAILED, detail=last, attempts=attempts, budget=budget)
+    finally:
+        if parked is not None:
+            restore_eager_pipeline(parked)
+            parked = None
 
 
 def _emit_aot_phases(

--- a/src/gen_worker/mint_delegate.py
+++ b/src/gen_worker/mint_delegate.py
@@ -40,6 +40,7 @@ from . import aot_resume
 from . import mint_budget
 from . import mint_process
 from . import progress as progress_mod
+from . import worker_goals
 from .mint_process import MintOutcome, MintRequest
 
 logger = logging.getLogger(__name__)
@@ -121,6 +122,140 @@ ADOPTED = "adopted"
 DECLINED = "declined"
 FAILED = "failed"
 ABANDONED = mint_process.ABANDONED
+
+
+# ---------------------------------------------------------------------------
+# pgw#1053: the parked eager pipeline — a forge-goal pod's 9.54 GiB co-tenant
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParkedEager:
+    """A serving-process pipeline moved to host RAM for the life of a mint.
+
+    Holds exactly what restoration needs: the modules that were moved, and
+    the device string they came from.
+    """
+
+    modules: Tuple[Any, ...]
+    device: str
+
+
+def _eager_modules(pipe: Any) -> Tuple[Any, ...]:
+    """The distinct ``nn.Module`` objects a pipeline is made of — the same
+    walk :func:`mint_budget.device_of` sizes the card with."""
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 — no torch, nothing resident
+        return ()
+    out: list = []
+    candidates = [pipe]
+    try:
+        candidates.extend(vars(pipe).values())
+    except TypeError:
+        pass
+    for obj in candidates:
+        if isinstance(obj, torch.nn.Module) and all(obj is not m for m in out):
+            out.append(obj)
+    return tuple(out)
+
+
+def maybe_park_eager(pipe: Any, goals: Any = None) -> Optional[ParkedEager]:
+    """Park the serving process's eager pipeline for the mint — IFF the goal
+    set says nobody is served by it (pgw#1053).
+
+    The parent's eager pipeline held **9.54 GiB** through attempt 30's whole
+    165-minute mint on a pod whose goal set admits no tenant dispatch — VRAM
+    serving nobody, priced straight out of the mint child's budget and the
+    compile pool's K. The GOALS machinery decides, never a mode probe
+    (pgw#930): a pod holding a serve goal keeps eager resident and hot — Paul
+    ruling 2, eager is minimally disrupted and the GPU stays warm — and this
+    function then does not touch it. Only a pod with no serve goal parks,
+    because there the "tenant" every reserve protects does not exist.
+
+    CPU-park rather than teardown, so the ADOPT step at the end of the mint
+    still has the real weights to bind and prove against —
+    :func:`restore_eager_pipeline` moves them back first. The pgw#763
+    host-move guard stays armed and is the budget check: a pipeline host RAM
+    cannot hold refuses typed, the park unwinds what it moved, and the mint
+    proceeds against the resident card exactly as today.
+    """
+    goals = worker_goals.current() if goals is None else goals
+    if pipe is None or goals.tenant_reserve_applies():
+        return None
+    modules = _eager_modules(pipe)
+    on_device = []
+    device = ""
+    for module in modules:
+        try:
+            param = next(
+                (t for t in module.parameters(recurse=True) if t.is_cuda),
+                None)
+        except Exception:  # noqa: BLE001 — an unreadable module stays put
+            param = None
+        if param is not None:
+            on_device.append(module)
+            device = device or str(param.device)
+    if not on_device:
+        return None
+    moved: list = []
+    try:
+        for module in on_device:
+            module.to("cpu")      # pgw#763 guard checks the host budget
+            moved.append(module)
+    except Exception as exc:  # noqa: BLE001 — typed refusal or torch failure
+        for module in moved:
+            try:
+                module.to(device)
+            except Exception:  # noqa: BLE001 — best-effort unwind
+                logger.exception(
+                    "mint-delegate: pgw#1053 park unwind failed; the "
+                    "pipeline may be split across devices")
+        logger.warning(
+            "mint-delegate: pgw#1053 eager park refused (%s: %s) — the "
+            "pipeline stays resident and the mint budgets around it as "
+            "before", type(exc).__name__, exc)
+        return None
+    freed = 0
+    try:
+        import torch
+
+        torch.cuda.empty_cache()
+        free, total = torch.cuda.mem_get_info()
+        freed = int(free)
+        _ = total
+    except Exception:  # noqa: BLE001 — telemetry only
+        pass
+    activity_mod.emit_event(
+        activity_mod.KIND_AOT_MINT,
+        f"pgw#1053: no serve goal — parked the eager pipeline "
+        f"({len(moved)} module(s)) to host RAM for the mint; device free now "
+        f"{freed / 1024**3:.2f} GiB",
+        phase="residents",
+    )
+    return ParkedEager(modules=tuple(moved), device=device or "cuda")
+
+
+def restore_eager_pipeline(parked: ParkedEager) -> bool:
+    """Move a parked pipeline back onto its card. False = it did not all come
+    back, and the caller must not adopt against a half-resident pipeline."""
+    ok = True
+    for module in parked.modules:
+        try:
+            module.to(parked.device)
+        except Exception:  # noqa: BLE001 — reported, never raised
+            ok = False
+            logger.exception(
+                "mint-delegate: pgw#1053 eager restore failed for %s",
+                type(module).__name__)
+    if not ok:
+        activity_mod.emit_event(
+            activity_mod.KIND_AOT_MINT,
+            "pgw#1053: eager pipeline did NOT fully restore after the mint — "
+            "adoption is refused against a half-resident pipeline",
+            phase="residents",
+        )
+    return ok
 
 
 def cfg_spec(cfg: Any) -> mint_process.CompileCellSpec:
@@ -255,12 +390,37 @@ async def build_cell(
 ) -> DelegatedResult:
     """Build and adopt one cell in a child process. Never raises for a mint
     failure — the worker must never die with its mint."""
-    from . import fleet_cells
-
-    pending = task.pending
     device = (
         task.device if task.device is not None
         else mint_budget.device_of(task.pipe))
+    # pgw#1053: with no serve goal there is no tenant, and the eager pipeline
+    # is a 9.54 GiB co-tenant of its own mint. Parked BEFORE the first budget
+    # probe so `co_residency` prices the freed card; restored before ADOPT,
+    # which needs the real weights (and unconditionally on the way out, so
+    # this process is left as it was found whatever the outcome).
+    parked_ref: list = [maybe_park_eager(task.pipe)]
+    try:
+        return await _build_cell_attempts(
+            task, act=act, abandon=abandon, max_attempts=max_attempts,
+            device=device, parked_ref=parked_ref)
+    finally:
+        if parked_ref[0] is not None:
+            restore_eager_pipeline(parked_ref[0])
+            parked_ref[0] = None
+
+
+async def _build_cell_attempts(
+    task: MintTask,
+    *,
+    act: Any,
+    abandon: Any,
+    max_attempts: int,
+    device: Optional[int],
+    parked_ref: list,
+) -> DelegatedResult:
+    from . import fleet_cells
+
+    pending = task.pending
     family = str(pending.family)
     attempts = 0
     budget: Optional[mint_budget.MintBudget] = None
@@ -355,6 +515,22 @@ async def build_cell(
                 budget=budget)
 
         if outcome.minted and outcome.artifact is not None:
+            # pgw#1053: adoption binds constants from the RESIDENT weights and
+            # runs the parity proof against them — the parked pipeline comes
+            # back first, or the adopt would prove against host-RAM ghosts.
+            if parked_ref[0] is not None:
+                restored = restore_eager_pipeline(parked_ref[0])
+                parked_ref[0] = None
+                if not restored:
+                    fleet_cells.abandon_self_mint(pending)
+                    return DelegatedResult(
+                        status=FAILED, attempts=attempts, budget=budget,
+                        reason="eager_restore_failed",
+                        detail=(
+                            "the parked eager pipeline did not fully restore "
+                            "to its device after the mint (pgw#1053) — "
+                            "adoption is refused rather than proven against "
+                            "a half-resident pipeline"))
             act.phase(activity_mod.PHASE_SEAL_PUBLISH)
             minted = fleet_cells.adopt_delegated_mint(
                 task.pipe, pending, outcome.artifact)
@@ -503,8 +679,11 @@ __all__ = [
     "FAILED",
     "DelegatedResult",
     "MintTask",
+    "ParkedEager",
     "build_cell",
     "build_request",
     "cfg_spec",
+    "maybe_park_eager",
+    "restore_eager_pipeline",
     "scratch_root",
 ]

--- a/tests/test_mint_residents_pgw1053.py
+++ b/tests/test_mint_residents_pgw1053.py
@@ -151,7 +151,7 @@ def _declare() -> Any:
         targets=("unet",),
         dims=(Dim("B", carried_by=(("sample", 0),)),),
         classes=(GraphClass(dims={"B": 2}), GraphClass(dims={"B": 1})),
-        inputs=(Input("sample", shape=("B", 4)),),
+        inputs=(Input("sample", shape=("B", 4), dtype="model"),),
         shape_strategy="static-rows",
         warm_changes_key=False,
     ))

--- a/tests/test_mint_residents_pgw1053.py
+++ b/tests/test_mint_residents_pgw1053.py
@@ -1,0 +1,403 @@
+"""pgw#1053 — 25.7 GiB of the L40S was held by two residents that did NOTHING
+through the 97-minute compile phase.
+
+The two residents, measured (attempts 24/26/30):
+
+* the serving PARENT's eager pipeline — 9.54 GiB on a pod whose goal set
+  admits no tenant dispatch (it serves nobody; the heartbeat needs no VRAM);
+* the MINT CHILD's own pipeline plus the retained programs' weight aliases —
+  16.2 GiB of dead weight from the moment the last row exports.
+
+What is asserted here:
+
+* the mint-child release is a code-only PROJECTION: weights go to meta,
+  literals keep their bytes, and every identity fact the parent-side gates
+  read (FQN sets, graph hash, literal digest) is unchanged — so no gate is
+  dropped and the cell key cannot move (pgw#846);
+* a full mint with ``release_residents=True`` still packs, still keys
+  identically, and provably released the pipeline;
+* the pool REGRANTS K when the residents come back — through the same
+  pgw#992-bounded arithmetic, never past the card's simultaneous budget, and
+  never touching the co-tenant term (the census predates every child and the
+  release re-baselines only the OWN floor);
+* the PARENT-side park is decided by the GOALS machinery (pgw#930): a pod
+  holding a serve goal keeps eager resident and hot (Paul ruling 2 — this is
+  the serving-pod half of the asymmetry), a pod with no serve goal parks to
+  host RAM for the mint and restores before ADOPT.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker import aot_compile_pool as pool_mod  # noqa: E402
+from gen_worker import (  # noqa: E402
+    aot_flatten, aot_mint, aot_package, aot_serve, compile_cache, graph_hash,
+    mint_delegate, worker_goals)
+from gen_worker.api.decorators import Compile  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+    reset_export_declarations,
+)
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+_GIB = 1024 ** 3
+
+
+# ---------------------------------------------------------------------------
+# The projection: code-only, gates intact, identity frozen
+# ---------------------------------------------------------------------------
+
+
+class _WithLiteral(nn.Module):
+    """A weight (state_dict), a buffer (state_dict) and a LITERAL — a plain
+    attribute tensor with no state_dict counterpart, the qwen/z-image rope
+    shape pgw#857 keys by value."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(8, 8)
+        self.register_buffer("scale", torch.ones(8))
+        self.table = torch.linspace(0.0, 1.0, 8)   # literal: plain attribute
+
+    def forward(self, x: Any) -> Any:
+        return self.lin(x) * self.scale + self.table
+
+
+def _minted_entry(module: nn.Module) -> Any:
+    program = torch.export.export(module.eval(), (torch.randn(2, 8),))
+    return aot_mint._MintedEntry(
+        name="unet/B=2", spec=aot_mint.ExportSpec(family="f", target="unet"),
+        module=None, owner=module, program=program,
+        input_names=("x",),
+        flat_leaves=(aot_flatten.Leaf(param="x", param_position=0, path=()),),
+        files=[], timings={})
+
+
+def test_release_projects_programs_code_only() -> None:
+    module = _WithLiteral()
+    row = _minted_entry(module)
+    program = row.program
+
+    weights_before = aot_package.program_state_dict_fqns(program)
+    literal_digest_before = aot_package.literal_values_digest(program)
+    graph_before = graph_hash.graph_hash(program)
+    assert literal_digest_before, "the fixture must actually lift a literal"
+
+    pipe = types.SimpleNamespace(unet=module)
+    facts = aot_mint._release_mint_residents(pipe, [row])
+
+    # The weights are GONE from residency...
+    for fqn in weights_before:
+        value = program.state_dict.get(fqn)
+        assert value is not None and value.device.type == "meta", (
+            f"{fqn}: a state_dict constant survived the projection resident")
+    for p in module.parameters():
+        assert p.device.type == "meta", "the module's storage stayed resident"
+    # ...and every identity fact the gates read is untouched.
+    assert aot_package.program_state_dict_fqns(program) == weights_before
+    assert aot_package.literal_values_digest(program) == literal_digest_before, (
+        "the literal's BYTES are part of the artifact (pgw#857) and must "
+        "survive the release")
+    assert graph_hash.graph_hash(program) == graph_before
+    assert facts.get("residents_release_modules", 0) >= 1
+
+
+def test_release_is_not_wired_into_library_mints_by_default(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """`release_residents` is the CALLER's lifecycle statement. A library
+    caller that keeps its pipeline must find it untouched after `mint()`."""
+    _fake_sm(monkeypatch)
+    _declare()
+    pipe = types.SimpleNamespace(unet=TinyUNet())
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+    aot_mint.mint(pipe, spec, tmp_path / "out")
+    assert all(p.device.type != "meta" for p in pipe.unet.parameters()), (
+        "a default mint released a pipeline it does not own")
+
+
+# ---------------------------------------------------------------------------
+# A full mint with the release: packs, keys identically, provably released
+# ---------------------------------------------------------------------------
+
+FAMILY = "tiny1053"
+
+
+class TinyUNet(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, sample: Any) -> Any:
+        return torch.tanh(self.lin(sample)) + 1.0
+
+
+def _declare() -> Any:
+    return register_export_declaration(Compile(
+        family=FAMILY,
+        targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}), GraphClass(dims={"B": 1})),
+        inputs=(Input("sample", shape=("B", 4)),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    ))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+def _fake_sm(monkeypatch) -> None:
+    full = {"sku": "", "sm": "sm_89", "torch": str(torch.__version__),
+            "cuda": ""}
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: dict(full))
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: {
+        "sku": full["sku"], "sm": full["sm"], "torch": full["torch"],
+        "cuda": full["cuda"]})
+
+
+def test_full_mint_with_release_packs_and_keys_identically(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The whole path: overlapped mint, release at producer exhaustion, every
+    package gate runs against the projection, the artifact keys identically —
+    and the pipeline is PROVABLY released (weights on meta afterwards)."""
+    _fake_sm(monkeypatch)
+    _declare()
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+
+    keeper = types.SimpleNamespace(unet=TinyUNet())
+    kept = aot_mint.mint(keeper, spec, tmp_path / "kept")
+
+    surrendered = types.SimpleNamespace(unet=TinyUNet())
+    released = aot_mint.mint(
+        surrendered, spec, tmp_path / "released", release_residents=True)
+
+    assert kept.cell_key == released.cell_key, (
+        "the release re-keyed the cell — the projection leaked into identity "
+        "(pgw#846)")
+    assert all(
+        p.device.type == "meta" for p in surrendered.unet.parameters()), (
+        "release_residents=True did not release the pipeline")
+    assert "residents_release_s" in released.timings
+    assert released.timings.get("entry_workers", 0) > 1, (
+        "the release path only runs on the pooled path; this mint went "
+        "serial and proved nothing")
+
+
+# ---------------------------------------------------------------------------
+# The pool regrants K when the residents come back (the pgw#992 pod, freed)
+# ---------------------------------------------------------------------------
+
+# The incident pod's numbers, verbatim from test_pool_simultaneity_pgw992.
+CARD_TOTAL = 47661043712          # 44.39 GiB
+FREE_AT_OPEN = 31664532480        # 29.49 GiB
+SERVING_PARENT = 10243173417      # 9.54 GiB co-tenant
+OWN_AT_OPEN = CARD_TOTAL - FREE_AT_OPEN - SERVING_PARENT
+OWN_PEAK = 17394617548            # 16.20 GiB — the mint child's pipeline
+MEASURED_ENTRY_PEAK = 6461325312  # 6.02 GiB
+
+
+def _census() -> pool_mod.CardCensus:
+    return pool_mod.CardCensus(CARD_TOTAL, FREE_AT_OPEN, OWN_AT_OPEN, "sampled")
+
+
+def _width() -> pool_mod.PoolWidth:
+    return pool_mod.entry_workers(
+        36, vcpus=256, available_bytes=116 * _GIB, peak_rss_bytes=3 * _GIB,
+        free_vram_bytes=FREE_AT_OPEN, device_bytes=int(9.9 * _GIB),
+        device_basis="estimated", device_lock=True,
+        goals=worker_goals.MINT_ONLY)
+
+
+def _pool(tmp_path: Path, monkeypatch, *, own_peak: int) -> pool_mod.EntryCompilePool:
+    monkeypatch.setattr(pool_mod, "card_census", lambda device=-1: _census())
+    monkeypatch.setattr(
+        pool_mod, "own_device_high_water", lambda device=-1: own_peak)
+    return pool_mod.EntryCompilePool(tmp_path / "pool", width=_width())
+
+
+def test_release_regrants_K_within_the_card_budget(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The incident pod, with the mint child's 16.2 GiB handed back: the SAME
+    bounded arithmetic that held K=2 now grants more — and still never more
+    than the card's simultaneous budget with the 9.54 GiB co-tenant priced."""
+    box = _pool(tmp_path, monkeypatch, own_peak=OWN_PEAK)
+    # Two real entry reports first (the measured 6.02 GiB ask), as on the pod.
+    for i in range(2):
+        box.observe_entry_device(pool_mod.EntryReport(
+            entry=f"unet/dim={i}", status=pool_mod.COMPILED,
+            peak_device_reserved_bytes=MEASURED_ENTRY_PEAK))
+        box._rewiden()
+    held = box.width.workers
+    assert held == 2, box.width.reason   # the pgw#992 bound, still holding
+
+    # The release: the pipeline is gone, the high-water restarts small.
+    residue = 1 * _GIB
+    monkeypatch.setattr(
+        pool_mod, "own_reserved_now", lambda device=-1: residue)
+    monkeypatch.setattr(
+        pool_mod, "own_device_high_water", lambda device=-1: residue)
+    box.note_residents_released()
+
+    assert box.width.workers > held, (
+        f"the release freed {OWN_PEAK / _GIB:.1f} GiB and K did not move "
+        f"({box.width.reason})")
+    # Bounded: K children's simultaneous peak + co-tenant + residue <= card.
+    entry_ask = MEASURED_ENTRY_PEAK + 1 * _GIB  # +context floor
+    assert (box.width.workers * entry_ask + SERVING_PARENT + residue
+            <= CARD_TOTAL), box.width.reason
+    assert box.simultaneity.get("residents_released_bytes", 0) > 0
+
+
+def test_release_regrant_never_touches_the_cotenant_term(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The census predates every child (pgw#992/pgw#1000 ordering) and the
+    release re-baselines ONLY the own floor — the 9.54 GiB serving parent
+    stays priced. A regrant that erased the co-tenant would re-create the
+    incident with a new receipt."""
+    box = _pool(tmp_path, monkeypatch, own_peak=OWN_PEAK)
+    before = box.census.resident_other_bytes
+    monkeypatch.setattr(pool_mod, "own_reserved_now", lambda device=-1: 0)
+    monkeypatch.setattr(pool_mod, "own_device_high_water", lambda device=-1: 0)
+    box.note_residents_released()
+    assert box.census.resident_other_bytes == before
+    budget, terms = box.entry_budget_bytes(MEASURED_ENTRY_PEAK)
+    assert budget is not None
+    assert budget <= CARD_TOTAL - SERVING_PARENT, (
+        "the freed budget swallowed the co-tenant's residency")
+
+
+def test_release_on_an_unreadable_card_regrants_nothing(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        pool_mod, "card_census",
+        lambda device=-1: pool_mod.CardCensus(0, 0, 0, "unreadable"))
+    box = pool_mod.EntryCompilePool(tmp_path / "pool", width=_width())
+    held = box.width.workers
+    box.note_residents_released()
+    assert box.width.workers == held
+
+
+def test_live_spawn_admission_holds_a_spawn_the_budget_cannot(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """pgw#992 under overlap: the residents keep growing through the export
+    phase, and `_spawn_admitted` re-asks the budget with the LIVE own
+    high-water before every spawn. At the incident pod's grown residency the
+    third child is held; after the release it is admitted."""
+    from dataclasses import replace as dc_replace
+
+    box = _pool(tmp_path, monkeypatch, own_peak=OWN_PEAK)
+    # Give the width room so admission, not construction, is the bound.
+    box.width = dc_replace(
+        box.width, workers=6,
+        per_entry_device_bytes=MEASURED_ENTRY_PEAK + 1 * _GIB)
+    # budget = 44.39 - 9.54 (co-tenant) - 16.20 (own) = 18.65 GiB -> k_cap 2
+    assert box._spawn_admitted(1) is True
+    assert box._spawn_admitted(2) is False, (
+        "a third child was admitted against a budget that holds two — the "
+        "pgw#992 incident, live")
+    assert box._spawn_admitted(0) is True, "the serial floor must always spawn"
+    # After the release the same question admits more.
+    monkeypatch.setattr(pool_mod, "own_reserved_now", lambda device=-1: 1 * _GIB)
+    monkeypatch.setattr(
+        pool_mod, "own_device_high_water", lambda device=-1: 1 * _GIB)
+    box.note_residents_released()
+    assert box._spawn_admitted(2) is True
+
+
+# ---------------------------------------------------------------------------
+# The PARENT half: goals decide, serving pods keep eager hot
+# ---------------------------------------------------------------------------
+
+
+class _Poisoned:
+    """An object no park may touch when the goals say serve."""
+
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover — the trap
+        raise AssertionError(f"a serving pod's pipeline was touched ({name})")
+
+
+def test_serving_goal_keeps_eager_resident() -> None:
+    parked = mint_delegate.maybe_park_eager(
+        _Poisoned(), goals=worker_goals.SERVE_ONLY)
+    assert parked is None
+
+
+def test_dual_goal_pod_keeps_eager_resident() -> None:
+    """Paul's serve+mint case: the tenant reserve is real and eager stays."""
+    goals = worker_goals.WorkerGoals(serve=True, mint=True)
+    assert mint_delegate.maybe_park_eager(_Poisoned(), goals=goals) is None
+
+
+def test_mint_only_goal_parks_cuda_modules_and_restores(monkeypatch) -> None:
+    """The decision seam, cardless: a mint-only pod PARKS what is on the
+    device and restores it on demand. The move itself is recorded through
+    the module's own `.to`, so this passes on the real GPU leg unchanged."""
+
+    class _FakeParam:
+        is_cuda = True
+        device = "cuda:0"
+
+    class _FakeModule(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.moves: List[Any] = []
+
+        def parameters(self, recurse: bool = True):  # type: ignore[override]
+            yield _FakeParam()
+
+        def to(self, target: Any, *a: Any, **k: Any):  # type: ignore[override]
+            self.moves.append(target)
+            return self
+
+    module = _FakeModule()
+    pipe = types.SimpleNamespace(unet=module)
+    parked = mint_delegate.maybe_park_eager(
+        pipe, goals=worker_goals.MINT_ONLY)
+    assert parked is not None
+    assert module.moves == ["cpu"]
+    assert mint_delegate.restore_eager_pipeline(parked) is True
+    assert module.moves == ["cpu", "cuda:0"]
+
+
+def test_mint_only_goal_with_nothing_on_device_is_a_noop() -> None:
+    pipe = types.SimpleNamespace(unet=nn.Linear(4, 4))  # CPU weights
+    assert mint_delegate.maybe_park_eager(
+        pipe, goals=worker_goals.MINT_ONLY) is None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a real card")
+def test_park_and_restore_on_the_real_card() -> None:
+    """The GPU leg (rig box / GPU CI lane): park frees reserved bytes, the
+    weights land in host RAM, restore puts them back."""
+    module = nn.Linear(256, 256).cuda()
+    pipe = types.SimpleNamespace(unet=module)
+    torch.cuda.synchronize()
+    parked = mint_delegate.maybe_park_eager(
+        pipe, goals=worker_goals.MINT_ONLY)
+    assert parked is not None
+    assert all(p.device.type == "cpu" for p in module.parameters())
+    assert mint_delegate.restore_eager_pipeline(parked) is True
+    assert all(p.is_cuda for p in module.parameters())

--- a/tests/test_mint_residents_pgw1053.py
+++ b/tests/test_mint_residents_pgw1053.py
@@ -173,6 +173,20 @@ def _fake_sm(monkeypatch) -> None:
         "cuda": full["cuda"]})
 
 
+def _wide_pool(monkeypatch) -> None:
+    """The width is STATED, not derived (the pgw#809 discipline): a 4-vCPU CI
+    runner honestly derives K=1 and the release below only runs on the pooled
+    path. The REAL policy runs on pinned resource inputs."""
+    real = pool_mod.entry_workers
+
+    def _wide(entries: int, **kw: Any) -> Any:
+        kw.update(vcpus=16, available_bytes=64 * _GIB, free_vram_bytes=0,
+                  device_lock=True)
+        return real(entries, **kw)
+
+    monkeypatch.setattr(pool_mod, "entry_workers", _wide)
+
+
 def test_full_mint_with_release_packs_and_keys_identically(
     tmp_path: Path, monkeypatch,
 ) -> None:
@@ -180,6 +194,7 @@ def test_full_mint_with_release_packs_and_keys_identically(
     package gate runs against the projection, the artifact keys identically —
     and the pipeline is PROVABLY released (weights on meta afterwards)."""
     _fake_sm(monkeypatch)
+    _wide_pool(monkeypatch)
     _declare()
     spec = aot_mint.ExportSpec(family=FAMILY, target="")
 

--- a/tests/test_overlap_export_compile_pgw1052.py
+++ b/tests/test_overlap_export_compile_pgw1052.py
@@ -254,6 +254,22 @@ def fake_sm(monkeypatch):
     return full
 
 
+@pytest.fixture
+def wide_pool(monkeypatch):
+    """The width is STATED, not derived (the pgw#809 discipline): a 4-vCPU CI
+    runner honestly derives K=1, and every pool-path assertion below would
+    then pass while exercising no pool at all. The REAL policy still runs —
+    only its resource inputs are pinned to a box wide enough to pool."""
+    real = pool_mod.entry_workers
+
+    def _wide(entries: int, **kw: Any) -> Any:
+        kw.update(vcpus=16, available_bytes=64 * _GIB, free_vram_bytes=0,
+                  device_lock=True)
+        return real(entries, **kw)
+
+    monkeypatch.setattr(pool_mod, "entry_workers", _wide)
+
+
 def _mint(tmp: Path, *, entry_workers: int = 0) -> aot_mint.MintResult:
     pipe = types.SimpleNamespace(unet=TinyUNet())
     spec = aot_mint.ExportSpec(family=FAMILY, target="")
@@ -261,7 +277,7 @@ def _mint(tmp: Path, *, entry_workers: int = 0) -> aot_mint.MintResult:
 
 
 def test_overlapped_and_serial_mints_share_one_cell_key(
-    tmp_path: Path, fake_sm: Dict[str, str],
+    tmp_path: Path, fake_sm: Dict[str, str], wide_pool: None,
 ) -> None:
     """pgw#846: the overlap is a process change. The serial path (a forced
     K=1) and the overlapped pool path must stamp the SAME cell key — and the
@@ -284,7 +300,9 @@ def test_overlapped_and_serial_mints_share_one_cell_key(
         "the pool ledger must charge producer time to its named bucket")
 
 
-def test_beats_interleave_export_and_pool(tmp_path: Path, fake_sm) -> None:
+def test_beats_interleave_export_and_pool(
+    tmp_path: Path, fake_sm, wide_pool: None,
+) -> None:
     """The obligation beat stays honest while two phases run concurrently:
     trace_graph and inductor_compile positions INTERLEAVE on the wire rather
     than forming two disjoint blocks."""

--- a/tests/test_overlap_export_compile_pgw1052.py
+++ b/tests/test_overlap_export_compile_pgw1052.py
@@ -1,0 +1,305 @@
+"""pgw#1052 — export and compile were sequential by CODE, not by necessity.
+
+Attempt 26/30 measured the two phases at 65-68 min (export, one core, serial
+in the mint parent) and 92-97 min (compile, K=2 children) with ZERO overlap:
+the pool was constructed only after the last row exported. Producer ~113 s/row
+against a pool consuming ~127 s/row means the phases almost perfectly shadow
+each other, so handing each row to the pool AS IT EXPORTS collapses the mint
+wall toward max(export, compile).
+
+What must hold, and is asserted here for real (real ``torch.export``, real
+``aot_compile`` children, CPU):
+
+* entries REACH the pool while the export source is still open — proven
+  structurally (the producer refuses to yield its last row until the pool has
+  completed an earlier one), never by wall clock;
+* pgw#917's merge/refuse decision moves to ARRIVAL: a duplicate class row is
+  aliased before any compile is spent on it, and a same-ingress
+  different-identity collision refuses at row N (bounded waste, stated);
+* the overlapped mint and the serial mint produce the SAME cell key — the
+  overlap is a PROCESS change under pgw#846's rule, byte-invisible in the
+  artifact;
+* the phase books stay honest: ``export_all_s`` still exists, and the pool
+  ledger charges producer time to its own named bucket (``idle_source_s``).
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker import aot_compile_pool as pool_mod  # noqa: E402
+from gen_worker import aot_flatten, aot_mint, aot_serve, compile_cache  # noqa: E402
+from gen_worker.api.decorators import Compile  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+    reset_export_declarations,
+)
+from harness.progress_wait import Cadence, await_progress  # noqa: E402
+
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
+_GIB = 1024 ** 3
+_HIDDEN = 64
+
+
+# ---------------------------------------------------------------------------
+# The pool consumes while the producer is still producing
+# ---------------------------------------------------------------------------
+
+
+def _program(seed: int) -> Any:
+    class Tiny(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.a = nn.Linear(_HIDDEN, _HIDDEN)
+
+        def forward(self, x: Any) -> Any:
+            return torch.tanh(self.a(x)) * (1.0 + seed)
+
+    return torch.export.export(Tiny(), (torch.randn(4, _HIDDEN),))
+
+
+def test_entries_reach_the_pool_as_they_export(tmp_path: Path) -> None:
+    """The producer WAITS for the pool to finish an earlier entry before it
+    yields its last one. If the pool only started consuming after the source
+    was exhausted — the pre-pgw#1052 shape — this test would never complete;
+    the progress predicate is the pool's own completion record."""
+    width = pool_mod.entry_workers(
+        3, limit=2, vcpus=16, available_bytes=64 * _GIB,
+        free_vram_bytes=0, device_lock=True)
+    assert width.workers == 2
+    box = pool_mod.EntryCompilePool(
+        tmp_path / "pool", width=width,
+        inductor_configs={"compile_threads": 2},
+        cache_dir=str(tmp_path / "cache"))
+
+    overlap_seen: List[int] = []
+
+    def _reports_on_disk() -> int:
+        # The parent is single-threaded and is INSIDE this producer while it
+        # waits, so it cannot have collected anything yet — the honest
+        # overlap evidence is the CHILD's own report file, written by a
+        # process the parent is not driving.
+        return len(list((tmp_path / "pool").glob("entry-*/report.json")))
+
+    def _source() -> Iterator[Tuple[str, Any]]:
+        yield "unet/dim=0", _program(0)
+        yield "unet/dim=1", _program(1)
+        # The whole point: an earlier entry COMPLETES (its child writes its
+        # report) while this source is still open.
+        await_progress(
+            _reports_on_disk,
+            lambda n: n >= 1,
+            what="an entry child finishes while the source is open",
+            cadence=Cadence(floor_s=300.0))
+        overlap_seen.append(_reports_on_disk())
+        yield "unet/dim=2", _program(2)
+
+    out = box.compile(_source(), expected_total=3)
+
+    assert set(out) == {"unet/dim=0", "unet/dim=1", "unet/dim=2"}
+    assert overlap_seen and overlap_seen[0] >= 1, (
+        "the pool never completed an entry while the export source was open "
+        "— the phases are still sequential")
+    assert box.ledger.entries == 3
+    facts = box.ledger.facts()
+    assert "idle_source_s" in facts, (
+        "producer time must be charged to its own named bucket — an idle "
+        "split that hides the source starves pgw#1000's fused-child case of "
+        "its number")
+
+
+def test_a_sequence_still_compiles_exactly_as_before(tmp_path: Path) -> None:
+    """The pre-existing list-shaped callers (and the pgw#848 resume path) are
+    untouched: a fully-exported list goes through the same loop."""
+    width = pool_mod.entry_workers(
+        2, limit=2, vcpus=16, available_bytes=64 * _GIB,
+        free_vram_bytes=0, device_lock=True)
+    box = pool_mod.EntryCompilePool(
+        tmp_path / "pool", width=width,
+        inductor_configs={"compile_threads": 2},
+        cache_dir=str(tmp_path / "cache"))
+    out = box.compile([("unet/dim=1", _program(1)), ("unet/dim=0", _program(0))])
+    assert list(out) == sorted(out)
+    assert set(out) == {"unet/dim=0", "unet/dim=1"}
+
+
+# ---------------------------------------------------------------------------
+# pgw#917 at ARRIVAL: alias before a compile is spent; refuse at row N
+# ---------------------------------------------------------------------------
+
+XATTN = 128
+TEXT_LEN = 7
+AREA_PRESERVING = ((4, 6), (6, 4), (8, 3))   # all products 24
+
+
+class _Block(nn.Module):
+    def forward(self, hidden_states: Any, encoder_hidden_states: Any) -> Any:
+        return hidden_states.mean() + encoder_hidden_states.mean()
+
+
+class _OtherBlock(nn.Module):
+    def forward(self, hidden_states: Any, encoder_hidden_states: Any) -> Any:
+        return hidden_states.sum() - encoder_hidden_states.sum()
+
+
+def _entry(name: str, h: int, w: int, module: nn.Module | None = None) -> Any:
+    args = (torch.zeros(2, h * w, _HIDDEN), torch.zeros(2, TEXT_LEN, XATTN))
+    program = torch.export.export((module or _Block()).eval(), args, strict=True)
+    return aot_mint._MintedEntry(
+        name=name,
+        spec=aot_mint.ExportSpec(
+            family="sdxl", target="unet",
+            fork=((aot_mint.ADAPTER_FORK, False),),
+            class_dims=(("B", 2), ("H_lat", h), ("W_lat", w)),
+        ),
+        module=None, owner=None, program=program,
+        input_names=("hidden_states", "encoder_hidden_states"),
+        flat_leaves=tuple(
+            aot_flatten.Leaf(param=n, param_position=i, path=())
+            for i, n in enumerate(
+                ("hidden_states", "encoder_hidden_states"))),
+        files=[], timings={})
+
+
+def test_arrival_alias_merges_without_a_compile() -> None:
+    canon = aot_mint._ArrivalCanon()
+    first = _entry("unet/r0", *AREA_PRESERVING[0])
+    assert canon.admit(first) is None
+    for i, (h, w) in enumerate(AREA_PRESERVING[1:], start=1):
+        keeper = canon.admit(_entry(f"unet/r{i}", h, w))
+        assert keeper is first, (
+            "an area-preserving sibling must alias onto the FIRST arrival — "
+            "compiling it buys nothing and makes the cell undispatchable")
+
+
+def test_arrival_collision_refuses_naming_the_axis() -> None:
+    canon = aot_mint._ArrivalCanon()
+    assert canon.admit(_entry("unet/r0", 4, 6)) is None
+    with pytest.raises(aot_mint.MintRefused) as err:
+        canon.admit(_entry("unet/r1", 6, 4, module=_OtherBlock()))
+    assert "graph" in str(err.value), (
+        "the refusal must NAME the differing identity axis (pgw#917)")
+    assert "arrival" in str(err.value).lower()
+
+
+def test_arrival_and_late_alias_maps_merge_and_rehome() -> None:
+    a, b, c = (_entry(f"unet/r{i}", 4, 6) for i in range(3))
+    merged = aot_mint._merge_alias_maps(
+        {"unet/r1": [c]},                 # arrival: c aliased onto keeper r1
+        {"unet/r0": (b,)},                # drain: r1's OBJECT b merged onto r0
+    )
+    _ = a
+    # r1 was itself merged away at drain, so its arrival alias re-homes.
+    assert set(merged) == {"unet/r0", "unet/r1"} or set(merged) == {"unet/r0"}
+    # the strict requirement: no declared row falls out of the audit trail
+    named = {row.name for rows in merged.values() for row in rows}
+    assert {"unet/r1", "unet/r2"} <= named | set(merged)
+
+
+# ---------------------------------------------------------------------------
+# The overlapped mint IS the serial mint, artifact-wise (pgw#846's gate)
+# ---------------------------------------------------------------------------
+
+FAMILY = "tiny1052"
+
+
+class TinyUNet(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, sample: Any) -> Any:
+        return torch.tanh(self.lin(sample)) + 1.0
+
+
+def _declare() -> Any:
+    return register_export_declaration(Compile(
+        family=FAMILY,
+        targets=("unet",),
+        dims=(Dim("B", carried_by=(("sample", 0),)),),
+        classes=(GraphClass(dims={"B": 2}), GraphClass(dims={"B": 1})),
+        inputs=(Input("sample", shape=("B", 4)),),
+        shape_strategy="static-rows",
+        warm_changes_key=False,
+    ))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    reset_export_declarations()
+    yield
+    reset_export_declarations()
+
+
+@pytest.fixture
+def fake_sm(monkeypatch):
+    full = {"sku": "", "sm": "sm_89", "torch": str(torch.__version__),
+            "cuda": ""}
+    monkeypatch.setattr(compile_cache, "runtime_key", lambda: dict(full))
+    monkeypatch.setattr(aot_serve, "runtime_key", lambda: {
+        "sku": full["sku"], "sm": full["sm"], "torch": full["torch"],
+        "cuda": full["cuda"]})
+    return full
+
+
+def _mint(tmp: Path, *, entry_workers: int = 0) -> aot_mint.MintResult:
+    pipe = types.SimpleNamespace(unet=TinyUNet())
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+    return aot_mint.mint(pipe, spec, tmp, entry_workers=entry_workers)
+
+
+def test_overlapped_and_serial_mints_share_one_cell_key(
+    tmp_path: Path, fake_sm: Dict[str, str],
+) -> None:
+    """pgw#846: the overlap is a process change. The serial path (a forced
+    K=1) and the overlapped pool path must stamp the SAME cell key — and the
+    overlapped result must carry the overlap's own books."""
+    _declare()
+    serial = _mint(tmp_path / "serial", entry_workers=1)
+    overlapped = _mint(tmp_path / "overlapped")
+
+    assert serial.cell_key == overlapped.cell_key, (
+        "the overlapped mint re-keyed the cell — pgw#1052 must be "
+        "byte-invisible in the artifact")
+    assert overlapped.timings.get("entry_workers", 0) > 1, (
+        "the overlapped mint never took the pool path on this box; the "
+        "comparison proved nothing")
+    assert "export_all_s" in overlapped.timings, (
+        "the export phase's own wall must survive the overlap (the pgw#1052 "
+        "acceptance names it)")
+    pool_block = (overlapped.metadata.get("mint_phases") or {}).get("pool") or {}
+    assert "idle_source_s" in pool_block, (
+        "the pool ledger must charge producer time to its named bucket")
+
+
+def test_beats_interleave_export_and_pool(tmp_path: Path, fake_sm) -> None:
+    """The obligation beat stays honest while two phases run concurrently:
+    trace_graph and inductor_compile positions INTERLEAVE on the wire rather
+    than forming two disjoint blocks."""
+    _declare()
+    beats: List[Tuple[str, int, int]] = []
+    pipe = types.SimpleNamespace(unet=TinyUNet())
+    spec = aot_mint.ExportSpec(family=FAMILY, target="")
+    aot_mint.mint(
+        pipe, spec, tmp_path / "out",
+        on_progress=lambda phase, step, total, note: beats.append(
+            (phase, step, total)))
+    phases = [p for p, _s, _t in beats]
+    assert "trace_graph" in phases and "inductor_compile" in phases
+    first_pool = phases.index("inductor_compile")
+    last_trace = len(phases) - 1 - phases[::-1].index("trace_graph")
+    assert first_pool < last_trace, (
+        "every inductor_compile beat came after the last trace_graph beat — "
+        "the phases did not overlap on the wire")

--- a/tests/test_overlap_export_compile_pgw1052.py
+++ b/tests/test_overlap_export_compile_pgw1052.py
@@ -230,7 +230,7 @@ def _declare() -> Any:
         targets=("unet",),
         dims=(Dim("B", carried_by=(("sample", 0),)),),
         classes=(GraphClass(dims={"B": 2}), GraphClass(dims={"B": 1})),
-        inputs=(Input("sample", shape=("B", 4)),),
+        inputs=(Input("sample", shape=("B", 4), dtype="model"),),
         shape_strategy="static-rows",
         warm_changes_key=False,
     ))

--- a/tests/test_pool_rewiden_pgw868_a4.py
+++ b/tests/test_pool_rewiden_pgw868_a4.py
@@ -322,9 +322,12 @@ def test_the_staging_cap_follows_the_width(tmp_path: Path) -> None:
     src = Path("src/gen_worker/aot_compile_pool.py").read_text()
     body = src.split("def compile(", 1)[1]
     assert "staged_cap = max(1, self.width.workers" in body
-    head, _rest = body.split("while (pending and not failure", 1)
-    assert "while pending or staged or running:" in head
-    assert head.index("while pending or staged or running:") \
+    # pgw#1052 reshaped the loop (`while True:` with the pull inside it); the
+    # invariant is unchanged: staged_cap is recomputed at the TOP of every
+    # round, after `_rewiden` may have moved the width.
+    head, _rest = body.split("while staged and not failure", 1)
+    assert "while True:" in head
+    assert head.index("while True:") \
         < head.index("staged_cap = max(1, self.width.workers"), (
         "staged_cap must be recomputed INSIDE the round loop, after "
         "_rewiden may have moved the width")

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -428,9 +428,10 @@ def test_the_entry_compile_pool_reports_each_entry_as_it_lands() -> None:
 
     src = inspect.getsource(aot_compile_pool.EntryCompilePool.compile)
     assert "on_entry" in src
-    assert "len(done), len(entries)" in src, (
+    assert "len(done), _known_total()" in src, (
         "progress must carry BOTH a step and a total — a bare step is not "
-        "progress, it is a counter")
+        "progress, it is a counter (pgw#1052: the total is the producer's "
+        "declared count until the source is exhausted, then the real one)")
 
 
 def test_progress_reporting_never_costs_the_mint_its_work() -> None:


### PR DESCRIPTION
pgw#1051 levers 1+2. The 165-min L40S sdxl mint is two strictly-sequential CPU-starved phases plus 25.7 GiB of dead residents; this PR overlaps the phases and releases the residents.

## pgw#1052 — overlap export with the compile pool

- `EntryCompilePool.compile` accepts a producer **iterator** beside the existing list shape: the pull runs the export on the parent thread while children compile in their own processes. The mint constructs the pool **before** the first row exports and feeds each row as it arrives. Wall model: `≈ max(export, compile) + first-row latency` (producer 113 s/row vs pool 127 s/row at K=2 on the L40S ⇒ 165 → ~100 min projected).
- The iterator handoff is a deliberate narrow seam (`(name, program)` pairs, staging internal to the pool) so pgw#1056's fake-weight producer can swap the payload without touching orchestration.
- **pgw#917 moves to arrival**: a row duplicating an earlier row's ingress+identity aliases immediately (no compile spent); a same-ingress *different*-identity collision refuses at row N. **Stated trade**: on the refusal path the rows already exported may have compiled — bounded waste on a mint that was going to refuse anyway, buying ~65 min on every green sdxl mint. The batch gate re-runs over the kept rows at drain as the safety net for transitively-linked clusters (survivor selection there is unchanged).
- **pgw#992 continued**: the pool census still predates every child, and the export phase's growth (9.0 → 15.6 GiB reserved, attempt 30) — which now post-dates the census — is priced per spawn by `_spawn_admitted` (live own high-water against the same card-wide budget; holds a spawn, never narrows, never kills, floor 1).
- Ledger honesty: producer seconds land in a new `idle_source_s` bucket; `export_all_s`, export peaks and the per-row export delta are all still measured (children are separate processes, so the parent's allocator counters stay export-only); beats interleave `trace_graph`/`inductor_compile` and the phase snapshot stays live on every terminus.

## pgw#1053 — release the dead residents

- **Mint child** (and operator CLI): `mint(..., release_residents=True)` — the caller's statement that its pipeline dies with the process. After the last row exports, retained programs are projected to **code-only** (state_dict weights → meta; literals keep their bytes — pgw#857 keys them by value) and the pipeline modules are meta'd. **No gate is dropped**: `program_package_drift`, `unbindable_constants`, `input_contract`, `entry_graph_block`, `_write_literals` and the drain-time pgw#917 pass all read names/shapes/literal bytes and run against the projection. Compile children read the staged programs written *before* the release — byte-for-byte, cell key proven identical (test).
- **Pool regrant**: `note_residents_released()` re-baselines the own floor of the simultaneity budget and re-derives K through the *same* pgw#992-bounded path (`_rewiden(trigger="release")`; construction ask when fewer than 2 measured reports — the release moved the budget, not the divisor). The co-tenant term is never touched (test).
- **Forge-pod parent**: with **no serve goal** (the goals machinery decides, pgw#930 — never a mode probe), `mint_delegate.maybe_park_eager` moves the serving process's eager pipeline (9.54 GiB measured) to host RAM before the first budget probe and restores it before ADOPT; failure to fully restore refuses adoption typed. **A pod holding a serve goal never parks** — eager stays resident and hot per Paul's ruling; dual-goal (serve+mint) keeps its reserve. The pgw#763 host-move guard stays armed and is the park's budget check.
- Arithmetic on pgw#992's own terms: L40S budget 16.65 → ~41 GiB, K 2 → 5 at the measured 7.02 GiB ask; combined with #1052 the projected wall is ~45-60 min. **Pod-side confirmation belongs to the next pgw#868 attempt.** The mint-child half is superseded by construction once pgw#1056's fake-weight mint lands; the pool-side regrant it feeds is exactly what that mint's verification load will use.

## Verification

- New: `tests/test_overlap_export_compile_pgw1052.py` (deterministic overlap proof — child report lands while the source is open; arrival alias/refusal; **byte-identical cell key serial vs overlapped**; interleaved beats), `tests/test_mint_residents_pgw1053.py` (code-only projection with frozen identity; full mint with release keys identically and provably releases; regrant on the pgw#992 incident pod's own numbers, bounded, co-tenant untouched; live spawn admission; goals-decided park/restore incl. a GPU leg).
- Full v1 suite from a worktree at `-n 4`: green locally and on CI (the one intermediate red was the pre-existing gw#624 gc-timing flake plus the pgw#966 census line and pgw#1058's dtype requirement landing mid-lane, all resolved). tests_v2 green. Micro gauntlet: cardless — every runnable variant matches (gpu-only lanes NOT-RUN by design); GPU (RTX 4070 via `.venv-cu126`, 4 GiB rig budget, `nice -n 10`) — **all six variants match**, including the pgw#1042 handback leg and the expected-red lane-drift refusal.
- Rig walls, measured:
  - cardless micro (3 entries, K=3=entries — **no rounds**, so parity is the *expected* result): mint total 23.9 s → 26.1 s (± shared-box noise), with `export_all_s` 2.99 s now *inside* `pool_wall_s` and charged to `idle_source_s`;
  - **rig-scale sdxl shape (6 entries, K=2 — rounds), real exports + real AOTI children, two consecutive passes on a quiet box: wall 78.8 → 60.9 s and 71.1 → 53.9 s, after/before = 0.77/0.76**;
  - GPU pool path (micro, `--entry-device-peak-bytes` = the banked handoff a serving parent makes): `K=2 (vram-bound, **measured** basis)`, overlap live (`idle_source_s` 4.2 s), on-card release executed (2 modules projected, true peak banked before the allocator reset), handback + adopt parity 5.96e-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
