### PR TITLE
pgw#891 (th#1457 item 2, worker half): a graph contract belongs to the ARTIFACT — a non-cell arm carries none

### DIFF
--- a/changelog.d/891-arm-graph-contract.md
+++ b/changelog.d/891-arm-graph-contract.md
@@ -1,0 +1,7 @@
+- `ExecutionSpec.arm.graph_contract_digest` now follows the artifact: required on an
+  `aot_cell` arm (pgw#903's pre-dlopen fence compares it), refused on `dynamo` and
+  `eager_only` arms. A non-cell arm has no traced graph the hub could name ahead of
+  dispatch, and `aot_identity.expected_from_plan` already returns `None` there — so the
+  old unconditional requirement made every non-cell dispatch unbuildable hub-side while
+  the value it demanded had no reader. Paired with tensorhub `1457-arm-graph-contract`;
+  both halves must ship together.

--- a/src/gen_worker/plan.py
+++ b/src/gen_worker/plan.py
@@ -163,6 +163,14 @@ class ArmRef(msgspec.Struct, frozen=True):
     arm instead of being recovered from the adapter list. ``artifact`` is set
     iff ``backend == "aot_cell"``: since pgw#1010 dynamo cells are neither
     sealed nor published, so DYNAMO has no artifact to name.
+
+    ``graph_contract_digest`` follows the artifact exactly: it is the
+    ``combined_graph_hash`` of a compiled cell, so it is non-empty iff the arm
+    names one, and empty otherwise. An ``eager_only`` arm traces nothing and a
+    ``dynamo`` arm compiles at serve time, so neither has a graph contract the
+    hub could name ahead of dispatch — and :func:`aot_identity.expected_from_plan`
+    already returns ``None`` for both, so nothing on this side ever reads it
+    there.
     """
 
     graph_contract_digest: str
@@ -507,9 +515,22 @@ def _arm(spec: Any) -> ArmRef:
     elif backend == "aot_cell":
         raise PlanRefusal(
             "spec.arm.artifact", "exactly one ArtifactIdentity on an aot_cell arm", "absent")
+    graph_contract = str(arm.graph_contract_digest or "").strip()
+    # Required on the arm that has an artifact (pgw#903's pre-dlopen fence
+    # compares exactly this value), refused on every other — symmetrically with
+    # ``artifact`` above. A graph contract on an arm that names no cell is a
+    # value the hub cannot produce and this worker never verifies, riding inside
+    # the execution digest.
+    if artifact is not None:
+        graph_contract = _require(graph_contract, "spec.arm.graph_contract_digest")
+    elif graph_contract:
+        raise PlanRefusal(
+            "spec.arm.graph_contract_digest",
+            "absent unless backend is aot_cell",
+            f"present with backend {backend}",
+        )
     return ArmRef(
-        graph_contract_digest=_require(
-            arm.graph_contract_digest, "spec.arm.graph_contract_digest"),
+        graph_contract_digest=graph_contract,
         shape=shape,
         adapter_rank_bucket=bucket,
         backend=backend,

--- a/tests/test_artifact_identity_pgw903.py
+++ b/tests/test_artifact_identity_pgw903.py
@@ -173,11 +173,13 @@ def test_identity_is_never_confirmed_by_comparing_bytes() -> None:
 
 def _plan(backend: int = pb.STEADY_BACKEND_AOT_CELL) -> Any:
     arm = pb.Arm(
-        graph_contract_digest="gc_01",
         shape=pb.ARM_SHAPE_BRANCHLESS,
         backend=backend,
     )
     if backend == pb.STEADY_BACKEND_AOT_CELL:
+        # The graph contract follows the artifact — an arm that names no cell
+        # carries neither.
+        arm.graph_contract_digest = "gc_01"
         arm.artifact.CopyFrom(pb.ArtifactIdentity(
             cell_ref="cozy/cells-micro#k1",
             content_digest="sha256:" + "c" * 64,

--- a/tests/test_plan_pgw902.py
+++ b/tests/test_plan_pgw902.py
@@ -269,13 +269,53 @@ def test_a_non_aot_arm_carrying_an_artifact_refuses() -> None:
     assert "dynamo" in exc.value.have
 
 
-def test_an_eager_only_arm_is_a_valid_plan_with_no_artifact() -> None:
-    p = _plan(arm=pb.Arm(
-        graph_contract_digest="gc_01",
-        shape=pb.ARM_SHAPE_BRANCHLESS,
-        backend=pb.STEADY_BACKEND_EAGER_ONLY))
-    assert p.arm.backend == "eager_only"
+@pytest.mark.parametrize(
+    "backend,token",
+    [
+        (pb.STEADY_BACKEND_EAGER_ONLY, "eager_only"),
+        (pb.STEADY_BACKEND_DYNAMO, "dynamo"),
+    ],
+)
+def test_a_non_cell_arm_is_a_valid_plan_with_no_artifact_and_no_graph_contract(
+    backend: int, token: str,
+) -> None:
+    """The shape most of the fleet's declared lanes need. `svdq-fp4-w4a4+eager`
+    is execution-eager-only in tensorhub's lane table — a lane that cannot be
+    compiled at all — so an EAGER_ONLY arm can never name a graph contract; a
+    DYNAMO arm compiles at serve time, so the hub cannot name one ahead of
+    dispatch either."""
+    p = _plan(arm=pb.Arm(shape=pb.ARM_SHAPE_BRANCHLESS, backend=backend))
+    assert p.arm.backend == token
     assert p.arm.artifact is None
+    assert p.arm.graph_contract_digest == ""
+
+
+@pytest.mark.parametrize(
+    "backend", [pb.STEADY_BACKEND_EAGER_ONLY, pb.STEADY_BACKEND_DYNAMO])
+def test_a_graph_contract_on_a_non_cell_arm_refuses(backend: int) -> None:
+    """Symmetric with the artifact rule: a graph contract on an arm that names
+    no cell is a value the hub cannot produce and this worker never verifies
+    (`aot_identity.expected_from_plan` returns None there), riding inside the
+    execution digest."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=pb.Arm(
+            graph_contract_digest="gc_01",
+            shape=pb.ARM_SHAPE_BRANCHLESS,
+            backend=backend))
+    assert exc.value.field == "spec.arm.graph_contract_digest"
+
+
+def test_an_aot_cell_arm_without_a_graph_contract_refuses() -> None:
+    """pgw#903's pre-dlopen fence compares exactly this value, so the arm that
+    HAS an artifact must still name it."""
+    with pytest.raises(PlanRefusal) as exc:
+        _plan(arm=pb.Arm(
+            shape=pb.ARM_SHAPE_BRANCHLESS,
+            backend=pb.STEADY_BACKEND_AOT_CELL,
+            artifact=pb.ArtifactIdentity(
+                cell_ref="r", content_digest="d", cell_key="k",
+                publisher_org="o", toolchain_digest="t", env_seal_digest="e")))
+    assert exc.value.field == "spec.arm.graph_contract_digest"
 
 
 def test_an_artifact_with_no_publisher_refuses() -> None:

--- a/tests/test_run_attempt_cutover_pgw904.py
+++ b/tests/test_run_attempt_cutover_pgw904.py
@@ -81,7 +81,7 @@ def _spec(
     spec.release.image_digest = "sha256:" + "1" * 64
     spec.release.code_closure_id = "cc-1"
     spec.numerical_lane.weights = pb.WEIGHT_LANE_BF16
-    spec.arm.graph_contract_digest = "gc-1"
+    # No graph contract: an eager arm names no cell, so it has none.
     spec.arm.shape = pb.ARM_SHAPE_BRANCHLESS
     spec.arm.backend = pb.STEADY_BACKEND_EAGER_ONLY
     spec.topology.accelerator = "none"


### PR DESCRIPTION
**DRAFT AND HELD.** Do not merge without the cutover decision — this is one half
of a coordinated pair. Paired PR: **cozy-creator/tensorhub#984** (branch
`1457-arm-graph-contract`). Neither half is deployable alone.

**This branch is NOT a release.** No version bump, no `uv lock` change — it
carries a `changelog.d/` fragment per the library-release rule. When it ships it
must ride the **same wheel** as the A2 driver lane's pgw#1080 slice and
th#1457's legacy-head deletion: **one 0.97.1 cut, not three.**

## What this fixes

`plan._arm` required `spec.arm.graph_contract_digest` on EVERY arm. It is the
`combined_graph_hash` of a compiled cell, so only an `aot_cell` arm has one — an
`eager_only` arm traces nothing, and a `dynamo` arm compiles at serve time, so
the hub cannot name a graph contract for either ahead of dispatch.

This side never read it there anyway: `aot_identity.expected_from_plan` returns
`None` whenever `arm.artifact` is absent, and its docstring already says so
("`None` is a complete answer, not a gap").

## The consequence was hub-side and total

tensorhub's producer has exactly one source for the value — a published cell's
`graph_contract` identity axis — so under the old rule every dispatch naming no
hub-verified cell was structurally unbuildable. Measured on the canonical
tensorhub `master` catalog, 2026-08-10: `svdq-fp4-w4a4+eager`, a lane tensorhub's
own table marks **uncompilable** (`executionEagerOnly`), is declared by **38 of
41 releases** (320 rows). The non-cell arm is the majority shape, not an edge.

## The rule now

Symmetric with `artifact`: **required** on an `aot_cell` arm (pgw#903's
pre-dlopen fence compares exactly this value), **refused** on `dynamo` and
`eager_only`. Required where something verifies it, refused where nothing
produces it — so an unverifiable value cannot ride inside the execution digest.

## Evidence

- 4 new parametrised tests in `test_plan_pgw902.py`, **RED-verified** against the
  pre-change `plan.py` (all four fail without it).
- Fixture corrections in pgw#903 / pgw#904 / pgw#807's suites: their `"gc_01"` /
  `"gc-1"` digests on **eager** arms existed only to satisfy the old rule. That
  three independent suites had to invent the value is the evidence the rule was
  wrong.
- `78 passed` across `test_plan_pgw902` + `test_artifact_identity_pgw903` +
  `test_run_attempt_cutover_pgw904` + `test_cell_publish_v2_pgw807`.
- `mypy src/gen_worker` — Success, no issues in 245 source files. `ruff` clean.
- Zero deletions.
- No `.proto`, no generated binding, no `PROTO_DIGEST` change (`19f8367c`
  unmoved). Implementation-level rule, not a schema change — so no drift
  interlock applies and the two halves may land in either order.