### PR TITLE
pgw#1023 + pgw#1017: the custom-Dockerfile path gets a REGISTRY, not a fifth one-off patch

### DIFF
--- a/changelog.d/pgw1023.md
+++ b/changelog.d/pgw1023.md
@@ -1,0 +1,33 @@
+- **pgw#1023 + pgw#1017: the custom-Dockerfile path is checked by a REGISTRY
+  now, not by another one-off patch.** `gen_worker.build_guarantees` enumerates
+  the steps tensorhub's SYNTHESIZED Dockerfile takes and a hand-written one must
+  take itself — discovery lock, worker entrypoint, the AOT `g++` layer, the
+  composed CUDA root, and the banned BuildKit cache mount — each row naming
+  where the platform itself refuses (an in-image `aot_preconditions` check, or
+  a hub-side inspection) and what skipping it costs. Authors run it in one line:
+
+      python -m gen_worker.build_guarantees .        # exits 1, names the fix
+      python -m gen_worker.build_guarantees --list   # what it checks, and why
+
+  Same division of labour as `python -m gen_worker.cuda_root`: the SDK owns the
+  table's correctness, the author owns invoking it, and the platform never
+  injects layers into author-owned content.
+- **Four filings were one defect.** pgw#1016 (a documented cache mount the
+  validator refuses), pgw#1017 (`g++` installed on the synthesized path only),
+  pgw#1017 GAP A (the CUDA root, which refused NOWHERE — the pod booted, loaded
+  and exported before dying at `CUDA_HOME`) and pgw#1068 (a family that shipped
+  its own Dockerfile missed the `cuda_root` step live, fixed one-off, the fleet
+  then swept by hand). Each is now a row rather than a patch: the checker run
+  against the pre-pgw#1068 tree (`b80d63fc`) refuses it by name, for $0.00, with
+  no build and no pod.
+- **A guarantee whose verifier is unwired now fails CI**, which is the same
+  defect one level up: every registry row backed by an `aot_preconditions` check
+  is asserted REACHABLE from `static_mint_preconditions`, and every row must
+  name a platform refusal at all. The examples and `docs/dockerfile.md` are
+  checked against the registry instead of against hard-coded strings, so
+  pgw#1016's and pgw#1017's assertions became consumers of one table.
+- `examples/micro-diffusion/Dockerfile`'s comment no longer says the family is
+  not pod-ready pending a CUDA root — the root is composed and the precondition
+  covers it. A comment describing a missing step is also, deliberately, not
+  accepted as the step: `require` rows read instructions, `forbid` rows read raw
+  bytes exactly as the hub's validator does.

--- a/docs/dockerfile.md
+++ b/docs/dockerfile.md
@@ -272,6 +272,36 @@ error: aot precondition cuda_root: torch's cpp_extension cannot host-compile on
 
 ---
 
+## Checking your Dockerfile against the platform's own steps
+
+Everything above is a step Tensorhub takes for you when you *don't* ship a
+Dockerfile, and cannot take when you do — your file is yours, and the platform
+never injects layers into it. That asymmetry has produced the same bug four
+times: a step the generated Dockerfile takes, which a hand-written one skips,
+which nothing asks for until a rented pod pays for it.
+
+So the steps are enumerated, and you can ask for them:
+
+```bash
+python -m gen_worker.build_guarantees .      # your endpoint source directory
+python -m gen_worker.build_guarantees --list # what it checks, and why
+```
+
+It exits non-zero and names the missing line, where the platform would have
+refused, and what skipping it costs. Run it in CI for every endpoint that ships
+its own Dockerfile — it needs no build, no image and no GPU, and it decides in
+milliseconds what a build otherwise decides in minutes and a pod in dollars.
+
+An endpoint with no Dockerfile is asked for nothing: it takes the generated
+path, where all of this is already true.
+
+The check is a pre-flight, not the authority. `gen_worker.discovery` still
+verifies the AOT preconditions inside your real image at build time, and
+Tensorhub still inspects the built image. This just moves the cheapest failures
+onto the diff that caused them.
+
+---
+
 ## Full real-world example (managed mode + uv)
 
 ```dockerfile

--- a/examples/micro-diffusion/Dockerfile
+++ b/examples/micro-diffusion/Dockerfile
@@ -18,12 +18,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # wrapper compile never invokes. `gen_worker.discovery` below verifies this at
 # build time and refuses the image if it is missing (pgw#996, pgw#1017).
 #
-# NOT SUFFICIENT ON ITS OWN, and this family is not pod-ready until pgw#1017
-# closes it: torch's cpp_extension also needs a discoverable CUDA root, which
-# this base does not have (CUDA arrives as pip wheels and /usr/local/cuda is
-# never created). Tensorhub's synthesized Dockerfile composes that root; a
-# custom Dockerfile has no equivalent and no precondition covers it yet, so a
-# mint on this image would die at CUDA_HOME after paying for the export.
+# NOT SUFFICIENT ON ITS OWN: torch's cpp_extension also needs a discoverable
+# CUDA root, which this base does not have (CUDA arrives as pip wheels and
+# /usr/local/cuda is never created). The `gen_worker.cuda_root` step below
+# composes it, and the `cuda_root` precondition refuses the build without it.
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl g++ \

--- a/src/gen_worker/build_guarantees.py
+++ b/src/gen_worker/build_guarantees.py
@@ -1,0 +1,358 @@
+"""What the SYNTHESIZED Dockerfile does, enumerated — and asked of custom ones.
+
+Tensorhub builds an endpoint image one of two ways. Dockerfile-LESS families get
+a Dockerfile the hub SYNTHESIZES, and every platform invariant is established
+there by writing a layer. A family that ships its own Dockerfile gets none of
+those layers: its file is author-owned content and the platform never injects
+into it (pgw#1017's settled contract). So on that path the platform can only
+VERIFY — and each invariant it forgets to verify is a guarantee that quietly
+holds on one path and not the other.
+
+That gap produced four filed instances in this repo, all the same shape:
+
+* pgw#1016 — the docs taught a BuildKit cache mount the publish validator
+  refuses, because no first-party family exercised the doc.
+* pgw#1017 — the AOT host toolchain (``g++``) was installed by the synthesized
+  file only, so a custom-Dockerfile family could never AOT-mint.
+* pgw#1017 GAP A — the composed ``/usr/local/cuda`` root: worse than the first
+  two, because nothing refused ANYWHERE. The pod booted, loaded, exported — the
+  expensive part — and died at ``CUDA_HOME``.
+* pgw#1068 — a family shipping its own Dockerfile missed the ``cuda_root`` step
+  live, and was fixed one-off. The fleet was then swept BY HAND, eight
+  Dockerfiles at a time.
+
+Four one-off patches and a manual sweep are not a mechanism. This module is the
+mechanism: ONE enumerated registry of the steps a hand-written Dockerfile owes,
+each row naming where the platform itself refuses if the author skips it, and a
+checker any repo can run over its own endpoints::
+
+    python -m gen_worker.build_guarantees path/to/endpoint [more...]
+
+The SDK owns the registry's correctness; the author owns invoking the check —
+the same division as ``python -m gen_worker.cuda_root``, and for the same
+reason: three spellings of one platform requirement drift the moment a base
+image changes.
+
+**Scope, stated rather than implied.** This is a STATIC pre-flight over a source
+tree. It is not the authority — ``aot_preconditions`` (in-image, at build) and
+tensorhub's post-build image inspection are, and every row here names which one.
+Its value is where it runs: in CI, on a diff, before a build exists, for $0.00.
+The audit's own standing instruction is what it encodes — *enumerate what the
+synthesized file DOES, line by line, not what it INSTALLS* — which is why two of
+these five rows are not packages at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Pattern, Sequence, Tuple
+
+#: Applicability: this step is owed by every hand-written Dockerfile.
+ALWAYS = "always"
+#: Applicability: owed only when an endpoint in the tree declares ``compile=``.
+DECLARES_AOT_EXPORT = "aot_export"
+
+#: A ``verified_by`` value naming an in-image ``aot_preconditions`` row. The
+#: registry test resolves the suffix against that module and asserts the row is
+#: reachable from ``static_mint_preconditions`` — a guarantee whose verifier is
+#: unwired is the very defect this registry exists to stop.
+PRECONDITION = "precondition:"
+
+#: `compile=Compile(...)` on an `@endpoint` is the AOT declaration, and matching
+#: it is exactly how pgw#1068's fleet sweep was done by hand. Conservative by
+#: construction: a family that hides the object behind an alias reads as no-AOT
+#: here and is still caught in-image by `aot_preconditions`, which asks the
+#: registered declaration rather than the source text.
+RE_AOT_DECLARATION = re.compile(r"compile\s*=\s*Compile\s*\(")
+
+# tensorhub/internal/builder/validation.go: reBuildKitCacheMount
+RE_BUILDKIT_CACHE_MOUNT = re.compile(r"(?i)--mount\s*=\s*type\s*=\s*cache\b")
+
+
+@dataclass(frozen=True)
+class Guarantee:
+    """One step the synthesized Dockerfile takes, and the custom path's answer.
+
+    ``require``/``forbid`` are what a hand-written Dockerfile must carry or must
+    not; exactly one is set. ``verified_by`` names the platform's own refusal —
+    a row that cannot name one is a guarantee nothing enforces, and the registry
+    test refuses it.
+    """
+
+    id: str
+    synthesized: str
+    applies: str
+    line: str
+    verified_by: str
+    cost: str
+    require: Optional[Pattern[str]] = None
+    forbid: Optional[Pattern[str]] = None
+    #: The hub matches the RAW BYTES of a Dockerfile for its bans, comments
+    #: included, so a `forbid` row must read comments too. A `require` row must
+    #: not: a comment mentioning a step is not the step.
+    reads_comments: bool = False
+
+
+REGISTRY: Tuple[Guarantee, ...] = (
+    Guarantee(
+        id="discovery_lock",
+        synthesized="generate_dockerfile.go — the discovery RUN step",
+        applies=ALWAYS,
+        require=re.compile(r"gen_worker\.discovery\b"),
+        line="RUN mkdir -p /app/.tensorhub \\\n"
+             "    && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock",
+        verified_by="tensorhub executor.go — endpoint.lock read out of the image",
+        cost="the build is refused after the whole image is built and pushed, "
+             "rather than on the diff that dropped the step",
+    ),
+    Guarantee(
+        id="worker_entrypoint",
+        synthesized="generate_dockerfile.go — the ENTRYPOINT line",
+        applies=ALWAYS,
+        require=re.compile(r"gen_worker\.entrypoint\b"),
+        line='ENTRYPOINT ["python", "-m", "gen_worker.entrypoint"]',
+        verified_by="tensorhub executor.go — matchesWorkerEntrypoint, from the "
+                    "image config",
+        cost="same as discovery_lock: a post-build refusal for a one-line omission",
+    ),
+    Guarantee(
+        id="cxx_toolchain",
+        synthesized="generate_dockerfile.go — the apt line (pgw#823)",
+        applies=DECLARES_AOT_EXPORT,
+        # `\bg\+\+\b` does NOT match "g++ " — `+` is a non-word character, so
+        # there is no word boundary after it. A trailing `\b` here silently
+        # refuses every Dockerfile that DOES install the compiler.
+        require=re.compile(r"\bg\+\+(?!\w)|\bbuild-essential\b"),
+        line="RUN apt-get update \\\n"
+             " && apt-get install -y --no-install-recommends "
+             "ca-certificates curl g++ \\\n"
+             " && rm -rf /var/lib/apt/lists/*",
+        verified_by=PRECONDITION + "CHECK_CXX_TOOLCHAIN",
+        cost="the in-image gate refuses the build for $0.00 — this row only "
+             "moves that refusal earlier, onto the diff (pgw#1017)",
+    ),
+    Guarantee(
+        id="cuda_root",
+        synthesized="generate_dockerfile.go — cudaRootLine (pgw#823, ~30 lines "
+                    "of shell composing a directory)",
+        applies=DECLARES_AOT_EXPORT,
+        require=re.compile(r"gen_worker\.cuda_root\b"),
+        line="RUN python -m gen_worker.cuda_root",
+        verified_by=PRECONDITION + "CHECK_CUDA_ROOT",
+        cost="the most expensive row in this table and the reason it exists: "
+             "before pgw#1017's precondition NOTHING refused, and the pod paid "
+             "for boot, load and export before dying at CUDA_HOME. The step is "
+             "a documented no-op on a CPU image, so it is owed unconditionally "
+             "by an AOT-declaring family rather than guessed from the base tag",
+    ),
+    Guarantee(
+        id="buildkit_cache_mount",
+        synthesized="generate_dockerfile.go never emits one",
+        applies=ALWAYS,
+        forbid=RE_BUILDKIT_CACHE_MOUNT,
+        reads_comments=True,
+        line="install uncached instead — `uv pip install --no-cache`",
+        verified_by="tensorhub validation.go — ErrBuildKitCache, 400 "
+                    "invalid_tarball at publish",
+        cost="the publish is refused, and pgw#1016 is the proof the doc itself "
+             "can teach the refusal: a constant cache id is one mutable "
+             "directory shared across tenant builds",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One guarantee a hand-written Dockerfile does not satisfy."""
+
+    guarantee: str
+    path: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}: build guarantee {self.guarantee}: {self.message}"
+
+
+def guarantee(guarantee_id: str) -> Guarantee:
+    for row in REGISTRY:
+        if row.id == guarantee_id:
+            return row
+    raise KeyError(guarantee_id)
+
+
+def verifier_text(row: Guarantee) -> str:
+    """``verified_by``, rendered for the author rather than for the registry.
+
+    A ``precondition:`` row stores the CONSTANT's name so the registry test can
+    resolve it and prove the gate emits it. What an author needs is the string
+    they will read in a failing build, so it is resolved here — one table, two
+    audiences, no second spelling of the check name.
+    """
+    if not row.verified_by.startswith(PRECONDITION):
+        return row.verified_by
+    from . import aot_preconditions as ap
+
+    check = getattr(ap, row.verified_by[len(PRECONDITION):])
+    return (f"the in-image build gate — `aot precondition {check}`, refused by "
+            f"`python -m gen_worker.discovery` inside your own image")
+
+
+def _instructions(text: str) -> str:
+    """The Dockerfile with comment lines removed.
+
+    A `require` row asks what the file DOES. A comment explaining a step — or
+    explaining why a step is missing, which is how pgw#1017's example read for
+    two days — is not the step.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def declares_aot_export(source_dir: Path) -> List[str]:
+    """Files under ``source_dir`` declaring ``compile=Compile(...)``."""
+    hits: List[str] = []
+    for path in sorted(source_dir.rglob("*.py")):
+        rel = path.relative_to(source_dir)
+        if any(part in {".venv", "venv", "build", "dist", "__pycache__", "tests"}
+               for part in rel.parts):
+            continue
+        try:
+            if RE_AOT_DECLARATION.search(path.read_text(errors="replace")):
+                hits.append(rel.as_posix())
+        except OSError:  # pragma: no cover — unreadable file in a source tree
+            continue
+    return hits
+
+
+def applicable(row: Guarantee, *, aot: bool) -> bool:
+    return row.applies == ALWAYS or (row.applies == DECLARES_AOT_EXPORT and aot)
+
+
+def check_dockerfile(text: str, *, aot: bool, path: str = "Dockerfile",
+                     why_aot: str = "") -> List[Finding]:
+    """Every guarantee ``text`` owes and does not satisfy."""
+    findings: List[Finding] = []
+    instructions = _instructions(text)
+    for row in REGISTRY:
+        if not applicable(row, aot=aot):
+            continue
+        haystack = text if row.reads_comments else instructions
+        if row.require is not None and not row.require.search(haystack):
+            findings.append(Finding(row.id, path, _missing(row, why_aot)))
+        elif row.forbid is not None and row.forbid.search(haystack):
+            findings.append(Finding(row.id, path, _present(row)))
+    return findings
+
+
+def _missing(row: Guarantee, why_aot: str) -> str:
+    trigger = ""
+    if row.applies == DECLARES_AOT_EXPORT:
+        trigger = (f" This is owed because an endpoint in this tree declares an "
+                   f"AOT export{' (' + why_aot + ')' if why_aot else ''}; a "
+                   f"family that declares none owes nothing here.")
+    return (f"a hand-written Dockerfile must carry this step; the synthesized "
+            f"path establishes it at {row.synthesized}.{trigger} Add:\n"
+            f"{_indent(row.line)}\n"
+            f"Platform refusal if you do not: {verifier_text(row)}. Cost of "
+            f"skipping it: {row.cost}")
+
+
+def _present(row: Guarantee) -> str:
+    return (f"this Dockerfile carries something the platform refuses "
+            f"({verifier_text(row)}); the synthesized path {row.synthesized}. "
+            f"Instead: {row.line}. Cost of skipping this check: {row.cost}")
+
+
+def _indent(block: str) -> str:
+    return "\n".join("    " + line for line in block.splitlines())
+
+
+def check_endpoint(source_dir: Path) -> List[Finding]:
+    """Check one endpoint source tree.
+
+    A tree with NO Dockerfile is silently fine: it takes the synthesized path,
+    where every row in the registry is established by a layer the hub writes.
+    That asymmetry is the whole subject of this module.
+    """
+    dockerfile = source_dir / "Dockerfile"
+    if not dockerfile.is_file():
+        return []
+    decls = declares_aot_export(source_dir)
+    return check_dockerfile(
+        dockerfile.read_text(errors="replace"),
+        aot=bool(decls),
+        path=dockerfile.as_posix(),
+        why_aot=", ".join(decls[:3]),
+    )
+
+
+def check_paths(paths: Iterable[Path]) -> List[Finding]:
+    findings: List[Finding] = []
+    for path in paths:
+        findings.extend(check_endpoint(path))
+    return findings
+
+
+def describe_registry() -> str:
+    out = []
+    for row in REGISTRY:
+        out.append(f"{row.id}  [{row.applies}]")
+        out.append(f"    synthesized: {row.synthesized}")
+        out.append(f"    verified by: {verifier_text(row)}")
+    return "\n".join(out)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m gen_worker.build_guarantees",
+        description=("Check a hand-written Dockerfile against the steps the "
+                     "hub's synthesized Dockerfile takes for you. Run it in "
+                     "CI for every endpoint that ships its own Dockerfile."))
+    parser.add_argument("paths", nargs="*", type=Path,
+                        help="endpoint source directories (default: .)")
+    parser.add_argument("--list", action="store_true",
+                        help="print the registry and exit")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print(describe_registry())
+        return 0
+
+    findings = check_paths(args.paths or [Path(".")])
+    for finding in findings:
+        print(f"error: {finding}", file=sys.stderr)
+    if findings:
+        print(f"\n{len(findings)} build guarantee(s) unmet. These are steps the "
+              f"hub takes for Dockerfile-less endpoints and cannot take for "
+              f"yours — your Dockerfile is author-owned content and the "
+              f"platform never injects into it.", file=sys.stderr)
+        return 1
+    return 0
+
+
+__all__ = [
+    "ALWAYS",
+    "DECLARES_AOT_EXPORT",
+    "PRECONDITION",
+    "REGISTRY",
+    "RE_BUILDKIT_CACHE_MOUNT",
+    "Finding",
+    "Guarantee",
+    "applicable",
+    "check_dockerfile",
+    "check_endpoint",
+    "check_paths",
+    "declares_aot_export",
+    "describe_registry",
+    "guarantee",
+    "verifier_text",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gen_worker/build_guarantees.py
+++ b/src/gen_worker/build_guarantees.py
@@ -279,6 +279,8 @@ def check_endpoint(source_dir: Path) -> List[Finding]:
     where every row in the registry is established by a layer the hub writes.
     That asymmetry is the whole subject of this module.
     """
+    if source_dir.is_file() and source_dir.name == "Dockerfile":
+        source_dir = source_dir.parent
     dockerfile = source_dir / "Dockerfile"
     if not dockerfile.is_file():
         return []
@@ -323,7 +325,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(describe_registry())
         return 0
 
-    findings = check_paths(args.paths or [Path(".")])
+    paths = list(args.paths) or [Path(".")]
+    for path in paths:
+        if not path.exists():
+            print(f"error: {path}: no such path", file=sys.stderr)
+            return 2
+        # Say what was checked. A check that passes because it looked at
+        # nothing reads exactly like a check that passed.
+        target = path.parent if path.name == "Dockerfile" else path
+        if not (target / "Dockerfile").is_file():
+            print(f"{path}: no Dockerfile — this endpoint takes the "
+                  f"synthesized path, where the hub establishes every one of "
+                  f"these steps itself. Nothing to check.", file=sys.stderr)
+
+    findings = check_paths(paths)
     for finding in findings:
         print(f"error: {finding}", file=sys.stderr)
     if findings:

--- a/tests/test_build_guarantees_pgw1023.py
+++ b/tests/test_build_guarantees_pgw1023.py
@@ -1,0 +1,308 @@
+"""The custom-Dockerfile path is checked by a REGISTRY, not by another patch.
+
+pgw#1016, pgw#1017, pgw#1017's GAP A and pgw#1068 are four instances of one
+defect: a step the synthesized Dockerfile takes, which a hand-written Dockerfile
+does not, which nothing asks for until a pod pays. Each was closed one-off, and
+pgw#1068 closed its instance by ALSO sweeping eight fleet Dockerfiles by hand.
+
+`gen_worker.build_guarantees` is the mechanism that ends the pattern: one
+enumerated table of the steps, each row naming where the platform itself
+refuses, and a checker that runs on a source tree for $0.00 before a build
+exists. These tests hold the mechanism to the two properties that make it one:
+
+* a row cannot exist without a platform refusal behind it, and where that
+  refusal is an in-image precondition it must be REACHABLE from the gate — an
+  unwired verifier is exactly the "holds on one path only" defect, one level up;
+* the registry, not a hard-coded string, is what the examples and the docs are
+  checked against, so pgw#1017's instance is a CONSUMER of the mechanism rather
+  than a second bespoke assertion.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gen_worker import aot_preconditions as ap
+from gen_worker import build_guarantees as bg
+from gen_worker import cuda_root as cr
+
+REPO = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO / "examples"
+DOC = REPO / "docs" / "dockerfile.md"
+MICRO = EXAMPLES / "micro-diffusion"
+FENCED_DOCKERFILE = re.compile(r"```dockerfile\n(.*?)```", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# The registry itself — a row with no enforcement behind it is decoration
+# ---------------------------------------------------------------------------
+
+def test_the_registry_is_well_formed() -> None:
+    ids = [row.id for row in bg.REGISTRY]
+    assert len(ids) == len(set(ids)), "duplicate guarantee id"
+    for row in bg.REGISTRY:
+        assert row.id.islower() and " " not in row.id
+        assert row.applies in (bg.ALWAYS, bg.DECLARES_AOT_EXPORT)
+        assert (row.require is None) != (row.forbid is None), (
+            f"{row.id}: a row states either what must be present or what must "
+            f"not, never both and never neither")
+        assert row.synthesized, f"{row.id}: name the synthesized step it mirrors"
+        assert row.verified_by, (
+            f"{row.id}: a guarantee with no platform refusal behind it is a "
+            f"style preference. Name where the build or the publish dies")
+        assert row.cost, f"{row.id}: say what skipping it costs"
+
+
+@pytest.mark.parametrize(
+    "row", [r for r in bg.REGISTRY if r.verified_by.startswith(bg.PRECONDITION)],
+    ids=lambda r: r.id)
+def test_a_precondition_backed_row_is_REACHABLE_from_the_gate(row, monkeypatch
+                                                              ) -> None:
+    """The registry may not claim a verifier the gate never emits.
+
+    This is the mechanism applied to itself. `_cuda_root_row(...)` asserted in
+    isolation proves a function's opinion and nothing about a build; a row that
+    is never stamped into `endpoint.lock` is a guarantee that holds nowhere,
+    which is the defect one level up from the one this module addresses.
+    """
+    name = row.verified_by[len(bg.PRECONDITION):]
+    check = getattr(ap, name)
+
+    monkeypatch.setattr(ap, "has_export_declaration", lambda _f: True)
+    monkeypatch.setattr(ap, "declaration_import_failures", lambda: ())
+    monkeypatch.setattr(
+        ap, "export_declaration",
+        lambda _f: type("D", (), {"classes": (), "targets": ()})())
+    monkeypatch.setattr(ap, "_torch_is_cuda_build", lambda: True)
+    monkeypatch.setattr(cr, "torch_cuda_home", lambda: "")
+
+    rows = ap.static_mint_preconditions({"micro-diffusion": 0},
+                                        torch_available=True,
+                                        torch_version="2.13.0")
+    assert check in {r.check for r in rows}, (
+        f"{row.id} names precondition {check!r}, which the gate never emits")
+
+
+# ---------------------------------------------------------------------------
+# Every example that ships a Dockerfile — the fleet check, as a test
+# ---------------------------------------------------------------------------
+
+def _endpoint_dirs() -> list[Path]:
+    return sorted(p for p in EXAMPLES.iterdir() if p.is_dir())
+
+
+@pytest.mark.parametrize("path", _endpoint_dirs(), ids=lambda p: p.name)
+def test_every_example_satisfies_its_build_guarantees(path: Path) -> None:
+    findings = bg.check_endpoint(path)
+    assert not findings, "\n".join(str(f) for f in findings)
+
+
+def test_a_dockerfile_less_endpoint_is_asked_for_nothing() -> None:
+    """`flux2-klein-image` declares an AOT export and ships no Dockerfile.
+
+    It takes the synthesized path, where the hub writes every one of these
+    layers itself. Asking it for the author-side lines would be the mirror
+    image of the bug — a refusal for a step something else already took.
+    """
+    src = EXAMPLES / "flux2-klein-image"
+    assert bg.declares_aot_export(src), "fixture drifted: no compile= here"
+    assert not (src / "Dockerfile").exists()
+    assert bg.check_endpoint(src) == []
+
+
+# ---------------------------------------------------------------------------
+# RED — each of the four historical instances, replayed against the mechanism
+# ---------------------------------------------------------------------------
+
+def _micro_dockerfile() -> str:
+    return (MICRO / "Dockerfile").read_text()
+
+
+def test_RED_the_pre_pgw1068_micro_dockerfile_is_REFUSED() -> None:
+    """The fourth instance, exactly as it shipped, caught for $0.00.
+
+    Until pgw#1068 (`8b05533f`) this file had no `cuda_root` step, and nothing
+    in CI said so — the miss was found by a live build and fixed one-off, then
+    the rest of the fleet was swept by hand. Dropping the line reproduces that
+    tree, and the checker must refuse it by name.
+    """
+    without = "\n".join(
+        line for line in _micro_dockerfile().splitlines()
+        if "gen_worker.cuda_root" not in line)
+    findings = bg.check_dockerfile(without, aot=True, why_aot="main_w8a8.py")
+    assert [f.guarantee for f in findings] == ["cuda_root"]
+    assert "RUN python -m gen_worker.cuda_root" in findings[0].message
+    assert "aot precondition cuda_root" in findings[0].message, (
+        "name the string the author will read in the failing build, not the "
+        "constant the registry stores")
+    assert "main_w8a8.py" in findings[0].message, (
+        "the refusal must name WHY the row applies to this tree")
+
+
+def test_RED_dropping_the_toolchain_layer_is_REFUSED() -> None:
+    """pgw#1017's own instance, now a consumer of the registry."""
+    without = _micro_dockerfile().replace("ca-certificates curl g++",
+                                          "ca-certificates curl")
+    findings = bg.check_dockerfile(without, aot=True)
+    assert [f.guarantee for f in findings] == ["cxx_toolchain"]
+    assert "pgw#823" in findings[0].message
+
+
+def test_RED_a_new_family_copying_the_minimum_viable_dockerfile_is_REFUSED(
+        tmp_path: Path) -> None:
+    """pgw#1068's shape, generalized: a NEW hand-written family.
+
+    This is the case the four one-off patches never covered — not the example
+    that was fixed, but the next author who copies the smallest documented
+    Dockerfile and declares a `compile=` export. Both AOT rows must fire, and
+    neither may fire for the family next door that declares no export.
+    """
+    src = tmp_path / "new-family"
+    (src / "src" / "newfam").mkdir(parents=True)
+    (src / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        "WORKDIR /app\n"
+        "COPY . /app\n"
+        "RUN pip install -e .\n"
+        "RUN mkdir -p /app/.tensorhub \\\n"
+        "    && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock\n"
+        'ENTRYPOINT ["python", "-m", "gen_worker.entrypoint"]\n')
+    main = src / "src" / "newfam" / "main.py"
+    main.write_text(
+        "@endpoint(\n"
+        '    compile=Compile(family="newfam", shapes=((512, 512),)),\n'
+        ")\ndef generate():\n    ...\n")
+
+    assert bg.declares_aot_export(src) == ["src/newfam/main.py"]
+    assert sorted(f.guarantee for f in bg.check_endpoint(src)) == [
+        "cuda_root", "cxx_toolchain"]
+
+    main.write_text("@endpoint()\ndef generate():\n    ...\n")
+    assert bg.check_endpoint(src) == [], (
+        "a JIT-only family owes the AOT lane nothing — intake mode is ruled, "
+        "and a CPU image must not start failing builds over a CUDA root it "
+        "never needed")
+
+
+def test_RED_the_always_rows_fire_for_a_family_with_no_export(tmp_path: Path
+                                                              ) -> None:
+    src = tmp_path / "bare"
+    src.mkdir()
+    (src / "Dockerfile").write_text("FROM python:3.12-slim\nCOPY . /app\n")
+    assert sorted(f.guarantee for f in bg.check_endpoint(src)) == [
+        "discovery_lock", "worker_entrypoint"]
+
+
+def test_RED_pgw1016s_cache_mount_is_the_same_table(tmp_path: Path) -> None:
+    """pgw#1016 is not a separate assertion any more — it is one row."""
+    poisoned = _micro_dockerfile().replace(
+        "RUN uv export --no-cache",
+        "RUN --mount=type=cache,target=/root/.cache uv export --no-cache")
+    findings = bg.check_dockerfile(poisoned, aot=True)
+    assert [f.guarantee for f in findings] == ["buildkit_cache_mount"]
+    assert "invalid_tarball" in findings[0].message
+
+
+def test_a_comment_ABOUT_a_step_is_not_the_step(tmp_path: Path) -> None:
+    """The trap this exact example fell into for two days.
+
+    Between pgw#1017 and pgw#1068 micro-diffusion's Dockerfile carried a
+    paragraph explaining that it had no CUDA root and was therefore not
+    pod-ready. A checker that greps raw bytes reads that paragraph as
+    compliance and stays green over the defect it describes.
+    """
+    src = tmp_path / "commented"
+    (src / "src").mkdir(parents=True)
+    (src / "src" / "m.py").write_text('compile=Compile(family="x")\n')
+    (src / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n"
+        "# a mint on this image would die at CUDA_HOME: it needs\n"
+        "# `python -m gen_worker.cuda_root`, which this file does not run,\n"
+        "# and g++, which it does not install either.\n"
+        "RUN mkdir -p /app/.tensorhub \\\n"
+        "    && python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock\n"
+        'ENTRYPOINT ["python", "-m", "gen_worker.entrypoint"]\n')
+    assert sorted(f.guarantee for f in bg.check_endpoint(src)) == [
+        "cuda_root", "cxx_toolchain"]
+
+
+def test_the_BAN_reads_comments_because_the_hub_does() -> None:
+    """The mirror rule, and it points the other way.
+
+    tensorhub's validator matches the raw bytes of the whole Dockerfile, so a
+    commented-out cache mount is refused exactly like a live one. `forbid` rows
+    must therefore read comments even though `require` rows must not.
+    """
+    text = ("FROM python:3.12-slim\n"
+            "# RUN --mount=type=cache,target=/root/.cache pip install .\n"
+            "RUN python -m gen_worker.discovery > /app/.tensorhub/endpoint.lock\n"
+            'ENTRYPOINT ["python", "-m", "gen_worker.entrypoint"]\n')
+    assert [f.guarantee for f in bg.check_dockerfile(text, aot=False)] == [
+        "buildkit_cache_mount"]
+    assert bg.guarantee("buildkit_cache_mount").reads_comments is True
+    assert bg.guarantee("cuda_root").reads_comments is False
+
+
+# ---------------------------------------------------------------------------
+# The docs are a consumer too — pgw#1016's root cause was a doc nobody ran
+# ---------------------------------------------------------------------------
+
+def _complete_doc_dockerfiles() -> list[str]:
+    return [b for b in FENCED_DOCKERFILE.findall(DOC.read_text())
+            if "FROM" in b and "ENTRYPOINT" in b]
+
+
+def test_the_doc_teaches_at_least_one_complete_AOT_capable_dockerfile() -> None:
+    """An author with a `compile=` export must find a file they can copy.
+
+    pgw#1016's root cause was a documented Dockerfile that no first-party
+    family exercised. Running the registry over the doc's own blocks is what
+    keeps the page and the platform from drifting apart again.
+    """
+    blocks = _complete_doc_dockerfiles()
+    assert blocks, "docs/dockerfile.md teaches no complete Dockerfile"
+    assert any(not bg.check_dockerfile(b, aot=True) for b in blocks), (
+        "no documented Dockerfile satisfies the AOT rows; an author with a "
+        "compile= export has nothing to copy that would build")
+
+
+@pytest.mark.parametrize("block", _complete_doc_dockerfiles(),
+                         ids=lambda b: b.splitlines()[0][:40])
+def test_every_complete_doc_dockerfile_satisfies_the_always_rows(block: str
+                                                                 ) -> None:
+    findings = bg.check_dockerfile(block, aot=False, path="docs/dockerfile.md")
+    assert not findings, "\n".join(str(f) for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# The invocation — the author runs it, the SDK owns whether it is right
+# ---------------------------------------------------------------------------
+
+def test_the_checker_is_runnable_as_one_line_and_exits_nonzero(tmp_path: Path
+                                                               ) -> None:
+    src = tmp_path / "ep"
+    src.mkdir()
+    (src / "Dockerfile").write_text("FROM python:3.12-slim\n")
+    proc = subprocess.run(
+        [sys.executable, "-m", "gen_worker.build_guarantees", str(src)],
+        capture_output=True, text=True, timeout=300, cwd=str(REPO),
+        env={"PYTHONPATH": str(REPO / "src"), "PATH": "/usr/bin:/bin"})
+    assert proc.returncode == 1
+    assert "discovery_lock" in proc.stderr and "worker_entrypoint" in proc.stderr
+
+    ok = subprocess.run(
+        [sys.executable, "-m", "gen_worker.build_guarantees", str(MICRO)],
+        capture_output=True, text=True, timeout=300, cwd=str(REPO),
+        env={"PYTHONPATH": str(REPO / "src"), "PATH": "/usr/bin:/bin"})
+    assert ok.returncode == 0, ok.stderr
+
+
+def test_the_registry_is_printable_for_an_author() -> None:
+    text = bg.describe_registry()
+    for row in bg.REGISTRY:
+        assert row.id in text and row.synthesized in text

--- a/tests/test_build_guarantees_pgw1023.py
+++ b/tests/test_build_guarantees_pgw1023.py
@@ -302,6 +302,35 @@ def test_the_checker_is_runnable_as_one_line_and_exits_nonzero(tmp_path: Path
     assert ok.returncode == 0, ok.stderr
 
 
+def test_the_checker_says_when_it_checked_NOTHING(tmp_path: Path) -> None:
+    """A pass because there was no Dockerfile must not read like a pass.
+
+    A green line that means "I looked at nothing" is how a gate becomes
+    decorative, and a repo wiring this into CI over the wrong directory would
+    get exactly that.
+    """
+    empty = tmp_path / "nodockerfile"
+    empty.mkdir()
+    proc = subprocess.run(
+        [sys.executable, "-m", "gen_worker.build_guarantees", str(empty)],
+        capture_output=True, text=True, timeout=300, cwd=str(REPO),
+        env={"PYTHONPATH": str(REPO / "src"), "PATH": "/usr/bin:/bin"})
+    assert proc.returncode == 0
+    assert "no Dockerfile" in proc.stderr
+
+    missing = subprocess.run(
+        [sys.executable, "-m", "gen_worker.build_guarantees",
+         str(tmp_path / "nope")],
+        capture_output=True, text=True, timeout=300, cwd=str(REPO),
+        env={"PYTHONPATH": str(REPO / "src"), "PATH": "/usr/bin:/bin"})
+    assert missing.returncode == 2, "a mistyped path must not pass"
+
+
+def test_a_dockerfile_path_checks_its_own_directory() -> None:
+    """`... build_guarantees examples/x/Dockerfile` is the obvious mistake."""
+    assert bg.check_endpoint(MICRO / "Dockerfile") == []
+
+
 def test_the_registry_is_printable_for_an_author() -> None:
     text = bg.describe_registry()
     for row in bg.REGISTRY:

--- a/tests/test_dockerfile_doc_contract_pgw1016.py
+++ b/tests/test_dockerfile_doc_contract_pgw1016.py
@@ -17,6 +17,14 @@ The hub matches the RAW BYTES of the whole Dockerfile, comments included, so
 these checks deliberately do not strip comments either: a file that merely
 mentions the directive while explaining the ban is refused exactly like one
 that uses it.
+
+pgw#1023 folded this defect into the general table: the ban is now the
+``buildkit_cache_mount`` row of ``gen_worker.build_guarantees``, checked over
+every example and every documented block alongside the four other steps a
+hand-written Dockerfile owes. What stays HERE is what is specific to this
+instance — the doc's prose surviving its own copy-paste, and the size argument
+for ``g++`` over ``build-essential`` — and it reads the pattern from the
+registry rather than keeping a second spelling of it.
 """
 
 from __future__ import annotations
@@ -24,19 +32,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
+from gen_worker.build_guarantees import RE_BUILDKIT_CACHE_MOUNT
 
 REPO = Path(__file__).resolve().parents[1]
 
-# tensorhub/internal/builder/validation.go: reBuildKitCacheMount
-RE_BUILDKIT_CACHE_MOUNT = re.compile(r"(?i)--mount\s*=\s*type\s*=\s*cache\b")
-
 DOC = REPO / "docs" / "dockerfile.md"
 FENCED_DOCKERFILE = re.compile(r"```dockerfile\n(.*?)```", re.DOTALL)
-
-
-def _example_dockerfiles() -> list[Path]:
-    return sorted((REPO / "examples").rglob("Dockerfile"))
 
 
 def test_doc_dockerfile_blocks_pass_the_hub_validator() -> None:
@@ -63,16 +64,6 @@ def test_the_ban_is_explained_without_spelling_the_directive() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "path", _example_dockerfiles(), ids=lambda p: p.parent.name
-)
-def test_example_dockerfiles_pass_the_hub_validator(path: Path) -> None:
-    assert not RE_BUILDKIT_CACHE_MOUNT.search(path.read_text()), (
-        f"{path.relative_to(REPO)} carries a BuildKit cache mount and cannot "
-        f"be published"
-    )
-
-
 def test_the_canonical_example_carries_the_aot_host_toolchain() -> None:
     """pgw#1017: the AUTHOR installs it, and the docs must say so.
 
@@ -80,6 +71,12 @@ def test_the_canonical_example_carries_the_aot_host_toolchain() -> None:
     toolchain at build time (`aot_preconditions.CHECK_CXX_TOOLCHAIN`) rather
     than injecting a layer into someone else's file. That only works if the
     canonical file an author copies has the layer.
+
+    WHETHER the layer is there is the registry's question now
+    (`build_guarantees.cxx_toolchain`, checked over every example). What is
+    asserted here is what that row deliberately does not enforce: the SHAPE of
+    the layer, which is a measured size argument rather than a platform
+    refusal.
     """
     path = REPO / "examples" / "micro-diffusion" / "Dockerfile"
     content = path.read_text()


### PR DESCRIPTION
Closes the class, not the instance.

## The defect, four times

| filing | the step | what refused | where |
|---|---|---|---|
| pgw#1016 | no BuildKit cache mount | the publish validator | `400 invalid_tarball` |
| pgw#1017 | the AOT `g++` layer | `aot precondition cxx_toolchain` | build, $0.00 |
| pgw#1017 GAP A | the composed `/usr/local/cuda` root | **nothing** | the pod, after boot+load+export |
| pgw#1068 | the same CUDA root, live | a hand build, then a HAND SWEEP of 8 fleet Dockerfiles | one-off |

One shape: Dockerfile-LESS families get a Dockerfile the hub synthesizes, where every invariant is ESTABLISHED by a layer. A family shipping its own gets none of them, because its file is author-owned content and the platform never injects into it (pgw#1017's settled contract). So the custom path can only VERIFY — and each invariant nobody remembered to verify is a guarantee that holds on one path only.

## The mechanism

`gen_worker.build_guarantees` — one enumerated registry of the steps a hand-written Dockerfile owes, each row naming the synthesized line it mirrors, **where the platform itself refuses**, and what skipping it costs.

```
python -m gen_worker.build_guarantees .        # exits 1, names the missing line
python -m gen_worker.build_guarantees --list   # what it checks, and why
```

The SDK owns the table's correctness; the author owns invoking it — the same division as `python -m gen_worker.cuda_root`, and for the same reason. pgw#1068's manual eight-Dockerfile sweep becomes a command any repo runs in CI.

pgw#1017's instance is now a **consumer**: the examples and `docs/dockerfile.md` are checked against the registry rather than against hard-coded strings.

## RED, against the tree that shipped the defect

`b80d63fc:examples/micro-diffusion` — the commit immediately before pgw#1068 fixed it by hand:

```
error: .../Dockerfile: build guarantee cuda_root: a hand-written Dockerfile must carry this
step; the synthesized path establishes it at generate_dockerfile.go — cudaRootLine … Add:
    RUN python -m gen_worker.cuda_root
Platform refusal if you do not: the in-image build gate — `aot precondition cuda_root` …
EXIT=1
```

No build, no image, no pod, $0.00. Dropping the same line from the live example turns `tests` red (`test_every_example_satisfies_its_build_guarantees[micro-diffusion]`), verified by mutation.

## Two properties that make it a mechanism, both tested

- **A row must name a platform refusal**, and where that refusal is an in-image precondition it must be REACHABLE from `static_mint_preconditions`. An unwired verifier is the same defect one level up.
- **`require` reads instructions; `forbid` reads raw bytes.** The hub's validator matches comments too — while a comment *describing* a missing step is exactly what this example carried for the two days between pgw#1017 and pgw#1068, and must never read as compliance.

## Also

The example Dockerfile's stale "not pod-ready until pgw#1017 closes it — no precondition covers it yet" paragraph is gone: the root is composed and the precondition covers it.