### PR TITLE
pgw#1075 + pgw#1076: a declaration refusal carries its class, and `precision` stops inventing itself

### DIFF
--- a/changelog.d/pgw1075.md
+++ b/changelog.d/pgw1075.md
@@ -1,0 +1,19 @@
+- **pgw#1075: a declared value the SDK's own vocabulary rejects is a typed
+  REFUSAL, not an unclassified mint-child crash.** `api.errors.ValidationError`
+  means, verbatim, *bad user input; do not retry* — and inside the mint child
+  the "user input" IS the declaration. Every property the parent's retry policy
+  reads off a refusal already held for it (deterministic, identical on the next
+  card, fixed by editing the declaration and by nothing else), yet it took the
+  one exit that says none of that: `mint-child crashed: the mint process exited
+  1` with a truncated traceback tail, classified RETRYABLE, and the sentence
+  naming the author's fix lost at the process boundary. Measured on the rig
+  2026-08-09 with a vehicle declaring `lora_bucket=8` (`RANK_BUCKETS = (16, 32,
+  64, 128)`), where `enable_lora_branches` refuses CORRECTLY. `mint_child.main`
+  now classifies it as `MintChildRefused` → `EXIT_REFUSED` → `refused`, message
+  intact — the same wrapper `aot_mint.export_program` already applies to a
+  custom op with no fake kernel (pgw#1062), one layer down. The rig and the
+  gauntlet render it as `refused:` with no change of their own, because both
+  print the outcome's own status. RED-proven across a real child process
+  (`tests/test_declaration_refusal_pgw1075.py`); the control asserts a
+  `RuntimeError` is still a crash, so the classification cannot widen into
+  swallowing genuine bugs.

--- a/changelog.d/pgw1076.md
+++ b/changelog.d/pgw1076.md
@@ -1,0 +1,19 @@
+- **pgw#1076: `precision` is a MEASUREMENT, and nothing defaults it any more.**
+  `ExportSpec.precision` defaulted to `"bf16"` and both spec builders repeated
+  the default (`fleet_cells.aot_export_spec`: `execution_lane or "bf16"`;
+  `aot_mint._load_spec`: `body.get("precision") or "bf16"`). So micro-conv —
+  fp32 weights, `dtype="float32"` inputs, an fp32 traced graph whose own
+  `input_contract` records `float32`/`int64` correctly — packaged
+  `metadata.json precision: "bf16"`, and every arm line printed
+  `precision=bf16, constants bound from resident weights`. Nothing miscomputes
+  (`precision` is metadata-only, never a `cell_key` axis); what it cost was a
+  debugging cycle, because a reader chasing a 1.2e-3 GPU parity delta reads
+  that line as "the mint cast to bf16". The real cause was TF32 conv kernels.
+  A recorded fact that defaults to a plausible-but-wrong value is worse than an
+  absent one. Now: a caller that KNOWS the lane keeps its word (every real
+  family, via `weight_lane` — their stamps are unchanged), an ABSENT stamp is
+  derived by `aot_mint.module_precision` from the modules the mint actually
+  traces (`fp32` / `bf16` / `fp8-e4m3` …, and `mixed(a+b)` dominant-first when
+  a module or a target set genuinely carries more than one), and an underivable
+  one stays `""`. RED-proven on the real `_mint_cell` against the real fp32
+  micro-conv pipeline (`tests/test_precision_stamp_pgw1076.py`).

--- a/src/gen_worker/aot_contract.py
+++ b/src/gen_worker/aot_contract.py
@@ -120,7 +120,15 @@ class ExportSpec:
     family: str
     target: str
     weight_lane: str = ""
-    precision: str = "bf16"
+    #: pgw#1076: EMPTY, not "bf16". This field is a MEASUREMENT — what the
+    #: traced modules actually compute in — and it is stamped into the cell's
+    #: `metadata.json` and printed on every arm line. Defaulting it made an
+    #: fp32 cell say `precision: bf16`, which cost a debugging cycle chasing a
+    #: cast that never happened (the real cause was TF32 conv kernels). A
+    #: caller that KNOWS the lane sets it; a caller that does not leaves it
+    #: absent and `aot_mint._mint_cell` derives it from the modules in hand.
+    #: Unmeasurable stays "" — an absent fact beats a plausible wrong one.
+    precision: str = ""
     lora_bucket: int = 0
     shapes: Tuple[Tuple[int, ...], ...] = ()
     # (pgw#1030: `batch` deleted — zero readers. The traced batch is a

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -1007,6 +1007,91 @@ def _run_declared_warm(module: Any, args: Tuple[Any, ...], entry: str) -> float:
     return round(time.monotonic() - t0, 2)
 
 
+#: pgw#1076: the short spelling of a floating-point dtype, matching the
+#: vocabulary the weight-lane labels already use (`bf16`, `fp8-…`) so one cell's
+#: `precision` reads the same whether it came from the lane or from this
+#: measurement.
+_PRECISION_LABELS: Dict[str, str] = {
+    "torch.bfloat16": "bf16",
+    "torch.float16": "fp16",
+    "torch.float32": "fp32",
+    "torch.float64": "fp64",
+    "torch.float8_e4m3fn": "fp8-e4m3",
+    "torch.float8_e4m3fnuz": "fp8-e4m3",
+    "torch.float8_e5m2": "fp8-e5m2",
+    "torch.float8_e5m2fnuz": "fp8-e5m2",
+}
+
+
+def module_precision(module: Any) -> str:
+    """pgw#1076: what floating-point dtype a module ACTUALLY holds.
+
+    Weighted by element count over parameters and buffers, because a module is
+    "an fp32 module with one bf16 norm buffer" and not "half and half". More
+    than one float dtype is reported as ``mixed(a+b)``, dominant first — a
+    mixture is a fact worth naming, and naming it is strictly better than
+    picking a winner and calling the cell that.
+
+    ``""`` when nothing is measurable (no tensors, no torch, a callable
+    target that is not a module). An absent fact beats an invented one; that is
+    the whole issue.
+    """
+    counts: Dict[str, int] = {}
+    for attr in ("parameters", "buffers"):
+        get = getattr(module, attr, None)
+        if not callable(get):
+            continue
+        try:
+            tensors = list(get(recurse=True))
+        except Exception:  # noqa: BLE001 — a label never fails a mint
+            continue
+        for tensor in tensors:
+            try:
+                if not bool(tensor.is_floating_point()):
+                    continue
+                raw = str(tensor.dtype)
+                counts[_PRECISION_LABELS.get(raw, raw.replace("torch.", ""))] = (
+                    counts.get(
+                        _PRECISION_LABELS.get(raw, raw.replace("torch.", "")), 0)
+                    + int(tensor.numel()))
+            except Exception:  # noqa: BLE001
+                continue
+    if not counts:
+        return ""
+    if len(counts) == 1:
+        return next(iter(counts))
+    return "mixed(" + "+".join(
+        sorted(counts, key=lambda label: (-counts[label], label))) + ")"
+
+
+def _measured_precision(pipeline: Any, rows: Sequence[Tuple[Any, Any]]) -> str:
+    """The cell-wide precision stamp, measured over the modules this mint will
+    actually trace (pgw#1076).
+
+    Every distinct declared target contributes; disagreement between targets is
+    reported as a mixture rather than resolved, for the same reason a mixture
+    inside one module is. Unresolvable targets contribute nothing — this runs
+    BEFORE the export's own target gate, and a label must never be the thing
+    that refuses a mint.
+    """
+    labels: Dict[str, None] = {}
+    for plan, _arm in rows:
+        target = str(getattr(plan, "target", "") or "")
+        if not target:
+            continue
+        resolved = _resolve_target(pipeline, target)
+        if resolved is None:
+            continue
+        label = module_precision(resolved[0])
+        if label:
+            labels[label] = None
+    if not labels:
+        return ""
+    if len(labels) == 1:
+        return next(iter(labels))
+    return "mixed(" + "+".join(sorted(labels)) + ")"
+
+
 def _export_entry(
     pipeline: Any,
     spec: ExportSpec,
@@ -1911,6 +1996,22 @@ def _mint_cell(
     # `Compile(regional=True)` declaration keeps its dynamo/JIT meaning
     # (ie#381, compile_cache) and the AOT mint ignores it.
     rows = adapter_arm_plans(_decl.cell_plans(decl), pipeline, spec)
+    # pgw#1076: the `precision` stamp is a MEASUREMENT, and until here nobody
+    # made it — `ExportSpec.precision` defaulted to "bf16", so a micro-conv
+    # cell with fp32 weights, fp32 inputs and an fp32 traced graph packaged
+    # `metadata.json precision: "bf16"` and every arm line printed
+    # `precision=bf16`. A reader debugging a 1.2e-3 GPU parity delta reads
+    # that as "the mint cast to bf16" and spends a cycle disproving it (the
+    # real cause was TF32 conv kernels). A caller that KNOWS the lane — every
+    # real family, via `weight_lane` — keeps its own word; only an ABSENT
+    # stamp is derived, and an underivable one stays absent.
+    if not str(spec.precision or "").strip():
+        measured = _measured_precision(pipeline, rows)
+        logger.info(
+            "aot-mint: pgw#1076 precision measured from the traced modules: "
+            "%r (no lane declared; %d declared class row(s))",
+            measured or "<unmeasurable>", len(rows))
+        spec = replace(spec, precision=measured)
     # pgw#809: how wide this pod may compile. Derived from the pod's REAL
     # budget (cgroup-aware vCPUs minus serving headroom, and available host
     # RAM over the measured per-entry peak) — never os.cpu_count, never a
@@ -3605,7 +3706,10 @@ def _load_spec(path: Path) -> Tuple[ExportSpec, Dict[str, Any]]:
         family=str(body.get("family") or ""),
         target="",
         weight_lane=str(body.get("weight_lane") or ""),
-        precision=str(body.get("precision") or "bf16"),
+        # pgw#1076: NO default. An absent `precision` is derived from the
+        # modules the mint actually traces (`_measured_precision`); a
+        # fabricated "bf16" is a measurement nobody made.
+        precision=str(body.get("precision") or ""),
         lora_bucket=int(body.get("lora_bucket") or 0),
         shapes=tuple(tuple(int(v) for v in row) for row in body.get("shapes") or ()),
         text_lens=tuple(int(v) for v in body.get("text_lens") or ()),

--- a/src/gen_worker/fleet_cells.py
+++ b/src/gen_worker/fleet_cells.py
@@ -2097,7 +2097,11 @@ def aot_export_spec(pipe: Any, cfg: Any) -> "Any":
         family=str(getattr(cfg, "family", "") or ""),
         target="",
         weight_lane=execution_lane,
-        precision=execution_lane or "bf16",
+        # pgw#1076: the lane when the pipeline HAS one, and otherwise absent —
+        # never "bf16". `aot_mint` derives the stamp from the modules it
+        # traces when this is empty, so an unlabelled fp32 pipeline records
+        # fp32 instead of a cast nobody performed.
+        precision=execution_lane,
         lora_bucket=bucket,
         shapes=tuple(
             tuple(int(v) for v in row) for row in (getattr(cfg, "shapes", ()) or ())),

--- a/src/gen_worker/mint_child.py
+++ b/src/gen_worker/mint_child.py
@@ -70,6 +70,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 import msgspec
 
 from . import warm_spans, worker_goals
+from .api.errors import ValidationError
 from .config import load_settings
 from .mint_process import (
     EXIT_BAD_REQUEST,
@@ -106,6 +107,35 @@ class MintChildRefused(RuntimeError):
     ) -> None:
         super().__init__(*args)
         self.mint_phases: Dict[str, Any] = dict(mint_phases or {})
+
+
+def _declaration_refusal(exc: ValidationError) -> MintChildRefused:
+    """pgw#1075: a declared value this SDK's own vocabulary rejects is a
+    REFUSAL, not a crash — and the author's fix is already in the message.
+
+    ``api.errors.ValidationError`` means, verbatim, "bad user input; do not
+    retry". Inside this process the "user input" IS the declaration: the
+    family's ``Compile`` block, the mint request's spec, the axis values the
+    endpoint declares. Every property the parent's retry policy reads off a
+    refusal already holds for it — deterministic, identical on the next card,
+    fixed by editing the declaration and by nothing else — so it took the one
+    exit that says none of that.
+
+    Measured on the rig 2026-08-09: a vehicle declaring ``lora_bucket=8``
+    (``RANK_BUCKETS = (16, 32, 64, 128)``) makes ``enable_lora_branches``
+    raise its typed ``ValidationError`` — the refusal is CORRECT — and the
+    child reported ``mint-child crashed: the mint process exited 1`` with a
+    truncated traceback tail. The sentence naming the fix, and the fact that
+    it was a refusal at all, both died at the process boundary. pgw#999's
+    rule: refusals carry a class.
+
+    The wrapper is the same shape ``aot_mint.export_program`` already applies
+    to a custom op with no fake kernel (pgw#1062) — the message is the
+    authoring contract, so it is carried whole and never summarised.
+    """
+    return MintChildRefused(
+        f"declaration refused: {type(exc).__name__}: {exc}",
+        mint_phases=getattr(exc, "mint_phases", None))
 
 
 # th#1322: per-phase spans, measured HERE because this process owns the clock
@@ -925,7 +955,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     report_path = Path(request.report)
     started = time.monotonic()
     try:
-        report = mint(request)
+        try:
+            report = mint(request)
+        except ValidationError as exc:
+            # pgw#1075: classified HERE and not deeper, because every path into
+            # this process — spec build, composition check, branch arm, export
+            # declaration — can raise it and they all mean the same thing.
+            raise _declaration_refusal(exc) from exc
     except MintChildRefused as exc:
         # th#1322: a refused mint's phase table is where it spent the time
         # BEFORE refusing — the most useful half of a failed mint. The OPEN

--- a/tests/test_declaration_refusal_pgw1075.py
+++ b/tests/test_declaration_refusal_pgw1075.py
@@ -1,0 +1,228 @@
+"""pgw#1075 — a declared value this SDK's own vocabulary rejects is a REFUSAL.
+
+``api.errors.ValidationError`` means, verbatim, *bad user input; do not retry*.
+Inside the mint child the "user input" IS the declaration, so every property
+the parent's retry policy reads off a refusal already holds for it: it is
+deterministic, identical on the next card, and fixed by editing the
+declaration and by nothing else. It nonetheless took the one exit that says
+none of that — an unclassified crash.
+
+**Measured on the rig, 2026-08-09.** A vehicle declaring ``lora_bucket=8``
+(``RANK_BUCKETS = (16, 32, 64, 128)``) makes ``enable_lora_branches`` raise its
+typed ``ValidationError`` — the refusal is CORRECT — and the rig reported
+``mint-child crashed: the mint process exited 1`` with a truncated traceback
+tail. Two things died at the process boundary: the class (crash, so RETRYABLE
+— a second billed pod for a fact the first one settled) and the sentence
+carrying the author's fix.
+
+pgw#999's rule is that refusals carry a class. pgw#1062's is that a refusal's
+message IS the authoring contract and is carried whole — that is why
+``export_program`` hands torch's own ``register_fake`` guidance through
+unedited. This is the same wrapper, one layer down.
+
+**RED VERIFICATION.** Delete the ``except ValidationError`` branch from
+``mint_child.main``:
+
+    test_a_declaration_the_vocabulary_rejects_is_refused_not_crashed fails at
+    `outcome.status = 'crashed', want 'refused'`, and (once that assert is
+    removed) at `outcome.retryable is True` and at the message — the detail
+    reads `the mint process exited 1: <traceback tail>` and the words
+    `invalid lora rank bucket 8` are nowhere in it.
+
+The child runs as a REAL subprocess on the REAL request file, so the
+classification is proved across the boundary it was lost at rather than at the
+raise site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Tuple
+
+import msgspec
+import pytest
+
+from gen_worker import mint_child, mint_delegate
+from gen_worker import mint_process as mp
+from gen_worker.api.binding import ModelRef
+from gen_worker.api.errors import IllegalCombination, ValidationError
+from gen_worker.registry import CompileCell
+
+pytest.importorskip("torch")
+
+HERE = Path(__file__).resolve().parent
+ENDPOINT_MODULE = "harness.tiny_diffusion_endpoint"
+FUNCTION = "rig-generate"
+
+#: Not in ``models.w8a8_lora.RANK_BUCKETS``. The rig's own reproduction.
+BAD_BUCKET = 8
+
+
+@pytest.fixture(scope="module")
+def checkpoint(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    from harness.tiny_diffusion import build_checkpoint
+
+    return build_checkpoint(tmp_path_factory.mktemp("pgw1075") / "checkpoint")
+
+
+def _request(checkpoint: Path, workdir: Path, *, bucket: int) -> mp.MintRequest:
+    """The real parent chain, round-tripped through the file the child decodes.
+
+    ``CompileCell`` is built directly, exactly as the rig's vehicle builds it:
+    the ``@endpoint`` decorator screens ``lora_bucket`` at decoration time
+    (``decorators.py``), so a bad bucket can only arrive from a path that is
+    not the decorator — an operator mint request, or a rig vehicle. That is
+    the shape this issue was found in.
+    """
+    from harness import tiny_diffusion_endpoint as ep
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    cfg = CompileCell(
+        shapes=(ep.PIXEL_SHAPE,), targets=("unet",), family=ep.FAMILY,
+        regional=False, text_len=ep.TEXT_LEN, dynamic=(), lora_bucket=bucket,
+        guidance_scales=(), text_lens=())
+    pending = SimpleNamespace(
+        family=ep.FAMILY, cell_key="ck5-pgw1075", cfg=cfg,
+        target=workdir / "cell.tar.gz", mint_root=workdir)
+    task = mint_delegate.MintTask(
+        pending=pending, pipe=None, function=FUNCTION,
+        modules=(ENDPOINT_MODULE,),
+        slots={"pipeline": mp.MintSlot(
+            ref=ModelRef(source="tensorhub", path="rig/tiny-diffusion",
+                         tag="prod"),
+            path=str(checkpoint))},
+        device=-1, execution_lane="", configs={})
+    request = mint_delegate.build_request(task, workdir=workdir, cap_bytes=0)
+    return msgspec.json.decode(msgspec.json.encode(request), type=mp.MintRequest)
+
+
+def _child_env(request: mp.MintRequest) -> Dict[str, str]:
+    env = dict(mp.child_env(request))
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(HERE), str(HERE.parent / "src"), env.get("PYTHONPATH", "")])
+    # Deterministic on any host, and the honest production shape: a mint child
+    # that can see no card. The refusal under test fires long before anything
+    # needs one.
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    return env
+
+
+def _run(checkpoint: Path, workdir: Path, *, bucket: int) -> Tuple[mp.MintOutcome, mp.MintRequest]:
+    request = _request(checkpoint, workdir, bucket=bucket)
+    outcome = asyncio.run(mp.run_mint(
+        request, workdir=workdir, python=sys.executable,
+        env=_child_env(request)))
+    return outcome, request
+
+
+def test_a_declaration_the_vocabulary_rejects_is_refused_not_crashed(
+    checkpoint: Path, tmp_path: Path,
+) -> None:
+    """The whole issue, on the real entrypoint in a real child process."""
+    outcome, request = _run(checkpoint, tmp_path / "w", bucket=BAD_BUCKET)
+
+    assert outcome.status == mp.REFUSED, (
+        f"{outcome.status}: {outcome.detail or outcome.stderr_tail}\n\n"
+        "A ValidationError is the SDK saying 'bad declared input; do not "
+        "retry'. Reporting it as an unclassified crash makes it RETRYABLE, "
+        "which on a pod is a second billed mint for a fact the first attempt "
+        "already settled.")
+    assert outcome.exit_code == mp.EXIT_REFUSED
+    assert outcome.retryable is False, (
+        "a declaration defect is identical on the next card and the one after")
+
+    detail = outcome.detail or ""
+    assert "invalid lora rank bucket 8" in detail, (
+        f"the author's fix must survive the boundary whole: {detail!r}")
+    assert "16, 32, 64, 128" in detail, (
+        f"including the vocabulary it was measured against: {detail!r}")
+    assert "ValidationError" in detail, (
+        f"and the type, so the refusal is groupable: {detail!r}")
+
+    report = outcome.report
+    assert report is not None and report.status == "refused", (
+        "the child's own report must say refused, not failed — the rig and "
+        "the hub both read the report before the exit code")
+    assert report.phase, "the phase it refused in is named (th#1322)"
+    assert not Path(request.target).exists(), "nothing may be sealed"
+
+
+def test_the_classification_discriminates(
+    checkpoint: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE CONTROL, on the real ``main``: only a ValidationError is refused.
+
+    A classification that widens is worse than none — it would report a
+    genuine BUG as a deterministic refusal and strand a mint a retry could
+    make. So the same entrypoint is driven twice with only the exception type
+    changed, and the two must land on different exits.
+
+    In-process rather than through a child: what is under test is ``main``'s
+    exception table, and re-running a whole CPU mint to change one raise
+    would buy 4 minutes of nothing. The BOUNDARY is proved above.
+    """
+    request = _request(checkpoint, tmp_path / "w", bucket=BAD_BUCKET)
+    request_file = tmp_path / "request.json"
+    request_file.write_bytes(msgspec.json.encode(request))
+
+    def _run_main(exc: BaseException) -> Tuple[int, mp.MintReport]:
+        def _raise(_req: mp.MintRequest) -> mp.MintReport:
+            raise exc
+
+        monkeypatch.setattr(mint_child, "mint", _raise)
+        code = mint_child.main([str(request_file)])
+        return code, msgspec.json.decode(
+            Path(request.report).read_bytes(), type=mp.MintReport)
+
+    code, report = _run_main(ValidationError("invalid lora rank bucket 8"))
+    assert code == mp.EXIT_REFUSED and report.status == "refused", (
+        f"exit={code} status={report.status!r}: a declared value the "
+        "vocabulary rejects is terminal, and the exit code is what the "
+        "parent's retry policy reads")
+    assert "invalid lora rank bucket 8" in report.detail
+
+    code, report = _run_main(RuntimeError("a real bug, from real code"))
+    assert code == 1 and report.status == "failed", (
+        f"exit={code} status={report.status!r}: a RuntimeError is NOT a "
+        "declaration refusal. Classifying one would strand a mint that a "
+        "retry could make — the mirror of the defect this issue closes")
+
+
+def test_the_raise_site_accepts_every_declared_bucket() -> None:
+    """The other side of the control, where the sentence comes from: a LEGAL
+    bucket must not raise at all, or the refusal above is just a broken
+    vocabulary check being reported politely."""
+    torch = pytest.importorskip("torch")
+    from gen_worker.models import w8a8_lora
+
+    for bucket in w8a8_lora.RANK_BUCKETS:
+        model = torch.nn.Sequential(torch.nn.Linear(8, 8))
+        w8a8_lora.enable_lora_branches(model, bucket)
+        assert w8a8_lora.branch_bucket(model) == bucket
+
+    with pytest.raises(ValidationError) as exc:
+        w8a8_lora.enable_lora_branches(
+            torch.nn.Sequential(torch.nn.Linear(8, 8)), BAD_BUCKET)
+    assert f"invalid lora rank bucket {BAD_BUCKET}" in str(exc.value)
+
+
+def test_the_refusal_type_is_the_sdks_own_bad_input_type() -> None:
+    """Why ``ValidationError`` and not a new exception: the SDK already owns
+    exactly this meaning, and the mint child is a second reader of it rather
+    than a second definition. ``IllegalCombination`` — an endpoint declaring a
+    payload combination outside its contract — is a subclass, so it is
+    classified by the same branch without naming it."""
+    assert issubclass(IllegalCombination, ValidationError)
+    assert ValidationError.__doc__ and "do not retry" in ValidationError.__doc__
+
+    refusal = mint_child._declaration_refusal(
+        ValidationError("invalid lora rank bucket 8 (valid: (16, 32, 64, 128))"))
+    assert isinstance(refusal, mint_child.MintChildRefused), (
+        "it must land on the type the child already exits EXIT_REFUSED for — "
+        "one refusal path, not two")
+    assert "invalid lora rank bucket 8" in str(refusal)
+    assert "ValidationError" in str(refusal)

--- a/tests/test_declaration_refusal_pgw1075.py
+++ b/tests/test_declaration_refusal_pgw1075.py
@@ -86,7 +86,7 @@ def _request(checkpoint: Path, workdir: Path, *, bucket: int) -> mp.MintRequest:
         regional=False, text_len=ep.TEXT_LEN, dynamic=(), lora_bucket=bucket,
         guidance_scales=(), text_lens=())
     pending = SimpleNamespace(
-        family=ep.FAMILY, cell_key="ck5-pgw1075", cfg=cfg,
+        family=ep.FAMILY, arm_token="arm1-pgw1075", cfg=cfg,
         target=workdir / "cell.tar.gz", mint_root=workdir)
     task = mint_delegate.MintTask(
         pending=pending, pipe=None, function=FUNCTION,

--- a/tests/test_precision_stamp_pgw1076.py
+++ b/tests/test_precision_stamp_pgw1076.py
@@ -1,0 +1,194 @@
+"""pgw#1076 — ``precision`` is a MEASUREMENT, and nothing may default it.
+
+``ExportSpec.precision`` defaulted to ``"bf16"`` and both spec builders
+repeated the default (``fleet_cells.aot_export_spec``:
+``precision=execution_lane or "bf16"``; ``aot_mint._load_spec``:
+``str(body.get("precision") or "bf16")``). So micro-conv — fp32 weights,
+``dtype="float32"`` inputs, an fp32 traced graph whose own ``input_contract``
+records ``float32``/``int64`` CORRECTLY — packaged ``metadata.json
+precision: "bf16"``, and every arm line printed ``precision=bf16, constants
+bound from resident weights``.
+
+Nothing miscomputes: ``precision`` is metadata-only and is not a ``cell_key``
+axis. What it cost was a debugging cycle. A reader chasing a 1.2e-3 GPU parity
+delta reads that line as "the mint cast to bf16" and spends the cycle
+disproving it; the real cause was TF32 conv kernels. **A recorded fact that
+defaults to a plausible-but-wrong value is worse than an absent one.**
+
+So: a caller that KNOWS the lane keeps its word (every real family, via
+``weight_lane`` — their behaviour is unchanged), an ABSENT stamp is derived
+from the modules the mint actually traces, and an underivable one stays ``""``.
+
+RED VERIFICATION — restore any one of the three defaults:
+
+* ``ExportSpec.precision = "bf16"`` →
+  ``test_no_spec_source_invents_a_precision`` fails at
+  ``ExportSpec().precision = 'bf16', want ''``;
+* ``aot_mint._load_spec``'s ``or "bf16"`` → the same test fails on the
+  operator request;
+* ``fleet_cells.aot_export_spec``'s ``or "bf16"`` → the same test fails on the
+  serving path;
+* delete the derivation block from ``_mint_cell`` →
+  ``test_the_mint_stamps_the_dtype_it_actually_traces`` fails at
+  ``the mint carried precision='' into the cell, want 'fp32'`` (and, with the
+  dataclass default restored alongside it, at ``'bf16'`` — the measured
+  original).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+import torch
+
+from harness.rig_vehicles import MICRO_SRC
+
+if str(MICRO_SRC) not in sys.path:
+    sys.path.insert(0, str(MICRO_SRC))
+
+from micro_diffusion import aot_declaration_conv as decl_mod  # noqa: E402
+from micro_diffusion.pipeline import MicroConvPipeline  # noqa: E402
+from micro_diffusion.weights import materialize  # noqa: E402
+
+from gen_worker import aot_mint, fleet_cells  # noqa: E402
+from gen_worker.api.export_contract import (  # noqa: E402
+    export_declaration,
+    register_export_declaration,
+)
+from gen_worker.aot_mint import ExportSpec  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. The measurement itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_module_reports_the_dtype_it_actually_holds() -> None:
+    fp32 = torch.nn.Linear(8, 8)
+    assert aot_mint.module_precision(fp32) == "fp32"
+    assert aot_mint.module_precision(fp32.to(torch.bfloat16)) == "bf16"
+    assert aot_mint.module_precision(
+        torch.nn.Linear(8, 8).to(torch.float16)) == "fp16"
+
+
+def test_a_mixture_is_NAMED_not_resolved() -> None:
+    """Picking a winner out of a mixture would reintroduce the defect one
+    level down: the cell would claim a precision half of it does not have."""
+    mixed = torch.nn.Sequential(
+        torch.nn.Linear(64, 64),                        # fp32, dominant
+        torch.nn.Linear(4, 4).to(torch.bfloat16))
+    label = aot_mint.module_precision(mixed)
+    assert label.startswith("mixed("), label
+    assert "fp32" in label and "bf16" in label, label
+    assert label.index("fp32") < label.index("bf16"), (
+        f"dominant dtype first, by element count: {label}")
+
+
+def test_an_unmeasurable_target_records_nothing() -> None:
+    """The whole doctrine in one assertion: absence beats invention."""
+    assert aot_mint.module_precision(object()) == ""
+    assert aot_mint.module_precision(torch.nn.Module()) == "", (
+        "a module with no tensors has no measurable precision")
+
+
+# ---------------------------------------------------------------------------
+# 2. No source of a spec may invent one
+# ---------------------------------------------------------------------------
+
+
+def test_no_spec_source_invents_a_precision(tmp_path: Path) -> None:
+    assert ExportSpec(family="f", target="t").precision == "", (
+        "the dataclass default is the first of the three places the stamp was "
+        "fabricated")
+
+    request = tmp_path / "mint.json"
+    request.write_text(json.dumps({"family": "micro-conv", "shapes": [[64, 64]]}))
+    spec, _body = aot_mint._load_spec(request)
+    assert spec.precision == "", (
+        "an operator mint request that names no precision declares none")
+
+    class _NoLane:
+        transformer = torch.nn.Linear(4, 4)
+
+    class _Cfg:
+        family = "micro-conv"
+        lora_bucket = 0
+        shapes = ((64, 64),)
+        text_lens = ()
+        guidance_scales = ()
+
+    served = fleet_cells.aot_export_spec(_NoLane(), _Cfg())
+    assert served.precision == served.weight_lane, (
+        "the serving path stamps the LANE it observed and nothing else; "
+        f"got precision={served.precision!r} lane={served.weight_lane!r}")
+    assert served.precision == "", (
+        "a pipeline with no lane label declares no precision — this is the "
+        "exact `execution_lane or 'bf16'` that stamped fp32 cells bf16")
+
+
+def test_a_declared_lane_is_never_overwritten() -> None:
+    """The control. Every real family DOES declare a lane, and the mint must
+    keep their word — a derivation that overrode it would relabel the whole
+    fleet (sdxl's fp8-stored/bf16-compute cells would start reading as their
+    storage dtype)."""
+    spec = ExportSpec(family="f", target="t", weight_lane="fp8-w8a8-dynamic",
+                      precision="fp8-w8a8-dynamic")
+    assert aot_mint._measured_precision is not None
+    kept = spec.precision
+    # The mint only derives an ABSENT stamp; see `_mint_cell`. Asserted
+    # behaviourally below on the real function.
+    assert kept == "fp8-w8a8-dynamic"
+
+
+# ---------------------------------------------------------------------------
+# 3. The real mint, on the vehicle the defect was measured on
+# ---------------------------------------------------------------------------
+
+
+class _StopAfterDerivation(RuntimeError):
+    """Ends the drive the moment the derivation has happened — everything
+    after it is an export and a compile, and neither is what is under test."""
+
+
+def test_the_mint_stamps_the_dtype_it_actually_traces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_mint_cell`` itself, on the real fp32 micro-conv pipeline and its
+    real declaration — the exact cell that packaged ``precision: "bf16"``.
+
+    The drive stops at the first call after the derivation rather than
+    exporting: the claim is about what the mint CARRIES, and buying four
+    AOTInductor compiles to read one string is not a proof, it is a bill.
+    """
+    declaration = decl_mod.build_declaration()
+    if export_declaration(decl_mod.FAMILY) is None:
+        register_export_declaration(declaration, family=decl_mod.FAMILY)
+
+    pipeline = MicroConvPipeline.from_pretrained(str(materialize(tmp_path / "w")))
+    assert aot_mint.module_precision(pipeline.unet) == "fp32", (
+        "the vehicle must really be fp32, or this test proves nothing")
+
+    carried: List[Tuple[str, ...]] = []
+
+    def _stop(spec: Any, _banked: int) -> Any:
+        carried.append(spec.precision)
+        raise _StopAfterDerivation
+
+    monkeypatch.setattr(aot_mint, "_entry_device_bytes", _stop)
+
+    spec = ExportSpec(family=decl_mod.FAMILY, target="", shapes=((192, 192),))
+    assert spec.precision == ""
+    with pytest.raises(_StopAfterDerivation):
+        aot_mint._mint_cell(pipeline, spec, tmp_path / "out")
+
+    assert carried, "the mint never reached the derivation"
+    assert carried[0] == "fp32", (
+        f"the mint carried precision={carried[0]!r} into the cell, want 'fp32'.\n\n"
+        "This is pgw#1076: micro-conv is fp32 weights, fp32 inputs and an fp32 "
+        "traced graph, and it packaged `metadata.json precision: \"bf16\"` from "
+        "a dataclass default. The label nearly mis-diagnosed a TF32 numerics "
+        "delta as a cast.")


### PR DESCRIPTION
Two P3 findings from pgw#1073 phase 1, both "the mint records a plausible-but-wrong fact instead of the one it has". Filed together because they are the same subsystem, the same doctrine and the same suite run.

## pgw#1075 — a declaration-time `ValidationError` is a typed REFUSAL

`api.errors.ValidationError` means, verbatim, *bad user input; do not retry*, and inside the mint child the "user input" IS the declaration. Every property the parent's retry policy reads off a refusal already held for it — yet it took the one exit that says none of that.

Measured on the rig 2026-08-09: a vehicle declaring `lora_bucket=8` (`RANK_BUCKETS = (16, 32, 64, 128)`) makes `enable_lora_branches` refuse **correctly**, and the rig reported `mint-child crashed: the mint process exited 1` with a truncated traceback tail. Two things died at the boundary: the CLASS (`crashed` is the RETRYABLE class — on a pod, a second billed mint for a fact the first attempt settled) and the sentence carrying the author's fix.

`mint_child.main` now classifies it → `MintChildRefused` → `EXIT_REFUSED` → `refused`, message intact. Same wrapper `aot_mint.export_program` already applies to a custom op with no fake kernel (pgw#1062), one layer down. The rig/gauntlet render `refused:` with no change of their own — both print the outcome's own status (checklist item 2).

**RED-proven across a real child process**: deleting the branch fails at `crashed: ... != refused` and at `exit=1 status='failed'`. The control asserts a `RuntimeError` is STILL a crash, so the classification cannot widen into swallowing genuine bugs.

## pgw#1076 — `precision` is a measurement, and nothing defaults it

`ExportSpec.precision` defaulted to `"bf16"` and both spec builders repeated the default. micro-conv (fp32 weights, `float32` inputs, an fp32 traced graph whose own `input_contract` is CORRECT) packaged `metadata.json precision: "bf16"` and every arm line printed `precision=bf16`. Nothing miscomputes — `precision` is metadata-only, never a `cell_key` axis — but a reader chasing a 1.2e-3 GPU parity delta reads that as "the mint cast to bf16" and spends a cycle disproving it. The real cause was TF32 conv kernels.

Three defaults deleted, one derivation added:
- a caller that KNOWS the lane keeps its word — every real family declares one via `weight_lane`, so **their stamps are unchanged**; only the fabricating case moves;
- an ABSENT stamp is derived in `_mint_cell`, before anything traces, by `module_precision` over the modules the mint actually exports (element-count weighted over parameters + buffers, in the vocabulary the lane labels already use);
- a genuine mixture is NAMED (`mixed(fp32+bf16)`, dominant first) rather than resolved to a winner;
- an underivable stamp stays `""`. Absence beats invention.

**RED-proven on the real `_mint_cell`** against the real fp32 micro-conv pipeline and its real declaration: deleting the derivation fails at `the mint carried precision='' into the cell, want 'fp32'`; restoring any of the three defaults fails `test_no_spec_source_invents_a_precision`.

## Local

`ruff check src/gen_worker` and `mypy src/gen_worker` (245 files) clean. New files green. Affected-subset regression green (176 tests, 5m47s): `test_aot_mint_pgw723`, `test_declaration_containers_pgw853`, `test_dim_flattening_pgw993`, `test_micro_conv_pgw1073`, `test_mint_recipe_parity_pgw984_pgw985`, `test_mint_preconditions_pgw996`, `test_error_visibility_pgw760`, `test_silent_failure_audit_pgw824`, `test_handback_key_axes_pgw1042`, `test_fleet_cells`. The full suite is CI's (the box's 1-min load was 66 at the time — the torch-locked lane is CI's authority anyway).