### PR TITLE
pgw#1084: repin the micro-diffusion gauntlet to gen-worker 0.97.0

### DIFF
--- a/changelog.d/pgw1084.md
+++ b/changelog.d/pgw1084.md
@@ -1,0 +1,5 @@
+- The `micro-diffusion` example endpoint — the fleet's AOT micro gauntlet — repins to
+  `gen-worker==0.97.0`, matching the fleet hardcut in `inference-endpoints` `2440905`
+  (ie#639). It sits outside that train, so it had been left on `==0.96.1`, a line
+  `fleet-floors.toml` has since deleted from `[supported]`. Cells minted from this pin
+  carry pgw#1059's four-axis `ck1` and are live-scheme (pgw#1084).

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "micro-diffusion"
-version = "0.1.0"
+version = "0.2.0"
 description = "The fleet's smallest REAL endpoint family — three export entries over a deterministically generated toy checkpoint, so a full AOT mint cycle costs minutes"
 requires-python = ">=3.12,<3.13"
 dependencies = [

--- a/examples/micro-diffusion/pyproject.toml
+++ b/examples/micro-diffusion/pyproject.toml
@@ -11,9 +11,16 @@ dependencies = [
     # ⚠️ THIS FAMILY'S SERVE PATH REQUIRES pgw#994 (`2165c2d5`): it declares a
     # `repeat=` container input with a plain input after it, and on <0.93.4 the
     # cell MINTS and SEALS and then refuses at ingress on its first served
-    # call. Never pin below that. 0.96.1 also matches the ie `e7384fc`
-    # fleet cutover, so the micro family and the fleet share one wheel.
-    "gen-worker==0.96.1",
+    # call. Never pin below that.
+    #
+    # 0.97.0 (pgw#1084): the fleet hardcut to it in `inference-endpoints`
+    # `2440905` (ie#639/PR ie#298 — 28 pins, floor, and `[supported]` all moved,
+    # 0.96 DELETED with no transition window). This example is outside that
+    # train, so it is repinned here by hand to keep the micro gauntlet on the
+    # SAME wheel the fleet serves — which is the whole reason the gauntlet is a
+    # usable probe. 0.97.0 also carries pgw#1059's four-axis `ck1`, so every
+    # cell minted from this pin is a live-scheme cell.
+    "gen-worker==0.97.0",
     "msgspec>=0.18",
     "safetensors>=0.4",
     "pillow",

--- a/examples/micro-diffusion/uv.lock
+++ b/examples/micro-diffusion/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.96.1"
+version = "0.97.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blake3" },
@@ -350,9 +350,9 @@ dependencies = [
     { name = "requests" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/ee/c36bddeead1fe93482645b059ce4fd867677a0c70febcc4c24e1ff0587d3/gen_worker-0.96.1.tar.gz", hash = "sha256:f558682276e6c3b17fd3df3f87ff92f54ae7ef848854eb4abd1820b17d624951", size = 1681080, upload-time = "2026-08-09T21:10:46.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/16/d9f70aa67fce5240cd418bbe06993f15e9c0d2814a84b6629c7a50abfb84/gen_worker-0.97.0.tar.gz", hash = "sha256:585d1efeb7e6e2d5e3efa50c9c913387ed242935e3de11dd8090a69627186ec1", size = 1740831, upload-time = "2026-08-10T14:23:44.353Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/19/2fbf6bf7588e317950ce69ba9d55041d62393fb44bd82cc66252310bd738/gen_worker-0.96.1-py3-none-any.whl", hash = "sha256:25fe222f53099aec346347a430bd1928c81a40d6f8cf30fa9627f6ce22a06702", size = 1840624, upload-time = "2026-08-09T21:10:44.192Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/32/6f565d35d324bb77ee0db0d5d1d32b0143bdf0cfcad6ae2a73b83f2713ac/gen_worker-0.97.0-py3-none-any.whl", hash = "sha256:cd0adea043f40a93db57fd9dd51b04dfc07ca145fdde4210278522108312266d", size = 1901447, upload-time = "2026-08-10T14:23:42.427Z" },
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ local = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gen-worker", specifier = "==0.96.1" },
+    { name = "gen-worker", specifier = "==0.97.0" },
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pillow" },
     { name = "safetensors", specifier = ">=0.4" },

--- a/examples/micro-diffusion/uv.lock
+++ b/examples/micro-diffusion/uv.lock
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "micro-diffusion"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gen-worker" },


### PR DESCRIPTION
The AOT micro gauntlet (`examples/micro-diffusion`) is the micro-probe-first vehicle for the pgw#1084 campaign, and it is only a usable probe while it runs the same wheel the fleet serves.

`inference-endpoints` hardcut to `gen-worker==0.97.0` in `2440905` (ie#639 / PR ie#298 — 28 pins, the floor, and `[supported]` all moved, 0.96 DELETED with no transition window). This example lives in python-gen-worker and is outside that train, so it was left pinned at `==0.96.1`, a line `fleet-floors.toml` no longer permits.

0.97.0 also carries pgw#1059's four-axis `ck1` redefinition, so cells minted from this pin are live-scheme rather than members of the stranded 0.96.x corpus (pgw#1084 §4).

`uv lock -p 3.12` ran in the same commit (ie#587: a pin moved without its lock is CI-fatal); `gen-worker` resolves `0.96.1 -> 0.97.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)