### PR TITLE
pgw#1082: the compiled lane that served 100% eager and reported jit_cell — declared marks that raise on every call, and a regional guard that never confessed its degrade

### DIFF
--- a/changelog.d/pgw1082.md
+++ b/changelog.d/pgw1082.md
@@ -1,0 +1,37 @@
+- **pgw#1082: a regional target that degraded on its FIRST call kept reporting
+  `serving_mode=jit_cell` for the life of the pod.** minimax-h3 0.4.3 served
+  6.27 s/step against the rig's 4.31 for the identical recipe, armed, entered,
+  with zero guard misses and an empty `fallback_reason`. Four defects, one
+  outcome:
+  - `_with_declared_marks` mapped a logical axis onto one dim of one KIND of
+    tensor (dim 1 of rank-3 floats for `sequence`). Every sibling tensor
+    carrying the same axis — an integer index tensor, a rotary `(cos, sin)`
+    TUPLE — stayed static, dynamo specialized the symbol on them and raised
+    `ConstraintViolationError` against the mark. The axis extent is now found
+    at its primary dim and marked wherever it appears in the argument tree,
+    integer tensors and nested containers included.
+  - A declared range the inputs leave is now a typed `DeclaredRangeExceeded`
+    naming the declaration, the axis and the observed extent — not a
+    dynamo-internal error nobody could attribute. minimax-h3 declared
+    `max=4096` (its TEXT bound) for an axis its own requests present at 38,015.
+  - `_guarded_regional`'s permanent-degrade branch never set
+    `failure_signal["degraded"]`, which is exactly what `is_compile_armed`
+    reads — so the wire reported a compiled lane while 100% of the work ran
+    eager. It sets it now, and any permanent guard degrade records an eager
+    POSTURE even on a JIT intake arm (which names no artifact, so the old
+    active-ref gate returned early for the only JIT lane the fleet has).
+  - `emit_jit_compile_event`'s `n_graphs` had NO caller. It is replaced by a
+    `GraphAudit` (`unique_graphs`, `graph_breaks`, per-reason histogram)
+    sampled across the same window as the compile wall, with a
+    `phase=graph_break` event per reason.
+- **The regional lane now compiles `fullgraph=True`.** A repeated block is one
+  traceable unit by construction; without fullgraph a break splits it into
+  eager-glued fragments that report a clean arm, never guard-miss and run at
+  eager speed. A break now raises, is classified `graph_break`, flips the wire
+  to explicit eager and names its reason. There is no configuration surface:
+  a silently fragmented region must not be expressible.
+- Two ref-only reporting gaps closed with the same reading: `_mark_warm_complete`
+  no longer emits `boot_ended_uncompiled` on a healthy JIT-intake pod, and
+  `_served_execution_lane` no longer reports `+eager` while `serving_mode`
+  reports `jit_cell` (`_served_identity`'s docstring says that cannot happen).
+- New eager-posture tokens: `graph_break`, `declared_range_exceeded`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen-worker"
-version = "0.97.0"
+version = "0.98.0"
 description = "A library used to build custom functions in Cozy Creator's serverless function platform."
 readme = "README.md"
 license = "MIT"

--- a/src/gen_worker/cell_adopt.py
+++ b/src/gen_worker/cell_adopt.py
@@ -122,6 +122,19 @@ class EagerPhase(StrEnum):
     #: and it must mean "nothing is dispatchable" (pgw#844), never "partial".
     BOOT_ENDED_UNCOMPILED = "boot_ended_uncompiled"
 
+    #: pgw#1082: the declared region did not trace WHOLE. Dynamo's fullgraph
+    #: refusal fired, the platform refused to serve eager-glued fragments as
+    #: compiled, and this instance degraded to explicit eager. An AUTHORING
+    #: defect in the endpoint's block, named as one — never a silent 1.0x
+    #: "compiled" lane (the ie#632/pgw#1078 failure class).
+    GRAPH_BREAK = "graph_break"
+
+    #: pgw#1082: the endpoint's `dynamic=(...)` declaration names a range its
+    #: own inputs leave, so the declared marks cannot be applied and the
+    #: target degraded to eager. Also an AUTHORING defect, and the one that
+    #: actually cost minimax-h3 its compiled wall.
+    DECLARED_RANGE_EXCEEDED = "declared_range_exceeded"
+
     #: `_fail_closed`'s default, for a caller that has not classified its exit.
     #: A new decline landing here rather than on its own member is the
     #: regression pgw#824 exists to catch.

--- a/src/gen_worker/compile_cache.py
+++ b/src/gen_worker/compile_cache.py
@@ -405,6 +405,73 @@ def _is_recompile_error(exc: BaseException) -> bool:
         return False
 
 
+#: pgw#1082: the token a graph-broken region reports, on the guard detail, on
+#: the `serve_eager_posture` phase, and on the request row's
+#: `fallback_reason`. One string, so "which releases are serving fragments"
+#: is a GROUP BY and never a log grep.
+GRAPH_BREAK_TOKEN = "graph_break"
+
+#: pgw#1082: the declaration named a dynamic range its own inputs leave.
+DECLARED_RANGE_TOKEN = "declared_range_exceeded"
+
+
+def _is_graph_break_error(exc: BaseException) -> bool:
+    """True for dynamo's fullgraph refusal — the region did NOT trace whole.
+
+    This is the ONLY honest signal that separates "compiled" from "compiled
+    into eager-glued fragments". Without ``fullgraph=True`` dynamo emits no
+    error at all for this case: it splits the region, reports a successful
+    arm, never guard-misses, and serves at eager speed (pgw#1078's measured
+    triple on a 20.1B denoiser). With it, the break RAISES and names itself.
+    """
+    try:
+        from torch._dynamo import exc as dexc
+
+        return isinstance(exc, (dexc.Unsupported, dexc.UserError))
+    except Exception:
+        return False
+
+
+def _emit_declared_range_event(label: str, exc: BaseException) -> None:
+    """Confess a declared-range refusal: the endpoint's `dynamic=(...)` names
+    a range its own inputs leave, so nothing can be marked and the target
+    degrades to eager. An authoring defect, named as one."""
+    try:
+        from . import activity as activity_mod
+
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            detail=f"target={label} lane=regional {DECLARED_RANGE_TOKEN}: "
+                   f"{_clip(str(exc), 600)}",
+            phase=DECLARED_RANGE_TOKEN,
+        )
+    except Exception:  # pragma: no cover — telemetry never fails the serve
+        logger.debug("compile-cache: declared-range event emission failed",
+                     exc_info=True)
+
+
+def _emit_graph_break_event(label: str, exc: BaseException) -> None:
+    """Confess a fullgraph refusal on the wire, once, at the moment it
+    happens. The `jit_compile` audit counts breaks over a whole window; this
+    names the target that lost its compiled lane because of them."""
+    try:
+        from . import activity as activity_mod
+
+        activity_mod.emit_event(
+            activity_mod.KIND_SERVE_DEGRADE,
+            detail=(
+                f"target={label} lane=regional {GRAPH_BREAK_TOKEN}: the "
+                f"region did not trace whole under fullgraph, so this "
+                f"instance serves it EAGER and says so. "
+                f"{_clip(str(exc), 600)}"
+            ),
+            phase=GRAPH_BREAK_TOKEN,
+        )
+    except Exception:  # pragma: no cover — telemetry never fails the serve
+        logger.debug("compile-cache: graph-break event emission failed",
+                     exc_info=True)
+
+
 @dataclass(frozen=True)
 class GuardMiss:
     """One tenant request that hit fail-on-recompile on a compiled target.
@@ -1483,6 +1550,76 @@ def counters_delta(before: Dict[str, int], after: Dict[str, int]) -> Dict[str, i
     return {k: int(after.get(k, 0)) - int(before.get(k, 0)) for k in after}
 
 
+@dataclass(frozen=True)
+class GraphAudit:
+    """How many graphs a compile produced, and what split them (pgw#1082).
+
+    ``unique_graphs`` and ``graph_breaks`` are dynamo's own process-global
+    counters; ``reasons`` is the break-reason histogram, highest first. A
+    region that traced whole reads ``graph_breaks=0``; anything else names
+    the ops that cut it, which is the only way to tell an armed-and-fast
+    region from an armed-and-fragmented one (the pgw#1078 measurement:
+    armed + entered + zero guard misses + zero speedup)."""
+
+    unique_graphs: int = 0
+    graph_breaks: int = 0
+    reasons: Tuple[Tuple[str, int], ...] = ()
+
+    @property
+    def whole(self) -> bool:
+        return self.graph_breaks == 0
+
+    def summary(self, top: int = 4) -> str:
+        head = f"n_graphs={self.unique_graphs} n_breaks={self.graph_breaks}"
+        if not self.reasons:
+            return head
+        top_reasons = " ".join(
+            f"{_clip(reason, 90)}x{count}"
+            for reason, count in self.reasons[:top])
+        return f"{head} breaks=[{top_reasons}]"
+
+
+def graph_audit() -> GraphAudit:
+    """This process's cumulative dynamo graph/break counters (monotonic).
+
+    pgw#1082: ``emit_jit_compile_event`` has carried an ``n_graphs``
+    parameter since th#1322 that NO caller ever populated, so every
+    ``jit_compile`` event on the platform read ``n_graphs=0`` and a fully
+    graph-broken 20.1B denoiser was indistinguishable on the wire from a
+    healthy one. This is the read that answers it."""
+    try:
+        from torch._dynamo.utils import counters
+
+        reasons = tuple(sorted(
+            ((str(k), int(v)) for k, v in counters["graph_break"].items()),
+            key=lambda kv: (-kv[1], kv[0])))
+        return GraphAudit(
+            unique_graphs=int(counters["stats"].get("unique_graphs", 0)),
+            graph_breaks=sum(c for _, c in reasons),
+            reasons=reasons,
+        )
+    except Exception:
+        logger.debug("compile-cache: dynamo graph counters unavailable",
+                     exc_info=True)
+        return GraphAudit()
+
+
+def graph_audit_delta(before: GraphAudit) -> GraphAudit:
+    """The audit of ONE compile window: after minus before, per reason."""
+    after = graph_audit()
+    prior = dict(before.reasons)
+    reasons = tuple(sorted(
+        ((reason, count - prior.get(reason, 0))
+         for reason, count in after.reasons
+         if count - prior.get(reason, 0) > 0),
+        key=lambda kv: (-kv[1], kv[0])))
+    return GraphAudit(
+        unique_graphs=max(0, after.unique_graphs - before.unique_graphs),
+        graph_breaks=sum(c for _, c in reasons),
+        reasons=reasons,
+    )
+
+
 def compile_wall_seconds() -> float:
     """This process's cumulative torch.compile wall time (monotonic, seconds).
 
@@ -2370,47 +2507,116 @@ def _mark_regional_blocks(owner: Any, dynamic_dims: tuple) -> int:
     return marked
 
 
+class DeclaredRangeExceeded(RuntimeError):
+    """A declared dynamic axis met an extent OUTSIDE its declared range.
+
+    pgw#1082: this used to be a ``ConstraintViolationError`` raised from
+    inside dynamo, caught by the guard as "some compiled target failed", and
+    swallowed into a permanent eager degrade that the wire still reported as
+    ``jit_cell``. It is an ENDPOINT DECLARATION defect — the declaration
+    named a range its own inputs leave — and it now says so by name.
+    """
+
+
+#: Logical axis -> the tensor dim it is PRIMARILY read from. The extent found
+#: there is then propagated to every argument that carries it (see
+#: :func:`_with_declared_marks`), because a sequence axis is never carried by
+#: one tensor: H3's block takes ``hidden_states[B, S, H]``, ``adaln_indices[S]``
+#: and a ``(cos[S, D], sin[S, D])`` TUPLE, and leaving the last two static is
+#: what specialized the symbol and violated the mark.
+_AXIS_PRIMARY_DIM: Dict[str, int] = {"batch": 0, "sequence": 1}
+_AXIS_MIN_RANK: Dict[str, int] = {"batch": 1, "sequence": 3}
+
+
+def _iter_arg_tensors(obj: Any, depth: int = 0) -> Iterator[Any]:
+    """Every tensor in an argument tree, through tuples/lists/dicts."""
+    import torch
+
+    if isinstance(obj, torch.Tensor):
+        yield obj
+    elif depth < 3 and isinstance(obj, (tuple, list)):
+        for item in obj:
+            yield from _iter_arg_tensors(item, depth + 1)
+    elif depth < 3 and isinstance(obj, dict):
+        for item in obj.values():
+            yield from _iter_arg_tensors(item, depth + 1)
+
+
 def _with_declared_marks(fn: Callable[..., Any], dynamic_dims: tuple) -> Callable[..., Any]:
     """Wrap a compiled callable so every call marks the DECLARED dynamic
-    dims on its tensor inputs before dynamo sees them.
+    axes COHERENTLY across its whole argument tree before dynamo sees them.
 
-    Mapping of logical axes to tensor dims: ``batch`` marks dim 0 of every
-    floating tensor argument; ``sequence`` marks dim 1 of rank-3 floating
-    tensors (the ``[B, seq, hidden]`` conditioning shape). A dim smaller
-    than the declared ``min`` is left unmarked — torch's 0/1 specialization
-    is not overridable (ie#543) and gets its own free specialized graph. A
-    mark torch cannot honor raises ``ConstraintViolationError`` at
-    compile/warm time — a LOUD build failure, never a silent fallback to
-    recompilation (the mint's warm calls do not guard)."""
+    pgw#1082 rewrote this. The old mapping marked one dim of one KIND of
+    tensor — dim 0 of every float for ``batch``, dim 1 of every rank-3 float
+    for ``sequence`` — and that is not what an axis is. Every sibling tensor
+    indexed by the same axis (integer index tensors, rotary tables inside a
+    tuple) stayed STATIC, so dynamo specialized the symbol on them and then
+    raised ``ConstraintViolationError`` against the mark on the float:
+
+        You marked L['hidden_states'].size()[1] as dynamic but your code
+        specialized it to be a constant
+
+    On minimax-h3 that fired on the FIRST call of every regional block, the
+    guard degraded the target to eager for the life of the pod, and (because
+    the regional guard forgot to raise the degraded flag) the wire still
+    reported ``serving_mode=jit_cell`` with an empty ``fallback_reason``. A
+    20.1B denoiser served 100% eager while every telemetry axis said
+    compiled — measured at 6.27 s/step against the rig's 4.31 (pgw#1078).
+
+    So: find the axis EXTENT at its primary dim, then mark that extent
+    wherever it appears in the argument tree, integer tensors included. An
+    extent outside the declared range is a typed :class:`DeclaredRangeExceeded`
+    — the declaration is wrong and the endpoint must fix it — never a
+    dynamo-internal error nobody can attribute.
+    """
 
     import torch
 
-    def _mark(t: Any) -> None:
-        if not isinstance(t, torch.Tensor) or not t.is_floating_point():
-            return
+    def _mark(tensors: List[Any]) -> None:
         for d in dynamic_dims:
-            # Only the two logical dynamo axes are markable here. A named
-            # declared Dim (pgw#739) carries (input, axis) bindings and is
-            # the EXPORT lane's business — marking it at axis 1 by the old
-            # sequence heuristic would mark the wrong axis silently.
-            if d.dim == "batch":
-                dim = 0
-            elif d.dim == "sequence" and t.dim() >= 3:
-                dim = 1
-            else:
+            primary = _AXIS_PRIMARY_DIM.get(str(d.dim), -1)
+            if primary < 0:
+                # A named declared Dim (pgw#739) carries (input, axis)
+                # bindings and is the EXPORT lane's business; marking it by
+                # a positional heuristic would mark the wrong axis silently.
                 continue
-            if t.dim() <= dim:
+            min_rank = _AXIS_MIN_RANK.get(str(d.dim), primary + 1)
+            extent = 0
+            for t in tensors:
+                if not t.is_floating_point() or t.dim() < min_rank:
+                    continue
+                size = int(t.shape[primary])
+                if size < int(d.min):
+                    # 0/1 (and sub-min) sizes keep their free static graph —
+                    # torch's 0/1 specialization is not overridable (ie#543).
+                    continue
+                if size > int(d.max):
+                    raise DeclaredRangeExceeded(
+                        f"declared dynamic axis {d.dim!r} has range "
+                        f"[{int(d.min)}, {int(d.max)}] but this call presents "
+                        f"{size} at dim {primary} of a {tuple(t.shape)} input. "
+                        f"The DECLARATION is wrong: widen it to the real "
+                        f"extent this target sees, or stop declaring the axis."
+                    )
+                extent = size
+                break
+            if not extent:
                 continue
-            if int(t.shape[dim]) < int(d.min):
-                continue  # 0/1 (and sub-min) sizes keep their free static graph
-            torch._dynamo.mark_dynamic(t, dim, min=int(d.min), max=int(d.max))
+            for t in tensors:
+                for dim in range(t.dim()):
+                    if int(t.shape[dim]) != extent:
+                        continue
+                    torch._dynamo.mark_dynamic(
+                        t, dim, min=int(d.min), max=int(d.max))
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
+        tensors: List[Any] = []
         for a in args:
-            _mark(a)
+            tensors.extend(_iter_arg_tensors(a))
         for v in kwargs.values():
-            _mark(v)
+            tensors.extend(_iter_arg_tensors(v))
+        _mark(tensors)
         return fn(*args, **kwargs)
 
     return wrapper
@@ -2794,11 +3000,37 @@ def _guarded_regional(
                         label, exc, args, kwargs, failure_signal, original)
                     return _eager_once(args, kwargs)
                 state["failed"] = True
+                broke = _is_graph_break_error(exc)
                 state["detail"] = (
-                    f"regional compiled {'W8A8 ' if fail_closed else ''}"
-                    f"target {label} failed: "
-                    f"{type(exc).__name__}: {exc}"
+                    (f"regional compiled target {label} GRAPH-BROKE under "
+                     f"fullgraph — this region did NOT trace whole and the "
+                     f"platform refuses to serve fragments as compiled "
+                     f"({GRAPH_BREAK_TOKEN}): {_clip(str(exc), 600)}")
+                    if broke else
+                    (f"regional compiled {'W8A8 ' if fail_closed else ''}"
+                     f"target {label} failed: "
+                     f"{type(exc).__name__}: {exc}")
                 )
+                # pgw#1082 — THE LIE. `_guarded` has always raised this
+                # flag on a permanent degrade; the REGIONAL twin never did,
+                # and `is_compile_armed` reads exactly it. So a regional
+                # target that degraded to eager on its very first call kept
+                # reporting `serving_mode=jit_cell`, `served_eager_fallback
+                # =false`, EMPTY `fallback_reason` — for the life of the pod,
+                # at eager speed. Every telemetry axis said compiled while
+                # 100% of the work ran eager (minimax-h3 0.4.3: 6.27 s/step
+                # against the rig's 4.31 for the identical recipe).
+                if isinstance(failure_signal, dict):
+                    failure_signal["degraded"] = True
+                    if broke:
+                        failure_signal["graph_break"] = _clip(str(exc), 600)
+                if broke:
+                    _emit_graph_break_event(label, exc)
+                elif isinstance(exc, DeclaredRangeExceeded):
+                    if isinstance(failure_signal, dict):
+                        failure_signal["declared_range_exceeded"] = _clip(
+                            str(exc), 600)
+                    _emit_declared_range_event(label, exc)
                 # Regional eager state is real only after the in-place block
                 # compilations are gone. Revoke proof after that mutation and
                 # before a state delta can be scheduled.
@@ -3069,7 +3301,20 @@ def apply(
             # place; the guard wrapper clears them on the first failure.
             #
             settings_authority.impose_dynamo()
-            owner.compile_repeated_blocks(dynamic=None)
+            # pgw#1082: FULLGRAPH IS THE REGIONAL LANE'S CONTRACT, not an
+            # option. A repeated block is by construction one traceable unit
+            # — that is the whole reason its author declared `regional=True`
+            # — so a break inside it is an AUTHORING DEFECT, and the only
+            # question is whether the platform says so. Without fullgraph
+            # dynamo splits the block into eager-glued fragments and reports
+            # a clean arm: armed, entered, zero guard misses, zero speedup
+            # (ie#632/pgw#1078, 6.27 s/step against the rig's 4.31 for the
+            # identical recipe). With it the break raises, `_guarded_regional`
+            # classifies it as `graph_break`, the wire flips to explicit
+            # eager, and the break reasons ride the `jit_compile` event.
+            # There is no configuration surface for this: a silently
+            # fragmented region must not be expressible.
+            owner.compile_repeated_blocks(dynamic=None, fullgraph=True)
             # pgw#1078: the declared marks are applied at the BLOCK ingress,
             # which is where this lane's graphs are traced. Without them
             # `regional=True` + `dynamic=(...)` used to DECLINE and send the
@@ -3213,6 +3458,29 @@ def is_compile_armed(pipeline: Any) -> bool:
     if isinstance(signal, dict) and signal.get("degraded"):
         return False
     return True
+
+
+def graph_break_reason(pipeline: Any) -> str:
+    """Torch's verbatim fullgraph refusal for this pipeline, or "".
+
+    Non-empty means the declared region did not trace whole and this process
+    permanently degraded it to eager. The executor turns it into the
+    ``graph_break`` eager posture, so every request the pod serves afterwards
+    names the real cause instead of an empty ``fallback_reason``."""
+    marker = getattr(pipeline, _MARKER_ATTR, None)
+    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
+    if isinstance(signal, dict):
+        return str(signal.get("graph_break") or "")
+    return ""
+
+
+def declared_range_refusal(pipeline: Any) -> str:
+    """The typed declared-range refusal for this pipeline, or ""."""
+    marker = getattr(pipeline, _MARKER_ATTR, None)
+    signal = marker.get("failure_signal") if isinstance(marker, dict) else None
+    if isinstance(signal, dict):
+        return str(signal.get("declared_range_exceeded") or "")
+    return ""
 
 
 def unwrap(pipeline: Any) -> bool:
@@ -3574,7 +3842,7 @@ def emit_jit_compile_event(
     family: str,
     execution_lane: str = "",
     route: str = "",
-    n_graphs: int = 0,
+    audit: Optional[GraphAudit] = None,
 ) -> None:
     """th#1322: report a JIT (dynamo/inductor) compile as typed NUMERIC events.
 
@@ -3586,11 +3854,19 @@ def emit_jit_compile_event(
     a grep of the other side's pod log (which a serve pod does not even
     expose, pgw#760).
 
+    pgw#1082: ``audit`` carries dynamo's OWN graph/break counters for this
+    compile window. It replaces the ``n_graphs`` parameter that shipped with
+    no caller — the blindness that let a graph-broken region report a clean
+    arm for two releases. A window with breaks also emits its own
+    ``phase=graph_break`` event per reason, so "which op cut this region"
+    is a column, not a pod log nobody can reach.
+
     Telemetry must never fail the compile it reports on.
     """
     try:
         from . import activity as activity_mod
 
+        audit = audit if audit is not None else GraphAudit()
         total_s = sum(float(v or 0.0) for v in timings.values())
         head = f"family={family or '(unset)'}"
         if execution_lane:
@@ -3607,11 +3883,17 @@ def emit_jit_compile_event(
                 phase=f"shape:{key}",
                 duration_ms=int(round(value * 1000)),
             )
+        for reason, count in audit.reasons[:8]:
+            activity_mod.emit_event(
+                activity_mod.KIND_JIT_COMPILE,
+                f"{head} graph_break x{count}: {_clip(reason, 300)}",
+                phase="graph_break",
+            )
         if total_s <= 0:
             return
         activity_mod.emit_event(
             activity_mod.KIND_JIT_COMPILE,
-            f"{head} n_shapes={len(timings)} n_graphs={n_graphs} "
+            f"{head} n_shapes={len(timings)} {audit.summary()} "
             f"total_s={round(total_s, 2)} shapes={dict(timings)}",
             phase=activity_mod.PHASE_MINTED,
             duration_ms=int(round(total_s * 1000)),
@@ -3638,6 +3920,7 @@ def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2, say: Any = None) -
 
     decode = any(t.startswith("vae") for t in cfg.targets)
     timings: Dict[str, float] = {}
+    audit_before = graph_audit()
     for shape in cfg.shapes:
         torch.cuda.synchronize()
         t0 = time.monotonic()
@@ -3657,9 +3940,12 @@ def _compile_and_warm(pipe: Any, cfg: Any, *, steps: int = 2, say: Any = None) -
     # (compile_cache.py:3803, "compiled %s in %.0fs") — a log-only important
     # metric, which is a defect class, not a style choice. Now it is a number in
     # a column too.
+    audit = graph_audit_delta(audit_before)
+    _say(f"  {audit.summary()}")
     emit_jit_compile_event(
         timings, family=getattr(cfg, "family", "") or "",
-        execution_lane=pipeline_weight_lane(pipe), route="compile_and_warm")
+        execution_lane=pipeline_weight_lane(pipe), route="compile_and_warm",
+        audit=audit)
 
 
 def mint_artifact(

--- a/src/gen_worker/executor.py
+++ b/src/gen_worker/executor.py
@@ -4099,6 +4099,30 @@ class Executor:
         """
         if rec.compile_targets.get(target.incarnation_id) is not target:
             raise RuntimeError("compiled target is no longer live")
+        # pgw#1082: classify BEFORE the active-ref gate below. A JIT INTAKE
+        # arm names no artifact by construction (pgw#1010), so that gate
+        # returns early for exactly the lane this defect lives on — and the
+        # graph-broken pod would keep reporting an empty `fallback_reason`.
+        broke = compile_cache.graph_break_reason(target.pipeline)
+        out_of_range = compile_cache.declared_range_refusal(target.pipeline)
+        if broke:
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.GRAPH_BREAK.value,
+                f"the declared regional target did not trace WHOLE under "
+                f"fullgraph; serving eager rather than eager-glued fragments "
+                f"reported as compiled: {broke}")
+        elif out_of_range:
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.DECLARED_RANGE_EXCEEDED.value,
+                out_of_range)
+        elif detail:
+            # pgw#1082: ANY permanent guard degrade must reach the request
+            # row. The gate below returns early for a JIT INTAKE arm (it
+            # names no artifact by construction, pgw#1010) — which is the
+            # only JIT lane the fleet has — so before this, a degraded
+            # intake pod recorded nothing at all and served eager silently.
+            self._note_eager_posture(
+                rec, cell_adopt.EagerPhase.JIT_ARM_FAILED.value, detail)
         with target.state_lock:
             if not (
                 target.active_compile_ref
@@ -5244,12 +5268,18 @@ class Executor:
         Fixed-mode bodies override it; a declared (handles=) instruction owns
         the full lane outright."""
 
+        # pgw#1082: the SAME reading `serving_mode.classify_mode` takes. A
+        # ref-only test made `metrics.lane` report `+eager` while
+        # `serving_mode` correctly reported `jit_cell` on the same request —
+        # a contradiction `_served_identity`'s docstring says cannot happen,
+        # because a JIT INTAKE arm names no artifact by construction.
         compiled = False
         if spec.cls is not None:
             rec = self._classes.get(spec.instance_key)
             if rec is not None:
                 compiled = any(
                     getattr(t, "active_compile_ref", "")
+                    or compile_cache.is_compile_armed(t.pipeline)
                     for t in rec.compile_targets.values())
         handled = self._handled_execution_lane_body(spec, instructed)
         if handled:
@@ -5713,9 +5743,19 @@ class Executor:
         part that was always real: the mint-goal latch and the pgw#805 backstop
         below.
         """
+        # pgw#1082: "is this record serving compiled" is ONE question with
+        # ONE answer. Reading only `active_compile_ref` asks "does it serve a
+        # NAMED artifact", and a JIT INTAKE arm names none BY CONSTRUCTION
+        # (pgw#1010) — so this row could never clear for an intake pod even
+        # while it served compiled, and 0.4.3 emitted `boot_ended_uncompiled`
+        # on a healthy H100. `is_compile_armed` is the same reading
+        # `_served_identity` and `serving_mode` take.
         armed = next(
             (t.active_compile_ref for t in rec.compile_targets.values()
-             if t.active_compile_ref), "")
+             if t.active_compile_ref), "") or (
+            "jit_intake" if any(
+                compile_cache.is_compile_armed(t.pipeline)
+                for t in rec.compile_targets.values()) else "")
         # th#1359: reaching here means this boot's mint disposition is FINAL
         # on every path (inline setup, adopted cell, eager-without-mint, and
         # the background mint's own `finally`). The mint-goal driver waits on
@@ -6861,6 +6901,10 @@ class Executor:
             # remaining dynamo compile on the platform would have been the one
             # nobody timed. A counter read costs nothing.
             compile_seconds_before = compile_cache.compile_wall_seconds()
+            # pgw#1082: dynamo's own graph/break counters across the SAME
+            # window. "How many graphs did this arm produce, and what cut
+            # them" was unanswerable over our telemetry until this sample.
+            graph_audit_before = compile_cache.graph_audit()
             # pgw#797: THE warmup split. `pipeline_load` used to be
             # load+warmup as one number, so "what does a cell save on warmup"
             # was only ever an estimate (`pipeline_load` minus a guessed
@@ -6926,6 +6970,7 @@ class Executor:
                     family=str(getattr(spec.compile, "family", "") or ""),
                     execution_lane=self._served_execution_lane(spec),
                     route="intake",
+                    audit=compile_cache.graph_audit_delta(graph_audit_before),
                 )
             if proves_inductor or proves_exported:
                 # gw#595 per-object provability: the proof scopes to objects

--- a/src/gen_worker/serving_mode.py
+++ b/src/gen_worker/serving_mode.py
@@ -79,6 +79,10 @@ POSTURE_MINT_IN_PROGRESS = EagerPhase.MINT_IN_PROGRESS.value
 POSTURE_NO_COMPILE_DECLARED = EagerPhase.NO_COMPILE_DECLARED.value
 #: Terminal fallback when a decline reached the request path unclassified.
 POSTURE_UNCOMPILED = EagerPhase.UNCOMPILED.value
+#: pgw#1082: the declared region did not trace whole under fullgraph.
+POSTURE_GRAPH_BREAK = EagerPhase.GRAPH_BREAK.value
+#: pgw#1082: the declaration named a dynamic range its own inputs leave.
+POSTURE_DECLARED_RANGE_EXCEEDED = EagerPhase.DECLARED_RANGE_EXCEEDED.value
 
 #: Step-count field names, in precedence order. Matches warmup._STEP_FIELDS so
 #: the boot warmup and the served request agree on what "steps" means.

--- a/tests/test_compile_duration_th1322.py
+++ b/tests/test_compile_duration_th1322.py
@@ -232,7 +232,8 @@ def test_both_mint_routes_report_duration_over_real_grpc() -> None:
         # REAL production emitter).
         cc.emit_jit_compile_event(
             {"boot": 612.5}, family="sdxl", execution_lane="w8a8",
-            route="intake", n_graphs=8)
+            route="intake",
+            audit=cc.GraphAudit(unique_graphs=8, graph_breaks=0))
 
         aot = _wait_for_phases(
             conn, aot_mint.MINT_PHASES_KIND,
@@ -257,6 +258,11 @@ def test_both_mint_routes_report_duration_over_real_grpc() -> None:
 
     assert jit["shape:boot"].duration_ms == 612_500
     assert "route=intake" in jit["minted"].detail
+    # pgw#1082: `n_graphs` finally has a caller. It read 0 on every event on
+    # the platform because `emit_jit_compile_event`'s parameter was never
+    # populated — the blindness that made a graph-broken 20.1B denoiser
+    # indistinguishable from a healthy one for two releases.
+    assert "n_graphs=8 n_breaks=0" in jit["minted"].detail
 
     # Every timed event is COMPLETED, which is what makes it durable hub-side
     # (th#1250 records terminal updates unconditionally).
@@ -275,7 +281,8 @@ def test_the_producer_warm_loop_reports_its_per_shape_compile_time() -> None:
         conn = sched.wait_connection(0)
         cc.emit_jit_compile_event(
             {"1024x1024": 41.5, "768x768": 12.25},
-            family="sdxl", execution_lane="w8a8", route="compile_and_warm", n_graphs=6)
+            family="sdxl", execution_lane="w8a8", route="compile_and_warm",
+                audit=cc.GraphAudit(unique_graphs=6, graph_breaks=0))
         jit = _wait_for_phases(
             conn, activity_mod.KIND_JIT_COMPILE,
             {"minted", "shape:1024x1024", "shape:768x768"})
@@ -286,7 +293,7 @@ def test_the_producer_warm_loop_reports_its_per_shape_compile_time() -> None:
     # total also covers per-mint package/declare/pack work).
     assert jit["minted"].duration_ms == 53_750
     assert "route=compile_and_warm" in jit["minted"].detail
-    assert "n_graphs=6" in jit["minted"].detail
+    assert "n_graphs=6 n_breaks=0" in jit["minted"].detail
 
 
 

--- a/tests/test_regional_marks_pgw1082.py
+++ b/tests/test_regional_marks_pgw1082.py
@@ -48,12 +48,15 @@ class _Block(torch.nn.Module):
         self.lin = torch.nn.Linear(8, 8)
 
     def forward(self, hidden, index, rotary):
+        # The H3 block's modulation, in miniature: a per-row table gathered by
+        # an INTEGER index tensor of the sequence length, broadcast into the
+        # rank-3 activation. Marking only `hidden` leaves the gather static,
+        # which specializes the symbol and violates the mark.
         cos, sin = rotary
         out = self.lin(hidden)
-        # index_select by a same-length index tensor is what specialized the
-        # sequence symbol when only `hidden` was marked.
-        gathered = out.index_select(1, index)
-        return gathered + cos.unsqueeze(0) + sin.unsqueeze(0)
+        scale = cos.index_select(0, index)
+        shift = sin.index_select(0, index)
+        return out * (1.0 + scale) + shift
 """
 
 

--- a/tests/test_regional_marks_pgw1082.py
+++ b/tests/test_regional_marks_pgw1082.py
@@ -1,0 +1,239 @@
+"""pgw#1082: the regional lane armed, entered, never guard-missed — and ran
+100% EAGER while every telemetry axis said compiled.
+
+pgw#1078 fixed *routing* (a ``regional=True`` + ``dynamic=(...)`` target now
+takes the dynamo regional branch). This suite covers what the routing fix
+then EXECUTED, measured on minimax-h3 0.4.3 at 6.27 s/step against the rig's
+4.31 for the identical recipe:
+
+1. ``_with_declared_marks`` marked one dim of one KIND of tensor. The sibling
+   tensors carrying the same axis — the integer ``adaln_indices[S]``, the
+   ``(cos[S, D], sin[S, D])`` rotary TUPLE — stayed static, dynamo specialized
+   the symbol on them, and the mark on the float raised
+   ``ConstraintViolationError`` on the FIRST call of every block.
+2. The declared range was the TEXT bound (4,096) while the marked axis is the
+   whole PACKED sequence (38,015), so it was out of range as well. That is an
+   endpoint declaration defect and now says so by name.
+3. ``_guarded_regional`` caught the raise, cleared the block compilations and
+   served eager forever — but, unlike its ``_guarded`` twin, NEVER set
+   ``failure_signal["degraded"]``. ``is_compile_armed`` reads exactly that, so
+   the wire kept reporting ``serving_mode=jit_cell``,
+   ``served_eager_fallback=false``, empty ``fallback_reason``.
+4. ``emit_jit_compile_event``'s ``n_graphs`` had no caller, so nothing could
+   see any of it.
+
+Every test here is RED on the pre-pgw#1082 code.
+"""
+
+from __future__ import annotations
+
+import gc
+import threading
+
+import pytest
+import torch
+
+from gen_worker import compile_cache as cc
+
+
+class _Dim:
+    def __init__(self, dim: str, mn: int, mx: int) -> None:
+        self.dim, self.min, self.max = dim, mn, mx
+
+
+_BLOCK_SRC = """
+class _Block(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(8, 8)
+
+    def forward(self, hidden, index, rotary):
+        cos, sin = rotary
+        out = self.lin(hidden)
+        # index_select by a same-length index tensor is what specialized the
+        # sequence symbol when only `hidden` was marked.
+        gathered = out.index_select(1, index)
+        return gathered + cos.unsqueeze(0) + sin.unsqueeze(0)
+"""
+
+
+def _fresh_block_cls():
+    """The H3 block's shape in miniature: one float activation carrying the
+    sequence axis, one INTEGER index tensor carrying it, and a rotary TUPLE
+    carrying it — the three ways the old mapping could miss an axis.
+
+    A FRESH code object per test: dynamo's caches are keyed on the code
+    object, so two tests declaring different ranges over one class would
+    otherwise inherit each other's guards.
+    """
+    ns = {"torch": torch}
+    exec(_BLOCK_SRC, ns)
+    return ns["_Block"]
+
+
+def _args(seq: int):
+    return (
+        torch.randn(1, seq, 8),
+        torch.arange(seq),
+        (torch.randn(seq, 8), torch.randn(seq, 8)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_dynamo():
+    """`nn.Module.compile()` traces the SHARED `Module._call_impl` frame, so
+    one test's declared range leaks into the next unless the caches are torn
+    down with the objects that hold them."""
+    gc.collect()
+    torch._dynamo.reset()
+    yield
+    gc.collect()
+    torch._dynamo.reset()
+
+
+def _marked_block(dims, fullgraph: bool = True):
+    torch._dynamo.reset()
+    block = _fresh_block_cls()().eval()
+    block.compile(dynamic=None, fullgraph=fullgraph)
+    if dims:
+        block._compiled_call_impl = cc._with_declared_marks(
+            block._compiled_call_impl, dims)
+    return block
+
+
+def test_the_declared_axis_is_marked_on_every_argument_that_carries_it():
+    """RED before: only dim 1 of rank>=3 FLOATS was marked, the index tensor
+    and the rotary tuple stayed static, and dynamo raised
+    ``ConstraintViolationError: you marked ... as dynamic but your code
+    specialized it to be a constant``. ONE graph must serve two lengths."""
+    from torch._dynamo.utils import counters
+
+    counters.clear()
+    block = _marked_block((_Dim("sequence", 2, 4096),))
+    with torch.no_grad():
+        block(*_args(96))
+        block(*_args(128))
+    audit = cc.graph_audit()
+    assert audit.unique_graphs == 1, audit.summary()
+    assert audit.graph_breaks == 0, audit.summary()
+
+
+def test_an_extent_outside_the_declared_range_is_a_typed_named_refusal():
+    """RED before: a dynamo-internal ``ConstraintViolationError`` that named
+    no declaration and no endpoint. minimax-h3 declared max=4096 for an axis
+    its own requests present at 38,015."""
+    block = _marked_block((_Dim("sequence", 2, 4096),))
+    try:
+        with torch.no_grad():
+            block(*_args(8192))
+    except cc.DeclaredRangeExceeded as exc:
+        assert "8192" in str(exc) and "4096" in str(exc)
+        assert "sequence" in str(exc)
+    else:
+        raise AssertionError("an out-of-range extent must refuse, typed")
+
+
+def test_the_marks_reach_the_integer_index_and_the_rotary_tuple():
+    """THE fix, stated directly. RED before: the mapping was "dim 0 of every
+    float for batch, dim 1 of every rank-3 float for sequence", so the
+    ``adaln_indices[S]`` integer tensor and the ``(cos[S,D], sin[S,D])``
+    rotary TUPLE — both carrying the SAME axis — were never marked, and
+    dynamo specialized the symbol on them."""
+    marked: list[tuple[tuple[int, ...], int]] = []
+
+    def _spy(t, dim, **kw):
+        marked.append((tuple(t.shape), dim))
+
+    original = torch._dynamo.mark_dynamic
+    torch._dynamo.mark_dynamic = _spy
+    try:
+        wrapped = cc._with_declared_marks(
+            lambda *a, **k: None, (_Dim("sequence", 2, 262144),))
+        wrapped(*_args(96))
+    finally:
+        torch._dynamo.mark_dynamic = original
+
+    assert ((1, 96, 8), 1) in marked, marked      # the float activation
+    assert ((96,), 0) in marked, marked           # the INTEGER index tensor
+    assert marked.count(((96, 8), 0)) == 2, marked  # both rotary tuple members
+
+
+def test_a_degraded_regional_target_stops_claiming_it_is_compiled():
+    """THE LIE. RED before: ``_guarded_regional``'s permanent-degrade branch
+    never set ``degraded``, which ``is_compile_armed`` reads — so a target
+    that fell to eager on its first call reported ``serving_mode=jit_cell``
+    with an empty ``fallback_reason`` for the life of the pod."""
+
+    class _Owner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, *a, **k):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("regional block exploded")
+            return "eager"
+
+    owner = _Owner()
+    signal = {
+        "lock": threading.Lock(), "successful_calls": 0, "cache_hits": 0,
+        "cache_misses": 0, "guard_misses": 0, "on_guard_miss": None,
+        "callback": None, "router": None,
+    }
+    guarded = cc._guarded_regional(
+        owner, owner.forward, "transformer", failure_signal=signal)
+    pipeline = type("_P", (), {})()
+    setattr(pipeline, cc._MARKER_ATTR, {"failure_signal": signal,
+                                        "originals": (), "regional_mods": ()})
+    assert cc.is_compile_armed(pipeline) is True
+    assert guarded() == "eager"   # degrades to eager, serves the call
+    assert signal.get("degraded") is True
+    assert cc.is_compile_armed(pipeline) is False
+
+
+def test_a_declared_range_refusal_is_readable_off_the_pipeline():
+    """The executor turns this into the ``declared_range_exceeded`` eager
+    posture, so the request row names the endpoint's declaration defect."""
+
+    class _Owner(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, *a, **k):
+            self.calls += 1
+            if self.calls == 1:
+                raise cc.DeclaredRangeExceeded(
+                    "declared dynamic axis 'sequence' has range [2, 4096]")
+            return "eager"
+
+    owner = _Owner()
+    signal = {
+        "lock": threading.Lock(), "successful_calls": 0, "cache_hits": 0,
+        "cache_misses": 0, "guard_misses": 0, "on_guard_miss": None,
+        "callback": None, "router": None,
+    }
+    guarded = cc._guarded_regional(
+        owner, owner.forward, "transformer", failure_signal=signal)
+    pipeline = type("_P", (), {})()
+    setattr(pipeline, cc._MARKER_ATTR, {"failure_signal": signal,
+                                        "originals": (), "regional_mods": ()})
+    assert guarded() == "eager"
+    assert "sequence" in cc.declared_range_refusal(pipeline)
+    assert cc.is_compile_armed(pipeline) is False
+
+
+def test_the_graph_audit_counts_what_no_caller_ever_populated():
+    """RED before: ``emit_jit_compile_event``'s ``n_graphs`` had NO caller, so
+    every ``jit_compile`` event on the platform read ``n_graphs=0``."""
+    from torch._dynamo.utils import counters
+
+    counters.clear()
+    before = cc.graph_audit()
+    block = _marked_block(())
+    with torch.no_grad():
+        block(*_args(64))
+    delta = cc.graph_audit_delta(before)
+    assert delta.unique_graphs >= 1
+    assert "n_graphs=" in delta.summary() and "n_breaks=" in delta.summary()

--- a/tests/test_silent_failure_audit_pgw824.py
+++ b/tests/test_silent_failure_audit_pgw824.py
@@ -209,6 +209,13 @@ def test_the_eager_phase_values_are_a_wire_contract() -> None:
         "NO_COMPILE_DECLARED": "no_compile_declared",
         "UNCOMPILED": "uncompiled",
         "BOOT_ENDED_UNCOMPILED": "boot_ended_uncompiled",
+        # pgw#1082: the two AUTHORING defects a compiled lane can die of, each
+        # named. Before them, a regional target that degraded on its first
+        # call recorded NOTHING (the guard-failure path returns early for a
+        # JIT intake arm, which names no artifact) and the pod served eager
+        # for its whole life reporting `serving_mode=jit_cell`.
+        "GRAPH_BREAK": "graph_break",
+        "DECLARED_RANGE_EXCEEDED": "declared_range_exceeded",
     }
     # The join the ArmOutcome docstring claims: a delegated mint's decline and
     # the serving posture that describes it are ONE token, not two that happen
@@ -217,6 +224,9 @@ def test_the_eager_phase_values_are_a_wire_contract() -> None:
     assert EagerPhase.ARM_PENDING == serving_mode.POSTURE_ARM_PENDING
     assert EagerPhase.NO_COMPILE_DECLARED == serving_mode.POSTURE_NO_COMPILE_DECLARED
     assert EagerPhase.UNCOMPILED == serving_mode.POSTURE_UNCOMPILED
+    assert EagerPhase.GRAPH_BREAK == serving_mode.POSTURE_GRAPH_BREAK
+    assert (EagerPhase.DECLARED_RANGE_EXCEEDED
+            == serving_mode.POSTURE_DECLARED_RANGE_EXCEEDED)
 
 
 def test_the_posture_tokens_are_the_enum_and_not_a_second_spelling() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "gen-worker"
-version = "0.97.0"
+version = "0.98.0"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## The measurement this closes

minimax-h3 0.4.3 (gen-worker 0.97.0, pgw#1078's routing fix live) served **6.27 s/step** against the rig's ARM A **4.31 s/step** for the identical recipe — armed, entered, **zero guard misses**, empty `fallback_reason`. The filed diagnosis was "the region is graph-broken."

**It is not.** Measured off-pod ($0, no pod) against the REAL vendored `MiniMaxH3TransformerBlock` plus the REAL te#171 `adaln_skip` cache:

| arm | n_graphs | n_breaks |
|---|---:|---:|
| one block, upstream | 1 | **0** |
| one block **+ te#171 AdaLN cache (production)** | 1 | **0** |
| block + declared marks, IN range | — | **`ConstraintViolationError`** |
| block + declared marks, S > declared max | — | **`ConstraintViolationError`: 8192 not in range [2, 4096]** |
| block + marks widened and applied to every carrier | **1** | **0** (S=96/128/8192) |

The AdaLN python-dict lookup traces clean. The FA3 kernel is exonerated by the rig, which compiled the same composition under `fullgraph=True`.

## Four defects, one outcome

1. **`_with_declared_marks` marked one dim of one KIND of tensor.** `sequence` → dim 1 of rank≥3 *floats*. The H3 block also takes `adaln_indices[S]` (int64) and `rotary_emb=(cos[S,D], sin[S,D])` — a TUPLE the walker never entered. The unmarked siblings specialized the symbol, and dynamo raised against the mark on the float, on the first call of every block, *in range*. Now: find the extent at the axis's primary dim, mark it wherever it appears in the argument tree (ints and nested containers included).
2. **A declared range the inputs leave is now a typed `DeclaredRangeExceeded`** naming the axis, the range and the observed extent — not a dynamo-internal error nobody could attribute.
3. **`_guarded_regional` never set `failure_signal["degraded"]`** — exactly what `is_compile_armed` reads. The guard degraded to eager for the life of the pod while the wire reported `jit_cell`. `_compile_guard_failed` also returned early with no `active_compile_ref`, which a JIT intake arm never has (pgw#1010), so nothing was recorded anywhere. Both fixed; new posture tokens `graph_break` and `declared_range_exceeded`.
4. **`emit_jit_compile_event`'s `n_graphs` had NO caller.** Replaced by `GraphAudit` (unique_graphs / graph_breaks / per-reason histogram) sampled across the same window as the compile wall, with one `phase=graph_break` event per reason.

## Fullgraph policy — decided

The regional lane **always** compiles `fullgraph=True`, with no configuration surface. A repeated block is one traceable unit by construction; a break is an authoring defect and must raise, be classified, and flip the wire to explicit eager. A silently fragmented region must not be expressible.

## Also

pgw#1078's two ref-only gaps, closed with the same `is_compile_armed` reading: `boot_ended_uncompiled` no longer fires on a healthy JIT-intake pod, and `metrics.lane` no longer disagrees with `serving_mode`.

## Tests

`tests/test_regional_marks_pgw1082.py` — six tests, each RED on the old behaviour.

Endpoint half: inference-endpoints `ie/1082-h3-packed-seq` (minimax-h3 0.4.4) replaces `MAX_TEXT_TOKENS` with a computed packed-sequence bound.

Version: **0.98.0**.