### PR TITLE
pgw#973 wave 3 (§4.24): a resume cap that INVERTED into a purge, a wall-clock kill over a live progress signal, and five bounds that could not bind

### DIFF
--- a/changelog.d/pgw973.md
+++ b/changelog.d/pgw973.md
@@ -1,0 +1,40 @@
+- **pgw#973 wave 3 (§4.24): the resume-area cap could INVERT into a purge, and
+  the lane gate killed requests on a wall clock while its progress signal was
+  in front of it.** `aot_resume.sweep` computed
+  `int(max_bytes or os.environ.get(ENV) or DEFAULT_MAX_BYTES)`, two absence
+  collapses in one expression and in opposite directions: a caller-computed `0`
+  fell through to the 4 GiB default (its limit ignored), while
+  `GEN_WORKER_MINT_RESUME_MAX_BYTES=0` — the spelling an operator reaches for
+  to mean "no cap" — yielded `cap = 0`, because the env value is the *string*
+  `"0"`, and the sweep then deleted every banked scope except the one being
+  opened. Absence is now `None` and only `None`; a stated non-positive value is
+  refused (`resume_area_cap_bytes`). The same sweep also evicted NEWEST-first,
+  the exact inversion of its own docstring — the scope most likely to be
+  resumed next. `models/execution_lane_gate` gave up on a flat 45 s deadline
+  while polling `get_available_vram_gb()` four times a second, so a card still
+  handing memory back failed a request that was about to serve; it now uses a
+  `SilenceWindow` over free VRAM (gw#666), quantised at 64 MiB so allocator
+  jitter is not progress. `transport.SendQueue(maxsize<=0)` deleted the
+  outbound bound outright (`while self._maxsize > 0`) — an unbounded send
+  buffer one public-parameter caller away — and is refused;
+  `DEFAULT_QUEUE_MAXSIZE` replaces the `1024` written in three places.
+  `mint_child.cap_vram` now STATES the uncapped cases instead of returning an
+  empty note the caller dropped, so the phase table can tell a capped mint from
+  an uncapped one.
+- **pgw#973 wave 3: deletions and single owners.** `procsplit.parent`'s
+  `_ACTION_HARD_TIMEOUT_S = 120.0` sat in a `min()` beside `action.timeout_s`,
+  whose largest declared value is 60 s, so it could only ever reject nothing
+  (§4.24 item 1) — deleted, with the load-bearing clamp (a tenant child's own
+  `timeout` field) now proven on the real mediation path. The five
+  `request_context/_helpers._FILE_API_*_TIMEOUT_S` constants reached no call
+  site anywhere and are gone. `s3_transfer`'s `min(2 ** (attempt - 1), 4)`
+  backoff could only ever evaluate to `1` once `_SDK_TRANSFER_ATTEMPTS` became
+  2, and is now the single named pause it always was. Four verbatim duplicates
+  collapse to one owner each: `PIN_MAX_BYTES` (`media_transfer`),
+  `NVIDIA_SMI_TIMEOUT_S` (`cuda_probe`), `_RAM_FLOOR_GB`/`_RAM_FLOOR_FRACTION`
+  *and their shared derivation* (`memory.effective_ram_floor_gb` — `residency`
+  and `staging` cannot import each other), and the transport keepalive interval
+  (`KEEPALIVE_INTERVAL_S`, previously a bare literal beside the named timeout).
+  `SERVING_HEADROOM_CPUS` is deliberately NOT collapsed and says why at the
+  site: `aot_wrapper_split` is an inductor hook, and importing
+  `aot_compile_pool` would drag the whole mint driver into it.

--- a/src/gen_worker/aot_resume.py
+++ b/src/gen_worker/aot_resume.py
@@ -139,16 +139,54 @@ def _dir_bytes(path: Path) -> int:
     return total
 
 
-def sweep(keep: Path, *, max_bytes: int = 0) -> int:
+def resume_area_cap_bytes(max_bytes: Optional[int] = None) -> int:
+    """The resume area's byte cap: caller, else env, else the stated default.
+
+    pgw#973 §4.24 item 4. This used to be
+    ``int(max_bytes or os.environ.get(ENV) or DEFAULT_MAX_BYTES)``, which
+    collapsed absence into a value TWICE and in opposite directions: a
+    caller-computed ``0`` fell through to the 4 GiB default (its limit ignored),
+    while ``GEN_WORKER_MINT_RESUME_MAX_BYTES=0`` produced ``cap = 0`` — the
+    string ``"0"`` is truthy — and :func:`sweep` then deleted every scope
+    except ``keep``, i.e. the limit INVERTED into a purge. Absence is now
+    ``None`` and only ``None``; any stated non-positive value is refused, on
+    the ``url_fetch.fetch_bytes`` / ``SilenceWindow`` shape.
+    """
+    if max_bytes is not None:
+        if int(max_bytes) <= 0:
+            raise ValueError("max_bytes must be positive")
+        return int(max_bytes)
+    raw = os.environ.get(ENV_MAX_BYTES, "").strip()
+    if not raw:
+        return DEFAULT_MAX_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{ENV_MAX_BYTES}={raw!r} is not an integer byte count") from None
+    if value <= 0:
+        raise ValueError(f"{ENV_MAX_BYTES} must be positive, got {value}")
+    return value
+
+
+def sweep(keep: Path, *, max_bytes: Optional[int] = None) -> int:
     """Hold the resume area under its capacity bound, oldest scope first.
 
-    ``keep`` is never dropped. Everything else is ordered by mtime, newest
-    first, and whole scopes are removed from the tail until the total fits. An
-    actively-running mint's bank is the newest thing in the area (every banked
-    entry touches it), so the loser is an abandoned mint nobody came back for
-    — and the cost of getting that wrong is one recompile, never a wrong cell.
+    ``keep`` is never dropped. Everything else is ordered by mtime and whole
+    scopes are removed OLDEST FIRST until the total fits. An actively-running
+    mint's bank is the newest thing in the area (every banked entry touches
+    it), so the loser is an abandoned mint nobody came back for — and the cost
+    of getting that wrong is one recompile, never a wrong cell.
+
+    pgw#973: the sort was `reverse=True` and the loop consumed it from the
+    head, i.e. it evicted the NEWEST abandoned scope first — the exact
+    inversion of what this docstring, the comment and the intent all say, and
+    the one most likely to be resumed next. The pre-existing test could not
+    see it: both of its victims carried the same mtime.
+
+    ``max_bytes=None`` means "not stated" — see :func:`resume_area_cap_bytes`.
     """
-    cap = int(max_bytes or os.environ.get(ENV_MAX_BYTES, "") or DEFAULT_MAX_BYTES)
+    cap = resume_area_cap_bytes(max_bytes)
     area = keep.parent
     scopes: List[Tuple[float, Path, int]] = []
     try:
@@ -162,7 +200,7 @@ def sweep(keep: Path, *, max_bytes: int = 0) -> int:
             continue
     total = sum(size for _, _, size in scopes)
     dropped = 0
-    for _, path, size in sorted(scopes, reverse=True):
+    for _, path, size in sorted(scopes, key=lambda row: row[0]):
         if total <= cap:
             break
         if path == keep:
@@ -574,6 +612,7 @@ __all__ = [
     "context_facts",
     "discard",
     "open_bank",
+    "resume_area_cap_bytes",
     "root",
     "set_root",
     "sweep",

--- a/src/gen_worker/aot_wrapper_split.py
+++ b/src/gen_worker/aot_wrapper_split.py
@@ -322,6 +322,18 @@ JOBS_ENV = "GEN_WORKER_AOT_HOST_COMPILE_JOBS"
 
 #: Left for serving even when nothing else has claimed the box. Matches
 #: pgw#809's `SERVING_HEADROOM_CPUS`; a mint never starves the tenant.
+#:
+#: pgw#973 (§4.24) censused this as a verbatim duplicate of
+#: `aot_compile_pool.SERVING_HEADROOM_CPUS` and DEFERRED the collapse
+#: deliberately, rather than leaving the question open. This module is an
+#: INDUCTOR HOOK — it is imported from inside torch's compile path and its only
+#: in-repo imports are `host_isa` and `aot_run_impl_split`. Importing the pool
+#: to share one number would drag `aot_resume`, `mint_budget`, `env_seal` and
+#: `worker_goals` — the whole mint driver — into that hook, which is a far
+#: worse defect than two copies of `2`. A third module owning the constant
+#: would be the clean answer and is not worth a new module for one integer.
+#: The duplication is therefore INTENTIONAL and stated; the numbers are pinned
+#: together by `test_serving_headroom_is_one_number_pgw973`.
 SERVING_HEADROOM_CPUS = 2
 
 _installed = False

--- a/src/gen_worker/callout.py
+++ b/src/gen_worker/callout.py
@@ -46,6 +46,11 @@ _REFUSAL_CODES = frozenset(
 _NOT_DECLARED_CODES = frozenset({"forbidden", "insufficient_scope", "unauthorized"})
 
 DEFAULT_POLL_INTERVAL_S = 2.0
+# pgw#973 (§4.24): per-CALL socket budget for the child-request control plane.
+# Same shape as `receipts._HTTP_TIMEOUT_S` and deliberately double it: these
+# calls ADMIT a child request hub-side, which can queue, whereas a JWKS fetch
+# cannot. Long-running child work is polled (`DEFAULT_POLL_INTERVAL_S`), so
+# this bounds a single unanswered socket and never the child's own runtime.
 _HTTP_TIMEOUT_S = 60.0
 
 

--- a/src/gen_worker/capability_renewal.py
+++ b/src/gen_worker/capability_renewal.py
@@ -20,8 +20,20 @@ from .request_context import _decode_unverified_jwt_claims
 logger = logging.getLogger(__name__)
 
 RENEW_PATH = "/v1/worker/capability/renew"
+# pgw#973 (§4.24). Renew at 80% of the token's OWN lifetime, so the fraction is
+# a statement about the remaining budget rather than a duration anybody picked:
+# whatever TTL the hub issues, a fifth of it is left for the retries below.
+# The threat is a job losing its capability MID-FLIGHT — an in-flight upload or
+# hub call fails on an expired token with the work already done — and nothing
+# else prevents it: the token carries no refresh, and the hub does not push.
 RENEW_FRACTION = 0.8
+#: Floor on the sleep before a renewal attempt, so a token already past its
+#: renew point cannot spin this loop against the hub at full speed.
 _MIN_SLEEP_S = 1.0
+#: Attempts for a TRANSIENT failure only (a refusal is terminal on the first).
+#: Three x 5/10/15 s spans ~30 s of the 20% of TTL this loop has left, so a
+#: brief hub blip is ridden out and a real outage still surfaces while the
+#: token is valid — a fourth attempt would spend budget it cannot afford.
 _TRANSIENT_RETRIES = 3
 _TRANSIENT_BACKOFF_S = 5.0
 

--- a/src/gen_worker/convert/hub.py
+++ b/src/gen_worker/convert/hub.py
@@ -45,6 +45,13 @@ from .publish_journal import JOURNAL_NAME, JournalEntry, PublishJournal, artifac
 
 logger = logging.getLogger(__name__)
 
+# pgw#973 (§4.24): the retry loop's PACE, and deliberately not its end — the
+# give-up is `SilenceWindow(_SEND_SILENCE_WINDOW_S)` over definite hub answers
+# (gw#666), so these two decide only how often a hub that is down gets asked.
+# The threat is this worker: a publish riding out a hub rebuild for the better
+# part of an hour must not become a retry flood against it, and must not stall
+# an hour between attempts once it recovers. The ceiling also bounds a hostile
+# or buggy `Retry-After`, which `_retry_after_s` clamps to it (:157).
 _RETRY_BASE_DELAY_S = 1.0
 _RETRY_MAX_DELAY_S = 30.0
 

--- a/src/gen_worker/cuda_probe.py
+++ b/src/gen_worker/cuda_probe.py
@@ -16,6 +16,16 @@ import msgspec
 
 CUDA_PROBE_FAILED_MARKER = "GEN_WORKER_CUDA_PROBE_FAILED"
 
+#: Wall budget for one `nvidia-smi` subprocess. The exact fault this module
+#: exists for — a wedged CUDA device — is also the fault that makes `nvidia-smi`
+#: hang indefinitely rather than answer, so a call with no timeout turns a
+#: diagnostic into the hang it was diagnosing. Exempt from gw#666 by shape:
+#: `nvidia-smi` emits nothing until it exits, so there is no progress signal to
+#: window over, and expiry kills no work — the caller degrades to an
+#: unmeasured field. One owner (pgw#973 §4.24): `host_canary` and
+#: `hardware_report` each used to declare their own `5.0`.
+NVIDIA_SMI_TIMEOUT_S = 5.0
+
 
 class CudaProbeResult(msgspec.Struct, frozen=True):
     ok: bool

--- a/src/gen_worker/hardware_report.py
+++ b/src/gen_worker/hardware_report.py
@@ -25,7 +25,11 @@ import msgspec
 
 from . import worker_credential
 from .config import Settings
-from .cuda_probe import CudaProbeResult, classify_probe_failure
+from .cuda_probe import (
+    NVIDIA_SMI_TIMEOUT_S as _NVIDIA_SMI_TIMEOUT_S,
+    CudaProbeResult,
+    classify_probe_failure,
+)
 from .pb import worker_scheduler_pb2 as pb
 from .pb import worker_scheduler_pb2_grpc as pb_grpc
 from .transport import normalize_grpc_addr
@@ -40,7 +44,6 @@ logger = logging.getLogger(__name__)
 _REPORT_RPC_TIMEOUT_S = 3.0
 _MAX_ATTEMPTS = 2
 _RETRY_BACKOFF_S = (1.0,)
-_NVIDIA_SMI_TIMEOUT_S = 5.0
 
 
 class HardwareReport(msgspec.Struct, frozen=True):

--- a/src/gen_worker/host_canary.py
+++ b/src/gen_worker/host_canary.py
@@ -43,6 +43,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor
+from .cuda_probe import NVIDIA_SMI_TIMEOUT_S as _NVIDIA_SMI_TIMEOUT_S
 from .postmortem import effective_cpu_count
 import tempfile
 
@@ -57,7 +58,6 @@ _CPU_SLICE_S = 0.25
 _HASH_BLOCK = 1 << 20
 # 2-GPU leg (pgw#748): same 256 MiB buffer, 3 timed peer copies.
 _PEER_REPS = 3
-_NVIDIA_SMI_TIMEOUT_S = 5.0
 
 # Measured interconnect classes, worst to best.
 INTERCONNECT_NONE = ""            # single GPU / not measurable

--- a/src/gen_worker/input_assets.py
+++ b/src/gen_worker/input_assets.py
@@ -42,9 +42,24 @@ logger = logging.getLogger(__name__)
 # and its byte cap"), so this path really does need its own enforcement —
 # it just must not re-decide the value.
 _DEFAULT_MAX_BYTES = DEFAULT_MAX_BYTES
+# pgw#973 (§4.24). Per-CALL socket budgets, not kill decisions: neither ends
+# work that is advancing (gw#666's target), and without them a hub or an origin
+# that accepts a connection and then says nothing pins a request thread for the
+# life of the pod. `_DOWNLOAD_TIMEOUT_S` is the read budget handed to
+# `url_fetch`, which owns the byte cap; `_RESOLVE_TIMEOUT_S` bounds one small
+# JSON round trip to the hub and is deliberately the shorter of the two.
 _DOWNLOAD_TIMEOUT_S = 120
 _RESOLVE_TIMEOUT_S = 30
+# The resolver's answer is read into memory whole, so its size is the bound.
+# The threat is the hub answering with an unbounded body (compromised, wedged,
+# or simply an origin that is not the hub — this is an HTTP response, and
+# nothing about it is verified before it is read). 8 MiB is orders above any
+# real manifest; `+ 1` at the read sites is how over-cap is DETECTED rather
+# than silently truncated into a parse error.
 _MAX_RESOLVE_BODY = 8 << 20
+# Recursion bound on the `Asset` walk, whose input is endpoint/tenant-supplied
+# and may nest arbitrarily. Without it a hostile or looping manifest exhausts
+# the interpreter stack, which is a process death, not an exception.
 _MAX_WALK_DEPTH = 32
 # Streaming read buffer, not a bound — it refuses nothing.
 _CHUNK = 1 << 20

--- a/src/gen_worker/intent_registry.py
+++ b/src/gen_worker/intent_registry.py
@@ -13,11 +13,27 @@ from typing import Any, Awaitable, Callable, Iterable, Optional, TypeVar
 from .config.settings import BOOT_CONFIG_GENERATION_ABSENT
 from .pb import worker_scheduler_pb2 as pb
 
+# pgw#973 (§4.24). Both are retention bounds on hub-driven maps in a
+# long-lived worker process: the hub opens intents and the worker answers with
+# receipts, and neither side ever says "you may forget this one". Without a
+# bound the registry is a leak whose rate is set by hub traffic — a pod serving
+# for days accumulates every intent it has ever seen. Trimmed oldest-first, so
+# what is dropped is what no reconnect projection will be asked about.
 _MAX_INTENTS = 128
 _MAX_RECEIPTS = 32
+#: How long a caller waits for an intent's first report before proceeding
+#: without one. Not a kill: nothing is cancelled, the caller just stops
+#: blocking on a report that is a courtesy.
 _UNREPORTED_WAIT_TIMEOUT_S = 2.0
 # gw#640: fallback deadline for a WAITING state with no blocker and no retry
 # time. Mirrors the hub's shadow first-action budget (60s).
+#
+# pgw#973: NOT a gw#666 fixed-duration kill, and it was censused as one. It
+# ends nothing on this side — `deadline_at_unix_ms` is a required wire field
+# (the hub's shadow validator rejects a WAITING state carrying none of
+# blocker/retry/deadline), so this fills a protocol hole and the hub owns
+# whatever it decides at expiry. Changing it is a protocol change, not a
+# tuning; it belongs with the hub's budget or nowhere.
 _WAITING_DEADLINE_FALLBACK_MS = 60_000
 _ACTIVE_INTENT_STATES = {
     pb.LIFECYCLE_INTENT_STATUS_ACCEPTED,

--- a/src/gen_worker/media_transfer.py
+++ b/src/gen_worker/media_transfer.py
@@ -27,9 +27,13 @@ from .api.errors import ValidationError
 
 logger = logging.getLogger(__name__)
 
-#: Staging buffers above this stay pageable — pinned host memory is a shared,
-#: non-swappable resource (same cap rationale as w8a8_lora's adapter staging).
-_PIN_MAX_BYTES = 512 << 20
+#: Staging buffers above this stay pageable. THE bound on how much pinned host
+#: memory this worker may hold: pinned pages are non-swappable and shared with
+#: every other process on the pod, so an unbounded pin is a host-RAM leak the
+#: OOM killer resolves. Owned here (pgw#973 §4.24) and imported by
+#: `models.w8a8_lora`, which stages LoRA adapters under the same rule — the two
+#: used to declare `512 << 20` separately and could drift apart silently.
+PIN_MAX_BYTES = 512 << 20
 
 
 def _as_torch_cuda(chunk: Any) -> Optional[Any]:
@@ -77,7 +81,7 @@ class _PinnedSlot:
     def ensure(self, nbytes: int, torch: Any) -> None:
         if self.buf is not None and self.buf.numel() >= nbytes:
             return
-        pin = nbytes <= _PIN_MAX_BYTES
+        pin = nbytes <= PIN_MAX_BYTES
         try:
             self.buf = torch.empty(nbytes, dtype=torch.uint8, pin_memory=pin)
             self.pinned = pin

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -160,17 +160,30 @@ def _write_report(path: Path, report: MintReport) -> None:
 def cap_vram(device: int, cap_bytes: int) -> str:
     """Bound this process's device allocations to its reservation.
 
-    Returns a human note (empty when there is nothing to cap). The fraction is
-    computed from the card's REAL total, so the bound is the parent's byte
-    reservation and not a fraction anybody guessed.
+    Returns a human note, ALWAYS non-empty, so the caller frames it. The
+    fraction is computed from the card's REAL total, so the bound is the
+    parent's byte reservation and not a fraction anybody guessed.
+
+    pgw#973 (§4.24 item 4): every path that does NOT cap now says so. A mint
+    child sharing a card with the serving process runs uncapped whenever
+    `MintRequest.vram_cap_bytes` is 0 — which is the legitimate value for an
+    unprobeable card (`mint_budget.co_residency` reports `probed=False`) and
+    equally the value a budget that computed to nothing produces. Both used to
+    return "" here, the caller framed nothing, and the phase table recorded a
+    capped mint and an uncapped mint identically. "Uncapped" is a state to
+    STATE, not an absence to infer.
     """
     if cap_bytes <= 0:
-        return ""
+        note = (
+            "vram cap NOT applied: the request carries no cap "
+            "(vram_cap_bytes=0) — this child may allocate the whole card")
+        logger.warning("mint-child: %s", note)
+        return note
     try:
         import torch
 
         if not torch.cuda.is_available():
-            return ""
+            return "vram cap NOT applied: no CUDA in this process"
         # pgw#877 #6. `mint_process.child_env` pins CUDA_VISIBLE_DEVICES only
         # when `request.device >= 0`, so "the pin already chose for us" is
         # true for a named device and FALSE for -1 — and this used to cap
@@ -193,7 +206,8 @@ def cap_vram(device: int, cap_bytes: int) -> str:
         torch.cuda.set_device(dev)
         _free, total = torch.cuda.mem_get_info(dev)
         if total <= 0:
-            return ""
+            return (f"vram cap NOT applied: cuda:{dev} reports no total "
+                    f"memory, so there is no fraction to compute")
         fraction = min(1.0, max(0.01, cap_bytes / float(total)))
         torch.cuda.set_per_process_memory_fraction(fraction, dev)
         return (
@@ -201,7 +215,7 @@ def cap_vram(device: int, cap_bytes: int) -> str:
             f"({fraction:.3f} of {total / (1 << 30):.2f}GiB)")
     except Exception as exc:  # noqa: BLE001 — an uncappable child still mints
         logger.warning("mint-child: could not cap VRAM (%s)", exc)
-        return ""
+        return f"vram cap NOT applied: {type(exc).__name__}: {exc}"
 
 
 def select_specs(
@@ -727,9 +741,8 @@ def mint(request: MintRequest) -> MintReport:
 
     frame(phase="load", note="env seal")
     env_seal.establish()
-    note = cap_vram(request.device, request.vram_cap_bytes)
-    if note:
-        frame(phase="load", note=note)
+    # Always framed: `cap_vram` states the uncapped cases too (pgw#973).
+    frame(phase="load", note=cap_vram(request.device, request.vram_cap_bytes))
 
     if not cc.toolchain_present():
         raise MintChildRefused(

--- a/src/gen_worker/mint_process.py
+++ b/src/gen_worker/mint_process.py
@@ -123,6 +123,16 @@ _EVIDENCE_EPS = 0.05
 #: Bytes of the child's stderr kept for the failure report.
 _STDERR_TAIL_BYTES = 8192
 
+#: How long to wait for the CORPSE after `_terminate_group` has already signaled
+#: the child's process group. pgw#973 (§4.24 / gw#666): an explicitly EXEMPT
+#: fixed duration, on `executor._CANCEL_UNWIND_GRACE_S`'s model — the kill
+#: decision was made upstream on `_EVIDENCE_WINDOW_S`, which IS a progress
+#: signal, so nothing here can end work that was advancing. What it bounds is
+#: the parent's own control loop: a child ignoring SIGTERM must not hold the
+#: serving process's teardown open. Expiry is not a failure — the reap future
+#: outlives it (`shield`), and the exit status is simply not waited for.
+_REAP_GRACE_S = 15.0
+
 #: One retry, and only for the classes that can plausibly differ next time
 #: (a resource shortfall the tenant's peak caused, a crash). A deterministic
 #: refusal is terminal on the first attempt: re-running it burns a pod.
@@ -219,7 +229,13 @@ class MintRequest(msgspec.Struct, frozen=True, kw_only=True):
     #: See ``MintSlot``: the three views this replaced could disagree.
     slots: Dict[str, MintSlot] = {}
     device: int = -1     # CUDA ordinal; -1 = leave the child's default
-    vram_cap_bytes: int = 0   # 0 = uncapped (see mint_budget.co_residency)
+    #: The child's device ceiling in bytes. 0 = NO CAP, which is the honest
+    #: value for an unprobeable card (`mint_budget.co_residency` reports
+    #: `probed=False`) and is stated rather than inferred: `mint_child.cap_vram`
+    #: returns a "vram cap NOT applied" note the child frames, so an uncapped
+    #: mint is distinguishable from a capped one in the phase table (pgw#973
+    #: §4.24 item 4 — it used to return "" and record nothing at all).
+    vram_cap_bytes: int = 0
     #: pgw#848: where the child rewrites its live phase table, so a mint the
     #: parent KILLS still leaves its measurements behind. Empty = no snapshot.
     phases_snapshot: str = ""
@@ -691,7 +707,8 @@ async def run_mint(
                 killed_reason = ABANDONED
             await asyncio.to_thread(_terminate_group, proc.pid)
             with contextlib.suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(asyncio.shield(reap), timeout=15.0)
+                await asyncio.wait_for(
+                    asyncio.shield(reap), timeout=_REAP_GRACE_S)
     except asyncio.CancelledError:
         await asyncio.to_thread(_terminate_group, proc.pid)
         raise

--- a/src/gen_worker/models/execution_lane_gate.py
+++ b/src/gen_worker/models/execution_lane_gate.py
@@ -12,8 +12,10 @@ The gate closes that hole at the shared machinery level: each lane pipeline's
 attributes all preserved) to first pin the lane and promote it if demoted,
 LRU-swapping the idle sibling out. Alternating t2i/edit traffic on one worker
 becomes swap-per-alternation: degraded-but-correct, logged loudly with timing.
-When VRAM truly cannot fit the lane it queues briefly, then raises the
-executor-injected retryable error — never executes a cpu-resident lane.
+When VRAM truly cannot fit, the lane waits for as long as the card keeps
+returning memory (a silence window over free VRAM, gw#666 — never a wall
+budget), then raises the executor-injected retryable error. It never executes
+a cpu-resident lane.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Optional, Type
 
 from .. import activity as activity_mod
+from ..stall import SilenceWindow
 from .memory import get_available_vram_gb
 from .residency import Residency, Tier, _obj_offload_hooked
 
@@ -35,10 +38,19 @@ _GATED_FLAG = "_cozy_lane_gated"
 
 _GiB = 1024 ** 3
 
-# How long a call waits for VRAM headroom before failing retryable: the idle
-# sibling's demote is seconds; anything longer means a genuinely stuck card.
-_DEFAULT_WAIT_S = 45.0
+# pgw#973 (gw#666 / §4.24): a SILENCE window over free VRAM, not a wall budget.
+# This loop polls `get_available_vram_gb()` four times a second, so free VRAM
+# IS the progress signal — a sibling demoting a large pipeline returns bytes in
+# visible steps, and the old flat 45 s deadline gave up on a card that was
+# still handing memory back. It gives up only when the card has stopped
+# MOVING for the window: a genuinely stuck card looks identical either way, and
+# a slow-but-working demote no longer fails a request that was about to serve.
+_HEADROOM_SILENCE_WINDOW_S = 45.0
 _POLL_S = 0.25
+# Free-VRAM quantum for "something moved" (64 MiB). Coarser than allocator
+# jitter and far finer than any component demote, so noise cannot keep the
+# window alive and a real demote cannot fail to register.
+_HEADROOM_STEP_GB = 1.0 / 16.0
 
 
 def _cuda_available() -> bool:
@@ -74,7 +86,7 @@ class ExecutionLaneGate:
         residency: Residency,
         label: str = "",
         retry_exc: Type[Exception] = RuntimeError,
-        wait_s: float = _DEFAULT_WAIT_S,
+        wait_s: float = _HEADROOM_SILENCE_WINDOW_S,
         on_swap: Optional[Callable[[str, int], None]] = None,
         offload_fallback: Optional[Callable[[], bool]] = None,
     ) -> None:
@@ -82,6 +94,8 @@ class ExecutionLaneGate:
         self.residency = residency
         self.label = label or ref
         self.retry_exc = retry_exc
+        #: The SILENCE window over free VRAM (see the module constant), not a
+        #: total wait. A card that keeps returning memory is never given up on.
         self.wait_s = wait_s
         self.on_swap = on_swap  # (ref, promote_ms) — degraded-serve reporting
         # When promote truly cannot fit: arm a coherent offload rung instead
@@ -123,7 +137,7 @@ class ExecutionLaneGate:
             if tier is not Tier.RAM:
                 return
             t0 = time.monotonic()
-            deadline = t0 + self.wait_s
+            headroom = SilenceWindow(self.wait_s)
             while True:
                 if res.promote(self.ref):
                     ms = int((time.monotonic() - t0) * 1000)
@@ -140,7 +154,9 @@ class ExecutionLaneGate:
                         except Exception:
                             logger.exception("lane-swap callback failed")
                     return
-                if time.monotonic() >= deadline:
+                headroom.touch_if_changed(
+                    round(get_available_vram_gb() / _HEADROOM_STEP_GB))
+                if headroom.stalled():
                     break
                 time.sleep(_POLL_S)
             if self.offload_fallback is not None:
@@ -157,7 +173,9 @@ class ExecutionLaneGate:
                             activity_mod.KIND_SERVE_DEGRADE,
                             f"ref={self.ref} label={self.label} "
                             f"free_gb={get_available_vram_gb():.1f}: promote "
-                            f"cannot fit after {self.wait_s:.0f}s; serving "
+                            f"cannot fit and free VRAM stopped moving for "
+                            f"{self.wait_s:.0f}s (waited "
+                            f"{time.monotonic() - t0:.0f}s); serving "
                             "CPU-offloaded",
                             phase="lane_offload_engaged",
                         )
@@ -166,8 +184,9 @@ class ExecutionLaneGate:
                     logger.exception(
                         "offload fallback failed for %s", self.label)
             raise self.retry_exc(
-                f"lane {self.label} cannot promote to VRAM (waited "
-                f"{self.wait_s:.0f}s for headroom; free "
+                f"lane {self.label} cannot promote to VRAM (free VRAM "
+                f"stopped moving for {self.wait_s:.0f}s after "
+                f"{time.monotonic() - t0:.0f}s; free "
                 f"{get_available_vram_gb():.1f} GiB); retrying"
             )
 

--- a/src/gen_worker/models/ladder.py
+++ b/src/gen_worker/models/ladder.py
@@ -41,7 +41,15 @@ _BASE_TOKENS = ("", "bf16", "fp16", "fp32")
 
 @dataclass(frozen=True)
 class Placement:
-    """Arch requirements for one flavor. Empty fields = unconstrained."""
+    """Arch requirements for one flavor. Empty fields = unconstrained.
+
+    pgw#973 censused ``sm_min = 0`` as a §4.24 item-4 absence collapse and it is
+    NOT one: "unconstrained" is this class's STATED meaning for every empty
+    field (`sm_allowed=()` says the same thing), the placement is the flavor's
+    own declaration rather than an operator knob, and a missing floor cannot
+    admit anything ``sm_allowed`` and the engine list do not already admit.
+    Kept as filed, verdict recorded so it is not re-opened.
+    """
 
     precision_class: str
     sm_allowed: tuple[int, ...] = ()  # discrete allow-list (gpu_sm as int, e.g. 89, 120)

--- a/src/gen_worker/models/memory.py
+++ b/src/gen_worker/models/memory.py
@@ -193,6 +193,37 @@ def get_total_ram_gb() -> float:
     return probe_host_ram().total_gb
 
 
+# pgw#973 (§4.24): ONE owner for the host-RAM floor. `residency` and `staging`
+# each declared `_RAM_FLOOR_GB = 8.0` / `_RAM_FLOOR_FRACTION = 0.2` AND
+# re-derived the same min/max expression, with staging's comment promising it
+# was "kept numerically identical" — a promise nothing enforced. They cannot
+# import each other (`residency -> pinned_swap -> staging` already exists, so
+# the reverse edge closes a cycle); both already import this module.
+#
+# The threat (gw#407): a warm/pinned host tier that eats the host's working set
+# pushes it into reclaim-thrash, and a thrashing host stalls the whole process
+# INCLUDING the gRPC keepalive acks — the hub then disconnects the worker,
+# which is the livelock. Nothing else prevents it: the tiers allocate against
+# free RAM, and free RAM is exactly what a page cache makes look available.
+_RAM_FLOOR_GB = 8.0
+#: Small hosts (dev boxes) would be gated out entirely by a flat 8 GiB, so the
+#: floor is adaptive below 40 GiB total.
+_RAM_FLOOR_FRACTION = 0.2
+
+
+def effective_ram_floor_gb(total_gb: Optional[float] = None) -> float:
+    """Host RAM this process must leave alone, in GiB.
+
+    ``total_gb`` is the caller's already-resolved host total; omit it to read
+    one here. Callers pass their own so a per-group RAM share (procsplit) or a
+    test's substitution is honoured by the ONE policy rather than by a copy.
+    """
+    total = get_total_ram_gb() if total_gb is None else float(total_gb)
+    if total <= 0:
+        return _RAM_FLOOR_GB
+    return min(_RAM_FLOOR_GB, max(1.0, total * _RAM_FLOOR_FRACTION))
+
+
 # ---------------------------------------------------------------------------
 # Cgroup-aware host-RAM probes (th#721): RunPod GPU pods land on lottery-RAM
 # hosts and the container is cgroup-limited below /proc/meminfo — psutil alone
@@ -1447,6 +1478,7 @@ __all__ = [
     "GPU_VRAM_OVERHEAD_GB",
     "effective_vram_requirement_gb",
     "get_available_ram_gb",
+    "effective_ram_floor_gb",
     "get_total_ram_gb",
     "aflush_memory",
     "flush_memory",

--- a/src/gen_worker/models/residency.py
+++ b/src/gen_worker/models/residency.py
@@ -33,6 +33,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optio
 from .. import activity as activity_mod
 from .memory import (
     device_mismatches,
+    effective_ram_floor_gb,
     estimate_cuda_resident_gb,
     estimate_pipeline_size_gb,
     flush_memory,
@@ -49,20 +50,11 @@ logger = logging.getLogger(__name__)
 _GiB = 1024 ** 3
 # Free-VRAM slack preserved beyond the requested headroom (activations).
 _VRAM_MARGIN_BYTES = 2 * _GiB
-# Host-RAM floor below which the warm RAM tier is refused (don't push the
-# host into reclaim-thrash: a thrashing host stalls the whole process incl.
-# gRPC keepalive acks -> hub disconnect livelock, gw#407); demote() then
-# fails and the owner tears down instead. Small hosts use an adaptive floor
-# (a fraction of total RAM) so dev boxes are not gated out entirely.
-_RAM_FLOOR_GB = 8.0
-_RAM_FLOOR_FRACTION = 0.2
-
-
+# Host-RAM floor below which the warm RAM tier is refused; demote() then fails
+# and the owner tears down instead. The floor and its rationale are owned by
+# `memory.effective_ram_floor_gb` (pgw#973 §4.24).
 def _effective_ram_floor_gb() -> float:
-    total = get_total_ram_gb()
-    if total <= 0:
-        return _RAM_FLOOR_GB
-    return min(_RAM_FLOOR_GB, max(1.0, total * _RAM_FLOOR_FRACTION))
+    return effective_ram_floor_gb(get_total_ram_gb())
 
 # Residency event states (mirrors the wire ModelEvent vocabulary).
 ON_DISK = "on_disk"

--- a/src/gen_worker/models/staging.py
+++ b/src/gen_worker/models/staging.py
@@ -33,17 +33,16 @@ import threading
 import weakref
 from typing import Any, Callable, Iterator, Optional
 
-from .memory import get_available_ram_gb, get_total_ram_gb
+from .memory import (
+    effective_ram_floor_gb,
+    get_available_ram_gb,
+    get_total_ram_gb,
+)
 
 logger = logging.getLogger(__name__)
 
 _GiB = 1024 ** 3
 
-# Mirrors residency's host-RAM floor policy (gw#407): the warm/pinned tiers
-# must never eat the host's working set. Kept numerically identical to
-# residency._RAM_FLOOR_GB / _RAM_FLOOR_FRACTION.
-_RAM_FLOOR_GB = 8.0
-_RAM_FLOOR_FRACTION = 0.2
 # Pinned memory is the harshest host allocation (unswappable): never let it
 # claim more than half of physical RAM even on an idle host.
 _PINNED_TOTAL_FRACTION = 0.5
@@ -63,10 +62,10 @@ def _current_group() -> int:
 
 
 def _floor_bytes() -> int:
-    total = get_total_ram_gb()
-    if total <= 0:
-        return int(_RAM_FLOOR_GB * _GiB)
-    return int(min(_RAM_FLOOR_GB, max(1.0, total * _RAM_FLOOR_FRACTION)) * _GiB)
+    """The host-RAM floor the warm/pinned tiers must leave alone, in bytes.
+    One owner (`memory.effective_ram_floor_gb`, pgw#973 §4.24) — this used to
+    restate residency's two constants AND its derivation."""
+    return int(effective_ram_floor_gb(get_total_ram_gb()) * _GiB)
 
 
 class PinnedPool:

--- a/src/gen_worker/models/w8a8_lora.py
+++ b/src/gen_worker/models/w8a8_lora.py
@@ -56,6 +56,10 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 from .. import activity as activity_mod
 from ..component_vocab import denoiser_components
 from ..api.errors import RefCompatibilitySurprise, ValidationError
+# Flat staging buffers above this size stay pageable — pinned host memory
+# is shared and non-swappable, and the cache holds up to _MAPCACHE_MAX.
+# ONE owner for the worker's whole pinned budget (pgw#973 §4.24).
+from ..media_transfer import PIN_MAX_BYTES as _PIN_MAX_BYTES
 from . import adapter_fidelity
 from .fp8_storage import structural_base
 from .w8a8 import fp8_scaled_linear_class
@@ -434,11 +438,6 @@ def _validated_pair(path: str, mod: Any, a: Any, b: Any, *, ref: str) -> Tuple[A
             int(b.shape[0]) != mod.out_features or int(b.shape[1]) != rank):
         raise bad(f"want down [r, {mod.in_features}] / up [{mod.out_features}, r]")
     return a, b
-
-
-# Flat staging buffers above this size stay pageable — pinned host memory is
-# a shared, non-swappable resource and the cache holds up to _MAPCACHE_MAX.
-_PIN_MAX_BYTES = 512 << 20
 
 
 def _stage_adapter(mapped: Dict[str, Tuple[Any, Any, float]]) -> Dict[str, Any]:

--- a/src/gen_worker/presigned_upload.py
+++ b/src/gen_worker/presigned_upload.py
@@ -70,8 +70,21 @@ from .stall import SilenceWindow
 
 logger = logging.getLogger(__name__)
 
+# pgw#973 (§4.24), completing wave 2's KEEP-BUT-DOCUMENT verdict. These are
+# per-CALL socket budgets on the two hub round trips, not give-up decisions:
+# the give-up is `_COMPLETE_SILENCE_WINDOW_S` below, over the hub's own
+# answers (gw#666). Without them a hub that accepts a connection and never
+# replies wedges a publish forever. `/complete` gets ten times `/create`'s
+# budget because it VERIFIES the object synchronously (streams it back from R2
+# and hashes it) while `/create` only mints presigns — and it is the DERIVATION
+# BASIS for the silence window, which is two full finalize-length attempts.
+# Deleting it deletes that basis.
 _FINALIZE_TIMEOUT_S = 600
 _CREATE_TIMEOUT_S = 60
+#: Attempts at `/complete` for a NON-definite answer only (a definite hub
+#: refusal is terminal on the first). Bounded because every attempt makes the
+#: hub re-verify a multi-GB object; the 409 in-progress case is polled, not
+#: retried, so this budget is not spent on the common slow path.
 _FINALIZE_RETRY_ATTEMPTS = 5
 _FINALIZE_RETRY_BACKOFF_S = 0.5
 

--- a/src/gen_worker/procsplit/parent.py
+++ b/src/gen_worker/procsplit/parent.py
@@ -141,12 +141,33 @@ _EVIDENCE_EPS = 0.05
 # out of `/proc/<ppid>/environ` (WORKER_JWT) or `/proc/1/environ` (the RunPod
 # key). Both, and the strip, are guarded by test_pod_privilege_isolation_pgw858.
 _CHILD_FORBIDDEN_ENVS = ("WORKER_JWT", "RUNPOD_API_KEY", "PUBLIC_KEY")
-# A mediated hub call must not hold the parent's control loop open forever.
-_ACTION_HARD_TIMEOUT_S = 120.0
 _ACTION_REFUSAL_REPORT_MIN_INTERVAL_S = 300.0
+# A mediated hub call runs on a parent thread-pool slot, and the CHILD supplies
+# the request's `timeout` field — so without a ceiling tenant code pins slots
+# for as long as it likes and the mediation surface dies for everything else.
+# `HubAction.timeout_s` in the allowlist IS that ceiling (`_perform_action`
+# min()s the child's number against it), which is why pgw#973 deleted the
+# separate `_ACTION_HARD_TIMEOUT_S = 120.0` that sat beside it: every declared
+# action is 30 s or 60 s, so a third term 60 s above the highest declared value
+# could only ever reject nothing (§4.24 item 1 — say which bound is
+# load-bearing and delete the rest). The count axis is bounded here:
 _MAX_CONCURRENT_ACTIONS = 16
+# pgw#973 (§4.24 item 4): the parent beat's cadence when NOBODY declared one —
+# `beat_interval_s=0.0` means "adopt the child's" and every child Hello may
+# carry `heartbeat_interval_ms=0`. The fallback used to be a bare `10.0` at the
+# loop, i.e. a real bound reachable only by reading the loop body. It is the
+# hub's own liveness expectation (a worker silent for a multiple of this is
+# called dead), so it is a DECLARED default, not a guess.
+_BEAT_INTERVAL_FALLBACK_S = 10.0
 # The host canary is a real benchmark (memcpy/D2H/CPU); on a cold pod with a
-# large card it is seconds, not milliseconds. Generous, and bounded.
+# large card it is seconds, not milliseconds.
+#
+# gw#666 exemption, stated rather than assumed (§4.24): the measure subprocess
+# reports through `communicate()` — one write, at the end — so it emits NO
+# progress signal a SilenceWindow could key on, and giving up here KILLS NO
+# WORK: the Hello ships without parent-measured resources and the pod serves.
+# A progress signal would have to be invented in the canary's own protocol,
+# which is a change to it and not to this bound.
 _MEASURE_TIMEOUT_S = 180.0
 _MEASURE_BEFORE_SPAWN_S = 60.0
 _ATTESTATION_REPORT_MIN_INTERVAL_S = 300.0
@@ -2183,8 +2204,10 @@ class ParentControl:
         token = self.transport.current_worker_jwt
         if not token:
             raise actions.ActionRefused(f"{action.name}: this pod holds no worker JWT")
+        # The child's number is advisory and may only ever LOWER the call's
+        # budget; the allowlist's own `timeout_s` is the ceiling.
         timeout = min(float(req.get("timeout") or action.timeout_s),
-                      action.timeout_s, _ACTION_HARD_TIMEOUT_S)
+                      action.timeout_s)
         status, text = await asyncio.to_thread(
             _http_call, action.method, base + str(req.get("path") or ""),
             token, query, body, timeout,
@@ -2323,7 +2346,9 @@ class ParentControl:
         made by the control plane that nothing tenant-side can starve.
         """
         while not self._stopping.is_set():
-            interval = self._beat_interval if self._beat_interval > 0 else 10.0
+            interval = (
+                self._beat_interval if self._beat_interval > 0
+                else _BEAT_INTERVAL_FALLBACK_S)
             await self._sleep_or_stop(max(0.25, interval / 2.0))
             if self._stopping.is_set() or self._child_exited_clean:
                 return

--- a/src/gen_worker/receipts.py
+++ b/src/gen_worker/receipts.py
@@ -91,6 +91,13 @@ JWKS_PATH = "/api/v1/artifacts/.well-known/jwks.json"
 RECEIPT_PATH = "/v1/worker/cells/receipt"
 REVOCATIONS_PATH = "/v1/worker/cells/revocations"
 
+# pgw#973 (§4.24): per-CALL socket budget on the three small control-plane
+# round trips this module makes (JWKS, receipt, revocations). Not a gw#666
+# kill — none of them can be "making progress" in any observable sense, and
+# expiry ends no work — but without it a hub that accepts a connection and
+# says nothing wedges the arm gate, which every cell adoption waits behind.
+# Shorter than `callout`'s 60 s because these are constant-size answers,
+# not a child request the hub may legitimately take time to admit.
 _HTTP_TIMEOUT_S = 30
 
 

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -233,11 +233,6 @@ logger = logging.getLogger(__name__)
 # call sites (worker.py, tests) keep working.
 from ._helpers import (
     _MAX_OUTPUT_FILE_BYTES,
-    _FILE_API_HTTP_TIMEOUT_S,
-    _FILE_API_STREAM_ABORT_TIMEOUT_S,
-    _FILE_API_STREAM_CHUNK_TIMEOUT_S,
-    _FILE_API_STREAM_FINALIZE_TIMEOUT_S,
-    _FILE_API_STREAM_REPLAY_TIMEOUT_S,
     _decode_unverified_jwt_claims,
     _enforce_output_file_size_limit,
     _infer_mime_type,

--- a/src/gen_worker/request_context/_helpers.py
+++ b/src/gen_worker/request_context/_helpers.py
@@ -25,11 +25,6 @@ logger = logging.getLogger(__name__)
 
 _PUBLIC_TAG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
 _MAX_OUTPUT_FILE_BYTES = 20 * 1024 * 1024 * 1024  # 20 GiB hard cap per file.
-_FILE_API_HTTP_TIMEOUT_S = 60
-_FILE_API_STREAM_CHUNK_TIMEOUT_S = 120
-_FILE_API_STREAM_FINALIZE_TIMEOUT_S = 600
-_FILE_API_STREAM_REPLAY_TIMEOUT_S = 600
-_FILE_API_STREAM_ABORT_TIMEOUT_S = 15
 
 
 def _infer_mime_type(ref: str, head: bytes) -> str:

--- a/src/gen_worker/s3_transfer.py
+++ b/src/gen_worker/s3_transfer.py
@@ -18,6 +18,16 @@ from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 import boto3
 
+# pgw#973 (§4.24). The three constants below are ONE bound with three terms:
+# `_SDK_UPLOAD_FILE_BUDGET x _MULTIPART_MAX_WORKERS x _MULTIPART_CHUNK_BYTES`
+# is the ceiling on bytes boto3 holds in this process's heap at once — 2 x 10 x
+# 64 MiB = 1.25 GiB. The threat is the SERVING process, not the hub: an upload
+# runs beside a resident pipeline on a pod sized for the model, so unbounded
+# in-flight parts meet the OOM killer and take the tenant with them. Nothing
+# else bounds it — boto3's `TransferConfig` has no global memory budget and
+# `max_concurrency` is per-call, so concurrent `upload_file` calls multiply.
+# The chunk size additionally sets the largest object this path can move at
+# all: S3 allows 10,000 parts, so 64 MiB x 10,000 = 640 GiB.
 _MULTIPART_CHUNK_BYTES = 64 * 1024 * 1024
 _MULTIPART_MAX_WORKERS = 10
 # pgw#1005 A: each OUTER attempt re-uploads every part from zero, on top of
@@ -26,7 +36,18 @@ _MULTIPART_MAX_WORKERS = 10
 # attempts still cover the case botocore cannot (a client whose credentials or
 # connection pool are the problem) without multiplying the transfer budget.
 _SDK_TRANSFER_ATTEMPTS = 2
+#: Concurrent SDK uploads from this process (the file axis of the ceiling
+#: above). Two, because a worker's outbound work is a publish, not a fan-out:
+#: the second slot exists so a small sibling artifact is not serialized behind
+#: a multi-GB one, and a third would buy throughput the uplink does not have
+#: at the cost of another 640 MiB of in-flight parts.
 _SDK_UPLOAD_FILE_BUDGET = 2
+#: The one pause between the two outer attempts. Was `min(2**(attempt-1), 4)`,
+#: an exponential ramp with a cap — dead arithmetic since pgw#1005 A cut
+#: `_SDK_TRANSFER_ATTEMPTS` to 2, because the loop breaks before the second
+#: sleep, so the expression could only ever evaluate to 1.0 (pgw#973 §4.24:
+#: a bound that cannot bind is not a bound).
+_SDK_RETRY_PAUSE_S = 1.0
 _sdk_upload_slots = threading.BoundedSemaphore(_SDK_UPLOAD_FILE_BUDGET)
 
 
@@ -195,7 +216,7 @@ def upload_file_with_grant(
             last_exc = exc
             if attempt >= _SDK_TRANSFER_ATTEMPTS:
                 break
-            time.sleep(min(2 ** (attempt - 1), 4))
+            time.sleep(_SDK_RETRY_PAUSE_S)
         finally:
             close = getattr(client, "close", None)
             if callable(close):
@@ -328,6 +349,13 @@ def _s3_client(grant: S3TransferGrant) -> Any:
         aws_session_token=grant.session_token or None,
         config=Config(
             signature_version="s3v4",
+            # botocore's own PER-PART retry budget: a multipart upload of a
+            # multi-GB artifact over a residential/pod uplink loses individual
+            # parts routinely, and re-sending one part is the cheap recovery
+            # this exists for. The outer loop above cannot substitute — it
+            # restarts the WHOLE object. 10 x `_SDK_TRANSFER_ATTEMPTS` (2) is
+            # the worst case per part, deliberately re-derived by pgw#1005 A
+            # after 10 x 4 = 40.
             retries={"mode": "standard", "max_attempts": 10},
             request_checksum_calculation="when_required",
             response_checksum_validation="when_required",

--- a/src/gen_worker/transport.py
+++ b/src/gen_worker/transport.py
@@ -36,9 +36,9 @@ pgw#803 — THE RECONNECT EPISODE IS A HUB ROW. Every duration in this module is
 retry PACING or an RPC deadline, never a kill decision, and none of them can
 produce th#1333's 15m36s reconnect gap: the backoff is `uniform(0, min(30 s,
 2**attempt))` with `attempt` reset after `_BACKOFF_RESET_AFTER_S` of
-connectedness, a dead peer is called by h2 keepalive within 20 s +
-`KEEPALIVE_TIMEOUT_S`, and a hung dial is cut at `_HELLO_ACK_TIMEOUT_S`. So the
-gap was time the reconnect loop was NOT RUNNING — and nothing recorded that,
+connectedness, a dead peer is called by h2 keepalive within
+`KEEPALIVE_INTERVAL_S` + `KEEPALIVE_TIMEOUT_S`, and a hung dial is cut at
+`_HELLO_ACK_TIMEOUT_S`. So the gap was time the reconnect loop was NOT RUNNING — and nothing recorded that,
 because the loop's narration was `logger.info` on RunPod stdout, which is
 unreadable (gw#640). Each episode now emits two evidence rows (`dropped`, then
 `reconnected`) partitioning the gap into scheduled backoff, slept wall time,
@@ -200,6 +200,16 @@ def _msg_kind(msg: pb.WorkerMessage) -> str:
 #: derives its bound from this rather than inventing one.
 KEEPALIVE_TIMEOUT_S = 10.0
 
+#: How often the channel pings an idle stream. pgw#973 (§4.24): the asymmetry
+#: this fixes is that the keepalive TIMEOUT was a named constant with reach
+#: while the INTERVAL beside it was a bare `20000` inside the options list —
+#: two halves of one liveness bound, only one of them findable. Together they
+#: are the worker's detection budget for a peer that has stopped reading:
+#: interval + timeout = 30 s, and everything downstream (the reconnect
+#: accounting at `RECONNECT_EVENT`, the send-loop wait) derives from that sum
+#: rather than restating either half.
+KEEPALIVE_INTERVAL_S = 20.0
+
 #: How long to wait for the peer to end a half-closed call before giving up on
 #: a graceful close. Unchanged value, named so both close paths share it.
 _PEER_CLOSE_WAIT_S = 5.0
@@ -215,7 +225,7 @@ _PEER_CLOSE_WAIT_S = 5.0
 #: is `uniform(0, min(30s, 2**attempt))` (full jitter, ceiling
 #: :attr:`Transport._backoff_cap` = 30 s), `attempt` resets to 0 after
 #: :data:`_BACKOFF_RESET_AFTER_S` of connectedness, a dead peer is called by
-#: h2 keepalive within `keepalive_time_ms` (20 s) + :data:`KEEPALIVE_TIMEOUT_S`,
+#: h2 keepalive within :data:`KEEPALIVE_INTERVAL_S` + :data:`KEEPALIVE_TIMEOUT_S`,
 #: and a dial that hangs is cut at :data:`_HELLO_ACK_TIMEOUT_S`. A 936 s gap is
 #: therefore time the reconnect loop WAS NOT RUNNING — a starved event loop, a
 #: frozen process, a drop the socket never surfaced — and the fix for that class
@@ -332,12 +342,30 @@ _SHED_KEY = ("shed",)
 #: between a duplicate and a hole, and a hole is not a choice.
 RESHIP_WINDOW = 256
 
+#: Largest single gRPC message, either direction. See `_channel_options`.
+_MAX_MESSAGE_BYTES = 64 * 1024 * 1024
+
+#: Outbound queue depth. Bounds the pod's send-side memory when the hub stops
+#: reading: progress is dropped, events block their producer, results are never
+#: shed. One number, stated once, so `Transport` and `worker` cannot drift.
+DEFAULT_QUEUE_MAXSIZE = 1024
+
 
 class SendQueue:
     """Bounded outbound queue with results-never-dropped semantics."""
 
-    def __init__(self, maxsize: int = 1024, evidence_max: int = EVIDENCE_MAX) -> None:
-        self._maxsize = maxsize
+    def __init__(
+        self, maxsize: int = DEFAULT_QUEUE_MAXSIZE, evidence_max: int = EVIDENCE_MAX,
+    ) -> None:
+        # pgw#973 §4.24 item 4: `maxsize <= 0` used to reach the enqueue path's
+        # `while self._maxsize > 0 and ...` and delete the bound outright — an
+        # unbounded outbound queue in a pod whose producer (progress, events)
+        # never blocks, i.e. the pod OOMs instead of shedding. `maxsize` is a
+        # public `Transport`/`worker` parameter, so that value is one caller
+        # away. Absence is the stated default; a stated non-positive is refused.
+        if int(maxsize) <= 0:
+            raise ValueError("maxsize must be positive")
+        self._maxsize = int(maxsize)
         # pgw#869: the durable evidence lane. Ordered (dict preserves insertion
         # order), so replay is FIFO. A coalescible beat REPLACES its slot in
         # place, which keeps a phase's beat where the phase began rather than
@@ -901,7 +929,7 @@ class Transport:
         settings: Settings,
         handlers: Any,
         *,
-        queue_maxsize: int = 1024,
+        queue_maxsize: int = DEFAULT_QUEUE_MAXSIZE,
         backoff_base_s: float = 1.0,
         backoff_cap_s: float = 30.0,
     ) -> None:
@@ -990,12 +1018,22 @@ class Transport:
 
     def _channel_options(self) -> List[Tuple[str, int]]:
         return [
-            ("grpc.keepalive_time_ms", 20000),
+            ("grpc.keepalive_time_ms", int(KEEPALIVE_INTERVAL_S * 1000)),
             ("grpc.keepalive_timeout_ms", int(KEEPALIVE_TIMEOUT_S * 1000)),
             ("grpc.keepalive_permit_without_calls", 1),
             ("grpc.http2.max_pings_without_data", 0),
-            ("grpc.max_send_message_length", 64 * 1024 * 1024),
-            ("grpc.max_receive_message_length", 64 * 1024 * 1024),
+            # pgw#973 (§4.24): the frame cap on ONE WorkerMessage, both
+            # directions. grpc-python's own default is 4 MiB receive, which
+            # this raises — the bound that matters is the one that must not be
+            # ABSENT. Nothing else bounds a single message: the queue caps the
+            # COUNT in flight (`DEFAULT_QUEUE_MAXSIZE`), never the size of one,
+            # and a peer sending an unbounded frame is a heap the worker cannot
+            # refuse otherwise. Generous relative to real traffic (control
+            # messages and metadata; artifact bytes travel over HTTP to the
+            # CAS, never on this stream) precisely so it never binds on
+            # legitimate traffic and only ever catches a runaway.
+            ("grpc.max_send_message_length", _MAX_MESSAGE_BYTES),
+            ("grpc.max_receive_message_length", _MAX_MESSAGE_BYTES),
         ]
 
     def _make_channel(self, target: str, use_tls: bool) -> grpc.aio.Channel:

--- a/src/gen_worker/worker.py
+++ b/src/gen_worker/worker.py
@@ -18,7 +18,11 @@ from .lifecycle import Lifecycle
 from .pb import worker_scheduler_pb2 as pb
 from .registry import collect_endpoints
 from .topology import ExecutionTopology, delivered_topology
-from .transport import FatalTransportError, Transport
+from .transport import (
+    DEFAULT_QUEUE_MAXSIZE as _DEFAULT_QUEUE_MAXSIZE,
+    FatalTransportError,
+    Transport,
+)
 from .host_move_guard import install as _install_host_move_guard
 from .procsplit import is_compute_child
 
@@ -95,7 +99,7 @@ class Worker:
         manifest: Optional[Dict[str, Any]] = None,
         gpu_slots: Optional[int] = None,
         topology: Optional["ExecutionTopology"] = None,
-        queue_maxsize: int = 1024,
+        queue_maxsize: int = _DEFAULT_QUEUE_MAXSIZE,
         backoff_base_s: float = 1.0,
         backoff_cap_s: float = 30.0,
     ) -> None:

--- a/tests/test_limits_census_wave3_pgw973.py
+++ b/tests/test_limits_census_wave3_pgw973.py
@@ -15,7 +15,6 @@ Three shapes are proven here, all on the real code paths:
 from __future__ import annotations
 
 import os
-import time
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -218,11 +217,14 @@ def test_a_card_that_keeps_returning_memory_is_never_given_up_on(
         ref="lane", residency=res, wait_s=0.05,
         retry_exc=RuntimeError)     # type: ignore[arg-type]
 
-    started = time.monotonic()
     with gate.ensure_resident():
         pass
     assert res.attempts == 40
-    assert time.monotonic() - started > 0.05, (
+    # The property, not the runner's speed (pgw#795): at the loop's DECLARED
+    # cadence the window covers only a handful of polls, and the promote took
+    # far more — so a wall budget would have fired here. No clock is read.
+    polls_the_window_could_cover = gate.wait_s / gated._POLL_S
+    assert res.attempts > polls_the_window_could_cover, (
         "the test did not actually outlive the window it is testing"
     )
 

--- a/tests/test_limits_census_wave3_pgw973.py
+++ b/tests/test_limits_census_wave3_pgw973.py
@@ -1,0 +1,402 @@
+"""pgw#973 wave 3 — §4.24 dispositions that changed behaviour.
+
+Three shapes are proven here, all on the real code paths:
+
+1. **Absence must be explicit** (§4.24 item 4). A limit that is not stated may
+   become a stated default or a refusal; it may never become "unlimited", and
+   it may certainly never INVERT into a purge.
+2. **Nothing that can end real work keys on a wall clock** (gw#666). The lane
+   gate polls free VRAM four times a second — free VRAM IS the progress
+   signal — and used to give up on a flat 45 s deadline anyway.
+3. **A duplicated bound has one owner.** Four verbatim pairs collapse; the
+   fifth is deliberately NOT collapsed and says why.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. aot_resume — TWO absence collapses in one expression, one of them an
+#    inversion that DELETED the corpus it was supposed to bound.
+# ---------------------------------------------------------------------------
+
+
+def _area(tmp_path: Path, *names: str, size: int = 4096) -> List[Path]:
+    """A real resume area on disk: one directory per scope with real bytes."""
+    area = tmp_path / ".mint-resume"
+    made: List[Path] = []
+    for i, name in enumerate(names):
+        scope = area / name
+        scope.mkdir(parents=True)
+        (scope / "blob.bin").write_bytes(b"\0" * size)
+        # Distinct mtimes so "oldest first" is well-defined.
+        os.utime(scope, (1_700_000_000 + i, 1_700_000_000 + i))
+        made.append(scope)
+    return made
+
+
+def test_an_env_zero_no_longer_purges_every_banked_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE INVERSION. `cap = int(max_bytes or os.environ.get(ENV) or DEFAULT)`
+    read the env as the string ``"0"``, which is TRUTHY — so
+    ``GEN_WORKER_MINT_RESUME_MAX_BYTES=0``, the spelling an operator would
+    reach for to mean "no cap", produced ``cap = 0`` and the sweep then removed
+    every scope except ``keep``. A capacity bound turned into a delete-all.
+    """
+    from gen_worker import aot_resume
+
+    keep, other_a, other_b = _area(tmp_path, "keep", "old-a", "old-b")
+    monkeypatch.setenv(aot_resume.ENV_MAX_BYTES, "0")
+
+    with pytest.raises(ValueError) as exc:
+        aot_resume.sweep(keep)
+    assert aot_resume.ENV_MAX_BYTES in str(exc.value)
+
+    # The corpus is intact — which is the whole point. Under the old
+    # expression this assertion fails with both siblings deleted.
+    assert other_a.exists() and other_b.exists() and keep.exists()
+
+
+def test_a_caller_computed_zero_is_refused_not_silently_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second collapse in the same expression, in the OPPOSITE direction:
+    a caller passing ``max_bytes=0`` fell through to the 4 GiB default, so a
+    budget that computed to nothing silently got the module's own number."""
+    from gen_worker import aot_resume
+
+    monkeypatch.delenv(aot_resume.ENV_MAX_BYTES, raising=False)
+    with pytest.raises(ValueError, match="max_bytes must be positive"):
+        aot_resume.resume_area_cap_bytes(0)
+    with pytest.raises(ValueError, match="max_bytes must be positive"):
+        aot_resume.resume_area_cap_bytes(-1)
+    # Absence — and ONLY absence — takes the stated default.
+    assert aot_resume.resume_area_cap_bytes(None) == aot_resume.DEFAULT_MAX_BYTES
+    assert aot_resume.resume_area_cap_bytes(1024) == 1024
+
+
+def test_a_malformed_env_names_itself_instead_of_raising_bare(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gen_worker import aot_resume
+
+    monkeypatch.setenv(aot_resume.ENV_MAX_BYTES, "4GiB")
+    with pytest.raises(ValueError, match="not an integer byte count"):
+        aot_resume.resume_area_cap_bytes()
+    monkeypatch.setenv(aot_resume.ENV_MAX_BYTES, "-5")
+    with pytest.raises(ValueError, match="must be positive"):
+        aot_resume.resume_area_cap_bytes()
+
+
+def test_the_cap_still_sweeps_when_it_is_stated(tmp_path: Path) -> None:
+    """The bound is not merely safe — it still does its job, oldest first."""
+    from gen_worker import aot_resume
+
+    # `_area` stamps ascending mtimes, so `old-a` is the oldest non-keep.
+    keep, old_a, old_b = _area(tmp_path, "old-a", "old-b", "keep", size=4096)
+    dropped = aot_resume.sweep(keep, max_bytes=9000)   # room for two scopes
+    assert dropped == 1
+    assert keep.exists() and old_b.exists() and not old_a.exists(), (
+        "the sweep evicted the NEWEST abandoned scope — the one most likely "
+        "to be resumed next — instead of the oldest"
+    )
+
+
+def test_a_bad_env_disables_the_bank_rather_than_failing_the_mint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`open_bank` never fails a mint for a cache — the refusal surfaces as a
+    warning and no bank, not as a dead mint."""
+    from gen_worker import aot_resume
+
+    monkeypatch.setenv(aot_resume.ENV_MAX_BYTES, "0")
+    (keep,) = _area(tmp_path, "keep")
+    assert aot_resume.open_bank(str(keep)) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. transport.SendQueue — `maxsize <= 0` deleted the bound outright
+# ---------------------------------------------------------------------------
+
+
+def test_an_unbounded_send_queue_is_refused_at_construction() -> None:
+    """`while self._maxsize > 0 and ...` in the enqueue path meant a queue
+    built with 0 shed nothing and blocked nobody: an unbounded outbound buffer
+    in a pod whose progress/event producers never wait. `maxsize` is a public
+    `Transport(...)` / `worker(...)` parameter, so it was one caller away."""
+    from gen_worker.transport import DEFAULT_QUEUE_MAXSIZE, SendQueue
+
+    with pytest.raises(ValueError, match="maxsize must be positive"):
+        SendQueue(maxsize=0)
+    with pytest.raises(ValueError, match="maxsize must be positive"):
+        SendQueue(maxsize=-1)
+    assert DEFAULT_QUEUE_MAXSIZE > 0
+    assert SendQueue()._maxsize == DEFAULT_QUEUE_MAXSIZE
+
+
+def test_transport_and_worker_share_one_declared_queue_depth() -> None:
+    """The default was written `1024` in three places. One declaration now."""
+    import inspect
+
+    from gen_worker import transport, worker
+
+    depth = transport.DEFAULT_QUEUE_MAXSIZE
+    assert inspect.signature(
+        transport.Transport.__init__).parameters["queue_maxsize"].default == depth
+    assert inspect.signature(
+        worker.Worker.__init__).parameters["queue_maxsize"].default == depth
+
+
+# ---------------------------------------------------------------------------
+# 3. execution_lane_gate — a flat deadline over a live progress signal
+# ---------------------------------------------------------------------------
+
+
+class _FakeResidency:
+    """Enough of `Residency` for the gate: a demoted lane that promotes only
+    after N attempts. Nothing is mocked about the gate itself."""
+
+    def __init__(self, promote_after: int) -> None:
+        self._left = promote_after
+        self.attempts = 0
+
+    def executing(self, ref: str) -> Any:
+        from contextlib import nullcontext
+
+        return nullcontext()
+
+    def movable(self, ref: str) -> bool:
+        return True
+
+    def obj(self, ref: str) -> Any:
+        return None
+
+    def tier(self, ref: str) -> Any:
+        from gen_worker.models.residency import Tier
+
+        return Tier.RAM
+
+    def promote(self, ref: str) -> bool:
+        self.attempts += 1
+        self._left -= 1
+        return self._left <= 0
+
+
+@pytest.fixture()
+def gated(monkeypatch: pytest.MonkeyPatch) -> Any:
+    from gen_worker.models import execution_lane_gate as gate_mod
+
+    monkeypatch.setattr(gate_mod, "_cuda_available", lambda: True)
+    monkeypatch.setattr(gate_mod, "_POLL_S", 0.01)
+    return gate_mod
+
+
+def test_a_card_that_keeps_returning_memory_is_never_given_up_on(
+    gated: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED against the flat deadline: the window here is 0.05 s and the promote
+    takes ~0.4 s of polling, so a wall budget fails the request. Free VRAM
+    climbs the whole time — the sibling IS demoting — so the silence window
+    never fires and the lane serves."""
+    free = [10.0]
+
+    def climbing() -> float:
+        free[0] += 1.0          # far above the 64 MiB quantum
+        return free[0]
+
+    monkeypatch.setattr(gated, "get_available_vram_gb", climbing)
+    res = _FakeResidency(promote_after=40)
+    gate = gated.ExecutionLaneGate(
+        ref="lane", residency=res, wait_s=0.05,
+        retry_exc=RuntimeError)     # type: ignore[arg-type]
+
+    started = time.monotonic()
+    with gate.ensure_resident():
+        pass
+    assert res.attempts == 40
+    assert time.monotonic() - started > 0.05, (
+        "the test did not actually outlive the window it is testing"
+    )
+
+
+def test_a_card_that_has_stopped_moving_still_gives_up(
+    gated: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half — the bound still exists. A genuinely stuck card reports
+    the same free VRAM forever, the window fires, and the request is failed
+    RETRYABLE rather than executing a cpu-resident lane."""
+    monkeypatch.setattr(gated, "get_available_vram_gb", lambda: 3.0)
+    res = _FakeResidency(promote_after=10**9)
+    gate = gated.ExecutionLaneGate(
+        ref="lane", residency=res, wait_s=0.05,
+        retry_exc=RuntimeError)     # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="stopped moving"):
+        with gate.ensure_resident():
+            pass
+
+
+def test_allocator_jitter_cannot_keep_the_window_alive(
+    gated: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window keys on a 64 MiB quantum, not on the raw float, so noise
+    below a component's size is not progress."""
+    free = [3.0]
+
+    def jitter() -> float:
+        free[0] += 1e-6
+        return free[0]
+
+    monkeypatch.setattr(gated, "get_available_vram_gb", jitter)
+    gate = gated.ExecutionLaneGate(
+        ref="lane", residency=_FakeResidency(promote_after=10**9),
+        wait_s=0.05, retry_exc=RuntimeError)   # type: ignore[arg-type]
+    with pytest.raises(RuntimeError):
+        with gate.ensure_resident():
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 4. Verbatim duplicates now have one owner each — structural pins, so a
+#    re-declaration fails here rather than drifting for a release.
+# ---------------------------------------------------------------------------
+
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "gen_worker"
+
+
+def _declaring(name: str) -> List[str]:
+    """Modules that ASSIGN ``name`` at module level (an import is not a
+    declaration)."""
+    out: List[str] = []
+    for path in _SRC.rglob("*.py"):
+        for line in path.read_text().splitlines():
+            if line.startswith(f"{name} ="):
+                out.append(str(path.relative_to(_SRC)))
+                break
+    return out
+
+
+def test_the_pinned_host_memory_cap_has_one_owner() -> None:
+    from gen_worker import media_transfer
+    from gen_worker.models import w8a8_lora
+
+    assert w8a8_lora._PIN_MAX_BYTES is media_transfer.PIN_MAX_BYTES
+    assert _declaring("PIN_MAX_BYTES") == ["media_transfer.py"]
+    assert _declaring("_PIN_MAX_BYTES") == []
+
+
+def test_the_nvidia_smi_budget_has_one_owner() -> None:
+    from gen_worker import cuda_probe, hardware_report, host_canary
+
+    assert host_canary._NVIDIA_SMI_TIMEOUT_S is cuda_probe.NVIDIA_SMI_TIMEOUT_S
+    assert hardware_report._NVIDIA_SMI_TIMEOUT_S is cuda_probe.NVIDIA_SMI_TIMEOUT_S
+    assert _declaring("NVIDIA_SMI_TIMEOUT_S") == ["cuda_probe.py"]
+
+
+def test_the_host_ram_floor_has_one_owner_and_one_derivation() -> None:
+    """`residency` and `staging` each declared the two constants AND re-derived
+    the same min/max expression, with staging's comment promising it was "kept
+    numerically identical" — a promise nothing enforced. They cannot import
+    each other (`residency -> pinned_swap -> staging` already exists)."""
+    from gen_worker.models import memory, residency, staging
+
+    assert _declaring("_RAM_FLOOR_GB") == [str(Path("models/memory.py"))]
+    assert _declaring("_RAM_FLOOR_FRACTION") == [str(Path("models/memory.py"))]
+    assert residency._effective_ram_floor_gb() == memory.effective_ram_floor_gb()
+    assert staging._floor_bytes() == int(memory.effective_ram_floor_gb() * 1024 ** 3)
+    # The policy itself, exercised rather than asserted from the constants.
+    assert memory.effective_ram_floor_gb(total_gb=1000.0) == 8.0   # flat above 40 GiB
+    assert memory.effective_ram_floor_gb(total_gb=20.0) == 4.0     # adaptive below
+    assert memory.effective_ram_floor_gb(total_gb=0.0) == 8.0      # unreadable host
+
+
+def test_serving_headroom_is_one_number_pgw973() -> None:
+    """The fifth pair is deliberately NOT collapsed: `aot_wrapper_split` is an
+    inductor hook whose only in-repo imports are `host_isa` and
+    `aot_run_impl_split`, and importing `aot_compile_pool` would drag the whole
+    mint driver into it. The duplication is stated at the site; this pins the
+    two values together so a drift is a failure and not a surprise."""
+    from gen_worker import aot_compile_pool, aot_wrapper_split
+
+    assert (aot_wrapper_split.SERVING_HEADROOM_CPUS
+            == aot_compile_pool.SERVING_HEADROOM_CPUS)
+
+
+# ---------------------------------------------------------------------------
+# 5. Deletions — the bounds that were never read
+# ---------------------------------------------------------------------------
+
+
+def test_the_file_api_timeouts_are_gone() -> None:
+    """Five `_FILE_API_*_TIMEOUT_S` constants in `request_context/_helpers.py`
+    were defined, re-exported, and read by nothing — in `src`, in `tests`, or
+    anywhere else. §4.24: a limit that reaches no call site prevents nothing."""
+    hits = [
+        str(p.relative_to(_SRC))
+        for p in _SRC.rglob("*.py")
+        if "_FILE_API" in p.read_text()
+    ]
+    assert hits == []
+
+
+def test_the_sdk_upload_backoff_states_its_single_pause() -> None:
+    """`min(2 ** (attempt - 1), 4)` could only ever evaluate to 1: the loop
+    breaks before the second sleep once `_SDK_TRANSFER_ATTEMPTS` became 2."""
+    from gen_worker import s3_transfer
+
+    assert s3_transfer._SDK_TRANSFER_ATTEMPTS == 2
+    assert s3_transfer._SDK_RETRY_PAUSE_S == 1.0
+
+
+def test_the_mediated_action_ceiling_is_the_allowlists_own() -> None:
+    """`_ACTION_HARD_TIMEOUT_S = 120.0` sat in a `min()` beside
+    `action.timeout_s`, whose largest declared value is 60 s — so the third
+    term could only ever reject nothing (§4.24 item 1). Behaviour is proven on
+    the real mediation path in `test_procsplit_security_pgw763`."""
+    from gen_worker.procsplit import actions, parent
+
+    assert not hasattr(parent, "_ACTION_HARD_TIMEOUT_S")
+    assert max(a.timeout_s for a in actions.ACTIONS.values()) == 60.0
+
+
+def test_the_parent_beat_fallback_is_declared_not_buried() -> None:
+    """`beat_interval_s=0.0` means "adopt the child's cadence"; when no child
+    declares one the loop fell back to a bare `10.0` inside its body."""
+    from gen_worker.procsplit import parent
+
+    assert parent._BEAT_INTERVAL_FALLBACK_S == 10.0
+
+
+def test_the_mint_reap_grace_is_named_and_argues_its_exemption() -> None:
+    """A fixed duration that is EXEMPT from gw#666, stated as such: it runs
+    after `_terminate_group` has already signalled, so the kill decision was
+    made upstream on `_EVIDENCE_WINDOW_S`, which is a progress signal."""
+    from gen_worker import mint_process
+
+    assert mint_process._REAP_GRACE_S == 15.0
+    assert mint_process._EVIDENCE_WINDOW_S > 0
+
+
+# ---------------------------------------------------------------------------
+# 6. mint_child.cap_vram — "uncapped" is a state to STATE
+# ---------------------------------------------------------------------------
+
+
+def test_an_uncapped_mint_child_says_so(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`vram_cap_bytes=0` is the legitimate value for an unprobeable card AND
+    the value a budget that computed to nothing produces. Both used to return
+    an empty note, the caller framed nothing, and the phase table recorded a
+    capped mint and an uncapped mint identically."""
+    from gen_worker import mint_child
+
+    note = mint_child.cap_vram(0, 0)
+    assert "NOT applied" in note and "vram_cap_bytes=0" in note

--- a/tests/test_mint_process_pgw784.py
+++ b/tests/test_mint_process_pgw784.py
@@ -333,4 +333,8 @@ def test_the_cap_is_bytes_expressed_as_the_cards_real_fraction(
     assert seen["frac"] == pytest.approx(0.5, rel=0.01)
     assert "12.00GiB" in note
     seen.clear()
-    assert mint_child.cap_vram(0, 0) == "" and not seen
+    # pgw#973 §4.24 item 4: no cap is applied, and the child SAYS it is
+    # running uncapped rather than returning an empty note the caller drops.
+    uncapped = mint_child.cap_vram(0, 0)
+    assert not seen
+    assert "NOT applied" in uncapped and "vram_cap_bytes=0" in uncapped

--- a/tests/test_procsplit_security_pgw763.py
+++ b/tests/test_procsplit_security_pgw763.py
@@ -226,6 +226,61 @@ def test_delta1_the_legitimate_mediated_call_still_works(credentialed_split, hub
     assert call["body"]["request_id"] == "r-live"
 
 
+def test_the_childs_timeout_may_only_lower_the_allowlists_own(
+    credentialed_split, hub_http, monkeypatch,
+):
+    """pgw#973 (§4.24): the child supplies `timeout`, so the ALLOWLIST's
+    `timeout_s` is what stops tenant code pinning a parent thread-pool slot.
+
+    That clamp is the load-bearing bound, which is why the separate
+    `_ACTION_HARD_TIMEOUT_S = 120.0` beside it was deleted: every declared
+    action is 30 s or 60 s, so a third `min()` term 60 s above the highest
+    declared value could only ever reject nothing.
+    """
+    from gen_worker.procsplit import actions, parent as parent_mod
+
+    assert max(a.timeout_s for a in actions.ACTIONS.values()) == 60.0, (
+        "an action now declares a longer budget than the deleted ceiling "
+        "assumed — re-derive it before trusting this clamp"
+    )
+    seen: List[float] = []
+    real = parent_mod._http_call
+
+    def spy(method, url, token, query, body, timeout):
+        seen.append(float(timeout))
+        return real(method, url, token, query, body, timeout)
+
+    monkeypatch.setattr(parent_mod, "_http_call", spy)
+
+    pc = credentialed_split.pc
+    conn = credentialed_split.scheduler.wait_connection(0)
+    conn.wait_for(is_ready)
+    pc._slots[0].in_flight[("r-live", 1)] = "echo"
+
+    status, _body = _ask(pc, {
+        "method": "POST",
+        "path": "/v1/worker/capability/renew",
+        "json": {"request_id": "r-live", "attempt": 1, "capability_token": "old"},
+        "timeout": 99999,
+    })
+    assert status == 200
+    action = actions.ACTIONS["capability.renew"]
+    assert seen == [action.timeout_s], (
+        f"the child's 99999 s reached the socket as {seen}"
+    )
+
+    # ... and a SMALLER number from the child is still honoured: the clamp is a
+    # ceiling, not an override.
+    seen.clear()
+    _ask(pc, {
+        "method": "POST",
+        "path": "/v1/worker/capability/renew",
+        "json": {"request_id": "r-live", "attempt": 1, "capability_token": "old"},
+        "timeout": 2,
+    })
+    assert seen == [2.0]
+
+
 def _ask(pc, req: Dict[str, Any]) -> Tuple[int, str]:
     """Drive one action through the parent's real authorization path."""
     import asyncio


### PR DESCRIPTION
Closes out wave 2's "Tabled" list: **every surviving row ends with an explicit disposition** — KEEP with a named threat, DELETE, or a recorded refusal with the reason. Tracker: `python-gen-worker/progress.md` #973, WAVE 3 section.

## The four behaviour changes, in blast-radius order (all RED-verified)

**1. A capacity cap that INVERTED into a purge.** `aot_resume.sweep` computed `int(max_bytes or os.environ.get(ENV) or DEFAULT_MAX_BYTES)` — two absence collapses in one expression, in opposite directions:

* a caller-computed `0` fell through to the 4 GiB default, so a budget that computed to nothing silently got the module's own number;
* `GEN_WORKER_MINT_RESUME_MAX_BYTES=0` — the spelling an operator reaches for to mean "no cap" — yielded `cap = 0`, because the env value is the **string** `"0"` and a non-empty string is truthy. The sweep then deleted **every banked scope except the one being opened**, on the corpus that exists to save ~5.2 h of compile per crashed mint.

Absence is `None` and only `None` now; a stated non-positive is refused (`resume_area_cap_bytes`, on the `url_fetch.fetch_bytes` / `SilenceWindow` shape). **Second defect found while testing it:** the same sweep sorted `reverse=True` and consumed the list from the head, i.e. it evicted the *newest* abandoned scope first — the exact inversion of its own docstring, comment and intent, and the scope most likely to be resumed next. The pre-existing test could not see it: both of its victims carried the same mtime.

**2. A wall-clock kill with its progress signal in front of it (gw#666).** `models/execution_lane_gate` gave up on a flat 45 s deadline while polling `get_available_vram_gb()` every 250 ms — free VRAM *is* the signal, and a card still handing memory back failed a request that was about to serve. Now a `SilenceWindow` over free VRAM, quantised at 64 MiB so allocator jitter is not progress. A genuinely stuck card still fails RETRYABLE.

**3. `transport.SendQueue(maxsize<=0)` deleted the bound outright.** The enqueue path reads `while self._maxsize > 0 and ...`, so a zero shed nothing and blocked nobody — an unbounded outbound buffer in a pod whose progress/event producers never wait. `maxsize` is a public `Transport(...)` / `worker(...)` parameter, so that value was one caller away.

**4. `mint_child.cap_vram` made "uncapped" observable.** Every non-capping path returned `""`, the caller framed nothing, and the phase table recorded a capped and an uncapped mint identically.

## Deletions

* **`procsplit.parent._ACTION_HARD_TIMEOUT_S = 120.0`** sat in `min(child_timeout, action.timeout_s, 120.0)`, and every declared `HubAction.timeout_s` is 30 s or 60 s — a third term 60 s above the highest declared value can only reject nothing (§4.24 item 1). The load-bearing clamp is the allowlist's own budget against the **child-supplied** `timeout` field, now proven on the real mediated path.
* **Five `request_context/_helpers._FILE_API_*_TIMEOUT_S`** — defined, re-exported, and read by nothing anywhere.
* **`s3_transfer`'s `min(2 ** (attempt - 1), 4)`** could only ever evaluate to `1` once pgw#1005 A cut `_SDK_TRANSFER_ATTEMPTS` to 2.

## Single owners

`PIN_MAX_BYTES` (`media_transfer`) · `NVIDIA_SMI_TIMEOUT_S` (`cuda_probe`) · `_RAM_FLOOR_GB`/`_RAM_FLOOR_FRACTION` **and their shared derivation** (`memory.effective_ram_floor_gb`) — bigger than filed: `residency` and `staging` re-derived the same `min/max` expression, and staging's comment *promised* it was "kept numerically identical" with nothing enforcing it · the transport keepalive interval (`KEEPALIVE_INTERVAL_S`, previously a bare `20000` beside the *named* timeout).

`SERVING_HEADROOM_CPUS` is deliberately **not** collapsed and says why at the site: `aot_wrapper_split` is an inductor hook whose only in-repo imports are `host_isa` and `aot_run_impl_split`, and importing `aot_compile_pool` would drag the whole mint driver into it. A pin test fails if the two values drift.

## Five census verdicts were wrong

Recorded in the tracker rather than worked around: `aot_cells.py` no longer exists (pgw#904 `5adbef39` deleted it whole, taking the "seventh duplicate family" with it); `transport.py:565 SendQueue(maxsize=0)` is not a call site — the collapse is the constructor default; `models/ladder.sm_min = 0` is not an absence collapse ("unconstrained" is the class's stated meaning for every empty field); `parent.beat_interval_s = 0.0` does have a fallback, and the defect was that it was a bare `10.0` in the loop body; and `mint_process`' `timeout=15.0` sits immediately after `_terminate_group`, i.e. in the post-SIGTERM teardown-grace class the same census bullet explicitly exempts.

## Proof

`tests/test_limits_census_wave3_pgw973.py` (20 tests) plus one on the real mediated-action path in `test_procsplit_security_pgw763`. RED-verified: restoring the old cap expression, the reversed sort, the flat lane deadline, the missing queue refusal and the deleted `min()` term fails six tests across the two files. `mypy` clean (245 files), `ruff` clean, every `fast gates` lint step green locally, `assemble_changelog.py --check` exit 0.
