### PR TITLE
pgw#1068: make the micro family publishable — cuda_root, the 0.96.1 pin, and the catalog bootstrap the runbook never had

### DIFF
--- a/examples/micro-diffusion/Dockerfile
+++ b/examples/micro-diffusion/Dockerfile
@@ -44,6 +44,13 @@ COPY . /app
 RUN uv pip install --no-cache --link-mode copy \
       --system --break-system-packages --no-deps --no-sources /app
 
+# pgw#823/pgw#1017: the pytorch runtime bases ship CUDA as pip wheels and never
+# create /usr/local/cuda, so AOT export reaches the LINK step and dies. Compose
+# the root from parts the image already ships. Dockerfile-less families get this
+# from the hub's synthesized Dockerfile (cudaRootLine); a family that writes its
+# own Dockerfile must ask for it explicitly. No-op if a root already exists.
+RUN python -m gen_worker.cuda_root
+
 # The checkpoint, generated and VERIFIED in the same layer. `--verify`
 # regenerates every tensor and byte-compares: an image whose weights did not
 # reproduce from the seed fails the build instead of shipping a checkpoint

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -107,6 +107,72 @@ Preconditions (all verified before step 1, none assumed):
   is a CATALOG slot with no code default, so a first release needs a binding
   naming a repo that already exists AND resolves (th#1087 + th#980).
 
+### 0. Catalog bootstrap — `tensorhub/micro-diffusion` must EXIST and RESOLVE
+
+Do this once per stack, before anything else. **Skipping it costs a build**:
+`main.py` declares `Slot(MicroPipeline, selected_by="model")` — a CATALOG slot
+with no `default_checkpoint=`, deliberately, because that is sdxl's shape and
+the shape the delegation boundary must survive. Since th#1087 a first release
+must carry a binding, and th#980 then checks that binding against the live
+catalog. On a stack with no such repo the deploy answers:
+
+```
+binding_repo_not_found — repo "tensorhub/micro-diffusion" does not exist   (422)
+```
+
+**An EMPTY repo does not satisfy it.** The gate
+(`internal/bindingcheck/check.go`, `checkTensorhubBinding`) does three things
+in order: resolve the owner org, `GetRepo`, then
+`ResolveCheckpointSelector(tag)` — and a repo with no checkpoint fails the
+third with the SAME `binding_repo_not_found` code. So the README's older
+"the pod regenerates the weights if the binding resolved to an empty tree"
+idea is not reachable through the deploy gate as it stands; the bootstrap
+publishes the tree.
+
+Which is cheap, because the tree is generated, not downloaded — the whole
+1.12 MB is a pure function of seed 997:
+
+```
+python -m micro_diffusion.weights --out /tmp/micro-weights --seed 997 --verify
+```
+
+Then the ordinary 3-step CAS publish v2 flow, as an operator
+(`POST /api/v1/password/login` → `access_token`):
+
+```
+POST /api/v1/repos/tensorhub/micro-diffusion/publishes
+     {"mode":"replace","files":[{path,size_bytes,digest:"sha256:<hex>"}...],
+      "tags":[{"tag":"prod"}]}
+PUT  <each grant.put_url>            # grant.headers VERBATIM — never rebuild
+POST /api/v1/repos/tensorhub/micro-diffusion/publishes/<id>/complete
+```
+
+Two things that are easy to get wrong:
+
+- **The repo row must be in the `tensorhub` org.** `POST /api/v1/repos` with a
+  user JWT always creates in the caller's PERSONAL org (`createRepo` →
+  `authorizePersonalOrgPermissionGin`), so a plain operator cannot create a
+  root-org repo through the API at all. Use an org-bound service token, or the
+  same direct `INSERT INTO repos` the e2e harness uses for root-org fixtures
+  (`e2e/scenarios/publish_v2_test.go`, `newThrowawayRepo`).
+- **Stamp `model_family = micro-diffusion`.** The byte classifier answers
+  `family_reason: "no architecture signature matched"` for a toy checkpoint, so
+  the family comes from the repo row (it fills blanks) or from
+  `PATCH /api/v1/repos/tensorhub/micro-diffusion/checkpoints/<id>/classification`.
+  Without it the gate fails closed on `binding_incompatible`: *"slot declares
+  family … but the artifact's family is undeterminable"*.
+
+One checkpoint serves all three families: `micro-4d` and `micro-escape` both
+root to `micro-diffusion` (they `load_state_dict(base.transformer.state_dict(),
+strict=True)`), so the seed-997 tree satisfies every slot the package declares.
+
+Verify before spending anything — the tag must resolve:
+
+```
+GET /api/v1/repos/tensorhub/micro-diffusion/tags/resolve?tag=prod
+GET /api/v1/repos/tensorhub/micro-diffusion/checkpoints     # model_family stamped
+```
+
 ### 1. Wheel — pin the endpoint at the version under test
 
 `gen-worker==<version>` in `pyproject.toml`, `uv lock`, tar the directory.

--- a/examples/micro-diffusion/README.md
+++ b/examples/micro-diffusion/README.md
@@ -97,12 +97,15 @@ Preconditions (all verified before step 1, none assumed):
   platform-paid work).
 - The wheel is a version that has completed a local `task rig:micro` cycle.
   A wheel nothing has proven locally is what this whole family exists to stop.
-- **pgw#1017's `cuda_root` gap is closed.** ⛔ It is not, today. This family
-  ships its own Dockerfile, so it gets no composed `/usr/local/cuda`, and
-  torch's `cpp_extension` finds no CUDA on the pytorch runtime base. The mint
-  would boot, load, export and then die at `CUDA_HOME environment variable is
-  not set` — a paid failure where the missing-`g++` sibling was a free one.
-  **The pod runbook is blocked on that, independently of Paul's go.**
+- **pgw#1017's `cuda_root` gap is closed** (pgw#1068). A family that ships its
+  own Dockerfile gets no composed `/usr/local/cuda` — Dockerfile-LESS families
+  inherit it from the hub's synthesized Dockerfile (`cudaRootLine`) — so this
+  one asks for it explicitly: `RUN python -m gen_worker.cuda_root` after the
+  app install. Without that line the 0.96.x discovery precondition refuses the
+  build (`aot precondition cuda_root: … Missing: the root itself`).
+- **Step 0 below has been run against the target stack.** The `pipeline` slot
+  is a CATALOG slot with no code default, so a first release needs a binding
+  naming a repo that already exists AND resolves (th#1087 + th#980).
 
 ### 1. Wheel — pin the endpoint at the version under test
 

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -8,15 +8,12 @@ dependencies = [
     # the gen-worker version, so a range would make an adopted cell's identity
     # depend on what the build happened to resolve.
     #
-    # ⚠️ THIS FAMILY'S SERVE PATH REQUIRES pgw#994. It declares a `repeat=`
-    # container input with a plain input after it, which is precisely the
-    # shape whose contract positions pgw#994 fixed. On 0.93.3 the cell MINTS
-    # and SEALS and then refuses at ingress on its first served call — the
-    # same failure z-image's tracker entry describes. Bump this to the first
-    # release carrying `2165c2d5` (0.93.4, or a master build) before any pod
-    # run; the local rig already runs against master and its parity leg is
-    # currently a green proof of that fix.
-    "gen-worker==0.93.3",
+    # ⚠️ THIS FAMILY'S SERVE PATH REQUIRES pgw#994 (`2165c2d5`): it declares a
+    # `repeat=` container input with a plain input after it, and on <0.93.4 the
+    # cell MINTS and SEALS and then refuses at ingress on its first served
+    # call. Never pin below that. 0.96.1 also matches the ie `e7384fc`
+    # fleet cutover, so the micro family and the fleet share one wheel.
+    "gen-worker==0.96.1",
     "msgspec>=0.18",
     "safetensors>=0.4",
     "pillow",

--- a/examples/micro-diffusion/uv.lock
+++ b/examples/micro-diffusion/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.93.3"
+version = "0.96.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -350,9 +350,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/6b/826f52ced372c48a3ef97a30282072a5ecd52f3157d35fb0629eeb442453/gen_worker-0.93.3.tar.gz", hash = "sha256:c92ca03a2b0fe59a76265abd8de6950fdafc5524735d0d4f1f9447923358cb1f", size = 1607538, upload-time = "2026-08-07T03:22:44.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/ee/c36bddeead1fe93482645b059ce4fd867677a0c70febcc4c24e1ff0587d3/gen_worker-0.96.1.tar.gz", hash = "sha256:f558682276e6c3b17fd3df3f87ff92f54ae7ef848854eb4abd1820b17d624951", size = 1681080, upload-time = "2026-08-09T21:10:46.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/a8/3bb23365239dc230ea4d14f6137e15ede7f6faae578203e82adc35db7b31/gen_worker-0.93.3-py3-none-any.whl", hash = "sha256:53d44aa27932ba5f71b4fd17e5d948c36f1f54d44e0e461a4b384353d87e089e", size = 1764478, upload-time = "2026-08-07T03:22:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/19/2fbf6bf7588e317950ce69ba9d55041d62393fb44bd82cc66252310bd738/gen_worker-0.96.1-py3-none-any.whl", hash = "sha256:25fe222f53099aec346347a430bd1928c81a40d6f8cf30fa9627f6ce22a06702", size = 1840624, upload-time = "2026-08-09T21:10:44.192Z" },
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ local = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gen-worker", specifier = "==0.93.3" },
+    { name = "gen-worker", specifier = "==0.96.1" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pillow" },
     { name = "safetensors", specifier = ">=0.4" },


### PR DESCRIPTION
The pgw#868 A1 attempt-31 micro-probe lane found three bring-up gaps for $0 (no
pod bought at any point) and could not land any of them — it held no worktree
for this repo. This is all three, plus the runbook step the third one revealed.

**Dockerfile — `RUN python -m gen_worker.cuda_root`.** Build `019fe879` died at
discovery: *"aot precondition cuda_root: torch's cpp_extension cannot
host-compile on this image and ['micro-4d','micro-diffusion','micro-escape']
declare an AOT export. Missing: the root itself."* Dockerfile-LESS families
(sdxl, z-image) are immune — the hub synthesizes their Dockerfile and
`cudaRootLine()` injects the step. A family that writes its own silently misses
it. Build `019fe87d` proved the line (`k8s_build=ok push=ok`).

**pyproject/uv.lock — gen-worker 0.93.3 → 0.96.1, relocked.** The file's own
comment demanded this before any pod run (pgw#994 / `2165c2d5`); 0.96.1 also
matches the ie `e7384fc` fleet cutover.

**README step 0 — the catalog bootstrap.** `main.py`'s `Slot(MicroPipeline,
selected_by="model")` is a catalog slot with no code default, so a first
release needs a binding and th#980 checks it against the live catalog:
`binding_repo_not_found — repo "tensorhub/micro-diffusion" does not exist`
(422). Step 0 is the seed-997 publish (1.12 MB, generated + `--verify`d, never
downloaded) through the real 3-step CAS publish v2 flow, plus the two traps:
`POST /api/v1/repos` on a user JWT always lands in the caller's PERSONAL org,
and a toy checkpoint classifies as `family_reason: "no architecture signature
matched"` so `model_family` has to be stamped or the gate fails closed.

The empty-repo variant is recorded as REFUTED, not deferred:
`checkTensorhubBinding` resolves the org, then `GetRepo`, then
`ResolveCheckpointSelector(tag)`, and a repo with no checkpoint fails the third
with the same code.

**Executed against the dev stack** (tensorhub `2eaa57e2`): repo row in the
`tensorhub` org, publish `1af70da0` promoted, checkpoint
`sha256:80301d54…`, tag `prod` resolves, `model_family=micro-diffusion`.
The real th#980 gate now answers "binding RESOLVES" for all three of
`generate`/`generate_4d`/`generate_escape` against that live catalog; pointed
at a nonexistent ref the same probe reproduces the driver's verbatim 422.

Companion: cozy-creator/tensorhub#944 registers `micro-escape` (gap 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)