### PR TITLE
pgw#1088 (pgw#763's deferred worker half): the declared-slot failure the hub has been waiting a fortnight to classify

### DIFF
--- a/changelog.d/pgw1088.md
+++ b/changelog.d/pgw1088.md
@@ -1,0 +1,16 @@
+- **pgw#1088 (pgw#763's deferred worker half): a FIXED declared slot that
+  fails to resolve now raises a TYPED `DeclaredSlotResolutionError`.** The
+  te#138 incident surfaced hub-side as `ValueError: slot 'pipeline': no repo
+  inference-defaults…` — a bare `ValueError` carrying no origin claim, so the
+  hub could only classify it by worker VERSION, and every protocol-stale
+  worker sits below `MinRefProvenanceWorkerVersion` and had its FATALs
+  discarded. The hub half has been waiting since tensorhub `c84939ff`:
+  `declaredFaultLabels` already allowlists `declaredslotresolutionerror` and
+  `declared_fault_labels_th1288_test.go` already asserts a 0.58.2 worker
+  emitting it classifies `EvidenceDeclaredRefLoad`. The worker simply never
+  emitted the label. `ctx.slots[name]` now raises the typed error for slots
+  whose ref is the RELEASE's own fixed declaration, and keeps the bare
+  `ValueError` for `Slot(selected_by=...)` slots — the payload participates in
+  picking those, and typing them would let one bad request feed the release's
+  health streak (th#1259's defect wearing a new label). The error subclasses
+  `ValueError`, so handlers already catching it are unaffected.

--- a/src/gen_worker/api/errors.py
+++ b/src/gen_worker/api/errors.py
@@ -248,6 +248,21 @@ class ComponentSubstitutionError(WorkerError):
         super().__init__(msg)
 
 
+class DeclaredSlotResolutionError(WorkerError, ValueError):
+    """A FIXED release-declared model slot failed to resolve (pgw#763/th#1288).
+
+    The failing ref is the RELEASE'S OWN declaration — no payload field
+    participates — so the label is the worker's origin claim and the hub
+    classifies it as `declared_ref_load` evidence at ANY worker version
+    (`declaredFaultLabels`, blame_ladder.go). A `Slot(selected_by=...)` slot
+    stays a bare `ValueError`: the payload picks there, so its failure is not
+    version-independent evidence about the release.
+
+    Subclasses `ValueError` because it replaces one at `ctx.slots[name]` —
+    handler code that already catches `ValueError` keeps working.
+    """
+
+
 class RefCompatibilitySurprise(ValidationError):
     """Post-download runtime mismatch on a caller-supplied PAYLOAD_REF.
 

--- a/src/gen_worker/cli/run.py
+++ b/src/gen_worker/cli/run.py
@@ -739,6 +739,7 @@ def _resolve_ctx_slots(ctx: Any, selected: "_SelectedFunction") -> None:
     slot_family = getattr(spec, "slot_family", {}) or {}
     resolved: Dict[str, Any] = {}
     errors: Dict[str, str] = {}
+    declared: List[str] = []  # pgw#763: FIXED slots only (see warmup)
     for name, slot in selected.slots.items():
         try:
             resolved[name] = resolve_slot(
@@ -748,6 +749,8 @@ def _resolve_ctx_slots(ctx: Any, selected: "_SelectedFunction") -> None:
             )
         except ValueError as exc:
             errors[name] = str(exc)
+            if not getattr(slot, "selected_by", ""):
+                declared.append(name)
     set_slots = getattr(ctx, "_set_resolved_slots", None)
     if callable(set_slots):
         root = ""
@@ -755,7 +758,9 @@ def _resolve_ctx_slots(ctx: Any, selected: "_SelectedFunction") -> None:
             if getattr(slot, "root", False):
                 root = name
                 break
-        set_slots(resolved, errors, root_slot=root)
+        set_slots(
+            resolved, errors, root_slot=root,
+            declared_slot_errors=tuple(declared))
 
 
 def _local_executing_execution_lane(

--- a/src/gen_worker/request_context/__init__.py
+++ b/src/gen_worker/request_context/__init__.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Literal,
@@ -55,6 +56,7 @@ from ..api.errors import (
     BlobForbiddenError,
     BlobNotFoundError,
     DatasetNotFoundError,
+    DeclaredSlotResolutionError,
 )
 from ..api.slot import ResolvedSlot
 
@@ -98,22 +100,34 @@ class _SlotTable(Mapping):
     no code fallback, no ref for the slot) are stored per-key and raised
     lazily on ``__getitem__`` — "clear error at request time" means when the
     HANDLER actually reads that slot, not a blanket failure for every
-    Slot-declared endpoint whose handler never touches an unresolved one."""
+    Slot-declared endpoint whose handler never touches an unresolved one.
 
-    __slots__ = ("_resolved", "_errors")
+    ``declared`` (pgw#763/th#1288) names the failed slots whose ref is the
+    RELEASE'S OWN fixed declaration; those raise the typed
+    ``DeclaredSlotResolutionError``, so the hub classifies the resulting FATAL
+    by ORIGIN at any worker version instead of discarding it. A
+    ``Slot(selected_by=...)`` slot keeps the bare ``ValueError`` — the payload
+    participates in picking it, so its failure is not evidence about the
+    release."""
+
+    __slots__ = ("_resolved", "_errors", "_declared")
 
     def __init__(
         self,
         resolved: Mapping[str, "ResolvedSlot[Any]"],
         errors: Mapping[str, str],
+        declared: Iterable[str] = (),
     ) -> None:
         self._resolved = dict(resolved)
         self._errors = dict(errors)
+        self._declared = frozenset(declared)
 
     def __getitem__(self, key: str) -> "ResolvedSlot[Any]":
         if key in self._resolved:
             return self._resolved[key]
         if key in self._errors:
+            if key in self._declared:
+                raise DeclaredSlotResolutionError(self._errors[key])
             raise ValueError(self._errors[key])
         raise KeyError(key)
 
@@ -293,6 +307,7 @@ class RequestContext(Generic[D]):
         loras: Optional[Dict[str, Any]] = None,
         resolved_slots: Optional[Mapping[str, "ResolvedSlot[Any]"]] = None,
         slot_errors: Optional[Mapping[str, str]] = None,
+        declared_slot_errors: Optional[Iterable[str]] = None,
         root_slot: str = "",
         boot_warmup: bool = False,
     ) -> None:
@@ -319,7 +334,8 @@ class RequestContext(Generic[D]):
         self._repo_scope_parse_reported = False
         self._models = _copy_context_metadata(models or {})
         self._loras = _copy_context_metadata(loras or {})
-        self._slots = _SlotTable(resolved_slots or {}, slot_errors or {})
+        self._slots = _SlotTable(
+            resolved_slots or {}, slot_errors or {}, declared_slot_errors or ())
         self._root_slot_name = str(root_slot or "").strip()
         # pgw#654: caller-visible adjustment warnings — structured rows the
         # merge/clamp layer emits whenever a requested value is modified.
@@ -430,11 +446,12 @@ class RequestContext(Generic[D]):
         resolved: Mapping[str, "ResolvedSlot[Any]"],
         errors: Optional[Mapping[str, str]] = None,
         root_slot: str = "",
+        declared_slot_errors: Optional[Iterable[str]] = None,
     ) -> None:
         """CLI-only mutator (``gen-worker run``/``serve``): the hub-less
         resolve step runs after context construction, unlike the executor
         which has every input up front."""
-        self._slots = _SlotTable(resolved, errors or {})
+        self._slots = _SlotTable(resolved, errors or {}, declared_slot_errors or ())
         if root_slot:
             self._root_slot_name = str(root_slot).strip()
 

--- a/src/gen_worker/warmup.py
+++ b/src/gen_worker/warmup.py
@@ -818,7 +818,10 @@ def resolved_slots_kwargs(
     spec and no job.
     """
     if not spec.slots:
-        return {"resolved_slots": {}, "slot_errors": {}, "root_slot": ""}
+        return {
+            "resolved_slots": {}, "slot_errors": {},
+            "declared_slot_errors": (), "root_slot": "",
+        }
 
     slot_orders = dict(slots or {})
     raw_defaults = {
@@ -839,6 +842,10 @@ def resolved_slots_kwargs(
         name: so.distilled_status for name, so in slot_orders.items()}
     resolved: Dict[str, Any] = {}
     errors: Dict[str, str] = {}
+    # pgw#763/th#1288: a FIXED slot's ref is the RELEASE's own declaration, so
+    # its resolution failure is version-independent origin evidence and gets a
+    # typed label. `selected_by` slots stay untyped — the payload picks there.
+    declared: list = []
     for name, slot in spec.slots.items():
         try:
             resolved[name] = resolve_slot(
@@ -856,9 +863,12 @@ def resolved_slots_kwargs(
             )
         except ValueError as exc:
             errors[name] = str(exc)
+            if not getattr(slot, "selected_by", ""):
+                declared.append(name)
     return {
         "resolved_slots": resolved,
         "slot_errors": errors,
+        "declared_slot_errors": tuple(declared),
         "root_slot": spec_root_slot(spec),
     }
 

--- a/tests/test_declared_slot_error_pgw763.py
+++ b/tests/test_declared_slot_error_pgw763.py
@@ -1,0 +1,102 @@
+"""pgw#1088 (pgw#763's deferred worker half, th#1288 fix 1).
+
+The te#138-class incident: a release-declared slot fails to resolve, the
+handler reads ``ctx.slots["pipeline"]``, and the worker reports
+
+    ValueError: slot 'pipeline': no repo inference-defaults metadata...
+
+A bare ``ValueError`` carries no origin claim, so the hub can only classify it
+by WORKER VERSION — and every protocol-stale worker sits below
+``MinRefProvenanceWorkerVersion``, so its FATALs are DISCARDED and neither the
+load-failure streak nor the spend brake ever sees the deterministic fault.
+
+The hub half (tensorhub ``c84939ff``) has been waiting for this label since:
+``declaredFaultLabels`` in ``blame_ladder.go`` already allowlists
+``declaredslotresolutionerror`` and ``declared_fault_labels_th1288_test.go``
+already asserts a 0.58.2 worker emitting it classifies
+``EvidenceDeclaredRefLoad``. The worker never emitted it.
+
+The FIXED/``selected_by`` split is the load-bearing half, not a detail: the
+hub's own rule is "never add a label a payload field can participate in
+producing". A ``Slot(selected_by="model")`` slot is picked by the payload, so
+its resolution failure is the CALLER's, and typing it would let one bad
+request feed the release's health streak — th#1259's defect wearing a new
+label.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gen_worker import executor, warmup
+from gen_worker.pb import worker_scheduler_pb2 as pb
+from gen_worker.api.errors import DeclaredSlotResolutionError
+from gen_worker.api.slot import Slot
+from gen_worker.request_context import RequestContext
+
+
+class _FakeSpec:
+    """The two fields ``resolved_slots_kwargs`` reads for this path.
+
+    Neither slot has a ``default_checkpoint`` and the warm shape supplies no
+    hub binding, so both fail resolution at ``resolve_slot``'s ``ref is None``
+    — the same shape as an unresolvable declared ref in production.
+    """
+
+    def __init__(self) -> None:
+        self.slots = {
+            "pipeline": Slot(str),                        # FIXED declaration
+            "model": Slot(str, selected_by="model"),      # payload picks
+        }
+        self.models: dict = {}
+        self.defaults_type = None
+        self.slot_family: dict = {}
+        self.objectives = None
+        self.distilled = None
+
+
+def _kwargs() -> dict:
+    kw = warmup.resolved_slots_kwargs(_FakeSpec(), None)
+    assert set(kw["slot_errors"]) == {"pipeline", "model"}, kw
+    return kw
+
+
+def test_fixed_declared_slot_raises_the_typed_origin_error() -> None:
+    ctx = RequestContext(request_id="r1", **_kwargs())
+    with pytest.raises(DeclaredSlotResolutionError) as caught:
+        ctx.slots["pipeline"]
+    assert "pipeline" in str(caught.value)
+    # Handlers that already catch ValueError keep working.
+    assert isinstance(caught.value, ValueError)
+
+
+def test_selected_by_slot_stays_an_untyped_value_error() -> None:
+    ctx = RequestContext(request_id="r2", **_kwargs())
+    with pytest.raises(ValueError) as caught:
+        ctx.slots["model"]
+    assert type(caught.value) is ValueError, (
+        "a payload-picked slot must NOT carry the declared-fault label")
+
+
+def test_the_hub_reads_the_class_name_as_the_fatal_label() -> None:
+    """``_map_exception`` is what puts the label on the wire, and the hub
+    matches on the lowercased text before the first colon."""
+    ctx = RequestContext(request_id="r3", **_kwargs())
+    try:
+        ctx.slots["pipeline"]
+    except Exception as exc:  # noqa: BLE001 — the mapper's own input
+        status, message = executor._map_exception(exc)
+    assert status == pb.JOB_STATUS_FATAL
+    assert message.split(":", 1)[0] == "DeclaredSlotResolutionError"
+
+    try:
+        ctx.slots["model"]
+    except Exception as exc:  # noqa: BLE001
+        picked_status, picked_message = executor._map_exception(exc)
+    assert picked_status == pb.JOB_STATUS_FATAL
+    assert picked_message.split(":", 1)[0] == "ValueError"
+
+
+def test_resolved_slots_carry_no_declared_errors() -> None:
+    empty = warmup.resolved_slots_kwargs(type("S", (), {"slots": {}})(), None)
+    assert empty["declared_slot_errors"] == ()


### PR DESCRIPTION
`pgw#763` shipped layers 2 and 3 of the endpoint-fault defence and recorded one residual it could not take that night — the files carried another lane's uncommitted WIP in the shared chaos worktree. This is that residual, re-derived against master.

## The gap

te#138's incident reached the hub as:

    ValueError: slot 'pipeline': no repo inference-defaults metadata...

A bare `ValueError` carries **no origin claim**, so `jobResultEvidence` can only classify it by worker VERSION — and every protocol-stale worker sits below `MinRefProvenanceWorkerVersion`, so its FATALs are *discarded*. Neither the load-failure streak nor th#1288's spend brake ever saw the deterministic fault, and the hub kept buying fresh pods for a release that could never stand up.

The hub half landed **two weeks ago** (tensorhub `c84939ff`) and has been waiting on this label ever since:

- `declaredFaultLabels` (`blame_ladder.go:310`) already allowlists `declaredslotresolutionerror`, commented `// reserved (pgw#763)`
- `declared_fault_labels_th1288_test.go:25` already asserts a **0.58.2** worker emitting `DeclaredSlotResolutionError: slot 'pipeline': …` classifies `EvidenceDeclaredRefLoad`

The worker simply never emitted it.

## The change

`ctx.slots[name]` raises the typed `DeclaredSlotResolutionError` when the slot's ref is the **RELEASE's own fixed declaration**, and keeps the bare `ValueError` for `Slot(selected_by=...)` slots.

That split is the load-bearing half, not a detail. The hub's own rule is *"never add a label a payload field can participate in producing"* — a `selected_by` slot is picked by the payload, so typing its failure would let one bad request feed the release's health streak and take a healthy release offline for everyone. That is th#1259's defect wearing a new label.

Both producers name the fixed slots (`warmup.resolved_slots_kwargs` for the executor + mint-child paths, `cli/run.py` for the hub-less path); `_SlotTable` picks the class. `DeclaredSlotResolutionError` subclasses `ValueError`, so handler code already catching it is unaffected.

## Proof

- `tests/test_declared_slot_error_pgw763.py` — 4 passed: the fixed slot raises the typed error, the `selected_by` slot stays `type(exc) is ValueError`, and `_map_exception` puts `DeclaredSlotResolutionError` in the wire label's leading position (the exact text the hub lowercases and matches)
- `test_mint_child_warm_context_pgw828.py` + `test_objectives_pgw654.py` — 36 passed (the two suites that read `slot_errors`)
- `mypy src` — clean, 246 files