### PR TITLE
pgw#1077: a REFUTED equality is not a pin — the declared-range gate reads the axiom's VALUE

### DIFF
--- a/changelog.d/pgw1077.md
+++ b/changelog.d/pgw1077.md
@@ -1,0 +1,14 @@
+- **pgw#1077: the declared-range gate no longer reads a REFUTED equality as a
+  pin.** `_pinning_guards` iterated `ShapeEnv.axioms` by KEY, but that map is
+  `{relation: sympy.true | sympy.false}` and torch's
+  `symbolic_shapes.get_implications` deposits `Eq(a, b) => false` — plus its
+  commuted mirror — for every `Ne(a, b)` the graph PROVES. So every inequality
+  a graph settled came back as an equality guard "which PINS the declared
+  dynamic symbol(s)", in mirrored pairs. Measured: six such keys
+  (`Eq(Mod(1, s18*s57), 0) => False` and friends) refused z-image on the
+  endpoint ie#637 had already fixed, with pgw#868 A2 blocked behind it. The
+  gate now consults the value — only a recognised `false` admits, so an
+  unreadable value stays refused exactly as before — and reports one refusal
+  per relation instead of one per orientation. Real pins are untouched: a
+  genuine `Eq(h*w, N)` still refuses, including when it survives only as a
+  TRUE axiom (`tests/test_axiom_refutations_pgw1077.py`, real exports).

--- a/src/gen_worker/aot_mint.py
+++ b/src/gen_worker/aot_mint.py
@@ -622,6 +622,29 @@ def _is_tautology(expr: Any) -> bool:
         return False
 
 
+def _refuted(value: Any) -> bool:
+    """``True`` when a dict source records this relation as PROVEN FALSE.
+
+    ``ShapeEnv.axioms`` is a ``{relation: sympy.true | sympy.false}`` map, and
+    ``symbolic_shapes.get_implications`` deposits ``Eq(a, b) => false`` — plus
+    its commuted mirror — for every ``Ne(a, b)`` the graph PROVES. So a bare
+    KEY of that map is a refutation as often as a pin: pgw#1077 measured six
+    such keys (``Eq(Mod(1, s18*s57), 0)`` and friends) refusing a z-image mint
+    whose declared symbols nothing pinned.
+
+    Only a recognised false admits; an unrecognised value stays refused, the
+    same fail-closed direction :func:`_is_tautology` takes.
+    """
+    if isinstance(value, bool):
+        return value is False
+    try:
+        import sympy
+
+        return value is sympy.false
+    except Exception:  # noqa: BLE001 — an unreadable value stays refused
+        return False
+
+
 def _pinning_guards(program: Any, declared_symbols: Sequence[Any]) -> List[str]:
     """Equality guards that pin a declared-dynamic symbol (ie#566 G3).
 
@@ -660,7 +683,10 @@ def _pinning_guards(program: Any, declared_symbols: Sequence[Any]) -> List[str]:
     for source in ("guards", "axioms"):
         entries = getattr(env, source, None) or ()
         if isinstance(entries, dict):
-            entries = list(entries)
+            # The VALUE is the truth the graph proved — reading keys alone
+            # reports every proven inequality as a pin (pgw#1077).
+            entries = [key for key, value in entries.items()
+                       if not _refuted(value)]
         for entry in entries:
             expr = getattr(entry, "expr", entry)
             if expr is None:
@@ -687,9 +713,12 @@ def _pinning_guards(program: Any, declared_symbols: Sequence[Any]) -> List[str]:
             if _is_tautology(expr):
                 continue
             text = str(expr)
-            if text in seen:
+            # ``Eq(a, b)`` and ``Eq(b, a)`` are one relation written twice —
+            # get_implications records both — so report it once (pgw#1077).
+            key = tuple(sorted(str(side) for side in sides))
+            if key in seen:
                 continue
-            seen.add(text)
+            seen.add(key)
             out.append(
                 f"the exported program carries the equality guard {text}, "
                 f"which PINS the declared dynamic symbol(s) {hit!r} — some "

--- a/tests/test_axiom_refutations_pgw1077.py
+++ b/tests/test_axiom_refutations_pgw1077.py
@@ -1,0 +1,133 @@
+"""pgw#1077 — a REFUTED equality is not a pin.
+
+``_pinning_guards`` iterated ``ShapeEnv.axioms`` by KEY. That map is
+``{relation: sympy.true | sympy.false}`` and torch's
+``symbolic_shapes.get_implications`` deposits ``Eq(a, b) => false`` plus its
+commuted mirror for every ``Ne(a, b)`` the graph PROVES — so every inequality
+the graph settled was reported as an equality guard PINNING the declared
+symbols, in mirrored pairs. Measured cost: six such keys refused z-image on the
+endpoint ie#637 had already fixed (`Eq(Mod(1, s18*s57), 0) => False` and
+friends), with A2 blocked behind it.
+
+Every test here drives a real ``torch.export`` and asserts on the shipped gate.
+The controls matter as much as the repro: a genuine ``Eq(h*w, N)`` pin must
+still refuse — from the axioms source alone, not only from ``guards`` — and an
+axiom whose value this gate cannot read stays refused, fail-closed.
+
+Scope note: the branch that proves ``Ne`` narrows the served set only when the
+refuted value is REACHABLE inside the declared hull. This gate has never
+modelled that (a ``Ne`` guard is not an ``Eq``, so the ``guards`` source skips
+it too), and the repro below is deliberately hull-clean — 102 is not a product
+of two integers both in [8, 32] — so nothing is excluded by admitting it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker import aot_mint  # noqa: E402
+
+
+_SPEC = {"x": {2: torch.export.Dim("h", min=8, max=32),
+               3: torch.export.Dim("w", min=8, max=32)}}
+_DIMS = (aot_mint.DynamicDim("x", 2, 8, 32),
+         aot_mint.DynamicDim("x", 3, 8, 32))
+
+
+class _ProvenInequality(torch.nn.Module):
+    """Asks a question the tracer can only answer by PROVING ``h*w != 102``.
+
+    102 = 2*3*17 has no factorization with both factors in [8, 32], so the
+    inequality holds for every shape the declaration admits — the same
+    situation as z-image's ``Mod(1, s18*s57) != 0``.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _b, _c, h, w = x.shape
+        if h * w != 102:
+            return x.flatten(2).sum(-1)
+        return x.flatten(2).mean(-1)
+
+
+class _GenuinePin(torch.nn.Module):
+    """The ie#566 G3 true positive: a static input length fixes ``h*w``."""
+
+    def forward(self, x: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
+        b, c, h, w = x.shape
+        return x.reshape(b, c, h * w) + tokens.reshape(1, 1, -1)
+
+
+def _proven_inequality_program() -> object:
+    return torch.export.export(
+        _ProvenInequality().eval(), (torch.randn(2, 4, 16, 24),), {},
+        dynamic_shapes=_SPEC, strict=True)
+
+
+def _genuine_pin_program() -> object:
+    h, w = 16, 24
+    return torch.export.export(
+        _GenuinePin().eval(),
+        (torch.randn(2, 4, h, w), torch.randn(h * w)), {},
+        dynamic_shapes={"x": _SPEC["x"], "tokens": None}, strict=True)
+
+
+def test_the_reproduction_really_is_a_REFUTED_axiom() -> None:
+    """Guard the repro itself: if torch stops writing the refuted mirror the
+    test below would pass vacuously, which is the wrong kind of green."""
+    sympy = pytest.importorskip("sympy")
+    env = aot_mint._shape_env(_proven_inequality_program())
+    guards = [str(getattr(g, "expr", g)) for g in getattr(env, "guards", ())]
+    assert guards == ["Ne(s37*s46, 102)"], guards
+    axioms = {str(k): v for k, v in (getattr(env, "axioms", {}) or {}).items()}
+    assert axioms["Eq(s37*s46, 102)"] is sympy.false, axioms
+    assert axioms["Eq(102, s37*s46)"] is sympy.false, axioms
+
+
+def test_a_proven_inequality_is_NOT_reported_as_a_pin() -> None:
+    """The z-image residue, in twelve lines: the graph PROVED the relation
+    does not hold, and the gate refused the mint for it anyway."""
+    gaps = aot_mint.declared_range_gaps(_proven_inequality_program(), _DIMS)
+    assert gaps == [], (
+        "an axiom recorded as sympy.false is a refutation, not a pin: "
+        f"{gaps!r}")
+
+
+def test_a_genuine_pin_is_STILL_refused() -> None:
+    """The primary control — ie#637's pre-fix arm, whose real pin arrives as a
+    TRUE axiom. It must keep refusing, and now says so ONCE."""
+    gaps = aot_mint.declared_range_gaps(_genuine_pin_program(), _DIMS)
+    assert len(gaps) == 1, f"one relation, one refusal: {gaps!r}"
+    assert "PINS" in gaps[0] and "Eq(s37*s46, 384)" in gaps[0]
+
+
+def test_a_true_axiom_refuses_even_with_the_guards_source_empty() -> None:
+    """The value filter must not amount to dropping ``axioms``: a pin present
+    only as a TRUE axiom (ie#637's ``Eq(PythonMod(-s18*s57, 32), 0) => True``)
+    still has to refuse."""
+    program = _genuine_pin_program()
+    env = aot_mint._shape_env(program)
+    env.guards = []
+    gaps = aot_mint.declared_range_gaps(program, _DIMS)
+    assert len(gaps) == 1 and "PINS" in gaps[0], gaps
+
+
+def test_an_unreadable_axiom_value_stays_refused() -> None:
+    """Fail-closed, the same direction ``_is_tautology`` takes: only a
+    recognised false admits."""
+    program = _proven_inequality_program()
+    env = aot_mint._shape_env(program)
+    env.axioms = {key: object() for key in env.axioms}
+    gaps = aot_mint.declared_range_gaps(program, _DIMS)
+    assert gaps and "PINS" in gaps[0], gaps
+
+
+def test_refuted_and_unreadable_values_discriminate_directly() -> None:
+    sympy = pytest.importorskip("sympy")
+    assert aot_mint._refuted(sympy.false)
+    assert aot_mint._refuted(False)
+    assert not aot_mint._refuted(sympy.true)
+    assert not aot_mint._refuted(True)
+    assert not aot_mint._refuted(object())
+    assert not aot_mint._refuted(None)


### PR DESCRIPTION
`_pinning_guards` iterated `ShapeEnv.axioms` by KEY. That map is `{relation: sympy.true | sympy.false}`, and torch's `symbolic_shapes.get_implications` deposits `Eq(a, b) => false` — plus its commuted mirror — for every `Ne(a, b)` the graph **proves**. So every inequality a graph settled came back as an equality guard *"which PINS the declared dynamic symbol(s)"*, and the mirrored pairs in every such refusal were that one rule written twice.

Measured by the ie#637 lane: six such keys (`Eq(Mod(1, s18*s57), 0)`, `Eq(Mod(s18, s18*s57), 0)`, `Eq(Mod(2, 64*(((s18*s57 + 31)//32))), 0)`, each with a mirror, all `=> False`) refused z-image on the endpoint ie#637 had already fixed (pad32, `3860b69`) — the last blocker in front of pgw#868 A2.

## The fix

- the gate consults the axiom's VALUE; only a recognised `false` admits, so an unreadable/absent value stays refused (the fail-closed direction `_is_tautology` already takes)
- `axioms` is **not** dropped as a source — a pin surviving only as a TRUE axiom must still refuse
- refusals dedupe per RELATION, not per orientation: one relation, one message

## RED chain (real exports, torch 2.13.0, off-GPU, $0)

`tests/test_axiom_refutations_pgw1077.py`

| case | master | this PR |
|---|---|---|
| proven inequality `Ne(s37*s46, 102)` (hull-clean: 102 has no factorization with both factors in [8, 32]) | **2 gaps — refused** | **0 — admitted** |
| genuine pin `Eq(s37*s46, 384)` (ie#566 G3's own case) | 2 gaps — refused | **1 — still refused** |
| the same pin with `guards` emptied (axioms-only, ie#637's `PythonMod(...) => True` shape) | refused | **still refused** |
| an axiom value the gate cannot read | refused | **still refused** |

The reproduction is itself guarded (`guards == ['Ne(s37*s46, 102)']`; both `Eq` orientations recorded `sympy.false`) so it cannot pass vacuously.

Existing gate suites re-run green — pgw#723 (G3 genuine / coincidence / sdxl regression), pgw#812 (flux2's vacuous `Mod(64*X, X)` still ADMITTED), pgw#993, pgw#739: **103 passed**. mypy 245 files clean; ruff clean on the touched files. pgw#1059-era admission surfaces untouched.

Scope note: a branch proving `Ne` narrows the served set only when the refuted value is REACHABLE in the declared hull. This gate has never modelled that (a `Ne` guard is not an `Eq`, so `guards` skipped it too), and z-image's six refutations are all unreachable. A hull-reachability check is a different gate, not this fix.

Ships as the `v0.96.3` vehicle immediately after merge (tag `v0.96.2` + this commit), then the inference-endpoints repin — pgw#868 A2 re-runs on it.