### PR TITLE
pgw#1065/th#1361: one spelling of the flavor-token mandate; the parses leave the public API

### DIFF
--- a/changelog.d/pgw1065.md
+++ b/changelog.d/pgw1065.md
@@ -1,0 +1,9 @@
+- **pgw#1065/th#1361: one spelling of the flavor-token mandate, and the
+  parses leave the public API.** The executor's inline `fp8-w8a8*`/
+  `nvfp4-w4a4*` prefix parse is replaced by
+  `execution_lanes.mandatory_traced_lane_of` — the single module now owns
+  every mandatory-traced-lane derivation. `classify_flavor_token`,
+  `placement_for_flavor`, `pick_family_fp8_flavor` and `is_w8a8_flavor`
+  leave `__all__` (the th#1433 twin the worker never did): they are
+  package-internal choke points that die when th#1721 typed descriptors
+  are backfilled, and nothing new may grow on them. No behavior change.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -114,7 +114,7 @@ from .models.memory import (
 from .models.cache_paths import tensorhub_cas_dir, tensorhub_fill_source_dir
 from .models.download import ensure_local, lookup_provider_for_ref
 from .models.errors import MissingSnapshotError, UrlExpiredError
-from .models.execution_lanes import ExecutionLaneUnavailableError
+from .models.execution_lanes import ExecutionLaneUnavailableError, mandatory_traced_lane_of
 from .models.residency import Residency
 from .topology import (
     ExecutionTopology,
@@ -694,7 +694,8 @@ _BG_THREAD_ADMIT_WAIT_S = 0.5
 
 def _ref_mandatory_execution_lane(ref: str) -> str:
     """The traced weight lane one canonical Tensorhub model ref MANDATES:
-    "w8a8" for `#fp8-w8a8` flavors, "w4a4" for `#nvfp4-w4a4`, "" otherwise."""
+    "w8a8" for `#fp8-w8a8` flavors, "w4a4" for `#nvfp4-w4a4`, "" otherwise.
+    The token parse itself lives in execution_lanes (one spelling, th#1361)."""
 
     try:
         parsed = parse_model_ref(ref).tensorhub
@@ -702,12 +703,7 @@ def _ref_mandatory_execution_lane(ref: str) -> str:
         return ""
     if parsed is None or parsed.owner == "root":
         return ""
-    flavor = parsed.flavor or ""
-    if flavor == "fp8-w8a8" or flavor.startswith("fp8-w8a8-"):
-        return "w8a8"
-    if flavor == "nvfp4-w4a4" or flavor.startswith("nvfp4-w4a4-"):
-        return "w4a4"
-    return ""
+    return mandatory_traced_lane_of(parsed.flavor or "")
 
 
 def _mandatory_execution_lane_of(refs: typing.Iterable[str]) -> str:

--- a/src/gen_worker/models/execution_lanes.py
+++ b/src/gen_worker/models/execution_lanes.py
@@ -210,6 +210,20 @@ def is_w8a8_flavor(token: str) -> bool:
     return t == "fp8-w8a8" or t.startswith("fp8-w8a8-")
 
 
+def mandatory_traced_lane_of(flavor: str) -> str:
+    """Traced weight lane a stored flavor MANDATES for fail-closed serving:
+    "w8a8" for `#fp8-w8a8` (gw#534), "w4a4" for `#nvfp4-w4a4` (gw#540), ""
+    otherwise. th#1059 twin of the hub's ``mandatoryTracedLane``; th#1361/
+    pgw#1065 choke point — replaced by the hub-resolved lane once th#1721
+    descriptors cover every ref."""
+    t = str(flavor or "").strip().lower()
+    if is_w8a8_flavor(t):
+        return "w8a8"
+    if t == "nvfp4-w4a4" or t.startswith("nvfp4-w4a4-"):
+        return "w4a4"
+    return ""
+
+
 def _with_supported_execution(execution_lane: ExecutionLane, compiled: bool) -> ExecutionLane:
     execution = EXEC_COMPILED if compiled else EXEC_EAGER
     body = _body_for_execution_lane(execution_lane)
@@ -287,7 +301,7 @@ __all__ = [
     "WEIGHTS_SVDQ_FP4",
     "WEIGHTS_SVDQ_INT4",
     "family_of",
-    "is_w8a8_flavor",
+    "mandatory_traced_lane_of",
     "known_execution_lane_bodies",
     "known_execution_lanes",
     "execution_lane_body_id",

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -262,6 +262,11 @@ EMERGENCY_NF4_VRAM_FACTOR = 0.45  # nf4 denoiser, encoders/VAE at compute dtype
 NF4_WEIGHT_BYTES_FACTOR = 0.30
 
 
+# th#1361/pgw#1065: the flavor-token parses (classify_flavor_token,
+# placement_for_flavor, pick_family_fp8_flavor) are package-internal choke
+# points, not public API — the hub unexported its twin under th#1433. They
+# die when th#1721 typed descriptors are backfilled; nothing new may grow
+# on them.
 __all__ = [
     "FP8_COMPUTE_MIN_SM",
     "CLASS_BASE",
@@ -274,12 +279,9 @@ __all__ = [
     "EMERGENCY_NF4_VRAM_FACTOR",
     "NF4_WEIGHT_BYTES_FACTOR",
     "Placement",
-    "classify_flavor_token",
     "default_placement",
     "family_root",
     "maybe_rebind_family_fp8",
-    "pick_family_fp8_flavor",
-    "placement_for_flavor",
     "placement_from_metadata",
     "placement_to_metadata",
     "w8a8_excluded_for_family",


### PR DESCRIPTION
Worker half of th#1361's executable-now increment, per pgw#1065's survivor map (every row re-verified fresh against master `8b05533f`).

- **Executor's inline `fp8-w8a8*`/`nvfp4-w4a4*` prefix parse → `execution_lanes.mandatory_traced_lane_of`** — the lane module owns every mandatory-traced-lane derivation (th#1059 twin of the hub's `mandatoryTracedLane`). Behavior parity asserted for exact/suffixed/case-varied tokens, root-owner refs, invalid refs.
- **`classify_flavor_token` / `placement_for_flavor` / `pick_family_fp8_flavor` / `is_w8a8_flavor` leave `__all__`** — the th#1433 boundary the hub drew (th#1724 §H item 6: "the worker never did"). They remain package-internal choke points, marked th#1361-gated in code: they die when th#1721 typed descriptors are backfilled.
- No behavior change; zero external consumers (swept inference-endpoints, private-inference-endpoints, training-endpoints, cozy-local, e2e, cozy-eval).

Local proof (worktree venv, py3.12): mypy clean (244 files), ruff clean, all 7 lint gates + changelog assemble green; **tests/ 3678 passed** (3 timing-shaped failures at box load ~60 all pass on re-run at idle), **tests_v2/ 21 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)