### PR TITLE
th#1721: the two weight contracts get their ratified names — TENSOR-LAYOUT and TENSOR-BINDING

### DIFF
--- a/changelog.d/pgw1060.md
+++ b/changelog.d/pgw1060.md
@@ -1,6 +1,6 @@
 - **pgw#1060: the vocabulary now says which half it means — `envelope` for the
   declared serving region, "the graph digest" for the traced fact, and "the
-  weight-binding contract" for the pgw#857 state-dict rule.** Nothing
+  tensor-binding contract" for the pgw#857 state-dict rule.** Nothing
   serialized moved. The `contract` axis fuses a MEASURED FACT (the traced-graph
   digest) with a DECLARED PROMISE (which resolutions, text lengths, guidance
   values and batch sizes the cell serves), and that fusion has bitten twice in
@@ -12,7 +12,7 @@
   DERIVED from the packaged program rather than a third independent fact, and
   refusal/log text reads "outside the declared envelope" instead of the fused
   "out-of-contract". `docs/endpoint-authoring.md`'s `register_buffer` section is
-  retitled **the weight-binding contract** and carries the two pgw#1056
+  retitled **the tensor-binding contract** and carries the two pgw#1056
   authoring corollaries: a GB-scale config-derived tensor is a named CAS
   component bound like a weight (scale decides, not provenance), and `__init__`
   must be meta-device safe for the zero-download forge. `gen_worker.api

--- a/changelog.d/th1721.md
+++ b/changelog.d/th1721.md
@@ -1,0 +1,23 @@
+- **th#1721 / DESIGN-RULINGS §1.30: the two weight contracts have ratified
+  names — the TENSOR-LAYOUT contract and the TENSOR-BINDING contract.** The
+  tensor-layout contract (was "the artifact contract", briefly "weight-format")
+  is how tensors exist ON DISK: byte packing, scale layout, swizzle, key-naming
+  convention, file topology, named by a descriptor handle
+  `<producer>.<format>@<major>`. The tensor-binding contract (was
+  "weight-binding") is the artifact's LINKING rule for tensors: bound by name at
+  load (dynamic — an opaque slot the compiler must never value-specialize, which
+  is what makes a cell checkpoint-agnostic) versus a baked literal (static — the
+  value folds into cell identity; driven to zero), with GB-scale derived data
+  neither, as a named CAS component. `tensor-` and not `weight-` in both,
+  deliberately: they govern scales, buffers and computed tables, not just
+  trained weights. The classification derives from `state_dict` membership at
+  trace time — the author configures the compiler by how the code is written,
+  never out of band. `gen_worker.models.artifact_contract` →
+  `gen_worker.models.tensor_layout_contract` and its marker attribute
+  `__cozy_artifact_contracts__` → `__cozy_tensor_layout_contracts__` (neither is
+  serialized; no alias, pre-launch hardcut). `docs/endpoint-authoring.md` and
+  `docs/compile-cache.md` now define both. **Every registered contract HANDLE
+  (`cozy.fp8-rowwise@1`, `cozy.svdq-nvfp4-lr8@1`, …) is stored data and is
+  UNCHANGED**, as are tensorhub's `artifact_contract` column, publish JSON field
+  and `artifact_contract_*` refusal codes — those ride one coordinated wire
+  moment tracked on th#1721.

--- a/docs/compile-cache.md
+++ b/docs/compile-cache.md
@@ -31,6 +31,30 @@ is what makes its refusals readable:
   artifact rather than declared beside it. A label carried alongside an artifact
   can drift from it, and a label that can drift is not an identity (pgw#1058).
 
+Two further contracts share the word and are neither of the above. Both are
+about the WEIGHTS, not about the compiled program:
+
+- **The tensor-layout contract** — how tensors exist ON DISK: byte packing,
+  scale layout, swizzle, key-naming convention, file topology. Named by a
+  registered descriptor handle `<producer>.<format>@<major>`
+  (`cozy.fp8-rowwise@1`, `cozy.svdq-nvfp4-lr8@1`, …); a decoder declares the
+  handles it implements with `@implements_contract`
+  (`gen_worker.models.tensor_layout_contract`), and the vocabulary itself lives
+  in tensorhub. It says what the bytes ARE and nothing about compilation.
+  (th#1580 / th#1721; was called "the artifact contract".)
+- **The tensor-binding contract** — the artifact's LINKING rule for tensors:
+  bound by name at load (DYNAMIC — an opaque slot the compiler must never
+  value-specialize, which is what makes a cell checkpoint-agnostic) versus a
+  baked literal (STATIC — the value folds into cell identity; driven to zero).
+  GB-scale derived data is neither and becomes a named CAS component. The
+  classification derives from `state_dict` membership at trace time: the author
+  configures the compiler by how the code is written, never out of band.
+  Authoring rules in `docs/endpoint-authoring.md`. (pgw#857; was
+  "weight-binding".)
+
+`tensor-` and not `weight-` in both names, deliberately — they govern scales,
+buffers and computed tables, not just trained weights.
+
 Widening the envelope moves the promise; it does not move the fact. The cell key
 still fuses both halves into one `contract` axis — splitting it into
 `graph` x `envelope` is a single coordinated change to the key schema (pgw#1059,

--- a/docs/endpoint-authoring.md
+++ b/docs/endpoint-authoring.md
@@ -69,14 +69,37 @@ annotation (`FluxPipeline` → `from_pretrained`; `str`/`Path` → the local
 snapshot dir), and owns device placement and low-VRAM offload. Endpoint code
 never calls `.to("cuda")`, `enable_model_cpu_offload()`, or `empty_cache()`.
 
-## The weight-binding contract: `register_buffer`, never a plain attribute (pgw#857)
+## The tensor-binding contract: `register_buffer`, never a plain attribute (pgw#857)
 
-A compiled cell rebinds weights **by name** at load, which is what lets one cell
+A compiled cell rebinds tensors **by name** at load, which is what lets one cell
 serve every fine-tune of a family. That only holds if every tensor your model
-needs is reachable through `state_dict()`. **The weight-binding contract** is
-that rule: a tensor your module holds is either a named state-dict entry the CAS
-delivers and rebinds, or it is baked into the artifact — there is no third
-outcome, and you choose which one by how you assign it.
+needs is reachable through `state_dict()`. **The tensor-binding contract**
+(formerly "weight-binding") is that rule — the artifact's LINKING rule for
+tensors. A tensor your module holds is either:
+
+- **bound by name at load** (DYNAMIC) — a named `state_dict` entry the CAS
+  delivers and rebinds. It is an opaque slot the compiler must never
+  value-specialize, and that opacity is exactly what makes a cell
+  CHECKPOINT-AGNOSTIC;
+- **a baked literal** (STATIC) — its value folds into the artifact's identity,
+  so two checkpoints differing only in that value need different cells. This
+  case is driven to zero;
+- for GB-scale derived data, neither: a **named CAS component** (corollary
+  below), bound by name exactly like a weight.
+
+There is no fourth outcome, and you choose which one by how you assign it.
+
+`tensor-` and not `weight-`, deliberately: the rule governs scales, buffers and
+computed tables, not just trained weights. Its sibling is the **tensor-layout
+contract** — how tensors exist ON DISK (byte packing, scale layout, swizzle,
+key-naming convention, file topology), named by a descriptor handle
+`<producer>.<format>@<major>`. Layout says what the bytes ARE; binding says how
+they are ADDRESSED at load.
+
+**You configure the compiler by how you write the code.** The classification is
+not a setting supplied out of band — it derives from `state_dict` membership at
+trace time. The code IS the configuration, and the assignment style below is the
+whole of it.
 
 If your model class holds a tensor that is **not** a learned parameter — a rope
 frequency table, a precomputed mask, any "just a cache" — **register it as a

--- a/src/gen_worker/cell_key.py
+++ b/src/gen_worker/cell_key.py
@@ -148,7 +148,7 @@ def is_key(value: str) -> bool:
     into ``unreadable_cell_key``, which is both a lie and a filter no axis
     justifies. A cell of an older scheme is admitted to the candidate list and
     then ruled on by the axes that actually decide whether this runtime can
-    execute it — the artifact contract, the identity axes and the numerics
+    execute it — the declared envelope, the identity axes and the numerics
     gate — not by the label on it.
     """
     v = str(value or "")

--- a/src/gen_worker/convert/writer.py
+++ b/src/gen_worker/convert/writer.py
@@ -547,7 +547,7 @@ def streaming_fp8_storage_cast(
 
 # ---------------------------------------------------------------------------
 # W8A8 per-channel-scaled fp8 producer (gw#557 / ie#494) — data-free requant
-# from the bf16 source, streaming. The artifact contract is gw#534's
+# from the bf16 source, streaming. The tensor-layout contract is gw#534's
 # ``#fp8-w8a8`` (consumed by gen_worker.models.w8a8): per quantized Linear a
 # F8_E4M3 ``weight`` plus a F32 [out] ``weight_scale`` DEQUANT twin; excluded
 # layers stay at source precision with NO scale tensor. Activation scales are

--- a/src/gen_worker/discovery/execution_lanes.py
+++ b/src/gen_worker/discovery/execution_lanes.py
@@ -23,7 +23,7 @@ import pkgutil
 
 import msgspec
 
-from gen_worker.models.artifact_contract import (
+from gen_worker.models.tensor_layout_contract import (
     ContractDecoder,
     contract_decoders_of,
 )

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -27,7 +27,7 @@ import sys
 
 from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
-from .artifact_contract import CONTRACT_PLAIN_BF16, implements_contract
+from .tensor_layout_contract import CONTRACT_PLAIN_BF16, implements_contract
 from .fp8_storage import restructure_fp8_storage
 from .memory import get_available_vram_gb, meta_tensors, probe_host_ram
 from .safetensors_header import header_len_ok

--- a/src/gen_worker/models/svdq_layout.py
+++ b/src/gen_worker/models/svdq_layout.py
@@ -63,7 +63,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
-from .artifact_contract import (
+from .tensor_layout_contract import (
     CONTRACT_COZY_SVDQ_NVFP4_LR8,
     CONTRACT_NUNCHAKU_V1,
     implements_contract,

--- a/src/gen_worker/models/tensor_layout_contract.py
+++ b/src/gen_worker/models/tensor_layout_contract.py
@@ -1,5 +1,12 @@
-"""th#1580 A4 (§1.30 declaration 2+3): a decoder declares WHICH ARTIFACT
+"""th#1580 A4 (§1.30 declaration 2+3): a decoder declares WHICH TENSOR-LAYOUT
 CONTRACT it implements, beside the code that implements it.
+
+The tensor-layout contract (th#1721; was "the artifact contract") is how
+tensors exist ON DISK — byte packing, scale layout, swizzle, key-naming
+convention, file topology — named by a descriptor handle
+``<producer>.<format>@<major>``. Its sibling, the tensor-binding contract
+(pgw#857, ``docs/endpoint-authoring.md``), is how a tensor is ADDRESSED at
+load: bound by name, or baked as a literal.
 
 The endpoint half of §1.30's compatibility intersection is DERIVED at image
 build (``gen_worker.discovery.execution_lanes``) from these markers. A
@@ -7,9 +14,9 @@ hand-maintained capability list is a second trusted string — the defect class
 th#1580 exists to remove — so there is no list: the declaration is a property
 of the decoder function, and it ships or fails to ship with it.
 
-The vocabulary lives in tensorhub's ``internal/artifactcontract`` (A2:
-contracts are CODE). This module carries only the handles a decoder may name
-and refuses anything else; it does not re-specify the descriptors.
+The vocabulary lives in tensorhub's ``internal/tensorlayout`` (A2: contracts
+are CODE). This module carries only the handles a decoder may name and refuses
+anything else; it does not re-specify the descriptors.
 
 **No exclusion marker exists, deliberately** (A4 corollary, Paul 2026-08-04).
 Exclusions are DERIVED from declared traits — ``composes_lora`` crossed with a
@@ -61,7 +68,7 @@ class ContractDecoder(msgspec.Struct, frozen=True, kw_only=True):
 # The declaration lives ON THE DECODER OBJECT, not in a module-level registry.
 # That is the point: it cannot be present without the decoder, cannot survive
 # the decoder being removed, and cannot be assembled anywhere else.
-MARKER = "__cozy_artifact_contracts__"
+MARKER = "__cozy_tensor_layout_contracts__"
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -76,7 +83,7 @@ def _validate(dec: ContractDecoder) -> None:
         raise ValueError(
             f"{dec.decoder}: contract {dec.contract!r} is not registered. "
             "Contracts are CODE (th#1580 A2): register it in tensorhub's "
-            "internal/artifactcontract with a descriptor and a probe set "
+            "internal/tensorlayout with a descriptor and a probe set "
             "before a decoder may claim it."
         )
     if not dec.serves:

--- a/src/gen_worker/models/w4a4.py
+++ b/src/gen_worker/models/w4a4.py
@@ -1,7 +1,7 @@
 """W4A4 nvfp4 loader mode (gw#540) — the gw#534 W8A8 pattern one tier down.
 
 A ``#nvfp4-w4a4`` flavor is a normal diffusers tree whose denoiser holds
-calibrated nvfp4 weights WITH two-level scales — the artifact contract
+calibrated nvfp4 weights WITH two-level scales — the tensor-layout contract
 (frozen in gw#540, consumed verbatim by the conversion side):
 
 - per quantized Linear ``L`` (modelopt export_hf_checkpoint shapes):
@@ -82,7 +82,7 @@ class W4a4Error(RuntimeError):
 
 
 class W4a4SnapshotError(W4a4Error):
-    """The flavor snapshot violates the artifact contract."""
+    """The flavor snapshot violates the tensor-layout contract."""
 
 
 @dataclass(frozen=True)

--- a/src/gen_worker/models/w8a8.py
+++ b/src/gen_worker/models/w8a8.py
@@ -1,7 +1,7 @@
 """W8A8 fp8-GEMM loader mode (gw#534).
 
 A ``#fp8-w8a8`` flavor is a normal diffusers tree whose denoiser holds
-calibrated fp8-E4M3 weights WITH scales — the artifact contract (frozen in
+calibrated fp8-E4M3 weights WITH scales — the tensor-layout contract (frozen in
 gw#534, consumed verbatim by the conversion side):
 
 - per quantized Linear ``L``: ``L.weight`` (F8_E4M3, [out, in]),
@@ -40,7 +40,7 @@ from pathlib import Path
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
 from .safetensors_header import header_len_ok
-from .artifact_contract import CONTRACT_COZY_FP8_ROWWISE, implements_contract
+from .tensor_layout_contract import CONTRACT_COZY_FP8_ROWWISE, implements_contract
 from typing import Any, Dict, List, Optional
 import shutil
 
@@ -61,7 +61,7 @@ class W8a8Error(RuntimeError):
 
 
 class W8a8SnapshotError(W8a8Error):
-    """The flavor snapshot violates the artifact contract."""
+    """The flavor snapshot violates the tensor-layout contract."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_compile_cache.py
+++ b/tests/test_compile_cache.py
@@ -950,9 +950,9 @@ def test_artifact_metadata_video_shapes_and_storage_dtype():
     assert cc.verify(meta, family="ltx-2.3") == ""
 
 
-def test_guidance_regimes_are_artifact_contract_axis():
+def test_guidance_regimes_are_an_envelope_axis():
     """SDK v2: warm guidance regimes live on the enriched CompileCell (from
-    payload CompileAxis classes), and remain an artifact contract axis."""
+    payload CompileAxis classes), and remain part of the declared envelope."""
     torch = pytest.importorskip("torch")
 
     class _Pipe:

--- a/tests/test_derived_execution_lanes_th1580.py
+++ b/tests/test_derived_execution_lanes_th1580.py
@@ -26,14 +26,14 @@ from gen_worker.discovery.execution_lanes import (
     execution_lanes_for_function,
     manifest_block,
 )
-from gen_worker.models.artifact_contract import (
+from gen_worker.models.tensor_layout_contract import (
     CONTRACT_COZY_FP8_ROWWISE,
     CONTRACT_NUNCHAKU_V1,
     implements_contract,
 )
 
 _GOOD_A = '''
-from gen_worker.models.artifact_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import implements_contract
 
 @implements_contract(
     contract="nunchaku.v1@1", serves=("svdq-fp4-w4a4",), composes_lora=False,
@@ -44,7 +44,7 @@ def decode_svdq(tensors):
 '''
 
 _GOOD_B = '''
-from gen_worker.models.artifact_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import implements_contract
 
 @implements_contract(
     contract="cozy.fp8-rowwise@1", serves=("fp8-w8a8-dynamic",),
@@ -59,7 +59,7 @@ def decode_fp8(tensors):
 _BROKEN = '''
 import a_dependency_this_image_does_not_have  # noqa: F401
 
-from gen_worker.models.artifact_contract import implements_contract
+from gen_worker.models.tensor_layout_contract import implements_contract
 
 @implements_contract(
     contract="bfl.nvfp4-preswizzled@1", serves=("nvfp4-w4a4-static",),

--- a/tests/test_graph_hash_pgw716.py
+++ b/tests/test_graph_hash_pgw716.py
@@ -46,7 +46,7 @@ class _TinyTwin(torch.nn.Module):
 
 
 class _TinyRenamed(torch.nn.Module):
-    """Same math, different parameter FQNs — a DIFFERENT artifact contract."""
+    """Same math, different parameter FQNs — a DIFFERENT tensor-binding contract."""
 
     def __init__(self, width: int = 8) -> None:
         super().__init__()
@@ -156,7 +156,7 @@ def test_same_graph_different_recipe_shares_the_hash():
 def test_module_rename_is_a_new_key():
     """A parameter FQN is what the serve path binds resident weights BY
     (pgw#721's constants-bound gate refuses by name), so renaming the module
-    that holds a weight is a different artifact contract, not the same graph."""
+    that holds a weight is a different tensor-binding contract, not the same graph."""
     assert gh.graph_hash(_export(_Tiny())) != gh.graph_hash(
         _export(_TinyRenamed()))
 

--- a/tests/test_nvfp4_fused_quant_pgw685.py
+++ b/tests/test_nvfp4_fused_quant_pgw685.py
@@ -79,7 +79,7 @@ def test_reference_chain_shapes_and_dequant_error() -> None:
 
 def test_low_nibble_holds_the_even_element() -> None:
     """The packed convention (element 2j in the LOW nibble) is what
-    ``torch.float4_e2m1fn_x2`` and the artifact contract assume; getting it
+    ``torch.float4_e2m1fn_x2`` and the tensor-layout contract assume; getting it
     backwards silently transposes every pair."""
     x = torch.zeros(1, 32)
     x[0, 0] = 6.0   # even position -> low nibble, code 7

--- a/tests/test_quantization_lanes.py
+++ b/tests/test_quantization_lanes.py
@@ -27,7 +27,7 @@ pytest.importorskip("accelerate")
 
 # ---------------------------------------------------------------------------
 # gw#534: W8A8 fp8-GEMM contract — real tiny diffusers pipeline (CPU, no
-# network), producer writes the exact artifact contract, loader dequants to
+# network), producer writes the exact tensor-layout contract, loader dequants to
 # bf16-resident and reproduces source weights to fp8 rounding.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Propagates the names Paul ratified 2026-08-09 (DESIGN-RULINGS §1.30 NAME RATIFIED block, th#1721 header), superseding the same-day "weight-format".

- **tensor-layout contract** (was "the artifact contract") — how tensors exist ON DISK: byte packing, scale layout, swizzle, key-naming convention, file topology. Descriptor handle `<producer>.<format>@<major>`.
- **tensor-binding contract** (was "weight-binding") — the artifact's LINKING rule for tensors: bound by name at load (dynamic; an opaque slot the compiler must never value-specialize, which is what makes a cell checkpoint-agnostic) vs a baked literal (static; the value folds into cell identity, driven to zero); GB-scale derived data is neither and becomes a named CAS component.

`tensor-` not `weight-` in both, deliberately: they govern scales, buffers and computed tables, not just trained weights. The classification is not configured out of band — it derives from `state_dict` membership at trace time, so the author configures the compiler by how the code is written.

### What moved
- `docs/endpoint-authoring.md` — section retitled, three outcomes stated explicitly, one inline "(formerly weight-binding)".
- `docs/compile-cache.md` — vocabulary section gains both contracts beside the graph-digest / envelope pair.
- `gen_worker.models.artifact_contract` → `gen_worker.models.tensor_layout_contract`; marker attribute `__cozy_artifact_contracts__` → `__cozy_tensor_layout_contracts__`. No alias (pre-launch hardcut). Neither is serialized; no repo outside this one imports the module.
- Prose in `models/w8a8`, `models/w4a4`, `convert/writer` and the quantization tests → "tensor-layout contract". `test_graph_hash_pgw716`'s FQN-rename cases → "tensor-binding contract" (what they were always about). `test_guidance_regimes_are_artifact_contract_axis` → `test_guidance_regimes_are_an_envelope_axis` — guidance regimes are the declared ENVELOPE, the homonym pgw#1060 fixed everywhere else.

### What deliberately did NOT move
Everything stored-as-data or wire-borne, deferred to th#1721's coordinated moment: every registered contract HANDLE (`cozy.fp8-rowwise@1`, `cozy.svdq-nvfp4-lr8@1`, …), tensorhub's `checkpoints.artifact_contract` column, the publish-v2 `artifact_contract` JSON field, and the `artifact_contract_*` refusal codes.

### Gates
mypy clean on every touched file; all seven lint guards green; changelog-fragment name check green; `test_derived_execution_lanes_th1580` (the marker's own suite) green. The three `test_compile_cache` failures locally are the known worktree torch-absent false-red — CI is the authority.