### PR TITLE
pgw#1074: a scalar timestep's dtype is a SAMPLER fact — the ingress normalizes it, and the refusal names the CLOSEST entry

### DIFF
--- a/changelog.d/pgw1074.md
+++ b/changelog.d/pgw1074.md
@@ -1,0 +1,44 @@
+- **pgw#1074: a scalar timestep's dtype is a per-request SAMPLER fact, and the
+  ingress now normalizes it — plus a `no_entry_admits` refusal that names the
+  CLOSEST entry instead of the first six.** On the pgw#868 A1 sdxl close
+  (attempt 32, cell `ck1-5f421149…`, 36/36 parity) the turbo arm served from
+  the cell and the base arm got `fallback_reason=ingress_refused` from an entry
+  whose dims matched it exactly. Measured off-pod at $0 over
+  `gen_worker.view.SAMPLERS` against the fleet's own diffusers: the dtype a
+  diffusers denoiser receives for its scalar timestep is decided by
+  `set_timesteps`, and the table splits —
+  `euler`/`euler_a`/`euler_trailing`/`heun`/`flow_euler` present **float32**
+  while `ddim{,_trailing}`/`ddpm`/`deis`/`dpmpp_2m{,_karras,_sde,_sde_karras}`/
+  `lcm`/`unipc` present **int64**. Four of sdxl's six legal samplers are int64;
+  turbo runs `euler_trailing` and served, the base arm ran an int64 sampler and
+  did not. CFG was a red herring — a `generate` call on `euler_a` would have
+  served and a `dmd2-4step` (`lcm`) turbo call would have been refused. The
+  sampler is per-request VIEW state and deliberately not a compile axis, so no
+  declared dtype can be right for every call, and ie#627's `float32` is not
+  wrong: it is what the graph is specialized on.
+  - **`aot_serve.recast_gap`** — the ingress recasts a **rank-0** input from an
+    **integer** dtype into a **float32/float64** declared one, staged through
+    pgw#791's existing aligned buffer (one `copy_`, no allocation per step, no
+    synchronise), counted, and announced once per (entry, input, pair) as the
+    typed `aot_input_recast`. float32 represents every integer below 2**24
+    exactly and the cast is the op the traced graph's own first node performs
+    (`get_timestep_embedding`: `timesteps[:, None].float()`), so a recast feed
+    is bit-identical to the eager call that presented the integer — proven
+    against a real AOTI package over a whole timestep ladder. Nothing else is
+    normalized: float→float stays refused (pgw#1058's bf16 cell is still
+    caught), float→int stays refused, bf16/fp16 are not recast targets (8
+    mantissa bits would round timestep 999 to 1000), and non-scalar rows are
+    untouched (wan-2.2's rank-1 `int64` timestep is unaffected). **No re-mint:
+    the already-published sdxl cell serves its base arm under this fix.**
+  - **The refusal that hid it.** `no packaged entry admits this call (36
+    tried)` then listed **six**, in iteration order, and the one entry whose
+    dims matched was not among them — so the covering entry's actual objection
+    was unavailable and diagnosis meant pulling the published cell apart. The
+    B2 check is now one collecting implementation (`aot_serve.ingress_report`,
+    which `assert_ingress` raises the first miss of), entries are ranked by
+    `miss_distance` (dtype before dims, fewer misses before more), and the
+    sentence leads with the closest entry, its full reason, and whether every
+    declared dim matched — then accounts for **every** remaining entry by
+    reason count instead of naming an arbitrary few. The whole line fits inside
+    the hub's detail truncation, which the informative entry previously fell
+    past.

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -1433,6 +1433,8 @@ def ingress_report(
     contract: ArtifactContract,
     args: Sequence[Any],
     kwargs: Mapping[str, Any],
+    *,
+    first_only: bool = False,
 ) -> Tuple[Tuple[IngressMiss, ...], Dict[str, int]]:
     """EVERY way this call misses this contract, plus the symbol bindings.
 
@@ -1440,6 +1442,12 @@ def ingress_report(
     raises this function's FIRST miss and :meth:`EntryDispatch.select` ranks
     whole entries by all of them, so an admission decision and the sentence
     that explains it can never be computed by two different rules.
+
+    ``first_only`` returns as soon as one miss is found. It is an early EXIT
+    from this same walk, never a second rule — every ADMISSION decision takes
+    it (an admitted call has no misses, so the two are identical there), and
+    the exhaustive walk is paid only on the refusal path, which is already
+    falling back to eager. A 36-entry cell is asked this per denoise step.
 
     Misses are collected in declaration order, per input in
     dtype -> rank -> dims order, which is the order the raising check used
@@ -1464,6 +1472,8 @@ def ingress_report(
     symbols: Dict[str, int] = {}
     owner: Dict[str, str] = {}
     for spec in contract.inputs:
+        if first_only and misses:
+            break
         if spec.name not in bound:
             continue
         value = bound[spec.name]
@@ -1513,7 +1523,7 @@ def ingress_report(
                 continue
             symbols[declared] = got
             owner.setdefault(declared, spec.name)
-    return tuple(misses), symbols
+    return (tuple(misses[:1]) if first_only else tuple(misses)), symbols
 
 
 def assert_ingress(
@@ -1539,7 +1549,7 @@ def assert_ingress(
       graph requires it, so a mismatch is out-of-contract even when both
       values are individually in range.
     """
-    misses, symbols = ingress_report(contract, args, kwargs)
+    misses, symbols = ingress_report(contract, args, kwargs, first_only=True)
     if misses:
         raise IngressContractError(misses[0].reason, misses[0].detail)
     return symbols
@@ -2055,16 +2065,24 @@ class EntryDispatch:
         self, args: Sequence[Any], kwargs: Mapping[str, Any],
     ) -> Tuple[str, ArtifactRunner]:
         admitted: List[Tuple[str, ArtifactRunner]] = []
-        missed: List[Tuple[Tuple[int, ...], str, Tuple[IngressMiss, ...]]] = []
+        missed: List[Tuple[str, ArtifactRunner]] = []
         for name, runner in self.runners:
-            misses, _symbols = ingress_report(runner.contract, args, kwargs)
+            misses, _symbols = ingress_report(
+                runner.contract, args, kwargs, first_only=True)
             if misses:
-                missed.append((miss_distance(misses), name, misses))
+                missed.append((name, runner))
                 continue
             admitted.append((name, runner))
         if not admitted:
+            # Only now is the exhaustive walk worth its cost: the call is
+            # already headed for the eager fallback, and the sentence it
+            # leaves behind is the whole diagnosis anyone will ever get.
+            ranked = [
+                (miss_distance(rep), name, rep) for name, rep in (
+                    (name, ingress_report(runner.contract, args, kwargs)[0])
+                    for name, runner in missed)]
             raise IngressContractError(
-                "no_entry_admits", no_entry_detail(len(self.runners), missed))
+                "no_entry_admits", no_entry_detail(len(self.runners), ranked))
         if len(admitted) > 1:
             names = sorted(name for name, _ in admitted)
             raise IngressContractError(

--- a/src/gen_worker/aot_serve.py
+++ b/src/gen_worker/aot_serve.py
@@ -117,6 +117,11 @@ ARTIFACT_KIND = "aot-inductor"
 #: was indistinguishable from one that was not. Coalesced: once per
 #: (entry, input, reason).
 REALIGN_EVENT = "aot_input_realigned"
+#: pgw#1074: a rank-0 input arrived in an INTEGER dtype where the graph is
+#: specialized on float32/float64, and this ingress recast it. Same shape and
+#: same doctrine as :data:`REALIGN_EVENT` — the ingress normalizes the feed to
+#: the artifact's contract and SAYS so, once per (entry, input, dtype pair).
+RECAST_EVENT = "aot_input_recast"
 #: AOTInductor generates its aligned-input fast path at 16 bytes
 #: (``torch._inductor.codegen.aoti_runtime``'s ALIGNMENT). An input whose
 #: ``data_ptr()`` is not a multiple of this — diffusers hands the denoiser
@@ -1196,6 +1201,56 @@ def excluded_inputs_present(
     return tuple(found)
 
 
+#: pgw#1074: the ONLY dtype normalization this ingress performs. Integer ->
+#: float32/float64 on a rank-0 input, and nothing else.
+#:
+#: float32 represents every integer up to 2**24 exactly, so the recast is
+#: value-preserving over any diffusion timestep domain, and it is EXACTLY the
+#: op the traced graph's own first node performs on this input (diffusers
+#: ``get_timestep_embedding``: ``timesteps[:, None].float()``) — so a recast
+#: feed produces bit-identical output to the eager call that presented the
+#: integer. bfloat16 and float16 are deliberately NOT targets: bf16 has 8
+#: mantissa bits and would round timestep 999 to 1000, which is a numeric
+#: change, not a normalization.
+RECAST_TARGETS = ("float32", "float64")
+_INTEGER_DTYPES = ("int8", "int16", "int32", "int64", "uint8")
+
+
+def recast_gap(spec: InputContract, value: Any) -> str:
+    """The named dtype normalization this feed needs, or ``''`` (pgw#1074).
+
+    ``''`` means either "already in contract" or "must be REFUSED" — this
+    function never widens the contract, it only names the one normalization
+    the ingress is allowed to perform, and :func:`ingress_report` refuses
+    every other dtype disagreement exactly as before.
+
+    **Why this exists.** The dtype a diffusers denoiser is handed for its
+    scalar timestep is a per-request SAMPLER fact, not a family fact. Measured
+    over ``gen_worker.view.SAMPLERS`` on the fleet's own diffusers (pgw#1074):
+    ``euler``/``euler_a``/``euler_trailing``/``heun``/``flow_euler`` present
+    **float32**; ``ddim``/``ddim_trailing``/``ddpm``/``deis``/``dpmpp_2m*``/
+    ``lcm``/``unipc`` present **int64** (``set_timesteps`` ends in
+    ``.to(dtype=torch.int64)``). sdxl's cell was minted float32 (ie#627, and
+    correct — it is what the graph is specialized on), so its turbo arm
+    (``euler_trailing``) served from the cell and its base arm, on an int64
+    sampler, was refused ``no_entry_admits`` by an entry that covered it in
+    every other respect. No single declared dtype can be right for a family
+    whose sampler is per-request VIEW state, and the sampler is deliberately
+    not a compile axis — so the normalization belongs at the boundary that
+    knows the contract, once, named and counted.
+    """
+    if spec.shape:  # rank-0 only: the timestep class, not a tensor of values
+        return ""
+    if spec.dtype not in RECAST_TARGETS:
+        return ""
+    got = _dtype_name(value)
+    if got not in _INTEGER_DTYPES:
+        return ""
+    if getattr(value, "shape", None) is None or tuple(value.shape):
+        return ""
+    return f"{got}_to_{spec.dtype}"
+
+
 def alignment_gap(value: Any) -> str:
     """'' when a feed satisfies the artifact's aligned-input contract, else
     the named reason (pgw#791).
@@ -1242,16 +1297,23 @@ class FeedAligner:
     def __init__(self) -> None:
         self._buffers: Dict[str, Any] = {}
 
-    def staged(self, name: str, value: Any) -> Any:
-        """A 16-byte-aligned contiguous copy of ``value`` in an owned buffer."""
+    def staged(self, name: str, value: Any, dtype: str = "") -> Any:
+        """A 16-byte-aligned contiguous copy of ``value`` in an owned buffer.
+
+        ``dtype`` (pgw#1074) stages into the artifact's DECLARED dtype instead
+        of the feed's own. The conversion is ``Tensor.copy_``'s — one device
+        kernel into the buffer this ingress already had to write, so the
+        recast costs nothing beyond the staging copy and never synchronises.
+        """
         import torch
 
+        want = getattr(torch, dtype) if dtype else value.dtype
         buf = self._buffers.get(name)
-        if (buf is None or buf.dtype is not value.dtype
+        if (buf is None or buf.dtype is not want
                 or buf.device != value.device
                 or tuple(buf.shape) != tuple(value.shape)):
             buf = torch.empty(
-                tuple(value.shape), dtype=value.dtype, device=value.device)
+                tuple(value.shape), dtype=want, device=value.device)
             if int(buf.data_ptr()) % AOTI_ALIGNMENT:
                 # torch's caching allocator hands out 512-byte-aligned blocks
                 # (CPU: 64). If that ever stops being true, realigning by
@@ -1276,9 +1338,14 @@ def aligned_feeds(
     contract: ArtifactContract,
     feeds: Sequence[Any],
     aligner: FeedAligner,
-    report: Optional[Callable[[str, str], None]] = None,
+    report: Optional[Callable[[str, str, str], None]] = None,
 ) -> List[Any]:
-    """``feeds`` with every out-of-contract input realigned in place (pgw#791).
+    """``feeds`` normalized to the artifact's contract (pgw#791 + pgw#1074).
+
+    Two normalizations, one staging buffer: the declared dtype
+    (:func:`recast_gap`) and the declared 16-byte alignment
+    (:func:`alignment_gap`). A recast implies a staged copy, so it subsumes
+    the alignment pass rather than running after it.
 
     ``feeds`` is :func:`marshal_positional`'s output, so it is one value per
     declared input in ``position`` order — the same order this walks, which is
@@ -1293,13 +1360,160 @@ def aligned_feeds(
             f"would realign the wrong slot")
     out = list(feeds)
     for idx, (spec, value) in enumerate(zip(specs, feeds)):
-        reason = alignment_gap(value)
+        recast = recast_gap(spec, value)
+        reason = recast or alignment_gap(value)
         if not reason:
             continue
-        out[idx] = aligner.staged(spec.name, value)
+        out[idx] = aligner.staged(spec.name, value, spec.dtype if recast else "")
         if report is not None:
-            report(spec.name, reason)
+            report(spec.name, reason, RECAST_EVENT if recast else REALIGN_EVENT)
     return out
+
+
+#: pgw#1074: how far each refusal reason puts an entry from the call. Dims
+#: LAST, so an entry that matches every declared dimension sorts to the front
+#: of a refusal listing whatever its remaining complaint is. The rungs are
+#: ordinal only — nothing reads their absolute values.
+MISS_RUNGS: Mapping[str, int] = {
+    # The call fits this graph's shape and disagrees about one scalar fact.
+    "dtype_mismatch": 1,
+    "input_not_tensor": 2,
+    # A branch/adapter routing disagreement: same shape family, wrong class.
+    "input_excluded": 3,
+    # Shape disagreements — the call does not fit this graph at all.
+    "static_dim_mismatch": 4,
+    "range_violation": 4,
+    "symbol_inconsistent": 4,
+    "rank_mismatch": 5,
+    # The call does not even carry the input; nothing else was measurable.
+    "input_missing": 6,
+}
+_MISS_RUNG_DEFAULT = 9
+#: How many non-closest entries a refusal names individually before it
+#: switches to a per-reason count. The closest entry is ALWAYS named in full
+#: and always first: this detail is truncated by the hub at ~573 chars, and
+#: pgw#1074 is what happens when the one informative entry falls past that.
+_MISS_SAMPLE = 3
+
+
+@dataclass(frozen=True)
+class IngressMiss:
+    """ONE reason one entry refuses one call (pgw#1074).
+
+    :attr:`rung` is how FAR that reason puts the entry from the call, and it
+    exists because a refusal listing has to be ORDERED by something. The
+    ordering is dims-first: an entry the call matches in every declared
+    dimension and misses only on dtype is the entry a reader is looking for,
+    and listing entries in iteration order buried exactly that one (36 tried,
+    6 listed, the dims-matching one not among them — the pgw#1074 filing).
+    """
+
+    reason: str
+    detail: str
+    input: str = ""
+    rung: int = _MISS_RUNG_DEFAULT
+
+
+def _rung(reason: str) -> int:
+    return MISS_RUNGS.get(reason, _MISS_RUNG_DEFAULT)
+
+
+def miss_distance(misses: Sequence[IngressMiss]) -> Tuple[int, ...]:
+    """Sort key over one entry's misses — lower is CLOSER to the call.
+
+    The sorted rung tuple, so that (a) an entry whose only complaint is a
+    shallow one beats an entry with a deep one, and (b) among entries with
+    the same shallowest complaint, the one with FEWER complaints wins (a
+    prefix sorts before its extension). Deterministic and total.
+    """
+    return tuple(sorted(_rung(m.reason) for m in misses))
+
+
+def ingress_report(
+    contract: ArtifactContract,
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any],
+) -> Tuple[Tuple[IngressMiss, ...], Dict[str, int]]:
+    """EVERY way this call misses this contract, plus the symbol bindings.
+
+    The one implementation of the pgw#704 B2 check. :func:`assert_ingress`
+    raises this function's FIRST miss and :meth:`EntryDispatch.select` ranks
+    whole entries by all of them, so an admission decision and the sentence
+    that explains it can never be computed by two different rules.
+
+    Misses are collected in declaration order, per input in
+    dtype -> rank -> dims order, which is the order the raising check used
+    before this became a collecting one.
+    """
+    present = excluded_inputs_present(contract, kwargs)
+    if present:
+        return ((IngressMiss(
+            "input_excluded",
+            f"this graph class REFUSES input(s) {list(present)!r}: the call "
+            f"carries them, so it must be served by the class that declares "
+            f"them (pgw#790 — a branchless class fed an adapter would return "
+            f"the base model and look correct)",
+            str(present[0])),), {})
+    try:
+        bound = bind_call_inputs(contract, args, kwargs)
+    except IngressContractError as exc:
+        # An input the call does not carry at all: nothing further about this
+        # entry can be measured, so it is one miss and the deepest rung.
+        return ((IngressMiss(exc.reason, str(exc)),), {})
+    misses: List[IngressMiss] = []
+    symbols: Dict[str, int] = {}
+    owner: Dict[str, str] = {}
+    for spec in contract.inputs:
+        if spec.name not in bound:
+            continue
+        value = bound[spec.name]
+        shape = getattr(value, "shape", None)
+        if shape is None:
+            misses.append(IngressMiss(
+                "input_not_tensor",
+                f"declared input {spec.name!r} is a "
+                f"{type(value).__name__} with no shape", spec.name))
+            continue
+        got_dtype = _dtype_name(value)
+        if got_dtype != spec.dtype and not recast_gap(spec, value):
+            misses.append(IngressMiss(
+                "dtype_mismatch",
+                f"input {spec.name!r} dtype {got_dtype or '<unknown>'} != "
+                f"declared {spec.dtype}", spec.name))
+        actual = tuple(int(d) for d in shape)
+        if len(actual) != len(spec.shape):
+            misses.append(IngressMiss(
+                "rank_mismatch",
+                f"input {spec.name!r} rank {len(actual)} != declared "
+                f"{len(spec.shape)} (declared shape {list(spec.shape)!r})",
+                spec.name))
+            continue
+        for pos, (declared, got) in enumerate(zip(spec.shape, actual)):
+            if isinstance(declared, int):
+                if got != declared:
+                    misses.append(IngressMiss(
+                        "static_dim_mismatch",
+                        f"input {spec.name!r} dim {pos} = {got} != "
+                        f"statically specialized {declared}", spec.name))
+                continue
+            lo, hi = contract.symbols[declared]
+            if not (lo <= got <= hi):
+                misses.append(IngressMiss(
+                    "range_violation",
+                    f"input {spec.name!r} dim {pos} (symbol {declared!r}) = "
+                    f"{got} outside declared range [{lo}, {hi}]", spec.name))
+                continue
+            prior = symbols.get(declared)
+            if prior is not None and prior != got:
+                misses.append(IngressMiss(
+                    "symbol_inconsistent",
+                    f"symbol {declared!r} = {got} on input {spec.name!r} dim "
+                    f"{pos} but {prior} on input {owner[declared]!r}",
+                    spec.name))
+                continue
+            symbols[declared] = got
+            owner.setdefault(declared, spec.name)
+    return tuple(misses), symbols
 
 
 def assert_ingress(
@@ -1311,10 +1525,12 @@ def assert_ingress(
 
     Returns the resolved symbol bindings on success; raises
     :class:`IngressContractError`, naming the input, the dim, the symbol,
-    the value and the bound, on any violation. Checks, per input:
+    the value and the bound, on the FIRST violation :func:`ingress_report`
+    finds. Checks, per input:
 
     * present (unless declared optional);
-    * dtype EXACT — an exported graph is specialized on dtype;
+    * dtype EXACT — an exported graph is specialized on dtype — except for
+      the one named normalization :func:`recast_gap` performs;
     * rank EXACT;
     * static dims EXACT — a specialized dim is not a range;
     * symbolic dims inside the declared inclusive range;
@@ -1323,61 +1539,9 @@ def assert_ingress(
       graph requires it, so a mismatch is out-of-contract even when both
       values are individually in range.
     """
-    present = excluded_inputs_present(contract, kwargs)
-    if present:
-        raise IngressContractError(
-            "input_excluded",
-            f"this graph class REFUSES input(s) {list(present)!r}: the call "
-            f"carries them, so it must be served by the class that declares "
-            f"them (pgw#790 — a branchless class fed an adapter would return "
-            f"the base model and look correct)")
-    bound = bind_call_inputs(contract, args, kwargs)
-    symbols: Dict[str, int] = {}
-    owner: Dict[str, str] = {}
-    for spec in contract.inputs:
-        if spec.name not in bound:
-            continue
-        value = bound[spec.name]
-        shape = getattr(value, "shape", None)
-        if shape is None:
-            raise IngressContractError(
-                "input_not_tensor",
-                f"declared input {spec.name!r} is a "
-                f"{type(value).__name__} with no shape")
-        got_dtype = _dtype_name(value)
-        if got_dtype != spec.dtype:
-            raise IngressContractError(
-                "dtype_mismatch",
-                f"input {spec.name!r} dtype {got_dtype or '<unknown>'} != "
-                f"declared {spec.dtype}")
-        actual = tuple(int(d) for d in shape)
-        if len(actual) != len(spec.shape):
-            raise IngressContractError(
-                "rank_mismatch",
-                f"input {spec.name!r} rank {len(actual)} != declared "
-                f"{len(spec.shape)} (declared shape {list(spec.shape)!r})")
-        for pos, (declared, got) in enumerate(zip(spec.shape, actual)):
-            if isinstance(declared, int):
-                if got != declared:
-                    raise IngressContractError(
-                        "static_dim_mismatch",
-                        f"input {spec.name!r} dim {pos} = {got} != "
-                        f"statically specialized {declared}")
-                continue
-            lo, hi = contract.symbols[declared]
-            if not (lo <= got <= hi):
-                raise IngressContractError(
-                    "range_violation",
-                    f"input {spec.name!r} dim {pos} (symbol {declared!r}) = "
-                    f"{got} outside declared range [{lo}, {hi}]")
-            prior = symbols.get(declared)
-            if prior is not None and prior != got:
-                raise IngressContractError(
-                    "symbol_inconsistent",
-                    f"symbol {declared!r} = {got} on input {spec.name!r} dim "
-                    f"{pos} but {prior} on input {owner[declared]!r}")
-            symbols[declared] = got
-            owner.setdefault(declared, spec.name)
+    misses, symbols = ingress_report(contract, args, kwargs)
+    if misses:
+        raise IngressContractError(misses[0].reason, misses[0].detail)
     return symbols
 
 
@@ -1597,8 +1761,10 @@ class ArtifactRunner:
     bound_fqns: Tuple[str, ...] = ()
     calls: int = 0
     refusals: Dict[str, int] = field(default_factory=dict)
-    #: pgw#791. ``"<input>/<reason>" -> count``; the typed event fires on the
-    #: first of each, the count keeps the whole tax countable afterwards.
+    #: pgw#791 + pgw#1074. ``"<input>/<reason>" -> count`` over every ingress
+    #: NORMALIZATION — realignment (``unaligned_16b``) and dtype recast
+    #: (``int64_to_float32``) alike; the typed event fires on the first of
+    #: each, the count keeps the whole tax countable afterwards.
     realigned: Dict[str, int] = field(default_factory=dict)
     aligner: FeedAligner = field(default_factory=FeedAligner)
     #: Set by :func:`load_and_wrap` so the typed realignment event can name
@@ -1723,9 +1889,9 @@ class ArtifactRunner:
                 f"{len(self.constants)} unbound constant(s): calling before "
                 f"load_constants segfaults the worker process")
 
-    def _report_realigned(self, name: str, reason: str) -> None:
+    def _report_normalized(self, name: str, reason: str, event: str) -> None:
         """First occurrence of an (input, reason) is a typed hub-visible
-        event; every occurrence is counted (pgw#791).
+        event; every occurrence is counted (pgw#791, pgw#1074).
 
         Coalesced deliberately: the defect fires 28+ times per request, and a
         per-call event would be the stderr spam it replaces, on a wire that
@@ -1736,19 +1902,31 @@ class ArtifactRunner:
         self.realigned[key] = seen + 1
         if seen:
             return
-        logger.warning(
-            "aot-serve: input %r arrived %s for entry %r; realigning into an "
-            "owned aligned buffer at ingress (the artifact would otherwise "
-            "copy it on every call and report only on stderr)",
-            name, reason, self.entry or self.module_name)
-        activity_mod.emit_event(
-            REALIGN_EVENT,
-            f"family={self.family} entry={self.entry or self.module_name} "
-            f"target={self.module_name} input={name}: {reason} — realigned at "
-            f"ingress into an owned {AOTI_ALIGNMENT}-byte aligned buffer "
-            f"(AOTInductor would otherwise copy it on every call)",
-            phase=reason,
-        )
+        entry = self.entry or self.module_name
+        if event == RECAST_EVENT:
+            logger.warning(
+                "aot-serve: input %r arrived %s for entry %r; recasting to "
+                "the declared dtype at ingress (the sampler, not the family, "
+                "decides this dtype)", name, reason, entry)
+            detail = (
+                f"family={self.family} entry={entry} "
+                f"target={self.module_name} input={name}: {reason} — recast "
+                f"at ingress to the dtype this graph is specialized on "
+                f"(pgw#1074: a scalar timestep's dtype is a per-request "
+                f"SAMPLER fact, not a family one)")
+        else:
+            logger.warning(
+                "aot-serve: input %r arrived %s for entry %r; realigning into "
+                "an owned aligned buffer at ingress (the artifact would "
+                "otherwise copy it on every call and report only on stderr)",
+                name, reason, entry)
+            detail = (
+                f"family={self.family} entry={entry} "
+                f"target={self.module_name} input={name}: {reason} — "
+                f"realigned at ingress into an owned {AOTI_ALIGNMENT}-byte "
+                f"aligned buffer (AOTInductor would otherwise copy it on "
+                f"every call)")
+        activity_mod.emit_event(event, detail, phase=reason)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         self.assert_ready()
@@ -1758,13 +1936,61 @@ class ArtifactRunner:
             # pgw#791: satisfy the artifact's ALIGNED-input contract here,
             # once, instead of letting the runner discover it per call.
             feeds = aligned_feeds(
-                self.contract, feeds, self.aligner, self._report_realigned)
+                self.contract, feeds, self.aligner, self._report_normalized)
         except IngressContractError as exc:
             self.refusals[exc.reason] = self.refusals.get(exc.reason, 0) + 1
             raise
         out = self.package(*feeds)
         self.calls += 1
         return out
+
+
+def no_entry_detail(
+    tried: int,
+    missed: Sequence[Tuple[Tuple[int, ...], str, Tuple[IngressMiss, ...]]],
+) -> str:
+    """The ``no_entry_admits`` sentence, CLOSEST ENTRY FIRST (pgw#1074).
+
+    The refusal this replaces said "36 tried" and then listed six in iteration
+    order — and the one entry whose dims matched the call was not among them,
+    so diagnosing a live refusal meant pulling the published cell apart off-pod
+    to find out what the covering entry actually objected to. A refusal that
+    hides the one relevant miss is the pgw#1058 lesson repeating one layer up,
+    in the diagnostics.
+
+    So: rank by :func:`miss_distance`, name the closest entry and its FULL
+    reason first (it survives any downstream truncation), then account for
+    every other entry by reason COUNT rather than by naming an arbitrary few.
+    Nothing is silently dropped — ``tried`` and the counts always add up.
+    """
+    if not missed:
+        return f"no packaged entry admits this call ({tried} tried)"
+    ranked = sorted(missed, key=lambda row: (row[0], row[1]))
+    _distance, closest, misses = ranked[0]
+    dims_ok = all(_rung(m.reason) < MISS_RUNGS["static_dim_mismatch"]
+                  for m in misses)
+    head = (
+        f"no packaged entry admits this call ({tried} tried); CLOSEST entry "
+        f"{closest!r}"
+        f"{' — every declared dim MATCHES' if dims_ok else ''}: "
+        + "; ".join(f"{m.reason} ({m.detail})" for m in misses[:2]))
+    rest = ranked[1:]
+    if not rest:
+        return head
+    # ONE count per entry, under its own closest reason, so the counts sum to
+    # exactly the number of entries tried and "36 tried" can be checked
+    # against the sentence that follows it.
+    tally: Dict[str, int] = {}
+    for _d, _name, other in rest:
+        primary = min(other, key=lambda m: _rung(m.reason)).reason
+        tally[primary] = tally.get(primary, 0) + 1
+    named = "; ".join(
+        f"{name}: {min(misses_, key=lambda m: _rung(m.reason)).reason}"
+        for _d, name, misses_ in rest[:_MISS_SAMPLE])
+    counted = ", ".join(
+        f"{reason} x{count}" for reason, count in
+        sorted(tally.items(), key=lambda kv: (-kv[1], kv[0])))
+    return f"{head}. Other {len(rest)} entries [{counted}] — next: {named}"
 
 
 @dataclass
@@ -1829,19 +2055,16 @@ class EntryDispatch:
         self, args: Sequence[Any], kwargs: Mapping[str, Any],
     ) -> Tuple[str, ArtifactRunner]:
         admitted: List[Tuple[str, ArtifactRunner]] = []
-        reasons: List[str] = []
+        missed: List[Tuple[Tuple[int, ...], str, Tuple[IngressMiss, ...]]] = []
         for name, runner in self.runners:
-            try:
-                assert_ingress(runner.contract, args, kwargs)
-            except IngressContractError as exc:
-                reasons.append(f"{name}: {exc.reason}")
+            misses, _symbols = ingress_report(runner.contract, args, kwargs)
+            if misses:
+                missed.append((miss_distance(misses), name, misses))
                 continue
             admitted.append((name, runner))
         if not admitted:
             raise IngressContractError(
-                "no_entry_admits",
-                f"no packaged entry admits this call "
-                f"({len(self.runners)} tried): {'; '.join(reasons[:6])}")
+                "no_entry_admits", no_entry_detail(len(self.runners), missed))
         if len(admitted) > 1:
             names = sorted(name for name, _ in admitted)
             raise IngressContractError(

--- a/tests/test_aot_input_alignment_pgw791.py
+++ b/tests/test_aot_input_alignment_pgw791.py
@@ -189,11 +189,12 @@ def test_the_marshalled_feed_is_realigned_in_place() -> None:
     feeds = aot_serve.marshal_positional(
         contract, (torch.randn(2, 8), view), {})
     assert aot_serve.alignment_gap(feeds[1]) == "unaligned_16b"
-    seen: List[Tuple[str, str]] = []
+    seen: List[Tuple[str, str, str]] = []
     out = aot_serve.aligned_feeds(
         contract, feeds, aot_serve.FeedAligner(),
-        lambda name, reason: seen.append((name, reason)))
-    assert seen == [("timestep", "unaligned_16b")]
+        lambda name, reason, event: seen.append((name, reason, event)))
+    assert seen == [
+        ("timestep", "unaligned_16b", aot_serve.REALIGN_EVENT)]
     assert aot_serve.alignment_gap(out[1]) == ""
     assert torch.equal(out[1], view)
     assert out[0] is feeds[0]      # an in-contract input is never copied

--- a/tests/test_ingress_recast_and_closest_entry_pgw1074.py
+++ b/tests/test_ingress_recast_and_closest_entry_pgw1074.py
@@ -409,6 +409,34 @@ def test_ingress_report_collects_every_miss_not_only_the_first() -> None:
     assert [m.input for m in misses] == ["sample", "timestep"]
 
 
+def test_the_short_circuit_never_changes_an_admission_decision() -> None:
+    """`select` walks 36 entries per denoise step, so the ADMISSION pass exits
+    at the first miss and only the refusal path pays the exhaustive walk. That
+    is an early exit from one walk, not a second rule — so admitted/refused
+    must agree exactly, over admitting and refusing calls alike."""
+    contracts = [
+        _contract(),
+        _contract(timestep_dtype="bfloat16"),
+        _contract(sample_dims=(1, 8)),
+        _contract(timestep_shape=[4]),
+    ]
+    calls = [
+        {"sample": torch.randn(2, 8), "timestep": torch.tensor(1.0)},
+        {"sample": torch.randn(2, 8), "timestep": torch.tensor(3,
+                                                               dtype=torch.int64)},
+        {"sample": torch.randn(1, 8), "timestep": torch.tensor(1.0)},
+        {"sample": torch.randn(2, 8)},
+    ]
+    for contract in contracts:
+        for call in calls:
+            full, _ = aot_serve.ingress_report(contract, (), call)
+            first, _ = aot_serve.ingress_report(
+                contract, (), call, first_only=True)
+            assert bool(full) == bool(first)
+            if full:
+                assert first == (full[0],)
+
+
 def test_assert_ingress_raises_ingress_reports_first_miss() -> None:
     """One implementation: what `select` ranks and what `assert_ingress`
     raises cannot drift, because there is only one rule."""

--- a/tests/test_ingress_recast_and_closest_entry_pgw1074.py
+++ b/tests/test_ingress_recast_and_closest_entry_pgw1074.py
@@ -1,0 +1,421 @@
+"""pgw#1074 — the sdxl CFG arm's `ingress_refused`, and the refusal that hid it.
+
+**The field observation** (pgw#868 A1 attempt 32, release `3a2a41bbb38b…`, cell
+`ck1-5f421149…`, adopt pod `vf3vwnun17vcwd`, 36/36 parity green): the turbo arm
+served FROM THE CELL; the base arm — same cell, an entry with exactly its dims —
+got `fallback_reason=ingress_refused`::
+
+    aot_ingress_refused/no_entry_admits — family=sdxl target=unet:
+      no packaged entry admits this call (36 tried) …
+      class=unet/#0=bfloat16[2,4,128,128],#1=int64[],…
+
+**Root cause, measured off-pod at \\$0** over `gen_worker.view.SAMPLERS` against
+the fleet's own diffusers: the dtype a diffusers denoiser is handed for its
+scalar timestep is a per-request SAMPLER fact, not a family fact.
+
+    euler / euler_a / euler_trailing / heun / flow_euler  -> float32
+    ddim / ddim_trailing / ddpm / deis / dpmpp_2m{,_karras,_sde,_sde_karras}
+    / lcm / unipc                                          -> int64
+
+Four of sdxl's six legal samplers (`SdxlScheduler`) present int64. The turbo arm
+runs `euler_trailing` (float32) and served; the base arm ran an int64 sampler and
+was refused. ie#627's `dtype="float32"` is NOT wrong — it is what the graph is
+specialized on — and CFG/B=2 is a red herring: a `generate` call on `euler_a`
+would have served, and a `dmd2-4step` turbo call (`lcm`) would have been refused.
+The sampler is per-request VIEW state and deliberately not a compile axis, so no
+declared dtype can be right for every call. The normalization belongs at the one
+boundary that knows the contract.
+
+**And the observability half.** The refusal said "36 tried" and then listed six,
+in iteration order — and the entry whose dims MATCHED was not among them, so its
+actual objection was unavailable and diagnosing it meant pulling the published
+cell apart. That is pgw#1058's lesson repeating in the diagnostics layer.
+
+Real codepaths: a real `torch.export` + real AOTI compile on CPU, driven through
+the real `ArtifactRunner`/`EntryDispatch`, on the pgw#791 rig.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker import activity, aot_serve  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# The rig: one real AOTI package specialized on a float32 scalar timestep
+# ---------------------------------------------------------------------------
+
+
+class TinyDenoiser(nn.Module):
+    """The sdxl shape in miniature: the timestep reaches the arithmetic
+    through a float cast, exactly as `get_timestep_embedding` does
+    (`timesteps[:, None].float()`) — which is why an int64 feed recast at
+    ingress is bit-identical to the eager call that presented it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(8, 8)
+
+    def forward(self, sample: Any, timestep: Any) -> Any:
+        return torch.tanh(self.lin(sample)) + timestep.float()
+
+
+@pytest.fixture(scope="module")
+def package(tmp_path_factory) -> Any:
+    module = TinyDenoiser().eval()
+    tmp_path = tmp_path_factory.mktemp("pgw1074")
+    with torch.no_grad():
+        program = torch.export.export(
+            module, (torch.randn(2, 8), torch.tensor(1.0)), {}, strict=False)
+        path = torch._inductor.aoti_compile_and_package(
+            program, package_path=str(tmp_path / "tiny.pt2"))
+    return torch._inductor.aoti_load_package(str(path))
+
+
+def _contract(timestep_dtype: str = "float32",
+              sample_dims: Tuple[int, int] = (2, 8),
+              timestep_shape: List[Any] | None = None,
+              ) -> aot_serve.ArtifactContract:
+    return aot_serve.contract_from_meta({
+        "inputs": [
+            {"name": "sample", "position": 0, "dtype": "float32",
+             "shape": list(sample_dims)},
+            {"name": "timestep", "position": 1, "dtype": timestep_dtype,
+             "shape": [] if timestep_shape is None else timestep_shape},
+        ],
+        "symbols": {},
+        "constants": [],
+    })
+
+
+def _runner(package: Any, contract: Any = None,
+            entry: str = "unet/adapter=false,cfg=false/B=1") -> Any:
+    runner = aot_serve.ArtifactRunner(
+        package=package, contract=contract or _contract(),
+        constants=(), module_name="unet", entry=entry, family="tiny1074")
+    runner.bound = True
+    return runner
+
+
+@pytest.fixture
+def sink(monkeypatch) -> List[Any]:
+    captured: List[Any] = []
+    monkeypatch.setattr(activity, "_emit", captured.append)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# HALF ONE — the class fix: an int64 scalar timestep is served, not refused
+# ---------------------------------------------------------------------------
+
+
+def test_the_int64_sampler_class_is_served_by_the_float32_entry(
+        package, sink) -> None:
+    """THE FIELD DEFECT. `dpmpp_2m_karras`/`lcm`/`ddim` present int64; the
+    cell is specialized float32; the call must SERVE, not fall back."""
+    runner = _runner(package)
+    sample = torch.randn(2, 8)
+    with torch.no_grad():
+        out = runner(sample, torch.tensor(7, dtype=torch.int64))
+    assert runner.refusals == {}, "the covering entry must admit this call"
+    assert runner.calls == 1
+    assert runner.realigned == {"timestep/int64_to_float32": 1}
+    events = [e for e in sink if e.kind == aot_serve.RECAST_EVENT]
+    assert len(events) == 1
+    assert "input=timestep" in events[0].detail
+    assert events[0].phase == "int64_to_float32"
+    with torch.no_grad():
+        eager = package(sample, torch.tensor(7.0))
+    assert torch.equal(out, eager), "the recast feed is the eager value"
+
+
+def test_the_recast_is_value_preserving_across_a_whole_timestep_ladder(
+        package) -> None:
+    """Not a spot check: every timestep an int64 sampler emits over a
+    1000-step schedule must produce exactly the float32 call's output."""
+    runner = _runner(package)
+    sample = torch.randn(2, 8)
+    with torch.no_grad():
+        for t in (999, 749, 499, 249, 1, 0):
+            got = runner(sample, torch.tensor(t, dtype=torch.int64))
+            want = package(sample, torch.tensor(float(t)))
+            assert torch.equal(got, want), f"timestep {t} diverged"
+    assert runner.calls == 6
+    assert runner.refusals == {}
+
+
+def test_the_staging_buffer_is_allocated_once_across_recast_calls(
+        package) -> None:
+    """The recast rides pgw#791's staging buffer, so it costs the copy that
+    ingress already made — not an allocation per denoise step."""
+    runner = _runner(package)
+    sample = torch.randn(2, 8)
+    with torch.no_grad():
+        for t in range(6):
+            runner(sample, torch.tensor(t, dtype=torch.int64))
+    assert runner.aligner.buffered() == ("timestep",)
+    assert runner.realigned == {"timestep/int64_to_float32": 6}
+    events = 6  # counted; the typed event is coalesced to one
+    assert sum(runner.realigned.values()) == events
+
+
+def test_a_float32_call_is_untouched(package, sink) -> None:
+    runner = _runner(package)
+    with torch.no_grad():
+        runner(torch.randn(2, 8), torch.tensor(1.0))
+    assert runner.realigned == {}
+    assert [e for e in sink if e.kind == aot_serve.RECAST_EVENT] == []
+
+
+# ---------------------------------------------------------------------------
+# The rails — every dtype disagreement this is NOT allowed to paper over
+# ---------------------------------------------------------------------------
+
+
+def test_pgw1058s_defect_is_still_caught_float32_call_bfloat16_entry() -> None:
+    """The attempt-30 cell: entries specialized bf16, every real call float32.
+    float -> float is not a normalization and must stay a named refusal, or
+    this fix would have silently served the cell pgw#1058 exists to reject."""
+    contract = _contract(timestep_dtype="bfloat16")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        aot_serve.assert_ingress(
+            contract, (), {"sample": torch.randn(2, 8),
+                           "timestep": torch.tensor(1.0)})
+    assert excinfo.value.reason == "dtype_mismatch"
+
+
+def test_an_int64_call_on_a_bfloat16_entry_is_refused() -> None:
+    """bf16 carries 8 mantissa bits: timestep 999 would land on 1000. A
+    normalization that changes the value is a numeric change, so float32 and
+    float64 are the ONLY recast targets."""
+    contract = _contract(timestep_dtype="bfloat16")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        aot_serve.assert_ingress(
+            contract, (), {"sample": torch.randn(2, 8),
+                           "timestep": torch.tensor(999, dtype=torch.int64)})
+    assert excinfo.value.reason == "dtype_mismatch"
+    assert aot_serve.RECAST_TARGETS == ("float32", "float64")
+
+
+def test_a_nonscalar_int64_input_is_refused() -> None:
+    """Rank-0 only. A tensor of integers is a payload, not a schedule
+    coordinate, and casting one would be a guess about its meaning."""
+    contract = _contract(timestep_shape=[4])
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        aot_serve.assert_ingress(
+            contract, (), {"sample": torch.randn(2, 8),
+                           "timestep": torch.zeros(4, dtype=torch.int64)})
+    assert excinfo.value.reason == "dtype_mismatch"
+
+
+def test_a_float32_call_on_an_int64_entry_is_refused() -> None:
+    """One direction only. wan-2.2 declares an int64 timestep; a karras-sigma
+    float32 timestep fed to it would silently truncate the fraction."""
+    contract = _contract(timestep_dtype="int64")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        aot_serve.assert_ingress(
+            contract, (), {"sample": torch.randn(2, 8),
+                           "timestep": torch.tensor(999.5)})
+    assert excinfo.value.reason == "dtype_mismatch"
+
+
+def test_dims_still_decide_admission(package) -> None:
+    """The recast widens nothing but dtype: a wrong-shape call is refused as
+    before, so an entry cannot serve a class it was not compiled for."""
+    runner = _runner(package, contract=_contract(sample_dims=(1, 8)))
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        with torch.no_grad():
+            runner(torch.randn(2, 8), torch.tensor(7, dtype=torch.int64))
+    assert excinfo.value.reason == "static_dim_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# HALF TWO — the refusal names the CLOSEST entry (acceptance item one)
+# ---------------------------------------------------------------------------
+
+
+#: (H_lat, W_lat) — the nine SDXL bucket rungs the field mint packaged.
+_ASPECTS = ((80, 192), (96, 168), (104, 152), (112, 144), (128, 128),
+            (144, 112), (152, 104), (168, 96), (192, 80))
+
+
+def _sdxl_entry(adapter: bool, cfg: bool, batch: int, h: int, w: int,
+                timestep_dtype: str) -> Tuple[str, Any]:
+    """One sdxl cell entry, labelled and shaped exactly as the field cell's
+    36 are (`unet/adapter=…,cfg=…/B=…,H_lat=…,T_txt=77,W_lat=…`). The adapter
+    fork is the pgw#790 one: the branchless class REFUSES the lifted pair, the
+    branch-bearing one declares it."""
+    name = (f"unet/adapter={str(adapter).lower()},cfg={str(cfg).lower()}"
+            f"/B={batch},H_lat={h},T_txt=77,W_lat={w}")
+    inputs: List[Dict[str, Any]] = [
+        {"name": "sample", "position": 0, "dtype": "bfloat16",
+         "shape": [batch, 4, h, w]},
+        {"name": "timestep", "position": 1, "dtype": timestep_dtype,
+         "shape": []},
+        {"name": "encoder_hidden_states", "position": 2,
+         "dtype": "bfloat16", "shape": [batch, 77, 2048]},
+    ]
+    excluded: List[str] = []
+    if adapter:
+        inputs += [
+            {"name": "lora_a", "position": 3, "dtype": "bfloat16",
+             "shape": [64, 8]},
+            {"name": "lora_b", "position": 4, "dtype": "bfloat16",
+             "shape": [8, 64]},
+        ]
+    else:
+        excluded = ["lora_a", "lora_b"]
+    contract = aot_serve.contract_from_meta({
+        "inputs": inputs, "symbols": {}, "constants": [],
+        "excluded_inputs": excluded,
+    })
+    return name, aot_serve.ArtifactRunner(
+        package=None, contract=contract, constants=(), module_name="unet",
+        entry=name, family="sdxl")
+
+
+def _sdxl_dispatch(timestep_dtype: str) -> aot_serve.EntryDispatch:
+    """The field cell: 36 entries = adapter{F,T} x cfg{F,T} x 9 aspect rungs,
+    B pinned by the cfg fork (cfg=true is ONE batch-2 forward, ie#345)."""
+    rows = []
+    for adapter in (False, True):
+        for cfg, batch in ((False, 1), (True, 2)):
+            for h, w in _ASPECTS:
+                rows.append(_sdxl_entry(
+                    adapter, cfg, batch, h, w, timestep_dtype))
+    assert len(rows) == 36
+    return aot_serve.EntryDispatch(tuple(rows))
+
+
+def _cfg_call() -> Dict[str, Any]:
+    """The refused call, verbatim from the field class line:
+    `#0=bfloat16[2,4,128,128],#1=int64[],encoder_hidden_states=…`."""
+    return {
+        "sample": torch.zeros(2, 4, 128, 128, dtype=torch.bfloat16),
+        "timestep": torch.tensor(999, dtype=torch.int64),
+        "encoder_hidden_states": torch.zeros(2, 77, 2048,
+                                             dtype=torch.bfloat16),
+    }
+
+
+_COVERING = ("unet/adapter=false,cfg=true/B=2,H_lat=128,T_txt=77,W_lat=128")
+
+
+def test_the_refusal_names_the_dims_matching_entry_not_the_first_six() -> None:
+    """RED BEFORE THE FIX. The dims-matching entry is 14th of 36 in iteration
+    order, so `reasons[:6]` truncated away the only informative one — which is
+    why the field report could say `36 tried` and show nothing that explained
+    anything. Here the entry is declared bfloat16 (the pgw#1058 shape) so that
+    it refuses for a reason the listing must surface rather than admitting."""
+    dispatch = _sdxl_dispatch("bfloat16")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        dispatch.select((), _cfg_call())
+    detail = str(excinfo.value)
+    assert excinfo.value.reason == "no_entry_admits"
+    assert _COVERING in detail, "the entry whose dims match must be NAMED"
+    assert "dtype_mismatch" in detail
+    assert "every declared dim MATCHES" in detail
+    assert "36 tried" in detail
+
+
+def test_the_closest_entry_survives_the_hub_detail_truncation() -> None:
+    """The field detail was cut at 573 chars and the informative entry fell
+    past the cut. The closest entry and its reason lead the sentence."""
+    dispatch = _sdxl_dispatch("bfloat16")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        dispatch.select((), _cfg_call())
+    detail = str(excinfo.value)
+    assert _COVERING in detail[:400]
+    assert "dtype_mismatch" in detail[:400]
+
+
+def test_every_tried_entry_is_accounted_for_never_silently_dropped() -> None:
+    """`36 tried` then 6 listed and 30 unexplained is the defect. Whatever is
+    not named individually is COUNTED by reason, and the counts add up."""
+    dispatch = _sdxl_dispatch("bfloat16")
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        dispatch.select((), _cfg_call())
+    detail = str(excinfo.value)
+    assert "Other 35 entries" in detail
+    # 17 branchless entries that reach the dtype check, 18 branch-bearing ones
+    # the call carries no adapter for. One count per entry, under its own
+    # closest reason, so the counts sum to exactly what "36 tried" promised.
+    counted = re.findall(r"(\w+) x(\d+)", detail)
+    assert dict((k, int(v)) for k, v in counted) == {
+        "dtype_mismatch": 17, "input_missing": 18}
+    assert sum(int(v) for _k, v in counted) == 35
+
+
+def test_the_field_cell_now_serves_the_cfg_arm_end_to_end() -> None:
+    """The whole issue, as one assertion: the SAME 36-entry cell, declared as
+    ie#627 declares it (float32), dispatches the int64 CFG call to the entry
+    that covers it."""
+    dispatch = _sdxl_dispatch("float32")
+    name, _runner_ = dispatch.select((), _cfg_call())
+    assert name == _COVERING
+
+
+def test_a_genuinely_uncovered_class_still_refuses() -> None:
+    """The dispatch is not weakened: an aspect the cell never minted is
+    refused by name, and the refusal reports a dim miss, not a dtype one."""
+    dispatch = _sdxl_dispatch("float32")
+    call = _cfg_call()
+    call["sample"] = torch.zeros(2, 4, 64, 64, dtype=torch.bfloat16)
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        dispatch.select((), call)
+    assert excinfo.value.reason == "no_entry_admits"
+    assert "static_dim_mismatch" in str(excinfo.value)
+    assert "every declared dim MATCHES" not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# The ranking itself — stated as a rule, not inferred from one example
+# ---------------------------------------------------------------------------
+
+
+def test_miss_distance_orders_dtype_before_dims_and_fewer_before_more(
+) -> None:
+    dtype_only = (aot_serve.IngressMiss("dtype_mismatch", "", "timestep"),)
+    dtype_and_dim = dtype_only + (
+        aot_serve.IngressMiss("static_dim_mismatch", "", "sample"),)
+    dims_only = (aot_serve.IngressMiss("static_dim_mismatch", "", "sample"),)
+    missing = (aot_serve.IngressMiss("input_missing", ""),)
+    order = sorted(
+        (dims_only, missing, dtype_and_dim, dtype_only),
+        key=aot_serve.miss_distance)
+    assert order == [dtype_only, dtype_and_dim, dims_only, missing]
+
+
+def test_ingress_report_collects_every_miss_not_only_the_first() -> None:
+    """The ranking is only as good as the diagnosis it ranks: one entry that
+    misses on two axes must report both."""
+    contract = _contract(timestep_dtype="bfloat16", sample_dims=(1, 8))
+    misses, symbols = aot_serve.ingress_report(
+        contract, (), {"sample": torch.randn(2, 8),
+                       "timestep": torch.tensor(1.0)})
+    assert symbols == {}
+    # Declaration order, per input dtype -> rank -> dims: exactly the order
+    # the raising check walked before it became a collecting one.
+    assert [m.reason for m in misses] == [
+        "static_dim_mismatch", "dtype_mismatch"]
+    assert [m.input for m in misses] == ["sample", "timestep"]
+
+
+def test_assert_ingress_raises_ingress_reports_first_miss() -> None:
+    """One implementation: what `select` ranks and what `assert_ingress`
+    raises cannot drift, because there is only one rule."""
+    contract = _contract(timestep_dtype="bfloat16", sample_dims=(1, 8))
+    call = {"sample": torch.randn(2, 8), "timestep": torch.tensor(1.0)}
+    misses, _ = aot_serve.ingress_report(contract, (), call)
+    with pytest.raises(aot_serve.IngressContractError) as excinfo:
+        aot_serve.assert_ingress(contract, (), call)
+    assert excinfo.value.reason == misses[0].reason
+    assert str(excinfo.value) == misses[0].detail


### PR DESCRIPTION
Closes the last pgw#868 A1 residual: on attempt 32 (release `3a2a41bbb38b…`, cell `ck1-5f421149…`, 36/36 parity) sdxl's turbo arm served **from the cell** and its base arm got `fallback_reason=ingress_refused` from an entry whose dims matched it exactly.

## Root cause — it is the SAMPLER, not CFG

Measured off-pod at **$0** by instantiating every row of `gen_worker.view.SAMPLERS` against the sdxl endpoint's own installed diffusers and reading `scheduler.timesteps.dtype`:

| dtype | samplers |
|---|---|
| **float32** | `euler`, `euler_a`, `euler_trailing`, `heun`, `flow_euler` |
| **int64** | `ddim`, `ddim_trailing`, `ddpm`, `deis`, `dpmpp_2m`, `dpmpp_2m_karras`, `dpmpp_2m_sde`, `dpmpp_2m_sde_karras`, `lcm`, `unipc` |

`DPMSolverMultistepScheduler.set_timesteps` ends in `.to(dtype=torch.int64)`; `LCMScheduler` in `dtype=torch.long`; `EulerDiscreteScheduler` in `.astype(np.float32)`.

**Four of sdxl's six legal samplers present int64.** Turbo runs `lightning-4step` ⇒ `euler_trailing` ⇒ float32 and served; the base arm ran the deploy's stamped int64 sampler and did not. **CFG is a red herring** — a `generate` call on `euler_a` would have served, and a `dmd2-4step` (⇒ `lcm`) turbo call would have been refused.

The sampler is per-request VIEW state (`ctx.for_request`) and deliberately not a compile axis, so **no declared dtype can be right for every call**. ie#627's `float32` is not wrong: it is what the graph is specialized on, and it is the only declaration that can serve both sampler classes under this fix.

## The class fix — `aot_serve.recast_gap`

The ingress recasts a **rank-0** input from an **integer** dtype into a **float32/float64** declared one, staged through pgw#791's existing aligned buffer (one `copy_`, no per-step allocation, no synchronise), counted, and announced once per (entry, input, pair) as the typed `aot_input_recast`.

Faithful by construction: float32 holds every integer below 2^24 exactly, and the cast **is** the traced graph's own first node on this input (`get_timestep_embedding`: `timesteps[:, None].float()`). Proven bit-identical to the eager call over a whole timestep ladder against a real AOTI package.

Nothing else is normalized — every rail has a test:
- float→float stays refused (**pgw#1058's bf16 cell is still caught by name**)
- float→int stays refused
- bf16/fp16 are not recast targets (8 mantissa bits would round timestep 999 → 1000)
- non-scalar rows untouched (wan-2.2's rank-1 `int64` timestep is unaffected)
- dims still decide admission

**No re-mint.** The already-published cell serves its base arm under this fix; proving it costs one adopt pod, not a $3 mint.

## Acceptance item one — the refusal that hid it

`no packaged entry admits this call (36 tried)` then listed **six**, in iteration order — and the dims-matching entry is **14th of 36**, so the covering entry's actual objection was never in the record and diagnosis meant pulling the published cell apart.

The B2 check is now ONE collecting implementation (`ingress_report`, whose first miss `assert_ingress` raises, so admission and the sentence explaining it cannot drift). Entries rank by `miss_distance` (dtype before dims, fewer misses before more). The sentence leads with the closest entry, its full reason, and whether every declared dim matched, then accounts for **every** remaining entry by reason count instead of naming an arbitrary few.

Before (this is the field sentence verbatim, reproduced on a 36-entry replica):
```
no packaged entry admits this call (36 tried): unet/adapter=false,cfg=false/B=1,H_lat=80,…: static_dim_mismatch; … (six B=1 entries, none of them the one that mattered)
```
After — 520 chars, answer in the first 175:
```
no packaged entry admits this call (36 tried); CLOSEST entry
'unet/adapter=false,cfg=true/B=2,H_lat=128,T_txt=77,W_lat=128' — every declared dim MATCHES:
dtype_mismatch (input 'timestep' dtype int64 != declared bfloat16).
Other 35 entries [input_missing x18, dtype_mismatch x17] — next: …
```

## Proof

`tests/test_ingress_recast_and_closest_entry_pgw1074.py` — real `torch.export` + real AOTI compile on CPU through the real `ArtifactRunner`/`EntryDispatch`, on the pgw#791 rig, plus a 36-entry replica of the field cell (adapter fork as pgw#790's excluded pair). **RED reproduced against `origin/master`: 11 failed / 6 passed** — and the six that passed are exactly the rails that must stay refusals.

## Owner residual (not guessed here)

The defect class is "a declared dtype that is actually per-request VIEW state". ie#629 verified flux/qwen cast the timestep in-loop, so they are immune. **wan-2.2 is the open mirror**: `Input("timestep", shape=("B",), dtype="int64")` is rank-1 (outside this recast), and its samplers span `FlowMatchEulerDiscreteScheduler` (float32) and `UniPCMultistepScheduler` (int64). Owner call on that family's real arms; recorded on pgw#1074.

The ie half (sdxl's comment now states the measured sampler table; a test asks the real schedulers) rides a separate inference-endpoints PR — it needs no SDK symbol, so it cannot repeat ie#629's two-way pin break.