### PR TITLE
pgw#1025 + pgw#1026: a resident shared component is charged once, and a tree the card holds boots on a host that cannot stage it

### DIFF
--- a/changelog.d/pgw1009.md
+++ b/changelog.d/pgw1009.md
@@ -1,0 +1,12 @@
+- **pgw#1009: `clone-huggingface` can publish into a classified mirror again.**
+  `run_clone` accepted `objective`/`distilled` (pgw#654) and spent them only on
+  the scheduler stamp written inside the produced tree; the `publish_v2(...)`
+  declare two hundred lines later never passed them, and `git log -S` shows it
+  never had. th#1411 refuses a v2 publish into a repo whose live rows carry
+  classification unless the request RESTATES it (a v2 publish mints a new
+  checkpoint identity and inherits nothing, th#1400), and mirrors are exactly
+  the repos that get classified — so every clone into a repo the catalog
+  already serves died at declare with `400 classification_required` before a
+  byte moved. Live: master's `tensorhub/wan22-t2v-a14b` repair leg was refused
+  twice (`074a2c19…`, `362957ad…`), the second time with the facts stated in
+  the payload, which is what proved they never reached the wire.

--- a/changelog.d/pgw1025.md
+++ b/changelog.d/pgw1025.md
@@ -1,0 +1,13 @@
+- **pgw#1025: a shared component is no longer charged twice against free
+  VRAM.** `select_auto_mode` set its fit requirement from
+  `estimate_pipeline_size_gb` — TOTAL weight bytes, including the gw#479
+  shared text encoder / VAE already resident on CUDA — and compared it against
+  free VRAM, which has already been reduced by those same bytes. Measured
+  overstatement: ~7.85 GB for z-image, ~15.5 GB for qwen-image, enough to push
+  a second shared lane off the resident rung entirely and, under th#1107's
+  `strict_vram`, into a hard refusal instead of a slower placement (th#1043).
+  Every comparison against LIVE free VRAM now uses the requirement net of
+  `estimate_cuda_resident_gb(pipeline)`; the per-SKU off-vs-`vae_only`
+  refinement deliberately keeps the GROSS requirement, because netting live
+  residency into it would restore exactly the mint-posture nondeterminism
+  pgw#750 removed.

--- a/changelog.d/pgw1026.md
+++ b/changelog.d/pgw1026.md
@@ -1,0 +1,18 @@
+- **pgw#1026: a modular tree the CARD holds but the HOST does not now boots.**
+  Staging was all-or-nothing while the load was already component-sequential
+  (pgw#1041), so host RAM bound tighter than VRAM: ie#615's H3 bring-up was
+  refused structurally at 134.1 GiB of tree + the 8 GiB staging floor against
+  116.4 GiB of host RAM. Two halves, one authority. `plan_streamed_hydration`
+  (models/loading.py) decides from three measurements — the whole tree does
+  not fit host RAM, the largest single component does, and free VRAM holds the
+  tree with 2 GB to spare — and `hydrate_modular_pipeline(place_device=…)`
+  then places each component as it lands and drops the host copy, so the
+  host-RAM high-water mark is one component instead of the tree. The
+  executor's host-RAM admission reads the same verdict and charges the largest
+  COMPONENT for such a slot, one level down from the "largest slot, not the
+  sum" rule it already applied across slots. It engages only when the whole
+  tree does not fit while the card does, so it can only turn a refusal into a
+  boot: a component that cannot be staged at all keeps the pgw#752 structural
+  refusal, and a card that cannot hold the tree keeps today's answer. NOT
+  fixed here: a tree larger than the CARD, which needs the sequencer-driven
+  stage schedule the issue also names.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -159,7 +159,11 @@ from .models.hub_client import WorkerResolvedChunk, WorkerResolvedRepo, WorkerRe
 from . import compile_cache
 from .models.config_identity import CANONICAL_JSON_MAX_BYTES, canonical_json_digest
 from .models.cozy_snapshot import _norm_rel_path
-from .models.loading import safetensors_file_valid
+from .models.loading import (
+    is_modular_pipeline_class,
+    plan_streamed_hydration,
+    safetensors_file_valid,
+)
 from .models.volume_verify import snapshot_verify_targets, verify_files
 from .models.cozy_snapshot import delete_blobs
 from .compile_cache import CompiledExecutionLaneUnavailableError
@@ -7504,24 +7508,29 @@ class Executor:
             res.touch(ref)
 
     @staticmethod
-    def _worker_loaded_slots(spec: EndpointSpec) -> set:
+    def _worker_loaded_slot_types(spec: EndpointSpec) -> Dict[str, type]:
         """Setup slots the WORKER materializes in host RAM (class-typed
-        annotations loaded via ``from_pretrained``). str/Path slots and
-        engine runtimes (vllm/llama-server) stream weights themselves and
-        must not be counted against the host-RAM admission gate."""
+        annotations loaded via ``from_pretrained``), with their annotated
+        classes. str/Path slots and engine runtimes (vllm/llama-server)
+        stream weights themselves and must not be counted against the
+        host-RAM admission gate."""
         if spec.cls is None or spec.runtime:
-            return set()
+            return {}
         setup = getattr(spec.cls, "setup", None)
         if setup is None:
-            return set()
+            return {}
         try:
             hints = typing.get_type_hints(setup)
         except Exception:
-            return set()
+            return {}
         return {
-            name for name, ann in hints.items()
+            name: ann for name, ann in hints.items()
             if isinstance(ann, type) and callable(getattr(ann, "from_pretrained", None))
         }
+
+    @staticmethod
+    def _worker_loaded_slots(spec: EndpointSpec) -> set:
+        return set(Executor._worker_loaded_slot_types(spec))
 
     async def _record_host_ram_failure(
         self, refs: List[str],
@@ -7770,8 +7779,17 @@ class Executor:
         slot's weights move to VRAM (freeing host RAM) before the next slot
         loads — so the honest staging requirement is the LARGEST slot, not
         the sum (gw#479 live: two 28GiB fp8 lanes were refused as "56.2GiB
-        incoming" on a 61GiB host that stages at most 28GiB at once)."""
-        slots = self._worker_loaded_slots(spec)
+        incoming" on a 61GiB host that stages at most 28GiB at once).
+
+        pgw#1026 applies the SAME rule one level down for a modular slot the
+        loader will stage component-by-component onto the device: its
+        requirement is its largest COMPONENT, not its tree. That is the only
+        thing standing between a tree the card holds and a structural
+        `HostRamCapacityError` (ie#615's H3: 134.1 GiB tree, 116.4 GiB host).
+        The verdict comes from `plan_streamed_hydration`, which the loader
+        re-reads — one authority, and it engages only when the whole tree
+        does not fit while the card does."""
+        slots = self._worker_loaded_slot_types(spec)
         if not paths or not slots:
             return
         incoming = 0
@@ -7784,9 +7802,22 @@ class Executor:
                 # slot's true staging requirement is their sum. ie#615:
                 # counting only the base under-admitted by the override's
                 # 27.6 GB.
-                for comp_path in ((component_paths or {}).get(slot) or {}).values():
+                comp_paths = dict((component_paths or {}).get(slot) or {})
+                for comp_path in comp_paths.values():
                     slot_bytes += await asyncio.to_thread(
                         disk_gc.tree_bytes, Path(comp_path))
+                if is_modular_pipeline_class(slots[slot]):
+                    plan = await asyncio.to_thread(
+                        functools.partial(
+                            plan_streamed_hydration, Path(p),
+                            component_trees=comp_paths),
+                    )
+                    if plan.engaged:
+                        logger.info(
+                            "host-RAM admission charges %s slot %s its "
+                            "largest COMPONENT, not its tree: %s",
+                            spec.name, slot, plan.summary())
+                        slot_bytes = plan.largest_unit_bytes
                 ref = wire_ref(spec.models[slot])
                 if slot_bytes > incoming:
                     incoming = slot_bytes

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -5,10 +5,12 @@ synthesis. There is no PipelineLoader — callers own ``from_pretrained``.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .. import activity as activity_mod
 from ..component_vocab import (
@@ -29,7 +31,12 @@ from ..capability import HostRamCapacityError, InsufficientHostRamError
 from . import disk_gc, load_progress
 from .tensor_layout_contract import CONTRACT_PLAIN_BF16, implements_contract
 from .fp8_storage import restructure_fp8_storage
-from .memory import get_available_vram_gb, meta_tensors, probe_host_ram
+from .memory import (
+    flush_memory,
+    get_available_vram_gb,
+    meta_tensors,
+    probe_host_ram,
+)
 from .safetensors_header import header_len_ok
 from .svdq import detect_svdq_artifact, load_svdq_pipeline
 from .w4a4 import (
@@ -1584,6 +1591,203 @@ def _admit_component_staging(component: str, nbytes: int) -> None:
         )
 
 
+def modular_staging_units(
+    base: Path,
+    component_trees: Optional[Mapping[str, str]] = None,
+) -> Dict[str, int]:
+    """Bytes per INDEPENDENTLY STAGED unit of a modular snapshot.
+
+    :func:`hydrate_modular_pipeline` loads one component at a time from that
+    component's own source dir, so the unit of host-RAM staging is a
+    component dir — never the tree. This reads the same sources the hydration
+    loop will: each ``modular_model_index.json`` entry's subfolder under
+    ``base`` (falling back to the component name), and each override tree in
+    ``component_trees`` in place of the base dir it replaces.
+
+    Empty when the index is absent or unreadable: callers treat that as "no
+    per-component knowledge" and keep whole-tree accounting."""
+    index = Path(base) / "modular_model_index.json"
+    try:
+        entries = json.loads(index.read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(entries, dict):
+        return {}
+    trees = dict(component_trees or {})
+    units: Dict[str, int] = {}
+    for name, entry in entries.items():
+        if str(name).startswith("_") or name in trees:
+            continue
+        sub = ""
+        if isinstance(entry, list) and len(entry) >= 3 and isinstance(entry[2], dict):
+            sub = str(entry[2].get("subfolder") or "")
+        src = None
+        for cand in (sub, str(name)):
+            if cand and (Path(base) / cand).is_dir():
+                src = Path(base) / cand
+                break
+        if src is None:
+            continue
+        units[str(name)] = disk_gc.tree_bytes(src)
+    for name, tree in trees.items():
+        root = Path(tree)
+        if not root.is_dir():
+            continue
+        units[f"{name} (override)"] = disk_gc.tree_bytes(
+            _resolve_override_tree(root, str(name)))
+    return units
+
+
+# The card must hold the tree with room to spare before hydration is allowed
+# to place components as they land. THREAT (§4.24): free VRAM is read once,
+# before the first component loads, and another tenant can take some of it
+# before the last one is placed — a `.to(device)` that OOMs mid-hydration
+# leaves a half-placed pipeline. This is the same 2 GB the placement ladder
+# holds back (`memory._DEFAULT_SAFETY_MARGIN_GB`); it is not a fudge factor
+# for estimate error, since these bytes are measured on disk, not estimated.
+_STREAMED_HYDRATION_VRAM_MARGIN_GB = 2.0
+
+
+@dataclass(frozen=True)
+class StreamedHydrationPlan:
+    """Whether a modular slot may hydrate component-by-component ONTO THE
+    DEVICE, so host RAM never holds more than one component at a time."""
+
+    engaged: bool
+    reason: str
+    tree_bytes: int
+    largest_unit_bytes: int
+    unit_count: int
+    host_total_bytes: int
+    device_free_bytes: int
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "engaged": self.engaged, "reason": self.reason,
+            "tree_bytes": self.tree_bytes,
+            "largest_unit_bytes": self.largest_unit_bytes,
+            "unit_count": self.unit_count,
+            "host_total_bytes": self.host_total_bytes,
+            "device_free_bytes": self.device_free_bytes,
+        }
+
+    def summary(self) -> str:
+        return (
+            f"tree={self.tree_bytes / _GIB:.1f}GiB "
+            f"largest_component={self.largest_unit_bytes / _GIB:.1f}GiB "
+            f"host_total={self.host_total_bytes / _GIB:.1f}GiB "
+            f"device_free={self.device_free_bytes / _GIB:.1f}GiB "
+            f"({self.reason})"
+        )
+
+
+def plan_streamed_hydration(
+    base: Path,
+    *,
+    component_trees: Optional[Mapping[str, str]] = None,
+    device_free_bytes: Optional[int] = None,
+) -> StreamedHydrationPlan:
+    """pgw#1026: decide whether this modular slot stages PER COMPONENT ONTO
+    THE DEVICE instead of staging its whole tree in host RAM first.
+
+    THREAT (§4.25): a tree the CARD holds but the HOST does not is refused
+    structurally at boot and no pod size fixes it — measured on ie#615's H3
+    bring-up, 134.1 GiB tree + the 8 GiB staging floor against 116.4 GiB of
+    host RAM on a 1x H100-80 pod, `HostRamCapacityError`. Host RAM binds
+    ~26 GiB tighter than VRAM there purely because staging is all-or-nothing
+    while the load is already component-sequential (pgw#1041).
+
+    THE OBSERVABLES, all measured rather than estimated:
+
+    1. the whole tree does NOT fit host RAM (bytes on disk vs
+       :func:`probe_host_ram`'s cgroup-aware total plus the gw#407 floor) —
+       otherwise nothing is wrong and the whole-tree path stands;
+    2. the LARGEST single component DOES fit host RAM — otherwise the
+       structural refusal is honest and must survive (no amount of
+       sequencing places a component that cannot be staged at all);
+    3. free VRAM holds the whole tree with :data:`
+       _STREAMED_HYDRATION_VRAM_MARGIN_GB` to spare — the components have to
+       go somewhere, and on this path that somewhere is the card.
+
+    Engaged only on all three. Every other answer keeps today's behaviour,
+    including the refusal, so this can only turn a refusal into a boot."""
+    units = modular_staging_units(Path(base), component_trees)
+    if device_free_bytes is None:
+        device_free_bytes = int(get_available_vram_gb() * _GIB)
+    return decide_streamed_hydration(
+        tree_bytes=sum(units.values()),
+        largest_unit_bytes=max(units.values(), default=0),
+        unit_count=len(units),
+        host_total_bytes=int(probe_host_ram().total_gb * _GIB),
+        device_free_bytes=int(device_free_bytes),
+    )
+
+
+def decide_streamed_hydration(
+    *,
+    tree_bytes: int,
+    largest_unit_bytes: int,
+    unit_count: int,
+    host_total_bytes: int,
+    device_free_bytes: int,
+) -> StreamedHydrationPlan:
+    """:func:`plan_streamed_hydration`'s decision, separated from its
+    measurements so the rule can be read — and tested — at the byte counts
+    that produced the issue rather than at whatever this host happens to
+    have."""
+    tree = int(tree_bytes)
+    largest = int(largest_unit_bytes)
+    host_total = int(host_total_bytes)
+    plan = functools.partial(
+        StreamedHydrationPlan, tree_bytes=tree, largest_unit_bytes=largest,
+        unit_count=int(unit_count), host_total_bytes=host_total,
+        device_free_bytes=int(device_free_bytes),
+    )
+    if unit_count <= 0 or largest <= 0:
+        return plan(engaged=False, reason="no per-component staging units")
+    if host_total <= 0:
+        return plan(engaged=False, reason="host RAM total unreadable")
+    floor = _staging_floor_bytes(host_total)
+    if tree + floor <= host_total:
+        return plan(engaged=False, reason="the whole tree fits host RAM")
+    if largest + floor > host_total:
+        return plan(
+            engaged=False,
+            reason="the largest component alone exceeds host RAM")
+    need = tree + int(_STREAMED_HYDRATION_VRAM_MARGIN_GB * _GIB)
+    if int(device_free_bytes) < need:
+        return plan(
+            engaged=False, reason="the device does not hold the whole tree")
+    return plan(
+        engaged=True,
+        reason="tree exceeds host RAM, largest component fits, device holds "
+               "the tree")
+
+
+def _place_and_release(pipe: Any, name: str, device: str) -> None:
+    """Move one just-hydrated component to ``device`` and drop the host copy.
+
+    This is what makes the per-component staging loop a per-component HIGH
+    WATER MARK rather than just an ordering: without it every hydrated
+    component stays in host RAM until placement, so the tree is resident on
+    the host by the last component either way."""
+    comp = getattr(pipe, name, None)
+    to = getattr(comp, "to", None)
+    if comp is None or not callable(to):
+        return
+    try:
+        to(device)
+    except Exception as exc:
+        raise ModularHydrationError(
+            f"per-component staging could not place component {name!r} on "
+            f"{device!r}: {type(exc).__name__}: {exc}. The tree does not fit "
+            f"host RAM, so there is no whole-tree path to fall back to — the "
+            f"device has to hold it."
+        ) from exc
+    del comp, to
+    flush_memory()
+
+
 def hydrate_modular_pipeline(
     pipe: Any,
     path: str | Path,
@@ -1591,6 +1795,7 @@ def hydrate_modular_pipeline(
     torch_dtype: Any = None,
     component_trees: Optional[Dict[str, str]] = None,
     preloaded: Optional[Dict[str, Any]] = None,
+    place_device: str = "",
 ) -> Dict[str, str]:
     """Hydrate a freshly constructed ``ModularPipeline`` from the LOCAL
     snapshot tree (pgw#1036).
@@ -1617,7 +1822,15 @@ def hydrate_modular_pipeline(
     Returns ``{component: source_path}`` for everything hydrated. The result
     is verified: ``load_components`` swallows load errors into a logger
     warning, so every requested component is re-checked non-``None`` and a
-    miss raises typed with the captured diffusers log text."""
+    miss raises typed with the captured diffusers log text.
+
+    ``place_device`` (pgw#1026) moves each component onto that device as it
+    lands and drops the host copy, so the host-RAM high-water mark is ONE
+    component instead of the tree. Set it from
+    :func:`plan_streamed_hydration`, never by hand: it is admissible only
+    when the card holds the whole tree, and a mid-hydration placement
+    failure is a typed refusal with no whole-tree path left to fall back
+    to."""
     base = Path(path)
     specs = dict(getattr(pipe, "_component_specs", None) or {})
     trees = dict(component_trees or {})
@@ -1728,6 +1941,11 @@ def hydrate_modular_pipeline(
                 if torch_dtype is not None:
                     kwargs["torch_dtype"] = torch_dtype
                 pipe.load_components(names=[n], **kwargs)
+                # pgw#1026: place it now and drop the host copy, so the next
+                # component's admission above sees the host RAM this one
+                # gave back rather than the tree accumulating behind it.
+                if place_device:
+                    _place_and_release(pipe, n, place_device)
                 disk_gc.reclaim_file_cache(comp_src)
         finally:
             dlog.removeHandler(handler)
@@ -1754,12 +1972,15 @@ def hydrate_modular_pipeline(
     except Exception:  # noqa: BLE001
         pass
     detail = " ".join(f"{n}<-{sources[n]}" for n in sorted(sources))
-    logger.info("modular hydration (%s): %s; skipped partitions: %s",
-                type(pipe).__name__, detail, skipped or "none")
+    logger.info("modular hydration (%s): %s; skipped partitions: %s%s",
+                type(pipe).__name__, detail, skipped or "none",
+                f"; staged per component onto {place_device}" if place_device
+                else "")
     activity_mod.emit_event(
         activity_mod.KIND_MODULAR_HYDRATION,
         f"pipeline={type(pipe).__name__} base={base} {detail}"
-        + (f" skipped={','.join(skipped)}" if skipped else ""),
+        + (f" skipped={','.join(skipped)}" if skipped else "")
+        + (f" place_device={place_device}" if place_device else ""),
         phase="hydrated",
     )
     return sources
@@ -2018,6 +2239,18 @@ def _load_modular_pipeline(
         # Same {"default": ..., part: ...} shape load_components' dict
         # routing understands (pgw#667 widened parts included).
         torch_dtype = per_component
+    # pgw#1026: a tree the card holds but the host does not stages ONE
+    # COMPONENT AT A TIME straight onto the device. Decided here, from the
+    # same measurements the executor's admission gate reads, so the two
+    # cannot disagree about which shape the load takes; if free VRAM moved
+    # between them the per-component gate inside hydration still refuses
+    # with the measured numbers rather than thrashing the host.
+    plan = plan_streamed_hydration(
+        Path(path), component_trees=component_trees)
+    if plan.engaged:
+        logger.info(
+            "modular slot stages per component onto the device: %s",
+            plan.summary())
     pipe = cls.from_pretrained(path)
     if not _is_modular_pipeline(pipe):
         raise ModularHydrationError(
@@ -2027,6 +2260,7 @@ def _load_modular_pipeline(
     hydrate_modular_pipeline(
         pipe, Path(path), torch_dtype=torch_dtype,
         component_trees=component_trees, preloaded=components,
+        place_device="cuda" if plan.engaged else "",
     )
     unmaterialized = meta_tensors(pipe)
     if unmaterialized:
@@ -2362,6 +2596,10 @@ __all__ = [
     "load_from_pretrained",
     "is_modular_pipeline_class",
     "hydrate_modular_pipeline",
+    "modular_staging_units",
+    "decide_streamed_hydration",
+    "plan_streamed_hydration",
+    "StreamedHydrationPlan",
     "ModularHydrationError",
     "ComponentSubstitutionError",
     "assert_composition_satisfiable",

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -763,6 +763,15 @@ def select_auto_mode(
     ``peak_vram_gb`` is the endpoint's DECLARED per-request peak
     (``Resources.peak_vram_per_request_gb``, #339); when provided the fit
     requirement becomes ``max(model_gb, peak_vram_gb)``.
+
+    pgw#1025: every comparison against LIVE FREE VRAM uses the requirement
+    NET of what this pipeline already holds on the card. ``avail`` has
+    already been reduced by the gw#479 shared components resident on CUDA,
+    so comparing it against the pipeline's TOTAL weight bytes counts those
+    bytes twice — measured at ~7.85 GB for z-image and ~15.5 GB for
+    qwen-image, enough to push a second shared lane off the resident rung
+    entirely (and, under th#1107's ``strict_vram``, into a hard refusal).
+    The per-SKU refinement below keeps the GROSS requirement on purpose.
     """
     avail = available_vram_gb if available_vram_gb is not None else get_available_vram_gb()
     if avail <= 0.0:
@@ -773,6 +782,9 @@ def select_auto_mode(
     if peak_vram_gb is not None and peak_vram_gb > 0.0:
         requirement = max(model_gb, float(peak_vram_gb))
     margin = _DEFAULT_SAFETY_MARGIN_GB
+    # What is already ON the card: free VRAM has paid for it, so the
+    # incremental cost of placing this pipeline is the rest.
+    fit_requirement = max(0.0, requirement - estimate_cuda_resident_gb(pipeline))
 
     if requirement > 0.0:
         usable = max(0.0, avail - margin)
@@ -781,7 +793,7 @@ def select_auto_mode(
         # absolute low-free-VRAM rule group-offloaded pipelines the emergency
         # rung had just shrunk to fit, making the rung pointless on exactly
         # the cards it exists for.
-        if requirement <= usable:
+        if fit_requirement <= usable:
             # pgw#750: BOTH branches are RESIDENT — this refinement only
             # toggles VAE slicing, which changes the traced decode graph
             # class and hence the compiled object set a mint proves. Key it
@@ -792,7 +804,10 @@ def select_auto_mode(
             # FIT decisions above/below stay free-VRAM-based (safety); a
             # card that later runs tight degrades reactively down
             # OFFLOAD_LADDER instead of choosing a nondeterministic mint
-            # posture up front.
+            # posture up front. pgw#1025 does NOT touch this comparison: it
+            # is the GROSS requirement against a per-SKU constant, and
+            # netting out live residency here would restore exactly the
+            # nondeterminism pgw#750 removed.
             total = total_vram_gb if total_vram_gb is not None \
                 else get_total_vram_gb()
             if total > 0.0:
@@ -801,7 +816,9 @@ def select_auto_mode(
                 if (sku_usable - requirement) >= _DEFAULT_OFF_HEADROOM_GB:
                     return "off"
                 return "vae_only"
-            if (usable - requirement) >= _DEFAULT_OFF_HEADROOM_GB:
+            # No total-capacity probe: the only input left is live free VRAM,
+            # so this one takes the NET requirement like the fit test above.
+            if (usable - fit_requirement) >= _DEFAULT_OFF_HEADROOM_GB:
                 return "off"
             return "vae_only"
         # Doesn't fit: very low free VRAM needs the aggressive rung.

--- a/tests/test_per_stage_staging_pgw1026.py
+++ b/tests/test_per_stage_staging_pgw1026.py
@@ -1,0 +1,337 @@
+"""pgw#1026: a modular tree the CARD holds but the HOST does not must boot.
+
+ie#615's H3 bring-up: a 134.1 GiB tree plus the 8 GiB staging floor against
+116.4 GiB of host RAM refused structurally (``HostRamCapacityError``) on a
+pod whose card story te#171 had already proved. Host RAM bound ~26 GiB
+tighter than VRAM purely because staging was all-or-nothing while the load
+was already component-sequential (pgw#1041). Two halves, both here:
+
+* the LOADER places each component as it lands and drops the host copy, so
+  the host-RAM high-water mark is one component instead of the tree;
+* the ADMISSION GATE charges that same largest component, so the boot is not
+  refused before the loader gets to run.
+
+Real trees throughout. The loader tests hydrate REAL diffusers modular
+pipelines (the pgw#1036 harness). The admission tests need ie#615's
+magnitudes, so their trees are real directories of SPARSE files — real
+``st_size``, real ``os.walk``, real index parsing, no disk cost.
+
+NOT COVERED HERE: the placement itself lands on ``meta`` rather than
+``cuda``. ``Module.to`` is the same call either way and ``meta`` frees the
+host storage exactly as a device move does, which is the property under
+test — but no CUDA device runs in this suite, so the device-side residency
+of a streamed hydration is proved on a pod, not here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker.capability import HostRamCapacityError
+from gen_worker.models import loading as loading_mod
+from gen_worker.models.loading import (
+    ModularHydrationError,
+    decide_streamed_hydration,
+    hydrate_modular_pipeline,
+    modular_staging_units,
+    plan_streamed_hydration,
+)
+from gen_worker.models.memory import HostRam
+
+from harness.modular_endpoint import (
+    TinyModularPipeline,
+    build_base_tree,
+    build_override_vae_tree,
+)
+
+_GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_HUB_DISABLE_TELEMETRY", "1")
+
+
+def _ram(total_gb: float, available_gb: float) -> HostRam:
+    return HostRam(
+        total_gb=total_gb, available_gb=available_gb,
+        meminfo_total_gb=total_gb, meminfo_available_gb=available_gb,
+        cgroup_limit_gb=total_gb, source="cgroup",
+    )
+
+
+# ---------------------------------------------------------------------------
+# the staging units: what one component's staging actually costs
+# ---------------------------------------------------------------------------
+
+
+def test_the_unit_of_staging_is_a_component_dir(tmp_path) -> None:
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    units = modular_staging_units(tree)
+
+    assert set(units) == {"unet", "vae", "vae_ref", "scheduler"}
+    for name, nbytes in units.items():
+        assert nbytes == loading_mod.disk_gc.tree_bytes(tree / name), name
+    # The config-only unselected partition (H3's `transformer_ref` shape)
+    # costs its config and nothing else.
+    assert units["vae_ref"] < units["vae"]
+    assert max(units.values()) < sum(units.values())
+
+
+def test_an_override_tree_replaces_the_base_unit(tmp_path) -> None:
+    """A pgw#617/th#980 override stages its OWN tree; the base dir it
+    replaces is never read, so it is not a unit."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    override = build_override_vae_tree(tmp_path / "ovr", fill=2.0, subdir=True)
+    units = modular_staging_units(tree, {"vae": str(override)})
+
+    assert "vae" not in units
+    assert units["vae (override)"] == loading_mod.disk_gc.tree_bytes(
+        override / "vae")
+
+
+def test_a_tree_with_no_modular_index_yields_no_units(tmp_path) -> None:
+    (tmp_path / "plain").mkdir()
+    assert modular_staging_units(tmp_path / "plain") == {}
+
+
+# ---------------------------------------------------------------------------
+# the decision, at ie#615's magnitudes
+# ---------------------------------------------------------------------------
+
+
+def _h3(**over: Any) -> Any:
+    """ie#615's measured shape: 134.1 GiB tree on a 116.4 GiB host, largest
+    component 46 GiB, on a card set that holds the tree."""
+    kwargs: Dict[str, Any] = dict(
+        tree_bytes=int(134.1 * _GIB),
+        largest_unit_bytes=int(46.0 * _GIB),
+        unit_count=6,
+        host_total_bytes=int(116.4 * _GIB),
+        device_free_bytes=int(141.0 * _GIB),
+    )
+    kwargs.update(over)
+    return decide_streamed_hydration(**kwargs)
+
+
+def test_the_ie615_shape_engages() -> None:
+    plan = _h3()
+    assert plan.engaged, plan.summary()
+    assert "134.1GiB" in plan.summary() and "46.0GiB" in plan.summary()
+
+
+def test_a_tree_that_fits_the_host_is_left_alone() -> None:
+    """Nothing is wrong on this path, so nothing changes on it."""
+    plan = _h3(tree_bytes=int(40.0 * _GIB), largest_unit_bytes=int(20.0 * _GIB))
+    assert not plan.engaged
+    assert plan.reason == "the whole tree fits host RAM"
+
+
+def test_a_component_bigger_than_the_host_still_refuses_honestly() -> None:
+    """Sequencing cannot place a component that cannot be staged at all —
+    the pgw#752 structural verdict has to survive this issue."""
+    plan = _h3(largest_unit_bytes=int(116.0 * _GIB))
+    assert not plan.engaged
+    assert plan.reason == "the largest component alone exceeds host RAM"
+
+
+def test_a_card_that_does_not_hold_the_tree_does_not_engage() -> None:
+    """The 1x H100-80 ie#615 actually ran on: the components have nowhere to
+    go, so this is te#172's (or a bigger pod's) problem, not this one's."""
+    assert not _h3(device_free_bytes=int(80.0 * _GIB)).engaged
+    # ... and the margin is real: exactly the tree is not enough.
+    assert not _h3(device_free_bytes=int(134.1 * _GIB)).engaged
+    assert _h3(device_free_bytes=int(137.0 * _GIB)).engaged
+
+
+def test_an_unreadable_host_probe_changes_nothing() -> None:
+    assert not _h3(host_total_bytes=0).engaged
+    assert not _h3(unit_count=0, largest_unit_bytes=0).engaged
+
+
+def test_the_plan_measures_a_real_tree(tmp_path, monkeypatch) -> None:
+    """The measuring wrapper reads the same units, the real host probe and
+    the real free-VRAM probe — the tiny harness tree fits any host, so it
+    does not engage, and that is the honest answer for it."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(64.0, 60.0))
+    plan = plan_streamed_hydration(tree, device_free_bytes=80 * _GIB)
+    assert not plan.engaged
+    assert plan.tree_bytes == sum(modular_staging_units(tree).values())
+    assert plan.unit_count == 4
+
+
+# ---------------------------------------------------------------------------
+# the admission gate: ie#615's tree, on a real Executor
+# ---------------------------------------------------------------------------
+
+
+def _sparse_h3_tree(root: Path) -> Path:
+    """A real modular tree whose component dirs measure H3's sizes. The
+    files are sparse: `st_size` (what `tree_bytes` reads) is real, the
+    blocks are not allocated."""
+    root.mkdir(parents=True, exist_ok=True)
+    sizes = {
+        "text_encoder": int(60.0 * _GIB),
+        "transformer": int(46.0 * _GIB),
+        "transformer_2": int(26.0 * _GIB),
+        "vae": int(2.1 * _GIB),
+    }
+    index: Dict[str, Any] = {
+        "_class_name": "TinyModularPipeline",
+        "_blocks_class_name": "TinyBlocks",
+    }
+    for name, nbytes in sizes.items():
+        d = root / name
+        d.mkdir()
+        with open(d / "model.safetensors", "wb") as f:
+            f.truncate(nbytes)
+        index[name] = ["diffusers", "UNet2DConditionModel", {
+            "pretrained_model_name_or_path": "upstream/h3",
+            "subfolder": name, "variant": None, "revision": None,
+        }]
+    (root / "modular_model_index.json").write_text(json.dumps(index))
+    return root
+
+
+async def _admit(spec, paths, *, component_paths=None):
+    from gen_worker.executor import Executor
+
+    async def _send(_msg: Any) -> None:
+        return None
+
+    ex = Executor([spec], _send)
+    await ex._ensure_host_ram_for(spec, paths, component_paths=component_paths)
+
+
+def _modular_spec():
+    from gen_worker.registry import extract_specs
+
+    from harness.modular_endpoint import ModularEndpoint
+
+    return extract_specs(ModularEndpoint)[0]
+
+
+def test_the_gate_charges_the_largest_component_for_a_modular_slot(
+    tmp_path, monkeypatch,
+) -> None:
+    """The whole point: 134.1 GiB of tree on a 116.4 GiB host is admitted,
+    because what stages at once is the 60 GiB text encoder."""
+    tree = _sparse_h3_tree(tmp_path / "h3")
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(116.4, 110.0))
+    monkeypatch.setattr(
+        "gen_worker.models.memory.probe_host_ram", lambda **_: _ram(116.4, 110.0))
+    monkeypatch.setattr(
+        loading_mod, "get_available_vram_gb", lambda *a, **k: 141.0)
+
+    asyncio.run(_admit(_modular_spec(), {"pipeline": str(tree)}))
+
+
+def test_the_gate_still_refuses_when_no_card_can_hold_the_tree(
+    tmp_path, monkeypatch,
+) -> None:
+    """1x H100-80, the pod ie#615 actually had: the refusal is correct and
+    must stay — with its measured numbers, not a softened verdict."""
+    tree = _sparse_h3_tree(tmp_path / "h3")
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(116.4, 110.0))
+    monkeypatch.setattr(
+        "gen_worker.models.memory.probe_host_ram", lambda **_: _ram(116.4, 110.0))
+    monkeypatch.setattr(
+        loading_mod, "get_available_vram_gb", lambda *a, **k: 80.0)
+
+    with pytest.raises(HostRamCapacityError) as exc:
+        asyncio.run(_admit(_modular_spec(), {"pipeline": str(tree)}))
+    assert exc.value.required_bytes > exc.value.total_bytes
+
+
+# ---------------------------------------------------------------------------
+# the loader: one component on the host at a time
+# ---------------------------------------------------------------------------
+
+
+def _device_of(comp: Any) -> Optional[str]:
+    if comp is None:
+        return None
+    try:
+        return next(iter(comp.parameters())).device.type
+    except StopIteration:
+        return None  # weightless (scheduler)
+    except AttributeError:
+        return None
+
+
+def _hydrate_watching_devices(tree: Path, monkeypatch, *, place_device: str):
+    """Hydrate for real, recording every component's device at the moment
+    each NEXT component starts staging (the pgw#1041 phase marker)."""
+    pipe = TinyModularPipeline.from_pretrained(tree)
+    observed: List[Dict[str, Optional[str]]] = []
+    real = loading_mod.load_progress.set_phase
+
+    def watch(phase: str, nbytes: int = 0, **kw):
+        if str(phase).startswith("hydrate:"):
+            observed.append({
+                n: _device_of(getattr(pipe, n, None))
+                for n in ("unet", "vae", "scheduler")
+            })
+        return real(phase, nbytes, **kw)
+
+    monkeypatch.setattr(loading_mod.load_progress, "set_phase", watch)
+    hydrate_modular_pipeline(pipe, tree, place_device=place_device)
+    return pipe, observed
+
+
+def test_each_component_leaves_the_host_before_the_next_one_stages(
+    tmp_path, monkeypatch,
+) -> None:
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe, observed = _hydrate_watching_devices(
+        tree, monkeypatch, place_device="meta")
+
+    assert len(observed) == 3  # scheduler, unet, vae (vae_ref is excluded)
+    for i, snapshot in enumerate(observed):
+        on_host = sorted(n for n, d in snapshot.items() if d == "cpu")
+        assert not on_host, (
+            f"staging component {i} with {on_host} still on the host — the "
+            "high-water mark is the tree again"
+        )
+    # and every component really is hydrated, just not on the host
+    assert _device_of(pipe.unet) == "meta"
+    assert _device_of(pipe.vae) == "meta"
+    assert pipe.scheduler is not None
+
+
+def test_without_a_place_device_the_tree_accumulates_on_the_host(
+    tmp_path, monkeypatch,
+) -> None:
+    """The control, and today's behaviour: unchanged for every slot the
+    plan does not engage for."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe, observed = _hydrate_watching_devices(
+        tree, monkeypatch, place_device="")
+
+    assert any(
+        d == "cpu" for snapshot in observed for d in snapshot.values()), (
+        "expected the pre-pgw#1026 shape: hydrated components stay on the "
+        "host until placement"
+    )
+    assert _device_of(pipe.unet) == "cpu"
+    assert _device_of(pipe.vae) == "cpu"
+
+
+def test_a_placement_that_fails_mid_hydration_is_typed(
+    tmp_path, monkeypatch,
+) -> None:
+    """Free VRAM is read once, before the first component loads. If it moved
+    under us the `.to()` fails, and it must fail NAMING the component — not
+    leave a half-placed pipeline behind a nameless torch error."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    pipe = TinyModularPipeline.from_pretrained(tree)
+    with pytest.raises(ModularHydrationError) as exc:
+        hydrate_modular_pipeline(pipe, tree, place_device="cuda:77")
+    assert "per-component staging could not place component" in str(exc.value)

--- a/tests/test_shared_resident_headroom_pgw1025.py
+++ b/tests/test_shared_resident_headroom_pgw1025.py
@@ -1,0 +1,151 @@
+"""pgw#1025: ``select_auto_mode`` must not count already-resident shared
+components twice.
+
+The gw#479 shape: a second lane of a shared-component endpoint boots against
+a card that ALREADY holds the shared text encoder / VAE. Free VRAM has
+already been reduced by those bytes, and the requirement estimate
+(``estimate_pipeline_size_gb``) counts them again — measured overstatement
+~7.85 GB for z-image, ~15.5 GB for qwen-image. Enough to fall off the
+resident rung entirely; under th#1107's ``strict_vram`` that is not a slower
+placement but a hard refusal (th#1043, the live failure).
+
+Sizes are declared through tensor SHAPE, not allocation: the exclusive
+component is a 1-element storage expanded to the weight count (a real CPU
+tensor with a real, distinct ``data_ptr`` so the storage dedupe behaves), and
+the already-resident component is a fake CUDA tensor. That is the only way to
+put a 15.5 GB CUDA-resident component in front of this arithmetic on a host
+with no CUDA device — and the arithmetic, which is what the issue is about,
+runs for real.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from gen_worker.models import memory
+
+_GIB = 1024 ** 3
+
+
+def _bf16_count(gb: float) -> int:
+    return int(gb * _GIB / 2)
+
+
+def _resident_component(gb: float) -> torch.nn.Module:
+    """A component whose weights are already on CUDA."""
+    m = torch.nn.Module()
+    with FakeTensorMode():
+        m._parameters["weight"] = torch.empty(
+            _bf16_count(gb), dtype=torch.bfloat16, device="cuda")
+    return m
+
+
+def _exclusive_component(gb: float) -> torch.nn.Module:
+    """A component still on the host, waiting to be placed."""
+    m = torch.nn.Module()
+    m._parameters["weight"] = torch.empty(
+        1, dtype=torch.bfloat16).expand(_bf16_count(gb))
+    return m
+
+
+class _SharedLanePipeline:
+    """qwen-image's second lane: 15.5 GB of shared components already on the
+    card, 40 GB of exclusive denoiser weights still to place."""
+
+    def __init__(self, *, shared_gb: float = 15.5, exclusive_gb: float = 40.0):
+        self.components = {
+            "text_encoder": _resident_component(shared_gb),
+            "transformer": _exclusive_component(exclusive_gb),
+        }
+
+
+def test_the_estimates_disagree_by_exactly_the_shared_bytes() -> None:
+    pipe = _SharedLanePipeline()
+    assert memory.estimate_pipeline_size_gb(pipe) == pytest.approx(55.5)
+    assert memory.estimate_cuda_resident_gb(pipe) == pytest.approx(15.5)
+
+
+def test_resident_shared_bytes_are_not_charged_twice() -> None:
+    """80 GB card, 45 GB free, 15.5 GB of it already this pipeline's.
+
+    Pre-fix: requirement 55.5 > usable 43.0 -> ``model_offload``, a 5-10x
+    tax on a lane that fits. Net requirement is 40.0, which fits.
+    """
+    mode = memory.select_auto_mode(
+        pipeline=_SharedLanePipeline(),
+        available_vram_gb=45.0,
+        total_vram_gb=80.0,
+    )
+    assert mode == "off", (
+        f"selected {mode!r}: the 15.5 GB already on the card was charged "
+        "against free VRAM that had already paid for it"
+    )
+
+
+def test_strict_vram_lane_places_instead_of_refusing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """th#1043 end to end through ``place_pipeline``: the overstatement is
+    what turned a working placement into a typed refusal, because th#1107
+    refuses an auto SELECTION into a CPU-touching rung."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(memory, "get_available_vram_gb", lambda *a, **k: 45.0)
+    monkeypatch.setattr(memory, "get_total_vram_gb", lambda *a, **k: 80.0)
+
+    applied: list[str] = []
+
+    def fake_apply(pipeline, *, mode, logger=None):
+        applied.append(mode)
+        return {"mode": mode}
+
+    monkeypatch.setattr(memory, "apply_low_vram_config", fake_apply)
+
+    result = memory.place_pipeline(
+        _SharedLanePipeline(), mode="auto", ref="qwen-image/edit",
+        strict_vram=True,
+    )
+    assert applied == ["off"]
+    assert result["mode"] == "off"
+
+
+def test_refinement_still_keys_on_the_gross_requirement_per_sku() -> None:
+    """pgw#750 is not disturbed. 70 GB SKU, 60.5 GB tree of which 15.5 GB is
+    already resident: the FIT test passes on the 45 GB net, but the off vs
+    vae_only refinement stays on the gross 60.5 against the SKU constant
+    (67 - 60.5 = 6.5 < 8), so the traced decode graph class stays a function
+    of the SKU and never of live residency."""
+    mode = memory.select_auto_mode(
+        pipeline=_SharedLanePipeline(shared_gb=15.5, exclusive_gb=45.0),
+        available_vram_gb=50.0,
+        total_vram_gb=70.0,
+    )
+    assert mode == "vae_only"
+
+
+def test_no_total_probe_falls_back_to_the_net_requirement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a total-capacity probe the refinement has only live free VRAM
+    to work with, so it takes the net requirement like the fit test — never
+    the double-counted one (pre-fix: 55.5 > 43.0 -> ``model_offload``)."""
+    monkeypatch.setattr(memory, "get_total_vram_gb", lambda *a, **k: 0.0)
+    mode = memory.select_auto_mode(
+        pipeline=_SharedLanePipeline(), available_vram_gb=45.0)
+    assert mode == "vae_only"
+
+
+def test_a_pipeline_with_nothing_resident_is_unchanged() -> None:
+    """The correction is exactly zero when nothing is on the card yet."""
+    class _ColdPipeline:
+        def __init__(self) -> None:
+            self.components = {"transformer": _exclusive_component(40.0)}
+
+    assert memory.estimate_cuda_resident_gb(_ColdPipeline()) == 0.0
+    assert memory.select_auto_mode(
+        pipeline=_ColdPipeline(), available_vram_gb=45.0,
+        total_vram_gb=80.0) == "off"
+    assert memory.select_auto_mode(
+        pipeline=_ColdPipeline(), available_vram_gb=30.0,
+        total_vram_gb=80.0) == "model_offload"


### PR DESCRIPTION
Two serve-path arithmetic defects that compose. Both premises were re-verified by content on `origin/master` first — neither was discharged by the 2026-08-09 night's merges.

## pgw#1025 — `select_auto_mode` double-counts already-resident shared components

`requirement` came from `estimate_pipeline_size_gb` — the pipeline's TOTAL weight bytes, *including* the gw#479 shared text encoder / VAE already resident on CUDA — and was compared against free VRAM, which has **already** been reduced by those same bytes. Measured overstatement: ~7.85 GB for z-image, ~15.5 GB for qwen-image. Enough to push a second shared lane off the resident rung, and under th#1107's `strict_vram` into a hard refusal rather than a slower placement (th#1043, the live failure).

Every comparison against LIVE free VRAM now uses the requirement net of `estimate_cuda_resident_gb(pipeline)`. The per-SKU off-vs-`vae_only` refinement deliberately keeps the **gross** requirement — netting live residency into it would restore exactly the mint-posture nondeterminism pgw#750 removed, which is what the issue's own task list asks for.

## pgw#1026 — per-stage staging for a tree the card holds and the host does not

pgw#1041 (merged tonight) already sequenced modular hydration one component at a time and admitted each against the cgroup budget — its own comment calls that "pgw#1026's minimal per-stage form". What it could not do is **free**: every hydrated component stayed in host RAM until placement, so the tree was host-resident by the last component either way, and the executor's admission gate still charged the whole tree. ie#615's H3 therefore refused structurally — 134.1 GiB of tree + the 8 GiB staging floor against 116.4 GiB of host RAM — on a pod te#171 had already proved the card story for.

* `plan_streamed_hydration` decides from three measurements: the whole tree does not fit host RAM, the largest single component does, and free VRAM holds the tree with 2 GB to spare.
* `hydrate_modular_pipeline(place_device=...)` then places each component as it lands and drops the host copy, so the host-RAM high-water mark is one component instead of the tree.
* The executor's host-RAM admission reads the **same** verdict and charges the largest COMPONENT for such a slot — one level down from the "largest slot, not the sum" rule it already applied across slots — because otherwise the gate refuses before the loader can run.

**§4.25.** The mechanism engages only when the whole tree does not fit while the card does, so it can only turn a refusal into a boot: a component that cannot be staged at all keeps the pgw#752 structural refusal, and a card that cannot hold the tree keeps today's answer. Free VRAM is read once, so a `.to()` that loses a race to another tenant refuses typed, naming the component, instead of leaving a half-placed pipeline.

**The two compose on purpose.** A streamed pipeline reaches `place_pipeline` already CUDA-resident; without pgw#1025 `select_auto_mode` would count every one of those bytes a second time and offload it straight back off the card.

## Not fixed here

* A tree larger than the **card** — that needs the sequencer-driven stage schedule the issue also names (H3 on 1x H100-80 stays te#172's fast path). Recorded as the remainder.
* Both issues' live-pod acceptance rows (qwen-image shared-lane boot on an H100-80; H3 on a 116 GiB host). No pod was touched by this lane.
* The streamed placement lands on `meta` in the tests rather than `cuda` — `Module.to` is the same call and `meta` frees the host storage exactly as a device move does, which is the property under test, but no CUDA device runs in this suite. Stated in the test module's docstring rather than left implied.

## Tests — revert-turns-red verified per half

* `tests/test_shared_resident_headroom_pgw1025.py` — 4 of 6 fail on the pre-fix tree; the other 2 are the pgw#750 invariant guards and pass both ways by design.
* `tests/test_per_stage_staging_pgw1026.py` — the admission test fails with the gate's verdict disabled; the loader tests fail with the placement disabled. Real diffusers modular pipelines for the loader half; real directories of **sparse** files for the admission half, so the gate runs at ie#615's actual magnitudes at no disk cost.

Full `tests/`: 3698 passed, 38 skipped, 1 xfailed. `tests_v2/`: 20 passed. Four failures across the two runs were investigated — all reproduce or clear identically on clean `origin/master` in this environment and all pass on this tree at low load; the box was carrying load 50-100 from sibling agents. The three hard lint gates (`lint_http_timeouts`, `lint_unreached_surface`, `lint_unbounded_reads`) pass, and `ruff` is clean on every changed file.

Also carries `changelog.d/pgw1009.md`, the release note the merged pgw#1009 PR (#527) landed without.