### PR TITLE
pgw#1080 (pgw#1056 corollary 2): the meta-instantiation gate — a real allocation under meta is a typed refusal naming the endpoint's own line

### DIFF
--- a/changelog.d/pgw1080.md
+++ b/changelog.d/pgw1080.md
@@ -1,0 +1,14 @@
+- **pgw#1080 (pgw#1056 corollary 2): the META-INSTANTIATION GATE.** The zero-download forge
+  instantiates model STRUCTURE on meta and exports it there, holding no checkpoint values — a
+  property that is invisible when it breaks, because the export still succeeds and the forge just
+  quietly starts needing weights again. `gen_worker.meta_instantiation` makes it checkable:
+  `guard(phase)` refuses the first real-device tensor materialized inside it, typed, naming the op,
+  device, shape, dtype and the **endpoint's own `file:line`** — never an SDK frame, because the fix
+  is always an authoring change. Scope is instantiation **OR trace** (ie#628's widening), which is
+  the case that matters: upstream z-image's `RopeEmbedder` is not an `nn.Module`, holds `None`, and
+  builds its tables on FIRST CALL inside `with torch.device("cpu")` — a pin that overrides any
+  ambient meta context and that an `__init__`-inspecting gate never sees. Both controls are pinned
+  as tests: that lazy-pinned shape is caught mid-trace after a clean `__init__`, and ie#630's fixed
+  form (buffers at `__init__`, no device pin) stays SILENT — a gate that fires on correctly-authored
+  code teaches authors to route around it. Fake tensors are treated as virtual by TYPE, since
+  `FakeTensorMode` reports a real device by design.

--- a/src/gen_worker/meta_instantiation.py
+++ b/src/gen_worker/meta_instantiation.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import contextlib
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, Iterator, Optional, Tuple
+from typing import Any, Iterator, List, Optional, Tuple
 
 from .api.errors import WorkerError
 
@@ -104,7 +104,7 @@ class Census:
     """What the gate saw. Empty ``events`` is the property holding."""
 
     phase: str = ""
-    events: list = field(default_factory=list)
+    events: List[Materialization] = field(default_factory=list)
 
     @property
     def clean(self) -> bool:
@@ -117,11 +117,14 @@ def is_virtual(tensor: Any) -> bool:
     Meta tensors by device; fake tensors by TYPE, because a fake tensor
     deliberately reports a real device while backing it with no storage.
     """
+    fake_cls: Optional[type] = None
     try:
         from torch._subclasses.fake_tensor import FakeTensor
+
+        fake_cls = FakeTensor
     except Exception:  # noqa: BLE001 — old/absent torch: fall back to device
-        FakeTensor = ()  # type: ignore[assignment]
-    if FakeTensor and isinstance(tensor, FakeTensor):  # type: ignore[arg-type]
+        fake_cls = None
+    if fake_cls is not None and isinstance(tensor, fake_cls):
         return True
     device = getattr(tensor, "device", None)
     if device is None:
@@ -157,7 +160,7 @@ def observe(phase: str, census: Optional[Census] = None) -> Iterator[Census]:
     out = census if census is not None else Census()
     out.phase = str(phase or out.phase)
 
-    class _Watch(TorchFunctionMode):  # type: ignore[misc]
+    class _Watch(TorchFunctionMode):
         def __torch_function__(
             self, func: Any, types: Any, args: Any = (), kwargs: Any = None,
         ) -> Any:

--- a/src/gen_worker/meta_instantiation.py
+++ b/src/gen_worker/meta_instantiation.py
@@ -1,0 +1,218 @@
+"""pgw#1080 (pgw#1056 authoring corollary 2): the META-INSTANTIATION GATE.
+
+The zero-download forge instantiates a model's STRUCTURE on the meta device and
+exports it there — no checkpoint values ever enter the process that traces and
+compiles. That property is invisible when it breaks: a module that does real
+tensor work at construction, or (worse) lazily at CALL time under an explicit
+device pin, silently materializes real tensors and the forge quietly starts
+needing weights again. Nothing downstream notices, because the export still
+succeeds.
+
+**So the property is GATED, not hoped for.** Run the instantiation AND the
+trace inside :func:`guard`, and any tensor that lands on a real device is a
+typed refusal naming the site that allocated it.
+
+WHY THE SCOPE IS "INSTANTIATION *OR* TRACE" (ie#628's widening)
+---------------------------------------------------------------
+An ``__init__``-inspecting gate is not enough, and z-image is the measured
+counterexample that made the point: upstream's ``RopeEmbedder`` is not an
+``nn.Module`` at all, holds ``self.freqs_cis = None``, and builds its tables on
+FIRST CALL inside ``with torch.device("cpu")`` — a pin that overrides any
+ambient meta context. Nothing happens at ``__init__``; the violation happens
+mid-trace. (z-image's endpoint has since bound those tables as buffers with no
+device pin — ie#630 — so it is the family this gate must stay SILENT on. The
+gate exists for the NEXT one.)
+
+WHY A ``TorchFunctionMode`` AND NOT A DEVICE CONTEXT
+---------------------------------------------------
+``with torch.device("meta")`` is a DEFAULT, and a default is exactly what model
+code overrides — explicitly (``torch.device("cpu")``) or implicitly
+(``device=`` / ``.to("cuda")`` / ``.cpu()``). A mode sits above the factory
+functions themselves, so it observes the tensor that was actually produced
+rather than the default that was requested, and an override is therefore
+visible instead of authoritative.
+
+WHAT IS DELIBERATELY *NOT* REFUSED
+----------------------------------
+Fake tensors. ``FakeTensorMode`` produces tensors whose ``.device`` reads as a
+real device by design (that is what makes them faithful to trace against) while
+allocating nothing. Refusing them would refuse the very mechanism this gate
+protects, so :func:`is_virtual` treats a fake tensor as virtual regardless of
+what its device says.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Optional, Tuple
+
+from .api.errors import WorkerError
+
+#: Devices a virtual tensor may claim. Anything else is real allocation.
+VIRTUAL_DEVICES: Tuple[str, ...] = ("meta",)
+
+
+class MetaMaterializationError(WorkerError):
+    """A real-device tensor was materialized under the meta-instantiation gate.
+
+    Named-axis refusal (the gw#577 pattern): the message carries WHAT was
+    allocated (op, shape, dtype, device), WHERE in the endpoint's own code it
+    happened, and the authoring rule that was broken — because the fix is
+    always an authoring change, never a knob.
+    """
+
+    def __init__(
+        self, *, phase: str, op: str, device: str, shape: str, dtype: str,
+        site: str,
+    ) -> None:
+        self.phase = str(phase or "")
+        self.op = str(op or "")
+        self.device = str(device or "")
+        self.shape = str(shape or "")
+        self.dtype = str(dtype or "")
+        self.site = str(site or "")
+        super().__init__(
+            f"meta-instantiation gate: during {self.phase}, {self.op} "
+            f"materialized a REAL tensor on {self.device!r} "
+            f"(shape={self.shape}, dtype={self.dtype}) at {self.site or '?'}. "
+            f"The zero-download forge instantiates structure on meta and never "
+            f"holds checkpoint values, so a real allocation here means this "
+            f"model needs weights to be exported at all. Fix it in the "
+            f"ENDPOINT: derived tables that are pure functions of config "
+            f"belong in `register_buffer` at __init__ with NO device pin "
+            f"(ie#630's `rope_buffers` is the worked example); an explicit "
+            f"`with torch.device(...)` inside model code is itself the "
+            f"violation to remove."
+        )
+
+
+@dataclass
+class Materialization:
+    """One observed real-device allocation."""
+
+    op: str
+    device: str
+    shape: str
+    dtype: str
+    site: str
+
+
+@dataclass
+class Census:
+    """What the gate saw. Empty ``events`` is the property holding."""
+
+    phase: str = ""
+    events: list = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        return not self.events
+
+
+def is_virtual(tensor: Any) -> bool:
+    """Whether this tensor allocated nothing.
+
+    Meta tensors by device; fake tensors by TYPE, because a fake tensor
+    deliberately reports a real device while backing it with no storage.
+    """
+    try:
+        from torch._subclasses.fake_tensor import FakeTensor
+    except Exception:  # noqa: BLE001 — old/absent torch: fall back to device
+        FakeTensor = ()  # type: ignore[assignment]
+    if FakeTensor and isinstance(tensor, FakeTensor):  # type: ignore[arg-type]
+        return True
+    device = getattr(tensor, "device", None)
+    if device is None:
+        return True
+    return str(getattr(device, "type", device)) in VIRTUAL_DEVICES
+
+
+def _endpoint_site(skip: int = 0) -> str:
+    """The innermost stack frame OUTSIDE this SDK — i.e. the endpoint's own
+    code, which is where the authoring fix has to be made.
+
+    Reporting an SDK frame would name the observer instead of the cause; the
+    whole value of this refusal is the `file:line` an author can go and edit.
+    """
+    for frame in reversed(traceback.extract_stack()[:-(1 + skip)]):
+        path = frame.filename.replace("\\", "/")
+        if "/gen_worker/" in path or "/torch/" in path:
+            continue
+        return f"{frame.filename}:{frame.lineno} in {frame.name}"
+    return ""
+
+
+@contextlib.contextmanager
+def observe(phase: str, census: Optional[Census] = None) -> Iterator[Census]:
+    """Record every real-device tensor produced inside the block.
+
+    Observation only — it never raises, so a caller can census a phase and
+    decide separately. :func:`guard` is the refusing wrapper.
+    """
+    import torch
+    from torch.overrides import TorchFunctionMode
+
+    out = census if census is not None else Census()
+    out.phase = str(phase or out.phase)
+
+    class _Watch(TorchFunctionMode):  # type: ignore[misc]
+        def __torch_function__(
+            self, func: Any, types: Any, args: Any = (), kwargs: Any = None,
+        ) -> Any:
+            result = func(*args, **(kwargs or {}))
+            if isinstance(result, torch.Tensor) and not is_virtual(result):
+                out.events.append(Materialization(
+                    op=getattr(func, "__name__", str(func)),
+                    device=str(result.device),
+                    shape=str(tuple(result.shape)),
+                    dtype=str(result.dtype),
+                    site=_endpoint_site(skip=1),
+                ))
+            return result
+
+    with _Watch():
+        yield out
+
+
+@contextlib.contextmanager
+def guard(phase: str) -> Iterator[Census]:
+    """Refuse the FIRST real-device materialization in this block, typed.
+
+    First rather than all: the census is for reporting, but a mint that has
+    already allocated real weights has lost the property this gate exists to
+    keep, and continuing would only produce a longer list of the same fact.
+    """
+    with observe(phase) as census:
+        yield census
+    if not census.clean:
+        first = census.events[0]
+        raise MetaMaterializationError(
+            phase=census.phase, op=first.op, device=first.device,
+            shape=first.shape, dtype=first.dtype, site=first.site)
+
+
+@contextlib.contextmanager
+def meta_device() -> Iterator[None]:
+    """Instantiate structure on meta.
+
+    A DEFAULT, deliberately paired with :func:`guard` rather than trusted on
+    its own — see the module docstring on why a default is not a property.
+    """
+    import torch
+
+    with torch.device("meta"):
+        yield
+
+
+__all__ = [
+    "Census",
+    "Materialization",
+    "MetaMaterializationError",
+    "VIRTUAL_DEVICES",
+    "guard",
+    "is_virtual",
+    "meta_device",
+    "observe",
+]

--- a/tests/test_meta_instantiation_pgw1080.py
+++ b/tests/test_meta_instantiation_pgw1080.py
@@ -1,0 +1,143 @@
+"""pgw#1080: the meta-instantiation gate, including ie#628's call-time widening.
+
+The RED control is the z-image rope pattern, transcribed: a plain object (not
+an `nn.Module`) holding `None`, which builds its tables on FIRST CALL inside
+`with torch.device("cpu")`. Nothing happens at `__init__`, so an
+`__init__`-inspecting gate sees a clean instantiation and the violation lands
+mid-trace. That is the exact shape ie#628 widened the gate for.
+
+The GREEN control is ie#630's fix for the same family: an `nn.Module` whose
+tables are `register_buffer`ed at `__init__` with no device pin. The gate must
+stay SILENT on it — a gate that fires on correctly-authored code is worse than
+no gate, because it teaches authors to route around it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.nn as nn  # noqa: E402
+
+from gen_worker import meta_instantiation as mi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# The two controls, transcribed from the real families
+# ---------------------------------------------------------------------------
+
+
+class LazyPinnedRope:
+    """RED — upstream z-image's `RopeEmbedder` shape (transformer_z_image.py).
+
+    Not an `nn.Module`; tables are `None` until first call; the build pins
+    `torch.device("cpu")`, which OVERRIDES any ambient meta context.
+    """
+
+    def __init__(self, dim: int = 8, end: int = 16) -> None:
+        self.dim = dim
+        self.end = end
+        self.freqs_cis = None
+
+    def __call__(self) -> torch.Tensor:
+        if self.freqs_cis is None:
+            with torch.device("cpu"):
+                self.freqs_cis = torch.arange(self.end, dtype=torch.float32)
+        return self.freqs_cis
+
+
+class BoundRope(nn.Module):
+    """GREEN — ie#630's fix: a buffer at `__init__`, no device pin."""
+
+    def __init__(self, dim: int = 8, end: int = 16) -> None:
+        super().__init__()
+        self.register_buffer(
+            "freqs", torch.arange(end, dtype=torch.float32), persistent=False)
+
+    def forward(self) -> torch.Tensor:
+        return self.freqs
+
+
+# ---------------------------------------------------------------------------
+# The property the gate keeps
+# ---------------------------------------------------------------------------
+
+
+def test_the_bound_rope_instantiates_entirely_on_meta() -> None:
+    """GREEN control: correctly-authored code allocates nothing real."""
+    with mi.guard("instantiation") as census:
+        with mi.meta_device():
+            module = BoundRope()
+    assert census.clean
+    assert module.freqs.device.type == "meta"
+
+
+def test_a_device_pin_at_CALL_time_is_caught_even_though_init_was_clean() -> None:
+    """RED control, and the whole reason ie#628 widened the scope.
+
+    Instantiation is clean — an `__init__`-inspecting gate would pass this —
+    and the violation happens on first call, under the pin.
+    """
+    with mi.guard("instantiation") as census:
+        with mi.meta_device():
+            rope = LazyPinnedRope()
+    assert census.clean, "the lazy build does nothing at __init__, by design"
+
+    with pytest.raises(mi.MetaMaterializationError) as caught:
+        with mi.guard("trace"):
+            with mi.meta_device():
+                rope()
+
+    error = caught.value
+    assert error.phase == "trace"
+    assert error.device.startswith("cpu")
+    # The refusal must be actionable: it names the authoring rule and the fix.
+    assert "register_buffer" in str(error)
+    assert "torch.device" in str(error)
+
+
+def test_the_refusal_names_the_ENDPOINT_site_not_an_sdk_frame() -> None:
+    """A refusal whose `file:line` points into the SDK names the observer
+    instead of the cause, and an author cannot act on it."""
+    with pytest.raises(mi.MetaMaterializationError) as caught:
+        with mi.guard("trace"):
+            with mi.meta_device():
+                LazyPinnedRope()()
+    site = caught.value.site
+    assert site, "the refusal carried no site at all"
+    assert "/gen_worker/" not in site.replace("\\", "/")
+    assert "test_meta_instantiation_pgw1080.py" in site
+
+
+def test_an_explicit_real_device_kwarg_is_caught_too() -> None:
+    """The pin is not the only way to escape a default."""
+    with pytest.raises(mi.MetaMaterializationError):
+        with mi.guard("instantiation"):
+            with mi.meta_device():
+                torch.zeros(4, device="cpu")
+
+
+def test_fake_tensors_are_VIRTUAL_and_never_refused() -> None:
+    """`FakeTensorMode` reports a real device by design — that is what makes it
+    faithful to trace against. Refusing it would refuse the mechanism the gate
+    exists to protect."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with mi.guard("trace") as census:
+        with FakeTensorMode():
+            made = torch.zeros(8, 8, device="cpu")
+            assert mi.is_virtual(made)
+            assert str(made.device) == "cpu"
+    assert census.clean
+
+
+def test_observe_reports_without_raising() -> None:
+    """The census is a measurement; only `guard` refuses."""
+    with mi.observe("instantiation") as census:
+        torch.zeros(2, device="cpu")
+        torch.ones(3, device="cpu")
+    assert not census.clean
+    assert len(census.events) == 2
+    assert {e.op for e in census.events} == {"zeros", "ones"}
+    assert all(e.device.startswith("cpu") for e in census.events)


### PR DESCRIPTION
First increment of the **pgw#1056 minimal slice** (the remedy Paul ruled for ie#638 after vetoing the residency-shuffling patch). Vehicle is **gen-worker 0.97.0**; this ships as **0.97.1**, `SEAL_VERSION` stays **4**, no 0.96.x compatibility.

## Why a gate and not a device context

The zero-download forge instantiates model STRUCTURE on meta and exports it there, holding no checkpoint values. **That property is invisible when it breaks** — the export still succeeds and the forge quietly starts needing weights again.

`with torch.device("meta")` is a *default*, and a default is exactly what model code overrides. A `TorchFunctionMode` sits above the factory functions, so it observes the tensor actually produced rather than the default requested, and an override becomes visible instead of authoritative.

## Scope is instantiation **OR TRACE** — ie#628's widening, and the case that matters

Upstream z-image's `RopeEmbedder` is not an `nn.Module`, holds `self.freqs_cis = None`, and builds its tables on **first call** inside `with torch.device("cpu")`. Nothing happens at `__init__`, so an `__init__`-inspecting gate passes it and the violation lands mid-trace.

Both controls are pinned as tests:

| control | shape | expected |
|---|---|---|
| `LazyPinnedRope` | upstream z-image: lazy, CPU-pinned, built in `__call__` | clean `__init__`, **caught mid-trace** |
| `BoundRope` | ie#630's fix: `register_buffer` at `__init__`, no device pin | gate stays **SILENT** |

The silent case is load-bearing: a gate that fires on correctly-authored code teaches authors to route around it. (z-image itself is the GREEN case today — ie#630 already bound those tables; see ie#640.)

## Refusals are actionable

`MetaMaterializationError` names the op, device, shape, dtype and the **endpoint's own `file:line`** — never an SDK frame, because the fix is always an authoring change and a refusal naming the observer cannot be acted on. It states the rule too (`register_buffer` at `__init__`, no device pin; an explicit `with torch.device(...)` in model code is itself the violation).

Fake tensors are virtual **by type** — `FakeTensorMode` reports a real device by design, and refusing it would refuse the very mechanism the gate protects.

## Honest scope

Lands **wired to tests only**. The wiring into `mint_child` is blocked on two decisions recorded in pgw#1080: `execution_lane_verdict_for` (pgw#947, `mint_child.py:564`) and `_drive_warm_plan(..., proof_only=True)` (pgw#984, `mint_child.py:844`) are real-value touchpoints living inside the child today, and the slice must re-site both. This is their prerequisite, not a substitute.

6 tests, ruff clean, mypy clean, the three hard lint gates clean.