### PR TITLE
pgw#1071: modular hydration loads every component at its OWN checkpoint dtype

### DIFF
--- a/changelog.d/pgw1071.md
+++ b/changelog.d/pgw1071.md
@@ -1,0 +1,19 @@
+- **pgw#1071: modular hydration loads every component at ITS OWN checkpoint
+  dtype.** The modular lane used to derive ONE dtype from a majority vote over
+  every safetensors header in the snapshot and apply it to the whole tree.
+  Both directions were wrong, and ie#615 measured both on minimax-h3: with the
+  vote outside the sniff's vocabulary no dtype was passed at all and diffusers'
+  fp32 default upcast the DiT — **74.9 GiB against a 66.28 GB bf16 checkpoint,
+  4 bytes/param** — which OOM'd every full-canvas request on an 80 GB H100
+  (37.5 GiB when correctly dtyped) and doubled host staging anon to ~130 GB
+  (the pgw#1041/#1063 pressure); with the vote narrow, a component the
+  checkpoint stores WIDE was silently truncated (H3's VAEs carry the opposite
+  instruction in their own source). Now: a declared composition dtype and
+  pgw#667's per-part facts still govern what they name, and everything else
+  loads at the dtype its own component dir stores — decided inside the
+  hydration loop, which is the only place that knows each component's real
+  source (a th#980/pgw#617 override tree is a different artifact from the base
+  dir it replaces). `_keep_in_fp32_modules` stays diffusers' business, and
+  naming a dtype is what lets it act at all. The dtype each component landed at
+  is now on the `modular_hydration` event, so the next upcast is visible from
+  the hub instead of taking three deploy cycles to name.

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1191,6 +1191,86 @@ def _component_dtype_map(
     return out
 
 
+#: Load dtype a component asks for, keyed by what its OWN safetensors headers
+#: store (pgw#1071). fp8 is a STORAGE fact — the artifact carries its own
+#: quantization config and bf16 is the compute dtype over it, which is why it
+#: maps to :data:`QUANT_EXECUTION_LANE_COMPUTE_DEFAULT` rather than to itself.
+_CHECKPOINT_LOAD_DTYPE = {
+    "bf16": "bf16",
+    "fp16": "fp16",
+    "fp32": "fp32",
+    "fp8": QUANT_EXECUTION_LANE_COMPUTE_DEFAULT,
+}
+
+
+def checkpoint_load_dtype(source: str | Path) -> str:
+    """The dtype ONE component tree's own bytes ask to be loaded at, or ``""``
+    when its headers say nothing (pgw#1071).
+
+    Read per COMPONENT, never per snapshot: a majority vote over a whole
+    mixed-precision tree upcasts every narrow component when the vote lands
+    wide and truncates every wide one when it lands narrow. ie#615 measured
+    both halves on minimax-h3 — a 66.28 GB bf16 DiT hydrating at 74.9 GiB
+    (4 bytes/param) because the tree-wide vote fell outside the map and
+    diffusers' fp32 default took over."""
+    return _CHECKPOINT_LOAD_DTYPE.get(detect_on_disk_dtype(Path(source)), "")
+
+
+def _declared_component_dtype(name: str, declared: Any) -> Any:
+    """The dtype the CALLER declared for ``name`` — diffusers' own
+    ``{"default": ..., "<part>": ...}`` routing, or a scalar that governs
+    every component. None when nothing was declared for it."""
+    if isinstance(declared, dict):
+        if name in declared:
+            return declared[name]
+        return declared.get("default")
+    return declared
+
+
+def _modular_declared_dtypes(
+    cls: Any, path: str | Path, scalar_dtype: Any,
+) -> Any:
+    """Everything the modular lane DECLARES about component dtypes: the
+    binding's own dtype when it has one, plus pgw#667's per-part facts.
+
+    ``None`` when nothing is declared — the hydration loop then reads each
+    component's checkpoint (pgw#1071). With a declared composition dtype this
+    is exactly :func:`_component_dtype_map`; without one the facts stand
+    alone, because a ``"default"`` key would put every unlisted component
+    back under a guess."""
+    if scalar_dtype is not None:
+        return _component_dtype_map(cls, path, scalar_dtype) or scalar_dtype
+    out: Dict[str, Any] = {}
+    for part, fact in component_load_dtypes(cls, path).items():
+        try:
+            out[part] = get_torch_dtype(fact.dtype)
+        except ImportError:
+            return None
+        logger.info(
+            "COMPONENT_DTYPE model=%s: loading %r at %s (no composition "
+            "dtype declared; every other component loads at its own "
+            "checkpoint dtype) — %s", path, part, fact.dtype, fact.reason,
+        )
+    return out or None
+
+
+def _hydration_dtype(name: str, declared: Any, source: str | Path) -> Any:
+    """Load dtype for ONE modular component: what the caller declared, else
+    what the component's own checkpoint stores, else None (nothing is known,
+    so diffusers keeps its own default and the load stays as honest as the
+    bytes allow)."""
+    wanted = _declared_component_dtype(name, declared)
+    if wanted is not None:
+        return wanted
+    token = checkpoint_load_dtype(source)
+    if not token:
+        return None
+    try:
+        return get_torch_dtype(token)
+    except ImportError:
+        return None  # torch-less host: the loader fails on its own terms
+
+
 class ComponentExecutionLaneUnsupported(RuntimeError):
     """This flavor has no component-level loader, so no honest one exists.
 
@@ -1824,6 +1904,13 @@ def hydrate_modular_pipeline(
     warning, so every requested component is re-checked non-``None`` and a
     miss raises typed with the captured diffusers log text.
 
+    ``torch_dtype`` is what the caller DECLARED — a scalar governing every
+    component, or diffusers' ``{"default": ..., "<part>": ...}`` map. What it
+    does not name loads at that component's OWN checkpoint dtype
+    (:func:`checkpoint_load_dtype`), never at a snapshot-wide majority and
+    never at diffusers' fp32 default (pgw#1071). ``_keep_in_fp32_modules``
+    stays diffusers' business: naming a dtype is what lets it act at all.
+
     ``place_device`` (pgw#1026) moves each component onto that device as it
     lands and drops the host copy, so the host-RAM high-water mark is ONE
     component instead of the tree. Set it from
@@ -1907,6 +1994,7 @@ def hydrate_modular_pipeline(
                 f"(base tree {base} holds: {listing})")
 
     names = sorted(sources)
+    dtypes: Dict[str, str] = {}
     if names:
         # load_components swallows per-component load failures into a
         # diffusers logger warning and registers nothing — capture that text
@@ -1938,8 +2026,15 @@ def hydrate_modular_pipeline(
                     "pretrained_model_name_or_path": {n: sources[n]},
                     "subfolder": {n: ""},
                 }
-                if torch_dtype is not None:
-                    kwargs["torch_dtype"] = torch_dtype
+                # pgw#1071: this component's OWN checkpoint dtype when the
+                # caller declared none. Sniffed here rather than by the
+                # caller because this is the only place that knows each
+                # component's actual source dir — an override tree is a
+                # different artifact from the base dir it replaces.
+                dt = _hydration_dtype(n, torch_dtype, comp_src)
+                if dt is not None:
+                    kwargs["torch_dtype"] = dt
+                    dtypes[n] = str(dt).removeprefix("torch.")
                 pipe.load_components(names=[n], **kwargs)
                 # pgw#1026: place it now and drop the host copy, so the next
                 # component's admission above sees the host RAM this one
@@ -1972,13 +2067,20 @@ def hydrate_modular_pipeline(
     except Exception:  # noqa: BLE001
         pass
     detail = " ".join(f"{n}<-{sources[n]}" for n in sorted(sources))
-    logger.info("modular hydration (%s): %s; skipped partitions: %s%s",
-                type(pipe).__name__, detail, skipped or "none",
+    # pgw#1071: the dtype each component actually loaded at is the evidence
+    # the fp32-upcast wall was invisible for — it belongs in the hub-visible
+    # record, not only in a log line.
+    dtype_detail = " ".join(f"{n}={dtypes[n]}" for n in sorted(dtypes))
+    logger.info("modular hydration (%s): %s; dtypes: %s; skipped partitions: "
+                "%s%s",
+                type(pipe).__name__, detail, dtype_detail or "loader default",
+                skipped or "none",
                 f"; staged per component onto {place_device}" if place_device
                 else "")
     activity_mod.emit_event(
         activity_mod.KIND_MODULAR_HYDRATION,
         f"pipeline={type(pipe).__name__} base={base} {detail}"
+        + (f" dtypes=[{dtype_detail}]" if dtype_detail else "")
         + (f" skipped={','.join(skipped)}" if skipped else "")
         + (f" place_device={place_device}" if place_device else ""),
         phase="hydrated",
@@ -2224,21 +2326,23 @@ def _load_modular_pipeline(
         logger.warning(
             "storage_dtype=%s ignored on the modular lane (component "
             "precision is a per-component artifact fact)", storage_dtype)
+    # pgw#1071: DECLARED dtypes only. The snapshot-wide dtype sniff that used
+    # to stand in for a declaration was a majority vote over every safetensors
+    # header in the tree — it truncated a wide component when the vote fell
+    # narrow (an fp32 VAE loading bf16) and, when the vote fell outside the
+    # sniff's own vocabulary, produced NO dtype at all and let diffusers'
+    # fp32 default upcast the whole tree (ie#615: a 66.28 GB bf16 DiT
+    # hydrating at 74.9 GiB, 4 bytes/param, OOM on an 80 GB card and ~130 GB
+    # of host staging anon). Undeclared components now load at their OWN
+    # checkpoint dtype, decided inside the hydration loop from each
+    # component's real source dir.
     scalar_dtype: Any = None
-    wanted = dtype or {
-        "bf16": "bf16", "fp16": "fp16", "fp8": "bf16",
-    }.get(detect_on_disk_dtype(Path(path)), "")
-    if wanted:
+    if dtype:
         try:
-            scalar_dtype = get_torch_dtype(wanted)
+            scalar_dtype = get_torch_dtype(dtype)
         except ImportError:
             pass  # torch-less environment: loaders fail on their own terms
-    torch_dtype: Any = scalar_dtype
-    per_component = _component_dtype_map(cls, path, scalar_dtype)
-    if per_component:
-        # Same {"default": ..., part: ...} shape load_components' dict
-        # routing understands (pgw#667 widened parts included).
-        torch_dtype = per_component
+    torch_dtype: Any = _modular_declared_dtypes(cls, path, scalar_dtype)
     # pgw#1026: a tree the card holds but the host does not stages ONE
     # COMPONENT AT A TIME straight onto the device. Decided here, from the
     # same measurements the executor's admission gate reads, so the two

--- a/tests/harness/modular_endpoint.py
+++ b/tests/harness/modular_endpoint.py
@@ -70,6 +70,27 @@ def tiny_unet(fill: float) -> UNet2DConditionModel:
     return m
 
 
+class KeepFp32Unet(UNet2DConditionModel):
+    """A DiT-shaped component in miniature (pgw#1071): a stack that stores
+    bf16 plus heads the class declares must stay fp32 — H3's
+    ``_keep_in_fp32_modules`` (patch/timestep/output projections) at test
+    scale."""
+
+    _keep_in_fp32_modules = ["conv_in"]
+
+
+def tiny_keep_fp32_unet(fill: float) -> "KeepFp32Unet":
+    base = tiny_unet(fill)
+    m = KeepFp32Unet(**{
+        k: v for k, v in base.config.items() if not str(k).startswith("_")
+    })
+    m.load_state_dict(base.state_dict())
+    return m
+
+
+diffusers.KeepFp32Unet = KeepFp32Unet
+
+
 def tiny_vae(fill: float) -> AutoencoderKL:
     m = AutoencoderKL(
         in_channels=3, out_channels=3, latent_channels=4, sample_size=8,
@@ -126,6 +147,44 @@ def build_base_tree(root: Path, *, fill: float = 1.0) -> Path:
         "scheduler": ["diffusers", "DDPMScheduler"],
     }))
     return root
+
+
+def build_mixed_precision_tree(
+    root: Path, *, fill: float = 1.0, unet_dtype: str = "bf16",
+    vae_dtype: str = "fp32", extra_fp32_parts: int = 0,
+) -> Path:
+    """ie#615's minimax-h3 shape at test scale (pgw#1071): a big narrow
+    denoiser (bf16 stack, fp32 ``_keep_in_fp32_modules`` heads) beside a VAE
+    the checkpoint stores WIDE, which a pipeline-level bf16 must not
+    downcast.
+
+    ``extra_fp32_parts`` adds fp32 siblings until the snapshot-wide majority
+    vote flips — the condition under which the old tree-wide sniff produced
+    no dtype at all and diffusers' fp32 default upcast the bf16 stack."""
+    import torch
+
+    tree = build_base_tree(root, fill=fill)
+    unet = tiny_keep_fp32_unet(fill).to(getattr(torch, _TORCH_DTYPES[unet_dtype]))
+    unet.conv_in.to(torch.float32)  # the checkpoint's own wide heads
+    unet.save_pretrained(tree / "unet")
+    tiny_vae(fill).to(getattr(torch, _TORCH_DTYPES[vae_dtype])).save_pretrained(
+        tree / "vae")
+
+    index = json.loads((tree / "modular_model_index.json").read_text())
+    model_index = json.loads((tree / "model_index.json").read_text())
+    index["unet"] = _spec_entry("KeepFp32Unet", "unet")
+    model_index["unet"] = ["diffusers", "KeepFp32Unet"]
+    for i in range(extra_fp32_parts):
+        name = f"vae_x{i}"
+        tiny_vae(fill).to(torch.float32).save_pretrained(tree / name)
+        index[name] = _spec_entry("AutoencoderKL", name)
+        model_index[name] = ["diffusers", "AutoencoderKL"]
+    (tree / "modular_model_index.json").write_text(json.dumps(index))
+    (tree / "model_index.json").write_text(json.dumps(model_index))
+    return tree
+
+
+_TORCH_DTYPES = {"bf16": "bfloat16", "fp16": "float16", "fp32": "float32"}
 
 
 def build_override_vae_tree(root: Path, *, fill: float = 2.0,

--- a/tests/test_modular_checkpoint_dtype_pgw1071.py
+++ b/tests/test_modular_checkpoint_dtype_pgw1071.py
@@ -1,0 +1,279 @@
+"""pgw#1071: modular hydration loads every component at ITS OWN checkpoint
+dtype.
+
+ie#615 measured the wall on minimax-h3 (gen-worker 0.96.1, pods
+``zbddo87qmm9e5c``/``0u7so0yxv3ag82``/``qt9ril82eb4t41``): the hydrated
+``MiniMaxH3Transformer3DModel`` weighed **74.9 GiB against a 66.28 GB bf16
+checkpoint** — ``ff.net.0.proj.weight`` at exactly 4 bytes/param. The DiT
+alone landed at 78.0 GiB on a 79.18 GiB H100 (CUDA OOM on every full-canvas
+request, where the correctly-dtyped module lands at 37.5 GiB) and host
+staging anon doubled to ~130 GB, which is the pgw#1041/#1063 pressure.
+
+The mechanism, and BOTH of its halves: the modular lane derived ONE dtype
+from a majority vote over every safetensors header in the snapshot and
+applied it to every component.
+
+* vote falls outside the sniff's vocabulary (a tree whose wide parts
+  outnumber the stack, or unreadable headers) -> no dtype at all ->
+  diffusers' fp32 default upcasts the narrow stack. The H3 wall.
+* vote falls narrow -> a component the checkpoint stores WIDE is silently
+  truncated. H3's VAEs carry the opposite instruction in their own source
+  ("a pipeline-level torch_dtype=bfloat16 must not downcast the weights").
+
+Real diffusers modular pipelines and real safetensors throughout (the
+pgw#1036 harness), under ``HF_HUB_OFFLINE=1``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from gen_worker import activity as activity_mod
+from gen_worker.models.loading import (
+    _load_modular_pipeline,
+    checkpoint_load_dtype,
+    hydrate_modular_pipeline,
+)
+
+from harness.modular_endpoint import (
+    TinyModularPipeline,
+    build_base_tree,
+    build_mixed_precision_tree,
+    build_override_vae_tree,
+    tiny_vae,
+)
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_HUB_DISABLE_TELEMETRY", "1")
+
+
+def _dtypes(module: Any) -> Dict[str, str]:
+    return {n: str(t.dtype) for n, t in
+            list(module.named_parameters()) + list(module.named_buffers())}
+
+
+def _bytes_per_param(module: Any) -> float:
+    total = sum(p.numel() for p in module.parameters())
+    return sum(p.numel() * p.element_size() for p in module.parameters()) / total
+
+
+def _checkpoint_dtypes(component: Path) -> Dict[str, str]:
+    """Per-tensor dtypes as the component's own safetensors headers store
+    them — the thing the load has to equal."""
+    out: Dict[str, str] = {}
+    for f in sorted(component.rglob("*.safetensors")):
+        with open(f, "rb") as fh:
+            import struct
+
+            (n,) = struct.unpack("<Q", fh.read(8))
+            header = json.loads(fh.read(n))
+        for key, value in header.items():
+            if isinstance(value, dict) and "dtype" in value:
+                out[key] = str(value["dtype"])
+    return out
+
+
+_SAFETENSORS_TO_TORCH = {"BF16": "torch.bfloat16", "F16": "torch.float16",
+                         "F32": "torch.float32"}
+
+
+# ---------------------------------------------------------------------------
+# the deliverable: per-tensor dtypes equal the checkpoint's
+# ---------------------------------------------------------------------------
+
+
+def test_a_mixed_tree_hydrates_at_the_checkpoints_own_per_tensor_dtypes(
+    tmp_path,
+) -> None:
+    """The H3 shape end to end: bf16 stack + fp32 keep-in-fp32 heads in one
+    component, a wide VAE beside it, no declared composition dtype."""
+    tree = build_mixed_precision_tree(tmp_path / "base")
+
+    pipe = _load_modular_pipeline(TinyModularPipeline, str(tree))
+
+    for name in ("unet", "vae"):
+        want = {k: _SAFETENSORS_TO_TORCH[v]
+                for k, v in _checkpoint_dtypes(tree / name).items()}
+        got = _dtypes(getattr(pipe, name))
+        assert want, name
+        assert {k: got[k] for k in want} == want, name
+
+
+def test_the_bf16_stack_is_not_upcast_when_the_tree_vote_falls_wide(
+    tmp_path,
+) -> None:
+    """ie#615's wall: with the wide parts outnumbering the stack, the
+    tree-wide vote produced NO dtype and diffusers' fp32 default doubled the
+    denoiser — 4 bytes/param against a 2-byte checkpoint."""
+    tree = build_mixed_precision_tree(tmp_path / "base", extra_fp32_parts=3)
+
+    pipe = _load_modular_pipeline(TinyModularPipeline, str(tree))
+
+    stack = {n: d for n, d in _dtypes(pipe.unet).items() if "conv_in" not in n}
+    assert set(stack.values()) == {"torch.bfloat16"}, stack
+    # the ie#615 metric itself, not a proxy for it
+    assert _bytes_per_param(pipe.unet) < 2.1
+
+
+def test_a_wide_component_is_not_truncated_by_a_narrow_tree_vote(
+    tmp_path,
+) -> None:
+    """The other half: an fp32 VAE inside a bf16-majority tree keeps its
+    precision. Upcasting it after the fact recovers nothing."""
+    tree = build_mixed_precision_tree(tmp_path / "base", extra_fp32_parts=0)
+
+    pipe = _load_modular_pipeline(TinyModularPipeline, str(tree))
+
+    assert set(_dtypes(pipe.vae).values()) == {"torch.float32"}
+
+
+def test_the_keep_in_fp32_heads_survive_the_narrow_stack(tmp_path) -> None:
+    """``_keep_in_fp32_modules`` is diffusers' business — and naming a dtype
+    is what lets it act at all. Passing nothing (the old undeclared path)
+    upcast the whole module instead."""
+    tree = build_mixed_precision_tree(tmp_path / "base")
+
+    pipe = _load_modular_pipeline(TinyModularPipeline, str(tree))
+
+    assert set(_dtypes(pipe.unet.conv_in).values()) == {"torch.float32"}
+
+
+# ---------------------------------------------------------------------------
+# a DECLARATION still governs; a sniff never overrides one
+# ---------------------------------------------------------------------------
+
+
+def test_a_declared_composition_dtype_governs_every_component(
+    tmp_path,
+) -> None:
+    tree = build_mixed_precision_tree(tmp_path / "base")
+
+    pipe = _load_modular_pipeline(TinyModularPipeline, str(tree), dtype="fp16")
+
+    assert set(_dtypes(pipe.vae).values()) == {"torch.float16"}
+    stack = {n: d for n, d in _dtypes(pipe.unet).items() if "conv_in" not in n}
+    assert set(stack.values()) == {"torch.float16"}
+
+
+def test_a_declared_scalar_reaches_hydration_unchanged(tmp_path) -> None:
+    tree = build_mixed_precision_tree(tmp_path / "base")
+    pipe = TinyModularPipeline.from_pretrained(str(tree))
+
+    hydrate_modular_pipeline(pipe, tree, torch_dtype=torch.bfloat16)
+
+    assert set(_dtypes(pipe.vae).values()) == {"torch.bfloat16"}
+
+
+def test_a_declared_map_routes_per_component_and_the_rest_read_disk(
+    tmp_path,
+) -> None:
+    """diffusers' own ``{"part": ...}`` shape: what it names is declared,
+    what it does not still comes off that component's own bytes."""
+    tree = build_mixed_precision_tree(tmp_path / "base")
+    pipe = TinyModularPipeline.from_pretrained(str(tree))
+
+    hydrate_modular_pipeline(pipe, tree, torch_dtype={"vae": torch.float16})
+
+    assert set(_dtypes(pipe.vae).values()) == {"torch.float16"}
+    stack = {n: d for n, d in _dtypes(pipe.unet).items() if "conv_in" not in n}
+    assert set(stack.values()) == {"torch.bfloat16"}
+
+
+# ---------------------------------------------------------------------------
+# the source of the dtype is the component's OWN dir
+# ---------------------------------------------------------------------------
+
+
+def test_an_override_tree_is_read_for_its_own_dtype(tmp_path) -> None:
+    """A th#980/pgw#617 override is a different artifact from the base dir it
+    replaces — the base tree's bytes say nothing about it."""
+    tree = build_mixed_precision_tree(tmp_path / "base", vae_dtype="bf16")
+    override = tmp_path / "ovr"
+    tiny_vae(2.0).to(torch.float32).save_pretrained(override / "vae")
+    pipe = TinyModularPipeline.from_pretrained(str(tree))
+
+    hydrate_modular_pipeline(
+        pipe, tree, component_trees={"vae": str(override)})
+
+    assert set(_dtypes(pipe.vae).values()) == {"torch.float32"}
+
+
+def test_the_hydration_event_carries_the_dtype_each_component_landed_at(
+    tmp_path, monkeypatch,
+) -> None:
+    """The upcast was invisible for three deploy cycles. The dtype is
+    hub-visible evidence now, not a log line."""
+    seen: list = []
+    monkeypatch.setattr(
+        activity_mod, "emit_event",
+        lambda kind, detail="", phase="", duration_ms=0: seen.append(
+            (kind, detail)))
+    tree = build_mixed_precision_tree(tmp_path / "base")
+    pipe = TinyModularPipeline.from_pretrained(str(tree))
+
+    hydrate_modular_pipeline(pipe, tree)
+
+    detail = next(d for k, d in seen
+                  if k == activity_mod.KIND_MODULAR_HYDRATION)
+    assert "unet=bfloat16" in detail and "vae=float32" in detail
+
+
+# ---------------------------------------------------------------------------
+# the token map, including the one entry that is not identity
+# ---------------------------------------------------------------------------
+
+
+def test_fp8_storage_asks_for_its_compute_dtype_not_for_fp8(tmp_path) -> None:
+    """An fp8-stored component is a quantized artifact: it carries its own
+    config and bf16 is the compute dtype over it. Handing torch fp8 as a
+    module dtype is not a thing the loaders do."""
+    comp = tmp_path / "fp8"
+    comp.mkdir()
+    save_file({"w": torch.zeros(4, 4, dtype=torch.float8_e4m3fn)},
+              str(comp / "model.safetensors"))
+
+    assert checkpoint_load_dtype(comp) == "bf16"
+
+
+def test_headers_that_say_nothing_declare_nothing(tmp_path) -> None:
+    """No sniff, no dtype — the loader keeps its own default rather than
+    this code inventing one."""
+    (tmp_path / "empty").mkdir()
+
+    assert checkpoint_load_dtype(tmp_path / "empty") == ""
+
+
+def test_each_stored_precision_maps_to_itself(tmp_path) -> None:
+    for token, dtype in (("bf16", torch.bfloat16), ("fp16", torch.float16),
+                         ("fp32", torch.float32)):
+        comp = tmp_path / token
+        comp.mkdir()
+        save_file({"w": torch.zeros(4, 4, dtype=dtype)},
+                  str(comp / "model.safetensors"))
+        assert checkpoint_load_dtype(comp) == token
+
+
+# ---------------------------------------------------------------------------
+# nothing changes on the uniform trees (the common case)
+# ---------------------------------------------------------------------------
+
+
+def test_a_uniform_tree_is_unaffected(tmp_path) -> None:
+    tree = build_base_tree(tmp_path / "base")
+    override = build_override_vae_tree(tmp_path / "ovr")
+
+    pipe = _load_modular_pipeline(
+        TinyModularPipeline, str(tree),
+        component_trees={"vae": str(override)})
+
+    assert set(_dtypes(pipe.unet).values()) == {"torch.float32"}
+    assert set(_dtypes(pipe.vae).values()) == {"torch.float32"}


### PR DESCRIPTION
Closes the pgw#1071 row filed by the ie#615 serve-proof lane.

## The defect, verified by content on `origin/master` `53ae96a0`

The modular lane derived ONE dtype from a **majority vote over every safetensors header in the snapshot** and applied it to every component. Both directions are wrong, and ie#615 measured both live on minimax-h3 (gen-worker 0.96.1):

| vote | consequence | measured |
|---|---|---|
| outside the sniff's `{bf16,fp16,fp8}` vocabulary (or headers unreadable) | **no dtype passed at all** → diffusers' fp32 default upcasts the narrow stack | 66.28 GB bf16 DiT hydrating at **74.9 GiB = 4 bytes/param**; DiT alone 78.0 GiB on a 79.18 GiB H100 → CUDA OOM on every full-canvas request (37.5 GiB when correctly dtyped); host staging anon ~130 GB instead of ~66 (the pgw#1041/#1063 pressure) |
| narrow | a component the checkpoint stores WIDE is silently truncated | H3's VAEs say so in their own source: "a pipeline-level `torch_dtype=bfloat16` must not downcast the weights" |

Both halves reproduced locally on the real diffusers modular path before any fix (probe: tree-wide sniff `fp32`, `unet` sniff `bf16` → `LOADED unet: torch.float32`; and tree-wide `bf16`, `vae` sniff `fp32` → `LOADED vae: torch.bfloat16`).

## The fix

- **Declarations govern what they name**: the binding's `dtype` and pgw#667's per-part facts still route exactly as before.
- **Everything else loads at its own component dir's checkpoint dtype**, decided *inside* the hydration loop — the only place that knows each component's real source, since a th#980/pgw#617 override tree is a different artifact from the base dir it replaces.
- `fp8` maps to its compute dtype (the artifact carries its own quantization config); an unreadable header declares nothing and leaves the loader its own default.
- `_keep_in_fp32_modules` stays diffusers' business — naming a dtype is what lets it act at all.
- The dtype each component landed at now rides the `modular_hydration` activity event, so the next upcast is hub-visible instead of taking three deploy cycles (0.3.5→0.3.8) to name.

## Proof

`tests/test_modular_checkpoint_dtype_pgw1071.py` — real diffusers modular pipelines, real mixed-precision safetensors trees, `HF_HUB_OFFLINE=1`. 13 pass here; **5 fail on `origin/master`** (run in a detached worktree at master with the same tests): the mixed-tree per-tensor equality, the fp32 upcast of the bf16 stack, the truncation of the wide component, the declared-map routing, and the event evidence.

Local gates: mypy 245 files clean, ruff clean, full `tests/` suite from this worktree.

## Not in this PR (owed elsewhere, stated rather than dropped)

The issue's third row — re-measure ie#615's `preland_dit` on a fresh pod and see `demoted=0.0GiB` on the FIRST load — needs a live H3 pod and belongs to the ie#615/H3 lane. minimax-h3's 0.3.7/0.3.8 preland demotions stay as belt-and-braces; this PR removes what they were compensating for.