### PR TITLE
pgw#1020 + pgw#1018 + pgw#945: a guard that could not see a quantized leaf, a formula that could not count a container, and a temp name two writers shared

### DIFF
--- a/changelog.d/pgw1018.md
+++ b/changelog.d/pgw1018.md
@@ -1,0 +1,11 @@
+- **pgw#1018: a countable container is a runtime-formula variable.**
+  `RuntimeFormula` accepted scalar payload fields only, so an endpoint whose
+  compute time scales with a list's LENGTH could not declare the term at all —
+  H3's ref2va (208 s vs 80 s for the same duration, ie#612) was cost-modeled as
+  if its references were free. An identifier naming a list or map field now
+  binds to that container's ITEM COUNT, which is the vocabulary the hub's
+  pricing side has had since th#833/ie#600, so one string
+  (`"a + b*num_inference_steps + c*references"`) prices and predicts the same
+  request. Deliberately NOT `len(...)`: the formula string is the wire
+  contract, calls are outside the grammar on both sides, and a term key the hub
+  cannot canonicalize identically is not a term.

--- a/changelog.d/pgw1020.md
+++ b/changelog.d/pgw1020.md
@@ -1,0 +1,11 @@
+- **pgw#1020: the mixed-compute-dtype guard can see a quantized leaf.**
+  pgw#683's load-time refusal collected its evidence with
+  `isinstance(leaf, (nn.Linear, nn.Conv*))`, and all five quantized leaves
+  (`_Fp8ScaledLinear`, `_W4A4Linear`, `_SvdqLinear`, `_SvdqFusedLinear`,
+  `_AwqPackedLinear`) subclass `nn.Module` directly — so a w8a8 fp16 denoiser
+  inside a bf16 composition, the exact cross-composition aliasing shape the
+  guard exists to refuse, produced `{}` evidence and PASSED. Now every leaf's
+  declared `compute_dtype` (recorded by pgw#1015/pgw#1019) counts as a GEMM
+  input dtype, so a bias-free quantized layer states its precision to the
+  guard. fp8/fp4 storage dtypes stay uncounted and embeddings keep their
+  exclusion.

--- a/changelog.d/pgw945.md
+++ b/changelog.d/pgw945.md
@@ -1,0 +1,10 @@
+- **pgw#945: the three remaining fixed-name temp paths, classified and fixed.**
+  `request_context/_datasets._download_url_streamed` was the racy one:
+  `resolve_dataset` materializes into a pod-wide content-keyed cache, so two
+  requests for one dataset reach the same `dest` — and the temp name was
+  derived from it, so one writer's failure path unlinked the other's in-flight
+  download and the victim then failed its own rename after paying for every
+  byte. `disk_gc.RefIndex._save_locked` holds a THREAD lock over an index in a
+  shared cache dir; `env_seal.write_library_memo` is per-attempt today but
+  promised atomicity in its own docstring. All three now write a unique temp
+  file in the destination directory; each site records its classification.

--- a/src/gen_worker/api/formula.py
+++ b/src/gen_worker/api/formula.py
@@ -25,6 +25,14 @@ Grammar (ASCII only; ``WS`` is space, tab, or newline)::
 
 There are no comments, calls, comparisons, Unicode identifiers, or numeric
 separators. Top-level ``+`` joins learned-coefficient terms.
+
+A COUNTABLE CONTAINER is a payload variable (pgw#1018, mirroring the hub's
+``internal/price`` th#833/ie#600 rule): an identifier naming a LIST or a MAP
+field binds to that container's ITEM COUNT. There is deliberately no ``len()``
+— the grammar is the wire contract, calls are excluded from it on both sides,
+and a term key the hub cannot canonicalize identically is not a term. One
+vocabulary: ``"a + b*num_inference_steps + c*references"`` prices and predicts
+the same reference-heavy request with the same string.
 """
 
 from __future__ import annotations
@@ -32,6 +40,8 @@ from __future__ import annotations
 import ast
 import math
 import re
+import types
+import typing
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 
@@ -46,6 +56,11 @@ __all__ = [
 ]
 
 _NUMERIC_TYPES = (int, float, bool)
+#: The container kinds that carry an item count. Exactly the hub's
+#: ``price.numericValue`` set (a JSON array or object) — `str`/`bytes` are
+#: Sized and are NOT countable containers: a prompt's length is not a declared
+#: cost dimension on either side, and admitting it here would price one.
+_COUNTABLE_TYPES = (list, tuple, set, frozenset, dict)
 _FORMULA_SPACE = " \t\n"
 _RESERVED_IDENTIFIERS = frozenset({
     "False", "None", "True", "and", "as", "assert", "async", "await",
@@ -167,6 +182,12 @@ class RuntimeFormula:
                 raise ValueError(
                     f"{owner}: runtime formula field {name!r} is not a payload field"
                 )
+            if _is_countable_container(getattr(f, "type", None)):
+                # pgw#1018: a list/map field IS a numeric term — its item
+                # count. It needs no numeric default: an omitted or null
+                # container is zero items, which is a reading of the field
+                # rather than a guess about it.
+                continue
             default = f.default
             if default is msgspec.NODEFAULT and f.default_factory is not msgspec.NODEFAULT:
                 default = f.default_factory()
@@ -226,6 +247,7 @@ class RuntimeFormula:
         explicit payload value wins; a ``None``/missing wire field falls
         back to the same-named field of ``defaults`` (the catalog-resolved
         recipe object, ``ctx.defaults``)."""
+        containers: Optional[Set[str]] = None   # resolved only if a None shows up
         values: Dict[str, float] = {}
         for name in self.fields:
             raw = getattr(payload, name, None)
@@ -233,8 +255,21 @@ class RuntimeFormula:
                 raw = getattr(defaults, name, None)
             if isinstance(raw, bool):
                 values[name] = 1.0 if raw else 0.0
+            elif isinstance(raw, _COUNTABLE_TYPES):
+                # pgw#1018: the countable-container reading, identical to the
+                # hub's `price.PayloadVars`.
+                values[name] = float(len(raw))
             elif isinstance(raw, (int, float)):
                 values[name] = raw
+            elif raw is None:
+                # A DECLARED container that arrived null/absent is zero items.
+                # Only the declaration makes this safe: a missing NUMBER stays
+                # missing, so the formula still declines rather than reading a
+                # zero into a term the request never stated.
+                if containers is None:
+                    containers = _countable_fields(type(payload))
+                if name in containers:
+                    values[name] = 0.0
         return self.term_values(values)
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -363,6 +398,36 @@ def _parse_terms(source: str, limits: FormulaLimits) -> List[_Term]:
             )
         terms.append(_Term(constant, key, factor))
     return terms
+
+
+def _is_countable_container(annotation: Any) -> bool:
+    """Is this declared field type a countable container (pgw#1018)?
+
+    ``list[X]``, ``dict[K, V]``, ``tuple[...]``, ``set[X]`` and their
+    ``Optional``/union spellings. A union counts only when EVERY non-``None``
+    member is countable — ``Union[list[X], int]`` is two different readings of
+    one identifier and is refused as a plain non-numeric field would be.
+    """
+    if annotation is None:
+        return False
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        members = [a for a in typing.get_args(annotation) if a is not type(None)]
+        return bool(members) and all(_is_countable_container(a) for a in members)
+    target = origin if origin is not None else annotation
+    return isinstance(target, type) and issubclass(target, _COUNTABLE_TYPES)
+
+
+def _countable_fields(payload_type: Any) -> Set[str]:
+    """Names of the struct's countable-container fields; empty for anything
+    that is not a msgspec Struct (the value-shape reading still applies)."""
+    try:
+        return {
+            f.name for f in msgspec.structs.fields(payload_type)
+            if _is_countable_container(getattr(f, "type", None))
+        }
+    except Exception:
+        return set()
 
 
 def _check_nodes(node: ast.expr) -> None:

--- a/src/gen_worker/env_seal.py
+++ b/src/gen_worker/env_seal.py
@@ -53,6 +53,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
@@ -317,10 +318,18 @@ def write_library_memo(path: Path) -> int:
 
     Cheap in a process that already sealed (the lru_cache is warm: the pass
     degenerates to stats); pays the full hash exactly once otherwise. The
-    write is atomic (tmp + rename) so a reader never sees a torn file.
-    Raises ``OSError`` on an unwritable destination — the CALLER decides
+    write is atomic (unique temp file + rename) so a reader never sees a torn
+    file. Raises ``OSError`` on an unwritable destination — the CALLER decides
     whether that is worth a typed event; children fall back to the full
-    rehash either way."""
+    rehash either way.
+
+    pgw#945 classification: today's only caller hands a PER-ATTEMPT path
+    (``aot_compile_pool`` seeds ``<mint workdir>/seal-lib-memo.json``, and the
+    workdir is ``<mint root>/child-<attempt>``), so no two writers meet. The
+    atomicity promise above is this FUNCTION's, though, not that caller's, and
+    a temp name derived from the destination silently makes it conditional on
+    a fact stated somewhere else. Unique per writer, so it holds for whatever
+    path arrives."""
     digests: Dict[str, str] = {}
     for _base, lib_paths in sorted(_toolchain_lib_paths().items()):
         for lib_path in lib_paths:
@@ -333,9 +342,15 @@ def write_library_memo(path: Path) -> int:
     encoded = json.dumps(
         {"memo_v": _MEMO_V, "digests": digests},
         sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(encoded)
-    os.replace(tmp, path)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent),
+                                    prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(encoded)
+        os.replace(tmp_name, path)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
     return len(digests)
 
 

--- a/src/gen_worker/models/disk_gc.py
+++ b/src/gen_worker/models/disk_gc.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import stat
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -45,11 +46,32 @@ class RefIndex:
             logger.warning("ref-index unreadable (%s); starting empty", exc)
 
     def _save_locked(self) -> None:
+        """Write the index through, atomically.
+
+        pgw#945: ``self._lock`` is a THREAD lock, so it orders the writers in
+        one process and says nothing about the others. The index lives in the
+        model cache dir — a path a mounted cache can share between processes
+        (procsplit members, a second container on the same volume) — and the
+        old temp name was derived from the destination, so every such writer
+        opened one file. Interleaved writes of two different index states
+        produce a torn document that the reader above logs as "unreadable" and
+        starts EMPTY from, losing the ref accounting GC and the boot rescan
+        reason in. A unique temp file per writer keeps the rename atomic and
+        makes the loser's outcome a whole valid index rather than a mixture.
+        """
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = self._path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(self._data), encoding="utf-8")
-            tmp.replace(self._path)
+            fd, tmp_name = tempfile.mkstemp(
+                dir=str(self._path.parent), prefix=self._path.name + ".",
+                suffix=".tmp")
+            tmp = Path(tmp_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(json.dumps(self._data))
+                tmp.replace(self._path)
+            except BaseException:
+                tmp.unlink(missing_ok=True)
+                raise
         except Exception as exc:
             logger.warning("ref-index write failed: %s", exc)
 

--- a/src/gen_worker/models/loading.py
+++ b/src/gen_worker/models/loading.py
@@ -1058,8 +1058,20 @@ _INCOMPATIBLE_COMPUTE = ("float16", "bfloat16")
 def _gemm_param_dtypes(module: Any) -> Dict[str, str]:
     """``{parameter path: dtype name}`` for every GEMM input under ``module``
     — Linear/conv weights and biases, the tensors torch actually refuses to
-    mix. Norms/embeddings are excluded: they carry their own (legitimately
-    wider) precision and never meet a weight in one kernel."""
+    mix, plus every quantized leaf's DECLARED ``compute_dtype``. Norms and
+    embeddings are excluded: they carry their own (legitimately wider)
+    precision and never meet a weight in one kernel.
+
+    pgw#1020: the isinstance selector alone is BLIND to the quantized lanes.
+    All five quantized leaves (``_Fp8ScaledLinear``, ``_W4A4Linear``,
+    ``_SvdqLinear``, ``_SvdqFusedLinear``, ``_AwqPackedLinear``) subclass
+    ``nn.Module`` directly, so a w8a8 fp16 denoiser inside a bf16 composition
+    — the exact cross-composition aliasing shape pgw#683 exists to refuse —
+    read as ``{}`` here and PASSED the guard. Their upcast target is a fact
+    they state: ``self.compute_dtype`` is what every one of their forwards
+    computes in (and what its bias must match), so it is a GEMM input dtype
+    whether or not a bias tensor exists to carry it.
+    """
     import torch.nn as nn
 
     gemm_types = (
@@ -1068,7 +1080,14 @@ def _gemm_param_dtypes(module: Any) -> Dict[str, str]:
     )
     out: Dict[str, str] = {}
     for name, leaf in module.named_modules():
-        if not isinstance(leaf, gemm_types):
+        declared = getattr(leaf, "compute_dtype", None)
+        # An embedding declares one on the fp8-storage lane
+        # (`restructure_fp8_storage` stamps every covered leaf, embeddings
+        # included). It stays excluded — the exclusion is about the kernel it
+        # feeds, not about how it stores its rows.
+        if isinstance(leaf, nn.Embedding):
+            continue
+        if not isinstance(leaf, gemm_types) and declared is None:
             continue
         for attr in ("weight", "bias"):
             t = getattr(leaf, attr, None)
@@ -1078,6 +1097,12 @@ def _gemm_param_dtypes(module: Any) -> Dict[str, str]:
             dt_name = str(dt).rsplit(".", 1)[-1]
             if dt_name in _COMPUTE_DTYPE_NAMES:
                 out[f"{name}.{attr}" if name else attr] = dt_name
+        # Storage dtypes stay uncounted here too: a leaf declaring an fp8
+        # `compute_dtype` fails the membership test exactly as its fp8 weight
+        # does, so pgw#683's carve-out is unchanged.
+        dec_name = str(declared).rsplit(".", 1)[-1] if declared is not None else ""
+        if dec_name in _COMPUTE_DTYPE_NAMES:
+            out[f"{name}.compute_dtype" if name else "compute_dtype"] = dec_name
     return out
 
 

--- a/src/gen_worker/request_context/_datasets.py
+++ b/src/gen_worker/request_context/_datasets.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
+import tempfile
 import time
 import urllib.parse
 from pathlib import Path
@@ -284,8 +286,21 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
                            expected_size: Optional[int]) -> None:
     """Stream ``url`` → ``dest`` (1MiB chunks), verifying digest/size.
 
-    Writes to ``dest.tmp`` then renames, so a partial download can never be
-    mistaken for a complete shard.
+    Writes to a UNIQUE temp file in ``dest``'s directory then renames, so a
+    partial download can never be mistaken for a complete shard.
+
+    pgw#945: this site is RACY, and it was the one of pgw#938's three that
+    is. ``resolve_dataset`` materializes into a pod-wide content-keyed cache
+    (``/tmp/gen_worker_datasets/<owner>/<name>/<snapshot>``), so two requests
+    in one container asking for one dataset arrive at the SAME ``dest`` — and
+    the old name was derived from it (``dest.tmp``), so they arrived at the
+    same temp file too. The bytes are identical (same snapshot), which is what
+    made this look harmless; the destruction is in the LIFECYCLE, not the
+    content. One writer's failure path runs ``tmp.unlink()`` on the other's
+    in-flight download, and the victim then fails its own ``replace`` after
+    paying for every byte. A unique name per writer costs one ``mkstemp`` and
+    removes the shared object entirely; the rename stays atomic, and two
+    winners simply publish the same verified bytes.
 
     pgw#1013: the size comparison used to sit after the loop, where the bytes
     are already on disk and the only thing it can report is how far past the
@@ -294,7 +309,10 @@ def _download_url_streamed(url: str, dest: Path, *, expected_digest: str,
     destination filesystem, which is what an unbounded shard exhausts.
     """
 
-    tmp = dest.with_name(dest.name + ".tmp")
+    fd, tmp_name = tempfile.mkstemp(dir=str(dest.parent), prefix=dest.name + ".",
+                                    suffix=".part")
+    os.close(fd)
+    tmp = Path(tmp_name)
     algo = expected_digest.partition(":")[0]
     # Not `.get(...) or None`: an unverifiable download must be unreachable,
     # and the way that guarantee dies is a hasher that is allowed to be absent.

--- a/tests/test_countable_container_formula_pgw1018.py
+++ b/tests/test_countable_container_formula_pgw1018.py
@@ -1,0 +1,142 @@
+"""pgw#1018: a RuntimeFormula could not express a countable-container term, so
+a reference-heavy request was cost-modeled as if its references were free.
+
+Measured by the H3 endpoint lane (ie#612): ref2va runs **208 s vs 80 s** for
+the same duration once references are present — ~2.6x — and the term for it
+could not be declared at all. The lane left it out rather than faking a
+constant, which is the honest failure and is why this is a filed gap instead
+of a wrong number in production.
+
+**The spelling the issue proposed (`len(references)`) is refused here, on
+purpose.** The formula STRING is the wire contract: `api/formula.py` mirrors
+tensorhub `internal/formula` byte-for-byte, calls are excluded from the
+grammar on both sides, and the term KEY is canonicalized from the expression —
+so a `len(...)` term would mint a key the hub can never reproduce. The
+platform already HAS this vocabulary and it is not a call: the hub's
+`internal/price` (th#833 / ie#600) binds an identifier naming an ARRAY or MAP
+to that container's ITEM COUNT. This closes the gap by teaching the worker the
+same reading, so pricing and runtime prediction share one string.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Dict, List, Optional
+
+import msgspec
+import pytest
+
+from gen_worker.api.formula import FormulaParseError, RuntimeFormula
+
+
+class RefPayload(msgspec.Struct):
+    prompt: str = ""
+    num_inference_steps: int = 28
+    references: List[str] = msgspec.field(default_factory=list)
+    knobs: Dict[str, float] = msgspec.field(default_factory=dict)
+    maybe_refs: Optional[List[str]] = None
+    caption: str = ""
+
+
+FORMULA = "a + b*num_inference_steps + c*references"
+
+
+def test_a_container_field_is_a_legal_term() -> None:
+    """The refusal that blocked H3: `references` has no numeric wire default
+    and never can have one, so declaration died before the endpoint could
+    price it."""
+    rf = RuntimeFormula(FORMULA)
+    rf.validate_for_payload(RefPayload, "ref2va")
+    assert rf.fields == ("num_inference_steps", "references")
+    # The key is the bare identifier — exactly what the hub canonicalizes for
+    # the same source. A term key that only one side can mint is not a term.
+    assert [t.key for t in rf.terms] == ["1", "num_inference_steps", "references"]
+
+
+def test_the_term_is_the_item_count() -> None:
+    rf = RuntimeFormula(FORMULA)
+    for n in (0, 1, 5):
+        got = rf.term_values_from_struct(
+            RefPayload(num_inference_steps=20, references=["r"] * n))
+        assert got == {"1": 1.0, "num_inference_steps": 20.0, "references": float(n)}
+
+
+def test_a_map_counts_its_entries() -> None:
+    """`maxProperties` is the hub's twin of `maxItems`; a name->value map is a
+    countable container on both sides."""
+    rf = RuntimeFormula("a + b*knobs")
+    rf.validate_for_payload(RefPayload, "ref2va")
+    assert rf.term_values_from_struct(
+        RefPayload(knobs={"x": 1.0, "y": 2.0})) == {"1": 1.0, "knobs": 2.0}
+
+
+def test_a_declared_container_that_arrives_null_is_zero_items() -> None:
+    """`Optional[list] = None` is the common no-extra-references call. Zero is
+    a READING of a declared container, not a guess: the field says what it is.
+    A missing NUMBER is a different thing and still declines below."""
+    rf = RuntimeFormula("a + b*maybe_refs")
+    rf.validate_for_payload(RefPayload, "ref2va")
+    assert rf.term_values_from_struct(RefPayload()) == {"1": 1.0, "maybe_refs": 0.0}
+    assert rf.term_values_from_struct(
+        RefPayload(maybe_refs=["a", "b", "c"])) == {"1": 1.0, "maybe_refs": 3.0}
+
+
+def test_a_missing_number_still_declines() -> None:
+    """The posture that must NOT widen: an unevaluable numeric term returns
+    None so the hub falls back to its own evaluation, instead of folding a
+    fabricated 0 into the learned constants."""
+    class Loose(msgspec.Struct):
+        num_inference_steps: Optional[int] = None
+
+    rf = RuntimeFormula("a + b*num_inference_steps")
+    assert rf.term_values_from_struct(Loose()) is None
+
+
+def test_a_string_is_not_a_countable_container() -> None:
+    """`str`/`bytes` are Sized and are deliberately NOT countable — the hub's
+    `price.numericValue` counts an array or an object and nothing else.
+    Admitting a prompt's length here would silently price one."""
+    with pytest.raises(ValueError, match="numeric/bool wire default"):
+        RuntimeFormula("a + b*caption").validate_for_payload(RefPayload, "ref2va")
+
+
+def test_len_is_not_grammar() -> None:
+    """The adjudication, pinned: no calls, on either side of the wire."""
+    for src in ("a + b*len(references)", "a + count(references)",
+                "a + b*count:references"):
+        with pytest.raises(FormulaParseError):
+            RuntimeFormula(src)
+
+
+def test_endpoint_declares_a_reference_term_end_to_end(tmp_path, monkeypatch) -> None:
+    """The whole path H3 hit: a real `@endpoint` with a real payload, through
+    real discovery. This is the case that raised at IMPORT."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    pkg = tmp_path / "ep_pgw1018"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(textwrap.dedent("""
+        from typing import List
+
+        import msgspec
+        from gen_worker import RequestContext, RuntimeFormula, endpoint
+
+        class In_(msgspec.Struct):
+            prompt: str = ""
+            num_inference_steps: int = 28
+            references: List[str] = msgspec.field(default_factory=list)
+
+        class Out_(msgspec.Struct):
+            y: str
+
+        @endpoint(runtime=RuntimeFormula(
+            "a + b*num_inference_steps + c*references"
+        ))
+        def generate(ctx: RequestContext, data: In_) -> Out_:
+            return Out_(y="ok")
+    """))
+
+    from gen_worker.discovery.discover import discover_functions
+
+    (fn,) = discover_functions(tmp_path, main_module="ep_pgw1018.main")
+    assert fn["runtime_formula"] == "a + b*num_inference_steps + c*references"

--- a/tests/test_fixed_name_temp_paths_pgw945.py
+++ b/tests/test_fixed_name_temp_paths_pgw945.py
@@ -1,0 +1,205 @@
+"""pgw#945 (tail of pgw#938): three more fixed-name temp paths, classified.
+
+pgw#938 replaced ``s3_transfer``'s ``dest.tmp`` and noticed three siblings
+without analysing them. Its own finding was that a pod-wide path can be
+CORRECT, so each site here is classified rather than assumed:
+
+* ``request_context/_datasets._download_url_streamed`` — **RACY, and it is
+  the real one.** ``resolve_dataset`` materializes into a pod-wide
+  content-keyed cache (``/tmp/gen_worker_datasets/<owner>/<name>/<snapshot>``),
+  so two requests in one container asking for one dataset reach the SAME
+  ``dest``, and the temp name was derived from it. The bytes are identical —
+  the destruction is in the LIFECYCLE: one writer's failure path unlinks the
+  other's in-flight download, and the victim fails its own rename after paying
+  for every byte. This file proves that, and proves the fix.
+* ``models/disk_gc.RefIndex._save_locked`` — **racy across PROCESSES.** The
+  lock it holds is a thread lock; the index sits in the shared model cache dir.
+* ``env_seal.write_library_memo`` — **per-attempt today** (its only caller
+  seeds ``<mint workdir>/seal-lib-memo.json``, and the workdir is per mint
+  attempt), but the atomicity promise is the function's, so it no longer
+  depends on a fact stated in another module.
+
+Reasons live at each site, not only here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import threading
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from gen_worker.env_seal import write_library_memo
+from gen_worker.models.disk_gc import RefIndex
+from gen_worker.request_context._datasets import _download_url_streamed
+
+#: One bound for every rendezvous below. Each wait is on a signal the OTHER
+#: thread sets unconditionally, so reaching it is a failed test, not a slow
+#: one — the number only decides how long a broken run hangs before saying so.
+_RENDEZVOUS_S = 60.0
+
+_PAYLOAD = bytes(range(256)) * 8192          # 2 MiB, > the 1 MiB read chunk
+_DIGEST = "sha256:" + hashlib.sha256(_PAYLOAD).hexdigest()
+
+
+class _Rendezvous:
+    """The three signals that order the two writers deterministically."""
+
+    def __init__(self) -> None:
+        self.first_partial = threading.Event()
+        self.second_partial = threading.Event()
+        self.first_failed = threading.Event()
+        self.connections = 0
+        self.lock = threading.Lock()
+
+    def wait(self, event: threading.Event, what: str) -> None:
+        assert event.wait(_RENDEZVOUS_S), f"rendezvous never reached: {what}"
+
+
+@pytest.fixture()
+def shard_server():
+    rv = _Rendezvous()
+    half = len(_PAYLOAD) // 2
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args: Any) -> None:  # quiet
+            pass
+
+        def do_GET(self) -> None:
+            with rv.lock:
+                rv.connections += 1
+                nth = rv.connections
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(_PAYLOAD)))
+            self.end_headers()
+            self.wfile.write(_PAYLOAD[:half])
+            self.wfile.flush()
+            if nth == 1:
+                # Writer A: stall until B is streaming, then die mid-shard.
+                rv.first_partial.set()
+                rv.wait(rv.second_partial, "second writer started streaming")
+                self.close_connection = True
+                self.connection.close()
+                return
+            # Writer B: stall until A's failure path has run, then finish.
+            rv.second_partial.set()
+            rv.wait(rv.first_failed, "first writer's cleanup ran")
+            self.wfile.write(_PAYLOAD[half:])
+            self.wfile.flush()
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, rv
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=_RENDEZVOUS_S)
+
+
+def test_a_failing_writer_cannot_destroy_a_concurrent_one(shard_server, tmp_path):
+    """Two requests, one dataset, one ``dest``. The first download dies
+    mid-shard; the second must still land its verified bytes.
+
+    Before the fix both wrote ``dest.tmp``, so the first writer's
+    ``tmp.unlink()`` deleted the second's open file and the second — having
+    transferred every byte and verified its own digest — died on ``replace``
+    with ``FileNotFoundError``.
+    """
+    server, rv = shard_server
+    url = f"http://127.0.0.1:{server.server_address[1]}/shard"
+    dest = tmp_path / "shards" / "data-00000.bin"
+    dest.parent.mkdir(parents=True)
+    errors: List[Optional[BaseException]] = [None, None]
+
+    def first() -> None:
+        try:
+            _download_url_streamed(url, dest, expected_digest=_DIGEST,
+                                   expected_size=len(_PAYLOAD))
+        except BaseException as exc:      # expected: the aborted connection
+            errors[0] = exc
+        finally:
+            rv.first_failed.set()
+
+    def second() -> None:
+        try:
+            _download_url_streamed(url, dest, expected_digest=_DIGEST,
+                                   expected_size=len(_PAYLOAD))
+        except BaseException as exc:
+            errors[1] = exc
+
+    a = threading.Thread(target=first)
+    a.start()
+    rv.wait(rv.first_partial, "first writer started streaming")
+    b = threading.Thread(target=second)
+    b.start()
+    for t in (a, b):
+        t.join(timeout=_RENDEZVOUS_S)
+        assert not t.is_alive(), "a writer never finished"
+
+    assert errors[0] is not None, "the first writer was supposed to be aborted"
+    assert errors[1] is None, f"the surviving writer was destroyed: {errors[1]!r}"
+    assert dest.read_bytes() == _PAYLOAD
+    # The loser cleans up after itself and nothing else: only the shard is left.
+    assert sorted(p.name for p in dest.parent.iterdir()) == [dest.name]
+
+
+def test_two_ref_index_writers_leave_a_whole_document(tmp_path):
+    """`RefIndex`'s lock is per-process, so two processes sharing a cache dir
+    are ordered by nothing. Whoever renames last wins — but every reader must
+    see a COMPLETE index, never a mixture of two states."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    left, right = RefIndex(cache), RefIndex(cache)
+    barrier = threading.Barrier(2, timeout=_RENDEZVOUS_S)
+
+    def write(index: RefIndex, prefix: str) -> None:
+        barrier.wait()
+        for i in range(60):
+            index.record(f"{prefix}/model-{i}", cache / f"{prefix}-{i}", 1024 * i)
+
+    threads = [threading.Thread(target=write, args=(left, "a")),
+               threading.Thread(target=write, args=(right, "b"))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=_RENDEZVOUS_S)
+        assert not t.is_alive()
+
+    doc = json.loads((cache / "ref-index.json").read_text("utf-8"))
+    # A torn write is not a partial dict — it is unparseable, or a document
+    # holding entries whose refs came from two different writers' states.
+    owners = {ref.split("/", 1)[0] for ref in doc}
+    assert owners in ({"a"}, {"b"}), f"the index mixes two writers: {sorted(doc)}"
+    assert not [p for p in cache.iterdir() if p.name != "ref-index.json"], \
+        "a temp file was left behind"
+
+
+def test_the_library_memo_survives_a_shared_destination(tmp_path):
+    """The per-attempt site: correct today by its caller's path, and now
+    correct by construction. Two writers of one memo path both produce a
+    parseable document."""
+    memo = tmp_path / "seal-lib-memo.json"
+    barrier = threading.Barrier(2, timeout=_RENDEZVOUS_S)
+    counts: List[int] = []
+
+    def write() -> None:
+        barrier.wait()
+        counts.append(write_library_memo(memo))
+
+    threads = [threading.Thread(target=write) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=_RENDEZVOUS_S)
+        assert not t.is_alive()
+
+    assert len(counts) == 2
+    doc = json.loads(memo.read_text())
+    assert isinstance(doc.get("digests"), dict)
+    assert [p.name for p in Path(tmp_path).iterdir()] == [memo.name]

--- a/tests/test_quantized_leaf_compute_dtype_pgw1020.py
+++ b/tests/test_quantized_leaf_compute_dtype_pgw1020.py
@@ -1,0 +1,170 @@
+"""pgw#1020: pgw#683's mixed-compute-dtype guard was BLIND to every quantized
+leaf, because its evidence collector selected leaves by
+``isinstance(leaf, (nn.Linear, nn.Conv*))`` and all five quantized leaves
+(``_Fp8ScaledLinear``, ``_W4A4Linear``, ``_SvdqLinear``, ``_SvdqFusedLinear``,
+``_AwqPackedLinear``) subclass ``nn.Module`` directly.
+
+Measured before the fix, cardless::
+
+    _gemm_param_dtypes on a w8a8 fp16 denoiser: {}
+    pgw#683 guard verdict: PASSED (blind)
+
+i.e. a w8a8 denoiser built at fp16 and composed into a bf16 pipeline — the
+exact cross-composition aliasing shape pgw#683 exists to refuse — passed
+silently, and the fp16-vs-bf16 collision surfaced where it always did: inside
+torch, mid-forward, naming neither the component nor the tensor.
+
+Newly fixable because pgw#1015/pgw#1019 made every quantized leaf RECORD
+``self.compute_dtype``. Before that a bias-free quantized leaf stated its
+compute dtype nowhere and the guard had nothing to read.
+
+Real classes throughout — the production module factories, not a stand-in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from gen_worker.models.loading import (  # noqa: E402
+    MixedComputeDtypeError,
+    _gemm_param_dtypes,
+    assert_uniform_compute_dtype,
+)
+from gen_worker.models.w4a4 import w4a4_linear_class  # noqa: E402
+from gen_worker.models.w8a8 import fp8_scaled_linear_class  # noqa: E402
+
+
+class _Pipe:
+    """A composition in the diffusers shape (`.components` -> modules)."""
+
+    def __init__(self, **parts: Any) -> None:
+        self._parts = parts
+
+    @property
+    def components(self) -> dict:
+        return dict(self._parts)
+
+
+def _w8a8_denoiser(compute_dtype: Any, *, bias: bool = False) -> Any:
+    """A denoiser whose projection is a REAL ``_Fp8ScaledLinear`` — the shape
+    `load_w8a8_denoiser` builds, bias-free by default because that is the case
+    that stated its compute dtype nowhere else."""
+    import torch.nn as nn
+
+    cls = fp8_scaled_linear_class()
+
+    class _Denoiser(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = cls(16, 16, bias=bias, compute_dtype=compute_dtype,
+                            static_input_scale=False, gemm_mode="rowwise")
+            self.norm = nn.LayerNorm(16)
+
+    return _Denoiser()
+
+
+def _w4a4_denoiser(compute_dtype: Any) -> Any:
+    """The same shape on the nvfp4 lane — a second leaf class, so the fix is
+    proven to be about the DECLARATION and not about one module."""
+    import torch.nn as nn
+
+    cls = w4a4_linear_class()
+
+    class _Denoiser(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = cls(32, 16, bias=False, compute_dtype=compute_dtype,
+                            static_input_scale=False)
+
+    return _Denoiser()
+
+
+@pytest.mark.parametrize("build", [_w8a8_denoiser, _w4a4_denoiser],
+                         ids=["w8a8", "w4a4"])
+def test_the_guard_can_see_a_quantized_leaf_at_all(build: Any) -> None:
+    """The blindness itself, at the collector: a bias-free quantized leaf used
+    to contribute NOTHING, so the guard's evidence for the whole denoiser was
+    ``{}`` and every verdict below it was vacuous."""
+    dtypes = _gemm_param_dtypes(build(torch.float16))
+    assert dtypes, "the quantized leaf is invisible to the pgw#683 collector"
+    assert dtypes["proj.compute_dtype"] == "float16"
+
+
+def test_fp16_quantized_denoiser_in_a_bf16_composition_refuses() -> None:
+    """The measured case. The w8a8 lane's composition dtype is bf16
+    (`composition_compute_dtype` returns the quant lane default), so an fp16
+    denoiser here is the pgw#683 aliasing shape and must be refused at LOAD,
+    naming the component."""
+    pipe = _Pipe(unet=_w8a8_denoiser(torch.float16),
+                 vae=torch.nn.Linear(16, 16).to(torch.bfloat16))
+    with pytest.raises(MixedComputeDtypeError) as excinfo:
+        assert_uniform_compute_dtype(pipe, "bf16", label="slot 'pipeline'")
+    msg = str(excinfo.value)
+    assert "unet" in msg, f"the component must be named: {msg}"
+    assert "proj.compute_dtype=float16" in msg, msg
+    assert "slot 'pipeline'" in msg
+
+
+def test_an_internally_mixed_quantized_denoiser_refuses() -> None:
+    """Verdict 1 needs no ``expected``: one component holding a bf16 leaf and
+    an fp16 leaf cannot survive its own forward, quantized or not."""
+    import torch.nn as nn
+
+    cls = fp8_scaled_linear_class()
+
+    class _Mixed(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.a = cls(16, 16, bias=False, compute_dtype=torch.bfloat16,
+                         static_input_scale=False, gemm_mode="rowwise")
+            self.b = cls(16, 16, bias=False, compute_dtype=torch.float16,
+                         static_input_scale=False, gemm_mode="rowwise")
+
+    with pytest.raises(MixedComputeDtypeError, match="internally mixed"):
+        assert_uniform_compute_dtype(_Pipe(unet=_Mixed()), "")
+
+
+def test_the_storage_carve_out_survives() -> None:
+    """pgw#683's whole point is that fp8/fp4 STORAGE is legal. The w8a8 leaf's
+    weight is `float8_e4m3fn` and the w4a4 leaf's is packed `uint8`; neither
+    may be counted as a compute dtype, or the guard refuses the lanes it was
+    written to admit."""
+    for build in (_w8a8_denoiser, _w4a4_denoiser):
+        dtypes = _gemm_param_dtypes(build(torch.bfloat16))
+        assert all(v in ("float16", "bfloat16", "float32", "float64")
+                   for v in dtypes.values()), dtypes
+        assert not any(k.endswith(".weight") for k in dtypes), dtypes
+
+
+def test_a_uniform_quantized_composition_is_admitted() -> None:
+    """No new refusal on the normal path: a bf16 quantized denoiser inside the
+    bf16 composition the loader actually builds (`compute` and the guard's
+    `expected` come from ONE declared dtype) passes, with and without bias."""
+    for bias in (False, True):
+        assert_uniform_compute_dtype(
+            _Pipe(unet=_w8a8_denoiser(torch.bfloat16, bias=bias),
+                  vae=torch.nn.Linear(16, 16).to(torch.bfloat16)),
+            "bf16")
+    assert_uniform_compute_dtype(_Pipe(unet=_w4a4_denoiser(torch.bfloat16)),
+                                 "bf16")
+    # pgw#667's declared widening is still not a collision.
+    assert_uniform_compute_dtype(
+        _Pipe(unet=_w8a8_denoiser(torch.bfloat16),
+              vae=torch.nn.Linear(16, 16).to(torch.float32)), "bf16")
+
+
+def test_an_embedding_keeps_its_exclusion() -> None:
+    """The fp8-storage lane stamps `compute_dtype` on EVERY covered leaf,
+    embeddings included (`restructure_fp8_storage`). Embeddings are excluded
+    from this guard by kind — they carry their own legitimately wider
+    precision — and reading a declaration must not smuggle them back in."""
+    import torch.nn as nn
+
+    emb = nn.Embedding(8, 16).to(torch.float16)
+    emb.compute_dtype = torch.float16
+    assert _gemm_param_dtypes(emb) == {}
+    assert_uniform_compute_dtype(_Pipe(text_encoder=emb), "bf16")


### PR DESCRIPTION
Three independent defects from the pgw#1020 / pgw#1018 / pgw#945 lane, each RED-verified against master before the fix. Full commit message has the detail; the short version:

Three independent defects, each RED-verified against master before the fix.

pgw#1020 — pgw#683's mixed-compute-dtype guard was BLIND to every quantized
leaf. `loading._gemm_param_dtypes` selected evidence by
`isinstance(leaf, (nn.Linear, nn.Conv*))`, and all five quantized leaves
(`_Fp8ScaledLinear`, `_W4A4Linear`, `_SvdqLinear`, `_SvdqFusedLinear`,
`_AwqPackedLinear`) subclass `nn.Module` directly. Measured cardless: a w8a8
fp16 denoiser yielded `{}` and the guard PASSED — the exact cross-composition
aliasing shape pgw#683 exists to refuse, arriving instead inside torch,
mid-forward, naming neither the component nor the tensor. Newly fixable
because pgw#1015/pgw#1019 made every quantized leaf record
`self.compute_dtype`; that declaration is now counted as a GEMM input dtype,
which is the only reading a BIAS-FREE quantized layer leaves anywhere. The
fp8/fp4 storage carve-out survives by the same membership test that always
enforced it, and embeddings keep their exclusion by kind (the fp8-storage lane
stamps `compute_dtype` on them too).

pgw#1018 — a RuntimeFormula could not express a countable-container term, so
H3's ref2va (208 s vs 80 s for the same duration, ie#612) was cost-modeled as
if its references were free. The issue proposed `len(references)`; that is
refused here and the reason is the point: the formula STRING is the wire
contract, `api/formula.py` mirrors tensorhub `internal/formula`, calls are
outside the grammar on both sides, and the term KEY is canonicalized from the
expression — a `len(...)` term mints a key the hub can never reproduce. The
platform already has this vocabulary and it is not a call: `internal/price`
(th#833 / ie#600) binds an identifier naming an array or map to its ITEM
COUNT. The worker now reads it the same way, so one string prices and predicts
the same request. A declared container arriving null is zero items; a missing
NUMBER still declines, so the fallback posture does not widen.

pgw#945 — the tail of pgw#938's three unanalysed temp paths, classified per
site with the reason in the source. `_datasets._download_url_streamed` is the
racy one: `resolve_dataset` materializes into a pod-wide content-keyed cache,
so two requests for one dataset reach the same `dest` and shared its derived
temp name. The bytes are identical, which is what made it look harmless — the
destruction is in the LIFECYCLE, and the test proves it: the loser's
`tmp.unlink()` deletes the winner's in-flight file and the winner dies on
`replace` with FileNotFoundError after transferring every byte.
`disk_gc.RefIndex._save_locked` is racy across PROCESSES (a thread lock over
an index in a shared cache dir; a torn document reads as "unreadable" and the
ref accounting restarts empty). `env_seal.write_library_memo` is per-attempt
under its only caller, but its docstring — not that caller — is where the
atomicity promise lives. All three take a unique temp file in the destination
directory.

Tests (all RED-verified by reverting the production change):
* `tests/test_quantized_leaf_compute_dtype_pgw1020.py` — 4 of 7 fail on
  master; the 3 controls (storage carve-out, uniform composition admitted,
  embedding excluded) pass in BOTH directions, so the suite cannot be
  satisfied by a guard that refuses everything. Real leaf classes from the
  production factories, two lanes.
* `tests/test_countable_container_formula_pgw1018.py` — 5 of 8 fail on master,
  including the end-to-end `@endpoint` + real discovery case that reproduces
  H3's import-time ValueError verbatim.
* `tests/test_fixed_name_temp_paths_pgw945.py` — the concurrency row fails on
  master with the FileNotFoundError above, against a real local HTTP server
  with the two writers ordered by explicit rendezvous rather than by timing.
