### PR TITLE
pgw#1064: dead-code wave 3 — 14 zero-consumer symbols, and the frozen Settings read directly

### DIFF
--- a/changelog.d/pgw1064.md
+++ b/changelog.d/pgw1064.md
@@ -1,0 +1,30 @@
+- **pgw#1064: dead-code wave 3 — 14 zero-consumer symbols outside the pgw#849
+  ratchet's fence, plus the defensive-`getattr` tail.** Every row was censused
+  by CONTENT (word-boundary + string-keyed grep over `src/ tests/ tests_v2/
+  scripts/ examples/ docs/ proto/ packages/ agents/`), across all six sibling
+  repos (`inference-endpoints`, `private-inference-endpoints`,
+  `training-endpoints`, `cozy-local`, `e2e`, `tensorhub`) and every live lane
+  worktree, and RE-verified on `d61370e9` before deletion. Deleted:
+  `convert/base_model_families.registered_foreign_sources`,
+  `convert/classifier._DEMO_EXTS`, `convert/ingest.{HFSourcePlan,
+  CivitaiSourcePlan}.bank_extra`, `models/memory._escalate_pipeline_mode`
+  (and the `_DEFAULT_ESCALATION` table + `TypeVar` only it named),
+  `component_vocab.ComponentVocabulary.{is_text_encoder,is_vae}`,
+  `geometry.FamilyGeometry.edit_area_ceiling` (and `max_edit_area`, the field
+  whose only reader it was — zero adopters in any repo that vendors the
+  wheel), `progress.UNIT_GRAPHS`, `topology.{installed_topology,
+  set_device_group}`, `models/lora_lifted.lifted_execution_lane_kwargs`,
+  `models/pinned_swap.prestage_object`,
+  `models/w8a8_lora.branch_execution_lanes_active`,
+  `models/svdq_native.SVDQ_ENGINE_NUNCHAKU`,
+  `request_context/_helpers._STALE_MIRROR_CLAIM_ERROR_CODES`.
+  **Nothing ever read the "bank extra" metadata** — `bank_files`, its
+  duck-type partner, is live, so this was a protocol method whose consumer
+  side never grew; noted here in case the banking feature's owner recognizes
+  a lost intent.
+- **pgw#1064 (pgw#881 defect class): `content_credentials.configure` and
+  `Lifecycle.__init__` read the frozen typed `Settings` DIRECTLY.** Five
+  `getattr(settings, "x", default)` sites became attribute access, and
+  `configure`'s parameter is typed `Settings` instead of `Any` — a defensive
+  getattr hides exactly the stale-field mistake the `bootstrap_worker_jwt`
+  rename was made to surface, and mypy can only catch it against a real type.

--- a/src/gen_worker/component_vocab.py
+++ b/src/gen_worker/component_vocab.py
@@ -50,12 +50,6 @@ class ComponentVocabulary:
     def is_denoiser(self, name: str) -> bool:
         return _head(name) in self.denoisers
 
-    def is_text_encoder(self, name: str) -> bool:
-        return _head(name) in self.text_encoders
-
-    def is_vae(self, name: str) -> bool:
-        return _head(name) in self.vaes
-
     def role_of(self, name: str) -> str:
         head = _head(name)
         if head in self.denoisers:

--- a/src/gen_worker/content_credentials.py
+++ b/src/gen_worker/content_credentials.py
@@ -58,10 +58,13 @@ import json
 import logging
 import threading
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 import os
 import tempfile
 from .procsplit import broker
+
+if TYPE_CHECKING:
+    from .config import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +188,7 @@ _config: Optional[_SignerConfig] = None
 _remote: Optional[_RemoteSigner] = None
 
 
-def configure(settings: Any) -> None:
+def configure(settings: Settings) -> None:
     """Install (or clear) the process-wide signer config from Settings.
 
     Called once at worker startup. Raises when signing is configured but
@@ -196,8 +199,8 @@ def configure(settings: Any) -> None:
     """
     global _configured, _config
     _refuse_pod_private_key_material(settings)
-    inline_cert = str(getattr(settings, "c2pa_cert_pem", "") or "").strip()
-    cert_path = str(getattr(settings, "c2pa_cert_path", "") or "").strip()
+    inline_cert = settings.c2pa_cert_pem.strip()
+    cert_path = settings.c2pa_cert_path.strip()
     with _lock:
         if not inline_cert and not cert_path:
             _config = None
@@ -216,11 +219,11 @@ def configure(settings: Any) -> None:
                 cert_pem = open(cert_path, "rb").read()
             except OSError as e:
                 raise C2paSigningError(f"cannot read C2PA signing cert: {e}") from e
-        alg = str(getattr(settings, "c2pa_alg", "") or "es256").strip().lower()
+        alg = (settings.c2pa_alg or "es256").strip().lower()
         cfg = _SignerConfig(
             cert_pem=cert_pem,
             alg=alg,
-            ta_url=str(getattr(settings, "c2pa_ta_url", "") or "").strip(),
+            ta_url=settings.c2pa_ta_url.strip(),
             generator_version=_generator_version(),
         )
         # Startup probe of everything checkable without the hub: the cert

--- a/src/gen_worker/convert/base_model_families.py
+++ b/src/gen_worker/convert/base_model_families.py
@@ -57,11 +57,6 @@ def civitai_to_family(value: str) -> Optional[str]:
     return foreign_to_family(CIVITAI, value)
 
 
-def registered_foreign_sources() -> tuple[str, ...]:
-    with _lock:
-        return tuple(sorted(_maps))
-
-
 def reset_foreign_family_maps() -> None:
     """Tests only."""
     with _lock:
@@ -73,6 +68,5 @@ __all__ = [
     "civitai_to_family",
     "declare_foreign_family_map",
     "foreign_to_family",
-    "registered_foreign_sources",
     "reset_foreign_family_maps",
 ]

--- a/src/gen_worker/convert/classifier.py
+++ b/src/gen_worker/convert/classifier.py
@@ -26,7 +26,6 @@ _JUNK_EXTS = {
     ".onnx", ".onnx_data", ".pb", ".h5", ".tflite", ".engine", ".plan",
     ".mlmodel", ".mlpackage", ".msgpack", ".nemo", ".xml",
 }
-_DEMO_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".mp4", ".mp3", ".wav", ".avif"}
 _ALWAYS_INCLUDE = {"readme.md", "license", "license.md", "license.txt", "notice", "usage_policy.md"}
 
 _SIZE_REFUSE_BYTES = 100 * 1024 * 1024 * 1024

--- a/src/gen_worker/convert/ingest.py
+++ b/src/gen_worker/convert/ingest.py
@@ -263,13 +263,6 @@ class HFSourcePlan:
             out.append((p, int(self.sizes.get(p, 0)), cid))
         return sorted(out)
 
-    def bank_extra(self) -> dict[str, str]:
-        attrs = {str(k): str(v) for k, v in (self.classification.attrs or {}).items()}
-        return {
-            "strategy": str(self.classification.strategy),
-            "attrs": json.dumps(attrs, sort_keys=True, separators=(",", ":")),
-        }
-
 
 @dataclass
 class CivitaiSourcePlan:
@@ -296,13 +289,6 @@ class CivitaiSourcePlan:
                 return []
             out.append((str(f.get("name")), int(f.get("size_bytes") or 0), f"sha256:{sha}"))
         return sorted(out)
-
-    def bank_extra(self) -> dict[str, str]:
-        model = self.payload.get("model") if isinstance(self.payload.get("model"), dict) else {}
-        return {
-            "base_model": str(self.payload.get("baseModel") or ""),
-            "model_type": str((model or {}).get("type") or ""),
-        }
 
 
 def _civitai_manifest_revision(file_names: list[str]) -> str:

--- a/src/gen_worker/geometry.py
+++ b/src/gen_worker/geometry.py
@@ -98,8 +98,6 @@ class FamilyGeometry(msgspec.Struct, frozen=True, kw_only=True):
     buckets: tuple[tuple[int, int], ...]
     #: Latent/patch alignment every row must satisfy.
     multiple_of: int = 16
-    #: Largest area an edit may be asked to produce. None -> ``native_area``.
-    max_edit_area: Optional[int] = None
 
     def __post_init__(self) -> None:
         if not self.buckets:
@@ -123,10 +121,6 @@ class FamilyGeometry(msgspec.Struct, frozen=True, kw_only=True):
                     f"outside {lo}..{hi}x (ie#599: this is exactly the t2i-table-on-an-"
                     f"edit-lane defect)"
                 )
-
-    @property
-    def edit_area_ceiling(self) -> int:
-        return self.native_area if self.max_edit_area is None else self.max_edit_area
 
     def assert_declared(self, shapes: Sequence[tuple[int, int]]) -> None:
         """Every bucket must be a declared compile shape. Call from tests."""

--- a/src/gen_worker/lifecycle.py
+++ b/src/gen_worker/lifecycle.py
@@ -269,7 +269,7 @@ class Lifecycle:
         # down as a plain value. A claim is not a credential.
         self.release_id = (
             str(claims.get("release_id") or "").strip()
-            or str(getattr(settings, "worker_release_id", "") or "").strip()
+            or settings.worker_release_id.strip()
         )
         self.intent_registry = IntentRegistry(
             self.release_id,

--- a/src/gen_worker/models/lora_lifted.py
+++ b/src/gen_worker/models/lora_lifted.py
@@ -517,16 +517,6 @@ def remove_lifted_lora_execution_lanes(pipe: Any) -> None:
         remove_lifted_lora_forward(model)
 
 
-def lifted_execution_lane_kwargs(pipe: Any) -> Dict[str, Dict[str, Any]]:
-    """component -> the two call kwargs for that component's compiled unit."""
-    out: Dict[str, Dict[str, Any]] = {}
-    for comp, model in branch_targets(pipe).items():
-        binding = lifted_binding(model)
-        if binding is not None:
-            out[comp] = binding.call_kwargs()
-    return out
-
-
 def swap_lifted_execution_lane_set(
     pipe: Any,
     routed: Mapping[str, Sequence[Tuple[Dict[str, Any], float, str]]],
@@ -693,7 +683,6 @@ __all__ = [
     "install_lifted_lora_execution_lanes",
     "lifted_binding",
     "lifted_input_names",
-    "lifted_execution_lane_kwargs",
     "is_exported_program",
     "lora_constant_fqns",
     "package_constant_audit",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -24,7 +24,7 @@ import gc
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, TypeVar
+from typing import Any, Dict, Iterable, List, Optional
 
 import msgspec
 
@@ -1350,38 +1350,6 @@ def _default_disk_offload_path() -> Optional[str]:
 # ---------------------------------------------------------------------------
 # OOM retry
 # ---------------------------------------------------------------------------
-
-
-_DEFAULT_ESCALATION: tuple[str, ...] = (
-    "vae_only", "model_offload", "group_offload", "sequential",
-)
-
-T = TypeVar("T")
-
-
-def _escalate_pipeline_mode(
-    pipeline: Any,
-    *,
-    logger: logging.Logger,
-    escalation: tuple[str, ...],
-) -> bool:
-    """Move a pipeline one step further up the offload ladder. False if maxed."""
-    cur = getattr(pipeline, _COZY_MODE_ATTR, None)
-    idx = escalation.index(cur) if cur in escalation else -1
-    next_idx = idx + 1
-    if next_idx >= len(escalation):
-        return False
-    next_mode = escalation[next_idx]
-    try:
-        delattr(pipeline, _COZY_MODE_ATTR)
-    except Exception:
-        try:
-            setattr(pipeline, _COZY_MODE_ATTR, None)
-        except Exception:
-            pass
-    logger.warning("low_vram: escalating %s -> %s on OOM", cur, next_mode)
-    apply_low_vram_config(pipeline, mode=next_mode, logger=logger)
-    return True
 
 
 def rearm_offload(pipeline: Any, mode: Mode = "model_offload") -> bool:

--- a/src/gen_worker/models/pinned_swap.py
+++ b/src/gen_worker/models/pinned_swap.py
@@ -283,23 +283,6 @@ def prestage_module(module: Any) -> int:
     return pinned_bytes
 
 
-def prestage_object(obj: Any) -> int:
-    """:func:`prestage_module` over a residency object: a bare ``nn.Module``
-    or a pipeline exposing ``components``. Returns total bytes pinned."""
-    try:
-        import torch.nn as nn
-    except Exception:
-        return 0
-    if isinstance(obj, nn.Module):
-        return prestage_module(obj)
-    comps = getattr(obj, "components", None)
-    if isinstance(comps, dict) and comps:
-        return sum(
-            prestage_module(m) for m in comps.values() if isinstance(m, nn.Module)
-        )
-    return 0
-
-
 def cached_swap_bytes(obj: Any) -> int:
     """Bytes already staged in pinned host caches under ``obj`` — a demote of
     this object needs that much LESS fresh host RAM."""
@@ -331,5 +314,4 @@ __all__ = [
     "swap_object",
     "cached_swap_bytes",
     "prestage_module",
-    "prestage_object",
 ]

--- a/src/gen_worker/models/svdq_native.py
+++ b/src/gen_worker/models/svdq_native.py
@@ -70,7 +70,6 @@ from .svdq_awq_packed import awq_packed_supported, build_awq_packed_linear
 logger = logging.getLogger(__name__)
 
 SVDQ_ENGINE_NATIVE = "native"
-SVDQ_ENGINE_NUNCHAKU = "nunchaku"
 
 # Blackwell fp4 tensor cores — the SAME silicon window as the #nvfp4-w4a4 lane
 # (both are block-scaled nvfp4 through torch._scaled_mm / cuBLASLt). torch's own
@@ -611,7 +610,6 @@ def load_svdq_native_pipeline(cls: Any, path: Any, art: Any, *,
 
 __all__ = [
     "SVDQ_ENGINE_NATIVE",
-    "SVDQ_ENGINE_NUNCHAKU",
     "SVDQ_NATIVE_FP4_SMS",
     "SvdqNativeError",
     "adanorm_splits_for",

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -664,10 +664,6 @@ def clear_branch_execution_lanes(pipe: Any) -> None:
         clear_branch_adapters(model)
 
 
-def branch_execution_lanes_active(pipe: Any) -> bool:
-    return any(branches_active(m) for m in branch_targets(pipe).values())
-
-
 def pipeline_branch_bucket(pipe: Any) -> int:
     """The pipeline's branch bucket — one value across the denoiser set (the
     set is always enabled/resized together), 0 when no branch is enabled."""
@@ -1133,7 +1129,6 @@ __all__ = [
     "apply_branch_adapters",
     "branch_bucket",
     "branch_execution_lane",
-    "branch_execution_lanes_active",
     "branch_modules",
     "branch_targets",
     "branches_active",

--- a/src/gen_worker/progress.py
+++ b/src/gen_worker/progress.py
@@ -22,7 +22,6 @@ from typing import Dict, List, Optional
 
 UNIT_BYTES = "bytes"
 UNIT_STEPS = "steps"
-UNIT_GRAPHS = "graphs"
 # Combined watchdog evidence (process+children CPU seconds + process disk
 # IO MB, see activity._default_evidence) — covers load/compile phases with
 # no natural app-level counter.

--- a/src/gen_worker/request_context/_helpers.py
+++ b/src/gen_worker/request_context/_helpers.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 _PUBLIC_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
-_STALE_MIRROR_CLAIM_ERROR_CODES = {"source_version_not_found", "source_variants_not_found"}
 _MAX_OUTPUT_FILE_BYTES = 20 * 1024 * 1024 * 1024  # 20 GiB hard cap per file.
 _FILE_API_HTTP_TIMEOUT_S = 60
 _FILE_API_STREAM_CHUNK_TIMEOUT_S = 120

--- a/src/gen_worker/topology.py
+++ b/src/gen_worker/topology.py
@@ -108,10 +108,6 @@ def current_device_group() -> int:
     return _current_group.get()
 
 
-def set_device_group(ordinal: int) -> contextvars.Token:
-    return _current_group.set(int(ordinal))
-
-
 # The delivered packing, published process-wide so the ambient group ordinal
 # can be TRANSLATED into the cards that group actually owns. An ordinal is not
 # a device index — at degree D group g owns ``[g*D, (g+1)*D)`` — and the
@@ -127,10 +123,6 @@ def install_topology(topo: Optional["ExecutionTopology"]) -> None:
     """Publish the delivered packing for the ordinal -> device translation."""
     global _installed
     _installed = topo
-
-
-def installed_topology() -> Optional["ExecutionTopology"]:
-    return _installed
 
 
 def group_devices(ordinal: Optional[int] = None) -> Tuple[int, ...]:

--- a/tests/test_disk_telemetry_pgw610.py
+++ b/tests/test_disk_telemetry_pgw610.py
@@ -13,8 +13,8 @@ import asyncio
 import os
 import time
 from pathlib import Path
-from types import SimpleNamespace
 
+from gen_worker.config import Settings
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.lifecycle import Lifecycle
 from gen_worker.models.disk_telemetry import DISK_QUANTUM_BYTES
@@ -147,8 +147,8 @@ def test_hello_and_state_delta_carry_measured_disk(tmp_path: Path) -> None:
         await store.refresh_disk_usage_report()
         ex = Executor([], _noop_send, store=store)
         lc = Lifecycle(
-            SimpleNamespace(bootstrap_worker_jwt="", worker_id="w-test",
-                            runpod_pod_id="", worker_image_digest=""),
+            Settings(bootstrap_worker_jwt="", worker_id="w-test",
+                     runpod_pod_id="", worker_image_digest=""),
             ex,
         )
         delta = lc._state_delta()

--- a/tests/test_executor_adopt.py
+++ b/tests/test_executor_adopt.py
@@ -10,7 +10,6 @@ import logging
 import threading
 from dataclasses import replace
 from pathlib import Path
-from types import SimpleNamespace
 
 import msgspec
 import pytest
@@ -30,6 +29,7 @@ from gen_worker.models import provision
 from gen_worker.api.binding import Hub
 from gen_worker.api.binding import wire_ref
 from gen_worker.api.errors import RetryableError
+from gen_worker.config import Settings
 from gen_worker.executor import Executor
 from gen_worker.lifecycle import Lifecycle
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -323,7 +323,7 @@ def test_compile_target_state_delta_is_exact_and_ready_only(tmp_path):
     assert target.active_compile_snapshot_digest == ""
 
     lifecycle = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="worker"), ex)
+        Settings(bootstrap_worker_jwt="", worker_id="worker"), ex)
     delta = lifecycle._state_delta()
     assert delta.compile_targets == ex.compile_targets()
 
@@ -1095,7 +1095,7 @@ def test_flux_base_w8a8_boot_proves_generate_and_edit_aliases(
     assert _events(sent, pb.MODEL_STATE_FAILED) == []
 
     lifecycle = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="worker"), ex)
+        Settings(bootstrap_worker_jwt="", worker_id="worker"), ex)
     failed_delta = lifecycle._state_delta()
     assert "edit" in failed_delta.available_functions
     assert "generate" in failed_delta.available_functions

--- a/tests/test_heartbeat_gw613.py
+++ b/tests/test_heartbeat_gw613.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import gen_worker.lifecycle as lifecycle_mod
+from gen_worker.config import Settings
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.lifecycle import HEARTBEAT_INTERVAL_MS, Lifecycle
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -45,8 +46,8 @@ def _lifecycle(tmp_path: Path) -> tuple[Lifecycle, _FakeTransport]:
     store = ModelStore(_noop_send, cache_dir=tmp_path)
     ex = Executor([], _noop_send, store=store)
     lc = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="w-beat",
-                        runpod_pod_id="", worker_image_digest=""),
+        Settings(bootstrap_worker_jwt="", worker_id="w-beat",
+                 runpod_pod_id="", worker_image_digest=""),
         ex,
     )
     transport = _FakeTransport()

--- a/tests/test_hello_ack_model_diff_gw614.py
+++ b/tests/test_hello_ack_model_diff_gw614.py
@@ -19,6 +19,7 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
+from gen_worker.config import Settings
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.lifecycle import Lifecycle
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -49,8 +50,8 @@ def _lifecycle(tmp_path: Path) -> Lifecycle:
     store = ModelStore(_noop_send, cache_dir=tmp_path)
     ex = Executor([], _noop_send, store=store)
     lc = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="w-ack-diff",
-                        runpod_pod_id="", worker_image_digest=""),
+        Settings(bootstrap_worker_jwt="", worker_id="w-ack-diff",
+                 runpod_pod_id="", worker_image_digest=""),
         ex,
     )
     lc.transport = _FakeTransport()

--- a/tests/test_host_canary.py
+++ b/tests/test_host_canary.py
@@ -13,11 +13,11 @@ classification are pure and tested against verbatim ``nvidia-smi`` output.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 
 import pytest
 
 from gen_worker import host_canary as hc
+from gen_worker.config import Settings
 from gen_worker.executor import Executor
 from gen_worker.lifecycle import Lifecycle
 
@@ -96,8 +96,8 @@ def _fake_cuda(monkeypatch: pytest.MonkeyPatch):
 def _hello_canary(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(hc, "_cached", None)
     lc = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="w-748",
-                        runpod_pod_id="", worker_image_digest=""),
+        Settings(bootstrap_worker_jwt="", worker_id="w-748",
+                 runpod_pod_id="", worker_image_digest=""),
         Executor([], lambda *a, **k: None),
     )
     return lc.build_hello().resources.host_canary

--- a/tests/test_superseded_disk_ref_th1330.py
+++ b/tests/test_superseded_disk_ref_th1330.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from gen_worker import activity as activity_mod
+from gen_worker.config import Settings
 from gen_worker.executor import Executor, ModelStore
 from gen_worker.lifecycle import Lifecycle
 from gen_worker.pb import worker_scheduler_pb2 as pb
@@ -55,8 +56,8 @@ def _lifecycle(tmp_path: Path) -> Lifecycle:
     store = ModelStore(_noop_send, cache_dir=tmp_path)
     ex = Executor([], _noop_send, store=store)
     lc = Lifecycle(
-        SimpleNamespace(bootstrap_worker_jwt="", worker_id="w-th1330",
-                        runpod_pod_id="", worker_image_digest=""),
+        Settings(bootstrap_worker_jwt="", worker_id="w-th1330",
+                 runpod_pod_id="", worker_image_digest=""),
         ex,
     )
     lc.transport = _FakeTransport()


### PR DESCRIPTION
pgw#1064: dead-code wave 3 — 14 zero-consumer symbols, and the frozen Settings read directly

Every row re-censused BY CONTENT on origin/master d61370e9 before deletion
(the filing's 582f3e87 has since moved): word-boundary + string-keyed grep
over src/ tests/ tests_v2/ scripts/ examples/ docs/ proto/ packages/ agents/,
across all six sibling repos (inference-endpoints, private-inference-endpoints,
training-endpoints, cozy-local, e2e, tensorhub) and every live lane worktree.
Zero consumers for all 14. None of these modules is inside the pgw#849
ratchet's aot/mint/serve fence, so scripts/unreached_surface_baseline.txt is
untouched — verified, the guard reports the same 12 rows before and after.

DELETED
  convert/base_model_families.registered_foreign_sources — introspection
    helper nobody introspects (def + its own __all__ entry, nothing else).
  convert/classifier._DEMO_EXTS — def-only. The classifier builds ALLOW-lists;
    _JUNK_EXTS is the live exclusion, so there is no exclude pass this should
    have fed.
  convert/ingest.HFSourcePlan.bank_extra + CivitaiSourcePlan.bank_extra —
    NOTHING EVER READ THE "BANK EXTRA" METADATA. The duck-type partner
    bank_files IS live (convert/clone.py, tests/convert/
    test_component_subfolder_pgw761.py), so this is a protocol method whose
    consumer side never grew. Recorded here in case the banking feature's
    owner recognizes a lost intent.
  models/memory._escalate_pipeline_mode — orphaned private; the surviving
    offload machinery (rearm_offload, apply_low_vram_config) never named it.
    Takes with it _DEFAULT_ESCALATION and the TypeVar T, both already
    zero-reference (verified whole-tree and cross-repo), and the now-unused
    TypeVar import.
  component_vocab.ComponentVocabulary.is_text_encoder + is_vae — exactly these
    two. The siblings is_denoiser/role_of stay live and are pinned by
    test_repack_engine_pgw740 / test_component_vocab_sweep_pgw740, so an
    over-wide deletion goes red.
  geometry.FamilyGeometry.edit_area_ceiling AND its field max_edit_area. The
    property was the field's ONLY reader, so keeping the field would leave
    declaration surface that literally cannot be read. Both have zero adopters
    in every repo that vendors the wheel (this is the author-surface caveat the
    aot_inputs.inputs_for false positive taught, checked and cleared).
  progress.UNIT_GRAPHS — zero readers; UNIT_BYTES/UNIT_STEPS/UNIT_EVIDENCE are
    live. The "graphs" hits in guard_closure.py are manifest keys, not units.
  topology.installed_topology + set_device_group — wrappers nobody calls; the
    state both wrap is used directly (_installed in group_devices,
    _current_group in device_group_scope). If pgw#648's "topology reporting"
    residue wants a getter seam, it should declare one there.
  models/lora_lifted.lifted_execution_lane_kwargs, models/pinned_swap.
    prestage_object, models/w8a8_lora.branch_execution_lanes_active — def +
    __all__ only. prestage_object checked against the open #907/#910/#911/#912
    pinned_swap arc: none of their bodies names it.
  models/svdq_native.SVDQ_ENGINE_NUNCHAKU — def + __all__ only. The engine
    vocabulary actually consulted is svdq.SVDQ_ENGINES plus literal "nunchaku"
    strings; SVDQ_ENGINE_NATIVE stays, it has a real use.
  request_context/_helpers._STALE_MIRROR_CLAIM_ERROR_CODES — def-only, and
    both literal error codes appear nowhere else in the tree. The classifier
    that consumed them is already gone.

SIMPLIFY (the pgw#881 defect class)
  content_credentials.configure and Lifecycle.__init__ now read the frozen
  typed Settings directly instead of through getattr(settings, "x", default).
  A defensive getattr hides exactly the stale-field mistake the
  bootstrap_worker_jwt rename was made to surface. configure's parameter is
  typed Settings rather than Any (TYPE_CHECKING import, no runtime cost), so
  mypy has something to check the access against — that is the fix's point.
  aot_mint.py:3391,3401 are the same class and are DELIBERATELY LEFT: that
  file belongs to the live pgw#1052/#1053 lane, which has the note.

Gates green locally: mypy clean (244 files), ruff clean, lint_http_timeouts,
lint_unreached_surface (exit 0, baseline unchanged), lint_config_reads,
lint_settings_writers, lint_ambient_census, lint_unbounded_reads.
