### PR TITLE
pgw#1067 + pgw#982 + pgw#1013 wave 3: the warmup kind collision, the preload/executor layering, and the artifact verifier's own two unbounded reads

### DIFF
--- a/changelog.d/pgw1013.md
+++ b/changelog.d/pgw1013.md
@@ -1,0 +1,14 @@
+- **pgw#1013 wave 3: the artifact verifier's own two unbounded reads are
+  bounded.** `receipts.verify_delivered_artifact` is the integrity gate for
+  every hub-delivered cell, and both reads it performs before it can compare
+  anything were sizeless. The packed `metadata.json` is now refused above
+  `artifact_meta.MAX_METADATA_BYTES` (16 MiB, 4x the 4 MiB control-plane
+  `CELL_DECLARE_MAX_BYTES` the hub already enforces on the declare assembled
+  from the same envelope) on the tar header's DECLARED size, before
+  decompressing — a gzipped 50 GB zero-filled member costs a few MB on the wire
+  and OOMs the pod inside the verifier, against an artifact whose digest has not
+  been checked yet. `receipts.MAX_RSA_MODULUS_BITS` (8192) bounds the hub JWKS
+  `n`/`e`: an oversized modulus makes every LATER receipt verification
+  super-linear for the life of the cached key while the signatures still check
+  out, so it is a typed `jwks_modulus_oversized` refusal of the whole document
+  rather than a key quietly skipped.

--- a/changelog.d/pgw1067.md
+++ b/changelog.d/pgw1067.md
@@ -1,0 +1,11 @@
+- **pgw#1067 (worker half of th#1723): the boot-forward roll-up is emitted as
+  `warmup_summary`, so it stops overwriting the live warmup activity.** One
+  kind string carried two shapes: `activity.begin(KIND_WARMUP)` opens the
+  RUNNING setup+warmup span, and the boot-forward roll-up was a self-contained
+  COMPLETED `emit_event("warmup", …)`. The hub keys `info.Activities` on kind
+  alone, and that slot feeds `SelfMintActivityRunning` — read by the stall
+  monitor, cap turnover and the unservable reaper — plus `InFlightMintKinds`,
+  so a still-loading worker read as finished to every one of them. New constant
+  `activity.KIND_WARMUP_SUMMARY`; `KIND_WARMUP` keeps meaning the ACTIVITY. No
+  hub change: the hub stores every kind generically and serves it at
+  `GET /v1/admin/worker-activity-events?kind=`.

--- a/changelog.d/pgw982.md
+++ b/changelog.d/pgw982.md
@@ -1,0 +1,10 @@
+- **pgw#982: the binding derivations moved to `gen_worker.api.binding`, where
+  the field they read lives.** `executor._binding_wire_refs` /
+  `_component_overrides` are now public `binding.binding_wire_refs()` /
+  `binding.component_overrides()`. The rotation preload driver used to reach
+  through both underscores from inside two function bodies — deferred imports
+  that existed only to dodge the `executor -> preload` cycle — which made it a
+  second consumer of the executor's placement semantics with no contract
+  holding the two together: change how the executor derives overrides and the
+  driver silently stages a different checkpoint. Both deferred imports are gone
+  and one inline third copy in `executor` was folded into the same function.

--- a/src/gen_worker/activity.py
+++ b/src/gen_worker/activity.py
@@ -48,7 +48,19 @@ from .pb import worker_scheduler_pb2 as pb
 logger = logging.getLogger(__name__)
 
 KIND_SELF_MINT_COMPILE = "self_mint_compile"
+#: The RUNNING setup+warmup activity — opened by :func:`begin`, ended when the
+#: load window closes. An eager release's boot load runs under this kind
+#: through the same executor call site (th#1021).
 KIND_WARMUP = "warmup"
+# pgw#1067 (worker half of th#1723): the boot-forward roll-up is a countable
+# EVENT about a span that already ended, and it needs its OWN kind. The hub
+# keys `info.Activities` on kind alone, and the `warmup` slot feeds
+# `SelfMintActivityRunning` (stall monitor, cap turnover, unservable reaper) and
+# `InFlightMintKinds` — so emitting the terminal roll-up as `warmup` made a
+# still-loading worker read as finished to all of them. No hub change: every
+# kind is stored generically and served at
+# GET /v1/admin/worker-activity-events?kind=.
+KIND_WARMUP_SUMMARY = "warmup_summary"
 # pgw#680: one tenant request hit fail-on-recompile on a compiled lane and
 # was served eager; phase carries the guard-reason class token, detail the
 # full confession. The hub accepts any kind and logs completions verbatim,

--- a/src/gen_worker/api/binding.py
+++ b/src/gen_worker/api/binding.py
@@ -265,6 +265,27 @@ def wire_ref(binding: Binding) -> str:
     return binding.path
 
 
+def component_overrides(binding: Binding) -> tuple[tuple[str, str], ...]:
+    """The ``(component, canonical ref)`` substitutions ``binding`` carries
+    (pgw#617), normalized and sorted by :class:`ModelRef` itself.
+
+    pgw#982: this and :func:`binding_wire_refs` live HERE, beside the field
+    they read — they answer "what does this binding resolve to", which is not
+    an executor internal. Every consumer (the executor, the rotation preload
+    driver) names the SAME derivation, so placement semantics cannot fork.
+
+    ``getattr`` so an externally-constructed stand-in is answered, not raised
+    at.
+    """
+    return tuple(getattr(binding, "component_overrides", ()) or ())
+
+
+def binding_wire_refs(binding: Binding) -> list[str]:
+    """The base :func:`wire_ref` plus every component-override ref (pgw#617):
+    the full set of refs materializing this binding pins and downloads."""
+    return [wire_ref(binding), *(ref for _, ref in component_overrides(binding))]
+
+
 def rebind_pick(
     binding: Binding,
     *,
@@ -316,5 +337,6 @@ def rebind_pick(
 
 __all__ = [
     "Binding", "BINDING_TYPES", "Civitai", "HF", "Hub", "ModelRef",
-    "ModelScope", "STORAGE_DTYPES", "rebind_pick", "wire_ref",
+    "ModelScope", "STORAGE_DTYPES", "binding_wire_refs", "component_overrides",
+    "rebind_pick", "wire_ref",
 ]

--- a/src/gen_worker/artifact_meta.py
+++ b/src/gen_worker/artifact_meta.py
@@ -31,6 +31,17 @@ from typing import Any, Dict, Optional, Union
 #: The packed envelope's member name, at the tar root, for every artifact kind.
 METADATA_NAME = "metadata.json"
 
+#: THREAT (pgw#1013 §4.24): the tarball is gzipped, so a 50 GB zero-filled
+#: ``metadata.json`` costs a few MB on the wire and OOMs the pod INSIDE
+#: ``receipts.verify_delivered_artifact`` — this reader supplies the envelope
+#: that gate is about to verify, so the read precedes the digest check and no
+#: caller can bound it instead. 4x ``fleet_cells.CELL_DECLARE_MAX_BYTES``, the
+#: 4 MiB bound the hub enforces on the declare built from this envelope
+#: (a literal because this module stays stdlib-only). Enforced ONCE, on the tar
+#: header's declared size: ``tarfile`` stops the member reader there, so an
+#: under-declaring header cannot yield a larger ``.read()``.
+MAX_METADATA_BYTES = 16 << 20
+
 
 class ArtifactMetadataError(ValueError):
     """An artifact carries no readable :data:`METADATA_NAME`."""
@@ -44,7 +55,8 @@ def read_metadata(artifact: Union[str, Path]) -> Dict[str, Any]:
     pays for the multi-GiB payload beside it.
 
     Raises :class:`ArtifactMetadataError` naming the artifact when the member is
-    absent, the tar is unreadable, or the payload is not a JSON object.
+    absent, the tar is unreadable, larger than :data:`MAX_METADATA_BYTES`, or
+    the payload is not a JSON object.
     """
     path = Path(artifact)
     try:
@@ -52,6 +64,11 @@ def read_metadata(artifact: Union[str, Path]) -> Dict[str, Any]:
             for member in tar:
                 if member.name != METADATA_NAME or not member.isfile():
                     continue
+                if member.size > MAX_METADATA_BYTES:
+                    raise ArtifactMetadataError(
+                        f"artifact {path} declares a {member.size}-byte "
+                        f"{METADATA_NAME}, over the {MAX_METADATA_BYTES}-byte "
+                        f"bound; refused before decompressing it")
                 src = tar.extractfile(member)
                 if src is None:
                     break
@@ -82,6 +99,7 @@ def try_read_metadata(artifact: Union[str, Path]) -> Optional[Dict[str, Any]]:
 
 
 __all__ = [
+    "MAX_METADATA_BYTES",
     "METADATA_NAME",
     "ArtifactMetadataError",
     "read_metadata",

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -55,7 +55,12 @@ from . import warmup
 from . import worker_credential
 from . import mint_goal as mint_goal_mod
 from . import worker_goals
-from .api.binding import ModelRef, wire_ref
+from .api.binding import (
+    ModelRef,
+    binding_wire_refs,
+    component_overrides,
+    wire_ref,
+)
 from .convert.hub import HubPublishError
 from .mint_process import MintSlot
 from .api.errors import (
@@ -433,17 +438,6 @@ def _hub_binding_for_wire_ref(ref: str) -> ModelRef:
     )
 
 
-def _component_overrides(binding: Any) -> Tuple[Tuple[str, str], ...]:
-    """(component, canonical ref) substitutions the binding carries (pgw#617)."""
-    return tuple(getattr(binding, "component_overrides", ()) or ())
-
-
-def _binding_wire_refs(binding: Any) -> List[str]:
-    """The base wire ref plus every component-override ref (pgw#617): the
-    full set of refs materializing this binding pins/downloads."""
-    return [wire_ref(binding), *(ref for _, ref in _component_overrides(binding))]
-
-
 def _snapshot_files_without_components(
     snapshot: "Optional[pb.Snapshot]", exclude: typing.Sequence[str],
 ) -> "List[pb.SnapshotFile]":
@@ -486,7 +480,7 @@ def _alias_binding_matches(alias: "EndpointSpec", slot_key: str, ref: str) -> bo
         return False
     if not comp:
         return wire_ref(binding).strip() == ref
-    return (comp, ref) in _component_overrides(binding)
+    return (comp, ref) in component_overrides(binding)
 
 
 def _map_exception(exc: BaseException) -> Tuple["pb.JobStatus", str]:
@@ -1871,7 +1865,7 @@ class ModelStore:
         Only components the snapshot ACTUALLY carries as a subfolder are
         excluded, so the value is a fetch fact and not a guess — and a
         narrowed tree therefore keys on exactly what was left out."""
-        overrides = _component_overrides(binding)
+        overrides = component_overrides(binding)
         if not overrides:
             return ()
         present = {
@@ -5394,7 +5388,7 @@ class Executor:
         return list(dict.fromkeys(
             [
                 r for s in slots
-                for r in _binding_wire_refs(spec.models[s])
+                for r in binding_wire_refs(spec.models[s])
                 if r not in execution_lane_refs
             ]
             + shared_ids
@@ -5525,7 +5519,7 @@ class Executor:
             if rec.ready and not rec.stale:
                 setup_refs = [
                     r for slot in self._setup_slots(spec)
-                    for r in _binding_wire_refs(spec.models[slot])
+                    for r in binding_wire_refs(spec.models[slot])
                 ]
                 for ref in setup_refs:
                     wanted = self.store.snapshot_digest(
@@ -5806,7 +5800,7 @@ class Executor:
                 # th#1322's numeric home, so the boot span and the activity
                 # stream agree on one number rather than two derivations.
                 activity_mod.emit_event(
-                    "warmup",
+                    activity_mod.KIND_WARMUP_SUMMARY,
                     f"boot warmup for {spec.name} "
                     f"({'armed' if armed else 'unarmed'}, {ran} forward"
                     f"{'' if ran == 1 else 's'})",
@@ -5856,7 +5850,7 @@ class Executor:
                 getattr(b, "flavor", "") or "",
                 getattr(b, "storage_dtype", "") or "",
                 getattr(b, "dtype", "") or "",
-                tuple(getattr(b, "component_overrides", ()) or ()),
+                component_overrides(b),
             )
             for slot, b in sorted(spec.models.items())
         )
@@ -6289,7 +6283,7 @@ class Executor:
         gated: List[str] = []
         for name, spec in self.specs.items():
             bound = any(
-                ref in _binding_wire_refs(binding)
+                ref in binding_wire_refs(binding)
                 for slot, binding in spec.models.items()
                 if slot not in spec.slots
             )
@@ -6433,7 +6427,7 @@ class Executor:
                 ref, snap, binding=binding)
             slot_identities[slot] = materialized.identity
             comps: Dict[str, str] = {}
-            for comp, comp_ref in _component_overrides(binding):
+            for comp, comp_ref in component_overrides(binding):
                 try:
                     comp_binding = self._hub_binding(comp_ref)
                 except ValueError:
@@ -6512,7 +6506,7 @@ class Executor:
                 | {
                     comp_ref
                     for slot in setup_slots
-                    for _, comp_ref in _component_overrides(spec.models[slot])
+                    for _, comp_ref in component_overrides(spec.models[slot])
                 }
             )
             rec.held_snapshot_digests = {
@@ -6539,7 +6533,7 @@ class Executor:
                         rec.held_snapshot_digests.get(comp_ref, ""),
                     )
                     for slot in setup_slots
-                    for comp, comp_ref in _component_overrides(spec.models[slot])
+                    for comp, comp_ref in component_overrides(spec.models[slot])
                 ]
             )
             setup = getattr(instance, "setup", None)

--- a/src/gen_worker/preload.py
+++ b/src/gen_worker/preload.py
@@ -55,7 +55,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 from . import activity as activity_mod
 from . import dispatch
-from .api.binding import wire_ref
+from .api.binding import binding_wire_refs, component_overrides, wire_ref
 from .models import residency as residency_mod
 from .models.loading import ComponentSubstitutionError
 from .models.pinned_swap import prestage_module
@@ -278,17 +278,13 @@ class Preloader:
 
     def _instance_refs(self, effective: Any) -> Dict[str, Any]:
         """ref -> binding for every setup slot and component override."""
-        # CYCLE: executor imports preload; hoisting makes `gen_worker.entrypoint`
-        # fail at boot.
-        from .executor import _binding_wire_refs, _component_overrides
-
         ex = self._ex
         out: Dict[str, Any] = {}
         for slot in ex._setup_slots(effective):
             binding = effective.models[slot]
-            for ref in _binding_wire_refs(binding):
+            for ref in binding_wire_refs(binding):
                 out.setdefault(ref, binding)
-            for _comp, comp_ref in _component_overrides(binding):
+            for _comp, comp_ref in component_overrides(binding):
                 try:
                     out.setdefault(comp_ref, ex._hub_binding(comp_ref))
                 except ValueError:
@@ -378,8 +374,6 @@ class Preloader:
         disk reads). Shared components already resident stay untouched —
         the component-first ruling by construction."""
 
-        # CYCLE (see _stage_components_): executor imports preload.
-        from .executor import _component_overrides
         # CYCLE: models.loading is reached through executor, which imports preload.
         from .models.loading import load_component_override
 
@@ -411,7 +405,7 @@ class Preloader:
             if not digests:
                 continue
             sizes = ex.store.component_sizes(ref)
-            overridden = {c for c, _ in _component_overrides(binding)}
+            overridden = {c for c, _ in component_overrides(binding)}
             for comp, digest in sorted(digests.items()):
                 if self._stopped or self._ex.draining:
                     return staged_any

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -316,14 +316,35 @@ def refuse_untrusted_publisher(
         f"{mine or '<unnamed>'} (org {my_org or '<unnamed>'})")
 
 
+#: THREAT (pgw#1013 §4.24): the JWKS `n` is base64url off the network with no
+#: declared length, so a multi-MB modulus makes EVERY later receipt
+#: verification super-linear for the life of the cached key — and nothing
+#: downstream refuses it, because the signatures still check out. Real keys are
+#: 2048-4096 bits. Bounded here because this is the only place the bytes become
+#: a key.
+MAX_RSA_MODULUS_BITS = 8192
+
+
 def _rsa_key_from_jwk(jwk: Mapping[str, object]) -> Optional[rsa.RSAPublicKey]:
     if str(jwk.get("kty") or "") != "RSA":
         return None
     n_raw, e_raw = str(jwk.get("n") or ""), str(jwk.get("e") or "")
     if not n_raw or not e_raw:
         return None
-    n = int.from_bytes(_b64url_decode(n_raw), "big")
-    e = int.from_bytes(_b64url_decode(e_raw), "big")
+    n_bytes, e_bytes = _b64url_decode(n_raw), _b64url_decode(e_raw)
+    # RSA requires 1 < e < n, so ONE bound covers both operands of the modexp
+    # whose cost is the threat. A key this big is refused, not skipped: the hub
+    # publishing one is a fact about the hub, and quietly dropping it would
+    # leave a pod verifying against whichever key happened to parse.
+    oversized = max(len(n_bytes), len(e_bytes)) * 8
+    if oversized > MAX_RSA_MODULUS_BITS:
+        raise ReceiptError(
+            "jwks_modulus_oversized",
+            f"hub JWKS key {str(jwk.get('kid') or '<unnamed>')!r} carries a "
+            f"{oversized}-bit modulus/exponent, over the "
+            f"{MAX_RSA_MODULUS_BITS}-bit bound")
+    n = int.from_bytes(n_bytes, "big")
+    e = int.from_bytes(e_bytes, "big")
     return rsa.RSAPublicNumbers(e=e, n=n).public_key()
 
 

--- a/tests/test_activity_gw601.py
+++ b/tests/test_activity_gw601.py
@@ -80,7 +80,12 @@ def test_executor_setup_emits_monotonic_activity_phases():
 
     ups = _updates(sent)
     assert ups, "no activity envelopes emitted"
-    assert all(u.kind == activity.KIND_WARMUP for u in ups)
+    # pgw#1067: the boot-forward roll-up is a self-contained EVENT under its
+    # own kind, not part of this activity's phase envelope. This assertion
+    # read as "one activity" only because the two used to share a kind.
+    assert {u.kind for u in ups} <= {
+        activity.KIND_WARMUP, activity.KIND_WARMUP_SUMMARY}
+    ups = [u for u in ups if u.kind == activity.KIND_WARMUP]
     seqs = [u.seq for u in ups]
     assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), seqs
     phases = [(u.phase, u.step, u.total_steps, u.state) for u in ups]

--- a/tests/test_binding_derivations_pgw982.py
+++ b/tests/test_binding_derivations_pgw982.py
@@ -1,0 +1,131 @@
+"""pgw#982: the rotation preload driver no longer reaches through the
+executor's underscores for the executor's own binding derivations.
+
+`preload` staged what `executor._binding_wire_refs` / `_component_overrides`
+said a binding resolved to, through two FUNCTION-BODY imports that existed only
+to dodge the `executor -> preload` cycle. That is two consumers of one
+derivation with no contract holding them together: change how the executor
+derives overrides and the rotation driver silently stages a different
+checkpoint, with nothing failing until the preloaded one is wrong.
+
+The derivations describe a BINDING, so they live on `api.binding` beside the
+field they read, and both consumers name the same public function. The cycle
+that forced the deferral is gone with them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from gen_worker import executor as executor_mod
+from gen_worker import preload as preload_mod
+from gen_worker.api.binding import (
+    HF,
+    Hub,
+    ModelRef,
+    binding_wire_refs,
+    component_overrides,
+    wire_ref,
+)
+
+
+def _with_overrides(*pairs: tuple[str, str]) -> ModelRef:
+    """A tensorhub binding carrying component substitutions — the shape the
+    executor mints at dispatch (``structs.replace(binding, component_overrides=…)``);
+    the ``Hub()`` factory has no keyword for it."""
+    return ModelRef(
+        source="tensorhub", path="acme/qwen", component_overrides=pairs)
+
+
+def _deferred_imports(module) -> list[tuple[str, tuple[str, ...]]]:
+    """Every `from X import ...` that runs inside a function body."""
+    tree = ast.parse(Path(inspect.getsourcefile(module)).read_text())
+    out: list[tuple[str, tuple[str, ...]]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.ImportFrom) and inner.module:
+                out.append((
+                    "." * inner.level + inner.module,
+                    tuple(a.name for a in inner.names),
+                ))
+    return out
+
+
+def test_preload_never_reaches_into_the_executor_at_runtime():
+    reaches = [
+        (mod, names) for mod, names in _deferred_imports(preload_mod)
+        if mod.endswith("executor")
+    ]
+    assert reaches == [], (
+        "preload still imports from executor inside a function body: "
+        f"{reaches!r}"
+    )
+
+
+def test_the_derivations_are_public_and_have_one_definition():
+    # The private executor copies are gone, not merely wrapped.
+    assert not hasattr(executor_mod, "_binding_wire_refs")
+    assert not hasattr(executor_mod, "_component_overrides")
+    # And both consumers resolve to the SAME object, which is what makes a
+    # change to one derivation reach the other.
+    assert executor_mod.component_overrides is component_overrides
+    assert executor_mod.binding_wire_refs is binding_wire_refs
+    assert preload_mod.component_overrides is component_overrides
+    assert preload_mod.binding_wire_refs is binding_wire_refs
+
+
+def test_component_overrides_reads_the_bindings_own_normalized_field():
+    b = _with_overrides(("vae", "acme/vae"), ("denoiser", "acme/dit"))
+    # ModelRef sorts and cleans the field itself; the accessor does not
+    # re-derive it.
+    assert component_overrides(b) == b.component_overrides
+    assert component_overrides(b) == (("denoiser", "acme/dit"), ("vae", "acme/vae"))
+    assert component_overrides(Hub("acme/qwen")) == ()
+
+
+def test_binding_wire_refs_is_the_base_ref_plus_every_override():
+    b = _with_overrides(("vae", "acme/vae"), ("denoiser", "acme/dit"))
+    assert binding_wire_refs(b) == [wire_ref(b), "acme/dit", "acme/vae"]
+    # A source with no override axis materializes exactly one ref.
+    hf = HF("black-forest-labs/FLUX.1-dev")
+    assert binding_wire_refs(hf) == [wire_ref(hf)]
+
+
+def test_a_stand_in_binding_is_answered_rather_than_raising():
+    """Specs assembled from the wire and test doubles reach these too."""
+
+    class _Stub:
+        source = "tensorhub"
+        path = "acme/qwen"
+        tag = "prod"
+        flavor = ""
+
+    assert component_overrides(_Stub()) == ()
+
+
+def test_import_binding_module_alone_pulls_in_neither_executor_nor_preload():
+    """The derivations must be reachable without the compile/serve stack —
+    that is the whole point of moving them off the executor."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import sys; import gen_worker.api.binding as b; "
+         "assert b.binding_wire_refs and b.component_overrides; "
+         "print(int('gen_worker.executor' in sys.modules), "
+         "int('gen_worker.preload' in sys.modules))"],
+        capture_output=True, text=True, check=True,
+    )
+    assert proc.stdout.split() == ["0", "0"], proc.stdout
+
+
+def test_the_public_names_are_exported():
+    import gen_worker.api.binding as binding_mod
+
+    assert "binding_wire_refs" in binding_mod.__all__
+    assert "component_overrides" in binding_mod.__all__

--- a/tests/test_verifier_bounds_pgw1013.py
+++ b/tests/test_verifier_bounds_pgw1013.py
@@ -1,0 +1,161 @@
+"""pgw#1013 wave 3 — the two unbounded reads that live INSIDE the artifact
+verifier, which is the worst place in the repo for one.
+
+`receipts.verify_delivered_artifact` is the integrity gate for every
+hub-delivered cell. Both of the reads it performs before it can compare
+anything were sizeless:
+
+* the packed `metadata.json` — read to obtain the envelope it will verify, off
+  a gzip member whose declared size nothing looked at. A 50 GB zero-filled
+  member costs a few MB on the wire, so the pod OOMs inside the verifier,
+  against an artifact whose digest had not been checked yet;
+* the hub JWKS `n` — `int.from_bytes` straight into `cryptography`, so a
+  multi-MB modulus makes every LATER verification super-linear for the life of
+  the cached key, with nothing downstream ever refusing it.
+
+Both are exercised on real bytes: a real gzip tarball built here, and a real
+JWKS document served through the real `_fetch_jwks` path.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from gen_worker import artifact_meta, receipts
+
+
+# ---------------------------------------------------------------------------
+# the packed envelope
+# ---------------------------------------------------------------------------
+
+
+def _cell(tmp_path: Path, meta_bytes: bytes, name: str = "cell.tar.gz") -> Path:
+    """A real gzip-compressed artifact carrying `meta_bytes` as its
+    metadata.json, plus a payload member so it is shaped like a cell."""
+    path = tmp_path / name
+    with tarfile.open(path, mode="w:gz") as tar:
+        info = tarfile.TarInfo(artifact_meta.METADATA_NAME)
+        info.size = len(meta_bytes)
+        tar.addfile(info, io.BytesIO(meta_bytes))
+        payload = b"weights"
+        pinfo = tarfile.TarInfo("payload.bin")
+        pinfo.size = len(payload)
+        tar.addfile(pinfo, io.BytesIO(payload))
+    return path
+
+
+def test_a_legitimate_envelope_still_reads(tmp_path: Path):
+    meta = {"kind": "aot", "entries": {f"e{i}": {"shape": [1, 4, 128, 128]}
+                                       for i in range(64)}}
+    raw = json.dumps(meta).encode()
+    assert len(raw) < artifact_meta.MAX_METADATA_BYTES
+    assert artifact_meta.read_metadata(_cell(tmp_path, raw)) == meta
+
+
+def test_a_decompression_bomb_in_the_envelope_is_refused_before_it_is_read(
+    tmp_path: Path,
+):
+    # 128 MiB of zeroes: ~128 KiB on disk after gzip, 8x the bound.
+    bomb = b"\0" * (128 << 20)
+    artifact = _cell(tmp_path, bomb)
+    on_disk = artifact.stat().st_size
+    assert on_disk < 2 << 20, (
+        f"the bomb must be cheap on the wire for the test to mean anything "
+        f"({on_disk} bytes)")
+
+    with pytest.raises(artifact_meta.ArtifactMetadataError) as exc:
+        artifact_meta.read_metadata(artifact)
+    assert str(artifact_meta.MAX_METADATA_BYTES) in str(exc.value)
+    assert "refused before decompressing it" in str(exc.value)
+
+
+def test_the_verifier_itself_refuses_the_bomb_with_a_typed_reason(
+    tmp_path: Path,
+):
+    """The read that matters is the one INSIDE `verify_delivered_artifact`;
+    it must surface as a named refusal, not as a dead pod."""
+    artifact = _cell(tmp_path, b"\0" * (64 << 20))
+    with pytest.raises(receipts.ReceiptError) as exc:
+        receipts._embedded_meta(artifact)
+    assert exc.value.reason == "artifact_unreadable"
+    assert str(artifact_meta.MAX_METADATA_BYTES) in str(exc.value)
+
+
+def test_the_bound_is_exact_at_both_sides(tmp_path: Path):
+    """A member EQUAL to the bound is admitted; one byte more is not — so the
+    refusal cannot be satisfied by a smaller legitimate envelope drifting."""
+    limit = artifact_meta.MAX_METADATA_BYTES
+    pad_key = '{"pad":"'
+    at = (pad_key + "x" * (limit - len(pad_key) - 2) + '"}').encode()
+    assert len(at) == limit
+    assert artifact_meta.read_metadata(_cell(tmp_path, at, "at.tar.gz"))["pad"]
+
+    over = (pad_key + "x" * (limit - len(pad_key) - 1) + '"}').encode()
+    assert len(over) == limit + 1
+    with pytest.raises(artifact_meta.ArtifactMetadataError):
+        artifact_meta.read_metadata(_cell(tmp_path, over, "over.tar.gz"))
+
+
+# ---------------------------------------------------------------------------
+# the hub JWKS
+# ---------------------------------------------------------------------------
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).decode().rstrip("=")
+
+
+def _jwk(modulus_bits: int, kid: str = "hub-1") -> dict:
+    n = (1 << (modulus_bits - 1)) | 1  # top bit set, odd
+    return {
+        "kty": "RSA", "kid": kid,
+        "n": _b64u(n.to_bytes(modulus_bits // 8, "big")),
+        "e": _b64u((65537).to_bytes(3, "big")),
+    }
+
+
+@pytest.mark.parametrize("bits", [2048, 3072, 4096, 8192])
+def test_every_modulus_the_hub_could_legitimately_publish_is_accepted(bits: int):
+    key = receipts._rsa_key_from_jwk(_jwk(bits))
+    assert key is not None and key.key_size == bits
+
+
+def test_a_multi_megabyte_modulus_is_a_typed_refusal_not_a_slow_pod():
+    with pytest.raises(receipts.ReceiptError) as exc:
+        receipts._rsa_key_from_jwk(_jwk(1 << 20))  # 1 Mibit = 128 KiB of `n`
+    assert exc.value.reason == "jwks_modulus_oversized"
+    assert "hub-1" in str(exc.value)
+
+
+def test_an_oversized_exponent_is_refused_by_the_same_bound():
+    jwk = _jwk(2048)
+    jwk["e"] = _b64u(b"\x01" * (16 << 10))
+    with pytest.raises(receipts.ReceiptError) as exc:
+        receipts._rsa_key_from_jwk(jwk)
+    assert exc.value.reason == "jwks_modulus_oversized"
+
+
+def test_the_fetch_path_refuses_the_whole_document_rather_than_skipping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A hub publishing an absurd key is a fact about the hub. Dropping it and
+    keeping the siblings would leave the pod verifying against whichever key
+    happened to parse — the vacuous shape this module refuses elsewhere."""
+
+    class _Resp:
+        status_code = 200
+
+        def json(self) -> dict:
+            return {"keys": [_jwk(2048, "good"), _jwk(1 << 20, "absurd")]}
+
+    monkeypatch.setattr(receipts.requests, "get", lambda *a, **k: _Resp())
+    cfg = receipts._Config(base_url="http://hub.invalid", worker_jwt=lambda: "")
+    with pytest.raises(receipts.ReceiptError) as exc:
+        receipts._fetch_jwks(cfg)
+    assert exc.value.reason == "jwks_modulus_oversized"

--- a/tests/test_warmup_kind_collision_pgw1067.py
+++ b/tests/test_warmup_kind_collision_pgw1067.py
@@ -1,0 +1,127 @@
+"""pgw#1067 (worker half of th#1723): the boot-forward roll-up is a countable
+EVENT about a span that already ended — never the RUNNING setup+warmup
+activity — so the two must not share the hub's one map slot per kind.
+
+The hub keys `info.Activities` on kind alone (`map[kind]WorkerActivityState`,
+ordered by `seq`), and the `warmup` slot feeds `SelfMintActivityRunning` — read
+by the stall monitor, cap turnover and the unservable reaper — plus
+`InFlightMintKinds`. Both shapes used to be emitted as kind `warmup`, so the
+roll-up's COMPLETED state landed on the live activity's slot mid-load and a
+still-loading worker read as finished to every one of those readers.
+
+Driven through the real `Executor.ensure_setup` path (the same one
+`test_activity_gw601.py` uses), because the collision is a property of the
+ORDER production emits in, not of either call site read on its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List
+
+import msgspec
+
+from gen_worker import activity
+from gen_worker.api import Resources, endpoint
+from gen_worker.executor import Executor
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import extract_specs
+
+RUNNING = pb.ActivityState.ACTIVITY_STATE_RUNNING
+COMPLETED = pb.ActivityState.ACTIVITY_STATE_COMPLETED
+
+
+class _In(msgspec.Struct):
+    prompt: str = "x"
+
+
+class _Out(msgspec.Struct):
+    y: str
+
+
+def _boot_updates() -> List[pb.ActivityUpdate]:
+    """Every ActivityUpdate a real boot setup+warmup emits, in `seq` order."""
+    sent: List[pb.WorkerMessage] = []
+
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    @endpoint(resources=Resources(vram_gb_hint=8))
+    class Ep:
+        def setup(self) -> None:
+            pass
+
+        def generate(self, ctx, payload: _In) -> _Out:
+            return _Out(y="ok")
+
+        def generate_turbo(self, ctx, payload: _In) -> _Out:
+            return _Out(y="ok")
+
+    specs = extract_specs(Ep)
+    ex = Executor(specs, _send)
+
+    async def _go() -> None:
+        await ex.ensure_setup(specs[0])
+        for _ in range(10):  # the sink schedules sends onto this loop
+            await asyncio.sleep(0)
+
+    asyncio.run(_go())
+
+    ups = [
+        m.activity_update for m in sent
+        if m.WhichOneof("msg") == "activity_update"
+    ]
+    assert ups, "no activity envelopes emitted by a real boot setup"
+    return sorted(ups, key=lambda u: u.seq)
+
+
+def test_the_roll_up_never_lands_on_the_live_warmup_activitys_slot():
+    ups = _boot_updates()
+
+    on_the_warmup_slot = [u for u in ups if u.kind == activity.KIND_WARMUP]
+    assert on_the_warmup_slot, "the setup+warmup activity reported nothing"
+
+    # The activity's own terminal is its LAST update; everything the hub folds
+    # onto that slot before it must still say RUNNING, or a reader asking
+    # "is this worker inside its own load window" gets the wrong answer.
+    for u in on_the_warmup_slot[:-1]:
+        assert u.state == RUNNING, (
+            f"a {pb.ActivityState.Name(u.state)} update (phase={u.phase!r}, "
+            f"duration_ms={u.duration_ms}) landed on the hub's `warmup` map "
+            f"slot while the setup+warmup activity was still running"
+        )
+    assert on_the_warmup_slot[-1].state == COMPLETED
+
+
+def test_the_roll_up_is_emitted_under_its_own_kind_carrying_the_span():
+    ups = _boot_updates()
+
+    summaries = [u for u in ups if u.kind == activity.KIND_WARMUP_SUMMARY]
+    assert len(summaries) == 1, [u.kind for u in ups]
+    (summary,) = summaries
+    assert summary.state == COMPLETED
+    assert summary.phase == activity.PHASE_WARMUP_FORWARD
+    # th#1322's numeric home: the roll-up exists to carry the measured span.
+    assert summary.duration_ms > 0
+    assert "boot warmup" in summary.detail
+
+    # It is an EVENT: it must not disturb the running activity's `_current`.
+    assert activity.KIND_WARMUP_SUMMARY != activity.KIND_WARMUP
+
+
+def test_the_hub_fold_keeps_the_worker_inside_its_load_window():
+    """The hub's own fold, replayed: `map[kind] -> state`, applied in `seq`
+    order. Replayed up to the roll-up, the `warmup` slot must still read
+    RUNNING — that slot IS `SelfMintActivityRunning`."""
+    ups = _boot_updates()
+    summary_seq = next(
+        u.seq for u in ups if u.kind == activity.KIND_WARMUP_SUMMARY)
+
+    slots: Dict[str, int] = {}
+    for u in ups:
+        if u.seq > summary_seq:
+            break
+        slots[u.kind] = u.state
+
+    assert slots[activity.KIND_WARMUP_SUMMARY] == COMPLETED
+    assert slots[activity.KIND_WARMUP] == RUNNING


### PR DESCRIPTION
pgw#1067 (worker half of th#1723, hub half 7e0cc1e0). `warmup` was BOTH the
running setup+warmup activity and the terminal boot-forward roll-up, and the
hub keys `info.Activities` on kind alone — so a COMPLETED roll-up landed on the
live activity's slot mid-load and made a still-loading worker read as finished
to `SelfMintActivityRunning` (stall monitor, cap turnover, unservable reaper)
and `InFlightMintKinds`. The roll-up now emits `activity.KIND_WARMUP_SUMMARY`;
`KIND_WARMUP` keeps meaning the ACTIVITY. No hub change: every kind is stored
generically and served at /v1/admin/worker-activity-events?kind=. th#1723
named this spelling at the const it could not fix.

RED through the real `Executor.ensure_setup` boot with the hub's own
map[kind]->state fold replayed in seq order: restore `"warmup"` and all three
rows fail. It also corrected `test_activity_gw601.py`, whose
`all(u.kind == KIND_WARMUP)` read as "one activity" only because the two
shapes shared a kind.

pgw#982. `executor._component_overrides` / `_binding_wire_refs` are now public
`api.binding.component_overrides()` / `binding_wire_refs()`, beside the
`ModelRef` field they read. `preload` reached through both underscores from
inside two function bodies — deferred imports that existed only to dodge the
`executor -> preload` cycle — making it a second consumer of the executor's
placement semantics with nothing holding the two together. A THIRD copy was
inline in `executor._warm_contract_key`, feeding the identity under which warm
runs are shared; folded into the same function. Both deferred imports are gone
and the cycle went with them.

RED: the test's AST predicate fires on origin/master's preload.py with exactly
the two filed sites and is empty here.

pgw#1013 wave 3. `receipts.verify_delivered_artifact` is the integrity gate for
every hub-delivered cell, and both reads it performs before it can compare
anything were sizeless.

  - the packed metadata.json, now bounded by artifact_meta.MAX_METADATA_BYTES
    (16 MiB) on the tar header's DECLARED size, before decompressing. The
    remainder list filed this as "12 sites, one family"; pgw#1040 has since
    collapsed seven of them into artifact_meta.read_metadata, so the family
    needed ONE fix. Derived as 4x fleet_cells.CELL_DECLARE_MAX_BYTES, the bound
    the hub already enforces on the declare built from this envelope.
  - the hub JWKS modulus, now receipts.MAX_RSA_MODULUS_BITS (8192). One bound
    covers n and e (RSA requires 1 < e < n). A typed jwks_modulus_oversized
    refusal of the whole document, not a key quietly skipped.

RED: 6 of 11 rows fail with the two checks removed; the 5 controls pass in both
directions. Real gzip bomb (128 MiB member, under 2 MiB on disk, asserted) and
the real _fetch_jwks path.

Not covered, and said in the tracker rather than left to a green run: the three
whole-artifact unpack loops and compile_cache's pickle.loads(f.read()) still
read members unbounded. They run AFTER verification, so they see digest-verified
bytes, and both files are inside live pgw#1058/pgw#1059 fences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)