### PR TITLE
pgw#1063: a degraded reload that cannot fit its own staging REFUSES, and the dial stops calling re-reads progress

### DIFF
--- a/changelog.d/pgw1063.md
+++ b/changelog.d/pgw1063.md
@@ -1,0 +1,24 @@
+- **pgw#1063: a degraded reload that cannot fit its own staging refuses instead
+  of thrashing the host to a kernel OOM.** ie#615's H3 pod took a CUDA OOM
+  mid-inference, the ladder prescribed `off->model_offload` and quarantined the
+  instance "for a clean offloaded reload", and that reload re-staged the 105 GB
+  set in the same process whose prior staging anon was still resident: at the
+  233.76 GiB cgroup ceiling every fault went through direct reclaim,
+  `read_bytes` reached **1.578 TB (a 15x re-read)** over **37 minutes** of
+  billed H100, and the kernel OOM-killed the child — a death that was
+  arithmetically certain at minute zero. Three fixes, one per link in that
+  chain: (1) pgw#1026's per-component host-RAM discount is the loader's promise
+  that each component LEAVES the host for the card, so a rung that keeps
+  weights in host RAM (any CPU-offload rung, including the sticky floor an OOM
+  degrade just learned) is charged its WHOLE TREE — by the admission and by the
+  loader, which now read the same rung; (2) the degrade is PRICED before it is
+  prescribed — a structurally unfittable offloaded reload is refused as a
+  hardware axis (the function self-disables here and the hub re-places it,
+  never a reload attempt), and one that merely does not fit right now publishes
+  the typed per-ref capacity block so the retry is not re-admitted onto this
+  worker mid-reload; (3) the load dial stops counting re-reads as progress —
+  capping read-derived credit at the set's own size means a stalled load looks
+  stalled to the stall clock, and a phase measured re-reading its own bytes
+  past three full passes while anon sits against the cgroup limit confesses a
+  typed `load_phase_thrash` event, after which no further component is admitted
+  into the crawl.

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -112,6 +112,7 @@ from .models.memory import (
     flush_memory,
     get_available_vram_gb,
     is_cuda_oom,
+    keeps_weights_in_host_ram,
     low_vram_mode,
     next_offload_rung,
     release_unused_pinned_host_cache,
@@ -7802,11 +7803,20 @@ class Executor:
                 for comp_path in comp_paths.values():
                     slot_bytes += await asyncio.to_thread(
                         disk_gc.tree_bytes, Path(comp_path))
+                ref = wire_ref(spec.models[slot])
                 if is_modular_pipeline_class(slots[slot]):
+                    # pgw#1063: the discount below is the loader's promise
+                    # that each component LEAVES the host for the card. The
+                    # rung decides whether that promise can be kept, so the
+                    # admission and the loader read the same one — a
+                    # CPU-offload rung (including the sticky floor an OOM
+                    # degrade learned) is charged its whole tree here and
+                    # stages whole-tree there.
                     plan = await asyncio.to_thread(
                         functools.partial(
                             plan_streamed_hydration, Path(p),
-                            component_trees=comp_paths),
+                            component_trees=comp_paths,
+                            placement_mode=self._placement_mode(spec, ref)),
                     )
                     if plan.engaged:
                         logger.info(
@@ -7814,7 +7824,6 @@ class Executor:
                             "largest COMPONENT, not its tree: %s",
                             spec.name, slot, plan.summary())
                         slot_bytes = plan.largest_unit_bytes
-                ref = wire_ref(spec.models[slot])
                 if slot_bytes > incoming:
                     incoming = slot_bytes
                     incoming_refs = [ref]
@@ -11539,6 +11548,9 @@ class Executor:
                 transitions.append(
                     (ref, before, after, estimate_pipeline_size_gb(obj))
                 )
+        refused = await self._refuse_unfittable_offload(spec, transitions)
+        if refused:
+            transitions = []
         for ref, from_mode, to_mode, needed_gb in transitions:
             self._record_demotion(
                 spec, ref=ref, phase="inference",
@@ -11551,6 +11563,19 @@ class Executor:
         rec = self._classes.get(spec.instance_key)
         if rec is not None and rec.ready:
             rec.stale = True
+        if refused:
+            try:
+                ctx.log(
+                    f"DEGRADED_MODE=refused fn={spec.name}: CUDA OOM, and the "
+                    f"offloaded reload the ladder would run does not fit this "
+                    f"pod's host RAM ({refused}). The function is disabled "
+                    f"here and the hub re-places it; this worker does not "
+                    f"attempt the reload.",
+                    level="error",
+                )
+            except Exception:
+                pass
+            return
         if not transitions:
             logger.warning(degraded_log_line(
                 event="engaged", fn=spec.name, phase="inference",
@@ -11565,6 +11590,106 @@ class Executor:
             )
         except Exception:
             pass
+
+    async def _refuse_unfittable_offload(
+        self, spec: EndpointSpec,
+        transitions: List[Tuple[str, str, str, float]],
+    ) -> str:
+        """pgw#1063: price the offloaded reload the ladder is about to
+        prescribe, and refuse the DEGRADE when the host cannot hold it.
+
+        THREAT (§4.25): an offload rung keeps the whole weight set in host
+        RAM. ie#615's H3 degrade re-staged a 105 GB set into a 233.76 GiB
+        cgroup that was already holding the previous staging's anon — every
+        fault went through direct reclaim, `read_bytes` reached 1.578 TB
+        (a 15x re-read of a 105 GB set) over 37 minutes of billed H100, and
+        the kernel OOM-killed the child. That death was arithmetically
+        certain at minute zero, off numbers this worker already had.
+
+        The observable is the same one pgw#752 refuses on: tree bytes on
+        disk plus the staging floor against the cgroup-aware host TOTAL. A
+        shortfall against the total is structural — no eviction, and no
+        identical pod, changes it (th#1228) — so it reports as a hardware
+        axis, the function self-disables here, and the hub places the work
+        somewhere that can hold it. A shortfall against what is available
+        RIGHT NOW keeps the rung but publishes the typed per-ref capacity
+        block, so the retry is not re-admitted onto this worker while the
+        quarantined instance's own staging is still resident — the window
+        attempt 5 sat in for the whole 37 minutes.
+
+        Returns the structural refusal summary, or "" when the ladder may
+        proceed."""
+        res = self.store.residency
+        worst: Tuple[int, str] = (0, "")
+        for ref, _from_mode, to_mode, _needed_gb in transitions:
+            if not keeps_weights_in_host_ram(to_mode):
+                continue
+            local = res.local_path(ref)
+            if local is None:
+                continue
+            tree = await asyncio.to_thread(disk_gc.tree_bytes, Path(local))
+            if tree > worst[0]:
+                worst = (tree, ref)
+        incoming, ref = worst
+        if incoming <= 0:
+            return ""
+        headroom = await asyncio.to_thread(res.host_ram_headroom, incoming)
+        if headroom.sufficient:
+            return ""
+        if not headroom.structural:
+            # It fits a host this size — just not this host RIGHT NOW, with
+            # the quarantined instance's own staging still resident. That is
+            # the ie#615 shape, and the thing that must not happen is the
+            # RE-ADMISSION landing back here mid-reload (attempt 5 sat in
+            # that window for the whole 37 minutes). Publishing the typed
+            # per-ref capacity block is how this worker says so; it clears
+            # itself the moment measured headroom covers the requirement.
+            await self._record_host_ram_failure([ref], InsufficientHostRamError(
+                spec.name,
+                incoming_bytes=incoming,
+                floor_bytes=headroom.floor_bytes,
+                required_bytes=headroom.required_bytes,
+                available_before_bytes=headroom.available_bytes,
+                available_after_bytes=headroom.available_bytes,
+                total_bytes=headroom.total_bytes,
+            ))
+            logger.warning(degraded_log_line(
+                event="engaged", fn=spec.name, model=ref, phase="inference",
+                from_rung="resident", to_rung="model_offload",
+                free_gb=get_available_vram_gb(),
+                detail="the offloaded reload does not fit this host's CURRENT "
+                       "headroom; the rung is learned but the ref is blocked "
+                       "here until measured headroom covers it, so the retry "
+                       "is not re-admitted into a reload that cannot fit "
+                       "(pgw#1063)",
+            ))
+            return ""
+        error = HostRamCapacityError(
+            spec.name,
+            incoming_bytes=incoming,
+            floor_bytes=headroom.floor_bytes,
+            required_bytes=headroom.required_bytes,
+            available_before_bytes=headroom.available_bytes,
+            available_after_bytes=headroom.available_bytes,
+            total_bytes=headroom.total_bytes,
+        )
+        summary = (
+            f"the {ref} weight set is "
+            f"{incoming / float(1 << 30):.1f}GiB and an offloaded pipeline "
+            f"keeps it in host RAM; required "
+            f"{headroom.required_bytes / float(1 << 30):.1f}GiB against a "
+            f"{headroom.total_bytes / float(1 << 30):.1f}GiB host total"
+        )
+        logger.error(degraded_log_line(
+            event="refused", fn=spec.name, model=ref, phase="inference",
+            from_rung="resident", to_rung="model_offload",
+            free_gb=get_available_vram_gb(),
+            detail=f"the offloaded reload cannot fit its own staging: "
+                   f"{summary}. Refusing the degrade instead of thrashing "
+                   f"the host to a kernel OOM (pgw#1063).",
+        ))
+        await self._record_host_ram_failure([ref], error)
+        return summary
 
     async def _execute(
         self,

--- a/src/gen_worker/models/load_progress.py
+++ b/src/gen_worker/models/load_progress.py
@@ -61,9 +61,26 @@ EVENT_PHASE = "load_phase"
 #: A load phase FINISHED, carrying its measured span (th#1322: the number
 #: goes in the column, never interpolated into the detail).
 EVENT_PHASE_DONE = "load_phase_done"
+#: pgw#1063: this phase is RE-READING its own set instead of staging it —
+#: the direct-reclaim crawl, confessed while the worker is still alive.
+EVENT_PHASE_THRASH = "load_phase_thrash"
 
 _INTERVAL_S = 5.0
 _GIB = float(1 << 30)
+
+#: How many full passes over a phase's own bytes count as staging before the
+#: reads are re-reads (pgw#1063). THREAT (§4.24): a staging admitted against
+#: an estimate that turned out low crawls in direct reclaim — ie#615 read
+#: 1.578 TB for a 105 GB set (a 15x re-read) across 37 minutes of billed
+#: H100 before the kernel OOM-killed it. Derivation: a cold load reads each
+#: byte ONCE (1x) and a page-cache-warm load reads ~0; 3x is three full
+#: passes, which no legitimate staging shape reaches. Conjunctive with the
+#: ceiling fraction below, so a merely large load cannot trip it.
+_REREAD_MULTIPLE = 3.0
+#: Fraction of the cgroup limit anon RSS must occupy for the re-reads to be
+#: attributable to reclaim pressure rather than to a big tree. Measured at
+#: the incident: 232.9 GiB anon of a 233.76 GiB cgv1 ceiling = 99.6%.
+_CEILING_FRACTION = 0.9
 
 _lock = threading.Lock()
 _active: Optional["LoadProgressReporter"] = None
@@ -117,6 +134,13 @@ class LoadProgressReporter:
         self._phase_bytes = 0
         self._phase_started = time.monotonic()
         self._staged = 0
+        # pgw#1063 thrash detection: this phase's own read/anon baselines and
+        # the verdict once it has been reached (sticky — the regime does not
+        # un-happen, and the loader reads it between components).
+        self._phase_read0 = 0
+        self._phase_anon0 = 0
+        self._thrash = ""
+        self._cgroup_limit = 0
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._io0: Optional[int] = None
@@ -134,6 +158,8 @@ class LoadProgressReporter:
         self._close_phase()
         self._phase, self._phase_bytes = phase, max(0, int(nbytes))
         self._phase_started = time.monotonic()
+        self._phase_read0 = _proc_read_bytes() or 0
+        self._phase_anon0 = (_proc_rss_anon_kb() or 0) * 1024
         self._announce_phase()
         self._tick()
 
@@ -212,6 +238,75 @@ class LoadProgressReporter:
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
         self.stop(clean=exc_type is None)
 
+    # -- the re-read (direct-reclaim) verdict (pgw#1063) ---------------------
+
+    @property
+    def thrash(self) -> str:
+        """This load's re-read verdict, or ``""``. Sticky once reached."""
+        return self._thrash
+
+    def _cgroup_limit_bytes(self) -> int:
+        if not self._cgroup_limit:
+            # CYCLE: memory imports nothing from here.
+            from .memory import cgroup_memory_limit_bytes
+
+            self._cgroup_limit = int(cgroup_memory_limit_bytes() or 0)
+        return self._cgroup_limit
+
+    def _check_thrash(self, read: Optional[int], anon: int) -> None:
+        """Decide whether this phase is STAGING or RE-READING.
+
+        THREAT (§4.25): a staging admitted against an estimate that turned
+        out low does not fail — it crawls. Every fault goes through direct
+        reclaim, the process reads its own set over and over, and the only
+        thing that ends it is the kernel's OOM killer, tens of minutes and
+        tens of dollars later (ie#615: 1.578 TB read for a 105 GB set, 37
+        minutes, rss_anon 232.9 GiB of a 233.76 GiB ceiling).
+
+        The observable that decides it correctly is a CONJUNCTION, because
+        each half alone has an innocent explanation: a big tree reads a lot,
+        and a load with room may sit high. Together — reads past several
+        full passes over this phase's OWN bytes, WHILE anon sits against the
+        cgroup limit — there is no innocent reading left: a healthy load
+        reads each byte about once and a page-cache-warm one reads ~none.
+
+        Anon GROWTH is deliberately not treated as proof of progress. In the
+        incident it grew the whole time (130 -> 232.9 GiB): the estimate was
+        simply wrong about what the set weighed, and "it is still staging"
+        is exactly the story that ran 37 minutes into a kernel kill.
+
+        The verdict is a confession, not a kill: the counter above already
+        stopped crediting re-reads, so the existing stall authority sees a
+        stalled load, and the loader refuses the next component with these
+        numbers instead of admitting one more into the crawl.
+        """
+        if self._thrash or self._phase_bytes <= 0 or read is None:
+            return
+        phase_read = max(0, read - self._phase_read0)
+        staged = max(0, anon - self._phase_anon0)
+        limit = self._cgroup_limit_bytes()
+        if phase_read <= _REREAD_MULTIPLE * self._phase_bytes:
+            return
+        if limit <= 0 or anon < _CEILING_FRACTION * limit:
+            return
+        self._thrash = (
+            f"{self._phase}: read {_gib(phase_read)} for a "
+            f"{_gib(self._phase_bytes)} set "
+            f"({phase_read / float(self._phase_bytes):.1f}x re-read) having "
+            f"staged {_gib(staged)}, with anon RSS "
+            f"{_gib(anon)} against a {_gib(limit)} cgroup limit — this load "
+            f"is re-reading its own bytes through direct reclaim, not "
+            f"staging them"
+        )
+        logger.error("load thrash (pgw#1063) %s: %s", self.label, self._thrash)
+        try:
+            activity_mod.emit_event(
+                EVENT_PHASE_THRASH, f"{self.label}: {self._thrash}",
+                phase=self._phase,
+            )
+        except Exception:  # noqa: BLE001 - reporting must never break a load
+            logger.debug("load-thrash event dropped", exc_info=True)
+
     # -- sampling -----------------------------------------------------------
 
     def _run(self) -> None:
@@ -228,8 +323,18 @@ class LoadProgressReporter:
             rss_anon_kb = _proc_rss_anon_kb() or 0
             # Bytes STAGED is evidenced by whichever is further along:
             # cold reads show in io, page-cache-warm loads show as anon RSS.
-            done = max(0, read, rss_anon_kb * 1024)
+            # pgw#1063: reads BEYOND the set's own size are re-reads, not
+            # progress — crediting them is what let a 37-minute direct-
+            # reclaim crawl report 1.578 TB of "advancement" for a 105 GB
+            # set, so the stall clock never saw a stalled load. Cap the
+            # read-derived credit at what there is to read; anon growth
+            # (real staged bytes) still advances it honestly.
+            readable = self.total_bytes or read
+            done = max(0, min(read, readable), rss_anon_kb * 1024)
             self._staged = done
+            # ABSOLUTE counters: the phase baselines are absolute too, and a
+            # delta-from-load-start would silently zero the comparison.
+            self._check_thrash(io_now, rss_anon_kb * 1024)
             c = progress_mod.counter(
                 COUNTER_NAME, "bytes",
                 max(self.total_bytes, done),
@@ -246,6 +351,7 @@ class LoadProgressReporter:
                 "started_unix": self._started_unix,
                 "ts_unix": time.time(),
                 "pid": os.getpid(),
+                "thrash": self._thrash,
             }, self.marker_path)
         except Exception:  # noqa: BLE001 - reporting must never break a load
             logger.debug("load-progress tick dropped", exc_info=True)
@@ -259,10 +365,23 @@ def set_phase(phase: str, nbytes: int = 0) -> None:
         rep.set_phase(phase, nbytes)
 
 
+def thrash_verdict() -> str:
+    """The active load's re-read verdict, or ``""`` (pgw#1063).
+
+    Non-empty means THIS process has been measured re-reading a set it
+    cannot hold instead of staging it. The loader refuses the next
+    component with it rather than admitting one more into the crawl."""
+    with _lock:
+        rep = _active
+    return rep.thrash if rep is not None else ""
+
+
 __all__ = [
     "COUNTER_NAME",
     "EVENT_PHASE",
     "EVENT_PHASE_DONE",
+    "EVENT_PHASE_THRASH",
     "LoadProgressReporter",
     "set_phase",
+    "thrash_verdict",
 ]

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -34,6 +34,7 @@ from .fp8_storage import restructure_fp8_storage
 from .memory import (
     flush_memory,
     get_available_vram_gb,
+    keeps_weights_in_host_ram,
     meta_tensors,
     probe_host_ram,
 )
@@ -1650,12 +1651,28 @@ def _admit_component_staging(component: str, nbytes: int) -> None:
     never blocks its own load. A component that cannot fit an EMPTY host is
     the structural pgw#752 verdict; one that cannot fit right now is the
     transient one. Both carry the measured numbers. An unreadable probe
-    fails open — no worse than the unchecked load it replaces."""
+    fails open — no worse than the unchecked load it replaces.
+
+    pgw#1063: the estimate can be wrong (an upcast, a quant unpack, an
+    allocator's own overhead), and when it is the load does not fail — it
+    crawls in direct reclaim until the kernel kills it. So a MEASURED
+    verdict outranks this arithmetic: a process the load dial has caught
+    re-reading its own set instead of staging it admits nothing further,
+    structurally, whatever the numbers below would have said."""
     if nbytes <= 0:
         return
     ram = probe_host_ram()
     total = int(ram.total_gb * _GIB)
     avail = int(ram.available_gb * _GIB)
+    thrash = load_progress.thrash_verdict()
+    if thrash:
+        raise HostRamCapacityError(
+            f"modular component {component!r} after a measured re-read "
+            f"crawl ({thrash})",
+            incoming_bytes=int(nbytes), floor_bytes=0,
+            required_bytes=int(nbytes), available_before_bytes=avail,
+            available_after_bytes=avail, total_bytes=total,
+        )
     if total <= 0:
         return
     floor = _staging_floor_bytes(total)
@@ -1740,6 +1757,9 @@ class StreamedHydrationPlan:
     unit_count: int
     host_total_bytes: int
     device_free_bytes: int
+    #: The rung the pipeline will be placed on (pgw#1063). An offload rung
+    #: keeps the weights in host RAM, so it never takes the discount.
+    placement_mode: str = ""
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -1749,6 +1769,7 @@ class StreamedHydrationPlan:
             "unit_count": self.unit_count,
             "host_total_bytes": self.host_total_bytes,
             "device_free_bytes": self.device_free_bytes,
+            "placement_mode": self.placement_mode,
         }
 
     def summary(self) -> str:
@@ -1757,7 +1778,8 @@ class StreamedHydrationPlan:
             f"largest_component={self.largest_unit_bytes / _GIB:.1f}GiB "
             f"host_total={self.host_total_bytes / _GIB:.1f}GiB "
             f"device_free={self.device_free_bytes / _GIB:.1f}GiB "
-            f"({self.reason})"
+            + (f"rung={self.placement_mode} " if self.placement_mode else "")
+            + f"({self.reason})"
         )
 
 
@@ -1766,6 +1788,7 @@ def plan_streamed_hydration(
     *,
     component_trees: Optional[Mapping[str, str]] = None,
     device_free_bytes: Optional[int] = None,
+    placement_mode: str = "",
 ) -> StreamedHydrationPlan:
     """pgw#1026: decide whether this modular slot stages PER COMPONENT ONTO
     THE DEVICE instead of staging its whole tree in host RAM first.
@@ -1800,6 +1823,7 @@ def plan_streamed_hydration(
         unit_count=len(units),
         host_total_bytes=int(probe_host_ram().total_gb * _GIB),
         device_free_bytes=int(device_free_bytes),
+        placement_mode=placement_mode,
     )
 
 
@@ -1810,11 +1834,17 @@ def decide_streamed_hydration(
     unit_count: int,
     host_total_bytes: int,
     device_free_bytes: int,
+    placement_mode: str = "",
 ) -> StreamedHydrationPlan:
     """:func:`plan_streamed_hydration`'s decision, separated from its
     measurements so the rule can be read — and tested — at the byte counts
     that produced the issue rather than at whatever this host happens to
-    have."""
+    have.
+
+    ``placement_mode`` is the rung the pipeline will be PLACED on. A rung
+    that keeps weights in host RAM (any CPU-offload rung, including the
+    sticky floor an OOM degrade learned) cannot take this discount at all —
+    see the refusal below."""
     tree = int(tree_bytes)
     largest = int(largest_unit_bytes)
     host_total = int(host_total_bytes)
@@ -1822,7 +1852,21 @@ def decide_streamed_hydration(
         StreamedHydrationPlan, tree_bytes=tree, largest_unit_bytes=largest,
         unit_count=int(unit_count), host_total_bytes=host_total,
         device_free_bytes=int(device_free_bytes),
+        placement_mode=str(placement_mode or ""),
     )
+    if keeps_weights_in_host_ram(placement_mode):
+        # pgw#1063: the discount is admissible ONLY because each component
+        # leaves the host for the card. An offload rung puts it back — the
+        # weights live on the host by definition — so the honest requirement
+        # is the whole tree, and charging one component here is what admitted
+        # ie#615's 105 GB re-stage into a cgroup that could not hold it (37
+        # minutes of direct-reclaim crawl, 1.578 TB read for a 105 GB set,
+        # then an OOM kill that was arithmetically certain at minute zero).
+        return plan(
+            engaged=False,
+            reason=f"placement rung {placement_mode!r} keeps the weights in "
+                   f"host RAM: an offloaded pipeline is charged its whole "
+                   f"tree, never one component")
     if unit_count <= 0 or largest <= 0:
         return plan(engaged=False, reason="no per-component staging units")
     if host_total <= 0:
@@ -2312,6 +2356,7 @@ def _load_modular_pipeline(
     storage_dtype: str = "",
     components: Optional[Dict[str, Any]] = None,
     component_trees: Optional[Dict[str, str]] = None,
+    placement_mode: str = "",
 ) -> Any:
     """The modular lane of :func:`load_from_pretrained` (pgw#1036):
     ``cls.from_pretrained(path)`` builds a SHELL (every weight-bearing
@@ -2350,7 +2395,8 @@ def _load_modular_pipeline(
     # between them the per-component gate inside hydration still refuses
     # with the measured numbers rather than thrashing the host.
     plan = plan_streamed_hydration(
-        Path(path), component_trees=component_trees)
+        Path(path), component_trees=component_trees,
+        placement_mode=placement_mode)
     if plan.engaged:
         logger.info(
             "modular slot stages per component onto the device: %s",
@@ -2395,6 +2441,7 @@ def load_from_pretrained(
     component_trees: Optional[Dict[str, str]] = None,
     declared_vram_gb: float = 0.0,
     ref: str = "",
+    placement_mode: str = "",
 ) -> Any:
     """``cls.from_pretrained(path)`` with the standard trimmings: torch dtype
     from the binding's dtype string, on-disk variant detection, quant-library
@@ -2414,12 +2461,16 @@ def load_from_pretrained(
     component spec at the LOCAL tree, hydrate; ``component_trees`` routes
     th#980/pgw#617 component overrides to their own materialized trees on
     that lane (the ``components=`` kwarg is what ``ModularPipeline.__init__``
-    silently discards)."""
+    silently discards). ``placement_mode`` is the rung the worker will place
+    this pipeline on: an offload rung keeps the weights in host RAM, so the
+    modular lane must not stage them onto the card and must not take the
+    per-component host-RAM discount (pgw#1063)."""
     path = str(path)
     if is_modular_pipeline_class(cls):
         return _load_modular_pipeline(
             cls, path, dtype=dtype, storage_dtype=storage_dtype,
             components=components, component_trees=component_trees,
+            placement_mode=placement_mode,
         )
     if component_trees:
         raise ModularHydrationError(

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -79,6 +79,19 @@ _CPU_OFFLOAD_MODES = ("model_offload", "group_offload", "sequential")
 OFFLOAD_LADDER: tuple[str, ...] = _CPU_OFFLOAD_MODES
 
 
+def keeps_weights_in_host_ram(mode: Optional[str]) -> bool:
+    """True when this placement rung leaves the model's weights RESIDENT IN
+    HOST RAM (pgw#1063).
+
+    Every CPU-offload rung does: that is what offloading IS — the weights
+    live on the host and stream to the card per forward. So an offloaded
+    pipeline's host-RAM requirement is its WHOLE TREE, and any accounting
+    that charges it less (pgw#1026's per-component staging discount, which
+    is admissible only because each component LEAVES the host for the card)
+    is admitting a load the host cannot hold."""
+    return str(mode or "") in _CPU_OFFLOAD_MODES
+
+
 def next_offload_rung(mode: Optional[str]) -> Optional[str]:
     """The next rung down the offload ladder from ``mode``.
 
@@ -1434,6 +1447,7 @@ __all__ = [
     "place_pipeline",
     "next_offload_rung",
     "deeper_offload_mode",
+    "keeps_weights_in_host_ram",
     "is_cuda_oom",
     "degraded_log_line",
     "OFFLOAD_LADDER",

--- a/src/gen_worker/models/provision.py
+++ b/src/gen_worker/models/provision.py
@@ -173,6 +173,10 @@ def load_slot(
             component_trees=component_trees or None,
             declared_vram_gb=declared_vram_gb,
             ref=ref,
+            # pgw#1063: the loader's own host-RAM decisions depend on where
+            # this pipeline will END UP. `place_pipeline(mode=...)` below is
+            # the same knowledge arriving too late to inform them.
+            placement_mode=mode,
         )
         out.obj = pipe
 

--- a/tests/test_degraded_reload_refusal_pgw1063.py
+++ b/tests/test_degraded_reload_refusal_pgw1063.py
@@ -1,0 +1,424 @@
+"""pgw#1063: a degraded reload that cannot fit its own staging REFUSES.
+
+ie#615, pod ``nzlrzusxjl8tm1`` (233.76 GiB cgv1 ceiling, gen-worker 0.96.0),
+verbatim off the postmortem dial:
+
+1. a request died CUDA OOM mid-inference (an endpoint defect, fixed there);
+2. the ladder engaged ``rung=off->model_offload``, quarantined the instance
+   "for a clean offloaded reload", and the retry was re-admitted **on the
+   same worker**;
+3. that reload re-staged the 105 GB set in the same process whose prior
+   staging anon was still resident. At the ceiling every fault went through
+   direct reclaim: ``read_bytes`` reached **1.578 TB — a 15x re-read of a
+   105 GB set** — rss_anon 232.9 GiB, for **37 minutes**, until the kernel
+   OOM-killed the child. $2+ of billed H100 to reach a death that was
+   arithmetically certain at minute zero.
+
+Three defects, one per section below:
+
+* the offload rung was charged pgw#1026's per-component discount, which is
+  the loader's promise that each component LEAVES the host for the card — a
+  promise an offloaded pipeline cannot keep, since offloading IS keeping the
+  weights on the host;
+* the degrade was never priced at decision time, so a reload that could not
+  fit was prescribed anyway;
+* the load dial counted re-reads as progress (1.578 TB of "advancement" for
+  a 105 GB set), so nothing — not the stall clock, not the next component's
+  admission — could see a load that had stopped making any.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from gen_worker.api.binding import wire_ref
+from gen_worker.capability import HostRamCapacityError
+from gen_worker.models import load_progress as lp
+from gen_worker.models import loading as loading_mod
+from gen_worker.models.loading import (
+    _admit_component_staging,
+    decide_streamed_hydration,
+    plan_streamed_hydration,
+)
+from gen_worker.models.memory import (
+    OFFLOAD_LADDER,
+    keeps_weights_in_host_ram,
+)
+from gen_worker.models.residency import HostRamHeadroom
+
+from harness.modular_endpoint import build_base_tree
+
+_GIB = 1024 ** 3
+
+
+def _ram(total_gb: float, available_gb: float):
+    from gen_worker.models.memory import HostRam
+
+    return HostRam(
+        total_gb=total_gb, available_gb=available_gb,
+        meminfo_total_gb=total_gb, meminfo_available_gb=available_gb,
+        cgroup_limit_gb=total_gb, source="cgroup",
+    )
+
+
+def _h3(**over: Any):
+    """ie#615's measured shape: 134.1 GiB tree, 46 GiB largest component,
+    116.4 GiB host, a card set that holds the tree."""
+    kwargs: Dict[str, Any] = dict(
+        tree_bytes=int(134.1 * _GIB),
+        largest_unit_bytes=int(46.0 * _GIB),
+        unit_count=6,
+        host_total_bytes=int(116.4 * _GIB),
+        device_free_bytes=int(141.0 * _GIB),
+    )
+    kwargs.update(over)
+    return decide_streamed_hydration(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. the discount is the loader's promise, and an offload rung cannot keep it
+# ---------------------------------------------------------------------------
+
+
+def test_an_offload_rung_never_takes_the_per_component_discount() -> None:
+    assert _h3().engaged, "the resident shape must still engage"
+    for rung in OFFLOAD_LADDER:
+        plan = _h3(placement_mode=rung)
+        assert not plan.engaged, rung
+        assert "host RAM" in plan.reason and rung in plan.reason
+
+
+def test_the_resident_rungs_are_untouched() -> None:
+    for rung in ("", "auto", "off", "vae_only"):
+        assert _h3(placement_mode=rung).engaged, rung
+        assert not keeps_weights_in_host_ram(rung)
+
+
+def test_the_rung_travels_with_the_plan(tmp_path, monkeypatch) -> None:
+    """The measuring wrapper carries it, so the executor and the loader
+    cannot reach different verdicts from the same tree."""
+    tree = build_base_tree(tmp_path / "base", fill=1.0)
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(64.0, 60.0))
+
+    plan = plan_streamed_hydration(
+        tree, device_free_bytes=80 * _GIB, placement_mode="group_offload")
+
+    assert plan.placement_mode == "group_offload"
+    assert not plan.engaged
+    assert "group_offload" in plan.summary()
+
+
+# ---------------------------------------------------------------------------
+# 2. the admission charges an offloaded reload its WHOLE TREE
+# ---------------------------------------------------------------------------
+
+
+def _sparse_h3_tree(root: Path) -> Path:
+    """A real modular tree whose component dirs measure H3's sizes; the
+    files are sparse, so ``st_size`` is real and the blocks are not."""
+    root.mkdir(parents=True, exist_ok=True)
+    sizes = {
+        "text_encoder": int(60.0 * _GIB),
+        "transformer": int(46.0 * _GIB),
+        "transformer_2": int(26.0 * _GIB),
+        "vae": int(2.1 * _GIB),
+    }
+    index: Dict[str, Any] = {
+        "_class_name": "TinyModularPipeline",
+        "_blocks_class_name": "TinyBlocks",
+    }
+    for name, nbytes in sizes.items():
+        d = root / name
+        d.mkdir()
+        with open(d / "model.safetensors", "wb") as f:
+            f.truncate(nbytes)
+        index[name] = ["diffusers", "UNet2DConditionModel", {
+            "pretrained_model_name_or_path": "upstream/h3",
+            "subfolder": name, "variant": None, "revision": None,
+        }]
+    (root / "modular_model_index.json").write_text(json.dumps(index))
+    return root
+
+
+def _modular_spec():
+    from gen_worker.registry import extract_specs
+
+    from harness.modular_endpoint import ModularEndpoint
+
+    return extract_specs(ModularEndpoint)[0]
+
+
+def _executor(spec):
+    from gen_worker.executor import Executor
+
+    async def _send(_msg: Any) -> None:
+        return None
+
+    return Executor([spec], _send)
+
+
+async def _admit(ex, spec, paths):
+    await ex._ensure_host_ram_for(spec, paths)
+
+
+def _host_of(monkeypatch, total_gb: float, avail_gb: float,
+             device_free_gb: float) -> None:
+    monkeypatch.setattr(
+        loading_mod, "probe_host_ram", lambda: _ram(total_gb, avail_gb))
+    monkeypatch.setattr(
+        "gen_worker.models.memory.probe_host_ram",
+        lambda **_: _ram(total_gb, avail_gb))
+    monkeypatch.setattr(
+        loading_mod, "get_available_vram_gb", lambda *a, **k: device_free_gb)
+
+
+def test_a_degraded_ref_is_charged_its_tree_and_refuses(
+    tmp_path, monkeypatch,
+) -> None:
+    """The incident's admission: 134.1 GiB of tree on a 116.4 GiB host with
+    a card that holds it. Resident, that is a boot (pgw#1026). On the rung
+    the OOM degrade just learned, it is a structural refusal — and the
+    refusal is what did not happen."""
+    tree = _sparse_h3_tree(tmp_path / "h3")
+    _host_of(monkeypatch, 116.4, 110.0, 141.0)
+    spec = _modular_spec()
+    ex = _executor(spec)
+    ex.degraded_floor[wire_ref(spec.models["pipeline"])] = "model_offload"
+
+    with pytest.raises(HostRamCapacityError) as exc:
+        asyncio.run(_admit(ex, spec, {"pipeline": str(tree)}))
+    assert exc.value.required_bytes > exc.value.total_bytes
+
+
+def test_without_the_degraded_floor_the_same_tree_still_boots(
+    tmp_path, monkeypatch,
+) -> None:
+    """pgw#1026 is untouched on the resident path — this issue may only turn
+    a boot into a refusal where the rung makes the discount a lie."""
+    tree = _sparse_h3_tree(tmp_path / "h3")
+    _host_of(monkeypatch, 116.4, 110.0, 141.0)
+    spec = _modular_spec()
+
+    asyncio.run(_admit(_executor(spec), spec, {"pipeline": str(tree)}))
+
+
+# ---------------------------------------------------------------------------
+# 3. the degrade is PRICED before it is prescribed
+# ---------------------------------------------------------------------------
+
+
+def _degrade_executor(monkeypatch, *, tree_bytes: int, headroom: HostRamHeadroom):
+    spec = _modular_spec()
+    ex = _executor(spec)
+    res = ex.store.residency
+    monkeypatch.setattr(res, "local_path", lambda ref: Path("/nonexistent"))
+    monkeypatch.setattr(res, "host_ram_headroom", lambda needed: headroom)
+    monkeypatch.setattr(
+        loading_mod.disk_gc, "tree_bytes", lambda p: tree_bytes)
+    monkeypatch.setattr(
+        "gen_worker.executor.disk_gc.tree_bytes", lambda p: tree_bytes)
+    sent: List[Any] = []
+
+    async def _record(refs, error):
+        sent.append((list(refs), error))
+
+    monkeypatch.setattr(ex, "_record_host_ram_failure", _record)
+    return ex, spec, sent
+
+
+_INCIDENT_SET = int(105e9)
+
+
+def _headroom(available_gb: float, total_gb: float) -> HostRamHeadroom:
+    floor = int(8 * _GIB)
+    return HostRamHeadroom(
+        available_bytes=int(available_gb * _GIB),
+        floor_bytes=floor,
+        required_bytes=_INCIDENT_SET + floor,
+        total_bytes=int(total_gb * _GIB),
+    )
+
+
+def test_a_structurally_unfittable_offload_reload_is_refused(
+    monkeypatch,
+) -> None:
+    """No eviction, and no identically-sized pod, can hold it: report the
+    hardware axis, disable the function here, do not reload."""
+    ex, spec, sent = _degrade_executor(
+        monkeypatch, tree_bytes=_INCIDENT_SET,
+        headroom=_headroom(available_gb=20.0, total_gb=64.0))
+
+    verdict = asyncio.run(ex._refuse_unfittable_offload(
+        spec, [("hub/h3:prod", "", "model_offload", 0.0)]))
+
+    assert verdict and "host RAM" in verdict
+    assert len(sent) == 1
+    assert isinstance(sent[0][1], HostRamCapacityError)
+
+
+def test_a_reload_that_does_not_fit_RIGHT_NOW_blocks_the_ref_here(
+    monkeypatch,
+) -> None:
+    """The incident's own shape: it fits a 233.76 GiB host, just not this
+    one while the quarantined instance's staging is still resident. The
+    rung is still learned; what must not happen is the retry landing back
+    here mid-reload."""
+    ex, spec, sent = _degrade_executor(
+        monkeypatch, tree_bytes=_INCIDENT_SET,
+        headroom=_headroom(available_gb=100.0, total_gb=233.76))
+
+    verdict = asyncio.run(ex._refuse_unfittable_offload(
+        spec, [("hub/h3:prod", "", "model_offload", 0.0)]))
+
+    assert verdict == ""  # the ladder proceeds
+    assert len(sent) == 1
+    assert sent[0][1].reason == "insufficient_host_ram"
+
+
+def test_an_affordable_reload_says_nothing(monkeypatch) -> None:
+    ex, spec, sent = _degrade_executor(
+        monkeypatch, tree_bytes=_INCIDENT_SET,
+        headroom=_headroom(available_gb=200.0, total_gb=233.76))
+
+    assert asyncio.run(ex._refuse_unfittable_offload(
+        spec, [("hub/h3:prod", "", "model_offload", 0.0)])) == ""
+    assert sent == []
+
+
+def test_a_resident_rung_is_not_priced_as_an_offload(monkeypatch) -> None:
+    """Only a rung that keeps weights on the host owes this price."""
+    ex, spec, sent = _degrade_executor(
+        monkeypatch, tree_bytes=_INCIDENT_SET,
+        headroom=_headroom(available_gb=1.0, total_gb=64.0))
+
+    assert asyncio.run(ex._refuse_unfittable_offload(
+        spec, [("hub/h3:prod", "", "vae_only", 0.0)])) == ""
+    assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# 4. re-reads are not progress
+# ---------------------------------------------------------------------------
+
+
+def _reporter(monkeypatch, *, total_bytes: int, limit_gb: float,
+              events: Optional[List] = None) -> lp.LoadProgressReporter:
+    if events is not None:
+        monkeypatch.setattr(
+            lp.activity_mod, "emit_event",
+            lambda kind, detail="", phase="", duration_ms=0: events.append(
+                (kind, detail)))
+    monkeypatch.setattr(
+        "gen_worker.models.memory.cgroup_memory_limit_bytes",
+        lambda *a, **k: int(limit_gb * _GIB))
+    rep = lp.LoadProgressReporter(
+        "h3:hub/h3:prod", total_bytes, marker_path=Path("/dev/null"))
+    # What `start()` does, without its thread: the load began at read 0, so
+    # the tick's own delta arithmetic is the production one.
+    rep._io0 = 0
+    return rep
+
+
+def _drive(rep, monkeypatch, *, read: int, anon: int) -> None:
+    monkeypatch.setattr(lp, "_proc_read_bytes", lambda: read)
+    monkeypatch.setattr(lp, "_proc_rss_anon_kb", lambda: anon // 1024)
+    rep._tick()
+
+
+def test_the_incident_is_named_while_the_worker_is_still_alive(
+    tmp_path, monkeypatch,
+) -> None:
+    """1.578 TB read for a 105 GB set, anon against the ceiling, and the
+    staging has not produced one copy of it."""
+    events: List = []
+    rep = _reporter(
+        monkeypatch, total_bytes=_INCIDENT_SET, limit_gb=233.76, events=events)
+    _drive(rep, monkeypatch, read=0, anon=int(130 * _GIB))
+    rep.set_phase("hydrate:transformer", int(46 * _GIB))
+
+    _drive(rep, monkeypatch, read=int(1.578e12), anon=int(232.9 * _GIB))
+
+    assert rep.thrash, "the crawl must name itself"
+    assert "re-reading" in rep.thrash
+    assert any(k == lp.EVENT_PHASE_THRASH for k, _ in events)
+
+
+def test_re_reads_stop_advancing_the_counter(tmp_path, monkeypatch) -> None:
+    """The stall clock runs on counter advancement; crediting a 15x re-read
+    as progress is what made a stalled load look busy for 37 minutes."""
+    rep = _reporter(monkeypatch, total_bytes=_INCIDENT_SET, limit_gb=233.76)
+    _drive(rep, monkeypatch, read=0, anon=0)
+    rep.set_phase("hydrate:transformer", int(46 * _GIB))
+
+    _drive(rep, monkeypatch, read=_INCIDENT_SET, anon=0)
+    once = rep._staged
+    _drive(rep, monkeypatch, read=int(1.578e12), anon=0)
+
+    assert rep._staged == once <= _INCIDENT_SET
+
+
+def test_a_healthy_cold_load_never_trips_it(tmp_path, monkeypatch) -> None:
+    """One pass over the bytes, anon growing with it: the ordinary shape of
+    every load this worker runs."""
+    rep = _reporter(monkeypatch, total_bytes=_INCIDENT_SET, limit_gb=233.76)
+    _drive(rep, monkeypatch, read=0, anon=0)
+    rep.set_phase("hydrate:transformer", int(46 * _GIB))
+
+    for frac in (0.25, 0.5, 0.75, 1.0):
+        staged = int(frac * 46 * _GIB)
+        _drive(rep, monkeypatch, read=staged, anon=staged)
+        assert not rep.thrash, frac
+
+
+def test_a_big_slow_load_far_from_the_ceiling_never_trips_it(
+    tmp_path, monkeypatch,
+) -> None:
+    """Re-reads alone are not the threat — reclaim pressure is. A host with
+    room is allowed to read as much as it likes."""
+    rep = _reporter(monkeypatch, total_bytes=_INCIDENT_SET, limit_gb=233.76)
+    _drive(rep, monkeypatch, read=0, anon=0)
+    rep.set_phase("hydrate:transformer", int(46 * _GIB))
+
+    _drive(rep, monkeypatch, read=int(10 * 46 * _GIB), anon=int(20 * _GIB))
+
+    assert not rep.thrash
+
+
+def test_growing_anon_at_the_ceiling_is_the_incident_not_an_excuse(
+    tmp_path, monkeypatch,
+) -> None:
+    """ie#615's anon DID keep growing (130 -> 232.9 GiB) — the estimate was
+    simply wrong about how much the set weighed. Staging more, at the
+    ceiling, while re-reading, is the crawl itself; treating growth as proof
+    of progress would exempt exactly the incident this issue is about."""
+    rep = _reporter(monkeypatch, total_bytes=_INCIDENT_SET, limit_gb=233.76)
+    _drive(rep, monkeypatch, read=0, anon=int(180 * _GIB))
+    rep.set_phase("hydrate:transformer", int(46 * _GIB))
+
+    _drive(rep, monkeypatch, read=int(10 * 46 * _GIB), anon=int(230 * _GIB))
+
+    assert rep.thrash
+
+
+def test_the_measured_verdict_outranks_the_estimate(monkeypatch) -> None:
+    """Admission arithmetic said yes; the process has been measured saying
+    otherwise. Nothing further is admitted into the crawl."""
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(233.76, 100.0))
+    monkeypatch.setattr(
+        loading_mod.load_progress, "thrash_verdict",
+        lambda: "hydrate:transformer: read 1.5 TiB for a 46 GiB set")
+
+    with pytest.raises(HostRamCapacityError) as exc:
+        _admit_component_staging("vae", int(2 * _GIB))
+    assert "re-read crawl" in str(exc.value)
+
+
+def test_without_a_verdict_the_arithmetic_still_decides(monkeypatch) -> None:
+    monkeypatch.setattr(loading_mod, "probe_host_ram", lambda: _ram(233.76, 200.0))
+
+    _admit_component_staging("vae", int(2 * _GIB))


### PR DESCRIPTION
Closes the pgw#1063 rows filed by the ie#615 serve-proof lane (pod `nzlrzusxjl8tm1`, 233.76 GiB cgv1 ceiling, gen-worker 0.96.0).

## The incident, and the three links in it

1. a request died **CUDA OOM mid-inference** (an endpoint defect, fixed in minimax-h3 0.3.4);
2. the ladder engaged `rung=off->model_offload`, quarantined the instance "for a clean offloaded reload", and the retry was re-admitted **on the same worker**;
3. that reload re-staged the 105 GB set in the same process whose prior staging anon was still resident. At the ceiling every fault went through direct reclaim: `read_bytes` reached **1.578 TB — a 15x re-read of a 105 GB set** — rss_anon 232.9 GiB, for **37 minutes**, until `oom_kill_delta=1`. **$2+ of billed H100 to reach a death that was arithmetically certain at minute zero**, off numbers the worker already had.

## What each row owed, and what landed

**Row 1 — the offloaded reload must be priced at decision time.**
- pgw#1026's per-component host-RAM discount is the loader's *promise that each component leaves the host for the card*. An offload rung cannot keep that promise — offloading **is** keeping the weights on the host. `decide_streamed_hydration` now takes the rung and refuses the discount for every `OFFLOAD_LADDER` mode, and both readers of that decision (the executor's `_ensure_host_ram_for` and the loader, via `load_slot(mode=…)` → `load_from_pretrained(placement_mode=…)`) pass the *same* rung, so they cannot disagree about the shape of the load.
- The degrade itself is priced before it is prescribed (`_refuse_unfittable_offload`): a **structurally** unfittable offloaded reload is refused — typed `HostRamCapacityError` on the hardware axis, function self-disables here, hub re-places, **no reload attempt** — and `DEGRADED_MODE=refused` says so to the client.

**Row 2 — admission must fail fast, and a collapsing staging must abort.**
- The load dial stopped counting re-reads as progress. `done` credited raw `read_bytes`, which is how a stalled load reported 1.578 TB of "advancement"; the read-derived credit is now capped at the set's own size, so the existing stall authority sees the truth instead of a marching number.
- A phase measured **re-reading past three full passes over its own bytes while anon RSS sits within 10% of the cgroup limit** confesses a typed, durable `load_phase_thrash` event (and stamps the postmortem breadcrumb). Conjunctive by design: a healthy cold load reads each byte ~once, a warm one reads ~none, and a load with room never satisfies the ceiling clause. No wall clock is consulted — §4.24/gw#666.
- `_admit_component_staging` treats that **measured** verdict as outranking its own arithmetic: once the process has been caught crawling, no further component is admitted into it.

**Row 3 — the retry must not land back here mid-reload.**
- When the offloaded reload does not fit *current* headroom (the incident's own shape: it fits a 233.76 GiB host, just not this one while the quarantined staging is resident), the worker publishes the typed per-ref host-RAM capacity block (pgw#548) at degrade time. That is the existing evidence the hub already consumes (`typedHostRAMCapacityEvidence`, `internal/orchestrator/grpc/connect_worker.go`), and it clears itself the moment measured headroom covers the requirement. The rung is still learned; what stops is the re-admission into a reload that cannot fit.

## Proof

`tests/test_degraded_reload_refusal_pgw1063.py` — 16 tests at ie#615's measured magnitudes, on real Executor instances and real (sparse) modular trees. **RED on `origin/master`**: the incident's own admission (134.1 GiB tree, 116.4 GiB host, card holds it, rung `model_offload`) is *admitted* there and refuses here; and the counter test shows master crediting the 15x re-read as progress.

Local gates: mypy clean, ruff clean, the three hard lint gates, `tests/` from this worktree.

## Deliberately not here

Nothing in this PR needs a pod. The endpoint-side compensations in minimax-h3 stay as they are.
