### PR TITLE
pgw#1062: the escape hatch is a standing gauntlet member — custom ops + Triton kernels through the whole mint

### DIFF
--- a/changelog.d/pgw1062.md
+++ b/changelog.d/pgw1062.md
@@ -1,0 +1,16 @@
+- **pgw#1062: the escape hatch is verified and standing — author-defined ops
+  (torch.library custom ops + hand-written Triton kernels) through the whole
+  mint.** New gauntlet member `micro-escape` (GPU lane): a `micro-diffusion`
+  variant whose traced graph carries a `custom_op` with a `register_fake`
+  kernel, a `triton_op`'d Triton kernel and a raw `@triton.jit` call, driven
+  through the REAL cycle — export → AOTI → seal → publish → second-process
+  adopt → arm → parity (measured max|delta| 1.67e-06 on sm_89). RED-provable:
+  dropping the `register_fake` makes the mint child refuse at export with the
+  typed `MintRefused` carrying torch's own `register_fake` guidance.
+  CI-side (`tests/test_escape_hatch_pgw1062.py`): the guidance-carrying
+  refusal, the FakeTensorMode traceability pgw#1056 stands on, the custom-op
+  `torch.export.save`/`load` hand-off, and a deliberate PIN on the measured
+  upstream break behind the flex_attention verdict — `torch.export.save`
+  refuses the flex HOP's block-mask argument (`SerializeError`, 2.13.0) even
+  though export + AOTI + parity all work in-process; the pin goes red the day
+  upstream fixes serde, so the verdict is revisited instead of fossilizing.

--- a/examples/micro-diffusion/src/micro_diffusion/aot_declaration_escape.py
+++ b/examples/micro-diffusion/src/micro_diffusion/aot_declaration_escape.py
@@ -1,0 +1,63 @@
+"""The pgw#1062 declaration: the escape-hatch graph, one entry.
+
+Deliberately the smallest declaration that still puts every author-defined-op
+surface inside a minted cell: ONE target, fork-free, batch fixed, two token
+rows collapsing under ``dynamic-collapse`` into a single entry. The variable
+under test is the OPS in the graph — a custom op with a fake kernel, a
+``triton_op`` kernel, a raw ``@triton.jit`` call — not entry count, so
+anything that would multiply entries is pinned.
+"""
+
+from __future__ import annotations
+
+from gen_worker import (
+    Compile,
+    Dim,
+    GraphClass,
+    Input,
+    register_export_declaration,
+)
+
+FAMILY = "micro-escape"
+
+LATENT_ROWS = (32, 48)
+VAE_SCALE = 8
+PIXEL_ROWS = tuple((n * VAE_SCALE, n * VAE_SCALE) for n in LATENT_ROWS)
+#: Token-shaped like the base family: the dynamic extent stays LINEAR in one
+#: symbol (pgw#998), so the only new facts in this cell are the ops.
+TOKEN_ROWS = tuple(n * n for n in LATENT_ROWS)
+COND_LEN = 16
+ARITY = 1
+
+
+def build_declaration() -> Compile:
+    return Compile(
+        family=FAMILY,
+        targets=("transformer",),
+        shapes=PIXEL_ROWS,
+        text_len=COND_LEN,
+        dims=(
+            Dim("N", carried_by=(("t", 0),)),
+            Dim("T", carried_by=(("x", 0),)),
+        ),
+        classes=tuple(
+            GraphClass(dims={"N": ARITY, "T": tokens})
+            for tokens in TOKEN_ROWS),
+        inputs=(
+            Input("x", shape=("T", ("config", "in_channels")),
+                  repeat="N", dtype="float32"),
+            Input("t", shape=("N",), dtype="float32"),
+            Input("cond", shape=(COND_LEN, ("config", "cond_dim")),
+                  repeat="N", dtype="float32"),
+        ),
+        shape_strategy="dynamic-collapse",
+        warm_changes_key=False,
+    )
+
+
+DECLARATION = build_declaration()
+
+register_export_declaration(DECLARATION, replace=True)
+
+__all__ = ["ARITY", "COND_LEN", "DECLARATION", "FAMILY", "LATENT_ROWS",
+           "PIXEL_ROWS", "TOKEN_ROWS", "VAE_SCALE", "build_declaration"]

--- a/examples/micro-diffusion/src/micro_diffusion/main_escape.py
+++ b/examples/micro-diffusion/src/micro_diffusion/main_escape.py
@@ -1,0 +1,84 @@
+"""The pgw#1062 variant's worker function — the escape-hatch graph.
+
+A separate FAMILY (`micro-escape`) with its own traced signature, mirroring
+`main_4d`'s structure exactly: catalog slot with no code default, declaration
+registered at import, `ctx.slots` dereferenced first. A difference in outcome
+against `micro` is therefore a difference in the OPS under test — the custom
+op, the `triton_op` kernel and the raw Triton call — and nothing else.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import msgspec
+import torch
+
+from gen_worker import Compile, RequestContext, Resources, Slot, endpoint
+from gen_worker.families import GenerationDefaults, family
+
+from .aot_declaration_escape import (  # noqa: F401 — registers at import
+    ARITY,
+    COND_LEN,
+    DECLARATION,
+    FAMILY,
+    PIXEL_ROWS,
+    TOKEN_ROWS,
+)
+from .pipeline import MicroEscapePipeline
+
+
+@family(FAMILY)
+class MicroEscapeDefaults(GenerationDefaults, frozen=True):
+    steps: int = 2
+
+
+class MicroEscapeIn(msgspec.Struct):
+    prompt: str = ""
+    model: str = ""
+
+
+class MicroEscapeOut(msgspec.Struct):
+    checkpoint: str = ""
+    shape: str = ""
+
+
+@endpoint(
+    models={"pipeline": Slot(MicroEscapePipeline, selected_by="model")},
+    compile=Compile(
+        family=FAMILY, targets=("transformer",), shapes=PIXEL_ROWS,
+        text_len=COND_LEN),
+    resources=Resources(gpu=True),
+)
+class GenerateEscape:
+    def setup(self, pipeline: MicroEscapePipeline) -> None:
+        self.pipe = pipeline
+
+    def generate_escape(
+        self, ctx: RequestContext[MicroEscapeDefaults], data: MicroEscapeIn,
+    ) -> MicroEscapeOut:
+        resolved = ctx.slots["pipeline"]
+        tokens = TOKEN_ROWS[0]
+        device = self.pipe.device
+        config = self.pipe.config
+        generator = ctx.generator(1062)
+        x: List[torch.Tensor] = [
+            torch.randn(tokens, config.in_channels, generator=generator,
+                        device=device, dtype=torch.float32)
+            for _ in range(ARITY)
+        ]
+        t = torch.full((ARITY,), 100.0, device=device, dtype=torch.float32)
+        cond: List[torch.Tensor] = [
+            torch.randn(COND_LEN, config.cond_dim, generator=generator,
+                        device=device, dtype=torch.float32)
+            for _ in range(ARITY)
+        ]
+        with torch.no_grad():
+            out = self.pipe.transformer(x, t, cond)
+        return MicroEscapeOut(
+            checkpoint=str(resolved.ref.path),
+            shape=str(tuple(int(n) for n in out.shape)))
+
+
+__all__ = ["DECLARATION", "FAMILY", "GenerateEscape", "MicroEscapeDefaults",
+           "MicroEscapeIn", "MicroEscapeOut"]

--- a/examples/micro-diffusion/src/micro_diffusion/model_escape.py
+++ b/examples/micro-diffusion/src/micro_diffusion/model_escape.py
@@ -1,0 +1,124 @@
+"""The pgw#1062 ESCAPE-HATCH variant: author-defined ops through the mint.
+
+pgw#1059 amendment 7 names one author-hint tier to verify PROACTIVELY —
+custom ops (``torch.library``) and hand-written Triton kernels preserved
+end-to-end through trace → package → publish → adopt — because its absence is
+silent until a launch depends on it. This module carries all three author
+surfaces the SDK sanctions, each the smallest thing that still exercises its
+whole path:
+
+* ``micro_escape::rms_gate`` — a ``torch.library.custom_op`` WITH
+  ``register_fake``. The fake kernel is what makes it traceable at all
+  (export traces on FakeTensors; pgw#1056's fake-weight mint doubles down on
+  that), and AOTI serves it as an opaque fallback call into the registered
+  impl. Remove the ``register_fake`` and the mint child refuses at export —
+  that is this variant's RED proof.
+* ``micro_escape::silu_scale`` — a hand-written Triton kernel through
+  ``torch.library.triton_op`` + ``wrap_triton``, the sanctioned authoring
+  surface: the kernel is visible to inductor, compiled and baked into the
+  cell like any generated kernel.
+* a RAW ``@triton.jit`` call in the forward — the unsanctioned-but-real form
+  authors actually write. Dynamo captures it as a triton HOP.
+
+GPU-ONLY by construction, like w8a8: inductor lowers a Triton implementation
+on every backend that declares one, and CPU declares none — measured on
+2.13.0: ``RuntimeError: 0 compatible backends for target (cpu)`` even with a
+``register_kernel("cpu")`` fallback present. A cardless run of this family
+would not be a weaker test, it would be a different one.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch.library import triton_op, wrap_triton
+
+from .model import MicroConfig, MicroDenoiser
+
+
+# ---------------------------------------------------------------------------
+# Surface 1: custom op with a fake kernel
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("micro_escape::rms_gate", mutates_args=())
+def rms_gate(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    rms = x.pow(2).mean(-1, keepdim=True).add(1e-6).rsqrt()
+    return x * rms * weight
+
+
+@rms_gate.register_fake
+def _rms_gate_fake(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+# ---------------------------------------------------------------------------
+# Surface 2: hand-written Triton kernel via triton_op (the sanctioned form)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _silu_scale_kernel(x_ptr, out_ptr, n_elem, scale, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n_elem
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, x * tl.sigmoid(x) * scale, mask=mask)
+
+
+@triton_op("micro_escape::silu_scale", mutates_args={})
+def silu_scale(x: torch.Tensor, scale: float) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n = x.numel()
+    wrap_triton(_silu_scale_kernel)[(triton.cdiv(n, 1024),)](
+        x, out, n, scale, BLOCK=1024)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Surface 3: a raw @triton.jit call in the forward (the form authors write)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _affine_kernel(x_ptr, out_ptr, n_elem, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n_elem
+    x = tl.load(x_ptr + offs, mask=mask)
+    # Dyadic constants: exact in fp32, so eager-vs-served parity is clean.
+    tl.store(out_ptr + offs, x * 1.0625 + 0.03125, mask=mask)
+
+
+def _affine(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n = x.numel()
+    _affine_kernel[(triton.cdiv(n, 1024),)](x, out, n, BLOCK=1024)
+    return out
+
+
+class MicroEscapeDenoiser(MicroDenoiser):
+    """Same weights and blocks as :class:`MicroDenoiser`; the escape-hatch
+    ops wrap its output, so every one of them is INSIDE the traced graph.
+
+    ``escape_gain`` is a non-persistent buffer (the ``freqs`` pattern,
+    pgw#857): derived from config, absent from the checkpoint, present in the
+    module — so the standard generated tree loads strictly unchanged.
+    """
+
+    def __init__(self, config: MicroConfig) -> None:
+        super().__init__(config)
+        self.register_buffer(
+            "escape_gain",
+            torch.linspace(0.5, 1.5, config.in_channels),
+            persistent=False)
+
+    def forward(self, x, t, cond):  # type: ignore[override]
+        h = super().forward(x, t, cond)
+        h = torch.ops.micro_escape.rms_gate(h, self.escape_gain)
+        h = torch.ops.micro_escape.silu_scale(h, 1.25)
+        return _affine(h)
+
+
+__all__ = ["MicroEscapeDenoiser", "rms_gate", "silu_scale"]

--- a/examples/micro-diffusion/src/micro_diffusion/pipeline.py
+++ b/examples/micro-diffusion/src/micro_diffusion/pipeline.py
@@ -135,8 +135,8 @@ class MicroPipeline:
         return self.unpatchify(cells, grid)
 
 
-__all__ = ["MicroConfig", "MicroGridPipeline", "MicroPipeline",
-           "MicroW8a8Pipeline"]
+__all__ = ["MicroConfig", "MicroEscapePipeline", "MicroGridPipeline",
+           "MicroPipeline", "MicroW8a8Pipeline"]
 
 
 class MicroGridPipeline(MicroPipeline):
@@ -189,3 +189,21 @@ class MicroW8a8Pipeline(MicroPipeline):
             str(root / "decoder" / "diffusion_pytorch_model.safetensors")),
             strict=True)
         return cls(transformer.eval(), decoder.eval(), source=str(root))
+
+
+class MicroEscapePipeline(MicroPipeline):
+    """The pgw#1062 vehicle's pipeline: same weights, escape-hatch transformer.
+
+    Only `.transformer` differs — a :class:`MicroEscapeDenoiser`, whose graph
+    carries a custom op (with fake kernel), a `triton_op` kernel and a raw
+    `@triton.jit` call. GPU-only: see `model_escape` for the measured reason.
+    """
+
+    @classmethod
+    def from_pretrained(cls, path: str, **_kw: Any) -> "MicroEscapePipeline":
+        from .model_escape import MicroEscapeDenoiser
+
+        base = MicroPipeline.from_pretrained(path)
+        escape = MicroEscapeDenoiser(base.config)
+        escape.load_state_dict(base.transformer.state_dict(), strict=True)
+        return cls(escape.eval(), base.decoder, source=base.source)

--- a/scripts/rig_gauntlet.py
+++ b/scripts/rig_gauntlet.py
@@ -43,6 +43,7 @@ ORDER = (
     "micro",
     "micro-lora",
     "micro-4d",
+    "micro-escape",
     "micro-w8a8",
     "micro-w8a8-lora",
     "micro-lora-plain-parent",

--- a/tests/harness/rig_vehicles.py
+++ b/tests/harness/rig_vehicles.py
@@ -803,9 +803,146 @@ MICRO_W8A8 = _w8a8_vehicle("micro-w8a8", 0)
 MICRO_W8A8_LORA = _w8a8_vehicle("micro-w8a8-lora", MICRO_LORA_BUCKET)
 
 
+# ---------------------------------------------------------------------------
+# micro-escape — pgw#1062's standing member: author-defined ops (the pgw#1059
+# amendment-7 escape hatch) through the whole mint. GPU-only: inductor lowers
+# a Triton impl on every backend that declares one and CPU declares none
+# (measured: `0 compatible backends for target (cpu)`).
+# ---------------------------------------------------------------------------
+
+
+def _micro_escape_cell() -> Any:
+    from gen_worker.registry import CompileCell
+
+    from micro_diffusion.aot_declaration_escape import COND_LEN, PIXEL_ROWS
+
+    return CompileCell(
+        shapes=PIXEL_ROWS, targets=("transformer",), family="micro-escape",
+        regional=False, text_len=COND_LEN, dynamic=(), lora_bucket=0,
+        guidance_scales=(), text_lens=())
+
+
+_MICRO_ESCAPE_ADOPT = '''
+import json, logging, os, sys
+for p in %(paths)r:
+    sys.path.insert(0, p)
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+import harness.rig_runtime  # noqa: F401
+import torch
+from pathlib import Path
+from gen_worker import aot_serve
+from gen_worker.models import provision
+from gen_worker.registry import CompileCell
+from micro_diffusion.aot_declaration_escape import (
+    ARITY, COND_LEN, PIXEL_ROWS, TOKEN_ROWS)
+from micro_diffusion.pipeline import MicroEscapePipeline
+
+torch.set_num_threads(2)
+DEVICE = "cuda"  # gpu_only vehicle: the ops in the graph require the card
+cfg = CompileCell(
+    shapes=PIXEL_ROWS, targets=("transformer",), family="micro-escape",
+    regional=False, text_len=COND_LEN, dynamic=(), lora_bucket=0,
+    guidance_scales=(), text_lens=())
+pipe = MicroEscapePipeline.from_pretrained(os.environ["PGW978_CHECKPOINT"]).to(DEVICE)
+ref = MicroEscapePipeline.from_pretrained(os.environ["PGW978_CHECKPOINT"]).to(DEVICE)
+config = pipe.config
+
+
+def _feed(tokens):
+    gen = torch.Generator().manual_seed(1062)
+    x = [torch.randn(tokens, config.in_channels, generator=gen).to(DEVICE)
+         for _ in range(ARITY)]
+    t = torch.full((ARITY,), 100.0, device=DEVICE)
+    cond = [torch.randn(COND_LEN, config.cond_dim, generator=gen).to(DEVICE)
+            for _ in range(ARITY)]
+    return x, t, cond
+
+
+# The row the artifact was NOT seeded on, so the derived range is exercised —
+# through the custom-op fallback, the triton_op kernel and the raw HOP.
+ARMS = [("transformer", TOKEN_ROWS[0])]
+eager = {}
+with torch.no_grad():
+    for name, tokens in ARMS:
+        x, t, cond = _feed(tokens)
+        eager[name] = ref.transformer(x, t, cond).clone()
+
+from harness.rig_fetch import fetch_named_cell as _fetch_cell
+from types import SimpleNamespace as _CellNS
+import hashlib as _hl
+from gen_worker import compile_cache as _syscc
+try:
+    _art = _fetch_cell(%(base)r, cfg.family, %(checkpoint)r, Path(%(cache)r))
+except Exception as _exc:
+    print("rig-fetch: named cell unavailable: %%s" %% (_exc,), file=sys.stderr)
+    cell = None
+else:
+    _key0 = str(aot_serve.unpack_metadata(_art).get("cell_key") or "")
+    cell = _CellNS(
+        artifact=_art, cell_key=_key0, family=cfg.family,
+        ref=_syscc.system_repo(cfg.family) + "#" + _key0,
+        snapshot_digest="sha256:" + _hl.sha256(_art.read_bytes()).hexdigest())
+out = {"pid": os.getpid(), "ok": cell is not None}
+if cell is not None:
+    meta = aot_serve.unpack_metadata(Path(cell.artifact))
+    out.update({
+        "cell_key": cell.cell_key, "family": cell.family, "ref": cell.ref,
+        "snapshot_digest": cell.snapshot_digest,
+        "artifact_bytes": Path(cell.artifact).stat().st_size,
+        "entries": sorted((meta.get("entries") or {})),
+    })
+    outcome = provision.arm_aot(pipe, cfg, Path(%(cache)r), Path(cell.artifact), 0)
+    out["armed"] = bool(outcome)
+    out["arm_reason"] = str(getattr(outcome, "reason", "") or "")
+    out["arm_detail"] = str(getattr(outcome, "detail", "") or "")[:400]
+    if outcome:
+        deltas = {}
+        with torch.no_grad():
+            for name, tokens in ARMS:
+                x, t, cond = _feed(tokens)
+                deltas[name] = float(
+                    (pipe.transformer(x, t, cond) - eager[name]).abs().max())
+        out["parity_max_abs"] = deltas
+        out["execution_count"] = int(aot_serve.execution_count(pipe))
+        out["parity_ok"] = all(v <= 1e-4 for v in deltas.values())
+        out["ok"] = bool(out["parity_ok"]) and out["execution_count"] > 0
+    else:
+        out["ok"] = False
+print("RIG_ADOPT " + json.dumps(out))
+'''
+
+
+def _micro_escape_adopt_source(base: str, cache: Path, checkpoint: str) -> str:
+    return _MICRO_ESCAPE_ADOPT % {
+        "paths": [str(REPO / "tests"), str(REPO / "src"), str(MICRO_SRC)],
+        "base": base, "cache": str(cache), "checkpoint": checkpoint}
+
+
+MICRO_ESCAPE = Vehicle(
+    name="micro-escape",
+    modules=(RUNTIME_HOOK, "micro_diffusion.main_escape"),
+    function="generate-escape",
+    family="micro-escape",
+    ref_path="cozy/micro-diffusion",
+    syspath=(str(MICRO_SRC),),
+    build_checkpoint=_micro_checkpoint,
+    checkpoint_bytes=_micro_checkpoint_bytes,
+    compile_cell=_micro_escape_cell,
+    adopt_source=_micro_escape_adopt_source,
+    parent_pipe=_micro_parent_for(0, "MicroEscapePipeline", _micro_escape_cell),
+    gpu_only=True,
+    covers=("pgw#1062 (pgw#1059 amendment 7's escape hatch): author-defined "
+            "ops through the WHOLE mint — a torch.library custom op with a "
+            "fake kernel, a triton_op'd hand-written Triton kernel, and a raw "
+            "@triton.jit call, all inside the traced graph. RED proof: drop "
+            "the custom op's register_fake and the mint child refuses at "
+            "export"),
+)
+
+
 VEHICLES: Dict[str, Vehicle] = {
     v.name: v for v in (TINY, MICRO, MICRO_LORA, MICRO_LORA_PLAIN_PARENT,
-                        MICRO_4D, MICRO_W8A8, MICRO_W8A8_LORA)}
+                        MICRO_4D, MICRO_ESCAPE, MICRO_W8A8, MICRO_W8A8_LORA)}
 DEFAULT_VEHICLE = TINY.name
 
 
@@ -817,6 +954,7 @@ def vehicle(name: str) -> Vehicle:
             f"unknown rig vehicle {name!r} (known: {sorted(VEHICLES)!r})")
 
 
-__all__ = ["DEFAULT_VEHICLE", "MICRO", "MICRO_LORA", "MICRO_LORA_BUCKET",
-           "MICRO_4D", "MICRO_LORA_PLAIN_PARENT", "MICRO_W8A8",
-           "MICRO_W8A8_LORA", "TINY", "VEHICLES", "Vehicle", "vehicle"]
+__all__ = ["DEFAULT_VEHICLE", "MICRO", "MICRO_ESCAPE", "MICRO_LORA",
+           "MICRO_LORA_BUCKET", "MICRO_4D", "MICRO_LORA_PLAIN_PARENT",
+           "MICRO_W8A8", "MICRO_W8A8_LORA", "TINY", "VEHICLES", "Vehicle",
+           "vehicle"]

--- a/tests/test_escape_hatch_pgw1062.py
+++ b/tests/test_escape_hatch_pgw1062.py
@@ -1,0 +1,160 @@
+"""pgw#1062 — the escape hatch (pgw#1059 amendment 7), asserted where CI can see it.
+
+The full escape-hatch cycle — a custom op, a ``triton_op`` kernel and a raw
+``@triton.jit`` call minted, published, adopted and parity-checked — is the
+``micro-escape`` gauntlet member and is LOCAL-ONLY (Triton has no CPU
+backend). What does NOT need a card is every claim about the SURFACE itself,
+and those are the ones that would rot silently:
+
+* a custom op without a fake kernel must refuse at export with GUIDANCE, not
+  crash obscurely — that refusal text is the authoring contract;
+* a custom op WITH a fake kernel must trace under ``FakeTensorMode`` — the
+  exact property pgw#1056's fake-weight mint stands on;
+* an exported program carrying a custom op must survive the mint's own
+  ``torch.export.save``/``load`` process hand-off;
+* flex_attention does NOT survive that hand-off on torch 2.13 — the pinned
+  upstream break behind pgw#1062's flex verdict. The pin is written to go
+  red the day upstream fixes it, so the verdict gets revisited instead of
+  fossilizing.
+
+Each test is written so it goes RED if the property it names stops holding.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from gen_worker.aot_mint import MintRefused, export_program
+
+
+# ---------------------------------------------------------------------------
+# The ops under test. Registered at module import, once per process.
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("pgw1062_test::with_fake", mutates_args=())
+def _with_fake(x: torch.Tensor) -> torch.Tensor:
+    return x * 2.0
+
+
+@_with_fake.register_fake
+def _with_fake_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@torch.library.custom_op("pgw1062_test::no_fake", mutates_args=())
+def _no_fake(x: torch.Tensor) -> torch.Tensor:
+    return x * 2.0
+
+
+class _WithFake(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.pgw1062_test.with_fake(x) + 1.0
+
+
+class _NoFake(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.pgw1062_test.no_fake(x) + 1.0
+
+
+# ---------------------------------------------------------------------------
+# The refusal is typed and carries the fix
+# ---------------------------------------------------------------------------
+
+
+def test_a_custom_op_without_a_fake_kernel_refuses_with_guidance() -> None:
+    """The mint's export wrapper must hand the author torch's own guidance.
+
+    ``export_program`` wraps every export failure in :class:`MintRefused`;
+    what matters here is that the wrapped text still NAMES the fix
+    (``register_fake``), because that message is the entire authoring
+    contract for the escape hatch's fake-kernel requirement.
+    """
+    with pytest.raises(MintRefused) as excinfo:
+        export_program(_NoFake(), (torch.randn(4, 8),), {})
+    assert "register_fake" in str(excinfo.value), (
+        "the export refusal no longer carries torch's register_fake "
+        "guidance — an author with a meta-less custom op now gets an "
+        "unactionable error")
+
+
+# ---------------------------------------------------------------------------
+# The fake-kernel property pgw#1056 stands on
+# ---------------------------------------------------------------------------
+
+
+def test_a_custom_op_with_a_fake_kernel_traces_under_fake_mode() -> None:
+    from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+    with FakeTensorMode():
+        x = torch.randn(4, 8)
+        y = torch.ops.pgw1062_test.with_fake(x)
+        assert isinstance(y, FakeTensor)
+        ep = torch.export.export(_WithFake(), (x,), strict=True)
+    ops = {str(node.target) for node in ep.graph.nodes
+           if node.op == "call_function"}
+    assert any("with_fake" in name for name in ops), sorted(ops)
+
+
+# ---------------------------------------------------------------------------
+# The process hand-off (torch.export.save/load — aot_compile_pool._stage)
+# ---------------------------------------------------------------------------
+
+
+def test_a_custom_op_program_survives_the_export_save_load_handoff(
+    tmp_path,
+) -> None:
+    ep = torch.export.export(_WithFake(), (torch.randn(4, 8),), strict=True)
+    torch.export.save(ep, tmp_path / "program.pt2")
+    loaded = torch.export.load(tmp_path / "program.pt2")
+    ops = {str(node.target) for node in loaded.graph.nodes
+           if node.op == "call_function"}
+    assert any("with_fake" in name for name in ops), (
+        f"the custom-op node did not survive torch.export.save/load — the "
+        f"mint's staged hand-off would drop it (graph ops: {sorted(ops)})")
+    got = loaded.module()(torch.ones(4, 8))
+    assert float((got - 3.0).abs().max()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The flex_attention pin — pgw#1062's measured upstream break
+# ---------------------------------------------------------------------------
+
+
+def test_flex_attention_still_breaks_at_the_save_handoff() -> None:
+    """The PINNED upstream gap behind pgw#1062's flex verdict.
+
+    Measured on 2.13.0 (cu126 and cpu identically): flex_attention EXPORTS,
+    and AOTI compiles + serves it with parity 5.7e-7 when export and compile
+    share a process — but ``torch.export.save`` refuses the flex HOP's
+    block-mask tuple argument (``torch/_export/serde/serialize.py``:
+    ``SerializeError: Unsupported list/tuple argument type``). The mint
+    stages every entry across exactly that save/load boundary
+    (``aot_compile_pool._stage``), so flex cannot ride the pipeline today.
+
+    IF THIS TEST FAILS because the save SUCCEEDED: upstream fixed HOP serde.
+    That is good news, deliberately made loud — reopen pgw#1062's flex
+    verdict (build the micro-flex gauntlet member) instead of deleting the
+    test.
+    """
+    from torch._export.serde.serialize import SerializeError
+    from torch.nn.attention.flex_attention import flex_attention
+
+    def rel_bias(score, b, h, q_idx, kv_idx):
+        return score + (q_idx - kv_idx) * 0.001
+
+    class FlexBlock(nn.Module):
+        def forward(self, q, k, v):
+            return flex_attention(q, k, v, score_mod=rel_bias)
+
+    q, k, v = (torch.randn(1, 2, 128, 32) for _ in range(3))
+    ep = torch.export.export(FlexBlock(), (q, k, v), strict=True)
+
+    import tempfile
+    from pathlib import Path
+
+    with pytest.raises(SerializeError):
+        torch.export.save(
+            ep, Path(tempfile.mkdtemp(prefix="pgw1062-flex-")) / "f.pt2")


### PR DESCRIPTION
pgw#1059 amendment 7 named the escape hatch — author-defined ops (torch.library custom ops, hand-written Triton kernels) preserved end-to-end through the mint — as the one author-hint tier to verify PROACTIVELY. Verified on the real pipeline and landed as a standing gauntlet member.

**What this adds**
- `examples/micro-diffusion` variant `micro-escape`: a traced graph carrying (1) a `torch.library.custom_op` WITH `register_fake`, (2) a `triton_op`'d hand-written Triton kernel, (3) a raw `@triton.jit` call. One entry, dynamic-collapse, same generated 1.1 MB weights (`escape_gain` is a non-persistent buffer, so the standard tree loads strictly unchanged).
- `MICRO_ESCAPE` rig vehicle + gauntlet `ORDER` slot. `gpu_only`: inductor lowers a Triton impl on every backend that declares one and CPU declares none (measured: `0 compatible backends for target (cpu)`).
- `tests/test_escape_hatch_pgw1062.py` (CPU CI): the typed `MintRefused` carrying torch's `register_fake` guidance for a meta-less op; FakeTensorMode traceability (the pgw#1056 fake-weight requirement); the custom-op `torch.export.save/load` hand-off; and a PIN on the measured flex_attention upstream break (`SerializeError` on the flex HOP's block-mask arg at save, while export + AOTI + parity 5.7e-7 work in-process) — the pin goes red the day upstream fixes serde.

**Proof (RTX 4070 sm_89, torch 2.13.0+cu126, rebased tree incl. pgw#1058)**
- Full cycle GREEN: mint 111 s, handback, publish over the real wire, second-process adopt + arm, parity max|delta| 1.67e-06.
- RED proof: removing `register_fake` → mint-child refuses at export with the typed guidance-carrying refusal.
- Gauntlet: `micro` + `micro-escape` both matched expectation on the card.

Tracker: pgw#1062 (verdict report, cross-linked under pgw#1059 amendment 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)