### PR TITLE
pgw#1078: armed at setup, eager at serve — the regional lane that declined itself, and the scope-armed slot that owned nothing

### DIFF
--- a/changelog.d/pgw1078.md
+++ b/changelog.d/pgw1078.md
@@ -1,0 +1,42 @@
+- **pgw#1078: `arm_compile()` said ARMED, no compile target was installed, and
+  the declared `regional=True` lane was never the lane that ran.** minimax-h3
+  0.4.2's boot proves the composed recipe engages (`w8a8 per-row fp8 on 300
+  Linears … fa3 exact … compile ARMED`) and then serves every request eager:
+  `lane=bf16-w16a16+eager`, 187.2 s of denoise for 30 steps (6.24 s/step)
+  against ARM A's measured 4.39 s/step. Three defects, one outcome.
+
+  **The execution half.** `_regional_dynamic_decline` (pgw#817/D4) declined the
+  dynamo regional branch for ANY declaration carrying `dynamic=(...)`, on the
+  premise that `compile_repeated_blocks(dynamic=None)` cannot apply the marks.
+  So a 20.1B denoiser whose author declared `regional=True` precisely because
+  whole-graph inductor planning is unaffordable for its class (ie#381) was
+  compiled WHOLE-FORWARD instead. Its boot warmup compiled one shape
+  (`jit_compile shape:boot compile_s=35.04`); every real request presents a
+  different packed sequence, `_guarded` runs under `_fail_on_recompile()`,
+  catches the recompile and returns the eager original — for every step of
+  every request, for the life of the pod. The premise was wrong:
+  `compile_repeated_blocks` compiles each repeated BLOCK, so the block call is
+  where this lane's graphs are traced and where the marks belong. The decline
+  is deleted; `_mark_regional_blocks` wraps each block's `_compiled_call_impl`
+  with the same `_with_declared_marks` the whole-forward branch uses.
+
+  **The attribution half.** A CLASS-annotated slot holding a lazily hydrating
+  `ModularPipeline` has no compile target at injection, so the automatic branch
+  skips it and the endpoint arms it itself inside `setup()`. The executor
+  attributed that scope-armed pipeline to `self_loaded_slots` — the str/Path
+  kwargs, EMPTY for a class-annotated slot — so `_install_compile_targets` got
+  a candidate owning no slots, computed no bindings, and omitted the target
+  `target_applicability_incomplete`. With no target the guard was never bound
+  (so the guard misses above were INVISIBLE — no `fallback_reason=guard_miss`,
+  no event), `hot_swap.enable()` never ran, and every request reported
+  `+eager`. Ownership now comes from the injected object's own slot.
+
+  **And the wire named the wrong cause.** `inj.eager_postures` was applied
+  first-token-wins BEFORE target installation, so the injection-time
+  `no_compile_target` — recorded before setup hydrated anything — outranked and
+  hid `target_applicability_incomplete` for the whole boot. A later successful
+  scope arm now disproves it. Separately, `_served_identity` carried a
+  target's pipeline into `serving_mode.resolve` only when the target named an
+  ACTIVE ref; a JIT INTAKE arm names no artifact by construction (pgw#1010), so
+  even a healthy intake target reported `eager`. It now carries the pipeline so
+  `classify_mode` can ask `is_compile_armed`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.96.3"
+version = "0.97.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/api/decorators.py
+++ b/src/gen_worker/api/decorators.py
@@ -899,14 +899,12 @@ class Compile(msgspec.Struct, frozen=True):
         if len({d.dim for d in dyn}) != len(dyn):
             raise ValueError("Compile.dynamic repeats a dim")
         force(self, "dynamic", dyn)
-        # `regional=True` + `dynamic=(...)` is ADMITTED at declaration.
-        # `regional` is the dynamo/JIT per-block knob (ie#381) — the AOT
-        # export lane ignores it entirely since pgw#846 retired regional
-        # cells. The dynamo regional branch calls `compile_repeated_blocks(
-        # dynamic=None)` and cannot honour the marks, so it declines by name
-        # (`compile_cache._regional_dynamic_decline`) instead of arming a
-        # graph that does not implement the contract its key asserts. The
-        # declaration is legal; the lane that cannot serve it says so.
+        # `regional=True` + `dynamic=(...)` is ADMITTED and, since pgw#1078,
+        # SERVED by both lanes. `regional` is the dynamo/JIT per-block knob
+        # (ie#381) — the AOT export lane ignores it entirely since pgw#846
+        # retired regional cells; the dynamo regional branch applies the
+        # declared marks at the compiled-block ingress
+        # (`compile_cache._mark_regional_blocks`).
         for name, typ in (("dims", Dim), ("forks", Fork),
                           ("classes", GraphClass), ("inputs", Input),
                           ("args", Arg)):

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -2330,30 +2330,44 @@ def execution_contract(pipeline: Any, cfg: Any) -> Tuple[str, Dict[str, Any]]:
     return hashlib.sha256(encoded).hexdigest(), weight_contract
 
 
-def _regional_dynamic_decline(cfg: Any, target: str) -> str:
-    """"" when the DYNAMO regional branch may arm ``target``, else the reason.
+def _mark_regional_blocks(owner: Any, dynamic_dims: tuple) -> int:
+    """Apply the DECLARED marks at the compiled-block ingress. Returns the
+    number of blocks wrapped.
 
-    pgw#817/D4 moved the `regional + dynamic` refusal out of the declaration
-    (where it forbade a combination the EXPORT lane measured as free) and into
-    the one lane that genuinely cannot honour it. `compile_repeated_blocks(
-    dynamic=None)` never applies the declared marks, so a dynamo regional arm
-    over a declaration carrying `dynamic=(...)` would serve a graph that does
-    not implement the contract its cell key asserts — the exact failure class
-    pgw#716 exists to prevent. Declining here sends the target to the
-    whole-forward branch, which DOES mark, so the declaration is still served;
-    it is only served by the other lane.
+    pgw#817/D4 answered "compile_repeated_blocks(dynamic=None) never applies
+    the declared marks" by DECLINING the dynamo regional branch whenever a
+    declaration carried ``dynamic=(...)``, which sent the target to the
+    whole-forward branch instead. That refusal is what ie#632 measured on
+    minimax-h3: a 20.1B denoiser whose author declared ``regional=True``
+    precisely because whole-graph inductor planning is unaffordable for its
+    class (ie#381) was silently compiled whole-forward, and every request
+    whose packed sequence differed from the boot warmup's guard-missed to
+    eager for the life of the pod.
+
+    The premise was wrong: ``compile_repeated_blocks`` compiles each repeated
+    BLOCK, so the block call is where this lane's graphs are traced and where
+    the marks belong. ``nn.Module.compile()`` installs ``_compiled_call_impl``;
+    wrapping it with the same :func:`_with_declared_marks` the whole-forward
+    branch uses makes the two lanes honour one declaration.
     """
-    dyn = tuple(getattr(cfg, "dynamic", ()) or ())
-    if not dyn:
-        return ""
-    names = ", ".join(str(getattr(d, "dim", "") or "?") for d in dyn)
-    return (
-        f"target {target!r} declares regional=True AND dynamic=({names}) — "
-        f"the dynamo regional branch calls compile_repeated_blocks("
-        f"dynamic=None) and never applies the declared marks, so it declines "
-        f"and this target takes the whole-forward branch (which does). The "
-        f"AOT export lane implements regional+dynamic directly (pgw#812 "
-        f"RESULT 3: free on a conv-free region)")
+    repeated = tuple(getattr(owner, "_repeated_blocks", ()) or ())
+    if not repeated:
+        return 0
+    marked = 0
+    for module in owner.modules():
+        if type(module).__name__ not in repeated:
+            continue
+        impl = getattr(module, "_compiled_call_impl", None)
+        if impl is None or getattr(impl, "_gw_declared_marks", False):
+            continue
+        wrapped = _with_declared_marks(impl, dynamic_dims)
+        wrapped._gw_declared_marks = True  # type: ignore[attr-defined]
+        module._compiled_call_impl = wrapped
+        marked += 1
+    logger.info(
+        "compile-cache: declared marks applied at the ingress of %d regional "
+        "block(s) on %s", marked, type(owner).__name__)
+    return marked
 
 
 def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callable[..., Any]:
@@ -3043,17 +3057,10 @@ def apply(
     applied: list[str] = []
     originals: list[Tuple[Any, str, Callable[..., Any]]] = []
     regional_mods: list[Any] = []
+    declared_dynamic = tuple(getattr(cfg, "dynamic", ()) or ())
     for target, owner, attr, fn in resolve_targets(pipeline, cfg):
-        # pgw#817/D4: computed BEFORE the branch so a declined regional target
-        # falls through to the whole-forward branch (which does apply the
-        # declared marks) instead of being skipped entirely.
-        regional_decline = _regional_dynamic_decline(cfg, target) \
-            if regional else ""
-        if regional_decline:
-            logger.info("compile-cache: %s", regional_decline)
         if (
             regional
-            and not regional_decline
             and attr == "forward"
             and callable(getattr(owner, "compile_repeated_blocks", None))
         ):
@@ -3063,6 +3070,15 @@ def apply(
             #
             settings_authority.impose_dynamo()
             owner.compile_repeated_blocks(dynamic=None)
+            # pgw#1078: the declared marks are applied at the BLOCK ingress,
+            # which is where this lane's graphs are traced. Without them
+            # `regional=True` + `dynamic=(...)` used to DECLINE and send the
+            # target to the whole-forward branch — silently serving a 20B
+            # denoiser by the one lane its author declared regional to avoid,
+            # then guard-missing to eager on every request whose sequence
+            # differed from the boot warmup's (minimax-h3, ie#632).
+            if declared_dynamic:
+                _mark_regional_blocks(owner, declared_dynamic)
             # pgw#681: regional entry crosses the same canonical boundary as
             # whole-graph entry — block guards mint over canonical inputs.
             ingress = guard_closure.canonical_ingress(fn, target)
@@ -3102,7 +3118,6 @@ def apply(
         # the config pair + dynamic=None, never dynamic=False.
         settings_authority.impose_dynamo()
         compiled = torch.compile(fn, dynamic=None)
-        declared_dynamic = tuple(getattr(cfg, "dynamic", ()) or ())
         if declared_dynamic:
             compiled = _with_declared_marks(compiled, declared_dynamic)
         # pgw#681: the single compiled-graph ingress — canonical strides +

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -5145,14 +5145,24 @@ class Executor:
         if spec is not None and spec.cls is not None:
             rec = self._classes.get(spec.instance_key)
             if rec is not None:
+                armed_pipeline = None
                 for target in rec.compile_targets.values():
                     with target.state_lock:
                         active = str(target.active_compile_ref or "")
                     if active:
                         ref, pipeline = active, target.pipeline
                         break
+                    # pgw#1078: a JIT INTAKE arm names no artifact — that is
+                    # the whole point of pgw#1010's `is_compile_armed` — so a
+                    # ref-only scan reports every intake-served request as
+                    # eager. Carry the pipeline so `classify_mode` can ask it.
+                    if armed_pipeline is None and compile_cache.is_compile_armed(
+                            target.pipeline):
+                        armed_pipeline = target.pipeline
                 if not ref:
-                    posture = self._eager_posture(spec, rec)
+                    pipeline = armed_pipeline
+                    if pipeline is None:
+                        posture = self._eager_posture(spec, rec)
         return serving_mode_mod.resolve(
             active_compile_ref=ref,
             pipeline=pipeline,
@@ -6581,6 +6591,25 @@ class Executor:
                     slot for slot in setup_slots
                     if isinstance(inj.kwargs.get(slot), (str, Path))
                 )
+                # pgw#1078: …and a WORKER-loaded slot object that only became
+                # compile-capable DURING setup owns itself. A lazy loader (a
+                # `ModularPipeline` whose weight-bearing components hydrate
+                # inside setup) has no compile target at injection time, so the
+                # automatic branch skips it; the endpoint then hydrates and
+                # calls `arm_compile(pipeline)`, which lands here. Attributing
+                # that pipeline to `self_loaded_slots` — EMPTY for a
+                # class-annotated slot — gave `_install_compile_targets` a
+                # candidate with no owned slots, hence no bindings, hence
+                # `target_applicability_incomplete`: the arm succeeded and NO
+                # target was installed, so the guard was never bound, the
+                # hot-swap router was never enabled, and every request reported
+                # `+eager` (ie#632, minimax-h3 0.4.2).
+                injected_slot_of = {
+                    id(obj): slot
+                    for slot in setup_slots
+                    if (obj := inj.kwargs.get(slot)) is not None
+                    and not isinstance(obj, (str, Path))
+                }
                 scope_mints = arming_scope.self_mints
                 for bug in arming_scope.selection_bugs.values():
                     # th#1031: the fleet policy already self-minted a working
@@ -6591,7 +6620,17 @@ class Executor:
                 for pipe, armed in arming_scope.objects:
                     if not compile_cache.has_compile_target(pipe, spec.compile):
                         continue
-                    inj.add_compile_object(pipe, self_loaded_slots)
+                    owning = injected_slot_of.get(id(pipe))
+                    inj.add_compile_object(
+                        pipe, (owning,) if owning else self_loaded_slots)
+                    if armed:
+                        # pgw#1078: this arm DISPROVES whatever the injection
+                        # -time attempt concluded about the same object — that
+                        # attempt ran before setup hydrated it. First-token-
+                        # wins across the two scopes is what put
+                        # `no_compile_target` on every 0.4.2 request while the
+                        # target resolved fine.
+                        inj.eager_postures.clear()
                     mint = scope_mints.get(id(pipe))
                     selection = _selection_for(compile_selection, mint)
                     if getattr(mint, "delegated", False):

--- a/tests/test_regional_dynamic_refusal_pgw746.py
+++ b/tests/test_regional_dynamic_refusal_pgw746.py
@@ -1,35 +1,32 @@
-"""pgw#746 (OQ-7), as pgw#817/D4 RELOCATED it: the ``regional=True`` +
-``dynamic=(...)`` refusal moved off the DECLARATION and onto the one lane that
-cannot honour it.
+"""pgw#746 (OQ-7) -> pgw#817/D4 -> **pgw#1078, which closes it**: the
+``regional=True`` + ``dynamic=(...)`` combination is now SERVED by the dynamo
+regional branch instead of declined by it.
 
-pgw#746 refused the combination in ``Compile.__post_init__`` on two premises,
-both of which pgw#812 then measured away:
+pgw#746 refused the combination in ``Compile.__post_init__``; pgw#817/D4 moved
+the refusal onto the dynamo arm, which then sent such a target to the
+whole-forward branch. Both rested on one premise — *"the dynamo regional
+branch cannot apply the declared marks"* — and ie#632 measured what it costs:
+minimax-h3's 20.1B denoiser declares ``regional=True`` precisely because
+whole-graph inductor planning is unaffordable for its class (ie#381), and the
+decline compiled it whole-forward anyway. Its boot warmup compiled one shape;
+every real request presented a different packed sequence, guard-missed, and
+`_guarded` served eager for the life of the pod (`lane=bf16-w16a16+eager`,
+257.7 s against a 131.7 s measured compiled wall).
 
-* *"regional never applies the declared marks, so the declaration is inert
-  while the contract digest claims the dynamism"* — true of the DYNAMO branch
-  only. Regional has an EXPORT counterpart (a block is exported with
-  ``dynamic_shapes`` exactly like a whole graph), and the symbolic inner axis
-  measured FREE on a conv-free region: +0.2% bf16 / 0.0% w8a8, against
-  pgw#730's +7.2% for the same axis on sdxl's conv lane.
-* *"regional is retiring in favour of whole-transformer export
-  (LTX-AOT-DESIGN §3.2), so teaching a departing lane to mark is building on
-  sand"* — regional is now 14.2x the whole-graph mint on the real sdxl w8a8
-  cell with serve parity at +0.24%. It is not departing; it is the adoption.
+The premise was simply wrong. ``compile_repeated_blocks`` compiles each
+repeated BLOCK, so the block call is where this lane's graphs are traced and
+where the marks belong — ``_mark_regional_blocks`` wraps each block's
+``_compiled_call_impl`` with the same ``_with_declared_marks`` the
+whole-forward branch uses. One declaration, two lanes, one meaning.
 
-What pgw#746 was RIGHT about survives, and this file pins it: the dynamo
-regional branch still calls ``compile_repeated_blocks(dynamic=None)`` and
-still cannot apply the marks, so it must never arm a graph that does not
-implement the contract its cell key asserts (the pgw#716 failure class). It
-now DECLINES BY NAME and the target falls through to the whole-forward
-branch — which does mark — so the declaration is still served, just by the
-other lane. A decline that SKIPPED the target would be a silent regression
-(an uncompiled target), which is why the fall-through is asserted here.
-
-Tested in both directions: the combination is admitted at declaration and
-declined at the dynamo arm, and each half alone is untouched.
+What pgw#746 was right about is unchanged and still pinned below: the contract
+digest distinguishes the two configs, because they genuinely produce different
+artifacts.
 """
 
 from __future__ import annotations
+
+import torch
 
 from gen_worker import compile_cache as cc
 from gen_worker.api.decorators import Compile, DynamicDim
@@ -90,30 +87,73 @@ def test_several_declared_dims_are_admitted_alongside_regional() -> None:
 
 
 # ---------------------------------------------------------------------------
-# direction 2: the DYNAMO ARM declines it, by name, naming every dim
+# direction 2: the DYNAMO REGIONAL ARM honours the marks at the block ingress
 # ---------------------------------------------------------------------------
 
-def test_the_dynamo_regional_arm_declines_and_names_every_offending_dim() -> None:
-    dims = (DynamicDim(dim="batch", min=2, max=8), _SEQ)
-    cfg = Compile(shapes=((768, 768),), regional=True, dynamic=dims)
+class _Block(torch.nn.Module):
+    def forward(self, hidden_states):  # pragma: no cover - never called here
+        return hidden_states
 
-    reason = cc._regional_dynamic_decline(cfg, "transformer")
-    assert reason, "the dynamo regional branch cannot honour declared marks"
-    assert "transformer" in reason
-    assert "batch" in reason and "sequence" in reason
-    assert "compile_repeated_blocks" in reason, (
-        "the reason must name the mechanism, not just the verdict"
+
+class _Owner(torch.nn.Module):
+    _repeated_blocks = ["_Block"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([_Block(), _Block(), _Block()])
+
+
+def test_the_dynamo_regional_arm_marks_every_repeated_block() -> None:
+    """The fix, stated as the behaviour: after ``compile_repeated_blocks``
+    every repeated block's compiled call is wrapped so the DECLARED dims are
+    marked before dynamo sees the inputs."""
+    owner = _Owner()
+    for block in owner.blocks:
+        block._compiled_call_impl = block._call_impl
+
+    marked = cc._mark_regional_blocks(
+        owner, (DynamicDim(dim="batch", min=2, max=8), _SEQ))
+
+    assert marked == 3, "every repeated block carries the declaration"
+    for block in owner.blocks:
+        assert getattr(block._compiled_call_impl, "_gw_declared_marks", False)
+
+
+def test_marking_regional_blocks_is_idempotent() -> None:
+    """A second arm on the same object must not stack mark wrappers."""
+    owner = _Owner()
+    for block in owner.blocks:
+        block._compiled_call_impl = block._call_impl
+    assert cc._mark_regional_blocks(owner, (_SEQ,)) == 3
+    assert cc._mark_regional_blocks(owner, (_SEQ,)) == 0
+
+
+def test_an_uncompiled_block_is_never_wrapped() -> None:
+    """``compile_repeated_blocks`` is what installs ``_compiled_call_impl``;
+    a block it did not compile has no ingress to mark."""
+    owner = _Owner()
+    assert cc._mark_regional_blocks(owner, (_SEQ,)) == 0
+
+
+def test_the_declared_marks_reach_the_block_input() -> None:
+    """Not decoration: the wrapper must actually mark the declared dim on the
+    tensor the block is called with."""
+    owner = _Owner()
+    seen: list = []
+
+    def _impl(hidden_states):
+        seen.append(tuple(
+            getattr(hidden_states, "_dynamo_dynamic_indices", set()) or ()))
+        return hidden_states
+
+    owner.blocks[0]._compiled_call_impl = _impl
+    cc._mark_regional_blocks(owner, (_SEQ,))
+    owner.blocks[0]._compiled_call_impl(torch.zeros(1, 8, 4))
+
+    assert seen == [(1,)], (
+        "`sequence` marks dim 1 of a rank-3 float tensor, exactly as the "
+        "whole-forward branch marks it"
     )
-    assert "whole-forward" in reason, (
-        "and it must say where the target goes instead — a decline that read "
-        "as a skip would be an uncompiled target"
-    )
-
-
-def test_regional_without_declared_dynamic_does_not_decline() -> None:
-    """The half pgw#746 always allowed: nothing to honour, nothing to decline."""
-    cfg = Compile(shapes=((768, 768),), regional=True)
-    assert cc._regional_dynamic_decline(cfg, "transformer") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scope_armed_slot_target_pgw1078.py
+++ b/tests/test_scope_armed_slot_target_pgw1078.py
@@ -1,0 +1,140 @@
+"""pgw#1078: a WORKER-loaded slot that only becomes compile-capable during
+`setup()` must end the boot with an INSTALLED compile target.
+
+The live failure (ie#632, minimax-h3 0.4.2 on the master stack): the endpoint
+declares `models={"pipeline": Slot(MiniMaxH3ModularPipeline)}` — class
+annotated, so the executor materializes it — but `ModularPipeline` hydrates its
+weight-bearing components lazily. At injection `pipeline.transformer is None`,
+`has_compile_target` is False, the automatic branch skips it and the arm
+declines `no_compile_target`. setup() then hydrates and calls
+`gen_worker.arm_compile(pipeline)`, which ARMS.
+
+The executor attributed that scope-armed pipeline to `self_loaded_slots` — the
+str/Path kwargs — which is EMPTY for a class-annotated slot. So
+`_install_compile_targets` saw a candidate owning no slots, computed no
+bindings, failed `bindings_valid`, and omitted the target. Nothing was left to
+bind the guard to, nothing enabled the hot-swap router, and every request
+reported `lane=…+eager  fallback_reason=no_compile_target` while the pipeline
+was in fact armed. 257.7 s served against a 131.7 s measured compiled wall.
+
+REVERT-TURNS-RED: both assertions below fail on the pre-fix executor —
+`rec.compile_targets` is empty and `rec.eager_posture` reads
+`no_compile_target`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import msgspec
+
+import gen_worker
+import gen_worker.executor as executor_mod
+from gen_worker import Compile, Resources
+from gen_worker import compile_cache as cc
+from gen_worker.api.binding import Hub, wire_ref
+from gen_worker.executor import Executor, ModelStore
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.registry import EndpointSpec
+
+FAMILY = "minimax-h3"
+
+
+class _In(msgspec.Struct):
+    prompt: str = ""
+
+
+class _Out(msgspec.Struct):
+    ok: bool = True
+
+
+class _LazyPipe:
+    """A worker-loaded pipeline whose compile target appears only after the
+    endpoint hydrates it inside setup()."""
+
+    hydrated = False
+
+    @classmethod
+    def from_pretrained(cls, path, **kw):
+        return cls()
+
+    def hydrate(self) -> None:
+        self.hydrated = True
+
+
+def _executor(spec: EndpointSpec, tmp_path: Path, sent: list, monkeypatch) -> Executor:
+    async def _send(msg: pb.WorkerMessage) -> None:
+        sent.append(msg)
+
+    store = ModelStore(_send, cache_dir=tmp_path / "cas", vram_budget_bytes=4 << 30)
+
+    async def _fake_ensure_local(ref, **kwargs) -> Path:
+        return tmp_path / "snap"
+
+    monkeypatch.setattr(executor_mod, "ensure_local", _fake_ensure_local)
+    return Executor([spec], _send, store=store)
+
+
+def test_a_lazily_hydrated_worker_loaded_slot_installs_its_compile_target(
+    tmp_path, monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        cc, "has_compile_target",
+        lambda pipeline, cfg: bool(getattr(pipeline, "hydrated", False)))
+    monkeypatch.setattr(cc, "apply", lambda *a, **k: True)
+    monkeypatch.setattr(cc, "is_compile_armed", lambda pipeline: True)
+    # The guard/lane leaves the target install consults — neutral answers so
+    # the test addresses OWNERSHIP, which is the defect.
+    monkeypatch.setattr(cc, "compile_target_execution_lane_error", lambda *a, **k: "")
+    monkeypatch.setattr(cc, "execution_contract_digest", lambda *a, **k: "d")
+
+    class Endpoint:
+        def setup(self, pipeline: _LazyPipe) -> None:
+            self.pipeline = pipeline
+            pipeline.hydrate()
+            self.armed = gen_worker.arm_compile(pipeline)
+
+        def warmup(self) -> None:
+            """A declared object-level warmup, so the contract has a name to
+            attribute — the ownership defect is the subject here, not proof."""
+
+        def run(self, ctx, payload: _In) -> _Out:  # pragma: no cover
+            return _Out()
+
+    spec = EndpointSpec(
+        name="generate", method=Endpoint.run, kind="inference",
+        payload_type=_In, output_mode="single", cls=Endpoint, attr_name="run",
+        models={"pipeline": Hub("tensorhub/minimax-h3")},
+        resources=Resources(gpu=True),
+        compile=Compile(family=FAMILY, shapes=((768, 768),), text_len=0),
+    )
+    sent: list = []
+
+    async def _go() -> None:
+        ex = _executor(spec, tmp_path, sent, monkeypatch)
+        inst = await ex.ensure_setup(spec, {
+            wire_ref(spec.models["pipeline"]): pb.Snapshot(
+                digest="blake3:" + "a" * 64),
+        })
+        assert inst.armed is True, "the in-setup arm must succeed"
+        rec = ex._classes[spec.instance_key]
+
+        assert rec.compile_targets, (
+            "a scope-armed worker-loaded slot owns ITSELF; with no owning slot "
+            "the target is omitted `target_applicability_incomplete` and the "
+            "pod serves eager with an armed pipeline"
+        )
+        target = next(iter(rec.compile_targets.values()))
+        assert target.pipeline is inst.pipeline
+        assert [slot for slot, _ref, _digest in target.model_bindings] == [
+            "pipeline"], "the binding must name the slot the object came from"
+
+        assert rec.eager_posture == "", (
+            "the injection-time `no_compile_target` decline ran BEFORE setup "
+            "hydrated the pipeline; a later successful arm disproves it, and "
+            "first-token-wins across the two scopes is what put the wrong "
+            "cause on every request"
+        )
+
+    asyncio.run(_go())

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.96.3"
+version = "0.97.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What ie#632 measured

minimax-h3 0.4.2 (release `9bee1370…`, master stack) boots and proves the composed serve recipe engages:

```
06:30:05Z residency_profile/serve_recipe
  cudnn 92000 >= 9.20, sdpa OK; w8a8 per-row fp8 on 300 Linears (70 kept bf16 by rule);
  fa3 exact bf16 on kernels-community/flash-attn3@43f0bd269777; compile ARMED
```

…and then serves the request eager:

```
06:35:09Z jit_compile/minted     family=minimax-h3 lane=bf16-w16a16+eager route=intake
                                 n_shapes=1 total_s=35.04 shapes={'boot': 35.04}
06:35:09Z serve_eager_posture/no_compile_target
06:35:09Z self_mint_skipped/boot_ended_uncompiled
request.completed  metrics.lane = "bf16-w16a16+eager"   generate = 257 682 ms
```

Denoise alone (residency stage events) = **187.2 s for 30 steps = 6.24 s/step**, against the ie#634 ladder's bf16-EAGER 6.56 and ARM A's **4.39**. VRAM peak 37.41 GiB matches ARM A, so the fp8 + AdaLN-skip halves ARE live — only the compile is missing.

## Root cause — three defects

**1. The declared `regional=True` lane was never the lane that ran.** `_regional_dynamic_decline` (pgw#817/D4) declined the dynamo regional branch for *any* declaration carrying `dynamic=(...)`, on the premise that `compile_repeated_blocks(dynamic=None)` cannot apply the marks. Verified against the deployed pin (0.96.3) on the endpoint's own declaration:

```
target 'transformer' declares regional=True AND dynamic=(sequence) — … it declines
and this target takes the whole-forward branch (which does).
```

So a 20.1B denoiser whose author declared `regional=True` *precisely because* whole-graph inductor planning is unaffordable for its class (ie#381) was compiled whole-forward. Its boot warmup compiled one shape; every real request presents a different packed sequence, `_guarded` runs under `_fail_on_recompile()`, catches the recompile and returns the eager original — every step, every request, for the life of the pod.

The premise was wrong. `compile_repeated_blocks` compiles each repeated **block**, so the block call is where this lane's graphs are traced and where the marks belong. The decline is deleted; `_mark_regional_blocks` wraps each block's `_compiled_call_impl` with the same `_with_declared_marks` the whole-forward branch uses.

**2. A scope-armed worker-loaded slot owned nothing.** `Slot(MiniMaxH3ModularPipeline)` is class-annotated, and `ModularPipeline` hydrates lazily — no compile target at injection, so the automatic branch skips it and the endpoint arms it itself inside `setup()`. The executor attributed that pipeline to `self_loaded_slots` (str/Path kwargs — **empty** for a class-annotated slot), so `_install_compile_targets` got a candidate owning no slots, computed no bindings, and omitted the target `target_applicability_incomplete`. With no target: the guard was never bound (**so defect 1's guard misses were invisible** — no `fallback_reason=guard_miss`, no event), `hot_swap.enable()` never ran, and every request reported `+eager`.

**3. The wire named the wrong cause.** `inj.eager_postures` was applied first-token-wins *before* target installation, so the injection-time `no_compile_target` outranked and hid the real omission for the whole boot. And `_served_identity` carried a target's pipeline into `serving_mode.resolve` only when it named an ACTIVE ref — a JIT INTAKE arm names no artifact by construction (pgw#1010), so even a healthy intake target reported eager.

## Tests

- `tests/test_scope_armed_slot_target_pgw1078.py` — new, REVERT-TURNS-RED through the real `ensure_setup()`: a lazily hydrated class-annotated slot armed in setup must install its target, bind to slot `pipeline`, and clear the stale posture.
- `tests/test_regional_dynamic_refusal_pgw746.py` — rewritten from "declines" to "marks every repeated block", including that the declared dim actually reaches the block input.
- Sweep: 357 passed on `-k "compile or arm or serving_mode or hot_swap or fleet_cells or executor or regional or posture or silent_failure"`. One wall-clock test (`test_mint_gate_pgw677`) timed out under `-n 4` at load average 40-64 and passes alone in 45 s.

## Version

**0.97.0** — behaviour change on the compile lane.

## Not in this PR

The billed compiled-wall proof. It needs 0.97.0 published, minimax-h3 repinned (**0.4.3**) and rebuilt, then one real request on the deployed endpoint showing `payload.metrics.lane` without `+eager` and an adjacent-frame pixel corr > 0.9. **No compiled wall is claimed anywhere here.**

Also unchanged and independent: `self_mint_skipped/no_export_declaration` (06:29:14Z) proves minimax-h3 registers no export declaration, so **no aot-inductor cell can be minted for it at all**. This PR makes the JIT intake lane actually serve compiled; AOT cell minting (th#1127) still needs the graph-class declaration first.